### PR TITLE
chore(nimbus): add some extra info to vnc integration test instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,7 +307,19 @@ Run the integration test suite for nimbus inside a containerized instance of Fir
 
 #### make integration_vnc_up
 
-Start a linux VM container with VNC available over `vnc://localhost:5900` with password `secret`. Right click on the desktop and select `Applications > Shell > Bash` and enter:
+First start a prod instance of Experimenter with:
+
+```bash
+make refresh&&make up_prod_detached
+```
+
+Then start the VNC service:
+
+```bash
+make integration_vnc_up
+```
+
+Then open your VNC client (Safari does this on OSX or just use [VNC Viewer](https://www.realvnc.com/en/connect/download/viewer/)) and open `vnc://localhost:5900` with password `secret`. Right click on the desktop and select `Applications > Shell > Bash` and enter:
 
 ```bash
 cd app


### PR DESCRIPTION
Because

* Just to be a little clearer about how to run the integration tests

This commit

* Adds some extra clarity to the integration test instructions