### PR TITLE
fixes #5044 fix(nimbus): enforce review flow order in reported events

### DIFF
--- a/app/experimenter/experiments/tests/api/v5/test_queries.py
+++ b/app/experimenter/experiments/tests/api/v5/test_queries.py
@@ -543,15 +543,17 @@ class TestNimbusQuery(GraphQLTestCase):
         user_email = "user@example.com"
         experiment = NimbusExperimentFactory.create_with_status(
             NimbusExperiment.Status.DRAFT,
-            publish_status=NimbusExperiment.PublishStatus.APPROVED,
+            publish_status=NimbusExperiment.PublishStatus.IDLE,
         )
-        experiment.publish_status = NimbusExperiment.PublishStatus.WAITING
-        experiment.save()
-        generate_nimbus_changelog(experiment, experiment.owner)
-
-        experiment.publish_status = NimbusExperiment.PublishStatus.REVIEW
-        experiment.save()
-        generate_nimbus_changelog(experiment, experiment.owner)
+        for publish_status in (
+            NimbusExperiment.PublishStatus.REVIEW,
+            NimbusExperiment.PublishStatus.APPROVED,
+            NimbusExperiment.PublishStatus.WAITING,
+            NimbusExperiment.PublishStatus.REVIEW,
+        ):
+            experiment.publish_status = publish_status
+            experiment.save()
+            generate_nimbus_changelog(experiment, experiment.owner)
 
         response = self.query(
             """


### PR DESCRIPTION
Because:

* we don't want to report rejections & timeouts for the wrong statuses
  or after retried review cycles

This commit:

* checks to ensure that every reported review flow changelog event
  happens after the previous expected event

* ignores changelog events for review flows not associated with the
  current experiment status