### PR TITLE
fixes #3702 feat(nimbus): Add Audience and Metrics pages

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/App/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/App/index.tsx
@@ -13,6 +13,8 @@ import PageDesign from "../PageDesign";
 import PageResults from "../PageResults";
 import PageEditOverview from "../PageEditOverview";
 import PageEditBranches from "../PageEditBranches";
+import PageEditMetrics from "../PageEditMetrics";
+import PageEditAudience from "../PageEditAudience";
 import PageRequestReview from "../PageRequestReview";
 
 type RootProps = {
@@ -36,6 +38,8 @@ const App = ({ basepath }: { basepath: string }) => {
         <Redirect from="/" to="overview" noThrow />
         <PageEditOverview path="overview" />
         <PageEditBranches path="branches" />
+        <PageEditMetrics path="metrics" />
+        <PageEditAudience path="audience" />
       </Root>
       <PageRequestReview path=":slug/request-review" />
       <PageDesign path=":slug/design" />

--- a/app/experimenter/nimbus-ui/src/components/AppLayoutWithSidebar/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/AppLayoutWithSidebar/index.test.tsx
@@ -51,6 +51,14 @@ describe("PageNew", () => {
         "href",
         `${BASE_PATH}/my-special-slug/edit/branches`,
       );
+      expect(screen.getByTestId("nav-edit-metrics")).toHaveAttribute(
+        "href",
+        `${BASE_PATH}/my-special-slug/edit/metrics`,
+      );
+      expect(screen.getByTestId("nav-edit-audience")).toHaveAttribute(
+        "href",
+        `${BASE_PATH}/my-special-slug/edit/audience`,
+      );
       expect(screen.getByTestId("nav-request-review")).toHaveAttribute(
         "href",
         `${BASE_PATH}/my-special-slug/request-review`,

--- a/app/experimenter/nimbus-ui/src/components/AppLayoutWithSidebar/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/AppLayoutWithSidebar/index.tsx
@@ -49,12 +49,20 @@ export const AppLayoutWithSidebar = ({
               >
                 Branches
               </LinkNav>
-              <Nav.Item as="li" className="text-secondary m-1">
+              <LinkNav
+                route={`${slug}/edit/metrics`}
+                storiesOf="pages/EditMetrics"
+                testid="nav-edit-metrics"
+              >
                 Metrics
-              </Nav.Item>
-              <Nav.Item as="li" className="text-secondary m-1">
+              </LinkNav>
+              <LinkNav
+                route={`${slug}/edit/audience`}
+                storiesOf="pages/EditAudience"
+                testid="nav-edit-audience"
+              >
                 Audience
-              </Nav.Item>
+              </LinkNav>
               <LinkNav
                 route={`${slug}/request-review`}
                 storiesOf="pages/RequestReview"

--- a/app/experimenter/nimbus-ui/src/components/PageEditAudience/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditAudience/index.stories.tsx
@@ -1,0 +1,20 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from "react";
+import { storiesOf } from "@storybook/react";
+import { RouterSlugProvider } from "../../lib/test-utils";
+import { withLinks } from "@storybook/addon-links";
+import { mockExperimentQuery } from "../../lib/mocks";
+import PageEditAudience from ".";
+
+const { mock } = mockExperimentQuery("demo-slug");
+
+storiesOf("pages/EditAudience", module)
+  .addDecorator(withLinks)
+  .add("basic", () => (
+    <RouterSlugProvider mocks={[mock]}>
+      <PageEditAudience />
+    </RouterSlugProvider>
+  ));

--- a/app/experimenter/nimbus-ui/src/components/PageEditAudience/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditAudience/index.test.tsx
@@ -1,0 +1,24 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from "react";
+import { screen, render, waitFor } from "@testing-library/react";
+import PageEditAudience from ".";
+import { RouterSlugProvider } from "../../lib/test-utils";
+import { mockExperimentQuery } from "../../lib/mocks";
+
+const { mock } = mockExperimentQuery("demo-slug");
+
+describe("PageEditAudience", () => {
+  it("renders as expected", async () => {
+    render(
+      <RouterSlugProvider mocks={[mock]}>
+        <PageEditAudience />
+      </RouterSlugProvider>,
+    );
+    await waitFor(() => {
+      expect(screen.queryByTestId("PageEditAudience")).toBeInTheDocument();
+    });
+  });
+});

--- a/app/experimenter/nimbus-ui/src/components/PageEditAudience/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditAudience/index.tsx
@@ -1,0 +1,17 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from "react";
+import { RouteComponentProps } from "@reach/router";
+import AppLayoutWithSidebarAndData from "../AppLayoutWithSidebarAndData";
+
+const PageEditAudience: React.FunctionComponent<RouteComponentProps> = () => {
+  return (
+    <AppLayoutWithSidebarAndData title="Audience" testId="PageEditAudience">
+      {({ experiment }) => <p>{experiment.name}</p>}
+    </AppLayoutWithSidebarAndData>
+  );
+};
+
+export default PageEditAudience;

--- a/app/experimenter/nimbus-ui/src/components/PageEditMetrics/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditMetrics/index.stories.tsx
@@ -1,0 +1,20 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from "react";
+import { storiesOf } from "@storybook/react";
+import { RouterSlugProvider } from "../../lib/test-utils";
+import { withLinks } from "@storybook/addon-links";
+import { mockExperimentQuery } from "../../lib/mocks";
+import PageEditMetrics from ".";
+
+const { mock } = mockExperimentQuery("demo-slug");
+
+storiesOf("pages/EditMetrics", module)
+  .addDecorator(withLinks)
+  .add("basic", () => (
+    <RouterSlugProvider mocks={[mock]}>
+      <PageEditMetrics />
+    </RouterSlugProvider>
+  ));

--- a/app/experimenter/nimbus-ui/src/components/PageEditMetrics/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditMetrics/index.test.tsx
@@ -1,0 +1,24 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from "react";
+import { screen, render, waitFor } from "@testing-library/react";
+import PageEditMetrics from ".";
+import { RouterSlugProvider } from "../../lib/test-utils";
+import { mockExperimentQuery } from "../../lib/mocks";
+
+const { mock } = mockExperimentQuery("demo-slug");
+
+describe("PageEditMetrics", () => {
+  it("renders as expected", async () => {
+    render(
+      <RouterSlugProvider mocks={[mock]}>
+        <PageEditMetrics />
+      </RouterSlugProvider>,
+    );
+    await waitFor(() => {
+      expect(screen.queryByTestId("PageEditMetrics")).toBeInTheDocument();
+    });
+  });
+});

--- a/app/experimenter/nimbus-ui/src/components/PageEditMetrics/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditMetrics/index.tsx
@@ -1,0 +1,17 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from "react";
+import { RouteComponentProps } from "@reach/router";
+import AppLayoutWithSidebarAndData from "../AppLayoutWithSidebarAndData";
+
+const PageEditMetrics: React.FunctionComponent<RouteComponentProps> = () => {
+  return (
+    <AppLayoutWithSidebarAndData title="Metrics" testId="PageEditMetrics">
+      {({ experiment }) => <p>{experiment.name}</p>}
+    </AppLayoutWithSidebarAndData>
+  );
+};
+
+export default PageEditMetrics;


### PR DESCRIPTION
This commit:
* Adds EditAudience and EditMetrics placeholder pages
* Enables links in sidebar

Because:
* We need the base pages in to begin building forms out