### PR TITLE
chore(nimbus): reset outcome cache once during test class

### DIFF
--- a/app/experimenter/experiments/tests/api/v5/test_mutations.py
+++ b/app/experimenter/experiments/tests/api/v5/test_mutations.py
@@ -48,7 +48,9 @@ class TestMutations(GraphQLTestCase):
     GRAPHQL_URL = reverse("nimbus-api-graphql")
     maxDiff = None
 
-    def setUp(self):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
         Outcomes.clear_cache()
 
     def test_create_experiment(self):

--- a/app/experimenter/experiments/tests/test_changelog_utils/test_changelog_utils_nimbus.py
+++ b/app/experimenter/experiments/tests/test_changelog_utils/test_changelog_utils_nimbus.py
@@ -17,7 +17,9 @@ from experimenter.projects.tests.factories import ProjectFactory
 class TestNimbusExperimentChangeLogSerializer(TestCase):
     maxDiff = None
 
-    def setUp(self):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
         Outcomes.clear_cache()
 
     def test_outputs_expected_schema_for_empty_experiment(self):

--- a/app/experimenter/outcomes/tests/test_outcomes.py
+++ b/app/experimenter/outcomes/tests/test_outcomes.py
@@ -8,7 +8,9 @@ from experimenter.outcomes.tests import mock_invalid_outcomes, mock_valid_outcom
 
 @mock_valid_outcomes
 class TestOutcomes(TestCase):
-    def setUp(self):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
         Outcomes.clear_cache()
 
     def test_load_all_outcomes_and_ignore_examples(self):


### PR DESCRIPTION
Because

* I noticed while debugging other tests that we were clearing the outcome cache in setUp, which means it's reloading all the outcomes from disk at the start of each test, which only needs to happen once at the start of the test class
* Also I noticed that sometimes we were doing that without overriding to use the test fixtures so some tests were completely testing the wrong thing

This commit

* calls Outcomes.clear_cache() in setUpClass instead of setUp to only hit the disk once
* mocks out the outcomes fixture path for any test that uses them