### PR TITLE
Export experiments to csv fixes #2634

### DIFF
--- a/app/experimenter/docs/openapi-schema.json
+++ b/app/experimenter/docs/openapi-schema.json
@@ -5,6 +5,158 @@
     "version": ""
   },
   "paths": {
+    "/api/v1/experiments/csv/": {
+      "get": {
+        "operationId": "listExperiments",
+        "description": "",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "text/csv": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "properties": {
+                      "name": {
+                        "type": "string",
+                        "maxLength": 255
+                      },
+                      "type": {
+                        "enum": [
+                          "pref",
+                          "addon",
+                          "generic",
+                          "rollout",
+                          "message"
+                        ]
+                      },
+                      "status": {
+                        "enum": [
+                          "Draft",
+                          "Review",
+                          "Ship",
+                          "Accepted",
+                          "Live",
+                          "Complete"
+                        ]
+                      },
+                      "experiment_url": {
+                        "type": "string",
+                        "readOnly": true
+                      },
+                      "public_name": {
+                        "type": "string",
+                        "nullable": true,
+                        "maxLength": 255
+                      },
+                      "public_description": {
+                        "type": "string",
+                        "nullable": true
+                      },
+                      "owner": {
+                        "type": "string",
+                        "readOnly": true
+                      },
+                      "analysis_owner": {
+                        "type": "string",
+                        "readOnly": true
+                      },
+                      "engineering_owner": {
+                        "type": "string",
+                        "nullable": true,
+                        "maxLength": 255
+                      },
+                      "short_description": {
+                        "type": "string",
+                        "nullable": true
+                      },
+                      "objectives": {
+                        "type": "string",
+                        "nullable": true
+                      },
+                      "parent": {
+                        "type": "string",
+                        "readOnly": true
+                      },
+                      "projects": {
+                        "type": "string",
+                        "readOnly": true
+                      },
+                      "data_science_issue_url": {
+                        "type": "string",
+                        "format": "uri",
+                        "nullable": true,
+                        "maxLength": 200,
+                        "pattern": "^(?:[a-z0-9\\.\\-\\+]*)://(?:[^\\s:@/]+(?::[^\\s:@/]*)?@)?(?:(?:25[0-5]|2[0-4]\\d|[0-1]?\\d?\\d)(?:\\.(?:25[0-5]|2[0-4]\\d|[0-1]?\\d?\\d)){3}|\\[[0-9a-f:\\.]+\\]|([a-z\u00a1-\uffff0-9](?:[a-z\u00a1-\uffff0-9-]{0,61}[a-z\u00a1-\uffff0-9])?(?:\\.(?!-)[a-z\u00a1-\uffff0-9-]{1,63}(?<!-))*\\.(?!-)(?:[a-z\u00a1-\uffff-]{2,63}|xn--[a-z0-9]{1,59})(?<!-)\\.?|localhost))(?::\\d{2,5})?(?:[/?#][^\\s]*)?\\Z"
+                      },
+                      "feature_bugzilla_url": {
+                        "type": "string",
+                        "format": "uri",
+                        "nullable": true,
+                        "maxLength": 200,
+                        "pattern": "^(?:[a-z0-9\\.\\-\\+]*)://(?:[^\\s:@/]+(?::[^\\s:@/]*)?@)?(?:(?:25[0-5]|2[0-4]\\d|[0-1]?\\d?\\d)(?:\\.(?:25[0-5]|2[0-4]\\d|[0-1]?\\d?\\d)){3}|\\[[0-9a-f:\\.]+\\]|([a-z\u00a1-\uffff0-9](?:[a-z\u00a1-\uffff0-9-]{0,61}[a-z\u00a1-\uffff0-9])?(?:\\.(?!-)[a-z\u00a1-\uffff0-9-]{1,63}(?<!-))*\\.(?!-)(?:[a-z\u00a1-\uffff-]{2,63}|xn--[a-z0-9]{1,59})(?<!-)\\.?|localhost))(?::\\d{2,5})?(?:[/?#][^\\s]*)?\\Z"
+                      },
+                      "firefox_channel": {
+                        "enum": [
+                          null,
+                          "Nightly",
+                          "Beta",
+                          "Release"
+                        ],
+                        "nullable": true
+                      },
+                      "normandy_slug": {
+                        "type": "string",
+                        "nullable": true,
+                        "maxLength": 255
+                      },
+                      "proposed_duration": {
+                        "type": "integer",
+                        "maximum": 1000,
+                        "nullable": true,
+                        "minimum": 0
+                      },
+                      "proposed_start_date": {
+                        "type": "string",
+                        "format": "date",
+                        "nullable": true
+                      },
+                      "related_to": {
+                        "type": "string",
+                        "readOnly": true
+                      },
+                      "related_work": {
+                        "type": "string",
+                        "nullable": true
+                      },
+                      "results_initial": {
+                        "type": "string",
+                        "nullable": true
+                      },
+                      "results_url": {
+                        "type": "string",
+                        "format": "uri",
+                        "nullable": true,
+                        "maxLength": 200,
+                        "pattern": "^(?:[a-z0-9\\.\\-\\+]*)://(?:[^\\s:@/]+(?::[^\\s:@/]*)?@)?(?:(?:25[0-5]|2[0-4]\\d|[0-1]?\\d?\\d)(?:\\.(?:25[0-5]|2[0-4]\\d|[0-1]?\\d?\\d)){3}|\\[[0-9a-f:\\.]+\\]|([a-z\u00a1-\uffff0-9](?:[a-z\u00a1-\uffff0-9-]{0,61}[a-z\u00a1-\uffff0-9])?(?:\\.(?!-)[a-z\u00a1-\uffff0-9-]{1,63}(?<!-))*\\.(?!-)(?:[a-z\u00a1-\uffff-]{2,63}|xn--[a-z0-9]{1,59})(?<!-)\\.?|localhost))(?::\\d{2,5})?(?:[/?#][^\\s]*)?\\Z"
+                      }
+                    },
+                    "required": [
+                      "name"
+                    ]
+                  }
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "tags": [
+          "public"
+        ]
+      }
+    },
     "/api/v1/experiments/{slug}/recipe/": {
       "get": {
         "operationId": "RetrieveExperiment",

--- a/app/experimenter/docs/swagger-ui.html
+++ b/app/experimenter/docs/swagger-ui.html
@@ -17,6 +17,158 @@
     "version": ""
   },
   "paths": {
+    "/api/v1/experiments/csv/": {
+      "get": {
+        "operationId": "listExperiments",
+        "description": "",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "text/csv": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "properties": {
+                      "name": {
+                        "type": "string",
+                        "maxLength": 255
+                      },
+                      "type": {
+                        "enum": [
+                          "pref",
+                          "addon",
+                          "generic",
+                          "rollout",
+                          "message"
+                        ]
+                      },
+                      "status": {
+                        "enum": [
+                          "Draft",
+                          "Review",
+                          "Ship",
+                          "Accepted",
+                          "Live",
+                          "Complete"
+                        ]
+                      },
+                      "experiment_url": {
+                        "type": "string",
+                        "readOnly": true
+                      },
+                      "public_name": {
+                        "type": "string",
+                        "nullable": true,
+                        "maxLength": 255
+                      },
+                      "public_description": {
+                        "type": "string",
+                        "nullable": true
+                      },
+                      "owner": {
+                        "type": "string",
+                        "readOnly": true
+                      },
+                      "analysis_owner": {
+                        "type": "string",
+                        "readOnly": true
+                      },
+                      "engineering_owner": {
+                        "type": "string",
+                        "nullable": true,
+                        "maxLength": 255
+                      },
+                      "short_description": {
+                        "type": "string",
+                        "nullable": true
+                      },
+                      "objectives": {
+                        "type": "string",
+                        "nullable": true
+                      },
+                      "parent": {
+                        "type": "string",
+                        "readOnly": true
+                      },
+                      "projects": {
+                        "type": "string",
+                        "readOnly": true
+                      },
+                      "data_science_issue_url": {
+                        "type": "string",
+                        "format": "uri",
+                        "nullable": true,
+                        "maxLength": 200,
+                        "pattern": "^(?:[a-z0-9\\.\\-\\+]*)://(?:[^\\s:@/]+(?::[^\\s:@/]*)?@)?(?:(?:25[0-5]|2[0-4]\\d|[0-1]?\\d?\\d)(?:\\.(?:25[0-5]|2[0-4]\\d|[0-1]?\\d?\\d)){3}|\\[[0-9a-f:\\.]+\\]|([a-z\u00a1-\uffff0-9](?:[a-z\u00a1-\uffff0-9-]{0,61}[a-z\u00a1-\uffff0-9])?(?:\\.(?!-)[a-z\u00a1-\uffff0-9-]{1,63}(?<!-))*\\.(?!-)(?:[a-z\u00a1-\uffff-]{2,63}|xn--[a-z0-9]{1,59})(?<!-)\\.?|localhost))(?::\\d{2,5})?(?:[/?#][^\\s]*)?\\Z"
+                      },
+                      "feature_bugzilla_url": {
+                        "type": "string",
+                        "format": "uri",
+                        "nullable": true,
+                        "maxLength": 200,
+                        "pattern": "^(?:[a-z0-9\\.\\-\\+]*)://(?:[^\\s:@/]+(?::[^\\s:@/]*)?@)?(?:(?:25[0-5]|2[0-4]\\d|[0-1]?\\d?\\d)(?:\\.(?:25[0-5]|2[0-4]\\d|[0-1]?\\d?\\d)){3}|\\[[0-9a-f:\\.]+\\]|([a-z\u00a1-\uffff0-9](?:[a-z\u00a1-\uffff0-9-]{0,61}[a-z\u00a1-\uffff0-9])?(?:\\.(?!-)[a-z\u00a1-\uffff0-9-]{1,63}(?<!-))*\\.(?!-)(?:[a-z\u00a1-\uffff-]{2,63}|xn--[a-z0-9]{1,59})(?<!-)\\.?|localhost))(?::\\d{2,5})?(?:[/?#][^\\s]*)?\\Z"
+                      },
+                      "firefox_channel": {
+                        "enum": [
+                          null,
+                          "Nightly",
+                          "Beta",
+                          "Release"
+                        ],
+                        "nullable": true
+                      },
+                      "normandy_slug": {
+                        "type": "string",
+                        "nullable": true,
+                        "maxLength": 255
+                      },
+                      "proposed_duration": {
+                        "type": "integer",
+                        "maximum": 1000,
+                        "nullable": true,
+                        "minimum": 0
+                      },
+                      "proposed_start_date": {
+                        "type": "string",
+                        "format": "date",
+                        "nullable": true
+                      },
+                      "related_to": {
+                        "type": "string",
+                        "readOnly": true
+                      },
+                      "related_work": {
+                        "type": "string",
+                        "nullable": true
+                      },
+                      "results_initial": {
+                        "type": "string",
+                        "nullable": true
+                      },
+                      "results_url": {
+                        "type": "string",
+                        "format": "uri",
+                        "nullable": true,
+                        "maxLength": 200,
+                        "pattern": "^(?:[a-z0-9\\.\\-\\+]*)://(?:[^\\s:@/]+(?::[^\\s:@/]*)?@)?(?:(?:25[0-5]|2[0-4]\\d|[0-1]?\\d?\\d)(?:\\.(?:25[0-5]|2[0-4]\\d|[0-1]?\\d?\\d)){3}|\\[[0-9a-f:\\.]+\\]|([a-z\u00a1-\uffff0-9](?:[a-z\u00a1-\uffff0-9-]{0,61}[a-z\u00a1-\uffff0-9])?(?:\\.(?!-)[a-z\u00a1-\uffff0-9-]{1,63}(?<!-))*\\.(?!-)(?:[a-z\u00a1-\uffff-]{2,63}|xn--[a-z0-9]{1,59})(?<!-)\\.?|localhost))(?::\\d{2,5})?(?:[/?#][^\\s]*)?\\Z"
+                      }
+                    },
+                    "required": [
+                      "name"
+                    ]
+                  }
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "tags": [
+          "public"
+        ]
+      }
+    },
     "/api/v1/experiments/{slug}/recipe/": {
       "get": {
         "operationId": "RetrieveExperiment",

--- a/app/experimenter/experiments/api_views.py
+++ b/app/experimenter/experiments/api_views.py
@@ -140,12 +140,14 @@ class ExperimentTimelinePopulationView(RetrieveUpdateAPIView):
 
 
 class ExperimentCSVListView(ListAPIView):
-    queryset = Experiment.objects.all()
+    queryset = Experiment.objects.order_by("status", "name")
     serializer_class = ExperimentCSVSerializer
     renderer_classes = (CSVRenderer,)
 
     def get_queryset(self):
-        return ExperimentFilterset(self.request.GET, super().get_queryset()).qs
+        return ExperimentFilterset(
+            self.request.GET, super().get_queryset(), request=self.request
+        ).qs
 
     def get_renderer_context(self):
         # Pass the ordered list of fields in to specify the ordering of the headers

--- a/app/experimenter/experiments/api_views.py
+++ b/app/experimenter/experiments/api_views.py
@@ -6,11 +6,15 @@ from rest_framework.generics import (
 )
 from rest_framework.response import Response
 from rest_framework import status
+from rest_framework_csv.renderers import CSVRenderer
 
 from experimenter.experiments.constants import ExperimentConstants
 from experimenter.experiments.models import Experiment
 from experimenter.experiments import email
-from experimenter.experiments.serializers.entities import ExperimentSerializer
+from experimenter.experiments.serializers.entities import (
+    ExperimentSerializer,
+    ExperimentCSVSerializer,
+)
 from experimenter.experiments.serializers.clone import ExperimentCloneSerializer
 from experimenter.experiments.serializers.design import (
     ExperimentDesignAddonRolloutSerializer,
@@ -26,6 +30,7 @@ from experimenter.experiments.serializers.timeline_population import (
     ExperimentTimelinePopSerializer,
 )
 from experimenter.experiments.serializers.recipe import ExperimentRecipeSerializer
+from experimenter.experiments.filtersets import ExperimentFilterset
 
 
 class ExperimentListView(ListAPIView):
@@ -132,3 +137,19 @@ class ExperimentTimelinePopulationView(RetrieveUpdateAPIView):
     lookup_field = "slug"
     queryset = Experiment.objects.all()
     serializer_class = ExperimentTimelinePopSerializer
+
+
+class ExperimentCSVListView(ListAPIView):
+    queryset = Experiment.objects.all()
+    serializer_class = ExperimentCSVSerializer
+    renderer_classes = (CSVRenderer,)
+
+    def get_queryset(self):
+        return ExperimentFilterset(self.request.GET, super().get_queryset()).qs
+
+    def get_renderer_context(self):
+        # Pass the ordered list of fields in to specify the ordering of the headers
+        # otherwise it defaults to sorting them alphabetically
+        context = super().get_renderer_context()
+        context["header"] = self.serializer_class.Meta.fields
+        return context

--- a/app/experimenter/experiments/public_api_urls.py
+++ b/app/experimenter/experiments/public_api_urls.py
@@ -1,6 +1,7 @@
 from django.conf.urls import url
 
 from experimenter.experiments.api_views import (
+    ExperimentCSVListView,
     ExperimentDetailView,
     ExperimentListView,
     ExperimentRecipeView,
@@ -8,6 +9,7 @@ from experimenter.experiments.api_views import (
 
 
 urlpatterns = [
+    url(r"^csv/$", ExperimentCSVListView.as_view(), name="experiments-api-csv",),
     url(
         r"^(?P<slug>[\w-]+)/recipe/$",
         ExperimentRecipeView.as_view(),

--- a/app/experimenter/experiments/serializers/entities.py
+++ b/app/experimenter/experiments/serializers/entities.py
@@ -258,3 +258,45 @@ class ExperimentSerializer(serializers.ModelSerializer):
 
     def get_results(self, obj):
         return ResultsSerializer(obj).data
+
+
+class ExperimentCSVSerializer(serializers.ModelSerializer):
+    analysis_owner = serializers.SlugRelatedField(read_only=True, slug_field="email")
+    owner = serializers.SlugRelatedField(read_only=True, slug_field="email")
+    parent = serializers.SlugRelatedField(read_only=True, slug_field="experiment_url")
+    projects = serializers.SerializerMethodField()
+    related_to = serializers.SerializerMethodField()
+
+    class Meta:
+        model = Experiment
+        fields = (
+            "name",
+            "type",
+            "status",
+            "experiment_url",
+            "public_name",
+            "public_description",
+            "owner",
+            "analysis_owner",
+            "engineering_owner",
+            "short_description",
+            "objectives",
+            "parent",
+            "projects",
+            "data_science_issue_url",
+            "feature_bugzilla_url",
+            "firefox_channel",
+            "normandy_slug",
+            "proposed_duration",
+            "proposed_start_date",
+            "related_to",
+            "related_work",
+            "results_initial",
+            "results_url",
+        )
+
+    def get_projects(self, obj):
+        return ", ".join([p.name for p in obj.projects.order_by("name")])
+
+    def get_related_to(self, obj):
+        return ", ".join([e.experiment_url for e in obj.related_to.order_by("slug")])

--- a/app/experimenter/experiments/tests/serializers/test_entities.py
+++ b/app/experimenter/experiments/tests/serializers/test_entities.py
@@ -15,10 +15,11 @@ from experimenter.experiments.tests.factories import (
 from experimenter.experiments.serializers.entities import (
     ChangeLogSerializer,
     ExperimentChangeLogSerializer,
+    ExperimentCSVSerializer,
+    ExperimentSerializer,
+    ExperimentVariantSerializer,
     JSTimestampField,
     PrefTypeField,
-    ExperimentVariantSerializer,
-    ExperimentSerializer,
 )
 
 from experimenter.experiments.serializers.recipe import ExperimentRecipeVariantSerializer
@@ -336,3 +337,51 @@ class TestChangeLogSerializer(TestCase):
         self.assertEqual(set(serializer.data.keys()), set(expected_data.keys()))
 
         self.assertEqual(serializer.data, expected_data)
+
+
+class TestExperimentCSVSerializer(TestCase):
+    def test_serializer_outputs_expected_schema(self):
+        project1 = ProjectFactory.create(name="a")
+        project2 = ProjectFactory.create(name="b")
+        parent = ExperimentFactory.create()
+        related_experiment1 = ExperimentFactory.create(slug="a")
+        related_experiment2 = ExperimentFactory.create(slug="b")
+        experiment = ExperimentFactory.create(
+            proposed_start_date=datetime.date(2020, 1, 1),
+            parent=parent,
+            projects=[project1, project2],
+        )
+        experiment.related_to.add(related_experiment1, related_experiment2)
+
+        serializer = ExperimentCSVSerializer(experiment)
+        self.assertDictEqual(
+            serializer.data,
+            {
+                "name": experiment.name,
+                "type": experiment.type,
+                "status": experiment.status,
+                "experiment_url": experiment.experiment_url,
+                "public_name": experiment.public_name,
+                "public_description": experiment.public_description,
+                "owner": experiment.owner.email,
+                "analysis_owner": experiment.analysis_owner.email,
+                "engineering_owner": experiment.engineering_owner,
+                "short_description": experiment.short_description,
+                "objectives": experiment.objectives,
+                "parent": experiment.parent.experiment_url,
+                "projects": f"{project1.name}, {project2.name}",
+                "data_science_issue_url": experiment.data_science_issue_url,
+                "feature_bugzilla_url": experiment.feature_bugzilla_url,
+                "firefox_channel": experiment.firefox_channel,
+                "normandy_slug": experiment.normandy_slug,
+                "proposed_duration": experiment.proposed_duration,
+                "proposed_start_date": "2020-01-01",
+                "related_to": (
+                    f"{related_experiment1.experiment_url}, "
+                    f"{related_experiment2.experiment_url}"
+                ),
+                "related_work": experiment.related_work,
+                "results_initial": experiment.results_initial,
+                "results_url": experiment.results_url,
+            },
+        )

--- a/app/experimenter/experiments/tests/test_api_views.py
+++ b/app/experimenter/experiments/tests/test_api_views.py
@@ -5,10 +5,14 @@ from django.core import mail
 from django.test import TestCase
 from django.urls import reverse
 from parameterized import parameterized
+from rest_framework_csv.renderers import CSVRenderer
 
 from experimenter.experiments.constants import ExperimentConstants
 from experimenter.experiments.models import Experiment
-from experimenter.experiments.serializers.entities import ExperimentSerializer
+from experimenter.experiments.serializers.entities import (
+    ExperimentSerializer,
+    ExperimentCSVSerializer,
+)
 from experimenter.experiments.serializers.recipe import ExperimentRecipeSerializer
 from experimenter.experiments.serializers.design import (
     ExperimentDesignAddonSerializer,
@@ -23,6 +27,7 @@ from experimenter.experiments.serializers.timeline_population import (
 from experimenter.experiments.tests.factories import (
     ExperimentFactory,
     ExperimentVariantFactory,
+    ProjectFactory,
     VariantPreferencesFactory,
 )
 
@@ -712,3 +717,44 @@ class TestExperimentTimelinePopulationView(TestCase):
         )
 
         self.assertEqual(response.status_code, 200)
+
+
+class TestExperimentCSVListView(TestCase):
+    def test_get_returns_csv_info(self):
+        user_email = "user@example.com"
+        experiment1 = ExperimentFactory.create_with_variants()
+        experiment2 = ExperimentFactory.create_with_variants()
+
+        response = self.client.get(
+            reverse("experiments-api-csv"), **{settings.OPENIDC_EMAIL_HEADER: user_email},
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+        csv_data = response.content
+        expected_csv_data = CSVRenderer().render(
+            ExperimentCSVSerializer([experiment1, experiment2], many=True).data,
+            renderer_context={"header": ExperimentCSVSerializer.Meta.fields},
+        )
+        self.assertEqual(csv_data, expected_csv_data)
+
+    def test_view_filters_by_project(self):
+        user_email = "user@example.com"
+        project = ProjectFactory.create()
+        experiment1 = ExperimentFactory.create_with_variants(projects=[project])
+        experiment2 = ExperimentFactory.create_with_variants(projects=[project])
+        ExperimentFactory.create_with_variants()
+
+        url = reverse("experiments-api-csv")
+        response = self.client.get(
+            f"{url}?projects={project.id}", **{settings.OPENIDC_EMAIL_HEADER: user_email}
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+        csv_data = response.content
+        expected_csv_data = CSVRenderer().render(
+            ExperimentCSVSerializer([experiment1, experiment2], many=True).data,
+            renderer_context={"header": ExperimentCSVSerializer.Meta.fields},
+        )
+        self.assertEqual(csv_data, expected_csv_data)

--- a/app/experimenter/experiments/tests/test_api_views.py
+++ b/app/experimenter/experiments/tests/test_api_views.py
@@ -9,6 +9,7 @@ from rest_framework_csv.renderers import CSVRenderer
 
 from experimenter.experiments.constants import ExperimentConstants
 from experimenter.experiments.models import Experiment
+from experimenter.openidc.tests.factories import UserFactory
 from experimenter.experiments.serializers.entities import (
     ExperimentSerializer,
     ExperimentCSVSerializer,
@@ -722,8 +723,12 @@ class TestExperimentTimelinePopulationView(TestCase):
 class TestExperimentCSVListView(TestCase):
     def test_get_returns_csv_info(self):
         user_email = "user@example.com"
-        experiment1 = ExperimentFactory.create_with_variants()
-        experiment2 = ExperimentFactory.create_with_variants()
+        experiment1 = ExperimentFactory.create_with_status(
+            Experiment.STATUS_DRAFT, name="a"
+        )
+        experiment2 = ExperimentFactory.create_with_status(
+            Experiment.STATUS_DRAFT, name="b"
+        )
 
         response = self.client.get(
             reverse("experiments-api-csv"), **{settings.OPENIDC_EMAIL_HEADER: user_email},
@@ -741,13 +746,43 @@ class TestExperimentCSVListView(TestCase):
     def test_view_filters_by_project(self):
         user_email = "user@example.com"
         project = ProjectFactory.create()
-        experiment1 = ExperimentFactory.create_with_variants(projects=[project])
-        experiment2 = ExperimentFactory.create_with_variants(projects=[project])
+        experiment1 = ExperimentFactory.create_with_status(
+            Experiment.STATUS_DRAFT, name="a", projects=[project]
+        )
+        experiment2 = ExperimentFactory.create_with_status(
+            Experiment.STATUS_DRAFT, name="b", projects=[project]
+        )
         ExperimentFactory.create_with_variants()
 
         url = reverse("experiments-api-csv")
         response = self.client.get(
             f"{url}?projects={project.id}", **{settings.OPENIDC_EMAIL_HEADER: user_email}
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+        csv_data = response.content
+        expected_csv_data = CSVRenderer().render(
+            ExperimentCSVSerializer([experiment1, experiment2], many=True).data,
+            renderer_context={"header": ExperimentCSVSerializer.Meta.fields},
+        )
+        self.assertEqual(csv_data, expected_csv_data)
+
+    def test_view_filters_by_subscriber(self):
+        user = UserFactory(email="user@example.com")
+        experiment1 = ExperimentFactory.create_with_status(
+            Experiment.STATUS_DRAFT, name="a"
+        )
+        experiment1.subscribers.add(user)
+        experiment2 = ExperimentFactory.create_with_status(
+            Experiment.STATUS_DRAFT, name="b"
+        )
+        experiment2.subscribers.add(user)
+        ExperimentFactory.create_with_variants()
+
+        url = reverse("experiments-api-csv")
+        response = self.client.get(
+            f"{url}?subscribed=on", **{settings.OPENIDC_EMAIL_HEADER: user.email}
         )
 
         self.assertEqual(response.status_code, 200)

--- a/app/experimenter/templates/experiments/list.html
+++ b/app/experimenter/templates/experiments/list.html
@@ -63,6 +63,7 @@
       <small class="text-muted">Page {{ page_obj.number }}</small>
     {% endif %}
   </h3>
+  <a href="{% url "experiments-api-csv" %}?{{ request.GET.urlencode }}"><i class="fas fa-file-csv"></i> Export as CSV</a>
 {% endblock %}
 
 {% block header_sidebar %}

--- a/app/pytest.ini
+++ b/app/pytest.ini
@@ -2,6 +2,6 @@
 [pytest]
 DJANGO_SETTINGS_MODULE = experimenter.settings
 # -- recommended but optional:
-addopts = -vvvv --ignore=tests/integration --show-capture=no --disable-warnings -n 4 
+addopts = -vvvv --ignore=tests/integration --show-capture=no --disable-warnings -n 4
 python_files = tests.py test_*.py *_tests.py
 norecursedirs = .cache .pytest_cache .vscode bin fixtures node_modules requirements static served

--- a/app/requirements/default.txt
+++ b/app/requirements/default.txt
@@ -153,3 +153,7 @@ tblib==1.6.0 \
 pytest-xdist==1.31.0 \
     --hash=sha256:0f46020d3d9619e6d17a65b5b989c1ebbb58fc7b1da8fb126d70f4bac4dfeed1 \
     --hash=sha256:7dc0d027d258cd0defc618fb97055fbd1002735ca7a6d17037018cf870e24011
+djangorestframework-csv==2.1.0 \
+    --hash=sha256:2f008b20a44f2d3c37835ea5b5ddfe19f54394f07b9cb267c616a917a7f7e27c
+unicodecsv==0.14.1 \
+    --hash=sha256:018c08037d48649a0412063ff4eda26eaa81eff1546dbffa51fa5293276ff7fc


### PR DESCRIPTION
This introduces the ability to export experiments to CSV for use in status reports, etc.

The workflow is

1) Land on list page
2) Use the filters on the right to filter for whatever you want
3) Click the 'Export to CSV' link at the top left
4) Receive CSV!

<img width="405" alt="Screenshot 2020-05-25 18 16 35" src="https://user-images.githubusercontent.com/119884/82845863-3218a800-9eb4-11ea-9b89-d3f4ca2545e7.png">
