### PR TITLE
fixes #4543 fix(nimbus): ensure dummy feature configs have schemas

### DIFF
--- a/app/experimenter/experiments/tests/factories/nimbus.py
+++ b/app/experimenter/experiments/tests/factories/nimbus.py
@@ -207,6 +207,19 @@ class NimbusBucketRangeFactory(factory.django.DjangoModelFactory):
         model = NimbusBucketRange
 
 
+FAKER_JSON_SCHEMA = """\
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "description": "Fake schema that matches NimbusBranchFactory feature_value factory",
+    "type": "object",
+    "patternProperties": {
+        "^.*$": { "type": "string" }
+    },
+    "additionalProperties": false
+}
+"""
+
+
 class NimbusFeatureConfigFactory(factory.django.DjangoModelFactory):
     name = factory.LazyAttribute(lambda o: faker.catch_phrase())
     slug = factory.LazyAttribute(
@@ -217,6 +230,14 @@ class NimbusFeatureConfigFactory(factory.django.DjangoModelFactory):
         lambda o: random.choice(list(NimbusExperiment.Application)).value
     )
     owner_email = factory.LazyAttribute(lambda o: faker.email())
+    schema = factory.LazyAttribute(
+        lambda o: faker.random_element(
+            elements=(
+                None,
+                FAKER_JSON_SCHEMA,
+            )
+        )
+    )
 
     class Meta:
         model = NimbusFeatureConfig

--- a/app/experimenter/experiments/tests/test_changelog_utils/test_changelog_utils_nimbus.py
+++ b/app/experimenter/experiments/tests/test_changelog_utils/test_changelog_utils_nimbus.py
@@ -76,7 +76,7 @@ class TestNimbusExperimentChangeLogSerializer(TestCase):
                     "description": feature_config.description,
                     "application": feature_config.application,
                     "owner_email": feature_config.owner_email,
-                    "schema": None,
+                    "schema": feature_config.schema,
                 },
                 "firefox_min_version": experiment.firefox_min_version,
                 "hypothesis": experiment.hypothesis,


### PR DESCRIPTION
Because:

- Not all features have values, it should be possible to select a
  feature and make it enable/disabled without setting a value.

This commit:

- Ensures there are dummy examples of feature configs both with and
  without a JSON schema, the presence of which causes a feature config
  value to be required in an experiment's branches