### PR TITLE
Make control branch always be in the right place fixes #1796

### DIFF
--- a/app/experimenter/static/js/designForm.js
+++ b/app/experimenter/static/js/designForm.js
@@ -31,6 +31,10 @@ export default class DesignForm extends React.Component {
 
     const json = await response.json();
 
+    const controlBranchIndex = json.variants.findIndex(element => element.is_control)
+    const controlBranch = json.variants.splice(controlBranchIndex, 1)[0]
+    json.variants.unshift(controlBranch)
+
     json.loaded = true;
 
     return this.setState(json);


### PR DESCRIPTION
Actually, I accidentally took out any `is_control` sorting in my last PR. It wasn't right, so I guess it's ok, but this right here seems like a decent way to move is_control to the first of the branches list always. 