### PR TITLE
fix(legacy): Add rel='noopener noreferrer' to external link

### DIFF
--- a/app/experimenter/legacy-ui/templates/experiments/section_normandy.html
+++ b/app/experimenter/legacy-ui/templates/experiments/section_normandy.html
@@ -39,6 +39,11 @@ Info {% endblock %} {% block section_content %} {% if experiment.recipe_slug %}
   <strong class="mr-2">Normandy Recipe Data: </strong>
 </p>
 <p>
-  <a href="{{ experiment.api_recipe_url }}" target="_blank">Preview</a>
+  <a
+    href="{{ experiment.api_recipe_url }}"
+    target="_blank"
+    rel="noopener noreferrer"
+    >Preview</a
+  >
 </p>
 {% endif %} {% endblock %}


### PR DESCRIPTION
Couldn't find a filed issue for this (and didn't bother, YOLO) but our codeQL scan is complaining about it: https://github.com/mozilla/experimenter/security/code-scanning/6?query=ref%3Arefs%2Fheads%2Fmain