### PR TITLE
chore(nimbus): eliminate all instance of __typename

### DIFF
--- a/app/experimenter/nimbus-ui/README.md
+++ b/app/experimenter/nimbus-ui/README.md
@@ -71,7 +71,6 @@ Would be analyzed and the corresponding types generated would look like this:
 
 ```ts
 export interface GetExperimentOverviews_experiments {
-  __typename: "NimbusExperimentType";
   name: string;
   slug: string;
   hypothesis: string | null;
@@ -362,7 +361,7 @@ const mkSimulatedQueries = ({
 const Subject = ({ simulatedQueries = mkSimulatedQueries() }) => {
   const mockLink = new SimulatedMockLink(simulatedQueries, false);
   return (
-    <MockedProvider link={mockLink} addTypename={false}>
+    <MockedProvider link={mockLink}>
       <PageNew />
     </MockedProvider>
   );

--- a/app/experimenter/nimbus-ui/package.json
+++ b/app/experimenter/nimbus-ui/package.json
@@ -15,7 +15,7 @@
     "storybook": "start-storybook -p 3001 --no-version-updates",
     "build-storybook": "build-storybook",
     "eject": "react-scripts eject",
-    "generate-types": "apollo codegen:generate --target typescript --outputFlat src/types --passthroughCustomScalars"
+    "generate-types": "apollo codegen:generate --target typescript --outputFlat src/types --passthroughCustomScalars --no-addTypename"
   },
   "jest": {
     "collectCoverageFrom": [

--- a/app/experimenter/nimbus-ui/src/components/FormOverview/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/FormOverview/index.test.tsx
@@ -47,12 +47,10 @@ describe("FormOverview", () => {
     const { experiment } = mockExperimentQuery("boo", {
       documentationLinks: [
         {
-          __typename: "NimbusDocumentationLinkType",
           title: NimbusDocumentationLinkTitle.DESIGN_DOC,
           link: "https://mozilla.com",
         },
         {
-          __typename: "NimbusDocumentationLinkType",
           title: NimbusDocumentationLinkTitle.DS_JIRA,
           link: "https://mozilla.com",
         },
@@ -264,7 +262,6 @@ describe("FormOverview", () => {
     const { experiment } = mockExperimentQuery("boo", {
       documentationLinks: [
         {
-          __typename: "NimbusDocumentationLinkType",
           title: NimbusDocumentationLinkTitle.DS_JIRA,
           link: "https://bingo.bongo",
         },
@@ -285,7 +282,6 @@ describe("FormOverview", () => {
     // Update the values of the first set
     await act(async () => {
       experiment.documentationLinks![0] = {
-        __typename: "NimbusDocumentationLinkType",
         title: NimbusDocumentationLinkTitle.ENG_TICKET,
         link: "https://",
       };
@@ -309,7 +305,6 @@ describe("FormOverview", () => {
     await act(async () => void fireEvent.click(addButton));
     await act(async () => {
       experiment.documentationLinks!.push({
-        __typename: "NimbusDocumentationLinkType",
         title: NimbusDocumentationLinkTitle.DESIGN_DOC,
         link: "https://boingo.oingo",
       });

--- a/app/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/index.test.tsx
@@ -108,7 +108,6 @@ describe("FormAudience", () => {
           experiment: {
             ...MOCK_EXPERIMENT,
             readyForReview: {
-              __typename: "NimbusReadyForReviewType",
               ready: false,
               message: "Test",
             },
@@ -215,7 +214,6 @@ describe("FormAudience", () => {
           experiment: {
             ...MOCK_EXPERIMENT,
             readyForReview: {
-              __typename: "NimbusReadyForReviewType",
               ready: false,
               message: {
                 population_percent: ["This field may not be null."],
@@ -251,21 +249,18 @@ const renderSubjectWithDefaultValues = (onSubmit = () => {}) => {
         ...MOCK_CONFIG,
         targetingConfigSlug: [
           {
-            __typename: "NimbusLabelValueType",
             label: NimbusExperimentTargetingConfigSlug.NO_TARGETING,
             value: NimbusExperimentTargetingConfigSlug.NO_TARGETING,
           },
         ],
         firefoxMinVersion: [
           {
-            __typename: "NimbusLabelValueType",
             label: NimbusExperimentFirefoxMinVersion.NO_VERSION,
             value: NimbusExperimentFirefoxMinVersion.NO_VERSION,
           },
         ],
         channel: [
           {
-            __typename: "NimbusLabelValueType",
             label: NimbusExperimentChannel.NO_CHANNEL,
             value: NimbusExperimentChannel.NO_CHANNEL,
           },

--- a/app/experimenter/nimbus-ui/src/components/PageEditAudience/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditAudience/index.stories.tsx
@@ -18,7 +18,6 @@ const { mock: mockMissingFields } = mockExperimentQuery("demo-slug", {
   proposedEnrollment: 0,
   proposedDuration: 0,
   readyForReview: {
-    __typename: "NimbusReadyForReviewType",
     ready: false,
     message: {
       proposed_duration: ["This field may not be null."],

--- a/app/experimenter/nimbus-ui/src/components/PageEditAudience/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditAudience/index.test.tsx
@@ -236,7 +236,6 @@ export const mockUpdateExperimentAudienceMutation = (
   },
 ) => {
   const updateExperiment: updateExperiment_updateExperiment = {
-    __typename: "UpdateExperiment",
     message,
   };
 

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/index.stories.tsx
@@ -136,7 +136,6 @@ storiesOf("pages/EditBranches/FormBranches", module)
         ...MOCK_EXPERIMENT,
         featureConfig: MOCK_FEATURE_CONFIG_WITH_SCHEMA,
         readyForReview: {
-          __typename: "NimbusReadyForReviewType",
           ready: false,
           message: {
             reference_branch: ["Description may not be blank"],

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/index.test.tsx
@@ -179,7 +179,6 @@ describe("FormBranches", () => {
           experiment: {
             ...MOCK_EXPERIMENT,
             referenceBranch: {
-              __typename: "NimbusBranchType",
               name: "",
               slug: "",
               description: "",
@@ -392,7 +391,6 @@ describe("FormBranches", () => {
           experiment: {
             ...MOCK_EXPERIMENT,
             readyForReview: {
-              __typename: "NimbusReadyForReviewType",
               ready: false,
               message: expectedReviewErrors,
             },
@@ -433,7 +431,6 @@ describe("FormBranches", () => {
           experiment: {
             ...MOCK_EXPERIMENT,
             readyForReview: {
-              __typename: "NimbusReadyForReviewType",
               ready: false,
               message: "unexpected error",
             },

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/mocks.tsx
@@ -15,7 +15,6 @@ import { FormBranchesState } from "./reducer/state";
 export const MOCK_EXPERIMENT = mockExperimentQuery("demo-slug", {
   treatmentBranches: [
     {
-      __typename: "NimbusBranchType",
       name: "Managed zero tolerance projection",
       slug: "managed-zero-tolerance-projection",
       description: "Next ask then he in degree order.",
@@ -24,7 +23,6 @@ export const MOCK_EXPERIMENT = mockExperimentQuery("demo-slug", {
       featureEnabled: false,
     },
     {
-      __typename: "NimbusBranchType",
       name: "Salt way link",
       slug: "salt-way-link",
       description: "Flame the dark true.",

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/index.stories.tsx
@@ -13,7 +13,6 @@ import { NimbusFeatureConfigApplication } from "../../types/globalTypes";
 
 const { mock } = mockExperimentQuery("demo-slug", {
   featureConfig: {
-    __typename: "NimbusFeatureConfigType",
     id: "2",
     name: "Mauris odio erat",
     slug: "mauris-odio-erat",
@@ -26,7 +25,6 @@ const { mock } = mockExperimentQuery("demo-slug", {
 
 const { mock: mockMissingFields } = mockExperimentQuery("demo-slug", {
   referenceBranch: {
-    __typename: "NimbusBranchType",
     name: "",
     slug: "",
     description: "",
@@ -36,7 +34,6 @@ const { mock: mockMissingFields } = mockExperimentQuery("demo-slug", {
   },
   treatmentBranches: [
     {
-      __typename: "NimbusBranchType",
       name: "",
       slug: "",
       description: "",
@@ -46,7 +43,6 @@ const { mock: mockMissingFields } = mockExperimentQuery("demo-slug", {
     },
   ],
   readyForReview: {
-    __typename: "NimbusReadyForReviewType",
     ready: false,
     message: {
       reference_branch: ["This field may not be null."],

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/index.test.tsx
@@ -301,7 +301,6 @@ export const mockUpdateExperimentBranchesMutation = (
   },
 ) => {
   const updateExperiment: updateExperiment_updateExperiment = {
-    __typename: "UpdateExperiment",
     message,
   };
   return {

--- a/app/experimenter/nimbus-ui/src/components/PageEditOverview/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditOverview/index.stories.tsx
@@ -14,7 +14,6 @@ const { mock } = mockExperimentQuery("demo-slug");
 const { mock: mockMissingFields } = mockExperimentQuery("demo-slug", {
   publicDescription: "",
   readyForReview: {
-    __typename: "NimbusReadyForReviewType",
     ready: false,
     message: {
       public_description: ["This field may not be null."],

--- a/app/experimenter/nimbus-ui/src/components/PageNew/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageNew/index.stories.tsx
@@ -46,7 +46,7 @@ const mkSimulatedQueries = ({
 const Subject = ({ simulatedQueries = mkSimulatedQueries() }) => {
   const mockLink = new SimulatedMockLink(simulatedQueries, false);
   return (
-    <MockedCache link={mockLink} addTypename={false}>
+    <MockedCache link={mockLink}>
       <PageNew />
     </MockedCache>
   );

--- a/app/experimenter/nimbus-ui/src/components/PageRequestReview/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageRequestReview/index.test.tsx
@@ -60,7 +60,6 @@ describe("PageRequestReview", () => {
     const { mock, experiment } = mockExperimentQuery("demo-slug", {
       status: NimbusExperimentStatus.DRAFT,
       readyForReview: {
-        __typename: "NimbusReadyForReviewType",
         ready: false,
         message: {
           // This field exists on the Audience page
@@ -83,7 +82,6 @@ describe("PageRequestReview", () => {
     const { mock, experiment } = mockExperimentQuery("demo-slug", {
       status: NimbusExperimentStatus.DRAFT,
       readyForReview: {
-        __typename: "NimbusReadyForReviewType",
         ready: false,
         message: {},
       },

--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableHighlights/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableHighlights/index.stories.tsx
@@ -27,17 +27,14 @@ storiesOf("pages/Results/TableHighlights", module)
     const { mock, experiment } = mockExperimentQuery("demo-slug", {
       primaryProbeSets: [
         {
-          __typename: "NimbusProbeSetType",
           slug: "picture_in_picture",
           name: "Picture-in-Picture",
         },
         {
-          __typename: "NimbusProbeSetType",
           slug: "feature_b",
           name: "Feature B",
         },
         {
-          __typename: "NimbusProbeSetType",
           slug: "feature_c",
           name: "Feature C",
         },

--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableHighlightsOverview/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableHighlightsOverview/index.stories.tsx
@@ -27,17 +27,14 @@ storiesOf("pages/Results/TableHighlightsOverview", module)
     const { mock, experiment } = mockExperimentQuery("demo-slug", {
       primaryProbeSets: [
         {
-          __typename: "NimbusProbeSetType",
           slug: "picture_in_picture",
           name: "Picture-in-Picture",
         },
         {
-          __typename: "NimbusProbeSetType",
           slug: "feature_b",
           name: "Feature B",
         },
         {
-          __typename: "NimbusProbeSetType",
           slug: "feature_c",
           name: "Feature C",
         },

--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableMetricPrimary/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableMetricPrimary/index.stories.tsx
@@ -15,7 +15,6 @@ storiesOf("pages/Results/TableMetricPrimary", module)
     const { experiment } = mockExperimentQuery("demo-slug", {
       primaryProbeSets: [
         {
-          __typename: "NimbusProbeSetType",
           slug: "picture_in_picture",
           name: "Picture-in-Picture",
         },
@@ -33,7 +32,6 @@ storiesOf("pages/Results/TableMetricPrimary", module)
     const { experiment } = mockExperimentQuery("demo-slug", {
       primaryProbeSets: [
         {
-          __typename: "NimbusProbeSetType",
           slug: "feature_b",
           name: "Feature B",
         },
@@ -51,7 +49,6 @@ storiesOf("pages/Results/TableMetricPrimary", module)
     const { experiment } = mockExperimentQuery("demo-slug", {
       primaryProbeSets: [
         {
-          __typename: "NimbusProbeSetType",
           slug: "feature_c",
           name: "Feature C",
         },

--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableMetricPrimary/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableMetricPrimary/index.test.tsx
@@ -92,7 +92,6 @@ describe("TableMetricPrimary", () => {
     const { mock, experiment } = mockExperimentQuery("demo-slug", {
       primaryProbeSets: [
         {
-          __typename: "NimbusProbeSetType",
           slug: "feature_b",
           name: "Feature B",
         },
@@ -120,7 +119,6 @@ describe("TableMetricPrimary", () => {
     const { mock, experiment } = mockExperimentQuery("demo-slug", {
       primaryProbeSets: [
         {
-          __typename: "NimbusProbeSetType",
           slug: "feature_c",
           name: "Feature C",
         },

--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableMetricSecondary/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableMetricSecondary/index.stories.tsx
@@ -15,7 +15,6 @@ storiesOf("pages/Results/TableMetricSecondary", module)
     const { experiment } = mockExperimentQuery("demo-slug", {
       secondaryProbeSets: [
         {
-          __typename: "NimbusProbeSetType",
           slug: "picture_in_picture",
           name: "Picture-in-Picture",
         },
@@ -46,7 +45,6 @@ storiesOf("pages/Results/TableMetricSecondary", module)
     const { experiment } = mockExperimentQuery("demo-slug", {
       secondaryProbeSets: [
         {
-          __typename: "NimbusProbeSetType",
           slug: "feature_c",
           name: "Feature C",
         },

--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableResults/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableResults/index.stories.tsx
@@ -27,17 +27,14 @@ storiesOf("pages/Results/TableResults", module)
     const { mock, experiment } = mockExperimentQuery("demo-slug", {
       primaryProbeSets: [
         {
-          __typename: "NimbusProbeSetType",
           slug: "picture_in_picture",
           name: "Picture-in-Picture",
         },
         {
-          __typename: "NimbusProbeSetType",
           slug: "feature_b",
           name: "Feature B",
         },
         {
-          __typename: "NimbusProbeSetType",
           slug: "feature_c",
           name: "Feature C",
         },

--- a/app/experimenter/nimbus-ui/src/components/Summary/TableBranches/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/TableBranches/index.stories.tsx
@@ -36,7 +36,6 @@ storiesOf("components/Summary/TableBranches", module)
         ...MOCK_EXPERIMENT,
         treatmentBranches: [
           {
-            __typename: "NimbusBranchType",
             name: "",
             slug: "",
             description: "",

--- a/app/experimenter/nimbus-ui/src/components/Summary/TableBranches/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/TableBranches/index.test.tsx
@@ -80,7 +80,6 @@ describe("TableBranches", () => {
           ...MOCK_EXPERIMENT,
           treatmentBranches: [
             {
-              __typename: "NimbusBranchType",
               ...expected,
               featureEnabled: true,
             },
@@ -113,7 +112,6 @@ describe("TableBranches", () => {
           ...MOCK_EXPERIMENT,
           treatmentBranches: [
             {
-              __typename: "NimbusBranchType",
               name: "",
               slug: "",
               description: "",

--- a/app/experimenter/nimbus-ui/src/components/Summary/TableSummary/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/TableSummary/index.stories.tsx
@@ -25,24 +25,20 @@ storiesOf("components/Summary/TableSummary", module)
       featureConfig: MOCK_CONFIG.featureConfig![1],
       primaryProbeSets: [
         {
-          __typename: "NimbusProbeSetType",
           slug: "picture_in_picture",
           name: "Picture-in-Picture",
         },
         {
-          __typename: "NimbusProbeSetType",
           slug: "feature_C",
           name: "Feature C",
         },
       ],
       secondaryProbeSets: [
         {
-          __typename: "NimbusProbeSetType",
           slug: "feature_b",
           name: "Feature B",
         },
         {
-          __typename: "NimbusProbeSetType",
           slug: "feature_d",
           name: "Feature D",
         },

--- a/app/experimenter/nimbus-ui/src/components/Summary/TableSummary/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/TableSummary/index.test.tsx
@@ -44,12 +44,10 @@ describe("TableSummary", () => {
       const { experiment } = mockExperimentQuery("demo-slug", {
         primaryProbeSets: [
           {
-            __typename: "NimbusProbeSetType",
             slug: "picture_in_picture",
             name: "Picture-in-Picture",
           },
           {
-            __typename: "NimbusProbeSetType",
             slug: "feature_c",
             name: "Feature C",
           },
@@ -83,12 +81,10 @@ describe("TableSummary", () => {
       const { experiment } = mockExperimentQuery("demo-slug", {
         secondaryProbeSets: [
           {
-            __typename: "NimbusProbeSetType",
             slug: "picture_in_picture",
             name: "Picture-in-Picture",
           },
           {
-            __typename: "NimbusProbeSetType",
             slug: "feature_b",
             name: "Feature B",
           },
@@ -176,12 +172,10 @@ describe("TableSummary", () => {
       const { experiment } = mockExperimentQuery("demo-slug", {
         documentationLinks: [
           {
-            __typename: "NimbusDocumentationLinkType",
             title: NimbusDocumentationLinkTitle.DESIGN_DOC,
             link: "https://mozilla.org",
           },
           {
-            __typename: "NimbusDocumentationLinkType",
             title: NimbusDocumentationLinkTitle.DS_JIRA,
             link: "https://twitter.com",
           },

--- a/app/experimenter/nimbus-ui/src/hooks/useExperiment.test.tsx
+++ b/app/experimenter/nimbus-ui/src/hooks/useExperiment.test.tsx
@@ -81,7 +81,6 @@ describe("hooks/useExperiment", () => {
 
         const { mock } = mockExperimentQuery("howdy", {
           readyForReview: {
-            __typename: "NimbusReadyForReviewType",
             ready: false,
             message: readyMessage,
           },
@@ -123,7 +122,6 @@ describe("hooks/useExperiment", () => {
       it("returns correct review info when not missing any details", async () => {
         const { mock } = mockExperimentQuery("howdy", {
           readyForReview: {
-            __typename: "NimbusReadyForReviewType",
             ready: true,
             message: {},
           },

--- a/app/experimenter/nimbus-ui/src/lib/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/lib/mocks.tsx
@@ -53,34 +53,28 @@ export interface MockedState {
 }
 
 export const MOCK_CONFIG: getConfig_nimbusConfig = {
-  __typename: "NimbusConfigurationType",
   application: [
     {
-      __typename: "NimbusLabelValueType",
       label: "Desktop",
       value: "DESKTOP",
     },
   ],
   channel: [
     {
-      __typename: "NimbusLabelValueType",
       label: "Desktop Beta",
       value: "BETA",
     },
     {
-      __typename: "NimbusLabelValueType",
       label: "Desktop Nightly",
       value: "NIGHTLY",
     },
     {
-      __typename: "NimbusLabelValueType",
       label: "Platypus Doorstop",
       value: "PLATYPUS_DOORSTOP",
     },
   ],
   featureConfig: [
     {
-      __typename: "NimbusFeatureConfigType",
       id: "1",
       name: "Picture-in-Picture",
       slug: "picture-in-picture",
@@ -91,7 +85,6 @@ export const MOCK_CONFIG: getConfig_nimbusConfig = {
       schema: null,
     },
     {
-      __typename: "NimbusFeatureConfigType",
       id: "2",
       name: "Mauris odio erat",
       slug: "mauris-odio-erat",
@@ -103,31 +96,26 @@ export const MOCK_CONFIG: getConfig_nimbusConfig = {
   ],
   firefoxMinVersion: [
     {
-      __typename: "NimbusLabelValueType",
       label: "Firefox 80",
       value: "FIREFOX_83",
     },
   ],
   probeSets: [
     {
-      __typename: "NimbusProbeSetType",
       name: "Probe Set A",
       slug: "probe-set-a",
     },
     {
-      __typename: "NimbusProbeSetType",
       name: "Probe Set B",
       slug: "probe-set-b",
     },
     {
-      __typename: "NimbusProbeSetType",
       name: "Probe Set C",
       slug: "probe-set-c",
     },
   ],
   targetingConfigSlug: [
     {
-      __typename: "NimbusLabelValueType",
       label: "Us Only",
       value: "US_ONLY",
     },
@@ -135,17 +123,14 @@ export const MOCK_CONFIG: getConfig_nimbusConfig = {
   hypothesisDefault: "Enter a hypothesis",
   documentationLink: [
     {
-      __typename: "NimbusLabelValueType",
       value: "DS_JIRA",
       label: "Data Science Jira Ticket",
     },
     {
-      __typename: "NimbusLabelValueType",
       value: "DESIGN_DOC",
       label: "Experiment Design Document",
     },
     {
-      __typename: "NimbusLabelValueType",
       value: "ENG_TICKET",
       label: "Engineering Ticket (Bugzilla/Jira/Github)",
     },
@@ -258,10 +243,8 @@ export function mockExperimentQuery<
 } {
   let experiment: getExperiment["experimentBySlug"] = Object.assign(
     {
-      __typename: "NimbusExperimentType",
       id: 1,
       owner: {
-        __typename: "NimbusExperimentOwner",
         email: "example@mozilla.com",
       },
       name: "Open-architected background installation",
@@ -274,7 +257,6 @@ export function mockExperimentQuery<
       publicDescription:
         "Official approach present industry strategy dream piece.",
       referenceBranch: {
-        __typename: "NimbusBranchType",
         name: "User-centric mobile solution",
         slug: "user-centric-mobile-solution",
         description: "Behind almost radio result personal none future current.",
@@ -285,7 +267,6 @@ export function mockExperimentQuery<
       featureConfig: null,
       treatmentBranches: [
         {
-          __typename: "NimbusBranchType",
           name: "Managed zero tolerance projection",
           slug: "managed-zero-tolerance-projection",
           description: "Next ask then he in degree order.",
@@ -296,14 +277,12 @@ export function mockExperimentQuery<
       ],
       primaryProbeSets: [
         {
-          __typename: "NimbusProbeSetType",
           slug: "picture_in_picture",
           name: "Picture-in-Picture",
         },
       ],
       secondaryProbeSets: [
         {
-          __typename: "NimbusProbeSetType",
           slug: "feature_b",
           name: "Feature B",
         },
@@ -319,7 +298,6 @@ export function mockExperimentQuery<
       readyForReview: {
         ready: true,
         message: {},
-        __typename: "NimbusReadyForReviewType",
       },
       startDate: new Date().toISOString(),
       endDate: new Date(Date.now() + 12096e5).toISOString(),
@@ -414,10 +392,8 @@ export function mockSingleDirectoryExperiment(
   overrides: Partial<getAllExperiments_experiments> = {},
 ): getAllExperiments_experiments {
   return {
-    __typename: "NimbusExperimentType",
     slug: `some-experiment-${Math.round(Math.random() * 100)}`,
     owner: {
-      __typename: "NimbusExperimentOwner",
       username: "example@mozilla.com",
     },
     monitoringDashboardUrl:
@@ -425,7 +401,6 @@ export function mockSingleDirectoryExperiment(
     name: "Open-architected background installation",
     status: NimbusExperimentStatus.COMPLETE,
     featureConfig: {
-      __typename: "NimbusFeatureConfigType",
       slug: "newtab",
       name: "New tab",
     },

--- a/app/experimenter/nimbus-ui/src/types/createExperiment.ts
+++ b/app/experimenter/nimbus-ui/src/types/createExperiment.ts
@@ -10,12 +10,10 @@ import { ExperimentInput } from "./globalTypes";
 // ====================================================
 
 export interface createExperiment_createExperiment_nimbusExperiment {
-  __typename: "NimbusExperimentType";
   slug: string;
 }
 
 export interface createExperiment_createExperiment {
-  __typename: "CreateExperiment";
   message: ObjectField | null;
   nimbusExperiment: createExperiment_createExperiment_nimbusExperiment | null;
 }

--- a/app/experimenter/nimbus-ui/src/types/endExperiment.ts
+++ b/app/experimenter/nimbus-ui/src/types/endExperiment.ts
@@ -10,7 +10,6 @@ import { ExperimentIdInput } from "./globalTypes";
 // ====================================================
 
 export interface endExperiment_endExperiment {
-  __typename: "EndExperiment";
   message: ObjectField | null;
 }
 

--- a/app/experimenter/nimbus-ui/src/types/getAllExperiments.ts
+++ b/app/experimenter/nimbus-ui/src/types/getAllExperiments.ts
@@ -10,18 +10,15 @@ import { NimbusExperimentStatus } from "./globalTypes";
 // ====================================================
 
 export interface getAllExperiments_experiments_owner {
-  __typename: "NimbusExperimentOwner";
   username: string;
 }
 
 export interface getAllExperiments_experiments_featureConfig {
-  __typename: "NimbusFeatureConfigType";
   slug: string;
   name: string;
 }
 
 export interface getAllExperiments_experiments {
-  __typename: "NimbusExperimentType";
   name: string;
   owner: getAllExperiments_experiments_owner;
   slug: string;

--- a/app/experimenter/nimbus-ui/src/types/getConfig.ts
+++ b/app/experimenter/nimbus-ui/src/types/getConfig.ts
@@ -10,19 +10,16 @@ import { NimbusFeatureConfigApplication } from "./globalTypes";
 // ====================================================
 
 export interface getConfig_nimbusConfig_application {
-  __typename: "NimbusLabelValueType";
   label: string | null;
   value: string | null;
 }
 
 export interface getConfig_nimbusConfig_channel {
-  __typename: "NimbusLabelValueType";
   label: string | null;
   value: string | null;
 }
 
 export interface getConfig_nimbusConfig_featureConfig {
-  __typename: "NimbusFeatureConfigType";
   id: string;
   name: string;
   slug: string;
@@ -33,31 +30,26 @@ export interface getConfig_nimbusConfig_featureConfig {
 }
 
 export interface getConfig_nimbusConfig_firefoxMinVersion {
-  __typename: "NimbusLabelValueType";
   label: string | null;
   value: string | null;
 }
 
 export interface getConfig_nimbusConfig_probeSets {
-  __typename: "NimbusProbeSetType";
   name: string;
   slug: string;
 }
 
 export interface getConfig_nimbusConfig_targetingConfigSlug {
-  __typename: "NimbusLabelValueType";
   label: string | null;
   value: string | null;
 }
 
 export interface getConfig_nimbusConfig_documentationLink {
-  __typename: "NimbusLabelValueType";
   label: string | null;
   value: string | null;
 }
 
 export interface getConfig_nimbusConfig {
-  __typename: "NimbusConfigurationType";
   application: (getConfig_nimbusConfig_application | null)[] | null;
   channel: (getConfig_nimbusConfig_channel | null)[] | null;
   featureConfig: (getConfig_nimbusConfig_featureConfig | null)[] | null;

--- a/app/experimenter/nimbus-ui/src/types/getExperiment.ts
+++ b/app/experimenter/nimbus-ui/src/types/getExperiment.ts
@@ -10,12 +10,10 @@ import { NimbusExperimentStatus, NimbusExperimentApplication, NimbusFeatureConfi
 // ====================================================
 
 export interface getExperiment_experimentBySlug_owner {
-  __typename: "NimbusExperimentOwner";
   email: string;
 }
 
 export interface getExperiment_experimentBySlug_referenceBranch {
-  __typename: "NimbusBranchType";
   name: string;
   slug: string;
   description: string;
@@ -25,7 +23,6 @@ export interface getExperiment_experimentBySlug_referenceBranch {
 }
 
 export interface getExperiment_experimentBySlug_treatmentBranches {
-  __typename: "NimbusBranchType";
   name: string;
   slug: string;
   description: string;
@@ -35,7 +32,6 @@ export interface getExperiment_experimentBySlug_treatmentBranches {
 }
 
 export interface getExperiment_experimentBySlug_featureConfig {
-  __typename: "NimbusFeatureConfigType";
   id: string;
   slug: string;
   name: string;
@@ -46,31 +42,26 @@ export interface getExperiment_experimentBySlug_featureConfig {
 }
 
 export interface getExperiment_experimentBySlug_primaryProbeSets {
-  __typename: "NimbusProbeSetType";
   slug: string;
   name: string;
 }
 
 export interface getExperiment_experimentBySlug_secondaryProbeSets {
-  __typename: "NimbusProbeSetType";
   slug: string;
   name: string;
 }
 
 export interface getExperiment_experimentBySlug_readyForReview {
-  __typename: "NimbusReadyForReviewType";
   ready: boolean | null;
   message: ObjectField | null;
 }
 
 export interface getExperiment_experimentBySlug_documentationLinks {
-  __typename: "NimbusDocumentationLinkType";
   title: NimbusDocumentationLinkTitle;
   link: string;
 }
 
 export interface getExperiment_experimentBySlug {
-  __typename: "NimbusExperimentType";
   id: number | null;
   name: string;
   slug: string;

--- a/app/experimenter/nimbus-ui/src/types/updateExperiment.ts
+++ b/app/experimenter/nimbus-ui/src/types/updateExperiment.ts
@@ -10,7 +10,6 @@ import { ExperimentInput } from "./globalTypes";
 // ====================================================
 
 export interface updateExperiment_updateExperiment {
-  __typename: "UpdateExperiment";
   message: ObjectField | null;
 }
 


### PR DESCRIPTION
We don't use `__typename` anywhere in our code, and we're kind of just carrying it around everywhere. We can just drop it from the generated types and our `MockedProvider` can add them automatically anyway.

🧁 