### PR TITLE
text only coverage report fixes #2270

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -3,6 +3,7 @@
   "jest": {
     "automock": false,
     "verbose": true,
+    "coverageReporters":["text"],
     "coverageThreshold": {
       "global": {
         "lines": 100


### PR DESCRIPTION
Currently running js tests generate coverage files...<img width="421" alt="Screen Shot 2020-02-10 at 2 28 33 PM" src="https://user-images.githubusercontent.com/25379936/74196746-bcdddb80-4c12-11ea-991e-d569e4392e1d.png">

I don't think we really need them... text console summary seems sufficient, so this is kinda extra clutter....