### PR TITLE
Prevent title wrapping on New page, make sidebar icons consistent

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/AppLayoutWithSidebar/index.scss
+++ b/app/experimenter/nimbus-ui/src/components/AppLayoutWithSidebar/index.scss
@@ -1,0 +1,8 @@
+@import "~bootstrap/scss/bootstrap";
+
+.sidebar-icon {
+  @extend .mr-3;
+  min-width: 18px;
+  width: 18px;
+  height: 18px;
+}

--- a/app/experimenter/nimbus-ui/src/components/AppLayoutWithSidebar/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/AppLayoutWithSidebar/index.tsx
@@ -21,6 +21,7 @@ import { ReactComponent as Clipboard } from "./clipboard.svg";
 import { ReactComponent as NotAllowed } from "./not-allowed.svg";
 import { ReactComponent as AlertCircle } from "./alert-circle.svg";
 import { ReactComponent as BarChart } from "./bar-chart.svg";
+import "./index.scss";
 
 type AppLayoutWithSidebarProps = {
   testid?: string;
@@ -45,22 +46,22 @@ const editPages = [
   {
     name: "Overview",
     slug: "overview",
-    icon: <Cog className="mr-3" width="18" height="18" />,
+    icon: <Cog className="sidebar-icon" />,
   },
   {
     name: "Branches",
     slug: "branches",
-    icon: <Layers className="mr-3" width="18" height="18" />,
+    icon: <Layers className="sidebar-icon" />,
   },
   {
     name: "Metrics",
     slug: "metrics",
-    icon: <ChartArrow className="mr-3" width="18" height="18" />,
+    icon: <ChartArrow className="sidebar-icon" />,
   },
   {
     name: "Audience",
     slug: "audience",
-    icon: <Person className="mr-3" width="18" height="18" />,
+    icon: <Person className="sidebar-icon" />,
   },
 ];
 
@@ -102,7 +103,7 @@ export const AppLayoutWithSidebar = ({
                     storiesOf={"pages/Design"}
                     testid={"nav-design"}
                   >
-                    <Clipboard className="mr-3" width="18" height="18" />
+                    <Clipboard className="sidebar-icon" />
                     Design
                   </LinkNav>
                   {analysis?.show_analysis ? (
@@ -111,7 +112,7 @@ export const AppLayoutWithSidebar = ({
                       storiesOf={"pages/Results"}
                       testid={"nav-results"}
                     >
-                      <BarChart className="mr-3" width="18" height="18" />
+                      <BarChart className="sidebar-icon" />
                       Results
                     </LinkNav>
                   ) : (
@@ -150,7 +151,7 @@ export const AppLayoutWithSidebar = ({
                       storiesOf="pages/RequestReview"
                       testid="nav-request-review"
                     >
-                      <Clipboard className="mr-3" width="18" height="18" />
+                      <Clipboard className="sidebar-icon" />
                       Review &amp; Launch
                     </LinkNav>
                   ) : (
@@ -257,7 +258,7 @@ const DisabledItem = ({ name, children, testId }: DisabledItemProps) => (
     className="mx-1 my-2 d-flex text-muted font-weight-normal"
     data-testid={testId}
   >
-    <NotAllowed className="mr-3 mt-1" width="18" height="18" />
+    <NotAllowed className="mt-1 sidebar-icon" />
     <div>
       <p className="mb-1">{name}</p>
       <p className="mt-0 small">{children}</p>

--- a/app/experimenter/nimbus-ui/src/components/PageNew/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageNew/index.tsx
@@ -7,8 +7,6 @@ import { RouteComponentProps } from "@reach/router";
 import AppLayout from "../AppLayout";
 import LinkExternal from "../LinkExternal";
 import FormOverview from "../FormOverview";
-import Row from "react-bootstrap/Row";
-import Col from "react-bootstrap/Col";
 import { ReactComponent as DeleteIcon } from "../../images/x.svg";
 
 import { useMutation } from "@apollo/client";
@@ -68,16 +66,12 @@ const PageNew: React.FunctionComponent<PageNewProps> = () => {
 
   return (
     <AppLayout testid="PageNew">
-      <Row>
-        <Col>
-          <h1 className="h2">Create a new Experiment</h1>
-        </Col>
-        <Col className="text-right">
-          <button title="Cancel" className="btn pr-0" onClick={onFormCancel}>
-            <DeleteIcon width="18" height="18" />{" "}
-          </button>
-        </Col>
-      </Row>
+      <div className="d-flex justify-content-between">
+        <h1 className="h2">Create a new Experiment</h1>
+        <button title="Cancel" className="btn pr-0" onClick={onFormCancel}>
+          <DeleteIcon width="18" height="18" />{" "}
+        </button>
+      </div>
       <p>
         Before launching an experiment, review the{" "}
         <LinkExternal href={TRAINING_DOC_URL}>


### PR DESCRIPTION
Closes #4041
Closes #4044

This PR makes two cosmetic adjustments to Nimbus UI:

- Makes the sidebar icons more consistent, prevents them from being sized too small
- Updates the layout of the New Experiment page so that the title doesn't wrap at a strange window size