### PR TITLE
fix #3748 fix(legacy): removed firefox channel sorting

### DIFF
--- a/app/experimenter/experiments/forms.py
+++ b/app/experimenter/experiments/forms.py
@@ -1008,8 +1008,6 @@ class ExperimentOrderingForm(forms.Form):
         ("latest_change", "Least Recently Updated"),
         ("firefox_min_version", "Firefox Min Version Ascending"),
         ("-firefox_min_version", "Firefox Min Version Descending"),
-        ("firefox_channel_sort", "Firefox Channel Ascending"),
-        ("-firefox_channel_sort", "Firefox Channel Descending"),
     )
 
     ordering = forms.ChoiceField(

--- a/app/experimenter/experiments/models/legacy.py
+++ b/app/experimenter/experiments/models/legacy.py
@@ -11,7 +11,7 @@ from django.contrib.postgres.fields import ArrayField, JSONField
 from django.core.serializers.json import DjangoJSONEncoder
 from django.core.validators import MaxValueValidator
 from django.db import models
-from django.db.models import Case, Max, Value, When
+from django.db.models import Max
 from django.urls import reverse
 from django.utils import timezone
 from django.utils.functional import cached_property
@@ -950,26 +950,6 @@ class Experiment(ExperimentConstants, models.Model):
             )
 
         return population
-
-    @staticmethod
-    def firefox_channel_sort():
-        """A Case that can be added to an Experiment QuerySet to sort."""
-        return Case(
-            When(
-                firefox_channel=ExperimentConstants.CHANNEL_RELEASE,
-                then=Value(ExperimentConstants.CHANNEL_RELEASE_ORDER),
-            ),
-            When(
-                firefox_channel=ExperimentConstants.CHANNEL_BETA,
-                then=Value(ExperimentConstants.CHANNEL_BETA_ORDER),
-            ),
-            When(
-                firefox_channel=ExperimentConstants.CHANNEL_NIGHTLY,
-                then=Value(ExperimentConstants.CHANNEL_NIGHTLY_ORDER),
-            ),
-            default=Value(ExperimentConstants.CHANNEL_UNSET_ORDER),
-            output_field=models.IntegerField(),
-        )
 
     @property
     def is_archivable(self):

--- a/app/experimenter/experiments/tests/test_models/test_legacy_models.py
+++ b/app/experimenter/experiments/tests/test_models/test_legacy_models.py
@@ -1465,28 +1465,6 @@ class TestExperimentModel(TestCase):
         )
         self.assertEqual(experiment.population, "Nightly Firefox 57.0")
 
-    def test_experiment_firefox_channel_sort_does_sorting(self):
-        ExperimentFactory.create(firefox_channel=Experiment.CHANNEL_NIGHTLY)
-        ExperimentFactory.create(firefox_channel=Experiment.CHANNEL_RELEASE)
-        ExperimentFactory.create(firefox_channel=Experiment.CHANNEL_BETA)
-        ExperimentFactory.create(firefox_channel="")
-        sorted_experiments = (
-            Experiment.objects.annotate(
-                firefox_channel_sort=Experiment.firefox_channel_sort()
-            )
-            .order_by("firefox_channel_sort")
-            .values("firefox_channel_sort")
-        )
-        self.assertEqual(
-            [r["firefox_channel_sort"] for r in sorted_experiments],
-            [
-                Experiment.CHANNEL_UNSET_ORDER,
-                Experiment.CHANNEL_NIGHTLY_ORDER,
-                Experiment.CHANNEL_BETA_ORDER,
-                Experiment.CHANNEL_RELEASE_ORDER,
-            ],
-        )
-
     def test_should_have_total_enrolled_true(self):
         experiment = ExperimentFactory(type=Experiment.TYPE_PREF)
         self.assertTrue(experiment.should_have_total_enrolled)

--- a/app/experimenter/experiments/tests/test_views.py
+++ b/app/experimenter/experiments/tests/test_views.py
@@ -123,36 +123,6 @@ class TestExperimentListView(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(list(context["experiments"]), list(filtered_ordered_experiments))
 
-    def test_list_view_orders_experiments_firefox_channel_sort(self):
-        user_email = "user@example.com"
-        ordering = "firefox_channel_sort"
-        channels = [
-            Experiment.CHANNEL_RELEASE,
-            Experiment.CHANNEL_NIGHTLY,
-            Experiment.CHANNEL_BETA,
-            "",
-        ]
-        for channel in channels:
-            ExperimentFactory.create(firefox_channel=channel)
-
-        response = self.client.get(
-            "{url}?{params}".format(
-                url=reverse("home"), params=urlencode({"ordering": ordering})
-            ),
-            **{settings.OPENIDC_EMAIL_HEADER: user_email},
-        )
-
-        context = response.context[0]
-        self.assertEqual(
-            list(exp.firefox_channel for exp in context["experiments"]),
-            [
-                "",
-                Experiment.CHANNEL_NIGHTLY,
-                Experiment.CHANNEL_BETA,
-                Experiment.CHANNEL_RELEASE,
-            ],
-        )
-
     def test_list_view_total_experiments_count(self):
         user_email = "user@example.com"
 

--- a/app/experimenter/experiments/views.py
+++ b/app/experimenter/experiments/views.py
@@ -46,11 +46,6 @@ class ExperimentListView(FilterView):
         kwargs["data"] = self.request.GET
         return kwargs
 
-    def get_queryset(self):
-        qs = super().get_queryset()
-        qs = qs.annotate(firefox_channel_sort=Experiment.firefox_channel_sort())
-        return qs
-
     def get_ordering(self):
         self.ordering_form = ExperimentOrderingForm(self.request.GET)
 


### PR DESCRIPTION
Because

* It's not being used by anyone
* it's cause some django update problems

This commit:

* Removes firefox channel sorting and everything related to it