### PR TITLE
Use ChangeLog labels and add missing ones fixes #1097

### DIFF
--- a/app/experimenter/experiments/constants.py
+++ b/app/experimenter/experiments/constants.py
@@ -27,7 +27,7 @@ class ExperimentConstants(object):
     STATUS_DRAFT_LABEL = "Draft"
     STATUS_REVIEW_LABEL = "Ready for Sign-Off"
     STATUS_SHIP_LABEL = "Ready to Ship"
-    STATUS_ACCEPTED_LABEL = "Accepted by Shield"
+    STATUS_ACCEPTED_LABEL = "Accepted by Normandy"
     STATUS_LIVE_LABEL = "Live"
     STATUS_COMPLETE_LABEL = "Complete"
     STATUS_REJECTED_LABEL = "Rejected"

--- a/app/experimenter/experiments/constants.py
+++ b/app/experimenter/experiments/constants.py
@@ -27,7 +27,7 @@ class ExperimentConstants(object):
     STATUS_DRAFT_LABEL = "Draft"
     STATUS_REVIEW_LABEL = "Ready for Sign-Off"
     STATUS_SHIP_LABEL = "Ready to Ship"
-    STATUS_ACCEPTED_LABEL = "Accepted by Normandy"
+    STATUS_ACCEPTED_LABEL = "Accepted by Shield"
     STATUS_LIVE_LABEL = "Live"
     STATUS_COMPLETE_LABEL = "Complete"
     STATUS_REJECTED_LABEL = "Rejected"

--- a/app/experimenter/experiments/models.py
+++ b/app/experimenter/experiments/models.py
@@ -541,13 +541,14 @@ class ExperimentChangeLogManager(models.Manager):
 
 
 class ExperimentChangeLog(models.Model):
-    STATUS_NONE_DRAFT = "Created Draft"
-    STATUS_DRAFT_DRAFT = "Edited Draft"
+    STATUS_NONE_DRAFT = "Created Experiment"
+    STATUS_DRAFT_DRAFT = "Edited Experiment"
     STATUS_DRAFT_REVIEW = "Ready for Sign-Off"
     STATUS_REVIEW_DRAFT = "Return to Draft"
+    STATUS_REVIEW_REVIEW = "Edited Experiment"
     STATUS_REVIEW_SHIP = "Marked as Ready to Ship"
-    STATUS_REVIEW_REJECTED = "Review Rejected"
-    STATUS_SHIP_ACCEPTED = "Accepted by Shield"
+    STATUS_REVIEW_REJECTED = "Experiment Rejected"
+    STATUS_SHIP_ACCEPTED = "Accepted by Normandy"
     STATUS_SHIP_REVIEW = "Canceled Ready to Ship"
     STATUS_ACCEPTED_LIVE = "Launched Experiment"
     STATUS_LIVE_COMPLETE = "Completed Experiment"
@@ -561,6 +562,7 @@ class ExperimentChangeLog(models.Model):
         },
         Experiment.STATUS_REVIEW: {
             Experiment.STATUS_DRAFT: STATUS_REVIEW_DRAFT,
+            Experiment.STATUS_REVIEW: STATUS_REVIEW_REVIEW,
             Experiment.STATUS_SHIP: STATUS_REVIEW_SHIP,
             Experiment.STATUS_REJECTED: STATUS_REVIEW_REJECTED,
         },

--- a/app/experimenter/experiments/tests/test_models.py
+++ b/app/experimenter/experiments/tests/test_models.py
@@ -852,14 +852,11 @@ class TestExperimentChangeLog(TestCase):
     def test_pretty_status_created_draft(self):
         experiment = ExperimentFactory.create_with_variants()
 
-        for old_status in ExperimentChangeLog.PRETTY_STATUS_LABELS.keys():
-            for new_status in ExperimentChangeLog.PRETTY_STATUS_LABELS[
-                old_status
-            ].keys():
-                expected_label = ExperimentChangeLog.PRETTY_STATUS_LABELS[
-                    old_status
-                ][new_status]
-
+        for (
+            old_status,
+            new_statuses,
+        ) in ExperimentChangeLog.PRETTY_STATUS_LABELS.items():
+            for new_status, expected_label in new_statuses.items():
                 changelog = ExperimentChangeLogFactory.create(
                     experiment=experiment,
                     old_status=old_status,


### PR DESCRIPTION
I changed my mind.  Rather than ditching the ChangeLog labels altogether and just emitting the status, we should keep it and just add the ones that were missing.  I thought it would be simpler to just emit the target status, but that loses two really important states: Created Experiment, Edited Experiment.  We shouldn't lose those.  So I'm reverting yesterdays change and adding the missing labels.  Sorry for all the back and forth.