### PR TITLE
fix #3743 fix #3744 feat(nimbus): feature branch editing UI logic

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/FormBranches/FormBranch.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/FormBranches/FormBranch.test.tsx
@@ -1,0 +1,158 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+
+import { MOCK_CONFIG } from "../../lib/mocks";
+import {
+  SubjectBranch,
+  MOCK_ANNOTATED_BRANCH,
+  MOCK_FEATURE_CONFIG,
+  MOCK_FEATURE_CONFIG_WITH_SCHEMA,
+} from "./mocks";
+
+describe("FormBranch", () => {
+  it("renders as expected", () => {
+    render(<SubjectBranch />);
+    expect(screen.getByTestId("FormBranch")).toBeInTheDocument();
+    expect(screen.queryByTestId("control-pill")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("equal-ratio")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("feature-config-edit")).toBeInTheDocument();
+    expect(screen.queryByTestId("feature-config-add")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("feature-value-edit")).not.toBeInTheDocument();
+  });
+
+  it("includes a control label when reference branch", () => {
+    render(<SubjectBranch isReference />);
+    expect(screen.getByTestId("control-pill")).toBeInTheDocument();
+  });
+
+  it("indicates equal ratio when enabled", () => {
+    render(<SubjectBranch equalRatio />);
+    expect(screen.getByTestId("equal-ratio")).toBeInTheDocument();
+  });
+
+  it("reflects when feature is disabled", () => {
+    const { container } = render(
+      <SubjectBranch
+        branch={{ ...MOCK_ANNOTATED_BRANCH, featureEnabled: false }}
+      />,
+    );
+    const featureSwitchLabel = container.querySelector(
+      "label[for=demo-featureEnabled]",
+    );
+    expect(featureSwitchLabel).toHaveTextContent("Off");
+  });
+
+  it("hides feature configuration edit when feature not selected", () => {
+    render(
+      <SubjectBranch
+        branch={MOCK_ANNOTATED_BRANCH}
+        experimentFeatureConfig={null}
+      />,
+    );
+    expect(screen.queryByTestId("feature-config-edit")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("feature-config-add")).toBeInTheDocument();
+  });
+
+  it("hides feature value edit when schema is null", () => {
+    render(
+      <SubjectBranch
+        branch={{
+          ...MOCK_ANNOTATED_BRANCH,
+        }}
+        experimentFeatureConfig={MOCK_FEATURE_CONFIG}
+      />,
+    );
+    expect(screen.queryByTestId("feature-value-edit")).not.toBeInTheDocument();
+  });
+
+  it("hides feature value edit when feature disabled", () => {
+    render(
+      <SubjectBranch
+        branch={{ ...MOCK_ANNOTATED_BRANCH, featureEnabled: false }}
+        experimentFeatureConfig={MOCK_FEATURE_CONFIG_WITH_SCHEMA}
+      />,
+    );
+    expect(screen.queryByTestId("feature-value-edit")).not.toBeInTheDocument();
+  });
+
+  it("displays feature value edit when value is non-null", () => {
+    render(
+      <SubjectBranch
+        branch={{
+          ...MOCK_ANNOTATED_BRANCH,
+          featureValue: "this is a default value",
+          featureEnabled: true,
+        }}
+        experimentFeatureConfig={MOCK_FEATURE_CONFIG_WITH_SCHEMA}
+      />,
+    );
+    expect(screen.queryByTestId("feature-value-edit")).toBeInTheDocument();
+  });
+
+  it("calls onFeatureConfigChange with selected feature", async () => {
+    const featureIdx = 1;
+    const onFeatureConfigChange = jest.fn();
+    render(<SubjectBranch {...{ onFeatureConfigChange }} />);
+    fireEvent.change(screen.getByTestId("feature-config-select"), {
+      target: { value: featureIdx },
+    });
+    expect(onFeatureConfigChange).toHaveBeenCalledWith(
+      MOCK_CONFIG!.featureConfig![featureIdx],
+    );
+  });
+
+  it("calls onFeatureConfigChange with null when blank feature selected", async () => {
+    const onFeatureConfigChange = jest.fn();
+    render(<SubjectBranch {...{ onFeatureConfigChange }} />);
+    fireEvent.change(screen.getByTestId("feature-config-select"), {
+      target: { value: "" },
+    });
+    expect(onFeatureConfigChange).toHaveBeenCalledWith(null);
+  });
+
+  it("calls onRemove when the branch remove button is clicked", async () => {
+    const onRemove = jest.fn();
+    render(<SubjectBranch {...{ onRemove }} />);
+    fireEvent.click(screen.getByTestId("remove-branch"));
+    expect(onRemove).toHaveBeenCalled();
+  });
+
+  it("calls onChange when branch fields are edited", async () => {
+    const id = "testing123";
+    const onChange = jest.fn();
+    const branch = {
+      ...MOCK_ANNOTATED_BRANCH,
+      featureValue: "this is a default value",
+      featureEnabled: true,
+    };
+
+    const { container } = render(
+      <SubjectBranch
+        {...{ id, onChange, branch }}
+        experimentFeatureConfig={MOCK_FEATURE_CONFIG_WITH_SCHEMA}
+      />,
+    );
+
+    const expectedData = {
+      name: "example name",
+      description: "example description",
+      ratio: "42",
+      featureValue: "example value",
+    };
+
+    for (const [name, value] of Object.entries(expectedData)) {
+      onChange.mockClear();
+      const field = container.querySelector(`#${id}-${name}`);
+      expect(field).not.toBeNull();
+      fireEvent.change(field!, { target: { value } });
+      expect(onChange).toHaveBeenCalledWith({ ...branch, [name]: value });
+    }
+
+    fireEvent.click(container.querySelector(`#${id}-featureEnabled`)!);
+    expect(onChange).toHaveBeenCalledWith({ ...branch, featureEnabled: false });
+  });
+});

--- a/app/experimenter/nimbus-ui/src/components/FormBranches/FormBranch.tsx
+++ b/app/experimenter/nimbus-ui/src/components/FormBranches/FormBranch.tsx
@@ -1,0 +1,224 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from "react";
+import Form from "react-bootstrap/Form";
+import Col from "react-bootstrap/Col";
+import Button from "react-bootstrap/Button";
+import Badge from "react-bootstrap/Badge";
+import { ReactComponent as DeleteIcon } from "../../images/x.svg";
+
+import { getExperiment_experimentBySlug } from "../../types/getExperiment";
+
+import {
+  getConfig_nimbusConfig,
+  getConfig_nimbusConfig_featureConfig,
+} from "../../types/getConfig";
+
+import { AnnotatedBranch } from "./reducer";
+
+export const FormBranch = ({
+  id,
+  branch,
+  equalRatio,
+  isReference,
+  experimentFeatureConfig,
+  featureConfig,
+  onRemove,
+  onChange,
+  onAddFeatureConfig,
+  onRemoveFeatureConfig,
+  onFeatureConfigChange,
+}: {
+  id: string;
+  branch: AnnotatedBranch;
+  equalRatio?: boolean;
+  isReference?: boolean;
+  experimentFeatureConfig: getExperiment_experimentBySlug["featureConfig"];
+  featureConfig: getConfig_nimbusConfig["featureConfig"];
+  onRemove?: () => void;
+  onChange: (branch: AnnotatedBranch) => void;
+  onAddFeatureConfig: () => void;
+  onRemoveFeatureConfig: () => void;
+  onFeatureConfigChange: (
+    featureConfig: getConfig_nimbusConfig_featureConfig | null,
+  ) => void;
+}) => {
+  const { name, description, ratio, featureValue, featureEnabled } = branch;
+
+  const handleRemoveClick = () => {
+    onRemove && onRemove();
+  };
+
+  const handleChange = (
+    propertyName: string,
+    targetAttr: keyof React.ChangeEvent<HTMLInputElement>["target"] = "value",
+  ) => (ev: React.ChangeEvent<HTMLInputElement>) => {
+    onChange({
+      ...branch,
+      [propertyName]: ev.target[targetAttr],
+    });
+  };
+
+  const handleFeatureConfigChange = (
+    ev: React.ChangeEvent<HTMLInputElement>,
+  ) => {
+    const selectedIdx = ev.target.value;
+    if (selectedIdx === "") {
+      return onFeatureConfigChange(null);
+    }
+    const feature = featureConfig![parseInt(selectedIdx, 10)];
+    return onFeatureConfigChange(feature);
+  };
+
+  return (
+    <Form
+      className="mb-3 border border-secondary rounded"
+      data-testid="FormBranch"
+    >
+      <Form.Group className="p-1 mx-3 mt-2 mb-0">
+        <Form.Row>
+          <Form.Group as={Col} controlId={`${id}-name`} sm={4} md={3}>
+            <Form.Label>
+              Branch{" "}
+              {isReference && (
+                <Badge pill variant="primary" data-testid="control-pill">
+                  control
+                </Badge>
+              )}
+            </Form.Label>
+            <Form.Control
+              type="text"
+              defaultValue={name}
+              onChange={handleChange("name")}
+            />
+          </Form.Group>
+          <Form.Group as={Col} controlId={`${id}-description`}>
+            <Form.Label>Description</Form.Label>
+            <Form.Control
+              type="text"
+              defaultValue={description}
+              onChange={handleChange("description")}
+            />
+          </Form.Group>
+          <Form.Group as={Col} controlId={`${id}-ratio`} sm={2} md={2}>
+            <Form.Label>Ratio</Form.Label>
+            {equalRatio ? (
+              <p data-testid="equal-ratio" className="p-0 m-0">
+                Equal
+              </p>
+            ) : (
+              <Form.Control
+                type="text"
+                defaultValue={ratio}
+                onChange={handleChange("ratio")}
+              />
+            )}
+          </Form.Group>
+          <Form.Group as={Col} sm={1} className="align-top text-right">
+            {!isReference && onRemove && (
+              <Button
+                data-testid="remove-branch"
+                variant="light"
+                className="bg-transparent border-0 p-0 m-0"
+                title="Remove branch"
+                onClick={handleRemoveClick}
+              >
+                <DeleteIcon width="18" height="18" />
+              </Button>
+            )}
+          </Form.Group>
+        </Form.Row>
+      </Form.Group>
+
+      {experimentFeatureConfig === null ? (
+        <Form.Group className="px-2 mx-3">
+          <Form.Row>
+            <Button
+              variant="outline-primary"
+              size="sm"
+              data-testid="feature-config-add"
+              onClick={onAddFeatureConfig}
+            >
+              + Feature configuration
+            </Button>
+          </Form.Row>
+        </Form.Group>
+      ) : (
+        <Form.Group
+          className="px-3 py-2 border-top"
+          data-testid="feature-config-edit"
+        >
+          <Form.Row>
+            <Col className="px-2">Feature configuration</Col>
+            <Form.Group as={Col} sm={1} className="align-top text-right">
+              <Button
+                variant="light"
+                className="bg-transparent border-0 p-0 m-0"
+                data-testid="feature-config-remove"
+                title="Remove feature configuration"
+                onClick={onRemoveFeatureConfig}
+              >
+                <DeleteIcon width="18" height="18" />
+              </Button>
+            </Form.Group>
+          </Form.Row>
+          <Form.Row className="align-middle">
+            <Form.Group as={Col} controlId={`${id}-feature`}>
+              <Form.Control
+                as="select"
+                data-testid="feature-config-select"
+                onChange={handleFeatureConfigChange}
+                value={featureConfig!.findIndex(
+                  (feature) => feature?.slug === experimentFeatureConfig?.slug,
+                )}
+              >
+                <option value="">Select...</option>
+                {featureConfig?.map(
+                  (feature, idx) =>
+                    feature && (
+                      <option
+                        key={`feature-${feature.slug}-${idx}`}
+                        value={idx}
+                      >
+                        {feature.name}
+                      </option>
+                    ),
+                )}
+              </Form.Control>
+            </Form.Group>
+            <Col sm={1} md={1} className="px-2 text-center">
+              is
+            </Col>
+            <Form.Group as={Col} controlId={`${id}-featureEnabled`}>
+              <Form.Check
+                type="switch"
+                label={featureEnabled ? "On" : "Off"}
+                defaultChecked={featureEnabled}
+                onChange={handleChange("featureEnabled", "checked")}
+              />
+            </Form.Group>
+          </Form.Row>
+          {experimentFeatureConfig !== null &&
+            !!experimentFeatureConfig.schema &&
+            featureEnabled && (
+              <Form.Row data-testid="feature-value-edit">
+                <Form.Group as={Col} controlId={`${id}-featureValue`}>
+                  <Form.Label>Value</Form.Label>
+                  <Form.Control
+                    as="textarea"
+                    rows={4}
+                    defaultValue={"" + featureValue}
+                    onChange={handleChange("featureValue")}
+                  />
+                </Form.Group>
+              </Form.Row>
+            )}
+        </Form.Group>
+      )}
+    </Form>
+  );
+};
+
+export default FormBranch;

--- a/app/experimenter/nimbus-ui/src/components/FormBranches/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/FormBranches/index.stories.tsx
@@ -4,29 +4,70 @@
 
 import React from "react";
 import { storiesOf } from "@storybook/react";
+import { action } from "@storybook/addon-actions";
 import {
   SubjectBranch,
   SubjectBranches,
   MOCK_EXPERIMENT,
-  MOCK_BRANCH,
+  MOCK_ANNOTATED_BRANCH,
   MOCK_FEATURE_CONFIG,
   MOCK_FEATURE_CONFIG_WITH_SCHEMA,
 } from "./mocks";
 
+const onRemove = action("onRemove");
+const onChange = action("onChange");
+const onAddFeatureConfig = action("onAddFeatureConfig");
+const onRemoveFeatureConfig = action("onRemoveFeatureConfig");
+const onFeatureConfigChange = action("onFeatureConfigChange");
+const onSave = action("onSave");
+const onNext = action("onNext");
+
+const commonFormBranchProps = {
+  onRemove,
+  onChange,
+  onAddFeatureConfig,
+  onRemoveFeatureConfig,
+  onFeatureConfigChange,
+};
+
+const commonFormBranchesProps = { onSave, onNext };
+
 storiesOf("components/FormBranches/FormBranch", module)
   .add("reference branch", () => (
     <SubjectBranch
-      branch={MOCK_EXPERIMENT.referenceBranch!}
+      {...commonFormBranchProps}
+      branch={{
+        ...MOCK_ANNOTATED_BRANCH,
+        featureValue: null,
+      }}
       isReference={true}
     />
   ))
-  .add("treatment branch", () => <SubjectBranch />)
-  .add("equal ratio", () => <SubjectBranch equalRatio />)
+  .add("treatment branch", () => (
+    <SubjectBranch
+      {...commonFormBranchProps}
+      branch={{
+        ...MOCK_ANNOTATED_BRANCH,
+        featureValue: null,
+      }}
+    />
+  ))
+  .add("equal ratio", () => (
+    <SubjectBranch
+      {...commonFormBranchProps}
+      equalRatio
+      branch={{
+        ...MOCK_ANNOTATED_BRANCH,
+        featureValue: null,
+      }}
+    />
+  ))
   .add("with feature", () => (
     <SubjectBranch
+      {...commonFormBranchProps}
       experimentFeatureConfig={MOCK_FEATURE_CONFIG}
       branch={{
-        ...MOCK_BRANCH,
+        ...MOCK_ANNOTATED_BRANCH,
         featureEnabled: false,
         featureValue: "this is a default value",
       }}
@@ -34,9 +75,10 @@ storiesOf("components/FormBranches/FormBranch", module)
   ))
   .add("with feature value", () => (
     <SubjectBranch
+      {...commonFormBranchProps}
       experimentFeatureConfig={MOCK_FEATURE_CONFIG_WITH_SCHEMA}
       branch={{
-        ...MOCK_BRANCH,
+        ...MOCK_ANNOTATED_BRANCH,
         featureEnabled: true,
         featureValue: "this is a default value",
       }}
@@ -44,10 +86,23 @@ storiesOf("components/FormBranches/FormBranch", module)
   ));
 
 storiesOf("components/FormBranches", module)
-  .add("with branches", () => <SubjectBranches />)
-  .add("with equal ratio", () => <SubjectBranches equalRatio={true} />)
+  .add("with branches", () => <SubjectBranches {...commonFormBranchesProps} />)
+  .add("with equal ratio", () => (
+    <SubjectBranches
+      {...commonFormBranchesProps}
+      experiment={{
+        ...MOCK_EXPERIMENT,
+        referenceBranch: { ...MOCK_EXPERIMENT.referenceBranch!, ratio: 1 },
+        treatmentBranches: MOCK_EXPERIMENT.treatmentBranches!.map((branch) => ({
+          ...branch!,
+          ratio: 1,
+        })),
+      }}
+    />
+  ))
   .add("empty", () => (
     <SubjectBranches
+      {...commonFormBranchesProps}
       experiment={{
         ...MOCK_EXPERIMENT,
         referenceBranch: null,
@@ -57,6 +112,7 @@ storiesOf("components/FormBranches", module)
   ))
   .add("with features", () => (
     <SubjectBranches
+      {...commonFormBranchesProps}
       experiment={{
         ...MOCK_EXPERIMENT,
         featureConfig: MOCK_FEATURE_CONFIG,
@@ -65,6 +121,7 @@ storiesOf("components/FormBranches", module)
   ))
   .add("with feature values", () => (
     <SubjectBranches
+      {...commonFormBranchesProps}
       experiment={{
         ...MOCK_EXPERIMENT,
         featureConfig: MOCK_FEATURE_CONFIG_WITH_SCHEMA,

--- a/app/experimenter/nimbus-ui/src/components/FormBranches/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/components/FormBranches/mocks.tsx
@@ -3,24 +3,38 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React from "react";
-import FormBranches, { FormBranch } from ".";
+import FormBranches from ".";
+import FormBranch from "./FormBranch";
 import { mockExperimentQuery, MOCK_CONFIG } from "../../lib/mocks";
+import { AnnotatedBranch } from "./reducer";
 
 export const SubjectBranch = ({
-  branch = MOCK_BRANCH,
+  id = "demo",
+  branch = MOCK_ANNOTATED_BRANCH,
   equalRatio = false,
   isReference = false,
   experimentFeatureConfig = MOCK_FEATURE_CONFIG,
   featureConfig = MOCK_CONFIG.featureConfig,
+  onRemove = () => {},
+  onChange = () => {},
+  onAddFeatureConfig = () => {},
+  onRemoveFeatureConfig = () => {},
+  onFeatureConfigChange = () => {},
 }: Partial<React.ComponentProps<typeof FormBranch>>) => (
   <div className="p-5">
     <FormBranch
       {...{
+        id,
         branch,
         isReference,
         equalRatio,
         featureConfig,
         experimentFeatureConfig,
+        onRemove,
+        onChange,
+        onAddFeatureConfig,
+        onRemoveFeatureConfig,
+        onFeatureConfigChange,
       }}
     />
   </div>
@@ -28,15 +42,17 @@ export const SubjectBranch = ({
 
 export const SubjectBranches = ({
   experiment = MOCK_EXPERIMENT,
-  equalRatio = false,
   featureConfig = MOCK_CONFIG.featureConfig,
+  onSave = () => {},
+  onNext = () => {},
 }: Partial<React.ComponentProps<typeof FormBranches>> = {}) => (
   <div className="p-5">
     <FormBranches
       {...{
         experiment,
-        equalRatio,
         featureConfig,
+        onSave,
+        onNext,
       }}
     />
   </div>
@@ -58,7 +74,7 @@ export const MOCK_EXPERIMENT = mockExperimentQuery("demo-slug", {
       name: "Salt way link",
       slug: "salt-way-link",
       description: "Flame the dark true.",
-      ratio: 1,
+      ratio: 2,
       featureValue: '{"frosted-wake": "simple-hesitation"}',
       featureEnabled: true,
     },
@@ -66,5 +82,9 @@ export const MOCK_EXPERIMENT = mockExperimentQuery("demo-slug", {
 })!.data!;
 
 export const MOCK_BRANCH = MOCK_EXPERIMENT.treatmentBranches![0]!;
+export const MOCK_ANNOTATED_BRANCH: AnnotatedBranch = {
+  __key: "branch-1",
+  ...MOCK_BRANCH,
+};
 export const MOCK_FEATURE_CONFIG = MOCK_CONFIG.featureConfig![0]!;
 export const MOCK_FEATURE_CONFIG_WITH_SCHEMA = MOCK_CONFIG.featureConfig![1]!;

--- a/app/experimenter/nimbus-ui/src/components/FormBranches/reducer.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/FormBranches/reducer.test.tsx
@@ -1,0 +1,90 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { formBranchesReducer, FormBranchesState } from "./reducer";
+import { MOCK_EXPERIMENT } from "./mocks";
+
+const MOCK_STATE: FormBranchesState = {
+  equalRatio: true,
+  lastId: 0,
+  featureConfig: MOCK_EXPERIMENT.featureConfig,
+  referenceBranch: {
+    __key: "branch-reference",
+    ...MOCK_EXPERIMENT.referenceBranch!,
+  },
+  treatmentBranches: MOCK_EXPERIMENT.treatmentBranches!.map((branch, idx) => ({
+    ...branch!,
+    __key: `branch-${idx}`,
+  })),
+};
+
+describe("formBranchesReducer", () => {
+  // Most code paths in reducer are exercised in UI tests - these tests
+  // catch a few corner cases for the sake of coverage.
+
+  it("yields the same state on an unknown action", () => {
+    const oldState = { ...MOCK_STATE };
+    const newState = formBranchesReducer(
+      oldState,
+      //@ts-ignore intentionally breaking the type to exercise default case
+      { type: "bogusAction" },
+    );
+    expect(newState).toEqual(oldState);
+  });
+
+  it("addBranch creates a new referenceBranch as necessary", () => {
+    const oldState = {
+      ...MOCK_STATE,
+      referenceBranch: null,
+      treatmentBranches: null,
+    };
+    const newState = formBranchesReducer(oldState, { type: "addBranch" });
+    expect(newState.referenceBranch).not.toBeNull();
+  });
+
+  it("addBranch creates a new treatmentBranches array as necessary", () => {
+    const oldState = {
+      ...MOCK_STATE,
+      treatmentBranches: null,
+    };
+    const newState = formBranchesReducer(oldState, { type: "addBranch" });
+    expect(Array.isArray(newState.treatmentBranches)).toEqual(true);
+  });
+
+  it("addBranch pushes onto existing treatmentBranches array", () => {
+    const oldState = {
+      ...MOCK_STATE,
+      treatmentBranches: [],
+    };
+    const newState = formBranchesReducer(oldState, { type: "addBranch" });
+    expect(newState.treatmentBranches!.length).toEqual(1);
+  });
+
+  it("equalRatio does nothing to branches if setting to false", () => {
+    const oldState = {
+      ...MOCK_STATE,
+      referenceBranch: null,
+      treatmentBranches: null,
+    };
+    const newState = formBranchesReducer(oldState, {
+      type: "setEqualRatio",
+      value: false,
+    });
+    expect(newState).toEqual({ ...oldState, equalRatio: false });
+  });
+
+  it("equalRatio set to true skips null branches", () => {
+    const oldState = {
+      ...MOCK_STATE,
+      equalRatio: false,
+      referenceBranch: null,
+      treatmentBranches: null,
+    };
+    const newState = formBranchesReducer(oldState, {
+      type: "setEqualRatio",
+      value: true,
+    });
+    expect(newState).toEqual({ ...oldState, equalRatio: true });
+  });
+});

--- a/app/experimenter/nimbus-ui/src/components/FormBranches/reducer.tsx
+++ b/app/experimenter/nimbus-ui/src/components/FormBranches/reducer.tsx
@@ -1,0 +1,266 @@
+import { useReducer, useMemo } from "react";
+import {
+  getExperiment_experimentBySlug,
+  getExperiment_experimentBySlug_treatmentBranches,
+} from "../../types/getExperiment";
+
+export function useFormBranchesReducer({
+  featureConfig,
+  referenceBranch,
+  treatmentBranches,
+}: getExperiment_experimentBySlug) {
+  const initialState = useMemo(() => {
+    let lastId = 0;
+
+    const equalRatio =
+      treatmentBranches !== null &&
+      treatmentBranches?.every(
+        (branch) => branch?.ratio === referenceBranch?.ratio,
+      );
+
+    const annotatedReferenceBranch =
+      referenceBranch === null
+        ? null
+        : annotateBranch("reference", referenceBranch!);
+
+    const annotatedTreatmentBranches = !Array.isArray(treatmentBranches)
+      ? null
+      : treatmentBranches.map((branch) => annotateBranch(lastId++, branch!));
+
+    return {
+      lastId,
+      equalRatio,
+      featureConfig,
+      referenceBranch: annotatedReferenceBranch,
+      treatmentBranches: annotatedTreatmentBranches,
+    };
+  }, [featureConfig, referenceBranch, treatmentBranches]);
+  return useReducer(formBranchesReducer, initialState);
+}
+
+export function formBranchesReducer(
+  state: FormBranchesState,
+  action: FormBranchesAction,
+): FormBranchesState {
+  switch (action.type) {
+    case "addBranch":
+      return addBranch(state);
+    case "removeBranch":
+      return removeBranch(state, action);
+    case "updateBranch":
+      return updateBranch(state, action);
+    case "removeFeatureConfig":
+      return removeFeatureConfig(state);
+    case "setFeatureConfig":
+      return setFeatureConfig(state, action);
+    case "setEqualRatio":
+      return setEqualRatio(state, action);
+    default:
+      return state;
+  }
+}
+
+export function extractSaveState(
+  state: FormBranchesState,
+): FormBranchesSaveState {
+  const { featureConfig, referenceBranch, treatmentBranches } = state;
+  return {
+    featureConfig,
+    referenceBranch: stripOneAnnotatedBranch(referenceBranch),
+    treatmentBranches: stripAnnotatedBranches(treatmentBranches),
+  };
+}
+
+export const REFERENCE_BRANCH_IDX = -1;
+
+export type FormBranchesState = Pick<
+  getExperiment_experimentBySlug,
+  "featureConfig"
+> & {
+  referenceBranch: null | AnnotatedBranch;
+  treatmentBranches: null | AnnotatedBranch[];
+  equalRatio: boolean;
+  lastId: number;
+};
+
+export type FormBranchesSaveState = Pick<
+  getExperiment_experimentBySlug,
+  "featureConfig" | "referenceBranch" | "treatmentBranches"
+>;
+
+export type FormBranchesAction =
+  | AddBranchAction
+  | RemoveBranchAction
+  | UpdateBranchAction
+  | RemoveFeatureConfigAction
+  | SetEqualRatioAction
+  | SetFeatureConfigAction;
+
+type AddBranchAction = {
+  type: "addBranch";
+};
+
+function addBranch(state: FormBranchesState) {
+  let { lastId, referenceBranch, treatmentBranches } = state;
+  lastId++;
+
+  if (referenceBranch === null) {
+    referenceBranch = makeBranch(lastId, "New control");
+  } else {
+    treatmentBranches = [
+      ...(treatmentBranches || []),
+      makeBranch(state.lastId, `New treatment ${lastId}`),
+    ];
+  }
+
+  return {
+    ...state,
+    lastId,
+    referenceBranch,
+    treatmentBranches,
+  };
+}
+
+type RemoveBranchAction = {
+  type: "removeBranch";
+  idx: number;
+};
+
+function removeBranch(state: FormBranchesState, { idx }: RemoveBranchAction) {
+  const treatmentBranches = state.treatmentBranches || [];
+  return {
+    ...state,
+    treatmentBranches: [
+      ...treatmentBranches.slice(0, idx),
+      ...treatmentBranches.slice(idx + 1),
+    ],
+  };
+}
+
+type UpdateBranchAction = {
+  type: "updateBranch";
+  idx: number;
+  value: AnnotatedBranch;
+};
+
+function updateBranch(
+  state: FormBranchesState,
+  { idx, value }: UpdateBranchAction,
+) {
+  let { referenceBranch, treatmentBranches } = state;
+  const updatedBranch = { ...value };
+  if (idx === REFERENCE_BRANCH_IDX) {
+    referenceBranch = updatedBranch;
+  } else {
+    treatmentBranches = (treatmentBranches || []).slice();
+    treatmentBranches[idx] = updatedBranch;
+  }
+  return {
+    ...state,
+    referenceBranch,
+    treatmentBranches,
+  };
+}
+
+type RemoveFeatureConfigAction = {
+  type: "removeFeatureConfig";
+};
+
+function removeFeatureConfig(state: FormBranchesState) {
+  return {
+    ...state,
+    featureConfig: null,
+  };
+}
+
+type SetFeatureConfigAction = {
+  type: "setFeatureConfig";
+  value: FormBranchesState["featureConfig"];
+};
+
+function setFeatureConfig(
+  state: FormBranchesState,
+  { value: featureConfig }: SetFeatureConfigAction,
+) {
+  return {
+    ...state,
+    featureConfig,
+  };
+}
+
+type SetEqualRatioAction = {
+  type: "setEqualRatio";
+  value: FormBranchesState["equalRatio"];
+};
+
+function setEqualRatio(
+  state: FormBranchesState,
+  { value: equalRatio }: SetEqualRatioAction,
+) {
+  let { referenceBranch, treatmentBranches } = state;
+  if (equalRatio) {
+    if (referenceBranch !== null) {
+      referenceBranch = { ...referenceBranch, ratio: 1 };
+    }
+    if (Array.isArray(treatmentBranches)) {
+      treatmentBranches = treatmentBranches.map(
+        (treatmentBranch) =>
+          treatmentBranch && {
+            ...treatmentBranch,
+            ratio: 1,
+          },
+      );
+    }
+  }
+  return {
+    ...state,
+    equalRatio,
+    referenceBranch,
+    treatmentBranches,
+  };
+}
+
+export type AnnotatedBranch = getExperiment_experimentBySlug_treatmentBranches & {
+  __key: string;
+};
+
+function annotateBranch(
+  lastId: number | string,
+  branch: getExperiment_experimentBySlug_treatmentBranches,
+) {
+  return {
+    ...branch,
+    __key: `branch-${lastId}`,
+  };
+}
+
+export function stripOneAnnotatedBranch(branch: null | AnnotatedBranch) {
+  if (!branch) return null;
+  const {
+    __key, // eslint-disable-line @typescript-eslint/no-unused-vars
+    ...strippedBranch
+  } = branch;
+  return strippedBranch;
+}
+
+export function stripAnnotatedBranches(
+  branches: null | AnnotatedBranch[],
+): getExperiment_experimentBySlug["treatmentBranches"] {
+  if (branches === null) return null;
+  return branches.map(stripOneAnnotatedBranch);
+}
+
+function makeBranch(lastId: number, name: string): AnnotatedBranch {
+  return {
+    __typename: "NimbusBranchType" as const,
+    __key: `branch-${lastId}`,
+    name,
+    slug: "",
+    description: "",
+    ratio: 1,
+    featureValue: null,
+    featureEnabled: true,
+  };
+}
+
+export default formBranchesReducer;

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/index.test.tsx
@@ -3,13 +3,23 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React from "react";
-import { screen, waitFor, render } from "@testing-library/react";
+import { screen, waitFor, render, fireEvent } from "@testing-library/react";
 import PageEditBranches from ".";
 import FormBranches from "../FormBranches";
 import { RouterSlugProvider } from "../../lib/test-utils";
 import { mockExperimentQuery, MOCK_CONFIG } from "../../lib/mocks";
 
 describe("PageEditBranches", () => {
+  const origConsole = console.log;
+
+  beforeEach(() => {
+    console.log = jest.fn();
+  });
+
+  afterEach(() => {
+    console.log = origConsole;
+  });
+
   it("renders as expected with experiment data", async () => {
     const { mock } = mockExperimentQuery("demo-slug");
     render(<Subject mocks={[mock]} />);
@@ -17,13 +27,37 @@ describe("PageEditBranches", () => {
       expect(screen.getByTestId("PageEditBranches")).toBeInTheDocument();
       expect(screen.getByTestId("header-experiment")).toBeInTheDocument();
     });
-    expect(screen.getByTestId("equal-ratio")).toHaveTextContent("false");
     expect(screen.getByTestId("FormBranches")).toBeInTheDocument();
     expect(screen.getByTestId("feature-config")).toBeInTheDocument();
     for (const feature of MOCK_CONFIG!.featureConfig!) {
       const { slug } = feature!;
       expect(screen.getByText(slug)).toBeInTheDocument();
     }
+  });
+
+  it("handles onSave from FormBranches", async () => {
+    const { mock, data: experiment } = mockExperimentQuery("demo-slug");
+    render(<Subject mocks={[mock]} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("PageEditBranches")).toBeInTheDocument();
+    });
+    fireEvent.click(await screen.findByTestId("save-button"));
+    expect(console.log).toHaveBeenCalledWith("SAVE", {
+      equalRatio: true,
+      featureConfig: experiment!.featureConfig,
+      referenceBranch: experiment!.referenceBranch,
+      treatmentBranches: experiment!.treatmentBranches,
+    });
+  });
+
+  it("handles onNext from FormBranches", async () => {
+    const { mock } = mockExperimentQuery("demo-slug");
+    render(<Subject mocks={[mock]} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("PageEditBranches")).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByTestId("next-button"));
+    expect(console.log).toHaveBeenCalledWith("NEXT");
   });
 });
 
@@ -41,15 +75,21 @@ jest.mock("../FormBranches", () => ({
   __esModule: true,
   default: ({
     experiment,
-    equalRatio,
     featureConfig,
+    onSave,
+    onNext,
   }: React.ComponentProps<typeof FormBranches>) => {
+    const saveState = {
+      equalRatio: true,
+      featureConfig: experiment.featureConfig,
+      referenceBranch: experiment.referenceBranch,
+      treatmentBranches: experiment.treatmentBranches,
+    };
     return (
       <div data-testid="FormBranches">
         {experiment && (
           <span data-testid="experiment-slug">{experiment.slug}</span>
         )}
-        <span data-testid="equal-ratio">{equalRatio ? "true" : "false"}</span>
         {featureConfig && (
           <ul data-testid="feature-config">
             {featureConfig.map(
@@ -58,6 +98,16 @@ jest.mock("../FormBranches", () => ({
             )}
           </ul>
         )}
+        <button data-testid="next-button" onClick={() => onNext()}>
+          Next
+        </button>
+        <button
+          data-testid="save-button"
+          type="submit"
+          onClick={() => onSave(saveState)}
+        >
+          <span>Save</span>
+        </button>
       </div>
     );
   },

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/index.tsx
@@ -26,13 +26,13 @@ const PageEditBranches: React.FunctionComponent<RouteComponentProps> = () => {
             at a time.{" "}
             <LinkExternal href={BRANCHES_DOC_URL}>Learn more</LinkExternal>
           </p>
-          {/* TODO: EXP-505 for accepting and saving edits to branches */}
           <FormBranches
             {...{
               experiment,
               featureConfig,
-              // TODO: supply this as default value, track changes within FormBranches
-              equalRatio: false,
+              /* TODO: EXP-505 for accepting and saving edits to branches */
+              onSave: async (update) => console.log("SAVE", update),
+              onNext: () => console.log("NEXT"),
             }}
           />
         </>


### PR DESCRIPTION
Because

* we want to manage editing feature branches for an experiment

This commit:

* wires up buttons and form elements in FormBranch and FormBranches

* implements support for adding / removing / changing a feature for configuration (issue #3744)

* implements equal ratio checkbox (issue #3743)

* implements a local reducer for managing editing state