### PR TITLE
fixes #4425 feat(nimbus): add end experiment UI

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/Summary/EndExperiment/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/EndExperiment/index.stories.tsx
@@ -1,0 +1,42 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { storiesOf } from "@storybook/react";
+import React from "react";
+import EndExperiment from ".";
+import { END_EXPERIMENT_MUTATION } from "../../../gql/experiments";
+import { getStatus } from "../../../lib/experiment";
+import {
+  MockedCache,
+  mockExperimentMutation,
+  mockExperimentQuery,
+} from "../../../lib/mocks";
+import { NimbusExperimentStatus } from "../../../types/globalTypes";
+
+storiesOf("components/Summary/EndExperiment", module)
+  .add("status: live", () => <Subject />)
+  .add("status: ending", () => <Subject ending />);
+
+const Subject = ({ ending = false }: { ending?: boolean }) => {
+  const { experiment } = mockExperimentQuery("demo-slug", {
+    status: NimbusExperimentStatus.LIVE,
+    isEndRequested: ending,
+  });
+  const experimentStatus = getStatus(experiment);
+  const mutationMock = mockExperimentMutation(
+    END_EXPERIMENT_MUTATION,
+    {
+      id: experiment.id!,
+    },
+    "endExperiment",
+  );
+
+  return (
+    <MockedCache mocks={[mutationMock]}>
+      <div className="container-lg py-5">
+        <EndExperiment {...{ experiment, status: experimentStatus }} />
+      </div>
+    </MockedCache>
+  );
+};

--- a/app/experimenter/nimbus-ui/src/components/Summary/EndExperiment/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/EndExperiment/index.test.tsx
@@ -1,0 +1,111 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import React from "react";
+import EndExperiment from ".";
+import { END_EXPERIMENT_MUTATION } from "../../../gql/experiments";
+import { getStatus } from "../../../lib/experiment";
+import {
+  MockedCache,
+  mockExperimentMutation,
+  mockExperimentQuery,
+} from "../../../lib/mocks";
+import { getExperiment } from "../../../types/getExperiment";
+import { NimbusExperimentStatus } from "../../../types/globalTypes";
+
+describe("EndExperiment", () => {
+  it("displays the end button when experiment is live", async () => {
+    render(<Subject experiment={{}} />);
+    await screen.findByTestId("end-experiment-start");
+  });
+
+  it("displays the ending UI when the experiment is ending", async () => {
+    render(
+      <Subject
+        experiment={{
+          isEndRequested: true,
+        }}
+      />,
+    );
+    await screen.findByTestId("experiment-ended-alert");
+  });
+
+  it("can start to but then cancel ending an experiment", async () => {
+    render(<Subject />);
+
+    const startEnd = await screen.findByTestId("end-experiment-start");
+    fireEvent.click(startEnd);
+    await screen.findByTestId("end-experiment-alert");
+
+    const cancelEnd = await screen.findByTestId("end-experiment-cancel");
+    fireEvent.click(cancelEnd);
+
+    await screen.findByTestId("end-experiment-start");
+  });
+
+  it("can correctly end an experiment", async () => {
+    render(<Subject withEndMock />);
+
+    const startEnd = await screen.findByTestId("end-experiment-start");
+    fireEvent.click(startEnd);
+    await screen.findByTestId("end-experiment-alert");
+
+    const confirmEnd = await screen.findByTestId("end-experiment-confirm");
+    fireEvent.click(confirmEnd);
+    await screen.findByTestId("experiment-ended-alert");
+  });
+
+  it("shows an error when something went wrong", async () => {
+    render(<Subject withEndMock withMockedError />);
+
+    const startEnd = await screen.findByTestId("end-experiment-start");
+    fireEvent.click(startEnd);
+    await screen.findByTestId("end-experiment-alert");
+
+    const confirmEnd = await screen.findByTestId("end-experiment-confirm");
+    fireEvent.click(confirmEnd);
+
+    await screen.findByTestId("experiment-end-error");
+  });
+});
+
+const Subject = ({
+  experiment: overrides = {},
+  withEndMock = false,
+  withMockedError = false,
+}: {
+  experiment?: Partial<getExperiment["experimentBySlug"]>;
+  withEndMock?: boolean;
+  withMockedError?: boolean;
+}) => {
+  const { experiment } = mockExperimentQuery("demo-slug", {
+    status: NimbusExperimentStatus.LIVE,
+    ...overrides,
+  });
+  const status = getStatus(experiment);
+
+  const mocks = [];
+  if (withEndMock) {
+    const mock = mockExperimentMutation(
+      END_EXPERIMENT_MUTATION,
+      {
+        id: experiment.id!,
+      },
+      "endExperiment",
+    );
+
+    if (withMockedError) {
+      mock.result.data["endExperiment"].message = "No can do";
+    }
+
+    mocks.push(mock);
+  }
+
+  return (
+    <MockedCache {...{ mocks }}>
+      <EndExperiment {...{ experiment, status }} />
+    </MockedCache>
+  );
+};

--- a/app/experimenter/nimbus-ui/src/components/Summary/EndExperiment/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/EndExperiment/index.tsx
@@ -1,0 +1,124 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { useMutation } from "@apollo/client";
+import React, { useCallback, useState } from "react";
+import { Alert, Button } from "react-bootstrap";
+import { END_EXPERIMENT_MUTATION } from "../../../gql/experiments";
+import { SUBMIT_ERROR } from "../../../lib/constants";
+import { getStatus } from "../../../lib/experiment";
+import { endExperiment_endExperiment as EndExperimentResult } from "../../../types/endExperiment";
+import { getExperiment_experimentBySlug } from "../../../types/getExperiment";
+import { ExperimentIdInput } from "../../../types/globalTypes";
+
+const EndExperiment = ({
+  experiment,
+  status,
+}: {
+  experiment: getExperiment_experimentBySlug;
+  status: ReturnType<typeof getStatus>;
+}) => {
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const [showEndConfirmation, setShowEndConfirmation] = useState(false);
+  const [endRequested, setEndRequested] = useState(false);
+  const isEnding = status.ending || endRequested;
+
+  const [endExperiment, { loading: endExperimentLoading }] = useMutation<
+    { endExperiment: EndExperimentResult },
+    { input: ExperimentIdInput }
+  >(END_EXPERIMENT_MUTATION);
+
+  const toggleShowEndConfirmation = useCallback(
+    () => setShowEndConfirmation(!showEndConfirmation),
+    [showEndConfirmation, setShowEndConfirmation],
+  );
+
+  const onConfirmEndClicked = useCallback(async () => {
+    try {
+      const result = await endExperiment({
+        variables: {
+          input: {
+            id: experiment.id,
+          },
+        },
+      });
+
+      if (
+        !result.data?.endExperiment ||
+        result.data.endExperiment.message !== "success"
+      ) {
+        throw new Error(SUBMIT_ERROR);
+      }
+
+      setEndRequested(true);
+    } catch (error) {
+      setSubmitError(SUBMIT_ERROR);
+    }
+  }, [experiment, endExperiment, setEndRequested]);
+
+  if (submitError) {
+    return (
+      <Alert
+        className="mb-4"
+        variant="warning"
+        data-testid="experiment-end-error"
+      >
+        {submitError}
+      </Alert>
+    );
+  }
+
+  return (
+    <div className="mb-4" data-testid="experiment-end">
+      {isEnding ? (
+        <Alert variant="warning" data-testid="experiment-ended-alert">
+          Users will no longer see the experiment once ending is approved in
+          Remote Settings, and is in &quot;Complete&quot; state.
+        </Alert>
+      ) : (
+        <>
+          {showEndConfirmation ? (
+            <Alert variant="warning" data-testid="end-experiment-alert">
+              <p>
+                Are you sure you want to end your experiment? It will turn off
+                the experiment for all users in production.
+              </p>
+
+              <div>
+                <Button
+                  variant="primary"
+                  onClick={onConfirmEndClicked}
+                  disabled={endExperimentLoading}
+                  data-testid="end-experiment-confirm"
+                >
+                  Yes, end the experiment
+                </Button>
+
+                <Button
+                  variant="secondary"
+                  className="ml-2"
+                  onClick={toggleShowEndConfirmation}
+                  disabled={endExperimentLoading}
+                  data-testid="end-experiment-cancel"
+                >
+                  Cancel
+                </Button>
+              </div>
+            </Alert>
+          ) : (
+            <Button
+              variant="primary"
+              onClick={toggleShowEndConfirmation}
+              data-testid="end-experiment-start"
+            >
+              End Experiment
+            </Button>
+          )}
+        </>
+      )}
+    </div>
+  );
+};
+
+export default EndExperiment;

--- a/app/experimenter/nimbus-ui/src/components/Summary/SummaryTimeline/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/SummaryTimeline/index.tsx
@@ -18,7 +18,7 @@ const SummaryTimeline = ({
   const status = getStatus(experiment);
 
   return (
-    <div className="mb-5" data-testid="summary-timeline">
+    <div className="mb-4" data-testid="summary-timeline">
       <StartEnd
         {...{
           status,

--- a/app/experimenter/nimbus-ui/src/components/Summary/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/index.stories.tsx
@@ -2,10 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import { MockedResponse } from "@apollo/client/testing";
 import { storiesOf } from "@storybook/react";
 import React from "react";
 import Summary from ".";
-import { mockExperimentQuery } from "../../lib/mocks";
+import { END_EXPERIMENT_MUTATION } from "../../gql/experiments";
+import { mockExperimentMutation, mockExperimentQuery } from "../../lib/mocks";
 import { RouterSlugProvider } from "../../lib/test-utils";
 import { getExperiment_experimentBySlug } from "../../types/getExperiment";
 import { NimbusExperimentStatus } from "../../types/globalTypes";
@@ -22,6 +24,26 @@ storiesOf("components/Summary", module)
     });
     return <Subject {...{ experiment }} />;
   })
+  .add("live status", () => {
+    const { experiment } = mockExperimentQuery("demo-slug", {
+      status: NimbusExperimentStatus.LIVE,
+    });
+    const mutationMock = mockExperimentMutation(
+      END_EXPERIMENT_MUTATION,
+      {
+        id: experiment.id!,
+      },
+      "endExperiment",
+    );
+    return <Subject {...{ experiment, mocks: [mutationMock] }} />;
+  })
+  .add("end requested", () => {
+    const { experiment } = mockExperimentQuery("demo-slug", {
+      status: NimbusExperimentStatus.LIVE,
+      isEndRequested: true,
+    });
+    return <Subject {...{ experiment }} />;
+  })
   .add("no branches", () => {
     const { experiment } = mockExperimentQuery("demo-slug", {
       referenceBranch: null,
@@ -32,11 +54,13 @@ storiesOf("components/Summary", module)
 
 const Subject = ({
   experiment,
+  mocks = [],
 }: {
   experiment: getExperiment_experimentBySlug;
+  mocks?: MockedResponse<Record<string, any>>[];
 }) => (
   <AppLayout>
-    <RouterSlugProvider>
+    <RouterSlugProvider {...{ mocks }}>
       <Summary {...{ experiment }} />
     </RouterSlugProvider>
   </AppLayout>

--- a/app/experimenter/nimbus-ui/src/components/Summary/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/index.test.tsx
@@ -14,12 +14,21 @@ describe("Summary", () => {
     const { experiment } = mockExperimentQuery("demo-slug");
     render(<Subject {...{ experiment }} />);
     expect(screen.getByTestId("summary-timeline")).toBeInTheDocument();
+    expect(screen.queryByTestId("experiment-end")).not.toBeInTheDocument();
     expect(screen.getByTestId("table-summary")).toBeInTheDocument();
     expect(screen.getByTestId("table-audience")).toBeInTheDocument();
     expect(screen.queryAllByTestId("table-branch")).toHaveLength(2);
     expect(screen.getByTestId("branches-section-title")).toHaveTextContent(
       "Branches (2)",
     );
+  });
+
+  it("renders end experiment component if experiment is live", async () => {
+    const { experiment } = mockExperimentQuery("demo-slug", {
+      status: NimbusExperimentStatus.LIVE,
+    });
+    render(<Subject {...{ experiment }} />);
+    expect(screen.queryByTestId("experiment-end")).toBeInTheDocument();
   });
 
   it("renders as expected with no defined branches", () => {

--- a/app/experimenter/nimbus-ui/src/components/Summary/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/index.tsx
@@ -10,6 +10,7 @@ import { getExperiment_experimentBySlug } from "../../types/getExperiment";
 import LinkExternal from "../LinkExternal";
 import LinkMonitoring from "../LinkMonitoring";
 import NotSet from "../NotSet";
+import EndExperiment from "./EndExperiment";
 import SummaryTimeline from "./SummaryTimeline";
 import TableAudience from "./TableAudience";
 import TableBranches from "./TableBranches";
@@ -28,9 +29,13 @@ const Summary = ({ experiment }: SummaryProps) => {
 
   return (
     <div data-testid="summary">
-      <LinkMonitoring {...experiment} />
       <h2 className="h5 mb-3">Timeline</h2>
       <SummaryTimeline {...{ experiment }} />
+      {status.live && <EndExperiment {...{ experiment, status }} />}
+
+      <hr />
+
+      <LinkMonitoring {...experiment} />
 
       <div className="d-flex flex-row justify-content-between">
         <h2 className="h5 mb-3">Summary</h2>

--- a/app/experimenter/nimbus-ui/src/gql/experiments.ts
+++ b/app/experimenter/nimbus-ui/src/gql/experiments.ts
@@ -88,6 +88,15 @@ export const UPDATE_EXPERIMENT_PROBESETS_MUTATION = gql`
   }
 `;
 
+export const END_EXPERIMENT_MUTATION = gql`
+  mutation endExperiment($input: ExperimentIdInput!) {
+    endExperiment(input: $input) {
+      message
+      status
+    }
+  }
+`;
+
 export const UPDATE_EXPERIMENT_AUDIENCE_MUTATION = gql`
   mutation updateExperimentAudience($input: ExperimentInput!) {
     updateExperiment(input: $input) {
@@ -115,6 +124,7 @@ export const GET_EXPERIMENT_QUERY = gql`
       slug
       status
       monitoringDashboardUrl
+      isEndRequested
 
       hypothesis
       application
@@ -205,6 +215,7 @@ export const GET_EXPERIMENTS_QUERY = gql`
       proposedEnrollment
       endDate
       status
+      isEndRequested
       monitoringDashboardUrl
       featureConfig {
         slug

--- a/app/experimenter/nimbus-ui/src/lib/experiment.test.ts
+++ b/app/experimenter/nimbus-ui/src/lib/experiment.test.ts
@@ -29,5 +29,8 @@ describe("getStatus", () => {
     expect(getStatus(experiment).complete).toBeTruthy();
     expect(getStatus(experiment).released).toBeTruthy();
     expect(getStatus(experiment).locked).toBeTruthy();
+
+    experiment.isEndRequested = true;
+    expect(getStatus(experiment).ending).toBeTruthy();
   });
 });

--- a/app/experimenter/nimbus-ui/src/lib/experiment.ts
+++ b/app/experimenter/nimbus-ui/src/lib/experiment.ts
@@ -10,7 +10,7 @@ export function getStatus(
   experiment?: getExperiment_experimentBySlug | getAllExperiments_experiments,
 ) {
   const status = experiment?.status;
-
+  const ending = NimbusExperimentStatus.LIVE && !!experiment?.isEndRequested;
   const released = status
     ? [NimbusExperimentStatus.LIVE, NimbusExperimentStatus.COMPLETE].includes(
         status,
@@ -35,6 +35,7 @@ export function getStatus(
     ].includes(status!),
     // The experiment is or was out in the wild (live or complete)
     released,
+    ending,
   };
 }
 

--- a/app/experimenter/nimbus-ui/src/lib/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/lib/mocks.tsx
@@ -295,6 +295,7 @@ export function mockExperimentQuery<
       name: "Open-architected background installation",
       slug,
       status: "DRAFT",
+      isEndRequested: false,
       monitoringDashboardUrl: "https://grafana.telemetry.mozilla.org",
       hypothesis: "Realize material say pretty.",
       application: "DESKTOP",
@@ -398,13 +399,16 @@ export const mockExperimentMutation = (
   input: ExperimentInput,
   key: string,
   {
-    status = 200,
-    message = "success",
+    status,
+    message,
     experiment,
   }: {
     status?: number;
     message?: string | Record<string, any>;
     experiment?: Record<string, any> | null;
+  } = {
+    status: 200,
+    message: "success",
   },
 ) => {
   return {
@@ -459,6 +463,7 @@ export function mockSingleDirectoryExperiment(
     proposedDuration: 28,
     startDate: fiveDaysAgo.toISOString(),
     endDate: new Date(Date.now() + 12096e5).toISOString(),
+    isEndRequested: false,
     ...overrides,
   };
 }

--- a/app/experimenter/nimbus-ui/src/types/endExperiment.ts
+++ b/app/experimenter/nimbus-ui/src/types/endExperiment.ts
@@ -1,0 +1,24 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+import { ExperimentIdInput } from "./globalTypes";
+
+// ====================================================
+// GraphQL mutation operation: endExperiment
+// ====================================================
+
+export interface endExperiment_endExperiment {
+  __typename: "EndExperiment";
+  message: ObjectField | null;
+  status: number | null;
+}
+
+export interface endExperiment {
+  endExperiment: endExperiment_endExperiment | null;
+}
+
+export interface endExperimentVariables {
+  input: ExperimentIdInput;
+}

--- a/app/experimenter/nimbus-ui/src/types/getAllExperiments.ts
+++ b/app/experimenter/nimbus-ui/src/types/getAllExperiments.ts
@@ -30,6 +30,7 @@ export interface getAllExperiments_experiments {
   proposedEnrollment: number;
   endDate: DateTime | null;
   status: NimbusExperimentStatus | null;
+  isEndRequested: boolean;
   monitoringDashboardUrl: string | null;
   featureConfig: getAllExperiments_experiments_featureConfig | null;
 }

--- a/app/experimenter/nimbus-ui/src/types/getExperiment.ts
+++ b/app/experimenter/nimbus-ui/src/types/getExperiment.ts
@@ -78,6 +78,7 @@ export interface getExperiment_experimentBySlug {
   slug: string;
   status: NimbusExperimentStatus | null;
   monitoringDashboardUrl: string | null;
+  isEndRequested: boolean;
   hypothesis: string;
   application: NimbusExperimentApplication | null;
   publicDescription: string;

--- a/app/experimenter/nimbus-ui/src/types/globalTypes.ts
+++ b/app/experimenter/nimbus-ui/src/types/globalTypes.ts
@@ -89,6 +89,10 @@ export interface DocumentationLinkType {
   link: string;
 }
 
+export interface ExperimentIdInput {
+  id?: number | null;
+}
+
 export interface ExperimentInput {
   id?: number | null;
   status?: NimbusExperimentStatus | null;


### PR DESCRIPTION
This PR adds the UI to request the end of an Experiment, including the initial button to end, the confirmation dialogue, and the "is ending" dialogue.

Storybook:

- [Summary page with LIVE experiment](https://storage.googleapis.com/mozilla-storybooks-experimenter/commits/5aee79269523d72af18e100fec17c2299b542a05/nimbus-ui/index.html?path=/story/components-summary--live-status)
- [Summary page with ENDING experiment](https://storage.googleapis.com/mozilla-storybooks-experimenter/commits/5aee79269523d72af18e100fec17c2299b542a05/nimbus-ui/index.html?path=/story/components-summary--end-requested)