### PR TITLE
fixes #4501 feat(nimbus): validate documentation link URL fields in the client

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/FormOverview/FormDocumentationLink.tsx
+++ b/app/experimenter/nimbus-ui/src/components/FormOverview/FormDocumentationLink.tsx
@@ -9,6 +9,7 @@ import Form from "react-bootstrap/Form";
 import { ArrayField, FieldError } from "react-hook-form";
 import { useCommonNestedForm, useConfig } from "../../hooks";
 import { ReactComponent as DeleteIcon } from "../../images/x.svg";
+import { URL_FIELD } from "../../lib/constants";
 import { AnnotatedDocumentationLink } from "./documentationLink";
 
 export const documentationLinkFieldNames = ["title", "link"] as const;
@@ -74,7 +75,7 @@ export const FormDocumentationLink = ({
           <Form.Control
             placeholder="Link"
             type="url"
-            {...formControlAttrs("link")}
+            {...formControlAttrs("link", URL_FIELD)}
           />
           <FormErrors name="link" />
         </Form.Group>

--- a/app/experimenter/nimbus-ui/src/components/FormOverview/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/FormOverview/index.test.tsx
@@ -11,6 +11,7 @@ import {
 } from "@testing-library/react";
 import React from "react";
 import { DOCUMENTATION_LINKS_TOOLTIP } from ".";
+import { FIELD_MESSAGES } from "../../lib/constants";
 import { mockExperimentQuery } from "../../lib/mocks";
 import { NimbusDocumentationLinkTitle } from "../../types/globalTypes";
 import { Subject } from "./mocks";
@@ -132,6 +133,7 @@ describe("FormOverview", () => {
     fireEvent.change(linkField, {
       target: { value: value.link },
     });
+    fireEvent.blur(linkField);
   };
 
   const checkExistingForm = async (expected: Record<string, any>) => {
@@ -257,8 +259,21 @@ describe("FormOverview", () => {
       experiment.documentationLinks![0] = {
         __typename: "NimbusDocumentationLinkType",
         title: NimbusDocumentationLinkTitle.ENG_TICKET,
-        link: "https://ooga.booga",
+        link: "https://",
       };
+      fillDocumentationLinkFields(experiment.documentationLinks![0], 0);
+    });
+
+    // Whoops! Invalid URL.
+    expect(
+      screen
+        .getByTestId("DocumentationLink")
+        .querySelector(".invalid-feedback"),
+    ).toHaveTextContent(FIELD_MESSAGES.URL);
+
+    // Fix the invalid URL
+    experiment.documentationLinks![0].link = "https://ooga.booga";
+    await act(async () => {
       fillDocumentationLinkFields(experiment.documentationLinks![0], 0);
     });
 

--- a/app/experimenter/nimbus-ui/src/components/FormOverview/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/FormOverview/index.tsx
@@ -18,7 +18,6 @@ import { useConfig } from "../../hooks/useConfig";
 import { ReactComponent as Info } from "../../images/info.svg";
 import { EXTERNAL_URLS, REQUIRED_FIELD } from "../../lib/constants";
 import { getExperiment } from "../../types/getExperiment";
-import { NimbusDocumentationLinkTitle } from "../../types/globalTypes";
 import InlineErrorIcon from "../InlineErrorIcon";
 import LinkExternal from "../LinkExternal";
 import {
@@ -68,22 +67,12 @@ const FormOverview = ({
 }: FormOverviewProps) => {
   const { application, hypothesisDefault } = useConfig();
 
-  const hasExistingDocLinks =
-    experiment?.documentationLinks && experiment?.documentationLinks.length > 0;
   const defaultValues = {
     name: experiment?.name || "",
     hypothesis: experiment?.hypothesis || (hypothesisDefault as string).trim(),
     application: "",
     publicDescription: experiment?.publicDescription as string,
     riskMitigationLink: experiment?.riskMitigationLink as string,
-    documentationLinks: (hasExistingDocLinks
-      ? experiment?.documentationLinks!
-      : [
-          {
-            title: "",
-            link: "",
-          },
-        ]) as { title: NimbusDocumentationLinkTitle | ""; link: string }[],
   };
 
   const {

--- a/app/experimenter/nimbus-ui/src/components/FormOverview/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/FormOverview/index.tsx
@@ -279,10 +279,10 @@ const FormOverview = ({
                           ]) ||
                         {},
                       //@ts-ignore react-hook-form types seem broken for nested fields
-                      errors: (errors?.documentationLink?.[index] ||
+                      errors: (errors?.documentationLinks?.[index] ||
                         {}) as FormDocumentationLinkProps["errors"],
                       //@ts-ignore react-hook-form types seem broken for nested fields
-                      touched: (touched?.documentationLink?.[index] ||
+                      touched: (touched?.documentationLinks?.[index] ||
                         {}) as FormDocumentationLinkProps["touched"],
                       onRemove: () => {
                         removeDocumentationLink(documentationLink);

--- a/app/experimenter/nimbus-ui/src/lib/constants.ts
+++ b/app/experimenter/nimbus-ui/src/lib/constants.ts
@@ -29,6 +29,7 @@ export const EXTERNAL_URLS = {
 export const FIELD_MESSAGES = {
   REQUIRED: "This field may not be blank.",
   NUMBER: "This field must be a number.",
+  URL: "This field must be a URL.",
 };
 
 export const REQUIRED_FIELD = {
@@ -37,4 +38,11 @@ export const REQUIRED_FIELD = {
 
 export const NUMBER_FIELD = {
   validate: (value) => (!!value && !isNaN(value)) || FIELD_MESSAGES.NUMBER,
+} as RegisterOptions;
+
+export const URL_FIELD = {
+  pattern: {
+    value: /^(http|https):\/\/[^ "]+$/,
+    message: FIELD_MESSAGES.URL,
+  },
 } as RegisterOptions;


### PR DESCRIPTION
Closes #4501

This PR adds very basic URL validation on documentation link URL fields.

FWIW, I tried to re-use [this Regexp](https://github.com/mozilla/experimenter/blob/main/app/experimenter/nimbus-ui/src/components/RichText/index.tsx#L9) that is being used to match URLs in `RichText`, but for whatever reason (matching groups? negative look-behind?) it wasn't working with `.test()`.

Also, I realized there was some old documentation link code, so I removed that as well.