### PR TITLE
fix #4867 feat(nimbus): validate reviewer is different from review requester in V5 API

### DIFF
--- a/app/experimenter/experiments/api/v5/serializers.py
+++ b/app/experimenter/experiments/api/v5/serializers.py
@@ -337,6 +337,16 @@ class NimbusExperimentSerializer(
         )
         super().__init__(instance=instance, data=data, **kwargs)
 
+    def validate_publish_status(self, publish_status):
+        if (
+            publish_status == NimbusExperiment.PublishStatus.APPROVED
+            and not self.instance.can_review(self.context["user"])
+        ):
+            raise serializers.ValidationError(
+                f'{self.context["user"]} can not review this experiment.'
+            )
+        return publish_status
+
     def validate_name(self, name):
         if not (self.instance or name):
             raise serializers.ValidationError("Name is required to create an experiment")

--- a/app/experimenter/experiments/api/v5/types.py
+++ b/app/experimenter/experiments/api/v5/types.py
@@ -135,6 +135,7 @@ class NimbusExperimentType(DjangoObjectType):
     computed_end_date = graphene.DateTime()
     is_enrollment_paused = graphene.Boolean()
     enrollment_end_date = graphene.DateTime()
+    can_review = graphene.Boolean()
 
     class Meta:
         model = NimbusExperiment
@@ -166,3 +167,6 @@ class NimbusExperimentType(DjangoObjectType):
 
     def resolve_enrollment_end_date(self, info):
         return self.proposed_enrollment_end_date
+
+    def resolve_can_review(self, info):
+        return self.can_review(info.context.user)

--- a/app/experimenter/experiments/changelog_utils/nimbus.py
+++ b/app/experimenter/experiments/changelog_utils/nimbus.py
@@ -48,7 +48,7 @@ def generate_nimbus_changelog(experiment, changed_by, message=None):
         old_status = latest_change.new_status
         old_publish_status = latest_change.new_publish_status
 
-    NimbusChangeLog.objects.create(
+    return NimbusChangeLog.objects.create(
         experiment=experiment,
         old_status=old_status,
         old_publish_status=old_publish_status,

--- a/app/experimenter/nimbus-ui/schema.graphql
+++ b/app/experimenter/nimbus-ui/schema.graphql
@@ -204,6 +204,7 @@ type NimbusExperimentType {
   computedEndDate: DateTime
   isEnrollmentPaused: Boolean
   enrollmentEndDate: DateTime
+  canReview: Boolean
 }
 
 enum NimbusFeatureConfigApplication {


### PR DESCRIPTION


Because

* We want reviews to be made by a different user than the user that requested review

This commit

* Adds logic to the NimbusExperiment to determine whether a user can review
* Exposes whether the current user can review an experiment in the V5 Query API
* Validates whether the current user can approve an experiment in the V5 Mutation API