### PR TITLE
fixes #4615 fix(nimbus): client validation to ensure positive numbers

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/index.test.tsx
@@ -64,7 +64,7 @@ describe("FormAudience", () => {
         expect(screen.getByTestId("submit-error")).toHaveTextContent(error);
       } else {
         expect(
-          container.querySelector(`.invalid-feedback[data-for=${fieldName}`),
+          container.querySelector(`.invalid-feedback[data-for=${fieldName}]`),
         ).toHaveTextContent(error);
       }
     }
@@ -166,6 +166,32 @@ describe("FormAudience", () => {
     );
   });
 
+  it("requires positive numbers in numeric fields (EXP-956)", async () => {
+    const onSubmit = jest.fn();
+    const { container } = render(<Subject {...{ onSubmit }} />);
+    await waitFor(() => {
+      expect(screen.queryByTestId("FormAudience")).toBeInTheDocument();
+    });
+
+    for (const fieldName of [
+      "populationPercent",
+      "totalEnrolledClients",
+      "proposedEnrollment",
+      "proposedDuration",
+    ]) {
+      await act(async () => {
+        const field = screen.getByTestId(fieldName);
+        fireEvent.click(field);
+        fireEvent.change(field, { target: { value: "-123" } });
+        fireEvent.blur(field);
+      });
+
+      expect(
+        container.querySelector(`.invalid-feedback[data-for=${fieldName}]`),
+      ).toHaveTextContent(FIELD_MESSAGES.POSITIVE_NUMBER);
+    }
+  });
+
   it("does not have any required modified fields", async () => {
     const onSubmit = jest.fn();
     renderSubjectWithDefaultValues(onSubmit);
@@ -212,8 +238,8 @@ describe("FormAudience", () => {
       });
 
       expect(
-        container.querySelector(`.invalid-feedback[data-for=${fieldName}`),
-      ).toHaveTextContent(FIELD_MESSAGES.NUMBER);
+        container.querySelector(`.invalid-feedback[data-for=${fieldName}]`),
+      ).toHaveTextContent(FIELD_MESSAGES.POSITIVE_NUMBER);
     }
   });
 

--- a/app/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/index.tsx
@@ -11,7 +11,7 @@ import ReactTooltip from "react-tooltip";
 import { useCommonForm, useConfig } from "../../../hooks";
 import {
   EXTERNAL_URLS,
-  NUMBER_FIELD,
+  POSITIVE_NUMBER_FIELD,
   POSITIVE_NUMBER_WITH_COMMAS_FIELD,
 } from "../../../lib/constants";
 import { getExperiment_experimentBySlug } from "../../../types/getExperiment";
@@ -183,7 +183,10 @@ export const FormAudience = ({
             </Form.Label>
             <InputGroup>
               <Form.Control
-                {...formControlAttrs("populationPercent", NUMBER_FIELD)}
+                {...formControlAttrs(
+                  "populationPercent",
+                  POSITIVE_NUMBER_FIELD,
+                )}
                 aria-describedby="populationPercent-unit"
                 type="number"
                 min="0"
@@ -226,7 +229,10 @@ export const FormAudience = ({
             </Form.Label>
             <InputGroup>
               <Form.Control
-                {...formControlAttrs("proposedEnrollment", NUMBER_FIELD)}
+                {...formControlAttrs(
+                  "proposedEnrollment",
+                  POSITIVE_NUMBER_FIELD,
+                )}
                 type="number"
                 min="0"
                 aria-describedby="proposedEnrollment-unit"
@@ -252,7 +258,7 @@ export const FormAudience = ({
             </Form.Label>
             <InputGroup className="mb-3">
               <Form.Control
-                {...formControlAttrs("proposedDuration", NUMBER_FIELD)}
+                {...formControlAttrs("proposedDuration", POSITIVE_NUMBER_FIELD)}
                 type="number"
                 min="0"
                 aria-describedby="proposedDuration-unit"

--- a/app/experimenter/nimbus-ui/src/lib/constants.ts
+++ b/app/experimenter/nimbus-ui/src/lib/constants.ts
@@ -29,6 +29,7 @@ export const EXTERNAL_URLS = {
 export const FIELD_MESSAGES = {
   REQUIRED: "This field may not be blank.",
   NUMBER: "This field must be a number.",
+  POSITIVE_NUMBER: "This field must be a positive number.",
   URL: "This field must be a URL.",
 };
 
@@ -40,9 +41,16 @@ export const NUMBER_FIELD = {
   validate: (value) => (!!value && !isNaN(value)) || FIELD_MESSAGES.NUMBER,
 } as RegisterOptions;
 
+export const POSITIVE_NUMBER_FIELD = {
+  validate: (value) =>
+    (!!value && !isNaN(value) && value >= 0) || FIELD_MESSAGES.POSITIVE_NUMBER,
+} as RegisterOptions;
+
 export const POSITIVE_NUMBER_WITH_COMMAS_FIELD = {
-  setValueAs: (value) => parseFloat(("" + value).trim().replace(/[^\d+]/g, "")),
-  validate: (value) => (!isNaN(value) && value >= 0) || FIELD_MESSAGES.NUMBER,
+  setValueAs: (value) =>
+    parseFloat(("" + value).trim().replace(/[^\d.-]+/g, "")),
+  validate: (value) =>
+    (!isNaN(value) && value >= 0) || FIELD_MESSAGES.POSITIVE_NUMBER,
 } as RegisterOptions;
 
 export const URL_FIELD = {


### PR DESCRIPTION
Because:

- fields on the audience page were allowing negative numbers

This commit:

- tweaks validation to assert positive numbers are required