### PR TITLE
Set startDate/endDate to None in recipe fixes #3108

### DIFF
--- a/app/experimenter/experiments/api/v4/serializers.py
+++ b/app/experimenter/experiments/api/v4/serializers.py
@@ -50,7 +50,7 @@ class ExperimentRapidArgumentSerializer(serializers.ModelSerializer):
     proposedEnrollment = serializers.ReadOnlyField(source="proposed_enrollment")
     bucketConfig = serializers.SerializerMethodField()
     startDate = serializers.SerializerMethodField()
-    endDate = serializers.ReadOnlyField(default=None)
+    endDate = serializers.SerializerMethodField()
     branches = ExperimentRapidBranchesSerializer(many=True, source="variants")
     referenceBranch = serializers.SerializerMethodField()
 
@@ -72,7 +72,6 @@ class ExperimentRapidArgumentSerializer(serializers.ModelSerializer):
         )
 
     def get_bucketConfig(self, obj):
-
         if hasattr(obj, "bucket"):
             return ExperimentBucketRangeSerializer(obj.bucket).data
         return {
@@ -92,6 +91,11 @@ class ExperimentRapidArgumentSerializer(serializers.ModelSerializer):
         # placeholder value
         if obj.start_date:
             return obj.start_date.isoformat()
+
+    def get_endDate(self, obj):
+        # placeholder value
+        if obj.end_date:
+            return obj.end_date.isoformat()
 
 
 class ExperimentRapidRecipeSerializer(serializers.ModelSerializer):

--- a/app/experimenter/experiments/tests/api/v4/test_serializers.py
+++ b/app/experimenter/experiments/tests/api/v4/test_serializers.py
@@ -1,5 +1,3 @@
-import datetime
-
 from django.test import TestCase
 
 from experimenter.experiments.models import Experiment, ExperimentBucketNamespace
@@ -11,95 +9,30 @@ from experimenter.experiments.api.v4.serializers import ExperimentRapidRecipeSer
 
 
 class TestExperimentRapidRecipeSerializer(TestCase):
-    def test_serializer_outputs_expected_schema(self):
+    maxDiff = None
+
+    def test_serializer_outputs_expected_schema_for_accepted(self):
         audience = "us_only"
         features = ["pinned_tabs", "picture_in_picture"]
-        recipe_slug = "experimenter-normandy-slug"
-        today = datetime.datetime.today()
-        experiment = ExperimentFactory.create(
-            type=Experiment.TYPE_RAPID,
-            rapid_type=Experiment.RAPID_AA,
+        experiment = ExperimentFactory.create_with_status(
+            Experiment.STATUS_ACCEPTED,
             audience=audience,
             features=features,
-            recipe_slug=recipe_slug,
-            firefox_min_version="80.0",
-            proposed_enrollment=9,
-            proposed_start_date=today,
-        )
-
-        ExperimentVariantFactory.create(
-            experiment=experiment, slug="control", is_control=True
-        )
-        ExperimentVariantFactory.create(experiment=experiment, slug="variant-2")
-
-        serializer = ExperimentRapidRecipeSerializer(experiment)
-        data = serializer.data
-
-        arguments = data.pop("arguments")
-        branches = arguments.pop("branches")
-
-        self.assertDictEqual(
-            data,
-            {
-                "id": recipe_slug,
-                "filter_expression": "env.version|versionCompare('80.!') >= 0",
-                "targeting": None,
-                "enabled": True,
-            },
-        )
-
-        self.assertDictEqual(
-            dict(arguments),
-            {
-                "userFacingName": experiment.name,
-                "userFacingDescription": experiment.public_description,
-                "slug": recipe_slug,
-                "active": True,
-                "isEnrollmentPaused": False,
-                "endDate": None,
-                "proposedEnrollment": experiment.proposed_enrollment,
-                "features": features,
-                "referenceBranch": "control",
-                "startDate": today.isoformat(),
-                "bucketConfig": {
-                    "count": 0,
-                    "namespace": "",
-                    "randomizationUnit": "normandy_id",
-                    "start": 0,
-                    "total": 10000,
-                },
-            },
-        )
-        converted_branches = [dict(branch) for branch in branches]
-        self.assertEqual(
-            converted_branches,
-            [
-                {"ratio": 33, "slug": "variant-2", "value": None},
-                {"ratio": 33, "slug": "control", "value": None},
-            ],
-        )
-
-    def test_serializer_outputs_expected_schema_with_nameSpace_bucket(self):
-        audience = "us_only"
-        features = ["pinned_tabs", "picture_in_picture"]
-        recipe_slug = "experimenter-recipe-slug"
-        today = datetime.datetime.today()
-        experiment = ExperimentFactory.create(
-            type=Experiment.TYPE_RAPID,
-            rapid_type=Experiment.RAPID_AA,
-            audience=audience,
-            features=features,
-            recipe_slug=recipe_slug,
-            firefox_min_version="80.0",
             firefox_channel=Experiment.CHANNEL_RELEASE,
-            proposed_enrollment=9,
-            proposed_start_date=today,
+            firefox_min_version="80.0",
+            proposed_start_date=None,
+            proposed_duration=28,
+            proposed_enrollment=7,
+            rapid_type=Experiment.RAPID_AA,
+            type=Experiment.TYPE_RAPID,
         )
-
+        experiment.variants.all().delete()
         ExperimentVariantFactory.create(
-            experiment=experiment, slug="control", is_control=True
+            experiment=experiment, ratio=1, slug="control", is_control=True
         )
-        ExperimentVariantFactory.create(experiment=experiment, slug="variant-2")
+        ExperimentVariantFactory.create(
+            experiment=experiment, ratio=1, slug="treatment", is_control=False
+        )
 
         ExperimentBucketNamespace.request_namespace_buckets(
             experiment.recipe_slug, experiment, 100
@@ -114,9 +47,9 @@ class TestExperimentRapidRecipeSerializer(TestCase):
         self.assertDictEqual(
             data,
             {
-                "id": recipe_slug,
+                "id": experiment.recipe_slug,
                 "filter_expression": "env.version|versionCompare('80.!') >= 0",
-                "targeting": '[userId, "experimenter-recipe-slug"]'
+                "targeting": f'[userId, "{experiment.recipe_slug}"]'
                 "|bucketSample(0, 100, 10000) "
                 "&& localeLanguageCode == 'en' && region == 'US' "
                 "&& browserSettings.update.channel == 'release'",
@@ -124,27 +57,25 @@ class TestExperimentRapidRecipeSerializer(TestCase):
             },
         )
 
-        bucket = experiment.bucket
-
         self.assertDictEqual(
             dict(arguments),
             {
                 "userFacingName": experiment.name,
                 "userFacingDescription": experiment.public_description,
-                "slug": recipe_slug,
+                "slug": experiment.recipe_slug,
                 "active": True,
                 "isEnrollmentPaused": False,
                 "endDate": None,
                 "proposedEnrollment": experiment.proposed_enrollment,
                 "features": features,
                 "referenceBranch": "control",
-                "startDate": today.isoformat(),
+                "startDate": None,
                 "bucketConfig": {
-                    "count": bucket.count,
-                    "namespace": bucket.namespace.name,
+                    "count": experiment.bucket.count,
+                    "namespace": experiment.bucket.namespace.name,
                     "randomizationUnit": "userId",
-                    "start": bucket.start,
-                    "total": bucket.namespace.total,
+                    "start": experiment.bucket.start,
+                    "total": experiment.bucket.namespace.total,
                 },
             },
         )
@@ -152,7 +83,84 @@ class TestExperimentRapidRecipeSerializer(TestCase):
         self.assertEqual(
             converted_branches,
             [
-                {"ratio": 33, "slug": "variant-2", "value": None},
-                {"ratio": 33, "slug": "control", "value": None},
+                {"ratio": 1, "slug": "treatment", "value": None},
+                {"ratio": 1, "slug": "control", "value": None},
+            ],
+        )
+
+    def test_serializer_outputs_expected_schema_for_live(self):
+        audience = "us_only"
+        features = ["pinned_tabs", "picture_in_picture"]
+        experiment = ExperimentFactory.create_with_status(
+            Experiment.STATUS_LIVE,
+            audience=audience,
+            features=features,
+            firefox_channel=Experiment.CHANNEL_RELEASE,
+            firefox_min_version="80.0",
+            proposed_start_date=None,
+            proposed_duration=28,
+            proposed_enrollment=7,
+            rapid_type=Experiment.RAPID_AA,
+            type=Experiment.TYPE_RAPID,
+        )
+        experiment.variants.all().delete()
+        ExperimentVariantFactory.create(
+            experiment=experiment, ratio=1, slug="control", is_control=True
+        )
+        ExperimentVariantFactory.create(
+            experiment=experiment, ratio=1, slug="treatment", is_control=False
+        )
+
+        ExperimentBucketNamespace.request_namespace_buckets(
+            experiment.recipe_slug, experiment, 100
+        )
+
+        serializer = ExperimentRapidRecipeSerializer(experiment)
+        data = serializer.data
+
+        arguments = data.pop("arguments")
+        branches = arguments.pop("branches")
+
+        self.assertDictEqual(
+            data,
+            {
+                "id": experiment.recipe_slug,
+                "filter_expression": "env.version|versionCompare('80.!') >= 0",
+                "targeting": f'[userId, "{experiment.recipe_slug}"]'
+                "|bucketSample(0, 100, 10000) "
+                "&& localeLanguageCode == 'en' && region == 'US' "
+                "&& browserSettings.update.channel == 'release'",
+                "enabled": True,
+            },
+        )
+
+        self.assertDictEqual(
+            dict(arguments),
+            {
+                "userFacingName": experiment.name,
+                "userFacingDescription": experiment.public_description,
+                "slug": experiment.recipe_slug,
+                "active": True,
+                "isEnrollmentPaused": False,
+                "endDate": experiment.end_date.isoformat(),
+                "proposedEnrollment": experiment.proposed_enrollment,
+                "features": features,
+                "referenceBranch": "control",
+                "startDate": experiment.start_date.isoformat(),
+                "bucketConfig": {
+                    "count": experiment.bucket.count,
+                    "namespace": experiment.bucket.namespace.name,
+                    "randomizationUnit": "userId",
+                    "start": experiment.bucket.start,
+                    "total": experiment.bucket.namespace.total,
+                },
+            },
+        )
+        converted_branches = [dict(branch) for branch in branches]
+        self.assertEqual(
+            converted_branches,
+            [
+                {"ratio": 1, "slug": "treatment", "value": None},
+                {"ratio": 1, "slug": "control", "value": None},
             ],
         )

--- a/app/experimenter/kinto/tasks.py
+++ b/app/experimenter/kinto/tasks.py
@@ -1,5 +1,3 @@
-import datetime
-
 import markus
 from celery.utils.log import get_task_logger
 from django.conf import settings
@@ -109,7 +107,6 @@ def check_kinto_push_queue():
             next_experiment,
             {
                 "status": Experiment.STATUS_ACCEPTED,
-                "proposed_start_date": datetime.date.today(),
                 "recipe_slug": next_experiment.generate_recipe_slug(),
             },
             settings.KINTO_DEFAULT_CHANGELOG_USER,

--- a/app/experimenter/kinto/tests/test_tasks.py
+++ b/app/experimenter/kinto/tests/test_tasks.py
@@ -155,7 +155,6 @@ class TestCheckKintoPushQueue(MockKintoClientMixin, TestCase):
         experiment = Experiment.objects.get(id=experiment.id)
         self.assertEqual(experiment.changes.count(), 3)
         self.assertEqual(experiment.status, Experiment.STATUS_ACCEPTED)
-        self.assertEqual(experiment.proposed_start_date, datetime.date.today())
         self.assertEqual(experiment.firefox_min_version, Experiment.VERSION_CHOICES[0][0])
         self.assertEqual(experiment.firefox_channel, Experiment.CHANNEL_RELEASE)
         self.assertEqual(experiment.recipe_slug, "bug-12345-rapid-test-release-55")


### PR DESCRIPTION
So basically to prevent the recipe dates from being wrong, we'll just set them to `None`, not use `proposed_start_date` at all, and then when the changelog for going live appears, the real startDate/endDate will be set and available in the V4 API.