### PR TITLE
Set initial population percent for rollout fixes #2176

### DIFF
--- a/app/experimenter/experiments/models.py
+++ b/app/experimenter/experiments/models.py
@@ -465,15 +465,15 @@ class Experiment(ExperimentConstants, models.Model):
             )
 
             if self.rollout_playbook == self.ROLLOUT_PLAYBOOK_LOW_RISK:
-                dates["first_increase"] = {"date": start_date, "percent": "25%"}
-                dates["second_increase"] = {"date": first_increase, "percent": "75%"}
-                dates["final_increase"] = {"date": final_increase, "percent": "100%"}
+                dates["first_increase"] = {"date": start_date, "percent": "25"}
+                dates["second_increase"] = {"date": first_increase, "percent": "75"}
+                dates["final_increase"] = {"date": final_increase, "percent": "100"}
             elif self.rollout_playbook == self.ROLLOUT_PLAYBOOK_HIGH_RISK:
-                dates["first_increase"] = {"date": start_date, "percent": "25%"}
-                dates["second_increase"] = {"date": first_increase, "percent": "50%"}
-                dates["final_increase"] = {"date": final_increase, "percent": "100%"}
+                dates["first_increase"] = {"date": start_date, "percent": "25"}
+                dates["second_increase"] = {"date": first_increase, "percent": "50"}
+                dates["final_increase"] = {"date": final_increase, "percent": "100"}
             elif self.rollout_playbook == self.ROLLOUT_PLAYBOOK_MARKETING:
-                dates["final_increase"] = {"date": start_date, "percent": "100%"}
+                dates["final_increase"] = {"date": start_date, "percent": "100"}
 
             return dates
 
@@ -545,7 +545,9 @@ class Experiment(ExperimentConstants, models.Model):
 
     @property
     def should_have_population_percent(self):
-        return self.type in (self.TYPE_PREF, self.TYPE_ADDON, self.TYPE_GENERIC)
+        return (self.type in (self.TYPE_PREF, self.TYPE_ADDON, self.TYPE_GENERIC)) or (
+            self.is_rollout and self.is_begun
+        )
 
     @property
     def completed_overview(self):

--- a/app/experimenter/experiments/tests/test_models.py
+++ b/app/experimenter/experiments/tests/test_models.py
@@ -596,9 +596,9 @@ class TestExperimentModel(TestCase):
         self.assertEqual(
             experiment.rollout_dates,
             {
-                "first_increase": {"date": "Jan 01, 2020", "percent": "25%"},
-                "second_increase": {"date": "Jan 08, 2020", "percent": "75%"},
-                "final_increase": {"date": "Jan 22, 2020", "percent": "100%"},
+                "first_increase": {"date": "Jan 01, 2020", "percent": "25"},
+                "second_increase": {"date": "Jan 08, 2020", "percent": "75"},
+                "final_increase": {"date": "Jan 22, 2020", "percent": "100"},
             },
         )
 
@@ -611,9 +611,9 @@ class TestExperimentModel(TestCase):
         self.assertEqual(
             experiment.rollout_dates,
             {
-                "first_increase": {"date": "Jan 01, 2020", "percent": "25%"},
-                "second_increase": {"date": "Jan 08, 2020", "percent": "50%"},
-                "final_increase": {"date": "Jan 22, 2020", "percent": "100%"},
+                "first_increase": {"date": "Jan 01, 2020", "percent": "25"},
+                "second_increase": {"date": "Jan 08, 2020", "percent": "50"},
+                "final_increase": {"date": "Jan 22, 2020", "percent": "100"},
             },
         )
 
@@ -625,7 +625,7 @@ class TestExperimentModel(TestCase):
         )
         self.assertEqual(
             experiment.rollout_dates,
-            {"final_increase": {"date": "Jan 01, 2020", "percent": "100%"}},
+            {"final_increase": {"date": "Jan 01, 2020", "percent": "100"}},
         )
 
     def test_rollout_dates_custom_playbook(self):

--- a/app/experimenter/templates/experiments/section_timeline.html
+++ b/app/experimenter/templates/experiments/section_timeline.html
@@ -18,7 +18,7 @@ Timeline
         {% if experiment.rollout_dates.first_increase %}
           <div class="col-4 text-center align-self-end">
             <div class="alert alert-primary">
-              Rollout to {{ experiment.rollout_dates.first_increase.percent }}
+              Rollout to {{ experiment.rollout_dates.first_increase.percent }}&percnt;
             </div>
             <p>{{ experiment.rollout_dates.first_increase.date }}</p>
           </div>
@@ -28,7 +28,7 @@ Timeline
           <div class="col-4 text-center align-self-end">
             <div class="alert alert-info">
               <br/>
-              Rollout to {{ experiment.rollout_dates.second_increase.percent }}
+              Rollout to {{ experiment.rollout_dates.second_increase.percent }}&percnt;
             </div>
             <p>{{ experiment.rollout_dates.second_increase.date }}</p>
           </div>
@@ -39,7 +39,7 @@ Timeline
             <div class="alert alert-success">
               <br/>
               <br/>
-              Rollout to {{ experiment.rollout_dates.final_increase.percent }}
+              Rollout to {{ experiment.rollout_dates.final_increase.percent }}&percnt;
             </div>
             <p>{{ experiment.rollout_dates.final_increase.date }}</p>
           </div>


### PR DESCRIPTION
Set population_percent to the first increase size for a rollout and then show it when it goes live.  Then we can update population_percent in the update task in a separate ticket.