### PR TITLE
fixes #5001 fix(nimbus): End experiment design review component tweaks

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/ChangeApprovalOperations/FormApproveOrReject.tsx
+++ b/app/experimenter/nimbus-ui/src/components/ChangeApprovalOperations/FormApproveOrReject.tsx
@@ -33,12 +33,12 @@ const FormApproveOrReject = ({
             <span role="img" aria-label="red X emoji">
               ❌
             </span>{" "}
-            Remote Settings request has timed out, please approve through Remote
-            Settings again
+            Remote Settings request has timed out, please go through the{" "}
+            {actionDescription} request and approval flow again.
           </p>
         </Alert>
       )}
-      <Alert variant="warning">
+      <Alert variant="secondary">
         <Form className="text-body">
           <p>
             <strong>{reviewRequestEvent!.changedBy!.email}</strong> requested to{" "}

--- a/app/experimenter/nimbus-ui/src/components/ChangeApprovalOperations/FormRemoteSettingsPending.tsx
+++ b/app/experimenter/nimbus-ui/src/components/ChangeApprovalOperations/FormRemoteSettingsPending.tsx
@@ -10,16 +10,18 @@ import Form from "react-bootstrap/Form";
 const FormApproveConfirm = ({
   isLoading,
   onConfirm,
+  actionDescription,
 }: {
   isLoading: boolean;
   onConfirm: () => void;
+  actionDescription: string;
 }) => {
   return (
-    <Alert variant="warning">
+    <Alert variant="secondary">
       <Form className="text-body">
         <p>
-          <strong>Action required —</strong> You need to approve this change in
-          Remote Settings.
+          <strong>Action required —</strong> Please review this change in Remote
+          Settings to {actionDescription} this experiment
         </p>
 
         <div className="d-flex bd-highlight">

--- a/app/experimenter/nimbus-ui/src/components/ChangeApprovalOperations/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/ChangeApprovalOperations/index.stories.tsx
@@ -138,6 +138,7 @@ export const FormRemoteSettingsPendingStory = () => (
     {...{
       isLoading: false,
       onConfirm: action("confirm"),
+      actionDescription: "frobulate",
     }}
   />
 );

--- a/app/experimenter/nimbus-ui/src/components/ChangeApprovalOperations/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/ChangeApprovalOperations/index.tsx
@@ -109,6 +109,7 @@ export const ChangeApprovalOperations: React.FC<
           {...{
             isLoading,
             onConfirm: startRemoteSettingsApproval,
+            actionDescription,
           }}
         />
       );
@@ -127,15 +128,15 @@ export const ChangeApprovalOperations: React.FC<
         <>
           <Alert variant="warning" data-testid="rejection-notice">
             <div className="text-body">
-              <p>
+              <p className="mb-2">
                 The request to {actionDescription} this experiment was{" "}
                 <strong>Rejected</strong> due to:
               </p>
-              <p className="mb-0">
+              <p className="mb-2">
                 {rejectionEvent!.changedBy!.email} on{" "}
                 {humanDate(rejectionEvent!.changedOn!)}:
               </p>
-              <p className="bg-white rounded border p-3">
+              <p className="bg-white rounded border p-2 mb-0">
                 {rejectionEvent!.message}
               </p>
             </div>

--- a/app/experimenter/nimbus-ui/src/components/PageRequestReview/FormLaunchDraftToPreview.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageRequestReview/FormLaunchDraftToPreview.tsx
@@ -19,7 +19,7 @@ const FormLaunchDraftToPreview = ({
   onLaunchWithoutPreview: () => void;
 }) => {
   return (
-    <Alert variant="warning">
+    <Alert variant="secondary">
       <Form className="text-body">
         <p>
           Do you want to test this experiment before launching to production?{" "}

--- a/app/experimenter/nimbus-ui/src/components/PageRequestReview/FormLaunchDraftToReview.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageRequestReview/FormLaunchDraftToReview.tsx
@@ -29,7 +29,7 @@ const FormLaunchDraftToReview = ({
   );
 
   return (
-    <Alert variant="warning">
+    <Alert variant="secondary">
       <Form className="text-body">
         <p className="my-1">
           <span className="text-danger">

--- a/app/experimenter/nimbus-ui/src/components/PageRequestReview/FormLaunchPreviewToReview.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageRequestReview/FormLaunchPreviewToReview.tsx
@@ -32,7 +32,7 @@ const FormLaunchPreviewToReview = ({
         </p>
       </Alert>
 
-      <Alert variant="warning">
+      <Alert variant="secondary">
         <Form className="text-body">
           <p className="my-1">
             This experiment is currently <strong>live for testing</strong>, but

--- a/app/experimenter/nimbus-ui/src/components/Summary/EndExperiment/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/EndExperiment/index.tsx
@@ -75,14 +75,14 @@ const EndExperiment = ({
   return (
     <div className="mb-4" data-testid="experiment-end">
       {isEnding ? (
-        <Alert variant="warning" data-testid="experiment-ended-alert">
+        <Alert variant="secondary" data-testid="experiment-ended-alert">
           Users will no longer see the experiment once ending is approved in
           Remote Settings, and is in &quot;Complete&quot; state.
         </Alert>
       ) : (
         <>
           {showEndConfirmation ? (
-            <Alert variant="warning" data-testid="end-experiment-alert">
+            <Alert variant="secondary" data-testid="end-experiment-alert">
               <p>
                 Are you sure you want to end your experiment? It will turn off
                 the experiment for all users in production.


### PR DESCRIPTION
fixes #5001

Because:
* After a design review some minor FE tweaks were requested

This commit:
* Updates copy in a couple of components
* Changes some Alert warning variants to other styles where needed
* Updates the spacing in the reject feedback alert

===

Opening this as a draft because I ran some of the alert styles by Ana and `primary`/`info` look pretty bad:
![image](https://user-images.githubusercontent.com/13018240/114242164-0e394600-9950-11eb-809d-d8245dcf63d0.png)

![image](https://user-images.githubusercontent.com/13018240/114242146-07123800-9950-11eb-8229-0f03ed88e4d2.png)


Secondary looks great on some of them:
![image](https://user-images.githubusercontent.com/13018240/114242201-1d1ff880-9950-11eb-9ce3-d3d3e93fa9c0.png)


But not on others:
![image](https://user-images.githubusercontent.com/13018240/114242214-2315d980-9950-11eb-9591-b0986b6e0123.png)


Will have a quick meeting with Ana to see what's preferred across all of them.