### PR TITLE
fix #3683 chore(project): reorder Dockerfile for better caching

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -80,7 +80,7 @@ RUN apt-get update
 RUN apt-get --no-install-recommends install -y apt-utils ca-certificates postgresql-client
 
 COPY --from=build /app/bin/ /app/bin/
-COPY --from=build /app/experimenter/ /app/experimenter/
 COPY --from=build /app/manage.py /app/manage.py
 COPY --from=build /usr/local/bin/ /usr/local/bin/
 COPY --from=build /usr/local/lib/python3.8/site-packages/ /usr/local/lib/python3.8/site-packages/
+COPY ./experimenter/ /app/experimenter/


### PR DESCRIPTION
Because

* We recently added a second stage to our Dockerfile that copies from the base image
* The order that copy commands occur affects the caching strategy that Docker uses

This commit

* Moves the most frequently changing path (application source) to the last step
* Copy application source from host fs instead of base image
* Improves build time for source only changes from ~17s to ~3s on my machine