### PR TITLE
fix #3874 feat(nimbus): compute bucket sample from population percent

### DIFF
--- a/app/experimenter/experiments/constants/nimbus.py
+++ b/app/experimenter/experiments/constants/nimbus.py
@@ -145,7 +145,6 @@ class NimbusConstants(object):
 
     # Bucket stuff
     BUCKET_TOTAL = 10000
-    BUCKET_COUNT = 100
     BUCKET_RANDOMIZATION_UNIT = "normandy_id"
 
     HYPOTHESIS_DEFAULT = """If we <do this/build this/create this change in the experiment> for <these users>, then we will see <this outcome>.

--- a/app/experimenter/kinto/tasks/nimbus.py
+++ b/app/experimenter/kinto/tasks/nimbus.py
@@ -1,3 +1,5 @@
+from decimal import Decimal
+
 import markus
 from celery.utils.log import get_task_logger
 from django.conf import settings
@@ -49,7 +51,11 @@ def nimbus_push_experiment_to_kinto(experiment_id):
             NimbusIsolationGroup.request_isolation_group_buckets(
                 experiment.slug,
                 experiment,
-                NimbusExperiment.BUCKET_COUNT,
+                int(
+                    experiment.population_percent
+                    / Decimal("100.0")
+                    * NimbusExperiment.BUCKET_TOTAL
+                ),
             )
 
         data = NimbusExperimentSerializer(experiment).data


### PR DESCRIPTION
Because

* We now expose a population percentage field in the nimbus ui to determine sizing

This commit

* Uses the user entered population_percent field to compute the number of buckets rather than using a hard coded default