### PR TITLE
fix #3947 feat(nimbus): synchronize preview experiments with preview kinto collection

### DIFF
--- a/app/bin/setup_kinto.py
+++ b/app/bin/setup_kinto.py
@@ -13,6 +13,7 @@ KINTO_BUCKET_WORKSPACE = "main-workspace"
 KINTO_BUCKET_MAIN = "main"
 KINTO_COLLECTION_NIMBUS_DESKTOP = "nimbus-desktop-experiments"
 KINTO_COLLECTION_NIMBUS_MOBILE = "nimbus-mobile-experiments"
+KINTO_COLLECTION_NIMBUS_PREVIEW = "nimbus-preview"
 
 
 def create_user(user, passw):
@@ -44,6 +45,7 @@ print(
 for collection in [
     KINTO_COLLECTION_NIMBUS_DESKTOP,
     KINTO_COLLECTION_NIMBUS_MOBILE,
+    KINTO_COLLECTION_NIMBUS_PREVIEW,
 ]:
     print(">>>> Creating kinto group: editors")
     print(

--- a/app/experimenter/settings.py
+++ b/app/experimenter/settings.py
@@ -337,6 +337,10 @@ CELERY_BEAT_SCHEDULE = {
         "task": "experimenter.kinto.tasks.nimbus_update_paused_experiments_in_kinto",
         "schedule": config("CELERY_SCHEDULE_INTERVAL", default=300, cast=int),
     },
+    "nimbus_synchronize_preview_experiments_in_kinto": {
+        "task": "experimenter.kinto.tasks.nimbus_synchronize_preview_experiments_in_kinto",
+        "schedule": config("CELERY_SCHEDULE_INTERVAL", default=300, cast=int),
+    },
 }
 
 # Recipe Configuration
@@ -407,6 +411,7 @@ KINTO_BUCKET_WORKSPACE = "main-workspace"
 KINTO_BUCKET_MAIN = "main"
 KINTO_COLLECTION_NIMBUS_DESKTOP = "nimbus-desktop-experiments"
 KINTO_COLLECTION_NIMBUS_MOBILE = "nimbus-mobile-experiments"
+KINTO_COLLECTION_NIMBUS_PREVIEW = "nimbus-preview"
 
 
 # Jetstream GCS Bucket data

--- a/kinto/server.ini
+++ b/kinto/server.ini
@@ -39,6 +39,9 @@ kinto.signer.autograph.server_url = http://autograph:8000
 # Use credentials from https://github.com/mozilla-services/autograph/blob/5b4a473/autograph.yaml
 kinto.signer.autograph.hawk_id = kintodev
 kinto.signer.autograph.hawk_secret = 3isey64n25fim18chqgewirm6z2gwva1mas0eu71e9jtisdwv6bd
+# disable review for preview
+kinto.signer.main-workspace.nimbus-preview.to_review_enabled = false
+kinto.signer.main-workspace.nimbus-preview.group_check_enabled = false
 
 [uwsgi]
 wsgi-file = app.wsgi


### PR DESCRIPTION


Because

* We want any experiments in the preview state to be immediately published to the preview kinto collection
* We want any experiments not in the preview state to be immediately unpublished from the preview kinto collection

This commit

* Adds a local nimbus-preview collection to the local dev remote settings and configures it to have reviews disabled
* Adds additional logic to our kinto client to support collections with reviewing disabled
* Adds a celery task that ensures only experiments in the preview state are published in the preview collection
* Adds that celery task to our celery schedule
* Explicitly invokes that celery task when an experiment is updated to the PREVIEW status