### PR TITLE
fix #5248: fix(visualization): Add a minimum width% for confidence intervals.

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/PageResults/ConfidenceInterval/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/ConfidenceInterval/index.stories.tsx
@@ -33,4 +33,28 @@ storiesOf("pages/Results/ConfidenceInterval", module)
       range={65}
       significance={SIGNIFICANCE.NEGATIVE}
     />
+  ))
+  .add("with small positive significance", () => (
+    <ConfidenceInterval
+      upper={50}
+      lower={45}
+      range={50}
+      significance={SIGNIFICANCE.POSITIVE}
+    />
+  ))
+  .add("with small neutral significance", () => (
+    <ConfidenceInterval
+      upper={2}
+      lower={-2}
+      range={2}
+      significance={SIGNIFICANCE.NEUTRAL}
+    />
+  ))
+  .add("with small negative significance", () => (
+    <ConfidenceInterval
+      upper={-45}
+      lower={-50}
+      range={50}
+      significance={SIGNIFICANCE.NEGATIVE}
+    />
   ));

--- a/app/experimenter/nimbus-ui/src/components/PageResults/ConfidenceInterval/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/ConfidenceInterval/index.tsx
@@ -8,6 +8,7 @@
 import React from "react";
 
 const BUFFER = 5;
+const MIN_BOUNDS_WIDTH = 22;
 
 const renderBounds = (
   lower: number,
@@ -15,27 +16,33 @@ const renderBounds = (
   leftPercent: number,
   barWidth: number,
   significance: string,
-) => (
-  <div
-    className="position-absolute"
-    style={{
-      // Add some buffer to space out the rendered bound values.
-      left: `${leftPercent - BUFFER * 2}%`,
-      width: `${barWidth + BUFFER * 3}%`,
-    }}
-  >
+) => {
+  if (barWidth < MIN_BOUNDS_WIDTH) {
+    leftPercent -= (MIN_BOUNDS_WIDTH - barWidth) / 2;
+  }
+
+  return (
     <div
-      className={`${significance}-significance text-left p-0 h6 font-weight-normal position-absolute`}
+      className="position-absolute"
+      style={{
+        // Add some buffer to space out the rendered bound values.
+        left: `${leftPercent - BUFFER * 2}%`,
+        width: `${Math.max(barWidth, MIN_BOUNDS_WIDTH) + BUFFER * 3}%`,
+      }}
     >
-      {lower}%
+      <div
+        className={`${significance}-significance text-left p-0 h6 font-weight-normal position-absolute`}
+      >
+        {lower}%
+      </div>
+      <div
+        className={`${significance}-significance text-right p-0 h6 font-weight-normal`}
+      >
+        {upper}%
+      </div>
     </div>
-    <div
-      className={`${significance}-significance text-right p-0 h6 font-weight-normal`}
-    >
-      {upper}%
-    </div>
-  </div>
-);
+  );
+};
 
 const renderLine = (
   leftPercent: number,


### PR DESCRIPTION
Because:
* The CI bounds text was overlapping

This commit:
* Adds a minimum width to ensure they don't overlap