### PR TITLE
Fix intent to ship checkbox/button fixes #1296

### DIFF
--- a/app/experimenter/templates/experiments/detail_review.html
+++ b/app/experimenter/templates/experiments/detail_review.html
@@ -52,25 +52,25 @@
         {% csrf_token %}
 
         {% for field in form.required_reviews %}
-            {% if field.name == 'review_intent_to_ship' and not experiment.review_intent_to_ship %}
-              <div class="checkbox mb-1">
-                <button type="button" class="btn btn-link p-0 send-intent-to-ship"
-                  data-toggle="modal" data-target="#send-intent-to-ship-modal"
-                  data-url="{% url 'experiments-api-send-intent-to-ship-email' experiment.slug %}"
-                >
-                  <strong>
-                    <span class="fas fa-envelope"></span> Send intent-to-ship email
-                  </strong>
-                </button>
-            {% else %}
-              <div class="checkbox">
-                <label>
-                  {{ field }}
-                  {{ field.label }}
-                </label>
-            {% endif %}
-              {{ field.help_text|safe }}
+          <div class="checkbox">
+            <label>
+              {{ field }}
+              {{ field.label }}
+            </label>
+            {{ field.help_text|safe }}
+          </div>
+          {% if field.name == 'review_intent_to_ship' and not experiment.review_intent_to_ship %}
+            <div class="checkbox mb-1 ml-3">
+              <button type="button" class="btn btn-link p-0 send-intent-to-ship"
+                data-toggle="modal" data-target="#send-intent-to-ship-modal"
+                data-url="{% url 'experiments-api-send-intent-to-ship-email' experiment.slug %}"
+              >
+                <strong>
+                  <span class="fas fa-envelope"></span> Send intent-to-ship email
+                </strong>
+              </button>
             </div>
+          {% endif %}
         {% endfor %}
 
         <h5 class="mt-3">Optional Sign-Off Checklist</h5>


### PR DESCRIPTION
Fixes #1296 

This PR updates the signoff list so that an 'intent to ship' checkbox and email button coexist. A user can send an email with the button (which automatically checks the box after sending) or send an email manually then check the checkbox to fullfill that checkoff requirement.

![Screen Shot 2019-05-27 at 5 54 13 PM](https://user-images.githubusercontent.com/1551682/58497404-b8c76780-8130-11e9-8f83-7adc2580330e.png)
