### PR TITLE
[WIP] Validation UX docs for client-side, server-side, and "required for launch" errors

### DIFF
--- a/app/experimenter/nimbus-ui/.storybook/design-docs/DocsFormValidation/helpers.tsx
+++ b/app/experimenter/nimbus-ui/.storybook/design-docs/DocsFormValidation/helpers.tsx
@@ -1,0 +1,127 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React, { useCallback } from "react";
+import Form from "react-bootstrap/Form";
+import Alert from "react-bootstrap/Alert";
+
+import { Card, Table } from "react-bootstrap";
+import { useCommonForm } from "../../../src/hooks";
+import InlineErrorIcon from "../../../src/components/InlineErrorIcon";
+
+export const TestCases: React.FunctionComponent = ({ children }) => (
+  <Table>
+    <thead>
+      <tr>
+        <th className="w-50">Test Steps</th>
+        <th>Expected</th>
+      </tr>
+    </thead>
+    <tbody>{children}</tbody>
+  </Table>
+);
+
+type ProtoFormProps = {
+  demoInputs: Array<{
+    name: string;
+    label: string;
+    defaultValue: string;
+    required?: boolean;
+    requiredAtLaunch?: boolean;
+  }>;
+  isLoading: boolean;
+  isServerValid: boolean;
+  submitErrors: Record<string, string[]>;
+  setSubmitErrors: React.Dispatch<React.SetStateAction<Record<string, any>>>;
+  onSubmit: (data: Record<string, any>, reset: Function) => void;
+};
+
+export const ProtoForm = ({
+  demoInputs,
+  isLoading,
+  isServerValid,
+  onSubmit,
+  submitErrors,
+  setSubmitErrors,
+}: ProtoFormProps) => {
+  const defaultValues: Record<string, string> = {};
+  demoInputs.forEach(
+    ({ name, defaultValue }) => (defaultValues[name] = defaultValue),
+  );
+
+  const {
+    FormErrors,
+    formControlAttrs,
+    isValid,
+    handleSubmit,
+    reset,
+    isSubmitted,
+    getValues,
+  } = useCommonForm(
+    defaultValues,
+    isServerValid,
+    submitErrors,
+    setSubmitErrors,
+  );
+
+  const handleSubmitAfterValidation = useCallback(
+    (data: Record<string, any>) => {
+      if (isLoading) return;
+      onSubmit(data, reset);
+    },
+    [isLoading, onSubmit, reset],
+  );
+
+  return (
+    <Card className="mb-4">
+      <Card.Header>Example Form</Card.Header>
+      <Card.Body>
+        <Form
+          noValidate
+          onSubmit={handleSubmit(handleSubmitAfterValidation)}
+          validated={isSubmitted && isValid}
+        >
+          {submitErrors["*"] && (
+            <Alert data-testid="submit-error" variant="warning">
+              {submitErrors["*"]}
+            </Alert>
+          )}
+          {demoInputs.map(
+            ({ name, label, required = false, requiredAtLaunch }) => (
+              <Form.Group key={name} controlId={name}>
+                <Form.Label>
+                  {label}
+
+                  {requiredAtLaunch && !getValues(name) && (
+                    <InlineErrorIcon
+                      name={name}
+                      message={`A valid ${label} must be set`}
+                    />
+                  )}
+                </Form.Label>
+                <Form.Control
+                  {...formControlAttrs(name, { required })}
+                  type="text"
+                />
+                <FormErrors name={name} />
+              </Form.Group>
+            ),
+          )}
+
+          <div className="p-2">
+            <button
+              data-testid="submit-button"
+              type="submit"
+              onClick={handleSubmit(handleSubmitAfterValidation)}
+              className="btn btn-primary"
+              disabled={isLoading}
+            >
+              {isLoading ? <span>Saving</span> : <span>Save</span>}
+            </button>
+          </div>
+        </Form>
+      </Card.Body>
+    </Card>
+  );
+};

--- a/app/experimenter/nimbus-ui/.storybook/design-docs/DocsFormValidation/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/.storybook/design-docs/DocsFormValidation/index.stories.tsx
@@ -1,0 +1,190 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React, { useState, useCallback } from "react";
+import { storiesOf } from "@storybook/react";
+import { ProtoForm, TestCases } from "./helpers";
+import { Container, Alert } from "react-bootstrap";
+import LinkExternal from "../../../src/components/LinkExternal";
+import InlineErrorIcon from "../../../src/components/InlineErrorIcon";
+
+const MODELS_URL =
+  "https://github.com/mozilla/experimenter/blob/main/app/experimenter/experiments/models/nimbus.py";
+
+storiesOf("Design Docs/Form Validation", module)
+  .add("client-side validation", () => {
+    const [submitErrors, setSubmitErrors] = useState<Record<string, any>>({});
+
+    return (
+      <Container className="pt-5">
+        <h2>Client-side Validation</h2>
+        <p>
+          Client-side validation should be used to prevent invalid mutations
+          from being attempted (i.e. the wrong type or fields that cannot be{" "}
+          <code>null</code> in the{" "}
+          <LinkExternal href={MODELS_URL}>database</LinkExternal>
+          ). It should be used to validate fields that are required for launch
+          or to duplicate server-side validation.
+        </p>
+
+        <ProtoForm
+          demoInputs={[
+            {
+              name: "name",
+              label: "Branch Name",
+              defaultValue: "",
+              required: true,
+            },
+          ]}
+          isLoading={false}
+          isServerValid
+          submitErrors={submitErrors}
+          setSubmitErrors={setSubmitErrors}
+          onSubmit={() => {}}
+        />
+
+        <TestCases>
+          <tr>
+            <td>Clear the input and click elsewhere</td>
+            <td>
+              The input should be marked invalid and an error message should
+              appear.
+            </td>
+          </tr>
+          <tr>
+            <td>With the input still empty, click Save</td>
+            <td>
+              The input should focused and the error message should still
+              appear.
+              <Alert variant="danger">
+                The Save button should not be disabled if there are error
+                messages – instead, you should draw attention to the invalid
+                fields when the Save button is clicked.
+              </Alert>
+            </td>
+          </tr>
+          <tr>
+            <td>Start typing in the input</td>
+            <td>The input should become valid again.</td>
+          </tr>
+        </TestCases>
+      </Container>
+    );
+  })
+  .add("required for launch", () => {
+    const [submitErrors, setSubmitErrors] = useState<Record<string, any>>({});
+
+    return (
+      <Container className="pt-5">
+        <h2>Required for launch</h2>
+        <p>
+          Some fields like <code>publicDescription</code> are allowed to be{" "}
+          <code>null</code> while someone is editing a draft, but must be set
+          before the experiment can move to the review status. You should NOT
+          mark these fields <code>required</code>, but rather add an{" "}
+          <code>InlineErrorIcon</code> (
+          <InlineErrorIcon
+            name="example"
+            message="A tooltip hint about this being required to launch"
+          />
+          ) with a tooltip indicating they must be filled out before launch.
+        </p>
+        <ProtoForm
+          demoInputs={[
+            {
+              name: "name",
+              label: "Totally optional field",
+              defaultValue: "",
+            },
+            {
+              name: "publicDescription",
+              label: "Public Description",
+              defaultValue: "",
+              requiredAtLaunch: true,
+            },
+          ]}
+          isLoading={false}
+          isServerValid
+          {...{ submitErrors, setSubmitErrors }}
+          onSubmit={() => {}}
+        />
+
+        <TestCases>
+          <tr>
+            <td>Type something in the Public Description field.</td>
+            <td>The warning icon should disappear</td>
+          </tr>
+          <tr>
+            <td>Remove all the text from the Public Description field.</td>
+            <td>The warning icon should show up again.</td>
+          </tr>
+        </TestCases>
+      </Container>
+    );
+  })
+  .add("server-side validation", () => {
+    const [submitErrors, setSubmitErrors] = useState<Record<string, any>>({});
+    const [isServerValid, setIsServerValid] = useState(true);
+    const [isLoading, setLoading] = useState(false);
+
+    const onFormSubmit = useCallback(async ({ name }: Record<string, any>) => {
+      setLoading(true);
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+      setLoading(false);
+      if (name === "really common name") {
+        setIsServerValid(false);
+        setSubmitErrors({ name: ["That name is taken."] });
+      } else {
+        setSubmitErrors({});
+        setIsServerValid(true);
+      }
+    }, []);
+
+    return (
+      <Container className="pt-5">
+        <h2>Server-side Validation</h2>
+        <p>
+          In general, validation (other than required values and type checking)
+          should be done server-side at Save/Submit time.
+        </p>
+
+        <ProtoForm
+          demoInputs={[
+            { name: "name", label: "Name", defaultValue: "really common name" },
+          ]}
+          isLoading={false}
+          isServerValid={isServerValid}
+          {...{ submitErrors, setSubmitErrors }}
+          setSubmitErrors={setSubmitErrors}
+          onSubmit={onFormSubmit}
+        />
+
+        <TestCases>
+          <tr>
+            <td>
+              Press the <code>Save</code> button. (The input value should be{" "}
+              <code>really common name</code>, which the fake server will reject
+              as already taken).
+            </td>
+            <td>
+              The button should say <code>Saving</code> and be disabled while
+              the server is waiting to respond. <br />
+              The input is marked as invalid and has an error message.
+            </td>
+          </tr>
+          <tr>
+            <td>Change the text to something else.</td>
+            <td>
+              As you start typing, the input should be marked as valid again and
+              the error message should disapear.
+            </td>
+          </tr>
+          <tr>
+            <td>Re-submit the form</td>
+            <td>The input should remain in a valid state.</td>
+          </tr>
+        </TestCases>
+      </Container>
+    );
+  });

--- a/app/experimenter/nimbus-ui/.storybook/main.js
+++ b/app/experimenter/nimbus-ui/.storybook/main.js
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 module.exports = {
-  stories: ["../src/**/*.stories.tsx"],
+  stories: ["./design-docs/**/*.stories.tsx", "../src/**/*.stories.tsx"],
   addons: [
     "@storybook/addon-actions",
     "@storybook/addon-links",

--- a/app/experimenter/nimbus-ui/README.md
+++ b/app/experimenter/nimbus-ui/README.md
@@ -89,11 +89,35 @@ export interface GetExperimentOverviews {
 
 This app has an [`AppErrorBoundary`](./src/components/AppErrorBoundary/index.tsx) that will capture any uncaught error that occurs and report them to Sentry. This acts as our last line of defense, but ideally we are able to handle errors before they get to this stage. As well, errors that we wish to display to the user should generally be handled in a consistent fashion.
 
-There are two types of errors to account for:
+### General errors
 
-### Validation errors
+General errors can occur when an operation fails altogether. This could be for any reason, such as when a network request fails, or a bad code path raises an exception. For these errors you'll use React Bootstrap's [`Alert`](https://react-bootstrap.github.io/components/alerts/) components.
 
-These occur when you try to create or modify a record and the server tells us that one or more fields provided incorrect data. For these you should use React Bootstrap's [`Form.Control.Feedback`](https://react-bootstrap.github.io/components/forms/#form-control-feedback-props) component in combination with other form components.
+For example, if error occurs while saving a record:
+
+```tsx
+<Alert variant="warning">Sorry, there was a problem.</Alert>
+```
+
+_Note:_ displaying technical error messages to the user may not be very helpful, so it's generally advised to either provide a [generic message](./src/lib/constants.ts) or instructions on what to do.
+
+## Form Validation
+
+**See the form validation section of [Storybook](https://storage.googleapis.com/mozilla-storybooks-experimenter/index.html) for much more detailed info and examples**
+
+There are three kinds of validation that need to be applied to forms: client-side, server-side, and "required for launch". For a visual guide to the interaction UX, see this STORYBOOK LINK
+
+#### Client-side validation errors
+
+Client-side validation should be used to prevent invalid mutations from being attempted (i.e. the wrong type or fields that cannot be `null` in the database). It should NOT be used to validate fields that are required for launch or to duplicate server-side validation.
+
+#### Required for launch validation
+
+Some fields like `publicDescription` are allowed to be `null` while someone is editing a draft, but must be set before the experiment can move to the `review` status. You should NOT mark these fields `required`, but rather add help text that indicates they must be filled out before launch.
+
+#### Server-side validation
+
+These occur when you try to create or modify a record and the server tells us that one or more fields provided incorrect data. For these you should use the `useCommonForm` hook or React Bootstrap's [`Form.Control.Feedback`](https://react-bootstrap.github.io/components/forms/#form-control-feedback-props) component in combination with other form components.
 
 A basic example might look like this:
 
@@ -109,18 +133,6 @@ A basic example might look like this:
   )}
 </Form.Group>
 ```
-
-### General errors
-
-General errors can occur when an operation fails altogether. This could be for any reason, such as when a network request fails, or a bad code path raises an exception. For these errors you'll use React Bootstrap's [`Alert`](https://react-bootstrap.github.io/components/alerts/) components.
-
-For example, if error occurs while saving a record:
-
-```tsx
-<Alert variant="warning">Sorry, there was a problem.</Alert>
-```
-
-_Note:_ displaying technical error messages to the user may not be very helpful, so it's generally advised to either provide a [generic message](./src/lib/constants.ts) or instructions on what to do.
 
 ## Handling GraphQL operation errors
 


### PR DESCRIPTION
Ok, here's my proposal for the form validation UX: 

## Form Validation

There are three kinds of validation that need to be applied to forms: client-side, server-side, and "required for launch". For a visual guide to the interaction UX, see this [storybook section](https://storage.googleapis.com/mozilla-storybooks-experimenter/commits/549c3eca94388859174185b1a95f6bdbb75afc73/nimbus-ui/index.html?path=/story/docs-form-validation--client-side-validation).

#### Client-side validation errors

Client-side validation should be used to prevent invalid mutations from being attempted (i.e. the wrong type or fields that cannot be `null` in the database). It should NOT be used to validate fields that are required for launch or to duplicate server-side validation.

#### Required for launch validation

Some fields like `publicDescription` are allowed to be `null` while someone is editing a draft, but must be set before the experiment can move to the `review` status. You should NOT mark these fields `required`, but rather add help text that indicates they must be filled out before launch.

#### Server-side validation

These occur when you try to create or modify a record and the server tells us that one or more fields provided incorrect data. For these you should use the `useCommonForm` hook or React Bootstrap's [`Form.Control.Feedback`](https://react-bootstrap.github.io/components/forms/#form-control-feedback-props) component in combination with other form components.

A basic example might look like this:

```tsx
<Form.Group controlId="description">
  <Form.Label>Description</Form.Label>
  <Form.Control type="text" autoFocus />
  <Form.Text>This is the description.</Form.Text>
  {errors["description"] && (
    <Form.Control.Feedback type="invalid">
      {errors["description"].message}
    </Form.Control.Feedback>
  )}
</Form.Group>
```