### PR TITLE
fix #3884 fix(nimbus): use set on unordered query

### DIFF
--- a/app/experimenter/experiments/tests/api/v5/test_mutation.py
+++ b/app/experimenter/experiments/tests/api/v5/test_mutation.py
@@ -360,7 +360,8 @@ class TestMutations(GraphQLTestCase):
             },
         )
         experiment = NimbusExperiment.objects.get(id=experiment.id)
-        self.assertEqual(list(experiment.probe_sets.all()), probe_sets)
+        self.assertEqual(set(experiment.probe_sets.all()), set(probe_sets))
+        # These must be compared as lists to ensure ordering is retained.
         self.assertEqual(list(experiment.primary_probe_sets), probe_sets[:2])
         self.assertEqual(list(experiment.secondary_probe_sets), probe_sets[2:])
 


### PR DESCRIPTION
Because:

* Django will return items in random order without it specified.

This commit:

* Uses a set comparison for the randomly ordered query comparison.