### PR TITLE
fix(project): include publish_status in admin form tests

### DIFF
--- a/app/experimenter/experiments/tests/test_admin/test_admin_nimbus.py
+++ b/app/experimenter/experiments/tests/test_admin/test_admin_nimbus.py
@@ -23,6 +23,7 @@ class TestNimbusExperimentAdminForm(TestCase):
             data={
                 "owner": experiment.owner,
                 "status": experiment.status,
+                "publish_status": experiment.publish_status,
                 "name": experiment.name,
                 "slug": experiment.slug,
                 "proposed_duration": experiment.proposed_duration,
@@ -44,6 +45,7 @@ class TestNimbusExperimentAdminForm(TestCase):
             data={
                 "owner": experiment.owner,
                 "status": experiment.status,
+                "publish_status": experiment.publish_status,
                 "name": experiment.name,
                 "slug": experiment.slug,
                 "proposed_duration": experiment.proposed_duration,


### PR DESCRIPTION
Looks like this is failing main, and I assume publish_status is required, so I just updated the tests that needed it to include it.