### PR TITLE
Move branch methods into branch manager fixes #1920

### DIFF
--- a/app/experimenter/static/js/components/AddonForm.js
+++ b/app/experimenter/static/js/components/AddonForm.js
@@ -1,4 +1,4 @@
-import { Map } from "immutable";
+import { List, Map } from "immutable";
 import PropTypes from "prop-types";
 import React from "react";
 import { Row, Col } from "react-bootstrap";
@@ -12,8 +12,7 @@ export default class AddonForm extends React.PureComponent {
     data: PropTypes.instanceOf(Map),
     errors: PropTypes.instanceOf(Map),
     handleDataChange: PropTypes.func,
-    onAddBranch: PropTypes.func,
-    onRemoveBranch: PropTypes.func,
+    handleErrorsChange: PropTypes.func,
   };
 
   render() {
@@ -81,14 +80,11 @@ export default class AddonForm extends React.PureComponent {
         <hr className="heavy-line my-5" />
 
         <BranchManager
-          branches={this.props.data.get("variants")}
-          onAddBranch={this.props.onAddBranch}
-          onRemoveBranch={this.props.onRemoveBranch}
-          onChange={value => {
-            this.props.handleDataChange("variants", value);
-          }}
           branchFieldsComponent={GenericBranchFields}
-          errors={this.props.errors}
+          branches={this.props.data.get("variants", new List())}
+          errors={this.props.errors.get("variants", new List())}
+          handleDataChange={this.props.handleDataChange}
+          handleErrorsChange={this.props.handleErrorsChange}
         />
       </div>
     );

--- a/app/experimenter/static/js/components/Branch.js
+++ b/app/experimenter/static/js/components/Branch.js
@@ -17,28 +17,27 @@ class Branch extends React.PureComponent {
 
   handleChange(key, value) {
     const { onChange, branch } = this.props;
-    const updated = branch
-      .set("is_control", this.props.index === 0)
-      .set(key, value);
-    onChange(updated);
+    onChange(branch.set(key, value));
   }
 
   renderTitle() {
-    if (this.props.index === 0) {
+    const { branch, index } = this.props;
+    if (branch.get("is_control")) {
       return <h4>Control Branch</h4>;
     }
-    return <h4>Branch {this.props.index}</h4>;
+    return <h4>Branch {index}</h4>;
   }
 
   renderRemoveButton() {
-    if (this.props.index === 0) {
+    const { branch, index } = this.props;
+    if (branch.get("is_control")) {
       return null;
     }
     return (
       <Button
         variant="danger"
         onClick={() => {
-          this.props.remove(this.props.index);
+          this.props.remove(index);
         }}
         id="remove-branch-button"
       >

--- a/app/experimenter/static/js/components/BranchManager.js
+++ b/app/experimenter/static/js/components/BranchManager.js
@@ -28,15 +28,7 @@ class BranchManager extends React.PureComponent {
       handleDataChange,
       handleErrorsChange,
     } = this.props;
-    const emptyBranch = fromJS({
-      ratio: "",
-      name: "",
-      description: "",
-      value: "",
-      is_control: false,
-    });
-
-    handleDataChange("variants", branches.push(emptyBranch));
+    handleDataChange("variants", branches.push(fromJS({is_control: false})));
     handleErrorsChange("variants", errors.push(fromJS({})));
   }
 

--- a/app/experimenter/static/js/components/BranchManager.js
+++ b/app/experimenter/static/js/components/BranchManager.js
@@ -28,7 +28,7 @@ class BranchManager extends React.PureComponent {
       handleDataChange,
       handleErrorsChange,
     } = this.props;
-    handleDataChange("variants", branches.push(fromJS({is_control: false})));
+    handleDataChange("variants", branches.push(fromJS({ is_control: false })));
     handleErrorsChange("variants", errors.push(fromJS({})));
   }
 

--- a/app/experimenter/static/js/components/DesignForm.js
+++ b/app/experimenter/static/js/components/DesignForm.js
@@ -34,42 +34,21 @@ class DesignForm extends React.PureComponent {
   async componentDidMount() {
     const data = await makeApiRequest(this.getEndpointUrl());
 
-    const errors = {
-      variants: data.variants.map(() => ({})),
-    };
-
     this.setState({
       loaded: true,
       data: fromJS(data),
-      errors: fromJS(errors),
     });
-  }
-
-  addBranch() {
-    const emptyBranch = fromJS({
-      ratio: "",
-      name: "",
-      description: "",
-      value: "",
-      is_control: false,
-    });
-
-    this.setState(({ data, errors }) => ({
-      data: data.update("variants", variants => variants.push(emptyBranch)),
-      errors: errors.update("variants", variants => variants.push({})),
-    }));
-  }
-
-  removeBranch(index) {
-    this.setState(({ data, errors }) => ({
-      data: data.update("variants", variants => variants.delete(index)),
-      errors: errors.update("variants", variants => variants.delete(index)),
-    }));
   }
 
   handleDataChange(key, value) {
     this.setState(({ data }) => ({
       data: data.set(key, value),
+    }));
+  }
+
+  handleErrorsChange(key, value) {
+    this.setState(({ errors }) => ({
+      errors: errors.set(key, value),
     }));
   }
 
@@ -147,8 +126,7 @@ class DesignForm extends React.PureComponent {
           <form onSubmit={this.handleSubmit} id="design-form">
             <Form
               handleDataChange={this.handleDataChange}
-              onAddBranch={this.addBranch}
-              onRemoveBranch={this.removeBranch}
+              handleErrorsChange={this.handleErrorsChange}
               data={this.state.data}
               errors={this.state.errors}
               loaded={this.state.loaded}

--- a/app/experimenter/static/js/components/GenericBranchFields.js
+++ b/app/experimenter/static/js/components/GenericBranchFields.js
@@ -14,11 +14,6 @@ class GenericBranchFields extends React.PureComponent {
     index: PropTypes.number,
   };
 
-  getErrorMessage(name) {
-    const { errors, index } = this.props;
-    return errors.getIn(["variants", index, name], "");
-  }
-
   renderField(name, label) {
     let helpContent;
     switch (name) {
@@ -83,7 +78,7 @@ class GenericBranchFields extends React.PureComponent {
         onChange={value => {
           this.props.handleChange(name, value);
         }}
-        error={this.getErrorMessage(name)}
+        error={this.props.errors.get(name)}
         helpContent={helpContent}
       />
     );

--- a/app/experimenter/static/js/components/GenericForm.js
+++ b/app/experimenter/static/js/components/GenericForm.js
@@ -1,4 +1,4 @@
-import { Map } from "immutable";
+import { List, Map } from "immutable";
 import PropTypes from "prop-types";
 import React from "react";
 
@@ -11,8 +11,7 @@ export default class GenericForm extends React.PureComponent {
     data: PropTypes.instanceOf(Map),
     errors: PropTypes.instanceOf(Map),
     handleDataChange: PropTypes.func,
-    onAddBranch: PropTypes.func,
-    onRemoveBranch: PropTypes.func,
+    handleErrorsChange: PropTypes.func,
   };
 
   render() {
@@ -38,14 +37,11 @@ export default class GenericForm extends React.PureComponent {
         <hr className="heavy-line my-5" />
 
         <BranchManager
-          branches={this.props.data.get("variants")}
-          onAddBranch={this.props.onAddBranch}
-          onRemoveBranch={this.props.onRemoveBranch}
-          onChange={value => {
-            this.props.handleDataChange("variants", value);
-          }}
           branchFieldsComponent={GenericBranchFields}
-          errors={this.props.errors}
+          branches={this.props.data.get("variants", new List())}
+          errors={this.props.errors.get("variants", new List())}
+          handleDataChange={this.props.handleDataChange}
+          handleErrorsChange={this.props.handleErrorsChange}
         />
       </div>
     );

--- a/app/experimenter/static/js/components/PrefBranchFields.js
+++ b/app/experimenter/static/js/components/PrefBranchFields.js
@@ -14,11 +14,6 @@ class PrefBranchFields extends React.PureComponent {
     index: PropTypes.number,
   };
 
-  getErrorMessage(name) {
-    const { errors, index } = this.props;
-    return errors.getIn(["variants", index, name], "");
-  }
-
   renderField(name, label) {
     let helpContent;
     switch (name) {
@@ -105,7 +100,7 @@ class PrefBranchFields extends React.PureComponent {
         onChange={value => {
           this.props.handleChange(name, value);
         }}
-        error={this.getErrorMessage(name)}
+        error={this.props.errors.get(name)}
         helpContent={helpContent}
       />
     );

--- a/app/experimenter/static/js/components/PrefForm.js
+++ b/app/experimenter/static/js/components/PrefForm.js
@@ -1,4 +1,4 @@
-import { Map } from "immutable";
+import { List, Map } from "immutable";
 import PropTypes from "prop-types";
 import React from "react";
 import { Row, Col } from "react-bootstrap";
@@ -12,8 +12,7 @@ export default class PrefForm extends React.PureComponent {
     data: PropTypes.instanceOf(Map),
     errors: PropTypes.instanceOf(Map),
     handleDataChange: PropTypes.func,
-    onAddBranch: PropTypes.func,
-    onRemoveBranch: PropTypes.func,
+    handleErrorsChange: PropTypes.func,
   };
 
   render() {
@@ -116,14 +115,11 @@ export default class PrefForm extends React.PureComponent {
         <hr className="heavy-line my-5" />
 
         <BranchManager
-          branches={this.props.data.get("variants")}
-          onAddBranch={this.props.onAddBranch}
-          onRemoveBranch={this.props.onRemoveBranch}
-          onChange={value => {
-            this.props.handleDataChange("variants", value);
-          }}
           branchFieldsComponent={PrefBranchFields}
-          errors={this.props.errors}
+          branches={this.props.data.get("variants", new List())}
+          errors={this.props.errors.get("variants", new List())}
+          handleDataChange={this.props.handleDataChange}
+          handleErrorsChange={this.props.handleErrorsChange}
         />
       </div>
     );


### PR DESCRIPTION
So my reasoning here was that there's gonna be many types of intake that have no branches (rollouts to start but probably others coming), so we should move the branch methods down into branch manager.  Also since we're going to be reactifying the timeline/population page and we'll probably split DesignForm into something more reusable, it's a good step towards making it more generic.  