### PR TITLE
Show risks after experiment starts fixes #2067

### DIFF
--- a/app/experimenter/experiments/models.py
+++ b/app/experimenter/experiments/models.py
@@ -643,6 +643,10 @@ class Experiment(ExperimentConstants, models.Model):
         return completed
 
     @property
+    def should_show_risks(self):
+        return self.completed_risks or self.is_begun
+
+    @property
     def completed_testing(self):
         return self.qa_status
 

--- a/app/experimenter/templates/experiments/detail_base.html
+++ b/app/experimenter/templates/experiments/detail_base.html
@@ -101,7 +101,7 @@
 
   {% include "experiments/section_analysis.html" with section_name=experiment.SECTION_ANALYSIS section_title="Analysis" section_complete=experiment.completed_objectives section_content=experiment.analysis experiment=experiment edit_url_name="experiments-objectives-update" comments=experiment.comments.sections.analysis %}
 
-  {% include "experiments/section_risks.html" with section_name=experiment.SECTION_RISKS section_complete=experiment.completed_risks experiment=experiment edit_url_name="experiments-risks-update" comments=experiment.comments.sections.risks %}
+  {% include "experiments/section_risks.html" with section_name=experiment.SECTION_RISKS section_complete=experiment.should_show_risks experiment=experiment edit_url_name="experiments-risks-update" comments=experiment.comments.sections.risks %}
 
   {% include "experiments/section_testing.html" with section_name=experiment.SECTION_TESTING section_title="Test Plan" section_complete=experiment.completed_testing experiment=experiment edit_url_name="experiments-risks-update" comments=experiment.comments.sections.testing %}
 


### PR DESCRIPTION
I noticed we have some experiments that launch before we add new risks and then the whole risk section is hidden, which isn't great.