### PR TITLE
chore(project): enable storybook ci task for main branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,10 +117,6 @@ workflows:
           name: publish_storybooks
           requires:
             - build
-          filters:
-            branches:
-              ignore:
-                - main
       - integration:
           name: integration
           requires:


### PR DESCRIPTION
Because:

* We'd like to be able to compare storybooks between main branch and
  other branches (e.g. PRs)

This commit

* Enables publish_storybooks for main branch in CI