### PR TITLE
Fix #5142: feat(visualization): Make control branch more prominent in tables.

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableHighlights/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableHighlights/index.stories.tsx
@@ -9,6 +9,10 @@ import TableHighlights from ".";
 import { mockExperimentQuery } from "../../../lib/mocks";
 import { RouterSlugProvider } from "../../../lib/test-utils";
 import { mockAnalysis } from "../../../lib/visualization/mocks";
+import { getSortedBranches } from "../../../lib/visualization/utils";
+
+const results = mockAnalysis();
+const sortedBranches = getSortedBranches(results);
 
 storiesOf("pages/Results/TableHighlights", module)
   .addDecorator(withLinks)
@@ -16,7 +20,7 @@ storiesOf("pages/Results/TableHighlights", module)
     const { mock, experiment } = mockExperimentQuery("demo-slug");
     return (
       <RouterSlugProvider mocks={[mock]}>
-        <TableHighlights results={mockAnalysis()} {...{ experiment }} />
+        <TableHighlights {...{ experiment, results, sortedBranches }} />
       </RouterSlugProvider>
     );
   })
@@ -26,7 +30,7 @@ storiesOf("pages/Results/TableHighlights", module)
     });
     return (
       <RouterSlugProvider mocks={[mock]}>
-        <TableHighlights results={mockAnalysis()} {...{ experiment }} />
+        <TableHighlights {...{ experiment, results, sortedBranches }} />
       </RouterSlugProvider>
     );
   });

--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableHighlights/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableHighlights/index.test.tsx
@@ -8,14 +8,17 @@ import TableHighlights from ".";
 import { mockExperimentQuery } from "../../../lib/mocks";
 import { RouterSlugProvider } from "../../../lib/test-utils";
 import { mockAnalysis } from "../../../lib/visualization/mocks";
+import { getSortedBranches } from "../../../lib/visualization/utils";
 
 const { mock, experiment } = mockExperimentQuery("demo-slug");
+const results = mockAnalysis();
+const sortedBranches = getSortedBranches(results);
 
 describe("TableHighlights", () => {
   it("has participants shown for each variant", () => {
     render(
       <RouterSlugProvider mocks={[mock]}>
-        <TableHighlights results={mockAnalysis()} {...{ experiment }} />
+        <TableHighlights {...{ experiment, results, sortedBranches }} />
       </RouterSlugProvider>,
     );
 
@@ -30,7 +33,7 @@ describe("TableHighlights", () => {
     const branchDescription = experiment.referenceBranch!.description;
     render(
       <RouterSlugProvider mocks={[mock]}>
-        <TableHighlights results={mockAnalysis()} {...{ experiment }} />
+        <TableHighlights {...{ experiment, results, sortedBranches }} />
       </RouterSlugProvider>,
     );
 
@@ -40,7 +43,7 @@ describe("TableHighlights", () => {
   it("has correctly labelled result significance", async () => {
     render(
       <RouterSlugProvider mocks={[mock]}>
-        <TableHighlights results={mockAnalysis()} {...{ experiment }} />
+        <TableHighlights {...{ experiment, results, sortedBranches }} />
       </RouterSlugProvider>,
     );
 
@@ -52,7 +55,7 @@ describe("TableHighlights", () => {
   it("has the expected control and treatment labels", async () => {
     render(
       <RouterSlugProvider mocks={[mock]}>
-        <TableHighlights results={mockAnalysis()} {...{ experiment }} />
+        <TableHighlights {...{ experiment, results, sortedBranches }} />
       </RouterSlugProvider>,
     );
 

--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableHighlights/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableHighlights/index.tsx
@@ -24,6 +24,7 @@ import TableVisualizationRow from "../TableVisualizationRow";
 type TableHighlightsProps = {
   results: AnalysisData;
   experiment: getExperiment_experimentBySlug;
+  sortedBranches: string[];
 };
 
 type Branch =
@@ -70,6 +71,7 @@ const TableHighlights = ({
     show_analysis: false,
   },
   experiment,
+  sortedBranches,
 }: TableHighlightsProps) => {
   const { primaryOutcomes } = useOutcomes(experiment);
   const highlightMetricsList = getHighlightMetrics(primaryOutcomes);
@@ -82,7 +84,7 @@ const TableHighlights = ({
   return (
     <table data-testid="table-highlights" className="table mt-4 mb-0">
       <tbody>
-        {Object.keys(overallResults).map((branch) => {
+        {sortedBranches.map((branch) => {
           const userCountMetric =
             overallResults[branch]["branch_data"][METRIC.USER_COUNT];
           const participantCount =

--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableHighlightsOverview/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableHighlightsOverview/index.stories.tsx
@@ -8,7 +8,6 @@ import React from "react";
 import TableHighlightsOverview from ".";
 import { mockExperimentQuery } from "../../../lib/mocks";
 import { RouterSlugProvider } from "../../../lib/test-utils";
-import { mockAnalysis } from "../../../lib/visualization/mocks";
 
 storiesOf("pages/Results/TableHighlightsOverview", module)
   .addDecorator(withLinks)
@@ -16,10 +15,7 @@ storiesOf("pages/Results/TableHighlightsOverview", module)
     const { mock, experiment } = mockExperimentQuery("demo-slug");
     return (
       <RouterSlugProvider mocks={[mock]}>
-        <TableHighlightsOverview
-          {...{ experiment }}
-          results={mockAnalysis().overall}
-        />
+        <TableHighlightsOverview {...{ experiment }} />
       </RouterSlugProvider>
     );
   })
@@ -29,10 +25,7 @@ storiesOf("pages/Results/TableHighlightsOverview", module)
     });
     return (
       <RouterSlugProvider mocks={[mock]}>
-        <TableHighlightsOverview
-          {...{ experiment }}
-          results={mockAnalysis().overall}
-        />
+        <TableHighlightsOverview {...{ experiment }} />
       </RouterSlugProvider>
     );
   });

--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableHighlightsOverview/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableHighlightsOverview/index.test.tsx
@@ -7,7 +7,6 @@ import React from "react";
 import TableHighlightsOverview from ".";
 import { mockExperimentQuery } from "../../../lib/mocks";
 import { RouterSlugProvider } from "../../../lib/test-utils";
-import { mockAnalysis } from "../../../lib/visualization/mocks";
 
 const { mock, experiment } = mockExperimentQuery("demo-slug");
 
@@ -17,10 +16,7 @@ describe("TableHighlightsOverview", () => {
 
     render(
       <RouterSlugProvider mocks={[mock]}>
-        <TableHighlightsOverview
-          {...{ experiment }}
-          results={mockAnalysis().overall}
-        />
+        <TableHighlightsOverview {...{ experiment }} />
       </RouterSlugProvider>,
     );
 
@@ -32,10 +28,7 @@ describe("TableHighlightsOverview", () => {
   it("has the expected targeting", async () => {
     render(
       <RouterSlugProvider mocks={[mock]}>
-        <TableHighlightsOverview
-          {...{ experiment }}
-          results={mockAnalysis().overall}
-        />
+        <TableHighlightsOverview {...{ experiment }} />
       </RouterSlugProvider>,
     );
 
@@ -47,10 +40,7 @@ describe("TableHighlightsOverview", () => {
   it("has the expected outcomes", async () => {
     render(
       <RouterSlugProvider mocks={[mock]}>
-        <TableHighlightsOverview
-          {...{ experiment }}
-          results={mockAnalysis().overall}
-        />
+        <TableHighlightsOverview {...{ experiment }} />
       </RouterSlugProvider>,
     );
 
@@ -60,10 +50,7 @@ describe("TableHighlightsOverview", () => {
   it("has the experiment owner", async () => {
     render(
       <RouterSlugProvider mocks={[mock]}>
-        <TableHighlightsOverview
-          {...{ experiment }}
-          results={mockAnalysis().overall}
-        />
+        <TableHighlightsOverview {...{ experiment }} />
       </RouterSlugProvider>,
     );
     expect(screen.getByText("example@mozilla.com")).toBeInTheDocument();

--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableHighlightsOverview/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableHighlightsOverview/index.tsx
@@ -5,12 +5,10 @@
 import React from "react";
 import { useConfig, useOutcomes } from "../../../hooks";
 import { getConfigLabel } from "../../../lib/getConfigLabel";
-import { AnalysisDataOverall } from "../../../lib/visualization/types";
 import { getExperiment_experimentBySlug } from "../../../types/getExperiment";
 
 type TableHighlightsOverviewProps = {
   experiment: getExperiment_experimentBySlug;
-  results: AnalysisDataOverall;
 };
 
 const TableHighlightsOverview = ({

--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableMetricSecondary/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableMetricSecondary/index.stories.tsx
@@ -8,6 +8,10 @@ import React from "react";
 import TableMetricSecondary from ".";
 import { mockExperimentQuery, mockOutcomeSets } from "../../../lib/mocks";
 import { mockAnalysis } from "../../../lib/visualization/mocks";
+import { getSortedBranches } from "../../../lib/visualization/utils";
+
+const results = mockAnalysis();
+const sortedBranches = getSortedBranches(results);
 
 storiesOf("pages/Results/TableMetricSecondary", module)
   .addDecorator(withLinks)
@@ -19,7 +23,7 @@ storiesOf("pages/Results/TableMetricSecondary", module)
 
     return (
       <TableMetricSecondary
-        results={mockAnalysis()}
+        {...{ results, sortedBranches }}
         outcomeSlug={secondaryOutcomes![0]!.slug!}
         outcomeDefaultName={secondaryOutcomes![0]!.friendlyName!}
         isDefault={false}
@@ -32,7 +36,7 @@ storiesOf("pages/Results/TableMetricSecondary", module)
 
     return (
       <TableMetricSecondary
-        results={mockAnalysis()}
+        {...{ results, sortedBranches }}
         outcomeSlug={secondaryOutcomes![0]!.slug!}
         outcomeDefaultName={secondaryOutcomes![0]!.friendlyName!}
         isDefault={false}
@@ -47,7 +51,7 @@ storiesOf("pages/Results/TableMetricSecondary", module)
 
     return (
       <TableMetricSecondary
-        results={mockAnalysis()}
+        {...{ results, sortedBranches }}
         outcomeSlug={secondaryOutcomes![0]!.slug!}
         outcomeDefaultName={secondaryOutcomes![0]!.friendlyName!}
         isDefault={false}

--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableMetricSecondary/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableMetricSecondary/index.test.tsx
@@ -8,6 +8,10 @@ import TableMetricSecondary from ".";
 import { mockExperimentQuery, mockOutcomeSets } from "../../../lib/mocks";
 import { RouterSlugProvider } from "../../../lib/test-utils";
 import { mockAnalysis } from "../../../lib/visualization/mocks";
+import { getSortedBranches } from "../../../lib/visualization/utils";
+
+const results = mockAnalysis();
+const sortedBranches = getSortedBranches(results);
 
 describe("TableMetricSecondary", () => {
   it("has the correct headings", () => {
@@ -18,10 +22,10 @@ describe("TableMetricSecondary", () => {
     render(
       <RouterSlugProvider mocks={[mock]}>
         <TableMetricSecondary
-          results={mockAnalysis()}
           outcomeSlug={secondaryOutcomes![0]!.slug!}
           outcomeDefaultName={secondaryOutcomes![0]!.friendlyName!}
           isDefault={false}
+          {...{ results, sortedBranches }}
         />
       </RouterSlugProvider>,
     );
@@ -38,10 +42,10 @@ describe("TableMetricSecondary", () => {
     render(
       <RouterSlugProvider mocks={[mock]}>
         <TableMetricSecondary
-          results={mockAnalysis()}
           outcomeSlug={secondaryOutcomes![0]!.slug!}
           outcomeDefaultName={secondaryOutcomes![0]!.friendlyName!}
           isDefault={false}
+          {...{ results, sortedBranches }}
         />
       </RouterSlugProvider>,
     );
@@ -61,10 +65,10 @@ describe("TableMetricSecondary", () => {
     render(
       <RouterSlugProvider mocks={[mock]}>
         <TableMetricSecondary
-          results={mockAnalysis()}
           outcomeSlug={secondaryOutcomes![0]!.slug!}
           outcomeDefaultName={secondaryOutcomes![0]!.friendlyName!}
           isDefault={false}
+          {...{ results, sortedBranches }}
         />
       </RouterSlugProvider>,
     );
@@ -80,10 +84,10 @@ describe("TableMetricSecondary", () => {
     render(
       <RouterSlugProvider mocks={[mock]}>
         <TableMetricSecondary
-          results={mockAnalysis()}
           outcomeSlug={secondaryOutcomes![0]!.slug!}
           outcomeDefaultName={secondaryOutcomes![0]!.friendlyName!}
           isDefault={false}
+          {...{ results, sortedBranches }}
         />
       </RouterSlugProvider>,
     );
@@ -103,15 +107,16 @@ describe("TableMetricSecondary", () => {
     render(
       <RouterSlugProvider mocks={[mock]}>
         <TableMetricSecondary
-          results={mockAnalysis()}
           outcomeSlug={secondaryOutcomes![0]!.slug!}
           outcomeDefaultName={secondaryOutcomes![0]!.friendlyName!}
           isDefault={false}
+          {...{ results, sortedBranches }}
         />
       </RouterSlugProvider>,
     );
 
-    expect(screen.queryAllByText("0.02 to 0.08")).toHaveLength(2);
+    expect(screen.queryAllByText("0.02 to 0.08")).toHaveLength(1);
+    expect(screen.queryAllByText("0.02 to 0.08 (baseline)")).toHaveLength(1);
   });
 
   it("uses the friendly name from the metadata", () => {
@@ -121,10 +126,10 @@ describe("TableMetricSecondary", () => {
     render(
       <RouterSlugProvider mocks={[mock]}>
         <TableMetricSecondary
-          results={mockAnalysis()}
           outcomeSlug="feature_d"
           outcomeDefaultName={secondaryOutcomes![0]!.friendlyName!}
           isDefault={false}
+          {...{ results, sortedBranches }}
         />
       </RouterSlugProvider>,
     );

--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableMetricSecondary/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableMetricSecondary/index.tsx
@@ -27,6 +27,7 @@ type TableMetricSecondaryProps = {
   outcomeSlug: string;
   outcomeDefaultName: string;
   isDefault?: boolean;
+  sortedBranches: string[];
 };
 
 const getStatistics = (slug: string): Array<SecondaryMetricStatistic> => {
@@ -52,6 +53,7 @@ const TableMetricSecondary = ({
   outcomeSlug,
   outcomeDefaultName,
   isDefault = true,
+  sortedBranches,
 }: TableMetricSecondaryProps) => {
   const secondaryMetricStatistics = getStatistics(outcomeSlug);
   const secondaryType = isDefault
@@ -109,7 +111,7 @@ const TableMetricSecondary = ({
           </tr>
         </thead>
         <tbody>
-          {Object.keys(overallResults).map((branch) => {
+          {sortedBranches.map((branch) => {
             return (
               <tr key={branch}>
                 <th className="align-middle" scope="row">

--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableResults/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableResults/index.stories.tsx
@@ -9,6 +9,10 @@ import TableResults from ".";
 import { mockExperimentQuery } from "../../../lib/mocks";
 import { RouterSlugProvider } from "../../../lib/test-utils";
 import { mockAnalysis } from "../../../lib/visualization/mocks";
+import { getSortedBranches } from "../../../lib/visualization/utils";
+
+const results = mockAnalysis();
+const sortedBranches = getSortedBranches(results);
 
 storiesOf("pages/Results/TableResults", module)
   .addDecorator(withLinks)
@@ -16,7 +20,7 @@ storiesOf("pages/Results/TableResults", module)
     const { mock, experiment } = mockExperimentQuery("demo-slug");
     return (
       <RouterSlugProvider mocks={[mock]}>
-        <TableResults {...{ experiment }} results={mockAnalysis()} />
+        <TableResults {...{ experiment, results, sortedBranches }} />
       </RouterSlugProvider>
     );
   })
@@ -26,7 +30,7 @@ storiesOf("pages/Results/TableResults", module)
     });
     return (
       <RouterSlugProvider mocks={[mock]}>
-        <TableResults {...{ experiment }} results={mockAnalysis()} />
+        <TableResults {...{ experiment, results, sortedBranches }} />
       </RouterSlugProvider>
     );
   });

--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableResults/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableResults/index.test.tsx
@@ -11,14 +11,17 @@ import {
   mockAnalysis,
   mockIncompleteAnalysis,
 } from "../../../lib/visualization/mocks";
+import { getSortedBranches } from "../../../lib/visualization/utils";
 
 const { mock, experiment } = mockExperimentQuery("demo-slug");
+const results = mockAnalysis();
+const sortedBranches = getSortedBranches(results);
 
 describe("TableResults", () => {
   it("renders correct headings", () => {
     render(
       <RouterSlugProvider mocks={[mock]}>
-        <TableResults {...{ experiment }} results={mockAnalysis()} />
+        <TableResults {...{ experiment, results, sortedBranches }} />
       </RouterSlugProvider>,
     );
     const EXPECTED_HEADINGS = [
@@ -37,7 +40,7 @@ describe("TableResults", () => {
   it("renders the expected variant and user count", () => {
     render(
       <RouterSlugProvider mocks={[mock]}>
-        <TableResults {...{ experiment }} results={mockAnalysis()} />
+        <TableResults {...{ experiment, results, sortedBranches }} />
       </RouterSlugProvider>,
     );
 
@@ -49,7 +52,7 @@ describe("TableResults", () => {
   it("renders correctly labelled result significance", () => {
     render(
       <RouterSlugProvider mocks={[mock]}>
-        <TableResults {...{ experiment }} results={mockAnalysis()} />
+        <TableResults {...{ experiment, results, sortedBranches }} />
       </RouterSlugProvider>,
     );
 
@@ -59,9 +62,12 @@ describe("TableResults", () => {
   });
 
   it("renders missing retention with warning", () => {
+    const results = mockIncompleteAnalysis();
+    const sortedBranches = getSortedBranches(results);
+
     render(
       <RouterSlugProvider mocks={[mock]}>
-        <TableResults {...{ experiment }} results={mockIncompleteAnalysis()} />
+        <TableResults {...{ experiment, results, sortedBranches }} />
       </RouterSlugProvider>,
     );
 

--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableResults/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableResults/index.tsx
@@ -20,6 +20,7 @@ import TooltipWithMarkdown from "../TooltipWithMarkdown";
 type TableResultsProps = {
   experiment: getExperiment_experimentBySlug;
   results: AnalysisData;
+  sortedBranches: string[];
 };
 
 const getResultMetrics = (outcomes: OutcomesList) => {
@@ -46,6 +47,7 @@ const TableResults = ({
     metadata: { metrics: {}, outcomes: {} },
     show_analysis: false,
   },
+  sortedBranches,
 }: TableResultsProps) => {
   const { primaryOutcomes } = useOutcomes(experiment);
   const resultsMetricsList = getResultMetrics(primaryOutcomes);
@@ -86,7 +88,7 @@ const TableResults = ({
         </tr>
       </thead>
       <tbody>
-        {Object.keys(overallResults).map((branch) => {
+        {sortedBranches.map((branch) => {
           return (
             <tr key={branch}>
               <th className="align-middle" scope="row">

--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableResultsWeekly/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableResultsWeekly/index.stories.tsx
@@ -8,13 +8,22 @@ import React from "react";
 import TableResultsWeekly from ".";
 import { HIGHLIGHTS_METRICS_LIST } from "../../../lib/visualization/constants";
 import { weeklyMockAnalysis } from "../../../lib/visualization/mocks";
+import { getSortedBranches } from "../../../lib/visualization/utils";
+
+const weeklyResults = weeklyMockAnalysis();
+const sortedBranches = getSortedBranches({
+  show_analysis: true,
+  daily: null,
+  weekly: weeklyResults,
+  overall: null,
+});
 
 storiesOf("pages/Results/TableResultsWeekly", module)
   .addDecorator(withLinks)
   .add("basic", () => {
     return (
       <TableResultsWeekly
-        weeklyResults={weeklyMockAnalysis()}
+        {...{ weeklyResults, sortedBranches }}
         hasOverallResults
         metricsList={HIGHLIGHTS_METRICS_LIST}
       />

--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableResultsWeekly/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableResultsWeekly/index.test.tsx
@@ -8,6 +8,15 @@ import TableResultsWeekly from ".";
 import { RouterSlugProvider } from "../../../lib/test-utils";
 import { HIGHLIGHTS_METRICS_LIST } from "../../../lib/visualization/constants";
 import { weeklyMockAnalysis } from "../../../lib/visualization/mocks";
+import { getSortedBranches } from "../../../lib/visualization/utils";
+
+const weeklyResults = weeklyMockAnalysis();
+const sortedBranches = getSortedBranches({
+  show_analysis: true,
+  daily: null,
+  weekly: weeklyResults,
+  overall: null,
+});
 
 describe("TableResultsWeekly", () => {
   it("has the correct headings", () => {
@@ -16,9 +25,9 @@ describe("TableResultsWeekly", () => {
     render(
       <RouterSlugProvider>
         <TableResultsWeekly
-          weeklyResults={weeklyMockAnalysis()}
           hasOverallResults
           metricsList={HIGHLIGHTS_METRICS_LIST}
+          {...{ weeklyResults, sortedBranches }}
         />
       </RouterSlugProvider>,
     );
@@ -35,9 +44,9 @@ describe("TableResultsWeekly", () => {
     render(
       <RouterSlugProvider>
         <TableResultsWeekly
-          weeklyResults={weeklyMockAnalysis()}
           hasOverallResults={false}
           metricsList={HIGHLIGHTS_METRICS_LIST}
+          {...{ weeklyResults, sortedBranches }}
         />
       </RouterSlugProvider>,
     );

--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableResultsWeekly/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableResultsWeekly/index.tsx
@@ -13,12 +13,14 @@ type TableResultsWeeklyProps = {
   weeklyResults: AnalysisDataWeekly;
   hasOverallResults: boolean;
   metricsList: { value: string; name: string; tooltip: string }[];
+  sortedBranches: string[];
 };
 
 const TableResultsWeekly = ({
   weeklyResults = {},
   hasOverallResults = false,
   metricsList,
+  sortedBranches,
 }: TableResultsWeeklyProps) => {
   const [open, setOpen] = useState(!hasOverallResults);
 
@@ -57,6 +59,7 @@ const TableResultsWeekly = ({
                   metricKey={metric.value}
                   metricName={metric.name}
                   results={weeklyResults}
+                  {...{ sortedBranches }}
                 />
               </div>
             );

--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableVisualizationRow/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableVisualizationRow/index.tsx
@@ -36,6 +36,7 @@ const dataTypeMapping = {
     [VARIANT_TYPE.VARIANT]: BRANCH_COMPARISON.ABSOLUTE,
   },
 };
+const BASELINE_TEXT = "(baseline)";
 
 const showSignificanceField = (
   significance: string | undefined,
@@ -43,6 +44,7 @@ const showSignificanceField = (
   name: string,
   tableLabel: string,
   tooltip: string,
+  isControl = false,
 ) => {
   let significanceIcon,
     changeText = "";
@@ -94,7 +96,7 @@ const showSignificanceField = (
   return (
     <>
       <span {...{ className }} data-testid={className}>
-        {significanceIcon}&nbsp;{interval}
+        {significanceIcon}&nbsp;{interval}&nbsp;{isControl && BASELINE_TEXT}
       </span>
       <ReactTooltip />
     </>
@@ -139,6 +141,7 @@ const countField = (
   metricName: string,
   tableLabel: string,
   tooltip: string,
+  isControl = false,
 ) => {
   const interval = `${lower.toFixed(2)} to ${upper.toFixed(2)}`;
   return showSignificanceField(
@@ -147,6 +150,7 @@ const countField = (
     metricName,
     tableLabel,
     tooltip,
+    isControl,
   );
 };
 
@@ -157,6 +161,7 @@ const percentField = (
   metricName: string,
   tableLabel: string,
   tooltip: string,
+  isControl = false,
 ) => {
   const interval = `${Math.round(lower * 1000) / 10}% to ${
     Math.round(upper * 1000) / 10
@@ -167,6 +172,7 @@ const percentField = (
     metricName,
     tableLabel,
     tooltip,
+    isControl,
   );
 };
 
@@ -210,7 +216,7 @@ const TableVisualizationRow: React.FC<{
   if (metricData) {
     className = "";
     tooltipText = tooltip;
-    field = <div className="font-italic">---baseline---</div>;
+    field = <div>{BASELINE_TEXT}</div>;
     const percent = branch_data[METRIC.USER_COUNT]["percent"];
     const branchType = is_control ? VARIANT_TYPE.CONTROL : VARIANT_TYPE.VARIANT;
     branchComparison =
@@ -240,6 +246,7 @@ const TableVisualizationRow: React.FC<{
             metricName,
             tableLabel,
             tooltipText,
+            is_control,
           );
           break;
         case DISPLAY_TYPE.PERCENT:
@@ -251,6 +258,7 @@ const TableVisualizationRow: React.FC<{
             metricName,
             tableLabel,
             tooltipText,
+            is_control,
           );
           break;
         case DISPLAY_TYPE.CONVERSION_COUNT:

--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableWeekly/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableWeekly/index.test.tsx
@@ -12,6 +12,7 @@ import {
   WEEKLY_TREATMENT,
   WONKY_WEEKLY_TREATMENT,
 } from "../../../lib/visualization/mocks";
+import { getSortedBranches } from "../../../lib/visualization/utils";
 
 describe("TableWeekly", () => {
   it("has the correct headings", () => {
@@ -29,12 +30,20 @@ describe("TableWeekly", () => {
       },
     };
 
+    const results = weeklyMockAnalysis(modified_treatment);
+    const sortedBranches = getSortedBranches({
+      show_analysis: true,
+      daily: null,
+      weekly: results,
+      overall: null,
+    });
+
     render(
       <RouterSlugProvider>
         <TableWeekly
           metricKey="retained"
           metricName="Retention"
-          results={weeklyMockAnalysis(modified_treatment)}
+          {...{ results, sortedBranches }}
         />
       </RouterSlugProvider>,
     );
@@ -46,13 +55,20 @@ describe("TableWeekly", () => {
 
   it("shows error text when metric data isn't available", () => {
     const ERROR_TEXT = "Some Made Up Metric is not available";
+    const results = weeklyMockAnalysis();
+    const sortedBranches = getSortedBranches({
+      show_analysis: true,
+      daily: null,
+      weekly: results,
+      overall: null,
+    });
 
     render(
       <RouterSlugProvider>
         <TableWeekly
           metricKey="fake"
           metricName="Some Made Up Metric"
-          results={weeklyMockAnalysis()}
+          {...{ results, sortedBranches }}
         />
       </RouterSlugProvider>,
     );

--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableWeekly/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableWeekly/index.tsx
@@ -19,9 +19,10 @@ type TableWeeklyProps = {
   metricKey: string;
   metricName: string;
   results: AnalysisDataWeekly;
+  sortedBranches: string[];
 };
 
-const getWeekCount = (
+const getWeekIndexList = (
   metric: string,
   weeklyResults: { [branch: string]: BranchDescription },
 ) => {
@@ -30,6 +31,7 @@ const getWeekCount = (
     if (!(metric in weeklyResults[branch].branch_data)) {
       return;
     }
+
     Object.values(BRANCH_COMPARISON).forEach((branchComparison) => {
       const branchData =
         weeklyResults[branch].branch_data[metric][branchComparison].all;
@@ -47,8 +49,9 @@ const TableWeekly = ({
   metricKey,
   metricName,
   results = {},
+  sortedBranches,
 }: TableWeeklyProps) => {
-  const weekIndexList = getWeekCount(metricKey, results);
+  const weekIndexList = getWeekIndexList(metricKey, results);
 
   return (
     <table
@@ -70,7 +73,7 @@ const TableWeekly = ({
         </tr>
       </thead>
       <tbody>
-        {Object.keys(results).map((branch) => {
+        {sortedBranches.map((branch) => {
           const displayType = getTableDisplayType(
             metricKey,
             TABLE_LABEL.RESULTS,

--- a/app/experimenter/nimbus-ui/src/components/PageResults/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/index.tsx
@@ -6,7 +6,10 @@ import { RouteComponentProps } from "@reach/router";
 import React from "react";
 import { useConfig } from "../../hooks";
 import { HIGHLIGHTS_METRICS_LIST } from "../../lib/visualization/constants";
-import { analysisUnavailable } from "../../lib/visualization/utils";
+import {
+  analysisUnavailable,
+  getSortedBranches,
+} from "../../lib/visualization/utils";
 import AppLayoutWithExperiment from "../AppLayoutWithExperiment";
 import LinkExternal from "../LinkExternal";
 import LinkMonitoring from "../LinkMonitoring";
@@ -43,6 +46,7 @@ const PageResults: React.FunctionComponent<RouteComponentProps> = () => {
         if (analysisUnavailable(analysis)) return;
 
         const slugUnderscored = experiment.slug.replace(/-/g, "_");
+        const sortedBranches = getSortedBranches(analysis!);
         return (
           <>
             <LinkMonitoring {...experiment} />
@@ -62,17 +66,20 @@ const PageResults: React.FunctionComponent<RouteComponentProps> = () => {
             <h3 className="h6">Hypothesis</h3>
             <p>{experiment.hypothesis}</p>
             {analysis?.overall && (
-              <TableHighlights results={analysis!} {...{ experiment }} />
+              <TableHighlights
+                results={analysis}
+                {...{ experiment, sortedBranches }}
+              />
             )}
-            <TableHighlightsOverview
-              {...{ experiment }}
-              results={analysis?.overall!}
-            />
+            <TableHighlightsOverview {...{ experiment }} />
 
             <div id="results_summary">
               <h2 className="h5 mb-3">Results Summary</h2>
               {analysis?.overall && (
-                <TableResults {...{ experiment }} results={analysis!} />
+                <TableResults
+                  {...{ experiment, sortedBranches }}
+                  results={analysis!}
+                />
               )}
 
               {analysis?.weekly && (
@@ -80,6 +87,7 @@ const PageResults: React.FunctionComponent<RouteComponentProps> = () => {
                   weeklyResults={analysis.weekly}
                   hasOverallResults={!!analysis?.overall}
                   metricsList={HIGHLIGHTS_METRICS_LIST}
+                  {...{ sortedBranches }}
                 />
               )}
             </div>
@@ -111,6 +119,7 @@ const PageResults: React.FunctionComponent<RouteComponentProps> = () => {
                       outcomeSlug={outcome!.slug!}
                       outcomeDefaultName={outcome!.friendlyName!}
                       isDefault={false}
+                      {...{ sortedBranches }}
                     />
                   );
                 })}
@@ -121,6 +130,7 @@ const PageResults: React.FunctionComponent<RouteComponentProps> = () => {
                     results={analysis}
                     outcomeSlug={metric}
                     outcomeDefaultName={analysis!.other_metrics![metric]}
+                    {...{ sortedBranches }}
                   />
                 ))}
             </div>

--- a/app/experimenter/nimbus-ui/src/lib/visualization/utils.tsx
+++ b/app/experimenter/nimbus-ui/src/lib/visualization/utils.tsx
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { DISPLAY_TYPE, METRIC, TABLE_LABEL } from "./constants";
-import { AnalysisData } from "./types";
+import { AnalysisData, BranchDescription } from "./types";
 
 // `show_analysis` is the feature flag for turning visualization on/off.
 // `overall` will be `null` if the analysis isn't available yet.
@@ -36,4 +36,22 @@ export const getTableDisplayType = (
   }
 
   return displayType;
+};
+
+export const getSortedBranches = (analysis: AnalysisData) => {
+  const results: { [branch: string]: BranchDescription } | null =
+    analysis?.overall || analysis?.weekly;
+  if (!results) {
+    return [];
+  }
+
+  const sortedBranches: string[] = [];
+  Object.keys(results).forEach((branch: string) => {
+    if (results[branch]["is_control"]) {
+      sortedBranches.unshift(branch);
+    } else {
+      sortedBranches.push(branch);
+    }
+  });
+  return sortedBranches;
 };


### PR DESCRIPTION
Because:
* People were confused about which branch is control and whether the data was absolute/relative

This commit:
* Shows the control branch at the top of a table, clearly labelled.