### PR TITLE
fix #4581 feat(nimbus): regenerate bucket range allocation every time experiment enters review

### DIFF
--- a/app/experimenter/experiments/models/nimbus.py
+++ b/app/experimenter/experiments/models/nimbus.py
@@ -184,16 +184,17 @@ class NimbusExperiment(NimbusConstants, models.Model):
         return self.status in [NimbusExperiment.Status.REVIEW]
 
     def allocate_bucket_range(self):
-        if not NimbusBucketRange.objects.filter(experiment=self).exists():
-            NimbusIsolationGroup.request_isolation_group_buckets(
-                self.slug,
-                self,
-                int(
-                    self.population_percent
-                    / Decimal("100.0")
-                    * NimbusExperiment.BUCKET_TOTAL
-                ),
-            )
+        existing_bucket_range = NimbusBucketRange.objects.filter(experiment=self)
+        if existing_bucket_range.exists():
+            existing_bucket_range.delete()
+
+        NimbusIsolationGroup.request_isolation_group_buckets(
+            self.slug,
+            self,
+            int(
+                self.population_percent / Decimal("100.0") * NimbusExperiment.BUCKET_TOTAL
+            ),
+        )
 
 
 class NimbusBranch(models.Model):

--- a/app/experimenter/experiments/tests/test_models/test_models_nimbus.py
+++ b/app/experimenter/experiments/tests/test_models/test_models_nimbus.py
@@ -206,6 +206,19 @@ class TestNimbusExperiment(TestCase):
         self.assertEqual(experiment.bucket_range.count, 5000)
         self.assertEqual(experiment.bucket_range.isolation_group.name, experiment.slug)
 
+    def test_allocate_buckets_creates_new_bucket_range_if_population_changes(self):
+        experiment = NimbusExperimentFactory(
+            status=NimbusExperiment.Status.DRAFT, population_percent=Decimal("50.0")
+        )
+        experiment.allocate_bucket_range()
+        self.assertEqual(experiment.bucket_range.count, 5000)
+        self.assertEqual(experiment.bucket_range.isolation_group.name, experiment.slug)
+
+        experiment.population_percent = Decimal("20.0")
+        experiment.allocate_bucket_range()
+        self.assertEqual(experiment.bucket_range.count, 2000)
+        self.assertEqual(experiment.bucket_range.isolation_group.name, experiment.slug)
+
 
 class TestNimbusBranch(TestCase):
     def test_str(self):


### PR DESCRIPTION


Because

* If an experiment is rejected in review, then the population percentage is edited, we need to regenerate the bucket allocation

This commit

* Deletes and recreates the bucket allocation everytime a bucket allocation is requested