### PR TITLE
Add public network to app container fixes #1848

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,7 @@ services:
     command: bash -c "/app/bin/wait-for-it.sh db:5432 -- python /app/manage.py collectstatic --noinput;python /app/manage.py runserver 0:7001"
     networks:
       - private_nw
+      - public_nw
 
   yarn:
     image: app:build


### PR DESCRIPTION
Anytime we want to go into `make bash` and modify packages with pip or yarn, that container needs public internet access so we should just leave this in here.