### PR TITLE
fixes #3855 feat(nimbus): read config from graphql server

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/App/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/App/index.test.tsx
@@ -6,20 +6,43 @@ import React, { ReactNode } from "react";
 import { screen, waitFor } from "@testing-library/react";
 import { renderWithRouter } from "../../lib/test-utils";
 import { MockedCache, mockExperimentQuery } from "../../lib/mocks";
+import * as apollo from "@apollo/client";
 import App from ".";
 
 const { mock } = mockExperimentQuery("my-special-slug");
 
 describe("App", () => {
+  it("displays loading when config is loading", () => {
+    (jest.spyOn(apollo, "useQuery") as jest.Mock).mockReturnValueOnce({
+      loading: true,
+    });
+
+    renderWithRouter(
+      <MockedCache mocks={[]}>
+        <App basepath="/" />
+      </MockedCache>,
+    );
+    expect(screen.getByTestId("page-loading")).toBeInTheDocument();
+  });
+
   it("routes to PageHome page", () => {
-    renderWithRouter(<App basepath="/" />);
+    renderWithRouter(
+      <MockedCache>
+        <App basepath="/" />
+      </MockedCache>,
+    );
     expect(screen.getByTestId("PageHome")).toBeInTheDocument();
   });
 
   it("routes to PageNew page", () => {
-    renderWithRouter(<App basepath="/foo/bar" />, {
-      route: "/foo/bar/new",
-    });
+    renderWithRouter(
+      <MockedCache>
+        <App basepath="/foo/bar" />
+      </MockedCache>,
+      {
+        route: "/foo/bar/new",
+      },
+    );
     expect(screen.getByTestId("PageNew")).toBeInTheDocument();
   });
 

--- a/app/experimenter/nimbus-ui/src/components/App/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/App/index.tsx
@@ -4,6 +4,9 @@
 
 import React from "react";
 import { Router, Redirect, RouteComponentProps } from "@reach/router";
+import { useQuery } from "@apollo/client";
+import { GET_CONFIG_QUERY } from "../../gql/config";
+import PageLoading from "../PageLoading";
 import PageHome from "../PageHome";
 import PageNew from "../PageNew";
 import PageEditOverview from "../PageEditOverview";
@@ -17,6 +20,12 @@ type RootProps = {
 const Root = (props: RootProps) => <>{props.children}</>;
 
 const App = ({ basepath }: { basepath: string }) => {
+  const { loading } = useQuery(GET_CONFIG_QUERY);
+
+  if (loading) {
+    return <PageLoading />;
+  }
+
   return (
     <Router {...{ basepath }}>
       <PageHome path="/" />

--- a/app/experimenter/nimbus-ui/src/gql/config.ts
+++ b/app/experimenter/nimbus-ui/src/gql/config.ts
@@ -1,0 +1,51 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { gql } from "@apollo/client";
+
+export const GET_CONFIG_QUERY = gql`
+  query getConfig {
+    nimbusConfig {
+      application {
+        label
+        value
+      }
+      channels {
+        label
+        value
+      }
+      featureConfig {
+        id
+        name
+        slug
+        description
+        application
+        ownerEmail
+        schema
+      }
+      firefoxMinVersion {
+        label
+        value
+      }
+      probeSets {
+        id
+        name
+        slug
+        probes {
+          id
+          kind
+          name
+          eventCategory
+          eventMethod
+          eventObject
+          eventValue
+        }
+      }
+      targetingConfigSlug {
+        label
+        value
+      }
+    }
+  }
+`;

--- a/app/experimenter/nimbus-ui/src/hooks/useConfig.test.tsx
+++ b/app/experimenter/nimbus-ui/src/hooks/useConfig.test.tsx
@@ -1,0 +1,31 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from "react";
+import { useConfig } from "./useConfig";
+import { MockedCache, MOCK_CONFIG } from "../lib/mocks";
+import { render, waitFor } from "@testing-library/react";
+import serverConfig from "../services/config";
+
+describe("hooks/useConfig", () => {
+  describe("useConfig", () => {
+    let hook: ReturnType<typeof useConfig>;
+    const config = { ...MOCK_CONFIG, ...serverConfig };
+
+    const TestConfig = () => {
+      hook = useConfig();
+      return <p>Bière forte</p>;
+    };
+
+    it("returns the config", async () => {
+      render(
+        <MockedCache>
+          <TestConfig />
+        </MockedCache>,
+      );
+
+      await waitFor(() => expect(hook).toEqual(config));
+    });
+  });
+});

--- a/app/experimenter/nimbus-ui/src/hooks/useConfig.tsx
+++ b/app/experimenter/nimbus-ui/src/hooks/useConfig.tsx
@@ -1,0 +1,31 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { useApolloClient } from "@apollo/client";
+import { GET_CONFIG_QUERY } from "../gql/config";
+import { getConfig } from "../types/getConfig";
+import serverConvig from "../services/config";
+
+/**
+ * Hook to retrieve GraphQL and Server config valyes.
+ *
+ * NOTE: This hook is dependent on the initial query to retrieve
+ * GraphQL config being performed inside the <App> component. Do
+ * not use before this component is rendered.
+ *
+ * Example:
+ *
+ * const { channels, probeSets } = useConfig();
+ */
+
+export function useConfig() {
+  const client = useApolloClient();
+  const { nimbusConfig } = client.cache.readQuery<{
+    nimbusConfig: getConfig["nimbusConfig"];
+  }>({
+    query: GET_CONFIG_QUERY,
+  })!;
+
+  return { ...nimbusConfig!, ...serverConvig };
+}

--- a/app/experimenter/nimbus-ui/src/lib/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/lib/mocks.tsx
@@ -17,8 +17,10 @@ import { equal } from "@wry/equality";
 import { print } from "graphql";
 import { GET_EXPERIMENT_QUERY } from "../gql/experiments";
 import { getExperiment } from "../types/getExperiment";
+import { GET_CONFIG_QUERY } from "../gql/config";
 
 export interface MockedProps {
+  config?: Partial<typeof MOCK_CONFIG> | null;
   childProps?: object;
   children?: React.ReactElement;
   mocks?: MockedResponse<Record<string, any>>[];
@@ -28,22 +30,84 @@ export interface MockedState {
   client: ApolloClient<any>;
 }
 
+export const MOCK_CONFIG = {
+  application: [
+    {
+      label: "Desktop",
+      value: "DESKTOP",
+    },
+  ],
+  channels: [
+    {
+      label: "Desktop Beta",
+      value: "DESKTOP_BETA",
+    },
+  ],
+  featureConfig: [
+    {
+      id: "1",
+      name: "Up-sized cohesive complexity",
+      slug: "up-sized-cohesive-complexity",
+      description:
+        "Quickly above also mission action. Become thing item institution plan.\nImpact friend wonder. Interview strategy nature question. Admit room without impact its enter forward.",
+      application: "REFERENCE_BROWSER",
+      ownerEmail: "sheila43@yahoo.com",
+      schema: null,
+    },
+  ],
+  firefoxMinVersion: [
+    {
+      label: "Firefox 80",
+      value: "FIREFOX_80",
+    },
+  ],
+  probeSets: [
+    {
+      id: "1",
+      name: "Inverse responsive methodology",
+      slug: "inverse-responsive-methodology",
+      probes: [
+        {
+          id: "1",
+          kind: "EVENT",
+          name: "Public-key intangible Graphical User Interface",
+          eventCategory: "persevering-intangible-productivity",
+          eventMethod: "monitored-system-worthy-core",
+          eventObject: "ameliorated-uniform-protocol",
+          eventValue: "front-line-5thgeneration-product",
+        },
+        {
+          id: "2",
+          kind: "SCALAR",
+          name: "Total didactic moderator",
+          eventCategory: "horizontal-bifurcated-attitude",
+          eventMethod: "optimized-homogeneous-system-engine",
+          eventObject: "virtual-discrete-customer-loyalty",
+          eventValue: "automated-national-infrastructure",
+        },
+      ],
+    },
+  ],
+  targetingConfigSlug: [
+    {
+      label: "First Run",
+      value: "FIRST_RUN",
+    },
+  ],
+};
+
 // Disabling this rule for now because we'll eventually
 // be using props from MockedProps.
 // eslint-disable-next-line no-empty-pattern
-export function createCache({}: MockedProps = {}) {
+export function createCache({ config = {} }: MockedProps = {}) {
   const cache = new InMemoryCache();
 
-  // As we set up new cached queries we can use
-  // `cache.writeQuery` to set up default data
-  // in tests with values set in MockedProps
-  //
-  // cache.writeQuery({
-  //   query: MY_QUERY,
-  //   data: {
-  //     queryDataDefault,
-  //   },
-  // });
+  cache.writeQuery({
+    query: GET_CONFIG_QUERY,
+    data: {
+      nimbusConfig: { ...MOCK_CONFIG, ...config },
+    },
+  });
 
   return cache;
 }

--- a/app/experimenter/nimbus-ui/src/types/getConfig.ts
+++ b/app/experimenter/nimbus-ui/src/types/getConfig.ts
@@ -1,0 +1,83 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+import { NimbusFeatureConfigApplication, NimbusProbeKind } from "./globalTypes";
+
+// ====================================================
+// GraphQL query operation: getConfig
+// ====================================================
+
+export interface getConfig_nimbusConfig_application {
+  __typename: "NimbusLabelValueType";
+  label: string | null;
+  value: string | null;
+}
+
+export interface getConfig_nimbusConfig_channels {
+  __typename: "NimbusLabelValueType";
+  label: string | null;
+  value: string | null;
+}
+
+export interface getConfig_nimbusConfig_featureConfig {
+  __typename: "NimbusFeatureConfigType";
+  id: string;
+  name: string;
+  slug: string;
+  description: string | null;
+  application: NimbusFeatureConfigApplication | null;
+  ownerEmail: string | null;
+  schema: string | null;
+}
+
+export interface getConfig_nimbusConfig_firefoxMinVersion {
+  __typename: "NimbusLabelValueType";
+  label: string | null;
+  value: string | null;
+}
+
+export interface getConfig_nimbusConfig_probeSets_probes {
+  __typename: "NimbusProbeType";
+  id: string;
+  kind: NimbusProbeKind;
+  name: string;
+  eventCategory: string;
+  eventMethod: string | null;
+  eventObject: string | null;
+  eventValue: string | null;
+}
+
+export interface getConfig_nimbusConfig_probeSets {
+  __typename: "NimbusProbeSetType";
+  id: string;
+  name: string;
+  slug: string;
+  probes: getConfig_nimbusConfig_probeSets_probes[];
+}
+
+export interface getConfig_nimbusConfig_targetingConfigSlug {
+  __typename: "NimbusLabelValueType";
+  label: string | null;
+  value: string | null;
+}
+
+export interface getConfig_nimbusConfig {
+  __typename: "NimbusConfigurationType";
+  application: (getConfig_nimbusConfig_application | null)[] | null;
+  channels: (getConfig_nimbusConfig_channels | null)[] | null;
+  featureConfig: (getConfig_nimbusConfig_featureConfig | null)[] | null;
+  firefoxMinVersion: (getConfig_nimbusConfig_firefoxMinVersion | null)[] | null;
+  probeSets: (getConfig_nimbusConfig_probeSets | null)[] | null;
+  targetingConfigSlug:
+    | (getConfig_nimbusConfig_targetingConfigSlug | null)[]
+    | null;
+}
+
+export interface getConfig {
+  /**
+   * Nimbus Configuration Data for front-end usage.
+   */
+  nimbusConfig: getConfig_nimbusConfig | null;
+}

--- a/app/experimenter/nimbus-ui/src/types/globalTypes.ts
+++ b/app/experimenter/nimbus-ui/src/types/globalTypes.ts
@@ -7,13 +7,10 @@
 // START Enums and Input Objects
 //==============================================================
 
-/**
- * An enumeration.
- */
 export enum NimbusExperimentApplication {
+  DESKTOP = "DESKTOP",
   FENIX = "FENIX",
-  FIREFOX_DESKTOP = "FIREFOX_DESKTOP",
-  REFERENCE_BROWSER = "REFERENCE_BROWSER",
+  REFERENCE = "REFERENCE",
 }
 
 export enum NimbusExperimentChannel {
@@ -64,11 +61,27 @@ export enum NimbusExperimentTargetingConfigSlug {
   US_ONLY = "US_ONLY",
 }
 
+/**
+ * An enumeration.
+ */
+export enum NimbusFeatureConfigApplication {
+  FENIX = "FENIX",
+  FIREFOX_DESKTOP = "FIREFOX_DESKTOP",
+  REFERENCE_BROWSER = "REFERENCE_BROWSER",
+}
+
+/**
+ * An enumeration.
+ */
+export enum NimbusProbeKind {
+  EVENT = "EVENT",
+  SCALAR = "SCALAR",
+}
+
 export interface CreateExperimentInput {
   clientMutationId?: string | null;
   name: string;
-  slug?: string | null;
-  application: string;
+  application: NimbusExperimentApplication;
   publicDescription?: string | null;
   hypothesis: string;
 }


### PR DESCRIPTION
I took a look but didn't see an issue this relates to, but I think we're going to need this pretty soon, so here it is.

This PR adds loading in the GraphQL Nimbus Config on app start and makes it available throughout the app via the `useConfig` hook.