### PR TITLE
fixes #4685 feat(project): only put accepted experiments into draft on rejection

### DIFF
--- a/app/experimenter/kinto/tasks.py
+++ b/app/experimenter/kinto/tasks.py
@@ -101,12 +101,16 @@ def handle_rejection(kinto_client):
     collection_data = kinto_client.get_rejected_collection_data()
     experiment = NimbusExperiment.objects.get(slug=rejected_slug)
 
+    has_changes = False
     if experiment.status == NimbusExperiment.Status.LIVE and experiment.is_end_requested:
         experiment.is_end_requested = False
-    else:
+        has_changes = True
+    elif experiment.status == NimbusExperiment.Status.ACCEPTED:
         experiment.status = NimbusExperiment.Status.DRAFT
+        has_changes = True
 
-    experiment.save()
+    if has_changes:
+        experiment.save()
 
     generate_nimbus_changelog(
         experiment,


### PR DESCRIPTION
Closes #4685

This work is slightly different from the issue description per my discussion with @jaredlockhart. This PR updates `handle_rejection` (kicked off by the `nimbus_check_kinto_push_queue` task) to:

- Add a condition to the elif that changes the experiment's status back to Draft only if the experiment was in an Accepted state to begin with
- Conditionally saves the experiment in the DB to avoid unnecessary writes

As we discussed, any reject will still 1) create a changelog, and 2) trigger a rollback