### PR TITLE
fixes #4866 feat(project): validate experiment changes and transitions relating to publish_status

### DIFF
--- a/app/experimenter/experiments/api/v5/serializers.py
+++ b/app/experimenter/experiments/api/v5/serializers.py
@@ -211,12 +211,13 @@ class NimbusStatusValidationMixin:
 
         if self.instance:
             status = self.instance.status
+            check_status_only = True
 
             for status_field, statuses in restrictive_statuses.items():
                 instance_value = getattr(self.instance, status_field)
                 if instance_value in statuses:
                     if set(data.keys()) == {status_field}:
-                        return data
+                        check_status_only = False
                     else:
                         raise serializers.ValidationError(
                             {
@@ -228,7 +229,7 @@ class NimbusStatusValidationMixin:
                             }
                         )
 
-            if status not in NimbusConstants.STATUS_ALLOWS_UPDATE:
+            if check_status_only and status not in NimbusConstants.STATUS_ALLOWS_UPDATE:
                 required_statuses = ", ".join(NimbusConstants.STATUS_ALLOWS_UPDATE)
                 raise serializers.ValidationError(
                     {

--- a/app/experimenter/experiments/api/v5/serializers.py
+++ b/app/experimenter/experiments/api/v5/serializers.py
@@ -205,14 +205,14 @@ class NimbusStatusValidationMixin:
         data = super().validate(data)
 
         restrictive_statuses = {
-            "status": NimbusConstants.STATUS_CHANGE_ONLY,
-            "publish_status": NimbusConstants.PUBLISH_STATUS_CHANGE_ONLY,
+            "status": NimbusConstants.STATUS_ALLOWS_UPDATE,
+            "publish_status": NimbusConstants.PUBLISH_STATUS_ALLOWS_UPDATE,
         }
 
         if self.instance:
             for status_field, restricted_statuses in restrictive_statuses.items():
                 current_status = getattr(self.instance, status_field)
-                is_locked = current_status in restricted_statuses
+                is_locked = current_status not in restricted_statuses
                 is_modifying_other_fields = set(data.keys()) != {status_field}
                 if is_locked and is_modifying_other_fields:
                     raise serializers.ValidationError(

--- a/app/experimenter/experiments/constants/nimbus.py
+++ b/app/experimenter/experiments/constants/nimbus.py
@@ -101,11 +101,37 @@ class NimbusConstants(object):
         LIVE = "Live"
         COMPLETE = "Complete"
 
+    VALID_STATUS_TRANSITIONS = {
+        Status.DRAFT: (
+            Status.PREVIEW,
+            Status.REVIEW,
+        ),
+        Status.PREVIEW: (
+            Status.DRAFT,
+            Status.REVIEW,
+        ),
+    }
+    STATUS_CHANGE_ONLY = (Status.PREVIEW,)
+    STATUS_ALLOWS_UPDATE = (Status.DRAFT,)
+
     class PublishStatus(models.TextChoices):
         IDLE = "Idle"
         REVIEW = "Review"
         APPROVED = "Approved"
         WAITING = "Waiting"
+
+    VALID_PUBLISH_STATUS_TRANSITIONS = {
+        PublishStatus.IDLE: (PublishStatus.REVIEW,),
+        PublishStatus.REVIEW: (
+            PublishStatus.IDLE,
+            PublishStatus.APPROVED,
+        ),
+    }
+    PUBLISH_STATUS_CHANGE_ONLY = (
+        PublishStatus.REVIEW,
+        PublishStatus.APPROVED,
+        PublishStatus.WAITING,
+    )
 
     class Application(models.TextChoices):
         DESKTOP = "firefox-desktop"

--- a/app/experimenter/experiments/constants/nimbus.py
+++ b/app/experimenter/experiments/constants/nimbus.py
@@ -111,7 +111,6 @@ class NimbusConstants(object):
             Status.REVIEW,
         ),
     }
-    STATUS_CHANGE_ONLY = (Status.PREVIEW,)
     STATUS_ALLOWS_UPDATE = (Status.DRAFT,)
 
     class PublishStatus(models.TextChoices):
@@ -127,11 +126,7 @@ class NimbusConstants(object):
             PublishStatus.APPROVED,
         ),
     }
-    PUBLISH_STATUS_CHANGE_ONLY = (
-        PublishStatus.REVIEW,
-        PublishStatus.APPROVED,
-        PublishStatus.WAITING,
-    )
+    PUBLISH_STATUS_ALLOWS_UPDATE = (PublishStatus.IDLE,)
 
     class Application(models.TextChoices):
         DESKTOP = "firefox-desktop"

--- a/app/experimenter/experiments/tests/api/v5/test_mutations.py
+++ b/app/experimenter/experiments/tests/api/v5/test_mutations.py
@@ -475,33 +475,6 @@ class TestMutations(GraphQLTestCase):
         experiment = NimbusExperiment.objects.get(id=experiment.id)
         self.assertEqual(experiment.status, NimbusExperiment.Status.REVIEW)
 
-    def test_update_experiment_status_error(self):
-        user_email = "user@example.com"
-        experiment = NimbusExperimentFactory.create(
-            status=NimbusExperiment.Status.ACCEPTED,
-        )
-        response = self.query(
-            UPDATE_EXPERIMENT_MUTATION,
-            variables={
-                "input": {
-                    "id": experiment.id,
-                    "status": NimbusExperiment.Status.REVIEW.name,
-                }
-            },
-            headers={settings.OPENIDC_EMAIL_HEADER: user_email},
-        )
-        self.assertEqual(response.status_code, 200, response.content)
-        content = json.loads(response.content)
-        result = content["data"]["updateExperiment"]
-        self.assertEqual(
-            result["message"],
-            {
-                "status": [
-                    "Nimbus Experiment status cannot transition from Accepted to Review."
-                ]
-            },
-        )
-
     def test_update_experiment_publish_status(self):
         user_email = "user@example.com"
         experiment = NimbusExperimentFactory.create(


### PR DESCRIPTION
Closes #4866

This PR adds validates experiment changes and transitions relating to an experiment's publish_status. Refer to #4866 for the rules I followed.