### PR TITLE
fixes #4587 docs(nimbus): Update "Training and planning documentation link" to right link.

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/PageNew/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageNew/index.tsx
@@ -69,7 +69,7 @@ const PageNew: React.FunctionComponent<PageNewProps> = () => {
 
       <p>
         Before launching an experiment, review the{" "}
-        <LinkExternal href={EXTERNAL_URLS.NIMBUS_MANA_DOC}>
+        <LinkExternal href={EXTERNAL_URLS.TRAINING_AND_PLANNING_DOC}>
           training and planning documentation
         </LinkExternal>
         .

--- a/app/experimenter/nimbus-ui/src/lib/constants.ts
+++ b/app/experimenter/nimbus-ui/src/lib/constants.ts
@@ -12,6 +12,8 @@ export const SUBMIT_ERROR =
   "Sorry, an error occurred while submitting. Please try again.";
 
 export const EXTERNAL_URLS = {
+  TRAINING_AND_PLANNING_DOC:
+    "https://mana.mozilla.org/wiki/display/FJT/Nimbus+Onboarding",
   RISK_MITIGATION_TEMPLATE_DOC:
     "https://docs.google.com/document/d/1zfG2g6pYe9aB7ItViQaw8OcOsXXdRUP70zpZoNC2xcA/edit",
   NIMBUS_MANA_DOC: "https://mana.mozilla.org/wiki/display/FJT/Project+Nimbus",


### PR DESCRIPTION
Because:

- we want to link to the correct documentation when creating a new
  experiment

This commit:

- updates the URL for the "training and planning documentation" on the
  experiment creation page