### PR TITLE
fixes #3756 feat(nimbus): Add Results and Design pages and routes

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/App/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/App/index.tsx
@@ -9,6 +9,8 @@ import { GET_CONFIG_QUERY } from "../../gql/config";
 import PageLoading from "../PageLoading";
 import PageHome from "../PageHome";
 import PageNew from "../PageNew";
+import PageDesign from "../PageDesign";
+import PageResults from "../PageResults";
 import PageEditOverview from "../PageEditOverview";
 import PageEditBranches from "../PageEditBranches";
 import PageRequestReview from "../PageRequestReview";
@@ -36,6 +38,8 @@ const App = ({ basepath }: { basepath: string }) => {
         <PageEditBranches path="branches" />
       </Root>
       <PageRequestReview path=":slug/request-review" />
+      <PageDesign path=":slug/design" />
+      <PageResults path=":slug/results" />
     </Router>
   );
 };

--- a/app/experimenter/nimbus-ui/src/components/AppLayoutWithSidebarAndData/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/AppLayoutWithSidebarAndData/index.stories.tsx
@@ -1,0 +1,25 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from "react";
+import { storiesOf } from "@storybook/react";
+import { RouterSlugProvider } from "../../lib/test-utils";
+import { withLinks } from "@storybook/addon-links";
+import AppLayoutWithSidebarAndData from ".";
+import { mockExperimentQuery } from "../../lib/mocks";
+
+const { mock } = mockExperimentQuery("demo-slug");
+
+storiesOf("components/AppLayoutWithSidebarAndData", module)
+  .addDecorator(withLinks)
+  .add("basic", () => (
+    <RouterSlugProvider mocks={[mock]}>
+      <AppLayoutWithSidebarAndData
+        title="Howdy!"
+        testId="AppLayoutWithSidebarAndData"
+      >
+        {({ experiment }) => <p>{experiment.name}</p>}
+      </AppLayoutWithSidebarAndData>
+    </RouterSlugProvider>
+  ));

--- a/app/experimenter/nimbus-ui/src/components/AppLayoutWithSidebarAndData/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/AppLayoutWithSidebarAndData/index.test.tsx
@@ -4,7 +4,7 @@
 
 import React from "react";
 import { render, screen, waitFor } from "@testing-library/react";
-import ContainerEditPage, { POLL_INTERVAL } from ".";
+import AppLayoutWithSidebarAndData, { POLL_INTERVAL } from ".";
 import { renderWithRouter, RouterSlugProvider } from "../../lib/test-utils";
 import { mockExperimentQuery } from "../../lib/mocks";
 import { NimbusExperimentStatus } from "../../types/globalTypes";
@@ -13,12 +13,14 @@ import { act } from "@testing-library/react";
 
 jest.useFakeTimers();
 
-describe("ContainerEditPage", () => {
+describe("AppLayoutWithSidebarAndData", () => {
   it("renders as expected", async () => {
     const { mock } = mockExperimentQuery("demo-slug");
     render(<Subject mocks={[mock]} />);
     await waitFor(() => {
-      expect(screen.getByTestId("ContainerEditPage")).toBeInTheDocument();
+      expect(
+        screen.getByTestId("AppLayoutWithSidebarAndData"),
+      ).toBeInTheDocument();
       expect(screen.getByTestId("page-title")).toBeInTheDocument();
       expect(screen.getByTestId("page-title")).toHaveTextContent("Howdy!");
       expect(screen.getByTestId("child")).toBeInTheDocument();
@@ -112,12 +114,12 @@ const Subject = ({
   polling?: boolean;
 }) => (
   <RouterSlugProvider {...{ mocks }}>
-    <ContainerEditPage
+    <AppLayoutWithSidebarAndData
       title="Howdy!"
-      testId="ContainerEditPage"
+      testId="AppLayoutWithSidebarAndData"
       {...{ polling }}
     >
       {({ experiment }) => <p data-testid="child">{experiment.slug}</p>}
-    </ContainerEditPage>
+    </AppLayoutWithSidebarAndData>
   </RouterSlugProvider>
 );

--- a/app/experimenter/nimbus-ui/src/components/AppLayoutWithSidebarAndData/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/AppLayoutWithSidebarAndData/index.tsx
@@ -11,12 +11,14 @@ import PageExperimentNotFound from "../PageExperimentNotFound";
 import { useExperiment } from "../../hooks";
 import { getExperiment_experimentBySlug } from "../../types/getExperiment";
 
-type ContainerEditPageChildrenProps = {
+type AppLayoutWithSidebarAndDataChildrenProps = {
   experiment: getExperiment_experimentBySlug;
 };
 
-type ContainerEditPageProps = {
-  children: (props: ContainerEditPageChildrenProps) => React.ReactNode | null;
+type AppLayoutWithSidebarAndDataProps = {
+  children: (
+    props: AppLayoutWithSidebarAndDataChildrenProps,
+  ) => React.ReactNode | null;
   testId: string;
   title: string;
   polling?: boolean;
@@ -24,12 +26,12 @@ type ContainerEditPageProps = {
 
 export const POLL_INTERVAL = 30000;
 
-const ContainerEditPage = ({
+const AppLayoutWithSidebarAndData = ({
   children,
   testId,
   title,
   polling = false,
-}: ContainerEditPageProps) => {
+}: AppLayoutWithSidebarAndDataProps) => {
   const { slug } = useParams();
   const {
     experiment,
@@ -77,4 +79,4 @@ const ContainerEditPage = ({
   );
 };
 
-export default ContainerEditPage;
+export default AppLayoutWithSidebarAndData;

--- a/app/experimenter/nimbus-ui/src/components/PageDesign/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageDesign/index.stories.tsx
@@ -1,0 +1,20 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from "react";
+import { storiesOf } from "@storybook/react";
+import { RouterSlugProvider } from "../../lib/test-utils";
+import { withLinks } from "@storybook/addon-links";
+import { mockExperimentQuery } from "../../lib/mocks";
+import PageDesign from ".";
+
+const { mock } = mockExperimentQuery("demo-slug");
+
+storiesOf("pages/Design", module)
+  .addDecorator(withLinks)
+  .add("basic", () => (
+    <RouterSlugProvider mocks={[mock]}>
+      <PageDesign />
+    </RouterSlugProvider>
+  ));

--- a/app/experimenter/nimbus-ui/src/components/PageDesign/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageDesign/index.test.tsx
@@ -1,0 +1,24 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from "react";
+import { screen, render, waitFor } from "@testing-library/react";
+import PageDesign from ".";
+import { RouterSlugProvider } from "../../lib/test-utils";
+import { mockExperimentQuery } from "../../lib/mocks";
+
+const { mock } = mockExperimentQuery("demo-slug");
+
+describe("PageDesign", () => {
+  it("renders as expected", async () => {
+    render(
+      <RouterSlugProvider mocks={[mock]}>
+        <PageDesign />
+      </RouterSlugProvider>,
+    );
+    await waitFor(() => {
+      expect(screen.queryByTestId("PageDesign")).toBeInTheDocument();
+    });
+  });
+});

--- a/app/experimenter/nimbus-ui/src/components/PageDesign/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageDesign/index.tsx
@@ -1,0 +1,17 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from "react";
+import { RouteComponentProps } from "@reach/router";
+import AppLayoutWithSidebarAndData from "../AppLayoutWithSidebarAndData";
+
+const PageDesign: React.FunctionComponent<RouteComponentProps> = () => {
+  return (
+    <AppLayoutWithSidebarAndData title="Design" testId="PageDesign">
+      {({ experiment }) => <p>{experiment.name}</p>}
+    </AppLayoutWithSidebarAndData>
+  );
+};
+
+export default PageDesign;

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/index.tsx
@@ -7,7 +7,7 @@ import { RouteComponentProps } from "@reach/router";
 import { useConfig } from "../../hooks";
 import FormBranches from "../FormBranches";
 import LinkExternal from "../LinkExternal";
-import ContainerEditPage from "../ContainerEditPage";
+import AppLayoutWithSidebarAndData from "../AppLayoutWithSidebarAndData";
 
 // TODO: find this doco URL
 const BRANCHES_DOC_URL =
@@ -17,7 +17,7 @@ const PageEditBranches: React.FunctionComponent<RouteComponentProps> = () => {
   const { featureConfig } = useConfig();
 
   return (
-    <ContainerEditPage title="Branches" testId="PageEditBranches">
+    <AppLayoutWithSidebarAndData title="Branches" testId="PageEditBranches">
       {({ experiment }) => (
         <>
           <p>
@@ -37,7 +37,7 @@ const PageEditBranches: React.FunctionComponent<RouteComponentProps> = () => {
           />
         </>
       )}
-    </ContainerEditPage>
+    </AppLayoutWithSidebarAndData>
   );
 };
 

--- a/app/experimenter/nimbus-ui/src/components/PageEditOverview/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditOverview/index.tsx
@@ -5,7 +5,7 @@
 import React, { useCallback, useRef, useState } from "react";
 import { navigate, RouteComponentProps } from "@reach/router";
 import FormOverview from "../FormOverview";
-import ContainerEditPage from "../ContainerEditPage";
+import AppLayoutWithSidebarAndData from "../AppLayoutWithSidebarAndData";
 import { useMutation } from "@apollo/client";
 import { UPDATE_EXPERIMENT_OVERVIEW_MUTATION } from "../../gql/experiments";
 import { SUBMIT_ERROR } from "../../lib/constants";
@@ -65,7 +65,7 @@ const PageEditOverview: React.FunctionComponent<PageEditOverviewProps> = () => {
   }, []);
 
   return (
-    <ContainerEditPage title="Overview" testId="PageEditOverview">
+    <AppLayoutWithSidebarAndData title="Overview" testId="PageEditOverview">
       {({ experiment }) => {
         currentExperiment.current = experiment;
 
@@ -81,7 +81,7 @@ const PageEditOverview: React.FunctionComponent<PageEditOverviewProps> = () => {
           />
         );
       }}
-    </ContainerEditPage>
+    </AppLayoutWithSidebarAndData>
   );
 };
 

--- a/app/experimenter/nimbus-ui/src/components/PageRequestReview/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageRequestReview/index.tsx
@@ -5,7 +5,7 @@
 import React, { useCallback, useRef, useState } from "react";
 import { useMutation } from "@apollo/client";
 import { RouteComponentProps } from "@reach/router";
-import ContainerEditPage from "../ContainerEditPage";
+import AppLayoutWithSidebarAndData from "../AppLayoutWithSidebarAndData";
 import TableSummary from "../TableSummary";
 import { SUBMIT_ERROR } from "../../lib/constants";
 import { UPDATE_EXPERIMENT_STATUS_MUTATION } from "../../gql/experiments";
@@ -61,7 +61,7 @@ const PageRequestReview: React.FunctionComponent<PageRequestReviewProps> = ({
   }, [submitForReview, currentExperiment]);
 
   return (
-    <ContainerEditPage
+    <AppLayoutWithSidebarAndData
       title="Review &amp; Launch"
       testId="PageRequestReview"
       {...{ polling }}
@@ -104,7 +104,7 @@ const PageRequestReview: React.FunctionComponent<PageRequestReviewProps> = ({
           </>
         );
       }}
-    </ContainerEditPage>
+    </AppLayoutWithSidebarAndData>
   );
 };
 

--- a/app/experimenter/nimbus-ui/src/components/PageResults/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/index.stories.tsx
@@ -6,17 +6,15 @@ import React from "react";
 import { storiesOf } from "@storybook/react";
 import { RouterSlugProvider } from "../../lib/test-utils";
 import { withLinks } from "@storybook/addon-links";
-import ContainerEditPage from ".";
 import { mockExperimentQuery } from "../../lib/mocks";
+import PageResults from ".";
 
 const { mock } = mockExperimentQuery("demo-slug");
 
-storiesOf("components/ContainerEditPage", module)
+storiesOf("pages/Results", module)
   .addDecorator(withLinks)
   .add("basic", () => (
     <RouterSlugProvider mocks={[mock]}>
-      <ContainerEditPage title="Howdy!" testId="ContainerEditPage">
-        {({ experiment }) => <p>{experiment.name}</p>}
-      </ContainerEditPage>
+      <PageResults />
     </RouterSlugProvider>
   ));

--- a/app/experimenter/nimbus-ui/src/components/PageResults/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/index.test.tsx
@@ -1,0 +1,24 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from "react";
+import { screen, render, waitFor } from "@testing-library/react";
+import PageResults from ".";
+import { RouterSlugProvider } from "../../lib/test-utils";
+import { mockExperimentQuery } from "../../lib/mocks";
+
+const { mock } = mockExperimentQuery("demo-slug");
+
+describe("PageResults", () => {
+  it("renders as expected", async () => {
+    render(
+      <RouterSlugProvider mocks={[mock]}>
+        <PageResults />
+      </RouterSlugProvider>,
+    );
+    await waitFor(() => {
+      expect(screen.queryByTestId("PageResults")).toBeInTheDocument();
+    });
+  });
+});

--- a/app/experimenter/nimbus-ui/src/components/PageResults/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/index.tsx
@@ -1,0 +1,17 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from "react";
+import { RouteComponentProps } from "@reach/router";
+import AppLayoutWithSidebarAndData from "../AppLayoutWithSidebarAndData";
+
+const PageResults: React.FunctionComponent<RouteComponentProps> = () => {
+  return (
+    <AppLayoutWithSidebarAndData title="Results" testId="PageResults">
+      {({ experiment }) => <p>{experiment.name}</p>}
+    </AppLayoutWithSidebarAndData>
+  );
+};
+
+export default PageResults;


### PR DESCRIPTION
Because:
* We need these pages for when the experiment is no longer in draft status.

This commit:
* Adds placeholder pages with routes for "Results" and "Design"
* Renames ContainerEditPage since it's used on more than just "Edit" pages

---

Open to suggestions on the new name for `ContainerEditPage`. I know `AppLayoutWithSidebarAndData` is very wordy, but it seemed to fit our naming pattern of other components and it's clear IMO what you're getting when using it. 🤷 

Also FWIW, displaying the links in the sidebar will be done in #3759.