### PR TITLE
Add word "experiment" to help text on experiment type fixes #1204

### DIFF
--- a/app/experimenter/experiments/constants.py
+++ b/app/experimenter/experiments/constants.py
@@ -191,13 +191,13 @@ class ExperimentConstants(object):
         delivered to Firefox users.
       </p>
       <p>
-        A <strong>{[1]}</strong> uses prefs to enable code which
+        A <strong>{[1]}</strong> experiment uses prefs to enable code which
         has already been merged into Firefox and deployed with a standard
         Firefox release in a disabled state, and will be selectively enabled
         for users that enroll into the experiment.
       </p>
       <p>
-        An <strong>{[1]}</strong> sends a Firefox Add-On which
+        An <strong>{[1]}</strong> experiment sends a Firefox Add-On which
         contains the code for the experimental feature to the users that
         enroll in the experiment.  After the experiment is complete, that
         add-on is automatically removed.


### PR DESCRIPTION
Fixes #1204 
Adds word "experiment" to help text of Experiment type on the "Add Experiment" form. 

![Screen Shot 2019-05-06 at 10 22 12 AM](https://user-images.githubusercontent.com/1551682/57242664-f8df7280-6fe8-11e9-97a6-0709ff801edd.png)
