### PR TITLE
Change page locator to rely on body tag class fixes #1646

### DIFF
--- a/app/experimenter/templates/base.html
+++ b/app/experimenter/templates/base.html
@@ -27,7 +27,7 @@
     {% endblock %}
   </head>
 
-  <body>
+  <body class="{% block page_id %}{% endblock %}">
 
     <div class="bg-primary text-white">
       <div class="container">

--- a/app/experimenter/templates/experiments/edit_base.html
+++ b/app/experimenter/templates/experiments/edit_base.html
@@ -62,3 +62,5 @@
     {% endblock %}
   </div>
 {% endblock %}
+
+{% block page_id %}page-edit-overview{% endblock %}

--- a/app/experimenter/templates/experiments/edit_variants.html
+++ b/app/experimenter/templates/experiments/edit_variants.html
@@ -152,3 +152,5 @@
 
   <script src="{% static "js/edit-variants.js" %}"></script>
 {% endblock %}
+
+{% block page_id %}page-edit-variants{% endblock %}

--- a/app/experimenter/templates/experiments/list.html
+++ b/app/experimenter/templates/experiments/list.html
@@ -198,3 +198,5 @@
 {% block extrascripts %}
   <script src="{% static "js/experiment-date-filter.js" %}"></script>
 {% endblock %}
+
+{% block page_id %}page-list-view{% endblock %}

--- a/tests/integration/pages/base.py
+++ b/tests/integration/pages/base.py
@@ -2,6 +2,7 @@
 
 from pypom import Page, Region
 from selenium.webdriver.common.by import By
+from selenium.webdriver.support import expected_conditions as EC
 
 
 class Base(Page):
@@ -9,6 +10,11 @@ class Base(Page):
         super(Base, self).__init__(
             selenium, base_url, locale=locale, timeout=30, **kwargs
         )
+
+    def wait_for_page_to_load(self):
+        self.wait.until(EC.presence_of_element_located(self._page_wait_locator))
+
+        return self
 
     @property
     def header(self):

--- a/tests/integration/pages/experiment_overview.py
+++ b/tests/integration/pages/experiment_overview.py
@@ -10,7 +10,7 @@ class ExperimentOverview(Base):
 
     _root_locator = (By.CSS_SELECTOR, ".form-group")
 
-    _overview_title_locator = (By.CSS_SELECTOR, "a.nav-link.active h4")
+    _page_wait_locator = (By.CSS_SELECTOR, "body.page-edit-overview")
     _overview_name_locator = (By.CSS_SELECTOR, "#id_name")
     _overview_description_locator = (By.CSS_SELECTOR, "#id_short_description")
     _overview_bugzilla_url_locator = (
@@ -19,12 +19,6 @@ class ExperimentOverview(Base):
     )
     _save_and_continue_btn_locator = (By.CSS_SELECTOR, ".btn-primary:nth-child(2)")
 
-    def wait_for_page_to_load(self):
-        self.wait.until(
-            lambda _: "Overview"
-            in self.find_element(*self._overview_title_locator).text
-        )
-        return self
 
     def fill_name(self, text=None):
         element = self.find_element(*self._overview_name_locator)

--- a/tests/integration/pages/experiment_population.py
+++ b/tests/integration/pages/experiment_population.py
@@ -38,23 +38,17 @@ class PopulationPage(Base):
     )
     _page_wait_locator = (
         By.CSS_SELECTOR,
-        "div.form-group:nth-child(2) > h4:nth-child(1)",
+        "body.page-edit-variants",
     )
 
-    def wait_for_page_to_load(self):
-        self.wait.until(
-            lambda _: "Population"
-            in self.find_element(*self._page_wait_locator).text
-        )
-        return self
-    
+
     def create_new_branch(self):
         """Creates a new branch."""
         num_of_branches = len(self.current_branches) + 1
         self.find_element(*self._add_branch_btn_locator).click()
         els = self.find_elements(*self._branch_form_root_locator)
         return self.BranchRegion(self, els[-1], count=num_of_branches)
-    
+
     @property
     def current_branches(self):
         """Returns list of current branches."""
@@ -100,7 +94,7 @@ class PopulationPage(Base):
 
     class BranchRegion(Region):
 
-        def __init__(self, page, root=None, count=None, **kwargs):  
+        def __init__(self, page, root=None, count=None, **kwargs):
             super().__init__(
                 page=page, root=root, **kwargs
             )
@@ -132,13 +126,13 @@ class PopulationPage(Base):
             element = self.find_element(*locator)
             element.send_keys(text)
             return
-        
+
         def set_branch_description(self, text=None):
             locator = (By.ID, f"id_variants-{self.number}-description")
             element = self.find_element(*locator)
             element.send_keys(text)
             return
-        
+
         def set_branch_value(self, text=None):
             locator = (By.ID, f"id_variants-{self.number}-value")
             element = self.find_element(*locator)

--- a/tests/integration/pages/home.py
+++ b/tests/integration/pages/home.py
@@ -6,14 +6,10 @@ from pages.base import Base
 class Home(Base):
 
     _create_experiment_btn_locator = (By.CSS_SELECTOR, "a.col.btn-primary")
-
-    def wait_for_page_to_load(self):
-        self.wait.until(
-            lambda _: self.find_element(
-                *self._create_experiment_btn_locator
-            ).is_displayed()
-        )
-        return self
+    _page_wait_locator = (
+        By.CSS_SELECTOR,
+        "body.page-list-view",
+    )
 
     def create_experiment(self):
         self.find_element(*self._create_experiment_btn_locator).click()

--- a/tests/integration/pages/owned_experiments.py
+++ b/tests/integration/pages/owned_experiments.py
@@ -8,14 +8,11 @@ from pages.base import Base
 class OwnedExperiments(Base):
 
     _owned_text_locator = (By.CSS_SELECTOR, ".m-0")
+    _page_wait_locator = (
+        By.CSS_SELECTOR,
+        "body.page-list-view",
+    )
 
-    def wait_for_page_to_load(self):
-        self.wait.until(
-            lambda _: self.find_element(
-                *self._owned_text_locator
-            ).is_displayed()
-        )
-        return self
 
     @property
     def count(self):

--- a/tests/integration/pages/subscribed_experiments.py
+++ b/tests/integration/pages/subscribed_experiments.py
@@ -8,14 +8,11 @@ from pages.base import Base
 class SubscribedExperiments(Base):
 
     _subscribed_text_locator = (By.CSS_SELECTOR, ".m-0")
+    _page_wait_locator = (
+        By.CSS_SELECTOR,
+        "body.page-list-view",
+    )
 
-    def wait_for_page_to_load(self):
-        self.wait.until(
-            lambda _: self.find_element(
-                *self._subscribed_text_locator
-            ).is_displayed()
-        )
-        return self
 
     @property
     def count(self):


### PR DESCRIPTION
inside integration tests, we decided to make the wait to load functions rely on a the body of the right page loading, instead of looking for specific words changing in titles.

I pulled the `wait_for_page_to_load` method out to the Base class that everything is inheriting from since that function ended up being the same everywhere.