### PR TITLE
fix(docs): small consistency fix to nimbus-ui feature flag docs

### DIFF
--- a/app/experimenter/nimbus-ui/README.md
+++ b/app/experimenter/nimbus-ui/README.md
@@ -486,7 +486,7 @@ export const SubjectEXP1234 = ({
 }: Partial<React.ComponentProps<typeof ExampleComponent>>) => (
   <MockConfigContext.Provider value={{
     featureFlags: {
-      exp866Preview: true
+      exp1234Preview: true
     }
   }}>
     <ExampleComponent ...{props} />


### PR DESCRIPTION
Just a small copy-pasta typo I noticed in the nimbus-ui docs I wrote on feature flags