### PR TITLE
fixes #4299 feat(nimbus): Make almost all form fields optional, client-side

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/FormOverview/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/FormOverview/index.tsx
@@ -12,7 +12,7 @@ import { useCommonForm, useExitWarning } from "../../hooks";
 import { useConfig } from "../../hooks/useConfig";
 import { ReactComponent as Info } from "../../images/info.svg";
 import { ReactComponent as DeleteIcon } from "../../images/x.svg";
-import { EXTERNAL_URLS } from "../../lib/constants";
+import { EXTERNAL_URLS, REQUIRED_FIELD } from "../../lib/constants";
 import { getExperiment } from "../../types/getExperiment";
 import { NimbusDocumentationLinkTitle } from "../../types/globalTypes";
 import InlineErrorIcon from "../InlineErrorIcon";
@@ -135,7 +135,7 @@ const FormOverview = ({
       <Form.Group controlId="name">
         <Form.Label>Public name</Form.Label>
         <Form.Control
-          {...formControlAttrs("name")}
+          {...formControlAttrs("name", REQUIRED_FIELD)}
           type="text"
           autoFocus={!experiment}
         />
@@ -148,7 +148,7 @@ const FormOverview = ({
       <Form.Group controlId="hypothesis">
         <Form.Label>Hypothesis</Form.Label>
         <Form.Control
-          {...formControlAttrs("hypothesis")}
+          {...formControlAttrs("hypothesis", REQUIRED_FIELD)}
           as="textarea"
           rows={5}
         />
@@ -169,7 +169,10 @@ const FormOverview = ({
             readOnly
           />
         ) : (
-          <Form.Control {...formControlAttrs("application")} as="select">
+          <Form.Control
+            {...formControlAttrs("application", REQUIRED_FIELD)}
+            as="select"
+          >
             <option value="">Select...</option>
             {application!.map((app, idx) => (
               <option key={`application-${idx}`} value={app!.value as string}>
@@ -204,7 +207,7 @@ const FormOverview = ({
             <Form.Control
               as="textarea"
               rows={3}
-              {...formControlAttrs("publicDescription", {})}
+              {...formControlAttrs("publicDescription")}
             />
             <Form.Text className="text-muted">
               This description will be public to users on about:studies
@@ -223,7 +226,7 @@ const FormOverview = ({
               )}
             </Form.Label>
             <Form.Control
-              {...formControlAttrs("riskMitigationLink", {})}
+              {...formControlAttrs("riskMitigationLink")}
               type="url"
             />
             <Form.Text className="text-muted">

--- a/app/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/index.tsx
@@ -9,7 +9,7 @@ import Form from "react-bootstrap/Form";
 import InputGroup from "react-bootstrap/InputGroup";
 import { useCommonForm } from "../../../hooks";
 import { useConfig } from "../../../hooks/useConfig";
-import { EXTERNAL_URLS } from "../../../lib/constants";
+import { EXTERNAL_URLS, NUMBER_FIELD } from "../../../lib/constants";
 import { getExperiment_experimentBySlug } from "../../../types/getExperiment";
 import InlineErrorIcon from "../../InlineErrorIcon";
 import LinkExternal from "../../LinkExternal";
@@ -188,7 +188,7 @@ export const FormAudience = ({
             </Form.Label>
             <InputGroup>
               <Form.Control
-                {...formControlAttrs("populationPercent")}
+                {...formControlAttrs("populationPercent", NUMBER_FIELD)}
                 aria-describedby="populationPercent-unit"
                 type="number"
                 min="0"
@@ -209,7 +209,7 @@ export const FormAudience = ({
           >
             <Form.Label>Expected number of clients</Form.Label>
             <Form.Control
-              {...formControlAttrs("totalEnrolledClients")}
+              {...formControlAttrs("totalEnrolledClients", NUMBER_FIELD)}
               type="number"
               min="0"
             />
@@ -230,7 +230,7 @@ export const FormAudience = ({
             </Form.Label>
             <InputGroup>
               <Form.Control
-                {...formControlAttrs("proposedEnrollment")}
+                {...formControlAttrs("proposedEnrollment", NUMBER_FIELD)}
                 type="number"
                 min="0"
                 aria-describedby="proposedEnrollment-unit"
@@ -256,7 +256,7 @@ export const FormAudience = ({
             </Form.Label>
             <InputGroup className="mb-3">
               <Form.Control
-                {...formControlAttrs("proposedDuration")}
+                {...formControlAttrs("proposedDuration", NUMBER_FIELD)}
                 type="number"
                 min="0"
                 aria-describedby="proposedDuration-unit"

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/FormBranch.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/FormBranch.test.tsx
@@ -10,6 +10,7 @@ import {
   waitFor,
 } from "@testing-library/react";
 import React from "react";
+import { FIELD_MESSAGES } from "../../../lib/constants";
 import { MOCK_CONFIG } from "../../../lib/mocks";
 import {
   MOCK_ANNOTATED_BRANCH,
@@ -136,13 +137,36 @@ describe("FormBranch", () => {
     const branch = {
       ...MOCK_ANNOTATED_BRANCH,
     };
-    const { container } = render(<SubjectBranch branch={branch} />);
+    const { container } = render(<SubjectBranch {...{ branch }} />);
     const field = screen.getByTestId("referenceBranch.ratio");
     act(() => {
       fireEvent.change(field, { target: { value: "abc" } });
       fireEvent.blur(field);
     });
     await assertInvalidField(container, "referenceBranch.ratio");
+    expect(
+      container.querySelector(
+        ".invalid-feedback[data-for='referenceBranch.ratio']",
+      ),
+    ).toHaveTextContent(FIELD_MESSAGES.NUMBER);
+  });
+
+  it("displays expected message on required fields", async () => {
+    const branch = {
+      ...MOCK_ANNOTATED_BRANCH,
+    };
+    const { container } = render(<SubjectBranch {...{ branch }} />);
+    const field = screen.getByTestId("referenceBranch.name");
+    act(() => {
+      fireEvent.change(field, { target: { value: "" } });
+      fireEvent.blur(field);
+    });
+    await assertInvalidField(container, "referenceBranch.name");
+    expect(
+      container.querySelector(
+        ".invalid-feedback[data-for='referenceBranch.name']",
+      ),
+    ).toHaveTextContent(FIELD_MESSAGES.REQUIRED);
   });
 
   it("should display server-side errors even when client-side validation is not defined", async () => {

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/FormBranch.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/FormBranch.tsx
@@ -10,6 +10,7 @@ import Form from "react-bootstrap/Form";
 import { FieldError } from "react-hook-form";
 import { useCommonNestedForm } from "../../../hooks";
 import { ReactComponent as DeleteIcon } from "../../../images/x.svg";
+import { NUMBER_FIELD, REQUIRED_FIELD } from "../../../lib/constants";
 import {
   getConfig_nimbusConfig,
   getConfig_nimbusConfig_featureConfig,
@@ -109,7 +110,10 @@ export const FormBranch = ({
                 </Badge>
               )}
             </Form.Label>
-            <Form.Control {...formControlAttrs("name")} type="text" />
+            <Form.Control
+              {...formControlAttrs("name", REQUIRED_FIELD)}
+              type="text"
+            />
             <FormErrors name="name" />
           </Form.Group>
           <Form.Group as={Col} controlId={`${id}-description`}>
@@ -139,8 +143,7 @@ export const FormBranch = ({
                 <Form.Control
                   {...formControlAttrs("ratio", {
                     valueAsNumber: true,
-                    validate: (value) =>
-                      (!!value && !isNaN(value)) || "Ratio must be a number.",
+                    ...NUMBER_FIELD,
                   })}
                   type="number"
                   min="1"

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/index.test.tsx
@@ -170,6 +170,38 @@ describe("FormBranches", () => {
     });
   });
 
+  it("requires only a branch name before save", async () => {
+    const onSave = jest.fn();
+    render(
+      <SubjectBranches
+        {...{
+          onSave,
+          experiment: {
+            ...MOCK_EXPERIMENT,
+            referenceBranch: {
+              __typename: "NimbusBranchType",
+              name: "",
+              slug: "",
+              description: "",
+              ratio: 1,
+              featureValue: null,
+              featureEnabled: false,
+            },
+            treatmentBranches: null,
+          },
+        }}
+      />,
+    );
+
+    const field = screen.getByTestId("referenceBranch.name");
+    act(() => {
+      fireEvent.change(field, { target: { value: "Big beautiful branch" } });
+      fireEvent.blur(field);
+    });
+
+    await clickAndWaitForSave(onSave);
+  });
+
   it("supports adding a treatment branch", async () => {
     const onSave = jest.fn();
     const { container } = render(

--- a/app/experimenter/nimbus-ui/src/hooks/useCommonForm/useCommonFormMethods.tsx
+++ b/app/experimenter/nimbus-ui/src/hooks/useCommonForm/useCommonFormMethods.tsx
@@ -38,13 +38,11 @@ export function useCommonFormMethods<FieldNames extends string>(
     }
   };
 
-  // Fields are required by default. Pass an empty object `{}` as `registerOptions`
-  // to allow form submission without that field being required.
+  // Fields are optional by default. Pass `REQUIRED_FIELD` into `registerOptions`
+  // to require a valid field before form submission is allowed.
   const formControlAttrs = <K extends FieldNames>(
     name: K,
-    registerOptions: RegisterOptions = {
-      required: "This field may not be blank.",
-    },
+    registerOptions: RegisterOptions = {},
     setDefaultValue = true,
     prefix?: string,
   ) => {

--- a/app/experimenter/nimbus-ui/src/lib/constants.ts
+++ b/app/experimenter/nimbus-ui/src/lib/constants.ts
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import { RegisterOptions } from "react-hook-form";
+
 export const BASE_PATH = "/nimbus";
 
 export const UNKNOWN_ERROR =
@@ -23,3 +25,16 @@ export const EXTERNAL_URLS = {
   PREVIEW_LAUNCH_DOC:
     "https://mana.mozilla.org/wiki/display/FJT/Project+Nimbus",
 };
+
+export const FIELD_MESSAGES = {
+  REQUIRED: "This field may not be blank.",
+  NUMBER: "This field must be a number.",
+};
+
+export const REQUIRED_FIELD = {
+  required: FIELD_MESSAGES.REQUIRED,
+} as RegisterOptions;
+
+export const NUMBER_FIELD = {
+  validate: (value) => (!!value && !isNaN(value)) || FIELD_MESSAGES.NUMBER,
+} as RegisterOptions;


### PR DESCRIPTION
Because:
* We want users to be able to fill in various pieces of experiments rather than requiring every field

This commit:
* Flips the default in useCommonForm to make fields optional
* Makes Overview form fields optional except for those filled out on the "New" page
* Makes Branch fields optional with the exception of a branch name
* Audience/Metrics fields are optional with the useCommonForm change
* Adds improved client-side validation on some Audience fields, requiring a number

fixes #4299