### PR TITLE
fixes #4902 chore(nimbus): Refactor NimbusExperimentFactory to incorporate publish_status

### DIFF
--- a/app/experimenter/base/management/commands/load_dummy_experiments.py
+++ b/app/experimenter/base/management/commands/load_dummy_experiments.py
@@ -22,9 +22,6 @@ class Command(BaseCommand):
             experiment = ExperimentFactory.create_with_status(status, type=random_type)
             logger.info("Created {}: {}".format(experiment, status))
 
-        for application in NimbusExperiment.Application:
-            for status in NimbusExperiment.Status:
-                experiment = NimbusExperimentFactory.create_with_status(
-                    status, application=application
-                )
-                logger.info("Created {}: {}".format(experiment, status))
+        for lifecycle in NimbusExperiment.Lifecycles:
+            experiment = NimbusExperimentFactory.create_with_lifecycle(lifecycle)
+            logger.info("Created {}: {}".format(experiment, lifecycle))

--- a/app/experimenter/base/tests/test_initial_data.py
+++ b/app/experimenter/base/tests/test_initial_data.py
@@ -13,10 +13,7 @@ class TestInitialData(TestCase):
         for status, _ in Experiment.STATUS_CHOICES:
             self.assertTrue(Experiment.objects.filter(status=status).exists())
 
-        for application in NimbusExperiment.Application:
-            for status in NimbusExperiment.Status:
-                self.assertTrue(
-                    NimbusExperiment.objects.filter(
-                        status=status, application=application
-                    ).exists()
-                )
+        for lifecycle in NimbusExperiment.Lifecycles:
+            states = lifecycle.value
+            final_state = states[-1].value
+            self.assertTrue(NimbusExperiment.objects.filter(**final_state).exists())

--- a/app/experimenter/experiments/constants/nimbus.py
+++ b/app/experimenter/experiments/constants/nimbus.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from enum import Enum
 from typing import Dict
 
 from django.conf import settings
@@ -156,24 +157,121 @@ APPLICATION_CONFIG_IOS = ApplicationConfig(
 )
 
 
+class Status(models.TextChoices):
+    DRAFT = "Draft"
+    PREVIEW = "Preview"
+    LIVE = "Live"
+    COMPLETE = "Complete"
+
+
+class PublishStatus(models.TextChoices):
+    IDLE = "Idle"
+    REVIEW = "Review"
+    APPROVED = "Approved"
+    WAITING = "Waiting"
+
+
+class LifecycleStates(Enum):
+    DRAFT_IDLE = {
+        "status": Status.DRAFT,
+        "publish_status": PublishStatus.IDLE,
+    }
+    PREVIEW_IDLE = {
+        "status": Status.PREVIEW,
+        "publish_status": PublishStatus.IDLE,
+    }
+    DRAFT_REVIEW = {
+        "status": Status.DRAFT,
+        "publish_status": PublishStatus.REVIEW,
+    }
+    DRAFT_APPROVED = {
+        "status": Status.DRAFT,
+        "publish_status": PublishStatus.APPROVED,
+    }
+    DRAFT_WAITING = {
+        "status": Status.DRAFT,
+        "publish_status": PublishStatus.WAITING,
+    }
+    LIVE_IDLE = {
+        "status": Status.LIVE,
+        "publish_status": PublishStatus.IDLE,
+    }
+    PAUSE_CANDIDATE = {
+        "status": Status.LIVE,
+        "publish_status": PublishStatus.IDLE,
+        "is_paused": False,
+    }
+    PAUSED = {
+        "status": Status.LIVE,
+        "publish_status": PublishStatus.IDLE,
+        "is_paused": True,
+    }
+    LIVE_REVIEW_ENDING = {
+        "status": Status.LIVE,
+        "publish_status": PublishStatus.REVIEW,
+        "is_end_requested": True,
+    }
+    LIVE_IDLE_REJECT_ENDING = {
+        "status": Status.LIVE,
+        "publish_status": PublishStatus.IDLE,
+        "is_end_requested": False,
+    }
+    LIVE_APPROVED_ENDING = {
+        "status": Status.LIVE,
+        "publish_status": PublishStatus.APPROVED,
+        "is_end_requested": True,
+    }
+    LIVE_WAITING_ENDING = {
+        "status": Status.LIVE,
+        "publish_status": PublishStatus.WAITING,
+        "is_end_requested": True,
+    }
+    COMPLETE_IDLE_ENDED = {
+        "status": Status.COMPLETE,
+        "publish_status": PublishStatus.IDLE,
+        "is_end_requested": True,
+    }
+
+
+class Lifecycles(Enum):
+    CREATED = (LifecycleStates.DRAFT_IDLE,)
+    PREVIEW = CREATED + (LifecycleStates.PREVIEW_IDLE,)
+    LAUNCH_REVIEW_REQUESTED = CREATED + (LifecycleStates.DRAFT_REVIEW,)
+    LAUNCH_REJECT = LAUNCH_REVIEW_REQUESTED + (LifecycleStates.DRAFT_IDLE,)
+    LAUNCH_APPROVE = LAUNCH_REVIEW_REQUESTED + (LifecycleStates.DRAFT_APPROVED,)
+    LAUNCH_APPROVE_WAITING = LAUNCH_APPROVE + (LifecycleStates.DRAFT_WAITING,)
+    LAUNCH_APPROVE_APPROVE = LAUNCH_APPROVE_WAITING + (LifecycleStates.LIVE_IDLE,)
+    LAUNCH_APPROVE_REJECT = LAUNCH_APPROVE_WAITING + (LifecycleStates.DRAFT_IDLE,)
+    LAUNCH_APPROVE_TIMEOUT = LAUNCH_APPROVE_WAITING + (LifecycleStates.DRAFT_REVIEW,)
+    PAUSED = LAUNCH_APPROVE_APPROVE + (LifecycleStates.PAUSED,)
+    ENDING_REVIEW_REQUESTED = LAUNCH_APPROVE_APPROVE + (
+        LifecycleStates.LIVE_REVIEW_ENDING,
+    )
+    ENDING_REJECT = ENDING_REVIEW_REQUESTED + (LifecycleStates.LIVE_IDLE_REJECT_ENDING,)
+    ENDING_APPROVE = ENDING_REVIEW_REQUESTED + (LifecycleStates.LIVE_APPROVED_ENDING,)
+    ENDING_APPROVE_WAITING = ENDING_APPROVE + (LifecycleStates.LIVE_WAITING_ENDING,)
+    ENDING_APPROVE_APPROVE = ENDING_APPROVE_WAITING + (
+        LifecycleStates.COMPLETE_IDLE_ENDED,
+    )
+    ENDING_APPROVE_REJECT = ENDING_APPROVE_WAITING + (
+        LifecycleStates.LIVE_IDLE_REJECT_ENDING,
+    )
+    ENDING_APPROVE_TIMEOUT = ENDING_APPROVE_WAITING + (
+        LifecycleStates.LIVE_REVIEW_ENDING,
+    )
+
+
 class NimbusConstants(object):
-    class Status(models.TextChoices):
-        DRAFT = "Draft"
-        PREVIEW = "Preview"
-        LIVE = "Live"
-        COMPLETE = "Complete"
+    Status = Status
+    PublishStatus = PublishStatus
+    LifecycleStates = LifecycleStates
+    Lifecycles = Lifecycles
 
     VALID_STATUS_TRANSITIONS = {
         Status.DRAFT: (Status.PREVIEW,),
         Status.PREVIEW: (Status.DRAFT,),
     }
     STATUS_ALLOWS_UPDATE = (Status.DRAFT,)
-
-    class PublishStatus(models.TextChoices):
-        IDLE = "Idle"
-        REVIEW = "Review"
-        APPROVED = "Approved"
-        WAITING = "Waiting"
 
     VALID_PUBLISH_STATUS_TRANSITIONS = {
         PublishStatus.IDLE: (PublishStatus.REVIEW, PublishStatus.APPROVED),

--- a/app/experimenter/experiments/tests/api/v5/test_mutations.py
+++ b/app/experimenter/experiments/tests/api/v5/test_mutations.py
@@ -221,8 +221,8 @@ class TestMutations(GraphQLTestCase):
 
     def test_does_not_delete_branches_when_other_fields_specified(self):
         user_email = "user@example.com"
-        experiment = NimbusExperimentFactory.create_with_status(
-            NimbusExperiment.Status.DRAFT
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperiment.Lifecycles.CREATED
         )
         branch_count = experiment.branches.count()
         response = self.query(
@@ -248,8 +248,8 @@ class TestMutations(GraphQLTestCase):
 
     def test_does_not_clear_feature_config_when_other_fields_specified(self):
         user_email = "user@example.com"
-        experiment = NimbusExperimentFactory.create_with_status(
-            NimbusExperiment.Status.DRAFT
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperiment.Lifecycles.CREATED
         )
         expected_feature_config = experiment.feature_config
 
@@ -536,9 +536,8 @@ class TestMutations(GraphQLTestCase):
 
     def test_reject_draft_experiment(self):
         user_email = "user@example.com"
-        experiment = NimbusExperimentFactory.create_with_status(
-            NimbusExperiment.Status.DRAFT,
-            publish_status=NimbusExperiment.PublishStatus.REVIEW,
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperiment.Lifecycles.LAUNCH_REVIEW_REQUESTED
         )
         response = self.query(
             UPDATE_EXPERIMENT_MUTATION,
@@ -561,10 +560,8 @@ class TestMutations(GraphQLTestCase):
 
     def test_reject_ending_experiment(self):
         user_email = "user@example.com"
-        experiment = NimbusExperimentFactory.create_with_status(
-            NimbusExperiment.Status.LIVE,
-            publish_status=NimbusExperiment.PublishStatus.REVIEW,
-            is_end_requested=True,
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperiment.Lifecycles.ENDING_REVIEW_REQUESTED
         )
         response = self.query(
             UPDATE_EXPERIMENT_MUTATION,

--- a/app/experimenter/experiments/tests/api/v6/test_serializers.py
+++ b/app/experimenter/experiments/tests/api/v6/test_serializers.py
@@ -15,9 +15,8 @@ class TestNimbusExperimentSerializer(TestCase):
     maxDiff = None
 
     def test_serializer_outputs_expected_schema_with_feature(self):
-        experiment = NimbusExperimentFactory.create_with_status(
-            NimbusExperiment.Status.COMPLETE,
-            publish_status=NimbusExperiment.PublishStatus.APPROVED,
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperiment.Lifecycles.ENDING_APPROVE_APPROVE,
             application=NimbusExperiment.Application.DESKTOP,
             firefox_min_version=NimbusExperiment.Version.FIREFOX_83,
             targeting_config_slug=NimbusExperiment.TargetingConfig.ALL_ENGLISH,
@@ -100,10 +99,9 @@ class TestNimbusExperimentSerializer(TestCase):
 
     @parameterized.expand(list(NimbusExperiment.Application))
     def test_serializers_with_missing_feature_value(self, application):
-        experiment = NimbusExperimentFactory.create_with_status(
-            NimbusExperiment.Status.DRAFT,
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperiment.Lifecycles.LAUNCH_APPROVE,
             application=application,
-            publish_status=NimbusExperiment.PublishStatus.APPROVED,
             branches=[],
         )
         experiment.reference_branch = NimbusBranchFactory(
@@ -196,12 +194,12 @@ class TestNimbusExperimentSerializer(TestCase):
         expected_appId,
         expected_appName,
     ):
-        experiment = NimbusExperimentFactory.create_with_status(
-            NimbusExperiment.Status.DRAFT,
-            publish_status=NimbusExperiment.PublishStatus.APPROVED,
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperiment.Lifecycles.LAUNCH_APPROVE,
             application=application,
             channel=channel,
         )
+
         serializer = NimbusExperimentSerializer(experiment)
         self.assertEqual(serializer.data["application"], expected_application)
         self.assertEqual(serializer.data["channel"], channel)
@@ -210,9 +208,8 @@ class TestNimbusExperimentSerializer(TestCase):
         check_schema("experiments/NimbusExperiment", serializer.data)
 
     def test_serializer_outputs_targeting(self):
-        experiment = NimbusExperimentFactory.create_with_status(
-            NimbusExperiment.Status.DRAFT,
-            publish_status=NimbusExperiment.PublishStatus.APPROVED,
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperiment.Lifecycles.LAUNCH_APPROVE,
             firefox_min_version=NimbusExperiment.Version.FIREFOX_83,
             targeting_config_slug=NimbusExperiment.TargetingConfig.ALL_ENGLISH,
             application=NimbusExperiment.Application.DESKTOP,
@@ -223,12 +220,13 @@ class TestNimbusExperimentSerializer(TestCase):
         check_schema("experiments/NimbusExperiment", serializer.data)
 
     def test_serializer_outputs_empty_targeting(self):
-        experiment = NimbusExperimentFactory.create_with_status(
-            NimbusExperiment.Status.DRAFT,
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperiment.Lifecycles.LAUNCH_APPROVE,
             publish_status=NimbusExperiment.PublishStatus.APPROVED,
             targeting_config_slug=NimbusExperiment.TargetingConfig.NO_TARGETING,
             application=NimbusExperiment.Application.FENIX,
         )
+
         serializer = NimbusExperimentSerializer(experiment)
         self.assertEqual(serializer.data["targeting"], "true")
         check_schema("experiments/NimbusExperiment", serializer.data)

--- a/app/experimenter/experiments/tests/api/v6/test_views.py
+++ b/app/experimenter/experiments/tests/api/v6/test_views.py
@@ -14,12 +14,15 @@ class TestNimbusExperimentViewSet(TestCase):
     def test_list_view_serializes_experiments(self):
         experiments = []
 
-        for status in NimbusExperiment.Status:
-            if status not in [
+        for lifecycle in NimbusExperiment.Lifecycles:
+            final_status = lifecycle.value[-1].value
+            if final_status["status"] not in [
                 NimbusExperiment.Status.DRAFT,
             ]:
                 experiments.append(
-                    NimbusExperimentFactory.create_with_status(status.value, slug=status)
+                    NimbusExperimentFactory.create_with_lifecycle(
+                        lifecycle, slug=lifecycle.name
+                    )
                 )
 
         response = self.client.get(
@@ -33,8 +36,8 @@ class TestNimbusExperimentViewSet(TestCase):
         self.assertEqual(json_slugs, expected_slugs)
 
     def test_get_nimbus_experiment_returns_expected_data(self):
-        experiment = NimbusExperimentFactory.create_with_status(
-            NimbusExperiment.Status.LIVE
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperiment.Lifecycles.LAUNCH_APPROVE_APPROVE, slug="test-rest-detail"
         )
 
         response = self.client.get(

--- a/app/experimenter/experiments/tests/test_admin/test_admin_nimbus.py
+++ b/app/experimenter/experiments/tests/test_admin/test_admin_nimbus.py
@@ -37,8 +37,10 @@ class TestNimbusExperimentAdminForm(TestCase):
         self.assertTrue(form.is_valid(), form.errors)
 
     def test_form_saves_outcomes(self):
-        experiment = NimbusExperimentFactory.create_with_status(
-            NimbusExperiment.Status.DRAFT, primary_outcomes=[], secondary_outcomes=[]
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperiment.Lifecycles.CREATED,
+            primary_outcomes=[],
+            secondary_outcomes=[],
         )
         form = NimbusExperimentAdminForm(
             instance=experiment,

--- a/app/experimenter/experiments/tests/test_changelog_utils/test_changelog_utils_nimbus.py
+++ b/app/experimenter/experiments/tests/test_changelog_utils/test_changelog_utils_nimbus.py
@@ -69,8 +69,8 @@ class TestNimbusExperimentChangeLogSerializer(TestCase):
         primary_outcome = Outcomes.by_application(application)[0].slug
         secondary_outcome = Outcomes.by_application(application)[1].slug
 
-        experiment = NimbusExperimentFactory.create_with_status(
-            NimbusExperiment.Status.COMPLETE,
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperiment.Lifecycles.ENDING_APPROVE_APPROVE,
             application=application,
             feature_config=feature_config,
             projects=[project],
@@ -181,8 +181,8 @@ class TestGenerateNimbusChangeLog(TestCase):
         )
 
     def test_generate_nimbus_changelog_with_prior_change(self):
-        experiment = NimbusExperimentFactory.create_with_status(
-            NimbusExperiment.Status.DRAFT
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperiment.Lifecycles.CREATED
         )
 
         self.assertEqual(experiment.changes.count(), 1)

--- a/app/experimenter/experiments/tests/test_email/test_email_nimbus.py
+++ b/app/experimenter/experiments/tests/test_email/test_email_nimbus.py
@@ -10,8 +10,8 @@ from experimenter.experiments.tests.factories import NimbusExperimentFactory
 
 class TestNimbusEmail(TestCase):
     def test_send_experiment_ending_email(self):
-        experiment = NimbusExperimentFactory.create_with_status(
-            NimbusExperiment.Status.LIVE,
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperiment.Lifecycles.LAUNCH_APPROVE_APPROVE,
             proposed_duration=10,
         )
         experiment.changes.filter(

--- a/app/experimenter/kinto/tasks.py
+++ b/app/experimenter/kinto/tasks.py
@@ -290,7 +290,7 @@ def nimbus_check_experiments_are_paused():
         records = kinto_client.get_main_records()
 
         pause_queue = NimbusExperiment.objects.filter(
-            NimbusExperiment.Filters.IS_PAUSE_QUEUED,
+            NimbusExperiment.Filters.IS_PAUSE_CANDIDATE,
             application__in=applications,
         )
 

--- a/app/experimenter/visualization/tests/api/test_views.py
+++ b/app/experimenter/visualization/tests/api/test_views.py
@@ -24,18 +24,18 @@ class TestVisualizationView(TestCase):
 
     @parameterized.expand(
         [
-            NimbusExperiment.Status.DRAFT,
-            NimbusExperiment.Status.COMPLETE,
+            (NimbusExperiment.Lifecycles.CREATED,),
+            (NimbusExperiment.Lifecycles.ENDING_APPROVE_APPROVE,),
         ]
     )
     @patch("django.core.files.storage.default_storage.exists")
-    def test_analysis_results_view_no_data(self, status, mock_exists):
+    def test_analysis_results_view_no_data(self, lifecycle, mock_exists):
         user_email = "user@example.com"
 
         mock_exists.return_value = False
         primary_outcome = "outcome"
-        experiment = NimbusExperimentFactory.create_with_status(
-            target_status=status, primary_outcomes=[primary_outcome]
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            lifecycle, primary_outcomes=[primary_outcome]
         )
 
         response = self.client.get(
@@ -103,13 +103,13 @@ class TestVisualizationView(TestCase):
 
     @parameterized.expand(
         [
-            NimbusExperiment.Status.DRAFT,
-            NimbusExperiment.Status.COMPLETE,
+            (NimbusExperiment.Lifecycles.CREATED,),
+            (NimbusExperiment.Lifecycles.ENDING_APPROVE_APPROVE,),
         ]
     )
     @patch("django.core.files.storage.default_storage.open")
     @patch("django.core.files.storage.default_storage.exists")
-    def test_analysis_results_view_data(self, status, mock_exists, mock_open):
+    def test_analysis_results_view_data(self, lifecycle, mock_exists, mock_open):
         user_email = "user@example.com"
 
         (
@@ -146,8 +146,8 @@ class TestVisualizationView(TestCase):
         mock_exists.return_value = True
         primary_outcome = "primary_outcome"
         secondary_outcome = "secondary_outcome"
-        experiment = NimbusExperimentFactory.create_with_status(
-            target_status=status,
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            lifecycle,
             primary_outcomes=[primary_outcome],
             secondary_outcomes=[secondary_outcome],
         )


### PR DESCRIPTION
Because:

* We want to add some logic to iterate the experiment through its status /
  publish_status stages to simplify the tests

This commit:

* Declare publishing lifecycles and states as constants

* Generate dummy experiments using with new create_with_lifecycle method
  to replace create_with_status

* Rework tests to use new lifecycle-based factory

* Tweak naming of PAUSE_QUEUE to PAUSE_CANDIDATE for clarity
