### PR TITLE
fixes #4697 fix(nimbus): ensure bucket range allocated in preview status

### DIFF
--- a/app/experimenter/experiments/models/nimbus.py
+++ b/app/experimenter/experiments/models/nimbus.py
@@ -228,7 +228,10 @@ class NimbusExperiment(NimbusConstants, models.Model):
 
     @property
     def should_allocate_bucket_range(self):
-        return self.status in [NimbusExperiment.Status.REVIEW]
+        return self.status in [
+            NimbusExperiment.Status.PREVIEW,
+            NimbusExperiment.Status.REVIEW,
+        ]
 
     def allocate_bucket_range(self):
         existing_bucket_range = NimbusBucketRange.objects.filter(experiment=self)

--- a/app/experimenter/experiments/tests/api/v5/test_serializers.py
+++ b/app/experimenter/experiments/tests/api/v5/test_serializers.py
@@ -1069,7 +1069,13 @@ class TestNimbusExperimentSerializer(TestCase):
             serializer.errors,
         )
 
-    def test_status_to_review_generates_bucket_allocation(self):
+    @parameterized.expand(
+        [
+            [NimbusExperiment.Status.REVIEW],
+            [NimbusExperiment.Status.PREVIEW],
+        ]
+    )
+    def test_status_generates_bucket_allocation(self, to_status):
         experiment = NimbusExperimentFactory.create_with_status(
             NimbusExperiment.Status.DRAFT, population_percent=Decimal("50.0")
         )
@@ -1078,7 +1084,7 @@ class TestNimbusExperimentSerializer(TestCase):
 
         serializer = NimbusExperimentSerializer(
             experiment,
-            data={"status": NimbusExperiment.Status.REVIEW},
+            data={"status": to_status},
             context={"user": self.user},
         )
         self.assertTrue(serializer.is_valid())

--- a/app/experimenter/experiments/tests/test_models/test_models_nimbus.py
+++ b/app/experimenter/experiments/tests/test_models/test_models_nimbus.py
@@ -242,6 +242,7 @@ class TestNimbusExperiment(TestCase):
     @parameterized.expand(
         [
             [False, NimbusExperiment.Status.DRAFT],
+            [True, NimbusExperiment.Status.PREVIEW],
             [True, NimbusExperiment.Status.REVIEW],
             [False, NimbusExperiment.Status.ACCEPTED],
             [False, NimbusExperiment.Status.LIVE],


### PR DESCRIPTION
Because:

- we need the bucket range allocated in preview status

This commit:

- ensures preview status is considered when allocating bucket range at
  the time of saving the experiment