### PR TITLE
fix #5027 feat(nimbus): reorganize kinto tasks to update by collection instead of by application

### DIFF
--- a/app/experimenter/experiments/constants/nimbus.py
+++ b/app/experimenter/experiments/constants/nimbus.py
@@ -114,7 +114,6 @@ class ApplicationConfig:
     app_name: str
     channel_app_id: Dict[str, str]
     default_app_id: str
-    collection: str
     randomization_unit: str
 
 
@@ -128,7 +127,6 @@ APPLICATION_CONFIG_DESKTOP = ApplicationConfig(
         Channel.RELEASE: "firefox-desktop",
     },
     default_app_id="firefox-desktop",
-    collection=settings.KINTO_COLLECTION_NIMBUS_DESKTOP,
     randomization_unit=BucketRandomizationUnit.NORMANDY,
 )
 
@@ -142,7 +140,6 @@ APPLICATION_CONFIG_FENIX = ApplicationConfig(
         Channel.RELEASE: "org.mozilla.firefox",
     },
     default_app_id="",
-    collection=settings.KINTO_COLLECTION_NIMBUS_MOBILE,
     randomization_unit=BucketRandomizationUnit.NIMBUS,
 )
 
@@ -156,7 +153,6 @@ APPLICATION_CONFIG_IOS = ApplicationConfig(
         Channel.RELEASE: "org.mozilla.ios.Firefox",
     },
     default_app_id="",
-    collection=settings.KINTO_COLLECTION_NIMBUS_MOBILE,
     randomization_unit=BucketRandomizationUnit.NIMBUS,
 )
 
@@ -380,3 +376,13 @@ Optional - We believe this outcome will <describe impact> on <core metric>
     # completion for "week 1" of the experiment. However, an extra
     # buffer day is added for Jetstream to compute the results.
     DAYS_UNTIL_ANALYSIS = 8
+
+    KINTO_COLLECTION_APPLICATIONS = {
+        settings.KINTO_COLLECTION_NIMBUS_DESKTOP: [
+            APPLICATION_CONFIG_DESKTOP.slug,
+        ],
+        settings.KINTO_COLLECTION_NIMBUS_MOBILE: [
+            APPLICATION_CONFIG_FENIX.slug,
+            APPLICATION_CONFIG_IOS.slug,
+        ],
+    }

--- a/app/experimenter/experiments/models/nimbus.py
+++ b/app/experimenter/experiments/models/nimbus.py
@@ -43,6 +43,12 @@ class NimbusExperimentManager(models.Manager):
             is_end_requested=True,
         )
 
+    def waiting(self, applications):
+        return self.filter(
+            publish_status=NimbusExperiment.PublishStatus.WAITING,
+            application__in=applications,
+        )
+
     def waiting_to_launch_queue(self):
         return self.filter(
             status=NimbusExperiment.Status.DRAFT,

--- a/app/experimenter/experiments/models/nimbus.py
+++ b/app/experimenter/experiments/models/nimbus.py
@@ -18,28 +18,28 @@ from experimenter.projects.models import Project
 
 
 class NimbusExperimentManager(models.Manager):
-    def launch_queue(self, application):
+    def launch_queue(self, applications):
         return self.filter(
             status=NimbusExperiment.Status.DRAFT,
             publish_status=NimbusExperiment.PublishStatus.APPROVED,
-            application=application,
+            application__in=applications,
         )
 
-    def pause_queue(self, application):
+    def pause_queue(self, applications):
         return self.filter(
             status=NimbusExperiment.Status.LIVE,
             is_paused=False,
-            application=application,
+            application__in=applications,
             id__in=[
                 experiment.id for experiment in self.all() if experiment.should_pause
             ],
         )
 
-    def end_queue(self, application):
+    def end_queue(self, applications):
         return self.filter(
             status=NimbusExperiment.Status.LIVE,
             publish_status=NimbusExperiment.PublishStatus.APPROVED,
-            application=application,
+            application__in=applications,
             is_end_requested=True,
         )
 

--- a/app/experimenter/experiments/tests/test_models/test_models_nimbus.py
+++ b/app/experimenter/experiments/tests/test_models/test_models_nimbus.py
@@ -125,6 +125,24 @@ class TestNimbusExperimentManager(TestCase):
             [experiment1],
         )
 
+    def test_waiting_returns_any_waiting_experiments(self):
+        NimbusExperimentFactory.create_with_status(
+            NimbusExperiment.Status.DRAFT,
+            publish_status=NimbusExperiment.PublishStatus.IDLE,
+            application=NimbusExperiment.Application.IOS,
+        )
+        desktop_live_waiting = NimbusExperimentFactory.create_with_status(
+            NimbusExperiment.Status.DRAFT,
+            publish_status=NimbusExperiment.PublishStatus.WAITING,
+            application=NimbusExperiment.Application.DESKTOP,
+        )
+        self.assertEqual(
+            list(
+                NimbusExperiment.objects.waiting([NimbusExperiment.Application.DESKTOP])
+            ),
+            [desktop_live_waiting],
+        )
+
     def test_waiting_to_launch_only_returns_launching_experiments(self):
         launching = NimbusExperimentFactory.create_with_status(
             NimbusExperiment.Status.DRAFT,

--- a/app/experimenter/experiments/tests/test_models/test_models_nimbus.py
+++ b/app/experimenter/experiments/tests/test_models/test_models_nimbus.py
@@ -40,7 +40,7 @@ class TestNimbusExperimentManager(TestCase):
         self.assertEqual(
             list(
                 NimbusExperiment.objects.launch_queue(
-                    NimbusExperiment.Application.DESKTOP
+                    [NimbusExperiment.Application.DESKTOP]
                 )
             ),
             [experiment1],
@@ -71,7 +71,7 @@ class TestNimbusExperimentManager(TestCase):
         )
         self.assertEqual(
             list(
-                NimbusExperiment.objects.end_queue(NimbusExperiment.Application.DESKTOP)
+                NimbusExperiment.objects.end_queue([NimbusExperiment.Application.DESKTOP])
             ),
             [experiment1],
         )
@@ -118,7 +118,9 @@ class TestNimbusExperimentManager(TestCase):
         )
         self.assertEqual(
             list(
-                NimbusExperiment.objects.pause_queue(NimbusExperiment.Application.DESKTOP)
+                NimbusExperiment.objects.pause_queue(
+                    [NimbusExperiment.Application.DESKTOP]
+                )
             ),
             [experiment1],
         )

--- a/app/experimenter/kinto/tasks.py
+++ b/app/experimenter/kinto/tasks.py
@@ -29,13 +29,13 @@ def nimbus_check_kinto_push_queue():
     A scheduled task that passes each application to a new scheduled
     task for working with kinto
     """
-    for application in NimbusExperiment.Application:
-        nimbus_check_kinto_push_queue_by_application.delay(application)
+    for collection in NimbusExperiment.KINTO_COLLECTION_APPLICATIONS.keys():
+        nimbus_check_kinto_push_queue_by_collection.delay(collection)
 
 
 @app.task
 @metrics.timer_decorator("check_kinto_push_queue_by_application")
-def nimbus_check_kinto_push_queue_by_application(application):
+def nimbus_check_kinto_push_queue_by_collection(collection):
     """
     Because kinto has a restriction that it can only have a single pending review, this
     task brokers the queue of all experiments ready to be pushed to kinto and ensures
@@ -50,15 +50,14 @@ def nimbus_check_kinto_push_queue_by_application(application):
     - Checks for experiments that should be paused but are not paused in the kinto
       collection and marks them as paused and updates the record in the collection.
     """
-    collection = NimbusExperiment.APPLICATION_CONFIGS[application].collection
-    metrics.incr(f"check_kinto_push_queue_by_{collection}_application.started")
-
+    metrics.incr(f"check_kinto_push_queue_by_collection:{collection}.started")
+    applications = NimbusExperiment.KINTO_COLLECTION_APPLICATIONS[collection]
     kinto_client = KintoClient(collection)
 
     should_rollback = False
     if kinto_client.has_pending_review():
         logger.info(f"{collection} has pending review")
-        should_abort = handle_pending_review(application, kinto_client)
+        should_abort = handle_pending_review(applications, kinto_client)
 
         if should_abort:
             return
@@ -67,29 +66,32 @@ def nimbus_check_kinto_push_queue_by_application(application):
 
     if kinto_client.has_rejection():
         logger.info(f"{collection} has rejection")
-        handle_rejection(application, kinto_client)
+        handle_rejection(applications, kinto_client)
         should_rollback = True
 
     if should_rollback:
         kinto_client.rollback_changes()
 
     if queued_launch_experiment := NimbusExperiment.objects.launch_queue(
-        application
+        applications
     ).first():
-        nimbus_push_experiment_to_kinto.delay(queued_launch_experiment.id)
-    elif queued_end_experiment := NimbusExperiment.objects.end_queue(application).first():
-        nimbus_end_experiment_in_kinto.delay(queued_end_experiment.id)
+        nimbus_push_experiment_to_kinto.delay(collection, queued_launch_experiment.id)
+    elif queued_end_experiment := NimbusExperiment.objects.end_queue(
+        applications
+    ).first():
+        nimbus_end_experiment_in_kinto.delay(collection, queued_end_experiment.id)
     elif queued_pause_experiment := NimbusExperiment.objects.pause_queue(
-        application
+        applications
     ).first():
-        nimbus_pause_experiment_in_kinto.delay(queued_pause_experiment.id)
+        nimbus_pause_experiment_in_kinto.delay(collection, queued_pause_experiment.id)
 
-    metrics.incr(f"check_kinto_push_queue_by_{collection}_application.completed")
+    metrics.incr(f"check_kinto_push_queue_by_collection:{collection}.completed")
 
 
-def handle_pending_review(application, kinto_client):
+def handle_pending_review(applications, kinto_client):
     experiment = NimbusExperiment.objects.filter(
-        application=application, publish_status=NimbusExperiment.PublishStatus.WAITING
+        application__in=applications,
+        publish_status=NimbusExperiment.PublishStatus.WAITING,
     ).first()
 
     if experiment:
@@ -110,10 +112,11 @@ def handle_pending_review(application, kinto_client):
             return True
 
 
-def handle_rejection(application, kinto_client):
+def handle_rejection(applications, kinto_client):
     collection_data = kinto_client.get_rejected_collection_data()
     experiment = NimbusExperiment.objects.filter(
-        application=application, publish_status=NimbusExperiment.PublishStatus.WAITING
+        application__in=applications,
+        publish_status=NimbusExperiment.PublishStatus.WAITING,
     ).first()
 
     if experiment:
@@ -132,7 +135,7 @@ def handle_rejection(application, kinto_client):
 
 @app.task
 @metrics.timer_decorator("push_experiment_to_kinto.timing")
-def nimbus_push_experiment_to_kinto(experiment_id):
+def nimbus_push_experiment_to_kinto(collection, experiment_id):
     """
     An invoked task that given a single experiment id, query it in the db, serialize it,
     and push its data to the configured collection. If it fails for any reason, log the
@@ -145,7 +148,7 @@ def nimbus_push_experiment_to_kinto(experiment_id):
         experiment = NimbusExperiment.objects.get(id=experiment_id)
         logger.info(f"Pushing {experiment.slug} to Kinto")
 
-        kinto_client = KintoClient(experiment.application_config.collection)
+        kinto_client = KintoClient(collection)
 
         data = NimbusExperimentSerializer(experiment).data
 
@@ -166,7 +169,7 @@ def nimbus_push_experiment_to_kinto(experiment_id):
 
 @app.task
 @metrics.timer_decorator("pause_experiment_in_kinto")
-def nimbus_pause_experiment_in_kinto(experiment_id):
+def nimbus_pause_experiment_in_kinto(collection, experiment_id):
     """
     An invoked task that given a single experiment id, marks it as paused
     and updates the record. If it fails for any reason, log the error and
@@ -178,7 +181,7 @@ def nimbus_pause_experiment_in_kinto(experiment_id):
         experiment = NimbusExperiment.objects.get(id=experiment_id)
         logger.info(f"Deleting {experiment.slug} from Kinto")
 
-        kinto_client = KintoClient(experiment.application_config.collection)
+        kinto_client = KintoClient(collection)
 
         records = {r["id"]: r for r in kinto_client.get_main_records()}
         record = records[experiment.slug]
@@ -203,7 +206,7 @@ def nimbus_pause_experiment_in_kinto(experiment_id):
 
 @app.task
 @metrics.timer_decorator("end_experiment_in_kinto")
-def nimbus_end_experiment_in_kinto(experiment_id):
+def nimbus_end_experiment_in_kinto(collection, experiment_id):
     """
     An invoked task that given a single experiment id, delete its data from
     the configured collection. If it fails for any reason, log the error and
@@ -215,7 +218,7 @@ def nimbus_end_experiment_in_kinto(experiment_id):
         experiment = NimbusExperiment.objects.get(id=experiment_id)
         logger.info(f"Deleting {experiment.slug} from Kinto")
 
-        kinto_client = KintoClient(experiment.application_config.collection)
+        kinto_client = KintoClient(collection)
         kinto_client.delete_record(experiment.slug)
 
         experiment.publish_status = NimbusExperiment.PublishStatus.WAITING
@@ -239,8 +242,8 @@ def nimbus_check_experiments_are_live():
     """
     metrics.incr("check_experiments_are_live.started")
 
-    for application_config in NimbusExperiment.APPLICATION_CONFIGS.values():
-        kinto_client = KintoClient(application_config.collection)
+    for collection in NimbusExperiment.KINTO_COLLECTION_APPLICATIONS.keys():
+        kinto_client = KintoClient(collection)
 
         records = kinto_client.get_main_records()
         record_ids = [r.get("id") for r in records]
@@ -276,12 +279,15 @@ def nimbus_check_experiments_are_paused():
     """
     metrics.incr("check_experiments_are_paused.started")
 
-    for application_config in NimbusExperiment.APPLICATION_CONFIGS.values():
-        kinto_client = KintoClient(application_config.collection)
+    for (
+        collection,
+        applications,
+    ) in NimbusExperiment.KINTO_COLLECTION_APPLICATIONS.items():
+        kinto_client = KintoClient(collection)
 
         live_experiments = NimbusExperiment.objects.filter(
             status=NimbusExperiment.Status.LIVE,
-            application=application_config.slug,
+            application__in=applications,
             is_paused=False,
         )
 
@@ -317,12 +323,15 @@ def nimbus_check_experiments_are_complete():
     """
     metrics.incr("check_experiments_are_complete.started")
 
-    for application_config in NimbusExperiment.APPLICATION_CONFIGS.values():
-        kinto_client = KintoClient(application_config.collection)
+    for (
+        collection,
+        applications,
+    ) in NimbusExperiment.KINTO_COLLECTION_APPLICATIONS.items():
+        kinto_client = KintoClient(collection)
 
         live_experiments = NimbusExperiment.objects.filter(
             status=NimbusExperiment.Status.LIVE,
-            application=application_config.slug,
+            application__in=applications,
         )
 
         records = kinto_client.get_main_records()

--- a/app/experimenter/kinto/tasks.py
+++ b/app/experimenter/kinto/tasks.py
@@ -89,10 +89,7 @@ def nimbus_check_kinto_push_queue_by_collection(collection):
 
 
 def handle_pending_review(applications, kinto_client):
-    experiment = NimbusExperiment.objects.filter(
-        application__in=applications,
-        publish_status=NimbusExperiment.PublishStatus.WAITING,
-    ).first()
+    experiment = NimbusExperiment.objects.waiting(applications).first()
 
     if experiment:
         if experiment.has_state(experiment.SHOULD_TIMEOUT):
@@ -114,10 +111,7 @@ def handle_pending_review(applications, kinto_client):
 
 def handle_rejection(applications, kinto_client):
     collection_data = kinto_client.get_rejected_collection_data()
-    experiment = NimbusExperiment.objects.filter(
-        application__in=applications,
-        publish_status=NimbusExperiment.PublishStatus.WAITING,
-    ).first()
+    experiment = NimbusExperiment.objects.waiting(applications).first()
 
     if experiment:
         experiment.publish_status = NimbusExperiment.PublishStatus.IDLE


### PR DESCRIPTION


Because

* We now have multiple applications that use the same collection
* Updating by application was causing duplicate changelogs to be created
* It also causes conflicting update tasks to attempt to update the same collection multiple times

This commit

* Changes all the kinto tasks to operate once per collection