### PR TITLE
fix #4007 feat(nimbus): add start/end date to experiment graphql type

### DIFF
--- a/app/experimenter/experiments/api/v5/types.py
+++ b/app/experimenter/experiments/api/v5/types.py
@@ -113,6 +113,8 @@ class NimbusExperimentType(DjangoObjectType):
     secondary_probe_sets = graphene.List(NimbusProbeSetType)
     ready_for_review = graphene.Field(NimbusReadyForReviewType)
     monitoring_dashboard_url = graphene.String()
+    start_date = graphene.DateTime()
+    end_date = graphene.DateTime()
 
     class Meta:
         model = NimbusExperiment

--- a/app/experimenter/nimbus-ui/schema.graphql
+++ b/app/experimenter/nimbus-ui/schema.graphql
@@ -22,6 +22,8 @@ input CreateExperimentInput {
   application: NimbusExperimentApplication!
 }
 
+scalar DateTime
+
 scalar Decimal
 
 type Mutation {
@@ -157,6 +159,8 @@ type NimbusExperimentType {
   secondaryProbeSets: [NimbusProbeSetType]
   readyForReview: NimbusReadyForReviewType
   monitoringDashboardUrl: String
+  startDate: DateTime
+  endDate: DateTime
 }
 
 enum NimbusFeatureConfigApplication {


### PR DESCRIPTION
Because

* We need to display the start/end dates in the nimbus ui

This commit

* Adds start/end date to the graphql query