### PR TITLE
chore(project): run make check on main

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,10 +109,6 @@ workflows:
           name: check
           requires:
             - build
-          filters:
-            branches:
-              ignore:
-                - main
       - publish_storybooks:
           name: publish_storybooks
           requires:
@@ -129,3 +125,5 @@ workflows:
           filters:
             branches:
               only: main
+          requires:
+           - check


### PR DESCRIPTION
Because

* We disabled the `up to date with main` branch protection, it's possible for changes that work as a pr to land on main and break main

This commit

* Gates deploying on running `make check` on main so if a pr lands on main that breaks we'll catch it before it gets deployed