### PR TITLE
Add text search for experiment details

### DIFF
--- a/app/experimenter/settings.py
+++ b/app/experimenter/settings.py
@@ -43,6 +43,7 @@ INSTALLED_APPS = [
     "django.contrib.sessions",
     "django.contrib.messages",
     "django.contrib.staticfiles",
+    "django.contrib.postgres",
     "django.forms",
     "corsheaders",
     "raven.contrib.django.raven_compat",

--- a/app/experimenter/templates/experiments/list.html
+++ b/app/experimenter/templates/experiments/list.html
@@ -147,6 +147,12 @@
     {% endfor %}
 
     <div class="form-group text-right">
+      {% if filter.has_any_filtering %}
+      <a href="." class="btn btn-secondary">
+        <span class="fas fa-times-circle"></span>
+        Clear
+      </a>
+      {% endif %}
       <button type="submit" class="btn btn-primary">
         <span class="fas fa-check"></span>
         Apply


### PR DESCRIPTION
Fixes #400 

<img width="1288" alt="Screen Shot 2019-03-22 at 5 17 08 PM" src="https://user-images.githubusercontent.com/26739/54853532-862f6780-4cc6-11e9-9c25-b8f560a55ccb.png">

Works. But...

* No tests at all. 
* If a freetext search is one of the active filters, it should offer to sort by ranking. 
* There's **weight** parameter sent to the `SearchVector` instance. You'd probably want to prioritize `name` over `short_description` for example. 
* Should search on things like `slug` too. 
* There's no DB index to make the search fast. But it probably doesn't need one for a long time since the database is so tiny and there [much bigger fish to fry](https://github.com/mozilla/experimenter/issues/1075).
