### PR TITLE
Add check for existing name fixes #1410

### DIFF
--- a/app/experimenter/experiments/serializers.py
+++ b/app/experimenter/experiments/serializers.py
@@ -3,6 +3,7 @@ import json
 from rest_framework import serializers
 from django.utils.text import slugify
 from django.urls import reverse
+from django.db.models import Q
 
 from experimenter.base.models import Country, Locale
 from experimenter.experiments.models import Experiment, ExperimentVariant
@@ -251,8 +252,11 @@ class ExperimentCloneSerializer(serializers.ModelSerializer):
         fields = ("name", "clone_url")
 
     def validate_name(self, value):
-        existing_slug = Experiment.objects.filter(slug=slugify(value))
-        if existing_slug:
+        existing_slug_or_name = Experiment.objects.filter(
+            Q(slug=slugify(value)) | Q(name=value)
+        )
+
+        if existing_slug_or_name:
             raise serializers.ValidationError(
                 "This experiment name already exists."
             )

--- a/app/experimenter/experiments/tests/test_serializers.py
+++ b/app/experimenter/experiments/tests/test_serializers.py
@@ -372,11 +372,22 @@ class TestExperimentRecipeSerializer(TestCase):
 
 class TestCloneSerializer(MockRequestMixin, TestCase):
 
-    def test_clone_serializer_rejects_duplicate_name(self):
-        experiment = ExperimentFactory.create(
-            name="great experiment", slug="great-experiment"
+    def test_clone_serializer_rejects_duplicate_slug(self):
+        experiment_1 = ExperimentFactory.create(
+            name="good experiment", slug="great-experiment"
         )
         clone_data = {"name": "great experiment"}
+        serializer = ExperimentCloneSerializer(
+            instance=experiment_1, data=clone_data
+        )
+
+        self.assertFalse(serializer.is_valid())
+
+    def test_clone_serializer_rejects_duplicate_name(self):
+        experiment = ExperimentFactory.create(
+            name="wonderful experiment", slug="amazing-experiment"
+        )
+        clone_data = {"name": "wonderful experiment"}
         serializer = ExperimentCloneSerializer(
             instance=experiment, data=clone_data
         )


### PR DESCRIPTION
Fixes #1410 

Instead of just finding experiments in the database that have the same slug (in order to prevent cloning if we find them), I modified the lookup to be a Q statement so that we can check if the slug or the name exists. 

The problem stemmed from the fact that when you modify the name of an experiment, we keep the old slug so people's links don't break. But that means that an experiment can be a state with the name "cat" and the slug "dog". If we then try to clone an experiment in this state, and we enter in the name "cat" to be the clone's name, we can't just say are there any existing experiments with slug "cat" because there won't be the cat slug (the parent cat name experiment has the dog slug). We have to check if the slug exists and if the name exists. 