### PR TITLE
Make grafana url reflect experiment start and end dates fixes #1159

### DIFF
--- a/app/experimenter/experiments/models.py
+++ b/app/experimenter/experiments/models.py
@@ -1,5 +1,6 @@
 import json
 import datetime
+import time
 from collections import defaultdict
 from urllib.parse import urljoin
 
@@ -267,8 +268,26 @@ class Experiment(ExperimentConstants, models.Model):
 
     @property
     def monitoring_dashboard_url(self):
+
+        def to_timestamp(date):
+            return int(time.mktime(date.timetuple())) * 1000
+
+        start_date = ""
+        end_date = ""
+
         if self.is_begun and self.normandy_slug:
-            return settings.MONITORING_URL.format(slug=self.normandy_slug)
+            start_date = to_timestamp(
+                self.start_date - datetime.timedelta(days=1)
+            )
+
+            if self.status == self.STATUS_COMPLETE:
+                end_date = to_timestamp(
+                    self.end_date + datetime.timedelta(days=2)
+                )
+
+            return settings.MONITORING_URL.format(
+                slug=self.normandy_slug, from_date=start_date, to_date=end_date
+            )
 
     def generate_normandy_slug(self):
         if self.is_addon_experiment:

--- a/app/experimenter/experiments/tests/test_models.py
+++ b/app/experimenter/experiments/tests/test_models.py
@@ -120,9 +120,59 @@ class TestExperimentModel(TestCase):
             status=Experiment.STATUS_LIVE,
             normandy_slug="normandy-slug",
         )
+
+        ExperimentChangeLogFactory.create(
+            experiment=experiment,
+            old_status=Experiment.STATUS_ACCEPTED,
+            new_status=Experiment.STATUS_LIVE,
+            changed_on=datetime.date(2019, 5, 1),
+        )
+
+        changed_on_in_milliseconds = 1556582400000
+
         self.assertEqual(
             experiment.monitoring_dashboard_url,
-            settings.MONITORING_URL.format(slug=experiment.normandy_slug),
+            settings.MONITORING_URL.format(
+                slug=experiment.normandy_slug,
+                from_date=changed_on_in_milliseconds,
+                to_date="",
+            ),
+        )
+
+    def test_monitoring_dashboard_url_returns_url_when_experiment_is_complete(
+        self
+    ):
+        experiment = ExperimentFactory.create(
+            type=Experiment.TYPE_PREF,
+            slug="experiment",
+            status=Experiment.STATUS_COMPLETE,
+            normandy_slug="normandy-slug",
+        )
+
+        ExperimentChangeLogFactory.create(
+            experiment=experiment,
+            old_status=Experiment.STATUS_ACCEPTED,
+            new_status=Experiment.STATUS_LIVE,
+            changed_on=datetime.date(2019, 5, 1),
+        )
+
+        ExperimentChangeLogFactory.create(
+            experiment=experiment,
+            old_status=Experiment.STATUS_LIVE,
+            new_status=Experiment.STATUS_COMPLETE,
+            changed_on=datetime.date(2019, 5, 10),
+        )
+
+        started_on_in_milliseconds = 1556582400000
+        completed_on_in_milliseconds = 1557619200000
+
+        self.assertEqual(
+            experiment.monitoring_dashboard_url,
+            settings.MONITORING_URL.format(
+                slug=experiment.normandy_slug,
+                from_date=started_on_in_milliseconds,
+                to_date=completed_on_in_milliseconds,
+            ),
         )
 
     def test_monitoring_dashboard_url_returns_url_when_experiment_is_addon(
@@ -134,9 +184,23 @@ class TestExperimentModel(TestCase):
             status=Experiment.STATUS_LIVE,
             normandy_slug="normandy-slug",
         )
+
+        ExperimentChangeLogFactory.create(
+            experiment=experiment,
+            old_status=Experiment.STATUS_ACCEPTED,
+            new_status=Experiment.STATUS_LIVE,
+            changed_on=datetime.date(2019, 5, 1),
+        )
+
+        changed_on_in_milliseconds = 1556582400000
+
         self.assertEqual(
             experiment.monitoring_dashboard_url,
-            settings.MONITORING_URL.format(slug=experiment.normandy_slug),
+            settings.MONITORING_URL.format(
+                slug=experiment.normandy_slug,
+                from_date=changed_on_in_milliseconds,
+                to_date="",
+            ),
         )
 
     def test_has_external_urls_is_false_when_no_external_urls(self):

--- a/app/experimenter/settings.py
+++ b/app/experimenter/settings.py
@@ -286,6 +286,7 @@ NORMANDY_SLUG_MAX_LEN = 80
 MONITORING_URL = (
     "https://grafana.telemetry.mozilla.org/d/3QA87kliz/"
     "experiment-enrollment?orgId=1&var-experiment_id={slug}"
+    "&from={from_date}&to={to_date}"
 )
 
 # Statsd via Markus


### PR DESCRIPTION
Fixes #1159 

Previously, when a user clicked on the 'Live Monitoring Dashboard', the dashboard defaulted to the last 6 months of time irrespective of an experiment's timeline. 

This PR changes the Grafana monitoring URL to include parameters for start and end dates (end dates only if the experiment has completed) so that the dashboard comes preset with a date range that focuses on an experiment's actual timeline. 

![Screen Shot 2019-05-06 at 6 07 20 PM](https://user-images.githubusercontent.com/1551682/57264950-e76a8a80-7029-11e9-8cd1-b46295ef3e37.png)



If an experiment is 'Live' and doesn't have an end date, we just use the start date in the parameters. 



![Screen Shot 2019-05-06 at 6 04 21 PM](https://user-images.githubusercontent.com/1551682/57264895-922e7900-7029-11e9-910a-5ba3853c10ef.png)

