### PR TITLE
fix #3794 feat(nimbus): add probesets mutation

### DIFF
--- a/app/experimenter/experiments/api/v5/inputs.py
+++ b/app/experimenter/experiments/api/v5/inputs.py
@@ -52,3 +52,13 @@ class UpdateExperimentBranchesInput(graphene.InputObjectType):
             "updated, or deleted to match the list provided."
         ),
     )
+
+
+class UpdateExperimentProbeSetsInput(graphene.InputObjectType):
+    client_mutation_id = graphene.String()
+    nimbus_experiment_id = graphene.Int(required=True)
+    probe_set_ids = graphene.List(
+        graphene.Int,
+        required=True,
+        description="List of probeset ids that should be set on the experiment.",
+    )

--- a/app/experimenter/experiments/api/v5/mutation.py
+++ b/app/experimenter/experiments/api/v5/mutation.py
@@ -17,10 +17,12 @@ from experimenter.experiments.api.v5.inputs import (
     CreateExperimentInput,
     UpdateExperimentBranchesInput,
     UpdateExperimentInput,
+    UpdateExperimentProbeSetsInput,
 )
 from experimenter.experiments.api.v5.serializers import (
     NimbusBranchUpdateSerializer,
     NimbusExperimentOverviewSerializer,
+    NimbusProbeSetUpdateSerializer,
 )
 from experimenter.experiments.api.v5.types import NimbusExperimentType
 from experimenter.experiments.models import NimbusExperiment
@@ -121,6 +123,37 @@ class UpdateExperimentBranches(graphene.Mutation):
         )
 
 
+class UpdateExperimentProbeSets(graphene.Mutation):
+    client_mutation_id = graphene.String()
+    nimbus_experiment = graphene.Field(NimbusExperimentType)
+    message = ObjectField()
+    status = graphene.Int()
+
+    class Arguments:
+        input = UpdateExperimentProbeSetsInput(required=True)
+
+    @classmethod
+    def mutate(cls, root, info, input: UpdateExperimentProbeSetsInput):
+        experiment = NimbusExperiment.objects.get(id=input.nimbus_experiment_id)
+        serializer = NimbusProbeSetUpdateSerializer(
+            experiment,
+            data={"probe_sets": input["probe_set_ids"]},
+            context={"user": info.context.user},
+        )
+        if serializer.is_valid():
+            obj = serializer.save()
+            msg = "success"
+        else:
+            msg = serializer.errors
+            obj = None
+        return cls(
+            nimbus_experiment=obj,
+            message=msg,
+            status=200,
+            client_mutation_id=input.client_mutation_id,
+        )
+
+
 class Mutation(graphene.ObjectType):
     create_experiment = CreateExperiment.Field(
         description="Create a new Nimbus Experiment."
@@ -129,4 +162,8 @@ class Mutation(graphene.ObjectType):
 
     update_experiment_branches = UpdateExperimentBranches.Field(
         description="Updates branches on a Nimbus Experiment."
+    )
+
+    update_experiment_probe_sets = UpdateExperimentProbeSets.Field(
+        description="Updates the probesets on a Nimbus Experiment."
     )

--- a/app/experimenter/experiments/api/v5/serializers.py
+++ b/app/experimenter/experiments/api/v5/serializers.py
@@ -4,7 +4,11 @@ from rest_framework import serializers
 
 from experimenter.experiments.changelog_utils import generate_nimbus_changelog
 from experimenter.experiments.models import NimbusExperiment
-from experimenter.experiments.models.nimbus import NimbusBranch, NimbusFeatureConfig
+from experimenter.experiments.models.nimbus import (
+    NimbusBranch,
+    NimbusFeatureConfig,
+    NimbusProbeSet,
+)
 
 
 class NimbusChangeLogMixin:
@@ -73,3 +77,13 @@ class NimbusBranchUpdateSerializer(NimbusChangeLogMixin, serializers.ModelSerial
                 )
             instance.save()
         return instance
+
+
+class NimbusProbeSetUpdateSerializer(NimbusChangeLogMixin, serializers.ModelSerializer):
+    probe_sets = serializers.PrimaryKeyRelatedField(
+        many=True, queryset=NimbusProbeSet.objects.all()
+    )
+
+    class Meta:
+        model = NimbusExperiment
+        fields = ("probe_sets",)


### PR DESCRIPTION
Co-authored-by: Jared Lockhart <119884+jaredlockhart@users.noreply.github.com>

Because:

* We want to add probe sets to an experiment.

This commit:

* Add's a mutation to update the probe sets for an experiment.