### PR TITLE
fixes #4686 feat(project): split nimbus_check_kinto_push_queue into multiple tasks

### DIFF
--- a/app/experimenter/experiments/models/nimbus.py
+++ b/app/experimenter/experiments/models/nimbus.py
@@ -16,6 +16,18 @@ from experimenter.experiments.constants import NimbusConstants
 from experimenter.projects.models import Project
 
 
+class NimbusExperimentManager(models.Manager):
+    def launch_queue(self, application):
+        return self.filter(status=NimbusExperiment.Status.REVIEW, application=application)
+
+    def end_queue(self, application):
+        return self.filter(
+            status=NimbusExperiment.Status.LIVE,
+            application=application,
+            is_end_requested=True,
+        )
+
+
 class NimbusExperiment(NimbusConstants, models.Model):
     owner = models.ForeignKey(
         get_user_model(),
@@ -72,6 +84,8 @@ class NimbusExperiment(NimbusConstants, models.Model):
     reference_branch = models.OneToOneField(
         "NimbusBranch", blank=True, null=True, on_delete=models.CASCADE
     )
+
+    objects = NimbusExperimentManager()
 
     class Meta:
         verbose_name = "Nimbus Experiment"

--- a/app/experimenter/experiments/tests/test_models/test_models_nimbus.py
+++ b/app/experimenter/experiments/tests/test_models/test_models_nimbus.py
@@ -19,6 +19,58 @@ from experimenter.experiments.tests.factories import (
 from experimenter.openidc.tests.factories import UserFactory
 
 
+class TestNimbusExperimentManager(TestCase):
+    def test_launch_queue_returns_queued_experiments_with_correct_application(self):
+        experiment1 = NimbusExperimentFactory.create_with_status(
+            NimbusExperiment.Status.REVIEW,
+            application=NimbusExperiment.Application.DESKTOP,
+        )
+        NimbusExperimentFactory.create_with_status(
+            NimbusExperiment.Status.REVIEW,
+            application=NimbusExperiment.Application.FENIX,
+        )
+        NimbusExperimentFactory.create_with_status(
+            NimbusExperiment.Status.LIVE,
+            application=NimbusExperiment.Application.DESKTOP,
+        )
+        self.assertEqual(
+            list(
+                NimbusExperiment.objects.launch_queue(
+                    NimbusExperiment.Application.DESKTOP
+                )
+            ),
+            [experiment1],
+        )
+
+    def test_end_queue_returns_ending_experiments_with_correct_application(self):
+        experiment1 = NimbusExperimentFactory.create_with_status(
+            NimbusExperiment.Status.LIVE,
+            is_end_requested=True,
+            application=NimbusExperiment.Application.DESKTOP,
+        )
+        NimbusExperimentFactory.create_with_status(
+            NimbusExperiment.Status.LIVE,
+            is_end_requested=True,
+            application=NimbusExperiment.Application.FENIX,
+        )
+        NimbusExperimentFactory.create_with_status(
+            NimbusExperiment.Status.LIVE,
+            is_end_requested=False,
+            application=NimbusExperiment.Application.DESKTOP,
+        )
+        NimbusExperimentFactory.create_with_status(
+            NimbusExperiment.Status.REVIEW,
+            is_end_requested=True,
+            application=NimbusExperiment.Application.DESKTOP,
+        )
+        self.assertEqual(
+            list(
+                NimbusExperiment.objects.end_queue(NimbusExperiment.Application.DESKTOP)
+            ),
+            [experiment1],
+        )
+
+
 class TestNimbusExperiment(TestCase):
     def test_str(self):
         experiment = NimbusExperimentFactory.create(slug="experiment-slug")

--- a/app/experimenter/kinto/client.py
+++ b/app/experimenter/kinto/client.py
@@ -69,6 +69,10 @@ class KintoClient:
         self._fetch_collection_data()
         return self.collection_data["status"] == KINTO_REVIEW_STATUS
 
+    def has_rejection(self):
+        self._fetch_collection_data()
+        return self.collection_data["status"] == KINTO_REJECTED_STATUS
+
     def get_rejected_collection_data(self):
         self._fetch_collection_data()
         if self.collection_data["status"] == KINTO_REJECTED_STATUS:

--- a/app/experimenter/kinto/tasks.py
+++ b/app/experimenter/kinto/tasks.py
@@ -78,54 +78,43 @@ def nimbus_check_kinto_push_queue():
     for application, collection in NimbusExperiment.KINTO_APPLICATION_COLLECTION.items():
         kinto_client = KintoClient(collection)
 
-        rejected_collection_data = kinto_client.get_rejected_collection_data()
-        if rejected_collection_data:
-            rejected_slug = kinto_client.get_rejected_record()
-            experiment = NimbusExperiment.objects.get(slug=rejected_slug)
-            if (
-                experiment.status == NimbusExperiment.Status.LIVE
-                and experiment.is_end_requested
-            ):
-                experiment.is_end_requested = False
-            else:
-                experiment.status = NimbusExperiment.Status.DRAFT
-
-            experiment.save()
-
-            generate_nimbus_changelog(
-                experiment,
-                get_kinto_user(),
-                message=f'Rejected: {rejected_collection_data["last_reviewer_comment"]}',
-            )
-
-            kinto_client.rollback_changes()
-
         if kinto_client.has_pending_review():
-            metrics.incr(f"check_kinto_push_queue.{collection}_pending_review")
             return
 
-        queued_experiments = NimbusExperiment.objects.filter(
-            status=NimbusExperiment.Status.REVIEW, application=application
-        )
-        end_requested_experiments = NimbusExperiment.objects.filter(
-            status=NimbusExperiment.Status.LIVE,
-            application=application,
-            is_end_requested=True,
-        )
-        if queued_experiments.exists():
-            nimbus_push_experiment_to_kinto.delay(queued_experiments.first().id)
-            metrics.incr(
-                f"check_kinto_push_queue.{collection}_queued_experiment_selected"
-            )
-        elif end_requested_experiments.exists():
-            nimbus_end_experiment_in_kinto.delay(end_requested_experiments.first().id)
-            metrics.incr(
-                f"check_kinto_push_queue.{collection}_end_requested_experiment_deleted"
-            )
-        else:
-            metrics.incr(f"check_kinto_push_queue.{collection}_no_experiments_queued")
+        if kinto_client.has_rejection():
+            handle_rejection(kinto_client)
+
+        if queued_launch_experiment := NimbusExperiment.objects.launch_queue(
+            application
+        ).first():
+            nimbus_push_experiment_to_kinto.delay(queued_launch_experiment.id)
+        elif queued_end_experiment := NimbusExperiment.objects.end_queue(
+            application
+        ).first():
+            nimbus_end_experiment_in_kinto.delay(queued_end_experiment.id)
 
     metrics.incr("check_kinto_push_queue.completed")
+
+
+def handle_rejection(kinto_client):
+    rejected_slug = kinto_client.get_rejected_record()
+    collection_data = kinto_client.get_rejected_collection_data()
+    experiment = NimbusExperiment.objects.get(slug=rejected_slug)
+
+    if experiment.status == NimbusExperiment.Status.LIVE and experiment.is_end_requested:
+        experiment.is_end_requested = False
+    else:
+        experiment.status = NimbusExperiment.Status.DRAFT
+
+    experiment.save()
+
+    generate_nimbus_changelog(
+        experiment,
+        get_kinto_user(),
+        message=f'Rejected: {collection_data["last_reviewer_comment"]}',
+    )
+
+    kinto_client.rollback_changes()
 
 
 @app.task


### PR DESCRIPTION
Fixes #4686

This PR breaks the Kinto task `nimbus_check_kinto_push_queue` into a handful of individual tasks that can be independently run. It also introduces a `NimbusExperimenterManager` for collecting groups of queued experiments.