### PR TITLE
Move margin to design input row fixes #1968

### DIFF
--- a/app/experimenter/static/js/components/DesignInput.js
+++ b/app/experimenter/static/js/components/DesignInput.js
@@ -19,7 +19,6 @@ class DesignInput extends React.PureComponent {
     id: PropTypes.string,
     index: PropTypes.number,
     label: PropTypes.string,
-    margin: PropTypes.string,
     name: PropTypes.string,
     onChange: PropTypes.func,
     rows: PropTypes.string,
@@ -41,9 +40,9 @@ class DesignInput extends React.PureComponent {
 
   render() {
     return (
-      <Row className={this.props.margin}>
-        <Col md={3} className="text-right mb-3">
-          <FormLabel>
+      <Row className="mb-3">
+        <Col md={3} className="text-right">
+          <FormLabel className="pt-2">
             <strong>{this.props.label}</strong>
           </FormLabel>
           <br />


### PR DESCRIPTION
I noticed this:

<img width="751" alt="Screenshot 2019-11-22 15 43 59" src="https://user-images.githubusercontent.com/119884/69459088-f4896580-0d3e-11ea-963e-67d8eae3aded.png">

and then I realized 'mb-3' was on the label, not the whole input row, so I moved it there, and put a little padding on the label so they line up with the input a little nicer:

<img width="763" alt="Screenshot 2019-11-22 15 42 15" src="https://user-images.githubusercontent.com/119884/69459121-09fe8f80-0d3f-11ea-9b16-416351567372.png">


