### PR TITLE
fix #4009 feat(nimbus): send default branches for new experiments in graphql

### DIFF
--- a/app/experimenter/experiments/api/v5/types.py
+++ b/app/experimenter/experiments/api/v5/types.py
@@ -120,6 +120,16 @@ class NimbusExperimentType(DjangoObjectType):
         model = NimbusExperiment
         exclude = ("branches", "probe_sets")
 
+    def resolve_reference_branch(self, info):
+        if self.reference_branch:
+            return self.reference_branch
+        return NimbusBranch(feature_enabled=False)
+
+    def resolve_treatment_branches(self, info):
+        if self.treatment_branches:
+            return self.treatment_branches
+        return [NimbusBranch(feature_enabled=False)]
+
     def resolve_ready_for_review(self, info):
         serializer = NimbusReadyForReviewSerializer(
             self,


### PR DESCRIPTION


Becasue

* We want the branch form to be prepopulated with an empty control and treatment branch

This commit

* Adds an empty control and treatment branch to the graphql serializer so the form has some empty defaults