### PR TITLE
fixes #3630 feat(backend): add status experiment filter

### DIFF
--- a/app/experimenter/experiments/api/v5/query.py
+++ b/app/experimenter/experiments/api/v5/query.py
@@ -5,7 +5,15 @@ from experimenter.experiments.models.nimbus import NimbusExperiment
 
 
 class Query(graphene.ObjectType):
-    all_experiments = graphene.List(NimbusExperimentType)
+    experiments_by_status = graphene.Field(
+        graphene.List(NimbusExperimentType),
+        status=graphene.Argument(
+            NimbusExperimentType._meta.fields["status"]._type, required=False
+        ),
+    )
+    all_experiments = graphene.List(
+        NimbusExperimentType,
+    )
     experiment_by_slug = graphene.Field(
         NimbusExperimentType, slug=graphene.String(required=True)
     )
@@ -18,3 +26,6 @@ class Query(graphene.ObjectType):
             return NimbusExperiment.objects.get(slug=slug)
         except NimbusExperiment.DoesNotExist:
             return None
+
+    def resolve_experiments_by_status(root, info, status):
+        return NimbusExperiment.objects.filter(status=status).all()

--- a/app/experimenter/experiments/tests/api/v5/test_query.py
+++ b/app/experimenter/experiments/tests/api/v5/test_query.py
@@ -79,3 +79,31 @@ class TestExperimentListView(GraphQLTestCase):
         content = json.loads(response.content)
         experiment = content["data"]["experimentBySlug"]
         self.assertIsNone(experiment)
+
+    def test_experiments_by_status(self):
+        user_email = "user@example.com"
+        draft_exp = NimbusExperimentFactory.create_with_status(
+            NimbusExperiment.Status.DRAFT
+        )
+        NimbusExperimentFactory.create_with_status(NimbusExperiment.Status.ACCEPTED)
+
+        response = self.query(
+            """
+            query {
+                experimentsByStatus(status: DRAFT) {
+                    name
+                    slug
+                    publicDescription
+                }
+            }
+            """,
+            headers={settings.OPENIDC_EMAIL_HEADER: user_email},
+        )
+        self.assertEqual(response.status_code, 200)
+        content = json.loads(response.content)
+        experiments = content["data"]["experimentsByStatus"]
+        self.assertEqual(len(experiments), 1)
+        for key in experiments[0]:
+            self.assertEqual(
+                experiments[0][key], str(getattr(draft_exp, to_snake_case(key)))
+            )

--- a/app/experimenter/experiments/tests/factories/nimbus.py
+++ b/app/experimenter/experiments/tests/factories/nimbus.py
@@ -50,6 +50,7 @@ class NimbusExperimentFactory(factory.django.DjangoModelFactory):
 
         NimbusBranchFactory.create(experiment=experiment)
         experiment.control_branch = NimbusBranchFactory.create(experiment=experiment)
+        experiment.status = target_status
         experiment.save()
 
         for status, _ in NimbusExperiment.Status.choices:


### PR DESCRIPTION
Because:

* We want to filter experiments by their status for display.

This commit:

* Adds a new experimentsByStatus query.

Closes #3630