### PR TITLE
Use pref key for multipref serializer fixes #1958

### DIFF
--- a/app/experimenter/experiments/serializers.py
+++ b/app/experimenter/experiments/serializers.py
@@ -308,11 +308,13 @@ class ExperimentRecipeMultiPrefVariantSerializer(serializers.ModelSerializer):
     def get_preferences(self, obj):
         preference_values = {}
         preference_values["preferenceBranchType"] = obj.experiment.pref_branch
-        preference_values["preferenceType"] = obj.experiment.pref_type
+        preference_values["preferenceType"] = PrefTypeField().to_representation(
+            obj.experiment.pref_type
+        )
         preference_values["preferenceValue"] = obj.value
 
         preferences = {}
-        preferences[obj.experiment.normandy_slug] = preference_values
+        preferences[obj.experiment.pref_key] = preference_values
 
         return preferences
 

--- a/app/experimenter/experiments/tests/test_serializers.py
+++ b/app/experimenter/experiments/tests/test_serializers.py
@@ -381,22 +381,23 @@ class TestExperimentRecipeMultiPrefVariantSerialzer(TestCase):
         experiment = ExperimentFactory.create(
             normandy_slug="normandy-slug",
             pref_branch=Experiment.PREF_BRANCH_DEFAULT,
-            pref_type=Experiment.PREF_TYPE_INT,
+            pref_type=Experiment.PREF_TYPE_JSON_STR,
+            pref_key="browser.pref",
         )
         variant = ExperimentVariant(
-            slug="slug-value", ratio=25, experiment=experiment, value=26
+            slug="control", ratio=25, experiment=experiment, value='{"some": "json"}'
         )
         serializer = ExperimentRecipeMultiPrefVariantSerializer(variant)
         expected_data = {
             "preferences": {
-                "normandy-slug": {
+                "browser.pref": {
                     "preferenceBranchType": "default",
-                    "preferenceType": "integer",
-                    "preferenceValue": 26,
+                    "preferenceType": "string",
+                    "preferenceValue": '{"some": "json"}',
                 }
             },
             "ratio": 25,
-            "slug": "slug-value",
+            "slug": "control",
         }
 
         self.assertEqual(expected_data, serializer.data)


### PR DESCRIPTION
1) We were sending normandy slug instead of the pref name
2) We weren't converting "json string" to "string"

<img width="1440" alt="Screenshot 2019-11-20 17 59 26" src="https://user-images.githubusercontent.com/119884/69285748-a732ba00-0bbf-11ea-962b-fda4f575d091.png">
