### PR TITLE
fixes #4275 fix(nimbus): accept commas in number of clients field

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/index.test.tsx
@@ -119,7 +119,7 @@ describe("FormAudience", () => {
       firefoxMinVersion: MOCK_EXPERIMENT.firefoxMinVersion,
       targetingConfigSlug: MOCK_EXPERIMENT.targetingConfigSlug,
       populationPercent: "" + MOCK_EXPERIMENT.populationPercent,
-      totalEnrolledClients: "" + MOCK_EXPERIMENT.totalEnrolledClients,
+      totalEnrolledClients: MOCK_EXPERIMENT.totalEnrolledClients,
       proposedEnrollment: "" + MOCK_EXPERIMENT.proposedEnrollment,
       proposedDuration: "" + MOCK_EXPERIMENT.proposedDuration,
     };
@@ -139,6 +139,31 @@ describe("FormAudience", () => {
       // Next button advances to next page
       [expected, true],
     ]);
+  });
+
+  it("accepts commas in the expected number of clients field (EXP-761)", async () => {
+    const enteredValue = "123,456,789";
+    const expectedValue = 123456789;
+
+    const onSubmit = jest.fn();
+    renderSubjectWithDefaultValues(onSubmit);
+    await screen.findByTestId("FormAudience");
+    await act(async () => {
+      const field = screen.getByTestId("totalEnrolledClients");
+      fireEvent.click(field);
+      fireEvent.change(field, { target: { value: enteredValue } });
+      fireEvent.blur(field);
+    });
+
+    const submitButton = screen.getByTestId("submit-button");
+    await act(async () => {
+      fireEvent.click(submitButton);
+    });
+
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    expect(onSubmit.mock.calls[0][0].totalEnrolledClients).toEqual(
+      expectedValue,
+    );
   });
 
   it("does not have any required modified fields", async () => {
@@ -234,7 +259,7 @@ describe("FormAudience", () => {
   });
 });
 
-const renderSubjectWithDefaultValues = (onSubmit = () => {}) => {
+const renderSubjectWithDefaultValues = (onSubmit = () => {}) =>
   render(
     <Subject
       {...{ onSubmit }}
@@ -270,4 +295,3 @@ const renderSubjectWithDefaultValues = (onSubmit = () => {}) => {
       }}
     />,
   );
-};

--- a/app/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/index.tsx
@@ -9,7 +9,11 @@ import Form from "react-bootstrap/Form";
 import InputGroup from "react-bootstrap/InputGroup";
 import ReactTooltip from "react-tooltip";
 import { useCommonForm, useConfig } from "../../../hooks";
-import { EXTERNAL_URLS, NUMBER_FIELD } from "../../../lib/constants";
+import {
+  EXTERNAL_URLS,
+  NUMBER_FIELD,
+  POSITIVE_NUMBER_WITH_COMMAS_FIELD,
+} from "../../../lib/constants";
 import { getExperiment_experimentBySlug } from "../../../types/getExperiment";
 import InlineErrorIcon from "../../InlineErrorIcon";
 import LinkExternal from "../../LinkExternal";
@@ -200,9 +204,10 @@ export const FormAudience = ({
           >
             <Form.Label>Expected number of clients</Form.Label>
             <Form.Control
-              {...formControlAttrs("totalEnrolledClients", NUMBER_FIELD)}
-              type="number"
-              min="0"
+              {...formControlAttrs(
+                "totalEnrolledClients",
+                POSITIVE_NUMBER_WITH_COMMAS_FIELD,
+              )}
             />
             <FormErrors name="totalEnrolledClients" />
           </Form.Group>

--- a/app/experimenter/nimbus-ui/src/lib/constants.ts
+++ b/app/experimenter/nimbus-ui/src/lib/constants.ts
@@ -40,6 +40,11 @@ export const NUMBER_FIELD = {
   validate: (value) => (!!value && !isNaN(value)) || FIELD_MESSAGES.NUMBER,
 } as RegisterOptions;
 
+export const POSITIVE_NUMBER_WITH_COMMAS_FIELD = {
+  setValueAs: (value) => parseFloat(("" + value).trim().replace(/[^\d+]/g, "")),
+  validate: (value) => (!isNaN(value) && value >= 0) || FIELD_MESSAGES.NUMBER,
+} as RegisterOptions;
+
 export const URL_FIELD = {
   pattern: {
     value: /^(http|https):\/\/[^ "]+$/,


### PR DESCRIPTION
Because:

- Firefox appears to allow commas on paste into number fields

This commit:

- adds a validator that accepts non-numeric characters but strips them
  before parsing and validating the input as a number