### PR TITLE
fixes #4790 fix(nimbus): update flaky PageNew test

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/PageNew/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageNew/index.test.tsx
@@ -4,7 +4,13 @@
 
 import { MockedResponse } from "@apollo/client/testing";
 import { navigate } from "@reach/router";
-import { act, fireEvent, render, screen } from "@testing-library/react";
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import React from "react";
 import PageNew from ".";
 import { CREATE_EXPERIMENT_MUTATION } from "../../gql/experiments";
@@ -78,11 +84,11 @@ describe("PageNew", () => {
   it("handles experiment form submission with server API error", async () => {
     mutationMock.result.errors = [new Error("an error")];
     render(<Subject mocks={[mutationMock]} />);
-    await act(async () => {
-      fireEvent.click(screen.getByTestId("submit"));
-    });
-    expect(screen.getByTestId("submitErrors")).toHaveTextContent(
-      JSON.stringify({ "*": SUBMIT_ERROR }),
+    fireEvent.click(screen.getByTestId("submit"));
+    await waitFor(() =>
+      expect(screen.getByTestId("submitErrors")).toHaveTextContent(
+        JSON.stringify({ "*": SUBMIT_ERROR }),
+      ),
     );
   });
 


### PR DESCRIPTION
Closes #4790

This should address that flaky `PageNew` test. I wish I could confidently tell you why this works, here's my best guess:

`act` attempts to understand how many state changes are involved when something is triggered and account/wait for them to complete, but it cannot know how long a network request will take and so sometimes it waits long enough for the mocked Apollo request to complete, and sometimes it doesn't. Also, `fireEvent` methods all call `act` [under the hood](https://kentcdodds.com/blog/common-mistakes-with-react-testing-library#wrapping-things-in-act-unnecessarily), so I don't think adding an additional one does anything (unconfirmed). `waitFor` on the other hand will repeatedly execute until the callback is no longer throwing (for up to 1 second unless specified otherwise).

That seems reasonable yeah?