### PR TITLE
fix #5028 feat(nimbus): support rejection during launch/pause/end

### DIFF
--- a/app/experimenter/kinto/client.py
+++ b/app/experimenter/kinto/client.py
@@ -78,19 +78,6 @@ class KintoClient:
         if self.collection_data["status"] == KINTO_REJECTED_STATUS:
             return self.collection_data
 
-    def get_rejected_record(self):
-        main_records = self.kinto_http_client.get_records(
-            bucket=settings.KINTO_BUCKET_MAIN, collection=self.collection
-        )
-
-        workspace_records = self.kinto_http_client.get_records(
-            bucket=settings.KINTO_BUCKET_WORKSPACE, collection=self.collection
-        )
-
-        main_record_ids = [record["id"] for record in main_records]
-        workspace_record_ids = [record["id"] for record in workspace_records]
-        return list(set(workspace_record_ids) - set(main_record_ids))[0]
-
     def rollback_changes(self):
         self.kinto_http_client.patch_collection(
             id=self.collection,

--- a/app/experimenter/kinto/tests/test_client.py
+++ b/app/experimenter/kinto/tests/test_client.py
@@ -137,15 +137,3 @@ class TestKintoClient(MockKintoClientMixin, TestCase):
     def test_returns_rejected_data(self):
         self.setup_kinto_rejected_review()
         self.assertTrue(self.client.get_rejected_collection_data())
-
-    def test_returns_rejected_record(self):
-        self.mock_kinto_client.get_records.side_effect = [
-            [{"id": "bug-12345-rapid-test-release-55"}],
-            [
-                {"id": "bug-12345-rapid-test-release-55"},
-                {"id": "bug-9999-rapid-test-release-55"},
-            ],
-        ]
-        self.assertEqual(
-            self.client.get_rejected_record(), "bug-9999-rapid-test-release-55"
-        )


### PR DESCRIPTION
Because

* We need to be able to handle remote settings rejection at any point during an experiments lifecycle

This commit

* Handles the case of rejection during launch/pause/end
* Pauses can not really be rejected so the rejection is ignored and the pause is resent
* We can't use the collection record diff to determine which record is being rejected so we look for an experiment in WAITING instead
* If no experiment is found in WAITING we roll back the collection and proceed as normal
* Reorganized the tests to cover all cases more clearly