### PR TITLE
fixes #3503 chore: Run circle on dependency prs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,16 +72,12 @@ workflows:
     jobs:
       - build:
           name: build
-          filters:
-            branches:
-              ignore: /dependabot.*/
       - integration:
           name: integration
           filters:
             branches:
               ignore:
                 - main
-                - /dependabot.*/
       - deploy:
           requires:
             - build

--- a/contributing.md
+++ b/contributing.md
@@ -69,14 +69,19 @@ Dependencies are automatically updated by [Dependabot](https://dependabot.com/) 
 directly into GitHub.  Each week Dependabot will create a large number of individual PRs that update
 each dependency.  To merge those into main, use the following process:
 
-1. Dependabot will create many individual PRs against the `dependencies` branch, which has no CI tasks
-or branch protections and so each of those PRs can be merged immediately by adding the following comment to
+
+### Merge Dependabot PRs
+1. Dependabot will create many individual PRs against the `dependencies` branch, which has no 
+branch protections and so each of those PRs can be merged automatically by adding the following comment to
 each PR:
         @dependabot squash and merge
+
 1. The dependencies branch can now be merged into `main` by [creating a PR using the GitHub web interface](https://github.com/mozilla/experimenter/compare/main...dependencies)
 
 1. Tag a reviewer for the Dependencies PR and when it is approved, merge it.
 
+
+### Clean up dependencies branch
 1. Check out the `main` branch on your local repo:
 
 ```


### PR DESCRIPTION
Because

* Running circle jobs against each individual dependency PR makes it easier to know
  if a single dependency change breaks the build rather than having to only run tests
  against all dependencies combined

This commit

* Enables circle jobs on dependency PRs