### PR TITLE
fixes #4017 #4018 feat(nimbus): support newlines and links in hypothesis text

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/RichText/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/RichText/index.stories.tsx
@@ -1,0 +1,18 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from "react";
+import { storiesOf } from "@storybook/react";
+import RichText from ".";
+
+const text = `Who we are
+
+Mozilla Manifesto: https://www.mozilla.org/about/manifesto
+Mozilla Foundation: http://foundation.mozilla.org
+Get Involved: www.mozilla.org/contribute
+Leadership (should not link): mozilla.org/about/leadership/`;
+
+storiesOf("components/RichText", module).add("basic", () => (
+  <RichText {...{ text }} />
+));

--- a/app/experimenter/nimbus-ui/src/components/RichText/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/RichText/index.test.tsx
@@ -1,0 +1,48 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from "react";
+import { render } from "@testing-library/react";
+import RichText from ".";
+
+it("renders text with newlines converted to <br> tags", () => {
+  const text = `Aliens
+
+  Galactic Federation
+
+  We are not ready`;
+
+  const result = render(<RichText {...{ text }} />);
+
+  // Each return should be replaced with a <br />
+  const lineBreaks = result.container.querySelectorAll("br");
+  expect(lineBreaks).toHaveLength(4);
+});
+
+it("renders text with strings that look like links converted to <a> tags", () => {
+  const url1 = "https://www.mozilla.org/about/manifesto";
+  const url2 = "http://foundation.mozilla.org/";
+  const url3 = "www.mozilla.org/contribute";
+  const url4 = "mozilla.org/about/leadership/";
+  const text = `Mozilla Manifesto: ${url1}
+  Mozilla Foundation: ${url2}
+  Get Involved: ${url3}
+  Leadership: ${url4}`;
+
+  const result = render(<RichText {...{ text }} />);
+
+  const anchors = result.container.querySelectorAll("a");
+  expect(anchors).toHaveLength(3);
+
+  expect(anchors[0]).toHaveProperty("href", url1);
+  expect(anchors[0]).toHaveTextContent(url1);
+
+  expect(anchors[1]).toHaveProperty("href", url2);
+  expect(anchors[1]).toHaveTextContent(url2);
+
+  // Non protocol links should be converted, with the text
+  // unchanged but the href prepended with https://
+  expect(anchors[2]).toHaveProperty("href", `https://${url3}`);
+  expect(anchors[2]).toHaveTextContent(url3);
+});

--- a/app/experimenter/nimbus-ui/src/components/RichText/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/RichText/index.tsx
@@ -1,0 +1,44 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from "react";
+import LinkExternal from "../LinkExternal";
+
+// Match http://, https://, www., a combo, but not neither
+const LINK_MATCHER = /((?<!\+)(?:https?:\/\/(?:www\.)?|www\.)(?:[a-zA-Z\d-_.]+(?:(?:\.|@)[a-zA-Z\d]{2,}))(?:(?:[-a-zA-Z\d:%_+.~#*$!?&//=@]*)(?:[,](?![\s]))*)*)/gi;
+const NEWLINE_MATCHER = /(\r\n|\r|\n)/gi;
+
+const RichText = ({ text }: { text: string }) => (
+  <>
+    {text
+      .split(
+        new RegExp(`${LINK_MATCHER.source}|${NEWLINE_MATCHER.source}`, "gi"),
+      )
+      .map((word, idx) => {
+        const linkMatch = word?.match(LINK_MATCHER);
+        const newlineMatch = word?.match(NEWLINE_MATCHER);
+
+        if (linkMatch) {
+          let href = (text = linkMatch[0]);
+          if (!href.startsWith("http")) {
+            href = `https://${href}`;
+          }
+          return <LinkExternal {...{ href, key: idx }}>{text}</LinkExternal>;
+        }
+
+        if (newlineMatch) {
+          return (
+            <React.Fragment key={idx}>
+              {word}
+              <br />
+            </React.Fragment>
+          );
+        }
+
+        return word;
+      })}
+  </>
+);
+
+export default RichText;

--- a/app/experimenter/nimbus-ui/src/components/TableSummary/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/TableSummary/index.tsx
@@ -7,6 +7,7 @@ import { getExperiment_experimentBySlug } from "../../types/getExperiment";
 import { Table } from "react-bootstrap";
 import { useConfig } from "../../hooks";
 import { displayConfigLabelOrNotSet, NotSet } from "../Summary";
+import RichText from "../RichText";
 
 type TableSummaryProps = {
   experiment: getExperiment_experimentBySlug;
@@ -40,7 +41,9 @@ const TableSummary = ({ experiment }: TableSummaryProps) => {
         </tr>
         <tr>
           <th>Hypothesis</th>
-          <td data-testid="experiment-hypothesis">{experiment.hypothesis}</td>
+          <td data-testid="experiment-hypothesis">
+            <RichText text={experiment.hypothesis || ""} />
+          </td>
         </tr>
         <tr>
           <th>Public description</th>


### PR DESCRIPTION
Closes #4017
Closes #4018

This PR:

- Adds a new component that takes a string of returns markup with newline characters converted to line break tags and URLs converted to anchor tags
- Uses this new component when rendering the hypothesis

In both issues @lmorchard noted that this is something that could be done on frontend or backend. @jaredlockhart do you have thoughts or strong opinions on that? This wasn't a lot of work if we do want to move it to backend

Storybook: [`RichText`](https://storage.googleapis.com/mozilla-storybooks-experimenter/commits/30328930e7fcb5d455f77ae201069ab1ff1ce174/nimbus-ui/index.html?path=/story/components-richtext--basic)