### PR TITLE
issue #4800 feat(nimbus): expose latest review approval in GQL

### DIFF
--- a/app/experimenter/experiments/admin/nimbus.py
+++ b/app/experimenter/experiments/admin/nimbus.py
@@ -71,8 +71,15 @@ class NimbusExperimentAdmin(admin.ModelAdmin):
         NimbusBranchInlineAdmin,
         NimbusExperimentChangeLogInlineAdmin,
     )
-    list_display = ("name", "status", "application", "channel", "firefox_min_version")
-    list_filter = ("status", "application")
+    list_display = (
+        "name",
+        "status",
+        "publish_status",
+        "application",
+        "channel",
+        "firefox_min_version",
+    )
+    list_filter = ("status", "publish_status", "application")
     prepopulated_fields = {"slug": ("name",)}
     form = NimbusExperimentAdminForm
 

--- a/app/experimenter/experiments/api/v5/types.py
+++ b/app/experimenter/experiments/api/v5/types.py
@@ -144,6 +144,7 @@ class NimbusExperimentType(DjangoObjectType):
     enrollment_end_date = graphene.DateTime()
     can_review = graphene.Boolean()
     review_request = graphene.Field(NimbusChangeLogType)
+    review_approval = graphene.Field(NimbusChangeLogType)
     rejection = graphene.Field(NimbusChangeLogType)
     timeout = graphene.Field(NimbusChangeLogType)
 
@@ -183,6 +184,9 @@ class NimbusExperimentType(DjangoObjectType):
 
     def resolve_review_request(self, info):
         return self.changes.latest_review_request()
+
+    def resolve_review_approval(self, info):
+        return self.changes.latest_review_approval()
 
     def resolve_rejection(self, info):
         return self.changes.latest_rejection()

--- a/app/experimenter/experiments/tests/api/v5/test_queries.py
+++ b/app/experimenter/experiments/tests/api/v5/test_queries.py
@@ -385,6 +385,71 @@ class TestNimbusQuery(GraphQLTestCase):
         experiment_data = content["data"]["experimentBySlug"]
         self.assertTrue(experiment_data["canReview"])
 
+    def test_experiment_no_approval_data(self):
+        user_email = "user@example.com"
+        experiment = NimbusExperimentFactory.create_with_status(
+            NimbusExperiment.Status.DRAFT,
+            publish_status=NimbusExperiment.PublishStatus.IDLE,
+        )
+
+        response = self.query(
+            """
+            query experimentBySlug($slug: String!) {
+                experimentBySlug(slug: $slug) {
+                    reviewApproval {
+                        changedBy {
+                            email
+                        }
+                    }
+                }
+            }
+            """,
+            variables={"slug": experiment.slug},
+            headers={settings.OPENIDC_EMAIL_HEADER: user_email},
+        )
+        self.assertEqual(response.status_code, 200, response.content)
+        content = json.loads(response.content)
+        experiment_data = content["data"]["experimentBySlug"]
+        self.assertIsNone(experiment_data["reviewApproval"])
+
+    def test_experiment_with_approval(self):
+        user_email = "user@example.com"
+        experiment = NimbusExperimentFactory.create_with_status(
+            NimbusExperiment.Status.DRAFT,
+            publish_status=NimbusExperiment.PublishStatus.IDLE,
+        )
+
+        for publish_status in (
+            NimbusExperiment.PublishStatus.REVIEW,
+            NimbusExperiment.PublishStatus.APPROVED,
+        ):
+            experiment.publish_status = publish_status
+            experiment.save()
+            generate_nimbus_changelog(experiment, experiment.owner)
+
+        response = self.query(
+            """
+            query experimentBySlug($slug: String!) {
+                experimentBySlug(slug: $slug) {
+                    reviewApproval {
+                        changedBy {
+                            email
+                        }
+                    }
+                }
+            }
+            """,
+            variables={"slug": experiment.slug},
+            headers={settings.OPENIDC_EMAIL_HEADER: user_email},
+        )
+        self.assertEqual(response.status_code, 200, response.content)
+        content = json.loads(response.content)
+        experiment_data = content["data"]["experimentBySlug"]
+        self.assertEqual(
+            experiment_data["reviewApproval"]["changedBy"]["email"],
+            experiment.owner.email,
+        )
+
     def test_experiment_no_rejection_data(self):
         user_email = "user@example.com"
         experiment = NimbusExperimentFactory.create_with_status(

--- a/app/experimenter/experiments/tests/api/v5/test_serializers.py
+++ b/app/experimenter/experiments/tests/api/v5/test_serializers.py
@@ -1141,6 +1141,26 @@ class TestNimbusExperimentSerializer(TestCase):
         self.assertFalse(serializer.is_valid())
         self.assertIn("primary_outcomes", serializer.errors)
 
+    def test_can_request_review_from_preview(self):
+        experiment = NimbusExperimentFactory.create_with_status(
+            NimbusExperiment.Status.PREVIEW,
+            publish_status=NimbusExperiment.PublishStatus.IDLE,
+        )
+
+        serializer = NimbusExperimentSerializer(
+            experiment,
+            data={
+                "status": NimbusExperiment.Status.DRAFT.value,
+                "publish_status": NimbusExperiment.PublishStatus.REVIEW.value,
+            },
+            context={"user": self.user},
+        )
+
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+        experiment = serializer.save()
+        self.assertEqual(experiment.status, NimbusExperiment.Status.DRAFT)
+        self.assertEqual(experiment.publish_status, NimbusExperiment.PublishStatus.REVIEW)
+
     def test_can_review_for_non_requesting_user(self):
         experiment = NimbusExperimentFactory.create_with_status(
             NimbusExperiment.Status.DRAFT,

--- a/app/experimenter/nimbus-ui/schema.graphql
+++ b/app/experimenter/nimbus-ui/schema.graphql
@@ -309,6 +309,7 @@ type NimbusExperimentType {
   enrollmentEndDate: DateTime
   canReview: Boolean
   reviewRequest: NimbusChangeLogType
+  reviewApproval: NimbusChangeLogType
   rejection: NimbusChangeLogType
   timeout: NimbusChangeLogType
 }


### PR DESCRIPTION
Because:

- we want the review flow UI to properly indicate a locally approved
  experiment that is still pending approval in Remote Settings

This commit:

- adds review_approval field to GQL experiment queries

- adds latest_review_approval method to NimbusChangeLogManager

- tweaks latest_review_request method to include transition from
  PREVIEW/IDLE to DRAFT/REVIEW

- tweaks can_review to report true also while in WAITING publish_status

- adds publish_status to NimbusExperiment list in admin