### PR TITLE
fix #4539 feat(nimbus): add enrollment data to v5 api

### DIFF
--- a/app/experimenter/experiments/api/v5/types.py
+++ b/app/experimenter/experiments/api/v5/types.py
@@ -132,6 +132,8 @@ class NimbusExperimentType(DjangoObjectType):
     monitoring_dashboard_url = graphene.String()
     start_date = graphene.DateTime()
     end_date = graphene.DateTime()
+    is_enrollment_paused = graphene.Boolean()
+    enrollment_end_date = graphene.DateTime()
 
     class Meta:
         model = NimbusExperiment
@@ -157,3 +159,9 @@ class NimbusExperimentType(DjangoObjectType):
 
     def resolve_jexl_targeting_expression(self, info):
         return self.targeting
+
+    def resolve_is_enrollment_paused(self, info):
+        return self.is_paused
+
+    def resolve_enrollment_end_date(self, info):
+        return self.proposed_enrollment_end_date

--- a/app/experimenter/nimbus-ui/schema.graphql
+++ b/app/experimenter/nimbus-ui/schema.graphql
@@ -192,6 +192,8 @@ type NimbusExperimentType {
   monitoringDashboardUrl: String
   startDate: DateTime
   endDate: DateTime
+  isEnrollmentPaused: Boolean
+  enrollmentEndDate: DateTime
 }
 
 enum NimbusFeatureConfigApplication {


### PR DESCRIPTION
Because

* We need to be able to display the pause state and date in the UI

This commit

* Adds enrollment paused and paused date to V5 API