### PR TITLE
chore(nimbus): test editCommonRedirects and remove similar redundant tests from page components

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/AppLayoutWithExperiment/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/AppLayoutWithExperiment/index.tsx
@@ -27,6 +27,16 @@ type AppLayoutWithExperimentChildrenProps = {
   analysis?: AnalysisData;
 };
 
+export type RedirectCheck = {
+  status: StatusCheck;
+  review?: {
+    ready: boolean;
+    invalidPages: string[];
+  };
+  analysis?: AnalysisData;
+  analysisError?: Error;
+};
+
 type AppLayoutWithExperimentProps = {
   children: (
     props: AppLayoutWithExperimentChildrenProps,
@@ -43,15 +53,7 @@ type AppLayoutWithExperimentProps = {
     review,
     analysis,
     analysisError,
-  }: {
-    status: StatusCheck;
-    review?: {
-      ready: boolean;
-      invalidPages: string[];
-    };
-    analysis?: AnalysisData;
-    analysisError?: Error;
-  }) => string | void;
+  }: RedirectCheck) => string | void;
 } & RouteComponentProps;
 
 export const POLL_INTERVAL = 30000;

--- a/app/experimenter/nimbus-ui/src/components/PageEditAudience/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditAudience/index.test.tsx
@@ -15,14 +15,13 @@ import fetchMock from "jest-fetch-mock";
 import React from "react";
 import PageEditAudience from ".";
 import { UPDATE_EXPERIMENT_MUTATION } from "../../gql/experiments";
-import { BASE_PATH, SUBMIT_ERROR } from "../../lib/constants";
+import { SUBMIT_ERROR } from "../../lib/constants";
 import { mockExperimentQuery } from "../../lib/mocks";
 import { RouterSlugProvider } from "../../lib/test-utils";
 import {
   ExperimentInput,
   NimbusExperimentChannel,
   NimbusExperimentFirefoxMinVersion,
-  NimbusExperimentStatus,
   NimbusExperimentTargetingConfigSlug,
 } from "../../types/globalTypes";
 import { updateExperiment_updateExperiment } from "../../types/updateExperiment";
@@ -54,67 +53,6 @@ describe("PageEditAudience", () => {
     render(<Subject />);
     await waitFor(() => {
       expect(screen.queryByTestId("PageEditAudience")).toBeInTheDocument();
-    });
-  });
-
-  it("redirects to the review page if the experiment status is review", async () => {
-    const { mock, experiment } = mockExperimentQuery("demo-slug", {
-      status: NimbusExperimentStatus.REVIEW,
-    });
-    render(<Subject mocks={[mock]} />);
-    await waitFor(() => {
-      expect(navigate).toHaveBeenCalledWith(
-        `${BASE_PATH}/${experiment.slug}/request-review`,
-        {
-          replace: true,
-        },
-      );
-    });
-  });
-
-  it("redirects to the design page if the experiment status is live", async () => {
-    const { mock, experiment } = mockExperimentQuery("demo-slug", {
-      status: NimbusExperimentStatus.LIVE,
-    });
-    render(<Subject mocks={[mock]} />);
-    await waitFor(() => {
-      expect(navigate).toHaveBeenCalledWith(
-        `${BASE_PATH}/${experiment.slug}/design`,
-        {
-          replace: true,
-        },
-      );
-    });
-  });
-
-  it("redirects to the review page if the experiment status is preview", async () => {
-    const { mock, experiment } = mockExperimentQuery("demo-slug", {
-      // @ts-ignore EXP-879 mock value until backend API & types are updated
-      status: NimbusExperimentStatus.PREVIEW,
-    });
-    render(<Subject mocks={[mock]} />);
-    await waitFor(() => {
-      expect(navigate).toHaveBeenCalledWith(
-        `${BASE_PATH}/${experiment.slug}/request-review`,
-        {
-          replace: true,
-        },
-      );
-    });
-  });
-
-  it("redirects to the design page if the experiment status is complete", async () => {
-    const { mock, experiment } = mockExperimentQuery("demo-slug", {
-      status: NimbusExperimentStatus.COMPLETE,
-    });
-    render(<Subject mocks={[mock]} />);
-    await waitFor(() => {
-      expect(navigate).toHaveBeenCalledWith(
-        `${BASE_PATH}/${experiment.slug}/design`,
-        {
-          replace: true,
-        },
-      );
     });
   });
 

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/index.test.tsx
@@ -14,13 +14,12 @@ import fetchMock from "jest-fetch-mock";
 import React from "react";
 import PageEditBranches, { SUBMIT_ERROR_MESSAGE } from ".";
 import { UPDATE_EXPERIMENT_MUTATION } from "../../gql/experiments";
-import { BASE_PATH, EXTERNAL_URLS } from "../../lib/constants";
+import { EXTERNAL_URLS } from "../../lib/constants";
 import { mockExperimentQuery, MOCK_CONFIG } from "../../lib/mocks";
 import { RouterSlugProvider } from "../../lib/test-utils";
 import { getExperiment_experimentBySlug } from "../../types/getExperiment";
 import {
   ExperimentInput,
-  NimbusExperimentStatus,
   NimbusFeatureConfigApplication,
 } from "../../types/globalTypes";
 import { updateExperiment_updateExperiment } from "../../types/updateExperiment";
@@ -40,67 +39,6 @@ describe("PageEditBranches", () => {
   beforeEach(() => {
     mockSetSubmitErrors.mockClear();
     mockClearSubmitErrors.mockClear();
-  });
-
-  it("redirects to the review page if the experiment status is review", async () => {
-    const { mock, experiment } = mockExperimentQuery("demo-slug", {
-      status: NimbusExperimentStatus.REVIEW,
-    });
-    render(<Subject mocks={[mock]} />);
-    await waitFor(() => {
-      expect(navigate).toHaveBeenCalledWith(
-        `${BASE_PATH}/${experiment.slug}/request-review`,
-        {
-          replace: true,
-        },
-      );
-    });
-  });
-
-  it("redirects to the review page if the experiment status is preview", async () => {
-    const { mock, experiment } = mockExperimentQuery("demo-slug", {
-      // @ts-ignore EXP-879 mock value until backend API & types are updated
-      status: NimbusExperimentStatus.PREVIEW,
-    });
-    render(<Subject mocks={[mock]} />);
-    await waitFor(() => {
-      expect(navigate).toHaveBeenCalledWith(
-        `${BASE_PATH}/${experiment.slug}/request-review`,
-        {
-          replace: true,
-        },
-      );
-    });
-  });
-
-  it("redirects to the design page if the experiment status is live", async () => {
-    const { mock, experiment } = mockExperimentQuery("demo-slug", {
-      status: NimbusExperimentStatus.LIVE,
-    });
-    render(<Subject mocks={[mock]} />);
-    await waitFor(() => {
-      expect(navigate).toHaveBeenCalledWith(
-        `${BASE_PATH}/${experiment.slug}/design`,
-        {
-          replace: true,
-        },
-      );
-    });
-  });
-
-  it("redirects to the design page if the experiment status is complete", async () => {
-    const { mock, experiment } = mockExperimentQuery("demo-slug", {
-      status: NimbusExperimentStatus.COMPLETE,
-    });
-    render(<Subject mocks={[mock]} />);
-    await waitFor(() => {
-      expect(navigate).toHaveBeenCalledWith(
-        `${BASE_PATH}/${experiment.slug}/design`,
-        {
-          replace: true,
-        },
-      );
-    });
   });
 
   it("renders as expected with experiment data", async () => {

--- a/app/experimenter/nimbus-ui/src/components/PageEditMetrics/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditMetrics/index.test.tsx
@@ -15,10 +15,9 @@ import fetchMock from "jest-fetch-mock";
 import React from "react";
 import PageEditMetrics from ".";
 import { UPDATE_EXPERIMENT_MUTATION } from "../../gql/experiments";
-import { BASE_PATH, EXTERNAL_URLS, SUBMIT_ERROR } from "../../lib/constants";
+import { EXTERNAL_URLS, SUBMIT_ERROR } from "../../lib/constants";
 import { mockExperimentMutation, mockExperimentQuery } from "../../lib/mocks";
 import { RouterSlugProvider } from "../../lib/test-utils";
-import { NimbusExperimentStatus } from "../../types/globalTypes";
 import FormMetrics from "./FormMetrics";
 
 const { mock, experiment } = mockExperimentQuery("demo-slug");
@@ -92,67 +91,6 @@ describe("PageEditMetrics", () => {
       expect(screen.getByTestId("core-metrics-link")).toHaveAttribute(
         "href",
         EXTERNAL_URLS.METRICS_GOOGLE_DOC,
-      );
-    });
-  });
-
-  it("redirects to the review page if the experiment status is review", async () => {
-    const { mock, experiment } = mockExperimentQuery("demo-slug", {
-      status: NimbusExperimentStatus.REVIEW,
-    });
-    render(<Subject mocks={[mock]} />);
-    await waitFor(() => {
-      expect(navigate).toHaveBeenCalledWith(
-        `${BASE_PATH}/${experiment.slug}/request-review`,
-        {
-          replace: true,
-        },
-      );
-    });
-  });
-
-  it("redirects to the review page if the experiment status is preview", async () => {
-    const { mock, experiment } = mockExperimentQuery("demo-slug", {
-      // @ts-ignore EXP-879 mock value until backend API & types are updated
-      status: NimbusExperimentStatus.PREVIEW,
-    });
-    render(<Subject mocks={[mock]} />);
-    await waitFor(() => {
-      expect(navigate).toHaveBeenCalledWith(
-        `${BASE_PATH}/${experiment.slug}/request-review`,
-        {
-          replace: true,
-        },
-      );
-    });
-  });
-
-  it("redirects to the design page if the experiment status is live", async () => {
-    const { mock, experiment } = mockExperimentQuery("demo-slug", {
-      status: NimbusExperimentStatus.LIVE,
-    });
-    render(<Subject mocks={[mock]} />);
-    await waitFor(() => {
-      expect(navigate).toHaveBeenCalledWith(
-        `${BASE_PATH}/${experiment.slug}/design`,
-        {
-          replace: true,
-        },
-      );
-    });
-  });
-
-  it("redirects to the design page if the experiment status is complete", async () => {
-    const { mock, experiment } = mockExperimentQuery("demo-slug", {
-      status: NimbusExperimentStatus.COMPLETE,
-    });
-    render(<Subject mocks={[mock]} />);
-    await waitFor(() => {
-      expect(navigate).toHaveBeenCalledWith(
-        `${BASE_PATH}/${experiment.slug}/design`,
-        {
-          replace: true,
-        },
       );
     });
   });

--- a/app/experimenter/nimbus-ui/src/components/PageEditOverview/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditOverview/index.test.tsx
@@ -15,10 +15,9 @@ import fetchMock from "jest-fetch-mock";
 import React from "react";
 import PageEditOverview from ".";
 import { UPDATE_EXPERIMENT_MUTATION } from "../../gql/experiments";
-import { BASE_PATH, SUBMIT_ERROR } from "../../lib/constants";
+import { SUBMIT_ERROR } from "../../lib/constants";
 import { mockExperimentMutation, mockExperimentQuery } from "../../lib/mocks";
 import { RouterSlugProvider } from "../../lib/test-utils";
-import { NimbusExperimentStatus } from "../../types/globalTypes";
 import FormOverview from "../FormOverview";
 
 const { mock, experiment } = mockExperimentQuery("demo-slug");
@@ -76,67 +75,6 @@ describe("PageEditOverview", () => {
     await waitFor(() => {
       expect(screen.getByTestId("PageEditOverview")).toBeInTheDocument();
       expect(screen.getByTestId("header-experiment")).toBeInTheDocument();
-    });
-  });
-
-  it("redirects to the review page if the experiment status is review", async () => {
-    const { mock, experiment } = mockExperimentQuery("demo-slug", {
-      status: NimbusExperimentStatus.REVIEW,
-    });
-    render(<Subject mocks={[mock]} />);
-    await waitFor(() => {
-      expect(navigate).toHaveBeenCalledWith(
-        `${BASE_PATH}/${experiment.slug}/request-review`,
-        {
-          replace: true,
-        },
-      );
-    });
-  });
-
-  it("redirects to the review page if the experiment status is preview", async () => {
-    const { mock, experiment } = mockExperimentQuery("demo-slug", {
-      // @ts-ignore EXP-879 mock value until backend API & types are updated
-      status: NimbusExperimentStatus.PREVIEW,
-    });
-    render(<Subject mocks={[mock]} />);
-    await waitFor(() => {
-      expect(navigate).toHaveBeenCalledWith(
-        `${BASE_PATH}/${experiment.slug}/request-review`,
-        {
-          replace: true,
-        },
-      );
-    });
-  });
-
-  it("redirects to the design page if the experiment status is live", async () => {
-    const { mock, experiment } = mockExperimentQuery("demo-slug", {
-      status: NimbusExperimentStatus.LIVE,
-    });
-    render(<Subject mocks={[mock]} />);
-    await waitFor(() => {
-      expect(navigate).toHaveBeenCalledWith(
-        `${BASE_PATH}/${experiment.slug}/design`,
-        {
-          replace: true,
-        },
-      );
-    });
-  });
-
-  it("redirects to the design page if the experiment status is complete", async () => {
-    const { mock, experiment } = mockExperimentQuery("demo-slug", {
-      status: NimbusExperimentStatus.COMPLETE,
-    });
-    render(<Subject mocks={[mock]} />);
-    await waitFor(() => {
-      expect(navigate).toHaveBeenCalledWith(
-        `${BASE_PATH}/${experiment.slug}/design`,
-        {
-          replace: true,
-        },
-      );
     });
   });
 

--- a/app/experimenter/nimbus-ui/src/lib/experiment.test.ts
+++ b/app/experimenter/nimbus-ui/src/lib/experiment.test.ts
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { NimbusExperimentStatus } from "../types/globalTypes";
-import { getStatus } from "./experiment";
+import { editCommonRedirects, getStatus } from "./experiment";
 import { mockExperimentQuery } from "./mocks";
 
 const { experiment } = mockExperimentQuery("boo");
@@ -32,5 +32,24 @@ describe("getStatus", () => {
 
     experiment.isEndRequested = true;
     expect(getStatus(experiment).ending).toBeTruthy();
+  });
+});
+
+describe("editCommonRedirects", () => {
+  const mockedCall = (status: NimbusExperimentStatus) => {
+    const { experiment } = mockExperimentQuery("boo", { status });
+    return editCommonRedirects({ status: getStatus(experiment) });
+  };
+
+  it("returns 'request-review' if the experiment is in review or preview", () => {
+    expect(mockedCall(NimbusExperimentStatus.REVIEW)).toEqual("request-review");
+    // @ts-ignore until backend API & types are updated
+    expect(mockedCall("PREVIEW")).toEqual("request-review");
+  });
+
+  it("returns 'design' if the experiment is in a locked state", () => {
+    expect(mockedCall(NimbusExperimentStatus.LIVE)).toEqual("design");
+    expect(mockedCall(NimbusExperimentStatus.COMPLETE)).toEqual("design");
+    expect(mockedCall(NimbusExperimentStatus.ACCEPTED)).toEqual("design");
   });
 });

--- a/app/experimenter/nimbus-ui/src/lib/experiment.ts
+++ b/app/experimenter/nimbus-ui/src/lib/experiment.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import { RedirectCheck } from "../components/AppLayoutWithExperiment";
 import { getAllExperiments_experiments } from "../types/getAllExperiments";
 import { getExperiment_experimentBySlug } from "../types/getExperiment";
 import { NimbusExperimentStatus } from "../types/globalTypes";
@@ -41,7 +42,7 @@ export function getStatus(
 
 export type StatusCheck = ReturnType<typeof getStatus>;
 
-export function editCommonRedirects({ status }: { status: StatusCheck }) {
+export function editCommonRedirects({ status }: RedirectCheck) {
   if (status.review || status.preview) {
     return "request-review";
   }


### PR DESCRIPTION
This seemed fairly straightforward, so... 

I removed all the duplicate redirect tests from the PageEdit* components, tested that the correct redirect strings are returned depending on the experiment status, and added an AppLayoutWithExperiment test to ensure redirecting happens.

🧁