### PR TITLE
Fix google analytics tests fixes #1189

### DIFF
--- a/app/experimenter/base/tests/test_views.py
+++ b/app/experimenter/base/tests/test_views.py
@@ -5,16 +5,19 @@ from django.urls import reverse
 
 class TestContextProcessors(TestCase):
 
-    def test_render_google_analytics_or_not(self):
-        headers = {settings.OPENIDC_EMAIL_HEADER: "user@example.com"}
-        response = self.client.get(reverse("home"), **headers)
-        self.assertEqual(response.status_code, 200)
-        html = response.content.decode("utf-8")
-        self.assertTrue("www.googletagmanager.com" in html)
-
+    def test_google_analytics_omitted_if_setting_false(self):
         with self.settings(USE_GOOGLE_ANALYTICS=False):
+            headers = {settings.OPENIDC_EMAIL_HEADER: "user@example.com"}
             response = self.client.get(reverse("home"), **headers)
             self.assertEqual(response.status_code, 200)
             html = response.content.decode("utf-8")
             # Note the 'not'!
-            self.assertTrue("www.googletagmanager.com" not in html)
+            self.assertNotIn("www.googletagmanager.com", html)
+
+    def test_google_analytics_included_if_setting_true(self):
+        with self.settings(USE_GOOGLE_ANALYTICS=True):
+            headers = {settings.OPENIDC_EMAIL_HEADER: "user@example.com"}
+            response = self.client.get(reverse("home"), **headers)
+            self.assertEqual(response.status_code, 200)
+            html = response.content.decode("utf-8")
+            self.assertIn("www.googletagmanager.com", html)


### PR DESCRIPTION
We should explicitly set the settings for each test rather than depending on the global project settings.