### PR TITLE
Signoffs available after ready to ship for messages only fixes #2648

### DIFF
--- a/app/experimenter/experiments/models.py
+++ b/app/experimenter/experiments/models.py
@@ -846,8 +846,17 @@ class Experiment(ExperimentConstants, models.Model):
         return completed
 
     @property
+    def should_have_signoffs_to_launch(self):
+        return self.type not in [self.TYPE_MESSAGE]
+
+    @property
     def is_ready_to_launch(self):
-        return self.completed_all_sections
+        ready_to_launch = self.completed_all_sections
+
+        if self.should_have_signoffs_to_launch:
+            ready_to_launch = ready_to_launch and self.completed_required_reviews
+
+        return ready_to_launch
 
     @property
     def format_firefox_versions(self):

--- a/app/experimenter/experiments/tests/test_models.py
+++ b/app/experimenter/experiments/tests/test_models.py
@@ -1203,10 +1203,55 @@ class TestExperimentModel(TestCase):
         )
         self.assertTrue(experiment.completed_all_sections)
 
-    def test_is_ready_to_launch_true_when_sections_complete(self):
+    def test_is_ready_to_launch_true_when_reviews_and_sections_complete(self):
         experiment = ExperimentFactory.create_with_status(
             Experiment.STATUS_REVIEW,
             type=Experiment.TYPE_PREF,
+            review_science=True,
+            review_engineering=True,
+            review_qa_requested=True,
+            review_intent_to_ship=True,
+            review_bugzilla=True,
+            review_qa=True,
+            review_relman=True,
+        )
+        self.assertTrue(experiment.is_ready_to_launch)
+
+    def test_is_ready_to_launch_true_with_conditional_review(self):
+        experiment = ExperimentFactory.create_with_status(
+            Experiment.STATUS_REVIEW,
+            review_science=True,
+            review_engineering=True,
+            review_qa_requested=True,
+            review_intent_to_ship=True,
+            review_bugzilla=True,
+            review_qa=True,
+            review_relman=True,
+            review_vp=True,
+            review_legal=True,
+            risk_partner_related=True,
+        )
+        self.assertTrue(experiment.is_ready_to_launch)
+
+    def test_is_ready_to_launch_is_false_without_conditional_review(self):
+        experiment = ExperimentFactory.create_with_status(
+            Experiment.STATUS_REVIEW,
+            review_science=True,
+            review_engineering=True,
+            review_qa_requested=True,
+            review_intent_to_ship=True,
+            review_bugzilla=True,
+            review_qa=True,
+            review_relman=True,
+            risk_partner_related=True,
+        )
+
+        self.assertFalse(experiment.is_ready_to_launch)
+
+    def test_is_ready_to_launch_without_signoffs_for_message_experiment(self):
+        experiment = ExperimentFactory.create_with_status(
+            Experiment.STATUS_REVIEW,
+            type=Experiment.TYPE_MESSAGE,
             review_science=False,
             review_engineering=False,
             review_qa_requested=False,

--- a/app/experimenter/templates/experiments/detail_accepted.html
+++ b/app/experimenter/templates/experiments/detail_accepted.html
@@ -1,5 +1,9 @@
 {% extends "experiments/detail_base.html" %}
 
-{% block main_sidebar_extra %}
-  {% include "experiments/signoff_form_inline.html" with experiment=experiment %}
+{% block main_sidebar_signoffs %}
+  {% if not experiment.should_have_signoffs_to_launch %}
+    {% include "experiments/signoff_form_inline.html" with experiment=experiment %}
+  {% else %}
+    {{ block.super }}
+  {% endif %}
 {% endblock %}

--- a/app/experimenter/templates/experiments/detail_base.html
+++ b/app/experimenter/templates/experiments/detail_base.html
@@ -177,7 +177,7 @@
   {% block main_sidebar_extra %}
   {% endblock %}
 
-  {% if not experiment.is_editable %}
+  {% block main_sidebar_signoffs %}
     <div class="row">
       <h5 class="col mt-3">Sign-Offs</h5>
     </div>
@@ -197,7 +197,7 @@
         </div>
       {% endfor %}
     </div>
-  {% endif %}
+  {% endblock %}
 
   <div class="row">
     <h5 class="col mt-3">History</h5>

--- a/app/experimenter/templates/experiments/detail_draft.html
+++ b/app/experimenter/templates/experiments/detail_draft.html
@@ -20,3 +20,6 @@
 
   </form>
 {% endblock %}
+
+{% block main_sidebar_signoffs %}
+{% endblock %}

--- a/app/experimenter/templates/experiments/detail_review.html
+++ b/app/experimenter/templates/experiments/detail_review.html
@@ -44,7 +44,7 @@
   </form>
 {% endblock %}
 
-{% block main_sidebar_extra %}
+{% block main_sidebar_signoffs %}
   {% include "experiments/signoff_form_inline.html" with experiment=experiment %}
 {% endblock %}
 

--- a/app/experimenter/templates/experiments/detail_ship.html
+++ b/app/experimenter/templates/experiments/detail_ship.html
@@ -109,9 +109,14 @@
   </div>
 {% endblock %}
 
-{% block main_sidebar_extra %}
-  {% include "experiments/signoff_form_inline.html" with experiment=experiment %}
+{% block main_sidebar_signoffs %}
+  {% if not experiment.should_have_signoffs_to_launch %}
+    {% include "experiments/signoff_form_inline.html" with experiment=experiment %}
+  {% else %}
+    {{ block.super }}
+  {% endif %}
 {% endblock %}
+
 
 {% block extrascripts %}
   {{ block.super }}


### PR DESCRIPTION
To test things out last week I made it so no experiments need signoffs to be ready to ship, but we probably still need that requirement for all non-message experiments, so I added it back for non message experiments.