### PR TITLE
Add date range filter to view fixes #799

### DIFF
--- a/app/experimenter/experiments/constants.py
+++ b/app/experimenter/experiments/constants.py
@@ -12,6 +12,11 @@ class ExperimentConstants(object):
 
     TYPE_CHOICES = ((TYPE_PREF, "Pref-Flip"), (TYPE_ADDON, "Add-On"))
 
+    # date range stuff
+    EXPERIMENT_STARTS = "starting"
+    EXPERIMENT_PAUSES = "pausing"
+    EXPERIMENT_ENDS = "ending"
+
     # Status stuff
     STATUS_DRAFT = "Draft"
     STATUS_REVIEW = "Review"

--- a/app/experimenter/static/js/experiment-date-filter.js
+++ b/app/experimenter/static/js/experiment-date-filter.js
@@ -1,0 +1,19 @@
+let dateRangeSelector = document.getElementById('id_experiment_date_field');
+let rangeElementInput0 = document.getElementById("id_date_range_0");
+let rangeElementInput1 = document.getElementById("id_date_range_1");
+
+
+function setUpDateRange () {
+  if (dateRangeSelector.value == '') {
+    rangeElementInput0.setAttribute("disabled", "")
+    rangeElementInput1.setAttribute("disabled", "")
+  } else {
+    rangeElementInput0.removeAttribute("disabled");
+    rangeElementInput1.removeAttribute("disabled");
+  }
+}
+
+setUpDateRange();
+
+
+dateRangeSelector.addEventListener("change", setUpDateRange);

--- a/app/experimenter/templates/experiments/list.html
+++ b/app/experimenter/templates/experiments/list.html
@@ -39,6 +39,9 @@
       with text "{{ filter.form.search.value }}"
     {% endif %}
 
+    {{ filter.form.get_display_start_date_info }}
+
+
     {% if is_paginated and page_obj.number > 1 %}
       <small class="text-muted">Page {{ page_obj.number }}</small>
     {% endif %}
@@ -138,16 +141,22 @@
     </div>
 
     {% for field in filter.form %}
-      {% ifequal field.name "archived" %}
+      {% if field.name == "archived" %}
         <label>
           {{ field }}
           {{ field.label }}
         </label>
+      {% elif field.name == "experiment_date_field" %}
+        <hr class="my-4">
+        <div class="form-group">
+          {{ field }}
+        </div>
+
       {% else %}
         <div class="form-group">
           {{ field }}
         </div>
-      {% endifequal %}
+      {% endif %}
     {% endfor %}
 
     <div class="form-group text-right">
@@ -157,4 +166,8 @@
       </button>
     </div>
   </form>
+{% endblock %}
+
+{% block extrascripts %}
+  <script src="{% static "js/experiment-date-filter.js" %}"></script>
 {% endblock %}

--- a/app/experimenter/templates/widgets/date_range.html
+++ b/app/experimenter/templates/widgets/date_range.html
@@ -1,0 +1,8 @@
+{# this is based off of https://github.com/carltongibson/django-filter/blob/master/django_filters/templates/django_filters/widgets/multiwidget.html #}
+
+<label class="mb-1">From</label>
+{% for widget in widget.subwidgets %}{% include widget.template_name %}
+  {% if forloop.first %}
+    <label class="mt-2">To</label>
+  {% endif %}
+{% endfor %}


### PR DESCRIPTION
Fixes #799 

With this PR I'm adding a new feature that allows a user to search for experiments by date range (after a certain date but before another) or by a single date (i.e. all experiments that pause after date X). 


![Screen Shot 2019-04-18 at 3 52 59 PM](https://user-images.githubusercontent.com/1551682/56396099-2effb280-61f2-11e9-82c8-c4c0abc3d2e5.png)

If users fill in one date but not the other, we assume they want all experiments up to or after that date.

![date-range-demo](https://user-images.githubusercontent.com/1551682/56396371-50ad6980-61f3-11e9-9a60-7f8c83f051f4.gif)

We make sure the title of the page reflects the way in which the user is interacting with the date range filter. Below, the user is using both dates to create a range:
![Screen Shot 2019-04-18 at 3 57 00 PM](https://user-images.githubusercontent.com/1551682/56396410-85b9bc00-61f3-11e9-8f67-a9728035cf25.png)
 

And here, the user wants all experiments after a date and until the end of time. 

![Screen Shot 2019-04-18 at 3 57 47 PM](https://user-images.githubusercontent.com/1551682/56396420-9407d800-61f3-11e9-8e09-36d757dbac8c.png)


