### PR TITLE
fixes #4013 #4008 feat(nimbus): add start/date dates, progress bar to experiment summary

### DIFF
--- a/app/experimenter/nimbus-ui/package.json
+++ b/app/experimenter/nimbus-ui/package.json
@@ -78,6 +78,7 @@
     "eslint-plugin-react-hooks": "4.x",
     "fetch-mock": "^9.10.7",
     "jest-fetch-mock": "^3.0.3",
+    "mockdate": "^3.0.2",
     "mutationobserver-shim": "^0.3.7",
     "node-sass": "^4.14.1",
     "prettier": "^2.1.2",

--- a/app/experimenter/nimbus-ui/src/components/AppLayout/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/AppLayout/index.tsx
@@ -4,8 +4,6 @@
 
 import React from "react";
 import Container from "react-bootstrap/Container";
-import Row from "react-bootstrap/Row";
-import Col from "react-bootstrap/Col";
 
 type AppLayoutProps = {
   testid?: string;
@@ -15,9 +13,7 @@ type AppLayoutProps = {
 export const AppLayout = ({ children, testid = "main" }: AppLayoutProps) => {
   return (
     <Container fluid as="main" className="h-100 pt-5" data-testid={testid}>
-      <Row className="h-100">
-        <Col className="ml-auto mr-auto col-md-10 col-lg-8">{children}</Col>
-      </Row>
+      <div className="h-100 container-lg mx-auto">{children}</div>
     </Container>
   );
 };

--- a/app/experimenter/nimbus-ui/src/components/AppLayoutWithExperiment/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/AppLayoutWithExperiment/index.test.tsx
@@ -26,6 +26,15 @@ describe("AppLayoutWithExperiment", () => {
     });
   });
 
+  it("can render without a title", async () => {
+    const { mock } = mockExperimentQuery("demo-slug");
+    render(<Subject mocks={[mock]} withTitle={false} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("AppLayoutWithExperiment")).toBeInTheDocument();
+      expect(screen.queryByTestId("page-title")).not.toBeInTheDocument();
+    });
+  });
+
   it("does not render the sidebar if prop is set to false", async () => {
     const { mock } = mockExperimentQuery("demo-slug");
     render(<Subject mocks={[mock]} sidebar={false} />);
@@ -117,14 +126,16 @@ const Subject = ({
   mocks = [],
   polling = false,
   sidebar = true,
+  withTitle = true,
 }: {
   mocks?: React.ComponentProps<typeof RouterSlugProvider>["mocks"];
   polling?: boolean;
   sidebar?: boolean;
+  withTitle?: boolean;
 }) => (
   <RouterSlugProvider {...{ mocks }}>
     <AppLayoutWithExperiment
-      title="Howdy!"
+      title={withTitle ? "Howdy!" : undefined}
       testId="AppLayoutWithExperiment"
       {...{ polling, sidebar }}
     >

--- a/app/experimenter/nimbus-ui/src/components/AppLayoutWithExperiment/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/AppLayoutWithExperiment/index.tsx
@@ -26,7 +26,7 @@ type AppLayoutWithExperimentProps = {
     props: AppLayoutWithExperimentChildrenProps,
   ) => React.ReactNode | null;
   testId: string;
-  title: string;
+  title?: string;
   polling?: boolean;
   sidebar?: boolean;
 } & RouteComponentProps;
@@ -79,10 +79,12 @@ const AppLayoutWithExperiment = ({
             status,
           }}
         />
-        <h2 className="mt-3 mb-4 h4" data-testid="page-title">
-          {title}
-        </h2>
-        {children({ experiment, review })}
+        {title && (
+          <h2 className="mt-3 mb-4 h4" data-testid="page-title">
+            {title}
+          </h2>
+        )}
+        <div className="mt-4">{children({ experiment, review })}</div>
       </section>
     </Layout>
   );

--- a/app/experimenter/nimbus-ui/src/components/PageSummary/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageSummary/index.test.tsx
@@ -24,6 +24,7 @@ describe("PageSummary", () => {
     // uses correct AppLayout
     expect(screen.queryByTestId("nav-sidebar")).not.toBeInTheDocument();
     expect(screen.queryByTestId("header-experiment")).toBeInTheDocument();
+    expect(screen.queryByTestId("summary-timeline")).toBeInTheDocument();
     expect(screen.queryByTestId("table-summary")).toBeInTheDocument();
   });
 });

--- a/app/experimenter/nimbus-ui/src/components/PageSummary/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageSummary/index.tsx
@@ -6,6 +6,7 @@ import React from "react";
 import { RouteComponentProps } from "@reach/router";
 import AppLayoutWithExperiment from "../AppLayoutWithExperiment";
 import TableSummary from "../TableSummary";
+import SummaryTimeline from "../SummaryTimeline";
 
 type PageRequestReviewProps = {
   polling?: boolean;
@@ -15,12 +16,19 @@ const PageSummary: React.FunctionComponent<PageRequestReviewProps> = ({
   polling = true,
 }) => (
   <AppLayoutWithExperiment
-    title="Experiment Summary"
     testId="PageSummary"
     sidebar={false}
     {...{ polling }}
   >
-    {({ experiment }) => <TableSummary {...{ experiment }} />}
+    {({ experiment }) => (
+      <>
+        <h2 className="h5 mb-3">Timeline</h2>
+        <SummaryTimeline {...{ experiment }} />
+
+        <h2 className="h5 mb-3">Summary</h2>
+        <TableSummary {...{ experiment }} />
+      </>
+    )}
   </AppLayoutWithExperiment>
 );
 

--- a/app/experimenter/nimbus-ui/src/components/SummaryTimeline/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/SummaryTimeline/index.stories.tsx
@@ -1,0 +1,23 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from "react";
+import { storiesOf } from "@storybook/react";
+import MockDate from "mockdate";
+import { NimbusExperimentStatus } from "../../types/globalTypes";
+import { Subject } from "./mocks";
+
+storiesOf("components/SummaryTimeline", module)
+  .addDecorator((getStory) => (
+    <div className="container-lg py-5">{getStory()}</div>
+  ))
+  .add("draft, review, accepted", () => <Subject />)
+  .add("live", () => {
+    MockDate.set("2020-12-06T14:52:44.704811+00:00");
+    return <Subject status={NimbusExperimentStatus.LIVE} />;
+  })
+  .add("complete", () => <Subject status={NimbusExperimentStatus.COMPLETE} />)
+  .add("missing details", () => (
+    <Subject proposedDuration={null} proposedEnrollment={null} />
+  ));

--- a/app/experimenter/nimbus-ui/src/components/SummaryTimeline/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/SummaryTimeline/index.test.tsx
@@ -1,0 +1,68 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from "react";
+import { screen, render, cleanup } from "@testing-library/react";
+import { Subject } from "./mocks";
+import { NimbusExperimentStatus } from "../../types/globalTypes";
+
+const innerBar = () => {
+  return screen
+    .getByTestId("timeline-progress-bar")
+    .querySelector(".progress-bar")!;
+};
+
+describe("SummaryTimeline", () => {
+  it("renders with a draft, in-review, and accepted experiment", () => {
+    [
+      NimbusExperimentStatus.DRAFT,
+      NimbusExperimentStatus.REVIEW,
+      NimbusExperimentStatus.ACCEPTED,
+    ].forEach((status) => {
+      render(<Subject {...{ status }} />);
+
+      expect(screen.queryByTestId("label-not-launched")).toBeInTheDocument();
+      expect(screen.queryByTestId("label-start-date")).not.toBeInTheDocument();
+      expect(screen.queryByTestId("label-end-date")).not.toBeInTheDocument();
+      expect(screen.queryByTestId("label-duration-days")).toBeInTheDocument();
+      expect(screen.queryByTestId("label-enrollment-days")).toBeInTheDocument();
+
+      cleanup();
+    });
+  });
+
+  it("renders with a live experiment", () => {
+    render(<Subject status={NimbusExperimentStatus.LIVE} />);
+
+    expect(innerBar().classList).toContain("progress-bar-animated");
+    expect(innerBar().classList).toContain("progress-bar-striped");
+
+    expect(screen.queryByTestId("label-not-launched")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("label-start-date")).toBeInTheDocument();
+    expect(screen.queryByTestId("label-end-date")).toBeInTheDocument();
+    expect(screen.queryByTestId("label-duration-days")).toBeInTheDocument();
+    expect(screen.queryByTestId("label-enrollment-days")).toBeInTheDocument();
+  });
+
+  it("renders with a completed experiment", () => {
+    render(<Subject status={NimbusExperimentStatus.COMPLETE} />);
+
+    expect(innerBar().classList).toContain("bg-success");
+
+    expect(screen.queryByTestId("label-not-launched")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("label-start-date")).toBeInTheDocument();
+    expect(screen.queryByTestId("label-end-date")).toBeInTheDocument();
+    expect(screen.queryByTestId("label-duration-days")).toBeInTheDocument();
+    expect(screen.queryByTestId("label-enrollment-days")).toBeInTheDocument();
+  });
+
+  it("renders with missing details", () => {
+    render(<Subject proposedDuration={null} proposedEnrollment={null} />);
+
+    expect(screen.queryByTestId("label-duration-not-set")).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("label-enrollment-not-set"),
+    ).toBeInTheDocument();
+  });
+});

--- a/app/experimenter/nimbus-ui/src/components/SummaryTimeline/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/SummaryTimeline/index.tsx
@@ -1,0 +1,150 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from "react";
+import ProgressBar from "react-bootstrap/ProgressBar";
+import { NimbusExperimentStatus } from "../../types/globalTypes";
+import pluralize from "../../lib/pluralize";
+import { getExperiment_experimentBySlug } from "../../types/getExperiment";
+
+const humanDate = (date: string): string => {
+  return new Date(date).toLocaleString("en-US", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+};
+
+const experimentStatus = (status: NimbusExperimentStatus) => {
+  return {
+    draft: status === NimbusExperimentStatus.DRAFT,
+    review: status === NimbusExperimentStatus.REVIEW,
+    accepted: status === NimbusExperimentStatus.ACCEPTED,
+    live: status === NimbusExperimentStatus.LIVE,
+    complete: status === NimbusExperimentStatus.COMPLETE,
+  };
+};
+
+const SummaryTimeline = ({
+  experiment,
+}: {
+  experiment: getExperiment_experimentBySlug;
+}) => {
+  const status = experimentStatus(experiment.status!);
+
+  return (
+    <div className="mb-4" data-testid="summary-timeline">
+      <StartEnd
+        {...{
+          status,
+          startDate: experiment.startDate,
+          endDate: experiment.endDate,
+        }}
+      />
+
+      <Progress
+        {...{
+          status,
+          startDate: experiment.startDate,
+          endDate: experiment.endDate,
+        }}
+      />
+
+      <Duration
+        {...{
+          duration: experiment.proposedDuration,
+          enrollment: experiment.proposedEnrollment,
+        }}
+      />
+    </div>
+  );
+};
+
+const StartEnd = ({
+  status,
+  startDate,
+  endDate,
+}: {
+  status: ReturnType<typeof experimentStatus>;
+  startDate: string | null;
+  endDate: string | null;
+}) => (
+  <div className="d-flex">
+    {status.draft || status.review || status.accepted ? (
+      <span className="flex-fill" data-testid="label-not-launched">
+        Not yet launched
+      </span>
+    ) : (
+      <>
+        <span className="flex-fill" data-testid="label-start-date">
+          {humanDate(startDate!)}
+        </span>
+        <span className="flex-fill text-right" data-testid="label-end-date">
+          {humanDate(endDate!)}
+        </span>
+      </>
+    )}
+  </div>
+);
+
+const Progress = ({
+  status,
+  startDate,
+  endDate,
+}: {
+  status: ReturnType<typeof experimentStatus>;
+  startDate: string | null;
+  endDate: string | null;
+}) => {
+  const props: React.ComponentProps<typeof ProgressBar> = {
+    style: { height: 5 },
+    className: "my-2",
+  };
+
+  if (status.complete) {
+    Object.assign(props, {
+      variant: "success",
+      now: 100,
+    });
+  } else if (status.accepted || status.live) {
+    Object.assign(props, {
+      striped: true,
+      animated: true,
+      min: Date.parse(startDate!),
+      max: Date.parse(endDate!),
+      now: Math.min(Date.now(), Date.parse(endDate!)),
+    });
+  }
+
+  return <ProgressBar {...props} data-testid="timeline-progress-bar" />;
+};
+
+const Duration = ({
+  duration,
+  enrollment,
+}: {
+  duration: number | null;
+  enrollment: number | null;
+}) => (
+  <span>
+    Total duration:{" "}
+    {duration ? (
+      <b data-testid="label-duration-days">{pluralize(duration, "day")}</b>
+    ) : (
+      <span className="text-danger" data-testid="label-duration-not-set">
+        Not set
+      </span>
+    )}{" "}
+    / Enrollment:{" "}
+    {enrollment ? (
+      <b data-testid="label-enrollment-days">{pluralize(enrollment, "day")}</b>
+    ) : (
+      <span className="text-danger" data-testid="label-enrollment-not-set">
+        Not set
+      </span>
+    )}
+  </span>
+);
+
+export default SummaryTimeline;

--- a/app/experimenter/nimbus-ui/src/components/SummaryTimeline/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/components/SummaryTimeline/mocks.tsx
@@ -1,0 +1,31 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from "react";
+import SummaryTimeline from ".";
+import { mockExperimentQuery } from "../../lib/mocks";
+import { NimbusExperimentStatus } from "../../types/globalTypes";
+
+export const Subject = ({
+  startDate = "2020-11-28T14:52:44.704811+00:00",
+  endDate = "2020-12-08T14:52:44.704811+00:00",
+  proposedDuration = 10,
+  proposedEnrollment = 1,
+  status = NimbusExperimentStatus.DRAFT,
+}: {
+  startDate?: string;
+  endDate?: string;
+  proposedDuration?: number | null;
+  proposedEnrollment?: number | null;
+  status?: NimbusExperimentStatus;
+}) => {
+  const { data: experiment } = mockExperimentQuery("something-vague", {
+    startDate,
+    endDate,
+    proposedDuration,
+    proposedEnrollment,
+    status,
+  });
+  return <SummaryTimeline experiment={experiment!} />;
+};

--- a/app/experimenter/nimbus-ui/src/gql/experiments.ts
+++ b/app/experimenter/nimbus-ui/src/gql/experiments.ts
@@ -140,6 +140,9 @@ export const GET_EXPERIMENT_QUERY = gql`
         ready
         message
       }
+
+      startDate
+      endDate
     }
   }
 `;

--- a/app/experimenter/nimbus-ui/src/lib/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/lib/mocks.tsx
@@ -299,6 +299,8 @@ export const mockExperimentQuery = (
               message: {},
               __typename: "NimbusReadyForReviewType",
             },
+            startDate: new Date().toISOString(),
+            endDate: new Date(Date.now() + 12096e5).toISOString(),
           },
           modifications,
         );

--- a/app/experimenter/nimbus-ui/src/lib/pluralize.test.ts
+++ b/app/experimenter/nimbus-ui/src/lib/pluralize.test.ts
@@ -1,0 +1,24 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import pluralize from "./pluralize";
+
+describe("pluralize", () => {
+  it("correctly return 0-count item", () => {
+    expect(pluralize(0, "day")).toEqual("0 days");
+  });
+
+  it("correctly returns 1-count item", () => {
+    expect(pluralize(1, "lamp")).toEqual("1 lamp");
+  });
+
+  it("correctly returns 2-count item", () => {
+    expect(pluralize(2, "car")).toEqual("2 cars");
+  });
+
+  it("correctly returns item with alternative pluralization", () => {
+    expect(pluralize(1, "factory", "factories")).toEqual("1 factory");
+    expect(pluralize(10, "factory", "factories")).toEqual("10 factories");
+  });
+});

--- a/app/experimenter/nimbus-ui/src/lib/pluralize.ts
+++ b/app/experimenter/nimbus-ui/src/lib/pluralize.ts
@@ -1,0 +1,12 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+export default function pluralize(
+  count: number,
+  singular: string,
+  plural?: string,
+) {
+  const pluralVal = plural ?? `${singular}s`;
+  return `${count} ${count === 1 ? singular : pluralVal}`;
+}

--- a/app/experimenter/nimbus-ui/src/types/getExperiment.ts
+++ b/app/experimenter/nimbus-ui/src/types/getExperiment.ts
@@ -86,6 +86,8 @@ export interface getExperiment_experimentBySlug {
   proposedEnrollment: number | null;
   proposedDuration: number | null;
   readyForReview: getExperiment_experimentBySlug_readyForReview | null;
+  startDate: any | null;
+  endDate: any | null;
 }
 
 export interface getExperiment {

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -13543,6 +13543,11 @@ mkdirp@1.0.4, mkdirp@1.x, mkdirp@^1.0.3, mkdirp@^1.0.4:
   dependencies:
     minimist "^1.2.5"
 
+mockdate@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/mockdate/-/mockdate-3.0.2.tgz#a5a7bb5820da617747af424d7a4dcb22c6c03d79"
+  integrity sha512-ldfYSUW1ocqSHGTK6rrODUiqAFPGAg0xaHqYJ5tvj1hQyFsjuHpuWgWFTZWwDVlzougN/s2/mhDr8r5nY5xDpA==
+
 moment@2.29.1, moment@^2.22.1:
   version "2.29.1"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.1.tgz#b2be769fa31940be9eeea6469c075e35006fa3d3"


### PR DESCRIPTION
Closes #4013
Closes #4008

This PR:

- Updates the `AppLayout` container to be less column-y and set a max-width that is consistent with the Edit pages
- Adds a helper to `pluralize` strings
- Makes the `title` in `AppLayoutWithExperiment` optional since the Summary page does not use it
- Adds start and ends dates, duration and enrollment, and progress bar to Summary page

Storybook: `SummaryTimeline`'s [`draft, review, accepted`](https://storage.googleapis.com/mozilla-storybooks-experimenter/commits/cc9b1b4f4cdd7e88b2bf8c33ed8508818b7fc6c0/nimbus-ui/index.html?path=/story/components-summarytimeline--draft-review-accepted), [`live`](https://storage.googleapis.com/mozilla-storybooks-experimenter/commits/cc9b1b4f4cdd7e88b2bf8c33ed8508818b7fc6c0/nimbus-ui/index.html?path=/story/components-summarytimeline--live), [`complete`](https://storage.googleapis.com/mozilla-storybooks-experimenter/commits/cc9b1b4f4cdd7e88b2bf8c33ed8508818b7fc6c0/nimbus-ui/index.html?path=/story/components-summarytimeline--complete), and [`missing details`](https://storage.googleapis.com/mozilla-storybooks-experimenter/commits/cc9b1b4f4cdd7e88b2bf8c33ed8508818b7fc6c0/nimbus-ui/index.html?path=/story/components-summarytimeline--missing-details).

---

We have a handful of spots where we do stuff based on experiment status. I think a nice followup would be to create a helper for that so we're not manually setting up these checks in each component they're needed. Maybe also one for manipulating experiment start/end dates too.