### PR TITLE
fixes #3479 feat(nimbus): add ability to send review request

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/FormRequestReview/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/FormRequestReview/index.stories.tsx
@@ -1,0 +1,16 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from "react";
+import { storiesOf } from "@storybook/react";
+import { withLinks } from "@storybook/addon-links";
+import { Subject } from "./mocks";
+import { action } from "@storybook/addon-actions";
+
+const onSubmit = action("onSubmit");
+
+storiesOf("components/FormRequestReview", module)
+  .addDecorator(withLinks)
+  .add("success", () => <Subject {...{ onSubmit }} />)
+  .add("error", () => <Subject {...{ onSubmit, submitError: "Uh oh!" }} />);

--- a/app/experimenter/nimbus-ui/src/components/FormRequestReview/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/FormRequestReview/index.tsx
@@ -1,0 +1,84 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React, { useState } from "react";
+import { Alert, Form } from "react-bootstrap";
+
+type FormRequestReviewProps = {
+  isLoading: boolean;
+  submitError: string | null;
+  onSubmit: () => void;
+};
+
+const checkboxLabels = [
+  "I have gone through the experiment onboarding program",
+  "I understand the risks associated with launching an experiment",
+];
+
+const FormRequestReview = ({
+  isLoading,
+  submitError,
+  onSubmit,
+}: FormRequestReviewProps) => {
+  const [checkedBoxes, setCheckedBoxes] = useState<string[]>([]);
+  const allBoxesChecked = checkboxLabels.every((element) =>
+    checkedBoxes.includes(element),
+  );
+
+  const handleConfirmChange = (labelText: string) => (
+    event: React.ChangeEvent<HTMLInputElement>,
+  ) => {
+    event.persist();
+    setCheckedBoxes((existing) => {
+      if (event.target.checked) {
+        return [...existing, labelText];
+      } else {
+        return [...existing.filter((text) => text !== labelText)];
+      }
+    });
+  };
+
+  return (
+    <Form className="py-2">
+      {submitError && (
+        <Alert data-testid="submit-error" variant="warning">
+          {submitError}
+        </Alert>
+      )}
+
+      <Form.Row className="my-3">
+        {checkboxLabels.map((labelText, index) => (
+          <Form.Group
+            key={index}
+            className="w-100"
+            controlId={`checkbox-${index}`}
+          >
+            <Form.Check
+              type="checkbox"
+              label={labelText}
+              onChange={handleConfirmChange(labelText)}
+              {...{ "data-testid": "required-checkbox" }}
+            />
+          </Form.Group>
+        ))}
+      </Form.Row>
+
+      <div className="d-flex bd-highlight">
+        <div className="py-2">
+          <button
+            data-testid="submit-button"
+            type="button"
+            className="btn btn-secondary"
+            disabled={isLoading || !allBoxesChecked}
+            onClick={onSubmit}
+          >
+            Launch
+          </button>
+        </div>
+      </div>
+    </Form>
+  );
+};
+
+export default FormRequestReview;

--- a/app/experimenter/nimbus-ui/src/components/FormRequestReview/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/components/FormRequestReview/mocks.tsx
@@ -1,0 +1,35 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from "react";
+import FormRequestReview from ".";
+import { MockedCache, mockExperimentQuery } from "../../lib/mocks";
+import { NimbusExperimentStatus } from "../../types/globalTypes";
+
+export const Subject = ({
+  isLoading = false,
+  submitError = null,
+  onSubmit = () => {},
+  status = NimbusExperimentStatus.DRAFT,
+}: Partial<React.ComponentProps<typeof FormRequestReview>> & {
+  status?: NimbusExperimentStatus;
+}) => {
+  const { mock } = mockExperimentQuery("demo-slug", {
+    status,
+  });
+
+  return (
+    <div className="p-5">
+      <MockedCache mocks={[mock]}>
+        <FormRequestReview
+          {...{
+            isLoading,
+            submitError,
+            onSubmit,
+          }}
+        />
+      </MockedCache>
+    </div>
+  );
+};

--- a/app/experimenter/nimbus-ui/src/components/PageNew/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageNew/index.stories.tsx
@@ -4,8 +4,7 @@
 
 import React from "react";
 import { Operation } from "@apollo/client";
-import { MockedProvider } from "@apollo/client/testing";
-import { createCache, SimulatedMockLink } from "../../lib/mocks";
+import { MockedCache, SimulatedMockLink } from "../../lib/mocks";
 import { storiesOf } from "@storybook/react";
 import { action } from "@storybook/addon-actions";
 import { CREATE_EXPERIMENT_MUTATION } from "../../gql/experiments";
@@ -48,8 +47,8 @@ const mkSimulatedQueries = ({
 const Subject = ({ simulatedQueries = mkSimulatedQueries() }) => {
   const mockLink = new SimulatedMockLink(simulatedQueries, false);
   return (
-    <MockedProvider link={mockLink} addTypename={false} cache={createCache()}>
+    <MockedCache link={mockLink} addTypename={false}>
       <PageNew />
-    </MockedProvider>
+    </MockedCache>
   );
 };

--- a/app/experimenter/nimbus-ui/src/components/PageRequestReview/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageRequestReview/index.stories.tsx
@@ -8,13 +8,31 @@ import { RouterSlugProvider } from "../../lib/test-utils";
 import { withLinks } from "@storybook/addon-links";
 import PageRequestReview from ".";
 import { mockExperimentQuery } from "../../lib/mocks";
+import { NimbusExperimentStatus } from "../../types/globalTypes";
+import { createMutationMock } from "./mocks";
 
-const { mock } = mockExperimentQuery("demo-slug");
+const { mock, data } = mockExperimentQuery("demo-slug");
 
 storiesOf("pages/RequestReview", module)
   .addDecorator(withLinks)
-  .add("basic", () => (
+  .add("success", () => (
+    <RouterSlugProvider mocks={[mock, createMutationMock(data!.id)]}>
+      <PageRequestReview />
+    </RouterSlugProvider>
+  ))
+  .add("error", () => (
     <RouterSlugProvider mocks={[mock]}>
       <PageRequestReview />
     </RouterSlugProvider>
-  ));
+  ))
+  .add("non-reviewable", () => {
+    const { mock } = mockExperimentQuery("demo-slug", {
+      status: NimbusExperimentStatus.ACCEPTED,
+    });
+
+    return (
+      <RouterSlugProvider mocks={[mock]}>
+        <PageRequestReview />
+      </RouterSlugProvider>
+    );
+  });

--- a/app/experimenter/nimbus-ui/src/components/PageRequestReview/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageRequestReview/index.test.tsx
@@ -3,19 +3,151 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React from "react";
-import { render, screen, waitFor } from "@testing-library/react";
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import PageRequestReview from ".";
 import { RouterSlugProvider } from "../../lib/test-utils";
 import { mockExperimentQuery } from "../../lib/mocks";
+import { NimbusExperimentStatus } from "../../types/globalTypes";
+import { createMutationMock } from "./mocks";
 
 describe("PageRequestReview", () => {
+  async function checkRequiredBoxes() {
+    const checkboxes = screen.queryAllByTestId("required-checkbox");
+
+    for (const checkbox of checkboxes) {
+      await act(async () => void fireEvent.click(checkbox));
+    }
+  }
+
   it("renders as expected", async () => {
     const { mock } = mockExperimentQuery("demo-slug");
     render(<Subject mocks={[mock]} />);
+    let submitButton: HTMLButtonElement;
     await waitFor(() => {
       expect(screen.getByTestId("PageRequestReview")).toBeInTheDocument();
+      submitButton = screen.getByText("Launch") as HTMLButtonElement;
     });
     expect(screen.getByTestId("table-summary")).toBeInTheDocument();
+    await checkRequiredBoxes();
+    expect(submitButton!).toBeEnabled();
+    await checkRequiredBoxes();
+    expect(submitButton!).toBeDisabled();
+  });
+
+  it("can submit for review", async () => {
+    const { mock, data } = mockExperimentQuery("demo-slug", {
+      status: NimbusExperimentStatus.DRAFT,
+    });
+    const mutationMock = createMutationMock(data!.id);
+
+    render(<Subject mocks={[mock, mutationMock]} />);
+    let submitButton: HTMLButtonElement;
+    await waitFor(
+      () => (submitButton = screen.getByText("Launch") as HTMLButtonElement),
+    );
+    await checkRequiredBoxes();
+    await act(async () => void fireEvent.click(submitButton));
+    await waitFor(() =>
+      expect(screen.getByTestId("in-review-label")).toBeInTheDocument(),
+    );
+  });
+
+  it("handles submission with bad server data", async () => {
+    const { mock, data } = mockExperimentQuery("demo-slug", {
+      status: NimbusExperimentStatus.DRAFT,
+    });
+    const mutationMock = createMutationMock(data!.id);
+    // @ts-ignore - intentionally breaking this type for error handling
+    delete mutationMock.result.data.updateExperimentStatus;
+    render(<Subject mocks={[mock, mutationMock]} />);
+    let submitButton: HTMLButtonElement;
+    await waitFor(
+      () => (submitButton = screen.getByText("Launch") as HTMLButtonElement),
+    );
+    await checkRequiredBoxes();
+    await act(async () => void fireEvent.click(submitButton));
+    await waitFor(() =>
+      expect(screen.getByTestId("submit-error")).toBeInTheDocument(),
+    );
+  });
+
+  it("handles submission with server API error", async () => {
+    const { mock, data } = mockExperimentQuery("demo-slug", {
+      status: NimbusExperimentStatus.DRAFT,
+    });
+    const mutationMock = createMutationMock(data!.id);
+    mutationMock.result.errors = [new Error("Boo")];
+    render(<Subject mocks={[mock, mutationMock]} />);
+    let submitButton: HTMLButtonElement;
+    await waitFor(
+      () => (submitButton = screen.getByText("Launch") as HTMLButtonElement),
+    );
+    await checkRequiredBoxes();
+    await act(async () => void fireEvent.click(submitButton));
+    await waitFor(() =>
+      expect(screen.getByTestId("submit-error")).toBeInTheDocument(),
+    );
+  });
+
+  it("handles submission with server-side validation errors", async () => {
+    const { mock, data } = mockExperimentQuery("demo-slug", {
+      status: NimbusExperimentStatus.DRAFT,
+    });
+    const mutationMock = createMutationMock(data!.id);
+    const errorMessage =
+      "Nimbus Experiments can only transition from DRAFT to REVIEW.";
+    mutationMock.result.data.updateExperimentStatus.message = {
+      status: [errorMessage],
+    };
+    render(<Subject mocks={[mock, mutationMock]} />);
+    let submitButton: HTMLButtonElement;
+    await waitFor(
+      () => (submitButton = screen.getByText("Launch") as HTMLButtonElement),
+    );
+    await checkRequiredBoxes();
+    await act(async () => void fireEvent.click(submitButton));
+    await waitFor(() => {
+      expect(screen.getByTestId("submit-error")).toBeInTheDocument();
+      expect(screen.getByTestId("submit-error")).toHaveTextContent(
+        errorMessage,
+      );
+    });
+  });
+
+  it("will not allow submitting if already in review", async () => {
+    const { mock } = mockExperimentQuery("demo-slug", {
+      status: NimbusExperimentStatus.REVIEW,
+    });
+    render(<Subject mocks={[mock]} />);
+    await waitFor(() =>
+      expect(screen.getByTestId("in-review-label")).toBeInTheDocument(),
+    );
+  });
+
+  it("will not allow submitting if already accepted", async () => {
+    const { mock } = mockExperimentQuery("demo-slug", {
+      status: NimbusExperimentStatus.ACCEPTED,
+    });
+    render(<Subject mocks={[mock]} />);
+    await waitFor(() =>
+      expect(screen.getByTestId("cant-review-label")).toBeInTheDocument(),
+    );
+  });
+
+  it("will not allow submitting if already complete", async () => {
+    const { mock } = mockExperimentQuery("demo-slug", {
+      status: NimbusExperimentStatus.COMPLETE,
+    });
+    render(<Subject mocks={[mock]} />);
+    await waitFor(() =>
+      expect(screen.getByTestId("cant-review-label")).toBeInTheDocument(),
+    );
   });
 });
 

--- a/app/experimenter/nimbus-ui/src/components/PageRequestReview/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageRequestReview/index.tsx
@@ -2,17 +2,102 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from "react";
+import React, { useCallback, useRef, useState } from "react";
+import { useMutation } from "@apollo/client";
 import { RouteComponentProps } from "@reach/router";
 import ContainerEditPage from "../ContainerEditPage";
 import TableSummary from "../TableSummary";
+import { SUBMIT_ERROR } from "../../lib/constants";
+import { UPDATE_EXPERIMENT_STATUS_MUTATION } from "../../gql/experiments";
+import {
+  UpdateExperimentStatusInput,
+  NimbusExperimentStatus,
+} from "../../types/globalTypes";
+import { updateExperimentStatus_updateExperimentStatus as UpdateExperimentStatus } from "../../types/updateExperimentStatus";
+import { getExperiment_experimentBySlug } from "../../types/getExperiment";
+import FormRequestReview from "../FormRequestReview";
 
 type PageRequestReviewProps = {} & RouteComponentProps;
 
-const PageRequestReview: React.FunctionComponent<PageRequestReviewProps> = () => (
-  <ContainerEditPage title="Review &#38; Launch" testId="PageRequestReview">
-    {({ experiment }) => <TableSummary {...{ experiment }} />}
-  </ContainerEditPage>
-);
+const PageRequestReview: React.FunctionComponent<PageRequestReviewProps> = () => {
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const [submitSuccess, setSubmitSuccess] = useState<boolean>(false);
+  const currentExperiment = useRef<getExperiment_experimentBySlug>();
+
+  const [submitForReview, { loading }] = useMutation<
+    { updateExperimentStatus: UpdateExperimentStatus },
+    { input: UpdateExperimentStatusInput }
+  >(UPDATE_EXPERIMENT_STATUS_MUTATION);
+
+  const onLaunchClicked = useCallback(async () => {
+    try {
+      const result = await submitForReview({
+        variables: {
+          input: {
+            nimbusExperimentId: parseInt(currentExperiment.current!.id),
+            status: NimbusExperimentStatus.REVIEW,
+          },
+        },
+      });
+
+      if (!result.data?.updateExperimentStatus) {
+        throw new Error(SUBMIT_ERROR);
+      }
+
+      const { message } = result.data.updateExperimentStatus;
+
+      if (message !== "success" && typeof message === "object") {
+        return void setSubmitError(message.status.join(", "));
+      }
+
+      setSubmitSuccess(true);
+    } catch (error) {
+      setSubmitError(SUBMIT_ERROR);
+    }
+  }, [submitForReview, currentExperiment]);
+
+  return (
+    <ContainerEditPage title="Review &amp; Launch" testId="PageRequestReview">
+      {({ experiment }) => {
+        currentExperiment.current = experiment;
+
+        return (
+          <>
+            <TableSummary {...{ experiment }} />
+
+            {![
+              NimbusExperimentStatus.REVIEW,
+              NimbusExperimentStatus.DRAFT,
+            ].includes(experiment.status!) && (
+              <p className="my-5" data-testid="cant-review-label">
+                This experiment&apos;s status is{" "}
+                <b className="text-lowercase">{experiment.status}</b> and cannot
+                be reviewed.
+              </p>
+            )}
+
+            {(submitSuccess ||
+              experiment.status === NimbusExperimentStatus.REVIEW) && (
+              <p className="my-5" data-testid="in-review-label">
+                All set! Your experiment is now <b>waiting for review</b>.
+              </p>
+            )}
+
+            {!submitSuccess &&
+              experiment.status === NimbusExperimentStatus.DRAFT && (
+                <FormRequestReview
+                  {...{
+                    isLoading: loading,
+                    submitError,
+                    onSubmit: onLaunchClicked,
+                  }}
+                />
+              )}
+          </>
+        );
+      }}
+    </ContainerEditPage>
+  );
+};
 
 export default PageRequestReview;

--- a/app/experimenter/nimbus-ui/src/components/PageRequestReview/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageRequestReview/mocks.tsx
@@ -1,0 +1,23 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { UPDATE_EXPERIMENT_STATUS_MUTATION } from "../../gql/experiments";
+import { mockExperimentMutation } from "../../lib/mocks";
+import { NimbusExperimentStatus } from "../../types/globalTypes";
+
+export function createMutationMock(id: string) {
+  return mockExperimentMutation(
+    UPDATE_EXPERIMENT_STATUS_MUTATION,
+    {
+      nimbusExperimentId: parseInt(id),
+      status: NimbusExperimentStatus.REVIEW,
+    },
+    "updateExperimentStatus",
+    {
+      experiment: {
+        status: NimbusExperimentStatus.REVIEW,
+      },
+    },
+  );
+}

--- a/app/experimenter/nimbus-ui/src/gql/experiments.ts
+++ b/app/experimenter/nimbus-ui/src/gql/experiments.ts
@@ -36,13 +36,23 @@ export const UPDATE_EXPERIMENT_OVERVIEW_MUTATION = gql`
   }
 `;
 
+export const UPDATE_EXPERIMENT_STATUS_MUTATION = gql`
+  mutation updateExperimentStatus($input: UpdateExperimentStatusInput!) {
+    updateExperimentStatus(input: $input) {
+      clientMutationId
+      message
+      status
+      nimbusExperiment {
+        status
+      }
+    }
+  }
+`;
+
 export const GET_EXPERIMENT_QUERY = gql`
   query getExperiment($slug: String!) {
     experimentBySlug(slug: $slug) {
       id
-      owner {
-        email
-      }
       name
       slug
       status
@@ -50,6 +60,10 @@ export const GET_EXPERIMENT_QUERY = gql`
       hypothesis
       application
       publicDescription
+
+      owner {
+        email
+      }
 
       referenceBranch {
         name

--- a/app/experimenter/nimbus-ui/src/lib/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/lib/mocks.tsx
@@ -29,6 +29,8 @@ export interface MockedProps {
   childProps?: object;
   children?: React.ReactElement;
   mocks?: MockedResponse<Record<string, any>>[];
+  addTypename?: boolean;
+  link?: ApolloLink;
 }
 
 export interface MockedState {
@@ -147,7 +149,9 @@ export class MockedCache extends React.Component<MockedProps, MockedState> {
     this.state = {
       client: new ApolloClient({
         cache: createCache(props),
-        link: new MockLink(props.mocks || [], true),
+        link:
+          props.link ||
+          new MockLink(props.mocks || [], props.addTypename || true),
       }),
     };
   }
@@ -312,7 +316,7 @@ export const mockExperimentQuery = (
 
 export const mockExperimentMutation = (
   mutation: DocumentNode,
-  input: Record<string, string>,
+  input: Record<string, string | number>,
   key: string,
   {
     status = 200,

--- a/app/experimenter/nimbus-ui/src/types/getExperiment.ts
+++ b/app/experimenter/nimbus-ui/src/types/getExperiment.ts
@@ -59,13 +59,13 @@ export interface getExperiment_experimentBySlug_secondaryProbeSets {
 export interface getExperiment_experimentBySlug {
   __typename: "NimbusExperimentType";
   id: string;
-  owner: getExperiment_experimentBySlug_owner | null;
   name: string;
   slug: string;
   status: NimbusExperimentStatus | null;
   hypothesis: string | null;
   application: NimbusExperimentApplication | null;
   publicDescription: string | null;
+  owner: getExperiment_experimentBySlug_owner | null;
   referenceBranch: getExperiment_experimentBySlug_referenceBranch | null;
   treatmentBranches: (getExperiment_experimentBySlug_treatmentBranches | null)[] | null;
   featureConfig: getExperiment_experimentBySlug_featureConfig | null;

--- a/app/experimenter/nimbus-ui/src/types/globalTypes.ts
+++ b/app/experimenter/nimbus-ui/src/types/globalTypes.ts
@@ -19,7 +19,6 @@ export enum NimbusExperimentChannel {
   FENIX_BETA = "FENIX_BETA",
   FENIX_NIGHTLY = "FENIX_NIGHTLY",
   FENIX_RELEASE = "FENIX_RELEASE",
-  REFERENCE_RELEASE = "REFERENCE_RELEASE",
 }
 
 export enum NimbusExperimentFirefoxMinVersion {
@@ -56,7 +55,8 @@ export enum NimbusExperimentStatus {
 
 export enum NimbusExperimentTargetingConfigSlug {
   ALL_ENGLISH = "ALL_ENGLISH",
-  FIRST_RUN = "FIRST_RUN",
+  TARGETING_FIRST_RUN = "TARGETING_FIRST_RUN",
+  TARGETING_FIRST_RUN_ABOUT_WELCOME = "TARGETING_FIRST_RUN_ABOUT_WELCOME",
   US_ONLY = "US_ONLY",
 }
 
@@ -91,6 +91,12 @@ export interface UpdateExperimentInput {
   publicDescription?: string | null;
   hypothesis?: string | null;
   id: string;
+}
+
+export interface UpdateExperimentStatusInput {
+  clientMutationId?: string | null;
+  nimbusExperimentId: number;
+  status: NimbusExperimentStatus;
 }
 
 //==============================================================

--- a/app/experimenter/nimbus-ui/src/types/updateExperimentStatus.ts
+++ b/app/experimenter/nimbus-ui/src/types/updateExperimentStatus.ts
@@ -1,0 +1,34 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+import { UpdateExperimentStatusInput, NimbusExperimentStatus } from "./globalTypes";
+
+// ====================================================
+// GraphQL mutation operation: updateExperimentStatus
+// ====================================================
+
+export interface updateExperimentStatus_updateExperimentStatus_nimbusExperiment {
+  __typename: "NimbusExperimentType";
+  status: NimbusExperimentStatus | null;
+}
+
+export interface updateExperimentStatus_updateExperimentStatus {
+  __typename: "UpdateExperimentStatus";
+  clientMutationId: string | null;
+  message: any | null;
+  status: number | null;
+  nimbusExperiment: updateExperimentStatus_updateExperimentStatus_nimbusExperiment | null;
+}
+
+export interface updateExperimentStatus {
+  /**
+   * Mark a Nimubs Experiment as ready for review.
+   */
+  updateExperimentStatus: updateExperimentStatus_updateExperimentStatus | null;
+}
+
+export interface updateExperimentStatusVariables {
+  input: UpdateExperimentStatusInput;
+}


### PR DESCRIPTION
This PR updates the `PageRequestReview` component to implement the mutation and button to actually submit your experiment for review. It also adds the required checkboxes to enable the submit button.

Closes #3479 
Closes #3834