### PR TITLE
Hide confusing Optional label for technical risk description fixes #888

### DIFF
--- a/app/experimenter/templates/experiments/edit_risks.html
+++ b/app/experimenter/templates/experiments/edit_risks.html
@@ -66,8 +66,14 @@
   <script>
     $(function () {
       function updateTechnicalRisk() {
+        // Show/hide the technical risk description field.
+
+        // From the Django point of view, the description is optional. But we make it
+        // mandatory when the technical risk radio is checked.
         const hasTechnicalRisk = $('[type="radio"][name="risk_technical"][value="True"]:checked').length > 0;
         $('#id_risk_technical_description').prop("required", hasTechnicalRisk);
+        // We hide the confusing "Optional" label manually here (#888)
+        $('#risks_technical_description_field .text-muted').hide();
 
         if (hasTechnicalRisk) {
           $('#risks_technical_description_field').show();


### PR DESCRIPTION
Flipping the required attribute of a form field based on another field is not entirely obvious. I thought this was the simplest approach. Thoughts?