### PR TITLE
fixes #5172 fix(nimbus): Show 'Not set' for featureConfig in Summary table

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/Summary/TableSummary/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/TableSummary/index.test.tsx
@@ -163,9 +163,9 @@ describe("TableSummary", () => {
     it("when not set", () => {
       const { experiment } = mockExperimentQuery("demo-slug");
       render(<Subject {...{ experiment }} />);
-      expect(
-        screen.queryByTestId("experiment-feature-config"),
-      ).not.toBeInTheDocument();
+      expect(screen.getByTestId("experiment-feature-config")).toHaveTextContent(
+        "Not set",
+      );
     });
   });
 

--- a/app/experimenter/nimbus-ui/src/components/Summary/TableSummary/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/TableSummary/index.tsx
@@ -136,14 +136,16 @@ const TableSummary = ({ experiment }: TableSummaryProps) => {
               </td>
             </tr>
           )}
-        {experiment.featureConfig?.name && (
-          <tr>
-            <th>Feature config</th>
-            <td data-testid="experiment-feature-config">
-              {experiment.featureConfig.name}
-            </td>
-          </tr>
-        )}
+        <tr>
+          <th>Feature config</th>
+          <td data-testid="experiment-feature-config">
+            {experiment.featureConfig?.name ? (
+              experiment.featureConfig.name
+            ) : (
+              <NotSet />
+            )}
+          </td>
+        </tr>
         {primaryOutcomes.length > 0 && (
           <tr>
             <th>Primary outcomes</th>


### PR DESCRIPTION
fixes #5171

Because:
* featureConfig is required and required fields should always be rendered in the table rows, showing the value or 'Not set'

This commit:
* Always shows the feature config row and value or 'Not set'

---

Other related issues are in the required for launch epic/are addressed elsewhere, this accounts for Ana's comment on this issue.