### PR TITLE
fix #3852 fix(legacy): changes to results to reduce questions asked

### DIFF
--- a/app/experimenter/experiments/constants/legacy.py
+++ b/app/experimenter/experiments/constants/legacy.py
@@ -926,7 +926,7 @@ class ExperimentConstants(object):
         "Did this delivery fail to launch at the expected time?"
     )
 
-    RESULTS_RECIPE_ERRORS_LABEL = "Did this delivery have recipe errors?"
+    RESULTS_RECIPE_ERRORS_LABEL = "Did this experiment encounter any issues or errors?"
 
     RESULTS_RESTARTS_LABEL = "Did this delivery require any restarts after it launched?"
 
@@ -946,9 +946,7 @@ class ExperimentConstants(object):
     RESULTS_DATA_FOR_HYPOTHESIS_LABEL = """Was the data required to prove or disprove your
         hypothesis (which may include a null result) obtained?"""
 
-    RESULTS_CONFIDENCE_LABEL = (
-        "Did this delivery provide the confidence needed to more forward?"
-    )
+    RESULTS_CONFIDENCE_LABEL = "Did this delivery move the primary metric?"
 
     RESULTS_MEASURE_IMPACT_LABEL = (
         "Did this delivery help understand/measure the impact of this feature?"

--- a/app/experimenter/experiments/forms.py
+++ b/app/experimenter/experiments/forms.py
@@ -340,44 +340,9 @@ class ExperimentResultsForm(ChangeLogMixin, forms.ModelForm):
         required=False,
     )
 
-    results_fail_to_launch = forms.ChoiceField(
-        required=False,
-        label=Experiment.RESULTS_FAIL_TO_LAUNCH_LABEL,
-        help_text=Experiment.RESULTS_QUESTIONS_HELP,
-        choices=RADIO_OPTIONS,
-        widget=RadioWidget,
-    )
     results_recipe_errors = forms.ChoiceField(
         required=False,
         label=Experiment.RESULTS_RECIPE_ERRORS_LABEL,
-        help_text=Experiment.RESULTS_QUESTIONS_HELP,
-        choices=RADIO_OPTIONS,
-        widget=RadioWidget,
-    )
-    results_restarts = forms.ChoiceField(
-        required=False,
-        label=Experiment.RESULTS_RESTARTS_LABEL,
-        help_text=Experiment.RESULTS_QUESTIONS_HELP,
-        choices=RADIO_OPTIONS,
-        widget=RadioWidget,
-    )
-    results_low_enrollment = forms.ChoiceField(
-        required=False,
-        label=Experiment.RESULTS_LOW_ENROLLMENT_LABEL,
-        help_text=Experiment.RESULTS_QUESTIONS_HELP,
-        choices=RADIO_OPTIONS,
-        widget=RadioWidget,
-    )
-    results_early_end = forms.ChoiceField(
-        required=False,
-        label=Experiment.RESULTS_EARLY_END_LABEL,
-        help_text=Experiment.RESULTS_QUESTIONS_HELP,
-        choices=RADIO_OPTIONS,
-        widget=RadioWidget,
-    )
-    results_no_usable_data = forms.ChoiceField(
-        required=False,
-        label=Experiment.RESULTS_NO_USABLE_DATA_LABEL,
         help_text=Experiment.RESULTS_QUESTIONS_HELP,
         choices=RADIO_OPTIONS,
         widget=RadioWidget,
@@ -389,39 +354,12 @@ class ExperimentResultsForm(ChangeLogMixin, forms.ModelForm):
         required=False,
     )
 
-    results_changes_to_firefox = forms.ChoiceField(
-        required=False,
-        label=Experiment.RESULTS_CHANGES_TO_FIREFOX_LABEL,
-        help_text=Experiment.RESULTS_QUESTIONS_HELP,
-        choices=RADIO_OPTIONS,
-        widget=RadioWidget,
-    )
-    results_data_for_hypothesis = forms.ChoiceField(
-        required=False,
-        label=Experiment.RESULTS_DATA_FOR_HYPOTHESIS_LABEL,
-        help_text=Experiment.RESULTS_QUESTIONS_HELP,
-        choices=RADIO_OPTIONS,
-        widget=RadioWidget,
-    )
     results_confidence = forms.ChoiceField(
         required=False,
         label=Experiment.RESULTS_CONFIDENCE_LABEL,
         help_text=Experiment.RESULTS_QUESTIONS_HELP,
         choices=RADIO_OPTIONS,
         widget=RadioWidget,
-    )
-    results_measure_impact = forms.ChoiceField(
-        required=False,
-        label=Experiment.RESULTS_MEASURE_IMPACT_LABEL,
-        help_text=Experiment.RESULTS_QUESTIONS_HELP,
-        choices=RADIO_OPTIONS,
-        widget=RadioWidget,
-    )
-    results_impact_notes = forms.CharField(
-        label=Experiment.RESULTS_NOTES_LABEL,
-        help_text="",
-        widget=forms.Textarea(attrs={"class": "form-control", "rows": 10}),
-        required=False,
     )
 
     class Meta:
@@ -430,18 +368,9 @@ class ExperimentResultsForm(ChangeLogMixin, forms.ModelForm):
             "results_url",
             "results_initial",
             "results_lessons_learned",
-            "results_fail_to_launch",
             "results_recipe_errors",
-            "results_restarts",
-            "results_low_enrollment",
-            "results_early_end",
-            "results_no_usable_data",
             "results_failures_notes",
-            "results_changes_to_firefox",
-            "results_data_for_hypothesis",
             "results_confidence",
-            "results_measure_impact",
-            "results_impact_notes",
         )
 
 

--- a/app/experimenter/experiments/models/legacy.py
+++ b/app/experimenter/experiments/models/legacy.py
@@ -762,6 +762,22 @@ class Experiment(ExperimentConstants, models.Model):
         return any([getattr(self, field) for field in results_fields])
 
     @property
+    def additional_results(self):
+        return any(
+            [
+                self.results_fail_to_launch,
+                self.results_restarts,
+                self.results_low_enrollment,
+                self.results_early_end,
+                self.results_no_usable_data,
+                self.results_changes_to_firefox,
+                self.results_data_for_hypothesis,
+                self.results_measure_impact,
+                self.results_impact_notes,
+            ]
+        )
+
+    @property
     def risk_fields(self):
         risk_fields = (
             "risk_partner_related",

--- a/app/experimenter/experiments/tests/test_forms.py
+++ b/app/experimenter/experiments/tests/test_forms.py
@@ -522,18 +522,9 @@ class TestExperimentResultsForm(MockRequestMixin, TestCase):
         "results_url": "https://example.com",
         "results_initial": "Initially, all went well.",
         "results_lessons_learned": "Lessons were learned.",
-        "results_fail_to_launch": RADIO_NO,
         "results_recipe_errors": RADIO_YES,
-        "results_restarts": RADIO_YES,
-        "results_low_enrollment": RADIO_NO,
-        "results_early_end": RADIO_YES,
-        "results_no_usable_data": RADIO_NO,
         "results_failures_notes": "Bad.",
-        "results_changes_to_firefox": RADIO_YES,
-        "results_data_for_hypothesis": RADIO_NO,
         "results_confidence": RADIO_YES,
-        "results_measure_impact": RADIO_NO,
-        "results_impact_notes": "Good.",
     }
 
     def test_no_fields_required(self):
@@ -543,7 +534,7 @@ class TestExperimentResultsForm(MockRequestMixin, TestCase):
 
     def test_form_saves_results(self):
         created_experiment = ExperimentFactory.create_with_status(
-            Experiment.STATUS_COMPLETE, results_early_end=False
+            Experiment.STATUS_COMPLETE
         )
         self.assertEqual(created_experiment.changes.count(), 6)
 
@@ -558,18 +549,9 @@ class TestExperimentResultsForm(MockRequestMixin, TestCase):
 
         self.assertEqual(experiment.results_url, "https://example.com")
         self.assertEqual(experiment.results_initial, "Initially, all went well.")
-        self.assertFalse(experiment.results_fail_to_launch)
         self.assertTrue(experiment.results_recipe_errors)
-        self.assertTrue(experiment.results_restarts)
-        self.assertFalse(experiment.results_low_enrollment)
-        self.assertTrue(experiment.results_early_end)
-        self.assertFalse(experiment.results_no_usable_data)
-        self.assertEqual(experiment.results_failures_notes, "Bad.")
-        self.assertTrue(experiment.results_changes_to_firefox)
-        self.assertFalse(experiment.results_data_for_hypothesis)
         self.assertTrue(experiment.results_confidence)
-        self.assertFalse(experiment.results_measure_impact)
-        self.assertEqual(experiment.results_impact_notes, "Good.")
+        self.assertEqual(experiment.results_failures_notes, "Bad.")
         self.assertEqual(experiment.changes.count(), 7)
 
 

--- a/app/experimenter/experiments/tests/test_models/test_models_legacy.py
+++ b/app/experimenter/experiments/tests/test_models/test_models_legacy.py
@@ -1352,6 +1352,14 @@ class TestExperimentModel(TestCase):
         )
         self.assertFalse(experiment.completed_results)
 
+    def test_additional_results_returns_true_with_non_primary_results(self):
+        experiment = ExperimentFactory.create(results_restarts=True)
+        self.assertTrue(experiment.additional_results)
+
+    def test_additional_results_return_false_without_non_primary_results(self):
+        experiment = ExperimentFactory.create()
+        self.assertFalse(experiment.additional_results)
+
     def test_experiment_is_not_archivable(self):
         experiment = ExperimentFactory.create_with_status(
             target_status=Experiment.STATUS_ACCEPTED

--- a/app/experimenter/legacy-ui/scripts/edit-results.js
+++ b/app/experimenter/legacy-ui/scripts/edit-results.js
@@ -1,0 +1,17 @@
+function updateResults() {
+  const failureNotes =
+    $('[type="radio"][name="results_recipe_errors"][value="True"]:checked')
+      .length > 0;
+
+  if (failureNotes) {
+    $("#results-failure-notes").show();
+  } else {
+    $("#results-failure-notes").hide();
+  }
+}
+
+$('[type="radio"]').change(function (e) {
+  updateResults();
+});
+
+updateResults();

--- a/app/experimenter/legacy-ui/templates/experiments/edit_results.html
+++ b/app/experimenter/legacy-ui/templates/experiments/edit_results.html
@@ -11,30 +11,19 @@ Edit <a href="{% url "experiments-detail" slug=object.slug %}">
 
 {% block edit_form %}
   {% include "experiments/field_inline.html" with field=form.results_url %}
-  {% include "experiments/field_inline.html" with field=form.results_initial %}
-  {% include "experiments/field_inline.html" with field=form.results_lessons_learned %}
-  <div class="row my-4">
-    <div class="col-10 offset-2">
-      <h4>What Went Wrong?</h4>
-    </div>
-  </div>
-  {% include "experiments/radio_field_inline.html" with field=form.results_fail_to_launch %}
-  {% include "experiments/radio_field_inline.html" with field=form.results_recipe_errors %}
-  {% include "experiments/radio_field_inline.html" with field=form.results_restarts %}
-  {% include "experiments/radio_field_inline.html" with field=form.results_low_enrollment %}
-  {% include "experiments/radio_field_inline.html" with field=form.results_early_end %}
-  {% include "experiments/radio_field_inline.html" with field=form.results_no_usable_data %}
-  {% include "experiments/field_inline.html" with field=form.results_failures_notes %}
-  <div class="row my-4">
-    <div class="col-10 offset-2">
-      <h4>What Went Right?</h4>
-    </div>
-  </div>
-  {% include "experiments/radio_field_inline.html" with field=form.results_changes_to_firefox %}
-  {% include "experiments/radio_field_inline.html" with field=form.results_data_for_hypothesis %}
+
   {% include "experiments/radio_field_inline.html" with field=form.results_confidence %}
-  {% include "experiments/radio_field_inline.html" with field=form.results_measure_impact %}
-  {% include "experiments/field_inline.html" with field=form.results_impact_notes %}
+
+  {% include "experiments/field_inline.html" with field=form.results_initial %}
+
+  {% include "experiments/radio_field_inline.html" with field=form.results_recipe_errors %}
+
+  <div id="results-failure-notes"  class="collapse">
+    {% include "experiments/field_inline.html" with field=form.results_failures_notes %}
+  </div>
+
+    {% include "experiments/field_inline.html" with field=form.results_lessons_learned %}
+
 {% endblock %}
 
 
@@ -55,3 +44,7 @@ Edit <a href="{% url "experiments-detail" slug=object.slug %}">
     {% endblock %}
   </div>
 </div>
+
+{% block extrascripts %}
+    <script src="{% static "scripts/edit-results.js" %}"></script>
+{% endblock %}

--- a/app/experimenter/legacy-ui/templates/experiments/section_results.html
+++ b/app/experimenter/legacy-ui/templates/experiments/section_results.html
@@ -12,12 +12,22 @@ Results
   {% else %}
     <p><em class="text-secondary">Not Complete.</em></p>
   {% endif %}
+
+  {% include "experiments/results_radio_field.html" with label=experiment.RESULTS_CONFIDENCE_LABEL field=experiment.results_confidence %}
+
   <p><strong>Initial Results: </strong></p>
   {% if experiment.results_initial %}
     <p>{{ experiment.results_initial|urlize|markdown }}</p>
   {% else %}
     <p><em class="text-secondary">Not Complete.</em></p>
   {% endif %}
+  {% include "experiments/results_radio_field.html" with label=experiment.RESULTS_RECIPE_ERRORS_LABEL field=experiment.results_recipe_errors %}
+  
+  {% if experiment.results_failures_notes %}
+    <p><strong>Recipe Error Notes: </strong></p>
+    <p>{{ experiment.results_failures_notes|urlize|markdown }}</ p>
+  {% endif %}
+  
   <p><strong>Lessons Learned: </strong></p>
   {% if experiment.results_lessons_learned %}
     <p>{{ experiment.results_lessons_learned|urlize|markdown }}</p>
@@ -25,33 +35,31 @@ Results
     <p><em class="text-secondary">Not Complete.</em></p>
   {% endif %}
 
+  {% if experiment.additional_results %}
+    <hr/>
+    <h4> Additional Results</h4>
+    <h5>What Went Wrong?</h5>
 
-  <hr/>
-  <h5>What Went Wrong?</h5>
+    {% include "experiments/results_radio_field.html" with label=experiment.RESULTS_FAIL_TO_LAUNCH_LABEL field=experiment.results_fail_to_launch %}
+  
+    {% include "experiments/results_radio_field.html" with label=experiment.RESULTS_RESTARTS_LABEL field=experiment.results_restarts %}
+    {% include "experiments/results_radio_field.html" with label=experiment.RESULTS_LOW_ENROLLMENT_LABEL field=experiment.results_low_enrollment %}
+    {% include "experiments/results_radio_field.html" with label=experiment.RESULTS_EARLY_END_LABEL field=experiment.results_early_end %}
+    {% include "experiments/results_radio_field.html" with label=experiment.RESULTS_NO_USABLE_DATA_LABEL field=experiment.results_no_usable_data %}
 
-  {% include "experiments/results_radio_field.html" with label=experiment.RESULTS_FAIL_TO_LAUNCH_LABEL field=experiment.results_fail_to_launch %}
-  {% include "experiments/results_radio_field.html" with label=experiment.RESULTS_RECIPE_ERRORS_LABEL field=experiment.results_recipe_errors %}
-  {% include "experiments/results_radio_field.html" with label=experiment.RESULTS_RESTARTS_LABEL field=experiment.results_restarts %}
-  {% include "experiments/results_radio_field.html" with label=experiment.RESULTS_LOW_ENROLLMENT_LABEL field=experiment.results_low_enrollment %}
-  {% include "experiments/results_radio_field.html" with label=experiment.RESULTS_EARLY_END_LABEL field=experiment.results_early_end %}
-  {% include "experiments/results_radio_field.html" with label=experiment.RESULTS_NO_USABLE_DATA_LABEL field=experiment.results_no_usable_data %}
+    <hr/>
+    <h5>What Went Right?</h5>
 
-  {% if experiment.results_failures_notes %}
-    <p><strong>Notes: </strong></p>
-    <p>{{ experiment.results_failures_notes|urlize|markdown }}</p>
-  {% endif %}
+    {% include "experiments/results_radio_field.html" with label=experiment.RESULTS_CHANGES_TO_FIREFOX_LABEL field=experiment.results_changes_to_firefox %}
+    {% include "experiments/results_radio_field.html" with label=experiment.RESULTS_DATA_FOR_HYPOTHESIS_LABEL field=experiment.results_data_for_hypothesis %}
 
-  <hr/>
-  <h5>What Went Right?</h5>
-
-  {% include "experiments/results_radio_field.html" with label=experiment.RESULTS_CHANGES_TO_FIREFOX_LABEL field=experiment.results_changes_to_firefox %}
-  {% include "experiments/results_radio_field.html" with label=experiment.RESULTS_DATA_FOR_HYPOTHESIS_LABEL field=experiment.results_data_for_hypothesis %}
-  {% include "experiments/results_radio_field.html" with label=experiment.RESULTS_CONFIDENCE_LABEL field=experiment.results_confidence %}
-  {% include "experiments/results_radio_field.html" with label=experiment.RESULTS_MEASURE_IMPACT_LABEL field=experiment.results_measure_impact %}
+    {% include "experiments/results_radio_field.html" with label=experiment.RESULTS_MEASURE_IMPACT_LABEL field=experiment.results_measure_impact %}
 
 
-  {% if experiment.results_impact_notes %}
-    <p><strong>Notes: </strong></p>
-    <p>{{ experiment.results_impact_notes|urlize|markdown }}</p>
+    {% if experiment.results_impact_notes %}
+      <p><strong>Notes: </strong></p>
+      <p>{{ experiment.results_impact_notes|urlize|markdown }}</p>
+    {% endif %}
+
   {% endif %}
 {% endblock %}


### PR DESCRIPTION
Because

* We would like to reduce the number of questions a user will need to complete

This commit

* Reduce number of result questions in the edit_results template
* Section_results to display "additional results" when relevant