### PR TITLE
fix #4958 bug(nimbus): update fenix beta app id

### DIFF
--- a/app/experimenter/experiments/constants/nimbus.py
+++ b/app/experimenter/experiments/constants/nimbus.py
@@ -130,7 +130,7 @@ APPLICATION_CONFIG_FENIX = ApplicationConfig(
     app_name="fenix",
     channel_app_id={
         Channel.NIGHTLY: "org.mozilla.fenix",
-        Channel.BETA: "org.mozilla.firefox.beta",
+        Channel.BETA: "org.mozilla.firefox_beta",
         Channel.RELEASE: "org.mozilla.firefox",
     },
     default_app_id="",

--- a/app/experimenter/experiments/tests/api/v6/test_serializers.py
+++ b/app/experimenter/experiments/tests/api/v6/test_serializers.py
@@ -121,8 +121,8 @@ class TestNimbusExperimentSerializer(TestCase):
             [
                 NimbusExperiment.Application.FENIX,
                 NimbusExperiment.Channel.BETA,
-                "org.mozilla.firefox.beta",
-                "org.mozilla.firefox.beta",
+                "org.mozilla.firefox_beta",
+                "org.mozilla.firefox_beta",
                 "fenix",
             ],
             [


### PR DESCRIPTION
Because

* We had the wrong app id for beta fenix

This commit

* Updates fenix beta app id to the correct value