### PR TITLE
Add validation for swapped pref names fixes #2640

### DIFF
--- a/app/experimenter/experiments/serializers/design.py
+++ b/app/experimenter/experiments/serializers/design.py
@@ -171,16 +171,17 @@ class ExperimentDesignBranchMultiPrefSerializer(
 
     def validate_preferences(self, data):
         variant = None
-        error_list = [{}] * len(data)
-        for i, pref in enumerate(data):
-            id = pref.get('id')
+        error_list = [{"pref_name": "You cannot swap pref names."}] * len(data)
+        for pref in data:
+            id = pref.get("id")
             if id and not variant:
                 variant = VariantPreferences.objects.get(id=id).variant
-            if (variant and variant.preferences
-                    .filter(pref_name=pref["pref_name"])
-                    .exclude(id=pref.get('id'))
-                    .exists()):
-                error_list[i] = {"pref_name": "You cannot swap pref names."}
+            if (
+                variant
+                and variant.preferences.filter(pref_name=pref["pref_name"])
+                .exclude(id=pref.get("id"))
+                .exists()
+            ):
                 raise serializers.ValidationError(error_list)
 
         if not self.is_pref_valid(data):

--- a/app/experimenter/experiments/serializers/design.py
+++ b/app/experimenter/experiments/serializers/design.py
@@ -173,16 +173,14 @@ class ExperimentDesignBranchMultiPrefSerializer(
         variant = None
         error_list = [{}] * len(data)
         for i, pref in enumerate(data):
-            id = pref.get("id")
+            id = pref.get('id')
             if id and not variant:
                 variant = VariantPreferences.objects.get(id=id).variant
-            if (
-                variant
-                and variant.preferences.filter(pref_name=pref["pref_name"])
-                .exclude(id=pref.get("id"))
-                .exists()
-            ):
-                error_list[i] = {"pref_name": "This pref name already exists."}
+            if (variant and variant.preferences
+                    .filter(pref_name=pref["pref_name"])
+                    .exclude(id=pref.get('id'))
+                    .exists()):
+                error_list[i] = {"pref_name": "You cannot swap pref names."}
                 raise serializers.ValidationError(error_list)
 
         if not self.is_pref_valid(data):

--- a/app/experimenter/experiments/serializers/design.py
+++ b/app/experimenter/experiments/serializers/design.py
@@ -170,6 +170,21 @@ class ExperimentDesignBranchMultiPrefSerializer(
         model = ExperimentVariant
 
     def validate_preferences(self, data):
+        variant = None
+        error_list = [{}] * len(data)
+        for i, pref in enumerate(data):
+            id = pref.get("id")
+            if id and not variant:
+                variant = VariantPreferences.objects.get(id=id).variant
+            if (
+                variant
+                and variant.preferences.filter(pref_name=pref["pref_name"])
+                .exclude(id=pref.get("id"))
+                .exists()
+            ):
+                error_list[i] = {"pref_name": "This pref name already exists."}
+                raise serializers.ValidationError(error_list)
+
         if not self.is_pref_valid(data):
             error_list = [{"pref_name": "Pref name per Branch needs to be unique"}] * len(
                 data


### PR DESCRIPTION
we were getting errors when people tried to swap the names of the prefs. Solution could be deleting all of them and recreating on any updates to the prefs 😆 😆 , or this... 

![prefswap](https://user-images.githubusercontent.com/1551682/81742185-89e6f600-9454-11ea-9820-c058d9998ee5.gif)
