### PR TITLE
allow for design to be blank fixes #1855

### DIFF
--- a/app/experimenter/experiments/models.py
+++ b/app/experimenter/experiments/models.py
@@ -499,7 +499,7 @@ class Experiment(ExperimentConstants, models.Model):
 
     @property
     def completed_design(self):
-        return self.design != self.DESIGN_DEFAULT
+        return self.design not in (self.DESIGN_DEFAULT, None, "")
 
     @property
     def completed_addon(self):

--- a/app/experimenter/static/js/components/DesignForm.js
+++ b/app/experimenter/static/js/components/DesignForm.js
@@ -11,7 +11,6 @@ import Serialize from "form-serialize";
 import PrefForm from "experimenter/components/PrefForm";
 import GenericForm from "experimenter/components/GenericForm";
 import AddonForm from "experimenter/components/AddonForm";
-import BranchManager from "experimenter/components/BranchManager";
 
 export default class DesignForm extends React.Component {
   constructor(props) {
@@ -100,6 +99,10 @@ export default class DesignForm extends React.Component {
     const form = document.querySelector("#design-form");
     let object = Serialize(form, { hash: true });
 
+    if (!object.design && this.state.values.type=="generic"){
+      object.design = null
+    }
+  
     //remove undefined/deleted variants
     object.variants = object.variants.filter(item=>item!=undefined);
 


### PR DESCRIPTION
when the form is serialized for the API call, if a field is blank, it's not picked up. Since the designed field is not required, the API call is successful without a "design" field included, therefore blanking the field wasn't able to occur. Added field to request body when design field is null and type is generic.