### PR TITLE
fixes #4940 feat(nimbus): wire up end review request flow

### DIFF
--- a/app/experimenter/kinto/tasks.py
+++ b/app/experimenter/kinto/tasks.py
@@ -124,7 +124,7 @@ def handle_rejection(application, kinto_client):
         generate_nimbus_changelog(
             experiment,
             get_kinto_user(),
-            message=f'Rejected: {collection_data["last_reviewer_comment"]}',
+            message=collection_data["last_reviewer_comment"],
         )
 
         logger.info(f"{experiment} rejected")

--- a/app/experimenter/kinto/tasks.py
+++ b/app/experimenter/kinto/tasks.py
@@ -221,6 +221,8 @@ def nimbus_end_experiment_in_kinto(experiment_id):
         experiment.publish_status = NimbusExperiment.PublishStatus.WAITING
         experiment.save()
 
+        generate_nimbus_changelog(experiment, get_kinto_user())
+
         logger.info(f"{experiment.slug} deleted from Kinto")
         metrics.incr("end_experiment_in_kinto.completed")
     except Exception as e:

--- a/app/experimenter/kinto/tests/test_tasks.py
+++ b/app/experimenter/kinto/tests/test_tasks.py
@@ -535,6 +535,12 @@ class TestEndExperimentInKinto(MockKintoClientMixin, TestCase):
         self.assertEqual(
             experiment.publish_status, NimbusExperiment.PublishStatus.WAITING
         )
+        self.assertTrue(
+            experiment.changes.filter(
+                old_publish_status=NimbusExperiment.PublishStatus.APPROVED,
+                new_publish_status=NimbusExperiment.PublishStatus.WAITING,
+            ).exists()
+        )
 
 
 class TestCheckExperimentIsLive(MockKintoClientMixin, TestCase):

--- a/app/experimenter/nimbus-ui/src/components/PageSummary/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageSummary/index.tsx
@@ -19,7 +19,9 @@ const PageSummary: React.FunctionComponent<PageRequestReviewProps> = ({
     {...{ polling }}
     analysisRequiredInSidebar
   >
-    {({ experiment }) => <Summary {...{ experiment }} />}
+    {({ experiment, review: { refetch } }) => (
+      <Summary {...{ experiment, refetch }} />
+    )}
   </AppLayoutWithExperiment>
 );
 

--- a/app/experimenter/nimbus-ui/src/components/Summary/EndExperiment/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/EndExperiment/index.stories.tsx
@@ -2,41 +2,18 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { storiesOf } from "@storybook/react";
+import { action } from "@storybook/addon-actions";
 import React from "react";
-import EndExperiment from ".";
-import { UPDATE_EXPERIMENT_MUTATION } from "../../../gql/experiments";
-import { getStatus } from "../../../lib/experiment";
-import {
-  MockedCache,
-  mockExperimentMutation,
-  mockExperimentQuery,
-} from "../../../lib/mocks";
-import { NimbusExperimentStatus } from "../../../types/globalTypes";
+import { Subject } from "./mocks";
 
-storiesOf("components/Summary/EndExperiment", module)
-  .add("status: live", () => <Subject />)
-  .add("status: ending", () => <Subject ending />);
-
-const Subject = ({ ending = false }: { ending?: boolean }) => {
-  const { experiment } = mockExperimentQuery("demo-slug", {
-    status: NimbusExperimentStatus.LIVE,
-    isEndRequested: ending,
-  });
-  const experimentStatus = getStatus(experiment);
-  const mutationMock = mockExperimentMutation(
-    UPDATE_EXPERIMENT_MUTATION,
-    {
-      id: experiment.id!,
-    },
-    "endExperiment",
-  );
-
-  return (
-    <MockedCache mocks={[mutationMock]}>
-      <div className="container-lg py-5">
-        <EndExperiment {...{ experiment, status: experimentStatus }} />
-      </div>
-    </MockedCache>
-  );
+export default {
+  title: "components/Summary/EndExperiment",
+  component: Subject,
 };
+
+export const canRequestEnd = () => {
+  const onSubmit = action("Confirm request end");
+  return <Subject {...{ onSubmit }} />;
+};
+
+export const loadingDisabled = () => <Subject isLoading={true} />;

--- a/app/experimenter/nimbus-ui/src/components/Summary/EndExperiment/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/EndExperiment/index.tsx
@@ -2,126 +2,62 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { useMutation } from "@apollo/client";
 import React, { useCallback, useState } from "react";
 import { Alert, Button } from "react-bootstrap";
-import { UPDATE_EXPERIMENT_MUTATION } from "../../../gql/experiments";
-import { SUBMIT_ERROR } from "../../../lib/constants";
-import { getExperiment_experimentBySlug } from "../../../types/getExperiment";
-import {
-  ExperimentInput,
-  NimbusExperimentPublishStatus,
-  NimbusExperimentStatus,
-} from "../../../types/globalTypes";
-import { updateExperiment_updateExperiment as UpdateExperimentEndResult } from "../../../types/updateExperiment";
 
 const EndExperiment = ({
-  experiment,
+  onSubmit,
+  isLoading,
 }: {
-  experiment: getExperiment_experimentBySlug;
+  isLoading: boolean;
+  onSubmit: () => void;
 }) => {
-  const [submitError, setSubmitError] = useState<string | null>(null);
   const [showEndConfirmation, setShowEndConfirmation] = useState(false);
-  const [endRequested, setEndRequested] = useState(false);
-  const isEnding =
-    (experiment.status === NimbusExperimentStatus.LIVE &&
-      experiment.isEndRequested) ||
-    endRequested;
-
-  const [endExperiment, { loading: endExperimentLoading }] = useMutation<
-    { updateExperiment: UpdateExperimentEndResult },
-    { input: ExperimentInput }
-  >(UPDATE_EXPERIMENT_MUTATION);
 
   const toggleShowEndConfirmation = useCallback(
     () => setShowEndConfirmation(!showEndConfirmation),
     [showEndConfirmation, setShowEndConfirmation],
   );
 
-  const onConfirmEndClicked = useCallback(async () => {
-    try {
-      const result = await endExperiment({
-        variables: {
-          input: {
-            id: experiment.id,
-            isEndRequested: true,
-            publishStatus: NimbusExperimentPublishStatus.APPROVED,
-          },
-        },
-      });
-
-      if (
-        !result.data?.updateExperiment ||
-        result.data.updateExperiment.message !== "success"
-      ) {
-        throw new Error(SUBMIT_ERROR);
-      }
-
-      setEndRequested(true);
-    } catch (error) {
-      setSubmitError(SUBMIT_ERROR);
-    }
-  }, [experiment, endExperiment, setEndRequested]);
-
-  if (submitError) {
-    return (
-      <Alert
-        className="mb-4"
-        variant="warning"
-        data-testid="experiment-end-error"
-      >
-        {submitError}
-      </Alert>
-    );
-  }
-
   return (
     <div className="mb-4" data-testid="experiment-end">
-      {isEnding ? (
-        <Alert variant="secondary" data-testid="experiment-ended-alert">
-          Users will no longer see the experiment once ending is approved in
-          Remote Settings, and is in &quot;Complete&quot; state.
-        </Alert>
-      ) : (
-        <>
-          {showEndConfirmation ? (
-            <Alert variant="secondary" data-testid="end-experiment-alert">
-              <p>
-                Are you sure you want to end your experiment? It will turn off
-                the experiment for all users in production.
-              </p>
+      {showEndConfirmation ? (
+        <Alert variant="secondary" data-testid="end-experiment-alert">
+          <p>
+            Are you sure you want to end your experiment? It will turn off the
+            experiment for all users in production.
+          </p>
 
-              <div>
-                <Button
-                  variant="primary"
-                  onClick={onConfirmEndClicked}
-                  disabled={endExperimentLoading}
-                  data-testid="end-experiment-confirm"
-                >
-                  Yes, end the experiment
-                </Button>
-
-                <Button
-                  variant="secondary"
-                  className="ml-2"
-                  onClick={toggleShowEndConfirmation}
-                  disabled={endExperimentLoading}
-                  data-testid="end-experiment-cancel"
-                >
-                  Cancel
-                </Button>
-              </div>
-            </Alert>
-          ) : (
+          <div>
             <Button
               variant="primary"
-              onClick={toggleShowEndConfirmation}
-              data-testid="end-experiment-start"
+              onClick={onSubmit}
+              disabled={isLoading}
+              data-testid="end-experiment-confirm"
             >
-              End Experiment
+              Yes, end the experiment
             </Button>
-          )}
-        </>
+
+            <Button
+              variant="secondary"
+              className="ml-2"
+              onClick={toggleShowEndConfirmation}
+              disabled={isLoading}
+              data-testid="end-experiment-cancel"
+            >
+              Cancel
+            </Button>
+          </div>
+        </Alert>
+      ) : (
+        <Button
+          variant="primary"
+          onClick={toggleShowEndConfirmation}
+          disabled={isLoading}
+          data-testid="end-experiment-start"
+        >
+          End Experiment
+        </Button>
       )}
     </div>
   );

--- a/app/experimenter/nimbus-ui/src/components/Summary/EndExperiment/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/EndExperiment/mocks.tsx
@@ -1,0 +1,26 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from "react";
+import EndExperiment from ".";
+import { mockExperimentQuery } from "../../../lib/mocks";
+import { getExperiment } from "../../../types/getExperiment";
+import { NimbusExperimentStatus } from "../../../types/globalTypes";
+
+export const Subject = ({
+  experiment: overrides = {},
+  isLoading = false,
+  onSubmit = () => {},
+}: {
+  experiment?: Partial<getExperiment["experimentBySlug"]>;
+  isLoading?: boolean;
+  onSubmit?: () => void;
+}) => {
+  const { experiment } = mockExperimentQuery("demo-slug", {
+    status: NimbusExperimentStatus.LIVE,
+    ...overrides,
+  });
+
+  return <EndExperiment {...{ experiment, isLoading, onSubmit }} />;
+};

--- a/app/experimenter/nimbus-ui/src/components/Summary/SummaryTimeline/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/SummaryTimeline/index.tsx
@@ -55,7 +55,7 @@ const StartEnd = ({
   computedEndDate: string | null;
 }) => (
   <div className="d-flex">
-    {status.draft || status.review || status.preview || status.waiting ? (
+    {status.draft || status.preview ? (
       <span className="flex-fill" data-testid="label-not-launched">
         Not yet launched
       </span>

--- a/app/experimenter/nimbus-ui/src/components/Summary/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/index.test.tsx
@@ -2,17 +2,19 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import React from "react";
-import Summary from ".";
-import { MockedCache, mockExperimentQuery } from "../../lib/mocks";
-import { getExperiment_experimentBySlug } from "../../types/getExperiment";
-import { NimbusExperimentStatus } from "../../types/globalTypes";
+import { SUBMIT_ERROR } from "../../lib/constants";
+import { mockExperimentQuery, MOCK_CONFIG } from "../../lib/mocks";
+import {
+  NimbusExperimentPublishStatus,
+  NimbusExperimentStatus,
+} from "../../types/globalTypes";
+import { createMutationMock, reviewRequestedBaseProps, Subject } from "./mocks";
 
 describe("Summary", () => {
   it("renders expected components", () => {
-    const { experiment } = mockExperimentQuery("demo-slug");
-    render(<Subject {...{ experiment }} />);
+    render(<Subject />);
     expect(screen.getByTestId("summary-timeline")).toBeInTheDocument();
     expect(screen.queryByTestId("experiment-end")).not.toBeInTheDocument();
     expect(screen.getByTestId("table-summary")).toBeInTheDocument();
@@ -23,48 +25,47 @@ describe("Summary", () => {
     );
   });
 
-  it("renders end experiment component if experiment is live", async () => {
-    const { experiment } = mockExperimentQuery("demo-slug", {
-      status: NimbusExperimentStatus.LIVE,
-    });
-    render(<Subject {...{ experiment }} />);
-    await screen.findByTestId("experiment-end");
-  });
-
   it("renders end experiment badge if end is requested", async () => {
-    const { experiment } = mockExperimentQuery("demo-slug", {
-      status: NimbusExperimentStatus.LIVE,
-      isEndRequested: true,
-    });
-    render(<Subject {...{ experiment }} />);
+    render(
+      <Subject
+        props={{
+          status: NimbusExperimentStatus.LIVE,
+          isEndRequested: true,
+        }}
+      />,
+    );
     await screen.findByTestId("pill-end-requested");
   });
 
-  it("renders end experiment badge if enrollment is not paused", async () => {
-    const { experiment } = mockExperimentQuery("demo-slug", {
-      status: NimbusExperimentStatus.LIVE,
-      isEnrollmentPaused: false,
-    });
-    render(<Subject {...{ experiment }} />);
+  it("renders enrollment active badge if enrollment is not paused", async () => {
+    render(
+      <Subject
+        props={{
+          status: NimbusExperimentStatus.LIVE,
+          isEnrollmentPaused: false,
+        }}
+      />,
+    );
     await screen.findByTestId("pill-enrolling-active");
   });
 
-  it("renders end experiment badge if enrollment is not paused", async () => {
-    const { experiment } = mockExperimentQuery("demo-slug", {
-      status: NimbusExperimentStatus.LIVE,
-      isEnrollmentPaused: true,
-      enrollmentEndDate: new Date().toISOString(),
-    });
-    render(<Subject {...{ experiment }} />);
+  it("renders enrollment complete badge if enrollment is not paused", async () => {
+    render(
+      <Subject
+        props={{
+          status: NimbusExperimentStatus.LIVE,
+          isEnrollmentPaused: true,
+          enrollmentEndDate: new Date().toISOString(),
+        }}
+      />,
+    );
     await screen.findByTestId("pill-enrolling-complete");
   });
 
   it("renders as expected with no defined branches", () => {
-    const { experiment } = mockExperimentQuery("demo-slug");
     render(
       <Subject
-        experiment={{
-          ...experiment,
+        props={{
           referenceBranch: null,
           treatmentBranches: null,
         }}
@@ -78,10 +79,7 @@ describe("Summary", () => {
 
   describe("JSON representation link", () => {
     function renderWithStatus(status: NimbusExperimentStatus) {
-      const { experiment } = mockExperimentQuery("demo-slug", {
-        status,
-      });
-      render(<Subject {...{ experiment }} />);
+      render(<Subject props={{ status }} />);
     }
     it("renders with the correct API link", () => {
       renderWithStatus(NimbusExperimentStatus.LIVE);
@@ -108,14 +106,126 @@ describe("Summary", () => {
       expect(screen.queryByTestId("link-json")).not.toBeInTheDocument();
     });
   });
-});
 
-const Subject = ({
-  experiment,
-}: {
-  experiment: getExperiment_experimentBySlug;
-}) => (
-  <MockedCache>
-    <Summary {...{ experiment }} />
-  </MockedCache>
-);
+  describe("ending an experiment", () => {
+    const origWindowOpen = global.window.open;
+    let mockWindowOpen: any;
+
+    beforeEach(() => {
+      mockWindowOpen = jest.fn();
+      global.window.open = mockWindowOpen;
+    });
+
+    afterEach(() => {
+      global.window.open = origWindowOpen;
+    });
+
+    it("can mark the experiment as requesting review on end confirmation", async () => {
+      const refetch = jest.fn();
+      const { experiment } = mockExperimentQuery("demo-slug", {
+        status: NimbusExperimentStatus.LIVE,
+      });
+      const mutationMock = createMutationMock(
+        experiment.id!,
+        NimbusExperimentPublishStatus.REVIEW,
+      );
+      render(
+        <Subject props={experiment} mocks={[mutationMock]} {...{ refetch }} />,
+      );
+      fireEvent.click(screen.getByTestId("end-experiment-start"));
+      await screen.findByTestId("end-experiment-alert");
+      fireEvent.click(screen.getByTestId("end-experiment-confirm"));
+      await waitFor(() => {
+        expect(refetch).toHaveBeenCalled();
+        expect(screen.queryByTestId("submit-error")).not.toBeInTheDocument();
+      });
+    });
+
+    it("handles submission with server API error", async () => {
+      const { experiment } = mockExperimentQuery("demo-slug", {
+        status: NimbusExperimentStatus.LIVE,
+      });
+      const mutationMock = createMutationMock(
+        experiment.id!,
+        NimbusExperimentPublishStatus.REVIEW,
+      );
+      mutationMock.result.errors = [new Error("Boo")];
+      render(<Subject props={experiment} mocks={[mutationMock]} />);
+      fireEvent.click(screen.getByTestId("end-experiment-start"));
+      await screen.findByTestId("end-experiment-alert");
+      fireEvent.click(screen.getByTestId("end-experiment-confirm"));
+      const errorContainer = await screen.findByTestId("submit-error");
+      expect(errorContainer).toHaveTextContent(SUBMIT_ERROR);
+    });
+
+    it("handles submission with server-side validation errors", async () => {
+      const { experiment } = mockExperimentQuery("demo-slug", {
+        status: NimbusExperimentStatus.LIVE,
+      });
+      const mutationMock = createMutationMock(
+        experiment.id!,
+        NimbusExperimentPublishStatus.REVIEW,
+      );
+      const errorMessage = "Something went very wrong.";
+      mutationMock.result.data.updateExperiment.message = {
+        status: [errorMessage],
+      };
+      render(<Subject props={experiment} mocks={[mutationMock]} />);
+      fireEvent.click(screen.getByTestId("end-experiment-start"));
+      await screen.findByTestId("end-experiment-alert");
+      fireEvent.click(screen.getByTestId("end-experiment-confirm"));
+      const errorContainer = await screen.findByTestId("submit-error");
+      expect(errorContainer).toHaveTextContent(errorMessage);
+    });
+
+    it("handles approval of end as expected", async () => {
+      const { experiment } = mockExperimentQuery("demo-slug", {
+        ...reviewRequestedBaseProps,
+        canReview: true,
+      });
+      const mutationMock = createMutationMock(
+        experiment.id!,
+        NimbusExperimentPublishStatus.APPROVED,
+      );
+      render(<Subject props={experiment} mocks={[mutationMock]} />);
+      const approveButton = await screen.findByTestId("approve-request");
+      fireEvent.click(approveButton);
+      const openRemoteSettingsButton = await screen.findByTestId(
+        "open-remote-settings",
+      );
+      fireEvent.click(openRemoteSettingsButton);
+      await waitFor(() => {
+        expect(mockWindowOpen).toHaveBeenCalledWith(
+          MOCK_CONFIG.kintoAdminUrl,
+          "_blank",
+        );
+      });
+    });
+
+    it("handles rejection of end as expected", async () => {
+      const expectedReason = "This smells bad.";
+      const { experiment } = mockExperimentQuery("demo-slug", {
+        ...reviewRequestedBaseProps,
+        canReview: true,
+      });
+      const mutationMock = createMutationMock(
+        experiment.id!,
+        NimbusExperimentPublishStatus.IDLE,
+        { changelogMessage: expectedReason },
+      );
+      render(<Subject props={experiment} mocks={[mutationMock]} />);
+      const rejectButton = await screen.findByTestId("reject-request");
+      fireEvent.click(rejectButton);
+      const rejectSubmitButton = await screen.findByTestId("reject-submit");
+      const rejectReasonField = await screen.findByTestId("reject-reason");
+      fireEvent.change(rejectReasonField, {
+        target: { value: expectedReason },
+      });
+      fireEvent.blur(rejectReasonField);
+      fireEvent.click(rejectSubmitButton);
+      await waitFor(() =>
+        expect(screen.queryByTestId("submit-error")).not.toBeInTheDocument(),
+      );
+    });
+  });
+});

--- a/app/experimenter/nimbus-ui/src/components/Summary/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/index.tsx
@@ -2,22 +2,15 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { useMutation } from "@apollo/client";
-import React, { useMemo, useState } from "react";
+import React, { useRef } from "react";
 import Alert from "react-bootstrap/Alert";
 import Badge from "react-bootstrap/Badge";
-import { UPDATE_EXPERIMENT_MUTATION } from "../../gql/experiments";
-import { useConfig } from "../../hooks";
+import { useChangeOperationMutation, useConfig } from "../../hooks";
 import { ReactComponent as ExternalIcon } from "../../images/external.svg";
-import { SUBMIT_ERROR } from "../../lib/constants";
 import { getStatus } from "../../lib/experiment";
 import { ConfigOptions, getConfigLabel } from "../../lib/getConfigLabel";
 import { getExperiment_experimentBySlug } from "../../types/getExperiment";
-import {
-  ExperimentInput,
-  NimbusExperimentPublishStatus,
-} from "../../types/globalTypes";
-import { updateExperiment_updateExperiment as UpdateExperiment } from "../../types/updateExperiment";
+import { NimbusExperimentPublishStatus } from "../../types/globalTypes";
 import ChangeApprovalOperations from "../ChangeApprovalOperations";
 import LinkExternal from "../LinkExternal";
 import LinkMonitoring from "../LinkMonitoring";
@@ -35,12 +28,18 @@ type SummaryProps = {
 
 const Summary = ({ experiment, refetch }: SummaryProps) => {
   const { kintoAdminUrl } = useConfig();
-  const [submitError, setSubmitError] = useState<string | null>(null);
   const status = getStatus(experiment);
   const branchCount = [
     experiment.referenceBranch,
     ...(experiment.treatmentBranches || []),
   ].filter((branch) => !!branch).length;
+
+  // TODO: PageRequestReview assigns the experiment and refetch values to refs,
+  // and since this component shares the same useChangeOperationMutation hook
+  // it also needs to pass its experiment/refetch values into refs. Ideally
+  // neither of these components need to use refs.
+  const currentExperiment = useRef<getExperiment_experimentBySlug>(experiment);
+  const refetchReview = useRef<(() => void) | undefined>(refetch);
 
   const {
     publishStatus,
@@ -54,69 +53,27 @@ const Summary = ({ experiment, refetch }: SummaryProps) => {
     window.open(kintoAdminUrl!, "_blank");
   };
 
-  const [updateExperiment, { loading: isLoading }] = useMutation<
-    { updateExperiment: UpdateExperiment },
-    { input: ExperimentInput }
-  >(UPDATE_EXPERIMENT_MUTATION);
-
-  // Set up our collection of status change handlers for review actions
-  const [
-    onConfirmEndClicked,
-    onReviewApprovedClicked,
-    onReviewRejectedClicked,
-  ] = useMemo(
-    () =>
-      [
-        {
-          publishStatus: NimbusExperimentPublishStatus.REVIEW,
-        },
-        {
-          isEndRequested: true,
-          publishStatus: NimbusExperimentPublishStatus.APPROVED,
-        },
-        {
-          publishStatus: NimbusExperimentPublishStatus.IDLE,
-        },
-      ].map(
-        (baseDataChanges: Partial<ExperimentInput>) => async (
-          _inputEvent?: any,
-          submitDataChanges?: Partial<ExperimentInput>,
-        ) => {
-          try {
-            setSubmitError(null);
-
-            const result = await updateExperiment({
-              variables: {
-                input: {
-                  id: experiment.id,
-                  ...baseDataChanges,
-                  ...submitDataChanges,
-                },
-              },
-            });
-
-            // istanbul ignore next - can't figure out how to trigger this in a test
-            if (!result.data?.updateExperiment) {
-              throw new Error(SUBMIT_ERROR);
-            }
-
-            const { message } = result.data.updateExperiment;
-
-            if (
-              message &&
-              message !== "success" &&
-              typeof message === "object"
-            ) {
-              return void setSubmitError(message.status.join(", "));
-            }
-
-            refetch!();
-          } catch (error) {
-            setSubmitError(SUBMIT_ERROR);
-          }
-        },
-      ),
-    [updateExperiment, experiment, refetch],
+  const {
+    isLoading,
+    submitError,
+    callbacks: [
+      onConfirmEndClicked,
+      onReviewApprovedClicked,
+      onReviewRejectedClicked,
+    ],
+  } = useChangeOperationMutation(
+    currentExperiment,
+    refetchReview,
+    {
+      publishStatus: NimbusExperimentPublishStatus.REVIEW,
+    },
+    {
+      isEndRequested: true,
+      publishStatus: NimbusExperimentPublishStatus.APPROVED,
+    },
+    {
+      publishStatus: NimbusExperimentPublishStatus.IDLE,
+    },
   );
 
   return (

--- a/app/experimenter/nimbus-ui/src/components/Summary/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/index.tsx
@@ -2,13 +2,22 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from "react";
+import { useMutation } from "@apollo/client";
+import React, { useMemo, useState } from "react";
+import Alert from "react-bootstrap/Alert";
 import Badge from "react-bootstrap/Badge";
-import { useFakeMutation } from "../../hooks";
+import { UPDATE_EXPERIMENT_MUTATION } from "../../gql/experiments";
+import { useConfig } from "../../hooks";
 import { ReactComponent as ExternalIcon } from "../../images/external.svg";
+import { SUBMIT_ERROR } from "../../lib/constants";
 import { getStatus } from "../../lib/experiment";
 import { ConfigOptions, getConfigLabel } from "../../lib/getConfigLabel";
 import { getExperiment_experimentBySlug } from "../../types/getExperiment";
+import {
+  ExperimentInput,
+  NimbusExperimentPublishStatus,
+} from "../../types/globalTypes";
+import { updateExperiment_updateExperiment as UpdateExperiment } from "../../types/updateExperiment";
 import ChangeApprovalOperations from "../ChangeApprovalOperations";
 import LinkExternal from "../LinkExternal";
 import LinkMonitoring from "../LinkMonitoring";
@@ -21,51 +30,94 @@ import TableSummary from "./TableSummary";
 
 type SummaryProps = {
   experiment: getExperiment_experimentBySlug;
+  refetch?: () => void;
 } & Partial<React.ComponentProps<typeof ChangeApprovalOperations>>; // TODO EXP-1143: temporary page-level props, should be replaced by API data for experiment & current user
 
-const Summary = ({
-  experiment,
-  /* istanbul ignore next until EXP-1143 & EXP-1144 done */
-  canReview = false,
-  /* istanbul ignore next until EXP-1143 & EXP-1144 done */
-  reviewRequestEvent,
-  /* istanbul ignore next until EXP-1143 & EXP-1144 done */
-  rejectionEvent,
-  /* istanbul ignore next until EXP-1143 & EXP-1144 done */
-  timeoutEvent,
-}: SummaryProps) => {
+const Summary = ({ experiment, refetch }: SummaryProps) => {
+  const { kintoAdminUrl } = useConfig();
+  const [submitError, setSubmitError] = useState<string | null>(null);
   const status = getStatus(experiment);
   const branchCount = [
     experiment.referenceBranch,
     ...(experiment.treatmentBranches || []),
   ].filter((branch) => !!branch).length;
 
-  /* istanbul ignore next until EXP-1143 & EXP-1144 done */
+  const {
+    publishStatus,
+    canReview,
+    reviewRequest: reviewRequestEvent,
+    rejection: rejectionEvent,
+    timeout: timeoutEvent,
+  } = experiment;
+
+  const startRemoteSettingsApproval = async () => {
+    window.open(kintoAdminUrl!, "_blank");
+  };
+
+  const [updateExperiment, { loading: isLoading }] = useMutation<
+    { updateExperiment: UpdateExperiment },
+    { input: ExperimentInput }
+  >(UPDATE_EXPERIMENT_MUTATION);
+
+  // Set up our collection of status change handlers for review actions
   const [
-    rejectExperimentEnd,
-    { loading: rejectExperimentEndLoading },
-  ] = useFakeMutation();
+    onConfirmEndClicked,
+    onReviewApprovedClicked,
+    onReviewRejectedClicked,
+  ] = useMemo(
+    () =>
+      [
+        {
+          publishStatus: NimbusExperimentPublishStatus.REVIEW,
+        },
+        {
+          isEndRequested: true,
+          publishStatus: NimbusExperimentPublishStatus.APPROVED,
+        },
+        {
+          publishStatus: NimbusExperimentPublishStatus.IDLE,
+        },
+      ].map(
+        (baseDataChanges: Partial<ExperimentInput>) => async (
+          _inputEvent?: any,
+          submitDataChanges?: Partial<ExperimentInput>,
+        ) => {
+          try {
+            setSubmitError(null);
 
-  /* istanbul ignore next until EXP-1143 & EXP-1144 done */
-  const [
-    approveExperimentEnd,
-    { loading: approveExperimentEndLoading },
-  ] = useFakeMutation();
+            const result = await updateExperiment({
+              variables: {
+                input: {
+                  id: experiment.id,
+                  ...baseDataChanges,
+                  ...submitDataChanges,
+                },
+              },
+            });
 
-  /* istanbul ignore next until EXP-1143 & EXP-1144 done */
-  const [
-    startRemoteSettingsApproval,
-    { loading: startRemoteSettingsApprovalLoading },
-  ] = useFakeMutation();
+            // istanbul ignore next - can't figure out how to trigger this in a test
+            if (!result.data?.updateExperiment) {
+              throw new Error(SUBMIT_ERROR);
+            }
 
-  // TODO: EXP-1144 wrap these new mutations in setSubmitError handling like updateExperiment uses below.
+            const { message } = result.data.updateExperiment;
 
-  const isLoading =
-    approveExperimentEndLoading ||
-    rejectExperimentEndLoading ||
-    startRemoteSettingsApprovalLoading;
+            if (
+              message &&
+              message !== "success" &&
+              typeof message === "object"
+            ) {
+              return void setSubmitError(message.status.join(", "));
+            }
 
-  const { publishStatus } = experiment;
+            refetch!();
+          } catch (error) {
+            setSubmitError(SUBMIT_ERROR);
+          }
+        },
+      ),
+    [updateExperiment, experiment, refetch],
+  );
 
   return (
     <div data-testid="summary">
@@ -76,22 +128,30 @@ const Summary = ({
 
       <SummaryTimeline {...{ experiment }} />
 
+      {submitError && (
+        <Alert data-testid="submit-error" variant="warning">
+          {submitError}
+        </Alert>
+      )}
+
       {status.live && (
         <ChangeApprovalOperations
           {...{
             actionDescription: "end",
             isLoading,
             publishStatus,
-            canReview,
+            canReview: !!canReview,
             reviewRequestEvent,
             rejectionEvent,
             timeoutEvent,
-            rejectChange: rejectExperimentEnd,
-            approveChange: approveExperimentEnd,
+            rejectChange: onReviewRejectedClicked,
+            approveChange: onReviewApprovedClicked,
             startRemoteSettingsApproval,
           }}
         >
-          <EndExperiment {...{ experiment }} />
+          {!experiment.isEndRequested && (
+            <EndExperiment {...{ isLoading, onSubmit: onConfirmEndClicked }} />
+          )}
         </ChangeApprovalOperations>
       )}
 

--- a/app/experimenter/nimbus-ui/src/components/Summary/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/mocks.tsx
@@ -1,0 +1,91 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { MockedResponse } from "@apollo/client/testing";
+import React from "react";
+import Summary from ".";
+import { UPDATE_EXPERIMENT_MUTATION } from "../../gql/experiments";
+import {
+  mockChangelog,
+  mockExperimentMutation,
+  mockExperimentQuery,
+} from "../../lib/mocks";
+import { RouterSlugProvider } from "../../lib/test-utils";
+import { getExperiment_experimentBySlug } from "../../types/getExperiment";
+import {
+  NimbusExperimentPublishStatus,
+  NimbusExperimentStatus,
+} from "../../types/globalTypes";
+import AppLayout from "../AppLayout";
+
+export function createMutationMock(
+  id: number,
+  publishStatus: NimbusExperimentPublishStatus,
+  additionalProps: Record<string, any> = {},
+) {
+  return mockExperimentMutation(
+    UPDATE_EXPERIMENT_MUTATION,
+    {
+      id,
+      publishStatus,
+      ...additionalProps,
+    },
+    "updateExperiment",
+    {
+      experiment: {
+        publishStatus,
+        ...additionalProps,
+      },
+    },
+  );
+}
+
+export const Subject = ({
+  props = {},
+  mocks = [],
+  refetch = () => {},
+}: {
+  props?: Partial<getExperiment_experimentBySlug | null>;
+  mocks?: MockedResponse<Record<string, any>>[];
+  refetch?: () => void;
+}) => {
+  const { experiment, mock } = mockExperimentQuery("demo-slug", props);
+
+  return (
+    <AppLayout>
+      <RouterSlugProvider mocks={[mock, ...mocks]}>
+        <Summary {...{ experiment, refetch }} />
+      </RouterSlugProvider>
+    </AppLayout>
+  );
+};
+
+export const reviewRequestedBaseProps = {
+  status: NimbusExperimentStatus.LIVE,
+  publishStatus: NimbusExperimentPublishStatus.REVIEW,
+  isEndRequested: true,
+  canReview: false,
+  reviewRequest: mockChangelog(),
+};
+
+export const reviewPendingBaseProps = {
+  status: NimbusExperimentStatus.LIVE,
+  publishStatus: NimbusExperimentPublishStatus.WAITING,
+  isEndRequested: true,
+  reviewRequest: mockChangelog(),
+};
+
+export const reviewTimedoutBaseProps = {
+  status: NimbusExperimentStatus.LIVE,
+  publishStatus: NimbusExperimentPublishStatus.REVIEW,
+  reviewRequest: mockChangelog(),
+  timeout: mockChangelog("def@mozilla.com"),
+};
+
+export const reviewRejectedBaseProps = {
+  status: NimbusExperimentStatus.LIVE,
+  publishStatus: NimbusExperimentPublishStatus.IDLE,
+  reviewRequest: mockChangelog(),
+  rejection: mockChangelog("def@mozilla.com", "It's bad. Just start over."),
+};

--- a/app/experimenter/nimbus-ui/src/hooks/index.ts
+++ b/app/experimenter/nimbus-ui/src/hooks/index.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 export * from "./useAnalysis";
+export * from "./useChangeOperationMutation";
 export * from "./useCommonForm";
 export * from "./useCommonForm/useCommonNestedForm";
 export * from "./useCommonForm/useForm";

--- a/app/experimenter/nimbus-ui/src/hooks/useChangeOperationMutation.test.tsx
+++ b/app/experimenter/nimbus-ui/src/hooks/useChangeOperationMutation.test.tsx
@@ -1,0 +1,113 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { MockedResponse } from "@apollo/client/testing";
+import { waitFor } from "@testing-library/dom";
+import { act, renderHook } from "@testing-library/react-hooks";
+import React, { useRef } from "react";
+import { UPDATE_EXPERIMENT_MUTATION } from "../gql/experiments";
+import {
+  MockedCache,
+  mockExperiment,
+  mockExperimentMutation,
+} from "../lib/mocks";
+import { getExperiment_experimentBySlug as Experiment } from "../types/getExperiment";
+import {
+  NimbusExperimentPublishStatus,
+  NimbusExperimentStatus,
+} from "../types/globalTypes";
+import { useChangeOperationMutation } from "./useChangeOperationMutation";
+
+describe("hooks/useChangeOperationMutation", () => {
+  it("can successfully execute mutation set callbacks", async () => {
+    const { callbacks, submitError } = setupTestHook();
+
+    for (const callback of callbacks) {
+      await act(async () => void callback());
+      await waitFor(() => expect(submitError).toBeNull());
+    }
+  });
+
+  it("indicates when loading", async () => {
+    const {
+      isLoading,
+      callbacks: [callback],
+    } = setupTestHook();
+    expect(isLoading).toBeFalsy();
+    await act(async () => void callback());
+    waitFor(() => expect(isLoading).toBeTruthy());
+  });
+});
+
+const setupTestHook = (customMocks: MockedResponse[] = []) => {
+  const { experiment, refetch } = setupRefArgs();
+  const mutationSets = [
+    {
+      isEndRequested: true,
+      publishStatus: NimbusExperimentPublishStatus.APPROVED,
+    },
+    {
+      status: NimbusExperimentStatus.LIVE,
+    },
+    {
+      status: NimbusExperimentStatus.DRAFT,
+      publishStatus: NimbusExperimentPublishStatus.APPROVED,
+    },
+  ];
+
+  const mocks = customMocks.length
+    ? customMocks
+    : mutationSets.reduce<MockedResponse[]>((acc, cur) => {
+        return acc.concat(
+          mockExperimentMutation(
+            UPDATE_EXPERIMENT_MUTATION,
+            {
+              id: experiment.current.id,
+              ...cur,
+            },
+            "updateExperiment",
+            {
+              experiment: {
+                ...cur,
+              },
+            },
+          ),
+        );
+      }, []);
+
+  const {
+    result: {
+      current: { isLoading, submitError, callbacks },
+    },
+  } = renderHook(
+    () => useChangeOperationMutation(experiment, refetch, ...mutationSets),
+    {
+      wrapper,
+      initialProps: { mocks },
+    },
+  );
+
+  return { isLoading, submitError, callbacks, mutationSets, refetch };
+};
+
+const setupRefArgs = () => {
+  const {
+    result: { current: experiment },
+  } = renderHook(() => useRef<Experiment>(mockExperiment()));
+  const {
+    result: { current: refetch },
+  } = renderHook(() => useRef<() => void>(jest.fn()));
+
+  return { experiment, refetch };
+};
+
+const wrapper = ({
+  mocks = [],
+  children,
+}: {
+  mocks?: MockedResponse[];
+  children?: React.ReactNode;
+}) => (
+  <MockedCache {...{ mocks }}>{children as React.ReactElement}</MockedCache>
+);

--- a/app/experimenter/nimbus-ui/src/hooks/useChangeOperationMutation.tsx
+++ b/app/experimenter/nimbus-ui/src/hooks/useChangeOperationMutation.tsx
@@ -1,0 +1,70 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { useMutation } from "@apollo/client";
+import { useMemo, useState } from "react";
+import { UPDATE_EXPERIMENT_MUTATION } from "../gql/experiments";
+import { SUBMIT_ERROR } from "../lib/constants";
+import { getExperiment_experimentBySlug as Experiment } from "../types/getExperiment";
+import { ExperimentInput } from "../types/globalTypes";
+import { updateExperiment_updateExperiment as UpdateExperiment } from "../types/updateExperiment";
+
+export function useChangeOperationMutation(
+  experiment: React.MutableRefObject<Experiment | undefined>,
+  refetch: React.MutableRefObject<(() => void) | undefined>,
+  ...dataSets: Partial<ExperimentInput>[]
+) {
+  const [submitError, setSubmitError] = useState<string | null>(null);
+
+  const [updateExperiment, { loading: isLoading }] = useMutation<
+    { updateExperiment: UpdateExperiment },
+    { input: ExperimentInput }
+  >(UPDATE_EXPERIMENT_MUTATION);
+
+  const callbacks = useMemo(
+    () =>
+      dataSets.map(
+        (baseDataChanges: Partial<ExperimentInput>) => async (
+          _inputEvent?: any,
+          submitDataChanges?: Partial<ExperimentInput>,
+        ) => {
+          try {
+            setSubmitError(null);
+
+            const result = await updateExperiment({
+              variables: {
+                input: {
+                  id: experiment.current?.id,
+                  ...baseDataChanges,
+                  ...submitDataChanges,
+                },
+              },
+            });
+
+            // istanbul ignore next - can't figure out how to trigger this in a test
+            if (!result.data?.updateExperiment) {
+              throw new Error(SUBMIT_ERROR);
+            }
+
+            const { message } = result.data.updateExperiment;
+
+            if (
+              message &&
+              message !== "success" &&
+              typeof message === "object"
+            ) {
+              return void setSubmitError(message.status.join(", "));
+            }
+
+            refetch.current && refetch.current();
+          } catch (error) {
+            setSubmitError(SUBMIT_ERROR);
+          }
+        },
+      ),
+    [updateExperiment, experiment, refetch, dataSets],
+  );
+
+  return { callbacks, isLoading, submitError };
+}


### PR DESCRIPTION
Closes #4940 

This PR:

- Wires up the End request UI to the new `ChangeApprovalOperations` component, including adding the necessary mutations
- This change also meant gutting a lot of the `EndExperiment` component, so now it only handles the initial request kickoff
- Refactors related Storybook stories into the new ES Module format

Check out some Storybooks:

- [`Summary`](https://storage.googleapis.com/mozilla-storybooks-experimenter/commits/997b5fe1f8ddee8ba8ed0d3f8cc7005a5a2ce78b/nimbus-ui/index.html?path=/story/components-summary--draft-status)
- [`EndExperiment`](https://storage.googleapis.com/mozilla-storybooks-experimenter/commits/997b5fe1f8ddee8ba8ed0d3f8cc7005a5a2ce78b/nimbus-ui/index.html?path=/story/components-summary-endexperiment--can-request-end)