### PR TITLE
fix #5353 chore(nimbus): split lifecycles and filters

### DIFF
--- a/app/experimenter/base/management/commands/load_dummy_experiments.py
+++ b/app/experimenter/base/management/commands/load_dummy_experiments.py
@@ -4,7 +4,6 @@ import random
 from django.core.management.base import BaseCommand
 
 from experimenter.experiments.models import Experiment
-from experimenter.experiments.models.nimbus import NimbusExperiment
 from experimenter.experiments.tests.factories import (
     ExperimentFactory,
     NimbusExperimentFactory,
@@ -22,6 +21,6 @@ class Command(BaseCommand):
             experiment = ExperimentFactory.create_with_status(status, type=random_type)
             logger.info("Created {}: {}".format(experiment, status))
 
-        for lifecycle in NimbusExperiment.Lifecycles:
+        for lifecycle in NimbusExperimentFactory.Lifecycles:
             experiment = NimbusExperimentFactory.create_with_lifecycle(lifecycle)
             logger.info("Created {}: {}".format(experiment, lifecycle))

--- a/app/experimenter/base/tests/test_initial_data.py
+++ b/app/experimenter/base/tests/test_initial_data.py
@@ -2,6 +2,7 @@ from django.core.management import call_command
 from django.test import TestCase
 
 from experimenter.experiments.models import Experiment, NimbusExperiment
+from experimenter.experiments.tests.factories import NimbusExperimentFactory
 
 
 class TestInitialData(TestCase):
@@ -13,7 +14,7 @@ class TestInitialData(TestCase):
         for status, _ in Experiment.STATUS_CHOICES:
             self.assertTrue(Experiment.objects.filter(status=status).exists())
 
-        for lifecycle in NimbusExperiment.Lifecycles:
+        for lifecycle in NimbusExperimentFactory.Lifecycles:
             states = lifecycle.value
             final_state = states[-1].value
             self.assertTrue(NimbusExperiment.objects.filter(**final_state).exists())

--- a/app/experimenter/experiments/constants/nimbus.py
+++ b/app/experimenter/experiments/constants/nimbus.py
@@ -1,5 +1,4 @@
 from dataclasses import dataclass
-from enum import Enum
 from typing import Dict
 
 from django.conf import settings
@@ -195,118 +194,19 @@ TARGETING_URLBAR_FIREFOX_SUGGEST = NimbusTargetingConfig(
 )
 
 
-class Status(models.TextChoices):
-    DRAFT = "Draft"
-    PREVIEW = "Preview"
-    LIVE = "Live"
-    COMPLETE = "Complete"
-
-
-class PublishStatus(models.TextChoices):
-    IDLE = "Idle"
-    REVIEW = "Review"
-    APPROVED = "Approved"
-    WAITING = "Waiting"
-
-
-class LifecycleStates(Enum):
-    DRAFT_IDLE = {
-        "status": Status.DRAFT,
-        "publish_status": PublishStatus.IDLE,
-    }
-    PREVIEW_IDLE = {
-        "status": Status.PREVIEW,
-        "publish_status": PublishStatus.IDLE,
-    }
-    DRAFT_REVIEW = {
-        "status": Status.DRAFT,
-        "publish_status": PublishStatus.REVIEW,
-    }
-    DRAFT_APPROVED = {
-        "status": Status.DRAFT,
-        "publish_status": PublishStatus.APPROVED,
-    }
-    DRAFT_WAITING = {
-        "status": Status.DRAFT,
-        "publish_status": PublishStatus.WAITING,
-    }
-    LIVE_IDLE = {
-        "status": Status.LIVE,
-        "publish_status": PublishStatus.IDLE,
-    }
-    LIVE_IDLE_ENROLLING = {
-        "status": Status.LIVE,
-        "publish_status": PublishStatus.IDLE,
-        "is_paused": False,
-    }
-    LIVE_WAITING_ENROLLING = {
-        "status": Status.LIVE,
-        "publish_status": PublishStatus.WAITING,
-        "is_paused": False,
-    }
-    LIVE_IDLE_PAUSED = {
-        "status": Status.LIVE,
-        "publish_status": PublishStatus.IDLE,
-        "is_paused": True,
-    }
-    LIVE_REVIEW_ENDING = {
-        "status": Status.LIVE,
-        "publish_status": PublishStatus.REVIEW,
-        "is_end_requested": True,
-    }
-    LIVE_IDLE_REJECT_ENDING = {
-        "status": Status.LIVE,
-        "publish_status": PublishStatus.IDLE,
-        "is_end_requested": False,
-    }
-    LIVE_APPROVED_ENDING = {
-        "status": Status.LIVE,
-        "publish_status": PublishStatus.APPROVED,
-        "is_end_requested": True,
-    }
-    LIVE_WAITING_ENDING = {
-        "status": Status.LIVE,
-        "publish_status": PublishStatus.WAITING,
-        "is_end_requested": True,
-    }
-    COMPLETE_IDLE = {
-        "status": Status.COMPLETE,
-        "publish_status": PublishStatus.IDLE,
-        "is_end_requested": True,
-    }
-
-
-class Lifecycles(Enum):
-    CREATED = (LifecycleStates.DRAFT_IDLE,)
-    PREVIEW = CREATED + (LifecycleStates.PREVIEW_IDLE,)
-    LAUNCH_REVIEW_REQUESTED = CREATED + (LifecycleStates.DRAFT_REVIEW,)
-    LAUNCH_REJECT = LAUNCH_REVIEW_REQUESTED + (LifecycleStates.DRAFT_IDLE,)
-    LAUNCH_APPROVE = LAUNCH_REVIEW_REQUESTED + (LifecycleStates.DRAFT_APPROVED,)
-    LAUNCH_APPROVE_WAITING = LAUNCH_APPROVE + (LifecycleStates.DRAFT_WAITING,)
-    LAUNCH_APPROVE_APPROVE = LAUNCH_APPROVE_WAITING + (LifecycleStates.LIVE_IDLE,)
-    LAUNCH_APPROVE_TIMEOUT = LAUNCH_APPROVE_WAITING + (LifecycleStates.DRAFT_REVIEW,)
-    LIVE_ENROLLING = LAUNCH_APPROVE_APPROVE + (LifecycleStates.LIVE_IDLE_ENROLLING,)
-    LIVE_ENROLLING_WAITING = LIVE_ENROLLING + (LifecycleStates.LIVE_WAITING_ENROLLING,)
-    LIVE_PAUSED = LIVE_ENROLLING + (LifecycleStates.LIVE_IDLE_PAUSED,)
-    ENDING_REVIEW_REQUESTED = LAUNCH_APPROVE_APPROVE + (
-        LifecycleStates.LIVE_REVIEW_ENDING,
-    )
-    ENDING_APPROVE = ENDING_REVIEW_REQUESTED + (LifecycleStates.LIVE_APPROVED_ENDING,)
-    ENDING_APPROVE_WAITING = ENDING_APPROVE + (LifecycleStates.LIVE_WAITING_ENDING,)
-    ENDING_APPROVE_APPROVE = ENDING_APPROVE_WAITING + (LifecycleStates.COMPLETE_IDLE,)
-    ENDING_APPROVE_REJECT = ENDING_APPROVE_WAITING + (
-        LifecycleStates.LIVE_IDLE_REJECT_ENDING,
-    )
-    ENDING_APPROVE_TIMEOUT = ENDING_APPROVE_WAITING + (
-        LifecycleStates.LIVE_REVIEW_ENDING,
-    )
-
-
 class NimbusConstants(object):
-    Status = Status
-    PublishStatus = PublishStatus
-    LifecycleStates = LifecycleStates
-    Lifecycles = Lifecycles
+    class Status(models.TextChoices):
+        DRAFT = "Draft"
+        PREVIEW = "Preview"
+        LIVE = "Live"
+        COMPLETE = "Complete"
+
+    class PublishStatus(models.TextChoices):
+        IDLE = "Idle"
+        REVIEW = "Review"
+        APPROVED = "Approved"
+        WAITING = "Waiting"
+
     Application = Application
 
     VALID_STATUS_TRANSITIONS = {

--- a/app/experimenter/experiments/models/nimbus.py
+++ b/app/experimenter/experiments/models/nimbus.py
@@ -137,12 +137,34 @@ class NimbusExperiment(NimbusConstants, FilterMixin, models.Model):
         verbose_name_plural = "Nimbus Experiments"
 
     class Filters:
-        IS_LAUNCH_QUEUED = Q(**NimbusConstants.LifecycleStates.DRAFT_APPROVED.value)
-        IS_LAUNCHING = Q(**NimbusConstants.LifecycleStates.DRAFT_WAITING.value)
-        IS_PAUSE_QUEUED = Q(**NimbusConstants.LifecycleStates.LIVE_IDLE_ENROLLING.value)
-        IS_PAUSING = Q(**NimbusConstants.LifecycleStates.LIVE_WAITING_ENROLLING.value)
-        IS_END_QUEUED = Q(**NimbusConstants.LifecycleStates.LIVE_APPROVED_ENDING.value)
-        IS_ENDING = Q(**NimbusConstants.LifecycleStates.LIVE_WAITING_ENDING.value)
+        IS_LAUNCH_QUEUED = Q(
+            status=NimbusConstants.Status.DRAFT,
+            publish_status=NimbusConstants.PublishStatus.APPROVED,
+        )
+        IS_LAUNCHING = Q(
+            status=NimbusConstants.Status.DRAFT,
+            publish_status=NimbusConstants.PublishStatus.WAITING,
+        )
+        IS_PAUSE_QUEUED = Q(
+            status=NimbusConstants.Status.LIVE,
+            publish_status=NimbusConstants.PublishStatus.IDLE,
+            is_paused=False,
+        )
+        IS_PAUSING = Q(
+            status=NimbusConstants.Status.LIVE,
+            publish_status=NimbusConstants.PublishStatus.WAITING,
+            is_paused=False,
+        )
+        IS_END_QUEUED = Q(
+            status=NimbusConstants.Status.LIVE,
+            publish_status=NimbusConstants.PublishStatus.APPROVED,
+            is_end_requested=True,
+        )
+        IS_ENDING = Q(
+            status=NimbusConstants.Status.LIVE,
+            publish_status=NimbusConstants.PublishStatus.WAITING,
+            is_end_requested=True,
+        )
         SHOULD_TIMEOUT = Q(IS_LAUNCHING | IS_ENDING)
         SHOULD_ALLOCATE_BUCKETS = Q(
             Q(status=NimbusConstants.Status.PREVIEW)

--- a/app/experimenter/experiments/tests/api/v5/test_mutations.py
+++ b/app/experimenter/experiments/tests/api/v5/test_mutations.py
@@ -219,7 +219,7 @@ class TestMutations(GraphQLTestCase):
     def test_does_not_delete_branches_when_other_fields_specified(self):
         user_email = "user@example.com"
         experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.CREATED
+            NimbusExperimentFactory.Lifecycles.CREATED
         )
         branch_count = experiment.branches.count()
         response = self.query(
@@ -246,7 +246,7 @@ class TestMutations(GraphQLTestCase):
     def test_does_not_clear_feature_config_when_other_fields_specified(self):
         user_email = "user@example.com"
         experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.CREATED
+            NimbusExperimentFactory.Lifecycles.CREATED
         )
         expected_feature_config = experiment.feature_config
 
@@ -534,7 +534,7 @@ class TestMutations(GraphQLTestCase):
     def test_reject_draft_experiment(self):
         user_email = "user@example.com"
         experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.LAUNCH_REVIEW_REQUESTED
+            NimbusExperimentFactory.Lifecycles.LAUNCH_REVIEW_REQUESTED
         )
         response = self.query(
             UPDATE_EXPERIMENT_MUTATION,
@@ -558,7 +558,7 @@ class TestMutations(GraphQLTestCase):
     def test_reject_ending_experiment(self):
         user_email = "user@example.com"
         experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.ENDING_REVIEW_REQUESTED
+            NimbusExperimentFactory.Lifecycles.ENDING_REVIEW_REQUESTED
         )
         response = self.query(
             UPDATE_EXPERIMENT_MUTATION,

--- a/app/experimenter/experiments/tests/api/v5/test_queries.py
+++ b/app/experimenter/experiments/tests/api/v5/test_queries.py
@@ -19,7 +19,7 @@ class TestNimbusQuery(GraphQLTestCase):
     def test_experiments(self):
         user_email = "user@example.com"
         experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.CREATED
+            NimbusExperimentFactory.Lifecycles.CREATED
         )
 
         response = self.query(
@@ -47,7 +47,7 @@ class TestNimbusQuery(GraphQLTestCase):
     def test_experiments_with_no_branches_returns_empty_treatment_values(self):
         user_email = "user@example.com"
         NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.CREATED, branches=[]
+            NimbusExperimentFactory.Lifecycles.CREATED, branches=[]
         )
 
         response = self.query(
@@ -76,7 +76,7 @@ class TestNimbusQuery(GraphQLTestCase):
     def test_experiments_with_branches_returns_branch_data(self):
         user_email = "user@example.com"
         experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.CREATED
+            NimbusExperimentFactory.Lifecycles.CREATED
         )
 
         response = self.query(
@@ -109,7 +109,7 @@ class TestNimbusQuery(GraphQLTestCase):
     def test_experiments_with_documentation_links_return_link_data(self):
         user_email = "user@example.com"
         experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.CREATED
+            NimbusExperimentFactory.Lifecycles.CREATED
         )
         documentation_links = experiment.documentation_links.all()
         self.assert_(len(documentation_links) > 0)
@@ -166,7 +166,7 @@ class TestNimbusQuery(GraphQLTestCase):
     def test_experiment_by_slug_ready_for_review(self):
         user_email = "user@example.com"
         experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.CREATED
+            NimbusExperimentFactory.Lifecycles.CREATED
         )
 
         response = self.query(
@@ -201,7 +201,7 @@ class TestNimbusQuery(GraphQLTestCase):
     def test_experiment_by_slug_not_ready_for_review(self):
         user_email = "user@example.com"
         experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.CREATED,
+            NimbusExperimentFactory.Lifecycles.CREATED,
             hypothesis=NimbusExperiment.HYPOTHESIS_DEFAULT,
         )
 
@@ -232,7 +232,9 @@ class TestNimbusQuery(GraphQLTestCase):
 
     def test_experiment_by_slug_not_found(self):
         user_email = "user@example.com"
-        NimbusExperimentFactory.create_with_lifecycle(NimbusExperiment.Lifecycles.CREATED)
+        NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED
+        )
 
         response = self.query(
             """
@@ -255,7 +257,7 @@ class TestNimbusQuery(GraphQLTestCase):
     def test_experiment_jexl_targeting_expression(self):
         user_email = "user@example.com"
         experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.CREATED,
+            NimbusExperimentFactory.Lifecycles.CREATED,
             targeting_config_slug=NimbusExperiment.TargetingConfig.ALL_ENGLISH,
             application=NimbusExperiment.Application.DESKTOP,
         )
@@ -278,7 +280,7 @@ class TestNimbusQuery(GraphQLTestCase):
     def test_experiment_no_jexl_targeting_expression(self):
         user_email = "user@example.com"
         experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.CREATED,
+            NimbusExperimentFactory.Lifecycles.CREATED,
             targeting_config_slug="",
             application=NimbusExperiment.Application.FENIX,
         )
@@ -304,7 +306,7 @@ class TestNimbusQuery(GraphQLTestCase):
     def test_experiment_computed_end_date_proposed(self):
         user_email = "user@example.com"
         experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.LAUNCH_APPROVE_APPROVE,
+            NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE_APPROVE,
             proposed_duration=10,
         )
         response = self.query(
@@ -329,7 +331,7 @@ class TestNimbusQuery(GraphQLTestCase):
     def test_experiment_computed_end_date_actual(self):
         user_email = "user@example.com"
         experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.ENDING_APPROVE_APPROVE
+            NimbusExperimentFactory.Lifecycles.ENDING_APPROVE_APPROVE
         )
         response = self.query(
             """
@@ -353,7 +355,7 @@ class TestNimbusQuery(GraphQLTestCase):
     def test_experiment_in_review_can_review(self):
         user_email = "user@example.com"
         experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.LAUNCH_REVIEW_REQUESTED
+            NimbusExperimentFactory.Lifecycles.LAUNCH_REVIEW_REQUESTED
         )
         response = self.query(
             """
@@ -374,7 +376,7 @@ class TestNimbusQuery(GraphQLTestCase):
     def test_experiment_no_rejection_data(self):
         user_email = "user@example.com"
         experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.CREATED
+            NimbusExperimentFactory.Lifecycles.CREATED
         )
 
         response = self.query(
@@ -400,7 +402,7 @@ class TestNimbusQuery(GraphQLTestCase):
     def test_experiment_with_rejection(self):
         user_email = "user@example.com"
         experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.LAUNCH_REJECT
+            NimbusExperimentFactory.Lifecycles.LAUNCH_REJECT
         )
         response = self.query(
             """
@@ -427,7 +429,7 @@ class TestNimbusQuery(GraphQLTestCase):
     def test_experiment_no_review_request_data(self):
         user_email = "user@example.com"
         experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.CREATED
+            NimbusExperimentFactory.Lifecycles.CREATED
         )
 
         response = self.query(
@@ -453,7 +455,7 @@ class TestNimbusQuery(GraphQLTestCase):
     def test_experiment_with_review_request(self):
         user_email = "user@example.com"
         experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.LAUNCH_REVIEW_REQUESTED
+            NimbusExperimentFactory.Lifecycles.LAUNCH_REVIEW_REQUESTED
         )
         response = self.query(
             """
@@ -480,7 +482,7 @@ class TestNimbusQuery(GraphQLTestCase):
     def test_experiment_without_timeout_returns_none(self):
         user_email = "user@example.com"
         experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.LAUNCH_APPROVE_WAITING
+            NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE_WAITING
         )
         response = self.query(
             """
@@ -505,7 +507,7 @@ class TestNimbusQuery(GraphQLTestCase):
     def test_experiment_with_timeout_returns_changelog(self):
         user_email = "user@example.com"
         experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.LAUNCH_APPROVE_TIMEOUT
+            NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE_TIMEOUT
         )
         response = self.query(
             """
@@ -532,7 +534,7 @@ class TestNimbusQuery(GraphQLTestCase):
     def test_recipe_json_returns_serialized_data(self):
         user_email = "user@example.com"
         experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.CREATED
+            NimbusExperimentFactory.Lifecycles.CREATED
         )
         response = self.query(
             """
@@ -665,7 +667,7 @@ class TestNimbusQuery(GraphQLTestCase):
     def test_paused_experiment_returns_date(self):
         user_email = "user@example.com"
         experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.LAUNCH_APPROVE_APPROVE,
+            NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE_APPROVE,
             is_paused=True,
             proposed_enrollment=7,
         )
@@ -697,7 +699,7 @@ class TestNimbusQuery(GraphQLTestCase):
     def test_signoff_recommendations(self):
         user_email = "user@example.com"
         experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.CREATED,
+            NimbusExperimentFactory.Lifecycles.CREATED,
             risk_brand=True,
             risk_revenue=True,
             risk_partner_related=True,

--- a/app/experimenter/experiments/tests/api/v5/test_serializers.py
+++ b/app/experimenter/experiments/tests/api/v5/test_serializers.py
@@ -101,7 +101,7 @@ class TestCreateNimbusExperimentOverviewSerializer(TestCase):
 
     def test_serializer_returns_error_for_non_unique_slug(self):
         NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.CREATED,
+            NimbusExperimentFactory.Lifecycles.CREATED,
             name="non unique slug",
             slug="non-unique-slug",
         )
@@ -157,7 +157,7 @@ class TestCreateNimbusExperimentOverviewSerializer(TestCase):
 
     def test_saves_existing_experiment_with_changelog(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.CREATED,
+            NimbusExperimentFactory.Lifecycles.CREATED,
             application=NimbusExperiment.Application.FENIX,
             hypothesis="Existing hypothesis",
             name="Existing Name",
@@ -613,7 +613,7 @@ class TestNimbusExperimentBranchMixin(TestCase):
             application=NimbusExperiment.Application.IOS, schema=self.BASIC_JSON_SCHEMA
         )
         experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.CREATED,
+            NimbusExperimentFactory.Lifecycles.CREATED,
             application=NimbusExperiment.Application.FENIX,
         )
         reference_branch = {
@@ -659,7 +659,7 @@ class TestNimbusExperimentBranchMixin(TestCase):
 
     def test_does_not_delete_branches_when_other_fields_specified(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.CREATED,
+            NimbusExperimentFactory.Lifecycles.CREATED,
         )
         branch_count = experiment.branches.count()
 
@@ -750,7 +750,7 @@ class TestNimbusExperimentSerializer(TestCase):
 
     def test_allows_empty_values_for_all_fields_existing_experiment(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.CREATED,
+            NimbusExperimentFactory.Lifecycles.CREATED,
         )
         data = {
             "name": "",
@@ -838,7 +838,7 @@ class TestNimbusExperimentSerializer(TestCase):
 
     def test_serializer_returns_error_for_non_unique_slug(self):
         NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.CREATED,
+            NimbusExperimentFactory.Lifecycles.CREATED,
             name="non unique slug",
             slug="non-unique-slug",
         )
@@ -894,7 +894,7 @@ class TestNimbusExperimentSerializer(TestCase):
 
     def test_saves_existing_experiment_with_changelog(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.CREATED,
+            NimbusExperimentFactory.Lifecycles.CREATED,
             application=NimbusExperiment.Application.FENIX,
             hypothesis="Existing hypothesis",
             name="Existing Name",
@@ -1057,7 +1057,7 @@ class TestNimbusExperimentSerializer(TestCase):
 
     def test_status_generates_bucket_allocation(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.CREATED, population_percent=Decimal("50.0")
+            NimbusExperimentFactory.Lifecycles.CREATED, population_percent=Decimal("50.0")
         )
 
         self.assertFalse(NimbusBucketRange.objects.filter(experiment=experiment).exists())
@@ -1079,7 +1079,7 @@ class TestNimbusExperimentSerializer(TestCase):
 
     def test_publish_status_generates_bucket_allocation(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.CREATED,
+            NimbusExperimentFactory.Lifecycles.CREATED,
             population_percent=Decimal("50.0"),
         )
 
@@ -1106,8 +1106,8 @@ class TestNimbusExperimentSerializer(TestCase):
 
     @parameterized.expand(
         [
-            [NimbusExperiment.Lifecycles.CREATED, NimbusExperiment.Status.PREVIEW],
-            [NimbusExperiment.Lifecycles.PREVIEW, NimbusExperiment.Status.DRAFT],
+            [NimbusExperimentFactory.Lifecycles.CREATED, NimbusExperiment.Status.PREVIEW],
+            [NimbusExperimentFactory.Lifecycles.PREVIEW, NimbusExperiment.Status.DRAFT],
         ]
     )
     def test_preview_draft_transition_invokes_kinto_task(
@@ -1133,7 +1133,7 @@ class TestNimbusExperimentSerializer(TestCase):
 
     def test_set_status_already_draft_doesnt_invoke_kinto_task(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.CREATED, population_percent=Decimal("50.0")
+            NimbusExperimentFactory.Lifecycles.CREATED, population_percent=Decimal("50.0")
         )
 
         serializer = NimbusExperimentSerializer(
@@ -1152,7 +1152,7 @@ class TestNimbusExperimentSerializer(TestCase):
 
     def test_serializer_updates_outcomes_on_experiment(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.CREATED,
+            NimbusExperimentFactory.Lifecycles.CREATED,
             application=NimbusExperiment.Application.DESKTOP,
             primary_outcomes=[],
             secondary_outcomes=[],
@@ -1181,7 +1181,7 @@ class TestNimbusExperimentSerializer(TestCase):
 
     def test_serializer_rejects_invalid_outcome_slugs(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.CREATED,
+            NimbusExperimentFactory.Lifecycles.CREATED,
             application=NimbusExperiment.Application.DESKTOP,
             primary_outcomes=[],
             secondary_outcomes=[],
@@ -1202,7 +1202,7 @@ class TestNimbusExperimentSerializer(TestCase):
 
     def test_serializer_rejects_outcomes_for_wrong_application(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.CREATED,
+            NimbusExperimentFactory.Lifecycles.CREATED,
             application=NimbusExperiment.Application.FENIX,
             primary_outcomes=[],
             secondary_outcomes=[],
@@ -1229,7 +1229,7 @@ class TestNimbusExperimentSerializer(TestCase):
 
     def test_serializer_rejects_duplicate_outcomes(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.CREATED,
+            NimbusExperimentFactory.Lifecycles.CREATED,
             application=NimbusExperiment.Application.DESKTOP,
             primary_outcomes=[],
             secondary_outcomes=[],
@@ -1258,7 +1258,7 @@ class TestNimbusExperimentSerializer(TestCase):
         NimbusConstants.MAX_PRIMARY_OUTCOMES = 1
 
         experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.CREATED,
+            NimbusExperimentFactory.Lifecycles.CREATED,
             application=NimbusExperiment.Application.DESKTOP,
             primary_outcomes=[],
             secondary_outcomes=[],
@@ -1281,7 +1281,7 @@ class TestNimbusExperimentSerializer(TestCase):
 
     def test_can_request_review_from_preview(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.PREVIEW,
+            NimbusExperimentFactory.Lifecycles.PREVIEW,
         )
 
         serializer = NimbusExperimentSerializer(
@@ -1301,7 +1301,7 @@ class TestNimbusExperimentSerializer(TestCase):
 
     def test_can_review_for_non_requesting_user(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.LAUNCH_REVIEW_REQUESTED,
+            NimbusExperimentFactory.Lifecycles.LAUNCH_REVIEW_REQUESTED,
         )
 
         serializer = NimbusExperimentSerializer(
@@ -1321,7 +1321,7 @@ class TestNimbusExperimentSerializer(TestCase):
 
     def test_cant_review_for_requesting_user(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.CREATED,
+            NimbusExperimentFactory.Lifecycles.CREATED,
         )
 
         experiment.publish_status = NimbusExperiment.PublishStatus.REVIEW
@@ -1343,7 +1343,7 @@ class TestNimbusExperimentSerializer(TestCase):
 
     def test_can_review_for_requesting_user_when_idle(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.CREATED,
+            NimbusExperimentFactory.Lifecycles.CREATED,
         )
 
         serializer = NimbusExperimentSerializer(
@@ -1359,7 +1359,7 @@ class TestNimbusExperimentSerializer(TestCase):
 
     def test_can_update_publish_status_for_non_approved_state(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.CREATED,
+            NimbusExperimentFactory.Lifecycles.CREATED,
         )
 
         experiment.publish_status = NimbusExperiment.PublishStatus.REVIEW
@@ -1382,7 +1382,7 @@ class TestNimbusExperimentSerializer(TestCase):
 
     def test_targeting_config_for_correct_application(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.CREATED,
+            NimbusExperimentFactory.Lifecycles.CREATED,
             application=NimbusExperiment.Application.DESKTOP.value,
         )
         data = {
@@ -1400,7 +1400,7 @@ class TestNimbusExperimentSerializer(TestCase):
 
     def test_targeting_config_for_wrong_application(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.CREATED,
+            NimbusExperimentFactory.Lifecycles.CREATED,
             application=NimbusExperiment.Application.IOS.value,
         )
         data = {
@@ -1434,7 +1434,7 @@ class TestNimbusReadyForReviewSerializer(TestCase):
 
     def test_valid_experiment(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.CREATED,
+            NimbusExperimentFactory.Lifecycles.CREATED,
             application=NimbusExperiment.Application.DESKTOP.value,
             feature_config=NimbusFeatureConfigFactory(
                 application=NimbusExperiment.Application.DESKTOP.value
@@ -1452,7 +1452,7 @@ class TestNimbusReadyForReviewSerializer(TestCase):
 
     def test_invalid_experiment_default_hypothesis(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.CREATED,
+            NimbusExperimentFactory.Lifecycles.CREATED,
             application=NimbusExperiment.Application.DESKTOP.value,
             feature_config=NimbusFeatureConfigFactory(
                 application=NimbusExperiment.Application.DESKTOP.value
@@ -1476,7 +1476,7 @@ class TestNimbusReadyForReviewSerializer(TestCase):
 
     def test_invalid_experiment_requires_reference_branch(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.CREATED,
+            NimbusExperimentFactory.Lifecycles.CREATED,
             application=NimbusExperiment.Application.DESKTOP.value,
             feature_config=NimbusFeatureConfigFactory(
                 application=NimbusExperiment.Application.DESKTOP.value
@@ -1500,7 +1500,7 @@ class TestNimbusReadyForReviewSerializer(TestCase):
 
     def test_invalid_experiment_reference_branch_requires_description(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.CREATED,
+            NimbusExperimentFactory.Lifecycles.CREATED,
             application=NimbusExperiment.Application.DESKTOP.value,
             feature_config=NimbusFeatureConfigFactory(
                 application=NimbusExperiment.Application.DESKTOP.value
@@ -1524,7 +1524,7 @@ class TestNimbusReadyForReviewSerializer(TestCase):
 
     def test_invalid_experiment_requires_non_zero_population_percent(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.CREATED,
+            NimbusExperimentFactory.Lifecycles.CREATED,
             population_percent=0.0,
         )
         serializer = NimbusReadyForReviewSerializer(
@@ -1543,7 +1543,7 @@ class TestNimbusReadyForReviewSerializer(TestCase):
 
     def test_invalid_experiment_treatment_branch_requires_description(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.CREATED,
+            NimbusExperimentFactory.Lifecycles.CREATED,
             application=NimbusExperiment.Application.DESKTOP.value,
             feature_config=NimbusFeatureConfigFactory(
                 application=NimbusExperiment.Application.DESKTOP.value
@@ -1570,7 +1570,7 @@ class TestNimbusReadyForReviewSerializer(TestCase):
 
     def test_invalid_experiment_missing_feature_config(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.CREATED,
+            NimbusExperimentFactory.Lifecycles.CREATED,
             application=NimbusExperiment.Application.DESKTOP.value,
             feature_config=None,
         )
@@ -1590,7 +1590,7 @@ class TestNimbusReadyForReviewSerializer(TestCase):
 
     def test_invalid_experiment_risk_questions(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.CREATED,
+            NimbusExperimentFactory.Lifecycles.CREATED,
             risk_partner_related=None,
             risk_revenue=None,
             risk_brand=None,

--- a/app/experimenter/experiments/tests/api/v6/test_serializers.py
+++ b/app/experimenter/experiments/tests/api/v6/test_serializers.py
@@ -16,7 +16,7 @@ class TestNimbusExperimentSerializer(TestCase):
 
     def test_serializer_outputs_expected_schema_with_feature(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.ENDING_APPROVE_APPROVE,
+            NimbusExperimentFactory.Lifecycles.ENDING_APPROVE_APPROVE,
             application=NimbusExperiment.Application.DESKTOP,
             firefox_min_version=NimbusExperiment.Version.FIREFOX_83,
             targeting_config_slug=NimbusExperiment.TargetingConfig.ALL_ENGLISH,
@@ -100,7 +100,7 @@ class TestNimbusExperimentSerializer(TestCase):
     @parameterized.expand(list(NimbusExperiment.Application))
     def test_serializers_with_missing_feature_value(self, application):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.LAUNCH_APPROVE,
+            NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE,
             application=application,
             branches=[],
         )
@@ -114,7 +114,7 @@ class TestNimbusExperimentSerializer(TestCase):
 
     def test_serializer_with_branches_no_feature(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.CREATED,
+            NimbusExperimentFactory.Lifecycles.CREATED,
             feature_config=None,
         )
         experiment.save()
@@ -204,7 +204,7 @@ class TestNimbusExperimentSerializer(TestCase):
         expected_appName,
     ):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.LAUNCH_APPROVE,
+            NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE,
             application=application,
             channel=channel,
         )
@@ -218,7 +218,7 @@ class TestNimbusExperimentSerializer(TestCase):
 
     def test_serializer_outputs_targeting(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.LAUNCH_APPROVE,
+            NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE,
             firefox_min_version=NimbusExperiment.Version.FIREFOX_83,
             targeting_config_slug=NimbusExperiment.TargetingConfig.ALL_ENGLISH,
             application=NimbusExperiment.Application.DESKTOP,
@@ -230,7 +230,7 @@ class TestNimbusExperimentSerializer(TestCase):
 
     def test_serializer_outputs_empty_targeting(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.LAUNCH_APPROVE,
+            NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE,
             publish_status=NimbusExperiment.PublishStatus.APPROVED,
             targeting_config_slug=NimbusExperiment.TargetingConfig.NO_TARGETING,
             application=NimbusExperiment.Application.FENIX,

--- a/app/experimenter/experiments/tests/api/v6/test_views.py
+++ b/app/experimenter/experiments/tests/api/v6/test_views.py
@@ -14,7 +14,7 @@ class TestNimbusExperimentViewSet(TestCase):
     def test_list_view_serializes_experiments(self):
         experiments = []
 
-        for lifecycle in NimbusExperiment.Lifecycles:
+        for lifecycle in NimbusExperimentFactory.Lifecycles:
             final_status = lifecycle.value[-1].value
             if final_status["status"] not in [
                 NimbusExperiment.Status.DRAFT,
@@ -37,7 +37,8 @@ class TestNimbusExperimentViewSet(TestCase):
 
     def test_get_nimbus_experiment_returns_expected_data(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.LAUNCH_APPROVE_APPROVE, slug="test-rest-detail"
+            NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE_APPROVE,
+            slug="test-rest-detail",
         )
 
         response = self.client.get(

--- a/app/experimenter/experiments/tests/test_admin/test_admin_nimbus.py
+++ b/app/experimenter/experiments/tests/test_admin/test_admin_nimbus.py
@@ -38,7 +38,7 @@ class TestNimbusExperimentAdminForm(TestCase):
 
     def test_form_saves_outcomes(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.CREATED,
+            NimbusExperimentFactory.Lifecycles.CREATED,
             primary_outcomes=[],
             secondary_outcomes=[],
         )

--- a/app/experimenter/experiments/tests/test_changelog_utils/test_changelog_utils_nimbus.py
+++ b/app/experimenter/experiments/tests/test_changelog_utils/test_changelog_utils_nimbus.py
@@ -70,7 +70,7 @@ class TestNimbusExperimentChangeLogSerializer(TestCase):
         secondary_outcome = Outcomes.by_application(application)[1].slug
 
         experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.ENDING_APPROVE_APPROVE,
+            NimbusExperimentFactory.Lifecycles.ENDING_APPROVE_APPROVE,
             application=application,
             feature_config=feature_config,
             projects=[project],
@@ -182,7 +182,7 @@ class TestGenerateNimbusChangeLog(TestCase):
 
     def test_generate_nimbus_changelog_with_prior_change(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.CREATED
+            NimbusExperimentFactory.Lifecycles.CREATED
         )
 
         self.assertEqual(experiment.changes.count(), 1)

--- a/app/experimenter/experiments/tests/test_email/test_email_nimbus.py
+++ b/app/experimenter/experiments/tests/test_email/test_email_nimbus.py
@@ -11,7 +11,7 @@ from experimenter.experiments.tests.factories import NimbusExperimentFactory
 class TestNimbusEmail(TestCase):
     def test_send_experiment_ending_email(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.LAUNCH_APPROVE_APPROVE,
+            NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE_APPROVE,
             proposed_duration=10,
         )
         experiment.changes.filter(

--- a/app/experimenter/experiments/tests/test_migrations.py
+++ b/app/experimenter/experiments/tests/test_migrations.py
@@ -49,7 +49,7 @@ class TestMigration0170(MigrationTestCase):
 
         # Experiment was created with no feature when features weren't required
         experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.CREATED,
+            NimbusExperimentFactory.Lifecycles.CREATED,
             feature_config=None,
             application=NimbusExperiment.Application.DESKTOP,
         )
@@ -78,7 +78,7 @@ class TestMigration0170(MigrationTestCase):
 
         # Experiment was created with no feature when features weren't required
         experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.CREATED,
+            NimbusExperimentFactory.Lifecycles.CREATED,
             feature_config=None,
             application=NimbusExperiment.Application.DESKTOP,
         )
@@ -103,7 +103,7 @@ class TestMigration0170(MigrationTestCase):
 
         # Experiment was created with no feature when features weren't required
         experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.CREATED,
+            NimbusExperimentFactory.Lifecycles.CREATED,
             feature_config=None,
         )
         generate_nimbus_changelog(experiment, experiment.owner, "feature is None")

--- a/app/experimenter/experiments/tests/test_models/test_models_nimbus.py
+++ b/app/experimenter/experiments/tests/test_models/test_models_nimbus.py
@@ -24,15 +24,15 @@ from experimenter.openidc.tests.factories import UserFactory
 class TestNimbusExperimentManager(TestCase):
     def test_launch_queue_returns_queued_experiments_with_correct_application(self):
         experiment1 = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.LAUNCH_APPROVE,
+            NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE,
             application=NimbusExperiment.Application.DESKTOP,
         )
         NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.LAUNCH_APPROVE,
+            NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE,
             application=NimbusExperiment.Application.FENIX,
         )
         NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.LAUNCH_APPROVE_APPROVE,
+            NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE_APPROVE,
             application=NimbusExperiment.Application.DESKTOP,
         )
         self.assertEqual(
@@ -46,20 +46,20 @@ class TestNimbusExperimentManager(TestCase):
 
     def test_end_queue_returns_ending_experiments_with_correct_application(self):
         experiment1 = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.ENDING_APPROVE,
+            NimbusExperimentFactory.Lifecycles.ENDING_APPROVE,
             application=NimbusExperiment.Application.DESKTOP,
         )
         NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.LAUNCH_APPROVE_APPROVE,
+            NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE_APPROVE,
             is_end_requested=True,
             application=NimbusExperiment.Application.FENIX,
         )
         NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.ENDING_APPROVE_REJECT,
+            NimbusExperimentFactory.Lifecycles.ENDING_APPROVE_REJECT,
             application=NimbusExperiment.Application.DESKTOP,
         )
         NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.LAUNCH_APPROVE,
+            NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE,
             is_end_requested=True,
             application=NimbusExperiment.Application.DESKTOP,
         )
@@ -83,7 +83,7 @@ class TestNimbusExperimentManager(TestCase):
 
         # Should end, with the correct application
         experiment1 = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.LAUNCH_APPROVE_APPROVE,
+            NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE_APPROVE,
             is_paused=False,
             proposed_enrollment=10,
             application=NimbusExperiment.Application.DESKTOP,
@@ -91,14 +91,14 @@ class TestNimbusExperimentManager(TestCase):
         rewind_launch(experiment1)
         # Should end, but wrong application
         experiment2 = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.LAUNCH_APPROVE_APPROVE,
+            NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE_APPROVE,
             proposed_enrollment=10,
             application=NimbusExperiment.Application.FENIX,
         )
         rewind_launch(experiment2)
         # Should end, but already paused
         experiment3 = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.LAUNCH_APPROVE_APPROVE,
+            NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE_APPROVE,
             is_paused=True,
             proposed_enrollment=10,
             application=NimbusExperiment.Application.DESKTOP,
@@ -106,7 +106,7 @@ class TestNimbusExperimentManager(TestCase):
         rewind_launch(experiment3)
         # Correct application, but should not end
         NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.LAUNCH_APPROVE_APPROVE,
+            NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE_APPROVE,
             proposed_enrollment=10,
             application=NimbusExperiment.Application.DESKTOP,
         )
@@ -121,11 +121,11 @@ class TestNimbusExperimentManager(TestCase):
 
     def test_waiting_returns_any_waiting_experiments(self):
         NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.CREATED,
+            NimbusExperimentFactory.Lifecycles.CREATED,
             application=NimbusExperiment.Application.IOS,
         )
         desktop_live_waiting = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.LAUNCH_APPROVE_WAITING,
+            NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE_WAITING,
             application=NimbusExperiment.Application.DESKTOP,
         )
         self.assertEqual(
@@ -137,14 +137,16 @@ class TestNimbusExperimentManager(TestCase):
 
     def test_waiting_to_launch_only_returns_launching_experiments(self):
         launching = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.LAUNCH_APPROVE_WAITING
-        )
-        NimbusExperimentFactory.create_with_lifecycle(NimbusExperiment.Lifecycles.CREATED)
-        NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.LAUNCH_APPROVE_APPROVE
+            NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE_WAITING
         )
         NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.ENDING_APPROVE_WAITING,
+            NimbusExperimentFactory.Lifecycles.CREATED
+        )
+        NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE_APPROVE
+        )
+        NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.ENDING_APPROVE_WAITING,
         )
 
         self.assertEqual(
@@ -156,14 +158,16 @@ class TestNimbusExperimentManager(TestCase):
 
     def test_waiting_to_pause_only_returns_pausing_experiments(self):
         pausing = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.LIVE_ENROLLING_WAITING
-        )
-        NimbusExperimentFactory.create_with_lifecycle(NimbusExperiment.Lifecycles.CREATED)
-        NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.LAUNCH_APPROVE_APPROVE
+            NimbusExperimentFactory.Lifecycles.LIVE_ENROLLING_WAITING
         )
         NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.ENDING_APPROVE_WAITING,
+            NimbusExperimentFactory.Lifecycles.CREATED
+        )
+        NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE_APPROVE
+        )
+        NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.ENDING_APPROVE_WAITING,
         )
 
         self.assertEqual(
@@ -206,7 +210,7 @@ class TestNimbusExperiment(TestCase):
 
     def test_empty_targeting_for_mobile(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.LAUNCH_APPROVE_APPROVE,
+            NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE_APPROVE,
             firefox_min_version=NimbusExperiment.Version.FIREFOX_83,
             targeting_config_slug=NimbusExperiment.TargetingConfig.NO_TARGETING,
             application=NimbusExperiment.Application.FENIX,
@@ -219,7 +223,7 @@ class TestNimbusExperiment(TestCase):
         self,
     ):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.LAUNCH_APPROVE_APPROVE,
+            NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE_APPROVE,
             firefox_min_version=NimbusExperiment.Version.NO_VERSION,
             targeting_config_slug=NimbusExperiment.TargetingConfig.ALL_ENGLISH,
             application=NimbusExperiment.Application.DESKTOP,
@@ -237,7 +241,7 @@ class TestNimbusExperiment(TestCase):
 
     def test_targeting_without_channel_version(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.LAUNCH_APPROVE_APPROVE,
+            NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE_APPROVE,
             firefox_min_version=NimbusExperiment.Version.NO_VERSION,
             targeting_config_slug=NimbusExperiment.TargetingConfig.NO_TARGETING,
             application=NimbusExperiment.Application.DESKTOP,
@@ -250,13 +254,13 @@ class TestNimbusExperiment(TestCase):
 
     def test_start_date_returns_None_for_not_started_experiment(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.CREATED,
+            NimbusExperimentFactory.Lifecycles.CREATED,
         )
         self.assertIsNone(experiment.start_date)
 
     def test_end_date_returns_None_for_not_ended_experiment(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.CREATED,
+            NimbusExperimentFactory.Lifecycles.CREATED,
         )
         self.assertIsNone(experiment.end_date)
 
@@ -280,13 +284,13 @@ class TestNimbusExperiment(TestCase):
 
     def test_proposed_end_date_returns_None_for_not_started_experiment(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.CREATED,
+            NimbusExperimentFactory.Lifecycles.CREATED,
         )
         self.assertIsNone(experiment.proposed_end_date)
 
     def test_proposed_end_date_returns_start_date_plus_duration(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.LAUNCH_APPROVE_APPROVE,
+            NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE_APPROVE,
             proposed_duration=10,
         )
         self.assertEqual(
@@ -296,14 +300,14 @@ class TestNimbusExperiment(TestCase):
 
     def test_should_end_returns_False_before_proposed_end_date(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.LAUNCH_APPROVE_APPROVE,
+            NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE_APPROVE,
             proposed_duration=10,
         )
         self.assertFalse(experiment.should_end)
 
     def test_should_end_returns_True_after_proposed_end_date(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.LAUNCH_APPROVE_APPROVE,
+            NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE_APPROVE,
             proposed_duration=10,
         )
         experiment.changes.filter(
@@ -379,7 +383,7 @@ class TestNimbusExperiment(TestCase):
 
     def test_clear_branches_deletes_branches_without_deleting_experiment(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.CREATED,
+            NimbusExperimentFactory.Lifecycles.CREATED,
         )
         self.assertIsNotNone(experiment.reference_branch)
         self.assertEqual(experiment.branches.count(), 2)
@@ -394,7 +398,7 @@ class TestNimbusExperiment(TestCase):
 
     def test_allocate_buckets_generates_bucket_range(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.CREATED, population_percent=Decimal("50.0")
+            NimbusExperimentFactory.Lifecycles.CREATED, population_percent=Decimal("50.0")
         )
         experiment.allocate_bucket_range()
         self.assertEqual(experiment.bucket_range.count, 5000)
@@ -404,7 +408,7 @@ class TestNimbusExperiment(TestCase):
 
     def test_allocate_buckets_creates_new_bucket_range_if_population_changes(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.CREATED, population_percent=Decimal("50.0")
+            NimbusExperimentFactory.Lifecycles.CREATED, population_percent=Decimal("50.0")
         )
         experiment.allocate_bucket_range()
         self.assertEqual(experiment.bucket_range.count, 5000)
@@ -421,13 +425,14 @@ class TestNimbusExperiment(TestCase):
 
     def test_proposed_enrollment_end_date_without_start_date_is_None(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.CREATED,
+            NimbusExperimentFactory.Lifecycles.CREATED,
         )
         self.assertIsNone(experiment.proposed_enrollment_end_date)
 
     def test_proposed_enrollment_end_date_with_start_date_returns_date(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.LAUNCH_APPROVE_APPROVE, proposed_enrollment=10
+            NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE_APPROVE,
+            proposed_enrollment=10,
         )
         self.assertEqual(
             experiment.proposed_enrollment_end_date,
@@ -436,13 +441,15 @@ class TestNimbusExperiment(TestCase):
 
     def test_should_pause_false_before_enrollment_end(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.LAUNCH_APPROVE_APPROVE, proposed_enrollment=10
+            NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE_APPROVE,
+            proposed_enrollment=10,
         )
         self.assertFalse(experiment.should_pause)
 
     def test_should_pause_true_after_enrollment_end(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.LAUNCH_APPROVE_APPROVE, proposed_enrollment=10
+            NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE_APPROVE,
+            proposed_enrollment=10,
         )
         launch_change = experiment.changes.get(
             old_status=NimbusExperiment.Status.DRAFT,
@@ -454,7 +461,7 @@ class TestNimbusExperiment(TestCase):
 
     def test_can_review_false_for_requesting_user(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.CREATED,
+            NimbusExperimentFactory.Lifecycles.CREATED,
         )
         experiment.publish_status = NimbusExperiment.PublishStatus.REVIEW
         experiment.save()
@@ -472,7 +479,7 @@ class TestNimbusExperiment(TestCase):
     )
     def test_can_review_true_for_non_requesting_user(self, last_publish_status):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.CREATED,
+            NimbusExperimentFactory.Lifecycles.CREATED,
         )
         for publish_status in (
             NimbusExperiment.PublishStatus.REVIEW,
@@ -516,10 +523,12 @@ class TestNimbusExperiment(TestCase):
     ):
         user = UserFactory.create(email=email)
         experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.CREATED,
+            NimbusExperimentFactory.Lifecycles.CREATED,
             owner=user,
         )
-        experiment.apply_lifecycle_state(NimbusExperiment.LifecycleStates.DRAFT_REVIEW)
+        experiment.apply_lifecycle_state(
+            NimbusExperimentFactory.LifecycleStates.DRAFT_REVIEW
+        )
         experiment.save()
 
         generate_nimbus_changelog(experiment, experiment.owner, "test message")
@@ -528,9 +537,11 @@ class TestNimbusExperiment(TestCase):
 
     def test_can_review_false_for_non_review_publish_status(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.CREATED,
+            NimbusExperimentFactory.Lifecycles.CREATED,
         )
-        experiment.apply_lifecycle_state(NimbusExperiment.LifecycleStates.DRAFT_REVIEW)
+        experiment.apply_lifecycle_state(
+            NimbusExperimentFactory.LifecycleStates.DRAFT_REVIEW
+        )
         experiment.save()
 
         generate_nimbus_changelog(experiment, experiment.owner, "test message")
@@ -544,14 +555,14 @@ class TestNimbusExperiment(TestCase):
     @parameterized.expand(
         [
             (
-                NimbusExperiment.Lifecycles.LAUNCH_APPROVE,
-                NimbusExperiment.Lifecycles.LAUNCH_APPROVE_WAITING,
-                NimbusExperiment.Lifecycles.LAUNCH_APPROVE_TIMEOUT,
+                NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE,
+                NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE_WAITING,
+                NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE_TIMEOUT,
             ),
             (
-                NimbusExperiment.Lifecycles.ENDING_APPROVE,
-                NimbusExperiment.Lifecycles.ENDING_APPROVE_WAITING,
-                NimbusExperiment.Lifecycles.ENDING_APPROVE_TIMEOUT,
+                NimbusExperimentFactory.Lifecycles.ENDING_APPROVE,
+                NimbusExperimentFactory.Lifecycles.ENDING_APPROVE_WAITING,
+                NimbusExperimentFactory.Lifecycles.ENDING_APPROVE_TIMEOUT,
             ),
         ]
     )
@@ -580,7 +591,7 @@ class TestNimbusExperiment(TestCase):
 
     def test_has_state_true(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.LAUNCH_APPROVE_WAITING,
+            NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE_WAITING,
         )
         self.assertTrue(
             experiment.has_filter(
@@ -593,7 +604,7 @@ class TestNimbusExperiment(TestCase):
 
     def test_has_state_false(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.LAUNCH_APPROVE_WAITING,
+            NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE_WAITING,
         )
         self.assertFalse(
             experiment.has_filter(
@@ -772,13 +783,13 @@ class TestNimbusIsolationGroup(TestCase):
 class TestNimbusChangeLogManager(TestCase):
     def test_latest_review_request_returns_none_for_no_review_request(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.CREATED,
+            NimbusExperimentFactory.Lifecycles.CREATED,
         )
         self.assertIsNone(experiment.changes.latest_review_request())
 
     def test_latest_review_request_returns_change_for_idle_to_review(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.CREATED,
+            NimbusExperimentFactory.Lifecycles.CREATED,
         )
 
         experiment.publish_status = NimbusExperiment.PublishStatus.REVIEW
@@ -791,7 +802,7 @@ class TestNimbusChangeLogManager(TestCase):
     def test_latest_review_request_returns_most_recent_review_request(self):
         reviewer = UserFactory()
         experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.CREATED,
+            NimbusExperimentFactory.Lifecycles.CREATED,
         )
         experiment.publish_status = NimbusExperiment.PublishStatus.REVIEW
         experiment.save()
@@ -813,13 +824,13 @@ class TestNimbusChangeLogManager(TestCase):
 
     def test_latest_rejection_returns_none_for_no_rejection(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.CREATED,
+            NimbusExperimentFactory.Lifecycles.CREATED,
         )
         self.assertIsNone(experiment.changes.latest_rejection())
 
     def test_latest_rejection_returns_rejection_for_review_to_idle(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.CREATED,
+            NimbusExperimentFactory.Lifecycles.CREATED,
         )
 
         changes = []
@@ -838,7 +849,7 @@ class TestNimbusChangeLogManager(TestCase):
 
     def test_latest_rejection_returns_rejection_for_waiting_to_idle(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.CREATED,
+            NimbusExperimentFactory.Lifecycles.CREATED,
         )
 
         changes = []
@@ -859,7 +870,7 @@ class TestNimbusChangeLogManager(TestCase):
 
     def test_launch_to_live_is_not_considered_latest_rejection(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.LAUNCH_APPROVE_APPROVE,
+            NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE_APPROVE,
         )
 
         experiment.status = NimbusExperiment.Status.LIVE
@@ -871,7 +882,7 @@ class TestNimbusChangeLogManager(TestCase):
 
     def test_stale_timeout_not_returned(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.CREATED,
+            NimbusExperimentFactory.Lifecycles.CREATED,
         )
         for publish_status in (
             NimbusExperiment.PublishStatus.REVIEW,
@@ -888,7 +899,7 @@ class TestNimbusChangeLogManager(TestCase):
 
     def test_stale_rejection_not_returned(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.CREATED,
+            NimbusExperimentFactory.Lifecycles.CREATED,
         )
         for publish_status in (
             NimbusExperiment.PublishStatus.REVIEW,

--- a/app/experimenter/kinto/tests/test_tasks.py
+++ b/app/experimenter/kinto/tests/test_tasks.py
@@ -61,12 +61,12 @@ class TestNimbusCheckKintoPushQueueByCollection(MockKintoClientMixin, TestCase):
 
     def test_check_with_no_approved_publish_status_pushes_nothing(self):
         for lifecycle in [
-            NimbusExperiment.Lifecycles.CREATED,
-            NimbusExperiment.Lifecycles.LAUNCH_REVIEW_REQUESTED,
-            NimbusExperiment.Lifecycles.LAUNCH_APPROVE_WAITING,
-            NimbusExperiment.Lifecycles.LAUNCH_APPROVE_APPROVE,
-            NimbusExperiment.Lifecycles.ENDING_REVIEW_REQUESTED,
-            NimbusExperiment.Lifecycles.ENDING_APPROVE_WAITING,
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            NimbusExperimentFactory.Lifecycles.LAUNCH_REVIEW_REQUESTED,
+            NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE_WAITING,
+            NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE_APPROVE,
+            NimbusExperimentFactory.Lifecycles.ENDING_REVIEW_REQUESTED,
+            NimbusExperimentFactory.Lifecycles.ENDING_APPROVE_WAITING,
         ]:
             NimbusExperimentFactory.create_with_lifecycle(
                 lifecycle,
@@ -86,7 +86,7 @@ class TestNimbusCheckKintoPushQueueByCollection(MockKintoClientMixin, TestCase):
         self,
     ):
         launching_experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.LAUNCH_APPROVE,
+            NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE,
             application=NimbusExperiment.Application.DESKTOP,
         )
 
@@ -100,7 +100,7 @@ class TestNimbusCheckKintoPushQueueByCollection(MockKintoClientMixin, TestCase):
 
     def test_check_with_approved_end_and_no_kinto_pending_ends_experiment(self):
         ending_experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.ENDING_APPROVE,
+            NimbusExperimentFactory.Lifecycles.ENDING_APPROVE,
             application=NimbusExperiment.Application.DESKTOP,
         )
 
@@ -114,7 +114,7 @@ class TestNimbusCheckKintoPushQueueByCollection(MockKintoClientMixin, TestCase):
 
     def test_check_with_pause_and_no_kinto_pending_pauses_experiment(self):
         pausing_experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.LAUNCH_APPROVE_APPROVE,
+            NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE_APPROVE,
             application=NimbusExperiment.Application.DESKTOP,
         )
         for change in pausing_experiment.changes.all():
@@ -135,11 +135,11 @@ class TestNimbusCheckKintoPushQueueByCollection(MockKintoClientMixin, TestCase):
         self,
     ):
         pending_experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.LAUNCH_APPROVE_WAITING,
+            NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE_WAITING,
             application=NimbusExperiment.Application.DESKTOP,
         )
         launching_experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.LAUNCH_APPROVE,
+            NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE,
             application=NimbusExperiment.Application.DESKTOP,
         )
 
@@ -175,7 +175,7 @@ class TestNimbusCheckKintoPushQueueByCollection(MockKintoClientMixin, TestCase):
         self,
     ):
         pausing_experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.LAUNCH_APPROVE_APPROVE,
+            NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE_APPROVE,
             application=NimbusExperiment.Application.DESKTOP,
         )
         for change in pausing_experiment.changes.all():
@@ -192,7 +192,7 @@ class TestNimbusCheckKintoPushQueueByCollection(MockKintoClientMixin, TestCase):
             pausing_experiment.save()
 
         NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.LAUNCH_APPROVE,
+            NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE,
             application=NimbusExperiment.Application.DESKTOP,
         )
 
@@ -211,11 +211,11 @@ class TestNimbusCheckKintoPushQueueByCollection(MockKintoClientMixin, TestCase):
         self,
     ):
         pending_experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.ENDING_APPROVE_WAITING,
+            NimbusExperimentFactory.Lifecycles.ENDING_APPROVE_WAITING,
             application=NimbusExperiment.Application.DESKTOP,
         )
         launching_experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.LAUNCH_APPROVE,
+            NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE,
             application=NimbusExperiment.Application.DESKTOP,
         )
 
@@ -249,11 +249,11 @@ class TestNimbusCheckKintoPushQueueByCollection(MockKintoClientMixin, TestCase):
 
     def test_check_with_rejected_launch_rolls_back_and_pushes(self):
         rejected_experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.LAUNCH_APPROVE_WAITING,
+            NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE_WAITING,
             application=NimbusExperiment.Application.DESKTOP,
         )
         launching_experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.LAUNCH_APPROVE,
+            NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE,
             application=NimbusExperiment.Application.DESKTOP,
         )
 
@@ -290,7 +290,7 @@ class TestNimbusCheckKintoPushQueueByCollection(MockKintoClientMixin, TestCase):
 
     def test_check_with_rejected_pause_rolls_back_and_pushes_same_pause(self):
         pausing_experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.LAUNCH_APPROVE_APPROVE,
+            NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE_APPROVE,
             application=NimbusExperiment.Application.DESKTOP,
         )
         for change in pausing_experiment.changes.all():
@@ -319,11 +319,11 @@ class TestNimbusCheckKintoPushQueueByCollection(MockKintoClientMixin, TestCase):
 
     def test_check_with_rejected_end_rolls_back_and_pushes(self):
         rejected_experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.ENDING_APPROVE_WAITING,
+            NimbusExperimentFactory.Lifecycles.ENDING_APPROVE_WAITING,
             application=NimbusExperiment.Application.DESKTOP,
         )
         launching_experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.LAUNCH_APPROVE,
+            NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE,
             application=NimbusExperiment.Application.DESKTOP,
         )
 
@@ -361,7 +361,7 @@ class TestNimbusCheckKintoPushQueueByCollection(MockKintoClientMixin, TestCase):
 
     def test_check_with_missing_review_and_queued_launch_rolls_back_and_pushes(self):
         launching_experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.LAUNCH_APPROVE,
+            NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE,
             application=NimbusExperiment.Application.DESKTOP,
         )
 
@@ -382,7 +382,7 @@ class TestNimbusCheckKintoPushQueueByCollection(MockKintoClientMixin, TestCase):
 
     def test_check_with_missing_rejection_and_queued_launch_rolls_back_and_pushes(self):
         launching_experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.LAUNCH_APPROVE,
+            NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE,
             application=NimbusExperiment.Application.DESKTOP,
         )
 
@@ -407,7 +407,7 @@ class TestNimbusPushExperimentToKintoTask(MockKintoClientMixin, TestCase):
         self,
     ):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.LAUNCH_APPROVE,
+            NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE,
             application=NimbusExperiment.Application.DESKTOP,
         )
 
@@ -438,7 +438,7 @@ class TestNimbusPushExperimentToKintoTask(MockKintoClientMixin, TestCase):
 
     def test_push_experiment_to_kinto_sends_fenix_experiment_data(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.LAUNCH_APPROVE,
+            NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE,
             application=NimbusExperiment.Application.DESKTOP,
         )
 
@@ -469,7 +469,7 @@ class TestNimbusPushExperimentToKintoTask(MockKintoClientMixin, TestCase):
 class TestNimbusPauseExperimentInKinto(MockKintoClientMixin, TestCase):
     def test_updates_experiment_record_isEnrollmentPaused_true_in_kinto(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.LAUNCH_APPROVE_APPROVE,
+            NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE_APPROVE,
             proposed_enrollment=10,
             application=NimbusExperiment.Application.DESKTOP,
         )
@@ -511,7 +511,7 @@ class TestNimbusPauseExperimentInKinto(MockKintoClientMixin, TestCase):
 
     def test_push_experiment_to_kinto_reraises_exception(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.LAUNCH_APPROVE_APPROVE,
+            NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE_APPROVE,
         )
         self.mock_kinto_client.get_records.side_effect = Exception
         with self.assertRaises(Exception):
@@ -523,7 +523,7 @@ class TestNimbusPauseExperimentInKinto(MockKintoClientMixin, TestCase):
 class TestNimbusEndExperimentInKinto(MockKintoClientMixin, TestCase):
     def test_exception_for_failed_delete(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.CREATED,
+            NimbusExperimentFactory.Lifecycles.CREATED,
             application=NimbusExperiment.Application.DESKTOP,
         )
         self.mock_kinto_client.delete_record.side_effect = Exception
@@ -534,7 +534,7 @@ class TestNimbusEndExperimentInKinto(MockKintoClientMixin, TestCase):
 
     def test_end_experiment_in_kinto_deletes_experiment(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.ENDING_APPROVE,
+            NimbusExperimentFactory.Lifecycles.ENDING_APPROVE,
             application=NimbusExperiment.Application.DESKTOP,
         )
 
@@ -570,13 +570,13 @@ class TestNimbusEndExperimentInKinto(MockKintoClientMixin, TestCase):
 class TestNimbusCheckExperimentsAreLive(MockKintoClientMixin, TestCase):
     def test_experiment_updates_when_record_is_in_main(self):
         experiment1 = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.LAUNCH_APPROVE_WAITING,
+            NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE_WAITING,
         )
         experiment2 = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.LAUNCH_APPROVE_WAITING,
+            NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE_WAITING,
         )
         experiment3 = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.CREATED,
+            NimbusExperimentFactory.Lifecycles.CREATED,
         )
 
         initial_change_count = experiment3.changes.count()
@@ -611,7 +611,7 @@ class TestNimbusCheckExperimentsAreLive(MockKintoClientMixin, TestCase):
 class TestNimbusCheckExperimentsArePaused(MockKintoClientMixin, TestCase):
     def test_ignores_unpaused_experiment_with_isEnrollmentPaused_false(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.LAUNCH_APPROVE_APPROVE,
+            NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE_APPROVE,
             application=NimbusExperiment.Application.DESKTOP,
         )
         changes_count = experiment.changes.count()
@@ -628,7 +628,7 @@ class TestNimbusCheckExperimentsArePaused(MockKintoClientMixin, TestCase):
 
     def test_updates_unpaused_experiment_with_isEnrollmentPaused_true(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.LIVE_ENROLLING_WAITING,
+            NimbusExperimentFactory.Lifecycles.LIVE_ENROLLING_WAITING,
             application=NimbusExperiment.Application.DESKTOP,
         )
         changes_count = experiment.changes.count()
@@ -649,7 +649,7 @@ class TestNimbusCheckExperimentsArePaused(MockKintoClientMixin, TestCase):
 
     def test_ignores_paused_experiment_with_isEnrollmentPaused_true(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.LIVE_PAUSED,
+            NimbusExperimentFactory.Lifecycles.LIVE_PAUSED,
             application=NimbusExperiment.Application.DESKTOP,
         )
         changes_count = experiment.changes.count()
@@ -668,13 +668,13 @@ class TestNimbusCheckExperimentsArePaused(MockKintoClientMixin, TestCase):
 class TestNimbusCheckExperimentsAreComplete(MockKintoClientMixin, TestCase):
     def test_experiment_updates_when_record_is_not_in_main(self):
         experiment1 = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.LAUNCH_APPROVE_APPROVE,
+            NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE_APPROVE,
         )
         experiment2 = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.ENDING_APPROVE_WAITING,
+            NimbusExperimentFactory.Lifecycles.ENDING_APPROVE_WAITING,
         )
         experiment3 = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.CREATED,
+            NimbusExperimentFactory.Lifecycles.CREATED,
         )
 
         initial_change_count = experiment3.changes.count()
@@ -730,7 +730,7 @@ class TestNimbusCheckExperimentsAreComplete(MockKintoClientMixin, TestCase):
         self,
     ):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.LAUNCH_APPROVE_APPROVE,
+            NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE_APPROVE,
             proposed_duration=10,
         )
         self.assertEqual(experiment.emails.count(), 0)
@@ -740,7 +740,7 @@ class TestNimbusCheckExperimentsAreComplete(MockKintoClientMixin, TestCase):
 
     def test_experiment_ending_email_sent_for_experiments_past_proposed_end_date(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.LAUNCH_APPROVE_APPROVE,
+            NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE_APPROVE,
             proposed_duration=10,
         )
         experiment.changes.filter(
@@ -762,11 +762,11 @@ class TestNimbusCheckExperimentsAreComplete(MockKintoClientMixin, TestCase):
 
     def test_only_completes_experiments_with_matching_application_collection(self):
         desktop_experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.LAUNCH_APPROVE_APPROVE,
+            NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE_APPROVE,
             application=NimbusExperiment.Application.DESKTOP,
         )
         fenix_experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.LAUNCH_APPROVE_APPROVE,
+            NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE_APPROVE,
             application=NimbusExperiment.Application.FENIX,
         )
 
@@ -794,10 +794,10 @@ class TestNimbusCheckExperimentsAreComplete(MockKintoClientMixin, TestCase):
 class TestNimbusSynchronizePreviewExperimentsInKinto(MockKintoClientMixin, TestCase):
     def test_publishes_preview_experiments_and_unpublishes_non_preview_experiments(self):
         should_publish_experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.PREVIEW,
+            NimbusExperimentFactory.Lifecycles.PREVIEW,
         )
         should_unpublish_experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperiment.Lifecycles.CREATED,
+            NimbusExperimentFactory.Lifecycles.CREATED,
         )
 
         self.setup_kinto_get_main_records([should_unpublish_experiment.slug])

--- a/app/experimenter/visualization/tests/api/test_views.py
+++ b/app/experimenter/visualization/tests/api/test_views.py
@@ -24,8 +24,8 @@ class TestVisualizationView(TestCase):
 
     @parameterized.expand(
         [
-            (NimbusExperiment.Lifecycles.CREATED,),
-            (NimbusExperiment.Lifecycles.ENDING_APPROVE_APPROVE,),
+            (NimbusExperimentFactory.Lifecycles.CREATED,),
+            (NimbusExperimentFactory.Lifecycles.ENDING_APPROVE_APPROVE,),
         ]
     )
     @patch("django.core.files.storage.default_storage.exists")
@@ -103,8 +103,8 @@ class TestVisualizationView(TestCase):
 
     @parameterized.expand(
         [
-            (NimbusExperiment.Lifecycles.CREATED,),
-            (NimbusExperiment.Lifecycles.ENDING_APPROVE_APPROVE,),
+            (NimbusExperimentFactory.Lifecycles.CREATED,),
+            (NimbusExperimentFactory.Lifecycles.ENDING_APPROVE_APPROVE,),
         ]
     )
     @patch("django.core.files.storage.default_storage.open")


### PR DESCRIPTION
Because

* While working on a recent bug I discovered that one of our lifecycle states was malformed
* Tests were passing becuase the same lifecycle state was used as part of logic and part of tests
* Using separate state definitions for logic and tests can help catch future bugs

This commit

* Moves the lifecycles over to the test factory and hard codes definitions in the model filters