### PR TITLE
fixes #3362 fix(visualization): Add start date, end date, and duration to results page.

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/AppLayoutWithExperiment/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/AppLayoutWithExperiment/index.tsx
@@ -117,7 +117,7 @@ const AppLayoutWithExperiment = ({
     return <PageExperimentNotFound {...{ slug }} />;
   }
 
-  const { name } = experiment;
+  const { name, startDate, endDate } = experiment;
 
   return (
     <Layout {...{ sidebar, children, review, analysis, analysisError, status }}>
@@ -130,6 +130,8 @@ const AppLayoutWithExperiment = ({
           {...{
             slug,
             name,
+            startDate,
+            endDate,
             status,
           }}
         />

--- a/app/experimenter/nimbus-ui/src/components/HeaderExperiment/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/HeaderExperiment/index.stories.tsx
@@ -19,6 +19,8 @@ storiesOf("components/HeaderExperiment", module)
       <HeaderExperiment
         name={experiment.name}
         slug={experiment.slug}
+        startDate={experiment.startDate}
+        endDate={experiment.endDate}
         status={mockGetStatus(experiment.status)}
       />
     </AppLayout>
@@ -28,6 +30,8 @@ storiesOf("components/HeaderExperiment", module)
       <HeaderExperiment
         name={experiment.name}
         slug={experiment.slug}
+        startDate={experiment.startDate}
+        endDate={experiment.endDate}
         status={mockGetStatus(NimbusExperimentStatus.REVIEW)}
       />
     </AppLayout>
@@ -37,6 +41,8 @@ storiesOf("components/HeaderExperiment", module)
       <HeaderExperiment
         name={experiment.name}
         slug={experiment.slug}
+        startDate={experiment.startDate}
+        endDate={null}
         status={mockGetStatus(NimbusExperimentStatus.LIVE)}
       />
     </AppLayout>
@@ -46,6 +52,19 @@ storiesOf("components/HeaderExperiment", module)
       <HeaderExperiment
         name={experiment.name}
         slug={experiment.slug}
+        startDate={experiment.startDate}
+        endDate={experiment.endDate}
+        status={mockGetStatus(NimbusExperimentStatus.COMPLETE)}
+      />
+    </AppLayout>
+  ))
+  .add("includes dates", () => (
+    <AppLayout>
+      <HeaderExperiment
+        name={experiment.name}
+        slug={experiment.slug}
+        startDate={experiment.startDate}
+        endDate={experiment.endDate}
         status={mockGetStatus(NimbusExperimentStatus.COMPLETE)}
       />
     </AppLayout>

--- a/app/experimenter/nimbus-ui/src/components/HeaderExperiment/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/HeaderExperiment/index.test.tsx
@@ -6,15 +6,18 @@ import React from "react";
 import { screen, render } from "@testing-library/react";
 import HeaderExperiment from ".";
 import { mockExperimentQuery, mockGetStatus } from "../../lib/mocks";
-
-const { experiment } = mockExperimentQuery("demo-slug");
+import { humanDate } from "../../lib/dateUtils";
+import { NimbusExperimentStatus } from "../../types/globalTypes";
 
 describe("HeaderExperiment", () => {
   it("renders as expected", () => {
+    const { experiment } = mockExperimentQuery("demo-slug");
     render(
       <HeaderExperiment
         name={experiment.name}
         slug={experiment.slug}
+        startDate={experiment.startDate}
+        endDate={experiment.endDate}
         status={mockGetStatus(experiment.status)}
       />,
     );
@@ -27,5 +30,29 @@ describe("HeaderExperiment", () => {
     expect(
       screen.getByTestId("header-experiment-status-active"),
     ).toHaveTextContent("Draft");
+  });
+
+  it("displays expected dates", () => {
+    const { experiment } = mockExperimentQuery("demo-slug", {
+      status: NimbusExperimentStatus.LIVE,
+    });
+    render(
+      <HeaderExperiment
+        name={experiment.name}
+        slug={experiment.slug}
+        startDate={experiment.startDate}
+        endDate={experiment.endDate}
+        status={mockGetStatus(experiment.status)}
+      />,
+    );
+    expect(
+      screen.getByTestId("header-experiment-status-active"),
+    ).toHaveTextContent("Live");
+    expect(screen.getByTestId("header-dates")).toHaveTextContent(
+      humanDate(experiment.startDate!),
+    );
+    expect(screen.getByTestId("header-dates")).toHaveTextContent(
+      humanDate(experiment.endDate!),
+    );
   });
 });

--- a/app/experimenter/nimbus-ui/src/components/HeaderExperiment/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/HeaderExperiment/index.tsx
@@ -7,13 +7,20 @@ import React from "react";
 import { getExperiment_experimentBySlug } from "../../types/getExperiment";
 import { StatusCheck } from "../../lib/experiment";
 import "./index.scss";
+import { humanDate, stringDateSubtract } from "../../lib/dateUtils";
 
 type HeaderExperimentProps = Pick<
   getExperiment_experimentBySlug,
-  "name" | "slug"
+  "name" | "slug" | "startDate" | "endDate"
 > & { status: StatusCheck };
 
-const HeaderExperiment = ({ name, slug, status }: HeaderExperimentProps) => (
+const HeaderExperiment = ({
+  name,
+  slug,
+  startDate = "",
+  endDate = "",
+  status,
+}: HeaderExperimentProps) => (
   <header className="border-bottom" data-testid="header-experiment">
     <h1 className="h5 font-weight-normal" data-testid="header-experiment-name">
       {name}
@@ -24,12 +31,36 @@ const HeaderExperiment = ({ name, slug, status }: HeaderExperimentProps) => (
     >
       {slug}
     </p>
-    <p className="header-experiment-status position-relative mt-2 d-inline-block">
-      <StatusPill label="Draft" active={status.draft} />
-      <StatusPill label="Review" active={status.review || status.accepted} />
-      <StatusPill label="Live" active={status.live} />
-      <StatusPill label="Complete" active={status.complete} padded={false} />
-    </p>
+    <div className="row">
+      <div className="col">
+        <p className="header-experiment-status position-relative mt-2 d-inline-block">
+          <StatusPill label="Draft" active={status.draft} />
+          <StatusPill
+            label="Review"
+            active={status.review || status.accepted}
+          />
+          <StatusPill label="Live" active={status.live} />
+          <StatusPill
+            label="Complete"
+            active={status.complete}
+            padded={false}
+          />
+        </p>
+      </div>
+      {(status.live || status.complete) && (
+        <div className="text-right col mt-2" data-testid="header-dates">
+          <span className="font-weight-bold">{humanDate(startDate!)}</span> to{" "}
+          {endDate ? (
+            <>
+              <span className="font-weight-bold">{humanDate(endDate!)}</span> (
+              {stringDateSubtract(endDate!, startDate!)})
+            </>
+          ) : (
+            <span className="font-weight-bold">Present</span>
+          )}
+        </div>
+      )}
+    </div>
   </header>
 );
 

--- a/app/experimenter/nimbus-ui/src/lib/dateUtils.ts
+++ b/app/experimenter/nimbus-ui/src/lib/dateUtils.ts
@@ -36,6 +36,19 @@ export function addDaysToDate(datestring: string, days: number): string {
 }
 
 /**
+ *  Subtract two dates (e.g. dateA - dateB) and return a string
+ *  with their difference in days.
+ */
+export function stringDateSubtract(dateA: string, dateB: string): string {
+  const DAY = 86400000; // Number of milliseconds in a day
+  const dateAConverted = +new Date(dateA);
+  const dateBConverted = +new Date(dateB);
+  const dateDifference = Math.abs(dateAConverted - dateBConverted);
+
+  return pluralize(Math.round(dateDifference / DAY), "day");
+}
+
+/**
  *  Renders an end date based on proposedDuration (e.g. Dec 2),
  *  or a number of days (e.g. "5 days") if startDate is not set.
  */


### PR DESCRIPTION
Because:
* Users need to see dates and duration when looking at results

This commit:
* Makes them visible in the header whenever analysis is displayed

I thought this change was simple enough that it didn't seem necessary to create a separate `AppLayoutWithAnalysis` component.