### PR TITLE
fix #2538 (Legacy): Update experiment versions after launch

### DIFF
--- a/app/experimenter/normandy/tasks.py
+++ b/app/experimenter/normandy/tasks.py
@@ -24,6 +24,8 @@ STATUS_UPDATE_MAPPING = {
     Experiment.STATUS_LIVE: Experiment.STATUS_COMPLETE,
 }
 
+NAMESPACE_FILTER_TOTAL = 10000
+
 logger = get_task_logger(__name__)
 metrics = markus.get_metrics("experiments.tasks")
 
@@ -94,7 +96,7 @@ def update_launched_experiments():
 
                 if experiment.status == Experiment.STATUS_LIVE:
                     update_is_high_population(experiment, recipe_data)
-                    update_population_percent(experiment, recipe_data)
+                    update_population_info(experiment, recipe_data)
                     set_is_paused_value_task.delay(experiment.id, recipe_data)
                     send_period_ending_emails_task(experiment)
 
@@ -152,15 +154,43 @@ def set_is_paused_value_task(experiment_id, recipe_data):
     metrics.incr("set_is_paused_value.completed")
 
 
-def update_population_percent(experiment, recipe_data):
+def update_population_info(experiment, recipe_data):
     if recipe_data and "filter_object" in recipe_data:
         filter_objects = {f["type"]: f for f in recipe_data["filter_object"]}
-        if "bucketSample" in filter_objects:
-            bucket_sample = filter_objects["bucketSample"]
-            experiment.population_percent = decimal.Decimal(
-                bucket_sample["count"] / bucket_sample["total"] * 100
+
+        update_population_percent(experiment, recipe_data, filter_objects)
+        update_firefox_versions(experiment, recipe_data, filter_objects)
+
+
+def update_population_percent(experiment, recipe_data, filter_objects):
+
+    if "bucketSample" in filter_objects:
+        bucket_sample = filter_objects["bucketSample"]
+        experiment.population_percent = decimal.Decimal(
+            bucket_sample["count"] / bucket_sample["total"] * 100
+        )
+        experiment.save()
+
+
+def update_firefox_versions(experiment, recipe_data, filter_objects):
+    changed_data = {}
+
+    if "version" in filter_objects:
+        versions = filter_objects["version"]
+        min_version = min(versions["versions"])
+        max_version = max(versions["versions"])
+        if experiment.firefox_min_version != min_version:
+            changed_data["firefox_min_version"] = min_version
+        if experiment.firefox_max_version != max(versions):
+            changed_data["firefox_max_version"] = max_version
+
+        if changed_data:
+            user_email = (
+                recipe_data.get("creator", {}).get("email", "")
+            ) or settings.NORMANDY_DEFAULT_CHANGELOG_USER
+            update_experiment_with_change_log(
+                experiment, changed_data, user_email, message="Added Version(s)"
             )
-            experiment.save()
 
 
 def update_is_high_population(experiment, recipe_data):

--- a/app/experimenter/normandy/tasks.py
+++ b/app/experimenter/normandy/tasks.py
@@ -24,8 +24,6 @@ STATUS_UPDATE_MAPPING = {
     Experiment.STATUS_LIVE: Experiment.STATUS_COMPLETE,
 }
 
-NAMESPACE_FILTER_TOTAL = 10000
-
 logger = get_task_logger(__name__)
 metrics = markus.get_metrics("experiments.tasks")
 
@@ -157,15 +155,13 @@ def set_is_paused_value_task(experiment_id, recipe_data):
 def update_population_info(experiment, recipe_data):
     if recipe_data and "filter_object" in recipe_data:
         filter_objects = {f["type"]: f for f in recipe_data["filter_object"]}
-
         update_population_percent(experiment, recipe_data, filter_objects)
         update_firefox_versions(experiment, recipe_data, filter_objects)
 
 
 def update_population_percent(experiment, recipe_data, filter_objects):
 
-    if "bucketSample" in filter_objects:
-        bucket_sample = filter_objects["bucketSample"]
+    if bucket_sample := filter_objects.get("bucketSample"):
         experiment.population_percent = decimal.Decimal(
             bucket_sample["count"] / bucket_sample["total"] * 100
         )
@@ -175,13 +171,12 @@ def update_population_percent(experiment, recipe_data, filter_objects):
 def update_firefox_versions(experiment, recipe_data, filter_objects):
     changed_data = {}
 
-    if "version" in filter_objects:
-        versions = filter_objects["version"]
-        min_version = min(versions["versions"])
-        max_version = max(versions["versions"])
+    if versions := filter_objects.get("version"):
+        min_version = min(versions["versions"]) * 1.0
+        max_version = max(versions["versions"]) * 1.0
         if experiment.firefox_min_version != min_version:
             changed_data["firefox_min_version"] = min_version
-        if experiment.firefox_max_version != max(versions):
+        if experiment.firefox_max_version != max_version:
             changed_data["firefox_max_version"] = max_version
 
         if changed_data:

--- a/app/experimenter/normandy/tests/test_tasks.py
+++ b/app/experimenter/normandy/tests/test_tasks.py
@@ -346,9 +346,7 @@ class TestUpdateExperimentTask(MockNormandyTasksMixin, MockNormandyMixin, TestCa
         mock_response_data = {
             "approved_revision": {
                 "enabled": True,
-                "filter_object": [
-                    {"type": "version", "versions": [79.0, 80.0, 81.0, 82.0]}
-                ],
+                "filter_object": [{"type": "version", "versions": [79, 80, 81, 82]}],
             }
         }
         mock_response = mock.Mock()

--- a/app/experimenter/normandy/tests/test_tasks.py
+++ b/app/experimenter/normandy/tests/test_tasks.py
@@ -335,6 +335,39 @@ class TestUpdateExperimentTask(MockNormandyTasksMixin, MockNormandyMixin, TestCa
         experiment = Experiment.objects.get(normandy_id=1234)
         self.assertEqual(experiment.population_percent, decimal.Decimal("50.000"))
 
+    def test_firefox_version_updates(self):
+        experiment = ExperimentFactory.create(
+            status=Experiment.STATUS_LIVE,
+            normandy_id=1234,
+            firefox_min_version="80.0",
+            firefox_max_version="80.0",
+        )
+
+        mock_response_data = {
+            "approved_revision": {
+                "enabled": True,
+                "filter_object": [
+                    {"type": "version", "versions": [79.0, 80.0, 81.0, 82.0]}
+                ],
+            }
+        }
+        mock_response = mock.Mock()
+        mock_response.json = mock.Mock()
+        mock_response.json.return_value = mock_response_data
+        mock_response.raise_for_status = mock.Mock()
+        mock_response.raise_for_status.side_effect = None
+        mock_response.status_code = 200
+
+        self.mock_normandy_requests_get.return_value = mock_response
+
+        tasks.update_launched_experiments()
+        experiment = Experiment.objects.get(normandy_id=1234)
+
+        self.assertEqual(experiment.firefox_min_version, "79.0")
+        self.assertEqual(experiment.firefox_max_version, "82.0")
+
+        self.assertTrue(experiment.changes.filter(message="Added Version(s)").exists())
+
     def test_live_isHighPopulation_update(self):
         experiment = ExperimentFactory.create(
             type=Experiment.TYPE_PREF,


### PR DESCRIPTION
Because

* After an experiment is launched and versions are changed, it's not reflected

This commit
* Add an additional task to check to ensure versions in experiment and normandy are the same,
  else it updates experimenter to reflect these changes, with a changelog added