### PR TITLE
fixes #3711 feat(nimbus): standardize and document error handling

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/index.tsx
@@ -5,7 +5,7 @@
 import React from "react";
 import { RouteComponentProps, useParams } from "@reach/router";
 import AppLayoutWithSidebar from "../AppLayoutWithSidebar";
-import { useExperiment } from "../../hooks/useExperiment";
+import { useExperiment } from "../../hooks";
 
 type PageEditBranchesProps = {} & RouteComponentProps;
 

--- a/app/experimenter/nimbus-ui/src/components/PageEditOverview/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditOverview/index.tsx
@@ -5,7 +5,7 @@
 import React from "react";
 import { RouteComponentProps, useParams } from "@reach/router";
 import AppLayoutWithSidebar from "../AppLayoutWithSidebar";
-import { useExperiment } from "../../hooks/useExperiment";
+import { useExperiment } from "../../hooks";
 
 type PageEditOverviewProps = {} & RouteComponentProps;
 

--- a/app/experimenter/nimbus-ui/src/components/PageNew/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageNew/index.test.tsx
@@ -14,6 +14,7 @@ import { MockedCache } from "../../lib/mocks";
 import PageNew from ".";
 import { navigate } from "@reach/router";
 import { CREATE_EXPERIMENT_MUTATION } from "../../gql/experiments";
+import { SUBMIT_ERROR } from "../../lib/constants";
 
 jest.mock("@reach/router", () => ({
   navigate: jest.fn(),
@@ -77,20 +78,21 @@ describe("PageNew", () => {
       fireEvent.click(screen.getByTestId("submit"));
     });
     expect(screen.getByTestId("submitErrors")).toHaveTextContent(
-      JSON.stringify({ "*": "Save failed, no error available" }),
+      JSON.stringify({ "*": SUBMIT_ERROR }),
     );
   });
 
   it("handles experiment form submission with server API error", async () => {
-    const expectedError = "Invalid slug";
     const gqlMocks = mkGqlMocks();
-    gqlMocks[0].result.errors = [new Error(expectedError)];
+    gqlMocks[0].result.errors = [new Error("an error")];
 
     render(<Subject {...{ gqlMocks }} />);
     await act(async () => {
       fireEvent.click(screen.getByTestId("submit"));
     });
-    expect(screen.getByTestId("submitErrors")).toHaveTextContent(expectedError);
+    expect(screen.getByTestId("submitErrors")).toHaveTextContent(
+      JSON.stringify({ "*": SUBMIT_ERROR }),
+    );
   });
 
   it("handles experiment form cancellation", () => {

--- a/app/experimenter/nimbus-ui/src/components/PageNew/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageNew/index.tsx
@@ -13,6 +13,7 @@ import { CREATE_EXPERIMENT_MUTATION } from "../../gql/experiments";
 import { CreateExperimentInput } from "../../types/globalTypes";
 import { createExperiment_createExperiment as CreateExperimentResult } from "../../types/createExperiment";
 import { navigate } from "@reach/router";
+import { SUBMIT_ERROR } from "../../lib/constants";
 
 const TRAINING_DOC_URL =
   "https://mana.mozilla.org/wiki/display/FJT/Project+Nimbus";
@@ -56,7 +57,7 @@ const PageNew = (props: PageNewProps) => {
         resetForm();
         navigate(`${nimbusExperiment!.slug}/edit/overview`);
       } catch (error) {
-        setSubmitErrors({ "*": error.message });
+        setSubmitErrors({ "*": SUBMIT_ERROR });
       }
     },
     [createExperiment],

--- a/app/experimenter/nimbus-ui/src/hooks/index.ts
+++ b/app/experimenter/nimbus-ui/src/hooks/index.ts
@@ -1,0 +1,2 @@
+export * from "./useExitWarning";
+export * from "./useExperiment";

--- a/app/experimenter/nimbus-ui/src/lib/constants.ts
+++ b/app/experimenter/nimbus-ui/src/lib/constants.ts
@@ -3,3 +3,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 export const BASE_PATH = "/experiments/nimbus";
+
+export const UNKNOWN_ERROR =
+  "Sorry, an error occurred but we don't know why. We're looking into it.";
+export const SUBMIT_ERROR =
+  "Sorry, an error occurred while submitting. Please try again.";


### PR DESCRIPTION
This is mostly just documentation on how we should approach errors in the Nimbus app. I originally started with the idea that we should create custom `useMutation`/`useQuery`/etc functions that handled all possible error paths for us, but eventually found this approach to be messy and possibly unreliable, so instead I returned to the idea of "you're responsible for implementation, but here are some guidelines".

As part of the standardizing I did a small update to the exist New Experiment form to display generic errors instead of technical ones.

Additionally, while I was in hook-land, I added an `index.ts` to that directory so you don't need to import hooks from each individual hook file.