### PR TITLE
fix #3846 feat(nimbus): use enum for application in gql

### DIFF
--- a/app/experimenter/experiments/api/v5/inputs.py
+++ b/app/experimenter/experiments/api/v5/inputs.py
@@ -1,6 +1,7 @@
 import graphene
 
 from experimenter.experiments.api.v5.types import (
+    NimbusExperimentApplication,
     NimbusExperimentChannel,
     NimbusExperimentFirefoxMinVersion,
     NimbusExperimentStatus,
@@ -11,7 +12,7 @@ from experimenter.experiments.api.v5.types import (
 class ExperimentInput(graphene.InputObjectType):
     client_mutation_id = graphene.String()
     name = graphene.String()
-    application = graphene.String()
+    application = NimbusExperimentApplication()
     public_description = graphene.String()
     hypothesis = graphene.String()
 
@@ -19,7 +20,7 @@ class ExperimentInput(graphene.InputObjectType):
 class CreateExperimentInput(ExperimentInput):
     name = graphene.String(required=True)
     hypothesis = graphene.String(required=True)
-    application = graphene.String(required=True)
+    application = NimbusExperimentApplication(required=True)
 
 
 class UpdateExperimentInput(ExperimentInput):

--- a/app/experimenter/experiments/api/v5/types.py
+++ b/app/experimenter/experiments/api/v5/types.py
@@ -34,6 +34,11 @@ class NimbusExperimentTargetingConfigSlug(graphene.Enum):
         enum = NimbusConstants.TargetingConfig
 
 
+class NimbusExperimentApplication(graphene.Enum):
+    class Meta:
+        enum = NimbusConstants.Application
+
+
 class NimbusBranchType(DjangoObjectType):
     class Meta:
         model = NimbusBranch
@@ -47,6 +52,7 @@ class NimbusFeatureConfigType(DjangoObjectType):
 
 class NimbusExperimentType(DjangoObjectType):
     status = NimbusExperimentStatus()
+    application = NimbusExperimentApplication()
     firefox_min_version = NimbusExperimentFirefoxMinVersion()
     channels = graphene.List(NimbusExperimentChannel)
     treatment_branches = graphene.List(NimbusBranchType)

--- a/app/experimenter/experiments/tests/api/v5/test_mutation.py
+++ b/app/experimenter/experiments/tests/api/v5/test_mutation.py
@@ -139,7 +139,7 @@ class TestMutations(GraphQLTestCase):
                 "input": {
                     "name": "Test 1234",
                     "hypothesis": "Test hypothesis",
-                    "application": "firefox-desktop",
+                    "application": NimbusExperiment.Application.DESKTOP.name,
                     "clientMutationId": "randomid",
                 }
             },
@@ -169,7 +169,7 @@ class TestMutations(GraphQLTestCase):
                 "input": {
                     "name": long_name,
                     "hypothesis": "Test hypothesis",
-                    "application": "firefox-desktop",
+                    "application": NimbusExperiment.Application.DESKTOP.name,
                     "clientMutationId": "randomid",
                 }
             },


### PR DESCRIPTION
Because:

* We want to use enum's consistently for enum model types.

This commit:

* Switches the GQL input for application from string to a matching
  graphene enum.