### PR TITLE
fix #5081 chore(nimbus): use more declarative filters

### DIFF
--- a/app/experimenter/experiments/api/v5/serializers.py
+++ b/app/experimenter/experiments/api/v5/serializers.py
@@ -473,7 +473,7 @@ class NimbusExperimentSerializer(
         with transaction.atomic():
             experiment = super().save(*args, **kwargs)
 
-            if experiment.should_allocate_bucket_range:
+            if experiment.has_filter(experiment.Filters.SHOULD_ALLOCATE_BUCKETS):
                 experiment.allocate_bucket_range()
 
             if self.should_call_preview_task:

--- a/app/experimenter/experiments/changelog_utils/nimbus.py
+++ b/app/experimenter/experiments/changelog_utils/nimbus.py
@@ -39,7 +39,7 @@ class NimbusExperimentChangeLogSerializer(serializers.ModelSerializer):
 
 
 def generate_nimbus_changelog(experiment, changed_by, message=None):
-    latest_change = experiment.latest_change()
+    latest_change = experiment.changes.latest_change()
     experiment_data = dict(NimbusExperimentChangeLogSerializer(experiment).data)
 
     old_status = None

--- a/app/experimenter/experiments/constants/nimbus.py
+++ b/app/experimenter/experiments/constants/nimbus.py
@@ -3,7 +3,6 @@ from typing import Dict
 
 from django.conf import settings
 from django.db import models
-from django.db.models import Q
 
 
 @dataclass
@@ -190,15 +189,6 @@ class NimbusConstants(object):
         "publish_status",
         "is_end_requested",
     )
-
-    # State Predicates
-    IS_LAUNCHING = Q(status=Status.DRAFT, publish_status=PublishStatus.WAITING)
-    IS_ENDING = Q(
-        status=Status.LIVE,
-        publish_status=PublishStatus.WAITING,
-        is_end_requested=True,
-    )
-    SHOULD_TIMEOUT = Q(IS_LAUNCHING | IS_ENDING)
 
     class Application(models.TextChoices):
         DESKTOP = (APPLICATION_CONFIG_DESKTOP.slug, APPLICATION_CONFIG_DESKTOP.name)

--- a/app/experimenter/experiments/tests/api/v6/test_serializers.py
+++ b/app/experimenter/experiments/tests/api/v6/test_serializers.py
@@ -51,9 +51,10 @@ class TestNimbusExperimentSerializer(TestCase):
                 # DRF manually replaces the isoformat suffix so we have to do the same
                 "startDate": experiment.start_date.isoformat().replace("+00:00", "Z"),
                 "targeting": (
-                    'browserSettings.update.channel == "nightly" && '
-                    "version|versionCompare('83.!') >= 0 && localeLanguageCode == "
-                    "'en' && 'app.shield.optoutstudies.enabled'|preferenceValue"
+                    'browserSettings.update.channel == "nightly" '
+                    "&& version|versionCompare('83.!') >= 0 "
+                    "&& 'app.shield.optoutstudies.enabled'|preferenceValue "
+                    "&& localeLanguageCode == 'en'"
                 ),
                 "userFacingDescription": experiment.public_description,
                 "userFacingName": experiment.name,

--- a/app/experimenter/experiments/tests/factories/nimbus.py
+++ b/app/experimenter/experiments/tests/factories/nimbus.py
@@ -11,7 +11,6 @@ from experimenter.experiments.changelog_utils import (
     NimbusExperimentChangeLogSerializer,
     generate_nimbus_changelog,
 )
-from experimenter.experiments.constants import NimbusConstants
 from experimenter.experiments.models import (
     NimbusBranch,
     NimbusBucketRange,
@@ -33,7 +32,7 @@ class NimbusExperimentFactory(factory.django.DjangoModelFactory):
     owner = factory.SubFactory(UserFactory)
     name = factory.LazyAttribute(lambda o: faker.catch_phrase())
     slug = factory.LazyAttribute(
-        lambda o: slugify(o.name)[: NimbusConstants.MAX_SLUG_LEN]
+        lambda o: slugify(o.name)[: NimbusExperiment.MAX_SLUG_LEN]
     )
     public_description = factory.LazyAttribute(lambda o: faker.text(200))
     risk_mitigation_link = factory.LazyAttribute(lambda o: faker.uri())
@@ -132,7 +131,7 @@ class NimbusExperimentFactory(factory.django.DjangoModelFactory):
             experiment.status = status
             experiment.save()
 
-            if experiment.should_allocate_bucket_range:
+            if experiment.has_filter(experiment.Filters.SHOULD_ALLOCATE_BUCKETS):
                 experiment.allocate_bucket_range()
 
             generate_nimbus_changelog(experiment, experiment.owner)
@@ -148,7 +147,7 @@ class NimbusBranchFactory(factory.django.DjangoModelFactory):
     experiment = factory.SubFactory(NimbusExperimentFactory)
     name = factory.LazyAttribute(lambda o: faker.catch_phrase())
     slug = factory.LazyAttribute(
-        lambda o: slugify(o.name)[: NimbusConstants.MAX_SLUG_LEN]
+        lambda o: slugify(o.name)[: NimbusExperiment.MAX_SLUG_LEN]
     )
     description = factory.LazyAttribute(lambda o: faker.text())
     feature_value = factory.LazyAttribute(
@@ -209,7 +208,7 @@ FAKER_JSON_SCHEMA = """\
 class NimbusFeatureConfigFactory(factory.django.DjangoModelFactory):
     name = factory.LazyAttribute(lambda o: faker.catch_phrase())
     slug = factory.LazyAttribute(
-        lambda o: slugify(o.name)[: NimbusConstants.MAX_SLUG_LEN]
+        lambda o: slugify(o.name)[: NimbusExperiment.MAX_SLUG_LEN]
     )
     description = factory.LazyAttribute(lambda o: faker.text(200))
     application = factory.LazyAttribute(

--- a/app/experimenter/experiments/tests/test_changelog_utils/test_changelog_utils_nimbus.py
+++ b/app/experimenter/experiments/tests/test_changelog_utils/test_changelog_utils_nimbus.py
@@ -174,7 +174,7 @@ class TestGenerateNimbusChangeLog(TestCase):
 
         self.assertEqual(experiment.changes.count(), 2)
 
-        change = experiment.latest_change()
+        change = experiment.changes.latest_change()
 
         self.assertEqual(change.experiment, experiment)
         self.assertEqual(change.changed_by, self.user)

--- a/app/experimenter/experiments/tests/test_models/test_models_nimbus.py
+++ b/app/experimenter/experiments/tests/test_models/test_models_nimbus.py
@@ -184,8 +184,8 @@ class TestNimbusExperiment(TestCase):
             experiment.targeting,
             (
                 "version|versionCompare('83.!') >= 0 "
-                "&& localeLanguageCode == 'en' "
-                "&& 'app.shield.optoutstudies.enabled'|preferenceValue"
+                "&& 'app.shield.optoutstudies.enabled'|preferenceValue "
+                "&& localeLanguageCode == 'en'"
             ),
         )
 
@@ -225,8 +225,8 @@ class TestNimbusExperiment(TestCase):
             experiment.targeting,
             (
                 'browserSettings.update.channel == "nightly" '
-                "&& localeLanguageCode == 'en' "
-                "&& 'app.shield.optoutstudies.enabled'|preferenceValue"
+                "&& 'app.shield.optoutstudies.enabled'|preferenceValue "
+                "&& localeLanguageCode == 'en'"
             ),
         )
 
@@ -386,30 +386,6 @@ class TestNimbusExperiment(TestCase):
         self.assertIsNone(experiment.reference_branch)
         self.assertEqual(experiment.branches.count(), 0)
         self.assertEqual(experiment.changes.count(), 1)
-
-    @parameterized.expand(
-        [
-            [False, NimbusExperiment.Status.DRAFT],
-            [True, NimbusExperiment.Status.PREVIEW],
-            [False, NimbusExperiment.Status.LIVE],
-            [False, NimbusExperiment.Status.COMPLETE],
-        ]
-    )
-    def test_status_should_allocate_buckets(self, expected_value, status):
-        experiment = NimbusExperimentFactory(status=status)
-        self.assertEqual(experiment.should_allocate_bucket_range, expected_value)
-
-    @parameterized.expand(
-        [
-            [False, NimbusExperiment.PublishStatus.IDLE],
-            [False, NimbusExperiment.PublishStatus.REVIEW],
-            [True, NimbusExperiment.PublishStatus.APPROVED],
-            [False, NimbusExperiment.PublishStatus.WAITING],
-        ]
-    )
-    def test_publish_status_should_allocate_buckets(self, expected_value, publish_status):
-        experiment = NimbusExperimentFactory(publish_status=publish_status)
-        self.assertEqual(experiment.should_allocate_bucket_range, expected_value)
 
     def test_allocate_buckets_generates_bucket_range(self):
         experiment = NimbusExperimentFactory(
@@ -576,7 +552,9 @@ class TestNimbusExperiment(TestCase):
         generate_nimbus_changelog(experiment, experiment.owner)
 
         # Timeout should be the latest changelog entry.
-        self.assertEqual(experiment.changes.latest_timeout(), experiment.latest_change())
+        self.assertEqual(
+            experiment.changes.latest_timeout(), experiment.changes.latest_change()
+        )
 
     def test_has_state_true(self):
         experiment = NimbusExperimentFactory.create_with_status(
@@ -584,7 +562,7 @@ class TestNimbusExperiment(TestCase):
             publish_status=NimbusExperiment.PublishStatus.WAITING,
         )
         self.assertTrue(
-            experiment.has_state(
+            experiment.has_filter(
                 Q(
                     status=NimbusExperiment.Status.DRAFT,
                     publish_status=NimbusExperiment.PublishStatus.WAITING,
@@ -598,7 +576,7 @@ class TestNimbusExperiment(TestCase):
             publish_status=NimbusExperiment.PublishStatus.WAITING,
         )
         self.assertFalse(
-            experiment.has_state(
+            experiment.has_filter(
                 Q(
                     status=NimbusExperiment.Status.DRAFT,
                     publish_status=NimbusExperiment.PublishStatus.IDLE,


### PR DESCRIPTION
Because

* I like this idea of declaring filters as reusable constants
* Enhances code reuse, makes things simpler to test, more readable

This commit

* Finds as many filters that can be moved to constants as reasonable