### PR TITLE
fix #3686 fix(project): Use built app path in deploy image

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -83,4 +83,4 @@ COPY --from=build /app/bin/ /app/bin/
 COPY --from=build /app/manage.py /app/manage.py
 COPY --from=build /usr/local/bin/ /usr/local/bin/
 COPY --from=build /usr/local/lib/python3.8/site-packages/ /usr/local/lib/python3.8/site-packages/
-COPY ./experimenter/ /app/experimenter/
+COPY --from=build /app/experimenter/ /app/experimenter/


### PR DESCRIPTION
Because

* The built app path contains the built static assets

This commit

* Uses the built app path from the build image in the deploy image