### PR TITLE
chore(project): disable intermittently failing integration tests

### DIFF
--- a/app/tests/integration/test_filter_expression_validation.py
+++ b/app/tests/integration/test_filter_expression_validation.py
@@ -1,3 +1,7 @@
+import pytest
+
+
+@pytest.mark.skip(reason="failing until we fix gh#4700")
 def test_filter_expressions_with_matching_firefox_versions(base_url, selenium):
     selenium.get("about:blank")
     with open("utils/filter_expression.js") as js:
@@ -6,6 +10,7 @@ def test_filter_expressions_with_matching_firefox_versions(base_url, selenium):
     assert script is True
 
 
+@pytest.mark.skip(reason="failing until we fix gh#4700")
 def test_filter_expressions_with_mismatching_firefox_versions(base_url, selenium):
     selenium.get("about:blank")
     with open("utils/filter_expression.js") as js:


### PR DESCRIPTION
Because

* We added integration tests to load and execute targeting expressions
* We use the latest Firefox Nightly build to run our integration tests
* Something may have changed that prevents these tests from running properly

This commit

* Disables the tests until we can find a better fix