### PR TITLE
fixes #5249 chore(project): add some default reviewers for DB migrations

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,6 @@
 app/tests @jrbenny35 @pdehaan
+app/experimenter/base/migrations @jaredlockhart @lmorchard
+app/experimenter/experiments/migrations @jaredlockhart @lmorchard
+app/experimenter/notifications/migrations @jaredlockhart @lmorchard
+app/experimenter/projects/migrations @jaredlockhart @lmorchard
+app/experimenter/reporting/migrations @jaredlockhart @lmorchard


### PR DESCRIPTION
Because:

* We'd like some elevated attention to PRs involving database migrations

This commit:

* Adds some folks to CODEOWNERS for changes to DB migrations