### PR TITLE
change to add error entry to variants when adding new branch fixes #1857

### DIFF
--- a/app/experimenter/static/js/components/BranchManager.js
+++ b/app/experimenter/static/js/components/BranchManager.js
@@ -31,6 +31,11 @@ export default class BranchManager extends React.Component {
   @boundMethod
   addBranch() {
     this.state.variants[this.state.variants_counter++] = {};
+    //add empty error entry for new variant branch
+    if (this.props.errors.variants){
+      this.props.errors.variants.push({})
+    }
+
     this.setState(this.state);
   }
 


### PR DESCRIPTION
When errors are present and "Add Branch" button is clicked, the size of the variants error array doesn't change. Therefore causing an index/type Error` TypeError: props.errors.variants[props.index] is undefined` 

Changes were made it so that if errors are present, an empty entry is added for the new branch