### PR TITLE
chore(nimbus): spread factory lifecycle changelog events out over a random timespan

### DIFF
--- a/app/experimenter/base/management/commands/load_dummy_experiments.py
+++ b/app/experimenter/base/management/commands/load_dummy_experiments.py
@@ -22,5 +22,7 @@ class Command(BaseCommand):
             logger.info("Created {}: {}".format(experiment, status))
 
         for lifecycle in NimbusExperimentFactory.Lifecycles:
-            experiment = NimbusExperimentFactory.create_with_lifecycle(lifecycle)
+            experiment = NimbusExperimentFactory.create_with_lifecycle(
+                lifecycle, with_random_timespan=True
+            )
             logger.info("Created {}: {}".format(experiment, lifecycle))


### PR DESCRIPTION
Because:

* Life cycle events in experiments created via load_dummy_experiments
  appear to happen all within the same minute

This commit:

* Spreads the life cycle events out over a much longer random timespan
  similar to legacy experimenter