### PR TITLE
fix #3831 chore(nimbus): ensure slug is read only in v5 API

### DIFF
--- a/app/experimenter/experiments/api/v5/inputs.py
+++ b/app/experimenter/experiments/api/v5/inputs.py
@@ -11,7 +11,6 @@ from experimenter.experiments.api.v5.types import (
 class ExperimentInput(graphene.InputObjectType):
     client_mutation_id = graphene.String()
     name = graphene.String()
-    slug = graphene.String()
     application = graphene.String()
     public_description = graphene.String()
     hypothesis = graphene.String()

--- a/app/experimenter/experiments/api/v5/mutation.py
+++ b/app/experimenter/experiments/api/v5/mutation.py
@@ -72,7 +72,7 @@ class CreateExperiment(graphene.Mutation):
         return handle_with_serializer(cls, serializer, input.client_mutation_id)
 
 
-class UpdateExperiment(graphene.Mutation):
+class UpdateExperimentOverview(graphene.Mutation):
     client_mutation_id = graphene.String()
     nimbus_experiment = graphene.Field(NimbusExperimentType)
     message = ObjectField()
@@ -173,7 +173,9 @@ class Mutation(graphene.ObjectType):
     create_experiment = CreateExperiment.Field(
         description="Create a new Nimbus Experiment."
     )
-    update_experiment = UpdateExperiment.Field(description="Update a Nimbus Experiment.")
+    update_experiment_overview = UpdateExperimentOverview.Field(
+        description="Update a Nimbus Experiment."
+    )
 
     update_experiment_branches = UpdateExperimentBranches.Field(
         description="Updates branches on a Nimbus Experiment."

--- a/app/experimenter/experiments/tests/api/v5/test_mutation.py
+++ b/app/experimenter/experiments/tests/api/v5/test_mutation.py
@@ -30,7 +30,7 @@ mutation($input: CreateExperimentInput!) {
 
 UPDATE_EXPERIMENT_MUTATION = """\
 mutation($input: UpdateExperimentInput!) {
-    updateExperiment(input: $input) {
+    updateExperimentOverview(input: $input) {
         nimbusExperiment {
             id
             status
@@ -187,7 +187,7 @@ class TestMutations(GraphQLTestCase):
         )
         self.assertEqual(result["status"], 200)
 
-    def test_update_experiment(self):
+    def test_update_experiment_overview(self):
         user_email = "user@example.com"
         experiment = NimbusExperimentFactory.create(status=NimbusExperiment.Status.DRAFT)
         response = self.query(
@@ -204,7 +204,7 @@ class TestMutations(GraphQLTestCase):
         )
         self.assertEqual(response.status_code, 200)
         content = json.loads(response.content)
-        result = content["data"]["updateExperiment"]
+        result = content["data"]["updateExperimentOverview"]
         experiment_result = result["nimbusExperiment"]
         self.assertEqual(
             experiment_result,
@@ -240,7 +240,7 @@ class TestMutations(GraphQLTestCase):
         )
         self.assertEqual(response.status_code, 200)
         content = json.loads(response.content)
-        result = content["data"]["updateExperiment"]
+        result = content["data"]["updateExperimentOverview"]
         self.assertEqual(result["nimbusExperiment"], None)
 
         self.assertEqual(result["clientMutationId"], "randomid")

--- a/app/experimenter/experiments/tests/api/v5/test_serializers.py
+++ b/app/experimenter/experiments/tests/api/v5/test_serializers.py
@@ -107,7 +107,6 @@ class TestCreateNimbusExperimentOverviewSerializer(TestCase):
             "hypothesis": "It does the thing",
             "name": "The Thing",
             "public_description": "Does it do the thing?",
-            "slug": "the_thing",
         }
 
         serializer = NimbusExperimentOverviewSerializer(
@@ -118,19 +117,27 @@ class TestCreateNimbusExperimentOverviewSerializer(TestCase):
 
         experiment = serializer.save()
         self.assertEqual(experiment.changes.count(), 1)
+        self.assertEqual(experiment.application, NimbusExperiment.Application.DESKTOP)
+        self.assertEqual(experiment.hypothesis, "It does the thing")
+        self.assertEqual(experiment.name, "The Thing")
+        self.assertEqual(experiment.slug, "the-thing")
 
     def test_saves_existing_experiment_with_changelog(self):
         experiment = NimbusExperimentFactory.create_with_status(
-            NimbusExperiment.Status.DRAFT
+            NimbusExperiment.Status.DRAFT,
+            application=NimbusExperiment.Application.FENIX,
+            hypothesis="Existing hypothesis",
+            name="Existing Name",
+            slug="existing-name",
+            public_description="Existing public description",
         )
         self.assertEqual(experiment.changes.count(), 1)
 
         data = {
             "application": NimbusExperiment.Application.DESKTOP,
-            "hypothesis": "It does the thing",
-            "name": "The Thing",
-            "public_description": "Does it do the thing?",
-            "slug": "the_thing",
+            "hypothesis": "New Hypothesis",
+            "name": "New Name",
+            "public_description": "New public description",
         }
 
         serializer = NimbusExperimentOverviewSerializer(
@@ -141,6 +148,11 @@ class TestCreateNimbusExperimentOverviewSerializer(TestCase):
 
         experiment = serializer.save()
         self.assertEqual(experiment.changes.count(), 2)
+        self.assertEqual(experiment.application, NimbusExperiment.Application.DESKTOP)
+        self.assertEqual(experiment.hypothesis, "New Hypothesis")
+        self.assertEqual(experiment.name, "New Name")
+        self.assertEqual(experiment.slug, "existing-name")
+        self.assertEqual(experiment.public_description, "New public description")
 
 
 class TestNimbusBranchSerializer(TestCase):


### PR DESCRIPTION
Because

* The slug should be auto generated by the server only once at create time

This commit

* Removes slug as an input in the V5 GQL API
* Updates tests to ensure slug is not updated after creation time
* Renames updateExperiment to updateExperimentOverview to make it clearer which form it pertains to