### PR TITLE
fix #5367 bug(nimbus): end experiment rejection hides end button

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/Summary/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/index.test.tsx
@@ -206,7 +206,7 @@ describe("Summary", () => {
       const mutationMock = createMutationMock(
         experiment.id!,
         NimbusExperimentPublishStatus.IDLE,
-        { changelogMessage: expectedReason },
+        { isEndRequested: false, changelogMessage: expectedReason },
       );
       render(<Subject props={experiment} mocks={[mutationMock]} />);
       const rejectButton = await screen.findByTestId("reject-request");

--- a/app/experimenter/nimbus-ui/src/components/Summary/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/index.tsx
@@ -66,6 +66,7 @@ const Summary = ({ experiment, refetch }: SummaryProps) => {
     },
     {
       publishStatus: NimbusExperimentPublishStatus.IDLE,
+      isEndRequested: false,
     },
   );
 


### PR DESCRIPTION
Because

* We neglected to reset the isEndRequested flag when rejecting from the nimbus UI
* Experiment gets stuck if it's rejected

This commit

* Resets isEndRequested to false when rejecting from nimbus ui

<img width="1163" alt="Screen Shot 2021-06-02 at 1 48 10 PM" src="https://user-images.githubusercontent.com/119884/120528825-df68aa80-c3a9-11eb-936e-19361c84d20e.png">
