### PR TITLE
fix #4450 fix(nimbus): ensure feature_config is not lost when saving

### DIFF
--- a/app/experimenter/experiments/api/v5/mutation.py
+++ b/app/experimenter/experiments/api/v5/mutation.py
@@ -63,7 +63,8 @@ class UpdateExperiment(graphene.Mutation):
     @classmethod
     def mutate(cls, root, info, input: ExperimentInput):
         exp = NimbusExperiment.objects.get(id=input.id)
-        input["feature_config"] = input.pop("feature_config_id", None)
+        if "feature_config_id" in input:
+            input["feature_config"] = input.pop("feature_config_id", None)
         serializer = NimbusExperimentUpdateSerializer(
             exp, data=input, partial=True, context={"user": info.context.user}
         )


### PR DESCRIPTION
Because:

- feature_config for branches gets lost when saving unrelated pages

This commit:

- ensures we check for the presence of feature_config_id in mutation
  input data before renaming it to feature_config for the serializer