### PR TITLE
fix #4795 fix #4796 fix #4797 feat(nimbus): implement approve / reject forms for new Review flow

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/PageRequestReview/FormApproveConfirm.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageRequestReview/FormApproveConfirm.tsx
@@ -1,0 +1,43 @@
+/* istanbul ignore file until EXP-1055 & EXP-1062 done */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from "react";
+import Alert from "react-bootstrap/Alert";
+import Button from "react-bootstrap/Button";
+import Form from "react-bootstrap/Form";
+
+const FormApproveConfirm = ({
+  isLoading,
+  onConfirm,
+}: {
+  isLoading: boolean;
+  onConfirm: () => void;
+}) => {
+  return (
+    <Alert variant="warning">
+      <Form className="text-body">
+        <p>
+          <strong>Action required —</strong> You need to deploy this experiment
+          to production on Remote Settings.
+        </p>
+
+        <div className="d-flex bd-highlight">
+          <div>
+            <Button
+              data-testid="open-remote-settings"
+              className="mr-2 btn btn-primary"
+              disabled={isLoading}
+              onClick={onConfirm}
+            >
+              Open Remote Settings
+            </Button>
+          </div>
+        </div>
+      </Form>
+    </Alert>
+  );
+};
+
+export default FormApproveConfirm;

--- a/app/experimenter/nimbus-ui/src/components/PageRequestReview/FormApproveOrRejectLaunch.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageRequestReview/FormApproveOrRejectLaunch.tsx
@@ -1,0 +1,55 @@
+/* istanbul ignore file until EXP-1055 & EXP-1062 done */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from "react";
+import Alert from "react-bootstrap/Alert";
+import Button from "react-bootstrap/Button";
+import Form from "react-bootstrap/Form";
+
+const FormApproveOrRejectLaunch = ({
+  launchRequestedByUsername,
+  isLoading,
+  onApprove,
+  onReject,
+}: {
+  launchRequestedByUsername: string;
+  isLoading: boolean;
+  onApprove: () => void;
+  onReject: () => void;
+}) => {
+  return (
+    <Alert variant="warning">
+      <Form className="text-body">
+        <p>
+          <strong>{launchRequestedByUsername}</strong> requested to launch this
+          experiment.
+        </p>
+
+        <div className="d-flex bd-highlight">
+          <div>
+            <Button
+              data-testid="approve-and-launch"
+              className="mr-2 btn btn-success"
+              disabled={isLoading}
+              onClick={onApprove}
+            >
+              Approve and Launch
+            </Button>
+            <Button
+              data-testid="reject-launch"
+              className="btn btn-danger"
+              disabled={isLoading}
+              onClick={onReject}
+            >
+              Reject
+            </Button>
+          </div>
+        </div>
+      </Form>
+    </Alert>
+  );
+};
+
+export default FormApproveOrRejectLaunch;

--- a/app/experimenter/nimbus-ui/src/components/PageRequestReview/FormRejectReason.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageRequestReview/FormRejectReason.tsx
@@ -1,0 +1,93 @@
+/* istanbul ignore file until EXP-1055 & EXP-1062 done */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from "react";
+import Alert from "react-bootstrap/Alert";
+import Button from "react-bootstrap/Button";
+import Form from "react-bootstrap/Form";
+import { FormProvider } from "react-hook-form";
+import { useCommonForm } from "../../hooks";
+import { REQUIRED_FIELD } from "../../lib/constants";
+
+export const rejectReasonFieldNames = ["reason"];
+type RejectReasonFieldNames = typeof rejectReasonFieldNames[number];
+
+const FormRejectReason = ({
+  isLoading,
+  onSubmit,
+  onCancel,
+}: {
+  isLoading: boolean;
+  onSubmit: (fields: { reason: string }) => void;
+  onCancel: () => void;
+}) => {
+  const isServerValid = true;
+  const submitErrors = {};
+  const setSubmitErrors = () => {};
+
+  const defaultValues = {
+    reason: "",
+  };
+  type DefaultValues = typeof defaultValues;
+
+  const {
+    FormErrors,
+    formControlAttrs,
+    formMethods,
+    handleSubmit,
+  } = useCommonForm<RejectReasonFieldNames>(
+    defaultValues,
+    isServerValid,
+    submitErrors,
+    setSubmitErrors,
+  );
+
+  const handleSubmitClick = handleSubmit(
+    (data: DefaultValues) => !isLoading && onSubmit(data),
+  );
+
+  return (
+    <Alert variant="warning">
+      <FormProvider {...formMethods}>
+        <Form className="text-body">
+          <p>
+            <strong>You are rejecting this review.</strong> Please add some
+            comments:
+          </p>
+          <Form.Group controlId="reason">
+            <Form.Control
+              {...formControlAttrs("reason", REQUIRED_FIELD)}
+              as="textarea"
+              rows={4}
+            />
+            <FormErrors name="reason" />
+          </Form.Group>
+          <div className="d-flex bd-highlight">
+            <div>
+              <Button
+                data-testid="reject-submit"
+                className="mr-2 btn btn-danger"
+                disabled={isLoading}
+                onClick={handleSubmitClick}
+              >
+                Reject
+              </Button>
+              <Button
+                data-testid="reject-cancel"
+                className="btn btn-secondary"
+                disabled={isLoading}
+                onClick={onCancel}
+              >
+                Cancel
+              </Button>
+            </div>
+          </div>
+        </Form>
+      </FormProvider>
+    </Alert>
+  );
+};
+
+export default FormRejectReason;

--- a/app/experimenter/nimbus-ui/src/components/PageRequestReview/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageRequestReview/index.stories.tsx
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import { action } from "@storybook/addon-actions";
 import { withLinks } from "@storybook/addon-links";
 import { storiesOf } from "@storybook/react";
 import React from "react";
@@ -9,6 +10,9 @@ import PageRequestReview from ".";
 import { mockExperimentQuery } from "../../lib/mocks";
 import { RouterSlugProvider } from "../../lib/test-utils";
 import { NimbusExperimentStatus } from "../../types/globalTypes";
+import FormApproveConfirm from "./FormApproveConfirm";
+import FormApproveOrRejectLaunch from "./FormApproveOrRejectLaunch";
+import FormRejectReason from "./FormRejectReason";
 import { mock, Subject } from "./mocks";
 
 storiesOf("pages/RequestReview", module)
@@ -38,4 +42,38 @@ storiesOf("pages/RequestReview", module)
     <RouterSlugProvider mocks={[mock]}>
       <PageRequestReview polling={false} />
     </RouterSlugProvider>
+  ));
+
+storiesOf("pages/RequestReview/EXP-1055/forms", module)
+  .addDecorator(withLinks)
+  .addDecorator((story) => <div className="p-5">{story()}</div>)
+  .add("FormApproveOrRejectLaunch", () => (
+    <FormApproveOrRejectLaunch
+      {...{
+        launchRequestedByUsername: "jdoe@mozilla.com",
+        isLoading: false,
+        onApprove: action("approve"),
+        onReject: action("reject"),
+      }}
+    />
+  ))
+  .add("FormRejectReason", () => (
+    <FormRejectReason
+      {...{
+        isLoading: false,
+        isServerValid: true,
+        submitErrors: {},
+        setSubmitErrors: () => {},
+        onSubmit: action("submit"),
+        onCancel: action("cancel"),
+      }}
+    />
+  ))
+  .add("FormApproveConfirm", () => (
+    <FormApproveConfirm
+      {...{
+        isLoading: false,
+        onConfirm: action("confirm"),
+      }}
+    />
   ));


### PR DESCRIPTION
Because:

- we want to implement forms to support the new Review flow

This commit:

- implements new forms for reviewer actions to approve or reject a
  request to launch an experiment