### PR TITLE
fixes #4655 feat(nimbus): add new warning style for review readiness validation

### DIFF
--- a/app/experimenter/nimbus-ui/.storybook/design-docs/DocsFormValidation/helpers.tsx
+++ b/app/experimenter/nimbus-ui/.storybook/design-docs/DocsFormValidation/helpers.tsx
@@ -3,12 +3,11 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React, { useCallback } from "react";
-import Form from "react-bootstrap/Form";
-import Alert from "react-bootstrap/Alert";
-
 import { Card, Table } from "react-bootstrap";
-import { useCommonForm } from "../../../src/hooks";
+import Alert from "react-bootstrap/Alert";
+import Form from "react-bootstrap/Form";
 import InlineErrorIcon from "../../../src/components/InlineErrorIcon";
+import { useCommonForm } from "../../../src/hooks";
 
 export const TestCases: React.FunctionComponent = ({ children }) => (
   <Table>
@@ -34,6 +33,7 @@ type ProtoFormProps = {
   isServerValid: boolean;
   submitErrors: Record<string, string[]>;
   setSubmitErrors: React.Dispatch<React.SetStateAction<Record<string, any>>>;
+  reviewMessages: Record<string, string[]>;
   onSubmit: (data: Record<string, any>, reset: Function) => void;
 };
 
@@ -44,6 +44,7 @@ export const ProtoForm = ({
   onSubmit,
   submitErrors,
   setSubmitErrors,
+  reviewMessages,
 }: ProtoFormProps) => {
   const defaultValues: Record<string, string> = {};
   demoInputs.forEach(
@@ -63,6 +64,7 @@ export const ProtoForm = ({
     isServerValid,
     submitErrors,
     setSubmitErrors,
+    reviewMessages,
   );
 
   const handleSubmitAfterValidation = useCallback(
@@ -95,7 +97,7 @@ export const ProtoForm = ({
 
                   {requiredAtLaunch && !getValues(name) && (
                     <InlineErrorIcon
-                      name={name}
+                      field={name}
                       message={`A valid ${label} must be set`}
                     />
                   )}

--- a/app/experimenter/nimbus-ui/.storybook/design-docs/DocsFormValidation/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/.storybook/design-docs/DocsFormValidation/index.stories.tsx
@@ -2,189 +2,174 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React, { useState, useCallback } from "react";
-import { storiesOf } from "@storybook/react";
-import { ProtoForm, TestCases } from "./helpers";
-import { Container, Alert } from "react-bootstrap";
+import React, { useCallback, useState } from "react";
+import { Alert, Container } from "react-bootstrap";
 import LinkExternal from "../../../src/components/LinkExternal";
-import InlineErrorIcon from "../../../src/components/InlineErrorIcon";
+import { ProtoForm, TestCases } from "./helpers";
 
 const MODELS_URL =
   "https://github.com/mozilla/experimenter/blob/main/app/experimenter/experiments/models/nimbus.py";
 
-storiesOf("Design Docs/Form Validation", module)
-  .add("client-side validation", () => {
-    const [submitErrors, setSubmitErrors] = useState<Record<string, any>>({});
+export default {
+  title: "Design Docs/Form Validation",
+};
 
-    return (
-      <Container className="pt-5">
-        <h2>Client-side Validation</h2>
-        <p>
-          Client-side validation should be used to prevent invalid mutations
-          from being attempted (i.e. the wrong type or fields that cannot be{" "}
-          <code>null</code> in the{" "}
-          <LinkExternal href={MODELS_URL}>database</LinkExternal>
-          ). It should be used to validate fields that are required for launch
-          or to duplicate server-side validation.
-        </p>
+export const ClientSide = () => {
+  const [submitErrors, setSubmitErrors] = useState<Record<string, any>>({});
 
-        <ProtoForm
-          demoInputs={[
-            {
-              name: "name",
-              label: "Branch Name",
-              defaultValue: "",
-              required: true,
-            },
-          ]}
-          isLoading={false}
-          isServerValid
-          submitErrors={submitErrors}
-          setSubmitErrors={setSubmitErrors}
-          onSubmit={() => {}}
-        />
+  return (
+    <Container className="pt-5">
+      <h2>Client-side Validation</h2>
+      <p>
+        Client-side validation should be used to prevent invalid mutations from
+        being attempted (i.e. the wrong type or fields that cannot be{" "}
+        <code>null</code> in the{" "}
+        <LinkExternal href={MODELS_URL}>database</LinkExternal>
+        ). It should be used to validate fields that are required for launch or
+        to duplicate server-side validation.
+      </p>
 
-        <TestCases>
-          <tr>
-            <td>Clear the input and click elsewhere</td>
-            <td>
-              The input should be marked invalid and an error message should
-              appear.
-            </td>
-          </tr>
-          <tr>
-            <td>With the input still empty, click Save</td>
-            <td>
-              The input should focused and the error message should still
-              appear.
-              <Alert variant="danger">
-                The Save button should not be disabled if there are error
-                messages – instead, you should draw attention to the invalid
-                fields when the Save button is clicked.
-              </Alert>
-            </td>
-          </tr>
-          <tr>
-            <td>Start typing in the input</td>
-            <td>The input should become valid again.</td>
-          </tr>
-        </TestCases>
-      </Container>
-    );
-  })
-  .add("required for launch", () => {
-    const [submitErrors, setSubmitErrors] = useState<Record<string, any>>({});
+      <ProtoForm
+        demoInputs={[
+          {
+            name: "name",
+            label: "Branch Name",
+            defaultValue: "",
+            required: true,
+          },
+        ]}
+        isLoading={false}
+        isServerValid
+        submitErrors={submitErrors}
+        setSubmitErrors={setSubmitErrors}
+        reviewMessages={{}}
+        onSubmit={() => {}}
+      />
 
-    return (
-      <Container className="pt-5">
-        <h2>Required for launch</h2>
-        <p>
-          Some fields like <code>publicDescription</code> are allowed to be{" "}
-          <code>null</code> while someone is editing a draft, but must be set
-          before the experiment can move to the review status. You should NOT
-          mark these fields <code>required</code>, but rather add an{" "}
-          <code>InlineErrorIcon</code> (
-          <InlineErrorIcon
-            name="example"
-            message="A tooltip hint about this being required to launch"
-          />
-          ) with a tooltip indicating they must be filled out before launch.
-        </p>
-        <ProtoForm
-          demoInputs={[
-            {
-              name: "name",
-              label: "Totally optional field",
-              defaultValue: "",
-            },
-            {
-              name: "publicDescription",
-              label: "Public Description",
-              defaultValue: "",
-              requiredAtLaunch: true,
-            },
-          ]}
-          isLoading={false}
-          isServerValid
-          {...{ submitErrors, setSubmitErrors }}
-          onSubmit={() => {}}
-        />
+      <TestCases>
+        <tr>
+          <td>Clear the input and click elsewhere</td>
+          <td>
+            The input should be marked invalid and an error message should
+            appear.
+          </td>
+        </tr>
+        <tr>
+          <td>With the input still empty, click Save</td>
+          <td>
+            The input should focused and the error message should still appear.
+            <Alert variant="danger">
+              The Save button should not be disabled if there are error messages
+              – instead, you should draw attention to the invalid fields when
+              the Save button is clicked.
+            </Alert>
+          </td>
+        </tr>
+        <tr>
+          <td>Start typing in the input</td>
+          <td>The input should become valid again.</td>
+        </tr>
+      </TestCases>
+    </Container>
+  );
+};
 
-        <TestCases>
-          <tr>
-            <td>Type something in the Public Description field.</td>
-            <td>The warning icon should disappear</td>
-          </tr>
-          <tr>
-            <td>Remove all the text from the Public Description field.</td>
-            <td>The warning icon should show up again.</td>
-          </tr>
-        </TestCases>
-      </Container>
-    );
-  })
-  .add("server-side validation", () => {
-    const [submitErrors, setSubmitErrors] = useState<Record<string, any>>({});
-    const [isServerValid, setIsServerValid] = useState(true);
-    const [isLoading, setLoading] = useState(false);
+export const ReviewReadiness = () => {
+  return (
+    <Container className="pt-5">
+      <h2>Review-readiness</h2>
+      <p>
+        All fields are optional while an experiment is being worked on, but
+        before it can be reviewed and launched there are fields that must be
+        completed. This is configured in the backend in the{" "}
+        <code>NimbusReadyForReviewSerializer</code>, so no additional work is
+        necessary in the front-end beyond correctly setting field names.
+      </p>
 
-    const onFormSubmit = useCallback(async ({ name }: Record<string, any>) => {
-      setLoading(true);
-      await new Promise((resolve) => setTimeout(resolve, 1000));
-      setLoading(false);
-      if (name === "really common name") {
-        setIsServerValid(false);
-        setSubmitErrors({ name: ["That name is taken."] });
-      } else {
-        setSubmitErrors({});
-        setIsServerValid(true);
-      }
-    }, []);
+      <ProtoForm
+        demoInputs={[
+          { name: "name", label: "Name", defaultValue: "" },
+          { name: "another_field", label: "Another Field", defaultValue: "" },
+        ]}
+        isServerValid={true}
+        submitErrors={{}}
+        setSubmitErrors={() => {}}
+        isLoading={false}
+        onSubmit={() => {}}
+        reviewMessages={{
+          name: ["This field cannot be empty."],
+          another_field: ["Something's wrong with this one too eh"],
+        }}
+      />
+    </Container>
+  );
+};
 
-    return (
-      <Container className="pt-5">
-        <h2>Server-side Validation</h2>
-        <p>
-          In general, validation (other than required values and type checking)
-          should be done server-side at Save/Submit time.
-        </p>
+export const ServerSide = () => {
+  const [submitErrors, setSubmitErrors] = useState<Record<string, any>>({});
+  const [isServerValid, setIsServerValid] = useState(true);
+  const [isLoading, setLoading] = useState(false);
 
-        <ProtoForm
-          demoInputs={[
-            { name: "name", label: "Name", defaultValue: "really common name" },
-          ]}
-          isLoading={false}
-          isServerValid={isServerValid}
-          {...{ submitErrors, setSubmitErrors }}
-          setSubmitErrors={setSubmitErrors}
-          onSubmit={onFormSubmit}
-        />
+  const onSubmit = useCallback(async ({ name }: Record<string, any>) => {
+    setLoading(true);
+    await new Promise((resolve) => setTimeout(resolve, 500));
+    setLoading(false);
+    if (name === "really common name") {
+      setIsServerValid(false);
+      setSubmitErrors({ name: ["That name is taken."] });
+    } else {
+      setSubmitErrors({});
+      setIsServerValid(true);
+    }
+  }, []);
 
-        <TestCases>
-          <tr>
-            <td>
-              Press the <code>Save</code> button. (The input value should be{" "}
-              <code>really common name</code>, which the fake server will reject
-              as already taken).
-            </td>
-            <td>
-              The button should say <code>Saving</code> and be disabled while
-              the server is waiting to respond. <br />
-              The input is marked as invalid and has an error message.
-            </td>
-          </tr>
-          <tr>
-            <td>Change the text to something else.</td>
-            <td>
-              As you start typing, the input should be marked as valid again and
-              the error message should disapear.
-            </td>
-          </tr>
-          <tr>
-            <td>Re-submit the form</td>
-            <td>The input should remain in a valid state.</td>
-          </tr>
-        </TestCases>
-      </Container>
-    );
-  });
+  return (
+    <Container className="pt-5">
+      <h2>Server-side Validation</h2>
+      <p>
+        In general, validation (other than required values and type checking)
+        should be done server-side at Save/Submit time.
+      </p>
+
+      <ProtoForm
+        demoInputs={[
+          { name: "name", label: "Name", defaultValue: "really common name" },
+        ]}
+        reviewMessages={{}}
+        {...{
+          onSubmit,
+          submitErrors,
+          setSubmitErrors,
+          isServerValid,
+          isLoading,
+        }}
+      />
+
+      <TestCases>
+        <tr>
+          <td>
+            Press the <code>Save</code> button. (The input value should be{" "}
+            <code>really common name</code>, which the fake server will reject
+            as already taken).
+          </td>
+          <td>
+            The button should say <code>Saving</code> and be disabled while the
+            server is waiting to respond. <br />
+            The input is marked as invalid and has an error message.
+          </td>
+        </tr>
+        <tr>
+          <td>Change the text to something else.</td>
+          <td>
+            As you start typing, the input should be marked as valid again and
+            the error message should disapear.
+          </td>
+        </tr>
+        <tr>
+          <td>Re-submit the form</td>
+          <td>The input should remain in a valid state.</td>
+        </tr>
+      </TestCases>
+    </Container>
+  );
+};

--- a/app/experimenter/nimbus-ui/src/components/InputRadios/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/InputRadios/index.tsx
@@ -36,15 +36,15 @@ export const InputRadios: React.FC<InputRadiosProps> = ({
 
       <Col sm={2} className="d-flex justify-content-end pr-0">
         {options.map((option) => (
-          <Form.Check
-            key={`radio-${name}-${option.value}`}
-            type="radio"
-            value={option.value}
-            label={option.label}
-            className="ml-3"
-            id={`${name}-${option.value}`}
-            {...formControlAttrs(name, {}, false)}
-          />
+          <span className="ml-3" key={`radio-${name}-${option.value}`}>
+            <Form.Check
+              type="radio"
+              value={option.value}
+              label={option.label}
+              id={`${name}-${option.value}`}
+              {...formControlAttrs(name, {}, false)}
+            />
+          </span>
         ))}
       </Col>
     </Row>

--- a/app/experimenter/nimbus-ui/src/hooks/useCommonForm/index.tsx
+++ b/app/experimenter/nimbus-ui/src/hooks/useCommonForm/index.tsx
@@ -14,6 +14,7 @@ export function useCommonForm<FieldNames extends string>(
   isServerValid: boolean,
   submitErrors: SubmitErrors,
   setSubmitErrors: React.Dispatch<React.SetStateAction<Record<string, any>>>,
+  reviewMessages: Record<string, string[]> = {},
 ) {
   const formMethods = useForm(defaultValues);
   const {
@@ -38,6 +39,7 @@ export function useCommonForm<FieldNames extends string>(
       register,
       errors,
       touched,
+      reviewMessages,
     );
 
   return {

--- a/app/experimenter/nimbus-ui/src/hooks/useCommonForm/useCommonFormMethods.tsx
+++ b/app/experimenter/nimbus-ui/src/hooks/useCommonForm/useCommonFormMethods.tsx
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import classNames from "classnames";
 import React from "react";
 import Form from "react-bootstrap/Form";
 import { FieldError, RegisterOptions, UseFormMethods } from "react-hook-form";
@@ -30,6 +31,7 @@ export function useCommonFormMethods<FieldNames extends string>(
   register: UseFormMethods["register"],
   errors: UseFormMethods["errors"],
   touched: UseFormMethods["formState"]["touched"],
+  reviewMessages: Record<string, string[]>,
 ) {
   const hideSubmitError = <K extends FieldNames>(name: K) => {
     if (submitErrors && submitErrors[camelToSnakeCase(name)]) {
@@ -48,10 +50,12 @@ export function useCommonFormMethods<FieldNames extends string>(
     prefix?: string,
   ) => {
     const fieldName = prefix ? `${prefix}.${name}` : name;
+    const hasReviewMessage = (reviewMessages[name] || []).length > 0;
     return {
       "data-testid": fieldName,
       name: fieldName,
       ref: register(registerOptions),
+      className: classNames(hasReviewMessage && "is-warning"),
       // setting `setDefaultValue = false` is handy when an input needs a default
       // value via `value` instead of `defaultValue` or if the value is boolean,
       // usually for hidden form fields or checkbox inputs
@@ -79,8 +83,16 @@ export function useCommonFormMethods<FieldNames extends string>(
     prefix?: string;
   }) => {
     const fieldName = prefix ? `${prefix}.${name}` : name;
+    const fieldReviewMessages = reviewMessages[name] || [];
     return (
       <>
+        {fieldReviewMessages.length > 0 && (
+          // @ts-ignore This component doesn't technically support type="warning", but
+          // all it's doing is using the string in a class, so we can safely override.
+          <Form.Control.Feedback type="warning" data-for={fieldName}>
+            {fieldReviewMessages.join(", ")}
+          </Form.Control.Feedback>
+        )}
         {errors[name] && (
           <Form.Control.Feedback type="invalid" data-for={fieldName}>
             {(errors[name] as FieldError).message}

--- a/app/experimenter/nimbus-ui/src/hooks/useCommonForm/useCommonNestedForm.tsx
+++ b/app/experimenter/nimbus-ui/src/hooks/useCommonForm/useCommonNestedForm.tsx
@@ -17,6 +17,7 @@ export function useCommonNestedForm<FieldNames extends string>(
   nestedSubmitErrors: Record<string, string[]>,
   nestedErrors: UseFormMethods["errors"],
   nestedTouched: UseFormMethods["formState"]["touched"],
+  nestedReviewMessages: Record<string, string[]> = {},
 ) {
   const { register, watch } = useFormContext();
 
@@ -27,6 +28,7 @@ export function useCommonNestedForm<FieldNames extends string>(
     register,
     nestedErrors,
     nestedTouched,
+    nestedReviewMessages,
   );
 
   const NestedFormErrors = <K extends FieldNames>({ name }: { name: K }) => (

--- a/app/experimenter/nimbus-ui/src/styles/index.scss
+++ b/app/experimenter/nimbus-ui/src/styles/index.scss
@@ -36,6 +36,28 @@ $sizes: (
   }
 }
 
+// Adds a new style of form feedback, warning, which is yellow
+// This adds the is-warning, warning-feedback form classes
+$form-feedback-warning-color: #e65722 !default;
+$form-feedback-icon-warning-color: $form-feedback-warning-color !default;
+$form-feedback-icon-warning: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' width='12' height='12' fill='none' stroke='#{$form-feedback-icon-warning-color}' viewBox='0 0 12 12'><circle cx='6' cy='6' r='4.5'/><path stroke-linejoin='round' d='M5.8 3.6h.4L6 6.5z'/><circle cx='6' cy='8.2' r='.6' fill='#{$form-feedback-icon-warning-color}' stroke='none'/></svg>") !default;
+$form-validation-states: map-merge(
+  (
+    "warning": (
+      "color": $form-feedback-warning-color,
+      "icon": $form-feedback-icon-warning,
+    ),
+  ),
+  $form-validation-states
+);
+@each $state, $data in $form-validation-states {
+  @include form-validation-state(
+    $state,
+    map-get($data, color),
+    map-get($data, icon)
+  );
+}
+
 .font-weight-semibold {
   font-weight: 600;
 }


### PR DESCRIPTION
Closes #4655

This PR adds a new form feedback style, "warning", to be used for when there are review-readiness messages to be displayed.

![Screen Shot 2021-05-13 at 2 46 05 PM](https://user-images.githubusercontent.com/6392049/118172215-1de9f580-b3fa-11eb-97d3-cbfb4d229b16.png)

The main parts:

- Add the new "style" to Bootstrap
- Update our `useCommonForm` bits to be able to receive review readiness messages
- Conditionally apply the class when there are messages for the given field

The requested color of `#FFC107` was super duper not WCAG compliant so I used this other orange color, but I am open to suggestions.

~This only adds the new style and does not update any of the fields to use it yet, so no Storybook changes just yet.~ Actually I was wrong, I updated [this Story](https://storage.googleapis.com/mozilla-storybooks-experimenter/commits/84159248fdd2458c4e706a77381e51becfb490a0/nimbus-ui/index.html?path=/story/design-docs-form-validation--review-readiness) in the design docs to reflect this new style. It addresses some of #4717, but it doesn't entirely close it so I'm not attaching it to this PR.