### PR TITLE
fix #5356 bug(nimbus): handle multiple launch/end changelogs

### DIFF
--- a/app/experimenter/experiments/models/nimbus.py
+++ b/app/experimenter/experiments/models/nimbus.py
@@ -239,20 +239,20 @@ class NimbusExperiment(NimbusConstants, FilterMixin, models.Model):
 
     @property
     def start_date(self):
-        start_changelog = self.changes.filter(
-            new_status=NimbusExperiment.Status.LIVE,
+        start_changelogs = self.changes.filter(
             old_status=NimbusExperiment.Status.DRAFT,
+            new_status=NimbusExperiment.Status.LIVE,
         )
-        if start_changelog.exists():
-            return start_changelog.get().changed_on
+        if start_changelogs.exists():
+            return start_changelogs.order_by("-changed_on").first().changed_on
 
     @property
     def end_date(self):
-        end_changelog = self.changes.filter(
+        end_changelogs = self.changes.filter(
             old_status=self.Status.LIVE, new_status=self.Status.COMPLETE
         )
-        if end_changelog.exists():
-            return end_changelog.get().changed_on
+        if end_changelogs.exists():
+            return end_changelogs.order_by("-changed_on").first().changed_on
 
     @property
     def proposed_enrollment_end_date(self):

--- a/app/experimenter/experiments/tests/test_models/test_models_nimbus.py
+++ b/app/experimenter/experiments/tests/test_models/test_models_nimbus.py
@@ -281,8 +281,36 @@ class TestNimbusExperiment(TestCase):
         )
         self.assertEqual(experiment.start_date, start_change.changed_on)
 
+    def test_start_date_uses_most_recent_start_change(self):
+        experiment = NimbusExperimentFactory.create()
+        NimbusChangeLogFactory(
+            experiment=experiment,
+            old_status=NimbusExperiment.Status.DRAFT,
+            new_status=NimbusExperiment.Status.LIVE,
+        )
+        start_change = NimbusChangeLogFactory(
+            experiment=experiment,
+            old_status=NimbusExperiment.Status.DRAFT,
+            new_status=NimbusExperiment.Status.LIVE,
+        )
+        self.assertEqual(experiment.start_date, start_change.changed_on)
+
     def test_end_date_returns_datetime_for_ended_experiment(self):
         experiment = NimbusExperimentFactory.create()
+        end_change = NimbusChangeLogFactory(
+            experiment=experiment,
+            old_status=NimbusExperiment.Status.LIVE,
+            new_status=NimbusExperiment.Status.COMPLETE,
+        )
+        self.assertEqual(experiment.end_date, end_change.changed_on)
+
+    def test_end_date_uses_most_recent_end_change(self):
+        experiment = NimbusExperimentFactory.create()
+        NimbusChangeLogFactory(
+            experiment=experiment,
+            old_status=NimbusExperiment.Status.LIVE,
+            new_status=NimbusExperiment.Status.COMPLETE,
+        )
         end_change = NimbusChangeLogFactory(
             experiment=experiment,
             old_status=NimbusExperiment.Status.LIVE,


### PR DESCRIPTION
Because

* We expect an experiment to only launch or end once and only have single launch/end changelogs
* Real data is muddy and messy
* We should elegantly handle the case where there's multiple starts/ends

This commit

* Uses the most recent launch or end changelog to compute the start/end dates