### PR TITLE
Use typescript-eslint parser for rapid .eslintrcjs

### DIFF
--- a/app/experimenter/static/rapid/.eslintrc.js
+++ b/app/experimenter/static/rapid/.eslintrc.js
@@ -4,7 +4,7 @@ const baseSettings = {
     browser: true,
     es6: true,
   },
-  parser: "babel-eslint",
+  parser: "@typescript-eslint/parser",
   plugins: ["import"],
   extends: [
     "eslint:recommended",


### PR DESCRIPTION
Fixes #2834 
Used typescript eslint parse instead of babel eslint parse.