### PR TITLE
fix #4473: fix(visualization) correctly compute truncation for countField

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableMetricSecondary/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableMetricSecondary/index.test.tsx
@@ -10,7 +10,7 @@ import { RouterSlugProvider } from "../../../lib/test-utils";
 import { mockAnalysis } from "../../../lib/visualization/mocks";
 
 describe("TableMetricSecondary", () => {
-  it("has the correct headings", async () => {
+  it("has the correct headings", () => {
     const EXPECTED_HEADINGS = ["Count", "Relative Improvement"];
     const { mock, experiment } = mockExperimentQuery("demo-slug");
 
@@ -30,7 +30,7 @@ describe("TableMetricSecondary", () => {
     });
   });
 
-  it("has correctly labelled result significance", async () => {
+  it("has correctly labelled result significance", () => {
     const { mock, experiment } = mockExperimentQuery("demo-slug");
     render(
       <RouterSlugProvider mocks={[mock]}>
@@ -51,7 +51,7 @@ describe("TableMetricSecondary", () => {
     expect(neutralSignificance).not.toBeInTheDocument();
   });
 
-  it("has the expected control and treatment labels", async () => {
+  it("has the expected control and treatment labels", () => {
     const { mock, experiment } = mockExperimentQuery("demo-slug");
     render(
       <RouterSlugProvider mocks={[mock]}>
@@ -68,7 +68,7 @@ describe("TableMetricSecondary", () => {
     expect(screen.getByText("treatment")).toBeInTheDocument();
   });
 
-  it("shows the negative improvement bar", async () => {
+  it("shows the negative improvement bar", () => {
     const { mock, experiment } = mockExperimentQuery("demo-slug");
     render(
       <RouterSlugProvider mocks={[mock]}>
@@ -87,5 +87,21 @@ describe("TableMetricSecondary", () => {
     expect(screen.getByTestId("negative-block")).toBeInTheDocument();
     expect(positiveBlock).not.toBeInTheDocument();
     expect(neutralBlock).not.toBeInTheDocument();
+  });
+
+  it("shows expected count values", () => {
+    const { mock, experiment } = mockExperimentQuery("demo-slug");
+    render(
+      <RouterSlugProvider mocks={[mock]}>
+        <TableMetricSecondary
+          results={mockAnalysis().overall}
+          probeSetSlug={experiment.secondaryProbeSets![0]!.slug}
+          probeSetName={experiment.secondaryProbeSets![0]!.name}
+          isDefault={false}
+        />
+      </RouterSlugProvider>,
+    );
+
+    expect(screen.queryAllByText("0.02 to 0.08")).toHaveLength(2);
   });
 });

--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableVisualizationRow/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableVisualizationRow/index.tsx
@@ -130,9 +130,7 @@ const countField = (
   metricName: string,
   tableLabel: string,
 ) => {
-  const interval = `${Math.round(lower * 1000) / 100} to ${
-    Math.round(upper * 1000) / 100
-  }`;
+  const interval = `${lower.toFixed(2)} to ${upper.toFixed(2)}`;
   return showSignificanceField(significance, interval, metricName, tableLabel);
 };
 


### PR DESCRIPTION
Because:
* There is a bug in the results page for countField computations

This commit:
* Fixes the bug by removing an extra 0.