### PR TITLE
Set bugzilla id to none for clone fixes #1394

### DIFF
--- a/app/experimenter/experiments/models.py
+++ b/app/experimenter/experiments/models.py
@@ -683,6 +683,7 @@ class Experiment(ExperimentConstants, models.Model):
             "addon_release_url",
             "normandy_slug",
             "normandy_id",
+            "bugzilla_id",
             "review_science",
             "review_engineering",
             "review_qa_requested",

--- a/app/experimenter/experiments/tests/test_models.py
+++ b/app/experimenter/experiments/tests/test_models.py
@@ -1084,6 +1084,7 @@ class TestExperimentModel(TestCase):
             proposed_enrollment=2,
             proposed_duration=30,
             owner=user_1,
+            bugzilla_id="4455667",
             pref_type=Experiment.TYPE_ADDON,
             data_science_bugzilla_url="https://bugzilla.mozilla.org/123/",
             feature_bugzilla_url="https://bugzilla.mozilla.org/123/",
@@ -1120,6 +1121,7 @@ class TestExperimentModel(TestCase):
             cloned_experiment.firefox_min_version,
             Experiment.VERSION_CHOICES[1][0],
         )
+        self.assertFalse(cloned_experiment.bugzilla_id)
         self.assertFalse(cloned_experiment.archived)
         self.assertFalse(cloned_experiment.review_science)
         self.assertFalse(cloned_experiment.review_ux)


### PR DESCRIPTION
The clone was using and modifying its parent experiment bugzilla ticket. The solution is to set the bugzilla_id on the clone to none. When the experiment is moved from draft to review a task will create the bugzilla ticket for the clone.