### PR TITLE
fixes #4305 feat(nimbus): Add Summary component to Design page

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/PageDesign/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageDesign/index.test.tsx
@@ -27,9 +27,10 @@ describe("PageDesign", () => {
         <PageDesign />
       </RouterSlugProvider>,
     );
-    await waitFor(() => {
+    waitFor(() => {
       expect(screen.queryByTestId("PageDesign")).toBeInTheDocument();
     });
+    expect(screen.queryByTestId("summary")).toBeInTheDocument();
   });
 
   it("redirects to the edit overview page if the experiment status is draft", async () => {

--- a/app/experimenter/nimbus-ui/src/components/PageDesign/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageDesign/index.tsx
@@ -5,6 +5,7 @@
 import React from "react";
 import { RouteComponentProps } from "@reach/router";
 import AppLayoutWithExperiment from "../AppLayoutWithExperiment";
+import Summary from "../Summary";
 
 const PageDesign: React.FunctionComponent<RouteComponentProps> = () => {
   return (
@@ -18,7 +19,7 @@ const PageDesign: React.FunctionComponent<RouteComponentProps> = () => {
         }
       }}
     >
-      {({ experiment }) => <p>{experiment.name}</p>}
+      {({ experiment }) => <Summary {...{ experiment }} />}
     </AppLayoutWithExperiment>
   );
 };


### PR DESCRIPTION
Because:
* We want the Design page to display all tables summarizing the experiment

This commit:
* Displays the Summary component inside PageDesign

---
fixes #4305
Quick end-of-day Friday task. 😎