### PR TITLE
fixes #4921 feat(project): add signoff recommendations to query based on risk fields

### DIFF
--- a/app/experimenter/experiments/api/v5/types.py
+++ b/app/experimenter/experiments/api/v5/types.py
@@ -130,6 +130,12 @@ class NimbusChangeLogType(DjangoObjectType):
         exclude = ("id",)
 
 
+class NimbusSignoffRecommendationsType(graphene.ObjectType):
+    qa_signoff = graphene.Boolean()
+    vp_signoff = graphene.Boolean()
+    legal_signoff = graphene.Boolean()
+
+
 class NimbusExperimentType(DjangoObjectType):
     id = graphene.Int()
     status = NimbusExperimentStatus()
@@ -155,6 +161,7 @@ class NimbusExperimentType(DjangoObjectType):
     review_request = graphene.Field(NimbusChangeLogType)
     rejection = graphene.Field(NimbusChangeLogType)
     timeout = graphene.Field(NimbusChangeLogType)
+    signoff_recommendations = graphene.Field(NimbusSignoffRecommendationsType)
 
     class Meta:
         model = NimbusExperiment

--- a/app/experimenter/experiments/models/nimbus.py
+++ b/app/experimenter/experiments/models/nimbus.py
@@ -325,6 +325,17 @@ class NimbusExperiment(NimbusConstants, FilterMixin, models.Model):
             )
             return datetime.date.today() >= resultsReadyDate
 
+    @property
+    def signoff_recommendations(self):
+        return {
+            # QA signoff is always recommended
+            "qa_signoff": True,
+            "vp_signoff": any(
+                (self.risk_brand, self.risk_revenue, self.risk_partner_related)
+            ),
+            "legal_signoff": any((self.risk_revenue, self.risk_partner_related)),
+        }
+
 
 class NimbusBranch(models.Model):
     experiment = models.ForeignKey(

--- a/app/experimenter/experiments/tests/test_models/test_models_nimbus.py
+++ b/app/experimenter/experiments/tests/test_models/test_models_nimbus.py
@@ -598,6 +598,34 @@ class TestNimbusExperiment(TestCase):
             )
         )
 
+    @parameterized.expand(
+        [
+            [False, False, False, False, False],
+            [True, False, False, True, False],
+            [False, True, False, True, True],
+            [False, False, True, True, True],
+        ]
+    )
+    def test_signoff_recommendations(
+        self,
+        risk_brand,
+        risk_revenue,
+        risk_partner_related,
+        vp_recommended,
+        legal_recommended,
+    ):
+        experiment = NimbusExperimentFactory.create(
+            status=NimbusExperiment.Status.DRAFT,
+            risk_brand=risk_brand,
+            risk_revenue=risk_revenue,
+            risk_partner_related=risk_partner_related,
+        )
+        self.assertEqual(experiment.signoff_recommendations["qa_signoff"], True)
+        self.assertEqual(experiment.signoff_recommendations["vp_signoff"], vp_recommended)
+        self.assertEqual(
+            experiment.signoff_recommendations["legal_signoff"], legal_recommended
+        )
+
 
 class TestNimbusBranch(TestCase):
     def test_str(self):

--- a/app/experimenter/nimbus-ui/schema.graphql
+++ b/app/experimenter/nimbus-ui/schema.graphql
@@ -313,6 +313,7 @@ type NimbusExperimentType {
   reviewRequest: NimbusChangeLogType
   rejection: NimbusChangeLogType
   timeout: NimbusChangeLogType
+  signoffRecommendations: NimbusSignoffRecommendationsType
 }
 
 type NimbusFeatureConfigType {
@@ -355,6 +356,12 @@ type NimbusOutcomeType {
 type NimbusReadyForReviewType {
   message: ObjectField
   ready: Boolean
+}
+
+type NimbusSignoffRecommendationsType {
+  qaSignoff: Boolean
+  vpSignoff: Boolean
+  legalSignoff: Boolean
 }
 
 type NimbusUser {

--- a/app/experimenter/nimbus-ui/src/gql/experiments.ts
+++ b/app/experimenter/nimbus-ui/src/gql/experiments.ts
@@ -96,6 +96,12 @@ export const GET_EXPERIMENT_QUERY = gql`
       riskBrand
       riskPartnerRelated
 
+      signoffRecommendations {
+        qaSignoff
+        vpSignoff
+        legalSignoff
+      }
+
       documentationLinks {
         title
         link

--- a/app/experimenter/nimbus-ui/src/types/getExperiment.ts
+++ b/app/experimenter/nimbus-ui/src/types/getExperiment.ts
@@ -46,6 +46,12 @@ export interface getExperiment_experimentBySlug_readyForReview {
   message: ObjectField | null;
 }
 
+export interface getExperiment_experimentBySlug_signoffRecommendations {
+  qaSignoff: boolean | null;
+  vpSignoff: boolean | null;
+  legalSignoff: boolean | null;
+}
+
 export interface getExperiment_experimentBySlug_documentationLinks {
   title: NimbusDocumentationLinkTitle;
   link: string;
@@ -112,6 +118,7 @@ export interface getExperiment_experimentBySlug {
   riskRevenue: boolean | null;
   riskBrand: boolean | null;
   riskPartnerRelated: boolean | null;
+  signoffRecommendations: getExperiment_experimentBySlug_signoffRecommendations | null;
   documentationLinks: getExperiment_experimentBySlug_documentationLinks[] | null;
   isEnrollmentPaused: boolean | null;
   enrollmentEndDate: DateTime | null;


### PR DESCRIPTION
Closes #4921

This PR adds a new field, `signoffRecommendations`, to the experiment query, which provides the sub-fields `qaSignoff`, `vpSignoff`, and `legalSignoff` (all booleans)

The issue description mentions collecting all the required signoffs to compare them against completed signoffs, but since we don't have a mechanism to verify completed signoffs and they are all recommendations I simplified this a bit. Let me know if I'm missing something.