### PR TITLE
issue #4800 fix(nimbus): tweak timeout to rollback to REVIEW publish status

### DIFF
--- a/app/experimenter/kinto/tasks.py
+++ b/app/experimenter/kinto/tasks.py
@@ -87,7 +87,7 @@ def handle_pending_review(application, kinto_client):
     )
 
     if experiment.has_state(experiment.SHOULD_TIMEOUT):
-        experiment.publish_status = NimbusExperiment.PublishStatus.IDLE
+        experiment.publish_status = NimbusExperiment.PublishStatus.REVIEW
         experiment.is_end_requested = False
         experiment.save()
 

--- a/app/experimenter/kinto/tests/test_tasks.py
+++ b/app/experimenter/kinto/tests/test_tasks.py
@@ -168,14 +168,14 @@ class TestCheckKintoPushQueueByApplication(MockKintoClientMixin, TestCase):
         )
         pending_experiment = NimbusExperiment.objects.get(slug=pending_experiment.slug)
         self.assertEqual(
-            pending_experiment.publish_status, NimbusExperiment.PublishStatus.IDLE
+            pending_experiment.publish_status, NimbusExperiment.PublishStatus.REVIEW
         )
         self.assertTrue(
             pending_experiment.changes.filter(
                 old_status=NimbusExperiment.Status.DRAFT,
                 old_publish_status=NimbusExperiment.PublishStatus.WAITING,
                 new_status=NimbusExperiment.Status.DRAFT,
-                new_publish_status=NimbusExperiment.PublishStatus.IDLE,
+                new_publish_status=NimbusExperiment.PublishStatus.REVIEW,
             ).exists()
         )
 
@@ -236,14 +236,14 @@ class TestCheckKintoPushQueueByApplication(MockKintoClientMixin, TestCase):
         )
         pending_experiment = NimbusExperiment.objects.get(slug=pending_experiment.slug)
         self.assertEqual(
-            pending_experiment.publish_status, NimbusExperiment.PublishStatus.IDLE
+            pending_experiment.publish_status, NimbusExperiment.PublishStatus.REVIEW
         )
         self.assertTrue(
             pending_experiment.changes.filter(
                 old_status=NimbusExperiment.Status.LIVE,
                 old_publish_status=NimbusExperiment.PublishStatus.WAITING,
                 new_status=NimbusExperiment.Status.LIVE,
-                new_publish_status=NimbusExperiment.PublishStatus.IDLE,
+                new_publish_status=NimbusExperiment.PublishStatus.REVIEW,
             ).exists()
         )
 


### PR DESCRIPTION
Because:

* we want the reviewer to retry approval and not the experimenter to
  retry review request

This commit:

* switches to REVIEW publish status instead of IDLE on timeout