### PR TITLE
fixes #4296 Improve tests, layout, for DirectoryView

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/DirectoryTable/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/DirectoryTable/index.test.tsx
@@ -1,0 +1,191 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import DirectoryTable, {
+  DirectoryColumnTitle,
+  DirectoryColumnOwner,
+  DirectoryColumnFeature,
+  DirectoryLiveTable,
+  DirectoryCompleteTable,
+  DirectoryDraftsTable,
+} from ".";
+import { mockSingleDirectoryExperiment } from "../../lib/mocks";
+import {
+  getProposedEndDate,
+  getProposedEnrollmentRange,
+  humanDate,
+} from "../../lib/dateUtils";
+
+const experiment = mockSingleDirectoryExperiment();
+
+describe("DirectoryColumnTitle", () => {
+  it("renders the experiment name and slug", () => {
+    render(<DirectoryColumnTitle {...experiment} />);
+    expect(screen.getByTestId("directory-title-name")).toHaveTextContent(
+      experiment.name,
+    );
+    expect(screen.getByTestId("directory-title-slug")).toHaveTextContent(
+      experiment.slug,
+    );
+  });
+});
+
+describe("DirectoryColumnOwner", () => {
+  it("renders the experiment owner if present", () => {
+    render(<DirectoryColumnOwner {...experiment} />);
+    expect(screen.getByTestId("directory-table-cell")).toHaveTextContent(
+      experiment.owner!.username,
+    );
+  });
+
+  it("renders the NotSet label if owner is not present", () => {
+    render(<DirectoryColumnOwner {...experiment} owner={null} />);
+    expect(screen.getByTestId("directory-table-cell")).toHaveTextContent(
+      "Not set",
+    );
+  });
+});
+
+describe("DirectoryColumnFeature", () => {
+  it("renders the feature config if present", () => {
+    render(<DirectoryColumnFeature {...experiment} />);
+    expect(
+      screen.getByTestId("directory-feature-config-name"),
+    ).toHaveTextContent(experiment.featureConfig!.name);
+    expect(
+      screen.getByTestId("directory-feature-config-slug"),
+    ).toHaveTextContent(experiment.featureConfig!.slug);
+  });
+
+  it("renders the None label if feature config is not present", () => {
+    render(<DirectoryColumnFeature {...experiment} featureConfig={null} />);
+    expect(
+      screen.getByTestId("directory-feature-config-none"),
+    ).toBeInTheDocument();
+  });
+});
+
+function expectTableCells(testId: string, cellTexts: string[]) {
+  const cells = screen.getAllByTestId(testId);
+  expect(cells).toHaveLength(cellTexts.length);
+  cellTexts.forEach((text, index) => {
+    expect(cells[index].textContent).toEqual(expect.stringContaining(text));
+  });
+}
+
+describe("DirectoryTable", () => {
+  it("renders as expected with default columns", () => {
+    const experiments = [experiment];
+    render(<DirectoryTable title="Woozle Wuzzle" {...{ experiments }} />);
+    expectTableCells("directory-table-header", [
+      "Woozle Wuzzle",
+      "Owner",
+      "Feature",
+    ]);
+    expectTableCells("directory-table-cell", [
+      experiment.name,
+      experiment.owner!.username,
+      experiment.featureConfig!.name,
+    ]);
+    expect(screen.getAllByTestId("directory-table-row")).toHaveLength(
+      experiments.length,
+    );
+  });
+
+  it("renders as expected without experiments", () => {
+    render(<DirectoryTable title="Sweet Pea" experiments={[]} />);
+    expectTableCells("directory-table-header", ["Sweet Pea"]);
+    expect(
+      screen.getByTestId("directory-table-no-experiments"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders as expected with custom columns", () => {
+    render(
+      <DirectoryTable
+        title="Record Numbers"
+        experiments={[experiment]}
+        columns={[
+          { label: "Cant think", component: DirectoryColumnTitle },
+          {
+            label: "Of a title",
+            component: ({ status }) => (
+              <td data-testid="directory-table-cell">{status}</td>
+            ),
+          },
+        ]}
+      />,
+    );
+    expectTableCells("directory-table-header", ["Cant think", "Of a title"]);
+    expectTableCells("directory-table-cell", [
+      experiment.name,
+      experiment.status!,
+    ]);
+  });
+});
+
+describe("DirectoryLiveTable", () => {
+  it("renders as expected with custom columns", () => {
+    render(
+      <DirectoryLiveTable
+        title="Live Experiments"
+        experiments={[experiment]}
+      />,
+    );
+    expectTableCells("directory-table-header", [
+      "Live Experiments",
+      "Owner",
+      "Feature",
+      "Enrolling",
+      "Ending",
+      "Monitoring",
+    ]);
+    expectTableCells("directory-table-cell", [
+      experiment.name,
+      experiment.owner!.username,
+      experiment.featureConfig!.name,
+      getProposedEnrollmentRange(experiment) as string,
+      getProposedEndDate(experiment) as string,
+      "Grafana",
+    ]);
+  });
+});
+
+describe("DirectoryCompleteTable", () => {
+  it("renders as expected with custom columns", () => {
+    render(
+      <DirectoryCompleteTable title="Completed" experiments={[experiment]} />,
+    );
+    expectTableCells("directory-table-header", [
+      "Completed",
+      "Owner",
+      "Feature",
+      "Started",
+      "Ended",
+      "Results",
+    ]);
+    expectTableCells("directory-table-cell", [
+      experiment.name,
+      experiment.owner!.username,
+      experiment.featureConfig!.name,
+      humanDate(experiment.startDate!),
+      humanDate(experiment.endDate!),
+      "Results",
+    ]);
+  });
+});
+
+describe("DirectoryDraftsTable", () => {
+  it("renders as expected with custom columns", () => {
+    render(<DirectoryDraftsTable title="Drafts" experiments={[experiment]} />);
+    expectTableCells("directory-table-header", ["Drafts", "Owner", "Feature"]);
+    expectTableCells("directory-table-cell", [
+      experiment.name,
+      experiment.owner!.username,
+      experiment.featureConfig!.name,
+    ]);
+  });
+});

--- a/app/experimenter/nimbus-ui/src/components/DirectoryTable/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/DirectoryTable/index.tsx
@@ -74,20 +74,29 @@ const DirectoryTable: React.FunctionComponent<DirectoryTableProps> = ({
     { label: "Feature", component: DirectoryColumnFeature },
   ];
   return (
-    <div className="directory-table pb-4" data-testid="DirectoryTable">
+    <div className="directory-table pb-2" data-testid="DirectoryTable">
       <table className="table">
         <thead>
           <tr>
-            {columns.map(({ label }, i) => (
+            {experiments.length ? (
+              columns.map(({ label }, i) => (
+                <th
+                  className={`border-top-0 ${
+                    i === 0 ? "font-weight-bold" : "font-weight-normal"
+                  }`}
+                  key={label}
+                >
+                  {label}
+                </th>
+              ))
+            ) : (
               <th
-                className={`border-top-0 ${
-                  i === 0 ? "font-weight-bold" : "font-weight-normal"
-                }`}
-                key={label}
+                colSpan={columns.length}
+                className="border-top-0 font-weight-bold"
               >
-                {label}
+                {columns[0].label}
               </th>
-            ))}
+            )}
           </tr>
         </thead>
         <tbody>

--- a/app/experimenter/nimbus-ui/src/components/DirectoryTable/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/DirectoryTable/index.tsx
@@ -20,32 +20,46 @@ export const DirectoryColumnTitle: React.FC<
   getAllExperiments_experiments & { subPath?: string; sbLink?: string }
 > = ({ slug, name, subPath = "", sbLink = "pages/Summary" }) => {
   return (
-    <td className="w-33">
-      <Link to={slug + subPath} data-sb-kind={sbLink}>
+    <td className="w-33" data-testid="directory-table-cell">
+      <Link
+        to={slug + subPath}
+        data-sb-kind={sbLink}
+        data-testid="directory-title-name"
+      >
         {name}
       </Link>
       <br />
-      <span className="text-monospace text-secondary small">{slug}</span>
+      <span
+        className="text-monospace text-secondary small"
+        data-testid="directory-title-slug"
+      >
+        {slug}
+      </span>
     </td>
   );
 };
 
 export const DirectoryColumnOwner: ColumnComponent = ({ owner }) => (
-  <td>{owner?.username || <NotSet />}</td>
+  <td data-testid="directory-table-cell">{owner?.username || <NotSet />}</td>
 );
 
 export const DirectoryColumnFeature: ColumnComponent = ({ featureConfig }) => (
-  <td>
+  <td data-testid="directory-table-cell">
     {featureConfig ? (
       <>
-        {featureConfig.name}
+        <span data-testid="directory-feature-config-name">
+          {featureConfig.name}
+        </span>
         <br />
-        <span className="text-monospace text-secondary small">
+        <span
+          className="text-monospace text-secondary small"
+          data-testid="directory-feature-config-slug"
+        >
           {featureConfig.slug}
         </span>
       </>
     ) : (
-      "(None)"
+      <span data-testid="directory-feature-config-none">(None)</span>
     )}
   </td>
 );
@@ -85,6 +99,7 @@ const DirectoryTable: React.FunctionComponent<DirectoryTableProps> = ({
                     i === 0 ? "font-weight-bold" : "font-weight-normal"
                   }`}
                   key={label}
+                  data-testid="directory-table-header"
                 >
                   {label}
                 </th>
@@ -93,6 +108,7 @@ const DirectoryTable: React.FunctionComponent<DirectoryTableProps> = ({
               <th
                 colSpan={columns.length}
                 className="border-top-0 font-weight-bold"
+                data-testid="directory-table-header"
               >
                 {columns[0].label}
               </th>
@@ -102,15 +118,20 @@ const DirectoryTable: React.FunctionComponent<DirectoryTableProps> = ({
         <tbody>
           {experiments.length ? (
             experiments.map((experiment) => (
-              <tr key={experiment.slug}>
+              <tr key={experiment.slug} data-testid="directory-table-row">
                 {columns.map(({ label, component: ColumnComponent }, i) => {
                   return <ColumnComponent key={label + i} {...experiment} />;
                 })}
               </tr>
             ))
           ) : (
-            <tr>
-              <td colSpan={columns.length}>No experiments found.</td>
+            <tr data-testid="directory-table-row">
+              <td
+                colSpan={columns.length}
+                data-testid="directory-table-no-experiments"
+              >
+                No experiments found.
+              </td>
             </tr>
           )}
         </tbody>
@@ -129,17 +150,23 @@ export const DirectoryLiveTable: React.FC<DirectoryTableProps> = (props) => (
       {
         label: "Enrolling",
         component: (experiment) => (
-          <td>{getProposedEnrollmentRange(experiment)}</td>
+          <td data-testid="directory-table-cell">
+            {getProposedEnrollmentRange(experiment)}
+          </td>
         ),
       },
       {
         label: "Ending",
-        component: (experiment) => <td>{getProposedEndDate(experiment)}</td>,
+        component: (experiment) => (
+          <td data-testid="directory-table-cell">
+            {getProposedEndDate(experiment)}
+          </td>
+        ),
       },
       {
         label: "Monitoring",
         component: ({ monitoringDashboardUrl }) => (
-          <td>
+          <td data-testid="directory-table-cell">
             {monitoringDashboardUrl && (
               <LinkExternal
                 href={monitoringDashboardUrl!}
@@ -166,16 +193,20 @@ export const DirectoryCompleteTable: React.FC<DirectoryTableProps> = (
       { label: "Feature", component: DirectoryColumnFeature },
       {
         label: "Started",
-        component: ({ startDate: d }) => <td>{d && humanDate(d)}</td>,
+        component: ({ startDate: d }) => (
+          <td data-testid="directory-table-cell">{d && humanDate(d)}</td>
+        ),
       },
       {
         label: "Ended",
-        component: ({ endDate: d }) => <td>{d && humanDate(d)}</td>,
+        component: ({ endDate: d }) => (
+          <td data-testid="directory-table-cell">{d && humanDate(d)}</td>
+        ),
       },
       {
         label: "Results",
         component: ({ slug }) => (
-          <td>
+          <td data-testid="directory-table-cell">
             <Link to={`${slug}/results`} data-sb-kind="pages/Results">
               Results
             </Link>

--- a/app/experimenter/nimbus-ui/src/components/PageHome/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageHome/index.test.tsx
@@ -18,7 +18,7 @@ describe("PageHome", () => {
     render(<Subject />);
 
     expect(screen.getByTestId("PageHome")).toBeInTheDocument();
-    expect(screen.getByText("New experiment")).toBeInTheDocument();
+    expect(screen.getByText("Create new")).toBeInTheDocument();
   });
   it("displays loading when experiments are still loading", () => {
     (jest.spyOn(apollo, "useQuery") as jest.Mock).mockReturnValueOnce({

--- a/app/experimenter/nimbus-ui/src/components/PageHome/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageHome/index.tsx
@@ -6,6 +6,7 @@ import React from "react";
 import AppLayout from "../AppLayout";
 import { RouteComponentProps, Link } from "@reach/router";
 import Head from "../Head";
+import { Tabs, Tab } from "react-bootstrap";
 import { useQuery } from "@apollo/client";
 import { getAllExperiments_experiments } from "../../types/getAllExperiments";
 import { GET_EXPERIMENTS_QUERY } from "../../gql/experiments";
@@ -34,12 +35,24 @@ export const Body = () => {
 
   const { live, complete, review, draft } = sortByStatus(data.experiments);
   return (
-    <>
-      <DirectoryLiveTable title="Live Experiments" experiments={live} />
-      <DirectoryCompleteTable title="Completed" experiments={complete} />
-      <DirectoryTable title="In Review" experiments={review} />
-      <DirectoryDraftsTable title="Drafts" experiments={draft} />
-    </>
+    <Tabs defaultActiveKey="active">
+      <Tab eventKey="active" title="Active">
+        <div className="mt-4">
+          <DirectoryLiveTable title="Live Experiments" experiments={live} />
+          <DirectoryTable title="In Review" experiments={review} />
+        </div>
+      </Tab>
+      <Tab eventKey="completed" title="Completed">
+        <div className="mt-4">
+          <DirectoryCompleteTable title="Completed" experiments={complete} />
+        </div>
+      </Tab>
+      <Tab eventKey="drafts" title="Drafts">
+        <div className="mt-4">
+          <DirectoryDraftsTable title="Drafts" experiments={draft} />
+        </div>
+      </Tab>
+    </Tabs>
   );
 };
 
@@ -48,16 +61,19 @@ const PageHome: React.FunctionComponent<PageHomeProps> = () => {
     <AppLayout testid="PageHome">
       <Head title="Experiments" />
 
-      <h2 className="mb-4">
-        Nimbus Experiments{" "}
-        <Link
-          to="new"
-          data-sb-kind="pages/New"
-          className="btn btn-primary btn-small ml-2"
-        >
-          New experiment
-        </Link>
-      </h2>
+      <div className="d-flex mb-4">
+        <h2 className="mb-0 mr-1">Nimbus Experiments </h2>
+        <div>
+          <Link
+            to="new"
+            data-sb-kind="pages/New"
+            className="btn btn-primary btn-small ml-2"
+          >
+            Create new
+          </Link>
+        </div>
+      </div>
+
       <Body />
     </AppLayout>
   );

--- a/app/experimenter/nimbus-ui/src/lib/dateUtils.test.ts
+++ b/app/experimenter/nimbus-ui/src/lib/dateUtils.test.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import {
+  humanDate,
   addDaysToDate,
   getProposedEndDate,
   getProposedEnrollmentRange,
@@ -10,6 +11,21 @@ import {
 import { mockSingleDirectoryExperiment as expFactory } from "./mocks";
 
 const FAKE_DATE = "Thu Dec 12 2020";
+const FAKE_ISO_DATE = "2020-12-25T15:28:01.821657+00:00";
+
+describe("humanDate", () => {
+  it("should produce the date and month", () => {
+    expect(humanDate(FAKE_ISO_DATE, false)).toEqual("Dec 25");
+  });
+
+  it("with year explicitly enabled, should produce the date, month, and year", () => {
+    expect(humanDate(FAKE_ISO_DATE, true)).toEqual("Dec 25, 2020");
+  });
+
+  it("with year set to 'past', should produce the date, month, and year", () => {
+    expect(humanDate(FAKE_ISO_DATE, "past")).toEqual("Dec 25, 2020");
+  });
+});
 
 describe("addDaysToDate", () => {
   it("should add days to a date and return a date string", () => {

--- a/app/experimenter/nimbus-ui/src/lib/dateUtils.ts
+++ b/app/experimenter/nimbus-ui/src/lib/dateUtils.ts
@@ -6,12 +6,27 @@ import { getAllExperiments_experiments } from "../types/getAllExperiments";
 import { getExperiment_experimentBySlug } from "../types/getExperiment";
 import pluralize from "./pluralize";
 
-export function humanDate(date: string): string {
-  return new Date(date).toLocaleString("en-US", {
+export function humanDate(
+  date: string,
+  year: boolean | "past" = "past",
+): string {
+  const today = new Date();
+  const parsedDate = new Date(date);
+  const options: Intl.DateTimeFormatOptions = {
     month: "short",
     day: "numeric",
-    year: "numeric",
-  });
+  };
+
+  // Only show the year if the date's year is not the current
+  // year, or if the option is explicitly enabled
+  if (
+    (year === "past" && today.getFullYear() !== parsedDate.getFullYear()) ||
+    year === true
+  ) {
+    options.year = "numeric";
+  }
+
+  return parsedDate.toLocaleString("en-US", options);
 }
 
 export function addDaysToDate(datestring: string, days: number): string {


### PR DESCRIPTION
Closes #4296

This PR largely adds a bunch of tests to the `DirectoryView`. But also:

- Updated the `humanDate` utility to support only rendering the year if the passed in date's year does not match the current year. This was not expressly requested, but I noted that the Figma designs do _not_ include year and I feel like that's fine if it's the same year, but experiments launched in previous years should probably display it.
- Couple small updates to the layout of `DirectoryView`, including using the tabbed setup per the Figma designs