### PR TITLE
fixes #4671 feat(nimbus): add computedEndDate to v5 API, use it instead of endDate

### DIFF
--- a/app/experimenter/experiments/api/v5/types.py
+++ b/app/experimenter/experiments/api/v5/types.py
@@ -131,7 +131,7 @@ class NimbusExperimentType(DjangoObjectType):
     ready_for_review = graphene.Field(NimbusReadyForReviewType)
     monitoring_dashboard_url = graphene.String()
     start_date = graphene.DateTime()
-    end_date = graphene.DateTime()
+    computed_end_date = graphene.DateTime()
     is_enrollment_paused = graphene.Boolean()
     enrollment_end_date = graphene.DateTime()
 

--- a/app/experimenter/experiments/models/nimbus.py
+++ b/app/experimenter/experiments/models/nimbus.py
@@ -190,6 +190,10 @@ class NimbusExperiment(NimbusConstants, models.Model):
             ).date()
 
     @property
+    def computed_end_date(self):
+        return self.end_date or self.proposed_end_date
+
+    @property
     def should_pause(self):
         if self.proposed_enrollment_end_date:
             return datetime.date.today() >= self.proposed_enrollment_end_date

--- a/app/experimenter/nimbus-ui/schema.graphql
+++ b/app/experimenter/nimbus-ui/schema.graphql
@@ -191,7 +191,7 @@ type NimbusExperimentType {
   readyForReview: NimbusReadyForReviewType
   monitoringDashboardUrl: String
   startDate: DateTime
-  endDate: DateTime
+  computedEndDate: DateTime
   isEnrollmentPaused: Boolean
   enrollmentEndDate: DateTime
 }

--- a/app/experimenter/nimbus-ui/src/components/AppLayoutWithExperiment/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/AppLayoutWithExperiment/index.tsx
@@ -135,7 +135,7 @@ const AppLayoutWithExperiment = ({
   const {
     name,
     startDate,
-    endDate,
+    computedEndDate,
     primaryProbeSets,
     secondaryProbeSets,
   } = experiment;
@@ -164,7 +164,7 @@ const AppLayoutWithExperiment = ({
             slug,
             name,
             startDate,
-            endDate,
+            computedEndDate,
             status,
             summaryView,
           }}

--- a/app/experimenter/nimbus-ui/src/components/HeaderExperiment/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/HeaderExperiment/index.stories.tsx
@@ -20,7 +20,7 @@ storiesOf("components/HeaderExperiment", module)
         name={experiment.name}
         slug={experiment.slug}
         startDate={experiment.startDate}
-        endDate={experiment.endDate}
+        computedEndDate={experiment.computedEndDate}
         status={mockGetStatus(experiment.status)}
       />
     </AppLayout>
@@ -31,7 +31,7 @@ storiesOf("components/HeaderExperiment", module)
         name={experiment.name}
         slug={experiment.slug}
         startDate={experiment.startDate}
-        endDate={experiment.endDate}
+        computedEndDate={experiment.computedEndDate}
         status={mockGetStatus(NimbusExperimentStatus.REVIEW)}
       />
     </AppLayout>
@@ -42,7 +42,7 @@ storiesOf("components/HeaderExperiment", module)
         name={experiment.name}
         slug={experiment.slug}
         startDate={experiment.startDate}
-        endDate={null}
+        computedEndDate={null}
         status={mockGetStatus(NimbusExperimentStatus.LIVE)}
       />
     </AppLayout>
@@ -53,7 +53,7 @@ storiesOf("components/HeaderExperiment", module)
         name={experiment.name}
         slug={experiment.slug}
         startDate={experiment.startDate}
-        endDate={experiment.endDate}
+        computedEndDate={experiment.computedEndDate}
         status={mockGetStatus(NimbusExperimentStatus.COMPLETE)}
       />
     </AppLayout>
@@ -64,7 +64,7 @@ storiesOf("components/HeaderExperiment", module)
         name={experiment.name}
         slug={experiment.slug}
         startDate={experiment.startDate}
-        endDate={experiment.endDate}
+        computedEndDate={experiment.computedEndDate}
         status={mockGetStatus(NimbusExperimentStatus.COMPLETE)}
       />
     </AppLayout>
@@ -78,7 +78,7 @@ storiesOf("components/HeaderExperiment/Summary View", module)
         name={experiment.name}
         slug={experiment.slug}
         startDate={experiment.startDate}
-        endDate={experiment.endDate}
+        computedEndDate={experiment.computedEndDate}
         status={mockGetStatus(NimbusExperimentStatus.DRAFT)}
         summaryView
       />
@@ -90,7 +90,7 @@ storiesOf("components/HeaderExperiment/Summary View", module)
         name={experiment.name}
         slug={experiment.slug}
         startDate={experiment.startDate}
-        endDate={experiment.endDate}
+        computedEndDate={experiment.computedEndDate}
         status={mockGetStatus(NimbusExperimentStatus.REVIEW)}
         summaryView
       />
@@ -102,7 +102,7 @@ storiesOf("components/HeaderExperiment/Summary View", module)
         name={experiment.name}
         slug={experiment.slug}
         startDate={experiment.startDate}
-        endDate={experiment.endDate}
+        computedEndDate={experiment.computedEndDate}
         status={mockGetStatus(NimbusExperimentStatus.LIVE)}
         summaryView
       />

--- a/app/experimenter/nimbus-ui/src/components/HeaderExperiment/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/HeaderExperiment/index.test.tsx
@@ -22,7 +22,7 @@ const assertStatusLink = async (
       name={experiment.name}
       slug={experiment.slug}
       startDate={experiment.startDate}
-      endDate={experiment.endDate}
+      computedEndDate={experiment.computedEndDate}
       status={mockGetStatus(experiment.status)}
       summaryView
     />,
@@ -41,7 +41,7 @@ describe("HeaderExperiment", () => {
         name={experiment.name}
         slug={experiment.slug}
         startDate={experiment.startDate}
-        endDate={experiment.endDate}
+        computedEndDate={experiment.computedEndDate}
         status={mockGetStatus(experiment.status)}
       />,
     );
@@ -65,7 +65,7 @@ describe("HeaderExperiment", () => {
         name={experiment.name}
         slug={experiment.slug}
         startDate={experiment.startDate}
-        endDate={experiment.endDate}
+        computedEndDate={experiment.computedEndDate}
         status={mockGetStatus(experiment.status)}
       />,
     );
@@ -76,7 +76,7 @@ describe("HeaderExperiment", () => {
       humanDate(experiment.startDate!),
     );
     expect(screen.getByTestId("header-dates")).toHaveTextContent(
-      humanDate(experiment.endDate!),
+      humanDate(experiment.computedEndDate!),
     );
   });
 
@@ -88,7 +88,7 @@ describe("HeaderExperiment", () => {
           name={experiment.name}
           slug={experiment.slug}
           startDate={experiment.startDate}
-          endDate={experiment.endDate}
+          computedEndDate={experiment.computedEndDate}
           status={mockGetStatus(experiment.status)}
           summaryView
         />,

--- a/app/experimenter/nimbus-ui/src/components/HeaderExperiment/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/HeaderExperiment/index.tsx
@@ -16,14 +16,14 @@ import "./index.scss";
 
 type HeaderExperimentProps = Pick<
   getExperiment_experimentBySlug,
-  "name" | "slug" | "startDate" | "endDate"
+  "name" | "slug" | "startDate" | "computedEndDate"
 > & { status: StatusCheck; summaryView?: boolean };
 
 const HeaderExperiment = ({
   name,
   slug,
   startDate = "",
-  endDate = "",
+  computedEndDate = "",
   status,
   summaryView = false,
 }: HeaderExperimentProps) => (
@@ -105,10 +105,12 @@ const HeaderExperiment = ({
       {(status.live || status.complete) && (
         <div className="text-right col mt-2" data-testid="header-dates">
           <span className="font-weight-bold">{humanDate(startDate!)}</span> to{" "}
-          {endDate ? (
+          {computedEndDate ? (
             <>
-              <span className="font-weight-bold">{humanDate(endDate!)}</span> (
-              {stringDateSubtract(endDate!, startDate!)})
+              <span className="font-weight-bold">
+                {humanDate(computedEndDate!)}
+              </span>{" "}
+              ({stringDateSubtract(computedEndDate!, startDate!)})
             </>
           ) : (
             <span className="font-weight-bold">Present</span>

--- a/app/experimenter/nimbus-ui/src/components/PageHome/DirectoryTable/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageHome/DirectoryTable/index.test.tsx
@@ -12,11 +12,7 @@ import DirectoryTable, {
   DirectoryDraftsTable,
   DirectoryLiveTable,
 } from ".";
-import {
-  getProposedEndDate,
-  getProposedEnrollmentRange,
-  humanDate,
-} from "../../../lib/dateUtils";
+import { getProposedEnrollmentRange, humanDate } from "../../../lib/dateUtils";
 import { mockSingleDirectoryExperiment } from "../../../lib/mocks";
 
 const experiment = mockSingleDirectoryExperiment();
@@ -180,7 +176,7 @@ describe("DirectoryLiveTable", () => {
       experiment.owner!.username,
       experiment.featureConfig!.name,
       getProposedEnrollmentRange(experiment) as string,
-      getProposedEndDate(experiment) as string,
+      humanDate(experiment.computedEndDate!),
       "Grafana",
     ]);
   });
@@ -204,7 +200,7 @@ describe("DirectoryCompleteTable", () => {
       experiment.owner!.username,
       experiment.featureConfig!.name,
       humanDate(experiment.startDate!),
-      humanDate(experiment.endDate!),
+      humanDate(experiment.computedEndDate!),
       "Results",
     ]);
   });

--- a/app/experimenter/nimbus-ui/src/components/PageHome/DirectoryTable/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageHome/DirectoryTable/index.tsx
@@ -4,11 +4,7 @@
 
 import { Link } from "@reach/router";
 import React from "react";
-import {
-  getProposedEndDate,
-  getProposedEnrollmentRange,
-  humanDate,
-} from "../../../lib/dateUtils";
+import { getProposedEnrollmentRange, humanDate } from "../../../lib/dateUtils";
 import { getAllExperiments_experiments } from "../../../types/getAllExperiments";
 import LinkExternal from "../../LinkExternal";
 import NotSet from "../../NotSet";
@@ -161,7 +157,7 @@ export const DirectoryLiveTable: React.FC<DirectoryTableProps> = (props) => (
         label: "Ending",
         component: (experiment) => (
           <td data-testid="directory-table-cell">
-            {getProposedEndDate(experiment)}
+            {humanDate(experiment.computedEndDate!)}
           </td>
         ),
       },
@@ -201,7 +197,7 @@ export const DirectoryCompleteTable: React.FC<DirectoryTableProps> = (
       },
       {
         label: "Ended",
-        component: ({ endDate: d }) => (
+        component: ({ computedEndDate: d }) => (
           <td data-testid="directory-table-cell">{d && humanDate(d)}</td>
         ),
       },

--- a/app/experimenter/nimbus-ui/src/components/Summary/SummaryTimeline/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/SummaryTimeline/index.tsx
@@ -23,7 +23,7 @@ const SummaryTimeline = ({
         {...{
           status,
           startDate: experiment.startDate,
-          endDate: experiment.endDate,
+          computedEndDate: experiment.computedEndDate,
         }}
       />
 
@@ -31,7 +31,7 @@ const SummaryTimeline = ({
         {...{
           status,
           startDate: experiment.startDate,
-          endDate: experiment.endDate,
+          computedEndDate: experiment.computedEndDate,
         }}
       />
 
@@ -48,14 +48,14 @@ const SummaryTimeline = ({
 const StartEnd = ({
   status,
   startDate,
-  endDate,
+  computedEndDate,
 }: {
   status: StatusCheck;
   startDate: string | null;
-  endDate: string | null;
+  computedEndDate: string | null;
 }) => (
   <div className="d-flex">
-    {status.draft || status.review || status.accepted ? (
+    {status.draft || status.review || status.preview || status.accepted ? (
       <span className="flex-fill" data-testid="label-not-launched">
         Not yet launched
       </span>
@@ -64,9 +64,9 @@ const StartEnd = ({
         <span className="flex-fill" data-testid="label-start-date">
           {humanDate(startDate!)}
         </span>
-        {endDate && (
+        {computedEndDate && (
           <span className="flex-fill text-right" data-testid="label-end-date">
-            {humanDate(endDate!)}
+            {humanDate(computedEndDate!)}
           </span>
         )}
       </>
@@ -77,11 +77,11 @@ const StartEnd = ({
 const Progress = ({
   status,
   startDate,
-  endDate,
+  computedEndDate,
 }: {
   status: StatusCheck;
   startDate: string | null;
-  endDate: string | null;
+  computedEndDate: string | null;
 }) => {
   const props: React.ComponentProps<typeof ProgressBar> = {
     style: { height: 5 },
@@ -98,8 +98,8 @@ const Progress = ({
       striped: true,
       animated: true,
       min: Date.parse(startDate!),
-      max: Date.parse(endDate!),
-      now: Math.min(Date.now(), Date.parse(endDate!)),
+      max: Date.parse(computedEndDate!),
+      now: Math.min(Date.now(), Date.parse(computedEndDate!)),
     });
   }
 

--- a/app/experimenter/nimbus-ui/src/components/Summary/SummaryTimeline/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/SummaryTimeline/mocks.tsx
@@ -9,20 +9,20 @@ import { NimbusExperimentStatus } from "../../../types/globalTypes";
 
 export const Subject = ({
   startDate = "2020-11-28T14:52:44.704811+00:00",
-  endDate = "2020-12-08T14:52:44.704811+00:00",
+  computedEndDate = "2020-12-08T14:52:44.704811+00:00",
   proposedDuration = 10,
   proposedEnrollment = 1,
   status = NimbusExperimentStatus.DRAFT,
 }: {
   startDate?: string;
-  endDate?: string;
+  computedEndDate?: string;
   proposedDuration?: number;
   proposedEnrollment?: number;
   status?: NimbusExperimentStatus;
 }) => {
   const { experiment } = mockExperimentQuery("something-vague", {
     startDate,
-    endDate,
+    computedEndDate,
     proposedDuration,
     proposedEnrollment,
     status,

--- a/app/experimenter/nimbus-ui/src/gql/experiments.ts
+++ b/app/experimenter/nimbus-ui/src/gql/experiments.ts
@@ -102,7 +102,7 @@ export const GET_EXPERIMENT_QUERY = gql`
       }
 
       startDate
-      endDate
+      computedEndDate
 
       riskMitigationLink
 
@@ -128,7 +128,7 @@ export const GET_EXPERIMENTS_QUERY = gql`
       startDate
       proposedDuration
       proposedEnrollment
-      endDate
+      computedEndDate
       status
       isEndRequested
       monitoringDashboardUrl

--- a/app/experimenter/nimbus-ui/src/lib/dateUtils.test.ts
+++ b/app/experimenter/nimbus-ui/src/lib/dateUtils.test.ts
@@ -4,7 +4,6 @@
 
 import {
   addDaysToDate,
-  getProposedEndDate,
   getProposedEnrollmentRange,
   humanDate,
 } from "./dateUtils";
@@ -36,36 +35,6 @@ describe("addDaysToDate", () => {
 describe("addDaysToDate", () => {
   it("should add days to a date and return a date string", () => {
     expect(addDaysToDate(FAKE_DATE, 2)).toEqual("Mon Dec 14 2020");
-  });
-});
-
-describe("getProposedEndDate", () => {
-  it("should render a proposed end date if startDate and proposedDuration are set", () => {
-    const actual = getProposedEndDate(
-      expFactory({
-        startDate: FAKE_DATE,
-        proposedDuration: 2,
-      }),
-    );
-    expect(actual).toBe("Dec 14, 2020");
-  });
-  it("should render a duration if no startDate is set", () => {
-    const actual = getProposedEndDate(
-      expFactory({
-        startDate: null,
-        proposedDuration: 4,
-      }),
-    );
-    expect(actual).toBe("4 days");
-  });
-  it("should render '1 day' (not plural) for duration = 1", () => {
-    const actual = getProposedEndDate(
-      expFactory({
-        startDate: null,
-        proposedDuration: 1,
-      }),
-    );
-    expect(actual).toBe("1 day");
   });
 });
 

--- a/app/experimenter/nimbus-ui/src/lib/dateUtils.ts
+++ b/app/experimenter/nimbus-ui/src/lib/dateUtils.ts
@@ -49,21 +49,6 @@ export function stringDateSubtract(dateA: string, dateB: string): string {
 }
 
 /**
- *  Renders an end date based on proposedDuration (e.g. Dec 2),
- *  or a number of days (e.g. "5 days") if startDate is not set.
- */
-export function getProposedEndDate(
-  experiment: getExperiment_experimentBySlug | getAllExperiments_experiments,
-): string {
-  const { startDate, proposedDuration } = experiment;
-  if (startDate) {
-    return humanDate(addDaysToDate(startDate, proposedDuration));
-  } else {
-    return pluralize(proposedDuration, "day");
-  }
-}
-
-/**
  *  Renders period of enrollment depend on what's available
  *  If startDate is set, it will return a range of dates
  *      e.g. Dec 2 - Dec 4

--- a/app/experimenter/nimbus-ui/src/lib/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/lib/mocks.tsx
@@ -294,7 +294,7 @@ export function mockExperiment<
         message: {},
       },
       startDate: new Date().toISOString(),
-      endDate: new Date(Date.now() + 12096e5).toISOString(),
+      computedEndDate: new Date(Date.now() + 12096e5).toISOString(),
       riskMitigationLink: "https://docs.google.com/document/d/banzinga/edit",
       documentationLinks: [
         {
@@ -412,7 +412,7 @@ export function mockSingleDirectoryExperiment(
     proposedEnrollment: 7,
     proposedDuration: 28,
     startDate: fiveDaysAgo.toISOString(),
-    endDate: new Date(Date.now() + 12096e5).toISOString(),
+    computedEndDate: new Date(Date.now() + 12096e5).toISOString(),
     isEndRequested: false,
     ...overrides,
   };
@@ -423,30 +423,30 @@ export function mockDirectoryExperiments(
     {
       status: NimbusExperimentStatus.DRAFT,
       startDate: null,
-      endDate: null,
+      computedEndDate: null,
     },
     {
       status: NimbusExperimentStatus.PREVIEW,
-      endDate: null,
+      computedEndDate: null,
     },
     {
       status: NimbusExperimentStatus.REVIEW,
-      endDate: null,
+      computedEndDate: null,
     },
     {
       status: NimbusExperimentStatus.REVIEW,
     },
     {
       status: NimbusExperimentStatus.LIVE,
-      endDate: null,
+      computedEndDate: null,
     },
     {
       status: NimbusExperimentStatus.LIVE,
-      endDate: null,
+      computedEndDate: null,
     },
     {
       status: NimbusExperimentStatus.LIVE,
-      endDate: null,
+      computedEndDate: null,
     },
     {
       status: NimbusExperimentStatus.COMPLETE,

--- a/app/experimenter/nimbus-ui/src/types/getAllExperiments.ts
+++ b/app/experimenter/nimbus-ui/src/types/getAllExperiments.ts
@@ -25,7 +25,7 @@ export interface getAllExperiments_experiments {
   startDate: DateTime | null;
   proposedDuration: number;
   proposedEnrollment: number;
-  endDate: DateTime | null;
+  computedEndDate: DateTime | null;
   status: NimbusExperimentStatus | null;
   isEndRequested: boolean;
   monitoringDashboardUrl: string | null;

--- a/app/experimenter/nimbus-ui/src/types/getExperiment.ts
+++ b/app/experimenter/nimbus-ui/src/types/getExperiment.ts
@@ -87,7 +87,7 @@ export interface getExperiment_experimentBySlug {
   proposedDuration: number;
   readyForReview: getExperiment_experimentBySlug_readyForReview | null;
   startDate: DateTime | null;
-  endDate: DateTime | null;
+  computedEndDate: DateTime | null;
   riskMitigationLink: string;
   documentationLinks: getExperiment_experimentBySlug_documentationLinks[] | null;
   isEnrollmentPaused: boolean | null;


### PR DESCRIPTION
Closes #4671 

This PR:

- Adds a new `computed_end_date` field to the v5 API, which returns the `end_date` if present, or `proposed_end_date`.
- Removes the `end_date` field from the API entirely as the client should be using `computed_end_date` everywhere anyway.
  - Replaces all instances of `end_date` with `computed_end_date` in the client.
- Removes the `getProposedEndDate` date helper in the client, in favor of the new `computedEndDate` value.

Did I test `computed_end_date` correctly?