### PR TITLE
fix #3631 feat(backend): add update experiment mutation

### DIFF
--- a/app/experimenter/experiments/api/v5/forms.py
+++ b/app/experimenter/experiments/api/v5/forms.py
@@ -1,9 +1,0 @@
-from django import forms
-
-from experimenter.experiments.models.nimbus import NimbusExperiment
-
-
-class CreateExperimentForm(forms.ModelForm):
-    class Meta:
-        model = NimbusExperiment
-        fields = ("name", "slug", "hypothesis", "public_description")

--- a/app/experimenter/experiments/api/v5/inputs.py
+++ b/app/experimenter/experiments/api/v5/inputs.py
@@ -1,0 +1,19 @@
+import graphene
+
+
+class ExperimentInput(graphene.InputObjectType):
+    clientMutationId = graphene.String()
+    name = graphene.String()
+    slug = graphene.String()
+    application = graphene.String()
+    public_description = graphene.String()
+    hypothesis = graphene.String()
+
+
+class CreateExperimentInput(ExperimentInput):
+    name = graphene.String(required=True)
+    slug = graphene.String(required=True)
+
+
+class UpdateExperimentInput(ExperimentInput):
+    id = graphene.ID(required=True)

--- a/app/experimenter/experiments/api/v5/mutation.py
+++ b/app/experimenter/experiments/api/v5/mutation.py
@@ -1,19 +1,77 @@
 import graphene
-from django.db.models import Field
-from graphene_django.forms.mutation import DjangoModelFormMutation
 
-from experimenter.experiments.api.v5.forms import CreateExperimentForm
+from experimenter.experiments.api.v5.inputs import (
+    CreateExperimentInput,
+    UpdateExperimentInput,
+)
+from experimenter.experiments.api.v5.serializers import NimbusExperimentSerializer
 from experimenter.experiments.api.v5.types import NimbusExperimentType
+from experimenter.experiments.models import NimbusExperiment
 
 
-class CreateExperimentMutation(DjangoModelFormMutation):
-    experiment = Field(NimbusExperimentType)
+class ObjectField(graphene.Scalar):
+    """Utilized to serialize out Serializer errors"""
 
-    class Meta:
-        form_class = CreateExperimentForm
+    @staticmethod
+    def serialize(dt):
+        return dt
+
+
+class CreateExperiment(graphene.Mutation):
+    clientMutationId = graphene.String()
+    nimbus_experiment = graphene.Field(NimbusExperimentType)
+    message = ObjectField()
+    status = graphene.Int()
+
+    class Arguments:
+        input = CreateExperimentInput(required=True)
+
+    @classmethod
+    def mutate(cls, root, info, input: CreateExperimentInput):
+        serializer = NimbusExperimentSerializer(data=input)
+        if serializer.is_valid():
+            obj = serializer.save()
+            msg = "success"
+        else:
+            msg = serializer.errors
+            obj = None
+        return cls(
+            nimbus_experiment=obj,
+            message=msg,
+            status=200,
+            clientMutationId=input.clientMutationId,
+        )
+
+
+class UpdateExperiment(graphene.Mutation):
+    clientMutationId = graphene.String()
+    nimbus_experiment = graphene.Field(NimbusExperimentType)
+    message = ObjectField()
+    status = graphene.Int()
+
+    class Arguments:
+        input = UpdateExperimentInput(required=True)
+
+    @classmethod
+    def mutate(cls, root, info, input: UpdateExperimentInput):
+        exp = NimbusExperiment.objects.get(id=input.id)
+        serializer = NimbusExperimentSerializer(exp, data=input, partial=True)
+        if serializer.is_valid():
+            obj = serializer.save()
+            msg = "success"
+        else:
+            msg = serializer.errors
+            obj = None
+        return cls(
+            nimbus_experiment=obj,
+            message=msg,
+            status=200,
+            clientMutationId=input.clientMutationId,
+        )
 
 
 class Mutation(graphene.ObjectType):
-    create_experiment = CreateExperimentMutation.Field(
+    create_experiment = CreateExperiment.Field(
         description="Create a new Nimbus Experiment."
     )
+    update_experiment = UpdateExperiment.Field(description="Update a Nimbus Experiment.")

--- a/app/experimenter/experiments/api/v5/serializers.py
+++ b/app/experimenter/experiments/api/v5/serializers.py
@@ -1,0 +1,9 @@
+from rest_framework import serializers
+
+from experimenter.experiments.models import NimbusExperiment
+
+
+class NimbusExperimentSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = NimbusExperiment
+        fields = ("name", "slug", "application", "public_description", "hypothesis")

--- a/app/experimenter/experiments/api/v5/types.py
+++ b/app/experimenter/experiments/api/v5/types.py
@@ -13,25 +13,22 @@ from experimenter.projects.models import Project
 class NimbusBranchType(DjangoObjectType):
     class Meta:
         model = NimbusBranch
-        exclude = ("id", "experiment", "nimbusexperiment")
+        exclude = ("experiment", "nimbusexperiment")
 
 
 class NimbusExperimentType(DjangoObjectType):
     class Meta:
         model = NimbusExperiment
-        exclude = ("id",)
 
 
 class ProjectType(DjangoObjectType):
     class Meta:
         model = Project
-        exclude = ("id",)
 
 
 class NimbusIsolationGroupType(DjangoObjectType):
     class Meta:
         model = NimbusIsolationGroup
-        exclude = ("id",)
 
 
 class NimbusBucketRangeType(DjangoObjectType):

--- a/app/experimenter/experiments/tests/api/v5/test_mutation.py
+++ b/app/experimenter/experiments/tests/api/v5/test_mutation.py
@@ -5,30 +5,48 @@ from django.urls import reverse
 from graphene_django.utils.testing import GraphQLTestCase
 
 from experimenter.experiments.models.nimbus import NimbusExperiment
+from experimenter.experiments.tests.factories.nimbus import NimbusExperimentFactory
+
+CREATE_EXPERIMENT_MUTATION = """\
+mutation($input: CreateExperimentInput!) {
+    createExperiment(input: $input) {
+        nimbusExperiment {
+            status
+            name
+            slug
+        }
+        message
+        status
+        clientMutationId
+    }
+}
+"""
 
 
-class TestCreateExperiment(GraphQLTestCase):
+UPDATE_EXPERIMENT_MUTATION = """\
+mutation($input: UpdateExperimentInput!) {
+    updateExperiment(input: $input) {
+        nimbusExperiment {
+            id
+            status
+            name
+            slug
+        }
+        message
+        status
+        clientMutationId
+    }
+}
+"""
+
+
+class TestMutations(GraphQLTestCase):
     GRAPHQL_URL = reverse("nimbus-api-graphql")
 
     def test_create_experiment(self):
         user_email = "user@example.com"
         response = self.query(
-            """
-            mutation($input: CreateExperimentMutationInput!) {
-                createExperiment(input: $input) {
-                    nimbusExperiment {
-                        status
-                        name
-                        slug
-                    }
-                    errors {
-                        field
-                        messages
-                    }
-                    clientMutationId
-                }
-            }
-            """,
+            CREATE_EXPERIMENT_MUTATION,
             variables={
                 "input": {
                     "name": "test1234",
@@ -47,9 +65,98 @@ class TestCreateExperiment(GraphQLTestCase):
         )
 
         self.assertEqual(result["clientMutationId"], "randomid")
-
-        errors = result["errors"]
-        self.assertEqual(errors, [])
+        self.assertEqual(result["message"], "success")
+        self.assertEqual(result["status"], 200)
 
         exp = NimbusExperiment.objects.first()
         self.assertEqual(exp.slug, "slug1234")
+
+    def test_create_experiment_error(self):
+        user_email = "user@example.com"
+        long_name = "test" * 1000
+        response = self.query(
+            CREATE_EXPERIMENT_MUTATION,
+            variables={
+                "input": {
+                    "name": long_name,
+                    "slug": "slug1234",
+                    "clientMutationId": "randomid",
+                }
+            },
+            headers={settings.OPENIDC_EMAIL_HEADER: user_email},
+        )
+        self.assertEqual(response.status_code, 200)
+        content = json.loads(response.content)
+        result = content["data"]["createExperiment"]
+        self.assertEqual(result["nimbusExperiment"], None)
+
+        self.assertEqual(result["clientMutationId"], "randomid")
+        self.assertEqual(
+            result["message"],
+            {"name": ["Ensure this field has no more than 255 characters."]},
+        )
+        self.assertEqual(result["status"], 200)
+
+    def test_update_experiment(self):
+        user_email = "user@example.com"
+        exp = NimbusExperimentFactory.create_with_status(NimbusExperiment.Status.DRAFT)
+        response = self.query(
+            UPDATE_EXPERIMENT_MUTATION,
+            variables={
+                "input": {
+                    "id": exp.id,
+                    "name": "test1234",
+                    "slug": "slug1234",
+                    "clientMutationId": "randomid",
+                }
+            },
+            headers={settings.OPENIDC_EMAIL_HEADER: user_email},
+        )
+        self.assertEqual(response.status_code, 200)
+        content = json.loads(response.content)
+        result = content["data"]["updateExperiment"]
+        experiment = result["nimbusExperiment"]
+        self.assertEqual(
+            experiment,
+            {
+                "id": f"{exp.id}",
+                "status": "DRAFT",
+                "name": "test1234",
+                "slug": "slug1234",
+            },
+        )
+
+        self.assertEqual(result["clientMutationId"], "randomid")
+        self.assertEqual(result["message"], "success")
+        self.assertEqual(result["status"], 200)
+
+        exp = NimbusExperiment.objects.first()
+        self.assertEqual(exp.slug, "slug1234")
+
+    def test_update_experiment_error(self):
+        user_email = "user@example.com"
+        long_name = "test" * 1000
+        exp = NimbusExperimentFactory.create_with_status(NimbusExperiment.Status.DRAFT)
+        response = self.query(
+            UPDATE_EXPERIMENT_MUTATION,
+            variables={
+                "input": {
+                    "id": exp.id,
+                    "name": long_name,
+                    "slug": "slug1234",
+                    "clientMutationId": "randomid",
+                }
+            },
+            headers={settings.OPENIDC_EMAIL_HEADER: user_email},
+        )
+        self.assertEqual(response.status_code, 200)
+        content = json.loads(response.content)
+        result = content["data"]["updateExperiment"]
+        self.assertEqual(result["nimbusExperiment"], None)
+
+        self.assertEqual(result["clientMutationId"], "randomid")
+        self.assertEqual(
+            result["message"],
+            {"name": ["Ensure this field has no more than 255 characters."]},
+        )
+        self.assertEqual(result["status"], 200)

--- a/app/experimenter/experiments/tests/api/v5/test_serializers.py
+++ b/app/experimenter/experiments/tests/api/v5/test_serializers.py
@@ -1,0 +1,28 @@
+from django.test import TestCase
+
+from experimenter.experiments.api.v5.serializers import NimbusExperimentSerializer
+from experimenter.experiments.models import NimbusExperiment
+from experimenter.experiments.tests.factories import NimbusExperimentFactory
+
+
+class TestNimbusExperimentSerializer(TestCase):
+    maxDiff = None
+
+    def test_serializer_outputs_expected_schema(self):
+        experiment = NimbusExperimentFactory.create_with_status(
+            NimbusExperiment.Status.ACCEPTED,
+        )
+
+        serializer = NimbusExperimentSerializer(experiment)
+        data = serializer.data
+
+        self.assertDictEqual(
+            data,
+            {
+                "application": experiment.application,
+                "hypothesis": experiment.hypothesis,
+                "name": experiment.name,
+                "public_description": experiment.public_description,
+                "slug": experiment.slug,
+            },
+        )


### PR DESCRIPTION
Because:

* We want to allow updating the mutation.
* Additional magic from graphene-django is starting to get in the way.

This commit:

* Add's a NimbusExperiment update mutation.
* Refactors the create experiment mutation to use the more verbose but
  configurable method used for update.

Closes #3631