### PR TITLE
fix #3978 bug(nimbus): use browserSettings.update.channel for channel

### DIFF
--- a/app/experimenter/experiments/constants/nimbus.py
+++ b/app/experimenter/experiments/constants/nimbus.py
@@ -139,7 +139,7 @@ class NimbusConstants(object):
     EMAIL_EXPERIMENT_END_SUBJECT = "Action required: Please turn off your Experiment"
 
     TARGETING_VERSION = "version|versionCompare('{version}') >= 0"
-    TARGETING_CHANNELS = "channel in {channels}"
+    TARGETING_CHANNELS = "browserSettings.update.channel in {channels}"
 
     TARGETING_CONFIGS = {
         TARGETING_ALL_ENGLISH.slug: TARGETING_ALL_ENGLISH,

--- a/app/experimenter/experiments/tests/api/v6/test_serializers.py
+++ b/app/experimenter/experiments/tests/api/v6/test_serializers.py
@@ -63,7 +63,8 @@ class TestNimbusExperimentSerializer(TestCase):
                     # DRF manually replaces the isoformat suffix so we have to do the same
                     "startDate": experiment.start_date.isoformat().replace("+00:00", "Z"),
                     "targeting": (
-                        'channel in ["nightly", "beta", "release"] '
+                        "browserSettings.update.channel in "
+                        '["nightly", "beta", "release"] '
                         "&& version|versionCompare('80.!') >= 0 "
                         "&& localeLanguageCode == 'en' "
                         "&& 'app.shield.optoutstudies.enabled'|preferenceValue"
@@ -143,7 +144,7 @@ class TestNimbusExperimentSerializer(TestCase):
         self.assertEqual(
             serializer.data["targeting"],
             (
-                'channel in ["nightly", "beta", "release"] '
+                'browserSettings.update.channel in ["nightly", "beta", "release"] '
                 "&& localeLanguageCode == 'en' "
                 "&& 'app.shield.optoutstudies.enabled'|preferenceValue"
             ),


### PR DESCRIPTION
Because:
* There is a bug that causes channel to return "release" during the week
  of RC in beta https://bugzilla.mozilla.org/show_bug.cgi?id=1677226

This commit
* Change channel targeting expression to use browserSettings.update.channel