### PR TITLE
feat(nimbus): update AppLayoutWithExperiment tests to use RTL best practices

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/AppLayoutWithExperiment/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/AppLayoutWithExperiment/index.tsx
@@ -169,11 +169,7 @@ const AppLayoutWithExperiment = ({
             summaryView,
           }}
         />
-        {title && (
-          <h2 className="mt-3 mb-4 h4" data-testid="page-title">
-            {title}
-          </h2>
-        )}
+        {title && <h2 className="mt-3 mb-4 h4">{title}</h2>}
         <div className="my-4">{children({ experiment, review, analysis })}</div>
       </section>
     </Layout>


### PR DESCRIPTION
(This is part of some test refactoring I hope to do in the future)

This PR is a refactor of the tests in `AppLayoutWithExperiment` for a few reasons:

- Organize and tighten them up; remove extra/unneeded code, make descriptions more concise; was able to reduce overall lines
- Address the issue that is part of #4213 - the "loading" state test can now be freely moved anywhere
- Incorporate some React Testing Library best practices. For this PR this includes:
  - Using async `findBy*` methods to determine if an element is in the DOM; only using `toBeInTheDocument()` to assert _absence_ of an element. ([Source](https://testing-library.com/docs/dom-testing-library/api-async/#findby-queries))
  - Where appropriate, using `*ByRole` and `*ByText` methods to assert the presence and inspect properties of DOM elements instead of `*ByTestId`. These methods behave more closely to what the user can actually see and interact with on the page. As a result of the above, was able to remove some `data-testid` attributes from our components. ([Source](https://testing-library.com/docs/queries/about/#priority))

There are more RTL best practices that I plan to fold in over time, and I will probably try to come up with a thorough blog post or even just internal documentation on the subject. Feel free to push back on any of this.