### PR TITLE
fixes #3932 feat(nimbus): Add Summary page with summary table

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/App/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/App/index.test.tsx
@@ -48,18 +48,15 @@ describe("App", () => {
 
   describe(":slug routes", () => {
     it("redirects from ':slug/edit' to ':slug/edit/overview'", async () => {
-      const {
-        history: { navigate },
-      } = renderWithRouter(
+      renderWithRouter(
         <MockedCache mocks={[mock]}>
           <App basepath="/" />
         </MockedCache>,
         {
-          route: `/my-special-slug/`,
+          route: `/my-special-slug/edit`,
         },
       );
 
-      await navigate("/my-special-slug/edit");
       // waitFor the redirect
       await waitFor(() => {
         expect(screen.getByTestId("PageEditOverview")).toBeInTheDocument();

--- a/app/experimenter/nimbus-ui/src/components/App/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/App/index.tsx
@@ -9,6 +9,7 @@ import { GET_CONFIG_QUERY } from "../../gql/config";
 import PageLoading from "../PageLoading";
 import PageHome from "../PageHome";
 import PageNew from "../PageNew";
+import PageSummary from "../PageSummary";
 import PageDesign from "../PageDesign";
 import PageResults from "../PageResults";
 import PageEditOverview from "../PageEditOverview";
@@ -34,6 +35,7 @@ const App = ({ basepath }: { basepath: string }) => {
     <Router {...{ basepath }}>
       <PageHome path="/" />
       <PageNew path="new" />
+      <PageSummary path=":slug" />
       <Root path=":slug/edit">
         <Redirect from="/" to="overview" noThrow />
         <PageEditOverview path="overview" />

--- a/app/experimenter/nimbus-ui/src/components/AppLayoutWithExperiment/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/AppLayoutWithExperiment/index.stories.tsx
@@ -1,0 +1,33 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from "react";
+import { storiesOf } from "@storybook/react";
+import { RouterSlugProvider } from "../../lib/test-utils";
+import { withLinks } from "@storybook/addon-links";
+import AppLayoutWithExperiment from ".";
+import { mockExperimentQuery } from "../../lib/mocks";
+
+const { mock } = mockExperimentQuery("demo-slug");
+
+storiesOf("components/AppLayoutWithExperiment", module)
+  .addDecorator(withLinks)
+  .add("default, with sidebar", () => (
+    <RouterSlugProvider mocks={[mock]}>
+      <AppLayoutWithExperiment title="Howdy!" testId="AppLayoutWithExperiment">
+        {({ experiment }) => <p>{experiment.name}</p>}
+      </AppLayoutWithExperiment>
+    </RouterSlugProvider>
+  ))
+  .add("without sidebar", () => (
+    <RouterSlugProvider mocks={[mock]}>
+      <AppLayoutWithExperiment
+        title="Howdy!"
+        testId="AppLayoutWithExperiment"
+        sidebar={false}
+      >
+        {({ experiment }) => <p>{experiment.name}</p>}
+      </AppLayoutWithExperiment>
+    </RouterSlugProvider>
+  ));

--- a/app/experimenter/nimbus-ui/src/components/AppLayoutWithExperiment/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/AppLayoutWithExperiment/index.test.tsx
@@ -3,27 +3,34 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React from "react";
-import { render, screen, waitFor } from "@testing-library/react";
-import AppLayoutWithSidebarAndData, { POLL_INTERVAL } from ".";
+import { render, screen, waitFor, act } from "@testing-library/react";
+import AppLayoutWithExperiment, { POLL_INTERVAL } from ".";
 import { renderWithRouter, RouterSlugProvider } from "../../lib/test-utils";
 import { mockExperimentQuery } from "../../lib/mocks";
 import { NimbusExperimentStatus } from "../../types/globalTypes";
 import { BASE_PATH } from "../../lib/constants";
-import { act } from "@testing-library/react";
 
 jest.useFakeTimers();
 
-describe("AppLayoutWithSidebarAndData", () => {
+describe("AppLayoutWithExperiment", () => {
   it("renders as expected", async () => {
     const { mock } = mockExperimentQuery("demo-slug");
     render(<Subject mocks={[mock]} />);
     await waitFor(() => {
-      expect(
-        screen.getByTestId("AppLayoutWithSidebarAndData"),
-      ).toBeInTheDocument();
+      expect(screen.getByTestId("AppLayoutWithExperiment")).toBeInTheDocument();
       expect(screen.getByTestId("page-title")).toBeInTheDocument();
       expect(screen.getByTestId("page-title")).toHaveTextContent("Howdy!");
       expect(screen.getByTestId("child")).toBeInTheDocument();
+      expect(screen.getByTestId("header-experiment")).toBeInTheDocument();
+      expect(screen.getByTestId("nav-sidebar")).toBeInTheDocument();
+    });
+  });
+
+  it("does not render the sidebar if prop is set to false", async () => {
+    const { mock } = mockExperimentQuery("demo-slug");
+    render(<Subject mocks={[mock]} sidebar={false} />);
+    await waitFor(() => {
+      expect(screen.queryByTestId("nav-sidebar")).not.toBeInTheDocument();
     });
   });
 
@@ -109,17 +116,19 @@ describe("AppLayoutWithSidebarAndData", () => {
 const Subject = ({
   mocks = [],
   polling = false,
+  sidebar = true,
 }: {
   mocks?: React.ComponentProps<typeof RouterSlugProvider>["mocks"];
   polling?: boolean;
+  sidebar?: boolean;
 }) => (
   <RouterSlugProvider {...{ mocks }}>
-    <AppLayoutWithSidebarAndData
+    <AppLayoutWithExperiment
       title="Howdy!"
-      testId="AppLayoutWithSidebarAndData"
-      {...{ polling }}
+      testId="AppLayoutWithExperiment"
+      {...{ polling, sidebar }}
     >
       {({ experiment }) => <p data-testid="child">{experiment.slug}</p>}
-    </AppLayoutWithSidebarAndData>
+    </AppLayoutWithExperiment>
   </RouterSlugProvider>
 );

--- a/app/experimenter/nimbus-ui/src/components/AppLayoutWithExperiment/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/AppLayoutWithExperiment/index.tsx
@@ -10,28 +10,31 @@ import PageLoading from "../PageLoading";
 import PageExperimentNotFound from "../PageExperimentNotFound";
 import { useExperiment } from "../../hooks";
 import { getExperiment_experimentBySlug } from "../../types/getExperiment";
+import AppLayout from "../AppLayout";
 
-type AppLayoutWithSidebarAndDataChildrenProps = {
+type AppLayoutWithExperimentChildrenProps = {
   experiment: getExperiment_experimentBySlug;
 };
 
-type AppLayoutWithSidebarAndDataProps = {
+type AppLayoutWithExperimentProps = {
   children: (
-    props: AppLayoutWithSidebarAndDataChildrenProps,
+    props: AppLayoutWithExperimentChildrenProps,
   ) => React.ReactNode | null;
   testId: string;
   title: string;
   polling?: boolean;
+  sidebar?: boolean;
 } & RouteComponentProps;
 
 export const POLL_INTERVAL = 30000;
 
-const AppLayoutWithSidebarAndData = ({
+const AppLayoutWithExperiment = ({
   children,
   testId,
   title,
+  sidebar = true,
   polling = false,
-}: AppLayoutWithSidebarAndDataProps) => {
+}: AppLayoutWithExperimentProps) => {
   const { slug } = useParams();
   const {
     experiment,
@@ -61,7 +64,7 @@ const AppLayoutWithSidebarAndData = ({
   const { name, status } = experiment;
 
   return (
-    <AppLayoutWithSidebar>
+    <Layout {...{ sidebar, children }}>
       <section data-testid={testId}>
         <HeaderEditExperiment
           {...{
@@ -75,8 +78,21 @@ const AppLayoutWithSidebarAndData = ({
         </h2>
         {children({ experiment })}
       </section>
-    </AppLayoutWithSidebar>
+    </Layout>
   );
 };
 
-export default AppLayoutWithSidebarAndData;
+const Layout = ({
+  sidebar,
+  children,
+}: {
+  sidebar: boolean;
+  children: React.ReactElement;
+}) =>
+  sidebar ? (
+    <AppLayoutWithSidebar>{children}</AppLayoutWithSidebar>
+  ) : (
+    <AppLayout>{children}</AppLayout>
+  );
+
+export default AppLayoutWithExperiment;

--- a/app/experimenter/nimbus-ui/src/components/AppLayoutWithSidebar/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/AppLayoutWithSidebar/index.test.tsx
@@ -13,7 +13,7 @@ import { MockedCache, mockExperimentQuery } from "../../lib/mocks";
 
 const { mock } = mockExperimentQuery("my-special-slug");
 
-describe("PageNew", () => {
+describe("AppLayoutWithSidebar", () => {
   it("renders app layout content with children", () => {
     renderWithRouter(
       <MockedCache mocks={[mock]}>
@@ -76,7 +76,7 @@ describe("PageNew", () => {
       const {
         history: { navigate },
       } = renderWithRouter(
-        <MockedCache mocks={[mock, mock]}>
+        <MockedCache mocks={[mock, mock, mock]}>
           <App basepath="/" />
         </MockedCache>,
         {

--- a/app/experimenter/nimbus-ui/src/components/AppLayoutWithSidebar/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/AppLayoutWithSidebar/index.tsx
@@ -30,7 +30,7 @@ export const AppLayoutWithSidebar = ({
           xl="2"
           className="bg-light pt-2 border-right shadow-sm"
         >
-          <nav data-testid="sidebarNav">
+          <nav data-testid="nav-sidebar">
             <Nav className="flex-column" as="ul">
               <LinkNav storiesOf="pages/Home" className="mb-2">
                 Experiments

--- a/app/experimenter/nimbus-ui/src/components/PageDesign/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageDesign/index.tsx
@@ -4,13 +4,13 @@
 
 import React from "react";
 import { RouteComponentProps } from "@reach/router";
-import AppLayoutWithSidebarAndData from "../AppLayoutWithSidebarAndData";
+import AppLayoutWithExperiment from "../AppLayoutWithExperiment";
 
 const PageDesign: React.FunctionComponent<RouteComponentProps> = () => {
   return (
-    <AppLayoutWithSidebarAndData title="Design" testId="PageDesign">
+    <AppLayoutWithExperiment title="Design" testId="PageDesign">
       {({ experiment }) => <p>{experiment.name}</p>}
-    </AppLayoutWithSidebarAndData>
+    </AppLayoutWithExperiment>
   );
 };
 

--- a/app/experimenter/nimbus-ui/src/components/PageEditAudience/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditAudience/index.tsx
@@ -4,13 +4,13 @@
 
 import React from "react";
 import { RouteComponentProps } from "@reach/router";
-import AppLayoutWithSidebarAndData from "../AppLayoutWithSidebarAndData";
+import AppLayoutWithExperiment from "../AppLayoutWithExperiment";
 
 const PageEditAudience: React.FunctionComponent<RouteComponentProps> = () => {
   return (
-    <AppLayoutWithSidebarAndData title="Audience" testId="PageEditAudience">
+    <AppLayoutWithExperiment title="Audience" testId="PageEditAudience">
       {({ experiment }) => <p>{experiment.name}</p>}
-    </AppLayoutWithSidebarAndData>
+    </AppLayoutWithExperiment>
   );
 };
 

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/index.tsx
@@ -7,7 +7,7 @@ import { RouteComponentProps } from "@reach/router";
 import { useConfig } from "../../hooks";
 import FormBranches from "../FormBranches";
 import LinkExternal from "../LinkExternal";
-import AppLayoutWithSidebarAndData from "../AppLayoutWithSidebarAndData";
+import AppLayoutWithExperiment from "../AppLayoutWithExperiment";
 
 // TODO: find this doco URL
 const BRANCHES_DOC_URL =
@@ -17,7 +17,7 @@ const PageEditBranches: React.FunctionComponent<RouteComponentProps> = () => {
   const { featureConfig } = useConfig();
 
   return (
-    <AppLayoutWithSidebarAndData title="Branches" testId="PageEditBranches">
+    <AppLayoutWithExperiment title="Branches" testId="PageEditBranches">
       {({ experiment }) => (
         <>
           <p>
@@ -37,7 +37,7 @@ const PageEditBranches: React.FunctionComponent<RouteComponentProps> = () => {
           />
         </>
       )}
-    </AppLayoutWithSidebarAndData>
+    </AppLayoutWithExperiment>
   );
 };
 

--- a/app/experimenter/nimbus-ui/src/components/PageEditMetrics/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditMetrics/index.tsx
@@ -4,13 +4,13 @@
 
 import React from "react";
 import { RouteComponentProps } from "@reach/router";
-import AppLayoutWithSidebarAndData from "../AppLayoutWithSidebarAndData";
+import AppLayoutWithExperiment from "../AppLayoutWithExperiment";
 
 const PageEditMetrics: React.FunctionComponent<RouteComponentProps> = () => {
   return (
-    <AppLayoutWithSidebarAndData title="Metrics" testId="PageEditMetrics">
+    <AppLayoutWithExperiment title="Metrics" testId="PageEditMetrics">
       {({ experiment }) => <p>{experiment.name}</p>}
-    </AppLayoutWithSidebarAndData>
+    </AppLayoutWithExperiment>
   );
 };
 

--- a/app/experimenter/nimbus-ui/src/components/PageEditOverview/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditOverview/index.tsx
@@ -5,7 +5,7 @@
 import React, { useCallback, useRef, useState } from "react";
 import { navigate, RouteComponentProps } from "@reach/router";
 import FormOverview from "../FormOverview";
-import AppLayoutWithSidebarAndData from "../AppLayoutWithSidebarAndData";
+import AppLayoutWithExperiment from "../AppLayoutWithExperiment";
 import { useMutation } from "@apollo/client";
 import { UPDATE_EXPERIMENT_OVERVIEW_MUTATION } from "../../gql/experiments";
 import { SUBMIT_ERROR } from "../../lib/constants";
@@ -65,7 +65,7 @@ const PageEditOverview: React.FunctionComponent<PageEditOverviewProps> = () => {
   }, []);
 
   return (
-    <AppLayoutWithSidebarAndData title="Overview" testId="PageEditOverview">
+    <AppLayoutWithExperiment title="Overview" testId="PageEditOverview">
       {({ experiment }) => {
         currentExperiment.current = experiment;
 
@@ -81,7 +81,7 @@ const PageEditOverview: React.FunctionComponent<PageEditOverviewProps> = () => {
           />
         );
       }}
-    </AppLayoutWithSidebarAndData>
+    </AppLayoutWithExperiment>
   );
 };
 

--- a/app/experimenter/nimbus-ui/src/components/PageRequestReview/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageRequestReview/index.tsx
@@ -5,7 +5,7 @@
 import React, { useCallback, useRef, useState } from "react";
 import { useMutation } from "@apollo/client";
 import { RouteComponentProps } from "@reach/router";
-import AppLayoutWithSidebarAndData from "../AppLayoutWithSidebarAndData";
+import AppLayoutWithExperiment from "../AppLayoutWithExperiment";
 import TableSummary from "../TableSummary";
 import { SUBMIT_ERROR } from "../../lib/constants";
 import { UPDATE_EXPERIMENT_STATUS_MUTATION } from "../../gql/experiments";
@@ -61,7 +61,7 @@ const PageRequestReview: React.FunctionComponent<PageRequestReviewProps> = ({
   }, [submitForReview, currentExperiment]);
 
   return (
-    <AppLayoutWithSidebarAndData
+    <AppLayoutWithExperiment
       title="Review &amp; Launch"
       testId="PageRequestReview"
       {...{ polling }}
@@ -104,7 +104,7 @@ const PageRequestReview: React.FunctionComponent<PageRequestReviewProps> = ({
           </>
         );
       }}
-    </AppLayoutWithSidebarAndData>
+    </AppLayoutWithExperiment>
   );
 };
 

--- a/app/experimenter/nimbus-ui/src/components/PageResults/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/index.tsx
@@ -4,7 +4,7 @@
 
 import React from "react";
 import { RouteComponentProps, useParams } from "@reach/router";
-import AppLayoutWithSidebarAndData from "../AppLayoutWithSidebarAndData";
+import AppLayoutWithExperiment from "../AppLayoutWithExperiment";
 import { useAnalysis } from "../../hooks";
 import { Alert } from "react-bootstrap";
 import LinkExternal from "../LinkExternal";
@@ -14,7 +14,11 @@ const PageResults: React.FunctionComponent<RouteComponentProps> = () => {
   const { loading, error, result } = useAnalysis(slug);
 
   return (
-    <AppLayoutWithSidebarAndData title="Results" testId="PageResults">
+    <AppLayoutWithExperiment
+      title="Results"
+      testId="PageResults"
+      sidebar={false}
+    >
       {({ experiment }) => (
         <>
           <p>
@@ -43,7 +47,7 @@ const PageResults: React.FunctionComponent<RouteComponentProps> = () => {
           )}
         </>
       )}
-    </AppLayoutWithSidebarAndData>
+    </AppLayoutWithExperiment>
   );
 };
 

--- a/app/experimenter/nimbus-ui/src/components/PageSummary/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageSummary/index.stories.tsx
@@ -6,20 +6,15 @@ import React from "react";
 import { storiesOf } from "@storybook/react";
 import { RouterSlugProvider } from "../../lib/test-utils";
 import { withLinks } from "@storybook/addon-links";
-import AppLayoutWithSidebarAndData from ".";
 import { mockExperimentQuery } from "../../lib/mocks";
+import PageSummary from ".";
 
 const { mock } = mockExperimentQuery("demo-slug");
 
-storiesOf("components/AppLayoutWithSidebarAndData", module)
+storiesOf("pages/Summary", module)
   .addDecorator(withLinks)
   .add("basic", () => (
     <RouterSlugProvider mocks={[mock]}>
-      <AppLayoutWithSidebarAndData
-        title="Howdy!"
-        testId="AppLayoutWithSidebarAndData"
-      >
-        {({ experiment }) => <p>{experiment.name}</p>}
-      </AppLayoutWithSidebarAndData>
+      <PageSummary polling={false} />
     </RouterSlugProvider>
   ));

--- a/app/experimenter/nimbus-ui/src/components/PageSummary/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageSummary/index.test.tsx
@@ -1,0 +1,29 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from "react";
+import { screen, render, waitFor } from "@testing-library/react";
+import PageSummary from ".";
+import { RouterSlugProvider } from "../../lib/test-utils";
+import { mockExperimentQuery } from "../../lib/mocks";
+
+const { mock } = mockExperimentQuery("demo-slug");
+
+describe("PageSummary", () => {
+  it("renders as expected", async () => {
+    render(
+      <RouterSlugProvider mocks={[mock]}>
+        <PageSummary />
+      </RouterSlugProvider>,
+    );
+    await waitFor(() => {
+      expect(screen.queryByTestId("PageSummary")).toBeInTheDocument();
+    });
+
+    // uses correct AppLayout
+    expect(screen.queryByTestId("nav-sidebar")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("header-experiment")).toBeInTheDocument();
+    expect(screen.queryByTestId("table-summary")).toBeInTheDocument();
+  });
+});

--- a/app/experimenter/nimbus-ui/src/components/PageSummary/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageSummary/index.tsx
@@ -1,0 +1,27 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from "react";
+import { RouteComponentProps } from "@reach/router";
+import AppLayoutWithExperiment from "../AppLayoutWithExperiment";
+import TableSummary from "../TableSummary";
+
+type PageRequestReviewProps = {
+  polling?: boolean;
+} & RouteComponentProps;
+
+const PageSummary: React.FunctionComponent<PageRequestReviewProps> = ({
+  polling = true,
+}) => (
+  <AppLayoutWithExperiment
+    title="Experiment Summary"
+    testId="PageSummary"
+    sidebar={false}
+    {...{ polling }}
+  >
+    {({ experiment }) => <TableSummary {...{ experiment }} />}
+  </AppLayoutWithExperiment>
+);
+
+export default PageSummary;


### PR DESCRIPTION
Because:
* We want users to be able to hit the URL with just the slug to reflect a summary page with experiment info.

This commit:
* Adds a PageSummary page shown at /:slug
* Renames AppLayoutWithSidebarAndData to AppLayoutWithExperiment