### PR TITLE
fixes #4369 feat(nimbus): add risk mitigation link field to overview form

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/AppLayoutWithExperiment/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/AppLayoutWithExperiment/index.tsx
@@ -156,7 +156,7 @@ const AppLayoutWithExperiment = ({
             {title}
           </h2>
         )}
-        <div className="mt-4">{children({ experiment, review, analysis })}</div>
+        <div className="my-4">{children({ experiment, review, analysis })}</div>
       </section>
     </Layout>
   );

--- a/app/experimenter/nimbus-ui/src/components/FormOverview/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/FormOverview/index.test.tsx
@@ -65,6 +65,7 @@ describe("FormOverview", () => {
       ["Public name", expected.name],
       ["Hypothesis", expected.hypothesis],
       ["Public description", expected.publicDescription],
+      ["Risk Mitigation Checklist Link", expected.riskMitigationLink],
     ]) {
       const fieldName = screen.getByLabelText(labelText) as HTMLInputElement;
       expect(fieldName.value).toEqual(fieldValue);
@@ -96,6 +97,7 @@ describe("FormOverview", () => {
       name: experiment.name,
       hypothesis: experiment.hypothesis as string,
       publicDescription: experiment.publicDescription as string,
+      riskMitigationLink: experiment.riskMitigationLink as string,
     };
 
     const onSubmit = jest.fn();

--- a/app/experimenter/nimbus-ui/src/components/FormOverview/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/FormOverview/index.tsx
@@ -9,6 +9,7 @@ import { getExperiment } from "../../types/getExperiment";
 import { useExitWarning, useCommonForm } from "../../hooks";
 import { useConfig } from "../../hooks/useConfig";
 import InlineErrorIcon from "../InlineErrorIcon";
+import LinkExternal from "../LinkExternal";
 
 type FormOverviewProps = {
   isLoading: boolean;
@@ -22,11 +23,15 @@ type FormOverviewProps = {
   onNext?: (ev: React.FormEvent) => void;
 };
 
+export const RISK_MITIGATION_TEMPLATE_LINK =
+  "https://docs.google.com/document/d/1zfG2g6pYe9aB7ItViQaw8OcOsXXdRUP70zpZoNC2xcA/edit";
+
 export const overviewFieldNames = [
   "name",
   "hypothesis",
   "application",
   "publicDescription",
+  "riskMitigationLink",
 ] as const;
 
 const FormOverview = ({
@@ -47,6 +52,7 @@ const FormOverview = ({
     hypothesis: experiment?.hypothesis || (hypothesisDefault as string).trim(),
     application: "",
     publicDescription: experiment?.publicDescription as string,
+    riskMitigationLink: experiment?.riskMitigationLink as string,
   };
 
   const {
@@ -164,26 +170,52 @@ const FormOverview = ({
       </Form.Group>
 
       {experiment && (
-        <Form.Group controlId="publicDescription">
-          <Form.Label className="d-flex align-items-center">
-            Public description
-            {isMissingField!("public_description") && (
-              <InlineErrorIcon
-                name="description"
-                message="Public description cannot be blank"
-              />
-            )}
-          </Form.Label>
-          <Form.Control
-            as="textarea"
-            rows={3}
-            {...formControlAttrs("publicDescription", {})}
-          />
-          <Form.Text className="text-muted">
-            This description will be public to users on about:studies
-          </Form.Text>
-          <FormErrors name="publicDescription" />
-        </Form.Group>
+        <>
+          <Form.Group controlId="publicDescription">
+            <Form.Label className="d-flex align-items-center">
+              Public description
+              {isMissingField!("public_description") && (
+                <InlineErrorIcon
+                  name="description"
+                  message="Public description cannot be blank"
+                />
+              )}
+            </Form.Label>
+            <Form.Control
+              as="textarea"
+              rows={3}
+              {...formControlAttrs("publicDescription", {})}
+            />
+            <Form.Text className="text-muted">
+              This description will be public to users on about:studies
+            </Form.Text>
+            <FormErrors name="publicDescription" />
+          </Form.Group>
+
+          <Form.Group controlId="riskMitigationLink">
+            <Form.Label>
+              Risk Mitigation Checklist Link
+              {isMissingField!("risk_mitigation_link") && (
+                <InlineErrorIcon
+                  name="risk_mitigation_link"
+                  message="A Risk Mitigation Checklist is required"
+                />
+              )}
+            </Form.Label>
+            <Form.Control
+              {...formControlAttrs("riskMitigationLink", {})}
+              type="url"
+            />
+            <Form.Text className="text-muted">
+              Go to the{" "}
+              <LinkExternal href={RISK_MITIGATION_TEMPLATE_LINK}>
+                risk mitigation checklist
+              </LinkExternal>{" "}
+              to make a copy and add the link above
+            </Form.Text>
+            <FormErrors name="riskMitigationLink" />
+          </Form.Group>
+        </>
       )}
 
       <div className="d-flex flex-row-reverse bd-highlight">

--- a/app/experimenter/nimbus-ui/src/components/PageEditOverview/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditOverview/index.test.tsx
@@ -59,6 +59,7 @@ describe("PageEditOverview", () => {
       name: experiment.name,
       hypothesis: experiment.hypothesis!,
       publicDescription: experiment.publicDescription!,
+      riskMitigationLink: experiment.riskMitigationLink!,
     };
     mutationMock = mockExperimentMutation(
       UPDATE_EXPERIMENT_OVERVIEW_MUTATION,

--- a/app/experimenter/nimbus-ui/src/components/PageEditOverview/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditOverview/index.tsx
@@ -28,7 +28,12 @@ const PageEditOverview: React.FunctionComponent<PageEditOverviewProps> = () => {
   const [isServerValid, setIsServerValid] = useState(true);
 
   const onFormSubmit = useCallback(
-    async ({ name, hypothesis, publicDescription }: Record<string, any>) => {
+    async ({
+      name,
+      hypothesis,
+      riskMitigationLink,
+      publicDescription,
+    }: Record<string, any>) => {
       try {
         const result = await updateExperimentOverview({
           variables: {
@@ -37,6 +42,7 @@ const PageEditOverview: React.FunctionComponent<PageEditOverviewProps> = () => {
               name,
               hypothesis,
               publicDescription,
+              riskMitigationLink,
             },
           },
         });

--- a/app/experimenter/nimbus-ui/src/gql/experiments.ts
+++ b/app/experimenter/nimbus-ui/src/gql/experiments.ts
@@ -185,6 +185,8 @@ export const GET_EXPERIMENT_QUERY = gql`
 
       startDate
       endDate
+
+      riskMitigationLink
     }
   }
 `;

--- a/app/experimenter/nimbus-ui/src/hooks/useCommonForm.test.tsx
+++ b/app/experimenter/nimbus-ui/src/hooks/useCommonForm.test.tsx
@@ -108,7 +108,7 @@ describe("hooks/useCommonForm", () => {
         });
 
         overviewFieldNames.forEach((name) => {
-          if (name !== "publicDescription") {
+          if (!["publicDescription", "riskMitigationLink"].includes(name)) {
             expect(
               screen.queryByTestId(`${name}-form-errors`),
             ).toBeInTheDocument();

--- a/app/experimenter/nimbus-ui/src/hooks/useExperiment.tsx
+++ b/app/experimenter/nimbus-ui/src/hooks/useExperiment.tsx
@@ -7,7 +7,7 @@ import { GET_EXPERIMENT_QUERY } from "../gql/experiments";
 import { getExperiment } from "../types/getExperiment";
 
 const fieldPageMap: { [page: string]: string[] } = {
-  overview: ["public_description"],
+  overview: ["public_description", "risk_mitigation_link"],
   branches: ["reference_branch", "treatment_branches"],
   audience: [
     "channel",

--- a/app/experimenter/nimbus-ui/src/lib/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/lib/mocks.tsx
@@ -350,6 +350,7 @@ export function mockExperimentQuery<
       },
       startDate: new Date().toISOString(),
       endDate: new Date(Date.now() + 12096e5).toISOString(),
+      riskMitigationLink: "https://docs.google.com/document/d/banzinga/edit",
     },
     modifications,
   );

--- a/app/experimenter/nimbus-ui/src/types/getExperiment.ts
+++ b/app/experimenter/nimbus-ui/src/types/getExperiment.ts
@@ -91,6 +91,7 @@ export interface getExperiment_experimentBySlug {
   readyForReview: getExperiment_experimentBySlug_readyForReview | null;
   startDate: DateTime | null;
   endDate: DateTime | null;
+  riskMitigationLink: string;
 }
 
 export interface getExperiment {


### PR DESCRIPTION
This PR adds the UI and updated the GQL mutation to set/update an experiment's "Risk Mitigation Checklist Link".