### PR TITLE
fixes mozilla/jetstream#385: GS_LOCATION statistics prefix

### DIFF
--- a/app/experimenter/settings.py
+++ b/app/experimenter/settings.py
@@ -405,5 +405,6 @@ KINTO_COLLECTION_NIMBUS_MOBILE = "nimbus-mobile-experiments"
 DEFAULT_FILE_STORAGE = "storages.backends.gcloud.GoogleCloudStorage"
 GS_PROJECT_ID = "experiments-analysis"
 GS_BUCKET_NAME = "mozanalysis"
+GS_LOCATION = "statistics"
 
 NIMBUS_SCHEMA_VERSION = pkg_resources.get_distribution("mozilla-nimbus-shared").version


### PR DESCRIPTION
Depends on https://github.com/mozilla/jetstream/pull/386 (so they should be merged together)