### PR TITLE
fix #4253 chore(nimbus): intermittent test failure in v6 API

### DIFF
--- a/app/experimenter/experiments/tests/api/v6/test_serializers.py
+++ b/app/experimenter/experiments/tests/api/v6/test_serializers.py
@@ -22,6 +22,7 @@ class TestNimbusExperimentSerializer(TestCase):
         probe_set = NimbusProbeSetFactory.create()
         experiment = NimbusExperimentFactory.create_with_status(
             NimbusExperiment.Status.COMPLETE,
+            application=NimbusExperiment.Application.DESKTOP,
             firefox_min_version=NimbusExperiment.Version.FIREFOX_80,
             targeting_config_slug=NimbusExperiment.TargetingConfig.ALL_ENGLISH,
             channel=NimbusExperiment.Channel.DESKTOP_NIGHTLY,


### PR DESCRIPTION
Because

* We added conditional logic that changes the channel field for fenix experiments without updating the test to lock it to desktop

This commit

* Specifies the application as desktop to prevent the conditional behaviour