### PR TITLE
added status field to experimenter api, fixes #1446

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,7 @@ Example: GET /api/v1/experiments/?project__slug=project-slug&status=Pending
               "reject_url":"https://localhost/api/v1/experiments/self-enabling-needs-based-hardware/reject",
               "slug":"self-enabling-needs-based-hardware",
               "start_date":1505767052000.0,
+              "status":"Complete",
               "variant":{
                  "description":"Modi perferendis repudiandae ducimus dolorem eum rem. Esse porro iure consectetur facere. Quidem nam enim dolore eius ab facilis.",
                  "name":"Business-focused upward-trending Graphic Interface",

--- a/app/experimenter/experiments/serializers.py
+++ b/app/experimenter/experiments/serializers.py
@@ -65,6 +65,7 @@ class ExperimentSerializer(serializers.ModelSerializer):
             "type",
             "name",
             "slug",
+            "status",
             "short_description",
             "client_matching",
             "locales",

--- a/app/experimenter/experiments/tests/test_serializers.py
+++ b/app/experimenter/experiments/tests/test_serializers.py
@@ -148,6 +148,7 @@ class TestExperimentSerializer(TestCase):
             "start_date": JSTimestampField().to_representation(
                 experiment.start_date
             ),
+            "status": Experiment.STATUS_COMPLETE,
             "type": experiment.type,
             "variants": [
                 ExperimentVariantSerializer(variant).data


### PR DESCRIPTION
Added `status` to experiment api because I needed that field to be displayed for project Avocado. Status will be accessible through https://experimenter.services.mozilla.com/api/v1/experiments/ 
