### PR TITLE
Added TabRoutes component (fixes #3211)

### DIFF
--- a/app/experimenter/experiments/urls.py
+++ b/app/experimenter/experiments/urls.py
@@ -25,7 +25,7 @@ urlpatterns = [
         r"^rapid/(?P<slug>)", ExperimentRapidView.as_view(), name="experiments-rapid"
     ),
     re_path(
-        r"^rapid/new", ExperimentRapidView.as_view(), name="experiments-rapid-create"
+        r"^rapid/new/", ExperimentRapidView.as_view(), name="experiments-rapid-create"
     ),
     re_path(r"^new/$", ExperimentCreateView.as_view(), name="experiments-create"),
     re_path(

--- a/app/experimenter/experiments/urls.py
+++ b/app/experimenter/experiments/urls.py
@@ -25,7 +25,7 @@ urlpatterns = [
         r"^rapid/(?P<slug>)", ExperimentRapidView.as_view(), name="experiments-rapid"
     ),
     re_path(
-        r"^rapid/new/", ExperimentRapidView.as_view(), name="experiments-rapid-create"
+        r"^rapid/new", ExperimentRapidView.as_view(), name="experiments-rapid-create"
     ),
     re_path(r"^new/$", ExperimentCreateView.as_view(), name="experiments-create"),
     re_path(

--- a/app/experimenter/static/rapid/__tests__/experimentForm.test.tsx
+++ b/app/experimenter/static/rapid/__tests__/experimentForm.test.tsx
@@ -7,7 +7,9 @@ import {
   renderWithRouter,
   wrapInExperimentProvider,
 } from "experimenter-rapid/__tests__/utils";
-import ExperimentForm from "experimenter-rapid/components/forms/ExperimentForm";
+import ExperimentForm, {
+  SettingsForm,
+} from "experimenter-rapid/components/forms/ExperimentForm";
 import {
   ExperimentStatus,
   FirefoxChannel,
@@ -18,10 +20,10 @@ afterEach(async () => {
   fetchMock.resetMocks();
 });
 
-describe("<ExperimentForm />", () => {
+describe("<SettingsForm />", () => {
   it("renders without issues", () => {
     const { getByText } = renderWithRouter(
-      wrapInExperimentProvider(<ExperimentForm />),
+      wrapInExperimentProvider(<SettingsForm />),
     );
     expect(getByText("Save")).toBeInTheDocument();
   });
@@ -37,7 +39,7 @@ describe("<ExperimentForm />", () => {
     });
 
     const { getByLabelText } = renderWithRouter(
-      wrapInExperimentProvider(<ExperimentForm />),
+      wrapInExperimentProvider(<SettingsForm />),
       {
         route: "/test-slug/edit/",
         matchRoutePath: "/:experimentSlug/edit/",
@@ -55,7 +57,7 @@ describe("<ExperimentForm />", () => {
 
   it("makes the correct API call on save new", async () => {
     const { getByText, getByLabelText, history } = renderWithRouter(
-      wrapInExperimentProvider(<ExperimentForm />),
+      wrapInExperimentProvider(<SettingsForm />),
       {
         route: "/new/",
       },
@@ -138,7 +140,7 @@ describe("<ExperimentForm />", () => {
       getByLabelText,
       getByDisplayValue,
       history,
-    } = renderWithRouter(wrapInExperimentProvider(<ExperimentForm />), {
+    } = renderWithRouter(wrapInExperimentProvider(<SettingsForm />), {
       route: "/test-slug/edit/",
       matchRoutePath: "/:experimentSlug/edit/",
     });
@@ -194,7 +196,7 @@ describe("<ExperimentForm />", () => {
   ].forEach((fieldName) => {
     it(`shows the appropriate error message for '${fieldName}' on save`, async () => {
       const { getByText } = renderWithRouter(
-        wrapInExperimentProvider(<ExperimentForm />),
+        wrapInExperimentProvider(<SettingsForm />),
       );
       fetchMock.mockOnce(async () => {
         return {
@@ -211,5 +213,20 @@ describe("<ExperimentForm />", () => {
         expect(getByText("an error occurred")).toBeInTheDocument(),
       );
     });
+  });
+});
+
+describe("<ExperimentForm />", () => {
+  it("should render the settings form by default", () => {
+    const { getByText } = renderWithRouter(<ExperimentForm />);
+    expect(getByText("Public Name")).toBeInTheDocument();
+  });
+  it("should render the branches form for /branches route", async () => {
+    const { getByText } = renderWithRouter(<ExperimentForm />);
+
+    // Click the branches tab
+    fireEvent.click(getByText("Branches"));
+
+    await waitFor(() => expect(getByText("Branch")).toBeInTheDocument());
   });
 });

--- a/app/experimenter/static/rapid/__tests__/tabRoutes.test.tsx
+++ b/app/experimenter/static/rapid/__tests__/tabRoutes.test.tsx
@@ -1,5 +1,6 @@
 import { cleanup, fireEvent, waitFor } from "@testing-library/react";
 import React from "react";
+import { Route, useParams } from "react-router-dom";
 
 import {
   TabRoutes,
@@ -64,6 +65,28 @@ describe("<TabRoutes />", () => {
       const hasClass = getByText("Bar Label").classList.contains("active");
       return expect(hasClass).toBe(true);
     });
+  });
+  it("should have access to URL params from parent route", () => {
+    const CheckIdComponent = () => {
+      const { id } = useParams();
+      return <div>The id is {id}</div>;
+    };
+
+    const { getByText } = renderWithRouter(
+      <Route exact={true} path="/experiments/:id">
+        <TabRoutes
+          tabs={[
+            {
+              path: "",
+              label: "Hello world",
+              component: CheckIdComponent,
+            },
+          ]}
+        />
+      </Route>,
+      { route: "/experiments/fooBarBaz" },
+    );
+    expect(getByText("The id is fooBarBaz")).toBeInTheDocument();
   });
 });
 

--- a/app/experimenter/static/rapid/__tests__/tabRoutes.test.tsx
+++ b/app/experimenter/static/rapid/__tests__/tabRoutes.test.tsx
@@ -1,7 +1,10 @@
 import { cleanup, fireEvent, waitFor } from "@testing-library/react";
 import React from "react";
 
-import { TabRoutes } from "experimenter-rapid/components/forms/TabRoutes";
+import {
+  TabRoutes,
+  pathJoinWithTrailingSlash,
+} from "experimenter-rapid/components/forms/TabRoutes";
 
 import { renderWithRouter } from "./utils";
 
@@ -22,7 +25,7 @@ const TEST_CONFIG = [
 
 afterEach(cleanup);
 
-describe.only("<TabRoutes />", () => {
+describe("<TabRoutes />", () => {
   it("should render tab labels", () => {
     const { getByText } = renderWithRouter(<TabRoutes tabs={TEST_CONFIG} />);
     expect(getByText("Foo Label")).toBeInTheDocument();
@@ -42,7 +45,7 @@ describe.only("<TabRoutes />", () => {
       <TabRoutes tabs={TEST_CONFIG} />,
     );
     fireEvent.click(getByText("Bar Label"));
-    expect(history.location.pathname).toBe("/bar");
+    expect(history.location.pathname).toBe("/bar/");
   });
   it("should change the content when a tab is clicked", () => {
     const { getByText } = renderWithRouter(<TabRoutes tabs={TEST_CONFIG} />);
@@ -61,5 +64,19 @@ describe.only("<TabRoutes />", () => {
       const hasClass = getByText("Bar Label").classList.contains("active");
       return expect(hasClass).toBe(true);
     });
+  });
+});
+
+describe("pathJoinWithTrailingSlash", () => {
+  it("should add a trailing slash", () => {
+    expect(pathJoinWithTrailingSlash("foo")).toBe("foo/");
+  });
+  it("should join paths without slashes", () => {
+    expect(pathJoinWithTrailingSlash("foo", "bar")).toBe("foo/bar/");
+  });
+  it("should remove extra slashes", () => {
+    expect(pathJoinWithTrailingSlash("/foo/", "/bar/", "baz//")).toBe(
+      "/foo/bar/baz/",
+    );
   });
 });

--- a/app/experimenter/static/rapid/__tests__/tabRoutes.test.tsx
+++ b/app/experimenter/static/rapid/__tests__/tabRoutes.test.tsx
@@ -1,0 +1,65 @@
+import { cleanup, fireEvent, waitFor } from "@testing-library/react";
+import React from "react";
+
+import { TabRoutes } from "experimenter-rapid/components/forms/TabRoutes";
+
+import { renderWithRouter } from "./utils";
+
+const TestTabFoo = () => <div>Test Tab Foo</div>;
+const TestTabBar = () => <div>Test Tab Bar</div>;
+const TEST_CONFIG = [
+  {
+    path: "",
+    label: "Foo Label",
+    component: TestTabFoo,
+  },
+  {
+    path: "bar",
+    label: "Bar Label",
+    component: TestTabBar,
+  },
+];
+
+afterEach(cleanup);
+
+describe.only("<TabRoutes />", () => {
+  it("should render tab labels", () => {
+    const { getByText } = renderWithRouter(<TabRoutes tabs={TEST_CONFIG} />);
+    expect(getByText("Foo Label")).toBeInTheDocument();
+    expect(getByText("Bar Label")).toBeInTheDocument();
+  });
+  it("should render default matching route", () => {
+    const { getByText } = renderWithRouter(<TabRoutes tabs={TEST_CONFIG} />);
+    expect(getByText("Test Tab Foo")).toBeInTheDocument();
+  });
+  it("should add .active class to the active link", () => {
+    const { getByText } = renderWithRouter(<TabRoutes tabs={TEST_CONFIG} />);
+    const container = getByText("Foo Label");
+    expect(container.classList.contains("active")).toBe(true);
+  });
+  it("should change the route when a tab is clicked", () => {
+    const { getByText, history } = renderWithRouter(
+      <TabRoutes tabs={TEST_CONFIG} />,
+    );
+    fireEvent.click(getByText("Bar Label"));
+    expect(history.location.pathname).toBe("/bar");
+  });
+  it("should change the content when a tab is clicked", () => {
+    const { getByText } = renderWithRouter(<TabRoutes tabs={TEST_CONFIG} />);
+    fireEvent.click(getByText("Bar Label"));
+    waitFor(() => {
+      return expect(getByText("Test Tab Bar")).toBeInTheDocument();
+    });
+  });
+  it("should add an .active class to the active label", () => {
+    const { getByText } = renderWithRouter(<TabRoutes tabs={TEST_CONFIG} />);
+    expect(getByText("Foo Label").classList.contains("active")).toBe(true);
+
+    fireEvent.click(getByText("Bar Label"));
+
+    waitFor(() => {
+      const hasClass = getByText("Bar Label").classList.contains("active");
+      return expect(hasClass).toBe(true);
+    });
+  });
+});

--- a/app/experimenter/static/rapid/__tests__/utils.tsx
+++ b/app/experimenter/static/rapid/__tests__/utils.tsx
@@ -13,13 +13,14 @@ export function renderWithRouter(
   {
     route = "/",
     matchRoutePath = route,
+    exact = false,
     history = createMemoryHistory({ initialEntries: [route] }),
   } = {},
 ): RenderWithRouterResult {
   const Wrapper = ({ children }) => (
     <Router history={history}>
       <Switch>
-        <Route exact path={matchRoutePath}>
+        <Route exact={exact} path={matchRoutePath}>
           {children}
         </Route>
       </Switch>

--- a/app/experimenter/static/rapid/components/App.tsx
+++ b/app/experimenter/static/rapid/components/App.tsx
@@ -16,15 +16,15 @@ const App: React.FC = () => {
   return (
     <Switch>
       <Route exact path="/">
-        <Link to="/new/">Create a new experiment</Link>
+        <Link to="/new">Create a new experiment</Link>
       </Route>
-      <Route exact path="/new/">
+      <Route path="/new">
         <ExperimentFormPage />
       </Route>
-      <Route exact path="/:experimentSlug/edit/">
+      <Route path="/:experimentSlug/edit">
         <ExperimentFormPage />
       </Route>
-      <Route exact path="/:experimentSlug/">
+      <Route exact path="/:experimentSlug">
         <ExperimentDetailsPage />
       </Route>
       <Route>

--- a/app/experimenter/static/rapid/components/App.tsx
+++ b/app/experimenter/static/rapid/components/App.tsx
@@ -16,15 +16,15 @@ const App: React.FC = () => {
   return (
     <Switch>
       <Route exact path="/">
-        <Link to="/new">Create a new experiment</Link>
+        <Link to="/new/">Create a new experiment</Link>
       </Route>
-      <Route path="/new">
+      <Route path="/new/">
         <ExperimentFormPage />
       </Route>
-      <Route path="/:experimentSlug/edit">
+      <Route path="/:experimentSlug/edit/">
         <ExperimentFormPage />
       </Route>
-      <Route exact path="/:experimentSlug">
+      <Route exact path="/:experimentSlug/">
         <ExperimentDetailsPage />
       </Route>
       <Route>

--- a/app/experimenter/static/rapid/components/forms/ExperimentForm.tsx
+++ b/app/experimenter/static/rapid/components/forms/ExperimentForm.tsx
@@ -17,6 +17,7 @@ import {
   firefoxChannelOptions,
   firefoxVersionOptions,
 } from "./ExperimentFormOptions";
+import { TabRoutes } from "./TabRoutes";
 import { XSelect } from "./XSelect";
 
 interface ErrorListProperties {
@@ -37,7 +38,7 @@ const ErrorList: React.FC<ErrorListProperties> = ({ errors }) => {
   );
 };
 
-const ExperimentForm: React.FC = () => {
+export const SettingsForm: React.FC = () => {
   const formData = {
     ...useExperimentState(),
     ...{ status: ExperimentStatus.DRAFT },
@@ -192,6 +193,64 @@ const ExperimentForm: React.FC = () => {
         Save
       </button>
     </form>
+  );
+};
+
+export const BranchesForm: React.FC = () => {
+  return (
+    <div>
+      <table className="table table-bordered">
+        <thead>
+          <tr>
+            <th>Branch</th>
+            <th>Description</th>
+            <th>Content</th>
+            <th>Ratio</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>
+              <code>control</code>
+            </td>
+            <td>An empty branch.</td>
+            <td>
+              <code>(empty)</code>
+            </td>
+            <td>50%</td>
+          </tr>
+          <tr>
+            <td>
+              <code>variant</code>
+            </td>
+            <td>An empty branch.</td>
+            <td>
+              <code>(empty)</code>
+            </td>
+            <td>50%</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  );
+};
+
+const ExperimentForm: React.FC = () => {
+  return (
+    <TabRoutes
+      tabs={[
+        {
+          label: "Settings",
+          path: "",
+          component: SettingsForm,
+        },
+        {
+          label: "Branches",
+          path: "branches",
+          component: BranchesForm,
+        },
+      ]}
+    />
   );
 };
 

--- a/app/experimenter/static/rapid/components/forms/TabRoutes.tsx
+++ b/app/experimenter/static/rapid/components/forms/TabRoutes.tsx
@@ -1,0 +1,60 @@
+import React from "react";
+import {
+  NavLink,
+  Route,
+  RouteProps,
+  Switch,
+  useRouteMatch,
+} from "react-router-dom";
+
+function pathJoin(...paths: Array<string>): string {
+  return paths.join("/").replace(/\/{1,}/g, "/");
+}
+
+interface TabProps {
+  tabs: Array<{
+    className?: string;
+    label: string;
+    path: string;
+    render?: RouteProps["render"];
+    component?: RouteProps["component"];
+  }>;
+}
+
+/**
+ * Creates horizontal tabs that will also trigger a route change.
+ * Paths are relative to the page on which TabRoutes is rendered, so
+ * the default route should be path=""
+ */
+export const TabRoutes: React.FC<TabProps> = ({ tabs }) => {
+  const { url } = useRouteMatch();
+  return (
+    <div>
+      <ul className="nav nav-tabs mb-4">
+        {tabs.map((tab) => (
+          <li key={tab.path} className="nav-item">
+            <NavLink
+              activeClassName="active"
+              className="nav-link"
+              exact={true}
+              to={pathJoin(url, tab.path)}
+            >
+              {tab.label}
+            </NavLink>
+          </li>
+        ))}
+      </ul>
+      <Switch>
+        {tabs.map((tab) => (
+          <Route
+            key={tab.path}
+            component={tab.component}
+            exact={true}
+            path={pathJoin(url, tab.path)}
+            render={tab.render}
+          />
+        ))}
+      </Switch>
+    </div>
+  );
+};

--- a/app/experimenter/static/rapid/components/forms/TabRoutes.tsx
+++ b/app/experimenter/static/rapid/components/forms/TabRoutes.tsx
@@ -31,7 +31,7 @@ interface TabProps {
  * the default route should be path=""
  */
 export const TabRoutes: React.FC<TabProps> = ({ tabs }) => {
-  const { url } = useRouteMatch();
+  const { url, path } = useRouteMatch();
   return (
     <div>
       <ul className="nav nav-tabs mb-4">
@@ -54,7 +54,7 @@ export const TabRoutes: React.FC<TabProps> = ({ tabs }) => {
             key={tab.path}
             component={tab.component}
             exact={true}
-            path={pathJoinWithTrailingSlash(url, tab.path)}
+            path={pathJoinWithTrailingSlash(path, tab.path)}
             render={tab.render}
           />
         ))}

--- a/app/experimenter/static/rapid/components/forms/TabRoutes.tsx
+++ b/app/experimenter/static/rapid/components/forms/TabRoutes.tsx
@@ -7,8 +7,12 @@ import {
   useRouteMatch,
 } from "react-router-dom";
 
-function pathJoin(...paths: Array<string>): string {
-  return paths.join("/").replace(/\/{1,}/g, "/");
+/**
+ * Helper function to join paths without duplicating slashes.
+ * Adds a trailing slash to be inline with Experimenter's style of URL
+ */
+export function pathJoinWithTrailingSlash(...paths: Array<string>): string {
+  return `${paths.join("/")}/`.replace(/\/{1,}/g, "/");
 }
 
 interface TabProps {
@@ -37,7 +41,7 @@ export const TabRoutes: React.FC<TabProps> = ({ tabs }) => {
               activeClassName="active"
               className="nav-link"
               exact={true}
-              to={pathJoin(url, tab.path)}
+              to={pathJoinWithTrailingSlash(url, tab.path)}
             >
               {tab.label}
             </NavLink>
@@ -50,7 +54,7 @@ export const TabRoutes: React.FC<TabProps> = ({ tabs }) => {
             key={tab.path}
             component={tab.component}
             exact={true}
-            path={pathJoin(url, tab.path)}
+            path={pathJoinWithTrailingSlash(url, tab.path)}
             render={tab.render}
           />
         ))}


### PR DESCRIPTION
This patch adds a `TabRoutes` component that adds nested sub-routes for each tab. I added it to the experiment form page with some placeholder content for the branches tab for now (this should be replaced with UI for editing branches eventually).

#### Example usage:

```ts
<TabRoutes
  tabs={[
    {
      label: "Settings",
      path: "",
      component: SettingsForm,
    },
    {
      label: "Branches",
      path: "branches",
      component: BranchesForm,
    },
  ]}
/>
```

#### QA steps
1. Go to `experiments/rapid/new`. You should see the Settings tab by default.
2. Click the Branches tab. You should now see the Branches tab.
3. Load `experiments/rapid/new/branches` directly. You should see the Branches tab. Try creating an experiment.
4. Also check `experiments/rapid/{some experiment}/edit` and `experiments/rapid/{some experiment}/edit/branches`. Try editing an experiment and make sure your changes get saved.

![image](https://user-images.githubusercontent.com/1455535/90056110-59f5fb80-dcac-11ea-8c9e-e04251bed3fa.png)
