### PR TITLE
fixes #3699 feat(nimbus): display missing field icons when special links clicked, show in edit overview

### DIFF
--- a/app/experimenter/nimbus-ui/package.json
+++ b/app/experimenter/nimbus-ui/package.json
@@ -12,7 +12,7 @@
     "lint:eslint": "eslint --color --max-warnings 0 --ext=.ts,.tsx .",
     "lint:tsc": "tsc --noEmit --project tsconfig.json",
     "lint:styles": "stylelint --config .stylelintrc **/*.scss",
-    "storybook": "start-storybook -p 3001",
+    "storybook": "start-storybook -p 3001 --no-version-updates",
     "build-storybook": "build-storybook",
     "eject": "react-scripts eject",
     "generate-types": "apollo codegen:generate --target typescript --outputFlat src/types"
@@ -52,6 +52,7 @@
     "@rescripts/cli": "^0.0.14",
     "@storybook/addon-actions": "^6.0.26",
     "@storybook/addon-links": "^6.1.2",
+    "@storybook/addon-queryparams": "^6.1.9",
     "@storybook/preset-create-react-app": "^3.1.4",
     "@storybook/react": "^6.0.28",
     "@testing-library/dom": "^7.24.3",

--- a/app/experimenter/nimbus-ui/src/components/AppLayoutWithExperiment/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/AppLayoutWithExperiment/index.tsx
@@ -15,6 +15,10 @@ import { NimbusExperimentStatus } from "../../types/globalTypes";
 
 type AppLayoutWithExperimentChildrenProps = {
   experiment: getExperiment_experimentBySlug;
+  review: {
+    isMissingField: (fieldName: string) => boolean;
+    refetch: () => void;
+  };
 };
 
 type AppLayoutWithExperimentProps = {
@@ -78,7 +82,7 @@ const AppLayoutWithExperiment = ({
         <h2 className="mt-3 mb-4 h4" data-testid="page-title">
           {title}
         </h2>
-        {children({ experiment })}
+        {children({ experiment, review })}
       </section>
     </Layout>
   );

--- a/app/experimenter/nimbus-ui/src/components/AppLayoutWithSidebar/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/AppLayoutWithSidebar/index.tsx
@@ -239,7 +239,7 @@ const MissingDetails = ({
               <Link
                 data-sb-kind={`pages/Edit${editPage.name}`}
                 data-testid={`missing-detail-link-${editPage.slug}`}
-                to={`${BASE_PATH}/${experimentSlug}/edit/${editPage.slug}`}
+                to={`${BASE_PATH}/${experimentSlug}/edit/${editPage.slug}?show-errors`}
               >
                 {editPage.name}
               </Link>

--- a/app/experimenter/nimbus-ui/src/components/FormOverview/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/FormOverview/index.test.tsx
@@ -205,4 +205,19 @@ describe("FormOverview", () => {
       expect(errorFeedback).toHaveAttribute("data-for", "name");
     });
   });
+
+  it("displays warning icon when public description is not filled out and server requires it", async () => {
+    Object.defineProperty(window, "location", {
+      value: {
+        search: "?show-errors",
+      },
+    });
+
+    const { data: experiment } = mockExperimentQuery("boo");
+    const isMissingField = jest.fn(() => true);
+    render(<Subject {...{ isMissingField, experiment }} />);
+
+    expect(isMissingField).toHaveBeenCalled();
+    expect(screen.queryByTestId("missing-description")).toBeInTheDocument();
+  });
 });

--- a/app/experimenter/nimbus-ui/src/components/FormOverview/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/FormOverview/index.tsx
@@ -4,15 +4,18 @@
 
 import React, { useCallback, useEffect } from "react";
 import { useForm, ValidationRules } from "react-hook-form";
+import ReactTooltip from "react-tooltip";
 import Form from "react-bootstrap/Form";
 import Alert from "react-bootstrap/Alert";
 import { getExperiment } from "../../types/getExperiment";
 import { useExitWarning } from "../../hooks";
 import { useConfig } from "../../hooks/useConfig";
+import { ReactComponent as ErrorCircle } from "../../images/error-circle.svg";
 
 type FormOverviewProps = {
   isLoading: boolean;
   isServerValid: boolean;
+  isMissingField?: (fieldName: string) => boolean;
   submitErrors: Record<string, string[]>;
   experiment?: getExperiment["experimentBySlug"];
   onSubmit: (data: Record<string, any>, reset: Function) => void;
@@ -23,6 +26,7 @@ type FormOverviewProps = {
 const FormOverview = ({
   isLoading,
   isServerValid,
+  isMissingField,
   submitErrors,
   experiment,
   onSubmit,
@@ -165,7 +169,21 @@ const FormOverview = ({
 
       {experiment && (
         <Form.Group controlId="publicDescription">
-          <Form.Label>Public description</Form.Label>
+          <Form.Label>
+            Public description
+            {isMissingField!("public_description") && (
+              <>
+                <ErrorCircle
+                  width="20"
+                  height="20"
+                  className="ml-1"
+                  data-testid="missing-description"
+                  data-tip="Public description cannot be blank"
+                />
+                <ReactTooltip />
+              </>
+            )}
+          </Form.Label>
           <Form.Control
             ref={register}
             name="publicDescription"

--- a/app/experimenter/nimbus-ui/src/components/FormOverview/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/components/FormOverview/mocks.tsx
@@ -9,6 +9,7 @@ import { MockedCache } from "../../lib/mocks";
 export const Subject = ({
   isLoading = false,
   isServerValid = true,
+  isMissingField = () => false,
   submitErrors = {},
   onSubmit = () => {},
   onCancel,
@@ -20,6 +21,7 @@ export const Subject = ({
       {...{
         isLoading,
         isServerValid,
+        isMissingField,
         submitErrors,
         onSubmit,
         onCancel,

--- a/app/experimenter/nimbus-ui/src/components/PageEditOverview/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditOverview/index.stories.tsx
@@ -5,16 +5,41 @@
 import React from "react";
 import { storiesOf } from "@storybook/react";
 import { withLinks } from "@storybook/addon-links";
+import { withQuery } from "@storybook/addon-queryparams";
 import { RouterSlugProvider } from "../../lib/test-utils";
 import { mockExperimentQuery } from "../../lib/mocks";
 import PageEditOverview from ".";
 
 const { mock } = mockExperimentQuery("demo-slug");
+const { mock: mockMissingFields } = mockExperimentQuery("demo-slug", {
+  publicDescription: null,
+  readyForReview: {
+    __typename: "NimbusReadyForReviewType",
+    ready: false,
+    message: {
+      public_description: ["This field may not be null."],
+    },
+  },
+});
 
 storiesOf("pages/EditOverview", module)
   .addDecorator(withLinks)
+  .addDecorator(withQuery)
   .add("basic", () => (
     <RouterSlugProvider mocks={[mock]}>
       <PageEditOverview />
     </RouterSlugProvider>
-  ));
+  ))
+  .add(
+    "missing fields",
+    () => (
+      <RouterSlugProvider mocks={[mockMissingFields]}>
+        <PageEditOverview />
+      </RouterSlugProvider>
+    ),
+    {
+      query: {
+        "show-errors": true,
+      },
+    },
+  );

--- a/app/experimenter/nimbus-ui/src/components/PageEditOverview/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditOverview/index.tsx
@@ -23,6 +23,7 @@ const PageEditOverview: React.FunctionComponent<PageEditOverviewProps> = () => {
 
   const [submitErrors, setSubmitErrors] = useState<Record<string, any>>({});
   const currentExperiment = useRef<getExperiment_experimentBySlug>();
+  const refetchReview = useRef<() => void>();
   const [isServerValid, setIsServerValid] = useState(true);
 
   const onFormSubmit = useCallback(
@@ -51,6 +52,8 @@ const PageEditOverview: React.FunctionComponent<PageEditOverviewProps> = () => {
         } else {
           setIsServerValid(true);
           setSubmitErrors({});
+          // In practice this should be defined by the time we get here
+          refetchReview.current!();
         }
       } catch (error) {
         setSubmitErrors({ "*": SUBMIT_ERROR });
@@ -65,14 +68,18 @@ const PageEditOverview: React.FunctionComponent<PageEditOverviewProps> = () => {
 
   return (
     <AppLayoutWithExperiment title="Overview" testId="PageEditOverview">
-      {({ experiment }) => {
+      {({ experiment, review }) => {
         currentExperiment.current = experiment;
+        refetchReview.current = review.refetch;
+
+        const { isMissingField } = review;
 
         return (
           <FormOverview
             {...{
               isLoading: loading,
               isServerValid,
+              isMissingField,
               experiment,
               submitErrors,
               onSubmit: onFormSubmit,

--- a/app/experimenter/nimbus-ui/src/hooks/useExperiment.test.tsx
+++ b/app/experimenter/nimbus-ui/src/hooks/useExperiment.test.tsx
@@ -52,6 +52,12 @@ describe("hooks/useExperiment", () => {
       };
 
       it("returns correct review info when missing details", async () => {
+        Object.defineProperty(window, "location", {
+          value: {
+            search: "?show-errors",
+          },
+        });
+
         const { mock } = mockExperimentQuery("howdy", {
           readyForReview: {
             __typename: "NimbusReadyForReviewType",

--- a/app/experimenter/nimbus-ui/src/hooks/useExperiment.tsx
+++ b/app/experimenter/nimbus-ui/src/hooks/useExperiment.tsx
@@ -41,7 +41,7 @@ const fieldPageMap: { [page: string]: string[] } = {
  */
 
 export function useExperiment(slug: string) {
-  const { data, loading, startPolling, stopPolling } = useQuery<{
+  const { data, loading, startPolling, stopPolling, refetch } = useQuery<{
     experimentBySlug: getExperiment["experimentBySlug"];
   }>(GET_EXPERIMENT_QUERY, {
     variables: { slug },
@@ -54,7 +54,11 @@ export function useExperiment(slug: string) {
     fieldPageMap[page].some((field) => missingFields.includes(field)),
   );
   const isMissingField = (fieldName: string) =>
-    missingFields.includes(fieldName);
+    missingFields.includes(fieldName) &&
+    // This is a bit hacky, but we only want to visually display missing field
+    // errors when you click the links under the "Missing details" section, not
+    // from a regular sidebar navigation link
+    window.location.search.includes("show-errors");
 
   return {
     experiment: experiment!,
@@ -67,6 +71,7 @@ export function useExperiment(slug: string) {
       invalidPages,
       missingFields,
       isMissingField,
+      refetch,
     },
   };
 }

--- a/app/experimenter/nimbus-ui/src/images/error-circle.svg
+++ b/app/experimenter/nimbus-ui/src/images/error-circle.svg
@@ -1,0 +1,1 @@
+<svg fill="none" height="20" viewBox="0 0 20 20" width="20" xmlns="http://www.w3.org/2000/svg"><path clip-rule="evenodd" d="m10 0c-5.52 0-10 4.48-10 10s4.48 10 10 10 10-4.48 10-10-4.48-10-10-10zm-1 15v-2h2v2zm0-10v6h2v-6z" fill="#840000" fill-rule="evenodd"/></svg>

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -1341,6 +1341,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.12.5":
+  version "7.12.5"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.12.5.tgz#410e7e487441e1b360c29be715d870d9b985882e"
+  integrity sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/template@^7.10.4", "@babel/template@^7.3.3", "@babel/template@^7.4.0", "@babel/template@^7.4.4", "@babel/template@^7.8.3", "@babel/template@^7.8.6":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.10.4.tgz#3251996c4200ebc71d1a8fc405fba940f36ba278"
@@ -2235,6 +2242,11 @@
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.5.3.tgz#4982b0b66b7a4cf949b86f5d25a8cf757d3cfd9d"
   integrity sha512-RFwCobxsvZ6j7twS7dHIZQZituMIDJJNHS/qY6iuthVebxS3zhRY+jaC2roEKiAYaVuTcGmX6Luc6YBcf6zJVg==
 
+"@popperjs/core@^2.4.4", "@popperjs/core@^2.5.4":
+  version "2.5.4"
+  resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.5.4.tgz#de25b5da9f727985a3757fd59b5d028aba75841a"
+  integrity sha512-ZpKr+WTb8zsajqgDkvCEWgp6d5eJT6Q63Ng2neTbzBO76Lbe91vX/iVIW9dikq+Fs3yEo+ls4cxeXABD2LtcbQ==
+
 "@reach/router@^1.3.3", "@reach/router@^1.3.4":
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/@reach/router/-/router-1.3.4.tgz#d2574b19370a70c80480ed91f3da840136d10f8c"
@@ -2430,6 +2442,23 @@
     regenerator-runtime "^0.13.7"
     ts-dedent "^2.0.0"
 
+"@storybook/addon-queryparams@^6.1.9":
+  version "6.1.9"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-queryparams/-/addon-queryparams-6.1.9.tgz#2df59b279fb4b7c5c00d059ecca5876369507315"
+  integrity sha512-Rp+1EMtYYcqRo1Kd96VJ8eMqZcYAqmlAkih48euWiHiBxc1OEja/VwmvKRd7kmt5g4EKWUT/qWXkTRV9ipZdZg==
+  dependencies:
+    "@storybook/addons" "6.1.9"
+    "@storybook/api" "6.1.9"
+    "@storybook/client-logger" "6.1.9"
+    "@storybook/components" "6.1.9"
+    "@storybook/core-events" "6.1.9"
+    "@storybook/theming" "6.1.9"
+    core-js "^3.0.1"
+    global "^4.3.2"
+    qs "^6.6.0"
+    regenerator-runtime "^0.13.7"
+    ts-dedent "^2.0.0"
+
 "@storybook/addons@6.0.26":
   version "6.0.26"
   resolved "https://registry.yarnpkg.com/@storybook/addons/-/addons-6.0.26.tgz#343cbea3eee2d39413b80bc2d66535a7f61488fc"
@@ -2471,6 +2500,21 @@
     "@storybook/core-events" "6.1.2"
     "@storybook/router" "6.1.2"
     "@storybook/theming" "6.1.2"
+    core-js "^3.0.1"
+    global "^4.3.2"
+    regenerator-runtime "^0.13.7"
+
+"@storybook/addons@6.1.9":
+  version "6.1.9"
+  resolved "https://registry.yarnpkg.com/@storybook/addons/-/addons-6.1.9.tgz#78f3cb27b7d934f091f311f89b6ca312d34f12b8"
+  integrity sha512-NRxdlGLmmSoVwlirVRgKC8xmW9cFkG+Sp5GEd4XkJDaaIg2vKR3RuFU9GuvIOVMxOhhERqhQ07bnDaAMKbFzGw==
+  dependencies:
+    "@storybook/api" "6.1.9"
+    "@storybook/channels" "6.1.9"
+    "@storybook/client-logger" "6.1.9"
+    "@storybook/core-events" "6.1.9"
+    "@storybook/router" "6.1.9"
+    "@storybook/theming" "6.1.9"
     core-js "^3.0.1"
     global "^4.3.2"
     regenerator-runtime "^0.13.7"
@@ -2552,6 +2596,31 @@
     ts-dedent "^2.0.0"
     util-deprecate "^1.0.2"
 
+"@storybook/api@6.1.9":
+  version "6.1.9"
+  resolved "https://registry.yarnpkg.com/@storybook/api/-/api-6.1.9.tgz#3f9bf00b2b18fa02965079fe775bd713677b30a3"
+  integrity sha512-S9SXlSiMeI450NIbOnx3UU9TZNyVD7jcBCjfNzhj0PqzRX/IG5Usj+R88Jm6MSIDjtsVjrWRCou+PrCh2xMnlQ==
+  dependencies:
+    "@reach/router" "^1.3.3"
+    "@storybook/channels" "6.1.9"
+    "@storybook/client-logger" "6.1.9"
+    "@storybook/core-events" "6.1.9"
+    "@storybook/csf" "0.0.1"
+    "@storybook/router" "6.1.9"
+    "@storybook/semver" "^7.3.2"
+    "@storybook/theming" "6.1.9"
+    "@types/reach__router" "^1.3.5"
+    core-js "^3.0.1"
+    fast-deep-equal "^3.1.1"
+    global "^4.3.2"
+    lodash "^4.17.15"
+    memoizerific "^1.11.3"
+    regenerator-runtime "^0.13.7"
+    store2 "^2.7.1"
+    telejson "^5.0.2"
+    ts-dedent "^2.0.0"
+    util-deprecate "^1.0.2"
+
 "@storybook/channel-postmessage@6.0.26":
   version "6.0.26"
   resolved "https://registry.yarnpkg.com/@storybook/channel-postmessage/-/channel-postmessage-6.0.26.tgz#a98a0132d6bdf06741afac2607e9feabe34ab98b"
@@ -2600,6 +2669,15 @@
   version "6.1.2"
   resolved "https://registry.yarnpkg.com/@storybook/channels/-/channels-6.1.2.tgz#e42b2cb3502291cfde36082b4844bd6de839ce86"
   integrity sha512-jek1xyLXgMnk3XbNjjVxx4xirOE7QwbwCbiESS7g2ELhRum4C636iVzLYUpt8rujXFmGibqwnoeOH4rPNIFuvA==
+  dependencies:
+    core-js "^3.0.1"
+    ts-dedent "^2.0.0"
+    util-deprecate "^1.0.2"
+
+"@storybook/channels@6.1.9":
+  version "6.1.9"
+  resolved "https://registry.yarnpkg.com/@storybook/channels/-/channels-6.1.9.tgz#94f07ff3615b11c07d1902be6b6cd298c0eea55c"
+  integrity sha512-aV+KsZPuoTtFKSMUkSCyVlVmtVHkSH35dSbyMazjlUD9cOLwkXB1s+LZL/GxxSR6a6uR75V0QWxItfNxaJETMQ==
   dependencies:
     core-js "^3.0.1"
     ts-dedent "^2.0.0"
@@ -2675,6 +2753,14 @@
     core-js "^3.0.1"
     global "^4.3.2"
 
+"@storybook/client-logger@6.1.9":
+  version "6.1.9"
+  resolved "https://registry.yarnpkg.com/@storybook/client-logger/-/client-logger-6.1.9.tgz#1d61a64000d4691780d75e19b78fd44adfdb5d9c"
+  integrity sha512-i7Q2ky9+Jwv+wmnlOGxmDOEdmaTIB69OQnnZNWGKufOwoIMjn6QO0VifARyA9W++nNSijjJ5th84tLJALaoCTA==
+  dependencies:
+    core-js "^3.0.1"
+    global "^4.3.2"
+
 "@storybook/components@6.0.26":
   version "6.0.26"
   resolved "https://registry.yarnpkg.com/@storybook/components/-/components-6.0.26.tgz#e1f6e16aae850a71c9ac7bdd1d44a068ec9cfdc1"
@@ -2731,6 +2817,32 @@
     react-textarea-autosize "^8.1.1"
     ts-dedent "^1.1.1"
 
+"@storybook/components@6.1.9":
+  version "6.1.9"
+  resolved "https://registry.yarnpkg.com/@storybook/components/-/components-6.1.9.tgz#f25d18f3a410cc7e9549ddb3c971c40d9108d4d8"
+  integrity sha512-cYYm3fHo9MW0bbl47lu1ncwulV7V9VEF8FC96uvys07oaCTFWKzQ0z/FD0nCqeK6eEz1+SEqnGwLFmOtqlRXDQ==
+  dependencies:
+    "@popperjs/core" "^2.4.4"
+    "@storybook/client-logger" "6.1.9"
+    "@storybook/csf" "0.0.1"
+    "@storybook/theming" "6.1.9"
+    "@types/overlayscrollbars" "^1.9.0"
+    "@types/react-color" "^3.0.1"
+    "@types/react-syntax-highlighter" "11.0.4"
+    core-js "^3.0.1"
+    fast-deep-equal "^3.1.1"
+    global "^4.3.2"
+    lodash "^4.17.15"
+    markdown-to-jsx "^6.11.4"
+    memoizerific "^1.11.3"
+    overlayscrollbars "^1.10.2"
+    polished "^3.4.4"
+    react-color "^2.17.0"
+    react-popper-tooltip "^3.1.0"
+    react-syntax-highlighter "^13.5.0"
+    react-textarea-autosize "^8.1.1"
+    ts-dedent "^2.0.0"
+
 "@storybook/core-events@6.0.26":
   version "6.0.26"
   resolved "https://registry.yarnpkg.com/@storybook/core-events/-/core-events-6.0.26.tgz#61181c9a8610d26cc85d47f133a563879044ca2d"
@@ -2749,6 +2861,13 @@
   version "6.1.2"
   resolved "https://registry.yarnpkg.com/@storybook/core-events/-/core-events-6.1.2.tgz#d29e9a8c7ef6bb41135282f4da8027bb6f399545"
   integrity sha512-Vhv22JyDLLJ9kqPCiXyMmePFYVbvYHREzXOtA3vgcf/leKxp6aGHE+OId1e4fycQN4ZU6kPbVnRrI9WFJwV+pA==
+  dependencies:
+    core-js "^3.0.1"
+
+"@storybook/core-events@6.1.9":
+  version "6.1.9"
+  resolved "https://registry.yarnpkg.com/@storybook/core-events/-/core-events-6.1.9.tgz#0a88281837d1aa657a93a9abf7f5aad65b8d68e7"
+  integrity sha512-oOpqpjCTJCt0U5lnQ16OZU0iKIDh2/MIg4yrnDw+Pt6zGyX3zSvtB+9W8LQFnMwm+cXaNmiizGwt/W+4OiORjQ==
   dependencies:
     core-js "^3.0.1"
 
@@ -2947,6 +3066,18 @@
     memoizerific "^1.11.3"
     qs "^6.6.0"
 
+"@storybook/router@6.1.9":
+  version "6.1.9"
+  resolved "https://registry.yarnpkg.com/@storybook/router/-/router-6.1.9.tgz#c0b24dc3ab53d58541b81c7abea2f11d7fbbebf6"
+  integrity sha512-kIlmSFBnqI198oMCncFZR7MxoV5/kP6KS0paFcyu1XE1zO2ovV6eQZ8pPpOjSsD/ISu4Y44uE+ZDNsEehjj6GQ==
+  dependencies:
+    "@reach/router" "^1.3.3"
+    "@types/reach__router" "^1.3.5"
+    core-js "^3.0.1"
+    global "^4.3.2"
+    memoizerific "^1.11.3"
+    qs "^6.6.0"
+
 "@storybook/semver@^7.3.2":
   version "7.3.2"
   resolved "https://registry.yarnpkg.com/@storybook/semver/-/semver-7.3.2.tgz#f3b9c44a1c9a0b933c04e66d0048fcf2fa10dac0"
@@ -3000,6 +3131,24 @@
     "@emotion/is-prop-valid" "^0.8.6"
     "@emotion/styled" "^10.0.23"
     "@storybook/client-logger" "6.1.2"
+    core-js "^3.0.1"
+    deep-object-diff "^1.1.0"
+    emotion-theming "^10.0.19"
+    global "^4.3.2"
+    memoizerific "^1.11.3"
+    polished "^3.4.4"
+    resolve-from "^5.0.0"
+    ts-dedent "^2.0.0"
+
+"@storybook/theming@6.1.9":
+  version "6.1.9"
+  resolved "https://registry.yarnpkg.com/@storybook/theming/-/theming-6.1.9.tgz#8c584aa623f3d6e33b1e3b3de2ec1f41bdc5d9ab"
+  integrity sha512-orzMQkyEhAQEi0E9iwmUkzh5yPHoYGBz17t2aydDeT6oGKii6if8Mq2oPVycfVKZ84QO7GFAS9q1nVCRcuD8oA==
+  dependencies:
+    "@emotion/core" "^10.1.1"
+    "@emotion/is-prop-valid" "^0.8.6"
+    "@emotion/styled" "^10.0.23"
+    "@storybook/client-logger" "6.1.9"
     core-js "^3.0.1"
     deep-object-diff "^1.1.0"
     emotion-theming "^10.0.19"
@@ -3451,6 +3600,13 @@
   dependencies:
     "@types/node" "*"
 
+"@types/hast@^2.0.0":
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/@types/hast/-/hast-2.3.1.tgz#b16872f2a6144c7025f296fb9636a667ebb79cd9"
+  integrity sha512-viwwrB+6xGzw+G1eWpF9geV3fnsDgXqHG+cqgiHrvQfDUW5hzhCyV7Sy3UJxhfRFBsgky2SSW33qi/YrIkjX5Q==
+  dependencies:
+    "@types/unist" "*"
+
 "@types/history@*":
   version "4.7.8"
   resolved "https://registry.yarnpkg.com/@types/history/-/history-4.7.8.tgz#49348387983075705fe8f4e02fb67f7daaec4934"
@@ -3739,7 +3895,7 @@
   dependencies:
     source-map "^0.6.1"
 
-"@types/unist@^2.0.0", "@types/unist@^2.0.2":
+"@types/unist@*", "@types/unist@^2.0.0", "@types/unist@^2.0.2":
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/@types/unist/-/unist-2.0.3.tgz#9c088679876f374eb5983f150d4787aa6fb32d7e"
   integrity sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ==
@@ -9038,7 +9194,7 @@ fastq@^1.6.0:
   dependencies:
     reusify "^1.0.4"
 
-fault@^1.0.2:
+fault@^1.0.0, fault@^1.0.2:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/fault/-/fault-1.0.4.tgz#eafcfc0a6d214fc94601e170df29954a4f842f13"
   integrity sha512-CJ0HCB5tL5fYTEA7ToAq5+kTwd++Borf1/bifxd9iT70QcXr4MRrO3Llf8Ifs70q+SJcGHFtnIE/Nw6giCtECA==
@@ -10032,6 +10188,17 @@ hastscript@^5.0.0:
     property-information "^5.0.0"
     space-separated-tokens "^1.0.0"
 
+hastscript@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/hastscript/-/hastscript-6.0.0.tgz#e8768d7eac56c3fdeac8a92830d58e811e5bf640"
+  integrity sha512-nDM6bvd7lIqDUiYEiu5Sl/+6ReP0BMk/2f4U/Rooccxkj0P5nm+acM5PrGJ/t5I8qPGiqZSE6hVAwZEdZIvP4w==
+  dependencies:
+    "@types/hast" "^2.0.0"
+    comma-separated-tokens "^1.0.0"
+    hast-util-parse-selector "^2.0.0"
+    property-information "^5.0.0"
+    space-separated-tokens "^1.0.0"
+
 he@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
@@ -10049,6 +10216,11 @@ hex-color-regex@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/hex-color-regex/-/hex-color-regex-1.1.0.tgz#4c06fccb4602fe2602b3c93df82d7e7dbf1a8a8e"
   integrity sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ==
+
+highlight.js@^10.1.1, highlight.js@~10.4.0:
+  version "10.4.0"
+  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-10.4.0.tgz#ef3ce475e5dfa7a48484260b49ea242ddab823a0"
+  integrity sha512-EfrUGcQ63oLJbj0J0RI9ebX6TAITbsDBLbsjr881L/X5fMO9+oadKzEF21C7R3ULKG6Gv3uoab2HiqVJa/4+oA==
 
 highlight.js@~9.15.0, highlight.js@~9.15.1:
   version "9.15.10"
@@ -12876,6 +13048,14 @@ lowlight@1.12.1:
     fault "^1.0.2"
     highlight.js "~9.15.0"
 
+lowlight@^1.14.0:
+  version "1.17.0"
+  resolved "https://registry.yarnpkg.com/lowlight/-/lowlight-1.17.0.tgz#a1143b2fba8239df8cd5893f9fe97aaf8465af4a"
+  integrity sha512-vmtBgYKD+QVNy7tIa7ulz5d//Il9R4MooOVh4nkOf9R9Cb/Dk5TXMSTieg/vDulkBkIWj59/BIlyFQxT9X1oAQ==
+  dependencies:
+    fault "^1.0.0"
+    highlight.js "~10.4.0"
+
 lru-cache@^4.0.1:
   version "4.1.5"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.5.tgz#8bbe50ea85bed59bc9e33dcab8235ee9bcf443cd"
@@ -15531,6 +15711,13 @@ prismjs@^1.20.0, prismjs@^1.8.4:
   optionalDependencies:
     clipboard "^2.0.0"
 
+prismjs@^1.21.0, prismjs@~1.22.0:
+  version "1.22.0"
+  resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.22.0.tgz#73c3400afc58a823dd7eed023f8e1ce9fd8977fa"
+  integrity sha512-lLJ/Wt9yy0AiSYBf212kK3mM5L8ycwlyTlSxHBAneXLR0nzFMlZ5y7riFPF3E33zXOF2IH95xdY5jIyZbM9z/w==
+  optionalDependencies:
+    clipboard "^2.0.0"
+
 prismjs@~1.17.0:
   version "1.17.1"
   resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.17.1.tgz#e669fcbd4cdd873c35102881c33b14d0d68519be"
@@ -16010,7 +16197,7 @@ react-error-overlay@^6.0.7:
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-6.0.7.tgz#1dcfb459ab671d53f660a991513cb2f0a0553108"
   integrity sha512-TAv1KJFh3RhqxNvhzxj6LeT5NWklP6rDr2a0jaTfsZ5wSZWHOGeqQyejUp3xxLfPt2UpyJEcVQB/zyPcmonNFA==
 
-react-fast-compare@^3.2.0:
+react-fast-compare@^3.0.1, react-fast-compare@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-3.2.0.tgz#641a9da81b6a6320f270e89724fb45a0b39e43bb"
   integrity sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA==
@@ -16086,6 +16273,15 @@ react-popper-tooltip@^2.11.0:
     "@babel/runtime" "^7.9.2"
     react-popper "^1.3.7"
 
+react-popper-tooltip@^3.1.0:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/react-popper-tooltip/-/react-popper-tooltip-3.1.1.tgz#329569eb7b287008f04fcbddb6370452ad3f9eac"
+  integrity sha512-EnERAnnKRptQBJyaee5GJScWNUKQPDD2ywvzZyUjst/wj5U64C8/CnSYLNEmP2hG0IJ3ZhtDxE8oDN+KOyavXQ==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    "@popperjs/core" "^2.5.4"
+    react-popper "^2.2.4"
+
 react-popper@^1.3.7:
   version "1.3.7"
   resolved "https://registry.yarnpkg.com/react-popper/-/react-popper-1.3.7.tgz#f6a3471362ef1f0d10a4963673789de1baca2324"
@@ -16097,6 +16293,14 @@ react-popper@^1.3.7:
     popper.js "^1.14.4"
     prop-types "^15.6.1"
     typed-styles "^0.0.7"
+    warning "^4.0.2"
+
+react-popper@^2.2.4:
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/react-popper/-/react-popper-2.2.4.tgz#d2ad3d2474ac9f1abf93df3099d408e5aa6a2e22"
+  integrity sha512-NacOu4zWupdQjVXq02XpTD3yFPSfg5a7fex0wa3uGKVkFK7UN6LvVxgcb+xYr56UCuWiNPMH20tntdVdJRwYew==
+  dependencies:
+    react-fast-compare "^3.0.1"
     warning "^4.0.2"
 
 react-router-dom@5.2.0:
@@ -16229,6 +16433,17 @@ react-syntax-highlighter@^12.2.1:
     lowlight "1.12.1"
     prismjs "^1.8.4"
     refractor "^2.4.1"
+
+react-syntax-highlighter@^13.5.0:
+  version "13.5.3"
+  resolved "https://registry.yarnpkg.com/react-syntax-highlighter/-/react-syntax-highlighter-13.5.3.tgz#9712850f883a3e19eb858cf93fad7bb357eea9c6"
+  integrity sha512-crPaF+QGPeHNIblxxCdf2Lg936NAHKhNhuMzRL3F9ct6aYXL3NcZtCL0Rms9+qVo6Y1EQLdXGypBNSbPL/r+qg==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
+    highlight.js "^10.1.1"
+    lowlight "^1.14.0"
+    prismjs "^1.21.0"
+    refractor "^3.1.0"
 
 react-textarea-autosize@^8.1.1:
   version "8.2.0"
@@ -16455,6 +16670,15 @@ refractor@^2.4.1:
     hastscript "^5.0.0"
     parse-entities "^1.1.2"
     prismjs "~1.17.0"
+
+refractor@^3.1.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/refractor/-/refractor-3.2.0.tgz#bc46f7cfbb6adbf45cd304e8e299b7fa854804e0"
+  integrity sha512-hSo+EyMIZTLBvNNgIU5lW4yjCzNYMZ4dcEhBq/3nReGfqzd2JfVhdlPDfU9rEsgcAyWx+OimIIUoL4ZU7NtYHQ==
+  dependencies:
+    hastscript "^6.0.0"
+    parse-entities "^2.0.0"
+    prismjs "~1.22.0"
 
 regenerate-unicode-properties@^8.2.0:
   version "8.2.0"


### PR DESCRIPTION
This PR does two things:

- Sets up the `useExperiment`'s `isMissingField` function to display the little ( ! ) icons across pages that use it.
- Adds the ( ! ) missing field icon to the EditOverview's public description, as this is the only field that is required and possibly null.

Storybook: `PageEditOverview`'s [`missing fields`](https://storage.googleapis.com/mozilla-storybooks-experimenter/commits/5593c835d03ab43f24de079dddbb2867b822aa17/nimbus-ui/index.html?path=/story/pages-editoverview--missing-fields)