### PR TITLE
fixes #4403, #4899 feat(nimbus): Show only one branch in form/summary table if user saved single branch

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/index.stories.tsx
@@ -96,6 +96,24 @@ storiesOf("pages/EditBranches/FormBranches", module)
     />
   ))
   .add("with branches", () => <SubjectBranches {...commonFormBranchesProps} />)
+  .add("with only one branch saved", () => (
+    <SubjectBranches
+      {...commonFormBranchesProps}
+      experiment={{
+        ...MOCK_EXPERIMENT,
+        treatmentBranches: [
+          {
+            name: "",
+            slug: "",
+            description: "",
+            ratio: 1,
+            featureValue: null,
+            featureEnabled: false,
+          },
+        ],
+      }}
+    />
+  ))
   .add("with equal ratio", () => (
     <SubjectBranches
       {...commonFormBranchesProps}

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/index.test.tsx
@@ -51,6 +51,7 @@ describe("FormBranches", () => {
             referenceBranch: {
               ...MOCK_EXPERIMENT.referenceBranch!,
               name: "",
+              slug: "",
             },
             treatmentBranches: [
               {

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/index.tsx
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React, { useEffect, useMemo } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import Alert from "react-bootstrap/Alert";
 import Button from "react-bootstrap/Button";
 import Col from "react-bootstrap/Col";
@@ -97,9 +97,26 @@ export const FormBranches = ({
 
   const clearSubmitErrors = () => dispatch({ type: "clearSubmitErrors" });
 
+  // We show two branches by default, an empty control/reference branch and treatment
+  // branch, which are given a default branch name. If a branch slug is not set, it means
+  // that branch hasn't been saved by the user. If only a reference branch was previously
+  // saved we _don't_ show a new treatment branch by default and instead, if "handleAddBranch"
+  // is called, we show the empty treatment branch instead of creating a new one.
+  const [showFirstTreatmentBranch, setShowFirstTreatmentBranch] = useState(
+    !defaultValues.referenceBranch?.slug ||
+      (defaultValues.treatmentBranches &&
+        defaultValues.treatmentBranches[0]?.slug),
+  );
+
   const handleAddBranch = () => {
     commitFormData();
-    dispatch({ type: "addBranch" });
+    if (
+      showFirstTreatmentBranch ||
+      (!showFirstTreatmentBranch && defaultValues.treatmentBranches === null)
+    ) {
+      dispatch({ type: "addBranch" });
+    }
+    if (!showFirstTreatmentBranch) setShowFirstTreatmentBranch(true);
   };
 
   const handleRemoveBranch = (idx: number) => () => {
@@ -223,6 +240,7 @@ export const FormBranches = ({
             />
           )}
           {treatmentBranches &&
+            showFirstTreatmentBranch &&
             treatmentBranches.map(
               (branch, idx) =>
                 branch && (

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/reducer/state.ts
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/reducer/state.ts
@@ -24,6 +24,7 @@ export type AnnotatedBranch = TreatmentBranchType & {
   isValid: boolean;
   isDirty: boolean;
   errors: Record<string, string[]>;
+  slug?: string;
 };
 
 export function createInitialState({

--- a/app/experimenter/nimbus-ui/src/components/Summary/TableBranches/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/TableBranches/index.stories.tsx
@@ -8,6 +8,23 @@ import { MOCK_EXPERIMENT, Subject } from "./mocks";
 
 storiesOf("components/Summary/TableBranches", module)
   .add("full branches", () => <Subject />)
+  .add("one branch", () => (
+    <Subject
+      experiment={{
+        ...MOCK_EXPERIMENT,
+        treatmentBranches: [
+          {
+            name: "",
+            slug: "",
+            description: "",
+            ratio: 0,
+            featureValue: null,
+            featureEnabled: false,
+          },
+        ],
+      }}
+    />
+  ))
   .add("unsaved branches", () => (
     <Subject
       experiment={{
@@ -55,17 +72,19 @@ storiesOf("components/Summary/TableBranches", module)
     <Subject
       experiment={{
         ...MOCK_EXPERIMENT,
-        treatmentBranches: [
-          {
-            name: "",
-            slug: "",
-            description: "",
-            ratio: 0,
-            featureValue: null,
-            featureEnabled: false,
-          },
-          ...MOCK_EXPERIMENT.treatmentBranches!,
-        ],
+        featureConfig: {
+          ...MOCK_EXPERIMENT.featureConfig!,
+          schema: "{}",
+        },
+        referenceBranch: {
+          name: "control",
+          slug: "control",
+          description: "",
+          ratio: 0,
+          featureValue: null,
+          featureEnabled: true,
+        },
+        treatmentBranches: [],
       }}
     />
   ));

--- a/app/experimenter/nimbus-ui/src/components/Summary/TableBranches/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/TableBranches/index.test.tsx
@@ -142,12 +142,20 @@ describe("TableBranches", () => {
     }
   });
 
-  it("displays not set for missing branch properties", () => {
+  it("hides branches without 'name' set, displays not set for missing branch properties", () => {
     render(
       <Subject
         experiment={{
           ...MOCK_EXPERIMENT,
           treatmentBranches: [
+            {
+              name: "treatment",
+              slug: "",
+              description: "",
+              ratio: 0,
+              featureValue: null,
+              featureEnabled: true,
+            },
             {
               name: "",
               slug: "",
@@ -156,24 +164,24 @@ describe("TableBranches", () => {
               featureValue: null,
               featureEnabled: true,
             },
-            ...MOCK_EXPERIMENT.treatmentBranches!,
           ],
         }}
       />,
     );
 
     const branchTables = screen.queryAllByTestId("table-branch");
-    expect(branchTables).toHaveLength(3);
+    expect(branchTables).toHaveLength(2);
 
     const subjectTable = branchTables[1];
-    for (const name of [
-      "name",
+    for (const property of [
       "slug",
       "description",
       "ratio",
       "featureValue",
     ] as const) {
-      const cell = subjectTable.querySelector(`[data-testid='branch-${name}']`);
+      const cell = subjectTable.querySelector(
+        `[data-testid='branch-${property}']`,
+      );
       expect(cell).toBeInTheDocument();
       const notSet = cell!.querySelector("[data-testid='not-set']");
       expect(notSet).toBeInTheDocument();

--- a/app/experimenter/nimbus-ui/src/components/Summary/TableBranches/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/TableBranches/index.tsx
@@ -41,8 +41,9 @@ const TableBranches = ({
     experiment.referenceBranch,
     ...(experiment.treatmentBranches || []),
   ].filter((branch): branch is Branch => branch !== null);
-  const branchCount = branches.length;
-  const hasOneBranchNameSet = Boolean(branches.find((branch) => branch.name));
+  const savedBranches = branches.filter((branch) => branch.name);
+  const branchCount = savedBranches.length;
+  const hasOneBranchNameSet = Boolean(savedBranches);
 
   return (
     <>
@@ -51,7 +52,7 @@ const TableBranches = ({
         <NotSet copy={NO_BRANCHES_COPY} />
       ) : (
         <>
-          {branches.map((branch, key) => (
+          {savedBranches.map((branch, key) => (
             <TableBranch key={key} {...{ hasSchema, branch }} />
           ))}
         </>
@@ -72,7 +73,7 @@ const TableBranch = ({
       <thead className="thead-light">
         <tr>
           <th colSpan={2} data-testid="branch-name">
-            {name ? name : <NotSet />}
+            {name}
           </th>
         </tr>
       </thead>


### PR DESCRIPTION
fixes #4403
fixes #4899 

Because:
* Users may want experiments with only one branch configured and we should hide the empty reference branch in the branches table and not display the branch in the branches form if they've saved one branch previously

This commit:
* Updates TableBranches to show each branch table based on branch name which is required when saving a branch
* Updates FormBranches to hide an empty treatment branch if the user saved a control branch without a treatment branch
* Updates storybook and tests