### PR TITLE
fix #4196 fix(nimbus): expect non-zero values for audience form

### DIFF
--- a/app/experimenter/experiments/api/v5/serializers.py
+++ b/app/experimenter/experiments/api/v5/serializers.py
@@ -457,11 +457,12 @@ class NimbusReadyForReviewSerializer(
     NimbusStatusRestrictionMixin, serializers.ModelSerializer
 ):
     public_description = serializers.CharField(required=True)
-    proposed_duration = serializers.IntegerField(required=True)
-    proposed_enrollment = serializers.IntegerField(required=True)
+    proposed_duration = serializers.IntegerField(required=True, min_value=1)
+    proposed_enrollment = serializers.IntegerField(required=True, min_value=1)
     population_percent = serializers.DecimalField(
         7, 4, min_value=0.0001, max_value=100.0, required=True
     )
+    total_enrolled_clients = serializers.IntegerField(required=True, min_value=1)
     firefox_min_version = serializers.ChoiceField(
         NimbusExperiment.Version.choices, required=True
     )

--- a/app/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/index.test.tsx
@@ -254,6 +254,7 @@ describe("FormAudience", () => {
     expect(
       screen.queryByTestId("missing-population-percent"),
     ).toBeInTheDocument();
+    expect(screen.queryByTestId("missing-clients")).toBeInTheDocument();
     expect(screen.queryByTestId("missing-enrollment")).toBeInTheDocument();
     expect(screen.queryByTestId("missing-duration")).toBeInTheDocument();
   });

--- a/app/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/index.tsx
@@ -202,7 +202,15 @@ export const FormAudience = ({
             className="mx-5"
             controlId="totalEnrolledClients"
           >
-            <Form.Label>Expected number of clients</Form.Label>
+            <Form.Label>
+              Expected number of clients
+              {isMissingField("total_enrolled_clients") && (
+                <InlineErrorIcon
+                  name="clients"
+                  message="Expected number of clients must be a number greater than zero"
+                />
+              )}
+            </Form.Label>
             <Form.Control
               {...formControlAttrs(
                 "totalEnrolledClients",
@@ -220,7 +228,7 @@ export const FormAudience = ({
               {isMissingField("proposed_enrollment") && (
                 <InlineErrorIcon
                   name="enrollment"
-                  message="Proposed enrollment cannot be blank"
+                  message="Proposed enrollment must be a number greater than zero"
                 />
               )}
             </Form.Label>
@@ -246,7 +254,7 @@ export const FormAudience = ({
               {isMissingField("proposed_duration") && (
                 <InlineErrorIcon
                   name="duration"
-                  message="Proposed duration cannot be blank"
+                  message="Proposed duration must be a number greater than zero"
                 />
               )}
             </Form.Label>

--- a/app/experimenter/nimbus-ui/src/components/Summary/SummaryTimeline/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/SummaryTimeline/index.test.tsx
@@ -57,12 +57,14 @@ describe("SummaryTimeline", () => {
     expect(screen.queryByTestId("label-enrollment-days")).toBeInTheDocument();
   });
 
-  it("renders with missing details", () => {
+  it("renders 0 days properly", () => {
     render(<Subject proposedDuration={0} proposedEnrollment={0} />);
 
-    expect(screen.queryByTestId("label-duration-not-set")).toBeInTheDocument();
-    expect(
-      screen.queryByTestId("label-enrollment-not-set"),
-    ).toBeInTheDocument();
+    expect(screen.queryByTestId("label-duration-days")).toHaveTextContent(
+      "0 days",
+    );
+    expect(screen.queryByTestId("label-enrollment-days")).toHaveTextContent(
+      "0 days",
+    );
   });
 });

--- a/app/experimenter/nimbus-ui/src/components/Summary/SummaryTimeline/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/SummaryTimeline/index.tsx
@@ -115,13 +115,13 @@ const Duration = ({
 }) => (
   <span>
     Total duration:{" "}
-    {duration ? (
+    {duration !== null ? (
       <b data-testid="label-duration-days">{pluralize(duration, "day")}</b>
     ) : (
       <NotSet data-testid="label-duration-not-set" />
     )}{" "}
     / Enrollment:{" "}
-    {enrollment ? (
+    {enrollment !== null ? (
       <b data-testid="label-enrollment-days">{pluralize(enrollment, "day")}</b>
     ) : (
       <NotSet data-testid="label-enrollment-not-set" />


### PR DESCRIPTION
Because:

- There is confusing behavior w/ 0 day enrollment period/duration

This commit:

- doesn't treat '0' duration and enrollment as not set

- does expect non-zero values for audience form values in review
  serializer