### PR TITLE
fixes #3758 #3757 feat(nimbus): redirect pages based on status, review, and analysis

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/PageDesign/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageDesign/index.tsx
@@ -12,6 +12,11 @@ const PageDesign: React.FunctionComponent<RouteComponentProps> = () => {
       title="Design"
       testId="PageDesign"
       analysisRequired
+      redirect={({ status }) => {
+        if (!status?.locked) {
+          return "edit/overview";
+        }
+      }}
     >
       {({ experiment }) => <p>{experiment.name}</p>}
     </AppLayoutWithExperiment>

--- a/app/experimenter/nimbus-ui/src/components/PageEditAudience/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditAudience/index.tsx
@@ -12,6 +12,7 @@ import { UPDATE_EXPERIMENT_AUDIENCE_MUTATION } from "../../gql/experiments";
 import { SUBMIT_ERROR } from "../../lib/constants";
 import { getExperiment_experimentBySlug } from "../../types/getExperiment";
 import FormAudience from "../FormAudience";
+import { editCommonRedirects } from "../../lib/experiment";
 
 const PageEditAudience: React.FunctionComponent<RouteComponentProps> = () => {
   const [updateExperimentAudience, { loading }] = useMutation<
@@ -76,7 +77,11 @@ const PageEditAudience: React.FunctionComponent<RouteComponentProps> = () => {
   }, []);
 
   return (
-    <AppLayoutWithExperiment title="Audience" testId="PageEditAudience">
+    <AppLayoutWithExperiment
+      title="Audience"
+      testId="PageEditAudience"
+      redirect={editCommonRedirects}
+    >
       {({ experiment, review }) => {
         currentExperiment.current = experiment;
         refetchReview.current = review.refetch;

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/index.test.tsx
@@ -11,32 +11,75 @@ import {
   act,
 } from "@testing-library/react";
 import { navigate } from "@reach/router";
+import fetchMock from "jest-fetch-mock";
 import PageEditBranches, { SUBMIT_ERROR_MESSAGE } from ".";
 import FormBranches from "../FormBranches";
 import { RouterSlugProvider } from "../../lib/test-utils";
 import { mockExperimentQuery, MOCK_CONFIG } from "../../lib/mocks";
 import { UPDATE_EXPERIMENT_BRANCHES_MUTATION } from "../../gql/experiments";
-import {
-  updateExperimentBranches_updateExperimentBranches,
-  updateExperimentBranches_updateExperimentBranches_nimbusExperiment,
-} from "../../types/updateExperimentBranches";
-import {
-  FormBranchesSaveState,
-  extractUpdateBranch,
-} from "../FormBranches/reducer/update";
+import { BASE_PATH } from "../../lib/constants";
 import { getExperiment_experimentBySlug } from "../../types/getExperiment";
 import {
+  NimbusExperimentStatus,
   NimbusFeatureConfigApplication,
   UpdateExperimentBranchesInput,
 } from "../../types/globalTypes";
+import {
+  updateExperimentBranches_updateExperimentBranches_nimbusExperiment,
+  updateExperimentBranches_updateExperimentBranches,
+} from "../../types/updateExperimentBranches";
+import { FormBranchesSaveState } from "../FormBranches/reducer";
+import { extractUpdateBranch } from "../FormBranches/reducer/update";
 
 describe("PageEditBranches", () => {
+  beforeAll(() => {
+    fetchMock.enableMocks();
+  });
+
+  afterAll(() => {
+    fetchMock.disableMocks();
+  });
+
   beforeEach(() => {
     mockSetSubmitErrors.mockClear();
     mockClearSubmitErrors.mockClear();
   });
 
-  afterEach(() => {});
+  it("redirects to the review page if the experiment status is review", async () => {
+    const { mock, experiment } = mockExperimentQuery("demo-slug", {
+      status: NimbusExperimentStatus.REVIEW,
+    });
+    render(<Subject mocks={[mock]} />);
+    await waitFor(() => {
+      expect(navigate).toHaveBeenCalledWith(
+        `${BASE_PATH}/${experiment.slug}/request-review`,
+      );
+    });
+  });
+
+  it("redirects to the design page if the experiment status is live", async () => {
+    const { mock, experiment } = mockExperimentQuery("demo-slug", {
+      status: NimbusExperimentStatus.LIVE,
+    });
+    render(<Subject mocks={[mock]} />);
+    await waitFor(() => {
+      expect(navigate).toHaveBeenCalledWith(
+        `${BASE_PATH}/${experiment.slug}/design`,
+      );
+    });
+  });
+
+  it("redirects to the design page if the experiment status is complete", async () => {
+    const { mock, experiment } = mockExperimentQuery("demo-slug", {
+      status: NimbusExperimentStatus.COMPLETE,
+    });
+    render(<Subject mocks={[mock]} />);
+    await waitFor(() => {
+      expect(navigate).toHaveBeenCalledWith(
+        `${BASE_PATH}/${experiment.slug}/design`,
+      );
+    });
+  });
 
   it("renders as expected with experiment data", async () => {
     const { mock } = mockExperimentQuery("demo-slug");

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/index.tsx
@@ -14,6 +14,7 @@ import { UPDATE_EXPERIMENT_BRANCHES_MUTATION } from "../../gql/experiments";
 import { UpdateExperimentBranchesInput } from "../../types/globalTypes";
 import { updateExperimentBranches_updateExperimentBranches as UpdateExperimentBranchesResult } from "../../types/updateExperimentBranches";
 import { getExperiment_experimentBySlug } from "../../types/getExperiment";
+import { editCommonRedirects } from "../../lib/experiment";
 
 // TODO: EXP-656 find this doco URL
 const BRANCHES_DOC_URL =
@@ -79,7 +80,11 @@ const PageEditBranches: React.FunctionComponent<RouteComponentProps> = () => {
   }, []);
 
   return (
-    <AppLayoutWithExperiment title="Branches" testId="PageEditBranches">
+    <AppLayoutWithExperiment
+      title="Branches"
+      testId="PageEditBranches"
+      redirect={editCommonRedirects}
+    >
       {({ experiment, review }) => {
         currentExperiment.current = experiment;
         refetchReview.current = review.refetch;

--- a/app/experimenter/nimbus-ui/src/components/PageEditMetrics/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditMetrics/index.test.tsx
@@ -10,6 +10,7 @@ import {
   fireEvent,
   act,
 } from "@testing-library/react";
+import fetchMock from "jest-fetch-mock";
 import PageEditMetrics from ".";
 import FormMetrics from "../FormMetrics";
 import { RouterSlugProvider } from "../../lib/test-utils";
@@ -17,7 +18,8 @@ import { mockExperimentMutation, mockExperimentQuery } from "../../lib/mocks";
 import { MockedResponse } from "@apollo/client/testing";
 import { navigate } from "@reach/router";
 import { UPDATE_EXPERIMENT_PROBESETS_MUTATION } from "../../gql/experiments";
-import { SUBMIT_ERROR } from "../../lib/constants";
+import { BASE_PATH, SUBMIT_ERROR } from "../../lib/constants";
+import { NimbusExperimentStatus } from "../../types/globalTypes";
 
 const { mock, experiment } = mockExperimentQuery("demo-slug");
 
@@ -30,6 +32,14 @@ let mockSubmitData: Record<string, number | number[]> = {};
 const mockSubmit = jest.fn();
 
 describe("PageEditMetrics", () => {
+  beforeAll(() => {
+    fetchMock.enableMocks();
+  });
+
+  afterAll(() => {
+    fetchMock.disableMocks();
+  });
+
   let mutationMock: any;
 
   const Subject = ({
@@ -81,6 +91,42 @@ describe("PageEditMetrics", () => {
     await waitFor(() => {
       expect(screen.getByTestId("PageEditMetrics")).toBeInTheDocument();
       expect(screen.getByTestId("header-experiment")).toBeInTheDocument();
+    });
+  });
+
+  it("redirects to the review page if the experiment status is review", async () => {
+    const { mock, experiment } = mockExperimentQuery("demo-slug", {
+      status: NimbusExperimentStatus.REVIEW,
+    });
+    render(<Subject mocks={[mock]} />);
+    await waitFor(() => {
+      expect(navigate).toHaveBeenCalledWith(
+        `${BASE_PATH}/${experiment.slug}/request-review`,
+      );
+    });
+  });
+
+  it("redirects to the design page if the experiment status is live", async () => {
+    const { mock, experiment } = mockExperimentQuery("demo-slug", {
+      status: NimbusExperimentStatus.LIVE,
+    });
+    render(<Subject mocks={[mock]} />);
+    await waitFor(() => {
+      expect(navigate).toHaveBeenCalledWith(
+        `${BASE_PATH}/${experiment.slug}/design`,
+      );
+    });
+  });
+
+  it("redirects to the design page if the experiment status is complete", async () => {
+    const { mock, experiment } = mockExperimentQuery("demo-slug", {
+      status: NimbusExperimentStatus.COMPLETE,
+    });
+    render(<Subject mocks={[mock]} />);
+    await waitFor(() => {
+      expect(navigate).toHaveBeenCalledWith(
+        `${BASE_PATH}/${experiment.slug}/design`,
+      );
     });
   });
 

--- a/app/experimenter/nimbus-ui/src/components/PageEditMetrics/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditMetrics/index.tsx
@@ -15,6 +15,7 @@ import { useConfig } from "../../hooks/useConfig";
 import AppLayoutWithExperiment from "../AppLayoutWithExperiment";
 import FormMetrics from "../FormMetrics";
 import LinkExternal from "../LinkExternal";
+import { editCommonRedirects } from "../../lib/experiment";
 
 const PageEditMetrics: React.FunctionComponent<RouteComponentProps> = () => {
   const { probeSets } = useConfig();
@@ -73,7 +74,11 @@ const PageEditMetrics: React.FunctionComponent<RouteComponentProps> = () => {
   }, []);
 
   return (
-    <AppLayoutWithExperiment title="Metrics" testId="PageEditMetrics">
+    <AppLayoutWithExperiment
+      title="Metrics"
+      testId="PageEditMetrics"
+      redirect={editCommonRedirects}
+    >
       {({ experiment, review }) => {
         currentExperiment.current = experiment;
         refetchReview.current = review.refetch;

--- a/app/experimenter/nimbus-ui/src/components/PageEditOverview/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditOverview/index.tsx
@@ -12,6 +12,7 @@ import { SUBMIT_ERROR } from "../../lib/constants";
 import { UpdateExperimentInput } from "../../types/globalTypes";
 import { updateExperimentOverview_updateExperimentOverview as UpdateExperimentOverviewResult } from "../../types/updateExperimentOverview";
 import { getExperiment_experimentBySlug } from "../../types/getExperiment";
+import { editCommonRedirects } from "../../lib/experiment";
 
 type PageEditOverviewProps = {} & RouteComponentProps;
 
@@ -67,7 +68,11 @@ const PageEditOverview: React.FunctionComponent<PageEditOverviewProps> = () => {
   }, []);
 
   return (
-    <AppLayoutWithExperiment title="Overview" testId="PageEditOverview">
+    <AppLayoutWithExperiment
+      title="Overview"
+      testId="PageEditOverview"
+      redirect={editCommonRedirects}
+    >
       {({ experiment, review }) => {
         currentExperiment.current = experiment;
         refetchReview.current = review.refetch;

--- a/app/experimenter/nimbus-ui/src/components/PageRequestReview/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageRequestReview/index.tsx
@@ -66,6 +66,17 @@ const PageRequestReview: React.FunctionComponent<PageRequestReviewProps> = ({
       title="Review &amp; Launch"
       testId="PageRequestReview"
       {...{ polling }}
+      redirect={({ status, review }) => {
+        if (review && status.draft && !review.ready) {
+          // If the experiment is not ready to be reviewed, let's send them to
+          // the first page we know needs fixing up, with field errors displayed
+          return `edit/${review.invalidPages[0] || "overview"}?show-errors`;
+        }
+
+        if (status.released) {
+          return "design";
+        }
+      }}
     >
       {({ experiment }) => {
         currentExperiment.current = experiment;
@@ -74,14 +85,6 @@ const PageRequestReview: React.FunctionComponent<PageRequestReviewProps> = ({
         return (
           <>
             <Summary {...{ experiment }} />
-
-            {status.locked && (
-              <p className="my-5" data-testid="cant-review-label">
-                This experiment&apos;s status is{" "}
-                <b className="text-lowercase">{experiment.status}</b> and cannot
-                be reviewed.
-              </p>
-            )}
 
             {(submitSuccess || status.review) && (
               <p className="my-5" data-testid="in-review-label">

--- a/app/experimenter/nimbus-ui/src/components/PageResults/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/index.test.tsx
@@ -4,12 +4,21 @@
 
 import React from "react";
 import { screen, render, waitFor } from "@testing-library/react";
+import fetchMock from "jest-fetch-mock";
 import PageResults from ".";
 import { RouterSlugProvider } from "../../lib/test-utils";
-import { mockExperimentQuery, MOCK_REVIEW } from "../../lib/mocks";
+import { mockExperimentQuery } from "../../lib/mocks";
 import { mockAnalysis } from "../../lib/visualization/mocks";
 import AppLayoutWithExperiment from "../AppLayoutWithExperiment";
 import { AnalysisData } from "../../lib/visualization/types";
+import { getStatus as mockGetStatus } from "../../lib/experiment";
+import { NimbusExperimentStatus } from "../../types/globalTypes";
+import { getExperiment_experimentBySlug } from "../../types/getExperiment";
+
+jest.mock("@reach/router", () => ({
+  ...jest.requireActual("@reach/router"),
+  navigate: jest.fn(),
+}));
 
 const Subject = () => (
   <RouterSlugProvider>
@@ -17,10 +26,21 @@ const Subject = () => (
   </RouterSlugProvider>
 );
 
-let mockAnalysisData: AnalysisData | undefined = mockAnalysis();
+let mockExperiment: getExperiment_experimentBySlug;
+let mockAnalysisData: AnalysisData | undefined;
+let redirectPath: string | void;
 
 describe("PageResults", () => {
+  beforeAll(() => {
+    fetchMock.enableMocks();
+  });
+
+  afterAll(() => {
+    fetchMock.disableMocks();
+  });
+
   it("renders as expected", async () => {
+    mockExperiment = mockExperimentQuery("demo-slug").experiment;
     render(<Subject />);
     await waitFor(() => {
       expect(screen.queryByTestId("PageResults")).toBeInTheDocument();
@@ -28,6 +48,8 @@ describe("PageResults", () => {
   });
 
   it("fetches analysis data and displays expected tables when analysis is ready", async () => {
+    mockExperiment = mockExperimentQuery("demo-slug").experiment;
+    mockAnalysisData = mockAnalysis();
     render(<Subject />);
 
     await waitFor(() => {
@@ -46,6 +68,7 @@ describe("PageResults", () => {
   });
 
   it("displays the monitoring dashboard link", async () => {
+    mockExperiment = mockExperimentQuery("demo-slug").experiment;
     render(<Subject />);
 
     await waitFor(() => {
@@ -57,7 +80,7 @@ describe("PageResults", () => {
   });
 
   it("fetches analysis data and displays as expected when analysis is not ready", async () => {
-    mockAnalysisData!.show_analysis = false;
+    mockAnalysisData = mockAnalysis({ show_analysis: false });
 
     render(<Subject />);
 
@@ -78,20 +101,56 @@ describe("PageResults", () => {
     });
     expect(screen.queryByTestId("analysis-error")).toBeInTheDocument();
   });
+
+  it("redirects to the edit overview page if the experiment status is draft", async () => {
+    mockExperiment = mockExperimentQuery("demo-slug", {
+      status: NimbusExperimentStatus.DRAFT,
+    }).experiment;
+    render(<Subject />);
+    expect(redirectPath).toEqual("edit/overview");
+  });
+
+  it("redirects to the edit overview page if the experiment status is review", async () => {
+    mockExperiment = mockExperimentQuery("demo-slug", {
+      status: NimbusExperimentStatus.REVIEW,
+    }).experiment;
+    render(<Subject />);
+    expect(redirectPath).toEqual("edit/overview");
+  });
+
+  it("redirects to the design page if the analysis results are not ready", async () => {
+    mockAnalysisData = mockAnalysis({ show_analysis: false });
+    mockExperiment = mockExperimentQuery("demo-slug", {
+      status: NimbusExperimentStatus.COMPLETE,
+    }).experiment;
+    render(<Subject />);
+    expect(redirectPath).toEqual("design");
+  });
 });
 
 // Mocking form component because validation is exercised in its own tests.
 jest.mock("../AppLayoutWithExperiment", () => ({
   __esModule: true,
-  default: (props: React.ComponentProps<typeof AppLayoutWithExperiment>) => (
-    <div data-testid="PageResults">
-      {props.children({
-        experiment: mockExperimentQuery("demo-slug").experiment,
-        analysis: mockAnalysisData,
-        review: {
-          ...MOCK_REVIEW,
-        },
-      })}
-    </div>
-  ),
+  default: (props: React.ComponentProps<typeof AppLayoutWithExperiment>) => {
+    const experiment = mockExperiment;
+    const analysis = mockAnalysisData;
+
+    redirectPath = props.redirect!({
+      status: mockGetStatus(experiment),
+      analysis: mockAnalysisData,
+    });
+
+    return (
+      <div data-testid="PageResults">
+        {props.children({
+          experiment,
+          analysis,
+          review: {
+            isMissingField: () => false,
+            refetch: () => {},
+          },
+        })}
+      </div>
+    );
+  },
 }));

--- a/app/experimenter/nimbus-ui/src/components/PageResults/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/index.tsx
@@ -22,6 +22,15 @@ const PageResults: React.FunctionComponent<RouteComponentProps> = () => (
     title="Analysis"
     testId="PageResults"
     analysisRequired
+    redirect={({ status, analysis }) => {
+      if (!status?.released) {
+        return "edit/overview";
+      }
+
+      if (analysis?.show_analysis === false) {
+        return "design";
+      }
+    }}
   >
     {({ experiment, analysis }) => (
       <>

--- a/app/experimenter/nimbus-ui/src/lib/experiment.ts
+++ b/app/experimenter/nimbus-ui/src/lib/experiment.ts
@@ -38,3 +38,13 @@ export function getStatus(
     released,
   };
 }
+
+export function editCommonRedirects({ status }: { status: StatusCheck }) {
+  if (status.review) {
+    return "request-review";
+  }
+
+  if (status.locked) {
+    return "design";
+  }
+}


### PR DESCRIPTION
Closes #3758
Closes #3757

This PR:

- Adds a new `redirect` function prop to `AppLayoutWithExperiment` where you can inspect the status, review state, and analysis data of an experiment to determine if the user should be redirected away from the page
- Updates all the page components that render `AppLayoutWithExperiment` to perform their own checks to enforce these redirects.