### PR TITLE
fix #4859 feat(nimbus): implement logic for new Review flow component rendering

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/PageRequestReview/DraftStatusOperations.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageRequestReview/DraftStatusOperations.tsx
@@ -1,0 +1,162 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React, { useCallback, useState } from "react";
+import Alert from "react-bootstrap/Alert";
+import { Config } from "../../hooks/useConfig";
+import { ReactComponent as Check } from "../../images/check.svg";
+import FormApproveConfirm from "./FormApproveConfirm";
+import FormApproveOrRejectLaunch from "./FormApproveOrRejectLaunch";
+import FormLaunchDraftToPreview from "./FormLaunchDraftToPreview";
+import FormLaunchDraftToReview from "./FormLaunchDraftToReview";
+import FormRejectReason from "./FormRejectReason";
+
+export enum DraftStatusOperationsState {
+  DraftToPreview,
+  DraftToReview,
+  LaunchApprovalPending,
+  LaunchApproveOrReject,
+  LaunchRejection,
+  ApprovalConfirmation,
+}
+
+export const DraftStatusOperations = ({
+  isLoading,
+  featureFlags = { exp1055ReviewFlow: false },
+  isLaunchRequested = false,
+  isLaunchApproved = false,
+  launchRequestedByUsername = "",
+  currentUsername = "",
+  currentUserCanApprove = false,
+  rejectExperimentLaunch,
+  approveExperimentLaunch,
+  confirmExperimentLaunchApproval,
+  onLaunchClicked,
+  onLaunchToPreviewClicked,
+}: {
+  isLoading: boolean;
+  featureFlags: Config["featureFlags"];
+  isLaunchRequested: boolean;
+  isLaunchApproved: boolean;
+  launchRequestedByUsername: string;
+  currentUsername: string;
+  currentUserCanApprove: boolean;
+  rejectExperimentLaunch: (fields: { reason: string }) => void;
+  approveExperimentLaunch: () => void;
+  confirmExperimentLaunchApproval: () => void;
+  onLaunchClicked: () => void;
+  onLaunchToPreviewClicked: () => void;
+}) => {
+  let defaultDraftUIState = DraftStatusOperationsState.DraftToPreview;
+  /* istanbul ignore next until EXP-1055 & EXP-1062 done */
+  if (featureFlags.exp1055ReviewFlow) {
+    const canApprove =
+      currentUserCanApprove && currentUsername !== launchRequestedByUsername;
+    if (isLaunchApproved) {
+      defaultDraftUIState = canApprove
+        ? DraftStatusOperationsState.ApprovalConfirmation
+        : DraftStatusOperationsState.LaunchApprovalPending;
+    } else if (isLaunchRequested) {
+      defaultDraftUIState = canApprove
+        ? DraftStatusOperationsState.LaunchApproveOrReject
+        : DraftStatusOperationsState.LaunchApprovalPending;
+    }
+  }
+
+  const [draftUIState, setDraftUIState] = useState<DraftStatusOperationsState>(
+    defaultDraftUIState,
+  );
+
+  /* istanbul ignore next until EXP-1055 & EXP-1062 done */
+  const resetDraftUIState = useCallback(
+    () => setDraftUIState(defaultDraftUIState),
+    [defaultDraftUIState, setDraftUIState],
+  );
+
+  /* istanbul ignore next until EXP-1055 & EXP-1062 done */
+  const handleLaunchApprovalClicked = useCallback(async () => {
+    await approveExperimentLaunch();
+    setDraftUIState(DraftStatusOperationsState.ApprovalConfirmation);
+  }, [approveExperimentLaunch, setDraftUIState]);
+
+  switch (draftUIState) {
+    /* istanbul ignore next until EXP-1055 & EXP-1062 done */
+    case DraftStatusOperationsState.LaunchApproveOrReject:
+      return (
+        <FormApproveOrRejectLaunch
+          {...{
+            isLoading,
+            launchRequestedByUsername,
+            onApprove: handleLaunchApprovalClicked,
+            onReject: () =>
+              setDraftUIState(DraftStatusOperationsState.LaunchRejection),
+          }}
+        />
+      );
+
+    /* istanbul ignore next until EXP-1055 & EXP-1062 done */
+    case DraftStatusOperationsState.ApprovalConfirmation:
+      return (
+        <FormApproveConfirm
+          {...{
+            isLoading,
+            onConfirm: confirmExperimentLaunchApproval,
+          }}
+        />
+      );
+
+    /* istanbul ignore next until EXP-1055 & EXP-1062 done */
+    case DraftStatusOperationsState.LaunchRejection:
+      return (
+        <FormRejectReason
+          {...{
+            isLoading,
+            onSubmit: rejectExperimentLaunch,
+            onCancel: resetDraftUIState,
+          }}
+        />
+      );
+
+    /* istanbul ignore next until EXP-1055 & EXP-1062 done */
+    case DraftStatusOperationsState.LaunchApprovalPending:
+      return (
+        <Alert
+          data-testid="submit-success"
+          variant="success"
+          className="bg-transparent text-success"
+        >
+          <p className="my-1" data-testid="in-review-label">
+            <Check className="align-top" /> All set! This experiment will launch
+            as soon as it is approved.
+          </p>
+        </Alert>
+      );
+
+    case DraftStatusOperationsState.DraftToReview:
+      return (
+        <FormLaunchDraftToReview
+          {...{
+            isLoading,
+            onSubmit: onLaunchClicked,
+            onCancel: resetDraftUIState,
+            onLaunchToPreview: onLaunchToPreviewClicked,
+          }}
+        />
+      );
+
+    default:
+      return (
+        <FormLaunchDraftToPreview
+          {...{
+            isLoading,
+            onSubmit: onLaunchToPreviewClicked,
+            onLaunchWithoutPreview: () =>
+              setDraftUIState(DraftStatusOperationsState.DraftToReview),
+          }}
+        />
+      );
+  }
+};
+
+export default DraftStatusOperations;

--- a/app/experimenter/nimbus-ui/src/components/PageRequestReview/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageRequestReview/index.stories.tsx
@@ -13,7 +13,12 @@ import { NimbusExperimentStatus } from "../../types/globalTypes";
 import FormApproveConfirm from "./FormApproveConfirm";
 import FormApproveOrRejectLaunch from "./FormApproveOrRejectLaunch";
 import FormRejectReason from "./FormRejectReason";
-import { mock, Subject } from "./mocks";
+import {
+  mock,
+  Subject,
+  SubjectDraftStatusOperations,
+  SubjectEXP1055,
+} from "./mocks";
 
 storiesOf("pages/RequestReview", module)
   .addDecorator(withLinks)
@@ -43,6 +48,173 @@ storiesOf("pages/RequestReview", module)
       <PageRequestReview polling={false} />
     </RouterSlugProvider>
   ));
+
+storiesOf("pages/RequestReview/EXP-1055", module)
+  .addDecorator(withLinks)
+  .add("review not requested", () => <SubjectEXP1055 />)
+  .add("review requested, user has reviewer role", () => (
+    <SubjectEXP1055
+      {...{
+        isLaunchRequested: true,
+        currentUserCanApprove: true,
+        currentUser: "abc@mozilla.com",
+        launchRequestedByUsername: "def@mozilla.com",
+      }}
+    />
+  ))
+  .add(
+    "review approved in experimenter, not yet approved in remote settings, user has reviewer role",
+    () => (
+      <SubjectEXP1055
+        {...{
+          isLaunchRequested: true,
+          isLaunchApproved: true,
+          currentUserCanApprove: true,
+          currentUsername: "abc@mozilla.com",
+          launchRequestedByUsername: "def@mozilla.com",
+        }}
+      />
+    ),
+  )
+  .add("review requested, user does not have reviewer role", () => (
+    <SubjectEXP1055
+      {...{ isLaunchRequested: true, currentUserCanApprove: false }}
+    />
+  ))
+  .add(
+    "review requested, user has reviewer role, but user requested this review",
+    () => (
+      <SubjectEXP1055
+        {...{
+          isLaunchRequested: true,
+          currentUserCanApprove: false,
+          currentUser: "abc@mozilla.com",
+          launchRequestedByUsername: "abc@mozilla.com",
+        }}
+      />
+    ),
+  )
+  .add(
+    "review approved in experimenter, not yet approved in remote settings, user does not have reviewer role",
+    () => (
+      <SubjectEXP1055
+        {...{
+          isLaunchRequested: true,
+          isLaunchApproved: true,
+          currentUserCanApprove: false,
+        }}
+      />
+    ),
+  )
+  .add(
+    "review approved in experimenter, not yet approved in remote settings, user has reviewer role, but user requested this review",
+    () => (
+      <SubjectEXP1055
+        {...{
+          isLaunchRequested: true,
+          isLaunchApproved: true,
+          currentUserCanApprove: true,
+          currentUsername: "abc@mozilla.com",
+          launchRequestedByUsername: "abc@mozilla.com",
+        }}
+      />
+    ),
+  );
+
+const SubjectDraftStatusOperationsWithActions = ({
+  rejectExperimentLaunch = action("rejectExperimentLaunch"),
+  approveExperimentLaunch = action("approveExperimentLaunch"),
+  confirmExperimentLaunchApproval = action("confirmExperimentLaunchApproval"),
+  onLaunchClicked = action("onLaunchClicked"),
+  onLaunchToPreviewClicked = action("onLaunchToPreviewClicked"),
+  ...props
+}: React.ComponentProps<typeof SubjectDraftStatusOperations>) => (
+  <SubjectDraftStatusOperations
+    {...{
+      rejectExperimentLaunch,
+      approveExperimentLaunch,
+      confirmExperimentLaunchApproval,
+      onLaunchClicked,
+      onLaunchToPreviewClicked,
+      ...props,
+    }}
+  />
+);
+
+storiesOf("pages/RequestReview/EXP-1055/DraftStatusOperations", module)
+  .addDecorator(withLinks)
+  .addDecorator((story) => <div className="p-5">{story()}</div>)
+  .add("review not requested", () => (
+    <SubjectDraftStatusOperationsWithActions />
+  ))
+  .add("review requested, user has reviewer role", () => (
+    <SubjectDraftStatusOperationsWithActions
+      {...{
+        isLaunchRequested: true,
+        currentUserCanApprove: true,
+        currentUsername: "abc@mozilla.com",
+        launchRequestedByUsername: "def@mozilla.com",
+      }}
+    />
+  ))
+  .add(
+    "review approved in experimenter, not yet approved in remote settings, user has reviewer role",
+    () => (
+      <SubjectDraftStatusOperationsWithActions
+        {...{
+          isLaunchRequested: true,
+          isLaunchApproved: true,
+          currentUserCanApprove: true,
+          currentUsername: "abc@mozilla.com",
+          launchRequestedByUsername: "def@mozilla.com",
+        }}
+      />
+    ),
+  )
+  .add("review requested, user does not have reviewer role", () => (
+    <SubjectDraftStatusOperationsWithActions
+      {...{ isLaunchRequested: true, currentUserCanApprove: false }}
+    />
+  ))
+  .add(
+    "review requested, user has reviewer role, but user requested this review",
+    () => (
+      <SubjectDraftStatusOperationsWithActions
+        {...{
+          isLaunchRequested: true,
+          currentUserCanApprove: true,
+          currentUsername: "abc@mozilla.com",
+          launchRequestedByUsername: "abc@mozilla.com",
+        }}
+      />
+    ),
+  )
+  .add(
+    "review approved in experimenter, not yet approved in remote settings, user does not have reviewer role",
+    () => (
+      <SubjectDraftStatusOperationsWithActions
+        {...{
+          isLaunchRequested: true,
+          isLaunchApproved: true,
+          currentUserCanApprove: false,
+        }}
+      />
+    ),
+  )
+  .add(
+    "review approved in experimenter, not yet approved in remote settings, user has reviewer role, but user requested this review",
+    () => (
+      <SubjectDraftStatusOperationsWithActions
+        {...{
+          isLaunchRequested: true,
+          isLaunchApproved: true,
+          currentUserCanApprove: true,
+          currentUsername: "abc@mozilla.com",
+          launchRequestedByUsername: "abc@mozilla.com",
+        }}
+      />
+    ),
+  );
 
 storiesOf("pages/RequestReview/EXP-1055/forms", module)
   .addDecorator(withLinks)

--- a/app/experimenter/nimbus-ui/src/components/PageRequestReview/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageRequestReview/index.tsx
@@ -4,9 +4,11 @@
 
 import { useMutation } from "@apollo/client";
 import { RouteComponentProps } from "@reach/router";
-import React, { useCallback, useMemo, useRef, useState } from "react";
+import React, { useMemo, useRef, useState } from "react";
 import Alert from "react-bootstrap/Alert";
 import { UPDATE_EXPERIMENT_MUTATION } from "../../gql/experiments";
+import { useConfig } from "../../hooks/useConfig";
+import { useFakeMutation } from "../../hooks/useFakeMutation";
 import { ReactComponent as Check } from "../../images/check.svg";
 import { SUBMIT_ERROR } from "../../lib/constants";
 import { getStatus } from "../../lib/experiment";
@@ -18,30 +20,67 @@ import {
 import { updateExperiment_updateExperiment as UpdateExperiment } from "../../types/updateExperiment";
 import AppLayoutWithExperiment from "../AppLayoutWithExperiment";
 import Summary from "../Summary";
-import FormLaunchDraftToPreview from "./FormLaunchDraftToPreview";
-import FormLaunchDraftToReview from "./FormLaunchDraftToReview";
+import DraftStatusOperations from "./DraftStatusOperations";
 import FormLaunchPreviewToReview from "./FormLaunchPreviewToReview";
 
 const PageRequestReview = ({
+  /* istanbul ignore next - only used in tests & stories */
   polling = true,
+  /* istanbul ignore next until EXP-1055 & EXP-1062 done */
+  isLaunchRequested = false, // new experiment property
+  /* istanbul ignore next until EXP-1055 & EXP-1062 done */
+  isLaunchApproved = false, // new experiment property
+  /* istanbul ignore next until EXP-1055 & EXP-1062 done */
+  launchRequestedByUsername = "", // new experiment property
+  /* istanbul ignore next until EXP-1055 & EXP-1062 done */
+  currentUsername = "", // new user ID / email property
+  /* istanbul ignore next until EXP-1055 & EXP-1062 done */
+  currentUserCanApprove = false, // new user permission property
 }: {
   polling?: boolean;
+  // TODO EXP-1062: temporary page-level props, should be replaced by API data for experiment & current user
+  isLaunchRequested?: boolean;
+  isLaunchApproved?: boolean;
+  launchRequestedByUsername?: string;
+  currentUsername?: string;
+  currentUserCanApprove?: boolean;
 } & RouteComponentProps) => {
+  const { featureFlags } = useConfig();
+
   const [submitError, setSubmitError] = useState<string | null>(null);
   const currentExperiment = useRef<getExperiment_experimentBySlug>();
   const refetchReview = useRef<() => void>();
 
-  const [updateExperiment, { loading }] = useMutation<
+  const [updateExperiment, { loading: updateExperimentLoading }] = useMutation<
     { updateExperiment: UpdateExperiment },
     { input: ExperimentInput }
   >(UPDATE_EXPERIMENT_MUTATION);
 
-  const [showLaunchDraftToReview, setShowLaunchDraftToReview] = useState(false);
+  /* istanbul ignore next until EXP-1055 & EXP-1062 done */
+  const [
+    rejectExperimentLaunch,
+    { loading: rejectExperimentLaunchLoading },
+  ] = useFakeMutation();
 
-  const toggleShowLaunchDraftToReview = useCallback(
-    () => setShowLaunchDraftToReview(!showLaunchDraftToReview),
-    [showLaunchDraftToReview, setShowLaunchDraftToReview],
-  );
+  /* istanbul ignore next until EXP-1055 & EXP-1062 done */
+  const [
+    approveExperimentLaunch,
+    { loading: approveExperimentLaunchLoading },
+  ] = useFakeMutation();
+
+  /* istanbul ignore next until EXP-1055 & EXP-1062 done */
+  const [
+    confirmExperimentLaunchApproval,
+    { loading: confirmExperimentLaunchApprovalLoading },
+  ] = useFakeMutation();
+
+  // TODO: EXP-1062 wrap these new mutations in setSubmitError handling like updateExperiment uses below.
+
+  const isLoading =
+    updateExperimentLoading ||
+    approveExperimentLaunchLoading ||
+    confirmExperimentLaunchApprovalLoading ||
+    rejectExperimentLaunchLoading;
 
   const [
     onLaunchToPreviewClicked,
@@ -77,7 +116,6 @@ const PageRequestReview = ({
           }
 
           refetchReview.current!();
-          setShowLaunchDraftToReview(false);
         } catch (error) {
           setSubmitError(SUBMIT_ERROR);
         }
@@ -115,6 +153,26 @@ const PageRequestReview = ({
                 {submitError}
               </Alert>
             )}
+
+            {status.draft && (
+              <DraftStatusOperations
+                {...{
+                  isLoading,
+                  featureFlags,
+                  isLaunchRequested,
+                  isLaunchApproved,
+                  launchRequestedByUsername,
+                  currentUserCanApprove,
+                  currentUsername,
+                  rejectExperimentLaunch,
+                  approveExperimentLaunch,
+                  confirmExperimentLaunchApproval,
+                  onLaunchClicked,
+                  onLaunchToPreviewClicked,
+                }}
+              />
+            )}
+
             {status.review && (
               <Alert
                 data-testid="submit-success"
@@ -127,34 +185,17 @@ const PageRequestReview = ({
                 </p>
               </Alert>
             )}
-            {status.draft &&
-              (showLaunchDraftToReview ? (
-                <FormLaunchDraftToReview
-                  {...{
-                    isLoading: loading,
-                    onSubmit: onLaunchClicked,
-                    onCancel: toggleShowLaunchDraftToReview,
-                    onLaunchToPreview: onLaunchToPreviewClicked,
-                  }}
-                />
-              ) : (
-                <FormLaunchDraftToPreview
-                  {...{
-                    isLoading: loading,
-                    onSubmit: onLaunchToPreviewClicked,
-                    onLaunchWithoutPreview: toggleShowLaunchDraftToReview,
-                  }}
-                />
-              ))}
+
             {status.preview && (
               <FormLaunchPreviewToReview
                 {...{
-                  isLoading: loading,
+                  isLoading,
                   onSubmit: onLaunchClicked,
                   onBackToDraft: onBackToDraftClicked,
                 }}
               />
             )}
+
             <Summary {...{ experiment }} />
           </>
         );

--- a/app/experimenter/nimbus-ui/src/components/PageRequestReview/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageRequestReview/mocks.tsx
@@ -5,9 +5,11 @@
 import React from "react";
 import PageRequestReview from ".";
 import { UPDATE_EXPERIMENT_MUTATION } from "../../gql/experiments";
+import { MockConfigContext } from "../../hooks";
 import { mockExperimentMutation, mockExperimentQuery } from "../../lib/mocks";
 import { RouterSlugProvider } from "../../lib/test-utils";
 import { NimbusExperimentStatus } from "../../types/globalTypes";
+import DraftStatusOperations from "./DraftStatusOperations";
 
 export const { mock, experiment } = mockExperimentQuery("demo-slug");
 
@@ -38,4 +40,57 @@ export const Subject = ({
   <RouterSlugProvider {...{ mocks }}>
     <PageRequestReview polling={false} />
   </RouterSlugProvider>
+);
+
+export const SubjectEXP1055 = ({
+  mocks = [mock, createMutationMock(experiment.id!)],
+  ...pageProps
+}: {
+  mocks?: React.ComponentProps<typeof RouterSlugProvider>["mocks"];
+} & React.ComponentProps<typeof PageRequestReview>) => (
+  <MockConfigContext.Provider
+    value={{
+      featureFlags: {
+        exp1055ReviewFlow: true,
+      },
+    }}
+  >
+    <RouterSlugProvider {...{ mocks }}>
+      <PageRequestReview polling={false} {...pageProps} />
+    </RouterSlugProvider>
+  </MockConfigContext.Provider>
+);
+
+export const SubjectDraftStatusOperations = ({
+  isLaunchRequested = false,
+  isLaunchApproved = false,
+  launchRequestedByUsername = "jdoe@mozilla.com",
+  currentUsername = "janed@mozilla.com",
+  currentUserCanApprove = false,
+  rejectExperimentLaunch = () => {},
+  approveExperimentLaunch = () => {},
+  confirmExperimentLaunchApproval = () => {},
+  onLaunchClicked = () => {},
+  onLaunchToPreviewClicked = () => {},
+  ...props
+}: Partial<React.ComponentProps<typeof DraftStatusOperations>>) => (
+  <DraftStatusOperations
+    {...{
+      featureFlags: {
+        exp1055ReviewFlow: true,
+      },
+      isLoading: false,
+      isLaunchRequested,
+      isLaunchApproved,
+      currentUserCanApprove,
+      currentUsername,
+      launchRequestedByUsername,
+      rejectExperimentLaunch,
+      approveExperimentLaunch,
+      confirmExperimentLaunchApproval,
+      onLaunchClicked,
+      onLaunchToPreviewClicked,
+      ...props,
+    }}
+  />
 );

--- a/app/experimenter/nimbus-ui/src/hooks/index.ts
+++ b/app/experimenter/nimbus-ui/src/hooks/index.ts
@@ -9,4 +9,5 @@ export * from "./useCommonForm/useForm";
 export * from "./useConfig";
 export * from "./useExitWarning";
 export * from "./useExperiment";
+export * from "./useFakeMutation";
 export * from "./useOutcomes";

--- a/app/experimenter/nimbus-ui/src/hooks/useFakeMutation.test.tsx
+++ b/app/experimenter/nimbus-ui/src/hooks/useFakeMutation.test.tsx
@@ -1,0 +1,22 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { act, renderHook } from "@testing-library/react-hooks";
+import { useFakeMutation } from "./useFakeMutation";
+
+describe("hooks/useMockMutation", () => {
+  it("simulates loading with a delay", async () => {
+    const { result } = renderHook(() => useFakeMutation(1000));
+    expect(result.current[1].loading).toEqual(false);
+    let pending: Promise<void>;
+    act(() => {
+      pending = result.current[0]();
+    });
+    expect(result.current[1].loading).toEqual(true);
+    await act(async () => {
+      await pending!;
+    });
+    expect(result.current[1].loading).toEqual(false);
+  });
+});

--- a/app/experimenter/nimbus-ui/src/hooks/useFakeMutation.tsx
+++ b/app/experimenter/nimbus-ui/src/hooks/useFakeMutation.tsx
@@ -1,0 +1,22 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { useCallback, useState } from "react";
+
+export const useFakeMutation = (delay = 1000) => {
+  const [loading, setLoading] = useState(false);
+  const mockMutationCall = useCallback(() => {
+    setLoading(true);
+    return new Promise<void>((resolve) => {
+      setTimeout(() => {
+        setLoading(false);
+        resolve();
+      }, delay);
+    });
+  }, [setLoading, delay]);
+
+  return [mockMutationCall, { loading }] as const;
+};
+
+export default useFakeMutation;

--- a/app/experimenter/nimbus-ui/src/services/config.ts
+++ b/app/experimenter/nimbus-ui/src/services/config.ts
@@ -8,7 +8,7 @@ export function getDefault() {
     sentry_dsn: "",
     version: "",
     featureFlags: {
-      exp866Preview: false,
+      exp1055ReviewFlow: false,
     },
   };
 }


### PR DESCRIPTION
While trying to stitch the new Review flow form components together in PR #4858, I found that the rendering logic on PageRequestReview started getting too hairy. Fell down a refactoring rabbit hole and came back out with this. Filed issue ~#4797~ #4859 to capture the work.