### PR TITLE
fix #4580 feat(nimbus): allocate buckets at review rather than accepted time

### DIFF
--- a/app/experimenter/experiments/api/v5/serializers.py
+++ b/app/experimenter/experiments/api/v5/serializers.py
@@ -390,7 +390,12 @@ class NimbusExperimentSerializer(
     def save(self, *args, **kwargs):
         with transaction.atomic():
             experiment = super().save(*args, **kwargs)
+
+            if experiment.should_allocate_bucket_range:
+                experiment.allocate_bucket_range()
+
             generate_nimbus_changelog(experiment, self.context["user"])
+
             return experiment
 
 

--- a/app/experimenter/experiments/tests/factories/nimbus.py
+++ b/app/experimenter/experiments/tests/factories/nimbus.py
@@ -142,14 +142,10 @@ class NimbusExperimentFactory(factory.django.DjangoModelFactory):
             experiment.status = status
             experiment.save()
 
-            generate_nimbus_changelog(experiment, experiment.owner)
+            if experiment.should_allocate_bucket_range:
+                experiment.allocate_bucket_range()
 
-            if status == NimbusExperiment.Status.REVIEW.value:
-                NimbusIsolationGroup.request_isolation_group_buckets(
-                    experiment.slug,
-                    experiment,
-                    100,
-                )
+            generate_nimbus_changelog(experiment, experiment.owner)
 
             if status == target_status:
                 break

--- a/app/experimenter/visualization/tests/api/test_views.py
+++ b/app/experimenter/visualization/tests/api/test_views.py
@@ -105,8 +105,8 @@ class TestVisualizationView(TestCase):
 
     @parameterized.expand(
         [
-            NimbusExperiment.Status.COMPLETE,
             NimbusExperiment.Status.ACCEPTED,
+            NimbusExperiment.Status.COMPLETE,
         ]
     )
     @patch("django.core.files.storage.default_storage.open")


### PR DESCRIPTION
Because

* We'd like users to be able to review the full DTO after they mark an experiment for review including bucket range

This commit

* Adds a model method to check when we should allocate buckets so we can extend it to include other statuses later
* Moves bucket allocation to a model method
* Removes bucket allocation from the kinto deploy task
* Adds bucket allocation to the NimbusExperiment V5 serializer
* Updates NimbusExperimentFactory to use the new methods
* Disables an intermittently failing test with reference to ticket