### PR TITLE
Don't send experiments to kinto if bugzilla id missing fixes #3012

### DIFF
--- a/app/experimenter/kinto/tasks.py
+++ b/app/experimenter/kinto/tasks.py
@@ -55,7 +55,7 @@ def check_kinto_push_queue():
 
     queued_experiments = Experiment.objects.filter(
         type=Experiment.TYPE_RAPID, status=Experiment.STATUS_REVIEW
-    )
+    ).exclude(bugzilla_id=None)
 
     if queued_experiments.exists():
         if client.has_pending_review():

--- a/app/experimenter/kinto/tests/test_tasks.py
+++ b/app/experimenter/kinto/tests/test_tasks.py
@@ -98,7 +98,25 @@ class TestCheckKintoPushQueue(MockKintoClientMixin, TestCase):
         tasks.check_kinto_push_queue()
         self.mock_push_task.assert_not_called()
 
-    def test_check_with_rapid_review_and_no_kinto_pending_pushes_experiment(self):
+    def test_check_with_rapid_review_and_no_bugzilla_and_no_kinto_pending_pushes_nothing(
+        self,
+    ):
+        ExperimentFactory.create_with_status(
+            Experiment.STATUS_REVIEW,
+            bugzilla_id=None,
+            firefox_channel=Experiment.CHANNEL_RELEASE,
+            firefox_max_version=None,
+            firefox_min_version=Experiment.VERSION_CHOICES[0][0],
+            name="test",
+            type=Experiment.TYPE_RAPID,
+        )
+        self.setup_kinto_no_pending_review()
+        tasks.check_kinto_push_queue()
+        self.mock_push_task.assert_not_called()
+
+    def test_check_with_rapid_review_and_bugzilla_and_no_kinto_pending_pushes_experiment(
+        self,
+    ):
         experiment = ExperimentFactory.create_with_status(
             Experiment.STATUS_REVIEW,
             bugzilla_id="12345",


### PR DESCRIPTION
I didn't even think of just omitting it from the queryset until the last minute, that's much simpler.