### PR TITLE
fix #4260 bug(nimbus): feature value should always be an object

### DIFF
--- a/app/experimenter/experiments/api/v6/serializers.py
+++ b/app/experimenter/experiments/api/v6/serializers.py
@@ -46,7 +46,7 @@ class NimbusBranchSerializer(serializers.ModelSerializer):
             return {
                 "featureId": obj.experiment.feature_config.slug,
                 "enabled": obj.feature_enabled,
-                "value": json.loads(obj.feature_value) if obj.feature_value else None,
+                "value": json.loads(obj.feature_value) if obj.feature_value else {},
             }
 
 

--- a/app/experimenter/experiments/tests/api/v6/test_serializers.py
+++ b/app/experimenter/experiments/tests/api/v6/test_serializers.py
@@ -111,7 +111,7 @@ class TestNimbusExperimentSerializer(TestCase):
         )
         experiment.save()
         serializer = NimbusExperimentSerializer(experiment)
-        self.assertIsNone(serializer.data["branches"][0]["feature"]["value"])
+        self.assertEqual(serializer.data["branches"][0]["feature"]["value"], {})
         check_schema("experiments/NimbusExperiment", serializer.data)
 
     @parameterized.expand(


### PR DESCRIPTION
Because

* Clients expect feature value to be a js object

This commit

* Defaults to {} instead of null for empty feature value