### PR TITLE
Use built container node_modules fixes #1865

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     volumes:
       - ./app:/app
       - static_volume:/app/experimenter/served/
-      - node_modules_volume:/app/node_modules/
+      - /app/node_modules/
     command: bash -c "/app/bin/wait-for-it.sh db:5432 -- python /app/manage.py collectstatic --noinput;python /app/manage.py runserver 0:7001"
     networks:
       - private_nw
@@ -24,7 +24,7 @@ services:
     volumes:
       - ./app:/app
       - static_volume:/app/experimenter/served/
-      - node_modules_volume:/app/node_modules/
+      - /app/node_modules/
     command: bash -c "yarn run watch"
     networks:
       - public_nw
@@ -85,7 +85,6 @@ services:
 volumes:
   db_volume:
   static_volume:
-  node_modules_volume:
 
 networks:
   private_nw:


### PR DESCRIPTION
Okay so this should mean

1) during container build time, install packages into /app/node_modules/ inside the container
2) when we start the containers using compose and map /app/ to the host, we preserve the /app/node_modules/ from the built image rather than the host filesystem, and not using a shared persistent volume