### PR TITLE
fix #4172 chore(nimbus): use string for populationPercent

### DIFF
--- a/app/experimenter/experiments/api/v5/inputs.py
+++ b/app/experimenter/experiments/api/v5/inputs.py
@@ -82,7 +82,7 @@ class UpdateExperimentAudienceInput(graphene.InputObjectType):
     nimbus_experiment_id = graphene.Int(required=True)
     channels = graphene.List(NimbusExperimentChannel)
     firefox_min_version = NimbusExperimentFirefoxMinVersion()
-    population_percent = graphene.Decimal()
+    population_percent = graphene.String()
     proposed_duration = graphene.Int()
     proposed_enrollment = graphene.String()
     targeting_config_slug = NimbusExperimentTargetingConfigSlug()

--- a/app/experimenter/experiments/api/v5/types.py
+++ b/app/experimenter/experiments/api/v5/types.py
@@ -106,6 +106,7 @@ class NimbusExperimentType(DjangoObjectType):
     status = NimbusExperimentStatus()
     application = NimbusExperimentApplication()
     firefox_min_version = NimbusExperimentFirefoxMinVersion()
+    population_percent = graphene.String()
     channels = graphene.List(NimbusExperimentChannel)
     treatment_branches = graphene.List(NimbusBranchType)
     targeting_config_slug = NimbusExperimentTargetingConfigSlug()

--- a/app/experimenter/experiments/tests/api/v5/test_mutation.py
+++ b/app/experimenter/experiments/tests/api/v5/test_mutation.py
@@ -446,7 +446,7 @@ class TestMutations(GraphQLTestCase):
                 "id": str(experiment.id),
                 "channels": [NimbusConstants.Channel.DESKTOP_BETA.name],
                 "firefoxMinVersion": NimbusConstants.Version.FIREFOX_80.name,
-                "populationPercent": 10.0,
+                "populationPercent": "10.0000",
                 "proposedDuration": 42,
                 "proposedEnrollment": 120,
                 "targetingConfigSlug": NimbusConstants.TargetingConfig.ALL_ENGLISH.name,

--- a/app/experimenter/nimbus-ui/schema.graphql
+++ b/app/experimenter/nimbus-ui/schema.graphql
@@ -24,8 +24,6 @@ input CreateExperimentInput {
 
 scalar DateTime
 
-scalar Decimal
-
 type Mutation {
   createExperiment(input: CreateExperimentInput!): CreateExperiment
   updateExperimentOverview(input: UpdateExperimentInput!): UpdateExperimentOverview
@@ -143,7 +141,7 @@ type NimbusExperimentType {
   isPaused: Boolean!
   proposedDuration: Int
   proposedEnrollment: Int
-  populationPercent: Float
+  populationPercent: String
   totalEnrolledClients: Int!
   firefoxMinVersion: NimbusExperimentFirefoxMinVersion
   application: NimbusExperimentApplication
@@ -265,7 +263,7 @@ input UpdateExperimentAudienceInput {
   nimbusExperimentId: Int!
   channels: [NimbusExperimentChannel]
   firefoxMinVersion: NimbusExperimentFirefoxMinVersion
-  populationPercent: Decimal
+  populationPercent: String
   proposedDuration: Int
   proposedEnrollment: String
   targetingConfigSlug: NimbusExperimentTargetingConfigSlug

--- a/app/experimenter/nimbus-ui/src/components/PageEditAudience/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditAudience/index.test.tsx
@@ -120,7 +120,7 @@ const MOCK_FORM_DATA = {
   ],
   firefoxMinVersion: NimbusExperimentFirefoxMinVersion.FIREFOX_80,
   targetingConfigSlug: NimbusExperimentTargetingConfigSlug.US_ONLY,
-  populationPercent: 40,
+  populationPercent: "40",
   totalEnrolledClients: 68000,
   proposedEnrollment: "1.0",
   proposedDuration: 28,

--- a/app/experimenter/nimbus-ui/src/components/TableAudience/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/TableAudience/index.stories.tsx
@@ -44,7 +44,7 @@ storiesOf("components/TableAudience", module)
     const { experiment } = mockExperimentQuery("demo-slug", {
       channels: [],
       firefoxMinVersion: null,
-      populationPercent: 0,
+      populationPercent: "0",
       totalEnrolledClients: 0,
       targetingConfigSlug: null,
     });

--- a/app/experimenter/nimbus-ui/src/lib/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/lib/mocks.tsx
@@ -299,7 +299,7 @@ export function mockExperimentQuery<
       channels: ["DESKTOP_NIGHTLY", "DESKTOP_BETA"],
       firefoxMinVersion: "FIREFOX_80",
       targetingConfigSlug: "US_ONLY",
-      populationPercent: 40,
+      populationPercent: "40",
       totalEnrolledClients: 68000,
       proposedEnrollment: 1,
       proposedDuration: 28,

--- a/app/experimenter/nimbus-ui/src/types/getExperiment.ts
+++ b/app/experimenter/nimbus-ui/src/types/getExperiment.ts
@@ -84,7 +84,7 @@ export interface getExperiment_experimentBySlug {
   channels: (NimbusExperimentChannel | null)[] | null;
   firefoxMinVersion: NimbusExperimentFirefoxMinVersion | null;
   targetingConfigSlug: NimbusExperimentTargetingConfigSlug | null;
-  populationPercent: number | null;
+  populationPercent: string | null;
   totalEnrolledClients: number;
   proposedEnrollment: number | null;
   proposedDuration: number | null;

--- a/app/experimenter/nimbus-ui/src/types/globalTypes.ts
+++ b/app/experimenter/nimbus-ui/src/types/globalTypes.ts
@@ -100,7 +100,7 @@ export interface UpdateExperimentAudienceInput {
   nimbusExperimentId: number;
   channels?: (NimbusExperimentChannel | null)[] | null;
   firefoxMinVersion?: NimbusExperimentFirefoxMinVersion | null;
-  populationPercent?: number | null;
+  populationPercent?: string | null;
   proposedDuration?: number | null;
   proposedEnrollment?: string | null;
   targetingConfigSlug?: NimbusExperimentTargetingConfigSlug | null;

--- a/app/experimenter/nimbus-ui/src/types/updateExperimentAudience.ts
+++ b/app/experimenter/nimbus-ui/src/types/updateExperimentAudience.ts
@@ -15,7 +15,7 @@ export interface updateExperimentAudience_updateExperimentAudience_nimbusExperim
   totalEnrolledClients: number;
   channels: (NimbusExperimentChannel | null)[] | null;
   firefoxMinVersion: NimbusExperimentFirefoxMinVersion | null;
-  populationPercent: number | null;
+  populationPercent: string | null;
   proposedDuration: number | null;
   proposedEnrollment: number | null;
   targetingConfigSlug: NimbusExperimentTargetingConfigSlug | null;


### PR DESCRIPTION
Because

* We were inconsistently using number/float/Decimal for populationPercent in the V5 API

This commit

* Uses string everywhere in the gql/frontend for populationPercent to preserve the exact value input by users
* The V5 serializer will enforce parsing and validating the string into a Decimal with the correct number of decimal places