### PR TITLE
Display the enrollment end date in experiments list view fixes #1292

### DIFF
--- a/app/experimenter/templates/experiments/list.html
+++ b/app/experimenter/templates/experiments/list.html
@@ -103,6 +103,9 @@
             <div class="col-4 text-right">
               <h5>{{ experiment.population }}</h5>
               <p>{{ experiment.dates }}</p>
+              {% if experiment.enrollment_end_date %}
+                <p>enrolling until {{ experiment.enrollment_end_date }}</p>
+              {% endif %}
             </div>
           </div>
         </div>


### PR DESCRIPTION
fixes #1292 

If there's an enrollemnt end date, it's displayed in the list view. 

![Screen Shot 2019-06-04 at 12 08 52 PM](https://user-images.githubusercontent.com/1551682/58906857-c09f8280-86c1-11e9-996a-71a98e3a1a20.png)
