### PR TITLE
Fix #4696: fix(visualization) - Null checks where appropriate.

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/AppLayoutSidebarLocked/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/AppLayoutSidebarLocked/index.tsx
@@ -64,7 +64,7 @@ const otherMetricsToFriendlyName = (
   Object.keys(otherMetrics).map(
     (metric) =>
       (newMap[metric] =
-        metricsMetaData[metric]!.friendly_name || otherMetrics[metric]),
+        metricsMetaData[metric]?.friendly_name || otherMetrics[metric]),
   );
   return newMap;
 };

--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableMetricSecondary/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableMetricSecondary/index.tsx
@@ -132,10 +132,12 @@ const TableMetricSecondary = ({
           })}
         </tbody>
       </table>
-      <GraphsWeekly
-        weeklyResults={results?.weekly!}
-        {...{ probeSetSlug, probeSetName }}
-      />
+      {results?.weekly && (
+        <GraphsWeekly
+          weeklyResults={results.weekly}
+          {...{ probeSetSlug, probeSetName }}
+        />
+      )}
     </div>
   );
 };


### PR DESCRIPTION
Because:
* Some pages don't load when there is no weekly data or metadata

This commit:
* Removes assumptions about the availability of weekly and meta data to fix page load issues