### PR TITLE
fix #3955 feat(nimbus): add monitoring dashboard url to experiment query

### DIFF
--- a/app/experimenter/experiments/api/v5/types.py
+++ b/app/experimenter/experiments/api/v5/types.py
@@ -112,6 +112,7 @@ class NimbusExperimentType(DjangoObjectType):
     primary_probe_sets = graphene.List(NimbusProbeSetType)
     secondary_probe_sets = graphene.List(NimbusProbeSetType)
     ready_for_review = graphene.Field(NimbusReadyForReviewType)
+    monitoring_dashboard_url = graphene.String()
 
     class Meta:
         model = NimbusExperiment

--- a/app/experimenter/experiments/models/nimbus.py
+++ b/app/experimenter/experiments/models/nimbus.py
@@ -1,4 +1,5 @@
 import datetime
+import time
 from urllib.parse import urljoin
 
 from django.conf import settings
@@ -162,6 +163,24 @@ class NimbusExperiment(NimbusConstants, models.Model):
     def should_end(self):
         if self.proposed_end_date:
             return datetime.date.today() >= self.proposed_end_date
+
+    @property
+    def monitoring_dashboard_url(self):
+        def to_timestamp(date):
+            return int(time.mktime(date.timetuple())) * 1000
+
+        start_date = ""
+        end_date = ""
+
+        if self.start_date:
+            start_date = to_timestamp(self.start_date - datetime.timedelta(days=1))
+
+        if self.end_date:
+            end_date = to_timestamp(self.end_date + datetime.timedelta(days=2))
+
+        return settings.MONITORING_URL.format(
+            slug=self.slug, from_date=start_date, to_date=end_date
+        )
 
 
 class NimbusBranch(models.Model):

--- a/app/experimenter/nimbus-ui/schema.graphql
+++ b/app/experimenter/nimbus-ui/schema.graphql
@@ -155,6 +155,7 @@ type NimbusExperimentType {
   primaryProbeSets: [NimbusProbeSetType]
   secondaryProbeSets: [NimbusProbeSetType]
   readyForReview: NimbusReadyForReviewType
+  monitoringDashboardUrl: String
 }
 
 enum NimbusFeatureConfigApplication {


### PR DESCRIPTION
Because

* Until we have the visualization doing monitoring we'll need to link out to grafana

This commit

* Adds a grafana monitoring link to the experiment graphql query