### PR TITLE
fix #3468 feat(nimbus): wire up GQL mutation for create form submit

### DIFF
--- a/app/experimenter/base/context_processors.py
+++ b/app/experimenter/base/context_processors.py
@@ -2,6 +2,7 @@ import json
 import urllib
 
 from django.conf import settings
+from django.urls import reverse
 
 
 def google_analytics(request):
@@ -18,6 +19,7 @@ def features(request):
             json.dumps(
                 {
                     "sentry_dsn": settings.SENTRY_DSN,
+                    "graphql_url": reverse("nimbus-api-graphql"),
                 }
             )
         ),

--- a/app/experimenter/experiments/api/v5/inputs.py
+++ b/app/experimenter/experiments/api/v5/inputs.py
@@ -18,7 +18,8 @@ class ExperimentInput(graphene.InputObjectType):
 
 class CreateExperimentInput(ExperimentInput):
     name = graphene.String(required=True)
-    slug = graphene.String(required=True)
+    hypothesis = graphene.String(required=True)
+    application = graphene.String(required=True)
 
 
 class UpdateExperimentInput(ExperimentInput):

--- a/app/experimenter/experiments/api/v5/serializers.py
+++ b/app/experimenter/experiments/api/v5/serializers.py
@@ -43,6 +43,40 @@ class NimbusExperimentOverviewSerializer(
             "hypothesis",
         )
 
+    slug = serializers.ReadOnlyField()
+
+    def validate(self, data):
+        if data.get("slug") is None:
+            slug = slugify(data.get("name"))
+
+            if not slug:
+                raise serializers.ValidationError(
+                    {"name": ["Name needs to contain alphanumeric characters"]}
+                )
+            if (
+                self.instance is None
+                and slug
+                and NimbusExperiment.objects.filter(slug=slug).exists()
+            ):
+                raise serializers.ValidationError(
+                    {
+                        "name": [
+                            "Name maps to a pre-existing slug, please choose another name"
+                        ]
+                    }
+                )
+
+        return data
+
+    def create(self, validated_data):
+        validated_data.update(
+            {
+                "slug": slugify(validated_data["name"]),
+            }
+        )
+        experiment = super().create(validated_data)
+        return experiment
+
 
 class NimbusBranchUpdateSerializer(NimbusChangeLogMixin, serializers.ModelSerializer):
     reference_branch = NimbusBranchSerializer()

--- a/app/experimenter/experiments/tests/api/v5/test_mutation.py
+++ b/app/experimenter/experiments/tests/api/v5/test_mutation.py
@@ -35,7 +35,7 @@ mutation($input: UpdateExperimentInput!) {
             id
             status
             name
-            slug
+            hypothesis
         }
         message
         status
@@ -123,8 +123,9 @@ class TestMutations(GraphQLTestCase):
             CREATE_EXPERIMENT_MUTATION,
             variables={
                 "input": {
-                    "name": "test1234",
-                    "slug": "slug1234",
+                    "name": "Test 1234",
+                    "hypothesis": "Test hypothesis",
+                    "application": "firefox-desktop",
                     "clientMutationId": "randomid",
                 }
             },
@@ -135,7 +136,7 @@ class TestMutations(GraphQLTestCase):
         result = content["data"]["createExperiment"]
         experiment = result["nimbusExperiment"]
         self.assertEqual(
-            experiment, {"status": "DRAFT", "name": "test1234", "slug": "slug1234"}
+            experiment, {"status": "DRAFT", "name": "Test 1234", "slug": "test-1234"}
         )
 
         self.assertEqual(result["clientMutationId"], "randomid")
@@ -143,7 +144,7 @@ class TestMutations(GraphQLTestCase):
         self.assertEqual(result["status"], 200)
 
         exp = NimbusExperiment.objects.first()
-        self.assertEqual(exp.slug, "slug1234")
+        self.assertEqual(exp.slug, "test-1234")
 
     def test_create_experiment_error(self):
         user_email = "user@example.com"
@@ -153,7 +154,8 @@ class TestMutations(GraphQLTestCase):
             variables={
                 "input": {
                     "name": long_name,
-                    "slug": "slug1234",
+                    "hypothesis": "Test hypothesis",
+                    "application": "firefox-desktop",
                     "clientMutationId": "randomid",
                 }
             },
@@ -179,8 +181,8 @@ class TestMutations(GraphQLTestCase):
             variables={
                 "input": {
                     "id": experiment.id,
-                    "name": "test1234",
-                    "slug": "slug1234",
+                    "name": "Test 1234",
+                    "hypothesis": "Test hypo 2",
                     "clientMutationId": "randomid",
                 }
             },
@@ -195,8 +197,8 @@ class TestMutations(GraphQLTestCase):
             {
                 "id": f"{experiment.id}",
                 "status": "DRAFT",
-                "name": "test1234",
-                "slug": "slug1234",
+                "name": "Test 1234",
+                "hypothesis": "Test hypo 2",
             },
         )
 
@@ -205,7 +207,7 @@ class TestMutations(GraphQLTestCase):
         self.assertEqual(result["status"], 200)
 
         experiment = NimbusExperiment.objects.first()
-        self.assertEqual(experiment.slug, "slug1234")
+        self.assertEqual(experiment.hypothesis, "Test hypo 2")
 
     def test_update_experiment_error(self):
         user_email = "user@example.com"
@@ -217,7 +219,6 @@ class TestMutations(GraphQLTestCase):
                 "input": {
                     "id": experiment.id,
                     "name": long_name,
-                    "slug": "slug1234",
                     "clientMutationId": "randomid",
                 }
             },

--- a/app/experimenter/nimbus-ui/package.json
+++ b/app/experimenter/nimbus-ui/package.json
@@ -14,7 +14,7 @@
     "storybook": "start-storybook -p 3001",
     "build-storybook": "build-storybook",
     "eject": "react-scripts eject",
-    "types": "NODE_TLS_REJECT_UNAUTHORIZED=0 apollo codegen:generate --target typescript --endpoint https://localhost/api/v5/graphql types"
+    "types": "NODE_TLS_REJECT_UNAUTHORIZED=0 apollo codegen:generate --target typescript --endpoint https://localhost/api/v5/graphql --outputFlat src/types"
   },
   "jest": {
     "collectCoverageFrom": [

--- a/app/experimenter/nimbus-ui/src/components/FormExperimentOverviewPartial/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/FormExperimentOverviewPartial/index.stories.tsx
@@ -9,15 +9,30 @@ import FormExperimentOverviewPartial from ".";
 
 const APPLICATIONS = ["firefox-desktop", "fenix", "reference-browser"];
 
-storiesOf("components/FormExperimentOverviewPartial", module).add(
-  "basic",
-  () => <Subject />,
-);
+storiesOf("components/FormExperimentOverviewPartial", module)
+  .add("basic", () => <Subject />)
+  .add("loading", () => <Subject isLoading />)
+  .add("errors", () => (
+    <Subject
+      submitErrors={{
+        "*": "Big bad server thing broke!",
+        name: "This name is terrible.",
+        hypothesis: "You call this a hypothesis?",
+        application: "That's a potato.",
+      }}
+    />
+  ));
 
 const Subject = ({
+  isLoading = false,
+  submitErrors = {},
   onSubmit = action("onSubmit"),
   onCancel = action("onCancel"),
   applications = APPLICATIONS,
 } = {}) => (
-  <FormExperimentOverviewPartial {...{ onSubmit, onCancel, applications }} />
+  <div className="p-5">
+    <FormExperimentOverviewPartial
+      {...{ isLoading, submitErrors, onSubmit, onCancel, applications }}
+    />
+  </div>
 );

--- a/app/experimenter/nimbus-ui/src/components/FormExperimentOverviewPartial/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/FormExperimentOverviewPartial/index.tsx
@@ -3,24 +3,37 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React, { useCallback } from "react";
-import { useForm, SubmitHandler } from "react-hook-form";
+import { useForm } from "react-hook-form";
 import Form from "react-bootstrap/Form";
+import Alert from "react-bootstrap/Alert";
 
 type FormExperimentOverviewPartialProps = {
-  onSubmit: SubmitHandler<Record<string, any>>;
+  isLoading: boolean;
+  submitErrors: Record<string, string[]>;
+  onSubmit: (data: Record<string, any>, reset: Function) => void;
   onCancel: (ev: React.FormEvent) => void;
   applications: string[];
 };
 
 const FormExperimentOverviewPartial = ({
+  isLoading,
+  submitErrors,
   onSubmit,
   onCancel,
   applications,
 }: FormExperimentOverviewPartialProps) => {
-  const { handleSubmit, register, errors, formState } = useForm({
+  const { handleSubmit, register, reset, errors, formState } = useForm({
     mode: "onTouched",
   });
   const { isSubmitted, isValid, isDirty, touched } = formState;
+
+  const handleSubmitAfterValidation = useCallback(
+    (data: Record<string, any>) => {
+      if (isLoading) return;
+      onSubmit(data, reset);
+    },
+    [isLoading, onSubmit, reset],
+  );
 
   const handleCancel = useCallback(
     (ev: React.FormEvent) => {
@@ -33,31 +46,52 @@ const FormExperimentOverviewPartial = ({
   const nameValidated = (
     name: string,
     // This could be ValidationRules from react-hook-form/validator, but
-    // register() has several signatures and only this one produces a ref 
-    validateRule: Parameters<typeof register>[1] = { required: "Required" },
+    // register() has several signatures and only this one produces a ref
+    validateRule: Parameters<typeof register>[1] = {
+      required: "This field may not be blank.",
+    },
   ) => ({
     name,
-    isInvalid: touched[name] && errors[name],
-    isValid: touched[name] && !errors[name],
+    isInvalid: !!submitErrors[name] || (touched[name] && errors[name]),
+    isValid: !submitErrors[name] && touched[name] && !errors[name],
     ref: register(validateRule),
   });
+
+  const FormErrors = ({ name }: { name: string }) => (
+    <>
+      {errors[name] && (
+        <Form.Control.Feedback type="invalid" data-for={name}>
+          {errors[name].message}
+        </Form.Control.Feedback>
+      )}
+      {submitErrors[name] && (
+        <Form.Control.Feedback type="invalid" data-for={name}>
+          {submitErrors[name]}
+        </Form.Control.Feedback>
+      )}
+    </>
+  );
 
   return (
     <Form
       noValidate
-      onSubmit={handleSubmit(onSubmit)}
+      onSubmit={handleSubmit(handleSubmitAfterValidation)}
       validated={isSubmitted && isValid}
       data-testid="FormExperimentOverviewPartial"
     >
+      {submitErrors["*"] && (
+        <Alert data-testid="submit-error" variant="warning">
+          {submitErrors["*"]}
+        </Alert>
+      )}
+
       <Form.Group controlId="name">
         <Form.Label>Public name</Form.Label>
         <Form.Control {...nameValidated("name")} type="text" autoFocus />
         <Form.Text className="text-muted">
           This name will be public to users in about:studies.
         </Form.Text>
-        <Form.Control.Feedback type="invalid">
-          This field may not be blank.
-        </Form.Control.Feedback>
+        <FormErrors name="name" />
       </Form.Group>
 
       <Form.Group controlId="hypothesis">
@@ -66,9 +100,7 @@ const FormExperimentOverviewPartial = ({
         <Form.Text className="text-muted">
           You can add any supporting documents here.
         </Form.Text>
-        <Form.Control.Feedback type="invalid">
-          This field may not be blank.
-        </Form.Control.Feedback>
+        <FormErrors name="hypothesis" />
       </Form.Group>
 
       <Form.Group controlId="application">
@@ -82,19 +114,23 @@ const FormExperimentOverviewPartial = ({
         <Form.Text className="text-muted">
           Experiments can only target one Application at a time.
         </Form.Text>
-        <Form.Control.Feedback type="invalid">
-          This field may not be blank.
-        </Form.Control.Feedback>
+        <FormErrors name="application" />
       </Form.Group>
 
       <div className="d-flex flex-row-reverse bd-highlight">
         <div className="p-2">
           <button
+            data-testid="submit-button"
             type="submit"
+            onClick={handleSubmit(handleSubmitAfterValidation)}
             className="btn btn-primary"
-            disabled={!isDirty || !isValid}
+            disabled={isLoading || !isDirty || !isValid}
           >
-            Create experiment
+            {isLoading ? (
+              <span>Submitting</span>
+            ) : (
+              <span>Create experiment</span>
+            )}
           </button>
         </div>
         <div className="p-2">

--- a/app/experimenter/nimbus-ui/src/gql/experiments.ts
+++ b/app/experimenter/nimbus-ui/src/gql/experiments.ts
@@ -1,0 +1,21 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { gql } from '@apollo/client';
+
+export const CREATE_EXPERIMENT_MUTATION = gql`
+  mutation createExperiment($input: CreateExperimentInput!) {
+    createExperiment(input: $input) {
+      clientMutationId
+      message
+      status
+      nimbusExperiment {
+        name
+        slug
+        hypothesis
+        application
+      }
+    }
+  }
+`;

--- a/app/experimenter/nimbus-ui/src/services/apollo.ts
+++ b/app/experimenter/nimbus-ui/src/services/apollo.ts
@@ -3,12 +3,13 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { ApolloClient, InMemoryCache, createHttpLink, from } from "@apollo/client";
+import config from "./config";
 
 export const cache = new InMemoryCache();
 
 export function createApolloClient() {
   const httpLink = createHttpLink({
-    uri: `/api/v5/graphql`,
+    uri: config.graphql_url,
   });
 
   const apolloClient = new ApolloClient({

--- a/app/experimenter/nimbus-ui/src/services/config.ts
+++ b/app/experimenter/nimbus-ui/src/services/config.ts
@@ -3,12 +3,14 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 export interface Config {
+  graphql_url: string;
   sentry_dsn: string;
   version: string;
 }
 
 export function getDefault() {
   return {
+    graphql_url: '',
     sentry_dsn: '',
     version: '',
   }

--- a/app/experimenter/nimbus-ui/src/types/createExperiment.ts
+++ b/app/experimenter/nimbus-ui/src/types/createExperiment.ts
@@ -1,0 +1,37 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+import { CreateExperimentInput, NimbusExperimentApplication } from "./globalTypes";
+
+// ====================================================
+// GraphQL mutation operation: createExperiment
+// ====================================================
+
+export interface createExperiment_createExperiment_nimbusExperiment {
+  __typename: "NimbusExperimentType";
+  name: string;
+  slug: string;
+  hypothesis: string | null;
+  application: NimbusExperimentApplication | null;
+}
+
+export interface createExperiment_createExperiment {
+  __typename: "CreateExperiment";
+  clientMutationId: string | null;
+  message: any | null;
+  status: number | null;
+  nimbusExperiment: createExperiment_createExperiment_nimbusExperiment | null;
+}
+
+export interface createExperiment {
+  /**
+   * Create a new Nimbus Experiment.
+   */
+  createExperiment: createExperiment_createExperiment | null;
+}
+
+export interface createExperimentVariables {
+  input: CreateExperimentInput;
+}

--- a/app/experimenter/nimbus-ui/src/types/globalTypes.ts
+++ b/app/experimenter/nimbus-ui/src/types/globalTypes.ts
@@ -1,0 +1,30 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+//==============================================================
+// START Enums and Input Objects
+//==============================================================
+
+/**
+ * An enumeration.
+ */
+export enum NimbusExperimentApplication {
+  FENIX = "FENIX",
+  FIREFOX_DESKTOP = "FIREFOX_DESKTOP",
+  REFERENCE_BROWSER = "REFERENCE_BROWSER",
+}
+
+export interface CreateExperimentInput {
+  clientMutationId?: string | null;
+  name: string;
+  slug?: string | null;
+  application: string;
+  publicDescription?: string | null;
+  hypothesis: string;
+}
+
+//==============================================================
+// END Enums and Input Objects
+//==============================================================


### PR DESCRIPTION
Because:

* we want to support creating an experiment from user input

This commit:

* sets the base URL for the GQL API from Django-supplied configuration

* tweaks server-side createExperiment mutation to auto-slugify
  experiment name and better match fields from UX design

* adds support for submit in-progress state and error messages in
  FormExperimentOverviewPartial

* wires up the client-side createExperiment GQL mutation in PageNew to
  create a new experiment on form submission

* adds SimulatedMockLink helper to simulate GQL responses in stories
  with arbitrary user input