### PR TITLE
fix #3784 feat(nimbus): add probesets to V6 API

### DIFF
--- a/app/experimenter/docs/openapi-schema.json
+++ b/app/experimenter/docs/openapi-schema.json
@@ -1582,6 +1582,63 @@
         ]
       }
     },
+    "/api/v6/probesets/": {
+      "get": {
+        "operationId": "listNimbusProbeSets",
+        "description": "",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/NimbusProbeSet"
+                  }
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "tags": [
+          "Nimbus: Public"
+        ]
+      }
+    },
+    "/api/v6/probesets/{slug}/": {
+      "get": {
+        "operationId": "retrieveNimbusProbeSet",
+        "description": "",
+        "parameters": [
+          {
+            "name": "slug",
+            "in": "path",
+            "required": true,
+            "description": "",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NimbusProbeSet"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "tags": [
+          "Nimbus: Public"
+        ]
+      }
+    },
     "/api/v3/experiments/": {
       "post": {
         "operationId": "createExperiment",
@@ -3505,6 +3562,68 @@
           "slug",
           "bucketConfig",
           "branches"
+        ]
+      },
+      "NimbusProbeSet": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "maxLength": 255
+          },
+          "slug": {
+            "type": "string",
+            "maxLength": 80,
+            "pattern": "^[-a-zA-Z0-9_]+$"
+          },
+          "probes": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "kind": {
+                  "enum": [
+                    "event",
+                    "scalar"
+                  ],
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string",
+                  "maxLength": 255
+                },
+                "event_category": {
+                  "type": "string",
+                  "maxLength": 255
+                },
+                "event_method": {
+                  "type": "string",
+                  "nullable": true,
+                  "maxLength": 255
+                },
+                "event_object": {
+                  "type": "string",
+                  "nullable": true,
+                  "maxLength": 255
+                },
+                "event_value": {
+                  "type": "string",
+                  "nullable": true,
+                  "maxLength": 255
+                }
+              },
+              "required": [
+                "kind",
+                "name",
+                "event_category"
+              ]
+            }
+          }
+        },
+        "required": [
+          "name",
+          "slug",
+          "probes"
         ]
       },
       "ExperimentClone": {

--- a/app/experimenter/docs/swagger-ui.html
+++ b/app/experimenter/docs/swagger-ui.html
@@ -1594,6 +1594,63 @@
         ]
       }
     },
+    "/api/v6/probesets/": {
+      "get": {
+        "operationId": "listNimbusProbeSets",
+        "description": "",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/NimbusProbeSet"
+                  }
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "tags": [
+          "Nimbus: Public"
+        ]
+      }
+    },
+    "/api/v6/probesets/{slug}/": {
+      "get": {
+        "operationId": "retrieveNimbusProbeSet",
+        "description": "",
+        "parameters": [
+          {
+            "name": "slug",
+            "in": "path",
+            "required": true,
+            "description": "",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NimbusProbeSet"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "tags": [
+          "Nimbus: Public"
+        ]
+      }
+    },
     "/api/v3/experiments/": {
       "post": {
         "operationId": "createExperiment",
@@ -3517,6 +3574,68 @@
           "slug",
           "bucketConfig",
           "branches"
+        ]
+      },
+      "NimbusProbeSet": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "maxLength": 255
+          },
+          "slug": {
+            "type": "string",
+            "maxLength": 80,
+            "pattern": "^[-a-zA-Z0-9_]+$"
+          },
+          "probes": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "kind": {
+                  "enum": [
+                    "event",
+                    "scalar"
+                  ],
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string",
+                  "maxLength": 255
+                },
+                "event_category": {
+                  "type": "string",
+                  "maxLength": 255
+                },
+                "event_method": {
+                  "type": "string",
+                  "nullable": true,
+                  "maxLength": 255
+                },
+                "event_object": {
+                  "type": "string",
+                  "nullable": true,
+                  "maxLength": 255
+                },
+                "event_value": {
+                  "type": "string",
+                  "nullable": true,
+                  "maxLength": 255
+                }
+              },
+              "required": [
+                "kind",
+                "name",
+                "event_category"
+              ]
+            }
+          }
+        },
+        "required": [
+          "name",
+          "slug",
+          "probes"
         ]
       },
       "ExperimentClone": {

--- a/app/experimenter/experiments/api/v6/serializers.py
+++ b/app/experimenter/experiments/api/v6/serializers.py
@@ -7,6 +7,8 @@ from experimenter.experiments.models import (
     NimbusBranch,
     NimbusBucketRange,
     NimbusExperiment,
+    NimbusProbe,
+    NimbusProbeSet,
 )
 
 
@@ -113,3 +115,24 @@ class NimbusExperimentSerializer(serializers.ModelSerializer):
                 )
 
             return f"{channels_expr}{version_expr}{obj.targeting_config.targeting}"
+
+
+class NimbusProbeSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = NimbusProbe
+        fields = (
+            "kind",
+            "name",
+            "event_category",
+            "event_method",
+            "event_object",
+            "event_value",
+        )
+
+
+class NimbusProbeSetSerializer(serializers.ModelSerializer):
+    probes = NimbusProbeSerializer(many=True)
+
+    class Meta:
+        model = NimbusProbeSet
+        fields = ("name", "slug", "probes")

--- a/app/experimenter/experiments/api/v6/urls.py
+++ b/app/experimenter/experiments/api/v6/urls.py
@@ -1,7 +1,11 @@
 from rest_framework.routers import SimpleRouter
 
-from experimenter.experiments.api.v6.views import NimbusExperimentViewSet
+from experimenter.experiments.api.v6.views import (
+    NimbusExperimentViewSet,
+    NimbusProbeSetViewSet,
+)
 
 router = SimpleRouter()
 router.register(r"experiments", NimbusExperimentViewSet, "nimbus-experiment-rest")
+router.register(r"probesets", NimbusProbeSetViewSet, "nimbus-probeset-rest")
 urlpatterns = router.urls

--- a/app/experimenter/experiments/api/v6/views.py
+++ b/app/experimenter/experiments/api/v6/views.py
@@ -1,7 +1,10 @@
 from rest_framework import mixins, viewsets
 
-from experimenter.experiments.api.v6.serializers import NimbusExperimentSerializer
-from experimenter.experiments.models import NimbusExperiment
+from experimenter.experiments.api.v6.serializers import (
+    NimbusExperimentSerializer,
+    NimbusProbeSetSerializer,
+)
+from experimenter.experiments.models import NimbusExperiment, NimbusProbeSet
 
 
 class NimbusExperimentViewSet(
@@ -14,3 +17,13 @@ class NimbusExperimentViewSet(
         status__in=[NimbusExperiment.Status.DRAFT, NimbusExperiment.Status.REVIEW]
     )
     serializer_class = NimbusExperimentSerializer
+
+
+class NimbusProbeSetViewSet(
+    mixins.RetrieveModelMixin,
+    mixins.ListModelMixin,
+    viewsets.GenericViewSet,
+):
+    lookup_field = "slug"
+    queryset = NimbusProbeSet.objects.all()
+    serializer_class = NimbusProbeSetSerializer

--- a/app/experimenter/settings.py
+++ b/app/experimenter/settings.py
@@ -153,6 +153,8 @@ OPENIDC_AUTH_WHITELIST = (
     "experiment-rapid-recipe-detail",
     "nimbus-experiment-rest-list",
     "nimbus-experiment-rest-detail",
+    "nimbus-probeset-rest-list",
+    "nimbus-probeset-rest-detail",
 )
 
 # Internationalization


### PR DESCRIPTION
Because

* The jetstream automated analysis system will need to pull the data for all probes/probesets to perform automated experiment analysis

This commit

* Adds a read only API to V6 that exposes probesets and probes that can be queried by jetstream