### PR TITLE
fixes #3958 bug(nimbus): add opt-out pref to targeting

### DIFF
--- a/app/experimenter/experiments/api/v6/serializers.py
+++ b/app/experimenter/experiments/api/v6/serializers.py
@@ -116,7 +116,11 @@ class NimbusExperimentArgumentsSerializer(serializers.ModelSerializer):
 
             targeting_config = obj.targeting_config.targeting.format(experiment=obj)
 
-            return f"{channels_expr}{version_expr}{targeting_config}"
+            # TODO: Remove opt-out after Firefox 84 is the earliest supported Desktop
+            return (
+                f"{channels_expr}{version_expr}{targeting_config} "
+                "&& 'app.shield.optoutstudies.enabled'|preferenceValue"
+            )
 
 
 class NimbusExperimentSerializer(NimbusExperimentArgumentsSerializer):

--- a/app/experimenter/experiments/tests/api/v6/test_serializers.py
+++ b/app/experimenter/experiments/tests/api/v6/test_serializers.py
@@ -65,7 +65,8 @@ class TestNimbusExperimentSerializer(TestCase):
                     "targeting": (
                         'channel in ["nightly", "beta", "release"] '
                         "&& version|versionCompare('80.!') >= 0 "
-                        "&& localeLanguageCode == 'en'"
+                        "&& localeLanguageCode == 'en' "
+                        "&& 'app.shield.optoutstudies.enabled'|preferenceValue"
                     ),
                     "userFacingDescription": experiment.public_description,
                     "userFacingName": experiment.name,
@@ -117,7 +118,11 @@ class TestNimbusExperimentSerializer(TestCase):
         serializer = NimbusExperimentSerializer(experiment)
         self.assertEqual(
             serializer.data["targeting"],
-            "version|versionCompare('80.!') >= 0 && localeLanguageCode == 'en'",
+            (
+                "version|versionCompare('80.!') >= 0 "
+                "&& localeLanguageCode == 'en' "
+                "&& 'app.shield.optoutstudies.enabled'|preferenceValue"
+            ),
         )
 
     def test_serializer_outputs_targeting_for_experiment_without_firefox_min_version(
@@ -137,7 +142,11 @@ class TestNimbusExperimentSerializer(TestCase):
         serializer = NimbusExperimentSerializer(experiment)
         self.assertEqual(
             serializer.data["targeting"],
-            'channel in ["nightly", "beta", "release"] && localeLanguageCode == \'en\'',
+            (
+                'channel in ["nightly", "beta", "release"] '
+                "&& localeLanguageCode == 'en' "
+                "&& 'app.shield.optoutstudies.enabled'|preferenceValue"
+            ),
         )
 
 


### PR DESCRIPTION
  Because

  * Firefox Desktop <84 does not have global opt-out preference disabling

  This commit

  * Add opt-out preference app.shield.optoutstudies.enabled to targeting