### PR TITLE
Refactor react components fixes #1988

### DIFF
--- a/app/experimenter/static/js/components/AddonForm.js
+++ b/app/experimenter/static/js/components/AddonForm.js
@@ -1,11 +1,15 @@
-import { List, Map } from "immutable";
 import PropTypes from "prop-types";
 import React from "react";
+import { List, Map } from "immutable";
 import { Row, Col } from "react-bootstrap";
 
 import BranchManager from "experimenter/components/BranchManager";
 import DesignInput from "experimenter/components/DesignInput";
 import GenericBranchFields from "experimenter/components/GenericBranchFields";
+import {
+  ADDON_EXPERIMENT_ID_HELP,
+  ADDON_RELEASE_URL_HELP,
+} from "experimenter/components/constants";
 
 export default class AddonForm extends React.PureComponent {
   static propTypes = {
@@ -32,22 +36,7 @@ export default class AddonForm extends React.PureComponent {
           }}
           value={this.props.data.get("addon_experiment_id")}
           error={this.props.errors.get("addon_experiment_id", "")}
-          helpContent={
-            <div>
-              <p>
-                Enter the <code>activeExperimentName</code> as it appears in the
-                add-on. It may appear in <code>manifest.json</code> as
-                <code> applications.gecko.id </code>
-                <a
-                  target="_blank"
-                  rel="noreferrer noopener"
-                  href="https://mana.mozilla.org/wiki/display/FIREFOX/Pref-Flip+and+Add-On+Experiments#Pref-FlipandAdd-OnExperiments-Add-ons"
-                >
-                  See here for more info.
-                </a>
-              </p>
-            </div>
-          }
+          helpContent={ADDON_EXPERIMENT_ID_HELP}
         />
 
         <DesignInput
@@ -58,23 +47,7 @@ export default class AddonForm extends React.PureComponent {
           }}
           value={this.props.data.get("addon_release_url")}
           error={this.props.errors.get("addon_release_url", "")}
-          helpContent={
-            <div>
-              <p>
-                Enter the URL where the release build of your add-on can be
-                found. This is often attached to a bugzilla ticket. This MUST BE
-                the release signed add-on (not the test add-on) that you want
-                deployed.&nbsp;
-                <a
-                  target="_blank"
-                  rel="noreferrer noopener"
-                  href="https://mana.mozilla.org/wiki/display/FIREFOX/Pref-Flip+and+Add-On+Experiments#Pref-FlipandAdd-OnExperiments-Add-ons"
-                >
-                  See here for more info.
-                </a>
-              </p>
-            </div>
-          }
+          helpContent={ADDON_RELEASE_URL_HELP}
         />
 
         <hr className="heavy-line my-5" />

--- a/app/experimenter/static/js/components/Branch.js
+++ b/app/experimenter/static/js/components/Branch.js
@@ -17,7 +17,7 @@ class Branch extends React.PureComponent {
     remove: PropTypes.func,
   };
 
-  handleChange(key, value) {
+  handleBranchFieldChange(key, value) {
     const { onChange, branch } = this.props;
     onChange(branch.set(key, value));
   }
@@ -38,7 +38,7 @@ class Branch extends React.PureComponent {
         id={`variants-${this.props.index}-${name}`}
         value={value}
         onChange={value => {
-          this.handleChange(name, value);
+          this.handleBranchFieldChange(name, value);
         }}
         error={error}
         helpContent={help}
@@ -79,7 +79,7 @@ class Branch extends React.PureComponent {
         <BranchFields
           branch={this.props.branch}
           errors={this.props.errors}
-          handleChange={this.handleChange}
+          onChange={this.handleBranchFieldChange}
           index={this.props.index}
           renderField={this.renderField}
         />

--- a/app/experimenter/static/js/components/Branch.js
+++ b/app/experimenter/static/js/components/Branch.js
@@ -1,8 +1,10 @@
-import { boundClass } from "autobind-decorator";
-import { Map } from "immutable";
 import PropTypes from "prop-types";
 import React from "react";
 import { Button, Row, Col } from "react-bootstrap";
+import { Map } from "immutable";
+import { boundClass } from "autobind-decorator";
+
+import DesignInput from "experimenter/components/DesignInput";
 
 @boundClass
 class Branch extends React.PureComponent {
@@ -26,6 +28,22 @@ class Branch extends React.PureComponent {
       return <h4>Control Branch</h4>;
     }
     return <h4>Branch {index}</h4>;
+  }
+
+  renderField(name, label, value, error, help) {
+    return (
+      <DesignInput
+        label={label}
+        name={`variants[${this.props.index}][${name}]`}
+        id={`variants-${this.props.index}-${name}`}
+        value={value}
+        onChange={value => {
+          this.handleChange(name, value);
+        }}
+        error={error}
+        helpContent={help}
+      />
+    );
   }
 
   renderRemoveButton() {
@@ -59,10 +77,11 @@ class Branch extends React.PureComponent {
         </Row>
 
         <BranchFields
-          handleChange={this.handleChange}
-          index={this.props.index}
           branch={this.props.branch}
           errors={this.props.errors}
+          handleChange={this.handleChange}
+          index={this.props.index}
+          renderField={this.renderField}
         />
 
         <hr className="heavy-line my-5" />

--- a/app/experimenter/static/js/components/BranchManager.js
+++ b/app/experimenter/static/js/components/BranchManager.js
@@ -16,11 +16,6 @@ class BranchManager extends React.PureComponent {
     handleErrorsChange: PropTypes.func,
   };
 
-  handleChange(index, value) {
-    const { branches, handleDataChange } = this.props;
-    handleDataChange("variants", branches.set(index, value));
-  }
-
   addBranch() {
     const {
       branches,
@@ -43,6 +38,11 @@ class BranchManager extends React.PureComponent {
     handleErrorsChange("variants", errors.delete(index));
   }
 
+  handleBranchChange(index, value) {
+    const { branches, handleDataChange } = this.props;
+    handleDataChange("variants", branches.set(index, value));
+  }
+
   renderBranch(branch, index) {
     const { branchFieldsComponent, errors } = this.props;
 
@@ -57,7 +57,7 @@ class BranchManager extends React.PureComponent {
         }}
         errors={errors.get(index, new Map())}
         onChange={value => {
-          this.handleChange(index, value);
+          this.handleBranchChange(index, value);
         }}
       />
     );

--- a/app/experimenter/static/js/components/GenericBranchFields.js
+++ b/app/experimenter/static/js/components/GenericBranchFields.js
@@ -14,7 +14,6 @@ class GenericBranchFields extends React.PureComponent {
   static propTypes = {
     branch: PropTypes.instanceOf(Map),
     errors: PropTypes.instanceOf(Map),
-    handleChange: PropTypes.func,
     index: PropTypes.number,
     renderField: PropTypes.func,
   };

--- a/app/experimenter/static/js/components/GenericBranchFields.js
+++ b/app/experimenter/static/js/components/GenericBranchFields.js
@@ -3,7 +3,6 @@ import React from "react";
 import { Map } from "immutable";
 import { boundClass } from "autobind-decorator";
 
-import DesignInput from "experimenter/components/DesignInput";
 import {
   BRANCH_RATIO_HELP,
   BRANCH_NAME_HELP,
@@ -17,32 +16,31 @@ class GenericBranchFields extends React.PureComponent {
     errors: PropTypes.instanceOf(Map),
     handleChange: PropTypes.func,
     index: PropTypes.number,
+    renderField: PropTypes.func,
   };
-
-  renderField(name, label, help) {
-    return (
-      <DesignInput
-        label={label}
-        name={`variants[${this.props.index}][${name}]`}
-        id={`variants-${this.props.index}-${name}`}
-        value={this.props.branch.get(name)}
-        onChange={value => {
-          this.props.handleChange(name, value);
-        }}
-        error={this.props.errors.get(name)}
-        helpContent={help}
-      />
-    );
-  }
 
   render() {
     return (
       <React.Fragment>
-        {this.renderField("ratio", "Branch Size", BRANCH_RATIO_HELP)}
-        {this.renderField("name", "Name", BRANCH_NAME_HELP)}
-        {this.renderField(
+        {this.props.renderField(
+          "ratio",
+          "Branch Size",
+          this.props.branch.get("ratio"),
+          this.props.errors.get("ratio"),
+          BRANCH_RATIO_HELP,
+        )}
+        {this.props.renderField(
+          "name",
+          "Name",
+          this.props.branch.get("name"),
+          this.props.errors.get("name"),
+          BRANCH_NAME_HELP,
+        )}
+        {this.props.renderField(
           "description",
           "Description",
+          this.props.branch.get("description"),
+          this.props.errors.get("description"),
           BRANCH_DESCRIPTION_HELP,
         )}
       </React.Fragment>

--- a/app/experimenter/static/js/components/GenericBranchFields.js
+++ b/app/experimenter/static/js/components/GenericBranchFields.js
@@ -1,9 +1,14 @@
-import { boundClass } from "autobind-decorator";
-import { Map } from "immutable";
 import PropTypes from "prop-types";
 import React from "react";
+import { Map } from "immutable";
+import { boundClass } from "autobind-decorator";
 
 import DesignInput from "experimenter/components/DesignInput";
+import {
+  BRANCH_RATIO_HELP,
+  BRANCH_NAME_HELP,
+  BRANCH_DESCRIPTION_HELP,
+} from "experimenter/components/constants";
 
 @boundClass
 class GenericBranchFields extends React.PureComponent {
@@ -14,61 +19,7 @@ class GenericBranchFields extends React.PureComponent {
     index: PropTypes.number,
   };
 
-  renderField(name, label) {
-    let helpContent;
-    switch (name) {
-      case "ratio":
-        helpContent = (
-          <div>
-            <p>
-              Choose the size of this branch represented as a whole number. The
-              size of all branches together must be equal to 100. It does not
-              have to be exact, so these sizes are simply a recommendation of
-              the relative distribution of the branches.
-            </p>
-            <p>
-              <strong>Example:</strong> 50
-            </p>
-          </div>
-        );
-        break;
-
-      case "name":
-        helpContent = (
-          <div>
-            <p>
-              The control group should represent the users receiving the
-              existing, unchanged version of what you're testing. For example,
-              if you're testing making a button larger to see if users click on
-              it more often, the control group would receive the existing button
-              size. You should name your control branch based on the experience
-              or functionality that group of users will be receiving. Don't name
-              it 'Control Group', we already know it's the control group!
-            </p>
-            <p>
-              <strong>Example:</strong> Normal Button Size
-            </p>
-          </div>
-        );
-        break;
-
-      case "description":
-        helpContent = (
-          <div>
-            <p>
-              Describe the experience or functionality the control group will
-              receive in more detail.
-            </p>
-            <p>
-              <strong>Example:</strong> The control group will receive the
-              existing 80px sign in button located at the top right of the
-              screen.
-            </p>
-          </div>
-        );
-        break;
-    }
-
+  renderField(name, label, help) {
     return (
       <DesignInput
         label={label}
@@ -79,7 +30,7 @@ class GenericBranchFields extends React.PureComponent {
           this.props.handleChange(name, value);
         }}
         error={this.props.errors.get(name)}
-        helpContent={helpContent}
+        helpContent={help}
       />
     );
   }
@@ -87,9 +38,13 @@ class GenericBranchFields extends React.PureComponent {
   render() {
     return (
       <React.Fragment>
-        {this.renderField("ratio", "Branch Size")}
-        {this.renderField("name", "Name")}
-        {this.renderField("description", "Description")}
+        {this.renderField("ratio", "Branch Size", BRANCH_RATIO_HELP)}
+        {this.renderField("name", "Name", BRANCH_NAME_HELP)}
+        {this.renderField(
+          "description",
+          "Description",
+          BRANCH_DESCRIPTION_HELP,
+        )}
       </React.Fragment>
     );
   }

--- a/app/experimenter/static/js/components/GenericForm.js
+++ b/app/experimenter/static/js/components/GenericForm.js
@@ -1,10 +1,11 @@
-import { List, Map } from "immutable";
 import PropTypes from "prop-types";
 import React from "react";
+import { List, Map } from "immutable";
 
 import BranchManager from "experimenter/components/BranchManager";
 import DesignInput from "experimenter/components/DesignInput";
 import GenericBranchFields from "experimenter/components/GenericBranchFields";
+import { DESIGN_HELP } from "experimenter/components/constants";
 
 export default class GenericForm extends React.PureComponent {
   static propTypes = {
@@ -27,11 +28,7 @@ export default class GenericForm extends React.PureComponent {
           error={this.props.errors.get("design", "")}
           as="textarea"
           rows="10"
-          helpContent={
-            <div>
-              <p>Specify the design of the experiment.</p>
-            </div>
-          }
+          helpContent={DESIGN_HELP}
         />
 
         <hr className="heavy-line my-5" />

--- a/app/experimenter/static/js/components/PrefBranchFields.js
+++ b/app/experimenter/static/js/components/PrefBranchFields.js
@@ -15,7 +15,6 @@ class PrefBranchFields extends React.PureComponent {
   static propTypes = {
     branch: PropTypes.instanceOf(Map),
     errors: PropTypes.instanceOf(Map),
-    handleChange: PropTypes.func,
     index: PropTypes.number,
     renderField: PropTypes.func,
   };

--- a/app/experimenter/static/js/components/PrefBranchFields.js
+++ b/app/experimenter/static/js/components/PrefBranchFields.js
@@ -3,7 +3,6 @@ import React from "react";
 import { Map } from "immutable";
 import { boundClass } from "autobind-decorator";
 
-import DesignInput from "experimenter/components/DesignInput";
 import {
   BRANCH_RATIO_HELP,
   BRANCH_NAME_HELP,
@@ -18,35 +17,40 @@ class PrefBranchFields extends React.PureComponent {
     errors: PropTypes.instanceOf(Map),
     handleChange: PropTypes.func,
     index: PropTypes.number,
+    renderField: PropTypes.func,
   };
-
-  renderField(name, label, help) {
-    return (
-      <DesignInput
-        label={label}
-        name={`variants[${this.props.index}][${name}]`}
-        id={`variants-${this.props.index}-${name}`}
-        value={this.props.branch.get(name)}
-        onChange={value => {
-          this.props.handleChange(name, value);
-        }}
-        error={this.props.errors.get(name)}
-        helpContent={help}
-      />
-    );
-  }
 
   render() {
     return (
       <React.Fragment>
-        {this.renderField("ratio", "Branch Size", BRANCH_RATIO_HELP)}
-        {this.renderField("name", "Name", BRANCH_NAME_HELP)}
-        {this.renderField(
+        {this.props.renderField(
+          "ratio",
+          "Branch Size",
+          this.props.branch.get("ratio"),
+          this.props.errors.get("ratio"),
+          BRANCH_RATIO_HELP,
+        )}
+        {this.props.renderField(
+          "name",
+          "Name",
+          this.props.branch.get("name"),
+          this.props.errors.get("name"),
+          BRANCH_NAME_HELP,
+        )}
+        {this.props.renderField(
           "description",
           "Description",
+          this.props.branch.get("description"),
+          this.props.errors.get("description"),
           BRANCH_DESCRIPTION_HELP,
         )}
-        {this.renderField("value", "Value", PREF_VALUE_HELP)}
+        {this.props.renderField(
+          "value",
+          "Value",
+          this.props.branch.get("value"),
+          this.props.errors.get("value"),
+          PREF_VALUE_HELP,
+        )}
       </React.Fragment>
     );
   }

--- a/app/experimenter/static/js/components/PrefBranchFields.js
+++ b/app/experimenter/static/js/components/PrefBranchFields.js
@@ -1,9 +1,15 @@
-import { boundClass } from "autobind-decorator";
-import { Map } from "immutable";
 import PropTypes from "prop-types";
 import React from "react";
+import { Map } from "immutable";
+import { boundClass } from "autobind-decorator";
 
 import DesignInput from "experimenter/components/DesignInput";
+import {
+  BRANCH_RATIO_HELP,
+  BRANCH_NAME_HELP,
+  BRANCH_DESCRIPTION_HELP,
+  PREF_VALUE_HELP,
+} from "experimenter/components/constants";
 
 @boundClass
 class PrefBranchFields extends React.PureComponent {
@@ -14,83 +20,7 @@ class PrefBranchFields extends React.PureComponent {
     index: PropTypes.number,
   };
 
-  renderField(name, label) {
-    let helpContent;
-    switch (name) {
-      case "ratio":
-        helpContent = (
-          <div>
-            <p>
-              Choose the size of this branch represented as a whole number. The
-              size of all branches together must be equal to 100. It does not
-              have to be exact, so these sizes are simply a recommendation of
-              the relative distribution of the branches.
-            </p>
-            <p>
-              <strong>Example:</strong> 50
-            </p>
-          </div>
-        );
-        break;
-
-      case "name":
-        helpContent = (
-          <div>
-            <p>
-              The control group should represent the users receiving the
-              existing, unchanged version of what you're testing. For example,
-              if you're testing making a button larger to see if users click on
-              it more often, the control group would receive the existing button
-              size. You should name your control branch based on the experience
-              or functionality that group of users will be receiving. Don't name
-              it 'Control Group', we already know it's the control group!
-            </p>
-            <p>
-              <strong>Example:</strong> Normal Button Size
-            </p>
-          </div>
-        );
-        break;
-
-      case "description":
-        helpContent = (
-          <div>
-            <p>
-              Describe the experience or functionality the control group will
-              receive in more detail.
-            </p>
-            <p>
-              <strong>Example:</strong> The control group will receive the
-              existing 80px sign in button located at the top right of the
-              screen.
-            </p>
-          </div>
-        );
-        break;
-
-      case "value":
-        helpContent = (
-          <div>
-            <p className="mt-2">
-              Choose the value of the pref for the control group. This value
-              must be valid JSON in order to be sent to Shield. This should be
-              the right type (boolean, string, number), and should be the value
-              that represents the control or default state to compare to.
-            </p>
-            <p>
-              <strong>Boolean Example:</strong> false
-            </p>
-            <p>
-              <strong>String Example:</strong> some text
-            </p>
-            <p>
-              <strong>Integer Example:</strong> 13
-            </p>
-          </div>
-        );
-        break;
-    }
-
+  renderField(name, label, help) {
     return (
       <DesignInput
         label={label}
@@ -101,7 +31,7 @@ class PrefBranchFields extends React.PureComponent {
           this.props.handleChange(name, value);
         }}
         error={this.props.errors.get(name)}
-        helpContent={helpContent}
+        helpContent={help}
       />
     );
   }
@@ -109,10 +39,14 @@ class PrefBranchFields extends React.PureComponent {
   render() {
     return (
       <React.Fragment>
-        {this.renderField("ratio", "Branch Size")}
-        {this.renderField("name", "Name")}
-        {this.renderField("description", "Description")}
-        {this.renderField("value", "Value")}
+        {this.renderField("ratio", "Branch Size", BRANCH_RATIO_HELP)}
+        {this.renderField("name", "Name", BRANCH_NAME_HELP)}
+        {this.renderField(
+          "description",
+          "Description",
+          BRANCH_DESCRIPTION_HELP,
+        )}
+        {this.renderField("value", "Value", PREF_VALUE_HELP)}
       </React.Fragment>
     );
   }

--- a/app/experimenter/static/js/components/PrefForm.js
+++ b/app/experimenter/static/js/components/PrefForm.js
@@ -1,11 +1,16 @@
-import { List, Map } from "immutable";
 import PropTypes from "prop-types";
 import React from "react";
+import { List, Map } from "immutable";
 import { Row, Col } from "react-bootstrap";
 
 import BranchManager from "experimenter/components/BranchManager";
 import DesignInput from "experimenter/components/DesignInput";
 import PrefBranchFields from "experimenter/components/PrefBranchFields";
+import {
+  PREF_KEY_HELP,
+  PREF_TYPE_HELP,
+  PREF_BRANCH_HELP,
+} from "experimenter/components/constants";
 
 export default class PrefForm extends React.PureComponent {
   static propTypes = {
@@ -33,21 +38,7 @@ export default class PrefForm extends React.PureComponent {
           }}
           value={this.props.data.get("pref_key")}
           error={this.props.errors.get("pref_key", "")}
-          helpContent={
-            <div>
-              <p>
-                Enter the full name of the Firefox pref key that this experiment
-                will control. A pref experiment can control exactly one pref,
-                and each branch will receive a different value for that pref.
-                You can find all Firefox prefs in about:config and any pref that
-                appears there can be the target of an experiment.
-              </p>
-              <p>
-                <strong>Example: </strong>
-                browser.example.component.enable_large_sign_in_button
-              </p>
-            </div>
-          }
+          helpContent={PREF_KEY_HELP}
         />
 
         <DesignInput
@@ -60,17 +51,7 @@ export default class PrefForm extends React.PureComponent {
           value={this.props.data.get("pref_type")}
           error={this.props.errors.get("pref_type", "")}
           as="select"
-          helpContent={
-            <div>
-              <p>
-                Select the type of the pref entered above. The pref type will be
-                shown in the third column in about:config.
-              </p>
-              <p>
-                <strong>Example:</strong> boolean
-              </p>
-            </div>
-          }
+          helpContent={PREF_TYPE_HELP}
         >
           <option>Firefox Pref Type</option>
           <option>boolean</option>
@@ -89,23 +70,7 @@ export default class PrefForm extends React.PureComponent {
           value={this.props.data.get("pref_branch")}
           error={this.props.errors.get("pref_branch", "")}
           as="select"
-          helpContent={
-            <div>
-              <p>
-                Select the pref branch the experiment will write its pref value
-                to. If you're not sure what this means, you should stick to the
-                'default' pref branch. Pref branches are a little more
-                complicated than can be written here, but you can find&nbsp;
-                <a href="https://developer.mozilla.org/en-US/docs/Archive/Add-ons/Code_snippets/Preferences#Default_preferences">
-                  more information here
-                </a>
-                .
-              </p>
-              <p>
-                <strong>Example:</strong> default
-              </p>
-            </div>
-          }
+          helpContent={PREF_BRANCH_HELP}
         >
           <option>Firefox Pref Branch</option>
           <option>default</option>

--- a/app/experimenter/static/js/components/constants.js
+++ b/app/experimenter/static/js/components/constants.js
@@ -1,5 +1,91 @@
 import React from "react";
 
+export const DESIGN_HELP = (
+  <div>
+    <p>Specify the design of the experiment.</p>
+  </div>
+);
+
+export const PREF_KEY_HELP = (
+  <div>
+    <p>
+      Enter the full name of the Firefox pref key that this experiment will
+      control. A pref experiment can control exactly one pref, and each branch
+      will receive a different value for that pref. You can find all Firefox
+      prefs in about:config and any pref that appears there can be the target of
+      an experiment.
+    </p>
+    <p>
+      <strong>Example: </strong>
+      browser.example.component.enable_large_sign_in_button
+    </p>
+  </div>
+);
+
+export const PREF_TYPE_HELP = (
+  <div>
+    <p>
+      Select the type of the pref entered above. The pref type will be shown in
+      the third column in about:config.
+    </p>
+    <p>
+      <strong>Example:</strong> boolean
+    </p>
+  </div>
+);
+
+export const PREF_BRANCH_HELP = (
+  <div>
+    <p>
+      Select the pref branch the experiment will write its pref value to. If
+      you're not sure what this means, you should stick to the 'default' pref
+      branch. Pref branches are a little more complicated than can be written
+      here, but you can find&nbsp;
+      <a href="https://developer.mozilla.org/en-US/docs/Archive/Add-ons/Code_snippets/Preferences#Default_preferences">
+        more information here
+      </a>
+      .
+    </p>
+    <p>
+      <strong>Example:</strong> default
+    </p>
+  </div>
+);
+
+export const ADDON_EXPERIMENT_ID_HELP = (
+  <div>
+    <p>
+      Enter the <code>activeExperimentName</code> as it appears in the add-on.
+      It may appear in <code>manifest.json</code> as
+      <code> applications.gecko.id </code>
+      <a
+        target="_blank"
+        rel="noreferrer noopener"
+        href="https://mana.mozilla.org/wiki/display/FIREFOX/Pref-Flip+and+Add-On+Experiments#Pref-FlipandAdd-OnExperiments-Add-ons"
+      >
+        See here for more info.
+      </a>
+    </p>
+  </div>
+);
+
+export const ADDON_RELEASE_URL_HELP = (
+  <div>
+    <p>
+      Enter the URL where the release build of your add-on can be found. This is
+      often attached to a bugzilla ticket. This MUST BE the release signed
+      add-on (not the test add-on) that you want deployed.&nbsp;
+      <a
+        target="_blank"
+        rel="noreferrer noopener"
+        href="https://mana.mozilla.org/wiki/display/FIREFOX/Pref-Flip+and+Add-On+Experiments#Pref-FlipandAdd-OnExperiments-Add-ons"
+      >
+        See here for more info.
+      </a>
+    </p>
+  </div>
+);
+
 export const BRANCH_RATIO_HELP = (
   <div>
     <p>

--- a/app/experimenter/static/js/components/constants.js
+++ b/app/experimenter/static/js/components/constants.js
@@ -1,0 +1,65 @@
+import React from "react";
+
+export const BRANCH_RATIO_HELP = (
+  <div>
+    <p>
+      Choose the size of this branch represented as a whole number. The size of
+      all branches together must be equal to 100. It does not have to be exact,
+      so these sizes are simply a recommendation of the relative distribution of
+      the branches.
+    </p>
+    <p>
+      <strong>Example:</strong> 50
+    </p>
+  </div>
+);
+
+export const BRANCH_NAME_HELP = (
+  <div>
+    <p>
+      The control group should represent the users receiving the existing,
+      unchanged version of what you're testing. For example, if you're testing
+      making a button larger to see if users click on it more often, the control
+      group would receive the existing button size. You should name your control
+      branch based on the experience or functionality that group of users will
+      be receiving. Don't name it 'Control Group', we already know it's the
+      control group!
+    </p>
+    <p>
+      <strong>Example:</strong> Normal Button Size
+    </p>
+  </div>
+);
+
+export const BRANCH_DESCRIPTION_HELP = (
+  <div>
+    <p>
+      Describe the experience or functionality the control group will receive in
+      more detail.
+    </p>
+    <p>
+      <strong>Example:</strong> The control group will receive the existing 80px
+      sign in button located at the top right of the screen.
+    </p>
+  </div>
+);
+
+export const PREF_VALUE_HELP = (
+  <div>
+    <p className="mt-2">
+      Choose the value of the pref for the control group. This value must be
+      valid JSON in order to be sent to Shield. This should be the right type
+      (boolean, string, number), and should be the value that represents the
+      control or default state to compare to.
+    </p>
+    <p>
+      <strong>Boolean Example:</strong> false
+    </p>
+    <p>
+      <strong>String Example:</strong> some text
+    </p>
+    <p>
+      <strong>Integer Example:</strong> 13
+    </p>
+  </div>
+);


### PR DESCRIPTION
- Move help strings to constants
- Rename/remove handleChange methods
- Move renderField up to Branch component
- Sort imports alphabetically