### PR TITLE
Fix bottom margin on intent to ship button #1209

### DIFF
--- a/app/experimenter/templates/experiments/detail_review.html
+++ b/app/experimenter/templates/experiments/detail_review.html
@@ -37,7 +37,7 @@
         {% for field in form.required_reviews %}
             <div class="checkbox">
               {% if field.name == 'review_intent_to_ship' and not experiment.review_intent_to_ship %}
-                <button type="button" class="btn btn-info send-intent-to-ship"
+                <button type="button" class="btn btn-info send-intent-to-ship mb-2"
                   data-toggle="modal" data-target="#send-intent-to-ship-modal"
                   data-url="{% url 'experiments-api-send-intent-to-ship-email' experiment.slug %}"
                 >


### PR DESCRIPTION
Fixes #1209 

Added some padding to bottom of button, but the button must remain in its place because its an ordered checklist. 
![Screen Shot 2019-05-01 at 4 20 15 PM](https://user-images.githubusercontent.com/1551682/57049461-08e40480-6c2d-11e9-8f04-818e1de4e358.png)

