### PR TITLE
add population_percent in review, fix case-mismatches in submit errors

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/FormAudience/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/FormAudience/index.test.tsx
@@ -13,6 +13,7 @@ import {
 import { Subject, MOCK_EXPERIMENT } from "./mocks";
 import { AUDIENCE_DOC_URL } from ".";
 import { MOCK_CONFIG } from "../../lib/mocks";
+import { snakeToCamelCase } from "../../lib/caseConversions";
 
 describe("FormAudience", () => {
   it("renders without error", async () => {
@@ -52,18 +53,19 @@ describe("FormAudience", () => {
     const submitErrors = {
       "*": ["Big bad server thing happened"],
       channel: ["Cannot tune in this channel"],
-      firefoxMinVersion: ["Bad min version"],
-      targetingConfigSlug: ["This slug is icky"],
-      populationPercent: ["This is not a percentage"],
-      totalEnrolledClients: ["Need a number here, bud."],
-      proposedEnrollment: ["Emoji are not numbers"],
-      proposedDuration: ["No negative numbers"],
+      firefox_min_version: ["Bad min version"],
+      targeting_config_slug: ["This slug is icky"],
+      population_percent: ["This is not a percentage"],
+      total_enrolled_clients: ["Need a number here, bud."],
+      proposed_enrollment: ["Emoji are not numbers"],
+      proposed_duration: ["No negative numbers"],
     };
     const { container } = render(<Subject submitErrors={submitErrors} />);
     await waitFor(() => {
       expect(screen.queryByTestId("FormAudience")).toBeInTheDocument();
     });
-    for (const [fieldName, [error]] of Object.entries(submitErrors)) {
+    for (const [submitErrorName, [error]] of Object.entries(submitErrors)) {
+      const fieldName = snakeToCamelCase(submitErrorName);
       if (fieldName === "*") {
         expect(screen.getByTestId("submit-error")).toHaveTextContent(error);
       } else {
@@ -194,6 +196,7 @@ describe("FormAudience", () => {
       "channel",
       "populationPercent",
       "totalEnrolledClients",
+      "populationPercent",
       "proposedEnrollment",
       "proposedDuration",
       "firefoxMinVersion",
@@ -230,6 +233,7 @@ describe("FormAudience", () => {
               __typename: "NimbusReadyForReviewType",
               ready: false,
               message: {
+                population_percent: ["This field may not be null."],
                 proposed_duration: ["This field may not be null."],
                 proposed_enrollment: ["This field may not be null."],
                 firefox_min_version: ["This field may not be null."],
@@ -246,6 +250,9 @@ describe("FormAudience", () => {
     expect(screen.queryByTestId("missing-channel")).toBeInTheDocument();
     expect(screen.queryByTestId("missing-ff-min")).toBeInTheDocument();
     expect(screen.queryByTestId("missing-config")).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("missing-population-percent"),
+    ).toBeInTheDocument();
     expect(screen.queryByTestId("missing-enrollment")).toBeInTheDocument();
     expect(screen.queryByTestId("missing-duration")).toBeInTheDocument();
   });

--- a/app/experimenter/nimbus-ui/src/components/FormAudience/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/FormAudience/index.tsx
@@ -192,7 +192,15 @@ export const FormAudience = ({
 
         <Form.Row>
           <Form.Group as={Col} className="mx-5" controlId="populationPercent">
-            <Form.Label>Percent of clients</Form.Label>
+            <Form.Label>
+              Percent of clients
+              {isMissingField("population_percent") && (
+                <InlineErrorIcon
+                  name="population-percent"
+                  message="A valid percent of clients must be set"
+                />
+              )}
+            </Form.Label>
             <InputGroup>
               <Form.Control
                 {...formControlAttrs("populationPercent")}

--- a/app/experimenter/nimbus-ui/src/components/FormBranches/reducer/actions.ts
+++ b/app/experimenter/nimbus-ui/src/components/FormBranches/reducer/actions.ts
@@ -8,7 +8,7 @@ import {
   createAnnotatedBranch,
 } from "./state";
 import { FormData } from "./update";
-import snakeToCamelCase from "../../../lib/snakeToCamelCase";
+import { snakeToCamelCase } from "../../../lib/caseConversions";
 
 export const REFERENCE_BRANCH_IDX = -1;
 

--- a/app/experimenter/nimbus-ui/src/hooks/useCommonForm.test.tsx
+++ b/app/experimenter/nimbus-ui/src/hooks/useCommonForm.test.tsx
@@ -60,7 +60,7 @@ describe("hooks/useCommonForm", () => {
 
     it("clears submit error onChange of multiselect", async () => {
       const submitErrors = {
-        primaryProbeSetIds: ["You primary probed the wrong bear."],
+        primary_probe_set_ids: ["You primary probed the wrong bear."],
       };
       const { experiment } = mockExperimentQuery("boo", {
         primaryProbeSets: [],
@@ -71,7 +71,7 @@ describe("hooks/useCommonForm", () => {
 
       const primaryProbeSets = screen.getByTestId("primary-probe-sets");
       const errorFeedback = screen.getByText(
-        submitErrors.primaryProbeSetIds[0],
+        submitErrors.primary_probe_set_ids[0],
       );
       expect(errorFeedback).toBeInTheDocument();
       expect(

--- a/app/experimenter/nimbus-ui/src/hooks/useCommonForm.tsx
+++ b/app/experimenter/nimbus-ui/src/hooks/useCommonForm.tsx
@@ -6,6 +6,7 @@ import React from "react";
 import { RegisterOptions, FieldError } from "react-hook-form";
 import Form from "react-bootstrap/Form";
 import { useForm } from "react-hook-form";
+import { camelToSnakeCase } from "../lib/caseConversions";
 
 // TODO: 'any' type on `onChange={(selectedOptions) => ...`,
 // it wants this, but can't seem to coerce it into SelectOption type
@@ -36,9 +37,9 @@ export function useCommonForm<FieldNames extends string>(
   const isDirtyUnsaved = isDirty && !(isValid && isSubmitted);
 
   const hideSubmitError = <K extends FieldNames>(name: K) => {
-    if (submitErrors[name]) {
+    if (submitErrors[camelToSnakeCase(name)]) {
       const modifiedSubmitErrors = { ...submitErrors };
-      delete modifiedSubmitErrors[name];
+      delete modifiedSubmitErrors[camelToSnakeCase(name)];
       setSubmitErrors(modifiedSubmitErrors);
     }
   };
@@ -56,8 +57,12 @@ export function useCommonForm<FieldNames extends string>(
     ref: register(registerOptions),
     defaultValue: defaultValues[name],
     onChange: () => hideSubmitError(name),
-    isInvalid: Boolean(submitErrors[name] || (touched[name] && errors[name])),
-    isValid: Boolean(!submitErrors[name] && touched[name] && !errors[name]),
+    isInvalid: Boolean(
+      submitErrors[camelToSnakeCase(name)] || (touched[name] && errors[name]),
+    ),
+    isValid: Boolean(
+      !submitErrors[camelToSnakeCase(name)] && touched[name] && !errors[name],
+    ),
   });
 
   const getValuesFromOptions = (selectedOptions: SelectOption[] | null) =>
@@ -76,7 +81,9 @@ export function useCommonForm<FieldNames extends string>(
       setValuesFromOptions(getValuesFromOptions(selectedOptions));
       hideSubmitError(name);
     },
-    className: Boolean(submitErrors[name] || (touched[name] && errors[name]))
+    className: Boolean(
+      submitErrors[camelToSnakeCase(name)] || (touched[name] && errors[name]),
+    )
       ? "is-invalid border border-danger rounded"
       : "",
   });
@@ -88,14 +95,14 @@ export function useCommonForm<FieldNames extends string>(
           {(errors[name] as FieldError).message}
         </Form.Control.Feedback>
       )}
-      {submitErrors[name] && (
+      {submitErrors[camelToSnakeCase(name)] && (
         <Form.Control.Feedback type="invalid" data-for={name}>
-          {submitErrors[name]}
+          {submitErrors[camelToSnakeCase(name)]}
         </Form.Control.Feedback>
       )}
       {/* for testing - can't wrap the errors in a container with a test ID
       because of Bootstrap's adjacent class CSS rules */}
-      {!errors[name] && !submitErrors[name] && (
+      {!errors[name] && !submitErrors[camelToSnakeCase(name)] && (
         <span data-testid={`${name}-form-errors`} />
       )}
     </>

--- a/app/experimenter/nimbus-ui/src/hooks/useExperiment.test.tsx
+++ b/app/experimenter/nimbus-ui/src/hooks/useExperiment.test.tsx
@@ -41,7 +41,7 @@ describe("hooks/useExperiment", () => {
     });
 
     describe("ready for review", () => {
-      const readyMessage = {
+      const readyMessages = {
         public_description: ["This field may not be null."],
         proposed_duration: ["This field may not be null."],
         proposed_enrollment: ["This field may not be null."],
@@ -49,9 +49,30 @@ describe("hooks/useExperiment", () => {
         targeting_config_slug: ["This field may not be null."],
         reference_branch: ["This field may not be null."],
         channel: ["This field may not be null."],
-      };
+        population_percent: [
+          "Ensure this value is greater than or equal to 0.0001.",
+        ],
+      } as const;
 
-      it("returns correct review info when missing details", async () => {
+      const pageNames = {
+        public_description: "overview",
+        proposed_duration: "audience",
+        proposed_enrollment: "audience",
+        firefox_min_version: "audience",
+        targeting_config_slug: "audience",
+        reference_branch: "branches",
+        channel: "audience",
+        population_percent: "audience",
+      } as const;
+
+      const commonMissingDetailsTest = (
+        fieldName: keyof typeof readyMessages,
+      ) => async () => {
+        const readyMessage = {
+          [fieldName]: readyMessages[fieldName],
+        };
+        const pageName = pageNames[fieldName];
+
         Object.defineProperty(window, "location", {
           value: {
             search: "?show-errors",
@@ -81,9 +102,7 @@ describe("hooks/useExperiment", () => {
           } = hook.review;
 
           expect(ready).toBeFalsy();
-          expect(invalidPages).toEqual(
-            expect.arrayContaining(["overview", "branches", "audience"]),
-          );
+          expect(invalidPages).toEqual(expect.arrayContaining([pageName]));
           expect(missingFields).toEqual(
             expect.arrayContaining(Object.keys(readyMessage)),
           );
@@ -91,7 +110,15 @@ describe("hooks/useExperiment", () => {
             expect(isMissingField(fieldName)).toBeTruthy();
           });
         });
-      });
+      };
+
+      let fieldName: keyof typeof readyMessages;
+      for (fieldName in readyMessages) {
+        it(
+          `returns correct review info when missing details for ${fieldName}`,
+          commonMissingDetailsTest(fieldName),
+        );
+      }
 
       it("returns correct review info when not missing any details", async () => {
         const { mock } = mockExperimentQuery("howdy", {
@@ -119,7 +146,7 @@ describe("hooks/useExperiment", () => {
           expect(ready).toBeTruthy();
           expect(invalidPages).toEqual([]);
           expect(missingFields).toEqual([]);
-          Object.keys(readyMessage).forEach((fieldName) => {
+          Object.keys(readyMessages).forEach((fieldName) => {
             expect(isMissingField(fieldName)).toBeFalsy();
           });
         });

--- a/app/experimenter/nimbus-ui/src/hooks/useExperiment.tsx
+++ b/app/experimenter/nimbus-ui/src/hooks/useExperiment.tsx
@@ -15,6 +15,7 @@ const fieldPageMap: { [page: string]: string[] } = {
     "targeting_config_slug",
     "proposed_enrollment",
     "proposed_duration",
+    "population_percent",
   ],
 };
 

--- a/app/experimenter/nimbus-ui/src/lib/caseConversions.test.ts
+++ b/app/experimenter/nimbus-ui/src/lib/caseConversions.test.ts
@@ -2,10 +2,16 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import snakeToCamelCase from "./snakeToCamelCase";
+import { snakeToCamelCase, camelToSnakeCase } from "./caseConversions";
 
 describe("snakeToCamelCase", () => {
   it("converts snake_case to camelCase", () => {
     expect(snakeToCamelCase("this_is_a_test")).toEqual("thisIsATest");
+  });
+});
+
+describe("camelToSnakeCase", () => {
+  it("converts camelCase to snake_case", () => {
+    expect(camelToSnakeCase("thisIsATest")).toEqual("this_is_a_test");
   });
 });

--- a/app/experimenter/nimbus-ui/src/lib/caseConversions.ts
+++ b/app/experimenter/nimbus-ui/src/lib/caseConversions.ts
@@ -2,8 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-export default function snakeToCamelCase(str: string) {
+export function snakeToCamelCase(str: string) {
   return str.replace(/([-_][a-z])/g, (group) =>
     group.toUpperCase().replace("-", "").replace("_", ""),
   );
+}
+
+export function camelToSnakeCase(str: string) {
+  return str.replace(/[A-Z]/g, (letter) => `_${letter.toLowerCase()}`);
 }


### PR DESCRIPTION
Because:

- we want to properly display submit errors

- we want to include population_percent in missing fields reported in
  review validation

This commit:

- adds population_percent to expected server errors and review errors

- adds a missing-info icon for population_percent in FormAudience

- split the test for missing review icons into per-field tests, because
  the missing population_percent icon was erroneously passing

- switches to snake_case for all submit_errors in tests, since that's
  what the server actually reports

- useCommonForm converts camel to snake case when accessing
  submit_errors

- adds a new camelToSnakeCase conversion utility and test