### PR TITLE
swap urlize and markdown template filter fixes #2637

### DIFF
--- a/app/experimenter/templates/experiments/section_analysis.html
+++ b/app/experimenter/templates/experiments/section_analysis.html
@@ -6,7 +6,7 @@ Analysis
 
 {% block section_content %}
   <div id="analysis-content">
-    {{ experiment.analysis|urlize|markdown }}
+    {{ experiment.analysis|markdown|urlize }}
   </div>
 
   {% if experiment.total_enrolled_clients %}
@@ -55,7 +55,7 @@ Analysis
 
     <p><strong>Survey Launch Instructions</strong></p>
     <div id="analysis-survey-launch-instructions">
-      {{ experiment.survey_instructions|urlize|markdown }}
+      {{ experiment.survey_instructions|markdown|urlize }}
     </div>
   {% endif %}
 

--- a/app/experimenter/templates/experiments/section_base.html
+++ b/app/experimenter/templates/experiments/section_base.html
@@ -54,7 +54,7 @@
                 {{ comment.created_by }}
                 <span class="text-muted">{{ comment.created_on }}</span>
               </a>
-              {{ comment.text|urlize|markdown }}
+              {{ comment.text|markdown|urlize }}
             </div>
           </div>
         {% endfor %}

--- a/app/experimenter/templates/experiments/section_design.html
+++ b/app/experimenter/templates/experiments/section_design.html
@@ -7,6 +7,6 @@ Design
 
 {% block section_content %}
   <p>
-    {{ experiment.design|urlize|markdown }}
+    {{ experiment.design|markdown|urlize }}
   </p>
 {% endblock %}

--- a/app/experimenter/templates/experiments/section_overview.html
+++ b/app/experimenter/templates/experiments/section_overview.html
@@ -6,7 +6,7 @@ Overview
 
 {% block section_content %}
   <p><strong>Description</strong></p>
-  {{ experiment.short_description|urlize|markdown }}
+  {{ experiment.short_description|markdown|urlize }}
 
   <p><strong>Delivery Owner</strong></p>
   <p>{{ experiment.owner }}</p>

--- a/app/experimenter/templates/experiments/section_results.html
+++ b/app/experimenter/templates/experiments/section_results.html
@@ -8,19 +8,19 @@ Results
 {% block section_content %}
   <p><strong>Primary Result URL: </strong></p>
   {% if experiment.results_url %}
-    <p>{{ experiment.results_url|urlize|markdown }}</p>
+    <p>{{ experiment.results_url|markdown|urlize }}</p>
   {% else %}
     <p><em class="text-secondary">Not Complete.</em></p>
   {% endif %}
   <p><strong>Initial Results: </strong></p>
   {% if experiment.results_initial %}
-    <p>{{ experiment.results_initial|urlize|markdown }}</p>
+    <p>{{ experiment.results_initial|markdown|urlize }}</p>
   {% else %}
     <p><em class="text-secondary">Not Complete.</em></p>
   {% endif %}
   <p><strong>Lessons Learned: </strong></p>
   {% if experiment.results_lessons_learned %}
-    <p>{{ experiment.results_lessons_learned|urlize|markdown }}</p>
+    <p>{{ experiment.results_lessons_learned|markdown|urlize }}</p>
   {% else %}
     <p><em class="text-secondary">Not Complete.</em></p>
   {% endif %}
@@ -38,7 +38,7 @@ Results
 
   {% if experiment.results_failures_notes %}
     <p><strong>Notes: </strong></p>
-    <p>{{ experiment.results_failures_notes|urlize|markdown }}</p>
+    <p>{{ experiment.results_failures_notes|markdown|urlize }}</p>
   {% endif %}
 
   <hr/>
@@ -52,6 +52,6 @@ Results
 
   {% if experiment.results_impact_notes %}
     <p><strong>Notes: </strong></p>
-    <p>{{ experiment.results_impact_notes|urlize|markdown }}</p>
+    <p>{{ experiment.results_impact_notes|markdown|urlize }}</p>
   {% endif %}
 {% endblock %}

--- a/app/experimenter/templates/experiments/section_risks.html
+++ b/app/experimenter/templates/experiments/section_risks.html
@@ -12,11 +12,11 @@
 
   {% if experiment.risk_technical %}
     <h5>Technical Risk/Complexity</h5>
-    {{ experiment.risk_technical_description|urlize|markdown }}
+    {{ experiment.risk_technical_description|markdown|urlize }}
   {% endif %}
 
   {% if experiment.is_high_risk %}
     <h5>Risk Details</h5>
-    {{ experiment.risks|urlize|markdown }}
+    {{ experiment.risks|markdown|urlize }}
   {% endif %}
 {% endblock %}

--- a/app/experimenter/templates/experiments/section_testing.html
+++ b/app/experimenter/templates/experiments/section_testing.html
@@ -8,14 +8,14 @@ Testing &amp; QA
 {% block section_content %}
   {% if experiment.testing %}
     <strong>Test Instructions</strong>
-    {{ experiment.testing|urlize|markdown }}
+    {{ experiment.testing|markdown|urlize }}
   {% endif %}
 
   {% if experiment.test_builds %}
     <strong>Test Builds</strong>
-    {{ experiment.test_builds|urlize|markdown }}
+    {{ experiment.test_builds|markdown|urlize }}
   {% endif %}
 
   <strong>QA Status</strong>
-  {{ experiment.qa_status|urlize|markdown }}
+  {{ experiment.qa_status|markdown|urlize }}
 {% endblock %}


### PR DESCRIPTION
<img width="377" alt="Screen Shot 2020-05-18 at 11 14 04 PM" src="https://user-images.githubusercontent.com/25379936/82291452-d43d0b00-995d-11ea-997c-687e86dc903c.png">

A semi fix.... multi-line code blocks unfortunately doesn't seem to work though....
