### PR TITLE
chore(nimbus): use curl/unzip instead of gitsubmodule to track jetstream-config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,3 +98,6 @@ app/coverage_html_report/
 node_modules
 
 google-credentials.json
+
+# Jetstream config
+app/experimenter/outcomes/jetstream-config*

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,0 @@
-[submodule "app/experimenter/outcomes/jetstream-config"]
-	path = app/experimenter/outcomes/jetstream-config
-	url = git@github.com:mozilla/jetstream-config.git
-	branch = main

--- a/Makefile
+++ b/Makefile
@@ -51,8 +51,8 @@ secretkey:
 	openssl rand -hex 24
 
 jetstream_config:
-	git submodule init
-	git submodule update --remote
+	curl -LJ -o app/experimenter/outcomes/jetstream-config.zip https://github.com/mozilla/jetstream-config/archive/main.zip
+	unzip -o -d app/experimenter/outcomes app/experimenter/outcomes/jetstream-config.zip
 
 build_dev: jetstream_config
 	docker build --target dev -f app/Dockerfile -t app:dev app/

--- a/app/experimenter/settings.py
+++ b/app/experimenter/settings.py
@@ -423,5 +423,5 @@ NIMBUS_SCHEMA_VERSION = pkg_resources.get_distribution("mozilla-nimbus-shared").
 
 # Jetstream config paths
 JETSTREAM_CONFIG_OUTCOMES_PATH = os.path.join(
-    BASE_DIR, "outcomes", "jetstream-config", "outcomes"
+    BASE_DIR, "outcomes", "jetstream-config-main", "outcomes"
 )


### PR DESCRIPTION

Because

* Using a git submodule will require that we always commit the latest commit hash which muddies the git history

This commit

* Uses curl/unzip to fetch the latest jetstream config archive and unpacks it into the outcomes folder
* Removes the gitsubmodule