### PR TITLE
fixes #4854 feat(project): add publish_status to v5 api

### DIFF
--- a/app/experimenter/experiments/api/v5/inputs.py
+++ b/app/experimenter/experiments/api/v5/inputs.py
@@ -5,6 +5,7 @@ from experimenter.experiments.api.v5.types import (
     NimbusExperimentChannel,
     NimbusExperimentDocumentationLink,
     NimbusExperimentFirefoxMinVersion,
+    NimbusExperimentPublishStatus,
     NimbusExperimentStatus,
     NimbusExperimentTargetingConfigSlug,
 )
@@ -42,6 +43,7 @@ class ExperimentIdInput(graphene.InputObjectType):
 class ExperimentInput(graphene.InputObjectType):
     id = graphene.Int()
     status = NimbusExperimentStatus()
+    publish_status = NimbusExperimentPublishStatus()
     name = graphene.String()
     hypothesis = graphene.String()
     application = NimbusExperimentApplication()

--- a/app/experimenter/experiments/api/v5/serializers.py
+++ b/app/experimenter/experiments/api/v5/serializers.py
@@ -294,11 +294,15 @@ class NimbusExperimentSerializer(
     population_percent = serializers.DecimalField(
         7, 4, min_value=0.0, max_value=100.0, required=False
     )
+    publish_status = serializers.ChoiceField(
+        choices=NimbusExperiment.PublishStatus.choices, required=False
+    )
 
     class Meta:
         model = NimbusExperiment
         fields = [
             "status",
+            "publish_status",
             "name",
             "slug",
             "risk_mitigation_link",

--- a/app/experimenter/experiments/api/v5/types.py
+++ b/app/experimenter/experiments/api/v5/types.py
@@ -29,6 +29,11 @@ class NimbusExperimentStatus(graphene.Enum):
         enum = NimbusConstants.Status
 
 
+class NimbusExperimentPublishStatus(graphene.Enum):
+    class Meta:
+        enum = NimbusConstants.PublishStatus
+
+
 class NimbusExperimentFirefoxMinVersion(graphene.Enum):
     class Meta:
         enum = NimbusConstants.Version
@@ -113,6 +118,7 @@ class NimbusReadyForReviewType(graphene.ObjectType):
 class NimbusExperimentType(DjangoObjectType):
     id = graphene.Int()
     status = NimbusExperimentStatus()
+    publish_status = NimbusExperimentPublishStatus()
     application = NimbusExperimentApplication()
     firefox_min_version = NimbusExperimentFirefoxMinVersion()
     population_percent = graphene.String()

--- a/app/experimenter/experiments/tests/api/v5/test_mutations.py
+++ b/app/experimenter/experiments/tests/api/v5/test_mutations.py
@@ -502,6 +502,26 @@ class TestMutations(GraphQLTestCase):
             },
         )
 
+    def test_update_experiment_publish_status(self):
+        user_email = "user@example.com"
+        experiment = NimbusExperimentFactory.create(
+            publish_status=NimbusExperiment.PublishStatus.IDLE,
+        )
+        response = self.query(
+            UPDATE_EXPERIMENT_MUTATION,
+            variables={
+                "input": {
+                    "id": experiment.id,
+                    "publishStatus": NimbusExperiment.PublishStatus.REVIEW.name,
+                }
+            },
+            headers={settings.OPENIDC_EMAIL_HEADER: user_email},
+        )
+        self.assertEqual(response.status_code, 200)
+
+        experiment = NimbusExperiment.objects.get(id=experiment.id)
+        self.assertEqual(experiment.publish_status, NimbusExperiment.PublishStatus.REVIEW)
+
     def test_end_experiment_in_kinto(self):
         user_email = "user@example.com"
         experiment = NimbusExperimentFactory.create(

--- a/app/experimenter/experiments/tests/api/v5/test_queries.py
+++ b/app/experimenter/experiments/tests/api/v5/test_queries.py
@@ -148,6 +148,30 @@ class TestNimbusQuery(GraphQLTestCase):
                 {getattr(b, key) for b in documentation_links},
             )
 
+    def test_experiment_returns_publish_status(self):
+        user_email = "user@example.com"
+        experiment = NimbusExperimentFactory.create(
+            publish_status=NimbusExperiment.PublishStatus.IDLE
+        )
+
+        response = self.query(
+            """
+            query {
+                experiments {
+                    publishStatus
+                }
+            }
+            """,
+            headers={settings.OPENIDC_EMAIL_HEADER: user_email},
+        )
+        self.assertEqual(response.status_code, 200)
+        content = json.loads(response.content)
+        experiment_data = content["data"]["experiments"][0]
+        self.assertEqual(
+            experiment_data["publishStatus"],
+            experiment.publish_status.name,
+        )
+
     def test_experiment_by_slug_ready_for_review(self):
         user_email = "user@example.com"
         experiment = NimbusExperimentFactory.create_with_status(

--- a/app/experimenter/nimbus-ui/schema.graphql
+++ b/app/experimenter/nimbus-ui/schema.graphql
@@ -26,6 +26,7 @@ input ExperimentIdInput {
 input ExperimentInput {
   id: Int
   status: NimbusExperimentStatus
+  publishStatus: NimbusExperimentPublishStatus
   name: String
   hypothesis: String
   application: NimbusExperimentApplication
@@ -172,7 +173,7 @@ type NimbusExperimentType {
   id: Int
   owner: NimbusExperimentOwner!
   status: NimbusExperimentStatus
-  publishStatus: NimbusExperimentPublishStatus!
+  publishStatus: NimbusExperimentPublishStatus
   name: String!
   slug: String!
   publicDescription: String!

--- a/app/experimenter/nimbus-ui/src/types/globalTypes.ts
+++ b/app/experimenter/nimbus-ui/src/types/globalTypes.ts
@@ -57,6 +57,13 @@ export enum NimbusExperimentFirefoxMinVersion {
   NO_VERSION = "NO_VERSION",
 }
 
+export enum NimbusExperimentPublishStatus {
+  APPROVED = "APPROVED",
+  IDLE = "IDLE",
+  REVIEW = "REVIEW",
+  WAITING = "WAITING",
+}
+
 export enum NimbusExperimentStatus {
   ACCEPTED = "ACCEPTED",
   COMPLETE = "COMPLETE",
@@ -93,6 +100,7 @@ export interface ExperimentIdInput {
 export interface ExperimentInput {
   id?: number | null;
   status?: NimbusExperimentStatus | null;
+  publishStatus?: NimbusExperimentPublishStatus | null;
   name?: string | null;
   hypothesis?: string | null;
   application?: NimbusExperimentApplication | null;


### PR DESCRIPTION
Closes #4854

This PR adds the new Experiment publish_status to the V5 API (types + serializer). It does not include any validation (#4866).