### PR TITLE
fix #3633 feat: add create experiment mutation

### DIFF
--- a/app/experimenter/experiments/api/v5/__init__.py
+++ b/app/experimenter/experiments/api/v5/__init__.py
@@ -1,5 +1,6 @@
 import graphene
 
+from experimenter.experiments.api.v5.mutation import Mutation
 from experimenter.experiments.api.v5.query import Query
 
-schema = graphene.Schema(query=Query)
+schema = graphene.Schema(query=Query, mutation=Mutation)

--- a/app/experimenter/experiments/api/v5/forms.py
+++ b/app/experimenter/experiments/api/v5/forms.py
@@ -1,0 +1,9 @@
+from django import forms
+
+from experimenter.experiments.models.nimbus import NimbusExperiment
+
+
+class CreateExperimentForm(forms.ModelForm):
+    class Meta:
+        model = NimbusExperiment
+        fields = ("name", "slug", "hypothesis", "public_description")

--- a/app/experimenter/experiments/api/v5/mutation.py
+++ b/app/experimenter/experiments/api/v5/mutation.py
@@ -1,0 +1,17 @@
+import graphene
+from django.db.models import Field
+from graphene_django.forms.mutation import DjangoModelFormMutation
+
+from experimenter.experiments.api.v5.forms import CreateExperimentForm
+from experimenter.experiments.api.v5.types import NimbusExperimentType
+
+
+class CreateExperimentMutation(DjangoModelFormMutation):
+    experiment = Field(NimbusExperimentType)
+
+    class Meta:
+        form_class = CreateExperimentForm
+
+
+class Mutation(graphene.ObjectType):
+    create_experiment = CreateExperimentMutation.Field()

--- a/app/experimenter/experiments/tests/api/v5/test_mutation.py
+++ b/app/experimenter/experiments/tests/api/v5/test_mutation.py
@@ -1,0 +1,55 @@
+import json
+
+from django.conf import settings
+from django.urls import reverse
+from graphene_django.utils.testing import GraphQLTestCase
+
+from experimenter.experiments.models.nimbus import NimbusExperiment
+
+
+class TestCreateExperiment(GraphQLTestCase):
+    GRAPHQL_URL = reverse("nimbus-api-graphql")
+
+    def test_create_experiment(self):
+        user_email = "user@example.com"
+        response = self.query(
+            """
+            mutation($input: CreateExperimentMutationInput!) {
+                createExperiment(input: $input) {
+                    nimbusExperiment {
+                        status
+                        name
+                        slug
+                    }
+                    errors {
+                        field
+                        messages
+                    }
+                    clientMutationId
+                }
+            }
+            """,
+            variables={
+                "input": {
+                    "name": "test1234",
+                    "slug": "slug1234",
+                    "clientMutationId": "randomid",
+                }
+            },
+            headers={settings.OPENIDC_EMAIL_HEADER: user_email},
+        )
+        self.assertEqual(response.status_code, 200)
+        content = json.loads(response.content)
+        result = content["data"]["createExperiment"]
+        experiment = result["nimbusExperiment"]
+        self.assertEqual(
+            experiment, {"status": "DRAFT", "name": "test1234", "slug": "slug1234"}
+        )
+
+        self.assertEqual(result["clientMutationId"], "randomid")
+
+        errors = result["errors"]
+        self.assertEqual(errors, [])
+
+        exp = NimbusExperiment.objects.first()
+        self.assertEqual(exp.slug, "slug1234")


### PR DESCRIPTION
Because:

* We want to create experiments via GraphQL.

This commit:

* Add's a graphql mutation for createExperiment.

Closes #3633