### PR TITLE
Add start date and set no enrollment period on task test fixes #1519

### DIFF
--- a/app/experimenter/experiments/tests/test_tasks.py
+++ b/app/experimenter/experiments/tests/test_tasks.py
@@ -370,7 +370,11 @@ class TestUpdateExperimentStatus(
 
     def test_accepted_experiment_becomes_live_if_normandy_enabled(self):
         ExperimentFactory.create_with_status(
-            target_status=Experiment.STATUS_ACCEPTED, normandy_id=1234
+            target_status=Experiment.STATUS_ACCEPTED,
+            normandy_id=1234,
+            proposed_start_date=date.today(),
+            proposed_duration=30,
+            proposed_enrollment=0,
         )
 
         tasks.update_experiment_info()


### PR DESCRIPTION
fixes #1519 

i think that by setting today's date as the proposed start date and the duration at 30, we can make sure the ending email won't be sent, and by setting the enrollment to 0 we can be sure the enrollment ending email won't be sent. 