### PR TITLE
Enrollment Pause changes to clone and worker task fixes #2660

### DIFF
--- a/app/experimenter/experiments/models.py
+++ b/app/experimenter/experiments/models.py
@@ -1006,6 +1006,7 @@ class Experiment(ExperimentConstants, models.Model):
         cloned.owner = user
         cloned.parent = self
         cloned.archived = False
+        cloned.is_paused = False
 
         for field in set_to_none_fields:
             setattr(cloned, field, None)

--- a/app/experimenter/experiments/tasks.py
+++ b/app/experimenter/experiments/tasks.py
@@ -255,13 +255,16 @@ def update_status_task(experiment, recipe_data):
 @metrics.timer_decorator("set_is_paused_value")
 def set_is_paused_value_task(experiment_id, recipe_data):
     experiment = Experiment.objects.get(id=experiment_id)
+    metrics.incr("set_is_paused_value.started")
+    logger.info("Updating Enrollment Value")
     if recipe_data:
         paused_val = is_paused(recipe_data)
         if paused_val is not None and paused_val != experiment.is_paused:
             with transaction.atomic():
                 experiment.is_paused = paused_val
                 experiment.save()
-
+            metrics.incr("set_is_paused_value.updated")
+            logger.info("Enrollment Value Updated")
             message = (
                 "Enrollment Completed"
                 if experiment.is_paused
@@ -272,6 +275,7 @@ def set_is_paused_value_task(experiment_id, recipe_data):
                 email=normandy_user, username=normandy_user
             )
             experiment.changes.create(message=message, changed_by=default_user)
+    metrics.incr("set_is_paused_value.completed")
 
 
 def update_population_percent(experiment, recipe_data):

--- a/app/experimenter/experiments/tests/test_models.py
+++ b/app/experimenter/experiments/tests/test_models.py
@@ -1490,6 +1490,7 @@ class TestExperimentModel(TestCase):
             addon_experiment_id="addon-id",
             addon_release_url="addon-url",
             archived=True,
+            is_paused=True,
             review_science=True,
             review_ux=True,
             firefox_min_version=Experiment.VERSION_CHOICES[1][0],
@@ -1528,6 +1529,7 @@ class TestExperimentModel(TestCase):
         self.assertCountEqual(cloned_experiment.locales.all(), experiment.locales.all())
         self.assertFalse(cloned_experiment.bugzilla_id)
         self.assertFalse(cloned_experiment.archived)
+        self.assertFalse(cloned_experiment.is_paused)
         self.assertFalse(cloned_experiment.review_science)
         self.assertFalse(cloned_experiment.review_ux)
         self.assertFalse(cloned_experiment.addon_experiment_id)


### PR DESCRIPTION
I believe this fixes https://github.com/mozilla/experimenter/issues/1843 as well based on the how the "Created Delivery" changelog entries on the mentioned experiments don't have changed values seems to suggest that they were cloned to me