### PR TITLE
Few small cosmetic Nimbus tweaks

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/FormOverview/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/FormOverview/index.test.tsx
@@ -25,8 +25,9 @@ describe("FormOverview", () => {
   });
 
   it("calls onNext when next clicked", async () => {
+    const { experiment } = mockExperimentQuery("boo");
     const onNext = jest.fn();
-    render(<Subject {...{ onNext }} />);
+    render(<Subject {...{ onNext, experiment }} />);
 
     const nextButton = screen.getByText("Next");
     await act(async () => void fireEvent.click(nextButton));
@@ -80,7 +81,7 @@ describe("FormOverview", () => {
     const onSubmit = jest.fn();
     render(<Subject {...{ onSubmit }} />);
 
-    const submitButton = screen.getByText("Create experiment");
+    const submitButton = screen.getByText("Next");
     await act(async () => fillOutNewForm(expected));
     await act(async () => void fireEvent.click(submitButton));
 

--- a/app/experimenter/nimbus-ui/src/components/FormOverview/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/FormOverview/index.tsx
@@ -187,7 +187,7 @@ const FormOverview = ({
       )}
 
       <div className="d-flex flex-row-reverse bd-highlight">
-        {onNext && (
+        {!!experiment && onNext && (
           <div className="p-2">
             <button
               onClick={handleNext}
@@ -211,7 +211,7 @@ const FormOverview = ({
             {isLoading ? (
               <span>{experiment ? "Saving" : "Submitting"}</span>
             ) : (
-              <span>{experiment ? "Save" : "Create experiment"}</span>
+              <span>{experiment ? "Save" : "Next"}</span>
             )}
           </button>
         </div>

--- a/app/experimenter/nimbus-ui/src/components/HeaderExperiment/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/HeaderExperiment/index.tsx
@@ -26,7 +26,7 @@ const HeaderExperiment = ({ name, slug, status }: HeaderExperimentProps) => (
     </p>
     <p className="header-experiment-status position-relative mt-2 d-inline-block">
       <StatusPill label="Draft" active={status.draft} />
-      <StatusPill label="Review" active={status.review} />
+      <StatusPill label="Review" active={status.review || status.accepted} />
       <StatusPill label="Live" active={status.live} />
       <StatusPill label="Complete" active={status.complete} padded={false} />
     </p>

--- a/app/experimenter/nimbus-ui/src/components/SummaryTimeline/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/SummaryTimeline/index.tsx
@@ -64,9 +64,11 @@ const StartEnd = ({
         <span className="flex-fill" data-testid="label-start-date">
           {humanDate(startDate!)}
         </span>
-        <span className="flex-fill text-right" data-testid="label-end-date">
-          {humanDate(endDate!)}
-        </span>
+        {endDate && (
+          <span className="flex-fill text-right" data-testid="label-end-date">
+            {humanDate(endDate!)}
+          </span>
+        )}
       </>
     )}
   </div>

--- a/app/experimenter/nimbus-ui/src/lib/dateUtils.test.ts
+++ b/app/experimenter/nimbus-ui/src/lib/dateUtils.test.ts
@@ -35,7 +35,7 @@ describe("getProposedEndDate", () => {
         proposedDuration: 2,
       }),
     );
-    expect(actual).toBe("Dec 14");
+    expect(actual).toBe("Dec 14, 2020");
   });
   it("should render a duration if no startDate is set", () => {
     const actual = getProposedEndDate(
@@ -71,7 +71,7 @@ describe("getProposedEnrollmentRange", () => {
         proposedEnrollment: 4,
       }),
     );
-    expect(actual).toBe("Dec 12 to Dec 16");
+    expect(actual).toBe("Dec 12, 2020 to Dec 16, 2020");
   });
   it("should render the enrollment duration if no startDate is set", () => {
     const actual = getProposedEnrollmentRange(

--- a/app/experimenter/nimbus-ui/src/lib/dateUtils.ts
+++ b/app/experimenter/nimbus-ui/src/lib/dateUtils.ts
@@ -10,6 +10,7 @@ export function humanDate(date: string): string {
   return new Date(date).toLocaleString("en-US", {
     month: "short",
     day: "numeric",
+    year: "numeric",
   });
 }
 


### PR DESCRIPTION
Closes #4186
Closes #4206
Closes #4268

Nothing major, just a few small changes I did before holidays:

- Start using the Review label when the experiment is an the Approved state
- Don't render a timeline end date if it does not exist to avoid getting a bad date
- Use "Next" instead of "Create Experiment" when submitting new experiment form
- Adds the Year back to the `humanDate` helper