### PR TITLE
Insert launch and ship emails into new email DB table fixes #1437

### DIFF
--- a/app/experimenter/experiments/email.py
+++ b/app/experimenter/experiments/email.py
@@ -41,6 +41,10 @@ def send_intent_to_ship_email(experiment_id):
     )
     email.send(fail_silently=False)
 
+    ExperimentEmail.objects.create(
+        experiment=experiment, type=Experiment.INTENT_TO_SHIP_EMAIL_LABEL
+    )
+
 
 def send_experiment_launch_email(experiment):
 
@@ -67,6 +71,10 @@ def send_experiment_launch_email(experiment):
     )
 
     email.send(fail_silently=False)
+
+    ExperimentEmail.objects.create(
+        experiment=experiment, type=Experiment.EXPERIMENT_STARTS
+    )
 
 
 def send_experiment_ending_email(experiment):

--- a/app/experimenter/experiments/tests/test_email.py
+++ b/app/experimenter/experiments/tests/test_email.py
@@ -73,6 +73,12 @@ Thank you!!
             [settings.EMAIL_RELEASE_DRIVERS, experiment.owner.email],
         )
 
+        self.assertTrue(
+            experiment.emails.filter(
+                type=ExperimentConstants.INTENT_TO_SHIP_EMAIL_LABEL
+            ).exists()
+        )
+
     def test_send_intent_to_ship_email_without_risk_fields(self):
         experiment = ExperimentFactory.create(
             name="Experiment",
@@ -179,6 +185,12 @@ class TestStatusUpdateEmail(TestCase):
         self.assertEqual(
             sent_email.subject,
             "Experiment launched: Greatest Experiment 68.0 to 69.0 Nightly",
+        )
+
+        self.assertTrue(
+            self.experiment.emails.filter(
+                type=ExperimentConstants.EXPERIMENT_STARTS
+            ).exists()
         )
 
     def test_send_experiment_ending_email(self):


### PR DESCRIPTION
Since we added a table to keep track of ending emails sent, I went back and inserted into the table when other emails were sent also. Now we'll be able to keep track of all the emails we send users!