### PR TITLE
fix #5070 bug(nimbus): set publish status to idle when complete

### DIFF
--- a/app/experimenter/kinto/tasks.py
+++ b/app/experimenter/kinto/tasks.py
@@ -345,6 +345,7 @@ def nimbus_check_experiments_are_complete():
                 )
 
                 experiment.status = NimbusExperiment.Status.COMPLETE
+                experiment.publish_status = NimbusExperiment.PublishStatus.IDLE
                 experiment.save()
 
                 generate_nimbus_changelog(experiment, get_kinto_user())

--- a/app/experimenter/kinto/tests/test_tasks.py
+++ b/app/experimenter/kinto/tests/test_tasks.py
@@ -641,14 +641,17 @@ class TestCheckExperimentIsComplete(MockKintoClientMixin, TestCase):
     def test_experiment_updates_when_record_is_not_in_main(self):
         experiment1 = NimbusExperimentFactory.create_with_status(
             NimbusExperiment.Status.LIVE,
+            publish_status=NimbusExperiment.PublishStatus.IDLE,
         )
 
         experiment2 = NimbusExperimentFactory.create_with_status(
             NimbusExperiment.Status.LIVE,
+            publish_status=NimbusExperiment.PublishStatus.WAITING,
         )
 
         experiment3 = NimbusExperimentFactory.create_with_status(
             NimbusExperiment.Status.DRAFT,
+            publish_status=NimbusExperiment.PublishStatus.IDLE,
         )
 
         self.assertEqual(experiment1.changes.count(), 2)
@@ -662,17 +665,23 @@ class TestCheckExperimentIsComplete(MockKintoClientMixin, TestCase):
 
         self.assertTrue(
             NimbusExperiment.objects.filter(
-                id=experiment1.id, status=NimbusExperiment.Status.LIVE
+                id=experiment1.id,
+                status=NimbusExperiment.Status.LIVE,
+                publish_status=NimbusExperiment.PublishStatus.IDLE,
             ).exists()
         )
         self.assertTrue(
             NimbusExperiment.objects.filter(
-                id=experiment2.id, status=NimbusExperiment.Status.COMPLETE
+                id=experiment2.id,
+                status=NimbusExperiment.Status.COMPLETE,
+                publish_status=NimbusExperiment.PublishStatus.IDLE,
             ).exists()
         )
         self.assertTrue(
             NimbusExperiment.objects.filter(
-                id=experiment3.id, status=NimbusExperiment.Status.DRAFT
+                id=experiment3.id,
+                status=NimbusExperiment.Status.DRAFT,
+                publish_status=NimbusExperiment.PublishStatus.IDLE,
             ).exists()
         )
 
@@ -688,7 +697,9 @@ class TestCheckExperimentIsComplete(MockKintoClientMixin, TestCase):
             experiment2.changes.filter(
                 changed_by__email=settings.KINTO_DEFAULT_CHANGELOG_USER,
                 old_status=NimbusExperiment.Status.LIVE,
+                old_publish_status=NimbusExperiment.PublishStatus.WAITING,
                 new_status=NimbusExperiment.Status.COMPLETE,
+                new_publish_status=NimbusExperiment.PublishStatus.IDLE,
             ).exists()
         )
 


### PR DESCRIPTION
Because

* We recently introduced publish_status
* publish_status gets set to WAITING as something is in review, such as when ending
* We neglected to set it back to IDLE after the completion flow is done

This commit

* Sets publish_status to IDLE when the experiment completes