### PR TITLE
Add free text search to filter list fixes #400

### DIFF
--- a/app/experimenter/experiments/tests/test_views.py
+++ b/app/experimenter/experiments/tests/test_views.py
@@ -177,6 +177,84 @@ class TestExperimentFilterset(TestCase):
             set(Experiment.objects.filter(firefox_channel=include_channel)),
         )
 
+    def test_list_filters_by_search_text(self):
+        user_email = "user@example.com"
+
+        exp_1 = ExperimentFactory.create_with_status(
+            random.choice(Experiment.STATUS_CHOICES)[0],
+            name="Experiment One Cat",
+            short_description="",
+            slug="exp-1",
+            related_work="",
+            addon_experiment_id="1",
+            pref_key="",
+            public_name="",
+            public_description="",
+            objectives="",
+            analysis="",
+            analysis_owner="",
+            engineering_owner="",
+            bugzilla_id="4",
+            normandy_slug="",
+        )
+
+        exp_2 = ExperimentFactory.create_with_status(
+            random.choice(Experiment.STATUS_CHOICES)[0],
+            name="Experiment Two Cat",
+            short_description="",
+            slug="exp-2",
+            related_work="",
+            addon_experiment_id="2",
+            pref_key="",
+            public_name="",
+            public_description="",
+            objectives="",
+            analysis="",
+            analysis_owner="",
+            engineering_owner="",
+            bugzilla_id="5",
+            normandy_slug="",
+        )
+
+        exp_3 = ExperimentFactory.create_with_status(
+            random.choice(Experiment.STATUS_CHOICES)[0],
+            name="Experiment Three Dog",
+            short_description="",
+            slug="exp-3",
+            related_work="",
+            addon_experiment_id="3",
+            pref_key="",
+            public_name="",
+            public_description="",
+            objectives="",
+            analysis="",
+            analysis_owner="",
+            engineering_owner="",
+            bugzilla_id="6",
+            normandy_slug="",
+        )
+
+        first_response_context = self.client.get(
+            "{url}?{params}".format(
+                url=reverse("home"), params=urlencode({"search": "Cat"})
+            ),
+            **{settings.OPENIDC_EMAIL_HEADER: user_email},
+        ).context[0]
+
+        second_response_context = self.client.get(
+            "{url}?{params}".format(
+                url=reverse("home"), params=urlencode({"search": "Dog"})
+            ),
+            **{settings.OPENIDC_EMAIL_HEADER: user_email},
+        ).context[0]
+
+        self.assertEqual(
+            set(first_response_context["experiments"]), set([exp_1, exp_2])
+        )
+        self.assertEqual(
+            set(second_response_context["experiments"]), set([exp_3])
+        )
+
 
 class TestExperimentOrderingForm(TestCase):
 

--- a/app/experimenter/experiments/views.py
+++ b/app/experimenter/experiments/views.py
@@ -7,6 +7,11 @@ from django.shortcuts import redirect
 from django.views.generic import CreateView, DetailView, UpdateView
 from django.views.generic.edit import ModelFormMixin
 from django_filters.views import FilterView
+from django.contrib.postgres.search import (
+    SearchQuery,
+    SearchRank,
+    SearchVector,
+)
 
 from experimenter.projects.models import Project
 from experimenter.experiments.forms import (
@@ -25,9 +30,12 @@ from experimenter.experiments.models import Experiment
 
 class ExperimentFiltersetForm(forms.ModelForm):
 
+    search = forms.CharField(required=False)
+
     class Meta:
         model = Experiment
         fields = (
+            "search",
             "type",
             "status",
             "firefox_channel",
@@ -65,6 +73,17 @@ class ExperimentFiltersetForm(forms.ModelForm):
 
 
 class ExperimentFilterset(filters.FilterSet):
+    search = filters.CharFilter(
+        method="filter_search",
+        widget=forms.widgets.TextInput(
+            attrs={
+                "class": "form-control",
+                "type": "search",
+                "placeholder": "Search Experiments",
+            }
+        ),
+    )
+
     type = filters.ChoiceFilter(
         empty_label="All Types",
         choices=Experiment.TYPE_CHOICES,
@@ -103,6 +122,33 @@ class ExperimentFilterset(filters.FilterSet):
         model = Experiment
         form = ExperimentFiltersetForm
         fields = ExperimentFiltersetForm.Meta.fields
+
+    def filter_search(self, queryset, name, value):
+        vector = SearchVector(
+            "name",
+            "short_description",
+            "owner__email",
+            "slug",
+            "related_work",
+            "addon_experiment_id",
+            "pref_key",
+            "public_name",
+            "public_description",
+            "objectives",
+            "analysis",
+            "analysis_owner",
+            "engineering_owner",
+            "bugzilla_id",
+            "normandy_slug",
+        )
+
+        query = SearchQuery(value)
+
+        return (
+            queryset.annotate(rank=SearchRank(vector, query), search=vector)
+            .filter(search=value)
+            .order_by("-rank")
+        )
 
 
 class ExperimentOrderingForm(forms.Form):

--- a/app/experimenter/templates/experiments/list.html
+++ b/app/experimenter/templates/experiments/list.html
@@ -35,6 +35,10 @@
       by {{ filter.form.get_owner_display_value }}
     {% endif %}
 
+    {% if filter.form.search.value %}
+      with text "{{ filter.form.search.value }}"
+    {% endif %}
+
     {% if is_paginated and page_obj.number > 1 %}
       <small class="text-muted">Page {{ page_obj.number }}</small>
     {% endif %}


### PR DESCRIPTION
Fixes #400 

This adds a field in the filter list that takes text and returns any experiments that have the text in their name or short description.

<img width="1598" alt="Screen Shot 2019-04-15 at 2 56 28 PM" src="https://user-images.githubusercontent.com/1551682/56168040-d54b7e00-5f8e-11e9-9806-e0a58e659838.png">
