### PR TITLE
fix #3995 feat(nimbus): add max primary probe sets constant to config graphql

### DIFF
--- a/app/experimenter/experiments/api/v5/query.py
+++ b/app/experimenter/experiments/api/v5/query.py
@@ -30,6 +30,7 @@ class NimbusConfigurationType(graphene.ObjectType):
     probe_sets = graphene.List(NimbusProbeSetType)
     targeting_config_slug = graphene.List(NimbusLabelValueType)
     hypothesis_default = graphene.String()
+    max_primary_probe_sets = graphene.Int()
 
     def _text_choices_to_label_value_list(root, text_choices):
         return [
@@ -71,6 +72,9 @@ class NimbusConfigurationType(graphene.ObjectType):
 
     def resolve_hypothesis_default(root, info):
         return NimbusExperiment.HYPOTHESIS_DEFAULT
+
+    def resolve_max_primary_probe_sets(root, info):
+        return NimbusExperiment.MAX_PRIMARY_PROBE_SETS
 
 
 class NimbusReadyForReviewType(graphene.ObjectType):

--- a/app/experimenter/experiments/api/v5/serializers.py
+++ b/app/experimenter/experiments/api/v5/serializers.py
@@ -231,14 +231,16 @@ class NimbusProbeSetUpdateSerializer(
         fields = ("primary_probe_sets", "secondary_probe_sets")
 
     def validate_primary_probe_sets(self, value):
-        if len(value) > 2:
+        if len(value) > NimbusExperiment.MAX_PRIMARY_PROBE_SETS:
             raise serializers.ValidationError(
-                "Exceeded maximum primary probe set limit of 2."
+                "Exceeded maximum primary probe set limit of "
+                f"{NimbusExperiment.MAX_PRIMARY_PROBE_SETS}."
             )
         return value
 
     def validate(self, data):
-        """Validate the probe sets don't overlap and have no more than 2 primary.
+        """Validate the probe sets don't overlap and have no more than the max
+        number of primary probesets.
 
         Note that the default DRF validation ensures all the probe id's are valid and
         it will not save overlapping probesets. It does not however throw an error with

--- a/app/experimenter/experiments/constants/nimbus.py
+++ b/app/experimenter/experiments/constants/nimbus.py
@@ -175,3 +175,5 @@ We believe this because we have observed <this> via <data source, UR, survey>.
 
 Optional - We believe this outcome will <describe impact> on <core metric>
     """  # noqa
+
+    MAX_PRIMARY_PROBE_SETS = 2

--- a/app/experimenter/experiments/tests/api/v5/test_query.py
+++ b/app/experimenter/experiments/tests/api/v5/test_query.py
@@ -199,6 +199,7 @@ class TestNimbusQuery(GraphQLTestCase):
                         value
                     }
                     hypothesisDefault
+                    maxPrimaryProbeSets
                 }
             }
             """,
@@ -248,3 +249,7 @@ class TestNimbusQuery(GraphQLTestCase):
             self.assertEqual(
                 config_feature_config["description"], feature_config.description
             )
+        self.assertEqual(config["hypothesisDefault"], NimbusExperiment.HYPOTHESIS_DEFAULT)
+        self.assertEqual(
+            config["maxPrimaryProbeSets"], NimbusExperiment.MAX_PRIMARY_PROBE_SETS
+        )

--- a/app/experimenter/nimbus-ui/schema.graphql
+++ b/app/experimenter/nimbus-ui/schema.graphql
@@ -57,6 +57,7 @@ type NimbusConfigurationType {
   probeSets: [NimbusProbeSetType]
   targetingConfigSlug: [NimbusLabelValueType]
   hypothesisDefault: String
+  maxPrimaryProbeSets: Int
 }
 
 enum NimbusExperimentApplication {


### PR DESCRIPTION


Because

* We can enforce the maximum number of primary probe sets right on the frontend

This commit

* Exposes it as a constant in the graphql config endpoint