### PR TITLE
fix(nimbus): allow apollo codegen to pass through custom scalars

### DIFF
--- a/app/experimenter/nimbus-ui/package.json
+++ b/app/experimenter/nimbus-ui/package.json
@@ -15,7 +15,7 @@
     "storybook": "start-storybook -p 3001 --no-version-updates",
     "build-storybook": "build-storybook",
     "eject": "react-scripts eject",
-    "generate-types": "apollo codegen:generate --target typescript --outputFlat src/types"
+    "generate-types": "apollo codegen:generate --target typescript --outputFlat src/types --passthroughCustomScalars"
   },
   "jest": {
     "collectCoverageFrom": [

--- a/app/experimenter/nimbus-ui/src/components/FormBranches/reducer/actions.ts
+++ b/app/experimenter/nimbus-ui/src/components/FormBranches/reducer/actions.ts
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { updateExperimentBranches_updateExperimentBranches } from "../../../types/updateExperimentBranches";
 import {
   AnnotatedBranch,
   FormBranchesState,
@@ -195,7 +194,7 @@ function setEqualRatio(
 
 type SetSubmitErrorsAction = {
   type: "setSubmitErrors";
-  submitErrors: updateExperimentBranches_updateExperimentBranches["message"];
+  submitErrors: Record<string, any> | null;
 };
 
 function setSubmitErrors(
@@ -205,6 +204,10 @@ function setSubmitErrors(
   let { referenceBranch, treatmentBranches } = state;
   const { submitErrors } = action;
   const globalErrors = [];
+
+  if (!submitErrors) {
+    return state;
+  }
 
   for (const name of ["*", "feature_config"]) {
     if (Array.isArray(submitErrors[name])) {

--- a/app/experimenter/nimbus-ui/src/components/FormBranches/reducer/index.test.ts
+++ b/app/experimenter/nimbus-ui/src/components/FormBranches/reducer/index.test.ts
@@ -232,6 +232,20 @@ describe("formBranchesReducer", () => {
         ],
       });
     });
+
+    it("returns the same state if no submitErrors", () => {
+      const oldState = {
+        ...MOCK_STATE,
+        globalErrors: [],
+        referenceBranch: null,
+        treatmentBranches: null,
+      };
+      const newState = formBranchesActionReducer(oldState, {
+        type: "setSubmitErrors",
+        submitErrors: null,
+      });
+      expect(newState).toEqual(oldState);
+    });
   });
 
   describe("clearSubmitErrors", () => {

--- a/app/experimenter/nimbus-ui/src/components/PageEditOverview/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditOverview/index.tsx
@@ -46,7 +46,7 @@ const PageEditOverview: React.FunctionComponent<PageEditOverviewProps> = () => {
 
         const { message } = result.data.updateExperimentOverview;
 
-        if (message !== "success" && typeof message === "object") {
+        if (message && message !== "success" && typeof message === "object") {
           setIsServerValid(false);
           return void setSubmitErrors(message);
         } else {

--- a/app/experimenter/nimbus-ui/src/components/PageNew/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageNew/index.tsx
@@ -50,7 +50,7 @@ const PageNew: React.FunctionComponent<PageNewProps> = () => {
         }
         const { message, nimbusExperiment } = result.data.createExperiment;
 
-        if (message !== "success" && typeof message === "object") {
+        if (message && message !== "success" && typeof message === "object") {
           setIsServerValid(false);
           return void setSubmitErrors(message);
         } else {

--- a/app/experimenter/nimbus-ui/src/components/PageRequestReview/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageRequestReview/index.tsx
@@ -50,7 +50,7 @@ const PageRequestReview: React.FunctionComponent<PageRequestReviewProps> = ({
 
       const { message } = result.data.updateExperimentStatus;
 
-      if (message !== "success" && typeof message === "object") {
+      if (message && message !== "success" && typeof message === "object") {
         return void setSubmitError(message.status.join(", "));
       }
 

--- a/app/experimenter/nimbus-ui/src/react-app-env.d.ts
+++ b/app/experimenter/nimbus-ui/src/react-app-env.d.ts
@@ -3,3 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 /// <reference types="react-scripts" />
+
+type DateTime = string;
+type ObjectField = Record<string, any> | string;

--- a/app/experimenter/nimbus-ui/src/types/createExperiment.ts
+++ b/app/experimenter/nimbus-ui/src/types/createExperiment.ts
@@ -20,7 +20,7 @@ export interface createExperiment_createExperiment_nimbusExperiment {
 export interface createExperiment_createExperiment {
   __typename: "CreateExperiment";
   clientMutationId: string | null;
-  message: any | null;
+  message: ObjectField | null;
   status: number | null;
   nimbusExperiment: createExperiment_createExperiment_nimbusExperiment | null;
 }

--- a/app/experimenter/nimbus-ui/src/types/getExperiment.ts
+++ b/app/experimenter/nimbus-ui/src/types/getExperiment.ts
@@ -60,7 +60,7 @@ export interface getExperiment_experimentBySlug_secondaryProbeSets {
 export interface getExperiment_experimentBySlug_readyForReview {
   __typename: "NimbusReadyForReviewType";
   ready: boolean | null;
-  message: any | null;
+  message: ObjectField | null;
 }
 
 export interface getExperiment_experimentBySlug {
@@ -86,8 +86,8 @@ export interface getExperiment_experimentBySlug {
   proposedEnrollment: number | null;
   proposedDuration: number | null;
   readyForReview: getExperiment_experimentBySlug_readyForReview | null;
-  startDate: any | null;
-  endDate: any | null;
+  startDate: DateTime | null;
+  endDate: DateTime | null;
 }
 
 export interface getExperiment {

--- a/app/experimenter/nimbus-ui/src/types/updateExperimentBranches.ts
+++ b/app/experimenter/nimbus-ui/src/types/updateExperimentBranches.ts
@@ -39,7 +39,7 @@ export interface updateExperimentBranches_updateExperimentBranches_nimbusExperim
 export interface updateExperimentBranches_updateExperimentBranches {
   __typename: "UpdateExperimentBranches";
   clientMutationId: string | null;
-  message: any | null;
+  message: ObjectField | null;
   status: number | null;
   nimbusExperiment: updateExperimentBranches_updateExperimentBranches_nimbusExperiment | null;
 }

--- a/app/experimenter/nimbus-ui/src/types/updateExperimentOverview.ts
+++ b/app/experimenter/nimbus-ui/src/types/updateExperimentOverview.ts
@@ -19,7 +19,7 @@ export interface updateExperimentOverview_updateExperimentOverview_nimbusExperim
 export interface updateExperimentOverview_updateExperimentOverview {
   __typename: "UpdateExperimentOverview";
   clientMutationId: string | null;
-  message: any | null;
+  message: ObjectField | null;
   status: number | null;
   nimbusExperiment: updateExperimentOverview_updateExperimentOverview_nimbusExperiment | null;
 }

--- a/app/experimenter/nimbus-ui/src/types/updateExperimentStatus.ts
+++ b/app/experimenter/nimbus-ui/src/types/updateExperimentStatus.ts
@@ -17,7 +17,7 @@ export interface updateExperimentStatus_updateExperimentStatus_nimbusExperiment 
 export interface updateExperimentStatus_updateExperimentStatus {
   __typename: "UpdateExperimentStatus";
   clientMutationId: string | null;
-  message: any | null;
+  message: ObjectField | null;
   status: number | null;
   nimbusExperiment: updateExperimentStatus_updateExperimentStatus_nimbusExperiment | null;
 }


### PR DESCRIPTION
Our GraphQL schema has a few types that don't directly translate to TypeScript, and as a result they end up as type `any`, which isn't the end of the world but also isn't great.

With this change we're now allowing these scalar types to pass through and bridging them with our own declarations.