### PR TITLE
fix #5140 bug(nimbus): set is_end_requested and don't unset it at timeout

### DIFF
--- a/app/experimenter/kinto/tasks.py
+++ b/app/experimenter/kinto/tasks.py
@@ -94,7 +94,6 @@ def handle_pending_review(applications, kinto_client):
     if experiment:
         if experiment.has_filter(experiment.Filters.SHOULD_TIMEOUT):
             experiment.publish_status = NimbusExperiment.PublishStatus.REVIEW
-            experiment.is_end_requested = False
             experiment.save()
 
             generate_nimbus_changelog(

--- a/app/experimenter/kinto/tests/test_tasks.py
+++ b/app/experimenter/kinto/tests/test_tasks.py
@@ -241,7 +241,6 @@ class TestNimbusCheckKintoPushQueueByCollection(MockKintoClientMixin, TestCase):
         self.assertEqual(
             pending_experiment.publish_status, NimbusExperiment.PublishStatus.REVIEW
         )
-        self.assertFalse(pending_experiment.is_end_requested)
         self.assertTrue(
             pending_experiment.changes.filter(
                 old_status=NimbusExperiment.Status.LIVE,

--- a/app/experimenter/nimbus-ui/src/components/Summary/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/index.test.tsx
@@ -113,7 +113,10 @@ describe("Summary", () => {
       const mutationMock = createMutationMock(
         experiment.id!,
         NimbusExperimentPublishStatus.REVIEW,
-        { changelogMessage: CHANGELOG_MESSAGES.REQUESTED_REVIEW_END },
+        {
+          changelogMessage: CHANGELOG_MESSAGES.REQUESTED_REVIEW_END,
+          isEndRequested: true,
+        },
       );
       render(
         <Subject props={experiment} mocks={[mutationMock]} {...{ refetch }} />,
@@ -152,7 +155,10 @@ describe("Summary", () => {
       const mutationMock = createMutationMock(
         experiment.id!,
         NimbusExperimentPublishStatus.REVIEW,
-        { changelogMessage: CHANGELOG_MESSAGES.REQUESTED_REVIEW_END },
+        {
+          changelogMessage: CHANGELOG_MESSAGES.REQUESTED_REVIEW_END,
+          isEndRequested: true,
+        },
       );
       const errorMessage = "Something went very wrong.";
       mutationMock.result.data.updateExperiment.message = {

--- a/app/experimenter/nimbus-ui/src/components/Summary/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/index.tsx
@@ -63,10 +63,10 @@ const Summary = ({ experiment, refetch }: SummaryProps) => {
     refetchReview,
     {
       publishStatus: NimbusExperimentPublishStatus.REVIEW,
+      isEndRequested: true,
       changelogMessage: CHANGELOG_MESSAGES.REQUESTED_REVIEW_END,
     },
     {
-      isEndRequested: true,
       publishStatus: NimbusExperimentPublishStatus.APPROVED,
       changelogMessage: CHANGELOG_MESSAGES.END_APPROVED,
     },


### PR DESCRIPTION


Because

* We treated is_end_requested incorrectly in our current implementation
* We were setting it at approval time rather than request time from the UI
* We were unsetting it on timeout
* These two errors ironically canceled each other out and the flow still worked correctly but
* Neither of these is correct according to the diagrams
* This caused confusion when debugging a production experiment

This commit

* Sets is_end_requested at end request time from the UI
* Does not unset it after a timeout