### PR TITLE
fixes #5071 fix(nimbus): treat Approved publish status as reviewable

### DIFF
--- a/app/experimenter/experiments/models/nimbus.py
+++ b/app/experimenter/experiments/models/nimbus.py
@@ -302,6 +302,7 @@ class NimbusExperiment(NimbusConstants, FilterMixin, models.Model):
 
         if self.publish_status in (
             NimbusExperiment.PublishStatus.REVIEW,
+            NimbusExperiment.PublishStatus.APPROVED,
             NimbusExperiment.PublishStatus.WAITING,
         ):
             review_request = self.changes.latest_review_request()


### PR DESCRIPTION
Because:

- we want reviewers to see the prompt to open remote settings after
  local review approval until remote settings approval is completed

This commit:

- adds consideration of the Approved publish status as a part of where
  can_review is True for an experiment