### PR TITLE
fix #4263 fix(nimbus): lookup isolation group by application

### DIFF
--- a/app/experimenter/experiments/models/nimbus.py
+++ b/app/experimenter/experiments/models/nimbus.py
@@ -232,12 +232,9 @@ class NimbusIsolationGroup(models.Model):
 
     @classmethod
     def request_isolation_group_buckets(cls, name, experiment, count):
-        if cls.objects.filter(name=name).exists():
-            isolation_group = (
-                cls.objects.filter(name=name, application=experiment.application)
-                .order_by("-instance")
-                .first()
-            )
+        query = cls.objects.filter(name=name, application=experiment.application)
+        if query.exists():
+            isolation_group = query.order_by("-instance").first()
         else:
             isolation_group = cls.objects.create(
                 name=name, application=experiment.application

--- a/app/experimenter/experiments/tests/test_models/test_models_nimbus.py
+++ b/app/experimenter/experiments/tests/test_models/test_models_nimbus.py
@@ -284,6 +284,29 @@ class TestNimbusIsolationGroup(TestCase):
             self.randomization_unit,
         )
 
+    def test_existing_isolation_group_with_matching_name_but_not_application_is_filtered(
+        self,
+    ):
+        """
+        Now that isolation groups are bound to applications, we have to check for the
+        case where isolation groups with the same name but different applications are
+        treated separately.
+        """
+        name = "isolation group name"
+        NimbusIsolationGroupFactory.create(
+            name=name, application=NimbusExperiment.Application.DESKTOP
+        )
+        experiment = NimbusExperimentFactory.create(
+            name=name, slug=name, application=NimbusExperiment.Application.FENIX
+        )
+        bucket = NimbusIsolationGroup.request_isolation_group_buckets(
+            name, experiment, 100
+        )
+        self.assertEqual(bucket.isolation_group.name, name)
+        self.assertEqual(
+            bucket.isolation_group.application, NimbusExperiment.Application.FENIX
+        )
+
 
 class TestNimbusChangeLog(TestCase):
     def test_uses_message_if_set(self):


### PR DESCRIPTION
Because

* We recently bound isolation groups to applications but neglected to look up the correct isolation group by application

This commit

* Queries existing isolation groups by name and application
* Adds a test