### PR TITLE
fixes #4159 fix(nimbus): Display JSON link if status is not draft/review

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/Summary/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/index.test.tsx
@@ -19,9 +19,9 @@ describe("Summary", () => {
   });
 
   describe("JSON representation link", () => {
-    it("renders in non-draft status", () => {
+    it("renders when status is not 'draft' or 'review'", () => {
       const { experiment } = mockExperimentQuery("demo-slug", {
-        status: NimbusExperimentStatus.COMPLETE,
+        status: NimbusExperimentStatus.ACCEPTED,
       });
       render(<Subject {...{ experiment }} />);
       expect(screen.getByTestId("link-json")).toBeInTheDocument();
@@ -32,8 +32,16 @@ describe("Summary", () => {
     });
   });
 
-  it("does not render in draft status", () => {
+  it("does not render in 'draft' status", () => {
     const { experiment } = mockExperimentQuery("demo-slug");
+    render(<Subject {...{ experiment }} />);
+    expect(screen.queryByTestId("link-json")).not.toBeInTheDocument();
+  });
+
+  it("does not render in 'review' status", () => {
+    const { experiment } = mockExperimentQuery("demo-slug", {
+      status: NimbusExperimentStatus.REVIEW,
+    });
     render(<Subject {...{ experiment }} />);
     expect(screen.queryByTestId("link-json")).not.toBeInTheDocument();
   });

--- a/app/experimenter/nimbus-ui/src/components/Summary/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/index.tsx
@@ -9,36 +9,40 @@ import SummaryTimeline from "../SummaryTimeline";
 import TableSummary from "../TableSummary";
 import TableAudience from "../TableAudience";
 import LinkExternal from "../LinkExternal";
-import { NimbusExperimentStatus } from "../../types/globalTypes";
+import { getStatus } from "../../lib/experiment";
 
 type SummaryProps = {
   experiment: getExperiment_experimentBySlug;
 };
 
-const Summary = ({ experiment }: SummaryProps) => (
-  <div data-testid="summary">
-    <h2 className="h5 mb-3">Timeline</h2>
-    <SummaryTimeline {...{ experiment }} />
+const Summary = ({ experiment }: SummaryProps) => {
+  const status = getStatus(experiment);
 
-    <div className="d-flex flex-row justify-content-between">
-      <h2 className="h5 mb-3">Summary</h2>
-      {experiment.status !== NimbusExperimentStatus.DRAFT && (
-        <span>
-          <LinkExternal
-            href={`/api/v6/experiments/${experiment.slug}/`}
-            data-testid="link-json"
-          >
-            See full JSON representation
-          </LinkExternal>
-        </span>
-      )}
+  return (
+    <div data-testid="summary">
+      <h2 className="h5 mb-3">Timeline</h2>
+      <SummaryTimeline {...{ experiment }} />
+
+      <div className="d-flex flex-row justify-content-between">
+        <h2 className="h5 mb-3">Summary</h2>
+        {!status.draft && !status.review && (
+          <span>
+            <LinkExternal
+              href={`/api/v6/experiments/${experiment.slug}/`}
+              data-testid="link-json"
+            >
+              See full JSON representation
+            </LinkExternal>
+          </span>
+        )}
+      </div>
+      <TableSummary {...{ experiment }} />
+
+      <h2 className="h5 mb-3">Audience</h2>
+      <TableAudience {...{ experiment }} />
     </div>
-    <TableSummary {...{ experiment }} />
-
-    <h2 className="h5 mb-3">Audience</h2>
-    <TableAudience {...{ experiment }} />
-  </div>
-);
+  );
+};
 
 type displayConfigOptionsProps =
   | getConfig_nimbusConfig["application"]


### PR DESCRIPTION
Because:
* The data from the endpoint is only available when the status is at least 'accepted'.

This commit:
* Updates the conditional for displaying the link in the Summary component.