### PR TITLE
fix #5023 chore(nimbus): expose all admin fields

### DIFF
--- a/app/experimenter/experiments/admin/nimbus.py
+++ b/app/experimenter/experiments/admin/nimbus.py
@@ -19,22 +19,11 @@ class NimbusBranchInlineAdmin(admin.StackedInline):
 class NimbusDocumentationLinkInlineAdmin(admin.TabularInline):
     model = NimbusDocumentationLink
     extra = 1
-    fields = ("title", "link")
 
 
-class NimbusExperimentChangeLogInlineAdmin(admin.TabularInline):
+class NimbusExperimentChangeLogInlineAdmin(admin.StackedInline):
     model = NimbusChangeLog
     extra = 1
-
-    fields = (
-        "changed_by",
-        "changed_on",
-        "old_status",
-        "old_publish_status",
-        "new_status",
-        "new_publish_status",
-        "message",
-    )
 
 
 class NimbusExperimentAdminForm(forms.ModelForm):


### PR DESCRIPTION
Because

* We just want to be able to edit the entire nimbus objects from the admin

This commit

* Removes any explicit field lists from nimbus admin