### PR TITLE
fix #4325 feat(nimbus): Use channel for application for fenix experiments

### DIFF
--- a/app/experimenter/docs/openapi-schema.json
+++ b/app/experimenter/docs/openapi-schema.json
@@ -2893,12 +2893,8 @@
             "readOnly": true
           },
           "application": {
-            "enum": [
-              "firefox-desktop",
-              "fenix"
-            ],
             "type": "string",
-            "nullable": true
+            "readOnly": true
           },
           "channel": {
             "enum": [

--- a/app/experimenter/docs/swagger-ui.html
+++ b/app/experimenter/docs/swagger-ui.html
@@ -2905,12 +2905,8 @@
             "readOnly": true
           },
           "application": {
-            "enum": [
-              "firefox-desktop",
-              "fenix"
-            ],
             "type": "string",
-            "nullable": true
+            "readOnly": true
           },
           "channel": {
             "enum": [

--- a/app/experimenter/experiments/api/v6/serializers.py
+++ b/app/experimenter/experiments/api/v6/serializers.py
@@ -55,6 +55,7 @@ class NimbusBranchSerializer(serializers.ModelSerializer):
 class NimbusExperimentArgumentsSerializer(serializers.ModelSerializer):
     schemaVersion = serializers.ReadOnlyField(default=settings.NIMBUS_SCHEMA_VERSION)
     id = serializers.ReadOnlyField(source="slug")
+    application = serializers.SerializerMethodField()
     userFacingName = serializers.ReadOnlyField(source="name")
     userFacingDescription = serializers.ReadOnlyField(source="public_description")
     isEnrollmentPaused = serializers.ReadOnlyField(source="is_paused")
@@ -89,6 +90,11 @@ class NimbusExperimentArgumentsSerializer(serializers.ModelSerializer):
             "proposedEnrollment",
             "referenceBranch",
         )
+
+    def get_application(self, obj):
+        if obj.is_fenix_experiment:
+            return obj.channel
+        return obj.application
 
     def get_probeSets(self, obj):
         return list(obj.probe_sets.all().order_by("slug").values_list("slug", flat=True))

--- a/app/experimenter/experiments/models/nimbus.py
+++ b/app/experimenter/experiments/models/nimbus.py
@@ -102,6 +102,10 @@ class NimbusExperiment(NimbusConstants, models.Model):
         )
 
     @property
+    def is_fenix_experiment(self):
+        return self.application == self.Application.FENIX
+
+    @property
     def targeting_config(self):
         if self.targeting_config_slug:
             return self.TARGETING_CONFIGS[self.targeting_config_slug]

--- a/app/experimenter/experiments/tests/api/v6/test_serializers.py
+++ b/app/experimenter/experiments/tests/api/v6/test_serializers.py
@@ -87,6 +87,20 @@ class TestNimbusExperimentSerializer(TestCase):
 
         check_schema("experiments/NimbusExperiment", serializer.data)
 
+    def test_sets_application_channel_for_fenix_experiment(self):
+        experiment = NimbusExperimentFactory.create_with_status(
+            NimbusExperiment.Status.ACCEPTED,
+            application=NimbusExperiment.Application.FENIX,
+            channel=NimbusExperiment.Channel.FENIX_NIGHTLY,
+        )
+        serializer = NimbusExperimentSerializer(experiment)
+        self.assertEqual(
+            serializer.data["application"], NimbusExperiment.Channel.FENIX_NIGHTLY
+        )
+        self.assertEqual(
+            serializer.data["channel"], NimbusExperiment.Channel.FENIX_NIGHTLY
+        )
+
     def test_serializer_outputs_expected_schema_without_feature(self):
         experiment = NimbusExperimentFactory.create_with_status(
             NimbusExperiment.Status.ACCEPTED,


### PR DESCRIPTION
Because

* The fenix client expects to find the value for channel in the application field in the serialized DTO

This commit

* Sets application to the channel value for only Fenix experiments in the DTO