### PR TITLE
Fix #4927: fix(visualization): broken weekly table headers.

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableWeekly/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableWeekly/index.test.tsx
@@ -6,18 +6,35 @@ import { render, screen } from "@testing-library/react";
 import React from "react";
 import TableWeekly from ".";
 import { RouterSlugProvider } from "../../../lib/test-utils";
-import { weeklyMockAnalysis } from "../../../lib/visualization/mocks";
+import {
+  weeklyMockAnalysis,
+  WEEKLY_IDENTITY,
+  WEEKLY_TREATMENT,
+  WONKY_WEEKLY_TREATMENT,
+} from "../../../lib/visualization/mocks";
 
 describe("TableWeekly", () => {
   it("has the correct headings", () => {
-    const EXPECTED_HEADINGS = ["Week 1", "Week 2"];
+    const EXPECTED_HEADINGS = ["Week 1", "Week 2", "Week 5"];
+    const modified_treatment = {
+      treatment: {
+        is_control: false,
+        branch_data: {
+          identity: WEEKLY_IDENTITY,
+          feature_d: WEEKLY_TREATMENT,
+          retained: WONKY_WEEKLY_TREATMENT,
+          search_count: WEEKLY_TREATMENT,
+          days_of_use: WEEKLY_TREATMENT,
+        },
+      },
+    };
 
     render(
       <RouterSlugProvider>
         <TableWeekly
           metricKey="retained"
           metricName="Retention"
-          results={weeklyMockAnalysis()}
+          results={weeklyMockAnalysis(modified_treatment)}
         />
       </RouterSlugProvider>,
     );

--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableWeekly/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableWeekly/index.tsx
@@ -25,7 +25,7 @@ const getWeekCount = (
   metric: string,
   weeklyResults: { [branch: string]: BranchDescription },
 ) => {
-  let maxWeeks = 0;
+  const weekIndexSet = new Set();
   Object.keys(weeklyResults).forEach((branch: string) => {
     if (!(metric in weeklyResults[branch].branch_data)) {
       return;
@@ -36,13 +36,11 @@ const getWeekCount = (
       branchData.forEach((dataPoint: FormattedAnalysisPoint) => {
         const weekIndex: number =
           "window_index" in dataPoint ? dataPoint["window_index"]! : 0;
-        if (weekIndex > maxWeeks) {
-          maxWeeks = weekIndex;
-        }
+        weekIndexSet.add(weekIndex);
       });
     });
   });
-  return maxWeeks;
+  return Array.from(weekIndexSet).sort();
 };
 
 const TableWeekly = ({
@@ -50,7 +48,7 @@ const TableWeekly = ({
   metricName,
   results = {},
 }: TableWeeklyProps) => {
-  const weekCount = getWeekCount(metricKey, results);
+  const weekIndexList = getWeekCount(metricKey, results);
 
   return (
     <table
@@ -60,13 +58,13 @@ const TableWeekly = ({
       <thead>
         <tr>
           <th scope="col" className="border-bottom-0 bg-light" />
-          {Array.from({ length: weekCount }).map((x, weekIndex) => (
+          {weekIndexList.map((weekIndex) => (
             <th
-              key={weekIndex}
+              key={`${weekIndex}`}
               className="border-bottom-0 bg-light"
               scope="col"
             >
-              <div>{`Week ${weekIndex + 1}`}</div>
+              <div>{`Week ${weekIndex}`}</div>
             </th>
           ))}
         </tr>

--- a/app/experimenter/nimbus-ui/src/lib/visualization/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/lib/visualization/mocks.tsx
@@ -149,6 +149,79 @@ export const WEEKLY_CONTROL = {
   },
 };
 
+export const WONKY_WEEKLY_TREATMENT = {
+  absolute: {
+    first: {
+      point: 0.049019607843137254,
+      lower: 0.023872203557007872,
+      upper: 0.08249069209461024,
+      count: 10,
+      window_index: 1,
+    },
+    all: [
+      {
+        point: 0.049019607843137254,
+        lower: 0.023872203557007872,
+        upper: 0.08249069209461024,
+        count: 10,
+        window_index: 1,
+      },
+      {
+        point: 0.06019607843137254,
+        lower: 0.023872203557007872,
+        upper: 0.08249069209461024,
+        count: 10,
+        window_index: 5,
+      },
+    ],
+  },
+  difference: {
+    first: {
+      point: -0.0006569487628876534,
+      upper: 0.04316381736512019,
+      lower: 0.04175095963994029,
+      window_index: 1,
+    },
+    all: [
+      {
+        point: -0.0006569487628876534,
+        upper: 0.04316381736512019,
+        lower: -0.04175095963994029,
+        window_index: 1,
+      },
+      {
+        point: -0.0006569487628876534,
+        upper: 0.04316381736512019,
+        lower: -0.04175095963994029,
+        window_index: 5,
+      },
+    ],
+  },
+  relative_uplift: {
+    first: {
+      lower: -0.455210299676828,
+      upper: 0.5104985718410426,
+      point: -0.06233954570562385,
+      window_index: 1,
+    },
+    all: [
+      {
+        lower: -0.455210299676828,
+        upper: 0.5104985718410426,
+        point: -0.06233954570562385,
+        window_index: 1,
+      },
+      {
+        lower: -0.455210299676828,
+        upper: 0.5104985718410426,
+        point: -0.06233954570562385,
+        window_index: 5,
+      },
+    ],
+  },
+  significance: { overall: {}, weekly: { "1": "negative" } },
+};
+
 export const WEEKLY_TREATMENT = {
   absolute: {
     first: {
@@ -222,7 +295,7 @@ export const WEEKLY_TREATMENT = {
   significance: { overall: {}, weekly: { "1": "negative" } },
 };
 
-const WEEKLY_IDENTITY = {
+export const WEEKLY_IDENTITY = {
   absolute: {
     all: [
       {

--- a/app/experimenter/visualization/api/v3/models.py
+++ b/app/experimenter/visualization/api/v3/models.py
@@ -29,6 +29,10 @@ class Statistic:
     COUNT = "count"
 
 
+class Segment:
+    ALL = "all"
+
+
 class JetstreamDataPoint(BaseModel):
     lower: float = None
     upper: float = None
@@ -38,6 +42,7 @@ class JetstreamDataPoint(BaseModel):
     statistic: str = None
     window_index: str = None
     comparison: str = None
+    segment: str = Segment.ALL
 
 
 class JetstreamData(BaseModel):
@@ -132,9 +137,13 @@ class ResultsObjectModelBase(BaseModel):
         super(ResultsObjectModelBase, self).__init__()
 
         for jetstream_data_point in data:
+            if jetstream_data_point.segment != Segment.ALL:
+                continue
+
             branch = jetstream_data_point.branch
             metric = jetstream_data_point.metric
             statistic = jetstream_data_point.statistic
+
             branch_comparison = (
                 BranchComparison.ABSOLUTE
                 if jetstream_data_point.comparison is None

--- a/app/experimenter/visualization/tests/api/constants.py
+++ b/app/experimenter/visualization/tests/api/constants.py
@@ -51,6 +51,9 @@ class TestConstants:
         VARIANT_DATA_ROW = DATA_IDENTITY_ROW.copy()
         VARIANT_DATA_ROW.branch = "variant"
 
+        SEGMENTED_ROW = VARIANT_DATA_ROW.copy()
+        SEGMENTED_ROW.segment = "some_segment"
+
         VARIANT_DATA_DEFAULT_METRIC_ROW_MEAN = DATA_IDENTITY_ROW.copy()
         VARIANT_DATA_DEFAULT_METRIC_ROW_MEAN.metric = "some_count"
         VARIANT_DATA_DEFAULT_METRIC_ROW_MEAN.statistic = Statistic.MEAN
@@ -87,6 +90,7 @@ class TestConstants:
         DAILY_DATA = [
             CONTROL_DATA_ROW.dict(exclude_none=True),
             VARIANT_DATA_ROW.dict(exclude_none=True),
+            SEGMENTED_ROW.dict(exclude_none=True),
             VARIANT_DATA_DEFAULT_METRIC_ROW_MEAN.dict(exclude_none=True),
             VARIANT_DATA_DEFAULT_METRIC_ROW_BINOMIAL.dict(exclude_none=True),
             VARIANT_POSITIVE_SIGNIFICANCE_DATA_ROW.dict(exclude_none=True),
@@ -109,7 +113,7 @@ class TestConstants:
         ABSOLUTE_METRIC_DATA_A = cls.get_absolute_metric_data(DATA_POINT_A)
         ABSOLUTE_METRIC_DATA_F = cls.get_absolute_metric_data(DATA_POINT_F)
         ABSOLUTE_METRIC_DATA_F_WITH_PERCENT = ABSOLUTE_METRIC_DATA_F.copy()
-        ABSOLUTE_METRIC_DATA_F_WITH_PERCENT.percent = 50.0
+        ABSOLUTE_METRIC_DATA_F_WITH_PERCENT.percent = 33.0
 
         DIFFERENCE_METRIC_DATA_WEEKLY_NEUTRAL = cls.get_difference_metric_data(
             DATA_POINT_B, SignificanceData(weekly={"1": Significance.NEUTRAL}, overall={})


### PR DESCRIPTION
Because:
* Segmented experiments were resulting broken weekly tables
* Missing weekly analysis were not correctly reflected in table headers

This commit:
* Only looks at "all" segment for experiments (for now)
* Makes sure headers are accurate even when data is missing