### PR TITLE
fixes #3698 feat(nimbus): update exp query to return readyForReview data, use it in sidebar

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/AppLayoutWithExperiment/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/AppLayoutWithExperiment/index.tsx
@@ -42,6 +42,7 @@ const AppLayoutWithExperiment = ({
     loading,
     startPolling,
     stopPolling,
+    review,
   } = useExperiment(slug);
 
   useEffect(() => {
@@ -64,7 +65,7 @@ const AppLayoutWithExperiment = ({
   const { name, status } = experiment;
 
   return (
-    <Layout {...{ sidebar, children }}>
+    <Layout {...{ sidebar, children, review }}>
       <section data-testid={testId}>
         <HeaderEditExperiment
           {...{
@@ -85,12 +86,17 @@ const AppLayoutWithExperiment = ({
 const Layout = ({
   sidebar,
   children,
+  review,
 }: {
   sidebar: boolean;
   children: React.ReactElement;
+  review: {
+    ready: boolean;
+    invalidPages: string[];
+  };
 }) =>
   sidebar ? (
-    <AppLayoutWithSidebar>{children}</AppLayoutWithSidebar>
+    <AppLayoutWithSidebar {...{ review }}>{children}</AppLayoutWithSidebar>
   ) : (
     <AppLayout>{children}</AppLayout>
   );

--- a/app/experimenter/nimbus-ui/src/gql/experiments.ts
+++ b/app/experimenter/nimbus-ui/src/gql/experiments.ts
@@ -135,6 +135,11 @@ export const GET_EXPERIMENT_QUERY = gql`
       totalEnrolledClients
       proposedEnrollment
       proposedDuration
+
+      readyForReview {
+        ready
+        message
+      }
     }
   }
 `;

--- a/app/experimenter/nimbus-ui/src/hooks/useExperiment.tsx
+++ b/app/experimenter/nimbus-ui/src/hooks/useExperiment.tsx
@@ -6,6 +6,18 @@ import { useQuery } from "@apollo/client";
 import { GET_EXPERIMENT_QUERY } from "../gql/experiments";
 import { getExperiment } from "../types/getExperiment";
 
+const fieldPageMap: { [page: string]: string[] } = {
+  overview: ["public_description"],
+  branches: ["reference_branch"],
+  audience: [
+    "channels",
+    "firefox_min_version",
+    "targeting_config_slug",
+    "proposed_enrollment",
+    "proposed_duration",
+  ],
+};
+
 /**
  * Hook to retrieve all Experiment data by slug.
  *
@@ -37,6 +49,12 @@ export function useExperiment(slug: string) {
   });
 
   const experiment = data?.experimentBySlug;
+  const missingFields = Object.keys(experiment?.readyForReview?.message || {});
+  const invalidPages = Object.keys(fieldPageMap).filter((page) =>
+    fieldPageMap[page].some((field) => missingFields.includes(field)),
+  );
+  const isMissingField = (fieldName: string) =>
+    missingFields.includes(fieldName);
 
   return {
     experiment: experiment!,
@@ -44,5 +62,11 @@ export function useExperiment(slug: string) {
     loading,
     startPolling,
     stopPolling,
+    review: {
+      ready: experiment?.readyForReview?.ready || false,
+      invalidPages,
+      missingFields,
+      isMissingField,
+    },
   };
 }

--- a/app/experimenter/nimbus-ui/src/lib/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/lib/mocks.tsx
@@ -294,6 +294,11 @@ export const mockExperimentQuery = (
             totalEnrolledClients: 68000,
             proposedEnrollment: 1,
             proposedDuration: 28,
+            readyForReview: {
+              ready: true,
+              message: {},
+              __typename: "NimbusReadyForReviewType",
+            },
           },
           modifications,
         );

--- a/app/experimenter/nimbus-ui/src/types/getExperiment.ts
+++ b/app/experimenter/nimbus-ui/src/types/getExperiment.ts
@@ -57,6 +57,12 @@ export interface getExperiment_experimentBySlug_secondaryProbeSets {
   name: string;
 }
 
+export interface getExperiment_experimentBySlug_readyForReview {
+  __typename: "NimbusReadyForReviewType";
+  ready: boolean | null;
+  message: any | null;
+}
+
 export interface getExperiment_experimentBySlug {
   __typename: "NimbusExperimentType";
   id: string;
@@ -79,6 +85,7 @@ export interface getExperiment_experimentBySlug {
   totalEnrolledClients: number;
   proposedEnrollment: number | null;
   proposedDuration: number | null;
+  readyForReview: getExperiment_experimentBySlug_readyForReview | null;
 }
 
 export interface getExperiment {


### PR DESCRIPTION
Closes #3698 

(Part of this issue was already completed in #4016)

This PR

- Updates the `experimentBySlug` GraphQL query to include `readyForReview` data
- Massages this new data into a set of `review` properties returned by the `useExperiment` hook
- Passes some of this down through `AppLayoutWithExperiment` so it can be used in `AppLayoutWithSidebar`