### PR TITLE
fix #3712 fix(legacy): stop changelogs with no version change

### DIFF
--- a/app/experimenter/normandy/tasks.py
+++ b/app/experimenter/normandy/tasks.py
@@ -172,8 +172,9 @@ def update_firefox_versions(experiment, recipe_data, filter_objects):
     changed_data = {}
 
     if versions := filter_objects.get("version"):
-        min_version = str(min(versions["versions"]) * 1.0)
-        max_version = str(max(versions["versions"]) * 1.0)
+
+        min_version = str(float(min(versions["versions"])))
+        max_version = str(float(max(versions["versions"])))
         if experiment.firefox_min_version != min_version:
             changed_data["firefox_min_version"] = min_version
         if experiment.firefox_max_version != max_version:

--- a/app/experimenter/normandy/tasks.py
+++ b/app/experimenter/normandy/tasks.py
@@ -172,8 +172,8 @@ def update_firefox_versions(experiment, recipe_data, filter_objects):
     changed_data = {}
 
     if versions := filter_objects.get("version"):
-        min_version = min(versions["versions"]) * 1.0
-        max_version = max(versions["versions"]) * 1.0
+        min_version = str(min(versions["versions"]) * 1.0)
+        max_version = str(max(versions["versions"]) * 1.0)
         if experiment.firefox_min_version != min_version:
             changed_data["firefox_min_version"] = min_version
         if experiment.firefox_max_version != max_version:

--- a/app/experimenter/normandy/tests/test_tasks.py
+++ b/app/experimenter/normandy/tests/test_tasks.py
@@ -366,6 +366,37 @@ class TestUpdateExperimentTask(MockNormandyTasksMixin, MockNormandyMixin, TestCa
 
         self.assertTrue(experiment.changes.filter(message="Added Version(s)").exists())
 
+    def test_firefox_version_no_updates_when_no_change(self):
+        experiment = ExperimentFactory.create(
+            status=Experiment.STATUS_LIVE,
+            normandy_id=1234,
+            firefox_min_version="79.0",
+            firefox_max_version="82.0",
+        )
+
+        mock_response_data = {
+            "approved_revision": {
+                "enabled": True,
+                "filter_object": [{"type": "version", "versions": [79, 80, 81, 82]}],
+            }
+        }
+        mock_response = mock.Mock()
+        mock_response.json = mock.Mock()
+        mock_response.json.return_value = mock_response_data
+        mock_response.raise_for_status = mock.Mock()
+        mock_response.raise_for_status.side_effect = None
+        mock_response.status_code = 200
+
+        self.mock_normandy_requests_get.return_value = mock_response
+
+        tasks.update_launched_experiments()
+        experiment = Experiment.objects.get(normandy_id=1234)
+
+        self.assertEqual(experiment.firefox_min_version, "79.0")
+        self.assertEqual(experiment.firefox_max_version, "82.0")
+
+        self.assertFalse(experiment.changes.filter(message="Added Version(s)").exists())
+
     def test_live_isHighPopulation_update(self):
         experiment = ExperimentFactory.create(
             type=Experiment.TYPE_PREF,


### PR DESCRIPTION
Because

* Changelogs are being created for no reason

This commit

* Converts normandy versions from recipe to a string before comparing with experimenter versions