### PR TITLE
feat(nimbus): add a link to the experimenter doc hub

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/PageHome/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageHome/index.tsx
@@ -5,11 +5,12 @@
 import { useQuery } from "@apollo/client";
 import { Link, RouteComponentProps } from "@reach/router";
 import React from "react";
-import { Tab, Tabs } from "react-bootstrap";
+import { Alert, Tab, Tabs } from "react-bootstrap";
 import { GET_EXPERIMENTS_QUERY } from "../../gql/experiments";
 import { getAllExperiments_experiments } from "../../types/getAllExperiments";
 import AppLayout from "../AppLayout";
 import Head from "../Head";
+import LinkExternal from "../LinkExternal";
 import PageLoading from "../PageLoading";
 import DirectoryTable, {
   DirectoryCompleteTable,
@@ -64,7 +65,7 @@ const PageHome: React.FunctionComponent<PageHomeProps> = () => {
     <AppLayout testid="PageHome">
       <Head title="Experiments" />
 
-      <div className="d-flex mb-4">
+      <div className="d-flex mb-4 justify-content-between">
         <h2 className="mb-0 mr-1">Nimbus Experiments </h2>
         <div>
           <Link
@@ -77,6 +78,17 @@ const PageHome: React.FunctionComponent<PageHomeProps> = () => {
           </Link>
         </div>
       </div>
+
+      <Alert variant="primary" className="mb-4">
+        <span role="img" aria-label="book emoji">
+          📖
+        </span>{" "}
+        Not sure where to start? Check out the{" "}
+        <LinkExternal href="https://mozilla.github.io/experimenter-docs/">
+          Experimenter documentation hub
+        </LinkExternal>
+        .
+      </Alert>
 
       <Body />
     </AppLayout>


### PR DESCRIPTION
Closes #5042

Adds a little information message to the home page that links you to the experimenter-docs

(also right-aligns the new experiment button)

<img width="1266" alt="Capture d’écran, le 2021-04-15 à 16 42 44" src="https://user-images.githubusercontent.com/6392049/114935819-a54b4580-9e09-11eb-9e32-75f0bafe0fe9.png">
