### PR TITLE
fix #3876 fix(nimbuS): add owner GQL type

### DIFF
--- a/app/experimenter/experiments/api/v5/types.py
+++ b/app/experimenter/experiments/api/v5/types.py
@@ -1,4 +1,5 @@
 import graphene
+from django.contrib.auth import get_user_model
 from graphene_django.types import DjangoObjectType
 
 from experimenter.experiments.constants.nimbus import NimbusConstants
@@ -79,6 +80,12 @@ class NimbusProbeSetType(DjangoObjectType):
 class NimbusLabelValueType(graphene.ObjectType):
     label = graphene.String()
     value = graphene.String()
+
+
+class NimbusExperimentOwner(DjangoObjectType):
+    class Meta:
+        model = get_user_model()
+        fields = ("id", "username", "first_name", "last_name", "email")
 
 
 class NimbusExperimentType(DjangoObjectType):


### PR DESCRIPTION
Because:

* We want owner information for Nimbus Experiments to be shown.

This commit:

* Includes the needed GQL type for the Nimbus Experiment owner.