### PR TITLE
fixes #3697 feat(nimbus): send overview mutation when form submitted

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/FormOverview/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/FormOverview/index.stories.tsx
@@ -4,35 +4,29 @@
 
 import React from "react";
 import { storiesOf } from "@storybook/react";
+import { Subject } from "./mocks";
 import { action } from "@storybook/addon-actions";
-import FormOverview from ".";
+import { mockExperimentQuery } from "../../lib/mocks";
 
-const APPLICATIONS = ["firefox-desktop", "fenix", "reference-browser"];
+const onSubmit = action("onSubmit");
+const onCancel = action("onCancel");
+const onNext = action("onNext");
 
 storiesOf("components/FormOverview", module)
-  .add("basic", () => <Subject />)
-  .add("loading", () => <Subject isLoading />)
+  .add("basic", () => <Subject {...{ onSubmit, onCancel }} />)
+  .add("loading", () => <Subject isLoading {...{ onSubmit, onCancel }} />)
   .add("errors", () => (
     <Subject
       submitErrors={{
-        "*": "Big bad server thing broke!",
-        name: "This name is terrible.",
-        hypothesis: "You call this a hypothesis?",
-        application: "That's a potato.",
+        "*": ["Big bad server thing broke!"],
+        name: ["This name is terrible."],
+        hypothesis: ["You call this a hypothesis?"],
+        application: ["That's a potato."],
       }}
+      {...{ onSubmit, onCancel }}
     />
-  ));
-
-const Subject = ({
-  isLoading = false,
-  submitErrors = {},
-  onSubmit = action("onSubmit"),
-  onCancel = action("onCancel"),
-  applications = APPLICATIONS,
-} = {}) => (
-  <div className="p-5">
-    <FormOverview
-      {...{ isLoading, submitErrors, onSubmit, onCancel, applications }}
-    />
-  </div>
-);
+  ))
+  .add("with experiment", () => {
+    const { data: experiment } = mockExperimentQuery("boo");
+    return <Subject {...{ experiment, onSubmit, onNext }} />;
+  });

--- a/app/experimenter/nimbus-ui/src/components/FormOverview/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/components/FormOverview/mocks.tsx
@@ -1,0 +1,29 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from "react";
+import FormOverview from ".";
+import { MockedCache } from "../../lib/mocks";
+
+export const Subject = ({
+  isLoading = false,
+  submitErrors = {},
+  onSubmit = () => {},
+  onCancel,
+  onNext,
+  experiment,
+}: Partial<React.ComponentProps<typeof FormOverview>>) => (
+  <MockedCache>
+    <FormOverview
+      {...{
+        isLoading,
+        submitErrors,
+        onSubmit,
+        onCancel,
+        onNext,
+        experiment,
+      }}
+    />
+  </MockedCache>
+);

--- a/app/experimenter/nimbus-ui/src/components/PageEditOverview/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditOverview/index.tsx
@@ -2,43 +2,85 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React, { useCallback, useState } from "react";
-import { RouteComponentProps } from "@reach/router";
+import React, { useCallback, useRef, useState } from "react";
+import { navigate, RouteComponentProps } from "@reach/router";
 import FormOverview from "../FormOverview";
 import PageEditContainer from "../PageEditContainer";
+import { useMutation } from "@apollo/client";
+import { UPDATE_EXPERIMENT_OVERVIEW_MUTATION } from "../../gql/experiments";
+import { SUBMIT_ERROR } from "../../lib/constants";
+import { UpdateExperimentInput } from "../../types/globalTypes";
+import { updateExperimentOverview_updateExperimentOverview as UpdateExperimentOverviewResult } from "../../types/updateExperimentOverview";
+import { getExperiment_experimentBySlug } from "../../types/getExperiment";
 
 type PageEditOverviewProps = {} & RouteComponentProps;
 
 const PageEditOverview: React.FunctionComponent<PageEditOverviewProps> = () => {
-  // TODO: EXP-462 Get this from constants / config loaded at app start?
-  const applications = ["firefox-desktop", "fenix", "reference-browser"];
+  const [updateExperimentOverview, { loading }] = useMutation<
+    { updateExperimentOverview: UpdateExperimentOverviewResult },
+    { input: UpdateExperimentInput }
+  >(UPDATE_EXPERIMENT_OVERVIEW_MUTATION);
 
-  const [submitErrors /* setSubmitErrors */] = useState<Record<string, any>>(
-    {},
+  const [submitErrors, setSubmitErrors] = useState<Record<string, any>>({});
+  const currentExperiment = useRef<getExperiment_experimentBySlug>();
+
+  const onFormSubmit = useCallback(
+    async (
+      { name, hypothesis, application, publicDescription }: Record<string, any>,
+      resetForm: Function,
+    ) => {
+      try {
+        const result = await updateExperimentOverview({
+          variables: {
+            input: {
+              id: currentExperiment.current!.id,
+              name,
+              hypothesis,
+              application,
+              publicDescription,
+            },
+          },
+        });
+
+        if (!result.data?.updateExperimentOverview) {
+          throw new Error("Save failed, no error available");
+        }
+
+        const { message } = result.data.updateExperimentOverview;
+
+        if (message !== "success" && typeof message === "object") {
+          return void setSubmitErrors(message);
+        }
+
+        resetForm({ name, hypothesis, application, publicDescription });
+      } catch (error) {
+        setSubmitErrors({ "*": SUBMIT_ERROR });
+      }
+    },
+    [updateExperimentOverview, currentExperiment],
   );
 
-  const onFormSubmit = useCallback(() => {
-    console.log("SUBMIT TBD");
-  }, []);
-
   const onFormNext = useCallback(() => {
-    console.log("NEXT TBD");
+    navigate(`branches`);
   }, []);
 
   return (
     <PageEditContainer title="Overview" testId="PageEditOverview">
-      {({ experiment }) => (
-        <FormOverview
-          {...{
-            isLoading: false,
-            applications,
-            experiment,
-            submitErrors,
-            onSubmit: onFormSubmit,
-            onNext: onFormNext,
-          }}
-        />
-      )}
+      {({ experiment }) => {
+        currentExperiment.current = experiment;
+
+        return (
+          <FormOverview
+            {...{
+              isLoading: loading,
+              experiment,
+              submitErrors,
+              onSubmit: onFormSubmit,
+              onNext: onFormNext,
+            }}
+          />
+        );
+      }}
     </PageEditContainer>
   );
 };

--- a/app/experimenter/nimbus-ui/src/components/PageNew/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageNew/index.tsx
@@ -21,9 +21,6 @@ const TRAINING_DOC_URL =
 type PageNewProps = {} & RouteComponentProps;
 
 const PageNew: React.FunctionComponent<PageNewProps> = () => {
-  // TODO: EXP-462 Get this from constants / config loaded at app start?
-  const applications = ["firefox-desktop", "fenix", "reference-browser"];
-
   const [createExperiment, { loading }] = useMutation<
     { createExperiment: CreateExperimentResult },
     { input: CreateExperimentInput }
@@ -32,9 +29,7 @@ const PageNew: React.FunctionComponent<PageNewProps> = () => {
   const [submitErrors, setSubmitErrors] = useState<Record<string, any>>({});
 
   const onFormCancel = useCallback(() => {
-    // TODO: EXP-462 cancel creation
-    // navigate(".")
-    console.log("CANCEL TBD");
+    navigate(".");
   }, []);
 
   const onFormSubmit = useCallback(
@@ -78,7 +73,6 @@ const PageNew: React.FunctionComponent<PageNewProps> = () => {
           {...{
             isLoading: loading,
             submitErrors,
-            applications,
             onSubmit: onFormSubmit,
             onCancel: onFormCancel,
           }}

--- a/app/experimenter/nimbus-ui/src/gql/experiments.ts
+++ b/app/experimenter/nimbus-ui/src/gql/experiments.ts
@@ -20,9 +20,26 @@ export const CREATE_EXPERIMENT_MUTATION = gql`
   }
 `;
 
+export const UPDATE_EXPERIMENT_OVERVIEW_MUTATION = gql`
+  mutation updateExperimentOverview($input: UpdateExperimentInput!) {
+    updateExperimentOverview(input: $input) {
+      clientMutationId
+      message
+      status
+      nimbusExperiment {
+        name
+        hypothesis
+        application
+        publicDescription
+      }
+    }
+  }
+`;
+
 export const GET_EXPERIMENT_QUERY = gql`
   query getExperiment($slug: String!) {
     experimentBySlug(slug: $slug) {
+      id
       name
       slug
       status

--- a/app/experimenter/nimbus-ui/src/lib/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/lib/mocks.tsx
@@ -14,7 +14,7 @@ import {
 import { Observable } from "@apollo/client/utilities";
 import { MockLink, MockedResponse } from "@apollo/client/testing";
 import { equal } from "@wry/equality";
-import { print } from "graphql";
+import { DocumentNode, print } from "graphql";
 import { GET_EXPERIMENT_QUERY } from "../gql/experiments";
 import { getExperiment } from "../types/getExperiment";
 import { getConfig_nimbusConfig } from "../types/getConfig";
@@ -216,7 +216,10 @@ export class SimulatedMockLink extends ApolloLink {
 export const mockExperimentQuery = (
   slug: string,
   modifications: Partial<getExperiment["experimentBySlug"]> = {},
-) => {
+): {
+  mock: MockedResponse<Record<string, any>>;
+  data: getExperiment["experimentBySlug"];
+} => {
   // If `null` is explicitely passed in for `modifications`, the experiment
   // data will be `null`.
   const experiment: getExperiment["experimentBySlug"] =
@@ -225,11 +228,12 @@ export const mockExperimentQuery = (
       : Object.assign(
           {
             __typename: "NimbusExperimentType",
+            id: "1",
             name: "Open-architected background installation",
             slug,
             status: "DRAFT",
             hypothesis: "Realize material say pretty.",
-            application: "FIREFOX_DESKTOP",
+            application: "DESKTOP",
             publicDescription:
               "Official approach present industry strategy dream piece.",
             referenceBranch: {
@@ -286,5 +290,40 @@ export const mockExperimentQuery = (
       },
     },
     data: experiment,
+  };
+};
+
+export const mockExperimentMutation = (
+  mutation: DocumentNode,
+  input: Record<string, string>,
+  key: string,
+  {
+    status = 200,
+    message = "success",
+    experiment,
+  }: {
+    status?: number;
+    message?: string | Record<string, any>;
+    experiment?: Record<string, any> | null;
+  },
+) => {
+  return {
+    request: {
+      query: mutation,
+      variables: {
+        input,
+      },
+    },
+    result: {
+      errors: undefined as undefined | any[],
+      data: {
+        [key]: {
+          clientMutationId: "8675309",
+          message,
+          status,
+          nimbusExperiment: experiment,
+        },
+      },
+    },
   };
 };

--- a/app/experimenter/nimbus-ui/src/types/getExperiment.ts
+++ b/app/experimenter/nimbus-ui/src/types/getExperiment.ts
@@ -47,6 +47,7 @@ export interface getExperiment_experimentBySlug_probeSets {
 
 export interface getExperiment_experimentBySlug {
   __typename: "NimbusExperimentType";
+  id: string;
   name: string;
   slug: string;
   status: NimbusExperimentStatus | null;

--- a/app/experimenter/nimbus-ui/src/types/globalTypes.ts
+++ b/app/experimenter/nimbus-ui/src/types/globalTypes.ts
@@ -86,6 +86,15 @@ export interface CreateExperimentInput {
   hypothesis: string;
 }
 
+export interface UpdateExperimentInput {
+  clientMutationId?: string | null;
+  name?: string | null;
+  application?: NimbusExperimentApplication | null;
+  publicDescription?: string | null;
+  hypothesis?: string | null;
+  id: string;
+}
+
 //==============================================================
 // END Enums and Input Objects
 //==============================================================

--- a/app/experimenter/nimbus-ui/src/types/updateExperimentOverview.ts
+++ b/app/experimenter/nimbus-ui/src/types/updateExperimentOverview.ts
@@ -1,0 +1,37 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+import { UpdateExperimentInput, NimbusExperimentApplication } from "./globalTypes";
+
+// ====================================================
+// GraphQL mutation operation: updateExperimentOverview
+// ====================================================
+
+export interface updateExperimentOverview_updateExperimentOverview_nimbusExperiment {
+  __typename: "NimbusExperimentType";
+  name: string;
+  hypothesis: string | null;
+  application: NimbusExperimentApplication | null;
+  publicDescription: string | null;
+}
+
+export interface updateExperimentOverview_updateExperimentOverview {
+  __typename: "UpdateExperimentOverview";
+  clientMutationId: string | null;
+  message: any | null;
+  status: number | null;
+  nimbusExperiment: updateExperimentOverview_updateExperimentOverview_nimbusExperiment | null;
+}
+
+export interface updateExperimentOverview {
+  /**
+   * Update a Nimbus Experiment.
+   */
+  updateExperimentOverview: updateExperimentOverview_updateExperimentOverview | null;
+}
+
+export interface updateExperimentOverviewVariables {
+  input: UpdateExperimentInput;
+}


### PR DESCRIPTION
This PR:

- Adds the mutation to update an experiment
  - This updated generated types
- Updates the shared FormOverview to enable Save and Next based on the status of the fields
  - Save will only be enabled if there are changes
  - Next will only be enabled if there are no changes (initial state and after save)
- Updates the shared FormOverview to use config-based Application dropdown (eliminating it from #3696)
- Because why not, I can remove this if desired: enables the Cancel button in the New Experiment form (eliminating it from #3696)
- Warns you on the New and Edit pages if you make changes and attempt to leave the page
- Moves some test mutation mocking over to the shared mocks file
- Adds missing Storybook for FormOverview with experiment mock data
- Updates tests

Some of these tests were a little clunky to get to 100%, so feel free to shame me if I've done anything super unclear.