### PR TITLE
fix #4148 feat(nimbus): add channel to v6 API

### DIFF
--- a/app/experimenter/docs/openapi-schema.json
+++ b/app/experimenter/docs/openapi-schema.json
@@ -2900,6 +2900,19 @@
             "type": "string",
             "nullable": true
           },
+          "channel": {
+            "enum": [
+              "beta",
+              "nightly",
+              "release",
+              "default",
+              "org.mozilla.firefox.beta",
+              "org.mozilla.fenix",
+              "org.mozilla.firefox"
+            ],
+            "type": "string",
+            "nullable": true
+          },
           "userFacingName": {
             "type": "string",
             "readOnly": true

--- a/app/experimenter/docs/swagger-ui.html
+++ b/app/experimenter/docs/swagger-ui.html
@@ -2912,6 +2912,19 @@
             "type": "string",
             "nullable": true
           },
+          "channel": {
+            "enum": [
+              "beta",
+              "nightly",
+              "release",
+              "default",
+              "org.mozilla.firefox.beta",
+              "org.mozilla.fenix",
+              "org.mozilla.firefox"
+            ],
+            "type": "string",
+            "nullable": true
+          },
           "userFacingName": {
             "type": "string",
             "readOnly": true

--- a/app/experimenter/experiments/api/v6/serializers.py
+++ b/app/experimenter/experiments/api/v6/serializers.py
@@ -75,6 +75,7 @@ class NimbusExperimentArgumentsSerializer(serializers.ModelSerializer):
             "slug",
             "id",
             "application",
+            "channel",
             "userFacingName",
             "userFacingDescription",
             "isEnrollmentPaused",

--- a/app/experimenter/experiments/tests/api/v6/test_serializers.py
+++ b/app/experimenter/experiments/tests/api/v6/test_serializers.py
@@ -38,6 +38,7 @@ class TestNimbusExperimentSerializer(TestCase):
                 experiment_data,
                 {
                     "application": experiment.application,
+                    "channel": experiment.channel,
                     "bucketConfig": {
                         "randomizationUnit": (
                             experiment.bucket_range.isolation_group.randomization_unit


### PR DESCRIPTION
Because

* Jetstream needs to know the experiment channel to filter telemetry correctly

This commit

* Adds channel to the V6 API