### PR TITLE
chore(project): disable deprecated tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ jobs:
     machine:
       docker_layer_caching: true
       image: ubuntu-1604:202007-01 # Ubuntu 16.04, Docker v19.03.12, Docker Compose v1.26.1
-    resource_class: xlarge
+    resource_class: large
     working_directory: ~/experimenter
     steps:
       - run:

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -58,6 +58,8 @@ COPY ./experimenter/nimbus-ui/package.json /app/experimenter/nimbus-ui/package.j
 RUN yarn install --frozen-lockfile
 
 
+FROM dev AS test
+
 # Copy source
 COPY . /app
 
@@ -67,8 +69,8 @@ FROM dev AS build
 
 
 # Build assets
-COPY --from=dev /app/experimenter/legacy-ui/ /app/experimenter/legacy-ui/
-COPY --from=dev /app/experimenter/nimbus-ui/ /app/experimenter/nimbus-ui/
+COPY ./experimenter/legacy-ui/ /app/experimenter/legacy-ui/
+COPY ./experimenter/nimbus-ui/ /app/experimenter/nimbus-ui/
 RUN yarn workspace @experimenter/core build
 RUN yarn workspace @experimenter/visualization build
 RUN yarn workspace @experimenter/rapid build
@@ -89,8 +91,10 @@ ENV PATH "/root/.poetry/bin:${PATH}"
 RUN apt-get update
 RUN apt-get --no-install-recommends install -y apt-utils ca-certificates postgresql-client
 
-COPY --from=build /app/bin/ /app/bin/
-COPY --from=build /app/manage.py /app/manage.py
-COPY --from=build /usr/local/bin/ /usr/local/bin/
-COPY --from=build /usr/local/lib/python3.9/site-packages/ /usr/local/lib/python3.9/site-packages/
-COPY --from=build /app/experimenter/ /app/experimenter/
+COPY --from=dev /usr/local/bin/ /usr/local/bin/
+COPY --from=dev /usr/local/lib/python3.9/site-packages/ /usr/local/lib/python3.9/site-packages/
+COPY --from=dev /app/bin/ /app/bin/
+COPY ./manage.py /app/manage.py
+COPY ./experimenter/ /app/experimenter/
+COPY --from=build /app/experimenter/legacy-ui/assets/ /app/experimenter/legacy-ui/assets/
+COPY --from=build /app/experimenter/nimbus-ui/build/ /app/experimenter/nimbus-ui/build/

--- a/app/tests/integration/test_create_experiment.py
+++ b/app/tests/integration/test_create_experiment.py
@@ -2,6 +2,7 @@ import pytest
 from pages.experiment_design import DesignPage
 
 
+@pytest.mark.skip(reason="superceded by e2e tests")
 @pytest.mark.nondestructive
 def test_add_branch(base_url, selenium, ds_issue_host, fill_overview):
     """Test adding a new branch."""
@@ -15,6 +16,7 @@ def test_add_branch(base_url, selenium, ds_issue_host, fill_overview):
     assert "Branch 2" in new_branch.branch_number.text
 
 
+@pytest.mark.skip(reason="superceded by e2e tests")
 @pytest.mark.nondestructive
 def test_remove_branch(base_url, selenium, fill_overview):
     """Test removing a branch."""
@@ -31,6 +33,7 @@ def test_remove_branch(base_url, selenium, fill_overview):
     assert "Control Branch" in branches[-1].branch_number.text
 
 
+@pytest.mark.skip(reason="superceded by e2e tests")
 @pytest.mark.nondestructive
 def test_duplicate_branch_name(base_url, selenium, ds_issue_host, fill_overview):
     """Test adding a branch with the same name as the control branch."""

--- a/app/tests/integration/test_homepage.py
+++ b/app/tests/integration/test_homepage.py
@@ -2,6 +2,7 @@ import pytest
 from pages.base import Base
 
 
+@pytest.mark.skip(reason="covered by unit tests")
 @pytest.mark.nondestructive
 def test_owned_experiments_page_loads(base_url, selenium):
     """Test Owned Deliveries link opens correct page."""
@@ -11,6 +12,7 @@ def test_owned_experiments_page_loads(base_url, selenium):
     assert f"{experiments.count} Deliveries by" in experiments.title
 
 
+@pytest.mark.skip(reason="covered by unit tests")
 @pytest.mark.nondestructive
 def test_subscribed_experiments_page_loads(base_url, selenium):
     """Test Subscribed Deliveries link opens correct page."""

--- a/app/tests/integration/test_objective_and_analysis.py
+++ b/app/tests/integration/test_objective_and_analysis.py
@@ -2,6 +2,7 @@ import pytest
 from pages.experiment_objective_and_analysis import ObjectiveAndAnalysisPage
 
 
+@pytest.mark.skip(reason="superceded by e2e tests")
 @pytest.mark.nondestructive
 def test_edit_objectives_box(base_url, selenium, fill_overview):
     analysis = ObjectiveAndAnalysisPage(
@@ -14,6 +15,7 @@ def test_edit_objectives_box(base_url, selenium, fill_overview):
     assert text in detail_page.objective_section.text
 
 
+@pytest.mark.skip(reason="superceded by e2e tests")
 @pytest.mark.nondestructive
 def test_edit_analysis_box(base_url, selenium, fill_overview):
     analysis = ObjectiveAndAnalysisPage(
@@ -27,6 +29,7 @@ def test_edit_analysis_box(base_url, selenium, fill_overview):
     assert text in detail_page.analysis_section.text
 
 
+@pytest.mark.skip(reason="superceded by e2e tests")
 @pytest.mark.nondestructive
 def test_survey_checkbox(base_url, selenium, fill_overview):
     analysis = ObjectiveAndAnalysisPage(
@@ -40,6 +43,7 @@ def test_survey_checkbox(base_url, selenium, fill_overview):
     assert analysis.survey_required_checkbox == "Yes"
 
 
+@pytest.mark.skip(reason="superceded by e2e tests")
 @pytest.mark.nondestructive
 def test_survey_urls(base_url, selenium, fill_overview):
     analysis = ObjectiveAndAnalysisPage(
@@ -55,6 +59,7 @@ def test_survey_urls(base_url, selenium, fill_overview):
     assert test_url in detail_page.analysis_section.survey_urls
 
 
+@pytest.mark.skip(reason="superceded by e2e tests")
 @pytest.mark.nondestructive
 def test_survey_launch_instructions(base_url, selenium, fill_overview):
     analysis = ObjectiveAndAnalysisPage(

--- a/app/tests/integration/test_overview.py
+++ b/app/tests/integration/test_overview.py
@@ -2,6 +2,7 @@ import pytest
 from pages.home import Home
 
 
+@pytest.mark.skip(reason="superceded by e2e tests")
 @pytest.mark.nondestructive
 def test_overview_type_changes_correctly(base_url, selenium):
     """Test changing experiment type."""
@@ -14,6 +15,7 @@ def test_overview_type_changes_correctly(base_url, selenium):
     assert exp_type in experiment.experiment_type
 
 
+@pytest.mark.skip(reason="superceded by e2e tests")
 @pytest.mark.nondestructive
 def test_overview_engineering_owner_changes_correctly(base_url, selenium):
     """Test changing engineering owner."""
@@ -39,6 +41,7 @@ def test_overview_owner_changes_correctly(base_url, selenium):
     assert owner in experiment.experiment_owner
 
 
+@pytest.mark.skip(reason="superceded by e2e tests")
 @pytest.mark.nondestructive
 def test_public_name_changes_correctly(base_url, selenium):
     """Test adding a public name."""
@@ -51,6 +54,7 @@ def test_public_name_changes_correctly(base_url, selenium):
     assert new_public_name in experiment.public_name
 
 
+@pytest.mark.skip(reason="superceded by e2e tests")
 @pytest.mark.nondestructive
 def test_public_description_changes_correctly(base_url, selenium):
     """Test adding a public description."""
@@ -63,6 +67,7 @@ def test_public_description_changes_correctly(base_url, selenium):
     assert new_public_description in experiment.public_description
 
 
+@pytest.mark.skip(reason="superceded by e2e tests")
 @pytest.mark.nondestructive
 def test_feature_bugzilla_url_changes_correctly(base_url, selenium):
     """Test adding a bugzilla url."""
@@ -75,6 +80,7 @@ def test_feature_bugzilla_url_changes_correctly(base_url, selenium):
     assert new_url in experiment.feature_bugzilla_url
 
 
+@pytest.mark.skip(reason="superceded by e2e tests")
 @pytest.mark.nondestructive
 def test_related_experiments_updates_correctly(base_url, selenium):
     """Test updating related experiments."""

--- a/app/tests/integration/test_timeline_and_population.py
+++ b/app/tests/integration/test_timeline_and_population.py
@@ -5,6 +5,7 @@ from dateutil.parser import parse
 from pages.experiment_timeline_and_population import TimelineAndPopulationPage
 
 
+@pytest.mark.skip(reason="superceded by e2e tests")
 @pytest.mark.nondestructive
 def test_proposed_start_date_fills_correctly(selenium, base_url, fill_overview):
     """Test proposed start date fills."""
@@ -19,6 +20,7 @@ def test_proposed_start_date_fills_correctly(selenium, base_url, fill_overview):
     assert timeline_pop_form.proposed_start_date == today
 
 
+@pytest.mark.skip(reason="superceded by e2e tests")
 @pytest.mark.nondestructive
 def test_proposed_experiment_duration_updates_correctly(
     selenium, base_url, fill_overview
@@ -33,6 +35,7 @@ def test_proposed_experiment_duration_updates_correctly(
     assert timeline_pop_form.proposed_experiment_duration == duration
 
 
+@pytest.mark.skip(reason="superceded by e2e tests")
 @pytest.mark.nondestructive
 def test_proposed_enrollment_duration_updates_correctly(
     selenium, base_url, fill_overview
@@ -47,6 +50,7 @@ def test_proposed_enrollment_duration_updates_correctly(
     assert timeline_pop_form.proposed_enrollment_duration == duration
 
 
+@pytest.mark.skip(reason="superceded by e2e tests")
 @pytest.mark.nondestructive
 def test_population_percentage_updates_correctly(selenium, base_url, fill_overview):
     """Test Population percentage updates."""
@@ -59,6 +63,7 @@ def test_population_percentage_updates_correctly(selenium, base_url, fill_overvi
     assert timeline_pop_form.population_percentage == percentage
 
 
+@pytest.mark.skip(reason="superceded by e2e tests")
 @pytest.mark.nondestructive
 def test_firefox_channel_updates_correctly(selenium, base_url, fill_overview):
     """Test selecting a Firefox Channel."""
@@ -71,6 +76,7 @@ def test_firefox_channel_updates_correctly(selenium, base_url, fill_overview):
     assert timeline_pop_form.firefox_channel == channel
 
 
+@pytest.mark.skip(reason="superceded by e2e tests")
 @pytest.mark.nondestructive
 def test_firefox_min_version_updates_correctly(selenium, base_url, fill_overview):
     """Test setting a Firefox min version."""
@@ -83,6 +89,7 @@ def test_firefox_min_version_updates_correctly(selenium, base_url, fill_overview
     assert timeline_pop_form.firefox_min_version == version
 
 
+@pytest.mark.skip(reason="superceded by e2e tests")
 @pytest.mark.nondestructive
 def test_firefox_max_version_updates_correctly(selenium, base_url, fill_overview):
     """Test setting a Firefox max version."""

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -17,7 +17,7 @@ services:
     command: bash -c "/app/bin/wait-for-it.sh kinto:8888 -- python bin/setup_kinto.py;/app/bin/wait-for-it.sh db:5432 -- python manage.py collectstatic --noinput&&gunicorn -w 4 -b 0.0.0.0:7001 experimenter.wsgi"
 
   worker:
-    image: app:dev
+    image: app:deploy
     env_file: .env
     links:
       - db
@@ -25,7 +25,7 @@ services:
     command: bash -c "/app/bin/wait-for-it.sh db:5432 -- celery -A experimenter worker -l DEBUG"
 
   beat:
-    image: app:dev
+    image: app:deploy
     env_file: .env
     links:
       - db

--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -2,7 +2,7 @@ version: "3"
 
 services:
   app:
-    image: app:dev
+    image: app:test
     env_file: .env.sample
     environment:
       - DEBUG=False

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,8 +16,6 @@ services:
       - ./app:/app
       - /app/experimenter/legacy-ui/core/.cache/
       - /app/experimenter/legacy-ui/core/node_modules/
-      - /app/experimenter/legacy-ui/rapid/node_modules/
-      - /app/experimenter/legacy-ui/visualization/node_modules/
       - /app/experimenter/nimbus-ui/node_modules/
       - /app/experimenter/served/
       - /app/node_modules/
@@ -33,8 +31,6 @@ services:
       - ./app:/app
       - /app/experimenter/legacy-ui/core/.cache/
       - /app/experimenter/legacy-ui/core/node_modules/
-      - /app/experimenter/legacy-ui/rapid/node_modules/
-      - /app/experimenter/legacy-ui/visualization/node_modules/
       - /app/experimenter/nimbus-ui/node_modules/
       - /app/experimenter/served/
       - /app/node_modules/
@@ -48,42 +44,10 @@ services:
       - ./app:/app
       - /app/experimenter/legacy-ui/core/.cache/
       - /app/experimenter/legacy-ui/core/node_modules/
-      - /app/experimenter/legacy-ui/rapid/node_modules/
-      - /app/experimenter/legacy-ui/visualization/node_modules/
       - /app/experimenter/nimbus-ui/node_modules/
       - /app/experimenter/served/
       - /app/node_modules/
     command: bash -c "yarn workspace @experimenter/core watch"
-
-  yarn-rapid:
-    image: app:dev
-    env_file: .env
-    tty: true
-    volumes:
-      - ./app:/app
-      - /app/experimenter/legacy-ui/core/.cache/
-      - /app/experimenter/legacy-ui/core/node_modules/
-      - /app/experimenter/legacy-ui/rapid/node_modules/
-      - /app/experimenter/legacy-ui/visualization/node_modules/
-      - /app/experimenter/nimbus-ui/node_modules/
-      - /app/experimenter/served/
-      - /app/node_modules/
-    command: bash -c "yarn workspace @experimenter/rapid watch"
-
-  yarn-visualization:
-    image: app:dev
-    env_file: .env
-    tty: true
-    volumes:
-      - ./app:/app
-      - /app/experimenter/legacy-ui/core/.cache/
-      - /app/experimenter/legacy-ui/core/node_modules/
-      - /app/experimenter/legacy-ui/rapid/node_modules/
-      - /app/experimenter/legacy-ui/visualization/node_modules/
-      - /app/experimenter/nimbus-ui/node_modules/
-      - /app/experimenter/served/
-      - /app/node_modules/
-    command: bash -c "yarn workspace @experimenter/visualization watch"
 
   worker:
     image: app:dev


### PR DESCRIPTION
Because

* We are now migrating all visualization work out of rapid and into nimbus
* All of the legacy/core ui is in maintenance mode
* Tests take up a lot of circle credits

This commit

* Disables all but the end to end integration tests for the legacy workflow
* Disables all of the rapid/visualization js tests/linting
* Disables the rapid/visualization dev yarn processes
* Decreases the size of the make check circle instance
* This should make the local dev lighter, make our tests faster, and reduce circle usage