### PR TITLE
chore(nimbus): change jetstream-config to track main branch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "app/experimenter/outcomes/jetstream-config"]
 	path = app/experimenter/outcomes/jetstream-config
 	url = git@github.com:mozilla/jetstream-config.git
+	branch = main

--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ secretkey:
 
 jetstream_config:
 	git submodule init
-	git submodule update
+	git submodule update --remote
 
 build_dev: jetstream_config
 	docker build --target dev -f app/Dockerfile -t app:dev app/


### PR DESCRIPTION
Because

* We always want the jetstream-config module to be up to date with the latest remote

This commit

* Configures the submodule to track the branch main rather than a specific commit