### PR TITLE
fixes #4551 fix(nimbus): Allow the JSON link to show up during REVIEW

### DIFF
--- a/app/experimenter/experiments/api/v6/views.py
+++ b/app/experimenter/experiments/api/v6/views.py
@@ -14,7 +14,7 @@ class NimbusExperimentViewSet(
 ):
     lookup_field = "slug"
     queryset = NimbusExperiment.objects.all().exclude(
-        status__in=[NimbusExperiment.Status.DRAFT, NimbusExperiment.Status.REVIEW]
+        status__in=[NimbusExperiment.Status.DRAFT]
     )
     serializer_class = NimbusExperimentSerializer
 

--- a/app/experimenter/nimbus-ui/src/components/Summary/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/index.test.tsx
@@ -40,31 +40,32 @@ describe("Summary", () => {
   });
 
   describe("JSON representation link", () => {
-    it("renders when status is not 'draft' or 'review'", () => {
+    function renderWithStatus(status: NimbusExperimentStatus) {
       const { experiment } = mockExperimentQuery("demo-slug", {
-        status: NimbusExperimentStatus.ACCEPTED,
+        status,
       });
       render(<Subject {...{ experiment }} />);
+    }
+    it("renders with the correct API link", () => {
+      renderWithStatus(NimbusExperimentStatus.LIVE);
       expect(screen.getByTestId("link-json")).toBeInTheDocument();
       expect(screen.getByTestId("link-json")).toHaveAttribute(
         "href",
         "/api/v6/experiments/demo-slug/",
       );
     });
-  });
-
-  it("does not render in 'draft' status", () => {
-    const { experiment } = mockExperimentQuery("demo-slug");
-    render(<Subject {...{ experiment }} />);
-    expect(screen.queryByTestId("link-json")).not.toBeInTheDocument();
-  });
-
-  it("does not render in 'review' status", () => {
-    const { experiment } = mockExperimentQuery("demo-slug", {
-      status: NimbusExperimentStatus.REVIEW,
+    it("renders when status is 'review'", () => {
+      renderWithStatus(NimbusExperimentStatus.REVIEW);
+      expect(screen.queryByTestId("link-json")).toBeInTheDocument();
     });
-    render(<Subject {...{ experiment }} />);
-    expect(screen.queryByTestId("link-json")).not.toBeInTheDocument();
+    it("renders when status is 'accepted'", () => {
+      renderWithStatus(NimbusExperimentStatus.ACCEPTED);
+      expect(screen.queryByTestId("link-json")).toBeInTheDocument();
+    });
+    it("does not render in 'draft' status", () => {
+      renderWithStatus(NimbusExperimentStatus.DRAFT);
+      expect(screen.queryByTestId("link-json")).not.toBeInTheDocument();
+    });
   });
 });
 

--- a/app/experimenter/nimbus-ui/src/components/Summary/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/index.tsx
@@ -34,7 +34,7 @@ const Summary = ({ experiment }: SummaryProps) => {
 
       <div className="d-flex flex-row justify-content-between">
         <h2 className="h5 mb-3">Summary</h2>
-        {!status.draft && !status.review && (
+        {!status.draft && (
           <span>
             <LinkExternal
               href={`/api/v6/experiments/${experiment.slug}/`}


### PR DESCRIPTION
Because

* It will make it easier to get access to the JSON for testing via staging

This commit

* Add JSON link to summary view for REVIEW status