### PR TITLE
fixes #4101 chore(nimbus): Add 'Learn more' links to Audience & Branches pages

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/FormAudience/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/FormAudience/index.test.tsx
@@ -11,6 +11,7 @@ import {
   act,
 } from "@testing-library/react";
 import selectEvent from "react-select-event";
+import { AUDIENCE_DOC_URL } from ".";
 import { Subject, MOCK_EXPERIMENT } from "./mocks";
 import { MOCK_CONFIG } from "../../lib/mocks";
 
@@ -24,6 +25,10 @@ describe("FormAudience", () => {
     expect(targetingConfigSlug).toBeInTheDocument();
     expect((targetingConfigSlug as HTMLSelectElement).value).toEqual(
       MOCK_CONFIG!.targetingConfigSlug![0]!.value,
+    );
+    expect(screen.getByTestId("learn-more")).toHaveAttribute(
+      "href",
+      AUDIENCE_DOC_URL,
     );
   });
 

--- a/app/experimenter/nimbus-ui/src/components/FormAudience/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/FormAudience/index.tsx
@@ -21,9 +21,8 @@ import { useConfig } from "../../hooks/useConfig";
 import { getExperiment_experimentBySlug } from "../../types/getExperiment";
 import { getConfig_nimbusConfig_channels } from "../../types/getConfig";
 
-// TODO: find this doco URL
-const AUDIENCE_DOC_URL =
-  "https://mana.mozilla.org/wiki/pages/viewpage.action?spaceKey=FJT&title=Project+Nimbus";
+export const AUDIENCE_DOC_URL =
+  "https://docs.google.com/document/d/155EUgzn22VTX8mFwesSROT3Z6JORSfb5VyoMoLra7ws/";
 
 export const FormAudience = ({
   experiment,
@@ -221,7 +220,9 @@ export const FormAudience = ({
       <Form.Group className="bg-light p-4">
         <p className="text-secondary">
           Please ask a data scientist to help you determine these values.{" "}
-          <LinkExternal href={AUDIENCE_DOC_URL}>Learn more</LinkExternal>
+          <LinkExternal href={AUDIENCE_DOC_URL} data-testid="learn-more">
+            Learn more
+          </LinkExternal>
         </p>
 
         <Form.Row>

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/index.test.tsx
@@ -11,7 +11,7 @@ import {
   act,
 } from "@testing-library/react";
 import { navigate } from "@reach/router";
-import PageEditBranches, { SUBMIT_ERROR_MESSAGE } from ".";
+import PageEditBranches, { SUBMIT_ERROR_MESSAGE, BRANCHES_DOC_URL } from ".";
 import FormBranches from "../FormBranches";
 import { RouterSlugProvider } from "../../lib/test-utils";
 import { mockExperimentQuery, MOCK_CONFIG } from "../../lib/mocks";
@@ -48,6 +48,10 @@ describe("PageEditBranches", () => {
       const { slug } = feature!;
       expect(screen.getByText(slug)).toBeInTheDocument();
     }
+    expect(screen.getByTestId("learn-more")).toHaveAttribute(
+      "href",
+      BRANCHES_DOC_URL,
+    );
   });
 
   it("handles onNext from FormBranches", async () => {
@@ -72,8 +76,8 @@ describe("PageEditBranches", () => {
       expect(screen.getByTestId("PageEditBranches")).toBeInTheDocument();
     });
     await act(async () => {
-      const saveButton = await screen.getByTestId("save-button");
-      await fireEvent.click(saveButton);
+      const saveButton = screen.getByTestId("save-button");
+      fireEvent.click(saveButton);
     });
     expect(mockSetSubmitErrors).not.toHaveBeenCalled();
   });
@@ -95,8 +99,8 @@ describe("PageEditBranches", () => {
     });
 
     await act(async () => {
-      const saveButton = await screen.getByTestId("save-button");
-      await fireEvent.click(saveButton);
+      const saveButton = screen.getByTestId("save-button");
+      fireEvent.click(saveButton);
     });
 
     expect(mockSetSubmitErrors).toHaveBeenCalledWith({
@@ -125,8 +129,8 @@ describe("PageEditBranches", () => {
     });
 
     await act(async () => {
-      const saveButton = await screen.getByTestId("save-button");
-      await fireEvent.click(saveButton);
+      const saveButton = screen.getByTestId("save-button");
+      fireEvent.click(saveButton);
     });
 
     expect(mockSetSubmitErrors).toHaveBeenCalledWith(

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/index.tsx
@@ -15,9 +15,8 @@ import { UpdateExperimentBranchesInput } from "../../types/globalTypes";
 import { updateExperimentBranches_updateExperimentBranches as UpdateExperimentBranchesResult } from "../../types/updateExperimentBranches";
 import { getExperiment_experimentBySlug } from "../../types/getExperiment";
 
-// TODO: find this doco URL
-const BRANCHES_DOC_URL =
-  "https://mana.mozilla.org/wiki/pages/viewpage.action?spaceKey=FJT&title=Project+Nimbus";
+export const BRANCHES_DOC_URL =
+  "https://docs.google.com/document/d/155EUgzn22VTX8mFwesSROT3Z6JORSfb5VyoMoLra7ws/";
 
 export const SUBMIT_ERROR_MESSAGE = "Save failed, no error available";
 
@@ -92,7 +91,9 @@ const PageEditBranches: React.FunctionComponent<RouteComponentProps> = () => {
               If you want, you can add a <strong>feature flag</strong>{" "}
               configuration to each branch. Experiments can only change one flag
               at a time.{" "}
-              <LinkExternal href={BRANCHES_DOC_URL}>Learn more</LinkExternal>
+              <LinkExternal href={BRANCHES_DOC_URL} data-testid="learn-more">
+                Learn more
+              </LinkExternal>
             </p>
             <FormBranches
               {...{


### PR DESCRIPTION
Because:
* We want to link users to the "more info" Experimentation with Nimbus doc

This commit:
* Adds the GDoc link to these pages. It may later be replaced with a Mana link.
* Removes a couple of unnecessary "awaits" in tests.

---

This GDoc may eventually move over to Mana, we can create a follow up to replace the URL if/when that happens.