### PR TITLE
Add filter for longrunning experiments fixes #1294

### DIFF
--- a/app/experimenter/experiments/tests/test_views.py
+++ b/app/experimenter/experiments/tests/test_views.py
@@ -319,8 +319,8 @@ class TestExperimentFilterset(MockRequestMixin, TestCase):
     def test_filters_for_longrunning_experiments(self):
         exp_1 = ExperimentFactory.create(
             name="Experiment 1",
-            firefox_min_version="67.0",
-            firefox_max_version="70.0",
+            firefox_min_version="67.0b",
+            firefox_max_version="70.0b",
         )
         exp_2 = ExperimentFactory.create(
             name="Experiment 2",

--- a/app/experimenter/experiments/tests/test_views.py
+++ b/app/experimenter/experiments/tests/test_views.py
@@ -316,6 +316,36 @@ class TestExperimentFilterset(MockRequestMixin, TestCase):
 
         self.assertEqual(list(subscribed_filter.qs), [exp_1])
 
+    def test_filters_for_longrunning_experiments(self):
+        exp_1 = ExperimentFactory.create(
+            name="Experiment 1",
+            firefox_min_version="67.0",
+            firefox_max_version="70.0",
+        )
+        exp_2 = ExperimentFactory.create(
+            name="Experiment 2",
+            firefox_min_version="64.0",
+            firefox_max_version="69.0",
+        )
+        ExperimentFactory.create(
+            name="Experiment 3",
+            firefox_min_version="64.0",
+            firefox_max_version="",
+        )
+        ExperimentFactory.create(
+            name="Experiment 4",
+            firefox_min_version="64.0",
+            firefox_max_version="65.0",
+        )
+
+        filter = ExperimentFilterset(
+            {"longrunning": "on"},
+            request=self.request,
+            queryset=Experiment.objects.all(),
+        )
+
+        self.assertEqual(set(filter.qs), set([exp_1, exp_2]))
+
 
 class TestExperimentOrderingForm(TestCase):
 

--- a/app/experimenter/experiments/views.py
+++ b/app/experimenter/experiments/views.py
@@ -2,8 +2,9 @@ import django_filters as filters
 from django import forms
 from django.conf import settings
 from django.contrib.auth import get_user_model
-from django.db.models import Q, F, FloatField
+from django.db.models import Q, F, IntegerField
 from django.db.models.functions import Cast
+from django.db.models.expressions import Func, Value
 from django.shortcuts import redirect
 from django.urls import reverse
 from django.views.generic import CreateView, DetailView, UpdateView
@@ -293,16 +294,25 @@ class ExperimentFilterset(filters.FilterSet):
             return (
                 queryset.exclude(firefox_max_version__exact="")
                 .annotate(
-                    firefox_min_float=Cast(
-                        "firefox_min_version", FloatField()
+                    firefox_min_int=Cast(
+                        Func(
+                            F("firefox_min_version"),
+                            Value(r"[\d]+"),
+                            function="substring",
+                        ),
+                        IntegerField(),
                     ),
-                    firefox_max_float=Cast(
-                        "firefox_max_version", FloatField()
+                    firefox_max_int=Cast(
+                        Func(
+                            F("firefox_max_version"),
+                            Value(r"[\d]+"),
+                            function="substring",
+                        ),
+                        IntegerField(),
                     ),
-                    version_count=F("firefox_max_float")
-                    - F("firefox_min_float"),
+                    version_count=F("firefox_max_int") - F("firefox_min_int"),
                 )
-                .filter(version_count__gte=3.0)
+                .filter(version_count__gte=3)
             )
 
         return queryset

--- a/app/experimenter/templates/experiments/list.html
+++ b/app/experimenter/templates/experiments/list.html
@@ -28,6 +28,10 @@
        subscribed
     {% endif %}
 
+    {% if filter.form.longrunning.value %}
+       long-running
+    {% endif %}
+
     Experiment{{ paginator.count|pluralize:"s" }}
 
     {% if filter.form.firefox_version.value %}
@@ -159,7 +163,7 @@
     </div>
 
     {% for field in filter.form %}
-      {% if field.name == "in_qa" or field.name == "surveys" or field.name == "archived" or field.name == "subscribed"%}
+      {% if field.name == "in_qa" or field.name == "surveys" or field.name == "archived" or field.name == "subscribed" or field.name == "longrunning" %}
         <label>
           {{ field }}
           {{ field.label }}


### PR DESCRIPTION
Fixes #1294 

This checkbox filters out experiments that span 3 or more Firefox versions.

![Screen Shot 2019-06-26 at 12 57 36 PM](https://user-images.githubusercontent.com/1551682/60210687-4d95b180-9812-11e9-92f5-e05cea963914.png)
