### PR TITLE
fix #3782: Audience form validation and submit mutation

### DIFF
--- a/app/experimenter/nimbus-ui/package.json
+++ b/app/experimenter/nimbus-ui/package.json
@@ -83,6 +83,7 @@
     "mutationobserver-shim": "^0.3.7",
     "node-sass": "^4.14.1",
     "prettier": "^2.1.2",
+    "react-select-event": "^5.1.0",
     "stylelint": "^13.7.1",
     "stylelint-config-prettier": "^8.0.2"
   },

--- a/app/experimenter/nimbus-ui/src/components/FormAudience/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/FormAudience/index.stories.tsx
@@ -4,6 +4,23 @@
 
 import React from "react";
 import { storiesOf } from "@storybook/react";
+import { action } from "@storybook/addon-actions";
 import { Subject } from "./mocks";
 
-storiesOf("components/FormAudience", module).add("basic", () => <Subject />);
+storiesOf("components/FormAudience", module)
+  .add("basic", () => <Subject onSubmit={action("submit")} />)
+  .add("loading", () => <Subject isLoading />)
+  .add("errors", () => (
+    <Subject
+      submitErrors={{
+        "*": ["Big bad server thing happened"],
+        channels: ["Cannot tune in these channels"],
+        firefoxMinVersion: ["Bad min version"],
+        targetingConfigSlug: ["This slug is icky"],
+        populationPercent: ["This is not a percentage"],
+        totalEnrolledClients: ["Need a number here, bud."],
+        proposedEnrollment: ["Emoji are not numbers"],
+        proposedDuration: ["No negative numbers"],
+      }}
+    />
+  ));

--- a/app/experimenter/nimbus-ui/src/components/FormAudience/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/FormAudience/index.test.tsx
@@ -3,16 +3,57 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React from "react";
-import { render, screen } from "@testing-library/react";
+import {
+  screen,
+  waitFor,
+  render,
+  fireEvent,
+  act,
+} from "@testing-library/react";
+import selectEvent from "react-select-event";
 import { Subject, MOCK_EXPERIMENT } from "./mocks";
 import { MOCK_CONFIG } from "../../lib/mocks";
 
 describe("FormAudience", () => {
-  it("renders without error", () => {
+  it("renders without error", async () => {
     render(<Subject />);
+    await waitFor(() => {
+      expect(screen.queryByTestId("FormAudience")).toBeInTheDocument();
+    });
+    const targetingConfigSlug = screen.queryByTestId("targetingConfigSlug");
+    expect(targetingConfigSlug).toBeInTheDocument();
+    expect((targetingConfigSlug as HTMLSelectElement).value).toEqual(
+      MOCK_CONFIG!.targetingConfigSlug![0]!.value,
+    );
   });
 
-  it("renders without error with a partial experiment", () => {
+  it("renders server errors", async () => {
+    const submitErrors = {
+      "*": ["Big bad server thing happened"],
+      channels: ["Cannot tune in these channels"],
+      firefoxMinVersion: ["Bad min version"],
+      targetingConfigSlug: ["This slug is icky"],
+      populationPercent: ["This is not a percentage"],
+      totalEnrolledClients: ["Need a number here, bud."],
+      proposedEnrollment: ["Emoji are not numbers"],
+      proposedDuration: ["No negative numbers"],
+    };
+    const { container } = render(<Subject submitErrors={submitErrors} />);
+    await waitFor(() => {
+      expect(screen.queryByTestId("FormAudience")).toBeInTheDocument();
+    });
+    for (const [fieldName, [error]] of Object.entries(submitErrors)) {
+      if (fieldName === "*") {
+        expect(screen.getByTestId("submit-error")).toHaveTextContent(error);
+      } else {
+        expect(
+          container.querySelector(`.invalid-feedback[data-for=${fieldName}`),
+        ).toHaveTextContent(error);
+      }
+    }
+  });
+
+  it("renders without error with a partial experiment", async () => {
     render(
       <Subject
         config={{
@@ -31,6 +72,140 @@ describe("FormAudience", () => {
         }}
       />,
     );
+    await waitFor(() => {
+      expect(screen.queryByTestId("FormAudience")).toBeInTheDocument();
+    });
+
+    for (const [fieldName, expected] of [
+      ["populationPercent", "0"],
+      ["proposedEnrollment", "7"],
+      ["proposedDuration", "28"],
+      ["firefoxMinVersion", ""],
+      ["targetingConfigSlug", ""],
+    ] as const) {
+      const field = screen.queryByTestId(fieldName);
+      expect(field).toBeInTheDocument();
+      expect((field as HTMLInputElement).value).toEqual(expected);
+    }
+  });
+
+  it("calls onNext when next button is clicked", async () => {
+    const onNext = jest.fn();
+    render(<Subject {...{ onNext }} />);
+    await waitFor(() => {
+      expect(screen.queryByTestId("FormAudience")).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByTestId("next-button"));
+    expect(onNext).toHaveBeenCalled();
+  });
+
+  it("disables next button when experiment is not ready for review", async () => {
+    const onNext = jest.fn();
+    render(
+      <Subject
+        {...{
+          onNext,
+          experiment: {
+            ...MOCK_EXPERIMENT,
+            readyForReview: {
+              __typename: "NimbusReadyForReviewType",
+              ready: false,
+              message: "Test",
+            },
+          },
+        }}
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.queryByTestId("FormAudience")).toBeInTheDocument();
+    });
+    const nextButton = screen.getByTestId("next-button");
+    expect(nextButton).toBeDisabled();
+    fireEvent.click(nextButton);
+    expect(onNext).not.toHaveBeenCalled();
+  });
+
+  it("calls onSubmit when save button is clicked", async () => {
+    const onSubmit = jest.fn();
+    render(<Subject {...{ onSubmit }} />);
+    await waitFor(() => {
+      expect(screen.queryByTestId("FormAudience")).toBeInTheDocument();
+    });
+    const submitButton = screen.getByTestId("submit-button");
+    expect(submitButton).toHaveTextContent("Save");
+    await act(async () => {
+      fireEvent.click(submitButton);
+    });
+    expect(onSubmit).toHaveBeenCalled();
+    const [[submitData]] = onSubmit.mock.calls;
+    expect(submitData).toEqual({
+      channels: MOCK_EXPERIMENT.channels,
+      firefoxMinVersion: MOCK_EXPERIMENT.firefoxMinVersion,
+      targetingConfigSlug: MOCK_EXPERIMENT.targetingConfigSlug,
+      populationPercent: "" + MOCK_EXPERIMENT.populationPercent,
+      totalEnrolledClients: "" + MOCK_EXPERIMENT.totalEnrolledClients,
+      proposedEnrollment: "" + MOCK_EXPERIMENT.proposedEnrollment,
+      proposedDuration: "" + MOCK_EXPERIMENT.proposedDuration,
+    });
+  });
+
+  it("does not call onSubmit when submitted while loading", async () => {
+    const onSubmit = jest.fn();
+    render(<Subject {...{ onSubmit, isLoading: true }} />);
+    await waitFor(() => {
+      expect(screen.queryByTestId("FormAudience")).toBeInTheDocument();
+    });
+    const form = screen.getByTestId("FormAudience");
+    await act(async () => {
+      fireEvent.submit(form);
+    });
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it("marks input fields as invalid when blank", async () => {
+    const onSubmit = jest.fn();
+    const { container } = render(<Subject {...{ onSubmit }} />);
+    await waitFor(() => {
+      expect(screen.queryByTestId("FormAudience")).toBeInTheDocument();
+    });
+
+    for (const fieldName of [
+      "populationPercent",
+      "totalEnrolledClients",
+      "proposedEnrollment",
+      "proposedDuration",
+      "firefoxMinVersion",
+      "targetingConfigSlug",
+    ]) {
+      await act(async () => {
+        const field = screen.getByTestId(fieldName);
+        fireEvent.click(field);
+        fireEvent.change(field, { target: { value: "" } });
+        fireEvent.blur(field);
+      });
+
+      expect(
+        container.querySelector(`.invalid-feedback[data-for=${fieldName}`),
+      ).toHaveTextContent("This field may not be blank.");
+    }
+  });
+
+  it("marks multi-select channels as invalid when none are selected", async () => {
+    const onSubmit = jest.fn();
+    const { container } = render(<Subject {...{ onSubmit }} />);
+    await waitFor(() => {
+      expect(screen.queryByTestId("FormAudience")).toBeInTheDocument();
+    });
+    const channelsSelect = screen.getByLabelText("Channels");
+    await selectEvent.clearAll(channelsSelect);
+    const submitButton = screen.getByTestId("submit-button");
+    expect(submitButton).toHaveTextContent("Save");
+    await act(async () => {
+      fireEvent.click(submitButton);
+    });
+    expect(
+      container.querySelector(".invalid-feedback[data-for=channels"),
+    ).toHaveTextContent("At least one channel must be selected");
   });
 
   it("displays warning icons when server complains fields are missing", async () => {

--- a/app/experimenter/nimbus-ui/src/components/FormAudience/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/components/FormAudience/mocks.tsx
@@ -3,22 +3,35 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React from "react";
-import { mockExperimentQuery, MOCK_CONFIG } from "../../lib/mocks";
+import { mockExperimentQuery } from "../../lib/mocks";
 import { FormAudience } from ".";
+import { MOCK_CONFIG, MockedCache } from "../../lib/mocks";
+import { getConfig_nimbusConfig } from "../../types/getConfig";
 
 export const Subject = ({
-  experiment = MOCK_EXPERIMENT,
   config = MOCK_CONFIG,
+  experiment = MOCK_EXPERIMENT,
+  submitErrors = {},
   isMissingField = () => false,
-}: Partial<React.ComponentProps<typeof FormAudience>>) => (
+  isLoading = false,
+  onSubmit = () => {},
+  onNext = () => {},
+}: {
+  config?: getConfig_nimbusConfig;
+} & Partial<React.ComponentProps<typeof FormAudience>>) => (
   <div className="p-5">
-    <FormAudience
-      {...{
-        experiment,
-        config,
-        isMissingField,
-      }}
-    />
+    <MockedCache {...{ config }}>
+      <FormAudience
+        {...{
+          experiment,
+          submitErrors,
+          isMissingField,
+          isLoading,
+          onSubmit,
+          onNext,
+        }}
+      />
+    </MockedCache>
   </div>
 );
 

--- a/app/experimenter/nimbus-ui/src/components/PageEditAudience/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditAudience/index.test.tsx
@@ -3,22 +3,206 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React from "react";
-import { screen, render, waitFor } from "@testing-library/react";
+import {
+  screen,
+  render,
+  waitFor,
+  fireEvent,
+  act,
+} from "@testing-library/react";
 import PageEditAudience from ".";
+import FormAudience from "../FormAudience";
 import { RouterSlugProvider } from "../../lib/test-utils";
 import { mockExperimentQuery } from "../../lib/mocks";
+import { MockedResponse } from "@apollo/client/testing";
+import { navigate } from "@reach/router";
+import { UPDATE_EXPERIMENT_AUDIENCE_MUTATION } from "../../gql/experiments";
+import { SUBMIT_ERROR } from "../../lib/constants";
+import {
+  updateExperimentAudience_updateExperimentAudience,
+  updateExperimentAudience_updateExperimentAudience_nimbusExperiment,
+} from "../../types/updateExperimentAudience";
+import {
+  NimbusExperimentChannel,
+  NimbusExperimentFirefoxMinVersion,
+  NimbusExperimentTargetingConfigSlug,
+  UpdateExperimentAudienceInput,
+} from "../../types/globalTypes";
 
-const { mock } = mockExperimentQuery("demo-slug");
+const { mock, data } = mockExperimentQuery("demo-slug");
+
+let mockSubmitData: Partial<UpdateExperimentAudienceInput>;
+let mutationMock: ReturnType<typeof mockUpdateExperimentAudienceMutation>;
 
 describe("PageEditAudience", () => {
-  it("renders as expected", async () => {
-    render(
-      <RouterSlugProvider mocks={[mock]}>
-        <PageEditAudience />
-      </RouterSlugProvider>,
+  beforeEach(() => {
+    mockSubmitData = { ...MOCK_FORM_DATA };
+    mutationMock = mockUpdateExperimentAudienceMutation(
+      { ...mockSubmitData, nimbusExperimentId: parseInt(data!.id, 10) },
+      {
+        experiment: {
+          ...MOCK_FORM_DATA,
+          __typename: "NimbusExperimentType",
+          id: data!.id!,
+          proposedEnrollment: parseFloat(MOCK_FORM_DATA.proposedEnrollment),
+        },
+      },
     );
+  });
+
+  it("renders as expected", async () => {
+    render(<Subject />);
     await waitFor(() => {
       expect(screen.queryByTestId("PageEditAudience")).toBeInTheDocument();
     });
   });
+
+  it("handles form next button", async () => {
+    render(<Subject />);
+    await waitFor(() => {
+      expect(screen.queryByTestId("PageEditAudience")).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByTestId("next"));
+    expect(navigate).toHaveBeenCalledWith("../request-review");
+  });
+
+  it("handles form submission", async () => {
+    render(<Subject mocks={[mock, mutationMock]} />);
+    let submitButton: HTMLButtonElement;
+    await waitFor(() => {
+      submitButton = screen.getByTestId("submit") as HTMLButtonElement;
+    });
+    await act(async () => {
+      fireEvent.click(submitButton);
+    });
+    expect(mockSubmit).toHaveBeenCalled();
+  });
+
+  it("handles experiment form submission with server-side validation errors", async () => {
+    const expectedErrors = {
+      channels: { message: "this is garbage" },
+    };
+    mutationMock.result.data.updateExperimentAudience.message = expectedErrors;
+    render(<Subject mocks={[mock, mutationMock]} />);
+    let submitButton: HTMLButtonElement;
+    await waitFor(() => {
+      submitButton = screen.getByTestId("submit") as HTMLButtonElement;
+    });
+    await act(async () => {
+      fireEvent.click(submitButton);
+    });
+    expect(screen.getByTestId("submitErrors")).toHaveTextContent(
+      JSON.stringify(expectedErrors),
+    );
+  });
+
+  it("handles form submission with bad server data", async () => {
+    // @ts-ignore - intentionally breaking this type for error handling
+    delete mutationMock.result.data.updateExperimentAudience;
+    render(<Subject mocks={[mock, mutationMock]} />);
+    let submitButton: HTMLButtonElement;
+    await waitFor(() => {
+      submitButton = screen.getByTestId("submit") as HTMLButtonElement;
+    });
+    await act(async () => {
+      fireEvent.click(submitButton);
+    });
+    expect(screen.getByTestId("submitErrors")).toHaveTextContent(
+      JSON.stringify({ "*": SUBMIT_ERROR }),
+    );
+  });
 });
+
+const MOCK_FORM_DATA = {
+  channels: [
+    NimbusExperimentChannel.DESKTOP_NIGHTLY,
+    NimbusExperimentChannel.DESKTOP_BETA,
+  ],
+  firefoxMinVersion: NimbusExperimentFirefoxMinVersion.FIREFOX_80,
+  targetingConfigSlug: NimbusExperimentTargetingConfigSlug.US_ONLY,
+  populationPercent: 40,
+  totalEnrolledClients: 68000,
+  proposedEnrollment: "1.0",
+  proposedDuration: 28,
+};
+
+const Subject = ({
+  mocks = [mock],
+}: {
+  mocks?: MockedResponse<Record<string, any>>[];
+}) => {
+  return (
+    <RouterSlugProvider {...{ mocks }}>
+      <PageEditAudience />
+    </RouterSlugProvider>
+  );
+};
+
+jest.mock("@reach/router", () => ({
+  ...jest.requireActual("@reach/router"),
+  navigate: jest.fn(),
+}));
+
+const mockSubmit = jest.fn();
+
+jest.mock("../FormAudience", () => ({
+  __esModule: true,
+  default: (props: React.ComponentProps<typeof FormAudience>) => {
+    const handleSubmit = (ev: React.FormEvent) => {
+      ev.preventDefault();
+      mockSubmit();
+      props.onSubmit(mockSubmitData, jest.fn());
+    };
+    const handleNext = (ev: React.FormEvent) => {
+      ev.preventDefault();
+      props.onNext && props.onNext(ev);
+    };
+    return (
+      <div data-testid="FormOverview">
+        <div data-testid="submitErrors">
+          {JSON.stringify(props.submitErrors)}
+        </div>
+        <button data-testid="submit" onClick={handleSubmit} />
+        <button data-testid="next" onClick={handleNext} />
+      </div>
+    );
+  },
+}));
+
+export const mockUpdateExperimentAudienceMutation = (
+  input: Partial<UpdateExperimentAudienceInput>,
+  {
+    clientMutationId = "8675309",
+    status = 200,
+    message = "success",
+    experiment,
+  }: {
+    clientMutationId?: string | null;
+    status?: number;
+    message?: string | Record<string, any>;
+    experiment: updateExperimentAudience_updateExperimentAudience_nimbusExperiment;
+  },
+) => {
+  const updateExperimentAudience: updateExperimentAudience_updateExperimentAudience = {
+    __typename: "UpdateExperimentAudience",
+    clientMutationId,
+    status,
+    message,
+    nimbusExperiment: experiment,
+  };
+
+  return {
+    request: {
+      query: UPDATE_EXPERIMENT_AUDIENCE_MUTATION,
+      variables: {
+        input,
+      },
+    },
+    result: {
+      errors: undefined as undefined | any[],
+      data: {
+        updateExperimentAudience,
+      },
+    },
+  };
+};

--- a/app/experimenter/nimbus-ui/src/gql/experiments.ts
+++ b/app/experimenter/nimbus-ui/src/gql/experiments.ts
@@ -95,6 +95,26 @@ export const UPDATE_EXPERIMENT_PROBESETS_MUTATION = gql`
   }
 `;
 
+export const UPDATE_EXPERIMENT_AUDIENCE_MUTATION = gql`
+  mutation updateExperimentAudience($input: UpdateExperimentAudienceInput!) {
+    updateExperimentAudience(input: $input) {
+      clientMutationId
+      message
+      status
+      nimbusExperiment {
+        id
+        totalEnrolledClients
+        channels
+        firefoxMinVersion
+        populationPercent
+        proposedDuration
+        proposedEnrollment
+        targetingConfigSlug
+      }
+    }
+  }
+`;
+
 export const GET_EXPERIMENT_QUERY = gql`
   query getExperiment($slug: String!) {
     experimentBySlug(slug: $slug) {

--- a/app/experimenter/nimbus-ui/src/types/globalTypes.ts
+++ b/app/experimenter/nimbus-ui/src/types/globalTypes.ts
@@ -95,6 +95,18 @@ export interface TreatmentBranchType {
   featureValue?: string | null;
 }
 
+export interface UpdateExperimentAudienceInput {
+  clientMutationId?: string | null;
+  nimbusExperimentId: number;
+  channels?: (NimbusExperimentChannel | null)[] | null;
+  firefoxMinVersion?: NimbusExperimentFirefoxMinVersion | null;
+  populationPercent?: number | null;
+  proposedDuration?: number | null;
+  proposedEnrollment?: string | null;
+  targetingConfigSlug?: NimbusExperimentTargetingConfigSlug | null;
+  totalEnrolledClients?: number | null;
+}
+
 export interface UpdateExperimentBranchesInput {
   clientMutationId?: string | null;
   nimbusExperimentId: number;

--- a/app/experimenter/nimbus-ui/src/types/updateExperimentAudience.ts
+++ b/app/experimenter/nimbus-ui/src/types/updateExperimentAudience.ts
@@ -1,0 +1,38 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+import { UpdateExperimentAudienceInput, NimbusExperimentChannel, NimbusExperimentFirefoxMinVersion, NimbusExperimentTargetingConfigSlug } from "./globalTypes";
+
+// ====================================================
+// GraphQL mutation operation: updateExperimentAudience
+// ====================================================
+
+export interface updateExperimentAudience_updateExperimentAudience_nimbusExperiment {
+  __typename: "NimbusExperimentType";
+  id: string;
+  totalEnrolledClients: number;
+  channels: (NimbusExperimentChannel | null)[] | null;
+  firefoxMinVersion: NimbusExperimentFirefoxMinVersion | null;
+  populationPercent: number | null;
+  proposedDuration: number | null;
+  proposedEnrollment: number | null;
+  targetingConfigSlug: NimbusExperimentTargetingConfigSlug | null;
+}
+
+export interface updateExperimentAudience_updateExperimentAudience {
+  __typename: "UpdateExperimentAudience";
+  clientMutationId: string | null;
+  message: ObjectField | null;
+  status: number | null;
+  nimbusExperiment: updateExperimentAudience_updateExperimentAudience_nimbusExperiment | null;
+}
+
+export interface updateExperimentAudience {
+  updateExperimentAudience: updateExperimentAudience_updateExperimentAudience | null;
+}
+
+export interface updateExperimentAudienceVariables {
+  input: UpdateExperimentAudienceInput;
+}

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -16397,7 +16397,7 @@ react-scripts@3.4.0:
   optionalDependencies:
     fsevents "2.1.2"
 
-react-select-event@5.1.0:
+react-select-event@5.1.0, react-select-event@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/react-select-event/-/react-select-event-5.1.0.tgz#d45ef68f2a9c872903e8c9725f3ae6e7576f7be0"
   integrity sha512-D5DzJlYCdZsGbDVFMQFynrG0OLalJM3ZzDT7KQADNVWE604JCeQF9bIuvPZqVD7IzhnPsFzOUCsilzDA6w6WRQ==


### PR DESCRIPTION
Because:

* We want to save changes the user makes to audience properties

This commit:

* Implements per-field validation in FormAudience

* Implements support for the "Next" button to navigate to next step

* Implements support for the "Save" button to submit changes to the
  updateExperimentAudience GQL mutation

* Add generated types for updateExperimentAudience GQL mutation

* Adds react-select-event dependency to manipulate the react-select
  element in testing for channels multi-select

* Switch to useConfig hook in FormAudience to get select options