### PR TITLE
fixes #4590 feat(nimbus): add ids to summary branches for linking

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/Summary/TableBranches/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/TableBranches/index.tsx
@@ -69,11 +69,11 @@ const TableBranch = ({
   branch: Branch;
 }) => {
   return (
-    <Table bordered data-testid="table-branch" className="mb-4">
+    <Table bordered data-testid="table-branch" className="mb-4" id={slug}>
       <thead className="thead-light">
         <tr>
           <th colSpan={2} data-testid="branch-name">
-            {name}
+            <a href={`#${slug}`}>#</a> {name}
           </th>
         </tr>
       </thead>


### PR DESCRIPTION
Closes #4590

Real simple, just adds an ID for each branch on pages that render the Summary component, allowing you to link to them on the page, as well as a link on the branch title.