### PR TITLE
removed id field for new branches #1898

### DIFF
--- a/app/experimenter/static/js/components/DesignForm.js
+++ b/app/experimenter/static/js/components/DesignForm.js
@@ -43,8 +43,7 @@ export default class DesignForm extends React.PureComponent {
             name: "",
             description: "",
             value: "",
-            is_control: false,
-            id: null
+            is_control: false
           }
         ]
       }


### PR DESCRIPTION
experimenter backend doesn't expect id for new branches that don't currently exist in experimenter. Experimenter returns 400 when id is given per new variant