### PR TITLE
Use end date if the experiment has completed else calculate fixes #1166

### DIFF
--- a/app/experimenter/experiments/models.py
+++ b/app/experimenter/experiments/models.py
@@ -356,7 +356,9 @@ class Experiment(ExperimentConstants, models.Model):
 
     @property
     def end_date(self):
-        return self._compute_end_date(self.proposed_duration)
+        return self._transition_date(
+            self.STATUS_LIVE, self.STATUS_COMPLETE
+        ) or self._compute_end_date(self.proposed_duration)
 
     @property
     def enrollment_end_date(self):

--- a/app/experimenter/experiments/tests/test_models.py
+++ b/app/experimenter/experiments/tests/test_models.py
@@ -376,13 +376,19 @@ class TestExperimentModel(TestCase):
             experiment._compute_end_date(experiment.MAX_DURATION + 1), None
         )
 
-    def test_end_date_uses_duration(self):
+    def test_end_date_uses_duration_if_change_is_missing(self):
         experiment = ExperimentFactory.create_with_variants(
-            proposed_start_date=datetime.date(2019, 1, 1),
-            proposed_duration=20,
-            proposed_enrollment=10,
+            proposed_start_date=datetime.date(2019, 1, 1), proposed_duration=20
         )
+
         self.assertEqual(experiment.end_date, datetime.date(2019, 1, 21))
+
+    def test_end_date_returns_datetime_if_change_exists(self):
+        change = ExperimentChangeLogFactory.create(
+            old_status=Experiment.STATUS_LIVE,
+            new_status=Experiment.STATUS_COMPLETE,
+        )
+        self.assertEqual(change.experiment.end_date, change.changed_on.date())
 
     def test_enrollment_end_date_uses_enrollment_duration(self):
         experiment = ExperimentFactory.create_with_variants(


### PR DESCRIPTION
Fixes #1166 

in this PR we're updating the `end_date` property on the experiment model to either:

- calculate the end date based on the proposed duration if the experiment hasn't ended
- use the status change from "live" to "complete" to assign the actual date the experiment ended.

It follows the pattern on the `start_date` property. 