### PR TITLE
fixes #4624 feat(nimbus): allow audience page select boxes to not select anything

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/index.test.tsx
@@ -192,6 +192,28 @@ describe("FormAudience", () => {
     }
   });
 
+  it("does not require a selection for channel, ff min version, targeting config (EXP-957)", async () => {
+    const onSubmit = jest.fn();
+    render(<Subject {...{ onSubmit }} />);
+    await screen.findByTestId("FormAudience");
+
+    for (const label of ["Channel", "Min Version", "Advanced Targeting"]) {
+      const field = screen.getByLabelText(label);
+      fireEvent.change(field, { target: { value: "" } });
+    }
+
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    const expectedValues = expect.objectContaining({
+      channel: "NO_CHANNEL",
+      firefoxMinVersion: "NO_VERSION",
+      targetingConfigSlug: "NO_TARGETING",
+    });
+    await waitFor(() =>
+      expect(onSubmit).toHaveBeenCalledWith(expectedValues, false),
+    );
+  });
+
   it("does not have any required modified fields", async () => {
     const onSubmit = jest.fn();
     renderSubjectWithDefaultValues(onSubmit);

--- a/app/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/index.tsx
@@ -15,6 +15,11 @@ import {
   POSITIVE_NUMBER_WITH_COMMAS_FIELD,
 } from "../../../lib/constants";
 import { getExperiment_experimentBySlug } from "../../../types/getExperiment";
+import {
+  NimbusExperimentChannel,
+  NimbusExperimentFirefoxMinVersion,
+  NimbusExperimentTargetingConfigSlug,
+} from "../../../types/globalTypes";
 import InlineErrorIcon from "../../InlineErrorIcon";
 import LinkExternal from "../../LinkExternal";
 
@@ -75,11 +80,25 @@ export const FormAudience = ({
   );
 
   type DefaultValues = typeof defaultValues;
+
+  const applyDefaults = (data: DefaultValues): DefaultValues => {
+    return {
+      ...data,
+      channel: data.channel || NimbusExperimentChannel.NO_CHANNEL,
+      firefoxMinVersion:
+        data.firefoxMinVersion || NimbusExperimentFirefoxMinVersion.NO_VERSION,
+      targetingConfigSlug:
+        data.targetingConfigSlug ||
+        NimbusExperimentTargetingConfigSlug.NO_TARGETING,
+    };
+  };
+
   const [handleSave, handleSaveNext] = useMemo(
     () =>
       [false, true].map((next) =>
         handleSubmit(
-          (dataIn: DefaultValues) => !isLoading && onSubmit(dataIn, next),
+          (dataIn: DefaultValues) =>
+            !isLoading && onSubmit(applyDefaults(dataIn), next),
         ),
       ),
     [isLoading, onSubmit, handleSubmit],


### PR DESCRIPTION
Closes #4624

This PR updates the select dropdowns on the Audience page so that they can all select "nothing" (that is, return the selection to the "Select..." item).

Since the backend requires one of an enum value be chosen and each enum has a "no selection" value, just default to that value any time "no" value is provided.