### PR TITLE
fixes #3474 feat(nimbus): Add summary table to request review page

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/ContainerEditPage/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/ContainerEditPage/index.stories.tsx
@@ -6,17 +6,17 @@ import React from "react";
 import { storiesOf } from "@storybook/react";
 import { RouterSlugProvider } from "../../lib/test-utils";
 import { withLinks } from "@storybook/addon-links";
-import PageEditContainer from ".";
+import ContainerEditPage from ".";
 import { mockExperimentQuery } from "../../lib/mocks";
 
 const { mock } = mockExperimentQuery("demo-slug");
 
-storiesOf("pages/EditContainer", module)
+storiesOf("components/ContainerEditPage", module)
   .addDecorator(withLinks)
   .add("basic", () => (
     <RouterSlugProvider mocks={[mock]}>
-      <PageEditContainer title="Howdy!" testId="PageEditContainer">
+      <ContainerEditPage title="Howdy!" testId="ContainerEditPage">
         {({ experiment }) => <p>{experiment.name}</p>}
-      </PageEditContainer>
+      </ContainerEditPage>
     </RouterSlugProvider>
   ));

--- a/app/experimenter/nimbus-ui/src/components/ContainerEditPage/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/ContainerEditPage/index.test.tsx
@@ -4,7 +4,7 @@
 
 import React from "react";
 import { render, screen, waitFor } from "@testing-library/react";
-import PageEditContainer from ".";
+import ContainerEditPage from ".";
 import { RouterSlugProvider } from "../../lib/test-utils";
 import { mockExperimentQuery } from "../../lib/mocks";
 
@@ -13,7 +13,7 @@ describe("PageRequestReview", () => {
     const { mock } = mockExperimentQuery("demo-slug");
     render(<Subject mocks={[mock]} />);
     await waitFor(() => {
-      expect(screen.getByTestId("PageEditContainer")).toBeInTheDocument();
+      expect(screen.getByTestId("ContainerEditPage")).toBeInTheDocument();
       expect(screen.getByTestId("page-title")).toBeInTheDocument();
       expect(screen.getByTestId("page-title")).toHaveTextContent("Howdy!");
       expect(screen.getByTestId("child")).toBeInTheDocument();
@@ -40,8 +40,8 @@ const Subject = ({
   mocks?: React.ComponentProps<typeof RouterSlugProvider>["mocks"];
 }) => (
   <RouterSlugProvider {...{ mocks }}>
-    <PageEditContainer title="Howdy!" testId="PageEditContainer">
+    <ContainerEditPage title="Howdy!" testId="ContainerEditPage">
       {({ experiment }) => <p data-testid="child">{experiment.slug}</p>}
-    </PageEditContainer>
+    </ContainerEditPage>
   </RouterSlugProvider>
 );

--- a/app/experimenter/nimbus-ui/src/components/ContainerEditPage/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/ContainerEditPage/index.tsx
@@ -11,21 +11,21 @@ import PageExperimentNotFound from "../PageExperimentNotFound";
 import { useExperiment } from "../../hooks";
 import { getExperiment_experimentBySlug } from "../../types/getExperiment";
 
-type PageEditContainerChildrenProps = {
+type ContainerEditPageChildrenProps = {
   experiment: getExperiment_experimentBySlug;
 };
 
-type PageEditContainerProps = {
-  children: (props: PageEditContainerChildrenProps) => React.ReactNode | null;
+type ContainerEditPageProps = {
+  children: (props: ContainerEditPageChildrenProps) => React.ReactNode | null;
   testId: string;
   title: string;
 } & RouteComponentProps;
 
-const PageEditContainer = ({
+const ContainerEditPage = ({
   children,
   testId,
   title,
-}: PageEditContainerProps) => {
+}: ContainerEditPageProps) => {
   const { slug } = useParams();
   const { experiment, notFound, loading } = useExperiment(slug);
 
@@ -58,4 +58,4 @@ const PageEditContainer = ({
   );
 };
 
-export default PageEditContainer;
+export default ContainerEditPage;

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/index.tsx
@@ -7,7 +7,7 @@ import { RouteComponentProps } from "@reach/router";
 import { useConfig } from "../../hooks";
 import FormBranches from "../FormBranches";
 import LinkExternal from "../LinkExternal";
-import PageEditContainer from "../PageEditContainer";
+import ContainerEditPage from "../ContainerEditPage";
 
 // TODO: find this doco URL
 const BRANCHES_DOC_URL =
@@ -17,7 +17,7 @@ const PageEditBranches: React.FunctionComponent<RouteComponentProps> = () => {
   const { featureConfig } = useConfig();
 
   return (
-    <PageEditContainer title="Branches" testId="PageEditBranches">
+    <ContainerEditPage title="Branches" testId="PageEditBranches">
       {({ experiment }) => (
         <>
           <p>
@@ -37,7 +37,7 @@ const PageEditBranches: React.FunctionComponent<RouteComponentProps> = () => {
           />
         </>
       )}
-    </PageEditContainer>
+    </ContainerEditPage>
   );
 };
 

--- a/app/experimenter/nimbus-ui/src/components/PageEditOverview/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditOverview/index.tsx
@@ -5,7 +5,7 @@
 import React, { useCallback, useRef, useState } from "react";
 import { navigate, RouteComponentProps } from "@reach/router";
 import FormOverview from "../FormOverview";
-import PageEditContainer from "../PageEditContainer";
+import ContainerEditPage from "../ContainerEditPage";
 import { useMutation } from "@apollo/client";
 import { UPDATE_EXPERIMENT_OVERVIEW_MUTATION } from "../../gql/experiments";
 import { SUBMIT_ERROR } from "../../lib/constants";
@@ -65,7 +65,7 @@ const PageEditOverview: React.FunctionComponent<PageEditOverviewProps> = () => {
   }, []);
 
   return (
-    <PageEditContainer title="Overview" testId="PageEditOverview">
+    <ContainerEditPage title="Overview" testId="PageEditOverview">
       {({ experiment }) => {
         currentExperiment.current = experiment;
 
@@ -81,7 +81,7 @@ const PageEditOverview: React.FunctionComponent<PageEditOverviewProps> = () => {
           />
         );
       }}
-    </PageEditContainer>
+    </ContainerEditPage>
   );
 };
 

--- a/app/experimenter/nimbus-ui/src/components/PageRequestReview/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageRequestReview/index.stories.tsx
@@ -7,11 +7,14 @@ import { storiesOf } from "@storybook/react";
 import { RouterSlugProvider } from "../../lib/test-utils";
 import { withLinks } from "@storybook/addon-links";
 import PageRequestReview from ".";
+import { mockExperimentQuery } from "../../lib/mocks";
+
+const { mock } = mockExperimentQuery("demo-slug");
 
 storiesOf("pages/RequestReview", module)
   .addDecorator(withLinks)
   .add("basic", () => (
-    <RouterSlugProvider>
+    <RouterSlugProvider mocks={[mock]}>
       <PageRequestReview />
     </RouterSlugProvider>
   ));

--- a/app/experimenter/nimbus-ui/src/components/PageRequestReview/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageRequestReview/index.test.tsx
@@ -15,6 +15,7 @@ describe("PageRequestReview", () => {
     await waitFor(() => {
       expect(screen.getByTestId("PageRequestReview")).toBeInTheDocument();
     });
+    expect(screen.getByTestId("table-summary")).toBeInTheDocument();
   });
 });
 

--- a/app/experimenter/nimbus-ui/src/components/PageRequestReview/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageRequestReview/index.tsx
@@ -4,14 +4,15 @@
 
 import React from "react";
 import { RouteComponentProps } from "@reach/router";
-import PageEditContainer from "../PageEditContainer";
+import ContainerEditPage from "../ContainerEditPage";
+import TableSummary from "../TableSummary";
 
 type PageRequestReviewProps = {} & RouteComponentProps;
 
 const PageRequestReview: React.FunctionComponent<PageRequestReviewProps> = () => (
-  <PageEditContainer title="Review & Launch" testId="PageRequestReview">
-    {({ experiment }) => <p>{experiment.name}</p>}
-  </PageEditContainer>
+  <ContainerEditPage title="Review &#38; Launch" testId="PageRequestReview">
+    {({ experiment }) => <TableSummary {...{ experiment }} />}
+  </ContainerEditPage>
 );
 
 export default PageRequestReview;

--- a/app/experimenter/nimbus-ui/src/components/TableSummary/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/TableSummary/index.stories.tsx
@@ -1,0 +1,59 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from "react";
+import { storiesOf } from "@storybook/react";
+import { mockExperimentQuery } from "../../lib/mocks";
+import AppLayout from "../AppLayout";
+import TableSummary from ".";
+import { RouterSlugProvider } from "../../lib/test-utils";
+
+storiesOf("components/TableSummary", module)
+  .add("filled out", () => {
+    const { data } = mockExperimentQuery("demo-slug");
+    return (
+      <Subject>
+        <TableSummary experiment={data!} />
+      </Subject>
+    );
+  })
+  .add("partially filled out", () => {
+    const { data } = mockExperimentQuery("demo-slug", {
+      secondaryProbeSets: [],
+      channels: [],
+      proposedDuration: 0,
+    });
+    return (
+      <Subject>
+        <TableSummary experiment={data!} />
+      </Subject>
+    );
+  })
+  .add("missing all fields", () => {
+    const { data } = mockExperimentQuery("demo-slug", {
+      owner: null,
+      hypothesis: null,
+      primaryProbeSets: [],
+      secondaryProbeSets: [],
+      channels: [],
+      firefoxMinVersion: null,
+      populationPercent: 0,
+      totalEnrolledClients: 0,
+      proposedEnrollment: 0,
+      proposedDuration: 0,
+      targetingConfigSlug: null,
+    });
+
+    return (
+      <Subject>
+        <TableSummary experiment={data!} />
+      </Subject>
+    );
+  });
+
+const Subject = ({ children }: { children: React.ReactElement }) => (
+  <AppLayout>
+    <RouterSlugProvider>{children}</RouterSlugProvider>
+  </AppLayout>
+);

--- a/app/experimenter/nimbus-ui/src/components/TableSummary/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/TableSummary/index.test.tsx
@@ -1,0 +1,161 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { MockedCache, mockExperimentQuery } from "../../lib/mocks";
+import TableSummary from ".";
+import { getExperiment_experimentBySlug } from "../../types/getExperiment";
+
+describe("TableSummary", () => {
+  describe("renders Experiment Owner row as expected", () => {
+    it("when set", () => {
+      const { data } = mockExperimentQuery("demo-slug");
+      render(<Subject experiment={data!} />);
+      expect(screen.getByTestId("experiment-owner")).toHaveTextContent(
+        "example@mozilla.com",
+      );
+    });
+    it("when not set", () => {
+      const { data } = mockExperimentQuery("demo-slug", {
+        owner: null,
+      });
+      render(<Subject experiment={data!} />);
+      expect(screen.getByTestId("experiment-owner")).toHaveTextContent(
+        "Owner not set",
+      );
+    });
+  });
+  describe("renders Hypothesis row as expected", () => {
+    it("when set", () => {
+      const { data } = mockExperimentQuery("demo-slug");
+      render(<Subject experiment={data!} />);
+      expect(screen.getByTestId("experiment-hypothesis")).toHaveTextContent(
+        "Realize material say pretty.",
+      );
+    });
+    it("when not set", () => {
+      const { data } = mockExperimentQuery("demo-slug", {
+        hypothesis: null,
+      });
+      render(<Subject experiment={data!} />);
+      expect(screen.getByTestId("experiment-hypothesis")).toHaveTextContent(
+        "Hypothesis not set",
+      );
+    });
+  });
+
+  describe("renders Probe Sets row as expected", () => {
+    it("when both are set", () => {
+      const { data } = mockExperimentQuery("demo-slug");
+      render(<Subject experiment={data!} />);
+      expect(screen.getByTestId("experiment-probe-primary")).toHaveTextContent(
+        "Primary: Enterprise-wide exuding focus group",
+      );
+      expect(
+        screen.getByTestId("experiment-probe-secondary"),
+      ).toHaveTextContent(
+        "Secondary: Public-key intangible Graphical User Interface",
+      );
+    });
+    it("when neither are set", () => {
+      const { data } = mockExperimentQuery("demo-slug", {
+        primaryProbeSets: [],
+        secondaryProbeSets: [],
+      });
+      render(<Subject experiment={data!} />);
+      expect(screen.getByTestId("experiment-probe-primary")).toHaveTextContent(
+        "Primary: probe not set",
+      );
+      expect(
+        screen.getByTestId("experiment-probe-secondary"),
+      ).toHaveTextContent("Secondary: probe not set");
+    });
+  });
+
+  describe("renders Audience row as expected", () => {
+    it("when all fields are set", () => {
+      const { data } = mockExperimentQuery("demo-slug");
+      render(<Subject experiment={data!} />);
+      expect(screen.getByTestId("experiment-target")).toHaveTextContent(
+        "Us Only",
+      );
+      expect(screen.getByTestId("experiment-channels")).toHaveTextContent(
+        "Desktop Nightly, Desktop Beta,",
+      );
+      expect(screen.getByTestId("experiment-ff-min")).toHaveTextContent(
+        "Firefox 80",
+      );
+      expect(screen.getByTestId("experiment-population")).toHaveTextContent(
+        "40% of population",
+      );
+      expect(screen.getByTestId("experiment-total-enrolled")).toHaveTextContent(
+        "totalling 68,000 expected enrolled clients",
+      );
+    });
+    it("when no fields are set", () => {
+      const { data } = mockExperimentQuery("demo-slug", {
+        channels: [],
+        firefoxMinVersion: null,
+        populationPercent: 0,
+        totalEnrolledClients: 0,
+        proposedEnrollment: 0,
+        proposedDuration: 0,
+        targetingConfigSlug: null,
+      });
+      render(<Subject experiment={data!} />);
+      expect(screen.getByTestId("experiment-target")).toHaveTextContent(
+        "Target audience not set",
+      );
+      expect(screen.getByTestId("experiment-channels")).toHaveTextContent(
+        "channel not set",
+      );
+      expect(screen.getByTestId("experiment-ff-min")).toHaveTextContent(
+        "Firefox minimum version not set",
+      );
+      expect(screen.getByTestId("experiment-population")).toHaveTextContent(
+        "Population percentage not set",
+      );
+      expect(screen.getByTestId("experiment-total-enrolled")).toHaveTextContent(
+        "totalling expected enrolled clients not set",
+      );
+    });
+  });
+
+  describe("renders Duration row as expected", () => {
+    it("when all fields are set", () => {
+      const { data } = mockExperimentQuery("demo-slug");
+      render(<Subject experiment={data!} />);
+      expect(screen.getByTestId("experiment-duration")).toHaveTextContent(
+        "28 days",
+      );
+      expect(screen.getByTestId("experiment-enrollment")).toHaveTextContent(
+        "over an enrollment period of 1 day",
+      );
+    });
+    it("when no fields are set", () => {
+      const { data } = mockExperimentQuery("demo-slug", {
+        proposedEnrollment: 0,
+        proposedDuration: 0,
+      });
+      render(<Subject experiment={data!} />);
+      expect(screen.getByTestId("experiment-duration")).toHaveTextContent(
+        "Proposed duration not set",
+      );
+      expect(screen.getByTestId("experiment-enrollment")).toHaveTextContent(
+        "over an enrollment period of proposed enrollment not set",
+      );
+    });
+  });
+});
+
+const Subject = ({
+  experiment,
+}: {
+  experiment: getExperiment_experimentBySlug;
+}) => (
+  <MockedCache>
+    <TableSummary {...{ experiment }} />
+  </MockedCache>
+);

--- a/app/experimenter/nimbus-ui/src/components/TableSummary/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/TableSummary/index.tsx
@@ -1,0 +1,160 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from "react";
+import { getExperiment_experimentBySlug } from "../../types/getExperiment";
+import { Table } from "react-bootstrap";
+import { useConfig } from "../../hooks";
+import { getConfig_nimbusConfig } from "../../types/getConfig";
+
+type TableSummaryProps = {
+  experiment: getExperiment_experimentBySlug;
+};
+
+const TableSummary = ({ experiment }: TableSummaryProps) => {
+  const { firefoxMinVersion, channels, targetingConfigSlug } = useConfig();
+
+  return (
+    <Table striped bordered className="mt-5" data-testid="table-summary">
+      <tbody>
+        <tr>
+          <th className="font-weight-bold">Experiment Owner</th>
+          <td data-testid="experiment-owner">
+            {experiment.owner?.email ? experiment.owner.email : notSet("Owner")}
+          </td>
+        </tr>
+        <tr>
+          <th className="font-weight-bold">
+            <b>Hypothesis</b>
+          </th>
+          <td data-testid="experiment-hypothesis">
+            {experiment.hypothesis
+              ? experiment.hypothesis
+              : notSet("Hypothesis")}
+          </td>
+        </tr>
+        <tr>
+          <th className="font-weight-bold">Probe Sets</th>
+          <td>
+            <span data-testid="experiment-probe-primary" className="d-block">
+              Primary:{" "}
+              {experiment.primaryProbeSets?.length
+                ? experiment.primaryProbeSets
+                    .map((probeSet) => probeSet?.name)
+                    .join(", ")
+                : notSet("probe")}
+            </span>
+            <span data-testid="experiment-probe-secondary">
+              Secondary:{" "}
+              {experiment.secondaryProbeSets?.length
+                ? experiment.secondaryProbeSets
+                    .map((probeSet) => probeSet?.name)
+                    .join(", ")
+                : notSet("probe")}
+            </span>
+          </td>
+        </tr>
+        <tr>
+          <th className="font-weight-bold">Audience</th>
+          <td>
+            <span data-testid="experiment-target">
+              {displayConfigLabelOrNotSet(
+                "Target audience",
+                experiment.targetingConfigSlug,
+                targetingConfigSlug,
+              )}
+              ,{" "}
+            </span>
+            <span data-testid="experiment-channels">
+              {experiment.channels?.length
+                ? experiment.channels
+                    .map((expChannel) =>
+                      displayConfigLabelOrNotSet(
+                        "channel",
+                        expChannel,
+                        channels,
+                      ),
+                    )
+                    .join(", ")
+                : notSet("channel")}
+              {", "}
+            </span>
+            <span data-testid="experiment-ff-min">
+              {displayConfigLabelOrNotSet(
+                "Firefox minimum version",
+                experiment.firefoxMinVersion,
+                firefoxMinVersion,
+              )}
+            </span>
+            <span className="d-block">
+              <span data-testid="experiment-population">
+                {experiment.populationPercent
+                  ? `${experiment.populationPercent}% of population`
+                  : notSet("Population percentage")}
+              </span>
+              <span data-testid="experiment-total-enrolled">
+                {" "}
+                totalling{" "}
+                {experiment.totalEnrolledClients
+                  ? `${experiment.totalEnrolledClients.toLocaleString()} expected enrolled clients`
+                  : notSet("expected enrolled clients")}
+              </span>
+            </span>
+          </td>
+        </tr>
+        <tr>
+          <th className="font-weight-bold">Duration</th>
+          <td>
+            <span data-testid="experiment-duration">
+              {displayDaysOrNotSet(
+                "Proposed duration",
+                experiment.proposedDuration,
+              )}{" "}
+            </span>
+            <span data-testid="experiment-enrollment">
+              over an enrollment period of{" "}
+              {displayDaysOrNotSet(
+                "proposed enrollment",
+                experiment.proposedEnrollment,
+              )}
+            </span>
+          </td>
+        </tr>
+      </tbody>
+    </Table>
+  );
+};
+
+type displayConfigOptionsProps =
+  | getConfig_nimbusConfig["firefoxMinVersion"]
+  | getConfig_nimbusConfig["channels"]
+  | getConfig_nimbusConfig["targetingConfigSlug"];
+
+const displayConfigLabelOrNotSet = (
+  description: string,
+  value: string | null,
+  options: displayConfigOptionsProps,
+) => {
+  if (!value) return notSet(description);
+  const label = options?.find((obj: any) => obj.value === value)?.label;
+  return label;
+};
+
+const displayDaysOrNotSet = (
+  description: string,
+  numberOfDays: number | null,
+) => {
+  if (!numberOfDays) return notSet(description);
+  if (numberOfDays === 1) {
+    return `${numberOfDays} day`;
+  } else {
+    return `${numberOfDays} days`;
+  }
+};
+
+const notSet = (description: string) => (
+  <span className="text-danger">{`${description} not set`}</span>
+);
+
+export default TableSummary;

--- a/app/experimenter/nimbus-ui/src/gql/experiments.ts
+++ b/app/experimenter/nimbus-ui/src/gql/experiments.ts
@@ -40,6 +40,9 @@ export const GET_EXPERIMENT_QUERY = gql`
   query getExperiment($slug: String!) {
     experimentBySlug(slug: $slug) {
       id
+      owner {
+        email
+      }
       name
       slug
       status
@@ -91,6 +94,7 @@ export const GET_EXPERIMENT_QUERY = gql`
       populationPercent
       totalEnrolledClients
       proposedEnrollment
+      proposedDuration
     }
   }
 `;

--- a/app/experimenter/nimbus-ui/src/lib/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/lib/mocks.tsx
@@ -50,6 +50,11 @@ export const MOCK_CONFIG: getConfig_nimbusConfig = {
       label: "Desktop Beta",
       value: "DESKTOP_BETA",
     },
+    {
+      __typename: "NimbusLabelValueType",
+      label: "Desktop Nightly",
+      value: "DESKTOP_NIGHTLY",
+    },
   ],
   featureConfig: [
     {
@@ -114,8 +119,8 @@ export const MOCK_CONFIG: getConfig_nimbusConfig = {
   targetingConfigSlug: [
     {
       __typename: "NimbusLabelValueType",
-      label: "First Run",
-      value: "FIRST_RUN",
+      label: "Us Only",
+      value: "US_ONLY",
     },
   ],
 };
@@ -229,6 +234,10 @@ export const mockExperimentQuery = (
           {
             __typename: "NimbusExperimentType",
             id: "1",
+            owner: {
+              __typename: "NimbusExperimentOwner",
+              email: "example@mozilla.com",
+            },
             name: "Open-architected background installation",
             slug,
             status: "DRAFT",
@@ -268,16 +277,17 @@ export const mockExperimentQuery = (
             secondaryProbeSets: [
               {
                 __typename: "NimbusProbeSetType",
-                slug: "enterprise-wide-exuding-focus-group",
-                name: "Enterprise-wide exuding focus group",
+                slug: "public-key-intangible-graphical-user-interface",
+                name: "Public-key intangible Graphical User Interface",
               },
             ],
-            channels: ["Nightly", "Beta"],
-            firefoxMinVersion: "A_83_",
+            channels: ["DESKTOP_NIGHTLY", "DESKTOP_BETA"],
+            firefoxMinVersion: "FIREFOX_80",
             targetingConfigSlug: "US_ONLY",
             populationPercent: 40,
             totalEnrolledClients: 68000,
-            proposedEnrollment: 15,
+            proposedEnrollment: 1,
+            proposedDuration: 28,
           },
           modifications,
         );

--- a/app/experimenter/nimbus-ui/src/types/getExperiment.ts
+++ b/app/experimenter/nimbus-ui/src/types/getExperiment.ts
@@ -9,6 +9,11 @@ import { NimbusExperimentStatus, NimbusExperimentApplication, NimbusFeatureConfi
 // GraphQL query operation: getExperiment
 // ====================================================
 
+export interface getExperiment_experimentBySlug_owner {
+  __typename: "NimbusExperimentOwner";
+  email: string;
+}
+
 export interface getExperiment_experimentBySlug_referenceBranch {
   __typename: "NimbusBranchType";
   name: string;
@@ -54,6 +59,7 @@ export interface getExperiment_experimentBySlug_secondaryProbeSets {
 export interface getExperiment_experimentBySlug {
   __typename: "NimbusExperimentType";
   id: string;
+  owner: getExperiment_experimentBySlug_owner | null;
   name: string;
   slug: string;
   status: NimbusExperimentStatus | null;
@@ -71,6 +77,7 @@ export interface getExperiment_experimentBySlug {
   populationPercent: number | null;
   totalEnrolledClients: number;
   proposedEnrollment: number | null;
+  proposedDuration: number | null;
 }
 
 export interface getExperiment {


### PR DESCRIPTION
This commit:
* Adds a TableSummary component to display experiment data on the request review page
* Adds owner and proposedDuration to getExperimentBySlug query
* Updates mocks as needed
* Renames PageEditContainer to ContainerEditPage

Because:
* We want to see a summary of the experiment on this page as well as on the Results page later

--

Got us a head start on EXP-524 / #3833 too.