### PR TITLE
fixes #3477 feat(nimbus): Add useExperiment polling to Request Review page

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/ContainerEditPage/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/ContainerEditPage/index.test.tsx
@@ -4,11 +4,16 @@
 
 import React from "react";
 import { render, screen, waitFor } from "@testing-library/react";
-import ContainerEditPage from ".";
-import { RouterSlugProvider } from "../../lib/test-utils";
+import ContainerEditPage, { POLL_INTERVAL } from ".";
+import { renderWithRouter, RouterSlugProvider } from "../../lib/test-utils";
 import { mockExperimentQuery } from "../../lib/mocks";
+import { NimbusExperimentStatus } from "../../types/globalTypes";
+import { BASE_PATH } from "../../lib/constants";
+import { act } from "react-dom/test-utils";
 
-describe("PageRequestReview", () => {
+jest.useFakeTimers();
+
+describe("ContainerEditPage", () => {
   it("renders as expected", async () => {
     const { mock } = mockExperimentQuery("demo-slug");
     render(<Subject mocks={[mock]} />);
@@ -28,6 +33,76 @@ describe("PageRequestReview", () => {
     });
   });
 
+  it("polls useExperiment when the option is passed in", async () => {
+    const { mock } = mockExperimentQuery("demo-slug");
+    const { mock: updatedMock } = mockExperimentQuery("demo-slug", {
+      status: NimbusExperimentStatus.REVIEW,
+    });
+    render(<Subject mocks={[mock, updatedMock]} polling />);
+    await waitFor(() => {
+      expect(screen.getByTestId("header-experiment-status")).toHaveTextContent(
+        NimbusExperimentStatus.DRAFT,
+      );
+    });
+
+    jest.advanceTimersByTime(POLL_INTERVAL);
+    await waitFor(() => {
+      expect(screen.getByTestId("header-experiment-status")).toHaveTextContent(
+        NimbusExperimentStatus.REVIEW,
+      );
+    });
+  });
+
+  it("does not poll useExperiment when the option is not passed in", async () => {
+    const { mock } = mockExperimentQuery("demo-slug");
+    const { mock: updatedMock } = mockExperimentQuery("demo-slug", {
+      status: NimbusExperimentStatus.REVIEW,
+    });
+    render(<Subject mocks={[mock, updatedMock]} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("header-experiment-status")).toHaveTextContent(
+        NimbusExperimentStatus.DRAFT,
+      );
+    });
+
+    jest.advanceTimersByTime(POLL_INTERVAL);
+    await waitFor(() => {
+      expect(screen.getByTestId("header-experiment-status")).toHaveTextContent(
+        NimbusExperimentStatus.DRAFT,
+      );
+    });
+  });
+
+  it("stops polling useExperiment when the option is passed in and the user navigates to a page without polling", async () => {
+    const { mock } = mockExperimentQuery("demo-slug");
+    const { mock: updatedMock } = mockExperimentQuery("demo-slug", {
+      status: NimbusExperimentStatus.REVIEW,
+    });
+    const {
+      history: { navigate },
+    } = renderWithRouter(<Subject mocks={[mock, updatedMock]} polling />, {
+      route: "/demo-slug",
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("header-experiment-status")).toHaveTextContent(
+        NimbusExperimentStatus.DRAFT,
+      );
+    });
+
+    window.history.pushState({}, "", `${BASE_PATH}/demo-slug/edit/overview`);
+    await act(() => navigate("/demo-slug/edit/overview"));
+
+    jest.advanceTimersByTime(POLL_INTERVAL);
+    // updatedMock should not be hit
+    await waitFor(() => {
+      expect(screen.getByTestId("header-experiment-status")).toHaveTextContent(
+        NimbusExperimentStatus.DRAFT,
+      );
+    });
+  });
+
+  // TODO: some sort of after test cleanup, can't add tests after without errors
   it("renders loading screen", () => {
     render(<Subject />);
     expect(screen.getByTestId("page-loading")).toBeInTheDocument();
@@ -36,11 +111,17 @@ describe("PageRequestReview", () => {
 
 const Subject = ({
   mocks = [],
+  polling = false,
 }: {
   mocks?: React.ComponentProps<typeof RouterSlugProvider>["mocks"];
+  polling?: boolean;
 }) => (
   <RouterSlugProvider {...{ mocks }}>
-    <ContainerEditPage title="Howdy!" testId="ContainerEditPage">
+    <ContainerEditPage
+      title="Howdy!"
+      testId="ContainerEditPage"
+      {...{ polling }}
+    >
       {({ experiment }) => <p data-testid="child">{experiment.slug}</p>}
     </ContainerEditPage>
   </RouterSlugProvider>

--- a/app/experimenter/nimbus-ui/src/components/ContainerEditPage/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/ContainerEditPage/index.test.tsx
@@ -9,7 +9,7 @@ import { renderWithRouter, RouterSlugProvider } from "../../lib/test-utils";
 import { mockExperimentQuery } from "../../lib/mocks";
 import { NimbusExperimentStatus } from "../../types/globalTypes";
 import { BASE_PATH } from "../../lib/constants";
-import { act } from "react-dom/test-utils";
+import { act } from "@testing-library/react";
 
 jest.useFakeTimers();
 

--- a/app/experimenter/nimbus-ui/src/components/ContainerEditPage/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/ContainerEditPage/index.tsx
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from "react";
+import React, { useEffect } from "react";
 import { RouteComponentProps, useParams } from "@reach/router";
 import AppLayoutWithSidebar from "../AppLayoutWithSidebar";
 import HeaderEditExperiment from "../HeaderEditExperiment";
@@ -19,15 +19,34 @@ type ContainerEditPageProps = {
   children: (props: ContainerEditPageChildrenProps) => React.ReactNode | null;
   testId: string;
   title: string;
+  polling?: boolean;
 } & RouteComponentProps;
+
+export const POLL_INTERVAL = 30000;
 
 const ContainerEditPage = ({
   children,
   testId,
   title,
+  polling = false,
 }: ContainerEditPageProps) => {
   const { slug } = useParams();
-  const { experiment, notFound, loading } = useExperiment(slug);
+  const {
+    experiment,
+    notFound,
+    loading,
+    startPolling,
+    stopPolling,
+  } = useExperiment(slug);
+
+  useEffect(() => {
+    if (polling && experiment) {
+      startPolling(POLL_INTERVAL);
+    }
+    return () => {
+      stopPolling();
+    };
+  }, [startPolling, stopPolling, experiment, polling]);
 
   if (loading) {
     return <PageLoading />;

--- a/app/experimenter/nimbus-ui/src/components/PageRequestReview/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageRequestReview/index.stories.tsx
@@ -17,7 +17,7 @@ storiesOf("pages/RequestReview", module)
   .addDecorator(withLinks)
   .add("success", () => (
     <RouterSlugProvider mocks={[mock, createMutationMock(data!.id)]}>
-      <PageRequestReview />
+      <PageRequestReview polling={false} />
     </RouterSlugProvider>
   ))
   .add("error", () => (
@@ -32,7 +32,7 @@ storiesOf("pages/RequestReview", module)
 
     return (
       <RouterSlugProvider mocks={[mock]}>
-        <PageRequestReview />
+        <PageRequestReview polling={false} />
       </RouterSlugProvider>
     );
   });

--- a/app/experimenter/nimbus-ui/src/components/PageRequestReview/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageRequestReview/index.stories.tsx
@@ -22,7 +22,7 @@ storiesOf("pages/RequestReview", module)
   ))
   .add("error", () => (
     <RouterSlugProvider mocks={[mock]}>
-      <PageRequestReview />
+      <PageRequestReview polling={false} />
     </RouterSlugProvider>
   ))
   .add("non-reviewable", () => {

--- a/app/experimenter/nimbus-ui/src/components/PageRequestReview/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageRequestReview/index.tsx
@@ -57,7 +57,11 @@ const PageRequestReview: React.FunctionComponent<PageRequestReviewProps> = () =>
   }, [submitForReview, currentExperiment]);
 
   return (
-    <ContainerEditPage title="Review &amp; Launch" testId="PageRequestReview">
+    <ContainerEditPage
+      title="Review &amp; Launch"
+      testId="PageRequestReview"
+      polling
+    >
       {({ experiment }) => {
         currentExperiment.current = experiment;
 

--- a/app/experimenter/nimbus-ui/src/components/PageRequestReview/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageRequestReview/index.tsx
@@ -17,9 +17,13 @@ import { updateExperimentStatus_updateExperimentStatus as UpdateExperimentStatus
 import { getExperiment_experimentBySlug } from "../../types/getExperiment";
 import FormRequestReview from "../FormRequestReview";
 
-type PageRequestReviewProps = {} & RouteComponentProps;
+type PageRequestReviewProps = {
+  polling?: boolean;
+} & RouteComponentProps;
 
-const PageRequestReview: React.FunctionComponent<PageRequestReviewProps> = () => {
+const PageRequestReview: React.FunctionComponent<PageRequestReviewProps> = ({
+  polling = true,
+}) => {
   const [submitError, setSubmitError] = useState<string | null>(null);
   const [submitSuccess, setSubmitSuccess] = useState<boolean>(false);
   const currentExperiment = useRef<getExperiment_experimentBySlug>();
@@ -60,7 +64,7 @@ const PageRequestReview: React.FunctionComponent<PageRequestReviewProps> = () =>
     <ContainerEditPage
       title="Review &amp; Launch"
       testId="PageRequestReview"
-      polling
+      {...{ polling }}
     >
       {({ experiment }) => {
         currentExperiment.current = experiment;

--- a/app/experimenter/nimbus-ui/src/hooks/useExperiment.tsx
+++ b/app/experimenter/nimbus-ui/src/hooks/useExperiment.tsx
@@ -29,7 +29,7 @@ import { getExperiment } from "../types/getExperiment";
  */
 
 export function useExperiment(slug: string) {
-  const { data, loading } = useQuery<{
+  const { data, loading, startPolling, stopPolling } = useQuery<{
     experimentBySlug: getExperiment["experimentBySlug"];
   }>(GET_EXPERIMENT_QUERY, {
     variables: { slug },
@@ -42,5 +42,7 @@ export function useExperiment(slug: string) {
     experiment: experiment!,
     notFound: !loading && experiment === null,
     loading,
+    startPolling,
+    stopPolling,
   };
 }


### PR DESCRIPTION

Because:
* We want this page to always reflect up-to-date information so the user can see the status of their experiment change without refreshing.

This commit:
* Adds a 'polling' option to ContainerEditPage and passes it in from the request review page