### PR TITLE
Fix #4755: feat(visualization) Confidence interval bars should reflect the scale of change.

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/PageResults/ConfidenceInterval/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/ConfidenceInterval/index.stories.tsx
@@ -14,20 +14,23 @@ storiesOf("pages/Results/ConfidenceInterval", module)
     <ConfidenceInterval
       upper={65}
       lower={45}
+      range={65}
       significance={SIGNIFICANCE.POSITIVE}
     />
   ))
   .add("with neutral significance", () => (
     <ConfidenceInterval
       upper={65}
-      lower={45}
+      lower={-45}
+      range={65}
       significance={SIGNIFICANCE.NEUTRAL}
     />
   ))
   .add("with negative significance", () => (
     <ConfidenceInterval
-      upper={65}
-      lower={45}
+      upper={-45}
+      lower={-65}
+      range={65}
       significance={SIGNIFICANCE.NEGATIVE}
     />
   ));

--- a/app/experimenter/nimbus-ui/src/components/PageResults/ConfidenceInterval/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/ConfidenceInterval/index.tsx
@@ -6,108 +6,88 @@
 // TODO: EXP-638 remove this ^
 
 import React from "react";
-import { SIGNIFICANCE } from "../../../lib/visualization/constants";
 
-const renderBounds = (lower: number, upper: number, significance: string) => {
-  const padding = <div className="col p-0" />;
-  const numbers = (
-    <>
-      <div
-        className={`${significance}-significance col text-left p-0 h6 font-weight-normal`}
-      >
-        {lower}%
-      </div>
-      <div
-        className={`${significance}-significance col text-right p-0 h6 font-weight-normal`}
-      >
-        {upper}%
-      </div>
-    </>
-  );
+const BUFFER = 5;
 
-  switch (significance) {
-    case SIGNIFICANCE.NEGATIVE:
-      return (
-        <>
-          {numbers}
-          {padding}
-          {padding}
-        </>
-      );
-    case SIGNIFICANCE.POSITIVE:
-      return (
-        <>
-          {padding}
-          {padding}
-          {numbers}
-        </>
-      );
-    case SIGNIFICANCE.NEUTRAL:
-      return (
-        <>
-          {padding}
-          {numbers}
-          {padding}
-        </>
-      );
-  }
-};
+const renderBounds = (
+  lower: number,
+  upper: number,
+  leftPercent: number,
+  barWidth: number,
+  significance: string,
+) => (
+  <div
+    className="position-absolute"
+    style={{
+      // Add some buffer to space out the rendered bound values.
+      left: `${leftPercent - BUFFER * 2}%`,
+      width: `${barWidth + BUFFER * 3}%`,
+    }}
+  >
+    <div
+      className={`${significance}-significance text-left p-0 h6 font-weight-normal position-absolute`}
+    >
+      {lower}%
+    </div>
+    <div
+      className={`${significance}-significance text-right p-0 h6 font-weight-normal`}
+    >
+      {upper}%
+    </div>
+  </div>
+);
 
-const renderLine = (significance: string) => {
-  let firstLine, secondLine, thirdLine;
-  firstLine = secondLine = thirdLine = "col";
-
-  if (SIGNIFICANCE.NEGATIVE === significance) {
-    firstLine = "col-md-1";
-    secondLine = "col-md-4";
-  }
-
-  if (SIGNIFICANCE.POSITIVE === significance) {
-    secondLine = "col-md-4";
-    thirdLine = "col-md-1";
-  }
-
-  return (
-    <>
-      <div className={`${firstLine} border-bottom border-dark border-3`} />
-      <div
-        className={`${secondLine} md-4 ml-md-auto py-2 ${significance} mb-n2`}
-      />
-      <div className={`${thirdLine} md-1 border-bottom border-dark border-3`} />
-    </>
-  );
-};
-
-const renderTick = (significance: string) => {
-  let position = "py-2";
-  if (SIGNIFICANCE.NEUTRAL === significance) {
-    position = "py-1 mt-2";
-  }
-
-  return <div className={`col border-left border-dark border-3 ${position}`} />;
-};
+const renderLine = (
+  leftPercent: number,
+  barWidth: number,
+  significance: string,
+) => (
+  <>
+    <div className="position-absolute border-bottom border-dark border-3 w-100" />
+    <div
+      className={`${significance} position-absolute md-4 ml-md-auto py-2 mt-n2`}
+      style={{
+        left: `${leftPercent}%`,
+        width: `${barWidth}%`,
+      }}
+    />
+  </>
+);
 
 const ConfidenceInterval: React.FC<{
   upper: number;
   lower: number;
+  range: number;
   significance: string;
-}> = ({ upper, lower, significance }) => {
-  const bounds = renderBounds(lower, upper, significance);
-  const line = renderLine(significance);
-  const tick = renderTick(significance);
+}> = ({ upper, lower, range, significance }) => {
+  range += BUFFER;
+  const fullWidth = range * 2;
+  const barWidth = ((upper - lower) / fullWidth) * 100;
+  const leftPercent = (Math.abs(lower - range * -1) / fullWidth) * 100;
+
+  const bounds = renderBounds(
+    lower,
+    upper,
+    leftPercent,
+    barWidth,
+    significance,
+  );
+  const line = renderLine(leftPercent, barWidth, significance);
 
   return (
     <div className="container">
-      <div className="row w-100 float-right">{bounds}</div>
-      <div className="row w-100 float-right">{line}</div>
+      <div className="row w-100 float-right position-relative">{bounds}</div>
+
       <div
-        className="row w-50 float-right"
+        className="row w-50 float-right mt-4"
         data-testid={`${significance}-block`}
       >
-        {tick}
+        <div className="position-absolute border-left border-dark border-3 py-2 mt-2" />
       </div>
+
+      <div className="row w-100 float-right position-relative mt-2">{line}</div>
       <div className="row w-100 float-right h6">
-        <div className="col d-flex justify-content-center">control</div>
+        <div className="col d-flex justify-content-center mt-3">control</div>
       </div>
     </div>
   );

--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableMetricPrimary/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableMetricPrimary/index.stories.tsx
@@ -8,6 +8,10 @@ import React from "react";
 import TableMetricPrimary from ".";
 import { mockExperimentQuery, mockOutcomeSets } from "../../../lib/mocks";
 import { mockAnalysis } from "../../../lib/visualization/mocks";
+import { getSortedBranches } from "../../../lib/visualization/utils";
+
+const results = mockAnalysis().overall;
+const sortedBranches = getSortedBranches(mockAnalysis());
 
 storiesOf("pages/Results/TableMetricPrimary", module)
   .addDecorator(withLinks)
@@ -19,7 +23,7 @@ storiesOf("pages/Results/TableMetricPrimary", module)
 
     return (
       <TableMetricPrimary
-        results={mockAnalysis().overall}
+        {...{ results, sortedBranches }}
         outcome={primaryOutcomes![0]!}
       />
     );
@@ -32,7 +36,7 @@ storiesOf("pages/Results/TableMetricPrimary", module)
 
     return (
       <TableMetricPrimary
-        results={mockAnalysis().overall}
+        {...{ results, sortedBranches }}
         outcome={primaryOutcomes![0]!}
       />
     );
@@ -45,7 +49,7 @@ storiesOf("pages/Results/TableMetricPrimary", module)
 
     return (
       <TableMetricPrimary
-        results={mockAnalysis().overall}
+        {...{ results, sortedBranches }}
         outcome={primaryOutcomes![0]!}
       />
     );

--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableMetricPrimary/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableMetricPrimary/index.test.tsx
@@ -8,6 +8,10 @@ import TableMetricPrimary from ".";
 import { mockExperimentQuery, mockOutcomeSets } from "../../../lib/mocks";
 import { RouterSlugProvider } from "../../../lib/test-utils";
 import { mockAnalysis } from "../../../lib/visualization/mocks";
+import { getSortedBranches } from "../../../lib/visualization/utils";
+
+const results = mockAnalysis().overall;
+const sortedBranches = getSortedBranches(mockAnalysis());
 
 describe("TableMetricPrimary", () => {
   it("has the correct headings", () => {
@@ -22,7 +26,7 @@ describe("TableMetricPrimary", () => {
     render(
       <RouterSlugProvider mocks={[mock]}>
         <TableMetricPrimary
-          results={mockAnalysis().overall}
+          {...{ results, sortedBranches }}
           outcome={primaryOutcomes![0]!}
         />
       </RouterSlugProvider>,
@@ -40,7 +44,7 @@ describe("TableMetricPrimary", () => {
     render(
       <RouterSlugProvider mocks={[mock]}>
         <TableMetricPrimary
-          results={mockAnalysis().overall}
+          {...{ results, sortedBranches }}
           outcome={primaryOutcomes![0]!}
         />
       </RouterSlugProvider>,
@@ -61,7 +65,7 @@ describe("TableMetricPrimary", () => {
     render(
       <RouterSlugProvider mocks={[mock]}>
         <TableMetricPrimary
-          results={mockAnalysis().overall}
+          {...{ results, sortedBranches }}
           outcome={primaryOutcomes![0]!}
         />
       </RouterSlugProvider>,
@@ -78,7 +82,7 @@ describe("TableMetricPrimary", () => {
     render(
       <RouterSlugProvider mocks={[mock]}>
         <TableMetricPrimary
-          results={mockAnalysis().overall}
+          {...{ results, sortedBranches }}
           outcome={primaryOutcomes![0]!}
         />
       </RouterSlugProvider>,
@@ -101,7 +105,7 @@ describe("TableMetricPrimary", () => {
     render(
       <RouterSlugProvider mocks={[mock]}>
         <TableMetricPrimary
-          results={mockAnalysis().overall}
+          {...{ results, sortedBranches }}
           outcome={primaryOutcomes![0]!}
         />
       </RouterSlugProvider>,
@@ -124,7 +128,7 @@ describe("TableMetricPrimary", () => {
     render(
       <RouterSlugProvider mocks={[mock]}>
         <TableMetricPrimary
-          results={mockAnalysis().overall}
+          {...{ results, sortedBranches }}
           outcome={primaryOutcomes![0]!}
         />
       </RouterSlugProvider>,

--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableMetricPrimary/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableMetricPrimary/index.tsx
@@ -9,6 +9,7 @@ import {
   TABLE_LABEL,
 } from "../../../lib/visualization/constants";
 import { AnalysisDataOverall } from "../../../lib/visualization/types";
+import { getExtremeBounds } from "../../../lib/visualization/utils";
 import { getConfig_nimbusConfig_outcomes } from "../../../types/getConfig";
 import TableVisualizationRow from "../TableVisualizationRow";
 
@@ -22,6 +23,7 @@ type PrimaryMetricStatistic = {
 type TableMetricPrimaryProps = {
   results: AnalysisDataOverall;
   outcome: getConfig_nimbusConfig_outcomes;
+  sortedBranches: string[];
 };
 
 const getStatistics = (slug: string): Array<PrimaryMetricStatistic> => {
@@ -41,9 +43,11 @@ const getStatistics = (slug: string): Array<PrimaryMetricStatistic> => {
 const TableMetricPrimary = ({
   results = {},
   outcome,
+  sortedBranches,
 }: TableMetricPrimaryProps) => {
   const primaryMetricStatistics = getStatistics(outcome.slug!);
   const metricKey = `${outcome.slug}_ever_used`;
+  const bounds = getExtremeBounds(sortedBranches, results, outcome.slug!);
 
   return (
     <div data-testid="table-metric-primary" className="mb-5">
@@ -78,7 +82,7 @@ const TableMetricPrimary = ({
                       key={`${displayType}-${value}`}
                       results={results[branch]}
                       tableLabel={TABLE_LABEL.PRIMARY_METRICS}
-                      {...{ metricKey, displayType, branchComparison }}
+                      {...{ metricKey, displayType, branchComparison, bounds }}
                     />
                   ),
                 )}

--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableMetricSecondary/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableMetricSecondary/index.tsx
@@ -11,6 +11,7 @@ import {
   TABLE_LABEL,
 } from "../../../lib/visualization/constants";
 import { AnalysisData } from "../../../lib/visualization/types";
+import { getExtremeBounds } from "../../../lib/visualization/utils";
 import GraphsWeekly from "../GraphsWeekly";
 import TableVisualizationRow from "../TableVisualizationRow";
 import TooltipWithMarkdown from "../TooltipWithMarkdown";
@@ -61,6 +62,7 @@ const TableMetricSecondary = ({
     : METRIC_TYPE.USER_SELECTED_SECONDARY;
 
   const overallResults = results?.overall!;
+  const bounds = getExtremeBounds(sortedBranches, overallResults, outcomeSlug);
   const outcomeName =
     results.metadata?.metrics[outcomeSlug]?.friendly_name || outcomeDefaultName;
   const outcomeDescription =
@@ -124,7 +126,7 @@ const TableMetricSecondary = ({
                       results={overallResults[branch]}
                       tableLabel={TABLE_LABEL.SECONDARY_METRICS}
                       metricKey={outcomeSlug}
-                      {...{ displayType, branchComparison }}
+                      {...{ displayType, branchComparison, bounds }}
                     />
                   ),
                 )}

--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableVisualizationRow/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableVisualizationRow/index.tsx
@@ -117,12 +117,14 @@ const conversionCountField = (totalConversions: number, totalUsers: number) => {
 const conversionChangeField = (
   lower: number,
   upper: number,
+  range: number,
   significance: string | undefined,
 ) => {
   lower = Math.round(lower * 1000) / 10;
   upper = Math.round(upper * 1000) / 10;
+  range = Math.round(range * 1000) / 10;
   significance = significance || SIGNIFICANCE.NEUTRAL;
-  return <ConfidenceInterval {...{ upper, lower, significance }} />;
+  return <ConfidenceInterval {...{ upper, lower, range, significance }} />;
 };
 
 const populationField = (point: number, percent: number | undefined) => {
@@ -195,6 +197,7 @@ const TableVisualizationRow: React.FC<{
   branchComparison?: string;
   tooltip?: string;
   window?: string;
+  bounds?: number;
 }> = ({
   metricKey,
   results,
@@ -204,6 +207,7 @@ const TableVisualizationRow: React.FC<{
   branchComparison,
   tooltip = "",
   window = "overall",
+  bounds = 0.05,
 }) => {
   const { branch_data, is_control } = results;
   const metricData = branch_data[metricKey];
@@ -265,7 +269,7 @@ const TableVisualizationRow: React.FC<{
           field = conversionCountField(count!, userCountMetric);
           break;
         case DISPLAY_TYPE.CONVERSION_CHANGE:
-          field = conversionChangeField(lower!, upper!, significance);
+          field = conversionChangeField(lower!, upper!, bounds, significance);
           break;
       }
       fieldList.push({ field, tooltipText, className });

--- a/app/experimenter/nimbus-ui/src/components/PageResults/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/index.tsx
@@ -103,6 +103,7 @@ const PageResults: React.FunctionComponent<RouteComponentProps> = () => {
                     key={slug}
                     results={analysis?.overall!}
                     outcome={outcome!}
+                    {...{ sortedBranches }}
                   />
                 );
               })}

--- a/app/experimenter/nimbus-ui/src/lib/visualization/utils.tsx
+++ b/app/experimenter/nimbus-ui/src/lib/visualization/utils.tsx
@@ -2,8 +2,18 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { DISPLAY_TYPE, METRIC, TABLE_LABEL } from "./constants";
-import { AnalysisData, BranchDescription } from "./types";
+import {
+  BRANCH_COMPARISON,
+  DISPLAY_TYPE,
+  METRIC,
+  TABLE_LABEL,
+} from "./constants";
+import {
+  AnalysisData,
+  AnalysisDataOverall,
+  BranchDescription,
+  FormattedAnalysisPoint,
+} from "./types";
 
 // `show_analysis` is the feature flag for turning visualization on/off.
 // `overall` will be `null` if the analysis isn't available yet.
@@ -54,4 +64,30 @@ export const getSortedBranches = (analysis: AnalysisData) => {
     }
   });
   return sortedBranches;
+};
+
+/**
+ * Find the most extreme upper or lower bound value
+ * for an outcome across all branches.
+ *
+ * This is used to scale the confidence interval bars
+ * shown for a metric.
+ */
+export const getExtremeBounds = (
+  sortedBranches: string[],
+  results: AnalysisDataOverall,
+  outcomeSlug: string,
+) => {
+  let extreme = 0;
+  sortedBranches.map((branch) => {
+    const branchComparison = BRANCH_COMPARISON.UPLIFT;
+    const metricDataList =
+      results[branch].branch_data[outcomeSlug][branchComparison]["all"];
+    metricDataList.forEach((dataPoint: FormattedAnalysisPoint) => {
+      const { lower, upper } = dataPoint;
+      const max = Math.max(Math.abs(lower!), Math.abs(upper!));
+      extreme = max > extreme ? max : extreme;
+    });
+  });
+  return extreme;
 };


### PR DESCRIPTION
Because:
* The schematic for confidence interval bars was a fixed size and sometimes misleading

This commit:
* Makes the bars scale