### PR TITLE
feat(nimbus): refactor useAnalysis and useExperiment hooks to use RTL react-hooks

### DIFF
--- a/app/experimenter/nimbus-ui/package.json
+++ b/app/experimenter/nimbus-ui/package.json
@@ -67,6 +67,7 @@
     "@testing-library/dom": "^7.24.3",
     "@testing-library/jest-dom": "^5.11.8",
     "@testing-library/react": "^11.0.4",
+    "@testing-library/react-hooks": "^5.0.3",
     "@testing-library/user-event": "^7.1.2",
     "@types/jest": "^24.0.0",
     "@types/node": "^14.11.5",

--- a/app/experimenter/nimbus-ui/src/hooks/useAnalysis.test.tsx
+++ b/app/experimenter/nimbus-ui/src/hooks/useAnalysis.test.tsx
@@ -2,40 +2,29 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { act, render } from "@testing-library/react";
+import { act, renderHook } from "@testing-library/react-hooks";
 import fetchMock from "jest-fetch-mock";
-import React from "react";
-import { useAnalysis } from "./useAnalysis";
+import { useAnalysis } from ".";
 
 describe("hooks/useVisualization", () => {
-  describe("useVisualization", () => {
-    let hook: ReturnType<typeof useAnalysis>;
+  it("fetches from the visualization endpoint and returns data", async () => {
+    fetchMock.enableMocks();
 
-    const TestHook = () => {
-      hook = useAnalysis();
-      return <p>Algonquin Provincial Park</p>;
-    };
+    const slug = "hungry";
+    const data = { burrito: "Crunchwrap Supreme®" };
+    fetchMock.mockResponseOnce(JSON.stringify(data));
 
-    it("fetches from the visualization endpoint and returns data", async () => {
-      fetchMock.enableMocks();
+    const { result } = renderHook(() => useAnalysis());
+    await act(async () => void result.current.execute([slug]));
 
-      const slug = "hungry";
-      const data = { burrito: "Crunchwrap Supreme®" };
-      fetchMock.mockResponseOnce(JSON.stringify(data));
-
-      render(<TestHook />);
-
-      await act(async () => void hook.execute([slug]));
-
-      expect(fetch).toHaveBeenCalledWith(`/api/v3/visualization/${slug}/`, {
-        headers: { "Content-Type": "application/json" },
-        method: "GET",
-      });
-
-      expect(hook.result).toEqual(data);
-      expect(hook.loading).toBeFalsy();
-
-      fetchMock.disableMocks();
+    expect(fetch).toHaveBeenCalledWith(`/api/v3/visualization/${slug}/`, {
+      headers: { "Content-Type": "application/json" },
+      method: "GET",
     });
+
+    expect(result.current.result).toEqual(data);
+    expect(result.current.loading).toBeFalsy();
+
+    fetchMock.disableMocks();
   });
 });

--- a/app/experimenter/nimbus-ui/src/hooks/useExperiment.test.tsx
+++ b/app/experimenter/nimbus-ui/src/hooks/useExperiment.test.tsx
@@ -2,163 +2,153 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { render, waitFor } from "@testing-library/react";
+import { MockedResponse } from "@apollo/client/testing";
+import { waitFor } from "@testing-library/react";
+import { renderHook } from "@testing-library/react-hooks";
 import React from "react";
 import { MockedCache, mockExperimentQuery } from "../lib/mocks";
 import { useExperiment } from "./useExperiment";
 
 describe("hooks/useExperiment", () => {
-  describe("useExperiment", () => {
-    let hook: ReturnType<typeof useExperiment>;
+  it("starts by loading", async () => {
+    const { result } = renderHook(() => useExperiment("howdy"), {
+      wrapper,
+    });
+    expect(result.current.loading).toBeTruthy();
+  });
 
-    const TestExperiment = ({ slug }: { slug: string }) => {
-      hook = useExperiment(slug);
-      return <p>Notre-Dame-du-Bon-Conseil, QC</p>;
+  it("loads the experiment", async () => {
+    const { mock, experiment } = mockExperimentQuery("howdy");
+    const { result } = renderHook(() => useExperiment(experiment.slug), {
+      wrapper,
+      initialProps: { mocks: [mock] },
+    });
+    await waitFor(() => expect(result.current.experiment).toEqual(experiment));
+  });
+
+  it("indicates notFound if there's no experiment", async () => {
+    const { mock } = mockExperimentQuery("howdy", null);
+    const { result } = renderHook(() => useExperiment("howdy"), {
+      wrapper,
+      initialProps: { mocks: [mock] },
+    });
+    await waitFor(() => expect(result.current.notFound).toBeTruthy());
+  });
+
+  describe("ready for review", () => {
+    const readyMessages = {
+      public_description: ["This field may not be null."],
+      proposed_duration: ["This field may not be null."],
+      proposed_enrollment: ["This field may not be null."],
+      firefox_min_version: ["This field may not be null."],
+      targeting_config_slug: ["This field may not be null."],
+      reference_branch: ["This field may not be null."],
+      channel: ["This field may not be null."],
+      population_percent: [
+        "Ensure this value is greater than or equal to 0.0001.",
+      ],
     };
 
-    it("returns the experiment", async () => {
-      const { mock, experiment } = mockExperimentQuery("howdy");
+    const pageNames = {
+      public_description: "overview",
+      proposed_duration: "audience",
+      proposed_enrollment: "audience",
+      firefox_min_version: "audience",
+      targeting_config_slug: "audience",
+      reference_branch: "branches",
+      channel: "audience",
+      population_percent: "audience",
+    };
 
-      render(
-        <MockedCache mocks={[mock]}>
-          <TestExperiment slug="howdy" />
-        </MockedCache>,
-      );
-
-      await waitFor(() => expect(hook.experiment).toEqual(experiment));
-    });
-
-    it("returns notFound if no experiment found", async () => {
-      const { mock } = mockExperimentQuery("howdy", null);
-
-      render(
-        <MockedCache mocks={[mock]}>
-          <TestExperiment slug="howdy" />
-        </MockedCache>,
-      );
-
-      await waitFor(() => expect(hook.notFound).toBeTruthy());
-    });
-
-    describe("ready for review", () => {
-      const readyMessages = {
-        public_description: ["This field may not be null."],
-        proposed_duration: ["This field may not be null."],
-        proposed_enrollment: ["This field may not be null."],
-        firefox_min_version: ["This field may not be null."],
-        targeting_config_slug: ["This field may not be null."],
-        reference_branch: ["This field may not be null."],
-        channel: ["This field may not be null."],
-        population_percent: [
-          "Ensure this value is greater than or equal to 0.0001.",
-        ],
-      } as const;
-
-      const pageNames = {
-        public_description: "overview",
-        proposed_duration: "audience",
-        proposed_enrollment: "audience",
-        firefox_min_version: "audience",
-        targeting_config_slug: "audience",
-        reference_branch: "branches",
-        channel: "audience",
-        population_percent: "audience",
-      } as const;
-
-      const commonMissingDetailsTest = (
-        fieldName: keyof typeof readyMessages,
-      ) => async () => {
-        const readyMessage = {
-          [fieldName]: readyMessages[fieldName],
-        };
-        const pageName = pageNames[fieldName];
-
-        Object.defineProperty(window, "location", {
-          value: {
-            search: "?show-errors",
-          },
-        });
-
-        const { mock } = mockExperimentQuery("howdy", {
-          readyForReview: {
-            ready: false,
-            message: readyMessage,
-          },
-        });
-
-        render(
-          <MockedCache mocks={[mock]}>
-            <TestExperiment slug="howdy" />
-          </MockedCache>,
-        );
-
-        await waitFor(() => {
-          const {
-            ready,
-            invalidPages,
-            missingFields,
-            isMissingField,
-          } = hook.review;
-
-          expect(ready).toBeFalsy();
-          expect(invalidPages).toEqual(expect.arrayContaining([pageName]));
-          expect(missingFields).toEqual(
-            expect.arrayContaining(Object.keys(readyMessage)),
-          );
-          Object.keys(readyMessage).forEach((fieldName) => {
-            expect(isMissingField(fieldName)).toBeTruthy();
-          });
-        });
-      };
-
-      let fieldName: keyof typeof readyMessages;
-      for (fieldName in readyMessages) {
-        it(
-          `returns correct review info when missing details for ${fieldName}`,
-          commonMissingDetailsTest(fieldName),
-        );
-      }
-
-      it("returns correct review info when not missing any details", async () => {
-        const { mock } = mockExperimentQuery("howdy", {
-          readyForReview: {
-            ready: true,
-            message: {},
-          },
-        });
-
-        render(
-          <MockedCache mocks={[mock]}>
-            <TestExperiment slug="howdy" />
-          </MockedCache>,
-        );
-
-        await waitFor(() => {
-          const {
-            ready,
-            invalidPages,
-            missingFields,
-            isMissingField,
-          } = hook.review;
-
-          expect(ready).toBeTruthy();
-          expect(invalidPages).toEqual([]);
-          expect(missingFields).toEqual([]);
-          Object.keys(readyMessages).forEach((fieldName) => {
-            expect(isMissingField(fieldName)).toBeFalsy();
-          });
-        });
+    beforeAll(() => {
+      Object.defineProperty(window, "location", {
+        value: {
+          search: "?show-errors",
+        },
       });
     });
 
-    it("starts by loading", async () => {
-      render(
-        <MockedCache mocks={[]}>
-          <TestExperiment slug="howdy" />
-        </MockedCache>,
-      );
+    const missingDetailsTest = (
+      fieldName: keyof typeof readyMessages,
+    ) => async () => {
+      const readyMessage = {
+        [fieldName]: readyMessages[fieldName],
+      };
+      const pageName = pageNames[fieldName];
+      const { mock } = mockExperimentQuery("howdy", {
+        readyForReview: {
+          ready: false,
+          message: readyMessage,
+        },
+      });
+      const { result } = renderHook(() => useExperiment("howdy"), {
+        wrapper,
+        initialProps: { mocks: [mock] },
+      });
 
-      expect(hook.loading).toBeTruthy();
+      await waitFor(() => {
+        const {
+          ready,
+          invalidPages,
+          missingFields,
+          isMissingField,
+        } = result.current.review;
+        expect(ready).toBeFalsy();
+        expect(invalidPages).toEqual(expect.arrayContaining([pageName]));
+        expect(missingFields).toEqual(
+          expect.arrayContaining(Object.keys(readyMessage)),
+        );
+        for (const fieldName of Object.keys(readyMessage)) {
+          expect(isMissingField(fieldName)).toBeTruthy();
+        }
+      });
+    };
+
+    let fieldName: keyof typeof readyMessages;
+    for (fieldName in readyMessages) {
+      it(
+        `returns correct review info when missing details for ${fieldName}`,
+        missingDetailsTest(fieldName),
+      );
+    }
+
+    it("returns correct review info when not missing any details", async () => {
+      const { mock } = mockExperimentQuery("howdy", {
+        readyForReview: {
+          ready: true,
+          message: {},
+        },
+      });
+
+      const { result } = renderHook(() => useExperiment("howdy"), {
+        wrapper,
+        initialProps: { mocks: [mock] },
+      });
+
+      await waitFor(() => {
+        const {
+          ready,
+          invalidPages,
+          missingFields,
+          isMissingField,
+        } = result.current.review;
+        expect(ready).toBeTruthy();
+        expect(invalidPages).toEqual([]);
+        expect(missingFields).toEqual([]);
+        for (const fieldName in readyMessages) {
+          expect(isMissingField(fieldName)).toBeFalsy();
+        }
+      });
     });
   });
 });
+
+const wrapper = ({
+  mocks = [],
+  children,
+}: {
+  mocks?: MockedResponse[];
+  children?: React.ReactNode;
+}) => (
+  <MockedCache {...{ mocks }}>{children as React.ReactElement}</MockedCache>
+);

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -3475,6 +3475,18 @@
     lodash "^4.17.15"
     redent "^3.0.0"
 
+"@testing-library/react-hooks@^5.0.3":
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/@testing-library/react-hooks/-/react-hooks-5.0.3.tgz#dd0d2048817b013b266d35ca45e3ea48a19fd87e"
+  integrity sha512-UrnnRc5II7LMH14xsYNm/WRch/67cBafmrSQcyFh0v+UUmSf1uzfB7zn5jQXSettGwOSxJwdQUN7PgkT0w22Lg==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    "@types/react" ">=16.9.0"
+    "@types/react-dom" ">=16.9.0"
+    "@types/react-test-renderer" ">=16.9.0"
+    filter-console "^0.1.1"
+    react-error-boundary "^3.1.0"
+
 "@testing-library/react@11.0.4", "@testing-library/react@^11.0.4":
   version "11.0.4"
   resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-11.0.4.tgz#c84082bfe1593d8fcd475d46baee024452f31dee"
@@ -3773,6 +3785,13 @@
   dependencies:
     "@types/react" "*"
 
+"@types/react-dom@>=16.9.0":
+  version "17.0.1"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-17.0.1.tgz#d92d77d020bfb083e07cc8e0ac9f933599a4d56a"
+  integrity sha512-yIVyopxQb8IDZ7SOHeTovurFq+fXiPICa+GV3gp0Xedsl+MwQlMLKmvrnEjFbQxjliH5YVAEWFh975eVNmKj7Q==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react-helmet@^6.1.0":
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/@types/react-helmet/-/react-helmet-6.1.0.tgz#af586ed685f4905e2adc7462d1d65ace52beee7a"
@@ -3804,6 +3823,13 @@
   dependencies:
     "@types/react" "*"
 
+"@types/react-test-renderer@>=16.9.0":
+  version "17.0.1"
+  resolved "https://registry.yarnpkg.com/@types/react-test-renderer/-/react-test-renderer-17.0.1.tgz#3120f7d1c157fba9df0118dae20cb0297ee0e06b"
+  integrity sha512-3Fi2O6Zzq/f3QR9dRnlnHso9bMl7weKCviFmfF6B4LS1Uat6Hkm15k0ZAQuDz+UBq6B3+g+NM6IT2nr5QgPzCw==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react-transition-group@*", "@types/react-transition-group@^4.4.0":
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/@types/react-transition-group/-/react-transition-group-4.4.0.tgz#882839db465df1320e4753e6e9f70ca7e9b4d46d"
@@ -3815,6 +3841,14 @@
   version "17.0.0"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.0.tgz#5af3eb7fad2807092f0046a1302b7823e27919b8"
   integrity sha512-aj/L7RIMsRlWML3YB6KZiXB3fV2t41+5RBGYF8z+tAKU43Px8C3cYUZsDvf1/+Bm4FK21QWBrDutu8ZJ/70qOw==
+  dependencies:
+    "@types/prop-types" "*"
+    csstype "^3.0.2"
+
+"@types/react@>=16.9.0":
+  version "17.0.2"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.2.tgz#3de24c4efef902dd9795a49c75f760cbe4f7a5a8"
+  integrity sha512-Xt40xQsrkdvjn1EyWe1Bc0dJLcil/9x2vAuW7ya+PuQip4UYUaXyhzWmAbwRsdMgwOFHpfp7/FFZebDU6Y8VHA==
   dependencies:
     "@types/prop-types" "*"
     csstype "^3.0.2"
@@ -9302,6 +9336,11 @@ fill-range@^7.0.1:
   integrity sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==
   dependencies:
     to-regex-range "^5.0.1"
+
+filter-console@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/filter-console/-/filter-console-0.1.1.tgz#6242be28982bba7415bcc6db74a79f4a294fa67c"
+  integrity sha512-zrXoV1Uaz52DqPs+qEwNJWJFAWZpYJ47UNmpN9q4j+/EYsz85uV0DC9k8tRND5kYmoVzL0W+Y75q4Rg8sRJCdg==
 
 finalhandler@~1.1.2:
   version "1.1.2"
@@ -16082,6 +16121,13 @@ react-draggable@^4.0.3:
   dependencies:
     classnames "^2.2.5"
     prop-types "^15.6.0"
+
+react-error-boundary@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/react-error-boundary/-/react-error-boundary-3.1.0.tgz#9487443df2f9ba1db90d8ab52351814907ea4af3"
+  integrity sha512-lmPrdi5SLRJR+AeJkqdkGlW/CRkAUvZnETahK58J4xb5wpbfDngasEGu+w0T1iXEhVrYBJZeW+c4V1hILCnMWQ==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
 
 react-error-overlay@^5.1.4:
   version "5.1.6"


### PR DESCRIPTION
(This is part of some test refactoring I hope to do in the future)

As it turns out, there is a testing-library [library](https://react-hooks-testing-library.com/) made specifically for React Hooks!

This PR adds that dependency and refactors the tests for two hooks, `useExperiment` and `useAnalysis`, to use RHTL. 

What does this get us? It takes care of most of the setup for rendering a hook, since it's required to be in the context of a component. Here's an example:

```tsx
// This...
let hook: ReturnType<typeof useAnalysis>;
const TestHook = () => {
  hook = useAnalysis();
  return <p>Foo</p>;
};
render(<TestHook />); 
expect(hook.loading).toBeFalsy();

// Becomes this...
const { result } = renderHook(() => useAnalysis());
expect(result.current.loading).toBeFalsy();
```

In the case of `useExperiment`, where a mocked cache is required, it also allows us to supply a wrapping component.

If we like this I'll work on updating the rest at some point.