### PR TITLE
fixes #4294 feat(nimbus): Add initial directory view

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/DirectoryTable/index.scss
+++ b/app/experimenter/nimbus-ui/src/components/DirectoryTable/index.scss
@@ -1,0 +1,7 @@
+.directory-table th {
+  font-weight: normal;
+  border-top: 0;
+  &:first-child {
+    font-weight: bold;
+  }
+}

--- a/app/experimenter/nimbus-ui/src/components/DirectoryTable/index.scss
+++ b/app/experimenter/nimbus-ui/src/components/DirectoryTable/index.scss
@@ -1,7 +1,0 @@
-.directory-table th {
-  font-weight: normal;
-  border-top: 0;
-  &:first-child {
-    font-weight: bold;
-  }
-}

--- a/app/experimenter/nimbus-ui/src/components/DirectoryTable/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/DirectoryTable/index.stories.tsx
@@ -1,0 +1,34 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from "react";
+import { storiesOf } from "@storybook/react";
+import { withLinks } from "@storybook/addon-links";
+import { mockDirectoryExperimentsFactory } from "../../lib/mocks";
+import DirectoryTable from ".";
+
+storiesOf("components/DirectoryTable", module)
+  .addDecorator(withLinks)
+  .add("basic", () => {
+    return (
+      <DirectoryTable
+        title="Mocked Experiments"
+        experiments={mockDirectoryExperimentsFactory()}
+      />
+    );
+  })
+  .add("custom components", () => {
+    return (
+      <DirectoryTable
+        title="Mocked Experiments"
+        experiments={mockDirectoryExperimentsFactory()}
+        columns={[
+          {
+            label: "Testing column",
+            component: ({ status }) => <td>Hello {status}</td>,
+          },
+        ]}
+      />
+    );
+  });

--- a/app/experimenter/nimbus-ui/src/components/DirectoryTable/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/DirectoryTable/index.stories.tsx
@@ -6,13 +6,29 @@ import React from "react";
 import { storiesOf } from "@storybook/react";
 import { withLinks } from "@storybook/addon-links";
 import { mockDirectoryExperimentsFactory } from "../../lib/mocks";
-import DirectoryTable from ".";
+import DirectoryTable, { DirectoryCompleteTable, DirectoryLiveTable } from ".";
 
 storiesOf("components/DirectoryTable", module)
   .addDecorator(withLinks)
   .add("basic", () => {
     return (
       <DirectoryTable
+        title="Mocked Experiments"
+        experiments={mockDirectoryExperimentsFactory()}
+      />
+    );
+  })
+  .add("live", () => {
+    return (
+      <DirectoryLiveTable
+        title="Mocked Experiments"
+        experiments={mockDirectoryExperimentsFactory()}
+      />
+    );
+  })
+  .add("complete", () => {
+    return (
+      <DirectoryCompleteTable
         title="Mocked Experiments"
         experiments={mockDirectoryExperimentsFactory()}
       />
@@ -29,6 +45,22 @@ storiesOf("components/DirectoryTable", module)
             component: ({ status }) => <td>Hello {status}</td>,
           },
         ]}
+      />
+    );
+  })
+  .add("missing owner", () => {
+    return (
+      <DirectoryTable
+        title="Mocked Experiments"
+        experiments={mockDirectoryExperimentsFactory([{ owner: null }])}
+      />
+    );
+  })
+  .add("no feature", () => {
+    return (
+      <DirectoryTable
+        title="Mocked Experiments"
+        experiments={mockDirectoryExperimentsFactory([{ featureConfig: null }])}
       />
     );
   });

--- a/app/experimenter/nimbus-ui/src/components/DirectoryTable/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/DirectoryTable/index.stories.tsx
@@ -6,7 +6,11 @@ import React from "react";
 import { storiesOf } from "@storybook/react";
 import { withLinks } from "@storybook/addon-links";
 import { mockDirectoryExperimentsFactory } from "../../lib/mocks";
-import DirectoryTable, { DirectoryCompleteTable, DirectoryLiveTable } from ".";
+import DirectoryTable, {
+  DirectoryCompleteTable,
+  DirectoryDraftsTable,
+  DirectoryLiveTable,
+} from ".";
 
 storiesOf("components/DirectoryTable", module)
   .addDecorator(withLinks)
@@ -29,6 +33,14 @@ storiesOf("components/DirectoryTable", module)
   .add("complete", () => {
     return (
       <DirectoryCompleteTable
+        title="Mocked Experiments"
+        experiments={mockDirectoryExperimentsFactory()}
+      />
+    );
+  })
+  .add("drafts", () => {
+    return (
+      <DirectoryDraftsTable
         title="Mocked Experiments"
         experiments={mockDirectoryExperimentsFactory()}
       />

--- a/app/experimenter/nimbus-ui/src/components/DirectoryTable/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/DirectoryTable/index.stories.tsx
@@ -5,7 +5,7 @@
 import React from "react";
 import { storiesOf } from "@storybook/react";
 import { withLinks } from "@storybook/addon-links";
-import { mockDirectoryExperimentsFactory } from "../../lib/mocks";
+import { mockDirectoryExperiments } from "../../lib/mocks";
 import DirectoryTable, {
   DirectoryCompleteTable,
   DirectoryDraftsTable,
@@ -18,7 +18,7 @@ storiesOf("components/DirectoryTable", module)
     return (
       <DirectoryTable
         title="Mocked Experiments"
-        experiments={mockDirectoryExperimentsFactory()}
+        experiments={mockDirectoryExperiments()}
       />
     );
   })
@@ -26,7 +26,7 @@ storiesOf("components/DirectoryTable", module)
     return (
       <DirectoryLiveTable
         title="Mocked Experiments"
-        experiments={mockDirectoryExperimentsFactory()}
+        experiments={mockDirectoryExperiments()}
       />
     );
   })
@@ -34,7 +34,7 @@ storiesOf("components/DirectoryTable", module)
     return (
       <DirectoryCompleteTable
         title="Mocked Experiments"
-        experiments={mockDirectoryExperimentsFactory()}
+        experiments={mockDirectoryExperiments()}
       />
     );
   })
@@ -42,7 +42,7 @@ storiesOf("components/DirectoryTable", module)
     return (
       <DirectoryDraftsTable
         title="Mocked Experiments"
-        experiments={mockDirectoryExperimentsFactory()}
+        experiments={mockDirectoryExperiments()}
       />
     );
   })
@@ -50,7 +50,7 @@ storiesOf("components/DirectoryTable", module)
     return (
       <DirectoryTable
         title="Mocked Experiments"
-        experiments={mockDirectoryExperimentsFactory()}
+        experiments={mockDirectoryExperiments()}
         columns={[
           {
             label: "Testing column",
@@ -64,7 +64,7 @@ storiesOf("components/DirectoryTable", module)
     return (
       <DirectoryTable
         title="Mocked Experiments"
-        experiments={mockDirectoryExperimentsFactory([{ owner: null }])}
+        experiments={mockDirectoryExperiments([{ owner: null }])}
       />
     );
   })
@@ -72,7 +72,7 @@ storiesOf("components/DirectoryTable", module)
     return (
       <DirectoryTable
         title="Mocked Experiments"
-        experiments={mockDirectoryExperimentsFactory([{ featureConfig: null }])}
+        experiments={mockDirectoryExperiments([{ featureConfig: null }])}
       />
     );
   });

--- a/app/experimenter/nimbus-ui/src/components/DirectoryTable/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/DirectoryTable/index.tsx
@@ -12,6 +12,7 @@ import {
   getProposedEnrollmentRange,
   humanDate,
 } from "../../lib/dateUtils";
+import { NotSet } from "../Summary";
 
 // These are all render functions for column type sin the table.
 export type ColumnComponent = React.FC<getAllExperiments_experiments>;
@@ -29,7 +30,7 @@ export const DirectoryColumnTitle: ColumnComponent = ({ slug, name }) => {
 };
 
 export const DirectoryColumnOwner: ColumnComponent = ({ owner }) => (
-  <td>{owner && owner.username}</td>
+  <td>{owner?.username || <NotSet />}</td>
 );
 
 export const DirectoryColumnFeature: ColumnComponent = ({ featureConfig }) => (
@@ -43,7 +44,7 @@ export const DirectoryColumnFeature: ColumnComponent = ({ featureConfig }) => (
         </span>
       </>
     ) : (
-      "Simple"
+      "(None)"
     )}
   </td>
 );
@@ -157,7 +158,7 @@ export const DirectoryCompleteTable: React.FC<DirectoryTableProps> = (
         component: ({ slug }) => (
           <td>
             <Link to={`${slug}/results`} data-sb-kind="pages/Results">
-              results
+              Results
             </Link>
           </td>
         ),

--- a/app/experimenter/nimbus-ui/src/components/DirectoryTable/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/DirectoryTable/index.tsx
@@ -4,7 +4,6 @@
 
 import React from "react";
 import { getAllExperiments_experiments } from "../../types/getAllExperiments";
-import "./index.scss";
 import { Link } from "@reach/router";
 import LinkExternal from "../LinkExternal";
 import {
@@ -79,8 +78,15 @@ const DirectoryTable: React.FunctionComponent<DirectoryTableProps> = ({
       <table className="table">
         <thead>
           <tr>
-            {columns.map(({ label }) => (
-              <th key={label}>{label}</th>
+            {columns.map(({ label }, i) => (
+              <th
+                className={`border-top-0 ${
+                  i === 0 ? "font-weight-bold" : "font-weight-normal"
+                }`}
+                key={label}
+              >
+                {label}
+              </th>
             ))}
           </tr>
         </thead>

--- a/app/experimenter/nimbus-ui/src/components/DirectoryTable/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/DirectoryTable/index.tsx
@@ -17,10 +17,12 @@ import { NotSet } from "../Summary";
 // These are all render functions for column type sin the table.
 export type ColumnComponent = React.FC<getAllExperiments_experiments>;
 
-export const DirectoryColumnTitle: ColumnComponent = ({ slug, name }) => {
+export const DirectoryColumnTitle: React.FC<
+  getAllExperiments_experiments & { subPath?: string; sbLink?: string }
+> = ({ slug, name, subPath = "", sbLink = "pages/Summary" }) => {
   return (
     <td className="w-33">
-      <Link to={slug} data-sb-kind="pages/Summary">
+      <Link to={slug + subPath} data-sb-kind={sbLink}>
         {name}
       </Link>
       <br />
@@ -65,16 +67,12 @@ interface DirectoryTableProps {
 const DirectoryTable: React.FunctionComponent<DirectoryTableProps> = ({
   title,
   experiments,
-  columns: customColumns = [],
+  columns: customColumns,
 }) => {
-  const columns = [
-    // All directory views start with these three columns...
+  const columns = customColumns || [
     { label: title, component: DirectoryColumnTitle },
     { label: "Owner", component: DirectoryColumnOwner },
     { label: "Feature", component: DirectoryColumnFeature },
-
-    // And add any additional ones.
-    ...customColumns,
   ];
   return (
     <div className="directory-table pb-4" data-testid="DirectoryTable">
@@ -110,6 +108,9 @@ export const DirectoryLiveTable: React.FC<DirectoryTableProps> = (props) => (
   <DirectoryTable
     {...props}
     columns={[
+      { label: props.title, component: DirectoryColumnTitle },
+      { label: "Owner", component: DirectoryColumnOwner },
+      { label: "Feature", component: DirectoryColumnFeature },
       {
         label: "Enrolling",
         component: (experiment) => (
@@ -145,6 +146,9 @@ export const DirectoryCompleteTable: React.FC<DirectoryTableProps> = (
   <DirectoryTable
     {...props}
     columns={[
+      { label: props.title, component: DirectoryColumnTitle },
+      { label: "Owner", component: DirectoryColumnOwner },
+      { label: "Feature", component: DirectoryColumnFeature },
       {
         label: "Started",
         component: ({ startDate: d }) => <td>{d && humanDate(d)}</td>,
@@ -163,6 +167,26 @@ export const DirectoryCompleteTable: React.FC<DirectoryTableProps> = (
           </td>
         ),
       },
+    ]}
+  />
+);
+
+export const DirectoryDraftsTable: React.FC<DirectoryTableProps> = (props) => (
+  <DirectoryTable
+    {...props}
+    columns={[
+      {
+        label: props.title,
+        component: (experiment) => (
+          <DirectoryColumnTitle
+            {...experiment}
+            subPath="/edit"
+            sbLink="pages/EditOverview"
+          />
+        ),
+      },
+      { label: "Owner", component: DirectoryColumnOwner },
+      { label: "Feature", component: DirectoryColumnFeature },
     ]}
   />
 );

--- a/app/experimenter/nimbus-ui/src/components/DirectoryTable/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/DirectoryTable/index.tsx
@@ -1,0 +1,169 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from "react";
+import { getAllExperiments_experiments } from "../../types/getAllExperiments";
+import "./index.scss";
+import { Link } from "@reach/router";
+import LinkExternal from "../LinkExternal";
+import {
+  getProposedEndDate,
+  getProposedEnrollmentRange,
+  humanDate,
+} from "../../lib/dateUtils";
+
+// These are all render functions for column type sin the table.
+export type ColumnComponent = React.FC<getAllExperiments_experiments>;
+
+export const DirectoryColumnTitle: ColumnComponent = ({ slug, name }) => {
+  return (
+    <td className="w-33">
+      <Link to={slug} data-sb-kind="pages/Summary">
+        {name}
+      </Link>
+      <br />
+      <span className="text-monospace text-secondary small">{slug}</span>
+    </td>
+  );
+};
+
+export const DirectoryColumnOwner: ColumnComponent = ({ owner }) => (
+  <td>{owner && owner.username}</td>
+);
+
+export const DirectoryColumnFeature: ColumnComponent = ({ featureConfig }) => (
+  <td>
+    {featureConfig ? (
+      <>
+        {featureConfig.name}
+        <br />
+        <span className="text-monospace text-secondary small">
+          {featureConfig.slug}
+        </span>
+      </>
+    ) : (
+      "Simple"
+    )}
+  </td>
+);
+
+interface Column {
+  /** The label of the column, which shows up in <th/> */
+  label: string;
+  /** A component that renders a <td/> given the experiment data */
+  component: ColumnComponent;
+}
+
+interface DirectoryTableProps {
+  title: string;
+  experiments: getAllExperiments_experiments[];
+  columns?: Column[];
+}
+
+const DirectoryTable: React.FunctionComponent<DirectoryTableProps> = ({
+  title,
+  experiments,
+  columns: customColumns = [],
+}) => {
+  const columns = [
+    // All directory views start with these three columns...
+    { label: title, component: DirectoryColumnTitle },
+    { label: "Owner", component: DirectoryColumnOwner },
+    { label: "Feature", component: DirectoryColumnFeature },
+
+    // And add any additional ones.
+    ...customColumns,
+  ];
+  return (
+    <div className="directory-table pb-4" data-testid="DirectoryTable">
+      <table className="table">
+        <thead>
+          <tr>
+            {columns.map(({ label }) => (
+              <th key={label}>{label}</th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {experiments.length ? (
+            experiments.map((experiment) => (
+              <tr key={experiment.slug}>
+                {columns.map(({ label, component: ColumnComponent }, i) => {
+                  return <ColumnComponent key={label + i} {...experiment} />;
+                })}
+              </tr>
+            ))
+          ) : (
+            <tr>
+              <td colSpan={columns.length}>No experiments found.</td>
+            </tr>
+          )}
+        </tbody>
+      </table>
+    </div>
+  );
+};
+
+export const DirectoryLiveTable: React.FC<DirectoryTableProps> = (props) => (
+  <DirectoryTable
+    {...props}
+    columns={[
+      {
+        label: "Enrolling",
+        component: (experiment) => (
+          <td>{getProposedEnrollmentRange(experiment)}</td>
+        ),
+      },
+      {
+        label: "Ending",
+        component: (experiment) => <td>{getProposedEndDate(experiment)}</td>,
+      },
+      {
+        label: "Monitoring",
+        component: ({ monitoringDashboardUrl }) => (
+          <td>
+            {monitoringDashboardUrl && (
+              <LinkExternal
+                href={monitoringDashboardUrl!}
+                data-testid="link-monitoring-dashboard"
+              >
+                Grafana
+              </LinkExternal>
+            )}
+          </td>
+        ),
+      },
+    ]}
+  />
+);
+
+export const DirectoryCompleteTable: React.FC<DirectoryTableProps> = (
+  props,
+) => (
+  <DirectoryTable
+    {...props}
+    columns={[
+      {
+        label: "Started",
+        component: ({ startDate: d }) => <td>{d && humanDate(d)}</td>,
+      },
+      {
+        label: "Ended",
+        component: ({ endDate: d }) => <td>{d && humanDate(d)}</td>,
+      },
+      {
+        label: "Results",
+        component: ({ slug }) => (
+          <td>
+            <Link to={`${slug}/results`} data-sb-kind="pages/Results">
+              results
+            </Link>
+          </td>
+        ),
+      },
+    ]}
+  />
+);
+
+export default DirectoryTable;

--- a/app/experimenter/nimbus-ui/src/components/PageHome/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageHome/index.stories.tsx
@@ -12,40 +12,32 @@ import { NimbusExperimentStatus } from "../../types/globalTypes";
 
 storiesOf("pages/Home", module)
   .addDecorator(withLinks)
-  .add("basic", () => {
-    return (
-      <RouterSlugProvider mocks={[mockDirectoryExperimentsQuery()]}>
-        <PageHome />
-      </RouterSlugProvider>
-    );
-  })
-  .add("loading", () => {
-    return (
-      <RouterSlugProvider mocks={[]}>
-        <PageHome />
-      </RouterSlugProvider>
-    );
-  })
-  .add("no experiments", () => {
-    return (
-      <MockedCache mocks={[mockDirectoryExperimentsQuery([])]}>
-        <PageHome />
-      </MockedCache>
-    );
-  })
-  .add("only drafts", () => {
-    return (
-      <MockedCache
-        mocks={[
-          mockDirectoryExperimentsQuery([
-            { status: NimbusExperimentStatus.DRAFT },
-            { status: NimbusExperimentStatus.DRAFT },
-            { status: NimbusExperimentStatus.DRAFT },
-            { status: NimbusExperimentStatus.DRAFT },
-          ]),
-        ]}
-      >
-        <PageHome />
-      </MockedCache>
-    );
-  });
+  .add("basic", () => (
+    <RouterSlugProvider mocks={[mockDirectoryExperimentsQuery()]}>
+      <PageHome />
+    </RouterSlugProvider>
+  ))
+  .add("loading", () => (
+    <RouterSlugProvider mocks={[]}>
+      <PageHome />
+    </RouterSlugProvider>
+  ))
+  .add("no experiments", () => (
+    <MockedCache mocks={[mockDirectoryExperimentsQuery([])]}>
+      <PageHome />
+    </MockedCache>
+  ))
+  .add("only drafts", () => (
+    <MockedCache
+      mocks={[
+        mockDirectoryExperimentsQuery([
+          { status: NimbusExperimentStatus.DRAFT },
+          { status: NimbusExperimentStatus.DRAFT },
+          { status: NimbusExperimentStatus.DRAFT },
+          { status: NimbusExperimentStatus.DRAFT },
+        ]),
+      ]}
+    >
+      <PageHome />
+    </MockedCache>
+  ));

--- a/app/experimenter/nimbus-ui/src/components/PageHome/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageHome/index.stories.tsx
@@ -4,9 +4,48 @@
 
 import React from "react";
 import { storiesOf } from "@storybook/react";
+import { RouterSlugProvider } from "../../lib/test-utils";
 import { withLinks } from "@storybook/addon-links";
+import { mockDirectoryExperimentsQuery, MockedCache } from "../../lib/mocks";
 import PageHome from ".";
+import { NimbusExperimentStatus } from "../../types/globalTypes";
 
 storiesOf("pages/Home", module)
   .addDecorator(withLinks)
-  .add("basic", () => <PageHome />);
+  .add("basic", () => {
+    return (
+      <RouterSlugProvider mocks={[mockDirectoryExperimentsQuery()]}>
+        <PageHome />
+      </RouterSlugProvider>
+    );
+  })
+  .add("loading", () => {
+    return (
+      <RouterSlugProvider mocks={[]}>
+        <PageHome />
+      </RouterSlugProvider>
+    );
+  })
+  .add("no experiments", () => {
+    return (
+      <MockedCache mocks={[mockDirectoryExperimentsQuery([])]}>
+        <PageHome />
+      </MockedCache>
+    );
+  })
+  .add("only drafts", () => {
+    return (
+      <MockedCache
+        mocks={[
+          mockDirectoryExperimentsQuery([
+            { status: NimbusExperimentStatus.DRAFT },
+            { status: NimbusExperimentStatus.DRAFT },
+            { status: NimbusExperimentStatus.DRAFT },
+            { status: NimbusExperimentStatus.DRAFT },
+          ]),
+        ]}
+      >
+        <PageHome />
+      </MockedCache>
+    );
+  });

--- a/app/experimenter/nimbus-ui/src/components/PageHome/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageHome/index.test.tsx
@@ -3,17 +3,55 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React from "react";
-import { render, screen } from "@testing-library/react";
+import {
+  render,
+  screen,
+  waitForElementToBeRemoved,
+} from "@testing-library/react";
 import PageHome from ".";
+import { mockDirectoryExperimentsQuery, MockedCache } from "../../lib/mocks";
+import { getAllExperiments_experiments } from "../../types/getAllExperiments";
+import * as apollo from "@apollo/client";
 
 describe("PageHome", () => {
   it("renders as expected", () => {
     render(<Subject />);
+
     expect(screen.getByTestId("PageHome")).toBeInTheDocument();
     expect(screen.getByText("New experiment")).toBeInTheDocument();
   });
+  it("displays loading when experiments are still loading", () => {
+    (jest.spyOn(apollo, "useQuery") as jest.Mock).mockReturnValueOnce({
+      loading: true,
+    });
 
-  const Subject = () => {
-    return <PageHome />;
-  };
+    render(<Subject experiments={[]} />);
+
+    expect(screen.queryByTestId("page-loading")).toBeInTheDocument();
+  });
+  it("displays loading when experiments are still loading", async () => {
+    await renderAndWaitForLoaded([]);
+    expect(screen.queryByText("No experiments found.")).toBeInTheDocument();
+  });
+  it("displays four Directory Tables (one for each status type)", async () => {
+    await renderAndWaitForLoaded();
+    expect(screen.queryAllByTestId("DirectoryTable")).toHaveLength(4);
+  });
 });
+
+const Subject = ({
+  experiments,
+}: {
+  experiments?: getAllExperiments_experiments[];
+}) => (
+  <MockedCache mocks={[mockDirectoryExperimentsQuery(experiments)]}>
+    <PageHome {...{ experiments }} />
+  </MockedCache>
+);
+
+const renderAndWaitForLoaded = async (
+  experiments?: getAllExperiments_experiments[],
+) => {
+  render(<Subject {...{ experiments }} />);
+  await waitForElementToBeRemoved(() => screen.getByTestId("page-loading"));
+};

--- a/app/experimenter/nimbus-ui/src/components/PageHome/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageHome/index.tsx
@@ -48,7 +48,7 @@ const PageHome: React.FunctionComponent<PageHomeProps> = () => {
       <Head title="Experiments" />
 
       <h2 className="mb-4">
-        Experiments{" "}
+        Nimbus Experiments{" "}
         <Link
           to="new"
           data-sb-kind="pages/New"

--- a/app/experimenter/nimbus-ui/src/components/PageHome/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageHome/index.tsx
@@ -8,7 +8,7 @@ import { RouteComponentProps, Link } from "@reach/router";
 import Head from "../Head";
 import { useQuery } from "@apollo/client";
 import { getAllExperiments_experiments } from "../../types/getAllExperiments";
-import { GET_ALL_EXPERIMENTS } from "../../gql/experiments";
+import { GET_EXPERIMENTS_QUERY } from "../../gql/experiments";
 import PageLoading from "../PageLoading";
 import sortByStatus from "./sortByStatus";
 import DirectoryTable, {
@@ -22,7 +22,7 @@ type PageHomeProps = {} & RouteComponentProps;
 export const Body = () => {
   const { data, loading } = useQuery<{
     experiments: getAllExperiments_experiments[];
-  }>(GET_ALL_EXPERIMENTS);
+  }>(GET_EXPERIMENTS_QUERY);
 
   if (loading) {
     return <PageLoading />;

--- a/app/experimenter/nimbus-ui/src/components/PageHome/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageHome/index.tsx
@@ -14,6 +14,7 @@ import sortByStatus from "./sortByStatus";
 import DirectoryTable, {
   DirectoryLiveTable,
   DirectoryCompleteTable,
+  DirectoryDraftsTable,
 } from "../DirectoryTable";
 
 type PageHomeProps = {} & RouteComponentProps;
@@ -37,7 +38,7 @@ export const Body = () => {
       <DirectoryLiveTable title="Live Experiments" experiments={live} />
       <DirectoryCompleteTable title="Completed" experiments={complete} />
       <DirectoryTable title="In Review" experiments={review} />
-      <DirectoryTable title="Drafts" experiments={draft} />
+      <DirectoryDraftsTable title="Drafts" experiments={draft} />
     </>
   );
 };

--- a/app/experimenter/nimbus-ui/src/components/PageHome/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageHome/index.tsx
@@ -6,18 +6,60 @@ import React from "react";
 import AppLayout from "../AppLayout";
 import { RouteComponentProps, Link } from "@reach/router";
 import Head from "../Head";
+import { useQuery } from "@apollo/client";
+import { getAllExperiments_experiments } from "../../types/getAllExperiments";
+import { GET_ALL_EXPERIMENTS } from "../../gql/experiments";
+import PageLoading from "../PageLoading";
+import sortByStatus from "./sortByStatus";
+import DirectoryTable, {
+  DirectoryLiveTable,
+  DirectoryCompleteTable,
+} from "../DirectoryTable";
 
 type PageHomeProps = {} & RouteComponentProps;
 
-const PageHome: React.FunctionComponent<PageHomeProps> = () => (
-  <AppLayout testid="PageHome">
-    <Head title="Experiments" />
+export const Body = () => {
+  const { data, loading } = useQuery<{
+    experiments: getAllExperiments_experiments[];
+  }>(GET_ALL_EXPERIMENTS);
 
-    <h1>Home</h1>
-    <Link to="new" data-sb-kind="pages/New">
-      New experiment
-    </Link>
-  </AppLayout>
-);
+  if (loading) {
+    return <PageLoading />;
+  }
+
+  if (!data) {
+    return <div>No experiments found.</div>;
+  }
+
+  const { live, complete, review, draft } = sortByStatus(data.experiments);
+  return (
+    <>
+      <DirectoryLiveTable title="Live Experiments" experiments={live} />
+      <DirectoryCompleteTable title="Completed" experiments={complete} />
+      <DirectoryTable title="In Review" experiments={review} />
+      <DirectoryTable title="Drafts" experiments={draft} />
+    </>
+  );
+};
+
+const PageHome: React.FunctionComponent<PageHomeProps> = () => {
+  return (
+    <AppLayout testid="PageHome">
+      <Head title="Experiments" />
+
+      <h2 className="mb-4">
+        Experiments{" "}
+        <Link
+          to="new"
+          data-sb-kind="pages/New"
+          className="btn btn-primary btn-small ml-2"
+        >
+          New experiment
+        </Link>
+      </h2>
+      <Body />
+    </AppLayout>
+  );
+};
 
 export default PageHome;

--- a/app/experimenter/nimbus-ui/src/components/PageHome/sortByStatus.ts
+++ b/app/experimenter/nimbus-ui/src/components/PageHome/sortByStatus.ts
@@ -5,12 +5,10 @@
 import { getStatus } from "../../lib/experiment";
 import { getAllExperiments_experiments } from "../../types/getAllExperiments";
 
-export interface ExperimentCollector {
-  draft: getAllExperiments_experiments[];
-  review: getAllExperiments_experiments[];
-  live: getAllExperiments_experiments[];
-  complete: getAllExperiments_experiments[];
-}
+export type ExperimentCollector = Record<
+  "draft" | "review" | "live" | "complete",
+  getAllExperiments_experiments[]
+>;
 
 function sortByStatus(experiments: getAllExperiments_experiments[] = []) {
   return experiments.reduce<ExperimentCollector>(
@@ -20,7 +18,7 @@ function sortByStatus(experiments: getAllExperiments_experiments[] = []) {
         collector.live.push(experiment);
       } else if (status.complete) {
         collector.complete.push(experiment);
-      } else if (status.review) {
+      } else if (status.review || status.accepted) {
         collector.review.push(experiment);
       } else {
         collector.draft.push(experiment);

--- a/app/experimenter/nimbus-ui/src/components/PageHome/sortByStatus.ts
+++ b/app/experimenter/nimbus-ui/src/components/PageHome/sortByStatus.ts
@@ -1,0 +1,39 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { getStatus } from "../../lib/experiment";
+import { getAllExperiments_experiments } from "../../types/getAllExperiments";
+
+export interface ExperimentCollector {
+  draft: getAllExperiments_experiments[];
+  review: getAllExperiments_experiments[];
+  live: getAllExperiments_experiments[];
+  complete: getAllExperiments_experiments[];
+}
+
+function sortByStatus(experiments: getAllExperiments_experiments[] = []) {
+  return experiments.reduce<ExperimentCollector>(
+    (collector, experiment) => {
+      const status = getStatus(experiment);
+      if (status.live) {
+        collector.live.push(experiment);
+      } else if (status.complete) {
+        collector.complete.push(experiment);
+      } else if (status.review) {
+        collector.review.push(experiment);
+      } else {
+        collector.draft.push(experiment);
+      }
+      return collector;
+    },
+    {
+      draft: [],
+      review: [],
+      live: [],
+      complete: [],
+    },
+  );
+}
+
+export default sortByStatus;

--- a/app/experimenter/nimbus-ui/src/components/SummaryTimeline/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/SummaryTimeline/index.tsx
@@ -8,14 +8,7 @@ import pluralize from "../../lib/pluralize";
 import { getExperiment_experimentBySlug } from "../../types/getExperiment";
 import { NotSet } from "../Summary";
 import { getStatus, StatusCheck } from "../../lib/experiment";
-
-const humanDate = (date: string): string => {
-  return new Date(date).toLocaleString("en-US", {
-    year: "numeric",
-    month: "short",
-    day: "numeric",
-  });
-};
+import { humanDate } from "../../lib/dateUtils";
 
 const SummaryTimeline = ({
   experiment,

--- a/app/experimenter/nimbus-ui/src/gql/experiments.ts
+++ b/app/experimenter/nimbus-ui/src/gql/experiments.ts
@@ -194,7 +194,7 @@ export const GET_EXPERIMENT_QUERY = gql`
 // TODO: Only the first 15 until we add pagination.
 export const GET_ALL_EXPERIMENTS = gql`
   query getAllExperiments {
-    experiments {
+    experiments(limit: 20) {
       name
       owner {
         username

--- a/app/experimenter/nimbus-ui/src/gql/experiments.ts
+++ b/app/experimenter/nimbus-ui/src/gql/experiments.ts
@@ -194,7 +194,7 @@ export const GET_EXPERIMENT_QUERY = gql`
 // TODO: Only the first 15 until we add pagination.
 export const GET_ALL_EXPERIMENTS = gql`
   query getAllExperiments {
-    experiments(limit: 20) {
+    experiments(limit: 50) {
       name
       owner {
         username

--- a/app/experimenter/nimbus-ui/src/gql/experiments.ts
+++ b/app/experimenter/nimbus-ui/src/gql/experiments.ts
@@ -190,3 +190,26 @@ export const GET_EXPERIMENT_QUERY = gql`
     }
   }
 `;
+
+// TODO: Only the first 15 until we add pagination.
+export const GET_ALL_EXPERIMENTS = gql`
+  query getAllExperiments {
+    experiments {
+      name
+      owner {
+        username
+      }
+      slug
+      startDate
+      proposedDuration
+      proposedEnrollment
+      endDate
+      status
+      monitoringDashboardUrl
+      featureConfig {
+        slug
+        name
+      }
+    }
+  }
+`;

--- a/app/experimenter/nimbus-ui/src/gql/experiments.ts
+++ b/app/experimenter/nimbus-ui/src/gql/experiments.ts
@@ -191,8 +191,8 @@ export const GET_EXPERIMENT_QUERY = gql`
   }
 `;
 
-// TODO: Only the first 15 until we add pagination.
-export const GET_ALL_EXPERIMENTS = gql`
+// TODO: Only the first 50 until we add pagination.
+export const GET_EXPERIMENTS_QUERY = gql`
   query getAllExperiments {
     experiments(limit: 50) {
       name

--- a/app/experimenter/nimbus-ui/src/lib/dateUtils.test.ts
+++ b/app/experimenter/nimbus-ui/src/lib/dateUtils.test.ts
@@ -1,0 +1,94 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import {
+  addDaysToDate,
+  getProposedEndDate,
+  getProposedEnrollmentRange,
+} from "./dateUtils";
+import { mockSingleDirectoryExperimentFactory as expFactory } from "./mocks";
+
+const FAKE_DATE = "Thu Dec 12 2020";
+
+describe("addDaysToDate", () => {
+  it("should add days to a date and return a date string", () => {
+    expect(addDaysToDate(FAKE_DATE, 2)).toEqual("Mon Dec 14 2020");
+  });
+});
+
+describe("addDaysToDate", () => {
+  it("should add days to a date and return a date string", () => {
+    expect(addDaysToDate(FAKE_DATE, 2)).toEqual("Mon Dec 14 2020");
+  });
+});
+
+describe("getProposedEndDate", () => {
+  it("should return null if no proposedDuration is set", () => {
+    const actual = getProposedEndDate(expFactory({ proposedDuration: null }));
+    expect(actual).toBeNull();
+  });
+  it("should render a proposed end date if startDate and proposedDuration are set", () => {
+    const actual = getProposedEndDate(
+      expFactory({
+        startDate: FAKE_DATE,
+        proposedDuration: 2,
+      }),
+    );
+    expect(actual).toBe("Dec 14");
+  });
+  it("should render a duration if no startDate is set", () => {
+    const actual = getProposedEndDate(
+      expFactory({
+        startDate: null,
+        proposedDuration: 4,
+      }),
+    );
+    expect(actual).toBe("4 days");
+  });
+  it("should render '1 day' (not plural) for duration = 1", () => {
+    const actual = getProposedEndDate(
+      expFactory({
+        startDate: null,
+        proposedDuration: 1,
+      }),
+    );
+    expect(actual).toBe("1 day");
+  });
+});
+
+describe("getProposedEnrollmentRange", () => {
+  it("should return null if no proposedEnrollment is set", () => {
+    const actual = getProposedEnrollmentRange(
+      expFactory({ proposedEnrollment: null }),
+    );
+    expect(actual).toBeNull();
+  });
+  it("should render a date range if startDate and proposedEnrollment are set", () => {
+    const actual = getProposedEnrollmentRange(
+      expFactory({
+        startDate: FAKE_DATE,
+        proposedEnrollment: 4,
+      }),
+    );
+    expect(actual).toBe("Dec 12 to Dec 16");
+  });
+  it("should render the enrollment duration if no startDate is set", () => {
+    const actual = getProposedEnrollmentRange(
+      expFactory({
+        startDate: null,
+        proposedEnrollment: 4,
+      }),
+    );
+    expect(actual).toBe("4 days");
+  });
+  it("should render '1 day' (not plural) for proposedEnrollment = 1", () => {
+    const actual = getProposedEnrollmentRange(
+      expFactory({
+        startDate: null,
+        proposedEnrollment: 1,
+      }),
+    );
+    expect(actual).toBe("1 day");
+  });
+});

--- a/app/experimenter/nimbus-ui/src/lib/dateUtils.ts
+++ b/app/experimenter/nimbus-ui/src/lib/dateUtils.ts
@@ -1,0 +1,61 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { getAllExperiments_experiments } from "../types/getAllExperiments";
+import { getExperiment_experimentBySlug } from "../types/getExperiment";
+import pluralize from "./pluralize";
+
+export function humanDate(date: string): string {
+  return new Date(date).toLocaleString("en-US", {
+    month: "short",
+    day: "numeric",
+  });
+}
+
+export function addDaysToDate(datestring: string, days: number): string {
+  const date = new Date(datestring);
+  date.setDate(date.getDate() + days);
+  return date.toDateString();
+}
+
+/**
+ *  Renders an end date based on proposedDuration (e.g. Dec 2),
+ *  or a number of days (e.g. "5 days") if startDate is not set.
+ */
+export function getProposedEndDate(
+  experiment?: getExperiment_experimentBySlug | getAllExperiments_experiments,
+): string | null {
+  if (!experiment?.proposedDuration) {
+    return null;
+  }
+  const { startDate, proposedDuration } = experiment;
+  if (startDate) {
+    return humanDate(addDaysToDate(startDate, proposedDuration));
+  } else {
+    return pluralize(proposedDuration, "day");
+  }
+}
+
+/**
+ *  Renders period of enrollment depend on what's available
+ *  If startDate is set, it will return a range of dates
+ *      e.g. Dec 2 - Dec 4
+ *  If startDate is not set, it will return a number of days
+ *      e.g. 2 days
+ */
+export function getProposedEnrollmentRange(
+  experiment?: getExperiment_experimentBySlug | getAllExperiments_experiments,
+): string | null {
+  if (!experiment?.proposedEnrollment) {
+    return null;
+  }
+  const { startDate, proposedEnrollment } = experiment;
+  if (startDate) {
+    return `${humanDate(startDate)} to ${humanDate(
+      addDaysToDate(startDate, proposedEnrollment),
+    )}`;
+  } else {
+    return pluralize(proposedEnrollment, "day");
+  }
+}

--- a/app/experimenter/nimbus-ui/src/lib/experiment.ts
+++ b/app/experimenter/nimbus-ui/src/lib/experiment.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { getExperiment_experimentBySlug } from "../types/getExperiment";
+import { getAllExperiments_experiments } from "../types/getAllExperiments";
 import { NimbusExperimentStatus } from "../types/globalTypes";
 
 export type StatusCheck = {
@@ -16,7 +17,7 @@ export type StatusCheck = {
 };
 
 export function getStatus(
-  experiment?: getExperiment_experimentBySlug,
+  experiment?: getExperiment_experimentBySlug | getAllExperiments_experiments,
 ): StatusCheck {
   const status = experiment?.status;
 

--- a/app/experimenter/nimbus-ui/src/lib/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/lib/mocks.tsx
@@ -16,7 +16,10 @@ import { MockLink, MockedResponse } from "@apollo/client/testing";
 import { equal } from "@wry/equality";
 import { DocumentNode, print } from "graphql";
 import { cacheConfig } from "../services/apollo";
-import { GET_ALL_EXPERIMENTS, GET_EXPERIMENT_QUERY } from "../gql/experiments";
+import {
+  GET_EXPERIMENTS_QUERY,
+  GET_EXPERIMENT_QUERY,
+} from "../gql/experiments";
 import {
   getExperiment,
   getExperiment_experimentBySlug,
@@ -410,7 +413,7 @@ const fiveDaysAgo = new Date();
 fiveDaysAgo.setDate(fiveDaysAgo.getDate() - 5);
 
 /** Creates a single mock experiment suitable for getAllExperiments queries.  */
-export function mockSingleDirectoryExperimentFactory(
+export function mockSingleDirectoryExperiment(
   overrides: Partial<getAllExperiments_experiments> = {},
 ): getAllExperiments_experiments {
   return {
@@ -437,7 +440,7 @@ export function mockSingleDirectoryExperimentFactory(
   };
 }
 
-export function mockDirectoryExperimentsFactory(
+export function mockDirectoryExperiments(
   overrides: Partial<getAllExperiments_experiments>[] = [
     {
       status: NimbusExperimentStatus.DRAFT,
@@ -471,17 +474,17 @@ export function mockDirectoryExperimentsFactory(
     },
   ],
 ): getAllExperiments_experiments[] {
-  return overrides.map(mockSingleDirectoryExperimentFactory);
+  return overrides.map(mockSingleDirectoryExperiment);
 }
 
 /** Creates a bunch of experiments for the Directory page  */
 export function mockDirectoryExperimentsQuery(
   overrides?: Partial<getAllExperiments_experiments>[],
 ): MockedResponse<getAllExperiments> {
-  const experiments = mockDirectoryExperimentsFactory(overrides);
+  const experiments = mockDirectoryExperiments(overrides);
   return {
     request: {
-      query: GET_ALL_EXPERIMENTS,
+      query: GET_EXPERIMENTS_QUERY,
     },
     result: {
       data: experiments.length ? { experiments } : null,

--- a/app/experimenter/nimbus-ui/src/types/getAllExperiments.ts
+++ b/app/experimenter/nimbus-ui/src/types/getAllExperiments.ts
@@ -1,0 +1,39 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+import { NimbusExperimentStatus } from "./globalTypes";
+
+// ====================================================
+// GraphQL query operation: getAllExperiments
+// ====================================================
+
+export interface getAllExperiments_experiments_owner {
+  __typename: "NimbusExperimentOwner";
+  username: string;
+}
+
+export interface getAllExperiments_experiments_featureConfig {
+  __typename: "NimbusFeatureConfigType";
+  slug: string;
+  name: string;
+}
+
+export interface getAllExperiments_experiments {
+  __typename: "NimbusExperimentType";
+  name: string;
+  owner: getAllExperiments_experiments_owner | null;
+  slug: string;
+  startDate: DateTime | null;
+  proposedDuration: number | null;
+  proposedEnrollment: number | null;
+  endDate: DateTime | null;
+  status: NimbusExperimentStatus | null;
+  monitoringDashboardUrl: string | null;
+  featureConfig: getAllExperiments_experiments_featureConfig | null;
+}
+
+export interface getAllExperiments {
+  experiments: (getAllExperiments_experiments | null)[] | null;
+}


### PR DESCRIPTION
This would really help be able to find experiments without Django Admin. How would we feel about something like this before I add tests etc. (also, am I doing this right? )