### PR TITLE
bug(nimbus): disable update paused experiments task temporarily

### DIFF
--- a/app/experimenter/settings.py
+++ b/app/experimenter/settings.py
@@ -333,10 +333,10 @@ CELERY_BEAT_SCHEDULE = {
         "task": "experimenter.kinto.tasks.nimbus_check_experiments_are_complete",
         "schedule": config("CELERY_SCHEDULE_INTERVAL", default=300, cast=int),
     },
-    "nimbus_update_paused_experiments_in_kinto": {
-        "task": "experimenter.kinto.tasks.nimbus_update_paused_experiments_in_kinto",
-        "schedule": config("CELERY_SCHEDULE_INTERVAL", default=300, cast=int),
-    },
+    # "nimbus_update_paused_experiments_in_kinto": {
+    #     "task": "experimenter.kinto.tasks.nimbus_update_paused_experiments_in_kinto",
+    #     "schedule": config("CELERY_SCHEDULE_INTERVAL", default=300, cast=int),
+    # },
     "nimbus_synchronize_preview_experiments_in_kinto": {
         "task": "experimenter.kinto.tasks.nimbus_synchronize_preview_experiments_in_kinto",
         "schedule": config("CELERY_SCHEDULE_INTERVAL", default=300, cast=int),


### PR DESCRIPTION
Because

* We need to check for pending reviews before we update a record
* This task is spamming remote settings changes

This commit

* Temporarily disables this task
* We'll re enable it with proper logic afterwards