### PR TITLE
fixes #5230 feat(nimbus): Render PreviewURL only for Desktop application

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/PreviewURL/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PreviewURL/index.test.tsx
@@ -40,6 +40,17 @@ describe("PreviewURL", () => {
 
     expect(screen.queryByText("Preview URL")).toBeInTheDocument();
   });
+  it("does not render when not desktop", () => {
+    render(
+      <PreviewURL
+        {...experiment}
+        application={null}
+        status={mockGetStatus({ status: NimbusExperimentStatus.LIVE })}
+      />,
+    );
+
+    expect(screen.queryByText("Preview URL")).toBeNull();
+  });
   it("does not render when missing content", () => {
     render(
       <PreviewURL

--- a/app/experimenter/nimbus-ui/src/components/PreviewURL/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PreviewURL/index.tsx
@@ -7,6 +7,7 @@ import Select from "react-select";
 import { SelectOption } from "../../hooks/useCommonForm/useCommonFormMethods";
 import { StatusCheck } from "../../lib/experiment";
 import { getExperiment_experimentBySlug } from "../../types/getExperiment";
+import { NimbusExperimentApplication } from "../../types/globalTypes";
 
 type CopyableURLProps = {
   experimentSlug: string;
@@ -19,24 +20,39 @@ const CopyableURL: React.FC<CopyableURLProps> = ({
   branch,
   collection,
 }) => {
+  // This about: url cannot be linked from web content, so help with auto-copy.
   let url = `about:studies?optin_slug=${experimentSlug}&optin_branch=${branch}`;
   const clipboard = navigator.clipboard;
   if (collection) {
     url = `${url}&optin_collection=${collection}`;
   }
-  return <code onClick={() => clipboard.writeText(url)}>{url}</code>;
+  return (
+    <code onClick={() => clipboard.writeText(url)} style={{ cursor: "copy" }}>
+      {url}
+    </code>
+  );
 };
 
 export const PreviewURL: React.FC<
   Pick<
     getExperiment_experimentBySlug,
-    "slug" | "referenceBranch" | "treatmentBranches"
+    "application" | "referenceBranch" | "slug" | "treatmentBranches"
   > & { status: StatusCheck }
-> = ({ slug: experimentSlug, referenceBranch, treatmentBranches, status }) => {
+> = ({
+  application,
+  referenceBranch,
+  slug: experimentSlug,
+  status,
+  treatmentBranches,
+}) => {
   const [selection, setSelection] = useState(referenceBranch?.slug || "");
   const slugs: SelectOption[] = [];
 
-  if (!referenceBranch || !Array.isArray(treatmentBranches)) {
+  if (
+    application !== NimbusExperimentApplication.DESKTOP ||
+    !referenceBranch ||
+    !Array.isArray(treatmentBranches)
+  ) {
     return null;
   }
 
@@ -53,8 +69,11 @@ export const PreviewURL: React.FC<
         Preview URL
       </h3>
       <p>
-        <b>Click to copy the link</b> and paste it in your browser. You need to
-        enable <code>nimbus.debug</code> pref before.
+        <b>
+          Click the <code>about:studies</code> link below to copy
+        </b>{" "}
+        then paste it in your browser. Ensure you enable{" "}
+        <code>nimbus.debug</code> in <code>about:config</code> first.
       </p>
       <form data-testid="preview-url-form" className="mb-2">
         <label htmlFor="preview-branch">Selected Branch</label>


### PR DESCRIPTION
Fix #5230 Also clarify that the about:studies link is the thing to click with text and cursor.

Preview for desktop (with updated text and mouse cursor):
![preview desktop](https://user-images.githubusercontent.com/438537/117913111-9daa7f80-b295-11eb-8a3b-2fcde934ae8b.png)

No preview for iOS:
![preview ios](https://user-images.githubusercontent.com/438537/117913133-a307ca00-b295-11eb-9fbd-70c7d4c8226a.png)
