### PR TITLE
fix(nimbus): update recommended sign-off labels

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/PageRequestReview/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageRequestReview/index.tsx
@@ -167,7 +167,7 @@ const PageRequestReview = ({
             <Table bordered data-testid="table-signoff" className="mb-4">
               <tr data-testid="table-signoff-qa">
                 <td>
-                  <strong>QA Sign - Off</strong>
+                  <strong>QA Sign-off</strong>
                 </td>
                 <td>
                   {experiment.signoffRecommendations?.qaSignoff && (
@@ -181,7 +181,7 @@ const PageRequestReview = ({
               </tr>
               <tr data-testid="table-signoff-vp">
                 <td>
-                  <strong>VP Sign - Off</strong>
+                  <strong>VP Sign-off</strong>
                 </td>
                 <td>
                   {experiment.signoffRecommendations?.vpSignoff && (
@@ -195,7 +195,7 @@ const PageRequestReview = ({
               </tr>
               <tr data-testid="table-signoff-legal">
                 <td>
-                  <strong>Legal Sign - Off</strong>
+                  <strong>Legal Sign-off</strong>
                 </td>
                 <td>
                   {experiment.signoffRecommendations?.legalSignoff && (


### PR DESCRIPTION
😈 Follow-up from this comment: https://github.com/mozilla/experimenter/pull/5174#discussion_r626737619

I just wanted to make sure this spelling of sign-off was updated since it's one word, not two!