### PR TITLE
fixes #4098 feat(nimbus): use a common method of checking an experiment's status

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/AppLayoutWithSidebar/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/AppLayoutWithSidebar/index.stories.tsx
@@ -8,6 +8,7 @@ import { withLinks } from "@storybook/addon-links";
 import { RouterSlugProvider } from "../../lib/test-utils";
 import AppLayoutWithSidebar from ".";
 import { NimbusExperimentStatus } from "../../types/globalTypes";
+import { mockGetStatus } from "../../lib/mocks";
 
 storiesOf("components/AppLayoutWithSidebar", module)
   .addDecorator(withLinks)
@@ -32,21 +33,25 @@ storiesOf("components/AppLayoutWithSidebar", module)
   ))
   .add("status: review", () => (
     <RouterSlugProvider>
-      <AppLayoutWithSidebar status={NimbusExperimentStatus.REVIEW}>
+      <AppLayoutWithSidebar
+        status={mockGetStatus(NimbusExperimentStatus.REVIEW)}
+      >
         <p>App contents go here</p>
       </AppLayoutWithSidebar>
     </RouterSlugProvider>
   ))
   .add("status: accepted", () => (
     <RouterSlugProvider>
-      <AppLayoutWithSidebar status={NimbusExperimentStatus.ACCEPTED}>
+      <AppLayoutWithSidebar
+        status={mockGetStatus(NimbusExperimentStatus.ACCEPTED)}
+      >
         <p>App contents go here</p>
       </AppLayoutWithSidebar>
     </RouterSlugProvider>
   ))
   .add("status: live", () => (
     <RouterSlugProvider>
-      <AppLayoutWithSidebar status={NimbusExperimentStatus.LIVE}>
+      <AppLayoutWithSidebar status={mockGetStatus(NimbusExperimentStatus.LIVE)}>
         <p>App contents go here</p>
       </AppLayoutWithSidebar>
     </RouterSlugProvider>
@@ -54,7 +59,7 @@ storiesOf("components/AppLayoutWithSidebar", module)
   .add("has analysis results", () => (
     <RouterSlugProvider>
       <AppLayoutWithSidebar
-        status={NimbusExperimentStatus.COMPLETE}
+        status={mockGetStatus(NimbusExperimentStatus.COMPLETE)}
         analysis={{
           show_analysis: true,
           daily: [],

--- a/app/experimenter/nimbus-ui/src/components/AppLayoutWithSidebar/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/AppLayoutWithSidebar/index.test.tsx
@@ -9,7 +9,11 @@ import { renderWithRouter, RouterSlugProvider } from "../../lib/test-utils";
 import { BASE_PATH } from "../../lib/constants";
 import { RouteComponentProps } from "@reach/router";
 import App from "../App";
-import { MockedCache, mockExperimentQuery } from "../../lib/mocks";
+import {
+  MockedCache,
+  mockExperimentQuery,
+  mockGetStatus,
+} from "../../lib/mocks";
 import { NimbusExperimentStatus } from "../../types/globalTypes";
 
 const { mock } = mockExperimentQuery("my-special-slug");
@@ -29,7 +33,7 @@ const Subject = ({
   <RouterSlugProvider mocks={[mock]} path="/my-special-slug/edit">
     <AppLayoutWithSidebar
       {...{
-        status,
+        status: mockGetStatus(status),
         review,
         analysis: withAnalysis
           ? {

--- a/app/experimenter/nimbus-ui/src/components/AppLayoutWithSidebar/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/AppLayoutWithSidebar/index.tsx
@@ -10,8 +10,8 @@ import Col from "react-bootstrap/Col";
 import Nav from "react-bootstrap/Nav";
 import classNames from "classnames";
 import { BASE_PATH } from "../../lib/constants";
-import { NimbusExperimentStatus } from "../../types/globalTypes";
 import { AnalysisData } from "../../lib/visualization/types";
+import { StatusCheck } from "../../lib/experiment";
 import { ReactComponent as ChevronLeft } from "./chevron-left.svg";
 import { ReactComponent as Cog } from "./cog.svg";
 import { ReactComponent as Layers } from "./layers.svg";
@@ -26,21 +26,13 @@ import "./index.scss";
 type AppLayoutWithSidebarProps = {
   testid?: string;
   children: React.ReactNode;
-  status?: NimbusExperimentStatus | null;
+  status?: StatusCheck;
   review?: {
     invalidPages: string[];
     ready: boolean;
   };
   analysis?: AnalysisData;
 } & RouteComponentProps;
-
-const experimentLocked = (status: NimbusExperimentStatus): boolean => {
-  return [
-    NimbusExperimentStatus.ACCEPTED,
-    NimbusExperimentStatus.LIVE,
-    NimbusExperimentStatus.COMPLETE,
-  ].includes(status);
-};
 
 const editPages = [
   {
@@ -73,9 +65,6 @@ export const AppLayoutWithSidebar = ({
   analysis,
 }: AppLayoutWithSidebarProps) => {
   const { slug } = useParams();
-  const locked = status && experimentLocked(status);
-  const inReview = status === NimbusExperimentStatus.REVIEW;
-  const isAccepted = status === NimbusExperimentStatus.ACCEPTED;
 
   return (
     <Container fluid className="h-100vh" data-testid={testid}>
@@ -96,7 +85,7 @@ export const AppLayoutWithSidebar = ({
                 <ChevronLeft className="ml-n1" width="18" height="18" />
                 Experiments
               </LinkNav>
-              {locked ? (
+              {status?.locked ? (
                 <>
                   <LinkNav
                     route={`${slug}/design`}
@@ -117,7 +106,7 @@ export const AppLayoutWithSidebar = ({
                     </LinkNav>
                   ) : (
                     <DisabledItem name="Results" testId="show-no-results">
-                      {isAccepted
+                      {status?.accepted
                         ? "Waiting for experiment to launch"
                         : "Experiment results not yet ready"}
                     </DisabledItem>
@@ -131,7 +120,7 @@ export const AppLayoutWithSidebar = ({
                       route={`${slug}/edit/${page.slug}`}
                       storiesOf={`pages/Edit${page.name}`}
                       testid={`nav-edit-${page.slug}`}
-                      disabled={inReview}
+                      disabled={status?.review}
                     >
                       {page.icon}
                       {page.name}
@@ -145,7 +134,7 @@ export const AppLayoutWithSidebar = ({
                       )}
                     </LinkNav>
                   ))}
-                  {!review || review.ready || inReview ? (
+                  {!review || review.ready || status?.review ? (
                     <LinkNav
                       route={`${slug}/request-review`}
                       storiesOf="pages/RequestReview"

--- a/app/experimenter/nimbus-ui/src/components/HeaderExperiment/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/HeaderExperiment/index.stories.tsx
@@ -6,7 +6,7 @@ import React from "react";
 import { storiesOf } from "@storybook/react";
 import { withLinks } from "@storybook/addon-links";
 import HeaderExperiment from ".";
-import { mockExperimentQuery } from "../../lib/mocks";
+import { mockExperimentQuery, mockGetStatus } from "../../lib/mocks";
 import AppLayout from "../AppLayout";
 import { NimbusExperimentStatus } from "../../types/globalTypes";
 
@@ -19,7 +19,7 @@ storiesOf("components/HeaderExperiment", module)
       <HeaderExperiment
         name={data!.name}
         slug={data!.slug}
-        status={data!.status}
+        status={mockGetStatus(data!.status)}
       />
     </AppLayout>
   ))
@@ -28,7 +28,7 @@ storiesOf("components/HeaderExperiment", module)
       <HeaderExperiment
         name={data!.name}
         slug={data!.slug}
-        status={NimbusExperimentStatus.REVIEW}
+        status={mockGetStatus(NimbusExperimentStatus.REVIEW)}
       />
     </AppLayout>
   ))
@@ -37,7 +37,7 @@ storiesOf("components/HeaderExperiment", module)
       <HeaderExperiment
         name={data!.name}
         slug={data!.slug}
-        status={NimbusExperimentStatus.LIVE}
+        status={mockGetStatus(NimbusExperimentStatus.LIVE)}
       />
     </AppLayout>
   ))
@@ -46,7 +46,7 @@ storiesOf("components/HeaderExperiment", module)
       <HeaderExperiment
         name={data!.name}
         slug={data!.slug}
-        status={NimbusExperimentStatus.COMPLETE}
+        status={mockGetStatus(NimbusExperimentStatus.COMPLETE)}
       />
     </AppLayout>
   ));

--- a/app/experimenter/nimbus-ui/src/components/HeaderExperiment/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/HeaderExperiment/index.test.tsx
@@ -5,7 +5,7 @@
 import React from "react";
 import { screen, render } from "@testing-library/react";
 import HeaderExperiment from ".";
-import { mockExperimentQuery } from "../../lib/mocks";
+import { mockExperimentQuery, mockGetStatus } from "../../lib/mocks";
 
 const { data } = mockExperimentQuery("demo-slug");
 
@@ -15,7 +15,7 @@ describe("HeaderExperiment", () => {
       <HeaderExperiment
         name={data!.name}
         slug={data!.slug}
-        status={data!.status}
+        status={mockGetStatus(data!.status)}
       />,
     );
     expect(screen.getByTestId("header-experiment-name")).toHaveTextContent(

--- a/app/experimenter/nimbus-ui/src/components/HeaderExperiment/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/HeaderExperiment/index.tsx
@@ -5,13 +5,13 @@
 import classNames from "classnames";
 import React from "react";
 import { getExperiment_experimentBySlug } from "../../types/getExperiment";
-import { NimbusExperimentStatus } from "../../types/globalTypes";
+import { StatusCheck } from "../../lib/experiment";
 import "./index.scss";
 
 type HeaderExperimentProps = Pick<
   getExperiment_experimentBySlug,
-  "name" | "slug" | "status"
->;
+  "name" | "slug"
+> & { status: StatusCheck };
 
 const HeaderExperiment = ({ name, slug, status }: HeaderExperimentProps) => (
   <header className="border-bottom" data-testid="header-experiment">
@@ -25,23 +25,10 @@ const HeaderExperiment = ({ name, slug, status }: HeaderExperimentProps) => (
       {slug}
     </p>
     <p className="header-experiment-status position-relative mt-2 d-inline-block">
-      <StatusPill
-        label="Draft"
-        active={status === NimbusExperimentStatus.DRAFT}
-      />
-      <StatusPill
-        label="Review"
-        active={status === NimbusExperimentStatus.REVIEW}
-      />
-      <StatusPill
-        label="Live"
-        active={status === NimbusExperimentStatus.LIVE}
-      />
-      <StatusPill
-        label="Complete"
-        active={status === NimbusExperimentStatus.COMPLETE}
-        padded={false}
-      />
+      <StatusPill label="Draft" active={status.draft} />
+      <StatusPill label="Review" active={status.review} />
+      <StatusPill label="Live" active={status.live} />
+      <StatusPill label="Complete" active={status.complete} padded={false} />
     </p>
   </header>
 );

--- a/app/experimenter/nimbus-ui/src/components/PageRequestReview/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageRequestReview/index.tsx
@@ -16,6 +16,7 @@ import { updateExperimentStatus_updateExperimentStatus as UpdateExperimentStatus
 import { getExperiment_experimentBySlug } from "../../types/getExperiment";
 import FormRequestReview from "../FormRequestReview";
 import Summary from "../Summary";
+import { getStatus } from "../../lib/experiment";
 
 type PageRequestReviewProps = {
   polling?: boolean;
@@ -68,15 +69,13 @@ const PageRequestReview: React.FunctionComponent<PageRequestReviewProps> = ({
     >
       {({ experiment }) => {
         currentExperiment.current = experiment;
+        const status = getStatus(experiment);
 
         return (
           <>
             <Summary {...{ experiment }} />
 
-            {![
-              NimbusExperimentStatus.REVIEW,
-              NimbusExperimentStatus.DRAFT,
-            ].includes(experiment.status!) && (
+            {status.locked && (
               <p className="my-5" data-testid="cant-review-label">
                 This experiment&apos;s status is{" "}
                 <b className="text-lowercase">{experiment.status}</b> and cannot
@@ -84,23 +83,21 @@ const PageRequestReview: React.FunctionComponent<PageRequestReviewProps> = ({
               </p>
             )}
 
-            {(submitSuccess ||
-              experiment.status === NimbusExperimentStatus.REVIEW) && (
+            {(submitSuccess || status.review) && (
               <p className="my-5" data-testid="in-review-label">
                 All set! Your experiment is now <b>waiting for review</b>.
               </p>
             )}
 
-            {!submitSuccess &&
-              experiment.status === NimbusExperimentStatus.DRAFT && (
-                <FormRequestReview
-                  {...{
-                    isLoading: loading,
-                    submitError,
-                    onSubmit: onLaunchClicked,
-                  }}
-                />
-              )}
+            {!submitSuccess && status.draft && (
+              <FormRequestReview
+                {...{
+                  isLoading: loading,
+                  submitError,
+                  onSubmit: onLaunchClicked,
+                }}
+              />
+            )}
           </>
         );
       }}

--- a/app/experimenter/nimbus-ui/src/components/SummaryTimeline/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/SummaryTimeline/index.tsx
@@ -4,10 +4,10 @@
 
 import React from "react";
 import ProgressBar from "react-bootstrap/ProgressBar";
-import { NimbusExperimentStatus } from "../../types/globalTypes";
 import pluralize from "../../lib/pluralize";
 import { getExperiment_experimentBySlug } from "../../types/getExperiment";
 import { NotSet } from "../Summary";
+import { getStatus, StatusCheck } from "../../lib/experiment";
 
 const humanDate = (date: string): string => {
   return new Date(date).toLocaleString("en-US", {
@@ -17,20 +17,12 @@ const humanDate = (date: string): string => {
   });
 };
 
-const experimentStatus = (status: NimbusExperimentStatus) => ({
-  draft: status === NimbusExperimentStatus.DRAFT,
-  review: status === NimbusExperimentStatus.REVIEW,
-  accepted: status === NimbusExperimentStatus.ACCEPTED,
-  live: status === NimbusExperimentStatus.LIVE,
-  complete: status === NimbusExperimentStatus.COMPLETE,
-});
-
 const SummaryTimeline = ({
   experiment,
 }: {
   experiment: getExperiment_experimentBySlug;
 }) => {
-  const status = experimentStatus(experiment.status!);
+  const status = getStatus(experiment);
 
   return (
     <div className="mb-5" data-testid="summary-timeline">
@@ -65,7 +57,7 @@ const StartEnd = ({
   startDate,
   endDate,
 }: {
-  status: ReturnType<typeof experimentStatus>;
+  status: StatusCheck;
   startDate: string | null;
   endDate: string | null;
 }) => (
@@ -92,7 +84,7 @@ const Progress = ({
   startDate,
   endDate,
 }: {
-  status: ReturnType<typeof experimentStatus>;
+  status: StatusCheck;
   startDate: string | null;
   endDate: string | null;
 }) => {

--- a/app/experimenter/nimbus-ui/src/lib/experiment.test.ts
+++ b/app/experimenter/nimbus-ui/src/lib/experiment.test.ts
@@ -1,0 +1,33 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { NimbusExperimentStatus } from "../types/globalTypes";
+import { getStatus } from "./experiment";
+import { mockExperimentQuery } from "./mocks";
+
+const experiment = mockExperimentQuery("boo").data!;
+
+describe("getStatus", () => {
+  it("correctly returns available experiment states", () => {
+    experiment.status = NimbusExperimentStatus.DRAFT;
+    expect(getStatus(experiment).draft).toBeTruthy();
+
+    experiment.status = NimbusExperimentStatus.REVIEW;
+    expect(getStatus(experiment).review).toBeTruthy();
+
+    experiment.status = NimbusExperimentStatus.ACCEPTED;
+    expect(getStatus(experiment).accepted).toBeTruthy();
+    expect(getStatus(experiment).locked).toBeTruthy();
+
+    experiment.status = NimbusExperimentStatus.LIVE;
+    expect(getStatus(experiment).live).toBeTruthy();
+    expect(getStatus(experiment).released).toBeTruthy();
+    expect(getStatus(experiment).locked).toBeTruthy();
+
+    experiment.status = NimbusExperimentStatus.COMPLETE;
+    expect(getStatus(experiment).complete).toBeTruthy();
+    expect(getStatus(experiment).released).toBeTruthy();
+    expect(getStatus(experiment).locked).toBeTruthy();
+  });
+});

--- a/app/experimenter/nimbus-ui/src/lib/experiment.ts
+++ b/app/experimenter/nimbus-ui/src/lib/experiment.ts
@@ -1,0 +1,40 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { getExperiment_experimentBySlug } from "../types/getExperiment";
+import { NimbusExperimentStatus } from "../types/globalTypes";
+
+export type StatusCheck = {
+  draft: boolean;
+  review: boolean;
+  accepted: boolean;
+  live: boolean;
+  complete: boolean;
+  locked: boolean;
+  released: boolean;
+};
+
+export function getStatus(
+  experiment?: getExperiment_experimentBySlug,
+): StatusCheck {
+  const status = experiment?.status;
+
+  const released = status
+    ? [NimbusExperimentStatus.LIVE, NimbusExperimentStatus.COMPLETE].includes(
+        status,
+      )
+    : false;
+
+  return {
+    draft: status === NimbusExperimentStatus.DRAFT,
+    review: status === NimbusExperimentStatus.REVIEW,
+    accepted: status === NimbusExperimentStatus.ACCEPTED,
+    live: status === NimbusExperimentStatus.LIVE,
+    complete: status === NimbusExperimentStatus.COMPLETE,
+    // The experiment's fields generally cannot be updated (accepted, live, or complete)
+    locked: released || status === NimbusExperimentStatus.ACCEPTED,
+    // The experiment is or was out in the wild (live or complete)
+    released,
+  };
+}

--- a/app/experimenter/nimbus-ui/src/lib/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/lib/mocks.tsx
@@ -20,6 +20,8 @@ import { GET_EXPERIMENT_QUERY } from "../gql/experiments";
 import { getExperiment } from "../types/getExperiment";
 import { getConfig_nimbusConfig } from "../types/getConfig";
 import { GET_CONFIG_QUERY } from "../gql/config";
+import { NimbusExperimentStatus } from "../types/globalTypes";
+import { getStatus } from "./experiment";
 import {
   NimbusFeatureConfigApplication,
   NimbusProbeKind,
@@ -364,4 +366,9 @@ export const mockExperimentMutation = (
       },
     },
   };
+};
+
+export const mockGetStatus = (status: NimbusExperimentStatus | null) => {
+  const { data } = mockExperimentQuery("boo", { status });
+  return getStatus(data!);
 };


### PR DESCRIPTION
Closes #4098

This PR:

- Adds a `getStatus` function that accepts an experiment and returns an object of status check. It includes checks for all the available `NimbusExperimentStatus` types, as well as some other common ones:
  - "released" if the experiment is or was out in the wild, that is live or complete
  - "locked" if the experiment's fields are locked, as in it is not a draft or in review
- Replaces all the various ways we've previously checked on an experiment's status with this new function