### PR TITLE
fix #3674 chore(project): Add /usr/local/bin/ to app:deploy

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -82,4 +82,5 @@ RUN apt-get --no-install-recommends install -y apt-utils ca-certificates postgre
 COPY --from=build /app/bin/ /app/bin/
 COPY --from=build /app/experimenter/ /app/experimenter/
 COPY --from=build /app/manage.py /app/manage.py
+COPY --from=build /usr/local/bin/ /usr/local/bin/
 COPY --from=build /usr/local/lib/python3.8/site-packages/ /usr/local/lib/python3.8/site-packages/


### PR DESCRIPTION
Because

* For gunicorn to start the executable needs to be copied over

This commit

* Copies /usr/local/bin/ over to app:deploy container