### PR TITLE
chore(nimbus): move kinto tasks around

### DIFF
--- a/app/experimenter/kinto/client.py
+++ b/app/experimenter/kinto/client.py
@@ -88,7 +88,6 @@ class KintoClient:
         )
 
         main_record_ids = [record["id"] for record in main_records]
-
         workspace_record_ids = [record["id"] for record in workspace_records]
         return list(set(workspace_record_ids) - set(main_record_ids))[0]
 


### PR DESCRIPTION
Because

- Now that we broke out all the individual kinto updates into separate tasks I'd like them to all be next to each other

This commit

- Just moves them around in the file so like tasks are next to each other