### PR TITLE
fix #4010 feat(nimbus): add branches table to summary & review pages

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/Summary/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/index.stories.tsx
@@ -21,6 +21,13 @@ storiesOf("components/Summary", module)
       status: NimbusExperimentStatus.ACCEPTED,
     });
     return <Subject {...{ experiment }} />;
+  })
+  .add("no branches", () => {
+    const { experiment } = mockExperimentQuery("demo-slug", {
+      referenceBranch: null,
+      treatmentBranches: null,
+    });
+    return <Subject {...{ experiment }} />;
   });
 
 const Subject = ({

--- a/app/experimenter/nimbus-ui/src/components/Summary/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/index.test.tsx
@@ -16,6 +16,27 @@ describe("Summary", () => {
     expect(screen.getByTestId("summary-timeline")).toBeInTheDocument();
     expect(screen.getByTestId("table-summary")).toBeInTheDocument();
     expect(screen.getByTestId("table-audience")).toBeInTheDocument();
+    expect(screen.queryAllByTestId("table-branch")).toHaveLength(2);
+    expect(screen.getByTestId("branches-section-title")).toHaveTextContent(
+      "Branches (2)",
+    );
+  });
+
+  it("renders as expected with no defined branches", () => {
+    const { experiment } = mockExperimentQuery("demo-slug");
+    render(
+      <Subject
+        experiment={{
+          ...experiment,
+          referenceBranch: null,
+          treatmentBranches: null,
+        }}
+      />,
+    );
+    expect(screen.queryAllByTestId("table-branch")).toHaveLength(0);
+    expect(screen.getByTestId("branches-section-title")).toHaveTextContent(
+      "Branches (0)",
+    );
   });
 
   describe("JSON representation link", () => {

--- a/app/experimenter/nimbus-ui/src/components/Summary/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/index.tsx
@@ -7,6 +7,7 @@ import { getExperiment_experimentBySlug } from "../../types/getExperiment";
 import SummaryTimeline from "../SummaryTimeline";
 import TableSummary from "../TableSummary";
 import TableAudience from "../TableAudience";
+import TableBranches from "../TableBranches";
 import LinkExternal from "../LinkExternal";
 import { getStatus } from "../../lib/experiment";
 import MonitoringLink from "../MonitoringLink";
@@ -19,6 +20,10 @@ type SummaryProps = {
 
 const Summary = ({ experiment }: SummaryProps) => {
   const status = getStatus(experiment);
+  const branchCount = [
+    experiment.referenceBranch,
+    ...(experiment.treatmentBranches || []),
+  ].filter((branch) => !!branch).length;
 
   return (
     <div data-testid="summary">
@@ -43,6 +48,11 @@ const Summary = ({ experiment }: SummaryProps) => {
 
       <h2 className="h5 mb-3">Audience</h2>
       <TableAudience {...{ experiment }} />
+
+      <h2 className="h5 mb-3" data-testid="branches-section-title">
+        Branches ({branchCount})
+      </h2>
+      <TableBranches {...{ experiment }} />
     </div>
   );
 };

--- a/app/experimenter/nimbus-ui/src/components/TableBranches/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/TableBranches/index.stories.tsx
@@ -1,0 +1,51 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from "react";
+import { storiesOf } from "@storybook/react";
+import { Subject, MOCK_EXPERIMENT } from "./mocks";
+
+storiesOf("components/TableBranches", module)
+  .add("full branches", () => <Subject />)
+  .add("disabled branch", () => (
+    <Subject
+      experiment={{
+        ...MOCK_EXPERIMENT,
+        referenceBranch: {
+          ...MOCK_EXPERIMENT.referenceBranch!,
+          featureEnabled: false,
+        },
+      }}
+    />
+  ))
+  .add("feature without schema", () => (
+    <Subject
+      experiment={{
+        ...MOCK_EXPERIMENT,
+        featureConfig: {
+          ...MOCK_EXPERIMENT.featureConfig!,
+          schema: null,
+        },
+      }}
+    />
+  ))
+  .add("missing fields", () => (
+    <Subject
+      experiment={{
+        ...MOCK_EXPERIMENT,
+        treatmentBranches: [
+          {
+            __typename: "NimbusBranchType",
+            name: "",
+            slug: "",
+            description: "",
+            ratio: 0,
+            featureValue: null,
+            featureEnabled: false,
+          },
+          ...MOCK_EXPERIMENT.treatmentBranches!,
+        ],
+      }}
+    />
+  ));

--- a/app/experimenter/nimbus-ui/src/components/TableBranches/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/TableBranches/index.test.tsx
@@ -1,0 +1,147 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { Subject, MOCK_EXPERIMENT } from "./mocks";
+
+describe("TableBranches", () => {
+  it("renders as expected with defaults", () => {
+    render(<Subject />);
+    expect(screen.queryByTestId("not-set")).not.toBeInTheDocument();
+    expect(screen.queryAllByTestId("table-branch")).toHaveLength(2);
+  });
+
+  it("handles zero defined branches", () => {
+    render(
+      <Subject
+        experiment={{
+          ...MOCK_EXPERIMENT,
+          referenceBranch: null,
+          treatmentBranches: null,
+        }}
+      />,
+    );
+    expect(screen.getByTestId("not-set")).toBeInTheDocument();
+  });
+
+  it("hides feature value when feature schema is null", () => {
+    render(
+      <Subject
+        experiment={{
+          ...MOCK_EXPERIMENT,
+          featureConfig: {
+            ...MOCK_EXPERIMENT.featureConfig!,
+            schema: null,
+          },
+        }}
+      />,
+    );
+    expect(screen.queryByTestId("branch-value")).not.toBeInTheDocument();
+  });
+
+  it("hides feature value when feature is not enabled", () => {
+    render(
+      <Subject
+        experiment={{
+          ...MOCK_EXPERIMENT,
+          referenceBranch: {
+            ...MOCK_EXPERIMENT.referenceBranch!,
+            featureEnabled: false,
+          },
+          treatmentBranches: [
+            {
+              ...MOCK_EXPERIMENT.treatmentBranches![0]!,
+              featureEnabled: false,
+            },
+          ],
+        }}
+      />,
+    );
+    expect(screen.queryByTestId("branch-value")).not.toBeInTheDocument();
+    for (const cell of screen.queryAllByTestId("branch-enabled")) {
+      expect(cell).toHaveTextContent("False");
+    }
+  });
+
+  it("renders expected content", () => {
+    const expected = {
+      name: "expected name",
+      slug: "expected slug",
+      description: "expected description",
+      ratio: 42,
+      featureValue: '{ "thing": true }',
+    };
+
+    render(
+      <Subject
+        experiment={{
+          ...MOCK_EXPERIMENT,
+          treatmentBranches: [
+            {
+              __typename: "NimbusBranchType",
+              ...expected,
+              featureEnabled: true,
+            },
+            ...MOCK_EXPERIMENT.treatmentBranches!,
+          ],
+        }}
+      />,
+    );
+
+    const branchTables = screen.queryAllByTestId("table-branch");
+    expect(branchTables).toHaveLength(3);
+
+    const subjectTable = branchTables[1];
+
+    const cell = subjectTable.querySelector(`[data-testid='branch-enabled']`);
+    expect(cell).toBeInTheDocument();
+    expect(cell).toHaveTextContent("True");
+
+    for (const [name, value] of Object.entries(expected)) {
+      const cell = subjectTable.querySelector(`[data-testid='branch-${name}']`);
+      expect(cell).toBeInTheDocument();
+      expect(cell).toHaveTextContent(String(value));
+    }
+  });
+
+  it("displays not set for missing branch properties", () => {
+    render(
+      <Subject
+        experiment={{
+          ...MOCK_EXPERIMENT,
+          treatmentBranches: [
+            {
+              __typename: "NimbusBranchType",
+              name: "",
+              slug: "",
+              description: "",
+              ratio: 0,
+              featureValue: null,
+              featureEnabled: true,
+            },
+            ...MOCK_EXPERIMENT.treatmentBranches!,
+          ],
+        }}
+      />,
+    );
+
+    const branchTables = screen.queryAllByTestId("table-branch");
+    expect(branchTables).toHaveLength(3);
+
+    const subjectTable = branchTables[1];
+    for (const name of [
+      "name",
+      "slug",
+      "description",
+      "ratio",
+      "featureValue",
+    ] as const) {
+      const cell = subjectTable.querySelector(`[data-testid='branch-${name}']`);
+      expect(cell).toBeInTheDocument();
+      const notSet = cell!.querySelector("[data-testid='not-set']");
+      expect(notSet).toBeInTheDocument();
+    }
+  });
+});

--- a/app/experimenter/nimbus-ui/src/components/TableBranches/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/TableBranches/index.tsx
@@ -1,0 +1,91 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from "react";
+import {
+  getExperiment_experimentBySlug,
+  getExperiment_experimentBySlug_referenceBranch,
+  getExperiment_experimentBySlug_treatmentBranches,
+} from "../../types/getExperiment";
+import { Table } from "react-bootstrap";
+import NotSet from "../NotSet";
+
+type Branch =
+  | getExperiment_experimentBySlug_referenceBranch
+  | getExperiment_experimentBySlug_treatmentBranches;
+
+const TableBranches = ({
+  experiment,
+}: {
+  experiment: getExperiment_experimentBySlug;
+}) => {
+  const { featureConfig } = experiment;
+  const hasSchema = featureConfig?.schema !== null;
+  const branches = [
+    experiment.referenceBranch,
+    ...(experiment.treatmentBranches || []),
+  ].filter((branch): branch is Branch => branch !== null);
+
+  if (branches.length === 0) {
+    return <NotSet />;
+  }
+
+  return (
+    <>
+      {branches.map((branch, key) => (
+        <TableBranch key={key} {...{ hasSchema, branch }} />
+      ))}
+    </>
+  );
+};
+
+const TableBranch = ({
+  hasSchema,
+  branch: { name, slug, description, ratio, featureValue, featureEnabled },
+}: {
+  hasSchema: boolean;
+  branch: Branch;
+}) => {
+  return (
+    <Table striped bordered data-testid="table-branch" className="mb-4">
+      <tbody>
+        <tr>
+          <th colSpan={2} data-testid="branch-name">
+            {name ? name : <NotSet />}
+          </th>
+        </tr>
+        <tr>
+          <th className="w-33">Slug</th>
+          <td data-testid="branch-slug">{slug ? slug : <NotSet />}</td>
+        </tr>
+        <tr>
+          <th>Description</th>
+          <td data-testid="branch-description">
+            {description ? description : <NotSet />}
+          </td>
+        </tr>
+        <tr>
+          <th>Ratio</th>
+          <td data-testid="branch-ratio">{ratio ? ratio : <NotSet />}</td>
+        </tr>
+        <tr>
+          <th>Enabled</th>
+          <td data-testid="branch-enabled">
+            {featureEnabled ? "True" : "False"}
+          </td>
+        </tr>
+        {hasSchema && featureEnabled && (
+          <tr>
+            <th>Value</th>
+            <td data-testid="branch-featureValue">
+              {featureValue ? featureValue : <NotSet />}
+            </td>
+          </tr>
+        )}
+      </tbody>
+    </Table>
+  );
+};
+
+export default TableBranches;

--- a/app/experimenter/nimbus-ui/src/components/TableBranches/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/components/TableBranches/mocks.tsx
@@ -1,0 +1,32 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from "react";
+import { mockExperimentQuery } from "../../lib/mocks";
+import AppLayout from "../AppLayout";
+import TableBranches from ".";
+import { RouterSlugProvider } from "../../lib/test-utils";
+
+type TableBranchesProps = React.ComponentProps<typeof TableBranches>;
+
+const { experiment } = mockExperimentQuery("demo-slug", {});
+export const MOCK_EXPERIMENT = {
+  ...experiment,
+  featureConfig: {
+    ...experiment.featureConfig!,
+    schema: "{}",
+  },
+};
+
+export const Subject = ({
+  experiment = MOCK_EXPERIMENT,
+}: Partial<TableBranchesProps>) => {
+  return (
+    <AppLayout>
+      <RouterSlugProvider>
+        <TableBranches {...{ experiment }} />
+      </RouterSlugProvider>
+    </AppLayout>
+  );
+};


### PR DESCRIPTION
Because:

- we want to display experiment branches on summary and review pages

This commit:

- creates a new TableBranches component to list experiment branches

- displays TableBranches component in Summary component

- includes updates to tests, stories, etc.