### PR TITLE
fix #4957 chore(nimbus): disable yarn dev for integration tests

### DIFF
--- a/app/experimenter/base/context_processors.py
+++ b/app/experimenter/base/context_processors.py
@@ -27,4 +27,4 @@ def features(request):
 
 
 def debug(request):
-    return {"DEBUG": settings.DEBUG}
+    return {"DEBUG": settings.DEBUG, "USE_YARN_DEV": settings.USE_YARN_DEV}

--- a/app/experimenter/nimbus-ui/templates/nimbus/index.html
+++ b/app/experimenter/nimbus-ui/templates/nimbus/index.html
@@ -13,7 +13,7 @@
   <meta name="viewport"
     content="width=device-width,initial-scale=1,minimum-scale=1,maximum-scale=2,user-scalable=yes" />
   <title>Mozilla Experimenter</title>
-  {% if not DEBUG %}
+  {% if not USE_YARN_DEV %}
     <link rel="stylesheet" href="{% static 'nimbus/static/css/main.css' %}" />
   {% endif %}
 </head>
@@ -22,7 +22,7 @@
   <noscript>Mozilla Experimenter requires JavaScript to run.</noscript>
   <div id="root" data-config="{{ APP_CONFIG }}"></div>
 
-  {% if DEBUG %}
+  {% if USE_YARN_DEV %}
     <script src="http://localhost:3000/static/js/main.js"></script>
   {% else %}
     <script src="{% static 'nimbus/static/js/main.js' %}"></script>

--- a/app/experimenter/settings.py
+++ b/app/experimenter/settings.py
@@ -42,6 +42,8 @@ ALLOWED_HOSTS = [HOSTNAME]
 if DEBUG:
     ALLOWED_HOSTS += ["localhost", "nginx"]  # pragma: no cover
 
+USE_YARN_DEV = config("USE_YARN_DEV", default=DEBUG, cast=bool)
+
 SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
 
 # Application definition

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -6,6 +6,7 @@ services:
     env_file: .env
     environment:
       - DEBUG=True
+      - USE_YARN_DEV=False
     stdin_open: true
     tty: true
     links:


### PR DESCRIPTION
Because

* We want the integration tests to run against the built assets rather than the yarn dev hosted ones to better replicate the production environment, as well as improve the performance of the integration tests

This commit

* Disables the yarn dev server for the integration tests