### PR TITLE
fixes #4542 fix(nimbus): remove targeting from experiment data if unset

### DIFF
--- a/app/experimenter/experiments/api/v6/serializers.py
+++ b/app/experimenter/experiments/api/v6/serializers.py
@@ -99,6 +99,17 @@ class NimbusExperimentSerializer(serializers.ModelSerializer):
             "featureIds",
         )
 
+    def to_representation(self, instance):
+        representation = super(NimbusExperimentSerializer, self).to_representation(
+            instance
+        )
+
+        # issue #4542: remove targeting altogether, if it's None
+        if representation["targeting"] is None:
+            representation.pop("targeting")
+
+        return representation
+
     def get_application(self, obj):
         return self.get_appId(obj)
 
@@ -142,6 +153,9 @@ class NimbusExperimentSerializer(serializers.ModelSerializer):
         # TODO: Remove opt-out after Firefox 84 is the earliest supported Desktop
         if obj.is_desktop_experiment:
             exprs.append("'app.shield.optoutstudies.enabled'|preferenceValue")
+
+        if len(exprs) == 0:
+            return None
 
         return " && ".join(exprs)
 

--- a/app/experimenter/experiments/tests/api/v6/test_serializers.py
+++ b/app/experimenter/experiments/tests/api/v6/test_serializers.py
@@ -264,7 +264,7 @@ class TestNimbusExperimentSerializer(TestCase):
         )
 
         serializer = NimbusExperimentSerializer(experiment)
-        self.assertEqual(serializer.data["targeting"], "")
+        self.assertTrue("targeting" not in serializer.data)
         check_schema("experiments/NimbusExperiment", serializer.data)
 
     def test_serializer_outputs_targeting_for_experiment_without_firefox_min_version(


### PR DESCRIPTION
Because:

- an empty string for targeting is problematic

This commit:

- removes the targeting property altogether if none is set