### PR TITLE
fixes #4067 feat(nimbus): move analysis lookup to AppLayoutWithExperiment level

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/AppLayoutWithSidebar/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/AppLayoutWithSidebar/index.stories.tsx
@@ -37,9 +37,31 @@ storiesOf("components/AppLayoutWithSidebar", module)
       </AppLayoutWithSidebar>
     </RouterSlugProvider>
   ))
+  .add("status: accepted", () => (
+    <RouterSlugProvider>
+      <AppLayoutWithSidebar status={NimbusExperimentStatus.ACCEPTED}>
+        <p>App contents go here</p>
+      </AppLayoutWithSidebar>
+    </RouterSlugProvider>
+  ))
   .add("status: live", () => (
     <RouterSlugProvider>
       <AppLayoutWithSidebar status={NimbusExperimentStatus.LIVE}>
+        <p>App contents go here</p>
+      </AppLayoutWithSidebar>
+    </RouterSlugProvider>
+  ))
+  .add("has analysis results", () => (
+    <RouterSlugProvider>
+      <AppLayoutWithSidebar
+        status={NimbusExperimentStatus.COMPLETE}
+        analysis={{
+          show_analysis: true,
+          daily: [],
+          weekly: [],
+          overall: {},
+        }}
+      >
         <p>App contents go here</p>
       </AppLayoutWithSidebar>
     </RouterSlugProvider>

--- a/app/experimenter/nimbus-ui/src/components/PageRequestReview/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageRequestReview/index.test.tsx
@@ -17,6 +17,24 @@ import { NimbusExperimentStatus } from "../../types/globalTypes";
 import { createMutationMock } from "./mocks";
 
 describe("PageRequestReview", () => {
+  // This component is currently set up to handle an experiment
+  // that is live, accepted, and complete, and as a result also performs
+  // an analysis lookup. In practice, and when EXP-497 is complete, this
+  // page should not be accessed. For now I'm stubbing the console.error
+  // that occurs when the analysis lookup happens.
+  // TODO: EXP-497, remove branches and tests that handle locked experiment
+  // state, and remove this console.error stubbing
+  let origError: typeof global.console.error;
+
+  beforeEach(() => {
+    origError = global.console.error;
+    global.console.error = jest.fn();
+  });
+
+  afterEach(() => {
+    global.console.error = origError;
+  });
+
   async function checkRequiredBoxes() {
     const checkboxes = screen.queryAllByTestId("required-checkbox");
 

--- a/app/experimenter/nimbus-ui/src/components/PageResults/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/index.tsx
@@ -3,9 +3,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React from "react";
-import { RouteComponentProps, useParams } from "@reach/router";
+import { RouteComponentProps } from "@reach/router";
 import AppLayoutWithExperiment from "../AppLayoutWithExperiment";
-import { useAnalysis } from "../../hooks";
 import { Alert } from "react-bootstrap";
 import { getExperiment_experimentBySlug } from "../../types/getExperiment";
 import LinkExternal from "../LinkExternal";
@@ -17,40 +16,29 @@ import TableMetricSecondary from "../TableMetricSecondary";
 import { AnalysisData } from "../../lib/visualization/types";
 import Summary from "../Summary";
 
-const PageResults: React.FunctionComponent<RouteComponentProps> = () => {
-  const { slug } = useParams();
-  const { loading, error, result: analysis } = useAnalysis(slug);
-
-  return (
-    <AppLayoutWithExperiment title="Analysis" testId="PageResults">
-      {({ experiment }) => (
-        <>
-          {loading ? (
-            <p data-testid="analysis-loading">Loading analysis data...</p>
-          ) : (
-            <>
-              <h3 className="h5 mb-3">Monitoring</h3>
-              <p>
-                <LinkExternal
-                  href={experiment.monitoringDashboardUrl!}
-                  data-testid="link-monitoring-dashboard"
-                >
-                  Click here
-                </LinkExternal>{" "}
-                to view the live monitoring dashboard.
-              </p>
-              {analysis?.show_analysis ? (
-                <AnalysisAvailable {...{ experiment, analysis }} />
-              ) : (
-                <AnalysisUnavailable {...{ experiment, error }} />
-              )}
-            </>
-          )}
-        </>
-      )}
-    </AppLayoutWithExperiment>
-  );
-};
+const PageResults: React.FunctionComponent<RouteComponentProps> = () => (
+  <AppLayoutWithExperiment title="Analysis" testId="PageResults">
+    {({ experiment, analysis }) => (
+      <>
+        <h3 className="h5 mb-3">Monitoring</h3>
+        <p>
+          <LinkExternal
+            href={experiment.monitoringDashboardUrl!}
+            data-testid="link-monitoring-dashboard"
+          >
+            Click here
+          </LinkExternal>{" "}
+          to view the live monitoring dashboard.
+        </p>
+        {analysis?.show_analysis ? (
+          <AnalysisAvailable {...{ experiment, analysis }} />
+        ) : (
+          <AnalysisUnavailable {...{ experiment, error: analysis == null }} />
+        )}
+      </>
+    )}
+  </AppLayoutWithExperiment>
+);
 
 const AnalysisAvailable = ({
   experiment,
@@ -137,7 +125,7 @@ const AnalysisUnavailable = ({
   error,
 }: {
   experiment: getExperiment_experimentBySlug;
-  error: Error | undefined;
+  error: boolean;
 }) => (
   <>
     {error ? <AlertError /> : <AlertUnavailable />}

--- a/app/experimenter/nimbus-ui/src/hooks/useAnalysis.test.tsx
+++ b/app/experimenter/nimbus-ui/src/hooks/useAnalysis.test.tsx
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React from "react";
-import { render, waitFor } from "@testing-library/react";
+import { act, render } from "@testing-library/react";
 import fetchMock from "jest-fetch-mock";
 import { useAnalysis } from "./useAnalysis";
 
@@ -11,8 +11,8 @@ describe("hooks/useVisualization", () => {
   describe("useVisualization", () => {
     let hook: ReturnType<typeof useAnalysis>;
 
-    const TestHook = ({ slug }: { slug: string }) => {
-      hook = useAnalysis(slug);
+    const TestHook = () => {
+      hook = useAnalysis();
       return <p>Algonquin Provincial Park</p>;
     };
 
@@ -23,18 +23,17 @@ describe("hooks/useVisualization", () => {
       const data = { burrito: "Crunchwrap Supreme®" };
       fetchMock.mockResponseOnce(JSON.stringify(data));
 
-      render(<TestHook {...{ slug }} />);
+      render(<TestHook />);
+
+      await act(async () => void hook.execute([slug]));
 
       expect(fetch).toHaveBeenCalledWith(`/api/v3/visualization/${slug}/`, {
         headers: { "Content-Type": "application/json" },
         method: "GET",
       });
 
-      expect(hook.loading).toBeTruthy();
-      await waitFor(() => {
-        expect(hook.loading).toBeFalsy();
-        expect(hook.result).toEqual(data);
-      });
+      expect(hook.result).toEqual(data);
+      expect(hook.loading).toBeFalsy();
 
       fetchMock.disableMocks();
     });

--- a/app/experimenter/nimbus-ui/src/hooks/useAnalysis.tsx
+++ b/app/experimenter/nimbus-ui/src/hooks/useAnalysis.tsx
@@ -19,6 +19,11 @@ export const fetchData = async (slug: string) =>
  * Hook to retrieve Experiment Analysis data by slug.
  */
 
-export function useAnalysis(slug: string) {
-  return useAsync<AnalysisData>(fetchData, [slug]);
+export function useAnalysis() {
+  // Because this is delayed execution the returned `execute`
+  // function needs to provide the slug parameter
+  return useAsync<AnalysisData>(fetchData, [], {
+    executeOnMount: false,
+    executeOnUpdate: false,
+  });
 }


### PR DESCRIPTION
Closes #4067

Because:

We currently fetch experiment analysis data on the the experiment results page, at the `PageResults` component level, but we need need to be able to update the contents of `AppLayoutWithSidebar` based on analysis status.

This PR:

Moves the analysis lookup request up a few levels and into `AppLayoutWithExperiment`, where it can then pass the data down to both `PageResults` _and_ `AppLayoutWithSidebar`.

---

This change felt a little clunky as it apparently touches a number of areas, you'll see a good chunk of the diff is just shuffling things around; please do let me know if you see anything that feels like it could be refactored.

Also, while I'm following a pattern of passing props down, I'm starting to think using Context might be beneficial for things like analysis and review. If others agree I'll make an issue and throw it into the Maintenance tag.