### PR TITLE
Add filter for experiments in QA fixes #941

### DIFF
--- a/app/experimenter/experiments/tests/test_views.py
+++ b/app/experimenter/experiments/tests/test_views.py
@@ -256,6 +256,23 @@ class TestExperimentFilterset(TestCase):
             set(second_response_context["experiments"]), set([exp_3])
         )
 
+    def test_filters_by_review_in_qa(self):
+        exp_1 = ExperimentFactory.create_with_variants(
+            review_qa_requested=True, review_qa=False
+        )
+        ExperimentFactory.create_with_variants(
+            review_qa_requested=False, review_qa=False
+        )
+        ExperimentFactory.create_with_variants(
+            review_qa_requested=True, review_qa=True
+        )
+
+        filter = ExperimentFilterset(
+            {"in_qa": "on"}, queryset=Experiment.objects.all()
+        )
+
+        self.assertEqual(set(filter.qs), set([exp_1]))
+
 
 class TestExperimentOrderingForm(TestCase):
 

--- a/app/experimenter/experiments/views.py
+++ b/app/experimenter/experiments/views.py
@@ -31,6 +31,7 @@ from experimenter.experiments.models import Experiment
 
 
 class ExperimentFiltersetForm(forms.ModelForm):
+    in_qa = forms.BooleanField(required=False)
 
     search = forms.CharField(required=False)
 
@@ -44,6 +45,7 @@ class ExperimentFiltersetForm(forms.ModelForm):
             "firefox_version",
             "project",
             "owner",
+            "in_qa",
             "archived",
         )
 
@@ -139,6 +141,7 @@ class ExperimentFilterset(filters.FilterSet):
         queryset=get_user_model().objects.all().order_by("email"),
         widget=forms.Select(attrs={"class": "form-control"}),
     )
+
     archived = filters.BooleanFilter(
         label="Show archived experiments", widget=forms.CheckboxInput()
     )
@@ -157,6 +160,12 @@ class ExperimentFilterset(filters.FilterSet):
         widget=DateRangeWidget(
             attrs={"type": "date", "class": "form-control"}
         ),
+    )
+
+    in_qa = filters.BooleanFilter(
+        label="Show only experiments in QA",
+        widget=forms.CheckboxInput(),
+        method="in_qa_filter",
     )
 
     class Meta:
@@ -222,6 +231,12 @@ class ExperimentFilterset(filters.FilterSet):
                 results.append(experiment.id)
 
         return queryset.filter(pk__in=results)
+
+    def in_qa_filter(self, queryset, name, value):
+        if value:
+            return queryset.filter(review_qa_requested=True, review_qa=False)
+        else:
+            return queryset
 
 
 class ExperimentOrderingForm(forms.Form):

--- a/app/experimenter/templates/experiments/list.html
+++ b/app/experimenter/templates/experiments/list.html
@@ -25,6 +25,10 @@
       {{ filter.form.firefox_version.value }}
     {% endif %}
 
+    {% if filter.form.in_qa.value == "in_qa" %}
+       in QA
+    {% endif %}
+
     {% if filter.form.project.value %}
       {{ filter.form.get_project_display_value }}
     {% endif %}
@@ -142,6 +146,11 @@
 
     {% for field in filter.form %}
       {% if field.name == "archived" %}
+        <label>
+          {{ field }}
+          {{ field.label }}
+        </label>
+      {% elif field.name == "in_qa" %}
         <label>
           {{ field }}
           {{ field.label }}


### PR DESCRIPTION
Fixes #941 

This PR adds a filter field for experiments that are "in QA"... or more specifically, if the `review_qa_requested` box has been checked...and the `review_qa` box has NOT been checked. 
Questions that remain are:
* Wording! Initially Shell suggested the select be called "all states" but that is kind of close to "all statuses". I used "all reviews" as a placeholder but I would love if someone weighed in on the best wording. Would be happy doing "states" if we want.
* Another wording question.. As I have it now, the title after filtering becomes something like "2 **in QA** experiments".. this isn't the best, grammatically speaking, but I think to make it fancier (like making it say "2 Experiments **in QA**") I'd have to put a method on the form, which is totally easy to do, but not sure if it's worth the extra code.
* If we'd like more tests than I currently have. I have a unit test but not an integration test. 


<img width="1584" alt="Screen Shot 2019-04-22 at 4 23 39 PM" src="https://user-images.githubusercontent.com/1551682/56540181-d0ea0c80-651c-11e9-9fc8-bea5102b589b.png">
Here's what the title currently looks like:
<img width="1565" alt="Screen Shot 2019-04-22 at 4 23 28 PM" src="https://user-images.githubusercontent.com/1551682/56540177-cf204900-651c-11e9-9be9-5a8567d52f46.png">
