### PR TITLE
fixes #4455 fix(nimbus): submitErrors casing fix in stories + Branches

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/index.stories.tsx
@@ -15,12 +15,12 @@ storiesOf("pages/EditAudience/FormAudience", module)
       submitErrors={{
         "*": ["Big bad server thing happened"],
         channel: ["Cannot tune in this channel"],
-        firefoxMinVersion: ["Bad min version"],
-        targetingConfigSlug: ["This slug is icky"],
-        populationPercent: ["This is not a percentage"],
-        totalEnrolledClients: ["Need a number here, bud."],
-        proposedEnrollment: ["Emoji are not numbers"],
-        proposedDuration: ["No negative numbers"],
+        firefox_min_version: ["Bad min version"],
+        targeting_config_slug: ["This slug is icky"],
+        population_percent: ["This is not a percentage"],
+        total_enrolled_clients: ["Need a number here, bud."],
+        proposed_enrollment: ["Emoji are not numbers"],
+        proposed_duration: ["No negative numbers"],
       }}
     />
   ));

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/reducer/actions.ts
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/reducer/actions.ts
@@ -8,7 +8,6 @@ import {
   createAnnotatedBranch,
 } from "./state";
 import { FormData } from "./update";
-import { snakeToCamelCase } from "../../../../lib/caseConversions";
 
 export const REFERENCE_BRANCH_IDX = -1;
 
@@ -194,16 +193,15 @@ function setSubmitErrors(
     referenceBranch = {
       ...referenceBranch,
       // TODO: EXP-614 submitErrors type is any, but in practical use it's AnnotatedBranch["errors"]
-      errors: normalizeFieldNames(
-        submitErrors["reference_branch"],
-      ) as AnnotatedBranch["errors"],
+      errors: (submitErrors["reference_branch"] ||
+        {}) as AnnotatedBranch["errors"],
     };
   }
 
   if (treatmentBranches && submitErrors["treatment_branches"]) {
     treatmentBranches = treatmentBranches.map((treatmentBranch, idx) => ({
       ...treatmentBranch,
-      errors: normalizeFieldNames(submitErrors["treatment_branches"][idx]),
+      errors: submitErrors["treatment_branches"][idx] || {},
     }));
   }
 
@@ -214,21 +212,6 @@ function setSubmitErrors(
     treatmentBranches,
   };
 }
-
-// Server-side field names are in snake-case, client-side field names are
-// in camel-case, this utility converts from server to client convention
-const normalizeFieldNames = (
-  errors: Record<string, string[]> | undefined,
-): Record<string, string[]> =>
-  errors
-    ? Object.entries(errors).reduce(
-        (acc, [key, value]) => ({
-          ...acc,
-          [snakeToCamelCase(key)]: value,
-        }),
-        {},
-      )
-    : {};
 
 type ClearSubmitErrorsAction = {
   type: "clearSubmitErrors";

--- a/app/experimenter/nimbus-ui/src/components/PageEditMetrics/FormMetrics/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditMetrics/FormMetrics/index.stories.tsx
@@ -18,8 +18,8 @@ storiesOf("pages/EditMetrics/FormMetrics", module)
     <Subject
       submitErrors={{
         "*": ["Big bad server thing broke!"],
-        primaryProbeSetIds: ["You primary probed the wrong bear."],
-        secondaryProbeSetIds: ["You secondary probed the wrong bear."],
+        primary_probe_set_ids: ["You primary probed the wrong bear."],
+        secondary_probe_set_ids: ["You secondary probed the wrong bear."],
       }}
       {...{ onSave, onNext }}
     />


### PR DESCRIPTION
Because:
* Many submit errors were not being displayed in at least Storybook

This commit:
* Removes case conversion in Branches now that its handled in useCommonForm (at least 'feature_value' submitError was not showing)
* Fixes some stories that had camelCase submit errors

fixes #4455 

---

@lmorchard even with proper snake_case `submitErrors` in Branches, the `feature_value` error wasn't showing. Doesn't look like we need `normalizeFieldNames` anymore since we're doing a case conversion in `useCommonForm`.