### PR TITLE
fix #3696 feat(nimbus): update overview form to match figma specs

### DIFF
--- a/app/experimenter/experiments/api/v5/inputs.py
+++ b/app/experimenter/experiments/api/v5/inputs.py
@@ -11,20 +11,18 @@ from experimenter.experiments.api.v5.types import (
 
 class ExperimentInput(graphene.InputObjectType):
     client_mutation_id = graphene.String()
-    name = graphene.String()
-    application = NimbusExperimentApplication()
-    public_description = graphene.String()
-    hypothesis = graphene.String()
+    name = graphene.String(required=True)
+    hypothesis = graphene.String(required=True)
 
 
 class CreateExperimentInput(ExperimentInput):
     name = graphene.String(required=True)
-    hypothesis = graphene.String(required=True)
     application = NimbusExperimentApplication(required=True)
 
 
 class UpdateExperimentInput(ExperimentInput):
     id = graphene.ID(required=True)
+    public_description = graphene.String()
 
 
 class BranchType(graphene.InputObjectType):

--- a/app/experimenter/experiments/api/v5/query.py
+++ b/app/experimenter/experiments/api/v5/query.py
@@ -29,6 +29,7 @@ class NimbusConfigurationType(graphene.ObjectType):
     firefox_min_version = graphene.List(NimbusLabelValueType)
     probe_sets = graphene.List(NimbusProbeSetType)
     targeting_config_slug = graphene.List(NimbusLabelValueType)
+    hypothesis_default = graphene.String()
 
     def _text_choices_to_label_value_list(root, text_choices):
         return [
@@ -67,6 +68,9 @@ class NimbusConfigurationType(graphene.ObjectType):
                 )
             )
         return app_channels
+
+    def resolve_hypothesis_default(root, info):
+        return NimbusExperiment.HYPOTHESIS_DEFAULT
 
 
 class NimbusReadyForReviewType(graphene.ObjectType):

--- a/app/experimenter/experiments/api/v5/serializers.py
+++ b/app/experimenter/experiments/api/v5/serializers.py
@@ -113,6 +113,13 @@ class NimbusExperimentOverviewSerializer(
 
         return name
 
+    def validate_hypothesis(self, hypothesis):
+        if hypothesis.strip() == NimbusExperiment.HYPOTHESIS_DEFAULT.strip():
+            raise serializers.ValidationError(
+                "Please describe the hypothesis of your experiment."
+            )
+        return hypothesis
+
     def create(self, validated_data):
         validated_data.update(
             {

--- a/app/experimenter/experiments/tests/api/v5/test_query.py
+++ b/app/experimenter/experiments/tests/api/v5/test_query.py
@@ -198,6 +198,7 @@ class TestNimbusQuery(GraphQLTestCase):
                         label
                         value
                     }
+                    hypothesisDefault
                 }
             }
             """,

--- a/app/experimenter/experiments/tests/api/v5/test_serializers.py
+++ b/app/experimenter/experiments/tests/api/v5/test_serializers.py
@@ -47,7 +47,7 @@ class TestCreateNimbusExperimentOverviewSerializer(TestCase):
         data = {
             "name": "Test 1234",
             "hypothesis": "Test hypothesis",
-            "application": "firefox-desktop",
+            "application": NimbusExperiment.Application.DESKTOP.value,
             "public_description": "Test description",
         }
 
@@ -67,7 +67,7 @@ class TestCreateNimbusExperimentOverviewSerializer(TestCase):
         data = {
             "name": "&^%&^%&^%&^%^&%^&",
             "hypothesis": "Test hypothesis",
-            "application": "firefox-desktop",
+            "application": NimbusExperiment.Application.DESKTOP.value,
             "public_description": "Test description",
         }
 
@@ -89,7 +89,7 @@ class TestCreateNimbusExperimentOverviewSerializer(TestCase):
         data = {
             "name": "non-unique slug",
             "hypothesis": "Test hypothesis",
-            "application": "firefox-desktop",
+            "application": NimbusExperiment.Application.DESKTOP.value,
             "public_description": "Test description",
         }
 
@@ -102,6 +102,20 @@ class TestCreateNimbusExperimentOverviewSerializer(TestCase):
             "Name maps to a pre-existing slug, please choose another name",
             serializer.errors["name"],
         )
+
+    def test_serializer_rejects_default_hypothesis(self):
+        data = {
+            "name": "Test 1234",
+            "hypothesis": NimbusExperiment.HYPOTHESIS_DEFAULT,
+            "application": NimbusExperiment.Application.DESKTOP.value,
+            "public_description": "Test description",
+        }
+
+        serializer = NimbusExperimentOverviewSerializer(
+            data=data, context={"user": self.user}
+        )
+        self.assertFalse(serializer.is_valid())
+        self.assertIn("hypothesis", serializer.errors)
 
     def test_saves_new_experiment_with_changelog(self):
         data = {

--- a/app/experimenter/nimbus-ui/schema.graphql
+++ b/app/experimenter/nimbus-ui/schema.graphql
@@ -18,9 +18,8 @@ type CreateExperiment {
 input CreateExperimentInput {
   clientMutationId: String
   name: String!
-  application: NimbusExperimentApplication!
-  publicDescription: String
   hypothesis: String!
+  application: NimbusExperimentApplication!
 }
 
 scalar Decimal
@@ -57,6 +56,7 @@ type NimbusConfigurationType {
   firefoxMinVersion: [NimbusLabelValueType]
   probeSets: [NimbusProbeSetType]
   targetingConfigSlug: [NimbusLabelValueType]
+  hypothesisDefault: String
 }
 
 enum NimbusExperimentApplication {
@@ -282,11 +282,10 @@ input UpdateExperimentBranchesInput {
 
 input UpdateExperimentInput {
   clientMutationId: String
-  name: String
-  application: NimbusExperimentApplication
-  publicDescription: String
-  hypothesis: String
+  name: String!
+  hypothesis: String!
   id: ID!
+  publicDescription: String
 }
 
 type UpdateExperimentOverview {

--- a/app/experimenter/nimbus-ui/src/components/FormOverview/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/FormOverview/index.test.tsx
@@ -40,15 +40,15 @@ describe("FormOverview", () => {
       ["Application", expected.application],
     ]) {
       const fieldName = screen.getByLabelText(labelText);
-      expect(fieldName).not.toHaveClass("is-invalid");
-      expect(fieldName).not.toHaveClass("is-valid");
 
       await act(async () => {
         fireEvent.click(fieldName);
         fireEvent.blur(fieldName);
       });
-      expect(fieldName).toHaveClass("is-invalid");
-      expect(fieldName).not.toHaveClass("is-valid");
+      if (labelText !== "Hypothesis") {
+        expect(fieldName).toHaveClass("is-invalid");
+        expect(fieldName).not.toHaveClass("is-valid");
+      }
 
       await act(async () => {
         fireEvent.change(fieldName, { target: { value: fieldValue } });
@@ -63,7 +63,6 @@ describe("FormOverview", () => {
     for (const [labelText, fieldValue] of [
       ["Public name", expected.name],
       ["Hypothesis", expected.hypothesis],
-      ["Application", expected.application],
       ["Public description", expected.publicDescription],
     ]) {
       const fieldName = screen.getByLabelText(labelText) as HTMLInputElement;
@@ -82,9 +81,6 @@ describe("FormOverview", () => {
     render(<Subject {...{ onSubmit }} />);
 
     const submitButton = screen.getByText("Create experiment");
-    await act(async () => void fireEvent.click(submitButton));
-    expect(onSubmit).not.toHaveBeenCalled();
-
     await act(async () => fillOutNewForm(expected));
     await act(async () => void fireEvent.click(submitButton));
 
@@ -98,7 +94,6 @@ describe("FormOverview", () => {
     const expected = {
       name: data!.name,
       hypothesis: data!.hypothesis as string,
-      application: data!.application as string,
       publicDescription: data!.publicDescription as string,
     };
 
@@ -108,7 +103,6 @@ describe("FormOverview", () => {
     const nextButton = screen.getByText("Next");
     const nameField = screen.getByLabelText("Public name");
 
-    expect(submitButton).not.toBeEnabled();
     expect(nextButton).toBeEnabled();
 
     await act(async () => checkExistingForm(expected));
@@ -117,7 +111,6 @@ describe("FormOverview", () => {
       fireEvent.change(nameField, { target: { value: "" } });
       fireEvent.blur(nameField);
     });
-    expect(submitButton).not.toBeEnabled();
 
     // Update the name in the form and expected data
     const newName = "Name THIS";

--- a/app/experimenter/nimbus-ui/src/components/FormOverview/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/components/FormOverview/mocks.tsx
@@ -8,6 +8,7 @@ import { MockedCache } from "../../lib/mocks";
 
 export const Subject = ({
   isLoading = false,
+  isServerValid = true,
   submitErrors = {},
   onSubmit = () => {},
   onCancel,
@@ -18,6 +19,7 @@ export const Subject = ({
     <FormOverview
       {...{
         isLoading,
+        isServerValid,
         submitErrors,
         onSubmit,
         onCancel,

--- a/app/experimenter/nimbus-ui/src/components/PageEditOverview/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditOverview/index.test.tsx
@@ -26,7 +26,8 @@ jest.mock("@reach/router", () => ({
   navigate: jest.fn(),
 }));
 
-let mockSubmit: Record<string, string> = {};
+let mockSubmitData: Record<string, string> = {};
+const mockSubmit = jest.fn();
 
 describe("PageEditOverview", () => {
   let mutationMock: any;
@@ -44,18 +45,17 @@ describe("PageEditOverview", () => {
   };
 
   beforeEach(() => {
-    mockSubmit = {
+    mockSubmitData = {
       name: data!.name,
       hypothesis: data!.hypothesis!,
-      application: data!.application!,
       publicDescription: data!.publicDescription!,
     };
     mutationMock = mockExperimentMutation(
       UPDATE_EXPERIMENT_OVERVIEW_MUTATION,
-      { ...mockSubmit, id: data!.id },
+      { ...mockSubmitData, id: data!.id },
       "updateExperimentOverview",
       {
-        experiment: mockSubmit,
+        experiment: mockSubmitData,
       },
     );
   });
@@ -70,10 +70,15 @@ describe("PageEditOverview", () => {
 
   it("handles form submission", async () => {
     render(<Subject mocks={[mock, mutationMock]} />);
+
+    let submitButton: HTMLButtonElement;
     await waitFor(() => {
-      const submitButton = screen.getByTestId("submit");
+      submitButton = screen.getByTestId("submit") as HTMLButtonElement;
+    });
+    await act(async () => {
       fireEvent.click(submitButton);
     });
+    expect(mockSubmit).toHaveBeenCalled();
   });
 
   it("handles experiment form submission with server-side validation errors", async () => {
@@ -138,7 +143,8 @@ jest.mock("../FormOverview", () => ({
   default: (props: React.ComponentProps<typeof FormOverview>) => {
     const handleSubmit = (ev: React.FormEvent) => {
       ev.preventDefault();
-      props.onSubmit(mockSubmit, jest.fn());
+      mockSubmit();
+      props.onSubmit(mockSubmitData, jest.fn());
     };
     const handleNext = (ev: React.FormEvent) => {
       ev.preventDefault();

--- a/app/experimenter/nimbus-ui/src/components/PageEditOverview/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditOverview/index.tsx
@@ -23,12 +23,10 @@ const PageEditOverview: React.FunctionComponent<PageEditOverviewProps> = () => {
 
   const [submitErrors, setSubmitErrors] = useState<Record<string, any>>({});
   const currentExperiment = useRef<getExperiment_experimentBySlug>();
+  const [isServerValid, setIsServerValid] = useState(true);
 
   const onFormSubmit = useCallback(
-    async (
-      { name, hypothesis, application, publicDescription }: Record<string, any>,
-      resetForm: Function,
-    ) => {
+    async ({ name, hypothesis, publicDescription }: Record<string, any>) => {
       try {
         const result = await updateExperimentOverview({
           variables: {
@@ -36,7 +34,6 @@ const PageEditOverview: React.FunctionComponent<PageEditOverviewProps> = () => {
               id: currentExperiment.current!.id,
               name,
               hypothesis,
-              application,
               publicDescription,
             },
           },
@@ -49,10 +46,12 @@ const PageEditOverview: React.FunctionComponent<PageEditOverviewProps> = () => {
         const { message } = result.data.updateExperimentOverview;
 
         if (message !== "success" && typeof message === "object") {
+          setIsServerValid(false);
           return void setSubmitErrors(message);
+        } else {
+          setIsServerValid(true);
+          setSubmitErrors({});
         }
-
-        resetForm({ name, hypothesis, application, publicDescription });
       } catch (error) {
         setSubmitErrors({ "*": SUBMIT_ERROR });
       }
@@ -73,6 +72,7 @@ const PageEditOverview: React.FunctionComponent<PageEditOverviewProps> = () => {
           <FormOverview
             {...{
               isLoading: loading,
+              isServerValid,
               experiment,
               submitErrors,
               onSubmit: onFormSubmit,

--- a/app/experimenter/nimbus-ui/src/components/PageNew/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageNew/index.tsx
@@ -7,6 +7,9 @@ import { RouteComponentProps } from "@reach/router";
 import AppLayout from "../AppLayout";
 import LinkExternal from "../LinkExternal";
 import FormOverview from "../FormOverview";
+import Row from "react-bootstrap/Row";
+import Col from "react-bootstrap/Col";
+import { ReactComponent as DeleteIcon } from "../../images/x.svg";
 
 import { useMutation } from "@apollo/client";
 import { CREATE_EXPERIMENT_MUTATION } from "../../gql/experiments";
@@ -27,6 +30,7 @@ const PageNew: React.FunctionComponent<PageNewProps> = () => {
   >(CREATE_EXPERIMENT_MUTATION);
 
   const [submitErrors, setSubmitErrors] = useState<Record<string, any>>({});
+  const [isServerValid, setIsServerValid] = useState(true);
 
   const onFormCancel = useCallback(() => {
     navigate(".");
@@ -47,12 +51,16 @@ const PageNew: React.FunctionComponent<PageNewProps> = () => {
         const { message, nimbusExperiment } = result.data.createExperiment;
 
         if (message !== "success" && typeof message === "object") {
+          setIsServerValid(false);
           return void setSubmitErrors(message);
+        } else {
+          setIsServerValid(true);
+          setSubmitErrors({});
         }
         resetForm();
         navigate(`${nimbusExperiment!.slug}/edit/overview`);
       } catch (error) {
-        setSubmitErrors({ "*": SUBMIT_ERROR });
+        setSubmitErrors({ "*": `${SUBMIT_ERROR}` });
       }
     },
     [createExperiment],
@@ -60,7 +68,16 @@ const PageNew: React.FunctionComponent<PageNewProps> = () => {
 
   return (
     <AppLayout testid="PageNew">
-      <h1 className="h2">Create a new Experiment</h1>
+      <Row>
+        <Col>
+          <h1 className="h2">Create a new Experiment</h1>
+        </Col>
+        <Col className="text-right">
+          <button title="Cancel" className="btn pr-0" onClick={onFormCancel}>
+            <DeleteIcon width="18" height="18" />{" "}
+          </button>
+        </Col>
+      </Row>
       <p>
         Before launching an experiment, review the{" "}
         <LinkExternal href={TRAINING_DOC_URL}>
@@ -72,6 +89,7 @@ const PageNew: React.FunctionComponent<PageNewProps> = () => {
         <FormOverview
           {...{
             isLoading: loading,
+            isServerValid,
             submitErrors,
             onSubmit: onFormSubmit,
             onCancel: onFormCancel,

--- a/app/experimenter/nimbus-ui/src/gql/config.ts
+++ b/app/experimenter/nimbus-ui/src/gql/config.ts
@@ -46,6 +46,7 @@ export const GET_CONFIG_QUERY = gql`
         label
         value
       }
+      hypothesisDefault
     }
   }
 `;

--- a/app/experimenter/nimbus-ui/src/gql/experiments.ts
+++ b/app/experimenter/nimbus-ui/src/gql/experiments.ts
@@ -29,7 +29,6 @@ export const UPDATE_EXPERIMENT_OVERVIEW_MUTATION = gql`
       nimbusExperiment {
         name
         hypothesis
-        application
         publicDescription
       }
     }

--- a/app/experimenter/nimbus-ui/src/lib/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/lib/mocks.tsx
@@ -125,6 +125,7 @@ export const MOCK_CONFIG: getConfig_nimbusConfig = {
       value: "US_ONLY",
     },
   ],
+  hypothesisDefault: "Enter a hypothesis",
 };
 
 // Disabling this rule for now because we'll eventually

--- a/app/experimenter/nimbus-ui/src/types/getConfig.ts
+++ b/app/experimenter/nimbus-ui/src/types/getConfig.ts
@@ -71,6 +71,7 @@ export interface getConfig_nimbusConfig {
   firefoxMinVersion: (getConfig_nimbusConfig_firefoxMinVersion | null)[] | null;
   probeSets: (getConfig_nimbusConfig_probeSets | null)[] | null;
   targetingConfigSlug: (getConfig_nimbusConfig_targetingConfigSlug | null)[] | null;
+  hypothesisDefault: string | null;
 }
 
 export interface getConfig {

--- a/app/experimenter/nimbus-ui/src/types/globalTypes.ts
+++ b/app/experimenter/nimbus-ui/src/types/globalTypes.ts
@@ -74,18 +74,16 @@ export enum NimbusProbeKind {
 export interface CreateExperimentInput {
   clientMutationId?: string | null;
   name: string;
-  application: NimbusExperimentApplication;
-  publicDescription?: string | null;
   hypothesis: string;
+  application: NimbusExperimentApplication;
 }
 
 export interface UpdateExperimentInput {
   clientMutationId?: string | null;
-  name?: string | null;
-  application?: NimbusExperimentApplication | null;
-  publicDescription?: string | null;
-  hypothesis?: string | null;
+  name: string;
+  hypothesis: string;
   id: string;
+  publicDescription?: string | null;
 }
 
 export interface UpdateExperimentStatusInput {

--- a/app/experimenter/nimbus-ui/src/types/updateExperimentOverview.ts
+++ b/app/experimenter/nimbus-ui/src/types/updateExperimentOverview.ts
@@ -3,7 +3,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import { UpdateExperimentInput, NimbusExperimentApplication } from "./globalTypes";
+import { UpdateExperimentInput } from "./globalTypes";
 
 // ====================================================
 // GraphQL mutation operation: updateExperimentOverview
@@ -13,7 +13,6 @@ export interface updateExperimentOverview_updateExperimentOverview_nimbusExperim
   __typename: "NimbusExperimentType";
   name: string;
   hypothesis: string | null;
-  application: NimbusExperimentApplication | null;
   publicDescription: string | null;
 }
 


### PR DESCRIPTION
Because

* We need the following changes to the create and edit overview pages
  - Add an X cancel button to create in the corner on create
  - Add the overview guidance text and validation for it
  - Make application readonly on edit overview

This commit

* Adds a cancel X at the top right of create
* Adds guidance text to the V5 API and frontend
* Adds validation for the guidance text on the backend
* Updates the overview form to treat server and client validation the same way
* Removes the invalid checks on button disables because you need to be able to save in an invalid state
* Removes the dirty checks on button disables because it requires focusing away from the input before it's clickable