### PR TITLE
fix #4422 featu(nimbus): automatically pause experiments after enrollment end date

### DIFF
--- a/app/bin/setup_kinto.py
+++ b/app/bin/setup_kinto.py
@@ -9,7 +9,7 @@ REVIEW_USER = REVIEW_PASS = "review"
 EXPERIMENTER_USER = os.environ["KINTO_USER"]
 EXPERIMENTER_PASS = os.environ["KINTO_PASS"]
 KINTO_HOST = os.environ["KINTO_HOST"]
-KINTO_BUCKET = "main-workspace"
+KINTO_BUCKET_WORKSPACE = "main-workspace"
 KINTO_BUCKET_MAIN = "main"
 KINTO_COLLECTION_NIMBUS_DESKTOP = "nimbus-desktop-experiments"
 KINTO_COLLECTION_NIMBUS_MOBILE = "nimbus-mobile-experiments"
@@ -31,10 +31,10 @@ create_user(EXPERIMENTER_USER, EXPERIMENTER_PASS)
 
 client = kinto_http.Client(server_url=KINTO_HOST, auth=(ADMIN_USER, ADMIN_PASS))
 
-print(f">>>> Creating kinto bucket: {KINTO_BUCKET}")
+print(f">>>> Creating kinto bucket: {KINTO_BUCKET_WORKSPACE}")
 print(
     client.create_bucket(
-        id=KINTO_BUCKET,
+        id=KINTO_BUCKET_WORKSPACE,
         permissions={"read": ["system.Everyone"]},
         if_not_exists=True,
     )
@@ -49,7 +49,7 @@ for collection in [
     print(
         client.create_group(
             id=f"{collection}-editors",
-            bucket=KINTO_BUCKET,
+            bucket=KINTO_BUCKET_WORKSPACE,
             data={"members": [f"account:{EXPERIMENTER_USER}"]},
             if_not_exists=True,
         )
@@ -59,7 +59,7 @@ for collection in [
     print(
         client.create_group(
             id=f"{collection}-reviewers",
-            bucket=KINTO_BUCKET,
+            bucket=KINTO_BUCKET_WORKSPACE,
             data={"members": [f"account:{REVIEW_USER}"]},
             if_not_exists=True,
         )
@@ -69,12 +69,18 @@ for collection in [
     print(
         client.create_collection(
             id=collection,
-            bucket=KINTO_BUCKET,
+            bucket=KINTO_BUCKET_WORKSPACE,
             permissions={
                 "read": ["system.Everyone"],
                 "write": [
-                    (f"/buckets/{KINTO_BUCKET}/groups/" f"{collection}-editors"),
-                    (f"/buckets/{KINTO_BUCKET}/groups/" f"{collection}-reviewers"),
+                    (
+                        f"/buckets/{KINTO_BUCKET_WORKSPACE}/groups/"
+                        f"{collection}-editors"
+                    ),
+                    (
+                        f"/buckets/{KINTO_BUCKET_WORKSPACE}/groups/"
+                        f"{collection}-reviewers"
+                    ),
                 ],
             },
             if_not_exists=True,

--- a/app/experimenter/experiments/models/nimbus.py
+++ b/app/experimenter/experiments/models/nimbus.py
@@ -145,11 +145,23 @@ class NimbusExperiment(NimbusConstants, models.Model):
             return end_changelog.get().changed_on
 
     @property
-    def proposed_end_date(self):
+    def proposed_enrollment_end_date(self):
         if self.start_date and self.proposed_enrollment:
+            return (
+                self.start_date + datetime.timedelta(days=self.proposed_enrollment)
+            ).date()
+
+    @property
+    def proposed_end_date(self):
+        if self.start_date and self.proposed_duration:
             return (
                 self.start_date + datetime.timedelta(days=self.proposed_duration)
             ).date()
+
+    @property
+    def should_pause(self):
+        if self.proposed_enrollment_end_date:
+            return datetime.date.today() >= self.proposed_enrollment_end_date
 
     @property
     def should_end(self):

--- a/app/experimenter/experiments/tests/test_models/test_models_nimbus.py
+++ b/app/experimenter/experiments/tests/test_models/test_models_nimbus.py
@@ -219,6 +219,39 @@ class TestNimbusExperiment(TestCase):
         self.assertEqual(experiment.bucket_range.count, 2000)
         self.assertEqual(experiment.bucket_range.isolation_group.name, experiment.slug)
 
+    def test_proposed_enrollment_end_date_without_start_date_is_None(self):
+        experiment = NimbusExperimentFactory.create_with_status(
+            NimbusExperiment.Status.DRAFT
+        )
+        self.assertIsNone(experiment.proposed_enrollment_end_date)
+
+    def test_proposed_enrollment_end_date_with_start_date_returns_date(self):
+        experiment = NimbusExperimentFactory.create_with_status(
+            NimbusExperiment.Status.LIVE, proposed_enrollment=10
+        )
+        self.assertEqual(
+            experiment.proposed_enrollment_end_date,
+            datetime.date.today() + datetime.timedelta(days=10),
+        )
+
+    def test_should_pause_false_before_enrollment_end(self):
+        experiment = NimbusExperimentFactory.create_with_status(
+            NimbusExperiment.Status.LIVE, proposed_enrollment=10
+        )
+        self.assertFalse(experiment.should_pause)
+
+    def test_should_pause_true_after_enrollment_end(self):
+        experiment = NimbusExperimentFactory.create_with_status(
+            NimbusExperiment.Status.LIVE, proposed_enrollment=10
+        )
+        launch_change = experiment.changes.get(
+            old_status=NimbusExperiment.Status.ACCEPTED,
+            new_status=NimbusExperiment.Status.LIVE,
+        )
+        launch_change.changed_on = datetime.datetime.now() - datetime.timedelta(days=11)
+        launch_change.save()
+        self.assertTrue(experiment.should_pause)
+
 
 class TestNimbusBranch(TestCase):
     def test_str(self):

--- a/app/experimenter/kinto/client.py
+++ b/app/experimenter/kinto/client.py
@@ -18,24 +18,37 @@ class KintoClient:
         self.kinto_http_client.create_record(
             data=data,
             collection=self.collection,
-            bucket=settings.KINTO_BUCKET,
+            bucket=settings.KINTO_BUCKET_WORKSPACE,
             if_not_exists=True,
         )
         self.kinto_http_client.patch_collection(
             id=self.collection,
             data={"status": KINTO_REVIEW_STATUS},
-            bucket=settings.KINTO_BUCKET,
+            bucket=settings.KINTO_BUCKET_WORKSPACE,
+        )
+
+    def update_record(self, data):
+        self.kinto_http_client.update_record(
+            data=data,
+            collection=self.collection,
+            bucket=settings.KINTO_BUCKET_WORKSPACE,
+            if_match='"0"',
+        )
+        self.kinto_http_client.patch_collection(
+            id=self.collection,
+            data={"status": KINTO_REVIEW_STATUS},
+            bucket=settings.KINTO_BUCKET_WORKSPACE,
         )
 
     def has_pending_review(self):
         collection = self.kinto_http_client.get_collection(
-            id=self.collection, bucket=settings.KINTO_BUCKET
+            id=self.collection, bucket=settings.KINTO_BUCKET_WORKSPACE
         )
         return collection["data"]["status"] == KINTO_REVIEW_STATUS
 
     def get_rejected_collection_data(self):
         collection = self.kinto_http_client.get_collection(
-            id=self.collection, bucket=settings.KINTO_BUCKET
+            id=self.collection, bucket=settings.KINTO_BUCKET_WORKSPACE
         )
 
         if collection["data"]["status"] == KINTO_REJECTED_STATUS:
@@ -47,7 +60,7 @@ class KintoClient:
         )
 
         workspace_records = self.kinto_http_client.get_records(
-            bucket=settings.KINTO_BUCKET, collection=self.collection
+            bucket=settings.KINTO_BUCKET_WORKSPACE, collection=self.collection
         )
 
         main_record_ids = [record["id"] for record in main_records]
@@ -59,7 +72,7 @@ class KintoClient:
         self.kinto_http_client.patch_collection(
             id=self.collection,
             data={"status": KINTO_ROLLBACK_STATUS},
-            bucket=settings.KINTO_BUCKET,
+            bucket=settings.KINTO_BUCKET_WORKSPACE,
         )
 
     def get_main_records(self):
@@ -71,10 +84,10 @@ class KintoClient:
         self.kinto_http_client.delete_record(
             id=id,
             collection=self.collection,
-            bucket=settings.KINTO_BUCKET,
+            bucket=settings.KINTO_BUCKET_WORKSPACE,
         )
         self.kinto_http_client.patch_collection(
             id=self.collection,
             data={"status": KINTO_REVIEW_STATUS},
-            bucket=settings.KINTO_BUCKET,
+            bucket=settings.KINTO_BUCKET_WORKSPACE,
         )

--- a/app/experimenter/kinto/tasks.py
+++ b/app/experimenter/kinto/tasks.py
@@ -165,6 +165,46 @@ def nimbus_check_experiments_are_live():
 
 
 @app.task
+@metrics.timer_decorator("check_experiments_are_paused")
+def nimbus_check_experiments_are_paused():
+    """
+    A scheduled task that checks the kinto collection for any experiment slugs that are
+    marked as enrollment paused in the collection but not in the database, and update them
+    in the database accordingly.
+    """
+    metrics.incr("check_experiments_are_paused.started")
+
+    for application, collection in NimbusExperiment.KINTO_APPLICATION_COLLECTION.items():
+        kinto_client = KintoClient(collection)
+
+        live_experiments = NimbusExperiment.objects.filter(
+            status=NimbusExperiment.Status.LIVE,
+            application=application,
+            is_paused=False,
+        )
+
+        records = {r["id"]: r for r in kinto_client.get_main_records()}
+
+        for experiment in live_experiments:
+            if records[experiment.slug]["isEnrollmentPaused"]:
+                nimbus_send_experiment_ending_email(experiment)
+                logger.info(
+                    f"{experiment} is_paused is being updated to True".format(
+                        experiment=experiment
+                    )
+                )
+
+                experiment.is_paused = True
+                experiment.save()
+
+                generate_nimbus_changelog(experiment, get_kinto_user())
+
+                logger.info(f"{experiment} is_paused is set to True")
+
+    metrics.incr("check_experiments_are_paused.completed")
+
+
+@app.task
 @metrics.timer_decorator("check_experiments_are_complete")
 def nimbus_check_experiments_are_complete():
     """
@@ -184,10 +224,8 @@ def nimbus_check_experiments_are_complete():
 
         records = kinto_client.get_main_records()
         record_ids = [r.get("id") for r in records]
-        print("found record ids", record_ids)
 
         for experiment in live_experiments:
-            print("checking", experiment)
             if (
                 experiment.should_end
                 and not experiment.emails.filter(
@@ -236,3 +274,33 @@ def nimbus_end_experiment_in_kinto(experiment_id):
         metrics.incr("end_experiment_in_kinto.failed")
         logger.info(f"Deleting experiment id {experiment_id} from Kinto failed: {e}")
         raise e
+
+
+@metrics.timer_decorator("nimbus_update_paused_experiments_in_kinto")
+def nimbus_update_paused_experiments_in_kinto():
+    """
+    A scheduled task that checks for experiments that should be paused
+    but are not paused in the kinto collection and marks them as paused
+    and updates the record in the collection.
+    """
+    metrics.incr("nimbus_update_paused_experiments_in_kinto.started")
+
+    for application, collection in NimbusExperiment.KINTO_APPLICATION_COLLECTION.items():
+        kinto_client = KintoClient(collection)
+        records = {r["id"]: r for r in kinto_client.get_main_records()}
+
+        live_experiments = NimbusExperiment.objects.filter(
+            status=NimbusExperiment.Status.LIVE,
+            application=application,
+        )
+
+        for experiment in live_experiments:
+            experiment_record = records[experiment.slug]
+            if experiment.should_pause and not experiment_record["isEnrollmentPaused"]:
+                updated_record = experiment_record.copy()
+                updated_record["isEnrollmentPaused"] = True
+
+                kinto_client.update_record(updated_record)
+                logger.info(f"{experiment} is being paused")
+
+    metrics.incr("nimbus_update_paused_experiments_in_kinto.completed")

--- a/app/experimenter/kinto/tests/test_client.py
+++ b/app/experimenter/kinto/tests/test_client.py
@@ -26,14 +26,14 @@ class TestKintoClient(MockKintoClientMixin, TestCase):
         self.mock_kinto_client.create_record.assert_called_with(
             data={"test": "data"},
             collection=self.collection,
-            bucket=settings.KINTO_BUCKET,
+            bucket=settings.KINTO_BUCKET_WORKSPACE,
             if_not_exists=True,
         )
 
         self.mock_kinto_client.patch_collection.assert_called_with(
             id=self.collection,
             data={"status": KINTO_REVIEW_STATUS},
-            bucket=settings.KINTO_BUCKET,
+            bucket=settings.KINTO_BUCKET_WORKSPACE,
         )
 
     def test_rollback_changes_patches_collection(self):
@@ -47,7 +47,7 @@ class TestKintoClient(MockKintoClientMixin, TestCase):
         self.mock_kinto_client.patch_collection.assert_called_with(
             id=self.collection,
             data={"status": KINTO_ROLLBACK_STATUS},
-            bucket=settings.KINTO_BUCKET,
+            bucket=settings.KINTO_BUCKET_WORKSPACE,
         )
 
     def test_returns_true_for_pending_review(self):
@@ -100,11 +100,29 @@ class TestKintoClient(MockKintoClientMixin, TestCase):
         self.mock_kinto_client.delete_record.assert_called_with(
             id=expected_id,
             collection=self.collection,
-            bucket=settings.KINTO_BUCKET,
+            bucket=settings.KINTO_BUCKET_WORKSPACE,
         )
 
         self.mock_kinto_client.patch_collection.assert_called_with(
             id=self.collection,
             data={"status": KINTO_REVIEW_STATUS},
-            bucket=settings.KINTO_BUCKET,
+            bucket=settings.KINTO_BUCKET_WORKSPACE,
+        )
+
+    def test_update_record_updates_collection_and_sets_review_status(self):
+        data = {"id": "my-record", "field": "value"}
+
+        self.client.update_record(data)
+
+        self.mock_kinto_client.update_record.assert_called_with(
+            data=data,
+            collection=self.collection,
+            bucket=settings.KINTO_BUCKET_WORKSPACE,
+            if_match='"0"',
+        )
+
+        self.mock_kinto_client.patch_collection.assert_called_with(
+            id=self.collection,
+            data={"status": KINTO_REVIEW_STATUS},
+            bucket=settings.KINTO_BUCKET_WORKSPACE,
         )

--- a/app/experimenter/settings.py
+++ b/app/experimenter/settings.py
@@ -325,8 +325,16 @@ CELERY_BEAT_SCHEDULE = {
         "task": "experimenter.kinto.tasks.nimbus_check_experiments_are_live",
         "schedule": config("CELERY_SCHEDULE_INTERVAL", default=300, cast=int),
     },
+    "nimbus_check_experiments_are_paused": {
+        "task": "experimenter.kinto.tasks.nimbus_check_experiments_are_paused",
+        "schedule": config("CELERY_SCHEDULE_INTERVAL", default=300, cast=int),
+    },
     "nimbus_check_experiments_are_complete": {
         "task": "experimenter.kinto.tasks.nimbus_check_experiments_are_complete",
+        "schedule": config("CELERY_SCHEDULE_INTERVAL", default=300, cast=int),
+    },
+    "nimbus_update_paused_experiments_in_kinto": {
+        "task": "experimenter.kinto.tasks.nimbus_update_paused_experiments_in_kinto",
         "schedule": config("CELERY_SCHEDULE_INTERVAL", default=300, cast=int),
     },
 }
@@ -395,7 +403,7 @@ FEATURE_ANALYSIS = config("FEATURE_ANALYSIS", default=False, cast=bool)
 KINTO_HOST = config("KINTO_HOST")
 KINTO_USER = config("KINTO_USER")
 KINTO_PASS = config("KINTO_PASS")
-KINTO_BUCKET = "main-workspace"
+KINTO_BUCKET_WORKSPACE = "main-workspace"
 KINTO_BUCKET_MAIN = "main"
 KINTO_COLLECTION_NIMBUS_DESKTOP = "nimbus-desktop-experiments"
 KINTO_COLLECTION_NIMBUS_MOBILE = "nimbus-mobile-experiments"


### PR DESCRIPTION


Because

* We want experimenter to automatically set the isEnrollmentPaused flag in remote settings automatically after the enrollment end date passes

This commit

* Adds logic to the nimbus model to compute when an experiment should be paused
* Adds a celery task to update the record in remote settings after the pause date has passed
* Adds a celery task to update the experiment in the db when remote settings has accepted the pause change and generate a changelog