### PR TITLE
fix #3632 feat(nimbus): add GQL query for config

### DIFF
--- a/app/experimenter/experiments/api/v5/types.py
+++ b/app/experimenter/experiments/api/v5/types.py
@@ -81,3 +81,8 @@ class NimbusProbeType(DjangoObjectType):
 class NimbusProbeSetType(DjangoObjectType):
     class Meta:
         model = NimbusProbeSet
+
+
+class NimbusLabelValueType(graphene.ObjectType):
+    label = graphene.String()
+    value = graphene.String()

--- a/app/experimenter/experiments/tests/api/v5/test_query.py
+++ b/app/experimenter/experiments/tests/api/v5/test_query.py
@@ -7,9 +7,13 @@ from graphene_django.utils.testing import GraphQLTestCase
 
 from experimenter.experiments.models.nimbus import NimbusExperiment
 from experimenter.experiments.tests.factories import NimbusExperimentFactory
+from experimenter.experiments.tests.factories.nimbus import (
+    NimbusFeatureConfigFactory,
+    NimbusProbeSetFactory,
+)
 
 
-class TestExperimentListView(GraphQLTestCase):
+class TestNimbusQuery(GraphQLTestCase):
     GRAPHQL_URL = reverse("nimbus-api-graphql")
 
     def test_experiments(self):
@@ -107,3 +111,79 @@ class TestExperimentListView(GraphQLTestCase):
         content = json.loads(response.content)
         experiment = content["data"]["experimentBySlug"]
         self.assertIsNone(experiment)
+
+    def test_nimbus_config(self):
+        user_email = "user@example.com"
+        # Create some probes and feature configs
+        feature_configs = NimbusFeatureConfigFactory.create_batch(10)
+        probe_sets = NimbusProbeSetFactory.create_batch(10)
+
+        response = self.query(
+            """
+            query{
+                nimbusConfig{
+                    application {
+                        label
+                        value
+                    }
+                    channels {
+                        label
+                        value
+                    }
+                    firefoxMinVersion {
+                        label
+                        value
+                    }
+                    featureConfig {
+                        name
+                        slug
+                        id
+                        description
+                    }
+                    probeSets {
+                        id
+                        name
+                    }
+                    targetingConfigSlug {
+                        label
+                        value
+                    }
+                }
+            }
+            """,
+            headers={settings.OPENIDC_EMAIL_HEADER: user_email},
+        )
+        self.assertEqual(response.status_code, 200)
+        content = json.loads(response.content)
+        config = content["data"]["nimbusConfig"]
+
+        def assertChoices(data, text_choices):
+            self.assertEqual(len(data), len(text_choices.names))
+            for index, name in enumerate(text_choices.names):
+                self.assertEqual(data[index]["label"], text_choices[name].label)
+                self.assertEqual(data[index]["value"], name)
+
+        assertChoices(config["application"], NimbusExperiment.Application)
+        assertChoices(config["channels"], NimbusExperiment.Channel)
+        assertChoices(config["firefoxMinVersion"], NimbusExperiment.Version)
+        assertChoices(config["targetingConfigSlug"], NimbusExperiment.TargetingConfig)
+        self.assertEqual(len(config["featureConfig"]), 10)
+        self.assertEqual(len(config["probeSets"]), 10)
+        for probe_set in probe_sets:
+            config_probe_set = next(
+                filter(lambda p: p["id"] == str(probe_set.id), config["probeSets"])
+            )
+            self.assertEqual(config_probe_set["id"], str(probe_set.id))
+            self.assertEqual(config_probe_set["name"], probe_set.name)
+        for feature_config in feature_configs:
+            config_feature_config = next(
+                filter(
+                    lambda f: f["id"] == str(feature_config.id), config["featureConfig"]
+                )
+            )
+            self.assertEqual(config_feature_config["id"], str(feature_config.id))
+            self.assertEqual(config_feature_config["name"], feature_config.name)
+            self.assertEqual(config_feature_config["slug"], feature_config.slug)
+            self.assertEqual(
+                config_feature_config["description"], feature_config.description
+            )


### PR DESCRIPTION
Because:

* We want the front-end to get human readable labels for enums and
  load select options that are dynamic from the back-end database.

This commit:

* Add's a GraphQL query that returns the nimbus application
  configuration values the front-end should use.