### PR TITLE
refactor(backend): fixup query options

### DIFF
--- a/app/experimenter/experiments/api/v5/mutation.py
+++ b/app/experimenter/experiments/api/v5/mutation.py
@@ -14,4 +14,6 @@ class CreateExperimentMutation(DjangoModelFormMutation):
 
 
 class Mutation(graphene.ObjectType):
-    create_experiment = CreateExperimentMutation.Field()
+    create_experiment = CreateExperimentMutation.Field(
+        description="Create a new Nimbus Experiment."
+    )

--- a/app/experimenter/experiments/api/v5/query.py
+++ b/app/experimenter/experiments/api/v5/query.py
@@ -1,31 +1,34 @@
 import graphene
 
 from experimenter.experiments.api.v5.types import NimbusExperimentType
+from experimenter.experiments.constants.nimbus import NimbusConstants
 from experimenter.experiments.models.nimbus import NimbusExperiment
 
 
 class Query(graphene.ObjectType):
-    experiments_by_status = graphene.Field(
-        graphene.List(NimbusExperimentType),
-        status=graphene.Argument(
-            NimbusExperimentType._meta.fields["status"]._type, required=False
-        ),
-    )
-    all_experiments = graphene.List(
+    experiments = graphene.List(
         NimbusExperimentType,
+        description="List Nimbus Experiments.",
+        offset=graphene.Int(),
+        limit=graphene.Int(),
+        status=graphene.Enum(
+            "NimbusExperimentOptionalStatus", NimbusConstants.Status.choices
+        )(),
     )
     experiment_by_slug = graphene.Field(
-        NimbusExperimentType, slug=graphene.String(required=True)
+        NimbusExperimentType,
+        description="Retrieve a Nimbus experiment by its slug.",
+        slug=graphene.String(required=True),
     )
 
-    def resolve_all_experiments(root, info):
-        return NimbusExperiment.objects.all()
+    def resolve_experiments(root, info, offset=0, limit=20, status=None):
+        q = NimbusExperiment.objects.all()
+        if status:
+            q = q.filter(status=status)
+        return q[offset:limit]
 
     def resolve_experiment_by_slug(root, info, slug):
         try:
             return NimbusExperiment.objects.get(slug=slug)
         except NimbusExperiment.DoesNotExist:
             return None
-
-    def resolve_experiments_by_status(root, info, status):
-        return NimbusExperiment.objects.filter(status=status).all()


### PR DESCRIPTION
Because:

* We want to be able to paginate and re-order experiment listings.

This commit:

* Add's limit/offset/order optional parameters to a new single
  experiments gql query.