### PR TITLE
Form checks if FF max version is greater than min fixes #1455

### DIFF
--- a/app/experimenter/experiments/forms.py
+++ b/app/experimenter/experiments/forms.py
@@ -470,6 +470,18 @@ class ExperimentVariantsBaseForm(ChangeLogMixin, forms.ModelForm):
 
         return population_percent
 
+    def clean_firefox_max_version(self):
+        firefox_min_version = self.cleaned_data["firefox_min_version"]
+        firefox_max_version = self.cleaned_data["firefox_max_version"]
+
+        if firefox_max_version:
+            if firefox_max_version <= firefox_min_version:
+                raise forms.ValidationError(
+                    "The max version must " "be larger than the min version."
+                )
+
+            return firefox_max_version
+
     def is_valid(self):
         return super().is_valid() and self.variants_formset.is_valid()
 

--- a/app/experimenter/experiments/tests/test_forms.py
+++ b/app/experimenter/experiments/tests/test_forms.py
@@ -903,6 +903,19 @@ class TestExperimentVariantsBaseForm(MockRequestMixin, TestCase):
         )
         self.assertEqual(experiment.platform, self.data["platform"])
 
+    def test_form_is_invalid_if_firefox_max_is_lower_than_min(self):
+        self.data["firefox_min_version"] = "66.0"
+        self.data["firefox_max_version"] = "64.0"
+        form = self.form_class(request=self.request, data=self.data)
+        self.assertFalse(form.is_valid())
+        self.assertIn("firefox_max_version", form.errors)
+
+    def test_form_is_valid_if_firefox_max_left_blank(self):
+        self.data["firefox_min_version"] = "66.0"
+        self.data["firefox_max_version"] = ""
+        form = self.form_class(request=self.request, data=self.data)
+        self.assertTrue(form.is_valid())
+
 
 class TestExperimentVariantsAddonForm(MockRequestMixin, TestCase):
 

--- a/app/experimenter/templates/experiments/edit_variants.html
+++ b/app/experimenter/templates/experiments/edit_variants.html
@@ -44,6 +44,7 @@
 
           <div class="col-5 pl-0">
             {% include "experiments/field_input_inline.html" with field=form.firefox_max_version %}
+            {% include "experiments/field_errors_inline.html" with field=form.firefox_max_version %}
           </div>
         </div>
       </div>


### PR DESCRIPTION
Adds a form validation method for firefox max value that makes sure the max is larger than the min. I don't allow them to be equal... if they want just one version they should leave the max blank. 

![maxversionerror](https://user-images.githubusercontent.com/1551682/61406942-ccba5a80-a891-11e9-8801-7d290acf3153.gif)
