### PR TITLE
Fix #4807 - fix(visualization) Add weekly significance computation.

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableVisualizationRow/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableVisualizationRow/index.tsx
@@ -188,6 +188,7 @@ const TableVisualizationRow: React.FC<{
   displayType?: DISPLAY_TYPE;
   branchComparison?: string;
   tooltip?: string;
+  window?: string;
 }> = ({
   metricKey,
   results,
@@ -196,6 +197,7 @@ const TableVisualizationRow: React.FC<{
   displayType,
   branchComparison,
   tooltip = "",
+  window = "overall",
 }) => {
   const { branch_data, is_control } = results;
   const metricData = branch_data[metricKey];
@@ -217,7 +219,6 @@ const TableVisualizationRow: React.FC<{
     const userCountsList =
       branch_data[METRIC.USER_COUNT][BRANCH_COMPARISON.ABSOLUTE]["all"];
     const metricDataList = metricData[branchComparison]["all"];
-    const significance = metricData["significance"];
 
     userCountsList.sort(formattedAnalysisPointComparator);
     metricDataList.sort(formattedAnalysisPointComparator);
@@ -225,6 +226,7 @@ const TableVisualizationRow: React.FC<{
     metricDataList.forEach((dataPoint: FormattedAnalysisPoint, i: number) => {
       const { lower, upper, point, count } = dataPoint;
       const userCountMetric = userCountsList[i]["point"];
+      const significance = metricData["significance"]?.[window][i + 1];
 
       switch (displayType) {
         case DISPLAY_TYPE.POPULATION:

--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableWeekly/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableWeekly/index.tsx
@@ -91,6 +91,7 @@ const TableWeekly = ({
                 tableLabel={TABLE_LABEL.RESULTS}
                 {...{ metricKey }}
                 {...{ displayType }}
+                window="weekly"
               />
             </tr>
           );

--- a/app/experimenter/nimbus-ui/src/lib/visualization/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/lib/visualization/mocks.tsx
@@ -109,11 +109,11 @@ export const TREATMENT_NEUTRAL = {
       },
     ],
   },
-  significance: "neutral",
+  significance: { overall: { "1": "neutral" }, weekly: {} },
 };
 
 export const TREATMENT_NEGATIVE = Object.assign({}, TREATMENT_NEUTRAL, {
-  significance: "negative",
+  significance: { overall: { "1": "negative" }, weekly: {} },
 });
 
 export const WEEKLY_CONTROL = {
@@ -219,6 +219,7 @@ export const WEEKLY_TREATMENT = {
       },
     ],
   },
+  significance: { overall: {}, weekly: { "1": "negative" } },
 };
 
 const WEEKLY_IDENTITY = {
@@ -611,7 +612,7 @@ export const mockAnalysis = (modifications = {}) =>
                   },
                 ],
               },
-              significance: "positive",
+              significance: { overall: { "1": "positive" }, weekly: {} },
             },
             picture_in_picture: {
               absolute: {
@@ -658,7 +659,7 @@ export const mockAnalysis = (modifications = {}) =>
                   },
                 ],
               },
-              significance: "positive",
+              significance: { overall: { "1": "positive" }, weekly: {} },
             },
             feature_b_ever_used: {
               absolute: {
@@ -705,7 +706,7 @@ export const mockAnalysis = (modifications = {}) =>
                   },
                 ],
               },
-              significance: "negative",
+              significance: { overall: { "1": "negative" }, weekly: {} },
             },
             feature_b: {
               absolute: {
@@ -752,7 +753,7 @@ export const mockAnalysis = (modifications = {}) =>
                   },
                 ],
               },
-              significance: "negative",
+              significance: { overall: { "1": "negative" }, weekly: {} },
             },
             feature_c_ever_used: {
               absolute: {
@@ -799,7 +800,7 @@ export const mockAnalysis = (modifications = {}) =>
                   },
                 ],
               },
-              significance: "neutral",
+              significance: { overall: { "1": "neutral" }, weekly: {} },
             },
             feature_c: TREATMENT_NEUTRAL,
             days_of_use: TREATMENT_NEUTRAL,
@@ -848,7 +849,7 @@ export const mockAnalysis = (modifications = {}) =>
                   },
                 ],
               },
-              significance: "positive",
+              significance: { overall: { "1": "positive" }, weekly: {} },
             },
             outcome_d: {
               absolute: {
@@ -895,7 +896,7 @@ export const mockAnalysis = (modifications = {}) =>
                   },
                 ],
               },
-              significance: "positive",
+              significance: { overall: { "1": "positive" }, weekly: {} },
             },
           },
         },
@@ -1231,7 +1232,7 @@ export const mockIncompleteAnalysis = (modifications = {}) =>
                 first: {},
                 all: [],
               },
-              significance: "negative",
+              significance: { overall: { "1": "negative" }, weekly: {} },
             },
             picture_in_picture_ever_used: {
               absolute: {
@@ -1278,7 +1279,7 @@ export const mockIncompleteAnalysis = (modifications = {}) =>
                   },
                 ],
               },
-              significance: "positive",
+              significance: { overall: { "1": "positive" }, weekly: {} },
             },
             picture_in_picture: {
               absolute: {
@@ -1325,7 +1326,7 @@ export const mockIncompleteAnalysis = (modifications = {}) =>
                   },
                 ],
               },
-              significance: "positive",
+              significance: { overall: { "1": "positive" }, weekly: {} },
             },
             feature_b_ever_used: {
               absolute: {
@@ -1372,7 +1373,7 @@ export const mockIncompleteAnalysis = (modifications = {}) =>
                   },
                 ],
               },
-              significance: "negative",
+              significance: { overall: { "1": "negative" }, weekly: {} },
             },
             feature_b: {
               absolute: {
@@ -1419,7 +1420,7 @@ export const mockIncompleteAnalysis = (modifications = {}) =>
                   },
                 ],
               },
-              significance: "negative",
+              significance: { overall: { "1": "negative" }, weekly: {} },
             },
             feature_c_ever_used: {
               absolute: {
@@ -1466,7 +1467,7 @@ export const mockIncompleteAnalysis = (modifications = {}) =>
                   },
                 ],
               },
-              significance: "neutral",
+              significance: { overall: { "1": "neutral" }, weekly: {} },
             },
             feature_c: {
               absolute: {
@@ -1513,7 +1514,7 @@ export const mockIncompleteAnalysis = (modifications = {}) =>
                   },
                 ],
               },
-              significance: "neutral",
+              significance: { overall: { "1": "neutral" }, weekly: {} },
             },
             feature_d: {
               absolute: {
@@ -1560,7 +1561,7 @@ export const mockIncompleteAnalysis = (modifications = {}) =>
                   },
                 ],
               },
-              significance: "positive",
+              significance: { overall: { "1": "positive" }, weekly: {} },
             },
             outcome_d: {
               absolute: {
@@ -1607,7 +1608,7 @@ export const mockIncompleteAnalysis = (modifications = {}) =>
                   },
                 ],
               },
-              significance: "positive",
+              significance: { overall: { "1": "positive" }, weekly: {} },
             },
           },
         },

--- a/app/experimenter/nimbus-ui/src/lib/visualization/types.ts
+++ b/app/experimenter/nimbus-ui/src/lib/visualization/types.ts
@@ -65,7 +65,7 @@ export interface BranchDescription {
         all: FormattedAnalysisPoint[];
       };
       percent?: number;
-      significance?: string;
+      significance?: { [window: string]: { [window_index: string]: string } };
     };
   };
 }

--- a/app/experimenter/visualization/api/v3/views.py
+++ b/app/experimenter/visualization/api/v3/views.py
@@ -162,7 +162,9 @@ def generate_results_object(data, experiment, window="overall"):
         upper = row.get("upper")
         point = row.get("point")
         statistic = row.get("statistic")
-        window_index = row.get("window_index")
+
+        # For "overall" data, set window_index to 1 for uniformity
+        window_index = 1 if window == "overall" else row.get("window_index")
 
         if (
             metric in result_metrics
@@ -183,6 +185,7 @@ def generate_results_object(data, experiment, window="overall"):
                     BranchComparison.ABSOLUTE: {"all": [], "first": {}},
                     BranchComparison.DIFFERENCE: {"all": [], "first": {}},
                     BranchComparison.UPLIFT: {"all": [], "first": {}},
+                    "significance": {"overall": {}, "weekly": {}},
                 },
             )
 
@@ -192,9 +195,10 @@ def generate_results_object(data, experiment, window="overall"):
 
             comparison = row.get("comparison", BranchComparison.ABSOLUTE)
             if comparison == BranchComparison.DIFFERENCE and lower and upper:
-                results[branch][BRANCH_DATA][metric].update(
-                    {"significance": compute_significance(lower, upper)}
-                )
+                results[branch][BRANCH_DATA][metric]["significance"][window][
+                    window_index
+                ] = compute_significance(lower, upper)
+
             data_point = {
                 "lower": lower,
                 "upper": upper,

--- a/app/experimenter/visualization/tests/api/constants.py
+++ b/app/experimenter/visualization/tests/api/constants.py
@@ -92,6 +92,7 @@ class TestConstants:
                         },
                         "difference": {"all": [], "first": {}},
                         "relative_uplift": {"all": [], "first": {}},
+                        "significance": {"overall": {}, "weekly": {}},
                     },
                     "retained": {
                         "absolute": {"all": [], "first": {}},
@@ -112,7 +113,10 @@ class TestConstants:
                             },
                         },
                         "relative_uplift": {"all": [], "first": {}},
-                        "significance": Significance.NEUTRAL,
+                        "significance": {
+                            "overall": {},
+                            "weekly": {"1": Significance.NEUTRAL},
+                        },
                     },
                 },
             },
@@ -138,6 +142,7 @@ class TestConstants:
                         },
                         "difference": {"all": [], "first": {}},
                         "relative_uplift": {"all": [], "first": {}},
+                        "significance": {"overall": {}, "weekly": {}},
                     },
                     "search_count": {
                         "absolute": {"all": [], "first": {}},
@@ -158,7 +163,10 @@ class TestConstants:
                             ],
                         },
                         "relative_uplift": {"all": [], "first": {}},
-                        "significance": Significance.POSITIVE,
+                        "significance": {
+                            "overall": {},
+                            "weekly": {"1": Significance.POSITIVE},
+                        },
                     },
                     "some_count": {
                         "absolute": {
@@ -179,6 +187,7 @@ class TestConstants:
                         },
                         "difference": {"all": [], "first": {}},
                         "relative_uplift": {"all": [], "first": {}},
+                        "significance": {"overall": {}, "weekly": {}},
                     },
                     "retained": {
                         "absolute": {"all": [], "first": {}},
@@ -199,7 +208,10 @@ class TestConstants:
                             ],
                         },
                         "relative_uplift": {"all": [], "first": {}},
-                        "significance": Significance.NEGATIVE,
+                        "significance": {
+                            "overall": {},
+                            "weekly": {"1": Significance.NEGATIVE},
+                        },
                     },
                 },
             },
@@ -216,6 +228,7 @@ class TestConstants:
                         },
                         "difference": {"all": [], "first": {}},
                         "relative_uplift": {"all": [], "first": {}},
+                        "significance": {"overall": {}, "weekly": {}},
                         "percent": 50,
                     },
                     "retained": {
@@ -240,7 +253,10 @@ class TestConstants:
                             },
                         },
                         "relative_uplift": {"all": [], "first": {}},
-                        "significance": Significance.NEUTRAL,
+                        "significance": {
+                            "overall": {"1": Significance.NEUTRAL},
+                            "weekly": {},
+                        },
                     },
                 },
             },
@@ -254,6 +270,7 @@ class TestConstants:
                         },
                         "difference": {"all": [], "first": {}},
                         "relative_uplift": {"all": [], "first": {}},
+                        "significance": {"overall": {}, "weekly": {}},
                         "percent": 50,
                     },
                     "search_count": {
@@ -263,7 +280,10 @@ class TestConstants:
                             "all": [{"lower": 10, "point": 12, "upper": 13}],
                         },
                         "relative_uplift": {"all": [], "first": {}},
-                        "significance": Significance.POSITIVE,
+                        "significance": {
+                            "overall": {"1": Significance.POSITIVE},
+                            "weekly": {},
+                        },
                     },
                     "some_count": {
                         "absolute": {
@@ -272,6 +292,7 @@ class TestConstants:
                         },
                         "difference": {"all": [], "first": {}},
                         "relative_uplift": {"all": [], "first": {}},
+                        "significance": {"overall": {}, "weekly": {}},
                     },
                     "retained": {
                         "absolute": {"all": [], "first": {}},
@@ -295,7 +316,10 @@ class TestConstants:
                             ],
                         },
                         "relative_uplift": {"all": [], "first": {}},
-                        "significance": Significance.NEGATIVE,
+                        "significance": {
+                            "overall": {"1": Significance.NEGATIVE},
+                            "weekly": {},
+                        },
                     },
                 },
             },

--- a/app/experimenter/visualization/tests/api/test_views.py
+++ b/app/experimenter/visualization/tests/api/test_views.py
@@ -68,6 +68,7 @@ class TestVisualizationView(TestCase):
                 },
                 "difference": {"all": [], "first": {}},
                 "relative_uplift": {"all": [], "first": {}},
+                "significance": {"overall": {}, "weekly": {}},
             }
             formatted_data_without_pop[branch]["branch_data"][primary_metric] = {
                 "absolute": {
@@ -76,6 +77,7 @@ class TestVisualizationView(TestCase):
                 },
                 "difference": {"all": [], "first": {}},
                 "relative_uplift": {"all": [], "first": {}},
+                "significance": {"overall": {}, "weekly": {}},
             }
             data.append(
                 {


### PR DESCRIPTION
Because:
* Significance was only computed overall and incorrectly shown for weekly results too

This commit:
* Computes weekly significance to show for weekly results