### PR TITLE
fix #4145 fix #4208 fix #4195 fix #4203: rework branch form validation

### DIFF
--- a/app/experimenter/nimbus-ui/package.json
+++ b/app/experimenter/nimbus-ui/package.json
@@ -45,7 +45,7 @@
     "react-bootstrap": "^1.3.0",
     "react-dom": "^16.13.1",
     "react-helmet": "^6.1.0",
-    "react-hook-form": "^6.9.2",
+    "react-hook-form": "^6.12.2",
     "react-scripts": "3.4.0",
     "react-select": "^3.1.1",
     "react-select-event": "^5.1.0",

--- a/app/experimenter/nimbus-ui/src/components/FormAudience/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/FormAudience/index.tsx
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React, { useCallback } from "react";
-import { useForm, ValidationRules, FieldError } from "react-hook-form";
+import { useForm, RegisterOptions, FieldError } from "react-hook-form";
 import Form from "react-bootstrap/Form";
 import Alert from "react-bootstrap/Alert";
 import InputGroup from "react-bootstrap/InputGroup";
@@ -99,13 +99,13 @@ export const FormAudience = ({
 
   const formControlCommon = <K extends DefaultValuesKey>(
     name: K,
-    validateRules: ValidationRules = {
+    registerOptions: RegisterOptions = {
       required: "This field may not be blank.",
     },
   ) => ({
     name,
     "data-testid": name,
-    ref: register(validateRules),
+    ref: register(registerOptions),
     defaultValue: defaultValues[name],
     ...fieldValidity(name),
   });

--- a/app/experimenter/nimbus-ui/src/components/FormBranches/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/FormBranches/index.stories.tsx
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from "react";
+import React, { useState } from "react";
 import { storiesOf } from "@storybook/react";
 import { action } from "@storybook/addon-actions";
 import { FormBranches } from ".";
@@ -16,7 +16,6 @@ import {
 } from "./mocks";
 
 const onRemove = action("onRemove");
-const onChange = action("onChange");
 const onAddFeatureConfig = action("onAddFeatureConfig");
 const onRemoveFeatureConfig = action("onRemoveFeatureConfig");
 const onFeatureConfigChange = action("onFeatureConfigChange");
@@ -25,7 +24,6 @@ const onNext = action("onNext");
 
 const commonFormBranchProps = {
   onRemove,
-  onChange,
   onAddFeatureConfig,
   onRemoveFeatureConfig,
   onFeatureConfigChange,
@@ -129,39 +127,56 @@ storiesOf("components/FormBranches", module)
       }}
     />
   ))
-  .add("with errors", () => {
+  .add("with submit errors", () => {
+    const [isLoading, setIsLoading] = useState(false);
+    const [saveOrClear, setSaveOrClear] = useState(false);
     const onSave: React.ComponentProps<typeof FormBranches>["onSave"] = (
       saveState,
       setSubmitErrors,
-      // clearSubmitErrors,
+      clearSubmitErrors,
     ) => {
-      // Kind of a random nonsensical assortment of errors, but want to
-      // exercise errors scattered between branches and fields.
-      setSubmitErrors({
-        "*": ["Solar flares prevent submission."],
-        feature_config: [
-          "Feature Config required when a branch has feature enabled.",
-        ],
-        reference_branch: {
-          name: ["This name stinks."],
-          description: ["Try harder to describe this branch."],
-          feature_value: ["ASCII art is not acceptable."],
-          ratio: ["You call that a number?"],
-        },
-        treatment_branches: [
-          {},
-          {
-            description: ["More errors."],
-            feature_value: ["Yeah, no."],
-            ratio: ["No roman numerals."],
-          },
-        ],
-      });
+      setIsLoading(true);
+      setTimeout(() => {
+        setIsLoading(false);
+        // Toggle between clearing and raising simulated errors with each submit.
+        setSaveOrClear(!saveOrClear);
+        if (saveOrClear) {
+          clearSubmitErrors();
+        } else {
+          // Kind of a random nonsensical assortment of errors, but want to
+          // exercise errors scattered between branches and fields.
+          setSubmitErrors({
+            "*": ["Solar flares prevent submission."],
+            feature_config: [
+              "Feature Config required when a branch has feature enabled.",
+            ],
+            reference_branch: {
+              name: ["This name stinks."],
+              description: ["Try harder to describe this branch."],
+              feature_value: ["ASCII art is not acceptable."],
+              ratio: ["You call that a number?"],
+            },
+            treatment_branches: [
+              {},
+              {
+                description: ["More errors."],
+                feature_value: ["Yeah, no."],
+                ratio: ["No roman numerals."],
+              },
+            ],
+          });
+        }
+      }, 500);
     };
 
     return (
       <SubjectBranches
-        {...{ ...commonFormBranchesProps, onSave, saveOnInitialRender: true }}
+        {...{
+          ...commonFormBranchesProps,
+          isLoading,
+          onSave,
+          saveOnInitialRender: true,
+        }}
         experiment={{
           ...MOCK_EXPERIMENT,
           featureConfig: MOCK_FEATURE_CONFIG_WITH_SCHEMA,

--- a/app/experimenter/nimbus-ui/src/components/FormBranches/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/components/FormBranches/mocks.tsx
@@ -3,44 +3,66 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React, { useEffect } from "react";
+import { useForm, FormProvider } from "react-hook-form";
 import FormBranches from ".";
 import FormBranch from "./FormBranch";
 import { mockExperimentQuery, MOCK_CONFIG } from "../../lib/mocks";
 import { AnnotatedBranch } from "./reducer";
 
+type FormBranchProps = React.ComponentProps<typeof FormBranch>;
+
 export const SubjectBranch = ({
-  id = "demo",
-  lastSubmitTime = Date.now(),
+  fieldNamePrefix = "referenceBranch",
   branch = MOCK_ANNOTATED_BRANCH,
   equalRatio = false,
   isReference = false,
   experimentFeatureConfig = MOCK_FEATURE_CONFIG,
   featureConfig = MOCK_CONFIG.featureConfig,
   onRemove = () => {},
-  onChange = () => {},
   onAddFeatureConfig = () => {},
   onRemoveFeatureConfig = () => {},
   onFeatureConfigChange = () => {},
-}: Partial<React.ComponentProps<typeof FormBranch>>) => (
-  <div className="p-5">
-    <FormBranch
-      {...{
-        id,
-        lastSubmitTime,
-        branch,
-        isReference,
-        equalRatio,
-        featureConfig,
-        experimentFeatureConfig,
-        onRemove,
-        onChange,
-        onAddFeatureConfig,
-        onRemoveFeatureConfig,
-        onFeatureConfigChange,
-      }}
-    />
-  </div>
-);
+}: Partial<React.ComponentProps<typeof FormBranch>>) => {
+  const defaultValues = {
+    referenceBranch: branch,
+    treatmentBranches: [branch],
+  };
+
+  const formMethods = useForm({
+    mode: "onBlur",
+    defaultValues,
+  });
+
+  const {
+    formState: { errors, touched },
+  } = formMethods;
+
+  return (
+    <FormProvider {...formMethods}>
+      <form className="p-5">
+        <FormBranch
+          {...{
+            fieldNamePrefix,
+            // react-hook-form types seem broken for nested fields
+            errors: (errors.referenceBranch || {}) as FormBranchProps["errors"],
+            // react-hook-form types seem broken for nested fields
+            touched: (touched.referenceBranch ||
+              {}) as FormBranchProps["touched"],
+            branch,
+            isReference,
+            equalRatio,
+            featureConfig,
+            experimentFeatureConfig,
+            onRemove,
+            onAddFeatureConfig,
+            onRemoveFeatureConfig,
+            onFeatureConfigChange,
+          }}
+        />
+      </form>
+    </FormProvider>
+  );
+};
 
 export const SubjectBranches = ({
   isLoading = false,

--- a/app/experimenter/nimbus-ui/src/components/FormBranches/reducer/index.ts
+++ b/app/experimenter/nimbus-ui/src/components/FormBranches/reducer/index.ts
@@ -21,7 +21,8 @@ export function useFormBranchesReducer(
   );
   return [
     formBranchesState,
-    () => extractUpdateState(formBranchesState),
+    (formValues: Parameters<typeof extractUpdateState>[1]) =>
+      extractUpdateState(formBranchesState, formValues),
     dispatch,
   ] as const;
 }

--- a/app/experimenter/nimbus-ui/src/components/FormBranches/reducer/state.ts
+++ b/app/experimenter/nimbus-ui/src/components/FormBranches/reducer/state.ts
@@ -6,6 +6,7 @@ import {
   getExperiment_experimentBySlug,
   getExperiment_experimentBySlug_treatmentBranches,
 } from "../../../types/getExperiment";
+import { TreatmentBranchType } from "../../../types/globalTypes";
 
 export type FormBranchesState = Pick<
   getExperiment_experimentBySlug,
@@ -18,7 +19,7 @@ export type FormBranchesState = Pick<
   globalErrors: string[];
 };
 
-export type AnnotatedBranch = getExperiment_experimentBySlug_treatmentBranches & {
+export type AnnotatedBranch = TreatmentBranchType & {
   key: string;
   isValid: boolean;
   isDirty: boolean;
@@ -77,16 +78,14 @@ export function createAnnotatedBranch(
   name: string,
 ): AnnotatedBranch {
   return {
-    __typename: "NimbusBranchType" as const,
     key: `branch-${lastId}`,
     errors: {},
     isValid: false,
     isDirty: false,
     name,
-    slug: "",
     description: "",
     ratio: 1,
     featureValue: null,
-    featureEnabled: true,
+    featureEnabled: false,
   };
 }

--- a/app/experimenter/nimbus-ui/src/components/FormOverview/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/FormOverview/index.tsx
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React, { useCallback, useEffect } from "react";
-import { useForm, ValidationRules } from "react-hook-form";
+import { useForm, RegisterOptions } from "react-hook-form";
 import Form from "react-bootstrap/Form";
 import Alert from "react-bootstrap/Alert";
 import { getExperiment } from "../../types/getExperiment";
@@ -71,14 +71,14 @@ const FormOverview = ({
 
   const nameValidated = (
     name: string,
-    validateRules: ValidationRules = {
+    registerOptions: RegisterOptions = {
       required: "This field may not be blank.",
     },
   ) => ({
     name,
     isInvalid: !!submitErrors[name] || (touched[name] && errors[name]),
     isValid: !submitErrors[name] && touched[name] && !errors[name],
-    ref: register(validateRules),
+    ref: register(registerOptions),
   });
 
   const FormErrors = ({ name }: { name: string }) => (

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/index.stories.tsx
@@ -9,8 +9,21 @@ import { withLinks } from "@storybook/addon-links";
 import { withQuery } from "@storybook/addon-queryparams";
 import { mockExperimentQuery } from "../../lib/mocks";
 import PageEditBranches from ".";
+import { NimbusFeatureConfigApplication } from "../../types/globalTypes";
 
-const { mock } = mockExperimentQuery("demo-slug");
+const { mock } = mockExperimentQuery("demo-slug", {
+  featureConfig: {
+    __typename: "NimbusFeatureConfigType",
+    id: "2",
+    name: "Mauris odio erat",
+    slug: "mauris-odio-erat",
+    description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+    application: NimbusFeatureConfigApplication.FENIX,
+    ownerEmail: "dude23@yahoo.com",
+    schema: '{ "sample": "schema" }',
+  },
+});
+
 const { mock: mockMissingFields } = mockExperimentQuery("demo-slug", {
   referenceBranch: {
     __typename: "NimbusBranchType",

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -15769,10 +15769,10 @@ react-helmet@^6.1.0:
     react-fast-compare "^3.1.1"
     react-side-effect "^2.1.0"
 
-react-hook-form@^6.9.2:
-  version "6.9.2"
-  resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-6.9.2.tgz#9512cd424e62235fda13c8fc1821f88c352e3d23"
-  integrity sha512-vCPEbHVCRvsoqrQARgQ7a3VrXzqbFOO53gHFRdQzLzHMT9kxum3wfcSi8A1b49KPRsomvsqexH4tBUJMneEu+Q==
+react-hook-form@^6.12.2:
+  version "6.12.2"
+  resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-6.12.2.tgz#aa67f47da4730a7bce44768583bdf5b749eed521"
+  integrity sha512-O72E2DXyk7djFqyy6eYi5yESGweKe0CNHHPS0Mx4JazpLbE4Ox+66ldZ23f0J5ZN/krEjDWRD+hUfg5Shvfhtw==
 
 react-hotkeys@2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Because:

- we want better user feedback and improved form validation on the
  branch management page

This commit:

- newly created branches no longer have `featureEnabled: true` by
  default (#4203)

- enables save button but raises validation errors and prevent
  submitting mutation when data is invalid

- moves to a single react-hook-form handler at the top FormBranches
  component level rather than multiple handers per individual FormBranch

- moves useFormBranchesReducer to mainly control form structure and
  leave react-hook-form to manage form fields and validation.

- no more onChange and updateBranch, branch data in reducer is only
  updated on submit or before structural changes

- upgrades react-hook-form to 6.12.2 to catch validation improvements,
  catches rename of type ValidationRules to RegisterOptions

- change some `await act` instances in tests to `await waitFor` for
  better assertion of results