### PR TITLE
feat(nimbus): proxy nimbus-ui webpack dev server through nginx

### DIFF
--- a/app/experimenter/base/context_processors.py
+++ b/app/experimenter/base/context_processors.py
@@ -27,4 +27,4 @@ def features(request):
 
 
 def debug(request):
-    return {"DEBUG": settings.DEBUG, "USE_YARN_DEV": settings.USE_YARN_DEV}
+    return {"DEBUG": settings.DEBUG}

--- a/app/experimenter/nimbus-ui/templates/nimbus/index.html
+++ b/app/experimenter/nimbus-ui/templates/nimbus/index.html
@@ -22,10 +22,6 @@
   <noscript>Mozilla Experimenter requires JavaScript to run.</noscript>
   <div id="root" data-config="{{ APP_CONFIG }}"></div>
 
-  {% if USE_YARN_DEV %}
-    <script src="http://localhost:3000/static/js/main.js"></script>
-  {% else %}
     <script src="{% static 'nimbus/static/js/main.js' %}"></script>
-  {% endif %}
   </body>
 </html>

--- a/app/experimenter/settings.py
+++ b/app/experimenter/settings.py
@@ -42,8 +42,6 @@ ALLOWED_HOSTS = [HOSTNAME]
 if DEBUG:
     ALLOWED_HOSTS += ["localhost", "nginx"]  # pragma: no cover
 
-USE_YARN_DEV = config("USE_YARN_DEV", default=DEBUG, cast=bool)
-
 SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
 
 # Application definition

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -70,10 +70,14 @@ services:
     command: bash -c "/app/bin/wait-for-it.sh db:5432 -- celery -A experimenter beat --pidfile /celerybeat.pid -s /celerybeat-schedule -l DEBUG"
 
   nginx:
-    build: ./nginx
+    build:
+      context: ./nginx
+      args:
+        nginx_conf: nginx-dev.conf
     env_file: .env
     links:
       - app
+      - yarn-nimbus-ui
     ports:
       - "443:443"
 

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,7 +1,9 @@
 FROM nginx:1.19.8
 
+ARG nginx_conf=nginx.conf
+
 RUN rm /etc/nginx/nginx.conf
-COPY nginx.conf /etc/nginx/
+COPY $nginx_conf /etc/nginx/nginx.conf
 
 COPY key.pem /etc/nginx/
 COPY cert.pem /etc/nginx/

--- a/nginx/nginx-dev.conf
+++ b/nginx/nginx-dev.conf
@@ -1,0 +1,68 @@
+user  nginx;
+worker_processes  4;
+
+error_log  /var/log/nginx/error.log warn;
+pid        /var/run/nginx.pid;
+
+
+events {
+    worker_connections  19000;
+}
+
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log  /var/log/nginx/access.log  main;
+
+    sendfile        on;
+    #tcp_nopush     on;
+
+    keepalive_timeout  65;
+
+    #gzip  on;
+
+    server {
+        listen 443 ssl;
+        server_name localhost nginx;
+
+        ssl_certificate     cert.pem;
+        ssl_certificate_key key.pem;
+        client_max_body_size 20M;
+
+        location ~ ^/api/v1/experiments/(?:[\w-]+/recipe/)?$ {
+            proxy_pass http://app:7001;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header Host $host;
+        }
+
+        # Proxy the nimbus-ui static assets from the CRA webpack dev server
+        location /static/nimbus/ {
+            proxy_pass http://yarn-nimbus-ui:3000/;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header Host $host;
+            proxy_set_header x-forwarded-user "dev@example.com";
+        }
+
+        # Proxy the websockets interface to CRA webpack dev server
+        location /sockjs-node {
+            proxy_pass http://yarn-nimbus-ui:3000/sockjs-node;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "Upgrade";
+            proxy_set_header Host $host;
+        }
+
+        location / {
+            proxy_pass http://app:7001;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header Host $host;
+            proxy_set_header x-forwarded-user "dev@example.com";
+        }
+    }
+}


### PR DESCRIPTION
Because:

* The way we link to the nimbus-ui JS in local development differs from
  production in a way that confused at least one tool (i.e. Sentry)

* We're not taking advantage of webpack dev server features like hot
  reloading and richer exception handling

This commit:

* Switches from using the nimbus-ui webpack dev server URL in the Django
  nimbus-ui template to proxying the webpack webpack dev server and
  websocket in nginx