### PR TITLE
fixes #4540 feat(nimbus): add badges to indicate enrollment active, completed, experiment end requested

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/Summary/EndExperiment/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/EndExperiment/index.tsx
@@ -7,22 +7,25 @@ import React, { useCallback, useState } from "react";
 import { Alert, Button } from "react-bootstrap";
 import { END_EXPERIMENT_MUTATION } from "../../../gql/experiments";
 import { SUBMIT_ERROR } from "../../../lib/constants";
-import { getStatus } from "../../../lib/experiment";
 import { endExperiment_endExperiment as EndExperimentResult } from "../../../types/endExperiment";
 import { getExperiment_experimentBySlug } from "../../../types/getExperiment";
-import { ExperimentIdInput } from "../../../types/globalTypes";
+import {
+  ExperimentIdInput,
+  NimbusExperimentStatus,
+} from "../../../types/globalTypes";
 
 const EndExperiment = ({
   experiment,
-  status,
 }: {
   experiment: getExperiment_experimentBySlug;
-  status: ReturnType<typeof getStatus>;
 }) => {
   const [submitError, setSubmitError] = useState<string | null>(null);
   const [showEndConfirmation, setShowEndConfirmation] = useState(false);
   const [endRequested, setEndRequested] = useState(false);
-  const isEnding = status.ending || endRequested;
+  const isEnding =
+    (experiment.status === NimbusExperimentStatus.LIVE &&
+      experiment.isEndRequested) ||
+    endRequested;
 
   const [endExperiment, { loading: endExperimentLoading }] = useMutation<
     { endExperiment: EndExperimentResult },

--- a/app/experimenter/nimbus-ui/src/components/Summary/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/index.stories.tsx
@@ -44,6 +44,28 @@ storiesOf("components/Summary", module)
     });
     return <Subject {...{ experiment }} />;
   })
+  .add("enrollment active", () => {
+    const { experiment } = mockExperimentQuery("demo-slug", {
+      status: NimbusExperimentStatus.LIVE,
+      isEnrollmentPaused: false,
+    });
+    return <Subject {...{ experiment }} />;
+  })
+  .add("enrollment ended", () => {
+    const { experiment } = mockExperimentQuery("demo-slug", {
+      status: NimbusExperimentStatus.LIVE,
+      enrollmentEndDate: new Date().toISOString(),
+    });
+    return <Subject {...{ experiment }} />;
+  })
+  .add("enrollment ended + end requested", () => {
+    const { experiment } = mockExperimentQuery("demo-slug", {
+      status: NimbusExperimentStatus.LIVE,
+      isEndRequested: true,
+      enrollmentEndDate: new Date().toISOString(),
+    });
+    return <Subject {...{ experiment }} />;
+  })
   .add("no branches", () => {
     const { experiment } = mockExperimentQuery("demo-slug", {
       referenceBranch: null,

--- a/app/experimenter/nimbus-ui/src/components/Summary/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/index.test.tsx
@@ -28,7 +28,35 @@ describe("Summary", () => {
       status: NimbusExperimentStatus.LIVE,
     });
     render(<Subject {...{ experiment }} />);
-    expect(screen.queryByTestId("experiment-end")).toBeInTheDocument();
+    await screen.findByTestId("experiment-end");
+  });
+
+  it("renders end experiment badge if end is requested", async () => {
+    const { experiment } = mockExperimentQuery("demo-slug", {
+      status: NimbusExperimentStatus.LIVE,
+      isEndRequested: true,
+    });
+    render(<Subject {...{ experiment }} />);
+    await screen.findByTestId("pill-end-requested");
+  });
+
+  it("renders end experiment badge if enrollment is not paused", async () => {
+    const { experiment } = mockExperimentQuery("demo-slug", {
+      status: NimbusExperimentStatus.LIVE,
+      isEnrollmentPaused: false,
+    });
+    render(<Subject {...{ experiment }} />);
+    await screen.findByTestId("pill-enrolling-active");
+  });
+
+  it("renders end experiment badge if enrollment is not paused", async () => {
+    const { experiment } = mockExperimentQuery("demo-slug", {
+      status: NimbusExperimentStatus.LIVE,
+      isEnrollmentPaused: true,
+      enrollmentEndDate: new Date().toISOString(),
+    });
+    render(<Subject {...{ experiment }} />);
+    await screen.findByTestId("pill-enrolling-complete");
   });
 
   it("renders as expected with no defined branches", () => {

--- a/app/experimenter/nimbus-ui/src/components/Summary/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/index.tsx
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React from "react";
+import Badge from "react-bootstrap/Badge";
 import { ReactComponent as ExternalIcon } from "../../images/external.svg";
 import { getStatus } from "../../lib/experiment";
 import { ConfigOptions, getConfigLabel } from "../../lib/getConfigLabel";
@@ -29,9 +30,13 @@ const Summary = ({ experiment }: SummaryProps) => {
 
   return (
     <div data-testid="summary">
-      <h2 className="h5 mb-3">Timeline</h2>
+      <h2 className="h5 mb-3">
+        Timeline
+        {status.live && <StatusPills {...{ experiment }} />}
+      </h2>
+
       <SummaryTimeline {...{ experiment }} />
-      {status.live && <EndExperiment {...{ experiment, status }} />}
+      {status.live && <EndExperiment {...{ experiment }} />}
 
       <hr />
 
@@ -75,3 +80,39 @@ export const displayConfigLabelOrNotSet = (
 };
 
 export default Summary;
+
+const StatusPills = ({
+  experiment,
+}: {
+  experiment: getExperiment_experimentBySlug;
+}) => (
+  <>
+    {experiment.isEndRequested && (
+      <StatusPill
+        testId="pill-end-requested"
+        label="Experiment End Requested"
+      />
+    )}
+    {experiment.isEnrollmentPaused === false && (
+      <StatusPill
+        testId="pill-enrolling-active"
+        label="Enrolling Users in Progress"
+      />
+    )}
+    {experiment.isEnrollmentPaused && experiment.enrollmentEndDate && (
+      <StatusPill
+        testId="pill-enrolling-complete"
+        label="Enrollment Complete"
+      />
+    )}
+  </>
+);
+
+const StatusPill = ({ label, testId }: { label: string; testId: string }) => (
+  <Badge
+    className="ml-2 border rounded-pill px-2 bg-white border-primary text-primary font-weight-normal"
+    data-testid={testId}
+  >
+    {label}
+  </Badge>
+);

--- a/app/experimenter/nimbus-ui/src/gql/experiments.ts
+++ b/app/experimenter/nimbus-ui/src/gql/experiments.ts
@@ -110,6 +110,9 @@ export const GET_EXPERIMENT_QUERY = gql`
         title
         link
       }
+
+      isEnrollmentPaused
+      enrollmentEndDate
     }
   }
 `;

--- a/app/experimenter/nimbus-ui/src/lib/experiment.test.ts
+++ b/app/experimenter/nimbus-ui/src/lib/experiment.test.ts
@@ -29,8 +29,5 @@ describe("getStatus", () => {
     expect(getStatus(experiment).complete).toBeTruthy();
     expect(getStatus(experiment).released).toBeTruthy();
     expect(getStatus(experiment).locked).toBeTruthy();
-
-    experiment.isEndRequested = true;
-    expect(getStatus(experiment).ending).toBeTruthy();
   });
 });

--- a/app/experimenter/nimbus-ui/src/lib/experiment.ts
+++ b/app/experimenter/nimbus-ui/src/lib/experiment.ts
@@ -10,7 +10,6 @@ export function getStatus(
   experiment?: getExperiment_experimentBySlug | getAllExperiments_experiments,
 ) {
   const status = experiment?.status;
-  const ending = NimbusExperimentStatus.LIVE && !!experiment?.isEndRequested;
   const released = status
     ? [NimbusExperimentStatus.LIVE, NimbusExperimentStatus.COMPLETE].includes(
         status,
@@ -35,7 +34,6 @@ export function getStatus(
     ].includes(status!),
     // The experiment is or was out in the wild (live or complete)
     released,
-    ending,
   };
 }
 

--- a/app/experimenter/nimbus-ui/src/lib/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/lib/mocks.tsx
@@ -330,6 +330,8 @@ export function mockExperimentQuery<
           link: "https://bingo.bongo",
         },
       ],
+      isEnrollmentPaused: true,
+      enrollmentEndDate: null,
     },
     modifications,
   );

--- a/app/experimenter/nimbus-ui/src/types/getExperiment.ts
+++ b/app/experimenter/nimbus-ui/src/types/getExperiment.ts
@@ -99,6 +99,8 @@ export interface getExperiment_experimentBySlug {
   endDate: DateTime | null;
   riskMitigationLink: string;
   documentationLinks: getExperiment_experimentBySlug_documentationLinks[] | null;
+  isEnrollmentPaused: boolean | null;
+  enrollmentEndDate: DateTime | null;
 }
 
 export interface getExperiment {


### PR DESCRIPTION
This PR adds three new conditional pill badges to the "Timeline" header on the Summary page.

Experiment must be in a "live" state in order to show any of these badges.

- "Enrolling Users in Progress" is displayed when the experiment property `isEnrollmentPaused` is false to indicate users are actively being enrolled in the experiment. [Storybook](https://storage.googleapis.com/mozilla-storybooks-experimenter/commits/248c2e65af816aa976ea4f54ffc8183e75f44bbe/nimbus-ui/index.html?path=/story/components-summary--enrollment-active).
- "Enrollment Complete" is displayed when `enrollmentCompletedDate` is defined (and `isEnrollmentPaused` is true to be safe) to indicate users will no longer be enrolled in this experiment. [Storybook](https://storage.googleapis.com/mozilla-storybooks-experimenter/commits/248c2e65af816aa976ea4f54ffc8183e75f44bbe/nimbus-ui/index.html?path=/story/components-summary--enrollment-ended)
- "Experiment End Requested" is displayed when `isEndRequested` is true to indicate the experiment owner has requested it be ended and is awaiting confirmation from RS. [Storybook](https://storage.googleapis.com/mozilla-storybooks-experimenter/commits/248c2e65af816aa976ea4f54ffc8183e75f44bbe/nimbus-ui/index.html?path=/story/components-summary--end-requested)

Only somewhat related, but I wanted to slip this in: I removed the `ending` property from the `getStatus` helper, as it had become a slippery slope for adding other non-status related properties (like one for enrollment active, completed). It'll just be used as a convenience for actual experiment status types.