### PR TITLE
fixes #4585 fix(nimbus): Allow Results sub-links to navigate to Results page

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/AppLayoutSidebarLocked/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/AppLayoutSidebarLocked/index.test.tsx
@@ -24,6 +24,7 @@ const Subject = ({
   withAnalysis = false,
   analysisError,
   analysisLoadingInSidebar = false,
+  analysisRequired = true,
   experiment = defaultExperiment,
 }: RouteComponentProps & {
   status?: NimbusExperimentStatus;
@@ -31,6 +32,7 @@ const Subject = ({
   analysis?: AnalysisData;
   analysisError?: boolean;
   analysisLoadingInSidebar?: boolean;
+  analysisRequired?: boolean;
   experiment?: getExperiment_experimentBySlug;
 }) => (
   <RouterSlugProvider mocks={[mock]} path="/my-special-slug/edit">
@@ -38,6 +40,7 @@ const Subject = ({
       {...{
         status: mockGetStatus(status),
         analysisLoadingInSidebar,
+        analysisRequired,
         analysisError: analysisError ? new Error("boop") : undefined,
         analysis: withAnalysis
           ? {
@@ -132,6 +135,24 @@ describe("AppLayoutSidebarLocked", () => {
     it("when complete has expected results page items in side bar", () => {
       const { experiment } = mockExperimentQuery("demo-slug");
       render(<Subject withAnalysis {...{ experiment }} />);
+      [
+        "Monitoring",
+        "Overview",
+        "Results Summary",
+        "Primary Metrics",
+        "Picture-in-Picture",
+        "Secondary Metrics",
+        "Feature B",
+      ].forEach((item) => {
+        expect(screen.getByText(item)).toBeInTheDocument();
+      });
+    });
+
+    it("when complete and page does not require full analaysis data, has expected results page items in side bar", () => {
+      const { experiment } = mockExperimentQuery("demo-slug");
+      render(
+        <Subject withAnalysis analysisRequired={false} {...{ experiment }} />,
+      );
       [
         "Monitoring",
         "Overview",

--- a/app/experimenter/nimbus-ui/src/components/AppLayoutWithExperiment/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/AppLayoutWithExperiment/index.tsx
@@ -133,6 +133,7 @@ const AppLayoutWithExperiment = ({
       {...{
         children,
         review,
+        analysisRequired,
         analysis,
         analysisLoadingInSidebar,
         analysisError,
@@ -166,6 +167,7 @@ type LayoutProps = {
   status: StatusCheck;
   review: ExperimentReview;
   analysis?: AnalysisData;
+  analysisRequired: boolean;
   analysisLoadingInSidebar: boolean;
   analysisError?: Error;
   experiment: getExperiment_experimentBySlug;
@@ -176,6 +178,7 @@ const Layout = ({
   review,
   status,
   analysis,
+  analysisRequired,
   analysisLoadingInSidebar,
   analysisError,
   experiment,
@@ -185,6 +188,7 @@ const Layout = ({
       {...{
         status,
         analysis,
+        analysisRequired,
         analysisLoadingInSidebar,
         analysisError,
         experiment,

--- a/app/experimenter/nimbus-ui/src/components/LinkNav/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/LinkNav/index.tsx
@@ -25,7 +25,7 @@ export const LinkNav = ({
   disabled = false,
   storiesOf,
   testid = "nav-home",
-  className,
+  className = "mx-1 my-2",
   textColor,
   title,
 }: LinkNavProps) => {
@@ -41,7 +41,7 @@ export const LinkNav = ({
   textColor = disabled ? "text-muted" : textColor;
 
   return (
-    <Nav.Item as="li" className={classNames("mx-1 my-2", className)}>
+    <Nav.Item as="li" {...{ className }}>
       {disabled ? (
         <span
           className={classNames(textColor, "d-flex align-items-center")}

--- a/app/experimenter/nimbus-ui/src/components/PageResults/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/index.tsx
@@ -69,7 +69,7 @@ const PageResults: React.FunctionComponent<RouteComponentProps> = () => {
               results={analysis?.overall!}
             />
 
-            <div id="results-summary">
+            <div id="results_summary">
               <h2 className="h5 mb-3">Results Summary</h2>
               {analysis?.overall && (
                 <TableResults {...{ experiment }} results={analysis!} />


### PR DESCRIPTION
Instead of linking to `currentpage#id` we now link to `/results#id`.

Because of a bug requiring Outcomes in the BE admin (#4785), I wasn't able to load Results data locally to double check this works as expected. This approach should fix the problem though and it LGTM in Storybook. If it doesn't fix the issue in prod we can reopen, I don't think we should block on #4785.

EDIT: We have a PR up for #4785 with #4847! I'll wait to merge this until I confirm things work as expected.

fixes #4585 