### PR TITLE
fixes #4297 feat(nimbus): move NotSet into its own component

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/DirectoryTable/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/DirectoryTable/index.tsx
@@ -6,12 +6,12 @@ import React from "react";
 import { getAllExperiments_experiments } from "../../types/getAllExperiments";
 import { Link } from "@reach/router";
 import LinkExternal from "../LinkExternal";
+import NotSet from "../NotSet";
 import {
   getProposedEndDate,
   getProposedEnrollmentRange,
   humanDate,
 } from "../../lib/dateUtils";
-import { NotSet } from "../Summary";
 
 // These are all render functions for column type sin the table.
 export type ColumnComponent = React.FC<getAllExperiments_experiments>;

--- a/app/experimenter/nimbus-ui/src/components/NotSet/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/NotSet/index.stories.tsx
@@ -1,0 +1,9 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from "react";
+import { storiesOf } from "@storybook/react";
+import NotSet from ".";
+
+storiesOf("Components/NotSet", module).add("basic", () => <NotSet />);

--- a/app/experimenter/nimbus-ui/src/components/NotSet/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/NotSet/index.tsx
@@ -1,0 +1,17 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from "react";
+
+const NotSet = ({
+  "data-testid": testid = "not-set",
+}: {
+  "data-testid"?: string;
+}) => (
+  <span className="text-danger" data-testid={testid}>
+    Not set
+  </span>
+);
+
+export default NotSet;

--- a/app/experimenter/nimbus-ui/src/components/Summary/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/index.tsx
@@ -11,6 +11,7 @@ import LinkExternal from "../LinkExternal";
 import { getStatus } from "../../lib/experiment";
 import MonitoringLink from "../MonitoringLink";
 import { getConfigLabel, ConfigOptions } from "../../lib/getConfigLabel";
+import NotSet from "../NotSet";
 
 type SummaryProps = {
   experiment: getExperiment_experimentBySlug;
@@ -53,15 +54,5 @@ export const displayConfigLabelOrNotSet = (
   if (!value) return <NotSet />;
   return getConfigLabel(value, options);
 };
-
-export const NotSet = ({
-  "data-testid": testid = "not-set",
-}: {
-  "data-testid"?: string;
-}) => (
-  <span className="text-danger" data-testid={testid}>
-    Not set
-  </span>
-);
 
 export default Summary;

--- a/app/experimenter/nimbus-ui/src/components/SummaryTimeline/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/SummaryTimeline/index.tsx
@@ -6,7 +6,7 @@ import React from "react";
 import ProgressBar from "react-bootstrap/ProgressBar";
 import pluralize from "../../lib/pluralize";
 import { getExperiment_experimentBySlug } from "../../types/getExperiment";
-import { NotSet } from "../Summary";
+import NotSet from "../NotSet";
 import { getStatus, StatusCheck } from "../../lib/experiment";
 import { humanDate } from "../../lib/dateUtils";
 

--- a/app/experimenter/nimbus-ui/src/components/TableAudience/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/TableAudience/index.tsx
@@ -6,7 +6,8 @@ import React from "react";
 import { getExperiment_experimentBySlug } from "../../types/getExperiment";
 import { Table } from "react-bootstrap";
 import { useConfig } from "../../hooks";
-import { displayConfigLabelOrNotSet, NotSet } from "../Summary";
+import { displayConfigLabelOrNotSet } from "../Summary";
+import NotSet from "../NotSet";
 
 type TableAudienceProps = {
   experiment: getExperiment_experimentBySlug;

--- a/app/experimenter/nimbus-ui/src/components/TableSummary/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/TableSummary/index.tsx
@@ -6,8 +6,9 @@ import React from "react";
 import { getExperiment_experimentBySlug } from "../../types/getExperiment";
 import { Table } from "react-bootstrap";
 import { useConfig } from "../../hooks";
-import { displayConfigLabelOrNotSet, NotSet } from "../Summary";
+import { displayConfigLabelOrNotSet } from "../Summary";
 import RichText from "../RichText";
+import NotSet from "../NotSet";
 
 type TableSummaryProps = {
   experiment: getExperiment_experimentBySlug;


### PR DESCRIPTION
Closes #4297

Real simple, just moves the simple `NotSet` label component out of the `Summary` component file and into its own file.