### PR TITLE
Include the Mozilla GitHub repository code of conduct fixes #963

### DIFF
--- a/code_of_conduct.md
+++ b/code_of_conduct.md
@@ -1,0 +1,15 @@
+## Community Participation Guidelines
+
+This repository is governed by Mozilla's code of conduct and etiquette guidelines.
+For more details, please read
+[Mozilla Community Participation Guidelines](https://www.mozilla.org/about/governance/policies/participation/).
+
+## How to Report
+For more information on how to report violations of the CPG, please read our '[How to Report](https://www.mozilla.org/en-US/about/governance/policies/participation/reporting/)' page.
+
+
+## Contributions
+
+For all other questions about contribution see our
+[contributing.md](https://github.com/mozilla/experimenter/blob/master/contributing.md)
+document.


### PR DESCRIPTION
Fixes #963 

So this is going to depend on the work of https://github.com/mozilla/experimenter/pull/928 which is going to need to land first. 

(Perhaps I should have contributed this patch to that PR instead?)