### PR TITLE
fix #5121 feat(nimbus): add locale/country to nimbus configuration in v5 api

### DIFF
--- a/app/experimenter/experiments/api/v5/queries.py
+++ b/app/experimenter/experiments/api/v5/queries.py
@@ -1,11 +1,14 @@
 import graphene
 from django.conf import settings
 
+from experimenter.base.models import Country, Locale
 from experimenter.experiments.api.v5.types import (
+    NimbusCountryType,
     NimbusExperimentTargetingConfigSlugChoice,
     NimbusExperimentType,
     NimbusFeatureConfigType,
     NimbusLabelValueType,
+    NimbusLocaleType,
     NimbusOutcomeType,
 )
 from experimenter.experiments.models.nimbus import NimbusExperiment, NimbusFeatureConfig
@@ -28,6 +31,8 @@ class NimbusConfigurationType(graphene.ObjectType):
     max_primary_outcomes = graphene.Int()
     documentation_link = graphene.List(NimbusLabelValueType)
     kinto_admin_url = graphene.String()
+    locales = graphene.List(NimbusLocaleType)
+    countries = graphene.List(NimbusCountryType)
 
     def _text_choices_to_label_value_list(root, text_choices):
         return [
@@ -76,6 +81,12 @@ class NimbusConfigurationType(graphene.ObjectType):
 
     def resolve_kinto_admin_url(root, info):
         return settings.KINTO_ADMIN_URL
+
+    def resolve_locales(root, info):
+        return Locale.objects.all().order_by("name")
+
+    def resolve_countries(root, info):
+        return Country.objects.all().order_by("name")
 
 
 class Query(graphene.ObjectType):

--- a/app/experimenter/experiments/api/v5/types.py
+++ b/app/experimenter/experiments/api/v5/types.py
@@ -5,6 +5,7 @@ from django.contrib.auth import get_user_model
 from graphene_django import DjangoListField
 from graphene_django.types import DjangoObjectType
 
+from experimenter.base.models import Country, Locale
 from experimenter.experiments.api.v5.serializers import NimbusReadyForReviewSerializer
 from experimenter.experiments.api.v6.serializers import NimbusExperimentSerializer
 from experimenter.experiments.constants.nimbus import NimbusConstants
@@ -26,6 +27,18 @@ class ObjectField(graphene.Scalar):
     @staticmethod
     def serialize(dt):
         return dt
+
+
+class NimbusCountryType(DjangoObjectType):
+    class Meta:
+        model = Country
+        exclude = ("id",)
+
+
+class NimbusLocaleType(DjangoObjectType):
+    class Meta:
+        model = Locale
+        exclude = ("id",)
 
 
 class NimbusUser(DjangoObjectType):

--- a/app/experimenter/experiments/tests/api/v5/test_queries.py
+++ b/app/experimenter/experiments/tests/api/v5/test_queries.py
@@ -6,6 +6,7 @@ from django.urls import reverse
 from graphene.utils.str_converters import to_snake_case
 from graphene_django.utils.testing import GraphQLTestCase
 
+from experimenter.base.models import Country, Locale
 from experimenter.experiments.api.v6.serializers import NimbusExperimentSerializer
 from experimenter.experiments.models.nimbus import NimbusExperiment
 from experimenter.experiments.tests.factories import NimbusExperimentFactory
@@ -601,6 +602,14 @@ class TestNimbusQuery(GraphQLTestCase):
                     hypothesisDefault
                     maxPrimaryOutcomes
                     kintoAdminUrl
+                    locales {
+                        code
+                        name
+                    }
+                    countries {
+                        code
+                        name
+                    }
                 }
             }
             """,
@@ -663,6 +672,14 @@ class TestNimbusQuery(GraphQLTestCase):
         self.assertEqual(
             config["maxPrimaryOutcomes"], NimbusExperiment.MAX_PRIMARY_OUTCOMES
         )
+
+        for locale in Locale.objects.all():
+            self.assertIn({"code": locale.code, "name": locale.name}, config["locales"])
+
+        for country in Country.objects.all():
+            self.assertIn(
+                {"code": country.code, "name": country.name}, config["countries"]
+            )
 
     def test_paused_experiment_returns_date(self):
         user_email = "user@example.com"

--- a/app/experimenter/nimbus-ui/schema.graphql
+++ b/app/experimenter/nimbus-ui/schema.graphql
@@ -118,6 +118,14 @@ type NimbusConfigurationType {
   maxPrimaryOutcomes: Int
   documentationLink: [NimbusLabelValueType]
   kintoAdminUrl: String
+  locales: [NimbusLocaleType]
+  countries: [NimbusCountryType]
+}
+
+type NimbusCountryType {
+  code: String!
+  name: String!
+  nimbusexperimentSet: [NimbusExperimentType!]!
 }
 
 enum NimbusDocumentationLinkTitle {
@@ -294,6 +302,8 @@ type NimbusExperimentType {
   firefoxMinVersion: NimbusExperimentFirefoxMinVersion
   application: NimbusExperimentApplication
   channel: NimbusExperimentChannel
+  locales: [NimbusLocaleType!]!
+  countries: [NimbusCountryType!]!
   projects: [ProjectType!]!
   hypothesis: String!
   primaryOutcomes: [String]
@@ -353,6 +363,12 @@ type NimbusIsolationGroupType {
 type NimbusLabelValueType {
   label: String
   value: String
+}
+
+type NimbusLocaleType {
+  code: String!
+  name: String!
+  nimbusexperimentSet: [NimbusExperimentType!]!
 }
 
 type NimbusOutcomeType {


### PR DESCRIPTION


Because

* We need to be able to display the list of all locales/countries in the UI

This commit

* Adds locales/countries to the V5 NimbusConfiguration API