### PR TITLE
feat(nimbus): automatically sort nimbus ts/tsx imports

### DIFF
--- a/app/experimenter/nimbus-ui/package.json
+++ b/app/experimenter/nimbus-ui/package.json
@@ -89,6 +89,7 @@
     "mutationobserver-shim": "^0.3.7",
     "node-sass": "^4.14.1",
     "prettier": "^2.1.2",
+    "prettier-plugin-organize-imports": "^1.1.1",
     "stylelint": "^13.7.1",
     "stylelint-config-prettier": "^8.0.2"
   },

--- a/app/experimenter/nimbus-ui/src/components/App/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/App/index.test.tsx
@@ -2,12 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React, { ReactNode } from "react";
-import { screen, waitFor } from "@testing-library/react";
-import { renderWithRouter } from "../../lib/test-utils";
-import { MockedCache, mockExperimentQuery } from "../../lib/mocks";
 import * as apollo from "@apollo/client";
+import { screen, waitFor } from "@testing-library/react";
+import React, { ReactNode } from "react";
 import App from ".";
+import { MockedCache, mockExperimentQuery } from "../../lib/mocks";
+import { renderWithRouter } from "../../lib/test-utils";
 
 const { mock } = mockExperimentQuery("my-special-slug");
 

--- a/app/experimenter/nimbus-ui/src/components/App/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/App/index.tsx
@@ -2,21 +2,21 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from "react";
-import { Router, Redirect, RouteComponentProps } from "@reach/router";
 import { useQuery } from "@apollo/client";
+import { Redirect, RouteComponentProps, Router } from "@reach/router";
+import React from "react";
 import { GET_CONFIG_QUERY } from "../../gql/config";
-import PageLoading from "../PageLoading";
-import PageHome from "../PageHome";
-import PageNew from "../PageNew";
-import PageSummary from "../PageSummary";
 import PageDesign from "../PageDesign";
-import PageResults from "../PageResults";
-import PageEditOverview from "../PageEditOverview";
+import PageEditAudience from "../PageEditAudience";
 import PageEditBranches from "../PageEditBranches";
 import PageEditMetrics from "../PageEditMetrics";
-import PageEditAudience from "../PageEditAudience";
+import PageEditOverview from "../PageEditOverview";
+import PageHome from "../PageHome";
+import PageLoading from "../PageLoading";
+import PageNew from "../PageNew";
 import PageRequestReview from "../PageRequestReview";
+import PageResults from "../PageResults";
+import PageSummary from "../PageSummary";
 
 type RootProps = {
   children: React.ReactNode;

--- a/app/experimenter/nimbus-ui/src/components/AppErrorBoundary/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/AppErrorBoundary/index.stories.tsx
@@ -1,5 +1,5 @@
-import React from "react";
 import { storiesOf } from "@storybook/react";
+import React from "react";
 import { AppErrorAlert } from ".";
 
 storiesOf("components/AppErrorAlert", module).add("basic", () => (

--- a/app/experimenter/nimbus-ui/src/components/AppErrorBoundary/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/AppErrorBoundary/index.test.tsx
@@ -2,8 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from "react";
 import { render, screen } from "@testing-library/react";
+import React from "react";
 import AppErrorBoundary, { AppErrorAlert } from ".";
 
 describe("AppErrorAlert", () => {

--- a/app/experimenter/nimbus-ui/src/components/AppLayout/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/AppLayout/index.stories.tsx
@@ -2,8 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from "react";
 import { storiesOf } from "@storybook/react";
+import React from "react";
 import AppLayout from ".";
 
 storiesOf("components/AppLayout", module).add("default", () => (

--- a/app/experimenter/nimbus-ui/src/components/AppLayout/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/AppLayout/index.test.tsx
@@ -2,8 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from "react";
 import { render, screen } from "@testing-library/react";
+import React from "react";
 import AppLayout from ".";
 
 test("renders app layout content with children", () => {

--- a/app/experimenter/nimbus-ui/src/components/AppLayoutSidebarLocked/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/AppLayoutSidebarLocked/index.stories.tsx
@@ -2,14 +2,14 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from "react";
-import { storiesOf } from "@storybook/react";
 import { withLinks } from "@storybook/addon-links";
-import { RouterSlugProvider } from "../../lib/test-utils";
+import { storiesOf } from "@storybook/react";
+import React from "react";
 import AppLayoutSidebarLocked from ".";
-import { NimbusExperimentStatus } from "../../types/globalTypes";
 import { mockExperimentQuery, mockGetStatus } from "../../lib/mocks";
+import { RouterSlugProvider } from "../../lib/test-utils";
 import { mockAnalysis } from "../../lib/visualization/mocks";
+import { NimbusExperimentStatus } from "../../types/globalTypes";
 
 const { experiment } = mockExperimentQuery("demo-slug");
 

--- a/app/experimenter/nimbus-ui/src/components/AppLayoutSidebarLocked/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/AppLayoutSidebarLocked/index.test.tsx
@@ -2,20 +2,20 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from "react";
-import { render, screen } from "@testing-library/react";
-import { RESULTS_LOADING_TEXT, AppLayoutSidebarLocked } from ".";
-import { RouterSlugProvider } from "../../lib/test-utils";
-import { BASE_PATH } from "../../lib/constants";
 import { RouteComponentProps } from "@reach/router";
+import { render, screen } from "@testing-library/react";
+import React from "react";
+import { AppLayoutSidebarLocked, RESULTS_LOADING_TEXT } from ".";
+import { BASE_PATH } from "../../lib/constants";
 import { mockExperimentQuery, mockGetStatus } from "../../lib/mocks";
-import { NimbusExperimentStatus } from "../../types/globalTypes";
+import { RouterSlugProvider } from "../../lib/test-utils";
 import { mockAnalysis } from "../../lib/visualization/mocks";
+import { AnalysisData } from "../../lib/visualization/types";
 import {
   getExperiment_experimentBySlug_primaryProbeSets,
   getExperiment_experimentBySlug_secondaryProbeSets,
 } from "../../types/getExperiment";
-import { AnalysisData } from "../../lib/visualization/types";
+import { NimbusExperimentStatus } from "../../types/globalTypes";
 
 const { mock } = mockExperimentQuery("my-special-slug/design");
 

--- a/app/experimenter/nimbus-ui/src/components/AppLayoutSidebarLocked/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/AppLayoutSidebarLocked/index.tsx
@@ -1,23 +1,23 @@
-import React from "react";
 import { RouteComponentProps, useParams } from "@reach/router";
-import Container from "react-bootstrap/Container";
-import Row from "react-bootstrap/Row";
+import React from "react";
 import Col from "react-bootstrap/Col";
+import Container from "react-bootstrap/Container";
 import Nav from "react-bootstrap/Nav";
+import Row from "react-bootstrap/Row";
 import Scrollspy from "react-scrollspy";
+import { ReactComponent as ChevronLeft } from "../../images/chevron-left.svg";
+import { ReactComponent as Clipboard } from "../../images/clipboard.svg";
+import { StatusCheck } from "../../lib/experiment";
 import { AnalysisData } from "../../lib/visualization/types";
 import { analysisAvailable } from "../../lib/visualization/utils";
-import { StatusCheck } from "../../lib/experiment";
-import { DisabledItem } from "../DisabledItem";
-import { LinkNav } from "../LinkNav";
 import {
   getExperiment_experimentBySlug_primaryProbeSets,
   getExperiment_experimentBySlug_secondaryProbeSets,
 } from "../../types/getExperiment";
-import { ReactComponent as ChevronLeft } from "../../images/chevron-left.svg";
-import { ReactComponent as Clipboard } from "../../images/clipboard.svg";
-import { ReactComponent as BarChart } from "./bar-chart.svg";
+import { DisabledItem } from "../DisabledItem";
 import LinkExternal from "../LinkExternal";
+import { LinkNav } from "../LinkNav";
+import { ReactComponent as BarChart } from "./bar-chart.svg";
 
 export const RESULTS_LOADING_TEXT = "Checking results availability...";
 

--- a/app/experimenter/nimbus-ui/src/components/AppLayoutWithExperiment/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/AppLayoutWithExperiment/index.stories.tsx
@@ -2,12 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from "react";
-import { storiesOf } from "@storybook/react";
-import { RouterSlugProvider } from "../../lib/test-utils";
 import { withLinks } from "@storybook/addon-links";
+import { storiesOf } from "@storybook/react";
+import React from "react";
 import AppLayoutWithExperiment from ".";
 import { mockExperimentQuery } from "../../lib/mocks";
+import { RouterSlugProvider } from "../../lib/test-utils";
 
 const { mock } = mockExperimentQuery("demo-slug");
 

--- a/app/experimenter/nimbus-ui/src/components/AppLayoutWithExperiment/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/AppLayoutWithExperiment/index.test.tsx
@@ -2,13 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import { act, render, screen, waitFor } from "@testing-library/react";
 import React from "react";
-import { render, screen, waitFor, act } from "@testing-library/react";
 import AppLayoutWithExperiment, { POLL_INTERVAL } from ".";
-import { renderWithRouter, RouterSlugProvider } from "../../lib/test-utils";
-import { mockExperimentQuery } from "../../lib/mocks";
-import { NimbusExperimentStatus } from "../../types/globalTypes";
 import { BASE_PATH } from "../../lib/constants";
+import { mockExperimentQuery } from "../../lib/mocks";
+import { renderWithRouter, RouterSlugProvider } from "../../lib/test-utils";
+import { NimbusExperimentStatus } from "../../types/globalTypes";
 
 jest.useFakeTimers();
 

--- a/app/experimenter/nimbus-ui/src/components/AppLayoutWithExperiment/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/AppLayoutWithExperiment/index.tsx
@@ -2,24 +2,24 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React, { useEffect } from "react";
 import { navigate, RouteComponentProps, useParams } from "@reach/router";
-import AppLayoutWithSidebar from "../AppLayoutWithSidebar";
-import AppLayoutSidebarLocked from "../AppLayoutSidebarLocked";
-import HeaderExperiment from "../HeaderExperiment";
-import PageLoading from "../PageLoading";
-import PageExperimentNotFound from "../PageExperimentNotFound";
-import { useAnalysis, useExperiment, ExperimentReview } from "../../hooks";
-import { getExperiment_experimentBySlug } from "../../types/getExperiment";
-import AppLayout from "../AppLayout";
-import { AnalysisData } from "../../lib/visualization/types";
-import Head from "../Head";
+import React, { useEffect } from "react";
+import { ExperimentReview, useAnalysis, useExperiment } from "../../hooks";
+import { BASE_PATH } from "../../lib/constants";
 import { getStatus, StatusCheck } from "../../lib/experiment";
+import { AnalysisData } from "../../lib/visualization/types";
 import {
+  getExperiment_experimentBySlug,
   getExperiment_experimentBySlug_primaryProbeSets,
   getExperiment_experimentBySlug_secondaryProbeSets,
 } from "../../types/getExperiment";
-import { BASE_PATH } from "../../lib/constants";
+import AppLayout from "../AppLayout";
+import AppLayoutSidebarLocked from "../AppLayoutSidebarLocked";
+import AppLayoutWithSidebar from "../AppLayoutWithSidebar";
+import Head from "../Head";
+import HeaderExperiment from "../HeaderExperiment";
+import PageExperimentNotFound from "../PageExperimentNotFound";
+import PageLoading from "../PageLoading";
 
 type AppLayoutWithExperimentChildrenProps = {
   experiment: getExperiment_experimentBySlug;

--- a/app/experimenter/nimbus-ui/src/components/AppLayoutWithSidebar/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/AppLayoutWithSidebar/index.stories.tsx
@@ -2,13 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from "react";
-import { storiesOf } from "@storybook/react";
 import { withLinks } from "@storybook/addon-links";
-import { RouterSlugProvider } from "../../lib/test-utils";
+import { storiesOf } from "@storybook/react";
+import React from "react";
 import AppLayoutWithSidebar from ".";
-import { NimbusExperimentStatus } from "../../types/globalTypes";
 import { mockGetStatus } from "../../lib/mocks";
+import { RouterSlugProvider } from "../../lib/test-utils";
+import { NimbusExperimentStatus } from "../../types/globalTypes";
 
 storiesOf("components/AppLayoutWithSidebar", module)
   .addDecorator(withLinks)

--- a/app/experimenter/nimbus-ui/src/components/AppLayoutWithSidebar/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/AppLayoutWithSidebar/index.test.tsx
@@ -2,19 +2,19 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from "react";
-import { act, render, screen, waitFor } from "@testing-library/react";
-import AppLayoutWithSidebar from ".";
-import { renderWithRouter, RouterSlugProvider } from "../../lib/test-utils";
-import { BASE_PATH } from "../../lib/constants";
 import { RouteComponentProps } from "@reach/router";
-import App from "../App";
+import { act, render, screen, waitFor } from "@testing-library/react";
+import React from "react";
+import AppLayoutWithSidebar from ".";
+import { BASE_PATH } from "../../lib/constants";
 import {
   MockedCache,
   mockExperimentQuery,
   mockGetStatus,
 } from "../../lib/mocks";
+import { renderWithRouter, RouterSlugProvider } from "../../lib/test-utils";
 import { NimbusExperimentStatus } from "../../types/globalTypes";
+import App from "../App";
 
 const { mock } = mockExperimentQuery("my-special-slug");
 

--- a/app/experimenter/nimbus-ui/src/components/AppLayoutWithSidebar/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/AppLayoutWithSidebar/index.tsx
@@ -2,23 +2,23 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import { Link, RouteComponentProps, useParams } from "@reach/router";
 import React from "react";
-import { RouteComponentProps, useParams, Link } from "@reach/router";
-import Container from "react-bootstrap/Container";
-import Row from "react-bootstrap/Row";
 import Col from "react-bootstrap/Col";
+import Container from "react-bootstrap/Container";
 import Nav from "react-bootstrap/Nav";
+import Row from "react-bootstrap/Row";
+import { ReactComponent as ChevronLeft } from "../../images/chevron-left.svg";
+import { ReactComponent as Clipboard } from "../../images/clipboard.svg";
 import { BASE_PATH } from "../../lib/constants";
 import { StatusCheck } from "../../lib/experiment";
 import { DisabledItem } from "../DisabledItem";
 import { LinkNav } from "../LinkNav";
-import { ReactComponent as ChevronLeft } from "../../images/chevron-left.svg";
+import { ReactComponent as AlertCircle } from "./alert-circle.svg";
+import { ReactComponent as ChartArrow } from "./chart-arrow.svg";
 import { ReactComponent as Cog } from "./cog.svg";
 import { ReactComponent as Layers } from "./layers.svg";
-import { ReactComponent as ChartArrow } from "./chart-arrow.svg";
 import { ReactComponent as Person } from "./person.svg";
-import { ReactComponent as Clipboard } from "../../images/clipboard.svg";
-import { ReactComponent as AlertCircle } from "./alert-circle.svg";
 
 type AppLayoutWithSidebarProps = {
   testid?: string;

--- a/app/experimenter/nimbus-ui/src/components/FormOverview/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/FormOverview/index.stories.tsx
@@ -2,11 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from "react";
-import { storiesOf } from "@storybook/react";
-import { Subject } from "./mocks";
 import { action } from "@storybook/addon-actions";
+import { storiesOf } from "@storybook/react";
+import React from "react";
 import { mockExperimentQuery } from "../../lib/mocks";
+import { Subject } from "./mocks";
 
 const onSubmit = action("onSubmit");
 const onCancel = action("onCancel");

--- a/app/experimenter/nimbus-ui/src/components/FormOverview/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/FormOverview/index.test.tsx
@@ -2,12 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import { act, fireEvent, render, screen } from "@testing-library/react";
 import React from "react";
-import { render, screen, act, fireEvent } from "@testing-library/react";
-import { mockExperimentQuery } from "../../lib/mocks";
-import { Subject } from "./mocks";
 import { DOCUMENTATION_LINKS_TOOLTIP } from ".";
+import { mockExperimentQuery } from "../../lib/mocks";
 import { NimbusDocumentationLinkTitle } from "../../types/globalTypes";
+import { Subject } from "./mocks";
 
 describe("FormOverview", () => {
   it("renders as expected", async () => {

--- a/app/experimenter/nimbus-ui/src/components/FormOverview/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/FormOverview/index.tsx
@@ -3,20 +3,20 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React, { useCallback, useEffect } from "react";
-import Form from "react-bootstrap/Form";
 import Alert from "react-bootstrap/Alert";
 import Button from "react-bootstrap/Button";
 import Col from "react-bootstrap/Col";
-import { getExperiment } from "../../types/getExperiment";
-import { useExitWarning, useCommonForm } from "../../hooks";
+import Form from "react-bootstrap/Form";
 import ReactTooltip from "react-tooltip";
+import { useCommonForm, useExitWarning } from "../../hooks";
 import { useConfig } from "../../hooks/useConfig";
-import InlineErrorIcon from "../InlineErrorIcon";
-import LinkExternal from "../LinkExternal";
 import { ReactComponent as Info } from "../../images/info.svg";
 import { ReactComponent as DeleteIcon } from "../../images/x.svg";
 import { EXTERNAL_URLS } from "../../lib/constants";
+import { getExperiment } from "../../types/getExperiment";
 import { NimbusDocumentationLinkTitle } from "../../types/globalTypes";
+import InlineErrorIcon from "../InlineErrorIcon";
+import LinkExternal from "../LinkExternal";
 
 type FormOverviewProps = {
   isLoading: boolean;

--- a/app/experimenter/nimbus-ui/src/components/HeaderExperiment/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/HeaderExperiment/index.stories.tsx
@@ -2,13 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from "react";
-import { storiesOf } from "@storybook/react";
 import { withLinks } from "@storybook/addon-links";
+import { storiesOf } from "@storybook/react";
+import React from "react";
 import HeaderExperiment from ".";
 import { mockExperimentQuery, mockGetStatus } from "../../lib/mocks";
-import AppLayout from "../AppLayout";
 import { NimbusExperimentStatus } from "../../types/globalTypes";
+import AppLayout from "../AppLayout";
 
 const { experiment } = mockExperimentQuery("demo-slug");
 

--- a/app/experimenter/nimbus-ui/src/components/HeaderExperiment/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/HeaderExperiment/index.test.tsx
@@ -2,11 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import { render, screen } from "@testing-library/react";
 import React from "react";
-import { screen, render } from "@testing-library/react";
 import HeaderExperiment from ".";
-import { mockExperimentQuery, mockGetStatus } from "../../lib/mocks";
 import { humanDate } from "../../lib/dateUtils";
+import { mockExperimentQuery, mockGetStatus } from "../../lib/mocks";
 import { NimbusExperimentStatus } from "../../types/globalTypes";
 
 describe("HeaderExperiment", () => {

--- a/app/experimenter/nimbus-ui/src/components/HeaderExperiment/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/HeaderExperiment/index.tsx
@@ -4,10 +4,10 @@
 
 import classNames from "classnames";
 import React from "react";
-import { getExperiment_experimentBySlug } from "../../types/getExperiment";
-import { StatusCheck } from "../../lib/experiment";
-import "./index.scss";
 import { humanDate, stringDateSubtract } from "../../lib/dateUtils";
+import { StatusCheck } from "../../lib/experiment";
+import { getExperiment_experimentBySlug } from "../../types/getExperiment";
+import "./index.scss";
 
 type HeaderExperimentProps = Pick<
   getExperiment_experimentBySlug,

--- a/app/experimenter/nimbus-ui/src/components/InlineErrorIcon/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/InlineErrorIcon/index.stories.tsx
@@ -2,8 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from "react";
 import { storiesOf } from "@storybook/react";
+import React from "react";
 import InlineErrorIcon from ".";
 
 storiesOf("components/InlineErrorIcon", module).add("basic", () => (

--- a/app/experimenter/nimbus-ui/src/components/LinkExternal/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/LinkExternal/index.stories.tsx
@@ -2,8 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from "react";
 import { storiesOf } from "@storybook/react";
+import React from "react";
 import LinkExternal from "./index";
 import { ReactComponent as OpenExternalIcon } from "./open-external.svg";
 

--- a/app/experimenter/nimbus-ui/src/components/LinkExternal/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/LinkExternal/index.test.tsx
@@ -2,8 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from "react";
 import { render } from "@testing-library/react";
+import React from "react";
 import LinkExternal from "./index";
 
 it("renders without imploding", () => {

--- a/app/experimenter/nimbus-ui/src/components/LinkMonitoring/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/LinkMonitoring/index.stories.tsx
@@ -2,8 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from "react";
 import { storiesOf } from "@storybook/react";
+import React from "react";
 import LinkMonitoring from ".";
 
 storiesOf("Components/LinkMonitoring", module)

--- a/app/experimenter/nimbus-ui/src/components/LinkNav/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/LinkNav/index.tsx
@@ -2,10 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from "react";
-import classNames from "classnames";
-import Nav from "react-bootstrap/Nav";
 import { Link } from "@reach/router";
+import classNames from "classnames";
+import React from "react";
+import Nav from "react-bootstrap/Nav";
 import { BASE_PATH } from "../../lib/constants";
 
 type LinkNavProps = {

--- a/app/experimenter/nimbus-ui/src/components/NotSet/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/NotSet/index.stories.tsx
@@ -2,8 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from "react";
 import { storiesOf } from "@storybook/react";
+import React from "react";
 import NotSet from ".";
 
 storiesOf("Components/NotSet", module).add("basic", () => <NotSet />);

--- a/app/experimenter/nimbus-ui/src/components/PageDesign/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageDesign/index.stories.tsx
@@ -2,12 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from "react";
-import { storiesOf } from "@storybook/react";
-import { RouterSlugProvider } from "../../lib/test-utils";
 import { withLinks } from "@storybook/addon-links";
-import { mockExperimentQuery } from "../../lib/mocks";
+import { storiesOf } from "@storybook/react";
+import React from "react";
 import PageDesign from ".";
+import { mockExperimentQuery } from "../../lib/mocks";
+import { RouterSlugProvider } from "../../lib/test-utils";
 
 const { mock } = mockExperimentQuery("demo-slug");
 

--- a/app/experimenter/nimbus-ui/src/components/PageDesign/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageDesign/index.test.tsx
@@ -2,17 +2,17 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import { render, screen, waitFor } from "@testing-library/react";
 import React from "react";
-import { screen, render, waitFor } from "@testing-library/react";
 import PageDesign from ".";
-import { RouterSlugProvider } from "../../lib/test-utils";
+import { getStatus as mockGetStatus } from "../../lib/experiment";
 import { mockExperimentQuery } from "../../lib/mocks";
+import { RouterSlugProvider } from "../../lib/test-utils";
 import { mockAnalysis } from "../../lib/visualization/mocks";
 import { AnalysisData } from "../../lib/visualization/types";
+import { getExperiment_experimentBySlug } from "../../types/getExperiment";
 import { NimbusExperimentStatus } from "../../types/globalTypes";
 import AppLayoutWithExperiment from "../AppLayoutWithExperiment";
-import { getStatus as mockGetStatus } from "../../lib/experiment";
-import { getExperiment_experimentBySlug } from "../../types/getExperiment";
 
 let mockExperiment: getExperiment_experimentBySlug;
 const mockAnalysisData: AnalysisData | undefined = mockAnalysis();

--- a/app/experimenter/nimbus-ui/src/components/PageDesign/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageDesign/index.tsx
@@ -2,8 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from "react";
 import { RouteComponentProps } from "@reach/router";
+import React from "react";
 import AppLayoutWithExperiment from "../AppLayoutWithExperiment";
 import Summary from "../Summary";
 

--- a/app/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/index.stories.tsx
@@ -2,9 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from "react";
-import { storiesOf } from "@storybook/react";
 import { action } from "@storybook/addon-actions";
+import { storiesOf } from "@storybook/react";
+import React from "react";
 import { Subject } from "./mocks";
 
 storiesOf("pages/EditAudience/FormAudience", module)

--- a/app/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/index.test.tsx
@@ -2,23 +2,23 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from "react";
 import {
+  act,
+  fireEvent,
+  render,
   screen,
   waitFor,
-  render,
-  fireEvent,
-  act,
 } from "@testing-library/react";
-import { Subject, MOCK_EXPERIMENT } from "./mocks";
-import { MOCK_CONFIG } from "../../../lib/mocks";
+import React from "react";
 import { snakeToCamelCase } from "../../../lib/caseConversions";
+import { EXTERNAL_URLS } from "../../../lib/constants";
+import { MOCK_CONFIG } from "../../../lib/mocks";
 import {
+  NimbusExperimentChannel,
   NimbusExperimentFirefoxMinVersion,
   NimbusExperimentTargetingConfigSlug,
-  NimbusExperimentChannel,
 } from "../../../types/globalTypes";
-import { EXTERNAL_URLS } from "../../../lib/constants";
+import { MOCK_EXPERIMENT, Subject } from "./mocks";
 
 describe("FormAudience", () => {
   it("renders without error", async () => {

--- a/app/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/index.tsx
@@ -3,18 +3,17 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React, { useCallback } from "react";
-import Form from "react-bootstrap/Form";
 import Alert from "react-bootstrap/Alert";
-import InputGroup from "react-bootstrap/InputGroup";
 import Col from "react-bootstrap/Col";
-import LinkExternal from "../../LinkExternal";
-import InlineErrorIcon from "../../InlineErrorIcon";
-import { useConfig } from "../../../hooks/useConfig";
-
-import { getExperiment_experimentBySlug } from "../../../types/getExperiment";
-import { getConfig_nimbusConfig_channel } from "../../../types/getConfig";
+import Form from "react-bootstrap/Form";
+import InputGroup from "react-bootstrap/InputGroup";
 import { useCommonForm } from "../../../hooks";
+import { useConfig } from "../../../hooks/useConfig";
 import { EXTERNAL_URLS } from "../../../lib/constants";
+import { getConfig_nimbusConfig_channel } from "../../../types/getConfig";
+import { getExperiment_experimentBySlug } from "../../../types/getExperiment";
+import InlineErrorIcon from "../../InlineErrorIcon";
+import LinkExternal from "../../LinkExternal";
 
 type FormAudienceProps = {
   experiment: getExperiment_experimentBySlug;

--- a/app/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/mocks.tsx
@@ -3,9 +3,12 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React, { useState } from "react";
-import { mockExperimentQuery } from "../../../lib/mocks";
 import { FormAudience } from ".";
-import { MOCK_CONFIG, MockedCache } from "../../../lib/mocks";
+import {
+  MockedCache,
+  mockExperimentQuery,
+  MOCK_CONFIG,
+} from "../../../lib/mocks";
 import { getConfig_nimbusConfig } from "../../../types/getConfig";
 
 export const Subject = ({

--- a/app/experimenter/nimbus-ui/src/components/PageEditAudience/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditAudience/index.stories.tsx
@@ -2,13 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from "react";
-import { storiesOf } from "@storybook/react";
-import { RouterSlugProvider } from "../../lib/test-utils";
 import { withLinks } from "@storybook/addon-links";
 import { withQuery } from "@storybook/addon-queryparams";
-import { mockExperimentQuery } from "../../lib/mocks";
+import { storiesOf } from "@storybook/react";
+import React from "react";
 import PageEditAudience from ".";
+import { mockExperimentQuery } from "../../lib/mocks";
+import { RouterSlugProvider } from "../../lib/test-utils";
 
 const { mock } = mockExperimentQuery("demo-slug");
 const { mock: mockMissingFields } = mockExperimentQuery("demo-slug", {

--- a/app/experimenter/nimbus-ui/src/components/PageEditAudience/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditAudience/index.test.tsx
@@ -2,34 +2,34 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from "react";
-import {
-  screen,
-  render,
-  waitFor,
-  fireEvent,
-  act,
-} from "@testing-library/react";
-import fetchMock from "jest-fetch-mock";
-import PageEditAudience from ".";
-import FormAudience from "./FormAudience";
-import { RouterSlugProvider } from "../../lib/test-utils";
-import { mockExperimentQuery } from "../../lib/mocks";
 import { MockedResponse } from "@apollo/client/testing";
 import { navigate } from "@reach/router";
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import fetchMock from "jest-fetch-mock";
+import React from "react";
+import PageEditAudience from ".";
 import { UPDATE_EXPERIMENT_AUDIENCE_MUTATION } from "../../gql/experiments";
 import { BASE_PATH, SUBMIT_ERROR } from "../../lib/constants";
+import { mockExperimentQuery } from "../../lib/mocks";
+import { RouterSlugProvider } from "../../lib/test-utils";
 import {
-  updateExperimentAudience_updateExperiment,
-  updateExperimentAudience_updateExperiment_nimbusExperiment,
-} from "../../types/updateExperimentAudience";
-import {
+  ExperimentInput,
   NimbusExperimentChannel,
   NimbusExperimentFirefoxMinVersion,
   NimbusExperimentStatus,
   NimbusExperimentTargetingConfigSlug,
-  ExperimentInput,
 } from "../../types/globalTypes";
+import {
+  updateExperimentAudience_updateExperiment,
+  updateExperimentAudience_updateExperiment_nimbusExperiment,
+} from "../../types/updateExperimentAudience";
+import FormAudience from "./FormAudience";
 
 const { mock, experiment } = mockExperimentQuery("demo-slug");
 

--- a/app/experimenter/nimbus-ui/src/components/PageEditAudience/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditAudience/index.tsx
@@ -2,17 +2,17 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React, { useCallback, useRef, useState } from "react";
-import { navigate, RouteComponentProps } from "@reach/router";
-import AppLayoutWithExperiment from "../AppLayoutWithExperiment";
 import { useMutation } from "@apollo/client";
-import { ExperimentInput } from "../../types/globalTypes";
-import { updateExperimentAudience_updateExperiment as UpdateExperimentAudienceResult } from "../../types/updateExperimentAudience";
+import { navigate, RouteComponentProps } from "@reach/router";
+import React, { useCallback, useRef, useState } from "react";
 import { UPDATE_EXPERIMENT_AUDIENCE_MUTATION } from "../../gql/experiments";
 import { SUBMIT_ERROR } from "../../lib/constants";
-import { getExperiment_experimentBySlug } from "../../types/getExperiment";
-import FormAudience from "./FormAudience";
 import { editCommonRedirects } from "../../lib/experiment";
+import { getExperiment_experimentBySlug } from "../../types/getExperiment";
+import { ExperimentInput } from "../../types/globalTypes";
+import { updateExperimentAudience_updateExperiment as UpdateExperimentAudienceResult } from "../../types/updateExperimentAudience";
+import AppLayoutWithExperiment from "../AppLayoutWithExperiment";
+import FormAudience from "./FormAudience";
 
 const PageEditAudience: React.FunctionComponent<RouteComponentProps> = () => {
   const [updateExperimentAudience, { loading }] = useMutation<

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/FormBranch.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/FormBranch.test.tsx
@@ -2,21 +2,20 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from "react";
 import {
+  act,
+  fireEvent,
   render,
   screen,
-  fireEvent,
-  act,
   waitFor,
 } from "@testing-library/react";
-
+import React from "react";
 import { MOCK_CONFIG } from "../../../lib/mocks";
 import {
-  SubjectBranch,
   MOCK_ANNOTATED_BRANCH,
   MOCK_FEATURE_CONFIG,
   MOCK_FEATURE_CONFIG_WITH_SCHEMA,
+  SubjectBranch,
 } from "./mocks";
 
 describe("FormBranch", () => {

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/FormBranch.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/FormBranch.tsx
@@ -3,22 +3,20 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React from "react";
-import { FieldError } from "react-hook-form";
-import Form from "react-bootstrap/Form";
-import Col from "react-bootstrap/Col";
-import Button from "react-bootstrap/Button";
 import Badge from "react-bootstrap/Badge";
+import Button from "react-bootstrap/Button";
+import Col from "react-bootstrap/Col";
+import Form from "react-bootstrap/Form";
+import { FieldError } from "react-hook-form";
+import { useCommonNestedForm } from "../../../hooks";
 import { ReactComponent as DeleteIcon } from "../../../images/x.svg";
-
-import { getExperiment_experimentBySlug } from "../../../types/getExperiment";
 import {
   getConfig_nimbusConfig,
   getConfig_nimbusConfig_featureConfig,
 } from "../../../types/getConfig";
-
-import { AnnotatedBranch } from "./reducer";
+import { getExperiment_experimentBySlug } from "../../../types/getExperiment";
 import InlineErrorIcon from "../../InlineErrorIcon";
-import { useCommonNestedForm } from "../../../hooks";
+import { AnnotatedBranch } from "./reducer";
 
 export const branchFieldNames = [
   "name",

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/index.stories.tsx
@@ -2,17 +2,17 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React, { useState } from "react";
-import { storiesOf } from "@storybook/react";
 import { action } from "@storybook/addon-actions";
+import { storiesOf } from "@storybook/react";
+import React, { useState } from "react";
 import { FormBranches } from ".";
 import {
-  SubjectBranch,
-  SubjectBranches,
-  MOCK_EXPERIMENT,
   MOCK_ANNOTATED_BRANCH,
+  MOCK_EXPERIMENT,
   MOCK_FEATURE_CONFIG,
   MOCK_FEATURE_CONFIG_WITH_SCHEMA,
+  SubjectBranch,
+  SubjectBranches,
 } from "./mocks";
 
 const onRemove = action("onRemove");

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/index.test.tsx
@@ -2,21 +2,21 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from "react";
 import {
+  act,
+  fireEvent,
   render,
   screen,
-  fireEvent,
-  act,
   waitFor,
 } from "@testing-library/react";
+import React from "react";
 import { MOCK_CONFIG } from "../../../lib/mocks";
 import {
-  SubjectBranches,
-  MOCK_EXPERIMENT,
   MOCK_BRANCH,
+  MOCK_EXPERIMENT,
   MOCK_FEATURE_CONFIG,
   MOCK_FEATURE_CONFIG_WITH_SCHEMA,
+  SubjectBranches,
 } from "./mocks";
 import { extractUpdateBranch } from "./reducer/update";
 

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/index.tsx
@@ -3,23 +3,21 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React, { useEffect, useMemo } from "react";
-import { FormProvider, SubmitHandler } from "react-hook-form";
-import Form from "react-bootstrap/Form";
-import Col from "react-bootstrap/Col";
-import Button from "react-bootstrap/Button";
 import Alert from "react-bootstrap/Alert";
-
+import Button from "react-bootstrap/Button";
+import Col from "react-bootstrap/Col";
+import Form from "react-bootstrap/Form";
+import { FormProvider, SubmitHandler } from "react-hook-form";
 import { useExitWarning, useForm } from "../../../hooks";
-import { getExperiment_experimentBySlug } from "../../../types/getExperiment";
+import { IsDirtyUnsaved } from "../../../hooks/useCommonForm/useCommonFormMethods";
 import {
   getConfig_nimbusConfig,
   getConfig_nimbusConfig_featureConfig,
 } from "../../../types/getConfig";
-
-import { useFormBranchesReducer, FormBranchesSaveState } from "./reducer";
-import { FormData } from "./reducer/update";
+import { getExperiment_experimentBySlug } from "../../../types/getExperiment";
 import FormBranch from "./FormBranch";
-import { IsDirtyUnsaved } from "../../../hooks/useCommonForm/useCommonFormMethods";
+import { FormBranchesSaveState, useFormBranchesReducer } from "./reducer";
+import { FormData } from "./reducer/update";
 
 type FormBranchesProps = {
   isLoading: boolean;

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/mocks.tsx
@@ -4,12 +4,12 @@
 
 import React, { useEffect } from "react";
 import { FormProvider } from "react-hook-form";
-import { formBranchesActionReducer } from "./reducer/actions";
 import FormBranches from ".";
-import FormBranch from "./FormBranch";
-import { mockExperimentQuery, MOCK_CONFIG } from "../../../lib/mocks";
-import { AnnotatedBranch } from "./reducer";
 import { useForm } from "../../../hooks";
+import { mockExperimentQuery, MOCK_CONFIG } from "../../../lib/mocks";
+import FormBranch from "./FormBranch";
+import { AnnotatedBranch } from "./reducer";
+import { formBranchesActionReducer } from "./reducer/actions";
 import { FormBranchesState } from "./reducer/state";
 
 export const MOCK_EXPERIMENT = mockExperimentQuery("demo-slug", {

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/reducer/actions.ts
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/reducer/actions.ts
@@ -2,13 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import { snakeToCamelCase } from "../../../../lib/caseConversions";
 import {
   AnnotatedBranch,
-  FormBranchesState,
   createAnnotatedBranch,
+  FormBranchesState,
 } from "./state";
 import { FormData } from "./update";
-import { snakeToCamelCase } from "../../../../lib/caseConversions";
 
 export const REFERENCE_BRANCH_IDX = -1;
 

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/reducer/index.test.ts
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/reducer/index.test.ts
@@ -2,10 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { formBranchesActionReducer, FormBranchesAction } from "./actions";
+import { MOCK_EXPERIMENT } from "../mocks";
+import { FormBranchesAction, formBranchesActionReducer } from "./actions";
 import { FormBranchesState } from "./state";
 import { extractUpdateState } from "./update";
-import { MOCK_EXPERIMENT } from "../mocks";
 
 const MOCK_STATE: FormBranchesState = {
   equalRatio: true,

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/reducer/index.ts
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/reducer/index.ts
@@ -2,10 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { useReducer, useMemo } from "react";
+import { useMemo, useReducer } from "react";
 import { getExperiment_experimentBySlug } from "../../../../types/getExperiment";
-import { createInitialState } from "./state";
 import { formBranchesActionReducer } from "./actions";
+import { createInitialState } from "./state";
 import { extractUpdateState } from "./update";
 
 export { REFERENCE_BRANCH_IDX } from "./actions";

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/reducer/update.ts
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/reducer/update.ts
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { ExperimentInput } from "../../../../types/globalTypes";
-import { FormBranchesState, AnnotatedBranch } from "./state";
+import { AnnotatedBranch, FormBranchesState } from "./state";
 
 export type FormBranchesSaveState = Pick<
   ExperimentInput,

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/index.stories.tsx
@@ -2,13 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from "react";
-import { storiesOf } from "@storybook/react";
-import { RouterSlugProvider } from "../../lib/test-utils";
 import { withLinks } from "@storybook/addon-links";
 import { withQuery } from "@storybook/addon-queryparams";
-import { mockExperimentQuery } from "../../lib/mocks";
+import { storiesOf } from "@storybook/react";
+import React from "react";
 import PageEditBranches from ".";
+import { mockExperimentQuery } from "../../lib/mocks";
+import { RouterSlugProvider } from "../../lib/test-utils";
 import { NimbusFeatureConfigApplication } from "../../types/globalTypes";
 
 const { mock } = mockExperimentQuery("demo-slug", {

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/index.test.tsx
@@ -2,32 +2,32 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from "react";
+import { navigate } from "@reach/router";
 import {
+  act,
+  fireEvent,
+  render,
   screen,
   waitFor,
-  render,
-  fireEvent,
-  act,
 } from "@testing-library/react";
-import { navigate } from "@reach/router";
 import fetchMock from "jest-fetch-mock";
+import React from "react";
 import PageEditBranches, { SUBMIT_ERROR_MESSAGE } from ".";
-import FormBranches from "./FormBranches";
-import { RouterSlugProvider } from "../../lib/test-utils";
-import { mockExperimentQuery, MOCK_CONFIG } from "../../lib/mocks";
 import { UPDATE_EXPERIMENT_BRANCHES_MUTATION } from "../../gql/experiments";
 import { BASE_PATH, EXTERNAL_URLS } from "../../lib/constants";
+import { mockExperimentQuery, MOCK_CONFIG } from "../../lib/mocks";
+import { RouterSlugProvider } from "../../lib/test-utils";
 import { getExperiment_experimentBySlug } from "../../types/getExperiment";
 import {
+  ExperimentInput,
   NimbusExperimentStatus,
   NimbusFeatureConfigApplication,
-  ExperimentInput,
 } from "../../types/globalTypes";
 import {
-  updateExperimentBranches_updateExperiment_nimbusExperiment,
   updateExperimentBranches_updateExperiment,
+  updateExperimentBranches_updateExperiment_nimbusExperiment,
 } from "../../types/updateExperimentBranches";
+import FormBranches from "./FormBranches";
 import { FormBranchesSaveState } from "./FormBranches/reducer";
 import { extractUpdateBranch } from "./FormBranches/reducer/update";
 

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/index.tsx
@@ -2,20 +2,20 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React, { useCallback, useRef } from "react";
-import { navigate, RouteComponentProps } from "@reach/router";
-import { useConfig } from "../../hooks";
-import FormBranches from "./FormBranches";
-import { FormBranchesSaveState } from "./FormBranches/reducer";
-import LinkExternal from "../LinkExternal";
-import AppLayoutWithExperiment from "../AppLayoutWithExperiment";
 import { useMutation } from "@apollo/client";
+import { navigate, RouteComponentProps } from "@reach/router";
+import React, { useCallback, useRef } from "react";
 import { UPDATE_EXPERIMENT_BRANCHES_MUTATION } from "../../gql/experiments";
+import { useConfig } from "../../hooks";
+import { EXTERNAL_URLS } from "../../lib/constants";
+import { editCommonRedirects } from "../../lib/experiment";
+import { getExperiment_experimentBySlug } from "../../types/getExperiment";
 import { ExperimentInput } from "../../types/globalTypes";
 import { updateExperimentBranches_updateExperiment as UpdateExperimentBranchesResult } from "../../types/updateExperimentBranches";
-import { getExperiment_experimentBySlug } from "../../types/getExperiment";
-import { editCommonRedirects } from "../../lib/experiment";
-import { EXTERNAL_URLS } from "../../lib/constants";
+import AppLayoutWithExperiment from "../AppLayoutWithExperiment";
+import LinkExternal from "../LinkExternal";
+import FormBranches from "./FormBranches";
+import { FormBranchesSaveState } from "./FormBranches/reducer";
 
 export const SUBMIT_ERROR_MESSAGE = "Save failed, no error available";
 

--- a/app/experimenter/nimbus-ui/src/components/PageEditMetrics/FormMetrics/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditMetrics/FormMetrics/index.stories.tsx
@@ -2,11 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from "react";
-import { storiesOf } from "@storybook/react";
-import { Subject } from "./mocks";
 import { action } from "@storybook/addon-actions";
+import { storiesOf } from "@storybook/react";
+import React from "react";
 import { mockExperimentQuery } from "../../../lib/mocks";
+import { Subject } from "./mocks";
 
 const onSave = action("onSave");
 const onNext = action("onNext");

--- a/app/experimenter/nimbus-ui/src/components/PageEditMetrics/FormMetrics/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditMetrics/FormMetrics/index.test.tsx
@@ -2,11 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import { act, fireEvent, render, screen } from "@testing-library/react";
 import React from "react";
-import { render, screen, act, fireEvent } from "@testing-library/react";
+import { PRIMARY_PROBE_SETS_TOOLTIP, SECONDARY_PROBE_SETS_TOOLTIP } from ".";
 import { mockExperimentQuery, MOCK_CONFIG } from "../../../lib/mocks";
 import { Subject } from "./mocks";
-import { PRIMARY_PROBE_SETS_TOOLTIP, SECONDARY_PROBE_SETS_TOOLTIP } from ".";
 
 describe("FormMetrics", () => {
   it("renders as expected", async () => {

--- a/app/experimenter/nimbus-ui/src/components/PageEditMetrics/FormMetrics/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditMetrics/FormMetrics/index.tsx
@@ -3,18 +3,18 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React, { useCallback, useEffect, useState } from "react";
-import Form from "react-bootstrap/Form";
 import Alert from "react-bootstrap/Alert";
+import Form from "react-bootstrap/Form";
 import Select from "react-select";
+import ReactTooltip from "react-tooltip";
+import { useCommonForm, useConfig, useExitWarning } from "../../../hooks";
+import { SelectOption } from "../../../hooks/useCommonForm/useCommonFormMethods";
+import { ReactComponent as Info } from "../../../images/info.svg";
 import {
   getExperiment,
   getExperiment_experimentBySlug_primaryProbeSets,
   getExperiment_experimentBySlug_secondaryProbeSets,
 } from "../../../types/getExperiment";
-import { useCommonForm, useConfig, useExitWarning } from "../../../hooks";
-import { SelectOption } from "../../../hooks/useCommonForm/useCommonFormMethods";
-import ReactTooltip from "react-tooltip";
-import { ReactComponent as Info } from "../../../images/info.svg";
 
 export const metricsFieldNames = [
   "primaryProbeSetIds",

--- a/app/experimenter/nimbus-ui/src/components/PageEditMetrics/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditMetrics/index.stories.tsx
@@ -2,12 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from "react";
-import { storiesOf } from "@storybook/react";
-import { RouterSlugProvider } from "../../lib/test-utils";
 import { withLinks } from "@storybook/addon-links";
-import { mockExperimentQuery } from "../../lib/mocks";
+import { storiesOf } from "@storybook/react";
+import React from "react";
 import PageEditMetrics from ".";
+import { mockExperimentQuery } from "../../lib/mocks";
+import { RouterSlugProvider } from "../../lib/test-utils";
 
 const { mock } = mockExperimentQuery("demo-slug");
 

--- a/app/experimenter/nimbus-ui/src/components/PageEditMetrics/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditMetrics/index.test.tsx
@@ -2,24 +2,24 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from "react";
-import {
-  screen,
-  waitFor,
-  render,
-  fireEvent,
-  act,
-} from "@testing-library/react";
-import fetchMock from "jest-fetch-mock";
-import PageEditMetrics from ".";
-import FormMetrics from "./FormMetrics";
-import { RouterSlugProvider } from "../../lib/test-utils";
-import { mockExperimentMutation, mockExperimentQuery } from "../../lib/mocks";
 import { MockedResponse } from "@apollo/client/testing";
 import { navigate } from "@reach/router";
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import fetchMock from "jest-fetch-mock";
+import React from "react";
+import PageEditMetrics from ".";
 import { UPDATE_EXPERIMENT_PROBESETS_MUTATION } from "../../gql/experiments";
 import { BASE_PATH, EXTERNAL_URLS, SUBMIT_ERROR } from "../../lib/constants";
+import { mockExperimentMutation, mockExperimentQuery } from "../../lib/mocks";
+import { RouterSlugProvider } from "../../lib/test-utils";
 import { NimbusExperimentStatus } from "../../types/globalTypes";
+import FormMetrics from "./FormMetrics";
 
 const { mock, experiment } = mockExperimentQuery("demo-slug");
 

--- a/app/experimenter/nimbus-ui/src/components/PageEditMetrics/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditMetrics/index.tsx
@@ -2,19 +2,18 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { navigate, RouteComponentProps } from "@reach/router";
 import { useMutation } from "@apollo/client";
-import React, { useState, useRef, useCallback } from "react";
-
-import { getExperiment_experimentBySlug } from "../../types/getExperiment";
-import { EXTERNAL_URLS, SUBMIT_ERROR } from "../../lib/constants";
+import { navigate, RouteComponentProps } from "@reach/router";
+import React, { useCallback, useRef, useState } from "react";
 import { UPDATE_EXPERIMENT_PROBESETS_MUTATION } from "../../gql/experiments";
-import { updateExperimentProbeSets_updateExperiment as UpdateExperimentProbeSetsResult } from "../../types/updateExperimentProbeSets";
-import { ExperimentInput } from "../../types/globalTypes";
-import AppLayoutWithExperiment from "../AppLayoutWithExperiment";
-import FormMetrics from "./FormMetrics";
-import LinkExternal from "../LinkExternal";
+import { EXTERNAL_URLS, SUBMIT_ERROR } from "../../lib/constants";
 import { editCommonRedirects } from "../../lib/experiment";
+import { getExperiment_experimentBySlug } from "../../types/getExperiment";
+import { ExperimentInput } from "../../types/globalTypes";
+import { updateExperimentProbeSets_updateExperiment as UpdateExperimentProbeSetsResult } from "../../types/updateExperimentProbeSets";
+import AppLayoutWithExperiment from "../AppLayoutWithExperiment";
+import LinkExternal from "../LinkExternal";
+import FormMetrics from "./FormMetrics";
 
 const PageEditMetrics: React.FunctionComponent<RouteComponentProps> = () => {
   const [updateExperimentProbeSets, { loading }] = useMutation<

--- a/app/experimenter/nimbus-ui/src/components/PageEditOverview/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditOverview/index.stories.tsx
@@ -2,13 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from "react";
-import { storiesOf } from "@storybook/react";
 import { withLinks } from "@storybook/addon-links";
 import { withQuery } from "@storybook/addon-queryparams";
-import { RouterSlugProvider } from "../../lib/test-utils";
-import { mockExperimentQuery } from "../../lib/mocks";
+import { storiesOf } from "@storybook/react";
+import React from "react";
 import PageEditOverview from ".";
+import { mockExperimentQuery } from "../../lib/mocks";
+import { RouterSlugProvider } from "../../lib/test-utils";
 
 const { mock } = mockExperimentQuery("demo-slug");
 const { mock: mockMissingFields } = mockExperimentQuery("demo-slug", {

--- a/app/experimenter/nimbus-ui/src/components/PageEditOverview/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditOverview/index.test.tsx
@@ -2,24 +2,24 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from "react";
-import {
-  screen,
-  waitFor,
-  render,
-  fireEvent,
-  act,
-} from "@testing-library/react";
-import fetchMock from "jest-fetch-mock";
-import PageEditOverview from ".";
-import FormOverview from "../FormOverview";
-import { RouterSlugProvider } from "../../lib/test-utils";
-import { mockExperimentMutation, mockExperimentQuery } from "../../lib/mocks";
 import { MockedResponse } from "@apollo/client/testing";
 import { navigate } from "@reach/router";
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import fetchMock from "jest-fetch-mock";
+import React from "react";
+import PageEditOverview from ".";
 import { UPDATE_EXPERIMENT_OVERVIEW_MUTATION } from "../../gql/experiments";
 import { BASE_PATH, SUBMIT_ERROR } from "../../lib/constants";
+import { mockExperimentMutation, mockExperimentQuery } from "../../lib/mocks";
+import { RouterSlugProvider } from "../../lib/test-utils";
 import { NimbusExperimentStatus } from "../../types/globalTypes";
+import FormOverview from "../FormOverview";
 
 const { mock, experiment } = mockExperimentQuery("demo-slug");
 

--- a/app/experimenter/nimbus-ui/src/components/PageEditOverview/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditOverview/index.tsx
@@ -2,17 +2,17 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React, { useCallback, useRef, useState } from "react";
-import { navigate, RouteComponentProps } from "@reach/router";
-import FormOverview from "../FormOverview";
-import AppLayoutWithExperiment from "../AppLayoutWithExperiment";
 import { useMutation } from "@apollo/client";
+import { navigate, RouteComponentProps } from "@reach/router";
+import React, { useCallback, useRef, useState } from "react";
 import { UPDATE_EXPERIMENT_OVERVIEW_MUTATION } from "../../gql/experiments";
 import { SUBMIT_ERROR } from "../../lib/constants";
+import { editCommonRedirects } from "../../lib/experiment";
+import { getExperiment_experimentBySlug } from "../../types/getExperiment";
 import { ExperimentInput } from "../../types/globalTypes";
 import { updateExperimentOverview_updateExperiment as UpdateExperimentOverviewResult } from "../../types/updateExperimentOverview";
-import { getExperiment_experimentBySlug } from "../../types/getExperiment";
-import { editCommonRedirects } from "../../lib/experiment";
+import AppLayoutWithExperiment from "../AppLayoutWithExperiment";
+import FormOverview from "../FormOverview";
 
 type PageEditOverviewProps = {} & RouteComponentProps;
 

--- a/app/experimenter/nimbus-ui/src/components/PageExperimentNotFound/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageExperimentNotFound/index.stories.tsx
@@ -2,9 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from "react";
-import { storiesOf } from "@storybook/react";
 import { withLinks } from "@storybook/addon-links";
+import { storiesOf } from "@storybook/react";
+import React from "react";
 import ExperimentNotFound from ".";
 
 storiesOf("pages/ExperimentNotFound", module)

--- a/app/experimenter/nimbus-ui/src/components/PageExperimentNotFound/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageExperimentNotFound/index.test.tsx
@@ -2,8 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import { render, screen } from "@testing-library/react";
 import React from "react";
-import { screen, render } from "@testing-library/react";
 import ExperimentNotFound from ".";
 import { BASE_PATH } from "../../lib/constants";
 

--- a/app/experimenter/nimbus-ui/src/components/PageHome/DirectoryTable/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageHome/DirectoryTable/index.stories.tsx
@@ -2,15 +2,15 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from "react";
-import { storiesOf } from "@storybook/react";
 import { withLinks } from "@storybook/addon-links";
-import { mockDirectoryExperiments } from "../../../lib/mocks";
+import { storiesOf } from "@storybook/react";
+import React from "react";
 import DirectoryTable, {
   DirectoryCompleteTable,
   DirectoryDraftsTable,
   DirectoryLiveTable,
 } from ".";
+import { mockDirectoryExperiments } from "../../../lib/mocks";
 
 storiesOf("pages/Home/DirectoryTable", module)
   .addDecorator(withLinks)

--- a/app/experimenter/nimbus-ui/src/components/PageHome/DirectoryTable/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageHome/DirectoryTable/index.test.tsx
@@ -2,22 +2,22 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from "react";
 import { render, screen } from "@testing-library/react";
+import React from "react";
 import DirectoryTable, {
-  DirectoryColumnTitle,
-  DirectoryColumnOwner,
   DirectoryColumnFeature,
-  DirectoryLiveTable,
+  DirectoryColumnOwner,
+  DirectoryColumnTitle,
   DirectoryCompleteTable,
   DirectoryDraftsTable,
+  DirectoryLiveTable,
 } from ".";
-import { mockSingleDirectoryExperiment } from "../../../lib/mocks";
 import {
   getProposedEndDate,
   getProposedEnrollmentRange,
   humanDate,
 } from "../../../lib/dateUtils";
+import { mockSingleDirectoryExperiment } from "../../../lib/mocks";
 
 const experiment = mockSingleDirectoryExperiment();
 

--- a/app/experimenter/nimbus-ui/src/components/PageHome/DirectoryTable/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageHome/DirectoryTable/index.tsx
@@ -2,16 +2,16 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from "react";
-import { getAllExperiments_experiments } from "../../../types/getAllExperiments";
 import { Link } from "@reach/router";
-import LinkExternal from "../../LinkExternal";
-import NotSet from "../../NotSet";
+import React from "react";
 import {
   getProposedEndDate,
   getProposedEnrollmentRange,
   humanDate,
 } from "../../../lib/dateUtils";
+import { getAllExperiments_experiments } from "../../../types/getAllExperiments";
+import LinkExternal from "../../LinkExternal";
+import NotSet from "../../NotSet";
 
 // These are all render functions for column type sin the table.
 export type ColumnComponent = React.FC<getAllExperiments_experiments>;

--- a/app/experimenter/nimbus-ui/src/components/PageHome/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageHome/index.stories.tsx
@@ -2,12 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from "react";
-import { storiesOf } from "@storybook/react";
-import { RouterSlugProvider } from "../../lib/test-utils";
 import { withLinks } from "@storybook/addon-links";
-import { mockDirectoryExperimentsQuery, MockedCache } from "../../lib/mocks";
+import { storiesOf } from "@storybook/react";
+import React from "react";
 import PageHome from ".";
+import { mockDirectoryExperimentsQuery, MockedCache } from "../../lib/mocks";
+import { RouterSlugProvider } from "../../lib/test-utils";
 import { NimbusExperimentStatus } from "../../types/globalTypes";
 
 storiesOf("pages/Home", module)

--- a/app/experimenter/nimbus-ui/src/components/PageHome/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageHome/index.test.tsx
@@ -2,16 +2,16 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from "react";
+import * as apollo from "@apollo/client";
 import {
   render,
   screen,
   waitForElementToBeRemoved,
 } from "@testing-library/react";
+import React from "react";
 import PageHome from ".";
 import { mockDirectoryExperimentsQuery, MockedCache } from "../../lib/mocks";
 import { getAllExperiments_experiments } from "../../types/getAllExperiments";
-import * as apollo from "@apollo/client";
 
 describe("PageHome", () => {
   it("renders as expected", () => {

--- a/app/experimenter/nimbus-ui/src/components/PageHome/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageHome/index.tsx
@@ -2,21 +2,21 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from "react";
-import AppLayout from "../AppLayout";
-import { RouteComponentProps, Link } from "@reach/router";
-import Head from "../Head";
-import { Tabs, Tab } from "react-bootstrap";
 import { useQuery } from "@apollo/client";
-import { getAllExperiments_experiments } from "../../types/getAllExperiments";
+import { Link, RouteComponentProps } from "@reach/router";
+import React from "react";
+import { Tab, Tabs } from "react-bootstrap";
 import { GET_EXPERIMENTS_QUERY } from "../../gql/experiments";
+import { getAllExperiments_experiments } from "../../types/getAllExperiments";
+import AppLayout from "../AppLayout";
+import Head from "../Head";
 import PageLoading from "../PageLoading";
-import sortByStatus from "./sortByStatus";
 import DirectoryTable, {
-  DirectoryLiveTable,
   DirectoryCompleteTable,
   DirectoryDraftsTable,
+  DirectoryLiveTable,
 } from "./DirectoryTable";
+import sortByStatus from "./sortByStatus";
 
 type PageHomeProps = {} & RouteComponentProps;
 

--- a/app/experimenter/nimbus-ui/src/components/PageLoading/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageLoading/index.stories.tsx
@@ -2,8 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from "react";
 import { storiesOf } from "@storybook/react";
+import React from "react";
 import PageLoading from ".";
 
 storiesOf("pages/Loading", module).add("basic", () => <PageLoading />);

--- a/app/experimenter/nimbus-ui/src/components/PageLoading/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageLoading/index.test.tsx
@@ -2,8 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import { render, screen } from "@testing-library/react";
 import React from "react";
-import { screen, render } from "@testing-library/react";
 import PageLoading from ".";
 
 describe("PageLoading", () => {

--- a/app/experimenter/nimbus-ui/src/components/PageNew/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageNew/index.stories.tsx
@@ -2,14 +2,14 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from "react";
 import { Operation } from "@apollo/client";
-import { MockedCache, SimulatedMockLink } from "../../lib/mocks";
-import { storiesOf } from "@storybook/react";
 import { action } from "@storybook/addon-actions";
-import { CREATE_EXPERIMENT_MUTATION } from "../../gql/experiments";
-import PageNew from ".";
 import { withLinks } from "@storybook/addon-links";
+import { storiesOf } from "@storybook/react";
+import React from "react";
+import PageNew from ".";
+import { CREATE_EXPERIMENT_MUTATION } from "../../gql/experiments";
+import { MockedCache, SimulatedMockLink } from "../../lib/mocks";
 
 storiesOf("pages/New", module)
   .addDecorator(withLinks)

--- a/app/experimenter/nimbus-ui/src/components/PageNew/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageNew/index.test.tsx
@@ -2,14 +2,14 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from "react";
-import { render, screen, fireEvent, act } from "@testing-library/react";
-import { MockedCache, mockExperimentMutation } from "../../lib/mocks";
-import PageNew from ".";
+import { MockedResponse } from "@apollo/client/testing";
 import { navigate } from "@reach/router";
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import React from "react";
+import PageNew from ".";
 import { CREATE_EXPERIMENT_MUTATION } from "../../gql/experiments";
 import { SUBMIT_ERROR } from "../../lib/constants";
-import { MockedResponse } from "@apollo/client/testing";
+import { MockedCache, mockExperimentMutation } from "../../lib/mocks";
 
 jest.mock("@reach/router", () => ({
   navigate: jest.fn(),

--- a/app/experimenter/nimbus-ui/src/components/PageNew/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageNew/index.tsx
@@ -2,20 +2,18 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React, { useCallback, useState } from "react";
-import { RouteComponentProps } from "@reach/router";
-import AppLayout from "../AppLayout";
-import LinkExternal from "../LinkExternal";
-import FormOverview from "../FormOverview";
-import { ReactComponent as DeleteIcon } from "../../images/x.svg";
-
 import { useMutation } from "@apollo/client";
+import { navigate, RouteComponentProps } from "@reach/router";
+import React, { useCallback, useState } from "react";
 import { CREATE_EXPERIMENT_MUTATION } from "../../gql/experiments";
-import { ExperimentInput } from "../../types/globalTypes";
-import { createExperiment_createExperiment as CreateExperimentResult } from "../../types/createExperiment";
-import { navigate } from "@reach/router";
+import { ReactComponent as DeleteIcon } from "../../images/x.svg";
 import { EXTERNAL_URLS, SUBMIT_ERROR } from "../../lib/constants";
+import { createExperiment_createExperiment as CreateExperimentResult } from "../../types/createExperiment";
+import { ExperimentInput } from "../../types/globalTypes";
+import AppLayout from "../AppLayout";
+import FormOverview from "../FormOverview";
 import Head from "../Head";
+import LinkExternal from "../LinkExternal";
 
 type PageNewProps = {} & RouteComponentProps;
 

--- a/app/experimenter/nimbus-ui/src/components/PageRequestReview/FormRequestReview/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageRequestReview/FormRequestReview/index.stories.tsx
@@ -2,11 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from "react";
-import { storiesOf } from "@storybook/react";
-import { withLinks } from "@storybook/addon-links";
-import { Subject } from "./mocks";
 import { action } from "@storybook/addon-actions";
+import { withLinks } from "@storybook/addon-links";
+import { storiesOf } from "@storybook/react";
+import React from "react";
+import { Subject } from "./mocks";
 
 const onSubmit = action("onSubmit");
 

--- a/app/experimenter/nimbus-ui/src/components/PageRequestReview/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageRequestReview/index.stories.tsx
@@ -2,12 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from "react";
-import { storiesOf } from "@storybook/react";
-import { RouterSlugProvider } from "../../lib/test-utils";
 import { withLinks } from "@storybook/addon-links";
+import { storiesOf } from "@storybook/react";
+import React from "react";
 import PageRequestReview from ".";
 import { mockExperimentQuery } from "../../lib/mocks";
+import { RouterSlugProvider } from "../../lib/test-utils";
 import { NimbusExperimentStatus } from "../../types/globalTypes";
 import { createMutationMock } from "./mocks";
 

--- a/app/experimenter/nimbus-ui/src/components/PageRequestReview/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageRequestReview/index.test.tsx
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from "react";
+import { navigate } from "@reach/router";
 import {
   act,
   fireEvent,
@@ -11,13 +11,13 @@ import {
   waitFor,
 } from "@testing-library/react";
 import fetchMock from "jest-fetch-mock";
+import React from "react";
 import PageRequestReview from ".";
-import { RouterSlugProvider } from "../../lib/test-utils";
+import { BASE_PATH } from "../../lib/constants";
 import { mockExperimentQuery } from "../../lib/mocks";
+import { RouterSlugProvider } from "../../lib/test-utils";
 import { NimbusExperimentStatus } from "../../types/globalTypes";
 import { createMutationMock } from "./mocks";
-import { navigate } from "@reach/router";
-import { BASE_PATH } from "../../lib/constants";
 
 jest.mock("@reach/router", () => ({
   ...jest.requireActual("@reach/router"),

--- a/app/experimenter/nimbus-ui/src/components/PageRequestReview/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageRequestReview/index.tsx
@@ -2,21 +2,21 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React, { useCallback, useRef, useState } from "react";
 import { useMutation } from "@apollo/client";
 import { RouteComponentProps } from "@reach/router";
-import AppLayoutWithExperiment from "../AppLayoutWithExperiment";
-import { SUBMIT_ERROR } from "../../lib/constants";
+import React, { useCallback, useRef, useState } from "react";
 import { UPDATE_EXPERIMENT_STATUS_MUTATION } from "../../gql/experiments";
+import { SUBMIT_ERROR } from "../../lib/constants";
+import { getStatus } from "../../lib/experiment";
+import { getExperiment_experimentBySlug } from "../../types/getExperiment";
 import {
   ExperimentInput,
   NimbusExperimentStatus,
 } from "../../types/globalTypes";
 import { updateExperimentStatus_updateExperiment as UpdateExperimentStatus } from "../../types/updateExperimentStatus";
-import { getExperiment_experimentBySlug } from "../../types/getExperiment";
-import FormRequestReview from "./FormRequestReview";
+import AppLayoutWithExperiment from "../AppLayoutWithExperiment";
 import Summary from "../Summary";
-import { getStatus } from "../../lib/experiment";
+import FormRequestReview from "./FormRequestReview";
 
 type PageRequestReviewProps = {
   polling?: boolean;

--- a/app/experimenter/nimbus-ui/src/components/PageResults/ConfidenceInterval/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/ConfidenceInterval/index.stories.tsx
@@ -2,9 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from "react";
-import { storiesOf } from "@storybook/react";
 import { withLinks } from "@storybook/addon-links";
+import { storiesOf } from "@storybook/react";
+import React from "react";
 import ConfidenceInterval from ".";
 import { SIGNIFICANCE } from "../../../lib/visualization/constants";
 

--- a/app/experimenter/nimbus-ui/src/components/PageResults/ConfidenceInterval/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/ConfidenceInterval/index.tsx
@@ -6,7 +6,6 @@
 // TODO: EXP-638 remove this ^
 
 import React from "react";
-
 import { SIGNIFICANCE } from "../../../lib/visualization/constants";
 
 const renderBounds = (lower: number, upper: number, significance: string) => {

--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableHighlights/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableHighlights/index.stories.tsx
@@ -2,12 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from "react";
-import { storiesOf } from "@storybook/react";
-import { RouterSlugProvider } from "../../../lib/test-utils";
 import { withLinks } from "@storybook/addon-links";
-import { mockExperimentQuery } from "../../../lib/mocks";
+import { storiesOf } from "@storybook/react";
+import React from "react";
 import TableHighlights from ".";
+import { mockExperimentQuery } from "../../../lib/mocks";
+import { RouterSlugProvider } from "../../../lib/test-utils";
 import { mockAnalysis } from "../../../lib/visualization/mocks";
 
 storiesOf("pages/Results/TableHighlights", module)

--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableHighlights/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableHighlights/index.test.tsx
@@ -2,12 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from "react";
 import { render, screen } from "@testing-library/react";
+import React from "react";
 import TableHighlights from ".";
 import { mockExperimentQuery } from "../../../lib/mocks";
-import { mockAnalysis } from "../../../lib/visualization/mocks";
 import { RouterSlugProvider } from "../../../lib/test-utils";
+import { mockAnalysis } from "../../../lib/visualization/mocks";
 
 const { mock, experiment } = mockExperimentQuery("demo-slug");
 

--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableHighlights/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableHighlights/index.tsx
@@ -3,19 +3,19 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React from "react";
-import { AnalysisDataOverall } from "../../../lib/visualization/types";
+import { ReactComponent as Info } from "../../../images/info.svg";
 import {
-  HIGHLIGHTS_METRICS_LIST,
-  METRICS_TIPS,
-  METRIC,
   BRANCH_COMPARISON,
+  HIGHLIGHTS_METRICS_LIST,
+  METRIC,
+  METRICS_TIPS,
   SEGMENT_TIPS,
   TABLE_LABEL,
 } from "../../../lib/visualization/constants";
+import { AnalysisDataOverall } from "../../../lib/visualization/types";
 import { getTableDisplayType } from "../../../lib/visualization/utils";
 import { getExperiment_experimentBySlug_primaryProbeSets } from "../../../types/getExperiment";
 import TableVisualizationRow from "../TableVisualizationRow";
-import { ReactComponent as Info } from "../../../images/info.svg";
 
 type TableHighlightsProps = {
   primaryProbeSets: (getExperiment_experimentBySlug_primaryProbeSets | null)[];

--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableHighlightsOverview/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableHighlightsOverview/index.stories.tsx
@@ -2,12 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from "react";
-import { storiesOf } from "@storybook/react";
-import { RouterSlugProvider } from "../../../lib/test-utils";
 import { withLinks } from "@storybook/addon-links";
-import { mockExperimentQuery } from "../../../lib/mocks";
+import { storiesOf } from "@storybook/react";
+import React from "react";
 import TableHighlightsOverview from ".";
+import { mockExperimentQuery } from "../../../lib/mocks";
+import { RouterSlugProvider } from "../../../lib/test-utils";
 import { mockAnalysis } from "../../../lib/visualization/mocks";
 
 storiesOf("pages/Results/TableHighlightsOverview", module)

--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableHighlightsOverview/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableHighlightsOverview/index.test.tsx
@@ -2,12 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from "react";
 import { render, screen } from "@testing-library/react";
+import React from "react";
 import TableHighlightsOverview from ".";
 import { mockExperimentQuery } from "../../../lib/mocks";
-import { mockAnalysis } from "../../../lib/visualization/mocks";
 import { RouterSlugProvider } from "../../../lib/test-utils";
+import { mockAnalysis } from "../../../lib/visualization/mocks";
 
 const { mock, experiment } = mockExperimentQuery("demo-slug");
 

--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableHighlightsOverview/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableHighlightsOverview/index.tsx
@@ -3,10 +3,10 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React from "react";
-import { getExperiment_experimentBySlug } from "../../../types/getExperiment";
-import { AnalysisDataOverall } from "../../../lib/visualization/types";
 import { useConfig } from "../../../hooks";
 import { getConfigLabel } from "../../../lib/getConfigLabel";
+import { AnalysisDataOverall } from "../../../lib/visualization/types";
+import { getExperiment_experimentBySlug } from "../../../types/getExperiment";
 
 type TableHighlightsOverviewProps = {
   experiment: getExperiment_experimentBySlug;

--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableMetricPrimary/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableMetricPrimary/index.stories.tsx
@@ -2,11 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from "react";
-import { storiesOf } from "@storybook/react";
 import { withLinks } from "@storybook/addon-links";
-import { mockExperimentQuery } from "../../../lib/mocks";
+import { storiesOf } from "@storybook/react";
+import React from "react";
 import TableMetricPrimary from ".";
+import { mockExperimentQuery } from "../../../lib/mocks";
 import { mockAnalysis } from "../../../lib/visualization/mocks";
 
 storiesOf("pages/Results/TableMetricPrimary", module)

--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableMetricPrimary/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableMetricPrimary/index.test.tsx
@@ -2,12 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from "react";
 import { render, screen } from "@testing-library/react";
+import React from "react";
 import TableMetricPrimary from ".";
 import { mockExperimentQuery } from "../../../lib/mocks";
-import { mockAnalysis } from "../../../lib/visualization/mocks";
 import { RouterSlugProvider } from "../../../lib/test-utils";
+import { mockAnalysis } from "../../../lib/visualization/mocks";
 
 describe("TableMetricPrimary", () => {
   it("has the correct headings", () => {

--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableMetricPrimary/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableMetricPrimary/index.tsx
@@ -3,14 +3,14 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React from "react";
-import { AnalysisDataOverall } from "../../../lib/visualization/types";
-import TableVisualizationRow from "../TableVisualizationRow";
-import { getExperiment_experimentBySlug_primaryProbeSets } from "../../../types/getExperiment";
 import {
+  DISPLAY_TYPE,
   PRIMARY_METRIC_COLUMNS,
   TABLE_LABEL,
-  DISPLAY_TYPE,
 } from "../../../lib/visualization/constants";
+import { AnalysisDataOverall } from "../../../lib/visualization/types";
+import { getExperiment_experimentBySlug_primaryProbeSets } from "../../../types/getExperiment";
+import TableVisualizationRow from "../TableVisualizationRow";
 
 type PrimaryMetricStatistic = {
   name: string;

--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableMetricSecondary/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableMetricSecondary/index.stories.tsx
@@ -2,11 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from "react";
-import { storiesOf } from "@storybook/react";
 import { withLinks } from "@storybook/addon-links";
-import { mockExperimentQuery } from "../../../lib/mocks";
+import { storiesOf } from "@storybook/react";
+import React from "react";
 import TableMetricSecondary from ".";
+import { mockExperimentQuery } from "../../../lib/mocks";
 import { mockAnalysis } from "../../../lib/visualization/mocks";
 
 storiesOf("pages/Results/TableMetricSecondary", module)

--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableMetricSecondary/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableMetricSecondary/index.test.tsx
@@ -2,12 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from "react";
 import { render, screen } from "@testing-library/react";
+import React from "react";
 import TableMetricSecondary from ".";
+import { mockExperimentQuery } from "../../../lib/mocks";
 import { RouterSlugProvider } from "../../../lib/test-utils";
 import { mockAnalysis } from "../../../lib/visualization/mocks";
-import { mockExperimentQuery } from "../../../lib/mocks";
 
 describe("TableMetricSecondary", () => {
   it("has the correct headings", async () => {

--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableMetricSecondary/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableMetricSecondary/index.tsx
@@ -5,9 +5,9 @@
 import React from "react";
 import {
   DISPLAY_TYPE,
+  METRIC_TYPE,
   SECONDARY_METRIC_COLUMNS,
   TABLE_LABEL,
-  METRIC_TYPE,
 } from "../../../lib/visualization/constants";
 import { AnalysisDataOverall } from "../../../lib/visualization/types";
 import TableVisualizationRow from "../TableVisualizationRow";

--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableResults/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableResults/index.stories.tsx
@@ -2,12 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from "react";
-import { storiesOf } from "@storybook/react";
-import { RouterSlugProvider } from "../../../lib/test-utils";
 import { withLinks } from "@storybook/addon-links";
-import { mockExperimentQuery } from "../../../lib/mocks";
+import { storiesOf } from "@storybook/react";
+import React from "react";
 import TableResults from ".";
+import { mockExperimentQuery } from "../../../lib/mocks";
+import { RouterSlugProvider } from "../../../lib/test-utils";
 import { mockAnalysis } from "../../../lib/visualization/mocks";
 
 storiesOf("pages/Results/TableResults", module)

--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableResults/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableResults/index.test.tsx
@@ -2,11 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from "react";
 import { render, screen } from "@testing-library/react";
+import React from "react";
 import TableResults from ".";
-import { RouterSlugProvider } from "../../../lib/test-utils";
 import { mockExperimentQuery } from "../../../lib/mocks";
+import { RouterSlugProvider } from "../../../lib/test-utils";
 import {
   mockAnalysis,
   mockIncompleteAnalysis,

--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableResults/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableResults/index.tsx
@@ -4,9 +4,9 @@
 
 import React from "react";
 import {
-  RESULTS_METRICS_LIST,
   METRICS_TIPS,
   METRIC_TYPE,
+  RESULTS_METRICS_LIST,
   TABLE_LABEL,
 } from "../../../lib/visualization/constants";
 import { AnalysisDataOverall } from "../../../lib/visualization/types";

--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableVisualizationRow/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableVisualizationRow/index.stories.tsx
@@ -2,19 +2,19 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from "react";
-import { storiesOf } from "@storybook/react";
 import { withLinks } from "@storybook/addon-links";
+import { storiesOf } from "@storybook/react";
+import React from "react";
 import TableVisualizationRow from ".";
+import {
+  BRANCH_COMPARISON,
+  DISPLAY_TYPE,
+  TABLE_LABEL,
+} from "../../../lib/visualization/constants";
 import {
   mockAnalysis,
   mockIncompleteAnalysis,
 } from "../../../lib/visualization/mocks";
-import {
-  DISPLAY_TYPE,
-  BRANCH_COMPARISON,
-  TABLE_LABEL,
-} from "../../../lib/visualization/constants";
 
 const MOCK_ANALYSIS = mockAnalysis();
 const MOCK_INCOMPLETE_ANALYSIS = mockIncompleteAnalysis();

--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableVisualizationRow/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableVisualizationRow/index.tsx
@@ -1,23 +1,20 @@
 import React from "react";
 import ReactTooltip from "react-tooltip";
-
-import ConfidenceInterval from "../ConfidenceInterval";
 import {
-  SIGNIFICANCE,
-  METRIC,
   BRANCH_COMPARISON,
+  DISPLAY_TYPE,
+  GENERAL_TIPS,
+  METRIC,
+  SIGNIFICANCE,
+  SIGNIFICANCE_TIPS,
   TABLE_LABEL,
   VARIANT_TYPE,
-  DISPLAY_TYPE,
-} from "../../../lib/visualization/constants";
-import {
-  SIGNIFICANCE_TIPS,
-  GENERAL_TIPS,
 } from "../../../lib/visualization/constants";
 import { BranchDescription } from "../../../lib/visualization/types";
+import ConfidenceInterval from "../ConfidenceInterval";
 import { ReactComponent as SignificanceNegative } from "./significance-negative.svg";
-import { ReactComponent as SignificancePositive } from "./significance-positive.svg";
 import { ReactComponent as SignificanceNeutral } from "./significance-neutral.svg";
+import { ReactComponent as SignificancePositive } from "./significance-positive.svg";
 
 // This is a mapping for which view on the analysis
 // to display given the branch and table type.

--- a/app/experimenter/nimbus-ui/src/components/PageResults/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/index.stories.tsx
@@ -2,13 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from "react";
-import { storiesOf } from "@storybook/react";
-import { RouterSlugProvider } from "../../lib/test-utils";
 import { withLinks } from "@storybook/addon-links";
-import { mockExperimentQuery } from "../../lib/mocks";
-import PageResults from ".";
+import { storiesOf } from "@storybook/react";
 import fetchMock from "fetch-mock";
+import React from "react";
+import PageResults from ".";
+import { mockExperimentQuery } from "../../lib/mocks";
+import { RouterSlugProvider } from "../../lib/test-utils";
 import { mockAnalysis } from "../../lib/visualization/mocks";
 import { NimbusExperimentStatus } from "../../types/globalTypes";
 

--- a/app/experimenter/nimbus-ui/src/components/PageResults/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/index.test.tsx
@@ -2,21 +2,21 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from "react";
-import { screen, render, waitFor } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import fetchMock from "jest-fetch-mock";
+import React from "react";
 import PageResults from ".";
-import { RouterSlugProvider } from "../../lib/test-utils";
+import { getStatus as mockGetStatus } from "../../lib/experiment";
 import { mockExperimentQuery } from "../../lib/mocks";
+import { RouterSlugProvider } from "../../lib/test-utils";
 import {
   mockAnalysis,
   MOCK_UNAVAILABLE_ANALYSIS,
 } from "../../lib/visualization/mocks";
-import AppLayoutWithExperiment from "../AppLayoutWithExperiment";
 import { AnalysisData } from "../../lib/visualization/types";
-import { getStatus as mockGetStatus } from "../../lib/experiment";
-import { NimbusExperimentStatus } from "../../types/globalTypes";
 import { getExperiment_experimentBySlug } from "../../types/getExperiment";
+import { NimbusExperimentStatus } from "../../types/globalTypes";
+import AppLayoutWithExperiment from "../AppLayoutWithExperiment";
 
 const Subject = () => (
   <RouterSlugProvider>

--- a/app/experimenter/nimbus-ui/src/components/PageResults/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/index.tsx
@@ -2,17 +2,17 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from "react";
 import { RouteComponentProps } from "@reach/router";
+import React from "react";
+import { analysisUnavailable } from "../../lib/visualization/utils";
 import AppLayoutWithExperiment from "../AppLayoutWithExperiment";
 import LinkExternal from "../LinkExternal";
-import TableResults from "./TableResults";
+import LinkMonitoring from "../LinkMonitoring";
 import TableHighlights from "./TableHighlights";
 import TableHighlightsOverview from "./TableHighlightsOverview";
 import TableMetricPrimary from "./TableMetricPrimary";
 import TableMetricSecondary from "./TableMetricSecondary";
-import LinkMonitoring from "../LinkMonitoring";
-import { analysisUnavailable } from "../../lib/visualization/utils";
+import TableResults from "./TableResults";
 
 const PageResults: React.FunctionComponent<RouteComponentProps> = () => (
   <AppLayoutWithExperiment

--- a/app/experimenter/nimbus-ui/src/components/PageSummary/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageSummary/index.stories.tsx
@@ -2,12 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from "react";
-import { storiesOf } from "@storybook/react";
-import { RouterSlugProvider } from "../../lib/test-utils";
 import { withLinks } from "@storybook/addon-links";
-import { mockExperimentQuery } from "../../lib/mocks";
+import { storiesOf } from "@storybook/react";
+import React from "react";
 import PageSummary from ".";
+import { mockExperimentQuery } from "../../lib/mocks";
+import { RouterSlugProvider } from "../../lib/test-utils";
 
 const { mock } = mockExperimentQuery("demo-slug");
 

--- a/app/experimenter/nimbus-ui/src/components/PageSummary/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageSummary/index.test.tsx
@@ -2,11 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import { render, screen, waitFor } from "@testing-library/react";
 import React from "react";
-import { screen, render, waitFor } from "@testing-library/react";
 import PageSummary from ".";
-import { RouterSlugProvider } from "../../lib/test-utils";
 import { mockExperimentQuery } from "../../lib/mocks";
+import { RouterSlugProvider } from "../../lib/test-utils";
 
 const { mock } = mockExperimentQuery("demo-slug");
 

--- a/app/experimenter/nimbus-ui/src/components/PageSummary/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageSummary/index.tsx
@@ -2,8 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from "react";
 import { RouteComponentProps } from "@reach/router";
+import React from "react";
 import AppLayoutWithExperiment from "../AppLayoutWithExperiment";
 import Summary from "../Summary";
 

--- a/app/experimenter/nimbus-ui/src/components/RichText/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/RichText/index.stories.tsx
@@ -2,8 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from "react";
 import { storiesOf } from "@storybook/react";
+import React from "react";
 import RichText from ".";
 
 const text = `Who we are

--- a/app/experimenter/nimbus-ui/src/components/RichText/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/RichText/index.test.tsx
@@ -2,8 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from "react";
 import { render } from "@testing-library/react";
+import React from "react";
 import RichText from ".";
 
 it("renders text with newlines converted to <br> tags", () => {

--- a/app/experimenter/nimbus-ui/src/components/Summary/SummaryTimeline/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/SummaryTimeline/index.stories.tsx
@@ -2,9 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from "react";
 import { storiesOf } from "@storybook/react";
 import MockDate from "mockdate";
+import React from "react";
 import { NimbusExperimentStatus } from "../../../types/globalTypes";
 import { Subject } from "./mocks";
 

--- a/app/experimenter/nimbus-ui/src/components/Summary/SummaryTimeline/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/SummaryTimeline/index.test.tsx
@@ -2,10 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import { cleanup, render, screen } from "@testing-library/react";
 import React from "react";
-import { screen, render, cleanup } from "@testing-library/react";
-import { Subject } from "./mocks";
 import { NimbusExperimentStatus } from "../../../types/globalTypes";
+import { Subject } from "./mocks";
 
 const innerBar = () => {
   return screen

--- a/app/experimenter/nimbus-ui/src/components/Summary/SummaryTimeline/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/SummaryTimeline/index.tsx
@@ -4,11 +4,11 @@
 
 import React from "react";
 import ProgressBar from "react-bootstrap/ProgressBar";
+import { humanDate } from "../../../lib/dateUtils";
+import { getStatus, StatusCheck } from "../../../lib/experiment";
 import pluralize from "../../../lib/pluralize";
 import { getExperiment_experimentBySlug } from "../../../types/getExperiment";
 import NotSet from "../../NotSet";
-import { getStatus, StatusCheck } from "../../../lib/experiment";
-import { humanDate } from "../../../lib/dateUtils";
 
 const SummaryTimeline = ({
   experiment,

--- a/app/experimenter/nimbus-ui/src/components/Summary/TableAudience/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/TableAudience/index.stories.tsx
@@ -2,13 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from "react";
 import { storiesOf } from "@storybook/react";
-import { mockExperimentQuery } from "../../../lib/mocks";
-import AppLayout from "../../AppLayout";
+import React from "react";
 import TableAudience from ".";
+import { mockExperimentQuery } from "../../../lib/mocks";
 import { RouterSlugProvider } from "../../../lib/test-utils";
 import { NimbusExperimentChannel } from "../../../types/globalTypes";
+import AppLayout from "../../AppLayout";
 
 storiesOf("components/Summary/TableAudience", module)
   .add("all fields filled out", () => {

--- a/app/experimenter/nimbus-ui/src/components/Summary/TableAudience/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/TableAudience/index.test.tsx
@@ -2,10 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from "react";
 import { render, screen } from "@testing-library/react";
-import { MockedCache, mockExperimentQuery } from "../../../lib/mocks";
+import React from "react";
 import TableAudience from ".";
+import { MockedCache, mockExperimentQuery } from "../../../lib/mocks";
 import { getExperiment_experimentBySlug } from "../../../types/getExperiment";
 import { NimbusExperimentChannel } from "../../../types/globalTypes";
 

--- a/app/experimenter/nimbus-ui/src/components/Summary/TableAudience/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/TableAudience/index.tsx
@@ -3,10 +3,10 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React from "react";
-import { getExperiment_experimentBySlug } from "../../../types/getExperiment";
 import { Table } from "react-bootstrap";
-import { useConfig } from "../../../hooks";
 import { displayConfigLabelOrNotSet } from "..";
+import { useConfig } from "../../../hooks";
+import { getExperiment_experimentBySlug } from "../../../types/getExperiment";
 import NotSet from "../../NotSet";
 
 type TableAudienceProps = {

--- a/app/experimenter/nimbus-ui/src/components/Summary/TableBranches/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/TableBranches/index.stories.tsx
@@ -2,9 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from "react";
 import { storiesOf } from "@storybook/react";
-import { Subject, MOCK_EXPERIMENT } from "./mocks";
+import React from "react";
+import { MOCK_EXPERIMENT, Subject } from "./mocks";
 
 storiesOf("components/Summary/TableBranches", module)
   .add("full branches", () => <Subject />)

--- a/app/experimenter/nimbus-ui/src/components/Summary/TableBranches/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/TableBranches/index.test.tsx
@@ -2,9 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from "react";
 import { render, screen } from "@testing-library/react";
-import { Subject, MOCK_EXPERIMENT } from "./mocks";
+import React from "react";
+import { MOCK_EXPERIMENT, Subject } from "./mocks";
 
 describe("TableBranches", () => {
   it("renders as expected with defaults", () => {

--- a/app/experimenter/nimbus-ui/src/components/Summary/TableBranches/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/TableBranches/index.tsx
@@ -3,12 +3,12 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React from "react";
+import { Table } from "react-bootstrap";
 import {
   getExperiment_experimentBySlug,
   getExperiment_experimentBySlug_referenceBranch,
   getExperiment_experimentBySlug_treatmentBranches,
 } from "../../../types/getExperiment";
-import { Table } from "react-bootstrap";
 import NotSet from "../../NotSet";
 
 type Branch =

--- a/app/experimenter/nimbus-ui/src/components/Summary/TableBranches/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/TableBranches/mocks.tsx
@@ -3,10 +3,10 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React from "react";
-import { mockExperimentQuery } from "../../../lib/mocks";
-import AppLayout from "../../AppLayout";
 import TableBranches from ".";
+import { mockExperimentQuery } from "../../../lib/mocks";
 import { RouterSlugProvider } from "../../../lib/test-utils";
+import AppLayout from "../../AppLayout";
 
 type TableBranchesProps = React.ComponentProps<typeof TableBranches>;
 

--- a/app/experimenter/nimbus-ui/src/components/Summary/TableSummary/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/TableSummary/index.stories.tsx
@@ -2,12 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from "react";
 import { storiesOf } from "@storybook/react";
-import { mockExperimentQuery, MOCK_CONFIG } from "../../../lib/mocks";
-import AppLayout from "../../AppLayout";
+import React from "react";
 import TableSummary from ".";
+import { mockExperimentQuery, MOCK_CONFIG } from "../../../lib/mocks";
 import { RouterSlugProvider } from "../../../lib/test-utils";
+import AppLayout from "../../AppLayout";
 
 storiesOf("components/Summary/TableSummary", module)
   .add("all fields filled out", () => {

--- a/app/experimenter/nimbus-ui/src/components/Summary/TableSummary/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/TableSummary/index.test.tsx
@@ -2,16 +2,16 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from "react";
 import { render, screen } from "@testing-library/react";
+import React from "react";
+import TableSummary from ".";
 import {
   MockedCache,
   mockExperimentQuery,
   MOCK_CONFIG,
 } from "../../../lib/mocks";
-import TableSummary from ".";
-import { NimbusDocumentationLinkTitle } from "../../../types/globalTypes";
 import { getExperiment_experimentBySlug } from "../../../types/getExperiment";
+import { NimbusDocumentationLinkTitle } from "../../../types/globalTypes";
 
 describe("TableSummary", () => {
   it("renders rows displaying required fields at experiment creation as expected", () => {

--- a/app/experimenter/nimbus-ui/src/components/Summary/TableSummary/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/TableSummary/index.tsx
@@ -3,14 +3,14 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React from "react";
-import { getExperiment_experimentBySlug } from "../../../types/getExperiment";
 import { Table } from "react-bootstrap";
-import { useConfig } from "../../../hooks";
 import { displayConfigLabelOrNotSet } from "..";
-import RichText from "../../RichText";
-import NotSet from "../../NotSet";
-import LinkExternal from "../../LinkExternal";
+import { useConfig } from "../../../hooks";
 import { ReactComponent as ExternalIcon } from "../../../images/external.svg";
+import { getExperiment_experimentBySlug } from "../../../types/getExperiment";
+import LinkExternal from "../../LinkExternal";
+import NotSet from "../../NotSet";
+import RichText from "../../RichText";
 
 type TableSummaryProps = {
   experiment: getExperiment_experimentBySlug;

--- a/app/experimenter/nimbus-ui/src/components/Summary/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/index.stories.tsx
@@ -2,14 +2,14 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from "react";
 import { storiesOf } from "@storybook/react";
-import { mockExperimentQuery } from "../../lib/mocks";
-import AppLayout from "../AppLayout";
+import React from "react";
 import Summary from ".";
+import { mockExperimentQuery } from "../../lib/mocks";
 import { RouterSlugProvider } from "../../lib/test-utils";
-import { NimbusExperimentStatus } from "../../types/globalTypes";
 import { getExperiment_experimentBySlug } from "../../types/getExperiment";
+import { NimbusExperimentStatus } from "../../types/globalTypes";
+import AppLayout from "../AppLayout";
 
 storiesOf("components/Summary", module)
   .add("draft status", () => {

--- a/app/experimenter/nimbus-ui/src/components/Summary/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/index.test.tsx
@@ -2,11 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from "react";
 import { render, screen } from "@testing-library/react";
+import React from "react";
+import Summary from ".";
 import { MockedCache, mockExperimentQuery } from "../../lib/mocks";
 import { getExperiment_experimentBySlug } from "../../types/getExperiment";
-import Summary from ".";
 import { NimbusExperimentStatus } from "../../types/globalTypes";
 
 describe("Summary", () => {

--- a/app/experimenter/nimbus-ui/src/components/Summary/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/index.tsx
@@ -3,17 +3,17 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React from "react";
+import { ReactComponent as ExternalIcon } from "../../images/external.svg";
+import { getStatus } from "../../lib/experiment";
+import { ConfigOptions, getConfigLabel } from "../../lib/getConfigLabel";
 import { getExperiment_experimentBySlug } from "../../types/getExperiment";
+import LinkExternal from "../LinkExternal";
+import LinkMonitoring from "../LinkMonitoring";
+import NotSet from "../NotSet";
 import SummaryTimeline from "./SummaryTimeline";
-import TableSummary from "./TableSummary";
 import TableAudience from "./TableAudience";
 import TableBranches from "./TableBranches";
-import LinkExternal from "../LinkExternal";
-import { getStatus } from "../../lib/experiment";
-import LinkMonitoring from "../LinkMonitoring";
-import { getConfigLabel, ConfigOptions } from "../../lib/getConfigLabel";
-import NotSet from "../NotSet";
-import { ReactComponent as ExternalIcon } from "../../images/external.svg";
+import TableSummary from "./TableSummary";
 
 type SummaryProps = {
   experiment: getExperiment_experimentBySlug;

--- a/app/experimenter/nimbus-ui/src/hooks/index.ts
+++ b/app/experimenter/nimbus-ui/src/hooks/index.ts
@@ -2,10 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-export * from "./useExitWarning";
-export * from "./useExperiment";
-export * from "./useConfig";
 export * from "./useAnalysis";
 export * from "./useCommonForm";
 export * from "./useCommonForm/useCommonNestedForm";
 export * from "./useCommonForm/useForm";
+export * from "./useConfig";
+export * from "./useExitWarning";
+export * from "./useExperiment";

--- a/app/experimenter/nimbus-ui/src/hooks/useAnalysis.test.tsx
+++ b/app/experimenter/nimbus-ui/src/hooks/useAnalysis.test.tsx
@@ -2,9 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from "react";
 import { act, render } from "@testing-library/react";
 import fetchMock from "jest-fetch-mock";
+import React from "react";
 import { useAnalysis } from "./useAnalysis";
 
 describe("hooks/useVisualization", () => {

--- a/app/experimenter/nimbus-ui/src/hooks/useCommonForm/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/hooks/useCommonForm/index.test.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from "react";
 import {
   act,
   fireEvent,
@@ -10,17 +9,18 @@ import {
   screen,
   waitFor,
 } from "@testing-library/react";
-import { Subject as OverviewSubject } from "../../components/FormOverview/mocks";
+import React from "react";
 import { overviewFieldNames } from "../../components/FormOverview";
-import { Subject as MetricsSubject } from "../../components/PageEditMetrics/FormMetrics/mocks";
-import { metricsFieldNames } from "../../components/PageEditMetrics/FormMetrics";
-import { Subject as AudienceSubject } from "../../components/PageEditAudience/FormAudience/mocks";
+import { Subject as OverviewSubject } from "../../components/FormOverview/mocks";
 import { audienceFieldNames } from "../../components/PageEditAudience/FormAudience";
+import { Subject as AudienceSubject } from "../../components/PageEditAudience/FormAudience/mocks";
 import { branchFieldNames } from "../../components/PageEditBranches/FormBranches/FormBranch";
 import {
-  SubjectBranch as BranchSubject,
   MOCK_FEATURE_CONFIG_WITH_SCHEMA,
+  SubjectBranch as BranchSubject,
 } from "../../components/PageEditBranches/FormBranches/mocks";
+import { metricsFieldNames } from "../../components/PageEditMetrics/FormMetrics";
+import { Subject as MetricsSubject } from "../../components/PageEditMetrics/FormMetrics/mocks";
 import { mockExperimentQuery } from "../../lib/mocks";
 
 describe("hooks/useCommonForm", () => {

--- a/app/experimenter/nimbus-ui/src/hooks/useCommonForm/useCommonFormMethods.tsx
+++ b/app/experimenter/nimbus-ui/src/hooks/useCommonForm/useCommonFormMethods.tsx
@@ -3,8 +3,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React from "react";
-import { RegisterOptions, FieldError, UseFormMethods } from "react-hook-form";
 import Form from "react-bootstrap/Form";
+import { FieldError, RegisterOptions, UseFormMethods } from "react-hook-form";
 import { camelToSnakeCase } from "../../lib/caseConversions";
 
 // TODO: 'any' type on `onChange={(selectedOptions) => ...`,

--- a/app/experimenter/nimbus-ui/src/hooks/useCommonForm/useCommonNestedForm.tsx
+++ b/app/experimenter/nimbus-ui/src/hooks/useCommonForm/useCommonNestedForm.tsx
@@ -3,8 +3,11 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React from "react";
-import { useFormContext } from "react-hook-form";
-import { RegisterOptions, UseFormMethods } from "react-hook-form";
+import {
+  RegisterOptions,
+  useFormContext,
+  UseFormMethods,
+} from "react-hook-form";
 import { useCommonFormMethods } from "./useCommonFormMethods";
 
 export function useCommonNestedForm<FieldNames extends string>(

--- a/app/experimenter/nimbus-ui/src/hooks/useConfig.test.tsx
+++ b/app/experimenter/nimbus-ui/src/hooks/useConfig.test.tsx
@@ -2,11 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from "react";
-import { useConfig } from "./useConfig";
-import { MockedCache, MOCK_CONFIG } from "../lib/mocks";
 import { render, waitFor } from "@testing-library/react";
+import React from "react";
+import { MockedCache, MOCK_CONFIG } from "../lib/mocks";
 import serverConfig from "../services/config";
+import { useConfig } from "./useConfig";
 
 describe("hooks/useConfig", () => {
   describe("useConfig", () => {

--- a/app/experimenter/nimbus-ui/src/hooks/useConfig.tsx
+++ b/app/experimenter/nimbus-ui/src/hooks/useConfig.tsx
@@ -4,8 +4,8 @@
 
 import { useApolloClient } from "@apollo/client";
 import { GET_CONFIG_QUERY } from "../gql/config";
-import { getConfig } from "../types/getConfig";
 import serverConvig from "../services/config";
+import { getConfig } from "../types/getConfig";
 
 /**
  * Hook to retrieve GraphQL and Server config valyes.

--- a/app/experimenter/nimbus-ui/src/hooks/useExitWarning.test.tsx
+++ b/app/experimenter/nimbus-ui/src/hooks/useExitWarning.test.tsx
@@ -2,8 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from "react";
 import { act, render } from "@testing-library/react";
+import React from "react";
 import { exitHandler, useExitWarning } from "./useExitWarning";
 
 describe("hooks/useExitWarning", () => {

--- a/app/experimenter/nimbus-ui/src/hooks/useExperiment.test.tsx
+++ b/app/experimenter/nimbus-ui/src/hooks/useExperiment.test.tsx
@@ -2,10 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from "react";
 import { render, waitFor } from "@testing-library/react";
-import { useExperiment } from "./useExperiment";
+import React from "react";
 import { MockedCache, mockExperimentQuery } from "../lib/mocks";
+import { useExperiment } from "./useExperiment";
 
 describe("hooks/useExperiment", () => {
   describe("useExperiment", () => {

--- a/app/experimenter/nimbus-ui/src/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/index.test.tsx
@@ -3,9 +3,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React, { ReactNode } from "react";
+import "./services/apollo";
 import "./services/config";
 import "./services/sentry";
-import "./services/apollo";
 
 describe("index", () => {
   const origError = global.console.error;

--- a/app/experimenter/nimbus-ui/src/index.tsx
+++ b/app/experimenter/nimbus-ui/src/index.tsx
@@ -2,16 +2,16 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import { ApolloProvider } from "@apollo/client";
 import React from "react";
 import ReactDOM from "react-dom";
-import { ApolloProvider } from "@apollo/client";
 import App from "./components/App";
 import AppErrorBoundary from "./components/AppErrorBoundary";
+import { BASE_PATH } from "./lib/constants";
+import { createApolloClient } from "./services/apollo";
 import config, { readConfig } from "./services/config";
 import sentryMetrics from "./services/sentry";
-import { createApolloClient } from "./services/apollo";
 import "./styles/index.scss";
-import { BASE_PATH } from "./lib/constants";
 
 try {
   const root = document.getElementById("root")!;

--- a/app/experimenter/nimbus-ui/src/lib/caseConversions.test.ts
+++ b/app/experimenter/nimbus-ui/src/lib/caseConversions.test.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { snakeToCamelCase, camelToSnakeCase } from "./caseConversions";
+import { camelToSnakeCase, snakeToCamelCase } from "./caseConversions";
 
 describe("snakeToCamelCase", () => {
   it("converts snake_case to camelCase", () => {

--- a/app/experimenter/nimbus-ui/src/lib/dateUtils.test.ts
+++ b/app/experimenter/nimbus-ui/src/lib/dateUtils.test.ts
@@ -3,10 +3,10 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import {
-  humanDate,
   addDaysToDate,
   getProposedEndDate,
   getProposedEnrollmentRange,
+  humanDate,
 } from "./dateUtils";
 import { mockSingleDirectoryExperiment as expFactory } from "./mocks";
 

--- a/app/experimenter/nimbus-ui/src/lib/experiment.ts
+++ b/app/experimenter/nimbus-ui/src/lib/experiment.ts
@@ -2,8 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { getExperiment_experimentBySlug } from "../types/getExperiment";
 import { getAllExperiments_experiments } from "../types/getAllExperiments";
+import { getExperiment_experimentBySlug } from "../types/getExperiment";
 import { NimbusExperimentStatus } from "../types/globalTypes";
 
 export type StatusCheck = {

--- a/app/experimenter/nimbus-ui/src/lib/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/lib/mocks.tsx
@@ -2,42 +2,42 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from "react";
 import {
-  InMemoryCache,
   ApolloClient,
-  ApolloProvider,
   ApolloLink,
-  Operation,
+  ApolloProvider,
   FetchResult,
+  InMemoryCache,
+  Operation,
 } from "@apollo/client";
+import { MockedResponse, MockLink } from "@apollo/client/testing";
 import { Observable } from "@apollo/client/utilities";
-import { MockLink, MockedResponse } from "@apollo/client/testing";
 import { equal } from "@wry/equality";
 import { DocumentNode, print } from "graphql";
-import { cacheConfig } from "../services/apollo";
+import React from "react";
+import { GET_CONFIG_QUERY } from "../gql/config";
 import {
   GET_EXPERIMENTS_QUERY,
   GET_EXPERIMENT_QUERY,
 } from "../gql/experiments";
-import {
-  getExperiment,
-  getExperiment_experimentBySlug,
-} from "../types/getExperiment";
-import { getConfig_nimbusConfig } from "../types/getConfig";
+import { ExperimentReview } from "../hooks";
+import { cacheConfig } from "../services/apollo";
 import {
   getAllExperiments,
   getAllExperiments_experiments,
 } from "../types/getAllExperiments";
-import { GET_CONFIG_QUERY } from "../gql/config";
-import { NimbusExperimentStatus } from "../types/globalTypes";
-import { getStatus } from "./experiment";
+import { getConfig_nimbusConfig } from "../types/getConfig";
 import {
+  getExperiment,
+  getExperiment_experimentBySlug,
+} from "../types/getExperiment";
+import {
+  ExperimentInput,
+  NimbusExperimentStatus,
   NimbusFeatureConfigApplication,
   NimbusProbeKind,
-  ExperimentInput,
 } from "../types/globalTypes";
-import { ExperimentReview } from "../hooks";
+import { getStatus } from "./experiment";
 
 export interface MockedProps {
   config?: Partial<typeof MOCK_CONFIG> | null;

--- a/app/experimenter/nimbus-ui/src/lib/test-utils.tsx
+++ b/app/experimenter/nimbus-ui/src/lib/test-utils.tsx
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from "react";
+import { MockedResponse } from "@apollo/client/testing";
 import {
   createHistory,
   createMemorySource,
@@ -11,7 +11,7 @@ import {
   Router,
 } from "@reach/router";
 import { render } from "@testing-library/react";
-import { MockedResponse } from "@apollo/client/testing";
+import React from "react";
 import { MockedCache } from "./mocks";
 
 export function renderWithRouter(

--- a/app/experimenter/nimbus-ui/src/services/apollo.test.ts
+++ b/app/experimenter/nimbus-ui/src/services/apollo.test.ts
@@ -2,8 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { createApolloClient, cache } from "./apollo";
 import { ApolloClient, InMemoryCache } from "@apollo/client/core";
+import { cache, createApolloClient } from "./apollo";
 
 describe("services/apollo", () => {
   describe("cache", () => {

--- a/app/experimenter/nimbus-ui/src/services/apollo.ts
+++ b/app/experimenter/nimbus-ui/src/services/apollo.ts
@@ -4,9 +4,9 @@
 
 import {
   ApolloClient,
-  InMemoryCache,
   createHttpLink,
   from,
+  InMemoryCache,
   InMemoryCacheConfig,
 } from "@apollo/client";
 import config from "./config";

--- a/app/experimenter/nimbus-ui/src/services/config.test.ts
+++ b/app/experimenter/nimbus-ui/src/services/config.test.ts
@@ -3,9 +3,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import config, {
+  decode,
   getDefault,
   readConfig,
-  decode,
   reset,
   update,
 } from "./config";

--- a/app/experimenter/nimbus-ui/src/setupTests.ts
+++ b/app/experimenter/nimbus-ui/src/setupTests.ts
@@ -2,5 +2,5 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import "mutationobserver-shim";
 import "@testing-library/jest-dom/extend-expect";
+import "mutationobserver-shim";

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -14843,6 +14843,11 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
+prettier-plugin-organize-imports@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/prettier-plugin-organize-imports/-/prettier-plugin-organize-imports-1.1.1.tgz#7f1ac1a13d4d1752dc16881894dde1c10ccbf3c0"
+  integrity sha512-rFA1lnek1FYkMGthm4xBKME41qUKItTovuo24bCGZu/Vu1n3gW71UPLAkIdwewwkZCe29gRVweSOPXvAdckFuw==
+
 prettier@2.1.2, prettier@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.1.2.tgz#3050700dae2e4c8b67c4c3f666cdb8af405e1ce5"


### PR DESCRIPTION
_I did this on a whim, so feel free to push back or suggest alternatives. 🙏_

This PR adds the [`prettier-plugin-organize-imports`](https://github.com/simonhaenisch/prettier-plugin-organize-imports) dependency to automatically sort the imports in our TS/X files. If you use VS Code or another IDE that supports Prettifying on save any new imports will automatically be sorted on save/paste/however you have it set up. And since it's a Prettier plugin, and our Prettier setup hooks into ESLint this allows sorting to happen automatically with our `yarn lint-fix` command.

From what I can tell this sorts imports first by external dependencies alphabetically, and then by relative path level descending then alphabetically. It also sorts multiple imports from the same statement alphabetically.

Alternatives:

- The [sort-imports](https://eslint.org/docs/rules/sort-imports) ESLint rule. I tried this but it appears it doesn't differentiate between dependencies and local modules, and I was encountering weird conflicts between it's automatic sort and Prettier auto-formatting on save. If you know of a way to fix these two things I would prefer to use this rule than another dependency.
- The TypeScript `organizeImports` feature. This is actually being used under the hood by this plugin. We could definitely set it up [at the VS Code level](https://stackoverflow.com/a/54690944/717633), but this would be specific to VS Code. We want this to be available to everyone, especially if CI is going to fail when the order is incorrect.