### PR TITLE
fixes #4695 feat(nimbus): more prominent banner indicating preview status

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/PageRequestReview/FormLaunchPreviewToReview.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageRequestReview/FormLaunchPreviewToReview.tsx
@@ -5,6 +5,7 @@
 import React, { useState } from "react";
 import Alert from "react-bootstrap/Alert";
 import Form from "react-bootstrap/Form";
+import { ReactComponent as Check } from "../../images/check.svg";
 import FormLaunchConfirmationCheckboxes from "./FormLaunchConfirmationCheckboxes";
 
 const FormLaunchPreviewToReview = ({
@@ -19,40 +20,54 @@ const FormLaunchPreviewToReview = ({
   const [allBoxesChecked, setAllBoxesChecked] = useState(false);
 
   return (
-    <Alert variant="warning">
-      <Form className="text-body">
-        <p className="my-1">
-          This experiment is currently <strong>live for testing</strong>, but
-          you will need to let QA know in your PI request. When you have
-          recieved a sign-off, click “Request launch” to launch the experiment.
+    <>
+      <Alert
+        data-testid="submit-success"
+        variant="success"
+        className="bg-transparent text-success"
+      >
+        <p className="my-1" data-testid="in-preview-label">
+          <Check className="align-top" /> All set! Your experiment is in Preview
+          mode and you can test it now.
         </p>
+      </Alert>
 
-        <FormLaunchConfirmationCheckboxes onChange={setAllBoxesChecked} />
+      <Alert variant="warning">
+        <Form className="text-body">
+          <p className="my-1">
+            This experiment is currently <strong>live for testing</strong>, but
+            you will need to let QA know in your PI request. When you have
+            recieved a sign-off, click “Request launch” to launch the
+            experiment.
+          </p>
 
-        <div className="d-flex bd-highlight">
-          <div className="py-2">
-            <button
-              data-testid="launch-preview-to-review"
-              type="button"
-              className="mr-3 btn btn-primary"
-              disabled={isLoading || !allBoxesChecked}
-              onClick={onSubmit}
-            >
-              Request Launch
-            </button>
-            <button
-              data-testid="launch-preview-to-draft"
-              type="button"
-              className="btn btn-secondary"
-              disabled={isLoading}
-              onClick={onBackToDraft}
-            >
-              Go Back to Draft
-            </button>
+          <FormLaunchConfirmationCheckboxes onChange={setAllBoxesChecked} />
+
+          <div className="d-flex bd-highlight">
+            <div className="py-2">
+              <button
+                data-testid="launch-preview-to-review"
+                type="button"
+                className="mr-3 btn btn-primary"
+                disabled={isLoading || !allBoxesChecked}
+                onClick={onSubmit}
+              >
+                Request Launch
+              </button>
+              <button
+                data-testid="launch-preview-to-draft"
+                type="button"
+                className="btn btn-secondary"
+                disabled={isLoading}
+                onClick={onBackToDraft}
+              >
+                Go Back to Draft
+              </button>
+            </div>
           </div>
-        </div>
-      </Form>
-    </Alert>
+        </Form>
+      </Alert>
+    </>
   );
 };
 

--- a/app/experimenter/nimbus-ui/src/components/PageRequestReview/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageRequestReview/index.test.tsx
@@ -128,6 +128,14 @@ describe("PageRequestReview", () => {
     );
   });
 
+  it("indicates status in preview", async () => {
+    const { mock } = mockExperimentQuery("demo-slug", {
+      status: NimbusExperimentStatus.PREVIEW,
+    });
+    render(<Subject mocks={[mock]} />);
+    await screen.findByTestId("in-preview-label");
+  });
+
   it("handles Launch to Preview from Draft as expected", async () => {
     const { mock, experiment } = mockExperimentQuery("demo-slug", {
       status: NimbusExperimentStatus.DRAFT,


### PR DESCRIPTION


Because:

- it's unclear to user that they are in Preview state in the UI.

This commit:

- adds a more prominent success banner to the form where preview status
  can be changed to draft or review