### PR TITLE
issue #4800 chore(nimbus): add publish_status to changelog listings in admin

### DIFF
--- a/app/experimenter/experiments/admin/nimbus.py
+++ b/app/experimenter/experiments/admin/nimbus.py
@@ -30,7 +30,9 @@ class NimbusExperimentChangeLogInlineAdmin(admin.TabularInline):
         "changed_by",
         "changed_on",
         "old_status",
+        "old_publish_status",
         "new_status",
+        "new_publish_status",
         "message",
     )
 


### PR DESCRIPTION
Because:

- it's useful to see full status transitions in admin

This commit:

- adds old_publish_status and new_publish_status to changelog listings in admin