### PR TITLE
Use get_user_model() in openidc tests

### DIFF
--- a/app/experimenter/openidc/tests/test_middleware.py
+++ b/app/experimenter/openidc/tests/test_middleware.py
@@ -1,5 +1,5 @@
 from django.conf import settings
-from django.contrib.auth.models import User
+from django.contrib.auth import get_user_model
 from django.urls import Resolver404
 from django.test import TestCase
 
@@ -56,6 +56,8 @@ class OpenIDCAuthMiddlewareTests(TestCase):
 
         request = mock.Mock()
         request.META = {settings.OPENIDC_EMAIL_HEADER: user_email}
+
+        User = get_user_model()
 
         self.assertEqual(User.objects.all().count(), 0)
 


### PR DESCRIPTION
The code itself actually does this already, but using get_user_model in
the tests makes it easier to transplant this code elsewhere.

See: https://docs.djangoproject.com/en/2.1/topics/auth/customizing/#referencing-the-user-model