### PR TITLE
fixes #4050 feat(nimbus): display missing field icons on branches and audience page

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/FormAudience/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/FormAudience/index.test.tsx
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React from "react";
-import { render } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { Subject, MOCK_EXPERIMENT } from "./mocks";
 import { MOCK_CONFIG } from "../../lib/mocks";
 
@@ -31,5 +31,43 @@ describe("FormAudience", () => {
         }}
       />,
     );
+  });
+
+  it("displays warning icons when server complains fields are missing", async () => {
+    Object.defineProperty(window, "location", {
+      value: {
+        search: "?show-errors",
+      },
+    });
+
+    const isMissingField = jest.fn(() => true);
+    render(
+      <Subject
+        {...{
+          isMissingField,
+          experiment: {
+            ...MOCK_EXPERIMENT,
+            readyForReview: {
+              __typename: "NimbusReadyForReviewType",
+              ready: false,
+              message: {
+                proposed_duration: ["This field may not be null."],
+                proposed_enrollment: ["This field may not be null."],
+                firefox_min_version: ["This field may not be null."],
+                targeting_config_slug: ["This field may not be null."],
+                channels: ["This list may not be empty."],
+              },
+            },
+          },
+        }}
+      />,
+    );
+
+    expect(isMissingField).toHaveBeenCalled();
+    expect(screen.queryByTestId("missing-channels")).toBeInTheDocument();
+    expect(screen.queryByTestId("missing-ff-min")).toBeInTheDocument();
+    expect(screen.queryByTestId("missing-config")).toBeInTheDocument();
+    expect(screen.queryByTestId("missing-enrollment")).toBeInTheDocument();
+    expect(screen.queryByTestId("missing-duration")).toBeInTheDocument();
   });
 });

--- a/app/experimenter/nimbus-ui/src/components/FormAudience/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/FormAudience/index.tsx
@@ -8,6 +8,7 @@ import Form from "react-bootstrap/Form";
 import InputGroup from "react-bootstrap/InputGroup";
 import Col from "react-bootstrap/Col";
 import LinkExternal from "../LinkExternal";
+import InlineErrorIcon from "../InlineErrorIcon";
 
 import { getExperiment_experimentBySlug } from "../../types/getExperiment";
 import {
@@ -27,9 +28,11 @@ type FormAudienceConfig = Pick<
 export const FormAudience = ({
   experiment,
   config,
+  isMissingField,
 }: {
   experiment: getExperiment_experimentBySlug;
   config: FormAudienceConfig;
+  isMissingField: (fieldName: string) => boolean;
 }) => {
   const {
     channels,
@@ -53,7 +56,15 @@ export const FormAudience = ({
       <Form.Group>
         <Form.Row>
           <Form.Group as={Col} controlId="channel" md={8} lg={8}>
-            <Form.Label>Channel</Form.Label>
+            <Form.Label className="d-flex align-items-center">
+              Channel
+              {isMissingField("channels") && (
+                <InlineErrorIcon
+                  name="channels"
+                  message="At least one channel must be selected"
+                />
+              )}
+            </Form.Label>
             <Select
               isMulti
               name="channel"
@@ -63,7 +74,15 @@ export const FormAudience = ({
             />
           </Form.Group>
           <Form.Group as={Col} controlId="minVersion">
-            <Form.Label>Min Version</Form.Label>
+            <Form.Label className="d-flex align-items-center">
+              Min Version
+              {isMissingField("firefox_min_version") && (
+                <InlineErrorIcon
+                  name="ff-min"
+                  message="A minimum Firefox version must be selected"
+                />
+              )}
+            </Form.Label>
             <Form.Control
               as="select"
               data-testid="minVersion"
@@ -75,7 +94,15 @@ export const FormAudience = ({
         </Form.Row>
         <Form.Row>
           <Form.Group as={Col} controlId="targeting">
-            <Form.Label>Advanced Targeting</Form.Label>
+            <Form.Label className="d-flex align-items-center">
+              Advanced Targeting
+              {isMissingField("targeting_config_slug") && (
+                <InlineErrorIcon
+                  name="config"
+                  message="A targeting config must be selected"
+                />
+              )}
+            </Form.Label>
             <Form.Control
               as="select"
               data-testid="targeting"
@@ -122,7 +149,15 @@ export const FormAudience = ({
 
         <Form.Row>
           <Form.Group as={Col} className="mx-5" controlId="enrollmentPeriod">
-            <Form.Label>Enrollment period</Form.Label>
+            <Form.Label className="d-flex align-items-center">
+              Enrollment period
+              {isMissingField("proposed_enrollment") && (
+                <InlineErrorIcon
+                  name="enrollment"
+                  message="Proposed enrollment cannot be blank"
+                />
+              )}
+            </Form.Label>
             <InputGroup>
               <Form.Control
                 placeholder="7"
@@ -138,7 +173,15 @@ export const FormAudience = ({
           </Form.Group>
 
           <Form.Group as={Col} className="mx-5" controlId="experimentDuration">
-            <Form.Label>Experiment duration</Form.Label>
+            <Form.Label className="d-flex align-items-center">
+              Experiment duration
+              {isMissingField("proposed_duration") && (
+                <InlineErrorIcon
+                  name="duration"
+                  message="Proposed duration cannot be blank"
+                />
+              )}
+            </Form.Label>
             <InputGroup className="mb-3">
               <Form.Control
                 placeholder="28"

--- a/app/experimenter/nimbus-ui/src/components/FormAudience/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/components/FormAudience/mocks.tsx
@@ -9,12 +9,14 @@ import { FormAudience } from ".";
 export const Subject = ({
   experiment = MOCK_EXPERIMENT,
   config = MOCK_CONFIG,
+  isMissingField = () => false,
 }: Partial<React.ComponentProps<typeof FormAudience>>) => (
   <div className="p-5">
     <FormAudience
       {...{
         experiment,
         config,
+        isMissingField,
       }}
     />
   </div>

--- a/app/experimenter/nimbus-ui/src/components/FormBranches/FormBranch.tsx
+++ b/app/experimenter/nimbus-ui/src/components/FormBranches/FormBranch.tsx
@@ -18,6 +18,7 @@ import {
 } from "../../types/getConfig";
 
 import { AnnotatedBranch } from "./reducer";
+import InlineErrorIcon from "../InlineErrorIcon";
 
 type DefaultValues = {
   name: string;
@@ -40,6 +41,7 @@ export const FormBranch = ({
   onAddFeatureConfig,
   onRemoveFeatureConfig,
   onFeatureConfigChange,
+  showMissingIcon,
 }: {
   id: string;
   branch: AnnotatedBranch;
@@ -55,6 +57,7 @@ export const FormBranch = ({
   onFeatureConfigChange: (
     featureConfig: getConfig_nimbusConfig_featureConfig | null,
   ) => void;
+  showMissingIcon?: boolean;
 }) => {
   const {
     register,
@@ -213,6 +216,13 @@ export const FormBranch = ({
               >
                 <DeleteIcon width="18" height="18" />
               </Button>
+            )}
+
+            {showMissingIcon && (
+              <InlineErrorIcon
+                name="control"
+                message="A control branch is required"
+              />
             )}
           </Form.Group>
         </Form.Row>

--- a/app/experimenter/nimbus-ui/src/components/FormBranches/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/FormBranches/index.test.tsx
@@ -333,6 +333,36 @@ describe("FormBranches", () => {
     expect(saveResult.referenceBranch).toEqual(expectedData);
     expect(saveResult.treatmentBranches[1]).toEqual(expectedData);
   });
+
+  it("displays warning icon when reference branch is not set and server requires it", async () => {
+    Object.defineProperty(window, "location", {
+      value: {
+        search: "?show-errors",
+      },
+    });
+
+    const isMissingField = jest.fn(() => true);
+    render(
+      <SubjectBranches
+        {...{
+          isMissingField,
+          experiment: {
+            ...MOCK_EXPERIMENT,
+            readyForReview: {
+              __typename: "NimbusReadyForReviewType",
+              ready: false,
+              message: {
+                reference_branch: ["This field may not be null."],
+              },
+            },
+          },
+        }}
+      />,
+    );
+
+    expect(isMissingField).toHaveBeenCalled();
+    expect(screen.queryByTestId("missing-control")).toBeInTheDocument();
+  });
 });
 
 async function fillInBranch(

--- a/app/experimenter/nimbus-ui/src/components/FormBranches/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/FormBranches/index.tsx
@@ -30,6 +30,7 @@ export const FormBranches = ({
   featureConfig,
   onSave,
   onNext,
+  isMissingField,
 }: {
   isLoading: boolean;
   experiment: getExperiment_experimentBySlug;
@@ -40,6 +41,7 @@ export const FormBranches = ({
     clearSubmitErrors: Function,
   ) => void;
   onNext: () => void;
+  isMissingField: (fieldName: string) => boolean;
 }) => {
   const [
     {
@@ -178,6 +180,7 @@ export const FormBranches = ({
               isReference: true,
               branch: { ...referenceBranch, key: "branch-reference" },
               onChange: handleUpdateBranch(REFERENCE_BRANCH_IDX),
+              showMissingIcon: isMissingField("reference_branch"),
             }}
           />
         )}

--- a/app/experimenter/nimbus-ui/src/components/FormBranches/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/components/FormBranches/mocks.tsx
@@ -49,6 +49,7 @@ export const SubjectBranches = ({
   onSave = () => {},
   onNext = () => {},
   saveOnInitialRender = false,
+  isMissingField = () => false,
 }: Partial<React.ComponentProps<typeof FormBranches>> & {
   saveOnInitialRender?: boolean;
 } = {}) => {
@@ -71,6 +72,7 @@ export const SubjectBranches = ({
           featureConfig,
           onSave,
           onNext,
+          isMissingField,
         }}
       />
     </div>

--- a/app/experimenter/nimbus-ui/src/components/FormOverview/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/FormOverview/index.tsx
@@ -4,13 +4,12 @@
 
 import React, { useCallback, useEffect } from "react";
 import { useForm, ValidationRules } from "react-hook-form";
-import ReactTooltip from "react-tooltip";
 import Form from "react-bootstrap/Form";
 import Alert from "react-bootstrap/Alert";
 import { getExperiment } from "../../types/getExperiment";
 import { useExitWarning } from "../../hooks";
 import { useConfig } from "../../hooks/useConfig";
-import { ReactComponent as ErrorCircle } from "../../images/error-circle.svg";
+import InlineErrorIcon from "../InlineErrorIcon";
 
 type FormOverviewProps = {
   isLoading: boolean;
@@ -169,19 +168,13 @@ const FormOverview = ({
 
       {experiment && (
         <Form.Group controlId="publicDescription">
-          <Form.Label>
+          <Form.Label className="d-flex align-items-center">
             Public description
             {isMissingField!("public_description") && (
-              <>
-                <ErrorCircle
-                  width="20"
-                  height="20"
-                  className="ml-1"
-                  data-testid="missing-description"
-                  data-tip="Public description cannot be blank"
-                />
-                <ReactTooltip />
-              </>
+              <InlineErrorIcon
+                name="description"
+                message="Public description cannot be blank"
+              />
             )}
           </Form.Label>
           <Form.Control

--- a/app/experimenter/nimbus-ui/src/components/InlineErrorIcon/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/InlineErrorIcon/index.stories.tsx
@@ -1,0 +1,11 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from "react";
+import { storiesOf } from "@storybook/react";
+import InlineErrorIcon from ".";
+
+storiesOf("components/InlineErrorIcon", module).add("basic", () => (
+  <InlineErrorIcon name="demo" message="This is a test" />
+));

--- a/app/experimenter/nimbus-ui/src/components/InlineErrorIcon/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/InlineErrorIcon/index.tsx
@@ -1,0 +1,28 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from "react";
+import ReactTooltip from "react-tooltip";
+import { ReactComponent as ErrorCircle } from "../../images/error-circle.svg";
+
+const InlineErrorIcon = ({
+  name,
+  message,
+}: {
+  name: string;
+  message: string;
+}) => (
+  <>
+    <ErrorCircle
+      width="20"
+      height="20"
+      className="ml-1"
+      data-testid={`missing-${name}`}
+      data-tip={message}
+    />
+    <ReactTooltip />
+  </>
+);
+
+export default InlineErrorIcon;

--- a/app/experimenter/nimbus-ui/src/components/PageEditAudience/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditAudience/index.stories.tsx
@@ -6,15 +6,48 @@ import React from "react";
 import { storiesOf } from "@storybook/react";
 import { RouterSlugProvider } from "../../lib/test-utils";
 import { withLinks } from "@storybook/addon-links";
+import { withQuery } from "@storybook/addon-queryparams";
 import { mockExperimentQuery } from "../../lib/mocks";
 import PageEditAudience from ".";
 
 const { mock } = mockExperimentQuery("demo-slug");
+const { mock: mockMissingFields } = mockExperimentQuery("demo-slug", {
+  channels: [],
+  firefoxMinVersion: null,
+  targetingConfigSlug: null,
+  proposedEnrollment: null,
+  proposedDuration: null,
+  readyForReview: {
+    __typename: "NimbusReadyForReviewType",
+    ready: false,
+    message: {
+      proposed_duration: ["This field may not be null."],
+      proposed_enrollment: ["This field may not be null."],
+      firefox_min_version: ["This field may not be null."],
+      targeting_config_slug: ["This field may not be null."],
+      channels: ["This list may not be empty."],
+    },
+  },
+});
 
 storiesOf("pages/EditAudience", module)
   .addDecorator(withLinks)
+  .addDecorator(withQuery)
   .add("basic", () => (
     <RouterSlugProvider mocks={[mock]}>
       <PageEditAudience />
     </RouterSlugProvider>
-  ));
+  ))
+  .add(
+    "missing fields",
+    () => (
+      <RouterSlugProvider mocks={[mockMissingFields]}>
+        <PageEditAudience />
+      </RouterSlugProvider>
+    ),
+    {
+      query: {
+        "show-errors": true,
+      },
+    },
+  );

--- a/app/experimenter/nimbus-ui/src/components/PageEditAudience/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditAudience/index.tsx
@@ -2,25 +2,38 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from "react";
+import React, { useRef } from "react";
 import { RouteComponentProps } from "@reach/router";
 import AppLayoutWithExperiment from "../AppLayoutWithExperiment";
 import { useConfig } from "../../hooks";
 import FormAudience from "../FormAudience";
+import { getExperiment_experimentBySlug } from "../../types/getExperiment";
 
 const PageEditAudience: React.FunctionComponent<RouteComponentProps> = () => {
   const config = useConfig();
 
+  const currentExperiment = useRef<getExperiment_experimentBySlug>();
+  // TODO: EXP-506 should call this when the form is saved
+  const refetchReview = useRef<() => void>();
+
   return (
     <AppLayoutWithExperiment title="Audience" testId="PageEditAudience">
-      {({ experiment }) => (
-        <FormAudience
-          {...{
-            experiment,
-            config,
-          }}
-        />
-      )}
+      {({ experiment, review }) => {
+        currentExperiment.current = experiment;
+        refetchReview.current = review.refetch;
+
+        const { isMissingField } = review;
+
+        return (
+          <FormAudience
+            {...{
+              experiment,
+              config,
+              isMissingField,
+            }}
+          />
+        );
+      }}
     </AppLayoutWithExperiment>
   );
 };

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/index.stories.tsx
@@ -6,15 +6,59 @@ import React from "react";
 import { storiesOf } from "@storybook/react";
 import { RouterSlugProvider } from "../../lib/test-utils";
 import { withLinks } from "@storybook/addon-links";
+import { withQuery } from "@storybook/addon-queryparams";
 import { mockExperimentQuery } from "../../lib/mocks";
 import PageEditBranches from ".";
 
 const { mock } = mockExperimentQuery("demo-slug");
+const { mock: mockMissingFields } = mockExperimentQuery("demo-slug", {
+  referenceBranch: {
+    __typename: "NimbusBranchType",
+    name: "",
+    slug: "",
+    description: "",
+    ratio: 1,
+    featureValue: "",
+    featureEnabled: false,
+  },
+  treatmentBranches: [
+    {
+      __typename: "NimbusBranchType",
+      name: "",
+      slug: "",
+      description: "",
+      ratio: 1,
+      featureValue: "",
+      featureEnabled: false,
+    },
+  ],
+  readyForReview: {
+    __typename: "NimbusReadyForReviewType",
+    ready: false,
+    message: {
+      reference_branch: ["This field may not be null."],
+    },
+  },
+});
 
 storiesOf("pages/EditBranches", module)
   .addDecorator(withLinks)
+  .addDecorator(withQuery)
   .add("basic", () => (
     <RouterSlugProvider mocks={[mock]}>
       <PageEditBranches />
     </RouterSlugProvider>
-  ));
+  ))
+  .add(
+    "missing fields",
+    () => (
+      <RouterSlugProvider mocks={[mockMissingFields]}>
+        <PageEditBranches />
+      </RouterSlugProvider>
+    ),
+    {
+      query: {
+        "show-errors": true,
+      },
+    },
+  );

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/index.tsx
@@ -30,6 +30,7 @@ const PageEditBranches: React.FunctionComponent<RouteComponentProps> = () => {
   >(UPDATE_EXPERIMENT_BRANCHES_MUTATION);
 
   const currentExperiment = useRef<getExperiment_experimentBySlug>();
+  const refetchReview = useRef<() => void>();
 
   const onFormSave = useCallback(
     async (
@@ -79,8 +80,12 @@ const PageEditBranches: React.FunctionComponent<RouteComponentProps> = () => {
 
   return (
     <AppLayoutWithExperiment title="Branches" testId="PageEditBranches">
-      {({ experiment }) => {
+      {({ experiment, review }) => {
         currentExperiment.current = experiment;
+        refetchReview.current = review.refetch;
+
+        const { isMissingField } = review;
+
         return (
           <>
             <p>
@@ -93,6 +98,7 @@ const PageEditBranches: React.FunctionComponent<RouteComponentProps> = () => {
               {...{
                 experiment,
                 featureConfig,
+                isMissingField,
                 isLoading: loading,
                 onSave: onFormSave,
                 onNext: onFormNext,


### PR DESCRIPTION
Closes #4050
Also addresses this specific task in #3782

This PR updates the Edit Branches and Audience page to display error icons next to missing fields that are preventing the experiment from going into Review.

Storybook: `EditAudience`'s [`missing fields`](https://storage.googleapis.com/mozilla-storybooks-experimenter/commits/50542f1ae3a4ffefe0745c5c6e0e68e07fc07b39/nimbus-ui/index.html?path=/story/pages-editaudience--missing-fields) and `EditBranch`'s [`missing fields`](https://storage.googleapis.com/mozilla-storybooks-experimenter/commits/50542f1ae3a4ffefe0745c5c6e0e68e07fc07b39/nimbus-ui/index.html?path=/story/pages-editbranches--missing-fields)