### PR TITLE
Enforce maximum normandy slug length fixes #1078

### DIFF
--- a/app/experimenter/experiments/forms.py
+++ b/app/experimenter/experiments/forms.py
@@ -1,6 +1,7 @@
 import json
 
 from django import forms
+from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.db import transaction
 from django.forms import BaseInlineFormSet
@@ -447,6 +448,7 @@ class ExperimentVariantsAddonForm(ExperimentVariantsBaseForm):
         help_text=Experiment.ADDON_NAME_HELP_TEXT,
     )
     addon_experiment_id = forms.CharField(
+        max_length=settings.NORMANDY_SLUG_MAX_LEN,
         required=False,
         label="Active Experiment Name",
         help_text=Experiment.ADDON_EXPERIMENT_ID_HELP_TEXT,

--- a/app/experimenter/experiments/models.py
+++ b/app/experimenter/experiments/models.py
@@ -277,10 +277,8 @@ class Experiment(ExperimentConstants, models.Model):
             f"-{self.firefox_channel}-{self.firefox_version}-"
             f"bug-{self.bugzilla_id}"
         )
-        remaining_chars = (
-            settings.NORMANDY_SLUG_MAX_LEN
-            - len(slug_prefix)
-            - len(slug_postfix)
+        remaining_chars = settings.NORMANDY_SLUG_MAX_LEN - len(
+            slug_prefix + slug_postfix
         )
         truncated_slug = self.slug[:remaining_chars]
         return f"{slug_prefix}{truncated_slug}{slug_postfix}".lower()

--- a/app/experimenter/experiments/models.py
+++ b/app/experimenter/experiments/models.py
@@ -272,10 +272,18 @@ class Experiment(ExperimentConstants, models.Model):
         if not self.bugzilla_id:
             raise ValueError(error_msg.format(field="Bugzilla ID"))
 
-        return (
-            f"{self.type}-{self.slug}-{self.firefox_channel}"
-            f"-{self.firefox_version}-bug-{self.bugzilla_id}"
-        ).lower()
+        slug_prefix = f"{self.type}-"
+        slug_postfix = (
+            f"-{self.firefox_channel}-{self.firefox_version}-"
+            f"bug-{self.bugzilla_id}"
+        )
+        remaining_chars = (
+            settings.NORMANDY_SLUG_MAX_LEN
+            - len(slug_prefix)
+            - len(slug_postfix)
+        )
+        truncated_slug = self.slug[:remaining_chars]
+        return f"{slug_prefix}{truncated_slug}{slug_postfix}".lower()
 
     @property
     def has_external_urls(self):

--- a/app/experimenter/experiments/tests/test_forms.py
+++ b/app/experimenter/experiments/tests/test_forms.py
@@ -3,6 +3,7 @@ import decimal
 import json
 
 from django import forms
+from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.test import TestCase
 from django.utils import timezone
@@ -898,6 +899,25 @@ class TestExperimentVariantsAddonForm(MockRequestMixin, TestCase):
         form = ExperimentVariantsAddonForm(
             request=self.request, data=self.data, instance=experiment2
         )
+        self.assertFalse(form.is_valid())
+        self.assertIn("addon_experiment_id", form.errors)
+
+    def test_addon_experiment_id_is_within_normandy_slug_max_len(self):
+        experiment = ExperimentFactory.create(
+            addon_name=None,
+            addon_experiment_id=None,
+            addon_testing_url=None,
+            addon_release_url=None,
+        )
+
+        self.data["addon_experiment_id"] = "-" * (
+            settings.NORMANDY_SLUG_MAX_LEN + 1
+        )
+
+        form = ExperimentVariantsAddonForm(
+            request=self.request, data=self.data, instance=experiment
+        )
+
         self.assertFalse(form.is_valid())
         self.assertIn("addon_experiment_id", form.errors)
 

--- a/app/experimenter/experiments/tests/test_models.py
+++ b/app/experimenter/experiments/tests/test_models.py
@@ -224,6 +224,23 @@ class TestExperimentModel(TestCase):
             experiment.generate_normandy_slug(), "addon_experiment_id"
         )
 
+    def test_generate_normandy_slug_is_shorter_than_max_normandy_len(self):
+        experiment = ExperimentFactory.create(
+            type=Experiment.TYPE_PREF,
+            slug="-" * (settings.NORMANDY_SLUG_MAX_LEN + 1),
+            firefox_version="57.0",
+            firefox_channel="Nightly",
+            bugzilla_id="12345",
+        )
+
+        self.assertGreater(
+            len(experiment.slug), settings.NORMANDY_SLUG_MAX_LEN
+        )
+
+        normandy_slug = experiment.generate_normandy_slug()
+
+        self.assertEqual(len(normandy_slug), settings.NORMANDY_SLUG_MAX_LEN)
+
     def test_start_date_returns_proposed_start_date_if_change_is_missing(self):
         experiment = ExperimentFactory.create_with_variants()
         self.assertEqual(experiment.start_date, experiment.proposed_start_date)

--- a/app/experimenter/settings.py
+++ b/app/experimenter/settings.py
@@ -273,3 +273,6 @@ REDIS_DB = config("REDIS_DB")
 CELERY_BROKER_URL = "redis://{host}:{port}/{db}".format(
     host=REDIS_HOST, port=REDIS_PORT, db=REDIS_DB
 )
+
+# Normandy Configuration
+NORMANDY_SLUG_MAX_LEN = 80


### PR DESCRIPTION
- Check the Addon Experiment ID since that will be used as the Normandy Slug verbatim for Add-on experiments
- Truncate the Experimenter slug so that the Normandy Slug is within the max for pref experiments

I didn't add a hard limit to the actual model field because there are past experiments that do have slugs that are longer than this limit and the behaviour as it relates to normandy is poorly defined, but I do want to be able to capture them accurately in our database, so we should enforce it for new experiments going forward.