### PR TITLE
Fix #5024: follow-up to #4894: Fix checks for available analysis.

### DIFF
--- a/app/experimenter/nimbus-ui/src/lib/visualization/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/lib/visualization/mocks.tsx
@@ -4,9 +4,9 @@
 
 export const MOCK_UNAVAILABLE_ANALYSIS = {
   show_analysis: true,
-  daily: [],
-  weekly: {},
-  overall: {},
+  daily: null,
+  weekly: null,
+  overall: null,
   metadata: {
     metrics: {},
     outcomes: {},

--- a/app/experimenter/nimbus-ui/src/lib/visualization/types.ts
+++ b/app/experimenter/nimbus-ui/src/lib/visualization/types.ts
@@ -4,8 +4,8 @@
 
 export interface AnalysisData {
   daily: AnalysisPoint[] | null;
-  weekly: { [branch: string]: BranchDescription };
-  overall: { [branch: string]: BranchDescription };
+  weekly: { [branch: string]: BranchDescription } | null;
+  overall: { [branch: string]: BranchDescription } | null;
   show_analysis: boolean;
   metadata?: Metadata;
   other_metrics?: { [metric: string]: string };

--- a/app/experimenter/nimbus-ui/src/lib/visualization/utils.tsx
+++ b/app/experimenter/nimbus-ui/src/lib/visualization/utils.tsx
@@ -8,9 +8,7 @@ import { AnalysisData } from "./types";
 // `show_analysis` is the feature flag for turning visualization on/off.
 // `overall` will be `null` if the analysis isn't available yet.
 export const analysisAvailable = (analysis: AnalysisData | undefined) =>
-  analysis?.show_analysis === true &&
-  (Object.keys(analysis?.overall).length > 0 ||
-    Object.keys(analysis?.weekly).length > 0);
+  analysis?.show_analysis && (analysis?.overall || analysis?.weekly);
 
 export const analysisUnavailable = (analysis: AnalysisData | undefined) =>
   analysis && !analysisAvailable(analysis);

--- a/app/experimenter/visualization/api/v3/models.py
+++ b/app/experimenter/visualization/api/v3/models.py
@@ -46,6 +46,9 @@ class JetstreamData(BaseModel):
     def __iter__(self):
         return iter(self.__root__)
 
+    def __len__(self):
+        return len(self.__root__)
+
     def append(self, item):
         self.__root__.append(item)
 

--- a/app/experimenter/visualization/tests/api/test_views.py
+++ b/app/experimenter/visualization/tests/api/test_views.py
@@ -47,11 +47,10 @@ class TestVisualizationView(TestCase):
         json_data = json.loads(response.content)
         self.assertEqual(
             {
-                "daily": [],
-                "metadata": [],
-                "weekly": {},
-                "overall": {},
-                "other_metrics": {},
+                "daily": None,
+                "metadata": None,
+                "weekly": None,
+                "overall": None,
                 "show_analysis": False,
             },
             json_data,


### PR DESCRIPTION
This PR reverts frontend changes made when moving over to pydantic: https://github.com/mozilla/experimenter/commit/0dddf336def53fccb6aee1bb18e083e9679210bd

Instead it makes the server-side set `None` for empty values in the API response as it did prior to that change.

Tested this with 2 broken experiments and it's resolved the issue