### PR TITLE
fixes #3992 fix(legacy) corrected email subscription url

### DIFF
--- a/app/experimenter/experiments/models/legacy.py
+++ b/app/experimenter/experiments/models/legacy.py
@@ -1285,9 +1285,8 @@ class ExperimentComment(ExperimentConstants, models.Model):
 
     objects = ExperimentCommentManager()
 
-    @property
     def get_absolute_url(self):
-        return urljoin(self.experiment.experiment_url, "#/comment{id}".format(id=self.id))
+        return f"{self.experiment.experiment_url}#comment{self.id}"
 
     class Meta:
         verbose_name = "Experiment Comment"

--- a/app/experimenter/experiments/models/legacy.py
+++ b/app/experimenter/experiments/models/legacy.py
@@ -1287,9 +1287,7 @@ class ExperimentComment(ExperimentConstants, models.Model):
 
     @property
     def get_absolute_url(self):
-        return "{comment.experiment.experiment_url}/#comment{comment.id}".format(
-            comment=self
-        )
+        return urljoin(self.experiment.experiment_url, "#/comment{id}".format(id=self.id))
 
     class Meta:
         verbose_name = "Experiment Comment"

--- a/app/experimenter/experiments/tests/test_models/test_models_legacy.py
+++ b/app/experimenter/experiments/tests/test_models/test_models_legacy.py
@@ -1738,6 +1738,15 @@ class TestExperimentComments(TestCase):
             testing_comment, experiment.comments.sections[experiment.SECTION_RISKS]
         )
 
+    def test_get_absolute_url(self):
+        experiment = ExperimentFactory.create(name="experiment1")
+        comment = ExperimentCommentFactory.create(id=5, experiment=experiment)
+        with override_settings(HOSTNAME="localhost"):
+            self.assertEqual(
+                comment.get_absolute_url(),
+                "https://localhost/experiments/experiment1_/#comment5",
+            )
+
 
 class TestExperimentBucketNamespace(TestCase):
     def test_empty_namespace_creates_namespace_and_bucket_range(self):

--- a/app/experimenter/legacy-ui/templates/experiments/emails/new_comment_email.html
+++ b/app/experimenter/legacy-ui/templates/experiments/emails/new_comment_email.html
@@ -15,6 +15,6 @@
 <p>Thank you!</p>
 <p>Experimenter and Normandy Teams</p>
 
-<a target="_blank" rel="noreferrer noopener" href="{{ comment.get_absolute_url }}">view it on Experimenter</a>.
+<a target="_blank" rel="noreferrer noopener" href="{{ comment.get_absolute_url }}">view it on Experimenter</a>
 
 {% endautoescape %}


### PR DESCRIPTION
Because

* There's an extra slash in the comment url

This commit:

* changes get_absolute_url for ExperimentComment to use urljoin