### PR TITLE
Split fixtures for e2e tests.

### DIFF
--- a/app/tests/integration/conftest.py
+++ b/app/tests/integration/conftest.py
@@ -51,6 +51,7 @@ def _verify_url(request, base_url):
 
 @pytest.fixture
 def fill_overview(selenium, base_url, ds_issue_host, request, variables):
+    """Fills overview page."""
     selenium.get(base_url)
     home = Home(selenium, base_url).wait_for_page_to_load()
     experiment = home.create_experiment()
@@ -78,6 +79,7 @@ def fill_overview(selenium, base_url, ds_issue_host, request, variables):
 
 @pytest.fixture
 def fill_timeline_page(selenium, base_url, request, variables, fill_overview):
+    """Fills timeline page."""
     experiment_type = getattr(request.module, "experiment_type", None)
     timeline = TimelineAndPopulationPage(
         selenium, base_url, experiment_url=f"{fill_overview.url}"
@@ -103,89 +105,92 @@ def fill_timeline_page(selenium, base_url, request, variables, fill_overview):
 
 @pytest.fixture
 def fill_design_page(selenium, base_url, request, variables, fill_overview):
+    """Fills design page according to default requirements."""
+    design = DesignPage(selenium, base_url, experiment_url=f"{fill_overview.url}").open()
+    design = design.wait_for_page_to_load()
+    design.input_firefox_pref_name("default_fixture")
+    design.select_firefox_pref_type("boolean")
+    design.select_firefox_pref_branch("default")
+    current_branchs = design.current_branches
+    control_branch = current_branchs[0]
+    control_branch.branch_name = "Fixture Branch"
+    control_branch.branch_description = "THIS IS A TEST"
+    control_branch.branch_value = "true"
+    current_branchs[1].branch_name = "Fixture Branch 2"
+    current_branchs[1].branch_description = "THIS IS A TEST"
+    current_branchs[1].branch_value = "false"
+    design.save_btn()
+    return design
+
+
+@pytest.fixture
+def fill_design_page_multi_prefs(selenium, base_url, request, variables, fill_overview):
+    """Fills design page according to multi pref requirements."""
     experiment_type = getattr(request.module, "experiment_type", None)
     design = DesignPage(selenium, base_url, experiment_url=f"{fill_overview.url}").open()
     design = design.wait_for_page_to_load()
-    if request.node.get_closest_marker("use_variables"):
-        # If using multi prefs, check and fill appropriately
-        if request.node.get_closest_marker("multi_prefs"):
-            design.enable_multipref()
-            branches = design.current_branches
-            for count, branch in enumerate(variables[experiment_type]["branches"]):
-                branches[count].branch_name = f"{branch['branch_name']}"
-                branches[count].branch_description = f"{branch['branch_description']}"
-                branches[count].add_pref_button.click()
-                prefs = branches[count].prefs(count)
-                for pref_num in range(
-                    0, len(branch["preferences"])
-                ):  # Fill in multi prefs
-                    prefs[
-                        pref_num
-                    ].pref_branch = (
-                        f"{branch['preferences'][pref_num]['firefox_pref_branch']}"
-                    )
-                    prefs[
-                        pref_num
-                    ].pref_type = (
-                        f"{branch['preferences'][pref_num]['firefox_pref_type']}"
-                    )
-                    prefs[
-                        pref_num
-                    ].pref_name = (
-                        f"{branch['preferences'][pref_num]['firefox_pref_name']}"
-                    )
-                    prefs[
-                        pref_num
-                    ].pref_value = (
-                        f"{branch['preferences'][pref_num]['firefox_pref_value']}"
-                    )
-        else:
-            design.input_firefox_pref_name(
-                f"{variables[experiment_type]['branches'][0]['firefox_pref_name']}"
-            )
-            design.select_firefox_pref_type(
-                f"{variables[experiment_type]['branches'][0]['firefox_pref_type']}"
-            )
-            design.select_firefox_pref_branch(
-                f"{variables[experiment_type]['branches'][0]['firefox_pref_branch']}"
-            )
-            current_branchs = design.current_branches
-            control_branch = current_branchs[0]
-            control_branch.branch_name = (
-                f"{variables[experiment_type]['branches'][0]['branch_name']}"
-            )
+    design.enable_multipref()
+    branches = design.current_branches
+    for count, branch in enumerate(variables[experiment_type]["branches"]):
+        branches[count].branch_name = f"{branch['branch_name']}"
+        branches[count].branch_description = f"{branch['branch_description']}"
+        branches[count].add_pref_button.click()
+        prefs = branches[count].prefs(count)
+        for pref_num in range(0, len(branch["preferences"])):  # Fill in multi prefs
+            prefs[
+                pref_num
+            ].pref_branch = f"{branch['preferences'][pref_num]['firefox_pref_branch']}"
+            prefs[
+                pref_num
+            ].pref_type = f"{branch['preferences'][pref_num]['firefox_pref_type']}"
+            prefs[
+                pref_num
+            ].pref_name = f"{branch['preferences'][pref_num]['firefox_pref_name']}"
+            prefs[
+                pref_num
+            ].pref_value = f"{branch['preferences'][pref_num]['firefox_pref_value']}"
+    design.save_btn()
+    return design
 
-            control_branch.branch_description = "THIS IS A TEST"
-            control_branch.branch_value = (
-                f"{variables[experiment_type]['branches'][0]['branch_value']}"
-            )
-            current_branchs[
-                1
-            ].branch_name = f"{variables[experiment_type]['branches'][1]['branch_name']}"
-            current_branchs[1].branch_description = "THIS IS A TEST"
-            current_branchs[
-                1
-            ].branch_value = (
-                f"{variables[experiment_type]['branches'][1]['branch_value']}"
-            )
-    else:
-        design.input_firefox_pref_name("default_fixture")
-        design.select_firefox_pref_type("boolean")
-        design.select_firefox_pref_branch("default")
-        current_branchs = design.current_branches
-        control_branch = current_branchs[0]
-        control_branch.branch_name = "Fixture Branch"
-        control_branch.branch_description = "THIS IS A TEST"
-        control_branch.branch_value = "true"
-        current_branchs[1].branch_name = "Fixture Branch 2"
-        current_branchs[1].branch_description = "THIS IS A TEST"
-        current_branchs[1].branch_value = "false"
+
+@pytest.fixture
+def fill_design_page_single_pref(selenium, base_url, request, variables, fill_overview):
+    """Fills design page according to single pref requirements."""
+    experiment_type = getattr(request.module, "experiment_type", None)
+    design = DesignPage(selenium, base_url, experiment_url=f"{fill_overview.url}").open()
+    design = design.wait_for_page_to_load()
+    design.input_firefox_pref_name(
+        f"{variables[experiment_type]['branches'][0]['firefox_pref_name']}"
+    )
+    design.select_firefox_pref_type(
+        f"{variables[experiment_type]['branches'][0]['firefox_pref_type']}"
+    )
+    design.select_firefox_pref_branch(
+        f"{variables[experiment_type]['branches'][0]['firefox_pref_branch']}"
+    )
+    current_branchs = design.current_branches
+    control_branch = current_branchs[0]
+    control_branch.branch_name = (
+        f"{variables[experiment_type]['branches'][0]['branch_name']}"
+    )
+    control_branch.branch_description = "THIS IS A TEST"
+    control_branch.branch_value = (
+        f"{variables[experiment_type]['branches'][0]['branch_value']}"
+    )
+    current_branchs[
+        1
+    ].branch_name = f"{variables[experiment_type]['branches'][1]['branch_name']}"
+    current_branchs[1].branch_description = "THIS IS A TEST"
+    current_branchs[
+        1
+    ].branch_value = f"{variables[experiment_type]['branches'][1]['branch_value']}"
     design.save_btn()
     return design
 
 
 @pytest.fixture
 def fill_analysis_page(selenium, base_url, request, variables, fill_overview):
+    """Fills analysis page."""
     analysis_page = ObjectiveAndAnalysisPage(
         selenium, base_url, experiment_url=f"{fill_overview.url}"
     ).open()
@@ -198,6 +203,7 @@ def fill_analysis_page(selenium, base_url, request, variables, fill_overview):
 
 @pytest.fixture
 def fill_risks_page(selenium, base_url, request, variables, fill_overview):
+    """Fills risks page."""
     from pages.experiment_risks_and_testing import RiskAndTestingPage
 
     risks_page = RiskAndTestingPage(
@@ -209,6 +215,22 @@ def fill_risks_page(selenium, base_url, request, variables, fill_overview):
     risks_page.qa_status_box = "Green"
     risks_page.save_btn()
     return risks_page
+
+
+@pytest.fixture
+def signoff_and_ship(selenium, base_url, fill_overview):
+    """"Fills signoffs and clicks 'Confirm ready to ship' button."""
+    detail_page = DetailPage(
+        selenium, base_url, experiment_url=f"{fill_overview.url}"
+    ).wait_for_page_to_load()
+    detail_page.begin_signoffs_button.click()
+    for checkbox in detail_page.required_checklist_section:
+        try:
+            checkbox.checkbox.click()
+        except Exception:
+            continue
+    detail_page.save_sign_offs_button.click()
+    detail_page.ready_to_ship_button.click()
 
 
 @pytest.fixture

--- a/app/tests/integration/conftest.py
+++ b/app/tests/integration/conftest.py
@@ -105,7 +105,7 @@ def fill_timeline_page(selenium, base_url, request, variables, fill_overview):
 
 @pytest.fixture
 def fill_design_page(selenium, base_url, request, variables, fill_overview):
-    """Fills design page according to default requirements."""
+    """Fills design page according to generic requirements."""
     design = DesignPage(selenium, base_url, experiment_url=f"{fill_overview.url}").open()
     design = design.wait_for_page_to_load()
     design.input_firefox_pref_name("default_fixture")

--- a/app/tests/integration/test_multi_pref_e2e.py
+++ b/app/tests/integration/test_multi_pref_e2e.py
@@ -10,7 +10,15 @@ experiment_type = "multi-pref-experiment"
 @pytest.mark.use_variables
 @pytest.mark.multi_prefs
 @pytest.mark.nondestructive
-def test_multi_pref_e2e(base_url, selenium, fill_experiment):
+def test_multi_pref_e2e(
+    base_url,
+    selenium,
+    fill_timeline_page,
+    fill_design_page_multi_prefs,
+    fill_analysis_page,
+    fill_risks_page,
+    signoff_and_ship,
+):
     url = urlparse(selenium.current_url)
     experiment_url = f"{url.scheme}://{url.netloc}/api/v1{url.path}recipe/"
     experiment_json = requests.get(f"{experiment_url}", verify=False).json()

--- a/app/tests/integration/test_single_pref_e2e.py
+++ b/app/tests/integration/test_single_pref_e2e.py
@@ -9,7 +9,15 @@ experiment_type = "single-pref-experiment"
 
 @pytest.mark.use_variables
 @pytest.mark.nondestructive
-def test_single_pref_e2e(base_url, selenium, fill_experiment):
+def test_single_pref_e2e(
+    base_url,
+    selenium,
+    fill_timeline_page,
+    fill_design_page_single_pref,
+    fill_analysis_page,
+    fill_risks_page,
+    signoff_and_ship,
+):
     url = urlparse(selenium.current_url)
     experiment_url = f"{url.scheme}://{url.netloc}/api/v1{url.path}recipe/"
     experiment_json = requests.get(f"{experiment_url}", verify=False).json()


### PR DESCRIPTION
Was adding some addon e2e tests and noticed this fixtures are getting very ugly and confusing. I split up the design page fixtures to be easier to read and use.