### PR TITLE
Pass all of state, including errors fixes #1818

### DIFF
--- a/app/experimenter/static/js/addonForm.js
+++ b/app/experimenter/static/js/addonForm.js
@@ -24,7 +24,7 @@ export default function AddonForm(props) {
         label="Addon Experiment Name"
         name="addon_experiment_id"
         handleInputChange={props.handleInputChange}
-        value={props.addon_experiment_id}
+        value={props.values.addon_experiment_id}
         error={props.errors ? props.errors.addon_experiment_id : ""}
         helpContent={
           <div>
@@ -47,7 +47,7 @@ export default function AddonForm(props) {
         label="Signed Release URL"
         name="addon_release_url"
         handleInputChange={props.handleInputChange}
-        value={props.addon_release_url}
+        value={props.values.addon_release_url}
         error={props.errors ? props.errors.addon_release_url : ""}
         helpContent={
           <div>

--- a/app/experimenter/static/js/designForm.js
+++ b/app/experimenter/static/js/designForm.js
@@ -119,7 +119,7 @@ export default class DesignForm extends React.Component {
     if (!dataExists) {
       return (
         <Container>
-          <div class="fa-5x">
+          <div className="fa-5x">
             <Row className="justify-content-center">
               <i className="fas fa-spinner fa-spin"></i>
             </Row>
@@ -134,7 +134,7 @@ export default class DesignForm extends React.Component {
               {this.state.values.type == "pref" ? (
                 <PrefForm
                   handleInputChange={this.handleInputChange}
-                  {...this.state.values}
+                  {...this.state}
                 ></PrefForm>
               ) : (
                 ""
@@ -142,7 +142,7 @@ export default class DesignForm extends React.Component {
               {this.state.values.type == "addon" ? (
                 <AddonForm
                   handleInputChange={this.handleInputChange}
-                  {...this.state.values}
+                  {...this.state}
                 ></AddonForm>
               ) : (
                 ""
@@ -150,7 +150,7 @@ export default class DesignForm extends React.Component {
               {this.state.values.type == "generic" ? (
                 <GenericForm
                   handleInputChange={this.handleInputChange}
-                  {...this.state.values}
+                  {...this.state}
                 ></GenericForm>
               ) : (
                 ""

--- a/app/experimenter/static/js/genericForm.js
+++ b/app/experimenter/static/js/genericForm.js
@@ -19,7 +19,7 @@ export default function GenericForm(props) {
         label="Design"
         name="design"
         handleInputChange={props.handleInputChange}
-        value={props.design}
+        value={props.values.design}
         error={props.errors ? props.errors.design : ""}
         as="textarea"
         rows="10"

--- a/app/experimenter/static/js/prefForm.js
+++ b/app/experimenter/static/js/prefForm.js
@@ -25,7 +25,7 @@ export default function PrefForm(props) {
         name="pref_key"
         id="id_pref_key"
         handleInputChange={props.handleInputChange}
-        value={props.pref_key}
+        value={props.values.pref_key}
         error={props.errors ? props.errors.pref_key : ""}
         helpContent={
           <div>
@@ -48,7 +48,7 @@ export default function PrefForm(props) {
         name="pref_type"
         id="id_pref_type"
         handleInputChange={props.handleInputChange}
-        value={props.pref_type}
+        value={props.values.pref_type}
         error={props.errors ? props.errors.pref_type : ""}
         as="select"
         helpContent={
@@ -75,7 +75,7 @@ export default function PrefForm(props) {
         name="pref_branch"
         id="id_pref_branch"
         handleInputChange={props.handleInputChange}
-        value={props.pref_branch}
+        value={props.values.pref_branch}
         error={props.errors ? props.errors.pref_branch : ""}
         as="select"
         helpContent={


### PR DESCRIPTION
We need to be passing the whole state down, not just `state.values`, or else we don't get the errors too. 