### PR TITLE
Move CSV API endpoint into V2 fixes #3045

### DIFF
--- a/app/experimenter/docs/openapi-schema.json
+++ b/app/experimenter/docs/openapi-schema.json
@@ -5,154 +5,6 @@
     "version": ""
   },
   "paths": {
-    "/api/v1/experiments/csv/": {
-      "get": {
-        "operationId": "listExperiments",
-        "description": "",
-        "parameters": [],
-        "responses": {
-          "200": {
-            "content": {
-              "text/csv": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "properties": {
-                      "name": {
-                        "type": "string",
-                        "maxLength": 255
-                      },
-                      "type": {
-                        "enum": [
-                          "pref",
-                          "addon",
-                          "generic",
-                          "rollout",
-                          "message",
-                          "rapid"
-                        ]
-                      },
-                      "status": {
-                        "enum": [
-                          "Draft",
-                          "Review",
-                          "Ship",
-                          "Accepted",
-                          "Live",
-                          "Complete"
-                        ]
-                      },
-                      "experiment_url": {
-                        "type": "string",
-                        "readOnly": true
-                      },
-                      "public_description": {
-                        "type": "string",
-                        "nullable": true
-                      },
-                      "owner": {
-                        "type": "string",
-                        "readOnly": true
-                      },
-                      "analysis_owner": {
-                        "type": "string",
-                        "readOnly": true
-                      },
-                      "engineering_owner": {
-                        "type": "string",
-                        "nullable": true,
-                        "maxLength": 255
-                      },
-                      "short_description": {
-                        "type": "string",
-                        "nullable": true
-                      },
-                      "objectives": {
-                        "type": "string",
-                        "nullable": true
-                      },
-                      "parent": {
-                        "type": "string",
-                        "readOnly": true
-                      },
-                      "projects": {
-                        "type": "string",
-                        "readOnly": true
-                      },
-                      "data_science_issue_url": {
-                        "type": "string",
-                        "format": "uri",
-                        "nullable": true,
-                        "maxLength": 200,
-                        "pattern": "^(?:[a-z0-9\\.\\-\\+]*)://(?:[^\\s:@/]+(?::[^\\s:@/]*)?@)?(?:(?:25[0-5]|2[0-4]\\d|[0-1]?\\d?\\d)(?:\\.(?:25[0-5]|2[0-4]\\d|[0-1]?\\d?\\d)){3}|\\[[0-9a-f:\\.]+\\]|([a-z\u00a1-\uffff0-9](?:[a-z\u00a1-\uffff0-9-]{0,61}[a-z\u00a1-\uffff0-9])?(?:\\.(?!-)[a-z\u00a1-\uffff0-9-]{1,63}(?<!-))*\\.(?!-)(?:[a-z\u00a1-\uffff-]{2,63}|xn--[a-z0-9]{1,59})(?<!-)\\.?|localhost))(?::\\d{2,5})?(?:[/?#][^\\s]*)?\\Z"
-                      },
-                      "feature_bugzilla_url": {
-                        "type": "string",
-                        "format": "uri",
-                        "nullable": true,
-                        "maxLength": 200,
-                        "pattern": "^(?:[a-z0-9\\.\\-\\+]*)://(?:[^\\s:@/]+(?::[^\\s:@/]*)?@)?(?:(?:25[0-5]|2[0-4]\\d|[0-1]?\\d?\\d)(?:\\.(?:25[0-5]|2[0-4]\\d|[0-1]?\\d?\\d)){3}|\\[[0-9a-f:\\.]+\\]|([a-z\u00a1-\uffff0-9](?:[a-z\u00a1-\uffff0-9-]{0,61}[a-z\u00a1-\uffff0-9])?(?:\\.(?!-)[a-z\u00a1-\uffff0-9-]{1,63}(?<!-))*\\.(?!-)(?:[a-z\u00a1-\uffff-]{2,63}|xn--[a-z0-9]{1,59})(?<!-)\\.?|localhost))(?::\\d{2,5})?(?:[/?#][^\\s]*)?\\Z"
-                      },
-                      "firefox_channel": {
-                        "enum": [
-                          null,
-                          "Nightly",
-                          "Beta",
-                          "Release"
-                        ],
-                        "nullable": true
-                      },
-                      "normandy_slug": {
-                        "type": "string",
-                        "nullable": true,
-                        "maxLength": 255
-                      },
-                      "proposed_duration": {
-                        "type": "integer",
-                        "maximum": 1000,
-                        "nullable": true,
-                        "minimum": 0
-                      },
-                      "proposed_start_date": {
-                        "type": "string",
-                        "format": "date",
-                        "nullable": true
-                      },
-                      "related_to": {
-                        "type": "string",
-                        "readOnly": true
-                      },
-                      "related_work": {
-                        "type": "string",
-                        "nullable": true
-                      },
-                      "results_initial": {
-                        "type": "string",
-                        "nullable": true
-                      },
-                      "results_url": {
-                        "type": "string",
-                        "format": "uri",
-                        "nullable": true,
-                        "maxLength": 200,
-                        "pattern": "^(?:[a-z0-9\\.\\-\\+]*)://(?:[^\\s:@/]+(?::[^\\s:@/]*)?@)?(?:(?:25[0-5]|2[0-4]\\d|[0-1]?\\d?\\d)(?:\\.(?:25[0-5]|2[0-4]\\d|[0-1]?\\d?\\d)){3}|\\[[0-9a-f:\\.]+\\]|([a-z\u00a1-\uffff0-9](?:[a-z\u00a1-\uffff0-9-]{0,61}[a-z\u00a1-\uffff0-9])?(?:\\.(?!-)[a-z\u00a1-\uffff0-9-]{1,63}(?<!-))*\\.(?!-)(?:[a-z\u00a1-\uffff-]{2,63}|xn--[a-z0-9]{1,59})(?<!-)\\.?|localhost))(?::\\d{2,5})?(?:[/?#][^\\s]*)?\\Z"
-                      }
-                    },
-                    "required": [
-                      "name"
-                    ]
-                  }
-                }
-              }
-            },
-            "description": ""
-          }
-        },
-        "tags": [
-          "Core: Public"
-        ]
-      }
-    },
     "/api/v1/experiments/{slug}/recipe/": {
       "get": {
         "operationId": "RetrieveExperiment",
@@ -1169,6 +1021,154 @@
         },
         "tags": [
           "Core: Public"
+        ]
+      }
+    },
+    "/api/v2/experiments/csv/": {
+      "get": {
+        "operationId": "listExperiments",
+        "description": "",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "text/csv": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "properties": {
+                      "name": {
+                        "type": "string",
+                        "maxLength": 255
+                      },
+                      "type": {
+                        "enum": [
+                          "pref",
+                          "addon",
+                          "generic",
+                          "rollout",
+                          "message",
+                          "rapid"
+                        ]
+                      },
+                      "status": {
+                        "enum": [
+                          "Draft",
+                          "Review",
+                          "Ship",
+                          "Accepted",
+                          "Live",
+                          "Complete"
+                        ]
+                      },
+                      "experiment_url": {
+                        "type": "string",
+                        "readOnly": true
+                      },
+                      "public_description": {
+                        "type": "string",
+                        "nullable": true
+                      },
+                      "owner": {
+                        "type": "string",
+                        "readOnly": true
+                      },
+                      "analysis_owner": {
+                        "type": "string",
+                        "readOnly": true
+                      },
+                      "engineering_owner": {
+                        "type": "string",
+                        "nullable": true,
+                        "maxLength": 255
+                      },
+                      "short_description": {
+                        "type": "string",
+                        "nullable": true
+                      },
+                      "objectives": {
+                        "type": "string",
+                        "nullable": true
+                      },
+                      "parent": {
+                        "type": "string",
+                        "readOnly": true
+                      },
+                      "projects": {
+                        "type": "string",
+                        "readOnly": true
+                      },
+                      "data_science_issue_url": {
+                        "type": "string",
+                        "format": "uri",
+                        "nullable": true,
+                        "maxLength": 200,
+                        "pattern": "^(?:[a-z0-9\\.\\-\\+]*)://(?:[^\\s:@/]+(?::[^\\s:@/]*)?@)?(?:(?:25[0-5]|2[0-4]\\d|[0-1]?\\d?\\d)(?:\\.(?:25[0-5]|2[0-4]\\d|[0-1]?\\d?\\d)){3}|\\[[0-9a-f:\\.]+\\]|([a-z\u00a1-\uffff0-9](?:[a-z\u00a1-\uffff0-9-]{0,61}[a-z\u00a1-\uffff0-9])?(?:\\.(?!-)[a-z\u00a1-\uffff0-9-]{1,63}(?<!-))*\\.(?!-)(?:[a-z\u00a1-\uffff-]{2,63}|xn--[a-z0-9]{1,59})(?<!-)\\.?|localhost))(?::\\d{2,5})?(?:[/?#][^\\s]*)?\\Z"
+                      },
+                      "feature_bugzilla_url": {
+                        "type": "string",
+                        "format": "uri",
+                        "nullable": true,
+                        "maxLength": 200,
+                        "pattern": "^(?:[a-z0-9\\.\\-\\+]*)://(?:[^\\s:@/]+(?::[^\\s:@/]*)?@)?(?:(?:25[0-5]|2[0-4]\\d|[0-1]?\\d?\\d)(?:\\.(?:25[0-5]|2[0-4]\\d|[0-1]?\\d?\\d)){3}|\\[[0-9a-f:\\.]+\\]|([a-z\u00a1-\uffff0-9](?:[a-z\u00a1-\uffff0-9-]{0,61}[a-z\u00a1-\uffff0-9])?(?:\\.(?!-)[a-z\u00a1-\uffff0-9-]{1,63}(?<!-))*\\.(?!-)(?:[a-z\u00a1-\uffff-]{2,63}|xn--[a-z0-9]{1,59})(?<!-)\\.?|localhost))(?::\\d{2,5})?(?:[/?#][^\\s]*)?\\Z"
+                      },
+                      "firefox_channel": {
+                        "enum": [
+                          null,
+                          "Nightly",
+                          "Beta",
+                          "Release"
+                        ],
+                        "nullable": true
+                      },
+                      "normandy_slug": {
+                        "type": "string",
+                        "nullable": true,
+                        "maxLength": 255
+                      },
+                      "proposed_duration": {
+                        "type": "integer",
+                        "maximum": 1000,
+                        "nullable": true,
+                        "minimum": 0
+                      },
+                      "proposed_start_date": {
+                        "type": "string",
+                        "format": "date",
+                        "nullable": true
+                      },
+                      "related_to": {
+                        "type": "string",
+                        "readOnly": true
+                      },
+                      "related_work": {
+                        "type": "string",
+                        "nullable": true
+                      },
+                      "results_initial": {
+                        "type": "string",
+                        "nullable": true
+                      },
+                      "results_url": {
+                        "type": "string",
+                        "format": "uri",
+                        "nullable": true,
+                        "maxLength": 200,
+                        "pattern": "^(?:[a-z0-9\\.\\-\\+]*)://(?:[^\\s:@/]+(?::[^\\s:@/]*)?@)?(?:(?:25[0-5]|2[0-4]\\d|[0-1]?\\d?\\d)(?:\\.(?:25[0-5]|2[0-4]\\d|[0-1]?\\d?\\d)){3}|\\[[0-9a-f:\\.]+\\]|([a-z\u00a1-\uffff0-9](?:[a-z\u00a1-\uffff0-9-]{0,61}[a-z\u00a1-\uffff0-9])?(?:\\.(?!-)[a-z\u00a1-\uffff0-9-]{1,63}(?<!-))*\\.(?!-)(?:[a-z\u00a1-\uffff-]{2,63}|xn--[a-z0-9]{1,59})(?<!-)\\.?|localhost))(?::\\d{2,5})?(?:[/?#][^\\s]*)?\\Z"
+                      }
+                    },
+                    "required": [
+                      "name"
+                    ]
+                  }
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "tags": [
+          "Core: Private"
         ]
       }
     },

--- a/app/experimenter/docs/swagger-ui.html
+++ b/app/experimenter/docs/swagger-ui.html
@@ -17,154 +17,6 @@
     "version": ""
   },
   "paths": {
-    "/api/v1/experiments/csv/": {
-      "get": {
-        "operationId": "listExperiments",
-        "description": "",
-        "parameters": [],
-        "responses": {
-          "200": {
-            "content": {
-              "text/csv": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "properties": {
-                      "name": {
-                        "type": "string",
-                        "maxLength": 255
-                      },
-                      "type": {
-                        "enum": [
-                          "pref",
-                          "addon",
-                          "generic",
-                          "rollout",
-                          "message",
-                          "rapid"
-                        ]
-                      },
-                      "status": {
-                        "enum": [
-                          "Draft",
-                          "Review",
-                          "Ship",
-                          "Accepted",
-                          "Live",
-                          "Complete"
-                        ]
-                      },
-                      "experiment_url": {
-                        "type": "string",
-                        "readOnly": true
-                      },
-                      "public_description": {
-                        "type": "string",
-                        "nullable": true
-                      },
-                      "owner": {
-                        "type": "string",
-                        "readOnly": true
-                      },
-                      "analysis_owner": {
-                        "type": "string",
-                        "readOnly": true
-                      },
-                      "engineering_owner": {
-                        "type": "string",
-                        "nullable": true,
-                        "maxLength": 255
-                      },
-                      "short_description": {
-                        "type": "string",
-                        "nullable": true
-                      },
-                      "objectives": {
-                        "type": "string",
-                        "nullable": true
-                      },
-                      "parent": {
-                        "type": "string",
-                        "readOnly": true
-                      },
-                      "projects": {
-                        "type": "string",
-                        "readOnly": true
-                      },
-                      "data_science_issue_url": {
-                        "type": "string",
-                        "format": "uri",
-                        "nullable": true,
-                        "maxLength": 200,
-                        "pattern": "^(?:[a-z0-9\\.\\-\\+]*)://(?:[^\\s:@/]+(?::[^\\s:@/]*)?@)?(?:(?:25[0-5]|2[0-4]\\d|[0-1]?\\d?\\d)(?:\\.(?:25[0-5]|2[0-4]\\d|[0-1]?\\d?\\d)){3}|\\[[0-9a-f:\\.]+\\]|([a-z\u00a1-\uffff0-9](?:[a-z\u00a1-\uffff0-9-]{0,61}[a-z\u00a1-\uffff0-9])?(?:\\.(?!-)[a-z\u00a1-\uffff0-9-]{1,63}(?<!-))*\\.(?!-)(?:[a-z\u00a1-\uffff-]{2,63}|xn--[a-z0-9]{1,59})(?<!-)\\.?|localhost))(?::\\d{2,5})?(?:[/?#][^\\s]*)?\\Z"
-                      },
-                      "feature_bugzilla_url": {
-                        "type": "string",
-                        "format": "uri",
-                        "nullable": true,
-                        "maxLength": 200,
-                        "pattern": "^(?:[a-z0-9\\.\\-\\+]*)://(?:[^\\s:@/]+(?::[^\\s:@/]*)?@)?(?:(?:25[0-5]|2[0-4]\\d|[0-1]?\\d?\\d)(?:\\.(?:25[0-5]|2[0-4]\\d|[0-1]?\\d?\\d)){3}|\\[[0-9a-f:\\.]+\\]|([a-z\u00a1-\uffff0-9](?:[a-z\u00a1-\uffff0-9-]{0,61}[a-z\u00a1-\uffff0-9])?(?:\\.(?!-)[a-z\u00a1-\uffff0-9-]{1,63}(?<!-))*\\.(?!-)(?:[a-z\u00a1-\uffff-]{2,63}|xn--[a-z0-9]{1,59})(?<!-)\\.?|localhost))(?::\\d{2,5})?(?:[/?#][^\\s]*)?\\Z"
-                      },
-                      "firefox_channel": {
-                        "enum": [
-                          null,
-                          "Nightly",
-                          "Beta",
-                          "Release"
-                        ],
-                        "nullable": true
-                      },
-                      "normandy_slug": {
-                        "type": "string",
-                        "nullable": true,
-                        "maxLength": 255
-                      },
-                      "proposed_duration": {
-                        "type": "integer",
-                        "maximum": 1000,
-                        "nullable": true,
-                        "minimum": 0
-                      },
-                      "proposed_start_date": {
-                        "type": "string",
-                        "format": "date",
-                        "nullable": true
-                      },
-                      "related_to": {
-                        "type": "string",
-                        "readOnly": true
-                      },
-                      "related_work": {
-                        "type": "string",
-                        "nullable": true
-                      },
-                      "results_initial": {
-                        "type": "string",
-                        "nullable": true
-                      },
-                      "results_url": {
-                        "type": "string",
-                        "format": "uri",
-                        "nullable": true,
-                        "maxLength": 200,
-                        "pattern": "^(?:[a-z0-9\\.\\-\\+]*)://(?:[^\\s:@/]+(?::[^\\s:@/]*)?@)?(?:(?:25[0-5]|2[0-4]\\d|[0-1]?\\d?\\d)(?:\\.(?:25[0-5]|2[0-4]\\d|[0-1]?\\d?\\d)){3}|\\[[0-9a-f:\\.]+\\]|([a-z\u00a1-\uffff0-9](?:[a-z\u00a1-\uffff0-9-]{0,61}[a-z\u00a1-\uffff0-9])?(?:\\.(?!-)[a-z\u00a1-\uffff0-9-]{1,63}(?<!-))*\\.(?!-)(?:[a-z\u00a1-\uffff-]{2,63}|xn--[a-z0-9]{1,59})(?<!-)\\.?|localhost))(?::\\d{2,5})?(?:[/?#][^\\s]*)?\\Z"
-                      }
-                    },
-                    "required": [
-                      "name"
-                    ]
-                  }
-                }
-              }
-            },
-            "description": ""
-          }
-        },
-        "tags": [
-          "Core: Public"
-        ]
-      }
-    },
     "/api/v1/experiments/{slug}/recipe/": {
       "get": {
         "operationId": "RetrieveExperiment",
@@ -1181,6 +1033,154 @@
         },
         "tags": [
           "Core: Public"
+        ]
+      }
+    },
+    "/api/v2/experiments/csv/": {
+      "get": {
+        "operationId": "listExperiments",
+        "description": "",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "text/csv": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "properties": {
+                      "name": {
+                        "type": "string",
+                        "maxLength": 255
+                      },
+                      "type": {
+                        "enum": [
+                          "pref",
+                          "addon",
+                          "generic",
+                          "rollout",
+                          "message",
+                          "rapid"
+                        ]
+                      },
+                      "status": {
+                        "enum": [
+                          "Draft",
+                          "Review",
+                          "Ship",
+                          "Accepted",
+                          "Live",
+                          "Complete"
+                        ]
+                      },
+                      "experiment_url": {
+                        "type": "string",
+                        "readOnly": true
+                      },
+                      "public_description": {
+                        "type": "string",
+                        "nullable": true
+                      },
+                      "owner": {
+                        "type": "string",
+                        "readOnly": true
+                      },
+                      "analysis_owner": {
+                        "type": "string",
+                        "readOnly": true
+                      },
+                      "engineering_owner": {
+                        "type": "string",
+                        "nullable": true,
+                        "maxLength": 255
+                      },
+                      "short_description": {
+                        "type": "string",
+                        "nullable": true
+                      },
+                      "objectives": {
+                        "type": "string",
+                        "nullable": true
+                      },
+                      "parent": {
+                        "type": "string",
+                        "readOnly": true
+                      },
+                      "projects": {
+                        "type": "string",
+                        "readOnly": true
+                      },
+                      "data_science_issue_url": {
+                        "type": "string",
+                        "format": "uri",
+                        "nullable": true,
+                        "maxLength": 200,
+                        "pattern": "^(?:[a-z0-9\\.\\-\\+]*)://(?:[^\\s:@/]+(?::[^\\s:@/]*)?@)?(?:(?:25[0-5]|2[0-4]\\d|[0-1]?\\d?\\d)(?:\\.(?:25[0-5]|2[0-4]\\d|[0-1]?\\d?\\d)){3}|\\[[0-9a-f:\\.]+\\]|([a-z\u00a1-\uffff0-9](?:[a-z\u00a1-\uffff0-9-]{0,61}[a-z\u00a1-\uffff0-9])?(?:\\.(?!-)[a-z\u00a1-\uffff0-9-]{1,63}(?<!-))*\\.(?!-)(?:[a-z\u00a1-\uffff-]{2,63}|xn--[a-z0-9]{1,59})(?<!-)\\.?|localhost))(?::\\d{2,5})?(?:[/?#][^\\s]*)?\\Z"
+                      },
+                      "feature_bugzilla_url": {
+                        "type": "string",
+                        "format": "uri",
+                        "nullable": true,
+                        "maxLength": 200,
+                        "pattern": "^(?:[a-z0-9\\.\\-\\+]*)://(?:[^\\s:@/]+(?::[^\\s:@/]*)?@)?(?:(?:25[0-5]|2[0-4]\\d|[0-1]?\\d?\\d)(?:\\.(?:25[0-5]|2[0-4]\\d|[0-1]?\\d?\\d)){3}|\\[[0-9a-f:\\.]+\\]|([a-z\u00a1-\uffff0-9](?:[a-z\u00a1-\uffff0-9-]{0,61}[a-z\u00a1-\uffff0-9])?(?:\\.(?!-)[a-z\u00a1-\uffff0-9-]{1,63}(?<!-))*\\.(?!-)(?:[a-z\u00a1-\uffff-]{2,63}|xn--[a-z0-9]{1,59})(?<!-)\\.?|localhost))(?::\\d{2,5})?(?:[/?#][^\\s]*)?\\Z"
+                      },
+                      "firefox_channel": {
+                        "enum": [
+                          null,
+                          "Nightly",
+                          "Beta",
+                          "Release"
+                        ],
+                        "nullable": true
+                      },
+                      "normandy_slug": {
+                        "type": "string",
+                        "nullable": true,
+                        "maxLength": 255
+                      },
+                      "proposed_duration": {
+                        "type": "integer",
+                        "maximum": 1000,
+                        "nullable": true,
+                        "minimum": 0
+                      },
+                      "proposed_start_date": {
+                        "type": "string",
+                        "format": "date",
+                        "nullable": true
+                      },
+                      "related_to": {
+                        "type": "string",
+                        "readOnly": true
+                      },
+                      "related_work": {
+                        "type": "string",
+                        "nullable": true
+                      },
+                      "results_initial": {
+                        "type": "string",
+                        "nullable": true
+                      },
+                      "results_url": {
+                        "type": "string",
+                        "format": "uri",
+                        "nullable": true,
+                        "maxLength": 200,
+                        "pattern": "^(?:[a-z0-9\\.\\-\\+]*)://(?:[^\\s:@/]+(?::[^\\s:@/]*)?@)?(?:(?:25[0-5]|2[0-4]\\d|[0-1]?\\d?\\d)(?:\\.(?:25[0-5]|2[0-4]\\d|[0-1]?\\d?\\d)){3}|\\[[0-9a-f:\\.]+\\]|([a-z\u00a1-\uffff0-9](?:[a-z\u00a1-\uffff0-9-]{0,61}[a-z\u00a1-\uffff0-9])?(?:\\.(?!-)[a-z\u00a1-\uffff0-9-]{1,63}(?<!-))*\\.(?!-)(?:[a-z\u00a1-\uffff-]{2,63}|xn--[a-z0-9]{1,59})(?<!-)\\.?|localhost))(?::\\d{2,5})?(?:[/?#][^\\s]*)?\\Z"
+                      }
+                    },
+                    "required": [
+                      "name"
+                    ]
+                  }
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "tags": [
+          "Core: Private"
         ]
       }
     },

--- a/app/experimenter/experiments/api/v1/serializers.py
+++ b/app/experimenter/experiments/api/v1/serializers.py
@@ -148,47 +148,6 @@ class ExperimentSerializer(serializers.ModelSerializer):
         return ResultsSerializer(obj).data
 
 
-class ExperimentCSVSerializer(serializers.ModelSerializer):
-    analysis_owner = serializers.SlugRelatedField(read_only=True, slug_field="email")
-    owner = serializers.SlugRelatedField(read_only=True, slug_field="email")
-    parent = serializers.SlugRelatedField(read_only=True, slug_field="experiment_url")
-    projects = serializers.SerializerMethodField()
-    related_to = serializers.SerializerMethodField()
-
-    class Meta:
-        model = Experiment
-        fields = (
-            "name",
-            "type",
-            "status",
-            "experiment_url",
-            "public_description",
-            "owner",
-            "analysis_owner",
-            "engineering_owner",
-            "short_description",
-            "objectives",
-            "parent",
-            "projects",
-            "data_science_issue_url",
-            "feature_bugzilla_url",
-            "firefox_channel",
-            "normandy_slug",
-            "proposed_duration",
-            "proposed_start_date",
-            "related_to",
-            "related_work",
-            "results_initial",
-            "results_url",
-        )
-
-    def get_projects(self, obj):
-        return ", ".join([p.name for p in obj.projects.order_by("name")])
-
-    def get_related_to(self, obj):
-        return ", ".join([e.experiment_url for e in obj.related_to.order_by("slug")])
-
-
 class ExperimentRapidBranchesSerializer(serializers.ModelSerializer):
     value = serializers.SerializerMethodField()
 

--- a/app/experimenter/experiments/api/v1/urls.py
+++ b/app/experimenter/experiments/api/v1/urls.py
@@ -1,7 +1,6 @@
 from django.conf.urls import url
 
 from experimenter.experiments.api.v1.views import (
-    ExperimentCSVListView,
     ExperimentDetailView,
     ExperimentListView,
     ExperimentRecipeView,
@@ -9,7 +8,6 @@ from experimenter.experiments.api.v1.views import (
 
 
 urlpatterns = [
-    url(r"^csv/$", ExperimentCSVListView.as_view(), name="experiments-api-csv",),
     url(
         r"^(?P<slug>[\w-]+)/recipe/$",
         ExperimentRecipeView.as_view(),

--- a/app/experimenter/experiments/api/v1/views.py
+++ b/app/experimenter/experiments/api/v1/views.py
@@ -2,16 +2,11 @@ from rest_framework.generics import (
     ListAPIView,
     RetrieveAPIView,
 )
-from rest_framework_csv.renderers import CSVRenderer
 
 from experimenter.experiments.constants import ExperimentConstants
 from experimenter.experiments.models import Experiment
-from experimenter.experiments.api.v1.serializers import (
-    ExperimentSerializer,
-    ExperimentCSVSerializer,
-)
-from experimenter.experiments.filtersets import ExperimentFilterset
 from experimenter.normandy.serializers import ExperimentRecipeSerializer
+from experimenter.experiments.api.v1.serializers import ExperimentSerializer
 
 
 class ExperimentListView(ListAPIView):
@@ -37,21 +32,3 @@ class ExperimentRecipeView(RetrieveAPIView):
         )
     )
     serializer_class = ExperimentRecipeSerializer
-
-
-class ExperimentCSVListView(ListAPIView):
-    queryset = Experiment.objects.get_prefetched().order_by("status", "name")
-    serializer_class = ExperimentCSVSerializer
-    renderer_classes = (CSVRenderer,)
-
-    def get_queryset(self):
-        return ExperimentFilterset(
-            self.request.GET, super().get_queryset(), request=self.request
-        ).qs
-
-    def get_renderer_context(self):
-        # Pass the ordered list of fields in to specify the ordering of the headers
-        # otherwise it defaults to sorting them alphabetically
-        context = super().get_renderer_context()
-        context["header"] = self.serializer_class.Meta.fields
-        return context

--- a/app/experimenter/experiments/api/v2/serializers.py
+++ b/app/experimenter/experiments/api/v2/serializers.py
@@ -728,3 +728,44 @@ class ExperimentCloneSerializer(serializers.ModelSerializer):
         name = validated_data.get("name")
 
         return instance.clone(name, user)
+
+
+class ExperimentCSVSerializer(serializers.ModelSerializer):
+    analysis_owner = serializers.SlugRelatedField(read_only=True, slug_field="email")
+    owner = serializers.SlugRelatedField(read_only=True, slug_field="email")
+    parent = serializers.SlugRelatedField(read_only=True, slug_field="experiment_url")
+    projects = serializers.SerializerMethodField()
+    related_to = serializers.SerializerMethodField()
+
+    class Meta:
+        model = Experiment
+        fields = (
+            "name",
+            "type",
+            "status",
+            "experiment_url",
+            "public_description",
+            "owner",
+            "analysis_owner",
+            "engineering_owner",
+            "short_description",
+            "objectives",
+            "parent",
+            "projects",
+            "data_science_issue_url",
+            "feature_bugzilla_url",
+            "firefox_channel",
+            "normandy_slug",
+            "proposed_duration",
+            "proposed_start_date",
+            "related_to",
+            "related_work",
+            "results_initial",
+            "results_url",
+        )
+
+    def get_projects(self, obj):
+        return ", ".join([p.name for p in obj.projects.order_by("name")])
+
+    def get_related_to(self, obj):
+        return ", ".join([e.experiment_url for e in obj.related_to.order_by("slug")])

--- a/app/experimenter/experiments/api/v2/urls.py
+++ b/app/experimenter/experiments/api/v2/urls.py
@@ -2,6 +2,7 @@ from django.conf.urls import url
 
 from experimenter.experiments.api.v2.views import (
     ExperimentCloneView,
+    ExperimentCSVListView,
     ExperimentDesignAddonRolloutView,
     ExperimentDesignAddonView,
     ExperimentDesignBranchedAddonView,
@@ -16,6 +17,7 @@ from experimenter.experiments.api.v2.views import (
 
 
 urlpatterns = [
+    url(r"^csv/$", ExperimentCSVListView.as_view(), name="experiments-api-csv",),
     url(
         r"^(?P<slug>[\w-]+)/intent-to-ship-email$",
         ExperimentSendIntentToShipEmailView.as_view(),

--- a/app/experimenter/experiments/tests/api/v1/test_serializers.py
+++ b/app/experimenter/experiments/tests/api/v1/test_serializers.py
@@ -14,14 +14,12 @@ from experimenter.experiments.tests.factories import (
 )
 from experimenter.experiments.api.v1.serializers import (
     ExperimentChangeLogSerializer,
-    ExperimentCSVSerializer,
     ExperimentRapidRecipeSerializer,
     ExperimentSerializer,
     ExperimentVariantSerializer,
     JSTimestampField,
     PrefTypeField,
 )
-from experimenter.projects.tests.factories import ProjectFactory
 from experimenter.normandy.serializers import ExperimentRecipeVariantSerializer
 
 
@@ -190,53 +188,6 @@ class TestExperimentChangeLogSerializer(TestCase):
         )
         serializer = ExperimentChangeLogSerializer(change_log)
         self.assertEqual(serializer.data["changed_on"], change_log.changed_on)
-
-
-class TestExperimentCSVSerializer(TestCase):
-    def test_serializer_outputs_expected_schema(self):
-        project1 = ProjectFactory.create(name="a")
-        project2 = ProjectFactory.create(name="b")
-        parent = ExperimentFactory.create()
-        related_experiment1 = ExperimentFactory.create(slug="a")
-        related_experiment2 = ExperimentFactory.create(slug="b")
-        experiment = ExperimentFactory.create(
-            proposed_start_date=datetime.date(2020, 1, 1),
-            parent=parent,
-            projects=[project1, project2],
-        )
-        experiment.related_to.add(related_experiment1, related_experiment2)
-
-        serializer = ExperimentCSVSerializer(experiment)
-        self.assertDictEqual(
-            serializer.data,
-            {
-                "name": experiment.name,
-                "type": experiment.type,
-                "status": experiment.status,
-                "experiment_url": experiment.experiment_url,
-                "public_description": experiment.public_description,
-                "owner": experiment.owner.email,
-                "analysis_owner": experiment.analysis_owner.email,
-                "engineering_owner": experiment.engineering_owner,
-                "short_description": experiment.short_description,
-                "objectives": experiment.objectives,
-                "parent": experiment.parent.experiment_url,
-                "projects": f"{project1.name}, {project2.name}",
-                "data_science_issue_url": experiment.data_science_issue_url,
-                "feature_bugzilla_url": experiment.feature_bugzilla_url,
-                "firefox_channel": experiment.firefox_channel,
-                "normandy_slug": experiment.normandy_slug,
-                "proposed_duration": experiment.proposed_duration,
-                "proposed_start_date": "2020-01-01",
-                "related_to": (
-                    f"{related_experiment1.experiment_url}, "
-                    f"{related_experiment2.experiment_url}"
-                ),
-                "related_work": experiment.related_work,
-                "results_initial": experiment.results_initial,
-                "results_url": experiment.results_url,
-            },
-        )
 
 
 class TestExperimentRapidSerializer(TestCase):

--- a/app/experimenter/experiments/tests/api/v1/test_views.py
+++ b/app/experimenter/experiments/tests/api/v1/test_views.py
@@ -4,18 +4,12 @@ from django.conf import settings
 from django.test import TestCase
 from django.urls import reverse
 from parameterized import parameterized
-from rest_framework_csv.renderers import CSVRenderer
 
 from experimenter.experiments.constants import ExperimentConstants
 from experimenter.experiments.models import Experiment
-from experimenter.experiments.api.v1.serializers import (
-    ExperimentSerializer,
-    ExperimentCSVSerializer,
-)
+from experimenter.experiments.api.v1.serializers import ExperimentSerializer
 from experimenter.experiments.tests.factories import ExperimentFactory
 from experimenter.normandy.serializers import ExperimentRecipeSerializer
-from experimenter.openidc.tests.factories import UserFactory
-from experimenter.projects.tests.factories import ProjectFactory
 
 
 class TestExperimentListView(TestCase):
@@ -119,78 +113,3 @@ class TestExperimentRecipeView(TestCase):
             **{settings.OPENIDC_EMAIL_HEADER: user_email},
         )
         self.assertEqual(response.status_code, 404)
-
-
-class TestExperimentCSVListView(TestCase):
-    def test_get_returns_csv_info(self):
-        user_email = "user@example.com"
-        experiment1 = ExperimentFactory.create_with_status(
-            Experiment.STATUS_DRAFT, name="a"
-        )
-        experiment2 = ExperimentFactory.create_with_status(
-            Experiment.STATUS_DRAFT, name="b"
-        )
-
-        response = self.client.get(
-            reverse("experiments-api-csv"), **{settings.OPENIDC_EMAIL_HEADER: user_email},
-        )
-
-        self.assertEqual(response.status_code, 200)
-
-        csv_data = response.content
-        expected_csv_data = CSVRenderer().render(
-            ExperimentCSVSerializer([experiment1, experiment2], many=True).data,
-            renderer_context={"header": ExperimentCSVSerializer.Meta.fields},
-        )
-        self.assertEqual(csv_data, expected_csv_data)
-
-    def test_view_filters_by_project(self):
-        user_email = "user@example.com"
-        project = ProjectFactory.create()
-        experiment1 = ExperimentFactory.create_with_status(
-            Experiment.STATUS_DRAFT, name="a", projects=[project]
-        )
-        experiment2 = ExperimentFactory.create_with_status(
-            Experiment.STATUS_DRAFT, name="b", projects=[project]
-        )
-        ExperimentFactory.create_with_variants()
-
-        url = reverse("experiments-api-csv")
-        response = self.client.get(
-            f"{url}?projects={project.id}", **{settings.OPENIDC_EMAIL_HEADER: user_email}
-        )
-
-        self.assertEqual(response.status_code, 200)
-
-        csv_data = response.content
-        expected_csv_data = CSVRenderer().render(
-            ExperimentCSVSerializer([experiment1, experiment2], many=True).data,
-            renderer_context={"header": ExperimentCSVSerializer.Meta.fields},
-        )
-        self.assertEqual(csv_data, expected_csv_data)
-
-    def test_view_filters_by_subscriber(self):
-        user = UserFactory(email="user@example.com")
-        experiment1 = ExperimentFactory.create_with_status(
-            Experiment.STATUS_DRAFT, name="a"
-        )
-        experiment1.subscribers.add(user)
-        experiment2 = ExperimentFactory.create_with_status(
-            Experiment.STATUS_DRAFT, name="b"
-        )
-        experiment2.subscribers.add(user)
-        ExperimentFactory.create_with_variants()
-
-        url = reverse("experiments-api-csv")
-        response = self.client.get(
-            f"{url}?subscribed=on", **{settings.OPENIDC_EMAIL_HEADER: user.email}
-        )
-
-        self.assertEqual(response.status_code, 200)
-
-        csv_data = response.content
-        expected_csv_data = CSVRenderer().render(
-            ExperimentCSVSerializer([experiment1, experiment2], many=True).data,
-            renderer_context={"header": ExperimentCSVSerializer.Meta.fields},
-        )
-        self.assertEqual(csv_data, expected_csv_data)

--- a/app/experimenter/experiments/tests/api/v2/test_serializers.py
+++ b/app/experimenter/experiments/tests/api/v2/test_serializers.py
@@ -3,6 +3,7 @@ import datetime
 from django.test import TestCase
 from rest_framework import serializers
 
+from experimenter.projects.tests.factories import ProjectFactory
 from experimenter.base.tests.factories import CountryFactory, LocaleFactory
 from experimenter.experiments.api.v1.serializers import ExperimentVariantSerializer
 from experimenter.experiments.constants import ExperimentConstants
@@ -22,6 +23,7 @@ from experimenter.experiments.tests.factories import (
 from experimenter.experiments.api.v2.serializers import (
     CountrySerializerMultiSelect,
     ExperimentCloneSerializer,
+    ExperimentCSVSerializer,
     ExperimentDesignAddonRolloutSerializer,
     ExperimentDesignAddonSerializer,
     ExperimentDesignBaseSerializer,
@@ -2020,3 +2022,50 @@ class TestCloneSerializer(MockRequestMixin, TestCase):
 
         self.assertEqual(serializer.data["name"], "best experiment")
         self.assertEqual(serializer.data["clone_url"], "/experiments/best-experiment/")
+
+
+class TestExperimentCSVSerializer(TestCase):
+    def test_serializer_outputs_expected_schema(self):
+        project1 = ProjectFactory.create(name="a")
+        project2 = ProjectFactory.create(name="b")
+        parent = ExperimentFactory.create()
+        related_experiment1 = ExperimentFactory.create(slug="a")
+        related_experiment2 = ExperimentFactory.create(slug="b")
+        experiment = ExperimentFactory.create(
+            proposed_start_date=datetime.date(2020, 1, 1),
+            parent=parent,
+            projects=[project1, project2],
+        )
+        experiment.related_to.add(related_experiment1, related_experiment2)
+
+        serializer = ExperimentCSVSerializer(experiment)
+        self.assertDictEqual(
+            serializer.data,
+            {
+                "name": experiment.name,
+                "type": experiment.type,
+                "status": experiment.status,
+                "experiment_url": experiment.experiment_url,
+                "public_description": experiment.public_description,
+                "owner": experiment.owner.email,
+                "analysis_owner": experiment.analysis_owner.email,
+                "engineering_owner": experiment.engineering_owner,
+                "short_description": experiment.short_description,
+                "objectives": experiment.objectives,
+                "parent": experiment.parent.experiment_url,
+                "projects": f"{project1.name}, {project2.name}",
+                "data_science_issue_url": experiment.data_science_issue_url,
+                "feature_bugzilla_url": experiment.feature_bugzilla_url,
+                "firefox_channel": experiment.firefox_channel,
+                "normandy_slug": experiment.normandy_slug,
+                "proposed_duration": experiment.proposed_duration,
+                "proposed_start_date": "2020-01-01",
+                "related_to": (
+                    f"{related_experiment1.experiment_url}, "
+                    f"{related_experiment2.experiment_url}"
+                ),
+                "related_work": experiment.related_work,
+                "results_initial": experiment.results_initial,
+                "results_url": experiment.results_url,
+            },
+        )

--- a/app/experimenter/experiments/tests/api/v2/test_views.py
+++ b/app/experimenter/experiments/tests/api/v2/test_views.py
@@ -4,22 +4,27 @@ from django.conf import settings
 from django.core import mail
 from django.test import TestCase
 from django.urls import reverse
+from rest_framework_csv.renderers import CSVRenderer
+
 
 from experimenter.experiments.constants import ExperimentConstants
 from experimenter.experiments.models import Experiment
 from experimenter.experiments.api.v2.serializers import (
-    ExperimentTimelinePopSerializer,
+    ExperimentCSVSerializer,
     ExperimentDesignAddonSerializer,
     ExperimentDesignGenericSerializer,
     ExperimentDesignMessageSerializer,
     ExperimentDesignMultiPrefSerializer,
     ExperimentDesignPrefSerializer,
+    ExperimentTimelinePopSerializer,
 )
 from experimenter.experiments.tests.factories import (
     ExperimentFactory,
     ExperimentVariantFactory,
     VariantPreferencesFactory,
 )
+from experimenter.openidc.tests.factories import UserFactory
+from experimenter.projects.tests.factories import ProjectFactory
 
 
 class TestExperimentSendIntentToShipEmailView(TestCase):
@@ -605,3 +610,78 @@ class TestExperimentTimelinePopulationView(TestCase):
         )
 
         self.assertEqual(response.status_code, 200)
+
+
+class TestExperimentCSVListView(TestCase):
+    def test_get_returns_csv_info(self):
+        user_email = "user@example.com"
+        experiment1 = ExperimentFactory.create_with_status(
+            Experiment.STATUS_DRAFT, name="a"
+        )
+        experiment2 = ExperimentFactory.create_with_status(
+            Experiment.STATUS_DRAFT, name="b"
+        )
+
+        response = self.client.get(
+            reverse("experiments-api-csv"), **{settings.OPENIDC_EMAIL_HEADER: user_email},
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+        csv_data = response.content
+        expected_csv_data = CSVRenderer().render(
+            ExperimentCSVSerializer([experiment1, experiment2], many=True).data,
+            renderer_context={"header": ExperimentCSVSerializer.Meta.fields},
+        )
+        self.assertEqual(csv_data, expected_csv_data)
+
+    def test_view_filters_by_project(self):
+        user_email = "user@example.com"
+        project = ProjectFactory.create()
+        experiment1 = ExperimentFactory.create_with_status(
+            Experiment.STATUS_DRAFT, name="a", projects=[project]
+        )
+        experiment2 = ExperimentFactory.create_with_status(
+            Experiment.STATUS_DRAFT, name="b", projects=[project]
+        )
+        ExperimentFactory.create_with_variants()
+
+        url = reverse("experiments-api-csv")
+        response = self.client.get(
+            f"{url}?projects={project.id}", **{settings.OPENIDC_EMAIL_HEADER: user_email}
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+        csv_data = response.content
+        expected_csv_data = CSVRenderer().render(
+            ExperimentCSVSerializer([experiment1, experiment2], many=True).data,
+            renderer_context={"header": ExperimentCSVSerializer.Meta.fields},
+        )
+        self.assertEqual(csv_data, expected_csv_data)
+
+    def test_view_filters_by_subscriber(self):
+        user = UserFactory(email="user@example.com")
+        experiment1 = ExperimentFactory.create_with_status(
+            Experiment.STATUS_DRAFT, name="a"
+        )
+        experiment1.subscribers.add(user)
+        experiment2 = ExperimentFactory.create_with_status(
+            Experiment.STATUS_DRAFT, name="b"
+        )
+        experiment2.subscribers.add(user)
+        ExperimentFactory.create_with_variants()
+
+        url = reverse("experiments-api-csv")
+        response = self.client.get(
+            f"{url}?subscribed=on", **{settings.OPENIDC_EMAIL_HEADER: user.email}
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+        csv_data = response.content
+        expected_csv_data = CSVRenderer().render(
+            ExperimentCSVSerializer([experiment1, experiment2], many=True).data,
+            renderer_context={"header": ExperimentCSVSerializer.Meta.fields},
+        )
+        self.assertEqual(csv_data, expected_csv_data)


### PR DESCRIPTION
I took off the auth gate on all V1 API endpoints, but the CSV endpoint should absolutely be authed so I moved it into V2.