### PR TITLE
Fix types in tests fixes #1873

### DIFF
--- a/app/experimenter/experiments/tests/test_serializers.py
+++ b/app/experimenter/experiments/tests/test_serializers.py
@@ -832,13 +832,13 @@ class TestExperimentDesignBaseSerializer(TestCase):
         )
 
     def test_serializer_rejects_ratio_not_100(self):
-        experiment = ExperimentFactory.create(type=ExperimentConstants.TYPE_ADDON)
+        experiment = ExperimentFactory.create(type=ExperimentConstants.TYPE_GENERIC)
 
         self.control_variant_data["ratio"] = 50
         self.treatment_variant_data["ratio"] = 40
 
         data = {
-            "type": ExperimentConstants.TYPE_PREF,
+            "type": ExperimentConstants.TYPE_GENERIC,
             "variants": [self.control_variant_data, self.treatment_variant_data],
         }
 
@@ -848,12 +848,12 @@ class TestExperimentDesignBaseSerializer(TestCase):
         self.assertIn("variants", serializer.errors)
 
     def test_serializer_rejects_ratios_of_0(self):
-        experiment = ExperimentFactory.create(type=ExperimentConstants.TYPE_ADDON)
+        experiment = ExperimentFactory.create(type=ExperimentConstants.TYPE_GENERIC)
 
         self.control_variant_data["ratio"] = 0
 
         data = {
-            "type": ExperimentConstants.TYPE_ADDON,
+            "type": ExperimentConstants.TYPE_GENERIC,
             "variants": [self.control_variant_data],
         }
 
@@ -863,12 +863,12 @@ class TestExperimentDesignBaseSerializer(TestCase):
         self.assertIn("variants", serializer.errors)
 
     def test_serializer_rejects_ratios_above_100(self):
-        experiment = ExperimentFactory.create(type=ExperimentConstants.TYPE_ADDON)
+        experiment = ExperimentFactory.create(type=ExperimentConstants.TYPE_GENERIC)
 
         self.control_variant_data["ratio"] = 110
 
         data = {
-            "type": ExperimentConstants.TYPE_ADDON,
+            "type": ExperimentConstants.TYPE_GENERIC,
             "variants": [self.control_variant_data],
         }
 
@@ -878,12 +878,12 @@ class TestExperimentDesignBaseSerializer(TestCase):
         self.assertIn("variants", serializer.errors)
 
     def test_serializer_rejects_duplicate_branch_names(self):
-        experiment = ExperimentFactory.create(type=ExperimentConstants.TYPE_PREF)
+        experiment = ExperimentFactory.create(type=ExperimentConstants.TYPE_GENERIC)
 
         self.control_variant_data["name"] = "Great branch"
 
         data = {
-            "type": ExperimentConstants.TYPE_PREF,
+            "type": ExperimentConstants.TYPE_GENERIC,
             "variants": [self.control_variant_data, self.treatment_variant_data],
         }
 
@@ -906,6 +906,34 @@ class TestExperimentDesignBaseSerializer(TestCase):
 
         self.assertFalse(serializer.is_valid())
         self.assertIn("variants", serializer.errors)
+
+    def test_serializer_outputs_dummy_variants_when_no_variants(self):
+        experiment = ExperimentFactory.create(type=ExperimentConstants.TYPE_GENERIC)
+
+        serializer = ExperimentDesignBaseSerializer(experiment)
+
+        self.assertCountEqual(
+            serializer.data,
+            {
+                "type": ExperimentConstants.TYPE_GENERIC,
+                "variants": [
+                    {
+                        "description": None,
+                        "is_control": True,
+                        "name": None,
+                        "ratio": None,
+                        "value": None,
+                    },
+                    {
+                        "description": None,
+                        "is_control": False,
+                        "name": None,
+                        "ratio": None,
+                        "value": None,
+                    },
+                ],
+            },
+        )
 
 
 class TestExperimentDesignPrefSerializer(TestCase):
@@ -943,37 +971,6 @@ class TestExperimentDesignPrefSerializer(TestCase):
                 "variants": [
                     ExperimentVariantSerializer(variant).data
                     for variant in experiment.variants.all()
-                ],
-            },
-        )
-
-    def test_serializer_outputs_dummy_variants_when_no_variants(self):
-        experiment = ExperimentFactory.create(type=ExperimentConstants.TYPE_PREF)
-
-        serializer = ExperimentDesignPrefSerializer(experiment)
-
-        self.assertCountEqual(
-            serializer.data,
-            {
-                "type": ExperimentConstants.TYPE_PREF,
-                "pref_key": experiment.pref_key,
-                "pref_type": experiment.pref_type,
-                "pref_branch": experiment.pref_branch,
-                "variants": [
-                    {
-                        "description": None,
-                        "is_control": True,
-                        "name": None,
-                        "ratio": None,
-                        "value": None,
-                    },
-                    {
-                        "description": None,
-                        "is_control": False,
-                        "name": None,
-                        "ratio": None,
-                        "value": None,
-                    },
                 ],
             },
         )
@@ -1204,35 +1201,6 @@ class TestExperimentDesignAddonSerializer(TestCase):
             },
         )
 
-    def test_serializer_outputs_dummy_variants_when_no_variants(self):
-        experiment = ExperimentFactory.create(type=ExperimentConstants.TYPE_ADDON)
-
-        serializer = ExperimentDesignPrefSerializer(experiment)
-
-        self.assertCountEqual(
-            serializer.data,
-            {
-                "type": ExperimentConstants.TYPE_PREF,
-                "pref_key": experiment.pref_key,
-                "pref_type": experiment.pref_type,
-                "pref_branch": experiment.pref_branch,
-                "variants": [
-                    {
-                        "description": None,
-                        "is_control": True,
-                        "name": None,
-                        "ratio": None,
-                    },
-                    {
-                        "description": None,
-                        "is_control": False,
-                        "name": None,
-                        "ratio": None,
-                    },
-                ],
-            },
-        )
-
     def test_serializer_checks_for_duplicate_addon_names(self):
         addon_experiment_id = "experiment@shield.org"
         ExperimentFactory.create(addon_experiment_id=addon_experiment_id)
@@ -1255,7 +1223,7 @@ class TestExperimentDesignAddonSerializer(TestCase):
         )
 
         data = {
-            "type": ExperimentConstants.TYPE_GENERIC,
+            "type": ExperimentConstants.TYPE_ADDON,
             "addon_release_url": "http://www.example.com",
             "addon_experiment_id": "experiment id new",
             "variants": [self.control_variant_data, self.treatment_variant_data],
@@ -1324,35 +1292,6 @@ class TestExperimentDesignGenericSerializer(TestCase):
                 "variants": [
                     ExperimentVariantSerializer(variant).data
                     for variant in experiment.variants.all()
-                ],
-            },
-        )
-
-    def test_serializer_outputs_dummy_variants_when_no_variants(self):
-        experiment = ExperimentFactory.create(type=ExperimentConstants.TYPE_GENERIC)
-
-        serializer = ExperimentDesignPrefSerializer(experiment)
-
-        self.assertCountEqual(
-            serializer.data,
-            {
-                "type": ExperimentConstants.TYPE_PREF,
-                "pref_key": experiment.pref_key,
-                "pref_type": experiment.pref_type,
-                "pref_branch": experiment.pref_branch,
-                "variants": [
-                    {
-                        "description": None,
-                        "is_control": True,
-                        "name": None,
-                        "ratio": None,
-                    },
-                    {
-                        "description": None,
-                        "is_control": False,
-                        "name": None,
-                        "ratio": None,
-                    },
                 ],
             },
         )

--- a/app/experimenter/experiments/tests/test_serializers.py
+++ b/app/experimenter/experiments/tests/test_serializers.py
@@ -907,34 +907,6 @@ class TestExperimentDesignBaseSerializer(TestCase):
         self.assertFalse(serializer.is_valid())
         self.assertIn("variants", serializer.errors)
 
-    def test_serializer_outputs_dummy_variants_when_no_variants(self):
-        experiment = ExperimentFactory.create(type=ExperimentConstants.TYPE_GENERIC)
-
-        serializer = ExperimentDesignBaseSerializer(experiment)
-
-        self.assertCountEqual(
-            serializer.data,
-            {
-                "type": ExperimentConstants.TYPE_GENERIC,
-                "variants": [
-                    {
-                        "description": None,
-                        "is_control": True,
-                        "name": None,
-                        "ratio": None,
-                        "value": None,
-                    },
-                    {
-                        "description": None,
-                        "is_control": False,
-                        "name": None,
-                        "ratio": None,
-                        "value": None,
-                    },
-                ],
-            },
-        )
-
 
 class TestExperimentDesignPrefSerializer(TestCase):
 
@@ -1164,6 +1136,39 @@ class TestExperimentDesignPrefSerializer(TestCase):
         self.assertFalse(serializer.is_valid())
         self.assertIn("pref_branch", serializer.errors)
 
+    def test_serializer_outputs_dummy_variants_when_no_variants(self):
+        experiment = ExperimentFactory.create(type=ExperimentConstants.TYPE_PREF)
+
+        serializer = ExperimentDesignPrefSerializer(experiment)
+
+        self.assertEqual(
+            serializer.data,
+            {
+                "type": ExperimentConstants.TYPE_PREF,
+                "pref_key": experiment.pref_key,
+                "pref_type": experiment.pref_type,
+                "pref_branch": experiment.pref_branch,
+                "variants": [
+                    {
+                        "description": None,
+                        "is_control": True,
+                        "name": None,
+                        "ratio": None,
+                        "value": None,
+                        "id": None,
+                    },
+                    {
+                        "description": None,
+                        "is_control": False,
+                        "name": None,
+                        "ratio": None,
+                        "value": None,
+                        "id": None,
+                    },
+                ],
+            },
+        )
+
 
 class TestExperimentDesignAddonSerializer(TestCase):
 
@@ -1274,6 +1279,36 @@ class TestExperimentDesignAddonSerializer(TestCase):
         self.assertFalse(serializer.is_valid())
         self.assertIn("addon_experiment_id", serializer.errors)
 
+    def test_serializer_outputs_dummy_variants_when_no_variants(self):
+        experiment = ExperimentFactory.create(type=ExperimentConstants.TYPE_ADDON)
+
+        serializer = ExperimentDesignAddonSerializer(experiment)
+
+        self.assertEqual(
+            serializer.data,
+            {
+                "type": ExperimentConstants.TYPE_ADDON,
+                "addon_release_url": experiment.addon_release_url,
+                "addon_experiment_id": experiment.addon_experiment_id,
+                "variants": [
+                    {
+                        "description": None,
+                        "is_control": True,
+                        "name": None,
+                        "ratio": None,
+                        "id": None,
+                    },
+                    {
+                        "description": None,
+                        "is_control": False,
+                        "name": None,
+                        "ratio": None,
+                        "id": None,
+                    },
+                ],
+            },
+        )
+
 
 class TestExperimentDesignGenericSerializer(TestCase):
 
@@ -1325,6 +1360,35 @@ class TestExperimentDesignGenericSerializer(TestCase):
         experiment = serializer.save()
 
         self.assertEqual(experiment.design, "Second Design")
+
+    def test_serializer_outputs_dummy_variants_when_no_variants(self):
+        experiment = ExperimentFactory.create(type=ExperimentConstants.TYPE_GENERIC)
+
+        serializer = ExperimentDesignGenericSerializer(experiment)
+
+        self.assertEqual(
+            serializer.data,
+            {
+                "type": ExperimentConstants.TYPE_GENERIC,
+                "design": experiment.design,
+                "variants": [
+                    {
+                        "description": None,
+                        "is_control": True,
+                        "name": None,
+                        "ratio": None,
+                        "id": None,
+                    },
+                    {
+                        "description": None,
+                        "is_control": False,
+                        "name": None,
+                        "ratio": None,
+                        "id": None,
+                    },
+                ],
+            },
+        )
 
 
 class TestCloneSerializer(MockRequestMixin, TestCase):


### PR DESCRIPTION
in some of the tests, we had the wrong `type` set. for instance, we were testing the pref serializer but by accident, in the data, we would set the `type` to addon. woops!

for clarity and consistency, i decided that all the tests on `TestExperimentDesignBaseSerializer` should just use the `generic` experiment type. so youll see me change some of the not messy tests to use these experiment types just for... again... consistency..

in the process of looking at this problem, i had to fix some of these types of errors in the tests on each experiment type called `test_serializer_outputs_dummy_variants_when_no_variants`. i realized we could move this test to to `TestExperimentDesignBaseSerializer` and NOT have this test on every experiment type. This behavior is implemented on the base, so it makes sense to me to test it only on `TestExperimentDesignBaseSerializer`.