### PR TITLE
fix #4925 feat(nimbus): display recommended signoffs on review page

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/FormOverview/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/FormOverview/index.tsx
@@ -184,7 +184,7 @@ const FormOverview = ({
             If the public, users or press, were to discover this experiment and
             description, do you think it would negatively impact their
             perception of the brand?{" "}
-            <LinkExternal href={EXTERNAL_URLS.SIGNOFF_BRAND}>
+            <LinkExternal href={EXTERNAL_URLS.RISK_BRAND}>
               Learn more
             </LinkExternal>
             {isMissingField!("risk_brand") && (
@@ -290,7 +290,7 @@ const FormOverview = ({
             >
               Does this experiment impact or rely on a partner or outside
               company (e.g. Google, Amazon)?{" "}
-              <LinkExternal href={EXTERNAL_URLS.SIGNOFF_PARTNER}>
+              <LinkExternal href={EXTERNAL_URLS.RISK_PARTNER}>
                 Learn more
               </LinkExternal>
               {isMissingField!("risk_partner_related") && (
@@ -313,7 +313,7 @@ const FormOverview = ({
             >
               Does this experiment have a risk to negatively impact revenue
               (e.g. search, Pocket revenue)?{" "}
-              <LinkExternal href={EXTERNAL_URLS.SIGNOFF_REVENUE}>
+              <LinkExternal href={EXTERNAL_URLS.RISK_REVENUE}>
                 Learn more
               </LinkExternal>
               {isMissingField!("risk_revenue") && (

--- a/app/experimenter/nimbus-ui/src/components/PageRequestReview/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageRequestReview/index.stories.tsx
@@ -44,10 +44,18 @@ export const draftStatus = storyWithExperimentProps({
   publishStatus: NimbusExperimentPublishStatus.IDLE,
 });
 
-export const previewStatus = storyWithExperimentProps({
-  status: NimbusExperimentStatus.PREVIEW,
-  publishStatus: NimbusExperimentPublishStatus.IDLE,
-});
+export const previewStatus = storyWithExperimentProps(
+  {
+    status: NimbusExperimentStatus.PREVIEW,
+    publishStatus: NimbusExperimentPublishStatus.IDLE,
+    signoffRecommendations: {
+      qaSignoff: true,
+      vpSignoff: false,
+      legalSignoff: false,
+    },
+  },
+  "Preview status, one recommended signoff",
+);
 
 export const reviewRequestedCanReview = storyWithExperimentProps(
   { ...reviewRequestedBaseProps, canReview: true },
@@ -82,6 +90,18 @@ export const reviewTimedoutCannotReview = storyWithExperimentProps(
 export const reviewRejected = storyWithExperimentProps(
   reviewRejectedBaseProps,
   "Review rejected",
+);
+
+export const reviewRecommendedSignoffs = storyWithExperimentProps(
+  {
+    ...reviewRequestedBaseProps,
+    signoffRecommendations: {
+      qaSignoff: true,
+      vpSignoff: true,
+      legalSignoff: true,
+    },
+  },
+  "Review with recommended sign offs",
 );
 
 export const error = () => (

--- a/app/experimenter/nimbus-ui/src/components/PageRequestReview/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageRequestReview/index.test.tsx
@@ -354,4 +354,68 @@ describe("PageRequestReview", () => {
       expect(screen.getByTestId("in-review-label")).toBeInTheDocument(),
     );
   });
+
+  it("shows no recommended signoff", async () => {
+    const { mock } = mockExperimentQuery("demo-slug", {
+      signoffRecommendations: {
+        qaSignoff: false,
+        vpSignoff: false,
+        legalSignoff: false,
+      },
+    });
+    render(<Subject mocks={[mock]} />);
+    await waitFor(() =>
+      expect(screen.getByTestId("table-signoff")).not.toHaveTextContent(
+        "Recommended",
+      ),
+    );
+  });
+
+  it("shows qa recommended signoff", async () => {
+    const { mock } = mockExperimentQuery("demo-slug", {
+      signoffRecommendations: {
+        qaSignoff: true,
+        vpSignoff: false,
+        legalSignoff: false,
+      },
+    });
+    render(<Subject mocks={[mock]} />);
+    await waitFor(() =>
+      expect(screen.getByTestId("table-signoff-qa")).toHaveTextContent(
+        "Recommended",
+      ),
+    );
+  });
+
+  it("shows vp recommended signoff", async () => {
+    const { mock } = mockExperimentQuery("demo-slug", {
+      signoffRecommendations: {
+        qaSignoff: false,
+        vpSignoff: true,
+        legalSignoff: false,
+      },
+    });
+    render(<Subject mocks={[mock]} />);
+    await waitFor(() =>
+      expect(screen.getByTestId("table-signoff-vp")).toHaveTextContent(
+        "Recommended",
+      ),
+    );
+  });
+
+  it("shows legal recommended signoff", async () => {
+    const { mock } = mockExperimentQuery("demo-slug", {
+      signoffRecommendations: {
+        qaSignoff: false,
+        vpSignoff: false,
+        legalSignoff: true,
+      },
+    });
+    render(<Subject mocks={[mock]} />);
+    await waitFor(() =>
+      expect(screen.getByTestId("table-signoff-legal")).toHaveTextContent(
+        "Recommended",
+      ),
+    );
+  });
 });

--- a/app/experimenter/nimbus-ui/src/components/PageRequestReview/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageRequestReview/index.tsx
@@ -4,10 +4,11 @@
 
 import { RouteComponentProps } from "@reach/router";
 import React, { useRef, useState } from "react";
+import { Table } from "react-bootstrap";
 import Alert from "react-bootstrap/Alert";
 import { useChangeOperationMutation } from "../../hooks";
 import { useConfig } from "../../hooks/useConfig";
-import { CHANGELOG_MESSAGES } from "../../lib/constants";
+import { CHANGELOG_MESSAGES, EXTERNAL_URLS } from "../../lib/constants";
 import { getStatus } from "../../lib/experiment";
 import { getExperiment_experimentBySlug } from "../../types/getExperiment";
 import {
@@ -16,6 +17,7 @@ import {
 } from "../../types/globalTypes";
 import AppLayoutWithExperiment from "../AppLayoutWithExperiment";
 import ChangeApprovalOperations from "../ChangeApprovalOperations";
+import LinkExternal from "../LinkExternal";
 import Summary from "../Summary";
 import FormLaunchDraftToPreview from "./FormLaunchDraftToPreview";
 import FormLaunchDraftToReview from "./FormLaunchDraftToReview";
@@ -160,6 +162,52 @@ const PageRequestReview = ({
                 )}
               </ChangeApprovalOperations>
             )}
+
+            <h3 className="h5 mb-3">Recommended actions before launch</h3>
+            <Table bordered data-testid="table-signoff" className="mb-4">
+              <tr data-testid="table-signoff-qa">
+                <td>
+                  <strong>QA Sign - Off</strong>
+                </td>
+                <td>
+                  {experiment.signoffRecommendations?.qaSignoff && (
+                    <span className="text-success">Recommended: </span>
+                  )}
+                  Describe what they should do.{" "}
+                  <LinkExternal href={EXTERNAL_URLS.SIGNOFF_QA}>
+                    Learn More
+                  </LinkExternal>
+                </td>
+              </tr>
+              <tr data-testid="table-signoff-vp">
+                <td>
+                  <strong>VP Sign - Off</strong>
+                </td>
+                <td>
+                  {experiment.signoffRecommendations?.vpSignoff && (
+                    <span className="text-success">Recommended: </span>
+                  )}
+                  Describe what they should do.{" "}
+                  <LinkExternal href={EXTERNAL_URLS.SIGNOFF_VP}>
+                    Learn More
+                  </LinkExternal>
+                </td>
+              </tr>
+              <tr data-testid="table-signoff-legal">
+                <td>
+                  <strong>Legal Sign - Off</strong>
+                </td>
+                <td>
+                  {experiment.signoffRecommendations?.legalSignoff && (
+                    <span className="text-success">Recommended: </span>
+                  )}
+                  Describe what they should do.{" "}
+                  <LinkExternal href={EXTERNAL_URLS.SIGNOFF_LEGAL}>
+                    Learn More
+                  </LinkExternal>
+                </td>
+              </tr>
+            </Table>
 
             <Summary {...{ experiment }} />
           </>

--- a/app/experimenter/nimbus-ui/src/lib/constants.ts
+++ b/app/experimenter/nimbus-ui/src/lib/constants.ts
@@ -26,12 +26,18 @@ export const EXTERNAL_URLS = {
   // EXP-866 TBD URL
   PREVIEW_LAUNCH_DOC:
     "https://mana.mozilla.org/wiki/display/FJT/Project+Nimbus",
-  SIGNOFF_BRAND:
-    "https://mana.mozilla.org/wiki/pages/viewpage.action?spaceKey=FIREFOX&title=Pref-Flip+and+Add-On+Experiments#PrefFlipandAddOnExperiments-VPSign-off",
-  SIGNOFF_PARTNER:
-    "https://mana.mozilla.org/wiki/display/FIREFOX/Pref-Flip+and+Add-On+Experiments#PrefFlipandAddOnExperiments-Isthisstudypartnerrelated?",
-  SIGNOFF_REVENUE:
-    "https://mana.mozilla.org/wiki/display/FIREFOX/Pref-Flip+and+Add-On+Experiments#PrefFlipandAddOnExperiments-Doesthisstudyhavepossiblenegativeimpactonrevenue?",
+  RISK_BRAND:
+    "https://mana.mozilla.org/wiki/display/FIREFOX/Pref-Flip+and+Add-On+Experiments#PrefFlipandAddOnExperiments-Doesthishavehighrisktothebrand?",
+  RISK_PARTNER:
+    "https://mana.mozilla.org/wiki/display/FIREFOX/Pref-Flip+and+Add-On+Experiments#PrefFlipandAddOnExperiments-Isthisstudypartnerrelated?riskPARTNER",
+  RISK_REVENUE:
+    "https://mana.mozilla.org/wiki/display/FIREFOX/Pref-Flip+and+Add-On+Experiments#PrefFlipandAddOnExperiments-riskREV",
+  SIGNOFF_QA:
+    "https://mana.mozilla.org/wiki/display/FIREFOX/Pref-Flip+and+Add-On+Experiments#PrefFlipandAddOnExperiments-QAsign-offsignQA",
+  SIGNOFF_VP:
+    "https://mana.mozilla.org/wiki/display/FIREFOX/Pref-Flip+and+Add-On+Experiments#PrefFlipandAddOnExperiments-VPSign-offsignVP",
+  SIGNOFF_LEGAL:
+    "https://mana.mozilla.org/wiki/display/FIREFOX/Pref-Flip+and+Add-On+Experiments#PrefFlipandAddOnExperiments-signLEGAL",
 };
 
 export const CHANGELOG_MESSAGES = {


### PR DESCRIPTION
Because

* After risk mitigation questions are filled out we need to show which sign offs are recommended

This commit

* Displays the recommended sign offs table on the review page

![Screenshot 2021-05-05 at 12-39-28 Expanded didactic access – Review Launch Experimenter](https://user-images.githubusercontent.com/119884/117178613-3d50a500-ada0-11eb-8c98-cf9de6dfe8fd.png)

Blocked on getting the three `Learn More` links from @AnaMedinac 