### PR TITLE
chore (project): run build on main

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,10 +101,6 @@ workflows:
     jobs:
       - build:
           name: build
-          filters:
-            branches:
-              ignore:
-                - main
       - check:
           name: check
           requires:


### PR DESCRIPTION
Because

* We want to run check on main and check requires build

This commit

* Enables build on main.  Derp.