### PR TITLE
fix #4750 chore(project): use makefile to build deploy container

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,7 +90,7 @@ jobs:
           name: Deploy to latest
           command: |
             ./scripts/store_git_info.sh
-            docker build --target deploy -f app/Dockerfile -t app:deploy app/
+            make build_prod
             docker login -u $DOCKER_USER -p $DOCKER_PASS
             docker tag app:deploy ${DOCKERHUB_REPO}:latest
             docker push ${DOCKERHUB_REPO}:latest


### PR DESCRIPTION
Becuase

* We recently added a dependency on checking out the git submodule for jetstream config to our build process
* We added that dependency to the makefile
* The circle config to build the deploy container was not using the makefile entry point to build the container
* Jetstream was not being pulled in before deploy build
* The system check we added to prevent starting worked correctly!

This commit

* Switches circle to use the makefile to build the deploy container