### PR TITLE
Fix yarn watcher for local dev fixes #2443

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ services:
       - /app/node_modules/
       - assets_volume:/app/experimenter/static/assets/
       - static_volume:/app/experimenter/served/
+      - /app/.cache
     command: bash -c "/app/bin/wait-for-it.sh db:5432 -- python /app/manage.py collectstatic --noinput;python /app/manage.py runserver 0:7001"
     networks:
       - private_nw

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,7 @@ services:
       - /app/node_modules/
       - assets_volume:/app/experimenter/static/assets/
       - static_volume:/app/experimenter/served/
+      - /app/.cache
     command: bash -c "yarn watch"
 
   worker:


### PR DESCRIPTION
Looks like we gotta prevent the yarn container from writing this back out to the host filesystem:

https://github.com/parcel-bundler/parcel/issues/2957#issuecomment-486915492