### PR TITLE
Hide date input form group if dates unrestricted fixes #2300

### DIFF
--- a/app/experimenter/static/js/scripts/experiment-date-filter.js
+++ b/app/experimenter/static/js/scripts/experiment-date-filter.js
@@ -1,15 +1,12 @@
 let dateRangeSelector = document.getElementById('id_experiment_date_field');
 let rangeElementInput0 = document.getElementById("id_date_range_0");
-let rangeElementInput1 = document.getElementById("id_date_range_1");
-
+let rangeElementGroup = rangeElementInput0.closest(".form-group");
 
 function setUpDateRange () {
   if (dateRangeSelector.value == '') {
-    rangeElementInput0.setAttribute("disabled", "")
-    rangeElementInput1.setAttribute("disabled", "")
+    rangeElementGroup.setAttribute("hidden", "");
   } else {
-    rangeElementInput0.removeAttribute("disabled");
-    rangeElementInput1.removeAttribute("disabled");
+    rangeElementGroup.removeAttribute("hidden");
   }
 }
 


### PR DESCRIPTION
First time contributor here! Attempting to fix #2300 by using the `hidden` attribute, which is conveniently enforced by

```css
[hidden] {
  display: none !important;
}
```

in `bootstrap.css`.

Before             |  After
:-------------------------:|:-------------------------:
[![Image from Gyazo](https://i.gyazo.com/7fa6aea4ab98dadd75027beef5ba9631.gif)](https://gyazo.com/7fa6aea4ab98dadd75027beef5ba9631)  |  [![Image from Gyazo](https://i.gyazo.com/71ae80a39c7b9e2df5b3c0788cadd982.gif)](https://gyazo.com/71ae80a39c7b9e2df5b3c0788cadd982)

