### PR TITLE
less console logging if desired

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -22,3 +22,6 @@ EMAIL_HOST_PASSWORD=
 BUGZILLA_HOST=
 BUGZILLA_API_KEY=
 BUGZILLA_CC_LIST=
+
+# Enables the mozlog JSON format for console logging.
+LOGGING_USE_JSON=True

--- a/app/experimenter/settings.py
+++ b/app/experimenter/settings.py
@@ -154,6 +154,9 @@ MEDIA_ROOT = os.path.join(BASE_DIR, "media")
 MEDIA_URL = "/media/"
 
 # Logging
+
+LOGGING_USE_JSON = config("LOGGING_USE_JSON", cast=bool, default=True)
+
 LOGGING = {
     "version": 1,
     "disable_existing_loggers": True,
@@ -161,13 +164,14 @@ LOGGING = {
         "mozlog": {
             "()": "dockerflow.logging.JsonLogFormatter",
             "logger_name": "experimenter",
-        }
+        },
+        "verbose": {"format": "%(levelname)s %(asctime)s %(name)s %(message)s"},
     },
     "handlers": {
         "console": {
             "level": "DEBUG",
             "class": "logging.StreamHandler",
-            "formatter": "mozlog",
+            "formatter": "mozlog" if LOGGING_USE_JSON else "verbose",
         }
     },
     "loggers": {


### PR DESCRIPTION
Fixes #925

That JSON logging format is super verbose (no pun intended) and noisy when doing local dev with `runserver`. This config makes it possible to disable it. 