### PR TITLE
fixes #3887 fix(legacy): ensure pop percent are fixed before comparing

### DIFF
--- a/app/experimenter/experiments/migrations/0133_prune_pop_percent_logs.py
+++ b/app/experimenter/experiments/migrations/0133_prune_pop_percent_logs.py
@@ -1,0 +1,20 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("experiments", "0132_auto_20201103_1710"),
+    ]
+
+    def prune_new_changelog(apps, schema_editor):
+
+        ExperimentChangeLog = apps.get_model("experiments", "ExperimentChangeLog")
+
+        ExperimentChangeLog.objects.filter(
+            message="Updated Population Percent", changed_values={}
+        ).delete()
+
+    operations = [
+        migrations.RunPython(prune_new_changelog, reverse_code=migrations.RunPython.noop)
+    ]

--- a/app/experimenter/normandy/tasks.py
+++ b/app/experimenter/normandy/tasks.py
@@ -166,11 +166,15 @@ def update_population_percent(experiment, recipe_data, filter_objects):
         "namespaceSample"
     ):
 
-        percent_decimal = bucket_sample["count"] / bucket_sample["total"] * 100
-        rounded_decimal = format(percent_decimal, ".4f")
+        decimal.getcontext().prec = 5
+        percent_decimal = (
+            decimal.Decimal(bucket_sample["count"])
+            / decimal.Decimal(bucket_sample["total"])
+            * decimal.Decimal(100)
+        )
 
-        if str(experiment.population_percent) != rounded_decimal:
-            changed_data = {"population_percent": rounded_decimal}
+        if experiment.population_percent != percent_decimal:
+            changed_data = {"population_percent": percent_decimal}
 
     if changed_data:
         user_email = (

--- a/app/experimenter/normandy/tasks.py
+++ b/app/experimenter/normandy/tasks.py
@@ -165,11 +165,12 @@ def update_population_percent(experiment, recipe_data, filter_objects):
     if bucket_sample := filter_objects.get("bucketSample") or filter_objects.get(
         "namespaceSample"
     ):
-        percent_decimal = decimal.Decimal(
-            bucket_sample["count"] / bucket_sample["total"] * 100
-        )
-        if experiment.population_percent != percent_decimal:
-            changed_data = {"population_percent": percent_decimal}
+
+        percent_decimal = bucket_sample["count"] / bucket_sample["total"] * 100
+        rounded_decimal = format(percent_decimal, ".4f")
+
+        if str(experiment.population_percent) != rounded_decimal:
+            changed_data = {"population_percent": rounded_decimal}
 
     if changed_data:
         user_email = (


### PR DESCRIPTION
Because:

* division and precision

This commit:

* formats normandy percent decimal before comparing with population percent
* migration to prune empty population percent changelogs