### PR TITLE
changed validation to not allow special characters fixes #1879

### DIFF
--- a/app/experimenter/experiments/constants.py
+++ b/app/experimenter/experiments/constants.py
@@ -189,6 +189,9 @@ class ExperimentConstants(object):
     # Branched Addon Stuff
     FX_MIN_BRANCHED_ADDON_VERSION = 68
 
+    # ExperimentVariantName REGEX
+    EXPERIMENT_VARIANT_NAME_REGEX = re.compile(r"^[a-z0-9 ]+$", re.IGNORECASE)
+
     # Labels
     RISK_INTERNAL_ONLY_LABEL = "Is this experiment sensitive and/or internal only?"
     RISK_PARTNER_RELATED_LABEL = "Is this experiment partner related?"

--- a/app/experimenter/experiments/serializers.py
+++ b/app/experimenter/experiments/serializers.py
@@ -1,6 +1,5 @@
 import time
 import json
-import re
 from rest_framework import serializers
 from django.utils.text import slugify
 from django.urls import reverse
@@ -511,8 +510,10 @@ class ExperimentDesignBaseSerializer(serializers.ModelSerializer):
         unique_names = len(
             set([slugify(variant["name"]) for variant in variants])
         ) == len(variants)
+
         all_contains_alphanumeric_and_spaces = all(
-            [re.match("^[A-Za-z0-9 ]*$", variant["name"]) for variant in variants]
+            Experiment.EXPERIMENT_VARIANT_NAME_REGEX.match(variant["name"])
+            for variant in variants
         )
 
         return unique_names and all_contains_alphanumeric_and_spaces

--- a/app/experimenter/experiments/tests/test_serializers.py
+++ b/app/experimenter/experiments/tests/test_serializers.py
@@ -790,6 +790,21 @@ class TestExperimentDesignBaseSerializer(TestCase):
         self.assertFalse(serializer.is_valid())
         self.assertIn("variants", serializer.errors)
 
+    def test_serializer_rejects_special_char_branch_names(self):
+        experiment = ExperimentFactory.create(type=ExperimentConstants.TYPE_PREF)
+
+        self.control_variant_data["name"] = "&re@t br@nche$!"
+
+        data = {
+            "type": ExperimentConstants.TYPE_PREF,
+            "variants": [self.control_variant_data, self.treatment_variant_data],
+        }
+
+        serializer = ExperimentDesignBaseSerializer(instance=experiment, data=data)
+
+        self.assertFalse(serializer.is_valid())
+        self.assertIn("variants", serializer.errors)
+
 
 class TestExperimentDesignPrefSerializer(TestCase):
 


### PR DESCRIPTION
since `slugify()` removes anything that isn't alphanumerics, underscores, hyphens, or whitespace, added validation to check if name only contain alphanumeric characters and spaces since the error message says no special characters. Not sure if this is too restrictive and we should be allowing underscores, hyphens and whitespaces as well. 