### PR TITLE
fixes #4230 fix(nimbus): Results page analysis unavailable error

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/AppLayoutWithSidebar/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/AppLayoutWithSidebar/index.stories.tsx
@@ -56,6 +56,16 @@ storiesOf("components/AppLayoutWithSidebar", module)
       </AppLayoutWithSidebar>
     </RouterSlugProvider>
   ))
+  .add("analysis results error", () => (
+    <RouterSlugProvider>
+      <AppLayoutWithSidebar
+        status={mockGetStatus(NimbusExperimentStatus.LIVE)}
+        analysisError={new Error("Boop")}
+      >
+        <p>App contents go here</p>
+      </AppLayoutWithSidebar>
+    </RouterSlugProvider>
+  ))
   .add("has analysis results", () => (
     <RouterSlugProvider>
       <AppLayoutWithSidebar

--- a/app/experimenter/nimbus-ui/src/components/AppLayoutWithSidebar/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/AppLayoutWithSidebar/index.test.tsx
@@ -21,6 +21,7 @@ const { mock } = mockExperimentQuery("my-special-slug");
 const Subject = ({
   status = NimbusExperimentStatus.DRAFT,
   withAnalysis = false,
+  analysisError,
   review,
 }: RouteComponentProps & {
   status?: NimbusExperimentStatus;
@@ -29,12 +30,14 @@ const Subject = ({
     invalidPages: string[];
   };
   withAnalysis?: boolean;
+  analysisError?: boolean;
 }) => (
   <RouterSlugProvider mocks={[mock]} path="/my-special-slug/edit">
     <AppLayoutWithSidebar
       {...{
         status: mockGetStatus(status),
         review,
+        analysisError: analysisError ? new Error("boop") : undefined,
         analysis: withAnalysis
           ? {
               show_analysis: true,
@@ -190,12 +193,23 @@ describe("AppLayoutWithSidebar", () => {
       );
     });
 
-    it("when accepted displays design link and disabled results item", async () => {
+    it("when accepted, displays design link and disabled results item", async () => {
       render(<Subject status={NimbusExperimentStatus.ACCEPTED} />);
 
       expect(screen.queryByTestId("show-no-results")).toBeInTheDocument();
       expect(screen.queryByTestId("show-no-results")).toHaveTextContent(
         "Waiting for experiment to launch",
+      );
+    });
+
+    it("when complete and analysis results fetch errors", async () => {
+      render(
+        <Subject status={NimbusExperimentStatus.COMPLETE} analysisError />,
+      );
+
+      expect(screen.queryByTestId("show-no-results")).toBeInTheDocument();
+      expect(screen.queryByTestId("show-no-results")).toHaveTextContent(
+        "Could not get visualization data. Please contact data science",
       );
     });
 

--- a/app/experimenter/nimbus-ui/src/components/AppLayoutWithSidebar/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/AppLayoutWithSidebar/index.tsx
@@ -11,6 +11,7 @@ import Nav from "react-bootstrap/Nav";
 import classNames from "classnames";
 import { BASE_PATH } from "../../lib/constants";
 import { AnalysisData } from "../../lib/visualization/types";
+import { analysisAvailable } from "../../lib/visualization/utils";
 import { StatusCheck } from "../../lib/experiment";
 import { ReactComponent as ChevronLeft } from "./chevron-left.svg";
 import { ReactComponent as Cog } from "./cog.svg";
@@ -22,6 +23,7 @@ import { ReactComponent as NotAllowed } from "./not-allowed.svg";
 import { ReactComponent as AlertCircle } from "./alert-circle.svg";
 import { ReactComponent as BarChart } from "./bar-chart.svg";
 import "./index.scss";
+import LinkExternal from "../LinkExternal";
 
 type AppLayoutWithSidebarProps = {
   testid?: string;
@@ -32,6 +34,7 @@ type AppLayoutWithSidebarProps = {
     ready: boolean;
   };
   analysis?: AnalysisData;
+  analysisError?: Error;
 } & RouteComponentProps;
 
 const editPages = [
@@ -63,6 +66,7 @@ export const AppLayoutWithSidebar = ({
   status,
   review,
   analysis,
+  analysisError,
 }: AppLayoutWithSidebarProps) => {
   const { slug } = useParams();
 
@@ -95,7 +99,7 @@ export const AppLayoutWithSidebar = ({
                     <Clipboard className="sidebar-icon" />
                     Design
                   </LinkNav>
-                  {analysis?.show_analysis ? (
+                  {analysisAvailable(analysis) ? (
                     <LinkNav
                       route={`${slug}/results`}
                       storiesOf={"pages/Results"}
@@ -106,9 +110,20 @@ export const AppLayoutWithSidebar = ({
                     </LinkNav>
                   ) : (
                     <DisabledItem name="Results" testId="show-no-results">
-                      {status?.accepted
-                        ? "Waiting for experiment to launch"
-                        : "Experiment results not yet ready"}
+                      {status?.accepted ? (
+                        "Waiting for experiment to launch"
+                      ) : analysisError ? (
+                        <>
+                          Could not get visualization data. Please contact data
+                          science in{" "}
+                          <LinkExternal href="https://mozilla.slack.com/archives/C0149JH7C1M">
+                            #cirrus
+                          </LinkExternal>
+                          .
+                        </>
+                      ) : (
+                        "Experiment results not yet ready"
+                      )}
                     </DisabledItem>
                   )}
                 </>

--- a/app/experimenter/nimbus-ui/src/components/PageResults/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/index.stories.tsx
@@ -18,31 +18,10 @@ const { mock } = mockExperimentQuery("demo-slug", {
 
 storiesOf("pages/Results", module)
   .addDecorator(withLinks)
-  .add("basic, analysis available", () => {
+  .add("basic", () => {
     fetchMock
       .restore()
       .getOnce("/api/v3/visualization/demo-slug/", mockAnalysis());
-    return (
-      <RouterSlugProvider mocks={[mock]}>
-        <PageResults />
-      </RouterSlugProvider>
-    );
-  })
-  .add("analysis unavailable", () => {
-    fetchMock
-      .restore()
-      .getOnce(
-        "/api/v3/visualization/demo-slug/",
-        mockAnalysis({ show_analysis: false }),
-      );
-    return (
-      <RouterSlugProvider mocks={[mock]}>
-        <PageResults />
-      </RouterSlugProvider>
-    );
-  })
-  .add("analysis fetch errors", () => {
-    fetchMock.restore().getOnce("/api/v3/visualization/demo-slug/", 500);
     return (
       <RouterSlugProvider mocks={[mock]}>
         <PageResults />

--- a/app/experimenter/nimbus-ui/src/components/PageResults/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/index.test.tsx
@@ -8,7 +8,10 @@ import fetchMock from "jest-fetch-mock";
 import PageResults from ".";
 import { RouterSlugProvider } from "../../lib/test-utils";
 import { mockExperimentQuery } from "../../lib/mocks";
-import { mockAnalysis } from "../../lib/visualization/mocks";
+import {
+  mockAnalysis,
+  MOCK_UNAVAILABLE_ANALYSIS,
+} from "../../lib/visualization/mocks";
 import AppLayoutWithExperiment from "../AppLayoutWithExperiment";
 import { AnalysisData } from "../../lib/visualization/types";
 import { getStatus as mockGetStatus } from "../../lib/experiment";
@@ -74,29 +77,6 @@ describe("PageResults", () => {
     });
   });
 
-  it("fetches analysis data and displays as expected when analysis is not ready", async () => {
-    mockAnalysisData = mockAnalysis({ show_analysis: false });
-
-    render(<Subject />);
-
-    await waitFor(() => {
-      expect(screen.queryByTestId("PageResults")).toBeInTheDocument();
-    });
-    expect(screen.queryByTestId("analysis-unavailable")).toBeInTheDocument();
-    expect(screen.queryByTestId("summary")).toBeInTheDocument();
-  });
-
-  it("displays analysis error when analysis fetch error occurs", async () => {
-    mockAnalysisData = undefined;
-
-    render(<Subject />);
-
-    await waitFor(() => {
-      expect(screen.queryByTestId("PageResults")).toBeInTheDocument();
-    });
-    expect(screen.queryByTestId("analysis-error")).toBeInTheDocument();
-  });
-
   it("redirects to the edit overview page if the experiment status is draft", async () => {
     mockExperiment = mockExperimentQuery("demo-slug", {
       status: NimbusExperimentStatus.DRAFT,
@@ -113,8 +93,17 @@ describe("PageResults", () => {
     expect(redirectPath).toEqual("edit/overview");
   });
 
-  it("redirects to the design page if the analysis results are not ready", async () => {
+  it("redirects to the design page if the visualization flag is set to false", async () => {
     mockAnalysisData = mockAnalysis({ show_analysis: false });
+    mockExperiment = mockExperimentQuery("demo-slug", {
+      status: NimbusExperimentStatus.COMPLETE,
+    }).experiment;
+    render(<Subject />);
+    expect(redirectPath).toEqual("design");
+  });
+
+  it("redirects to the design page if the visualization results are not ready", async () => {
+    mockAnalysisData = MOCK_UNAVAILABLE_ANALYSIS;
     mockExperiment = mockExperimentQuery("demo-slug", {
       status: NimbusExperimentStatus.COMPLETE,
     }).experiment;

--- a/app/experimenter/nimbus-ui/src/components/PageResults/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/index.tsx
@@ -5,17 +5,14 @@
 import React from "react";
 import { RouteComponentProps } from "@reach/router";
 import AppLayoutWithExperiment from "../AppLayoutWithExperiment";
-import { Alert } from "react-bootstrap";
-import { getExperiment_experimentBySlug } from "../../types/getExperiment";
 import LinkExternal from "../LinkExternal";
 import TableResults from "../TableResults";
 import TableHighlights from "../TableHighlights";
 import TableHighlightsOverview from "../TableHighlightsOverview";
 import TableMetricPrimary from "../TableMetricPrimary";
 import TableMetricSecondary from "../TableMetricSecondary";
-import { AnalysisData } from "../../lib/visualization/types";
-import Summary from "../Summary";
 import MonitoringLink from "../MonitoringLink";
+import { analysisAvailable } from "../../lib/visualization/utils";
 
 const PageResults: React.FunctionComponent<RouteComponentProps> = () => (
   <AppLayoutWithExperiment
@@ -27,125 +24,79 @@ const PageResults: React.FunctionComponent<RouteComponentProps> = () => (
         return "edit/overview";
       }
 
-      if (analysis?.show_analysis === false) {
+      if (!analysisAvailable(analysis)) {
         return "design";
       }
     }}
   >
-    {({ experiment, analysis }) => (
-      <>
-        <MonitoringLink {...experiment} />
-        {analysis?.show_analysis ? (
-          <AnalysisAvailable {...{ experiment, analysis }} />
-        ) : (
-          <AnalysisUnavailable {...{ experiment, error: analysis == null }} />
-        )}
-      </>
-    )}
+    {({ experiment, analysis }) => {
+      // For testing - users will be redirected if the analysis is unavailable
+      // before reaching this return, but tests reach this return and
+      // analysis.overall is expected to be an object (EXP-800)
+      if (!analysisAvailable(analysis)) return <></>;
+
+      const slugUnderscored = experiment.slug.replace(/-/g, "_");
+      return (
+        <>
+          <MonitoringLink {...experiment} />
+          <h3 className="h5 mb-3 mt-4">Overview</h3>
+          <p className="mb-4">
+            Detailed analysis{" "}
+            <LinkExternal
+              href={`https://protosaur.dev/partybal/${slugUnderscored}.html`}
+              data-testid="link-external-results"
+            >
+              can be found here
+            </LinkExternal>
+            .
+          </p>
+          <h3 className="h6">Hypothesis</h3>
+          <p>{experiment.hypothesis}</p>
+          <TableHighlights
+            primaryProbeSets={experiment.primaryProbeSets!}
+            results={analysis?.overall!}
+          />
+          <TableHighlightsOverview
+            {...{ experiment }}
+            results={analysis?.overall!}
+          />
+
+          <h2 className="h5 mb-3">Results</h2>
+          <TableResults
+            primaryProbeSets={experiment.primaryProbeSets!}
+            results={analysis?.overall!}
+          />
+          <div>
+            {experiment.primaryProbeSets?.map((probeSet) => (
+              <TableMetricPrimary
+                key={probeSet?.slug}
+                results={analysis?.overall!}
+                probeSet={probeSet!}
+              />
+            ))}
+            {experiment.secondaryProbeSets?.map((probeSet) => (
+              <TableMetricSecondary
+                key={probeSet!.slug}
+                results={analysis?.overall!}
+                probeSetSlug={probeSet!.slug}
+                probeSetName={probeSet!.name}
+                isDefault={false}
+              />
+            ))}
+            {analysis?.other_metrics &&
+              Object.keys(analysis.other_metrics).map((metric) => (
+                <TableMetricSecondary
+                  key={metric}
+                  results={analysis?.overall!}
+                  probeSetSlug={metric}
+                  probeSetName={analysis!.other_metrics![metric]}
+                />
+              ))}
+          </div>
+        </>
+      );
+    }}
   </AppLayoutWithExperiment>
-);
-
-const AnalysisAvailable = ({
-  experiment,
-  analysis,
-}: {
-  experiment: getExperiment_experimentBySlug;
-  analysis: AnalysisData | undefined;
-}) => {
-  const slugUnderscored = experiment.slug.replace(/-/g, "_");
-  return (
-    <>
-      <h3 className="h5 mb-3 mt-4">Overview</h3>
-      <p className="mb-4">
-        Detailed analysis{" "}
-        <LinkExternal
-          href={`https://protosaur.dev/partybal/${slugUnderscored}.html`}
-          data-testid="link-external-results"
-        >
-          can be found here
-        </LinkExternal>
-        .
-      </p>
-      <h3 className="h6">Hypothesis</h3>
-      <p>{experiment.hypothesis}</p>
-      <TableHighlights
-        primaryProbeSets={experiment.primaryProbeSets!}
-        results={analysis?.overall!}
-      />
-      <TableHighlightsOverview
-        {...{ experiment }}
-        results={analysis?.overall!}
-      />
-
-      <h2 className="h5 mb-3">Results</h2>
-      <TableResults
-        primaryProbeSets={experiment.primaryProbeSets!}
-        results={analysis?.overall!}
-      />
-      <div>
-        {experiment.primaryProbeSets?.map((probeSet) => (
-          <TableMetricPrimary
-            key={probeSet?.slug}
-            results={analysis?.overall!}
-            probeSet={probeSet!}
-          />
-        ))}
-        {experiment.secondaryProbeSets?.map((probeSet) => (
-          <TableMetricSecondary
-            key={probeSet!.slug}
-            results={analysis?.overall!}
-            probeSetSlug={probeSet!.slug}
-            probeSetName={probeSet!.name}
-            isDefault={false}
-          />
-        ))}
-        {Object.keys(analysis?.other_metrics!).map((metric) => (
-          <TableMetricSecondary
-            key={metric}
-            results={analysis?.overall!}
-            probeSetSlug={metric}
-            probeSetName={analysis!.other_metrics![metric]}
-          />
-        ))}
-      </div>
-    </>
-  );
-};
-
-const AlertError = () => (
-  <Alert data-testid="analysis-error" variant="warning" className="my-4">
-    Could not load experiment analysis data. Please contact data science in{" "}
-    <LinkExternal href="https://mozilla.slack.com/archives/C0149JH7C1M">
-      #cirrus
-    </LinkExternal>{" "}
-    about this.
-  </Alert>
-);
-
-const AlertUnavailable = () => (
-  <Alert data-testid="analysis-unavailable" variant="warning" className="my-4">
-    <p>
-      <strong>The analysis is not yet available.</strong>
-    </p>
-    <p className="mb-0">
-      {" "}
-      The results will be available 7 days after the experiment is launched. An
-      email will be sent to you once we start recording data.
-    </p>
-  </Alert>
-);
-
-const AnalysisUnavailable = ({
-  experiment,
-  error,
-}: {
-  experiment: getExperiment_experimentBySlug;
-  error: boolean;
-}) => (
-  <>
-    {error ? <AlertError /> : <AlertUnavailable />}
-    <Summary {...{ experiment }} />
-  </>
 );
 
 export default PageResults;

--- a/app/experimenter/nimbus-ui/src/components/TableHighlights/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/TableHighlights/index.tsx
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React from "react";
-import { AnalysisData } from "../../lib/visualization/types";
+import { AnalysisDataOverall } from "../../lib/visualization/types";
 import {
   HIGHLIGHTS_METRICS_LIST,
   METRICS_TIPS,
@@ -19,7 +19,7 @@ import { ReactComponent as Info } from "../../images/info.svg";
 
 type TableHighlightsProps = {
   primaryProbeSets: (getExperiment_experimentBySlug_primaryProbeSets | null)[];
-  results: AnalysisData["overall"];
+  results: AnalysisDataOverall;
 };
 
 const getHighlightMetrics = (

--- a/app/experimenter/nimbus-ui/src/components/TableHighlightsOverview/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/TableHighlightsOverview/index.tsx
@@ -4,13 +4,13 @@
 
 import React from "react";
 import { getExperiment_experimentBySlug } from "../../types/getExperiment";
-import { AnalysisData } from "../../lib/visualization/types";
+import { AnalysisDataOverall } from "../../lib/visualization/types";
 import { useConfig } from "../../hooks";
 import { getConfigLabel } from "../../lib/getConfigLabel";
 
 type TableHighlightsOverviewProps = {
   experiment: getExperiment_experimentBySlug;
-  results: AnalysisData["overall"];
+  results: AnalysisDataOverall;
 };
 
 const TableHighlightsOverview = ({

--- a/app/experimenter/nimbus-ui/src/components/TableMetricPrimary/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/TableMetricPrimary/index.tsx
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React from "react";
-import { AnalysisData } from "../../lib/visualization/types";
+import { AnalysisDataOverall } from "../../lib/visualization/types";
 import TableVisualizationRow from "../TableVisualizationRow";
 import { getExperiment_experimentBySlug_primaryProbeSets } from "../../types/getExperiment";
 import {
@@ -20,7 +20,7 @@ type PrimaryMetricStatistic = {
 };
 
 type TableMetricPrimaryProps = {
-  results: AnalysisData["overall"];
+  results: AnalysisDataOverall;
   probeSet: getExperiment_experimentBySlug_primaryProbeSets;
 };
 

--- a/app/experimenter/nimbus-ui/src/components/TableMetricSecondary/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/TableMetricSecondary/index.tsx
@@ -9,7 +9,7 @@ import {
   TABLE_LABEL,
   METRIC_TYPE,
 } from "../../lib/visualization/constants";
-import { AnalysisData } from "../../lib/visualization/types";
+import { AnalysisDataOverall } from "../../lib/visualization/types";
 import TableVisualizationRow from "../TableVisualizationRow";
 
 type SecondaryMetricStatistic = {
@@ -20,7 +20,7 @@ type SecondaryMetricStatistic = {
 };
 
 type TableMetricSecondaryProps = {
-  results: AnalysisData["overall"];
+  results: AnalysisDataOverall;
   probeSetSlug: string;
   probeSetName: string;
   isDefault?: boolean;

--- a/app/experimenter/nimbus-ui/src/components/TableResults/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/TableResults/index.tsx
@@ -9,14 +9,14 @@ import {
   METRIC_TYPE,
   TABLE_LABEL,
 } from "../../lib/visualization/constants";
-import { AnalysisData } from "../../lib/visualization/types";
+import { AnalysisDataOverall } from "../../lib/visualization/types";
 import { getTableDisplayType } from "../../lib/visualization/utils";
 import { getExperiment_experimentBySlug_primaryProbeSets } from "../../types/getExperiment";
 import TableVisualizationRow from "../TableVisualizationRow";
 
 type TableResultsProps = {
   primaryProbeSets: (getExperiment_experimentBySlug_primaryProbeSets | null)[];
-  results: AnalysisData["overall"];
+  results: AnalysisDataOverall;
 };
 
 const getResultMetrics = (

--- a/app/experimenter/nimbus-ui/src/lib/visualization/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/lib/visualization/mocks.tsx
@@ -4,6 +4,13 @@
 
 import { SIGNIFICANCE } from "./constants";
 
+export const MOCK_UNAVAILABLE_ANALYSIS = {
+  show_analysis: true,
+  daily: null,
+  weekly: null,
+  overall: null,
+};
+
 export const mockAnalysis = (modifications = {}) =>
   Object.assign(
     {

--- a/app/experimenter/nimbus-ui/src/lib/visualization/types.ts
+++ b/app/experimenter/nimbus-ui/src/lib/visualization/types.ts
@@ -3,12 +3,14 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 export interface AnalysisData {
-  daily: AnalysisPoint[];
-  weekly: AnalysisPoint[];
-  overall: { [branch: string]: BranchDescription };
+  daily: AnalysisPoint[] | null;
+  weekly: AnalysisPoint[] | null;
+  overall: { [branch: string]: BranchDescription } | null;
   show_analysis: boolean;
   other_metrics?: { [metric: string]: string };
 }
+
+export type AnalysisDataOverall = Exclude<AnalysisData["overall"], null>;
 
 export interface AnalysisPoint {
   metric: string;

--- a/app/experimenter/nimbus-ui/src/lib/visualization/utils.tsx
+++ b/app/experimenter/nimbus-ui/src/lib/visualization/utils.tsx
@@ -3,6 +3,12 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { DISPLAY_TYPE, METRIC, TABLE_LABEL } from "./constants";
+import { AnalysisData } from "./types";
+
+// `show_analysis` is the feature flag for turning visualization on/off.
+// `overall` will be `null` if the analysis isn't available yet.
+export const analysisAvailable = (analysis: AnalysisData | undefined) =>
+  analysis?.show_analysis === true && analysis?.overall !== null;
 
 export const getTableDisplayType = (
   metricKey: string,


### PR DESCRIPTION
Because:
* A general application error is shown on the Results page when results are unavailable instead of redirecting the user or displaying the error state.

This commit:
* Adds analysisAvailable helper checking for 'overall' as well as 'analysis_available' in fetched data
* Checks for error from visualization API call and displays this state in the sidebar instead of on page since the user should be redirected to the Design page

---

This PR fixes #4230 by checking for `overall !== null` (as well as `show_analysis === true`) when checking if analysis data is available, per [this comment](https://github.com/mozilla/experimenter/pull/4302/files#r546082662) / https://github.com/mozilla/experimenter/issues/4230#issuecomment-743287022.

Additionally, I explored addressing [this problem](https://github.com/mozilla/experimenter/pull/4302/files#r546079822), which [you can visually see hangs on "loading" Storybook](https://storage.googleapis.com/mozilla-storybooks-experimenter/commits/d58dbc127d95f54e142d233507a69321b02d6d81/nimbus-ui/index.html?path=/story/pages-results--analysis-fetch-errors) when the visualization fetch fails which lead me to question if (looking at Storybook) the "analysis unavailable" and "analysis fetch errors" state should even be handled on the Results page. Since we have a redirect in place to the Design page if the analysis is unavailable, these states should not be reachable. I've moved handling of this into the sidebar.

--

So in bulleted point form, (and to make it easier for @AnaMedinac to check this out), **besides the bug fix** -

Before this PR:
* a visualization data fetch fail was supposed to [show this screen](https://storage.googleapis.com/mozilla-storybooks-experimenter/commits/db8fcebc619ad03a61493455e99d62ed16813af6/nimbus-ui/index.html?path=/story/pages-results--analysis-fetch-errors) with the "contact #cirrus" text, but regression from a different bug caused [this screen to show](https://storage.googleapis.com/mozilla-storybooks-experimenter/commits/d58dbc127d95f54e142d233507a69321b02d6d81/nimbus-ui/index.html?path=/story/pages-results--analysis-fetch-errors) with the loader indefinitely
* if the analysis was unavailable and the Results page was hit, [this screen](https://storage.googleapis.com/mozilla-storybooks-experimenter/commits/d58dbc127d95f54e142d233507a69321b02d6d81/nimbus-ui/index.html?path=/story/pages-results--analysis-unavailable) was supposed to be shown, but as of #4223, this state isn't accessible because the user is redirected to the Design page

After this PR:
* a visualization data fetch fail ([see Storybook](https://storage.googleapis.com/mozilla-storybooks-experimenter/commits/504af50f4705f75966814dd50301bf3376444607/nimbus-ui/index.html?path=/story/components-applayoutwithsidebar--analysis-results-error)) redirects the user to the Design page with the error handled in the sidebar component with a "contact #cirrus" message
* The "analysis unavailable" state is removed from the Results page since the user is redirected, the user can only access the Results page if the fetch was successful and results are available