### PR TITLE
fix #3954 chore(nimbus): use int for all ids

### DIFF
--- a/app/experimenter/experiments/api/v5/inputs.py
+++ b/app/experimenter/experiments/api/v5/inputs.py
@@ -36,10 +36,6 @@ class TreatmentBranchType(BranchType):
         )
 
 
-class ExperimentIdInput(graphene.InputObjectType):
-    id = graphene.Int()
-
-
 class ExperimentInput(graphene.InputObjectType):
     id = graphene.Int()
     status = NimbusExperimentStatus()

--- a/app/experimenter/experiments/api/v5/types.py
+++ b/app/experimenter/experiments/api/v5/types.py
@@ -26,6 +26,8 @@ class ObjectField(graphene.Scalar):
 
 
 class NimbusUser(DjangoObjectType):
+    id = graphene.Int()
+
     class Meta:
         model = get_user_model()
         fields = ("id", "username", "first_name", "last_name", "email")
@@ -79,6 +81,7 @@ class NimbusDocumentationLinkType(DjangoObjectType):
 
 
 class NimbusFeatureConfigType(DjangoObjectType):
+    id = graphene.Int()
     application = NimbusExperimentApplication()
 
     class Meta:
@@ -86,6 +89,8 @@ class NimbusFeatureConfigType(DjangoObjectType):
 
 
 class ProjectType(DjangoObjectType):
+    id = graphene.Int()
+
     class Meta:
         model = Project
 
@@ -93,6 +98,7 @@ class ProjectType(DjangoObjectType):
 class NimbusIsolationGroupType(DjangoObjectType):
     class Meta:
         model = NimbusIsolationGroup
+        exclude = ("id",)
 
 
 class NimbusBucketRangeType(DjangoObjectType):

--- a/app/experimenter/experiments/tests/api/v5/test_queries.py
+++ b/app/experimenter/experiments/tests/api/v5/test_queries.py
@@ -656,11 +656,9 @@ class TestNimbusQuery(GraphQLTestCase):
 
         for feature_config in feature_configs:
             config_feature_config = next(
-                filter(
-                    lambda f: f["id"] == str(feature_config.id), config["featureConfig"]
-                )
+                filter(lambda f: f["id"] == feature_config.id, config["featureConfig"])
             )
-            self.assertEqual(config_feature_config["id"], str(feature_config.id))
+            self.assertEqual(config_feature_config["id"], feature_config.id)
             self.assertEqual(config_feature_config["name"], feature_config.name)
             self.assertEqual(config_feature_config["slug"], feature_config.slug)
             self.assertEqual(

--- a/app/experimenter/nimbus-ui/schema.graphql
+++ b/app/experimenter/nimbus-ui/schema.graphql
@@ -309,7 +309,7 @@ type NimbusExperimentType {
 }
 
 type NimbusFeatureConfigType {
-  id: ID!
+  id: Int
   name: String!
   slug: String!
   description: String
@@ -326,7 +326,6 @@ enum NimbusIsolationGroupApplication {
 }
 
 type NimbusIsolationGroupType {
-  id: ID!
   application: NimbusIsolationGroupApplication!
   name: String!
   instance: Int!
@@ -352,7 +351,7 @@ type NimbusReadyForReviewType {
 }
 
 type NimbusUser {
-  id: ID!
+  id: Int
   username: String!
   firstName: String!
   lastName: String!
@@ -362,7 +361,7 @@ type NimbusUser {
 scalar ObjectField
 
 type ProjectType {
-  id: ID!
+  id: Int
   name: String!
   slug: String!
   nimbusexperimentSet: [NimbusExperimentType!]!

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/index.test.tsx
@@ -265,7 +265,7 @@ describe("FormBranches", () => {
     });
     await clickAndWaitForSave(onSave);
     expect(onSave.mock.calls[0][0].featureConfigId).toEqual(
-      parseInt(MOCK_CONFIG.featureConfig![0]!.id, 10),
+      MOCK_CONFIG.featureConfig![0]!.id,
     );
   });
 
@@ -360,7 +360,7 @@ describe("FormBranches", () => {
     const saveResult = onSave.mock.calls[0][0];
 
     expect(saveResult.featureConfigId).toEqual(
-      parseInt(MOCK_FEATURE_CONFIG_WITH_SCHEMA.id, 10),
+      MOCK_FEATURE_CONFIG_WITH_SCHEMA.id,
     );
     expect(saveResult.referenceBranch).toEqual(expectedData);
     expect(saveResult.treatmentBranches[1]).toEqual(expectedData);

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/reducer/update.ts
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/reducer/update.ts
@@ -27,9 +27,7 @@ export function extractUpdateState(
     throw new UpdateStateError("Control branch is required");
   }
 
-  // issue #3954: Need to parse string IDs into numbers
-  const featureConfigId =
-    featureConfig === null ? null : parseInt(featureConfig.id, 10);
+  const featureConfigId = featureConfig === null ? null : featureConfig.id;
 
   return {
     featureConfigId,

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/index.stories.tsx
@@ -13,7 +13,7 @@ import { NimbusExperimentApplication } from "../../types/globalTypes";
 
 const { mock } = mockExperimentQuery("demo-slug", {
   featureConfig: {
-    id: "2",
+    id: 2,
     name: "Mauris odio erat",
     slug: "mauris-odio-erat",
     description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/index.test.tsx
@@ -175,11 +175,8 @@ const mockClearSubmitErrors = jest.fn();
 let mockUpdateState: FormBranchesSaveState;
 
 function setMockUpdateState(experiment: getExperiment_experimentBySlug) {
-  // issue #3954: Need to parse string IDs into numbers
   const featureConfigId =
-    experiment.featureConfig === null
-      ? null
-      : parseInt(experiment.featureConfig.id, 10);
+    experiment.featureConfig === null ? null : experiment.featureConfig.id;
   mockUpdateState = {
     featureConfigId,
     // @ts-ignore type mismatch covers discarded annotation properties

--- a/app/experimenter/nimbus-ui/src/lib/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/lib/mocks.tsx
@@ -78,7 +78,7 @@ export const MOCK_CONFIG: getConfig_nimbusConfig = {
   ],
   featureConfig: [
     {
-      id: "1",
+      id: 1,
       name: "Picture-in-Picture",
       slug: "picture-in-picture",
       description:
@@ -88,7 +88,7 @@ export const MOCK_CONFIG: getConfig_nimbusConfig = {
       schema: null,
     },
     {
-      id: "2",
+      id: 2,
       name: "Mauris odio erat",
       slug: "mauris-odio-erat",
       description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
@@ -97,7 +97,7 @@ export const MOCK_CONFIG: getConfig_nimbusConfig = {
       schema: '{ "sample": "schema" }',
     },
     {
-      id: "3",
+      id: 3,
       name: "Foo lila sat",
       slug: "foo-lila-sat",
       description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",

--- a/app/experimenter/nimbus-ui/src/types/getConfig.ts
+++ b/app/experimenter/nimbus-ui/src/types/getConfig.ts
@@ -20,7 +20,7 @@ export interface getConfig_nimbusConfig_channel {
 }
 
 export interface getConfig_nimbusConfig_featureConfig {
-  id: string;
+  id: number | null;
   name: string;
   slug: string;
   description: string | null;

--- a/app/experimenter/nimbus-ui/src/types/getExperiment.ts
+++ b/app/experimenter/nimbus-ui/src/types/getExperiment.ts
@@ -32,7 +32,7 @@ export interface getExperiment_experimentBySlug_treatmentBranches {
 }
 
 export interface getExperiment_experimentBySlug_featureConfig {
-  id: string;
+  id: number | null;
   slug: string;
   name: string;
   description: string | null;


### PR DESCRIPTION
Because

* We should be consistent in our use of ID fields in our GQL API as integers

This commit

* Changes feature config id to an int
* Removes unused ExperimentIDInput