### PR TITLE
fix #3638 chore(project): Update celery commands

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -80,7 +80,7 @@ services:
       - redis
     volumes:
       - ./app:/app
-    command: bash -c "/app/bin/wait-for-it.sh db:5432 -- celery -A experimenter worker -l debug"
+    command: bash -c "/app/bin/wait-for-it.sh db:5432 -- celery -A experimenter worker -l DEBUG"
 
   beat:
     image: app:build
@@ -90,7 +90,7 @@ services:
       - redis
     volumes:
       - ./app:/app
-    command: bash -c "/app/bin/wait-for-it.sh db:5432 -- celery -A experimenter beat --pidfile /celerybeat.pid -s /celerybeat-schedule -l debug"
+    command: bash -c "/app/bin/wait-for-it.sh db:5432 -- celery -A experimenter beat --pidfile /celerybeat.pid -s /celerybeat-schedule -l DEBUG"
 
   nginx:
     build: ./nginx


### PR DESCRIPTION
Becuase

* Celery 5.0 changed their invocation parameters

This commit

* Updates the celery commands to use the new log directives