### PR TITLE
fix #4285 fix(nimbus): handle empty feature_value

### DIFF
--- a/app/experimenter/experiments/api/v6/serializers.py
+++ b/app/experimenter/experiments/api/v6/serializers.py
@@ -48,7 +48,7 @@ class NimbusBranchSerializer(serializers.ModelSerializer):
             return {
                 "featureId": obj.experiment.feature_config.slug,
                 "enabled": obj.feature_enabled,
-                "value": json.loads(obj.feature_value),
+                "value": json.loads(obj.feature_value) if obj.feature_value else None,
             }
 
 

--- a/app/tests/integration/test_filter_expression_validation.py
+++ b/app/tests/integration/test_filter_expression_validation.py
@@ -1,6 +1,4 @@
-def test_filter_expressions_with_matching_firefox_versions(
-    base_url, selenium
-):
+def test_filter_expressions_with_matching_firefox_versions(base_url, selenium):
     selenium.get("about:blank")
     with open("utils/filter_expression.js") as js:
         with selenium.context(selenium.CONTEXT_CHROME):
@@ -8,9 +6,7 @@ def test_filter_expressions_with_matching_firefox_versions(
     assert script is True
 
 
-def test_filter_expressions_with_mismatching_firefox_versions(
-    base_url, selenium
-):
+def test_filter_expressions_with_mismatching_firefox_versions(base_url, selenium):
     selenium.get("about:blank")
     with open("utils/filter_expression.js") as js:
         with selenium.context(selenium.CONTEXT_CHROME):


### PR DESCRIPTION
Because

* Even if an experiment sets a feature_config, not all branches are required to have a feature_value

This commit

* Checks whether a feature_value is defined on a branch before attempting to serialize it
* Adds the schema check to all serializer tests just to ensure we always match the schema