### PR TITLE
fixes #3399 chore: Change dependabot to update yarn.lock

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,17 +1,7 @@
 version: 2
 updates:
 - package-ecosystem: npm
-  directory: "/app/experimenter/nimbus-ui"
-  schedule:
-    interval: weekly
-  target-branch: dependencies
-- package-ecosystem: npm
-  directory: "/app/experimenter/legacy-ui/rapid"
-  schedule:
-    interval: weekly
-  target-branch: dependencies
-- package-ecosystem: npm
-  directory: "/app/experimenter/legacy-ui/core"
+  directory: "/app"
   schedule:
     interval: weekly
   target-branch: dependencies


### PR DESCRIPTION
Becuase

* Dependabot was configured to look at each npm dir individually it was missing the global yarn.lock

This commit

* Changes dependabot to look at root and it should pick up each workspace and update yarn.lock