### PR TITLE
Add pytest conf to pytest.ini fixes #2579

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ COMPOSE_FULL = docker-compose -f docker-compose.yml -f docker-compose-full.yml
 
 JOBS = 4
 PARALLEL = parallel --halt now,fail=1 --jobs ${JOBS} {} :::
-PYTHON_TEST = pytest -vvvv --cov --cov-report term-missing --show-capture=no --disable-warnings --ignore=tests/integration -n ${JOBS}
+PYTHON_TEST = pytest --cov --cov-report term-missing
 PYTHON_CHECK_MIGRATIONS = python manage.py makemigrations --check --dry-run --noinput
 ESLINT = yarn lint
 ESLINT_FIX = yarn lint-fix

--- a/app/pytest.ini
+++ b/app/pytest.ini
@@ -2,6 +2,6 @@
 [pytest]
 DJANGO_SETTINGS_MODULE = experimenter.settings
 # -- recommended but optional:
-addopts = -p no:warnings
+addopts = -vvvv --ignore=tests/integration --show-capture=no --disable-warnings -n 4 
 python_files = tests.py test_*.py *_tests.py
 norecursedirs = .cache .pytest_cache .vscode bin fixtures node_modules requirements static served


### PR DESCRIPTION
Move the general config from Makefile to pytest.ini, but I had to keep the coverage commands in the makefile otherwise vscode choked.