### PR TITLE
fix #3905 feat(nimbus): validate channels for experiment mutation

### DIFF
--- a/app/experimenter/experiments/api/v5/serializers.py
+++ b/app/experimenter/experiments/api/v5/serializers.py
@@ -284,6 +284,21 @@ class NimbusAudienceUpdateSerializer(
             "total_enrolled_clients",
         )
 
+    def validate_channels(self, value):
+        # If we have an instance, we can validate the channels against the application
+        if value and self.instance and self.instance.application:
+            valid_channels = set(
+                channel.value
+                for channel in NimbusExperiment.ApplicationChannels[
+                    self.instance.application
+                ]
+            )
+            if not valid_channels.issuperset(set(value)):
+                raise serializers.ValidationError(
+                    "Invalid channels for experiment application."
+                )
+        return value
+
 
 class NimbusStatusUpdateSerializer(
     NimbusChangeLogMixin, NimbusStatusRestrictionMixin, serializers.ModelSerializer

--- a/app/experimenter/experiments/tests/api/v5/test_mutation.py
+++ b/app/experimenter/experiments/tests/api/v5/test_mutation.py
@@ -394,6 +394,7 @@ class TestMutations(GraphQLTestCase):
         experiment = NimbusExperimentFactory.create(
             status=NimbusExperiment.Status.DRAFT,
             channels=[],
+            application=NimbusConstants.Application.DESKTOP,
             firefox_min_version=None,
             population_percent=None,
             proposed_duration=None,

--- a/app/experimenter/experiments/tests/api/v5/test_serializers.py
+++ b/app/experimenter/experiments/tests/api/v5/test_serializers.py
@@ -552,6 +552,7 @@ class TestNimbusAudienceUpdateSerializer(TestCase):
         user = UserFactory()
         experiment = NimbusExperimentFactory(
             channels=[],
+            application=NimbusExperiment.Application.DESKTOP,
             firefox_min_version=None,
             population_percent=None,
             proposed_duration=None,
@@ -592,6 +593,40 @@ class TestNimbusAudienceUpdateSerializer(TestCase):
             NimbusConstants.TargetingConfig.ALL_ENGLISH.value,
         )
         self.assertEqual(experiment.total_enrolled_clients, 100)
+
+    def test_serializer_updates_audience_on_experiment_invalid_channels(self):
+        user = UserFactory()
+        experiment = NimbusExperimentFactory(
+            channels=[],
+            application=NimbusExperiment.Application.FENIX,
+            firefox_min_version=None,
+            population_percent=None,
+            proposed_duration=None,
+            proposed_enrollment=None,
+            targeting_config_slug=None,
+            total_enrolled_clients=0,
+        )
+        serializer = NimbusAudienceUpdateSerializer(
+            experiment,
+            {
+                "channels": [NimbusConstants.Channel.DESKTOP_BETA.value],
+                "firefox_min_version": NimbusConstants.Version.FIREFOX_80.value,
+                "population_percent": 10,
+                "proposed_duration": 42,
+                "proposed_enrollment": 120,
+                "targeting_config_slug": (
+                    NimbusConstants.TargetingConfig.ALL_ENGLISH.value
+                ),
+                "total_enrolled_clients": 100,
+            },
+            context={"user": user},
+        )
+        self.assertEqual(experiment.changes.count(), 0)
+        self.assertFalse(serializer.is_valid())
+        self.assertEqual(
+            serializer.errors,
+            {"channels": ["Invalid channels for experiment application."]},
+        )
 
 
 class TestNimbusStatusUpdateSerializer(TestCase):


### PR DESCRIPTION
Because:

* We want to avoid setting invalid channels on an experiment.

This commit:

* Adds channel validation to the audience update mutation to ensure
  submitted channels are valid for the application.