### PR TITLE
fixes #4598 feat(nimbus): remove limit, offset, and status filter from experiments query entirely

### DIFF
--- a/app/experimenter/experiments/api/v5/queries.py
+++ b/app/experimenter/experiments/api/v5/queries.py
@@ -6,7 +6,6 @@ from experimenter.experiments.api.v5.types import (
     NimbusLabelValueType,
     NimbusProbeSetType,
 )
-from experimenter.experiments.constants.nimbus import NimbusConstants
 from experimenter.experiments.models.nimbus import (
     NimbusExperiment,
     NimbusFeatureConfig,
@@ -71,11 +70,6 @@ class Query(graphene.ObjectType):
     experiments = graphene.List(
         NimbusExperimentType,
         description="List Nimbus Experiments.",
-        offset=graphene.Int(),
-        limit=graphene.Int(),
-        status=graphene.Enum(
-            "NimbusExperimentOptionalStatus", NimbusConstants.Status.choices
-        )(),
     )
     experiment_by_slug = graphene.Field(
         NimbusExperimentType,
@@ -88,11 +82,8 @@ class Query(graphene.ObjectType):
         description="Nimbus Configuration Data for front-end usage.",
     )
 
-    def resolve_experiments(root, info, offset=0, limit=20, status=None):
-        q = NimbusExperiment.objects.all()
-        if status:
-            q = q.filter(status=status)
-        return q[offset:limit]
+    def resolve_experiments(root, info):
+        return NimbusExperiment.objects.all()
 
     def resolve_experiment_by_slug(root, info, slug):
         try:

--- a/app/experimenter/experiments/tests/api/v5/test_queries.py
+++ b/app/experimenter/experiments/tests/api/v5/test_queries.py
@@ -149,34 +149,6 @@ class TestNimbusQuery(GraphQLTestCase):
                 {getattr(b, key) for b in documentation_links},
             )
 
-    def test_experiments_by_status(self):
-        user_email = "user@example.com"
-        draft_exp = NimbusExperimentFactory.create_with_status(
-            NimbusExperiment.Status.DRAFT
-        )
-        NimbusExperimentFactory.create_with_status(NimbusExperiment.Status.ACCEPTED)
-
-        response = self.query(
-            """
-            query {
-                experiments(status: Draft) {
-                    name
-                    slug
-                    publicDescription
-                }
-            }
-            """,
-            headers={settings.OPENIDC_EMAIL_HEADER: user_email},
-        )
-        self.assertEqual(response.status_code, 200)
-        content = json.loads(response.content)
-        experiments = content["data"]["experiments"]
-        self.assertEqual(len(experiments), 1)
-        for key in experiments[0]:
-            self.assertEqual(
-                experiments[0][key], str(getattr(draft_exp, to_snake_case(key)))
-            )
-
     def test_experiment_by_slug_ready_for_review(self):
         user_email = "user@example.com"
         experiment = NimbusExperimentFactory.create_with_status(

--- a/app/experimenter/nimbus-ui/schema.graphql
+++ b/app/experimenter/nimbus-ui/schema.graphql
@@ -137,14 +137,6 @@ enum NimbusExperimentFirefoxMinVersion {
   FIREFOX_100
 }
 
-enum NimbusExperimentOptionalStatus {
-  Draft
-  Review
-  Accepted
-  Live
-  Complete
-}
-
 type NimbusExperimentOwner {
   id: ID!
   username: String!
@@ -278,7 +270,7 @@ type ProjectType {
 }
 
 type Query {
-  experiments(offset: Int, limit: Int, status: NimbusExperimentOptionalStatus): [NimbusExperimentType]
+  experiments: [NimbusExperimentType]
   experimentBySlug(slug: String!): NimbusExperimentType
   nimbusConfig: NimbusConfigurationType
 }

--- a/app/experimenter/nimbus-ui/src/gql/experiments.ts
+++ b/app/experimenter/nimbus-ui/src/gql/experiments.ts
@@ -191,7 +191,6 @@ export const GET_EXPERIMENT_QUERY = gql`
   }
 `;
 
-// TODO: Only the first 50 until we add pagination.
 export const GET_EXPERIMENTS_QUERY = gql`
   query getAllExperiments {
     experiments {


### PR DESCRIPTION
Closes #4598

We [recently](https://github.com/mozilla/experimenter/pull/4595) removed the limit from the client, but now the default limit of 20 is kicking in. Will eventually be doing all sorting and paginating in the client anyway.