### PR TITLE
upgrade psycopg2

### DIFF
--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -13,7 +13,7 @@ flake8==3.2.1
 gunicorn==19.7.1
 ipdb==0.10.1
 mock==2.0.0
-psycopg2==2.6.2
+psycopg2==2.7.7
 pytest==3.10.1
 pytest-django==3.4.2
 pytest-testmon==0.9.13


### PR DESCRIPTION
I'm trying to set up `experimenter` in a virtualenv on my mac and every almost works except it can't install psycopg2 2.6.2 because it's unable to parse my version of postgresql:

```
▶ pip install psycopg2==2.6.2
Collecting psycopg2==2.6.2
  Using cached https://files.pythonhosted.org/packages/7b/a8/dc2d50a6f37c157459cd18bab381c8e6134b9381b50fbe969997b2ae7dbc/psycopg2-2.6.2.tar.gz
    Complete output from command python setup.py egg_info:
    running egg_info
    creating pip-egg-info/psycopg2.egg-info
    writing pip-egg-info/psycopg2.egg-info/PKG-INFO
    writing dependency_links to pip-egg-info/psycopg2.egg-info/dependency_links.txt
    writing top-level names to pip-egg-info/psycopg2.egg-info/top_level.txt
    writing manifest file 'pip-egg-info/psycopg2.egg-info/SOURCES.txt'
    Error: could not determine PostgreSQL version from '11.1'

    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /private/var/folders/1x/2hf5hbs902q54g3bgby5bzt40000gn/T/pip-install-xo4xvlk3/psycopg2/
```

Simply upgrading to the latest version alleviates that problem. 