### PR TITLE
fix: #3643 feat(backend): update experiment branches

### DIFF
--- a/app/experimenter/experiments/api/v5/inputs.py
+++ b/app/experimenter/experiments/api/v5/inputs.py
@@ -2,7 +2,7 @@ import graphene
 
 
 class ExperimentInput(graphene.InputObjectType):
-    clientMutationId = graphene.String()
+    client_mutation_id = graphene.String()
     name = graphene.String()
     slug = graphene.String()
     application = graphene.String()
@@ -17,3 +17,38 @@ class CreateExperimentInput(ExperimentInput):
 
 class UpdateExperimentInput(ExperimentInput):
     id = graphene.ID(required=True)
+
+
+class BranchType(graphene.InputObjectType):
+    name = graphene.String(required=True)
+    description = graphene.String(required=True)
+    ratio = graphene.Int(required=True)
+    feature_enabled = graphene.Boolean()
+    feature_value = graphene.String()
+
+
+class ControlBranchType(BranchType):
+    class Meta:
+        description = "The control branch"
+
+
+class TreatmentBranchType(BranchType):
+    class Meta:
+        description = (
+            "The treatment branch that should be in this position on the experiment."
+        )
+
+
+class UpdateExperimentBranchesInput(graphene.InputObjectType):
+    client_mutation_id = graphene.String()
+    nimbus_experiment_id = graphene.Int(required=True)
+    feature_config_id = graphene.Int()
+    control_branch = graphene.Field(ControlBranchType, required=True)
+    treatment_branches = graphene.List(
+        TreatmentBranchType,
+        required=True,
+        description=(
+            "List of treatment branches for this experiment. Branches will be created, "
+            "updated, or deleted to match the list provided."
+        ),
+    )

--- a/app/experimenter/experiments/api/v5/serializers.py
+++ b/app/experimenter/experiments/api/v5/serializers.py
@@ -1,7 +1,10 @@
+from django.db import transaction
+from django.utils.text import slugify
 from rest_framework import serializers
 
 from experimenter.experiments.changelog_utils import generate_nimbus_changelog
 from experimenter.experiments.models import NimbusExperiment
+from experimenter.experiments.models.nimbus import NimbusBranch, NimbusFeatureConfig
 
 
 class NimbusChangeLogMixin:
@@ -11,7 +14,62 @@ class NimbusChangeLogMixin:
         return experiment
 
 
-class NimbusExperimentSerializer(NimbusChangeLogMixin, serializers.ModelSerializer):
+class NimbusBranchSerializer(NimbusChangeLogMixin, serializers.ModelSerializer):
+    class Meta:
+        model = NimbusBranch
+        fields = (
+            "name",
+            "description",
+            "ratio",
+            "feature_enabled",
+            "feature_value",
+        )
+
+
+class NimbusExperimentOverviewSerializer(
+    NimbusChangeLogMixin, serializers.ModelSerializer
+):
     class Meta:
         model = NimbusExperiment
-        fields = ("name", "slug", "application", "public_description", "hypothesis")
+        fields = (
+            "name",
+            "slug",
+            "application",
+            "public_description",
+            "hypothesis",
+        )
+
+
+class NimbusBranchUpdateSerializer(NimbusChangeLogMixin, serializers.ModelSerializer):
+    control_branch = NimbusBranchSerializer()
+    treatment_branches = NimbusBranchSerializer(many=True)
+    feature_config = serializers.PrimaryKeyRelatedField(
+        queryset=NimbusFeatureConfig.objects.all(),
+        allow_null=True,
+    )
+
+    class Meta:
+        model = NimbusExperiment
+        fields = (
+            "feature_config",
+            "control_branch",
+            "treatment_branches",
+        )
+
+    def update(self, experiment, data):
+        control_branch_data = data.pop("control_branch")
+        treatment_branches = data.pop("treatment_branches")
+        with transaction.atomic():
+            instance = super().update(experiment, data)
+            NimbusBranch.objects.filter(experiment=instance).delete()
+            experiment.control_branch = NimbusBranch.objects.create(
+                experiment=instance,
+                slug=slugify(control_branch_data["name"]),
+                **control_branch_data
+            )
+            for branch_data in treatment_branches:
+                NimbusBranch.objects.create(
+                    experiment=instance, slug=slugify(branch_data["name"]), **branch_data
+                )
+            instance.save()
+        return instance

--- a/app/experimenter/experiments/api/v5/types.py
+++ b/app/experimenter/experiments/api/v5/types.py
@@ -1,3 +1,4 @@
+import graphene
 from graphene_django.types import DjangoObjectType
 
 from experimenter.experiments.models.nimbus import (
@@ -15,12 +16,20 @@ from experimenter.projects.models import Project
 class NimbusBranchType(DjangoObjectType):
     class Meta:
         model = NimbusBranch
-        exclude = ("experiment", "nimbusexperiment")
+        exclude = ("id", "experiment", "nimbusexperiment")
+
+
+class NimbusFeatureConfigType(DjangoObjectType):
+    class Meta:
+        model = NimbusFeatureConfig
 
 
 class NimbusExperimentType(DjangoObjectType):
+    treatment_branches = graphene.List(NimbusBranchType)
+
     class Meta:
         model = NimbusExperiment
+        exclude = ("branches",)
 
 
 class ProjectType(DjangoObjectType):
@@ -37,11 +46,6 @@ class NimbusBucketRangeType(DjangoObjectType):
     class Meta:
         model = NimbusBucketRange
         exclude = ("id", "experiment")
-
-
-class NimbusFeatureConfigType(DjangoObjectType):
-    class Meta:
-        model = NimbusFeatureConfig
 
 
 class NimbusProbeType(DjangoObjectType):

--- a/app/experimenter/experiments/models/nimbus.py
+++ b/app/experimenter/experiments/models/nimbus.py
@@ -95,6 +95,10 @@ class NimbusExperiment(NimbusConstants, models.Model):
     def latest_change(self):
         return self.changes.order_by("-changed_on").first()
 
+    @property
+    def treatment_branches(self):
+        return self.branches.exclude(id=self.control_branch.id).order_by("id")
+
 
 class NimbusBranch(models.Model):
     experiment = models.ForeignKey(

--- a/app/experimenter/experiments/tests/api/v5/test_mutation.py
+++ b/app/experimenter/experiments/tests/api/v5/test_mutation.py
@@ -4,8 +4,11 @@ from django.conf import settings
 from django.urls import reverse
 from graphene_django.utils.testing import GraphQLTestCase
 
-from experimenter.experiments.models.nimbus import NimbusExperiment
-from experimenter.experiments.tests.factories.nimbus import NimbusExperimentFactory
+from experimenter.experiments.models.nimbus import NimbusExperiment, NimbusFeatureConfig
+from experimenter.experiments.tests.factories.nimbus import (
+    NimbusExperimentFactory,
+    NimbusFeatureConfigFactory,
+)
 
 CREATE_EXPERIMENT_MUTATION = """\
 mutation($input: CreateExperimentInput!) {
@@ -40,8 +43,39 @@ mutation($input: UpdateExperimentInput!) {
 """
 
 
+UPDATE_EXPERIMENT_BRANCHES_MUTATION = """\
+mutation ($input: UpdateExperimentBranchesInput !) {
+  updateExperimentBranches(input: $input){
+    clientMutationId
+    nimbusExperiment {
+      id
+      featureConfig {
+        name
+      }
+      status
+      name
+      slug
+      controlBranch {
+        name
+        description
+        ratio
+      }
+      treatmentBranches {
+        name
+        description
+        ratio
+      }
+    }
+    message
+    status
+  }
+}
+"""
+
+
 class TestMutations(GraphQLTestCase):
     GRAPHQL_URL = reverse("nimbus-api-graphql")
+    maxDiff = None
 
     def test_create_experiment(self):
         user_email = "user@example.com"
@@ -99,12 +133,12 @@ class TestMutations(GraphQLTestCase):
 
     def test_update_experiment(self):
         user_email = "user@example.com"
-        exp = NimbusExperimentFactory.create_with_status(NimbusExperiment.Status.DRAFT)
+        experiment = NimbusExperimentFactory.create(status=NimbusExperiment.Status.DRAFT)
         response = self.query(
             UPDATE_EXPERIMENT_MUTATION,
             variables={
                 "input": {
-                    "id": exp.id,
+                    "id": experiment.id,
                     "name": "test1234",
                     "slug": "slug1234",
                     "clientMutationId": "randomid",
@@ -115,11 +149,11 @@ class TestMutations(GraphQLTestCase):
         self.assertEqual(response.status_code, 200)
         content = json.loads(response.content)
         result = content["data"]["updateExperiment"]
-        experiment = result["nimbusExperiment"]
+        experiment_result = result["nimbusExperiment"]
         self.assertEqual(
-            experiment,
+            experiment_result,
             {
-                "id": f"{exp.id}",
+                "id": f"{experiment.id}",
                 "status": "DRAFT",
                 "name": "test1234",
                 "slug": "slug1234",
@@ -130,18 +164,18 @@ class TestMutations(GraphQLTestCase):
         self.assertEqual(result["message"], "success")
         self.assertEqual(result["status"], 200)
 
-        exp = NimbusExperiment.objects.first()
-        self.assertEqual(exp.slug, "slug1234")
+        experiment = NimbusExperiment.objects.first()
+        self.assertEqual(experiment.slug, "slug1234")
 
     def test_update_experiment_error(self):
         user_email = "user@example.com"
         long_name = "test" * 1000
-        exp = NimbusExperimentFactory.create_with_status(NimbusExperiment.Status.DRAFT)
+        experiment = NimbusExperimentFactory.create(status=NimbusExperiment.Status.DRAFT)
         response = self.query(
             UPDATE_EXPERIMENT_MUTATION,
             variables={
                 "input": {
-                    "id": exp.id,
+                    "id": experiment.id,
                     "name": long_name,
                     "slug": "slug1234",
                     "clientMutationId": "randomid",
@@ -160,3 +194,73 @@ class TestMutations(GraphQLTestCase):
             {"name": ["Ensure this field has no more than 255 characters."]},
         )
         self.assertEqual(result["status"], 200)
+
+    def test_update_experiment_branches_with_feature_config(self):
+        user_email = "user@example.com"
+        feature = NimbusFeatureConfigFactory()
+        experiment = NimbusExperimentFactory.create(status=NimbusExperiment.Status.DRAFT)
+        experiment_id = experiment.id
+        control_branch = {"name": "control", "description": "a control", "ratio": 1}
+        treatment_branches = [{"name": "treatment1", "description": "desc1", "ratio": 1}]
+        response = self.query(
+            UPDATE_EXPERIMENT_BRANCHES_MUTATION,
+            variables={
+                "input": {
+                    "nimbusExperimentId": experiment.id,
+                    "featureConfigId": feature.id,
+                    "clientMutationId": "randomid",
+                    "controlBranch": control_branch,
+                    "treatmentBranches": treatment_branches,
+                }
+            },
+            headers={settings.OPENIDC_EMAIL_HEADER: user_email},
+        )
+        self.assertEqual(response.status_code, 200)
+        content = json.loads(response.content)
+        result = content["data"]["updateExperimentBranches"]
+        self.assertEqual(
+            result["nimbusExperiment"],
+            {
+                "id": str(experiment.id),
+                "featureConfig": {"name": feature.name},
+                "status": experiment.status.upper(),
+                "name": experiment.name,
+                "slug": experiment.slug,
+                "controlBranch": control_branch,
+                "treatmentBranches": treatment_branches,
+            },
+        )
+        experiment = NimbusExperiment.objects.get(id=experiment_id)
+        self.assertEqual(experiment.feature_config, feature)
+        self.assertEqual(experiment.branches.count(), 2)
+        self.assertEqual(experiment.control_branch.name, control_branch["name"])
+        treatment_branch = experiment.treatment_branches[0]
+        self.assertEqual(treatment_branch.name, treatment_branches[0]["name"])
+
+    def test_update_experiment_branches_with_feature_config_error(self):
+        user_email = "user@example.com"
+        experiment = NimbusExperimentFactory.create(status=NimbusExperiment.Status.DRAFT)
+        control_branch = {"name": "control", "description": "a control", "ratio": 1}
+        treatment_branches = [{"name": "treatment1", "description": "desc1", "ratio": 1}]
+        # The NimbusExperimentFactory always creates a single feature config.
+        self.assertEqual(NimbusFeatureConfig.objects.count(), 1)
+        response = self.query(
+            UPDATE_EXPERIMENT_BRANCHES_MUTATION,
+            variables={
+                "input": {
+                    "nimbusExperimentId": experiment.id,
+                    "featureConfigId": 2,
+                    "clientMutationId": "randomid",
+                    "controlBranch": control_branch,
+                    "treatmentBranches": treatment_branches,
+                }
+            },
+            headers={settings.OPENIDC_EMAIL_HEADER: user_email},
+        )
+        self.assertEqual(response.status_code, 200)
+        content = json.loads(response.content)
+        result = content["data"]["updateExperimentBranches"]
+        self.assertEqual(
+            result["message"],
+            {"feature_config": ['Invalid pk "2" - object does not exist.']},
+        )

--- a/app/experimenter/experiments/tests/api/v5/test_serializers.py
+++ b/app/experimenter/experiments/tests/api/v5/test_serializers.py
@@ -1,12 +1,15 @@
 from django.test import TestCase
 
-from experimenter.experiments.api.v5.serializers import NimbusExperimentSerializer
+from experimenter.experiments.api.v5.serializers import (
+    NimbusBranchUpdateSerializer,
+    NimbusExperimentOverviewSerializer,
+)
 from experimenter.experiments.models import NimbusExperiment
 from experimenter.experiments.tests.factories import NimbusExperimentFactory
 from experimenter.openidc.tests.factories import UserFactory
 
 
-class TestNimbusExperimentSerializer(TestCase):
+class TestCreateNimbusExperimentSerializer(TestCase):
     maxDiff = None
 
     def setUp(self):
@@ -14,11 +17,11 @@ class TestNimbusExperimentSerializer(TestCase):
         self.user = UserFactory()
 
     def test_serializer_outputs_expected_schema(self):
-        experiment = NimbusExperimentFactory.create_with_status(
-            NimbusExperiment.Status.ACCEPTED,
+        experiment = NimbusExperimentFactory.create(
+            status=NimbusExperiment.Status.ACCEPTED,
         )
 
-        serializer = NimbusExperimentSerializer(experiment, context={"user": self.user})
+        serializer = NimbusExperimentOverviewSerializer(experiment)
         data = serializer.data
 
         self.assertDictEqual(
@@ -41,7 +44,9 @@ class TestNimbusExperimentSerializer(TestCase):
             "slug": "the_thing",
         }
 
-        serializer = NimbusExperimentSerializer(data=data, context={"user": self.user})
+        serializer = NimbusExperimentOverviewSerializer(
+            data=data, context={"user": self.user}
+        )
 
         self.assertTrue(serializer.is_valid())
 
@@ -62,7 +67,7 @@ class TestNimbusExperimentSerializer(TestCase):
             "slug": "the_thing",
         }
 
-        serializer = NimbusExperimentSerializer(
+        serializer = NimbusExperimentOverviewSerializer(
             experiment, data=data, context={"user": self.user}
         )
 
@@ -70,3 +75,42 @@ class TestNimbusExperimentSerializer(TestCase):
 
         experiment = serializer.save()
         self.assertEqual(experiment.changes.count(), 2)
+
+
+class TestUpdateNimbusExperimentSerializer(TestCase):
+    maxDiff = None
+
+    def setUp(self):
+        super().setUp()
+        self.user = UserFactory()
+
+    def test_serializer_update_branches(self):
+        experiment = NimbusExperimentFactory.create(
+            status=NimbusExperiment.Status.DRAFT,
+        )
+
+        control_branch = {"name": "control", "description": "a control", "ratio": 1}
+        treatment_branches = [
+            {"name": "treatment1", "description": "desc1", "ratio": 1},
+            {"name": "testment2", "description": "desc2", "ratio": 1},
+        ]
+
+        input = {
+            "feature_config": None,
+            "control_branch": control_branch,
+            "treatment_branches": treatment_branches,
+        }
+        serializer = NimbusBranchUpdateSerializer(
+            experiment, data=input, partial=True, context={"user": self.user}
+        )
+        self.assertTrue(serializer.is_valid())
+        experiment = serializer.save()
+        for key, val in control_branch.items():
+            self.assertEqual(getattr(experiment.control_branch, key), val)
+
+        experiment_treatment_branches = experiment.branches.exclude(
+            id=experiment.control_branch.id
+        ).order_by("id")
+        for index, branch in enumerate(treatment_branches):
+            for key, val in branch.items():
+                self.assertEqual(getattr(experiment_treatment_branches[index], key), val)


### PR DESCRIPTION
Because:

* We want to update an experiment to include a feature config along with
  its control and treatment branches.

This commit:

* Add's a GraphQL mutation that will update the Nimbus experiment to
  reflect the passed in data. Control/Treatment branches will be updated
  to match the GraphQL input, with branches being deleted than set to
  the input.