### PR TITLE
Remove quotation marks from help text when editing branches fixes #1211

### DIFF
--- a/app/experimenter/experiments/constants.py
+++ b/app/experimenter/experiments/constants.py
@@ -476,7 +476,7 @@ class ExperimentConstants(object):
         or default state to compare to.
       </p>
       <p><strong>Boolean Example:</strong> false</p>
-      <p><strong>String Example:</strong> "some text"</p>
+      <p><strong>String Example:</strong> some text</p>
       <p><strong>Integer Example:</strong> 13</p>
     """
 


### PR DESCRIPTION
Fixes #1211 

Removed the quotation marks from the help example text. 

![Screen Shot 2019-05-01 at 3 21 41 PM](https://user-images.githubusercontent.com/1551682/57046300-de8e4900-6c24-11e9-8094-1257a6b32096.png)
