### PR TITLE
fix #4362 chore(nimbus): remove clientMutationId

### DIFF
--- a/app/experimenter/experiments/api/v5/inputs.py
+++ b/app/experimenter/experiments/api/v5/inputs.py
@@ -36,7 +36,6 @@ class TreatmentBranchType(BranchType):
 
 
 class ExperimentInput(graphene.InputObjectType):
-    client_mutation_id = graphene.String()
     id = graphene.Int()
     status = NimbusExperimentStatus()
     name = graphene.String()

--- a/app/experimenter/experiments/api/v5/mutation.py
+++ b/app/experimenter/experiments/api/v5/mutation.py
@@ -19,7 +19,7 @@ from experimenter.experiments.api.v5.types import NimbusExperimentType, ObjectFi
 from experimenter.experiments.models import NimbusExperiment
 
 
-def handle_with_serializer(cls, serializer, client_mutation_id):
+def handle_with_serializer(cls, serializer):
     if serializer.is_valid():
         obj = serializer.save()
         msg = "success"
@@ -30,12 +30,10 @@ def handle_with_serializer(cls, serializer, client_mutation_id):
         nimbus_experiment=obj,
         message=msg,
         status=200,
-        client_mutation_id=client_mutation_id,
     )
 
 
 class CreateExperiment(graphene.Mutation):
-    client_mutation_id = graphene.String()
     nimbus_experiment = graphene.Field(NimbusExperimentType)
     message = ObjectField()
     status = graphene.Int()
@@ -48,11 +46,10 @@ class CreateExperiment(graphene.Mutation):
         serializer = NimbusExperimentUpdateSerializer(
             data=input, context={"user": info.context.user}
         )
-        return handle_with_serializer(cls, serializer, input.client_mutation_id)
+        return handle_with_serializer(cls, serializer)
 
 
 class UpdateExperiment(graphene.Mutation):
-    client_mutation_id = graphene.String()
     nimbus_experiment = graphene.Field(NimbusExperimentType)
     message = ObjectField()
     status = graphene.Int()
@@ -68,7 +65,7 @@ class UpdateExperiment(graphene.Mutation):
         serializer = NimbusExperimentUpdateSerializer(
             exp, data=input, partial=True, context={"user": info.context.user}
         )
-        return handle_with_serializer(cls, serializer, input.client_mutation_id)
+        return handle_with_serializer(cls, serializer)
 
 
 class Mutation(graphene.ObjectType):

--- a/app/experimenter/experiments/tests/api/v5/test_mutation.py
+++ b/app/experimenter/experiments/tests/api/v5/test_mutation.py
@@ -22,7 +22,6 @@ mutation($input: ExperimentInput!) {
         }
         message
         status
-        clientMutationId
     }
 }
 """
@@ -40,7 +39,6 @@ mutation($input: ExperimentInput!) {
         }
         message
         status
-        clientMutationId
     }
 }
 """
@@ -49,7 +47,6 @@ mutation($input: ExperimentInput!) {
 UPDATE_EXPERIMENT_DOCUMENTATION_LINKS_MUTATION = """\
 mutation ($input: ExperimentInput !) {
   updateExperiment(input: $input){
-    clientMutationId
     nimbusExperiment {
       id
       status
@@ -70,7 +67,6 @@ mutation ($input: ExperimentInput !) {
 UPDATE_EXPERIMENT_BRANCHES_MUTATION = """\
 mutation ($input: ExperimentInput !) {
   updateExperiment(input: $input){
-    clientMutationId
     nimbusExperiment {
       id
       featureConfig {
@@ -100,7 +96,6 @@ mutation ($input: ExperimentInput !) {
 UPDATE_EXPERIMENT_PROBESETS_MUTATION = """\
 mutation ($input: ExperimentInput!) {
   updateExperiment(input: $input){
-    clientMutationId
     nimbusExperiment {
       id
       primaryProbeSets {
@@ -119,7 +114,6 @@ mutation ($input: ExperimentInput!) {
 UPDATE_EXPERIMENT_AUDIENCE_MUTATION = """\
 mutation ($input: ExperimentInput!){
   updateExperiment(input: $input){
-    clientMutationId
     nimbusExperiment {
       id
       totalEnrolledClients
@@ -139,7 +133,6 @@ mutation ($input: ExperimentInput!){
 UPDATE_EXPERIMENT_STATUS_MUTATION = """\
 mutation ($input: ExperimentInput!){
   updateExperiment(input: $input){
-    clientMutationId
     nimbusExperiment {
       id
       status
@@ -164,7 +157,6 @@ class TestMutations(GraphQLTestCase):
                     "name": "Test 1234",
                     "hypothesis": "Test hypothesis",
                     "application": NimbusExperiment.Application.DESKTOP.name,
-                    "clientMutationId": "randomid",
                 }
             },
             headers={settings.OPENIDC_EMAIL_HEADER: user_email},
@@ -182,7 +174,6 @@ class TestMutations(GraphQLTestCase):
             },
         )
 
-        self.assertEqual(result["clientMutationId"], "randomid")
         self.assertEqual(result["message"], "success")
         self.assertEqual(result["status"], 200)
 
@@ -199,7 +190,6 @@ class TestMutations(GraphQLTestCase):
                     "name": long_name,
                     "hypothesis": "Test hypothesis",
                     "application": NimbusExperiment.Application.DESKTOP.name,
-                    "clientMutationId": "randomid",
                 }
             },
             headers={settings.OPENIDC_EMAIL_HEADER: user_email},
@@ -209,7 +199,6 @@ class TestMutations(GraphQLTestCase):
         result = content["data"]["createExperiment"]
         self.assertEqual(result["nimbusExperiment"], None)
 
-        self.assertEqual(result["clientMutationId"], "randomid")
         self.assertEqual(
             result["message"],
             {"name": ["Ensure this field has no more than 255 characters."]},
@@ -234,7 +223,6 @@ class TestMutations(GraphQLTestCase):
                     "hypothesis": "new hypothesis",
                     "publicDescription": "new public description",
                     "riskMitigationLink": "https://example.com/risk",
-                    "clientMutationId": "randomid",
                 }
             },
             headers={settings.OPENIDC_EMAIL_HEADER: user_email},
@@ -254,7 +242,6 @@ class TestMutations(GraphQLTestCase):
             },
         )
 
-        self.assertEqual(result["clientMutationId"], "randomid")
         self.assertEqual(result["message"], "success")
         self.assertEqual(result["status"], 200)
 
@@ -276,7 +263,6 @@ class TestMutations(GraphQLTestCase):
                     "name": long_name,
                     "hypothesis": "new hypothesis",
                     "riskMitigationLink": "i like pie",
-                    "clientMutationId": "randomid",
                 }
             },
             headers={settings.OPENIDC_EMAIL_HEADER: user_email},
@@ -286,7 +272,6 @@ class TestMutations(GraphQLTestCase):
         result = content["data"]["updateExperiment"]
         self.assertEqual(result["nimbusExperiment"], None)
 
-        self.assertEqual(result["clientMutationId"], "randomid")
         self.assertEqual(
             result["message"],
             {
@@ -321,7 +306,6 @@ class TestMutations(GraphQLTestCase):
             variables={
                 "input": {
                     "id": experiment.id,
-                    "clientMutationId": "randomid",
                     "documentationLinks": documentation_links,
                 }
             },
@@ -367,7 +351,6 @@ class TestMutations(GraphQLTestCase):
                     "name": "new name",
                     "hypothesis": "new hypothesis",
                     "publicDescription": "new public description",
-                    "clientMutationId": "randomid",
                 }
             },
             headers={settings.OPENIDC_EMAIL_HEADER: user_email},
@@ -396,7 +379,6 @@ class TestMutations(GraphQLTestCase):
                     "name": "new name",
                     "hypothesis": "new hypothesis",
                     "publicDescription": "new public description",
-                    "clientMutationId": "randomid",
                 }
             },
             headers={settings.OPENIDC_EMAIL_HEADER: user_email},
@@ -423,7 +405,6 @@ class TestMutations(GraphQLTestCase):
                 "input": {
                     "id": experiment.id,
                     "featureConfigId": feature.id,
-                    "clientMutationId": "randomid",
                     "referenceBranch": reference_branch,
                     "treatmentBranches": treatment_branches,
                 }
@@ -465,7 +446,6 @@ class TestMutations(GraphQLTestCase):
                 "input": {
                     "id": experiment.id,
                     "featureConfigId": 2,
-                    "clientMutationId": "randomid",
                     "referenceBranch": reference_branch,
                     "treatmentBranches": treatment_branches,
                 }
@@ -491,7 +471,6 @@ class TestMutations(GraphQLTestCase):
             variables={
                 "input": {
                     "id": experiment.id,
-                    "clientMutationId": "randomid",
                     "primaryProbeSetIds": [p.id for p in probe_sets[:2]],
                     "secondaryProbeSetIds": [p.id for p in probe_sets[2:]],
                 }
@@ -529,7 +508,6 @@ class TestMutations(GraphQLTestCase):
             variables={
                 "input": {
                     "id": experiment.id,
-                    "clientMutationId": "randomid",
                     "primaryProbeSetIds": [123],
                     "secondaryProbeSetIds": [],
                 }
@@ -562,7 +540,6 @@ class TestMutations(GraphQLTestCase):
             variables={
                 "input": {
                     "id": experiment.id,
-                    "clientMutationId": "randomid",
                     "channel": NimbusConstants.Channel.DESKTOP_BETA.name,
                     "firefoxMinVersion": NimbusConstants.Version.FIREFOX_80.name,
                     "populationPercent": "10",
@@ -622,7 +599,6 @@ class TestMutations(GraphQLTestCase):
             variables={
                 "input": {
                     "id": experiment.id,
-                    "clientMutationId": "randomid",
                     "populationPercent": "10.23471",
                 }
             },
@@ -650,7 +626,6 @@ class TestMutations(GraphQLTestCase):
             variables={
                 "input": {
                     "id": experiment.id,
-                    "clientMutationId": "randomid",
                     "status": NimbusExperiment.Status.REVIEW.name,
                 }
             },
@@ -679,7 +654,6 @@ class TestMutations(GraphQLTestCase):
             variables={
                 "input": {
                     "id": experiment.id,
-                    "clientMutationId": "randomid",
                     "status": NimbusExperiment.Status.REVIEW.name,
                 }
             },

--- a/app/experimenter/nimbus-ui/README.md
+++ b/app/experimenter/nimbus-ui/README.md
@@ -299,7 +299,6 @@ const mkSimulatedQueries = ({
       return {
         data: {
           createExperiment: {
-            clientMutationId: "8675309",
             message,
             status,
             nimbusExperiment,

--- a/app/experimenter/nimbus-ui/schema.graphql
+++ b/app/experimenter/nimbus-ui/schema.graphql
@@ -9,7 +9,6 @@ type ApplicationChannel {
 }
 
 type CreateExperiment {
-  clientMutationId: String
   nimbusExperiment: NimbusExperimentType
   message: ObjectField
   status: Int
@@ -23,7 +22,6 @@ input DocumentationLinkType {
 }
 
 input ExperimentInput {
-  clientMutationId: String
   id: Int
   status: NimbusExperimentStatus
   name: String
@@ -299,7 +297,6 @@ input TreatmentBranchType {
 }
 
 type UpdateExperiment {
-  clientMutationId: String
   nimbusExperiment: NimbusExperimentType
   message: ObjectField
   status: Int

--- a/app/experimenter/nimbus-ui/src/components/PageEditAudience/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditAudience/index.test.tsx
@@ -224,12 +224,10 @@ jest.mock("./FormAudience", () => ({
 export const mockUpdateExperimentAudienceMutation = (
   input: Partial<ExperimentInput>,
   {
-    clientMutationId = "8675309",
     status = 200,
     message = "success",
     experiment,
   }: {
-    clientMutationId?: string | null;
     status?: number;
     message?: string | Record<string, any>;
     experiment: updateExperimentAudience_updateExperiment_nimbusExperiment;
@@ -237,7 +235,6 @@ export const mockUpdateExperimentAudienceMutation = (
 ) => {
   const updateExperiment: updateExperimentAudience_updateExperiment = {
     __typename: "UpdateExperiment",
-    clientMutationId,
     status,
     message,
     nimbusExperiment: experiment,

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/index.test.tsx
@@ -282,12 +282,10 @@ jest.mock("./FormBranches", () => ({
 export const mockUpdateExperimentBranchesMutation = (
   input: Partial<ExperimentInput>,
   {
-    clientMutationId = "8675309",
     status = 200,
     message = "success",
     experiment,
   }: {
-    clientMutationId?: string | null;
     status?: number;
     message?: string | Record<string, any>;
     experiment: updateExperimentBranches_updateExperiment_nimbusExperiment;
@@ -295,7 +293,6 @@ export const mockUpdateExperimentBranchesMutation = (
 ) => {
   const updateExperiment: updateExperimentBranches_updateExperiment = {
     __typename: "UpdateExperiment",
-    clientMutationId,
     status,
     message,
     nimbusExperiment: experiment,

--- a/app/experimenter/nimbus-ui/src/components/PageNew/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageNew/index.stories.tsx
@@ -33,7 +33,6 @@ const mkSimulatedQueries = ({
       return {
         data: {
           createExperiment: {
-            clientMutationId: "8675309",
             message,
             status,
             nimbusExperiment,

--- a/app/experimenter/nimbus-ui/src/gql/experiments.ts
+++ b/app/experimenter/nimbus-ui/src/gql/experiments.ts
@@ -7,7 +7,6 @@ import { gql } from "@apollo/client";
 export const CREATE_EXPERIMENT_MUTATION = gql`
   mutation createExperiment($input: ExperimentInput!) {
     createExperiment(input: $input) {
-      clientMutationId
       message
       status
       nimbusExperiment {
@@ -23,7 +22,6 @@ export const CREATE_EXPERIMENT_MUTATION = gql`
 export const UPDATE_EXPERIMENT_OVERVIEW_MUTATION = gql`
   mutation updateExperimentOverview($input: ExperimentInput!) {
     updateExperiment(input: $input) {
-      clientMutationId
       message
       status
       nimbusExperiment {
@@ -38,7 +36,6 @@ export const UPDATE_EXPERIMENT_OVERVIEW_MUTATION = gql`
 export const UPDATE_EXPERIMENT_STATUS_MUTATION = gql`
   mutation updateExperimentStatus($input: ExperimentInput!) {
     updateExperiment(input: $input) {
-      clientMutationId
       message
       status
       nimbusExperiment {
@@ -51,7 +48,6 @@ export const UPDATE_EXPERIMENT_STATUS_MUTATION = gql`
 export const UPDATE_EXPERIMENT_BRANCHES_MUTATION = gql`
   mutation updateExperimentBranches($input: ExperimentInput!) {
     updateExperiment(input: $input) {
-      clientMutationId
       message
       status
       nimbusExperiment {
@@ -77,7 +73,6 @@ export const UPDATE_EXPERIMENT_BRANCHES_MUTATION = gql`
 export const UPDATE_EXPERIMENT_PROBESETS_MUTATION = gql`
   mutation updateExperimentProbeSets($input: ExperimentInput!) {
     updateExperiment(input: $input) {
-      clientMutationId
       nimbusExperiment {
         id
         primaryProbeSets {
@@ -96,7 +91,6 @@ export const UPDATE_EXPERIMENT_PROBESETS_MUTATION = gql`
 export const UPDATE_EXPERIMENT_AUDIENCE_MUTATION = gql`
   mutation updateExperimentAudience($input: ExperimentInput!) {
     updateExperiment(input: $input) {
-      clientMutationId
       message
       status
       nimbusExperiment {

--- a/app/experimenter/nimbus-ui/src/lib/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/lib/mocks.tsx
@@ -431,7 +431,6 @@ export const mockExperimentMutation = (
       errors: undefined as undefined | any[],
       data: {
         [key]: {
-          clientMutationId: "8675309",
           message,
           status,
           nimbusExperiment: experiment,

--- a/app/experimenter/nimbus-ui/src/types/createExperiment.ts
+++ b/app/experimenter/nimbus-ui/src/types/createExperiment.ts
@@ -19,7 +19,6 @@ export interface createExperiment_createExperiment_nimbusExperiment {
 
 export interface createExperiment_createExperiment {
   __typename: "CreateExperiment";
-  clientMutationId: string | null;
   message: ObjectField | null;
   status: number | null;
   nimbusExperiment: createExperiment_createExperiment_nimbusExperiment | null;

--- a/app/experimenter/nimbus-ui/src/types/globalTypes.ts
+++ b/app/experimenter/nimbus-ui/src/types/globalTypes.ts
@@ -93,7 +93,6 @@ export interface DocumentationLinkType {
 }
 
 export interface ExperimentInput {
-  clientMutationId?: string | null;
   id?: number | null;
   status?: NimbusExperimentStatus | null;
   name?: string | null;

--- a/app/experimenter/nimbus-ui/src/types/updateExperimentAudience.ts
+++ b/app/experimenter/nimbus-ui/src/types/updateExperimentAudience.ts
@@ -23,7 +23,6 @@ export interface updateExperimentAudience_updateExperiment_nimbusExperiment {
 
 export interface updateExperimentAudience_updateExperiment {
   __typename: "UpdateExperiment";
-  clientMutationId: string | null;
   message: ObjectField | null;
   status: number | null;
   nimbusExperiment: updateExperimentAudience_updateExperiment_nimbusExperiment | null;

--- a/app/experimenter/nimbus-ui/src/types/updateExperimentBranches.ts
+++ b/app/experimenter/nimbus-ui/src/types/updateExperimentBranches.ts
@@ -38,7 +38,6 @@ export interface updateExperimentBranches_updateExperiment_nimbusExperiment {
 
 export interface updateExperimentBranches_updateExperiment {
   __typename: "UpdateExperiment";
-  clientMutationId: string | null;
   message: ObjectField | null;
   status: number | null;
   nimbusExperiment: updateExperimentBranches_updateExperiment_nimbusExperiment | null;

--- a/app/experimenter/nimbus-ui/src/types/updateExperimentOverview.ts
+++ b/app/experimenter/nimbus-ui/src/types/updateExperimentOverview.ts
@@ -18,7 +18,6 @@ export interface updateExperimentOverview_updateExperiment_nimbusExperiment {
 
 export interface updateExperimentOverview_updateExperiment {
   __typename: "UpdateExperiment";
-  clientMutationId: string | null;
   message: ObjectField | null;
   status: number | null;
   nimbusExperiment: updateExperimentOverview_updateExperiment_nimbusExperiment | null;

--- a/app/experimenter/nimbus-ui/src/types/updateExperimentProbeSets.ts
+++ b/app/experimenter/nimbus-ui/src/types/updateExperimentProbeSets.ts
@@ -28,7 +28,6 @@ export interface updateExperimentProbeSets_updateExperiment_nimbusExperiment {
 
 export interface updateExperimentProbeSets_updateExperiment {
   __typename: "UpdateExperiment";
-  clientMutationId: string | null;
   nimbusExperiment: updateExperimentProbeSets_updateExperiment_nimbusExperiment | null;
   message: ObjectField | null;
   status: number | null;

--- a/app/experimenter/nimbus-ui/src/types/updateExperimentStatus.ts
+++ b/app/experimenter/nimbus-ui/src/types/updateExperimentStatus.ts
@@ -16,7 +16,6 @@ export interface updateExperimentStatus_updateExperiment_nimbusExperiment {
 
 export interface updateExperimentStatus_updateExperiment {
   __typename: "UpdateExperiment";
-  clientMutationId: string | null;
   message: ObjectField | null;
   status: number | null;
   nimbusExperiment: updateExperimentStatus_updateExperiment_nimbusExperiment | null;


### PR DESCRIPTION
Because

- Turns out apollo doesn't utilize clientMutationId

This commit

- Removes clientMutationId