### PR TITLE
Add DeepSource configuration with Dockerfile analyzer

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -1,0 +1,11 @@
+version = 1
+
+[[analyzers]]
+name = "docker"
+enabled = true
+
+  [analyzers.meta]
+  dockerfile_paths = [
+    "app/Dockerfile",
+    "nginx/Dockerfile"
+  ]


### PR DESCRIPTION
Ref: https://github.com/mozilla/experimenter/issues/2034

Ran analysis on a fork and found these issues - https://deepsource.io/gh/jaipradeesh/experimenter/issues/

This PR adds .deepsource.toml configuration file to run static analysis on Dockerfiles on pull requests.

To enable DeepSource analysis after merging this PR, please follow these steps:
- Sign up on [DeepSource](https://deepsource.io/signup) with your GitHub account and grant access to this repo.
- Activate analysis on this repo [here](https://deepsource.io/gh/mozilla/experimenter).

You can also look at the [dockerfile analyzer docs](https://deepsource.io/docs/analyzers/docker.html) for more details.

Signed-off-by: Jai <jai@deepsource.io>