### PR TITLE
Fix server error when no name entered fixes 1203

### DIFF
--- a/app/experimenter/experiments/forms.py
+++ b/app/experimenter/experiments/forms.py
@@ -290,9 +290,13 @@ class ExperimentVariantsFormSet(BaseInlineFormSet):
                     "The size of all branches must add up to 100"
                 ]
 
-        unique_slugs = set([form.cleaned_data["name"] for form in alive_forms])
+        unique_names = set(
+            form.cleaned_data["name"]
+            for form in alive_forms
+            if form.cleaned_data.get("name")
+        )
 
-        if not len(unique_slugs) == len(alive_forms):
+        if not len(unique_names) == len(alive_forms):
             for form in alive_forms:
                 form._errors["name"] = ["All branches must have a unique name"]
 

--- a/app/experimenter/projects/tests/test_forms.py
+++ b/app/experimenter/projects/tests/test_forms.py
@@ -63,6 +63,12 @@ class TestUniqueNameSlugFormMixin(TestCase):
         self.assertFalse(form.is_valid())
         self.assertIn("name", form.errors)
 
+    def test_invalid_for_no_name_entered(self):
+        ProjectFactory(name="Unique Existing Name", slug="existing-slug")
+        form = self.Form({"name": ""})
+        self.assertFalse(form.is_valid())
+        self.assertIn("name", form.errors)
+
 
 class TestProjectForm(TestCase):
 


### PR DESCRIPTION
Fixes #1203 

This PR fixes a 500 server error that a user sees if they were to delete the name of a branch upon editing. Issue #1203 has a good screen recording showing the problem. 

I added a test to the bottom of an existing testcase... not sure if there is a better place for the test. 