### PR TITLE
chore(nimbus): refactor graphql into a single mutation

### DIFF
--- a/app/experimenter/experiments/api/v5/inputs.py
+++ b/app/experimenter/experiments/api/v5/inputs.py
@@ -9,22 +9,6 @@ from experimenter.experiments.api.v5.types import (
 )
 
 
-class ExperimentInput(graphene.InputObjectType):
-    client_mutation_id = graphene.String()
-    name = graphene.String(required=True)
-    hypothesis = graphene.String(required=True)
-
-
-class CreateExperimentInput(ExperimentInput):
-    name = graphene.String(required=True)
-    application = NimbusExperimentApplication(required=True)
-
-
-class UpdateExperimentInput(ExperimentInput):
-    id = graphene.ID(required=True)
-    public_description = graphene.String()
-
-
 class BranchType(graphene.InputObjectType):
     name = graphene.String(required=True)
     description = graphene.String(required=True)
@@ -45,41 +29,20 @@ class TreatmentBranchType(BranchType):
         )
 
 
-class UpdateExperimentBranchesInput(graphene.InputObjectType):
+class ExperimentInput(graphene.InputObjectType):
     client_mutation_id = graphene.String()
-    nimbus_experiment_id = graphene.Int(required=True)
+    id = graphene.Int()
+    status = NimbusExperimentStatus()
+    name = graphene.String()
+    hypothesis = graphene.String()
+    name = graphene.String()
+    application = NimbusExperimentApplication()
+    public_description = graphene.String()
     feature_config_id = graphene.Int()
-    reference_branch = graphene.Field(ReferenceBranchType, required=True)
-    treatment_branches = graphene.List(
-        TreatmentBranchType,
-        required=True,
-        description=(
-            "List of treatment branches for this experiment. Branches will be created, "
-            "updated, or deleted to match the list provided."
-        ),
-    )
-
-
-class UpdateExperimentProbeSetsInput(graphene.InputObjectType):
-    client_mutation_id = graphene.String()
-    nimbus_experiment_id = graphene.Int(required=True)
-    primary_probe_set_ids = graphene.List(
-        graphene.Int,
-        required=True,
-        description="List of primary probeset ids that should be set on the experiment.",
-    )
-    secondary_probe_set_ids = graphene.List(
-        graphene.Int,
-        required=True,
-        description=(
-            "List of secondary probeset ids that should be set on the experiment."
-        ),
-    )
-
-
-class UpdateExperimentAudienceInput(graphene.InputObjectType):
-    client_mutation_id = graphene.String()
-    nimbus_experiment_id = graphene.Int(required=True)
+    reference_branch = graphene.Field(ReferenceBranchType)
+    treatment_branches = graphene.List(TreatmentBranchType)
+    primary_probe_set_ids = graphene.List(graphene.Int)
+    secondary_probe_set_ids = graphene.List(graphene.Int)
     channel = NimbusExperimentChannel()
     firefox_min_version = NimbusExperimentFirefoxMinVersion()
     population_percent = graphene.String()
@@ -87,9 +50,3 @@ class UpdateExperimentAudienceInput(graphene.InputObjectType):
     proposed_enrollment = graphene.String()
     targeting_config_slug = NimbusExperimentTargetingConfigSlug()
     total_enrolled_clients = graphene.Int()
-
-
-class UpdateExperimentStatusInput(graphene.InputObjectType):
-    client_mutation_id = graphene.String()
-    nimbus_experiment_id = graphene.Int(required=True)
-    status = NimbusExperimentStatus(required=True)

--- a/app/experimenter/experiments/api/v5/mutation.py
+++ b/app/experimenter/experiments/api/v5/mutation.py
@@ -13,21 +13,8 @@
 """
 import graphene
 
-from experimenter.experiments.api.v5.inputs import (
-    CreateExperimentInput,
-    UpdateExperimentAudienceInput,
-    UpdateExperimentBranchesInput,
-    UpdateExperimentInput,
-    UpdateExperimentProbeSetsInput,
-    UpdateExperimentStatusInput,
-)
-from experimenter.experiments.api.v5.serializers import (
-    NimbusAudienceUpdateSerializer,
-    NimbusBranchUpdateSerializer,
-    NimbusExperimentOverviewSerializer,
-    NimbusProbeSetUpdateSerializer,
-    NimbusStatusUpdateSerializer,
-)
+from experimenter.experiments.api.v5.inputs import ExperimentInput
+from experimenter.experiments.api.v5.serializers import NimbusExperimentUpdateSerializer
 from experimenter.experiments.api.v5.types import NimbusExperimentType, ObjectField
 from experimenter.experiments.models import NimbusExperiment
 
@@ -54,112 +41,31 @@ class CreateExperiment(graphene.Mutation):
     status = graphene.Int()
 
     class Arguments:
-        input = CreateExperimentInput(required=True)
+        input = ExperimentInput(required=True)
 
     @classmethod
-    def mutate(cls, root, info, input: CreateExperimentInput):
-        serializer = NimbusExperimentOverviewSerializer(
+    def mutate(cls, root, info, input: ExperimentInput):
+        serializer = NimbusExperimentUpdateSerializer(
             data=input, context={"user": info.context.user}
         )
         return handle_with_serializer(cls, serializer, input.client_mutation_id)
 
 
-class UpdateExperimentOverview(graphene.Mutation):
+class UpdateExperiment(graphene.Mutation):
     client_mutation_id = graphene.String()
     nimbus_experiment = graphene.Field(NimbusExperimentType)
     message = ObjectField()
     status = graphene.Int()
 
     class Arguments:
-        input = UpdateExperimentInput(required=True)
+        input = ExperimentInput(required=True)
 
     @classmethod
-    def mutate(cls, root, info, input: UpdateExperimentInput):
+    def mutate(cls, root, info, input: ExperimentInput):
         exp = NimbusExperiment.objects.get(id=input.id)
-        serializer = NimbusExperimentOverviewSerializer(
-            exp, data=input, partial=True, context={"user": info.context.user}
-        )
-        return handle_with_serializer(cls, serializer, input.client_mutation_id)
-
-
-class UpdateExperimentBranches(graphene.Mutation):
-    client_mutation_id = graphene.String()
-    nimbus_experiment = graphene.Field(NimbusExperimentType)
-    message = ObjectField()
-    status = graphene.Int()
-
-    class Arguments:
-        input = UpdateExperimentBranchesInput(required=True)
-
-    @classmethod
-    def mutate(cls, root, info, input: UpdateExperimentBranchesInput):
-        exp = NimbusExperiment.objects.get(id=input.nimbus_experiment_id)
         input["feature_config"] = input.pop("feature_config_id", None)
-        serializer = NimbusBranchUpdateSerializer(
+        serializer = NimbusExperimentUpdateSerializer(
             exp, data=input, partial=True, context={"user": info.context.user}
-        )
-        return handle_with_serializer(cls, serializer, input.client_mutation_id)
-
-
-class UpdateExperimentProbeSets(graphene.Mutation):
-    client_mutation_id = graphene.String()
-    nimbus_experiment = graphene.Field(NimbusExperimentType)
-    message = ObjectField()
-    status = graphene.Int()
-
-    class Arguments:
-        input = UpdateExperimentProbeSetsInput(required=True)
-
-    @classmethod
-    def mutate(cls, root, info, input: UpdateExperimentProbeSetsInput):
-        experiment = NimbusExperiment.objects.get(id=input.nimbus_experiment_id)
-        serializer = NimbusProbeSetUpdateSerializer(
-            experiment,
-            data={
-                "primary_probe_sets": input["primary_probe_set_ids"],
-                "secondary_probe_sets": input["secondary_probe_set_ids"],
-            },
-            context={"user": info.context.user},
-        )
-        return handle_with_serializer(cls, serializer, input.client_mutation_id)
-
-
-class UpdateExperimentAudience(graphene.Mutation):
-    client_mutation_id = graphene.String()
-    nimbus_experiment = graphene.Field(NimbusExperimentType)
-    message = ObjectField()
-    status = graphene.Int()
-
-    class Arguments:
-        input = UpdateExperimentAudienceInput(required=True)
-
-    @classmethod
-    def mutate(cls, root, info, input: UpdateExperimentAudienceInput):
-        experiment = NimbusExperiment.objects.get(id=input.nimbus_experiment_id)
-        serializer = NimbusAudienceUpdateSerializer(
-            experiment,
-            data=input,
-            context={"user": info.context.user},
-        )
-        return handle_with_serializer(cls, serializer, input.client_mutation_id)
-
-
-class UpdateExperimentStatus(graphene.Mutation):
-    client_mutation_id = graphene.String()
-    nimbus_experiment = graphene.Field(NimbusExperimentType)
-    message = ObjectField()
-    status = graphene.Int()
-
-    class Arguments:
-        input = UpdateExperimentStatusInput(required=True)
-
-    @classmethod
-    def mutate(cls, root, info, input: UpdateExperimentStatusInput):
-        experiment = NimbusExperiment.objects.get(id=input.nimbus_experiment_id)
-        serializer = NimbusStatusUpdateSerializer(
-            experiment,
-            data=input,
-            context={"user": info.context.user},
         )
         return handle_with_serializer(cls, serializer, input.client_mutation_id)
 
@@ -168,22 +74,4 @@ class Mutation(graphene.ObjectType):
     create_experiment = CreateExperiment.Field(
         description="Create a new Nimbus Experiment."
     )
-    update_experiment_overview = UpdateExperimentOverview.Field(
-        description="Update a Nimbus Experiment."
-    )
-
-    update_experiment_branches = UpdateExperimentBranches.Field(
-        description="Updates branches on a Nimbus Experiment."
-    )
-
-    update_experiment_probe_sets = UpdateExperimentProbeSets.Field(
-        description="Updates the probesets on a Nimbus Experiment."
-    )
-
-    update_experiment_audience = UpdateExperimentAudience.Field(
-        description="Updates the audience on a Nimbus Experiment."
-    )
-
-    update_experiment_status = UpdateExperimentStatus.Field(
-        description="Mark a Nimubs Experiment as ready for review."
-    )
+    update_experiment = UpdateExperiment.Field(description="Update a Nimbus Experiment.")

--- a/app/experimenter/experiments/api/v5/types.py
+++ b/app/experimenter/experiments/api/v5/types.py
@@ -103,6 +103,7 @@ class NimbusReadyForReviewType(graphene.ObjectType):
 
 
 class NimbusExperimentType(DjangoObjectType):
+    id = graphene.Int()
     status = NimbusExperimentStatus()
     application = NimbusExperimentApplication()
     firefox_min_version = NimbusExperimentFirefoxMinVersion()

--- a/app/experimenter/experiments/tests/api/v5/test_serializers.py
+++ b/app/experimenter/experiments/tests/api/v5/test_serializers.py
@@ -3,13 +3,9 @@ from django.utils.text import slugify
 from parameterized import parameterized
 
 from experimenter.experiments.api.v5.serializers import (
-    NimbusAudienceUpdateSerializer,
     NimbusBranchSerializer,
-    NimbusBranchUpdateSerializer,
-    NimbusExperimentOverviewSerializer,
-    NimbusProbeSetUpdateSerializer,
+    NimbusExperimentUpdateSerializer,
     NimbusReadyForReviewSerializer,
-    NimbusStatusUpdateSerializer,
 )
 from experimenter.experiments.constants.nimbus import NimbusConstants
 from experimenter.experiments.models import NimbusExperiment
@@ -53,7 +49,7 @@ class TestCreateNimbusExperimentOverviewSerializer(TestCase):
             "public_description": "Test description",
         }
 
-        serializer = NimbusExperimentOverviewSerializer(
+        serializer = NimbusExperimentUpdateSerializer(
             data=data, context={"user": self.user}
         )
         self.assertTrue(serializer.is_valid())
@@ -75,7 +71,7 @@ class TestCreateNimbusExperimentOverviewSerializer(TestCase):
             "public_description": "Test description",
         }
 
-        serializer = NimbusExperimentOverviewSerializer(
+        serializer = NimbusExperimentUpdateSerializer(
             data=data, context={"user": self.user}
         )
         self.assertFalse(serializer.is_valid())
@@ -97,7 +93,7 @@ class TestCreateNimbusExperimentOverviewSerializer(TestCase):
             "public_description": "Test description",
         }
 
-        serializer = NimbusExperimentOverviewSerializer(
+        serializer = NimbusExperimentUpdateSerializer(
             data=data, context={"user": self.user}
         )
         self.assertFalse(serializer.is_valid())
@@ -115,7 +111,7 @@ class TestCreateNimbusExperimentOverviewSerializer(TestCase):
             "public_description": "Test description",
         }
 
-        serializer = NimbusExperimentOverviewSerializer(
+        serializer = NimbusExperimentUpdateSerializer(
             data=data, context={"user": self.user}
         )
         self.assertFalse(serializer.is_valid())
@@ -129,7 +125,7 @@ class TestCreateNimbusExperimentOverviewSerializer(TestCase):
             "public_description": "Does it do the thing?",
         }
 
-        serializer = NimbusExperimentOverviewSerializer(
+        serializer = NimbusExperimentUpdateSerializer(
             data=data, context={"user": self.user}
         )
 
@@ -160,11 +156,11 @@ class TestCreateNimbusExperimentOverviewSerializer(TestCase):
             "public_description": "New public description",
         }
 
-        serializer = NimbusExperimentOverviewSerializer(
+        serializer = NimbusExperimentUpdateSerializer(
             experiment, data=data, context={"user": self.user}
         )
 
-        self.assertTrue(serializer.is_valid())
+        self.assertTrue(serializer.is_valid(), serializer.errors)
 
         experiment = serializer.save()
         self.assertEqual(experiment.changes.count(), 2)
@@ -260,7 +256,7 @@ class TestNimbusBranchUpdateSerializer(TestCase):
             "reference_branch": reference_branch,
             "treatment_branches": treatment_branches,
         }
-        serializer = NimbusBranchUpdateSerializer(
+        serializer = NimbusExperimentUpdateSerializer(
             experiment, data=input, partial=True, context={"user": self.user}
         )
         self.assertTrue(serializer.is_valid())
@@ -310,10 +306,10 @@ class TestNimbusBranchUpdateSerializer(TestCase):
             "reference_branch": reference_branch,
             "treatment_branches": treatment_branches,
         }
-        serializer = NimbusBranchUpdateSerializer(
+        serializer = NimbusExperimentUpdateSerializer(
             experiment, data=input, partial=True, context={"user": self.user}
         )
-        self.assertTrue(serializer.is_valid())
+        self.assertTrue(serializer.is_valid(), serializer.errors)
         experiment = serializer.save()
         for key, val in reference_branch.items():
             self.assertEqual(getattr(experiment.reference_branch, key), val)
@@ -360,7 +356,7 @@ class TestNimbusBranchUpdateSerializer(TestCase):
             "reference_branch": reference_branch,
             "treatment_branches": treatment_branches,
         }
-        serializer = NimbusBranchUpdateSerializer(
+        serializer = NimbusExperimentUpdateSerializer(
             experiment, data=input, partial=True, context={"user": self.user}
         )
         self.assertFalse(serializer.is_valid())
@@ -401,7 +397,7 @@ class TestNimbusBranchUpdateSerializer(TestCase):
             "reference_branch": reference_branch,
             "treatment_branches": treatment_branches,
         }
-        serializer = NimbusBranchUpdateSerializer(
+        serializer = NimbusExperimentUpdateSerializer(
             experiment, data=input, partial=True, context={"user": self.user}
         )
         self.assertFalse(serializer.is_valid())
@@ -440,7 +436,7 @@ class TestNimbusBranchUpdateSerializer(TestCase):
             "reference_branch": reference_branch,
             "treatment_branches": treatment_branches,
         }
-        serializer = NimbusBranchUpdateSerializer(
+        serializer = NimbusExperimentUpdateSerializer(
             experiment, data=input, partial=True, context={"user": self.user}
         )
         self.assertFalse(serializer.is_valid())
@@ -485,7 +481,7 @@ class TestNimbusBranchUpdateSerializer(TestCase):
             "reference_branch": reference_branch,
             "treatment_branches": treatment_branches,
         }
-        serializer = NimbusBranchUpdateSerializer(
+        serializer = NimbusExperimentUpdateSerializer(
             experiment, data=input, partial=True, context={"user": self.user}
         )
         self.assertFalse(serializer.is_valid())
@@ -501,17 +497,17 @@ class TestNimbusProbeSetUpdateSerializer(TestCase):
     def test_serializer_updates_probe_sets_on_experiment(self):
         user = UserFactory()
         experiment = NimbusExperimentFactory(probe_sets=[])
-        primary_probe_sets = [
+        primary_probe_set_ids = [
             NimbusProbeSetFactory().id
             for i in range(NimbusExperiment.MAX_PRIMARY_PROBE_SETS)
         ]
-        secondary_probe_sets = [NimbusProbeSetFactory().id for i in range(3)]
+        secondary_probe_set_ids = [NimbusProbeSetFactory().id for i in range(3)]
 
-        serializer = NimbusProbeSetUpdateSerializer(
+        serializer = NimbusExperimentUpdateSerializer(
             experiment,
             {
-                "primary_probe_sets": primary_probe_sets,
-                "secondary_probe_sets": secondary_probe_sets,
+                "primary_probe_set_ids": primary_probe_set_ids,
+                "secondary_probe_set_ids": secondary_probe_set_ids,
             },
             context={"user": user},
         )
@@ -522,16 +518,16 @@ class TestNimbusProbeSetUpdateSerializer(TestCase):
         self.assertEqual(experiment.changes.count(), 1)
 
         self.assertEqual(
-            set(primary_probe_sets) | set(secondary_probe_sets),
+            set(primary_probe_set_ids) | set(secondary_probe_set_ids),
             set(experiment.probe_sets.all().values_list("id", flat=True)),
         )
         self.assertEqual(
             set([p.id for p in experiment.primary_probe_sets]),
-            set(primary_probe_sets),
+            set(primary_probe_set_ids),
         )
         self.assertEqual(
             set([p.id for p in experiment.secondary_probe_sets]),
-            set(secondary_probe_sets),
+            set(secondary_probe_set_ids),
         )
 
     def test_serializer_rejects_duplicate_probes(self):
@@ -539,13 +535,13 @@ class TestNimbusProbeSetUpdateSerializer(TestCase):
         experiment = NimbusExperimentFactory(probe_sets=[])
         probe_sets = [NimbusProbeSetFactory() for i in range(3)]
 
-        serializer = NimbusProbeSetUpdateSerializer(
+        serializer = NimbusExperimentUpdateSerializer(
             experiment,
             {
-                "primary_probe_sets": [
+                "primary_probe_set_ids": [
                     p.id for p in probe_sets[: NimbusExperiment.MAX_PRIMARY_PROBE_SETS]
                 ],
-                "secondary_probe_sets": [p.id for p in probe_sets],
+                "secondary_probe_set_ids": [p.id for p in probe_sets],
             },
             context={"user": user},
         )
@@ -554,7 +550,7 @@ class TestNimbusProbeSetUpdateSerializer(TestCase):
         self.assertFalse(serializer.is_valid())
         self.assertEqual(experiment.changes.count(), 0)
         self.assertEqual(
-            serializer.errors["primary_probe_sets"][0],
+            serializer.errors["primary_probe_set_ids"][0],
             "Primary probe sets cannot overlap with secondary probe sets.",
         )
 
@@ -563,11 +559,11 @@ class TestNimbusProbeSetUpdateSerializer(TestCase):
         experiment = NimbusExperimentFactory(probe_sets=[])
         probe_sets = [NimbusProbeSetFactory() for i in range(3)]
 
-        serializer = NimbusProbeSetUpdateSerializer(
+        serializer = NimbusExperimentUpdateSerializer(
             experiment,
             {
-                "primary_probe_sets": [p.id for p in probe_sets],
-                "secondary_probe_sets": [],
+                "primary_probe_set_ids": [p.id for p in probe_sets],
+                "secondary_probe_set_ids": [],
             },
             context={"user": user},
         )
@@ -577,7 +573,7 @@ class TestNimbusProbeSetUpdateSerializer(TestCase):
         self.assertEqual(experiment.changes.count(), 0)
         self.assertIn(
             "Exceeded maximum primary probe set limit of",
-            serializer.errors["primary_probe_sets"][0],
+            serializer.errors["primary_probe_set_ids"][0],
         )
 
 
@@ -594,7 +590,7 @@ class TestNimbusAudienceUpdateSerializer(TestCase):
             targeting_config_slug=None,
             total_enrolled_clients=0,
         )
-        serializer = NimbusAudienceUpdateSerializer(
+        serializer = NimbusExperimentUpdateSerializer(
             experiment,
             {
                 "channel": NimbusConstants.Channel.DESKTOP_BETA.value,
@@ -638,7 +634,7 @@ class TestNimbusAudienceUpdateSerializer(TestCase):
             targeting_config_slug=None,
             total_enrolled_clients=0,
         )
-        serializer = NimbusAudienceUpdateSerializer(
+        serializer = NimbusExperimentUpdateSerializer(
             experiment,
             {
                 "channel": NimbusConstants.Channel.DESKTOP_BETA.value,
@@ -675,7 +671,7 @@ class TestNimbusAudienceUpdateSerializer(TestCase):
     def test_population_percent_bounds_check(self, expected_valid, population_percent):
         user = UserFactory()
         experiment = NimbusExperimentFactory()
-        serializer = NimbusAudienceUpdateSerializer(
+        serializer = NimbusExperimentUpdateSerializer(
             experiment,
             {"population_percent": population_percent},
             context={"user": user},
@@ -696,7 +692,7 @@ class TestNimbusStatusUpdateSerializer(TestCase):
 
     def test_status_update(self):
         experiment = NimbusExperimentFactory(status=NimbusExperiment.Status.DRAFT)
-        serializer = NimbusStatusUpdateSerializer(
+        serializer = NimbusExperimentUpdateSerializer(
             experiment,
             data={"status": NimbusExperiment.Status.REVIEW},
             context={"user": self.user},
@@ -709,7 +705,7 @@ class TestNimbusStatusUpdateSerializer(TestCase):
 
     def test_status_with_invalid_target_status(self):
         experiment = NimbusExperimentFactory(status=NimbusExperiment.Status.DRAFT)
-        serializer = NimbusStatusUpdateSerializer(
+        serializer = NimbusExperimentUpdateSerializer(
             experiment,
             data={"status": NimbusExperiment.Status.ACCEPTED},
             context={"user": self.user},
@@ -723,7 +719,7 @@ class TestNimbusStatusUpdateSerializer(TestCase):
 
     def test_status_with_invalid_existing_status(self):
         experiment = NimbusExperimentFactory(status=NimbusExperiment.Status.ACCEPTED)
-        serializer = NimbusStatusUpdateSerializer(
+        serializer = NimbusExperimentUpdateSerializer(
             experiment,
             data={"status": NimbusExperiment.Status.REVIEW},
             context={"user": self.user},

--- a/app/experimenter/nimbus-ui/schema.graphql
+++ b/app/experimenter/nimbus-ui/schema.graphql
@@ -15,22 +15,33 @@ type CreateExperiment {
   status: Int
 }
 
-input CreateExperimentInput {
-  clientMutationId: String
-  name: String!
-  hypothesis: String!
-  application: NimbusExperimentApplication!
-}
-
 scalar DateTime
 
+input ExperimentInput {
+  clientMutationId: String
+  id: Int
+  status: NimbusExperimentStatus
+  hypothesis: String
+  name: String
+  application: NimbusExperimentApplication
+  publicDescription: String
+  featureConfigId: Int
+  referenceBranch: ReferenceBranchType
+  treatmentBranches: [TreatmentBranchType]
+  primaryProbeSetIds: [Int]
+  secondaryProbeSetIds: [Int]
+  channel: NimbusExperimentChannel
+  firefoxMinVersion: NimbusExperimentFirefoxMinVersion
+  populationPercent: String
+  proposedDuration: Int
+  proposedEnrollment: String
+  targetingConfigSlug: NimbusExperimentTargetingConfigSlug
+  totalEnrolledClients: Int
+}
+
 type Mutation {
-  createExperiment(input: CreateExperimentInput!): CreateExperiment
-  updateExperimentOverview(input: UpdateExperimentInput!): UpdateExperimentOverview
-  updateExperimentBranches(input: UpdateExperimentBranchesInput!): UpdateExperimentBranches
-  updateExperimentProbeSets(input: UpdateExperimentProbeSetsInput!): UpdateExperimentProbeSets
-  updateExperimentAudience(input: UpdateExperimentAudienceInput!): UpdateExperimentAudience
-  updateExperimentStatus(input: UpdateExperimentStatusInput!): UpdateExperimentStatus
+  createExperiment(input: ExperimentInput!): CreateExperiment
+  updateExperiment(input: ExperimentInput!): UpdateExperiment
 }
 
 type NimbusBranchType {
@@ -132,7 +143,7 @@ enum NimbusExperimentTargetingConfigSlug {
 }
 
 type NimbusExperimentType {
-  id: ID!
+  id: Int
   owner: NimbusExperimentOwner
   status: NimbusExperimentStatus
   name: String!
@@ -256,78 +267,9 @@ input TreatmentBranchType {
   featureValue: String
 }
 
-type UpdateExperimentAudience {
+type UpdateExperiment {
   clientMutationId: String
   nimbusExperiment: NimbusExperimentType
   message: ObjectField
   status: Int
-}
-
-input UpdateExperimentAudienceInput {
-  clientMutationId: String
-  nimbusExperimentId: Int!
-  channel: NimbusExperimentChannel
-  firefoxMinVersion: NimbusExperimentFirefoxMinVersion
-  populationPercent: String
-  proposedDuration: Int
-  proposedEnrollment: String
-  targetingConfigSlug: NimbusExperimentTargetingConfigSlug
-  totalEnrolledClients: Int
-}
-
-type UpdateExperimentBranches {
-  clientMutationId: String
-  nimbusExperiment: NimbusExperimentType
-  message: ObjectField
-  status: Int
-}
-
-input UpdateExperimentBranchesInput {
-  clientMutationId: String
-  nimbusExperimentId: Int!
-  featureConfigId: Int
-  referenceBranch: ReferenceBranchType!
-  treatmentBranches: [TreatmentBranchType]!
-}
-
-input UpdateExperimentInput {
-  clientMutationId: String
-  name: String!
-  hypothesis: String!
-  id: ID!
-  publicDescription: String
-}
-
-type UpdateExperimentOverview {
-  clientMutationId: String
-  nimbusExperiment: NimbusExperimentType
-  message: ObjectField
-  status: Int
-}
-
-type UpdateExperimentProbeSets {
-  clientMutationId: String
-  nimbusExperiment: NimbusExperimentType
-  message: ObjectField
-  status: Int
-}
-
-input UpdateExperimentProbeSetsInput {
-  clientMutationId: String
-  nimbusExperimentId: Int!
-  primaryProbeSetIds: [Int]!
-  secondaryProbeSetIds: [Int]!
-}
-
-type UpdateExperimentStatus {
-  clientMutationId: String
-  nimbusExperiment: NimbusExperimentType
-  message: ObjectField
-  status: Int
-}
-
-input UpdateExperimentStatusInput {
-  clientMutationId: String
-  nimbusExperimentId: Int!
-  status: NimbusExperimentStatus!
 }

--- a/app/experimenter/nimbus-ui/src/components/FormBranches/reducer/index.test.ts
+++ b/app/experimenter/nimbus-ui/src/components/FormBranches/reducer/index.test.ts
@@ -49,7 +49,7 @@ describe("extractUpdateState", () => {
       ],
     };
     const updateState = extractUpdateState(state, formData);
-    expect(updateState.referenceBranch.name).toEqual(
+    expect(updateState.referenceBranch!.name).toEqual(
       formData.referenceBranch.name,
     );
     expect(updateState.treatmentBranches![0]!.description).toEqual(

--- a/app/experimenter/nimbus-ui/src/components/FormBranches/reducer/update.ts
+++ b/app/experimenter/nimbus-ui/src/components/FormBranches/reducer/update.ts
@@ -2,11 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { UpdateExperimentBranchesInput } from "../../../types/globalTypes";
+import { ExperimentInput } from "../../../types/globalTypes";
 import { FormBranchesState, AnnotatedBranch } from "./state";
 
 export type FormBranchesSaveState = Pick<
-  UpdateExperimentBranchesInput,
+  ExperimentInput,
   "featureConfigId" | "referenceBranch" | "treatmentBranches"
 >;
 
@@ -40,8 +40,9 @@ export function extractUpdateState(
     treatmentBranches:
       treatmentBranches === null
         ? []
-        : treatmentBranches.map((branch, idx) =>
-            extractUpdateBranch(branch, formData.treatmentBranches?.[idx]!),
+        : treatmentBranches.map(
+            (branch, idx) =>
+              extractUpdateBranch(branch, formData.treatmentBranches?.[idx]!)!,
           ),
   };
 }

--- a/app/experimenter/nimbus-ui/src/components/PageEditAudience/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditAudience/index.test.tsx
@@ -20,20 +20,20 @@ import { navigate } from "@reach/router";
 import { UPDATE_EXPERIMENT_AUDIENCE_MUTATION } from "../../gql/experiments";
 import { BASE_PATH, SUBMIT_ERROR } from "../../lib/constants";
 import {
-  updateExperimentAudience_updateExperimentAudience,
-  updateExperimentAudience_updateExperimentAudience_nimbusExperiment,
+  updateExperimentAudience_updateExperiment,
+  updateExperimentAudience_updateExperiment_nimbusExperiment,
 } from "../../types/updateExperimentAudience";
 import {
   NimbusExperimentChannel,
   NimbusExperimentFirefoxMinVersion,
   NimbusExperimentStatus,
   NimbusExperimentTargetingConfigSlug,
-  UpdateExperimentAudienceInput,
+  ExperimentInput,
 } from "../../types/globalTypes";
 
 const { mock, experiment } = mockExperimentQuery("demo-slug");
 
-let mockSubmitData: Partial<UpdateExperimentAudienceInput>;
+let mockSubmitData: Partial<ExperimentInput>;
 let mutationMock: ReturnType<typeof mockUpdateExperimentAudienceMutation>;
 
 describe("PageEditAudience", () => {
@@ -48,7 +48,7 @@ describe("PageEditAudience", () => {
   beforeEach(() => {
     mockSubmitData = { ...MOCK_FORM_DATA };
     mutationMock = mockUpdateExperimentAudienceMutation(
-      { ...mockSubmitData, nimbusExperimentId: parseInt(experiment.id, 10) },
+      { ...mockSubmitData, id: experiment.id },
       {
         experiment: {
           ...MOCK_FORM_DATA,
@@ -137,7 +137,7 @@ describe("PageEditAudience", () => {
     const expectedErrors = {
       channel: { message: "this is garbage" },
     };
-    mutationMock.result.data.updateExperimentAudience.message = expectedErrors;
+    mutationMock.result.data.updateExperiment.message = expectedErrors;
     render(<Subject mocks={[mock, mutationMock]} />);
     let submitButton: HTMLButtonElement;
     await waitFor(() => {
@@ -153,7 +153,7 @@ describe("PageEditAudience", () => {
 
   it("handles form submission with bad server data", async () => {
     // @ts-ignore - intentionally breaking this type for error handling
-    delete mutationMock.result.data.updateExperimentAudience;
+    delete mutationMock.result.data.updateExperiment;
     render(<Subject mocks={[mock, mutationMock]} />);
     let submitButton: HTMLButtonElement;
     await waitFor(() => {
@@ -222,7 +222,7 @@ jest.mock("../FormAudience", () => ({
 }));
 
 export const mockUpdateExperimentAudienceMutation = (
-  input: Partial<UpdateExperimentAudienceInput>,
+  input: Partial<ExperimentInput>,
   {
     clientMutationId = "8675309",
     status = 200,
@@ -232,11 +232,11 @@ export const mockUpdateExperimentAudienceMutation = (
     clientMutationId?: string | null;
     status?: number;
     message?: string | Record<string, any>;
-    experiment: updateExperimentAudience_updateExperimentAudience_nimbusExperiment;
+    experiment: updateExperimentAudience_updateExperiment_nimbusExperiment;
   },
 ) => {
-  const updateExperimentAudience: updateExperimentAudience_updateExperimentAudience = {
-    __typename: "UpdateExperimentAudience",
+  const updateExperiment: updateExperimentAudience_updateExperiment = {
+    __typename: "UpdateExperiment",
     clientMutationId,
     status,
     message,
@@ -253,7 +253,7 @@ export const mockUpdateExperimentAudienceMutation = (
     result: {
       errors: undefined as undefined | any[],
       data: {
-        updateExperimentAudience,
+        updateExperiment,
       },
     },
   };

--- a/app/experimenter/nimbus-ui/src/components/PageEditAudience/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditAudience/index.tsx
@@ -6,8 +6,8 @@ import React, { useCallback, useRef, useState } from "react";
 import { navigate, RouteComponentProps } from "@reach/router";
 import AppLayoutWithExperiment from "../AppLayoutWithExperiment";
 import { useMutation } from "@apollo/client";
-import { UpdateExperimentAudienceInput } from "../../types/globalTypes";
-import { updateExperimentAudience_updateExperimentAudience as UpdateExperimentAudienceResult } from "../../types/updateExperimentAudience";
+import { ExperimentInput } from "../../types/globalTypes";
+import { updateExperimentAudience_updateExperiment as UpdateExperimentAudienceResult } from "../../types/updateExperimentAudience";
 import { UPDATE_EXPERIMENT_AUDIENCE_MUTATION } from "../../gql/experiments";
 import { SUBMIT_ERROR } from "../../lib/constants";
 import { getExperiment_experimentBySlug } from "../../types/getExperiment";
@@ -16,8 +16,8 @@ import { editCommonRedirects } from "../../lib/experiment";
 
 const PageEditAudience: React.FunctionComponent<RouteComponentProps> = () => {
   const [updateExperimentAudience, { loading }] = useMutation<
-    { updateExperimentAudience: UpdateExperimentAudienceResult },
-    { input: UpdateExperimentAudienceInput }
+    { updateExperiment: UpdateExperimentAudienceResult },
+    { input: ExperimentInput }
   >(UPDATE_EXPERIMENT_AUDIENCE_MUTATION);
 
   const [submitErrors, setSubmitErrors] = useState<Record<string, any>>({});
@@ -37,11 +37,11 @@ const PageEditAudience: React.FunctionComponent<RouteComponentProps> = () => {
     }: Record<string, any>) => {
       try {
         // issue #3954: Need to parse string IDs into numbers
-        const nimbusExperimentId = parseInt(currentExperiment.current!.id, 10);
+        const nimbusExperimentId = currentExperiment.current!.id;
         const result = await updateExperimentAudience({
           variables: {
             input: {
-              nimbusExperimentId,
+              id: nimbusExperimentId,
               channel,
               firefoxMinVersion,
               targetingConfigSlug,
@@ -53,11 +53,11 @@ const PageEditAudience: React.FunctionComponent<RouteComponentProps> = () => {
           },
         });
 
-        if (!result.data?.updateExperimentAudience) {
+        if (!result.data?.updateExperiment) {
           throw new Error(SUBMIT_ERROR);
         }
 
-        const { message } = result.data.updateExperimentAudience;
+        const { message } = result.data.updateExperiment;
 
         if (message && message !== "success" && typeof message === "object") {
           setIsServerValid(false);

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/index.test.tsx
@@ -22,11 +22,11 @@ import { getExperiment_experimentBySlug } from "../../types/getExperiment";
 import {
   NimbusExperimentStatus,
   NimbusFeatureConfigApplication,
-  UpdateExperimentBranchesInput,
+  ExperimentInput,
 } from "../../types/globalTypes";
 import {
-  updateExperimentBranches_updateExperimentBranches_nimbusExperiment,
-  updateExperimentBranches_updateExperimentBranches,
+  updateExperimentBranches_updateExperiment_nimbusExperiment,
+  updateExperimentBranches_updateExperiment,
 } from "../../types/updateExperimentBranches";
 import { FormBranchesSaveState } from "../FormBranches/reducer";
 import { extractUpdateBranch } from "../FormBranches/reducer/update";
@@ -133,7 +133,7 @@ describe("PageEditBranches", () => {
     const { mock, experiment } = mockExperimentQuery("demo-slug");
     setMockUpdateState(experiment);
     const mockMutation = mockUpdateExperimentBranchesMutation(
-      { ...mockUpdateState, nimbusExperimentId: 1 },
+      { ...mockUpdateState, id: 1 },
       { experiment },
     );
     render(<Subject mocks={[mock, mockMutation, mock]} />);
@@ -152,11 +152,11 @@ describe("PageEditBranches", () => {
     setMockUpdateState(experiment);
 
     const mockMutation = mockUpdateExperimentBranchesMutation(
-      { ...mockUpdateState, nimbusExperimentId: 1 },
+      { ...mockUpdateState, id: 1 },
       { experiment },
     );
     // @ts-ignore - intentionally breaking this type for error handling
-    delete mockMutation.result.data.updateExperimentBranches;
+    delete mockMutation.result.data.updateExperiment;
 
     render(<Subject mocks={[mock, mockMutation, mock]} />);
     await waitFor(() => {
@@ -178,11 +178,11 @@ describe("PageEditBranches", () => {
     setMockUpdateState(experiment);
 
     const mockMutation = mockUpdateExperimentBranchesMutation(
-      { ...mockUpdateState, nimbusExperimentId: 1 },
+      { ...mockUpdateState, id: 1 },
       { experiment },
     );
 
-    mockMutation.result.data.updateExperimentBranches.message = {
+    mockMutation.result.data.updateExperiment.message = {
       reference_branch: {
         name: ["This name stinks."],
       },
@@ -199,7 +199,7 @@ describe("PageEditBranches", () => {
     });
 
     expect(mockSetSubmitErrors).toHaveBeenCalledWith(
-      mockMutation.result.data.updateExperimentBranches.message,
+      mockMutation.result.data.updateExperiment.message,
     );
   });
 });
@@ -233,9 +233,10 @@ function setMockUpdateState(experiment: getExperiment_experimentBySlug) {
     featureConfigId,
     // @ts-ignore type mismatch covers discarded annotation properties
     referenceBranch: extractUpdateBranch(experiment.referenceBranch!),
-    treatmentBranches: experiment.treatmentBranches!.map((branch) =>
-      // @ts-ignore type mismatch covers discarded annotation properties
-      extractUpdateBranch(branch!),
+    treatmentBranches: experiment.treatmentBranches!.map(
+      (branch) =>
+        // @ts-ignore type mismatch covers discarded annotation properties
+        extractUpdateBranch(branch!)!,
     ),
   };
 }
@@ -279,7 +280,7 @@ jest.mock("../FormBranches", () => ({
 }));
 
 export const mockUpdateExperimentBranchesMutation = (
-  input: Partial<UpdateExperimentBranchesInput>,
+  input: Partial<ExperimentInput>,
   {
     clientMutationId = "8675309",
     status = 200,
@@ -289,11 +290,11 @@ export const mockUpdateExperimentBranchesMutation = (
     clientMutationId?: string | null;
     status?: number;
     message?: string | Record<string, any>;
-    experiment: updateExperimentBranches_updateExperimentBranches_nimbusExperiment;
+    experiment: updateExperimentBranches_updateExperiment_nimbusExperiment;
   },
 ) => {
-  const updateExperimentBranches: updateExperimentBranches_updateExperimentBranches = {
-    __typename: "UpdateExperimentBranches",
+  const updateExperiment: updateExperimentBranches_updateExperiment = {
+    __typename: "UpdateExperiment",
     clientMutationId,
     status,
     message,
@@ -309,7 +310,7 @@ export const mockUpdateExperimentBranchesMutation = (
     result: {
       errors: undefined as undefined | any[],
       data: {
-        updateExperimentBranches,
+        updateExperiment,
       },
     },
   };

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/index.tsx
@@ -11,8 +11,8 @@ import LinkExternal from "../LinkExternal";
 import AppLayoutWithExperiment from "../AppLayoutWithExperiment";
 import { useMutation } from "@apollo/client";
 import { UPDATE_EXPERIMENT_BRANCHES_MUTATION } from "../../gql/experiments";
-import { UpdateExperimentBranchesInput } from "../../types/globalTypes";
-import { updateExperimentBranches_updateExperimentBranches as UpdateExperimentBranchesResult } from "../../types/updateExperimentBranches";
+import { ExperimentInput } from "../../types/globalTypes";
+import { updateExperimentBranches_updateExperiment as UpdateExperimentBranchesResult } from "../../types/updateExperimentBranches";
 import { getExperiment_experimentBySlug } from "../../types/getExperiment";
 import { editCommonRedirects } from "../../lib/experiment";
 
@@ -25,8 +25,8 @@ const PageEditBranches: React.FunctionComponent<RouteComponentProps> = () => {
   const { featureConfig } = useConfig();
 
   const [updateExperimentBranches, { loading }] = useMutation<
-    { updateExperimentBranches: UpdateExperimentBranchesResult },
-    { input: UpdateExperimentBranchesInput }
+    { updateExperiment: UpdateExperimentBranchesResult },
+    { input: ExperimentInput }
   >(UPDATE_EXPERIMENT_BRANCHES_MUTATION);
 
   const currentExperiment = useRef<getExperiment_experimentBySlug>();
@@ -44,11 +44,11 @@ const PageEditBranches: React.FunctionComponent<RouteComponentProps> = () => {
     ) => {
       try {
         // issue #3954: Need to parse string IDs into numbers
-        const nimbusExperimentId = parseInt(currentExperiment.current!.id, 10);
+        const nimbusExperimentId = currentExperiment.current!.id;
         const result = await updateExperimentBranches({
           variables: {
             input: {
-              nimbusExperimentId,
+              id: nimbusExperimentId,
               featureConfigId,
               referenceBranch,
               treatmentBranches,
@@ -56,11 +56,11 @@ const PageEditBranches: React.FunctionComponent<RouteComponentProps> = () => {
           },
         });
 
-        if (!result.data?.updateExperimentBranches) {
+        if (!result.data?.updateExperiment) {
           throw new Error(SUBMIT_ERROR_MESSAGE);
         }
 
-        const { message } = result.data.updateExperimentBranches;
+        const { message } = result.data.updateExperiment;
 
         if (message !== "success" && typeof message === "object") {
           return void setSubmitErrors(message);

--- a/app/experimenter/nimbus-ui/src/components/PageEditMetrics/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditMetrics/index.test.tsx
@@ -56,7 +56,7 @@ describe("PageEditMetrics", () => {
 
   beforeEach(() => {
     mockSubmitData = {
-      nimbusExperimentId: parseInt(experiment.id),
+      id: experiment.id!,
       primaryProbeSetIds: experiment.primaryProbeSets!.map((p) =>
         parseInt(p!.id),
       ),
@@ -81,7 +81,7 @@ describe("PageEditMetrics", () => {
     mutationMock = mockExperimentMutation(
       UPDATE_EXPERIMENT_PROBESETS_MUTATION,
       mockSubmitData,
-      "updateExperimentProbeSets",
+      "updateExperiment",
       mockResponse,
     );
   });
@@ -158,7 +158,7 @@ describe("PageEditMetrics", () => {
 
   it("handles experiment form submission with bad server data", async () => {
     // @ts-ignore - intentionally breaking this type for error handling
-    delete mutationMock.result.data.updateExperimentProbeSets;
+    delete mutationMock.result.data.updateExperiment;
     render(<Subject mocks={[mock, mutationMock]} />);
     let submitButton: HTMLButtonElement;
     await waitFor(() => {
@@ -188,7 +188,7 @@ describe("PageEditMetrics", () => {
   });
 
   it("handles server validation error", async () => {
-    mutationMock.result.data.updateExperimentProbeSets.message = {
+    mutationMock.result.data.updateExperiment.message = {
       primaryProbeSets: ["Bad probe sets"],
     };
     render(<Subject mocks={[mock, mutationMock]} />);

--- a/app/experimenter/nimbus-ui/src/components/PageEditMetrics/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditMetrics/index.tsx
@@ -9,8 +9,8 @@ import React, { useState, useRef, useCallback } from "react";
 import { getExperiment_experimentBySlug } from "../../types/getExperiment";
 import { SUBMIT_ERROR } from "../../lib/constants";
 import { UPDATE_EXPERIMENT_PROBESETS_MUTATION } from "../../gql/experiments";
-import { updateExperimentProbeSets_updateExperimentProbeSets as UpdateExperimentProbeSetsResult } from "../../types/updateExperimentProbeSets";
-import { UpdateExperimentProbeSetsInput } from "../../types/globalTypes";
+import { updateExperimentProbeSets_updateExperiment as UpdateExperimentProbeSetsResult } from "../../types/updateExperimentProbeSets";
+import { ExperimentInput } from "../../types/globalTypes";
 import AppLayoutWithExperiment from "../AppLayoutWithExperiment";
 import FormMetrics from "../FormMetrics";
 import LinkExternal from "../LinkExternal";
@@ -21,8 +21,8 @@ export const CORE_METRICS_DOC_URL =
 
 const PageEditMetrics: React.FunctionComponent<RouteComponentProps> = () => {
   const [updateExperimentProbeSets, { loading }] = useMutation<
-    { updateExperimentProbeSets: UpdateExperimentProbeSetsResult },
-    { input: UpdateExperimentProbeSetsInput }
+    { updateExperiment: UpdateExperimentProbeSetsResult },
+    { input: ExperimentInput }
   >(UPDATE_EXPERIMENT_PROBESETS_MUTATION);
 
   const [submitErrors, setSubmitErrors] = useState<Record<string, any>>({});
@@ -36,22 +36,22 @@ const PageEditMetrics: React.FunctionComponent<RouteComponentProps> = () => {
       secondaryProbeSetIds,
     }: Record<string, number[]>) => {
       try {
-        const nimbusExperimentId = parseInt(currentExperiment.current!.id, 10);
+        const nimbusExperimentId = currentExperiment.current!.id;
         const result = await updateExperimentProbeSets({
           variables: {
             input: {
-              nimbusExperimentId,
+              id: nimbusExperimentId,
               primaryProbeSetIds,
               secondaryProbeSetIds,
             },
           },
         });
 
-        if (!result.data?.updateExperimentProbeSets) {
+        if (!result.data?.updateExperiment) {
           throw new Error("Save failed, no error available");
         }
 
-        const { message } = result.data.updateExperimentProbeSets;
+        const { message } = result.data.updateExperiment;
 
         if (message && message !== "success" && typeof message === "object") {
           setIsServerValid(false);

--- a/app/experimenter/nimbus-ui/src/components/PageEditOverview/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditOverview/index.test.tsx
@@ -63,7 +63,7 @@ describe("PageEditOverview", () => {
     mutationMock = mockExperimentMutation(
       UPDATE_EXPERIMENT_OVERVIEW_MUTATION,
       { ...mockSubmitData, id: experiment.id },
-      "updateExperimentOverview",
+      "updateExperiment",
       {
         experiment: mockSubmitData,
       },
@@ -140,7 +140,7 @@ describe("PageEditOverview", () => {
     const expectedErrors = {
       name: { message: "already exists" },
     };
-    mutationMock.result.data.updateExperimentOverview.message = expectedErrors;
+    mutationMock.result.data.updateExperiment.message = expectedErrors;
     render(<Subject mocks={[mock, mutationMock]} />);
     let submitButton: HTMLButtonElement;
     await waitFor(() => {
@@ -156,7 +156,7 @@ describe("PageEditOverview", () => {
 
   it("handles experiment form submission with bad server data", async () => {
     // @ts-ignore - intentionally breaking this type for error handling
-    delete mutationMock.result.data.updateExperimentOverview;
+    delete mutationMock.result.data.updateExperiment;
     render(<Subject mocks={[mock, mutationMock]} />);
     let submitButton: HTMLButtonElement;
     await waitFor(() => {

--- a/app/experimenter/nimbus-ui/src/components/PageEditOverview/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditOverview/index.tsx
@@ -9,8 +9,8 @@ import AppLayoutWithExperiment from "../AppLayoutWithExperiment";
 import { useMutation } from "@apollo/client";
 import { UPDATE_EXPERIMENT_OVERVIEW_MUTATION } from "../../gql/experiments";
 import { SUBMIT_ERROR } from "../../lib/constants";
-import { UpdateExperimentInput } from "../../types/globalTypes";
-import { updateExperimentOverview_updateExperimentOverview as UpdateExperimentOverviewResult } from "../../types/updateExperimentOverview";
+import { ExperimentInput } from "../../types/globalTypes";
+import { updateExperimentOverview_updateExperiment as UpdateExperimentOverviewResult } from "../../types/updateExperimentOverview";
 import { getExperiment_experimentBySlug } from "../../types/getExperiment";
 import { editCommonRedirects } from "../../lib/experiment";
 
@@ -18,8 +18,8 @@ type PageEditOverviewProps = {} & RouteComponentProps;
 
 const PageEditOverview: React.FunctionComponent<PageEditOverviewProps> = () => {
   const [updateExperimentOverview, { loading }] = useMutation<
-    { updateExperimentOverview: UpdateExperimentOverviewResult },
-    { input: UpdateExperimentInput }
+    { updateExperiment: UpdateExperimentOverviewResult },
+    { input: ExperimentInput }
   >(UPDATE_EXPERIMENT_OVERVIEW_MUTATION);
 
   const [submitErrors, setSubmitErrors] = useState<Record<string, any>>({});
@@ -41,11 +41,11 @@ const PageEditOverview: React.FunctionComponent<PageEditOverviewProps> = () => {
           },
         });
 
-        if (!result.data?.updateExperimentOverview) {
+        if (!result.data?.updateExperiment) {
           throw new Error("Save failed, no error available");
         }
 
-        const { message } = result.data.updateExperimentOverview;
+        const { message } = result.data.updateExperiment;
 
         if (message && message !== "success" && typeof message === "object") {
           setIsServerValid(false);

--- a/app/experimenter/nimbus-ui/src/components/PageNew/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageNew/index.tsx
@@ -11,7 +11,7 @@ import { ReactComponent as DeleteIcon } from "../../images/x.svg";
 
 import { useMutation } from "@apollo/client";
 import { CREATE_EXPERIMENT_MUTATION } from "../../gql/experiments";
-import { CreateExperimentInput } from "../../types/globalTypes";
+import { ExperimentInput } from "../../types/globalTypes";
 import { createExperiment_createExperiment as CreateExperimentResult } from "../../types/createExperiment";
 import { navigate } from "@reach/router";
 import { SUBMIT_ERROR } from "../../lib/constants";
@@ -25,7 +25,7 @@ type PageNewProps = {} & RouteComponentProps;
 const PageNew: React.FunctionComponent<PageNewProps> = () => {
   const [createExperiment, { loading }] = useMutation<
     { createExperiment: CreateExperimentResult },
-    { input: CreateExperimentInput }
+    { input: ExperimentInput }
   >(CREATE_EXPERIMENT_MUTATION);
 
   const [submitErrors, setSubmitErrors] = useState<Record<string, any>>({});

--- a/app/experimenter/nimbus-ui/src/components/PageRequestReview/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageRequestReview/index.stories.tsx
@@ -16,7 +16,7 @@ const { mock, experiment } = mockExperimentQuery("demo-slug");
 storiesOf("pages/RequestReview", module)
   .addDecorator(withLinks)
   .add("success", () => (
-    <RouterSlugProvider mocks={[mock, createMutationMock(experiment.id)]}>
+    <RouterSlugProvider mocks={[mock, createMutationMock(experiment.id!)]}>
       <PageRequestReview polling={false} />
     </RouterSlugProvider>
   ))

--- a/app/experimenter/nimbus-ui/src/components/PageRequestReview/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageRequestReview/index.test.tsx
@@ -133,7 +133,7 @@ describe("PageRequestReview", () => {
     const { mock, experiment } = mockExperimentQuery("demo-slug", {
       status: NimbusExperimentStatus.DRAFT,
     });
-    const mutationMock = createMutationMock(experiment.id);
+    const mutationMock = createMutationMock(experiment.id!);
 
     render(<Subject mocks={[mock, mutationMock]} />);
     let submitButton: HTMLButtonElement;
@@ -151,9 +151,9 @@ describe("PageRequestReview", () => {
     const { mock, experiment } = mockExperimentQuery("demo-slug", {
       status: NimbusExperimentStatus.DRAFT,
     });
-    const mutationMock = createMutationMock(experiment.id);
+    const mutationMock = createMutationMock(experiment.id!);
     // @ts-ignore - intentionally breaking this type for error handling
-    delete mutationMock.result.data.updateExperimentStatus;
+    delete mutationMock.result.data.updateExperiment;
     render(<Subject mocks={[mock, mutationMock]} />);
     let submitButton: HTMLButtonElement;
     await waitFor(
@@ -170,7 +170,7 @@ describe("PageRequestReview", () => {
     const { mock, experiment } = mockExperimentQuery("demo-slug", {
       status: NimbusExperimentStatus.DRAFT,
     });
-    const mutationMock = createMutationMock(experiment.id);
+    const mutationMock = createMutationMock(experiment.id!);
     mutationMock.result.errors = [new Error("Boo")];
     render(<Subject mocks={[mock, mutationMock]} />);
     let submitButton: HTMLButtonElement;
@@ -188,10 +188,10 @@ describe("PageRequestReview", () => {
     const { mock, experiment } = mockExperimentQuery("demo-slug", {
       status: NimbusExperimentStatus.DRAFT,
     });
-    const mutationMock = createMutationMock(experiment.id);
+    const mutationMock = createMutationMock(experiment.id!);
     const errorMessage =
       "Nimbus Experiments can only transition from DRAFT to REVIEW.";
-    mutationMock.result.data.updateExperimentStatus.message = {
+    mutationMock.result.data.updateExperiment.message = {
       status: [errorMessage],
     };
     render(<Subject mocks={[mock, mutationMock]} />);

--- a/app/experimenter/nimbus-ui/src/components/PageRequestReview/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageRequestReview/index.tsx
@@ -9,10 +9,10 @@ import AppLayoutWithExperiment from "../AppLayoutWithExperiment";
 import { SUBMIT_ERROR } from "../../lib/constants";
 import { UPDATE_EXPERIMENT_STATUS_MUTATION } from "../../gql/experiments";
 import {
-  UpdateExperimentStatusInput,
+  ExperimentInput,
   NimbusExperimentStatus,
 } from "../../types/globalTypes";
-import { updateExperimentStatus_updateExperimentStatus as UpdateExperimentStatus } from "../../types/updateExperimentStatus";
+import { updateExperimentStatus_updateExperiment as UpdateExperimentStatus } from "../../types/updateExperimentStatus";
 import { getExperiment_experimentBySlug } from "../../types/getExperiment";
 import FormRequestReview from "../FormRequestReview";
 import Summary from "../Summary";
@@ -30,8 +30,8 @@ const PageRequestReview: React.FunctionComponent<PageRequestReviewProps> = ({
   const currentExperiment = useRef<getExperiment_experimentBySlug>();
 
   const [submitForReview, { loading }] = useMutation<
-    { updateExperimentStatus: UpdateExperimentStatus },
-    { input: UpdateExperimentStatusInput }
+    { updateExperiment: UpdateExperimentStatus },
+    { input: ExperimentInput }
   >(UPDATE_EXPERIMENT_STATUS_MUTATION);
 
   const onLaunchClicked = useCallback(async () => {
@@ -39,17 +39,17 @@ const PageRequestReview: React.FunctionComponent<PageRequestReviewProps> = ({
       const result = await submitForReview({
         variables: {
           input: {
-            nimbusExperimentId: parseInt(currentExperiment.current!.id),
+            id: currentExperiment.current!.id,
             status: NimbusExperimentStatus.REVIEW,
           },
         },
       });
 
-      if (!result.data?.updateExperimentStatus) {
+      if (!result.data?.updateExperiment) {
         throw new Error(SUBMIT_ERROR);
       }
 
-      const { message } = result.data.updateExperimentStatus;
+      const { message } = result.data.updateExperiment;
 
       if (message && message !== "success" && typeof message === "object") {
         return void setSubmitError(message.status.join(", "));

--- a/app/experimenter/nimbus-ui/src/components/PageRequestReview/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageRequestReview/mocks.tsx
@@ -6,14 +6,14 @@ import { UPDATE_EXPERIMENT_STATUS_MUTATION } from "../../gql/experiments";
 import { mockExperimentMutation } from "../../lib/mocks";
 import { NimbusExperimentStatus } from "../../types/globalTypes";
 
-export function createMutationMock(id: string) {
+export function createMutationMock(id: number) {
   return mockExperimentMutation(
     UPDATE_EXPERIMENT_STATUS_MUTATION,
     {
-      nimbusExperimentId: parseInt(id),
+      id,
       status: NimbusExperimentStatus.REVIEW,
     },
-    "updateExperimentStatus",
+    "updateExperiment",
     {
       experiment: {
         status: NimbusExperimentStatus.REVIEW,

--- a/app/experimenter/nimbus-ui/src/gql/experiments.ts
+++ b/app/experimenter/nimbus-ui/src/gql/experiments.ts
@@ -5,7 +5,7 @@
 import { gql } from "@apollo/client";
 
 export const CREATE_EXPERIMENT_MUTATION = gql`
-  mutation createExperiment($input: CreateExperimentInput!) {
+  mutation createExperiment($input: ExperimentInput!) {
     createExperiment(input: $input) {
       clientMutationId
       message
@@ -21,8 +21,8 @@ export const CREATE_EXPERIMENT_MUTATION = gql`
 `;
 
 export const UPDATE_EXPERIMENT_OVERVIEW_MUTATION = gql`
-  mutation updateExperimentOverview($input: UpdateExperimentInput!) {
-    updateExperimentOverview(input: $input) {
+  mutation updateExperimentOverview($input: ExperimentInput!) {
+    updateExperiment(input: $input) {
       clientMutationId
       message
       status
@@ -36,8 +36,8 @@ export const UPDATE_EXPERIMENT_OVERVIEW_MUTATION = gql`
 `;
 
 export const UPDATE_EXPERIMENT_STATUS_MUTATION = gql`
-  mutation updateExperimentStatus($input: UpdateExperimentStatusInput!) {
-    updateExperimentStatus(input: $input) {
+  mutation updateExperimentStatus($input: ExperimentInput!) {
+    updateExperiment(input: $input) {
       clientMutationId
       message
       status
@@ -49,8 +49,8 @@ export const UPDATE_EXPERIMENT_STATUS_MUTATION = gql`
 `;
 
 export const UPDATE_EXPERIMENT_BRANCHES_MUTATION = gql`
-  mutation updateExperimentBranches($input: UpdateExperimentBranchesInput!) {
-    updateExperimentBranches(input: $input) {
+  mutation updateExperimentBranches($input: ExperimentInput!) {
+    updateExperiment(input: $input) {
       clientMutationId
       message
       status
@@ -75,18 +75,16 @@ export const UPDATE_EXPERIMENT_BRANCHES_MUTATION = gql`
 `;
 
 export const UPDATE_EXPERIMENT_PROBESETS_MUTATION = gql`
-  mutation updateExperimentProbeSets($input: UpdateExperimentProbeSetsInput!) {
-    updateExperimentProbeSets(input: $input) {
+  mutation updateExperimentProbeSets($input: ExperimentInput!) {
+    updateExperiment(input: $input) {
       clientMutationId
       nimbusExperiment {
         id
         primaryProbeSets {
           id
-          name
         }
         secondaryProbeSets {
           id
-          name
         }
       }
       message
@@ -96,8 +94,8 @@ export const UPDATE_EXPERIMENT_PROBESETS_MUTATION = gql`
 `;
 
 export const UPDATE_EXPERIMENT_AUDIENCE_MUTATION = gql`
-  mutation updateExperimentAudience($input: UpdateExperimentAudienceInput!) {
-    updateExperimentAudience(input: $input) {
+  mutation updateExperimentAudience($input: ExperimentInput!) {
+    updateExperiment(input: $input) {
       clientMutationId
       message
       status

--- a/app/experimenter/nimbus-ui/src/lib/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/lib/mocks.tsx
@@ -35,6 +35,7 @@ import { getStatus } from "./experiment";
 import {
   NimbusFeatureConfigApplication,
   NimbusProbeKind,
+  ExperimentInput,
 } from "../types/globalTypes";
 import { ExperimentReview } from "../hooks";
 
@@ -285,7 +286,7 @@ export function mockExperimentQuery<
   let experiment: getExperiment["experimentBySlug"] = Object.assign(
     {
       __typename: "NimbusExperimentType",
-      id: "1",
+      id: 1,
       owner: {
         __typename: "NimbusExperimentOwner",
         email: "example@mozilla.com",
@@ -385,7 +386,7 @@ export const MOCK_REVIEW: ExperimentReview = {
 
 export const mockExperimentMutation = (
   mutation: DocumentNode,
-  input: Record<string, string | number | string[] | number[]>,
+  input: ExperimentInput,
   key: string,
   {
     status = 200,

--- a/app/experimenter/nimbus-ui/src/types/createExperiment.ts
+++ b/app/experimenter/nimbus-ui/src/types/createExperiment.ts
@@ -3,7 +3,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import { CreateExperimentInput, NimbusExperimentApplication } from "./globalTypes";
+import { ExperimentInput, NimbusExperimentApplication } from "./globalTypes";
 
 // ====================================================
 // GraphQL mutation operation: createExperiment
@@ -30,5 +30,5 @@ export interface createExperiment {
 }
 
 export interface createExperimentVariables {
-  input: CreateExperimentInput;
+  input: ExperimentInput;
 }

--- a/app/experimenter/nimbus-ui/src/types/getExperiment.ts
+++ b/app/experimenter/nimbus-ui/src/types/getExperiment.ts
@@ -67,7 +67,7 @@ export interface getExperiment_experimentBySlug_readyForReview {
 
 export interface getExperiment_experimentBySlug {
   __typename: "NimbusExperimentType";
-  id: string;
+  id: number | null;
   name: string;
   slug: string;
   status: NimbusExperimentStatus | null;

--- a/app/experimenter/nimbus-ui/src/types/globalTypes.ts
+++ b/app/experimenter/nimbus-ui/src/types/globalTypes.ts
@@ -72,11 +72,26 @@ export enum NimbusProbeKind {
   SCALAR = "SCALAR",
 }
 
-export interface CreateExperimentInput {
+export interface ExperimentInput {
   clientMutationId?: string | null;
-  name: string;
-  hypothesis: string;
-  application: NimbusExperimentApplication;
+  id?: number | null;
+  status?: NimbusExperimentStatus | null;
+  hypothesis?: string | null;
+  name?: string | null;
+  application?: NimbusExperimentApplication | null;
+  publicDescription?: string | null;
+  featureConfigId?: number | null;
+  referenceBranch?: ReferenceBranchType | null;
+  treatmentBranches?: (TreatmentBranchType | null)[] | null;
+  primaryProbeSetIds?: (number | null)[] | null;
+  secondaryProbeSetIds?: (number | null)[] | null;
+  channel?: NimbusExperimentChannel | null;
+  firefoxMinVersion?: NimbusExperimentFirefoxMinVersion | null;
+  populationPercent?: string | null;
+  proposedDuration?: number | null;
+  proposedEnrollment?: string | null;
+  targetingConfigSlug?: NimbusExperimentTargetingConfigSlug | null;
+  totalEnrolledClients?: number | null;
 }
 
 export interface ReferenceBranchType {
@@ -93,47 +108,6 @@ export interface TreatmentBranchType {
   ratio: number;
   featureEnabled?: boolean | null;
   featureValue?: string | null;
-}
-
-export interface UpdateExperimentAudienceInput {
-  clientMutationId?: string | null;
-  nimbusExperimentId: number;
-  channel?: NimbusExperimentChannel | null;
-  firefoxMinVersion?: NimbusExperimentFirefoxMinVersion | null;
-  populationPercent?: string | null;
-  proposedDuration?: number | null;
-  proposedEnrollment?: string | null;
-  targetingConfigSlug?: NimbusExperimentTargetingConfigSlug | null;
-  totalEnrolledClients?: number | null;
-}
-
-export interface UpdateExperimentBranchesInput {
-  clientMutationId?: string | null;
-  nimbusExperimentId: number;
-  featureConfigId?: number | null;
-  referenceBranch: ReferenceBranchType;
-  treatmentBranches: (TreatmentBranchType | null)[];
-}
-
-export interface UpdateExperimentInput {
-  clientMutationId?: string | null;
-  name: string;
-  hypothesis: string;
-  id: string;
-  publicDescription?: string | null;
-}
-
-export interface UpdateExperimentProbeSetsInput {
-  clientMutationId?: string | null;
-  nimbusExperimentId: number;
-  primaryProbeSetIds: (number | null)[];
-  secondaryProbeSetIds: (number | null)[];
-}
-
-export interface UpdateExperimentStatusInput {
-  clientMutationId?: string | null;
-  nimbusExperimentId: number;
-  status: NimbusExperimentStatus;
 }
 
 //==============================================================

--- a/app/experimenter/nimbus-ui/src/types/updateExperimentAudience.ts
+++ b/app/experimenter/nimbus-ui/src/types/updateExperimentAudience.ts
@@ -3,15 +3,15 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import { UpdateExperimentAudienceInput, NimbusExperimentChannel, NimbusExperimentFirefoxMinVersion, NimbusExperimentTargetingConfigSlug } from "./globalTypes";
+import { ExperimentInput, NimbusExperimentChannel, NimbusExperimentFirefoxMinVersion, NimbusExperimentTargetingConfigSlug } from "./globalTypes";
 
 // ====================================================
 // GraphQL mutation operation: updateExperimentAudience
 // ====================================================
 
-export interface updateExperimentAudience_updateExperimentAudience_nimbusExperiment {
+export interface updateExperimentAudience_updateExperiment_nimbusExperiment {
   __typename: "NimbusExperimentType";
-  id: string;
+  id: number | null;
   totalEnrolledClients: number;
   channel: NimbusExperimentChannel | null;
   firefoxMinVersion: NimbusExperimentFirefoxMinVersion | null;
@@ -21,18 +21,18 @@ export interface updateExperimentAudience_updateExperimentAudience_nimbusExperim
   targetingConfigSlug: NimbusExperimentTargetingConfigSlug | null;
 }
 
-export interface updateExperimentAudience_updateExperimentAudience {
-  __typename: "UpdateExperimentAudience";
+export interface updateExperimentAudience_updateExperiment {
+  __typename: "UpdateExperiment";
   clientMutationId: string | null;
   message: ObjectField | null;
   status: number | null;
-  nimbusExperiment: updateExperimentAudience_updateExperimentAudience_nimbusExperiment | null;
+  nimbusExperiment: updateExperimentAudience_updateExperiment_nimbusExperiment | null;
 }
 
 export interface updateExperimentAudience {
-  updateExperimentAudience: updateExperimentAudience_updateExperimentAudience | null;
+  updateExperiment: updateExperimentAudience_updateExperiment | null;
 }
 
 export interface updateExperimentAudienceVariables {
-  input: UpdateExperimentAudienceInput;
+  input: ExperimentInput;
 }

--- a/app/experimenter/nimbus-ui/src/types/updateExperimentBranches.ts
+++ b/app/experimenter/nimbus-ui/src/types/updateExperimentBranches.ts
@@ -3,51 +3,51 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import { UpdateExperimentBranchesInput } from "./globalTypes";
+import { ExperimentInput } from "./globalTypes";
 
 // ====================================================
 // GraphQL mutation operation: updateExperimentBranches
 // ====================================================
 
-export interface updateExperimentBranches_updateExperimentBranches_nimbusExperiment_featureConfig {
+export interface updateExperimentBranches_updateExperiment_nimbusExperiment_featureConfig {
   __typename: "NimbusFeatureConfigType";
   name: string;
 }
 
-export interface updateExperimentBranches_updateExperimentBranches_nimbusExperiment_referenceBranch {
+export interface updateExperimentBranches_updateExperiment_nimbusExperiment_referenceBranch {
   __typename: "NimbusBranchType";
   name: string;
   description: string;
   ratio: number;
 }
 
-export interface updateExperimentBranches_updateExperimentBranches_nimbusExperiment_treatmentBranches {
+export interface updateExperimentBranches_updateExperiment_nimbusExperiment_treatmentBranches {
   __typename: "NimbusBranchType";
   name: string;
   description: string;
   ratio: number;
 }
 
-export interface updateExperimentBranches_updateExperimentBranches_nimbusExperiment {
+export interface updateExperimentBranches_updateExperiment_nimbusExperiment {
   __typename: "NimbusExperimentType";
-  id: string;
-  featureConfig: updateExperimentBranches_updateExperimentBranches_nimbusExperiment_featureConfig | null;
-  referenceBranch: updateExperimentBranches_updateExperimentBranches_nimbusExperiment_referenceBranch | null;
-  treatmentBranches: (updateExperimentBranches_updateExperimentBranches_nimbusExperiment_treatmentBranches | null)[] | null;
+  id: number | null;
+  featureConfig: updateExperimentBranches_updateExperiment_nimbusExperiment_featureConfig | null;
+  referenceBranch: updateExperimentBranches_updateExperiment_nimbusExperiment_referenceBranch | null;
+  treatmentBranches: (updateExperimentBranches_updateExperiment_nimbusExperiment_treatmentBranches | null)[] | null;
 }
 
-export interface updateExperimentBranches_updateExperimentBranches {
-  __typename: "UpdateExperimentBranches";
+export interface updateExperimentBranches_updateExperiment {
+  __typename: "UpdateExperiment";
   clientMutationId: string | null;
   message: ObjectField | null;
   status: number | null;
-  nimbusExperiment: updateExperimentBranches_updateExperimentBranches_nimbusExperiment | null;
+  nimbusExperiment: updateExperimentBranches_updateExperiment_nimbusExperiment | null;
 }
 
 export interface updateExperimentBranches {
-  updateExperimentBranches: updateExperimentBranches_updateExperimentBranches | null;
+  updateExperiment: updateExperimentBranches_updateExperiment | null;
 }
 
 export interface updateExperimentBranchesVariables {
-  input: UpdateExperimentBranchesInput;
+  input: ExperimentInput;
 }

--- a/app/experimenter/nimbus-ui/src/types/updateExperimentOverview.ts
+++ b/app/experimenter/nimbus-ui/src/types/updateExperimentOverview.ts
@@ -3,31 +3,31 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import { UpdateExperimentInput } from "./globalTypes";
+import { ExperimentInput } from "./globalTypes";
 
 // ====================================================
 // GraphQL mutation operation: updateExperimentOverview
 // ====================================================
 
-export interface updateExperimentOverview_updateExperimentOverview_nimbusExperiment {
+export interface updateExperimentOverview_updateExperiment_nimbusExperiment {
   __typename: "NimbusExperimentType";
   name: string;
   hypothesis: string | null;
   publicDescription: string | null;
 }
 
-export interface updateExperimentOverview_updateExperimentOverview {
-  __typename: "UpdateExperimentOverview";
+export interface updateExperimentOverview_updateExperiment {
+  __typename: "UpdateExperiment";
   clientMutationId: string | null;
   message: ObjectField | null;
   status: number | null;
-  nimbusExperiment: updateExperimentOverview_updateExperimentOverview_nimbusExperiment | null;
+  nimbusExperiment: updateExperimentOverview_updateExperiment_nimbusExperiment | null;
 }
 
 export interface updateExperimentOverview {
-  updateExperimentOverview: updateExperimentOverview_updateExperimentOverview | null;
+  updateExperiment: updateExperimentOverview_updateExperiment | null;
 }
 
 export interface updateExperimentOverviewVariables {
-  input: UpdateExperimentInput;
+  input: ExperimentInput;
 }

--- a/app/experimenter/nimbus-ui/src/types/updateExperimentProbeSets.ts
+++ b/app/experimenter/nimbus-ui/src/types/updateExperimentProbeSets.ts
@@ -3,43 +3,41 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import { UpdateExperimentProbeSetsInput } from "./globalTypes";
+import { ExperimentInput } from "./globalTypes";
 
 // ====================================================
 // GraphQL mutation operation: updateExperimentProbeSets
 // ====================================================
 
-export interface updateExperimentProbeSets_updateExperimentProbeSets_nimbusExperiment_primaryProbeSets {
+export interface updateExperimentProbeSets_updateExperiment_nimbusExperiment_primaryProbeSets {
   __typename: "NimbusProbeSetType";
   id: string;
-  name: string;
 }
 
-export interface updateExperimentProbeSets_updateExperimentProbeSets_nimbusExperiment_secondaryProbeSets {
+export interface updateExperimentProbeSets_updateExperiment_nimbusExperiment_secondaryProbeSets {
   __typename: "NimbusProbeSetType";
   id: string;
-  name: string;
 }
 
-export interface updateExperimentProbeSets_updateExperimentProbeSets_nimbusExperiment {
+export interface updateExperimentProbeSets_updateExperiment_nimbusExperiment {
   __typename: "NimbusExperimentType";
-  id: string;
-  primaryProbeSets: (updateExperimentProbeSets_updateExperimentProbeSets_nimbusExperiment_primaryProbeSets | null)[] | null;
-  secondaryProbeSets: (updateExperimentProbeSets_updateExperimentProbeSets_nimbusExperiment_secondaryProbeSets | null)[] | null;
+  id: number | null;
+  primaryProbeSets: (updateExperimentProbeSets_updateExperiment_nimbusExperiment_primaryProbeSets | null)[] | null;
+  secondaryProbeSets: (updateExperimentProbeSets_updateExperiment_nimbusExperiment_secondaryProbeSets | null)[] | null;
 }
 
-export interface updateExperimentProbeSets_updateExperimentProbeSets {
-  __typename: "UpdateExperimentProbeSets";
+export interface updateExperimentProbeSets_updateExperiment {
+  __typename: "UpdateExperiment";
   clientMutationId: string | null;
-  nimbusExperiment: updateExperimentProbeSets_updateExperimentProbeSets_nimbusExperiment | null;
+  nimbusExperiment: updateExperimentProbeSets_updateExperiment_nimbusExperiment | null;
   message: ObjectField | null;
   status: number | null;
 }
 
 export interface updateExperimentProbeSets {
-  updateExperimentProbeSets: updateExperimentProbeSets_updateExperimentProbeSets | null;
+  updateExperiment: updateExperimentProbeSets_updateExperiment | null;
 }
 
 export interface updateExperimentProbeSetsVariables {
-  input: UpdateExperimentProbeSetsInput;
+  input: ExperimentInput;
 }

--- a/app/experimenter/nimbus-ui/src/types/updateExperimentStatus.ts
+++ b/app/experimenter/nimbus-ui/src/types/updateExperimentStatus.ts
@@ -3,29 +3,29 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import { UpdateExperimentStatusInput, NimbusExperimentStatus } from "./globalTypes";
+import { ExperimentInput, NimbusExperimentStatus } from "./globalTypes";
 
 // ====================================================
 // GraphQL mutation operation: updateExperimentStatus
 // ====================================================
 
-export interface updateExperimentStatus_updateExperimentStatus_nimbusExperiment {
+export interface updateExperimentStatus_updateExperiment_nimbusExperiment {
   __typename: "NimbusExperimentType";
   status: NimbusExperimentStatus | null;
 }
 
-export interface updateExperimentStatus_updateExperimentStatus {
-  __typename: "UpdateExperimentStatus";
+export interface updateExperimentStatus_updateExperiment {
+  __typename: "UpdateExperiment";
   clientMutationId: string | null;
   message: ObjectField | null;
   status: number | null;
-  nimbusExperiment: updateExperimentStatus_updateExperimentStatus_nimbusExperiment | null;
+  nimbusExperiment: updateExperimentStatus_updateExperiment_nimbusExperiment | null;
 }
 
 export interface updateExperimentStatus {
-  updateExperimentStatus: updateExperimentStatus_updateExperimentStatus | null;
+  updateExperiment: updateExperimentStatus_updateExperiment | null;
 }
 
 export interface updateExperimentStatusVariables {
-  input: UpdateExperimentStatusInput;
+  input: ExperimentInput;
 }


### PR DESCRIPTION
Because

* While implementing changes to the graphql API to make all mutations partial, I discovered it would be easier if we had a single mutation rather than many and have to update many inputs, serializers, queries, etc

This commit

* Flattens all mutations into a single partial mutation on the experiment object which gets us most of the way to having fully partial mutations per page, I think we might need to do a bit extra on top of this as an immediate followup but this should get most of the way there.
* Plus I cleaned a few things up like
  - Making sure we use the same key for experiment id everywhere (instead of id sometimes and nimbus_experiment_id others)
  - Making sure nimbus experiment id is always a number instead of sometimes a number and sometimes a string
  - I noticed ids for other objects are sometimes strings but I can do that as a followup it's filed as a separate ticket