### PR TITLE
fixes #3977 feat(nimbus): Add Results table to Results page

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/PageResults/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/index.tsx
@@ -40,7 +40,7 @@ const PageResults: React.FunctionComponent<RouteComponentProps> = () => {
                 </LinkExternal>{" "}
                 to view the live monitoring dashboard.
               </p>
-              <h3 className="h5 my-3">Overview</h3>
+              <h3 className="h5 mb-3 mt-4">Overview</h3>
 
               {error && <AnalysisFetchError />}
               {analysis?.show_analysis ? (
@@ -82,8 +82,11 @@ const AnalysisAvailable = ({
     />
     <TableOverview />
 
-    <h2 className="h5 my-3">Results</h2>
-    <TableResults />
+    <h2 className="h5 mb-3 mt-4">Results</h2>
+    <TableResults
+      primaryProbeSets={experiment.primaryProbeSets!}
+      results={analysis?.overall!}
+    />
     <div>
       {experiment.primaryProbeSets?.map((probeSet) => (
         <TableMetricPrimary key={probeSet?.slug} />

--- a/app/experimenter/nimbus-ui/src/components/TableHighlights/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/TableHighlights/index.tsx
@@ -63,7 +63,7 @@ const TableHighlights = ({
                 <span className="align-middle">All Users&nbsp;</span>
                 <Info data-tip={SEGMENT_TIPS.ALL_USERS} />
               </td>
-              <td className="pt-1 px-1 pt-lg-3 px-lg-3">
+              <td className="pt-3 px-1 px-lg-3">
                 {highlightMetricsList.map((metric) => {
                   const metricKey = metric.value;
                   const displayType = getTableDisplayType(

--- a/app/experimenter/nimbus-ui/src/components/TableResults/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/TableResults/index.stories.tsx
@@ -8,14 +8,47 @@ import { RouterSlugProvider } from "../../lib/test-utils";
 import { withLinks } from "@storybook/addon-links";
 import { mockExperimentQuery } from "../../lib/mocks";
 import TableResults from ".";
-// import { mockAnalysis } from "../../lib/visualization/mocks";
-
-const { mock } = mockExperimentQuery("demo-slug");
+import { mockAnalysis } from "../../lib/visualization/mocks";
 
 storiesOf("visualization/TableResults", module)
   .addDecorator(withLinks)
-  .add("basic", () => (
-    <RouterSlugProvider mocks={[mock]}>
-      <TableResults />
-    </RouterSlugProvider>
-  ));
+  .add("basic, with one primary probe set", () => {
+    const { mock, data } = mockExperimentQuery("demo-slug");
+    return (
+      <RouterSlugProvider mocks={[mock]}>
+        <TableResults
+          primaryProbeSets={data!.primaryProbeSets!}
+          results={mockAnalysis().overall}
+        />
+      </RouterSlugProvider>
+    );
+  })
+  .add("with multiple primary probe sets", () => {
+    const { mock, data } = mockExperimentQuery("demo-slug", {
+      primaryProbeSets: [
+        {
+          __typename: "NimbusProbeSetType",
+          slug: "picture-in-picture",
+          name: "Picture-in-Picture",
+        },
+        {
+          __typename: "NimbusProbeSetType",
+          slug: "feature-b",
+          name: "Feature B",
+        },
+        {
+          __typename: "NimbusProbeSetType",
+          slug: "feature-c",
+          name: "Feature C",
+        },
+      ],
+    });
+    return (
+      <RouterSlugProvider mocks={[mock]}>
+        <TableResults
+          primaryProbeSets={data!.primaryProbeSets!}
+          results={mockAnalysis().overall}
+        />
+      </RouterSlugProvider>
+    );
+  });

--- a/app/experimenter/nimbus-ui/src/components/TableResults/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/TableResults/index.test.tsx
@@ -5,11 +5,61 @@
 import React from "react";
 import { render, screen } from "@testing-library/react";
 import TableResults from ".";
+import { RouterSlugProvider } from "../../lib/test-utils";
+import { mockExperimentQuery } from "../../lib/mocks";
+import { mockAnalysis } from "../../lib/visualization/mocks";
+
+const { mock, data } = mockExperimentQuery("demo-slug");
 
 describe("TableResults", () => {
-  it("renders as expected", () => {
-    render(<TableResults />);
+  it("renders correct headings", () => {
+    render(
+      <RouterSlugProvider mocks={[mock]}>
+        <TableResults
+          primaryProbeSets={data!.primaryProbeSets!}
+          results={mockAnalysis().overall}
+        />
+      </RouterSlugProvider>,
+    );
+    const EXPECTED_HEADINGS = [
+      "Picture-in-Picture Conversion",
+      "2-Week Browser Retention",
+      "Daily Mean Searches Per User",
+      "Total Users",
+    ];
 
-    expect(screen.queryByTestId("table-results")).toBeInTheDocument();
+    EXPECTED_HEADINGS.forEach((heading) => {
+      expect(screen.getByText(heading)).toBeInTheDocument();
+    });
+  });
+
+  it("renders the expected variant and user count", () => {
+    render(
+      <RouterSlugProvider mocks={[mock]}>
+        <TableResults
+          primaryProbeSets={data!.primaryProbeSets!}
+          results={mockAnalysis().overall}
+        />
+      </RouterSlugProvider>,
+    );
+
+    expect(screen.getByText("control")).toBeInTheDocument();
+    expect(screen.getByText("treatment")).toBeInTheDocument();
+    expect(screen.getByText("198")).toBeInTheDocument();
+  });
+
+  it("renders correctly labelled result significance", () => {
+    render(
+      <RouterSlugProvider mocks={[mock]}>
+        <TableResults
+          primaryProbeSets={data!.primaryProbeSets!}
+          results={mockAnalysis().overall}
+        />
+      </RouterSlugProvider>,
+    );
+
+    expect(screen.getByTestId("positive-significance")).toBeInTheDocument();
+    expect(screen.getByTestId("negative-significance")).toBeInTheDocument();
+    expect(screen.getByTestId("neutral-significance")).toBeInTheDocument();
   });
 });

--- a/app/experimenter/nimbus-ui/src/components/TableResults/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/TableResults/index.tsx
@@ -3,9 +3,101 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React from "react";
+import {
+  RESULTS_METRICS_LIST,
+  METRICS_TIPS,
+  METRIC_TYPE,
+  TABLE_LABEL,
+} from "../../lib/visualization/constants";
+import { AnalysisData } from "../../lib/visualization/types";
+import { getTableDisplayType } from "../../lib/visualization/utils";
+import { getExperiment_experimentBySlug_primaryProbeSets } from "../../types/getExperiment";
+import TableVisualizationRow from "../TableVisualizationRow";
 
-const TableResults: React.FunctionComponent = () => {
-  return <div data-testid="table-results">results table</div>;
+type TableResultsProps = {
+  primaryProbeSets: (getExperiment_experimentBySlug_primaryProbeSets | null)[];
+  results: AnalysisData["overall"];
+};
+
+const getResultMetrics = (
+  probeSets: (getExperiment_experimentBySlug_primaryProbeSets | null)[],
+) => {
+  // Make a copy of `RESULTS_METRICS_LIST` since we modify it.
+  const resultsMetricsList = [...RESULTS_METRICS_LIST];
+  probeSets.forEach((probeSet) => {
+    resultsMetricsList.unshift({
+      value: `${probeSet!.slug.replace(/-/g, "_")}_ever_used`,
+      name: `${probeSet!.name} Conversion`,
+      tooltip: METRICS_TIPS.CONVERSION,
+      type: METRIC_TYPE.PRIMARY,
+    });
+  });
+
+  return resultsMetricsList;
+};
+
+const TableResults = ({
+  primaryProbeSets,
+  results = {},
+}: TableResultsProps) => {
+  const resultsMetricsList = getResultMetrics(primaryProbeSets);
+
+  return (
+    <table className="table text-center mb-5" data-testid="table-results">
+      <thead>
+        <tr>
+          <th scope="col" className="border-bottom-0" />
+          {resultsMetricsList.map((metric, index) => {
+            const badgeClass = `badge ${metric.type?.badge}`;
+            return (
+              <th
+                key={index}
+                scope="col"
+                className="border-bottom-0 align-middle"
+              >
+                <h3 className="h6 mb-0" data-tip={metric.tooltip}>
+                  {metric.name}
+                </h3>
+                {metric.type && (
+                  <span className={badgeClass} data-tip={metric.type.tooltip}>
+                    {metric.type.label}
+                  </span>
+                )}
+              </th>
+            );
+          })}
+        </tr>
+      </thead>
+      <tbody>
+        {Object.keys(results).map((branch) => {
+          return (
+            <tr key={branch}>
+              <th className="align-middle" scope="row">
+                {branch}
+              </th>
+              {resultsMetricsList.map((metric) => {
+                const metricKey = metric.value;
+                const displayType = getTableDisplayType(
+                  metricKey,
+                  TABLE_LABEL.RESULTS,
+                  results[branch]["is_control"],
+                );
+                return (
+                  <TableVisualizationRow
+                    key={metricKey}
+                    results={results[branch]}
+                    tableLabel={TABLE_LABEL.RESULTS}
+                    {...{ metricKey }}
+                    {...{ displayType }}
+                  />
+                );
+              })}
+            </tr>
+          );
+        })}
+      </tbody>
+    </table>
+  );
 };
 
 export default TableResults;

--- a/app/experimenter/nimbus-ui/src/components/TableVisualizationRow/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/TableVisualizationRow/index.stories.tsx
@@ -9,24 +9,42 @@ import { withLinks } from "@storybook/addon-links";
 import { mockExperimentQuery } from "../../lib/mocks";
 import TableVisualizationRow from ".";
 import { mockAnalysis } from "../../lib/visualization/mocks";
-import { DISPLAY_TYPE } from "../../lib/visualization/constants";
+import { DISPLAY_TYPE, TABLE_LABEL } from "../../lib/visualization/constants";
 
 const { mock } = mockExperimentQuery("demo-slug");
 
-// TODO: this can use a lot more stories as other tables are built out
 storiesOf("visualization/TableVisualizationRow", module)
   .addDecorator(withLinks)
-  .add("in Highlights table", () => {
-    const MOCK_ANALYSIS = mockAnalysis();
-    return (
-      <RouterSlugProvider mocks={[mock]}>
-        <TableVisualizationRow
-          key="retained"
-          results={MOCK_ANALYSIS.overall.control}
-          tableLabel="highlights"
-          metricKey="retained"
-          displayType={DISPLAY_TYPE.POPULATION}
-        />
-      </RouterSlugProvider>
-    );
-  });
+  .add("Population field", () => (
+    <RouterSlugProvider mocks={[mock]}>
+      <TableVisualizationRow
+        key="retained"
+        results={mockAnalysis().overall.control}
+        tableLabel={TABLE_LABEL.HIGHLIGHTS}
+        metricKey="retained"
+        displayType={DISPLAY_TYPE.POPULATION}
+      />
+    </RouterSlugProvider>
+  ))
+  .add("Count field", () => (
+    <RouterSlugProvider mocks={[mock]}>
+      <TableVisualizationRow
+        key="retained"
+        results={mockAnalysis().overall.control}
+        tableLabel={TABLE_LABEL.HIGHLIGHTS}
+        metricKey="retained"
+        displayType={DISPLAY_TYPE.COUNT}
+      />
+    </RouterSlugProvider>
+  ))
+  .add("Percent field", () => (
+    <RouterSlugProvider mocks={[mock]}>
+      <TableVisualizationRow
+        key="retained"
+        results={mockAnalysis().overall.control}
+        tableLabel={TABLE_LABEL.RESULTS}
+        metricKey="retained"
+        displayType={DISPLAY_TYPE.PERCENT}
+      />
+    </RouterSlugProvider>
+  ));

--- a/app/experimenter/nimbus-ui/src/components/TableVisualizationRow/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/TableVisualizationRow/index.tsx
@@ -4,7 +4,7 @@ import ReactTooltip from "react-tooltip";
 // import ConfidenceInterval from "../ConfidenceInterval";
 import {
   SIGNIFICANCE,
-  // METRIC,
+  METRIC,
   BRANCH_COMPARISON,
   TABLE_LABEL,
   VARIANT_TYPE,
@@ -108,14 +108,14 @@ const showSignificanceField = (
 //   return <ConfidenceInterval {...{ upper, lower, significance }} />;
 // };
 
-// const populationField = (point: number, percent: number | undefined) => {
-//   return (
-//     <div>
-//       <p className="font-weight-bold">{point}</p>
-//       <p className="h6">{percent}%</p>
-//     </div>
-//   );
-// };
+const populationField = (point: number, percent: number | undefined) => {
+  return (
+    <>
+      <p className="font-weight-bold mb-1">{point}</p>
+      <p className="mb-0">{percent}%</p>
+    </>
+  );
+};
 
 const countField = (
   lower: number,
@@ -159,7 +159,7 @@ const TableVisualizationRow: React.FC<{
   const { branch_data, is_control } = results;
 
   const metricData = branch_data[metricKey];
-  // const percent = branch_data[METRIC.USER_COUNT]["percent"];
+  const percent = branch_data[METRIC.USER_COUNT]["percent"];
   // const userCountMetric =
   //   branch_data[METRIC.USER_COUNT][BRANCH_COMPARISON.ABSOLUTE]["point"];
 
@@ -167,14 +167,14 @@ const TableVisualizationRow: React.FC<{
   branchComparison =
     branchComparison || dataTypeMapping[tableLabel][branchType];
   // const { lower, upper, point, count } = metricData[branchComparison];
-  const { lower, upper } = metricData[branchComparison];
+  const { lower, upper, point } = metricData[branchComparison];
   const significance = metricData["significance"];
 
   let field;
   switch (displayType) {
-    // case DISPLAY_TYPE.POPULATION:
-    //   field = populationField(point, percent);
-    //   break;
+    case DISPLAY_TYPE.POPULATION:
+      field = populationField(point, percent);
+      break;
     case DISPLAY_TYPE.COUNT:
       field = countField(lower, upper, significance, metricName, tableLabel);
       break;

--- a/app/experimenter/nimbus-ui/src/lib/visualization/constants.ts
+++ b/app/experimenter/nimbus-ui/src/lib/visualization/constants.ts
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 export const METRICS_TIPS = {
-  RETENTION: "Percentage of users w ho returned to Firefox two weeks later",
+  RETENTION: "Percentage of users who returned to Firefox two weeks later",
   SEARCH: "Daily mean number of searches per user",
   USER_COUNT:
     "Total users in a variant and the % of users out of the entire experiment population",
@@ -19,6 +19,11 @@ export const SIGNIFICANCE_TIPS = {
   NEGATIVE: "Treatment variant is significantly worse than control variant",
   NEUTRAL:
     "Treatment variant has no significant difference relative to control variant",
+};
+
+export const BADGE_TIPS = {
+  PRIMARY_METRIC: "Main metric you are trying to impact in this experiment",
+  GUARDRAIL_METRIC: "Metric that should not regress",
 };
 
 export enum VARIANT_TYPE {
@@ -47,6 +52,25 @@ export const METRIC = {
   USER_COUNT: "identity",
 };
 
+export const METRIC_TYPE = {
+  PRIMARY: {
+    label: "Primary Metric",
+    badge: "badge-primary",
+    tooltip: BADGE_TIPS.PRIMARY_METRIC,
+  },
+  SECONDARY: {
+    label: "Secondary Metric",
+    badge: "badge-secondary",
+  },
+  GUARDRAIL: {
+    label: "Guardrail Metric",
+    badge: "badge-warning",
+    tooltip: BADGE_TIPS.GUARDRAIL_METRIC,
+  },
+};
+
+// This is used as an ordered list of items to
+// display in the highlights table from top to bottom.
 export const HIGHLIGHTS_METRICS_LIST = [
   {
     value: METRIC.RETENTION,
@@ -57,6 +81,28 @@ export const HIGHLIGHTS_METRICS_LIST = [
     value: METRIC.SEARCH,
     name: "Search",
     tooltip: METRICS_TIPS.SEARCH,
+  },
+];
+
+// This is used as an ordered list of metrics to
+// display in the results table from left to right.
+export const RESULTS_METRICS_LIST = [
+  {
+    value: METRIC.RETENTION,
+    name: "2-Week Browser Retention",
+    tooltip: METRICS_TIPS.RETENTION,
+    type: METRIC_TYPE.GUARDRAIL,
+  },
+  {
+    value: METRIC.SEARCH,
+    name: "Daily Mean Searches Per User",
+    tooltip: METRICS_TIPS.SEARCH,
+    type: METRIC_TYPE.GUARDRAIL,
+  },
+  {
+    value: METRIC.USER_COUNT,
+    name: "Total Users",
+    tooltip: METRICS_TIPS.USER_COUNT,
   },
 ];
 

--- a/app/experimenter/nimbus-ui/src/lib/visualization/utils.tsx
+++ b/app/experimenter/nimbus-ui/src/lib/visualization/utils.tsx
@@ -11,9 +11,9 @@ export const getTableDisplayType = (
 ): DISPLAY_TYPE => {
   let displayType;
   switch (metricKey) {
-    // case METRIC.USER_COUNT:
-    //   displayType = DISPLAY_TYPE.POPULATION;
-    //   break;
+    case METRIC.USER_COUNT:
+      displayType = DISPLAY_TYPE.POPULATION;
+      break;
     case METRIC.SEARCH:
       if (tableLabel === TABLE_LABEL.RESULTS || isControl) {
         displayType = DISPLAY_TYPE.COUNT;


### PR DESCRIPTION
This commit:
* Adds the Results table, copied from the 'rapid' legacy project, into the Results page

Because:
* We want to be able to see this table when the analysis data is available.