### PR TITLE
fix #3907 chore(nimbus): make types_check should fail with graphql changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,4 +91,3 @@ app/coverage_html_report/
 
 # Dependencies
 node_modules
-

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -46,8 +46,14 @@ RUN poetry check
 COPY ./package.json /app/package.json
 COPY ./yarn.lock /app/yarn.lock
 COPY ./experimenter/legacy-ui/core/package.json /app/experimenter/legacy-ui/core/package.json
+RUN yarn install --frozen-lockfile
+
 COPY ./experimenter/legacy-ui/rapid/package.json /app/experimenter/legacy-ui/rapid/package.json
+RUN yarn install --frozen-lockfile
+
 COPY ./experimenter/legacy-ui/visualization/package.json /app/experimenter/legacy-ui/visualization/package.json
+RUN yarn install --frozen-lockfile
+
 COPY ./experimenter/nimbus-ui/package.json /app/experimenter/nimbus-ui/package.json
 RUN yarn install --frozen-lockfile
 

--- a/app/experimenter/nimbus-ui/README.md
+++ b/app/experimenter/nimbus-ui/README.md
@@ -51,7 +51,7 @@ You can read up over on their page if you want to know all the details, but if y
 
 All of our GraphQL resolvers produce types that are compatible with TypeScript, so there is no need to write new types for the queries you perform with Apollo.
 
-To generate types, just run `yarn types`. This will generate type declarations inside a `types/` directory at the root of this app. Once generated you can import and use as you see fit.
+To generate types, just run `yarn generate-types`. This will generate type declarations inside a `types/` directory at the root of this app. Once generated you can import and use as you see fit.  If there are changes to the graphql API on the server, run `make generate_types` to export the server schema and update the typescript stubs.
 
 For example, a query that looks like this:
 
@@ -84,8 +84,6 @@ export interface GetExperimentOverviews {
   experiments: (GetExperimentOverviews_experiments | null)[] | null;
 }
 ```
-
-**Note**: this command performs introspection on the GraphQL endpoint, so your local server must be running for it to work.
 
 ## Error handling
 

--- a/app/experimenter/nimbus-ui/apollo.config.js
+++ b/app/experimenter/nimbus-ui/apollo.config.js
@@ -1,0 +1,9 @@
+module.exports = {
+  client: {
+    service: {
+      name: 'experimenter',
+      localSchemaFile: './schema.graphql'
+    }
+  }
+};
+

--- a/app/experimenter/nimbus-ui/package.json
+++ b/app/experimenter/nimbus-ui/package.json
@@ -15,8 +15,7 @@
     "storybook": "start-storybook -p 3001",
     "build-storybook": "build-storybook",
     "eject": "react-scripts eject",
-    "types-check": "NODE_TLS_REJECT_UNAUTHORIZED=0 apollo codegen:generate --target typescript --endpoint http://localhost:7001/api/v5/graphql --outputFlat /dev/null",
-    "types-generate": "NODE_TLS_REJECT_UNAUTHORIZED=0 apollo codegen:generate --target typescript --endpoint http://localhost:7001/api/v5/graphql --outputFlat src/types"
+    "generate-types": "apollo codegen:generate --target typescript --outputFlat src/types"
   },
   "jest": {
     "collectCoverageFrom": [

--- a/app/experimenter/nimbus-ui/schema.graphql
+++ b/app/experimenter/nimbus-ui/schema.graphql
@@ -1,0 +1,323 @@
+schema {
+  query: Query
+  mutation: Mutation
+}
+
+type ApplicationChannel {
+  label: String
+  channels: [String]
+}
+
+type CreateExperiment {
+  clientMutationId: String
+  nimbusExperiment: NimbusExperimentType
+  message: ObjectField
+  status: Int
+}
+
+input CreateExperimentInput {
+  clientMutationId: String
+  name: String!
+  application: NimbusExperimentApplication!
+  publicDescription: String
+  hypothesis: String!
+}
+
+scalar Decimal
+
+type Mutation {
+  createExperiment(input: CreateExperimentInput!): CreateExperiment
+  updateExperimentOverview(input: UpdateExperimentInput!): UpdateExperimentOverview
+  updateExperimentBranches(input: UpdateExperimentBranchesInput!): UpdateExperimentBranches
+  updateExperimentProbeSets(input: UpdateExperimentProbeSetsInput!): UpdateExperimentProbeSets
+  updateExperimentAudience(input: UpdateExperimentAudienceInput!): UpdateExperimentAudience
+  updateExperimentStatus(input: UpdateExperimentStatusInput!): UpdateExperimentStatus
+}
+
+type NimbusBranchType {
+  name: String!
+  slug: String!
+  description: String!
+  ratio: Int!
+  featureEnabled: Boolean!
+  featureValue: String
+}
+
+type NimbusBucketRangeType {
+  isolationGroup: NimbusIsolationGroupType!
+  start: Int!
+  count: Int!
+}
+
+type NimbusConfigurationType {
+  application: [NimbusLabelValueType]
+  channels: [NimbusLabelValueType]
+  applicationChannels: [ApplicationChannel]
+  featureConfig: [NimbusFeatureConfigType]
+  firefoxMinVersion: [NimbusLabelValueType]
+  probeSets: [NimbusProbeSetType]
+  targetingConfigSlug: [NimbusLabelValueType]
+}
+
+enum NimbusExperimentApplication {
+  DESKTOP
+  FENIX
+}
+
+enum NimbusExperimentChannel {
+  DESKTOP_BETA
+  DESKTOP_NIGHTLY
+  DESKTOP_RELEASE
+  FENIX_BETA
+  FENIX_NIGHTLY
+  FENIX_RELEASE
+}
+
+enum NimbusExperimentFirefoxMinVersion {
+  FIREFOX_80
+  FIREFOX_81
+  FIREFOX_82
+  FIREFOX_83
+  FIREFOX_84
+  FIREFOX_85
+  FIREFOX_86
+  FIREFOX_87
+  FIREFOX_88
+  FIREFOX_89
+  FIREFOX_90
+  FIREFOX_91
+  FIREFOX_92
+  FIREFOX_93
+  FIREFOX_94
+  FIREFOX_95
+  FIREFOX_96
+  FIREFOX_97
+  FIREFOX_98
+  FIREFOX_99
+  FIREFOX_100
+}
+
+enum NimbusExperimentOptionalStatus {
+  Draft
+  Review
+  Accepted
+  Live
+  Complete
+}
+
+type NimbusExperimentOwner {
+  id: ID!
+  username: String!
+  firstName: String!
+  lastName: String!
+  email: String!
+}
+
+enum NimbusExperimentStatus {
+  DRAFT
+  REVIEW
+  ACCEPTED
+  LIVE
+  COMPLETE
+}
+
+enum NimbusExperimentTargetingConfigSlug {
+  ALL_ENGLISH
+  US_ONLY
+  TARGETING_FIRST_RUN
+  TARGETING_FIRST_RUN_ABOUT_WELCOME
+}
+
+type NimbusExperimentType {
+  id: ID!
+  owner: NimbusExperimentOwner
+  status: NimbusExperimentStatus
+  name: String!
+  slug: String!
+  publicDescription: String
+  isPaused: Boolean!
+  proposedDuration: Int
+  proposedEnrollment: Int
+  populationPercent: Float
+  totalEnrolledClients: Int!
+  firefoxMinVersion: NimbusExperimentFirefoxMinVersion
+  application: NimbusExperimentApplication
+  channels: [NimbusExperimentChannel]
+  projects: [ProjectType!]!
+  hypothesis: String
+  featureConfig: NimbusFeatureConfigType
+  targetingConfigSlug: NimbusExperimentTargetingConfigSlug
+  referenceBranch: NimbusBranchType
+  bucketRange: NimbusBucketRangeType
+  treatmentBranches: [NimbusBranchType]
+  primaryProbeSets: [NimbusProbeSetType]
+  secondaryProbeSets: [NimbusProbeSetType]
+}
+
+enum NimbusFeatureConfigApplication {
+  FIREFOX_DESKTOP
+  FENIX
+}
+
+type NimbusFeatureConfigType {
+  id: ID!
+  name: String!
+  slug: String!
+  description: String
+  application: NimbusFeatureConfigApplication
+  ownerEmail: String
+  schema: String
+  nimbusexperimentSet: [NimbusExperimentType!]!
+}
+
+type NimbusIsolationGroupType {
+  id: ID!
+  name: String!
+  instance: Int!
+  total: Int!
+  randomizationUnit: String!
+  bucketRanges: [NimbusBucketRangeType!]!
+}
+
+type NimbusLabelValueType {
+  label: String
+  value: String
+}
+
+enum NimbusProbeKind {
+  EVENT
+  SCALAR
+}
+
+type NimbusProbeSetType {
+  id: ID!
+  name: String!
+  slug: String!
+  probes: [NimbusProbeType!]!
+  nimbusexperimentSet: [NimbusExperimentType!]!
+}
+
+type NimbusProbeType {
+  id: ID!
+  kind: NimbusProbeKind!
+  name: String!
+  eventCategory: String!
+  eventMethod: String
+  eventObject: String
+  eventValue: String
+  nimbusprobesetSet: [NimbusProbeSetType!]!
+}
+
+type NimbusReadyForReviewType {
+  message: ObjectField
+  ready: Boolean
+}
+
+scalar ObjectField
+
+type ProjectType {
+  id: ID!
+  name: String!
+  slug: String!
+  nimbusexperimentSet: [NimbusExperimentType!]!
+}
+
+type Query {
+  experiments(offset: Int, limit: Int, status: NimbusExperimentOptionalStatus): [NimbusExperimentType]
+  experimentBySlug(slug: String!): NimbusExperimentType
+  experimentReadyForReviewBySlug(slug: String!): NimbusReadyForReviewType
+  nimbusConfig: NimbusConfigurationType
+}
+
+input ReferenceBranchType {
+  name: String!
+  description: String!
+  ratio: Int!
+  featureEnabled: Boolean
+  featureValue: String
+}
+
+input TreatmentBranchType {
+  name: String!
+  description: String!
+  ratio: Int!
+  featureEnabled: Boolean
+  featureValue: String
+}
+
+type UpdateExperimentAudience {
+  clientMutationId: String
+  nimbusExperiment: NimbusExperimentType
+  message: ObjectField
+  status: Int
+}
+
+input UpdateExperimentAudienceInput {
+  clientMutationId: String
+  nimbusExperimentId: Int!
+  channels: [NimbusExperimentChannel]
+  firefoxMinVersion: NimbusExperimentFirefoxMinVersion
+  populationPercent: Decimal
+  proposedDuration: Int
+  proposedEnrollment: String
+  targetingConfigSlug: NimbusExperimentTargetingConfigSlug
+  totalEnrolledClients: Int
+}
+
+type UpdateExperimentBranches {
+  clientMutationId: String
+  nimbusExperiment: NimbusExperimentType
+  message: ObjectField
+  status: Int
+}
+
+input UpdateExperimentBranchesInput {
+  clientMutationId: String
+  nimbusExperimentId: Int!
+  featureConfigId: Int
+  referenceBranch: ReferenceBranchType!
+  treatmentBranches: [TreatmentBranchType]!
+}
+
+input UpdateExperimentInput {
+  clientMutationId: String
+  name: String
+  application: NimbusExperimentApplication
+  publicDescription: String
+  hypothesis: String
+  id: ID!
+}
+
+type UpdateExperimentOverview {
+  clientMutationId: String
+  nimbusExperiment: NimbusExperimentType
+  message: ObjectField
+  status: Int
+}
+
+type UpdateExperimentProbeSets {
+  clientMutationId: String
+  nimbusExperiment: NimbusExperimentType
+  message: ObjectField
+  status: Int
+}
+
+input UpdateExperimentProbeSetsInput {
+  clientMutationId: String
+  nimbusExperimentId: Int!
+  primaryProbeSetIds: [Int]!
+  secondaryProbeSetIds: [Int]!
+}
+
+type UpdateExperimentStatus {
+  clientMutationId: String
+  nimbusExperiment: NimbusExperimentType
+  message: ObjectField
+  status: Int
+}
+
+input UpdateExperimentStatusInput {
+  clientMutationId: String
+  nimbusExperimentId: Int!
+  status: NimbusExperimentStatus!
+}

--- a/app/experimenter/nimbus-ui/src/types/createExperiment.ts
+++ b/app/experimenter/nimbus-ui/src/types/createExperiment.ts
@@ -26,9 +26,6 @@ export interface createExperiment_createExperiment {
 }
 
 export interface createExperiment {
-  /**
-   * Create a new Nimbus Experiment.
-   */
   createExperiment: createExperiment_createExperiment | null;
 }
 

--- a/app/experimenter/nimbus-ui/src/types/getConfig.ts
+++ b/app/experimenter/nimbus-ui/src/types/getConfig.ts
@@ -74,8 +74,5 @@ export interface getConfig_nimbusConfig {
 }
 
 export interface getConfig {
-  /**
-   * Nimbus Configuration Data for front-end usage.
-   */
   nimbusConfig: getConfig_nimbusConfig | null;
 }

--- a/app/experimenter/nimbus-ui/src/types/getExperiment.ts
+++ b/app/experimenter/nimbus-ui/src/types/getExperiment.ts
@@ -81,9 +81,6 @@ export interface getExperiment_experimentBySlug {
 }
 
 export interface getExperiment {
-  /**
-   * Retrieve a Nimbus experiment by its slug.
-   */
   experimentBySlug: getExperiment_experimentBySlug | null;
 }
 

--- a/app/experimenter/nimbus-ui/src/types/globalTypes.ts
+++ b/app/experimenter/nimbus-ui/src/types/globalTypes.ts
@@ -60,17 +60,11 @@ export enum NimbusExperimentTargetingConfigSlug {
   US_ONLY = "US_ONLY",
 }
 
-/**
- * An enumeration.
- */
 export enum NimbusFeatureConfigApplication {
   FENIX = "FENIX",
   FIREFOX_DESKTOP = "FIREFOX_DESKTOP",
 }
 
-/**
- * An enumeration.
- */
 export enum NimbusProbeKind {
   EVENT = "EVENT",
   SCALAR = "SCALAR",

--- a/app/experimenter/nimbus-ui/src/types/updateExperimentOverview.ts
+++ b/app/experimenter/nimbus-ui/src/types/updateExperimentOverview.ts
@@ -26,9 +26,6 @@ export interface updateExperimentOverview_updateExperimentOverview {
 }
 
 export interface updateExperimentOverview {
-  /**
-   * Update a Nimbus Experiment.
-   */
   updateExperimentOverview: updateExperimentOverview_updateExperimentOverview | null;
 }
 

--- a/app/experimenter/nimbus-ui/src/types/updateExperimentStatus.ts
+++ b/app/experimenter/nimbus-ui/src/types/updateExperimentStatus.ts
@@ -23,9 +23,6 @@ export interface updateExperimentStatus_updateExperimentStatus {
 }
 
 export interface updateExperimentStatus {
-  /**
-   * Mark a Nimubs Experiment as ready for review.
-   */
   updateExperimentStatus: updateExperimentStatus_updateExperimentStatus | null;
 }
 

--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -14,8 +14,6 @@ services:
       - STORYBOOKS_GCP_BUCKET
       - STORYBOOKS_GCP_PRIVATE_KEY_BASE64
       - STORYBOOKS_GCP_CLIENT_EMAIL
-    volumes:
-      - /app/node_modules/
     links:
       - db
 


### PR DESCRIPTION
Because

* We'd like to make sure that the apollo client generated code stays in sync with the server

This commit

* Uses the schema.graphql to check whether the backend is in sync with the frontend codebase
* Regenerates the schema.graphql and typescript stubs together so they stay in sync