### PR TITLE
fix #4673: paused experiments not updating in remote settings

### DIFF
--- a/app/experimenter/kinto/tasks.py
+++ b/app/experimenter/kinto/tasks.py
@@ -278,6 +278,7 @@ def nimbus_end_experiment_in_kinto(experiment_id):
         raise e
 
 
+@app.task
 @metrics.timer_decorator("nimbus_update_paused_experiments_in_kinto")
 def nimbus_update_paused_experiments_in_kinto():
     """


### PR DESCRIPTION
Because

* After an experiment passes its enrollment end date it should automatically update remote settings to set isEnrollmentPaused to true

This commit

* Sploops, forgot to decorate the task with @app.task
* I think integration tests will be the right place to enforce this in the future