### PR TITLE
fix #3640 feat(nimbus): add remote settings tasks for nimbus

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -27,6 +27,7 @@ HOSTNAME=localhost
 KINTO_BUCKET_MAIN=main
 KINTO_BUCKET=main-workspace
 KINTO_COLLECTION=messaging-experiments
+KINTO_COLLECTION_NIMBUS=nimbus-desktop-experiments
 KINTO_HOST=http://kinto:8888/v1
 KINTO_PASS=experimenter
 KINTO_USER=experimenter

--- a/app/bin/setup_kinto.py
+++ b/app/bin/setup_kinto.py
@@ -8,13 +8,17 @@ ADMIN_USER = ADMIN_PASS = "admin"
 REVIEW_USER = REVIEW_PASS = "review"
 EXPERIMENTER_USER = os.environ["KINTO_USER"]
 EXPERIMENTER_PASS = os.environ["KINTO_PASS"]
+KINTO_HOST = os.environ["KINTO_HOST"]
+KINTO_BUCKET = os.environ["KINTO_BUCKET"]
+KINTO_COLLECTION_LEGACY = (os.environ["KINTO_COLLECTION"],)
+KINTO_COLLECTION_NIMBUS = os.environ["KINTO_COLLECTION_NIMBUS"]
 
 
 def create_user(user, passw):
     print(f">>>> Creating kinto user: {user}:{passw}")
     print(
         requests.put(
-            urllib.parse.urljoin(os.environ["KINTO_HOST"], f"/accounts/{user}"),
+            urllib.parse.urljoin(KINTO_HOST, f"/accounts/{user}"),
             json={"data": {"password": passw}},
         ).content,
     )
@@ -24,58 +28,51 @@ create_user(ADMIN_USER, ADMIN_PASS)
 create_user(REVIEW_USER, REVIEW_PASS)
 create_user(EXPERIMENTER_USER, EXPERIMENTER_PASS)
 
-client = kinto_http.Client(
-    server_url=os.environ["KINTO_HOST"], auth=(ADMIN_USER, ADMIN_PASS)
-)
+client = kinto_http.Client(server_url=KINTO_HOST, auth=(ADMIN_USER, ADMIN_PASS))
 
-print(f">>>> Creating kinto bucket: {os.environ['KINTO_BUCKET']}")
+print(f">>>> Creating kinto bucket: {KINTO_BUCKET}")
 print(
     client.create_bucket(
-        id=os.environ["KINTO_BUCKET"],
+        id=KINTO_BUCKET,
         permissions={"read": ["system.Everyone"]},
         if_not_exists=True,
     )
 )
 
 
-print(">>>> Creating kinto group: editors")
-print(
-    client.create_group(
-        id=f"{os.environ['KINTO_COLLECTION']}-editors",
-        bucket=os.environ["KINTO_BUCKET"],
-        data={"members": [f"account:{os.environ['KINTO_USER']}"]},
-        if_not_exists=True,
+for collection in [KINTO_COLLECTION_LEGACY, KINTO_COLLECTION_NIMBUS]:
+    print(">>>> Creating kinto group: editors")
+    print(
+        client.create_group(
+            id=f"{collection}-editors",
+            bucket=KINTO_BUCKET,
+            data={"members": [f"account:{EXPERIMENTER_USER}"]},
+            if_not_exists=True,
+        )
     )
-)
 
-print(">>>> Creating kinto group: reviewers")
-print(
-    client.create_group(
-        id=f"{os.environ['KINTO_COLLECTION']}-reviewers",
-        bucket=os.environ["KINTO_BUCKET"],
-        data={"members": [f"account:{REVIEW_USER}"]},
-        if_not_exists=True,
+    print(">>>> Creating kinto group: reviewers")
+    print(
+        client.create_group(
+            id=f"{collection}-reviewers",
+            bucket=KINTO_BUCKET,
+            data={"members": [f"account:{REVIEW_USER}"]},
+            if_not_exists=True,
+        )
     )
-)
 
-print(f">>>> Creating kinto collection: {os.environ['KINTO_COLLECTION']}")
-print(
-    client.create_collection(
-        id=os.environ["KINTO_COLLECTION"],
-        bucket=os.environ["KINTO_BUCKET"],
-        permissions={
-            "read": ["system.Everyone"],
-            "write": [
-                (
-                    f"/buckets/{os.environ['KINTO_BUCKET']}/groups/"
-                    f"{os.environ['KINTO_COLLECTION']}-editors"
-                ),
-                (
-                    f"/buckets/{os.environ['KINTO_BUCKET']}/groups/"
-                    f"{os.environ['KINTO_COLLECTION']}-reviewers"
-                ),
-            ],
-        },
-        if_not_exists=True,
+    print(f">>>> Creating kinto collection: {collection}")
+    print(
+        client.create_collection(
+            id=collection,
+            bucket=KINTO_BUCKET,
+            permissions={
+                "read": ["system.Everyone"],
+                "write": [
+                    (f"/buckets/{KINTO_BUCKET}/groups/" f"{collection}-editors"),
+                    (f"/buckets/{KINTO_BUCKET}/groups/" f"{collection}-reviewers"),
+                ],
+            },
+            if_not_exists=True,
+        )
     )
-)

--- a/app/experimenter/experiments/changelog_utils/nimbus.py
+++ b/app/experimenter/experiments/changelog_utils/nimbus.py
@@ -42,7 +42,7 @@ class NimbusExperimentChangeLogSerializer(serializers.ModelSerializer):
         exclude = ("id",)
 
 
-def generate_nimbus_changelog(experiment, changed_by):
+def generate_nimbus_changelog(experiment, changed_by, message=None):
     latest_change = experiment.latest_change()
     experiment_data = dict(NimbusExperimentChangeLogSerializer(experiment).data)
 
@@ -56,4 +56,5 @@ def generate_nimbus_changelog(experiment, changed_by):
         new_status=experiment.status,
         changed_by=changed_by,
         experiment_data=experiment_data,
+        message=message,
     )

--- a/app/experimenter/experiments/constants/nimbus.py
+++ b/app/experimenter/experiments/constants/nimbus.py
@@ -136,7 +136,7 @@ class NimbusConstants(object):
 
     # Bucket stuff
     BUCKET_TOTAL = 10000
-    BUCKET_AA_COUNT = 100
+    BUCKET_COUNT = 100
     BUCKET_RANDOMIZATION_UNIT = "normandy_id"
 
     HYPOTHESIS_DEFAULT = """If we <do this/build this/create this change in the experiment> for <these users>, then we will see <this outcome>.

--- a/app/experimenter/kinto/tasks/__init__.py
+++ b/app/experimenter/kinto/tasks/__init__.py
@@ -1,0 +1,12 @@
+from experimenter.kinto.tasks.legacy import (  # noqa: F401
+    check_experiment_is_complete,
+    check_experiment_is_live,
+    check_kinto_push_queue,
+    push_experiment_to_kinto,
+)
+from experimenter.kinto.tasks.nimbus import (  # noqa: F401
+    nimbus_check_experiments_are_complete,
+    nimbus_check_experiments_are_live,
+    nimbus_check_kinto_push_queue,
+    nimbus_push_experiment_to_kinto,
+)

--- a/app/experimenter/kinto/tasks/nimbus.py
+++ b/app/experimenter/kinto/tasks/nimbus.py
@@ -1,0 +1,189 @@
+import markus
+from celery.utils.log import get_task_logger
+from django.conf import settings
+from django.contrib.auth import get_user_model
+
+from experimenter.celery import app
+from experimenter.experiments.api.v6.serializers import NimbusExperimentSerializer
+from experimenter.experiments.changelog_utils import generate_nimbus_changelog
+from experimenter.experiments.models import (
+    NimbusBucketRange,
+    NimbusExperiment,
+    NimbusIsolationGroup,
+)
+from experimenter.kinto.client import KintoClient
+
+logger = get_task_logger(__name__)
+metrics = markus.get_metrics("kinto.nimbus_tasks")
+
+
+def get_kinto_user():
+    user, _ = get_user_model().objects.get_or_create(
+        email=settings.KINTO_DEFAULT_CHANGELOG_USER,
+        username=settings.KINTO_DEFAULT_CHANGELOG_USER,
+    )
+    return user
+
+
+@app.task
+@metrics.timer_decorator("push_experiment_to_kinto.timing")
+def nimbus_push_experiment_to_kinto(experiment_id):
+    """
+    An invoked task that given a single experiment id, query it in the db, serialize it,
+    and push its data to the configured collection. If it fails for any reason, log the
+    error and reraise it so it will be forwarded to sentry.
+    """
+    kinto_client = KintoClient(settings.KINTO_COLLECTION_NIMBUS)
+
+    metrics.incr("push_experiment_to_kinto.started")
+
+    try:
+        experiment = NimbusExperiment.objects.get(id=experiment_id)
+        logger.info(f"Pushing {experiment} to Kinto")
+
+        if not NimbusBucketRange.objects.filter(experiment=experiment).exists():
+            NimbusIsolationGroup.request_isolation_group_buckets(
+                experiment.slug,
+                experiment,
+                NimbusExperiment.BUCKET_COUNT,
+            )
+
+        data = NimbusExperimentSerializer(experiment).data
+
+        kinto_client.push_to_kinto(data)
+
+        experiment.status = NimbusExperiment.Status.ACCEPTED
+        experiment.save()
+
+        generate_nimbus_changelog(experiment, get_kinto_user())
+
+        logger.info(f"{experiment} pushed to Kinto")
+        metrics.incr("push_experiment_to_kinto.completed")
+    except Exception as e:
+        metrics.incr("push_experiment_to_kinto.failed")
+        logger.info(f"Pushing experiment id {experiment_id} to Kinto failed: {e}")
+        raise e
+
+
+@app.task
+@metrics.timer_decorator("check_kinto_push_queue")
+def nimbus_check_kinto_push_queue():
+    """
+    Because kinto has a restriction that it can only have a single pending review, this
+    task brokers the queue of all experiments ready to be pushed to kinto and ensures
+    that only a single experiment is ever in review.
+
+    A scheduled task that
+    - Checks the kinto collection for a single rejected experiment from a previous push
+      - If one exists, pull it out of the collection and mark it as rejected
+    - Checks if there is still a pending review and if so, aborts
+    - Gets the list of all experiments ready to be pushed to kinto and pushes the first
+      one
+    """
+    kinto_client = KintoClient(settings.KINTO_COLLECTION_NIMBUS)
+
+    metrics.incr("check_kinto_push_queue.started")
+
+    rejected_collection_data = kinto_client.get_rejected_collection_data()
+    if rejected_collection_data:
+        rejected_slug = kinto_client.get_rejected_record()
+        experiment = NimbusExperiment.objects.get(slug=rejected_slug)
+        experiment.status = NimbusExperiment.Status.DRAFT
+        experiment.save()
+
+        generate_nimbus_changelog(
+            experiment,
+            get_kinto_user(),
+            message=f'Rejected: {rejected_collection_data["last_reviewer_comment"]}',
+        )
+
+        kinto_client.delete_rejected_record(rejected_slug)
+
+    if kinto_client.has_pending_review():
+        metrics.incr("check_kinto_push_queue.pending_review")
+        return
+
+    queued_experiments = NimbusExperiment.objects.filter(
+        status=NimbusExperiment.Status.REVIEW
+    )
+    if queued_experiments.exists():
+        nimbus_push_experiment_to_kinto.delay(queued_experiments.first().id)
+        metrics.incr("check_kinto_push_queue.queued_experiment_selected")
+    else:
+        metrics.incr("check_kinto_push_queue.no_experiments_queued")
+
+    metrics.incr("check_kinto_push_queue.completed")
+
+
+@app.task
+@metrics.timer_decorator("check_experiments_are_live")
+def nimbus_check_experiments_are_live():
+    """
+    A scheduled task that checks the kinto collection for any experiment slugs that are
+    present in the collection but are not yet marked as live in the database and marks
+    them as live.
+    """
+    kinto_client = KintoClient(settings.KINTO_COLLECTION_NIMBUS)
+
+    metrics.incr("check_experiments_are_live.started")
+
+    accepted_experiments = NimbusExperiment.objects.filter(
+        status=NimbusExperiment.Status.ACCEPTED
+    )
+
+    records = kinto_client.get_main_records()
+    record_ids = [r.get("id") for r in records]
+
+    for experiment in accepted_experiments:
+        if experiment.slug in record_ids:
+            logger.info(
+                "{experiment} status is being updated to live".format(
+                    experiment=experiment
+                )
+            )
+
+            experiment.status = NimbusExperiment.Status.LIVE
+            experiment.save()
+
+            generate_nimbus_changelog(experiment, get_kinto_user())
+
+            logger.info("{experiment} status is set to Live")
+
+    metrics.incr("check_experiments_are_live.completed")
+
+
+@app.task
+@metrics.timer_decorator("check_experiments_are_complete")
+def nimbus_check_experiments_are_complete():
+    """
+    A scheduled task that checks the kinto collection for any experiment slugs that are
+    marked as live in the database but missing from the collection, indicating that they
+    are no longer live and can be marked as complete.
+    """
+    kinto_client = KintoClient(settings.KINTO_COLLECTION_NIMBUS)
+
+    metrics.incr("check_experiments_are_complete.started")
+
+    live_experiments = NimbusExperiment.objects.filter(
+        status=NimbusExperiment.Status.LIVE
+    )
+
+    records = kinto_client.get_main_records()
+    record_ids = [r.get("id") for r in records]
+
+    for experiment in live_experiments:
+        if experiment.slug not in record_ids:
+            logger.info(
+                "{experiment} status is being updated to complete".format(
+                    experiment=experiment
+                )
+            )
+
+            experiment.status = NimbusExperiment.Status.COMPLETE
+            experiment.save()
+
+            generate_nimbus_changelog(experiment, get_kinto_user())
+
+            logger.info("{experiment} status is set to Complete")
+
+    metrics.incr("check_experiments_are_complete.completed")

--- a/app/experimenter/kinto/tests/mixins.py
+++ b/app/experimenter/kinto/tests/mixins.py
@@ -33,16 +33,5 @@ class MockKintoClientMixin(object):
             }
         }
 
-    def setup_kinto_get_main_records(self):
-        self.mock_kinto_client.get_records.return_value = [
-            {"id": "bug-12345-rapid-test-release-55"}
-        ]
-
-    def setup_kinto_get_workspace_records(self):
-        self.mock_kinto_client.get_records.return_value = [
-            {"id": "bug-12345-rapid-test-release-55"},
-            {"id": "bug-99999-rapid-test-release-55"},
-        ]
-
-    def setup_kinto_no_main_records(self):
-        self.mock_kinto_client.get_records.return_value = []
+    def setup_kinto_get_main_records(self, slugs):
+        self.mock_kinto_client.get_records.return_value = [{"id": slug} for slug in slugs]

--- a/app/experimenter/kinto/tests/test_client.py
+++ b/app/experimenter/kinto/tests/test_client.py
@@ -1,13 +1,17 @@
 from django.conf import settings
 from django.test import TestCase
 
-from experimenter.kinto import client
+from experimenter.kinto.client import KintoClient
 from experimenter.kinto.tests.mixins import MockKintoClientMixin
 
 
-class TestPushToKinto(MockKintoClientMixin, TestCase):
+class TestKintoClient(MockKintoClientMixin, TestCase):
+    def setUp(self):
+        super().setUp()
+        self.client = KintoClient(settings.KINTO_COLLECTION)
+
     def test_push_to_kinto_sends_data_updates_collection(self):
-        client.push_to_kinto({"test": "data"})
+        self.client.push_to_kinto({"test": "data"})
 
         self.mock_kinto_client_creator.assert_called_with(
             server_url=settings.KINTO_HOST,
@@ -27,38 +31,31 @@ class TestPushToKinto(MockKintoClientMixin, TestCase):
             bucket=settings.KINTO_BUCKET,
         )
 
-
-class TestHasPendingReview(MockKintoClientMixin, TestCase):
     def test_returns_true_for_pending_review(self):
         self.setup_kinto_pending_review()
-        self.assertTrue(client.has_pending_review())
+        self.assertTrue(self.client.has_pending_review())
 
     def test_returns_false_for_no_pending_review(self):
         self.setup_kinto_no_pending_review()
-        self.assertFalse(client.has_pending_review())
+        self.assertFalse(self.client.has_pending_review())
 
-
-class TestGetMainRecords(MockKintoClientMixin, TestCase):
     def test_returns_records(self):
-        self.setup_kinto_get_main_records()
-        self.assertEqual(len(client.get_main_records()), 1)
+        slug = "test-slug"
+        self.setup_kinto_get_main_records([slug])
+        self.assertEqual(self.client.get_main_records(), [{"id": slug}])
 
     def test_returns_no_records(self):
-        self.setup_kinto_no_main_records()
-        self.assertEqual(client.get_main_records(), [])
+        self.setup_kinto_get_main_records([])
+        self.assertEqual(self.client.get_main_records(), [])
 
-
-class TestGetRejectedCollectionData(MockKintoClientMixin, TestCase):
     def test_returns_nothing_when_not_rejects(self):
         self.setup_kinto_no_pending_review()
-        self.assertIsNone(client.get_rejected_collection_data())
+        self.assertIsNone(self.client.get_rejected_collection_data())
 
     def test_returns_rejected_data(self):
         self.setup_kinto_rejected_review()
-        self.assertTrue(client.get_rejected_collection_data())
+        self.assertTrue(self.client.get_rejected_collection_data())
 
-
-class TestGetRejectedRecords(MockKintoClientMixin, TestCase):
     def test_returns_rejected_record(self):
         self.mock_kinto_client.get_records.side_effect = [
             [{"id": "bug-12345-rapid-test-release-55"}],
@@ -67,4 +64,6 @@ class TestGetRejectedRecords(MockKintoClientMixin, TestCase):
                 {"id": "bug-9999-rapid-test-release-55"},
             ],
         ]
-        self.assertEqual(client.get_rejected_record(), ["bug-9999-rapid-test-release-55"])
+        self.assertEqual(
+            self.client.get_rejected_record(), "bug-9999-rapid-test-release-55"
+        )

--- a/app/experimenter/kinto/tests/test_tasks/test_tasks_legacy.py
+++ b/app/experimenter/kinto/tests/test_tasks/test_tasks_legacy.py
@@ -208,6 +208,7 @@ class TestCheckExperimentIsLive(MockKintoClientMixin, TestCase):
             firefox_max_version=None,
             firefox_min_version=Experiment.VERSION_CHOICES[0][0],
             name="test",
+            recipe_slug="experiment-1",
             type=Experiment.TYPE_RAPID,
         )
 
@@ -218,6 +219,7 @@ class TestCheckExperimentIsLive(MockKintoClientMixin, TestCase):
             firefox_max_version=None,
             firefox_min_version=Experiment.VERSION_CHOICES[0][0],
             name="test1",
+            recipe_slug="experiment-2",
             type=Experiment.TYPE_RAPID,
         )
 
@@ -228,6 +230,7 @@ class TestCheckExperimentIsLive(MockKintoClientMixin, TestCase):
             firefox_max_version=None,
             firefox_min_version=Experiment.VERSION_CHOICES[0][0],
             name="test2",
+            recipe_slug="experiment-3",
             type=Experiment.TYPE_RAPID,
         )
 
@@ -235,7 +238,7 @@ class TestCheckExperimentIsLive(MockKintoClientMixin, TestCase):
         self.assertEqual(experiment2.changes.count(), 4)
         self.assertEqual(experiment3.changes.count(), 1)
 
-        self.setup_kinto_get_main_records()
+        self.setup_kinto_get_main_records([experiment1.recipe_slug])
         tasks.check_experiment_is_live()
 
         self.assertEqual(experiment3.changes.count(), 1)
@@ -293,7 +296,7 @@ class TestCheckExperimentIsComplete(MockKintoClientMixin, TestCase):
         self.assertEqual(experiment2.changes.count(), 5)
         self.assertEqual(experiment3.changes.count(), 1)
 
-        self.setup_kinto_get_main_records()
+        self.setup_kinto_get_main_records([experiment1.recipe_slug])
         tasks.check_experiment_is_complete()
 
         self.assertEqual(experiment3.changes.count(), 1)

--- a/app/experimenter/kinto/tests/test_tasks/test_tasks_nimbus.py
+++ b/app/experimenter/kinto/tests/test_tasks/test_tasks_nimbus.py
@@ -1,0 +1,215 @@
+import mock
+from django.conf import settings
+from django.test import TestCase
+
+from experimenter.experiments.api.v6.serializers import NimbusExperimentSerializer
+from experimenter.experiments.models import (
+    NimbusBucketRange,
+    NimbusChangeLog,
+    NimbusExperiment,
+)
+from experimenter.experiments.tests.factories import NimbusExperimentFactory
+from experimenter.kinto import tasks
+from experimenter.kinto.client import KINTO_REJECTED_STATUS
+from experimenter.kinto.tests.mixins import MockKintoClientMixin
+
+
+class TestPushExperimentToKintoTask(MockKintoClientMixin, TestCase):
+    def setUp(self):
+        super().setUp()
+        self.experiment = NimbusExperimentFactory.create_with_status(
+            NimbusExperiment.Status.DRAFT,
+        )
+
+    def test_push_experiment_to_kinto_sends_experiment_data(self):
+        tasks.nimbus_push_experiment_to_kinto(self.experiment.id)
+
+        data = NimbusExperimentSerializer(self.experiment).data
+
+        self.assertTrue(
+            NimbusBucketRange.objects.filter(experiment=self.experiment).exists()
+        )
+
+        self.mock_kinto_client.create_record.assert_called_with(
+            data=data,
+            collection=settings.KINTO_COLLECTION_NIMBUS,
+            bucket=settings.KINTO_BUCKET,
+            if_not_exists=True,
+        )
+
+        self.assertTrue(
+            NimbusChangeLog.objects.filter(
+                experiment=self.experiment,
+                changed_by__email=settings.KINTO_DEFAULT_CHANGELOG_USER,
+                old_status=NimbusExperiment.Status.DRAFT,
+                new_status=NimbusExperiment.Status.ACCEPTED,
+            ).exists()
+        )
+
+    def test_push_experiment_to_kinto_reraises_exception(self):
+        self.mock_kinto_client.create_record.side_effect = Exception
+
+        with self.assertRaises(Exception):
+            tasks.nimbus_push_experiment_to_kinto(self.experiment.id)
+
+
+class TestCheckKintoPushQueue(MockKintoClientMixin, TestCase):
+    def setUp(self):
+        super().setUp()
+        mock_push_task_patcher = mock.patch(
+            "experimenter.kinto.tasks.nimbus_push_experiment_to_kinto.delay"
+        )
+        self.mock_push_task = mock_push_task_patcher.start()
+        self.addCleanup(mock_push_task_patcher.stop)
+
+    def test_check_with_empty_queue_pushes_nothing(self):
+        self.setup_kinto_no_pending_review()
+        tasks.nimbus_check_kinto_push_queue()
+        self.mock_push_task.assert_not_called()
+
+    def test_check_experiment_with_no_review_status_pushes_nothing(self):
+        for status in [
+            NimbusExperiment.Status.DRAFT,
+            NimbusExperiment.Status.ACCEPTED,
+            NimbusExperiment.Status.LIVE,
+            NimbusExperiment.Status.COMPLETE,
+        ]:
+            NimbusExperimentFactory.create(status=status)
+
+        self.setup_kinto_no_pending_review()
+        tasks.nimbus_check_kinto_push_queue()
+        self.mock_push_task.assert_not_called()
+
+    def test_check_experiment_with_review_and_kinto_pending_pushes_nothing(self):
+        NimbusExperimentFactory.create(
+            status=NimbusExperiment.Status.REVIEW,
+        )
+        self.setup_kinto_pending_review()
+        tasks.nimbus_check_kinto_push_queue()
+        self.mock_push_task.assert_not_called()
+
+    def test_checkexperiment_with_review_and_no_kinto_pending_pushes_experiment(
+        self,
+    ):
+        experiment = NimbusExperimentFactory.create_with_status(
+            NimbusExperiment.Status.REVIEW
+        )
+        self.assertEqual(experiment.changes.count(), 2)
+
+        self.setup_kinto_no_pending_review()
+        tasks.nimbus_check_kinto_push_queue()
+        self.mock_push_task.assert_called_with(experiment.id)
+
+    def test_check_with_reject_review(self):
+        experiment = NimbusExperimentFactory.create_with_status(
+            NimbusExperiment.Status.ACCEPTED,
+        )
+
+        self.mock_kinto_client.delete_record.return_value = {}
+        self.mock_kinto_client.get_collection.side_effect = [
+            {
+                "data": {
+                    "status": KINTO_REJECTED_STATUS,
+                    "last_reviewer_comment": "it's no good",
+                }
+            },
+            {"data": {"status": "anything"}},
+        ]
+        self.mock_kinto_client.get_records.side_effect = [
+            [{"id": "another-experiment"}],
+            [
+                {"id": "another-experiment"},
+                {"id": experiment.slug},
+            ],
+        ]
+        tasks.nimbus_check_kinto_push_queue()
+
+        self.mock_kinto_client.delete_record.assert_called()
+
+        self.assertTrue(
+            experiment.changes.filter(
+                changed_by__email=settings.KINTO_DEFAULT_CHANGELOG_USER,
+                old_status=NimbusExperiment.Status.ACCEPTED,
+                new_status=NimbusExperiment.Status.DRAFT,
+            ).exists()
+        )
+
+
+class TestCheckExperimentIsLive(MockKintoClientMixin, TestCase):
+    def test_experiment_updates_when_record_is_in_main(self):
+        experiment1 = NimbusExperimentFactory.create_with_status(
+            NimbusExperiment.Status.ACCEPTED,
+        )
+
+        experiment2 = NimbusExperimentFactory.create_with_status(
+            NimbusExperiment.Status.ACCEPTED,
+        )
+
+        experiment3 = NimbusExperimentFactory.create_with_status(
+            NimbusExperiment.Status.DRAFT,
+        )
+
+        self.assertEqual(experiment1.changes.count(), 3)
+        self.assertEqual(experiment2.changes.count(), 3)
+        self.assertEqual(experiment3.changes.count(), 1)
+
+        self.setup_kinto_get_main_records([experiment1.slug])
+        tasks.nimbus_check_experiments_are_live()
+
+        self.assertEqual(experiment3.changes.count(), 1)
+
+        self.assertTrue(
+            experiment1.changes.filter(
+                changed_by__email=settings.KINTO_DEFAULT_CHANGELOG_USER,
+                old_status=NimbusExperiment.Status.ACCEPTED,
+                new_status=NimbusExperiment.Status.LIVE,
+            ).exists()
+        )
+
+        self.assertFalse(
+            experiment2.changes.filter(
+                changed_by__email=settings.KINTO_DEFAULT_CHANGELOG_USER,
+                old_status=NimbusExperiment.Status.ACCEPTED,
+                new_status=NimbusExperiment.Status.LIVE,
+            ).exists()
+        )
+
+
+class TestCheckExperimentIsComplete(MockKintoClientMixin, TestCase):
+    def test_experiment_updates_when_record_is_not_in_main(self):
+        experiment1 = NimbusExperimentFactory.create_with_status(
+            NimbusExperiment.Status.LIVE,
+        )
+
+        experiment2 = NimbusExperimentFactory.create_with_status(
+            NimbusExperiment.Status.LIVE,
+        )
+
+        experiment3 = NimbusExperimentFactory.create_with_status(
+            NimbusExperiment.Status.DRAFT,
+        )
+
+        self.assertEqual(experiment1.changes.count(), 4)
+        self.assertEqual(experiment2.changes.count(), 4)
+        self.assertEqual(experiment3.changes.count(), 1)
+
+        self.setup_kinto_get_main_records([experiment1.slug])
+        tasks.nimbus_check_experiments_are_complete()
+
+        self.assertEqual(experiment3.changes.count(), 1)
+
+        self.assertFalse(
+            experiment1.changes.filter(
+                changed_by__email=settings.KINTO_DEFAULT_CHANGELOG_USER,
+                old_status=NimbusExperiment.Status.LIVE,
+                new_status=NimbusExperiment.Status.COMPLETE,
+            ).exists()
+        )
+
+        self.assertTrue(
+            experiment2.changes.filter(
+                changed_by__email=settings.KINTO_DEFAULT_CHANGELOG_USER,
+                old_status=NimbusExperiment.Status.LIVE,
+                new_status=NimbusExperiment.Status.COMPLETE,
+            ).exists()
+        )

--- a/app/experimenter/settings.py
+++ b/app/experimenter/settings.py
@@ -320,15 +320,27 @@ CELERY_BEAT_SCHEDULE = {
         "schedule": config("CELERY_SCHEDULE_INTERVAL", default=300, cast=int),
     },
     "check_kinto_push_queue_task": {
-        "task": "experimenter.kinto.tasks.check_kinto_push_queue",
+        "task": "experimenter.kinto.tasks.legacy.check_kinto_push_queue",
         "schedule": config("CELERY_SCHEDULE_INTERVAL", default=300, cast=int),
     },
     "check_experiment_is_live": {
-        "task": "experimenter.kinto.tasks.check_experiment_is_live",
+        "task": "experimenter.kinto.tasks.legacy.check_experiment_is_live",
         "schedule": config("CELERY_SCHEDULE_INTERVAL", default=300, cast=int),
     },
     "check_experiment_is_complete": {
-        "task": "experimenter.kinto.tasks.check_experiment_is_complete",
+        "task": "experimenter.kinto.tasks.legacy.check_experiment_is_complete",
+        "schedule": config("CELERY_SCHEDULE_INTERVAL", default=300, cast=int),
+    },
+    "nimbus_check_kinto_push_queue_task": {
+        "task": "experimenter.kinto.tasks.nimbus.nimbus_check_kinto_push_queue",
+        "schedule": config("CELERY_SCHEDULE_INTERVAL", default=300, cast=int),
+    },
+    "nimbus_check_experiments_are_live": {
+        "task": "experimenter.kinto.tasks.nimbus.nimbus_check_experiments_are_live",
+        "schedule": config("CELERY_SCHEDULE_INTERVAL", default=300, cast=int),
+    },
+    "nimbus_check_experiments_are_complete": {
+        "task": "experimenter.kinto.tasks.nimbus.nimbus_check_experiments_are_complete",
         "schedule": config("CELERY_SCHEDULE_INTERVAL", default=300, cast=int),
     },
 }
@@ -397,6 +409,7 @@ KINTO_PASS = config("KINTO_PASS")
 KINTO_BUCKET = config("KINTO_BUCKET")
 KINTO_BUCKET_MAIN = config("KINTO_BUCKET_MAIN")
 KINTO_COLLECTION = config("KINTO_COLLECTION")
+KINTO_COLLECTION_NIMBUS = config("KINTO_COLLECTION_NIMBUS")
 
 
 # Jetstream GCS Bucket data


### PR DESCRIPTION
Because

* We need to send and receive nimbus experiments from a specific remote settings collection

This commit

* Adds tasks to push and read nimbus experiments from the nimbus specific collection
  - Push to collection and mark for review with a changelog
  - Read rejected experiments and mark them as draft with a changelog
  - Check for reviewed experiments that have been accepted and mark them live with a changelog
  - Check for removed experiments and mark them completed with a changelog