### PR TITLE
Add public-url to parcel commands fixes #1657

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -7,8 +7,8 @@
   "devDependencies": {},
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "build": "parcel build experimenter/static/css/index.css experimenter/static/js/index.js --out-dir experimenter/static/assets",
-    "watch": "parcel watch experimenter/static/css/index.css experimenter/static/js/index.js --out-dir experimenter/static/assets --https --hmr-hostname localhost --hmr-port 33123"
+    "build": "parcel build experimenter/static/css/index.css experimenter/static/js/index.js --out-dir experimenter/static/assets --public-url /static/assets/",
+    "watch": "parcel watch experimenter/static/css/index.css experimenter/static/js/index.js --out-dir experimenter/static/assets --https --hmr-hostname localhost --hmr-port 33123 --public-url /static/assets/"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Adding `--public-url` to both build and watch fixes the bad path.