### PR TITLE
issue #4475 test(visualization): turn on full diff in assertion failure

### DIFF
--- a/app/experimenter/visualization/tests/api/test_views.py
+++ b/app/experimenter/visualization/tests/api/test_views.py
@@ -16,6 +16,10 @@ from experimenter.visualization.tests.api.constants import TestConstants
 
 @override_settings(FEATURE_ANALYSIS=False)
 class TestVisualizationView(TestCase):
+
+    # issue #4475: full diff enabled for more information on failure
+    maxDiff = None
+
     @parameterized.expand(
         [
             NimbusExperiment.Status.ACCEPTED,
@@ -92,7 +96,7 @@ class TestVisualizationView(TestCase):
     @parameterized.expand(
         [
             NimbusExperiment.Status.ACCEPTED,
-            # NimbusExperiment.Status.COMPLETE, ref: #4475
+            NimbusExperiment.Status.COMPLETE,
         ]
     )
     @patch("django.core.files.storage.default_storage.open")


### PR DESCRIPTION
Because:

- we need more information to diagnose an intermittent failure in tests

This commit:

- enables full diff output for assertions which otherwise obscures
  information needed to diagnose