### PR TITLE
fix(nimbus): remove unused import; fix linting

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/reducer/actions.ts
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/reducer/actions.ts
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { snakeToCamelCase } from "../../../../lib/caseConversions";
 import {
   AnnotatedBranch,
   createAnnotatedBranch,


### PR DESCRIPTION
Apparently my import sorting shenanigans [broke](https://circleci.com/gh/mozilla/experimenter/21410?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link) main. Not sure why the branch was green tho.