### PR TITLE
Remove survey links fixes #2447

### DIFF
--- a/app/experimenter/templates/experiments/edit_results.html
+++ b/app/experimenter/templates/experiments/edit_results.html
@@ -35,22 +35,6 @@ Edit <a href="{% url "experiments-detail" slug=object.slug %}">
   {% include "experiments/radio_field_inline.html" with field=form.results_confidence %}
   {% include "experiments/radio_field_inline.html" with field=form.results_measure_impact %}
   {% include "experiments/field_inline.html" with field=form.results_impact_notes %}
-
-
-
-
-  <div class="row my-4">
-    <div class="col-10 offset-2">
-      <p>
-        We'd welcome your feedback via
-        <a target="_blank" rel="noreferrer noopener" href="https://qsurvey.mozilla.com/s3/Experimenter-Study-Feedback?origin=experimenter">this survey</a>
-        if you were engaged with this delivery from data science, product
-        management, program management,
-        product team engineering, experiment operations, or another capacity.
-      </p>
-    </div>
-  </div>
-
 {% endblock %}
 
 

--- a/app/experimenter/templates/experiments/section_base.html
+++ b/app/experimenter/templates/experiments/section_base.html
@@ -24,8 +24,7 @@
               {{ section_content|urlize|linebreaks }}
             {% endblock %}
           {% elif section_name == "results" and not section_complete %}
-            <p>Please <a href="{% url edit_url_name slug=experiment.slug %}">add results </a> to this delivery and take <a target="_blank" rel="noreferrer noopener" href="https://qsurvey.mozilla.com/s3/Experimenter-Study-Feedback?origin=experimenter">this survey</a> about your experience.</p>
-
+            <p>Please <a href="{% url edit_url_name slug=experiment.slug %}">add results </a> to this delivery.</p>
           {% else %}
             <p>You must <a href="{% url edit_url_name slug=experiment.slug %}">complete the {{ section_name }} form</a> before you can launch your delivery.</p>
           {% endif %}

--- a/app/experimenter/templates/experiments/section_results.html
+++ b/app/experimenter/templates/experiments/section_results.html
@@ -6,13 +6,6 @@ Results
 {% endblock %}
 
 {% block section_content %}
-  <p>
-    <span class="fas fa-info-circle"></span> <em>We'd welcome your feedback via
-    <a target="_blank" rel="noreferrer noopener" href="https://qsurvey.mozilla.com/s3/Experimenter-Study-Feedback?origin=experimenter">this survey</a>
-    if you were engaged with this delivery from data science, product
-    management, program management,
-    product team engineering, experiment operations, or another capacity.</em>
-  </p>
   <p><strong>Primary Result URL: </strong></p>
   {% if experiment.results_url %}
     <p>{{ experiment.results_url|urlize|markdown }}</p>


### PR DESCRIPTION
<img width="881" alt="Screenshot 2020-03-27 14 19 11" src="https://user-images.githubusercontent.com/119884/77787565-1de03800-7036-11ea-96d2-6c03295191d7.png">

![Screenshot_2020-03-27 Centralized solution-oriented task-force](https://user-images.githubusercontent.com/119884/77787636-3b150680-7036-11ea-85e6-c6ee77e9690b.png)


<img width="885" alt="Screenshot 2020-03-27 14 19 51" src="https://user-images.githubusercontent.com/119884/77787590-26387300-7036-11ea-9e70-8695b59fbed5.png">
