### PR TITLE
fixes #4656 feat(nimbus): render review-readiness messages in new format

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/FormOverview/FormDocumentationLink.tsx
+++ b/app/experimenter/nimbus-ui/src/components/FormOverview/FormDocumentationLink.tsx
@@ -22,9 +22,10 @@ export type FormDocumentationLinkProps = {
   errors: Record<string, FieldError>;
   onRemove: () => void;
   canRemove: boolean;
-  submitErrors: Record<string, string[]>;
+  submitErrors: SerializerMessages;
   setSubmitErrors: React.Dispatch<React.SetStateAction<Record<string, any>>>;
   touched: Record<string, boolean>;
+  reviewMessages: SerializerMessages;
 };
 
 export const FormDocumentationLink = ({
@@ -36,6 +37,7 @@ export const FormDocumentationLink = ({
   submitErrors,
   setSubmitErrors,
   touched,
+  reviewMessages,
 }: FormDocumentationLinkProps) => {
   const { documentationLink: documentationLinkOptions } = useConfig();
 
@@ -50,6 +52,7 @@ export const FormDocumentationLink = ({
       submitErrors,
       errors,
       touched,
+      reviewMessages,
     );
 
   return (

--- a/app/experimenter/nimbus-ui/src/components/FormOverview/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/FormOverview/index.test.tsx
@@ -7,6 +7,7 @@ import React from "react";
 import { DOCUMENTATION_LINKS_TOOLTIP } from ".";
 import { FIELD_MESSAGES } from "../../lib/constants";
 import { mockExperimentQuery } from "../../lib/mocks";
+import { assertSerializerMessages } from "../../lib/test-utils";
 import { optionalBoolString } from "../../lib/utils";
 import { NimbusDocumentationLinkTitle } from "../../types/globalTypes";
 import { Subject } from "./mocks";
@@ -359,34 +360,21 @@ describe("FormOverview", () => {
     });
   });
 
-  it("displays warning icons when server complains fields are missing", () => {
-    Object.defineProperty(window, "location", {
-      value: {
-        search: "?show-errors",
-      },
+  it("can display server review-readiness messages on all fields", async () => {
+    await assertSerializerMessages(Subject, {
+      name: ["That's not your real name"],
+      hypothesis: ["You really think that's gonna happen?"],
+      application: ["Firefox for Palm Trio"],
+      public_description: ["Give Carly Rae Jepson a sword"],
+      risk_brand: ["Be nice to Foxy!"],
+      risk_revenue: ["Racks on racks on racks.", "Yuh, yuh, yuh, let's go"],
+      risk_partner_related: ["Be noice to your friends"],
+      documentation_links: [
+        {
+          title: ["Stop being so en-title-d"],
+          link: ["Link it up bro"],
+        },
+      ],
     });
-
-    const invalidFields = {
-      public_description: ["This field may not be null."],
-      risk_brand: ["This field may not be null."],
-      risk_revenue: ["This field may not be null."],
-      risk_partner_related: ["This field may not be null."],
-    };
-
-    const { experiment } = mockExperimentQuery("boo", {
-      readyForReview: {
-        ready: false,
-        message: invalidFields,
-      },
-    });
-    render(<Subject {...{ experiment }} />);
-
-    for (const [field, errors] of Object.entries(invalidFields)) {
-      expect(screen.getByTestId(`missing-${field}`).dataset).toEqual(
-        expect.objectContaining({
-          tip: errors.join(", "),
-        }),
-      );
-    }
   });
 });

--- a/app/experimenter/nimbus-ui/src/components/FormOverview/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/FormOverview/index.tsx
@@ -8,13 +8,7 @@ import Button from "react-bootstrap/Button";
 import Form from "react-bootstrap/Form";
 import { FormProvider } from "react-hook-form";
 import ReactTooltip from "react-tooltip";
-import {
-  SubmitErrorRecord,
-  SubmitErrors,
-  useCommonForm,
-  useExitWarning,
-  useReviewCheck,
-} from "../../hooks";
+import { useCommonForm, useExitWarning, useReviewCheck } from "../../hooks";
 import { useConfig } from "../../hooks/useConfig";
 import { ReactComponent as Info } from "../../images/info.svg";
 import {
@@ -37,7 +31,7 @@ import FormDocumentationLink, {
 type FormOverviewProps = {
   isLoading: boolean;
   isServerValid: boolean;
-  submitErrors: SubmitErrors;
+  submitErrors: SerializerMessages;
   setSubmitErrors: React.Dispatch<React.SetStateAction<Record<string, any>>>;
   experiment?: getExperiment["experimentBySlug"];
   onSubmit: (data: Record<string, any>, next: boolean) => void;
@@ -70,7 +64,7 @@ const FormOverview = ({
   onCancel,
 }: FormOverviewProps) => {
   const { application, hypothesisDefault } = useConfig();
-  const { FieldReview } = useReviewCheck(experiment);
+  const { fieldMessages } = useReviewCheck(experiment);
 
   const defaultValues = {
     name: experiment?.name || "",
@@ -99,6 +93,7 @@ const FormOverview = ({
     isServerValid,
     submitErrors,
     setSubmitErrors,
+    fieldMessages,
   );
 
   const { documentationLinks, addDocumentationLink, removeDocumentationLink } =
@@ -183,7 +178,6 @@ const FormOverview = ({
             <LinkExternal href={EXTERNAL_URLS.RISK_BRAND}>
               Learn more
             </LinkExternal>
-            <FieldReview field="risk_brand" />
           </InputRadios>
         )}
 
@@ -227,7 +221,6 @@ const FormOverview = ({
             <Form.Group controlId="publicDescription">
               <Form.Label className="d-flex align-items-center">
                 Public description
-                <FieldReview field="public_description" />
               </Form.Label>
               <Form.Control
                 as="textarea"
@@ -252,7 +245,6 @@ const FormOverview = ({
               <LinkExternal href={EXTERNAL_URLS.RISK_PARTNER}>
                 Learn more
               </LinkExternal>
-              <FieldReview field="risk_partner_related" />
             </InputRadios>
 
             <InputRadios
@@ -267,7 +259,6 @@ const FormOverview = ({
               <LinkExternal href={EXTERNAL_URLS.RISK_REVENUE}>
                 Learn more
               </LinkExternal>
-              <FieldReview field="risk_revenue" />
             </InputRadios>
 
             <Form.Group controlId="documentationLinks">
@@ -290,12 +281,12 @@ const FormOverview = ({
                       documentationLink,
                       setSubmitErrors,
                       fieldNamePrefix: `documentationLinks[${index}]`,
-                      submitErrors:
-                        (submitErrors?.documentation_links &&
-                          (
-                            submitErrors?.documentation_links as SubmitErrorRecord[]
-                          )[index]) ||
-                        {},
+                      submitErrors: (submitErrors.documentation_links?.[
+                        index
+                      ] || {}) as SerializerMessages<string>,
+                      reviewMessages: (fieldMessages.documentationLinks?.[
+                        index
+                      ] || {}) as SerializerMessages<string>,
                       //@ts-ignore react-hook-form types seem broken for nested fields
                       errors: (errors?.documentationLinks?.[index] ||
                         {}) as FormDocumentationLinkProps["errors"],

--- a/app/experimenter/nimbus-ui/src/components/InputRadios/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/InputRadios/index.tsx
@@ -26,29 +26,38 @@ export const InputRadios: React.FC<InputRadiosProps> = ({
   options,
   FormErrors,
   formControlAttrs,
-}) => (
-  <Form.Group controlId={name} as={Container}>
-    <Row className="align-items-center mt-4 mb-4">
-      <Col sm={10} className="col-sm-10 pl-0">
-        <Form.Label className="mb-0">{children}</Form.Label>
-        <FormErrors {...{ name }} />
-      </Col>
+}) => {
+  const controlAttrs = formControlAttrs(name, {}, false);
 
-      <Col sm={2} className="d-flex justify-content-end pr-0">
-        {options.map((option) => (
-          <span className="ml-3" key={`radio-${name}-${option.value}`}>
-            <Form.Check
-              type="radio"
-              value={option.value}
-              label={option.label}
-              id={`${name}-${option.value}`}
-              {...formControlAttrs(name, {}, false)}
-            />
-          </span>
-        ))}
-      </Col>
-    </Row>
-  </Form.Group>
-);
+  return (
+    <Form.Group controlId={name} as={Container}>
+      <Row className="align-items-center mt-4 mb-4">
+        <Col sm={10} className="col-sm-10 pl-0">
+          {/* FormErrors relies on the adjacent selector to have
+              the warning class in order to make it show up, so
+              extract that class from formControlAttrs */}
+          <Form.Label className={`mb-0 ${controlAttrs.className}`}>
+            {children}
+          </Form.Label>
+          <FormErrors {...{ name }} />
+        </Col>
+
+        <Col sm={2} className="d-flex justify-content-end pr-0">
+          {options.map((option) => (
+            <span className="ml-3" key={`radio-${name}-${option.value}`}>
+              <Form.Check
+                type="radio"
+                value={option.value}
+                label={option.label}
+                id={`${name}-${option.value}`}
+                {...controlAttrs}
+              />
+            </span>
+          ))}
+        </Col>
+      </Row>
+    </Form.Group>
+  );
+};
 
 export default InputRadios;

--- a/app/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/index.test.tsx
@@ -14,6 +14,7 @@ import { filterTargetingConfigSlug } from ".";
 import { snakeToCamelCase } from "../../../lib/caseConversions";
 import { EXTERNAL_URLS, FIELD_MESSAGES } from "../../../lib/constants";
 import { MOCK_CONFIG } from "../../../lib/mocks";
+import { assertSerializerMessages } from "../../../lib/test-utils";
 import {
   NimbusExperimentApplication,
   NimbusExperimentChannel,
@@ -258,44 +259,21 @@ describe("FormAudience", () => {
     }
   });
 
-  it("displays warning icons when server complains fields are missing", () => {
-    Object.defineProperty(window, "location", {
-      value: {
-        search: "?show-errors",
-      },
+  it("can display server review-readiness messages on all fields", async () => {
+    await assertSerializerMessages(Subject, {
+      population_percent: ["When it feels like the world is on your shoulders"],
+      proposed_duration: ["And all the madness has got you goin' crazy"],
+      proposed_enrollment: ["It's time to get out"],
+      total_enrolled_clients: ["Step out into the street"],
+      firefox_min_version: [
+        "Where all of the action is right there at your feet.",
+      ],
+      targeting_config_slug: [
+        "Well, I know a place",
+        "Where we can dance the whole night away",
+      ],
+      channel: ["Underneath the electric stars."],
     });
-
-    const invalidFields = {
-      population_percent: ["This field may not be null."],
-      proposed_duration: ["This field may not be null."],
-      proposed_enrollment: ["This field may not be null."],
-      total_enrolled_clients: ["This field may not be null"],
-      firefox_min_version: ["This field may not be null."],
-      targeting_config_slug: ["This field may not be null."],
-      channel: ["This list may not be empty."],
-    };
-
-    render(
-      <Subject
-        {...{
-          experiment: {
-            ...MOCK_EXPERIMENT,
-            readyForReview: {
-              ready: false,
-              message: invalidFields,
-            },
-          },
-        }}
-      />,
-    );
-
-    for (const [key, value] of Object.entries(invalidFields)) {
-      expect(screen.getByTestId(`missing-${key}`).dataset).toEqual(
-        expect.objectContaining({
-          tip: value.join(", "),
-        }),
-      );
-    }
   });
 });
 

--- a/app/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/index.tsx
@@ -22,7 +22,7 @@ import LinkExternal from "../../LinkExternal";
 
 type FormAudienceProps = {
   experiment: getExperiment_experimentBySlug;
-  submitErrors: Record<string, string[]>;
+  submitErrors: SerializerMessages;
   setSubmitErrors: React.Dispatch<React.SetStateAction<Record<string, any>>>;
   isServerValid: boolean;
   isLoading: boolean;
@@ -50,7 +50,7 @@ export const FormAudience = ({
   onSubmit,
 }: FormAudienceProps) => {
   const config = useConfig();
-  const { FieldReview } = useReviewCheck(experiment);
+  const { fieldMessages } = useReviewCheck(experiment);
 
   const defaultValues = {
     channel: experiment.channel,
@@ -68,6 +68,7 @@ export const FormAudience = ({
       isServerValid,
       submitErrors,
       setSubmitErrors,
+      fieldMessages,
     );
 
   type DefaultValues = typeof defaultValues;
@@ -108,7 +109,6 @@ export const FormAudience = ({
           <Form.Group as={Col} controlId="channel" md={8} lg={8}>
             <Form.Label className="d-flex align-items-center">
               Channel
-              <FieldReview field="channel" />
             </Form.Label>
             <Form.Control {...formControlAttrs("channel")} as="select">
               <SelectOptions options={config.channel} />
@@ -118,7 +118,6 @@ export const FormAudience = ({
           <Form.Group as={Col} controlId="minVersion">
             <Form.Label className="d-flex align-items-center">
               Min Version
-              <FieldReview field="firefox_min_version" />
             </Form.Label>
             <Form.Control
               {...formControlAttrs("firefoxMinVersion")}
@@ -133,7 +132,6 @@ export const FormAudience = ({
           <Form.Group as={Col} controlId="targeting">
             <Form.Label className="d-flex align-items-center">
               Advanced Targeting
-              <FieldReview field="targeting_config_slug" />
             </Form.Label>
             <Form.Control
               {...formControlAttrs("targetingConfigSlug")}
@@ -159,10 +157,7 @@ export const FormAudience = ({
 
         <Form.Row>
           <Form.Group as={Col} className="mx-5" controlId="populationPercent">
-            <Form.Label>
-              Percent of clients
-              <FieldReview field="population_percent" />
-            </Form.Label>
+            <Form.Label>Percent of clients</Form.Label>
             <InputGroup>
               <Form.Control
                 {...formControlAttrs(
@@ -187,10 +182,7 @@ export const FormAudience = ({
             className="mx-5"
             controlId="totalEnrolledClients"
           >
-            <Form.Label>
-              Expected number of clients
-              <FieldReview field="total_enrolled_clients" />
-            </Form.Label>
+            <Form.Label>Expected number of clients</Form.Label>
             <Form.Control
               {...formControlAttrs(
                 "totalEnrolledClients",
@@ -205,7 +197,6 @@ export const FormAudience = ({
           <Form.Group as={Col} className="mx-5" controlId="proposedEnrollment">
             <Form.Label className="d-flex align-items-center">
               Enrollment period
-              <FieldReview field="proposed_enrollment" />
             </Form.Label>
             <InputGroup>
               <Form.Control
@@ -229,7 +220,6 @@ export const FormAudience = ({
           <Form.Group as={Col} className="mx-5" controlId="proposedDuration">
             <Form.Label className="d-flex align-items-center">
               Experiment duration
-              <FieldReview field="proposed_duration" />
             </Form.Label>
             <InputGroup className="mb-3">
               <Form.Control

--- a/app/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/mocks.tsx
@@ -22,7 +22,7 @@ export const Subject = ({
   config?: getConfig_nimbusConfig;
 } & Partial<React.ComponentProps<typeof FormAudience>>) => {
   const [submitErrorsDefault, setSubmitErrors] =
-    useState<Record<string, any>>(submitErrors);
+    useState<SerializerMessages>(submitErrors);
   return (
     <div className="p-5">
       <MockedCache {...{ config }}>

--- a/app/experimenter/nimbus-ui/src/components/PageEditAudience/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditAudience/index.stories.tsx
@@ -4,49 +4,55 @@
 
 import { withLinks } from "@storybook/addon-links";
 import { withQuery } from "@storybook/addon-queryparams";
-import { storiesOf } from "@storybook/react";
 import React from "react";
 import PageEditAudience from ".";
 import { mockExperimentQuery } from "../../lib/mocks";
 import { RouterSlugProvider } from "../../lib/test-utils";
+import { getExperiment_experimentBySlug } from "../../types/getExperiment";
 
-const { mock } = mockExperimentQuery("demo-slug");
-const { mock: mockMissingFields } = mockExperimentQuery("demo-slug", {
-  channel: null,
-  firefoxMinVersion: null,
-  targetingConfigSlug: null,
-  proposedEnrollment: 0,
-  proposedDuration: 0,
-  readyForReview: {
-    ready: false,
-    message: {
-      proposed_duration: ["This field may not be null."],
-      proposed_enrollment: ["This field may not be null."],
-      firefox_min_version: ["This field may not be null."],
-      targeting_config_slug: ["This field may not be null."],
-      channel: ["This field may not be null."],
-    },
-  },
-});
+export default {
+  title: "pages/EditAudience",
+  component: PageEditAudience,
+  decorators: [withLinks, withQuery],
+};
 
-storiesOf("pages/EditAudience", module)
-  .addDecorator(withLinks)
-  .addDecorator(withQuery)
-  .add("basic", () => (
+const storyWithExperiment = (
+  experiment?: Partial<getExperiment_experimentBySlug>,
+) => {
+  const { mock } = mockExperimentQuery("demo-slug", experiment);
+  return (
     <RouterSlugProvider mocks={[mock]}>
       <PageEditAudience />
     </RouterSlugProvider>
-  ))
-  .add(
-    "missing fields",
-    () => (
-      <RouterSlugProvider mocks={[mockMissingFields]}>
-        <PageEditAudience />
-      </RouterSlugProvider>
-    ),
-    {
-      query: {
-        "show-errors": true,
+  );
+};
+
+export const Basic = () => storyWithExperiment();
+
+export const MissingFields = () =>
+  storyWithExperiment({
+    readyForReview: {
+      ready: false,
+      message: {
+        population_percent: [
+          "When it feels like the world is on your shoulders",
+        ],
+        proposed_duration: ["And all the madness has got you goin' crazy"],
+        proposed_enrollment: ["It's time to get out"],
+        total_enrolled_clients: ["Step out into the street"],
+        firefox_min_version: [
+          "Where all of the action is right there at your feet.",
+        ],
+        targeting_config_slug: [
+          "Well, I know a place",
+          "Where we can dance the whole night away",
+        ],
+        channel: ["Underneath the electric stars."],
       },
     },
-  );
+  });
+MissingFields.parameters = {
+  query: {
+    "show-errors": true,
+  },
+};

--- a/app/experimenter/nimbus-ui/src/components/PageEditMetrics/FormMetrics/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditMetrics/FormMetrics/index.test.tsx
@@ -12,6 +12,7 @@ import {
 import React from "react";
 import { PRIMARY_OUTCOMES_TOOLTIP, SECONDARY_OUTCOMES_TOOLTIP } from ".";
 import { mockExperimentQuery, MOCK_CONFIG } from "../../../lib/mocks";
+import { assertSerializerMessages } from "../../../lib/test-utils";
 import { Subject } from "./mocks";
 
 const outcomeNames = MOCK_CONFIG.outcomes!.map(
@@ -183,6 +184,13 @@ describe("FormMetrics", () => {
       expect(primaryOutcomes).toHaveTextContent(outcomeNames[0]);
       expect(primaryOutcomes).toHaveTextContent(outcomeNames[1]);
       expect(primaryOutcomes).not.toHaveTextContent(outcomeNames[2]);
+    });
+  });
+
+  it("can display server review-readiness messages on all fields", async () => {
+    await assertSerializerMessages(Subject, {
+      primary_outcomes: ["Primarily, tell me what's up."],
+      secondary_outcomes: ["On second thought..."],
     });
   });
 });

--- a/app/experimenter/nimbus-ui/src/components/PageEditMetrics/FormMetrics/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditMetrics/FormMetrics/index.tsx
@@ -12,6 +12,7 @@ import {
   useConfig,
   useExitWarning,
   useOutcomes,
+  useReviewCheck,
 } from "../../../hooks";
 import { SelectOption } from "../../../hooks/useCommonForm/useCommonFormMethods";
 import { ReactComponent as Info } from "../../../images/info.svg";
@@ -27,7 +28,7 @@ type FormMetricsProps = {
   experiment: getExperiment["experimentBySlug"];
   isLoading: boolean;
   isServerValid: boolean;
-  submitErrors: Record<string, string[]>;
+  submitErrors: SerializerMessages;
   setSubmitErrors: React.Dispatch<React.SetStateAction<Record<string, any>>>;
   onSave: (data: Record<string, any>, next: boolean) => void;
 };
@@ -53,6 +54,7 @@ const FormMetrics = ({
     available: availableOutcomes,
   } = useOutcomes(experiment!);
   const { maxPrimaryOutcomes } = useConfig();
+  const { fieldMessages } = useReviewCheck(experiment);
 
   // We must alter primary outcome options when a secondary set is selected
   // to exclude the set from primary outcome options and vice versa
@@ -100,6 +102,7 @@ const FormMetrics = ({
     isServerValid,
     submitErrors,
     setSubmitErrors,
+    fieldMessages,
   );
 
   const shouldWarnOnExit = useExitWarning();

--- a/app/experimenter/nimbus-ui/src/components/PageEditMetrics/FormMetrics/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditMetrics/FormMetrics/mocks.tsx
@@ -14,7 +14,7 @@ export const Subject = ({
   experiment = mockExperimentQuery("boo").experiment,
 }: Partial<React.ComponentProps<typeof FormMetrics>>) => {
   const [submitErrorsDefault, setSubmitErrors] =
-    useState<Record<string, any>>(submitErrors);
+    useState<SerializerMessages>(submitErrors);
   return (
     <MockedCache>
       <FormMetrics

--- a/app/experimenter/nimbus-ui/src/components/PageEditMetrics/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditMetrics/index.stories.tsx
@@ -3,18 +3,44 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { withLinks } from "@storybook/addon-links";
-import { storiesOf } from "@storybook/react";
+import { withQuery } from "@storybook/addon-queryparams";
 import React from "react";
 import PageEditMetrics from ".";
 import { mockExperimentQuery } from "../../lib/mocks";
 import { RouterSlugProvider } from "../../lib/test-utils";
+import { getExperiment_experimentBySlug } from "../../types/getExperiment";
 
-const { mock } = mockExperimentQuery("demo-slug");
+export default {
+  title: "pages/EditMetrics",
+  component: PageEditMetrics,
+  decorators: [withLinks, withQuery],
+};
 
-storiesOf("pages/EditMetrics", module)
-  .addDecorator(withLinks)
-  .add("basic", () => (
+const storyWithExperiment = (
+  experiment?: Partial<getExperiment_experimentBySlug>,
+) => {
+  const { mock } = mockExperimentQuery("demo-slug", experiment);
+  return (
     <RouterSlugProvider mocks={[mock]}>
       <PageEditMetrics />
     </RouterSlugProvider>
-  ));
+  );
+};
+
+export const Basic = () => storyWithExperiment();
+
+export const MissingFields = () =>
+  storyWithExperiment({
+    readyForReview: {
+      ready: false,
+      message: {
+        primary_outcomes: ["Primarily, tell me what's up."],
+        secondary_outcomes: ["On second thought..."],
+      },
+    },
+  });
+MissingFields.parameters = {
+  query: {
+    "show-errors": true,
+  },
+};

--- a/app/experimenter/nimbus-ui/src/components/PageEditOverview/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditOverview/index.stories.tsx
@@ -4,47 +4,54 @@
 
 import { withLinks } from "@storybook/addon-links";
 import { withQuery } from "@storybook/addon-queryparams";
-import { storiesOf } from "@storybook/react";
 import React from "react";
 import PageEditOverview from ".";
 import { mockExperimentQuery } from "../../lib/mocks";
 import { RouterSlugProvider } from "../../lib/test-utils";
+import { getExperiment_experimentBySlug } from "../../types/getExperiment";
 
-const { mock } = mockExperimentQuery("demo-slug");
-const { mock: mockMissingFields } = mockExperimentQuery("demo-slug", {
-  publicDescription: "",
-  riskBrand: null,
-  riskPartnerRelated: null,
-  riskRevenue: null,
-  readyForReview: {
-    ready: false,
-    message: {
-      public_description: ["This field may not be null."],
-      risk_brand: ["This field may not be null."],
-      risk_revenue: ["This field may not be null."],
-      risk_partner_related: ["This field may not be null."],
-    },
-  },
-});
+export default {
+  title: "pages/EditOverview",
+  component: PageEditOverview,
+  decorators: [withLinks, withQuery],
+};
 
-storiesOf("pages/EditOverview", module)
-  .addDecorator(withLinks)
-  .addDecorator(withQuery)
-  .add("basic", () => (
+const storyWithExperiment = (
+  experiment?: Partial<getExperiment_experimentBySlug>,
+) => {
+  const { mock } = mockExperimentQuery("demo-slug", experiment);
+  return (
     <RouterSlugProvider mocks={[mock]}>
       <PageEditOverview />
     </RouterSlugProvider>
-  ))
-  .add(
-    "missing fields",
-    () => (
-      <RouterSlugProvider mocks={[mockMissingFields]}>
-        <PageEditOverview />
-      </RouterSlugProvider>
-    ),
-    {
-      query: {
-        "show-errors": true,
+  );
+};
+
+export const Basic = () => storyWithExperiment();
+
+export const MissingFields = () =>
+  storyWithExperiment({
+    readyForReview: {
+      ready: false,
+      message: {
+        name: ["That's not your real name"],
+        hypothesis: ["You really think that's gonna happen?"],
+        application: ["Firefox for Palm Trio"],
+        public_description: ["Give Carly Rae Jepson a sword"],
+        risk_brand: ["Be nice to Foxy!"],
+        risk_revenue: ["Racks on racks on racks.", "Yuh, yuh, yuh, let's go"],
+        risk_partner_related: ["Be noice to your friends"],
+        documentation_links: [
+          {
+            title: ["Stop being so en-title-d"],
+            link: ["Link it up bro"],
+          },
+        ],
       },
     },
-  );
+  });
+MissingFields.parameters = {
+  query: {
+    "show-errors": true,
+  },
+};

--- a/app/experimenter/nimbus-ui/src/hooks/useCommonForm/index.tsx
+++ b/app/experimenter/nimbus-ui/src/hooks/useCommonForm/index.tsx
@@ -6,15 +6,12 @@ import React from "react";
 import { IsDirtyUnsaved, useCommonFormMethods } from "./useCommonFormMethods";
 import { useForm } from "./useForm";
 
-export type SubmitErrorRecord = Record<string, string[]>;
-export type SubmitErrors = Record<string, string[] | SubmitErrorRecord[]>;
-
 export function useCommonForm<FieldNames extends string>(
   defaultValues: Record<string, any>,
   isServerValid: boolean,
-  submitErrors: SubmitErrors,
+  submitErrors: SerializerMessages,
   setSubmitErrors: React.Dispatch<React.SetStateAction<Record<string, any>>>,
-  reviewMessages: Record<string, string[]> = {},
+  reviewMessages?: SerializerMessages,
 ) {
   const formMethods = useForm(defaultValues);
   const {

--- a/app/experimenter/nimbus-ui/src/hooks/useCommonForm/useCommonFormMethods.tsx
+++ b/app/experimenter/nimbus-ui/src/hooks/useCommonForm/useCommonFormMethods.tsx
@@ -6,7 +6,6 @@ import classNames from "classnames";
 import React from "react";
 import Form from "react-bootstrap/Form";
 import { FieldError, RegisterOptions, UseFormMethods } from "react-hook-form";
-import { SubmitErrors } from ".";
 import { camelToSnakeCase } from "../../lib/caseConversions";
 
 // TODO: 'any' type on `onChange={(selectedOptions) => ...`,
@@ -27,11 +26,11 @@ export const IsDirtyUnsaved = (
 export function useCommonFormMethods<FieldNames extends string>(
   defaultValues: Record<string, any>,
   setSubmitErrors: React.Dispatch<React.SetStateAction<Record<string, any>>>,
-  submitErrors: SubmitErrors,
+  submitErrors: SerializerMessages,
   register: UseFormMethods["register"],
   errors: UseFormMethods["errors"],
   touched: UseFormMethods["formState"]["touched"],
-  reviewMessages: Record<string, string[]>,
+  reviewMessages: SerializerMessages = {},
 ) {
   const hideSubmitError = <K extends FieldNames>(name: K) => {
     if (submitErrors && submitErrors[camelToSnakeCase(name)]) {
@@ -128,11 +127,13 @@ export function useCommonFormMethods<FieldNames extends string>(
       setValuesFromOptions(getValuesFromOptions(selectedOptions));
       hideSubmitError(name);
     },
-    className: Boolean(
-      submitErrors![camelToSnakeCase(name)] || (touched[name] && errors[name]),
-    )
-      ? "is-invalid border border-danger rounded"
-      : "",
+    className: classNames(
+      (submitErrors![camelToSnakeCase(name)] ||
+        (touched[name] && errors[name])) &&
+        "is-invalid border border-danger rounded",
+      (reviewMessages[name] || []).length > 0 &&
+        "is-warning border-feedback-warning rounded",
+    ),
   });
 
   return {

--- a/app/experimenter/nimbus-ui/src/hooks/useCommonForm/useCommonNestedForm.tsx
+++ b/app/experimenter/nimbus-ui/src/hooks/useCommonForm/useCommonNestedForm.tsx
@@ -14,10 +14,10 @@ export function useCommonNestedForm<FieldNames extends string>(
   defaultValues: Record<string, any>,
   setSubmitErrors: React.Dispatch<React.SetStateAction<Record<string, any>>>,
   prefix: string,
-  nestedSubmitErrors: Record<string, string[]>,
+  nestedSubmitErrors: SerializerMessages,
   nestedErrors: UseFormMethods["errors"],
   nestedTouched: UseFormMethods["formState"]["touched"],
-  nestedReviewMessages: Record<string, string[]> = {},
+  nestedReviewMessages?: SerializerMessages,
 ) {
   const { register, watch } = useFormContext();
 

--- a/app/experimenter/nimbus-ui/src/lib/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/lib/mocks.tsx
@@ -369,8 +369,7 @@ export function mockExperimentQuery<
 export const MOCK_REVIEW: ReviewCheck = {
   ready: true,
   invalidPages: [],
-  fieldReviewMessages: () => [],
-  FieldReview: () => <></>,
+  fieldMessages: {},
   InvalidPagesList: () => <></>,
 };
 

--- a/app/experimenter/nimbus-ui/src/react-app-env.d.ts
+++ b/app/experimenter/nimbus-ui/src/react-app-env.d.ts
@@ -6,3 +6,8 @@
 
 type DateTime = string;
 type ObjectField = Record<string, any> | string;
+
+type SerializerMessages<T = string | Record<string, string[]>> = Record<
+  string,
+  T[]
+>;

--- a/app/experimenter/nimbus-ui/src/styles/index.scss
+++ b/app/experimenter/nimbus-ui/src/styles/index.scss
@@ -57,6 +57,10 @@ $form-validation-states: map-merge(
     map-get($data, icon)
   );
 }
+// There's already a border-warning class, so add a feedback-specific one
+.border-feedback-warning {
+  border: 1px solid $form-feedback-warning-color !important;
+}
 
 .font-weight-semibold {
   font-weight: 600;


### PR DESCRIPTION
Closes #4656 

This PR introduces a visual change to the edit experiment flow; it replaces, when the URL indicates the page should show review-readiness messages, the dark red (!) icons containing the feedback inside a tooltip with our new orange always-visible field feedback (similar to validation messages).

<img width="1209" alt="Screen Shot 2021-05-19 at 12 00 51 PM" src="https://user-images.githubusercontent.com/6392049/118845912-3050ad00-b89a-11eb-88d3-fc5daf328d6f.png">

Some notes on this:

- All this is really doing is feeding the review-readiness feedback into the `useCommonForm` hook and subsequent `FormErrors` component.
- I made this work and tested it for the Overview, Metrics, and Audience pages, but intentionally haven't touched the Branches page since it is its own unique setup and will be covered as part of EXP-978 and EXP-768
- You'll notice I changed the types of `submitErrors`. That's because the responses for both field validation errors and field review-readiness messages are both Django serializer objects, so I decided it was appropriate to consolidate this type into one.
- Also updated any Storybooks I touched to the new story writing format