### PR TITLE
    chore(nimbus): temporarily disable intermittent visualization test

### DIFF
--- a/app/experimenter/visualization/tests/api/test_views.py
+++ b/app/experimenter/visualization/tests/api/test_views.py
@@ -92,7 +92,7 @@ class TestVisualizationView(TestCase):
     @parameterized.expand(
         [
             NimbusExperiment.Status.ACCEPTED,
-            NimbusExperiment.Status.COMPLETE,
+            # NimbusExperiment.Status.COMPLETE, ref: #4475
         ]
     )
     @patch("django.core.files.storage.default_storage.open")


### PR DESCRIPTION
    Because
    
    * There is a frequently intermittently failing test in the visualization test suite
    * Requires some more rigorous digging in to fix
    
    This commit
    
    * Temporarily disables the test so PRs can at least land while it's being investigated