### PR TITLE
Always put control branch first fixes #1926

### DIFF
--- a/app/experimenter/experiments/serializers.py
+++ b/app/experimenter/experiments/serializers.py
@@ -500,7 +500,9 @@ class VariantsListSerializer(serializers.ListSerializer):
             data = [control_blank_variant, blank_variant]
 
         control_branch = [b for b in data if b["is_control"]][0]
-        treatment_branches = [b for b in data if not b["is_control"]]
+        treatment_branches = sorted(
+            [b for b in data if not b["is_control"]], key=lambda b: b.get("id")
+        )
 
         return [control_branch] + treatment_branches
 

--- a/app/experimenter/experiments/serializers.py
+++ b/app/experimenter/experiments/serializers.py
@@ -35,27 +35,6 @@ class PrefTypeField(serializers.Field):
             return obj
 
 
-class VariantsListSerializer(serializers.ListSerializer):
-
-    def to_representation(self, data):
-        data = super().to_representation(data)
-        if data == []:
-            blank_variant = {}
-            control_blank_variant = {}
-            initial_fields = set(self.child.fields) - set(["id"])
-            for field in initial_fields:
-                blank_variant[field] = None
-                control_blank_variant[field] = None
-
-            blank_variant["is_control"] = False
-            blank_variant["ratio"] = 50
-            control_blank_variant["is_control"] = True
-            control_blank_variant["ratio"] = 50
-
-            return [control_blank_variant, blank_variant]
-        return data
-
-
 class ExperimentVariantSerializer(serializers.ModelSerializer):
 
     class Meta:
@@ -498,6 +477,32 @@ class ExperimentCloneSerializer(serializers.ModelSerializer):
         name = validated_data.get("name")
 
         return instance.clone(name, user)
+
+
+class VariantsListSerializer(serializers.ListSerializer):
+
+    def to_representation(self, data):
+        data = super().to_representation(data)
+
+        if data == []:
+            blank_variant = {}
+            control_blank_variant = {}
+            initial_fields = set(self.child.fields) - set(["id"])
+            for field in initial_fields:
+                blank_variant[field] = None
+                control_blank_variant[field] = None
+
+            blank_variant["is_control"] = False
+            blank_variant["ratio"] = 50
+            control_blank_variant["is_control"] = True
+            control_blank_variant["ratio"] = 50
+
+            data = [control_blank_variant, blank_variant]
+
+        control_branch = [b for b in data if b["is_control"]][0]
+        treatment_branches = [b for b in data if not b["is_control"]]
+
+        return [control_branch] + treatment_branches
 
 
 class ExperimentDesignBranchBaseSerializer(serializers.ModelSerializer):

--- a/app/experimenter/experiments/tests/test_serializers.py
+++ b/app/experimenter/experiments/tests/test_serializers.py
@@ -664,6 +664,15 @@ class TestExperimentDesignBranchBaseSerializer(TestCase):
         self.assertFalse(serializer.is_valid())
         self.assertIn("name", serializer.errors)
 
+    def test_serializer_puts_control_branch_first(self):
+        ExperimentVariantFactory.create(is_control=True)
+        [ExperimentVariantFactory.create(is_control=False) for i in range(3)]
+        serializer = ExperimentDesignBranchBaseSerializer(
+            ExperimentVariant.objects.all().order_by("-id"), many=True
+        )
+        self.assertTrue(serializer.data[0]["is_control"])
+        self.assertFalse(any([b["is_control"] for b in serializer.data[1:]]))
+
 
 class TestExperimentDesignBaseSerializer(TestCase):
 

--- a/app/experimenter/experiments/tests/test_serializers.py
+++ b/app/experimenter/experiments/tests/test_serializers.py
@@ -664,14 +664,17 @@ class TestExperimentDesignBranchBaseSerializer(TestCase):
         self.assertFalse(serializer.is_valid())
         self.assertIn("name", serializer.errors)
 
-    def test_serializer_puts_control_branch_first(self):
+    def test_serializer_puts_control_branch_first_and_sorts_rest_by_id(self):
         ExperimentVariantFactory.create(is_control=True)
-        [ExperimentVariantFactory.create(is_control=False) for i in range(3)]
+        sorted_treatment_ids = sorted(
+            [ExperimentVariantFactory.create(is_control=False).id for i in range(3)]
+        )
         serializer = ExperimentDesignBranchBaseSerializer(
             ExperimentVariant.objects.all().order_by("-id"), many=True
         )
         self.assertTrue(serializer.data[0]["is_control"])
         self.assertFalse(any([b["is_control"] for b in serializer.data[1:]]))
+        self.assertEqual(sorted_treatment_ids, [b["id"] for b in serializer.data[1:]])
 
 
 class TestExperimentDesignBaseSerializer(TestCase):

--- a/app/experimenter/static/js/components/BranchManager.js
+++ b/app/experimenter/static/js/components/BranchManager.js
@@ -40,25 +40,15 @@ class BranchManager extends React.PureComponent {
     );
   }
 
-  renderBranches() {
-    const { branches } = this.props;
-
-    return branches
-      .withMutations(mutable => {
-        // Make sure the control branch is the first branch
-        mutable
-          .filter(b => b.get("is_control"))
-          .concat(branches.filter(b => !b.get("is_control")));
-      })
-      .map(this.renderBranch);
-  }
-
   render() {
-    const { onAddBranch } = this.props;
+    const { onAddBranch, branches } = this.props;
+    const controlBranch = branches.filter(b => b.get("is_control")).get(0);
+    const treatmentBranches = branches.filter(b => !b.get("is_control"));
 
     return (
       <React.Fragment>
-        {this.renderBranches()}
+        {this.renderBranch(controlBranch, 0)}
+        {treatmentBranches.map((b, i) => this.renderBranch(b, i + 1))}
         <Row>
           <Col className="text-right">
             <Button

--- a/app/experimenter/static/js/components/BranchManager.js
+++ b/app/experimenter/static/js/components/BranchManager.js
@@ -42,13 +42,9 @@ class BranchManager extends React.PureComponent {
 
   render() {
     const { onAddBranch, branches } = this.props;
-    const controlBranch = branches.get(0);
-    const treatmentBranches = branches.slice(1);
-
     return (
       <React.Fragment>
-        {this.renderBranch(controlBranch, 0)}
-        {treatmentBranches.map((b, i) => this.renderBranch(b, i + 1))}
+        {branches.map((b, i) => this.renderBranch(b, i))}
         <Row>
           <Col className="text-right">
             <Button

--- a/app/experimenter/static/js/components/BranchManager.js
+++ b/app/experimenter/static/js/components/BranchManager.js
@@ -42,8 +42,8 @@ class BranchManager extends React.PureComponent {
 
   render() {
     const { onAddBranch, branches } = this.props;
-    const controlBranch = branches.filter(b => b.get("is_control")).get(0);
-    const treatmentBranches = branches.filter(b => !b.get("is_control"));
+    const controlBranch = branches.get(0);
+    const treatmentBranches = branches.slice(1);
 
     return (
       <React.Fragment>


### PR DESCRIPTION
Basically the serializer needs to always put the control branch first, and then we can expect that ordering once it gets to the client.  

If we don't do that and only separate them when we render, then you can wind up in this situation where the top level state has `[branch1, control]` but it's rendered out as `[control, branch1]` so when you send the update info back up to the top it's in the wrong order.  

So I changed the serializer to always put control first, then the client will just blindly expect that.  

Also I changed the serializer to always order by db id, which will mimic the order they're created in, so that way when you edit they should be sticky with the order they were originally created in, so you don't get branches jumping around which is confusing. 