### PR TITLE
fixes #4143 fix(nimbus): Check for owner email truthiness to prevent page erroring

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/TableSummary/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/TableSummary/index.test.tsx
@@ -27,6 +27,14 @@ describe("TableSummary", () => {
     );
   });
 
+  it("renders Not Set if experiment owner is not set", () => {
+    const { data } = mockExperimentQuery("demo-slug", {
+      owner: null,
+    });
+    render(<Subject experiment={data!} />);
+    expect(screen.getByTestId("experiment-owner")).toHaveTextContent("Not set");
+  });
+
   describe("renders 'Primary probe sets' row as expected", () => {
     it("with one probe set", () => {
       const { data } = mockExperimentQuery("demo-slug");

--- a/app/experimenter/nimbus-ui/src/components/TableSummary/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/TableSummary/index.tsx
@@ -28,7 +28,9 @@ const TableSummary = ({ experiment }: TableSummaryProps) => {
         </tr>
         <tr>
           <th>Experiment owner</th>
-          <td data-testid="experiment-owner">{experiment.owner!.email}</td>
+          <td data-testid="experiment-owner">
+            {experiment.owner ? experiment.owner.email : <NotSet />}
+          </td>
         </tr>
         <tr>
           <th>Application</th>


### PR DESCRIPTION
Because:
* We've had a bug hanging around that's prevented owner email from being added to experiments created so all experiments created in Nimbus UI until that bug is fixed will not have an owner experiment set. This prevents those experiment pages from erroring.

This commit:
* Displays "Not set" if experiment owner is not set in the Summary Table