### PR TITLE
fix #5134 bug(nimbus): intermittent integration test failure

### DIFF
--- a/app/experimenter/base/management/commands/load_dummy_experiments.py
+++ b/app/experimenter/base/management/commands/load_dummy_experiments.py
@@ -22,6 +22,9 @@ class Command(BaseCommand):
             experiment = ExperimentFactory.create_with_status(status, type=random_type)
             logger.info("Created {}: {}".format(experiment, status))
 
-        for status, _ in NimbusExperiment.Status.choices:
-            experiment = NimbusExperimentFactory.create_with_status(status)
-            logger.info("Created {}: {}".format(experiment, status))
+        for application in NimbusExperiment.Application:
+            for status in NimbusExperiment.Status:
+                experiment = NimbusExperimentFactory.create_with_status(
+                    status, application=application
+                )
+                logger.info("Created {}: {}".format(experiment, status))

--- a/app/experimenter/base/tests/test_initial_data.py
+++ b/app/experimenter/base/tests/test_initial_data.py
@@ -9,7 +9,14 @@ class TestInitialData(TestCase):
         self.assertFalse(Experiment.objects.exists())
         self.assertFalse(NimbusExperiment.objects.exists())
         call_command("load_dummy_experiments")
-        self.assertEqual(Experiment.objects.count(), len(Experiment.STATUS_CHOICES))
-        self.assertEqual(
-            NimbusExperiment.objects.count(), len(NimbusExperiment.Status.choices)
-        )
+
+        for status, _ in Experiment.STATUS_CHOICES:
+            self.assertTrue(Experiment.objects.filter(status=status).exists())
+
+        for application in NimbusExperiment.Application:
+            for status in NimbusExperiment.Status:
+                self.assertTrue(
+                    NimbusExperiment.objects.filter(
+                        status=status, application=application
+                    ).exists()
+                )


### PR DESCRIPTION
Because

* The integration tests rely on there being a feature config for all applications to successfully create a test experiment

This commit

* Updates load_dummy_experiments to create an experiment for each application, which will create feature configs for each application as well