### PR TITLE
Check for missing analysis_owner in migration fixes #1740

### DIFF
--- a/app/experimenter/experiments/migrations/0073_experiment_new_analysis_owner.py
+++ b/app/experimenter/experiments/migrations/0073_experiment_new_analysis_owner.py
@@ -8,13 +8,14 @@ import django.db.models.deletion
 
 
 def closest_user(users, target_name):
-    return sorted(
-        [
-            (SM(None, user.email.lower(), target_name.lower()).ratio(), user)
-            for user in users
-        ],
-        reverse=True,
-    )[0][1]
+    if target_name:
+        return sorted(
+            [
+                (SM(None, user.email.lower(), target_name.lower()).ratio(), user)
+                for user in users
+            ],
+            reverse=True,
+        )[0][1]
 
 
 def forward_analysis_owner(apps, schema_editor):

--- a/app/experimenter/experiments/tests/test_migrations.py
+++ b/app/experimenter/experiments/tests/test_migrations.py
@@ -37,7 +37,11 @@ class TestMigration0073(MigrationTestCase):
 
         user_jdata = OldUser.objects.create(username=jdata, email=jdata)
         OldUser.objects.create(username=jdota, email=jdota)
-        experiment = OldExperiment.objects.create(analysis_owner="Jim Data")
+        experiment = OldExperiment.objects.create(
+            name="Beep", slug="beep", analysis_owner="Jim Data"
+        )
+
+        OldExperiment.objects.create(name="Boop", slug="boop", analysis_owner=None)
 
         self.migrate_to_dest()
 


### PR DESCRIPTION
Forgot to check for experiments where `analysis_owner=None` in the migration.