### PR TITLE
fixes #4902 feat(project): collapse publish status changes into experiment factory class method

### DIFF
--- a/app/experimenter/experiments/tests/api/v5/test_mutations.py
+++ b/app/experimenter/experiments/tests/api/v5/test_mutations.py
@@ -479,8 +479,8 @@ class TestMutations(GraphQLTestCase):
 
     def test_update_experiment_publish_status(self):
         user_email = "user@example.com"
-        experiment = NimbusExperimentFactory.create(
-            publish_status=NimbusExperiment.PublishStatus.IDLE,
+        experiment = NimbusExperimentFactory.create_with_publish_status(
+            NimbusExperiment.PublishStatus.IDLE,
         )
         response = self.query(
             UPDATE_EXPERIMENT_MUTATION,
@@ -499,9 +499,8 @@ class TestMutations(GraphQLTestCase):
 
     def test_reject_draft_experiment(self):
         user_email = "user@example.com"
-        experiment = NimbusExperimentFactory.create_with_status(
-            NimbusExperiment.Status.DRAFT,
-            publish_status=NimbusExperiment.PublishStatus.REVIEW,
+        experiment = NimbusExperimentFactory.create_with_publish_status(
+            NimbusExperiment.PublishStatus.REVIEW,
         )
         response = self.query(
             UPDATE_EXPERIMENT_MUTATION,

--- a/app/experimenter/experiments/tests/api/v5/test_queries.py
+++ b/app/experimenter/experiments/tests/api/v5/test_queries.py
@@ -382,9 +382,8 @@ class TestNimbusQuery(GraphQLTestCase):
 
     def test_experiment_no_approval_data(self):
         user_email = "user@example.com"
-        experiment = NimbusExperimentFactory.create_with_status(
-            NimbusExperiment.Status.DRAFT,
-            publish_status=NimbusExperiment.PublishStatus.IDLE,
+        experiment = NimbusExperimentFactory.create_with_publish_status(
+            NimbusExperiment.PublishStatus.IDLE,
         )
 
         response = self.query(
@@ -438,9 +437,8 @@ class TestNimbusQuery(GraphQLTestCase):
 
     def test_experiment_no_rejection_data(self):
         user_email = "user@example.com"
-        experiment = NimbusExperimentFactory.create_with_status(
-            NimbusExperiment.Status.DRAFT,
-            publish_status=NimbusExperiment.PublishStatus.IDLE,
+        experiment = NimbusExperimentFactory.create_with_publish_status(
+            NimbusExperiment.PublishStatus.IDLE,
         )
 
         response = self.query(
@@ -497,9 +495,8 @@ class TestNimbusQuery(GraphQLTestCase):
 
     def test_experiment_no_review_request_data(self):
         user_email = "user@example.com"
-        experiment = NimbusExperimentFactory.create_with_status(
-            NimbusExperiment.Status.DRAFT,
-            publish_status=NimbusExperiment.PublishStatus.IDLE,
+        experiment = NimbusExperimentFactory.create_with_publish_status(
+            NimbusExperiment.PublishStatus.IDLE,
         )
 
         response = self.query(

--- a/app/experimenter/experiments/tests/api/v5/test_serializers.py
+++ b/app/experimenter/experiments/tests/api/v5/test_serializers.py
@@ -971,15 +971,10 @@ class TestNimbusExperimentSerializer(TestCase):
         self.assertEqual(experiment.bucket_range.count, 5000)
 
     def test_publish_status_generates_bucket_allocation(self):
-        experiment = NimbusExperimentFactory.create_with_status(
-            NimbusExperiment.Status.DRAFT,
-            publish_status=NimbusExperiment.PublishStatus.IDLE,
+        experiment = NimbusExperimentFactory.create_with_publish_status(
+            NimbusExperiment.PublishStatus.REVIEW,
             population_percent=Decimal("50.0"),
         )
-
-        experiment.publish_status = NimbusExperiment.PublishStatus.REVIEW
-        experiment.save()
-        generate_nimbus_changelog(experiment, experiment.owner)
 
         self.assertFalse(NimbusBucketRange.objects.filter(experiment=experiment).exists())
 
@@ -1178,15 +1173,9 @@ class TestNimbusExperimentSerializer(TestCase):
         self.assertEqual(experiment.publish_status, NimbusExperiment.PublishStatus.REVIEW)
 
     def test_can_review_for_non_requesting_user(self):
-        experiment = NimbusExperimentFactory.create_with_status(
-            NimbusExperiment.Status.DRAFT,
-            publish_status=NimbusExperiment.PublishStatus.IDLE,
+        experiment = NimbusExperimentFactory.create_with_publish_status(
+            NimbusExperiment.PublishStatus.REVIEW,
         )
-
-        experiment.publish_status = NimbusExperiment.PublishStatus.REVIEW
-        experiment.save()
-
-        generate_nimbus_changelog(experiment, experiment.owner)
 
         serializer = NimbusExperimentSerializer(
             experiment,
@@ -1203,13 +1192,9 @@ class TestNimbusExperimentSerializer(TestCase):
         )
 
     def test_cant_review_for_requesting_user(self):
-        experiment = NimbusExperimentFactory.create_with_status(
-            NimbusExperiment.Status.DRAFT,
-            publish_status=NimbusExperiment.PublishStatus.IDLE,
+        experiment = NimbusExperimentFactory.create_with_publish_status(
+            NimbusExperiment.PublishStatus.REVIEW,
         )
-
-        experiment.publish_status = NimbusExperiment.PublishStatus.REVIEW
-        experiment.save()
 
         generate_nimbus_changelog(experiment, experiment.owner)
 
@@ -1225,12 +1210,9 @@ class TestNimbusExperimentSerializer(TestCase):
         self.assertIn("publish_status", serializer.errors)
 
     def test_can_review_for_requesting_user_when_idle(self):
-        experiment = NimbusExperimentFactory.create_with_status(
-            NimbusExperiment.Status.DRAFT,
-            publish_status=NimbusExperiment.PublishStatus.IDLE,
+        experiment = NimbusExperimentFactory.create_with_publish_status(
+            NimbusExperiment.PublishStatus.IDLE,
         )
-
-        generate_nimbus_changelog(experiment, experiment.owner)
 
         serializer = NimbusExperimentSerializer(
             experiment,
@@ -1243,15 +1225,9 @@ class TestNimbusExperimentSerializer(TestCase):
         self.assertTrue(serializer.is_valid())
 
     def test_can_update_publish_status_for_non_approved_state(self):
-        experiment = NimbusExperimentFactory.create_with_status(
-            NimbusExperiment.Status.DRAFT,
-            publish_status=NimbusExperiment.PublishStatus.IDLE,
+        experiment = NimbusExperimentFactory.create_with_publish_status(
+            NimbusExperiment.PublishStatus.REVIEW,
         )
-
-        experiment.publish_status = NimbusExperiment.PublishStatus.REVIEW
-        experiment.save()
-
-        generate_nimbus_changelog(experiment, experiment.owner)
 
         serializer = NimbusExperimentSerializer(
             experiment,
@@ -1435,8 +1411,8 @@ class TestNimbusStatusTransitionValidator(TestCase):
         )
 
     def test_update_publish_status_from_approved_to_review_error(self):
-        experiment = NimbusExperimentFactory.create(
-            publish_status=NimbusExperiment.PublishStatus.APPROVED,
+        experiment = NimbusExperimentFactory.create_with_publish_status(
+            NimbusExperiment.PublishStatus.APPROVED,
         )
         serializer = NimbusExperimentSerializer(
             experiment,
@@ -1460,8 +1436,8 @@ class TestNimbusStatusValidationMixin(TestCase):
         self.user = UserFactory()
 
     def test_update_experiment_publish_status_while_in_preview(self):
-        experiment = NimbusExperimentFactory.create(
-            status=NimbusExperiment.Status.PREVIEW,
+        experiment = NimbusExperimentFactory.create_with_status(
+            NimbusExperiment.Status.PREVIEW,
         )
         serializer = NimbusExperimentSerializer(
             experiment,
@@ -1487,8 +1463,8 @@ class TestNimbusStatusValidationMixin(TestCase):
         self.assertIn("experiment", serializer.errors)
 
     def test_update_experiment_with_invalid_publish_status_error(self):
-        experiment = NimbusExperimentFactory.create(
-            publish_status=NimbusExperiment.PublishStatus.REVIEW,
+        experiment = NimbusExperimentFactory.create_with_publish_status(
+            NimbusExperiment.PublishStatus.REVIEW,
         )
         serializer = NimbusExperimentSerializer(
             experiment,

--- a/app/experimenter/experiments/tests/factories/nimbus.py
+++ b/app/experimenter/experiments/tests/factories/nimbus.py
@@ -266,3 +266,10 @@ class NimbusChangeLogFactory(factory.django.DjangoModelFactory):
 
     class Meta:
         model = NimbusChangeLog
+
+
+def transition_publish_status(experiment, target_publish_status, reviewer=None):
+    experiment.publish_status = target_publish_status
+    experiment.save()
+    user = reviewer if reviewer else experiment.owner
+    return generate_nimbus_changelog(experiment, user)


### PR DESCRIPTION
Closes #4902

This PR adds a new class method, `create_with_publish_status` to `NimbusExperimentFactory`, as well as a helper utility, `transition_publish_status`, for transitioning publish statuses. It replaces a lot of uses of `create_with_status` or areas where we are manually generating changelogs for publish status changes.