### PR TITLE
possible to reduce the default log level in dev mode

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -28,3 +28,6 @@ EXPERIMENTS_PAGINATE_BY=50
 LOGGING_USE_JSON=True
 # This will print all sent emails to stdout without requiring a server.
 EMAIL_BACKEND=django.core.mail.backends.console.EmailBackend
+# Controls what filter level to apply to logging for the console
+# handler.
+LOGGING_CONSOLE_LEVEL=INFO

--- a/app/experimenter/settings.py
+++ b/app/experimenter/settings.py
@@ -153,6 +153,9 @@ STATICFILES_DIRS = [os.path.join(BASE_DIR, "static")]
 MEDIA_ROOT = os.path.join(BASE_DIR, "media")
 MEDIA_URL = "/media/"
 
+
+LOGGING_CONSOLE_LEVEL = config("LOGGING_CONSOLE_LEVEL", default="DEBUG")
+
 # Logging
 
 LOGGING_USE_JSON = config("LOGGING_USE_JSON", cast=bool, default=True)
@@ -171,7 +174,7 @@ LOGGING = {
     },
     "handlers": {
         "console": {
-            "level": "DEBUG",
+            "level": LOGGING_CONSOLE_LEVEL,
             "class": "logging.StreamHandler",
             "formatter": "mozlog" if LOGGING_USE_JSON else "verbose",
         }


### PR DESCRIPTION
Fixes #924

By setting it to `INFO` you don't get the verbose logging for requests and `django.db`. So much less noise. 