### PR TITLE
fixes #4372 feat(nimbus): add ui for documentation links to overview form

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/FormOverview/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/FormOverview/index.test.tsx
@@ -6,6 +6,7 @@ import React from "react";
 import { render, screen, act, fireEvent } from "@testing-library/react";
 import { mockExperimentQuery } from "../../lib/mocks";
 import { Subject } from "./mocks";
+import { DOCUMENTATION_LINKS_TOOLTIP } from ".";
 
 describe("FormOverview", () => {
   it("renders as expected", async () => {
@@ -107,6 +108,13 @@ describe("FormOverview", () => {
     const nameField = screen.getByLabelText("Public name");
 
     expect(nextButton).toBeEnabled();
+
+    expect(screen.getByTestId("tooltip-documentation-links")).toHaveAttribute(
+      "data-tip",
+      DOCUMENTATION_LINKS_TOOLTIP,
+    );
+    // TODO: This will be changed to iterate across default/existing DocumentationLinks in #4371
+    expect(screen.getByTestId("DocumentationLink")).toBeInTheDocument();
 
     await act(async () => checkExistingForm(expected));
 

--- a/app/experimenter/nimbus-ui/src/gql/experiments.ts
+++ b/app/experimenter/nimbus-ui/src/gql/experiments.ts
@@ -187,6 +187,11 @@ export const GET_EXPERIMENT_QUERY = gql`
       endDate
 
       riskMitigationLink
+
+      documentationLinks {
+        title
+        link
+      }
     }
   }
 `;

--- a/app/experimenter/nimbus-ui/src/hooks/useCommonForm.test.tsx
+++ b/app/experimenter/nimbus-ui/src/hooks/useCommonForm.test.tsx
@@ -93,7 +93,9 @@ describe("hooks/useCommonForm", () => {
         render(<OverviewSubject {...{ experiment }} />);
 
         overviewFieldNames.forEach((name) => {
-          if (name !== "application") {
+          // TODO EXP-805 test errors form saving once
+          // documentationLinks uses useCommonForm
+          if (!["application", "documentationLinks"].includes(name)) {
             expect(
               screen.queryByTestId(`${name}-form-errors`),
             ).toBeInTheDocument();
@@ -108,7 +110,13 @@ describe("hooks/useCommonForm", () => {
         });
 
         overviewFieldNames.forEach((name) => {
-          if (!["publicDescription", "riskMitigationLink"].includes(name)) {
+          if (
+            ![
+              "publicDescription",
+              "documentationLinks",
+              "riskMitigationLink",
+            ].includes(name)
+          ) {
             expect(
               screen.queryByTestId(`${name}-form-errors`),
             ).toBeInTheDocument();

--- a/app/experimenter/nimbus-ui/src/lib/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/lib/mocks.tsx
@@ -351,6 +351,9 @@ export function mockExperimentQuery<
       startDate: new Date().toISOString(),
       endDate: new Date(Date.now() + 12096e5).toISOString(),
       riskMitigationLink: "https://docs.google.com/document/d/banzinga/edit",
+      documentationLinks: [
+        { title: "Bingo bongo", link: "https://bingo.bongo" },
+      ],
     },
     modifications,
   );

--- a/app/experimenter/nimbus-ui/src/types/getExperiment.ts
+++ b/app/experimenter/nimbus-ui/src/types/getExperiment.ts
@@ -65,6 +65,12 @@ export interface getExperiment_experimentBySlug_readyForReview {
   message: ObjectField | null;
 }
 
+export interface getExperiment_experimentBySlug_documentationLinks {
+  __typename: "NimbusDocumentationLinkType";
+  title: string;
+  link: string;
+}
+
 export interface getExperiment_experimentBySlug {
   __typename: "NimbusExperimentType";
   id: number | null;
@@ -92,6 +98,7 @@ export interface getExperiment_experimentBySlug {
   startDate: DateTime | null;
   endDate: DateTime | null;
   riskMitigationLink: string;
+  documentationLinks: getExperiment_experimentBySlug_documentationLinks[] | null;
 }
 
 export interface getExperiment {


### PR DESCRIPTION
Closes #4372

This PR adds the basic UI for document links ("Additional link"), as well as rendering existing existing links. The Add/Remove functionality will be added in a followup.