### PR TITLE
Remove docker-compose-gunicorn fixes #1556

### DIFF
--- a/docker-compose-gunicorn.yml
+++ b/docker-compose-gunicorn.yml
@@ -1,5 +1,0 @@
-version: "3"
-
-services:
-  app:
-    command: bash -c "/app/bin/wait-for-it.sh db:5432 -- python /app/manage.py collectstatic --noinput;gunicorn -b 0.0.0.0:7001 experimenter.wsgi"


### PR DESCRIPTION
I put this in so we could run a local dev server with gunicorn in case we needed to recreate some gunicorn specific issue but in 2 years it hasn't come up so I'm gonna take it out.