### PR TITLE
Fix bug that allowed user to make a clone with invalid name fixes #1391

### DIFF
--- a/app/experimenter/experiments/serializers.py
+++ b/app/experimenter/experiments/serializers.py
@@ -252,9 +252,14 @@ class ExperimentCloneSerializer(serializers.ModelSerializer):
     def validate_name(self, value):
         existing_slug = Experiment.objects.filter(slug=slugify(value))
         if existing_slug:
-            raise serializers.ValidationError("Duplicate Name Error")
+            raise serializers.ValidationError(
+                "This experiment name already exists."
+            )
 
-        return value
+        if slugify(value):
+            return value
+        else:
+            raise serializers.ValidationError("That's an invalid name.")
 
     def get_clone_url(self, obj):
         return reverse("experiments-detail", kwargs={"slug": obj.slug})

--- a/app/experimenter/experiments/tests/test_serializers.py
+++ b/app/experimenter/experiments/tests/test_serializers.py
@@ -354,6 +354,18 @@ class TestCloneSerializer(MockRequestMixin, TestCase):
 
         self.assertFalse(serializer.is_valid())
 
+    def test_clone_serializer_rejects_invalid_name(self):
+        experiment = ExperimentFactory.create(
+            name="great experiment", slug="great-experiment"
+        )
+
+        clone_data = {"name": "@@@@@@@@"}
+        serializer = ExperimentCloneSerializer(
+            instance=experiment, data=clone_data
+        )
+
+        self.assertFalse(serializer.is_valid())
+
     def test_clone_serializer_accepts_unique_name(self):
         experiment = ExperimentFactory.create(
             name="great experiment", slug="great-experiment"

--- a/app/experimenter/static/js/detail-base.js
+++ b/app/experimenter/static/js/detail-base.js
@@ -1,12 +1,18 @@
 // Hook up cloning experiments
 jQuery(function($) {
   let sendUrl;
+
+  const modal = $("#clone-experiment-modal");
+  const errorField = modal.find(".error-field");
+
   $("button.clone-experiment").on("click", function(e) {
+    // make sure no previous error messages are showing
+    errorField.addClass("d-none");
+    errorField.text("");
     sendUrl = this.dataset.url;
     // Let Bootstrap handle showing the modal itself
   });
 
-  const modal = $("#clone-experiment-modal");
 
   modal.find("button.send").on("click", async function(e) {
     data = {"name": modal.find("#experiment-name-input").val()}
@@ -21,11 +27,12 @@ jQuery(function($) {
       },
       body: JSON.stringify(data)
     });
+    body = await resp.json();
     if (resp.status == 200) {
-      body = await resp.json();
       location.replace(body.clone_url);
     } else {
-      modal.find(".name-error").removeClass("d-none");
+      errorField.text(body.name[0])
+      errorField.removeClass("d-none")
       this.disabled = false;
       this.innerHTML = "Clone";
     }

--- a/app/experimenter/templates/experiments/detail_base.html
+++ b/app/experimenter/templates/experiments/detail_base.html
@@ -213,8 +213,7 @@
             <input id="experiment-name-input" type="text" class="form-control" name="name" aria-describedby="experimentName" value="{{experiment.name}} V2">
           </div>
 
-          <p class="name-error d-none text-danger">
-            This experiment name is taken. Please choose a new one.
+          <p class="error-field d-none text-danger">
           </p>
 
           <div class="modal-footer">


### PR DESCRIPTION
The cloning serializer was not catching instances where the user supplied an invalid experiment name that couldn't be made into a slug with `slugify()`. So an experiment was getting created with that invalid name and NO slug. I added a check that raises a `ValidationError` if the name cannot be turned into a slug. So there are now two `ValidationError`s that could be raised depending on if the name is already in use or if the name isn't a valid choice.

I updated the Jquery to display the text of the specific validation error that is sent back in 400 response's body. That means that the modal's `<p>` tag for displaying errors was made to be generic to all errors and empty initially. If there is an error, we add whatever the `ValidationError`s text is that is set on the server side and sent in the response body with `errorField.text(body.name[0]).`

![Screen Shot 2019-06-25 at 1 02 15 PM](https://user-images.githubusercontent.com/1551682/60129903-f7aa0680-974a-11e9-8ed3-9cf5957a53e9.png)

![Screen Shot 2019-06-25 at 1 27 20 PM](https://user-images.githubusercontent.com/1551682/60130928-0d203000-974d-11e9-8c70-abb18689a606.png)

