### PR TITLE
fixes #4379 fix(nimbus): Don't redirect from Results page when analysis is available

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/AppLayoutWithSidebar/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/AppLayoutWithSidebar/index.stories.tsx
@@ -56,6 +56,16 @@ storiesOf("components/AppLayoutWithSidebar", module)
       </AppLayoutWithSidebar>
     </RouterSlugProvider>
   ))
+  .add("analysis results loading", () => (
+    <RouterSlugProvider>
+      <AppLayoutWithSidebar
+        status={mockGetStatus(NimbusExperimentStatus.LIVE)}
+        analysisLoadingInSidebar
+      >
+        <p>App contents go here</p>
+      </AppLayoutWithSidebar>
+    </RouterSlugProvider>
+  ))
   .add("analysis results error", () => (
     <RouterSlugProvider>
       <AppLayoutWithSidebar

--- a/app/experimenter/nimbus-ui/src/components/AppLayoutWithSidebar/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/AppLayoutWithSidebar/index.test.tsx
@@ -4,7 +4,7 @@
 
 import React from "react";
 import { act, render, screen, waitFor } from "@testing-library/react";
-import AppLayoutWithSidebar from ".";
+import AppLayoutWithSidebar, { RESULTS_LOADING_TEXT } from ".";
 import { renderWithRouter, RouterSlugProvider } from "../../lib/test-utils";
 import { BASE_PATH } from "../../lib/constants";
 import { RouteComponentProps } from "@reach/router";
@@ -23,6 +23,7 @@ const Subject = ({
   withAnalysis = false,
   analysisError,
   review,
+  analysisLoadingInSidebar = false,
 }: RouteComponentProps & {
   status?: NimbusExperimentStatus;
   review?: {
@@ -31,12 +32,14 @@ const Subject = ({
   };
   withAnalysis?: boolean;
   analysisError?: boolean;
+  analysisLoadingInSidebar?: boolean;
 }) => (
   <RouterSlugProvider mocks={[mock]} path="/my-special-slug/edit">
     <AppLayoutWithSidebar
       {...{
         status: mockGetStatus(status),
         review,
+        analysisLoadingInSidebar,
         analysisError: analysisError ? new Error("boop") : undefined,
         analysis: withAnalysis
           ? {
@@ -210,6 +213,20 @@ describe("AppLayoutWithSidebar", () => {
       expect(screen.queryByTestId("show-no-results")).toBeInTheDocument();
       expect(screen.queryByTestId("show-no-results")).toHaveTextContent(
         "Could not get visualization data. Please contact data science",
+      );
+    });
+
+    it("when complete and analysis is required in sidebar and loading", async () => {
+      render(
+        <Subject
+          status={NimbusExperimentStatus.COMPLETE}
+          analysisLoadingInSidebar
+        />,
+      );
+
+      expect(screen.queryByTestId("show-no-results")).toBeInTheDocument();
+      expect(screen.queryByTestId("show-no-results")).toHaveTextContent(
+        RESULTS_LOADING_TEXT,
       );
     });
 

--- a/app/experimenter/nimbus-ui/src/components/AppLayoutWithSidebar/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/AppLayoutWithSidebar/index.tsx
@@ -25,6 +25,8 @@ import { ReactComponent as BarChart } from "./bar-chart.svg";
 import "./index.scss";
 import LinkExternal from "../LinkExternal";
 
+export const RESULTS_LOADING_TEXT = "Checking results availability...";
+
 type AppLayoutWithSidebarProps = {
   testid?: string;
   children: React.ReactNode;
@@ -34,6 +36,7 @@ type AppLayoutWithSidebarProps = {
     ready: boolean;
   };
   analysis?: AnalysisData;
+  analysisLoadingInSidebar?: boolean;
   analysisError?: Error;
 } & RouteComponentProps;
 
@@ -66,6 +69,7 @@ export const AppLayoutWithSidebar = ({
   status,
   review,
   analysis,
+  analysisLoadingInSidebar = false,
   analysisError,
 }: AppLayoutWithSidebarProps) => {
   const { slug } = useParams();
@@ -112,6 +116,8 @@ export const AppLayoutWithSidebar = ({
                     <DisabledItem name="Results" testId="show-no-results">
                       {status?.accepted ? (
                         "Waiting for experiment to launch"
+                      ) : analysisLoadingInSidebar ? (
+                        RESULTS_LOADING_TEXT
                       ) : analysisError ? (
                         <>
                           Could not get visualization data. Please contact data

--- a/app/experimenter/nimbus-ui/src/components/PageDesign/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageDesign/index.tsx
@@ -11,7 +11,7 @@ const PageDesign: React.FunctionComponent<RouteComponentProps> = () => {
     <AppLayoutWithExperiment
       title="Design"
       testId="PageDesign"
-      analysisRequired
+      analysisRequiredInSidebar
       redirect={({ status }) => {
         if (!status?.locked) {
           return "edit/overview";

--- a/app/experimenter/nimbus-ui/src/components/PageResults/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/index.tsx
@@ -12,7 +12,7 @@ import TableHighlightsOverview from "../TableHighlightsOverview";
 import TableMetricPrimary from "../TableMetricPrimary";
 import TableMetricSecondary from "../TableMetricSecondary";
 import MonitoringLink from "../MonitoringLink";
-import { analysisAvailable } from "../../lib/visualization/utils";
+import { analysisUnavailable } from "../../lib/visualization/utils";
 
 const PageResults: React.FunctionComponent<RouteComponentProps> = () => (
   <AppLayoutWithExperiment
@@ -24,7 +24,7 @@ const PageResults: React.FunctionComponent<RouteComponentProps> = () => (
         return "edit/overview";
       }
 
-      if (!analysisAvailable(analysis)) {
+      if (analysisUnavailable(analysis)) {
         return "design";
       }
     }}
@@ -33,7 +33,7 @@ const PageResults: React.FunctionComponent<RouteComponentProps> = () => (
       // For testing - users will be redirected if the analysis is unavailable
       // before reaching this return, but tests reach this return and
       // analysis.overall is expected to be an object (EXP-800)
-      if (!analysisAvailable(analysis)) return <></>;
+      if (analysisUnavailable(analysis)) return <></>;
 
       const slugUnderscored = experiment.slug.replace(/-/g, "_");
       return (

--- a/app/experimenter/nimbus-ui/src/lib/visualization/utils.tsx
+++ b/app/experimenter/nimbus-ui/src/lib/visualization/utils.tsx
@@ -10,6 +10,9 @@ import { AnalysisData } from "./types";
 export const analysisAvailable = (analysis: AnalysisData | undefined) =>
   analysis?.show_analysis === true && analysis?.overall !== null;
 
+export const analysisUnavailable = (analysis: AnalysisData | undefined) =>
+  analysis && !analysisAvailable(analysis);
+
 export const getTableDisplayType = (
   metricKey: string,
   tableLabel: string,


### PR DESCRIPTION
Fixes #4379

Because:
* The Results page should display as expected when results are available

This commit:
* Fixes the bug
* Shows the loader on Results page until experiment data and results have both been fetched
* Shows 'results loading' text in the sidebar on the Design page so the page content can be displayed before results are fetched