### PR TITLE
chore(project): add nimbus integration tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,7 +59,7 @@ jobs:
             ./scripts/store_git_info.sh
             make publish_storybooks
 
-  integration:
+  integration_legacy:
     machine:
       docker_layer_caching: true
       image: ubuntu-2004:202101-01 # Ubuntu 20.04, Docker v20.10.2, Docker Compose v1.28.2
@@ -80,6 +80,28 @@ jobs:
             make refresh
             make up_prod_detached
             make integration_test_legacy
+
+  integration_nimbus:
+    machine:
+      docker_layer_caching: true
+      image: ubuntu-2004:202101-01 # Ubuntu 20.04, Docker v20.10.2, Docker Compose v1.28.2
+    resource_class: xlarge
+    working_directory: ~/experimenter
+    steps:
+      - run:
+          name: Docker info
+          command: docker -v
+      - run:
+          name: Docker compose info
+          command: docker-compose -v
+      - checkout
+      - run:
+          name: Run integration tests
+          command: |
+            cp .env.sample .env
+            make refresh
+            make up_prod_detached
+            make integration_test_nimbus
 
   deploy:
     working_directory: ~/experimenter
@@ -111,14 +133,24 @@ workflows:
           name: publish_storybooks
           requires:
             - build
-      - integration:
-          name: integration
+      - integration_legacy:
+          name: integration_legacy
           requires:
             - build
           filters:
             branches:
               ignore:
                 - main
+
+      - integration_nimbus:
+          name: integration_nimbus
+          requires:
+            - build
+          filters:
+            branches:
+              ignore:
+                - main
+
       - deploy:
           filters:
             branches:


### PR DESCRIPTION
Because

* We now have an integration test suite for nimbus we want to enable in circle

This commit

* Enables both the legacy and nimbus integration tests in circle