### PR TITLE
Add a reference to #ask-experimenter slack

### DIFF
--- a/app/experimenter/templates/base.html
+++ b/app/experimenter/templates/base.html
@@ -45,6 +45,11 @@
               ({{ request.user.experiment_set.count }} Experiment{{ request.user.experiment_set.count|pluralize:"s" }})
             </a>
             <br/>
+            <a class="text-white" href="slack://channel?id=CF94YGE03">
+              <span class="fab fa-slack"></span>
+              #ask-experimenter on Slack
+            </a>
+            &nbsp;
             <a class="text-white" target="_blank" rel="noreferrer noopener" href="https://github.com/mozilla/experimenter/issues/new">
               <span class="fas fa-comment-alt"></span>
               Leave Feedback


### PR DESCRIPTION
Fixes #764 

The spacing between the two links isn't great but it's probably as good as it's going to get under the size constraints.

<img width="415" alt="screen shot 2019-02-19 at 4 33 27 pm" src="https://user-images.githubusercontent.com/26739/53049111-593c2a80-3464-11e9-9ada-8a2a8fdd863e.png">

By the way, I think our Font Awesome is out of date. Compare the screenshot above with: https://fontawesome.com/icons?d=gallery&q=slack&m=free
But, all we need to do is upgrade Font Awesome and I think this'll automatically fix. 
