### PR TITLE
fix #3976 chore(visualization): Copy overview table from `rapid` into TableOverview component.

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/PageResults/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/index.tsx
@@ -80,7 +80,7 @@ const AnalysisAvailable = ({
       primaryProbeSets={experiment.primaryProbeSets!}
       results={analysis?.overall!}
     />
-    <TableOverview />
+    <TableOverview {...{ experiment }} results={analysis?.overall!} />
 
     <h2 className="h5 my-3">Results</h2>
     <TableResults />

--- a/app/experimenter/nimbus-ui/src/components/TableOverview/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/TableOverview/index.stories.tsx
@@ -8,14 +8,41 @@ import { RouterSlugProvider } from "../../lib/test-utils";
 import { withLinks } from "@storybook/addon-links";
 import { mockExperimentQuery } from "../../lib/mocks";
 import TableOverview from ".";
-// import { mockAnalysis } from "../../lib/visualization/mocks";
-
-const { mock } = mockExperimentQuery("demo-slug");
+import { mockAnalysis } from "../../lib/visualization/mocks";
 
 storiesOf("visualization/TableOverview", module)
   .addDecorator(withLinks)
-  .add("basic", () => (
-    <RouterSlugProvider mocks={[mock]}>
-      <TableOverview />
-    </RouterSlugProvider>
-  ));
+  .add("basic, with one primary probe set", () => {
+    const { mock, data } = mockExperimentQuery("demo-slug");
+    return (
+      <RouterSlugProvider mocks={[mock]}>
+        <TableOverview experiment={data!} results={mockAnalysis().overall} />
+      </RouterSlugProvider>
+    );
+  })
+  .add("with multiple primary probe sets", () => {
+    const { mock, data } = mockExperimentQuery("demo-slug", {
+      primaryProbeSets: [
+        {
+          __typename: "NimbusProbeSetType",
+          slug: "picture-in-picture",
+          name: "Picture-in-Picture",
+        },
+        {
+          __typename: "NimbusProbeSetType",
+          slug: "feature-b",
+          name: "Feature B",
+        },
+        {
+          __typename: "NimbusProbeSetType",
+          slug: "feature-c",
+          name: "Feature C",
+        },
+      ],
+    });
+    return (
+      <RouterSlugProvider mocks={[mock]}>
+        <TableOverview experiment={data!} results={mockAnalysis().overall} />
+      </RouterSlugProvider>
+    );
+  });

--- a/app/experimenter/nimbus-ui/src/components/TableOverview/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/TableOverview/index.test.tsx
@@ -5,11 +5,57 @@
 import React from "react";
 import { render, screen } from "@testing-library/react";
 import TableOverview from ".";
+import { mockExperimentQuery } from "../../lib/mocks";
+import { mockAnalysis } from "../../lib/visualization/mocks";
+import { RouterSlugProvider } from "../../lib/test-utils";
+
+const { mock, data } = mockExperimentQuery("demo-slug");
 
 describe("TableOverview", () => {
-  it("renders as expected", () => {
-    render(<TableOverview />);
+  it("has the correct headings", async () => {
+    const EXPECTED_HEADINGS = ["Targeting", "Probe Sets", "Owner"];
 
-    expect(screen.queryByTestId("table-overview")).toBeInTheDocument();
+    render(
+      <RouterSlugProvider mocks={[mock]}>
+        <TableOverview experiment={data!} results={mockAnalysis().overall} />
+      </RouterSlugProvider>,
+    );
+
+    EXPECTED_HEADINGS.forEach((heading) => {
+      expect(screen.getByText(heading)).toBeInTheDocument();
+    });
+  });
+
+  it("has the expected targeting", async () => {
+    render(
+      <RouterSlugProvider mocks={[mock]}>
+        <TableOverview experiment={data!} results={mockAnalysis().overall} />
+      </RouterSlugProvider>,
+    );
+
+    expect(screen.getByText("Firefox 80+")).toBeInTheDocument();
+    expect(
+      screen.getByText("Desktop Nightly, Desktop Beta"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Us Only")).toBeInTheDocument();
+  });
+
+  it("has the expected probe sets", async () => {
+    render(
+      <RouterSlugProvider mocks={[mock]}>
+        <TableOverview experiment={data!} results={mockAnalysis().overall} />
+      </RouterSlugProvider>,
+    );
+
+    expect(screen.getByText("Picture-in-Picture")).toBeInTheDocument();
+  });
+
+  it("has the experiment owner", async () => {
+    render(
+      <RouterSlugProvider mocks={[mock]}>
+        <TableOverview experiment={data!} results={mockAnalysis().overall} />
+      </RouterSlugProvider>,
+    );
+    expect(screen.getByText("example@mozilla.com")).toBeInTheDocument();
   });
 });

--- a/app/experimenter/nimbus-ui/src/components/TableOverview/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/TableOverview/index.tsx
@@ -3,9 +3,81 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React from "react";
+import { getExperiment_experimentBySlug } from "../../types/getExperiment";
+import { AnalysisData } from "../../lib/visualization/types";
+import { useConfig } from "../../hooks";
+import { getConfig_nimbusConfig } from "../../types/getConfig";
 
-const TableOverview: React.FunctionComponent = () => {
-  return <div data-testid="table-overview">overview table</div>;
+type TableOverviewProps = {
+  experiment: getExperiment_experimentBySlug;
+  results: AnalysisData["overall"];
+};
+
+type displayConfigOptionsProps =
+  | getConfig_nimbusConfig["firefoxMinVersion"]
+  | getConfig_nimbusConfig["channels"]
+  | getConfig_nimbusConfig["targetingConfigSlug"];
+
+const TableOverview = ({ experiment }: TableOverviewProps) => {
+  const { firefoxMinVersion, channels, targetingConfigSlug } = useConfig();
+
+  return (
+    <div className="mb-5" data-testid="table-overview">
+      <table className="table text-left m-0">
+        <tbody>
+          <tr>
+            <td scope="col">
+              <h3 className="h6">Targeting</h3>
+              <span>
+                {displayConfigLabel(
+                  experiment.firefoxMinVersion,
+                  firefoxMinVersion,
+                )}
+                +
+              </span>
+              <br />
+              <span>
+                {experiment.channels?.length
+                  ? experiment.channels
+                      .map((expChannel) =>
+                        displayConfigLabel(expChannel, channels),
+                      )
+                      .join(", ")
+                  : ""}
+              </span>
+              <br />
+              <span>
+                {displayConfigLabel(
+                  experiment.targetingConfigSlug,
+                  targetingConfigSlug,
+                )}
+              </span>
+            </td>
+            <td scope="col">
+              <h3 className="h6">Probe Sets</h3>
+              {experiment.primaryProbeSets?.length
+                ? experiment.primaryProbeSets.map((probeSet) => (
+                    <span key={probeSet?.name}>{probeSet?.name}</span>
+                  ))
+                : ""}
+            </td>
+            <td scope="col">
+              <h3 className="h6">Owner</h3>
+              <span>{experiment.owner?.email}</span>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+      <hr className="mt-0 mb-5" />
+    </div>
+  );
+};
+
+const displayConfigLabel = (
+  value: string | null,
+  options: displayConfigOptionsProps,
+) => {
+  return options?.find((obj: any) => obj.value === value)?.label;
 };
 
 export default TableOverview;


### PR DESCRIPTION
Building off of https://github.com/mozilla/experimenter/pull/3973