### PR TITLE
Fix intermittent test failure in clean locales test

### DIFF
--- a/app/experimenter/experiments/tests/test_forms.py
+++ b/app/experimenter/experiments/tests/test_forms.py
@@ -719,7 +719,7 @@ class TestExperimentVariantsBaseForm(MockRequestMixin, TestCase):
         )
         self.assertTrue(form.is_valid())
         self.assertEqual(
-            list(form.cleaned_data["locales"]), [locale2, locale1]
+            set(form.cleaned_data["locales"]), set([locale2, locale1])
         )
 
     def test_clean_locales_all(self):


### PR DESCRIPTION
This test is occasionally failing because it didn't use set. 