### PR TITLE
fix #3832 feat(nimbus): add review ready gql query

### DIFF
--- a/app/experimenter/experiments/api/v5/serializers.py
+++ b/app/experimenter/experiments/api/v5/serializers.py
@@ -298,3 +298,37 @@ class NimbusStatusUpdateSerializer(
     class Meta:
         model = NimbusExperiment
         fields = ("status",)
+
+
+class NimbusReadyForReviewSerializer(
+    NimbusStatusRestrictionMixin, serializers.ModelSerializer
+):
+    public_description = serializers.CharField(required=True)
+    proposed_duration = serializers.IntegerField(required=True)
+    proposed_enrollment = serializers.IntegerField(required=True)
+    population_percent = serializers.DecimalField(7, 4, required=True)
+    firefox_min_version = serializers.ChoiceField(
+        NimbusExperiment.Version.choices, required=True
+    )
+    application = serializers.ChoiceField(
+        NimbusExperiment.Application.choices, required=True
+    )
+    hypothesis = serializers.CharField(required=True)
+    targeting_config_slug = serializers.ChoiceField(
+        NimbusExperiment.TargetingConfig.choices, required=True
+    )
+    reference_branch = NimbusBranchSerializer(required=True)
+    treatment_branches = NimbusBranchSerializer(many=True)
+    feature_config = serializers.PrimaryKeyRelatedField(
+        queryset=NimbusFeatureConfig.objects.all(),
+        allow_null=True,
+    )
+
+    class Meta:
+        model = NimbusExperiment
+        exclude = ("id",)
+
+    def validate_hypothesis(self, value):
+        if value == NimbusExperiment.HYPOTHESIS_DEFAULT.strip():
+            raise serializers.ValidationError("Hypothesis cannot be the default value.")
+        return value

--- a/app/experimenter/experiments/models/nimbus.py
+++ b/app/experimenter/experiments/models/nimbus.py
@@ -114,7 +114,10 @@ class NimbusExperiment(NimbusConstants, models.Model):
 
     @property
     def treatment_branches(self):
-        return self.branches.exclude(id=self.reference_branch.id).order_by("id")
+        if self.reference_branch:
+            return self.branches.exclude(id=self.reference_branch.id).order_by("id")
+        else:
+            return self.branches.order_by("id")
 
     @property
     def primary_probe_sets(self):


### PR DESCRIPTION
Because:

* The UX needs to know when the experiment is review-ready.

This commit:

* Add's a GQL query that verifies the Nimbus experiment with the
  provided slug is ready or not.