### PR TITLE
fix #3634 chore(project): Use separate build and deploy Docker images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,7 +66,7 @@ jobs:
           command: |
             ./scripts/build.sh
             docker login -u $DOCKER_USER -p $DOCKER_PASS
-            docker tag app:build ${DOCKERHUB_REPO}:latest
+            docker tag app:deploy ${DOCKERHUB_REPO}:latest
             docker push ${DOCKERHUB_REPO}:latest
 
 workflows:

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -1,7 +1,7 @@
-FROM python:3.8.2
+# Build image
+FROM python:3.8.2 AS build
 
 WORKDIR /app
-EXPOSE 7001
 
 
 # Disable python pyc files
@@ -41,6 +41,7 @@ RUN poetry install
 # will exit non-zero and print what is usually just a warning in `poetry install`
 RUN poetry check
 
+
 # Node packages
 COPY ./package.json /app/package.json
 COPY ./yarn.lock /app/yarn.lock
@@ -62,3 +63,23 @@ RUN yarn workspace @experimenter/nimbus-ui build
 
 # Copy source
 COPY . /app
+
+
+# Deploy image
+FROM python:3.8.2-slim AS deploy
+
+WORKDIR /app
+EXPOSE 7001
+
+# Disable python pyc files
+ENV PYTHONDONTWRITEBYTECODE 1
+# Add poetry to path
+ENV PATH "/root/.poetry/bin:${PATH}"
+
+RUN apt-get update
+RUN apt-get --no-install-recommends install -y apt-utils ca-certificates postgresql-client
+
+COPY --from=build /app/bin/ /app/bin/
+COPY --from=build /app/experimenter/ /app/experimenter/
+COPY --from=build /app/manage.py /app/manage.py
+COPY --from=build /usr/local/lib/python3.8/site-packages/ /usr/local/lib/python3.8/site-packages/

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -3,4 +3,5 @@
 cp ./app/experimenter/version.json ./app/version.json
 git log -n 1 --no-color --pretty='%s' > ./app/commit-summary.txt
 git log -n 1 --no-color --pretty=medium > ./app/commit-description.txt
-docker build -f app/Dockerfile -t app:build app/
+docker build --target build -f app/Dockerfile -t app:build app/
+docker build --target deploy -f app/Dockerfile -t app:deploy app/


### PR DESCRIPTION
Because

* We want to shrhink the size of the deployable Docker image down from its current 2.71gb(1gb compressed)

This commit

* Adds a second stage to our Dockerfile for a deploy image which is a much more reasonable 480mb(133mb compressed)
* Use deploy image for Django container in local dev compose