### PR TITLE
fixes #5116 feat(nimbus): filter targeting choices by application

### DIFF
--- a/app/experimenter/experiments/api/v5/queries.py
+++ b/app/experimenter/experiments/api/v5/queries.py
@@ -2,6 +2,7 @@ import graphene
 from django.conf import settings
 
 from experimenter.experiments.api.v5.types import (
+    NimbusExperimentTargetingConfigSlugChoice,
     NimbusExperimentType,
     NimbusFeatureConfigType,
     NimbusLabelValueType,
@@ -22,7 +23,7 @@ class NimbusConfigurationType(graphene.ObjectType):
     feature_config = graphene.List(NimbusFeatureConfigType)
     firefox_min_version = graphene.List(NimbusLabelValueType)
     outcomes = graphene.List(NimbusOutcomeType)
-    targeting_config_slug = graphene.List(NimbusLabelValueType)
+    targeting_config_slug = graphene.List(NimbusExperimentTargetingConfigSlugChoice)
     hypothesis_default = graphene.String()
     max_primary_outcomes = graphene.Int()
     documentation_link = graphene.List(NimbusLabelValueType)
@@ -53,7 +54,16 @@ class NimbusConfigurationType(graphene.ObjectType):
         return Outcomes.all()
 
     def resolve_targeting_config_slug(root, info):
-        return root._text_choices_to_label_value_list(NimbusExperiment.TargetingConfig)
+        return [
+            NimbusExperimentTargetingConfigSlugChoice(
+                label=choice.label,
+                value=choice.name,
+                application_values=NimbusExperiment.TARGETING_CONFIGS[
+                    choice.value
+                ].application_choice_names,
+            )
+            for choice in NimbusExperiment.TargetingConfig
+        ]
 
     def resolve_hypothesis_default(root, info):
         return NimbusExperiment.HYPOTHESIS_DEFAULT

--- a/app/experimenter/experiments/api/v5/serializers.py
+++ b/app/experimenter/experiments/api/v5/serializers.py
@@ -464,6 +464,21 @@ class NimbusExperimentSerializer(
                     )
                 }
             )
+
+        if self.instance and "targeting_config_slug" in data:
+            targeting_config_slug = data["targeting_config_slug"]
+            application_choice = NimbusExperiment.Application(self.instance.application)
+            targeting_config = NimbusExperiment.TARGETING_CONFIGS[targeting_config_slug]
+            if application_choice.name not in targeting_config.application_choice_names:
+                raise serializers.ValidationError(
+                    {
+                        "targeting_config_slug": (
+                            f"Targeting config '{targeting_config.name}' is not "
+                            f"available for application '{application_choice.label}'"
+                        )
+                    }
+                )
+
         return data
 
     def update(self, experiment, validated_data):

--- a/app/experimenter/experiments/api/v5/types.py
+++ b/app/experimenter/experiments/api/v5/types.py
@@ -61,6 +61,12 @@ class NimbusExperimentTargetingConfigSlug(graphene.Enum):
         enum = NimbusConstants.TargetingConfig
 
 
+class NimbusExperimentTargetingConfigSlugChoice(graphene.ObjectType):
+    label = graphene.String()
+    value = graphene.String()
+    application_values = graphene.List(graphene.String)
+
+
 class NimbusExperimentApplication(graphene.Enum):
     class Meta:
         enum = NimbusConstants.Application

--- a/app/experimenter/experiments/models/nimbus.py
+++ b/app/experimenter/experiments/models/nimbus.py
@@ -179,7 +179,7 @@ class NimbusExperiment(NimbusConstants, FilterMixin, models.Model):
             # TODO: Remove opt-out after Firefox 84 is the earliest supported Desktop
             expressions.append("'app.shield.optoutstudies.enabled'|preferenceValue")
 
-        if self.targeting_config:
+        if self.targeting_config and self.targeting_config.targeting:
             expressions.append(self.targeting_config.targeting)
 
         #  If there is no targeting defined all clients should match, so we return "true"

--- a/app/experimenter/experiments/tests/api/v5/test_queries.py
+++ b/app/experimenter/experiments/tests/api/v5/test_queries.py
@@ -600,6 +600,7 @@ class TestNimbusQuery(GraphQLTestCase):
                     targetingConfigSlug {
                         label
                         value
+                        applicationValues
                     }
                     documentationLink {
                         label
@@ -626,7 +627,6 @@ class TestNimbusQuery(GraphQLTestCase):
         assertChoices(config["application"], NimbusExperiment.Application)
         assertChoices(config["channel"], NimbusExperiment.Channel)
         assertChoices(config["firefoxMinVersion"], NimbusExperiment.Version)
-        assertChoices(config["targetingConfigSlug"], NimbusExperiment.TargetingConfig)
         assertChoices(config["documentationLink"], NimbusExperiment.DocumentationLink)
         self.assertEqual(config["kintoAdminUrl"], settings.KINTO_ADMIN_URL)
         self.assertEqual(len(config["featureConfig"]), 13)
@@ -651,6 +651,20 @@ class TestNimbusQuery(GraphQLTestCase):
             self.assertEqual(config_feature_config["slug"], feature_config.slug)
             self.assertEqual(
                 config_feature_config["description"], feature_config.description
+            )
+
+        for choice in NimbusExperiment.TargetingConfig:
+            self.assertIn(
+                {
+                    "label": choice.label,
+                    "value": choice.name,
+                    "applicationValues": list(
+                        NimbusExperiment.TARGETING_CONFIGS[
+                            choice.value
+                        ].application_choice_names
+                    ),
+                },
+                config["targetingConfigSlug"],
             )
 
         self.assertEqual(config["hypothesisDefault"], NimbusExperiment.HYPOTHESIS_DEFAULT)

--- a/app/experimenter/nimbus-ui/schema.graphql
+++ b/app/experimenter/nimbus-ui/schema.graphql
@@ -112,7 +112,7 @@ type NimbusConfigurationType {
   featureConfig: [NimbusFeatureConfigType]
   firefoxMinVersion: [NimbusLabelValueType]
   outcomes: [NimbusOutcomeType]
-  targetingConfigSlug: [NimbusLabelValueType]
+  targetingConfigSlug: [NimbusExperimentTargetingConfigSlugChoice]
   hypothesisDefault: String
   maxPrimaryOutcomes: Int
   documentationLink: [NimbusLabelValueType]
@@ -267,6 +267,12 @@ enum NimbusExperimentTargetingConfigSlug {
   TARGETING_FIRST_RUN_WINDOWS_1903_NEWER
   TARGETING_HOMEPAGE_GOOGLE
   TARGETING_URLBAR_FIREFOX_SUGGEST
+}
+
+type NimbusExperimentTargetingConfigSlugChoice {
+  label: String
+  value: String
+  applicationValues: [String]
 }
 
 type NimbusExperimentType {

--- a/app/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/index.tsx
@@ -13,6 +13,10 @@ import {
   POSITIVE_NUMBER_FIELD,
   POSITIVE_NUMBER_WITH_COMMAS_FIELD,
 } from "../../../lib/constants";
+import {
+  getConfig_nimbusConfig,
+  getConfig_nimbusConfig_targetingConfigSlug,
+} from "../../../types/getConfig";
 import { getExperiment_experimentBySlug } from "../../../types/getExperiment";
 import LinkExternal from "../../LinkExternal";
 
@@ -77,6 +81,15 @@ export const FormAudience = ({
     [isLoading, onSubmit, handleSubmit],
   );
 
+  const targetingConfigSlugOptions = useMemo(
+    () =>
+      filterTargetingConfigSlug(
+        config.targetingConfigSlug,
+        experiment.application,
+      ),
+    [config, experiment],
+  );
+
   return (
     <Form
       noValidate
@@ -126,7 +139,7 @@ export const FormAudience = ({
               {...formControlAttrs("targetingConfigSlug")}
               as="select"
             >
-              <SelectOptions options={config.targetingConfigSlug} />
+              <SelectOptions options={targetingConfigSlugOptions} />
             </Form.Control>
             <FormErrors name="targetingConfigSlug" />
           </Form.Group>
@@ -283,5 +296,20 @@ const SelectOptions = ({
     )}
   </>
 );
+
+export const filterTargetingConfigSlug = (
+  targetingConfigs: getConfig_nimbusConfig["targetingConfigSlug"],
+  application: getExperiment_experimentBySlug["application"],
+) =>
+  targetingConfigs == null
+    ? []
+    : targetingConfigs.filter(
+        (
+          targetingConfig,
+        ): targetingConfig is getConfig_nimbusConfig_targetingConfigSlug =>
+          targetingConfig !== null &&
+          Array.isArray(targetingConfig.applicationValues) &&
+          targetingConfig.applicationValues.includes(application),
+      );
 
 export default FormAudience;

--- a/app/experimenter/nimbus-ui/src/gql/config.ts
+++ b/app/experimenter/nimbus-ui/src/gql/config.ts
@@ -37,6 +37,7 @@ export const GET_CONFIG_QUERY = gql`
       targetingConfigSlug {
         label
         value
+        applicationValues
       }
       hypothesisDefault
       documentationLink {

--- a/app/experimenter/nimbus-ui/src/lib/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/lib/mocks.tsx
@@ -61,6 +61,10 @@ export const MOCK_CONFIG: getConfig_nimbusConfig = {
       label: "Desktop",
       value: "DESKTOP",
     },
+    {
+      label: "Toaster",
+      value: "TOASTER",
+    },
   ],
   channel: [
     {
@@ -142,6 +146,7 @@ export const MOCK_CONFIG: getConfig_nimbusConfig = {
     {
       label: "Us Only",
       value: "US_ONLY",
+      applicationValues: ["DESKTOP"],
     },
   ],
   hypothesisDefault: "Enter a hypothesis",

--- a/app/experimenter/nimbus-ui/src/types/getConfig.ts
+++ b/app/experimenter/nimbus-ui/src/types/getConfig.ts
@@ -44,6 +44,7 @@ export interface getConfig_nimbusConfig_outcomes {
 export interface getConfig_nimbusConfig_targetingConfigSlug {
   label: string | null;
   value: string | null;
+  applicationValues: (string | null)[] | null;
 }
 
 export interface getConfig_nimbusConfig_documentationLink {


### PR DESCRIPTION
Because:

* audience targeting should be considered as application-dependent

This commit:

* associates each NimbusTargetingConfig with an ApplicationConfig -
  currently all APPLICATION_CONFIG_DESKTOP

* adds NimbusExperimentTargetingConfigChoice type in GQL to represent
  targeting choices augmented with application filtering context

* filters targeting choices in nimbus-ui by current experiment
  application

* make NO_TARGETING a proper NimbusTargetingConfig instance for
  consistency