### PR TITLE
fix #4906 feat(nimbus): add review request to v5 api

### DIFF
--- a/app/experimenter/experiments/api/v5/types.py
+++ b/app/experimenter/experiments/api/v5/types.py
@@ -143,6 +143,7 @@ class NimbusExperimentType(DjangoObjectType):
     is_enrollment_paused = graphene.Boolean()
     enrollment_end_date = graphene.DateTime()
     can_review = graphene.Boolean()
+    review_request = graphene.Field(NimbusChangeLogType)
     rejection = graphene.Field(NimbusChangeLogType)
     timeout = graphene.Field(NimbusChangeLogType)
 
@@ -179,6 +180,9 @@ class NimbusExperimentType(DjangoObjectType):
 
     def resolve_can_review(self, info):
         return self.can_review(info.context.user)
+
+    def resolve_review_request(self, info):
+        return self.changes.latest_review_request()
 
     def resolve_rejection(self, info):
         return self.changes.latest_rejection()

--- a/app/experimenter/nimbus-ui/schema.graphql
+++ b/app/experimenter/nimbus-ui/schema.graphql
@@ -244,6 +244,7 @@ type NimbusExperimentType {
   isEnrollmentPaused: Boolean
   enrollmentEndDate: DateTime
   canReview: Boolean
+  reviewRequest: NimbusChangeLogType
   rejection: NimbusChangeLogType
   timeout: NimbusChangeLogType
 }


### PR DESCRIPTION
Because

* We need to display information about the review request in the UI

This commit

* Exposes the review request to the V5 API