### PR TITLE
ensure type is checked for multipref recipe args fixes #3140

### DIFF
--- a/app/experimenter/experiments/models.py
+++ b/app/experimenter/experiments/models.py
@@ -204,9 +204,7 @@ class Experiment(ExperimentConstants, models.Model):
         default=default_all_platforms,
     )
     windows_versions = ArrayField(
-        models.CharField(max_length=200),
-        blank=True,
-        null=True,
+        models.CharField(max_length=200), blank=True, null=True,
     )
     profile_age = models.CharField(
         max_length=255,
@@ -927,11 +925,11 @@ class Experiment(ExperimentConstants, models.Model):
 
     @property
     def use_multi_pref_serializer(self):
-        return (
-            self.is_pref_experiment
-            and self.firefox_min_version_integer
+        return self.is_pref_experiment and (
+            self.firefox_min_version_integer
             >= ExperimentConstants.FX_MIN_MULTI_BRANCHED_VERSION
-        ) or self.is_multi_pref
+            or self.is_multi_pref
+        )
 
     @property
     def versions_integer_list(self):

--- a/app/experimenter/experiments/models.py
+++ b/app/experimenter/experiments/models.py
@@ -204,7 +204,9 @@ class Experiment(ExperimentConstants, models.Model):
         default=default_all_platforms,
     )
     windows_versions = ArrayField(
-        models.CharField(max_length=200), blank=True, null=True,
+        models.CharField(max_length=200),
+        blank=True,
+        null=True,
     )
     profile_age = models.CharField(
         max_length=255,

--- a/app/experimenter/experiments/tests/test_models.py
+++ b/app/experimenter/experiments/tests/test_models.py
@@ -1438,6 +1438,10 @@ class TestExperimentModel(TestCase):
         )
         self.assertFalse(experiment.use_multi_pref_serializer)
 
+    def test_use_multi_pref_serializer_is_false_when_type_not_pref(self):
+        experiment = ExperimentFactory(type=Experiment.TYPE_ROLLOUT, is_multi_pref=True)
+        self.assertFalse(experiment.use_multi_pref_serializer)
+
     def test_is_multi_pref_returns_false_for_addon_type(self):
         experiment = ExperimentFactory(type=Experiment.TYPE_ADDON)
         self.assertFalse(experiment.use_multi_pref_serializer)


### PR DESCRIPTION
removing fields felt a little too messy, decided to go with the simplest solution of checking is_multi_pref and is_pref_experiment