### PR TITLE
Explicitly set postgres password and version fixes #2291

### DIFF
--- a/app/.dockerignore
+++ b/app/.dockerignore
@@ -1,3 +1,4 @@
+.vscode
 .cache
 .git
 .gitignore

--- a/docker-compose-full.yml
+++ b/docker-compose-full.yml
@@ -43,10 +43,12 @@ services:
       - public_nw
 
   normandy_db:
-    image: postgres:9.6
-    environment:
-      POSTGRES_DB: normandy
+    restart: always
+    image: postgres:9.6.17
     ports:
       - "5431:5432"
     networks:
       - private_nw
+    environment:
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: normandy

--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -7,7 +7,6 @@ services:
     environment:
       - DEBUG=False
     volumes:
-      - ./app:/app
       - /app/node_modules/
     links:
       - db
@@ -16,7 +15,9 @@ services:
 
   db:
     restart: always
-    image: postgres:9.6
+    image: postgres:9.6.17
+    environment:
+      POSTGRES_PASSWORD: postgres
     networks:
       - private_nw
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -70,7 +70,9 @@ services:
 
   db:
     restart: always
-    image: postgres:9.6
+    image: postgres:9.6.17
+    environment:
+      POSTGRES_PASSWORD: postgres
     volumes:
       - db_volume:/var/lib/postgresql
     networks:


### PR DESCRIPTION
Looks like the postgres docker image default security behaviour has changed: https://github.com/docker-library/postgres/pull/658 so we gotta explicitly set the password now, and we should pin to a specific version so that random changes like this don't sneak in and start breaking local dev or ci.