### PR TITLE
Remove platform filter object from recipe serializer fixes #2568

### DIFF
--- a/app/experimenter/experiments/serializers/recipe.py
+++ b/app/experimenter/experiments/serializers/recipe.py
@@ -67,17 +67,6 @@ class FilterObjectChannelSerializer(serializers.ModelSerializer):
         return [obj.firefox_channel.lower()]
 
 
-# class FilterObjectPlatformSerializer(serializers.ModelSerializer):
-#     type = serializers.SerializerMethodField()
-#
-#     class Meta:
-#         model = Experiment
-#         fields = ("type", "platforms")
-#
-#     def get_type(self, obj):
-#         return "platform"
-
-
 class FilterObjectVersionsSerializer(serializers.ModelSerializer):
     type = serializers.SerializerMethodField()
     versions = serializers.SerializerMethodField()

--- a/app/experimenter/experiments/serializers/recipe.py
+++ b/app/experimenter/experiments/serializers/recipe.py
@@ -7,7 +7,6 @@ from experimenter.experiments.models import (
     VariantPreferences,
     RolloutPreference,
 )
-from experimenter.experiments.constants import ExperimentConstants
 
 from experimenter.experiments.serializers.entities import PrefTypeField
 
@@ -68,15 +67,15 @@ class FilterObjectChannelSerializer(serializers.ModelSerializer):
         return [obj.firefox_channel.lower()]
 
 
-class FilterObjectPlatformSerializer(serializers.ModelSerializer):
-    type = serializers.SerializerMethodField()
-
-    class Meta:
-        model = Experiment
-        fields = ("type", "platforms")
-
-    def get_type(self, obj):
-        return "platform"
+# class FilterObjectPlatformSerializer(serializers.ModelSerializer):
+#     type = serializers.SerializerMethodField()
+#
+#     class Meta:
+#         model = Experiment
+#         fields = ("type", "platforms")
+#
+#     def get_type(self, obj):
+#         return "platform"
 
 
 class FilterObjectVersionsSerializer(serializers.ModelSerializer):
@@ -348,9 +347,6 @@ class ExperimentRecipeSerializer(serializers.ModelSerializer):
         if obj.countries.count():
             filter_objects.append(FilterObjectCountrySerializer(obj).data)
 
-        if len(obj.platforms) < len(ExperimentConstants.PLATFORMS_LIST):
-            filter_objects.append(FilterObjectPlatformSerializer(obj).data)
-
         return filter_objects
 
     def get_arguments(self, obj):
@@ -368,4 +364,4 @@ class ExperimentRecipeSerializer(serializers.ModelSerializer):
             return ExperimentRecipePrefRolloutArgumentsSerializer(obj).data
 
     def get_comment(self, obj):
-        return f"{obj.client_matching}"
+        return f"Platform: {obj.platforms}\n{obj.client_matching}"

--- a/app/experimenter/experiments/tests/serializers/test_recipe.py
+++ b/app/experimenter/experiments/tests/serializers/test_recipe.py
@@ -29,7 +29,6 @@ from experimenter.experiments.serializers.recipe import (
     FilterObjectCountrySerializer,
     FilterObjectLocaleSerializer,
     FilterObjectVersionsSerializer,
-    FilterObjectPlatformSerializer,
     PrefValueField,
 )
 
@@ -326,7 +325,7 @@ class TestExperimentRecipeSerializer(TestCase):
         serializer = ExperimentRecipeSerializer(experiment)
         self.assertEqual(serializer.data["action_name"], "preference-experiment")
         self.assertEqual(serializer.data["name"], experiment.name)
-        expected_comment = experiment.client_matching
+        expected_comment = "Platform: ['All Mac']\n{}".format(experiment.client_matching)
         self.assertEqual(serializer.data["comment"], expected_comment)
         self.assertEqual(
             serializer.data["filter_object"],
@@ -336,7 +335,6 @@ class TestExperimentRecipeSerializer(TestCase):
                 FilterObjectVersionsSerializer(experiment).data,
                 FilterObjectLocaleSerializer(experiment).data,
                 FilterObjectCountrySerializer(experiment).data,
-                FilterObjectPlatformSerializer(experiment).data,
             ],
         )
         self.assertEqual(
@@ -359,7 +357,9 @@ class TestExperimentRecipeSerializer(TestCase):
         self.assertEqual(serializer.data["action_name"], "opt-out-study")
         self.assertEqual(serializer.data["name"], experiment.name)
 
-        expected_comment = experiment.client_matching
+        expected_comment = "Platform: ['All Windows']\n{}".format(
+            experiment.client_matching
+        )
         self.assertEqual(serializer.data["comment"], expected_comment)
         self.assertEqual(
             serializer.data["filter_object"],
@@ -369,7 +369,6 @@ class TestExperimentRecipeSerializer(TestCase):
                 FilterObjectVersionsSerializer(experiment).data,
                 FilterObjectLocaleSerializer(experiment).data,
                 FilterObjectCountrySerializer(experiment).data,
-                FilterObjectPlatformSerializer(experiment).data,
             ],
         )
         self.assertEqual(
@@ -399,7 +398,9 @@ class TestExperimentRecipeSerializer(TestCase):
         serializer = ExperimentRecipeSerializer(experiment)
         self.assertEqual(serializer.data["action_name"], "branched-addon-study")
         self.assertEqual(serializer.data["name"], experiment.name)
-        expected_comment = experiment.client_matching
+        expected_comment = "Platform: ['All Linux']\n{}".format(
+            experiment.client_matching
+        )
         self.assertEqual(serializer.data["comment"], expected_comment)
         self.assertEqual(
             serializer.data["filter_object"],
@@ -409,7 +410,6 @@ class TestExperimentRecipeSerializer(TestCase):
                 FilterObjectVersionsSerializer(experiment).data,
                 FilterObjectLocaleSerializer(experiment).data,
                 FilterObjectCountrySerializer(experiment).data,
-                FilterObjectPlatformSerializer(experiment).data,
             ],
         )
         self.assertEqual(
@@ -442,7 +442,9 @@ class TestExperimentRecipeSerializer(TestCase):
 
         variant.save()
 
-        expected_comment = experiment.client_matching
+        expected_comment = "Platform: ['All Windows']\n{}".format(
+            experiment.client_matching
+        )
         serializer = ExperimentRecipeSerializer(experiment)
         self.assertEqual(serializer.data["action_name"], "multi-preference-experiment")
         self.assertEqual(serializer.data["name"], experiment.name)
@@ -455,7 +457,6 @@ class TestExperimentRecipeSerializer(TestCase):
                 FilterObjectVersionsSerializer(experiment).data,
                 FilterObjectLocaleSerializer(experiment).data,
                 FilterObjectCountrySerializer(experiment).data,
-                FilterObjectPlatformSerializer(experiment).data,
             ],
         )
         expected_data = {
@@ -501,7 +502,9 @@ class TestExperimentRecipeSerializer(TestCase):
 
         pref = VariantPreferencesFactory.create(variant=variant)
 
-        expected_comment = experiment.client_matching
+        expected_comment = "Platform: ['All Windows']\n{}".format(
+            experiment.client_matching
+        )
         serializer = ExperimentRecipeSerializer(experiment)
         self.assertEqual(serializer.data["action_name"], "multi-preference-experiment")
         self.assertEqual(serializer.data["name"], experiment.name)
@@ -514,7 +517,6 @@ class TestExperimentRecipeSerializer(TestCase):
                 FilterObjectVersionsSerializer(experiment).data,
                 FilterObjectLocaleSerializer(experiment).data,
                 FilterObjectCountrySerializer(experiment).data,
-                FilterObjectPlatformSerializer(experiment).data,
             ],
         )
 
@@ -565,7 +567,9 @@ class TestExperimentRecipeSerializer(TestCase):
                     "extensionApiId": "TODO: https://www.example.com/addon.xpi",
                     "slug": "normandy-slug",
                 },
-                "comment": "Geos: US, CA, GB\n" 'Some "additional" filtering',
+                "comment": "Platform: ['All Windows']\n"
+                "Geos: US, CA, GB\n"
+                'Some "additional" filtering',
                 "experimenter_slug": "experimenter-slug",
                 "filter_object": [
                     {
@@ -577,7 +581,6 @@ class TestExperimentRecipeSerializer(TestCase):
                     },
                     {"channels": ["beta"], "type": "channel"},
                     {"type": "version", "versions": [70, 71]},
-                    {"type": "platform", "platforms": ["All Windows"]},
                 ],
                 "name": "Experimenter Name",
             },
@@ -615,7 +618,9 @@ class TestExperimentRecipeSerializer(TestCase):
                     "preferences": [{"preferenceName": "browser.pref", "value": True}],
                     "slug": "normandy-slug",
                 },
-                "comment": "Geos: US, CA, GB\n" 'Some "additional" filtering',
+                "comment": "Platform: ['All Windows']\n"
+                "Geos: US, CA, GB\n"
+                'Some "additional" filtering',
                 "experimenter_slug": "experimenter-slug",
                 "filter_object": [
                     {
@@ -627,7 +632,6 @@ class TestExperimentRecipeSerializer(TestCase):
                     },
                     {"type": "channel", "channels": ["beta"]},
                     {"type": "version", "versions": [70, 71]},
-                    {"type": "platform", "platforms": ["All Windows"]},
                 ],
                 "name": "Experimenter Name",
             },


### PR DESCRIPTION
I commented out the filter object. If I leave the platforms FO, but dont use it, we won't pass our test coverage. I was always testing the platforms fo as part of the whole recipe output. 

I left the comment in the form of a list of strings. i didn't think it was worth putting effort into formatting a comment to look slightly nicer when we're about to throw this comment code away in a few weeks anyway. 