### PR TITLE
fix #3769 feat(nimbus): exclude DRAFT and REVIEW experiments from v6 API

### DIFF
--- a/app/experimenter/experiments/api/v6/views.py
+++ b/app/experimenter/experiments/api/v6/views.py
@@ -10,5 +10,7 @@ class NimbusExperimentViewSet(
     viewsets.GenericViewSet,
 ):
     lookup_field = "slug"
-    queryset = NimbusExperiment.objects.all()
+    queryset = NimbusExperiment.objects.all().exclude(
+        status__in=[NimbusExperiment.Status.DRAFT, NimbusExperiment.Status.REVIEW]
+    )
     serializer_class = NimbusExperimentSerializer

--- a/app/experimenter/experiments/tests/api/v6/test_views.py
+++ b/app/experimenter/experiments/tests/api/v6/test_views.py
@@ -12,8 +12,14 @@ class TestNimbusExperimentViewSet(TestCase):
     def test_list_view_serializes_experiments(self):
         experiments = []
 
-        for status, _ in NimbusExperiment.Status.choices:
-            experiments.append(NimbusExperimentFactory.create_with_status(status))
+        for status in NimbusExperiment.Status:
+            if status not in [
+                NimbusExperiment.Status.DRAFT,
+                NimbusExperiment.Status.REVIEW,
+            ]:
+                experiments.append(
+                    NimbusExperimentFactory.create_with_status(status.value, slug=status)
+                )
 
         response = self.client.get(
             reverse("nimbus-experiment-rest-list"),


### PR DESCRIPTION
Because

* Experiments are not stable while they're in draft/review, and consumers shouldn't need access to them,
  they should be excluded from the V6 API

This commit

* Filters draft/review experiments out from the V6 API view