### PR TITLE
No naive datetimes fixes #926

### DIFF
--- a/app/experimenter/experiments/forms.py
+++ b/app/experimenter/experiments/forms.py
@@ -1,10 +1,10 @@
-import datetime
 import json
 
 from django import forms
 from django.contrib.auth import get_user_model
 from django.forms import BaseInlineFormSet
 from django.forms import inlineformset_factory
+from django.utils import timezone
 
 from experimenter.experiments.constants import ExperimentConstants
 from experimenter.experiments import tasks
@@ -156,7 +156,7 @@ class ExperimentOverviewForm(
     def clean_proposed_start_date(self):
         start_date = self.cleaned_data["proposed_start_date"]
 
-        if start_date < datetime.date.today():
+        if start_date < timezone.now().date():
             raise forms.ValidationError(
                 (
                     "The experiment start date must "

--- a/app/experimenter/experiments/tests/factories.py
+++ b/app/experimenter/experiments/tests/factories.py
@@ -5,6 +5,7 @@ import random
 
 import factory
 from django.utils.text import slugify
+from django.utils import timezone
 from faker import Factory as FakerFactory
 
 from experimenter.experiments.constants import ExperimentConstants
@@ -39,7 +40,7 @@ class ExperimentFactory(
     related_work = "See also: https://www.example.com/myproject/"
     proposed_start_date = factory.LazyAttribute(
         lambda o: (
-            datetime.date.today()
+            timezone.now().date()
             + datetime.timedelta(days=random.randint(1, 10))
         )
     )
@@ -143,7 +144,7 @@ class ExperimentFactory(
     def create_with_status(cls, target_status, *args, **kwargs):
         experiment = cls.create_with_variants(*args, **kwargs)
 
-        now = datetime.datetime.now() - datetime.timedelta(
+        now = timezone.now() - datetime.timedelta(
             days=random.randint(100, 200)
         )
 

--- a/app/experimenter/experiments/tests/test_forms.py
+++ b/app/experimenter/experiments/tests/test_forms.py
@@ -6,6 +6,7 @@ from django import forms
 from django.core.exceptions import ValidationError
 from django.forms import inlineformset_factory
 from django.test import TestCase
+from django.utils import timezone
 
 from experimenter.experiments.forms import (
     BugzillaURLField,
@@ -187,7 +188,7 @@ class TestExperimentOverviewForm(MockRequestMixin, TestCase):
             "data_science_bugzilla_url": "https://bugzilla.mozilla.org/123/",
             "feature_bugzilla_url": "https://bugzilla.mozilla.org/123/",
             "related_work": "Designs: https://www.example.com/myproject/",
-            "proposed_start_date": datetime.date.today(),
+            "proposed_start_date": timezone.now().date(),
             "proposed_enrollment": 10,
             "proposed_duration": 20,
         }
@@ -244,7 +245,7 @@ class TestExperimentOverviewForm(MockRequestMixin, TestCase):
     def test_start_date_must_be_greater_or_equal_to_current_date(self):
         self.data[
             "proposed_start_date"
-        ] = datetime.date.today() - datetime.timedelta(days=1)
+        ] = timezone.now().date() - datetime.timedelta(days=1)
 
         form = ExperimentOverviewForm(request=self.request, data=self.data)
         self.assertFalse(form.is_valid())

--- a/app/experimenter/experiments/tests/test_models.py
+++ b/app/experimenter/experiments/tests/test_models.py
@@ -2,6 +2,7 @@ import datetime
 
 from django.conf import settings
 from django.test import TestCase
+from django.utils import timezone
 
 from experimenter.openidc.tests.factories import UserFactory
 from experimenter.experiments.models import (
@@ -19,7 +20,7 @@ from experimenter.experiments.tests.factories import (
 class TestExperimentManager(TestCase):
 
     def test_queryset_annotated_with_latest_change(self):
-        now = datetime.datetime.now()
+        now = timezone.now()
         experiment1 = ExperimentFactory.create_with_variants()
         experiment2 = ExperimentFactory.create_with_variants()
 
@@ -294,9 +295,9 @@ class TestExperimentModel(TestCase):
     def test_grouped_changes_groups_by_date_then_user(self):
         experiment = ExperimentFactory.create()
 
-        date1 = datetime.datetime.now() - datetime.timedelta(days=2)
-        date2 = datetime.datetime.now() - datetime.timedelta(days=1)
-        date3 = datetime.datetime.now()
+        date1 = timezone.now() - datetime.timedelta(days=2)
+        date2 = timezone.now() - datetime.timedelta(days=1)
+        date3 = timezone.now()
 
         user1 = UserFactory.create()
         user2 = UserFactory.create()
@@ -385,9 +386,9 @@ class TestExperimentModel(TestCase):
     def test_ordered_changes_orders_by_date(self):
         experiment = ExperimentFactory.create()
 
-        date1 = datetime.datetime.now() - datetime.timedelta(days=2)
-        date2 = datetime.datetime.now() - datetime.timedelta(days=1)
-        date3 = datetime.datetime.now()
+        date1 = timezone.now() - datetime.timedelta(days=2)
+        date2 = timezone.now() - datetime.timedelta(days=1)
+        date3 = timezone.now()
 
         user1 = UserFactory.create()
         user2 = UserFactory.create()
@@ -681,7 +682,7 @@ class TestExperimentModel(TestCase):
 class TestExperimentChangeLog(TestCase):
 
     def test_latest_returns_most_recent_changelog(self):
-        now = datetime.datetime.now()
+        now = timezone.now()
         experiment = ExperimentFactory.create_with_variants()
 
         changelog1 = ExperimentChangeLogFactory.create(

--- a/app/experimenter/experiments/tests/test_views.py
+++ b/app/experimenter/experiments/tests/test_views.py
@@ -7,6 +7,7 @@ import mock
 from django.conf import settings
 from django.test import TestCase
 from django.urls import reverse
+from django.utils import timezone
 
 from experimenter.experiments.forms import (
     ExperimentVariantsAddonForm,
@@ -395,7 +396,7 @@ class TestExperimentCreateView(TestCase):
             "data_science_bugzilla_url": "https://bugzilla.mozilla.org/123/",
             "feature_bugzilla_url": "https://bugzilla.mozilla.org/123/",
             "related_work": "Designs: https://www.example.com/myproject/",
-            "proposed_start_date": datetime.date.today(),
+            "proposed_start_date": timezone.now().date(),
             "proposed_enrollment": 10,
             "proposed_duration": 20,
         }
@@ -428,7 +429,7 @@ class TestExperimentOverviewUpdateView(TestCase):
             Experiment.STATUS_DRAFT, proposed_enrollment=1, proposed_duration=2
         )
 
-        new_start_date = datetime.date.today() + datetime.timedelta(
+        new_start_date = timezone.now().date() + datetime.timedelta(
             days=random.randint(1, 100)
         )
         new_enrollment = experiment.proposed_enrollment + 1


### PR DESCRIPTION
Ahhh. No more 6 pages of pytest warnings when running `pytest`