### PR TITLE
Invalid HTML in lots of places fixes #954

### DIFF
--- a/app/experimenter/experiments/constants.py
+++ b/app/experimenter/experiments/constants.py
@@ -475,13 +475,11 @@ class ExperimentConstants(object):
         analyzed to determine the outcome of the study,
         and who will be responsible for that analysis.
       </p>
-      <p>
-        <strong>Example:</strong>
-        <p>Unique page views</p>
-        <p>Usage hours</p>
-        <p>Attracting heavy users and influencers.</p>
-        <p>Understanding the landscape of the web (research)</p>
-      </p>
+      <p><strong>Example:</strong></p>
+      <p>Unique page views</p>
+      <p>Usage hours</p>
+      <p>Attracting heavy users and influencers.</p>
+      <p>Understanding the landscape of the web (research)</p>
     """
 
     RISKS_HELP_TEXT = """

--- a/app/experimenter/static/css/experimenter.css
+++ b/app/experimenter/static/css/experimenter.css
@@ -85,10 +85,10 @@ select {
 }
 
 .heavy-line {
-   border: 0; 
-  height: 1px; 
-  background: #333; 
-  background-image: linear-gradient(to right, #ccc, #333, #ccc); 
+   border: 0;
+  height: 1px;
+  background: #333;
+  background-image: linear-gradient(to right, #ccc, #333, #ccc);
 }
 
 .status-pill {
@@ -152,11 +152,11 @@ select {
 }
 
 .border-bottom-blue {
-	border-bottom: 3px solid #45a1ff; 
+	border-bottom: 3px solid #45a1ff;
 }
 
 .border-bottom-green {
-	border-bottom: 3px solid #30e60b; 
+	border-bottom: 3px solid #30e60b;
 }
 
 .border-bottom-teal {
@@ -166,4 +166,8 @@ select {
 .bubble {
   border-radius: 4px;
 	background-color: #F3F3F3;
+}
+
+label .optional-marker {
+  display: block;
 }

--- a/app/experimenter/templates/base.html
+++ b/app/experimenter/templates/base.html
@@ -32,7 +32,7 @@
             <h3 class="pt-2">
               <a class="noanchorstyle" href="{% url "home" %}">
                 <svg id="header-icon">
-                  <?xml version="1.0" ?><svg viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg"><defs></defs><title/><rect class="a" height="21" rx="4" ry="4" width="12" x="2" y="40"/><rect class="a" height="40" rx="4" ry="4" width="12" x="18" y="21"/><rect class="a" height="30" rx="4" ry="4" width="12" x="34" y="31"/><rect class="a" height="51" rx="4" ry="4" width="12" x="50" y="10"/></svg>
+                  <svg viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg"><defs></defs><title/><rect class="a" height="21" rx="4" ry="4" width="12" x="2" y="40"/><rect class="a" height="40" rx="4" ry="4" width="12" x="18" y="21"/><rect class="a" height="30" rx="4" ry="4" width="12" x="34" y="31"/><rect class="a" height="51" rx="4" ry="4" width="12" x="50" y="10"/></svg>
                 </svg>
                 <strong>Mozilla</strong> Experimenter
               </a>
@@ -41,7 +41,7 @@
           <div class="col text-right">
             <span class="fas fa-user"></span>
             {{ request.user }}
-            <a class="nocolorstyle" href="{% url "home" %}?owner={{ request.user.id }}&archived=on">
+            <a class="nocolorstyle" href="{% url "home" %}?owner={{ request.user.id }}&amp;archived=on">
               ({{ request.user.experiment_set.count }} Experiment{{ request.user.experiment_set.count|pluralize:"s" }})
             </a>
             <br/>

--- a/app/experimenter/templates/experiments/detail_base.html
+++ b/app/experimenter/templates/experiments/detail_base.html
@@ -20,21 +20,21 @@
     <div class="col py-2">
       {% if experiment.bugzilla_url %}
         <a class="alert-link mr-4" target="_blank" rel="noreferrer noopener" href="{{ experiment.bugzilla_url }}">
-          <img class="link-icon" src="{% static "imgs/bugzilla.png" %}">
+          <img class="link-icon" src="{% static "imgs/bugzilla.png" %}" alt="bugzilla">
           Experiment Bugzilla Ticket
         </a>
       {% endif %}
 
       {% if experiment.data_science_bugzilla_url %}
         <a class="alert-link mr-4" target="_blank" rel="noreferrer noopener" href="{{ experiment.data_science_bugzilla_url }}">
-          <img class="link-icon" src="{% static "imgs/bugzilla.png" %}">
+          <img class="link-icon" src="{% static "imgs/bugzilla.png" %}" alt="bugzilla">
           Data Science Bugzilla Ticket
         </a>
       {% endif %}
 
       {% if experiment.feature_bugzilla_url %}
         <a class="alert-link mr-4" target="_blank" rel="noreferrer noopener" href="{{ experiment.feature_bugzilla_url }}">
-          <img class="link-icon" src="{% static "imgs/bugzilla.png" %}">
+          <img class="link-icon" src="{% static "imgs/bugzilla.png" %}" alt="bugzilla">
           Feature Bugzilla Ticket
         </a>
       {% endif %}
@@ -71,7 +71,7 @@
 {% endblock %}
 
 {% block main_sidebar %}
-  <h4>&nbsp</h4>
+  <h4>&nbsp;</h4>
 
   {% block main_sidebar_extra %}
   {% endblock %}

--- a/app/experimenter/templates/experiments/edit_objectives.html
+++ b/app/experimenter/templates/experiments/edit_objectives.html
@@ -1,9 +1,9 @@
 {% extends "experiments/edit_base.html" %}
 
 {% load static %}
-      
+
 {% block edit_title %}
-  Edit {{ object.name }} Objectives & Analysis
+  Edit {{ object.name }} Objectives &amp; Analysis
 {% endblock %}
 
 {% block edit_nav %}
@@ -11,7 +11,7 @@
 {% endblock %}
 
 {% block edit_info %}
-  <h4><span class="fas fa-info-circle"></span> Objectives & Analysis</h4>
+  <h4><span class="fas fa-info-circle"></span> Objectives &amp; Analysis</h4>
   <p>
     The objective of your experiment is the thing you are trying to measure or learn
     by doing the experiment.

--- a/app/experimenter/templates/experiments/edit_risks.html
+++ b/app/experimenter/templates/experiments/edit_risks.html
@@ -3,7 +3,7 @@
 {% load static %}
 
 {% block edit_title %}
-  Edit {{ object.name }} Risks & Testing
+  Edit {{ object.name }} Risks &amp; Testing
 {% endblock %}
 
 {% block edit_nav %}
@@ -52,7 +52,7 @@
 {% endblock %}
 
 {% block edit_info %}
-  <h4><span class="fas fa-info-circle"></span> Risks & Testing</h4>
+  <h4><span class="fas fa-info-circle"></span> Risks &amp; Testing</h4>
   <p>
     An experiment may have risks to its user population or the entire Firefox population, help identify them here.
   </p>

--- a/app/experimenter/templates/experiments/edit_variants.html
+++ b/app/experimenter/templates/experiments/edit_variants.html
@@ -47,7 +47,7 @@
           </div>
 
         </div>
-				
+
         {% include "experiments/field_errors_inline.html" with field=form.population_percent %}
 
         <div id="population-percent-help" class="collapse text-muted">

--- a/app/experimenter/templates/experiments/field_inline.html
+++ b/app/experimenter/templates/experiments/field_inline.html
@@ -3,7 +3,7 @@
     <label class="col-form-label" for="{{ field.id_for_label }}">
       <strong>{{ field.label }}</strong>
       {% if not field.field.required %}
-        <div class="text-muted">Optional</div>
+        <span class="text-muted optional-marker">Optional</span>
       {% endif %}
     </label>
     <br>


### PR DESCRIPTION
Fixes #954

Unfortunately, the [instructions for `django-formset-js`](https://github.com/pretix/django-formset-js#render-the-formset) force you to use invalid HTML. I.e. 

```html
<script type="form-template" data-formset-empty-form>
```
...is not valid HTML5 because the type (if not `text/javascript`) [must to be a valid MIME type](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script)  like `form/template`. 