### PR TITLE
fixes #5238 feat(nimbus): add PreviewURL component to Storybook

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/PreviewURL/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PreviewURL/index.stories.tsx
@@ -1,0 +1,24 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from "react";
+import PreviewURL from ".";
+import { getStatus } from "../../lib/experiment";
+import { mockExperiment } from "../../lib/mocks";
+
+export default {
+  title: "components/PreviewURL",
+  component: PreviewURL,
+};
+
+export const Basic = () => {
+  const experiment = mockExperiment();
+  const status = getStatus(experiment);
+
+  return (
+    <div className="p-3">
+      <PreviewURL {...{ ...experiment, status }} />
+    </div>
+  );
+};

--- a/app/experimenter/nimbus-ui/src/components/PreviewURL/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PreviewURL/index.tsx
@@ -27,7 +27,7 @@ const CopyableURL: React.FC<CopyableURLProps> = ({
     url = `${url}&optin_collection=${collection}`;
   }
   return (
-    <code onClick={() => clipboard.writeText(url)} style={{ cursor: "copy" }}>
+    <code onClick={() => clipboard.writeText(url)} className="cursor-copy">
       {url}
     </code>
   );

--- a/app/experimenter/nimbus-ui/src/styles/index.scss
+++ b/app/experimenter/nimbus-ui/src/styles/index.scss
@@ -125,3 +125,7 @@ select.form-control.is-warning {
 .__react_component_tooltip > p:last-child {
   margin-bottom: 0;
 }
+
+.cursor-copy {
+  cursor: copy;
+}


### PR DESCRIPTION
Closes #5238

Adds the `PreviewURL` component to storybook, moves its inline copy cursor styles to a utility class.