### PR TITLE
fixes #4022 feat(nimbus): make next button save before continuing

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/FormOverview/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/components/FormOverview/mocks.tsx
@@ -13,7 +13,6 @@ export const Subject = ({
   submitErrors = {},
   onSubmit = () => {},
   onCancel,
-  onNext,
   experiment,
 }: Partial<React.ComponentProps<typeof FormOverview>>) => {
   const [submitErrorsDefault, setSubmitErrors] = useState<Record<string, any>>(
@@ -30,7 +29,6 @@ export const Subject = ({
           setSubmitErrors,
           onSubmit,
           onCancel,
-          onNext,
           experiment,
         }}
       />

--- a/app/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/mocks.tsx
@@ -19,7 +19,6 @@ export const Subject = ({
   isLoading = false,
   isServerValid = true,
   onSubmit = () => {},
-  onNext = () => {},
 }: {
   config?: getConfig_nimbusConfig;
 } & Partial<React.ComponentProps<typeof FormAudience>>) => {
@@ -38,7 +37,6 @@ export const Subject = ({
             isLoading,
             isServerValid,
             onSubmit,
-            onNext,
           }}
         />
       </MockedCache>

--- a/app/experimenter/nimbus-ui/src/components/PageEditAudience/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditAudience/index.test.tsx
@@ -119,23 +119,17 @@ describe("PageEditAudience", () => {
   });
 
   it("handles form next button", async () => {
-    render(<Subject />);
-    await waitFor(() => {
-      expect(screen.queryByTestId("PageEditAudience")).toBeInTheDocument();
-    });
-    fireEvent.click(screen.getByTestId("next"));
+    render(<Subject mocks={[mock, mutationMock]} />);
+    await screen.findByTestId("PageEditAudience");
+    await act(async () => void fireEvent.click(screen.getByTestId("next")));
+    expect(mockSubmit).toHaveBeenCalled();
     expect(navigate).toHaveBeenCalledWith("../request-review");
   });
 
   it("handles form submission", async () => {
     render(<Subject mocks={[mock, mutationMock]} />);
-    let submitButton: HTMLButtonElement;
-    await waitFor(() => {
-      submitButton = screen.getByTestId("submit") as HTMLButtonElement;
-    });
-    await act(async () => {
-      fireEvent.click(submitButton);
-    });
+    await screen.findByTestId("PageEditAudience");
+    await act(async () => void fireEvent.click(screen.getByTestId("submit")));
     expect(mockSubmit).toHaveBeenCalled();
   });
 
@@ -209,11 +203,12 @@ jest.mock("./FormAudience", () => ({
     const handleSubmit = (ev: React.FormEvent) => {
       ev.preventDefault();
       mockSubmit();
-      props.onSubmit(mockSubmitData, jest.fn());
+      props.onSubmit(mockSubmitData, false);
     };
     const handleNext = (ev: React.FormEvent) => {
       ev.preventDefault();
-      props.onNext && props.onNext(ev);
+      mockSubmit();
+      props.onSubmit(mockSubmitData, true);
     };
     return (
       <div data-testid="FormOverview">

--- a/app/experimenter/nimbus-ui/src/components/PageEditAudience/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditAudience/index.tsx
@@ -26,15 +26,18 @@ const PageEditAudience: React.FunctionComponent<RouteComponentProps> = () => {
   const [isServerValid, setIsServerValid] = useState(true);
 
   const onFormSubmit = useCallback(
-    async ({
-      channel,
-      firefoxMinVersion,
-      targetingConfigSlug,
-      populationPercent,
-      totalEnrolledClients,
-      proposedEnrollment,
-      proposedDuration,
-    }: Record<string, any>) => {
+    async (
+      {
+        channel,
+        firefoxMinVersion,
+        targetingConfigSlug,
+        populationPercent,
+        totalEnrolledClients,
+        proposedEnrollment,
+        proposedDuration,
+      }: Record<string, any>,
+      next: boolean,
+    ) => {
       try {
         // issue #3954: Need to parse string IDs into numbers
         const nimbusExperimentId = currentExperiment.current!.id;
@@ -67,6 +70,10 @@ const PageEditAudience: React.FunctionComponent<RouteComponentProps> = () => {
           setSubmitErrors({});
           // In practice this should be defined by the time we get here
           refetchReview.current!();
+
+          if (next) {
+            navigate("../request-review");
+          }
         }
       } catch (error) {
         setSubmitErrors({ "*": SUBMIT_ERROR });
@@ -74,10 +81,6 @@ const PageEditAudience: React.FunctionComponent<RouteComponentProps> = () => {
     },
     [updateExperimentAudience, currentExperiment],
   );
-
-  const onFormNext = useCallback(() => {
-    navigate("../request-review");
-  }, []);
 
   return (
     <AppLayoutWithExperiment
@@ -101,7 +104,6 @@ const PageEditAudience: React.FunctionComponent<RouteComponentProps> = () => {
               isServerValid,
               isLoading: loading,
               onSubmit: onFormSubmit,
-              onNext: onFormNext,
             }}
           />
         );

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/index.test.tsx
@@ -118,13 +118,6 @@ describe("FormBranches", () => {
     });
   });
 
-  it("calls onNext when next button clicked", () => {
-    const onNext = jest.fn();
-    render(<SubjectBranches {...{ onNext }} />);
-    fireEvent.click(screen.getByTestId("next-button"));
-    expect(onNext).toHaveBeenCalled();
-  });
-
   it("sets all branch ratios to 1 when equal ratio checkbox enabled", async () => {
     const onSave = jest.fn();
     render(<SubjectBranches {...{ onSave }} />);

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/mocks.tsx
@@ -122,7 +122,6 @@ export const SubjectBranches = ({
   experiment = MOCK_EXPERIMENT,
   featureConfig = MOCK_CONFIG.featureConfig,
   onSave = () => {},
-  onNext = () => {},
   saveOnInitialRender = false,
 }: Partial<React.ComponentProps<typeof FormBranches>> & {
   saveOnInitialRender?: boolean;
@@ -145,7 +144,6 @@ export const SubjectBranches = ({
           experiment,
           featureConfig,
           onSave,
-          onNext,
         }}
       />
     </div>

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/index.test.tsx
@@ -132,13 +132,18 @@ describe("PageEditBranches", () => {
     }
   });
 
-  it("handles onNext from FormBranches", async () => {
-    const { mock } = mockExperimentQuery("demo-slug");
-    render(<Subject mocks={[mock]} />);
-    await waitFor(() => {
-      expect(screen.getByTestId("PageEditBranches")).toBeInTheDocument();
-    });
-    fireEvent.click(screen.getByTestId("next-button"));
+  it("handles onSave with next from FormBranches", async () => {
+    const { mock, experiment } = mockExperimentQuery("demo-slug");
+    setMockUpdateState(experiment);
+    const mockMutation = mockUpdateExperimentBranchesMutation(
+      { ...mockUpdateState, id: 1 },
+      {},
+    );
+    render(<Subject mocks={[mock, mockMutation]} />);
+    await screen.findByTestId("PageEditBranches");
+    await act(
+      async () => void fireEvent.click(screen.getByTestId("next-button")),
+    );
     expect(navigate).toHaveBeenCalledWith("metrics");
   });
 
@@ -150,13 +155,10 @@ describe("PageEditBranches", () => {
       {},
     );
     render(<Subject mocks={[mock, mockMutation, mock]} />);
-    await waitFor(() => {
-      expect(screen.getByTestId("PageEditBranches")).toBeInTheDocument();
-    });
-    await act(async () => {
-      const saveButton = screen.getByTestId("save-button");
-      fireEvent.click(saveButton);
-    });
+    await screen.findByTestId("PageEditBranches");
+    await act(
+      async () => void fireEvent.click(screen.getByTestId("save-button")),
+    );
     expect(mockSetSubmitErrors).not.toHaveBeenCalled();
   });
 
@@ -260,7 +262,6 @@ jest.mock("./FormBranches", () => ({
     experiment,
     featureConfig,
     onSave,
-    onNext,
   }: React.ComponentProps<typeof FormBranches>) => {
     return (
       <div data-testid="FormBranches">
@@ -275,14 +276,29 @@ jest.mock("./FormBranches", () => ({
             )}
           </ul>
         )}
-        <button data-testid="next-button" onClick={() => onNext()}>
-          Next
+        <button
+          data-testid="next-button"
+          onClick={() =>
+            onSave(
+              mockUpdateState,
+              mockSetSubmitErrors,
+              mockClearSubmitErrors,
+              true,
+            )
+          }
+        >
+          Save and Continue
         </button>
         <button
           data-testid="save-button"
           type="submit"
           onClick={() =>
-            onSave(mockUpdateState, mockSetSubmitErrors, mockClearSubmitErrors)
+            onSave(
+              mockUpdateState,
+              mockSetSubmitErrors,
+              mockClearSubmitErrors,
+              false,
+            )
           }
         >
           <span>Save</span>

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/index.tsx
@@ -39,6 +39,7 @@ const PageEditBranches: React.FunctionComponent<RouteComponentProps> = () => {
       }: FormBranchesSaveState,
       setSubmitErrors,
       clearSubmitErrors,
+      next: boolean,
     ) => {
       try {
         // issue #3954: Need to parse string IDs into numbers
@@ -64,16 +65,16 @@ const PageEditBranches: React.FunctionComponent<RouteComponentProps> = () => {
           return void setSubmitErrors(message);
         }
         clearSubmitErrors();
+
+        if (next) {
+          navigate("metrics");
+        }
       } catch (error) {
         setSubmitErrors({ "*": [error.message] });
       }
     },
     [updateExperimentBranches],
   );
-
-  const onFormNext = useCallback(() => {
-    navigate("metrics");
-  }, []);
 
   return (
     <AppLayoutWithExperiment
@@ -104,7 +105,6 @@ const PageEditBranches: React.FunctionComponent<RouteComponentProps> = () => {
                 featureConfig,
                 isLoading: loading,
                 onSave: onFormSave,
-                onNext: onFormNext,
               }}
             />
           </>

--- a/app/experimenter/nimbus-ui/src/components/PageEditMetrics/FormMetrics/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditMetrics/FormMetrics/index.test.tsx
@@ -25,22 +25,17 @@ describe("FormMetrics", () => {
     );
   });
 
-  it("calls onNext when next clicked", async () => {
-    const onNext = jest.fn();
-    render(<Subject {...{ onNext }} />);
-
-    const nextButton = screen.getByText("Next");
-    await act(async () => void fireEvent.click(nextButton));
-    expect(onNext).toHaveBeenCalled();
-  });
-
-  it("calls onSave when save clicked", async () => {
+  it("calls onSave when save and next buttons are clicked", async () => {
     const onSave = jest.fn();
     render(<Subject {...{ onSave }} />);
 
-    const saveButton = screen.getByText("Save");
-    await act(async () => void fireEvent.click(saveButton));
-    expect(onSave).toHaveBeenCalled();
+    const submitButton = screen.getByTestId("submit-button");
+    const nextButton = screen.getByTestId("next-button");
+    await act(async () => {
+      fireEvent.click(submitButton);
+      fireEvent.click(nextButton);
+    });
+    expect(onSave).toHaveBeenCalledTimes(2);
   });
 
   it("disables save when loading", async () => {

--- a/app/experimenter/nimbus-ui/src/components/PageEditMetrics/FormMetrics/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditMetrics/FormMetrics/mocks.tsx
@@ -11,7 +11,6 @@ export const Subject = ({
   isServerValid = true,
   submitErrors = {},
   onSave = () => {},
-  onNext = () => {},
   experiment = mockExperimentQuery("boo").experiment,
 }: Partial<React.ComponentProps<typeof FormMetrics>>) => {
   const [submitErrorsDefault, setSubmitErrors] = useState<Record<string, any>>(
@@ -26,7 +25,6 @@ export const Subject = ({
           isServerValid,
           setSubmitErrors,
           onSave,
-          onNext,
           experiment,
         }}
       />

--- a/app/experimenter/nimbus-ui/src/components/PageEditMetrics/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditMetrics/index.test.tsx
@@ -159,14 +159,8 @@ describe("PageEditMetrics", () => {
 
   it("handles form submission", async () => {
     render(<Subject mocks={[mock, mutationMock]} />);
-
-    let submitButton: HTMLButtonElement;
-    await waitFor(() => {
-      submitButton = screen.getByTestId("submit") as HTMLButtonElement;
-    });
-    await act(async () => {
-      fireEvent.click(submitButton);
-    });
+    await screen.findByTestId("PageEditMetrics");
+    await act(async () => void fireEvent.click(screen.getByTestId("submit")));
     expect(mockSubmit).toHaveBeenCalled();
   });
 
@@ -216,8 +210,10 @@ describe("PageEditMetrics", () => {
   });
 
   it("handles form next button", async () => {
-    render(<Subject mocks={[mock]} />);
-    await waitFor(() => fireEvent.click(screen.getByTestId("next")));
+    render(<Subject mocks={[mock, mutationMock]} />);
+    await screen.findByTestId("PageEditMetrics");
+    await act(async () => void fireEvent.click(screen.getByTestId("next")));
+    expect(mockSubmit).toHaveBeenCalled();
     expect(navigate).toHaveBeenCalledWith("audience");
   });
 });
@@ -229,11 +225,12 @@ jest.mock("./FormMetrics", () => ({
     const handleSubmit = (ev: React.FormEvent) => {
       ev.preventDefault();
       mockSubmit();
-      props.onSave(mockSubmitData, jest.fn());
+      props.onSave(mockSubmitData, false);
     };
     const handleNext = (ev: React.FormEvent) => {
       ev.preventDefault();
-      props.onNext && props.onNext(ev);
+      mockSubmit();
+      props.onSave(mockSubmitData, true);
     };
     return (
       <div data-testid="FormMetrics">

--- a/app/experimenter/nimbus-ui/src/components/PageEditMetrics/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditMetrics/index.tsx
@@ -27,10 +27,13 @@ const PageEditMetrics: React.FunctionComponent<RouteComponentProps> = () => {
   const [isServerValid, setIsServerValid] = useState(true);
 
   const onSave = useCallback(
-    async ({
-      primaryProbeSetSlugs,
-      secondaryProbeSetSlugs,
-    }: Record<string, string[]>) => {
+    async (
+      {
+        primaryProbeSetSlugs,
+        secondaryProbeSetSlugs,
+      }: Record<string, string[]>,
+      next: boolean,
+    ) => {
       try {
         const nimbusExperimentId = currentExperiment.current!.id;
         const result = await updateExperimentProbeSets({
@@ -57,6 +60,10 @@ const PageEditMetrics: React.FunctionComponent<RouteComponentProps> = () => {
           setSubmitErrors({});
           // In practice this should be defined by the time we get here
           refetchReview.current!();
+
+          if (next) {
+            navigate("audience");
+          }
         }
       } catch (error) {
         setSubmitErrors({ "*": SUBMIT_ERROR });
@@ -64,10 +71,6 @@ const PageEditMetrics: React.FunctionComponent<RouteComponentProps> = () => {
     },
     [updateExperimentProbeSets, currentExperiment],
   );
-
-  const onNext = useCallback(() => {
-    navigate("audience");
-  }, []);
 
   return (
     <AppLayoutWithExperiment
@@ -102,7 +105,6 @@ const PageEditMetrics: React.FunctionComponent<RouteComponentProps> = () => {
                 submitErrors,
                 setSubmitErrors,
                 onSave,
-                onNext,
               }}
             />
           </>

--- a/app/experimenter/nimbus-ui/src/components/PageEditOverview/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditOverview/index.test.tsx
@@ -142,14 +142,8 @@ describe("PageEditOverview", () => {
 
   it("handles form submission", async () => {
     render(<Subject mocks={[mock, mutationMock]} />);
-
-    let submitButton: HTMLButtonElement;
-    await waitFor(() => {
-      submitButton = screen.getByTestId("submit") as HTMLButtonElement;
-    });
-    await act(async () => {
-      fireEvent.click(submitButton);
-    });
+    await screen.findByTestId("PageEditOverview");
+    await act(async () => void fireEvent.click(screen.getByTestId("submit")));
     expect(mockSubmit).toHaveBeenCalled();
   });
 
@@ -203,8 +197,10 @@ describe("PageEditOverview", () => {
   });
 
   it("handles form next button", async () => {
-    render(<Subject mocks={[mock]} />);
-    await waitFor(() => fireEvent.click(screen.getByTestId("next")));
+    render(<Subject mocks={[mock, mutationMock]} />);
+    await screen.findByTestId("PageEditOverview");
+    await act(async () => void fireEvent.click(screen.getByTestId("next")));
+    expect(mockSubmit).toHaveBeenCalled();
     expect(navigate).toHaveBeenCalledWith("branches");
   });
 });
@@ -216,11 +212,12 @@ jest.mock("../FormOverview", () => ({
     const handleSubmit = (ev: React.FormEvent) => {
       ev.preventDefault();
       mockSubmit();
-      props.onSubmit(mockSubmitData, jest.fn());
+      props.onSubmit(mockSubmitData, false);
     };
     const handleNext = (ev: React.FormEvent) => {
       ev.preventDefault();
-      props.onNext && props.onNext(ev);
+      mockSubmit();
+      props.onSubmit(mockSubmitData, true);
     };
     return (
       <div data-testid="FormOverview">

--- a/app/experimenter/nimbus-ui/src/components/PageEditOverview/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditOverview/index.tsx
@@ -28,13 +28,16 @@ const PageEditOverview: React.FunctionComponent<PageEditOverviewProps> = () => {
   const [isServerValid, setIsServerValid] = useState(true);
 
   const onFormSubmit = useCallback(
-    async ({
-      name,
-      hypothesis,
-      riskMitigationLink,
-      publicDescription,
-      documentationLinks,
-    }: Record<string, any>) => {
+    async (
+      {
+        name,
+        hypothesis,
+        riskMitigationLink,
+        publicDescription,
+        documentationLinks,
+      }: Record<string, any>,
+      next: boolean,
+    ) => {
       try {
         const result = await updateExperimentOverview({
           variables: {
@@ -63,6 +66,10 @@ const PageEditOverview: React.FunctionComponent<PageEditOverviewProps> = () => {
           setSubmitErrors({});
           // In practice this should be defined by the time we get here
           refetchReview.current!();
+
+          if (next) {
+            navigate(`branches`);
+          }
         }
       } catch (error) {
         setSubmitErrors({ "*": SUBMIT_ERROR });
@@ -70,10 +77,6 @@ const PageEditOverview: React.FunctionComponent<PageEditOverviewProps> = () => {
     },
     [updateExperimentOverview, currentExperiment],
   );
-
-  const onFormNext = useCallback(() => {
-    navigate(`branches`);
-  }, []);
 
   return (
     <AppLayoutWithExperiment
@@ -97,7 +100,6 @@ const PageEditOverview: React.FunctionComponent<PageEditOverviewProps> = () => {
               submitErrors,
               setSubmitErrors,
               onSubmit: onFormSubmit,
-              onNext: onFormNext,
             }}
           />
         );

--- a/app/experimenter/nimbus-ui/src/components/PageNew/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageNew/index.tsx
@@ -31,10 +31,7 @@ const PageNew: React.FunctionComponent<PageNewProps> = () => {
   }, []);
 
   const onFormSubmit = useCallback(
-    async (
-      { name, hypothesis, application }: Record<string, any>,
-      resetForm: Function,
-    ) => {
+    async ({ name, hypothesis, application }: Record<string, any>) => {
       try {
         const result = await createExperiment({
           variables: { input: { name, hypothesis, application } },
@@ -51,7 +48,6 @@ const PageNew: React.FunctionComponent<PageNewProps> = () => {
           setIsServerValid(true);
           setSubmitErrors({});
         }
-        resetForm();
         navigate(`${nimbusExperiment!.slug}/edit/overview`);
       } catch (error) {
         setSubmitErrors({ "*": `${SUBMIT_ERROR}` });


### PR DESCRIPTION
Closes #4022

This PR modifies to "Next" button on all four experiment pages:

- Updates their label to "Save and Continue"
- Saves the experiment data before continuing to next page
  - Save must be valid (no client or server/validation errors

Couple notes:

- Although the button was changed from "Next" to "Save and Continue" I left most of the internal references as "next", since it does take you next and renaming everything to the much longer "save-and-continue-button" didn't seem worth it.
- The Audience page needs to prevent you from continuing to the Request Review page until all valid fields are filled out, and so the Save and Continue button is disabled until the server allows you to continue. But since that button also saves, you could in theory set an empty value, hit Save and Continue, the value would save, and you would be redirected to the Review page -- _however_, by the time you hit that page it'll know you have an invalid experiment and will just redirect you back to the Audience page.