### PR TITLE
Fix migration order issue regarding migration numbers 49-53

### DIFF
--- a/app/experimenter/experiments/migrations/0053_create_relman_and_qa_groups.py
+++ b/app/experimenter/experiments/migrations/0053_create_relman_and_qa_groups.py
@@ -70,7 +70,7 @@ def remove_groups(apps, schema_editor):
 class Migration(migrations.Migration):
 
     dependencies = [
-        ("experiments", "0048_experiment_risk_external_team_impact"),
+        ("experiments", "0052_experiment_risk_security"),
         ("auth", "0009_alter_user_last_name_max_length"),
         ("contenttypes", "0002_remove_content_type_name"),
     ]


### PR DESCRIPTION
After a PR #1225 merged with master, there were database migrations that were out of order. This reorders the migration dependencies and file names. 