### PR TITLE
Don't change slug for existing instances fixes #1129

### DIFF
--- a/app/experimenter/experiments/forms.py
+++ b/app/experimenter/experiments/forms.py
@@ -275,7 +275,7 @@ class ExperimentVariantsFormSet(BaseInlineFormSet):
                     "The size of all branches must add up to 100"
                 ]
 
-        unique_slugs = set([form.cleaned_data["slug"] for form in alive_forms])
+        unique_slugs = set([form.cleaned_data["name"] for form in alive_forms])
 
         if not len(unique_slugs) == len(alive_forms):
             for form in alive_forms:

--- a/app/experimenter/projects/forms.py
+++ b/app/experimenter/projects/forms.py
@@ -23,8 +23,11 @@ class NameSlugFormMixin(object):
     def clean(self):
         cleaned_data = super().clean()
 
-        name = cleaned_data.get("name")
-        cleaned_data["slug"] = slugify(name)
+        if self.instance.slug:
+            del cleaned_data["slug"]
+        else:
+            name = cleaned_data.get("name")
+            cleaned_data["slug"] = slugify(name)
 
         return cleaned_data
 

--- a/app/experimenter/projects/tests/test_forms.py
+++ b/app/experimenter/projects/tests/test_forms.py
@@ -1,7 +1,67 @@
+from django import forms
 from django.test import TestCase
 
-from experimenter.projects.forms import ProjectForm
+from experimenter.projects.models import Project
+from experimenter.projects.forms import (
+    ProjectForm,
+    NameSlugFormMixin,
+    UniqueNameSlugFormMixin,
+)
 from experimenter.projects.tests.factories import ProjectFactory
+
+
+class TestNameSlugFormMixin(TestCase):
+
+    def setUp(self):
+
+        class TestForm(NameSlugFormMixin, forms.ModelForm):
+            name = forms.CharField()
+            slug = forms.CharField(required=False)
+
+            class Meta:
+                model = Project
+                fields = ("name", "slug")
+
+        self.Form = TestForm
+
+    def test_sets_slug_for_new_instance(self):
+        form = self.Form({"name": "New Name"})
+        self.assertTrue(form.is_valid())
+        project = form.save()
+        self.assertEqual(project.slug, "new-name")
+
+    def test_doesnt_set_slug_for_existing_instance(self):
+        project = ProjectFactory.create(name="Old Name", slug="old-slug")
+        form = self.Form({"name": "New Name"}, instance=project)
+        self.assertTrue(form.is_valid())
+        project = form.save()
+        self.assertEqual(project.name, "New Name")
+        self.assertEqual(project.slug, "old-slug")
+
+
+class TestUniqueNameSlugFormMixin(TestCase):
+
+    def setUp(self):
+
+        class TestForm(UniqueNameSlugFormMixin, forms.ModelForm):
+            name = forms.CharField()
+            slug = forms.CharField(required=False)
+
+            class Meta:
+                model = Project
+                fields = ("name", "slug")
+
+        self.Form = TestForm
+
+    def test_valid_for_no_slug_match(self):
+        form = self.Form({"name": "New Name"})
+        self.assertTrue(form.is_valid())
+
+    def test_invalid_for_existing_slug_match(self):
+        ProjectFactory(name="Unique Existing Name", slug="existing-slug")
+        form = self.Form({"name": "Existing Slug"})
+        self.assertFalse(form.is_valid())
+        self.assertIn("name", form.errors)
 
 
 class TestProjectForm(TestCase):

--- a/app/experimenter/projects/tests/test_views.py
+++ b/app/experimenter/projects/tests/test_views.py
@@ -54,7 +54,6 @@ class TestProjectUpdateView(TestCase):
         updated_project = Project.objects.get(id=project.id)
 
         self.assertEqual(updated_project.name, project_data["name"])
-        self.assertEqual(updated_project.slug, "new-name")
         self.assertRedirects(
             response,
             reverse("projects-detail", kwargs={"slug": updated_project.slug}),


### PR DESCRIPTION
We auto generate the slug for things like Experiment, ExperimentVariant from its name, but we were doing it on every save so it's possible to change the slug of an experiment after it's been created (which is bad because then it changes the URL you find it at so you could break somebody's bookmarks).  This change prevents changing the slug if it's already been set.