### PR TITLE
chore(nimbus): add kinto to make up_prod

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -8,8 +8,8 @@ WORKDIR /app
 ENV PYTHONDONTWRITEBYTECODE 1
 
 
-# Script for waiting for the db to initialize
-COPY bin/wait-for-it.sh /app/bin/wait-for-it.sh
+# Scripts for waiting for the db and setting up kinto
+COPY bin/ /app/bin/
 RUN chmod +x /app/bin/wait-for-it.sh
 
 

--- a/docker-compose-integration-test.yml
+++ b/docker-compose-integration-test.yml
@@ -11,6 +11,7 @@ services:
       - /code/app/tests/integration/.tox
     links:
       - nginx
+      - kinto
     expose:
       - "4444"
     ports:


### PR DESCRIPTION
Because

- The integration tests run against make up_prod
- The integration tests will need to interact with kinto

This commit

- Exposes kinto to make up_prod