### PR TITLE
fix(visualization): Retitle search metric

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableResults/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableResults/index.test.tsx
@@ -27,7 +27,7 @@ describe("TableResults", () => {
     const EXPECTED_HEADINGS = [
       "Picture-in-Picture Conversion",
       "2-Week Browser Retention",
-      "Daily Mean Searches Per User",
+      "Mean Searches Per User",
       "Overall Mean Days of Use Per User",
       "Total Users",
     ];

--- a/app/experimenter/nimbus-ui/src/lib/visualization/constants.ts
+++ b/app/experimenter/nimbus-ui/src/lib/visualization/constants.ts
@@ -138,7 +138,7 @@ export const RESULTS_METRICS_LIST = [
   },
   {
     value: METRIC.SEARCH,
-    name: "Daily Mean Searches Per User",
+    name: "Mean Searches Per User",
     tooltip: METRICS_TIPS.SEARCH,
     type: METRIC_TYPE.GUARDRAIL,
   },


### PR DESCRIPTION
Inspired by some pre-presentation close reading...

These are not scaled by day, so "daily" isn't correct; right now these are sums over the entire period of analysis.