### PR TITLE
fix #3795 feat(nimbus): add status update mutation

### DIFF
--- a/app/experimenter/experiments/api/v5/inputs.py
+++ b/app/experimenter/experiments/api/v5/inputs.py
@@ -3,6 +3,7 @@ import graphene
 from experimenter.experiments.api.v5.types import (
     NimbusExperimentChannel,
     NimbusExperimentFirefoxMinVersion,
+    NimbusExperimentStatus,
     NimbusExperimentTargetingConfigSlug,
 )
 
@@ -80,3 +81,9 @@ class UpdateExperimentAudienceInput(graphene.InputObjectType):
     proposed_enrollment = graphene.String()
     targeting_config_slug = NimbusExperimentTargetingConfigSlug()
     total_enrolled_clients = graphene.Int()
+
+
+class UpdateExperimentStatusInput(graphene.InputObjectType):
+    client_mutation_id = graphene.String()
+    nimbus_experiment_id = graphene.Int(required=True)
+    status = NimbusExperimentStatus(required=True)

--- a/app/experimenter/experiments/api/v5/types.py
+++ b/app/experimenter/experiments/api/v5/types.py
@@ -14,6 +14,11 @@ from experimenter.experiments.models.nimbus import (
 from experimenter.projects.models import Project
 
 
+class NimbusExperimentStatus(graphene.Enum):
+    class Meta:
+        enum = NimbusConstants.Status
+
+
 class NimbusExperimentFirefoxMinVersion(graphene.Enum):
     class Meta:
         enum = NimbusConstants.Version
@@ -41,6 +46,7 @@ class NimbusFeatureConfigType(DjangoObjectType):
 
 
 class NimbusExperimentType(DjangoObjectType):
+    status = NimbusExperimentStatus()
     firefox_min_version = NimbusExperimentFirefoxMinVersion()
     channels = graphene.List(NimbusExperimentChannel)
     treatment_branches = graphene.List(NimbusBranchType)


### PR DESCRIPTION
Because:

* We want to update the status to indicate it is ready for review.
* We want to restrict mutations to an experiment that is no longer
  in draft status.

This commit:

* Add's a mutation that allows a DRAFT experiment to be marked for
  review.
* Add's a serializer mixin to mutations to prevent updates if the
  experiment is not in draft status.