### PR TITLE
chore(project): allow nested .vscode folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,7 +74,7 @@ target/
 .psql_history
 
 # VS Code
-.vscode/*
+**/.vscode/*
 !.vscode/settings.json
 !.vscode/tasks.json
 !.vscode/launch.json


### PR DESCRIPTION
Because

* It can be necessary to have a .vscode directory under the root or under ./app

This commit

* Ignores .vscode directories at any depth