### PR TITLE
fix #4463 feat(nimbus): add featureIds to V6 API

### DIFF
--- a/app/experimenter/docs/openapi-schema.json
+++ b/app/experimenter/docs/openapi-schema.json
@@ -3014,6 +3014,10 @@
           "referenceBranch": {
             "type": "string",
             "readOnly": true
+          },
+          "featureIds": {
+            "type": "string",
+            "readOnly": true
           }
         },
         "required": [

--- a/app/experimenter/docs/swagger-ui.html
+++ b/app/experimenter/docs/swagger-ui.html
@@ -3026,6 +3026,10 @@
           "referenceBranch": {
             "type": "string",
             "readOnly": true
+          },
+          "featureIds": {
+            "type": "string",
+            "readOnly": true
           }
         },
         "required": [

--- a/app/experimenter/experiments/api/v6/serializers.py
+++ b/app/experimenter/experiments/api/v6/serializers.py
@@ -71,6 +71,7 @@ class NimbusExperimentSerializer(serializers.ModelSerializer):
     proposedDuration = serializers.ReadOnlyField(source="proposed_duration")
     proposedEnrollment = serializers.ReadOnlyField(source="proposed_enrollment")
     referenceBranch = serializers.SerializerMethodField()
+    featureIds = serializers.SerializerMethodField()
 
     class Meta:
         model = NimbusExperiment
@@ -95,6 +96,7 @@ class NimbusExperimentSerializer(serializers.ModelSerializer):
             "proposedDuration",
             "proposedEnrollment",
             "referenceBranch",
+            "featureIds",
         )
 
     def get_application(self, obj):
@@ -147,6 +149,11 @@ class NimbusExperimentSerializer(serializers.ModelSerializer):
             f"{channel_expr}{version_expr}{targeting_expr}"
             "'app.shield.optoutstudies.enabled'|preferenceValue"
         )
+
+    def get_featureIds(self, obj):
+        if obj.feature_config:
+            return [obj.feature_config.slug]
+        return []
 
 
 class NimbusProbeSerializer(serializers.ModelSerializer):

--- a/app/experimenter/experiments/tests/api/v6/test_serializers.py
+++ b/app/experimenter/experiments/tests/api/v6/test_serializers.py
@@ -63,6 +63,7 @@ class TestNimbusExperimentSerializer(TestCase):
                 "userFacingDescription": experiment.public_description,
                 "userFacingName": experiment.name,
                 "probeSets": [probe_set.slug],
+                "featureIds": [experiment.feature_config.slug],
             },
         )
         self.assertEqual(
@@ -203,6 +204,7 @@ class TestNimbusExperimentSerializer(TestCase):
         )
         serializer = NimbusExperimentSerializer(experiment)
         experiment_data = serializer.data.copy()
+        self.assertEqual(experiment_data["featureIds"], [])
         branches_data = [dict(b) for b in experiment_data.pop("branches")]
         self.assertEqual(len(branches_data), 2)
         for branch in experiment.branches.all():


### PR DESCRIPTION
Because

* The 1.3.0 nimbus shared experiment schema allows for a top level featureIds property which stores the list of feature ids targeted by the experiment

This commit

* Adds a featureIds property to the V6 API which includes an array of 1 element for now (until we later support multiple feature configs per experiment)