### PR TITLE
Pref branch and type are not reflected on detail page Fixes #846

### DIFF
--- a/app/experimenter/templates/experiments/section_branches.html
+++ b/app/experimenter/templates/experiments/section_branches.html
@@ -5,6 +5,12 @@
 {% endblock %}
 
 {% block section_content %}
+  {% if experiment.pref_type %}
+  <strong>Pref Type</strong> <p>{{ experiment.pref_type }}</p>
+  {% endif %}
+  {% if experiment.pref_branch %}
+  <strong>Pref Branch</strong> <p>{{ experiment.pref_branch }}</p>
+  {% endif %}
   {% for variant in experiment.variants.all %}
     <div class="border-left-grey pl-3 mb-4">
       <h5>{{ variant.ratio }}% {{ variant.name }}</h5>


### PR DESCRIPTION
Fixes #846

Before:
<img width="910" alt="screen shot 2019-02-12 at 2 57 57 pm" src="https://user-images.githubusercontent.com/26739/52666196-98ee9980-2edb-11e9-9d3e-3c65f4377cd2.png">

After:
<img width="872" alt="screen shot 2019-02-12 at 3 33 13 pm" src="https://user-images.githubusercontent.com/26739/52666204-9f7d1100-2edb-11e9-82ad-1e3b44815199.png">

I wasn't sure how to style it but I looked at how it was done elsewhere.