### PR TITLE
Rapid exp title changes dependent on new or edit fixes #2901

### DIFF
--- a/app/experimenter/static/rapid/__tests__/app.test.tsx
+++ b/app/experimenter/static/rapid/__tests__/app.test.tsx
@@ -25,7 +25,7 @@ describe("<App />", () => {
     const { getByText } = renderWithRouter(<App />, {
       route: "/new/",
     });
-    expect(getByText("Create a New A/A Experiment")).toBeInTheDocument();
+    expect(getByText(/Create a New A\/A Experiment/)).toBeInTheDocument();
   });
 
   it("includes the experiment form page at `/:experimentSlug/edit/`", async () => {

--- a/app/experimenter/static/rapid/__tests__/app.test.tsx
+++ b/app/experimenter/static/rapid/__tests__/app.test.tsx
@@ -41,7 +41,11 @@ describe("<App />", () => {
     const { getByText, getByLabelText } = renderWithRouter(<App />, {
       route: "/test-slug/edit/",
     });
-    expect(getByText("Create a New A/A Experiment")).toBeInTheDocument();
+    await waitFor(() => {
+      return expect(
+        getByText("Edit Experiment: Test Name"),
+      ).toBeInTheDocument();
+    });
 
     const nameField = getByLabelText("Public Name") as HTMLInputElement;
     await waitFor(() => {

--- a/app/experimenter/static/rapid/components/experiments/ExperimentEditHeader.tsx
+++ b/app/experimenter/static/rapid/components/experiments/ExperimentEditHeader.tsx
@@ -1,13 +1,10 @@
 import React from "react";
-import { useHistory } from "react-router-dom";
-
 import { useExperimentState } from "experimenter-rapid/contexts/experiment/hooks";
 
 const ExperimentFormPage: React.FC = () => {
-  const { location } = useHistory();
-  let pageHeading = "Create a New A/A Experiment";
-  if (location.pathname.includes("edit")) {
-    const experimentData = useExperimentState();
+  const experimentData = useExperimentState();
+  let pageHeading = `Create a New A/A Experiment: ${experimentData.name}`;
+  if (experimentData.slug) {
     pageHeading = `Edit Experiment: ${experimentData.name}`;
   }
 

--- a/app/experimenter/static/rapid/components/experiments/ExperimentEditHeader.tsx
+++ b/app/experimenter/static/rapid/components/experiments/ExperimentEditHeader.tsx
@@ -1,0 +1,28 @@
+import React from "react";
+import { useHistory } from "react-router-dom";
+
+import { useExperimentState } from "experimenter-rapid/contexts/experiment/hooks";
+
+const ExperimentFormPage: React.FC = () => {
+  const { location } = useHistory();
+  let pageHeading = "Create a New A/A Experiment";
+  if (location.pathname.includes("edit")) {
+    const experimentData = useExperimentState();
+    pageHeading = `Edit Experiment: ${experimentData.name}`;
+  }
+
+  return (
+    <div className="mb-4">
+      <div className="d-flex align-items-center">
+        <h3 className="mr-3">{pageHeading}</h3>
+        <span className="badge badge-secondary mb-1">Draft</span>
+      </div>
+      <p>
+        Create and automatically launch an A/A CFR experiment. A/A experiments
+        measure the accuracy of the tool.
+      </p>
+    </div>
+  );
+};
+
+export default ExperimentFormPage;

--- a/app/experimenter/static/rapid/components/experiments/ExperimentEditHeader.tsx
+++ b/app/experimenter/static/rapid/components/experiments/ExperimentEditHeader.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+
 import { useExperimentState } from "experimenter-rapid/contexts/experiment/hooks";
 
 const ExperimentFormPage: React.FC = () => {

--- a/app/experimenter/static/rapid/components/pages/ExperimentFormPage.tsx
+++ b/app/experimenter/static/rapid/components/pages/ExperimentFormPage.tsx
@@ -1,25 +1,15 @@
 import React from "react";
 
+import ExperimentEditHeader from "experimenter-rapid/components/experiments/ExperimentEditHeader";
 import ExperimentForm from "experimenter-rapid/components/forms/ExperimentForm";
 import ExperimentProvider from "experimenter-rapid/contexts/experiment/provider";
 
 const ExperimentFormPage: React.FC = () => {
   return (
     <ExperimentProvider>
-      <div className="col pt-3">
-        <div className="mb-4">
-          <div className="d-flex align-items-center">
-            <h3 className="mr-3">Create a New A/A Experiment</h3>
-            <span className="badge badge-secondary mb-1">Draft</span>
-          </div>
-          <p>
-            Create and automatically launch an A/A CFR experiment. A/A
-            experiments measure the accuracy of the tool.
-          </p>
-        </div>
+      <ExperimentEditHeader />
 
-        <ExperimentForm />
-      </div>
+      <ExperimentForm />
     </ExperimentProvider>
   );
 };


### PR DESCRIPTION
![Screen Shot 2020-07-07 at 1 48 37 PM](https://user-images.githubusercontent.com/25379936/86841319-a9675d00-c058-11ea-9f49-2961294ade70.png)

Not entirely sure if it's desirable but when changing the public name, the title will change to match it....