### PR TITLE
Add filter for surveys fixes 1265

### DIFF
--- a/app/experimenter/experiments/tests/test_views.py
+++ b/app/experimenter/experiments/tests/test_views.py
@@ -273,6 +273,19 @@ class TestExperimentFilterset(TestCase):
 
         self.assertEqual(set(filter.qs), set([exp_1]))
 
+    def test_filters_experiments_with_surveys(self):
+        exp_1 = ExperimentFactory.create_with_variants(survey_required=True)
+        exp_2 = ExperimentFactory.create_with_variants(
+            survey_required=True, review_qa=False
+        )
+        ExperimentFactory.create_with_variants(survey_required=False)
+
+        filter = ExperimentFilterset(
+            {"surveys": "on"}, queryset=Experiment.objects.all()
+        )
+
+        self.assertEqual(set(filter.qs), set([exp_1, exp_2]))
+
 
 class TestExperimentOrderingForm(TestCase):
 

--- a/app/experimenter/experiments/views.py
+++ b/app/experimenter/experiments/views.py
@@ -33,7 +33,7 @@ from experimenter.experiments.models import Experiment
 
 class ExperimentFiltersetForm(forms.ModelForm):
     in_qa = forms.BooleanField(required=False)
-
+    surveys = forms.BooleanField(required=False)
     search = forms.CharField(required=False)
 
     class Meta:
@@ -47,6 +47,7 @@ class ExperimentFiltersetForm(forms.ModelForm):
             "project",
             "owner",
             "in_qa",
+            "surveys",
             "archived",
         )
 
@@ -169,6 +170,12 @@ class ExperimentFilterset(filters.FilterSet):
         method="in_qa_filter",
     )
 
+    surveys = filters.BooleanFilter(
+        label="Show experiments with surveys",
+        widget=forms.CheckboxInput(),
+        method="surveys_filter",
+    )
+
     class Meta:
         model = Experiment
         form = ExperimentFiltersetForm
@@ -236,6 +243,12 @@ class ExperimentFilterset(filters.FilterSet):
     def in_qa_filter(self, queryset, name, value):
         if value:
             return queryset.filter(review_qa_requested=True, review_qa=False)
+        else:
+            return queryset
+
+    def surveys_filter(self, queryset, name, value):
+        if value:
+            return queryset.filter(survey_required=True)
         else:
             return queryset
 

--- a/app/experimenter/templates/experiments/list.html
+++ b/app/experimenter/templates/experiments/list.html
@@ -25,15 +25,19 @@
       {{ filter.form.firefox_version.value }}
     {% endif %}
 
-    {% if filter.form.in_qa.value == "in_qa" %}
-       in QA
-    {% endif %}
-
     {% if filter.form.project.value %}
       {{ filter.form.get_project_display_value }}
     {% endif %}
 
     Experiment{{ paginator.count|pluralize:"s" }}
+
+    {% if filter.form.in_qa.value %}
+       in QA
+    {% endif %}
+
+    {% if filter.form.surveys.value %}
+       with surveys
+    {% endif %}
 
     {% if filter.form.owner.value %}
       by {{ filter.form.get_owner_display_value }}
@@ -145,12 +149,7 @@
     </div>
 
     {% for field in filter.form %}
-      {% if field.name == "archived" %}
-        <label>
-          {{ field }}
-          {{ field.label }}
-        </label>
-      {% elif field.name == "in_qa" %}
+      {% if field.name == "in_qa" or field.name == "surveys" or field.name == "archived" %}
         <label>
           {{ field }}
           {{ field.label }}
@@ -160,7 +159,6 @@
         <div class="form-group">
           {{ field }}
         </div>
-
       {% else %}
         <div class="form-group">
           {{ field }}


### PR DESCRIPTION
Fixes #1279 
Depends on #1264 

Here we are adding a filter for experiments that have surveys attached to them. 

<img width="1348" alt="Screen Shot 2019-05-13 at 3 35 53 PM" src="https://user-images.githubusercontent.com/1551682/57659997-55b6cc00-7599-11e9-88a5-e0b019f92f08.png">

When a user has selected the radio button we filter and add "with surveys" to the title.

<img width="1280" alt="Screen Shot 2019-05-13 at 3 54 48 PM" src="https://user-images.githubusercontent.com/1551682/57660027-7b43d580-7599-11e9-8b96-408634264c2a.png">
