### PR TITLE
fixes #3462 feat(nimbus): Add HeaderEditExperiment, not found/loading experiment states

### DIFF
--- a/app/experimenter/nimbus-ui/package.json
+++ b/app/experimenter/nimbus-ui/package.json
@@ -27,6 +27,7 @@
     "@sentry/browser": "^5.25.0",
     "apollo": "^2.31.0",
     "bootstrap": "^4.5.2",
+    "classnames": "^2.2.6",
     "graphql": "^15.3.0",
     "react": "^16.13.1",
     "react-bootstrap": "^1.3.0",

--- a/app/experimenter/nimbus-ui/src/components/AppLayout/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/AppLayout/index.tsx
@@ -14,7 +14,7 @@ type AppLayoutProps = {
 
 export const AppLayout = ({ children, testid = "main" }: AppLayoutProps) => {
   return (
-    <Container fluid as="main" className="h-100" data-testid={testid}>
+    <Container fluid as="main" className="h-100 pt-5" data-testid={testid}>
       <Row className="h-100">
         <Col className="ml-auto mr-auto col-md-10 col-lg-8">{children}</Col>
       </Row>

--- a/app/experimenter/nimbus-ui/src/components/AppLayoutWithSidebar/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/AppLayoutWithSidebar/index.test.tsx
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React from "react";
-import { act, screen } from "@testing-library/react";
+import { act, screen, waitFor } from "@testing-library/react";
 import AppLayoutWithSidebar from ".";
 import { renderWithRouter } from "../../lib/test-utils";
 import { BASE_PATH } from "../../lib/constants";
@@ -76,25 +76,29 @@ describe("PageNew", () => {
         },
       );
 
+      let overviewLink: HTMLElement, branchesLink: HTMLElement;
+
       pushState("edit/overview");
-      await navigate("/my-special-slug/edit/overview");
-      let overviewLink = screen.getByTestId("nav-edit-overview");
-      let branchesLink = screen.getByTestId("nav-edit-branches");
-      expect(overviewLink).toHaveClass("text-primary");
-      expect(overviewLink).not.toHaveClass("text-dark");
-      expect(branchesLink).toHaveClass("text-dark");
-      expect(branchesLink).not.toHaveClass("text-primary");
+      await act(() => navigate("/my-special-slug/edit/overview"));
+      await waitFor(() => {
+        overviewLink = screen.getByTestId("nav-edit-overview");
+        branchesLink = screen.getByTestId("nav-edit-branches");
+      });
+      expect(overviewLink!).toHaveClass("text-primary");
+      expect(overviewLink!).not.toHaveClass("text-dark");
+      expect(branchesLink!).toHaveClass("text-dark");
+      expect(branchesLink!).not.toHaveClass("text-primary");
 
       pushState("edit/branches");
-      await act(async () => {
-        await navigate("/my-special-slug/edit/branches");
+      await act(() => navigate("/my-special-slug/edit/branches"));
+      await waitFor(() => {
+        overviewLink = screen.getByTestId("nav-edit-overview");
+        branchesLink = screen.getByTestId("nav-edit-branches");
       });
-      overviewLink = screen.getByTestId("nav-edit-overview");
-      branchesLink = screen.getByTestId("nav-edit-branches");
-      expect(branchesLink).toHaveClass("text-primary");
-      expect(branchesLink).not.toHaveClass("text-dark");
-      expect(overviewLink).toHaveClass("text-dark");
-      expect(overviewLink).not.toHaveClass("text-primary");
+      expect(branchesLink!).toHaveClass("text-primary");
+      expect(branchesLink!).not.toHaveClass("text-dark");
+      expect(overviewLink!).toHaveClass("text-dark");
+      expect(overviewLink!).not.toHaveClass("text-primary");
     });
   });
 });

--- a/app/experimenter/nimbus-ui/src/components/AppLayoutWithSidebar/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/AppLayoutWithSidebar/index.tsx
@@ -9,6 +9,7 @@ import Row from "react-bootstrap/Row";
 import Col from "react-bootstrap/Col";
 import Nav from "react-bootstrap/Nav";
 import { BASE_PATH } from "../../lib/constants";
+import classNames from "classnames";
 
 type AppLayoutWithSidebarProps = {
   testid?: string;
@@ -23,10 +24,17 @@ export const AppLayoutWithSidebar = ({
   return (
     <Container fluid className="h-100vh" data-testid={testid}>
       <Row className="h-md-100">
-        <Col md="3" lg="3" xl="2" className="bg-light border-right shadow-sm">
+        <Col
+          md="3"
+          lg="3"
+          xl="2"
+          className="bg-light pt-2 border-right shadow-sm"
+        >
           <nav data-testid="sidebarNav">
             <Nav className="flex-column" as="ul">
-              <LinkNav storiesOf="pages/Home">Experiments</LinkNav>
+              <LinkNav storiesOf="pages/Home" className="mb-2">
+                Experiments
+              </LinkNav>
               <LinkNav
                 route={`${slug}/edit/overview`}
                 storiesOf="pages/EditOverview"
@@ -57,7 +65,7 @@ export const AppLayoutWithSidebar = ({
             </Nav>
           </nav>
         </Col>
-        <Col className="ml-auto mr-auto col-md-9 col-xl-10">
+        <Col className="ml-auto mr-auto col-md-9 col-xl-10 pt-5 px-md-3 px-lg-5">
           <main>{children}</main>
         </Col>
       </Row>
@@ -70,6 +78,7 @@ type LinkNavProps = {
   route?: string;
   storiesOf: string;
   testid?: string;
+  className?: string;
 };
 
 const LinkNav = ({
@@ -77,6 +86,7 @@ const LinkNav = ({
   children,
   storiesOf,
   testid = "nav-home",
+  className,
 }: LinkNavProps) => {
   const to = route ? `${BASE_PATH}/${route}` : BASE_PATH;
   // an alternative to reach-router's `isCurrent` with identical
@@ -84,7 +94,7 @@ const LinkNav = ({
   // eslint-disable-next-line
   const isCurrentPage = location.pathname === to;
   return (
-    <Nav.Item as="li" className="m-1">
+    <Nav.Item as="li" className={classNames("m-1", className)}>
       <Link
         {...{ to }}
         data-sb-kind={storiesOf}

--- a/app/experimenter/nimbus-ui/src/components/FormExperimentOverviewPartial/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/FormExperimentOverviewPartial/index.tsx
@@ -125,6 +125,7 @@ const FormExperimentOverviewPartial = ({
             onClick={handleSubmit(handleSubmitAfterValidation)}
             className="btn btn-primary"
             disabled={isLoading || !isDirty || !isValid}
+            data-sb-kind="pages/EditOverview"
           >
             {isLoading ? (
               <span>Submitting</span>

--- a/app/experimenter/nimbus-ui/src/components/HeaderEditExperiment/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/HeaderEditExperiment/index.stories.tsx
@@ -5,16 +5,20 @@
 import React from "react";
 import { storiesOf } from "@storybook/react";
 import { withLinks } from "@storybook/addon-links";
-import { RouterSlugProvider } from "../../lib/test-utils";
+import HeaderEditExperiment from ".";
 import { mockExperimentQuery } from "../../lib/mocks";
-import PageEditOverview from ".";
+import AppLayout from "../AppLayout";
 
-const { mock } = mockExperimentQuery("demo-slug");
+const { data } = mockExperimentQuery("demo-slug");
 
-storiesOf("pages/EditOverview", module)
+storiesOf("components/HeaderEditExperiment", module)
   .addDecorator(withLinks)
   .add("basic", () => (
-    <RouterSlugProvider mocks={[mock]}>
-      <PageEditOverview />
-    </RouterSlugProvider>
+    <AppLayout>
+      <HeaderEditExperiment
+        name={data!.name}
+        slug={data!.slug}
+        status={data!.status}
+      />
+    </AppLayout>
   ));

--- a/app/experimenter/nimbus-ui/src/components/HeaderEditExperiment/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/HeaderEditExperiment/index.test.tsx
@@ -1,0 +1,31 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from "react";
+import { screen, render } from "@testing-library/react";
+import HeaderEditExperiment from ".";
+import { mockExperimentQuery } from "../../lib/mocks";
+
+const { data } = mockExperimentQuery("demo-slug");
+
+describe("HeaderEditExperiment", () => {
+  it("renders as expected", () => {
+    render(
+      <HeaderEditExperiment
+        name={data!.name}
+        slug={data!.slug}
+        status={data!.status}
+      />,
+    );
+    expect(screen.getByTestId("header-experiment-name")).toHaveTextContent(
+      "Open-architected background installation",
+    );
+    expect(screen.getByTestId("header-experiment-slug")).toHaveTextContent(
+      "demo-slug",
+    );
+    expect(screen.getByTestId("header-experiment-status")).toHaveTextContent(
+      "DRAFT",
+    );
+  });
+});

--- a/app/experimenter/nimbus-ui/src/components/HeaderEditExperiment/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/HeaderEditExperiment/index.tsx
@@ -1,0 +1,32 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from "react";
+import { getExperiment_experimentBySlug } from "../../types/getExperiment";
+
+type HeaderEditExperimentProps = Pick<
+  getExperiment_experimentBySlug,
+  "name" | "slug" | "status"
+>;
+
+const HeaderEditExperiment = ({
+  name,
+  slug,
+  status,
+}: HeaderEditExperimentProps) => (
+  <header className="border-bottom" data-testid="header-experiment">
+    <h1 className="h5 font-weight-normal" data-testid="header-experiment-name">
+      {name}
+    </h1>
+    <p
+      className="text-monospace text-secondary mb-1"
+      data-testid="header-experiment-slug"
+    >
+      {slug}
+    </p>
+    <p data-testid="header-experiment-status">{status}</p>
+  </header>
+);
+
+export default HeaderEditExperiment;

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/index.stories.tsx
@@ -6,17 +6,15 @@ import React from "react";
 import { storiesOf } from "@storybook/react";
 import { RouterSlugProvider } from "../../lib/test-utils";
 import { withLinks } from "@storybook/addon-links";
-import { MockedCache, mockExperimentQuery } from "../../lib/mocks";
+import { mockExperimentQuery } from "../../lib/mocks";
 import PageEditBranches from ".";
 
-const { mock } = mockExperimentQuery();
+const { mock } = mockExperimentQuery("demo-slug");
 
 storiesOf("pages/EditBranches", module)
   .addDecorator(withLinks)
   .add("basic", () => (
-    <RouterSlugProvider>
-      <MockedCache mocks={[mock]}>
-        <PageEditBranches />
-      </MockedCache>
+    <RouterSlugProvider mocks={[mock]}>
+      <PageEditBranches />
     </RouterSlugProvider>
   ));

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/index.test.tsx
@@ -3,20 +3,47 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React from "react";
-import { screen } from "@testing-library/react";
+import { screen, waitFor, render } from "@testing-library/react";
 import PageEditBranches from ".";
-import { renderWithRouter } from "../../lib/test-utils";
-import { MockedCache, mockExperimentQuery } from "../../lib/mocks";
+import { RouterSlugProvider } from "../../lib/test-utils";
+import { mockExperimentQuery } from "../../lib/mocks";
 
-const { mock } = mockExperimentQuery();
+const { mock } = mockExperimentQuery("demo-slug");
+const { mock: notFoundMock } = mockExperimentQuery("demo-slug", null);
 
 describe("PageEditBranches", () => {
-  it("renders as expected", () => {
-    renderWithRouter(
-      <MockedCache mocks={[mock]}>
+  it("renders as expected with experiment data", async () => {
+    render(
+      <RouterSlugProvider mocks={[mock]}>
         <PageEditBranches />
-      </MockedCache>,
+      </RouterSlugProvider>,
     );
-    expect(screen.getByTestId("PageEditBranches")).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("PageEditBranches")).toBeInTheDocument();
+      expect(screen.getByTestId("header-experiment")).toBeInTheDocument();
+    });
+  });
+
+  it("renders not found screen", async () => {
+    render(
+      <RouterSlugProvider mocks={[notFoundMock]}>
+        <PageEditBranches />
+      </RouterSlugProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("not-found")).toBeInTheDocument();
+    });
+  });
+
+  it("renders loading screen", () => {
+    render(
+      <RouterSlugProvider>
+        <PageEditBranches />
+      </RouterSlugProvider>,
+    );
+
+    expect(screen.getByTestId("page-loading")).toBeInTheDocument();
   });
 });

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/index.tsx
@@ -6,21 +6,36 @@ import React from "react";
 import { RouteComponentProps, useParams } from "@reach/router";
 import AppLayoutWithSidebar from "../AppLayoutWithSidebar";
 import { useExperiment } from "../../hooks";
+import HeaderEditExperiment from "../HeaderEditExperiment";
+import ExperimentNotFound from "../PageExperimentNotFound";
+import PageLoading from "../PageLoading";
 
 type PageEditBranchesProps = {} & RouteComponentProps;
 
 const PageEditBranches = (props: PageEditBranchesProps) => {
   const { slug } = useParams();
-  const { experiment } = useExperiment(slug);
+  const { experiment, notFound, loading } = useExperiment(slug);
 
-  if (experiment != null) {
-    console.log(experiment.referenceBranch, experiment.treatmentBranches);
+  if (loading) {
+    return <PageLoading />;
   }
 
+  if (notFound) {
+    return <ExperimentNotFound {...{ slug }} />;
+  }
+
+  const { name, status } = experiment;
   return (
     <AppLayoutWithSidebar>
       <section data-testid="PageEditBranches">
-        <h1>PageEditBranches</h1>
+        <HeaderEditExperiment
+          {...{
+            slug,
+            name,
+            status,
+          }}
+        />
+        <h2 className="mt-3 h4">Branches</h2>
       </section>
     </AppLayoutWithSidebar>
   );

--- a/app/experimenter/nimbus-ui/src/components/PageEditOverview/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditOverview/index.test.tsx
@@ -3,20 +3,44 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React from "react";
-import { screen } from "@testing-library/react";
+import { screen, waitFor, render } from "@testing-library/react";
 import PageEditOverview from ".";
-import { renderWithRouter } from "../../lib/test-utils";
-import { MockedCache, mockExperimentQuery } from "../../lib/mocks";
+import { RouterSlugProvider } from "../../lib/test-utils";
+import { mockExperimentQuery } from "../../lib/mocks";
 
-const { mock } = mockExperimentQuery();
+const { mock } = mockExperimentQuery("demo-slug");
+const { mock: notFoundMock } = mockExperimentQuery("demo-slug", null);
 
 describe("PageEditOverview", () => {
-  it("renders as expected", () => {
-    renderWithRouter(
-      <MockedCache mocks={[mock]}>
+  it("renders as expected", async () => {
+    render(
+      <RouterSlugProvider mocks={[mock]}>
         <PageEditOverview />
-      </MockedCache>,
+      </RouterSlugProvider>,
     );
-    expect(screen.getByTestId("PageEditOverview")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByTestId("PageEditOverview")).toBeInTheDocument();
+      expect(screen.getByTestId("header-experiment")).toBeInTheDocument();
+    });
+  });
+
+  it("renders not found screen", async () => {
+    render(
+      <RouterSlugProvider mocks={[notFoundMock]}>
+        <PageEditOverview />
+      </RouterSlugProvider>,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId("not-found")).toBeInTheDocument();
+    });
+  });
+
+  it("renders loading screen", () => {
+    render(
+      <RouterSlugProvider>
+        <PageEditOverview />
+      </RouterSlugProvider>,
+    );
+    expect(screen.getByTestId("page-loading")).toBeInTheDocument();
   });
 });

--- a/app/experimenter/nimbus-ui/src/components/PageEditOverview/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditOverview/index.tsx
@@ -6,25 +6,36 @@ import React from "react";
 import { RouteComponentProps, useParams } from "@reach/router";
 import AppLayoutWithSidebar from "../AppLayoutWithSidebar";
 import { useExperiment } from "../../hooks";
+import HeaderEditExperiment from "../HeaderEditExperiment";
+import PageExperimentNotFound from "../PageExperimentNotFound";
+import PageLoading from "../PageLoading";
 
 type PageEditOverviewProps = {} & RouteComponentProps;
 
 const PageEditOverview = (props: PageEditOverviewProps) => {
   const { slug } = useParams();
-  const { experiment } = useExperiment(slug);
+  const { experiment, notFound, loading } = useExperiment(slug);
 
-  if (experiment != null) {
-    console.log(
-      experiment.hypothesis,
-      experiment.application,
-      experiment.publicDescription,
-    );
+  if (loading) {
+    return <PageLoading />;
   }
 
+  if (notFound) {
+    return <PageExperimentNotFound {...{ slug }} />;
+  }
+
+  const { name, status } = experiment;
   return (
     <AppLayoutWithSidebar>
       <section data-testid="PageEditOverview">
-        <h1>PageEditOverview</h1>
+        <HeaderEditExperiment
+          {...{
+            slug,
+            name,
+            status,
+          }}
+        />
+        <h2 className="mt-3 h4">Overview</h2>
       </section>
     </AppLayoutWithSidebar>
   );

--- a/app/experimenter/nimbus-ui/src/components/PageExperimentNotFound/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageExperimentNotFound/index.stories.tsx
@@ -1,0 +1,12 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from "react";
+import { storiesOf } from "@storybook/react";
+import { withLinks } from "@storybook/addon-links";
+import ExperimentNotFound from ".";
+
+storiesOf("pages/ExperimentNotFound", module)
+  .addDecorator(withLinks)
+  .add("basic", () => <ExperimentNotFound slug="foo-bar-baz" />);

--- a/app/experimenter/nimbus-ui/src/components/PageExperimentNotFound/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageExperimentNotFound/index.test.tsx
@@ -1,0 +1,19 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from "react";
+import { screen, render } from "@testing-library/react";
+import ExperimentNotFound from ".";
+import { BASE_PATH } from "../../lib/constants";
+
+describe("PageExperimentNotFound", () => {
+  it("renders as expected", () => {
+    render(<ExperimentNotFound slug="foo-bar-baz" />);
+    expect(screen.getByTestId("not-found")).toHaveTextContent("foo-bar-baz");
+    expect(screen.getByTestId("not-found-home")).toHaveAttribute(
+      "href",
+      BASE_PATH,
+    );
+  });
+});

--- a/app/experimenter/nimbus-ui/src/components/PageExperimentNotFound/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageExperimentNotFound/index.tsx
@@ -1,0 +1,28 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { Link } from "@reach/router";
+import React from "react";
+import { BASE_PATH } from "../../lib/constants";
+import AppLayout from "../AppLayout";
+
+const ExperimentNotFound = ({ slug }: { slug: string }) => (
+  <AppLayout testid="not-found">
+    <section className="text-center">
+      <h1 className="h2">Experiment Not Found</h1>
+      <p className="pt-3">
+        The experiment with slug "{slug}" could not be found. ☹️
+      </p>
+      <Link
+        to={BASE_PATH}
+        data-sb-kind="pages/Home"
+        data-testid="not-found-home"
+      >
+        Go Home
+      </Link>
+    </section>
+  </AppLayout>
+);
+
+export default ExperimentNotFound;

--- a/app/experimenter/nimbus-ui/src/components/PageHome/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageHome/index.tsx
@@ -11,7 +11,7 @@ type PageHomeProps = {} & RouteComponentProps;
 const PageHome = (props: PageHomeProps) => (
   <AppLayout testid="PageHome">
     <h1>Home</h1>
-    <Link to="./new" data-sb-kind="pages/New">
+    <Link to="new" data-sb-kind="pages/New">
       New experiment
     </Link>
   </AppLayout>

--- a/app/experimenter/nimbus-ui/src/components/PageLoading/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageLoading/index.stories.tsx
@@ -1,0 +1,9 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from "react";
+import { storiesOf } from "@storybook/react";
+import PageLoading from ".";
+
+storiesOf("pages/Loading", module).add("basic", () => <PageLoading />);

--- a/app/experimenter/nimbus-ui/src/components/PageLoading/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageLoading/index.test.tsx
@@ -1,0 +1,16 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from "react";
+import { screen, render } from "@testing-library/react";
+import PageLoading from ".";
+
+describe("PageLoading", () => {
+  it("renders as expected", () => {
+    render(<PageLoading />);
+    const spinner = screen.getByTestId("spinner");
+    expect(screen.getByTestId("page-loading")).toContainElement(spinner);
+    expect(spinner).toHaveClass("spinner-border");
+  });
+});

--- a/app/experimenter/nimbus-ui/src/components/PageLoading/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageLoading/index.tsx
@@ -1,0 +1,22 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from "react";
+import AppLayout from "../AppLayout";
+
+const PageLoading = () => (
+  <AppLayout testid="page-loading">
+    <div className="text-center">
+      <div
+        className="spinner-border text-primary"
+        role="status"
+        data-testid="spinner"
+      >
+        <span className="sr-only">Loading...</span>
+      </div>
+    </div>
+  </AppLayout>
+);
+
+export default PageLoading;

--- a/app/experimenter/nimbus-ui/src/components/PageNew/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageNew/index.stories.tsx
@@ -10,8 +10,11 @@ import { storiesOf } from "@storybook/react";
 import { action } from "@storybook/addon-actions";
 import { CREATE_EXPERIMENT_MUTATION } from "../../gql/experiments";
 import PageNew from ".";
+import { withLinks } from "@storybook/addon-links";
 
-storiesOf("pages/PageNew", module).add("basic", () => <Subject />);
+storiesOf("pages/New", module)
+  .addDecorator(withLinks)
+  .add("basic", () => <Subject />);
 
 const actionCreateExperiment = action("createExperiment");
 

--- a/app/experimenter/nimbus-ui/src/components/PageNew/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageNew/index.tsx
@@ -65,7 +65,7 @@ const PageNew = (props: PageNewProps) => {
 
   return (
     <AppLayout testid="PageNew">
-      <h1>Create a new Experiment</h1>
+      <h1 className="h2">Create a new Experiment</h1>
       <p>
         Before launching an experiment, review the{" "}
         <LinkExternal href={TRAINING_DOC_URL}>

--- a/app/experimenter/nimbus-ui/src/hooks/useExperiment.test.tsx
+++ b/app/experimenter/nimbus-ui/src/hooks/useExperiment.test.tsx
@@ -27,5 +27,27 @@ describe("hooks/useExperiment", () => {
 
       await waitFor(() => expect(hook.experiment).toEqual(data));
     });
+
+    it("returns notFound if no experiment found", async () => {
+      const { mock } = mockExperimentQuery("howdy", null);
+
+      render(
+        <MockedCache mocks={[mock]}>
+          <TestExperiment slug="howdy" />
+        </MockedCache>,
+      );
+
+      await waitFor(() => expect(hook.notFound).toBeTruthy());
+    });
+
+    it("starts by loading", async () => {
+      render(
+        <MockedCache mocks={[]}>
+          <TestExperiment slug="howdy" />
+        </MockedCache>,
+      );
+
+      expect(hook.loading).toBeTruthy();
+    });
   });
 });

--- a/app/experimenter/nimbus-ui/src/hooks/useExperiment.tsx
+++ b/app/experimenter/nimbus-ui/src/hooks/useExperiment.tsx
@@ -29,7 +29,7 @@ import { getExperiment } from "../types/getExperiment";
  */
 
 export function useExperiment(slug: string) {
-  const { data } = useQuery<{
+  const { data, loading } = useQuery<{
     experimentBySlug: getExperiment["experimentBySlug"];
   }>(GET_EXPERIMENT_QUERY, {
     variables: { slug },
@@ -39,8 +39,8 @@ export function useExperiment(slug: string) {
   const experiment = data?.experimentBySlug;
 
   return {
-    experiment,
-    notFound: experiment === null,
-    loading: experiment === undefined,
+    experiment: experiment!,
+    notFound: !loading && experiment === null,
+    loading,
   };
 }

--- a/app/experimenter/nimbus-ui/src/lib/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/lib/mocks.tsx
@@ -126,55 +126,61 @@ export class SimulatedMockLink extends ApolloLink {
 }
 
 export const mockExperimentQuery = (
-  slug = "blah",
+  slug: string,
   modifications: Partial<getExperiment["experimentBySlug"]> = {},
 ) => {
-  const experiment = Object.assign(
-    {
-      __typename: "NimbusExperimentType",
-      name: "Open-architected background installation",
-      slug,
-      status: "DRAFT",
-      hypothesis: "Realize material say pretty.",
-      application: "FIREFOX_DESKTOP",
-      publicDescription:
-        "Official approach present industry strategy dream piece.",
-      controlBranch: {
-        __typename: "NimbusBranchType",
-        name: "User-centric mobile solution",
-        slug: "user-centric-mobile-solution",
-        description: "Behind almost radio result personal none future current.",
-        ratio: 1,
-        featureValue: '{"environmental-fact": "really-citizen"}',
-        featureEnabled: true,
-      },
-      treatmentBranches: [
-        {
-          __typename: "NimbusBranchType",
-          name: "Managed zero tolerance projection",
-          slug: "managed-zero-tolerance-projection",
-          description: "Next ask then he in degree order.",
-          ratio: 1,
-          featureValue: '{"effect-effect-whole": "close-teach-exactly"}',
-          featureEnabled: true,
-        },
-      ],
-      probeSets: [
-        {
-          __typename: "NimbusProbeSetType",
-          slug: "enterprise-wide-exuding-focus-group",
-          name: "Enterprise-wide exuding focus group",
-        },
-      ],
-      channels: ["Nightly", "Beta"],
-      firefoxMinVersion: "A_83_",
-      targetingConfigSlug: "US_ONLY",
-      populationPercent: 40,
-      totalEnrolledClients: 68000,
-      proposedEnrollment: 15,
-    },
-    modifications,
-  );
+  // If `null` is explicitely passed in for `modifications`, the experiment
+  // data will be `null`.
+  const experiment =
+    modifications === null
+      ? null
+      : Object.assign(
+          {
+            __typename: "NimbusExperimentType",
+            name: "Open-architected background installation",
+            slug,
+            status: "DRAFT",
+            hypothesis: "Realize material say pretty.",
+            application: "FIREFOX_DESKTOP",
+            publicDescription:
+              "Official approach present industry strategy dream piece.",
+            controlBranch: {
+              __typename: "NimbusBranchType",
+              name: "User-centric mobile solution",
+              slug: "user-centric-mobile-solution",
+              description:
+                "Behind almost radio result personal none future current.",
+              ratio: 1,
+              featureValue: '{"environmental-fact": "really-citizen"}',
+              featureEnabled: true,
+            },
+            treatmentBranches: [
+              {
+                __typename: "NimbusBranchType",
+                name: "Managed zero tolerance projection",
+                slug: "managed-zero-tolerance-projection",
+                description: "Next ask then he in degree order.",
+                ratio: 1,
+                featureValue: '{"effect-effect-whole": "close-teach-exactly"}',
+                featureEnabled: true,
+              },
+            ],
+            probeSets: [
+              {
+                __typename: "NimbusProbeSetType",
+                slug: "enterprise-wide-exuding-focus-group",
+                name: "Enterprise-wide exuding focus group",
+              },
+            ],
+            channels: ["Nightly", "Beta"],
+            firefoxMinVersion: "A_83_",
+            targetingConfigSlug: "US_ONLY",
+            populationPercent: 40,
+            totalEnrolledClients: 68000,
+            proposedEnrollment: 15,
+          },
+          modifications,
+        );
 
   return {
     mock: {
@@ -190,6 +196,6 @@ export const mockExperimentQuery = (
         },
       },
     },
-    data: experiment,
+    data: experiment as getExperiment["experimentBySlug"],
   };
 };

--- a/app/experimenter/nimbus-ui/src/lib/test-utils.tsx
+++ b/app/experimenter/nimbus-ui/src/lib/test-utils.tsx
@@ -11,6 +11,8 @@ import {
   Router,
 } from "@reach/router";
 import { render } from "@testing-library/react";
+import { MockedResponse } from "@apollo/client/testing";
+import { MockedCache } from "./mocks";
 
 export function renderWithRouter(
   ui: React.ReactElement,
@@ -23,18 +25,25 @@ export function renderWithRouter(
 }
 
 export const RouterSlugProvider = ({
-  path = "/demoslug/edit",
+  path = "/demo-slug/edit",
+  mocks = [],
   children,
 }: {
   path?: string;
+  mocks?: MockedResponse<Record<string, any>>[];
   children: React.ReactElement;
 }) => {
-  let source = createMemorySource(path);
-  let history = createHistory(source);
+  const source = createMemorySource(path);
+  const history = createHistory(source);
+
   return (
     <LocationProvider {...{ history }}>
       <Router>
-        <Route path=":slug/edit" data-testid="app" component={() => children} />
+        <Route
+          path=":slug/edit"
+          data-testid="app"
+          component={() => <MockedCache {...{ mocks }}>{children}</MockedCache>}
+        />
       </Router>
     </LocationProvider>
   );


### PR DESCRIPTION
This commit:
* Adds HeaderEditExperiment and displays the data on the Branches and Overview pages
* Adds an experiment loading state and not found page
* Tweaks more styles
* Alters the `useExperiment` mock hook
* Adds additional functionality to `RouterSlugProvider` to take in `mocks` for DRYing up purposes

Because:
* We want the name, slug, and experiment status displayed at the top of "Edit" pages, to be edited later.