### PR TITLE
fix #5038 chore(project): include integration tests in format/check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,7 @@ kill: compose_stop compose_rm volumes_rm
 	echo "All containers removed!"
 
 check: compose_build_test
-	$(COMPOSE_TEST) run app sh -c '$(WAIT_FOR_DB) (${PARALLEL} "$(NIMBUS_SCHEMA_CHECK)" "$(PYTHON_CHECK_MIGRATIONS)" "$(CHECK_DOCS)" "${PY_IMPORT_CHECK}"  "$(BLACK_CHECK)" "$(FLAKE8)" "$(ESLINT_CORE)" "$(ESLINT_NIMBUS_UI)" "$(TYPECHECK_NIMBUS_UI)" "$(JS_TEST_CORE)" "$(JS_TEST_NIMBUS_UI)" "$(PYTHON_TEST)") ${COLOR_CHECK}'
+	$(COMPOSE_TEST) run app sh -c '$(WAIT_FOR_DB) (${PARALLEL} "$(NIMBUS_SCHEMA_CHECK)" "$(PYTHON_CHECK_MIGRATIONS)" "$(CHECK_DOCS)" "${PY_IMPORT_CHECK}" "$(BLACK_CHECK)" "$(FLAKE8)" "$(ESLINT_CORE)" "$(ESLINT_NIMBUS_UI)" "$(TYPECHECK_NIMBUS_UI)" "$(JS_TEST_CORE)" "$(JS_TEST_NIMBUS_UI)" "$(PYTHON_TEST)") ${COLOR_CHECK}'
 
 pytest: compose_build_test
 	$(COMPOSE_TEST) run app sh -c '$(WAIT_FOR_DB) $(PYTHON_TEST)'

--- a/app/.dockerignore
+++ b/app/.dockerignore
@@ -9,6 +9,5 @@ docs
 experimenter/legacy-ui/assets
 experimenter/nimbus-ui/build
 node_modules
-tests
 experimenter/legacy-ui/core/.cache/
 experimenter/nimbus-ui/yarn-error.log

--- a/app/tests/integration/nimbus/conftest.py
+++ b/app/tests/integration/nimbus/conftest.py
@@ -1,10 +1,7 @@
-import datetime
 import os
-from urllib.parse import urlparse
 
 import pytest
 import requests
-from dateutil.parser import parse
 from requests.adapters import HTTPAdapter
 from requests.packages.urllib3.util.retry import Retry
 

--- a/app/tests/integration/nimbus/pages/base.py
+++ b/app/tests/integration/nimbus/pages/base.py
@@ -1,7 +1,7 @@
 """Base page."""
 import time
 
-from pypom import Page, Region
+from pypom import Page
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as EC
 

--- a/app/tests/integration/nimbus/pages/home.py
+++ b/app/tests/integration/nimbus/pages/home.py
@@ -1,4 +1,4 @@
-from pypom import Page, Region
+from pypom import Page
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as EC
 

--- a/app/tests/integration/nimbus/pages/new_experiment.py
+++ b/app/tests/integration/nimbus/pages/new_experiment.py
@@ -1,5 +1,4 @@
 from nimbus.pages.base import Base
-from pypom import Page, Region
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.select import Select
@@ -19,13 +18,6 @@ class NewExperiment(Base):
         self.wait.until(EC.presence_of_element_located(self._page_wait_locator))
 
         return self
-
-    def save_and_continue(self):
-        element = self.selenium.find_element(*self._save_continue_btn_locator)
-        element.click()
-        from pages.overview import OverviewPage
-
-        return OverviewPage(self.driver, self.base_url).wait_for_page_to_load()
 
     @property
     def public_name(self):

--- a/app/tests/integration/nimbus/pages/overview.py
+++ b/app/tests/integration/nimbus/pages/overview.py
@@ -1,5 +1,4 @@
 from nimbus.pages.base import Base
-from nimbus.pages.new_experiment import NewExperiment
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as EC
 


### PR DESCRIPTION
Because

* We wanna make sure all paths are included in linting/checking so we don't accidentally miss lint issues and let them sneak into other prs

This commit

* Removes `tests` from .dockerignore to ensure that path is included in the test container