### PR TITLE
fix #4504 - feature(visualization): Add days of use as a guardrail metric

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableHighlights/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableHighlights/index.test.tsx
@@ -45,7 +45,7 @@ describe("TableHighlights", () => {
 
     expect(screen.getByTestId("positive-significance")).toBeInTheDocument();
     expect(screen.getByTestId("negative-significance")).toBeInTheDocument();
-    expect(screen.getByTestId("neutral-significance")).toBeInTheDocument();
+    expect(screen.queryAllByTestId("neutral-significance")).toHaveLength(2);
   });
 
   it("has the expected control and treatment labels", async () => {

--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableResults/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableResults/index.test.tsx
@@ -28,6 +28,7 @@ describe("TableResults", () => {
       "Picture-in-Picture Conversion",
       "2-Week Browser Retention",
       "Daily Mean Searches Per User",
+      "Overall Mean Days of Use Per User",
       "Total Users",
     ];
 
@@ -63,7 +64,7 @@ describe("TableResults", () => {
 
     expect(screen.getByTestId("positive-significance")).toBeInTheDocument();
     expect(screen.getByTestId("negative-significance")).toBeInTheDocument();
-    expect(screen.getByTestId("neutral-significance")).toBeInTheDocument();
+    expect(screen.queryAllByTestId("neutral-significance")).toHaveLength(2);
   });
 
   it("renders missing retention with warning", () => {

--- a/app/experimenter/nimbus-ui/src/lib/visualization/constants.ts
+++ b/app/experimenter/nimbus-ui/src/lib/visualization/constants.ts
@@ -8,6 +8,7 @@ export const METRICS_TIPS = {
   USER_COUNT:
     "Total users in a variant and the % of users out of the entire experiment population",
   CONVERSION: "Percentage of users in the variant who used this feature",
+  DAYS_OF_USE: "Average number of days each client sent a main ping",
 };
 
 export const SEGMENT_TIPS = {
@@ -58,6 +59,7 @@ export const SIGNIFICANCE = {
 export const METRIC = {
   RETENTION: "retained",
   SEARCH: "search_count",
+  DAYS_OF_USE: "days_of_use",
   USER_COUNT: "identity",
 };
 
@@ -116,6 +118,11 @@ export const HIGHLIGHTS_METRICS_LIST = [
     name: "Search",
     tooltip: METRICS_TIPS.SEARCH,
   },
+  {
+    value: METRIC.DAYS_OF_USE,
+    name: "Days of Use",
+    tooltip: METRICS_TIPS.DAYS_OF_USE,
+  },
 ];
 
 // This is used as an ordered list of metrics to
@@ -131,6 +138,12 @@ export const RESULTS_METRICS_LIST = [
     value: METRIC.SEARCH,
     name: "Daily Mean Searches Per User",
     tooltip: METRICS_TIPS.SEARCH,
+    type: METRIC_TYPE.GUARDRAIL,
+  },
+  {
+    value: METRIC.DAYS_OF_USE,
+    name: "Overall Mean Days of Use Per User",
+    tooltip: METRICS_TIPS.DAYS_OF_USE,
     type: METRIC_TYPE.GUARDRAIL,
   },
   {

--- a/app/experimenter/nimbus-ui/src/lib/visualization/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/lib/visualization/mocks.tsx
@@ -9,6 +9,81 @@ export const MOCK_UNAVAILABLE_ANALYSIS = {
   overall: null,
 };
 
+export const CONTROL_NEUTRAL = {
+  absolute: {
+    first: {
+      point: 0.05,
+      count: 10,
+      lower: 0.024357271316207685,
+      upper: 0.08411463700173483,
+    },
+    all: [
+      {
+        point: 0.05,
+        count: 10,
+        lower: 0.024357271316207685,
+        upper: 0.08411463700173483,
+      },
+    ],
+  },
+  difference: {
+    first: {},
+    all: [],
+  },
+  relative_uplift: {
+    first: {},
+    all: [],
+  },
+};
+
+export const TREATMENT_NEUTRAL = {
+  absolute: {
+    first: {
+      point: 0.049019607843137254,
+      count: 10,
+      lower: 0.023872203557007872,
+      upper: 0.08249069209461024,
+    },
+    all: [
+      {
+        point: 0.049019607843137254,
+        count: 10,
+        lower: 0.023872203557007872,
+        upper: 0.08249069209461024,
+      },
+    ],
+  },
+  difference: {
+    first: {
+      point: -0.0006569487628876534,
+      upper: 0.04316381736512019,
+      lower: 0.04175095963994029,
+    },
+    all: [
+      {
+        point: -0.0006569487628876534,
+        upper: 0.04316381736512019,
+        lower: 0.04175095963994029,
+      },
+    ],
+  },
+  relative_uplift: {
+    first: {
+      lower: -0.455210299676828,
+      upper: 0.5104985718410426,
+      point: -0.06233954570562385,
+    },
+    all: [
+      {
+        lower: -0.455210299676828,
+        upper: 0.5104985718410426,
+        point: -0.06233954570562385,
+      },
+    ],
+  },
+  significance: "neutral",
+};
+
 export const weeklyMockAnalysis = (modifications = {}) =>
   Object.assign(
     {
@@ -338,32 +413,8 @@ export const mockAnalysis = (modifications = {}) =>
                 all: [],
               },
             },
-            feature_c: {
-              absolute: {
-                first: {
-                  point: 0.05,
-                  count: 10,
-                  lower: 0.024357271316207685,
-                  upper: 0.08411463700173483,
-                },
-                all: [
-                  {
-                    point: 0.05,
-                    count: 10,
-                    lower: 0.024357271316207685,
-                    upper: 0.08411463700173483,
-                  },
-                ],
-              },
-              difference: {
-                first: {},
-                all: [],
-              },
-              relative_uplift: {
-                first: {},
-                all: [],
-              },
-            },
+            feature_c: CONTROL_NEUTRAL,
+            days_of_use: CONTROL_NEUTRAL,
             feature_d: {
               absolute: {
                 first: {
@@ -747,53 +798,8 @@ export const mockAnalysis = (modifications = {}) =>
               },
               significance: "neutral",
             },
-            feature_c: {
-              absolute: {
-                first: {
-                  point: 0.049019607843137254,
-                  count: 10,
-                  lower: 0.023872203557007872,
-                  upper: 0.08249069209461024,
-                },
-                all: [
-                  {
-                    point: 0.049019607843137254,
-                    count: 10,
-                    lower: 0.023872203557007872,
-                    upper: 0.08249069209461024,
-                  },
-                ],
-              },
-              difference: {
-                first: {
-                  point: -0.0006569487628876534,
-                  upper: 0.04316381736512019,
-                  lower: 0.04175095963994029,
-                },
-                all: [
-                  {
-                    point: -0.0006569487628876534,
-                    upper: 0.04316381736512019,
-                    lower: 0.04175095963994029,
-                  },
-                ],
-              },
-              relative_uplift: {
-                first: {
-                  lower: -0.455210299676828,
-                  upper: 0.5104985718410426,
-                  point: -0.06233954570562385,
-                },
-                all: [
-                  {
-                    lower: -0.455210299676828,
-                    upper: 0.5104985718410426,
-                    point: -0.06233954570562385,
-                  },
-                ],
-              },
-              significance: "neutral",
-            },
+            feature_c: TREATMENT_NEUTRAL,
+            days_of_use: TREATMENT_NEUTRAL,
             feature_d: {
               absolute: {
                 first: {

--- a/app/experimenter/nimbus-ui/src/lib/visualization/utils.tsx
+++ b/app/experimenter/nimbus-ui/src/lib/visualization/utils.tsx
@@ -24,6 +24,7 @@ export const getTableDisplayType = (
       displayType = DISPLAY_TYPE.POPULATION;
       break;
     case METRIC.SEARCH:
+    case METRIC.DAYS_OF_USE:
       if (tableLabel === TABLE_LABEL.RESULTS || isControl) {
         displayType = DISPLAY_TYPE.COUNT;
         break;

--- a/app/experimenter/visualization/api/v3/views.py
+++ b/app/experimenter/visualization/api/v3/views.py
@@ -24,6 +24,7 @@ class BranchComparison:
 class Metric:
     RETENTION = "retained"
     SEARCH = "search_count"
+    DAYS_OF_USE = "days_of_use"
     USER_COUNT = "identity"
 
 
@@ -52,6 +53,7 @@ def get_results_metrics_map(primary_probe_sets, secondary_probe_sets):
     RESULTS_METRICS_MAP = {
         Metric.RETENTION: set([Statistic.BINOMIAL]),
         Metric.SEARCH: set([Statistic.MEAN]),
+        Metric.DAYS_OF_USE: set([Statistic.MEAN]),
         Metric.USER_COUNT: set([Statistic.COUNT, Statistic.PERCENT]),
     }
     primary_metrics_set = set()


### PR DESCRIPTION
Because:
* Days of use is a newly added guardrail metric

This commit:
* Processes it as one