### PR TITLE
fixes #3893 fix(nimbus): Add cache to PageNew story for useConfig hook

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/PageNew/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageNew/index.stories.tsx
@@ -5,7 +5,7 @@
 import React from "react";
 import { Operation } from "@apollo/client";
 import { MockedProvider } from "@apollo/client/testing";
-import { SimulatedMockLink } from "../../lib/mocks";
+import { createCache, SimulatedMockLink } from "../../lib/mocks";
 import { storiesOf } from "@storybook/react";
 import { action } from "@storybook/addon-actions";
 import { CREATE_EXPERIMENT_MUTATION } from "../../gql/experiments";
@@ -48,7 +48,7 @@ const mkSimulatedQueries = ({
 const Subject = ({ simulatedQueries = mkSimulatedQueries() }) => {
   const mockLink = new SimulatedMockLink(simulatedQueries, false);
   return (
-    <MockedProvider link={mockLink} addTypename={false}>
+    <MockedProvider link={mockLink} addTypename={false} cache={createCache()}>
       <PageNew />
     </MockedProvider>
   );


### PR DESCRIPTION
Because:
* The PageNew story is broken and needs access to the mock config object.

This commit:
* Adds the default cache to MockedProvider.

---

I noticed even with this fix, PageNew will error on submission and per https://github.com/mozilla/experimenter/pull/3843#discussion_r517555131 it should not. I filed an issue (#3896) for that.