### PR TITLE
fix #3796 feat(nimbus): add mutation for audience update

### DIFF
--- a/app/experimenter/experiments/api/v5/inputs.py
+++ b/app/experimenter/experiments/api/v5/inputs.py
@@ -1,5 +1,11 @@
 import graphene
 
+from experimenter.experiments.api.v5.types import (
+    NimbusExperimentChannel,
+    NimbusExperimentFirefoxMinVersion,
+    NimbusExperimentTargetingConfigSlug,
+)
+
 
 class ExperimentInput(graphene.InputObjectType):
     client_mutation_id = graphene.String()
@@ -62,3 +68,15 @@ class UpdateExperimentProbeSetsInput(graphene.InputObjectType):
         required=True,
         description="List of probeset ids that should be set on the experiment.",
     )
+
+
+class UpdateExperimentAudienceInput(graphene.InputObjectType):
+    client_mutation_id = graphene.String()
+    nimbus_experiment_id = graphene.Int(required=True)
+    channels = graphene.List(NimbusExperimentChannel)
+    firefox_min_version = NimbusExperimentFirefoxMinVersion()
+    population_percent = graphene.Decimal()
+    proposed_duration = graphene.Int()
+    proposed_enrollment = graphene.String()
+    targeting_config_slug = NimbusExperimentTargetingConfigSlug()
+    total_enrolled_clients = graphene.Int()

--- a/app/experimenter/experiments/api/v5/mutation.py
+++ b/app/experimenter/experiments/api/v5/mutation.py
@@ -15,17 +15,34 @@ import graphene
 
 from experimenter.experiments.api.v5.inputs import (
     CreateExperimentInput,
+    UpdateExperimentAudienceInput,
     UpdateExperimentBranchesInput,
     UpdateExperimentInput,
     UpdateExperimentProbeSetsInput,
 )
 from experimenter.experiments.api.v5.serializers import (
+    NimbusAudienceUpdateSerializer,
     NimbusBranchUpdateSerializer,
     NimbusExperimentOverviewSerializer,
     NimbusProbeSetUpdateSerializer,
 )
 from experimenter.experiments.api.v5.types import NimbusExperimentType
 from experimenter.experiments.models import NimbusExperiment
+
+
+def handle_with_serializer(cls, serializer, client_mutation_id):
+    if serializer.is_valid():
+        obj = serializer.save()
+        msg = "success"
+    else:
+        msg = serializer.errors
+        obj = None
+    return cls(
+        nimbus_experiment=obj,
+        message=msg,
+        status=200,
+        client_mutation_id=client_mutation_id,
+    )
 
 
 class ObjectField(graphene.Scalar):
@@ -50,18 +67,7 @@ class CreateExperiment(graphene.Mutation):
         serializer = NimbusExperimentOverviewSerializer(
             data=input, context={"user": info.context.user}
         )
-        if serializer.is_valid():
-            obj = serializer.save()
-            msg = "success"
-        else:
-            msg = serializer.errors
-            obj = None
-        return cls(
-            nimbus_experiment=obj,
-            message=msg,
-            status=200,
-            client_mutation_id=input.client_mutation_id,
-        )
+        return handle_with_serializer(cls, serializer, input.client_mutation_id)
 
 
 class UpdateExperiment(graphene.Mutation):
@@ -79,18 +85,7 @@ class UpdateExperiment(graphene.Mutation):
         serializer = NimbusExperimentOverviewSerializer(
             exp, data=input, partial=True, context={"user": info.context.user}
         )
-        if serializer.is_valid():
-            obj = serializer.save()
-            msg = "success"
-        else:
-            msg = serializer.errors
-            obj = None
-        return cls(
-            nimbus_experiment=obj,
-            message=msg,
-            status=200,
-            client_mutation_id=input.client_mutation_id,
-        )
+        return handle_with_serializer(cls, serializer, input.client_mutation_id)
 
 
 class UpdateExperimentBranches(graphene.Mutation):
@@ -109,18 +104,7 @@ class UpdateExperimentBranches(graphene.Mutation):
         serializer = NimbusBranchUpdateSerializer(
             exp, data=input, partial=True, context={"user": info.context.user}
         )
-        if serializer.is_valid():
-            obj = serializer.save()
-            msg = "success"
-        else:
-            msg = serializer.errors
-            obj = None
-        return cls(
-            nimbus_experiment=obj,
-            message=msg,
-            status=200,
-            client_mutation_id=input.client_mutation_id,
-        )
+        return handle_with_serializer(cls, serializer, input.client_mutation_id)
 
 
 class UpdateExperimentProbeSets(graphene.Mutation):
@@ -140,18 +124,27 @@ class UpdateExperimentProbeSets(graphene.Mutation):
             data={"probe_sets": input["probe_set_ids"]},
             context={"user": info.context.user},
         )
-        if serializer.is_valid():
-            obj = serializer.save()
-            msg = "success"
-        else:
-            msg = serializer.errors
-            obj = None
-        return cls(
-            nimbus_experiment=obj,
-            message=msg,
-            status=200,
-            client_mutation_id=input.client_mutation_id,
+        return handle_with_serializer(cls, serializer, input.client_mutation_id)
+
+
+class UpdateExperimentAudience(graphene.Mutation):
+    client_mutation_id = graphene.String()
+    nimbus_experiment = graphene.Field(NimbusExperimentType)
+    message = ObjectField()
+    status = graphene.Int()
+
+    class Arguments:
+        input = UpdateExperimentAudienceInput(required=True)
+
+    @classmethod
+    def mutate(cls, root, info, input: UpdateExperimentAudienceInput):
+        experiment = NimbusExperiment.objects.get(id=input.nimbus_experiment_id)
+        serializer = NimbusAudienceUpdateSerializer(
+            experiment,
+            data=input,
+            context={"user": info.context.user},
         )
+        return handle_with_serializer(cls, serializer, input.client_mutation_id)
 
 
 class Mutation(graphene.ObjectType):
@@ -166,4 +159,8 @@ class Mutation(graphene.ObjectType):
 
     update_experiment_probe_sets = UpdateExperimentProbeSets.Field(
         description="Updates the probesets on a Nimbus Experiment."
+    )
+
+    update_experiment_audience = UpdateExperimentAudience.Field(
+        description="Updates the audience on a Nimbus Experiment."
     )

--- a/app/experimenter/experiments/api/v5/serializers.py
+++ b/app/experimenter/experiments/api/v5/serializers.py
@@ -87,3 +87,17 @@ class NimbusProbeSetUpdateSerializer(NimbusChangeLogMixin, serializers.ModelSeri
     class Meta:
         model = NimbusExperiment
         fields = ("probe_sets",)
+
+
+class NimbusAudienceUpdateSerializer(NimbusChangeLogMixin, serializers.ModelSerializer):
+    class Meta:
+        model = NimbusExperiment
+        fields = (
+            "channels",
+            "firefox_min_version",
+            "population_percent",
+            "proposed_duration",
+            "proposed_enrollment",
+            "targeting_config_slug",
+            "total_enrolled_clients",
+        )

--- a/app/experimenter/experiments/api/v5/types.py
+++ b/app/experimenter/experiments/api/v5/types.py
@@ -1,6 +1,7 @@
 import graphene
 from graphene_django.types import DjangoObjectType
 
+from experimenter.experiments.constants.nimbus import NimbusConstants
 from experimenter.experiments.models.nimbus import (
     NimbusBranch,
     NimbusBucketRange,
@@ -11,6 +12,21 @@ from experimenter.experiments.models.nimbus import (
     NimbusProbeSet,
 )
 from experimenter.projects.models import Project
+
+
+class NimbusExperimentFirefoxMinVersion(graphene.Enum):
+    class Meta:
+        enum = NimbusConstants.Version
+
+
+class NimbusExperimentChannel(graphene.Enum):
+    class Meta:
+        enum = NimbusConstants.Channel
+
+
+class NimbusExperimentTargetingConfigSlug(graphene.Enum):
+    class Meta:
+        enum = NimbusConstants.TargetingConfig
 
 
 class NimbusBranchType(DjangoObjectType):
@@ -25,7 +41,10 @@ class NimbusFeatureConfigType(DjangoObjectType):
 
 
 class NimbusExperimentType(DjangoObjectType):
+    firefox_min_version = NimbusExperimentFirefoxMinVersion()
+    channels = graphene.List(NimbusExperimentChannel)
     treatment_branches = graphene.List(NimbusBranchType)
+    targeting_config_slug = NimbusExperimentTargetingConfigSlug()
 
     class Meta:
         model = NimbusExperiment


### PR DESCRIPTION
Because:

* We want to add audience information for a Nimbus experiment.
* We want to re-use the GraphQL enums inside NimbusExperiment elsewhere
  for inputs.

This commit:

* Adds a GraphQL mutation to update the audience for an experiment.
* Refactors the NimbusExperimentType to use separate graphene.Enum's so
  that we can re-use them in mutation Inputs.