### PR TITLE
fix #3480 chore(project): use docker caching for circle deploy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     machine:
       docker_layer_caching: true
-      image: ubuntu-1604:201903-01 # recommended linux image - includes Ubuntu 16.04, docker 18.09.3, docker-compose 1.23.1
+      image: ubuntu-1604:202007-01 # Ubuntu 16.04, Docker v19.03.12, Docker Compose v1.26.1
     resource_class: large
     working_directory: ~/experimenter
     steps:
@@ -27,8 +27,8 @@ jobs:
   integration:
     machine:
       docker_layer_caching: true
-      image: ubuntu-1604:201903-01 # recommended linux image - includes Ubuntu 16.04, docker 18.09.3, docker-compose 1.23.1
-    resource_class: large
+      image: ubuntu-1604:202007-01 # Ubuntu 16.04, Docker v19.03.12, Docker Compose v1.26.1
+    resource_class: xlarge
     working_directory: ~/experimenter
     steps:
       - run:
@@ -57,10 +57,11 @@ jobs:
   deploy:
     working_directory: ~/experimenter
     docker:
-      - image: docker:17.06.0-ce-git
+      - image: docker:19.03.13-git
     steps:
       - checkout
-      - setup_remote_docker
+      - setup_remote_docker:
+          docker_layer_caching: true
       - deploy:
           name: Deploy to latest
           command: |

--- a/Makefile
+++ b/Makefile
@@ -128,4 +128,4 @@ integration_vnc_up_detached: integration_build
 	$(COMPOSE_INTEGRATION) up -d firefox
 
 integration_test: integration_build
-	MOZ_HEADLESS=1 $(COMPOSE_INTEGRATION) run firefox tox -c app/tests/integration -- -n 2
+	MOZ_HEADLESS=1 $(COMPOSE_INTEGRATION) run firefox tox -c app/tests/integration -- -n 4


### PR DESCRIPTION
Because

* The circle deploy task runs after every PR lands and it's not being cached it takes ~10m to rebuild everything from scratch every time

This commit

* Enables docker layer caching for the deploy task which means in the common case it should take <1m
* Bump to the latest circle docker image