### PR TITLE
Add slug to experiment details page (fixes #3170)

### DIFF
--- a/app/experimenter/docs/openapi-schema.json
+++ b/app/experimenter/docs/openapi-schema.json
@@ -7689,6 +7689,10 @@
                     "reject_feedback": {
                       "type": "string",
                       "readOnly": true
+                    },
+                    "recipe_slug": {
+                      "type": "string",
+                      "readOnly": true
                     }
                   },
                   "required": [
@@ -8150,6 +8154,10 @@
                     "reject_feedback": {
                       "type": "string",
                       "readOnly": true
+                    },
+                    "recipe_slug": {
+                      "type": "string",
+                      "readOnly": true
                     }
                   },
                   "required": [
@@ -8585,6 +8593,10 @@
                       ]
                     },
                     "reject_feedback": {
+                      "type": "string",
+                      "readOnly": true
+                    },
+                    "recipe_slug": {
                       "type": "string",
                       "readOnly": true
                     }
@@ -9297,6 +9309,10 @@
                     "reject_feedback": {
                       "type": "string",
                       "readOnly": true
+                    },
+                    "recipe_slug": {
+                      "type": "string",
+                      "readOnly": true
                     }
                   },
                   "required": [
@@ -9758,6 +9774,10 @@
                       ]
                     },
                     "reject_feedback": {
+                      "type": "string",
+                      "readOnly": true
+                    },
+                    "recipe_slug": {
                       "type": "string",
                       "readOnly": true
                     }

--- a/app/experimenter/docs/swagger-ui.html
+++ b/app/experimenter/docs/swagger-ui.html
@@ -7701,6 +7701,10 @@
                     "reject_feedback": {
                       "type": "string",
                       "readOnly": true
+                    },
+                    "recipe_slug": {
+                      "type": "string",
+                      "readOnly": true
                     }
                   },
                   "required": [
@@ -8162,6 +8166,10 @@
                     "reject_feedback": {
                       "type": "string",
                       "readOnly": true
+                    },
+                    "recipe_slug": {
+                      "type": "string",
+                      "readOnly": true
                     }
                   },
                   "required": [
@@ -8597,6 +8605,10 @@
                       ]
                     },
                     "reject_feedback": {
+                      "type": "string",
+                      "readOnly": true
+                    },
+                    "recipe_slug": {
                       "type": "string",
                       "readOnly": true
                     }
@@ -9309,6 +9321,10 @@
                     "reject_feedback": {
                       "type": "string",
                       "readOnly": true
+                    },
+                    "recipe_slug": {
+                      "type": "string",
+                      "readOnly": true
                     }
                   },
                   "required": [
@@ -9770,6 +9786,10 @@
                       ]
                     },
                     "reject_feedback": {
+                      "type": "string",
+                      "readOnly": true
+                    },
+                    "recipe_slug": {
                       "type": "string",
                       "readOnly": true
                     }

--- a/app/experimenter/experiments/api/v3/serializers.py
+++ b/app/experimenter/experiments/api/v3/serializers.py
@@ -43,6 +43,7 @@ class ExperimentRapidSerializer(
     rapid_type = serializers.HiddenField(default=Experiment.RAPID_AA_CFR)
     owner = serializers.ReadOnlyField(source="owner.email")
     slug = serializers.ReadOnlyField()
+    recipe_slug = serializers.ReadOnlyField(source="normandy_slug")
     public_description = serializers.HiddenField(
         default=Experiment.BUGZILLA_RAPID_EXPERIMENT_TEMPLATE
     )
@@ -81,6 +82,7 @@ class ExperimentRapidSerializer(
             "status",
             "type",
             "reject_feedback",
+            "recipe_slug",
         )
 
     def get_reject_feedback(self, obj):

--- a/app/experimenter/experiments/tests/api/v3/test_serializers.py
+++ b/app/experimenter/experiments/tests/api/v3/test_serializers.py
@@ -53,6 +53,7 @@ class TestExperimentRapidSerializer(MockRequestMixin, MockBugzillaTasksMixin, Te
                 "reject_feedback": None,
                 "owner": "owner@example.com",
                 "slug": "rapid-experiment",
+                "recipe_slug": experiment.normandy_slug,
                 "status": Experiment.STATUS_DRAFT,
             },
         )
@@ -93,6 +94,7 @@ class TestExperimentRapidSerializer(MockRequestMixin, MockBugzillaTasksMixin, Te
                 "owner": "owner@example.com",
                 "reject_feedback": None,
                 "slug": "rapid-experiment",
+                "recipe_slug": experiment.normandy_slug,
                 "status": Experiment.STATUS_LIVE,
             },
         )
@@ -147,6 +149,7 @@ class TestExperimentRapidSerializer(MockRequestMixin, MockBugzillaTasksMixin, Te
                     "message": "It's no good",
                 },
                 "slug": "rapid-experiment",
+                "recipe_slug": experiment.normandy_slug,
                 "status": Experiment.STATUS_REJECTED,
             },
         )

--- a/app/experimenter/static/rapid/__tests__/app.test.tsx
+++ b/app/experimenter/static/rapid/__tests__/app.test.tsx
@@ -66,13 +66,13 @@ describe("<App />", () => {
       });
     });
 
-    const { getByText, getByDisplayValue } = renderWithRouter(<App />, {
+    const { getByText } = renderWithRouter(<App />, {
       route: "/test-slug/",
     });
     expect(getByText("Experiment Summary")).toBeInTheDocument();
 
     await waitFor(() => {
-      return expect(getByDisplayValue("test@owner.com")).toBeInTheDocument();
+      return expect(getByText("test@owner.com")).toBeInTheDocument();
     });
   });
 });

--- a/app/experimenter/static/rapid/__tests__/app.test.tsx
+++ b/app/experimenter/static/rapid/__tests__/app.test.tsx
@@ -66,11 +66,13 @@ describe("<App />", () => {
       });
     });
 
-    const { getByText } = renderWithRouter(<App />, {
+    const { getByText, getAllByText } = renderWithRouter(<App />, {
       route: "/test-slug/",
     });
-    expect(getByText("Experiment Summary")).toBeInTheDocument();
 
+    await waitFor(() => {
+      return expect(getAllByText("Test Name")).toHaveLength(2);
+    });
     await waitFor(() => {
       return expect(getByText("test@owner.com")).toBeInTheDocument();
     });

--- a/app/experimenter/static/rapid/__tests__/experimentDetails.test.tsx
+++ b/app/experimenter/static/rapid/__tests__/experimentDetails.test.tsx
@@ -26,7 +26,7 @@ describe("<ExperimentDetails />", () => {
 
   it("renders in DRAFT state", async () => {
     await act(async () => {
-      const { getByDisplayValue } = renderWithRouter(
+      const { getByText } = renderWithRouter(
         wrapInExperimentProvider(<ExperimentDetails />, {
           initialState: {
             status: ExperimentStatus.DRAFT,
@@ -43,21 +43,22 @@ describe("<ExperimentDetails />", () => {
       );
 
       await waitFor(() => {
-        return expect(getByDisplayValue("test@owner.com")).toBeInTheDocument();
+        return expect(getByText("test@owner.com")).toBeInTheDocument();
       });
 
-      expect(getByDisplayValue("Test Name")).toBeInTheDocument();
-      expect(getByDisplayValue("Test objectives")).toBeInTheDocument();
+      expect(getByText("Test Name")).toBeInTheDocument();
+      expect(getByText("Test objectives")).toBeInTheDocument();
     });
   });
 
   it("renders in LIVE state", async () => {
     await act(async () => {
-      const { getByDisplayValue, queryByText } = renderWithRouter(
+      const { getByText, queryByText } = renderWithRouter(
         wrapInExperimentProvider(<ExperimentDetails />, {
           initialState: {
             status: ExperimentStatus.LIVE,
             slug: "test-slug",
+            recipe_slug: "bug-123-test-slug",
             name: "Test Name",
             objectives: "Test objectives",
             owner: "test@owner.com",
@@ -70,9 +71,10 @@ describe("<ExperimentDetails />", () => {
       );
 
       await waitFor(() => {
-        return expect(getByDisplayValue("test@owner.com")).toBeInTheDocument();
+        return expect(getByText("test@owner.com")).toBeInTheDocument();
       });
 
+      expect(getByText("bug-123-test-slug")).toBeInTheDocument();
       expect(queryByText("Back")).toBe(null);
       expect(queryByText("Request Approval")).toBe(null);
     });
@@ -80,7 +82,7 @@ describe("<ExperimentDetails />", () => {
 
   it("renders in REJECTED state", async () => {
     await act(async () => {
-      const { getByDisplayValue, getByText } = renderWithRouter(
+      const { getByText } = renderWithRouter(
         wrapInExperimentProvider(<ExperimentDetails />, {
           initialState: {
             status: ExperimentStatus.REJECTED,
@@ -101,7 +103,7 @@ describe("<ExperimentDetails />", () => {
       );
 
       await waitFor(() => {
-        return expect(getByDisplayValue("test@owner.com")).toBeInTheDocument();
+        return expect(getByText("test@owner.com")).toBeInTheDocument();
       });
 
       expect(getByText("Review Feedback")).toBeInTheDocument();
@@ -156,6 +158,28 @@ describe("<ExperimentDetails />", () => {
       );
 
       expect(queryByText(/Bugzilla ticket/)).toBe(null);
+    });
+  });
+
+  it("renders without recipe_slug when data missing", async () => {
+    await act(async () => {
+      const { queryByText } = renderWithRouter(
+        wrapInExperimentProvider(<ExperimentDetails />, {
+          initialState: {
+            status: ExperimentStatus.DRAFT,
+            slug: "test-slug",
+            name: "Test Name",
+            objectives: "Test objectives",
+            owner: "test@owner.com",
+            features: ["pinned_tabs", "picture_in_picture"],
+            audience: "all_english",
+            firefox_channel: FirefoxChannel.RELEASE,
+            firefox_min_version: "78.0",
+          },
+        }),
+      );
+
+      expect(queryByText(/Experiment slug/)).toBe(null);
     });
   });
 

--- a/app/experimenter/static/rapid/__tests__/experimentDetails.test.tsx
+++ b/app/experimenter/static/rapid/__tests__/experimentDetails.test.tsx
@@ -26,7 +26,7 @@ describe("<ExperimentDetails />", () => {
 
   it("renders in DRAFT state", async () => {
     await act(async () => {
-      const { getByText } = renderWithRouter(
+      const { getByText, getAllByText } = renderWithRouter(
         wrapInExperimentProvider(<ExperimentDetails />, {
           initialState: {
             status: ExperimentStatus.DRAFT,
@@ -46,7 +46,7 @@ describe("<ExperimentDetails />", () => {
         return expect(getByText("test@owner.com")).toBeInTheDocument();
       });
 
-      expect(getByText("Test Name")).toBeInTheDocument();
+      expect(getAllByText("Test Name")).toHaveLength(2);
       expect(getByText("Test objectives")).toBeInTheDocument();
     });
   });

--- a/app/experimenter/static/rapid/components/experiments/ExperimentDetails.tsx
+++ b/app/experimenter/static/rapid/components/experiments/ExperimentDetails.tsx
@@ -26,15 +26,13 @@ const LabelledRow: React.FC<{ label: string; value?: string }> = ({
   value,
 }) => {
   return (
-    <div className="row my-3">
-      <label className="col-2 d-inline-block pt-2 font-weight-bold">
-        {label}
-      </label>
-      <span className="col-10">
-        <input readOnly className="w-100" type="text" value={value || ""} />
+    <tr>
+      <th style={{ whiteSpace: "nowrap", width: "1%" }}>{label}</th>
+      <td>
+        {value}
         {children}
-      </span>
-    </div>
+      </td>
+    </tr>
   );
 };
 
@@ -69,15 +67,17 @@ const ExperimentDetails: React.FC = () => {
   let bugzilla_url;
   if (experimentData.bugzilla_url) {
     bugzilla_url = (
-      <div className="my-2">
-        Bugzilla ticket can be found{" "}
-        <a
-          href={experimentData.bugzilla_url}
-          rel="noopener noreferrer"
-          target="_blank"
-        >
-          here
-        </a>
+      <div>
+        <small>
+          Bugzilla ticket can be found{" "}
+          <a
+            href={experimentData.bugzilla_url}
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            here
+          </a>
+        </small>
       </div>
     );
   }
@@ -197,46 +197,61 @@ const ExperimentDetails: React.FC = () => {
   return (
     <div className="col pt-3">
       <div className="mb-4">
-        <div className="d-flex align-items-center">
-          <h3 className="mr-3">Experiment Summary</h3>
-          <span className="badge badge-secondary mb-1">
-            {experimentData.status}
-          </span>
+        <div className="mb-4">
+          <h3 className="mb-0">
+            {experimentData.name}{" "}
+            <span className="badge badge-pill badge-small badge-secondary">
+              {experimentData.status}
+            </span>
+          </h3>
+          {experimentData.recipe_slug && (
+            <p>
+              <code>{experimentData.recipe_slug}</code>
+            </p>
+          )}
         </div>
-        <LabelledRow label="Experiment Owner" value={experimentData.owner} />
-        <LabelledRow label="Public Name" value={experimentData.name}>
-          {bugzilla_url}
-        </LabelledRow>
-        <LabelledRow label="Hypothesis" value={experimentData.objectives} />
-        <LabelledRow
-          label="Feature"
-          value={displaySelectOptionLabels(
-            featureOptions,
-            experimentData.features,
-          )}
-        />
-        <LabelledRow
-          label="Audience"
-          value={displaySelectOptionLabels(
-            audienceOptions,
-            experimentData.audience,
-          )}
-        />
-        <LabelledRow
-          label="Firefox Minimum Version"
-          value={displaySelectOptionLabels(
-            firefoxVersionOptions,
-            experimentData.firefox_min_version,
-          )}
-        />
 
-        <LabelledRow
-          label="Firefox Channel"
-          value={displaySelectOptionLabels(
-            firefoxChannelOptions,
-            experimentData.firefox_channel,
-          )}
-        />
+        <table className="table table-bordered">
+          <tbody>
+            <LabelledRow
+              label="Experiment Owner"
+              value={experimentData.owner}
+            />
+            <LabelledRow label="Public Name" value={experimentData.name}>
+              {bugzilla_url}
+            </LabelledRow>
+            <LabelledRow label="Hypothesis" value={experimentData.objectives} />
+            <LabelledRow
+              label="Feature"
+              value={displaySelectOptionLabels(
+                featureOptions,
+                experimentData.features,
+              )}
+            />
+            <LabelledRow
+              label="Audience"
+              value={displaySelectOptionLabels(
+                audienceOptions,
+                experimentData.audience,
+              )}
+            />
+            <LabelledRow
+              label="Firefox Minimum Version"
+              value={displaySelectOptionLabels(
+                firefoxVersionOptions,
+                experimentData.firefox_min_version,
+              )}
+            />
+
+            <LabelledRow
+              label="Firefox Channel"
+              value={displaySelectOptionLabels(
+                firefoxChannelOptions,
+                experimentData.firefox_channel,
+              )}
+            />
+          </tbody>
+        </table>
 
         {monitoring_url}
 

--- a/app/experimenter/static/rapid/components/experiments/ExperimentDetails.tsx
+++ b/app/experimenter/static/rapid/components/experiments/ExperimentDetails.tsx
@@ -86,7 +86,7 @@ const ExperimentDetails: React.FC = () => {
   if (experimentData.monitoring_dashboard_url) {
     monitoring_url = (
       <>
-        <h3 className="my-4">Monitoring</h3>
+        <h4 className="my-4">Monitoring</h4>
         <p>
           The live monitoring dashboard can be found here:
           <a
@@ -112,7 +112,7 @@ const ExperimentDetails: React.FC = () => {
     const slug_underscored = experimentData.slug.split("-").join("_");
     analysis_report = (
       <>
-        <h3 className="my-4">Results</h3>
+        <h4 className="my-4">Results</h4>
         <p>
           The results will be available 7 days after the experiment is launched.
           An email will be sent to you once we start recording data.

--- a/app/experimenter/static/rapid/types/experiment.ts
+++ b/app/experimenter/static/rapid/types/experiment.ts
@@ -24,6 +24,7 @@ export interface ExperimentData {
   objectives: string;
   owner?: string;
   slug?: string;
+  recipe_slug?: string;
   reject_feedback?: RejectFeedback;
   status: ExperimentStatus;
 }


### PR DESCRIPTION
Also fixes #3093 by converting display to table.

(This will need a small rebase if https://github.com/mozilla/experimenter/pull/3206 lands first)

![image](https://user-images.githubusercontent.com/1455535/89890349-2f6b4c00-dba1-11ea-936f-c6d49633494e.png)
