### PR TITLE
Add uwsgi for production

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -17,7 +17,7 @@ COPY bin/dumb-init /usr/local/bin/dumb-init
 RUN chmod a+x /usr/local/bin/dumb-init
 ENTRYPOINT ["/usr/local/bin/dumb-init", "--"]
 
-RUN apk add --no-cache gcc musl-dev postgresql-dev postgresql-client bash
+RUN apk add --no-cache gcc musl-dev postgresql-dev postgresql-client bash uwsgi
 
 COPY ./requirements.txt /app/requirements.txt
 


### PR DESCRIPTION
@jaredkerim after chatting with the other cloud-ops folks the recommended way to run Python apps is to install uwsgi inside the service container and expose an http port for nginx