### PR TITLE
fix #4700 chore(project): increase integration circle instance size

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,7 +61,7 @@ jobs:
     machine:
       docker_layer_caching: true
       image: ubuntu-1604:202007-01 # Ubuntu 16.04, Docker v19.03.12, Docker Compose v1.26.1
-    resource_class: xlarge
+    resource_class: 2xlarge # using 2xlarge to mitigate firefox resource constraints
     working_directory: ~/experimenter
     steps:
       - run:


### PR DESCRIPTION
Because

* We've recently seen some intermittent integration test failures
* The errors are from firefox running out of file handlers, which might indicate a resource constraint issue

This commit

* Increases the integration test circle ci instance size to mitigate