### PR TITLE
fix #4505, #4659: feat(visualization) Add tooltips for guardrail metrics and update control content for highlights table

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableHighlights/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableHighlights/index.stories.tsx
@@ -18,7 +18,7 @@ storiesOf("pages/Results/TableHighlights", module)
       <RouterSlugProvider mocks={[mock]}>
         <TableHighlights
           primaryProbeSets={experiment.primaryProbeSets!}
-          results={mockAnalysis().overall}
+          results={mockAnalysis()}
         />
       </RouterSlugProvider>
     );
@@ -44,7 +44,7 @@ storiesOf("pages/Results/TableHighlights", module)
       <RouterSlugProvider mocks={[mock]}>
         <TableHighlights
           primaryProbeSets={experiment.primaryProbeSets!}
-          results={mockAnalysis().overall}
+          results={mockAnalysis()}
         />
       </RouterSlugProvider>
     );

--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableHighlights/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableHighlights/index.test.tsx
@@ -19,7 +19,7 @@ describe("TableHighlights", () => {
       <RouterSlugProvider mocks={[mock]}>
         <TableHighlights
           primaryProbeSets={experiment.primaryProbeSets!}
-          results={mockAnalysis().overall}
+          results={mockAnalysis()}
         />
       </RouterSlugProvider>,
     );
@@ -38,7 +38,7 @@ describe("TableHighlights", () => {
       <RouterSlugProvider mocks={[mock]}>
         <TableHighlights
           primaryProbeSets={experiment.primaryProbeSets!}
-          results={mockAnalysis().overall}
+          results={mockAnalysis()}
         />
       </RouterSlugProvider>,
     );
@@ -53,7 +53,7 @@ describe("TableHighlights", () => {
       <RouterSlugProvider mocks={[mock]}>
         <TableHighlights
           primaryProbeSets={experiment.primaryProbeSets!}
-          results={mockAnalysis().overall}
+          results={mockAnalysis()}
         />
       </RouterSlugProvider>,
     );

--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableMetricSecondary/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableMetricSecondary/index.tsx
@@ -3,8 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React from "react";
-import ReactMarkdown from "react-markdown";
-import ReactTooltip from "react-tooltip";
 import { ReactComponent as Info } from "../../../images/info.svg";
 import {
   DISPLAY_TYPE,
@@ -15,6 +13,7 @@ import {
 import { AnalysisData } from "../../../lib/visualization/types";
 import GraphsWeekly from "../GraphsWeekly";
 import TableVisualizationRow from "../TableVisualizationRow";
+import TooltipWithMarkdown from "../TooltipWithMarkdown";
 
 type SecondaryMetricStatistic = {
   name: string;
@@ -79,16 +78,10 @@ const TableMetricSecondary = ({
                   data-for={probeSetSlug}
                   className="align-baseline"
                 />
-                <ReactTooltip
-                  id={probeSetSlug}
-                  multiline
-                  clickable
-                  className="w-25"
-                  delayHide={200}
-                  effect="solid"
-                >
-                  <ReactMarkdown source={probeSetDescription!} />
-                </ReactTooltip>
+                <TooltipWithMarkdown
+                  tooltipId={probeSetSlug}
+                  markdown={probeSetDescription}
+                />
               </>
             )}
           </div>

--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableResults/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableResults/index.stories.tsx
@@ -18,7 +18,7 @@ storiesOf("pages/Results/TableResults", module)
       <RouterSlugProvider mocks={[mock]}>
         <TableResults
           primaryProbeSets={experiment.primaryProbeSets!}
-          results={mockAnalysis().overall}
+          results={mockAnalysis()}
         />
       </RouterSlugProvider>
     );
@@ -44,7 +44,7 @@ storiesOf("pages/Results/TableResults", module)
       <RouterSlugProvider mocks={[mock]}>
         <TableResults
           primaryProbeSets={experiment.primaryProbeSets!}
-          results={mockAnalysis().overall}
+          results={mockAnalysis()}
         />
       </RouterSlugProvider>
     );

--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableResults/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableResults/index.test.tsx
@@ -20,7 +20,7 @@ describe("TableResults", () => {
       <RouterSlugProvider mocks={[mock]}>
         <TableResults
           primaryProbeSets={experiment.primaryProbeSets!}
-          results={mockAnalysis().overall}
+          results={mockAnalysis()}
         />
       </RouterSlugProvider>,
     );
@@ -42,7 +42,7 @@ describe("TableResults", () => {
       <RouterSlugProvider mocks={[mock]}>
         <TableResults
           primaryProbeSets={experiment.primaryProbeSets!}
-          results={mockAnalysis().overall}
+          results={mockAnalysis()}
         />
       </RouterSlugProvider>,
     );
@@ -57,7 +57,7 @@ describe("TableResults", () => {
       <RouterSlugProvider mocks={[mock]}>
         <TableResults
           primaryProbeSets={experiment.primaryProbeSets!}
-          results={mockAnalysis().overall}
+          results={mockAnalysis()}
         />
       </RouterSlugProvider>,
     );
@@ -72,7 +72,7 @@ describe("TableResults", () => {
       <RouterSlugProvider mocks={[mock]}>
         <TableResults
           primaryProbeSets={experiment.primaryProbeSets!}
-          results={mockIncompleteAnalysis().overall}
+          results={mockIncompleteAnalysis()}
         />
       </RouterSlugProvider>,
     );

--- a/app/experimenter/nimbus-ui/src/components/PageResults/TooltipWithMarkdown/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TooltipWithMarkdown/index.tsx
@@ -1,0 +1,32 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from "react";
+import ReactMarkdown from "react-markdown";
+import ReactTooltip from "react-tooltip";
+
+type TooltipWithMarkdownProps = {
+  tooltipId: string;
+  markdown: string;
+};
+
+const TooltipWithMarkdown = ({
+  tooltipId,
+  markdown,
+}: TooltipWithMarkdownProps) => {
+  return (
+    <ReactTooltip
+      id={tooltipId}
+      multiline
+      clickable
+      className="w-25 font-weight-normal"
+      delayHide={200}
+      effect="solid"
+    >
+      <ReactMarkdown source={markdown!} />
+    </ReactTooltip>
+  );
+};
+
+export default TooltipWithMarkdown;

--- a/app/experimenter/nimbus-ui/src/components/PageResults/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/index.tsx
@@ -56,7 +56,7 @@ const PageResults: React.FunctionComponent<RouteComponentProps> = () => (
           <p>{experiment.hypothesis}</p>
           <TableHighlights
             primaryProbeSets={experiment.primaryProbeSets!}
-            results={analysis?.overall!}
+            results={analysis!}
           />
           <TableHighlightsOverview
             {...{ experiment }}
@@ -68,7 +68,7 @@ const PageResults: React.FunctionComponent<RouteComponentProps> = () => (
           </h2>
           <TableResults
             primaryProbeSets={experiment.primaryProbeSets!}
-            results={analysis?.overall!}
+            results={analysis!}
           />
           <div>
             {experiment.primaryProbeSets?.map((probeSet) => (

--- a/app/experimenter/nimbus-ui/src/lib/visualization/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/lib/visualization/mocks.tsx
@@ -27,6 +27,12 @@ export const MOCK_METADATA = {
         "This is a metric description. It's made by a data scientist at the creation time of the metric [I'm a link](https://www.example.com)",
       friendly_name: "Feature D Friendly Name",
     },
+    search_count: {
+      bigger_is_better: true,
+      description:
+        "This is a metric description for search. It's made by a data scientist at the creation time of the metric [Link](https://www.example.com)",
+      friendly_name: "Search Count",
+    },
   },
   probesets: {},
 };
@@ -105,6 +111,10 @@ export const TREATMENT_NEUTRAL = {
   },
   significance: "neutral",
 };
+
+export const TREATMENT_NEGATIVE = Object.assign({}, TREATMENT_NEUTRAL, {
+  significance: "negative",
+});
 
 export const weeklyMockAnalysis = (modifications = {}) =>
   Object.assign(
@@ -491,7 +501,7 @@ export const mockAnalysis = (modifications = {}) =>
           },
         },
         treatment: {
-          is_control: true,
+          is_control: false,
           branch_data: {
             identity: {
               absolute: {
@@ -514,76 +524,8 @@ export const mockAnalysis = (modifications = {}) =>
               },
               percent: 55,
             },
-            search_count: {
-              absolute: {
-                first: {
-                  point: 25.456361412643364,
-                  lower: 18.998951440573688,
-                  upper: 33.54929175463715,
-                },
-                all: [
-                  {
-                    point: 25.456361412643364,
-                    lower: 18.998951440573688,
-                    upper: 33.54929175463715,
-                  },
-                ],
-              },
-              difference: {
-                first: {
-                  point: 5.075852767646001,
-                  upper: -5.63685604594333,
-                  lower: -15.289651027022447,
-                },
-                all: [
-                  {
-                    point: 5.075852767646001,
-                    upper: -5.63685604594333,
-                    lower: -15.289651027022447,
-                  },
-                ],
-              },
-              relative_uplift: {
-                first: {},
-                all: [],
-              },
-              significance: "negative",
-            },
-            retained: {
-              absolute: {
-                first: {
-                  point: 0.6421568627450981,
-                  lower: 0.5752946065083696,
-                  upper: 0.7063786618426765,
-                },
-                all: [
-                  {
-                    point: 0.6421568627450981,
-                    lower: 0.5752946065083696,
-                    upper: 0.7063786618426765,
-                  },
-                ],
-              },
-              difference: {
-                first: {
-                  point: 0.032060163779913255,
-                  lower: -0.06502380421429996,
-                  upper: 0.12483606976999304,
-                },
-                all: [
-                  {
-                    point: 0.032060163779913255,
-                    lower: -0.06502380421429996,
-                    upper: 0.12483606976999304,
-                  },
-                ],
-              },
-              relative_uplift: {
-                first: {},
-                all: [],
-              },
-              significance: "neutral",
-            },
+            search_count: TREATMENT_NEGATIVE,
+            retained: TREATMENT_NEUTRAL,
             picture_in_picture_ever_used: {
               absolute: {
                 first: {
@@ -1193,7 +1135,7 @@ export const mockIncompleteAnalysis = (modifications = {}) =>
           },
         },
         treatment: {
-          is_control: true,
+          is_control: false,
           branch_data: {
             identity: {
               absolute: {


### PR DESCRIPTION
Because
* The content for "control" in the highlights table was confusing
* The guardrail computations were not clear

This commit:
* Shows "baseline" for control in the highlights table
* Adds tooltips using metadata about the guardrail metrics