### PR TITLE
fixes #4624 feat(nimbus): remove unselected state from Audience form selects

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/index.tsx
@@ -322,7 +322,6 @@ const SelectOptions = ({
   options: null | (null | { label: null | string; value: null | string })[];
 }) => (
   <>
-    <option value="">Select...</option>
     {options?.map(
       (item, idx) =>
         item && (


### PR DESCRIPTION
Closes #4624

This was originally #4839 but this approach is way simpler.

You can't submit an "empty" value for fields that expect one of an enum (Channel, FF Min Version, Targeting Config), and that's what's happening if you try to save with any of those dropdowns set to "Select..." (the no-selection option).

Lucky for us each of those enums has a [value](https://github.com/mozilla/experimenter/blob/main/app/experimenter/experiments/constants/nimbus.py#L111:L111) representing "no selection". Let's just remove that initial "Select..." option and let the "no selection" enum value be the default.

<img width="1152" alt="Screen Shot 2021-03-17 at 3 01 08 PM" src="https://user-images.githubusercontent.com/6392049/111523392-9e111900-8731-11eb-846c-6629963ffec6.png">
