### PR TITLE
 fixes #4959 feat(nimbus): Display default branch names, alter TableBranches

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/NotSet/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/NotSet/index.stories.tsx
@@ -6,4 +6,6 @@ import { storiesOf } from "@storybook/react";
 import React from "react";
 import NotSet from ".";
 
-storiesOf("Components/NotSet", module).add("basic", () => <NotSet />);
+storiesOf("Components/NotSet", module)
+  .add("basic", () => <NotSet />)
+  .add("custom copy", () => <NotSet copy="YOU'RE the one that's not set." />);

--- a/app/experimenter/nimbus-ui/src/components/NotSet/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/NotSet/index.tsx
@@ -5,12 +5,14 @@
 import React from "react";
 
 const NotSet = ({
+  copy = "Not set",
   "data-testid": testid = "not-set",
 }: {
+  copy?: string;
   "data-testid"?: string;
 }) => (
   <span className="text-danger" data-testid={testid}>
-    Not set
+    {copy}
   </span>
 );
 

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/index.test.tsx
@@ -42,6 +42,39 @@ describe("FormBranches", () => {
     expect(onNext).not.toHaveBeenCalled();
   });
 
+  it("sets expected default name values", async () => {
+    render(
+      <SubjectBranches
+        {...{
+          experiment: {
+            ...MOCK_EXPERIMENT,
+            referenceBranch: {
+              ...MOCK_EXPERIMENT.referenceBranch!,
+              name: "",
+            },
+            treatmentBranches: [
+              {
+                name: "",
+                slug: "",
+                description: "",
+                ratio: 0,
+                featureValue: null,
+                featureEnabled: false,
+              },
+            ],
+          },
+        }}
+      />,
+    );
+    expect(
+      (screen.getByTestId("referenceBranch.name") as HTMLInputElement).value,
+    ).toEqual("control");
+    expect(
+      (screen.getByTestId("treatmentBranches[0].name") as HTMLInputElement)
+        .value,
+    ).toEqual("treatment");
+  });
+
   it("calls onSave with extracted update when save button clicked", async () => {
     const onSave = jest.fn();
     render(<SubjectBranches {...{ onSave }} />);

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/reducer/actions.ts
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/reducer/actions.ts
@@ -56,11 +56,11 @@ function addBranch(state: FormBranchesState) {
   lastId++;
 
   if (referenceBranch === null) {
-    referenceBranch = createAnnotatedBranch(lastId, "New control");
+    referenceBranch = createAnnotatedBranch(lastId, "control");
   } else {
     treatmentBranches = [
       ...(treatmentBranches || []),
-      createAnnotatedBranch(state.lastId, `New treatment ${lastId}`),
+      createAnnotatedBranch(state.lastId, `treatment ${lastId}`),
     ];
   }
 

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/reducer/state.ts
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/reducer/state.ts
@@ -66,6 +66,11 @@ export function annotateExperimentBranch(
 ) {
   return {
     ...branch,
+    // Set default branch names - reference branch to "control" and first treatment branch to "treatment"
+    ...(branch.name === "" && {
+      name:
+        lastId === "reference" ? "control" : lastId === 0 ? "treatment" : "",
+    }),
     key: `branch-${lastId}`,
     isValid: true,
     isDirty: false,

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/index.stories.tsx
@@ -53,13 +53,18 @@ const { mock: mockMissingFields } = mockExperimentQuery("demo-slug", {
 storiesOf("pages/EditBranches", module)
   .addDecorator(withLinks)
   .addDecorator(withQuery)
-  .add("basic", () => (
+  .add("default", () => (
+    <RouterSlugProvider mocks={[mockMissingFields]}>
+      <PageEditBranches />
+    </RouterSlugProvider>
+  ))
+  .add("filled out", () => (
     <RouterSlugProvider mocks={[mock]}>
       <PageEditBranches />
     </RouterSlugProvider>
   ))
   .add(
-    "missing fields",
+    "show missing fields",
     () => (
       <RouterSlugProvider mocks={[mockMissingFields]}>
         <PageEditBranches />

--- a/app/experimenter/nimbus-ui/src/components/Summary/TableBranches/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/TableBranches/index.stories.tsx
@@ -8,6 +8,27 @@ import { MOCK_EXPERIMENT, Subject } from "./mocks";
 
 storiesOf("components/Summary/TableBranches", module)
   .add("full branches", () => <Subject />)
+  .add("unsaved branches", () => (
+    <Subject
+      experiment={{
+        ...MOCK_EXPERIMENT,
+        referenceBranch: {
+          ...MOCK_EXPERIMENT.referenceBranch!,
+          name: "",
+        },
+        treatmentBranches: [
+          {
+            name: "",
+            slug: "",
+            description: "",
+            ratio: 0,
+            featureValue: null,
+            featureEnabled: false,
+          },
+        ],
+      }}
+    />
+  ))
   .add("disabled branch", () => (
     <Subject
       experiment={{

--- a/app/experimenter/nimbus-ui/src/components/Summary/TableBranches/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/TableBranches/index.test.tsx
@@ -4,6 +4,7 @@
 
 import { render, screen } from "@testing-library/react";
 import React from "react";
+import { NO_BRANCHES_COPY } from ".";
 import { MOCK_EXPERIMENT, Subject } from "./mocks";
 
 describe("TableBranches", () => {
@@ -11,6 +12,9 @@ describe("TableBranches", () => {
     render(<Subject />);
     expect(screen.queryByTestId("not-set")).not.toBeInTheDocument();
     expect(screen.queryAllByTestId("table-branch")).toHaveLength(2);
+    expect(screen.getByTestId("branches-section-title")).toHaveTextContent(
+      "Branches (2)",
+    );
   });
 
   it("handles zero defined branches", () => {
@@ -23,7 +27,40 @@ describe("TableBranches", () => {
         }}
       />,
     );
-    expect(screen.getByTestId("not-set")).toBeInTheDocument();
+    expect(screen.getByTestId("not-set")).toHaveTextContent(NO_BRANCHES_COPY);
+    expect(screen.queryAllByTestId("table-branch")).toHaveLength(0);
+    expect(screen.getByTestId("branches-section-title")).toHaveTextContent(
+      "Branches",
+    );
+  });
+
+  it("displays expected text with no branch names set", () => {
+    render(
+      <Subject
+        experiment={{
+          ...MOCK_EXPERIMENT,
+          referenceBranch: {
+            ...MOCK_EXPERIMENT.referenceBranch!,
+            name: "",
+          },
+          treatmentBranches: [
+            {
+              name: "",
+              slug: "",
+              description: "",
+              ratio: 0,
+              featureValue: null,
+              featureEnabled: false,
+            },
+          ],
+        }}
+      />,
+    );
+    expect(screen.getByTestId("not-set")).toHaveTextContent(NO_BRANCHES_COPY);
+    expect(screen.queryAllByTestId("table-branch")).toHaveLength(0);
+    expect(screen.getByTestId("branches-section-title")).toHaveTextContent(
+      "Branches",
+    );
   });
 
   it("hides feature value when feature schema is null", () => {

--- a/app/experimenter/nimbus-ui/src/components/Summary/TableBranches/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/TableBranches/index.tsx
@@ -11,9 +11,23 @@ import {
 } from "../../../types/getExperiment";
 import NotSet from "../../NotSet";
 
+export const NO_BRANCHES_COPY = "No branches have been saved yet";
+
 type Branch =
   | getExperiment_experimentBySlug_referenceBranch
   | getExperiment_experimentBySlug_treatmentBranches;
+
+const TableTitle = ({
+  branchCount,
+  hasOneBranchNameSet,
+}: {
+  branchCount: number;
+  hasOneBranchNameSet?: boolean;
+}) => (
+  <h2 className="h5 mb-3" data-testid="branches-section-title">
+    Branches {branchCount > 0 && hasOneBranchNameSet && `(${branchCount})`}
+  </h2>
+);
 
 const TableBranches = ({
   experiment,
@@ -26,16 +40,21 @@ const TableBranches = ({
     experiment.referenceBranch,
     ...(experiment.treatmentBranches || []),
   ].filter((branch): branch is Branch => branch !== null);
-
-  if (branches.length === 0) {
-    return <NotSet />;
-  }
+  const branchCount = branches.length;
+  const hasOneBranchNameSet = Boolean(branches.find((branch) => branch.name));
 
   return (
     <>
-      {branches.map((branch, key) => (
-        <TableBranch key={key} {...{ hasSchema, branch }} />
-      ))}
+      <TableTitle {...{ branchCount, hasOneBranchNameSet }} />
+      {branchCount === 0 || !hasOneBranchNameSet ? (
+        <NotSet copy={NO_BRANCHES_COPY} />
+      ) : (
+        <>
+          {branches.map((branch, key) => (
+            <TableBranch key={key} {...{ hasSchema, branch }} />
+          ))}
+        </>
+      )}
     </>
   );
 };

--- a/app/experimenter/nimbus-ui/src/components/Summary/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/index.test.tsx
@@ -21,7 +21,7 @@ describe("Summary", () => {
     expect(screen.getByTestId("table-audience")).toBeInTheDocument();
     expect(screen.queryAllByTestId("table-branch")).toHaveLength(2);
     expect(screen.getByTestId("branches-section-title")).toHaveTextContent(
-      "Branches (2)",
+      "Branches",
     );
   });
 
@@ -60,21 +60,6 @@ describe("Summary", () => {
       />,
     );
     await screen.findByTestId("pill-enrolling-complete");
-  });
-
-  it("renders as expected with no defined branches", () => {
-    render(
-      <Subject
-        props={{
-          referenceBranch: null,
-          treatmentBranches: null,
-        }}
-      />,
-    );
-    expect(screen.queryAllByTestId("table-branch")).toHaveLength(0);
-    expect(screen.getByTestId("branches-section-title")).toHaveTextContent(
-      "Branches (0)",
-    );
   });
 
   describe("JSON representation link", () => {

--- a/app/experimenter/nimbus-ui/src/components/Summary/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/index.tsx
@@ -29,10 +29,6 @@ type SummaryProps = {
 const Summary = ({ experiment, refetch }: SummaryProps) => {
   const { kintoAdminUrl } = useConfig();
   const status = getStatus(experiment);
-  const branchCount = [
-    experiment.referenceBranch,
-    ...(experiment.treatmentBranches || []),
-  ].filter((branch) => !!branch).length;
 
   // TODO: PageRequestReview assigns the experiment and refetch values to refs,
   // and since this component shares the same useChangeOperationMutation hook
@@ -77,7 +73,7 @@ const Summary = ({ experiment, refetch }: SummaryProps) => {
   );
 
   return (
-    <div data-testid="summary">
+    <div data-testid="summary" className="mb-5">
       <h2 className="h5 mb-3">
         Timeline
         {status.live && <StatusPills {...{ experiment }} />}
@@ -137,9 +133,7 @@ const Summary = ({ experiment, refetch }: SummaryProps) => {
       <h2 className="h5 mb-3">Audience</h2>
       <TableAudience {...{ experiment }} />
 
-      <h2 className="h5 mb-3" data-testid="branches-section-title">
-        Branches ({branchCount})
-      </h2>
+      {/* Branches title is inside its table */}
       <TableBranches {...{ experiment }} />
     </div>
   );


### PR DESCRIPTION
fixes #4959

Because:
* It's more convenient for users to have these filled out by default
* The branches table shouldn't display info until users have saved a branch, which requires a name

This commit:
* Displays 'control' in the branch 'name' input and 'treatment' in the first reference branch if experiment branch details have not already been saved
* Displays custom NotSet copy in TableBranches if at least one branch name hasn't been set
* Moves some logic out of Summary into TableBranches
* Adds extra space at the bottom of the Summary component for readability
* Removes 'New' from 'New treatment X' when new treatment branches are added

We can't just add `value="whatever"` in the input because it has to go through `react-hook-form` as a default value.

===

[note: no longer applicable, but leaving this note since there were some comments in response to it]
I'm opening this as a draft before adding a new Storybook state and test to make sure we want to do this client-side. Is it confusing to users if they see "control" and "treatment" filled out already, when if they go to the Summary page, they're shown as "not set"? I feel perhaps this is fine since they have to fill out branch descriptions and when they click "save" the branches will _actually_ have their names set, but I wonder if it's preferable to set the names when an experiment is created, though maybe we want the experiment data in the BE to be "empty" until a user has actually saved it.

![branches-default](https://user-images.githubusercontent.com/13018240/115053178-7504b500-9ea4-11eb-80c5-11f6ffbbc368.gif)

===

[update]
I spoke with Kate and Ana to confirm this direction and this copy.

**Please feel free to push to this branch and/or merge this PR since I'm out next week!** Or, leave it and I'll get to it on 4/26.
