### PR TITLE
chore(docs): Add link to Nimbus Documentation Hub to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Experimenter is a platform for managing experiments in [Mozilla Firefox](https:/
 
 ## Important Links
 
+Check out the [🌩 **Nimbus Documentation Hub**](https://mozilla.github.io/experimenter-docs/) or go to [the repository](https://github.com/mozilla/experimenter-docs/) that house those docs.
+
 | Link            | Prod                                                  | Staging                                                            | Local Dev (Default)                           |
 | --------------- | ----------------------------------------------------- | ------------------------------------------------------------------ | --------------------------------------------- |
 | Legacy Home     | [experimenter.services.mozilla.com][legacy_home_prod] | [stage.experimenter.nonprod.dataops.mozgcp.net][legacy_home_stage] | https://localhost                             |


### PR DESCRIPTION
This link did not feel right in the "Important Links" table because those seem developer-specific for _this_ repo and wouldn't stand out for a user looking for this link. Do we like the table for that section, anyway? 🤔 I can file a follow up issue if needed there, this doesn't have an associated issue but I thought we could use the cross-link now even if we want to tweak this section later.