### PR TITLE
Add enrollment pause emails fixes #811

### DIFF
--- a/app/experimenter/experiments/constants.py
+++ b/app/experimenter/experiments/constants.py
@@ -849,6 +849,11 @@ If applicable, link to any relevant test builds / staging information
 
     ENDING_EMAIL_SUBJECT = "Experiment ending soon: {name} {version} {channel}"
 
+    PAUSE_EMAIL_SUBJECT = (
+        "Experimenter enrollment ending verification "
+        "for: {name} {version} {channel}"
+    )
+
     NORMANDY_CHANGE_WINDOW = """
         https://mana.mozilla.org/wiki/display/FIREFOX/Pref-Flip+and+Add-On+Experiments#Pref-FlipandAdd-OnExperiments-NormandyChangeWindow
     """

--- a/app/experimenter/experiments/email.py
+++ b/app/experimenter/experiments/email.py
@@ -57,6 +57,20 @@ def send_experiment_ending_email(experiment):
     )
 
 
+def send_enrollment_pause_email(experiment):
+
+    format_and_send_html_email(
+        experiment,
+        "experiments/emails/enrollment_pause_email.html",
+        {
+            "experiment": experiment,
+            "change_window_url": ExperimentConstants.NORMANDY_CHANGE_WINDOW,
+        },
+        Experiment.PAUSE_EMAIL_SUBJECT,
+        Experiment.EXPERIMENT_PAUSES,
+    )
+
+
 def format_and_send_html_email(
     experiment,
     file_string,

--- a/app/experimenter/experiments/models.py
+++ b/app/experimenter/experiments/models.py
@@ -414,6 +414,18 @@ class Experiment(ExperimentConstants, models.Model):
         ) or self._compute_end_date(self.proposed_duration)
 
     @property
+    def enrollment_ending_soon(self):
+        return (
+            self.enrollment_end_date - datetime.date.today()
+        ) <= datetime.timedelta(days=5)
+
+    @property
+    def ending_soon(self):
+        return (self.end_date - datetime.date.today()) <= datetime.timedelta(
+            days=5
+        )
+
+    @property
     def enrollment_end_date(self):
         return self._compute_end_date(self.proposed_enrollment)
 

--- a/app/experimenter/experiments/tasks.py
+++ b/app/experimenter/experiments/tasks.py
@@ -216,7 +216,7 @@ def send_period_ending_emails(experiment):
         if (experiment.enrollment_end_date - date.today()) <= timedelta(
             days=5
         ):
-            if not Experiment.objects.filter(
+            if not ExperimentEmail.objects.filter(
                 experiment=experiment,
                 type=ExperimentConstants.EXPERIMENT_PAUSES,
             ):

--- a/app/experimenter/experiments/tasks.py
+++ b/app/experimenter/experiments/tasks.py
@@ -10,7 +10,6 @@ from experimenter.experiments import bugzilla, normandy, email
 from experimenter.experiments.constants import ExperimentConstants
 from experimenter.experiments.models import Experiment, ExperimentEmail
 from experimenter.notifications.models import Notification
-from datetime import date, timedelta
 
 
 logger = get_task_logger(__name__)
@@ -201,10 +200,10 @@ def update_status(experiment):
 
 def send_period_ending_emails(experiment):
     # send experiment ending soon emails if end date is 5 days out
-    if (experiment.end_date - date.today()) <= timedelta(days=5):
+    if experiment.ending_soon:
         if not ExperimentEmail.objects.filter(
             experiment=experiment, type=ExperimentConstants.EXPERIMENT_ENDS
-        ):
+        ).exists():
             email.send_experiment_ending_email(experiment)
             logger.info(
                 "Sent ending email for Experiment: {}".format(experiment)
@@ -213,13 +212,11 @@ def send_period_ending_emails(experiment):
     # send enrollment ending emails if enrollment end
     # date is 5 days out
     if experiment.enrollment_end_date:
-        if (experiment.enrollment_end_date - date.today()) <= timedelta(
-            days=5
-        ):
+        if experiment.enrollment_ending_soon:
             if not ExperimentEmail.objects.filter(
                 experiment=experiment,
                 type=ExperimentConstants.EXPERIMENT_PAUSES,
-            ):
+            ).exists():
                 email.send_enrollment_pause_email(experiment)
                 logger.info(
                     "Sent enrollment pause email for Experiment: {}".format(

--- a/app/experimenter/experiments/tasks.py
+++ b/app/experimenter/experiments/tasks.py
@@ -210,6 +210,23 @@ def send_period_ending_emails(experiment):
                 "Sent ending email for Experiment: {}".format(experiment)
             )
 
+    # send enrollment ending emails if enrollment end
+    # date is 5 days out
+    if experiment.enrollment_end_date:
+        if (experiment.enrollment_end_date - date.today()) <= timedelta(
+            days=5
+        ):
+            if not Experiment.objects.filter(
+                experiment=experiment,
+                type=ExperimentConstants.EXPERIMENT_PAUSES,
+            ):
+                email.send_enrollment_pause_email(experiment)
+                logger.info(
+                    "Sent enrollment pause email for Experiment: {}".format(
+                        experiment
+                    )
+                )
+
 
 def needs_to_be_updated(recipe_data, status):
     if recipe_data is None:

--- a/app/experimenter/experiments/tests/test_email.py
+++ b/app/experimenter/experiments/tests/test_email.py
@@ -7,6 +7,7 @@ from experimenter.experiments.email import (
     send_intent_to_ship_email,
     send_experiment_launch_email,
     send_experiment_ending_email,
+    send_enrollment_pause_email,
 )
 from experimenter.experiments.tests.factories import (
     ExperimentFactory,
@@ -206,3 +207,27 @@ class TestStatusUpdateEmail(TestCase):
             [self.experiment.owner.email, self.subscribing_user.email],
         )
         self.assertIn("May 11, 2019", sent_email.body)
+
+    def test_send_experiment_pausing_email(self):
+        send_enrollment_pause_email(self.experiment)
+
+        sent_email = mail.outbox[-1]
+
+        self.assertEqual(
+            sent_email.subject,
+            (
+                "Experimenter enrollment ending verification for: "
+                "Greatest Experiment 68.0 to 69.0 Nightly"
+            ),
+        )
+        self.assertEqual(sent_email.content_subtype, "html")
+        self.assertTrue(
+            self.experiment.emails.filter(
+                type=ExperimentConstants.EXPERIMENT_PAUSES
+            ).exists()
+        )
+        self.assertEqual(
+            sent_email.recipients(),
+            [self.experiment.owner.email, self.subscribing_user.email],
+        )
+        self.assertIn("May 6, 2019", sent_email.body)

--- a/app/experimenter/experiments/tests/test_models.py
+++ b/app/experimenter/experiments/tests/test_models.py
@@ -478,6 +478,36 @@ class TestExperimentModel(TestCase):
         )
         self.assertEqual(experiment.end_date, datetime.date(2019, 1, 21))
 
+    def test_enrollment_ending_soon(self):
+        experiment_1 = ExperimentFactory.create_with_variants(
+            proposed_start_date=datetime.date.today(),
+            proposed_duration=20,
+            proposed_enrollment=5,
+        )
+        self.assertTrue(experiment_1.enrollment_ending_soon)
+
+        experiment_2 = ExperimentFactory.create_with_variants(
+            proposed_start_date=datetime.date.today(),
+            proposed_duration=20,
+            proposed_enrollment=8,
+        )
+        self.assertFalse(experiment_2.enrollment_ending_soon)
+
+    def test_experiment_ending_soon(self):
+        experiment_1 = ExperimentFactory.create_with_variants(
+            proposed_start_date=datetime.date.today(),
+            proposed_duration=5,
+            proposed_enrollment=0,
+        )
+        self.assertTrue(experiment_1.ending_soon)
+
+        experiment_2 = ExperimentFactory.create_with_variants(
+            proposed_start_date=datetime.date.today(),
+            proposed_duration=20,
+            proposed_enrollment=0,
+        )
+        self.assertFalse(experiment_2.ending_soon)
+
     def test_format_date_string_accepts_none_for_start(self):
         experiment = ExperimentFactory.create_with_variants()
         output = experiment._format_date_string(

--- a/app/experimenter/experiments/tests/test_tasks.py
+++ b/app/experimenter/experiments/tests/test_tasks.py
@@ -521,6 +521,20 @@ class TestUpdateExperimentStatus(
 
         self.assertEqual(len(mail.outbox), 0)
 
+    def test_send_enrollment_pausing_email(self):
+        ExperimentFactory.create_with_status(
+            target_status=Experiment.STATUS_LIVE,
+            normandy_id=1234,
+            proposed_start_date=date.today(),
+            proposed_enrollment=5,
+        )
+
+        tasks.update_experiment_info()
+
+        sent_email = mail.outbox[-1]
+
+        self.assertTrue(sent_email)
+
 
 class TestUpdateResolutionTask(MockRequestMixin, MockBugzillaMixin, TestCase):
 

--- a/app/experimenter/templates/experiments/emails/enrollment_pause_email.html
+++ b/app/experimenter/templates/experiments/emails/enrollment_pause_email.html
@@ -1,0 +1,24 @@
+{% autoescape off %}
+
+<p>Hello,</p>
+
+<p>
+  This is an automatic email from Experimenter about
+  <a target="_blank" rel="noreferrer noopener" href="{{ experiment.experiment_url }}">{{ experiment.name }}</a>.
+  Enrollment is scheduled to end on or within 6 days after {{ experiment.enrollment_end_date }}
+  during the next Normandy
+  <a target="_blank" rel="noreferrer noopener" href="{{ change_window_url }}">change window</a>.
+  Please check how enrollment is progressing. If you need a specific date sooner or if you
+  need the enrollment extended, please SLACK: #ask-experimenter for changes.
+</p>
+
+<p>
+  <a target="_blank" rel="noreferrer noopener" href="{{ experiment.experiment_url }}">{{ experiment.name }}</a>
+  is scheduled to end on {{ experiment.end_date }}. If everything looks good, no action is needed.
+</p>
+
+
+<p>Thank you!</p>
+<p>Experimenter and Normandy Teams</p>
+
+{% endautoescape %}


### PR DESCRIPTION
Adds enrollment ending email! Will send email 5 days (or less) out to owner, subscribers! 