### PR TITLE
css to stop pref table overflow fixes #2701

### DIFF
--- a/app/experimenter/static/css/experimenter.css
+++ b/app/experimenter/static/css/experimenter.css
@@ -1,5 +1,5 @@
 :root {
-  --font-family-sans-serif: 'Fira Sans', sans-serif;
+  --font-family-sans-serif: "Fira Sans", sans-serif;
 }
 
 html {
@@ -7,9 +7,9 @@ html {
 }
 
 body {
-  background-color: #F8F8F8;
+  background-color: #f8f8f8;
   color: #212121;
-  font-family: 'Fira Sans', sans-serif;
+  font-family: "Fira Sans", sans-serif;
 }
 
 btn {
@@ -21,7 +21,7 @@ p {
 }
 
 a.nocolorstyle {
-	color: inherit;
+  color: inherit;
 }
 
 a.noanchorstyle {
@@ -68,11 +68,11 @@ select {
 }
 
 .card {
-  transition: box-shadow ease-in-out .1s;
+  transition: box-shadow ease-in-out 0.1s;
 }
 
 .hovershadow:hover > .card {
-    box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.2);
+  box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.2);
 }
 
 .section-anchor-link {
@@ -85,7 +85,7 @@ select {
 }
 
 .heavy-line {
-   border: 0;
+  border: 0;
   height: 1px;
   background: #333;
   background-image: linear-gradient(to right, #ccc, #333, #ccc);
@@ -132,18 +132,18 @@ select {
   background-color: #e9433e;
 }
 
-.enrollment-complete-color{
+.enrollment-complete-color {
   color: white;
   background-color: #457b27;
 }
 
-.proceed-status-color{
+.proceed-status-color {
   color: white;
   background-color: #00cc00;
 }
 
-.back-status-color{
-  color:white;
+.back-status-color {
+  color: white;
   background-color: #ee9a49;
 }
 .subscribe-bell {
@@ -162,19 +162,19 @@ select {
 }
 
 .border-left-grey {
-	border-left: 3px solid #ccc;
+  border-left: 3px solid #ccc;
 }
 
 .border-bottom-grey {
-	border-bottom: 3px solid #ccc;
+  border-bottom: 3px solid #ccc;
 }
 
 .border-bottom-blue {
-	border-bottom: 3px solid #45a1ff;
+  border-bottom: 3px solid #45a1ff;
 }
 
 .border-bottom-green {
-	border-bottom: 3px solid #30e60b;
+  border-bottom: 3px solid #30e60b;
 }
 
 .border-bottom-teal {
@@ -183,31 +183,41 @@ select {
 
 .bubble {
   border-radius: 4px;
-	background-color: #F3F3F3;
+  background-color: #f3f3f3;
+}
+
+.pref-table {
+  width: 100%;
+  table-layout: fixed;
+}
+
+.pref-value-cell {
+  white-space: pre-wrap;
+  word-wrap: break-word;
 }
 
 pre.json {
-	overflow-x: auto;
-	white-space: pre-wrap;
-	white-space: -moz-pre-wrap;
-	white-space: -pre-wrap;
-	white-space: -o-pre-wrap;
-	word-wrap: break-word;
+  overflow-x: auto;
+  white-space: pre-wrap;
+  white-space: -moz-pre-wrap;
+  white-space: -pre-wrap;
+  white-space: -o-pre-wrap;
+  word-wrap: break-word;
   line-height: 2em;
   border: none !important;
 }
 
 .list-summary:before {
-  content:'';
-  width:100%;
-  height:100%;
-  position:absolute;
-  left:0;
-  top:0;
-  background:linear-gradient(transparent 12em, white);
+  content: "";
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  left: 0;
+  top: 0;
+  background: linear-gradient(transparent 12em, white);
 }
 
-.list-summary{
+.list-summary {
   overflow: hidden;
   max-height: 15em;
 }

--- a/app/experimenter/templates/experiments/section_branches.html
+++ b/app/experimenter/templates/experiments/section_branches.html
@@ -20,7 +20,7 @@
       <h5>{{ variant.ratio }}% {{ variant.name }}</h5>
       {% if experiment.is_pref_experiment %}
         <p><strong>Prefs:</strong></p>
-        <table class="table table-bordered">
+        <table class="table table-bordered pref-table">
         <thead>
           <tr>
             <th scope="col">Name</th>
@@ -39,7 +39,7 @@
             {% if preference.is_json_string_type %}
               <pre class="text-info">{{ preference.pref_value|as_json }}</pre>  
             {% else %}
-              <pre class="text-info">{{ preference.pref_value }}</pre>
+              <pre class="text-info pref-value-cell">{{ preference.pref_value }}</pre>
             {% endif %}
           </td>
             <td>{{ preference.pref_type }}</td>
@@ -56,7 +56,7 @@
               {% if experiment.is_pref_value_json_string %}
               <pre class="text-info">{{ variant.value|as_json }}</pre>
               {% else %}
-              <pre class="text-info">{{ variant.value }}</pre>
+              <pre class="text-info pref-value-cell">{{ variant.value }}</pre>
               {% endif %}
             </td>
             <td>{{ experiment.pref_type }}</td>

--- a/app/experimenter/templates/experiments/section_rollout.html
+++ b/app/experimenter/templates/experiments/section_rollout.html
@@ -11,7 +11,7 @@
   <p>{{ experiment.design|urlize|linebreaks }}</p>
   {% if experiment.is_pref_rollout %}
   <p><strong>Prefs:</strong></p>
-  <table class="table table-bordered">
+  <table class="table table-bordered pref-table">
   <thead>
     <tr>
       <th scope="col">Name</th>
@@ -24,7 +24,7 @@
     <tr>
       <td>{{ preference.pref_name }}</td>
       {% if preference.is_json_string_type %}
-        <td><pre class="text-info">{{ preference.pref_value|as_json }}</pre></td>
+        <td><pre class="text-info pref-value-cell">{{ preference.pref_value|as_json }}</pre></td>
       {% else %}
         <td><pre class="text-info">{{ preference.pref_value }}</pre></td>
       {% endif %}


### PR DESCRIPTION
<img width="799" alt="Screen Shot 2020-05-29 at 10 34 00 AM" src="https://user-images.githubusercontent.com/25379936/83289502-ff173280-a199-11ea-94ed-56575a36ff85.png">

It was bothering me.... 
As an aside note, this doesn't format json nicely, but ideally users should select "json string" for json strings...