### PR TITLE
fix #3770 feat(nimbus): validate v6 schema against nimbus shared schema

### DIFF
--- a/app/experimenter/docs/openapi-schema.json
+++ b/app/experimenter/docs/openapi-schema.json
@@ -3381,6 +3381,11 @@
       "NimbusExperiment": {
         "type": "object",
         "properties": {
+          "schemaVersion": {
+            "type": "string",
+            "readOnly": true,
+            "default": "1.0.0"
+          },
           "slug": {
             "type": "string",
             "maxLength": 80,

--- a/app/experimenter/docs/swagger-ui.html
+++ b/app/experimenter/docs/swagger-ui.html
@@ -3393,6 +3393,11 @@
       "NimbusExperiment": {
         "type": "object",
         "properties": {
+          "schemaVersion": {
+            "type": "string",
+            "readOnly": true,
+            "default": "1.0.0"
+          },
           "slug": {
             "type": "string",
             "maxLength": 80,

--- a/app/experimenter/experiments/api/v3/serializers.py
+++ b/app/experimenter/experiments/api/v3/serializers.py
@@ -1,5 +1,4 @@
 from django.utils.text import slugify
-from mozilla_nimbus_shared import get_data
 from rest_framework import serializers
 
 from experimenter.bugzilla.tasks import create_experiment_bug_task
@@ -8,13 +7,12 @@ from experimenter.experiments.api.v2.serializers import (
     ExperimentDesignVariantBaseSerializer,
 )
 from experimenter.experiments.changelog_utils import ChangelogSerializerMixin
+from experimenter.experiments.constants.shared_data import NIMBUS_DATA
 from experimenter.experiments.models import (
     Experiment,
     ExperimentChangeLog,
     ExperimentVariant,
 )
-
-NIMBUS_DATA = get_data()
 
 
 class ExperimentRapidRejectChangeLogSerializer(serializers.ModelSerializer):

--- a/app/experimenter/experiments/api/v4/serializers.py
+++ b/app/experimenter/experiments/api/v4/serializers.py
@@ -1,13 +1,11 @@
-from mozilla_nimbus_shared import get_data
 from rest_framework import serializers
 
+from experimenter.experiments.constants.shared_data import NIMBUS_DATA
 from experimenter.experiments.models import (
     Experiment,
     ExperimentBucketRange,
     ExperimentVariant,
 )
-
-NIMBUS_DATA = get_data()
 
 
 class ExperimentRapidBranchesSerializer(serializers.ModelSerializer):

--- a/app/experimenter/experiments/constants/shared_data.py
+++ b/app/experimenter/experiments/constants/shared_data.py
@@ -1,0 +1,69 @@
+# flake8: noqa
+NIMBUS_DATA = {
+    "Audiences": {
+        "all_english": {
+            "name": "All English users",
+            "description": "All users in en-* locales using the release channel.",
+            "targeting": "localeLanguageCode == 'en' && browserSettings.update.channel == '{firefox_channel}'",
+            "desktop_telemetry": "STARTS_WITH(environment.settings.locale, 'en')",
+        },
+        "us_only": {
+            "name": "US users (en)",
+            "description": "All users in the US with an en-* locale using the release channel.",
+            "targeting": "localeLanguageCode == 'en' && region == 'US' && browserSettings.update.channel == '{firefox_channel}'",
+            "desktop_telemetry": "STARTS_WITH(environment.settings.locale, 'en') AND normalized_country_code = 'US'",
+        },
+        "first_run": {
+            "name": "First start-up users (en)",
+            "description": "First start-up users (e.g. for about:welcome) with an en-* locale using the release channel.",
+            "targeting": "localeLanguageCode == 'en' && (isFirstStartup || '{slug}' in activeExperiments) && browserSettings.update.channel == '{firefox_channel}'",
+            "desktop_telemetry": "STARTS_WITH(environment.settings.locale, 'en') AND payload.info.profile_subsession_counter = 1",
+        },
+    },
+    "ExperimentDesignPresets": {
+        "empty_aa": {
+            "name": "A/A Experiment",
+            "description": "A design for diagnostic testing of targeting or enrollment. Fixed to 1% of the population.",
+            "preset": {
+                "filter_expression": "env.version|versionCompare('{minFirefoxVersion}') >= 0",
+                "targeting": '[{randomizationUnit}, "{bucketNamespace}"]|bucketSample({bucketStart}, {bucketCount}, {bucketTotal}) && {audienceTargeting}',
+                "arguments": {
+                    "proposedDuration": 28,
+                    "proposedEnrollment": 7,
+                    "branches": [
+                        {"slug": "control", "ratio": 1, "value": None},
+                        {"slug": "treatment", "ratio": 1, "value": None},
+                    ],
+                    "bucketConfig": {
+                        "randomizationUnit": "userId",
+                        "count": 100,
+                        "total": 10000,
+                    },
+                },
+            },
+        }
+    },
+    "features": {
+        "picture_in_picture": {
+            "name": "Picture-in-Picture",
+            "description": "Counts the fraction of users and the number of times that users open Picture-in-Picture\nwindows from videos. PiP can be opened by clicking on the PiP overlay or the video's context\nmenu.\n",
+            "telemetry": [
+                {
+                    "kind": "event",
+                    "event_category": "pictureinpicture",
+                    "event_method": "create",
+                    "event_object": "player",
+                }
+            ],
+            "slug": "picture_in_picture",
+        },
+        "pinned_tabs": {
+            "name": "Pinned tabs",
+            "description": "Counts the number of times that a client pinned a tab. This doesn't measure whether users\nalready had tabs pinned when observation began.\n",
+            "telemetry": [
+                {"kind": "scalar", "name": "browser.engagement.tab_pinned_event_count"}
+            ],
+            "slug": "pinned_tabs",
+        },
+    },
+}

--- a/app/experimenter/experiments/tests/api/v3/test_serializers.py
+++ b/app/experimenter/experiments/tests/api/v3/test_serializers.py
@@ -2,7 +2,6 @@ from collections import OrderedDict
 
 from django.conf import settings
 from django.test import TestCase
-from mozilla_nimbus_shared import get_data
 
 from experimenter.base.tests.mixins import MockRequestMixin
 from experimenter.bugzilla.tests.mixins import MockBugzillaTasksMixin
@@ -11,14 +10,13 @@ from experimenter.experiments.api.v3.serializers import (
     ExperimentRapidStatusSerializer,
     ExperimentRapidVariantSerializer,
 )
+from experimenter.experiments.constants.shared_data import NIMBUS_DATA
 from experimenter.experiments.models import Experiment, ExperimentChangeLog
 from experimenter.experiments.tests.factories import (
     ExperimentRapidFactory,
     ExperimentVariantFactory,
 )
 from experimenter.openidc.tests.factories import UserFactory
-
-NIMBUS_DATA = get_data()
 
 
 class TestExperimentRapidSerializer(MockRequestMixin, MockBugzillaTasksMixin, TestCase):

--- a/app/experimenter/experiments/tests/api/v6/test_serializers.py
+++ b/app/experimenter/experiments/tests/api/v6/test_serializers.py
@@ -1,4 +1,8 @@
+import json
+
+from django.conf import settings
 from django.test import TestCase
+from mozilla_nimbus_shared import check_schema
 
 from experimenter.experiments.api.v6.serializers import NimbusExperimentSerializer
 from experimenter.experiments.models import NimbusExperiment
@@ -11,61 +15,7 @@ from experimenter.experiments.tests.factories import (
 class TestNimbusExperimentSerializer(TestCase):
     maxDiff = None
 
-    def test_serializer_outputs_expected_schema_for_draft(self):
-        probe_set = NimbusProbeSetFactory.create()
-        experiment = NimbusExperimentFactory.create_with_status(
-            NimbusExperiment.Status.DRAFT,
-            firefox_min_version=NimbusExperiment.Version.FIREFOX_80,
-            targeting_config_slug=NimbusExperiment.TargetingConfig.ALL_ENGLISH,
-            channels=[
-                NimbusExperiment.Channel.DESKTOP_NIGHTLY,
-                NimbusExperiment.Channel.DESKTOP_BETA,
-                NimbusExperiment.Channel.DESKTOP_RELEASE,
-            ],
-            probe_sets=[probe_set],
-        )
-
-        serializer = NimbusExperimentSerializer(experiment)
-        experiment_data = serializer.data.copy()
-        branches_data = experiment_data.pop("branches")
-        self.assertDictEqual(
-            experiment_data,
-            {
-                "application": experiment.application,
-                "bucketConfig": None,
-                "endDate": None,
-                "id": experiment.slug,
-                "isEnrollmentPaused": False,
-                "proposedDuration": experiment.proposed_duration,
-                "proposedEnrollment": experiment.proposed_enrollment,
-                "referenceBranch": experiment.control_branch.slug,
-                "slug": experiment.slug,
-                "startDate": None,
-                "targeting": (
-                    'channel in ["Nightly", "Beta", "Release"] && '
-                    "version|versionCompare('80.!') >= .! && localeLanguageCode == 'en'"
-                ),
-                "userFacingDescription": experiment.public_description,
-                "userFacingName": experiment.name,
-                "probeSets": [probe_set.slug],
-            },
-        )
-        self.assertEqual(len(branches_data), 2)
-        for branch in experiment.branches.all():
-            self.assertIn(
-                {
-                    "slug": branch.slug,
-                    "ratio": branch.ratio,
-                    "feature": {
-                        "featureId": experiment.feature_config.slug,
-                        "enabled": branch.feature_enabled,
-                        "value": branch.feature_value,
-                    },
-                },
-                [dict(b) for b in branches_data],
-            )
-
-    def test_serializer_outputs_expected_schema_for_accepted(self):
+    def test_serializer_outputs_expected_schema_with_feature(self):
         probe_set = NimbusProbeSetFactory.create()
         experiment = NimbusExperimentFactory.create_with_status(
             NimbusExperiment.Status.ACCEPTED,
@@ -81,7 +31,7 @@ class TestNimbusExperimentSerializer(TestCase):
 
         serializer = NimbusExperimentSerializer(experiment)
         experiment_data = serializer.data.copy()
-        branches_data = experiment_data.pop("branches")
+        branches_data = [dict(b) for b in experiment_data.pop("branches")]
         self.assertDictEqual(
             experiment_data,
             {
@@ -101,6 +51,7 @@ class TestNimbusExperimentSerializer(TestCase):
                 "proposedDuration": experiment.proposed_duration,
                 "proposedEnrollment": experiment.proposed_enrollment,
                 "referenceBranch": experiment.control_branch.slug,
+                "schemaVersion": settings.NIMBUS_SCHEMA_VERSION,
                 "slug": experiment.slug,
                 "startDate": None,
                 "targeting": (
@@ -121,11 +72,30 @@ class TestNimbusExperimentSerializer(TestCase):
                     "feature": {
                         "featureId": experiment.feature_config.slug,
                         "enabled": branch.feature_enabled,
-                        "value": branch.feature_value,
+                        "value": json.loads(branch.feature_value),
                     },
                 },
-                [dict(b) for b in branches_data],
+                branches_data,
             )
+
+        check_schema("experiments/NimbusExperiment", serializer.data)
+
+    def test_serializer_outputs_expected_schema_without_feature(self):
+        experiment = NimbusExperimentFactory.create_with_status(
+            NimbusExperiment.Status.ACCEPTED,
+            feature_config=None,
+        )
+        serializer = NimbusExperimentSerializer(experiment)
+        experiment_data = serializer.data.copy()
+        branches_data = [dict(b) for b in experiment_data.pop("branches")]
+        self.assertEqual(len(branches_data), 2)
+        for branch in experiment.branches.all():
+            self.assertIn(
+                {"slug": branch.slug, "ratio": branch.ratio},
+                branches_data,
+            )
+
+        check_schema("experiments/NimbusExperiment", serializer.data)
 
     def test_serializer_outputs_targeting_for_experiment_without_channels(self):
         experiment = NimbusExperimentFactory.create_with_status(

--- a/app/experimenter/experiments/tests/factories/legacy.py
+++ b/app/experimenter/experiments/tests/factories/legacy.py
@@ -8,10 +8,10 @@ from django.conf import settings
 from django.utils import timezone
 from django.utils.text import slugify
 from faker import Factory as FakerFactory
-from mozilla_nimbus_shared import get_data
 
 from experimenter.base.models import Country, Locale
 from experimenter.experiments.constants import ExperimentConstants
+from experimenter.experiments.constants.shared_data import NIMBUS_DATA
 from experimenter.experiments.models import (
     Experiment,
     ExperimentBucketNamespace,
@@ -26,9 +26,6 @@ from experimenter.projects.tests.factories import ProjectFactory
 
 faker = FakerFactory.create()
 NORMANDY_STATUS_CHOICES = Experiment.STATUS_CHOICES[:-1]
-
-
-NIMBUS_DATA = get_data()
 
 
 class ExperimentFactory(ExperimentConstants, factory.django.DjangoModelFactory):

--- a/app/experimenter/experiments/tests/factories/nimbus.py
+++ b/app/experimenter/experiments/tests/factories/nimbus.py
@@ -30,9 +30,7 @@ class NimbusExperimentFactory(factory.django.DjangoModelFactory):
     public_description = factory.LazyAttribute(lambda o: faker.text(200))
     proposed_duration = factory.LazyAttribute(lambda o: random.randint(10, 60))
     proposed_enrollment = factory.LazyAttribute(
-        lambda o: random.choice([None, random.randint(2, o.proposed_duration)])
-        if o.proposed_duration
-        else None
+        lambda o: random.randint(2, o.proposed_duration)
     )
     population_percent = factory.LazyAttribute(
         lambda o: decimal.Decimal(random.randint(1, 10) * 10)

--- a/app/experimenter/kinto/tasks.py
+++ b/app/experimenter/kinto/tasks.py
@@ -2,11 +2,11 @@ import markus
 from celery.utils.log import get_task_logger
 from django.conf import settings
 from django.contrib.auth import get_user_model
-from mozilla_nimbus_shared import get_data
 
 from experimenter.celery import app
 from experimenter.experiments.api.v4.serializers import ExperimentRapidRecipeSerializer
 from experimenter.experiments.changelog_utils import update_experiment_with_change_log
+from experimenter.experiments.constants.shared_data import NIMBUS_DATA
 from experimenter.experiments.models import (
     Experiment,
     ExperimentBucketNamespace,
@@ -17,8 +17,6 @@ from experimenter.kinto import client
 
 logger = get_task_logger(__name__)
 metrics = markus.get_metrics("kinto.tasks")
-
-NIMBUS_DATA = get_data()
 
 
 @app.task

--- a/app/experimenter/kinto/tests/test_tasks.py
+++ b/app/experimenter/kinto/tests/test_tasks.py
@@ -3,9 +3,9 @@ import datetime
 import mock
 from django.conf import settings
 from django.test import TestCase
-from mozilla_nimbus_shared import get_data
 
 from experimenter.experiments.api.v4.serializers import ExperimentRapidRecipeSerializer
+from experimenter.experiments.constants.shared_data import NIMBUS_DATA
 from experimenter.experiments.models import (
     Experiment,
     ExperimentBucketRange,
@@ -15,8 +15,6 @@ from experimenter.experiments.tests.factories import ExperimentFactory
 from experimenter.kinto import tasks
 from experimenter.kinto.client import KINTO_REJECTED_STATUS
 from experimenter.kinto.tests.mixins import MockKintoClientMixin
-
-NIMBUS_DATA = get_data()
 
 
 class TestPushExperimentToKintoTask(MockKintoClientMixin, TestCase):

--- a/app/experimenter/settings.py
+++ b/app/experimenter/settings.py
@@ -9,10 +9,10 @@ https://docs.djangoproject.com/en/1.9/topics/settings/
 For the full list of settings and their values, see
 https://docs.djangoproject.com/en/1.9/ref/settings/
 """
-
 import os
 from urllib.parse import urljoin
 
+import pkg_resources
 from celery.schedules import crontab
 from decouple import config
 
@@ -401,3 +401,5 @@ KINTO_COLLECTION = config("KINTO_COLLECTION")
 DEFAULT_FILE_STORAGE = "storages.backends.gcloud.GoogleCloudStorage"
 GS_PROJECT_ID = "experiments-analysis"
 GS_BUCKET_NAME = "mozanalysis"
+
+NIMBUS_SCHEMA_VERSION = pkg_resources.get_distribution("mozilla-nimbus-shared").version

--- a/app/poetry.lock
+++ b/app/poetry.lock
@@ -511,7 +511,6 @@ optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,>=2.7"
 
 [package.dependencies]
-importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
 mccabe = ">=0.6.0,<0.7.0"
 pycodestyle = ">=2.6.0a1,<2.7.0"
 pyflakes = ">=2.2.0,<2.3.0"
@@ -717,21 +716,6 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
-name = "importlib-metadata"
-version = "2.0.0"
-description = "Read metadata from Python packages"
-category = "main"
-optional = false
-python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
-
-[package.dependencies]
-zipp = ">=0.5"
-
-[package.extras]
-docs = ["sphinx", "rst.linker"]
-testing = ["packaging", "pep517", "importlib-resources (>=1.3)"]
-
-[[package]]
 name = "iniconfig"
 version = "1.0.1"
 description = "iniconfig: brain-dead simple config-ini parsing"
@@ -827,7 +811,6 @@ python-versions = "*"
 
 [package.dependencies]
 attrs = ">=17.4.0"
-importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
 pyrsistent = ">=0.14.0"
 six = ">=1.11.0"
 
@@ -857,7 +840,6 @@ python-versions = ">=3.6"
 
 [package.dependencies]
 amqp = ">=5.0.0,<6.0.0"
-importlib-metadata = {version = ">=0.18", markers = "python_version < \"3.8\""}
 
 [package.extras]
 azureservicebus = ["azure-servicebus (>=0.21.1)"]
@@ -926,7 +908,7 @@ python-versions = ">=3.5"
 
 [[package]]
 name = "mozilla-nimbus-shared"
-version = "0.0.9"
+version = "1.0.0"
 description = "Shared data and schemas for Project Nimbus"
 category = "main"
 optional = false
@@ -1027,9 +1009,6 @@ description = "plugin and hook calling mechanisms for python"
 category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-
-[package.dependencies]
-importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
 
 [package.extras]
 dev = ["pre-commit", "tox"]
@@ -1189,7 +1168,6 @@ python-versions = ">=3.5"
 atomicwrites = {version = ">=1.0", markers = "sys_platform == \"win32\""}
 attrs = ">=17.4.0"
 colorama = {version = "*", markers = "sys_platform == \"win32\""}
-importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
 iniconfig = "*"
 more-itertools = ">=4.0.0"
 packaging = "*"
@@ -1564,24 +1542,11 @@ python-versions = ">=3.5"
 [package.dependencies]
 idna = ">=2.0"
 multidict = ">=4.0"
-typing-extensions = {version = ">=3.7.4", markers = "python_version < \"3.8\""}
-
-[[package]]
-name = "zipp"
-version = "3.2.0"
-description = "Backport of pathlib-compatible object wrapper for zip files"
-category = "main"
-optional = false
-python-versions = ">=3.6"
-
-[package.extras]
-docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
-testing = ["pytest (>=3.5,<3.7.3 || >3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pytest-cov", "jaraco.test (>=3.2.0)", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy"]
 
 [metadata]
 lock-version = "1.1"
-python-versions = "^3.7"
-content-hash = "34281efcf31ceeb8bdd0085624fb92a18c2e54b9b77abff682d44ed841ea4757"
+python-versions = "^3.9"
+content-hash = "ff65113c14bfc452299988d2270dbfbc4a66a7544239551e0c03ebacc4b4ddd3"
 
 [metadata.files]
 aiohttp = [
@@ -1910,10 +1875,6 @@ idna = [
     {file = "idna-2.10-py2.py3-none-any.whl", hash = "sha256:b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0"},
     {file = "idna-2.10.tar.gz", hash = "sha256:b307872f855b18632ce0c21c5e45be78c0ea7ae4c15c828c20788b26921eb3f6"},
 ]
-importlib-metadata = [
-    {file = "importlib_metadata-2.0.0-py2.py3-none-any.whl", hash = "sha256:cefa1a2f919b866c5beb7c9f7b0ebb4061f30a8a9bf16d609b000e2dfaceb9c3"},
-    {file = "importlib_metadata-2.0.0.tar.gz", hash = "sha256:77a540690e24b0305878c37ffd421785a6f7e53c8b5720d211b211de8d0e95da"},
-]
 iniconfig = [
     {file = "iniconfig-1.0.1-py3-none-any.whl", hash = "sha256:80cf40c597eb564e86346103f609d74efce0f6b4d4f30ec8ce9e2c26411ba437"},
     {file = "iniconfig-1.0.1.tar.gz", hash = "sha256:e5f92f89355a67de0595932a6c6c02ab4afddc6fcdc0bfc5becd0d60884d3f69"},
@@ -1970,8 +1931,8 @@ more-itertools = [
     {file = "more_itertools-8.5.0-py3-none-any.whl", hash = "sha256:9b30f12df9393f0d28af9210ff8efe48d10c94f73e5daf886f10c4b0b0b4f03c"},
 ]
 mozilla-nimbus-shared = [
-    {file = "mozilla_nimbus_shared-0.0.9-py3-none-any.whl", hash = "sha256:98542a8d4e0b75ee2394eb9c25775f63d5ef31fed0f8a38ce5bb2835e6e64b1b"},
-    {file = "mozilla_nimbus_shared-0.0.9.tar.gz", hash = "sha256:7f2c8c24ea66fefac42e94e1cae8c3232cfdf3b9a8daf8b8fb738037218d82aa"},
+    {file = "mozilla_nimbus_shared-1.0.0-py3-none-any.whl", hash = "sha256:0ade872847b609b579d6d927bb1cb6d5f7e6d4943d3dce4df9dbb3b3fa0bb289"},
+    {file = "mozilla_nimbus_shared-1.0.0.tar.gz", hash = "sha256:ef9ae589ed77280ac63c99c69b9048524df62a271e2e9815fccbab0a89a7c0a0"},
 ]
 multidict = [
     {file = "multidict-4.7.6-cp35-cp35m-macosx_10_14_x86_64.whl", hash = "sha256:275ca32383bc5d1894b6975bb4ca6a7ff16ab76fa622967625baeebcf8079000"},
@@ -2327,8 +2288,4 @@ yarl = [
     {file = "yarl-1.6.0-cp38-cp38-win32.whl", hash = "sha256:3cc860d72ed989f3b1f3abbd6ecf38e412de722fb38b8f1b1a086315cf0d69c5"},
     {file = "yarl-1.6.0-cp38-cp38-win_amd64.whl", hash = "sha256:e32f0fb443afcfe7f01f95172b66f279938fbc6bdaebe294b0ff6747fb6db020"},
     {file = "yarl-1.6.0.tar.gz", hash = "sha256:61d3ea3c175fe45f1498af868879c6ffeb989d4143ac542163c45538ba5ec21b"},
-]
-zipp = [
-    {file = "zipp-3.2.0-py3-none-any.whl", hash = "sha256:43f4fa8d8bb313e65d8323a3952ef8756bf40f9a5c3ea7334be23ee4ec8278b6"},
-    {file = "zipp-3.2.0.tar.gz", hash = "sha256:b52f22895f4cfce194bc8172f3819ee8de7540aa6d873535a8668b730b8b411f"},
 ]

--- a/app/pyproject.toml
+++ b/app/pyproject.toml
@@ -49,11 +49,11 @@ djangorestframework-csv = "2.1.0"
 unicodecsv = "0.14.1"
 kinto-http = "10.7.0"
 jsonschema = "3.2.0"
-mozilla-nimbus-shared = "0.0.9"
 isort = "5.6.3"
 google-cloud-storage = "1.31.2"
 django-storages = "1.7.1"
 graphene-django = "^2.13.0"
+mozilla-nimbus-shared = "^1.0.0"
 
 [tool.poetry.dev-dependencies]
 rope = "^0.18.0"


### PR DESCRIPTION
Because

* The schema for the V6 API must conform to the experiment schema published in nimbus shared
  https://github.com/mozilla/nimbus-shared/blob/main/types/experiments.ts

This commit

* Updates to the latest mozilla-nimbus-shared v1.0.0
* Makes small changes to the v6 serializer to adhere to the schema
  - add schemaVersion
  - branch feature key must be omitted if no feature_config is set on the experiment
* Temporarily backport nimbus shared data which is no longer present in nimbus shared v1.0.0
  but is required for the rapid experiment prototype to remain functional, this data can be
  removed along with the rest of the rapid prototype when the new Nimbus implementation reaches
  parity