### PR TITLE
Automatically generate SSL key and cert when needed.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ secretkey:
 build:
 	./scripts/build.sh
 
-compose_build: build
+compose_build: build ssl
 	docker-compose build
 
 up: compose_build
@@ -43,5 +43,13 @@ bash: compose_build
 kill:
 	docker ps -a -q | xargs docker kill;docker ps -a -q | xargs docker rm
 
-ssl:
-	openssl req -x509 -newkey rsa:4096 -keyout nginx/key.pem -out nginx/cert.pem -days 365 -nodes
+
+ssl: nginx/key.pem nginx/cert.pem
+
+nginx/key.pem:
+	openssl genrsa -out nginx/key.pem 4096
+
+nginx/cert.pem: nginx/key.pem
+	openssl req -new -x509 -nodes -sha256 -key nginx/key.pem \
+		-subj "/C=US/ST=California/L=Mountain View/O=Mozilla/CN=experiment_local" \
+		> nginx/cert.pem

--- a/README.md
+++ b/README.md
@@ -64,10 +64,6 @@ An experiment has three parts:
 
         make createuser
 
-1. Add dummy SSL certs
-
-        make ssl
-
 1. Run a dev instance
 
         make up
@@ -115,7 +111,9 @@ Start an ipython shell inside the container (this lets you import and test code,
 Start a bash shell inside the container (this lets you interact with the containerized filesystem)
 
 ### ssl
-Create dummy SSL certs to use the dev server over a locally secure connection (this helps test client behaviour with a secure connection)
+Create dummy SSL certs to use the dev server over a locally secure
+connection. This helps test client behaviour with a secure
+connection. This task is run automatically when needed.
 
 ## API
 


### PR DESCRIPTION
This makes the `Makefile` create SSL keys when needed, automatically, once. This should simplify set up of Experimenter for new users.