### PR TITLE
Remove release drivers from launch and ending emails fixes #1457

### DIFF
--- a/app/experimenter/experiments/email.py
+++ b/app/experimenter/experiments/email.py
@@ -66,8 +66,7 @@ def send_experiment_launch_email(experiment):
         ),
         content,
         settings.EMAIL_SENDER,
-        [settings.EMAIL_RELEASE_DRIVERS],
-        cc=recipients,
+        recipients,
     )
 
     email.send(fail_silently=False)
@@ -99,8 +98,7 @@ def send_experiment_ending_email(experiment):
         ),
         html_content,
         settings.EMAIL_SENDER,
-        [settings.EMAIL_RELEASE_DRIVERS],
-        cc=recipients,
+        recipients,
     )
     email.content_subtype = "html"
 

--- a/app/experimenter/experiments/tests/test_email.py
+++ b/app/experimenter/experiments/tests/test_email.py
@@ -7,7 +7,10 @@ from experimenter.experiments.email import (
     send_experiment_launch_email,
     send_experiment_ending_email,
 )
-from experimenter.experiments.tests.factories import ExperimentFactory
+from experimenter.experiments.tests.factories import (
+    ExperimentFactory,
+    UserFactory,
+)
 from experimenter.experiments.constants import ExperimentConstants
 
 
@@ -178,6 +181,9 @@ class TestStatusUpdateEmail(TestCase):
             firefox_channel="Nightly",
         )
 
+        self.subscribing_user = UserFactory.create()
+        self.experiment.subscribers.add(self.subscribing_user)
+
     def test_send_experiment_launch_email(self):
         send_experiment_launch_email(self.experiment)
 
@@ -191,6 +197,11 @@ class TestStatusUpdateEmail(TestCase):
             self.experiment.emails.filter(
                 type=ExperimentConstants.EXPERIMENT_STARTS
             ).exists()
+        )
+
+        self.assertEqual(
+            sent_email.recipients(),
+            [self.experiment.owner.email, self.subscribing_user.email],
         )
 
     def test_send_experiment_ending_email(self):
@@ -208,4 +219,8 @@ class TestStatusUpdateEmail(TestCase):
             ).exists()
         )
 
+        self.assertEqual(
+            sent_email.recipients(),
+            [self.experiment.owner.email, self.subscribing_user.email],
+        )
         self.assertEqual(sent_email.content_subtype, "html")

--- a/app/experimenter/experiments/tests/test_tasks.py
+++ b/app/experimenter/experiments/tests/test_tasks.py
@@ -340,12 +340,10 @@ class TestUpdateExperimentStatus(
         self.mock_normandy_requests_get.assert_not_called()
 
     def test_accepted_experiment_becomes_live_if_normandy_enabled(self):
-        exp_1 = ExperimentFactory.create_with_status(
+        ExperimentFactory.create_with_status(
             target_status=Experiment.STATUS_ACCEPTED, normandy_id=1234
         )
 
-        subscribing_user = UserFactory.create()
-        exp_1.subscribers.add(subscribing_user)
         tasks.update_experiment_info()
         experiment = Experiment.objects.get(normandy_id=1234)
         self.assertEqual(experiment.status, Experiment.STATUS_LIVE)
@@ -366,9 +364,6 @@ class TestUpdateExperimentStatus(
             {"comment": comment},
         )
         self.assertEqual(len(mail.outbox), 1)
-        self.assertEqual(
-            mail.outbox[0].cc, [experiment.owner.email, subscribing_user.email]
-        )
 
     def test_accepted_experiment_stays_accepted_if_normandy_disabled(self):
         ExperimentFactory.create_with_status(


### PR DESCRIPTION
instead of sending to release drivers and cc-ing the recipients we're interested in, owner and subscribed, we are just directly sending to owner and subscribed, removing release drivers entirely. 

