### PR TITLE
fixes #4869 feat(nimbus): expose timeout data in V5 API

### DIFF
--- a/app/experimenter/experiments/api/v5/types.py
+++ b/app/experimenter/experiments/api/v5/types.py
@@ -144,6 +144,7 @@ class NimbusExperimentType(DjangoObjectType):
     enrollment_end_date = graphene.DateTime()
     can_review = graphene.Boolean()
     rejection = graphene.Field(NimbusChangeLogType)
+    timeout = graphene.Field(NimbusChangeLogType)
 
     class Meta:
         model = NimbusExperiment
@@ -181,3 +182,6 @@ class NimbusExperimentType(DjangoObjectType):
 
     def resolve_rejection(self, info):
         return self.changes.latest_rejection()
+
+    def resolve_timeout(self, info):
+        return self.changes.latest_timeout()

--- a/app/experimenter/experiments/models/nimbus.py
+++ b/app/experimenter/experiments/models/nimbus.py
@@ -450,6 +450,26 @@ class NimbusChangeLogManager(models.Manager):
             .order_by("-changed_on")
         ).first()
 
+    def latest_timeout(self):
+        return (
+            self.all()
+            .filter(
+                Q(
+                    old_status=NimbusExperiment.Status.DRAFT,
+                    new_status=NimbusExperiment.Status.DRAFT,
+                )
+                | Q(
+                    old_status=NimbusExperiment.Status.LIVE,
+                    new_status=NimbusExperiment.Status.LIVE,
+                )
+            )
+            .filter(
+                old_publish_status=NimbusExperiment.PublishStatus.WAITING,
+                new_publish_status=NimbusExperiment.PublishStatus.REVIEW,
+            )
+            .order_by("-changed_on")
+        ).first()
+
 
 class NimbusChangeLog(models.Model):
     def current_datetime():

--- a/app/experimenter/nimbus-ui/schema.graphql
+++ b/app/experimenter/nimbus-ui/schema.graphql
@@ -245,6 +245,7 @@ type NimbusExperimentType {
   enrollmentEndDate: DateTime
   canReview: Boolean
   rejection: NimbusChangeLogType
+  timeout: NimbusChangeLogType
 }
 
 enum NimbusFeatureConfigApplication {


### PR DESCRIPTION
Because:

- To support the new timeout UI we need to look up the timeout in the
  changelogs and expose it in a convenient field in the V5 API.

This commit:

- Adds a `timeout` property to the NimbusExperiment model that looks up
  the latest changelog entry that transitions from publish status waiting
  to review, as long as the experiment is still in review status

- Exposes the `timeout` model property as a field in GQL queries