### PR TITLE
fixes #5041 feat(nimbus): Use more specific remote settings review url

### DIFF
--- a/app/experimenter/experiments/api/v5/queries.py
+++ b/app/experimenter/experiments/api/v5/queries.py
@@ -1,5 +1,4 @@
 import graphene
-from django.conf import settings
 
 from experimenter.base.models import Country, Locale
 from experimenter.experiments.api.v5.types import (
@@ -30,7 +29,6 @@ class NimbusConfigurationType(graphene.ObjectType):
     hypothesis_default = graphene.String()
     max_primary_outcomes = graphene.Int()
     documentation_link = graphene.List(NimbusLabelValueType)
-    kinto_admin_url = graphene.String()
     locales = graphene.List(NimbusLocaleType)
     countries = graphene.List(NimbusCountryType)
 
@@ -78,9 +76,6 @@ class NimbusConfigurationType(graphene.ObjectType):
 
     def resolve_documentation_link(root, info):
         return root._text_choices_to_label_value_list(NimbusExperiment.DocumentationLink)
-
-    def resolve_kinto_admin_url(root, info):
-        return settings.KINTO_ADMIN_URL
 
     def resolve_locales(root, info):
         return Locale.objects.all().order_by("name")

--- a/app/experimenter/experiments/api/v5/types.py
+++ b/app/experimenter/experiments/api/v5/types.py
@@ -186,6 +186,7 @@ class NimbusExperimentType(DjangoObjectType):
     timeout = graphene.Field(NimbusChangeLogType)
     signoff_recommendations = graphene.Field(NimbusSignoffRecommendationsType)
     recipe_json = graphene.String()
+    review_url = graphene.String()
 
     class Meta:
         model = NimbusExperiment

--- a/app/experimenter/experiments/constants/nimbus.py
+++ b/app/experimenter/experiments/constants/nimbus.py
@@ -39,7 +39,7 @@ APPLICATION_CONFIG_DESKTOP = ApplicationConfig(
         Channel.RELEASE: "firefox-desktop",
     },
     default_app_id="firefox-desktop",
-    rs_experiments_collection="nimbus-desktop-experiments",
+    rs_experiments_collection=settings.KINTO_COLLECTION_NIMBUS_DESKTOP,
     randomization_unit=BucketRandomizationUnit.NORMANDY,
 )
 
@@ -53,7 +53,7 @@ APPLICATION_CONFIG_FENIX = ApplicationConfig(
         Channel.RELEASE: "org.mozilla.firefox",
     },
     default_app_id="",
-    rs_experiments_collection="nimbus-mobile-experiments",
+    rs_experiments_collection=settings.KINTO_COLLECTION_NIMBUS_MOBILE,
     randomization_unit=BucketRandomizationUnit.NIMBUS,
 )
 
@@ -67,7 +67,7 @@ APPLICATION_CONFIG_IOS = ApplicationConfig(
         Channel.RELEASE: "org.mozilla.ios.Firefox",
     },
     default_app_id="",
-    rs_experiments_collection="nimbus-mobile-experiments",
+    rs_experiments_collection=settings.KINTO_COLLECTION_NIMBUS_MOBILE,
     randomization_unit=BucketRandomizationUnit.NIMBUS,
 )
 

--- a/app/experimenter/experiments/constants/nimbus.py
+++ b/app/experimenter/experiments/constants/nimbus.py
@@ -25,6 +25,7 @@ class ApplicationConfig:
     app_name: str
     channel_app_id: Dict[str, str]
     default_app_id: str
+    rs_experiments_collection: str
     randomization_unit: str
 
 
@@ -38,6 +39,7 @@ APPLICATION_CONFIG_DESKTOP = ApplicationConfig(
         Channel.RELEASE: "firefox-desktop",
     },
     default_app_id="firefox-desktop",
+    rs_experiments_collection="nimbus-desktop-experiments",
     randomization_unit=BucketRandomizationUnit.NORMANDY,
 )
 
@@ -51,6 +53,7 @@ APPLICATION_CONFIG_FENIX = ApplicationConfig(
         Channel.RELEASE: "org.mozilla.firefox",
     },
     default_app_id="",
+    rs_experiments_collection="nimbus-mobile-experiments",
     randomization_unit=BucketRandomizationUnit.NIMBUS,
 )
 
@@ -64,6 +67,7 @@ APPLICATION_CONFIG_IOS = ApplicationConfig(
         Channel.RELEASE: "org.mozilla.ios.Firefox",
     },
     default_app_id="",
+    rs_experiments_collection="nimbus-mobile-experiments",
     randomization_unit=BucketRandomizationUnit.NIMBUS,
 )
 

--- a/app/experimenter/experiments/models/nimbus.py
+++ b/app/experimenter/experiments/models/nimbus.py
@@ -308,14 +308,12 @@ class NimbusExperiment(NimbusConstants, FilterMixin, models.Model):
 
     @property
     def review_url(self):
-        is_staging = "settings-writer.stage" in settings.KINTO_ADMIN_URL
-
         return "{base_url}/{collection_path}/{collection}/{review_path}".format(
             base_url=settings.KINTO_ADMIN_URL,
             collection_path="#/buckets/main-workspace/collections",
             collection=self.application_config.rs_experiments_collection,
-            # TODO: Update when simple-review is on prod in remote settings
-            review_path="simple-review" if is_staging else "records",
+            # TODO: Remove IS_STAGING https://github.com/mozilla/experimenter/issues/5451
+            review_path="simple-review" if settings.IS_STAGING else "records",
         )
 
     def delete_branches(self):

--- a/app/experimenter/experiments/models/nimbus.py
+++ b/app/experimenter/experiments/models/nimbus.py
@@ -306,6 +306,18 @@ class NimbusExperiment(NimbusConstants, FilterMixin, models.Model):
             slug=self.slug, from_date=start_date, to_date=end_date
         )
 
+    @property
+    def review_url(self):
+        is_staging = "settings-writer.stage" in settings.KINTO_ADMIN_URL
+
+        return "{base_url}/{collection_path}/{collection}/{review_path}".format(
+            base_url=settings.KINTO_ADMIN_URL,
+            collection_path="#/buckets/main-workspace/collections",
+            collection=self.application_config.rs_experiments_collection,
+            # TODO: Update when simple-review is on prod in remote settings
+            review_path="simple-review" if is_staging else "records",
+        )
+
     def delete_branches(self):
         self.reference_branch = None
         self.save()

--- a/app/experimenter/experiments/tests/api/v5/test_queries.py
+++ b/app/experimenter/experiments/tests/api/v5/test_queries.py
@@ -601,7 +601,6 @@ class TestNimbusQuery(GraphQLTestCase):
                     }
                     hypothesisDefault
                     maxPrimaryOutcomes
-                    kintoAdminUrl
                     locales {
                         code
                         name
@@ -629,7 +628,6 @@ class TestNimbusQuery(GraphQLTestCase):
         assertChoices(config["channel"], NimbusExperiment.Channel)
         assertChoices(config["firefoxMinVersion"], NimbusExperiment.Version)
         assertChoices(config["documentationLink"], NimbusExperiment.DocumentationLink)
-        self.assertEqual(config["kintoAdminUrl"], settings.KINTO_ADMIN_URL)
         self.assertEqual(len(config["featureConfig"]), 13)
 
         for outcome in Outcomes.all():

--- a/app/experimenter/experiments/tests/test_models/test_models_nimbus.py
+++ b/app/experimenter/experiments/tests/test_models/test_models_nimbus.py
@@ -420,7 +420,8 @@ class TestNimbusExperiment(TestCase):
 
     def test_review_url_stage_should_return_simple_review_url(self):
         with override_settings(
-            KINTO_ADMIN_URL="https://settings-writer.stage.mozaws.net/v1/admin"
+            IS_STAGING=True,
+            KINTO_ADMIN_URL="https://settings-writer.stage.mozaws.net/v1/admin",
         ):
             expected = (
                 "https://settings-writer.stage.mozaws.net/v1/admin/#/buckets"
@@ -434,7 +435,8 @@ class TestNimbusExperiment(TestCase):
 
     def test_review_url_prod_should_return_records_url(self):
         with override_settings(
-            KINTO_ADMIN_URL="https://settings-writer.prod.mozaws.net/v1/admin"
+            IS_STAGING=False,
+            KINTO_ADMIN_URL="https://settings-writer.prod.mozaws.net/v1/admin",
         ):
             expected = (
                 "https://settings-writer.prod.mozaws.net/v1/admin/#/buckets"

--- a/app/experimenter/experiments/tests/test_models/test_models_nimbus.py
+++ b/app/experimenter/experiments/tests/test_models/test_models_nimbus.py
@@ -418,6 +418,34 @@ class TestNimbusExperiment(TestCase):
             ),
         )
 
+    def test_review_url_stage_should_return_simple_review_url(self):
+        with override_settings(
+            KINTO_ADMIN_URL="https://settings-writer.stage.mozaws.net/v1/admin"
+        ):
+            expected = (
+                "https://settings-writer.stage.mozaws.net/v1/admin/#/buckets"
+                "/main-workspace/collections/nimbus-desktop-experiments/simple-review"
+            )
+            experiment = NimbusExperimentFactory.create_with_lifecycle(
+                NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE,
+                application=NimbusExperiment.Application.DESKTOP,
+            )
+            self.assertEqual(experiment.review_url, expected)
+
+    def test_review_url_prod_should_return_records_url(self):
+        with override_settings(
+            KINTO_ADMIN_URL="https://settings-writer.prod.mozaws.net/v1/admin"
+        ):
+            expected = (
+                "https://settings-writer.prod.mozaws.net/v1/admin/#/buckets"
+                "/main-workspace/collections/nimbus-mobile-experiments/records"
+            )
+            experiment = NimbusExperimentFactory.create_with_lifecycle(
+                NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE,
+                application=NimbusExperiment.Application.FENIX,
+            )
+            self.assertEqual(experiment.review_url, expected)
+
     def test_clear_branches_deletes_branches_without_deleting_experiment(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.CREATED,

--- a/app/experimenter/nimbus-ui/schema.graphql
+++ b/app/experimenter/nimbus-ui/schema.graphql
@@ -133,7 +133,6 @@ type NimbusConfigurationType {
   hypothesisDefault: String
   maxPrimaryOutcomes: Int
   documentationLink: [NimbusLabelValueType]
-  kintoAdminUrl: String
   locales: [NimbusLocaleType]
   countries: [NimbusCountryType]
 }
@@ -350,6 +349,7 @@ type NimbusExperimentType {
   timeout: NimbusChangeLogType
   signoffRecommendations: NimbusSignoffRecommendationsType
   recipeJson: String
+  reviewUrl: String
 }
 
 type NimbusFeatureConfigType {

--- a/app/experimenter/nimbus-ui/src/components/PageRequestReview/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageRequestReview/index.test.tsx
@@ -17,7 +17,7 @@ import {
   CHANGELOG_MESSAGES,
   SERVER_ERRORS,
 } from "../../lib/constants";
-import { mockExperimentQuery, MOCK_CONFIG } from "../../lib/mocks";
+import { mockExperimentQuery } from "../../lib/mocks";
 import {
   NimbusExperimentPublishStatus,
   NimbusExperimentStatus,
@@ -241,7 +241,7 @@ describe("PageRequestReview", () => {
     fireEvent.click(openRemoteSettingsButton);
     await waitFor(() => {
       expect(mockWindowOpen).toHaveBeenCalledWith(
-        MOCK_CONFIG.kintoAdminUrl,
+        experiment.reviewUrl,
         "_blank",
       );
     });

--- a/app/experimenter/nimbus-ui/src/components/PageRequestReview/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageRequestReview/index.tsx
@@ -7,7 +7,6 @@ import React, { useState } from "react";
 import { Table } from "react-bootstrap";
 import Alert from "react-bootstrap/Alert";
 import { useChangeOperationMutation, useReviewCheck } from "../../hooks";
-import { useConfig } from "../../hooks/useConfig";
 import { CHANGELOG_MESSAGES, EXTERNAL_URLS } from "../../lib/constants";
 import { getStatus } from "../../lib/experiment";
 import { getExperiment_experimentBySlug } from "../../types/getExperiment";
@@ -50,13 +49,13 @@ const PageContent: React.FC<{
   experiment: getExperiment_experimentBySlug;
   refetch: () => void;
 }> = ({ experiment, refetch }) => {
-  const { kintoAdminUrl } = useConfig();
+  const { reviewUrl } = experiment;
   const [showLaunchToReview, setShowLaunchToReview] = useState(false);
   const { invalidPages, InvalidPagesList } = useReviewCheck(experiment);
 
   const status = getStatus(experiment);
   const startRemoteSettingsApproval = async () => {
-    window.open(kintoAdminUrl!, "_blank");
+    window.open(reviewUrl!, "_blank");
   };
 
   const {

--- a/app/experimenter/nimbus-ui/src/components/Summary/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/index.test.tsx
@@ -5,7 +5,7 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import React from "react";
 import { CHANGELOG_MESSAGES, SUBMIT_ERROR } from "../../lib/constants";
-import { mockExperimentQuery, MOCK_CONFIG } from "../../lib/mocks";
+import { mockExperimentQuery } from "../../lib/mocks";
 import {
   NimbusExperimentPublishStatus,
   NimbusExperimentStatus,
@@ -161,7 +161,7 @@ describe("Summary", () => {
       fireEvent.click(openRemoteSettingsButton);
       await waitFor(() => {
         expect(mockWindowOpen).toHaveBeenCalledWith(
-          MOCK_CONFIG.kintoAdminUrl,
+          experiment.reviewUrl,
           "_blank",
         );
       });

--- a/app/experimenter/nimbus-ui/src/components/Summary/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/index.tsx
@@ -5,7 +5,7 @@
 import React from "react";
 import Alert from "react-bootstrap/Alert";
 import Badge from "react-bootstrap/Badge";
-import { useChangeOperationMutation, useConfig } from "../../hooks";
+import { useChangeOperationMutation } from "../../hooks";
 import { CHANGELOG_MESSAGES } from "../../lib/constants";
 import { getStatus } from "../../lib/experiment";
 import { ConfigOptions, getConfigLabel } from "../../lib/getConfigLabel";
@@ -30,7 +30,7 @@ type SummaryProps = {
 } & Partial<React.ComponentProps<typeof ChangeApprovalOperations>>; // TODO EXP-1143: temporary page-level props, should be replaced by API data for experiment & current user
 
 const Summary = ({ experiment, refetch }: SummaryProps) => {
-  const { kintoAdminUrl } = useConfig();
+  const { reviewUrl } = experiment;
   const status = getStatus(experiment);
 
   const {
@@ -42,7 +42,7 @@ const Summary = ({ experiment, refetch }: SummaryProps) => {
   } = experiment;
 
   const startRemoteSettingsApproval = async () => {
-    window.open(kintoAdminUrl!, "_blank");
+    window.open(reviewUrl!, "_blank");
   };
 
   const {

--- a/app/experimenter/nimbus-ui/src/gql/config.ts
+++ b/app/experimenter/nimbus-ui/src/gql/config.ts
@@ -45,7 +45,6 @@ export const GET_CONFIG_QUERY = gql`
         value
       }
       maxPrimaryOutcomes
-      kintoAdminUrl
     }
   }
 `;

--- a/app/experimenter/nimbus-ui/src/gql/experiments.ts
+++ b/app/experimenter/nimbus-ui/src/gql/experiments.ts
@@ -131,6 +131,7 @@ export const GET_EXPERIMENT_QUERY = gql`
         }
       }
       recipeJson
+      reviewUrl
     }
   }
 `;

--- a/app/experimenter/nimbus-ui/src/lib/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/lib/mocks.tsx
@@ -165,7 +165,6 @@ export const MOCK_CONFIG: getConfig_nimbusConfig = {
     },
   ],
   maxPrimaryOutcomes: 2,
-  kintoAdminUrl: "https://kinto.example.com/v1/admin/",
 };
 
 // Disabling this rule for now because we'll eventually
@@ -331,6 +330,8 @@ export function mockExperiment<
       riskBrand: false,
       riskRevenue: true,
       riskPartnerRelated: false,
+      reviewUrl:
+        "https://kinto.example.com/v1/admin/#/buckets/main-workspace/collections/nimbus-desktop-experiments/simple-review",
     },
     modifications,
   ) as T;

--- a/app/experimenter/nimbus-ui/src/types/getConfig.ts
+++ b/app/experimenter/nimbus-ui/src/types/getConfig.ts
@@ -62,7 +62,6 @@ export interface getConfig_nimbusConfig {
   hypothesisDefault: string | null;
   documentationLink: (getConfig_nimbusConfig_documentationLink | null)[] | null;
   maxPrimaryOutcomes: number | null;
-  kintoAdminUrl: string | null;
 }
 
 export interface getConfig {

--- a/app/experimenter/nimbus-ui/src/types/getExperiment.ts
+++ b/app/experimenter/nimbus-ui/src/types/getExperiment.ts
@@ -127,6 +127,7 @@ export interface getExperiment_experimentBySlug {
   rejection: getExperiment_experimentBySlug_rejection | null;
   timeout: getExperiment_experimentBySlug_timeout | null;
   recipeJson: string | null;
+  reviewUrl: string | null;
 }
 
 export interface getExperiment {

--- a/app/experimenter/settings.py
+++ b/app/experimenter/settings.py
@@ -37,6 +37,8 @@ DEBUG = config("DEBUG", default=False, cast=bool)
 
 HOSTNAME = config("HOSTNAME")
 
+IS_STAGING = "stage." in HOSTNAME
+
 ALLOWED_HOSTS = [HOSTNAME]
 
 if DEBUG:


### PR DESCRIPTION
Because

* We have a new UI for reviewing we'd like to try on staging

This commit

* Adds a review_url property to the nimbus model
* Replaces kinto_admin_url usages in the front end to use the review_url
* Sets the review_url path to /{collection}/simple-review for staging
* Sets the review+url path to /{collection}/records for prod