### PR TITLE
fixes #5034 fix(nimbus): address some flaky frontend tests

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/PageEditMetrics/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditMetrics/index.test.tsx
@@ -4,13 +4,7 @@
 
 import { MockedResponse } from "@apollo/client/testing";
 import { navigate } from "@reach/router";
-import {
-  act,
-  fireEvent,
-  render,
-  screen,
-  waitFor,
-} from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import fetchMock from "jest-fetch-mock";
 import React from "react";
 import PageEditMetrics from ".";
@@ -91,61 +85,58 @@ describe("PageEditMetrics", () => {
   it("handles form submission", async () => {
     render(<Subject mocks={[mock, mutationMock]} />);
     await screen.findByTestId("PageEditMetrics");
-    await act(async () => void fireEvent.click(screen.getByTestId("submit")));
-    expect(mockSubmit).toHaveBeenCalled();
+    fireEvent.click(screen.getByTestId("submit"));
+    await waitFor(() => expect(mockSubmit).toHaveBeenCalled());
   });
 
   it("handles experiment form submission with bad server data", async () => {
     // @ts-ignore - intentionally breaking this type for error handling
     delete mutationMock.result.data.updateExperiment;
     render(<Subject mocks={[mock, mutationMock]} />);
-    let submitButton: HTMLButtonElement;
-    await waitFor(() => {
-      submitButton = screen.getByTestId("submit") as HTMLButtonElement;
-    });
-    await act(async () => {
-      fireEvent.click(submitButton);
-    });
-    expect(screen.getByTestId("submitErrors")).toHaveTextContent(
-      JSON.stringify({ "*": SUBMIT_ERROR }),
+    const submitButton = await screen.findByTestId("submit");
+    fireEvent.click(submitButton);
+    await waitFor(() =>
+      expect(screen.getByTestId("submitErrors")).toHaveTextContent(
+        JSON.stringify({ "*": SUBMIT_ERROR }),
+      ),
     );
   });
 
   it("handles experiment form submission with server API error", async () => {
     mutationMock.result.errors = [new Error("an error")];
     render(<Subject mocks={[mock, mutationMock]} />);
-    let submitButton: HTMLButtonElement;
-    await waitFor(() => {
-      submitButton = screen.getByTestId("submit") as HTMLButtonElement;
-    });
-    await act(async () => {
-      fireEvent.click(submitButton);
-    });
-    expect(screen.getByTestId("submitErrors")).toHaveTextContent(
-      JSON.stringify({ "*": SUBMIT_ERROR }),
+    const submitButton = await screen.findByTestId("submit");
+    fireEvent.click(submitButton);
+    await waitFor(() =>
+      expect(screen.getByTestId("submitErrors")).toHaveTextContent(
+        JSON.stringify({ "*": SUBMIT_ERROR }),
+      ),
     );
   });
 
   it("handles server validation error", async () => {
-    mutationMock.result.data.updateExperiment.message = {
+    const expectedErrors = {
       primaryOutcomes: ["Bad outcomes"],
     };
+    mutationMock.result.data.updateExperiment.message = expectedErrors;
     render(<Subject mocks={[mock, mutationMock]} />);
-    let submitButton: HTMLButtonElement;
-    await waitFor(() => {
-      submitButton = screen.getByTestId("submit") as HTMLButtonElement;
-    });
-    await act(async () => {
-      fireEvent.click(submitButton);
-    });
+    const submitButton = await screen.findByTestId("submit");
+    fireEvent.click(submitButton);
+    await waitFor(() =>
+      expect(screen.getByTestId("submitErrors")).toHaveTextContent(
+        JSON.stringify(expectedErrors),
+      ),
+    );
   });
 
   it("handles form next button", async () => {
     render(<Subject mocks={[mock, mutationMock]} />);
     await screen.findByTestId("PageEditMetrics");
-    await act(async () => void fireEvent.click(screen.getByTestId("next")));
-    expect(mockSubmit).toHaveBeenCalled();
-    expect(navigate).toHaveBeenCalledWith("audience");
+    fireEvent.click(screen.getByTestId("next"));
+    await waitFor(() => {
+      expect(mockSubmit).toHaveBeenCalled();
+      expect(navigate).toHaveBeenCalledWith("audience");
+    });
   });
 });
 

--- a/app/experimenter/nimbus-ui/src/components/PageEditOverview/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditOverview/index.test.tsx
@@ -4,13 +4,7 @@
 
 import { MockedResponse } from "@apollo/client/testing";
 import { navigate } from "@reach/router";
-import {
-  act,
-  fireEvent,
-  render,
-  screen,
-  waitFor,
-} from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import fetchMock from "jest-fetch-mock";
 import React from "react";
 import PageEditOverview from ".";
@@ -81,8 +75,8 @@ describe("PageEditOverview", () => {
   it("handles form submission", async () => {
     render(<Subject mocks={[mock, mutationMock]} />);
     await screen.findByTestId("PageEditOverview");
-    await act(async () => void fireEvent.click(screen.getByTestId("submit")));
-    expect(mockSubmit).toHaveBeenCalled();
+    fireEvent.click(screen.getByTestId("submit"));
+    await waitFor(() => expect(mockSubmit).toHaveBeenCalled());
   });
 
   it("handles experiment form submission with server-side validation errors", async () => {
@@ -91,15 +85,12 @@ describe("PageEditOverview", () => {
     };
     mutationMock.result.data.updateExperiment.message = expectedErrors;
     render(<Subject mocks={[mock, mutationMock]} />);
-    let submitButton: HTMLButtonElement;
-    await waitFor(() => {
-      submitButton = screen.getByTestId("submit") as HTMLButtonElement;
-    });
-    await act(async () => {
-      fireEvent.click(submitButton);
-    });
-    expect(screen.getByTestId("submitErrors")).toHaveTextContent(
-      JSON.stringify(expectedErrors),
+    const submitButton = await screen.findByTestId("submit");
+    fireEvent.click(submitButton);
+    await waitFor(() =>
+      expect(screen.getByTestId("submitErrors")).toHaveTextContent(
+        JSON.stringify(expectedErrors),
+      ),
     );
   });
 
@@ -107,39 +98,35 @@ describe("PageEditOverview", () => {
     // @ts-ignore - intentionally breaking this type for error handling
     delete mutationMock.result.data.updateExperiment;
     render(<Subject mocks={[mock, mutationMock]} />);
-    let submitButton: HTMLButtonElement;
-    await waitFor(() => {
-      submitButton = screen.getByTestId("submit") as HTMLButtonElement;
-    });
-    await act(async () => {
-      fireEvent.click(submitButton);
-    });
-    expect(screen.getByTestId("submitErrors")).toHaveTextContent(
-      JSON.stringify({ "*": SUBMIT_ERROR }),
+    const submitButton = await screen.findByTestId("submit");
+    fireEvent.click(submitButton);
+    await waitFor(() =>
+      expect(screen.getByTestId("submitErrors")).toHaveTextContent(
+        JSON.stringify({ "*": SUBMIT_ERROR }),
+      ),
     );
   });
 
   it("handles experiment form submission with server API error", async () => {
     mutationMock.result.errors = [new Error("an error")];
     render(<Subject mocks={[mock, mutationMock]} />);
-    let submitButton: HTMLButtonElement;
-    await waitFor(() => {
-      submitButton = screen.getByTestId("submit") as HTMLButtonElement;
-    });
-    await act(async () => {
-      fireEvent.click(submitButton);
-    });
-    expect(screen.getByTestId("submitErrors")).toHaveTextContent(
-      JSON.stringify({ "*": SUBMIT_ERROR }),
+    const submitButton = await screen.findByTestId("submit");
+    fireEvent.click(submitButton);
+    await waitFor(() =>
+      expect(screen.getByTestId("submitErrors")).toHaveTextContent(
+        JSON.stringify({ "*": SUBMIT_ERROR }),
+      ),
     );
   });
 
   it("handles form next button", async () => {
     render(<Subject mocks={[mock, mutationMock]} />);
     await screen.findByTestId("PageEditOverview");
-    await act(async () => void fireEvent.click(screen.getByTestId("next")));
-    expect(mockSubmit).toHaveBeenCalled();
-    expect(navigate).toHaveBeenCalledWith("branches");
+    fireEvent.click(screen.getByTestId("next"));
+    await waitFor(() => {
+      expect(mockSubmit).toHaveBeenCalled();
+      expect(navigate).toHaveBeenCalledWith("branches");
+    });
   });
 });
 

--- a/app/experimenter/nimbus-ui/src/components/PageNew/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageNew/index.test.tsx
@@ -4,13 +4,7 @@
 
 import { MockedResponse } from "@apollo/client/testing";
 import { navigate } from "@reach/router";
-import {
-  act,
-  fireEvent,
-  render,
-  screen,
-  waitFor,
-} from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import React from "react";
 import PageNew from ".";
 import { CREATE_EXPERIMENT_MUTATION } from "../../gql/experiments";
@@ -42,17 +36,15 @@ describe("PageNew", () => {
 
   it("renders as expected", async () => {
     render(<Subject />);
-    await act(async () => {
-      expect(screen.getByTestId("PageNew")).toBeInTheDocument();
-    });
+    await screen.findByTestId("PageNew");
   });
 
   it("handles experiment form submission", async () => {
     render(<Subject mocks={[mutationMock]} />);
-    await act(async () => {
-      fireEvent.click(screen.getByTestId("submit"));
-    });
-    expect(navigate).toHaveBeenCalledWith("foo-bar-baz/edit/overview");
+    fireEvent.click(screen.getByTestId("submit"));
+    await waitFor(() =>
+      expect(navigate).toHaveBeenCalledWith("foo-bar-baz/edit/overview"),
+    );
   });
 
   it("handles experiment form submission with server-side validation errors", async () => {
@@ -61,11 +53,12 @@ describe("PageNew", () => {
     };
     mutationMock.result.data.createExperiment.message = expectedErrors;
     render(<Subject mocks={[mutationMock]} />);
-    await act(async () => {
-      fireEvent.click(screen.getByTestId("submit"));
-    });
-    expect(screen.getByTestId("submitErrors")).toHaveTextContent(
-      JSON.stringify(expectedErrors),
+    const submitButton = await screen.findByTestId("submit");
+    fireEvent.click(submitButton);
+    await waitFor(() =>
+      expect(screen.getByTestId("submitErrors")).toHaveTextContent(
+        JSON.stringify(expectedErrors),
+      ),
     );
   });
 
@@ -73,11 +66,12 @@ describe("PageNew", () => {
     // @ts-ignore - intentionally breaking this type for error handling
     delete mutationMock.result.data.createExperiment;
     render(<Subject mocks={[mutationMock]} />);
-    await act(async () => {
-      fireEvent.click(screen.getByTestId("submit"));
-    });
-    expect(screen.getByTestId("submitErrors")).toHaveTextContent(
-      JSON.stringify({ "*": SUBMIT_ERROR }),
+    const submitButton = await screen.findByTestId("submit");
+    fireEvent.click(submitButton);
+    await waitFor(() =>
+      expect(screen.getByTestId("submitErrors")).toHaveTextContent(
+        JSON.stringify({ "*": SUBMIT_ERROR }),
+      ),
     );
   });
 


### PR DESCRIPTION
Closes #4941
Closes #5034

This PR should address some of the flaky frontend tests by removing some usages of `act` and adding some usages of `waitFor`. As a general reminder:

- All RTL `fireEvent` methods internally wrap their calls with `act`, so adding it around a `fireEvent` call is redundant
- `act` is mostly meant for handling "effects", so state changes and lifecycle events, but cannot know if/when things like network requests occur (or finish)
- `waitFor` will repeatedly call its callback (up to a limit) until all assertions are true