### PR TITLE
chore(nimbus): Update docs hub URL and add ADR for domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Experimenter is a platform for managing experiments in [Mozilla Firefox](https:/
 
 ## Important Links
 
-Check out the [🌩 **Nimbus Documentation Hub**](https://mozilla.github.io/experimenter-docs/) or go to [the repository](https://github.com/mozilla/experimenter-docs/) that house those docs.
+Check out the [🌩 **Nimbus Documentation Hub**](https://experimenter.info) or go to [the repository](https://github.com/mozilla/experimenter-docs/) that house those docs.
 
 | Link            | Prod                                                  | Staging                                                            | Local Dev (Default)                           |
 | --------------- | ----------------------------------------------------- | ------------------------------------------------------------------ | --------------------------------------------- |

--- a/app/experimenter/docs/adrs/0007-doc-hub-url.md
+++ b/app/experimenter/docs/adrs/0007-doc-hub-url.md
@@ -1,0 +1,24 @@
+# "Docs Hub" URL
+
+- Status: **accepted**
+- Deciders: Kate Hudson, with input from Jared Lockhart, Lauren Zugai, Tim Smith, Les Orchard, Jody Heavener, Mark Reid
+
+- Date: 2021-04-16
+
+## Context and Problem Statement
+
+We'd like to have a permanent URL for the experimenter docs hub that is:
+
+- Memorable
+- Stable
+- Ideally, part of the rest of our data information architecture
+
+## Considered Options
+
+- Use the github.io URL
+- Use a data.mozilla.org URL
+- Use a custom domain (experimenter.info)
+
+## Decision Outcome
+
+We will use a custom domain for now (experimenter.info) until a decision is made on the general organization of data.mozilla.org in the future, at which time we will update the URL to fit in with the rest of our data documentation.

--- a/app/experimenter/nimbus-ui/src/components/PageHome/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageHome/index.tsx
@@ -84,7 +84,7 @@ const PageHome: React.FunctionComponent<PageHomeProps> = () => {
           📖
         </span>{" "}
         Not sure where to start? Check out the{" "}
-        <LinkExternal href="https://mozilla.github.io/experimenter-docs/">
+        <LinkExternal href="https://experimenter.info">
           Experimenter documentation hub
         </LinkExternal>
         .


### PR DESCRIPTION
See also https://github.com/mozilla/experimenter-docs/pull/36, which needs to be merged first

Because

* We are updating docs hub URL to a custom domain

This commit

* Updates the link on the front page to point to experimenter.info
* Adds an ADR describing the decision