### PR TITLE
fix #3661 chore(project): Dependabot PR against main

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,14 +4,14 @@ updates:
   directory: "/app"
   schedule:
     interval: weekly
-  target-branch: dependencies
+  target-branch: main
 - package-ecosystem: pip
   directory: "/app"
   schedule:
     interval: weekly
-  target-branch: dependencies
+  target-branch: main
 - package-ecosystem: pip
   directory: "/app/tests"
   schedule:
     interval: weekly
-  target-branch: dependencies
+  target-branch: main

--- a/contributing.md
+++ b/contributing.md
@@ -71,46 +71,10 @@ each dependency.  To merge those into main, use the following process:
 
 
 ### Merge Dependabot PRs
-1. Dependabot will create many individual PRs against the `dependencies` branch, which has no 
+1. Dependabot will create many individual PRs against the `main` branch, which has no
 branch protections and so each of those PRs can be merged automatically by adding the following comment to
 each PR:
         @dependabot squash and merge
-
-1. The dependencies branch can now be merged into `main` by [creating a PR using the GitHub web interface](https://github.com/mozilla/experimenter/compare/main...dependencies)
-
-1. Tag a reviewer for the Dependencies PR and when it is approved, merge it.
-
-
-### Clean up dependencies branch
-1. Check out the `main` branch on your local repo:
-
-```
-git checkout main
-```
-
-1. Make sure it's up to date with the Mozilla remote
-
-```
-git pull <mozilla> main
-```
-
-1. Delete your local dependencies branch
-
-```
-git branch -D dependencies
-```
-
-1. Recreate the dependencies branch from your up to date main
-
-```
-git checkout -B dependencies
-```
-
-1. Force push that on to the Mozilla repo
-
-```
-git push <mozilla> dependencies -f
-```  
 
 All done!
 


### PR DESCRIPTION
Because

* We're experimenting with disabling main branch protections
* And can use a few more circle credits

This commit

* Configures dependabot to PR against main