### PR TITLE
fix #4703 chore(project): reduce integration test circle instance size

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,7 +61,7 @@ jobs:
     machine:
       docker_layer_caching: true
       image: ubuntu-1604:202007-01 # Ubuntu 16.04, Docker v19.03.12, Docker Compose v1.26.1
-    resource_class: 2xlarge # using 2xlarge to mitigate firefox resource constraints
+    resource_class: xlarge
     working_directory: ~/experimenter
     steps:
       - run:


### PR DESCRIPTION
Because

* We increased the instance size in an attempt to reduce integration test errors we were seeing in Firefox
* The increase in size didn't mitigate the errors

This commit

* This reverts commit 1ab43e6494d734704c09e7cc354b012904df17d8.