### PR TITLE
Add filter for experiments to which a user is subscribed fixes #1259

### DIFF
--- a/app/experimenter/experiments/views.py
+++ b/app/experimenter/experiments/views.py
@@ -35,6 +35,7 @@ class ExperimentFiltersetForm(forms.ModelForm):
     in_qa = forms.BooleanField(required=False)
     surveys = forms.BooleanField(required=False)
     search = forms.CharField(required=False)
+    subscribed = forms.BooleanField(required=False)
 
     class Meta:
         model = Experiment
@@ -49,6 +50,7 @@ class ExperimentFiltersetForm(forms.ModelForm):
             "in_qa",
             "surveys",
             "archived",
+            "subscribed",
         )
 
     def clean_archived(self):
@@ -176,6 +178,12 @@ class ExperimentFilterset(filters.FilterSet):
         method="surveys_filter",
     )
 
+    subscribed = filters.BooleanFilter(
+        label="Show subscribed experiments",
+        widget=forms.CheckboxInput(),
+        method="subscribed_filter",
+    )
+
     class Meta:
         model = Experiment
         form = ExperimentFiltersetForm
@@ -243,14 +251,20 @@ class ExperimentFilterset(filters.FilterSet):
     def in_qa_filter(self, queryset, name, value):
         if value:
             return queryset.filter(review_qa_requested=True, review_qa=False)
-        else:
-            return queryset
+
+        return queryset
 
     def surveys_filter(self, queryset, name, value):
         if value:
             return queryset.filter(survey_required=True)
-        else:
-            return queryset
+
+        return queryset
+
+    def subscribed_filter(self, queryset, name, value):
+        if value:
+            return queryset.filter(subscribers__in=[self.request.user.id])
+
+        return queryset
 
 
 class ExperimentOrderingForm(forms.Form):

--- a/app/experimenter/static/css/experimenter.css
+++ b/app/experimenter/static/css/experimenter.css
@@ -132,6 +132,10 @@ select {
   background-color: #e9433e;
 }
 
+.subscribe-bell {
+  color: #e432af;
+}
+
 .header-link {
   margin-top: 10px;
   margin-bottom: 10px;

--- a/app/experimenter/templates/experiments/detail_base.html
+++ b/app/experimenter/templates/experiments/detail_base.html
@@ -11,6 +11,9 @@
     {% if experiment.archived %}
       <span class="badge badge-pill badge-small align-middle bg-secondary text-white">Archived</span>
     {% endif %}
+    {% if request.user in experiment.subscribers.all %}
+      <span class="fas fa-bell subscribe-bell"></span>
+    {% endif %}
   </h3>
 
   {{ experiment.dates }}

--- a/app/experimenter/templates/experiments/list.html
+++ b/app/experimenter/templates/experiments/list.html
@@ -29,6 +29,10 @@
       {{ filter.form.get_project_display_value }}
     {% endif %}
 
+    {% if filter.form.subscribed.value %}
+       subscribed
+    {% endif %}
+
     Experiment{{ paginator.count|pluralize:"s" }}
 
     {% if filter.form.in_qa.value %}
@@ -75,6 +79,9 @@
           <h5>
             {{ experiment }}
             <span class="badge badge-pill badge-small align-middle status-color-{{ experiment.status }}">{{ experiment.get_status_display }}</span>
+            {% if request.user in experiment.subscribers.all %}
+              <span class="fas fa-bell subscribe-bell"></span>
+            {% endif %}
             {% if experiment.archived %}
               <span class="badge badge-pill badge-small align-middle bg-secondary text-white">Archived</span>
             {% endif %}
@@ -149,7 +156,7 @@
     </div>
 
     {% for field in filter.form %}
-      {% if field.name == "in_qa" or field.name == "surveys" or field.name == "archived" %}
+      {% if field.name == "in_qa" or field.name == "surveys" or field.name == "archived" or field.name == "subscribed"%}
         <label>
           {{ field }}
           {{ field.label }}


### PR DESCRIPTION
Fixes #1259 

In this PR we add another filter of the checkbox variety to the filter set. We also add a bell next to each experiment name on the list page, and a bell the the title of each experiment in the detail view, indicating the user is subscribed. 

perhaps the color of this bell will be in dispute, so I have screenshots below in two colors... my preferred, the pink, and maybe a more standard blue (although I think using this blue could be confusing because it's often used for a link... and also, there's already a blue pill for 'Complete' experiments). 

![Screen Shot 2019-05-31 at 4 01 29 PM](https://user-images.githubusercontent.com/1551682/58740722-dada1780-83c6-11e9-9712-ed08ebe69d33.png)


![Screen Shot 2019-05-31 at 4 23 16 PM](https://user-images.githubusercontent.com/1551682/58740732-efb6ab00-83c6-11e9-9471-f0b7df093aac.png)

![Screen Shot 2019-05-31 at 5 10 35 PM](https://user-images.githubusercontent.com/1551682/58740764-2260a380-83c7-11e9-8696-7203a3752952.png)

__________________________________________

this is an alternate color.. which doesn't look as good to me....
_________________________________________
![Screen Shot 2019-05-31 at 4 23 00 PM](https://user-images.githubusercontent.com/1551682/58740788-4fad5180-83c7-11e9-8640-736389b051eb.png)

![Screen Shot 2019-05-31 at 4 22 38 PM](https://user-images.githubusercontent.com/1551682/58740777-2ee4fc00-83c7-11e9-90b4-c1e078092b39.png)
