### PR TITLE
move pref info into table fixes #2457

### DIFF
--- a/app/experimenter/templates/experiments/section_branches.html
+++ b/app/experimenter/templates/experiments/section_branches.html
@@ -41,12 +41,13 @@
         {% for preference in variant.preferences.all %}
           <tr>
             <td>{{ preference.pref_name }}</td>
+            <td>
             {% if preference.is_json_string_type %}
-            <td><pre class="text-info">{{ preference.pref_value|as_json }}</pre></td>
-              
+              <pre class="text-info">{{ preference.pref_value|as_json }}</pre>     
             {% else %}
-            <td><pref class="text-info">{{ preference.pref_value }}</pref></td>
+              <pre class="text-info">{{ preference.pref_value }}</pre>
             {% endif %}
+            </td>
             <td>{{ preference.pref_type }}</td>
             <td>{{ preference.pref_branch }}</td>
           </tr>

--- a/app/experimenter/templates/experiments/section_branches.html
+++ b/app/experimenter/templates/experiments/section_branches.html
@@ -18,7 +18,6 @@
   {% for variant in experiment.variants.all %}
     <div class=" pl-3 my-3">
       <h5>{{ variant.ratio }}% {{ variant.name }}</h5>
-      {% if experiment.is_multi_pref %}
         <p><strong>Prefs:</strong></p>
         <table class="table table-bordered">
         <thead>
@@ -30,6 +29,7 @@
           </tr>
         </thead>
         <tbody>
+      {% if experiment.is_multi_pref %}
         {% for preference in variant.preferences.all %}
           <tr>
             <td>{{ preference.pref_name }}</td>
@@ -49,24 +49,16 @@
         </tbody>
         </table>
       {% elif experiment.is_pref_experiment %}
-      <table class="table table-bordered">
-        <thead>
-          <tr>
-            <th scope="col">Name</th>
-            <th scope="col">Value</th>
-            <th scope="col">Type</th>
-            <th scope="col">Branch</th>
-          </tr>
-        </thead>
-        <tbody>
           <tr>
             <td>{{ experiment.pref_name}}</td>
             <td>
+              <pre class="text-info"></pre>
               {% if experiment.is_pref_value_json_string %}
-              <pre class="text-info">{{ variant.value|as_json }}</pre></strong></p>
+              {{ variant.value|as_json }}
               {% else %}
                 {{ variant.value }}
               {% endif %}
+              </pre>
             </td>
             <td>{{ experiment.pref_type }}</td>
             <td>{{ experiment.pref_branch }}</td>

--- a/app/experimenter/templates/experiments/section_branches.html
+++ b/app/experimenter/templates/experiments/section_branches.html
@@ -7,14 +7,6 @@
 {% endblock %}
 
 {% block section_content %}
-  {% if not experiment.is_multi_pref %}
-    {% if experiment.pref_type %}
-    <strong>Pref Type</strong> <p>{{ experiment.pref_type }}</p>
-    {% endif %}
-    {% if experiment.pref_branch %}
-    <strong>Pref Branch</strong> <p>{{ experiment.pref_branch }}</p>
-    {% endif %}
-  {% endif %}
   {% if experiment.is_message_experiment %}
     {% if experiment.message_type %}
       <strong>Message Type</strong> <p>{{ experiment.get_message_type_display }}</p>
@@ -42,12 +34,14 @@
           <tr>
             <td>{{ preference.pref_name }}</td>
             <td>
+            <pre class="text-info">
             {% if preference.is_json_string_type %}
-              <pre class="text-info">{{ preference.pref_value|as_json }}</pre>     
+              {{ preference.pref_value|as_json }}   
             {% else %}
-              <pre class="text-info">{{ preference.pref_value }}</pre>
+              {{ preference.pref_value }}
             {% endif %}
-            </td>
+            </pre>
+          </td>
             <td>{{ preference.pref_type }}</td>
             <td>{{ preference.pref_branch }}</td>
           </tr>
@@ -55,11 +49,30 @@
         </tbody>
         </table>
       {% elif experiment.is_pref_experiment %}
-        {% if experiment.is_pref_value_json_string %}
-          <p><strong>{{ experiment.pref_name }} = <pre class="text-info">{{ variant.value|as_json }}</pre></strong></p>
-        {% else %}
-          <p><strong>{{ experiment.pref_name }} = <span class="text-info">{{ variant.value }}</span></strong></p>
-        {% endif %}
+      <table class="table table-bordered">
+        <thead>
+          <tr>
+            <th scope="col">Name</th>
+            <th scope="col">Value</th>
+            <th scope="col">Type</th>
+            <th scope="col">Branch</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>{{ experiment.pref_name}}</td>
+            <td>
+              {% if experiment.is_pref_value_json_string %}
+              <pre class="text-info">{{ variant.value|as_json }}</pre></strong></p>
+              {% else %}
+                {{ variant.value }}
+              {% endif %}
+            </td>
+            <td>{{ experiment.pref_type }}</td>
+            <td>{{ experiment.pref_branch }}</td>
+          </tr>
+        </tbody>
+        </table>
       {% endif %}
       <p>{{ variant.description|urlize|linebreaks }}</p>
       {% if experiment.is_branched_addon %}

--- a/app/experimenter/templates/experiments/section_branches.html
+++ b/app/experimenter/templates/experiments/section_branches.html
@@ -24,21 +24,35 @@
     {% endif %}
   {% endif %}
   {% for variant in experiment.variants.all %}
-    <div class="border-left-grey pl-3 my-3">
+    <div class=" pl-3 my-3">
       <h5>{{ variant.ratio }}% {{ variant.name }}</h5>
       {% if experiment.is_multi_pref %}
         <p><strong>Prefs:</strong></p>
+        <table class="table table-bordered">
+        <thead>
+          <tr>
+            <th scope="col">Name</th>
+            <th scope="col">Value</th>
+            <th scope="col">Type</th>
+            <th scope="col">Branch</th>
+          </tr>
+        </thead>
+        <tbody>
         {% for preference in variant.preferences.all %}
-          <div class="border-left-grey pl-3 ml-2 mb-3">
-           {% if preference.is_json_string_type %}
-            <p><strong> {{ preference.pref_name }} = <pre class="text-info">{{ preference.pref_value|as_json }}</pre></strong></p>
-           {% else %}
-            <p><strong> {{ preference.pref_name }} = <span class="text-info">{{ preference.pref_value }}</span></strong></p>
-           {% endif %}
-           <p>Pref Type: <span class="text-info">{{ preference.pref_type }}</span></p>
-           <p>Pref Branch: <span class="text-info">{{ preference.pref_branch }}</span></p>
-          </div>
+          <tr>
+            <td>{{ preference.pref_name }}</td>
+            {% if preference.is_json_string_type %}
+            <td><pre class="text-info">{{ preference.pref_value|as_json }}</pre></td>
+              
+            {% else %}
+            <td><pref class="text-info">{{ preference.pref_value }}</pref></td>
+            {% endif %}
+            <td>{{ preference.pref_type }}</td>
+            <td>{{ preference.pref_branch }}</td>
+          </tr>
         {% endfor %}
+        </tbody>
+        </table>
       {% elif experiment.is_pref_experiment %}
         {% if experiment.is_pref_value_json_string %}
           <p><strong>{{ experiment.pref_name }} = <pre class="text-info">{{ variant.value|as_json }}</pre></strong></p>

--- a/app/experimenter/templates/experiments/section_branches.html
+++ b/app/experimenter/templates/experiments/section_branches.html
@@ -34,11 +34,10 @@
           <tr>
             <td>{{ preference.pref_name }}</td>
             <td>
-            <pre class="text-info">
             {% if preference.is_json_string_type %}
-              {{ preference.pref_value|as_json }}   
+              <pre class="text-info">{{ preference.pref_value|as_json }}</pre>  
             {% else %}
-              {{ preference.pref_value }}
+              <pre class="text-info">{{ preference.pref_value }}</pre>
             {% endif %}
             </pre>
           </td>
@@ -52,11 +51,11 @@
           <tr>
             <td>{{ experiment.pref_name}}</td>
             <td>
-              <pre class="text-info"></pre>
+              
               {% if experiment.is_pref_value_json_string %}
-              {{ variant.value|as_json }}
+              <pre class="text-info">{{ variant.value|as_json }}</pre>
               {% else %}
-                {{ variant.value }}
+              <pre class="text-info">{{ variant.value }}</pre>
               {% endif %}
               </pre>
             </td>

--- a/app/experimenter/templates/experiments/section_rollout.html
+++ b/app/experimenter/templates/experiments/section_rollout.html
@@ -24,10 +24,9 @@
     <tr>
       <td>{{ preference.pref_name }}</td>
       {% if preference.is_json_string_type %}
-      <td><pre class="text-info">{{ preference.pref_value|as_json }}</pre></td>
-        
+        <td><pre class="text-info">{{ preference.pref_value|as_json }}</pre></td>
       {% else %}
-      <td><pref class="text-info">{{ preference.pref_value }}</pref></td>
+        <td><pre class="text-info">{{ preference.pref_value }}</pre></td>
       {% endif %}
 
       <td>{{ preference.pref_type }}</td>

--- a/app/experimenter/templates/experiments/section_rollout.html
+++ b/app/experimenter/templates/experiments/section_rollout.html
@@ -11,16 +11,30 @@
   <p>{{ experiment.design|urlize|linebreaks }}</p>
   {% if experiment.is_pref_rollout %}
   <p><strong>Prefs:</strong></p>
-    {% for preference in experiment.preferences.all %}
-      <div class="border-left-grey pl-3 ml-2 mb-3">
-       {% if preference.is_json_string_type %}
-        <p><strong> {{ preference.pref_name }} = <pre class="text-info">{{ preference.pref_value|as_json }}</pre></strong></p>
-       {% else %}
-        <p><strong> {{ preference.pref_name }} = <span class="text-info">{{ preference.pref_value }}</span></strong></p>
-       {% endif %}
-       <p>Pref Type: <span class="text-info">{{ preference.pref_type }}</span></p>
-      </div>
-    {% endfor %}
+  <table class="table table-bordered">
+  <thead>
+    <tr>
+      <th scope="col">Name</th>
+      <th scope="col">Value</th>
+      <th scope="col">Type</th>
+    </tr>
+  </thead>
+  <tbody>
+  {% for preference in experiment.preferences.all %}
+    <tr>
+      <td>{{ preference.pref_name }}</td>
+      {% if preference.is_json_string_type %}
+      <td><pre class="text-info">{{ preference.pref_value|as_json }}</pre></td>
+        
+      {% else %}
+      <td><pref class="text-info">{{ preference.pref_value }}</pref></td>
+      {% endif %}
+
+      <td>{{ preference.pref_type }}</td>
+    </tr>
+  {% endfor %}
+  </tbody>
+  </table>
   {% endif %}
 
   {% if experiment.is_addon_rollout %}


### PR DESCRIPTION
Multi Pref:
![Screen Shot 2020-05-03 at 8 48 00 PM](https://user-images.githubusercontent.com/25379936/80935421-626f9980-8d81-11ea-8e7b-a86f40d089d4.png)

Rollout:
![Screen Shot 2020-05-03 at 8 57 10 PM](https://user-images.githubusercontent.com/25379936/80935424-64d1f380-8d81-11ea-82e3-2e8bcf81a5a9.png)

decided not to do a modal for json strings.... it doesn't seem to look so bad in the table to me..
