### PR TITLE
Migration 073 fails for equal string matches fixes #1757

### DIFF
--- a/app/experimenter/experiments/migrations/0073_experiment_new_analysis_owner.py
+++ b/app/experimenter/experiments/migrations/0073_experiment_new_analysis_owner.py
@@ -11,11 +11,11 @@ def closest_user(users, target_name):
     if target_name:
         return sorted(
             [
-                (SM(None, user.email.lower(), target_name.lower()).ratio(), user)
+                (SM(None, user.email.lower(), target_name.lower()).ratio(), user.id, user)
                 for user in users
             ],
             reverse=True,
-        )[0][1]
+        )[0][2]
 
 
 def forward_analysis_owner(apps, schema_editor):

--- a/app/experimenter/experiments/tests/test_migrations.py
+++ b/app/experimenter/experiments/tests/test_migrations.py
@@ -37,6 +37,7 @@ class TestMigration0073(MigrationTestCase):
 
         user_jdata = OldUser.objects.create(username=jdata, email=jdata)
         OldUser.objects.create(username=jdota, email=jdota)
+        OldUser.objects.create(username="duplicate jdota", email=jdota)
         experiment = OldExperiment.objects.create(
             name="Beep", slug="beep", analysis_owner="Jim Data"
         )


### PR DESCRIPTION
If two users string match identically then `sorted` moves on to compare the next element, which in the original version was a `User` object which doesn't implement `__cmp__` (which I find silly it should just fall back to comparing db ids, or maybe there's a meta field for that?), so if I just stick `user.id` into the tuple it'll fall back to comparing those.