### PR TITLE
fix #3903 feat(nimbus): include app/channel map in GQL config

### DIFF
--- a/app/experimenter/experiments/api/v5/query.py
+++ b/app/experimenter/experiments/api/v5/query.py
@@ -16,9 +16,15 @@ from experimenter.experiments.models.nimbus import (
 )
 
 
+class ApplicationChannel(graphene.ObjectType):
+    label = graphene.String()
+    channels = graphene.List(graphene.String)
+
+
 class NimbusConfigurationType(graphene.ObjectType):
     application = graphene.List(NimbusLabelValueType)
     channels = graphene.List(NimbusLabelValueType)
+    application_channels = graphene.List(ApplicationChannel)
     feature_config = graphene.List(NimbusFeatureConfigType)
     firefox_min_version = graphene.List(NimbusLabelValueType)
     probe_sets = graphene.List(NimbusProbeSetType)
@@ -50,6 +56,17 @@ class NimbusConfigurationType(graphene.ObjectType):
 
     def resolve_targeting_config_slug(root, info):
         return root._text_choices_to_label_value_list(NimbusExperiment.TargetingConfig)
+
+    def resolve_application_channels(root, info):
+        app_channels = []
+        for app_label, channel_names in NimbusExperiment.ApplicationChannels.items():
+            app_channels.append(
+                ApplicationChannel(
+                    label=app_label.label,
+                    channels=[channel.label for channel in channel_names],
+                )
+            )
+        return app_channels
 
 
 class NimbusReadyForReviewType(graphene.ObjectType):

--- a/app/experimenter/experiments/tests/api/v5/test_query.py
+++ b/app/experimenter/experiments/tests/api/v5/test_query.py
@@ -168,6 +168,10 @@ class TestNimbusQuery(GraphQLTestCase):
             """
             query{
                 nimbusConfig{
+                    applicationChannels {
+                        label
+                        channels
+                    }
                     application {
                         label
                         value
@@ -215,6 +219,16 @@ class TestNimbusQuery(GraphQLTestCase):
         assertChoices(config["targetingConfigSlug"], NimbusExperiment.TargetingConfig)
         self.assertEqual(len(config["featureConfig"]), 10)
         self.assertEqual(len(config["probeSets"]), 10)
+        app_channels = config["applicationChannels"]
+        self.assertEqual(len(app_channels), len(NimbusExperiment.ApplicationChannels))
+        # Transform list to dict for easier comparison
+        app_channel_dict = {ac["label"]: ac["channels"] for ac in app_channels}
+        for app_label, channel_names in NimbusExperiment.ApplicationChannels.items():
+            app_compare_channels = app_channel_dict[app_label.label]
+            self.assertEqual(
+                set(app_compare_channels),
+                set(channel.label for channel in channel_names),
+            )
         for probe_set in probe_sets:
             config_probe_set = next(
                 filter(lambda p: p["id"] == str(probe_set.id), config["probeSets"])


### PR DESCRIPTION
Because:

* We want to display the appropriate channels for each application.

This commit:

* Includes a label mapping of application label to the channel labels
  in the GQL config query.