### PR TITLE
Move test w/ coverage flag to its own command, move mock experiment to its own helper

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ ESLINT_NIMBUS_UI = yarn workspace @experimenter/nimbus-ui lint
 ESLINT_FIX_NIMBUS_UI = yarn workspace @experimenter/nimbus-ui lint-fix
 TYPECHECK_NIMBUS_UI = yarn workspace @experimenter/nimbus-ui lint:tsc
 JS_TEST_CORE = yarn workspace @experimenter/core test
-JS_TEST_NIMBUS_UI = CI=yes yarn workspace @experimenter/nimbus-ui test
+JS_TEST_NIMBUS_UI = CI=yes yarn workspace @experimenter/nimbus-ui test:cov
 NIMBUS_SCHEMA_CHECK = python manage.py graphql_schema --out experimenter/nimbus-ui/test_schema.graphql&&diff experimenter/nimbus-ui/test_schema.graphql experimenter/nimbus-ui/schema.graphql || (echo GraphQL Schema is out of sync please run make generate_types;exit 1)
 NIMBUS_TYPES_GENERATE = python manage.py graphql_schema --out experimenter/nimbus-ui/schema.graphql&&yarn workspace @experimenter/nimbus-ui generate-types
 FLAKE8 = flake8 .

--- a/app/experimenter/nimbus-ui/README.md
+++ b/app/experimenter/nimbus-ui/README.md
@@ -259,6 +259,13 @@ yarn test -t="renders as expected"
 
 # See a full code coverage report
 yarn test --watchAll=false
+
+# Our tests require 100% line coverage, which can be checked with
+yarn test:cov
+
+# Or, if you want to test and get coverage for a specific test
+# This excludes Storybook stories while running coverage on a specific component
+yarn test:cov --collectCoverageFrom='./src/components/LinkExternal/*[!.stories].tsx' LinkExternal
 ```
 
 Refer to Jest's [CLI documentation](https://jestjs.io/docs/en/cli) for more advanced test configuration.

--- a/app/experimenter/nimbus-ui/package.json
+++ b/app/experimenter/nimbus-ui/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "start": "SKIP_PREFLIGHT_CHECK=true rescripts start",
     "build": "SKIP_PREFLIGHT_CHECK=true rescripts build",
-    "test": "SKIP_PREFLIGHT_CHECK=true rescripts test --coverage",
+    "test": "SKIP_PREFLIGHT_CHECK=true rescripts test",
+    "test:cov": "yarn test --coverage",
     "lint": "yarn lint:eslint && yarn lint:tsc && yarn lint:styles",
     "lint-fix": "yarn lint:eslint --fix && yarn lint:styles --fix",
     "lint:eslint": "eslint --color --max-warnings 0 --ext=.ts,.tsx .",

--- a/app/experimenter/nimbus-ui/src/lib/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/lib/mocks.tsx
@@ -232,23 +232,17 @@ export class SimulatedMockLink extends ApolloLink {
   }
 }
 
-export function mockExperimentQuery<
+export function mockExperiment<
   T extends getExperiment["experimentBySlug"] = getExperiment_experimentBySlug
->(
-  slug: string,
-  modifications: Partial<getExperiment["experimentBySlug"]> = {},
-): {
-  mock: MockedResponse<Record<string, any>>;
-  experiment: T;
-} {
-  let experiment: getExperiment["experimentBySlug"] = Object.assign(
+>(modifications: Partial<getExperiment["experimentBySlug"]> = {}): T {
+  return Object.assign(
     {
       id: 1,
       owner: {
         email: "example@mozilla.com",
       },
       name: "Open-architected background installation",
-      slug,
+      slug: "open-architected-background-installation",
       status: "DRAFT",
       isEndRequested: false,
       monitoringDashboardUrl: "https://grafana.telemetry.mozilla.org",
@@ -312,11 +306,20 @@ export function mockExperimentQuery<
       enrollmentEndDate: null,
     },
     modifications,
-  );
+  ) as T;
+}
 
-  if (modifications === null) {
-    experiment = null;
-  }
+export function mockExperimentQuery<
+  T extends getExperiment["experimentBySlug"] = getExperiment_experimentBySlug
+>(
+  slug = "foo",
+  modifications: Partial<getExperiment["experimentBySlug"]> = {},
+): {
+  mock: MockedResponse<Record<string, any>>;
+  experiment: T;
+} {
+  const experiment =
+    modifications === null ? null : mockExperiment({ slug, ...modifications });
 
   return {
     mock: {


### PR DESCRIPTION
(This is part of some test refactoring I hope to do in the future)

This PR:

1. Updates `yarn test` to _not_ generate coverage output by default, adds a new `yarn test:cov` that does this (and updates the Makefile to use it), and documents how you could run coverage on a subset of tests
  - Why change `test`? During development I often want to have the tests running on file change, and this is obscured by the long output of coverage results on each run.

2. Adds a new helper, `mockExperiment` that just generates a mocked experiment (and updates `mockedExperimentQuery` to use it). We have a number of tests that need a mocked experiment that either make no use of or have nothing to do with GraphQL, so it doesn't make sense that it should need to also mock the query.