### PR TITLE
bug(nimbus): update test to use lifecycles

### DIFF
--- a/app/experimenter/experiments/tests/api/v6/test_serializers.py
+++ b/app/experimenter/experiments/tests/api/v6/test_serializers.py
@@ -113,9 +113,8 @@ class TestNimbusExperimentSerializer(TestCase):
         check_schema("experiments/NimbusExperiment", serializer.data)
 
     def test_serializer_with_branches_no_feature(self):
-        experiment = NimbusExperimentFactory.create_with_status(
-            NimbusExperiment.Status.DRAFT,
-            publish_status=NimbusExperiment.PublishStatus.IDLE,
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperiment.Lifecycles.CREATED,
             feature_config=None,
         )
         experiment.save()


### PR DESCRIPTION
Because

* We refactored our tests to use a new lifecycle method
* Missed one test!

This commit

* Updates the stray test to use the new lifecycle method