### PR TITLE
fixes #4490 feat(nimbus): redirect away from edit pages when experiment is in preview state

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/PageEditAudience/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditAudience/index.test.tsx
@@ -97,6 +97,22 @@ describe("PageEditAudience", () => {
     });
   });
 
+  it("redirects to the review page if the experiment status is preview", async () => {
+    const { mock, experiment } = mockExperimentQuery("demo-slug", {
+      // @ts-ignore EXP-879 mock value until backend API & types are updated
+      status: NimbusExperimentStatus.PREVIEW,
+    });
+    render(<Subject mocks={[mock]} />);
+    await waitFor(() => {
+      expect(navigate).toHaveBeenCalledWith(
+        `${BASE_PATH}/${experiment.slug}/request-review`,
+        {
+          replace: true,
+        },
+      );
+    });
+  });
+
   it("redirects to the design page if the experiment status is complete", async () => {
     const { mock, experiment } = mockExperimentQuery("demo-slug", {
       status: NimbusExperimentStatus.COMPLETE,

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/index.test.tsx
@@ -60,6 +60,22 @@ describe("PageEditBranches", () => {
     });
   });
 
+  it("redirects to the review page if the experiment status is preview", async () => {
+    const { mock, experiment } = mockExperimentQuery("demo-slug", {
+      // @ts-ignore EXP-879 mock value until backend API & types are updated
+      status: NimbusExperimentStatus.PREVIEW,
+    });
+    render(<Subject mocks={[mock]} />);
+    await waitFor(() => {
+      expect(navigate).toHaveBeenCalledWith(
+        `${BASE_PATH}/${experiment.slug}/request-review`,
+        {
+          replace: true,
+        },
+      );
+    });
+  });
+
   it("redirects to the design page if the experiment status is live", async () => {
     const { mock, experiment } = mockExperimentQuery("demo-slug", {
       status: NimbusExperimentStatus.LIVE,

--- a/app/experimenter/nimbus-ui/src/components/PageEditMetrics/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditMetrics/index.test.tsx
@@ -113,6 +113,22 @@ describe("PageEditMetrics", () => {
     });
   });
 
+  it("redirects to the review page if the experiment status is preview", async () => {
+    const { mock, experiment } = mockExperimentQuery("demo-slug", {
+      // @ts-ignore EXP-879 mock value until backend API & types are updated
+      status: NimbusExperimentStatus.PREVIEW,
+    });
+    render(<Subject mocks={[mock]} />);
+    await waitFor(() => {
+      expect(navigate).toHaveBeenCalledWith(
+        `${BASE_PATH}/${experiment.slug}/request-review`,
+        {
+          replace: true,
+        },
+      );
+    });
+  });
+
   it("redirects to the design page if the experiment status is live", async () => {
     const { mock, experiment } = mockExperimentQuery("demo-slug", {
       status: NimbusExperimentStatus.LIVE,

--- a/app/experimenter/nimbus-ui/src/components/PageEditOverview/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditOverview/index.test.tsx
@@ -94,6 +94,22 @@ describe("PageEditOverview", () => {
     });
   });
 
+  it("redirects to the review page if the experiment status is preview", async () => {
+    const { mock, experiment } = mockExperimentQuery("demo-slug", {
+      // @ts-ignore EXP-879 mock value until backend API & types are updated
+      status: NimbusExperimentStatus.PREVIEW,
+    });
+    render(<Subject mocks={[mock]} />);
+    await waitFor(() => {
+      expect(navigate).toHaveBeenCalledWith(
+        `${BASE_PATH}/${experiment.slug}/request-review`,
+        {
+          replace: true,
+        },
+      );
+    });
+  });
+
   it("redirects to the design page if the experiment status is live", async () => {
     const { mock, experiment } = mockExperimentQuery("demo-slug", {
       status: NimbusExperimentStatus.LIVE,

--- a/app/experimenter/nimbus-ui/src/lib/experiment.ts
+++ b/app/experimenter/nimbus-ui/src/lib/experiment.ts
@@ -41,7 +41,7 @@ export function getStatus(
 export type StatusCheck = ReturnType<typeof getStatus>;
 
 export function editCommonRedirects({ status }: { status: StatusCheck }) {
-  if (status.review) {
+  if (status.review || status.preview) {
     return "request-review";
   }
 


### PR DESCRIPTION
Closes #4490 

This PR implements redirecting away from experiment Edit pages while an experiment is in a "preview" state.

It also includes some @ts-ignores until #4498 is complete, similar to how we roughed out the UI.