### PR TITLE
fixes #3918 #3917 feat(nimbus): filter configs and channels by experiment application

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/FormAudience/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/FormAudience/index.test.tsx
@@ -25,6 +25,23 @@ describe("FormAudience", () => {
     expect((targetingConfigSlug as HTMLSelectElement).value).toEqual(
       MOCK_CONFIG!.targetingConfigSlug![0]!.value,
     );
+
+    // Assert that we have all the channels for our application available
+    for (const channel of MOCK_CONFIG.channels!.filter((channel) =>
+      ["DESKTOP_BETA", "DESKTOP_NIGHTLY"].includes(channel?.value!),
+    )) {
+      const { label } = channel!;
+      expect(screen.getByText(label!)).toBeInTheDocument();
+    }
+
+    // Assert that non of the channels that don't belong to our application are available
+    for (const channel of MOCK_CONFIG.channels!.filter(
+      (channel) =>
+        !["DESKTOP_BETA", "DESKTOP_NIGHTLY"].includes(channel?.value!),
+    )) {
+      const { label } = channel!;
+      expect(screen.queryByText(label!)).not.toBeInTheDocument();
+    }
   });
 
   it("renders server errors", async () => {

--- a/app/experimenter/nimbus-ui/src/components/FormAudience/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/FormAudience/index.tsx
@@ -42,8 +42,20 @@ export const FormAudience = ({
 }) => {
   const config = useConfig();
 
+  // This could be improved on the GraphQL side, but right now in order
+  // to filter available channels we need to
+  //   - identify the application label by experiment application value
+  //   - use that label to identify the available channels
+  //   - and then filter all channels against our eligible subset
+  const experimentApplication = config.application?.find(
+    (a) => a?.value === experiment.application,
+  );
+  const applicationChannels = config.applicationChannels?.find(
+    (ac) => ac?.label === experimentApplication?.label,
+  )?.channels;
   const channelsOptions = config.channels?.filter(
-    (item): item is getConfig_nimbusConfig_channels => item !== null,
+    (item): item is getConfig_nimbusConfig_channels =>
+      item !== null && (applicationChannels?.includes(item.label) || false),
   );
   const channelsDefaultValue = experiment.channels?.map((channel) =>
     channelsOptions?.find((option) => option?.value === channel),

--- a/app/experimenter/nimbus-ui/src/components/FormOverview/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/FormOverview/index.tsx
@@ -129,7 +129,9 @@ const FormOverview = ({
           {...nameValidated("hypothesis")}
           as="textarea"
           rows={5}
-          defaultValue={experiment?.hypothesis || (hypothesisDefault as string)}
+          defaultValue={
+            experiment?.hypothesis || (hypothesisDefault as string).trim()
+          }
         />
         <Form.Text className="text-muted">
           You can add any supporting documents here.

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/index.test.tsx
@@ -18,6 +18,7 @@ import { mockExperimentQuery, MOCK_CONFIG } from "../../lib/mocks";
 import { UPDATE_EXPERIMENT_BRANCHES_MUTATION } from "../../gql/experiments";
 import {
   NimbusExperimentApplication,
+  NimbusFeatureConfigApplication,
   UpdateExperimentBranchesInput,
 } from "../../types/globalTypes";
 import {
@@ -49,11 +50,36 @@ describe("PageEditBranches", () => {
     });
     expect(screen.getByTestId("FormBranches")).toBeInTheDocument();
     expect(screen.getByTestId("feature-config")).toBeInTheDocument();
+
+    MOCK_CONFIG.featureConfig = [
+      ...MOCK_CONFIG.featureConfig!,
+      {
+        __typename: "NimbusFeatureConfigType",
+        id: "3",
+        name: "Foo bar",
+        slug: "foo-bar",
+        description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+        application: NimbusFeatureConfigApplication.FIREFOX_DESKTOP,
+        ownerEmail: "dude23@yahoo.com",
+        schema: '{ "sample": "schema" }',
+      },
+    ];
+
+    // Assert that we have all the feature configs for our application (Fenix) available
     for (const feature of MOCK_CONFIG!.featureConfig!.filter(
-      (config) => config?.application === experiment!.application,
+      (config) => config?.application === experiment.application,
     )) {
       const { slug } = feature!;
       expect(screen.getByText(slug)).toBeInTheDocument();
+    }
+
+    // Assert that non of the feature configs that don't belong to our application are available
+    for (const feature of MOCK_CONFIG!.featureConfig!.filter(
+      (config) =>
+        config?.application === NimbusFeatureConfigApplication.FIREFOX_DESKTOP,
+    )) {
+      const { slug } = feature!;
+      expect(screen.queryByText(slug)).not.toBeInTheDocument();
     }
   });
 

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/index.test.tsx
@@ -16,7 +16,10 @@ import FormBranches from "../FormBranches";
 import { RouterSlugProvider } from "../../lib/test-utils";
 import { mockExperimentQuery, MOCK_CONFIG } from "../../lib/mocks";
 import { UPDATE_EXPERIMENT_BRANCHES_MUTATION } from "../../gql/experiments";
-import { UpdateExperimentBranchesInput } from "../../types/globalTypes";
+import {
+  NimbusExperimentApplication,
+  UpdateExperimentBranchesInput,
+} from "../../types/globalTypes";
 import {
   updateExperimentBranches_updateExperimentBranches,
   updateExperimentBranches_updateExperimentBranches_nimbusExperiment,
@@ -36,7 +39,9 @@ describe("PageEditBranches", () => {
   afterEach(() => {});
 
   it("renders as expected with experiment data", async () => {
-    const { mock } = mockExperimentQuery("demo-slug");
+    const { mock, experiment } = mockExperimentQuery("demo-slug", {
+      application: NimbusExperimentApplication.FENIX,
+    });
     render(<Subject mocks={[mock]} />);
     await waitFor(() => {
       expect(screen.getByTestId("PageEditBranches")).toBeInTheDocument();
@@ -44,7 +49,9 @@ describe("PageEditBranches", () => {
     });
     expect(screen.getByTestId("FormBranches")).toBeInTheDocument();
     expect(screen.getByTestId("feature-config")).toBeInTheDocument();
-    for (const feature of MOCK_CONFIG!.featureConfig!) {
+    for (const feature of MOCK_CONFIG!.featureConfig!.filter(
+      (config) => config?.application === experiment!.application,
+    )) {
       const { slug } = feature!;
       expect(screen.getByText(slug)).toBeInTheDocument();
     }

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/index.tsx
@@ -85,6 +85,10 @@ const PageEditBranches: React.FunctionComponent<RouteComponentProps> = () => {
         refetchReview.current = review.refetch;
 
         const { isMissingField } = review;
+        const applicationFeatureConfigs =
+          featureConfig?.filter(
+            (config) => config?.application === experiment.application,
+          ) || [];
 
         return (
           <>
@@ -97,7 +101,7 @@ const PageEditBranches: React.FunctionComponent<RouteComponentProps> = () => {
             <FormBranches
               {...{
                 experiment,
-                featureConfig,
+                featureConfig: applicationFeatureConfigs,
                 isMissingField,
                 isLoading: loading,
                 onSave: onFormSave,

--- a/app/experimenter/nimbus-ui/src/gql/config.ts
+++ b/app/experimenter/nimbus-ui/src/gql/config.ts
@@ -11,6 +11,10 @@ export const GET_CONFIG_QUERY = gql`
         label
         value
       }
+      applicationChannels {
+        label
+        channels
+      }
       channels {
         label
         value

--- a/app/experimenter/nimbus-ui/src/lib/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/lib/mocks.tsx
@@ -69,6 +69,23 @@ export const MOCK_CONFIG: getConfig_nimbusConfig = {
       value: "PLATYPUS_DOORSTOP",
     },
   ],
+  applicationChannels: [
+    {
+      __typename: "ApplicationChannel",
+      label: "Desktop",
+      channels: [
+        "Desktop Unbranded",
+        "Desktop Nightly",
+        "Desktop Beta",
+        "Desktop Release",
+      ],
+    },
+    {
+      __typename: "ApplicationChannel",
+      label: "Fenix",
+      channels: ["Fenix Nightly", "Fenix Beta", "Fenix Release"],
+    },
+  ],
   featureConfig: [
     {
       __typename: "NimbusFeatureConfigType",

--- a/app/experimenter/nimbus-ui/src/types/getConfig.ts
+++ b/app/experimenter/nimbus-ui/src/types/getConfig.ts
@@ -15,6 +15,12 @@ export interface getConfig_nimbusConfig_application {
   value: string | null;
 }
 
+export interface getConfig_nimbusConfig_applicationChannels {
+  __typename: "ApplicationChannel";
+  label: string | null;
+  channels: (string | null)[] | null;
+}
+
 export interface getConfig_nimbusConfig_channels {
   __typename: "NimbusLabelValueType";
   label: string | null;
@@ -66,6 +72,7 @@ export interface getConfig_nimbusConfig_targetingConfigSlug {
 export interface getConfig_nimbusConfig {
   __typename: "NimbusConfigurationType";
   application: (getConfig_nimbusConfig_application | null)[] | null;
+  applicationChannels: (getConfig_nimbusConfig_applicationChannels | null)[] | null;
   channels: (getConfig_nimbusConfig_channels | null)[] | null;
   featureConfig: (getConfig_nimbusConfig_featureConfig | null)[] | null;
   firefoxMinVersion: (getConfig_nimbusConfig_firefoxMinVersion | null)[] | null;


### PR DESCRIPTION
Closes #3918
Closes #3917

This is a few maintenance fixes:

- Trim whitespace around default hypothesis (not in a ticket, it was just bugging me)
- Filter available feature configs by experiment application
- Filter available channels by experiment application