### PR TITLE
fix #5340 bug(nimbus): test_404 fails in make bash pytest but passes in make check

### DIFF
--- a/app/experimenter/experiments/tests/test_views.py
+++ b/app/experimenter/experiments/tests/test_views.py
@@ -787,6 +787,11 @@ class TestNimbusUIView(TestCase):
 class Test404View(TestCase):
     def test_404(self):
         user_email = "user@example.com"
-        response = self.client.get("/404", **{settings.OPENIDC_EMAIL_HEADER: user_email})
+        response = self.client.get(
+            # test path should be a string that doesn't match any existing url patterns
+            # or django will attempt to 301 and append a slash before 404ing
+            "/invalid/",
+            **{settings.OPENIDC_EMAIL_HEADER: user_email},
+        )
         self.assertTemplateUsed(response, "nimbus/404.html")
         self.assertEqual(response.status_code, 404)


### PR DESCRIPTION


Because

* We noticed test_404 was failing locally in make bash pytest but passing in make check
* It's passing in manage.py test in either context
* So what is happening?

This commit
* Figured out that pytest and django both set DEBUG=False when running tests, overriding whatever your local DEBUG is set to
* But they do it differently, django sets it globally from startup, whereas pytest will use the environment DEBUG and only set it to False within individual test runs
* We have a urlpattern for /404/ when DEBUG is True
* When pytest starts on a local environment with DEBUG=True, that path will get registered
* If /404/ is a registered path then attempting to resolve /404 will trigger a redirect to append the slash to hit /404/ which happens when pytest is run in an environment with DEBUG=True in .env
* If /404/ is NOT a registered path, ie when DEBUG is globally False or when using manage.py test, then /404 will result in an expected 404
* Woof.