### PR TITLE
Fix #1011 #ask-experimenter deep link

### DIFF
--- a/app/experimenter/templates/base.html
+++ b/app/experimenter/templates/base.html
@@ -45,7 +45,7 @@
               ({{ request.user.experiment_set.count }} Experiment{{ request.user.experiment_set.count|pluralize:"s" }})
             </a>
             <br/>
-            <a class="text-white" href="slack://channel?id=CF94YGE03">
+            <a class="text-white" href="slack://channel?team=T027LFU12&id=CF94YGE03">
               <span class="fab fa-slack"></span>
               #ask-experimenter on Slack
             </a>


### PR DESCRIPTION
Adds the team ID to the #ask-experimenter link per [slack deep linking docs](https://api.slack.com/docs/deep-linking#open_a_channel). 