### PR TITLE
fixes #4083 fix(legacy): Ensure prefs from multipref are in changelog

### DIFF
--- a/app/experimenter/experiments/api/v1/serializers.py
+++ b/app/experimenter/experiments/api/v1/serializers.py
@@ -8,6 +8,7 @@ from experimenter.experiments.models import (
     ExperimentChangeLog,
     ExperimentVariant,
     VariantPreferences,
+    RolloutPreference,
 )
 from experimenter.projects.models import Project
 
@@ -33,10 +34,16 @@ class PrefTypeField(serializers.Field):
             return obj
 
 
-class ExperimentPreferenceSerializer(serializers.ModelSerializer):
+class ExperimentVariantPreferenceSerializer(serializers.ModelSerializer):
     class Meta:
         model = VariantPreferences
         fields = ("pref_name", "pref_type", "pref_branch", "pref_value")
+
+
+class ExperimentRolloutPreferenceSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = RolloutPreference
+        fields = ("pref_name", "pref_type", "pref_value")
 
 
 class ProjectSerializer(serializers.ModelSerializer):
@@ -46,7 +53,7 @@ class ProjectSerializer(serializers.ModelSerializer):
 
 
 class ExperimentVariantSerializer(serializers.ModelSerializer):
-    preferences = ExperimentPreferenceSerializer(many=True, required=False)
+    preferences = ExperimentVariantPreferenceSerializer(many=True, required=False)
 
     class Meta:
         model = ExperimentVariant

--- a/app/experimenter/experiments/changelog_utils/legacy.py
+++ b/app/experimenter/experiments/changelog_utils/legacy.py
@@ -2,7 +2,10 @@ from django.contrib.auth import get_user_model
 from rest_framework import serializers
 
 from experimenter.base.serializers import CountrySerializer, LocaleSerializer
-from experimenter.experiments.api.v1.serializers import ExperimentVariantSerializer
+from experimenter.experiments.api.v1.serializers import (
+    ExperimentVariantSerializer,
+    ExperimentRolloutPreferenceSerializer,
+)
 from experimenter.experiments.email import send_experiment_change_email
 from experimenter.experiments.models import Experiment, ExperimentChangeLog
 from experimenter.projects.serializers import ProjectSerializer
@@ -31,6 +34,7 @@ class ChangeLogSerializer(serializers.ModelSerializer):
     locales = LocaleSerializer(many=True, required=False)
     countries = CountrySerializer(many=True, required=False)
     projects = ProjectSerializer(many=True, required=False)
+    preferences = ExperimentRolloutPreferenceSerializer(many=True, required=False)
 
     class Meta:
         model = Experiment
@@ -129,6 +133,7 @@ class ChangeLogSerializer(serializers.ModelSerializer):
             "rollout_playbook",
             "message_type",
             "message_template",
+            "preferences",
         )
 
 

--- a/app/experimenter/experiments/tests/test_changelog_utils/test_changelog_utils_legacy.py
+++ b/app/experimenter/experiments/tests/test_changelog_utils/test_changelog_utils_legacy.py
@@ -149,10 +149,18 @@ class TestChangeLogSerializer(TestCase):
             "rollout_type": experiment.rollout_type,
             "message_type": experiment.message_type,
             "message_template": experiment.message_template,
+            "preferences": [
+                {
+                    "pref_name": preference.pref_name,
+                    "pref_type": preference.pref_type,
+                    "pref_value": preference.pref_value,
+                }
+                for preference in experiment.preferences.all()
+            ],
         }
 
         self.assertEqual(set(serializer.data.keys()), set(expected_data.keys()))
-
+        self.maxDiff = None
         self.assertEqual(serializer.data, expected_data)
 
 


### PR DESCRIPTION
Because:

* Changelogs need to capture multipref changes

This commit:

* Moves the update_changelog method out of the DesignBaseSerializer
* Implements the update method for all design serializers as needed