### PR TITLE
Add loading spinner fixes #1783

### DIFF
--- a/app/experimenter/static/js/designForm.js
+++ b/app/experimenter/static/js/designForm.js
@@ -111,7 +111,15 @@ export default class DesignForm extends React.Component {
   render() {
     const dataExists = this.state.loaded;
     if (!dataExists) {
-      return null;
+      return (
+        <Container>
+          <div class="fa-5x">
+            <Row className="justify-content-center">
+              <i className="fas fa-spinner fa-spin"></i>
+            </Row>
+          </div>
+        </Container>
+      );
     } else {
       return (
         <div>


### PR DESCRIPTION
here's a quick loading spinner. It happens pretty quick that content loads, so quick that the spinner only makes a few motions... and it's kinda entirely lost in the screen shot... unfortunately... but IRL it does swirl briefly around. 

![spinner](https://user-images.githubusercontent.com/1551682/67530213-3b6a3980-f673-11e9-8b07-3731ebf6ebe2.gif)

