### PR TITLE
fix(nimbus) Fix console error in TableSummary

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/TableSummary/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/TableSummary/index.tsx
@@ -58,7 +58,7 @@ const TableSummary = ({ experiment }: TableSummaryProps) => {
             </td>
           </tr>
         )}
-        {experiment.primaryProbeSets?.length && (
+        {experiment.primaryProbeSets?.length !== 0 && (
           <tr>
             <th>Primary probe sets</th>
             <td data-testid="experiment-probe-primary">
@@ -68,7 +68,7 @@ const TableSummary = ({ experiment }: TableSummaryProps) => {
             </td>
           </tr>
         )}
-        {experiment.secondaryProbeSets?.length && (
+        {experiment.secondaryProbeSets?.length !== 0 && (
           <tr>
             <th>Secondary probe sets</th>
             <td data-testid="experiment-probe-secondary">


### PR DESCRIPTION
Facepalm moment. In https://github.com/mozilla/experimenter/pull/4112#discussion_r536171709, I'd changed these lines to demonstrate why we have to have `!== 0` on these lines by removing it, then accidentally committed it. 😅 