### PR TITLE
fix #4961 bug(nimbus): update randomization unit to be in application config

### DIFF
--- a/app/experimenter/experiments/constants/nimbus.py
+++ b/app/experimenter/experiments/constants/nimbus.py
@@ -101,6 +101,11 @@ class Channel(models.TextChoices):
     RELEASE = "release"
 
 
+class BucketRandomizationUnit(models.TextChoices):
+    NORMANDY = "normandy_id"
+    NIMBUS = "nimbus_id"
+
+
 @dataclass
 class ApplicationConfig:
     name: str
@@ -109,6 +114,7 @@ class ApplicationConfig:
     channel_app_id: Dict[str, str]
     default_app_id: str
     collection: str
+    randomization_unit: str
 
 
 APPLICATION_CONFIG_DESKTOP = ApplicationConfig(
@@ -122,6 +128,7 @@ APPLICATION_CONFIG_DESKTOP = ApplicationConfig(
     },
     default_app_id="firefox-desktop",
     collection=settings.KINTO_COLLECTION_NIMBUS_DESKTOP,
+    randomization_unit=BucketRandomizationUnit.NORMANDY,
 )
 
 APPLICATION_CONFIG_FENIX = ApplicationConfig(
@@ -135,6 +142,7 @@ APPLICATION_CONFIG_FENIX = ApplicationConfig(
     },
     default_app_id="",
     collection=settings.KINTO_COLLECTION_NIMBUS_MOBILE,
+    randomization_unit=BucketRandomizationUnit.NIMBUS,
 )
 
 APPLICATION_CONFIG_IOS = ApplicationConfig(
@@ -148,6 +156,7 @@ APPLICATION_CONFIG_IOS = ApplicationConfig(
     },
     default_app_id="",
     collection=settings.KINTO_COLLECTION_NIMBUS_MOBILE,
+    randomization_unit=BucketRandomizationUnit.NIMBUS,
 )
 
 
@@ -300,15 +309,6 @@ class NimbusConstants(object):
 
     class EmailType(models.TextChoices):
         EXPERIMENT_END = "experiment end"
-
-    class BucketRandomizationUnit(models.TextChoices):
-        NORMANDY = "normandy_id"
-        NIMBUS = "nimbus_id"
-
-    APPLICATION_BUCKET_RANDOMIZATION_UNIT = {
-        Application.DESKTOP: BucketRandomizationUnit.NORMANDY,
-        Application.FENIX: BucketRandomizationUnit.NIMBUS,
-    }
 
     EMAIL_EXPERIMENT_END_SUBJECT = "Action required: Please turn off your Experiment"
 

--- a/app/experimenter/experiments/models/nimbus.py
+++ b/app/experimenter/experiments/models/nimbus.py
@@ -332,7 +332,7 @@ class NimbusIsolationGroup(models.Model):
 
     @property
     def randomization_unit(self):
-        return NimbusExperiment.APPLICATION_BUCKET_RANDOMIZATION_UNIT[self.application]
+        return NimbusExperiment.APPLICATION_CONFIGS[self.application].randomization_unit
 
     @property
     def namespace(self):

--- a/app/experimenter/experiments/tests/api/v6/test_serializers.py
+++ b/app/experimenter/experiments/tests/api/v6/test_serializers.py
@@ -96,9 +96,11 @@ class TestNimbusExperimentSerializer(TestCase):
 
         check_schema("experiments/NimbusExperiment", serializer.data)
 
-    def test_serializers_with_feature_value_None(self):
+    @parameterized.expand(list(NimbusExperiment.Application))
+    def test_serializers_with_feature_value_None(self, application):
         experiment = NimbusExperimentFactory.create_with_status(
             NimbusExperiment.Status.ACCEPTED,
+            application=application,
             branches=[],
         )
         experiment.reference_branch = NimbusBranchFactory(

--- a/app/experimenter/experiments/tests/test_models/test_models_nimbus.py
+++ b/app/experimenter/experiments/tests/test_models/test_models_nimbus.py
@@ -494,19 +494,7 @@ class TestNimbusDocumentLink(TestCase):
         self.assertEqual(str(doco_link), f"{doco_link.title} ({doco_link.link})")
 
 
-@parameterized_class(
-    ("application", "randomization_unit"),
-    [
-        [
-            NimbusExperiment.Application.DESKTOP,
-            NimbusExperiment.BucketRandomizationUnit.NORMANDY,
-        ],
-        [
-            NimbusExperiment.Application.FENIX,
-            NimbusExperiment.BucketRandomizationUnit.NIMBUS,
-        ],
-    ],
-)
+@parameterized_class(("application",), [list(NimbusExperiment.Application)])
 class TestNimbusIsolationGroup(TestCase):
     def test_empty_isolation_group_creates_isolation_group_and_bucket_range(self):
         """
@@ -526,7 +514,7 @@ class TestNimbusIsolationGroup(TestCase):
         self.assertEqual(bucket.isolation_group.total, NimbusExperiment.BUCKET_TOTAL)
         self.assertEqual(
             bucket.isolation_group.randomization_unit,
-            self.randomization_unit,
+            experiment.application_config.randomization_unit,
         )
 
     def test_existing_isolation_group_adds_bucket_range(self):
@@ -548,7 +536,7 @@ class TestNimbusIsolationGroup(TestCase):
         self.assertEqual(bucket.isolation_group, isolation_group)
         self.assertEqual(
             bucket.isolation_group.randomization_unit,
-            self.randomization_unit,
+            experiment.application_config.randomization_unit,
         )
 
     def test_existing_isolation_group_with_buckets_adds_next_bucket_range(self):
@@ -573,7 +561,7 @@ class TestNimbusIsolationGroup(TestCase):
         self.assertEqual(bucket.isolation_group, isolation_group)
         self.assertEqual(
             bucket.isolation_group.randomization_unit,
-            self.randomization_unit,
+            experiment.application_config.randomization_unit,
         )
 
     def test_full_isolation_group_creates_next_isolation_group_adds_bucket_range(
@@ -603,7 +591,7 @@ class TestNimbusIsolationGroup(TestCase):
         self.assertEqual(bucket.isolation_group.instance, isolation_group.instance + 1)
         self.assertEqual(
             bucket.isolation_group.randomization_unit,
-            self.randomization_unit,
+            experiment.application_config.randomization_unit,
         )
 
     def test_existing_isolation_group_with_matching_name_but_not_application_is_filtered(


### PR DESCRIPTION


Becuase

* We recently refactored applications to store all their info in application config
* Neglected to move the randomization unit in there for ios

This commit

* Moves randomization unit into application config
* Updates references to use that
* Updates tests to be parameterized across application to prevent intermittency like this in the future