### PR TITLE
fix #4417 feat(nimbus): move hard-coded external links into constant

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/FormAudience/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/FormAudience/index.test.tsx
@@ -11,7 +11,6 @@ import {
   act,
 } from "@testing-library/react";
 import { Subject, MOCK_EXPERIMENT } from "./mocks";
-import { AUDIENCE_DOC_URL } from ".";
 import { MOCK_CONFIG } from "../../lib/mocks";
 import { snakeToCamelCase } from "../../lib/caseConversions";
 import {
@@ -19,6 +18,7 @@ import {
   NimbusExperimentTargetingConfigSlug,
   NimbusExperimentChannel,
 } from "../../types/globalTypes";
+import { EXTERNAL_URLS } from "../../lib/constants";
 
 describe("FormAudience", () => {
   it("renders without error", async () => {
@@ -28,7 +28,7 @@ describe("FormAudience", () => {
     });
     expect(screen.getByTestId("learn-more-link")).toHaveAttribute(
       "href",
-      AUDIENCE_DOC_URL,
+      EXTERNAL_URLS.WORKFLOW_MANA_DOC,
     );
     const targetingConfigSlug = screen.queryByTestId("targetingConfigSlug");
     expect(targetingConfigSlug).toBeInTheDocument();

--- a/app/experimenter/nimbus-ui/src/components/FormAudience/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/FormAudience/index.tsx
@@ -14,9 +14,7 @@ import { useConfig } from "../../hooks/useConfig";
 import { getExperiment_experimentBySlug } from "../../types/getExperiment";
 import { getConfig_nimbusConfig_channel } from "../../types/getConfig";
 import { useCommonForm } from "../../hooks";
-
-export const AUDIENCE_DOC_URL =
-  "https://mana.mozilla.org/wiki/pages/viewpage.action?pageId=109990007";
+import { EXTERNAL_URLS } from "../../lib/constants";
 
 type FormAudienceProps = {
   experiment: getExperiment_experimentBySlug;
@@ -185,7 +183,10 @@ export const FormAudience = ({
       <Form.Group className="bg-light p-4">
         <p className="text-secondary">
           Please ask a data scientist to help you determine these values.{" "}
-          <LinkExternal href={AUDIENCE_DOC_URL} data-testid="learn-more-link">
+          <LinkExternal
+            href={EXTERNAL_URLS.WORKFLOW_MANA_DOC}
+            data-testid="learn-more-link"
+          >
             Learn more
           </LinkExternal>
         </p>

--- a/app/experimenter/nimbus-ui/src/components/FormOverview/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/FormOverview/index.tsx
@@ -15,6 +15,7 @@ import InlineErrorIcon from "../InlineErrorIcon";
 import LinkExternal from "../LinkExternal";
 import { ReactComponent as Info } from "../../images/info.svg";
 import { ReactComponent as DeleteIcon } from "../../images/x.svg";
+import { EXTERNAL_URLS } from "../../lib/constants";
 
 type FormOverviewProps = {
   isLoading: boolean;
@@ -28,8 +29,6 @@ type FormOverviewProps = {
   onNext?: (ev: React.FormEvent) => void;
 };
 
-export const RISK_MITIGATION_TEMPLATE_LINK =
-  "https://docs.google.com/document/d/1zfG2g6pYe9aB7ItViQaw8OcOsXXdRUP70zpZoNC2xcA/edit";
 export const DOCUMENTATION_LINKS_TOOLTIP =
   "Any additional links you would like to add, for example, Jira DS Ticket, Jira QA ticket, or experiment brief.";
 
@@ -229,7 +228,7 @@ const FormOverview = ({
             />
             <Form.Text className="text-muted">
               Go to the{" "}
-              <LinkExternal href={RISK_MITIGATION_TEMPLATE_LINK}>
+              <LinkExternal href={EXTERNAL_URLS.RISK_MITIGATION_TEMPLATE_DOC}>
                 risk mitigation checklist
               </LinkExternal>{" "}
               to make a copy and add the link above

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/index.test.tsx
@@ -12,12 +12,12 @@ import {
 } from "@testing-library/react";
 import { navigate } from "@reach/router";
 import fetchMock from "jest-fetch-mock";
-import PageEditBranches, { SUBMIT_ERROR_MESSAGE, BRANCHES_DOC_URL } from ".";
+import PageEditBranches, { SUBMIT_ERROR_MESSAGE } from ".";
 import FormBranches from "../FormBranches";
 import { RouterSlugProvider } from "../../lib/test-utils";
 import { mockExperimentQuery, MOCK_CONFIG } from "../../lib/mocks";
 import { UPDATE_EXPERIMENT_BRANCHES_MUTATION } from "../../gql/experiments";
-import { BASE_PATH } from "../../lib/constants";
+import { BASE_PATH, EXTERNAL_URLS } from "../../lib/constants";
 import { getExperiment_experimentBySlug } from "../../types/getExperiment";
 import {
   NimbusExperimentStatus,
@@ -101,7 +101,7 @@ describe("PageEditBranches", () => {
     expect(screen.getByTestId("feature-config")).toBeInTheDocument();
     expect(screen.getByTestId("learn-more-link")).toHaveAttribute(
       "href",
-      BRANCHES_DOC_URL,
+      EXTERNAL_URLS.BRANCHES_GOOGLE_DOC,
     );
 
     for (const feature of MOCK_CONFIG!.featureConfig!) {

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/index.tsx
@@ -15,9 +15,7 @@ import { ExperimentInput } from "../../types/globalTypes";
 import { updateExperimentBranches_updateExperiment as UpdateExperimentBranchesResult } from "../../types/updateExperimentBranches";
 import { getExperiment_experimentBySlug } from "../../types/getExperiment";
 import { editCommonRedirects } from "../../lib/experiment";
-
-export const BRANCHES_DOC_URL =
-  "https://docs.google.com/document/d/155EUgzn22VTX8mFwesSROT3Z6JORSfb5VyoMoLra7ws/edit#heading=h.i8g4ppfvkq0x";
+import { EXTERNAL_URLS } from "../../lib/constants";
 
 export const SUBMIT_ERROR_MESSAGE = "Save failed, no error available";
 
@@ -94,7 +92,7 @@ const PageEditBranches: React.FunctionComponent<RouteComponentProps> = () => {
               configuration to each branch. Experiments can only change one flag
               at a time.{" "}
               <LinkExternal
-                href={BRANCHES_DOC_URL}
+                href={EXTERNAL_URLS.BRANCHES_GOOGLE_DOC}
                 data-testid="learn-more-link"
               >
                 Learn more

--- a/app/experimenter/nimbus-ui/src/components/PageEditMetrics/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditMetrics/index.test.tsx
@@ -11,14 +11,14 @@ import {
   act,
 } from "@testing-library/react";
 import fetchMock from "jest-fetch-mock";
-import PageEditMetrics, { CORE_METRICS_DOC_URL } from ".";
+import PageEditMetrics from ".";
 import FormMetrics from "../FormMetrics";
 import { RouterSlugProvider } from "../../lib/test-utils";
 import { mockExperimentMutation, mockExperimentQuery } from "../../lib/mocks";
 import { MockedResponse } from "@apollo/client/testing";
 import { navigate } from "@reach/router";
 import { UPDATE_EXPERIMENT_PROBESETS_MUTATION } from "../../gql/experiments";
-import { BASE_PATH, SUBMIT_ERROR } from "../../lib/constants";
+import { BASE_PATH, EXTERNAL_URLS, SUBMIT_ERROR } from "../../lib/constants";
 import { NimbusExperimentStatus } from "../../types/globalTypes";
 
 const { mock, experiment } = mockExperimentQuery("demo-slug");
@@ -93,7 +93,7 @@ describe("PageEditMetrics", () => {
       expect(screen.getByTestId("header-experiment")).toBeInTheDocument();
       expect(screen.getByTestId("core-metrics-link")).toHaveAttribute(
         "href",
-        CORE_METRICS_DOC_URL,
+        EXTERNAL_URLS.METRICS_GOOGLE_DOC,
       );
     });
   });

--- a/app/experimenter/nimbus-ui/src/components/PageEditMetrics/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditMetrics/index.tsx
@@ -7,7 +7,7 @@ import { useMutation } from "@apollo/client";
 import React, { useState, useRef, useCallback } from "react";
 
 import { getExperiment_experimentBySlug } from "../../types/getExperiment";
-import { SUBMIT_ERROR } from "../../lib/constants";
+import { EXTERNAL_URLS, SUBMIT_ERROR } from "../../lib/constants";
 import { UPDATE_EXPERIMENT_PROBESETS_MUTATION } from "../../gql/experiments";
 import { updateExperimentProbeSets_updateExperiment as UpdateExperimentProbeSetsResult } from "../../types/updateExperimentProbeSets";
 import { ExperimentInput } from "../../types/globalTypes";
@@ -15,9 +15,6 @@ import AppLayoutWithExperiment from "../AppLayoutWithExperiment";
 import FormMetrics from "../FormMetrics";
 import LinkExternal from "../LinkExternal";
 import { editCommonRedirects } from "../../lib/experiment";
-
-export const CORE_METRICS_DOC_URL =
-  "https://docs.google.com/document/d/155EUgzn22VTX8mFwesSROT3Z6JORSfb5VyoMoLra7ws/edit#heading=h.uq23fsvh16rc";
 
 const PageEditMetrics: React.FunctionComponent<RouteComponentProps> = () => {
   const [updateExperimentProbeSets, { loading }] = useMutation<
@@ -91,7 +88,7 @@ const PageEditMetrics: React.FunctionComponent<RouteComponentProps> = () => {
               <strong>Retention, Search Count, and Ad Click</strong> metrics.
               Get more information on{" "}
               <LinkExternal
-                href={CORE_METRICS_DOC_URL}
+                href={EXTERNAL_URLS.METRICS_GOOGLE_DOC}
                 data-testid="core-metrics-link"
               >
                 Core Firefox Metrics

--- a/app/experimenter/nimbus-ui/src/components/PageNew/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageNew/index.tsx
@@ -14,11 +14,8 @@ import { CREATE_EXPERIMENT_MUTATION } from "../../gql/experiments";
 import { ExperimentInput } from "../../types/globalTypes";
 import { createExperiment_createExperiment as CreateExperimentResult } from "../../types/createExperiment";
 import { navigate } from "@reach/router";
-import { SUBMIT_ERROR } from "../../lib/constants";
+import { EXTERNAL_URLS, SUBMIT_ERROR } from "../../lib/constants";
 import Head from "../Head";
-
-const TRAINING_DOC_URL =
-  "https://mana.mozilla.org/wiki/display/FJT/Project+Nimbus";
 
 type PageNewProps = {} & RouteComponentProps;
 
@@ -78,7 +75,7 @@ const PageNew: React.FunctionComponent<PageNewProps> = () => {
 
       <p>
         Before launching an experiment, review the{" "}
-        <LinkExternal href={TRAINING_DOC_URL}>
+        <LinkExternal href={EXTERNAL_URLS.NIMBUS_MANA_DOC}>
           training and planning documentation
         </LinkExternal>
         .

--- a/app/experimenter/nimbus-ui/src/lib/constants.ts
+++ b/app/experimenter/nimbus-ui/src/lib/constants.ts
@@ -8,3 +8,15 @@ export const UNKNOWN_ERROR =
   "Sorry, an error occurred but we don't know why. We're looking into it.";
 export const SUBMIT_ERROR =
   "Sorry, an error occurred while submitting. Please try again.";
+
+export const EXTERNAL_URLS = {
+  RISK_MITIGATION_TEMPLATE_DOC:
+    "https://docs.google.com/document/d/1zfG2g6pYe9aB7ItViQaw8OcOsXXdRUP70zpZoNC2xcA/edit",
+  NIMBUS_MANA_DOC: "https://mana.mozilla.org/wiki/display/FJT/Project+Nimbus",
+  WORKFLOW_MANA_DOC:
+    "https://mana.mozilla.org/wiki/pages/viewpage.action?pageId=109990007",
+  BRANCHES_GOOGLE_DOC:
+    "https://docs.google.com/document/d/155EUgzn22VTX8mFwesSROT3Z6JORSfb5VyoMoLra7ws/edit#heading=h.i8g4ppfvkq0x",
+  METRICS_GOOGLE_DOC:
+    "https://docs.google.com/document/d/155EUgzn22VTX8mFwesSROT3Z6JORSfb5VyoMoLra7ws/edit#heading=h.uq23fsvh16rc",
+};


### PR DESCRIPTION
Closes #4417

Simple PR, just moves all our external links to a central place.