### PR TITLE
fix #3428 feat(nimbus-ui): add AppErrorBoundary and Sentry for error logging

### DIFF
--- a/app/experimenter/nimbus-ui/package.json
+++ b/app/experimenter/nimbus-ui/package.json
@@ -16,9 +16,12 @@
     "eject": "react-scripts eject"
   },
   "jest": {
-    "collectCoverageFrom": ["!src/**/*.stories.*"]
+    "collectCoverageFrom": [
+      "!src/**/*.stories.*"
+    ]
   },
   "dependencies": {
+    "@sentry/browser": "^5.24.2",
     "bootstrap": "^4.5.2",
     "react": "^16.13.1",
     "react-bootstrap": "^1.3.0",

--- a/app/experimenter/nimbus-ui/src/components/AppErrorBoundary/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/AppErrorBoundary/index.test.tsx
@@ -1,0 +1,46 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import AppErrorBoundary from ".";
+
+describe("AppErrorBoundary", () => {
+  let origError: typeof global.console.error;
+
+  beforeEach(() => {
+    origError = global.console.error;
+    global.console.error = jest.fn();
+  });
+
+  afterEach(() => {
+    global.console.error = origError;
+  });
+
+  it("renders children that do not cause exceptions", () => {
+    const GoodComponent = () => <p data-testid="good-component">Hi</p>;
+
+    render(
+      <AppErrorBoundary>
+        <GoodComponent />
+      </AppErrorBoundary>,
+    );
+
+    expect(screen.queryByTestId("error-loading-app")).not.toBeInTheDocument();
+  });
+
+  it("renders a general error dialog on exception in child component", () => {
+    const BadComponent = () => {
+      throw new Error("bad");
+    };
+
+    render(
+      <AppErrorBoundary>
+        <BadComponent />
+      </AppErrorBoundary>,
+    );
+
+    expect(screen.queryByTestId("error-loading-app")).toBeInTheDocument();
+  });
+});

--- a/app/experimenter/nimbus-ui/src/components/AppErrorBoundary/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/AppErrorBoundary/index.tsx
@@ -1,0 +1,33 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from "react";
+import AppErrorDialog from "../AppErrorDialog";
+import sentryMetrics from "../../services/sentry";
+
+class AppErrorBoundary extends React.Component {
+  state: {
+    error: undefined | Error;
+  };
+
+  constructor(props: {}) {
+    super(props);
+    this.state = { error: undefined };
+  }
+
+  static getDerivedStateFromError(error: Error) {
+    return { error };
+  }
+
+  componentDidCatch(error: Error) {
+    sentryMetrics.captureException(error);
+  }
+
+  render() {
+    const { error } = this.state;
+    return error ? <AppErrorDialog {...{ error }} /> : this.props.children;
+  }
+}
+
+export default AppErrorBoundary;

--- a/app/experimenter/nimbus-ui/src/components/AppErrorDialog/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/AppErrorDialog/index.stories.tsx
@@ -1,0 +1,7 @@
+import React from "react";
+import { storiesOf } from "@storybook/react";
+import AppErrorDialog from "./index";
+
+storiesOf("Components/AppErrorDialog", module).add("basic", () => (
+  <AppErrorDialog error={new Error("Uh oh!")} />
+));

--- a/app/experimenter/nimbus-ui/src/components/AppErrorDialog/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/AppErrorDialog/index.test.tsx
@@ -1,0 +1,17 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from "react";
+import { render } from "@testing-library/react";
+import AppErrorDialog from ".";
+
+describe("AppErrorDialog", () => {
+  it("renders a general error dialog", () => {
+    const { queryByTestId } = render(
+      <AppErrorDialog error={new Error("bad")} />,
+    );
+
+    expect(queryByTestId("error-loading-app")).toBeInTheDocument();
+  });
+});

--- a/app/experimenter/nimbus-ui/src/components/AppErrorDialog/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/AppErrorDialog/index.tsx
@@ -1,0 +1,25 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from "react";
+
+const AppErrorDialog = ({ error }: { error: Error }) => {
+  return (
+    <div className="bg-grey-20 flex items-center flex-col justify-center h-screen">
+      <div className="text-center max-w-lg">
+        <h2
+          className="text-grey-600 font-header text-lg font-bold mb-3"
+          data-testid="error-loading-app"
+        >
+          General application error
+        </h2>
+        <p className="text-grey-400">
+          Something went wrong. Please try again later.
+        </p>
+      </div>
+    </div>
+  );
+};
+
+export default AppErrorDialog;

--- a/app/experimenter/nimbus-ui/src/components/AppLayout/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/AppLayout/index.stories.tsx
@@ -6,7 +6,7 @@ import React from "react";
 import { storiesOf } from "@storybook/react";
 import AppLayout from ".";
 
-storiesOf("AppLayout", module).add("default", () => (
+storiesOf("components/AppLayout", module).add("default", () => (
   <AppLayout>
     <p>App contents go here</p>
   </AppLayout>

--- a/app/experimenter/nimbus-ui/src/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/index.test.tsx
@@ -5,6 +5,7 @@
 import React from "react";
 import ReactDOM from "react-dom";
 import App from "./components/App";
+import AppErrorBoundary from "./components/AppErrorBoundary";
 
 jest.mock("react-dom", () => ({ render: jest.fn() }));
 
@@ -16,7 +17,9 @@ describe("index.tsx", () => {
     require("./index");
     expect(ReactDOM.render).toHaveBeenCalledWith(
       <React.StrictMode>
-        <App />
+        <AppErrorBoundary>
+          <App />
+        </AppErrorBoundary>
       </React.StrictMode>,
       div,
     );

--- a/app/experimenter/nimbus-ui/src/index.tsx
+++ b/app/experimenter/nimbus-ui/src/index.tsx
@@ -5,11 +5,14 @@
 import React from "react";
 import ReactDOM from "react-dom";
 import App from "./components/App";
+import AppErrorBoundary from "./components/AppErrorBoundary";
 import "./styles/index.scss";
 
 ReactDOM.render(
   <React.StrictMode>
-    <App />
+    <AppErrorBoundary>
+      <App />
+    </AppErrorBoundary>              
   </React.StrictMode>,
   document.getElementById("root"),
 );

--- a/app/experimenter/nimbus-ui/src/services/logger.test.ts
+++ b/app/experimenter/nimbus-ui/src/services/logger.test.ts
@@ -1,0 +1,68 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Logger from "./logger";
+
+type ValueOf<T> = T[keyof T];
+const loggerMethodNames = ["info", "trace", "warn", "error"] as const;
+
+describe("services/logger", () => {
+  let logger: Logger;
+
+  describe("constructor", () => {
+    it("should create logger with expected methods", () => {
+      logger = new Logger();
+      for (const loggerMethodName of loggerMethodNames) {
+        expect(typeof logger[loggerMethodName]).toEqual("function");
+      }
+    });
+  });
+
+  loggerMethodNames.forEach((loggerMethodName) => {
+    describe(loggerMethodName, () => {
+      const windowLogMethod = loggerMethodName;
+      let origMethod: ValueOf<typeof global.console>;
+      let mockMethod: Function;
+
+      beforeEach(() => {
+        origMethod = global.console[windowLogMethod];
+        mockMethod = jest.fn();
+        global.console[windowLogMethod] = mockMethod as typeof origMethod;
+      });
+
+      afterEach(() => {
+        global.console[windowLogMethod] = origMethod;
+      });
+
+      it(`should use expected window.console.${windowLogMethod}`, () => {
+        const msg = `log message for ${loggerMethodName}`;
+        logger[loggerMethodName](msg);
+        expect(mockMethod).toHaveBeenCalledWith(msg);
+      });
+
+      if (loggerMethodName === "error") {
+        it("should do nothing if error method is missing", () => {
+          // @ts-ignore next
+          global.console.error = null;
+          logger.error("this should be ignored");
+          expect(mockMethod).not.toHaveBeenCalled();
+        });
+
+        it("should log from object", () => {
+          const error = {
+            message: "something went wrong",
+            errorModule: {
+              toInterpolatedMessage: jest.fn(() => "whew"),
+            },
+          };
+          logger.error(error);
+          expect(error.errorModule.toInterpolatedMessage).toHaveBeenCalledWith(
+            error,
+          );
+          expect(mockMethod).toHaveBeenCalledWith("whew");
+        });
+      }
+    });
+  });
+});

--- a/app/experimenter/nimbus-ui/src/services/logger.ts
+++ b/app/experimenter/nimbus-ui/src/services/logger.ts
@@ -1,0 +1,81 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * Logging module that performs proper checks and string
+ * interpolation before logging message.
+ *
+ */
+
+interface ModuleError {
+  errorModule: {
+    toInterpolatedMessage: (arg0: ModuleError) => string;
+  };
+}
+
+/**
+ * Constructor of log module.
+ *
+ * @param {Object} console Console object used for logging.
+ *
+ * @constructor
+ */
+class Logger {
+  private _console: Console;
+
+  constructor(console: Console = window.console) {
+    this._console = console;
+  }
+
+  /**
+   * Wrapper for `console.info` function that checks for availability and
+   * then prints info.
+   *
+   */
+  info(...args: any) {
+    this._console?.info(...args);
+  }
+
+  /**
+   * Wrapper for `console.trace` function that checks for availability and then prints
+   * trace.
+   *
+   */
+  trace(...args: any) {
+    this._console?.trace(...args);
+  }
+
+  /**
+   * Wrapper for `console.warn` function that checks for availability and
+   * then prints warn.
+   *
+   */
+  warn(...args: any) {
+    this._console?.warn(...args);
+  }
+
+  /**
+   * Wrapper for `console.error` function that checks for availability and interpolates
+   * error messages if a translation exists.
+   *
+   * @param {Error} error Error object with optional errorModule.
+   */
+  error(...args: any) {
+    if (this._console?.error) {
+      let errorMessage = "";
+
+      // If error module is present, attempt to interpolate string, else use error object message
+      if (args[0]?.errorModule) {
+        const error = args[0];
+        errorMessage = error.errorModule.toInterpolatedMessage(error);
+        this._console.error(errorMessage);
+      } else {
+        // Use regular console.error
+        this._console.error(...args);
+      }
+    }
+  }
+}
+
+export default Logger;

--- a/app/experimenter/nimbus-ui/src/services/sentry.test.ts
+++ b/app/experimenter/nimbus-ui/src/services/sentry.test.ts
@@ -1,0 +1,268 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import * as Sentry from "@sentry/browser";
+import sentryMetrics, { _Sentry } from "./sentry";
+
+const dsn = "https://public:private@host:port/1";
+type ValueOf<T> = T[keyof T];
+const loggerMethodNames = ["info", "trace", "warn", "error"] as const;
+
+describe("services/sentry", () => {
+  let origMethods: { [name: string]: ValueOf<typeof global.console> } = {};
+
+  beforeEach(() => {
+    // Reduce console log noise in test output
+    loggerMethodNames.forEach((name) => {
+      origMethods[name] = global.console[name];
+      global.console[name] = jest.fn();
+    });
+  });
+
+  afterEach(() => {
+    loggerMethodNames.forEach((name) => {
+      global.console[name] = origMethods[name];
+    });
+  });
+
+  describe("configure", () => {
+    let sentryInit: jest.SpyInstance;
+
+    beforeEach(() => {
+      sentryInit = jest.spyOn(_Sentry, "init").mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+      sentryInit.mockRestore();
+    });
+
+    it("properly configures with dsn", () => {
+      let errThrown = null;
+      try {
+        sentryMetrics.configure(dsn);
+      } catch (e) {
+        errThrown = e;
+      }
+      expect(errThrown).toBeNull();
+      expect(sentryInit).toHaveBeenCalled();
+      expect(global.console.error).not.toHaveBeenCalled();
+    });
+
+    it("logs an error without dsn", () => {
+      let errThrown = null;
+      try {
+        // @ts-ignore
+        sentryMetrics.configure(null);
+      } catch (e) {
+        errThrown = e;
+      }
+      expect(errThrown).toBeNull();
+      expect(sentryInit).not.toHaveBeenCalled();
+      expect(global.console.error).toHaveBeenCalled();
+    });
+  });
+
+  describe("beforeSend", () => {
+    beforeEach(() => {
+      sentryMetrics.configure(dsn);
+    });
+
+    it("works without request url", () => {
+      const data = {
+        key: "value",
+      } as Sentry.Event;
+
+      const resultData = sentryMetrics.__beforeSend(data);
+
+      expect(data).toEqual(resultData);
+    });
+
+    it("fingerprints errno", () => {
+      const data = {
+        request: {
+          url: "https://example.com",
+        },
+        tags: {
+          errno: "100",
+        },
+      } as Sentry.Event;
+
+      const resultData = sentryMetrics.__beforeSend(data);
+
+      expect(resultData.fingerprint![0]).toEqual("errno100");
+      expect(resultData.level).toEqual(Sentry.Severity.Info);
+    });
+
+    it("properly erases sensitive information from url", () => {
+      const url = "https://accounts.firefox.com/complete_reset_password";
+      const badQuery =
+        "?token=foo&code=bar&email=some%40restmail.net&service=sync";
+      const goodQuery = "?token=VALUE&code=VALUE&email=VALUE&service=sync";
+      const badData = {
+        request: {
+          url: url + badQuery,
+        },
+      };
+
+      const goodData = {
+        request: {
+          url: url + goodQuery,
+        },
+      };
+
+      const resultData = sentryMetrics.__beforeSend(badData);
+      expect(resultData.request!.url).toEqual(goodData.request.url);
+    });
+
+    it("properly erases sensitive information from referrer", () => {
+      const url = "https://accounts.firefox.com/complete_reset_password";
+      const badQuery =
+        "?token=foo&code=bar&email=some%40restmail.net&service=sync";
+      const goodQuery = "?token=VALUE&code=VALUE&email=VALUE&service=sync";
+      const badData = {
+        request: {
+          headers: {
+            Referer: url + badQuery,
+          },
+        },
+      };
+
+      const goodData = {
+        request: {
+          headers: {
+            Referer: url + goodQuery,
+          },
+        },
+      };
+
+      const resultData = sentryMetrics.__beforeSend(badData);
+      expect(resultData.request?.headers?.Referer).toEqual(
+        goodData.request.headers.Referer,
+      );
+    });
+
+    it("properly erases sensitive information from abs_path", () => {
+      const url = "https://accounts.firefox.com/complete_reset_password";
+      const badCulprit =
+        "https://accounts.firefox.com/scripts/57f6d4e4.main.js";
+      const badAbsPath =
+        "https://accounts.firefox.com/complete_reset_password?token=foo&code=bar&email=a@a.com&service=sync&resume=barbar";
+      const goodAbsPath =
+        "https://accounts.firefox.com/complete_reset_password?token=VALUE&code=VALUE&email=VALUE&service=sync&resume=VALUE";
+      const data = {
+        culprit: badCulprit,
+        exception: {
+          values: [
+            {
+              stacktrace: {
+                frames: [
+                  {
+                    abs_path: badAbsPath, // eslint-disable-line camelcase
+                  },
+                  {
+                    abs_path: badAbsPath, // eslint-disable-line camelcase
+                  },
+                ],
+              },
+            },
+          ],
+        },
+        request: {
+          url,
+        },
+      };
+
+      const resultData = sentryMetrics.__beforeSend(data);
+
+      expect(
+        resultData.exception!.values![0].stacktrace!.frames![0].abs_path,
+      ).toEqual(goodAbsPath);
+      expect(
+        resultData.exception!.values![0].stacktrace!.frames![1].abs_path,
+      ).toEqual(goodAbsPath);
+    });
+
+    it("properly ignores some unexpected data structure in exception", () => {
+      const url = "https://accounts.firefox.com/complete_reset_password";
+      const badCulprit =
+        "https://accounts.firefox.com/scripts/57f6d4e4.main.js";
+      const data = {
+        culprit: badCulprit,
+        exception: {
+          values: [
+            {
+              stacktrace: {
+                frames: [{}],
+              },
+            },
+            {
+              stacktrace: {},
+            },
+          ],
+        },
+        request: {
+          url,
+        },
+      };
+      const resultData = sentryMetrics.__beforeSend(data);
+      expect(resultData).toEqual(data);
+    });
+  });
+
+  describe("cleanUpQueryParam", () => {
+    it("properly erases sensitive information", () => {
+      const fixtureUrl =
+        "https://accounts.firefox.com/complete_reset_password?token=foo&code=bar&email=some%40restmail.net";
+      const expectedUrl =
+        "https://accounts.firefox.com/complete_reset_password?token=VALUE&code=VALUE&email=VALUE";
+      const resultUrl = sentryMetrics.__cleanUpQueryParam(fixtureUrl);
+
+      expect(resultUrl).toEqual(expectedUrl);
+    });
+
+    it("properly erases sensitive information, keeps allowed fields", () => {
+      const fixtureUrl =
+        "https://accounts.firefox.com/signup?client_id=foo&service=sync";
+      const expectedUrl =
+        "https://accounts.firefox.com/signup?client_id=foo&service=sync";
+      const resultUrl = sentryMetrics.__cleanUpQueryParam(fixtureUrl);
+
+      expect(resultUrl).toEqual(expectedUrl);
+    });
+
+    it("properly returns the url when there is no query", () => {
+      const expectedUrl = "https://accounts.firefox.com/signup";
+      const resultUrl = sentryMetrics.__cleanUpQueryParam(expectedUrl);
+
+      expect(resultUrl).toEqual(expectedUrl);
+    });
+  });
+
+  describe("captureException", () => {
+    let sentryCaptureException: jest.SpyInstance;
+
+    beforeEach(() => {
+      sentryCaptureException = jest
+        .spyOn(_Sentry, "captureException")
+        .mockImplementation(() => "");
+    });
+
+    afterEach(() => {
+      sentryCaptureException.mockRestore();
+    });
+
+    it("calls Sentry.captureException", () => {
+      const error = new Error("testo");
+      sentryMetrics.captureException(error);
+      expect(sentryCaptureException).toHaveBeenCalled();
+    });
+
+    it("handles error tags with errno", () => {
+      const error = new Error("testo");
+      Object.assign(error, { errno: 110 });
+      sentryMetrics.captureException(error);
+      expect(sentryCaptureException).toHaveBeenCalled();
+    });
+  });
+});

--- a/app/experimenter/nimbus-ui/src/services/sentry.ts
+++ b/app/experimenter/nimbus-ui/src/services/sentry.ts
@@ -1,0 +1,180 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import * as Sentry from "@sentry/browser";
+import Logger from "./logger";
+
+// HACK: allow tests to stub this function from Sentry
+// https://stackoverflow.com/questions/35240469/how-to-mock-the-imports-of-an-es6-module
+export const _Sentry = {
+  init: Sentry.init,
+  captureException: Sentry.captureException,
+  withScope: Sentry.withScope,
+};
+
+const ALLOWED_QUERY_PARAMETERS = [
+  "automatedBrowser",
+  "client_id",
+  "context",
+  "entrypoint",
+  "keys",
+  "migration",
+  "redirect_uri",
+  "scope",
+  "service",
+  "setting",
+  "style",
+];
+
+/**
+ * function that gets called before data gets sent to error metrics
+ *
+ * @param {Object} data
+ *  Error object data
+ * @returns {Object} data
+ *  Modified error object data
+ * @private
+ */
+function beforeSend(data: Sentry.Event): Sentry.Event {
+  if (data.request) {
+    if (data.request.url) {
+      data.request.url = cleanUpQueryParam(data.request.url);
+    }
+
+    // if this is a known errno, then use grouping with fingerprints
+    // Docs: https://docs.sentry.io/hosted/learn/rollups/#fallback-grouping
+    if (data.tags?.errno) {
+      data.fingerprint = ["errno" + data.tags.errno];
+      // if it is a known error change the error level to info.
+      data.level = Sentry.Severity.Info;
+    }
+
+    if (data.exception?.values) {
+      data.exception.values.forEach((value: Sentry.Exception) => {
+        if (value.stacktrace?.frames) {
+          value.stacktrace.frames.forEach((frame: { abs_path?: string }) => {
+            if (frame.abs_path) {
+              frame.abs_path = cleanUpQueryParam(frame.abs_path); // eslint-disable-line camelcase
+            }
+          });
+        }
+      });
+    }
+
+    if (data.request.headers?.Referer) {
+      data.request.headers.Referer = cleanUpQueryParam(
+        data.request.headers.Referer,
+      );
+    }
+  }
+
+  return data;
+}
+
+/**
+ * Overwrites sensitive query parameters with a dummy value.
+ *
+ * @param {String} url
+ * @returns {String} url
+ * @private
+ */
+function cleanUpQueryParam(url: string) {
+  const urlObj = new URL(url);
+
+  if (!urlObj.search.length) {
+    return url;
+  }
+
+  // Iterate the search parameters.
+  urlObj.searchParams.forEach((_, key) => {
+    if (!ALLOWED_QUERY_PARAMETERS.includes(key)) {
+      // if the param is a PII (not allowed) then reset the value.
+      urlObj.searchParams.set(key, "VALUE");
+    }
+  });
+
+  return urlObj.href;
+}
+
+/**
+ * Exception fields that are imported as tags
+ */
+const exceptionTags = ["code", "context", "errno", "namespace", "status"];
+
+interface SentryMetrics {
+  _logger: Logger;
+  configure: (arg0: string, arg1?: string) => void;
+  captureException: (arg0: Error) => void;
+  __beforeSend: (arg0: Sentry.Event) => Sentry.Event;
+  __cleanUpQueryParam: (arg0: string) => string;
+}
+
+/**
+ * Creates a SentryMetrics singleton object that starts up Sentry/browser.
+ *
+ * This must be configured with the `configure` method before use.
+ *
+ * Read more at https://docs.sentry.io/platforms/javascript
+ *
+ * @constructor
+ */
+const SentryMetrics = (function (this: SentryMetrics) {
+  this._logger = new Logger();
+} as any) as new () => SentryMetrics;
+
+SentryMetrics.prototype = {
+  /**
+   * Configure the SentryMetrics instance for this singleton.
+   *
+   * @param {String} dsn
+   * @param {String} [release] - settings release version
+   */
+  configure(dsn: string, release: string) {
+    this._logger.info("release: " + release);
+    this._release = release;
+    if (!dsn) {
+      this._logger.error("No Sentry dsn provided");
+      return;
+    }
+
+    try {
+      _Sentry.init({
+        release,
+        dsn,
+        beforeSend,
+      });
+    } catch (e) {
+      this._logger.error(e);
+    }
+  },
+  /**
+   * Capture an exception. Error fields listed in exceptionTags
+   * will be added as tags to the sentry data.
+   *
+   * @param {Error} err
+   */
+  captureException(err: Error) {
+    _Sentry.withScope((scope: Sentry.Scope) => {
+      exceptionTags.forEach((tagName) => {
+        if (tagName in err) {
+          scope.setTag(
+            tagName,
+            (err as {
+              [key: string]: any;
+            })[tagName],
+          );
+        }
+      });
+      _Sentry.captureException(err);
+    });
+  },
+
+  // Private functions, exposed for testing
+  __beforeSend: beforeSend,
+  __cleanUpQueryParam: cleanUpQueryParam,
+};
+
+const sentryMetrics = new SentryMetrics();
+
+export default sentryMetrics;

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -1993,6 +1993,58 @@
     estree-walker "^1.0.1"
     picomatch "^2.2.2"
 
+"@sentry/browser@^5.24.2":
+  version "5.24.2"
+  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-5.24.2.tgz#e2c2786dbf07699ee12f12babf0138d633abc494"
+  integrity sha512-P/uZC/VrLRpU7MVEJnlZK5+AkEmuHu+mns5gC91Z4gjn7GamjR/CaXVedHGw/15ZrsQiAiwoWwuxpv4Ypd/+SA==
+  dependencies:
+    "@sentry/core" "5.24.2"
+    "@sentry/types" "5.24.2"
+    "@sentry/utils" "5.24.2"
+    tslib "^1.9.3"
+
+"@sentry/core@5.24.2":
+  version "5.24.2"
+  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-5.24.2.tgz#1724652855c0887a690c3fc6acd2519d4072b511"
+  integrity sha512-nuAwCGU1l9hgMinl5P/8nIQGRXDP2FI9cJnq5h1qiP/XIOvJkJz2yzBR6nTyqr4vBth0tvxQJbIpDNGd7vHJLg==
+  dependencies:
+    "@sentry/hub" "5.24.2"
+    "@sentry/minimal" "5.24.2"
+    "@sentry/types" "5.24.2"
+    "@sentry/utils" "5.24.2"
+    tslib "^1.9.3"
+
+"@sentry/hub@5.24.2":
+  version "5.24.2"
+  resolved "https://registry.yarnpkg.com/@sentry/hub/-/hub-5.24.2.tgz#64a02fd487599945e488ae23aba4ce4df44ee79e"
+  integrity sha512-xmO1Ivvpb5Qr9WgekinuZZlpl9Iw7iPETUe84HQOhUrXf+2gKO+LaUYMMsYSVDwXQEmR6/tTMyOtS6iavldC6w==
+  dependencies:
+    "@sentry/types" "5.24.2"
+    "@sentry/utils" "5.24.2"
+    tslib "^1.9.3"
+
+"@sentry/minimal@5.24.2":
+  version "5.24.2"
+  resolved "https://registry.yarnpkg.com/@sentry/minimal/-/minimal-5.24.2.tgz#14e8b136842398a32987459f0574359b6dc57a1f"
+  integrity sha512-biFpux5bI3R8xiD/Zzvrk1kRE6bqPtfWXmZYAHRtaUMCAibprTKSY9Ta8QYHynOAEoJ5Akedy6HUsEkK5DoZfA==
+  dependencies:
+    "@sentry/hub" "5.24.2"
+    "@sentry/types" "5.24.2"
+    tslib "^1.9.3"
+
+"@sentry/types@5.24.2":
+  version "5.24.2"
+  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-5.24.2.tgz#e2c25d1e75d8dbec5dbbd9a309a321425b61c2ca"
+  integrity sha512-HcOK00R0tQG5vzrIrqQ0jC28+z76jWSgQCzXiessJ5SH/9uc6NzdO7sR7K8vqMP2+nweCHckFohC8G0T1DLzuQ==
+
+"@sentry/utils@5.24.2":
+  version "5.24.2"
+  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-5.24.2.tgz#90b7dff939bbbf4bb8edcac6aac2d04a0552af80"
+  integrity sha512-oPGde4tNEDHKk0Cg9q2p0qX649jLDUOwzJXHKpd0X65w3A6eJByDevMr8CSzKV9sesjrUpxqAv6f9WWlz185tA==
+  dependencies:
+    "@sentry/types" "5.24.2"
+    tslib "^1.9.3"
+
 "@sinonjs/commons@^1.7.0":
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.8.1.tgz#e7df00f98a203324f6dc7cc606cad9d4a8ab2217"
@@ -16992,7 +17044,7 @@ tsconfig-paths@^3.9.0:
     minimist "^1.2.0"
     strip-bom "^3.0.0"
 
-tslib@^1.10.0, tslib@^1.8.1, tslib@^1.9.0:
+tslib@^1.10.0, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   version "1.13.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.13.0.tgz#c881e13cc7015894ed914862d276436fa9a47043"
   integrity sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==


### PR DESCRIPTION
Because we want to catch errors within the nimbus-ui React app, this
commit adds a Logger service wrapper for console.log and a Sentry
service to report errors back to us.

I copied over the React components and service code from FxA. Needed to convert tests from Mocha to Jest along the way and added some coverage to get to 100%. Also made an executive decision to use a `services` directory instead of the more generic `lib`