### PR TITLE
fixes #4628 feat(nimbus): Return targeting: "true" for experiments match all clients

### DIFF
--- a/app/experimenter/experiments/api/v6/serializers.py
+++ b/app/experimenter/experiments/api/v6/serializers.py
@@ -98,17 +98,6 @@ class NimbusExperimentSerializer(serializers.ModelSerializer):
             "featureIds",
         )
 
-    def to_representation(self, instance):
-        representation = super(NimbusExperimentSerializer, self).to_representation(
-            instance
-        )
-
-        # issue #4542: remove targeting altogether, if it's None
-        if representation["targeting"] is None:
-            representation.pop("targeting")
-
-        return representation
-
     def get_application(self, obj):
         return self.get_appId(obj)
 

--- a/app/experimenter/experiments/models/nimbus.py
+++ b/app/experimenter/experiments/models/nimbus.py
@@ -122,8 +122,9 @@ class NimbusExperiment(NimbusConstants, models.Model):
         if self.is_desktop_experiment:
             expressions.append("'app.shield.optoutstudies.enabled'|preferenceValue")
 
+        #  If there is no targeting defined all clients should match, so we return "true"
         if len(expressions) == 0:
-            return None
+            return "true"
 
         return " && ".join(expressions)
 

--- a/app/experimenter/experiments/tests/api/v5/test_queries.py
+++ b/app/experimenter/experiments/tests/api/v5/test_queries.py
@@ -283,7 +283,7 @@ class TestNimbusQuery(GraphQLTestCase):
         experiment_data = content["data"]["experimentBySlug"]
         self.assertEqual(
             experiment_data["jexlTargetingExpression"],
-            None,
+            "true",
         )
 
     def test_nimbus_config(self):

--- a/app/experimenter/experiments/tests/api/v6/test_serializers.py
+++ b/app/experimenter/experiments/tests/api/v6/test_serializers.py
@@ -240,7 +240,7 @@ class TestNimbusExperimentSerializer(TestCase):
             application=NimbusExperiment.Application.FENIX,
         )
         serializer = NimbusExperimentSerializer(experiment)
-        self.assertTrue("targeting" not in serializer.data)
+        self.assertEqual(serializer.data["targeting"], "true")
         check_schema("experiments/NimbusExperiment", serializer.data)
 
 

--- a/app/experimenter/experiments/tests/test_models/test_models_nimbus.py
+++ b/app/experimenter/experiments/tests/test_models/test_models_nimbus.py
@@ -60,7 +60,7 @@ class TestNimbusExperiment(TestCase):
             channel=NimbusExperiment.Channel.NO_CHANNEL,
         )
 
-        self.assertEqual(experiment.targeting, None)
+        self.assertEqual(experiment.targeting, "true")
 
     def test_targeting_without_firefox_min_version(
         self,


### PR DESCRIPTION
Because

* 'true' is more explicit than null or undefined  targeting

This commit

* Change the Nimbus model to return targeting: "true" for experiments match all clients