### PR TITLE
Fix #5045: Only include All segment for percent calculations.

### DIFF
--- a/app/experimenter/visualization/api/v3/models.py
+++ b/app/experimenter/visualization/api/v3/models.py
@@ -67,6 +67,9 @@ class JetstreamData(BaseModel):
         total_population = 0
         branches = {}
         for jetstream_data_point in self.__root__:
+            if jetstream_data_point.segment != Segment.ALL:
+                continue
+
             if jetstream_data_point.metric == Metric.USER_COUNT:
                 total_population += jetstream_data_point.point
                 branches[jetstream_data_point.branch] = jetstream_data_point.point

--- a/app/experimenter/visualization/tests/api/constants.py
+++ b/app/experimenter/visualization/tests/api/constants.py
@@ -113,7 +113,7 @@ class TestConstants:
         ABSOLUTE_METRIC_DATA_A = cls.get_absolute_metric_data(DATA_POINT_A)
         ABSOLUTE_METRIC_DATA_F = cls.get_absolute_metric_data(DATA_POINT_F)
         ABSOLUTE_METRIC_DATA_F_WITH_PERCENT = ABSOLUTE_METRIC_DATA_F.copy()
-        ABSOLUTE_METRIC_DATA_F_WITH_PERCENT.percent = 33.0
+        ABSOLUTE_METRIC_DATA_F_WITH_PERCENT.percent = 50.0
 
         DIFFERENCE_METRIC_DATA_WEEKLY_NEUTRAL = cls.get_difference_metric_data(
             DATA_POINT_B, SignificanceData(weekly={"1": Significance.NEUTRAL}, overall={})


### PR DESCRIPTION
Because:
* Not filtering out other segments was making incorrect population % calculations

This commit:
* Does this correct filtering

This is related to https://github.com/mozilla/experimenter/pull/5031 which was also related to segmentation filtering