### PR TITLE
fix #3833, #3704, #4015 feat(nimbus) Summary table tweaks, create Audience table

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/PageRequestReview/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageRequestReview/index.tsx
@@ -6,7 +6,6 @@ import React, { useCallback, useRef, useState } from "react";
 import { useMutation } from "@apollo/client";
 import { RouteComponentProps } from "@reach/router";
 import AppLayoutWithExperiment from "../AppLayoutWithExperiment";
-import TableSummary from "../TableSummary";
 import { SUBMIT_ERROR } from "../../lib/constants";
 import { UPDATE_EXPERIMENT_STATUS_MUTATION } from "../../gql/experiments";
 import {
@@ -16,6 +15,7 @@ import {
 import { updateExperimentStatus_updateExperimentStatus as UpdateExperimentStatus } from "../../types/updateExperimentStatus";
 import { getExperiment_experimentBySlug } from "../../types/getExperiment";
 import FormRequestReview from "../FormRequestReview";
+import Summary from "../Summary";
 
 type PageRequestReviewProps = {
   polling?: boolean;
@@ -71,7 +71,7 @@ const PageRequestReview: React.FunctionComponent<PageRequestReviewProps> = ({
 
         return (
           <>
-            <TableSummary {...{ experiment }} />
+            <Summary {...{ experiment }} />
 
             {![
               NimbusExperimentStatus.REVIEW,

--- a/app/experimenter/nimbus-ui/src/components/PageResults/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/index.test.tsx
@@ -53,6 +53,10 @@ describe("PageResults", () => {
     expect(screen.queryByTestId("table-results")).toBeInTheDocument();
     expect(screen.queryByTestId("table-metric-primary")).toBeInTheDocument();
     expect(screen.queryByTestId("table-metric-secondary")).toBeInTheDocument();
+    expect(screen.queryByTestId("link-external-results")).toHaveAttribute(
+      "href",
+      "https://protosaur.dev/partybal/demo_slug.html",
+    );
   });
 
   it("displays the monitoring dashboard link", async () => {
@@ -77,6 +81,7 @@ describe("PageResults", () => {
       expect(screen.queryByTestId("PageResults")).toBeInTheDocument();
     });
     expect(screen.queryByTestId("analysis-error")).toBeInTheDocument();
+    expect(screen.queryByTestId("summary")).toBeInTheDocument();
   });
 
   it("displays analysis loading", async () => {
@@ -103,10 +108,8 @@ describe("PageResults", () => {
     await waitFor(() => {
       expect(screen.queryByTestId("PageResults")).toBeInTheDocument();
     });
-    expect(screen.queryByTestId("table-summary")).toBeInTheDocument();
-    expect(screen.queryByTestId("link-external-results")).toHaveAttribute(
-      "href",
-      "https://protosaur.dev/partybal/demo_slug.html",
-    );
+
+    expect(screen.queryByTestId("analysis-unavailable")).toBeInTheDocument();
+    expect(screen.queryByTestId("summary")).toBeInTheDocument();
   });
 });

--- a/app/experimenter/nimbus-ui/src/components/PageResults/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/index.tsx
@@ -9,13 +9,13 @@ import { useAnalysis } from "../../hooks";
 import { Alert } from "react-bootstrap";
 import { getExperiment_experimentBySlug } from "../../types/getExperiment";
 import LinkExternal from "../LinkExternal";
-import TableSummary from "../TableSummary";
 import TableResults from "../TableResults";
 import TableHighlights from "../TableHighlights";
-import TableOverview from "../TableOverview";
+import TableHighlightsOverview from "../TableHighlightsOverview";
 import TableMetricPrimary from "../TableMetricPrimary";
 import TableMetricSecondary from "../TableMetricSecondary";
 import { AnalysisData } from "../../lib/visualization/types";
+import Summary from "../Summary";
 
 const PageResults: React.FunctionComponent<RouteComponentProps> = () => {
   const { slug } = useParams();
@@ -39,13 +39,10 @@ const PageResults: React.FunctionComponent<RouteComponentProps> = () => {
                 </LinkExternal>{" "}
                 to view the live monitoring dashboard.
               </p>
-              <h3 className="h5 mb-3 mt-4">Overview</h3>
-
-              {error && <AnalysisFetchError />}
               {analysis?.show_analysis ? (
                 <AnalysisAvailable {...{ experiment, analysis }} />
               ) : (
-                <AnalysisUnavailable {...{ experiment }} />
+                <AnalysisUnavailable {...{ experiment, error }} />
               )}
             </>
           )}
@@ -55,73 +52,19 @@ const PageResults: React.FunctionComponent<RouteComponentProps> = () => {
   );
 };
 
-const AnalysisFetchError = () => (
-  <Alert data-testid="analysis-error" variant="warning">
-    Could not load experiment analysis data. Please contact data science in{" "}
-    <LinkExternal href="https://mozilla.slack.com/archives/C0149JH7C1M">
-      #cirrus
-    </LinkExternal>{" "}
-    about this.
-  </Alert>
-);
-
 const AnalysisAvailable = ({
   experiment,
   analysis,
 }: {
   experiment: getExperiment_experimentBySlug;
   analysis: AnalysisData | undefined;
-}) => (
-  <>
-    <h3 className="h6">Hypothesis</h3>
-    <p>{experiment.hypothesis}</p>
-    <TableHighlights
-      primaryProbeSets={experiment.primaryProbeSets!}
-      results={analysis?.overall!}
-    />
-    <TableOverview {...{ experiment }} results={analysis?.overall!} />
-
-    <h2 className="h5 mb-3">Results</h2>
-    <TableResults
-      primaryProbeSets={experiment.primaryProbeSets!}
-      results={analysis?.overall!}
-    />
-    <div>
-      {experiment.primaryProbeSets?.length &&
-        experiment.primaryProbeSets.map((probeSet) => (
-          <TableMetricPrimary
-            key={probeSet?.slug}
-            results={analysis?.overall!}
-            probeSet={probeSet!}
-          />
-        ))}
-      {experiment.secondaryProbeSets?.length &&
-        experiment.secondaryProbeSets.map((probeSet) => (
-          <TableMetricSecondary
-            key={probeSet?.slug}
-            results={analysis?.overall!}
-            probeSet={probeSet!}
-          />
-        ))}
-    </div>
-  </>
-);
-
-const AnalysisUnavailable = ({
-  experiment,
-}: {
-  experiment: getExperiment_experimentBySlug;
 }) => {
   const slugUnderscored = experiment.slug.replace(/-/g, "_");
   return (
     <>
-      <TableSummary {...{ experiment }} />
-      <p>
-        The results will be available 7 days after the experiment is launched.
-        An email will be sent to you once we start recording data.
-      </p>
-      <p>
-        The results{" "}
+      <h3 className="h5 mb-3 mt-4">Overview</h3>
+      <p className="mb-4">
+        Detailed analysis{" "}
         <LinkExternal
           href={`https://protosaur.dev/partybal/${slugUnderscored}.html`}
           data-testid="link-external-results"
@@ -130,8 +73,78 @@ const AnalysisUnavailable = ({
         </LinkExternal>
         .
       </p>
+      <h3 className="h6">Hypothesis</h3>
+      <p>{experiment.hypothesis}</p>
+      <TableHighlights
+        primaryProbeSets={experiment.primaryProbeSets!}
+        results={analysis?.overall!}
+      />
+      <TableHighlightsOverview
+        {...{ experiment }}
+        results={analysis?.overall!}
+      />
+
+      <h2 className="h5 mb-3">Results</h2>
+      <TableResults
+        primaryProbeSets={experiment.primaryProbeSets!}
+        results={analysis?.overall!}
+      />
+      <div>
+        {experiment.primaryProbeSets?.length &&
+          experiment.primaryProbeSets.map((probeSet) => (
+            <TableMetricPrimary
+              key={probeSet?.slug}
+              results={analysis?.overall!}
+              probeSet={probeSet!}
+            />
+          ))}
+        {experiment.secondaryProbeSets?.length &&
+          experiment.secondaryProbeSets.map((probeSet) => (
+            <TableMetricSecondary
+              key={probeSet?.slug}
+              results={analysis?.overall!}
+              probeSet={probeSet!}
+            />
+          ))}
+      </div>
     </>
   );
 };
+
+const AlertError = () => (
+  <Alert data-testid="analysis-error" variant="warning" className="my-4">
+    Could not load experiment analysis data. Please contact data science in{" "}
+    <LinkExternal href="https://mozilla.slack.com/archives/C0149JH7C1M">
+      #cirrus
+    </LinkExternal>{" "}
+    about this.
+  </Alert>
+);
+
+const AlertUnavailable = () => (
+  <Alert data-testid="analysis-unavailable" variant="warning" className="my-4">
+    <p>
+      <strong>The analysis is not yet available.</strong>
+    </p>
+    <p className="mb-0">
+      {" "}
+      The results will be available 7 days after the experiment is launched. An
+      email will be sent to you once we start recording data.
+    </p>
+  </Alert>
+);
+
+const AnalysisUnavailable = ({
+  experiment,
+  error,
+}: {
+  experiment: getExperiment_experimentBySlug;
+  error: Error | undefined;
+}) => (
+  <>
+    {error ? <AlertError /> : <AlertUnavailable />}
+    <Summary {...{ experiment }} />
+  </>
+);
 
 export default PageResults;

--- a/app/experimenter/nimbus-ui/src/components/PageResults/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/index.tsx
@@ -90,22 +90,20 @@ const AnalysisAvailable = ({
         results={analysis?.overall!}
       />
       <div>
-        {experiment.primaryProbeSets?.length &&
-          experiment.primaryProbeSets.map((probeSet) => (
-            <TableMetricPrimary
-              key={probeSet?.slug}
-              results={analysis?.overall!}
-              probeSet={probeSet!}
-            />
-          ))}
-        {experiment.secondaryProbeSets?.length &&
-          experiment.secondaryProbeSets.map((probeSet) => (
-            <TableMetricSecondary
-              key={probeSet?.slug}
-              results={analysis?.overall!}
-              probeSet={probeSet!}
-            />
-          ))}
+        {experiment.primaryProbeSets?.map((probeSet) => (
+          <TableMetricPrimary
+            key={probeSet?.slug}
+            results={analysis?.overall!}
+            probeSet={probeSet!}
+          />
+        ))}
+        {experiment.secondaryProbeSets?.map((probeSet) => (
+          <TableMetricSecondary
+            key={probeSet?.slug}
+            results={analysis?.overall!}
+            probeSet={probeSet!}
+          />
+        ))}
       </div>
     </>
   );

--- a/app/experimenter/nimbus-ui/src/components/PageSummary/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageSummary/index.tsx
@@ -5,8 +5,7 @@
 import React from "react";
 import { RouteComponentProps } from "@reach/router";
 import AppLayoutWithExperiment from "../AppLayoutWithExperiment";
-import TableSummary from "../TableSummary";
-import SummaryTimeline from "../SummaryTimeline";
+import Summary from "../Summary";
 
 type PageRequestReviewProps = {
   polling?: boolean;
@@ -20,15 +19,7 @@ const PageSummary: React.FunctionComponent<PageRequestReviewProps> = ({
     sidebar={false}
     {...{ polling }}
   >
-    {({ experiment }) => (
-      <>
-        <h2 className="h5 mb-3">Timeline</h2>
-        <SummaryTimeline {...{ experiment }} />
-
-        <h2 className="h5 mb-3">Summary</h2>
-        <TableSummary {...{ experiment }} />
-      </>
-    )}
+    {({ experiment }) => <Summary {...{ experiment }} />}
   </AppLayoutWithExperiment>
 );
 

--- a/app/experimenter/nimbus-ui/src/components/Summary/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/index.stories.tsx
@@ -1,0 +1,37 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from "react";
+import { storiesOf } from "@storybook/react";
+import { mockExperimentQuery } from "../../lib/mocks";
+import AppLayout from "../AppLayout";
+import Summary from ".";
+import { RouterSlugProvider } from "../../lib/test-utils";
+import { NimbusExperimentStatus } from "../../types/globalTypes";
+
+storiesOf("components/Summary", module)
+  .add("draft status", () => {
+    const { data } = mockExperimentQuery("demo-slug");
+    return (
+      <Subject>
+        <Summary experiment={data!} />
+      </Subject>
+    );
+  })
+  .add("non-draft status", () => {
+    const { data } = mockExperimentQuery("demo-slug", {
+      status: NimbusExperimentStatus.ACCEPTED,
+    });
+    return (
+      <Subject>
+        <Summary experiment={data!} />
+      </Subject>
+    );
+  });
+
+const Subject = ({ children }: { children: React.ReactElement }) => (
+  <AppLayout>
+    <RouterSlugProvider>{children}</RouterSlugProvider>
+  </AppLayout>
+);

--- a/app/experimenter/nimbus-ui/src/components/Summary/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/index.stories.tsx
@@ -9,29 +9,28 @@ import AppLayout from "../AppLayout";
 import Summary from ".";
 import { RouterSlugProvider } from "../../lib/test-utils";
 import { NimbusExperimentStatus } from "../../types/globalTypes";
+import { getExperiment_experimentBySlug } from "../../types/getExperiment";
 
 storiesOf("components/Summary", module)
   .add("draft status", () => {
     const { data } = mockExperimentQuery("demo-slug");
-    return (
-      <Subject>
-        <Summary experiment={data!} />
-      </Subject>
-    );
+    return <Subject experiment={data!} />;
   })
   .add("non-draft status", () => {
     const { data } = mockExperimentQuery("demo-slug", {
       status: NimbusExperimentStatus.ACCEPTED,
     });
-    return (
-      <Subject>
-        <Summary experiment={data!} />
-      </Subject>
-    );
+    return <Subject experiment={data!} />;
   });
 
-const Subject = ({ children }: { children: React.ReactElement }) => (
+const Subject = ({
+  experiment,
+}: {
+  experiment: getExperiment_experimentBySlug;
+}) => (
   <AppLayout>
-    <RouterSlugProvider>{children}</RouterSlugProvider>
+    <RouterSlugProvider>
+      <Summary {...{ experiment }} />
+    </RouterSlugProvider>
   </AppLayout>
 );

--- a/app/experimenter/nimbus-ui/src/components/Summary/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/index.test.tsx
@@ -1,0 +1,50 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { MockedCache, mockExperimentQuery } from "../../lib/mocks";
+import { getExperiment_experimentBySlug } from "../../types/getExperiment";
+import Summary from ".";
+import { NimbusExperimentStatus } from "../../types/globalTypes";
+
+describe("Summary", () => {
+  it("renders expected components", () => {
+    const { data } = mockExperimentQuery("demo-slug");
+    render(<Subject experiment={data!} />);
+    expect(screen.getByTestId("summary-timeline")).toBeInTheDocument();
+    expect(screen.getByTestId("table-summary")).toBeInTheDocument();
+    expect(screen.getByTestId("table-audience")).toBeInTheDocument();
+  });
+
+  describe("JSON representation link", () => {
+    it("renders in non-draft status", () => {
+      const { data } = mockExperimentQuery("demo-slug", {
+        status: NimbusExperimentStatus.COMPLETE,
+      });
+      render(<Subject experiment={data!} />);
+      expect(screen.getByTestId("link-json")).toBeInTheDocument();
+      expect(screen.getByTestId("link-json")).toHaveAttribute(
+        "href",
+        "https://experimenter.services.mozilla.com/api/v6/experiments/demo-slug/",
+      );
+    });
+  });
+
+  it("does not render in draft status", () => {
+    const { data } = mockExperimentQuery("demo-slug");
+    render(<Subject experiment={data!} />);
+    expect(screen.queryByTestId("link-json")).not.toBeInTheDocument();
+  });
+});
+
+const Subject = ({
+  experiment,
+}: {
+  experiment: getExperiment_experimentBySlug;
+}) => (
+  <MockedCache>
+    <Summary {...{ experiment }} />
+  </MockedCache>
+);

--- a/app/experimenter/nimbus-ui/src/components/Summary/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/index.test.tsx
@@ -27,7 +27,7 @@ describe("Summary", () => {
       expect(screen.getByTestId("link-json")).toBeInTheDocument();
       expect(screen.getByTestId("link-json")).toHaveAttribute(
         "href",
-        "https://experimenter.services.mozilla.com/api/v6/experiments/demo-slug/",
+        "/api/v6/experiments/demo-slug/",
       );
     });
   });

--- a/app/experimenter/nimbus-ui/src/components/Summary/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/index.tsx
@@ -1,0 +1,67 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from "react";
+import { getExperiment_experimentBySlug } from "../../types/getExperiment";
+import { getConfig_nimbusConfig } from "../../types/getConfig";
+import SummaryTimeline from "../SummaryTimeline";
+import TableSummary from "../TableSummary";
+import TableAudience from "../TableAudience";
+import LinkExternal from "../LinkExternal";
+import { NimbusExperimentStatus } from "../../types/globalTypes";
+
+type SummaryProps = {
+  experiment: getExperiment_experimentBySlug;
+};
+
+const Summary = ({ experiment }: SummaryProps) => (
+  <div data-testid="summary">
+    <h2 className="h5 mb-3">Timeline</h2>
+    <SummaryTimeline {...{ experiment }} />
+
+    <div className="d-flex flex-row justify-content-between">
+      <h2 className="h5 mb-3">Summary</h2>
+      {experiment.status !== NimbusExperimentStatus.DRAFT && (
+        <span>
+          <LinkExternal
+            href={`https://experimenter.services.mozilla.com/api/v6/experiments/${experiment.slug}/`}
+            data-testid="link-json"
+          >
+            See full JSON representation
+          </LinkExternal>
+        </span>
+      )}
+    </div>
+    <TableSummary {...{ experiment }} />
+
+    <h2 className="h5 mb-3">Audience</h2>
+    <TableAudience {...{ experiment }} />
+  </div>
+);
+
+type displayConfigOptionsProps =
+  | getConfig_nimbusConfig["application"]
+  | getConfig_nimbusConfig["firefoxMinVersion"]
+  | getConfig_nimbusConfig["channels"]
+  | getConfig_nimbusConfig["targetingConfigSlug"];
+
+export const displayConfigLabelOrNotSet = (
+  value: string | null,
+  options: displayConfigOptionsProps,
+) => {
+  if (!value) return <NotSet />;
+  return options?.find((obj: any) => obj.value === value)?.label;
+};
+
+export const NotSet = ({
+  "data-testid": testid = "not-set",
+}: {
+  "data-testid"?: string;
+}) => (
+  <span className="text-danger" data-testid={testid}>
+    Not set
+  </span>
+);
+
+export default Summary;

--- a/app/experimenter/nimbus-ui/src/components/Summary/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/index.tsx
@@ -25,7 +25,7 @@ const Summary = ({ experiment }: SummaryProps) => (
       {experiment.status !== NimbusExperimentStatus.DRAFT && (
         <span>
           <LinkExternal
-            href={`https://experimenter.services.mozilla.com/api/v6/experiments/${experiment.slug}/`}
+            href={`/api/v6/experiments/${experiment.slug}/`}
             data-testid="link-json"
           >
             See full JSON representation

--- a/app/experimenter/nimbus-ui/src/components/SummaryTimeline/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/SummaryTimeline/index.tsx
@@ -7,6 +7,7 @@ import ProgressBar from "react-bootstrap/ProgressBar";
 import { NimbusExperimentStatus } from "../../types/globalTypes";
 import pluralize from "../../lib/pluralize";
 import { getExperiment_experimentBySlug } from "../../types/getExperiment";
+import { NotSet } from "../Summary";
 
 const humanDate = (date: string): string => {
   return new Date(date).toLocaleString("en-US", {
@@ -16,15 +17,13 @@ const humanDate = (date: string): string => {
   });
 };
 
-const experimentStatus = (status: NimbusExperimentStatus) => {
-  return {
-    draft: status === NimbusExperimentStatus.DRAFT,
-    review: status === NimbusExperimentStatus.REVIEW,
-    accepted: status === NimbusExperimentStatus.ACCEPTED,
-    live: status === NimbusExperimentStatus.LIVE,
-    complete: status === NimbusExperimentStatus.COMPLETE,
-  };
-};
+const experimentStatus = (status: NimbusExperimentStatus) => ({
+  draft: status === NimbusExperimentStatus.DRAFT,
+  review: status === NimbusExperimentStatus.REVIEW,
+  accepted: status === NimbusExperimentStatus.ACCEPTED,
+  live: status === NimbusExperimentStatus.LIVE,
+  complete: status === NimbusExperimentStatus.COMPLETE,
+});
 
 const SummaryTimeline = ({
   experiment,
@@ -34,7 +33,7 @@ const SummaryTimeline = ({
   const status = experimentStatus(experiment.status!);
 
   return (
-    <div className="mb-4" data-testid="summary-timeline">
+    <div className="mb-5" data-testid="summary-timeline">
       <StartEnd
         {...{
           status,
@@ -132,17 +131,13 @@ const Duration = ({
     {duration ? (
       <b data-testid="label-duration-days">{pluralize(duration, "day")}</b>
     ) : (
-      <span className="text-danger" data-testid="label-duration-not-set">
-        Not set
-      </span>
+      <NotSet data-testid="label-duration-not-set" />
     )}{" "}
     / Enrollment:{" "}
     {enrollment ? (
       <b data-testid="label-enrollment-days">{pluralize(enrollment, "day")}</b>
     ) : (
-      <span className="text-danger" data-testid="label-enrollment-not-set">
-        Not set
-      </span>
+      <NotSet data-testid="label-enrollment-not-set" />
     )}
   </span>
 );

--- a/app/experimenter/nimbus-ui/src/components/TableAudience/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/TableAudience/index.stories.tsx
@@ -1,0 +1,63 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from "react";
+import { storiesOf } from "@storybook/react";
+import { mockExperimentQuery } from "../../lib/mocks";
+import AppLayout from "../AppLayout";
+import TableAudience from ".";
+import { RouterSlugProvider } from "../../lib/test-utils";
+import { NimbusExperimentChannel } from "../../types/globalTypes";
+
+storiesOf("components/TableAudience", module)
+  .add("all fields filled out", () => {
+    const { data } = mockExperimentQuery("demo-slug", {
+      channels: [NimbusExperimentChannel.DESKTOP_BETA],
+    });
+    return (
+      <Subject>
+        <TableAudience experiment={data!} />
+      </Subject>
+    );
+  })
+  .add("filled out with multiple channels", () => {
+    const { data } = mockExperimentQuery("demo-slug");
+    return (
+      <Subject>
+        <TableAudience experiment={data!} />
+      </Subject>
+    );
+  })
+  .add("only required fields filled out", () => {
+    const { data } = mockExperimentQuery("demo-slug", {
+      totalEnrolledClients: 0,
+      targetingConfigSlug: null,
+    });
+    return (
+      <Subject>
+        <TableAudience experiment={data!} />
+      </Subject>
+    );
+  })
+  .add("missing required fields", () => {
+    const { data } = mockExperimentQuery("demo-slug", {
+      channels: [],
+      firefoxMinVersion: null,
+      populationPercent: 0,
+      totalEnrolledClients: 0,
+      targetingConfigSlug: null,
+    });
+
+    return (
+      <Subject>
+        <TableAudience experiment={data!} />
+      </Subject>
+    );
+  });
+
+const Subject = ({ children }: { children: React.ReactElement }) => (
+  <AppLayout>
+    <RouterSlugProvider>{children}</RouterSlugProvider>
+  </AppLayout>
+);

--- a/app/experimenter/nimbus-ui/src/components/TableAudience/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/TableAudience/index.test.tsx
@@ -1,0 +1,123 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { MockedCache, mockExperimentQuery } from "../../lib/mocks";
+import TableSummary from ".";
+import { getExperiment_experimentBySlug } from "../../types/getExperiment";
+import { NimbusExperimentChannel } from "../../types/globalTypes";
+
+describe("TableAudience", () => {
+  describe("renders 'Channels' row as expected", () => {
+    it("with one channel", () => {
+      const { data } = mockExperimentQuery("demo-slug", {
+        channels: [NimbusExperimentChannel.DESKTOP_BETA],
+      });
+      render(<Subject experiment={data!} />);
+      expect(screen.getByTestId("experiment-channels")).toHaveTextContent(
+        "Desktop Beta",
+      );
+    });
+    it("with multiple channels", () => {
+      const { data } = mockExperimentQuery("demo-slug");
+      render(<Subject experiment={data!} />);
+      expect(screen.getByTestId("experiment-channels")).toHaveTextContent(
+        "Desktop Nightly, Desktop Beta",
+      );
+    });
+    it("when not set", () => {
+      const { data } = mockExperimentQuery("demo-slug", {
+        channels: [],
+      });
+      render(<Subject experiment={data!} />);
+      expect(screen.getByTestId("experiment-channels")).toHaveTextContent(
+        "Not set",
+      );
+    });
+  });
+  describe("renders 'Minimum version' row as expected", () => {
+    it("when set", () => {
+      const { data } = mockExperimentQuery("demo-slug");
+      render(<Subject experiment={data!} />);
+      expect(screen.getByTestId("experiment-ff-min")).toHaveTextContent(
+        "Firefox 80",
+      );
+    });
+    it("when not set", () => {
+      const { data } = mockExperimentQuery("demo-slug", {
+        firefoxMinVersion: null,
+      });
+      render(<Subject experiment={data!} />);
+      expect(screen.getByTestId("experiment-ff-min")).toHaveTextContent(
+        "Not set",
+      );
+    });
+  });
+
+  describe("renders 'Population %' row as expected", () => {
+    it("when set", () => {
+      const { data } = mockExperimentQuery("demo-slug");
+      render(<Subject experiment={data!} />);
+      expect(screen.getByTestId("experiment-population")).toHaveTextContent(
+        "40%",
+      );
+    });
+    it("when not set", () => {
+      const { data } = mockExperimentQuery("demo-slug", {
+        populationPercent: null,
+      });
+      render(<Subject experiment={data!} />);
+      expect(screen.getByTestId("experiment-population")).toHaveTextContent(
+        "Not set",
+      );
+    });
+  });
+
+  describe("renders 'Expected enrolled clients' row as expected", () => {
+    it("when set", () => {
+      const { data } = mockExperimentQuery("demo-slug");
+      render(<Subject experiment={data!} />);
+      expect(screen.getByTestId("experiment-total-enrolled")).toHaveTextContent(
+        "68,000",
+      );
+    });
+    it("when not set", () => {
+      const { data } = mockExperimentQuery("demo-slug", {
+        totalEnrolledClients: 0,
+      });
+      render(<Subject experiment={data!} />);
+      expect(
+        screen.queryByTestId("experiment-total-enrolled"),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe("renders 'Custom audience' row as expected", () => {
+    it("when set", () => {
+      const { data } = mockExperimentQuery("demo-slug");
+      render(<Subject experiment={data!} />);
+      expect(screen.getByTestId("experiment-target")).toHaveTextContent(
+        "Us Only",
+      );
+    });
+    it("when not set", () => {
+      const { data } = mockExperimentQuery("demo-slug", {
+        targetingConfigSlug: null,
+      });
+      render(<Subject experiment={data!} />);
+      expect(screen.queryByTestId("experiment-target")).not.toBeInTheDocument();
+    });
+  });
+});
+
+const Subject = ({
+  experiment,
+}: {
+  experiment: getExperiment_experimentBySlug;
+}) => (
+  <MockedCache>
+    <TableSummary {...{ experiment }} />
+  </MockedCache>
+);

--- a/app/experimenter/nimbus-ui/src/components/TableAudience/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/TableAudience/index.tsx
@@ -1,0 +1,80 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from "react";
+import { getExperiment_experimentBySlug } from "../../types/getExperiment";
+import { Table } from "react-bootstrap";
+import { useConfig } from "../../hooks";
+import { displayConfigLabelOrNotSet, NotSet } from "../Summary";
+
+type TableAudienceProps = {
+  experiment: getExperiment_experimentBySlug;
+};
+
+// `<tr>`s showing optional fields that are not set are not displayed.
+
+const TableAudience = ({ experiment }: TableAudienceProps) => {
+  const { firefoxMinVersion, channels, targetingConfigSlug } = useConfig();
+
+  return (
+    <Table striped bordered data-testid="table-audience" className="mb-4">
+      <tbody>
+        <tr>
+          <th className="w-33">Channels</th>
+          <td data-testid="experiment-channels">
+            {experiment.channels?.length ? (
+              experiment.channels
+                .map((expChannel) =>
+                  displayConfigLabelOrNotSet(expChannel, channels),
+                )
+                .join(", ")
+            ) : (
+              <NotSet />
+            )}
+          </td>
+        </tr>
+        <tr>
+          <th>Minimum version</th>
+          <td data-testid="experiment-ff-min">
+            {displayConfigLabelOrNotSet(
+              experiment.firefoxMinVersion,
+              firefoxMinVersion,
+            )}
+          </td>
+        </tr>
+        <tr>
+          <th>Population %</th>
+          <td data-testid="experiment-population">
+            {experiment.populationPercent ? (
+              `${experiment.populationPercent}%`
+            ) : (
+              <NotSet />
+            )}
+          </td>
+        </tr>
+        {experiment.totalEnrolledClients > 0 && (
+          <tr>
+            <th>Expected enrolled clients</th>
+            <td data-testid="experiment-total-enrolled">
+              {experiment.totalEnrolledClients.toLocaleString()}
+            </td>
+          </tr>
+        )}
+        {experiment.targetingConfigSlug && (
+          <tr>
+            <th>Custom audience</th>
+            <td data-testid="experiment-target">
+              {displayConfigLabelOrNotSet(
+                experiment.targetingConfigSlug,
+                targetingConfigSlug,
+              )}
+            </td>
+          </tr>
+        )}
+      </tbody>
+    </Table>
+  );
+};
+
+export default TableAudience;

--- a/app/experimenter/nimbus-ui/src/components/TableHighlights/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/TableHighlights/index.stories.tsx
@@ -29,19 +29,19 @@ storiesOf("visualization/TableHighlights", module)
         {
           __typename: "NimbusProbeSetType",
           id: "1",
-          slug: "picture-in-picture",
+          slug: "picture_in_picture",
           name: "Picture-in-Picture",
         },
         {
           __typename: "NimbusProbeSetType",
           id: "2",
-          slug: "feature-b",
+          slug: "feature_b",
           name: "Feature B",
         },
         {
           __typename: "NimbusProbeSetType",
           id: "3",
-          slug: "feature-c",
+          slug: "feature_c",
           name: "Feature C",
         },
       ],

--- a/app/experimenter/nimbus-ui/src/components/TableHighlightsOverview/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/TableHighlightsOverview/index.stories.tsx
@@ -7,16 +7,19 @@ import { storiesOf } from "@storybook/react";
 import { RouterSlugProvider } from "../../lib/test-utils";
 import { withLinks } from "@storybook/addon-links";
 import { mockExperimentQuery } from "../../lib/mocks";
-import TableOverview from ".";
+import TableHighlightsOverview from ".";
 import { mockAnalysis } from "../../lib/visualization/mocks";
 
-storiesOf("visualization/TableOverview", module)
+storiesOf("visualization/TableHighlightsOverview", module)
   .addDecorator(withLinks)
   .add("basic, with one primary probe set", () => {
     const { mock, data } = mockExperimentQuery("demo-slug");
     return (
       <RouterSlugProvider mocks={[mock]}>
-        <TableOverview experiment={data!} results={mockAnalysis().overall} />
+        <TableHighlightsOverview
+          experiment={data!}
+          results={mockAnalysis().overall}
+        />
       </RouterSlugProvider>
     );
   })
@@ -45,7 +48,10 @@ storiesOf("visualization/TableOverview", module)
     });
     return (
       <RouterSlugProvider mocks={[mock]}>
-        <TableOverview experiment={data!} results={mockAnalysis().overall} />
+        <TableHighlightsOverview
+          experiment={data!}
+          results={mockAnalysis().overall}
+        />
       </RouterSlugProvider>
     );
   });

--- a/app/experimenter/nimbus-ui/src/components/TableHighlightsOverview/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/TableHighlightsOverview/index.stories.tsx
@@ -29,19 +29,19 @@ storiesOf("visualization/TableHighlightsOverview", module)
         {
           __typename: "NimbusProbeSetType",
           id: "1",
-          slug: "picture-in-picture",
+          slug: "picture_in_picture",
           name: "Picture-in-Picture",
         },
         {
           __typename: "NimbusProbeSetType",
           id: "2",
-          slug: "feature-b",
+          slug: "feature_b",
           name: "Feature B",
         },
         {
           __typename: "NimbusProbeSetType",
           id: "3",
-          slug: "feature-c",
+          slug: "feature_c",
           name: "Feature C",
         },
       ],

--- a/app/experimenter/nimbus-ui/src/components/TableHighlightsOverview/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/TableHighlightsOverview/index.test.tsx
@@ -4,20 +4,23 @@
 
 import React from "react";
 import { render, screen } from "@testing-library/react";
-import TableOverview from ".";
+import TableHighlightsOverview from ".";
 import { mockExperimentQuery } from "../../lib/mocks";
 import { mockAnalysis } from "../../lib/visualization/mocks";
 import { RouterSlugProvider } from "../../lib/test-utils";
 
 const { mock, data } = mockExperimentQuery("demo-slug");
 
-describe("TableOverview", () => {
+describe("TableHighlightsOverview", () => {
   it("has the correct headings", async () => {
     const EXPECTED_HEADINGS = ["Targeting", "Probe Sets", "Owner"];
 
     render(
       <RouterSlugProvider mocks={[mock]}>
-        <TableOverview experiment={data!} results={mockAnalysis().overall} />
+        <TableHighlightsOverview
+          experiment={data!}
+          results={mockAnalysis().overall}
+        />
       </RouterSlugProvider>,
     );
 
@@ -29,7 +32,10 @@ describe("TableOverview", () => {
   it("has the expected targeting", async () => {
     render(
       <RouterSlugProvider mocks={[mock]}>
-        <TableOverview experiment={data!} results={mockAnalysis().overall} />
+        <TableHighlightsOverview
+          experiment={data!}
+          results={mockAnalysis().overall}
+        />
       </RouterSlugProvider>,
     );
 
@@ -43,7 +49,10 @@ describe("TableOverview", () => {
   it("has the expected probe sets", async () => {
     render(
       <RouterSlugProvider mocks={[mock]}>
-        <TableOverview experiment={data!} results={mockAnalysis().overall} />
+        <TableHighlightsOverview
+          experiment={data!}
+          results={mockAnalysis().overall}
+        />
       </RouterSlugProvider>,
     );
 
@@ -53,7 +62,10 @@ describe("TableOverview", () => {
   it("has the experiment owner", async () => {
     render(
       <RouterSlugProvider mocks={[mock]}>
-        <TableOverview experiment={data!} results={mockAnalysis().overall} />
+        <TableHighlightsOverview
+          experiment={data!}
+          results={mockAnalysis().overall}
+        />
       </RouterSlugProvider>,
     );
     expect(screen.getByText("example@mozilla.com")).toBeInTheDocument();

--- a/app/experimenter/nimbus-ui/src/components/TableHighlightsOverview/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/TableHighlightsOverview/index.tsx
@@ -8,7 +8,7 @@ import { AnalysisData } from "../../lib/visualization/types";
 import { useConfig } from "../../hooks";
 import { getConfig_nimbusConfig } from "../../types/getConfig";
 
-type TableOverviewProps = {
+type TableHighlightsOverviewProps = {
   experiment: getExperiment_experimentBySlug;
   results: AnalysisData["overall"];
 };
@@ -18,7 +18,9 @@ type displayConfigOptionsProps =
   | getConfig_nimbusConfig["channels"]
   | getConfig_nimbusConfig["targetingConfigSlug"];
 
-const TableOverview = ({ experiment }: TableOverviewProps) => {
+const TableHighlightsOverview = ({
+  experiment,
+}: TableHighlightsOverviewProps) => {
   const { firefoxMinVersion, channels, targetingConfigSlug } = useConfig();
 
   return (
@@ -78,4 +80,4 @@ const displayConfigLabel = (
   return options?.find((obj: any) => obj.value === value)?.label;
 };
 
-export default TableOverview;
+export default TableHighlightsOverview;

--- a/app/experimenter/nimbus-ui/src/components/TableResults/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/TableResults/index.stories.tsx
@@ -29,19 +29,19 @@ storiesOf("visualization/TableResults", module)
         {
           __typename: "NimbusProbeSetType",
           id: "1",
-          slug: "picture-in-picture",
+          slug: "picture_in_picture",
           name: "Picture-in-Picture",
         },
         {
           __typename: "NimbusProbeSetType",
           id: "2",
-          slug: "feature-b",
+          slug: "feature_b",
           name: "Feature B",
         },
         {
           __typename: "NimbusProbeSetType",
           id: "3",
-          slug: "feature-c",
+          slug: "feature_c",
           name: "Feature C",
         },
       ],

--- a/app/experimenter/nimbus-ui/src/components/TableSummary/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/TableSummary/index.stories.tsx
@@ -4,25 +4,15 @@
 
 import React from "react";
 import { storiesOf } from "@storybook/react";
-import { mockExperimentQuery } from "../../lib/mocks";
+import { mockExperimentQuery, MOCK_CONFIG } from "../../lib/mocks";
 import AppLayout from "../AppLayout";
 import TableSummary from ".";
 import { RouterSlugProvider } from "../../lib/test-utils";
 
 storiesOf("components/TableSummary", module)
-  .add("filled out", () => {
-    const { data } = mockExperimentQuery("demo-slug");
-    return (
-      <Subject>
-        <TableSummary experiment={data!} />
-      </Subject>
-    );
-  })
-  .add("partially filled out", () => {
+  .add("all fields filled out", () => {
     const { data } = mockExperimentQuery("demo-slug", {
-      secondaryProbeSets: [],
-      channels: [],
-      proposedDuration: 0,
+      featureConfig: MOCK_CONFIG.featureConfig![1],
     });
     return (
       <Subject>
@@ -30,19 +20,60 @@ storiesOf("components/TableSummary", module)
       </Subject>
     );
   })
-  .add("missing all fields", () => {
+  .add("filled out with multiple probe sets", () => {
     const { data } = mockExperimentQuery("demo-slug", {
-      owner: null,
-      hypothesis: null,
+      featureConfig: MOCK_CONFIG.featureConfig![1],
+      primaryProbeSets: [
+        {
+          __typename: "NimbusProbeSetType",
+          id: "1",
+          slug: "picture_in_picture",
+          name: "Picture-in-Picture",
+        },
+        {
+          __typename: "NimbusProbeSetType",
+          id: "2",
+          slug: "feature_C",
+          name: "Feature C",
+        },
+      ],
+      secondaryProbeSets: [
+        {
+          __typename: "NimbusProbeSetType",
+          id: "1",
+          slug: "feature_b",
+          name: "Feature B",
+        },
+        {
+          __typename: "NimbusProbeSetType",
+          id: "2",
+          slug: "feature_d",
+          name: "Feature D",
+        },
+      ],
+    });
+    return (
+      <Subject>
+        <TableSummary experiment={data!} />
+      </Subject>
+    );
+  })
+  .add("only required fields filled out", () => {
+    const { data } = mockExperimentQuery("demo-slug", {
       primaryProbeSets: [],
       secondaryProbeSets: [],
-      channels: [],
-      firefoxMinVersion: null,
-      populationPercent: 0,
-      totalEnrolledClients: 0,
-      proposedEnrollment: 0,
-      proposedDuration: 0,
-      targetingConfigSlug: null,
+    });
+    return (
+      <Subject>
+        <TableSummary experiment={data!} />
+      </Subject>
+    );
+  })
+  .add("missing required fields", () => {
+    const { data } = mockExperimentQuery("demo-slug", {
+      primaryProbeSets: [],
+      secondaryProbeSets: [],
+      publicDescription: null,
     });
 
     return (

--- a/app/experimenter/nimbus-ui/src/components/TableSummary/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/TableSummary/index.test.tsx
@@ -4,146 +4,146 @@
 
 import React from "react";
 import { render, screen } from "@testing-library/react";
-import { MockedCache, mockExperimentQuery } from "../../lib/mocks";
+import { MockedCache, mockExperimentQuery, MOCK_CONFIG } from "../../lib/mocks";
 import TableSummary from ".";
 import { getExperiment_experimentBySlug } from "../../types/getExperiment";
 
 describe("TableSummary", () => {
-  describe("renders Experiment Owner row as expected", () => {
-    it("when set", () => {
-      const { data } = mockExperimentQuery("demo-slug");
-      render(<Subject experiment={data!} />);
-      expect(screen.getByTestId("experiment-owner")).toHaveTextContent(
-        "example@mozilla.com",
-      );
-    });
-    it("when not set", () => {
-      const { data } = mockExperimentQuery("demo-slug", {
-        owner: null,
-      });
-      render(<Subject experiment={data!} />);
-      expect(screen.getByTestId("experiment-owner")).toHaveTextContent(
-        "Owner not set",
-      );
-    });
-  });
-  describe("renders Hypothesis row as expected", () => {
-    it("when set", () => {
-      const { data } = mockExperimentQuery("demo-slug");
-      render(<Subject experiment={data!} />);
-      expect(screen.getByTestId("experiment-hypothesis")).toHaveTextContent(
-        "Realize material say pretty.",
-      );
-    });
-    it("when not set", () => {
-      const { data } = mockExperimentQuery("demo-slug", {
-        hypothesis: null,
-      });
-      render(<Subject experiment={data!} />);
-      expect(screen.getByTestId("experiment-hypothesis")).toHaveTextContent(
-        "Hypothesis not set",
-      );
-    });
+  it("renders rows displaying required fields at experiment creation as expected", () => {
+    const { data } = mockExperimentQuery("demo-slug");
+    render(<Subject experiment={data!} />);
+
+    expect(screen.getByTestId("experiment-slug")).toHaveTextContent(
+      "demo-slug",
+    );
+    expect(screen.getByTestId("experiment-owner")).toHaveTextContent(
+      "example@mozilla.com",
+    );
+    expect(screen.getByTestId("experiment-application")).toHaveTextContent(
+      "Desktop",
+    );
+    expect(screen.getByTestId("experiment-hypothesis")).toHaveTextContent(
+      "Realize material say pretty.",
+    );
   });
 
-  describe("renders Probe Sets row as expected", () => {
-    it("when both are set", () => {
+  describe("renders 'Primary probe sets' row as expected", () => {
+    it("with one probe set", () => {
       const { data } = mockExperimentQuery("demo-slug");
       render(<Subject experiment={data!} />);
       expect(screen.getByTestId("experiment-probe-primary")).toHaveTextContent(
-        "Primary: Picture-in-Picture",
+        "Picture-in-Picture",
       );
-      expect(
-        screen.getByTestId("experiment-probe-secondary"),
-      ).toHaveTextContent("Secondary: Feature B");
     });
-    it("when neither are set", () => {
+    it("with multiple probe sets", () => {
+      const { data } = mockExperimentQuery("demo-slug", {
+        primaryProbeSets: [
+          {
+            __typename: "NimbusProbeSetType",
+            id: "1",
+            slug: "picture_in_picture",
+            name: "Picture-in-Picture",
+          },
+          {
+            __typename: "NimbusProbeSetType",
+            id: "2",
+            slug: "feature_c",
+            name: "Feature C",
+          },
+        ],
+      });
+      render(<Subject experiment={data!} />);
+      expect(screen.getByTestId("experiment-probe-primary")).toHaveTextContent(
+        "Picture-in-Picture, Feature C",
+      );
+    });
+    it("when not set", () => {
       const { data } = mockExperimentQuery("demo-slug", {
         primaryProbeSets: [],
+      });
+      render(<Subject experiment={data!} />);
+      expect(
+        screen.queryByTestId("experiment-probe-primary"),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe("renders 'Secondary probe sets' row as expected", () => {
+    it("with one probe set", () => {
+      const { data } = mockExperimentQuery("demo-slug");
+      render(<Subject experiment={data!} />);
+      expect(
+        screen.getByTestId("experiment-probe-secondary"),
+      ).toHaveTextContent("Feature B");
+    });
+    it("with multiple probe sets", () => {
+      const { data } = mockExperimentQuery("demo-slug", {
+        secondaryProbeSets: [
+          {
+            __typename: "NimbusProbeSetType",
+            id: "1",
+            slug: "picture_in_picture",
+            name: "Picture-in-Picture",
+          },
+          {
+            __typename: "NimbusProbeSetType",
+            id: "2",
+            slug: "feature_b",
+            name: "Feature B",
+          },
+        ],
+      });
+      render(<Subject experiment={data!} />);
+      expect(
+        screen.getByTestId("experiment-probe-secondary"),
+      ).toHaveTextContent("Picture-in-Picture, Feature B");
+    });
+    it("when not set", () => {
+      const { data } = mockExperimentQuery("demo-slug", {
         secondaryProbeSets: [],
       });
       render(<Subject experiment={data!} />);
-      expect(screen.getByTestId("experiment-probe-primary")).toHaveTextContent(
-        "Primary: probe not set",
-      );
       expect(
-        screen.getByTestId("experiment-probe-secondary"),
-      ).toHaveTextContent("Secondary: probe not set");
+        screen.queryByTestId("experiment-probe-secondary"),
+      ).not.toBeInTheDocument();
+    });
+
+    describe("renders 'Public description' row as expected", () => {
+      it("when set", () => {
+        const { data } = mockExperimentQuery("demo-slug");
+        render(<Subject experiment={data!} />);
+        expect(screen.getByTestId("experiment-description")).toHaveTextContent(
+          "Official approach present industry strategy dream piece.",
+        );
+      });
+      it("when not set", () => {
+        const { data } = mockExperimentQuery("demo-slug", {
+          publicDescription: null,
+        });
+        render(<Subject experiment={data!} />);
+        expect(screen.getByTestId("experiment-description")).toHaveTextContent(
+          "Not set",
+        );
+      });
     });
   });
 
-  describe("renders Audience row as expected", () => {
-    it("when all fields are set", () => {
-      const { data } = mockExperimentQuery("demo-slug");
-      render(<Subject experiment={data!} />);
-      expect(screen.getByTestId("experiment-target")).toHaveTextContent(
-        "Us Only",
-      );
-      expect(screen.getByTestId("experiment-channels")).toHaveTextContent(
-        "Desktop Nightly, Desktop Beta,",
-      );
-      expect(screen.getByTestId("experiment-ff-min")).toHaveTextContent(
-        "Firefox 80",
-      );
-      expect(screen.getByTestId("experiment-population")).toHaveTextContent(
-        "40% of population",
-      );
-      expect(screen.getByTestId("experiment-total-enrolled")).toHaveTextContent(
-        "totalling 68,000 expected enrolled clients",
-      );
-    });
-    it("when no fields are set", () => {
+  describe("renders 'Feature config' row as expected", () => {
+    it("when set", () => {
       const { data } = mockExperimentQuery("demo-slug", {
-        channels: [],
-        firefoxMinVersion: null,
-        populationPercent: 0,
-        totalEnrolledClients: 0,
-        proposedEnrollment: 0,
-        proposedDuration: 0,
-        targetingConfigSlug: null,
+        featureConfig: MOCK_CONFIG.featureConfig![1],
       });
       render(<Subject experiment={data!} />);
-      expect(screen.getByTestId("experiment-target")).toHaveTextContent(
-        "Target audience not set",
-      );
-      expect(screen.getByTestId("experiment-channels")).toHaveTextContent(
-        "channel not set",
-      );
-      expect(screen.getByTestId("experiment-ff-min")).toHaveTextContent(
-        "Firefox minimum version not set",
-      );
-      expect(screen.getByTestId("experiment-population")).toHaveTextContent(
-        "Population percentage not set",
-      );
-      expect(screen.getByTestId("experiment-total-enrolled")).toHaveTextContent(
-        "totalling expected enrolled clients not set",
+      expect(screen.getByTestId("experiment-feature-config")).toHaveTextContent(
+        "Mauris odio erat",
       );
     });
-  });
-
-  describe("renders Duration row as expected", () => {
-    it("when all fields are set", () => {
+    it("when not set", () => {
       const { data } = mockExperimentQuery("demo-slug");
       render(<Subject experiment={data!} />);
-      expect(screen.getByTestId("experiment-duration")).toHaveTextContent(
-        "28 days",
-      );
-      expect(screen.getByTestId("experiment-enrollment")).toHaveTextContent(
-        "over an enrollment period of 1 day",
-      );
-    });
-    it("when no fields are set", () => {
-      const { data } = mockExperimentQuery("demo-slug", {
-        proposedEnrollment: 0,
-        proposedDuration: 0,
-      });
-      render(<Subject experiment={data!} />);
-      expect(screen.getByTestId("experiment-duration")).toHaveTextContent(
-        "Proposed duration not set",
-      );
-      expect(screen.getByTestId("experiment-enrollment")).toHaveTextContent(
-        "over an enrollment period of proposed enrollment not set",
-      );
+      expect(
+        screen.queryByTestId("experiment-feature-config"),
+      ).not.toBeInTheDocument();
     });
   });
 });

--- a/app/experimenter/nimbus-ui/src/components/TableSummary/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/TableSummary/index.tsx
@@ -6,155 +6,81 @@ import React from "react";
 import { getExperiment_experimentBySlug } from "../../types/getExperiment";
 import { Table } from "react-bootstrap";
 import { useConfig } from "../../hooks";
-import { getConfig_nimbusConfig } from "../../types/getConfig";
+import { displayConfigLabelOrNotSet, NotSet } from "../Summary";
 
 type TableSummaryProps = {
   experiment: getExperiment_experimentBySlug;
 };
 
+// `<tr>`s showing optional fields that are not set are not displayed.
+
 const TableSummary = ({ experiment }: TableSummaryProps) => {
-  const { firefoxMinVersion, channels, targetingConfigSlug } = useConfig();
+  const { application } = useConfig();
 
   return (
-    <Table striped bordered data-testid="table-summary">
+    <Table striped bordered data-testid="table-summary" className="mb-4">
       <tbody>
         <tr>
-          <th className="font-weight-bold">Experiment Owner</th>
-          <td data-testid="experiment-owner">
-            {experiment.owner?.email ? experiment.owner.email : notSet("Owner")}
+          <th className="w-33">Slug</th>
+          <td data-testid="experiment-slug" className="text-monospace">
+            {experiment.slug}
           </td>
         </tr>
         <tr>
-          <th className="font-weight-bold">
-            <b>Hypothesis</b>
-          </th>
-          <td data-testid="experiment-hypothesis">
-            {experiment.hypothesis
-              ? experiment.hypothesis
-              : notSet("Hypothesis")}
+          <th>Experiment owner</th>
+          <td data-testid="experiment-owner">{experiment.owner!.email}</td>
+        </tr>
+        <tr>
+          <th>Application</th>
+          <td data-testid="experiment-application">
+            {displayConfigLabelOrNotSet(experiment.application, application)}
           </td>
         </tr>
         <tr>
-          <th className="font-weight-bold">Probe Sets</th>
-          <td>
-            <span data-testid="experiment-probe-primary" className="d-block">
-              Primary:{" "}
-              {experiment.primaryProbeSets?.length
-                ? experiment.primaryProbeSets
-                    .map((probeSet) => probeSet?.name)
-                    .join(", ")
-                : notSet("probe")}
-            </span>
-            <span data-testid="experiment-probe-secondary">
-              Secondary:{" "}
-              {experiment.secondaryProbeSets?.length
-                ? experiment.secondaryProbeSets
-                    .map((probeSet) => probeSet?.name)
-                    .join(", ")
-                : notSet("probe")}
-            </span>
-          </td>
+          <th>Hypothesis</th>
+          <td data-testid="experiment-hypothesis">{experiment.hypothesis}</td>
         </tr>
         <tr>
-          <th className="font-weight-bold">Audience</th>
-          <td>
-            <span data-testid="experiment-target">
-              {displayConfigLabelOrNotSet(
-                "Target audience",
-                experiment.targetingConfigSlug,
-                targetingConfigSlug,
-              )}
-              ,{" "}
-            </span>
-            <span data-testid="experiment-channels">
-              {experiment.channels?.length
-                ? experiment.channels
-                    .map((expChannel) =>
-                      displayConfigLabelOrNotSet(
-                        "channel",
-                        expChannel,
-                        channels,
-                      ),
-                    )
-                    .join(", ")
-                : notSet("channel")}
-              {", "}
-            </span>
-            <span data-testid="experiment-ff-min">
-              {displayConfigLabelOrNotSet(
-                "Firefox minimum version",
-                experiment.firefoxMinVersion,
-                firefoxMinVersion,
-              )}
-            </span>
-            <span className="d-block">
-              <span data-testid="experiment-population">
-                {experiment.populationPercent
-                  ? `${experiment.populationPercent}% of population`
-                  : notSet("Population percentage")}
-              </span>
-              <span data-testid="experiment-total-enrolled">
-                {" "}
-                totalling{" "}
-                {experiment.totalEnrolledClients
-                  ? `${experiment.totalEnrolledClients.toLocaleString()} expected enrolled clients`
-                  : notSet("expected enrolled clients")}
-              </span>
-            </span>
+          <th>Public description</th>
+          <td data-testid="experiment-description">
+            {experiment.publicDescription ? (
+              experiment.publicDescription
+            ) : (
+              <NotSet />
+            )}
           </td>
         </tr>
-        <tr>
-          <th className="font-weight-bold">Duration</th>
-          <td>
-            <span data-testid="experiment-duration">
-              {displayDaysOrNotSet(
-                "Proposed duration",
-                experiment.proposedDuration,
-              )}{" "}
-            </span>
-            <span data-testid="experiment-enrollment">
-              over an enrollment period of{" "}
-              {displayDaysOrNotSet(
-                "proposed enrollment",
-                experiment.proposedEnrollment,
-              )}
-            </span>
-          </td>
-        </tr>
+        {experiment.featureConfig?.name && (
+          <tr>
+            <th>Feature config</th>
+            <td data-testid="experiment-feature-config">
+              {experiment.featureConfig.name}
+            </td>
+          </tr>
+        )}
+        {experiment.primaryProbeSets?.length !== 0 && (
+          <tr>
+            <th>Primary probe sets</th>
+            <td data-testid="experiment-probe-primary">
+              {experiment
+                .primaryProbeSets!.map((probeSet) => probeSet?.name)
+                .join(", ")}
+            </td>
+          </tr>
+        )}
+        {experiment.secondaryProbeSets?.length !== 0 && (
+          <tr>
+            <th>Secondary probe sets</th>
+            <td data-testid="experiment-probe-secondary">
+              {experiment
+                .secondaryProbeSets!.map((probeSet) => probeSet?.name)
+                .join(", ")}
+            </td>
+          </tr>
+        )}
       </tbody>
     </Table>
   );
 };
-
-type displayConfigOptionsProps =
-  | getConfig_nimbusConfig["firefoxMinVersion"]
-  | getConfig_nimbusConfig["channels"]
-  | getConfig_nimbusConfig["targetingConfigSlug"];
-
-const displayConfigLabelOrNotSet = (
-  description: string,
-  value: string | null,
-  options: displayConfigOptionsProps,
-) => {
-  if (!value) return notSet(description);
-  const label = options?.find((obj: any) => obj.value === value)?.label;
-  return label;
-};
-
-const displayDaysOrNotSet = (
-  description: string,
-  numberOfDays: number | null,
-) => {
-  if (!numberOfDays) return notSet(description);
-  if (numberOfDays === 1) {
-    return `${numberOfDays} day`;
-  } else {
-    return `${numberOfDays} days`;
-  }
-};
-
-const notSet = (description: string) => (
-  <span className="text-danger">{`${description} not set`}</span>
-);
 
 export default TableSummary;

--- a/app/experimenter/nimbus-ui/src/components/TableSummary/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/TableSummary/index.tsx
@@ -58,7 +58,7 @@ const TableSummary = ({ experiment }: TableSummaryProps) => {
             </td>
           </tr>
         )}
-        {experiment.primaryProbeSets?.length !== 0 && (
+        {experiment.primaryProbeSets?.length && (
           <tr>
             <th>Primary probe sets</th>
             <td data-testid="experiment-probe-primary">
@@ -68,7 +68,7 @@ const TableSummary = ({ experiment }: TableSummaryProps) => {
             </td>
           </tr>
         )}
-        {experiment.secondaryProbeSets?.length !== 0 && (
+        {experiment.secondaryProbeSets?.length && (
           <tr>
             <th>Secondary probe sets</th>
             <td data-testid="experiment-probe-secondary">

--- a/app/experimenter/nimbus-ui/src/styles/index.scss
+++ b/app/experimenter/nimbus-ui/src/styles/index.scss
@@ -40,6 +40,10 @@ $sizes: (
   font-weight: 600;
 }
 
+.w-33 {
+  width: 33.33%;
+}
+
 .positive-significance {
   @extend .text-success;
   @extend .font-weight-bold;


### PR DESCRIPTION
This commit:
* Updates the Summary table to reflect the latest design
* Adds the Audience table
* Adds a Summary component to contain common components used on multiple pages with JSON link - this is currently used on the Request Review page, Summary page, and Results page
* Renames TableOverview to TableHighlightsOverview for better clarity
* Makes minor tweaks on the Results page to better reflect states

Because:
* We want to present users with tables displaying experiment data

fixes #3833
fixes #3704, but needs two follow-up issues for the "Full targeting expression" piece because we don't yet have that piece of data available, will link them in the AM after I make them (edit: they're #4114 and #4115)
fixes #4015 