### PR TITLE
Use prefetch for all public APIs fixes #3002

### DIFF
--- a/app/experimenter/experiments/api/v1/views.py
+++ b/app/experimenter/experiments/api/v1/views.py
@@ -16,19 +16,19 @@ from experimenter.normandy.serializers import ExperimentRecipeSerializer
 
 class ExperimentListView(ListAPIView):
     filter_fields = ("status",)
-    queryset = Experiment.objects.all()
+    queryset = Experiment.objects.get_prefetched()
     serializer_class = ExperimentSerializer
 
 
 class ExperimentDetailView(RetrieveAPIView):
     lookup_field = "slug"
-    queryset = Experiment.objects.all()
+    queryset = Experiment.objects.get_prefetched()
     serializer_class = ExperimentSerializer
 
 
 class ExperimentRecipeView(RetrieveAPIView):
     lookup_field = "slug"
-    queryset = Experiment.objects.filter(
+    queryset = Experiment.objects.get_prefetched().filter(
         status__in=(
             ExperimentConstants.STATUS_SHIP,
             ExperimentConstants.STATUS_ACCEPTED,
@@ -40,7 +40,7 @@ class ExperimentRecipeView(RetrieveAPIView):
 
 
 class ExperimentCSVListView(ListAPIView):
-    queryset = Experiment.objects.order_by("status", "name")
+    queryset = Experiment.objects.get_prefetched().order_by("status", "name")
     serializer_class = ExperimentCSVSerializer
     renderer_classes = (CSVRenderer,)
 

--- a/app/experimenter/experiments/models.py
+++ b/app/experimenter/experiments/models.py
@@ -33,13 +33,16 @@ class ExperimentManager(models.Manager):
 
     def get_prefetched(self):
         return self.get_queryset().prefetch_related(
-            "changes",
             "changes__changed_by",
-            "owner",
-            "comments",
+            "changes",
             "comments__created_by",
-            "locales",
+            "comments",
             "countries",
+            "locales",
+            "owner",
+            "preferences",
+            "variants__preferences",
+            "variants",
         )
 
 

--- a/app/experimenter/experiments/tests/api/v1/test_views.py
+++ b/app/experimenter/experiments/tests/api/v1/test_views.py
@@ -32,7 +32,7 @@ class TestExperimentListView(TestCase):
         json_data = json.loads(response.content)
 
         serialized_experiments = ExperimentSerializer(
-            Experiment.objects.all(), many=True
+            Experiment.objects.get_prefetched(), many=True
         ).data
 
         self.assertEqual(serialized_experiments, json_data)
@@ -59,7 +59,8 @@ class TestExperimentListView(TestCase):
         json_data = json.loads(response.content)
 
         serialized_experiments = ExperimentSerializer(
-            Experiment.objects.filter(status=Experiment.STATUS_REVIEW), many=True
+            Experiment.objects.get_prefetched().filter(status=Experiment.STATUS_REVIEW),
+            many=True,
         ).data
 
         self.assertEqual(serialized_experiments, json_data)


### PR DESCRIPTION
Ah we should've been using prefetch for all the V1 API calls anyways!  This should help.  If it's not enough we can add caching after.