### PR TITLE
fix #4028 feat(nimbus): rollback collection after rejected review

### DIFF
--- a/app/experimenter/kinto/client.py
+++ b/app/experimenter/kinto/client.py
@@ -3,6 +3,7 @@ from django.conf import settings
 
 KINTO_REVIEW_STATUS = "to-review"
 KINTO_REJECTED_STATUS = "work-in-progress"
+KINTO_ROLLBACK_STATUS = "to-rollback"
 
 
 class KintoClient:
@@ -54,15 +55,10 @@ class KintoClient:
         workspace_record_ids = [record["id"] for record in workspace_records]
         return list(set(workspace_record_ids) - set(main_record_ids))[0]
 
-    def delete_rejected_record(self, record_id):
-        self.kinto_http_client.delete_record(
-            id=record_id,
-            bucket=settings.KINTO_BUCKET,
-            collection=self.collection,
-        )
+    def rollback_changes(self):
         self.kinto_http_client.patch_collection(
             id=self.collection,
-            data={"status": KINTO_REVIEW_STATUS},
+            data={"status": KINTO_ROLLBACK_STATUS},
             bucket=settings.KINTO_BUCKET,
         )
 

--- a/app/experimenter/kinto/tasks.py
+++ b/app/experimenter/kinto/tasks.py
@@ -108,7 +108,7 @@ def nimbus_check_kinto_push_queue():
                 message=f'Rejected: {rejected_collection_data["last_reviewer_comment"]}',
             )
 
-            kinto_client.delete_rejected_record(rejected_slug)
+            kinto_client.rollback_changes()
 
         if kinto_client.has_pending_review():
             metrics.incr(f"check_kinto_push_queue.{collection}_pending_review")

--- a/app/experimenter/kinto/tests/test_client.py
+++ b/app/experimenter/kinto/tests/test_client.py
@@ -1,7 +1,11 @@
 from django.conf import settings
 from django.test import TestCase
 
-from experimenter.kinto.client import KintoClient
+from experimenter.kinto.client import (
+    KINTO_REVIEW_STATUS,
+    KINTO_ROLLBACK_STATUS,
+    KintoClient,
+)
 from experimenter.kinto.tests.mixins import MockKintoClientMixin
 
 
@@ -28,27 +32,21 @@ class TestKintoClient(MockKintoClientMixin, TestCase):
 
         self.mock_kinto_client.patch_collection.assert_called_with(
             id=self.collection,
-            data={"status": "to-review"},
+            data={"status": KINTO_REVIEW_STATUS},
             bucket=settings.KINTO_BUCKET,
         )
 
-    def test_delete_rejected_record_removes_record_patches_collection(self):
-        self.client.delete_rejected_record("test_id")
+    def test_rollback_changes_patches_collection(self):
+        self.client.rollback_changes()
 
         self.mock_kinto_client_creator.assert_called_with(
             server_url=settings.KINTO_HOST,
             auth=(settings.KINTO_USER, settings.KINTO_PASS),
         )
 
-        self.mock_kinto_client.delete_record.assert_called_with(
-            id="test_id",
-            bucket=settings.KINTO_BUCKET,
-            collection=self.collection,
-        )
-
         self.mock_kinto_client.patch_collection.assert_called_with(
             id=self.collection,
-            data={"status": "to-review"},
+            data={"status": KINTO_ROLLBACK_STATUS},
             bucket=settings.KINTO_BUCKET,
         )
 


### PR DESCRIPTION
Because

* I had set this up to delete a record after it was rejected which requires a second review in remote settings which is kind of a lame workflow

This commit

* Sets the collection to the rollback status rather than issuing a deletion, so it can clean up after a rejection without requiring a second review