### PR TITLE
Fix #4824: Add priority list for allowable statistics.

### DIFF
--- a/app/experimenter/visualization/tests/api/constants.py
+++ b/app/experimenter/visualization/tests/api/constants.py
@@ -24,11 +24,19 @@ class TestConstants:
                 "branch": "variant",
             },
         }
-        VARIANT_DATA_DEFAULT_METRIC_ROW = {
+        VARIANT_DATA_DEFAULT_METRIC_ROW_MEAN = {
             **DATA_IDENTITY_ROW,
             **{
                 "metric": "some_count",
                 "statistic": "mean",
+                "branch": "variant",
+            },
+        }
+        VARIANT_DATA_DEFAULT_METRIC_ROW_BINOMIAL = {
+            **DATA_IDENTITY_ROW,
+            **{
+                "metric": "another_count",
+                "statistic": "binomial",
                 "branch": "variant",
             },
         }
@@ -63,7 +71,8 @@ class TestConstants:
         DATA_WITHOUT_POPULATION_PERCENTAGE = [
             CONTROL_DATA_ROW,
             VARIANT_DATA_ROW,
-            VARIANT_DATA_DEFAULT_METRIC_ROW,
+            VARIANT_DATA_DEFAULT_METRIC_ROW_MEAN,
+            VARIANT_DATA_DEFAULT_METRIC_ROW_BINOMIAL,
             VARIANT_POSITIVE_SIGNIFICANCE_DATA_ROW,
             VARIANT_NEGATIVE_SIGNIFICANCE_DATA_ROW,
             CONTROL_NEUTRAL_SIGNIFICANCE_DATA_ROW,
@@ -180,6 +189,26 @@ class TestConstants:
                         "difference": {"all": [], "first": {}},
                         "relative_uplift": {"all": [], "first": {}},
                     },
+                    "another_count": {
+                        "absolute": {
+                            "first": {
+                                "lower": 10,
+                                "point": 12,
+                                "upper": 13,
+                                "window_index": "1",
+                            },
+                            "all": [
+                                {
+                                    "lower": 10,
+                                    "point": 12,
+                                    "upper": 13,
+                                    "window_index": "1",
+                                }
+                            ],
+                        },
+                        "difference": {"all": [], "first": {}},
+                        "relative_uplift": {"all": [], "first": {}},
+                    },
                     "retained": {
                         "absolute": {"all": [], "first": {}},
                         "difference": {
@@ -266,6 +295,14 @@ class TestConstants:
                         "significance": Significance.POSITIVE,
                     },
                     "some_count": {
+                        "absolute": {
+                            "first": {"lower": 10, "point": 12, "upper": 13},
+                            "all": [{"lower": 10, "point": 12, "upper": 13}],
+                        },
+                        "difference": {"all": [], "first": {}},
+                        "relative_uplift": {"all": [], "first": {}},
+                    },
+                    "another_count": {
                         "absolute": {
                             "first": {"lower": 10, "point": 12, "upper": 13},
                             "all": [{"lower": 10, "point": 12, "upper": 13}],

--- a/app/experimenter/visualization/tests/api/test_views.py
+++ b/app/experimenter/visualization/tests/api/test_views.py
@@ -122,7 +122,10 @@ class TestVisualizationView(TestCase):
             "daily": DATA_WITHOUT_POPULATION_PERCENTAGE,
             "weekly": FORMATTED_DATA_WITHOUT_POPULATION_PERCENTAGE,
             "overall": FORMATTED_DATA_WITH_POPULATION_PERCENTAGE,
-            "other_metrics": {"some_count": "Some Count"},
+            "other_metrics": {
+                "some_count": "Some Count",
+                "another_count": "Another Count",
+            },
             "metadata": {},
             "show_analysis": False,
         }


### PR DESCRIPTION
Because:
* metrics with non-mean statistics were missing/not processed

This commit:
* creates a priority list (for now with only mean and binomial) to decide which statistic to show for a metric