### PR TITLE
chore(nimbus): always return a dict from kinto get_main_records

### DIFF
--- a/app/experimenter/kinto/client.py
+++ b/app/experimenter/kinto/client.py
@@ -86,6 +86,9 @@ class KintoClient:
         )
 
     def get_main_records(self):
-        return self.kinto_http_client.get_records(
-            bucket=settings.KINTO_BUCKET_MAIN, collection=self.collection
-        )
+        return {
+            r["id"]: r
+            for r in self.kinto_http_client.get_records(
+                bucket=settings.KINTO_BUCKET_MAIN, collection=self.collection
+            )
+        }

--- a/app/experimenter/kinto/tests/test_client.py
+++ b/app/experimenter/kinto/tests/test_client.py
@@ -124,11 +124,11 @@ class TestKintoClient(MockKintoClientMixin, TestCase):
     def test_returns_records(self):
         slug = "test-slug"
         self.setup_kinto_get_main_records([slug])
-        self.assertEqual(self.client.get_main_records(), [{"id": slug}])
+        self.assertEqual(self.client.get_main_records(), {slug: {"id": slug}})
 
     def test_returns_no_records(self):
         self.setup_kinto_get_main_records([])
-        self.assertEqual(self.client.get_main_records(), [])
+        self.assertEqual(self.client.get_main_records(), {})
 
     def test_returns_nothing_when_not_rejects(self):
         self.setup_kinto_no_pending_review()


### PR DESCRIPTION
Because

* I noticed we're always treating the kinto records as a dict

This commit

* Just returns a dict from get_main_records so we don't do that transformation everywhere