### PR TITLE
    fix #3747 feat(nimbus): save probesets

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/FormMetrics/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/FormMetrics/index.test.tsx
@@ -112,16 +112,19 @@ describe("FormMetrics", () => {
         },
       ],
     });
-
-    render(<Subject {...{ experiment: data }} />);
+    render(<Subject {...{ experiment: data, probeSets }} />);
 
     const secondaryProbeSets = screen.getByTestId("secondary-probe-sets");
     expect(secondaryProbeSets).toHaveTextContent("Probe Set A");
   });
 
   it("selects a primary probe set and excludes it from secondary probe sets", async () => {
-    render(<Subject {...{ probeSets }} />);
+    const { data } = mockExperimentQuery("boo", {
+      primaryProbeSets: [],
+      secondaryProbeSets: [],
+    });
 
+    render(<Subject {...{ experiment: data, probeSets }} />);
     const primaryProbeSets = screen.getByTestId("primary-probe-sets");
     const secondaryProbeSets = screen.getByTestId("secondary-probe-sets");
 
@@ -148,7 +151,12 @@ describe("FormMetrics", () => {
   });
 
   it("selects a secondary probe set and excludes it from primary probe sets", async () => {
-    render(<Subject {...{ probeSets }} />);
+    const { data } = mockExperimentQuery("boo", {
+      primaryProbeSets: [],
+      secondaryProbeSets: [],
+    });
+
+    render(<Subject {...{ experiment: data, probeSets }} />);
 
     const primaryProbeSets = screen.getByTestId("primary-probe-sets");
     const secondaryProbeSets = screen.getByTestId("secondary-probe-sets");
@@ -176,7 +184,10 @@ describe("FormMetrics", () => {
   });
 
   it("allows maximum 2 primary probe sets", async () => {
-    const { data } = mockExperimentQuery("boo", { primaryProbeSets: [] });
+    const { data } = mockExperimentQuery("boo", {
+      primaryProbeSets: [],
+      secondaryProbeSets: [],
+    });
 
     render(<Subject {...{ experiment: data, probeSets }} />);
 

--- a/app/experimenter/nimbus-ui/src/components/FormMetrics/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/FormMetrics/index.tsx
@@ -20,7 +20,7 @@ type FormMetricsProps = {
   isServerValid: boolean;
   submitErrors: Record<string, string[]>;
   onSave: (data: Record<string, any>, reset: Function) => void;
-  onNext?: (ev: React.FormEvent) => void;
+  onNext: (ev: React.FormEvent) => void;
 };
 
 const FormMetrics = ({
@@ -38,11 +38,13 @@ const FormMetrics = ({
   const { isSubmitted, isDirty } = formState;
   const [selectedPrimaryProbeSetIds, setSelectedPrimaryProbeSetIds] = useState<
     string[]
-  >([]);
+  >(experiment?.primaryProbeSets?.map((p) => p?.id as string) || []);
   const [
     selectedSecondaryProbeSetsIds,
     setselectedSecondaryProbeSetsIds,
-  ] = useState<string[]>([]);
+  ] = useState<string[]>(
+    experiment?.secondaryProbeSets?.map((p) => p?.id as string) || [],
+  );
 
   const isValid = isServerValid && formState.isValid;
   const isDirtyUnsaved = isDirty && !(isValid && isSubmitted);
@@ -52,13 +54,22 @@ const FormMetrics = ({
     shouldWarnOnExit(isDirtyUnsaved);
   }, [shouldWarnOnExit, isDirtyUnsaved]);
 
-  const handleSubmitAfterValidation = useCallback(
-    (data: Record<string, any>) => {
-      if (isLoading) return;
-      onSave(data, reset);
-    },
-    [isLoading, onSave, reset],
-  );
+  const handleSubmitAfterValidation = useCallback(() => {
+    if (isLoading) return;
+    onSave(
+      {
+        primaryProbeSetIds: selectedPrimaryProbeSetIds,
+        secondaryProbeSetIds: selectedSecondaryProbeSetsIds,
+      },
+      reset,
+    );
+  }, [
+    isLoading,
+    onSave,
+    reset,
+    selectedPrimaryProbeSetIds,
+    selectedSecondaryProbeSetsIds,
+  ]);
 
   const handleNext = useCallback(
     (ev: React.FormEvent) => {
@@ -175,7 +186,7 @@ const FormMetrics = ({
               onClick={handleNext}
               className="btn btn-secondary"
               disabled={isLoading}
-              data-sb-kind="pages/EditBranches"
+              data-sb-kind="pages/EditMetrics"
             >
               Next
             </button>

--- a/app/experimenter/nimbus-ui/src/components/PageEditMetrics/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditMetrics/index.test.tsx
@@ -3,46 +3,171 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React from "react";
-import { screen, render, waitFor, fireEvent } from "@testing-library/react";
+import {
+  screen,
+  waitFor,
+  render,
+  fireEvent,
+  act,
+} from "@testing-library/react";
 import PageEditMetrics from ".";
+import FormMetrics from "../FormMetrics";
 import { RouterSlugProvider } from "../../lib/test-utils";
-import { mockExperimentQuery } from "../../lib/mocks";
+import { mockExperimentMutation, mockExperimentQuery } from "../../lib/mocks";
+import { MockedResponse } from "@apollo/client/testing";
+import { navigate } from "@reach/router";
+import { UPDATE_EXPERIMENT_PROBESETS_MUTATION } from "../../gql/experiments";
+import { SUBMIT_ERROR } from "../../lib/constants";
 
-const { mock } = mockExperimentQuery("demo-slug");
+const { mock, data } = mockExperimentQuery("demo-slug");
+
+jest.mock("@reach/router", () => ({
+  ...jest.requireActual("@reach/router"),
+  navigate: jest.fn(),
+}));
+
+let mockSubmitData: Record<string, number | number[]> = {};
+const mockSubmit = jest.fn();
 
 describe("PageEditMetrics", () => {
+  let mutationMock: any;
+
+  const Subject = ({
+    mocks = [],
+  }: {
+    mocks?: MockedResponse<Record<string, any>>[];
+  }) => {
+    return (
+      <RouterSlugProvider {...{ mocks }}>
+        <PageEditMetrics />
+      </RouterSlugProvider>
+    );
+  };
+
+  beforeEach(() => {
+    mockSubmitData = {
+      nimbusExperimentId: parseInt(data!.id),
+      primaryProbeSetIds: data!.primaryProbeSets!.map((p) => parseInt(p!.id)),
+      secondaryProbeSetIds: data!.secondaryProbeSets!.map((p) =>
+        parseInt(p!.id),
+      ),
+    };
+    const mockResponse = {
+      experiment: {
+        id: data!.id,
+        primaryProbeSets: data!.primaryProbeSets!.map((p) => ({
+          id: p?.id,
+          name: p?.name,
+        })),
+        secondaryProbeSets: data!.secondaryProbeSets!.map((p) => ({
+          id: p?.id,
+          name: p?.name,
+        })),
+      },
+    };
+
+    mutationMock = mockExperimentMutation(
+      UPDATE_EXPERIMENT_PROBESETS_MUTATION,
+      mockSubmitData,
+      "updateExperimentProbeSets",
+      mockResponse,
+    );
+  });
+
   it("renders as expected", async () => {
-    render(
-      <RouterSlugProvider mocks={[mock]}>
-        <PageEditMetrics />
-      </RouterSlugProvider>,
-    );
+    render(<Subject mocks={[mock]} />);
     await waitFor(() => {
-      expect(screen.queryByTestId("PageEditMetrics")).toBeInTheDocument();
+      expect(screen.getByTestId("PageEditMetrics")).toBeInTheDocument();
+      expect(screen.getByTestId("header-experiment")).toBeInTheDocument();
     });
   });
 
-  it("does nothing on Save", async () => {
-    render(
-      <RouterSlugProvider mocks={[mock]}>
-        <PageEditMetrics />
-      </RouterSlugProvider>,
-    );
+  it("handles form submission", async () => {
+    render(<Subject mocks={[mock, mutationMock]} />);
+
+    let submitButton: HTMLButtonElement;
     await waitFor(() => {
-      expect(screen.queryByTestId("PageEditMetrics")).toBeInTheDocument();
+      submitButton = screen.getByTestId("submit") as HTMLButtonElement;
     });
-    fireEvent.click(screen.getByText("Save"));
+    await act(async () => {
+      fireEvent.click(submitButton);
+    });
+    expect(mockSubmit).toHaveBeenCalled();
   });
 
-  it("does nothing on Next", async () => {
-    render(
-      <RouterSlugProvider mocks={[mock]}>
-        <PageEditMetrics />
-      </RouterSlugProvider>,
-    );
+  it("handles experiment form submission with bad server data", async () => {
+    // @ts-ignore - intentionally breaking this type for error handling
+    delete mutationMock.result.data.updateExperimentProbeSets;
+    render(<Subject mocks={[mock, mutationMock]} />);
+    let submitButton: HTMLButtonElement;
     await waitFor(() => {
-      expect(screen.queryByTestId("PageEditMetrics")).toBeInTheDocument();
+      submitButton = screen.getByTestId("submit") as HTMLButtonElement;
     });
-    fireEvent.click(screen.getByText("Next"));
+    await act(async () => {
+      fireEvent.click(submitButton);
+    });
+    expect(screen.getByTestId("submitErrors")).toHaveTextContent(
+      JSON.stringify({ "*": SUBMIT_ERROR }),
+    );
+  });
+
+  it("handles experiment form submission with server API error", async () => {
+    mutationMock.result.errors = [new Error("an error")];
+    render(<Subject mocks={[mock, mutationMock]} />);
+    let submitButton: HTMLButtonElement;
+    await waitFor(() => {
+      submitButton = screen.getByTestId("submit") as HTMLButtonElement;
+    });
+    await act(async () => {
+      fireEvent.click(submitButton);
+    });
+    expect(screen.getByTestId("submitErrors")).toHaveTextContent(
+      JSON.stringify({ "*": SUBMIT_ERROR }),
+    );
+  });
+
+  it("handles server validation error", async () => {
+    mutationMock.result.data.updateExperimentProbeSets.message = {
+      primaryProbeSets: ["Bad probe sets"],
+    };
+    render(<Subject mocks={[mock, mutationMock]} />);
+    let submitButton: HTMLButtonElement;
+    await waitFor(() => {
+      submitButton = screen.getByTestId("submit") as HTMLButtonElement;
+    });
+    await act(async () => {
+      fireEvent.click(submitButton);
+    });
+  });
+
+  it("handles form next button", async () => {
+    render(<Subject mocks={[mock]} />);
+    await waitFor(() => fireEvent.click(screen.getByTestId("next")));
+    expect(navigate).toHaveBeenCalledWith("audience");
   });
 });
+
+// Mocking form component because validation is exercised in its own tests.
+jest.mock("../FormMetrics", () => ({
+  __esModule: true,
+  default: (props: React.ComponentProps<typeof FormMetrics>) => {
+    const handleSubmit = (ev: React.FormEvent) => {
+      ev.preventDefault();
+      mockSubmit();
+      props.onSave(mockSubmitData, jest.fn());
+    };
+    const handleNext = (ev: React.FormEvent) => {
+      ev.preventDefault();
+      props.onNext && props.onNext(ev);
+    };
+    return (
+      <div data-testid="FormMetrics">
+        <div data-testid="submitErrors">
+          {JSON.stringify(props.submitErrors)}
+        </div>
+        <button data-testid="submit" onClick={handleSubmit} />
+        <button data-testid="next" onClick={handleNext} />
+      </div>
+    );
+  },
+}));

--- a/app/experimenter/nimbus-ui/src/components/PageEditMetrics/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditMetrics/index.tsx
@@ -2,41 +2,107 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from "react";
-import { RouteComponentProps } from "@reach/router";
+import { navigate, RouteComponentProps } from "@reach/router";
+import { useMutation } from "@apollo/client";
+import React, { useState, useRef, useCallback } from "react";
+
+import { getExperiment_experimentBySlug } from "../../types/getExperiment";
+import { SUBMIT_ERROR } from "../../lib/constants";
+import { UPDATE_EXPERIMENT_PROBESETS_MUTATION } from "../../gql/experiments";
+import { updateExperimentProbeSets_updateExperimentProbeSets as UpdateExperimentProbeSetsResult } from "../../types/updateExperimentProbeSets";
+import { UpdateExperimentProbeSetsInput } from "../../types/globalTypes";
+import { useConfig } from "../../hooks/useConfig";
 import AppLayoutWithExperiment from "../AppLayoutWithExperiment";
 import FormMetrics from "../FormMetrics";
 import LinkExternal from "../LinkExternal";
-import { useConfig } from "../../hooks/useConfig";
 
 const PageEditMetrics: React.FunctionComponent<RouteComponentProps> = () => {
   const { probeSets } = useConfig();
 
+  const [updateExperimentProbeSets, { loading }] = useMutation<
+    { updateExperimentProbeSets: UpdateExperimentProbeSetsResult },
+    { input: UpdateExperimentProbeSetsInput }
+  >(UPDATE_EXPERIMENT_PROBESETS_MUTATION);
+
+  const [submitErrors, setSubmitErrors] = useState<Record<string, any>>({});
+  const currentExperiment = useRef<getExperiment_experimentBySlug>();
+  const refetchReview = useRef<() => void>();
+  const [isServerValid, setIsServerValid] = useState(true);
+
+  const onSave = useCallback(
+    async ({
+      primaryProbeSetIds,
+      secondaryProbeSetIds,
+    }: Record<string, number[]>) => {
+      try {
+        const nimbusExperimentId = parseInt(currentExperiment.current!.id, 10);
+        const result = await updateExperimentProbeSets({
+          variables: {
+            input: {
+              nimbusExperimentId,
+              primaryProbeSetIds,
+              secondaryProbeSetIds,
+            },
+          },
+        });
+
+        if (!result.data?.updateExperimentProbeSets) {
+          throw new Error("Save failed, no error available");
+        }
+
+        const { message } = result.data.updateExperimentProbeSets;
+
+        if (message && message !== "success" && typeof message === "object") {
+          setIsServerValid(false);
+          return void setSubmitErrors(message);
+        } else {
+          setIsServerValid(true);
+          setSubmitErrors({});
+          // In practice this should be defined by the time we get here
+          refetchReview.current!();
+        }
+      } catch (error) {
+        setSubmitErrors({ "*": SUBMIT_ERROR });
+      }
+    },
+    [updateExperimentProbeSets, currentExperiment],
+  );
+
+  const onNext = useCallback(() => {
+    navigate(`audience`);
+  }, []);
+
   return (
     <AppLayoutWithExperiment title="Metrics" testId="PageEditMetrics">
-      {({ experiment }) => (
-        <>
-          <p>
-            Every experiment analysis automatically includes how your experiment
-            has impacted <strong>Retention, Search Count, and Ad Click</strong>{" "}
-            metrics. Get more information on{" "}
-            {/* TODO Requires url https://jira.mozilla.com/browse/EXP-656 */}
-            <LinkExternal href="">Core Firefox Metrics.</LinkExternal>
-          </p>
-          <FormMetrics
-            {...{
-              experiment,
-              probeSets,
-              isLoading: false,
-              isServerValid: true,
-              submitErrors: {},
-              /* TODO: EXP-505 for accepting and saving edits to branches */
-              onSave: async (update) => console.log("SAVE", update),
-              onNext: () => console.log("NEXT"),
-            }}
-          />
-        </>
-      )}
+      {({ experiment, review }) => {
+        currentExperiment.current = experiment;
+        refetchReview.current = review.refetch;
+
+        return (
+          <>
+            <p>
+              Every experiment analysis automatically includes how your
+              experiment has impacted{" "}
+              <strong>Retention, Search Count, and Ad Click</strong> metrics.
+              Get more information on{" "}
+              {/* TODO Requires url https://jira.mozilla.com/browse/EXP-656 */}
+              <LinkExternal href="">Core Firefox Metrics.</LinkExternal>
+            </p>
+            <FormMetrics
+              {...{
+                experiment,
+                probeSets,
+                isLoading: loading,
+                isServerValid,
+                submitErrors,
+                /* TODO: EXP-505 for accepting and saving edits to branches */
+                onSave,
+                onNext,
+              }}
+            />
+          </>
+        );
+      }}
     </AppLayoutWithExperiment>
   );
 };

--- a/app/experimenter/nimbus-ui/src/gql/experiments.ts
+++ b/app/experimenter/nimbus-ui/src/gql/experiments.ts
@@ -74,6 +74,27 @@ export const UPDATE_EXPERIMENT_BRANCHES_MUTATION = gql`
   }
 `;
 
+export const UPDATE_EXPERIMENT_PROBESETS_MUTATION = gql`
+  mutation updateExperimentProbeSets($input: UpdateExperimentProbeSetsInput!) {
+    updateExperimentProbeSets(input: $input) {
+      clientMutationId
+      nimbusExperiment {
+        id
+        primaryProbeSets {
+          id
+          name
+        }
+        secondaryProbeSets {
+          id
+          name
+        }
+      }
+      message
+      status
+    }
+  }
+`;
+
 export const GET_EXPERIMENT_QUERY = gql`
   query getExperiment($slug: String!) {
     experimentBySlug(slug: $slug) {

--- a/app/experimenter/nimbus-ui/src/lib/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/lib/mocks.tsx
@@ -282,6 +282,7 @@ export const mockExperimentQuery = (
             primaryProbeSets: [
               {
                 __typename: "NimbusProbeSetType",
+                id: "1",
                 slug: "picture_in_picture",
                 name: "Picture-in-Picture",
               },
@@ -289,6 +290,7 @@ export const mockExperimentQuery = (
             secondaryProbeSets: [
               {
                 __typename: "NimbusProbeSetType",
+                id: "2",
                 slug: "feature_b",
                 name: "Feature B",
               },
@@ -331,7 +333,7 @@ export const mockExperimentQuery = (
 
 export const mockExperimentMutation = (
   mutation: DocumentNode,
-  input: Record<string, string | number>,
+  input: Record<string, string | number | string[] | number[]>,
   key: string,
   {
     status = 200,

--- a/app/experimenter/nimbus-ui/src/types/globalTypes.ts
+++ b/app/experimenter/nimbus-ui/src/types/globalTypes.ts
@@ -111,6 +111,13 @@ export interface UpdateExperimentInput {
   publicDescription?: string | null;
 }
 
+export interface UpdateExperimentProbeSetsInput {
+  clientMutationId?: string | null;
+  nimbusExperimentId: number;
+  primaryProbeSetIds: (number | null)[];
+  secondaryProbeSetIds: (number | null)[];
+}
+
 export interface UpdateExperimentStatusInput {
   clientMutationId?: string | null;
   nimbusExperimentId: number;

--- a/app/experimenter/nimbus-ui/src/types/updateExperimentProbeSets.ts
+++ b/app/experimenter/nimbus-ui/src/types/updateExperimentProbeSets.ts
@@ -1,0 +1,45 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+import { UpdateExperimentProbeSetsInput } from "./globalTypes";
+
+// ====================================================
+// GraphQL mutation operation: updateExperimentProbeSets
+// ====================================================
+
+export interface updateExperimentProbeSets_updateExperimentProbeSets_nimbusExperiment_primaryProbeSets {
+  __typename: "NimbusProbeSetType";
+  id: string;
+  name: string;
+}
+
+export interface updateExperimentProbeSets_updateExperimentProbeSets_nimbusExperiment_secondaryProbeSets {
+  __typename: "NimbusProbeSetType";
+  id: string;
+  name: string;
+}
+
+export interface updateExperimentProbeSets_updateExperimentProbeSets_nimbusExperiment {
+  __typename: "NimbusExperimentType";
+  id: string;
+  primaryProbeSets: (updateExperimentProbeSets_updateExperimentProbeSets_nimbusExperiment_primaryProbeSets | null)[] | null;
+  secondaryProbeSets: (updateExperimentProbeSets_updateExperimentProbeSets_nimbusExperiment_secondaryProbeSets | null)[] | null;
+}
+
+export interface updateExperimentProbeSets_updateExperimentProbeSets {
+  __typename: "UpdateExperimentProbeSets";
+  clientMutationId: string | null;
+  nimbusExperiment: updateExperimentProbeSets_updateExperimentProbeSets_nimbusExperiment | null;
+  message: ObjectField | null;
+  status: number | null;
+}
+
+export interface updateExperimentProbeSets {
+  updateExperimentProbeSets: updateExperimentProbeSets_updateExperimentProbeSets | null;
+}
+
+export interface updateExperimentProbeSetsVariables {
+  input: UpdateExperimentProbeSetsInput;
+}


### PR DESCRIPTION
    fix #3747 feat(nimbus): save probesets
    
    Because
    
    * We want to save the probe sets in the metrics form to the server
    
    This commit
    
    * Hooks up the mutation in PageEditMetrics
    * Adds tests