### PR TITLE
fix #4694 feat(nimbus): make feature config required

### DIFF
--- a/app/experimenter/experiments/api/v5/serializers.py
+++ b/app/experimenter/experiments/api/v5/serializers.py
@@ -512,7 +512,7 @@ class NimbusReadyForReviewSerializer(serializers.ModelSerializer):
     treatment_branches = NimbusBranchSerializer(many=True)
     feature_config = serializers.PrimaryKeyRelatedField(
         queryset=NimbusFeatureConfig.objects.all(),
-        allow_null=True,
+        allow_null=False,
     )
     primary_outcomes = serializers.ListField(
         child=serializers.CharField(), required=False

--- a/app/experimenter/experiments/api/v6/serializers.py
+++ b/app/experimenter/experiments/api/v6/serializers.py
@@ -35,19 +35,12 @@ class NimbusBranchSerializer(serializers.ModelSerializer):
         model = NimbusBranch
         fields = ("slug", "ratio", "feature")
 
-    def to_representation(self, branch):
-        data = super().to_representation(branch)
-        if not branch.experiment.feature_config:
-            data = {k: v for k, v in data.items() if k != "feature"}
-        return data
-
     def get_feature(self, obj):
-        if obj.experiment.feature_config:
-            return {
-                "featureId": obj.experiment.feature_config.slug,
-                "enabled": obj.feature_enabled,
-                "value": json.loads(obj.feature_value) if obj.feature_value else None,
-            }
+        return {
+            "featureId": obj.experiment.feature_config.slug,
+            "enabled": obj.feature_enabled,
+            "value": json.loads(obj.feature_value) if obj.feature_value else {},
+        }
 
 
 class NimbusExperimentSerializer(serializers.ModelSerializer):
@@ -126,6 +119,4 @@ class NimbusExperimentSerializer(serializers.ModelSerializer):
             return obj.reference_branch.slug
 
     def get_featureIds(self, obj):
-        if obj.feature_config:
-            return [obj.feature_config.slug]
-        return []
+        return [obj.feature_config.slug]

--- a/app/experimenter/experiments/tests/api/v5/test_serializers.py
+++ b/app/experimenter/experiments/tests/api/v5/test_serializers.py
@@ -1469,6 +1469,25 @@ class TestNimbusReadyForReviewSerializer(TestCase):
             ["Description cannot be blank."],
         )
 
+    def test_invalid_experiment_missing_feature_config(self):
+        experiment = NimbusExperimentFactory.create_with_status(
+            NimbusExperiment.Status.DRAFT,
+            application=NimbusExperiment.Application.DESKTOP.value,
+            feature_config=None,
+        )
+        serializer = NimbusReadyForReviewSerializer(
+            experiment,
+            data=NimbusReadyForReviewSerializer(
+                experiment,
+                context={"user": self.user},
+            ).data,
+            context={"user": self.user},
+        )
+        self.assertFalse(serializer.is_valid())
+        self.assertEqual(
+            serializer.errors["feature_config"], ["This field may not be null."]
+        )
+
 
 class TestNimbusStatusTransitionValidator(TestCase):
     maxDiff = None

--- a/app/experimenter/experiments/tests/api/v6/test_serializers.py
+++ b/app/experimenter/experiments/tests/api/v6/test_serializers.py
@@ -99,7 +99,7 @@ class TestNimbusExperimentSerializer(TestCase):
         check_schema("experiments/NimbusExperiment", serializer.data)
 
     @parameterized.expand(list(NimbusExperiment.Application))
-    def test_serializers_with_feature_value_None(self, application):
+    def test_serializers_with_missing_feature_value(self, application):
         experiment = NimbusExperimentFactory.create_with_status(
             NimbusExperiment.Status.DRAFT,
             application=application,
@@ -111,7 +111,7 @@ class TestNimbusExperimentSerializer(TestCase):
         )
         experiment.save()
         serializer = NimbusExperimentSerializer(experiment)
-        self.assertIsNone(serializer.data["branches"][0]["feature"]["value"])
+        self.assertEqual(serializer.data["branches"][0]["feature"]["value"], {})
         check_schema("experiments/NimbusExperiment", serializer.data)
 
     @parameterized.expand(
@@ -207,26 +207,6 @@ class TestNimbusExperimentSerializer(TestCase):
         self.assertEqual(serializer.data["channel"], channel)
         self.assertEqual(serializer.data["appName"], expected_appName)
         self.assertEqual(serializer.data["appId"], expected_appId)
-        check_schema("experiments/NimbusExperiment", serializer.data)
-
-    def test_serializer_outputs_expected_schema_without_feature(self):
-        experiment = NimbusExperimentFactory.create_with_status(
-            NimbusExperiment.Status.DRAFT,
-            publish_status=NimbusExperiment.PublishStatus.APPROVED,
-            application=NimbusExperiment.Application.DESKTOP,
-            feature_config=None,
-        )
-        serializer = NimbusExperimentSerializer(experiment)
-        experiment_data = serializer.data.copy()
-        self.assertEqual(experiment_data["featureIds"], [])
-        branches_data = [dict(b) for b in experiment_data.pop("branches")]
-        self.assertEqual(len(branches_data), 2)
-        for branch in experiment.branches.all():
-            self.assertIn(
-                {"slug": branch.slug, "ratio": branch.ratio},
-                branches_data,
-            )
-
         check_schema("experiments/NimbusExperiment", serializer.data)
 
     def test_serializer_outputs_targeting(self):

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/FormBranch.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/FormBranch.tsx
@@ -182,6 +182,7 @@ export const FormBranch = ({
         <Form.Group className="px-2 mx-3">
           <Form.Row>
             <Button
+              className="feature-config-add"
               variant="outline-primary"
               size="sm"
               data-testid="feature-config-add"

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/index.tsx
@@ -94,9 +94,8 @@ const PageEditBranches: React.FunctionComponent<RouteComponentProps> = () => {
         return (
           <>
             <p>
-              If you want, you can add a <strong>feature flag</strong>{" "}
-              configuration to each branch. Experiments can only change one flag
-              at a time.{" "}
+              You must add a <strong>feature flag</strong> configuration to each
+              branch. Experiments can only change one flag at a time.{" "}
               <LinkExternal
                 href={EXTERNAL_URLS.BRANCHES_GOOGLE_DOC}
                 data-testid="learn-more-link"

--- a/app/experimenter/nimbus-ui/src/hooks/useExperiment.tsx
+++ b/app/experimenter/nimbus-ui/src/hooks/useExperiment.tsx
@@ -8,7 +8,7 @@ import { getExperiment } from "../types/getExperiment";
 
 const fieldPageMap: { [page: string]: string[] } = {
   overview: ["public_description", "risk_mitigation_link"],
-  branches: ["reference_branch", "treatment_branches"],
+  branches: ["reference_branch", "treatment_branches", "feature_config"],
   audience: [
     "channel",
     "firefox_min_version",

--- a/app/tests/integration/nimbus/pages/branches.py
+++ b/app/tests/integration/nimbus/pages/branches.py
@@ -12,6 +12,7 @@ class BranchesPage(Base):
         "#referenceBranch-description",
     )
     _remove_branch_locator = (By.CSS_SELECTOR, ".bg-transparent")
+    _add_feature_locator = (By.CSS_SELECTOR, ".feature-config-add")
     _page_wait_locator = (By.CSS_SELECTOR, "#PageEditBranches")
     _save_continue_btn_locator = (By.CSS_SELECTOR, "#save-and-continue-button")
 
@@ -47,4 +48,8 @@ class BranchesPage(Base):
 
     def remove_branch(self):
         el = self.find_element(*self._remove_branch_locator)
+        el.click()
+
+    def select_feature(self):
+        el = self.find_element(*self._add_feature_locator)
         el.click()

--- a/app/tests/integration/nimbus/test_e2e_create_experiment.py
+++ b/app/tests/integration/nimbus/test_e2e_create_experiment.py
@@ -18,9 +18,10 @@ def test_create_new_experiment(selenium, base_url):
     overview.risk_mitigation = "http://risk.mitigation"
     # Fill Branches page
     branches = overview.save_and_continue()
+    branches.remove_branch()
     branches.reference_branch_name = "name 1"
     branches.reference_branch_description = "a nice experiment"
-    branches.remove_branch()
+    branches.select_feature()
     # Fill Metrics page
     metrics = branches.save_and_continue()
     # Fill Audience page


### PR DESCRIPTION
Because

* We now want all experiments to include a feature config

This commit

* Makes feature_config required to be not null to launch

Filed https://github.com/mozilla/experimenter/issues/5103 as a followup