### PR TITLE
fixes ##4273 feat(nimbus): Add monitoring link to summary page

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/MonitoringLink/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/MonitoringLink/index.stories.tsx
@@ -1,0 +1,19 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from "react";
+import { storiesOf } from "@storybook/react";
+import MonitoringLink from "./index";
+
+storiesOf("Components/MonitoringLink", module)
+  .add("basic", () => (
+    <div className="m-3">
+      <MonitoringLink monitoringDashboardUrl="https://grafana.telemetry.mozilla.org" />
+    </div>
+  ))
+  .add("no link", () => (
+    <div className="m-3">
+      <MonitoringLink monitoringDashboardUrl="" />
+    </div>
+  ));

--- a/app/experimenter/nimbus-ui/src/components/MonitoringLink/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/MonitoringLink/index.tsx
@@ -1,0 +1,31 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from "react";
+import { getExperiment_experimentBySlug } from "../../types/getExperiment";
+import LinkExternal from "../LinkExternal";
+
+export const MonitoringLink: React.FC<Pick<
+  getExperiment_experimentBySlug,
+  "monitoringDashboardUrl"
+>> = ({ monitoringDashboardUrl }) => (
+  <>
+    <h3 className="h5 mb-3">Monitoring</h3>
+    {monitoringDashboardUrl ? (
+      <p>
+        <LinkExternal
+          href={monitoringDashboardUrl}
+          data-testid="link-monitoring-dashboard"
+        >
+          Click here
+        </LinkExternal>{" "}
+        to view the live monitoring dashboard.
+      </p>
+    ) : (
+      <p>No dashboard is available yet.</p>
+    )}
+  </>
+);
+
+export default MonitoringLink;

--- a/app/experimenter/nimbus-ui/src/components/PageResults/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/index.tsx
@@ -15,6 +15,7 @@ import TableMetricPrimary from "../TableMetricPrimary";
 import TableMetricSecondary from "../TableMetricSecondary";
 import { AnalysisData } from "../../lib/visualization/types";
 import Summary from "../Summary";
+import MonitoringLink from "../MonitoringLink";
 
 const PageResults: React.FunctionComponent<RouteComponentProps> = () => (
   <AppLayoutWithExperiment
@@ -24,16 +25,7 @@ const PageResults: React.FunctionComponent<RouteComponentProps> = () => (
   >
     {({ experiment, analysis }) => (
       <>
-        <h3 className="h5 mb-3">Monitoring</h3>
-        <p>
-          <LinkExternal
-            href={experiment.monitoringDashboardUrl!}
-            data-testid="link-monitoring-dashboard"
-          >
-            Click here
-          </LinkExternal>{" "}
-          to view the live monitoring dashboard.
-        </p>
+        <MonitoringLink {...experiment} />
         {analysis?.show_analysis ? (
           <AnalysisAvailable {...{ experiment, analysis }} />
         ) : (

--- a/app/experimenter/nimbus-ui/src/components/Summary/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/index.tsx
@@ -10,6 +10,7 @@ import TableSummary from "../TableSummary";
 import TableAudience from "../TableAudience";
 import LinkExternal from "../LinkExternal";
 import { getStatus } from "../../lib/experiment";
+import MonitoringLink from "../MonitoringLink";
 
 type SummaryProps = {
   experiment: getExperiment_experimentBySlug;
@@ -20,6 +21,7 @@ const Summary = ({ experiment }: SummaryProps) => {
 
   return (
     <div data-testid="summary">
+      <MonitoringLink {...experiment} />
       <h2 className="h5 mb-3">Timeline</h2>
       <SummaryTimeline {...{ experiment }} />
 


### PR DESCRIPTION
Because

* It's hard to find the Grafana link right now

This commit

* Add a <MonitoringLink> component to use in summary and results.