### PR TITLE
Require distinct pref values in branches fix #777

### DIFF
--- a/app/experimenter/experiments/forms.py
+++ b/app/experimenter/experiments/forms.py
@@ -260,9 +260,30 @@ class ExperimentVariantsFormSet(BaseInlineFormSet):
                 form._errors["name"] = ["All branches must have a unique name"]
 
 
+class ExperimentVariantsPrefFormSet(BaseInlineFormSet):
+
+    def clean(self):
+        alive_forms = [
+            form for form in self.forms if not form.cleaned_data["DELETE"]
+        ]
+
+        forms_by_value = {}
+        for form in alive_forms:
+            value = form.cleaned_data["value"]
+            forms_by_value.setdefault(value, []).append(form)
+
+        for forms in forms_by_value.values():
+            if len(forms) > 1:
+                for form in forms:
+                    form.add_error(
+                        "value", "All branches must have a unique pref value"
+                    )
+
+
 class ExperimentVariantsAddonForm(ChangeLogMixin, forms.ModelForm):
 
     FORMSET_FORM_CLASS = ExperimentVariantAddonForm
+    FORMSET_CLASS = ExperimentVariantsFormSet
 
     population_percent = forms.DecimalField(
         label="Population Size",
@@ -306,7 +327,7 @@ class ExperimentVariantsAddonForm(ChangeLogMixin, forms.ModelForm):
             can_delete=True,
             extra=extra,
             form=self.FORMSET_FORM_CLASS,
-            formset=ExperimentVariantsFormSet,
+            formset=self.FORMSET_CLASS,
             model=ExperimentVariant,
             parent_model=Experiment,
         )
@@ -342,6 +363,7 @@ class ExperimentVariantsAddonForm(ChangeLogMixin, forms.ModelForm):
 class ExperimentVariantsPrefForm(ExperimentVariantsAddonForm):
 
     FORMSET_FORM_CLASS = ExperimentVariantPrefForm
+    FORMSET_CLASS = ExperimentVariantsPrefFormSet
 
     pref_key = forms.CharField(
         label="Pref Name",

--- a/app/experimenter/experiments/forms.py
+++ b/app/experimenter/experiments/forms.py
@@ -272,9 +272,9 @@ class ExperimentVariantsPrefFormSet(BaseInlineFormSet):
             value = form.cleaned_data["value"]
             forms_by_value.setdefault(value, []).append(form)
 
-        for forms in forms_by_value.values():
-            if len(forms) > 1:
-                for form in forms:
+        for dupe_forms in forms_by_value.values():
+            if len(dupe_forms) > 1:
+                for form in dupe_forms:
                     form.add_error(
                         "value", "All branches must have a unique pref value"
                     )

--- a/app/experimenter/experiments/tests/test_forms.py
+++ b/app/experimenter/experiments/tests/test_forms.py
@@ -679,6 +679,14 @@ class TestExperimentVariantsPrefForm(MockRequestMixin, TestCase):
         )
         self.assertEqual(branch2.value, self.data["variants-2-value"])
 
+    def test_form_is_invalid_if_branches_have_duplicate_pref_values(self):
+        self.data["variants-0-value"] = self.data["variants-1-value"]
+        form = ExperimentVariantsPrefForm(request=self.request, data=self.data)
+        self.assertFalse(form.is_valid())
+        self.assertIn("value", form.variants_formset.errors[0])
+        self.assertIn("value", form.variants_formset.errors[1])
+        self.assertNotIn("value", form.variants_formset.errors[2])
+
 
 class TestExperimentObjectivesForm(MockRequestMixin, TestCase):
 


### PR DESCRIPTION
fix #777 

Don't hesitate to criticize the approach, there might be a more elegant way (or simpler if we don't care about showing errors pn non duplicated values like it's done for unique names)