### PR TITLE
fixes #4021 refactor(nimbus): Add 'useCommonForm' w/error clear onChange, use in Overview, Metrics, + Audience forms

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/FormAudience/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/FormAudience/index.stories.tsx
@@ -10,7 +10,7 @@ import { Subject } from "./mocks";
 storiesOf("components/FormAudience", module)
   .add("basic", () => <Subject onSubmit={action("submit")} />)
   .add("loading", () => <Subject isLoading />)
-  .add("errors", () => (
+  .add("server/submit errors", () => (
     <Subject
       submitErrors={{
         "*": ["Big bad server thing happened"],

--- a/app/experimenter/nimbus-ui/src/components/FormAudience/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/components/FormAudience/mocks.tsx
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from "react";
+import React, { useState } from "react";
 import { mockExperimentQuery } from "../../lib/mocks";
 import { FormAudience } from ".";
 import { MOCK_CONFIG, MockedCache } from "../../lib/mocks";
@@ -14,25 +14,33 @@ export const Subject = ({
   submitErrors = {},
   isMissingField = () => false,
   isLoading = false,
+  isServerValid = true,
   onSubmit = () => {},
   onNext = () => {},
 }: {
   config?: getConfig_nimbusConfig;
-} & Partial<React.ComponentProps<typeof FormAudience>>) => (
-  <div className="p-5">
-    <MockedCache {...{ config }}>
-      <FormAudience
-        {...{
-          experiment,
-          submitErrors,
-          isMissingField,
-          isLoading,
-          onSubmit,
-          onNext,
-        }}
-      />
-    </MockedCache>
-  </div>
-);
+} & Partial<React.ComponentProps<typeof FormAudience>>) => {
+  const [submitErrorsDefault, setSubmitErrors] = useState<Record<string, any>>(
+    submitErrors,
+  );
+  return (
+    <div className="p-5">
+      <MockedCache {...{ config }}>
+        <FormAudience
+          submitErrors={submitErrorsDefault}
+          {...{
+            experiment,
+            setSubmitErrors,
+            isMissingField,
+            isLoading,
+            isServerValid,
+            onSubmit,
+            onNext,
+          }}
+        />
+      </MockedCache>
+    </div>
+  );
+};
 
 export const MOCK_EXPERIMENT = mockExperimentQuery("demo-slug").experiment;

--- a/app/experimenter/nimbus-ui/src/components/FormMetrics/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/FormMetrics/index.stories.tsx
@@ -14,10 +14,12 @@ const onNext = action("onNext");
 storiesOf("components/FormMetrics", module)
   .add("basic", () => <Subject {...{ onSave, onNext }} />)
   .add("loading", () => <Subject isLoading {...{ onSave, onNext }} />)
-  .add("errors", () => (
+  .add("server/submit errors", () => (
     <Subject
       submitErrors={{
         "*": ["Big bad server thing broke!"],
+        primaryProbeSetIds: ["You primary probed the wrong bear."],
+        secondaryProbeSetIds: ["You secondary probed the wrong bear."],
       }}
       {...{ onSave, onNext }}
     />

--- a/app/experimenter/nimbus-ui/src/components/FormMetrics/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/FormMetrics/index.test.tsx
@@ -4,36 +4,11 @@
 
 import React from "react";
 import { render, screen, act, fireEvent } from "@testing-library/react";
-import { mockExperimentQuery } from "../../lib/mocks";
+import { mockExperimentQuery, MOCK_CONFIG } from "../../lib/mocks";
 import { Subject } from "./mocks";
-import { getConfig_nimbusConfig_probeSets } from "../../types/getConfig";
 import { PRIMARY_PROBE_SETS_TOOLTIP, SECONDARY_PROBE_SETS_TOOLTIP } from ".";
 
 describe("FormMetrics", () => {
-  const probeSets: getConfig_nimbusConfig_probeSets[] = [
-    {
-      __typename: "NimbusProbeSetType",
-      id: "1",
-      name: "Probe Set A",
-      slug: "probe-set-a",
-      probes: [],
-    },
-    {
-      __typename: "NimbusProbeSetType",
-      id: "2",
-      name: "Probe Set B",
-      slug: "probe-set-b",
-      probes: [],
-    },
-    {
-      __typename: "NimbusProbeSetType",
-      id: "3",
-      name: "Probe Set C",
-      slug: "probe-set-c",
-      probes: [],
-    },
-  ];
-
   it("renders as expected", async () => {
     render(<Subject />);
     await act(async () =>
@@ -95,14 +70,7 @@ describe("FormMetrics", () => {
 
   it("displays saved primary probe sets", async () => {
     const { experiment } = mockExperimentQuery("boo", {
-      primaryProbeSets: [
-        {
-          __typename: "NimbusProbeSetType",
-          id: "1",
-          name: "Probe Set A",
-          slug: "probe-set-a",
-        },
-      ],
+      primaryProbeSets: [MOCK_CONFIG.probeSets![0]],
     });
 
     render(<Subject {...{ experiment }} />);
@@ -113,16 +81,9 @@ describe("FormMetrics", () => {
 
   it("displays saved secondary probe sets", async () => {
     const { experiment } = mockExperimentQuery("boo", {
-      secondaryProbeSets: [
-        {
-          __typename: "NimbusProbeSetType",
-          id: "1",
-          name: "Probe Set A",
-          slug: "probe-set-a",
-        },
-      ],
+      secondaryProbeSets: [MOCK_CONFIG.probeSets![0]],
     });
-    render(<Subject {...{ experiment, probeSets }} />);
+    render(<Subject {...{ experiment }} />);
 
     const secondaryProbeSets = screen.getByTestId("secondary-probe-sets");
     expect(secondaryProbeSets).toHaveTextContent("Probe Set A");
@@ -134,7 +95,7 @@ describe("FormMetrics", () => {
       secondaryProbeSets: [],
     });
 
-    render(<Subject {...{ experiment, probeSets }} />);
+    render(<Subject {...{ experiment }} />);
     const primaryProbeSets = screen.getByTestId("primary-probe-sets");
     const secondaryProbeSets = screen.getByTestId("secondary-probe-sets");
 
@@ -166,7 +127,7 @@ describe("FormMetrics", () => {
       secondaryProbeSets: [],
     });
 
-    render(<Subject {...{ experiment, probeSets }} />);
+    render(<Subject {...{ experiment }} />);
 
     const primaryProbeSets = screen.getByTestId("primary-probe-sets");
     const secondaryProbeSets = screen.getByTestId("secondary-probe-sets");
@@ -199,7 +160,7 @@ describe("FormMetrics", () => {
       secondaryProbeSets: [],
     });
 
-    render(<Subject {...{ experiment, probeSets }} />);
+    render(<Subject {...{ experiment }} />);
 
     const primaryProbeSets = screen.getByTestId("primary-probe-sets");
 

--- a/app/experimenter/nimbus-ui/src/components/FormMetrics/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/components/FormMetrics/mocks.tsx
@@ -2,9 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from "react";
+import React, { useState } from "react";
 import FormMetrics from ".";
-import { MockedCache, mockExperimentQuery, MOCK_CONFIG } from "../../lib/mocks";
+import { MockedCache, mockExperimentQuery } from "../../lib/mocks";
 
 export const Subject = ({
   isLoading = false,
@@ -13,19 +13,23 @@ export const Subject = ({
   onSave = () => {},
   onNext = () => {},
   experiment = mockExperimentQuery("boo").experiment,
-  probeSets = MOCK_CONFIG.probeSets,
-}: Partial<React.ComponentProps<typeof FormMetrics>>) => (
-  <MockedCache>
-    <FormMetrics
-      {...{
-        isLoading,
-        isServerValid,
-        submitErrors,
-        onSave,
-        onNext,
-        experiment,
-        probeSets,
-      }}
-    />
-  </MockedCache>
-);
+}: Partial<React.ComponentProps<typeof FormMetrics>>) => {
+  const [submitErrorsDefault, setSubmitErrors] = useState<Record<string, any>>(
+    submitErrors,
+  );
+  return (
+    <MockedCache>
+      <FormMetrics
+        submitErrors={submitErrorsDefault}
+        {...{
+          isLoading,
+          isServerValid,
+          setSubmitErrors,
+          onSave,
+          onNext,
+          experiment,
+        }}
+      />
+    </MockedCache>
+  );
+};

--- a/app/experimenter/nimbus-ui/src/components/FormOverview/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/FormOverview/index.stories.tsx
@@ -15,7 +15,7 @@ const onNext = action("onNext");
 storiesOf("components/FormOverview", module)
   .add("basic", () => <Subject {...{ onSubmit, onCancel }} />)
   .add("loading", () => <Subject isLoading {...{ onSubmit, onCancel }} />)
-  .add("errors", () => (
+  .add("server/submit errors", () => (
     <Subject
       submitErrors={{
         "*": ["Big bad server thing broke!"],

--- a/app/experimenter/nimbus-ui/src/components/FormOverview/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/FormOverview/index.test.tsx
@@ -196,7 +196,7 @@ describe("FormOverview", () => {
 
   it("displays feedback for per-field error", async () => {
     const submitErrors = {
-      name: ["That name is terrble, man"],
+      name: ["That name is terrible, man"],
     };
     render(<Subject {...{ submitErrors }} />);
     const errorFeedback = screen.getByText(submitErrors["name"][0]);

--- a/app/experimenter/nimbus-ui/src/components/FormOverview/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/components/FormOverview/mocks.tsx
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from "react";
+import React, { useState } from "react";
 import FormOverview from ".";
 import { MockedCache } from "../../lib/mocks";
 
@@ -15,19 +15,25 @@ export const Subject = ({
   onCancel,
   onNext,
   experiment,
-}: Partial<React.ComponentProps<typeof FormOverview>>) => (
-  <MockedCache>
-    <FormOverview
-      {...{
-        isLoading,
-        isServerValid,
-        isMissingField,
-        submitErrors,
-        onSubmit,
-        onCancel,
-        onNext,
-        experiment,
-      }}
-    />
-  </MockedCache>
-);
+}: Partial<React.ComponentProps<typeof FormOverview>>) => {
+  const [submitErrorsDefault, setSubmitErrors] = useState<Record<string, any>>(
+    submitErrors,
+  );
+  return (
+    <MockedCache>
+      <FormOverview
+        submitErrors={submitErrorsDefault}
+        {...{
+          isLoading,
+          isServerValid,
+          isMissingField,
+          setSubmitErrors,
+          onSubmit,
+          onCancel,
+          onNext,
+          experiment,
+        }}
+      />
+    </MockedCache>
+  );
+};

--- a/app/experimenter/nimbus-ui/src/components/PageEditAudience/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditAudience/index.tsx
@@ -23,6 +23,7 @@ const PageEditAudience: React.FunctionComponent<RouteComponentProps> = () => {
   const [submitErrors, setSubmitErrors] = useState<Record<string, any>>({});
   const currentExperiment = useRef<getExperiment_experimentBySlug>();
   const refetchReview = useRef<() => void>();
+  const [isServerValid, setIsServerValid] = useState(true);
 
   const onFormSubmit = useCallback(
     async ({
@@ -59,8 +60,10 @@ const PageEditAudience: React.FunctionComponent<RouteComponentProps> = () => {
         const { message } = result.data.updateExperimentAudience;
 
         if (message && message !== "success" && typeof message === "object") {
+          setIsServerValid(false);
           return void setSubmitErrors(message);
         } else {
+          setIsServerValid(true);
           setSubmitErrors({});
           // In practice this should be defined by the time we get here
           refetchReview.current!();
@@ -93,7 +96,9 @@ const PageEditAudience: React.FunctionComponent<RouteComponentProps> = () => {
             {...{
               experiment,
               submitErrors,
+              setSubmitErrors,
               isMissingField,
+              isServerValid,
               isLoading: loading,
               onSubmit: onFormSubmit,
               onNext: onFormNext,

--- a/app/experimenter/nimbus-ui/src/components/PageEditMetrics/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditMetrics/index.tsx
@@ -11,7 +11,6 @@ import { SUBMIT_ERROR } from "../../lib/constants";
 import { UPDATE_EXPERIMENT_PROBESETS_MUTATION } from "../../gql/experiments";
 import { updateExperimentProbeSets_updateExperimentProbeSets as UpdateExperimentProbeSetsResult } from "../../types/updateExperimentProbeSets";
 import { UpdateExperimentProbeSetsInput } from "../../types/globalTypes";
-import { useConfig } from "../../hooks/useConfig";
 import AppLayoutWithExperiment from "../AppLayoutWithExperiment";
 import FormMetrics from "../FormMetrics";
 import LinkExternal from "../LinkExternal";
@@ -21,8 +20,6 @@ export const CORE_METRICS_DOC_URL =
   "https://docs.google.com/document/d/155EUgzn22VTX8mFwesSROT3Z6JORSfb5VyoMoLra7ws/edit#heading=h.uq23fsvh16rc";
 
 const PageEditMetrics: React.FunctionComponent<RouteComponentProps> = () => {
-  const { probeSets } = useConfig();
-
   const [updateExperimentProbeSets, { loading }] = useMutation<
     { updateExperimentProbeSets: UpdateExperimentProbeSetsResult },
     { input: UpdateExperimentProbeSetsInput }
@@ -104,10 +101,10 @@ const PageEditMetrics: React.FunctionComponent<RouteComponentProps> = () => {
             <FormMetrics
               {...{
                 experiment,
-                probeSets,
                 isLoading: loading,
                 isServerValid,
                 submitErrors,
+                setSubmitErrors,
                 onSave,
                 onNext,
               }}

--- a/app/experimenter/nimbus-ui/src/components/PageEditOverview/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditOverview/index.tsx
@@ -87,6 +87,7 @@ const PageEditOverview: React.FunctionComponent<PageEditOverviewProps> = () => {
               isMissingField,
               experiment,
               submitErrors,
+              setSubmitErrors,
               onSubmit: onFormSubmit,
               onNext: onFormNext,
             }}

--- a/app/experimenter/nimbus-ui/src/components/PageNew/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageNew/index.tsx
@@ -89,6 +89,7 @@ const PageNew: React.FunctionComponent<PageNewProps> = () => {
             isLoading: loading,
             isServerValid,
             submitErrors,
+            setSubmitErrors,
             onSubmit: onFormSubmit,
             onCancel: onFormCancel,
           }}

--- a/app/experimenter/nimbus-ui/src/components/Summary/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/index.tsx
@@ -4,13 +4,13 @@
 
 import React from "react";
 import { getExperiment_experimentBySlug } from "../../types/getExperiment";
-import { getConfig_nimbusConfig } from "../../types/getConfig";
 import SummaryTimeline from "../SummaryTimeline";
 import TableSummary from "../TableSummary";
 import TableAudience from "../TableAudience";
 import LinkExternal from "../LinkExternal";
 import { getStatus } from "../../lib/experiment";
 import MonitoringLink from "../MonitoringLink";
+import { getConfigLabel, ConfigOptions } from "../../lib/getConfigLabel";
 
 type SummaryProps = {
   experiment: getExperiment_experimentBySlug;
@@ -46,18 +46,12 @@ const Summary = ({ experiment }: SummaryProps) => {
   );
 };
 
-type displayConfigOptionsProps =
-  | getConfig_nimbusConfig["application"]
-  | getConfig_nimbusConfig["firefoxMinVersion"]
-  | getConfig_nimbusConfig["channel"]
-  | getConfig_nimbusConfig["targetingConfigSlug"];
-
 export const displayConfigLabelOrNotSet = (
   value: string | null,
-  options: displayConfigOptionsProps,
+  options: ConfigOptions,
 ) => {
   if (!value) return <NotSet />;
-  return options?.find((obj: any) => obj.value === value)?.label;
+  return getConfigLabel(value, options);
 };
 
 export const NotSet = ({

--- a/app/experimenter/nimbus-ui/src/components/TableHighlightsOverview/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/TableHighlightsOverview/index.tsx
@@ -6,17 +6,12 @@ import React from "react";
 import { getExperiment_experimentBySlug } from "../../types/getExperiment";
 import { AnalysisData } from "../../lib/visualization/types";
 import { useConfig } from "../../hooks";
-import { getConfig_nimbusConfig } from "../../types/getConfig";
+import { getConfigLabel } from "../../lib/getConfigLabel";
 
 type TableHighlightsOverviewProps = {
   experiment: getExperiment_experimentBySlug;
   results: AnalysisData["overall"];
 };
-
-type displayConfigOptionsProps =
-  | getConfig_nimbusConfig["firefoxMinVersion"]
-  | getConfig_nimbusConfig["channel"]
-  | getConfig_nimbusConfig["targetingConfigSlug"];
 
 const TableHighlightsOverview = ({
   experiment,
@@ -33,15 +28,11 @@ const TableHighlightsOverview = ({
           <td>
             <h3 className="h6">Targeting</h3>
             <div>
-              {displayConfigLabel(
-                experiment.firefoxMinVersion,
-                firefoxMinVersion,
-              )}
-              +
+              {getConfigLabel(experiment.firefoxMinVersion, firefoxMinVersion)}+
             </div>
-            <div>{displayConfigLabel(experiment.channel, channel)}</div>
+            <div>{getConfigLabel(experiment.channel, channel)}</div>
             <div>
-              {displayConfigLabel(
+              {getConfigLabel(
                 experiment.targetingConfigSlug,
                 targetingConfigSlug,
               )}
@@ -63,13 +54,6 @@ const TableHighlightsOverview = ({
       </tbody>
     </table>
   );
-};
-
-const displayConfigLabel = (
-  value: string | null,
-  options: displayConfigOptionsProps,
-) => {
-  return options?.find((obj: any) => obj.value === value)?.label;
 };
 
 export default TableHighlightsOverview;

--- a/app/experimenter/nimbus-ui/src/hooks/index.ts
+++ b/app/experimenter/nimbus-ui/src/hooks/index.ts
@@ -2,3 +2,4 @@ export * from "./useExitWarning";
 export * from "./useExperiment";
 export * from "./useConfig";
 export * from "./useAnalysis";
+export * from "./useCommonForm";

--- a/app/experimenter/nimbus-ui/src/hooks/useCommonForm.test.tsx
+++ b/app/experimenter/nimbus-ui/src/hooks/useCommonForm.test.tsx
@@ -1,0 +1,141 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from "react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { Subject as OverviewSubject } from "../components/FormOverview/mocks";
+import { overviewFieldNames } from "../components/FormOverview";
+import { Subject as MetricsSubject } from "../components/FormMetrics/mocks";
+import { metricsFieldNames } from "../components/FormMetrics";
+import { Subject as AudienceSubject } from "../components/FormAudience/mocks";
+import { audienceFieldNames } from "../components/FormAudience";
+import { mockExperimentQuery } from "../lib/mocks";
+import * as CommonForm from ".";
+
+describe("hooks/useCommonForm", () => {
+  describe("works as expected", () => {
+    const overviewSetup = () => {
+      const submitErrors = {
+        name: ["That name is terrible, man"],
+        hypothesis: ["Big bad happened"],
+      };
+      render(<OverviewSubject {...{ submitErrors }} />);
+      return { nameField: screen.getByLabelText("Public name"), submitErrors };
+    };
+
+    it("clears submit error onChange of input field with error", async () => {
+      const { nameField, submitErrors } = overviewSetup();
+      const nameError = screen.getByText(submitErrors["name"][0]);
+      expect(nameField).toHaveClass("is-invalid");
+      expect(nameError).toBeInTheDocument();
+
+      await act(async () => {
+        fireEvent.change(nameField, {
+          target: { value: "abc" },
+        });
+        fireEvent.blur(nameField);
+      });
+
+      expect(nameField).toHaveClass("is-valid");
+      expect(nameError).not.toBeInTheDocument();
+    });
+
+    it("clears only its own field submit error onChange of field with error", async () => {
+      const { nameField, submitErrors } = overviewSetup();
+      const getHypothesisError = () =>
+        screen.queryByText(submitErrors["hypothesis"][0]);
+      const hypothesisField = screen.getByLabelText("Hypothesis");
+      expect(hypothesisField).toHaveClass("is-invalid");
+      expect(getHypothesisError()).toBeInTheDocument();
+
+      await act(async () => {
+        fireEvent.change(nameField, {
+          target: { value: "abc" },
+        });
+        fireEvent.blur(nameField);
+      });
+      expect(hypothesisField).toHaveClass("is-invalid");
+      expect(getHypothesisError()).toBeInTheDocument();
+    });
+
+    it("clears submit error onChange of multiselect", async () => {
+      const submitErrors = {
+        primaryProbeSetIds: ["You primary probed the wrong bear."],
+      };
+      const { experiment } = mockExperimentQuery("boo", {
+        primaryProbeSets: [],
+      });
+      const { container } = render(
+        <MetricsSubject {...{ submitErrors, experiment }} />,
+      );
+
+      const primaryProbeSets = screen.getByTestId("primary-probe-sets");
+      const errorFeedback = screen.getByText(
+        submitErrors.primaryProbeSetIds[0],
+      );
+      expect(errorFeedback).toBeInTheDocument();
+      expect(
+        container.querySelector("[for='primaryProbeSetIds'] + div"),
+      ).toHaveClass("is-invalid border border-danger rounded");
+
+      fireEvent.keyDown(primaryProbeSets.children[1], { key: "ArrowDown" });
+      fireEvent.click(screen.getByText("Probe Set A"));
+      expect(errorFeedback).not.toBeInTheDocument();
+    });
+  });
+
+  describe("is used on expected fields", () => {
+    // TODO EXP-780 - improve these tests by mocking `useCommonForm` to ensure `<FormErrors />`,
+    // `formControlAttrs`, and `formSelectAttrs` are all called with the expected field names
+    describe("FormOverview", () => {
+      it("with experiment data", () => {
+        const { experiment } = mockExperimentQuery("boo");
+        render(<OverviewSubject {...{ experiment }} />);
+
+        overviewFieldNames.forEach((name) => {
+          if (name !== "application") {
+            expect(
+              screen.queryByTestId(`${name}-form-errors`),
+            ).toBeInTheDocument();
+            expect(screen.queryByTestId(name)).toBeInTheDocument();
+          }
+        });
+      });
+
+      it("without experiment data", async () => {
+        await act(async () => {
+          render(<OverviewSubject />);
+        });
+
+        overviewFieldNames.forEach((name) => {
+          if (name !== "publicDescription") {
+            expect(
+              screen.queryByTestId(`${name}-form-errors`),
+            ).toBeInTheDocument();
+            expect(screen.queryByTestId(name)).toBeInTheDocument();
+          }
+        });
+      });
+    });
+
+    it("FormMetrics", () => {
+      render(<MetricsSubject />);
+
+      metricsFieldNames.forEach((name) => {
+        expect(screen.queryByTestId(`${name}-form-errors`)).toBeInTheDocument();
+        // TODO EXP-780
+        // expect(screen.queryByTestId(name)).toBeInTheDocument();
+      });
+    });
+
+    it("FormAudience", () => {
+      render(<AudienceSubject />);
+
+      audienceFieldNames.forEach((name) => {
+        expect(screen.queryByTestId(`${name}-form-errors`)).toBeInTheDocument();
+        expect(screen.queryByTestId(name)).toBeInTheDocument();
+      });
+    });
+  });
+});

--- a/app/experimenter/nimbus-ui/src/hooks/useCommonForm.tsx
+++ b/app/experimenter/nimbus-ui/src/hooks/useCommonForm.tsx
@@ -1,0 +1,114 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from "react";
+import { RegisterOptions, FieldError } from "react-hook-form";
+import Form from "react-bootstrap/Form";
+import { useForm } from "react-hook-form";
+
+// TODO: 'any' type on `onChange={(selectedOptions) => ...`,
+// it wants this, but can't seem to coerce it into SelectOption type
+// type SelectedOption = {
+//   value: ValueType<any, true>;
+//   action: ActionMeta<any>;
+// };
+export type SelectOption = { label: string; value: string };
+
+export function useCommonForm<FieldNames extends string>(
+  defaultValues: Record<string, any>,
+  isServerValid: boolean,
+  submitErrors: Record<string, string[]>,
+  setSubmitErrors: React.Dispatch<React.SetStateAction<Record<string, any>>>,
+) {
+  const {
+    handleSubmit,
+    register,
+    reset,
+    errors,
+    formState: { isSubmitted, isDirty, touched, isValid: isClientValid },
+  } = useForm({
+    mode: "onTouched",
+    defaultValues,
+  });
+
+  const isValid = isServerValid && isClientValid;
+  const isDirtyUnsaved = isDirty && !(isValid && isSubmitted);
+
+  const hideSubmitError = <K extends FieldNames>(name: K) => {
+    if (submitErrors[name]) {
+      const modifiedSubmitErrors = { ...submitErrors };
+      delete modifiedSubmitErrors[name];
+      setSubmitErrors(modifiedSubmitErrors);
+    }
+  };
+
+  // Fields are required by default. Pass an empty object `{}` as `registerOptions`
+  // to allow form submission without that field being required.
+  const formControlAttrs = <K extends FieldNames>(
+    name: K,
+    registerOptions: RegisterOptions = {
+      required: "This field may not be blank.",
+    },
+  ) => ({
+    name,
+    "data-testid": name,
+    ref: register(registerOptions),
+    defaultValue: defaultValues[name],
+    onChange: () => hideSubmitError(name),
+    isInvalid: Boolean(submitErrors[name] || (touched[name] && errors[name])),
+    isValid: Boolean(!submitErrors[name] && touched[name] && !errors[name]),
+  });
+
+  const getValuesFromOptions = (selectedOptions: SelectOption[] | null) =>
+    selectedOptions?.map((option) => option?.value) || [];
+
+  /* <Select /> handles `register` internally and only renders certain props.
+   * Prefer `<Form.Control as="select">` with `formControlAttrs` instead and
+   * only use this for multiselects using the `react-select` package.
+   */
+  const formSelectAttrs = <K extends FieldNames>(
+    name: K,
+    setValuesFromOptions: React.Dispatch<React.SetStateAction<string[]>>,
+  ) => ({
+    defaultValue: defaultValues[name],
+    onChange: (selectedOptions: any) => {
+      setValuesFromOptions(getValuesFromOptions(selectedOptions));
+      hideSubmitError(name);
+    },
+    className: Boolean(submitErrors[name] || (touched[name] && errors[name]))
+      ? "is-invalid border border-danger rounded"
+      : "",
+  });
+
+  const FormErrors = <K extends FieldNames>({ name }: { name: K }) => (
+    <>
+      {errors[name] && (
+        <Form.Control.Feedback type="invalid" data-for={name}>
+          {(errors[name] as FieldError).message}
+        </Form.Control.Feedback>
+      )}
+      {submitErrors[name] && (
+        <Form.Control.Feedback type="invalid" data-for={name}>
+          {submitErrors[name]}
+        </Form.Control.Feedback>
+      )}
+      {/* for testing - can't wrap the errors in a container with a test ID
+      because of Bootstrap's adjacent class CSS rules */}
+      {!errors[name] && !submitErrors[name] && (
+        <span data-testid={`${name}-form-errors`} />
+      )}
+    </>
+  );
+
+  return {
+    FormErrors,
+    formControlAttrs,
+    formSelectAttrs,
+    handleSubmit,
+    reset,
+    isValid,
+    isDirtyUnsaved,
+    isSubmitted,
+  };
+}

--- a/app/experimenter/nimbus-ui/src/lib/getConfigLabel.ts
+++ b/app/experimenter/nimbus-ui/src/lib/getConfigLabel.ts
@@ -1,0 +1,16 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { getConfig_nimbusConfig } from "../types/getConfig";
+
+export type ConfigOptions =
+  | getConfig_nimbusConfig["application"]
+  | getConfig_nimbusConfig["firefoxMinVersion"]
+  | getConfig_nimbusConfig["channel"]
+  | getConfig_nimbusConfig["targetingConfigSlug"];
+
+export const getConfigLabel = (
+  value: string | null,
+  configOptions: ConfigOptions,
+) => configOptions?.find((option: any) => option.value === value)?.label;

--- a/app/experimenter/nimbus-ui/src/lib/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/lib/mocks.tsx
@@ -128,8 +128,8 @@ export const MOCK_CONFIG: getConfig_nimbusConfig = {
     {
       __typename: "NimbusProbeSetType",
       id: "1",
-      name: "Inverse responsive methodology",
-      slug: "inverse-responsive-methodology",
+      name: "Probe Set A",
+      slug: "probe-set-a",
       probes: [
         {
           __typename: "NimbusProbeType",
@@ -152,6 +152,20 @@ export const MOCK_CONFIG: getConfig_nimbusConfig = {
           eventValue: "automated-national-infrastructure",
         },
       ],
+    },
+    {
+      __typename: "NimbusProbeSetType",
+      id: "2",
+      name: "Probe Set B",
+      slug: "probe-set-b",
+      probes: [],
+    },
+    {
+      __typename: "NimbusProbeSetType",
+      id: "3",
+      name: "Probe Set C",
+      slug: "probe-set-c",
+      probes: [],
     },
   ],
   targetingConfigSlug: [


### PR DESCRIPTION
Because:
* We have a lot of common functionality floating around and need a place to pull from for consistency across all of our forms.
* We want server errors to clear onChange of that field.

This commit:
* Creates useCommonForm hook
* Refactors/makes FormOverview, FormMetrics, and FormAudience consistent using said hook
* Contains additional MetricsForm refactoring for consistency/readability
* Clears per-field submitError onChange of fields for inputs, selects, and multiselects
* Displays submit errors in FormMetrics
* Cleans up some tests

fixes #4021

---

I'll create follow up tickets:
1) to use `useCommonForm` in the Branches page: https://jira.mozilla.com/browse/EXP-781