### PR TITLE
fix #3994 bug(nimbus): compute end dates correctly

### DIFF
--- a/app/experimenter/experiments/models/nimbus.py
+++ b/app/experimenter/experiments/models/nimbus.py
@@ -146,7 +146,7 @@ class NimbusExperiment(NimbusConstants, models.Model):
     @property
     def end_date(self):
         end_changelog = self.changes.filter(
-            old_status=self.Status.ACCEPTED, new_status=self.Status.LIVE
+            old_status=self.Status.LIVE, new_status=self.Status.COMPLETE
         )
         if end_changelog.exists():
             return end_changelog.get().changed_on

--- a/app/experimenter/experiments/tests/test_models/test_models_nimbus.py
+++ b/app/experimenter/experiments/tests/test_models/test_models_nimbus.py
@@ -47,16 +47,22 @@ class TestNimbusExperiment(TestCase):
         self.assertIsNone(experiment.end_date)
 
     def test_start_date_returns_datetime_for_started_experiment(self):
-        experiment = NimbusExperimentFactory.create_with_status(
-            NimbusExperiment.Status.LIVE
+        experiment = NimbusExperimentFactory.create()
+        start_change = NimbusChangeLogFactory(
+            experiment=experiment,
+            old_status=NimbusExperiment.Status.ACCEPTED,
+            new_status=NimbusExperiment.Status.LIVE,
         )
-        self.assertEqual(type(experiment.start_date), datetime.datetime)
+        self.assertEqual(experiment.start_date, start_change.changed_on)
 
     def test_end_date_returns_datetime_for_ended_experiment(self):
-        experiment = NimbusExperimentFactory.create_with_status(
-            NimbusExperiment.Status.COMPLETE
+        experiment = NimbusExperimentFactory.create()
+        end_change = NimbusChangeLogFactory(
+            experiment=experiment,
+            old_status=NimbusExperiment.Status.LIVE,
+            new_status=NimbusExperiment.Status.COMPLETE,
         )
-        self.assertEqual(type(experiment.end_date), datetime.datetime)
+        self.assertEqual(experiment.end_date, end_change.changed_on)
 
     def test_proposed_end_date_returns_None_for_not_started_experiment(self):
         experiment = NimbusExperimentFactory.create_with_status(


### PR DESCRIPTION
Because

* I accidentally computed end date incorrectly (copypasta errors hooray!)

This commit

* Computes end date correctly and updates tests