### PR TITLE
fix #3858 feat(nimbus): add primary/secondary probe set gql

### DIFF
--- a/app/experimenter/experiments/api/v5/inputs.py
+++ b/app/experimenter/experiments/api/v5/inputs.py
@@ -65,10 +65,17 @@ class UpdateExperimentBranchesInput(graphene.InputObjectType):
 class UpdateExperimentProbeSetsInput(graphene.InputObjectType):
     client_mutation_id = graphene.String()
     nimbus_experiment_id = graphene.Int(required=True)
-    probe_set_ids = graphene.List(
+    primary_probe_set_ids = graphene.List(
         graphene.Int,
         required=True,
-        description="List of probeset ids that should be set on the experiment.",
+        description="List of primary probeset ids that should be set on the experiment.",
+    )
+    secondary_probe_set_ids = graphene.List(
+        graphene.Int,
+        required=True,
+        description=(
+            "List of secondary probeset ids that should be set on the experiment."
+        ),
     )
 
 

--- a/app/experimenter/experiments/api/v5/mutation.py
+++ b/app/experimenter/experiments/api/v5/mutation.py
@@ -123,7 +123,10 @@ class UpdateExperimentProbeSets(graphene.Mutation):
         experiment = NimbusExperiment.objects.get(id=input.nimbus_experiment_id)
         serializer = NimbusProbeSetUpdateSerializer(
             experiment,
-            data={"probe_sets": input["probe_set_ids"]},
+            data={
+                "primary_probe_sets": input["primary_probe_set_ids"],
+                "secondary_probe_sets": input["secondary_probe_set_ids"],
+            },
             context={"user": info.context.user},
         )
         return handle_with_serializer(cls, serializer, input.client_mutation_id)

--- a/app/experimenter/experiments/api/v5/types.py
+++ b/app/experimenter/experiments/api/v5/types.py
@@ -50,19 +50,6 @@ class NimbusFeatureConfigType(DjangoObjectType):
         model = NimbusFeatureConfig
 
 
-class NimbusExperimentType(DjangoObjectType):
-    status = NimbusExperimentStatus()
-    application = NimbusExperimentApplication()
-    firefox_min_version = NimbusExperimentFirefoxMinVersion()
-    channels = graphene.List(NimbusExperimentChannel)
-    treatment_branches = graphene.List(NimbusBranchType)
-    targeting_config_slug = NimbusExperimentTargetingConfigSlug()
-
-    class Meta:
-        model = NimbusExperiment
-        exclude = ("branches",)
-
-
 class ProjectType(DjangoObjectType):
     class Meta:
         model = Project
@@ -92,3 +79,18 @@ class NimbusProbeSetType(DjangoObjectType):
 class NimbusLabelValueType(graphene.ObjectType):
     label = graphene.String()
     value = graphene.String()
+
+
+class NimbusExperimentType(DjangoObjectType):
+    status = NimbusExperimentStatus()
+    application = NimbusExperimentApplication()
+    firefox_min_version = NimbusExperimentFirefoxMinVersion()
+    channels = graphene.List(NimbusExperimentChannel)
+    treatment_branches = graphene.List(NimbusBranchType)
+    targeting_config_slug = NimbusExperimentTargetingConfigSlug()
+    primary_probe_sets = graphene.List(NimbusProbeSetType)
+    secondary_probe_sets = graphene.List(NimbusProbeSetType)
+
+    class Meta:
+        model = NimbusExperiment
+        exclude = ("branches", "probe_sets")

--- a/app/experimenter/experiments/models/nimbus.py
+++ b/app/experimenter/experiments/models/nimbus.py
@@ -117,6 +117,22 @@ class NimbusExperiment(NimbusConstants, models.Model):
         return self.branches.exclude(id=self.reference_branch.id).order_by("id")
 
     @property
+    def primary_probe_sets(self):
+        return (
+            self.probe_sets.filter(nimbusexperimentprobesets__is_primary=True)
+            .order_by("id")
+            .all()
+        )
+
+    @property
+    def secondary_probe_sets(self):
+        return (
+            self.probe_sets.filter(nimbusexperimentprobesets__is_primary=False)
+            .order_by("id")
+            .all()
+        )
+
+    @property
     def start_date(self):
         start_changelog = self.changes.filter(
             old_status=self.Status.ACCEPTED, new_status=self.Status.LIVE


### PR DESCRIPTION
Because:

* We want to allow primary/secondary probe sets to be updated and
  displayed via GQL.

This commit:

* Updates the GQL types and mutations for primary/secondary probe sets.