### PR TITLE
fix(nimbus): update out-of-date types

### DIFF
--- a/app/experimenter/nimbus-ui/src/gql/experiments.ts
+++ b/app/experimenter/nimbus-ui/src/gql/experiments.ts
@@ -74,7 +74,12 @@ export const GET_EXPERIMENT_QUERY = gql`
         schema
       }
 
-      probeSets {
+      primaryProbeSets {
+        slug
+        name
+      }
+
+      secondaryProbeSets {
         slug
         name
       }

--- a/app/experimenter/nimbus-ui/src/lib/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/lib/mocks.tsx
@@ -59,7 +59,7 @@ export const MOCK_CONFIG: getConfig_nimbusConfig = {
       slug: "up-sized-cohesive-complexity",
       description:
         "Quickly above also mission action. Become thing item institution plan.\nImpact friend wonder. Interview strategy nature question. Admit room without impact its enter forward.",
-      application: NimbusFeatureConfigApplication.REFERENCE_BROWSER,
+      application: NimbusFeatureConfigApplication.FENIX,
       ownerEmail: "sheila43@yahoo.com",
       schema: null,
     },
@@ -258,7 +258,14 @@ export const mockExperimentQuery = (
                 featureEnabled: true,
               },
             ],
-            probeSets: [
+            primaryProbeSets: [
+              {
+                __typename: "NimbusProbeSetType",
+                slug: "enterprise-wide-exuding-focus-group",
+                name: "Enterprise-wide exuding focus group",
+              },
+            ],
+            secondaryProbeSets: [
               {
                 __typename: "NimbusProbeSetType",
                 slug: "enterprise-wide-exuding-focus-group",

--- a/app/experimenter/nimbus-ui/src/types/getExperiment.ts
+++ b/app/experimenter/nimbus-ui/src/types/getExperiment.ts
@@ -39,7 +39,13 @@ export interface getExperiment_experimentBySlug_featureConfig {
   schema: string | null;
 }
 
-export interface getExperiment_experimentBySlug_probeSets {
+export interface getExperiment_experimentBySlug_primaryProbeSets {
+  __typename: "NimbusProbeSetType";
+  slug: string;
+  name: string;
+}
+
+export interface getExperiment_experimentBySlug_secondaryProbeSets {
   __typename: "NimbusProbeSetType";
   slug: string;
   name: string;
@@ -57,7 +63,8 @@ export interface getExperiment_experimentBySlug {
   referenceBranch: getExperiment_experimentBySlug_referenceBranch | null;
   treatmentBranches: (getExperiment_experimentBySlug_treatmentBranches | null)[] | null;
   featureConfig: getExperiment_experimentBySlug_featureConfig | null;
-  probeSets: getExperiment_experimentBySlug_probeSets[];
+  primaryProbeSets: (getExperiment_experimentBySlug_primaryProbeSets | null)[] | null;
+  secondaryProbeSets: (getExperiment_experimentBySlug_secondaryProbeSets | null)[] | null;
   channels: (NimbusExperimentChannel | null)[] | null;
   firefoxMinVersion: NimbusExperimentFirefoxMinVersion | null;
   targetingConfigSlug: NimbusExperimentTargetingConfigSlug | null;

--- a/app/experimenter/nimbus-ui/src/types/globalTypes.ts
+++ b/app/experimenter/nimbus-ui/src/types/globalTypes.ts
@@ -10,7 +10,6 @@
 export enum NimbusExperimentApplication {
   DESKTOP = "DESKTOP",
   FENIX = "FENIX",
-  REFERENCE = "REFERENCE",
 }
 
 export enum NimbusExperimentChannel {
@@ -67,7 +66,6 @@ export enum NimbusExperimentTargetingConfigSlug {
 export enum NimbusFeatureConfigApplication {
   FENIX = "FENIX",
   FIREFOX_DESKTOP = "FIREFOX_DESKTOP",
-  REFERENCE_BROWSER = "REFERENCE_BROWSER",
 }
 
 /**


### PR DESCRIPTION
Nimbus experiments are currently borked on main due to changing `probeSets` to `primaryProbeSets` and `secondaryProbeSets`.