### PR TITLE
fix #5167 feat(nimbus): display recipe json on summary page

### DIFF
--- a/app/experimenter/experiments/api/v5/types.py
+++ b/app/experimenter/experiments/api/v5/types.py
@@ -1,9 +1,12 @@
+import json
+
 import graphene
 from django.contrib.auth import get_user_model
 from graphene_django import DjangoListField
 from graphene_django.types import DjangoObjectType
 
 from experimenter.experiments.api.v5.serializers import NimbusReadyForReviewSerializer
+from experimenter.experiments.api.v6.serializers import NimbusExperimentSerializer
 from experimenter.experiments.constants.nimbus import NimbusConstants
 from experimenter.experiments.models.nimbus import (
     NimbusBranch,
@@ -162,6 +165,7 @@ class NimbusExperimentType(DjangoObjectType):
     rejection = graphene.Field(NimbusChangeLogType)
     timeout = graphene.Field(NimbusChangeLogType)
     signoff_recommendations = graphene.Field(NimbusSignoffRecommendationsType)
+    recipe_json = graphene.String()
 
     class Meta:
         model = NimbusExperiment
@@ -205,3 +209,6 @@ class NimbusExperimentType(DjangoObjectType):
 
     def resolve_timeout(self, info):
         return self.changes.latest_timeout()
+
+    def resolve_recipe_json(self, info):
+        return json.dumps(NimbusExperimentSerializer(self).data, indent=2, sort_keys=True)

--- a/app/experimenter/experiments/api/v6/serializers.py
+++ b/app/experimenter/experiments/api/v6/serializers.py
@@ -119,4 +119,7 @@ class NimbusExperimentSerializer(serializers.ModelSerializer):
             return obj.reference_branch.slug
 
     def get_featureIds(self, obj):
-        return [obj.feature_config.slug]
+        feature_ids = []
+        if obj.feature_config:
+            feature_ids.append(obj.feature_config.slug)
+        return feature_ids

--- a/app/experimenter/nimbus-ui/schema.graphql
+++ b/app/experimenter/nimbus-ui/schema.graphql
@@ -314,6 +314,7 @@ type NimbusExperimentType {
   rejection: NimbusChangeLogType
   timeout: NimbusChangeLogType
   signoffRecommendations: NimbusSignoffRecommendationsType
+  recipeJson: String
 }
 
 type NimbusFeatureConfigType {

--- a/app/experimenter/nimbus-ui/src/components/Summary/TableAudience/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/TableAudience/index.test.tsx
@@ -122,6 +122,23 @@ describe("TableAudience", () => {
       ).not.toBeInTheDocument();
     });
   });
+
+  describe("renders 'Recipe JSON' row as expected", () => {
+    it("when set", () => {
+      const { experiment } = mockExperimentQuery("demo-slug");
+      render(<Subject {...{ experiment }} />);
+      expect(screen.getByTestId("experiment-recipe-json")).toBeInTheDocument();
+    });
+    it("when recipeJson is null", () => {
+      const { experiment } = mockExperimentQuery("demo-slug", {
+        recipeJson: null,
+      });
+      render(<Subject {...{ experiment }} />);
+      expect(
+        screen.queryByTestId("experiment-recipe-json"),
+      ).not.toBeInTheDocument();
+    });
+  });
 });
 
 const Subject = ({

--- a/app/experimenter/nimbus-ui/src/components/Summary/TableAudience/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/TableAudience/index.tsx
@@ -19,7 +19,12 @@ const TableAudience = ({ experiment }: TableAudienceProps) => {
   const { firefoxMinVersion, channel, targetingConfigSlug } = useConfig();
 
   return (
-    <Table bordered data-testid="table-audience" className="mb-4">
+    <Table
+      bordered
+      data-testid="table-audience"
+      className="mb-4"
+      style={{ tableLayout: "fixed" }}
+    >
       <tbody>
         <tr>
           <th className="w-33">Channel</th>
@@ -72,7 +77,19 @@ const TableAudience = ({ experiment }: TableAudienceProps) => {
               data-testid="experiment-target-expression"
               className="text-monospace"
             >
-              {experiment.jexlTargetingExpression}
+              <code>
+                <pre>{experiment.jexlTargetingExpression}</pre>
+              </code>
+            </td>
+          </tr>
+        )}
+        {experiment.recipeJson && (
+          <tr>
+            <th>Recipe JSON</th>
+            <td data-testid="experiment-recipe-json">
+              <code>
+                <pre>{experiment.recipeJson}</pre>
+              </code>
             </td>
           </tr>
         )}

--- a/app/experimenter/nimbus-ui/src/gql/experiments.ts
+++ b/app/experimenter/nimbus-ui/src/gql/experiments.ts
@@ -130,6 +130,7 @@ export const GET_EXPERIMENT_QUERY = gql`
           email
         }
       }
+      recipeJson
     }
   }
 `;

--- a/app/experimenter/nimbus-ui/src/lib/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/lib/mocks.tsx
@@ -321,6 +321,8 @@ export function mockExperiment<
       ],
       isEnrollmentPaused: true,
       enrollmentEndDate: null,
+      recipeJson:
+        '{"schemaVersion": "1.5.0", "slug": "pre-emptive-zero-tolerance-data-warehouse", "id": "pre-emptive-zero-tolerance-data-warehouse", "arguments": {}, "application": "", "appName": "firefox_ios", "appId": "", "channel": "", "userFacingName": "Pre-emptive zero tolerance data-warehouse", "userFacingDescription": "Analysis art mean sort serve stuff. Scene alone current television up write company. Without admit she occur total generation by mother. Environmental remember account huge drive policy play strong.", "isEnrollmentPaused": false, "bucketConfig": null, "probeSets": [], "outcomes": [{"slug": "example_config", "priority": "primary"}, {"slug": "newtab_visibility", "priority": "primary"}, {"slug": "picture_in_picture", "priority": "secondary"}], "branches": [{"slug": "horizontal-well-modulated-conglomeration", "ratio": 1, "feature": {"featureId": "decentralized-solution-oriented-neural-net", "enabled": true, "value": {"trouble-left-back": "west-receive"}}}, {"slug": "fully-configurable-context-sensitive-local-area-network", "ratio": 1, "feature": {"featureId": "decentralized-solution-oriented-neural-net", "enabled": true, "value": {"financial-school": "peace-light-might"}}}], "targeting": "localeLanguageCode == \'en\' && ((isFirstStartup && !(\'trailhead.firstrun.didSeeAboutWelcome\'|preferenceValue)) || experiment.slug in activeExperiments)", "startDate": null, "endDate": null, "proposedDuration": 60, "proposedEnrollment": 45, "referenceBranch": "horizontal-well-modulated-conglomeration", "featureIds": ["decentralized-solution-oriented-neural-net"]}',
     },
     modifications,
   ) as T;

--- a/app/experimenter/nimbus-ui/src/types/getExperiment.ts
+++ b/app/experimenter/nimbus-ui/src/types/getExperiment.ts
@@ -126,6 +126,7 @@ export interface getExperiment_experimentBySlug {
   reviewRequest: getExperiment_experimentBySlug_reviewRequest | null;
   rejection: getExperiment_experimentBySlug_rejection | null;
   timeout: getExperiment_experimentBySlug_timeout | null;
+  recipeJson: string | null;
 }
 
 export interface getExperiment {


### PR DESCRIPTION


Because

* We need a way to display the recipe json before an experiment launches for review
* The link to the V6 API will no longer work in the new lifecycle flow

This commit

* Exposes the recipe json via the V5 API
* Displays it on the summary table


![Screenshot 2021-05-04 at 16-14-53 Public-key content-based leverage – Review Launch Experimenter](https://user-images.githubusercontent.com/119884/117067434-01fa9b80-acf8-11eb-8772-5400a4b978e7.png)