### PR TITLE
feat(nimbus): move common experiment edit elements to PageEditContainer component

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/index.test.tsx
@@ -25,19 +25,6 @@ describe("PageEditBranches", () => {
       expect(screen.getByText(slug)).toBeInTheDocument();
     }
   });
-
-  it("renders not found screen", async () => {
-    const { mock: notFoundMock } = mockExperimentQuery("demo-slug", null);
-    render(<Subject mocks={[notFoundMock]} />);
-    await waitFor(() => {
-      expect(screen.getByTestId("not-found")).toBeInTheDocument();
-    });
-  });
-
-  it("renders loading screen", () => {
-    render(<Subject />);
-    expect(screen.getByTestId("page-loading")).toBeInTheDocument();
-  });
 });
 
 const Subject = ({

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/index.tsx
@@ -3,60 +3,41 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React from "react";
-import { RouteComponentProps, useParams } from "@reach/router";
-import AppLayoutWithSidebar from "../AppLayoutWithSidebar";
-import { useExperiment, useConfig } from "../../hooks";
-import HeaderEditExperiment from "../HeaderEditExperiment";
-import ExperimentNotFound from "../PageExperimentNotFound";
-import PageLoading from "../PageLoading";
+import { RouteComponentProps } from "@reach/router";
+import { useConfig } from "../../hooks";
 import FormBranches from "../FormBranches";
 import LinkExternal from "../LinkExternal";
+import PageEditContainer from "../PageEditContainer";
 
 // TODO: find this doco URL
 const BRANCHES_DOC_URL =
   "https://mana.mozilla.org/wiki/pages/viewpage.action?spaceKey=FJT&title=Project+Nimbus";
 
 const PageEditBranches: React.FunctionComponent<RouteComponentProps> = () => {
-  const { slug } = useParams();
-  const { experiment, notFound, loading } = useExperiment(slug);
   const { featureConfig } = useConfig();
 
-  if (loading) {
-    return <PageLoading />;
-  }
-
-  if (notFound) {
-    return <ExperimentNotFound {...{ slug }} />;
-  }
-
-  const { name, status } = experiment;
   return (
-    <AppLayoutWithSidebar>
-      <section data-testid="PageEditBranches">
-        <HeaderEditExperiment
-          {...{
-            slug,
-            name,
-            status,
-          }}
-        />
-        <h2 className="mt-3 h4">Branches</h2>
-        <p>
-          If you want, you can add a <strong>feature flag</strong> configuration
-          to each branch. Experiments can only change one flag at a time.{" "}
-          <LinkExternal href={BRANCHES_DOC_URL}>Learn more</LinkExternal>
-        </p>
-        {/* TODO: EXP-505 for accepting and saving edits to branches */}
-        <FormBranches
-          {...{
-            experiment,
-            featureConfig,
-            // TODO: supply this as default value, track changes within FormBranches
-            equalRatio: false,
-          }}
-        />
-      </section>
-    </AppLayoutWithSidebar>
+    <PageEditContainer title="Branches" testId="PageEditBranches">
+      {({ experiment }) => (
+        <>
+          <p>
+            If you want, you can add a <strong>feature flag</strong>{" "}
+            configuration to each branch. Experiments can only change one flag
+            at a time.{" "}
+            <LinkExternal href={BRANCHES_DOC_URL}>Learn more</LinkExternal>
+          </p>
+          {/* TODO: EXP-505 for accepting and saving edits to branches */}
+          <FormBranches
+            {...{
+              experiment,
+              featureConfig,
+              // TODO: supply this as default value, track changes within FormBranches
+              equalRatio: false,
+            }}
+          />
+        </>
+      )}
+    </PageEditContainer>
   );
 };
 

--- a/app/experimenter/nimbus-ui/src/components/PageEditContainer/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditContainer/index.stories.tsx
@@ -1,0 +1,22 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from "react";
+import { storiesOf } from "@storybook/react";
+import { RouterSlugProvider } from "../../lib/test-utils";
+import { withLinks } from "@storybook/addon-links";
+import PageEditContainer from ".";
+import { mockExperimentQuery } from "../../lib/mocks";
+
+const { mock } = mockExperimentQuery("demo-slug");
+
+storiesOf("pages/EditContainer", module)
+  .addDecorator(withLinks)
+  .add("basic", () => (
+    <RouterSlugProvider mocks={[mock]}>
+      <PageEditContainer title="Howdy!" testId="PageEditContainer">
+        {({ experiment }) => <p>{experiment.name}</p>}
+      </PageEditContainer>
+    </RouterSlugProvider>
+  ));

--- a/app/experimenter/nimbus-ui/src/components/PageEditContainer/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditContainer/index.test.tsx
@@ -1,0 +1,47 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import PageEditContainer from ".";
+import { RouterSlugProvider } from "../../lib/test-utils";
+import { mockExperimentQuery } from "../../lib/mocks";
+
+describe("PageRequestReview", () => {
+  it("renders as expected", async () => {
+    const { mock } = mockExperimentQuery("demo-slug");
+    render(<Subject mocks={[mock]} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("PageEditContainer")).toBeInTheDocument();
+      expect(screen.getByTestId("page-title")).toBeInTheDocument();
+      expect(screen.getByTestId("page-title")).toHaveTextContent("Howdy!");
+      expect(screen.getByTestId("child")).toBeInTheDocument();
+    });
+  });
+
+  it("renders not found screen", async () => {
+    const { mock: notFoundMock } = mockExperimentQuery("demo-slug", null);
+    render(<Subject mocks={[notFoundMock]} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("not-found")).toBeInTheDocument();
+    });
+  });
+
+  it("renders loading screen", () => {
+    render(<Subject />);
+    expect(screen.getByTestId("page-loading")).toBeInTheDocument();
+  });
+});
+
+const Subject = ({
+  mocks = [],
+}: {
+  mocks?: React.ComponentProps<typeof RouterSlugProvider>["mocks"];
+}) => (
+  <RouterSlugProvider {...{ mocks }}>
+    <PageEditContainer title="Howdy!" testId="PageEditContainer">
+      {({ experiment }) => <p data-testid="child">{experiment.slug}</p>}
+    </PageEditContainer>
+  </RouterSlugProvider>
+);

--- a/app/experimenter/nimbus-ui/src/components/PageEditContainer/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditContainer/index.tsx
@@ -1,0 +1,61 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from "react";
+import { RouteComponentProps, useParams } from "@reach/router";
+import AppLayoutWithSidebar from "../AppLayoutWithSidebar";
+import HeaderEditExperiment from "../HeaderEditExperiment";
+import PageLoading from "../PageLoading";
+import PageExperimentNotFound from "../PageExperimentNotFound";
+import { useExperiment } from "../../hooks";
+import { getExperiment_experimentBySlug } from "../../types/getExperiment";
+
+type PageEditContainerChildrenProps = {
+  experiment: getExperiment_experimentBySlug;
+};
+
+type PageEditContainerProps = {
+  children: (props: PageEditContainerChildrenProps) => React.ReactNode | null;
+  testId: string;
+  title: string;
+} & RouteComponentProps;
+
+const PageEditContainer = ({
+  children,
+  testId,
+  title,
+}: PageEditContainerProps) => {
+  const { slug } = useParams();
+  const { experiment, notFound, loading } = useExperiment(slug);
+
+  if (loading) {
+    return <PageLoading />;
+  }
+
+  if (notFound) {
+    return <PageExperimentNotFound {...{ slug }} />;
+  }
+
+  const { name, status } = experiment;
+
+  return (
+    <AppLayoutWithSidebar>
+      <section data-testid={testId}>
+        <HeaderEditExperiment
+          {...{
+            slug,
+            name,
+            status,
+          }}
+        />
+        <h2 className="mt-3 mb-4 h4" data-testid="page-title">
+          {title}
+        </h2>
+        {children({ experiment })}
+      </section>
+    </AppLayoutWithSidebar>
+  );
+};
+
+export default PageEditContainer;

--- a/app/experimenter/nimbus-ui/src/components/PageEditOverview/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditOverview/index.test.tsx
@@ -11,7 +11,6 @@ import { mockExperimentQuery } from "../../lib/mocks";
 import { MockedResponse } from "@apollo/client/testing";
 
 const { mock } = mockExperimentQuery("demo-slug");
-const { mock: notFoundMock } = mockExperimentQuery("demo-slug", null);
 
 let origConsoleLog: typeof global.console.log;
 let mockSubmit: Record<string, string> = {};
@@ -61,18 +60,6 @@ describe("PageEditOverview", () => {
     render(<Subject mocks={[mock]} />);
     await waitFor(() => fireEvent.click(screen.getByTestId("next")));
     expect(global.console.log).toHaveBeenCalledWith("NEXT TBD");
-  });
-
-  it("renders not found screen", async () => {
-    render(<Subject mocks={[notFoundMock]} />);
-    await waitFor(() => {
-      expect(screen.getByTestId("not-found")).toBeInTheDocument();
-    });
-  });
-
-  it("renders loading screen", () => {
-    render(<Subject />);
-    expect(screen.getByTestId("page-loading")).toBeInTheDocument();
   });
 });
 

--- a/app/experimenter/nimbus-ui/src/components/PageEditOverview/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditOverview/index.tsx
@@ -3,13 +3,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React, { useCallback, useState } from "react";
-import { RouteComponentProps, useParams } from "@reach/router";
-import AppLayoutWithSidebar from "../AppLayoutWithSidebar";
-import { useExperiment } from "../../hooks";
-import HeaderEditExperiment from "../HeaderEditExperiment";
-import PageExperimentNotFound from "../PageExperimentNotFound";
-import PageLoading from "../PageLoading";
+import { RouteComponentProps } from "@reach/router";
 import FormOverview from "../FormOverview";
+import PageEditContainer from "../PageEditContainer";
 
 type PageEditOverviewProps = {} & RouteComponentProps;
 
@@ -17,8 +13,6 @@ const PageEditOverview: React.FunctionComponent<PageEditOverviewProps> = () => {
   // TODO: EXP-462 Get this from constants / config loaded at app start?
   const applications = ["firefox-desktop", "fenix", "reference-browser"];
 
-  const { slug } = useParams();
-  const { experiment, notFound, loading } = useExperiment(slug);
   const [submitErrors /* setSubmitErrors */] = useState<Record<string, any>>(
     {},
   );
@@ -31,30 +25,12 @@ const PageEditOverview: React.FunctionComponent<PageEditOverviewProps> = () => {
     console.log("NEXT TBD");
   }, []);
 
-  if (loading) {
-    return <PageLoading />;
-  }
-
-  if (notFound) {
-    return <PageExperimentNotFound {...{ slug }} />;
-  }
-
-  const { name, status } = experiment;
-
   return (
-    <AppLayoutWithSidebar>
-      <section data-testid="PageEditOverview">
-        <HeaderEditExperiment
-          {...{
-            slug,
-            name,
-            status,
-          }}
-        />
-        <h2 className="mt-3 mb-4 h4">Overview</h2>
+    <PageEditContainer title="Overview" testId="PageEditOverview">
+      {({ experiment }) => (
         <FormOverview
           {...{
-            isLoading: loading,
+            isLoading: false,
             applications,
             experiment,
             submitErrors,
@@ -62,8 +38,8 @@ const PageEditOverview: React.FunctionComponent<PageEditOverviewProps> = () => {
             onNext: onFormNext,
           }}
         />
-      </section>
-    </AppLayoutWithSidebar>
+      )}
+    </PageEditContainer>
   );
 };
 

--- a/app/experimenter/nimbus-ui/src/components/PageRequestReview/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageRequestReview/index.test.tsx
@@ -3,13 +3,27 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React from "react";
-import { screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import PageRequestReview from ".";
-import { renderWithRouter } from "../../lib/test-utils";
+import { RouterSlugProvider } from "../../lib/test-utils";
+import { mockExperimentQuery } from "../../lib/mocks";
 
 describe("PageRequestReview", () => {
-  it("renders as expected", () => {
-    renderWithRouter(<PageRequestReview />);
-    expect(screen.getByTestId("PageRequestReview")).toBeInTheDocument();
+  it("renders as expected", async () => {
+    const { mock } = mockExperimentQuery("demo-slug");
+    render(<Subject mocks={[mock]} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("PageRequestReview")).toBeInTheDocument();
+    });
   });
 });
+
+const Subject = ({
+  mocks = [],
+}: {
+  mocks?: React.ComponentProps<typeof RouterSlugProvider>["mocks"];
+}) => (
+  <RouterSlugProvider {...{ mocks }}>
+    <PageRequestReview />
+  </RouterSlugProvider>
+);

--- a/app/experimenter/nimbus-ui/src/components/PageRequestReview/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageRequestReview/index.tsx
@@ -4,16 +4,14 @@
 
 import React from "react";
 import { RouteComponentProps } from "@reach/router";
-import AppLayoutWithSidebar from "../AppLayoutWithSidebar";
+import PageEditContainer from "../PageEditContainer";
 
 type PageRequestReviewProps = {} & RouteComponentProps;
 
 const PageRequestReview: React.FunctionComponent<PageRequestReviewProps> = () => (
-  <AppLayoutWithSidebar>
-    <section data-testid="PageRequestReview">
-      <h1>PageRequestReview</h1>
-    </section>
-  </AppLayoutWithSidebar>
+  <PageEditContainer title="Review & Launch" testId="PageRequestReview">
+    {({ experiment }) => <p>{experiment.name}</p>}
+  </PageEditContainer>
 );
 
 export default PageRequestReview;


### PR DESCRIPTION
All this does is DRY up some of the Experiment edit pages by moving the Experiment slug query, loading state, and not found state to its own component.