### PR TITLE
fixes #3746 feat(nimbus): Add Tooltips to Metrics page

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/FormMetrics/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/FormMetrics/index.test.tsx
@@ -7,6 +7,7 @@ import { render, screen, act, fireEvent } from "@testing-library/react";
 import { mockExperimentQuery } from "../../lib/mocks";
 import { Subject } from "./mocks";
 import { getConfig_nimbusConfig_probeSets } from "../../types/getConfig";
+import { PRIMARY_PROBE_SETS_TOOLTIP, SECONDARY_PROBE_SETS_TOOLTIP } from ".";
 
 describe("FormMetrics", () => {
   const probeSets: getConfig_nimbusConfig_probeSets[] = [
@@ -37,6 +38,15 @@ describe("FormMetrics", () => {
     render(<Subject />);
     await act(async () =>
       expect(screen.getByTestId("FormMetrics")).toBeInTheDocument(),
+    );
+
+    expect(screen.getByTestId("tooltip-primary-probe-sets")).toHaveAttribute(
+      "data-tip",
+      PRIMARY_PROBE_SETS_TOOLTIP,
+    );
+    expect(screen.getByTestId("tooltip-secondary-probe-sets")).toHaveAttribute(
+      "data-tip",
+      SECONDARY_PROBE_SETS_TOOLTIP,
     );
   });
 

--- a/app/experimenter/nimbus-ui/src/components/FormMetrics/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/FormMetrics/index.tsx
@@ -6,10 +6,12 @@ import React, { useCallback, useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 import Form from "react-bootstrap/Form";
 import Alert from "react-bootstrap/Alert";
+import ReactTooltip from "react-tooltip";
 import { getExperiment } from "../../types/getExperiment";
 import { getConfig_nimbusConfig_probeSets } from "../../types/getConfig";
 import { useExitWarning } from "../../hooks";
 import Select, { ActionMeta, ValueType } from "react-select";
+import { ReactComponent as Info } from "../../images/info.svg";
 
 type SelectOption = { label: string; value: string };
 
@@ -22,6 +24,11 @@ type FormMetricsProps = {
   onSave: (data: Record<string, any>, reset: Function) => void;
   onNext: (ev: React.FormEvent) => void;
 };
+
+export const PRIMARY_PROBE_SETS_TOOLTIP =
+  "Specific metrics you’d like to impact in your experiment, which will be part of the analysis.";
+export const SECONDARY_PROBE_SETS_TOOLTIP =
+  "Specific metrics that you are interested in observing in your experiment but they don't affect the results of your experiment.";
 
 const FormMetrics = ({
   experiment,
@@ -132,7 +139,17 @@ const FormMetrics = ({
         controlId="selectedPrimaryProbeSetIds"
         data-testid="primary-probe-sets"
       >
-        <Form.Label>Primary Probe sets</Form.Label>
+        <Form.Label>
+          Primary Probe sets{" "}
+          <Info
+            data-tip={PRIMARY_PROBE_SETS_TOOLTIP}
+            data-testid="tooltip-primary-probe-sets"
+            width="20"
+            height="20"
+            className="ml-1"
+          />
+          <ReactTooltip />
+        </Form.Label>
         <Select
           options={primaryProbeSetOptions}
           defaultValue={experiment?.primaryProbeSets?.map((p) => ({
@@ -158,7 +175,16 @@ const FormMetrics = ({
         controlId="selectedSecondaryProbeSetsIds"
         data-testid="secondary-probe-sets"
       >
-        <Form.Label>Secondary Probe sets</Form.Label>
+        <Form.Label>
+          Secondary Probe sets{" "}
+          <Info
+            data-tip={SECONDARY_PROBE_SETS_TOOLTIP}
+            data-testid="tooltip-secondary-probe-sets"
+            width="20"
+            height="20"
+            className="ml-1"
+          />
+        </Form.Label>
         <Select
           options={secondaryProbeSetOptions}
           defaultValue={experiment?.secondaryProbeSets?.map((p) => ({

--- a/app/experimenter/nimbus-ui/src/components/PageEditMetrics/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditMetrics/index.tsx
@@ -70,7 +70,7 @@ const PageEditMetrics: React.FunctionComponent<RouteComponentProps> = () => {
   );
 
   const onNext = useCallback(() => {
-    navigate(`audience`);
+    navigate("audience");
   }, []);
 
   return (


### PR DESCRIPTION
Because:
* We want to display extra info to the user about what probe sets are.

This commit:
* Adds primary probe sets and secondary probe sets tooltips.

---

Opening as a draft, Ana aims to get me these by EOD.

These had to be placed in the form label itself, placing them just after it caused other test failures that looked hairy to fix.