### PR TITLE
fixes #5022 feat(nimbus): set a changelog message for all experiment changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,7 +303,15 @@ Run the integration test suite inside a containerized instance of Firefox. You m
 
 #### make integration_vnc_up
 
-Start a linux VM container with VNC available over `vnc://localhost:5900` with password `secret`. Right click on the desktop and select `Applications > Shell > Bash` and enter `tox -c tests/integration/` to run the integration tests and watch them run in a Firefox instance you can watch and interact with.
+Start a linux VM container with VNC available over `vnc://localhost:5900` with password `secret`. Right click on the desktop and select `Applications > Shell > Bash` and enter:
+
+```bash
+cd app
+sudo mkdir -m 0777 tests/integration/.tox/logs
+tox -c tests/integration/
+```
+
+This should run the integration tests and watch them run in a Firefox instance you can watch and interact with.
 
 ## Accessing Remote Settings locally
 

--- a/app/experimenter/experiments/api/v5/serializers.py
+++ b/app/experimenter/experiments/api/v5/serializers.py
@@ -321,6 +321,9 @@ class NimbusExperimentSerializer(
             )
         ],
     )
+    changelog_message = serializers.CharField(
+        min_length=0, max_length=1024, required=True, allow_blank=False
+    )
 
     class Meta:
         model = NimbusExperiment
@@ -347,6 +350,7 @@ class NimbusExperimentSerializer(
             "targeting_config_slug",
             "total_enrolled_clients",
             "is_end_requested",
+            "changelog_message",
         ]
 
     def __init__(self, instance=None, data=None, **kwargs):
@@ -360,7 +364,6 @@ class NimbusExperimentSerializer(
                 and data.get("status") == NimbusExperiment.Status.DRAFT
             )
         )
-        self.changelog_message = data and data.pop("changelog_message", "") or ""
         super().__init__(instance=instance, data=data, **kwargs)
 
     def validate_publish_status(self, publish_status):
@@ -460,6 +463,10 @@ class NimbusExperimentSerializer(
             )
         return data
 
+    def update(self, experiment, validated_data):
+        self.changelog_message = validated_data.pop("changelog_message")
+        return super().update(experiment, validated_data)
+
     def create(self, validated_data):
         validated_data.update(
             {
@@ -467,6 +474,7 @@ class NimbusExperimentSerializer(
                 "owner": self.context["user"],
             }
         )
+        self.changelog_message = validated_data.pop("changelog_message")
         return super().create(validated_data)
 
     def save(self, *args, **kwargs):

--- a/app/experimenter/experiments/changelog_utils/nimbus.py
+++ b/app/experimenter/experiments/changelog_utils/nimbus.py
@@ -38,7 +38,7 @@ class NimbusExperimentChangeLogSerializer(serializers.ModelSerializer):
         exclude = ("id",)
 
 
-def generate_nimbus_changelog(experiment, changed_by, message=None):
+def generate_nimbus_changelog(experiment, changed_by, message):
     latest_change = experiment.changes.latest_change()
     experiment_data = dict(NimbusExperimentChangeLogSerializer(experiment).data)
 

--- a/app/experimenter/experiments/models/nimbus.py
+++ b/app/experimenter/experiments/models/nimbus.py
@@ -548,6 +548,14 @@ class NimbusChangeLog(FilterMixin, models.Model):
             new_publish_status=NimbusExperiment.PublishStatus.REVIEW,
         )
 
+    class Messages:
+        TIMED_OUT_IN_KINTO = "Timed Out"
+        PUSHED_TO_KINTO = "Pushed to Kinto"
+        DELETED_FROM_KINTO = "Deleted from Kinto"
+        LIVE = "Experiment is now live!"
+        PAUSED = "Enrollment was paused"
+        COMPLETED = "Experiment is complete"
+
     def __str__(self):
         if self.message:
             return self.message

--- a/app/experimenter/experiments/tests/api/v5/test_mutations.py
+++ b/app/experimenter/experiments/tests/api/v5/test_mutations.py
@@ -62,6 +62,7 @@ class TestMutations(GraphQLTestCase):
                     "name": "Test 1234",
                     "hypothesis": "Test hypothesis",
                     "application": NimbusExperiment.Application.DESKTOP.name,
+                    "changelogMessage": "test changelog message",
                 }
             },
             headers={settings.OPENIDC_EMAIL_HEADER: user_email},
@@ -95,7 +96,10 @@ class TestMutations(GraphQLTestCase):
         result = content["data"]["createExperiment"]
         self.assertEqual(
             result["message"],
-            {"name": ["Ensure this field has no more than 255 characters."]},
+            {
+                "changelog_message": ["This field is required."],
+                "name": ["Ensure this field has no more than 255 characters."],
+            },
         )
 
     def test_update_experiment_overview(self):
@@ -116,6 +120,7 @@ class TestMutations(GraphQLTestCase):
                     "hypothesis": "new hypothesis",
                     "publicDescription": "new public description",
                     "riskMitigationLink": "https://example.com/risk",
+                    "changelogMessage": "test changelog message",
                 }
             },
             headers={settings.OPENIDC_EMAIL_HEADER: user_email},
@@ -144,6 +149,7 @@ class TestMutations(GraphQLTestCase):
                     "name": long_name,
                     "hypothesis": "new hypothesis",
                     "riskMitigationLink": "i like pie",
+                    "changelogMessage": "test changelog message",
                 }
             },
             headers={settings.OPENIDC_EMAIL_HEADER: user_email},
@@ -185,6 +191,7 @@ class TestMutations(GraphQLTestCase):
                 "input": {
                     "id": experiment.id,
                     "documentationLinks": documentation_links,
+                    "changelogMessage": "test changelog message",
                 }
             },
             headers={settings.OPENIDC_EMAIL_HEADER: user_email},
@@ -217,6 +224,7 @@ class TestMutations(GraphQLTestCase):
                     "name": "new name",
                     "hypothesis": "new hypothesis",
                     "publicDescription": "new public description",
+                    "changelogMessage": "test changelog message",
                 }
             },
             headers={settings.OPENIDC_EMAIL_HEADER: user_email},
@@ -244,6 +252,7 @@ class TestMutations(GraphQLTestCase):
                     "name": "new name",
                     "hypothesis": "new hypothesis",
                     "publicDescription": "new public description",
+                    "changelogMessage": "test changelog message",
                 }
             },
             headers={settings.OPENIDC_EMAIL_HEADER: user_email},
@@ -276,6 +285,7 @@ class TestMutations(GraphQLTestCase):
                     "featureConfigId": feature.id,
                     "referenceBranch": reference_branch,
                     "treatmentBranches": treatment_branches,
+                    "changelogMessage": "test changelog message",
                 }
             },
             headers={settings.OPENIDC_EMAIL_HEADER: user_email},
@@ -304,6 +314,7 @@ class TestMutations(GraphQLTestCase):
                     "featureConfigId": 2,
                     "referenceBranch": reference_branch,
                     "treatmentBranches": treatment_branches,
+                    "changelogMessage": "test changelog message",
                 }
             },
             headers={settings.OPENIDC_EMAIL_HEADER: user_email},
@@ -337,6 +348,7 @@ class TestMutations(GraphQLTestCase):
                     "id": experiment.id,
                     "primaryOutcomes": primary_outcomes,
                     "secondaryOutcomes": secondary_outcomes,
+                    "changelogMessage": "test changelog message",
                 }
             },
             headers={settings.OPENIDC_EMAIL_HEADER: user_email},
@@ -363,6 +375,7 @@ class TestMutations(GraphQLTestCase):
                     "id": experiment.id,
                     "primaryOutcomes": ["invalid-outcome"],
                     "secondaryOutcomes": ["invalid-outcome"],
+                    "changelogMessage": "test changelog message",
                 }
             },
             headers={settings.OPENIDC_EMAIL_HEADER: user_email},
@@ -409,6 +422,7 @@ class TestMutations(GraphQLTestCase):
                         NimbusConstants.TargetingConfig.ALL_ENGLISH.name
                     ),
                     "totalEnrolledClients": 100,
+                    "changelogMessage": "test changelog message",
                 }
             },
             headers={settings.OPENIDC_EMAIL_HEADER: user_email},
@@ -446,6 +460,7 @@ class TestMutations(GraphQLTestCase):
                 "input": {
                     "id": experiment.id,
                     "populationPercent": "10.23471",
+                    "changelogMessage": "test changelog message",
                 }
             },
             headers={settings.OPENIDC_EMAIL_HEADER: user_email},
@@ -473,6 +488,7 @@ class TestMutations(GraphQLTestCase):
                 "input": {
                     "id": experiment.id,
                     "status": NimbusExperiment.Status.PREVIEW.name,
+                    "changelogMessage": "test changelog message",
                 }
             },
             headers={settings.OPENIDC_EMAIL_HEADER: user_email},
@@ -493,6 +509,7 @@ class TestMutations(GraphQLTestCase):
                 "input": {
                     "id": experiment.id,
                     "publishStatus": NimbusExperiment.PublishStatus.REVIEW.name,
+                    "changelogMessage": "test changelog message",
                 }
             },
             headers={settings.OPENIDC_EMAIL_HEADER: user_email},
@@ -570,6 +587,7 @@ class TestMutations(GraphQLTestCase):
                 "input": {
                     "id": experiment.id,
                     "isEndRequested": True,
+                    "changelogMessage": "test changelog message",
                 }
             },
             headers={settings.OPENIDC_EMAIL_HEADER: user_email},
@@ -591,6 +609,7 @@ class TestMutations(GraphQLTestCase):
                 "input": {
                     "id": experiment.id,
                     "isEndRequested": True,
+                    "changelogMessage": "test changelog message",
                 }
             },
             headers={settings.OPENIDC_EMAIL_HEADER: user_email},

--- a/app/experimenter/experiments/tests/api/v5/test_queries.py
+++ b/app/experimenter/experiments/tests/api/v5/test_queries.py
@@ -368,7 +368,7 @@ class TestNimbusQuery(GraphQLTestCase):
 
         experiment.publish_status = NimbusExperiment.PublishStatus.REVIEW
         experiment.save()
-        generate_nimbus_changelog(experiment, experiment.owner)
+        generate_nimbus_changelog(experiment, experiment.owner, "test message")
         response = self.query(
             """
             query experimentBySlug($slug: String!) {
@@ -425,7 +425,7 @@ class TestNimbusQuery(GraphQLTestCase):
         ):
             experiment.publish_status = publish_status
             experiment.save()
-            generate_nimbus_changelog(experiment, experiment.owner)
+            generate_nimbus_changelog(experiment, experiment.owner, "test message")
 
         response = self.query(
             """
@@ -485,7 +485,7 @@ class TestNimbusQuery(GraphQLTestCase):
 
         experiment.publish_status = NimbusExperiment.PublishStatus.REVIEW
         experiment.save()
-        generate_nimbus_changelog(experiment, experiment.owner)
+        generate_nimbus_changelog(experiment, experiment.owner, "test message")
 
         response = self.query(
             """
@@ -517,7 +517,7 @@ class TestNimbusQuery(GraphQLTestCase):
         )
         experiment.publish_status = NimbusExperiment.PublishStatus.WAITING
         experiment.save()
-        generate_nimbus_changelog(experiment, experiment.owner)
+        generate_nimbus_changelog(experiment, experiment.owner, "test message")
 
         response = self.query(
             """
@@ -553,7 +553,7 @@ class TestNimbusQuery(GraphQLTestCase):
         ):
             experiment.publish_status = publish_status
             experiment.save()
-            generate_nimbus_changelog(experiment, experiment.owner)
+            generate_nimbus_changelog(experiment, experiment.owner, "test message")
 
         response = self.query(
             """

--- a/app/experimenter/experiments/tests/api/v5/test_serializers.py
+++ b/app/experimenter/experiments/tests/api/v5/test_serializers.py
@@ -56,6 +56,7 @@ class TestCreateNimbusExperimentOverviewSerializer(TestCase):
             "application": NimbusExperiment.Application.DESKTOP.value,
             "risk_mitigation_link": "https://example.com/risk",
             "public_description": "Test description",
+            "changelog_message": "test changelog message",
         }
 
         serializer = NimbusExperimentSerializer(data=data, context={"user": self.user})
@@ -78,6 +79,7 @@ class TestCreateNimbusExperimentOverviewSerializer(TestCase):
             "application": NimbusExperiment.Application.DESKTOP.value,
             "public_description": "Test description",
             "risk_mitigation_link": "",
+            "changelog_message": "test changelog message",
         }
         serializer = NimbusExperimentSerializer(data=data, context={"user": self.user})
         self.assertTrue(serializer.is_valid())
@@ -88,6 +90,7 @@ class TestCreateNimbusExperimentOverviewSerializer(TestCase):
             "hypothesis": "Test hypothesis",
             "application": NimbusExperiment.Application.DESKTOP.value,
             "public_description": "Test description",
+            "changelog_message": "test changelog message",
         }
 
         serializer = NimbusExperimentSerializer(data=data, context={"user": self.user})
@@ -108,6 +111,7 @@ class TestCreateNimbusExperimentOverviewSerializer(TestCase):
             "hypothesis": "Test hypothesis",
             "application": NimbusExperiment.Application.DESKTOP.value,
             "public_description": "Test description",
+            "changelog_message": "test changelog message",
         }
 
         serializer = NimbusExperimentSerializer(data=data, context={"user": self.user})
@@ -124,6 +128,7 @@ class TestCreateNimbusExperimentOverviewSerializer(TestCase):
             "hypothesis": NimbusExperiment.HYPOTHESIS_DEFAULT,
             "application": NimbusExperiment.Application.DESKTOP.value,
             "public_description": "Test description",
+            "changelog_message": "test changelog message",
         }
 
         serializer = NimbusExperimentSerializer(data=data, context={"user": self.user})
@@ -136,6 +141,7 @@ class TestCreateNimbusExperimentOverviewSerializer(TestCase):
             "hypothesis": "It does the thing",
             "name": "The Thing",
             "public_description": "Does it do the thing?",
+            "changelog_message": "test changelog message",
         }
 
         serializer = NimbusExperimentSerializer(data=data, context={"user": self.user})
@@ -165,6 +171,7 @@ class TestCreateNimbusExperimentOverviewSerializer(TestCase):
             "hypothesis": "New Hypothesis",
             "name": "New Name",
             "public_description": "New public description",
+            "changelog_message": "test changelog message",
         }
 
         serializer = NimbusExperimentSerializer(
@@ -254,6 +261,7 @@ class TestNimbusExperimentDocumentationLinkMixin(TestCase):
             status=NimbusExperiment.Status.DRAFT,
         )
         data = {
+            "changelog_message": "test changelog message",
             "public_description": "changed",
             "documentation_links": [
                 {
@@ -285,7 +293,10 @@ class TestNimbusExperimentDocumentationLinkMixin(TestCase):
                     "link": link.link,
                 }
             )
-        data = {"public_description": "changed"}
+        data = {
+            "public_description": "changed",
+            "changelog_message": "test changelog message",
+        }
         serializer = NimbusExperimentSerializer(
             experiment, data=data, partial=True, context={"user": self.user}
         )
@@ -342,6 +353,7 @@ class TestNimbusExperimentBranchMixin(TestCase):
             "feature_config": None,
             "reference_branch": reference_branch,
             "treatment_branches": treatment_branches,
+            "changelog_message": "test changelog message",
         }
         serializer = NimbusExperimentSerializer(
             experiment, data=data, partial=True, context={"user": self.user}
@@ -394,6 +406,7 @@ class TestNimbusExperimentBranchMixin(TestCase):
             "feature_config": feature_config.id,
             "reference_branch": reference_branch,
             "treatment_branches": treatment_branches,
+            "changelog_message": "test changelog message",
         }
         serializer = NimbusExperimentSerializer(
             experiment, data=data, partial=True, context={"user": self.user}
@@ -447,6 +460,7 @@ class TestNimbusExperimentBranchMixin(TestCase):
             "feature_config": feature_config.id,
             "reference_branch": reference_branch,
             "treatment_branches": treatment_branches,
+            "changelog_message": "test changelog message",
         }
         serializer = NimbusExperimentSerializer(
             experiment, data=data, partial=True, context={"user": self.user}
@@ -491,6 +505,7 @@ class TestNimbusExperimentBranchMixin(TestCase):
             "feature_config": feature_config.id,
             "reference_branch": reference_branch,
             "treatment_branches": treatment_branches,
+            "changelog_message": "test changelog message",
         }
         serializer = NimbusExperimentSerializer(
             experiment, data=data, partial=True, context={"user": self.user}
@@ -530,6 +545,7 @@ class TestNimbusExperimentBranchMixin(TestCase):
         data = {
             "reference_branch": reference_branch,
             "treatment_branches": treatment_branches,
+            "changelog_message": "test changelog message",
         }
         serializer = NimbusExperimentSerializer(
             experiment, data=data, partial=True, context={"user": self.user}
@@ -579,6 +595,7 @@ class TestNimbusExperimentBranchMixin(TestCase):
             "feature_config": feature_config.id,
             "reference_branch": reference_branch,
             "treatment_branches": treatment_branches,
+            "changelog_message": "test changelog message",
         }
         serializer = NimbusExperimentSerializer(
             experiment, data=data, partial=True, context={"user": self.user}
@@ -622,6 +639,7 @@ class TestNimbusExperimentBranchMixin(TestCase):
                 "feature_config": feature_config.id,
                 "reference_branch": reference_branch,
                 "treatment_branches": treatment_branches,
+                "changelog_message": "test changelog message",
             },
             partial=True,
             context={"user": self.user},
@@ -646,7 +664,10 @@ class TestNimbusExperimentBranchMixin(TestCase):
 
         serializer = NimbusExperimentSerializer(
             instance=experiment,
-            data={"name": "new name"},
+            data={
+                "name": "new name",
+                "changelog_message": "test changelog message",
+            },
             context={"user": UserFactory()},
         )
         self.assertTrue(serializer.is_valid())
@@ -670,6 +691,7 @@ class TestNimbusExperimentBranchMixin(TestCase):
             "feature_config": None,
             "reference_branch": reference_branch,
             "treatment_branches": treatment_branches,
+            "changelog_message": "test changelog message",
         }
         serializer = NimbusExperimentSerializer(
             experiment, data=data, partial=True, context={"user": self.user}
@@ -712,6 +734,7 @@ class TestNimbusExperimentSerializer(TestCase):
             "name": "",
             "hypothesis": NimbusExperiment.HYPOTHESIS_DEFAULT,
             "application": "",
+            "changelog_message": "test changelog message",
         }
 
         serializer = NimbusExperimentSerializer(
@@ -743,6 +766,7 @@ class TestNimbusExperimentSerializer(TestCase):
             "proposed_enrollment": 0,
             "targeting_config_slug": NimbusExperiment.TargetingConfig.NO_TARGETING,
             "total_enrolled_clients": 0,
+            "changelog_message": "test changelog message",
         }
 
         serializer = NimbusExperimentSerializer(
@@ -781,6 +805,7 @@ class TestNimbusExperimentSerializer(TestCase):
             "hypothesis": "Test hypothesis",
             "application": NimbusExperiment.Application.DESKTOP.value,
             "public_description": "Test description",
+            "changelog_message": "test changelog message",
         }
 
         serializer = NimbusExperimentSerializer(data=data, context={"user": self.user})
@@ -801,6 +826,7 @@ class TestNimbusExperimentSerializer(TestCase):
             "hypothesis": "Test hypothesis",
             "application": NimbusExperiment.Application.DESKTOP.value,
             "public_description": "Test description",
+            "changelog_message": "test changelog message",
         }
 
         serializer = NimbusExperimentSerializer(data=data, context={"user": self.user})
@@ -821,6 +847,7 @@ class TestNimbusExperimentSerializer(TestCase):
             "hypothesis": "Test hypothesis",
             "application": NimbusExperiment.Application.DESKTOP.value,
             "public_description": "Test description",
+            "changelog_message": "test changelog message",
         }
 
         serializer = NimbusExperimentSerializer(data=data, context={"user": self.user})
@@ -837,6 +864,7 @@ class TestNimbusExperimentSerializer(TestCase):
             "hypothesis": NimbusExperiment.HYPOTHESIS_DEFAULT,
             "application": NimbusExperiment.Application.DESKTOP.value,
             "public_description": "Test description",
+            "changelog_message": "test changelog message",
         }
 
         serializer = NimbusExperimentSerializer(data=data, context={"user": self.user})
@@ -849,6 +877,7 @@ class TestNimbusExperimentSerializer(TestCase):
             "hypothesis": "It does the thing",
             "name": "The Thing",
             "public_description": "Does it do the thing?",
+            "changelog_message": "test changelog message",
         }
 
         serializer = NimbusExperimentSerializer(data=data, context={"user": self.user})
@@ -878,6 +907,7 @@ class TestNimbusExperimentSerializer(TestCase):
             "hypothesis": "New Hypothesis",
             "name": "New Name",
             "public_description": "New public description",
+            "changelog_message": "test changelog message",
         }
 
         serializer = NimbusExperimentSerializer(
@@ -917,6 +947,7 @@ class TestNimbusExperimentSerializer(TestCase):
                     NimbusConstants.TargetingConfig.ALL_ENGLISH.value
                 ),
                 "total_enrolled_clients": 100,
+                "changelog_message": "test changelog message",
             },
             context={"user": self.user},
         )
@@ -953,7 +984,10 @@ class TestNimbusExperimentSerializer(TestCase):
         experiment = NimbusExperimentFactory()
         serializer = NimbusExperimentSerializer(
             experiment,
-            {"population_percent": population_percent},
+            {
+                "population_percent": population_percent,
+                "changelog_message": "test changelog message",
+            },
             context={"user": self.user},
         )
         self.assertEqual(serializer.is_valid(), expected_valid)
@@ -972,7 +1006,10 @@ class TestNimbusExperimentSerializer(TestCase):
         experiment = NimbusExperimentFactory(status=from_status)
         serializer = NimbusExperimentSerializer(
             experiment,
-            data={"status": to_status},
+            data={
+                "status": to_status,
+                "changelog_message": "test changelog message",
+            },
             context={"user": self.user},
         )
         self.assertEqual(experiment.changes.count(), 0)
@@ -985,7 +1022,10 @@ class TestNimbusExperimentSerializer(TestCase):
         experiment = NimbusExperimentFactory(status=NimbusExperiment.Status.DRAFT)
         serializer = NimbusExperimentSerializer(
             experiment,
-            data={"status": NimbusExperiment.Status.COMPLETE},
+            data={
+                "status": NimbusExperiment.Status.COMPLETE,
+                "changelog_message": "test changelog message",
+            },
             context={"user": self.user},
         )
         self.assertEqual(experiment.changes.count(), 0)
@@ -1004,7 +1044,10 @@ class TestNimbusExperimentSerializer(TestCase):
         experiment = NimbusExperimentFactory(status=NimbusExperiment.Status.LIVE)
         serializer = NimbusExperimentSerializer(
             experiment,
-            data={"name": "new name"},
+            data={
+                "name": "new name",
+                "changelog_message": "test changelog message",
+            },
             context={"user": self.user},
         )
         self.assertEqual(experiment.changes.count(), 0)
@@ -1020,7 +1063,10 @@ class TestNimbusExperimentSerializer(TestCase):
 
         serializer = NimbusExperimentSerializer(
             experiment,
-            data={"status": NimbusExperiment.Status.PREVIEW},
+            data={
+                "status": NimbusExperiment.Status.PREVIEW,
+                "changelog_message": "test changelog message",
+            },
             context={"user": self.user},
         )
         self.assertTrue(serializer.is_valid())
@@ -1039,13 +1085,16 @@ class TestNimbusExperimentSerializer(TestCase):
 
         experiment.publish_status = NimbusExperiment.PublishStatus.REVIEW
         experiment.save()
-        generate_nimbus_changelog(experiment, experiment.owner)
+        generate_nimbus_changelog(experiment, experiment.owner, "test message")
 
         self.assertFalse(NimbusBucketRange.objects.filter(experiment=experiment).exists())
 
         serializer = NimbusExperimentSerializer(
             experiment,
-            data={"publish_status": NimbusExperiment.PublishStatus.APPROVED},
+            data={
+                "publish_status": NimbusExperiment.PublishStatus.APPROVED,
+                "changelog_message": "test changelog message",
+            },
             context={"user": self.user},
         )
         self.assertTrue(serializer.is_valid())
@@ -1068,7 +1117,10 @@ class TestNimbusExperimentSerializer(TestCase):
 
         serializer = NimbusExperimentSerializer(
             experiment,
-            data={"status": to_status},
+            data={
+                "status": to_status,
+                "changelog_message": "test changelog message",
+            },
             context={"user": self.user},
         )
         self.assertTrue(serializer.is_valid())
@@ -1084,7 +1136,10 @@ class TestNimbusExperimentSerializer(TestCase):
 
         serializer = NimbusExperimentSerializer(
             experiment,
-            data={"status": NimbusExperiment.Status.DRAFT},
+            data={
+                "status": NimbusExperiment.Status.DRAFT,
+                "changelog_message": "test changelog message",
+            },
             context={"user": self.user},
         )
         self.assertTrue(serializer.is_valid())
@@ -1112,6 +1167,7 @@ class TestNimbusExperimentSerializer(TestCase):
             data={
                 "primary_outcomes": primary_outcomes,
                 "secondary_outcomes": secondary_outcomes,
+                "changelog_message": "test changelog message",
             },
             context={"user": self.user},
         )
@@ -1134,6 +1190,7 @@ class TestNimbusExperimentSerializer(TestCase):
             data={
                 "primary_outcomes": ["invalid-slug"],
                 "secondary_outcomes": ["invalid-slug"],
+                "changelog_message": "test changelog message",
             },
             context={"user": self.user},
         )
@@ -1160,6 +1217,7 @@ class TestNimbusExperimentSerializer(TestCase):
             data={
                 "primary_outcomes": primary_outcomes,
                 "secondary_outcomes": secondary_outcomes,
+                "changelog_message": "test changelog message",
             },
             context={"user": self.user},
         )
@@ -1187,6 +1245,7 @@ class TestNimbusExperimentSerializer(TestCase):
             data={
                 "primary_outcomes": outcomes,
                 "secondary_outcomes": outcomes,
+                "changelog_message": "test changelog message",
             },
             context={"user": self.user},
         )
@@ -1211,6 +1270,7 @@ class TestNimbusExperimentSerializer(TestCase):
                     "someotheroutcome",
                     "toomanyoutcomes",
                 ],
+                "changelog_message": "test changelog message",
             },
             context={"user": self.user},
         )
@@ -1228,6 +1288,7 @@ class TestNimbusExperimentSerializer(TestCase):
             data={
                 "status": NimbusExperiment.Status.DRAFT.value,
                 "publish_status": NimbusExperiment.PublishStatus.REVIEW.value,
+                "changelog_message": "test changelog message",
             },
             context={"user": self.user},
         )
@@ -1246,12 +1307,13 @@ class TestNimbusExperimentSerializer(TestCase):
         experiment.publish_status = NimbusExperiment.PublishStatus.REVIEW
         experiment.save()
 
-        generate_nimbus_changelog(experiment, experiment.owner)
+        generate_nimbus_changelog(experiment, experiment.owner, "test message")
 
         serializer = NimbusExperimentSerializer(
             experiment,
             data={
                 "publish_status": NimbusExperiment.PublishStatus.APPROVED.value,
+                "changelog_message": "test changelog message",
             },
             context={"user": self.user},
         )
@@ -1271,12 +1333,13 @@ class TestNimbusExperimentSerializer(TestCase):
         experiment.publish_status = NimbusExperiment.PublishStatus.REVIEW
         experiment.save()
 
-        generate_nimbus_changelog(experiment, experiment.owner)
+        generate_nimbus_changelog(experiment, experiment.owner, "test message")
 
         serializer = NimbusExperimentSerializer(
             experiment,
             data={
                 "publish_status": NimbusExperiment.PublishStatus.APPROVED.value,
+                "changelog_message": "test changelog message",
             },
             context={"user": experiment.owner},
         )
@@ -1290,12 +1353,13 @@ class TestNimbusExperimentSerializer(TestCase):
             publish_status=NimbusExperiment.PublishStatus.IDLE,
         )
 
-        generate_nimbus_changelog(experiment, experiment.owner)
+        generate_nimbus_changelog(experiment, experiment.owner, "test message")
 
         serializer = NimbusExperimentSerializer(
             experiment,
             data={
                 "publish_status": NimbusExperiment.PublishStatus.APPROVED.value,
+                "changelog_message": "test changelog message",
             },
             context={"user": experiment.owner},
         )
@@ -1311,12 +1375,13 @@ class TestNimbusExperimentSerializer(TestCase):
         experiment.publish_status = NimbusExperiment.PublishStatus.REVIEW
         experiment.save()
 
-        generate_nimbus_changelog(experiment, experiment.owner)
+        generate_nimbus_changelog(experiment, experiment.owner, "test message")
 
         serializer = NimbusExperimentSerializer(
             experiment,
             data={
                 "publish_status": NimbusExperiment.PublishStatus.IDLE.value,
+                "changelog_message": "test changelog message",
             },
             context={"user": experiment.owner},
         )
@@ -1504,6 +1569,7 @@ class TestNimbusStatusTransitionValidator(TestCase):
             experiment,
             data={
                 "status": NimbusExperiment.Status.LIVE,
+                "changelog_message": "test changelog message",
             },
             context={"user": self.user},
         )
@@ -1521,6 +1587,7 @@ class TestNimbusStatusTransitionValidator(TestCase):
             experiment,
             data={
                 "publish_status": NimbusExperiment.PublishStatus.REVIEW,
+                "changelog_message": "test changelog message",
             },
             context={"user": self.user},
         )
@@ -1546,6 +1613,7 @@ class TestNimbusStatusValidationMixin(TestCase):
             experiment,
             data={
                 "publish_status": NimbusExperiment.PublishStatus.APPROVED,
+                "changelog_message": "test changelog message",
             },
             context={"user": self.user},
         )
@@ -1559,6 +1627,7 @@ class TestNimbusStatusValidationMixin(TestCase):
             experiment,
             data={
                 "public_description": "who knows, really",
+                "changelog_message": "test changelog message",
             },
             context={"user": self.user},
         )
@@ -1573,6 +1642,7 @@ class TestNimbusStatusValidationMixin(TestCase):
             experiment,
             data={
                 "public_description": "who knows, really",
+                "changelog_message": "test changelog message",
             },
             context={"user": self.user},
         )

--- a/app/experimenter/experiments/tests/factories/nimbus.py
+++ b/app/experimenter/experiments/tests/factories/nimbus.py
@@ -134,7 +134,11 @@ class NimbusExperimentFactory(factory.django.DjangoModelFactory):
             if experiment.has_filter(experiment.Filters.SHOULD_ALLOCATE_BUCKETS):
                 experiment.allocate_bucket_range()
 
-            generate_nimbus_changelog(experiment, experiment.owner)
+            generate_nimbus_changelog(
+                experiment,
+                experiment.owner,
+                f"set status to {status}, target status is {target_status}",
+            )
 
             if status == target_status:
                 break

--- a/app/experimenter/experiments/tests/test_changelog_utils/test_changelog_utils_nimbus.py
+++ b/app/experimenter/experiments/tests/test_changelog_utils/test_changelog_utils_nimbus.py
@@ -142,13 +142,14 @@ class TestGenerateNimbusChangeLog(TestCase):
 
         self.assertEqual(experiment.changes.count(), 0)
 
-        generate_nimbus_changelog(experiment, self.user)
+        generate_nimbus_changelog(experiment, self.user, "test message")
 
         self.assertEqual(experiment.changes.count(), 1)
 
         change = experiment.changes.get()
 
         self.assertEqual(change.experiment, experiment)
+        self.assertEqual(change.message, "test message")
         self.assertEqual(change.changed_by, self.user)
         self.assertEqual(change.old_status, None)
         self.assertEqual(change.old_publish_status, None)
@@ -170,13 +171,14 @@ class TestGenerateNimbusChangeLog(TestCase):
         experiment.publish_status = NimbusExperiment.PublishStatus.REVIEW
         experiment.save()
 
-        generate_nimbus_changelog(experiment, self.user)
+        generate_nimbus_changelog(experiment, self.user, "test message")
 
         self.assertEqual(experiment.changes.count(), 2)
 
         change = experiment.changes.latest_change()
 
         self.assertEqual(change.experiment, experiment)
+        self.assertEqual(change.message, "test message")
         self.assertEqual(change.changed_by, self.user)
         self.assertEqual(change.old_status, NimbusExperiment.Status.DRAFT)
         self.assertEqual(change.old_publish_status, NimbusExperiment.PublishStatus.IDLE)

--- a/app/experimenter/experiments/tests/test_models/test_models_nimbus.py
+++ b/app/experimenter/experiments/tests/test_models/test_models_nimbus.py
@@ -455,7 +455,7 @@ class TestNimbusExperiment(TestCase):
         experiment.publish_status = NimbusExperiment.PublishStatus.REVIEW
         experiment.save()
 
-        generate_nimbus_changelog(experiment, experiment.owner)
+        generate_nimbus_changelog(experiment, experiment.owner, "test message")
 
         self.assertFalse(experiment.can_review(experiment.owner))
 
@@ -467,7 +467,7 @@ class TestNimbusExperiment(TestCase):
         experiment.publish_status = NimbusExperiment.PublishStatus.REVIEW
         experiment.save()
 
-        generate_nimbus_changelog(experiment, experiment.owner)
+        generate_nimbus_changelog(experiment, experiment.owner, "test message")
 
         self.assertTrue(experiment.can_review(UserFactory.create()))
 
@@ -507,7 +507,7 @@ class TestNimbusExperiment(TestCase):
         experiment.publish_status = NimbusExperiment.PublishStatus.REVIEW
         experiment.save()
 
-        generate_nimbus_changelog(experiment, experiment.owner)
+        generate_nimbus_changelog(experiment, experiment.owner, "test message")
 
         self.assertEqual(experiment.can_review(user), is_allowed)
 
@@ -525,7 +525,7 @@ class TestNimbusExperiment(TestCase):
         experiment.publish_status = NimbusExperiment.PublishStatus.REVIEW
         experiment.save()
 
-        generate_nimbus_changelog(experiment, experiment.owner)
+        generate_nimbus_changelog(experiment, experiment.owner, "test message")
 
         experiment.publish_status = publish_status
         experiment.save()
@@ -547,7 +547,7 @@ class TestNimbusExperiment(TestCase):
         # Simulate waiting for approval in remote settings
         experiment.publish_status = NimbusExperiment.PublishStatus.WAITING
         experiment.save()
-        generate_nimbus_changelog(experiment, experiment.owner)
+        generate_nimbus_changelog(experiment, experiment.owner, "test message")
 
         # No timeout at first.
         self.assertIsNone(experiment.changes.latest_timeout())
@@ -555,7 +555,7 @@ class TestNimbusExperiment(TestCase):
         # Next, simulate a timeout.
         experiment.publish_status = NimbusExperiment.PublishStatus.REVIEW
         experiment.save()
-        generate_nimbus_changelog(experiment, experiment.owner)
+        generate_nimbus_changelog(experiment, experiment.owner, "test message")
 
         # Timeout should be the latest changelog entry.
         self.assertEqual(
@@ -744,7 +744,7 @@ class TestNimbusChangeLogManager(TestCase):
         experiment.publish_status = NimbusExperiment.PublishStatus.REVIEW
         experiment.save()
 
-        change = generate_nimbus_changelog(experiment, experiment.owner)
+        change = generate_nimbus_changelog(experiment, experiment.owner, "test message")
 
         self.assertEqual(experiment.changes.latest_review_request(), change)
 
@@ -757,16 +757,18 @@ class TestNimbusChangeLogManager(TestCase):
         experiment.publish_status = NimbusExperiment.PublishStatus.REVIEW
         experiment.save()
 
-        generate_nimbus_changelog(experiment, experiment.owner)
+        generate_nimbus_changelog(experiment, experiment.owner, "test message")
 
         experiment.publish_status = NimbusExperiment.PublishStatus.IDLE
         experiment.save()
-        generate_nimbus_changelog(experiment, reviewer)
+        generate_nimbus_changelog(experiment, reviewer, "test message")
 
         experiment.publish_status = NimbusExperiment.PublishStatus.REVIEW
         experiment.save()
 
-        second_request = generate_nimbus_changelog(experiment, experiment.owner)
+        second_request = generate_nimbus_changelog(
+            experiment, experiment.owner, "test message"
+        )
 
         self.assertEqual(experiment.changes.latest_review_request(), second_request)
 
@@ -790,7 +792,9 @@ class TestNimbusChangeLogManager(TestCase):
         ):
             experiment.publish_status = publish_status
             experiment.save()
-            changes.append(generate_nimbus_changelog(experiment, experiment.owner))
+            changes.append(
+                generate_nimbus_changelog(experiment, experiment.owner, "test message")
+            )
 
         self.assertEqual(experiment.changes.latest_review_request(), changes[0])
         self.assertEqual(experiment.changes.latest_rejection(), changes[1])
@@ -810,7 +814,9 @@ class TestNimbusChangeLogManager(TestCase):
         ):
             experiment.publish_status = publish_status
             experiment.save()
-            changes.append(generate_nimbus_changelog(experiment, experiment.owner))
+            changes.append(
+                generate_nimbus_changelog(experiment, experiment.owner, "test message")
+            )
 
         self.assertEqual(experiment.changes.latest_review_request(), changes[0])
         self.assertEqual(experiment.changes.latest_rejection(), changes[3])
@@ -824,7 +830,7 @@ class TestNimbusChangeLogManager(TestCase):
         experiment.status = NimbusExperiment.Status.LIVE
         experiment.publish_status = NimbusExperiment.PublishStatus.IDLE
         experiment.save()
-        generate_nimbus_changelog(experiment, experiment.owner)
+        generate_nimbus_changelog(experiment, experiment.owner, "test message")
 
         self.assertIsNone(experiment.changes.latest_rejection())
 
@@ -842,7 +848,7 @@ class TestNimbusChangeLogManager(TestCase):
         ):
             experiment.publish_status = publish_status
             experiment.save()
-            generate_nimbus_changelog(experiment, experiment.owner)
+            generate_nimbus_changelog(experiment, experiment.owner, "test message")
 
         self.assertIsNone(experiment.changes.latest_timeout())
 
@@ -861,7 +867,7 @@ class TestNimbusChangeLogManager(TestCase):
         ):
             experiment.publish_status = publish_status
             experiment.save()
-            generate_nimbus_changelog(experiment, experiment.owner)
+            generate_nimbus_changelog(experiment, experiment.owner, "test message")
 
         self.assertIsNone(experiment.changes.latest_rejection())
 

--- a/app/experimenter/kinto/tasks.py
+++ b/app/experimenter/kinto/tasks.py
@@ -7,7 +7,7 @@ from experimenter.celery import app
 from experimenter.experiments.api.v6.serializers import NimbusExperimentSerializer
 from experimenter.experiments.changelog_utils import generate_nimbus_changelog
 from experimenter.experiments.email import nimbus_send_experiment_ending_email
-from experimenter.experiments.models import NimbusExperiment
+from experimenter.experiments.models import NimbusChangeLog, NimbusExperiment
 from experimenter.kinto.client import KintoClient
 
 logger = get_task_logger(__name__)
@@ -100,7 +100,7 @@ def handle_pending_review(applications, kinto_client):
             generate_nimbus_changelog(
                 experiment,
                 get_kinto_user(),
-                message="Timed Out",
+                message=NimbusChangeLog.Messages.TIMED_OUT_IN_KINTO,
             )
 
             logger.info(f"{experiment} timed out")
@@ -151,7 +151,11 @@ def nimbus_push_experiment_to_kinto(collection, experiment_id):
         experiment.publish_status = NimbusExperiment.PublishStatus.WAITING
         experiment.save()
 
-        generate_nimbus_changelog(experiment, get_kinto_user())
+        generate_nimbus_changelog(
+            experiment,
+            get_kinto_user(),
+            message=NimbusChangeLog.Messages.PUSHED_TO_KINTO,
+        )
 
         logger.info(f"{experiment.slug} pushed to Kinto")
         metrics.incr("push_experiment_to_kinto.completed")
@@ -217,7 +221,11 @@ def nimbus_end_experiment_in_kinto(collection, experiment_id):
         experiment.publish_status = NimbusExperiment.PublishStatus.WAITING
         experiment.save()
 
-        generate_nimbus_changelog(experiment, get_kinto_user())
+        generate_nimbus_changelog(
+            experiment,
+            get_kinto_user(),
+            message=NimbusChangeLog.Messages.DELETED_FROM_KINTO,
+        )
 
         logger.info(f"{experiment.slug} deleted from Kinto")
         metrics.incr("end_experiment_in_kinto.completed")
@@ -254,7 +262,9 @@ def nimbus_check_experiments_are_live():
                 experiment.save()
 
                 generate_nimbus_changelog(
-                    experiment, get_kinto_user(), message="Experiment is now live!"
+                    experiment,
+                    get_kinto_user(),
+                    message=NimbusChangeLog.Messages.LIVE,
                 )
 
                 logger.info(f"{experiment.slug} status is set to Live")
@@ -296,7 +306,11 @@ def nimbus_check_experiments_are_paused():
                 experiment.is_paused = True
                 experiment.save()
 
-                generate_nimbus_changelog(experiment, get_kinto_user())
+                generate_nimbus_changelog(
+                    experiment,
+                    get_kinto_user(),
+                    message=NimbusChangeLog.Messages.PAUSED,
+                )
 
                 logger.info(f"{experiment.slug} is_paused is set to True")
 
@@ -346,7 +360,11 @@ def nimbus_check_experiments_are_complete():
                 experiment.publish_status = NimbusExperiment.PublishStatus.IDLE
                 experiment.save()
 
-                generate_nimbus_changelog(experiment, get_kinto_user())
+                generate_nimbus_changelog(
+                    experiment,
+                    get_kinto_user(),
+                    message=NimbusChangeLog.Messages.COMPLETED,
+                )
 
                 logger.info(f"{experiment.slug} status is set to Complete")
 

--- a/app/experimenter/kinto/tests/test_tasks.py
+++ b/app/experimenter/kinto/tests/test_tasks.py
@@ -6,7 +6,7 @@ from django.core import mail
 from django.test import TestCase
 
 from experimenter.experiments.api.v6.serializers import NimbusExperimentSerializer
-from experimenter.experiments.models import NimbusExperiment
+from experimenter.experiments.models import NimbusChangeLog, NimbusExperiment
 from experimenter.experiments.tests.factories import NimbusExperimentFactory
 from experimenter.kinto import tasks
 from experimenter.kinto.client import KINTO_REVIEW_STATUS, KINTO_ROLLBACK_STATUS
@@ -442,6 +442,7 @@ class TestNimbusPushExperimentToKintoTask(MockKintoClientMixin, TestCase):
             experiment.changes.filter(
                 old_publish_status=NimbusExperiment.PublishStatus.APPROVED,
                 new_publish_status=NimbusExperiment.PublishStatus.WAITING,
+                message="Pushed to Kinto",
             ).exists()
         )
 
@@ -574,6 +575,7 @@ class TestNimbusEndExperimentInKinto(MockKintoClientMixin, TestCase):
             experiment.changes.filter(
                 old_publish_status=NimbusExperiment.PublishStatus.APPROVED,
                 new_publish_status=NimbusExperiment.PublishStatus.WAITING,
+                message=NimbusChangeLog.Messages.DELETED_FROM_KINTO,
             ).exists()
         )
 
@@ -658,6 +660,9 @@ class TestNimbusCheckExperimentsArePaused(MockKintoClientMixin, TestCase):
         experiment = NimbusExperiment.objects.get(id=experiment.id)
         self.assertTrue(experiment.is_paused)
         self.assertEqual(experiment.changes.count(), changes_count + 1)
+        self.assertTrue(
+            experiment.changes.filter(message=NimbusChangeLog.Messages.PAUSED).exists()
+        )
 
     def test_ignores_paused_experiment_with_isEnrollmentPaused_true(self):
         experiment = NimbusExperimentFactory.create_with_status(
@@ -731,6 +736,7 @@ class TestNimbusCheckExperimentsAreComplete(MockKintoClientMixin, TestCase):
                 changed_by__email=settings.KINTO_DEFAULT_CHANGELOG_USER,
                 old_status=NimbusExperiment.Status.LIVE,
                 new_status=NimbusExperiment.Status.COMPLETE,
+                message=NimbusChangeLog.Messages.COMPLETED,
             ).exists()
         )
 
@@ -741,6 +747,7 @@ class TestNimbusCheckExperimentsAreComplete(MockKintoClientMixin, TestCase):
                 old_publish_status=NimbusExperiment.PublishStatus.WAITING,
                 new_status=NimbusExperiment.Status.COMPLETE,
                 new_publish_status=NimbusExperiment.PublishStatus.IDLE,
+                message=NimbusChangeLog.Messages.COMPLETED,
             ).exists()
         )
 

--- a/app/experimenter/nimbus-ui/src/components/PageEditAudience/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditAudience/index.test.tsx
@@ -15,7 +15,7 @@ import fetchMock from "jest-fetch-mock";
 import React from "react";
 import PageEditAudience from ".";
 import { UPDATE_EXPERIMENT_MUTATION } from "../../gql/experiments";
-import { SUBMIT_ERROR } from "../../lib/constants";
+import { CHANGELOG_MESSAGES, SUBMIT_ERROR } from "../../lib/constants";
 import { mockExperimentQuery } from "../../lib/mocks";
 import { RouterSlugProvider } from "../../lib/test-utils";
 import {
@@ -44,7 +44,11 @@ describe("PageEditAudience", () => {
   beforeEach(() => {
     mockSubmitData = { ...MOCK_FORM_DATA };
     mutationMock = mockUpdateExperimentAudienceMutation(
-      { ...mockSubmitData, id: experiment.id },
+      {
+        ...mockSubmitData,
+        id: experiment.id,
+        changelogMessage: CHANGELOG_MESSAGES.UPDATED_AUDIENCE,
+      },
       {},
     );
   });

--- a/app/experimenter/nimbus-ui/src/components/PageEditAudience/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditAudience/index.tsx
@@ -6,7 +6,7 @@ import { useMutation } from "@apollo/client";
 import { navigate, RouteComponentProps } from "@reach/router";
 import React, { useCallback, useRef, useState } from "react";
 import { UPDATE_EXPERIMENT_MUTATION } from "../../gql/experiments";
-import { SUBMIT_ERROR } from "../../lib/constants";
+import { CHANGELOG_MESSAGES, SUBMIT_ERROR } from "../../lib/constants";
 import { editCommonRedirects } from "../../lib/experiment";
 import { getExperiment_experimentBySlug } from "../../types/getExperiment";
 import { ExperimentInput } from "../../types/globalTypes";
@@ -45,6 +45,7 @@ const PageEditAudience: React.FunctionComponent<RouteComponentProps> = () => {
           variables: {
             input: {
               id: nimbusExperimentId,
+              changelogMessage: CHANGELOG_MESSAGES.UPDATED_AUDIENCE,
               channel,
               firefoxMinVersion,
               targetingConfigSlug,

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/index.test.tsx
@@ -66,13 +66,14 @@ describe("FormBranches", () => {
         }}
       />,
     );
-    expect(
-      (screen.getByTestId("referenceBranch.name") as HTMLInputElement).value,
-    ).toEqual("control");
-    expect(
-      (screen.getByTestId("treatmentBranches[0].name") as HTMLInputElement)
-        .value,
-    ).toEqual("treatment");
+    const controlBranchName = (await screen.findByTestId(
+      "referenceBranch.name",
+    )) as HTMLInputElement;
+    expect(controlBranchName.value).toEqual("control");
+    const treatmentBranchName = (await screen.findByTestId(
+      "treatmentBranches[0].name",
+    )) as HTMLInputElement;
+    expect(treatmentBranchName.value).toEqual("treatment");
   });
 
   it("calls onSave with extracted update when save button clicked", async () => {

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/index.test.tsx
@@ -14,7 +14,7 @@ import fetchMock from "jest-fetch-mock";
 import React from "react";
 import PageEditBranches, { SUBMIT_ERROR_MESSAGE } from ".";
 import { UPDATE_EXPERIMENT_MUTATION } from "../../gql/experiments";
-import { EXTERNAL_URLS } from "../../lib/constants";
+import { CHANGELOG_MESSAGES, EXTERNAL_URLS } from "../../lib/constants";
 import { mockExperimentQuery, MOCK_CONFIG } from "../../lib/mocks";
 import { RouterSlugProvider } from "../../lib/test-utils";
 import { getExperiment_experimentBySlug } from "../../types/getExperiment";
@@ -72,7 +72,11 @@ describe("PageEditBranches", () => {
     const { mock, experiment } = mockExperimentQuery("demo-slug");
     setMockUpdateState(experiment);
     const mockMutation = mockUpdateExperimentBranchesMutation(
-      { ...mockUpdateState, id: 1 },
+      {
+        ...mockUpdateState,
+        id: 1,
+        changelogMessage: CHANGELOG_MESSAGES.UPDATED_BRANCHES,
+      },
       {},
     );
     render(<Subject mocks={[mock, mockMutation]} />);
@@ -87,7 +91,11 @@ describe("PageEditBranches", () => {
     const { mock, experiment } = mockExperimentQuery("demo-slug");
     setMockUpdateState(experiment);
     const mockMutation = mockUpdateExperimentBranchesMutation(
-      { ...mockUpdateState, id: 1 },
+      {
+        ...mockUpdateState,
+        id: 1,
+        changelogMessage: CHANGELOG_MESSAGES.UPDATED_BRANCHES,
+      },
       {},
     );
     render(<Subject mocks={[mock, mockMutation, mock]} />);
@@ -103,7 +111,11 @@ describe("PageEditBranches", () => {
     setMockUpdateState(experiment);
 
     const mockMutation = mockUpdateExperimentBranchesMutation(
-      { ...mockUpdateState, id: 1 },
+      {
+        ...mockUpdateState,
+        id: 1,
+        changelogMessage: CHANGELOG_MESSAGES.UPDATED_BRANCHES,
+      },
       {},
     );
     // @ts-ignore - intentionally breaking this type for error handling
@@ -129,7 +141,11 @@ describe("PageEditBranches", () => {
     setMockUpdateState(experiment);
 
     const mockMutation = mockUpdateExperimentBranchesMutation(
-      { ...mockUpdateState, id: 1 },
+      {
+        ...mockUpdateState,
+        id: 1,
+        changelogMessage: CHANGELOG_MESSAGES.UPDATED_BRANCHES,
+      },
       {},
     );
 

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/index.tsx
@@ -7,7 +7,7 @@ import { navigate, RouteComponentProps } from "@reach/router";
 import React, { useCallback, useRef } from "react";
 import { UPDATE_EXPERIMENT_MUTATION } from "../../gql/experiments";
 import { useConfig } from "../../hooks";
-import { EXTERNAL_URLS } from "../../lib/constants";
+import { CHANGELOG_MESSAGES, EXTERNAL_URLS } from "../../lib/constants";
 import { editCommonRedirects } from "../../lib/experiment";
 import { getExperiment_experimentBySlug } from "../../types/getExperiment";
 import { ExperimentInput } from "../../types/globalTypes";
@@ -48,6 +48,7 @@ const PageEditBranches: React.FunctionComponent<RouteComponentProps> = () => {
           variables: {
             input: {
               id: nimbusExperimentId,
+              changelogMessage: CHANGELOG_MESSAGES.UPDATED_BRANCHES,
               featureConfigId,
               referenceBranch,
               treatmentBranches,

--- a/app/experimenter/nimbus-ui/src/components/PageEditMetrics/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditMetrics/index.test.tsx
@@ -9,7 +9,11 @@ import fetchMock from "jest-fetch-mock";
 import React from "react";
 import PageEditMetrics from ".";
 import { UPDATE_EXPERIMENT_MUTATION } from "../../gql/experiments";
-import { EXTERNAL_URLS, SUBMIT_ERROR } from "../../lib/constants";
+import {
+  CHANGELOG_MESSAGES,
+  EXTERNAL_URLS,
+  SUBMIT_ERROR,
+} from "../../lib/constants";
 import { mockExperimentMutation, mockExperimentQuery } from "../../lib/mocks";
 import { RouterSlugProvider } from "../../lib/test-utils";
 import { OutcomeSlugs } from "../../lib/types";
@@ -22,7 +26,7 @@ jest.mock("@reach/router", () => ({
   navigate: jest.fn(),
 }));
 
-let mockSubmitData: { [key: string]: OutcomeSlugs | number } = {};
+let mockSubmitData: { [key: string]: OutcomeSlugs | number | string } = {};
 const mockSubmit = jest.fn();
 
 describe("PageEditMetrics", () => {
@@ -51,6 +55,7 @@ describe("PageEditMetrics", () => {
   beforeEach(() => {
     mockSubmitData = {
       id: experiment.id!,
+      changelogMessage: CHANGELOG_MESSAGES.UPDATED_OUTCOMES,
       primaryOutcomes: experiment.primaryOutcomes!,
       secondaryOutcomes: experiment.secondaryOutcomes!,
     };

--- a/app/experimenter/nimbus-ui/src/components/PageEditMetrics/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditMetrics/index.tsx
@@ -6,7 +6,11 @@ import { useMutation } from "@apollo/client";
 import { navigate, RouteComponentProps } from "@reach/router";
 import React, { useCallback, useRef, useState } from "react";
 import { UPDATE_EXPERIMENT_MUTATION } from "../../gql/experiments";
-import { EXTERNAL_URLS, SUBMIT_ERROR } from "../../lib/constants";
+import {
+  CHANGELOG_MESSAGES,
+  EXTERNAL_URLS,
+  SUBMIT_ERROR,
+} from "../../lib/constants";
 import { editCommonRedirects } from "../../lib/experiment";
 import { getExperiment_experimentBySlug } from "../../types/getExperiment";
 import { ExperimentInput } from "../../types/globalTypes";
@@ -37,6 +41,7 @@ const PageEditMetrics: React.FunctionComponent<RouteComponentProps> = () => {
           variables: {
             input: {
               id: nimbusExperimentId,
+              changelogMessage: CHANGELOG_MESSAGES.UPDATED_OUTCOMES,
               primaryOutcomes,
               secondaryOutcomes,
             },

--- a/app/experimenter/nimbus-ui/src/components/PageEditOverview/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditOverview/index.test.tsx
@@ -9,7 +9,7 @@ import fetchMock from "jest-fetch-mock";
 import React from "react";
 import PageEditOverview from ".";
 import { UPDATE_EXPERIMENT_MUTATION } from "../../gql/experiments";
-import { SUBMIT_ERROR } from "../../lib/constants";
+import { CHANGELOG_MESSAGES, SUBMIT_ERROR } from "../../lib/constants";
 import { mockExperimentMutation, mockExperimentQuery } from "../../lib/mocks";
 import { RouterSlugProvider } from "../../lib/test-utils";
 import FormOverview from "../FormOverview";
@@ -49,6 +49,7 @@ describe("PageEditOverview", () => {
 
   beforeEach(() => {
     mockSubmitData = {
+      changelogMessage: CHANGELOG_MESSAGES.UPDATED_OVERVIEW,
       name: experiment.name,
       hypothesis: experiment.hypothesis!,
       publicDescription: experiment.publicDescription!,
@@ -56,7 +57,11 @@ describe("PageEditOverview", () => {
     };
     mutationMock = mockExperimentMutation(
       UPDATE_EXPERIMENT_MUTATION,
-      { ...mockSubmitData, id: experiment.id },
+      {
+        ...mockSubmitData,
+        id: experiment.id,
+        changelogMessage: CHANGELOG_MESSAGES.UPDATED_OVERVIEW,
+      },
       "updateExperiment",
       {
         experiment: mockSubmitData,

--- a/app/experimenter/nimbus-ui/src/components/PageEditOverview/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditOverview/index.tsx
@@ -6,7 +6,7 @@ import { useMutation } from "@apollo/client";
 import { navigate, RouteComponentProps } from "@reach/router";
 import React, { useCallback, useRef, useState } from "react";
 import { UPDATE_EXPERIMENT_MUTATION } from "../../gql/experiments";
-import { SUBMIT_ERROR } from "../../lib/constants";
+import { CHANGELOG_MESSAGES, SUBMIT_ERROR } from "../../lib/constants";
 import { editCommonRedirects } from "../../lib/experiment";
 import { getExperiment_experimentBySlug } from "../../types/getExperiment";
 import { ExperimentInput } from "../../types/globalTypes";
@@ -43,6 +43,7 @@ const PageEditOverview: React.FunctionComponent<PageEditOverviewProps> = () => {
           variables: {
             input: {
               id: currentExperiment.current!.id,
+              changelogMessage: CHANGELOG_MESSAGES.UPDATED_OVERVIEW,
               name,
               hypothesis,
               publicDescription,

--- a/app/experimenter/nimbus-ui/src/components/PageNew/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageNew/index.stories.tsx
@@ -28,8 +28,13 @@ const mkSimulatedQueries = ({
     },
     delay: 1000,
     result: (operation: Operation) => {
-      const { name, application, hypothesis } = operation.variables.input;
-      actionCreateExperiment(name, application, hypothesis);
+      const {
+        name,
+        application,
+        hypothesis,
+        changelogMessage,
+      } = operation.variables.input;
+      actionCreateExperiment(name, application, hypothesis, changelogMessage);
       return {
         data: {
           createExperiment: {

--- a/app/experimenter/nimbus-ui/src/components/PageNew/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageNew/index.test.tsx
@@ -8,7 +8,7 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import React from "react";
 import PageNew from ".";
 import { CREATE_EXPERIMENT_MUTATION } from "../../gql/experiments";
-import { SUBMIT_ERROR } from "../../lib/constants";
+import { CHANGELOG_MESSAGES, SUBMIT_ERROR } from "../../lib/constants";
 import { MockedCache, mockExperimentMutation } from "../../lib/mocks";
 
 jest.mock("@reach/router", () => ({
@@ -23,6 +23,7 @@ describe("PageNew", () => {
       name: "Foo bar baz",
       hypothesis: "Some thing",
       application: "firefox-desktop",
+      changelogMessage: CHANGELOG_MESSAGES.CREATED_EXPERIMENT,
     };
     mutationMock = mockExperimentMutation(
       CREATE_EXPERIMENT_MUTATION,

--- a/app/experimenter/nimbus-ui/src/components/PageNew/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageNew/index.tsx
@@ -7,7 +7,11 @@ import { navigate, RouteComponentProps } from "@reach/router";
 import React, { useCallback, useState } from "react";
 import { CREATE_EXPERIMENT_MUTATION } from "../../gql/experiments";
 import { ReactComponent as DeleteIcon } from "../../images/x.svg";
-import { EXTERNAL_URLS, SUBMIT_ERROR } from "../../lib/constants";
+import {
+  CHANGELOG_MESSAGES,
+  EXTERNAL_URLS,
+  SUBMIT_ERROR,
+} from "../../lib/constants";
 import { createExperiment_createExperiment as CreateExperimentResult } from "../../types/createExperiment";
 import { ExperimentInput } from "../../types/globalTypes";
 import AppLayout from "../AppLayout";
@@ -34,7 +38,14 @@ const PageNew: React.FunctionComponent<PageNewProps> = () => {
     async ({ name, hypothesis, application }: Record<string, any>) => {
       try {
         const result = await createExperiment({
-          variables: { input: { name, hypothesis, application } },
+          variables: {
+            input: {
+              name,
+              hypothesis,
+              application,
+              changelogMessage: CHANGELOG_MESSAGES.CREATED_EXPERIMENT,
+            },
+          },
         });
         if (!result.data?.createExperiment) {
           throw new Error("Save failed, no error available");

--- a/app/experimenter/nimbus-ui/src/components/PageRequestReview/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageRequestReview/index.test.tsx
@@ -12,7 +12,7 @@ import {
 } from "@testing-library/react";
 import fetchMock from "jest-fetch-mock";
 import React from "react";
-import { BASE_PATH } from "../../lib/constants";
+import { BASE_PATH, CHANGELOG_MESSAGES } from "../../lib/constants";
 import { mockExperimentQuery, MOCK_CONFIG } from "../../lib/mocks";
 import {
   NimbusExperimentPublishStatus,
@@ -164,6 +164,7 @@ describe("PageRequestReview", () => {
     const mutationMock = createStatusMutationMock(
       experiment.id!,
       NimbusExperimentStatus.PREVIEW,
+      CHANGELOG_MESSAGES.LAUNCHED_TO_PREVIEW,
     );
     render(<Subject mocks={[mock, mutationMock]} />);
     const launchButton = (await screen.findByTestId(
@@ -180,6 +181,7 @@ describe("PageRequestReview", () => {
       experiment.id!,
       NimbusExperimentStatus.DRAFT,
       NimbusExperimentPublishStatus.REVIEW,
+      CHANGELOG_MESSAGES.REQUESTED_REVIEW,
     );
     render(<Subject mocks={[mock, mutationMock]} />);
     await launchFromDraftToReview();
@@ -210,6 +212,7 @@ describe("PageRequestReview", () => {
     const mutationMock = createStatusMutationMock(
       experiment.id!,
       NimbusExperimentStatus.PREVIEW,
+      CHANGELOG_MESSAGES.LAUNCHED_TO_PREVIEW,
     );
     render(<Subject mocks={[mock, mutationMock]} />);
 
@@ -231,6 +234,7 @@ describe("PageRequestReview", () => {
     const mutationMock = createStatusMutationMock(
       experiment.id!,
       NimbusExperimentStatus.DRAFT,
+      CHANGELOG_MESSAGES.RETURNED_TO_DRAFT,
     );
     render(<Subject mocks={[mock, mutationMock]} />);
     const launchButton = (await screen.findByTestId(
@@ -248,6 +252,7 @@ describe("PageRequestReview", () => {
       experiment.id!,
       NimbusExperimentStatus.DRAFT,
       NimbusExperimentPublishStatus.APPROVED,
+      CHANGELOG_MESSAGES.REVIEW_APPROVED,
     );
     render(<Subject mocks={[mock, mutationMock]} />);
     const approveButton = await screen.findByTestId("approve-request");
@@ -308,6 +313,7 @@ describe("PageRequestReview", () => {
     const mutationMock = createPublishStatusMutationMock(
       experiment.id!,
       NimbusExperimentPublishStatus.REVIEW,
+      CHANGELOG_MESSAGES.REQUESTED_REVIEW,
     );
     const errorMessage = "Something went very wrong.";
     mutationMock.result.data.updateExperiment.message = {

--- a/app/experimenter/nimbus-ui/src/components/PageRequestReview/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageRequestReview/index.tsx
@@ -7,6 +7,7 @@ import React, { useRef, useState } from "react";
 import Alert from "react-bootstrap/Alert";
 import { useChangeOperationMutation } from "../../hooks";
 import { useConfig } from "../../hooks/useConfig";
+import { CHANGELOG_MESSAGES } from "../../lib/constants";
 import { getStatus } from "../../lib/experiment";
 import { getExperiment_experimentBySlug } from "../../types/getExperiment";
 import {
@@ -50,15 +51,23 @@ const PageRequestReview = ({
   } = useChangeOperationMutation(
     currentExperiment,
     refetchReview,
-    { status: NimbusExperimentStatus.PREVIEW },
-    { status: NimbusExperimentStatus.DRAFT },
+    {
+      status: NimbusExperimentStatus.PREVIEW,
+      changelogMessage: CHANGELOG_MESSAGES.LAUNCHED_TO_PREVIEW,
+    },
+    {
+      status: NimbusExperimentStatus.DRAFT,
+      changelogMessage: CHANGELOG_MESSAGES.RETURNED_TO_DRAFT,
+    },
     {
       status: NimbusExperimentStatus.DRAFT,
       publishStatus: NimbusExperimentPublishStatus.REVIEW,
+      changelogMessage: CHANGELOG_MESSAGES.REQUESTED_REVIEW,
     },
     {
       status: NimbusExperimentStatus.DRAFT,
       publishStatus: NimbusExperimentPublishStatus.APPROVED,
+      changelogMessage: CHANGELOG_MESSAGES.REVIEW_APPROVED,
     },
     {
       status: NimbusExperimentStatus.DRAFT,

--- a/app/experimenter/nimbus-ui/src/components/PageRequestReview/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageRequestReview/mocks.tsx
@@ -5,6 +5,7 @@
 import React from "react";
 import PageRequestReview from ".";
 import { UPDATE_EXPERIMENT_MUTATION } from "../../gql/experiments";
+import { CHANGELOG_MESSAGES } from "../../lib/constants";
 import {
   mockChangelog,
   mockExperimentMutation,
@@ -21,12 +22,14 @@ export const { mock, experiment } = mockExperimentQuery("demo-slug");
 export function createStatusMutationMock(
   id: number,
   status = NimbusExperimentStatus.DRAFT,
+  changelogMessage = CHANGELOG_MESSAGES.RETURNED_TO_DRAFT as string,
 ) {
   return mockExperimentMutation(
     UPDATE_EXPERIMENT_MUTATION,
     {
       id,
       status,
+      changelogMessage,
     },
     "updateExperiment",
     {
@@ -40,6 +43,7 @@ export function createStatusMutationMock(
 export function createPublishStatusMutationMock(
   id: number,
   publishStatus = NimbusExperimentPublishStatus.APPROVED,
+  changelogMessage = CHANGELOG_MESSAGES.REVIEW_APPROVED as string,
 ) {
   return mockExperimentMutation(
     UPDATE_EXPERIMENT_MUTATION,
@@ -47,6 +51,7 @@ export function createPublishStatusMutationMock(
       id,
       publishStatus,
       status: NimbusExperimentStatus.DRAFT,
+      changelogMessage,
     },
     "updateExperiment",
     {

--- a/app/experimenter/nimbus-ui/src/components/Summary/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/index.test.tsx
@@ -4,7 +4,7 @@
 
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import React from "react";
-import { SUBMIT_ERROR } from "../../lib/constants";
+import { CHANGELOG_MESSAGES, SUBMIT_ERROR } from "../../lib/constants";
 import { mockExperimentQuery, MOCK_CONFIG } from "../../lib/mocks";
 import {
   NimbusExperimentPublishStatus,
@@ -113,6 +113,7 @@ describe("Summary", () => {
       const mutationMock = createMutationMock(
         experiment.id!,
         NimbusExperimentPublishStatus.REVIEW,
+        { changelogMessage: CHANGELOG_MESSAGES.REQUESTED_REVIEW_END },
       );
       render(
         <Subject props={experiment} mocks={[mutationMock]} {...{ refetch }} />,
@@ -133,6 +134,7 @@ describe("Summary", () => {
       const mutationMock = createMutationMock(
         experiment.id!,
         NimbusExperimentPublishStatus.REVIEW,
+        { changelogMessage: CHANGELOG_MESSAGES.REQUESTED_REVIEW_END },
       );
       mutationMock.result.errors = [new Error("Boo")];
       render(<Subject props={experiment} mocks={[mutationMock]} />);
@@ -150,6 +152,7 @@ describe("Summary", () => {
       const mutationMock = createMutationMock(
         experiment.id!,
         NimbusExperimentPublishStatus.REVIEW,
+        { changelogMessage: CHANGELOG_MESSAGES.REQUESTED_REVIEW_END },
       );
       const errorMessage = "Something went very wrong.";
       mutationMock.result.data.updateExperiment.message = {
@@ -171,6 +174,7 @@ describe("Summary", () => {
       const mutationMock = createMutationMock(
         experiment.id!,
         NimbusExperimentPublishStatus.APPROVED,
+        { changelogMessage: CHANGELOG_MESSAGES.END_APPROVED },
       );
       render(<Subject props={experiment} mocks={[mutationMock]} />);
       const approveButton = await screen.findByTestId("approve-request");

--- a/app/experimenter/nimbus-ui/src/components/Summary/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/index.tsx
@@ -7,6 +7,7 @@ import Alert from "react-bootstrap/Alert";
 import Badge from "react-bootstrap/Badge";
 import { useChangeOperationMutation, useConfig } from "../../hooks";
 import { ReactComponent as ExternalIcon } from "../../images/external.svg";
+import { CHANGELOG_MESSAGES } from "../../lib/constants";
 import { getStatus } from "../../lib/experiment";
 import { ConfigOptions, getConfigLabel } from "../../lib/getConfigLabel";
 import { getExperiment_experimentBySlug } from "../../types/getExperiment";
@@ -62,10 +63,12 @@ const Summary = ({ experiment, refetch }: SummaryProps) => {
     refetchReview,
     {
       publishStatus: NimbusExperimentPublishStatus.REVIEW,
+      changelogMessage: CHANGELOG_MESSAGES.REQUESTED_REVIEW_END,
     },
     {
       isEndRequested: true,
       publishStatus: NimbusExperimentPublishStatus.APPROVED,
+      changelogMessage: CHANGELOG_MESSAGES.END_APPROVED,
     },
     {
       publishStatus: NimbusExperimentPublishStatus.IDLE,

--- a/app/experimenter/nimbus-ui/src/lib/constants.ts
+++ b/app/experimenter/nimbus-ui/src/lib/constants.ts
@@ -28,6 +28,20 @@ export const EXTERNAL_URLS = {
     "https://mana.mozilla.org/wiki/display/FJT/Project+Nimbus",
 };
 
+export const CHANGELOG_MESSAGES = {
+  CREATED_EXPERIMENT: "Created Experiment",
+  UPDATED_BRANCHES: "Updated Branches",
+  UPDATED_AUDIENCE: "Updated Audience",
+  UPDATED_OUTCOMES: "Updated Outcomes",
+  UPDATED_OVERVIEW: "Updated Overview",
+  LAUNCHED_TO_PREVIEW: "Launched to Preview",
+  RETURNED_TO_DRAFT: "Returned to Draft Status",
+  REQUESTED_REVIEW: "Review Requested for Launch",
+  REVIEW_APPROVED: "Launch Review Approved",
+  REQUESTED_REVIEW_END: "Requested Review to End",
+  END_APPROVED: "End Review Approved",
+} as const;
+
 export const FIELD_MESSAGES = {
   REQUIRED: "This field may not be blank.",
   NUMBER: "This field must be a number.",


### PR DESCRIPTION
Because:

* always setting a changelog message will make reviewing an experiment's
  changelog history easier and make the UI easier to populate

This commit:

* makes changelog_message a required field for
  NimbusExperimentSerializer saves and updates

* ensures all Kinto tasks supply a changelog message on changes

* ensures each mutation call in nimbus-ui supplies a changelog message