### PR TITLE
fix #4342: feature(visualization) - Incorporate metric metadata from Jetstream.

### DIFF
--- a/app/experimenter/nimbus-ui/package.json
+++ b/app/experimenter/nimbus-ui/package.json
@@ -46,6 +46,7 @@
     "react-dom": "^16.13.1",
     "react-helmet": "^6.1.0",
     "react-hook-form": "^6.12.2",
+    "react-markdown": "^5.0.3",
     "react-scripts": "3.4.0",
     "react-scrollspy": "^3.4.3",
     "react-select": "^3.1.1",

--- a/app/experimenter/nimbus-ui/src/components/AppLayoutSidebarLocked/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/AppLayoutSidebarLocked/index.test.tsx
@@ -51,6 +51,7 @@ const Subject = ({
               daily: [],
               weekly: {},
               overall: mockAnalysis().overall,
+              metadata: mockAnalysis().metadata,
               other_metrics: mockAnalysis().other_metrics,
             }
           : undefined,
@@ -134,7 +135,7 @@ describe("AppLayoutSidebarLocked", () => {
         "Overview",
         "Results Summary",
         "Default Metrics",
-        "Feature D",
+        "Feature D Friendly Name",
       ].forEach((item) => {
         expect(screen.getByText(item)).toBeInTheDocument();
       });

--- a/app/experimenter/nimbus-ui/src/components/AppLayoutSidebarLocked/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/AppLayoutSidebarLocked/index.tsx
@@ -8,7 +8,7 @@ import Scrollspy from "react-scrollspy";
 import { ReactComponent as ChevronLeft } from "../../images/chevron-left.svg";
 import { ReactComponent as Clipboard } from "../../images/clipboard.svg";
 import { StatusCheck } from "../../lib/experiment";
-import { AnalysisData } from "../../lib/visualization/types";
+import { AnalysisData, MetadataPoint } from "../../lib/visualization/types";
 import { analysisAvailable } from "../../lib/visualization/utils";
 import {
   getExperiment_experimentBySlug_primaryProbeSets,
@@ -56,6 +56,19 @@ const probesetToMapping = (
   return newMap;
 };
 
+const otherMetricsToFriendlyName = (
+  otherMetrics: { [metric: string]: string },
+  metricsMetaData: { [metric: string]: MetadataPoint },
+) => {
+  const newMap: { [key: string]: string } = {};
+  Object.keys(otherMetrics).map(
+    (metric) =>
+      (newMap[metric] =
+        metricsMetaData[metric]!.friendly_name || otherMetrics[metric]),
+  );
+  return newMap;
+};
+
 type AppLayoutSidebarLockedProps = {
   testid?: string;
   children: React.ReactNode;
@@ -84,6 +97,11 @@ export const AppLayoutSidebarLocked = ({
   const { slug } = useParams();
   const primaryMetrics = probesetToMapping(primaryProbeSets || []);
   const secondaryMetrics = probesetToMapping(secondaryProbeSets || []);
+  const otherMetrics = otherMetricsToFriendlyName(
+    analysis?.other_metrics || {},
+    analysis?.metadata?.metrics || {},
+  );
+
   const sidebarKeys = [
     "monitoring",
     "overview",
@@ -94,7 +112,7 @@ export const AppLayoutSidebarLocked = ({
     .concat("secondary-metrics")
     .concat(Object.keys(secondaryMetrics || []))
     .concat("default-metrics")
-    .concat(Object.keys(analysis?.other_metrics || []));
+    .concat(Object.keys(otherMetrics || []));
 
   return (
     <Container fluid className="h-100vh" data-testid={testid}>
@@ -160,11 +178,8 @@ export const AppLayoutSidebarLocked = ({
                       getSidebarItems(primaryMetrics, "Primary Metrics")}
                     {Object.keys(secondaryMetrics).length &&
                       getSidebarItems(secondaryMetrics, "Secondary Metrics")}
-                    {analysis?.other_metrics &&
-                      getSidebarItems(
-                        analysis?.other_metrics,
-                        "Default Metrics",
-                      )}
+                    {otherMetrics &&
+                      getSidebarItems(otherMetrics, "Default Metrics")}
                   </Scrollspy>
                 </>
               ) : (

--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableMetricSecondary/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableMetricSecondary/index.stories.tsx
@@ -26,7 +26,7 @@ storiesOf("pages/Results/TableMetricSecondary", module)
       <TableMetricSecondary
         results={mockAnalysis()}
         probeSetSlug={experiment.secondaryProbeSets![0]!.slug}
-        probeSetName={experiment.secondaryProbeSets![0]!.name}
+        probeSetDefaultName={experiment.secondaryProbeSets![0]!.name}
         isDefault={false}
       />
     );
@@ -37,7 +37,7 @@ storiesOf("pages/Results/TableMetricSecondary", module)
       <TableMetricSecondary
         results={mockAnalysis()}
         probeSetSlug={experiment.secondaryProbeSets![0]!.slug}
-        probeSetName={experiment.secondaryProbeSets![0]!.name}
+        probeSetDefaultName={experiment.secondaryProbeSets![0]!.name}
         isDefault={false}
       />
     );
@@ -57,7 +57,7 @@ storiesOf("pages/Results/TableMetricSecondary", module)
       <TableMetricSecondary
         results={mockAnalysis()}
         probeSetSlug={experiment.secondaryProbeSets![0]!.slug}
-        probeSetName={experiment.secondaryProbeSets![0]!.name}
+        probeSetDefaultName={experiment.secondaryProbeSets![0]!.name}
         isDefault={false}
       />
     );

--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableMetricSecondary/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableMetricSecondary/index.test.tsx
@@ -19,7 +19,7 @@ describe("TableMetricSecondary", () => {
         <TableMetricSecondary
           results={mockAnalysis()}
           probeSetSlug={experiment.secondaryProbeSets![0]!.slug}
-          probeSetName={experiment.secondaryProbeSets![0]!.name}
+          probeSetDefaultName={experiment.secondaryProbeSets![0]!.name}
           isDefault={false}
         />
       </RouterSlugProvider>,
@@ -37,7 +37,7 @@ describe("TableMetricSecondary", () => {
         <TableMetricSecondary
           results={mockAnalysis()}
           probeSetSlug={experiment.secondaryProbeSets![0]!.slug}
-          probeSetName={experiment.secondaryProbeSets![0]!.name}
+          probeSetDefaultName={experiment.secondaryProbeSets![0]!.name}
           isDefault={false}
         />
       </RouterSlugProvider>,
@@ -58,7 +58,7 @@ describe("TableMetricSecondary", () => {
         <TableMetricSecondary
           results={mockAnalysis()}
           probeSetSlug={experiment.secondaryProbeSets![0]!.slug}
-          probeSetName={experiment.secondaryProbeSets![0]!.name}
+          probeSetDefaultName={experiment.secondaryProbeSets![0]!.name}
           isDefault={false}
         />
       </RouterSlugProvider>,
@@ -75,7 +75,7 @@ describe("TableMetricSecondary", () => {
         <TableMetricSecondary
           results={mockAnalysis()}
           probeSetSlug={experiment.secondaryProbeSets![0]!.slug}
-          probeSetName={experiment.secondaryProbeSets![0]!.name}
+          probeSetDefaultName={experiment.secondaryProbeSets![0]!.name}
           isDefault={false}
         />
       </RouterSlugProvider>,
@@ -96,12 +96,28 @@ describe("TableMetricSecondary", () => {
         <TableMetricSecondary
           results={mockAnalysis()}
           probeSetSlug={experiment.secondaryProbeSets![0]!.slug}
-          probeSetName={experiment.secondaryProbeSets![0]!.name}
+          probeSetDefaultName={experiment.secondaryProbeSets![0]!.name}
           isDefault={false}
         />
       </RouterSlugProvider>,
     );
 
     expect(screen.queryAllByText("0.02 to 0.08")).toHaveLength(2);
+  });
+
+  it("uses the friendly name from the metadata", () => {
+    const { mock, experiment } = mockExperimentQuery("demo-slug");
+    render(
+      <RouterSlugProvider mocks={[mock]}>
+        <TableMetricSecondary
+          results={mockAnalysis()}
+          probeSetSlug="feature_d"
+          probeSetDefaultName={experiment.secondaryProbeSets![0]!.name}
+          isDefault={false}
+        />
+      </RouterSlugProvider>,
+    );
+
+    expect(screen.queryByText("Feature D Friendly Name")).toBeInTheDocument();
   });
 });

--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableMetricSecondary/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableMetricSecondary/index.tsx
@@ -3,6 +3,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React from "react";
+import ReactMarkdown from "react-markdown";
+import ReactTooltip from "react-tooltip";
+import { ReactComponent as Info } from "../../../images/info.svg";
 import {
   DISPLAY_TYPE,
   METRIC_TYPE,
@@ -23,7 +26,7 @@ type SecondaryMetricStatistic = {
 type TableMetricSecondaryProps = {
   results: AnalysisData;
   probeSetSlug: string;
-  probeSetName: string;
+  probeSetDefaultName: string;
   isDefault?: boolean;
 };
 
@@ -44,10 +47,11 @@ const TableMetricSecondary = ({
     daily: [],
     weekly: {},
     overall: {},
+    metadata: { metrics: {}, probesets: {} },
     show_analysis: false,
   },
   probeSetSlug,
-  probeSetName,
+  probeSetDefaultName,
   isDefault = true,
 }: TableMetricSecondaryProps) => {
   const secondaryMetricStatistics = getStatistics(probeSetSlug);
@@ -56,11 +60,39 @@ const TableMetricSecondary = ({
     : METRIC_TYPE.USER_SELECTED_SECONDARY;
 
   const overallResults = results?.overall!;
+  const probeSetName =
+    results.metadata?.metrics[probeSetSlug]?.friendly_name ||
+    probeSetDefaultName;
+  const probeSetDescription =
+    results.metadata?.metrics[probeSetSlug]?.description || undefined;
 
   return (
     <div data-testid="table-metric-secondary" className="mb-5">
       <h2 className="h5 mb-3" id={probeSetSlug}>
-        <div>{probeSetName}</div>
+        <div>
+          <div className="d-inline-block">
+            {probeSetName}{" "}
+            {probeSetDescription && (
+              <>
+                <Info
+                  data-tip
+                  data-for={probeSetSlug}
+                  className="align-baseline"
+                />
+                <ReactTooltip
+                  id={probeSetSlug}
+                  multiline
+                  clickable
+                  className="w-25"
+                  delayHide={200}
+                  effect="solid"
+                >
+                  <ReactMarkdown source={probeSetDescription!} />
+                </ReactTooltip>
+              </>
+            )}
+          </div>
+        </div>
         <div
           className={`badge ${secondaryType.badge}`}
           data-tip={secondaryType.tooltip}

--- a/app/experimenter/nimbus-ui/src/components/PageResults/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/index.tsx
@@ -84,17 +84,17 @@ const PageResults: React.FunctionComponent<RouteComponentProps> = () => (
                   key={probeSet!.slug}
                   results={analysis}
                   probeSetSlug={probeSet!.slug}
-                  probeSetName={probeSet!.name}
+                  probeSetDefaultName={probeSet!.name}
                   isDefault={false}
                 />
               ))}
             {analysis?.other_metrics &&
-              Object.keys(analysis.other_metrics).map((metric) => (
+              Object.keys(analysis.other_metrics).map((metric: string) => (
                 <TableMetricSecondary
                   key={metric}
                   results={analysis}
                   probeSetSlug={metric}
-                  probeSetName={analysis!.other_metrics![metric]}
+                  probeSetDefaultName={analysis!.other_metrics![metric]}
                 />
               ))}
           </div>

--- a/app/experimenter/nimbus-ui/src/lib/visualization/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/lib/visualization/mocks.tsx
@@ -7,6 +7,28 @@ export const MOCK_UNAVAILABLE_ANALYSIS = {
   daily: null,
   weekly: null,
   overall: null,
+  metadata: {
+    metrics: {},
+    probesets: {},
+  },
+};
+
+export const MOCK_METADATA = {
+  metrics: {
+    feature_b: {
+      bigger_is_better: true,
+      description:
+        "This is a metric description. It's made by a data scientist at the creation time of the metric [I'm a link](https://www.example.com)",
+      friendly_name: "Feature B",
+    },
+    feature_d: {
+      bigger_is_better: true,
+      description:
+        "This is a metric description. It's made by a data scientist at the creation time of the metric [I'm a link](https://www.example.com)",
+      friendly_name: "Feature D Friendly Name",
+    },
+  },
+  probesets: {},
 };
 
 export const CONTROL_NEUTRAL = {
@@ -204,9 +226,8 @@ export const weeklyMockAnalysis = (modifications = {}) =>
 export const mockAnalysis = (modifications = {}) =>
   Object.assign(
     {
-      other_metrics: {
-        feature_d: "Feature D",
-      },
+      other_metrics: { feature_d: "Feature D" },
+      metadata: MOCK_METADATA,
       show_analysis: true,
       daily: [],
       weekly: weeklyMockAnalysis(),
@@ -907,9 +928,8 @@ export const mockAnalysis = (modifications = {}) =>
 export const mockIncompleteAnalysis = (modifications = {}) =>
   Object.assign(
     {
-      other_metrics: {
-        feature_d: "Feature D",
-      },
+      other_metrics: { feature_d: "Feature D" },
+      metadata: MOCK_METADATA,
       show_analysis: true,
       daily: [],
       weekly: {},

--- a/app/experimenter/nimbus-ui/src/lib/visualization/types.ts
+++ b/app/experimenter/nimbus-ui/src/lib/visualization/types.ts
@@ -7,11 +7,23 @@ export interface AnalysisData {
   weekly: { [branch: string]: BranchDescription } | null;
   overall: { [branch: string]: BranchDescription } | null;
   show_analysis: boolean;
+  metadata?: Metadata;
   other_metrics?: { [metric: string]: string };
 }
 
 export type AnalysisDataOverall = Exclude<AnalysisData["overall"], null>;
 export type AnalysisDataWeekly = Exclude<AnalysisData["weekly"], null>;
+
+export interface Metadata {
+  metrics: { [metric: string]: MetadataPoint };
+  probesets: { [probeset: string]: MetadataPoint };
+}
+
+export interface MetadataPoint {
+  description: string;
+  friendly_name: string;
+  bigger_is_better: boolean;
+}
 
 export interface AnalysisPoint {
   metric: string;

--- a/app/experimenter/nimbus-ui/src/styles/index.scss
+++ b/app/experimenter/nimbus-ui/src/styles/index.scss
@@ -86,3 +86,7 @@ $sizes: (
   width: 18px;
   height: 18px;
 }
+
+.__react_component_tooltip > p:last-child {
+  margin-bottom: 0;
+}

--- a/app/experimenter/settings.py
+++ b/app/experimenter/settings.py
@@ -418,6 +418,5 @@ KINTO_COLLECTION_NIMBUS_PREVIEW = "nimbus-preview"
 DEFAULT_FILE_STORAGE = "storages.backends.gcloud.GoogleCloudStorage"
 GS_PROJECT_ID = "experiments-analysis"
 GS_BUCKET_NAME = "mozanalysis"
-GS_LOCATION = "statistics"
 
 NIMBUS_SCHEMA_VERSION = pkg_resources.get_distribution("mozilla-nimbus-shared").version

--- a/app/experimenter/visualization/tests/api/test_views.py
+++ b/app/experimenter/visualization/tests/api/test_views.py
@@ -46,6 +46,7 @@ class TestVisualizationView(TestCase):
                 "daily": None,
                 "weekly": None,
                 "overall": None,
+                "metadata": None,
                 "show_analysis": False,
             },
             json_data,
@@ -125,14 +126,23 @@ class TestVisualizationView(TestCase):
             "weekly": FORMATTED_DATA_WITHOUT_POPULATION_PERCENTAGE,
             "overall": FORMATTED_DATA_WITH_POPULATION_PERCENTAGE,
             "other_metrics": {"some_count": "Some Count"},
+            "metadata": {},
             "show_analysis": False,
         }
 
         class File:
+            def __init__(self, filename):
+                self.name = filename
+
             def read(self):
+                if "metadata" in self.name:
+                    return "{}"
                 return json.dumps(DATA_WITHOUT_POPULATION_PERCENTAGE)
 
-        mock_open.return_value = File()
+        def open_file(filename):
+            return File(filename)
+
+        mock_open.side_effect = open_file
         mock_exists.return_value = True
         primary_probe_set = NimbusProbeSetFactory.create()
         experiment = NimbusExperimentFactory.create_with_status(

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -3669,6 +3669,13 @@
   dependencies:
     "@types/react" "*"
 
+"@types/mdast@^3.0.0", "@types/mdast@^3.0.3":
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/@types/mdast/-/mdast-3.0.3.tgz#2d7d671b1cd1ea3deb306ea75036c2a0407d2deb"
+  integrity sha512-SXPBMnFVQg1s00dlMCc/jCdvPqdE4mXaMMCeRlxLDmTAEoegHT53xKtkDnzDTOcmMHUfcjyf36/YYZ6SxRdnsw==
+  dependencies:
+    "@types/unist" "*"
+
 "@types/micromatch@^4.0.1":
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/@types/micromatch/-/micromatch-4.0.1.tgz#9381449dd659fc3823fd2a4190ceacc985083bc7"
@@ -3866,7 +3873,7 @@
   resolved "https://registry.yarnpkg.com/@types/ungap__global-this/-/ungap__global-this-0.3.1.tgz#18ce9f657da556037a29d50604335614ce703f4c"
   integrity sha512-+/DsiV4CxXl6ZWefwHZDXSe1Slitz21tom38qPCaG0DYCS1NnDPIQDTKcmQ/tvK/edJUKkmuIDBJbmKDiB0r/g==
 
-"@types/unist@*", "@types/unist@^2.0.0", "@types/unist@^2.0.2":
+"@types/unist@*", "@types/unist@^2.0.0", "@types/unist@^2.0.2", "@types/unist@^2.0.3":
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/@types/unist/-/unist-2.0.3.tgz#9c088679876f374eb5983f150d4787aa6fb32d7e"
   integrity sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ==
@@ -7905,6 +7912,15 @@ dom-serializer@0:
     domelementtype "^2.0.1"
     entities "^2.0.0"
 
+dom-serializer@^1.0.1:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-1.2.0.tgz#3433d9136aeb3c627981daa385fc7f32d27c48f1"
+  integrity sha512-n6kZFH/KlCrqs/1GHMOd5i2fd/beQHuehKdWvNNffbGHTr/almdhuVvTVFb3V7fglz+nC50fFusu3lY33h12pA==
+  dependencies:
+    domelementtype "^2.0.1"
+    domhandler "^4.0.0"
+    entities "^2.0.0"
+
 dom-walk@^0.1.0:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/dom-walk/-/dom-walk-0.1.2.tgz#0c548bef048f4d1f2a97249002236060daa3fd84"
@@ -7924,6 +7940,11 @@ domelementtype@^2.0.1:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-2.0.2.tgz#f3b6e549201e46f588b59463dd77187131fe6971"
   integrity sha512-wFwTwCVebUrMgGeAwRL/NhZtHAUyT9n9yg4IMDwf10+6iCMxSkVq9MGCVEH+QZWo1nNidy8kNvwmv4zWHDTqvA==
+
+domelementtype@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-2.1.0.tgz#a851c080a6d1c3d94344aed151d99f669edf585e"
+  integrity sha512-LsTgx/L5VpD+Q8lmsXSHW2WpA+eBlZ9HPf3erD1IoPF00/3JKHZ3BknUVA2QGDNu69ZNmyFmCWBSO45XjYKC5w==
 
 domexception@^1.0.1:
   version "1.0.1"
@@ -7946,6 +7967,20 @@ domhandler@^2.3.0:
   dependencies:
     domelementtype "1"
 
+domhandler@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-3.3.0.tgz#6db7ea46e4617eb15cf875df68b2b8524ce0037a"
+  integrity sha512-J1C5rIANUbuYK+FuFL98650rihynUOEzRLxW+90bKZRWB6A1X1Tf82GxR1qAWLyfNPRvjqfip3Q5tdYlmAa9lA==
+  dependencies:
+    domelementtype "^2.0.1"
+
+domhandler@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-4.0.0.tgz#01ea7821de996d85f69029e81fa873c21833098e"
+  integrity sha512-KPTbnGQ1JeEMQyO1iYXoagsI6so/C96HZiFyByU3T6iAzpXn8EGEvct6unm1ZGoed8ByO2oirxgwxBmqKF9haA==
+  dependencies:
+    domelementtype "^2.1.0"
+
 domutils@1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/domutils/-/domutils-1.5.1.tgz#dcd8488a26f563d61079e48c9f7b7e32373682cf"
@@ -7961,6 +7996,15 @@ domutils@^1.5.1, domutils@^1.7.0:
   dependencies:
     dom-serializer "0"
     domelementtype "1"
+
+domutils@^2.4.2:
+  version "2.4.4"
+  resolved "https://registry.yarnpkg.com/domutils/-/domutils-2.4.4.tgz#282739c4b150d022d34699797369aad8d19bbbd3"
+  integrity sha512-jBC0vOsECI4OMdD0GC9mGn7NXPLb+Qt6KW1YDQzeQYRUFKmNG8lh7mO5HiELfr+lLQE7loDVI4QcAxV80HS+RA==
+  dependencies:
+    dom-serializer "^1.0.1"
+    domelementtype "^2.0.1"
+    domhandler "^4.0.0"
 
 dot-case@^3.0.3:
   version "3.0.3"
@@ -10247,6 +10291,16 @@ html-tags@^3.1.0:
   resolved "https://registry.yarnpkg.com/html-tags/-/html-tags-3.1.0.tgz#7b5e6f7e665e9fb41f30007ed9e0d41e97fb2140"
   integrity sha512-1qYz89hW3lFDEazhjW0yVAV87lw8lVkrJocr72XmBkMKsoSVJCQx3W8BXsC7hO2qAt8BoVjYjtAcZ9perqGnNg==
 
+html-to-react@^1.3.4:
+  version "1.4.5"
+  resolved "https://registry.yarnpkg.com/html-to-react/-/html-to-react-1.4.5.tgz#59091c11021d1ef315ef738460abb6a4a41fe1ce"
+  integrity sha512-KONZUDFPg5OodWaQu2ymfkDmU0JA7zB1iPfvyHehTmMUZnk0DS7/TyCMTzsLH6b4BvxX15g88qZCXFhJWktsmA==
+  dependencies:
+    domhandler "^3.3.0"
+    htmlparser2 "^5.0"
+    lodash.camelcase "^4.3.0"
+    ramda "^0.27.1"
+
 html-webpack-plugin@4.0.0-beta.11:
   version "4.0.0-beta.11"
   resolved "https://registry.yarnpkg.com/html-webpack-plugin/-/html-webpack-plugin-4.0.0-beta.11.tgz#3059a69144b5aecef97708196ca32f9e68677715"
@@ -10299,6 +10353,16 @@ htmlparser2@^3.10.0, htmlparser2@^3.3.0, htmlparser2@^3.9.2:
     entities "^1.1.1"
     inherits "^2.0.1"
     readable-stream "^3.1.1"
+
+htmlparser2@^5.0:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-5.0.1.tgz#7daa6fc3e35d6107ac95a4fc08781f091664f6e7"
+  integrity sha512-vKZZra6CSe9qsJzh0BjBGXo8dvzNsq/oGvsjfRdOrrryfeD9UOBEEQdeoqCRmKZchF5h2zOBMQ6YuQ0uRUmdbQ==
+  dependencies:
+    domelementtype "^2.0.1"
+    domhandler "^3.3.0"
+    domutils "^2.4.2"
+    entities "^2.0.0"
 
 http-call@^5.2.2:
   version "5.3.0"
@@ -12719,6 +12783,11 @@ lodash._reinterpolate@^3.0.0:
   resolved "https://registry.yarnpkg.com/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz#0ccf2d89166af03b3663c796538b75ac6e114d9d"
   integrity sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=
 
+lodash.camelcase@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz#b28aa6288a2b9fc651035c7711f65ab6190331a6"
+  integrity sha1-soqmKIorn8ZRA1x3EfZathkDMaY=
+
 lodash.clone@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.clone/-/lodash.clone-4.5.0.tgz#195870450f5a13192478df4bc3d23d2dea1907b6"
@@ -13017,12 +13086,35 @@ md5.js@^1.3.4:
     inherits "^2.0.1"
     safe-buffer "^5.1.2"
 
+mdast-add-list-metadata@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/mdast-add-list-metadata/-/mdast-add-list-metadata-1.0.1.tgz#95e73640ce2fc1fa2dcb7ec443d09e2bfe7db4cf"
+  integrity sha512-fB/VP4MJ0LaRsog7hGPxgOrSL3gE/2uEdZyDuSEnKCv/8IkYHiDkIQSbChiJoHyxZZXZ9bzckyRk+vNxFzh8rA==
+  dependencies:
+    unist-util-visit-parents "1.1.2"
+
 mdast-util-compact@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/mdast-util-compact/-/mdast-util-compact-2.0.1.tgz#cabc69a2f43103628326f35b1acf735d55c99490"
   integrity sha512-7GlnT24gEwDrdAwEHrU4Vv5lLWrEer4KOkAiKT9nYstsTad7Oc1TwqT2zIMKRdZF7cTuaf+GA1E4Kv7jJh8mPA==
   dependencies:
     unist-util-visit "^2.0.0"
+
+mdast-util-from-markdown@^0.8.0:
+  version "0.8.5"
+  resolved "https://registry.yarnpkg.com/mdast-util-from-markdown/-/mdast-util-from-markdown-0.8.5.tgz#d1ef2ca42bc377ecb0463a987910dae89bd9a28c"
+  integrity sha512-2hkTXtYYnr+NubD/g6KGBS/0mFmBcifAsI0yIWRiRo0PjVs6SSOSOdtzbp6kSGnShDN6G5aWZpKQ2lWRy27mWQ==
+  dependencies:
+    "@types/mdast" "^3.0.0"
+    mdast-util-to-string "^2.0.0"
+    micromark "~2.11.0"
+    parse-entities "^2.0.0"
+    unist-util-stringify-position "^2.0.0"
+
+mdast-util-to-string@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/mdast-util-to-string/-/mdast-util-to-string-2.0.0.tgz#b8cfe6a713e1091cb5b728fc48885a4767f8b97b"
+  integrity sha512-AW4DRS3QbBayY/jJmD8437V1Gombjf8RSOUCMFBuo5iHi58AGEgVCKQ+ezHkZZDpAQS75hcBMpLqjpJTjtUL7w==
 
 mdn-data@2.0.4:
   version "2.0.4"
@@ -13149,6 +13241,14 @@ microevent.ts@~0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/microevent.ts/-/microevent.ts-0.1.1.tgz#70b09b83f43df5172d0205a63025bce0f7357fa0"
   integrity sha512-jo1OfR4TaEwd5HOrt5+tAZ9mqT4jmpNAusXtyfNzqVm9uiSYFZlKM1wYL4oU7azZW/PxQW53wM0S6OR1JHNa2g==
+
+micromark@~2.11.0:
+  version "2.11.4"
+  resolved "https://registry.yarnpkg.com/micromark/-/micromark-2.11.4.tgz#d13436138eea826383e822449c9a5c50ee44665a"
+  integrity sha512-+WoovN/ppKolQOFIAajxi7Lu9kInbPxFuTBVEavFcL8eAfVstoc5MocPmqBeAdBOJV00uaVjegzH4+MA0DN/uA==
+  dependencies:
+    debug "^4.0.0"
+    parse-entities "^2.0.0"
 
 micromatch@^3.0.4, micromatch@^3.1.10, micromatch@^3.1.4:
   version "3.1.10"
@@ -15779,6 +15879,11 @@ ramda@^0.26.0:
   resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.26.1.tgz#8d41351eb8111c55353617fc3bbffad8e4d35d06"
   integrity sha512-hLWjpy7EnsDBb0p+Z3B7rPi3GDeRG5ZtiI33kJhTt+ORCd38AbAIjB/9zRIUoeTbE/AVX5ZkU7m6bznsvrf8eQ==
 
+ramda@^0.27.1:
+  version "0.27.1"
+  resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.27.1.tgz#66fc2df3ef873874ffc2da6aa8984658abacf5c9"
+  integrity sha512-PgIdVpn5y5Yns8vqb8FzBUEYn98V3xcPgawAkkgj0YJ0qDsnHCiNmZYfOGMgOvoB0eWFLpYbhxUR3mxfDIMvpw==
+
 randombytes@^2.0.0, randombytes@^2.0.1, randombytes@^2.0.5, randombytes@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/randombytes/-/randombytes-2.1.0.tgz#df6f84372f0270dc65cdf6291349ab7a473d4f2a"
@@ -16042,7 +16147,7 @@ react-inspector@^5.0.1:
     is-dom "^1.0.0"
     prop-types "^15.0.0"
 
-react-is@^16.12.0, react-is@^16.3.2, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.4:
+react-is@^16.12.0, react-is@^16.3.2, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.4, react-is@^16.8.6:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
@@ -16056,6 +16161,22 @@ react-lifecycles-compat@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
   integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
+
+react-markdown@^5.0.3:
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/react-markdown/-/react-markdown-5.0.3.tgz#41040ea7a9324b564b328fb81dd6c04f2a5373ac"
+  integrity sha512-jDWOc1AvWn0WahpjW6NK64mtx6cwjM4iSsLHJPNBqoAgGOVoIdJMqaKX4++plhOtdd4JksdqzlDibgPx6B/M2w==
+  dependencies:
+    "@types/mdast" "^3.0.3"
+    "@types/unist" "^2.0.3"
+    html-to-react "^1.3.4"
+    mdast-add-list-metadata "1.0.1"
+    prop-types "^15.7.2"
+    react-is "^16.8.6"
+    remark-parse "^9.0.0"
+    unified "^9.0.0"
+    unist-util-visit "^2.0.0"
+    xtend "^4.0.1"
 
 react-overlays@^4.1.0:
   version "4.1.0"
@@ -16533,6 +16654,13 @@ remark-parse@^8.0.0:
     unist-util-remove-position "^2.0.0"
     vfile-location "^3.0.0"
     xtend "^4.0.1"
+
+remark-parse@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/remark-parse/-/remark-parse-9.0.0.tgz#4d20a299665880e4f4af5d90b7c7b8a935853640"
+  integrity sha512-geKatMwSzEXKHuzBNU1z676sGcDcFoChMK38TgdHJNAYfFtsfHDQG7MoJAjs6sgYMqyLduCYWDIWZIxiPeafEw==
+  dependencies:
+    mdast-util-from-markdown "^0.8.0"
 
 remark-stringify@^8.0.0:
   version "8.1.1"
@@ -18783,6 +18911,11 @@ unist-util-stringify-position@^2.0.0:
   integrity sha512-3faScn5I+hy9VleOq/qNbAd6pAx7iH5jYBMS9I1HgQVijz/4mv5Bvw5iw1sC/90CODiKo81G/ps8AJrISn687g==
   dependencies:
     "@types/unist" "^2.0.2"
+
+unist-util-visit-parents@1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/unist-util-visit-parents/-/unist-util-visit-parents-1.1.2.tgz#f6e3afee8bdbf961c0e6f028ea3c0480028c3d06"
+  integrity sha512-yvo+MMLjEwdc3RhhPYSximset7rwjMrdt9E41Smmvg25UQIenzrN83cRnF1JMzoMi9zZOQeYXHSDf7p+IQkW3Q==
 
 unist-util-visit-parents@^3.0.0:
   version "3.1.0"


### PR DESCRIPTION
Because:
* We want to have human-friendly metric names and detailed descriptinos

This commit:
* Pulls in that data from Jetstream and uses it for labels and tooltips.