### PR TITLE
fix #3745 feat(nimbus): add metrics form

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/FormMetrics/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/FormMetrics/index.stories.tsx
@@ -1,0 +1,28 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from "react";
+import { storiesOf } from "@storybook/react";
+import { Subject } from "./mocks";
+import { action } from "@storybook/addon-actions";
+import { mockExperimentQuery } from "../../lib/mocks";
+
+const onSave = action("onSave");
+const onNext = action("onNext");
+
+storiesOf("components/FormMetrics", module)
+  .add("basic", () => <Subject {...{ onSave, onNext }} />)
+  .add("loading", () => <Subject isLoading {...{ onSave, onNext }} />)
+  .add("errors", () => (
+    <Subject
+      submitErrors={{
+        "*": ["Big bad server thing broke!"],
+      }}
+      {...{ onSave, onNext }}
+    />
+  ))
+  .add("with experiment", () => {
+    const { data: experiment } = mockExperimentQuery("boo");
+    return <Subject {...{ experiment, onSave, onNext }} />;
+  });

--- a/app/experimenter/nimbus-ui/src/components/FormMetrics/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/FormMetrics/index.test.tsx
@@ -1,0 +1,201 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from "react";
+import { render, screen, act, fireEvent } from "@testing-library/react";
+import { mockExperimentQuery } from "../../lib/mocks";
+import { Subject } from "./mocks";
+import { getConfig_nimbusConfig_probeSets } from "../../types/getConfig";
+
+describe("FormMetrics", () => {
+  const probeSets: getConfig_nimbusConfig_probeSets[] = [
+    {
+      __typename: "NimbusProbeSetType",
+      id: "1",
+      name: "Probe Set A",
+      slug: "probe-set-a",
+      probes: [],
+    },
+    {
+      __typename: "NimbusProbeSetType",
+      id: "2",
+      name: "Probe Set B",
+      slug: "probe-set-b",
+      probes: [],
+    },
+    {
+      __typename: "NimbusProbeSetType",
+      id: "3",
+      name: "Probe Set C",
+      slug: "probe-set-c",
+      probes: [],
+    },
+  ];
+
+  it("renders as expected", async () => {
+    render(<Subject />);
+    await act(async () =>
+      expect(screen.getByTestId("FormMetrics")).toBeInTheDocument(),
+    );
+  });
+
+  it("calls onNext when next clicked", async () => {
+    const onNext = jest.fn();
+    render(<Subject {...{ onNext }} />);
+
+    const nextButton = screen.getByText("Next");
+    await act(async () => void fireEvent.click(nextButton));
+    expect(onNext).toHaveBeenCalled();
+  });
+
+  it("calls onSave when save clicked", async () => {
+    const onSave = jest.fn();
+    render(<Subject {...{ onSave }} />);
+
+    const saveButton = screen.getByText("Save");
+    await act(async () => void fireEvent.click(saveButton));
+    expect(onSave).toHaveBeenCalled();
+  });
+
+  it("disables save when loading", async () => {
+    const onSave = jest.fn();
+    render(<Subject {...{ onSave, isLoading: true }} />);
+
+    const submitButton = screen.getByTestId("submit-button");
+    expect(submitButton).toBeDisabled();
+    expect(submitButton).toHaveTextContent("Saving");
+
+    await act(async () => {
+      fireEvent.click(submitButton);
+      fireEvent.submit(screen.getByTestId("FormMetrics"));
+    });
+
+    expect(onSave).not.toHaveBeenCalled();
+  });
+
+  it("displays saving button when loading", async () => {
+    const { data } = mockExperimentQuery("boo");
+    const onSave = jest.fn();
+    render(<Subject {...{ onSave, experiment: data, isLoading: true }} />);
+
+    const submitButton = screen.getByTestId("submit-button");
+    expect(submitButton).toHaveTextContent("Saving");
+  });
+
+  it("displays saved primary probe sets", async () => {
+    const { data } = mockExperimentQuery("boo", {
+      primaryProbeSets: [
+        {
+          __typename: "NimbusProbeSetType",
+          id: "1",
+          name: "Probe Set A",
+          slug: "probe-set-a",
+        },
+      ],
+    });
+
+    render(<Subject {...{ experiment: data }} />);
+
+    const primaryProbeSets = screen.getByTestId("primary-probe-sets");
+    expect(primaryProbeSets).toHaveTextContent("Probe Set A");
+  });
+
+  it("displays saved secondary probe sets", async () => {
+    const { data } = mockExperimentQuery("boo", {
+      secondaryProbeSets: [
+        {
+          __typename: "NimbusProbeSetType",
+          id: "1",
+          name: "Probe Set A",
+          slug: "probe-set-a",
+        },
+      ],
+    });
+
+    render(<Subject {...{ experiment: data }} />);
+
+    const secondaryProbeSets = screen.getByTestId("secondary-probe-sets");
+    expect(secondaryProbeSets).toHaveTextContent("Probe Set A");
+  });
+
+  it("selects a primary probe set and excludes it from secondary probe sets", async () => {
+    render(<Subject {...{ probeSets }} />);
+
+    const primaryProbeSets = screen.getByTestId("primary-probe-sets");
+    const secondaryProbeSets = screen.getByTestId("secondary-probe-sets");
+
+    fireEvent.keyDown(primaryProbeSets.children[1], { key: "ArrowDown" });
+    await act(async () => {
+      expect(primaryProbeSets).toHaveTextContent("Probe Set A");
+      expect(primaryProbeSets).toHaveTextContent("Probe Set B");
+      expect(primaryProbeSets).toHaveTextContent("Probe Set C");
+    });
+
+    fireEvent.click(screen.getByText("Probe Set A"));
+    await act(async () => {
+      expect(primaryProbeSets).toHaveTextContent("Probe Set A");
+      expect(primaryProbeSets).not.toHaveTextContent("Probe Set B");
+      expect(primaryProbeSets).not.toHaveTextContent("Probe Set C");
+    });
+
+    fireEvent.keyDown(secondaryProbeSets.children[1], { key: "ArrowDown" });
+    await act(async () => {
+      expect(secondaryProbeSets).not.toHaveTextContent("Probe Set A");
+      expect(secondaryProbeSets).toHaveTextContent("Probe Set B");
+      expect(secondaryProbeSets).toHaveTextContent("Probe Set C");
+    });
+  });
+
+  it("selects a secondary probe set and excludes it from primary probe sets", async () => {
+    render(<Subject {...{ probeSets }} />);
+
+    const primaryProbeSets = screen.getByTestId("primary-probe-sets");
+    const secondaryProbeSets = screen.getByTestId("secondary-probe-sets");
+
+    fireEvent.keyDown(secondaryProbeSets.children[1], { key: "ArrowDown" });
+    await act(async () => {
+      expect(secondaryProbeSets).toHaveTextContent("Probe Set A");
+      expect(secondaryProbeSets).toHaveTextContent("Probe Set B");
+      expect(secondaryProbeSets).toHaveTextContent("Probe Set C");
+    });
+
+    fireEvent.click(screen.getByText("Probe Set A"));
+    await act(async () => {
+      expect(secondaryProbeSets).toHaveTextContent("Probe Set A");
+      expect(secondaryProbeSets).not.toHaveTextContent("Probe Set B");
+      expect(secondaryProbeSets).not.toHaveTextContent("Probe Set C");
+    });
+
+    fireEvent.keyDown(primaryProbeSets.children[1], { key: "ArrowDown" });
+    await act(async () => {
+      expect(primaryProbeSets).not.toHaveTextContent("Probe Set A");
+      expect(primaryProbeSets).toHaveTextContent("Probe Set B");
+      expect(primaryProbeSets).toHaveTextContent("Probe Set C");
+    });
+  });
+
+  it("allows maximum 2 primary probe sets", async () => {
+    const { data } = mockExperimentQuery("boo", { primaryProbeSets: [] });
+
+    render(<Subject {...{ experiment: data, probeSets }} />);
+
+    const primaryProbeSets = screen.getByTestId("primary-probe-sets");
+
+    fireEvent.keyDown(primaryProbeSets.children[1], { key: "ArrowDown" });
+    fireEvent.click(screen.getByText("Probe Set A"));
+
+    fireEvent.keyDown(primaryProbeSets.children[1], { key: "ArrowDown" });
+    fireEvent.click(screen.getByText("Probe Set B"));
+
+    fireEvent.keyDown(primaryProbeSets.children[1], { key: "ArrowDown" });
+    fireEvent.click(screen.getByText("Probe Set C"));
+    fireEvent.keyDown(primaryProbeSets.children[1], { key: "Escape" });
+
+    await act(async () => {
+      expect(primaryProbeSets).toHaveTextContent("Probe Set A");
+      expect(primaryProbeSets).toHaveTextContent("Probe Set B");
+      expect(primaryProbeSets).not.toHaveTextContent("Probe Set C");
+    });
+  });
+});

--- a/app/experimenter/nimbus-ui/src/components/FormMetrics/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/FormMetrics/index.tsx
@@ -1,0 +1,201 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React, { useCallback, useEffect, useState } from "react";
+import { useForm } from "react-hook-form";
+import Form from "react-bootstrap/Form";
+import Alert from "react-bootstrap/Alert";
+import { getExperiment } from "../../types/getExperiment";
+import { getConfig_nimbusConfig_probeSets } from "../../types/getConfig";
+import { useExitWarning } from "../../hooks";
+import Select, { ActionMeta, ValueType } from "react-select";
+
+type SelectOption = { label: string; value: string };
+
+type FormMetricsProps = {
+  experiment: getExperiment["experimentBySlug"];
+  probeSets: (getConfig_nimbusConfig_probeSets | null)[] | null;
+  isLoading: boolean;
+  isServerValid: boolean;
+  submitErrors: Record<string, string[]>;
+  onSave: (data: Record<string, any>, reset: Function) => void;
+  onNext?: (ev: React.FormEvent) => void;
+};
+
+const FormMetrics = ({
+  experiment,
+  probeSets,
+  isLoading,
+  isServerValid,
+  submitErrors,
+  onSave,
+  onNext,
+}: FormMetricsProps) => {
+  const { handleSubmit, reset, formState } = useForm({
+    mode: "onTouched",
+  });
+  const { isSubmitted, isDirty } = formState;
+  const [selectedPrimaryProbeSetIds, setSelectedPrimaryProbeSetIds] = useState<
+    string[]
+  >([]);
+  const [
+    selectedSecondaryProbeSetsIds,
+    setselectedSecondaryProbeSetsIds,
+  ] = useState<string[]>([]);
+
+  const isValid = isServerValid && formState.isValid;
+  const isDirtyUnsaved = isDirty && !(isValid && isSubmitted);
+
+  const shouldWarnOnExit = useExitWarning();
+  useEffect(() => {
+    shouldWarnOnExit(isDirtyUnsaved);
+  }, [shouldWarnOnExit, isDirtyUnsaved]);
+
+  const handleSubmitAfterValidation = useCallback(
+    (data: Record<string, any>) => {
+      if (isLoading) return;
+      onSave(data, reset);
+    },
+    [isLoading, onSave, reset],
+  );
+
+  const handleNext = useCallback(
+    (ev: React.FormEvent) => {
+      ev.preventDefault();
+      onNext!(ev);
+    },
+    [onNext],
+  );
+
+  const handlePrimaryProbeSetsChange = (
+    selectedOptions: SelectOption[] | null,
+  ) => {
+    const probeSetIds = selectedOptions?.map((option) => option?.value) || [];
+    setSelectedPrimaryProbeSetIds(probeSetIds);
+  };
+
+  const handleSecondaryProbeSetsChange = (
+    selectedOptions: SelectOption[] | null,
+  ) => {
+    const probeSetIds = selectedOptions?.map((option) => option?.value) || [];
+    setselectedSecondaryProbeSetsIds(probeSetIds);
+  };
+
+  const primaryProbeSetOptions: SelectOption[] = [];
+  const secondaryProbeSetOptions: SelectOption[] = [];
+
+  if (probeSets) {
+    for (const probeSet of probeSets) {
+      if (probeSet) {
+        if (!selectedSecondaryProbeSetsIds.includes(probeSet.id)) {
+          primaryProbeSetOptions.push({
+            label: probeSet.name,
+            value: probeSet.id,
+          });
+        }
+        if (!selectedPrimaryProbeSetIds.includes(probeSet.id)) {
+          secondaryProbeSetOptions.push({
+            label: probeSet.name,
+            value: probeSet.id,
+          });
+        }
+      }
+    }
+  }
+
+  return (
+    <Form
+      noValidate
+      onSubmit={handleSubmit(handleSubmitAfterValidation)}
+      validated={isSubmitted && isValid}
+      data-testid="FormMetrics"
+    >
+      {submitErrors["*"] && (
+        <Alert data-testid="submit-error" variant="warning">
+          {submitErrors["*"]}
+        </Alert>
+      )}
+
+      <Form.Group
+        controlId="selectedPrimaryProbeSetIds"
+        data-testid="primary-probe-sets"
+      >
+        <Form.Label>Primary Probe sets</Form.Label>
+        <Select
+          options={primaryProbeSetOptions}
+          defaultValue={experiment?.primaryProbeSets?.map((p) => ({
+            label: p?.name as string,
+            value: p?.id as string,
+          }))}
+          onChange={
+            handlePrimaryProbeSetsChange as (
+              value: ValueType<SelectOption>,
+              actionMeta: ActionMeta<SelectOption>,
+            ) => void
+          }
+          isOptionDisabled={() => selectedPrimaryProbeSetIds.length >= 2}
+          isMulti
+        />
+        <Form.Text className="text-muted">
+          Select the user action or feature that you are measuring with this
+          experiment. You may select up to 2 primary probe sets.
+        </Form.Text>
+      </Form.Group>
+
+      <Form.Group
+        controlId="selectedSecondaryProbeSetsIds"
+        data-testid="secondary-probe-sets"
+      >
+        <Form.Label>Secondary Probe sets</Form.Label>
+        <Select
+          options={secondaryProbeSetOptions}
+          defaultValue={experiment?.secondaryProbeSets?.map((p) => ({
+            label: p?.name as string,
+            value: p?.id as string,
+          }))}
+          onChange={
+            handleSecondaryProbeSetsChange as (
+              value: ValueType<SelectOption>,
+              actionMeta: ActionMeta<SelectOption>,
+            ) => void
+          }
+          isMulti
+        />
+        <Form.Text className="text-muted">
+          Select the user action or feature that you are measuring with this
+          experiment.
+        </Form.Text>
+      </Form.Group>
+
+      <div className="d-flex flex-row-reverse bd-highlight">
+        {onNext && (
+          <div className="p-2">
+            <button
+              onClick={handleNext}
+              className="btn btn-secondary"
+              disabled={isLoading}
+              data-sb-kind="pages/EditBranches"
+            >
+              Next
+            </button>
+          </div>
+        )}
+        <div className="p-2">
+          <button
+            data-testid="submit-button"
+            type="submit"
+            onClick={handleSubmit(handleSubmitAfterValidation)}
+            className="btn btn-primary"
+            disabled={isLoading}
+            data-sb-kind="pages/EditMetrics"
+          >
+            {isLoading ? <span>Saving</span> : <span>Save</span>}
+          </button>
+        </div>
+      </div>
+    </Form>
+  );
+};
+
+export default FormMetrics;

--- a/app/experimenter/nimbus-ui/src/components/FormMetrics/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/components/FormMetrics/mocks.tsx
@@ -1,0 +1,31 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from "react";
+import FormMetrics from ".";
+import { MockedCache, mockExperimentQuery, MOCK_CONFIG } from "../../lib/mocks";
+
+export const Subject = ({
+  isLoading = false,
+  isServerValid = true,
+  submitErrors = {},
+  onSave = () => {},
+  onNext = () => {},
+  experiment = mockExperimentQuery("boo").data,
+  probeSets = MOCK_CONFIG.probeSets,
+}: Partial<React.ComponentProps<typeof FormMetrics>>) => (
+  <MockedCache>
+    <FormMetrics
+      {...{
+        isLoading,
+        isServerValid,
+        submitErrors,
+        onSave,
+        onNext,
+        experiment,
+        probeSets,
+      }}
+    />
+  </MockedCache>
+);

--- a/app/experimenter/nimbus-ui/src/components/PageEditMetrics/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditMetrics/index.test.tsx
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React from "react";
-import { screen, render, waitFor } from "@testing-library/react";
+import { screen, render, waitFor, fireEvent } from "@testing-library/react";
 import PageEditMetrics from ".";
 import { RouterSlugProvider } from "../../lib/test-utils";
 import { mockExperimentQuery } from "../../lib/mocks";
@@ -20,5 +20,29 @@ describe("PageEditMetrics", () => {
     await waitFor(() => {
       expect(screen.queryByTestId("PageEditMetrics")).toBeInTheDocument();
     });
+  });
+
+  it("does nothing on Save", async () => {
+    render(
+      <RouterSlugProvider mocks={[mock]}>
+        <PageEditMetrics />
+      </RouterSlugProvider>,
+    );
+    await waitFor(() => {
+      expect(screen.queryByTestId("PageEditMetrics")).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByText("Save"));
+  });
+
+  it("does nothing on Next", async () => {
+    render(
+      <RouterSlugProvider mocks={[mock]}>
+        <PageEditMetrics />
+      </RouterSlugProvider>,
+    );
+    await waitFor(() => {
+      expect(screen.queryByTestId("PageEditMetrics")).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByText("Next"));
   });
 });

--- a/app/experimenter/nimbus-ui/src/components/PageEditMetrics/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditMetrics/index.tsx
@@ -5,11 +5,38 @@
 import React from "react";
 import { RouteComponentProps } from "@reach/router";
 import AppLayoutWithExperiment from "../AppLayoutWithExperiment";
+import FormMetrics from "../FormMetrics";
+import LinkExternal from "../LinkExternal";
+import { useConfig } from "../../hooks/useConfig";
 
 const PageEditMetrics: React.FunctionComponent<RouteComponentProps> = () => {
+  const { probeSets } = useConfig();
+
   return (
     <AppLayoutWithExperiment title="Metrics" testId="PageEditMetrics">
-      {({ experiment }) => <p>{experiment.name}</p>}
+      {({ experiment }) => (
+        <>
+          <p>
+            Every experiment analysis automatically includes how your experiment
+            has impacted <strong>Retention, Search Count, and Ad Click</strong>{" "}
+            metrics. Get more information on{" "}
+            {/* TODO Requires url https://jira.mozilla.com/browse/EXP-656 */}
+            <LinkExternal href="">Core Firefox Metrics.</LinkExternal>
+          </p>
+          <FormMetrics
+            {...{
+              experiment,
+              probeSets,
+              isLoading: false,
+              isServerValid: true,
+              submitErrors: {},
+              /* TODO: EXP-505 for accepting and saving edits to branches */
+              onSave: async (update) => console.log("SAVE", update),
+              onNext: () => console.log("NEXT"),
+            }}
+          />
+        </>
+      )}
     </AppLayoutWithExperiment>
   );
 };

--- a/app/experimenter/nimbus-ui/src/components/TableHighlights/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/TableHighlights/index.stories.tsx
@@ -28,16 +28,19 @@ storiesOf("visualization/TableHighlights", module)
       primaryProbeSets: [
         {
           __typename: "NimbusProbeSetType",
+          id: "1",
           slug: "picture-in-picture",
           name: "Picture-in-Picture",
         },
         {
           __typename: "NimbusProbeSetType",
+          id: "2",
           slug: "feature-b",
           name: "Feature B",
         },
         {
           __typename: "NimbusProbeSetType",
+          id: "3",
           slug: "feature-c",
           name: "Feature C",
         },

--- a/app/experimenter/nimbus-ui/src/components/TableMetricPrimary/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/TableMetricPrimary/index.stories.tsx
@@ -16,6 +16,7 @@ storiesOf("visualization/TableMetricPrimary", module)
       primaryProbeSets: [
         {
           __typename: "NimbusProbeSetType",
+          id: "1",
           slug: "picture_in_picture",
           name: "Picture-in-Picture",
         },
@@ -34,6 +35,7 @@ storiesOf("visualization/TableMetricPrimary", module)
       primaryProbeSets: [
         {
           __typename: "NimbusProbeSetType",
+          id: "1",
           slug: "feature_b",
           name: "Feature B",
         },
@@ -52,6 +54,7 @@ storiesOf("visualization/TableMetricPrimary", module)
       primaryProbeSets: [
         {
           __typename: "NimbusProbeSetType",
+          id: "1",
           slug: "feature_c",
           name: "Feature C",
         },

--- a/app/experimenter/nimbus-ui/src/components/TableMetricPrimary/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/TableMetricPrimary/index.test.tsx
@@ -93,6 +93,7 @@ describe("TableMetricPrimary", () => {
       primaryProbeSets: [
         {
           __typename: "NimbusProbeSetType",
+          id: "1",
           slug: "feature_b",
           name: "Feature B",
         },
@@ -121,6 +122,7 @@ describe("TableMetricPrimary", () => {
       primaryProbeSets: [
         {
           __typename: "NimbusProbeSetType",
+          id: "1",
           slug: "feature_c",
           name: "Feature C",
         },

--- a/app/experimenter/nimbus-ui/src/components/TableMetricSecondary/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/TableMetricSecondary/index.stories.tsx
@@ -16,6 +16,7 @@ storiesOf("visualization/TableMetricSecondary", module)
       secondaryProbeSets: [
         {
           __typename: "NimbusProbeSetType",
+          id: "1",
           slug: "picture_in_picture",
           name: "Picture-in-Picture",
         },
@@ -43,6 +44,7 @@ storiesOf("visualization/TableMetricSecondary", module)
       secondaryProbeSets: [
         {
           __typename: "NimbusProbeSetType",
+          id: "1",
           slug: "feature_c",
           name: "Feature C",
         },

--- a/app/experimenter/nimbus-ui/src/components/TableOverview/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/TableOverview/index.stories.tsx
@@ -25,16 +25,19 @@ storiesOf("visualization/TableOverview", module)
       primaryProbeSets: [
         {
           __typename: "NimbusProbeSetType",
+          id: "1",
           slug: "picture-in-picture",
           name: "Picture-in-Picture",
         },
         {
           __typename: "NimbusProbeSetType",
+          id: "2",
           slug: "feature-b",
           name: "Feature B",
         },
         {
           __typename: "NimbusProbeSetType",
+          id: "3",
           slug: "feature-c",
           name: "Feature C",
         },

--- a/app/experimenter/nimbus-ui/src/components/TableResults/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/TableResults/index.stories.tsx
@@ -28,16 +28,19 @@ storiesOf("visualization/TableResults", module)
       primaryProbeSets: [
         {
           __typename: "NimbusProbeSetType",
+          id: "1",
           slug: "picture-in-picture",
           name: "Picture-in-Picture",
         },
         {
           __typename: "NimbusProbeSetType",
+          id: "2",
           slug: "feature-b",
           name: "Feature B",
         },
         {
           __typename: "NimbusProbeSetType",
+          id: "3",
           slug: "feature-c",
           name: "Feature C",
         },

--- a/app/experimenter/nimbus-ui/src/gql/experiments.ts
+++ b/app/experimenter/nimbus-ui/src/gql/experiments.ts
@@ -119,11 +119,13 @@ export const GET_EXPERIMENT_QUERY = gql`
       }
 
       primaryProbeSets {
+        id
         slug
         name
       }
 
       secondaryProbeSets {
+        id
         slug
         name
       }

--- a/app/experimenter/nimbus-ui/src/types/getExperiment.ts
+++ b/app/experimenter/nimbus-ui/src/types/getExperiment.ts
@@ -47,12 +47,14 @@ export interface getExperiment_experimentBySlug_featureConfig {
 
 export interface getExperiment_experimentBySlug_primaryProbeSets {
   __typename: "NimbusProbeSetType";
+  id: string;
   slug: string;
   name: string;
 }
 
 export interface getExperiment_experimentBySlug_secondaryProbeSets {
   __typename: "NimbusProbeSetType";
+  id: string;
   slug: string;
   name: string;
 }

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -16404,7 +16404,7 @@ react-select-event@5.1.0:
   dependencies:
     "@testing-library/dom" ">=7"
 
-react-select@3.1.0:
+react-select@3.1.0, react-select@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/react-select/-/react-select-3.1.0.tgz#ab098720b2e9fe275047c993f0d0caf5ded17c27"
   integrity sha512-wBFVblBH1iuCBprtpyGtd1dGMadsG36W5/t2Aj8OE6WbByDg5jIFyT7X5gT+l0qmT5TqWhxX+VsKJvCEl2uL9g==


### PR DESCRIPTION
Because

* We need to set primary and secondary probe sets on an experiment

This commit

* Adds the PageEditMetrics component + tests + storybook
* Adds the FormMetrics component + tests + storybook
* Updates the gql queries for probesets and all the related tests/references