### PR TITLE
fixes #4165: fix(visualization) Add retention tooltip.

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/TableVisualizationRow/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/TableVisualizationRow/index.tsx
@@ -10,7 +10,10 @@ import {
   VARIANT_TYPE,
   DISPLAY_TYPE,
 } from "../../lib/visualization/constants";
-import { SIGNIFICANCE_TIPS } from "../../lib/visualization/constants";
+import {
+  SIGNIFICANCE_TIPS,
+  GENERAL_TIPS,
+} from "../../lib/visualization/constants";
 import { BranchDescription } from "../../lib/visualization/types";
 import { ReactComponent as SignificanceNegative } from "./significance-negative.svg";
 import { ReactComponent as SignificancePositive } from "./significance-positive.svg";
@@ -168,9 +171,11 @@ const TableVisualizationRow: React.FC<{
   const metricData = branch_data[metricKey];
 
   let field = <>{metricName} is not available</>;
+  let tooltipText =
+    metricKey === METRIC.RETENTION ? GENERAL_TIPS.MISSING_RETENTION : "";
   let className = "text-danger";
   if (metricData) {
-    className = "";
+    className = tooltipText = "";
     const percent = branch_data[METRIC.USER_COUNT]["percent"];
     const userCountMetric =
       branch_data[METRIC.USER_COUNT][BRANCH_COMPARISON.ABSOLUTE]["point"];
@@ -208,11 +213,15 @@ const TableVisualizationRow: React.FC<{
   }
 
   return tableLabel === TABLE_LABEL.HIGHLIGHTS ? (
-    <div key={metricKey} {...{ className }}>
+    <div key={metricKey} {...{ className }} data-tip={tooltipText}>
       {field}
     </div>
   ) : (
-    <td key={metricKey} className={`align-middle ${className}`}>
+    <td
+      key={metricKey}
+      className={`align-middle ${className}`}
+      data-tip={tooltipText}
+    >
       <div>{field}</div>
     </td>
   );

--- a/app/experimenter/nimbus-ui/src/lib/visualization/constants.ts
+++ b/app/experimenter/nimbus-ui/src/lib/visualization/constants.ts
@@ -30,6 +30,11 @@ export const BADGE_TIPS = {
   GUARDRAIL_METRIC: "Metric that should not regress",
 };
 
+export const GENERAL_TIPS = {
+  MISSING_RETENTION:
+    "Retention is only available after at least 1 week of data post enrollment",
+};
+
 export enum VARIANT_TYPE {
   CONTROL,
   VARIANT,


### PR DESCRIPTION
Because
* We want users to understand why retention is missing

This commit
* Adds a tooltip for when retention is missing