### PR TITLE
Fix error message when field name for branch is deleted fixes #1253

### DIFF
--- a/app/experimenter/experiments/forms.py
+++ b/app/experimenter/experiments/forms.py
@@ -290,15 +290,18 @@ class ExperimentVariantsFormSet(BaseInlineFormSet):
                     "The size of all branches must add up to 100"
                 ]
 
-        unique_names = set(
-            form.cleaned_data["name"]
-            for form in alive_forms
-            if form.cleaned_data.get("name")
-        )
+        if all([f.is_valid() for f in alive_forms]):
+            unique_names = set(
+                form.cleaned_data["name"]
+                for form in alive_forms
+                if form.cleaned_data.get("name")
+            )
 
-        if not len(unique_names) == len(alive_forms):
-            for form in alive_forms:
-                form._errors["name"] = ["All branches must have a unique name"]
+            if not len(unique_names) == len(alive_forms):
+                for form in alive_forms:
+                    form._errors["name"] = [
+                        "All branches must have a unique name"
+                    ]
 
 
 class ExperimentVariantsPrefFormSet(ExperimentVariantsFormSet):


### PR DESCRIPTION
Fixes #1253 

Fixes the error message a user sees when they try to delete a branch name.  Previously, it would show "unique name" error, and now it shows 'field required' error. 

<img width="1051" alt="Screen Shot 2019-05-07 at 11 33 48 AM" src="https://user-images.githubusercontent.com/1551682/57324328-6d371600-70bc-11e9-9b4b-04260b1045f4.png">
