### PR TITLE
fix #4114 fix #4115 feat(nimbus): Add "Full targeting expression" to Audience table

### DIFF
--- a/app/experimenter/experiments/api/v5/types.py
+++ b/app/experimenter/experiments/api/v5/types.py
@@ -120,6 +120,7 @@ class NimbusExperimentType(DjangoObjectType):
     documentation_links = DjangoListField(NimbusDocumentationLinkType)
     treatment_branches = graphene.List(NimbusBranchType)
     targeting_config_slug = NimbusExperimentTargetingConfigSlug()
+    targeting_config_targeting = graphene.String()
     primary_probe_sets = graphene.List(NimbusProbeSetType)
     secondary_probe_sets = graphene.List(NimbusProbeSetType)
     ready_for_review = graphene.Field(NimbusReadyForReviewType)
@@ -150,3 +151,10 @@ class NimbusExperimentType(DjangoObjectType):
         )
         ready = serializer.is_valid()
         return NimbusReadyForReviewType(message=serializer.errors, ready=ready)
+
+    def resolve_targeting_config_targeting(self, info):
+        targeting_config = self.TARGETING_CONFIGS.get(self.targeting_config_slug, None)
+        if targeting_config:
+            return targeting_config.targeting
+        else:
+            return ""

--- a/app/experimenter/nimbus-ui/schema.graphql
+++ b/app/experimenter/nimbus-ui/schema.graphql
@@ -181,6 +181,7 @@ type NimbusExperimentType {
   documentationLinks: [NimbusDocumentationLinkType!]
   bucketRange: NimbusBucketRangeType
   treatmentBranches: [NimbusBranchType]
+  targetingConfigTargeting: String
   primaryProbeSets: [NimbusProbeSetType]
   secondaryProbeSets: [NimbusProbeSetType]
   readyForReview: NimbusReadyForReviewType

--- a/app/experimenter/nimbus-ui/src/components/TableAudience/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/TableAudience/index.test.tsx
@@ -103,6 +103,25 @@ describe("TableAudience", () => {
       expect(screen.queryByTestId("experiment-target")).not.toBeInTheDocument();
     });
   });
+
+  describe("renders 'Full targeting expression' row as expected", () => {
+    it("when set", () => {
+      const { experiment } = mockExperimentQuery("demo-slug");
+      render(<Subject {...{ experiment }} />);
+      expect(
+        screen.getByTestId("experiment-target-expression"),
+      ).toHaveTextContent(experiment.targetingConfigTargeting!);
+    });
+    it("when targetingConfigTargeting is empty", () => {
+      const { experiment } = mockExperimentQuery("demo-slug", {
+        targetingConfigTargeting: "",
+      });
+      render(<Subject {...{ experiment }} />);
+      expect(
+        screen.queryByTestId("experiment-target-expression"),
+      ).not.toBeInTheDocument();
+    });
+  });
 });
 
 const Subject = ({

--- a/app/experimenter/nimbus-ui/src/components/TableAudience/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/TableAudience/index.tsx
@@ -65,6 +65,17 @@ const TableAudience = ({ experiment }: TableAudienceProps) => {
             </td>
           </tr>
         )}
+        {experiment.targetingConfigTargeting !== "" && (
+          <tr>
+            <th>Full targeting expression</th>
+            <td
+              data-testid="experiment-target-expression"
+              className="text-monospace"
+            >
+              {experiment.targetingConfigTargeting}
+            </td>
+          </tr>
+        )}
       </tbody>
     </Table>
   );

--- a/app/experimenter/nimbus-ui/src/gql/experiments.ts
+++ b/app/experimenter/nimbus-ui/src/gql/experiments.ts
@@ -172,6 +172,7 @@ export const GET_EXPERIMENT_QUERY = gql`
       channel
       firefoxMinVersion
       targetingConfigSlug
+      targetingConfigTargeting
 
       populationPercent
       totalEnrolledClients

--- a/app/experimenter/nimbus-ui/src/lib/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/lib/mocks.tsx
@@ -339,6 +339,7 @@ export function mockExperimentQuery<
       channel: "DESKTOP_NIGHTLY",
       firefoxMinVersion: "FIREFOX_80",
       targetingConfigSlug: "US_ONLY",
+      targetingConfigTargeting: "localeLanguageCode == 'en' && region == 'US'",
       populationPercent: "40",
       totalEnrolledClients: 68000,
       proposedEnrollment: 1,

--- a/app/experimenter/nimbus-ui/src/types/getExperiment.ts
+++ b/app/experimenter/nimbus-ui/src/types/getExperiment.ts
@@ -90,6 +90,7 @@ export interface getExperiment_experimentBySlug {
   channel: NimbusExperimentChannel | null;
   firefoxMinVersion: NimbusExperimentFirefoxMinVersion | null;
   targetingConfigSlug: NimbusExperimentTargetingConfigSlug | null;
+  targetingConfigTargeting: string | null;
   populationPercent: string | null;
   totalEnrolledClients: number;
   proposedEnrollment: number;


### PR DESCRIPTION
Because:

- We need to show the full targeting expression on the last row of the Audience table.

This commit:

- adds targetingConfigTargeting field to experimentBySlug query as a
  lookup of targetingConfigSlug against constants

- adds a row to TableAudience to display targetingConfigTargeting when
  targetingConfigSlug is set