### PR TITLE
fixes #4164: fix(visualization) show loader until data loads.

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/AppLayoutWithExperiment/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/AppLayoutWithExperiment/index.tsx
@@ -49,30 +49,22 @@ const AppLayoutWithExperiment = ({
   const {
     experiment,
     notFound,
-    loading: experimentLoading,
+    loading,
     startPolling,
     stopPolling,
     review,
   } = useExperiment(slug);
-  // We won't know if an analysis lookup is required until the initial experiment query
-  // is complete and we inspect its status. To prevent content from flashing on the screen
-  // between the experiment and analysis requests, assume we need to wait for analysis
-  // until we can prove otherwise.
   const [analysisFetched, setAnalysisFetched] = useState<boolean>(false);
   const status = getStatus(experiment);
 
-  const {
-    execute: fetchAnalysis,
-    result: analysis,
-    loading: analysisLoading,
-  } = useAnalysis();
+  const { execute: fetchAnalysis, result: analysis } = useAnalysis();
 
   useEffect(() => {
-    if (!analysisFetched && !experimentLoading && status.released) {
+    if (!analysisFetched && !loading && status.released) {
       fetchAnalysis([experiment?.slug]);
       setAnalysisFetched(true);
     }
-  }, [fetchAnalysis, experimentLoading, experiment, analysisFetched, status]);
+  }, [fetchAnalysis, loading, experiment, analysisFetched, status]);
 
   useEffect(() => {
     if (polling && experiment) {
@@ -83,7 +75,7 @@ const AppLayoutWithExperiment = ({
     };
   }, [startPolling, stopPolling, experiment, polling]);
 
-  if (experimentLoading || (analysisRequired && analysisLoading)) {
+  if (loading || (analysisRequired && !analysis)) {
     return <PageLoading />;
   }
 

--- a/app/experimenter/nimbus-ui/src/components/AppLayoutWithExperiment/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/AppLayoutWithExperiment/index.tsx
@@ -32,6 +32,7 @@ type AppLayoutWithExperimentProps = {
   title?: string;
   polling?: boolean;
   sidebar?: boolean;
+  analysisRequired?: boolean;
 } & RouteComponentProps;
 
 export const POLL_INTERVAL = 30000;
@@ -42,6 +43,7 @@ const AppLayoutWithExperiment = ({
   title,
   sidebar = true,
   polling = false,
+  analysisRequired = false,
 }: AppLayoutWithExperimentProps) => {
   const { slug } = useParams();
   const {
@@ -56,7 +58,6 @@ const AppLayoutWithExperiment = ({
   // is complete and we inspect its status. To prevent content from flashing on the screen
   // between the experiment and analysis requests, assume we need to wait for analysis
   // until we can prove otherwise.
-  const [analysisRequired, setAnalysisRequired] = useState<boolean>(true);
   const [analysisFetched, setAnalysisFetched] = useState<boolean>(false);
   const status = getStatus(experiment);
 
@@ -74,12 +75,6 @@ const AppLayoutWithExperiment = ({
   }, [fetchAnalysis, experimentLoading, experiment, analysisFetched, status]);
 
   useEffect(() => {
-    if (!experimentLoading && !analysisLoading) {
-      setAnalysisRequired(false);
-    }
-  }, [experimentLoading, analysisLoading]);
-
-  useEffect(() => {
     if (polling && experiment) {
       startPolling(POLL_INTERVAL);
     }
@@ -88,7 +83,7 @@ const AppLayoutWithExperiment = ({
     };
   }, [startPolling, stopPolling, experiment, polling]);
 
-  if (experimentLoading || analysisRequired) {
+  if (experimentLoading || (analysisRequired && analysisLoading)) {
     return <PageLoading />;
   }
 

--- a/app/experimenter/nimbus-ui/src/components/PageDesign/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageDesign/index.test.tsx
@@ -7,8 +7,12 @@ import { screen, render, waitFor } from "@testing-library/react";
 import PageDesign from ".";
 import { RouterSlugProvider } from "../../lib/test-utils";
 import { mockExperimentQuery } from "../../lib/mocks";
+import { mockAnalysis } from "../../lib/visualization/mocks";
+import { AnalysisData } from "../../lib/visualization/types";
+import AppLayoutWithExperiment from "../AppLayoutWithExperiment";
 
-const { mock } = mockExperimentQuery("demo-slug");
+const { mock, experiment: mockExperiment } = mockExperimentQuery("demo-slug");
+const mockAnalysisData: AnalysisData | undefined = mockAnalysis();
 
 describe("PageDesign", () => {
   it("renders as expected", async () => {
@@ -22,3 +26,20 @@ describe("PageDesign", () => {
     });
   });
 });
+
+// Mocking form component because validation is exercised in its own tests.
+jest.mock("../AppLayoutWithExperiment", () => ({
+  __esModule: true,
+  default: (props: React.ComponentProps<typeof AppLayoutWithExperiment>) => (
+    <div data-testid="PageDesign">
+      {props.children({
+        experiment: mockExperiment,
+        analysis: mockAnalysisData,
+        review: {
+          isMissingField: () => false,
+          refetch: () => {},
+        },
+      })}
+    </div>
+  ),
+}));

--- a/app/experimenter/nimbus-ui/src/components/PageDesign/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageDesign/index.tsx
@@ -8,7 +8,11 @@ import AppLayoutWithExperiment from "../AppLayoutWithExperiment";
 
 const PageDesign: React.FunctionComponent<RouteComponentProps> = () => {
   return (
-    <AppLayoutWithExperiment title="Design" testId="PageDesign">
+    <AppLayoutWithExperiment
+      title="Design"
+      testId="PageDesign"
+      analysisRequired
+    >
       {({ experiment }) => <p>{experiment.name}</p>}
     </AppLayoutWithExperiment>
   );

--- a/app/experimenter/nimbus-ui/src/components/PageResults/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/index.tsx
@@ -17,7 +17,11 @@ import { AnalysisData } from "../../lib/visualization/types";
 import Summary from "../Summary";
 
 const PageResults: React.FunctionComponent<RouteComponentProps> = () => (
-  <AppLayoutWithExperiment title="Analysis" testId="PageResults">
+  <AppLayoutWithExperiment
+    title="Analysis"
+    testId="PageResults"
+    analysisRequired
+  >
     {({ experiment, analysis }) => (
       <>
         <h3 className="h5 mb-3">Monitoring</h3>


### PR DESCRIPTION
Because
* We don't want content flashing then changing

This commit
* Waits for data to load before showing content

