### PR TITLE
chore(nimbus): remove vestigial pause task reference

### DIFF
--- a/app/experimenter/settings.py
+++ b/app/experimenter/settings.py
@@ -332,10 +332,6 @@ CELERY_BEAT_SCHEDULE = {
         "task": "experimenter.kinto.tasks.nimbus_check_experiments_are_complete",
         "schedule": config("CELERY_SCHEDULE_INTERVAL", default=300, cast=int),
     },
-    "nimbus_update_paused_experiments_in_kinto": {
-        "task": "experimenter.kinto.tasks.nimbus_update_paused_experiments_in_kinto",
-        "schedule": config("CELERY_SCHEDULE_INTERVAL", default=300, cast=int),
-    },
     "nimbus_synchronize_preview_experiments_in_kinto": {
         "task": "experimenter.kinto.tasks.nimbus_synchronize_preview_experiments_in_kinto",
         "schedule": config("CELERY_SCHEDULE_INTERVAL", default=300, cast=int),


### PR DESCRIPTION
Because

* We recently consolidated and renamed the nimbus kinto tasks but left an outdated task reference behind

This commit

* Removes the vestigial tail