### PR TITLE
fixes #4547 feat(Legacy) added projects to v1 api

### DIFF
--- a/app/experimenter/experiments/api/v1/serializers.py
+++ b/app/experimenter/experiments/api/v1/serializers.py
@@ -111,6 +111,7 @@ class ExperimentSerializer(serializers.ModelSerializer):
     changes = ExperimentChangeLogSerializer(many=True)
     results = serializers.SerializerMethodField()
     normandy_slug = serializers.CharField(source="recipe_slug")
+    projects = serializers.SerializerMethodField()
 
     class Meta:
         model = Experiment
@@ -147,7 +148,11 @@ class ExperimentSerializer(serializers.ModelSerializer):
             "variants",
             "results",
             "changes",
+            "projects",
         )
 
     def get_results(self, obj):
         return ResultsSerializer(obj).data
+
+    def get_projects(self, obj):
+        return list(obj.projects.values_list("name", flat=True))

--- a/app/experimenter/experiments/tests/api/v1/test_serializers.py
+++ b/app/experimenter/experiments/tests/api/v1/test_serializers.py
@@ -153,6 +153,7 @@ class TestExperimentSerializer(TestCase):
                 "results_measure_impact": None,
                 "results_impact_notes": None,
             },
+            "projects": list(experiment.projects.values_list("name", flat=True)),
         }
 
         self.assertEqual(set(serializer.data.keys()), set(expected_data.keys()))


### PR DESCRIPTION
Because:

* this will allow sources to consume project info for experiments

This Commit:

* adds projects to the v1 experiments api