### PR TITLE
Exclude editing experiment from addon duplicate check fixes #1877

### DIFF
--- a/app/experimenter/experiments/serializers.py
+++ b/app/experimenter/experiments/serializers.py
@@ -606,7 +606,12 @@ class ExperimentDesignAddonSerializer(ExperimentDesignBaseSerializer):
         fields = ("type", "addon_release_url", "addon_experiment_id", "variants")
 
     def validate_addon_experiment_id(self, value):
-        if Experiment.objects.filter(addon_experiment_id=value).exists():
+        existing = Experiment.objects.filter(addon_experiment_id=value)
+
+        if self.instance:
+            existing = existing.exclude(id=self.instance.id)
+
+        if existing.exists():
             raise serializers.ValidationError(
                 ["An experiment with this Addon Experiment Name already exists."]
             )

--- a/app/experimenter/experiments/tests/test_serializers.py
+++ b/app/experimenter/experiments/tests/test_serializers.py
@@ -1120,6 +1120,27 @@ class TestExperimentDesignAddonSerializer(TestCase):
 
         self.assertEqual(experiment.addon_experiment_id, "experiment id new")
 
+    def test_serializer_saves_unmodified_addon_experiment_id(self):
+        addon_experiment_id = "experiment@shield.org"
+        experiment = ExperimentFactory.create(addon_experiment_id=addon_experiment_id)
+
+        data = {
+            "type": ExperimentConstants.TYPE_ADDON,
+            "addon_release_url": "http://www.example.com",
+            "addon_experiment_id": addon_experiment_id,
+            "variants": [
+                {
+                    "name": "Terrific branch",
+                    "ratio": 100,
+                    "description": "Very terrific branch.",
+                    "is_control": True,
+                }
+            ],
+        }
+
+        serializer = ExperimentDesignAddonSerializer(instance=experiment, data=data)
+        self.assertTrue(serializer.is_valid())
+
 
 class TestExperimentDesignGenericSerializer(TestCase):
 


### PR DESCRIPTION
Found another bug, if you try to save an addon experiment without changing its addon experiment id, the duplicate check collides with itself so you can't save.