### PR TITLE
fix #4785 chore(nimbus): make admin fields optional

### DIFF
--- a/app/experimenter/experiments/admin/nimbus.py
+++ b/app/experimenter/experiments/admin/nimbus.py
@@ -1,5 +1,6 @@
 from django import forms
 from django.contrib import admin
+from django.contrib.postgres.forms import SimpleArrayField
 
 from experimenter.experiments.models import (
     NimbusBranch,
@@ -36,6 +37,16 @@ class NimbusExperimentChangeLogInlineAdmin(admin.TabularInline):
 
 class NimbusExperimentAdminForm(forms.ModelForm):
     channel = forms.ChoiceField(choices=NimbusExperiment.Channel.choices)
+    public_description = forms.CharField(required=False, widget=forms.Textarea())
+    firefox_min_version = forms.ChoiceField(
+        choices=NimbusExperiment.Version.choices, required=False
+    )
+    channel = forms.ChoiceField(choices=NimbusExperiment.Channel.choices, required=False)
+    primary_outcomes = SimpleArrayField(forms.CharField(), required=False)
+    secondary_outcomes = SimpleArrayField(forms.CharField(), required=False)
+    targeting_config_slug = forms.ChoiceField(
+        choices=NimbusExperiment.TargetingConfig.choices, required=False
+    )
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/app/experimenter/experiments/tests/test_admin/test_admin_nimbus.py
+++ b/app/experimenter/experiments/tests/test_admin/test_admin_nimbus.py
@@ -1,13 +1,66 @@
 from django.test import TestCase
 
 from experimenter.experiments.admin.nimbus import NimbusExperimentAdminForm
+from experimenter.experiments.models import NimbusExperiment
 from experimenter.experiments.tests.factories import (
     NimbusBranchFactory,
     NimbusExperimentFactory,
 )
+from experimenter.openidc.tests.factories import UserFactory
 
 
 class TestNimbusExperimentAdminForm(TestCase):
+    def test_form_required_fields(self):
+        experiment = NimbusExperiment.objects.create(
+            owner=UserFactory.create(),
+            status=NimbusExperiment.Status.DRAFT,
+            name="name",
+            slug="slug",
+            application=NimbusExperiment.Application.DESKTOP,
+        )
+        form = NimbusExperimentAdminForm(
+            instance=experiment,
+            data={
+                "owner": experiment.owner,
+                "status": experiment.status,
+                "name": experiment.name,
+                "slug": experiment.slug,
+                "proposed_duration": experiment.proposed_duration,
+                "proposed_enrollment": experiment.proposed_enrollment,
+                "population_percent": experiment.population_percent,
+                "total_enrolled_clients": experiment.total_enrolled_clients,
+                "application": experiment.application,
+                "hypothesis": experiment.hypothesis,
+            },
+        )
+        self.assertTrue(form.is_valid(), form.errors)
+
+    def test_form_saves_outcomes(self):
+        experiment = NimbusExperimentFactory.create_with_status(
+            NimbusExperiment.Status.DRAFT, primary_outcomes=[], secondary_outcomes=[]
+        )
+        form = NimbusExperimentAdminForm(
+            instance=experiment,
+            data={
+                "owner": experiment.owner,
+                "status": experiment.status,
+                "name": experiment.name,
+                "slug": experiment.slug,
+                "proposed_duration": experiment.proposed_duration,
+                "proposed_enrollment": experiment.proposed_enrollment,
+                "population_percent": experiment.population_percent,
+                "total_enrolled_clients": experiment.total_enrolled_clients,
+                "application": experiment.application,
+                "hypothesis": experiment.hypothesis,
+                "primary_outcomes": "outcome1, outcome2",
+                "secondary_outcomes": "outcome3, outcome4",
+            },
+        )
+        self.assertTrue(form.is_valid(), form.errors)
+        experiment = form.save()
+        self.assertEqual(experiment.primary_outcomes, ["outcome1", "outcome2"])
+        self.assertEqual(experiment.secondary_outcomes, ["outcome3", "outcome4"])
+
     def test_form_rejects_any_branch_if_no_experiment_provided(self):
         branch = NimbusBranchFactory.create()
 


### PR DESCRIPTION
Because

* All admin fields for a newly created experiment should be optional
* Default empty fields being required makes using the admin cumbersome

This commit

* Makes all fields that have default values optional in the admin
* Updates tests