### PR TITLE
Add jquery to show normandy id form fixes #1704

### DIFF
--- a/app/experimenter/templates/experiments/detail_ship.html
+++ b/app/experimenter/templates/experiments/detail_ship.html
@@ -49,25 +49,18 @@
                 target="_blank"
                 class="btn btn-primary"
                 role="button"
+                id="export-normandy-button"
               >
                 Export to Normandy
               </a>
-
-              <button
-                class="btn btn-secondary mx-1"
-                data-toggle="collapse"
-                data-target="#stn-step2"
-              >
-                Already exported
-              </button>
             </p>
           </div>
 
           <form
             method="post"
             action="{% url "experiments-normandy-update" slug=experiment.slug %}"
-            class="collapse {% if normandy_id_form.normandy_id.value or normandy_id_form.other_normandy_ids.value %}show{% endif %}"
-            id="stn-step2"
+            id="id-form"
+            class="d-none"
           >
             {% csrf_token %}
             <hr />
@@ -106,6 +99,16 @@
 
 {% block extrascripts %}
   {{ block.super }}
+  <script>
+    const modal = $("#normandyModal");
+    const normandyIdForm = modal.find("#id-form");
+
+    jQuery(function($) {
+      $("#export-normandy-button").on("click", function(e) {
+        normandyIdForm.removeClass("d-none");
+      })
+    })
+  </script>
 
   {% if normandy_id_form.errors %}
     <script>
@@ -114,4 +117,5 @@
       });
     </script>
   {% endif %}
+
 {% endblock %}


### PR DESCRIPTION
![normandymodal](https://user-images.githubusercontent.com/1551682/65910882-7208a900-e380-11e9-87c9-ffa9e148586b.gif)

So I didn't really worry about hiding the form at any point... I figured that if they clicked away from the modal accidentally AFTER pressing the export button, it would make sense that those form fields still be showing if they then tried to reopen the modal by pressing the export to normandy button? I could see it either way I guess.

Not sure if there is a case I'm missing where it would be useful to have a way, like a small x button, to get rid of that piece of form or not... on demand... let me know. 