### PR TITLE
fixes #4355 fix(nimbus): Validate branch names for uniqueness server-side

### DIFF
--- a/app/experimenter/experiments/constants/nimbus.py
+++ b/app/experimenter/experiments/constants/nimbus.py
@@ -204,3 +204,6 @@ Optional - We believe this outcome will <describe impact> on <core metric>
     MAX_PRIMARY_PROBE_SETS = 2
     DEFAULT_PROPOSED_DURATION = 28
     DEFAULT_PROPOSED_ENROLLMENT = 7
+
+    # Serializer validation errors
+    ERROR_DUPLICATE_BRANCH_NAME = "Branch names must be unique."


### PR DESCRIPTION
Because:
* We want a human-friendly error message when duplicate branch names are present

This commit:
* Adds a validation function checking for branch name duplicates in the serializer and returns an error message if branch names are not all unique

Co-authored-by: Jared Lockhart <119884+jaredlockhart@users.noreply.github.com>