### PR TITLE
fix #4679 bug(nimbus): check for pending requests in remote settings before updating paused experiments

### DIFF
--- a/app/experimenter/kinto/tasks.py
+++ b/app/experimenter/kinto/tasks.py
@@ -290,6 +290,13 @@ def nimbus_update_paused_experiments_in_kinto():
 
     for application, collection in NimbusExperiment.KINTO_APPLICATION_COLLECTION.items():
         kinto_client = KintoClient(collection)
+
+        if kinto_client.has_pending_review():
+            metrics.incr(
+                f"nimbus_update_paused_experiments_in_kinto.{collection}_pending_review"
+            )
+            continue
+
         records = {r["id"]: r for r in kinto_client.get_main_records()}
 
         live_experiments = NimbusExperiment.objects.filter(

--- a/app/experimenter/settings.py
+++ b/app/experimenter/settings.py
@@ -333,10 +333,10 @@ CELERY_BEAT_SCHEDULE = {
         "task": "experimenter.kinto.tasks.nimbus_check_experiments_are_complete",
         "schedule": config("CELERY_SCHEDULE_INTERVAL", default=300, cast=int),
     },
-    # "nimbus_update_paused_experiments_in_kinto": {
-    #     "task": "experimenter.kinto.tasks.nimbus_update_paused_experiments_in_kinto",
-    #     "schedule": config("CELERY_SCHEDULE_INTERVAL", default=300, cast=int),
-    # },
+    "nimbus_update_paused_experiments_in_kinto": {
+        "task": "experimenter.kinto.tasks.nimbus_update_paused_experiments_in_kinto",
+        "schedule": config("CELERY_SCHEDULE_INTERVAL", default=300, cast=int),
+    },
     "nimbus_synchronize_preview_experiments_in_kinto": {
         "task": "experimenter.kinto.tasks.nimbus_synchronize_preview_experiments_in_kinto",
         "schedule": config("CELERY_SCHEDULE_INTERVAL", default=300, cast=int),


### PR DESCRIPTION

Because

* The update paused experiments task would mark the collection for review every time it was invoked regardless of whether there was already a pending change for review
* This accidentally spammed a bajillion notification emails

This commit

* Changes the update paused task to check whether there's a pending review before updating a record