### PR TITLE
fixes #3808 chore(nimbus): Require 100% test line coverage, add test to meet threshold

### DIFF
--- a/app/experimenter/nimbus-ui/package.json
+++ b/app/experimenter/nimbus-ui/package.json
@@ -18,8 +18,16 @@
   },
   "jest": {
     "collectCoverageFrom": [
-      "!src/**/*.stories.*"
-    ]
+      "src/**/*",
+      "!src/**/*.stories.*",
+      "!src/lib/mocks.tsx",
+      "!src/lib/test-utils.tsx"
+    ],
+    "coverageThreshold": {
+      "global": {
+        "lines": 100
+      }
+    }
   },
   "dependencies": {
     "@apollo/client": "^3.2.2",

--- a/app/experimenter/nimbus-ui/package.json
+++ b/app/experimenter/nimbus-ui/package.json
@@ -20,8 +20,7 @@
     "collectCoverageFrom": [
       "src/**/*",
       "!src/**/*.stories.*",
-      "!src/lib/mocks.tsx",
-      "!src/lib/test-utils.tsx"
+      "!src/lib/{mocks,test-utils}.tsx"
     ],
     "coverageThreshold": {
       "global": {

--- a/app/experimenter/nimbus-ui/src/hooks/useExitWarning.test.tsx
+++ b/app/experimenter/nimbus-ui/src/hooks/useExitWarning.test.tsx
@@ -53,6 +53,19 @@ describe("hooks/useExitWarning", () => {
       );
     });
 
+    it("doesn't warn by default when you leave the page when an init value is not passed in", () => {
+      const TestExitWarningDefaultInit = () => {
+        shouldWarnFn = useExitWarning();
+        return <p>Danbury, CT</p>;
+      };
+
+      render(<TestExitWarningDefaultInit />);
+      expect(addListener).not.toHaveBeenCalledWith(
+        "beforeunload",
+        expect.any(Function),
+      );
+    });
+
     it("doesn't warn when you tell it not to when you leave the page", async () => {
       render(<TestExitWarning shouldWarn={true} />);
       expect(addListener).toHaveBeenCalledWith(


### PR DESCRIPTION
This commit:
* Requires 100% global test threshold in jest unit tests for nimbus-ui
* Adds one test to meet coverage

Because:
* We need a global threshold set and 100% line coverage was agreed upon