### PR TITLE
fix #4757 feat(nimbus): add outcomes to V6 API

### DIFF
--- a/app/experimenter/docs/openapi-schema.json
+++ b/app/experimenter/docs/openapi-schema.json
@@ -2966,6 +2966,10 @@
               "count"
             ]
           },
+          "outcomes": {
+            "type": "string",
+            "readOnly": true
+          },
           "probeSets": {
             "type": "string",
             "readOnly": true

--- a/app/experimenter/docs/swagger-ui.html
+++ b/app/experimenter/docs/swagger-ui.html
@@ -2978,6 +2978,10 @@
               "count"
             ]
           },
+          "outcomes": {
+            "type": "string",
+            "readOnly": true
+          },
           "probeSets": {
             "type": "string",
             "readOnly": true

--- a/app/experimenter/experiments/api/v6/serializers.py
+++ b/app/experimenter/experiments/api/v6/serializers.py
@@ -64,6 +64,7 @@ class NimbusExperimentSerializer(serializers.ModelSerializer):
     isEnrollmentPaused = serializers.ReadOnlyField(source="is_paused")
     bucketConfig = NimbusBucketRangeSerializer(source="bucket_range")
     probeSets = serializers.SerializerMethodField()
+    outcomes = serializers.SerializerMethodField()
     branches = NimbusBranchSerializer(many=True)
     startDate = serializers.DateTimeField(source="start_date")
     endDate = serializers.DateTimeField(source="end_date")
@@ -87,6 +88,7 @@ class NimbusExperimentSerializer(serializers.ModelSerializer):
             "userFacingDescription",
             "isEnrollmentPaused",
             "bucketConfig",
+            "outcomes",
             "probeSets",
             "branches",
             "targeting",
@@ -113,6 +115,17 @@ class NimbusExperimentSerializer(serializers.ModelSerializer):
 
     def get_probeSets(self, obj):
         return list(obj.probe_sets.all().order_by("slug").values_list("slug", flat=True))
+
+    def get_outcomes(self, obj):
+        prioritized_outcomes = (
+            ("primary", obj.primary_outcomes),
+            ("secondary", obj.secondary_outcomes),
+        )
+        return [
+            {"slug": slug, "priority": priority}
+            for (priority, outcomes) in prioritized_outcomes
+            for slug in outcomes
+        ]
 
     def get_referenceBranch(self, obj):
         if obj.reference_branch:

--- a/app/experimenter/experiments/tests/api/v6/test_serializers.py
+++ b/app/experimenter/experiments/tests/api/v6/test_serializers.py
@@ -29,6 +29,8 @@ class TestNimbusExperimentSerializer(TestCase):
             targeting_config_slug=NimbusExperiment.TargetingConfig.ALL_ENGLISH,
             channel=NimbusExperiment.Channel.NIGHTLY,
             probe_sets=[probe_set],
+            primary_outcomes=["foo", "bar", "baz"],
+            secondary_outcomes=["quux", "xyzzy"],
         )
 
         serializer = NimbusExperimentSerializer(experiment)
@@ -63,6 +65,13 @@ class TestNimbusExperimentSerializer(TestCase):
                 "userFacingDescription": experiment.public_description,
                 "userFacingName": experiment.name,
                 "probeSets": [probe_set.slug],
+                "outcomes": [
+                    {"priority": "primary", "slug": "foo"},
+                    {"priority": "primary", "slug": "bar"},
+                    {"priority": "primary", "slug": "baz"},
+                    {"priority": "secondary", "slug": "quux"},
+                    {"priority": "secondary", "slug": "xyzzy"},
+                ],
                 "featureIds": [experiment.feature_config.slug],
             },
         )

--- a/app/experimenter/experiments/tests/factories/nimbus.py
+++ b/app/experimenter/experiments/tests/factories/nimbus.py
@@ -67,7 +67,7 @@ class NimbusExperimentFactory(factory.django.DjangoModelFactory):
     primary_outcomes = factory.LazyAttribute(
         lambda o: [oc.slug for oc in Outcomes.all()[:2]]
     )
-    primary_outcomes = factory.LazyAttribute(
+    secondary_outcomes = factory.LazyAttribute(
         lambda o: [oc.slug for oc in Outcomes.all()[2:]]
     )
 


### PR DESCRIPTION
Because:

- We need to expose the new outcomes in the V6 API for jetstream to consume

This commit:

- adds the outcome field tp V6 API output to match nimbus-shared schema

- fixes a small bug where primary_outcomes was listed twice in model
  factories instead of defining secondary_outcomes

- updates to docs via make generate_docs