### PR TITLE
fix #3790 feat(nimbus): add feature config mutation validation

### DIFF
--- a/app/experimenter/experiments/tests/api/v5/test_mutation.py
+++ b/app/experimenter/experiments/tests/api/v5/test_mutation.py
@@ -252,7 +252,7 @@ class TestMutations(GraphQLTestCase):
 
     def test_update_experiment_branches_with_feature_config(self):
         user_email = "user@example.com"
-        feature = NimbusFeatureConfigFactory()
+        feature = NimbusFeatureConfigFactory(schema="{}")
         experiment = NimbusExperimentFactory.create(status=NimbusExperiment.Status.DRAFT)
         experiment_id = experiment.id
         reference_branch = {"name": "control", "description": "a control", "ratio": 1}


### PR DESCRIPTION
Because:

* We want to verify branch updates that include feature config
  information validate against the feature config schema.
* Branch names must be able to slugify.

This commit:

* Add's additional validation logic to ensure feature config's are
  present when needed and validate the enabled branch feature values.
* Ensures branch names result in a slugify value.