### PR TITLE
fixes #4610 feat(nimbus): filter and validate feature config application against experiment application

### DIFF
--- a/app/experimenter/experiments/api/v5/serializers.py
+++ b/app/experimenter/experiments/api/v5/serializers.py
@@ -118,6 +118,16 @@ class NimbusExperimentBranchMixin:
         if not feature_config or not feature_config.schema or not self.instance:
             return data
 
+        if self.instance.application != feature_config.application:
+            raise serializers.ValidationError(
+                {
+                    "feature_config": [
+                        f"Feature Config application {feature_config.application} does "
+                        f"not match experiment application {self.instance.application}."
+                    ]
+                }
+            )
+
         schema = json.loads(feature_config.schema)
         error_result = {}
         if data["reference_branch"].get("feature_enabled"):

--- a/app/experimenter/experiments/api/v5/types.py
+++ b/app/experimenter/experiments/api/v5/types.py
@@ -79,6 +79,8 @@ class NimbusDocumentationLinkType(DjangoObjectType):
 
 
 class NimbusFeatureConfigType(DjangoObjectType):
+    application = NimbusExperimentApplication()
+
     class Meta:
         model = NimbusFeatureConfig
 

--- a/app/experimenter/experiments/tests/api/v5/test_mutations.py
+++ b/app/experimenter/experiments/tests/api/v5/test_mutations.py
@@ -258,8 +258,13 @@ class TestMutations(GraphQLTestCase):
 
     def test_update_experiment_branches_with_feature_config(self):
         user_email = "user@example.com"
-        feature = NimbusFeatureConfigFactory(schema="{}")
-        experiment = NimbusExperimentFactory.create(status=NimbusExperiment.Status.DRAFT)
+        feature = NimbusFeatureConfigFactory(
+            schema="{}", application=NimbusExperiment.Application.FENIX
+        )
+        experiment = NimbusExperimentFactory.create(
+            status=NimbusExperiment.Status.DRAFT,
+            application=NimbusExperiment.Application.FENIX,
+        )
         experiment_id = experiment.id
         reference_branch = {"name": "control", "description": "a control", "ratio": 1}
         treatment_branches = [{"name": "treatment1", "description": "desc1", "ratio": 1}]

--- a/app/experimenter/nimbus-ui/schema.graphql
+++ b/app/experimenter/nimbus-ui/schema.graphql
@@ -308,18 +308,12 @@ type NimbusExperimentType {
   timeout: NimbusChangeLogType
 }
 
-enum NimbusFeatureConfigApplication {
-  FIREFOX_DESKTOP
-  FENIX
-  IOS
-}
-
 type NimbusFeatureConfigType {
   id: ID!
   name: String!
   slug: String!
   description: String
-  application: NimbusFeatureConfigApplication
+  application: NimbusExperimentApplication
   ownerEmail: String
   schema: String
   nimbusexperimentSet: [NimbusExperimentType!]!

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/index.stories.tsx
@@ -9,7 +9,7 @@ import React from "react";
 import PageEditBranches from ".";
 import { mockExperimentQuery } from "../../lib/mocks";
 import { RouterSlugProvider } from "../../lib/test-utils";
-import { NimbusFeatureConfigApplication } from "../../types/globalTypes";
+import { NimbusExperimentApplication } from "../../types/globalTypes";
 
 const { mock } = mockExperimentQuery("demo-slug", {
   featureConfig: {
@@ -17,7 +17,7 @@ const { mock } = mockExperimentQuery("demo-slug", {
     name: "Mauris odio erat",
     slug: "mauris-odio-erat",
     description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
-    application: NimbusFeatureConfigApplication.FENIX,
+    application: NimbusExperimentApplication.FENIX,
     ownerEmail: "dude23@yahoo.com",
     schema: '{ "sample": "schema" }',
   },

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/index.test.tsx
@@ -20,7 +20,7 @@ import { RouterSlugProvider } from "../../lib/test-utils";
 import { getExperiment_experimentBySlug } from "../../types/getExperiment";
 import {
   ExperimentInput,
-  NimbusFeatureConfigApplication,
+  NimbusExperimentApplication,
 } from "../../types/globalTypes";
 import { updateExperiment_updateExperiment } from "../../types/updateExperiment";
 import FormBranches from "./FormBranches";
@@ -42,7 +42,9 @@ describe("PageEditBranches", () => {
   });
 
   it("renders as expected with experiment data", async () => {
-    const { mock } = mockExperimentQuery("demo-slug");
+    const { mock, experiment } = mockExperimentQuery("demo-slug", {
+      application: NimbusExperimentApplication.FENIX,
+    });
     render(<Subject mocks={[mock]} />);
     await waitFor(() => {
       expect(screen.getByTestId("PageEditBranches")).toBeInTheDocument();
@@ -56,17 +58,13 @@ describe("PageEditBranches", () => {
     );
 
     for (const feature of MOCK_CONFIG!.featureConfig!) {
-      const { slug } = feature!;
-      expect(screen.getByText(slug)).toBeInTheDocument();
-    }
-
-    // Assert that non of the feature configs that don't belong to our application are available
-    for (const feature of MOCK_CONFIG!.featureConfig!.filter(
-      (config) =>
-        config?.application === NimbusFeatureConfigApplication.FIREFOX_DESKTOP,
-    )) {
-      const { slug } = feature!;
-      expect(screen.queryByText(slug)).not.toBeInTheDocument();
+      const { slug, application } = feature!;
+      const configEl = screen.queryByText(slug);
+      if (application === experiment!.application) {
+        expect(configEl).toBeInTheDocument();
+      } else {
+        expect(configEl).not.toBeInTheDocument();
+      }
     }
   });
 

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/index.tsx
@@ -85,6 +85,12 @@ const PageEditBranches: React.FunctionComponent<RouteComponentProps> = () => {
       {({ experiment, review }) => {
         currentExperiment.current = experiment;
         refetchReview.current = review.refetch;
+
+        const applicationFeatureConfigs =
+          featureConfig?.filter(
+            (config) => config?.application === experiment.application,
+          ) || [];
+
         return (
           <>
             <p>
@@ -101,8 +107,7 @@ const PageEditBranches: React.FunctionComponent<RouteComponentProps> = () => {
             <FormBranches
               {...{
                 experiment,
-                // TODO: EXP-560 - configs should be filtered by application type
-                featureConfig,
+                featureConfig: applicationFeatureConfigs,
                 isLoading: loading,
                 onSave: onFormSave,
               }}

--- a/app/experimenter/nimbus-ui/src/lib/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/lib/mocks.tsx
@@ -37,7 +37,6 @@ import {
   NimbusExperimentApplication,
   NimbusExperimentPublishStatus,
   NimbusExperimentStatus,
-  NimbusFeatureConfigApplication,
 } from "../types/globalTypes";
 import { getStatus } from "./experiment";
 import { OutcomesList, OutcomeSlugs } from "./types";
@@ -83,7 +82,7 @@ export const MOCK_CONFIG: getConfig_nimbusConfig = {
       slug: "picture-in-picture",
       description:
         "Quickly above also mission action. Become thing item institution plan.\nImpact friend wonder. Interview strategy nature question. Admit room without impact its enter forward.",
-      application: NimbusFeatureConfigApplication.FENIX,
+      application: NimbusExperimentApplication.FENIX,
       ownerEmail: "sheila43@yahoo.com",
       schema: null,
     },
@@ -92,7 +91,16 @@ export const MOCK_CONFIG: getConfig_nimbusConfig = {
       name: "Mauris odio erat",
       slug: "mauris-odio-erat",
       description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
-      application: NimbusFeatureConfigApplication.FENIX,
+      application: NimbusExperimentApplication.DESKTOP,
+      ownerEmail: "dude23@yahoo.com",
+      schema: '{ "sample": "schema" }',
+    },
+    {
+      id: "3",
+      name: "Foo lila sat",
+      slug: "foo-lila-sat",
+      description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+      application: NimbusExperimentApplication.IOS,
       ownerEmail: "dude23@yahoo.com",
       schema: '{ "sample": "schema" }',
     },

--- a/app/experimenter/nimbus-ui/src/types/getConfig.ts
+++ b/app/experimenter/nimbus-ui/src/types/getConfig.ts
@@ -3,7 +3,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import { NimbusFeatureConfigApplication, NimbusExperimentApplication } from "./globalTypes";
+import { NimbusExperimentApplication } from "./globalTypes";
 
 // ====================================================
 // GraphQL query operation: getConfig
@@ -24,7 +24,7 @@ export interface getConfig_nimbusConfig_featureConfig {
   name: string;
   slug: string;
   description: string | null;
-  application: NimbusFeatureConfigApplication | null;
+  application: NimbusExperimentApplication | null;
   ownerEmail: string | null;
   schema: string | null;
 }

--- a/app/experimenter/nimbus-ui/src/types/getExperiment.ts
+++ b/app/experimenter/nimbus-ui/src/types/getExperiment.ts
@@ -3,7 +3,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import { NimbusExperimentStatus, NimbusExperimentPublishStatus, NimbusExperimentApplication, NimbusFeatureConfigApplication, NimbusExperimentChannel, NimbusExperimentFirefoxMinVersion, NimbusExperimentTargetingConfigSlug, NimbusDocumentationLinkTitle } from "./globalTypes";
+import { NimbusExperimentStatus, NimbusExperimentPublishStatus, NimbusExperimentApplication, NimbusExperimentChannel, NimbusExperimentFirefoxMinVersion, NimbusExperimentTargetingConfigSlug, NimbusDocumentationLinkTitle } from "./globalTypes";
 
 // ====================================================
 // GraphQL query operation: getExperiment
@@ -36,7 +36,7 @@ export interface getExperiment_experimentBySlug_featureConfig {
   slug: string;
   name: string;
   description: string | null;
-  application: NimbusFeatureConfigApplication | null;
+  application: NimbusExperimentApplication | null;
   ownerEmail: string | null;
   schema: string | null;
 }

--- a/app/experimenter/nimbus-ui/src/types/globalTypes.ts
+++ b/app/experimenter/nimbus-ui/src/types/globalTypes.ts
@@ -151,12 +151,6 @@ export enum NimbusExperimentTargetingConfigSlug {
   US_ONLY = "US_ONLY",
 }
 
-export enum NimbusFeatureConfigApplication {
-  FENIX = "FENIX",
-  FIREFOX_DESKTOP = "FIREFOX_DESKTOP",
-  IOS = "IOS",
-}
-
 export interface DocumentationLinkType {
   title: NimbusExperimentDocumentationLink;
   link: string;


### PR DESCRIPTION
Closes #4610

This PR:

- Filters an experiment's available feature configs based on its application in the front end
- Validates an experiment's feature config against against its application in the v5 serializer