### PR TITLE
fixes #4459 fix(nimbus): Address UI DOM/test console warnings

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/Summary/TableAudience/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/TableAudience/index.tsx
@@ -20,12 +20,7 @@ const TableAudience = ({ experiment }: TableAudienceProps) => {
   const { firefoxMinVersion, channel, targetingConfigSlug } = useConfig();
 
   return (
-    <Table
-      bordered
-      data-testid="table-audience"
-      className="mb-4"
-      style={{ tableLayout: "fixed" }}
-    >
+    <Table bordered data-testid="table-audience" className="mb-4 table-fixed">
       <tbody>
         <tr>
           <th className="w-33">Channel</th>
@@ -72,17 +67,17 @@ const TableAudience = ({ experiment }: TableAudienceProps) => {
           </tr>
         )}
         {experiment.jexlTargetingExpression &&
-          experiment.jexlTargetingExpression !== "" && (
-            <tr>
-              <th>Full targeting expression</th>
-              <td
-                data-testid="experiment-target-expression"
-                className="text-monospace"
-              >
-                <Code codeString={experiment.jexlTargetingExpression} />
-              </td>
-            </tr>
-          )}
+        experiment.jexlTargetingExpression !== "" ? (
+          <tr>
+            <th>Full targeting expression</th>
+            <td
+              data-testid="experiment-target-expression"
+              className="text-monospace"
+            >
+              <Code codeString={experiment.jexlTargetingExpression} />
+            </td>
+          </tr>
+        ) : null}
         {experiment.recipeJson && (
           <tr>
             <th>Recipe JSON</th>

--- a/app/experimenter/nimbus-ui/src/lib/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/lib/mocks.tsx
@@ -421,9 +421,10 @@ fiveDaysAgo.setDate(fiveDaysAgo.getDate() - 5);
 /** Creates a single mock experiment suitable for getAllExperiments queries.  */
 export function mockSingleDirectoryExperiment(
   overrides: Partial<getAllExperiments_experiments> = {},
+  slugIndex: number = Math.round(Math.random() * 100),
 ): getAllExperiments_experiments {
   return {
-    slug: `some-experiment-${Math.round(Math.random() * 100)}`,
+    slug: `some-experiment-${slugIndex}`,
     owner: {
       username: "example@mozilla.com",
     },

--- a/app/experimenter/nimbus-ui/src/styles/index.scss
+++ b/app/experimenter/nimbus-ui/src/styles/index.scss
@@ -80,6 +80,10 @@ $sizes: (
   color: inherit;
 }
 
+.table-fixed {
+  table-layout: fixed;
+}
+
 .sidebar-icon {
   @extend .mr-3;
   min-width: 18px;


### PR DESCRIPTION
fixes #4459 

Because:
* A test was occasionally logging a warning about duplicate experiment keys

This commit:
* Fixes the flaky console error in DirectoryTable test by accepting the mapped array's index in the callback
* Fixes a 'whitespace text' DOM warning noticed when running tests by explicitly returning null in a ternary
* Moves an inline style into a class for reuse later