### PR TITLE
fix #4453 chore(nimbus): specify test factory parameters for intermittent test

### DIFF
--- a/app/experimenter/experiments/tests/api/v5/test_query.py
+++ b/app/experimenter/experiments/tests/api/v5/test_query.py
@@ -268,7 +268,8 @@ class TestNimbusQuery(GraphQLTestCase):
     def test_experiment_targeting_config_targeting(self):
         user_email = "user@example.com"
         experiment = NimbusExperimentFactory.create_with_status(
-            NimbusExperiment.Status.DRAFT
+            NimbusExperiment.Status.DRAFT,
+            targeting_config_slug=NimbusExperiment.TargetingConfig.ALL_ENGLISH,
         )
         response = self.query(
             """


### PR DESCRIPTION
Because

* We recently added an empty option for targeting
* Tests should generally explicitly specify all the factory parameters needed for the test to pass to prevent intermittent failures

This commit

* Explicitly specifies a targeting config in the targeting config query test to prevent intermittent failure