### PR TITLE
fixes #3971 feat(nimbus): promote Nimbus UI to /nimbus, removing /experiments from path

### DIFF
--- a/app/experimenter/experiments/models/nimbus.py
+++ b/app/experimenter/experiments/models/nimbus.py
@@ -97,7 +97,7 @@ class NimbusExperiment(NimbusConstants, models.Model):
         return self.name
 
     def get_absolute_url(self):
-        return reverse("experiments-nimbus", kwargs={"slug": self.slug})
+        return reverse("nimbus-detail", kwargs={"slug": self.slug})
 
     @property
     def experiment_url(self):

--- a/app/experimenter/experiments/tests/test_views.py
+++ b/app/experimenter/experiments/tests/test_views.py
@@ -774,11 +774,11 @@ class TestExperimentNormandyUpdateView(TestCase):
         )
 
 
-class TestExperimentNimbusUIView(TestCase):
+class TestNimbusUIView(TestCase):
     def test_page_loads(self):
         user_email = "user@example.com"
         response = self.client.get(
-            reverse("experiments-nimbus"),
+            reverse("nimbus-list"),
             **{settings.OPENIDC_EMAIL_HEADER: user_email},
         )
         self.assertEqual(response.status_code, 200)

--- a/app/experimenter/experiments/urls.py
+++ b/app/experimenter/experiments/urls.py
@@ -6,7 +6,6 @@ from experimenter.experiments.views import (
     ExperimentCreateView,
     ExperimentDesignUpdateView,
     ExperimentDetailView,
-    ExperimentNimbusUIView,
     ExperimentNormandyUpdateView,
     ExperimentObjectivesUpdateView,
     ExperimentOverviewUpdateView,
@@ -19,12 +18,6 @@ from experimenter.experiments.views import (
 )
 
 urlpatterns = [
-    re_path(r"^nimbus/", ExperimentNimbusUIView.as_view(), name="experiments-nimbus"),
-    re_path(
-        r"^nimbus/(?P<slug>[\w-]+)/",
-        ExperimentNimbusUIView.as_view(),
-        name="experiments-nimbus",
-    ),
     re_path(r"^new/$", ExperimentCreateView.as_view(), name="experiments-create"),
     re_path(
         r"^(?P<slug>[\w-]+)/edit/$",

--- a/app/experimenter/experiments/views.py
+++ b/app/experimenter/experiments/views.py
@@ -228,5 +228,5 @@ class ExperimentCommentCreateView(ExperimentFormMixin, CreateView):
         )
 
 
-class ExperimentNimbusUIView(TemplateView):
+class NimbusUIView(TemplateView):
     template_name = "nimbus/index.html"

--- a/app/experimenter/nimbus-ui/src/lib/constants.ts
+++ b/app/experimenter/nimbus-ui/src/lib/constants.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-export const BASE_PATH = "/experiments/nimbus";
+export const BASE_PATH = "/nimbus";
 
 export const UNKNOWN_ERROR =
   "Sorry, an error occurred but we don't know why. We're looking into it.";

--- a/app/experimenter/urls.py
+++ b/app/experimenter/urls.py
@@ -3,7 +3,7 @@ from django.conf.urls import include, re_path
 from django.conf.urls.static import static
 from django.contrib import admin
 
-from experimenter.experiments.views import ExperimentListView
+from experimenter.experiments.views import ExperimentListView, NimbusUIView
 
 urlpatterns = [
     re_path(r"^api/v1/experiments/", include("experimenter.experiments.api.v1.urls")),
@@ -13,6 +13,8 @@ urlpatterns = [
     re_path(r"^api/v6/", include("experimenter.experiments.api.v6.urls")),
     re_path(r"^admin/", admin.site.urls),
     re_path(r"^experiments/", include("experimenter.experiments.urls")),
+    re_path(r"^nimbus/", NimbusUIView.as_view(), name="nimbus-list"),
+    re_path(r"^nimbus/(?P<slug>[\w-]+)/", NimbusUIView.as_view(), name="nimbus-detail"),
     re_path(r"^$", ExperimentListView.as_view(), name="home"),
 ]
 


### PR DESCRIPTION
Close #3971

I think I did this correctly?

This PR moves the Nimbus UI app from `/experiments/nimbus` to `/nimbus`. I also updated the code to remove the concept that Nimbus is an "experiment" (although the view is still living in `/experiments/views.py`, how do we feel about that? Where would it live otherwise?).