### PR TITLE
issue #4800 chore(nimbus): backfill tests for ChangeApprovalOperations

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/ChangeApprovalOperations/FormApproveOrReject.tsx
+++ b/app/experimenter/nimbus-ui/src/components/ChangeApprovalOperations/FormApproveOrReject.tsx
@@ -1,4 +1,3 @@
-/* istanbul ignore file until EXP-1055 & EXP-1062 done */
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
@@ -29,7 +28,7 @@ const FormApproveOrReject = ({
   return (
     <>
       {timeoutEvent && (
-        <Alert variant="danger">
+        <Alert variant="danger" data-testid="timeout-notice">
           <p className="mb-0">
             <span role="img" aria-label="red X emoji">
               ❌
@@ -49,7 +48,7 @@ const FormApproveOrReject = ({
           <div className="d-flex bd-highlight">
             <div>
               <Button
-                data-testid="approve-and-launch"
+                data-testid="approve-request"
                 className="mr-2 btn btn-success"
                 disabled={isLoading}
                 onClick={onApprove}
@@ -57,7 +56,7 @@ const FormApproveOrReject = ({
                 Approve and {ucActionDescription}
               </Button>
               <Button
-                data-testid="reject-launch"
+                data-testid="reject-request"
                 className="btn btn-danger"
                 disabled={isLoading}
                 onClick={onReject}

--- a/app/experimenter/nimbus-ui/src/components/ChangeApprovalOperations/FormRejectReason.tsx
+++ b/app/experimenter/nimbus-ui/src/components/ChangeApprovalOperations/FormRejectReason.tsx
@@ -1,4 +1,3 @@
-/* istanbul ignore file until EXP-1055 & EXP-1062 done */
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
@@ -25,6 +24,7 @@ const FormRejectReason = ({
 }) => {
   const isServerValid = true;
   const submitErrors = {};
+  // istanbul ignore next - no submit errors used here
   const setSubmitErrors = () => {};
 
   const defaultValues = {
@@ -37,6 +37,7 @@ const FormRejectReason = ({
     formControlAttrs,
     formMethods,
     handleSubmit,
+    isValid,
   } = useCommonForm<RejectReasonFieldNames>(
     defaultValues,
     isServerValid,
@@ -60,6 +61,7 @@ const FormRejectReason = ({
             <Form.Control
               {...formControlAttrs("reason", REQUIRED_FIELD)}
               as="textarea"
+              data-testid="reject-reason"
               rows={4}
             />
             <FormErrors name="reason" />
@@ -69,7 +71,7 @@ const FormRejectReason = ({
               <Button
                 data-testid="reject-submit"
                 className="mr-2 btn btn-danger"
-                disabled={isLoading}
+                disabled={isLoading || !isValid}
                 onClick={handleSubmitClick}
               >
                 Reject

--- a/app/experimenter/nimbus-ui/src/components/ChangeApprovalOperations/FormRemoteSettingsPending.tsx
+++ b/app/experimenter/nimbus-ui/src/components/ChangeApprovalOperations/FormRemoteSettingsPending.tsx
@@ -1,4 +1,3 @@
-/* istanbul ignore file until EXP-1055 & EXP-1062 done */
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */

--- a/app/experimenter/nimbus-ui/src/components/ChangeApprovalOperations/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/ChangeApprovalOperations/index.stories.tsx
@@ -9,15 +9,15 @@ import React from "react";
 import FormApproveOrReject from "./FormApproveOrReject";
 import FormRejectReason from "./FormRejectReason";
 import FormRemoteSettingsPending from "./FormRemoteSettingsPending";
-import { mockChangelog, SubjectChangeApprovalOperations } from "./mocks";
+import { BaseSubject, mockChangelog } from "./mocks";
 
-const SubjectChangeApprovalOperationsWithActions = ({
+const Subject = ({
   rejectChange = action("rejectChange"),
   approveChange = action("approveChange"),
   startRemoteSettingsApproval = action("startRemoteSettingsApproval"),
   ...props
-}: React.ComponentProps<typeof SubjectChangeApprovalOperations>) => (
-  <SubjectChangeApprovalOperations
+}: React.ComponentProps<typeof BaseSubject>) => (
+  <BaseSubject
     {...{
       rejectChange,
       approveChange,
@@ -30,11 +30,9 @@ const SubjectChangeApprovalOperationsWithActions = ({
 storiesOf("components/ChangeApprovalOperations", module)
   .addDecorator(withLinks)
   .addDecorator((story) => <div className="p-5">{story()}</div>)
-  .add("review not requested", () => (
-    <SubjectChangeApprovalOperationsWithActions />
-  ))
+  .add("review not requested", () => <Subject />)
   .add("review requested, user can review", () => (
-    <SubjectChangeApprovalOperationsWithActions
+    <Subject
       {...{
         reviewRequestEvent: mockChangelog(),
         canReview: true,
@@ -42,7 +40,7 @@ storiesOf("components/ChangeApprovalOperations", module)
     />
   ))
   .add("review pending in Remote Rettings, user can review", () => (
-    <SubjectChangeApprovalOperationsWithActions
+    <Subject
       {...{
         reviewRequestEvent: mockChangelog(),
         approvalEvent: mockChangelog("def@mozilla.com"),
@@ -51,7 +49,7 @@ storiesOf("components/ChangeApprovalOperations", module)
     />
   ))
   .add("review timed out in Remote Settings, user can review", () => (
-    <SubjectChangeApprovalOperationsWithActions
+    <Subject
       {...{
         reviewRequestEvent: mockChangelog(),
         approvalEvent: mockChangelog("def@mozilla.com"),
@@ -61,7 +59,7 @@ storiesOf("components/ChangeApprovalOperations", module)
     />
   ))
   .add("review requested, user cannot review", () => (
-    <SubjectChangeApprovalOperationsWithActions
+    <Subject
       {...{
         reviewRequestEvent: mockChangelog(),
         canReview: false,
@@ -69,7 +67,7 @@ storiesOf("components/ChangeApprovalOperations", module)
     />
   ))
   .add("review pending in Remote Settings, user cannot review", () => (
-    <SubjectChangeApprovalOperationsWithActions
+    <Subject
       {...{
         reviewRequestEvent: mockChangelog(),
         approvalEvent: mockChangelog("def@mozilla.com"),
@@ -78,7 +76,7 @@ storiesOf("components/ChangeApprovalOperations", module)
     />
   ))
   .add("review timed out in Remote Settings, user cannot review", () => (
-    <SubjectChangeApprovalOperationsWithActions
+    <Subject
       {...{
         reviewRequestEvent: mockChangelog(),
         approvalEvent: mockChangelog("def@mozilla.com"),
@@ -88,7 +86,7 @@ storiesOf("components/ChangeApprovalOperations", module)
     />
   ))
   .add("review rejected in experimenter or remote settings", () => (
-    <SubjectChangeApprovalOperationsWithActions
+    <Subject
       {...{
         reviewRequestEvent: mockChangelog(),
         approvalEvent: mockChangelog("def@mozilla.com"),

--- a/app/experimenter/nimbus-ui/src/components/ChangeApprovalOperations/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/ChangeApprovalOperations/index.test.tsx
@@ -1,0 +1,210 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import React from "react";
+import { BaseSubject, mockChangelog } from "./mocks";
+
+const Subject = ({
+  rejectChange = () => {},
+  approveChange = () => {},
+  startRemoteSettingsApproval = () => {},
+  ...props
+}: React.ComponentProps<typeof BaseSubject>) => (
+  <BaseSubject
+    {...{
+      rejectChange,
+      approveChange,
+      startRemoteSettingsApproval,
+      ...props,
+    }}
+  />
+);
+
+describe("ChangeApprovalOperations", () => {
+  it("renders as expected", async () => {
+    render(<Subject />);
+    await screen.findByTestId("action-button");
+  });
+
+  it("when user can review, supports approval and opening remote settings", async () => {
+    const approveChange = jest.fn();
+    const startRemoteSettingsApproval = jest.fn();
+    render(
+      <Subject
+        {...{
+          canReview: true,
+          reviewRequestEvent: mockChangelog(),
+          approveChange,
+          startRemoteSettingsApproval,
+        }}
+      />,
+    );
+    const approveButton = await screen.findByTestId("approve-request");
+    fireEvent.click(approveButton);
+    await waitFor(() => {
+      expect(approveChange).toHaveBeenCalled();
+    });
+    const openRemoteSettingsButton = await screen.findByTestId(
+      "open-remote-settings",
+    );
+    fireEvent.click(openRemoteSettingsButton);
+    expect(startRemoteSettingsApproval).toHaveBeenCalled();
+  });
+
+  it("when user cannot review, an approval pending notice is displayed", async () => {
+    render(
+      <Subject
+        {...{
+          canReview: false,
+          reviewRequestEvent: mockChangelog(),
+        }}
+      />,
+    );
+    await screen.findByTestId("approval-pending");
+    expect(screen.queryByTestId("approve-request")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("reject-request")).not.toBeInTheDocument();
+  });
+
+  it("when user can review and review has been approved, button to open remote settings is offered", async () => {
+    const startRemoteSettingsApproval = jest.fn();
+    render(
+      <Subject
+        {...{
+          canReview: true,
+          reviewRequestEvent: mockChangelog(),
+          approvalEvent: mockChangelog(),
+          startRemoteSettingsApproval,
+        }}
+      />,
+    );
+    const openRemoteSettingsButton = await screen.findByTestId(
+      "open-remote-settings",
+    );
+    fireEvent.click(openRemoteSettingsButton);
+    expect(startRemoteSettingsApproval).toHaveBeenCalled();
+  });
+
+  it("when user cannot review and review has been approved, an approval pending notice is displayed", async () => {
+    const startRemoteSettingsApproval = jest.fn();
+    render(
+      <Subject
+        {...{
+          canReview: false,
+          reviewRequestEvent: mockChangelog(),
+          approvalEvent: mockChangelog(),
+          startRemoteSettingsApproval,
+        }}
+      />,
+    );
+    await screen.findByTestId("approval-pending");
+    expect(
+      screen.queryByTestId("open-remote-settings"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("when user can review, supports rejection and supplying a reason", async () => {
+    const expectedReason = "hovercraft contains eels";
+    const rejectChange = jest.fn();
+    render(
+      <Subject
+        {...{
+          canReview: true,
+          reviewRequestEvent: mockChangelog(),
+          rejectChange,
+        }}
+      />,
+    );
+    const rejectButton = await screen.findByTestId("reject-request");
+    fireEvent.click(rejectButton);
+    const rejectSubmitButton = await screen.findByTestId("reject-submit");
+    const rejectReasonField = await screen.findByTestId("reject-reason");
+    expect(rejectSubmitButton).not.toBeEnabled();
+    fireEvent.change(rejectReasonField, {
+      target: { value: expectedReason },
+    });
+    fireEvent.blur(rejectReasonField);
+    await waitFor(() => {
+      expect(rejectSubmitButton).toBeEnabled();
+    });
+    fireEvent.click(rejectSubmitButton);
+    await waitFor(() => {
+      expect(rejectChange).toBeCalledWith({ reason: expectedReason });
+    });
+  });
+
+  it("when user can review, supports rejection and cancelling", async () => {
+    const rejectChange = jest.fn();
+    render(
+      <Subject
+        {...{
+          canReview: true,
+          reviewRequestEvent: mockChangelog(),
+          rejectChange,
+        }}
+      />,
+    );
+    const rejectButton = await screen.findByTestId("reject-request");
+    fireEvent.click(rejectButton);
+    const rejectCancelButton = await screen.findByTestId("reject-cancel");
+    fireEvent.click(rejectCancelButton);
+    await screen.findByTestId("approve-request");
+    await screen.findByTestId("reject-request");
+    expect(screen.queryByTestId("reject-reason")).not.toBeInTheDocument();
+    expect(rejectChange).not.toHaveBeenCalled();
+  });
+
+  it("reports a rejection reason when review is rejected", async () => {
+    const actionDescription = "gizmofy";
+    const rejectionUser = "jdoe@mozilla.com";
+    const rejectionMessage = "chutes too narrow";
+    render(
+      <Subject
+        {...{
+          actionDescription,
+          reviewRequestEvent: mockChangelog(),
+          rejectionEvent: mockChangelog(rejectionUser, rejectionMessage),
+        }}
+      />,
+    );
+    await screen.findByTestId("action-button");
+    await screen.findByText(
+      `The request to ${actionDescription} this experiment was`,
+      { exact: false },
+    );
+    await screen.findByText(rejectionMessage, { exact: false });
+    await screen.findByText(rejectionUser, { exact: false });
+  });
+
+  it("when user can review and review has timed out, a timeout notice is displayed", async () => {
+    render(
+      <Subject
+        {...{
+          canReview: true,
+          reviewRequestEvent: mockChangelog(),
+          timeoutEvent: mockChangelog(),
+        }}
+      />,
+    );
+    await screen.findByTestId("timeout-notice");
+    await screen.findByTestId("approve-request");
+    await screen.findByTestId("reject-request");
+  });
+
+  it("when user can review and review has timed out, a timeout notice is displayed", async () => {
+    render(
+      <Subject
+        {...{
+          canReview: false,
+          reviewRequestEvent: mockChangelog(),
+          timeoutEvent: mockChangelog(),
+        }}
+      />,
+    );
+    await screen.findByTestId("approval-pending");
+    expect(screen.queryByTestId("timeout-notice")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("approve-request")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("reject-request")).not.toBeInTheDocument();
+  });
+});

--- a/app/experimenter/nimbus-ui/src/components/ChangeApprovalOperations/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/ChangeApprovalOperations/index.tsx
@@ -1,4 +1,3 @@
-/* istanbul ignore file until EXP-1055 & EXP-1062 done */
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
@@ -39,8 +38,8 @@ export const ChangeApprovalOperations: React.FC<
   React.PropsWithChildren<ChangeApprovalOperationsProps>
 > = ({
   actionDescription,
-  isLoading = false,
-  canReview = false,
+  isLoading,
+  canReview,
   reviewRequestEvent,
   approvalEvent,
   rejectionEvent,
@@ -78,7 +77,7 @@ export const ChangeApprovalOperations: React.FC<
     case ChangeApprovalOperationsState.ApprovalPending:
       return (
         <Alert
-          data-testid="submit-success"
+          data-testid="approval-pending"
           variant="success"
           className="bg-transparent text-success"
         >
@@ -126,7 +125,7 @@ export const ChangeApprovalOperations: React.FC<
     case ChangeApprovalOperationsState.Rejected:
       return (
         <>
-          <Alert variant="warning">
+          <Alert variant="warning" data-testid="rejection-notice">
             <div className="text-body">
               <p>
                 The request to {actionDescription} this experiment was{" "}

--- a/app/experimenter/nimbus-ui/src/components/ChangeApprovalOperations/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/components/ChangeApprovalOperations/mocks.tsx
@@ -23,7 +23,7 @@ export const mockChangelog = (
   message,
 });
 
-export const SubjectChangeApprovalOperations = ({
+export const BaseSubject = ({
   actionDescription = "frobulate",
   isLoading = false,
   canReview = false,
@@ -54,7 +54,7 @@ export const SubjectChangeApprovalOperations = ({
       ...props,
     }}
   >
-    <Button data-testid="approve-and-launch" className="mr-2 btn btn-success">
+    <Button data-testid="action-button" className="mr-2 btn btn-success">
       Frobulate experiment
     </Button>
   </ChangeApprovalOperations>


### PR DESCRIPTION
Because:

- we have stabilized the ChangeApprovalOperations UI component design
- we want 100% test coverage

This commit:

- backfills tests for ChangeApprovalOperations
- removes the istanbul ignore comments to require coverage