### PR TITLE
Add rapid experiment base template fixes #2685

### DIFF
--- a/app/experimenter/base/context_processors.py
+++ b/app/experimenter/base/context_processors.py
@@ -5,3 +5,7 @@ def google_analytics(request):
     """Context processor bits you need related to injecting Google Analytics
     in the rendered templates."""
     return {"USE_GOOGLE_ANALYTICS": settings.USE_GOOGLE_ANALYTICS}
+
+
+def features(request):
+    return {"FEATURE_MESSAGE_TYPE": settings.FEATURE_MESSAGE_TYPE}

--- a/app/experimenter/experiments/tests/test_views.py
+++ b/app/experimenter/experiments/tests/test_views.py
@@ -808,3 +808,12 @@ class TestExperimentNormandyUpdateView(TestCase):
             f"&other_normandy_ids={other_normandy_ids}",
             fetch_redirect_response=False,
         )
+
+
+class TestExperimentRapidView(TestCase):
+    def test_page_loads(self):
+        user_email = "user@example.com"
+        response = self.client.get(
+            reverse("experiments-rapid"), **{settings.OPENIDC_EMAIL_HEADER: user_email},
+        )
+        self.assertEqual(response.status_code, 200)

--- a/app/experimenter/experiments/views.py
+++ b/app/experimenter/experiments/views.py
@@ -2,7 +2,7 @@ import json
 from django.conf import settings
 from django.shortcuts import redirect
 from django.urls import reverse
-from django.views.generic import CreateView, DetailView, UpdateView
+from django.views.generic import CreateView, DetailView, UpdateView, TemplateView
 from django.views.generic.edit import ModelFormMixin
 from django_filters.views import FilterView
 
@@ -227,3 +227,7 @@ class ExperimentCommentCreateView(ExperimentFormMixin, CreateView):
         return redirect(
             reverse("experiments-detail", kwargs={"slug": self.kwargs["slug"]})
         )
+
+
+class ExperimentRapidView(TemplateView):
+    template_name = "experiments/rapid.html"

--- a/app/experimenter/experiments/web_urls.py
+++ b/app/experimenter/experiments/web_urls.py
@@ -4,21 +4,23 @@ from experimenter.experiments.views import (
     ExperimentArchiveUpdateView,
     ExperimentCommentCreateView,
     ExperimentCreateView,
+    ExperimentDesignUpdateView,
     ExperimentDetailView,
     ExperimentNormandyUpdateView,
     ExperimentObjectivesUpdateView,
     ExperimentOverviewUpdateView,
+    ExperimentRapidView,
+    ExperimentResultsUpdateView,
     ExperimentReviewUpdateView,
     ExperimentRisksUpdateView,
     ExperimentStatusUpdateView,
     ExperimentSubscribedUpdateView,
-    ExperimentDesignUpdateView,
-    ExperimentResultsUpdateView,
     ExperimentTimelinePopulationUpdateView,
 )
 
 
 urlpatterns = [
+    re_path(r"^rapid/$", ExperimentRapidView.as_view(), name="experiments-rapid"),
     re_path(r"^new/$", ExperimentCreateView.as_view(), name="experiments-create"),
     re_path(
         r"^(?P<slug>[\w-]+)/edit/$",

--- a/app/experimenter/settings.py
+++ b/app/experimenter/settings.py
@@ -92,6 +92,7 @@ TEMPLATES = [
                 "django.contrib.auth.context_processors.auth",
                 "django.contrib.messages.context_processors.messages",
                 "experimenter.base.context_processors.google_analytics",
+                "experimenter.base.context_processors.features",
             ],
             "debug": DEBUG,
         },
@@ -343,3 +344,6 @@ SECURE_REFERRER_POLICY = config("SECURE_REFERRER_POLICY", default="origin")
 
 # Silenced ssl_redirect and sts checks
 SILENCED_SYSTEM_CHECKS = ["security.W008", "security.W004"]
+
+# Feature Flags
+FEATURE_MESSAGE_TYPE = config("FEATURE_MESSAGE_TYPE", default=False, cast=bool)

--- a/app/experimenter/templates/base.html
+++ b/app/experimenter/templates/base.html
@@ -29,7 +29,6 @@
 </head>
 
 <body class="{% block page_id %}{% endblock %}" data-ndt="experimenter">
-
   <div class="bg-primary text-white">
     <div class="container">
       <div class="row py-3">
@@ -65,7 +64,6 @@
             <span class="fas fa-user"></span>
             {{ request.user }}
           </div>
-
           <div>
             <a class="nocolorstyle d-block" href="{% url "home" %}?owner={{ request.user.id }}&amp;archived=on">
               {{ request.user.owned_experiments.count }} Owned

--- a/app/experimenter/templates/experiments/list.html
+++ b/app/experimenter/templates/experiments/list.html
@@ -74,6 +74,17 @@
       </a>
     </div>
   </div>
+
+  {% if FEATURE_MESSAGE_TYPE %}
+    <div class="row mt-2">
+      <div class="col">
+        <a class="col btn btn-outline-primary" href="{% url "experiments-rapid" %}">
+          <span class="fas fa-shipping-fast"></span>
+          Create Rapid Experiment
+        </a>
+      </div>
+    </div>
+  {% endif %}
 {% endblock %}
 
 {% block main_content %}

--- a/app/experimenter/templates/experiments/rapid.html
+++ b/app/experimenter/templates/experiments/rapid.html
@@ -1,0 +1,8 @@
+{% extends "base.html" %}
+
+{% block main %}
+Rapid Experiments
+{% endblock %}
+
+{% block extrascripts %}
+{% endblock %}


### PR DESCRIPTION
This introduces a new view and base template for the new rapid experimentation type.  I hid it behind the old `FEATURE_MESSAGE_TYPE` flag because that's already set on `stage=True` and `prod=False`.  Next we'll add the React skeleton to this.