### PR TITLE
fixes #5105 feat(nimbus): use letters when adding new treatment branches

### DIFF
--- a/app/experimenter/experiments/api/v5/serializers.py
+++ b/app/experimenter/experiments/api/v5/serializers.py
@@ -162,7 +162,7 @@ class NimbusExperimentBranchMixin:
     def create(self, validated_data):
         experiment = super().create(validated_data)
         experiment.reference_branch = NimbusBranch.objects.create(
-            experiment=experiment, name="control", feature_enabled=False
+            experiment=experiment, name="Control", feature_enabled=False
         )
         experiment.save()
         return experiment

--- a/app/experimenter/experiments/tests/api/v5/test_mutations.py
+++ b/app/experimenter/experiments/tests/api/v5/test_mutations.py
@@ -76,7 +76,7 @@ class TestMutations(GraphQLTestCase):
         self.assertEqual(experiment.name, "Test 1234")
         self.assertEqual(experiment.slug, "test-1234")
         self.assertEqual(experiment.application, NimbusExperiment.Application.DESKTOP)
-        self.assertEqual(experiment.reference_branch.name, "control")
+        self.assertEqual(experiment.reference_branch.name, "Control")
 
     def test_create_experiment_error(self):
         user_email = "user@example.com"

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/index.test.tsx
@@ -72,7 +72,7 @@ describe("FormBranches", () => {
     const treatmentBranchName = (await screen.findByTestId(
       "treatmentBranches[0].name",
     )) as HTMLInputElement;
-    expect(treatmentBranchName.value).toEqual("treatment");
+    expect(treatmentBranchName.value).toEqual("Treatment A");
   });
 
   it("calls onSave with extracted update when save button clicked", async () => {

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/reducer/actions.ts
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/reducer/actions.ts
@@ -57,7 +57,11 @@ function addBranch(state: FormBranchesState) {
   } else {
     treatmentBranches = [
       ...(treatmentBranches || []),
-      createAnnotatedBranch(state.lastId, `treatment ${lastId}`),
+      createAnnotatedBranch(
+        state.lastId,
+        // 65 is A, but we generate a control, so start at 64
+        `Treatment ${String.fromCharCode(64 + lastId)}`,
+      ),
     ];
   }
 

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/reducer/state.ts
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/reducer/state.ts
@@ -69,7 +69,7 @@ export function annotateExperimentBranch(
     ...branch,
     // Set default treatment branch name - reference branch is set by the server
     ...(branch.name === "" && {
-      name: lastId === 0 ? "treatment" : "",
+      name: lastId === 0 ? "Treatment A" : "",
     }),
     key: `branch-${lastId}`,
     isValid: true,


### PR DESCRIPTION
Closes #5105

This PR:

- Updates the default branches to use capitalized titles
- Changes the generation of treatment branches to increment in letters instead of numbers