### PR TITLE
fix #3705 chore(project): isolate .tox to container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -121,11 +121,8 @@ integration_shell: integration_build
 integration_vnc_up: integration_build
 	$(COMPOSE_INTEGRATION) up firefox
 
-integration_vnc_up_shell: integration_build
-	$(COMPOSE_INTEGRATION) run firefox bash
-
 integration_vnc_up_detached: integration_build
 	$(COMPOSE_INTEGRATION) up -d firefox
 
 integration_test: integration_build
-	MOZ_HEADLESS=1 $(COMPOSE_INTEGRATION) run firefox tox -c app/tests/integration -- -n 4
+	MOZ_HEADLESS=1 $(COMPOSE_INTEGRATION) run firefox sh -c "sudo chmod a+rwx /code/app/tests/integration/.tox;tox -c app/tests/integration -- -n 4"

--- a/docker-compose.integration-test.yml
+++ b/docker-compose.integration-test.yml
@@ -8,6 +8,7 @@ services:
       - MOZ_HEADLESS
     volumes:
       - .:/code
+      - /code/app/tests/integration/.tox
     links:
       - nginx
     expose:


### PR DESCRIPTION
Because

* The integration tests mount the host filesystem and install dependencies to .tox which bleeds onto the host filesystem which then is accidentally causing make code_format to attempt to reform the python files in there

This commit

* Isolates the .tox folder to the firefox container so those files don't bleed on to the host filesystem at all