### PR TITLE
disallow incompatible python package versions

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -17,4 +17,8 @@ COPY ./requirements /app/requirements
 
 RUN pip install -r requirements/default.txt --no-cache-dir --disable-pip-version-check
 
+# If any package is installed, that is incompatible by version, this command
+# will exit non-zero and print what is usually just a warning in `pip install`
+RUN pip check
+
 COPY . /app

--- a/app/requirements/constraints.txt
+++ b/app/requirements/constraints.txt
@@ -11,8 +11,8 @@ attrs==18.2.0 \
 appdirs==1.4.3 \
     --hash=sha256:9e5896d1372858f8dd3344faf4e5014d21849c756c8d5701f78f8a103b372d92 \
     --hash=sha256:d8b24664561d0d34ddfaec54636d502d7cea6e29c3eaf68f3df6180863e2166e
-billiard==3.6.0.0 \
-    --hash=sha256:756bf323f250db8bf88462cd042c992ba60d8f5e07fc5636c24ba7d6f4261d84
+billiard==3.5.0.5 \
+    --hash=sha256:42d9a227401ac4fba892918bba0a0c409def5435c4b483267ebfe821afaaba0e
 kombu==4.4.0 \
     --hash=sha256:b1a68fe8a1144eab0359be6bbae5e03b6684c98b9b53de7a17ce6d64ef24e4ea \
     --hash=sha256:750579c10e4ce82636cebdaad3cfc96970b4c7c483a040bb94fb52040bc53a48


### PR DESCRIPTION
Fixes #1017 

Most importantly, this reverts the [billiard 3.6.0.0](https://github.com/mozilla/experimenter/pull/988) upgrade. Now `pytest` works again on a fresh new virutalenv. 

With this new `pip check`, we won't allow accidentally merge in Dependabot PRs that upgrades packages that are NOT compatible with each other. 

Word of warning: I have seen situations where `pip check` would fail but there's no actual problem. E.g on my personal blog, which also uses Django I get this:

```
▶ pip check
awesome-slugify 1.6.5 has requirement Unidecode<0.05,>=0.04.14, but you have unidecode 1.0.23.
```

I know it doesn't actually break things in runtime. 

So, mayhaps one day we have a pypi package complaining about being installed together with so other package but we know in our hearts that it's supposed to be ignored. (Like the warning `pip install` yields when there are incompatible versions). That day we can tackle it. Unfortunately, there's nothing like `pip check --ignore=foo`