### PR TITLE
Make value state live in designInput, use FormData for fetch fixes #1790

### DIFF
--- a/app/experimenter/static/js/addonForm.js
+++ b/app/experimenter/static/js/addonForm.js
@@ -25,7 +25,7 @@ export default function AddonForm(props) {
         name="addon_experiment_id"
         handleInputChange={props.handleInputChange}
         value={props.addon_experiment_id}
-        error={props.errors.addon_experiment_id}
+        error={props.errors ? props.errors.addon_experiment_id : ""}
         helpContent={
           <div>
             <p>
@@ -48,7 +48,7 @@ export default function AddonForm(props) {
         name="addon_release_url"
         handleInputChange={props.handleInputChange}
         value={props.addon_release_url}
-        error={props.errors.addon_release_url}
+        error={props.errors ? props.errors.addon_release_url : ""}
         helpContent={
           <div>
             <p>

--- a/app/experimenter/static/js/designInput.js
+++ b/app/experimenter/static/js/designInput.js
@@ -17,6 +17,7 @@ export default class DesignInput extends React.Component {
     super(props);
 
     this.state = {
+      value: this.props.value,
       help_showing: false
     };
   }
@@ -24,6 +25,11 @@ export default class DesignInput extends React.Component {
   @boundMethod
   toggleHelp(e) {
     this.setState({ help_showing: !this.state.help_showing });
+  }
+
+  @boundMethod
+  updateValue(e) {
+    this.setState({ value: e.target.value });
   }
 
   render() {
@@ -51,8 +57,8 @@ export default class DesignInput extends React.Component {
             id={this.props.id}
             type="text"
             name={this.props.name}
-            onChange={this.props.handleInputChange}
-            value={this.props.value}
+            onChange={this.updateValue}
+            value={this.state.value}
             className={this.props.error ? "is-invalid" : ""}
           >
             {this.props.children}

--- a/app/experimenter/static/js/genericForm.js
+++ b/app/experimenter/static/js/genericForm.js
@@ -20,7 +20,7 @@ export default function GenericForm(props) {
         name="design"
         handleInputChange={props.handleInputChange}
         value={props.design}
-        error={props.errors.design}
+        error={props.errors ? props.errors.design : ""}
         as="textarea"
         rows="10"
         helpContent={

--- a/app/experimenter/static/js/prefForm.js
+++ b/app/experimenter/static/js/prefForm.js
@@ -26,7 +26,7 @@ export default function PrefForm(props) {
         id="id_pref_key"
         handleInputChange={props.handleInputChange}
         value={props.pref_key}
-        error={props.errors.pref_key}
+        error={props.errors ? props.errors.pref_key : ""}
         helpContent={
           <div>
             <p>
@@ -49,7 +49,7 @@ export default function PrefForm(props) {
         id="id_pref_type"
         handleInputChange={props.handleInputChange}
         value={props.pref_type}
-        error={props.errors.pref_type}
+        error={props.errors ? props.errors.pref_type : ""}
         as="select"
         helpContent={
           <div>
@@ -76,7 +76,7 @@ export default function PrefForm(props) {
         id="id_pref_branch"
         handleInputChange={props.handleInputChange}
         value={props.pref_branch}
-        error={props.errors.pref_branch}
+        error={props.errors ? props.errors.pref_branch : ""}
         as="select"
         helpContent={
           <div>

--- a/app/package.json
+++ b/app/package.json
@@ -13,7 +13,8 @@
     "react": ">=16.8.0",
     "react-bootstrap": "^1.0.0-beta.11",
     "react-dom": ">=16.8.0",
-    "@babel/plugin-proposal-decorators": "7.6.0"
+    "@babel/plugin-proposal-decorators": "7.6.0",
+    "form-serialize": "0.7.2"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0-0",

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -314,7 +314,7 @@
     "@babel/helper-remap-async-to-generator" "^7.1.0"
     "@babel/plugin-syntax-async-generators" "^7.2.0"
 
-"@babel/plugin-proposal-decorators@^7.6.0":
+"@babel/plugin-proposal-decorators@7.6.0":
   version "7.6.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.6.0.tgz#6659d2572a17d70abd68123e89a12a43d90aa30c"
   integrity sha512-ZSyYw9trQI50sES6YxREXKu+4b7MAg6Qx2cvyDDYjP2Hpzd3FleOUwC9cqn1+za8d0A2ZU8SHujxFao956efUg==
@@ -2444,6 +2444,11 @@ form-data@~2.3.2:
     asynckit "^0.4.0"
     combined-stream "^1.0.6"
     mime-types "^2.1.12"
+
+form-serialize@^0.7.2:
+  version "0.7.2"
+  resolved "https://registry.yarnpkg.com/form-serialize/-/form-serialize-0.7.2.tgz#b0a2ff0c22026fb6d3d15c9d33f6de6a432e4732"
+  integrity sha1-sKL/DCICb7bT0VydM/beakMuRzI=
 
 fragment-cache@^0.2.1:
   version "0.2.1"


### PR DESCRIPTION
In this PR I move the input value state down to the DesignInput component. In doing this I could remove all state initialization besides `is_loaded`. Because then there were no errors in state initialization, I had to modify the way we passed errors down as props, so you'll see that in this PR. Once all state is controlled at input level, we had to change over to using formData in handleSubmit. We needed a library called form-serialize to format the data coming out of all the form inputs correctly for sending to server. 