### PR TITLE
issue #4154: progress on reworking branches form validation and submission

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/FormBranches/reducer/index.ts
+++ b/app/experimenter/nimbus-ui/src/components/FormBranches/reducer/index.ts
@@ -21,7 +21,8 @@ export function useFormBranchesReducer(
   );
   return [
     formBranchesState,
-    () => extractUpdateState(formBranchesState),
+    (formValues: Parameters<typeof extractUpdateState>[1]) =>
+      extractUpdateState(formBranchesState, formValues),
     dispatch,
   ] as const;
 }

--- a/app/experimenter/nimbus-ui/src/components/FormBranches/reducer/state.ts
+++ b/app/experimenter/nimbus-ui/src/components/FormBranches/reducer/state.ts
@@ -6,6 +6,7 @@ import {
   getExperiment_experimentBySlug,
   getExperiment_experimentBySlug_treatmentBranches,
 } from "../../../types/getExperiment";
+import { TreatmentBranchType } from "../../../types/globalTypes";
 
 export type FormBranchesState = Pick<
   getExperiment_experimentBySlug,
@@ -18,7 +19,7 @@ export type FormBranchesState = Pick<
   globalErrors: string[];
 };
 
-export type AnnotatedBranch = getExperiment_experimentBySlug_treatmentBranches & {
+export type AnnotatedBranch = TreatmentBranchType & {
   key: string;
   isValid: boolean;
   isDirty: boolean;
@@ -77,13 +78,13 @@ export function createAnnotatedBranch(
   name: string,
 ): AnnotatedBranch {
   return {
-    __typename: "NimbusBranchType" as const,
+    //__typename: "NimbusBranchType" as const,
     key: `branch-${lastId}`,
     errors: {},
     isValid: false,
     isDirty: false,
     name,
-    slug: "",
+    //slug: "",
     description: "",
     ratio: 1,
     featureValue: null,

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/index.stories.tsx
@@ -9,8 +9,21 @@ import { withLinks } from "@storybook/addon-links";
 import { withQuery } from "@storybook/addon-queryparams";
 import { mockExperimentQuery } from "../../lib/mocks";
 import PageEditBranches from ".";
+import { NimbusFeatureConfigApplication } from "../../types/globalTypes";
 
-const { mock } = mockExperimentQuery("demo-slug");
+const { mock } = mockExperimentQuery("demo-slug", {
+  featureConfig: {
+    __typename: "NimbusFeatureConfigType",
+    id: "2",
+    name: "Mauris odio erat",
+    slug: "mauris-odio-erat",
+    description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+    application: NimbusFeatureConfigApplication.FENIX,
+    ownerEmail: "dude23@yahoo.com",
+    schema: '{ "sample": "schema" }',
+  },
+});
+
 const { mock: mockMissingFields } = mockExperimentQuery("demo-slug", {
   referenceBranch: {
     __typename: "NimbusBranchType",


### PR DESCRIPTION
Opening as a draft in case anyone wants to see what I've got so far. Still need to tighten a few bolts and update tests.

Main change here is to stop updating the Branch page reducer on every form field change. Instead, the relationship is flipped so that the forms manage themselves up until the submit button is clicked, at which point the parent component walks through to force validation and gather the form data. This allows a forced validation with feedback on submission, as well as reducing a bunch of glitchiness while typing