### PR TITLE
fix #4888 feat(nimbus): time out launch and end reviews in remote settings

### DIFF
--- a/app/experimenter/experiments/constants/nimbus.py
+++ b/app/experimenter/experiments/constants/nimbus.py
@@ -3,6 +3,7 @@ from typing import Dict
 
 from django.conf import settings
 from django.db import models
+from django.db.models import Q
 
 
 @dataclass
@@ -193,6 +194,15 @@ class NimbusConstants(object):
         "publish_status",
         "is_end_requested",
     )
+
+    # State Predicates
+    IS_LAUNCHING = Q(status=Status.DRAFT, publish_status=PublishStatus.WAITING)
+    IS_ENDING = Q(
+        status=Status.LIVE,
+        publish_status=PublishStatus.WAITING,
+        is_end_requested=True,
+    )
+    SHOULD_TIMEOUT = Q(IS_LAUNCHING | IS_ENDING)
 
     class Application(models.TextChoices):
         DESKTOP = (APPLICATION_CONFIG_DESKTOP.slug, APPLICATION_CONFIG_DESKTOP.name)

--- a/app/experimenter/experiments/models/nimbus.py
+++ b/app/experimenter/experiments/models/nimbus.py
@@ -38,12 +38,16 @@ class NimbusExperimentManager(models.Manager):
     def end_queue(self, application):
         return self.filter(
             status=NimbusExperiment.Status.LIVE,
+            publish_status=NimbusExperiment.PublishStatus.APPROVED,
             application=application,
             is_end_requested=True,
         )
 
-    def waiting_queue(self):
-        return self.filter(publish_status=NimbusExperiment.PublishStatus.WAITING)
+    def waiting_to_launch_queue(self):
+        return self.filter(
+            status=NimbusExperiment.Status.DRAFT,
+            publish_status=NimbusExperiment.PublishStatus.WAITING,
+        )
 
 
 class NimbusExperiment(NimbusConstants, models.Model):
@@ -119,6 +123,9 @@ class NimbusExperiment(NimbusConstants, models.Model):
 
     def get_absolute_url(self):
         return reverse("nimbus-detail", kwargs={"slug": self.slug})
+
+    def has_state(self, state):
+        return type(self).objects.filter(id=self.id).filter(state).exists()
 
     @property
     def experiment_url(self):

--- a/app/experimenter/experiments/tests/test_models/test_models_nimbus.py
+++ b/app/experimenter/experiments/tests/test_models/test_models_nimbus.py
@@ -2,6 +2,7 @@ import datetime
 from decimal import Decimal
 
 from django.conf import settings
+from django.db.models import Q
 from django.test import TestCase
 from django.utils import timezone
 from parameterized import parameterized_class
@@ -48,6 +49,7 @@ class TestNimbusExperimentManager(TestCase):
     def test_end_queue_returns_ending_experiments_with_correct_application(self):
         experiment1 = NimbusExperimentFactory.create_with_status(
             NimbusExperiment.Status.LIVE,
+            publish_status=NimbusExperiment.PublishStatus.APPROVED,
             is_end_requested=True,
             application=NimbusExperiment.Application.DESKTOP,
         )
@@ -119,6 +121,29 @@ class TestNimbusExperimentManager(TestCase):
                 NimbusExperiment.objects.pause_queue(NimbusExperiment.Application.DESKTOP)
             ),
             [experiment1],
+        )
+
+    def test_waiting_to_launch_only_returns_launching_experiments(self):
+        launching = NimbusExperimentFactory.create_with_status(
+            NimbusExperiment.Status.DRAFT,
+            publish_status=NimbusExperiment.PublishStatus.WAITING,
+        )
+        NimbusExperimentFactory.create_with_status(
+            NimbusExperiment.Status.DRAFT,
+            publish_status=NimbusExperiment.PublishStatus.IDLE,
+        )
+        NimbusExperimentFactory.create_with_status(
+            NimbusExperiment.Status.LIVE,
+            publish_status=NimbusExperiment.PublishStatus.IDLE,
+        )
+        NimbusExperimentFactory.create_with_status(
+            NimbusExperiment.Status.LIVE,
+            publish_status=NimbusExperiment.PublishStatus.WAITING,
+            is_end_requested=True,
+        )
+
+        self.assertEqual(
+            list(NimbusExperiment.objects.waiting_to_launch_queue()), [launching]
         )
 
 
@@ -493,6 +518,34 @@ class TestNimbusExperiment(TestCase):
 
         # Timeout should be the latest changelog entry.
         self.assertEqual(experiment.changes.latest_timeout(), experiment.latest_change())
+
+    def test_has_state_true(self):
+        experiment = NimbusExperimentFactory.create_with_status(
+            NimbusExperiment.Status.DRAFT,
+            publish_status=NimbusExperiment.PublishStatus.WAITING,
+        )
+        self.assertTrue(
+            experiment.has_state(
+                Q(
+                    status=NimbusExperiment.Status.DRAFT,
+                    publish_status=NimbusExperiment.PublishStatus.WAITING,
+                )
+            )
+        )
+
+    def test_has_state_false(self):
+        experiment = NimbusExperimentFactory.create_with_status(
+            NimbusExperiment.Status.DRAFT,
+            publish_status=NimbusExperiment.PublishStatus.WAITING,
+        )
+        self.assertFalse(
+            experiment.has_state(
+                Q(
+                    status=NimbusExperiment.Status.DRAFT,
+                    publish_status=NimbusExperiment.PublishStatus.IDLE,
+                )
+            )
+        )
 
 
 class TestNimbusBranch(TestCase):

--- a/app/experimenter/kinto/tests/test_tasks.py
+++ b/app/experimenter/kinto/tests/test_tasks.py
@@ -137,17 +137,115 @@ class TestCheckKintoPushQueueByApplication(MockKintoClientMixin, TestCase):
         self.mock_push_task.assert_not_called()
         self.mock_end_task.assert_not_called()
 
-    def test_check_experiment_with_approved_and_kinto_pending_pushes_nothing(self):
-        NimbusExperimentFactory.create(
+    def test_check_with_review_and_kinto_pending_launch_rolls_back_and_pushes(self):
+        pending_experiment = NimbusExperimentFactory.create_with_status(
+            NimbusExperiment.Status.DRAFT,
+            publish_status=NimbusExperiment.PublishStatus.WAITING,
+            application=NimbusExperiment.Application.FENIX,
+        )
+        launching_experiment = NimbusExperimentFactory.create_with_status(
+            NimbusExperiment.Status.DRAFT,
             publish_status=NimbusExperiment.PublishStatus.APPROVED,
-            application=NimbusExperiment.Application.DESKTOP,
+            application=NimbusExperiment.Application.FENIX,
         )
+
         self.setup_kinto_pending_review()
+        self.mock_kinto_client.get_records.side_effect = [
+            [],
+            [{"id": pending_experiment.slug}],
+        ]
+
         tasks.nimbus_check_kinto_push_queue_by_application(
-            NimbusExperiment.Application.DESKTOP
+            NimbusExperiment.Application.FENIX
         )
+
+        self.mock_push_task.assert_called_with(launching_experiment.id)
+
+        self.mock_kinto_client.patch_collection.assert_called_with(
+            id="nimbus-mobile-experiments",
+            data={"status": "to-rollback"},
+            bucket="main-workspace",
+        )
+        pending_experiment = NimbusExperiment.objects.get(slug=pending_experiment.slug)
+        self.assertEqual(
+            pending_experiment.publish_status, NimbusExperiment.PublishStatus.IDLE
+        )
+        self.assertTrue(
+            pending_experiment.changes.filter(
+                old_status=NimbusExperiment.Status.DRAFT,
+                old_publish_status=NimbusExperiment.PublishStatus.WAITING,
+                new_status=NimbusExperiment.Status.DRAFT,
+                new_publish_status=NimbusExperiment.PublishStatus.IDLE,
+            ).exists()
+        )
+
+    def test_check_with_review_and_kinto_pending_update_doesnt_update_collection(self):
+        pending_experiment = NimbusExperimentFactory.create_with_status(
+            NimbusExperiment.Status.LIVE,
+            publish_status=NimbusExperiment.PublishStatus.WAITING,
+            application=NimbusExperiment.Application.FENIX,
+        )
+        NimbusExperimentFactory.create_with_status(
+            NimbusExperiment.Status.DRAFT,
+            publish_status=NimbusExperiment.PublishStatus.APPROVED,
+            application=NimbusExperiment.Application.FENIX,
+        )
+
+        self.setup_kinto_pending_review()
+        self.mock_kinto_client.get_records.side_effect = [
+            [],
+            [{"id": pending_experiment.slug}],
+        ]
+
+        tasks.nimbus_check_kinto_push_queue_by_application(
+            NimbusExperiment.Application.FENIX
+        )
+
         self.mock_push_task.assert_not_called()
-        self.mock_end_task.assert_not_called()
+        self.mock_kinto_client.patch_collection.assert_not_called()
+
+    def test_check_with_review_and_kinto_pending_end_rolls_back_and_pushes(self):
+        pending_experiment = NimbusExperimentFactory.create_with_status(
+            NimbusExperiment.Status.LIVE,
+            publish_status=NimbusExperiment.PublishStatus.WAITING,
+            is_end_requested=True,
+            application=NimbusExperiment.Application.FENIX,
+        )
+        launching_experiment = NimbusExperimentFactory.create_with_status(
+            NimbusExperiment.Status.DRAFT,
+            publish_status=NimbusExperiment.PublishStatus.APPROVED,
+            application=NimbusExperiment.Application.FENIX,
+        )
+
+        self.setup_kinto_pending_review()
+        self.mock_kinto_client.get_records.side_effect = [
+            [{"id": pending_experiment.slug}],
+            [{"id": pending_experiment.slug}],
+        ]
+
+        tasks.nimbus_check_kinto_push_queue_by_application(
+            NimbusExperiment.Application.FENIX
+        )
+
+        self.mock_push_task.assert_called_with(launching_experiment.id)
+
+        self.mock_kinto_client.patch_collection.assert_called_with(
+            id="nimbus-mobile-experiments",
+            data={"status": "to-rollback"},
+            bucket="main-workspace",
+        )
+        pending_experiment = NimbusExperiment.objects.get(slug=pending_experiment.slug)
+        self.assertEqual(
+            pending_experiment.publish_status, NimbusExperiment.PublishStatus.IDLE
+        )
+        self.assertTrue(
+            pending_experiment.changes.filter(
+                old_status=NimbusExperiment.Status.LIVE,
+                old_publish_status=NimbusExperiment.PublishStatus.WAITING,
+                new_status=NimbusExperiment.Status.LIVE,
+                new_publish_status=NimbusExperiment.PublishStatus.IDLE,
+            ).exists()
+        )
 
     def test_checkexperiment_with_approved_and_no_kinto_pending_pushes_experiment(
         self,
@@ -379,6 +477,7 @@ class TestCheckKintoPushQueueByApplication(MockKintoClientMixin, TestCase):
     ):
         experiment = NimbusExperimentFactory.create_with_status(
             NimbusExperiment.Status.LIVE,
+            publish_status=NimbusExperiment.PublishStatus.APPROVED,
             application=NimbusExperiment.Application.DESKTOP,
             is_end_requested=True,
         )
@@ -622,6 +721,8 @@ class TestEndExperimentInKinto(MockKintoClientMixin, TestCase):
     def test_end_experiment_in_kinto_deletes_experiment(self):
         experiment = NimbusExperimentFactory.create_with_status(
             NimbusExperiment.Status.LIVE,
+            publish_status=NimbusExperiment.PublishStatus.APPROVED,
+            is_end_requested=True,
             application=NimbusExperiment.Application.DESKTOP,
         )
 
@@ -637,6 +738,11 @@ class TestEndExperimentInKinto(MockKintoClientMixin, TestCase):
             id=settings.KINTO_COLLECTION_NIMBUS_DESKTOP,
             bucket=settings.KINTO_BUCKET_WORKSPACE,
             data={"status": KINTO_REVIEW_STATUS},
+        )
+
+        experiment = NimbusExperiment.objects.get(id=experiment.id)
+        self.assertEqual(
+            experiment.publish_status, NimbusExperiment.PublishStatus.WAITING
         )
 
 

--- a/app/experimenter/nimbus-ui/src/components/Summary/EndExperiment/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/EndExperiment/index.test.tsx
@@ -13,7 +13,10 @@ import {
   mockExperimentQuery,
 } from "../../../lib/mocks";
 import { getExperiment } from "../../../types/getExperiment";
-import { NimbusExperimentStatus } from "../../../types/globalTypes";
+import {
+  NimbusExperimentPublishStatus,
+  NimbusExperimentStatus,
+} from "../../../types/globalTypes";
 
 describe("EndExperiment", () => {
   it("displays the end button when experiment is live", async () => {
@@ -93,6 +96,7 @@ const Subject = ({
       {
         id: experiment.id!,
         isEndRequested: true,
+        publishStatus: NimbusExperimentPublishStatus.APPROVED,
       },
       "updateExperiment",
     );

--- a/app/experimenter/nimbus-ui/src/components/Summary/EndExperiment/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/EndExperiment/index.tsx
@@ -10,6 +10,7 @@ import { SUBMIT_ERROR } from "../../../lib/constants";
 import { getExperiment_experimentBySlug } from "../../../types/getExperiment";
 import {
   ExperimentInput,
+  NimbusExperimentPublishStatus,
   NimbusExperimentStatus,
 } from "../../../types/globalTypes";
 import { updateExperiment_updateExperiment as UpdateExperimentEndResult } from "../../../types/updateExperiment";
@@ -44,6 +45,7 @@ const EndExperiment = ({
           input: {
             id: experiment.id,
             isEndRequested: true,
+            publishStatus: NimbusExperimentPublishStatus.APPROVED,
           },
         },
       });


### PR DESCRIPTION


Becuase

* Remote settings can only have a single review up at a time
* This means a neglected review can block other experiments from launching/ending
* We would like unattended reviews to time out and get backed out

This commit

* Adds a new handle_pending case to the check collection task
* If a pending review is for a launching or ending experiment, it gets rolled back
* If a pending review is for a pause update, it does not get rolled back and must be accepted (for now, until we add live experiment updates then it will behave like launch/end cases)
* I added a new way to check experiment states using Django Q objects so that we can define aggregate states as constants rather than dumping them all as methods, in theory this should let us continue to define and modify aggregate states without needing to add/modify new methods/tests all the time