### PR TITLE
issue #4289: progress on per-field review error icons for branch forms

### DIFF
--- a/app/experimenter/experiments/api/v5/serializers.py
+++ b/app/experimenter/experiments/api/v5/serializers.py
@@ -364,19 +364,22 @@ class NimbusReadyForReviewSerializer(
         model = NimbusExperiment
         exclude = ("id",)
 
+    def _validate_branch(self, branch):
+        error = {}
+        if branch["description"] == "":
+            error["description"] = ["Description cannot be blank."]
+        return error
+
     def validate_reference_branch(self, value):
-        if value["description"] == "":
-            raise serializers.ValidationError("Description cannot be blank.")
+        error = self._validate_branch(value)
+        if error:
+            raise serializers.ValidationError(error)
         return value
 
     def validate_treatment_branches(self, value):
         errors = []
         for branch in value:
-            error = None
-            if branch["description"] == "":
-                error = ["Description cannot be blank."]
-            errors.append(error)
-
+            errors.append(self._validate_branch(branch))
         if any(x is not None for x in errors):
             raise serializers.ValidationError(errors)
         return value

--- a/app/experimenter/experiments/tests/api/v5/test_serializers.py
+++ b/app/experimenter/experiments/tests/api/v5/test_serializers.py
@@ -829,7 +829,7 @@ class TestNimbusReadyForReviewSerializer(TestCase):
         self.assertFalse(serializer.is_valid())
         self.assertEqual(
             serializer.errors,
-            {"reference_branch": ["Description cannot be blank."]},
+            {"reference_branch": { "description": ["Description cannot be blank."] }},
         )
 
     def test_invalid_experiment_requires_non_zero_population_percent(self):
@@ -875,5 +875,5 @@ class TestNimbusReadyForReviewSerializer(TestCase):
         self.assertFalse(serializer.is_valid())
         self.assertEqual(
             serializer.errors["treatment_branches"][1],
-            ["Description cannot be blank."],
+            { "description": ["Description cannot be blank."] },
         )

--- a/app/experimenter/nimbus-ui/src/components/FormBranches/FormBranch.tsx
+++ b/app/experimenter/nimbus-ui/src/components/FormBranches/FormBranch.tsx
@@ -46,7 +46,7 @@ export const FormBranch = ({
   fieldNamePrefix: string;
   touched: Record<string, boolean>;
   errors: Record<string, FieldError>;
-  reviewErrors: string[] | undefined;
+  reviewErrors: string[] | Record<string, string[]> | undefined;
   branch: AnnotatedBranch;
   equalRatio?: boolean;
   isReference?: boolean;
@@ -125,6 +125,21 @@ export const FormBranch = ({
     </>
   );
 
+  const ReviewErrors = ({ name }: { name: string }) => (
+    <>
+      {reviewErrors &&
+        !Array.isArray(reviewErrors) &&
+        Array.isArray(reviewErrors[name]) &&
+        reviewErrors[name].map((error, idx) => (
+          <InlineErrorIcon
+            key={`${fieldNamePrefix}-${name}-missing-icon-${idx}`}
+            name={`${fieldNamePrefix}-${name}-missing-icon-${idx}`}
+            message={error}
+          />
+        ))}
+    </>
+  );
+
   return (
     <div
       className="mb-3 border border-secondary rounded"
@@ -139,13 +154,16 @@ export const FormBranch = ({
                 <Badge pill variant="primary" data-testid="control-pill">
                   control
                 </Badge>
-              )}
+              )}{" "}
+               <ReviewErrors name="name" />
             </Form.Label>
             <Form.Control {...formControlCommon("name")} type="text" />
             <FormErrors name="name" />
           </Form.Group>
           <Form.Group as={Col} controlId={`${id}-description`}>
-            <Form.Label>Description</Form.Label>
+            <Form.Label>
+              Description <ReviewErrors name="description" />
+            </Form.Label>
             <Form.Control
               {...formControlCommon("description", false)}
               type="text"
@@ -153,7 +171,7 @@ export const FormBranch = ({
             <FormErrors name="description" />
           </Form.Group>
           <Form.Group as={Col} controlId={`${id}-ratio`} sm={2} md={2}>
-            <Form.Label>Ratio</Form.Label>
+            <Form.Label>Ratio <ReviewErrors name="ratio" /></Form.Label>
             {equalRatio ? (
               <p data-testid="equal-ratio" className="p-0 m-0">
                 Equal
@@ -179,12 +197,14 @@ export const FormBranch = ({
             )}
           </Form.Group>
           <Form.Group as={Col} sm={1} className="align-top text-right">
+            {/* TODO: the serializer error here is usually "This field may
+                not be null" but does not mention the branch name */}
             {Array.isArray(reviewErrors) &&
               reviewErrors.map((error, idx) => (
                 <InlineErrorIcon
                   key={`${fieldNamePrefix}-missing-icon-${idx}`}
-                  name={`${fieldNamePrefix}-missing-icon-${idx}`}
-                  message={error}
+                  name={`${fieldNamePrefix}-missing-icon-${idx}`}                  
+                  message="Branch must be defined"
                 />
               ))}
             {!isReference && onRemove && (
@@ -274,7 +294,7 @@ export const FormBranch = ({
           featureEnabled ? (
             <Form.Row data-testid="feature-value-edit">
               <Form.Group as={Col} controlId={`${id}-featureValue`}>
-                <Form.Label>Value</Form.Label>
+                <Form.Label>Value <ReviewErrors name="feature_value" /></Form.Label>
                 {/* TODO: EXP-732 Maybe do some JSON schema validation here client-side? */}
                 <Form.Control
                   {...formControlCommon("featureValue")}

--- a/app/experimenter/nimbus-ui/src/components/FormBranches/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/FormBranches/index.stories.tsx
@@ -82,6 +82,35 @@ storiesOf("components/FormBranches/FormBranch", module)
         featureValue: "this is a default value",
       }}
     />
+  ))
+  .add("with review error (missing control branch)", () => (
+    <SubjectBranch
+      {...commonFormBranchProps}
+      experimentFeatureConfig={MOCK_FEATURE_CONFIG_WITH_SCHEMA}
+      branch={{
+        ...MOCK_ANNOTATED_BRANCH,
+        featureEnabled: true,
+        featureValue: "this is a default value",
+      }}
+      reviewErrors={["This field may not be null"]}
+    />
+  ))
+  .add("with review errors", () => (
+    <SubjectBranch
+      {...commonFormBranchProps}
+      experimentFeatureConfig={MOCK_FEATURE_CONFIG_WITH_SCHEMA}
+      branch={{
+        ...MOCK_ANNOTATED_BRANCH,
+        featureEnabled: true,
+        featureValue: "this is a default value",
+      }}
+      reviewErrors={{
+        name: ["Bad name"],
+        description: ["No way, bad description"],
+        ratio: ["Bad ratio yuck"],
+        feature_value: ["Terrible JSON, dang"],
+      }}
+    />
   ));
 
 storiesOf("components/FormBranches", module)
@@ -139,8 +168,16 @@ storiesOf("components/FormBranches", module)
           __typename: "NimbusReadyForReviewType",
           ready: false,
           message: {
-            reference_branch: ["Description may not be blank"],
-            treatment_branches: [null, ["Description may not be blank"]],
+            reference_branch: ["This field may not be null"],
+            treatment_branches: [
+              null,
+              {
+                name: ["Bad name"],
+                description: ["Bad description"],
+                ratio: ["Bad ratio yuck"],
+                feature_value: ["Terrible JSON, dang"],
+              },
+            ],
           },
         },
       }}

--- a/app/experimenter/nimbus-ui/src/components/FormBranches/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/components/FormBranches/mocks.tsx
@@ -14,6 +14,7 @@ type FormBranchProps = React.ComponentProps<typeof FormBranch>;
 export const SubjectBranch = ({
   fieldNamePrefix = "referenceBranch",
   branch = MOCK_ANNOTATED_BRANCH,
+  reviewErrors,
   equalRatio = false,
   isReference = false,
   experimentFeatureConfig = MOCK_FEATURE_CONFIG,
@@ -48,7 +49,7 @@ export const SubjectBranch = ({
             // react-hook-form types seem broken for nested fields
             touched: (touched.referenceBranch ||
               {}) as FormBranchProps["touched"],
-            reviewErrors: undefined,
+            reviewErrors,
             branch,
             isReference,
             equalRatio,


### PR DESCRIPTION
Opening initially as a draft so I can get a Storybook build to share around. Not entirely sure this is how we want the review feedback UI to work.

Also need to rework tests on both server and client side, but wanted to hold off on that until after getting some eyes on the UI.