### PR TITLE
fix #4607 feat(nimbus): generate accepted changelog in kinto push task

### DIFF
--- a/app/experimenter/kinto/tasks.py
+++ b/app/experimenter/kinto/tasks.py
@@ -48,6 +48,8 @@ def nimbus_push_experiment_to_kinto(experiment_id):
         experiment.status = NimbusExperiment.Status.ACCEPTED
         experiment.save()
 
+        generate_nimbus_changelog(experiment, get_kinto_user())
+
         logger.info(f"{experiment} pushed to Kinto")
         metrics.incr("push_experiment_to_kinto.completed")
     except Exception as e:

--- a/app/experimenter/kinto/tests/test_tasks.py
+++ b/app/experimenter/kinto/tests/test_tasks.py
@@ -18,7 +18,9 @@ from experimenter.kinto.tests.mixins import MockKintoClientMixin
 
 
 class TestPushExperimentToKintoTask(MockKintoClientMixin, TestCase):
-    def test_push_experiment_to_kinto_sends_desktop_experiment_data(self):
+    def test_push_experiment_to_kinto_sends_desktop_experiment_data_and_sets_accepted(
+        self,
+    ):
         experiment = NimbusExperimentFactory.create_with_status(
             NimbusExperiment.Status.REVIEW,
             application=NimbusExperiment.Application.DESKTOP,
@@ -33,6 +35,15 @@ class TestPushExperimentToKintoTask(MockKintoClientMixin, TestCase):
             collection=settings.KINTO_COLLECTION_NIMBUS_DESKTOP,
             bucket=settings.KINTO_BUCKET,
             if_not_exists=True,
+        )
+
+        experiment = NimbusExperiment.objects.get(id=experiment.id)
+        self.assertEqual(experiment.status, NimbusExperiment.Status.ACCEPTED)
+        self.assertTrue(
+            experiment.changes.filter(
+                old_status=NimbusExperiment.Status.REVIEW,
+                new_status=NimbusExperiment.Status.ACCEPTED,
+            ).exists()
         )
 
     def test_push_experiment_to_kinto_sends_fenix_experiment_data(self):


### PR DESCRIPTION
Because

* We rely on a changelog recording REVIEW > ACCEPTED and ACCEPTED > LIVE to know the experiment start date
* We neglected to create a REVIEW > ACCEPTED changelog after the experiment is pushed to kinto so we were accidentally creating REVIEW > LIVE changelogs

This commit

* Creates a changelog when the experiment goes to REVIEW > ACCEPTED
* Updates test