### PR TITLE
Fix #4507: feat(visualization) Add treatment and control definitions to the top of the page.

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableHighlights/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableHighlights/index.stories.tsx
@@ -19,6 +19,7 @@ storiesOf("pages/Results/TableHighlights", module)
         <TableHighlights
           primaryProbeSets={experiment.primaryProbeSets!}
           results={mockAnalysis()}
+          {...{ experiment }}
         />
       </RouterSlugProvider>
     );
@@ -45,6 +46,7 @@ storiesOf("pages/Results/TableHighlights", module)
         <TableHighlights
           primaryProbeSets={experiment.primaryProbeSets!}
           results={mockAnalysis()}
+          {...{ experiment }}
         />
       </RouterSlugProvider>
     );

--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableHighlights/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableHighlights/index.test.tsx
@@ -12,25 +12,37 @@ import { mockAnalysis } from "../../../lib/visualization/mocks";
 const { mock, experiment } = mockExperimentQuery("demo-slug");
 
 describe("TableHighlights", () => {
-  it("has participants for all users shown for each variant", () => {
-    const EXPECTED_LABELS = ["participants", "All Users"];
-
+  it("has participants shown for each variant", () => {
     render(
       <RouterSlugProvider mocks={[mock]}>
         <TableHighlights
           primaryProbeSets={experiment.primaryProbeSets!}
           results={mockAnalysis()}
+          {...{ experiment }}
         />
       </RouterSlugProvider>,
     );
 
-    EXPECTED_LABELS.forEach((label) => {
-      expect(
-        screen.getAllByText(label, {
-          exact: false,
-        }),
-      ).toHaveLength(2);
-    });
+    expect(
+      screen.getAllByText("participants", {
+        exact: false,
+      }),
+    ).toHaveLength(2);
+  });
+
+  it("has an expected branch description", () => {
+    const branchDescription = experiment.referenceBranch!.description;
+    render(
+      <RouterSlugProvider mocks={[mock]}>
+        <TableHighlights
+          primaryProbeSets={experiment.primaryProbeSets!}
+          results={mockAnalysis()}
+          {...{ experiment }}
+        />
+      </RouterSlugProvider>,
+    );
+
+    expect(screen.getByText(branchDescription)).toBeInTheDocument();
   });
 
   it("has correctly labelled result significance", async () => {
@@ -39,6 +51,7 @@ describe("TableHighlights", () => {
         <TableHighlights
           primaryProbeSets={experiment.primaryProbeSets!}
           results={mockAnalysis()}
+          {...{ experiment }}
         />
       </RouterSlugProvider>,
     );
@@ -54,6 +67,7 @@ describe("TableHighlights", () => {
         <TableHighlights
           primaryProbeSets={experiment.primaryProbeSets!}
           results={mockAnalysis()}
+          {...{ experiment }}
         />
       </RouterSlugProvider>,
     );

--- a/app/experimenter/nimbus-ui/src/components/PageResults/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/index.tsx
@@ -58,6 +58,7 @@ const PageResults: React.FunctionComponent<RouteComponentProps> = () => (
           <TableHighlights
             primaryProbeSets={experiment.primaryProbeSets!}
             results={analysis!}
+            {...{ experiment }}
           />
           <TableHighlightsOverview
             {...{ experiment }}

--- a/app/experimenter/nimbus-ui/src/lib/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/lib/mocks.tsx
@@ -252,7 +252,7 @@ export function mockExperiment<
         "Official approach present industry strategy dream piece.",
       referenceBranch: {
         name: "User-centric mobile solution",
-        slug: "user-centric-mobile-solution",
+        slug: "control",
         description: "Behind almost radio result personal none future current.",
         ratio: 1,
         featureValue: '{"environmental-fact": "really-citizen"}',
@@ -262,7 +262,7 @@ export function mockExperiment<
       treatmentBranches: [
         {
           name: "Managed zero tolerance projection",
-          slug: "managed-zero-tolerance-projection",
+          slug: "treatment",
           description: "Next ask then he in degree order.",
           ratio: 1,
           featureValue: '{"effect-effect-whole": "close-teach-exactly"}',


### PR DESCRIPTION
Because:
* Users want to see descriptions of branches when they are looking at results
* Users are confused by "All Users" in the highlights when there is nothing to contrast it

This commit:
* Adds branch descriptions at the top of the results page
* Removes "All Users" from highlights - we can add this back in when there are more segments to work with (e.g. first-run users).