### PR TITLE
fix #4011 bug(nimbus): update nimbus kinto task paths

### DIFF
--- a/app/experimenter/settings.py
+++ b/app/experimenter/settings.py
@@ -320,15 +320,15 @@ CELERY_BEAT_SCHEDULE = {
         "schedule": config("CELERY_SCHEDULE_INTERVAL", default=300, cast=int),
     },
     "nimbus_check_kinto_push_queue_task": {
-        "task": "experimenter.kinto.tasks.nimbus.nimbus_check_kinto_push_queue",
+        "task": "experimenter.kinto.tasks.nimbus_check_kinto_push_queue",
         "schedule": config("CELERY_SCHEDULE_INTERVAL", default=300, cast=int),
     },
     "nimbus_check_experiments_are_live": {
-        "task": "experimenter.kinto.tasks.nimbus.nimbus_check_experiments_are_live",
+        "task": "experimenter.kinto.tasks.nimbus_check_experiments_are_live",
         "schedule": config("CELERY_SCHEDULE_INTERVAL", default=300, cast=int),
     },
     "nimbus_check_experiments_are_complete": {
-        "task": "experimenter.kinto.tasks.nimbus.nimbus_check_experiments_are_complete",
+        "task": "experimenter.kinto.tasks.nimbus_check_experiments_are_complete",
         "schedule": config("CELERY_SCHEDULE_INTERVAL", default=300, cast=int),
     },
 }


### PR DESCRIPTION
Because

* We removed the legacy rapid kinto tasks and reorganized the module paths but didn't update the paths in settings.py

This commit

* Updates the task paths in settings.py