### PR TITLE
fix #5351 bug(nimbus): paused experiments are stuck in waiting

### DIFF
--- a/app/experimenter/experiments/constants/nimbus.py
+++ b/app/experimenter/experiments/constants/nimbus.py
@@ -234,12 +234,17 @@ class LifecycleStates(Enum):
         "status": Status.LIVE,
         "publish_status": PublishStatus.IDLE,
     }
-    PAUSE_CANDIDATE = {
+    LIVE_IDLE_ENROLLING = {
         "status": Status.LIVE,
         "publish_status": PublishStatus.IDLE,
         "is_paused": False,
     }
-    PAUSED = {
+    LIVE_WAITING_ENROLLING = {
+        "status": Status.LIVE,
+        "publish_status": PublishStatus.WAITING,
+        "is_paused": False,
+    }
+    LIVE_IDLE_PAUSED = {
         "status": Status.LIVE,
         "publish_status": PublishStatus.IDLE,
         "is_paused": True,
@@ -264,7 +269,7 @@ class LifecycleStates(Enum):
         "publish_status": PublishStatus.WAITING,
         "is_end_requested": True,
     }
-    COMPLETE_IDLE_ENDED = {
+    COMPLETE_IDLE = {
         "status": Status.COMPLETE,
         "publish_status": PublishStatus.IDLE,
         "is_end_requested": True,
@@ -279,18 +284,16 @@ class Lifecycles(Enum):
     LAUNCH_APPROVE = LAUNCH_REVIEW_REQUESTED + (LifecycleStates.DRAFT_APPROVED,)
     LAUNCH_APPROVE_WAITING = LAUNCH_APPROVE + (LifecycleStates.DRAFT_WAITING,)
     LAUNCH_APPROVE_APPROVE = LAUNCH_APPROVE_WAITING + (LifecycleStates.LIVE_IDLE,)
-    LAUNCH_APPROVE_REJECT = LAUNCH_APPROVE_WAITING + (LifecycleStates.DRAFT_IDLE,)
     LAUNCH_APPROVE_TIMEOUT = LAUNCH_APPROVE_WAITING + (LifecycleStates.DRAFT_REVIEW,)
-    PAUSED = LAUNCH_APPROVE_APPROVE + (LifecycleStates.PAUSED,)
+    LIVE_ENROLLING = LAUNCH_APPROVE_APPROVE + (LifecycleStates.LIVE_IDLE_ENROLLING,)
+    LIVE_ENROLLING_WAITING = LIVE_ENROLLING + (LifecycleStates.LIVE_WAITING_ENROLLING,)
+    LIVE_PAUSED = LIVE_ENROLLING + (LifecycleStates.LIVE_IDLE_PAUSED,)
     ENDING_REVIEW_REQUESTED = LAUNCH_APPROVE_APPROVE + (
         LifecycleStates.LIVE_REVIEW_ENDING,
     )
-    ENDING_REJECT = ENDING_REVIEW_REQUESTED + (LifecycleStates.LIVE_IDLE_REJECT_ENDING,)
     ENDING_APPROVE = ENDING_REVIEW_REQUESTED + (LifecycleStates.LIVE_APPROVED_ENDING,)
     ENDING_APPROVE_WAITING = ENDING_APPROVE + (LifecycleStates.LIVE_WAITING_ENDING,)
-    ENDING_APPROVE_APPROVE = ENDING_APPROVE_WAITING + (
-        LifecycleStates.COMPLETE_IDLE_ENDED,
-    )
+    ENDING_APPROVE_APPROVE = ENDING_APPROVE_WAITING + (LifecycleStates.COMPLETE_IDLE,)
     ENDING_APPROVE_REJECT = ENDING_APPROVE_WAITING + (
         LifecycleStates.LIVE_IDLE_REJECT_ENDING,
     )

--- a/app/experimenter/experiments/tests/test_models/test_models_nimbus.py
+++ b/app/experimenter/experiments/tests/test_models/test_models_nimbus.py
@@ -148,7 +148,27 @@ class TestNimbusExperimentManager(TestCase):
         )
 
         self.assertEqual(
-            list(NimbusExperiment.objects.waiting_to_launch_queue()), [launching]
+            list(
+                NimbusExperiment.objects.waiting_to_launch_queue([launching.application])
+            ),
+            [launching],
+        )
+
+    def test_waiting_to_pause_only_returns_pausing_experiments(self):
+        pausing = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperiment.Lifecycles.LIVE_ENROLLING_WAITING
+        )
+        NimbusExperimentFactory.create_with_lifecycle(NimbusExperiment.Lifecycles.CREATED)
+        NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperiment.Lifecycles.LAUNCH_APPROVE_APPROVE
+        )
+        NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperiment.Lifecycles.ENDING_APPROVE_WAITING,
+        )
+
+        self.assertEqual(
+            list(NimbusExperiment.objects.waiting_to_pause_queue([pausing.application])),
+            [pausing],
         )
 
 

--- a/app/experimenter/kinto/tests/test_tasks.py
+++ b/app/experimenter/kinto/tests/test_tasks.py
@@ -628,7 +628,7 @@ class TestNimbusCheckExperimentsArePaused(MockKintoClientMixin, TestCase):
 
     def test_updates_unpaused_experiment_with_isEnrollmentPaused_true(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.LAUNCH_APPROVE_APPROVE,
+            NimbusExperiment.Lifecycles.LIVE_ENROLLING_WAITING,
             application=NimbusExperiment.Application.DESKTOP,
         )
         changes_count = experiment.changes.count()
@@ -649,7 +649,7 @@ class TestNimbusCheckExperimentsArePaused(MockKintoClientMixin, TestCase):
 
     def test_ignores_paused_experiment_with_isEnrollmentPaused_true(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.PAUSED,
+            NimbusExperiment.Lifecycles.LIVE_PAUSED,
             application=NimbusExperiment.Application.DESKTOP,
         )
         changes_count = experiment.changes.count()


### PR DESCRIPTION
Because

* We recently refactored everything to use these handy declarative lifecycles
* We accidentally used the wrong one when considering experiments to update their pause state

This commit

* Renames some of the lifecycles to be more consistent
* Adds the necessary lifecycle for experiments waiting to be paused
* Updates tasks/tests