### PR TITLE
fix #5113 bug(nimbus): total_enrolled_population is required to launch on audience page

### DIFF
--- a/app/experimenter/nimbus-ui/src/hooks/useExperiment.tsx
+++ b/app/experimenter/nimbus-ui/src/hooks/useExperiment.tsx
@@ -16,6 +16,7 @@ const fieldPageMap: { [page: string]: string[] } = {
     "proposed_enrollment",
     "proposed_duration",
     "population_percent",
+    "total_enrolled_clients",
   ],
 };
 


### PR DESCRIPTION


Becuase

* Total enrolled clients is required to launch but isn't marked as one of the required to launch fields on audience

This commit

* Adds it to the list of required to launch fields on audience