### PR TITLE
chore(project): check in select vscode settings files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,9 +71,14 @@ target/
 # Environment file
 .env
 .envrc
-
-.vscode/
 .psql_history
+
+# VS Code
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
 
 # Hosted assets
 app/experimenter/media/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,12 @@
+{
+  "python.linting.enabled": true,
+  "python.linting.flake8Enabled": true,
+  "python.linting.flake8Args": [
+    "--config=app/.flake8"
+  ],
+  "python.formatting.provider": "black",
+  "python.formatting.blackArgs": [
+    "--line-length",
+    "90"
+  ]
+}


### PR DESCRIPTION
It'll be good to start setting project-wide VS code settings, and so I'm using [this recommendation](https://stackoverflow.com/a/57749909/717633) on checking in `.vscode` JSON files.

I hope to add more settings and launch files down the road, but for now I just want to add Black and Flake8 linting settings. Now VS Code can also pick up on these args and use them in auto-formatting/linting.