### PR TITLE
chore(nimbus-ui): hook up storybook publishing on build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,6 +20,9 @@ jobs:
       - run:
           name: Run tests and linting
           command: make check
+      - run:
+          name: Publish Storybooks
+          command: make publish_storybooks
 
   integration:
     machine:

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ var/
 *.egg-info/
 .installed.cfg
 *.egg
+storybook-static/
 
 # PyInstaller
 #  Usually these files are written by a python script from a template
@@ -73,6 +74,7 @@ target/
 .envrc
 
 version.json
+commit-*.txt
 
 .vscode/
 .psql_history

--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,7 @@ LOAD_COUNTRIES = python manage.py loaddata ./experimenter/base/fixtures/countrie
 LOAD_LOCALES = python manage.py loaddata ./experimenter/base/fixtures/locales.json
 LOAD_DUMMY_EXPERIMENTS = python manage.py load_dummy_experiments
 MIGRATE = python manage.py migrate
+PUBLISH_STORYBOOKS = npx github:mozilla-fxa/storybook-gcp-publisher --commit-summary commit-summary.txt --commit-description commit-description.txt --version-json version.json
 
 test_build: build
 	$(COMPOSE_TEST) build
@@ -85,6 +86,9 @@ up_detached: compose_stop compose_build
 
 generate_docs: compose_build
 	$(COMPOSE) run app sh -c "$(GENERATE_DOCS)"
+
+publish_storybooks: build
+	$(COMPOSE_TEST) run app sh -c "$(PUBLISH_STORYBOOKS)"
 
 code_format: compose_build
 	$(COMPOSE) run app sh -c "${PY_IMPORT_SORT}&&$(BLACK_FIX)&&$(ESLINT_FIX_CORE)&&$(ESLINT_FIX_RAPID)&&$(ESLINT_FIX_NIMBUS_UI)"

--- a/app/experimenter/nimbus-ui/README.md
+++ b/app/experimenter/nimbus-ui/README.md
@@ -26,7 +26,14 @@ Refer to Jest's [CLI documentation](https://jestjs.io/docs/en/cli) for more adva
 
 This project uses [Storybook](https://storybook.js.org/) to visually show each component and page of this project in various application states without requiring the full stack to run.
 
-In local development, `yarn storybook` will start a Storybook server at <http://localhost:3001> with hot module replacement to reflect live changes. We plan to push Storybook builds from pull requests and commits to a GH pages URL in the very near future.
+In local development, `yarn storybook` will start a Storybook server at <http://localhost:3001> with hot module replacement to reflect live changes. 
+
+For Pull Requests to the mozilla/experimenter repository on GitHub, Storybook builds [are published to a static website][storybook-builds] via CircleCI test runs. You can view these to see the result of changes without needing to install and run code locally.
+
+The specific build for any given PR or commit should be available as a [status check][status-check] associated with the commit - the check labelled "storybooks: pull request" should have a "details" link for the build.
+
+[storybook-builds]: https://storage.googleapis.com/mozilla-storybooks-experimenter/index.html
+[status-check]: https://docs.github.com/en/free-pro-team@latest/github/collaborating-with-issues-and-pull-requests/about-status-checks
 
 ## Writing styles
 

--- a/app/experimenter/nimbus-ui/package.json
+++ b/app/experimenter/nimbus-ui/package.json
@@ -12,6 +12,7 @@
     "lint:tsc": "tsc --noEmit --project tsconfig.json",
     "lint:styles": "stylelint --config .stylelintrc **/*.scss",
     "storybook": "start-storybook -p 3001",
+    "build-storybook": "build-storybook",
     "eject": "react-scripts eject"
   },
   "jest": {

--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -6,6 +6,14 @@ services:
     env_file: .env.sample
     environment:
       - DEBUG=False
+      - CIRCLE_PULL_REQUEST
+      - CIRCLE_BRANCH
+      - STORYBOOKS_GITHUB_REPO
+      - STORYBOOKS_GITHUB_TOKEN
+      - STORYBOOKS_GCP_PROJECT_ID
+      - STORYBOOKS_GCP_BUCKET
+      - STORYBOOKS_GCP_PRIVATE_KEY_BASE64
+      - STORYBOOKS_GCP_CLIENT_EMAIL
     volumes:
       - /app/node_modules/
     links:

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,4 +1,6 @@
 #/bin/sh
 ./scripts/echo_version_json.sh > ./app/experimenter/version.json
 cp ./app/experimenter/version.json ./app/version.json
+git log -n 1 --no-color --pretty='%s' > ./app/commit-summary.txt
+git log -n 1 --no-color --pretty=medium > ./app/commit-description.txt
 docker build -f app/Dockerfile -t app:build app/


### PR DESCRIPTION
Because

* We want to publish Storybook builds to demo and preview component work
  in nimbus-ui

This commit

* Integrates [mozilla-fxa/storybook-gcp-publisher](github.com/mozilla-fxa/storybook-gcp-publisher) into the CircleCI flow
  so that Storybooks are built and published to a Google Cloud static
  site for every test run

EXP-281
fixes #3427