### PR TITLE
fix #3546 feat(nimbus): create NimbusExperiments in load_dummy_experi…

### DIFF
--- a/app/experimenter/base/management/commands/load_dummy_experiments.py
+++ b/app/experimenter/base/management/commands/load_dummy_experiments.py
@@ -4,7 +4,11 @@ import random
 from django.core.management.base import BaseCommand
 
 from experimenter.experiments.models import Experiment
-from experimenter.experiments.tests.factories import ExperimentFactory
+from experimenter.experiments.models.nimbus import NimbusExperiment
+from experimenter.experiments.tests.factories import (
+    ExperimentFactory,
+    NimbusExperimentFactory,
+)
 
 logger = logging.getLogger()
 
@@ -12,26 +16,12 @@ logger = logging.getLogger()
 class Command(BaseCommand):
     help = "Generates dummy experiment data"
 
-    def add_arguments(self, parser):
-        parser.add_argument("--num_of_experiments", default=10, type=int)
-        parser.add_argument(
-            "--status",
-            choices=[choice[0] for choice in Experiment.STATUS_CHOICES],
-            help="status of experiments populated",
-        )
-
     def handle(self, *args, **options):
-        self.load_dummy_experiments(options)
-
-    @staticmethod
-    def load_dummy_experiments(options):
-        for i in range(options["num_of_experiments"]):
+        for status, _ in Experiment.STATUS_CHOICES:
             random_type = random.choice(Experiment.TYPE_CHOICES)[0]
-            if options["status"]:
-                ExperimentFactory.create_with_status(options["status"], type=random_type)
-            else:
-                status = Experiment.STATUS_CHOICES[i % len(Experiment.STATUS_CHOICES)][0]
-                experiment = ExperimentFactory.create_with_status(
-                    status, type=random_type
-                )
-                logger.info("Created {}: {}".format(experiment, status))
+            experiment = ExperimentFactory.create_with_status(status, type=random_type)
+            logger.info("Created {}: {}".format(experiment, status))
+
+        for status, _ in NimbusExperiment.Status.choices:
+            experiment = NimbusExperimentFactory.create_with_status(status)
+            logger.info("Created {}: {}".format(experiment, status))

--- a/app/experimenter/base/tests/test_initial_data.py
+++ b/app/experimenter/base/tests/test_initial_data.py
@@ -1,24 +1,15 @@
 from django.core.management import call_command
 from django.test import TestCase
 
-from experimenter.experiments.constants import ExperimentConstants
-from experimenter.experiments.models import Experiment
+from experimenter.experiments.models import Experiment, NimbusExperiment
 
 
 class TestInitialData(TestCase):
     def test_load_dummy_experiments(self):
         self.assertFalse(Experiment.objects.exists())
+        self.assertFalse(NimbusExperiment.objects.exists())
         call_command("load_dummy_experiments")
-        self.assertTrue(Experiment.objects.exists())
-
-    def test_load_dummy_experiments_with_specified_values(self):
-        call_command(
-            "load_dummy_experiments",
-            num_of_experiments=20,
-            status=ExperimentConstants.STATUS_DRAFT,
-        )
-        self.assertTrue(Experiment.objects.exists())
-        self.assertEqual(Experiment.objects.count(), 20)
+        self.assertEqual(Experiment.objects.count(), len(Experiment.STATUS_CHOICES))
         self.assertEqual(
-            Experiment.objects.filter(status=ExperimentConstants.STATUS_DRAFT).count(), 20
+            NimbusExperiment.objects.count(), len(NimbusExperiment.Status.choices)
         )


### PR DESCRIPTION
…ments

Because

* It'll help with local dev and testing to have dummy NimbusExperiments in the db

This commit

* Creates NimbusExperiments in the load_dummy_experiments management command
* I took out all the arguments to the management command because it gets really tricky to
  reason about their behaviour with two completely different experiment types, and I don't
  think those arguments get used very often