### PR TITLE
Fix v3 intermittent test failure fixes #3394

### DIFF
--- a/app/experimenter/experiments/tests/api/v3/test_serializers.py
+++ b/app/experimenter/experiments/tests/api/v3/test_serializers.py
@@ -388,6 +388,7 @@ class TestExperimentRapidSerializer(MockRequestMixin, MockBugzillaTasksMixin, Te
             audience="us_only",
             features=["picture_in_picture", "pinned_tabs"],
             firefox_channel=Experiment.CHANNEL_RELEASE,
+            firefox_min_version="79.0",
         )
         experiment.variants.all().delete()
         variant = ExperimentVariantFactory.create(experiment=experiment)
@@ -399,7 +400,7 @@ class TestExperimentRapidSerializer(MockRequestMixin, MockBugzillaTasksMixin, Te
             "audience": "all_english",
             "features": ["pinned_tabs"],
             "firefox_channel": Experiment.CHANNEL_NIGHTLY,
-            "firefox_min_version": Experiment.VERSION_CHOICES[1][0],
+            "firefox_min_version": "80.0",
             "variants": [
                 {
                     "id": variant.id,


### PR DESCRIPTION
Oops! Always declare all the expected inputs to your test factory! 