### PR TITLE
fixes #3795 feat(nimbus): Add secondary metric table to Results page + other vis table tweaks

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/PageResults/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/index.stories.tsx
@@ -10,8 +10,11 @@ import { mockExperimentQuery } from "../../lib/mocks";
 import PageResults from ".";
 import fetchMock from "fetch-mock";
 import { mockAnalysis } from "../../lib/visualization/mocks";
+import { NimbusExperimentStatus } from "../../types/globalTypes";
 
-const { mock } = mockExperimentQuery("demo-slug");
+const { mock } = mockExperimentQuery("demo-slug", {
+  status: NimbusExperimentStatus.COMPLETE,
+});
 
 storiesOf("pages/Results", module)
   .addDecorator(withLinks)

--- a/app/experimenter/nimbus-ui/src/components/PageResults/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/index.tsx
@@ -82,22 +82,28 @@ const AnalysisAvailable = ({
     />
     <TableOverview {...{ experiment }} results={analysis?.overall!} />
 
-    <h2 className="h5 mb-3 mt-4">Results</h2>
+    <h2 className="h5 mb-3">Results</h2>
     <TableResults
       primaryProbeSets={experiment.primaryProbeSets!}
       results={analysis?.overall!}
     />
     <div>
-      {experiment.primaryProbeSets?.map((probeSet) => (
-        <TableMetricPrimary
-          key={probeSet?.slug}
-          results={analysis?.overall!}
-          {...{ probeSet }}
-        />
-      ))}
-      {experiment.secondaryProbeSets?.map((probeSet) => (
-        <TableMetricSecondary key={probeSet?.slug} />
-      ))}
+      {experiment.primaryProbeSets?.length &&
+        experiment.primaryProbeSets.map((probeSet) => (
+          <TableMetricPrimary
+            key={probeSet?.slug}
+            results={analysis?.overall!}
+            probeSet={probeSet!}
+          />
+        ))}
+      {experiment.secondaryProbeSets?.length &&
+        experiment.secondaryProbeSets.map((probeSet) => (
+          <TableMetricSecondary
+            key={probeSet?.slug}
+            results={analysis?.overall!}
+            probeSet={probeSet!}
+          />
+        ))}
     </div>
   </>
 );

--- a/app/experimenter/nimbus-ui/src/components/TableHighlights/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/TableHighlights/index.tsx
@@ -29,7 +29,7 @@ const getHighlightMetrics = (
   const highlightMetricsList = [...HIGHLIGHTS_METRICS_LIST];
   probeSets.forEach((probeSet) => {
     highlightMetricsList.unshift({
-      value: `${probeSet!.slug.replace(/-/g, "_")}_ever_used`,
+      value: `${probeSet!.slug}_ever_used`,
       name: `${probeSet!.name} conversion`,
       tooltip: METRICS_TIPS.CONVERSION,
     });
@@ -45,7 +45,7 @@ const TableHighlights = ({
   const highlightMetricsList = getHighlightMetrics(primaryProbeSets);
 
   return (
-    <table data-testid="table-highlights" className="mt-4">
+    <table data-testid="table-highlights" className="table mt-4 mb-0">
       <tbody>
         {Object.keys(results).map((branch) => {
           const userCountMetric =
@@ -59,11 +59,11 @@ const TableHighlights = ({
                   participants ({userCountMetric["percent"]}%)
                 </p>
               </th>
-              <td className="p-1 p-lg-3">
+              <td className="p-1 p-lg-3 align-middle">
                 <span className="align-middle">All Users&nbsp;</span>
                 <Info data-tip={SEGMENT_TIPS.ALL_USERS} />
               </td>
-              <td className="pt-3 px-1 px-lg-3">
+              <td className="pt-3 px-3 pb-0">
                 {highlightMetricsList.map((metric) => {
                   const metricKey = metric.value;
                   const displayType = getTableDisplayType(
@@ -73,7 +73,7 @@ const TableHighlights = ({
                   );
                   return (
                     <TableVisualizationRow
-                      key={metricKey}
+                      key={`${displayType}-${metricKey}`}
                       metricName={metric.name}
                       results={results[branch]}
                       tableLabel={TABLE_LABEL.HIGHLIGHTS}

--- a/app/experimenter/nimbus-ui/src/components/TableMetricPrimary/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/TableMetricPrimary/index.stories.tsx
@@ -4,7 +4,6 @@
 
 import React from "react";
 import { storiesOf } from "@storybook/react";
-import { RouterSlugProvider } from "../../lib/test-utils";
 import { withLinks } from "@storybook/addon-links";
 import { mockExperimentQuery } from "../../lib/mocks";
 import TableMetricPrimary from ".";
@@ -13,7 +12,7 @@ import { mockAnalysis } from "../../lib/visualization/mocks";
 storiesOf("visualization/TableMetricPrimary", module)
   .addDecorator(withLinks)
   .add("with positive primary metric", () => {
-    const { mock, data } = mockExperimentQuery("demo-slug", {
+    const { data } = mockExperimentQuery("demo-slug", {
       primaryProbeSets: [
         {
           __typename: "NimbusProbeSetType",
@@ -24,16 +23,14 @@ storiesOf("visualization/TableMetricPrimary", module)
     });
 
     return (
-      <RouterSlugProvider mocks={[mock]}>
-        <TableMetricPrimary
-          results={mockAnalysis().overall}
-          probeSet={data!.primaryProbeSets![0]}
-        />
-      </RouterSlugProvider>
+      <TableMetricPrimary
+        results={mockAnalysis().overall}
+        probeSet={data!.primaryProbeSets![0]!}
+      />
     );
   })
   .add("with negative primary metric", () => {
-    const { mock, data } = mockExperimentQuery("demo-slug", {
+    const { data } = mockExperimentQuery("demo-slug", {
       primaryProbeSets: [
         {
           __typename: "NimbusProbeSetType",
@@ -44,16 +41,14 @@ storiesOf("visualization/TableMetricPrimary", module)
     });
 
     return (
-      <RouterSlugProvider mocks={[mock]}>
-        <TableMetricPrimary
-          results={mockAnalysis().overall}
-          probeSet={data!.primaryProbeSets![0]}
-        />
-      </RouterSlugProvider>
+      <TableMetricPrimary
+        results={mockAnalysis().overall}
+        probeSet={data!.primaryProbeSets![0]!}
+      />
     );
   })
   .add("with neutral primary metric", () => {
-    const { mock, data } = mockExperimentQuery("demo-slug", {
+    const { data } = mockExperimentQuery("demo-slug", {
       primaryProbeSets: [
         {
           __typename: "NimbusProbeSetType",
@@ -64,11 +59,9 @@ storiesOf("visualization/TableMetricPrimary", module)
     });
 
     return (
-      <RouterSlugProvider mocks={[mock]}>
-        <TableMetricPrimary
-          results={mockAnalysis().overall}
-          probeSet={data!.primaryProbeSets![0]}
-        />
-      </RouterSlugProvider>
+      <TableMetricPrimary
+        results={mockAnalysis().overall}
+        probeSet={data!.primaryProbeSets![0]!}
+      />
     );
   });

--- a/app/experimenter/nimbus-ui/src/components/TableMetricPrimary/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/TableMetricPrimary/index.test.tsx
@@ -10,7 +10,7 @@ import { mockAnalysis } from "../../lib/visualization/mocks";
 import { RouterSlugProvider } from "../../lib/test-utils";
 
 describe("TableMetricPrimary", () => {
-  it("has the correct headings", async () => {
+  it("has the correct headings", () => {
     const EXPECTED_HEADINGS = [
       "Conversions / Total Users",
       "Conversion Rate",
@@ -22,7 +22,7 @@ describe("TableMetricPrimary", () => {
       <RouterSlugProvider mocks={[mock]}>
         <TableMetricPrimary
           results={mockAnalysis().overall}
-          probeSet={data!.primaryProbeSets![0]}
+          probeSet={data!.primaryProbeSets![0]!}
         />
       </RouterSlugProvider>,
     );
@@ -32,14 +32,14 @@ describe("TableMetricPrimary", () => {
     });
   });
 
-  it("has correctly labelled result significance", async () => {
+  it("has correctly labelled result significance", () => {
     const { mock, data } = mockExperimentQuery("demo-slug");
 
     render(
       <RouterSlugProvider mocks={[mock]}>
         <TableMetricPrimary
           results={mockAnalysis().overall}
-          probeSet={data!.primaryProbeSets![0]}
+          probeSet={data!.primaryProbeSets![0]!}
         />
       </RouterSlugProvider>,
     );
@@ -52,14 +52,14 @@ describe("TableMetricPrimary", () => {
     expect(neutralSignificance).not.toBeInTheDocument();
   });
 
-  it("has the expected control and treatment labels", async () => {
+  it("has the expected control and treatment labels", () => {
     const { mock, data } = mockExperimentQuery("demo-slug");
 
     render(
       <RouterSlugProvider mocks={[mock]}>
         <TableMetricPrimary
           results={mockAnalysis().overall}
-          probeSet={data!.primaryProbeSets![0]}
+          probeSet={data!.primaryProbeSets![0]!}
         />
       </RouterSlugProvider>,
     );
@@ -68,14 +68,14 @@ describe("TableMetricPrimary", () => {
     expect(screen.getByText("treatment")).toBeInTheDocument();
   });
 
-  it("shows the positive improvement bar", async () => {
+  it("shows the positive improvement bar", () => {
     const { mock, data } = mockExperimentQuery("demo-slug");
 
     render(
       <RouterSlugProvider mocks={[mock]}>
         <TableMetricPrimary
           results={mockAnalysis().overall}
-          probeSet={data!.primaryProbeSets![0]}
+          probeSet={data!.primaryProbeSets![0]!}
         />
       </RouterSlugProvider>,
     );
@@ -88,7 +88,7 @@ describe("TableMetricPrimary", () => {
     expect(neutralBlock).not.toBeInTheDocument();
   });
 
-  it("shows the negative improvement bar", async () => {
+  it("shows the negative improvement bar", () => {
     const { mock, data } = mockExperimentQuery("demo-slug", {
       primaryProbeSets: [
         {
@@ -103,7 +103,7 @@ describe("TableMetricPrimary", () => {
       <RouterSlugProvider mocks={[mock]}>
         <TableMetricPrimary
           results={mockAnalysis().overall}
-          probeSet={data!.primaryProbeSets![0]}
+          probeSet={data!.primaryProbeSets![0]!}
         />
       </RouterSlugProvider>,
     );
@@ -116,7 +116,7 @@ describe("TableMetricPrimary", () => {
     expect(neutralBlock).not.toBeInTheDocument();
   });
 
-  it("shows the neutral improvement bar", async () => {
+  it("shows the neutral improvement bar", () => {
     const { mock, data } = mockExperimentQuery("demo-slug", {
       primaryProbeSets: [
         {
@@ -131,7 +131,7 @@ describe("TableMetricPrimary", () => {
       <RouterSlugProvider mocks={[mock]}>
         <TableMetricPrimary
           results={mockAnalysis().overall}
-          probeSet={data!.primaryProbeSets![0]}
+          probeSet={data!.primaryProbeSets![0]!}
         />
       </RouterSlugProvider>,
     );

--- a/app/experimenter/nimbus-ui/src/components/TableMetricPrimary/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/TableMetricPrimary/index.tsx
@@ -21,13 +21,11 @@ type PrimaryMetricStatistic = {
 
 type TableMetricPrimaryProps = {
   results: AnalysisData["overall"];
-  probeSet: getExperiment_experimentBySlug_primaryProbeSets | null;
+  probeSet: getExperiment_experimentBySlug_primaryProbeSets;
 };
 
-const getStatistics = (
-  probeset: string | null,
-): Array<PrimaryMetricStatistic> => {
-  const probesetMetricID = `${probeset}_ever_used`;
+const getStatistics = (slug: string): Array<PrimaryMetricStatistic> => {
+  const probesetMetricID = `${slug}_ever_used`;
 
   // Make a copy of `PRIMARY_METRIC_COLUMNS` since we modify it.
   const primaryMetricStatisticsList = PRIMARY_METRIC_COLUMNS.map(
@@ -45,17 +43,21 @@ const TableMetricPrimary = ({
   probeSet,
 }: TableMetricPrimaryProps) => {
   const primaryMetricStatistics = getStatistics(probeSet!.slug);
-  const metricKey = `${probeSet?.slug}_ever_used`;
+  const metricKey = `${probeSet.slug}_ever_used`;
 
   return (
     <div data-testid="table-metric-primary">
-      <h2 className="h5 mb-3 mt-4">{probeSet?.name}</h2>
-      <table className="table text-center mb-5 mt-4">
+      <h2 className="h5 mb-3">{probeSet.name}</h2>
+      <table className="table-visualization-center">
         <thead>
           <tr>
-            <th scope="col" className="border-bottom-0" />
+            <th scope="col" className="border-bottom-0 bg-light" />
             {PRIMARY_METRIC_COLUMNS.map((value) => (
-              <th className="border-bottom-0" key={value.name} scope="col">
+              <th
+                className="border-bottom-0 bg-light"
+                key={value.name}
+                scope="col"
+              >
                 <div>{value.name}</div>
               </th>
             ))}
@@ -68,16 +70,16 @@ const TableMetricPrimary = ({
                 <th className="align-middle" scope="row">
                   {branch}
                 </th>
-                {primaryMetricStatistics.map((column) => (
-                  <TableVisualizationRow
-                    key={column.displayType}
-                    branchComparison={column.branchComparison}
-                    displayType={column.displayType}
-                    results={results[branch]}
-                    tableLabel={TABLE_LABEL.PRIMARY_METRICS}
-                    {...{ metricKey }}
-                  />
-                ))}
+                {primaryMetricStatistics.map(
+                  ({ displayType, branchComparison, value }) => (
+                    <TableVisualizationRow
+                      key={`${displayType}-${value}`}
+                      results={results[branch]}
+                      tableLabel={TABLE_LABEL.PRIMARY_METRICS}
+                      {...{ metricKey, displayType, branchComparison }}
+                    />
+                  ),
+                )}
               </tr>
             );
           })}

--- a/app/experimenter/nimbus-ui/src/components/TableMetricSecondary/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/TableMetricSecondary/index.stories.tsx
@@ -4,18 +4,55 @@
 
 import React from "react";
 import { storiesOf } from "@storybook/react";
-import { RouterSlugProvider } from "../../lib/test-utils";
 import { withLinks } from "@storybook/addon-links";
 import { mockExperimentQuery } from "../../lib/mocks";
 import TableMetricSecondary from ".";
-// import { mockAnalysis } from "../../lib/visualization/mocks";
-
-const { mock } = mockExperimentQuery("demo-slug");
+import { mockAnalysis } from "../../lib/visualization/mocks";
 
 storiesOf("visualization/TableMetricSecondary", module)
   .addDecorator(withLinks)
-  .add("basic", () => (
-    <RouterSlugProvider mocks={[mock]}>
-      <TableMetricSecondary />
-    </RouterSlugProvider>
-  ));
+  .add("with positive secondary metric", () => {
+    const { data } = mockExperimentQuery("demo-slug", {
+      secondaryProbeSets: [
+        {
+          __typename: "NimbusProbeSetType",
+          slug: "picture_in_picture",
+          name: "Picture-in-Picture",
+        },
+      ],
+    });
+
+    return (
+      <TableMetricSecondary
+        results={mockAnalysis().overall}
+        probeSet={data!.secondaryProbeSets![0]!}
+      />
+    );
+  })
+  .add("with negative secondary metric", () => {
+    const { data } = mockExperimentQuery("demo-slug");
+    return (
+      <TableMetricSecondary
+        results={mockAnalysis().overall}
+        probeSet={data!.secondaryProbeSets![0]!}
+      />
+    );
+  })
+  .add("with neutral secondary metric", () => {
+    const { data } = mockExperimentQuery("demo-slug", {
+      secondaryProbeSets: [
+        {
+          __typename: "NimbusProbeSetType",
+          slug: "feature_c",
+          name: "Feature C",
+        },
+      ],
+    });
+
+    return (
+      <TableMetricSecondary
+        results={mockAnalysis().overall}
+        probeSet={data!.secondaryProbeSets![0]!}
+      />
+    );
+  });

--- a/app/experimenter/nimbus-ui/src/components/TableMetricSecondary/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/TableMetricSecondary/index.test.tsx
@@ -5,11 +5,79 @@
 import React from "react";
 import { render, screen } from "@testing-library/react";
 import TableMetricSecondary from ".";
+import { RouterSlugProvider } from "../../lib/test-utils";
+import { mockAnalysis } from "../../lib/visualization/mocks";
+import { mockExperimentQuery } from "../../lib/mocks";
 
 describe("TableMetricSecondary", () => {
-  it("renders as expected", () => {
-    render(<TableMetricSecondary />);
+  it("has the correct headings", async () => {
+    const EXPECTED_HEADINGS = ["Count", "Relative Improvement"];
+    const { mock, data } = mockExperimentQuery("demo-slug");
 
-    expect(screen.queryByTestId("table-metric-secondary")).toBeInTheDocument();
+    render(
+      <RouterSlugProvider mocks={[mock]}>
+        <TableMetricSecondary
+          results={mockAnalysis().overall}
+          probeSet={data!.primaryProbeSets![0]!}
+        />
+      </RouterSlugProvider>,
+    );
+
+    EXPECTED_HEADINGS.forEach((heading) => {
+      expect(screen.getByText(heading)).toBeInTheDocument();
+    });
+  });
+
+  it("has correctly labelled result significance", async () => {
+    const { mock, data } = mockExperimentQuery("demo-slug");
+    render(
+      <RouterSlugProvider mocks={[mock]}>
+        <TableMetricSecondary
+          results={mockAnalysis().overall}
+          probeSet={data!.primaryProbeSets![0]!}
+        />
+      </RouterSlugProvider>,
+    );
+
+    const negativeSignificance = screen.queryByTestId("negative-significance");
+    const neutralSignificance = screen.queryByTestId("neutral-significance");
+
+    expect(screen.getByTestId("positive-significance")).toBeInTheDocument();
+    expect(negativeSignificance).not.toBeInTheDocument();
+    expect(neutralSignificance).not.toBeInTheDocument();
+  });
+
+  it("has the expected control and treatment labels", async () => {
+    const { mock, data } = mockExperimentQuery("demo-slug");
+    render(
+      <RouterSlugProvider mocks={[mock]}>
+        <TableMetricSecondary
+          results={mockAnalysis().overall}
+          probeSet={data!.primaryProbeSets![0]!}
+        />
+      </RouterSlugProvider>,
+    );
+
+    expect(screen.getAllByText("control")).toHaveLength(2);
+    expect(screen.getByText("treatment")).toBeInTheDocument();
+  });
+
+  it("shows the positive improvement bar", async () => {
+    const { mock, data } = mockExperimentQuery("demo-slug");
+    render(
+      <RouterSlugProvider mocks={[mock]}>
+        <TableMetricSecondary
+          results={mockAnalysis().overall}
+          probeSet={data!.primaryProbeSets![0]!}
+        />
+      </RouterSlugProvider>,
+    );
+
+    const negativeBlock = screen.queryByTestId("negative-block");
+    const neutralBlock = screen.queryByTestId("neutral-block");
+
+    expect(screen.getByTestId("positive-block")).toBeInTheDocument();
+    expect(negativeBlock).not.toBeInTheDocument();
+    expect(neutralBlock).not.toBeInTheDocument();
   });
 });

--- a/app/experimenter/nimbus-ui/src/components/TableMetricSecondary/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/TableMetricSecondary/index.tsx
@@ -3,9 +3,88 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React from "react";
+import {
+  DISPLAY_TYPE,
+  SECONDARY_METRIC_COLUMNS,
+  TABLE_LABEL,
+} from "../../lib/visualization/constants";
+import { AnalysisData } from "../../lib/visualization/types";
+import { getExperiment_experimentBySlug_secondaryProbeSets } from "../../types/getExperiment";
+import TableVisualizationRow from "../TableVisualizationRow";
 
-const TableMetricSecondary: React.FunctionComponent = () => {
-  return <div data-testid="table-metric-secondary">secondary metric table</div>;
+type SecondaryMetricStatistic = {
+  name: string;
+  displayType: DISPLAY_TYPE;
+  branchComparison?: string;
+  value?: string;
+};
+
+type TableMetricSecondaryProps = {
+  results: AnalysisData["overall"];
+  probeSet: getExperiment_experimentBySlug_secondaryProbeSets;
+};
+
+const getStatistics = (slug: string): Array<SecondaryMetricStatistic> => {
+  // Make a copy of `SECONDARY_METRIC_COLUMNS` since we modify it.
+  const secondaryMetricStatisticsList = SECONDARY_METRIC_COLUMNS.map(
+    (statistic: SecondaryMetricStatistic) => {
+      statistic["value"] = slug;
+      return statistic;
+    },
+  );
+
+  return secondaryMetricStatisticsList;
+};
+
+const TableMetricSecondary = ({
+  results = {},
+  probeSet,
+}: TableMetricSecondaryProps) => {
+  const secondaryMetricStatistics = getStatistics(probeSet.slug);
+  const metricKey = `${probeSet.slug}_ever_used`;
+
+  return (
+    <div data-testid="table-metric-secondary">
+      <h2 className="h5 mb-3">{probeSet?.name}</h2>
+      <table className="table-visualization-center">
+        <thead>
+          <tr>
+            <th scope="col" className="border-bottom-0 bg-light" />
+            {SECONDARY_METRIC_COLUMNS.map((value) => (
+              <th
+                key={value.name}
+                className="border-bottom-0 bg-light"
+                scope="col"
+              >
+                <div>{value.name}</div>
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {Object.keys(results).map((branch) => {
+            return (
+              <tr key={branch}>
+                <th className="align-middle" scope="row">
+                  {branch}
+                </th>
+                {secondaryMetricStatistics.map(
+                  ({ displayType, branchComparison, value }) => (
+                    <TableVisualizationRow
+                      key={`${displayType}-${value}`}
+                      results={results[branch]}
+                      tableLabel={TABLE_LABEL.SECONDARY_METRICS}
+                      {...{ metricKey, displayType, branchComparison }}
+                    />
+                  ),
+                )}
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
 };
 
 export default TableMetricSecondary;

--- a/app/experimenter/nimbus-ui/src/components/TableOverview/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/TableOverview/index.tsx
@@ -22,52 +22,52 @@ const TableOverview = ({ experiment }: TableOverviewProps) => {
   const { firefoxMinVersion, channels, targetingConfigSlug } = useConfig();
 
   return (
-    <div className="mb-5" data-testid="table-overview">
-      <table className="table text-left m-0">
-        <tbody>
-          <tr>
-            <td scope="col">
-              <h3 className="h6">Targeting</h3>
-              <div>
-                {displayConfigLabel(
-                  experiment.firefoxMinVersion,
-                  firefoxMinVersion,
-                )}
-                +
-              </div>
-              <div>
-                {experiment.channels?.length
-                  ? experiment.channels
-                      .map((expChannel) =>
-                        displayConfigLabel(expChannel, channels),
-                      )
-                      .join(", ")
-                  : ""}
-              </div>
-              <div>
-                {displayConfigLabel(
-                  experiment.targetingConfigSlug,
-                  targetingConfigSlug,
-                )}
-              </div>
-            </td>
-            <td scope="col">
-              <h3 className="h6">Probe Sets</h3>
-              {experiment.primaryProbeSets?.length
-                ? experiment.primaryProbeSets.map((probeSet) => (
-                    <div key={probeSet?.name}>{probeSet?.name}</div>
-                  ))
+    <table
+      className="table text-left mb-5 border-bottom"
+      data-testid="table-overview"
+    >
+      <tbody>
+        <tr>
+          <td>
+            <h3 className="h6">Targeting</h3>
+            <div>
+              {displayConfigLabel(
+                experiment.firefoxMinVersion,
+                firefoxMinVersion,
+              )}
+              +
+            </div>
+            <div>
+              {experiment.channels?.length
+                ? experiment.channels
+                    .map((expChannel) =>
+                      displayConfigLabel(expChannel, channels),
+                    )
+                    .join(", ")
                 : ""}
-            </td>
-            <td scope="col">
-              <h3 className="h6">Owner</h3>
-              <span>{experiment.owner?.email}</span>
-            </td>
-          </tr>
-        </tbody>
-      </table>
-      <hr className="mt-0 mb-5" />
-    </div>
+            </div>
+            <div>
+              {displayConfigLabel(
+                experiment.targetingConfigSlug,
+                targetingConfigSlug,
+              )}
+            </div>
+          </td>
+          <td>
+            <h3 className="h6">Probe Sets</h3>
+            {experiment.primaryProbeSets?.length
+              ? experiment.primaryProbeSets.map((probeSet) => (
+                  <div key={probeSet?.name}>{probeSet?.name}</div>
+                ))
+              : ""}
+          </td>
+          <td>
+            <h3 className="h6">Owner</h3>
+            <span>{experiment.owner?.email}</span>
+          </td>
+        </tr>
+      </tbody>
+    </table>
   );
 };
 

--- a/app/experimenter/nimbus-ui/src/components/TableResults/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/TableResults/index.tsx
@@ -26,7 +26,7 @@ const getResultMetrics = (
   const resultsMetricsList = [...RESULTS_METRICS_LIST];
   probeSets.forEach((probeSet) => {
     resultsMetricsList.unshift({
-      value: `${probeSet!.slug.replace(/-/g, "_")}_ever_used`,
+      value: `${probeSet!.slug}_ever_used`,
       name: `${probeSet!.name} Conversion`,
       tooltip: METRICS_TIPS.CONVERSION,
       type: METRIC_TYPE.PRIMARY,
@@ -43,17 +43,17 @@ const TableResults = ({
   const resultsMetricsList = getResultMetrics(primaryProbeSets);
 
   return (
-    <table className="table text-center mb-5" data-testid="table-results">
+    <table className="table-visualization-center" data-testid="table-results">
       <thead>
         <tr>
-          <th scope="col" className="border-bottom-0" />
+          <th scope="col" className="border-bottom-0 bg-light" />
           {resultsMetricsList.map((metric, index) => {
             const badgeClass = `badge ${metric.type?.badge}`;
             return (
               <th
-                key={index}
+                key={`${metric.type}-${index}`}
                 scope="col"
-                className="border-bottom-0 align-middle"
+                className="border-bottom-0 align-middle bg-light"
               >
                 <h3 className="h6 mb-0" data-tip={metric.tooltip}>
                   {metric.name}
@@ -84,7 +84,7 @@ const TableResults = ({
                 );
                 return (
                   <TableVisualizationRow
-                    key={metricKey}
+                    key={`${displayType}-${metricKey}`}
                     results={results[branch]}
                     tableLabel={TABLE_LABEL.RESULTS}
                     {...{ metricKey }}

--- a/app/experimenter/nimbus-ui/src/components/TableSummary/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/TableSummary/index.test.tsx
@@ -55,9 +55,7 @@ describe("TableSummary", () => {
       );
       expect(
         screen.getByTestId("experiment-probe-secondary"),
-      ).toHaveTextContent(
-        "Secondary: Public-key intangible Graphical User Interface",
-      );
+      ).toHaveTextContent("Secondary: Feature B");
     });
     it("when neither are set", () => {
       const { data } = mockExperimentQuery("demo-slug", {

--- a/app/experimenter/nimbus-ui/src/components/TableVisualizationRow/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/TableVisualizationRow/index.stories.tsx
@@ -4,9 +4,7 @@
 
 import React from "react";
 import { storiesOf } from "@storybook/react";
-import { RouterSlugProvider } from "../../lib/test-utils";
 import { withLinks } from "@storybook/addon-links";
-import { mockExperimentQuery } from "../../lib/mocks";
 import TableVisualizationRow from ".";
 import { mockAnalysis } from "../../lib/visualization/mocks";
 import {
@@ -15,100 +13,67 @@ import {
   TABLE_LABEL,
 } from "../../lib/visualization/constants";
 
-const { mock } = mockExperimentQuery("demo-slug");
+const MOCK_ANALYSIS = mockAnalysis();
 
 storiesOf("visualization/TableVisualizationRow", module)
   .addDecorator(withLinks)
   .add("Population field", () => (
-    <RouterSlugProvider mocks={[mock]}>
-      <TableVisualizationRow
-        key="retained"
-        results={mockAnalysis().overall.control}
-        tableLabel={TABLE_LABEL.HIGHLIGHTS}
-        metricKey="retained"
-        displayType={DISPLAY_TYPE.POPULATION}
-      />
-    </RouterSlugProvider>
+    <TableVisualizationRow
+      results={MOCK_ANALYSIS.overall.control}
+      tableLabel={TABLE_LABEL.HIGHLIGHTS}
+      metricKey="retained"
+      displayType={DISPLAY_TYPE.POPULATION}
+    />
   ))
   .add("Count field", () => (
-    <RouterSlugProvider mocks={[mock]}>
-      <TableVisualizationRow
-        key="retained"
-        results={mockAnalysis().overall.control}
-        tableLabel={TABLE_LABEL.HIGHLIGHTS}
-        metricKey="retained"
-        displayType={DISPLAY_TYPE.COUNT}
-      />
-    </RouterSlugProvider>
+    <TableVisualizationRow
+      results={MOCK_ANALYSIS.overall.control}
+      tableLabel={TABLE_LABEL.HIGHLIGHTS}
+      metricKey="retained"
+      displayType={DISPLAY_TYPE.COUNT}
+    />
   ))
   .add("Percent field", () => (
-    <RouterSlugProvider mocks={[mock]}>
-      <TableVisualizationRow
-        key="retained"
-        results={mockAnalysis().overall.control}
-        tableLabel={TABLE_LABEL.RESULTS}
-        metricKey="retained"
-        displayType={DISPLAY_TYPE.PERCENT}
-      />
-    </RouterSlugProvider>
+    <TableVisualizationRow
+      results={MOCK_ANALYSIS.overall.control}
+      tableLabel={TABLE_LABEL.RESULTS}
+      metricKey="retained"
+      displayType={DISPLAY_TYPE.PERCENT}
+    />
   ))
-  .add("Conversion count field", () => {
-    const MOCK_ANALYSIS = mockAnalysis();
-    return (
-      <RouterSlugProvider mocks={[mock]}>
-        <TableVisualizationRow
-          key={DISPLAY_TYPE.CONVERSION_COUNT}
-          branchComparison={BRANCH_COMPARISON.ABSOLUTE}
-          displayType={DISPLAY_TYPE.CONVERSION_COUNT}
-          results={MOCK_ANALYSIS.overall.treatment}
-          tableLabel={TABLE_LABEL.PRIMARY_METRICS}
-          metricKey="picture_in_picture_ever_used"
-        />
-      </RouterSlugProvider>
-    );
-  })
-  .add("Conversion change field (positive)", () => {
-    const MOCK_ANALYSIS = mockAnalysis();
-    return (
-      <RouterSlugProvider mocks={[mock]}>
-        <TableVisualizationRow
-          key={DISPLAY_TYPE.CONVERSION_COUNT}
-          branchComparison={BRANCH_COMPARISON.UPLIFT}
-          displayType={DISPLAY_TYPE.CONVERSION_CHANGE}
-          results={MOCK_ANALYSIS.overall.treatment}
-          tableLabel={TABLE_LABEL.PRIMARY_METRICS}
-          metricKey="picture_in_picture_ever_used"
-        />
-      </RouterSlugProvider>
-    );
-  })
-  .add("Conversion change field (negative)", () => {
-    const MOCK_ANALYSIS = mockAnalysis();
-    return (
-      <RouterSlugProvider mocks={[mock]}>
-        <TableVisualizationRow
-          key={DISPLAY_TYPE.CONVERSION_COUNT}
-          branchComparison={BRANCH_COMPARISON.UPLIFT}
-          displayType={DISPLAY_TYPE.CONVERSION_CHANGE}
-          results={MOCK_ANALYSIS.overall.treatment}
-          tableLabel={TABLE_LABEL.PRIMARY_METRICS}
-          metricKey="feature_b_ever_used"
-        />
-      </RouterSlugProvider>
-    );
-  })
-  .add("Conversion change field (neutral)", () => {
-    const MOCK_ANALYSIS = mockAnalysis();
-    return (
-      <RouterSlugProvider mocks={[mock]}>
-        <TableVisualizationRow
-          key={DISPLAY_TYPE.CONVERSION_COUNT}
-          branchComparison={BRANCH_COMPARISON.UPLIFT}
-          displayType={DISPLAY_TYPE.CONVERSION_CHANGE}
-          results={MOCK_ANALYSIS.overall.treatment}
-          tableLabel={TABLE_LABEL.PRIMARY_METRICS}
-          metricKey="feature_c_ever_used"
-        />
-      </RouterSlugProvider>
-    );
-  });
+  .add("Conversion count field", () => (
+    <TableVisualizationRow
+      branchComparison={BRANCH_COMPARISON.ABSOLUTE}
+      displayType={DISPLAY_TYPE.CONVERSION_COUNT}
+      results={MOCK_ANALYSIS.overall.treatment}
+      tableLabel={TABLE_LABEL.PRIMARY_METRICS}
+      metricKey="picture_in_picture_ever_used"
+    />
+  ))
+  .add("Conversion change field (positive)", () => (
+    <TableVisualizationRow
+      branchComparison={BRANCH_COMPARISON.UPLIFT}
+      displayType={DISPLAY_TYPE.CONVERSION_CHANGE}
+      results={MOCK_ANALYSIS.overall.treatment}
+      tableLabel={TABLE_LABEL.PRIMARY_METRICS}
+      metricKey="picture_in_picture_ever_used"
+    />
+  ))
+  .add("Conversion change field (negative)", () => (
+    <TableVisualizationRow
+      branchComparison={BRANCH_COMPARISON.UPLIFT}
+      displayType={DISPLAY_TYPE.CONVERSION_CHANGE}
+      results={MOCK_ANALYSIS.overall.treatment}
+      tableLabel={TABLE_LABEL.PRIMARY_METRICS}
+      metricKey="feature_b_ever_used"
+    />
+  ))
+  .add("Conversion change field (neutral)", () => (
+    <TableVisualizationRow
+      branchComparison={BRANCH_COMPARISON.UPLIFT}
+      displayType={DISPLAY_TYPE.CONVERSION_CHANGE}
+      results={MOCK_ANALYSIS.overall.treatment}
+      tableLabel={TABLE_LABEL.PRIMARY_METRICS}
+      metricKey="feature_c_ever_used"
+    />
+  ));

--- a/app/experimenter/nimbus-ui/src/components/TableVisualizationRow/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/TableVisualizationRow/index.tsx
@@ -69,15 +69,21 @@ const showSignificanceField = (
     intervalText = `(${interval})`;
   }
 
+  if (tableLabel === TABLE_LABEL.HIGHLIGHTS) {
+    return (
+      <>
+        <p {...{ className }} data-testid={className}>
+          {significanceIcon}&nbsp;{name} {changeText} {intervalText}
+        </p>
+        <ReactTooltip />
+      </>
+    );
+  }
   return (
     <>
-      <p {...{ className }} data-testid={className}>
-        {significanceIcon}
-        &nbsp;
-        {tableLabel === TABLE_LABEL.HIGHLIGHTS
-          ? `${name} ${changeText} ${intervalText}`
-          : `${interval}`}
-      </p>
+      <span {...{ className }} data-testid={className}>
+        {significanceIcon}&nbsp;{interval}
+      </span>
       <ReactTooltip />
     </>
   );

--- a/app/experimenter/nimbus-ui/src/lib/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/lib/mocks.tsx
@@ -283,8 +283,8 @@ export const mockExperimentQuery = (
             secondaryProbeSets: [
               {
                 __typename: "NimbusProbeSetType",
-                slug: "public-key-intangible-graphical-user-interface",
-                name: "Public-key intangible Graphical User Interface",
+                slug: "feature_b",
+                name: "Feature B",
               },
             ],
             channels: ["DESKTOP_NIGHTLY", "DESKTOP_BETA"],

--- a/app/experimenter/nimbus-ui/src/lib/visualization/constants.ts
+++ b/app/experimenter/nimbus-ui/src/lib/visualization/constants.ts
@@ -69,6 +69,19 @@ export const METRIC_TYPE = {
   },
 };
 
+export const BRANCH_COMPARISON = {
+  ABSOLUTE: "absolute",
+  DIFFERENCE: "difference",
+  UPLIFT: "relative_uplift",
+};
+
+export const TABLE_LABEL = {
+  HIGHLIGHTS: "highlights",
+  RESULTS: "results",
+  PRIMARY_METRICS: "primary_metrics",
+  SECONDARY_METRICS: "secondary_metrics",
+};
+
 // This is used as an ordered list of items to
 // display in the highlights table from top to bottom.
 export const HIGHLIGHTS_METRICS_LIST = [
@@ -106,12 +119,6 @@ export const RESULTS_METRICS_LIST = [
   },
 ];
 
-export const BRANCH_COMPARISON = {
-  ABSOLUTE: "absolute",
-  DIFFERENCE: "difference",
-  UPLIFT: "relative_uplift",
-};
-
 // This is used as an ordered list of items to
 // display in the primary metric table from left to right.
 export const PRIMARY_METRIC_COLUMNS = [
@@ -131,8 +138,17 @@ export const PRIMARY_METRIC_COLUMNS = [
   },
 ];
 
-export const TABLE_LABEL = {
-  HIGHLIGHTS: "highlights",
-  RESULTS: "results",
-  PRIMARY_METRICS: "primary_metrics",
-};
+// This is used as an ordered list of items to
+// display in the secondary metric table from left to right.
+export const SECONDARY_METRIC_COLUMNS = [
+  {
+    name: "Count",
+    displayType: DISPLAY_TYPE.COUNT,
+    branchComparison: BRANCH_COMPARISON.ABSOLUTE,
+  },
+  {
+    name: "Relative Improvement",
+    displayType: DISPLAY_TYPE.CONVERSION_CHANGE,
+    branchComparison: BRANCH_COMPARISON.UPLIFT,
+  },
+];

--- a/app/experimenter/nimbus-ui/src/styles/index.scss
+++ b/app/experimenter/nimbus-ui/src/styles/index.scss
@@ -62,6 +62,13 @@ $sizes: (
   @extend .bg-secondary;
 }
 
+.table-visualization-center {
+  @extend .table;
+  @extend .text-center;
+  @extend .mb-5;
+  @extend .border-bottom;
+}
+
 .border-3 {
   border-width: 3px !important;
 }


### PR DESCRIPTION
This commit:
* Copies the secondary metric table from the legacy UI into nimbus UI results page
* Tweaks all visualization tables for consistency in classes
* Adds slightly better typing in related files
* Removes unneeded GQL mocks in some storybook stories

Because:
* We want to see the secondary probe sets table on the Results page and want the tables to appear consistently styled

---

@emtwo I did a little extra here with the styles, feel free to push back on anything. :)