### PR TITLE
fix #4378 bug(nimbus): don't delete branches if they're not being updated

### DIFF
--- a/app/experimenter/experiments/api/v5/serializers.py
+++ b/app/experimenter/experiments/api/v5/serializers.py
@@ -178,12 +178,14 @@ class NimbusExperimentBranchMixin:
         return data
 
     def update(self, experiment, data):
-        control_branch_data = data.pop("reference_branch", {})
-        treatment_branches_data = data.pop("treatment_branches", {})
-
         with transaction.atomic():
+            if set(data.keys()).intersection({"reference_branch", "treatment_branches"}):
+                experiment.delete_branches()
+
+            control_branch_data = data.pop("reference_branch", {})
+            treatment_branches_data = data.pop("treatment_branches", [])
+
             experiment = super().update(experiment, data)
-            experiment.delete_branches()
 
             if control_branch_data:
                 experiment.reference_branch = NimbusBranch.objects.create(

--- a/app/experimenter/experiments/tests/api/v5/test_serializers.py
+++ b/app/experimenter/experiments/tests/api/v5/test_serializers.py
@@ -491,6 +491,24 @@ class TestNimbusBranchUpdateSerializer(TestCase):
         )
         self.assertEqual(len(serializer.errors), 1)
 
+    def test_does_not_delete_branches_when_other_fields_specified(self):
+        experiment = NimbusExperimentFactory.create_with_status(
+            NimbusExperiment.Status.DRAFT
+        )
+        branch_count = experiment.branches.count()
+
+        serializer = NimbusExperimentUpdateSerializer(
+            instance=experiment,
+            data={"name": "new name"},
+            context={"user": UserFactory()},
+        )
+        self.assertTrue(serializer.is_valid())
+        serializer.save()
+
+        experiment = NimbusExperiment.objects.get(id=experiment.id)
+        self.assertEqual(experiment.branches.count(), branch_count)
+        self.assertEqual(experiment.name, "new name")
+
 
 class TestNimbusProbeSetUpdateSerializer(TestCase):
     def test_serializer_updates_probe_sets_on_experiment(self):


### PR DESCRIPTION

Because

- We recently folded all the experiment serializers into one
- But neglected to only delete branches if they're also going to be updated

This commit

- Only deletes branchces if they're also going to be updated