### PR TITLE
fixes #5103 feat(nimbus): Display feature config review readiness errors, remove +/x feature config

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/FormBranch.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/FormBranch.test.tsx
@@ -26,7 +26,6 @@ describe("FormBranch", () => {
     expect(screen.queryByTestId("control-pill")).not.toBeInTheDocument();
     expect(screen.queryByTestId("equal-ratio")).not.toBeInTheDocument();
     expect(screen.queryByTestId("feature-config-edit")).toBeInTheDocument();
-    expect(screen.queryByTestId("feature-config-add")).not.toBeInTheDocument();
     expect(screen.queryByTestId("feature-value-edit")).not.toBeInTheDocument();
   });
 
@@ -56,17 +55,6 @@ describe("FormBranch", () => {
       'label[for="referenceBranch.featureEnabled"]',
     );
     expect(featureSwitchLabel).toHaveTextContent("Off");
-  });
-
-  it("hides feature configuration edit when feature not selected", () => {
-    render(
-      <SubjectBranch
-        branch={MOCK_ANNOTATED_BRANCH}
-        experimentFeatureConfig={null}
-      />,
-    );
-    expect(screen.queryByTestId("feature-config-edit")).not.toBeInTheDocument();
-    expect(screen.queryByTestId("feature-config-add")).toBeInTheDocument();
   });
 
   it("hides feature value edit when schema is null", () => {

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/FormBranch.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/FormBranch.tsx
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import classNames from "classnames";
 import React from "react";
 import Badge from "react-bootstrap/Badge";
 import Button from "react-bootstrap/Button";
@@ -24,6 +25,7 @@ export const branchFieldNames = [
   "ratio",
   "featureValue",
   "featureEnabled",
+  "featureConfig",
 ] as const;
 
 type BranchFieldName = typeof branchFieldNames[number];
@@ -39,8 +41,6 @@ export const FormBranch = ({
   experimentFeatureConfig,
   featureConfig,
   onRemove,
-  onAddFeatureConfig,
-  onRemoveFeatureConfig,
   onFeatureConfigChange,
   defaultValues,
   setSubmitErrors,
@@ -55,8 +55,6 @@ export const FormBranch = ({
   experimentFeatureConfig: getExperiment_experimentBySlug["featureConfig"];
   featureConfig: getConfig_nimbusConfig["featureConfig"];
   onRemove?: () => void;
-  onAddFeatureConfig: () => void;
-  onRemoveFeatureConfig: () => void;
   onFeatureConfigChange: (
     featureConfig: getConfig_nimbusConfig_featureConfig | null,
   ) => void;
@@ -167,98 +165,78 @@ export const FormBranch = ({
         </Form.Row>
       </Form.Group>
 
-      {experimentFeatureConfig === null ? (
-        <Form.Group className="px-2 mx-3">
-          <Form.Row>
-            <Button
-              className="feature-config-add"
-              variant="outline-primary"
-              size="sm"
-              data-testid="feature-config-add"
-              onClick={onAddFeatureConfig}
-            >
-              + Feature configuration
-            </Button>
-          </Form.Row>
-        </Form.Group>
-      ) : (
-        <Form.Group
-          className="px-3 py-2 border-top"
-          data-testid="feature-config-edit"
-        >
-          <Form.Row>
-            <Col className="px-2">Feature configuration</Col>
-            <Form.Group as={Col} sm={1} className="align-top text-right">
-              <Button
-                variant="light"
-                className="bg-transparent border-0 p-0 m-0"
-                data-testid="feature-config-remove"
-                title="Remove feature configuration"
-                onClick={onRemoveFeatureConfig}
-              >
-                <DeleteIcon width="18" height="18" />
-              </Button>
-            </Form.Group>
-          </Form.Row>
-          <Form.Row className="align-middle">
-            <Form.Group as={Col} controlId={`${id}-feature`}>
-              <Form.Control
-                as="select"
-                data-testid="feature-config-select"
-                onChange={handleFeatureConfigChange}
-                value={featureConfig!.findIndex(
-                  (feature) => feature?.slug === experimentFeatureConfig?.slug,
-                )}
-              >
-                <option value="">Select...</option>
-                {featureConfig?.map(
-                  (feature, idx) =>
-                    feature && (
-                      <option
-                        key={`feature-${feature.slug}-${idx}`}
-                        value={idx}
-                      >
-                        {feature.name}
-                      </option>
-                    ),
-                )}
-              </Form.Control>
-            </Form.Group>
-            <Col sm={1} md={1} className="px-2 text-center">
-              is
-            </Col>
-            <Form.Group as={Col} controlId={`${id}.featureEnabled`}>
-              <Form.Check
-                {...formControlAttrs("featureEnabled", {}, false)}
-                type="switch"
-                label={featureEnabled ? "On" : "Off"}
-              />
-            </Form.Group>
-          </Form.Row>
-          {experimentFeatureConfig !== null &&
-          !!experimentFeatureConfig.schema &&
-          featureEnabled ? (
-            <Form.Row data-testid="feature-value-edit">
-              <Form.Group as={Col} controlId={`${id}-featureValue`}>
-                <Form.Label>Value</Form.Label>
-                {/* TODO: EXP-732 Maybe do some JSON schema validation here client-side? */}
-                <Form.Control
-                  {...formControlAttrs("featureValue")}
-                  as="textarea"
-                  rows={4}
-                />
-                <FormErrors name="featureValue" />
-              </Form.Group>
-            </Form.Row>
-          ) : (
+      <Form.Group
+        className="px-3 pt-2 border-top"
+        data-testid="feature-config-edit"
+      >
+        <Form.Row>
+          <Col>
+            <Form.Label htmlFor={`${id}-featureConfig`}>
+              Feature configuration
+            </Form.Label>
+          </Col>
+        </Form.Row>
+        <Form.Row className="align-middle">
+          <Form.Group as={Col} controlId={`${id}-featureConfig`}>
             <Form.Control
-              {...formControlAttrs("featureValue", {}, false)}
-              type="hidden"
-              value=""
+              as="select"
+              data-testid="feature-config-select"
+              // Displaying the review-readiness error is handled here instead of `formControlAttrs`
+              // due to a state conflict between `react-hook-form` and our internal branch state mangement
+              className={classNames(
+                reviewErrors.featureConfig?.length > 0 && "is-warning",
+              )}
+              onChange={handleFeatureConfigChange}
+              value={featureConfig!.findIndex(
+                (feature) => feature?.slug === experimentFeatureConfig?.slug,
+              )}
+            >
+              <option value="">Select...</option>
+              {featureConfig?.map(
+                (feature, idx) =>
+                  feature && (
+                    <option key={`feature-${feature.slug}-${idx}`} value={idx}>
+                      {feature.name}
+                    </option>
+                  ),
+              )}
+            </Form.Control>
+            <FormErrors name="featureConfig" />
+          </Form.Group>
+          <Col sm={1} md={1} className="px-2 text-center">
+            is
+          </Col>
+          <Form.Group as={Col} controlId={`${id}.featureEnabled`}>
+            <Form.Check
+              {...formControlAttrs("featureEnabled", {}, false)}
+              type="switch"
+              label={featureEnabled ? "On" : "Off"}
             />
-          )}
-        </Form.Group>
-      )}
+          </Form.Group>
+        </Form.Row>
+        {experimentFeatureConfig !== null &&
+        !!experimentFeatureConfig.schema &&
+        featureEnabled ? (
+          <Form.Row data-testid="feature-value-edit">
+            <Form.Group as={Col} controlId={`${id}-featureValue`}>
+              <Form.Label>Value</Form.Label>
+              {/* TODO: EXP-732 Maybe do some JSON schema validation here client-side? */}
+              <Form.Control
+                {...formControlAttrs("featureValue")}
+                as="textarea"
+                rows={4}
+              />
+              <FormErrors name="featureValue" />
+            </Form.Group>
+          </Form.Row>
+        ) : (
+          <Form.Control
+            {...formControlAttrs("featureValue", {}, false)}
+            type="hidden"
+            value=""
+          />
+        )}
+      </Form.Group>
     </div>
   );
 };

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/index.stories.tsx
@@ -17,16 +17,12 @@ import {
 } from "./mocks";
 
 const onRemove = action("onRemove");
-const onAddFeatureConfig = action("onAddFeatureConfig");
-const onRemoveFeatureConfig = action("onRemoveFeatureConfig");
 const onFeatureConfigChange = action("onFeatureConfigChange");
 const onSave = action("onSave");
 const onNext = action("onNext");
 
 const commonFormBranchProps = {
   onRemove,
-  onAddFeatureConfig,
-  onRemoveFeatureConfig,
   onFeatureConfigChange,
 };
 

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/mocks.tsx
@@ -64,8 +64,6 @@ export const SubjectBranch = ({
   experimentFeatureConfig = MOCK_FEATURE_CONFIG,
   featureConfig = MOCK_CONFIG.featureConfig,
   onRemove = () => {},
-  onAddFeatureConfig = () => {},
-  onRemoveFeatureConfig = () => {},
   onFeatureConfigChange = () => {},
 }: Partial<React.ComponentProps<typeof FormBranch>>) => {
   const defaultValues = {
@@ -103,8 +101,6 @@ export const SubjectBranch = ({
             featureConfig,
             experimentFeatureConfig,
             onRemove,
-            onAddFeatureConfig,
-            onRemoveFeatureConfig,
             onFeatureConfigChange,
             defaultValues: defaultValues.referenceBranch || {},
             setSubmitErrors,

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/reducer/actions.ts
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/reducer/actions.ts
@@ -20,8 +20,6 @@ export function formBranchesActionReducer(
       return addBranch(state);
     case "removeBranch":
       return removeBranch(state, action);
-    case "removeFeatureConfig":
-      return removeFeatureConfig(state);
     case "setFeatureConfig":
       return setFeatureConfig(state, action);
     case "setEqualRatio":
@@ -40,7 +38,6 @@ export function formBranchesActionReducer(
 export type FormBranchesAction =
   | AddBranchAction
   | RemoveBranchAction
-  | RemoveFeatureConfigAction
   | SetEqualRatioAction
   | SetFeatureConfigAction
   | SetSubmitErrorsAction
@@ -87,10 +84,6 @@ function removeBranch(state: FormBranchesState, { idx }: RemoveBranchAction) {
     ],
   };
 }
-
-type RemoveFeatureConfigAction = {
-  type: "removeFeatureConfig";
-};
 
 function removeFeatureConfig(state: FormBranchesState) {
   let { referenceBranch, treatmentBranches } = state;

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/reducer/index.test.ts
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/reducer/index.test.ts
@@ -177,29 +177,6 @@ describe("formBranchesReducer", () => {
     );
   });
 
-  describe("removeFeatureConfig", () => {
-    it(
-      "disables any enabled features in branches when the config is cleared",
-      commonClearFeatureConfigTest({
-        type: "removeFeatureConfig",
-      }),
-    );
-
-    it("works without error when no branches are defined", () => {
-      const oldState = {
-        ...MOCK_STATE,
-        referenceBranch: null,
-        treatmentBranches: null,
-      };
-
-      const newState = formBranchesActionReducer(oldState, {
-        type: "removeFeatureConfig",
-      });
-
-      expect(newState.featureConfig).toBeNull();
-    });
-  });
-
   describe("setSubmitErrors", () => {
     const submitErrors = {
       "*": ["This is bad"],

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/index.stories.tsx
@@ -6,6 +6,7 @@ import { withLinks } from "@storybook/addon-links";
 import { withQuery } from "@storybook/addon-queryparams";
 import React from "react";
 import PageEditBranches from ".";
+import { SERVER_ERRORS } from "../../lib/constants";
 import { mockExperimentQuery } from "../../lib/mocks";
 import { RouterSlugProvider } from "../../lib/test-utils";
 import { getExperiment_experimentBySlug } from "../../types/getExperiment";
@@ -70,6 +71,7 @@ export const MissingFields = () =>
     readyForReview: {
       ready: false,
       message: {
+        feature_config: [SERVER_ERRORS.FEATURE_CONFIG],
         reference_branch: {
           name: ["Drop a heart", "and break a name"],
           description: [

--- a/app/experimenter/nimbus-ui/src/hooks/useCommonForm/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/hooks/useCommonForm/index.test.tsx
@@ -172,8 +172,10 @@ describe("hooks/useCommonForm", () => {
 
       branchFieldNames.forEach((name) => {
         const fieldName = `referenceBranch.${name}`;
-        // all branch field names call `formControlAttrs`
-        expect(screen.queryByTestId(fieldName)).toBeInTheDocument();
+        // all branch field names call `formControlAttrs` except for featureConfig
+        if (name !== "featureConfig") {
+          expect(screen.queryByTestId(fieldName)).toBeInTheDocument();
+        }
 
         // featureValue must be "enabled" to show the submit error
         if (name === "featureValue") {

--- a/app/experimenter/nimbus-ui/src/lib/constants.ts
+++ b/app/experimenter/nimbus-ui/src/lib/constants.ts
@@ -16,6 +16,7 @@ export const SERVER_ERRORS = {
   NULL_FIELD: "This field may not be null.",
   EMPTY_LIST: "This list may not be empty.",
   BLANK_DESCRIPTION: "Description may not be blank.",
+  FEATURE_CONFIG: "You must select a feature configuration from the drop down.",
 };
 
 export const EXTERNAL_URLS = {

--- a/app/experimenter/nimbus-ui/src/styles/index.scss
+++ b/app/experimenter/nimbus-ui/src/styles/index.scss
@@ -62,6 +62,11 @@ $form-validation-states: map-merge(
   border: 1px solid $form-feedback-warning-color !important;
 }
 
+// This scoots the warning img to the left to prevent overlap with the drop-down caret
+select.form-control.is-warning {
+  background-position: right 1em center;
+}
+
 .font-weight-semibold {
   font-weight: 600;
 }

--- a/app/tests/integration/nimbus/pages/branches.py
+++ b/app/tests/integration/nimbus/pages/branches.py
@@ -1,6 +1,7 @@
 from nimbus.pages.base import Base
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as EC
+from selenium.webdriver.support.select import Select
 
 
 class BranchesPage(Base):
@@ -12,7 +13,7 @@ class BranchesPage(Base):
         "#referenceBranch-description",
     )
     _remove_branch_locator = (By.CSS_SELECTOR, ".bg-transparent")
-    _add_feature_locator = (By.CSS_SELECTOR, ".feature-config-add")
+    _feature_select_locator = (By.CSS_SELECTOR, "#referenceBranch-featureConfig")
     _page_wait_locator = (By.CSS_SELECTOR, "#PageEditBranches")
     _save_continue_btn_locator = (By.CSS_SELECTOR, "#save-and-continue-button")
 
@@ -50,6 +51,12 @@ class BranchesPage(Base):
         el = self.find_element(*self._remove_branch_locator)
         el.click()
 
-    def select_feature(self):
-        el = self.find_element(*self._add_feature_locator)
-        el.click()
+    @property
+    def feature_config(self):
+        return self.find_element(*self._feature_select_locator).text
+
+    @feature_config.setter
+    def feature_config(self, feature_config="No Feature Firefox Desktop"):
+        el = self.find_element(*self._feature_select_locator)
+        select = Select(el)
+        select.select_by_visible_text(feature_config)

--- a/app/tests/integration/nimbus/test_e2e_create_experiment.py
+++ b/app/tests/integration/nimbus/test_e2e_create_experiment.py
@@ -25,7 +25,7 @@ def test_create_new_experiment(selenium, base_url):
     branches.remove_branch()
     branches.reference_branch_name = "name 1"
     branches.reference_branch_description = "a nice experiment"
-    branches.select_feature()
+    branches.feature_config = "No Feature Firefox Desktop"
 
     # Fill Metrics page
     metrics = branches.save_and_continue()


### PR DESCRIPTION
closes #5103

Because:
* We want to display the feature config ready for review error
* Since feature configs are now required, we no longer want "+ Feature config" and "X" for removal

This commit:
* Displays feature config review readiness error in reference branch
* Displays feature config review readiness error in treatment branch if that branch has previously been saved or shows other errors
* Removes the "+ Feature configuration" button, "X" removal, and related UI elements/tests to always show this drawer as open
* Adds missing label for feature config