### PR TITLE
Add push to kinto task fixes #2801

### DIFF
--- a/app/experimenter/kinto/__init__.py
+++ b/app/experimenter/kinto/__init__.py
@@ -1,1 +1,0 @@
-from experimenter.bugzilla.client import *  # noqa

--- a/app/experimenter/kinto/__init__.py
+++ b/app/experimenter/kinto/__init__.py
@@ -1,0 +1,1 @@
+from experimenter.bugzilla.client import *  # noqa

--- a/app/experimenter/kinto/client.py
+++ b/app/experimenter/kinto/client.py
@@ -1,0 +1,19 @@
+import kinto_http
+from django.conf import settings
+
+
+def push_to_kinto(data):
+    client = kinto_http.Client(
+        server_url=settings.KINTO_HOST, auth=(settings.KINTO_USER, settings.KINTO_PASS),
+    )
+    client.create_record(
+        data=data,
+        collection=settings.KINTO_COLLECTION,
+        bucket=settings.KINTO_BUCKET,
+        if_not_exists=True,
+    )
+    client.patch_collection(
+        id=settings.KINTO_COLLECTION,
+        data={"status": "to-review"},
+        bucket=settings.KINTO_BUCKET,
+    )

--- a/app/experimenter/kinto/tasks.py
+++ b/app/experimenter/kinto/tasks.py
@@ -1,0 +1,29 @@
+import markus
+from celery.utils.log import get_task_logger
+
+from experimenter.celery import app
+from experimenter.experiments.models import Experiment
+from experimenter.kinto import client
+
+
+logger = get_task_logger(__name__)
+metrics = markus.get_metrics("kinto.tasks")
+
+
+@app.task
+@metrics.timer_decorator("push_experiment_to_kinto.timing")
+def push_experiment_to_kinto(experiment_id):
+    metrics.incr("push_experiment_to_kinto.started")
+
+    experiment = Experiment.objects.get(id=experiment_id)
+    logger.info(f"Pushing {experiment} to Kinto")
+
+    try:
+        client.push_to_kinto({"slug": experiment.slug})
+
+        logger.info(f"{experiment} pushed to Kinto")
+        metrics.incr("push_experiment_to_kinto.completed")
+    except Exception as e:
+        metrics.incr("push_experiment_to_kinto.failed")
+        logger.info("Pushing {")
+        raise e

--- a/app/experimenter/kinto/tasks.py
+++ b/app/experimenter/kinto/tasks.py
@@ -25,5 +25,5 @@ def push_experiment_to_kinto(experiment_id):
         metrics.incr("push_experiment_to_kinto.completed")
     except Exception as e:
         metrics.incr("push_experiment_to_kinto.failed")
-        logger.info("Pushing {")
+        logger.info(f"Pushing {experiment} to Kinto failed: {e}")
         raise e

--- a/app/experimenter/kinto/tests/mixins.py
+++ b/app/experimenter/kinto/tests/mixins.py
@@ -1,0 +1,14 @@
+import mock
+
+
+class MockKintoClientMixin(object):
+    def setUp(self):
+        super().setUp()
+
+        mock_kinto_client_patcher = mock.patch(
+            "experimenter.kinto.client.kinto_http.Client"
+        )
+        self.mock_kinto_client_creator = mock_kinto_client_patcher.start()
+        self.mock_kinto_client = mock.Mock()
+        self.mock_kinto_client_creator.return_value = self.mock_kinto_client
+        self.addCleanup(mock_kinto_client_patcher.stop)

--- a/app/experimenter/kinto/tests/test_client.py
+++ b/app/experimenter/kinto/tests/test_client.py
@@ -1,0 +1,28 @@
+from django.test import TestCase
+from django.conf import settings
+
+from experimenter.kinto import client
+from experimenter.kinto.tests.mixins import MockKintoClientMixin
+
+
+class TestPushToKinto(MockKintoClientMixin, TestCase):
+    def test_push_to_kinto_sends_data_updates_collection(self):
+        client.push_to_kinto({"test": "data"})
+
+        self.mock_kinto_client_creator.assert_called_with(
+            server_url=settings.KINTO_HOST,
+            auth=(settings.KINTO_USER, settings.KINTO_PASS),
+        )
+
+        self.mock_kinto_client.create_record.assert_called_with(
+            data={"test": "data"},
+            collection=settings.KINTO_COLLECTION,
+            bucket=settings.KINTO_BUCKET,
+            if_not_exists=True,
+        )
+
+        self.mock_kinto_client.patch_collection.assert_called_with(
+            id=settings.KINTO_COLLECTION,
+            data={"status": "to-review"},
+            bucket=settings.KINTO_BUCKET,
+        )

--- a/app/experimenter/kinto/tests/test_tasks.py
+++ b/app/experimenter/kinto/tests/test_tasks.py
@@ -1,0 +1,29 @@
+from django.conf import settings
+from django.test import TestCase
+
+from experimenter.experiments.models import Experiment
+from experimenter.experiments.tests.factories import ExperimentFactory
+from experimenter.kinto.tests.mixins import MockKintoClientMixin
+from experimenter.kinto import tasks
+
+
+class TestPushExperimentToKintoTask(MockKintoClientMixin, TestCase):
+    def setUp(self):
+        super().setUp()
+        self.experiment = ExperimentFactory.create_with_status(Experiment.STATUS_DRAFT)
+
+    def test_push_experiment_to_kinto_sends_experiment_data(self):
+        tasks.push_experiment_to_kinto(self.experiment.id)
+
+        self.mock_kinto_client.create_record.assert_called_with(
+            data={"slug": self.experiment.slug},
+            collection=settings.KINTO_COLLECTION,
+            bucket=settings.KINTO_BUCKET,
+            if_not_exists=True,
+        )
+
+    def test_push_experiment_to_kinto_reraises_exception(self):
+        self.mock_kinto_client.create_record.side_effect = Exception
+
+        with self.assertRaises(Exception):
+            tasks.push_experiment_to_kinto(self.experiment.id)

--- a/app/experimenter/settings.py
+++ b/app/experimenter/settings.py
@@ -45,24 +45,28 @@ SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
 # Application definition
 
 INSTALLED_APPS = [
+    # Django
     "django.contrib.admin",
     "django.contrib.auth",
     "django.contrib.contenttypes",
-    "django.contrib.sessions",
     "django.contrib.messages",
+    "django.contrib.sessions",
     "django.contrib.staticfiles",
     "django.forms",
+    # Libraries
     "corsheaders",
+    "django_markdown2",
     "raven.contrib.django.raven_compat",
     "rest_framework",
     "widget_tweaks",
+    # Experimenter
     "experimenter.base",
     "experimenter.experiments",
+    "experimenter.kinto",
+    "experimenter.normandy",
     "experimenter.notifications",
     "experimenter.openidc",
     "experimenter.projects",
-    "experimenter.normandy",
-    "django_markdown2",
 ]
 
 MIDDLEWARE = [
@@ -351,3 +355,10 @@ SILENCED_SYSTEM_CHECKS = ["security.W008", "security.W004"]
 
 # Feature Flags
 FEATURE_MESSAGE_TYPE = config("FEATURE_MESSAGE_TYPE", default=False, cast=bool)
+
+# Kinto settings
+KINTO_HOST = config("KINTO_HOST")
+KINTO_USER = config("KINTO_USER")
+KINTO_PASS = config("KINTO_PASS")
+KINTO_BUCKET = config("KINTO_BUCKET")
+KINTO_COLLECTION = config("KINTO_COLLECTION")


### PR DESCRIPTION
This adds a kinto client call to push data to a collection and mark it for review, and wraps that in a celery task.  Right now I just set it to send a dummy payload with the slug, that'll be replaced by the full JSON of the A/A recipe after we do https://github.com/mozilla/experimenter/issues/2688