### PR TITLE
fixes #4661 feat(nimbus): make request review page always accessible 

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/AppLayoutWithExperiment/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/AppLayoutWithExperiment/index.tsx
@@ -4,7 +4,7 @@
 
 import { navigate, RouteComponentProps, useParams } from "@reach/router";
 import React, { useEffect } from "react";
-import { useAnalysis, useExperiment, useReviewCheck } from "../../hooks";
+import { useAnalysis, useExperiment } from "../../hooks";
 import { BASE_PATH } from "../../lib/constants";
 import { getStatus, StatusCheck } from "../../lib/experiment";
 import { AnalysisData } from "../../lib/visualization/types";
@@ -43,7 +43,6 @@ type AppLayoutWithExperimentProps = {
   analysisRequiredInSidebar?: boolean; // only the sidebar needs analysis data
   redirect?: ({
     status,
-    review,
     analysis,
     analysisError,
   }: RedirectCheck) => string | void;
@@ -75,20 +74,19 @@ const AppLayoutWithExperiment = ({
     error: analysisError,
     status: analysisFetchStatus,
   } = useAnalysis();
-  const review = useReviewCheck(experiment);
   const status = getStatus(experiment);
   const analysisLoading = analysisFetchStatus === "loading";
   const analysisFetched = analysisFetchStatus !== "not-requested";
   const analysisLoadingInSidebar = analysisRequiredInSidebar && analysisLoading;
 
   // If the redirect prop function is supplied let's call it with
-  // experiment status, review, and analysis details. If it returns
+  // experiment status, and analysis details. If it returns
   // a string we know to redirect to it as a path.
   let redirectPath: string | undefined, redirectResult: string | void;
   if (
     !loading &&
     redirect &&
-    (redirectResult = redirect!({ status, review, analysis })) != null
+    (redirectResult = redirect!({ status, analysis })) != null
   ) {
     redirectResult = redirectResult.length
       ? `/${redirectResult}`
@@ -182,10 +180,8 @@ const Layout = ({
   analysisLoadingInSidebar,
   analysisError,
   experiment,
-}: LayoutProps) => {
-  const review = useReviewCheck(experiment);
-
-  return status?.launched ? (
+}: LayoutProps) =>
+  status?.launched ? (
     <AppLayoutSidebarLaunched
       {...{
         status,
@@ -199,10 +195,7 @@ const Layout = ({
       {children}
     </AppLayoutSidebarLaunched>
   ) : (
-    <AppLayoutWithSidebar {...{ status, review }}>
-      {children}
-    </AppLayoutWithSidebar>
+    <AppLayoutWithSidebar {...{ experiment }}>{children}</AppLayoutWithSidebar>
   );
-};
 
 export default AppLayoutWithExperiment;

--- a/app/experimenter/nimbus-ui/src/components/AppLayoutWithSidebar/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/AppLayoutWithSidebar/index.stories.tsx
@@ -3,40 +3,43 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { withLinks } from "@storybook/addon-links";
-import { storiesOf } from "@storybook/react";
 import React from "react";
 import AppLayoutWithSidebar from ".";
-import { mockGetStatus } from "../../lib/mocks";
-import { RouterSlugProvider } from "../../lib/test-utils";
 import { NimbusExperimentStatus } from "../../types/globalTypes";
+import { Subject } from "./mocks";
 
-storiesOf("components/AppLayoutWithSidebar", module)
-  .addDecorator(withLinks)
-  .add("status: draft", () => (
-    <RouterSlugProvider>
-      <AppLayoutWithSidebar>
-        <p>App contents go here</p>
-      </AppLayoutWithSidebar>
-    </RouterSlugProvider>
-  ))
-  .add("status: preview", () => (
-    <RouterSlugProvider>
-      <AppLayoutWithSidebar
-        status={mockGetStatus({ status: NimbusExperimentStatus.PREVIEW })}
-      >
-        <p>App contents go here</p>
-      </AppLayoutWithSidebar>
-    </RouterSlugProvider>
-  ))
-  .add("missing details", () => (
-    <RouterSlugProvider>
-      <AppLayoutWithSidebar
-        review={{
-          ready: false,
-          invalidPages: ["branches", "audience"],
-        }}
-      >
-        <p>App contents go here</p>
-      </AppLayoutWithSidebar>
-    </RouterSlugProvider>
-  ));
+export default {
+  title: "components/AppLayoutWithSidebar",
+  component: AppLayoutWithSidebar,
+  decorators: [withLinks],
+};
+
+export const DraftStatus = () => (
+  <Subject
+    experiment={{
+      status: NimbusExperimentStatus.DRAFT,
+    }}
+  />
+);
+
+export const PreviewStatus = () => (
+  <Subject
+    experiment={{
+      status: NimbusExperimentStatus.PREVIEW,
+    }}
+  />
+);
+
+export const MissingDetails = () => (
+  <Subject
+    experiment={{
+      readyForReview: {
+        ready: false,
+        message: {
+          reference_branch: ["This field may not be null."],
+          channel: ["This list may not be empty."],
+        },
+      },
+    }}
+  />
+);

--- a/app/experimenter/nimbus-ui/src/components/AppLayoutWithSidebar/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/AppLayoutWithSidebar/index.test.tsx
@@ -2,48 +2,17 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { RouteComponentProps } from "@reach/router";
 import { act, render, screen, waitFor } from "@testing-library/react";
 import React from "react";
-import AppLayoutWithSidebar from ".";
 import { BASE_PATH } from "../../lib/constants";
-import {
-  MockedCache,
-  mockExperimentQuery,
-  mockGetStatus,
-} from "../../lib/mocks";
-import { renderWithRouter, RouterSlugProvider } from "../../lib/test-utils";
+import { MockedCache, mockExperimentQuery } from "../../lib/mocks";
+import { renderWithRouter } from "../../lib/test-utils";
 import {
   NimbusExperimentPublishStatus,
   NimbusExperimentStatus,
 } from "../../types/globalTypes";
 import App from "../App";
-
-const { mock } = mockExperimentQuery("my-special-slug");
-
-const Subject = ({
-  status = NimbusExperimentStatus.DRAFT,
-  publishStatus = NimbusExperimentPublishStatus.IDLE,
-  review,
-}: RouteComponentProps & {
-  status?: NimbusExperimentStatus;
-  publishStatus?: NimbusExperimentPublishStatus;
-  review?: {
-    ready: boolean;
-    invalidPages: string[];
-  };
-}) => (
-  <RouterSlugProvider mocks={[mock]} path="/my-special-slug/edit">
-    <AppLayoutWithSidebar
-      {...{
-        status: mockGetStatus({ status, publishStatus }),
-        review,
-      }}
-    >
-      <p data-testid="test-child">Hello, world!</p>
-    </AppLayoutWithSidebar>
-  </RouterSlugProvider>
-);
+import { Subject } from "./mocks";
 
 const assertDisabledNav = () => {
   for (const slug of ["overview", "branches", "metrics", "audience"]) {
@@ -92,6 +61,7 @@ describe("AppLayoutWithSidebar", () => {
           `${BASE_PATH}/my-special-slug/${page}`,
         );
       }
+      const { mock } = mockExperimentQuery("my-special-slug");
       const {
         history: { navigate },
       } = renderWithRouter(
@@ -129,34 +99,26 @@ describe("AppLayoutWithSidebar", () => {
     });
 
     it("renders information about missing experiment details", async () => {
-      const review = {
-        ready: false,
-        invalidPages: ["overview", "branches", "metrics", "audience"],
-      };
-      render(<Subject {...{ review }} />);
+      render(
+        <Subject
+          experiment={{
+            readyForReview: {
+              ready: false,
+              message: {
+                channel: ["This list may not be empty."],
+              },
+            },
+          }}
+        />,
+      );
 
-      expect(screen.queryByTestId("missing-details")).toBeInTheDocument();
-
-      review.invalidPages.forEach((page) => {
-        expect(
-          screen.queryByTestId(`missing-detail-link-${page}`),
-        ).toBeInTheDocument();
-      });
-    });
-
-    it("renders the review & launch link when the experiment is ready for review", async () => {
-      const review = {
-        ready: true,
-        invalidPages: [],
-      };
-      render(<Subject {...{ review }} />);
-
-      expect(screen.queryByTestId("missing-details")).not.toBeInTheDocument();
-      expect(screen.queryByTestId("nav-request-review")).toBeInTheDocument();
+      await screen.findByText(/Missing details in:/);
     });
 
     it("when in preview, disables all edit page links", async () => {
-      render(<Subject status={NimbusExperimentStatus.PREVIEW} />);
+      render(
+        <Subject experiment={{ status: NimbusExperimentStatus.PREVIEW }} />,
+      );
 
       // In preview these should all not be <a> tags, but instead <span>s
       ["overview", "branches", "metrics", "audience"].forEach((slug) => {
@@ -165,19 +127,29 @@ describe("AppLayoutWithSidebar", () => {
     });
 
     it("when in draft and publish status review, disables all edit page links", async () => {
-      render(<Subject publishStatus={NimbusExperimentPublishStatus.REVIEW} />);
+      render(
+        <Subject
+          experiment={{ publishStatus: NimbusExperimentPublishStatus.REVIEW }}
+        />,
+      );
       assertDisabledNav();
     });
 
     it("when in draft and publish status approved, disables all edit page links", async () => {
       render(
-        <Subject publishStatus={NimbusExperimentPublishStatus.APPROVED} />,
+        <Subject
+          experiment={{ publishStatus: NimbusExperimentPublishStatus.APPROVED }}
+        />,
       );
       assertDisabledNav();
     });
 
     it("when in in draft and publish status waiting, disables all edit page links", async () => {
-      render(<Subject publishStatus={NimbusExperimentPublishStatus.WAITING} />);
+      render(
+        <Subject
+          experiment={{ publishStatus: NimbusExperimentPublishStatus.WAITING }}
+        />,
+      );
       assertDisabledNav();
     });
   });

--- a/app/experimenter/nimbus-ui/src/components/AppLayoutWithSidebar/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/components/AppLayoutWithSidebar/mocks.tsx
@@ -1,0 +1,29 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { RouteComponentProps } from "@reach/router";
+import React from "react";
+import { AppLayoutWithSidebar } from ".";
+import { mockExperimentQuery } from "../../lib/mocks";
+import { RouterSlugProvider } from "../../lib/test-utils";
+import { getExperiment_experimentBySlug } from "../../types/getExperiment";
+
+export const Subject = ({
+  experiment: overrides,
+}: RouteComponentProps & {
+  experiment?: Partial<getExperiment_experimentBySlug>;
+}) => {
+  const { mock, experiment } = mockExperimentQuery(
+    "my-special-slug",
+    overrides,
+  );
+
+  return (
+    <RouterSlugProvider mocks={[mock]} path="/my-special-slug/edit">
+      <AppLayoutWithSidebar {...{ experiment }}>
+        <p data-testid="test-child">Hello, world!</p>
+      </AppLayoutWithSidebar>
+    </RouterSlugProvider>
+  );
+};

--- a/app/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/index.test.tsx
@@ -89,29 +89,6 @@ describe("FormAudience", () => {
     }
   });
 
-  it("disables next button when experiment is not ready for review", async () => {
-    const onSubmit = jest.fn();
-    render(
-      <Subject
-        {...{
-          onSubmit,
-          experiment: {
-            ...MOCK_EXPERIMENT,
-            readyForReview: {
-              ready: false,
-              message: "Test",
-            },
-          },
-        }}
-      />,
-    );
-    await screen.findByTestId("FormAudience");
-    const nextButton = screen.getByTestId("next-button");
-    expect(nextButton).toBeDisabled();
-    fireEvent.click(nextButton);
-    expect(onSubmit).not.toHaveBeenCalled();
-  });
-
   it("calls onSubmit when save and next buttons are clicked", async () => {
     const onSubmit = jest.fn();
     const expected = {

--- a/app/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/index.tsx
@@ -7,7 +7,6 @@ import Alert from "react-bootstrap/Alert";
 import Col from "react-bootstrap/Col";
 import Form from "react-bootstrap/Form";
 import InputGroup from "react-bootstrap/InputGroup";
-import ReactTooltip from "react-tooltip";
 import { useCommonForm, useConfig, useReviewCheck } from "../../../hooks";
 import {
   EXTERNAL_URLS,
@@ -82,9 +81,6 @@ export const FormAudience = ({
       ),
     [isLoading, onSubmit, handleSubmit],
   );
-
-  const notReadyForReview = !experiment?.readyForReview?.ready;
-  const isNextDisabled = isLoading || notReadyForReview;
 
   return (
     <Form
@@ -251,17 +247,12 @@ export const FormAudience = ({
             onClick={handleSaveNext}
             className="btn btn-secondary"
             id="save-and-continue-button"
-            disabled={isNextDisabled}
+            disabled={isLoading}
             data-testid="next-button"
             data-sb-kind="pages/RequestReview"
-            data-tip={
-              notReadyForReview &&
-              "Required fields must be completed before proceeding to review."
-            }
           >
             Save and Continue
           </button>
-          {notReadyForReview && <ReactTooltip />}
         </div>
         <div className="p-2">
           <button

--- a/app/experimenter/nimbus-ui/src/components/PageRequestReview/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageRequestReview/index.stories.tsx
@@ -39,6 +39,19 @@ export default {
   decorators: [withLinks],
 };
 
+export const missingRequiredFields = storyWithExperimentProps(
+  {
+    readyForReview: {
+      ready: false,
+      message: {
+        reference_branch: ["This field may not be null."],
+        channel: ["This list may not be empty."],
+      },
+    },
+  },
+  "Missing fields required for review",
+);
+
 export const draftStatus = storyWithExperimentProps({
   status: NimbusExperimentStatus.DRAFT,
   publishStatus: NimbusExperimentPublishStatus.IDLE,

--- a/app/experimenter/nimbus-ui/src/components/PageRequestReview/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageRequestReview/index.test.tsx
@@ -74,45 +74,18 @@ describe("PageRequestReview", () => {
     expect(screen.getByTestId("table-summary")).toBeInTheDocument();
   });
 
-  it("redirects to the first edit page containing missing fields if the experiment status is draft and its not ready for review", async () => {
-    const { mock, experiment } = mockExperimentQuery("demo-slug", {
-      status: NimbusExperimentStatus.DRAFT,
+  it("displays a banner for pages missing fields required for review", async () => {
+    const { mock } = mockExperimentQuery("demo-slug", {
       readyForReview: {
         ready: false,
         message: {
-          // This field exists on the Audience page
-          firefox_min_version: ["This field may not be null."],
+          channel: ["This list may not be empty."],
         },
       },
     });
     render(<Subject mocks={[mock]} />);
-    await waitFor(() => {
-      expect(
-        navigate,
-      ).toHaveBeenCalledWith(
-        `${BASE_PATH}/${experiment.slug}/edit/audience?show-errors`,
-        { replace: true },
-      );
-    });
-  });
-
-  it("redirects to the overview edit page if the experiment status is draft and its not ready for review, and for some reason invalid pages is empty", async () => {
-    const { mock, experiment } = mockExperimentQuery("demo-slug", {
-      status: NimbusExperimentStatus.DRAFT,
-      readyForReview: {
-        ready: false,
-        message: {},
-      },
-    });
-    render(<Subject mocks={[mock]} />);
-    await waitFor(() => {
-      expect(
-        navigate,
-      ).toHaveBeenCalledWith(
-        `${BASE_PATH}/${experiment.slug}/edit/overview?show-errors`,
-        { replace: true },
-      );
-    });
+    await screen.findByText(/all required fields must be completed/);
+    expect(screen.queryByTestId("launch-draft-to-preview")).toBeNull();
   });
 
   it("redirects to the summary page if the experiment status is live", async () => {

--- a/app/experimenter/nimbus-ui/src/components/Summary/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/index.tsx
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React, { useRef } from "react";
+import React from "react";
 import Alert from "react-bootstrap/Alert";
 import Badge from "react-bootstrap/Badge";
 import { useChangeOperationMutation, useConfig } from "../../hooks";
@@ -32,13 +32,6 @@ const Summary = ({ experiment, refetch }: SummaryProps) => {
   const { kintoAdminUrl } = useConfig();
   const status = getStatus(experiment);
 
-  // TODO: PageRequestReview assigns the experiment and refetch values to refs,
-  // and since this component shares the same useChangeOperationMutation hook
-  // it also needs to pass its experiment/refetch values into refs. Ideally
-  // neither of these components need to use refs.
-  const currentExperiment = useRef<getExperiment_experimentBySlug>(experiment);
-  const refetchReview = useRef<(() => void) | undefined>(refetch);
-
   const {
     publishStatus,
     canReview,
@@ -60,8 +53,8 @@ const Summary = ({ experiment, refetch }: SummaryProps) => {
       onReviewRejectedClicked,
     ],
   } = useChangeOperationMutation(
-    currentExperiment,
-    refetchReview,
+    experiment,
+    refetch,
     {
       publishStatus: NimbusExperimentPublishStatus.REVIEW,
       isEndRequested: true,

--- a/app/experimenter/nimbus-ui/src/hooks/useChangeOperationMutation.test.tsx
+++ b/app/experimenter/nimbus-ui/src/hooks/useChangeOperationMutation.test.tsx
@@ -5,14 +5,13 @@
 import { MockedResponse } from "@apollo/client/testing";
 import { waitFor } from "@testing-library/dom";
 import { act, renderHook } from "@testing-library/react-hooks";
-import React, { useRef } from "react";
+import React from "react";
 import { UPDATE_EXPERIMENT_MUTATION } from "../gql/experiments";
 import {
   MockedCache,
   mockExperiment,
   mockExperimentMutation,
 } from "../lib/mocks";
-import { getExperiment_experimentBySlug as Experiment } from "../types/getExperiment";
 import {
   NimbusExperimentPublishStatus,
   NimbusExperimentStatus,
@@ -41,7 +40,8 @@ describe("hooks/useChangeOperationMutation", () => {
 });
 
 const setupTestHook = (customMocks: MockedResponse[] = []) => {
-  const { experiment, refetch } = setupRefArgs();
+  const experiment = mockExperiment();
+  const refetch = jest.fn();
   const mutationSets = [
     {
       isEndRequested: true,
@@ -63,7 +63,7 @@ const setupTestHook = (customMocks: MockedResponse[] = []) => {
           mockExperimentMutation(
             UPDATE_EXPERIMENT_MUTATION,
             {
-              id: experiment.current.id,
+              id: experiment.id,
               ...cur,
             },
             "updateExperiment",
@@ -89,17 +89,6 @@ const setupTestHook = (customMocks: MockedResponse[] = []) => {
   );
 
   return { isLoading, submitError, callbacks, mutationSets, refetch };
-};
-
-const setupRefArgs = () => {
-  const {
-    result: { current: experiment },
-  } = renderHook(() => useRef<Experiment>(mockExperiment()));
-  const {
-    result: { current: refetch },
-  } = renderHook(() => useRef<() => void>(jest.fn()));
-
-  return { experiment, refetch };
 };
 
 const wrapper = ({

--- a/app/experimenter/nimbus-ui/src/hooks/useChangeOperationMutation.tsx
+++ b/app/experimenter/nimbus-ui/src/hooks/useChangeOperationMutation.tsx
@@ -11,8 +11,8 @@ import { ExperimentInput } from "../types/globalTypes";
 import { updateExperiment_updateExperiment as UpdateExperiment } from "../types/updateExperiment";
 
 export function useChangeOperationMutation(
-  experiment: React.MutableRefObject<Experiment | undefined>,
-  refetch: React.MutableRefObject<(() => void) | undefined>,
+  experiment: Experiment | undefined,
+  refetch: (() => void) | undefined,
   ...dataSets: Partial<ExperimentInput>[]
 ) {
   const [submitError, setSubmitError] = useState<string | null>(null);
@@ -35,7 +35,7 @@ export function useChangeOperationMutation(
             const result = await updateExperiment({
               variables: {
                 input: {
-                  id: experiment.current?.id,
+                  id: experiment?.id,
                   ...baseDataChanges,
                   ...submitDataChanges,
                 },
@@ -57,7 +57,7 @@ export function useChangeOperationMutation(
               return void setSubmitError(message.status.join(", "));
             }
 
-            refetch.current && refetch.current();
+            refetch && refetch();
           } catch (error) {
             setSubmitError(SUBMIT_ERROR);
           }

--- a/app/experimenter/nimbus-ui/src/hooks/useReviewCheck.tsx
+++ b/app/experimenter/nimbus-ui/src/hooks/useReviewCheck.tsx
@@ -2,8 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import { Link } from "@reach/router";
 import React from "react";
+import { editPages } from "../components/AppLayoutWithSidebar";
 import InlineErrorIcon from "../components/InlineErrorIcon";
+import { BASE_PATH } from "../lib/constants";
 import { getExperiment_experimentBySlug } from "../types/getExperiment";
 
 export type ReviewCheck = ReturnType<typeof useReviewCheck>;
@@ -34,9 +37,10 @@ export function useReviewCheck(
     string,
     string[]
   >;
-  const invalidFields = Object.keys(reviewItems);
   const invalidPages = Object.keys(fieldPageMap).filter((page) =>
-    fieldPageMap[page].some((field) => invalidFields.includes(field)),
+    fieldPageMap[page].some((field) =>
+      Object.keys(reviewItems).includes(field),
+    ),
   );
   const fieldReviewMessages = (fieldName: string): string[] =>
     reviewItems[fieldName] || [];
@@ -57,12 +61,33 @@ export function useReviewCheck(
       </span>
     );
   };
+  const InvalidPagesList: React.FC = () => (
+    <>
+      {experiment &&
+        invalidPages.map((missingPage, idx) => {
+          const editPage = editPages.find((p) => p.slug === missingPage)!;
+
+          return (
+            <React.Fragment key={`missing-${idx}`}>
+              <Link
+                to={`${BASE_PATH}/${experiment.slug}/edit/${editPage.slug}?show-errors`}
+                data-testid={`missing-detail-link-${editPage.slug}`}
+              >
+                {editPage.name}
+              </Link>
+
+              {idx !== invalidPages.length - 1 && ", "}
+            </React.Fragment>
+          );
+        })}
+    </>
+  );
 
   return {
     ready: experiment?.readyForReview?.ready || false,
     invalidPages,
-    invalidFields,
     fieldReviewMessages,
     FieldReview,
+    InvalidPagesList,
   };
 }

--- a/app/experimenter/nimbus-ui/src/lib/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/lib/mocks.tsx
@@ -364,9 +364,9 @@ export function mockExperimentQuery<
 export const MOCK_REVIEW: ReviewCheck = {
   ready: true,
   invalidPages: [],
-  invalidFields: [],
   fieldReviewMessages: () => [],
   FieldReview: () => <></>,
+  InvalidPagesList: () => <></>,
 };
 
 export const mockExperimentMutation = (


### PR DESCRIPTION
Closes #4661
Closes #4806

Opening now for early looks. I'm going to add some more tests but this should generally be good to look at.

This PR:

- Make the Review & Launch page always accessible
- When required fields are missing they will still display in the sidebar, but they will also display on the Review & Launch page, blocking any launch UI