### PR TITLE
feat(nimbus): remove limit on home experiment query

### DIFF
--- a/app/experimenter/nimbus-ui/src/gql/experiments.ts
+++ b/app/experimenter/nimbus-ui/src/gql/experiments.ts
@@ -194,7 +194,7 @@ export const GET_EXPERIMENT_QUERY = gql`
 // TODO: Only the first 50 until we add pagination.
 export const GET_EXPERIMENTS_QUERY = gql`
   query getAllExperiments {
-    experiments(limit: 50) {
+    experiments {
       name
       owner {
         username


### PR DESCRIPTION
We're not going to hit any performance issues with the relatively small number of experiments we have, and we'll eventually be updating this page to sort and paginate them. 