### PR TITLE
Reject ratios of 0 or above 100 fixes #1863

### DIFF
--- a/app/experimenter/experiments/serializers.py
+++ b/app/experimenter/experiments/serializers.py
@@ -450,6 +450,12 @@ class ExperimentDesignBranchBaseSerializer(serializers.ModelSerializer):
     name = serializers.CharField()
     ratio = serializers.IntegerField()
 
+    def validate_ratio(self, value):
+        if value == 0 or value == 100:
+            raise serializers.ValidationError(["Branch sizes must be between 1 and 99."])
+
+        return value
+
     class Meta:
         list_serializer_class = VariantsListSerializer
         fields = ["id", "description", "is_control", "name", "ratio"]

--- a/app/experimenter/experiments/serializers.py
+++ b/app/experimenter/experiments/serializers.py
@@ -451,10 +451,10 @@ class ExperimentDesignBranchBaseSerializer(serializers.ModelSerializer):
     ratio = serializers.IntegerField()
 
     def validate_ratio(self, value):
-        if value == 0 or value == 100:
-            raise serializers.ValidationError(["Branch sizes must be between 1 and 99."])
+        if 1 <= value <= 100:
+            return value
 
-        return value
+        raise serializers.ValidationError(["Branch sizes must be between 1 and 100."])
 
     class Meta:
         list_serializer_class = VariantsListSerializer

--- a/app/experimenter/experiments/tests/test_serializers.py
+++ b/app/experimenter/experiments/tests/test_serializers.py
@@ -745,6 +745,22 @@ class TestExperimentDesignBaseSerializer(TestCase):
         self.assertFalse(serializer.is_valid())
         self.assertIn("variants", serializer.errors)
 
+    def test_serializer_rejects_ratios_0_or_100(self):
+        experiment = ExperimentFactory.create(type=ExperimentConstants.TYPE_ADDON)
+
+        self.control_variant_data["ratio"] = 0
+        self.treatment_variant_data["ratio"] = 100
+
+        data = {
+            "type": ExperimentConstants.TYPE_ADDON,
+            "variants": [self.control_variant_data, self.treatment_variant_data],
+        }
+
+        serializer = ExperimentDesignBaseSerializer(instance=experiment, data=data)
+
+        self.assertFalse(serializer.is_valid())
+        self.assertIn("variants", serializer.errors)
+
     def test_serializer_rejects_duplicate_branch_names(self):
         experiment = ExperimentFactory.create(type=ExperimentConstants.TYPE_PREF)
 

--- a/app/experimenter/experiments/tests/test_serializers.py
+++ b/app/experimenter/experiments/tests/test_serializers.py
@@ -745,15 +745,29 @@ class TestExperimentDesignBaseSerializer(TestCase):
         self.assertFalse(serializer.is_valid())
         self.assertIn("variants", serializer.errors)
 
-    def test_serializer_rejects_ratios_0_or_above_100(self):
+    def test_serializer_rejects_ratios_of_0(self):
         experiment = ExperimentFactory.create(type=ExperimentConstants.TYPE_ADDON)
 
         self.control_variant_data["ratio"] = 0
-        self.treatment_variant_data["ratio"] = 100
 
         data = {
             "type": ExperimentConstants.TYPE_ADDON,
-            "variants": [self.control_variant_data, self.treatment_variant_data],
+            "variants": [self.control_variant_data],
+        }
+
+        serializer = ExperimentDesignBaseSerializer(instance=experiment, data=data)
+
+        self.assertFalse(serializer.is_valid())
+        self.assertIn("variants", serializer.errors)
+
+    def test_serializer_rejects_ratios_above_100(self):
+        experiment = ExperimentFactory.create(type=ExperimentConstants.TYPE_ADDON)
+
+        self.control_variant_data["ratio"] = 110
+
+        data = {
+            "type": ExperimentConstants.TYPE_ADDON,
+            "variants": [self.control_variant_data],
         }
 
         serializer = ExperimentDesignBaseSerializer(instance=experiment, data=data)

--- a/app/experimenter/experiments/tests/test_serializers.py
+++ b/app/experimenter/experiments/tests/test_serializers.py
@@ -745,7 +745,7 @@ class TestExperimentDesignBaseSerializer(TestCase):
         self.assertFalse(serializer.is_valid())
         self.assertIn("variants", serializer.errors)
 
-    def test_serializer_rejects_ratios_0_or_100(self):
+    def test_serializer_rejects_ratios_0_or_above_100(self):
         experiment = ExperimentFactory.create(type=ExperimentConstants.TYPE_ADDON)
 
         self.control_variant_data["ratio"] = 0


### PR DESCRIPTION
this check happens before the ratio adding to 100 check, because it happens on the base serializer

<img width="856" alt="Screen Shot 2019-10-31 at 11 26 20 AM" src="https://user-images.githubusercontent.com/1551682/67976924-4d4c5f00-fbd4-11e9-8d48-a9beb027545d.png">
<img width="850" alt="Screen Shot 2019-10-31 at 11 26 32 AM" src="https://user-images.githubusercontent.com/1551682/67976925-4d4c5f00-fbd4-11e9-95a8-a9968b97eba2.png">
<img width="729" alt="Screen Shot 2019-10-31 at 11 26 57 AM" src="https://user-images.githubusercontent.com/1551682/67976926-4d4c5f00-fbd4-11e9-9730-1af2e8ba1493.png">
