### PR TITLE
Change dependabot to PR against dependencies branch fixes #2944

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,13 +5,16 @@ updates:
   schedule:
     interval: weekly
   open-pull-requests-limit: 99
+  target_branch: dependencies
 - package-ecosystem: npm
   directory: "/app/experimenter/static/core"
   schedule:
     interval: weekly
   open-pull-requests-limit: 99
+  target_branch: dependencies
 - package-ecosystem: pip
   directory: "/app/requirements"
   schedule:
     interval: weekly
   open-pull-requests-limit: 99
+  target_branch: dependencies


### PR DESCRIPTION
I hav ea theory that if we have dependabot pr against this branch, disable CI checks against this branch so we can merge all PRs instantly, then create a single PR from that branch onto master we can get rid of this dependabot infinite pr hell.