### PR TITLE
fixes #4113 fix(nimbus): refactor mockExperimentQuery to use generic for return type, rename data to experiment

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/FormAudience/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/components/FormAudience/mocks.tsx
@@ -35,4 +35,4 @@ export const Subject = ({
   </div>
 );
 
-export const MOCK_EXPERIMENT = mockExperimentQuery("demo-slug")!.data!;
+export const MOCK_EXPERIMENT = mockExperimentQuery("demo-slug").experiment;

--- a/app/experimenter/nimbus-ui/src/components/FormBranches/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/components/FormBranches/mocks.tsx
@@ -100,7 +100,7 @@ export const MOCK_EXPERIMENT = mockExperimentQuery("demo-slug", {
       featureEnabled: true,
     },
   ],
-})!.data!;
+}).experiment;
 
 export const MOCK_BRANCH = MOCK_EXPERIMENT.treatmentBranches![0]!;
 export const MOCK_ANNOTATED_BRANCH: AnnotatedBranch = {

--- a/app/experimenter/nimbus-ui/src/components/FormMetrics/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/FormMetrics/index.stories.tsx
@@ -23,6 +23,6 @@ storiesOf("components/FormMetrics", module)
     />
   ))
   .add("with experiment", () => {
-    const { data: experiment } = mockExperimentQuery("boo");
+    const { experiment } = mockExperimentQuery("boo");
     return <Subject {...{ experiment, onSave, onNext }} />;
   });

--- a/app/experimenter/nimbus-ui/src/components/FormMetrics/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/FormMetrics/index.test.tsx
@@ -75,16 +75,16 @@ describe("FormMetrics", () => {
   });
 
   it("displays saving button when loading", async () => {
-    const { data } = mockExperimentQuery("boo");
+    const { experiment } = mockExperimentQuery("boo");
     const onSave = jest.fn();
-    render(<Subject {...{ onSave, experiment: data, isLoading: true }} />);
+    render(<Subject {...{ onSave, experiment, isLoading: true }} />);
 
     const submitButton = screen.getByTestId("submit-button");
     expect(submitButton).toHaveTextContent("Saving");
   });
 
   it("displays saved primary probe sets", async () => {
-    const { data } = mockExperimentQuery("boo", {
+    const { experiment } = mockExperimentQuery("boo", {
       primaryProbeSets: [
         {
           __typename: "NimbusProbeSetType",
@@ -95,14 +95,14 @@ describe("FormMetrics", () => {
       ],
     });
 
-    render(<Subject {...{ experiment: data }} />);
+    render(<Subject {...{ experiment }} />);
 
     const primaryProbeSets = screen.getByTestId("primary-probe-sets");
     expect(primaryProbeSets).toHaveTextContent("Probe Set A");
   });
 
   it("displays saved secondary probe sets", async () => {
-    const { data } = mockExperimentQuery("boo", {
+    const { experiment } = mockExperimentQuery("boo", {
       secondaryProbeSets: [
         {
           __typename: "NimbusProbeSetType",
@@ -112,19 +112,19 @@ describe("FormMetrics", () => {
         },
       ],
     });
-    render(<Subject {...{ experiment: data, probeSets }} />);
+    render(<Subject {...{ experiment, probeSets }} />);
 
     const secondaryProbeSets = screen.getByTestId("secondary-probe-sets");
     expect(secondaryProbeSets).toHaveTextContent("Probe Set A");
   });
 
   it("selects a primary probe set and excludes it from secondary probe sets", async () => {
-    const { data } = mockExperimentQuery("boo", {
+    const { experiment } = mockExperimentQuery("boo", {
       primaryProbeSets: [],
       secondaryProbeSets: [],
     });
 
-    render(<Subject {...{ experiment: data, probeSets }} />);
+    render(<Subject {...{ experiment, probeSets }} />);
     const primaryProbeSets = screen.getByTestId("primary-probe-sets");
     const secondaryProbeSets = screen.getByTestId("secondary-probe-sets");
 
@@ -151,12 +151,12 @@ describe("FormMetrics", () => {
   });
 
   it("selects a secondary probe set and excludes it from primary probe sets", async () => {
-    const { data } = mockExperimentQuery("boo", {
+    const { experiment } = mockExperimentQuery("boo", {
       primaryProbeSets: [],
       secondaryProbeSets: [],
     });
 
-    render(<Subject {...{ experiment: data, probeSets }} />);
+    render(<Subject {...{ experiment, probeSets }} />);
 
     const primaryProbeSets = screen.getByTestId("primary-probe-sets");
     const secondaryProbeSets = screen.getByTestId("secondary-probe-sets");
@@ -184,12 +184,12 @@ describe("FormMetrics", () => {
   });
 
   it("allows maximum 2 primary probe sets", async () => {
-    const { data } = mockExperimentQuery("boo", {
+    const { experiment } = mockExperimentQuery("boo", {
       primaryProbeSets: [],
       secondaryProbeSets: [],
     });
 
-    render(<Subject {...{ experiment: data, probeSets }} />);
+    render(<Subject {...{ experiment, probeSets }} />);
 
     const primaryProbeSets = screen.getByTestId("primary-probe-sets");
 

--- a/app/experimenter/nimbus-ui/src/components/FormMetrics/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/components/FormMetrics/mocks.tsx
@@ -12,7 +12,7 @@ export const Subject = ({
   submitErrors = {},
   onSave = () => {},
   onNext = () => {},
-  experiment = mockExperimentQuery("boo").data,
+  experiment = mockExperimentQuery("boo").experiment,
   probeSets = MOCK_CONFIG.probeSets,
 }: Partial<React.ComponentProps<typeof FormMetrics>>) => (
   <MockedCache>

--- a/app/experimenter/nimbus-ui/src/components/FormOverview/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/FormOverview/index.stories.tsx
@@ -27,6 +27,6 @@ storiesOf("components/FormOverview", module)
     />
   ))
   .add("with experiment", () => {
-    const { data: experiment } = mockExperimentQuery("boo");
+    const { experiment } = mockExperimentQuery("boo");
     return <Subject {...{ experiment, onSubmit, onNext }} />;
   });

--- a/app/experimenter/nimbus-ui/src/components/FormOverview/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/FormOverview/index.test.tsx
@@ -89,16 +89,16 @@ describe("FormOverview", () => {
   });
 
   it("with existing experiment data, asserts field values before allowing submit and next", async () => {
-    const { data } = mockExperimentQuery("boo");
+    const { experiment } = mockExperimentQuery("boo");
 
     const expected = {
-      name: data!.name,
-      hypothesis: data!.hypothesis as string,
-      publicDescription: data!.publicDescription as string,
+      name: experiment.name,
+      hypothesis: experiment.hypothesis as string,
+      publicDescription: experiment.publicDescription as string,
     };
 
     const onSubmit = jest.fn();
-    render(<Subject {...{ onSubmit, experiment: data, onNext: jest.fn() }} />);
+    render(<Subject {...{ onSubmit, experiment, onNext: jest.fn() }} />);
     const submitButton = screen.getByText("Save");
     const nextButton = screen.getByText("Next");
     const nameField = screen.getByLabelText("Public name");
@@ -129,10 +129,10 @@ describe("FormOverview", () => {
   });
 
   it("with missing public description, still allows submit", async () => {
-    const { data } = mockExperimentQuery("boo");
+    const { experiment } = mockExperimentQuery("boo");
 
     const onSubmit = jest.fn();
-    render(<Subject {...{ onSubmit, experiment: data }} />);
+    render(<Subject {...{ onSubmit, experiment }} />);
     const descriptionField = screen.getByLabelText("Public description");
     const submitButton = screen.getByText("Save");
 
@@ -174,9 +174,9 @@ describe("FormOverview", () => {
   });
 
   it("displays saving button when loading", async () => {
-    const { data } = mockExperimentQuery("boo");
+    const { experiment } = mockExperimentQuery("boo");
     const onSubmit = jest.fn();
-    render(<Subject {...{ onSubmit, experiment: data, isLoading: true }} />);
+    render(<Subject {...{ onSubmit, experiment, isLoading: true }} />);
 
     const submitButton = screen.getByTestId("submit-button");
     expect(submitButton).toHaveTextContent("Saving");
@@ -213,7 +213,7 @@ describe("FormOverview", () => {
       },
     });
 
-    const { data: experiment } = mockExperimentQuery("boo");
+    const { experiment } = mockExperimentQuery("boo");
     const isMissingField = jest.fn(() => true);
     render(<Subject {...{ isMissingField, experiment }} />);
 

--- a/app/experimenter/nimbus-ui/src/components/HeaderExperiment/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/HeaderExperiment/index.stories.tsx
@@ -10,24 +10,24 @@ import { mockExperimentQuery, mockGetStatus } from "../../lib/mocks";
 import AppLayout from "../AppLayout";
 import { NimbusExperimentStatus } from "../../types/globalTypes";
 
-const { data } = mockExperimentQuery("demo-slug");
+const { experiment } = mockExperimentQuery("demo-slug");
 
 storiesOf("components/HeaderExperiment", module)
   .addDecorator(withLinks)
   .add("status: draft", () => (
     <AppLayout>
       <HeaderExperiment
-        name={data!.name}
-        slug={data!.slug}
-        status={mockGetStatus(data!.status)}
+        name={experiment.name}
+        slug={experiment.slug}
+        status={mockGetStatus(experiment.status)}
       />
     </AppLayout>
   ))
   .add("status: review", () => (
     <AppLayout>
       <HeaderExperiment
-        name={data!.name}
-        slug={data!.slug}
+        name={experiment.name}
+        slug={experiment.slug}
         status={mockGetStatus(NimbusExperimentStatus.REVIEW)}
       />
     </AppLayout>
@@ -35,8 +35,8 @@ storiesOf("components/HeaderExperiment", module)
   .add("status: live", () => (
     <AppLayout>
       <HeaderExperiment
-        name={data!.name}
-        slug={data!.slug}
+        name={experiment.name}
+        slug={experiment.slug}
         status={mockGetStatus(NimbusExperimentStatus.LIVE)}
       />
     </AppLayout>
@@ -44,8 +44,8 @@ storiesOf("components/HeaderExperiment", module)
   .add("status: complete", () => (
     <AppLayout>
       <HeaderExperiment
-        name={data!.name}
-        slug={data!.slug}
+        name={experiment.name}
+        slug={experiment.slug}
         status={mockGetStatus(NimbusExperimentStatus.COMPLETE)}
       />
     </AppLayout>

--- a/app/experimenter/nimbus-ui/src/components/HeaderExperiment/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/HeaderExperiment/index.test.tsx
@@ -7,15 +7,15 @@ import { screen, render } from "@testing-library/react";
 import HeaderExperiment from ".";
 import { mockExperimentQuery, mockGetStatus } from "../../lib/mocks";
 
-const { data } = mockExperimentQuery("demo-slug");
+const { experiment } = mockExperimentQuery("demo-slug");
 
 describe("HeaderExperiment", () => {
   it("renders as expected", () => {
     render(
       <HeaderExperiment
-        name={data!.name}
-        slug={data!.slug}
-        status={mockGetStatus(data!.status)}
+        name={experiment.name}
+        slug={experiment.slug}
+        status={mockGetStatus(experiment.status)}
       />,
     );
     expect(screen.getByTestId("header-experiment-name")).toHaveTextContent(

--- a/app/experimenter/nimbus-ui/src/components/PageEditAudience/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditAudience/index.test.tsx
@@ -29,7 +29,7 @@ import {
   UpdateExperimentAudienceInput,
 } from "../../types/globalTypes";
 
-const { mock, data } = mockExperimentQuery("demo-slug");
+const { mock, experiment } = mockExperimentQuery("demo-slug");
 
 let mockSubmitData: Partial<UpdateExperimentAudienceInput>;
 let mutationMock: ReturnType<typeof mockUpdateExperimentAudienceMutation>;
@@ -38,12 +38,12 @@ describe("PageEditAudience", () => {
   beforeEach(() => {
     mockSubmitData = { ...MOCK_FORM_DATA };
     mutationMock = mockUpdateExperimentAudienceMutation(
-      { ...mockSubmitData, nimbusExperimentId: parseInt(data!.id, 10) },
+      { ...mockSubmitData, nimbusExperimentId: parseInt(experiment.id, 10) },
       {
         experiment: {
           ...MOCK_FORM_DATA,
           __typename: "NimbusExperimentType",
-          id: data!.id!,
+          id: experiment.id!,
           proposedEnrollment: parseFloat(MOCK_FORM_DATA.proposedEnrollment),
         },
       },

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/index.test.tsx
@@ -61,11 +61,11 @@ describe("PageEditBranches", () => {
   });
 
   it("handles onSave from FormBranches", async () => {
-    const { mock, data: experiment } = mockExperimentQuery("demo-slug");
-    setMockUpdateState(experiment!);
+    const { mock, experiment } = mockExperimentQuery("demo-slug");
+    setMockUpdateState(experiment);
     const mockMutation = mockUpdateExperimentBranchesMutation(
       { ...mockUpdateState, nimbusExperimentId: 1 },
-      { experiment: experiment! },
+      { experiment },
     );
     render(<Subject mocks={[mock, mockMutation, mock]} />);
     await waitFor(() => {
@@ -79,12 +79,12 @@ describe("PageEditBranches", () => {
   });
 
   it("sets a global submit error when updateExperimentBranches fails", async () => {
-    const { mock, data: experiment } = mockExperimentQuery("demo-slug");
-    setMockUpdateState(experiment!);
+    const { mock, experiment } = mockExperimentQuery("demo-slug");
+    setMockUpdateState(experiment);
 
     const mockMutation = mockUpdateExperimentBranchesMutation(
       { ...mockUpdateState, nimbusExperimentId: 1 },
-      { experiment: experiment! },
+      { experiment },
     );
     // @ts-ignore - intentionally breaking this type for error handling
     delete mockMutation.result.data.updateExperimentBranches;
@@ -105,12 +105,12 @@ describe("PageEditBranches", () => {
   });
 
   it("sets submit errors when updateExperimentBranches is not a success", async () => {
-    const { mock, data: experiment } = mockExperimentQuery("demo-slug");
-    setMockUpdateState(experiment!);
+    const { mock, experiment } = mockExperimentQuery("demo-slug");
+    setMockUpdateState(experiment);
 
     const mockMutation = mockUpdateExperimentBranchesMutation(
       { ...mockUpdateState, nimbusExperimentId: 1 },
-      { experiment: experiment! },
+      { experiment },
     );
 
     mockMutation.result.data.updateExperimentBranches.message = {

--- a/app/experimenter/nimbus-ui/src/components/PageEditMetrics/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditMetrics/index.test.tsx
@@ -19,7 +19,7 @@ import { navigate } from "@reach/router";
 import { UPDATE_EXPERIMENT_PROBESETS_MUTATION } from "../../gql/experiments";
 import { SUBMIT_ERROR } from "../../lib/constants";
 
-const { mock, data } = mockExperimentQuery("demo-slug");
+const { mock, experiment } = mockExperimentQuery("demo-slug");
 
 jest.mock("@reach/router", () => ({
   ...jest.requireActual("@reach/router"),
@@ -46,20 +46,22 @@ describe("PageEditMetrics", () => {
 
   beforeEach(() => {
     mockSubmitData = {
-      nimbusExperimentId: parseInt(data!.id),
-      primaryProbeSetIds: data!.primaryProbeSets!.map((p) => parseInt(p!.id)),
-      secondaryProbeSetIds: data!.secondaryProbeSets!.map((p) =>
+      nimbusExperimentId: parseInt(experiment.id),
+      primaryProbeSetIds: experiment.primaryProbeSets!.map((p) =>
+        parseInt(p!.id),
+      ),
+      secondaryProbeSetIds: experiment.secondaryProbeSets!.map((p) =>
         parseInt(p!.id),
       ),
     };
     const mockResponse = {
       experiment: {
-        id: data!.id,
-        primaryProbeSets: data!.primaryProbeSets!.map((p) => ({
+        id: experiment.id,
+        primaryProbeSets: experiment.primaryProbeSets!.map((p) => ({
           id: p?.id,
           name: p?.name,
         })),
-        secondaryProbeSets: data!.secondaryProbeSets!.map((p) => ({
+        secondaryProbeSets: experiment.secondaryProbeSets!.map((p) => ({
           id: p?.id,
           name: p?.name,
         })),

--- a/app/experimenter/nimbus-ui/src/components/PageEditOverview/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditOverview/index.test.tsx
@@ -19,7 +19,7 @@ import { navigate } from "@reach/router";
 import { UPDATE_EXPERIMENT_OVERVIEW_MUTATION } from "../../gql/experiments";
 import { SUBMIT_ERROR } from "../../lib/constants";
 
-const { mock, data } = mockExperimentQuery("demo-slug");
+const { mock, experiment } = mockExperimentQuery("demo-slug");
 
 jest.mock("@reach/router", () => ({
   ...jest.requireActual("@reach/router"),
@@ -46,13 +46,13 @@ describe("PageEditOverview", () => {
 
   beforeEach(() => {
     mockSubmitData = {
-      name: data!.name,
-      hypothesis: data!.hypothesis!,
-      publicDescription: data!.publicDescription!,
+      name: experiment.name,
+      hypothesis: experiment.hypothesis!,
+      publicDescription: experiment.publicDescription!,
     };
     mutationMock = mockExperimentMutation(
       UPDATE_EXPERIMENT_OVERVIEW_MUTATION,
-      { ...mockSubmitData, id: data!.id },
+      { ...mockSubmitData, id: experiment.id },
       "updateExperimentOverview",
       {
         experiment: mockSubmitData,

--- a/app/experimenter/nimbus-ui/src/components/PageRequestReview/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageRequestReview/index.stories.tsx
@@ -11,12 +11,12 @@ import { mockExperimentQuery } from "../../lib/mocks";
 import { NimbusExperimentStatus } from "../../types/globalTypes";
 import { createMutationMock } from "./mocks";
 
-const { mock, data } = mockExperimentQuery("demo-slug");
+const { mock, experiment } = mockExperimentQuery("demo-slug");
 
 storiesOf("pages/RequestReview", module)
   .addDecorator(withLinks)
   .add("success", () => (
-    <RouterSlugProvider mocks={[mock, createMutationMock(data!.id)]}>
+    <RouterSlugProvider mocks={[mock, createMutationMock(experiment.id)]}>
       <PageRequestReview polling={false} />
     </RouterSlugProvider>
   ))

--- a/app/experimenter/nimbus-ui/src/components/PageRequestReview/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageRequestReview/index.test.tsx
@@ -59,10 +59,10 @@ describe("PageRequestReview", () => {
   });
 
   it("can submit for review", async () => {
-    const { mock, data } = mockExperimentQuery("demo-slug", {
+    const { mock, experiment } = mockExperimentQuery("demo-slug", {
       status: NimbusExperimentStatus.DRAFT,
     });
-    const mutationMock = createMutationMock(data!.id);
+    const mutationMock = createMutationMock(experiment.id);
 
     render(<Subject mocks={[mock, mutationMock]} />);
     let submitButton: HTMLButtonElement;
@@ -77,10 +77,10 @@ describe("PageRequestReview", () => {
   });
 
   it("handles submission with bad server data", async () => {
-    const { mock, data } = mockExperimentQuery("demo-slug", {
+    const { mock, experiment } = mockExperimentQuery("demo-slug", {
       status: NimbusExperimentStatus.DRAFT,
     });
-    const mutationMock = createMutationMock(data!.id);
+    const mutationMock = createMutationMock(experiment.id);
     // @ts-ignore - intentionally breaking this type for error handling
     delete mutationMock.result.data.updateExperimentStatus;
     render(<Subject mocks={[mock, mutationMock]} />);
@@ -96,10 +96,10 @@ describe("PageRequestReview", () => {
   });
 
   it("handles submission with server API error", async () => {
-    const { mock, data } = mockExperimentQuery("demo-slug", {
+    const { mock, experiment } = mockExperimentQuery("demo-slug", {
       status: NimbusExperimentStatus.DRAFT,
     });
-    const mutationMock = createMutationMock(data!.id);
+    const mutationMock = createMutationMock(experiment.id);
     mutationMock.result.errors = [new Error("Boo")];
     render(<Subject mocks={[mock, mutationMock]} />);
     let submitButton: HTMLButtonElement;
@@ -114,10 +114,10 @@ describe("PageRequestReview", () => {
   });
 
   it("handles submission with server-side validation errors", async () => {
-    const { mock, data } = mockExperimentQuery("demo-slug", {
+    const { mock, experiment } = mockExperimentQuery("demo-slug", {
       status: NimbusExperimentStatus.DRAFT,
     });
-    const mutationMock = createMutationMock(data!.id);
+    const mutationMock = createMutationMock(experiment.id);
     const errorMessage =
       "Nimbus Experiments can only transition from DRAFT to REVIEW.";
     mutationMock.result.data.updateExperimentStatus.message = {

--- a/app/experimenter/nimbus-ui/src/components/PageResults/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/index.test.tsx
@@ -86,7 +86,7 @@ jest.mock("../AppLayoutWithExperiment", () => ({
   default: (props: React.ComponentProps<typeof AppLayoutWithExperiment>) => (
     <div data-testid="PageResults">
       {props.children({
-        experiment: mockExperimentQuery("demo-slug").data!,
+        experiment: mockExperimentQuery("demo-slug").experiment,
         analysis: mockAnalysisData,
         review: {
           isMissingField: () => false,

--- a/app/experimenter/nimbus-ui/src/components/Summary/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/index.stories.tsx
@@ -13,14 +13,14 @@ import { getExperiment_experimentBySlug } from "../../types/getExperiment";
 
 storiesOf("components/Summary", module)
   .add("draft status", () => {
-    const { data } = mockExperimentQuery("demo-slug");
-    return <Subject experiment={data!} />;
+    const { experiment } = mockExperimentQuery("demo-slug");
+    return <Subject {...{ experiment }} />;
   })
   .add("non-draft status", () => {
-    const { data } = mockExperimentQuery("demo-slug", {
+    const { experiment } = mockExperimentQuery("demo-slug", {
       status: NimbusExperimentStatus.ACCEPTED,
     });
-    return <Subject experiment={data!} />;
+    return <Subject {...{ experiment }} />;
   });
 
 const Subject = ({

--- a/app/experimenter/nimbus-ui/src/components/Summary/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/index.test.tsx
@@ -11,8 +11,8 @@ import { NimbusExperimentStatus } from "../../types/globalTypes";
 
 describe("Summary", () => {
   it("renders expected components", () => {
-    const { data } = mockExperimentQuery("demo-slug");
-    render(<Subject experiment={data!} />);
+    const { experiment } = mockExperimentQuery("demo-slug");
+    render(<Subject {...{ experiment }} />);
     expect(screen.getByTestId("summary-timeline")).toBeInTheDocument();
     expect(screen.getByTestId("table-summary")).toBeInTheDocument();
     expect(screen.getByTestId("table-audience")).toBeInTheDocument();
@@ -20,10 +20,10 @@ describe("Summary", () => {
 
   describe("JSON representation link", () => {
     it("renders in non-draft status", () => {
-      const { data } = mockExperimentQuery("demo-slug", {
+      const { experiment } = mockExperimentQuery("demo-slug", {
         status: NimbusExperimentStatus.COMPLETE,
       });
-      render(<Subject experiment={data!} />);
+      render(<Subject {...{ experiment }} />);
       expect(screen.getByTestId("link-json")).toBeInTheDocument();
       expect(screen.getByTestId("link-json")).toHaveAttribute(
         "href",
@@ -33,8 +33,8 @@ describe("Summary", () => {
   });
 
   it("does not render in draft status", () => {
-    const { data } = mockExperimentQuery("demo-slug");
-    render(<Subject experiment={data!} />);
+    const { experiment } = mockExperimentQuery("demo-slug");
+    render(<Subject {...{ experiment }} />);
     expect(screen.queryByTestId("link-json")).not.toBeInTheDocument();
   });
 });

--- a/app/experimenter/nimbus-ui/src/components/SummaryTimeline/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/components/SummaryTimeline/mocks.tsx
@@ -20,12 +20,12 @@ export const Subject = ({
   proposedEnrollment?: number | null;
   status?: NimbusExperimentStatus;
 }) => {
-  const { data: experiment } = mockExperimentQuery("something-vague", {
+  const { experiment } = mockExperimentQuery("something-vague", {
     startDate,
     endDate,
     proposedDuration,
     proposedEnrollment,
     status,
   });
-  return <SummaryTimeline experiment={experiment!} />;
+  return <SummaryTimeline {...{ experiment }} />;
 };

--- a/app/experimenter/nimbus-ui/src/components/TableAudience/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/TableAudience/index.stories.tsx
@@ -12,36 +12,36 @@ import { NimbusExperimentChannel } from "../../types/globalTypes";
 
 storiesOf("components/TableAudience", module)
   .add("all fields filled out", () => {
-    const { data } = mockExperimentQuery("demo-slug", {
+    const { experiment } = mockExperimentQuery("demo-slug", {
       channels: [NimbusExperimentChannel.DESKTOP_BETA],
     });
     return (
       <Subject>
-        <TableAudience experiment={data!} />
+        <TableAudience {...{ experiment }} />
       </Subject>
     );
   })
   .add("filled out with multiple channels", () => {
-    const { data } = mockExperimentQuery("demo-slug");
+    const { experiment } = mockExperimentQuery("demo-slug");
     return (
       <Subject>
-        <TableAudience experiment={data!} />
+        <TableAudience {...{ experiment }} />
       </Subject>
     );
   })
   .add("only required fields filled out", () => {
-    const { data } = mockExperimentQuery("demo-slug", {
+    const { experiment } = mockExperimentQuery("demo-slug", {
       totalEnrolledClients: 0,
       targetingConfigSlug: null,
     });
     return (
       <Subject>
-        <TableAudience experiment={data!} />
+        <TableAudience {...{ experiment }} />
       </Subject>
     );
   })
   .add("missing required fields", () => {
-    const { data } = mockExperimentQuery("demo-slug", {
+    const { experiment } = mockExperimentQuery("demo-slug", {
       channels: [],
       firefoxMinVersion: null,
       populationPercent: 0,
@@ -51,7 +51,7 @@ storiesOf("components/TableAudience", module)
 
     return (
       <Subject>
-        <TableAudience experiment={data!} />
+        <TableAudience {...{ experiment }} />
       </Subject>
     );
   });

--- a/app/experimenter/nimbus-ui/src/components/TableAudience/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/TableAudience/index.test.tsx
@@ -12,26 +12,26 @@ import { NimbusExperimentChannel } from "../../types/globalTypes";
 describe("TableAudience", () => {
   describe("renders 'Channels' row as expected", () => {
     it("with one channel", () => {
-      const { data } = mockExperimentQuery("demo-slug", {
+      const { experiment } = mockExperimentQuery("demo-slug", {
         channels: [NimbusExperimentChannel.DESKTOP_BETA],
       });
-      render(<Subject experiment={data!} />);
+      render(<Subject {...{ experiment }} />);
       expect(screen.getByTestId("experiment-channels")).toHaveTextContent(
         "Desktop Beta",
       );
     });
     it("with multiple channels", () => {
-      const { data } = mockExperimentQuery("demo-slug");
-      render(<Subject experiment={data!} />);
+      const { experiment } = mockExperimentQuery("demo-slug");
+      render(<Subject {...{ experiment }} />);
       expect(screen.getByTestId("experiment-channels")).toHaveTextContent(
         "Desktop Nightly, Desktop Beta",
       );
     });
     it("when not set", () => {
-      const { data } = mockExperimentQuery("demo-slug", {
+      const { experiment } = mockExperimentQuery("demo-slug", {
         channels: [],
       });
-      render(<Subject experiment={data!} />);
+      render(<Subject {...{ experiment }} />);
       expect(screen.getByTestId("experiment-channels")).toHaveTextContent(
         "Not set",
       );
@@ -39,17 +39,17 @@ describe("TableAudience", () => {
   });
   describe("renders 'Minimum version' row as expected", () => {
     it("when set", () => {
-      const { data } = mockExperimentQuery("demo-slug");
-      render(<Subject experiment={data!} />);
+      const { experiment } = mockExperimentQuery("demo-slug");
+      render(<Subject {...{ experiment }} />);
       expect(screen.getByTestId("experiment-ff-min")).toHaveTextContent(
         "Firefox 80",
       );
     });
     it("when not set", () => {
-      const { data } = mockExperimentQuery("demo-slug", {
+      const { experiment } = mockExperimentQuery("demo-slug", {
         firefoxMinVersion: null,
       });
-      render(<Subject experiment={data!} />);
+      render(<Subject {...{ experiment }} />);
       expect(screen.getByTestId("experiment-ff-min")).toHaveTextContent(
         "Not set",
       );
@@ -58,17 +58,17 @@ describe("TableAudience", () => {
 
   describe("renders 'Population %' row as expected", () => {
     it("when set", () => {
-      const { data } = mockExperimentQuery("demo-slug");
-      render(<Subject experiment={data!} />);
+      const { experiment } = mockExperimentQuery("demo-slug");
+      render(<Subject {...{ experiment }} />);
       expect(screen.getByTestId("experiment-population")).toHaveTextContent(
         "40%",
       );
     });
     it("when not set", () => {
-      const { data } = mockExperimentQuery("demo-slug", {
+      const { experiment } = mockExperimentQuery("demo-slug", {
         populationPercent: null,
       });
-      render(<Subject experiment={data!} />);
+      render(<Subject {...{ experiment }} />);
       expect(screen.getByTestId("experiment-population")).toHaveTextContent(
         "Not set",
       );
@@ -77,17 +77,17 @@ describe("TableAudience", () => {
 
   describe("renders 'Expected enrolled clients' row as expected", () => {
     it("when set", () => {
-      const { data } = mockExperimentQuery("demo-slug");
-      render(<Subject experiment={data!} />);
+      const { experiment } = mockExperimentQuery("demo-slug");
+      render(<Subject {...{ experiment }} />);
       expect(screen.getByTestId("experiment-total-enrolled")).toHaveTextContent(
         "68,000",
       );
     });
     it("when not set", () => {
-      const { data } = mockExperimentQuery("demo-slug", {
+      const { experiment } = mockExperimentQuery("demo-slug", {
         totalEnrolledClients: 0,
       });
-      render(<Subject experiment={data!} />);
+      render(<Subject {...{ experiment }} />);
       expect(
         screen.queryByTestId("experiment-total-enrolled"),
       ).not.toBeInTheDocument();
@@ -96,17 +96,17 @@ describe("TableAudience", () => {
 
   describe("renders 'Custom audience' row as expected", () => {
     it("when set", () => {
-      const { data } = mockExperimentQuery("demo-slug");
-      render(<Subject experiment={data!} />);
+      const { experiment } = mockExperimentQuery("demo-slug");
+      render(<Subject {...{ experiment }} />);
       expect(screen.getByTestId("experiment-target")).toHaveTextContent(
         "Us Only",
       );
     });
     it("when not set", () => {
-      const { data } = mockExperimentQuery("demo-slug", {
+      const { experiment } = mockExperimentQuery("demo-slug", {
         targetingConfigSlug: null,
       });
-      render(<Subject experiment={data!} />);
+      render(<Subject {...{ experiment }} />);
       expect(screen.queryByTestId("experiment-target")).not.toBeInTheDocument();
     });
   });

--- a/app/experimenter/nimbus-ui/src/components/TableHighlights/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/TableHighlights/index.stories.tsx
@@ -13,18 +13,18 @@ import { mockAnalysis } from "../../lib/visualization/mocks";
 storiesOf("visualization/TableHighlights", module)
   .addDecorator(withLinks)
   .add("basic, with one primary probe set", () => {
-    const { mock, data } = mockExperimentQuery("demo-slug");
+    const { mock, experiment } = mockExperimentQuery("demo-slug");
     return (
       <RouterSlugProvider mocks={[mock]}>
         <TableHighlights
-          primaryProbeSets={data!.primaryProbeSets!}
+          primaryProbeSets={experiment.primaryProbeSets!}
           results={mockAnalysis().overall}
         />
       </RouterSlugProvider>
     );
   })
   .add("with multiple primary probe sets", () => {
-    const { mock, data } = mockExperimentQuery("demo-slug", {
+    const { mock, experiment } = mockExperimentQuery("demo-slug", {
       primaryProbeSets: [
         {
           __typename: "NimbusProbeSetType",
@@ -49,7 +49,7 @@ storiesOf("visualization/TableHighlights", module)
     return (
       <RouterSlugProvider mocks={[mock]}>
         <TableHighlights
-          primaryProbeSets={data!.primaryProbeSets!}
+          primaryProbeSets={experiment.primaryProbeSets!}
           results={mockAnalysis().overall}
         />
       </RouterSlugProvider>

--- a/app/experimenter/nimbus-ui/src/components/TableHighlights/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/TableHighlights/index.test.tsx
@@ -9,7 +9,7 @@ import { mockExperimentQuery } from "../../lib/mocks";
 import { mockAnalysis } from "../../lib/visualization/mocks";
 import { RouterSlugProvider } from "../../lib/test-utils";
 
-const { mock, data } = mockExperimentQuery("demo-slug");
+const { mock, experiment } = mockExperimentQuery("demo-slug");
 
 describe("TableHighlights", () => {
   it("has participants for all users shown for each variant", () => {
@@ -18,7 +18,7 @@ describe("TableHighlights", () => {
     render(
       <RouterSlugProvider mocks={[mock]}>
         <TableHighlights
-          primaryProbeSets={data!.primaryProbeSets!}
+          primaryProbeSets={experiment.primaryProbeSets!}
           results={mockAnalysis().overall}
         />
       </RouterSlugProvider>,
@@ -37,7 +37,7 @@ describe("TableHighlights", () => {
     render(
       <RouterSlugProvider mocks={[mock]}>
         <TableHighlights
-          primaryProbeSets={data!.primaryProbeSets!}
+          primaryProbeSets={experiment.primaryProbeSets!}
           results={mockAnalysis().overall}
         />
       </RouterSlugProvider>,
@@ -52,7 +52,7 @@ describe("TableHighlights", () => {
     render(
       <RouterSlugProvider mocks={[mock]}>
         <TableHighlights
-          primaryProbeSets={data!.primaryProbeSets!}
+          primaryProbeSets={experiment.primaryProbeSets!}
           results={mockAnalysis().overall}
         />
       </RouterSlugProvider>,

--- a/app/experimenter/nimbus-ui/src/components/TableHighlightsOverview/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/TableHighlightsOverview/index.stories.tsx
@@ -13,18 +13,18 @@ import { mockAnalysis } from "../../lib/visualization/mocks";
 storiesOf("visualization/TableHighlightsOverview", module)
   .addDecorator(withLinks)
   .add("basic, with one primary probe set", () => {
-    const { mock, data } = mockExperimentQuery("demo-slug");
+    const { mock, experiment } = mockExperimentQuery("demo-slug");
     return (
       <RouterSlugProvider mocks={[mock]}>
         <TableHighlightsOverview
-          experiment={data!}
+          {...{ experiment }}
           results={mockAnalysis().overall}
         />
       </RouterSlugProvider>
     );
   })
   .add("with multiple primary probe sets", () => {
-    const { mock, data } = mockExperimentQuery("demo-slug", {
+    const { mock, experiment } = mockExperimentQuery("demo-slug", {
       primaryProbeSets: [
         {
           __typename: "NimbusProbeSetType",
@@ -49,7 +49,7 @@ storiesOf("visualization/TableHighlightsOverview", module)
     return (
       <RouterSlugProvider mocks={[mock]}>
         <TableHighlightsOverview
-          experiment={data!}
+          {...{ experiment }}
           results={mockAnalysis().overall}
         />
       </RouterSlugProvider>

--- a/app/experimenter/nimbus-ui/src/components/TableHighlightsOverview/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/TableHighlightsOverview/index.test.tsx
@@ -9,7 +9,7 @@ import { mockExperimentQuery } from "../../lib/mocks";
 import { mockAnalysis } from "../../lib/visualization/mocks";
 import { RouterSlugProvider } from "../../lib/test-utils";
 
-const { mock, data } = mockExperimentQuery("demo-slug");
+const { mock, experiment } = mockExperimentQuery("demo-slug");
 
 describe("TableHighlightsOverview", () => {
   it("has the correct headings", async () => {
@@ -18,7 +18,7 @@ describe("TableHighlightsOverview", () => {
     render(
       <RouterSlugProvider mocks={[mock]}>
         <TableHighlightsOverview
-          experiment={data!}
+          {...{ experiment }}
           results={mockAnalysis().overall}
         />
       </RouterSlugProvider>,
@@ -33,7 +33,7 @@ describe("TableHighlightsOverview", () => {
     render(
       <RouterSlugProvider mocks={[mock]}>
         <TableHighlightsOverview
-          experiment={data!}
+          {...{ experiment }}
           results={mockAnalysis().overall}
         />
       </RouterSlugProvider>,
@@ -50,7 +50,7 @@ describe("TableHighlightsOverview", () => {
     render(
       <RouterSlugProvider mocks={[mock]}>
         <TableHighlightsOverview
-          experiment={data!}
+          {...{ experiment }}
           results={mockAnalysis().overall}
         />
       </RouterSlugProvider>,
@@ -63,7 +63,7 @@ describe("TableHighlightsOverview", () => {
     render(
       <RouterSlugProvider mocks={[mock]}>
         <TableHighlightsOverview
-          experiment={data!}
+          {...{ experiment }}
           results={mockAnalysis().overall}
         />
       </RouterSlugProvider>,

--- a/app/experimenter/nimbus-ui/src/components/TableMetricPrimary/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/TableMetricPrimary/index.stories.tsx
@@ -12,7 +12,7 @@ import { mockAnalysis } from "../../lib/visualization/mocks";
 storiesOf("visualization/TableMetricPrimary", module)
   .addDecorator(withLinks)
   .add("with positive primary metric", () => {
-    const { data } = mockExperimentQuery("demo-slug", {
+    const { experiment } = mockExperimentQuery("demo-slug", {
       primaryProbeSets: [
         {
           __typename: "NimbusProbeSetType",
@@ -26,12 +26,12 @@ storiesOf("visualization/TableMetricPrimary", module)
     return (
       <TableMetricPrimary
         results={mockAnalysis().overall}
-        probeSet={data!.primaryProbeSets![0]!}
+        probeSet={experiment.primaryProbeSets![0]!}
       />
     );
   })
   .add("with negative primary metric", () => {
-    const { data } = mockExperimentQuery("demo-slug", {
+    const { experiment } = mockExperimentQuery("demo-slug", {
       primaryProbeSets: [
         {
           __typename: "NimbusProbeSetType",
@@ -45,12 +45,12 @@ storiesOf("visualization/TableMetricPrimary", module)
     return (
       <TableMetricPrimary
         results={mockAnalysis().overall}
-        probeSet={data!.primaryProbeSets![0]!}
+        probeSet={experiment.primaryProbeSets![0]!}
       />
     );
   })
   .add("with neutral primary metric", () => {
-    const { data } = mockExperimentQuery("demo-slug", {
+    const { experiment } = mockExperimentQuery("demo-slug", {
       primaryProbeSets: [
         {
           __typename: "NimbusProbeSetType",
@@ -64,7 +64,7 @@ storiesOf("visualization/TableMetricPrimary", module)
     return (
       <TableMetricPrimary
         results={mockAnalysis().overall}
-        probeSet={data!.primaryProbeSets![0]!}
+        probeSet={experiment.primaryProbeSets![0]!}
       />
     );
   });

--- a/app/experimenter/nimbus-ui/src/components/TableMetricPrimary/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/TableMetricPrimary/index.test.tsx
@@ -16,13 +16,13 @@ describe("TableMetricPrimary", () => {
       "Conversion Rate",
       "Relative Improvement",
     ];
-    const { mock, data } = mockExperimentQuery("demo-slug");
+    const { mock, experiment } = mockExperimentQuery("demo-slug");
 
     render(
       <RouterSlugProvider mocks={[mock]}>
         <TableMetricPrimary
           results={mockAnalysis().overall}
-          probeSet={data!.primaryProbeSets![0]!}
+          probeSet={experiment.primaryProbeSets![0]!}
         />
       </RouterSlugProvider>,
     );
@@ -33,13 +33,13 @@ describe("TableMetricPrimary", () => {
   });
 
   it("has correctly labelled result significance", () => {
-    const { mock, data } = mockExperimentQuery("demo-slug");
+    const { mock, experiment } = mockExperimentQuery("demo-slug");
 
     render(
       <RouterSlugProvider mocks={[mock]}>
         <TableMetricPrimary
           results={mockAnalysis().overall}
-          probeSet={data!.primaryProbeSets![0]!}
+          probeSet={experiment.primaryProbeSets![0]!}
         />
       </RouterSlugProvider>,
     );
@@ -53,13 +53,13 @@ describe("TableMetricPrimary", () => {
   });
 
   it("has the expected control and treatment labels", () => {
-    const { mock, data } = mockExperimentQuery("demo-slug");
+    const { mock, experiment } = mockExperimentQuery("demo-slug");
 
     render(
       <RouterSlugProvider mocks={[mock]}>
         <TableMetricPrimary
           results={mockAnalysis().overall}
-          probeSet={data!.primaryProbeSets![0]!}
+          probeSet={experiment.primaryProbeSets![0]!}
         />
       </RouterSlugProvider>,
     );
@@ -69,13 +69,13 @@ describe("TableMetricPrimary", () => {
   });
 
   it("shows the positive improvement bar", () => {
-    const { mock, data } = mockExperimentQuery("demo-slug");
+    const { mock, experiment } = mockExperimentQuery("demo-slug");
 
     render(
       <RouterSlugProvider mocks={[mock]}>
         <TableMetricPrimary
           results={mockAnalysis().overall}
-          probeSet={data!.primaryProbeSets![0]!}
+          probeSet={experiment.primaryProbeSets![0]!}
         />
       </RouterSlugProvider>,
     );
@@ -89,7 +89,7 @@ describe("TableMetricPrimary", () => {
   });
 
   it("shows the negative improvement bar", () => {
-    const { mock, data } = mockExperimentQuery("demo-slug", {
+    const { mock, experiment } = mockExperimentQuery("demo-slug", {
       primaryProbeSets: [
         {
           __typename: "NimbusProbeSetType",
@@ -104,7 +104,7 @@ describe("TableMetricPrimary", () => {
       <RouterSlugProvider mocks={[mock]}>
         <TableMetricPrimary
           results={mockAnalysis().overall}
-          probeSet={data!.primaryProbeSets![0]!}
+          probeSet={experiment.primaryProbeSets![0]!}
         />
       </RouterSlugProvider>,
     );
@@ -118,7 +118,7 @@ describe("TableMetricPrimary", () => {
   });
 
   it("shows the neutral improvement bar", () => {
-    const { mock, data } = mockExperimentQuery("demo-slug", {
+    const { mock, experiment } = mockExperimentQuery("demo-slug", {
       primaryProbeSets: [
         {
           __typename: "NimbusProbeSetType",
@@ -133,7 +133,7 @@ describe("TableMetricPrimary", () => {
       <RouterSlugProvider mocks={[mock]}>
         <TableMetricPrimary
           results={mockAnalysis().overall}
-          probeSet={data!.primaryProbeSets![0]!}
+          probeSet={experiment.primaryProbeSets![0]!}
         />
       </RouterSlugProvider>,
     );

--- a/app/experimenter/nimbus-ui/src/components/TableMetricSecondary/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/TableMetricSecondary/index.stories.tsx
@@ -12,7 +12,7 @@ import { mockAnalysis } from "../../lib/visualization/mocks";
 storiesOf("visualization/TableMetricSecondary", module)
   .addDecorator(withLinks)
   .add("with positive secondary metric", () => {
-    const { data } = mockExperimentQuery("demo-slug", {
+    const { experiment } = mockExperimentQuery("demo-slug", {
       secondaryProbeSets: [
         {
           __typename: "NimbusProbeSetType",
@@ -26,21 +26,21 @@ storiesOf("visualization/TableMetricSecondary", module)
     return (
       <TableMetricSecondary
         results={mockAnalysis().overall}
-        probeSet={data!.secondaryProbeSets![0]!}
+        probeSet={experiment.secondaryProbeSets![0]!}
       />
     );
   })
   .add("with negative secondary metric", () => {
-    const { data } = mockExperimentQuery("demo-slug");
+    const { experiment } = mockExperimentQuery("demo-slug");
     return (
       <TableMetricSecondary
         results={mockAnalysis().overall}
-        probeSet={data!.secondaryProbeSets![0]!}
+        probeSet={experiment.secondaryProbeSets![0]!}
       />
     );
   })
   .add("with neutral secondary metric", () => {
-    const { data } = mockExperimentQuery("demo-slug", {
+    const { experiment } = mockExperimentQuery("demo-slug", {
       secondaryProbeSets: [
         {
           __typename: "NimbusProbeSetType",
@@ -54,7 +54,7 @@ storiesOf("visualization/TableMetricSecondary", module)
     return (
       <TableMetricSecondary
         results={mockAnalysis().overall}
-        probeSet={data!.secondaryProbeSets![0]!}
+        probeSet={experiment.secondaryProbeSets![0]!}
       />
     );
   });

--- a/app/experimenter/nimbus-ui/src/components/TableMetricSecondary/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/TableMetricSecondary/index.test.tsx
@@ -12,13 +12,13 @@ import { mockExperimentQuery } from "../../lib/mocks";
 describe("TableMetricSecondary", () => {
   it("has the correct headings", async () => {
     const EXPECTED_HEADINGS = ["Count", "Relative Improvement"];
-    const { mock, data } = mockExperimentQuery("demo-slug");
+    const { mock, experiment } = mockExperimentQuery("demo-slug");
 
     render(
       <RouterSlugProvider mocks={[mock]}>
         <TableMetricSecondary
           results={mockAnalysis().overall}
-          probeSet={data!.primaryProbeSets![0]!}
+          probeSet={experiment.primaryProbeSets![0]!}
         />
       </RouterSlugProvider>,
     );
@@ -29,12 +29,12 @@ describe("TableMetricSecondary", () => {
   });
 
   it("has correctly labelled result significance", async () => {
-    const { mock, data } = mockExperimentQuery("demo-slug");
+    const { mock, experiment } = mockExperimentQuery("demo-slug");
     render(
       <RouterSlugProvider mocks={[mock]}>
         <TableMetricSecondary
           results={mockAnalysis().overall}
-          probeSet={data!.primaryProbeSets![0]!}
+          probeSet={experiment.primaryProbeSets![0]!}
         />
       </RouterSlugProvider>,
     );
@@ -48,12 +48,12 @@ describe("TableMetricSecondary", () => {
   });
 
   it("has the expected control and treatment labels", async () => {
-    const { mock, data } = mockExperimentQuery("demo-slug");
+    const { mock, experiment } = mockExperimentQuery("demo-slug");
     render(
       <RouterSlugProvider mocks={[mock]}>
         <TableMetricSecondary
           results={mockAnalysis().overall}
-          probeSet={data!.primaryProbeSets![0]!}
+          probeSet={experiment.primaryProbeSets![0]!}
         />
       </RouterSlugProvider>,
     );
@@ -63,12 +63,12 @@ describe("TableMetricSecondary", () => {
   });
 
   it("shows the positive improvement bar", async () => {
-    const { mock, data } = mockExperimentQuery("demo-slug");
+    const { mock, experiment } = mockExperimentQuery("demo-slug");
     render(
       <RouterSlugProvider mocks={[mock]}>
         <TableMetricSecondary
           results={mockAnalysis().overall}
-          probeSet={data!.primaryProbeSets![0]!}
+          probeSet={experiment.primaryProbeSets![0]!}
         />
       </RouterSlugProvider>,
     );

--- a/app/experimenter/nimbus-ui/src/components/TableResults/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/TableResults/index.stories.tsx
@@ -13,18 +13,18 @@ import { mockAnalysis } from "../../lib/visualization/mocks";
 storiesOf("visualization/TableResults", module)
   .addDecorator(withLinks)
   .add("basic, with one primary probe set", () => {
-    const { mock, data } = mockExperimentQuery("demo-slug");
+    const { mock, experiment } = mockExperimentQuery("demo-slug");
     return (
       <RouterSlugProvider mocks={[mock]}>
         <TableResults
-          primaryProbeSets={data!.primaryProbeSets!}
+          primaryProbeSets={experiment.primaryProbeSets!}
           results={mockAnalysis().overall}
         />
       </RouterSlugProvider>
     );
   })
   .add("with multiple primary probe sets", () => {
-    const { mock, data } = mockExperimentQuery("demo-slug", {
+    const { mock, experiment } = mockExperimentQuery("demo-slug", {
       primaryProbeSets: [
         {
           __typename: "NimbusProbeSetType",
@@ -49,7 +49,7 @@ storiesOf("visualization/TableResults", module)
     return (
       <RouterSlugProvider mocks={[mock]}>
         <TableResults
-          primaryProbeSets={data!.primaryProbeSets!}
+          primaryProbeSets={experiment.primaryProbeSets!}
           results={mockAnalysis().overall}
         />
       </RouterSlugProvider>

--- a/app/experimenter/nimbus-ui/src/components/TableResults/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/TableResults/index.test.tsx
@@ -12,14 +12,14 @@ import {
   mockIncompleteAnalysis,
 } from "../../lib/visualization/mocks";
 
-const { mock, data } = mockExperimentQuery("demo-slug");
+const { mock, experiment } = mockExperimentQuery("demo-slug");
 
 describe("TableResults", () => {
   it("renders correct headings", () => {
     render(
       <RouterSlugProvider mocks={[mock]}>
         <TableResults
-          primaryProbeSets={data!.primaryProbeSets!}
+          primaryProbeSets={experiment.primaryProbeSets!}
           results={mockAnalysis().overall}
         />
       </RouterSlugProvider>,
@@ -40,7 +40,7 @@ describe("TableResults", () => {
     render(
       <RouterSlugProvider mocks={[mock]}>
         <TableResults
-          primaryProbeSets={data!.primaryProbeSets!}
+          primaryProbeSets={experiment.primaryProbeSets!}
           results={mockAnalysis().overall}
         />
       </RouterSlugProvider>,
@@ -55,7 +55,7 @@ describe("TableResults", () => {
     render(
       <RouterSlugProvider mocks={[mock]}>
         <TableResults
-          primaryProbeSets={data!.primaryProbeSets!}
+          primaryProbeSets={experiment.primaryProbeSets!}
           results={mockAnalysis().overall}
         />
       </RouterSlugProvider>,
@@ -70,7 +70,7 @@ describe("TableResults", () => {
     render(
       <RouterSlugProvider mocks={[mock]}>
         <TableResults
-          primaryProbeSets={data!.primaryProbeSets!}
+          primaryProbeSets={experiment.primaryProbeSets!}
           results={mockIncompleteAnalysis().overall}
         />
       </RouterSlugProvider>,

--- a/app/experimenter/nimbus-ui/src/components/TableSummary/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/TableSummary/index.stories.tsx
@@ -11,17 +11,17 @@ import { RouterSlugProvider } from "../../lib/test-utils";
 
 storiesOf("components/TableSummary", module)
   .add("all fields filled out", () => {
-    const { data } = mockExperimentQuery("demo-slug", {
+    const { experiment } = mockExperimentQuery("demo-slug", {
       featureConfig: MOCK_CONFIG.featureConfig![1],
     });
     return (
       <Subject>
-        <TableSummary experiment={data!} />
+        <TableSummary {...{ experiment }} />
       </Subject>
     );
   })
   .add("filled out with multiple probe sets", () => {
-    const { data } = mockExperimentQuery("demo-slug", {
+    const { experiment } = mockExperimentQuery("demo-slug", {
       featureConfig: MOCK_CONFIG.featureConfig![1],
       primaryProbeSets: [
         {
@@ -54,23 +54,23 @@ storiesOf("components/TableSummary", module)
     });
     return (
       <Subject>
-        <TableSummary experiment={data!} />
+        <TableSummary {...{ experiment }} />
       </Subject>
     );
   })
   .add("only required fields filled out", () => {
-    const { data } = mockExperimentQuery("demo-slug", {
+    const { experiment } = mockExperimentQuery("demo-slug", {
       primaryProbeSets: [],
       secondaryProbeSets: [],
     });
     return (
       <Subject>
-        <TableSummary experiment={data!} />
+        <TableSummary {...{ experiment }} />
       </Subject>
     );
   })
   .add("missing required fields", () => {
-    const { data } = mockExperimentQuery("demo-slug", {
+    const { experiment } = mockExperimentQuery("demo-slug", {
       primaryProbeSets: [],
       secondaryProbeSets: [],
       publicDescription: null,
@@ -78,7 +78,7 @@ storiesOf("components/TableSummary", module)
 
     return (
       <Subject>
-        <TableSummary experiment={data!} />
+        <TableSummary {...{ experiment }} />
       </Subject>
     );
   });

--- a/app/experimenter/nimbus-ui/src/components/TableSummary/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/TableSummary/index.test.tsx
@@ -10,8 +10,8 @@ import { getExperiment_experimentBySlug } from "../../types/getExperiment";
 
 describe("TableSummary", () => {
   it("renders rows displaying required fields at experiment creation as expected", () => {
-    const { data } = mockExperimentQuery("demo-slug");
-    render(<Subject experiment={data!} />);
+    const { experiment } = mockExperimentQuery("demo-slug");
+    render(<Subject {...{ experiment }} />);
 
     expect(screen.getByTestId("experiment-slug")).toHaveTextContent(
       "demo-slug",
@@ -28,23 +28,23 @@ describe("TableSummary", () => {
   });
 
   it("renders Not Set if experiment owner is not set", () => {
-    const { data } = mockExperimentQuery("demo-slug", {
+    const { experiment } = mockExperimentQuery("demo-slug", {
       owner: null,
     });
-    render(<Subject experiment={data!} />);
+    render(<Subject {...{ experiment }} />);
     expect(screen.getByTestId("experiment-owner")).toHaveTextContent("Not set");
   });
 
   describe("renders 'Primary probe sets' row as expected", () => {
     it("with one probe set", () => {
-      const { data } = mockExperimentQuery("demo-slug");
-      render(<Subject experiment={data!} />);
+      const { experiment } = mockExperimentQuery("demo-slug");
+      render(<Subject {...{ experiment }} />);
       expect(screen.getByTestId("experiment-probe-primary")).toHaveTextContent(
         "Picture-in-Picture",
       );
     });
     it("with multiple probe sets", () => {
-      const { data } = mockExperimentQuery("demo-slug", {
+      const { experiment } = mockExperimentQuery("demo-slug", {
         primaryProbeSets: [
           {
             __typename: "NimbusProbeSetType",
@@ -60,16 +60,16 @@ describe("TableSummary", () => {
           },
         ],
       });
-      render(<Subject experiment={data!} />);
+      render(<Subject {...{ experiment }} />);
       expect(screen.getByTestId("experiment-probe-primary")).toHaveTextContent(
         "Picture-in-Picture, Feature C",
       );
     });
     it("when not set", () => {
-      const { data } = mockExperimentQuery("demo-slug", {
+      const { experiment } = mockExperimentQuery("demo-slug", {
         primaryProbeSets: [],
       });
-      render(<Subject experiment={data!} />);
+      render(<Subject {...{ experiment }} />);
       expect(
         screen.queryByTestId("experiment-probe-primary"),
       ).not.toBeInTheDocument();
@@ -78,14 +78,14 @@ describe("TableSummary", () => {
 
   describe("renders 'Secondary probe sets' row as expected", () => {
     it("with one probe set", () => {
-      const { data } = mockExperimentQuery("demo-slug");
-      render(<Subject experiment={data!} />);
+      const { experiment } = mockExperimentQuery("demo-slug");
+      render(<Subject {...{ experiment }} />);
       expect(
         screen.getByTestId("experiment-probe-secondary"),
       ).toHaveTextContent("Feature B");
     });
     it("with multiple probe sets", () => {
-      const { data } = mockExperimentQuery("demo-slug", {
+      const { experiment } = mockExperimentQuery("demo-slug", {
         secondaryProbeSets: [
           {
             __typename: "NimbusProbeSetType",
@@ -101,16 +101,16 @@ describe("TableSummary", () => {
           },
         ],
       });
-      render(<Subject experiment={data!} />);
+      render(<Subject {...{ experiment }} />);
       expect(
         screen.getByTestId("experiment-probe-secondary"),
       ).toHaveTextContent("Picture-in-Picture, Feature B");
     });
     it("when not set", () => {
-      const { data } = mockExperimentQuery("demo-slug", {
+      const { experiment } = mockExperimentQuery("demo-slug", {
         secondaryProbeSets: [],
       });
-      render(<Subject experiment={data!} />);
+      render(<Subject {...{ experiment }} />);
       expect(
         screen.queryByTestId("experiment-probe-secondary"),
       ).not.toBeInTheDocument();
@@ -118,17 +118,17 @@ describe("TableSummary", () => {
 
     describe("renders 'Public description' row as expected", () => {
       it("when set", () => {
-        const { data } = mockExperimentQuery("demo-slug");
-        render(<Subject experiment={data!} />);
+        const { experiment } = mockExperimentQuery("demo-slug");
+        render(<Subject {...{ experiment }} />);
         expect(screen.getByTestId("experiment-description")).toHaveTextContent(
           "Official approach present industry strategy dream piece.",
         );
       });
       it("when not set", () => {
-        const { data } = mockExperimentQuery("demo-slug", {
+        const { experiment } = mockExperimentQuery("demo-slug", {
           publicDescription: null,
         });
-        render(<Subject experiment={data!} />);
+        render(<Subject {...{ experiment }} />);
         expect(screen.getByTestId("experiment-description")).toHaveTextContent(
           "Not set",
         );
@@ -138,17 +138,17 @@ describe("TableSummary", () => {
 
   describe("renders 'Feature config' row as expected", () => {
     it("when set", () => {
-      const { data } = mockExperimentQuery("demo-slug", {
+      const { experiment } = mockExperimentQuery("demo-slug", {
         featureConfig: MOCK_CONFIG.featureConfig![1],
       });
-      render(<Subject experiment={data!} />);
+      render(<Subject {...{ experiment }} />);
       expect(screen.getByTestId("experiment-feature-config")).toHaveTextContent(
         "Mauris odio erat",
       );
     });
     it("when not set", () => {
-      const { data } = mockExperimentQuery("demo-slug");
-      render(<Subject experiment={data!} />);
+      const { experiment } = mockExperimentQuery("demo-slug");
+      render(<Subject {...{ experiment }} />);
       expect(
         screen.queryByTestId("experiment-feature-config"),
       ).not.toBeInTheDocument();

--- a/app/experimenter/nimbus-ui/src/hooks/useExperiment.test.tsx
+++ b/app/experimenter/nimbus-ui/src/hooks/useExperiment.test.tsx
@@ -17,7 +17,7 @@ describe("hooks/useExperiment", () => {
     };
 
     it("returns the experiment", async () => {
-      const { mock, data } = mockExperimentQuery("howdy");
+      const { mock, experiment } = mockExperimentQuery("howdy");
 
       render(
         <MockedCache mocks={[mock]}>
@@ -25,7 +25,7 @@ describe("hooks/useExperiment", () => {
         </MockedCache>,
       );
 
-      await waitFor(() => expect(hook.experiment).toEqual(data));
+      await waitFor(() => expect(hook.experiment).toEqual(experiment));
     });
 
     it("returns notFound if no experiment found", async () => {

--- a/app/experimenter/nimbus-ui/src/lib/experiment.test.ts
+++ b/app/experimenter/nimbus-ui/src/lib/experiment.test.ts
@@ -6,7 +6,7 @@ import { NimbusExperimentStatus } from "../types/globalTypes";
 import { getStatus } from "./experiment";
 import { mockExperimentQuery } from "./mocks";
 
-const experiment = mockExperimentQuery("boo").data!;
+const { experiment } = mockExperimentQuery("boo");
 
 describe("getStatus", () => {
   it("correctly returns available experiment states", () => {

--- a/app/experimenter/nimbus-ui/src/lib/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/lib/mocks.tsx
@@ -17,7 +17,10 @@ import { equal } from "@wry/equality";
 import { DocumentNode, print } from "graphql";
 import { cacheConfig } from "../services/apollo";
 import { GET_EXPERIMENT_QUERY } from "../gql/experiments";
-import { getExperiment } from "../types/getExperiment";
+import {
+  getExperiment,
+  getExperiment_experimentBySlug,
+} from "../types/getExperiment";
 import { getConfig_nimbusConfig } from "../types/getConfig";
 import { GET_CONFIG_QUERY } from "../gql/config";
 import { NimbusExperimentStatus } from "../types/globalTypes";
@@ -231,89 +234,89 @@ export class SimulatedMockLink extends ApolloLink {
   }
 }
 
-export const mockExperimentQuery = (
+export function mockExperimentQuery<
+  T extends getExperiment["experimentBySlug"] = getExperiment_experimentBySlug
+>(
   slug: string,
   modifications: Partial<getExperiment["experimentBySlug"]> = {},
 ): {
   mock: MockedResponse<Record<string, any>>;
-  data: getExperiment["experimentBySlug"];
-} => {
-  // If `null` is explicitely passed in for `modifications`, the experiment
-  // data will be `null`.
-  const experiment: getExperiment["experimentBySlug"] =
-    modifications === null
-      ? null
-      : Object.assign(
-          {
-            __typename: "NimbusExperimentType",
-            id: "1",
-            owner: {
-              __typename: "NimbusExperimentOwner",
-              email: "example@mozilla.com",
-            },
-            name: "Open-architected background installation",
-            slug,
-            status: "DRAFT",
-            monitoringDashboardUrl: "https://grafana.telemetry.mozilla.org",
-            hypothesis: "Realize material say pretty.",
-            application: "DESKTOP",
-            publicDescription:
-              "Official approach present industry strategy dream piece.",
-            referenceBranch: {
-              __typename: "NimbusBranchType",
-              name: "User-centric mobile solution",
-              slug: "user-centric-mobile-solution",
-              description:
-                "Behind almost radio result personal none future current.",
-              ratio: 1,
-              featureValue: '{"environmental-fact": "really-citizen"}',
-              featureEnabled: true,
-            },
-            featureConfig: null,
-            treatmentBranches: [
-              {
-                __typename: "NimbusBranchType",
-                name: "Managed zero tolerance projection",
-                slug: "managed-zero-tolerance-projection",
-                description: "Next ask then he in degree order.",
-                ratio: 1,
-                featureValue: '{"effect-effect-whole": "close-teach-exactly"}',
-                featureEnabled: true,
-              },
-            ],
-            primaryProbeSets: [
-              {
-                __typename: "NimbusProbeSetType",
-                id: "1",
-                slug: "picture_in_picture",
-                name: "Picture-in-Picture",
-              },
-            ],
-            secondaryProbeSets: [
-              {
-                __typename: "NimbusProbeSetType",
-                id: "2",
-                slug: "feature_b",
-                name: "Feature B",
-              },
-            ],
-            channels: ["DESKTOP_NIGHTLY", "DESKTOP_BETA"],
-            firefoxMinVersion: "FIREFOX_80",
-            targetingConfigSlug: "US_ONLY",
-            populationPercent: 40,
-            totalEnrolledClients: 68000,
-            proposedEnrollment: 1,
-            proposedDuration: 28,
-            readyForReview: {
-              ready: true,
-              message: {},
-              __typename: "NimbusReadyForReviewType",
-            },
-            startDate: new Date().toISOString(),
-            endDate: new Date(Date.now() + 12096e5).toISOString(),
-          },
-          modifications,
-        );
+  experiment: T;
+} {
+  let experiment: getExperiment["experimentBySlug"] = Object.assign(
+    {
+      __typename: "NimbusExperimentType",
+      id: "1",
+      owner: {
+        __typename: "NimbusExperimentOwner",
+        email: "example@mozilla.com",
+      },
+      name: "Open-architected background installation",
+      slug,
+      status: "DRAFT",
+      monitoringDashboardUrl: "https://grafana.telemetry.mozilla.org",
+      hypothesis: "Realize material say pretty.",
+      application: "DESKTOP",
+      publicDescription:
+        "Official approach present industry strategy dream piece.",
+      referenceBranch: {
+        __typename: "NimbusBranchType",
+        name: "User-centric mobile solution",
+        slug: "user-centric-mobile-solution",
+        description: "Behind almost radio result personal none future current.",
+        ratio: 1,
+        featureValue: '{"environmental-fact": "really-citizen"}',
+        featureEnabled: true,
+      },
+      featureConfig: null,
+      treatmentBranches: [
+        {
+          __typename: "NimbusBranchType",
+          name: "Managed zero tolerance projection",
+          slug: "managed-zero-tolerance-projection",
+          description: "Next ask then he in degree order.",
+          ratio: 1,
+          featureValue: '{"effect-effect-whole": "close-teach-exactly"}',
+          featureEnabled: true,
+        },
+      ],
+      primaryProbeSets: [
+        {
+          __typename: "NimbusProbeSetType",
+          id: "1",
+          slug: "picture_in_picture",
+          name: "Picture-in-Picture",
+        },
+      ],
+      secondaryProbeSets: [
+        {
+          __typename: "NimbusProbeSetType",
+          id: "2",
+          slug: "feature_b",
+          name: "Feature B",
+        },
+      ],
+      channels: ["DESKTOP_NIGHTLY", "DESKTOP_BETA"],
+      firefoxMinVersion: "FIREFOX_80",
+      targetingConfigSlug: "US_ONLY",
+      populationPercent: 40,
+      totalEnrolledClients: 68000,
+      proposedEnrollment: 1,
+      proposedDuration: 28,
+      readyForReview: {
+        ready: true,
+        message: {},
+        __typename: "NimbusReadyForReviewType",
+      },
+      startDate: new Date().toISOString(),
+      endDate: new Date(Date.now() + 12096e5).toISOString(),
+    },
+    modifications,
+  );
+
+  if (modifications === null) {
+    experiment = null;
+  }
 
   return {
     mock: {
@@ -329,9 +332,9 @@ export const mockExperimentQuery = (
         },
       },
     },
-    data: experiment,
+    experiment: experiment as T,
   };
-};
+}
 
 export const mockExperimentMutation = (
   mutation: DocumentNode,
@@ -369,6 +372,6 @@ export const mockExperimentMutation = (
 };
 
 export const mockGetStatus = (status: NimbusExperimentStatus | null) => {
-  const { data } = mockExperimentQuery("boo", { status });
-  return getStatus(data!);
+  const { experiment } = mockExperimentQuery("boo", { status });
+  return getStatus(experiment);
 };


### PR DESCRIPTION
Closes #4113

This PR:

- Refactors `mockExperimentQuery` to use generic for return type, rename data to experiment
	- Now we no longer need to non-null assert on the experiment data every single time
	- The majority of our mock components and functions accept `experiment` as an arg/prop, so destructuring it as `experiment` allows us to shorthand it everywhere