### PR TITLE
Change label to Jira request sent with a link fixes #1219

### DIFF
--- a/app/experimenter/experiments/forms.py
+++ b/app/experimenter/experiments/forms.py
@@ -8,6 +8,7 @@ from django.forms import BaseInlineFormSet
 from django.forms import inlineformset_factory
 from django.forms.models import ModelChoiceIterator
 from django.utils import timezone
+from django.utils.safestring import mark_safe
 
 from experimenter.base.models import Country, Locale
 from experimenter.experiments.constants import ExperimentConstants
@@ -773,7 +774,10 @@ class ExperimentReviewForm(
     )
     review_qa_requested = forms.BooleanField(
         required=False,
-        label="QA Requested",
+        label=mark_safe(
+            f"QA <a href={settings.JIRA_URL} target='_blank'>"
+            "Jira</a> Request Sent"
+        ),
         help_text=Experiment.REVIEW_QA_REQUESTED_HELP_TEXT,
     )
     review_intent_to_ship = forms.BooleanField(

--- a/app/experimenter/settings.py
+++ b/app/experimenter/settings.py
@@ -313,3 +313,6 @@ DELIVERY_CONSOLE_NEW_RECIPE_URL = urljoin(DELIVERY_CONSOLE_HOST, "/recipe/new")
 DELIVERY_CONSOLE_RECIPE_URL = urljoin(DELIVERY_CONSOLE_HOST, "/recipe/{id}/")
 NORMANDY_API_HOST = config("NORMANDY_API_HOST")
 NORMANDY_API_RECIPE_URL = urljoin(NORMANDY_API_HOST, "/api/v3/recipe/{id}/")
+
+# Jira URL
+JIRA_URL = "https://moz-pi-test.atlassian.net/servicedesk/customer/portal/9"


### PR DESCRIPTION
Fixes #1219

<img width="461" alt="Screen Shot 2019-04-30 at 3 30 57 PM" src="https://user-images.githubusercontent.com/1551682/57000001-8729a380-6b66-11e9-9c9b-5a98ce4d5b14.png">

Do we want the blue link text though? Feeling unsure.