### PR TITLE
fixes #4371 feat(nimbus): add documentation add/remove functionality 

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/FormOverview/FormDocumentationLink.tsx
+++ b/app/experimenter/nimbus-ui/src/components/FormOverview/FormDocumentationLink.tsx
@@ -1,0 +1,99 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from "react";
+import Button from "react-bootstrap/Button";
+import Col from "react-bootstrap/Col";
+import Form from "react-bootstrap/Form";
+import { ArrayField, FieldError } from "react-hook-form";
+import { useCommonNestedForm, useConfig } from "../../hooks";
+import { ReactComponent as DeleteIcon } from "../../images/x.svg";
+import { AnnotatedDocumentationLink } from "./documentationLink";
+
+export const documentationLinkFieldNames = ["title", "link"] as const;
+
+type DocumentationLinkFieldName = typeof documentationLinkFieldNames[number];
+
+export type FormDocumentationLinkProps = {
+  fieldNamePrefix: string;
+  documentationLink: Partial<ArrayField<AnnotatedDocumentationLink, "id">>;
+  errors: Record<string, FieldError>;
+  onRemove: () => void;
+  canRemove: boolean;
+  submitErrors: Record<string, string[]>;
+  setSubmitErrors: React.Dispatch<React.SetStateAction<Record<string, any>>>;
+  touched: Record<string, boolean>;
+};
+
+export const FormDocumentationLink = ({
+  fieldNamePrefix,
+  documentationLink,
+  errors,
+  onRemove,
+  canRemove,
+  submitErrors,
+  setSubmitErrors,
+  touched,
+}: FormDocumentationLinkProps) => {
+  const { documentationLink: documentationLinkOptions } = useConfig();
+
+  const { FormErrors, formControlAttrs } = useCommonNestedForm<
+    DocumentationLinkFieldName
+  >(
+    {
+      title: documentationLink.title,
+      link: documentationLink.link,
+    },
+    setSubmitErrors,
+    fieldNamePrefix,
+    submitErrors,
+    errors,
+    touched,
+  );
+
+  return (
+    <Form.Group className="mb-0" data-testid="DocumentationLink">
+      <Form.Row>
+        <Form.Group as={Col} sm={4} md={3}>
+          <Form.Control as="select" {...formControlAttrs("title")}>
+            <option value="">Select document type...</option>
+            {documentationLinkOptions &&
+              documentationLinkOptions.map((linkType, optIdx) => (
+                <option
+                  key={`${documentationLink.id}-opt-${optIdx}`}
+                  value={linkType!.value as string}
+                >
+                  {linkType!.label}
+                </option>
+              ))}
+          </Form.Control>
+          <FormErrors name="title" />
+        </Form.Group>
+        <Form.Group as={Col}>
+          <Form.Control
+            placeholder="Link"
+            type="url"
+            {...formControlAttrs("link")}
+          />
+          <FormErrors name="link" />
+        </Form.Group>
+        {canRemove && (
+          <Form.Group as={Col} className="flex-grow-0">
+            <Button
+              data-testid={`${fieldNamePrefix}.remove`}
+              variant="light"
+              className="bg-transparent border-0 p-0 m-0 mt-px"
+              title="Remove link"
+              onClick={onRemove}
+            >
+              <DeleteIcon width="18" height="18" />
+            </Button>
+          </Form.Group>
+        )}
+      </Form.Row>
+    </Form.Group>
+  );
+};
+
+export default FormDocumentationLink;

--- a/app/experimenter/nimbus-ui/src/components/FormOverview/documentationLink.ts
+++ b/app/experimenter/nimbus-ui/src/components/FormOverview/documentationLink.ts
@@ -1,0 +1,104 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { useEffect, useMemo } from "react";
+import { ArrayField, useFieldArray, UseFormMethods } from "react-hook-form";
+import { getExperiment_experimentBySlug } from "../../types/getExperiment";
+import { NimbusDocumentationLinkTitle } from "../../types/globalTypes";
+
+type DefaultDocumentationLink = {
+  title: NimbusDocumentationLinkTitle | "";
+  link: string;
+};
+
+export type AnnotatedDocumentationLink = DefaultDocumentationLink & {
+  isValid: boolean;
+  isDirty: boolean;
+  errors: Record<string, string[]>;
+};
+
+export function useDocumentationLinks(
+  experiment: getExperiment_experimentBySlug | null | undefined,
+  control: UseFormMethods["control"],
+  setValue: UseFormMethods["setValue"],
+) {
+  const { fields: documentationLinks, append, remove } = useFieldArray<
+    AnnotatedDocumentationLink
+  >({
+    control,
+    name: "documentationLinks",
+  });
+
+  const stateAPI = useMemo(
+    () => ({
+      addDocumentationLink: () => {
+        append(emptyDocumentationLink());
+      },
+      removeDocumentationLink: (
+        documentationLink: Partial<
+          ArrayField<AnnotatedDocumentationLink, "id">
+        >,
+      ) => {
+        const index = documentationLinks.findIndex(
+          (d) => d.id === documentationLink.id,
+        );
+        remove(index);
+      },
+    }),
+    [documentationLinks, append, remove],
+  );
+
+  useEffect(() => {
+    const documentationLinks = setupDocumentationLinks(
+      experiment?.documentationLinks,
+    );
+    setValue("documentationLinks", documentationLinks);
+  }, [experiment, setValue]);
+
+  return { documentationLinks, ...stateAPI };
+}
+
+export const setupDocumentationLinks = (
+  existing?: getExperiment_experimentBySlug["documentationLinks"],
+) => {
+  const hasExisting = existing && existing.length > 0;
+  const initialDocumentationLinks = hasExisting
+    ? (existing! as DefaultDocumentationLink[]).map(annotateDocumentationLink)
+    : [emptyDocumentationLink()];
+
+  return initialDocumentationLinks;
+};
+
+export const emptyDocumentationLink = () => {
+  return annotateDocumentationLink({ title: "", link: "" });
+};
+
+export function annotateDocumentationLink(
+  documentationLink: DefaultDocumentationLink,
+): AnnotatedDocumentationLink {
+  return {
+    ...documentationLink,
+    isValid: true,
+    isDirty: false,
+    errors: {},
+  };
+}
+
+export function stripInvalidDocumentationLinks(data: Record<string, any>) {
+  let documentationLinks: DefaultDocumentationLink[] = data.documentationLinks;
+
+  if (!documentationLinks || !documentationLinks.length) {
+    return data;
+  }
+
+  documentationLinks = documentationLinks.filter(
+    (documentationLink) =>
+      documentationLink.title.length && documentationLink.link.length,
+  );
+
+  return {
+    ...data,
+    documentationLinks,
+  };
+}

--- a/app/experimenter/nimbus-ui/src/components/FormOverview/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/FormOverview/index.tsx
@@ -5,24 +5,35 @@
 import React, { useCallback, useEffect } from "react";
 import Alert from "react-bootstrap/Alert";
 import Button from "react-bootstrap/Button";
-import Col from "react-bootstrap/Col";
 import Form from "react-bootstrap/Form";
+import { FormProvider } from "react-hook-form";
 import ReactTooltip from "react-tooltip";
-import { useCommonForm, useExitWarning } from "../../hooks";
+import {
+  SubmitErrorRecord,
+  SubmitErrors,
+  useCommonForm,
+  useExitWarning,
+} from "../../hooks";
 import { useConfig } from "../../hooks/useConfig";
 import { ReactComponent as Info } from "../../images/info.svg";
-import { ReactComponent as DeleteIcon } from "../../images/x.svg";
 import { EXTERNAL_URLS, REQUIRED_FIELD } from "../../lib/constants";
 import { getExperiment } from "../../types/getExperiment";
 import { NimbusDocumentationLinkTitle } from "../../types/globalTypes";
 import InlineErrorIcon from "../InlineErrorIcon";
 import LinkExternal from "../LinkExternal";
+import {
+  stripInvalidDocumentationLinks,
+  useDocumentationLinks,
+} from "./documentationLink";
+import FormDocumentationLink, {
+  FormDocumentationLinkProps,
+} from "./FormDocumentationLink";
 
 type FormOverviewProps = {
   isLoading: boolean;
   isServerValid: boolean;
   isMissingField?: (fieldName: string) => boolean;
-  submitErrors: Record<string, string[]>;
+  submitErrors: SubmitErrors;
   setSubmitErrors: React.Dispatch<React.SetStateAction<Record<string, any>>>;
   experiment?: getExperiment["experimentBySlug"];
   onSubmit: (data: Record<string, any>, reset: Function) => void;
@@ -55,7 +66,7 @@ const FormOverview = ({
   onCancel,
   onNext,
 }: FormOverviewProps) => {
-  const { application, hypothesisDefault, documentationLink } = useConfig();
+  const { application, hypothesisDefault } = useConfig();
 
   const hasExistingDocLinks =
     experiment?.documentationLinks && experiment?.documentationLinks.length > 0;
@@ -83,12 +94,23 @@ const FormOverview = ({
     handleSubmit,
     reset,
     isSubmitted,
+    errors,
+    touched,
+    formMethods,
+    control,
+    setValue,
   } = useCommonForm<OverviewFieldName>(
     defaultValues,
     isServerValid,
     submitErrors,
     setSubmitErrors,
   );
+
+  const {
+    documentationLinks,
+    addDocumentationLink,
+    removeDocumentationLink,
+  } = useDocumentationLinks(experiment, control, setValue);
 
   const shouldWarnOnExit = useExitWarning();
   useEffect(() => {
@@ -98,6 +120,7 @@ const FormOverview = ({
   const handleSubmitAfterValidation = useCallback(
     (data: Record<string, any>) => {
       if (isLoading) return;
+      data = stripInvalidDocumentationLinks(data);
       onSubmit(data, reset);
     },
     [isLoading, onSubmit, reset],
@@ -120,236 +143,220 @@ const FormOverview = ({
   );
 
   return (
-    <Form
-      noValidate
-      onSubmit={handleSubmit(handleSubmitAfterValidation)}
-      validated={isSubmitted && isValid}
-      data-testid="FormOverview"
-    >
-      {submitErrors["*"] && (
-        <Alert data-testid="submit-error" variant="warning">
-          {submitErrors["*"]}
-        </Alert>
-      )}
-
-      <Form.Group controlId="name">
-        <Form.Label>Public name</Form.Label>
-        <Form.Control
-          {...formControlAttrs("name", REQUIRED_FIELD)}
-          type="text"
-          autoFocus={!experiment}
-        />
-        <Form.Text className="text-muted">
-          This name will be public to users in about:studies.
-        </Form.Text>
-        <FormErrors name="name" />
-      </Form.Group>
-
-      <Form.Group controlId="hypothesis">
-        <Form.Label>Hypothesis</Form.Label>
-        <Form.Control
-          {...formControlAttrs("hypothesis", REQUIRED_FIELD)}
-          as="textarea"
-          rows={5}
-        />
-        <Form.Text className="text-muted">
-          You can add any supporting documents here.
-        </Form.Text>
-        <FormErrors name="hypothesis" />
-      </Form.Group>
-      <Form.Group controlId="application">
-        <Form.Label>Application</Form.Label>
-        {experiment ? (
-          <Form.Control
-            as="input"
-            value={
-              application!.find((a) => a?.value === experiment.application)
-                ?.label as string
-            }
-            readOnly
-          />
-        ) : (
-          <Form.Control
-            {...formControlAttrs("application", REQUIRED_FIELD)}
-            as="select"
-          >
-            <option value="">Select...</option>
-            {application!.map((app, idx) => (
-              <option key={`application-${idx}`} value={app!.value as string}>
-                {app!.label}
-              </option>
-            ))}
-          </Form.Control>
+    <FormProvider {...formMethods}>
+      <Form
+        noValidate
+        onSubmit={handleSubmit(handleSubmitAfterValidation)}
+        validated={isSubmitted && isValid}
+        data-testid="FormOverview"
+      >
+        {submitErrors["*"] && (
+          <Alert data-testid="submit-error" variant="warning">
+            {submitErrors["*"]}
+          </Alert>
         )}
-        <Form.Text className="text-muted">
-          <p className="mb-0">
-            Experiments can only target one Application at a time.
-          </p>
-          <p className="mb-0">
-            Application can not be changed after an experiment is created.
-          </p>
-        </Form.Text>
-        <FormErrors name="application" />
-      </Form.Group>
 
-      {experiment && (
-        <>
-          <Form.Group controlId="publicDescription">
-            <Form.Label className="d-flex align-items-center">
-              Public description
-              {isMissingField!("public_description") && (
-                <InlineErrorIcon
-                  name="description"
-                  message="Public description cannot be blank"
-                />
-              )}
-            </Form.Label>
+        <Form.Group controlId="name">
+          <Form.Label>Public name</Form.Label>
+          <Form.Control
+            {...formControlAttrs("name", REQUIRED_FIELD)}
+            type="text"
+            autoFocus={!experiment}
+          />
+          <Form.Text className="text-muted">
+            This name will be public to users in about:studies.
+          </Form.Text>
+          <FormErrors name="name" />
+        </Form.Group>
+
+        <Form.Group controlId="hypothesis">
+          <Form.Label>Hypothesis</Form.Label>
+          <Form.Control
+            {...formControlAttrs("hypothesis", REQUIRED_FIELD)}
+            as="textarea"
+            rows={5}
+          />
+          <Form.Text className="text-muted">
+            You can add any supporting documents here.
+          </Form.Text>
+          <FormErrors name="hypothesis" />
+        </Form.Group>
+        <Form.Group controlId="application">
+          <Form.Label>Application</Form.Label>
+          {experiment ? (
             <Form.Control
-              as="textarea"
-              rows={3}
-              {...formControlAttrs("publicDescription")}
+              as="input"
+              value={
+                application!.find((a) => a?.value === experiment.application)
+                  ?.label as string
+              }
+              readOnly
             />
-            <Form.Text className="text-muted">
-              This description will be public to users on about:studies
-            </Form.Text>
-            <FormErrors name="publicDescription" />
-          </Form.Group>
-
-          <Form.Group controlId="riskMitigationLink">
-            <Form.Label className="d-flex align-items-center">
-              Risk Mitigation Checklist Link
-              {isMissingField!("risk_mitigation_link") && (
-                <InlineErrorIcon
-                  name="risk_mitigation_link"
-                  message="A Risk Mitigation Checklist is required"
-                />
-              )}
-            </Form.Label>
+          ) : (
             <Form.Control
-              {...formControlAttrs("riskMitigationLink")}
-              type="url"
-            />
-            <Form.Text className="text-muted">
-              Go to the{" "}
-              <LinkExternal href={EXTERNAL_URLS.RISK_MITIGATION_TEMPLATE_DOC}>
-                risk mitigation checklist
-              </LinkExternal>{" "}
-              to make a copy and add the link above
-            </Form.Text>
-            <FormErrors name="riskMitigationLink" />
-          </Form.Group>
-
-          <Form.Group controlId="documentationLinks">
-            <Form.Label>
-              Additional Links
-              <Info
-                data-tip={DOCUMENTATION_LINKS_TOOLTIP}
-                data-testid="tooltip-documentation-links"
-                width="20"
-                height="20"
-                className="ml-1"
-              />
-              <ReactTooltip />
-            </Form.Label>
-            <div>
-              {defaultValues.documentationLinks.map((docLink, docIdx) => (
-                <Form.Group
-                  className="mb-0"
-                  data-testid="DocumentationLink"
-                  key={`doc-link-${docIdx}`}
-                >
-                  <Form.Row>
-                    <Form.Group as={Col} sm={4} md={3}>
-                      <Form.Control as="select" defaultValue={docLink.title}>
-                        <option value="" disabled>
-                          Select document type...
-                        </option>
-                        {documentationLink &&
-                          documentationLink.map((linkType, optIdx) => (
-                            <option
-                              key={`doc-link-${docIdx}-opt-${optIdx}`}
-                              value={linkType!.value as string}
-                            >
-                              {linkType!.label}
-                            </option>
-                          ))}
-                      </Form.Control>
-                    </Form.Group>
-                    <Form.Group as={Col}>
-                      <Form.Control
-                        placeholder="Link"
-                        type="url"
-                        defaultValue={docLink.link}
-                      />
-                    </Form.Group>
-                    <Form.Group as={Col} className="flex-grow-0">
-                      <Button
-                        data-testid="remove-documentation-link"
-                        variant="light"
-                        className="bg-transparent border-0 p-0 m-0 mt-px"
-                        title="Remove link"
-                        onClick={() => {}}
-                      >
-                        <DeleteIcon width="18" height="18" />
-                      </Button>
-                    </Form.Group>
-                  </Form.Row>
-                </Form.Group>
+              {...formControlAttrs("application", REQUIRED_FIELD)}
+              as="select"
+            >
+              <option value="">Select...</option>
+              {application!.map((app, idx) => (
+                <option key={`application-${idx}`} value={app!.value as string}>
+                  {app!.label}
+                </option>
               ))}
-            </div>
+            </Form.Control>
+          )}
+          <Form.Text className="text-muted">
+            <p className="mb-0">
+              Experiments can only target one Application at a time.
+            </p>
+            <p className="mb-0">
+              Application can not be changed after an experiment is created.
+            </p>
+          </Form.Text>
+          <FormErrors name="application" />
+        </Form.Group>
 
-            <div className="pt-2 mb-5 text-right">
-              <Button
-                data-testid="add-additional-link"
-                variant="outline-primary"
-                size="sm"
-                onClick={() => {}}
+        {experiment && (
+          <>
+            <Form.Group controlId="publicDescription">
+              <Form.Label className="d-flex align-items-center">
+                Public description
+                {isMissingField!("public_description") && (
+                  <InlineErrorIcon
+                    name="description"
+                    message="Public description cannot be blank"
+                  />
+                )}
+              </Form.Label>
+              <Form.Control
+                as="textarea"
+                rows={3}
+                {...formControlAttrs("publicDescription")}
+              />
+              <Form.Text className="text-muted">
+                This description will be public to users on about:studies
+              </Form.Text>
+              <FormErrors name="publicDescription" />
+            </Form.Group>
+
+            <Form.Group controlId="riskMitigationLink">
+              <Form.Label className="d-flex align-items-center">
+                Risk Mitigation Checklist Link
+                {isMissingField!("risk_mitigation_link") && (
+                  <InlineErrorIcon
+                    name="risk_mitigation_link"
+                    message="A Risk Mitigation Checklist is required"
+                  />
+                )}
+              </Form.Label>
+              <Form.Control
+                {...formControlAttrs("riskMitigationLink")}
+                type="url"
+              />
+              <Form.Text className="text-muted">
+                Go to the{" "}
+                <LinkExternal href={EXTERNAL_URLS.RISK_MITIGATION_TEMPLATE_DOC}>
+                  risk mitigation checklist
+                </LinkExternal>{" "}
+                to make a copy and add the link above
+              </Form.Text>
+              <FormErrors name="riskMitigationLink" />
+            </Form.Group>
+
+            <Form.Group controlId="documentationLinks">
+              <Form.Label>
+                Additional Links
+                <Info
+                  data-tip={DOCUMENTATION_LINKS_TOOLTIP}
+                  data-testid="tooltip-documentation-links"
+                  width="20"
+                  height="20"
+                  className="ml-1"
+                />
+                <ReactTooltip />
+              </Form.Label>
+              <div>
+                {documentationLinks.map((documentationLink, index) => (
+                  <FormDocumentationLink
+                    key={documentationLink.id}
+                    {...{
+                      documentationLink,
+                      setSubmitErrors,
+                      fieldNamePrefix: `documentationLinks[${index}]`,
+                      submitErrors:
+                        (submitErrors?.documentation_links &&
+                          (submitErrors?.documentation_links as SubmitErrorRecord[])[
+                            index
+                          ]) ||
+                        {},
+                      //@ts-ignore react-hook-form types seem broken for nested fields
+                      errors: (errors?.documentationLink?.[index] ||
+                        {}) as FormDocumentationLinkProps["errors"],
+                      //@ts-ignore react-hook-form types seem broken for nested fields
+                      touched: (touched?.documentationLink?.[index] ||
+                        {}) as FormDocumentationLinkProps["touched"],
+                      onRemove: () => {
+                        removeDocumentationLink(documentationLink);
+                      },
+                      canRemove: index !== 0,
+                    }}
+                  />
+                ))}
+              </div>
+
+              <div className="pt-2 mb-5 text-right">
+                <Button
+                  data-testid="add-additional-link"
+                  variant="outline-primary"
+                  size="sm"
+                  onClick={addDocumentationLink}
+                >
+                  + Add Link
+                </Button>
+              </div>
+            </Form.Group>
+          </>
+        )}
+
+        <div className="d-flex flex-row-reverse bd-highlight">
+          {!!experiment && onNext && (
+            <div className="p-2">
+              <button
+                onClick={handleNext}
+                className="btn btn-secondary"
+                disabled={isLoading}
+                data-sb-kind="pages/EditBranches"
               >
-                + Add Link
-              </Button>
+                Next
+              </button>
             </div>
-          </Form.Group>
-        </>
-      )}
-
-      <div className="d-flex flex-row-reverse bd-highlight">
-        {!!experiment && onNext && (
+          )}
           <div className="p-2">
             <button
-              onClick={handleNext}
-              className="btn btn-secondary"
+              data-testid="submit-button"
+              type="submit"
+              onClick={handleSubmit(handleSubmitAfterValidation)}
+              className="btn btn-primary"
               disabled={isLoading}
-              data-sb-kind="pages/EditBranches"
+              data-sb-kind="pages/EditOverview"
             >
-              Next
+              {isLoading ? (
+                <span>{experiment ? "Saving" : "Submitting"}</span>
+              ) : (
+                <span>{experiment ? "Save" : "Next"}</span>
+              )}
             </button>
           </div>
-        )}
-        <div className="p-2">
-          <button
-            data-testid="submit-button"
-            type="submit"
-            onClick={handleSubmit(handleSubmitAfterValidation)}
-            className="btn btn-primary"
-            disabled={isLoading}
-            data-sb-kind="pages/EditOverview"
-          >
-            {isLoading ? (
-              <span>{experiment ? "Saving" : "Submitting"}</span>
-            ) : (
-              <span>{experiment ? "Save" : "Next"}</span>
-            )}
-          </button>
+          {onCancel && (
+            <div className="p-2">
+              <button onClick={handleCancel} className="btn btn-light">
+                Cancel
+              </button>
+            </div>
+          )}
         </div>
-        {onCancel && (
-          <div className="p-2">
-            <button onClick={handleCancel} className="btn btn-light">
-              Cancel
-            </button>
-          </div>
-        )}
-      </div>
-    </Form>
+      </Form>
+    </FormProvider>
   );
 };
 

--- a/app/experimenter/nimbus-ui/src/components/PageEditOverview/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditOverview/index.tsx
@@ -33,6 +33,7 @@ const PageEditOverview: React.FunctionComponent<PageEditOverviewProps> = () => {
       hypothesis,
       riskMitigationLink,
       publicDescription,
+      documentationLinks,
     }: Record<string, any>) => {
       try {
         const result = await updateExperimentOverview({
@@ -43,6 +44,7 @@ const PageEditOverview: React.FunctionComponent<PageEditOverviewProps> = () => {
               hypothesis,
               publicDescription,
               riskMitigationLink,
+              documentationLinks,
             },
           },
         });

--- a/app/experimenter/nimbus-ui/src/components/Summary/TableSummary/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/TableSummary/index.tsx
@@ -19,7 +19,10 @@ type TableSummaryProps = {
 // `<tr>`s showing optional fields that are not set are not displayed.
 
 const TableSummary = ({ experiment }: TableSummaryProps) => {
-  const { application } = useConfig();
+  const {
+    application,
+    documentationLink: configDocumentationLinks,
+  } = useConfig();
 
   return (
     <Table striped bordered data-testid="table-summary" className="mb-4">
@@ -86,7 +89,11 @@ const TableSummary = ({ experiment }: TableSummaryProps) => {
                     className="d-block"
                   >
                     <span className="mr-1 align-middle">
-                      {documentationLink.title}
+                      {
+                        configDocumentationLinks!.find(
+                          (d) => d?.value === documentationLink.title,
+                        )?.label
+                      }
                     </span>
                     <ExternalIcon />
                   </LinkExternal>

--- a/app/experimenter/nimbus-ui/src/hooks/useCommonForm/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/hooks/useCommonForm/index.test.tsx
@@ -100,20 +100,18 @@ describe("hooks/useCommonForm", () => {
     // `formControlAttrs`, and `formSelectAttrs` are all called with the expected field names
     // and/or move these form tests into their corresponding form test files
     describe("FormOverview", () => {
-      it("with experiment data", () => {
+      it("with experiment data", async () => {
         const { experiment } = mockExperimentQuery("boo");
         render(<OverviewSubject {...{ experiment }} />);
 
-        overviewFieldNames.forEach((name) => {
+        for (const name of overviewFieldNames) {
           // TODO EXP-805 test errors form saving once
           // documentationLinks uses useCommonForm
           if (!["application", "documentationLinks"].includes(name)) {
-            expect(
-              screen.queryByTestId(`${name}-form-errors`),
-            ).toBeInTheDocument();
-            expect(screen.queryByTestId(name)).toBeInTheDocument();
+            await screen.findByTestId(`${name}-form-errors`);
+            await screen.findByTestId(name);
           }
-        });
+        }
       });
 
       it("without experiment data", async () => {

--- a/app/experimenter/nimbus-ui/src/hooks/useCommonForm/index.tsx
+++ b/app/experimenter/nimbus-ui/src/hooks/useCommonForm/index.tsx
@@ -6,20 +6,26 @@ import React from "react";
 import { IsDirtyUnsaved, useCommonFormMethods } from "./useCommonFormMethods";
 import { useForm } from "./useForm";
 
+export type SubmitErrorRecord = Record<string, string[]>;
+export type SubmitErrors = Record<string, string[] | SubmitErrorRecord[]>;
+
 export function useCommonForm<FieldNames extends string>(
   defaultValues: Record<string, any>,
   isServerValid: boolean,
-  submitErrors: Record<string, string[]>,
+  submitErrors: SubmitErrors,
   setSubmitErrors: React.Dispatch<React.SetStateAction<Record<string, any>>>,
 ) {
+  const formMethods = useForm(defaultValues);
   const {
     handleSubmit,
     register,
     reset,
     getValues,
+    setValue,
     errors,
+    control,
     formState: { isSubmitted, isDirty, touched, isValid: isClientValid },
-  } = useForm(defaultValues);
+  } = formMethods;
 
   const isDirtyUnsaved = IsDirtyUnsaved(isDirty, isClientValid, isSubmitted);
   const isValid = isServerValid && isClientValid;
@@ -44,10 +50,13 @@ export function useCommonForm<FieldNames extends string>(
     handleSubmit,
     reset,
     getValues,
+    setValue,
     errors,
     touched,
     isValid,
     isDirtyUnsaved,
     isSubmitted,
+    formMethods,
+    control,
   };
 }

--- a/app/experimenter/nimbus-ui/src/hooks/useCommonForm/useCommonFormMethods.tsx
+++ b/app/experimenter/nimbus-ui/src/hooks/useCommonForm/useCommonFormMethods.tsx
@@ -5,6 +5,7 @@
 import React from "react";
 import Form from "react-bootstrap/Form";
 import { FieldError, RegisterOptions, UseFormMethods } from "react-hook-form";
+import { SubmitErrors } from ".";
 import { camelToSnakeCase } from "../../lib/caseConversions";
 
 // TODO: 'any' type on `onChange={(selectedOptions) => ...`,
@@ -25,7 +26,7 @@ export const IsDirtyUnsaved = (
 export function useCommonFormMethods<FieldNames extends string>(
   defaultValues: Record<string, any>,
   setSubmitErrors: React.Dispatch<React.SetStateAction<Record<string, any>>>,
-  submitErrors: Record<string, string[]>,
+  submitErrors: SubmitErrors,
   register: UseFormMethods["register"],
   errors: UseFormMethods["errors"],
   touched: UseFormMethods["formState"]["touched"],

--- a/app/experimenter/nimbus-ui/src/lib/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/lib/mocks.tsx
@@ -33,6 +33,7 @@ import {
 } from "../types/getExperiment";
 import {
   ExperimentInput,
+  NimbusDocumentationLinkTitle,
   NimbusExperimentStatus,
   NimbusFeatureConfigApplication,
   NimbusProbeKind,
@@ -353,7 +354,10 @@ export function mockExperimentQuery<
       endDate: new Date(Date.now() + 12096e5).toISOString(),
       riskMitigationLink: "https://docs.google.com/document/d/banzinga/edit",
       documentationLinks: [
-        { title: "Bingo bongo", link: "https://bingo.bongo" },
+        {
+          title: NimbusDocumentationLinkTitle.DS_JIRA,
+          link: "https://bingo.bongo",
+        },
       ],
     },
     modifications,


### PR DESCRIPTION
Closes #4371

This PR adds the functionality for adding and removing experiment documentation links.

- Add a new documentation link set using the "+ Add Link" button
- Remove a link set by clicking its adjacent "X" button
- Removing the last set should display a reset/empty set
- Client and server validation errors should show up correctly
- Click "Save" with a partially complete set should strip it and not save it

Additionally, I noticed `SummaryTable` was incorrectly rendering saved documentation links, so I snuck that in here.

PS - You're going to want to enable GitHub's "Hide whitespace changes" when looking at this diff as I had to shift indentation in `FormOverview`.