### PR TITLE
Add versions filter object to normandy recipe serializer fixes #1447

### DIFF
--- a/app/experimenter/experiments/models.py
+++ b/app/experimenter/experiments/models.py
@@ -669,6 +669,28 @@ class Experiment(ExperimentConstants, models.Model):
             return self.firefox_min_version
 
     @property
+    def versions_integer_list(self):
+        min_integer = int(
+            ExperimentConstants.VERSION_REGEX.match(
+                self.firefox_min_version
+            ).group(0)
+        )
+
+        integers_list = [min_integer]
+
+        if self.firefox_max_version:
+            max_integer = int(
+                ExperimentConstants.VERSION_REGEX.match(
+                    self.firefox_max_version
+                ).group(0)
+            )
+
+            for x in range(min_integer + 1, max_integer + 1):
+                integers_list.append(x)
+
+        return integers_list
+
+    @property
     def population(self):
         return "{percent:g}% of {channel} Firefox {firefox_version}".format(
             percent=float(self.population_percent),

--- a/app/experimenter/experiments/models.py
+++ b/app/experimenter/experiments/models.py
@@ -343,15 +343,12 @@ class Experiment(ExperimentConstants, models.Model):
         if not self.bugzilla_id:
             raise ValueError(error_msg.format(field="Bugzilla ID"))
 
-        slug_min_version = ExperimentConstants.VERSION_REGEX.match(
-            self.firefox_min_version
-        ).group(0)
-        version_string = slug_min_version
+        version_string = self.firefox_min_version_integer
         if self.firefox_max_version:
-            slug_max_version = ExperimentConstants.VERSION_REGEX.match(
-                self.firefox_max_version
-            ).group(0)
-            version_string = f"{slug_min_version}-{slug_max_version}"
+            version_string = (
+                f"{self.firefox_min_version_integer}-"
+                f"{self.firefox_max_version_integer}"
+            )
 
         slug_prefix = f"{self.type}-"
         slug_postfix = (
@@ -669,26 +666,29 @@ class Experiment(ExperimentConstants, models.Model):
             return self.firefox_min_version
 
     @property
-    def versions_integer_list(self):
-        min_integer = int(
-            ExperimentConstants.VERSION_REGEX.match(
-                self.firefox_min_version
-            ).group(0)
-        )
-
-        integers_list = [min_integer]
-
+    def firefox_max_version_integer(self):
         if self.firefox_max_version:
-            max_integer = int(
+            return int(
                 ExperimentConstants.VERSION_REGEX.match(
                     self.firefox_max_version
                 ).group(0)
             )
 
-            for x in range(min_integer + 1, max_integer + 1):
-                integers_list.append(x)
+    @property
+    def firefox_min_version_integer(self):
+        return int(
+            ExperimentConstants.VERSION_REGEX.match(
+                self.firefox_min_version
+            ).group(0)
+        )
 
-        return integers_list
+    @property
+    def versions_integer_list(self):
+        max = (
+            self.firefox_max_version_integer
+            or self.firefox_min_version_integer
+        )
+        return list(range(self.firefox_min_version_integer, max + 1))
 
     @property
     def population(self):

--- a/app/experimenter/experiments/serializers.py
+++ b/app/experimenter/experiments/serializers.py
@@ -222,6 +222,21 @@ class FilterObjectChannelSerializer(serializers.ModelSerializer):
         return [obj.firefox_channel.lower()]
 
 
+class FilterObjectVersionsSerializer(serializers.ModelSerializer):
+    type = serializers.SerializerMethodField()
+    versions = serializers.SerializerMethodField()
+
+    class Meta:
+        model = Experiment
+        fields = ("type", "versions")
+
+    def get_type(self, obj):
+        return "version"
+
+    def get_versions(self, obj):
+        return obj.versions_integer_list
+
+
 class FilterObjectLocaleSerializer(serializers.ModelSerializer):
     type = serializers.SerializerMethodField()
     locales = serializers.SerializerMethodField()
@@ -322,6 +337,7 @@ class ExperimentRecipeSerializer(serializers.ModelSerializer):
         filter_objects = [
             FilterObjectBucketSampleSerializer(obj).data,
             FilterObjectChannelSerializer(obj).data,
+            FilterObjectVersionsSerializer(obj).data,
         ]
 
         if obj.locales.count():

--- a/app/experimenter/experiments/tests/test_models.py
+++ b/app/experimenter/experiments/tests/test_models.py
@@ -1085,6 +1085,17 @@ class TestExperimentModel(TestCase):
         self.assertEqual(experiment_1.format_firefox_versions, "57.0")
         self.assertEqual(experiment_2.format_firefox_versions, "57.0 to 59.0")
 
+    def test_versions_integer_list_returns_correct_list(self):
+        experiment_1 = ExperimentFactory(
+            firefox_min_version="57.0", firefox_max_version=""
+        )
+        experiment_2 = ExperimentFactory(
+            firefox_min_version="57.0", firefox_max_version="59.0"
+        )
+
+        self.assertEqual(experiment_1.versions_integer_list, [57])
+        self.assertEqual(experiment_2.versions_integer_list, [57, 58, 59])
+
     def test_experiment_population_returns_correct_string(self):
         experiment = ExperimentFactory(
             population_percent="0.5",

--- a/app/experimenter/experiments/tests/test_models.py
+++ b/app/experimenter/experiments/tests/test_models.py
@@ -1085,16 +1085,33 @@ class TestExperimentModel(TestCase):
         self.assertEqual(experiment_1.format_firefox_versions, "57.0")
         self.assertEqual(experiment_2.format_firefox_versions, "57.0 to 59.0")
 
-    def test_versions_integer_list_returns_correct_list(self):
-        experiment_1 = ExperimentFactory(
+    def test_versions_integer_list_with_only_min_returns_correct_list(self):
+        experiment = ExperimentFactory(
             firefox_min_version="57.0", firefox_max_version=""
         )
-        experiment_2 = ExperimentFactory(
+
+        self.assertEqual(experiment.versions_integer_list, [57])
+
+    def test_versions_integer_list_with_min_max_returns_correct_list(self):
+        experiment = ExperimentFactory(
             firefox_min_version="57.0", firefox_max_version="59.0"
         )
 
-        self.assertEqual(experiment_1.versions_integer_list, [57])
-        self.assertEqual(experiment_2.versions_integer_list, [57, 58, 59])
+        self.assertEqual(experiment.versions_integer_list, [57, 58, 59])
+
+    def test_firefox_max_version_integer_returns_correct_integer(self):
+        experiment = ExperimentFactory(
+            firefox_min_version="57.0", firefox_max_version="59.0"
+        )
+
+        self.assertEqual(experiment.firefox_max_version_integer, 59)
+
+    def test_firefox_min_version_integer_returns_correct_integer(self):
+        experiment = ExperimentFactory(
+            firefox_min_version="57.0", firefox_max_version="59.0"
+        )
+
+        self.assertEqual(experiment.firefox_min_version_integer, 57)
 
     def test_experiment_population_returns_correct_string(self):
         experiment = ExperimentFactory(

--- a/app/experimenter/experiments/tests/test_serializers.py
+++ b/app/experimenter/experiments/tests/test_serializers.py
@@ -23,6 +23,7 @@ from experimenter.experiments.serializers import (
     FilterObjectChannelSerializer,
     FilterObjectCountrySerializer,
     FilterObjectLocaleSerializer,
+    FilterObjectVersionsSerializer,
     JSTimestampField,
     PrefTypeField,
     LocaleSerializer,
@@ -332,6 +333,27 @@ class TestFilterObjectChannelSerializer(TestCase):
         )
 
 
+class TestFilterObjectVersionsSerializer(TestCase):
+
+    def test_serializer_outputs_version_string_with_only_min(self):
+        experiment = ExperimentFactory.create(
+            firefox_min_version="68.0", firefox_max_version=""
+        )
+        serializer = FilterObjectVersionsSerializer(experiment)
+        self.assertEqual(
+            serializer.data, {"type": "version", "versions": [68]}
+        )
+
+    def test_serializer_outputs_version_string_with_range(self):
+        experiment = ExperimentFactory.create(
+            firefox_min_version="68.0", firefox_max_version="70.0"
+        )
+        serializer = FilterObjectVersionsSerializer(experiment)
+        self.assertEqual(
+            serializer.data, {"type": "version", "versions": [68, 69, 70]}
+        )
+
+
 class TestFilterObjectLocaleSerializer(TestCase):
 
     def test_serializer_outputs_expected_schema(self):
@@ -431,6 +453,7 @@ class TestExperimentRecipeSerializer(TestCase):
             [
                 FilterObjectBucketSampleSerializer(experiment).data,
                 FilterObjectChannelSerializer(experiment).data,
+                FilterObjectVersionsSerializer(experiment).data,
                 FilterObjectLocaleSerializer(experiment).data,
                 FilterObjectCountrySerializer(experiment).data,
             ],
@@ -458,6 +481,7 @@ class TestExperimentRecipeSerializer(TestCase):
             [
                 FilterObjectBucketSampleSerializer(experiment).data,
                 FilterObjectChannelSerializer(experiment).data,
+                FilterObjectVersionsSerializer(experiment).data,
                 FilterObjectLocaleSerializer(experiment).data,
                 FilterObjectCountrySerializer(experiment).data,
             ],


### PR DESCRIPTION
fixes #1447 

adds filter object with list of integers for all versions the recipe affects. 

![Screen Shot 2019-07-30 at 1 49 06 PM](https://user-images.githubusercontent.com/1551682/62172793-66e5be00-b2e8-11e9-9ecd-4eba169afdc0.png)
