### PR TITLE
fixes #4635 fix(Legacy): Add default for total for normandy sampling …

### DIFF
--- a/app/experimenter/normandy/tasks.py
+++ b/app/experimenter/normandy/tasks.py
@@ -192,7 +192,7 @@ def update_population_percent(experiment, recipe_data, filter_objects):
     ):
 
         decimal.getcontext().prec = 5
-        bucket_total = bucket_sample.get("total", 10000)
+        bucket_total = bucket_sample.get("total", experiment.BUCKET_TOTAL)
         percent_decimal = (
             decimal.Decimal(bucket_sample["count"])
             / decimal.Decimal(bucket_total)

--- a/app/experimenter/normandy/tasks.py
+++ b/app/experimenter/normandy/tasks.py
@@ -192,9 +192,10 @@ def update_population_percent(experiment, recipe_data, filter_objects):
     ):
 
         decimal.getcontext().prec = 5
+        bucket_total = bucket_sample.get("total", 10000)
         percent_decimal = (
             decimal.Decimal(bucket_sample["count"])
-            / decimal.Decimal(bucket_sample["total"])
+            / decimal.Decimal(bucket_total)
             * decimal.Decimal(100)
         )
 

--- a/app/experimenter/normandy/tests/test_tasks.py
+++ b/app/experimenter/normandy/tests/test_tasks.py
@@ -353,7 +353,6 @@ class TestUpdateExperimentTask(MockNormandyTasksMixin, MockNormandyMixin, TestCa
                         "count": 300,
                         "namespace": "first-run",
                         "start": 9700,
-                        "total": 10000,
                         "type": "namespaceSample",
                     }
                 ],


### PR DESCRIPTION
…filter

Because:

* the namespace filter does not include a total value

This commit:

* add default value of 10000 for total for sampling filters