### PR TITLE
fixes #5412 fix(nimbus): tweak storybook config to fix breakage after typescript upgrade

### DIFF
--- a/app/experimenter/nimbus-ui/.storybook/main.js
+++ b/app/experimenter/nimbus-ui/.storybook/main.js
@@ -9,4 +9,7 @@ module.exports = {
     "@storybook/addon-links",
     "@storybook/preset-create-react-app",
   ],
+  typescript: {
+    reactDocgen: 'react-docgen',
+  }
 };

--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -14,6 +14,7 @@ services:
       - STORYBOOKS_GCP_BUCKET
       - STORYBOOKS_GCP_PRIVATE_KEY_BASE64
       - STORYBOOKS_GCP_CLIENT_EMAIL
+      - STORYBOOKS_USE_YARN_WORKSPACES=false
     links:
       - db
 


### PR DESCRIPTION
Because:

* Storybook builds have been failing

This commit:

* Switches from react-docgen-typescript to react-docgen in main config
  per [this advice in an upstream issue comment][comment]

* This should probably be a temporary changei until upstream releases
  fix it, though we're not (yet?) using [this feature of Storybook][react-docgen]

[comment]: https://github.com/styleguidist/react-docgen-typescript/issues/356#issuecomment-857887751
[react-docgen]: https://storybook.js.org/addons/storybook-addon-react-docgen