### PR TITLE
fixes #4926 feat(nimbus): Display risk mitigation questions in summary table

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/FormOverview/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/FormOverview/index.tsx
@@ -16,7 +16,11 @@ import {
 } from "../../hooks";
 import { useConfig } from "../../hooks/useConfig";
 import { ReactComponent as Info } from "../../images/info.svg";
-import { EXTERNAL_URLS, REQUIRED_FIELD } from "../../lib/constants";
+import {
+  EXTERNAL_URLS,
+  REQUIRED_FIELD,
+  RISK_QUESTIONS,
+} from "../../lib/constants";
 import { optionalBoolString } from "../../lib/utils";
 import { getExperiment } from "../../types/getExperiment";
 import InlineErrorIcon from "../InlineErrorIcon";
@@ -179,9 +183,7 @@ const FormOverview = ({
             ]}
             {...{ FormErrors, formControlAttrs }}
           >
-            If the public, users or press, were to discover this experiment and
-            description, do you think it would negatively impact their
-            perception of the brand?{" "}
+            {RISK_QUESTIONS.BRAND}{" "}
             <LinkExternal href={EXTERNAL_URLS.RISK_BRAND}>
               Learn more
             </LinkExternal>
@@ -262,8 +264,7 @@ const FormOverview = ({
               ]}
               {...{ FormErrors, formControlAttrs }}
             >
-              Does this experiment impact or rely on a partner or outside
-              company (e.g. Google, Amazon)?{" "}
+              {RISK_QUESTIONS.PARTNER}{" "}
               <LinkExternal href={EXTERNAL_URLS.RISK_PARTNER}>
                 Learn more
               </LinkExternal>
@@ -285,8 +286,7 @@ const FormOverview = ({
               ]}
               {...{ FormErrors, formControlAttrs }}
             >
-              Does this experiment have a risk to negatively impact revenue
-              (e.g. search, Pocket revenue)?{" "}
+              {RISK_QUESTIONS.REVENUE}{" "}
               <LinkExternal href={EXTERNAL_URLS.RISK_REVENUE}>
                 Learn more
               </LinkExternal>

--- a/app/experimenter/nimbus-ui/src/components/Summary/TableSummary/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/TableSummary/index.stories.tsx
@@ -49,6 +49,9 @@ storiesOf("components/Summary/TableSummary", module)
       primaryOutcomes: [],
       secondaryOutcomes: [],
       publicDescription: "",
+      riskRevenue: null,
+      riskBrand: null,
+      riskPartnerRelated: null,
       documentationLinks: [],
     });
 

--- a/app/experimenter/nimbus-ui/src/components/Summary/TableSummary/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/TableSummary/index.test.tsx
@@ -5,6 +5,7 @@
 import { render, screen } from "@testing-library/react";
 import React from "react";
 import TableSummary from ".";
+import { RISK_QUESTIONS } from "../../../lib/constants";
 import {
   MockedCache,
   mockExperimentQuery,
@@ -104,6 +105,48 @@ describe("TableSummary", () => {
           "Not set",
         );
       });
+    });
+  });
+
+  describe("renders 'Risk mitigation question' rows as expected", () => {
+    it("when not set", () => {
+      const { experiment } = mockExperimentQuery("demo-slug", {
+        riskRevenue: null,
+        riskBrand: null,
+        riskPartnerRelated: null,
+      });
+      render(<Subject {...{ experiment }} />);
+      for (const question of Object.values(RISK_QUESTIONS)) {
+        expect(screen.getByText(question, { exact: false })).toHaveTextContent(
+          "Not set",
+        );
+      }
+    });
+    it("when set to false", () => {
+      const { experiment } = mockExperimentQuery("demo-slug", {
+        riskRevenue: false,
+        riskBrand: false,
+        riskPartnerRelated: false,
+      });
+      render(<Subject {...{ experiment }} />);
+      for (const question of Object.values(RISK_QUESTIONS)) {
+        expect(screen.getByText(question, { exact: false })).toHaveTextContent(
+          "No",
+        );
+      }
+    });
+    it("when set to true", () => {
+      const { experiment } = mockExperimentQuery("demo-slug", {
+        riskRevenue: true,
+        riskBrand: true,
+        riskPartnerRelated: true,
+      });
+      render(<Subject {...{ experiment }} />);
+      for (const question of Object.values(RISK_QUESTIONS)) {
+        expect(screen.getByText(question, { exact: false })).toHaveTextContent(
+          "Yes",
+        );
+      }
     });
   });
 

--- a/app/experimenter/nimbus-ui/src/components/Summary/TableSummary/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/TableSummary/index.tsx
@@ -7,6 +7,7 @@ import { Table } from "react-bootstrap";
 import { displayConfigLabelOrNotSet } from "..";
 import { useConfig, useOutcomes } from "../../../hooks";
 import { ReactComponent as ExternalIcon } from "../../../images/external.svg";
+import { RISK_QUESTIONS } from "../../../lib/constants";
 import { getExperiment_experimentBySlug } from "../../../types/getExperiment";
 import LinkExternal from "../../LinkExternal";
 import NotSet from "../../NotSet";
@@ -17,6 +18,8 @@ type TableSummaryProps = {
 };
 
 // `<tr>`s showing optional fields that are not set are not displayed.
+
+const getRiskLabel = (answer: boolean) => (answer ? "Yes" : "No");
 
 const TableSummary = ({ experiment }: TableSummaryProps) => {
   const {
@@ -75,6 +78,39 @@ const TableSummary = ({ experiment }: TableSummaryProps) => {
             </td>
           </tr>
         )}
+        <tr>
+          <th>Risk mitigation question (1):</th>
+          <td>
+            {RISK_QUESTIONS.BRAND} —{" "}
+            {experiment.riskBrand !== null ? (
+              getRiskLabel(experiment.riskBrand)
+            ) : (
+              <NotSet />
+            )}
+          </td>
+        </tr>
+        <tr>
+          <th>Risk mitigation question (2):</th>
+          <td>
+            {RISK_QUESTIONS.PARTNER} —{" "}
+            {experiment.riskPartnerRelated !== null ? (
+              getRiskLabel(experiment.riskPartnerRelated)
+            ) : (
+              <NotSet />
+            )}
+          </td>
+        </tr>
+        <tr>
+          <th>Risk mitigation question (3):</th>
+          <td>
+            {RISK_QUESTIONS.REVENUE} —{" "}
+            {experiment.riskRevenue !== null ? (
+              getRiskLabel(experiment.riskRevenue)
+            ) : (
+              <NotSet />
+            )}
+          </td>
+        </tr>
         {experiment.documentationLinks &&
           experiment.documentationLinks?.length > 0 && (
             <tr>

--- a/app/experimenter/nimbus-ui/src/lib/constants.ts
+++ b/app/experimenter/nimbus-ui/src/lib/constants.ts
@@ -38,6 +38,15 @@ export const EXTERNAL_URLS = {
     "https://mana.mozilla.org/wiki/display/FIREFOX/Pref-Flip+and+Add-On+Experiments#PrefFlipandAddOnExperiments-signLEGAL",
 };
 
+export const RISK_QUESTIONS = {
+  BRAND:
+    "If the public, users or press, were to discover this experiment and description, do you think it would negatively impact their perception of the brand?",
+  PARTNER:
+    "Does this experiment impact or rely on a partner or outside company (e.g. Google, Amazon)?",
+  REVENUE:
+    "Does this experiment have a risk to negatively impact revenue (e.g. search, Pocket revenue)?",
+};
+
 export const CHANGELOG_MESSAGES = {
   CREATED_EXPERIMENT: "Created Experiment",
   UPDATED_BRANCHES: "Updated Branches",


### PR DESCRIPTION
fixes #4926 

Because:
* The new risk mitigation question fields need to be displayed to users to see what they've been set to (or if they haven't been answered) in the summary table component

This commit:
* Displays all 3 questions and yes/no answers, or not set, in separate rows in TableSummary