### PR TITLE
fixes #5355 feat(nimbus): display gql error on homepage directory

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/PageHome/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageHome/index.test.tsx
@@ -33,6 +33,17 @@ describe("PageHome", () => {
     await renderAndWaitForLoaded([]);
     expect(screen.queryByText("No experiments found.")).toBeInTheDocument();
   });
+  it("displays an error message when there is one", async () => {
+    const error = new Error("You done it now!");
+
+    (jest.spyOn(apollo, "useQuery") as jest.Mock).mockReturnValueOnce({
+      error,
+    });
+
+    render(<Subject />);
+
+    await screen.findByText(error.message, { exact: false });
+  });
   it("displays five Directory Tables (one for each status type)", async () => {
     await renderAndWaitForLoaded();
     expect(screen.queryAllByTestId("DirectoryTable")).toHaveLength(5);

--- a/app/experimenter/nimbus-ui/src/components/PageHome/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageHome/index.tsx
@@ -22,12 +22,20 @@ import sortByStatus from "./sortByStatus";
 type PageHomeProps = {} & RouteComponentProps;
 
 export const Body = () => {
-  const { data, loading } = useQuery<{
+  const { data, loading, error } = useQuery<{
     experiments: getAllExperiments_experiments[];
   }>(GET_EXPERIMENTS_QUERY);
 
   if (loading) {
     return <PageLoading />;
+  }
+
+  if (error) {
+    return (
+      <Alert variant="warning">
+        An error occurred while looking up experiments: {error.message}
+      </Alert>
+    );
   }
 
   if (!data) {


### PR DESCRIPTION
Closes #5355

This PR updates the experiment directory page to display a GQL request error if it occurs.