### PR TITLE
fix #3749 fix #3750: audience form with saved data

### DIFF
--- a/app/experimenter/nimbus-ui/package.json
+++ b/app/experimenter/nimbus-ui/package.json
@@ -45,6 +45,7 @@
     "react-dom": "^16.13.1",
     "react-hook-form": "^6.9.2",
     "react-scripts": "3.4.0",
+    "react-select": "^3.1.1",
     "react-tooltip": "^4.2.10",
     "typescript": "4.0.3"
   },

--- a/app/experimenter/nimbus-ui/src/components/FormAudience/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/FormAudience/index.stories.tsx
@@ -1,0 +1,9 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from "react";
+import { storiesOf } from "@storybook/react";
+import { Subject } from "./mocks";
+
+storiesOf("components/FormAudience", module).add("basic", () => <Subject />);

--- a/app/experimenter/nimbus-ui/src/components/FormAudience/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/FormAudience/index.test.tsx
@@ -1,0 +1,35 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from "react";
+import { render } from "@testing-library/react";
+import { Subject, MOCK_EXPERIMENT } from "./mocks";
+import { MOCK_CONFIG } from "../../lib/mocks";
+
+describe("FormAudience", () => {
+  it("renders without error", () => {
+    render(<Subject />);
+  });
+
+  it("renders without error with a partial experiment", () => {
+    render(
+      <Subject
+        config={{
+          ...MOCK_CONFIG,
+          targetingConfigSlug: [
+            { __typename: "NimbusLabelValueType", label: null, value: null },
+          ],
+        }}
+        experiment={{
+          ...MOCK_EXPERIMENT,
+          firefoxMinVersion: null,
+          targetingConfigSlug: null,
+          populationPercent: null,
+          proposedEnrollment: null,
+          proposedDuration: null,
+        }}
+      />,
+    );
+  });
+});

--- a/app/experimenter/nimbus-ui/src/components/FormAudience/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/FormAudience/index.tsx
@@ -1,0 +1,196 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from "react";
+import Select from "react-select";
+import Form from "react-bootstrap/Form";
+import InputGroup from "react-bootstrap/InputGroup";
+import Col from "react-bootstrap/Col";
+import LinkExternal from "../LinkExternal";
+
+import { getExperiment_experimentBySlug } from "../../types/getExperiment";
+import {
+  getConfig_nimbusConfig,
+  getConfig_nimbusConfig_channels,
+} from "../../types/getConfig";
+
+// TODO: find this doco URL
+const AUDIENCE_DOC_URL =
+  "https://mana.mozilla.org/wiki/pages/viewpage.action?spaceKey=FJT&title=Project+Nimbus";
+
+type FormAudienceConfig = Pick<
+  getConfig_nimbusConfig,
+  "channels" | "firefoxMinVersion" | "targetingConfigSlug"
+>;
+
+export const FormAudience = ({
+  experiment,
+  config,
+}: {
+  experiment: getExperiment_experimentBySlug;
+  config: FormAudienceConfig;
+}) => {
+  const {
+    channels,
+    firefoxMinVersion,
+    targetingConfigSlug,
+    populationPercent,
+    totalEnrolledClients,
+    proposedEnrollment,
+    proposedDuration,
+  } = experiment;
+
+  const channelsOptions = config.channels?.filter(
+    (item): item is getConfig_nimbusConfig_channels => item !== null,
+  );
+  const channelsDefaultValue = channels?.map((channel) =>
+    channelsOptions?.find((option) => option?.value === channel),
+  );
+
+  return (
+    <Form data-testid="FormAudience">
+      <Form.Group>
+        <Form.Row>
+          <Form.Group as={Col} controlId="channel" md={8} lg={8}>
+            <Form.Label>Channel</Form.Label>
+            <Select
+              isMulti
+              name="channel"
+              data-testid="channel"
+              defaultValue={channelsDefaultValue}
+              options={channelsOptions}
+            />
+          </Form.Group>
+          <Form.Group as={Col} controlId="minVersion">
+            <Form.Label>Min Version</Form.Label>
+            <Form.Control
+              as="select"
+              data-testid="minVersion"
+              defaultValue={firefoxMinVersion || ""}
+            >
+              <SelectOptions options={config.firefoxMinVersion} />
+            </Form.Control>
+          </Form.Group>
+        </Form.Row>
+        <Form.Row>
+          <Form.Group as={Col} controlId="targeting">
+            <Form.Label>Advanced Targeting</Form.Label>
+            <Form.Control
+              as="select"
+              data-testid="targeting"
+              defaultValue={targetingConfigSlug || ""}
+            >
+              <SelectOptions options={config.targetingConfigSlug} />
+            </Form.Control>
+          </Form.Group>
+        </Form.Row>
+      </Form.Group>
+
+      <Form.Group className="bg-light p-4">
+        <p className="text-secondary">
+          Please ask a data scientist to help you determine these values.{" "}
+          <LinkExternal href={AUDIENCE_DOC_URL}>Learn more</LinkExternal>
+        </p>
+
+        <Form.Row>
+          <Form.Group as={Col} className="mx-5" controlId="clientsPercent">
+            <Form.Label>Percent of clients</Form.Label>
+            <InputGroup>
+              <Form.Control
+                placeholder="0.00"
+                aria-describedby="clientsPercent-unit"
+                type="text"
+                defaultValue={populationPercent || 0}
+              />
+              <InputGroup.Append>
+                <InputGroup.Text id="clientsPercent-unit">%</InputGroup.Text>
+              </InputGroup.Append>
+            </InputGroup>
+          </Form.Group>
+
+          <Form.Group as={Col} className="mx-5" controlId="clientsNumber">
+            <Form.Label>Expected number of clients</Form.Label>
+            <Form.Control
+              name="clientsNumber"
+              placeholder="0"
+              type="text"
+              defaultValue={totalEnrolledClients}
+            />
+          </Form.Group>
+        </Form.Row>
+
+        <Form.Row>
+          <Form.Group as={Col} className="mx-5" controlId="enrollmentPeriod">
+            <Form.Label>Enrollment period</Form.Label>
+            <InputGroup>
+              <Form.Control
+                placeholder="7"
+                aria-describedby="enrollmentPeriod-unit"
+                defaultValue={proposedEnrollment || 7}
+              />
+              <InputGroup.Append>
+                <InputGroup.Text id="enrollmentPeriod-unit">
+                  days
+                </InputGroup.Text>
+              </InputGroup.Append>
+            </InputGroup>
+          </Form.Group>
+
+          <Form.Group as={Col} className="mx-5" controlId="experimentDuration">
+            <Form.Label>Experiment duration</Form.Label>
+            <InputGroup className="mb-3">
+              <Form.Control
+                placeholder="28"
+                aria-describedby="experimentDuration-unit"
+                defaultValue={proposedDuration || 28}
+              />
+              <InputGroup.Append>
+                <InputGroup.Text id="experimentDuration-unit">
+                  days
+                </InputGroup.Text>
+              </InputGroup.Append>
+            </InputGroup>
+          </Form.Group>
+        </Form.Row>
+      </Form.Group>
+
+      <div className="d-flex flex-row-reverse bd-highlight">
+        <div className="p-2">
+          <button data-testid="next-button" className="btn btn-secondary">
+            Next
+          </button>
+        </div>
+        <div className="p-2">
+          <button
+            data-testid="save-button"
+            type="submit"
+            className="btn btn-primary"
+          >
+            <span>Save</span>
+          </button>
+        </div>
+      </div>
+    </Form>
+  );
+};
+
+const SelectOptions = ({
+  options,
+}: {
+  options: null | (null | { label: null | string; value: null | string })[];
+}) => (
+  <>
+    <option value="">Select...</option>
+    {options?.map(
+      (item, idx) =>
+        item && (
+          <option key={idx} value={item.value || ""}>
+            {item.label}
+          </option>
+        ),
+    )}
+  </>
+);
+
+export default FormAudience;

--- a/app/experimenter/nimbus-ui/src/components/FormAudience/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/components/FormAudience/mocks.tsx
@@ -1,0 +1,23 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from "react";
+import { mockExperimentQuery, MOCK_CONFIG } from "../../lib/mocks";
+import { FormAudience } from ".";
+
+export const Subject = ({
+  experiment = MOCK_EXPERIMENT,
+  config = MOCK_CONFIG,
+}: Partial<React.ComponentProps<typeof FormAudience>>) => (
+  <div className="p-5">
+    <FormAudience
+      {...{
+        experiment,
+        config,
+      }}
+    />
+  </div>
+);
+
+export const MOCK_EXPERIMENT = mockExperimentQuery("demo-slug")!.data!;

--- a/app/experimenter/nimbus-ui/src/components/PageEditAudience/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditAudience/index.tsx
@@ -5,11 +5,22 @@
 import React from "react";
 import { RouteComponentProps } from "@reach/router";
 import AppLayoutWithExperiment from "../AppLayoutWithExperiment";
+import { useConfig } from "../../hooks";
+import FormAudience from "../FormAudience";
 
 const PageEditAudience: React.FunctionComponent<RouteComponentProps> = () => {
+  const config = useConfig();
+
   return (
     <AppLayoutWithExperiment title="Audience" testId="PageEditAudience">
-      {({ experiment }) => <p>{experiment.name}</p>}
+      {({ experiment }) => (
+        <FormAudience
+          {...{
+            experiment,
+            config,
+          }}
+        />
+      )}
     </AppLayoutWithExperiment>
   );
 };

--- a/app/experimenter/nimbus-ui/src/lib/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/lib/mocks.tsx
@@ -58,6 +58,11 @@ export const MOCK_CONFIG: getConfig_nimbusConfig = {
       label: "Desktop Nightly",
       value: "DESKTOP_NIGHTLY",
     },
+    {
+      __typename: "NimbusLabelValueType",
+      label: "Platypus Doorstop",
+      value: "PLATYPUS_DOORSTOP",
+    },
   ],
   featureConfig: [
     {

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -16209,6 +16209,20 @@ react-select@3.1.0:
     react-input-autosize "^2.2.2"
     react-transition-group "^4.3.0"
 
+react-select@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/react-select/-/react-select-3.1.1.tgz#156a5b4a6c22b1e3d62a919cb1fd827adb4060bc"
+  integrity sha512-HjC6jT2BhUxbIbxMZWqVcDibrEpdUJCfGicN0MMV+BQyKtCaPTgFekKWiOizSCy4jdsLMGjLqcFGJMhVGWB0Dg==
+  dependencies:
+    "@babel/runtime" "^7.4.4"
+    "@emotion/cache" "^10.0.9"
+    "@emotion/core" "^10.0.9"
+    "@emotion/css" "^10.0.9"
+    memoize-one "^5.0.0"
+    prop-types "^15.6.0"
+    react-input-autosize "^2.2.2"
+    react-transition-group "^4.3.0"
+
 react-sizeme@^2.6.7:
   version "2.6.12"
   resolved "https://registry.yarnpkg.com/react-sizeme/-/react-sizeme-2.6.12.tgz#ed207be5476f4a85bf364e92042520499455453e"


### PR DESCRIPTION
Because:

- we want to manage audience attributes for an experiment

This commit:

- adds react-select as a dependency

- introduces FormAudience component to manage audience attributes

- displays saved audience data and uses configuration for valid choices
