### PR TITLE
fixes #4454 feat(nimbus): remove alternating row colors, use gray branch thead,  on summary tables

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/Summary/TableAudience/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/TableAudience/index.tsx
@@ -19,7 +19,7 @@ const TableAudience = ({ experiment }: TableAudienceProps) => {
   const { firefoxMinVersion, channel, targetingConfigSlug } = useConfig();
 
   return (
-    <Table striped bordered data-testid="table-audience" className="mb-4">
+    <Table bordered data-testid="table-audience" className="mb-4">
       <tbody>
         <tr>
           <th className="w-33">Channel</th>

--- a/app/experimenter/nimbus-ui/src/components/Summary/TableBranches/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/TableBranches/index.tsx
@@ -48,13 +48,15 @@ const TableBranch = ({
   branch: Branch;
 }) => {
   return (
-    <Table striped bordered data-testid="table-branch" className="mb-4">
-      <tbody>
+    <Table bordered data-testid="table-branch" className="mb-4">
+      <thead className="thead-light">
         <tr>
           <th colSpan={2} data-testid="branch-name">
             {name ? name : <NotSet />}
           </th>
         </tr>
+      </thead>
+      <tbody>
         <tr>
           <th className="w-33">Slug</th>
           <td data-testid="branch-slug">{slug ? slug : <NotSet />}</td>

--- a/app/experimenter/nimbus-ui/src/components/Summary/TableSummary/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/TableSummary/index.tsx
@@ -25,7 +25,7 @@ const TableSummary = ({ experiment }: TableSummaryProps) => {
   } = useConfig();
 
   return (
-    <Table striped bordered data-testid="table-summary" className="mb-4">
+    <Table bordered data-testid="table-summary" className="mb-4">
       <tbody>
         <tr>
           <th className="w-33">Slug</th>


### PR DESCRIPTION
Real quick one. This PR just removes the alternating row colors used in the `<Summary>` tables, and adds a grey header style to branch names.

[Storybook](https://storage.googleapis.com/mozilla-storybooks-experimenter/commits/814d5375f4d166b53dc2bc44f33f0ae775d6748b/nimbus-ui/index.html?path=/story/pages-summary--basic)