### PR TITLE
fix #5360 bug(nimbus): intermittent test failure test_waiting_to_pause_only_returns_pausing_experiments

### DIFF
--- a/app/experimenter/experiments/models/nimbus.py
+++ b/app/experimenter/experiments/models/nimbus.py
@@ -149,11 +149,13 @@ class NimbusExperiment(NimbusConstants, FilterMixin, models.Model):
             status=NimbusConstants.Status.LIVE,
             publish_status=NimbusConstants.PublishStatus.IDLE,
             is_paused=False,
+            is_end_requested=False,
         )
         IS_PAUSING = Q(
             status=NimbusConstants.Status.LIVE,
             publish_status=NimbusConstants.PublishStatus.WAITING,
             is_paused=False,
+            is_end_requested=False,
         )
         IS_END_QUEUED = Q(
             status=NimbusConstants.Status.LIVE,

--- a/app/experimenter/experiments/tests/test_models/test_models_nimbus.py
+++ b/app/experimenter/experiments/tests/test_models/test_models_nimbus.py
@@ -137,16 +137,20 @@ class TestNimbusExperimentManager(TestCase):
 
     def test_waiting_to_launch_only_returns_launching_experiments(self):
         launching = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE_WAITING
+            NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE_WAITING,
+            name="launching",
         )
         NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperimentFactory.Lifecycles.CREATED
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            name="created",
         )
         NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE_APPROVE
+            NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE_APPROVE,
+            name="launch approve approve",
         )
         NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.ENDING_APPROVE_WAITING,
+            name="ending approve waiting",
         )
 
         self.assertEqual(
@@ -158,16 +162,20 @@ class TestNimbusExperimentManager(TestCase):
 
     def test_waiting_to_pause_only_returns_pausing_experiments(self):
         pausing = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperimentFactory.Lifecycles.LIVE_ENROLLING_WAITING
+            NimbusExperimentFactory.Lifecycles.LIVE_ENROLLING_WAITING,
+            name="pausing",
         )
         NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperimentFactory.Lifecycles.CREATED
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            name="created",
         )
         NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE_APPROVE
+            NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE_APPROVE,
+            name="launch approve approve",
         )
         NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.ENDING_APPROVE_WAITING,
+            name="ending approve waiting",
         )
 
         self.assertEqual(


### PR DESCRIPTION


Because

* We recently fixed a bug with pausing and added a new test
* Just noticed that it's intermittent

This commit

* Adds additional filters to prevent intermittency