### PR TITLE
    feat(nimbus): use feature config slug as bucket namespace

### DIFF
--- a/app/experimenter/experiments/models/nimbus.py
+++ b/app/experimenter/experiments/models/nimbus.py
@@ -285,7 +285,7 @@ class NimbusExperiment(NimbusConstants, FilterMixin, models.Model):
             existing_bucket_range.delete()
 
         NimbusIsolationGroup.request_isolation_group_buckets(
-            self.slug,
+            self.feature_config.slug,
             self,
             int(
                 self.population_percent / Decimal("100.0") * NimbusExperiment.BUCKET_TOTAL

--- a/app/experimenter/experiments/tests/test_models/test_models_nimbus.py
+++ b/app/experimenter/experiments/tests/test_models/test_models_nimbus.py
@@ -393,7 +393,9 @@ class TestNimbusExperiment(TestCase):
         )
         experiment.allocate_bucket_range()
         self.assertEqual(experiment.bucket_range.count, 5000)
-        self.assertEqual(experiment.bucket_range.isolation_group.name, experiment.slug)
+        self.assertEqual(
+            experiment.bucket_range.isolation_group.name, experiment.feature_config.slug
+        )
 
     def test_allocate_buckets_creates_new_bucket_range_if_population_changes(self):
         experiment = NimbusExperimentFactory(
@@ -401,12 +403,16 @@ class TestNimbusExperiment(TestCase):
         )
         experiment.allocate_bucket_range()
         self.assertEqual(experiment.bucket_range.count, 5000)
-        self.assertEqual(experiment.bucket_range.isolation_group.name, experiment.slug)
+        self.assertEqual(
+            experiment.bucket_range.isolation_group.name, experiment.feature_config.slug
+        )
 
         experiment.population_percent = Decimal("20.0")
         experiment.allocate_bucket_range()
         self.assertEqual(experiment.bucket_range.count, 2000)
-        self.assertEqual(experiment.bucket_range.isolation_group.name, experiment.slug)
+        self.assertEqual(
+            experiment.bucket_range.isolation_group.name, experiment.feature_config.slug
+        )
 
     def test_proposed_enrollment_end_date_without_start_date_is_None(self):
         experiment = NimbusExperimentFactory.create_with_status(


### PR DESCRIPTION
Because
    
* All experiments must now have a feature config
* We want a client to only be enrolled in a single experiment for a given feature
    
This commit
    
* Changes the bucketing to use the feature config slug as the bucketing namespace