### PR TITLE
Wait for form tag on design page fixes #2053

### DIFF
--- a/tests/integration/pages/experiment_design.py
+++ b/tests/integration/pages/experiment_design.py
@@ -32,7 +32,7 @@ class DesignPage(Base):
     )
     _page_wait_locator = (
         By.CSS_SELECTOR,
-        "body.page-edit-variants",
+        "form",
     )
 
 

--- a/tests/integration/pages/experiment_design.py
+++ b/tests/integration/pages/experiment_design.py
@@ -32,7 +32,7 @@ class DesignPage(Base):
     )
     _page_wait_locator = (
         By.CSS_SELECTOR,
-        "form",
+        "#id_pref_key",
     )
 
 


### PR DESCRIPTION
Switching the page wait locator for design page to the actual form tag, which won't load until we've gotten back data from the server.

previously, we were waiting on the body to be present, which in the case of the design form, happens before we've fetched from server and set up the form. 