### PR TITLE
fix #4647 bug(nimbus): only send ending emails when experiment is ending

### DIFF
--- a/app/experimenter/kinto/tasks.py
+++ b/app/experimenter/kinto/tasks.py
@@ -289,7 +289,6 @@ def nimbus_check_experiments_are_paused():
 
         for experiment in live_experiments:
             if records[experiment.slug]["isEnrollmentPaused"]:
-                nimbus_send_experiment_ending_email(experiment)
                 logger.info(
                     f"{experiment.slug} is_paused is being updated to True".format(
                         experiment=experiment


### PR DESCRIPTION
Because

* Looks like I made the pause task by copying the end task and accidentally included sending the email at pause time

This commit

* Doesn't send the ending email at pause time