### PR TITLE
Update variant slugs on save fixes #1733

### DIFF
--- a/app/experimenter/experiments/forms.py
+++ b/app/experimenter/experiments/forms.py
@@ -27,34 +27,6 @@ from experimenter.experiments.serializers import ChangeLogSerializer
 from experimenter.notifications.models import Notification
 
 
-class NameSlugFormMixin(object):
-    """
-    Automatically generate a slug from the name field
-    """
-
-    def clean_name(self):
-        name = self.cleaned_data["name"]
-        slug = slugify(name)
-
-        if not slug:
-            raise forms.ValidationError(
-                "This name must include non-punctuation characters."
-            )
-
-        return name
-
-    def clean(self):
-        cleaned_data = super().clean()
-
-        if self.instance.slug:
-            del cleaned_data["slug"]
-        else:
-            name = cleaned_data.get("name")
-            cleaned_data["slug"] = slugify(name)
-
-        return cleaned_data
-
-
 class JSONField(forms.CharField):
 
     def clean(self, value):
@@ -206,7 +178,7 @@ class ChangeLogMixin(object):
         )
 
 
-class ExperimentOverviewForm(NameSlugFormMixin, ChangeLogMixin, forms.ModelForm):
+class ExperimentOverviewForm(ChangeLogMixin, forms.ModelForm):
 
     type = forms.ChoiceField(
         label="Type", choices=Experiment.TYPE_CHOICES, help_text=Experiment.TYPE_HELP_TEXT
@@ -296,8 +268,13 @@ class ExperimentOverviewForm(NameSlugFormMixin, ChangeLogMixin, forms.ModelForm)
     related_to.widget.attrs.update({"data-live-search": "true"})
 
     def clean_name(self):
-        name = super().clean_name()
+        name = self.cleaned_data["name"]
         slug = slugify(name)
+
+        if not slug:
+            raise forms.ValidationError(
+                "This name must include non-punctuation characters."
+            )
 
         if (
             self.instance.pk is None
@@ -308,8 +285,19 @@ class ExperimentOverviewForm(NameSlugFormMixin, ChangeLogMixin, forms.ModelForm)
 
         return name
 
+    def clean(self):
+        cleaned_data = super().clean()
 
-class ExperimentVariantGenericForm(NameSlugFormMixin, forms.ModelForm):
+        if self.instance.slug:
+            del cleaned_data["slug"]
+        else:
+            name = cleaned_data.get("name")
+            cleaned_data["slug"] = slugify(name)
+
+        return cleaned_data
+
+
+class ExperimentVariantGenericForm(forms.ModelForm):
 
     experiment = forms.ModelChoiceField(queryset=Experiment.objects.all(), required=False)
     is_control = forms.BooleanField(required=False)
@@ -336,6 +324,25 @@ class ExperimentVariantGenericForm(NameSlugFormMixin, forms.ModelForm):
     class Meta:
         model = ExperimentVariant
         fields = ["description", "experiment", "is_control", "name", "ratio", "slug"]
+
+    def clean_name(self):
+        name = self.cleaned_data["name"]
+        slug = slugify(name)
+
+        if not slug:
+            raise forms.ValidationError(
+                "This name must include non-punctuation characters."
+            )
+
+        return name
+
+    def clean(self):
+        cleaned_data = super().clean()
+
+        name = cleaned_data.get("name")
+        cleaned_data["slug"] = slugify(name)
+
+        return cleaned_data
 
 
 class ExperimentVariantPrefForm(ExperimentVariantGenericForm):

--- a/app/experimenter/experiments/tests/test_forms.py
+++ b/app/experimenter/experiments/tests/test_forms.py
@@ -139,6 +139,22 @@ class TestExperimentVariantGenericForm(TestCase):
         self.assertFalse(form.is_valid())
         self.assertIn("ratio", form.errors)
 
+    def test_checks_empty_slug(self):
+        self.data["name"] = "!"
+        form = ExperimentVariantGenericForm(self.data)
+
+        self.assertFalse(form.is_valid())
+        self.assertIn("name", form.errors)
+
+    def test_updates_variant_slug(self):
+        variant = ExperimentVariantFactory.create(slug="the-treatment-variant")
+        form = ExperimentVariantGenericForm(self.data, instance=variant)
+
+        self.assertTrue(form.is_valid())
+
+        saved_variant = form.save()
+        self.assertEqual(saved_variant.slug, "the-control-variant")
+
 
 class TestExperimentVariantPrefForm(TestCase):
 


### PR DESCRIPTION
Previously we used a shared mixin for both Experiment and ExperimentVariant to automatically set `slug` from `name` but because we only want to set the experiment slug once (on first save) we automatically got that same behaviour for variants.  But this leads to the case where someone clones an experiment, renames the variants, but the old variant slugs still go to Normandy so it looks wonky.  

I took out that mixin and just flattened the code into each of Experiment and ExperimentVariant forms because we don't really benefit all that much from pulling it out if they behave differently enough.  

This way cloned variants always have a slug, and if they never change the variant names then the slugs stay the same, and if they do, they get the new slugs.