### PR TITLE
fixes #5712 feat(project): add country and locale to v5 input/serializer

### DIFF
--- a/app/experimenter/experiments/api/v5/inputs.py
+++ b/app/experimenter/experiments/api/v5/inputs.py
@@ -63,3 +63,5 @@ class ExperimentInput(graphene.InputObjectType):
     risk_partner_related = graphene.Boolean()
     risk_revenue = graphene.Boolean()
     risk_brand = graphene.Boolean()
+    countries = graphene.List(graphene.Int)
+    locales = graphene.List(graphene.Int)

--- a/app/experimenter/experiments/api/v5/serializers.py
+++ b/app/experimenter/experiments/api/v5/serializers.py
@@ -5,6 +5,7 @@ from django.db import transaction
 from django.utils.text import slugify
 from rest_framework import serializers
 
+from experimenter.base.models import Country, Locale
 from experimenter.experiments.changelog_utils import generate_nimbus_changelog
 from experimenter.experiments.constants.nimbus import NimbusConstants
 from experimenter.experiments.models import NimbusExperiment
@@ -335,6 +336,18 @@ class NimbusExperimentSerializer(
     changelog_message = serializers.CharField(
         min_length=0, max_length=1024, required=True, allow_blank=False
     )
+    countries = serializers.PrimaryKeyRelatedField(
+        queryset=Country.objects.all(),
+        allow_null=True,
+        required=False,
+        many=True,
+    )
+    locales = serializers.PrimaryKeyRelatedField(
+        queryset=Locale.objects.all(),
+        allow_null=True,
+        required=False,
+        many=True,
+    )
 
     class Meta:
         model = NimbusExperiment
@@ -365,6 +378,8 @@ class NimbusExperimentSerializer(
             "risk_partner_related",
             "risk_revenue",
             "risk_brand",
+            "countries",
+            "locales",
         ]
 
     def __init__(self, instance=None, data=None, **kwargs):

--- a/app/experimenter/experiments/api/v5/types.py
+++ b/app/experimenter/experiments/api/v5/types.py
@@ -30,15 +30,21 @@ class ObjectField(graphene.Scalar):
 
 
 class NimbusCountryType(DjangoObjectType):
+    id = graphene.Int()
+    code = graphene.String()
+    name = graphene.String()
+
     class Meta:
         model = Country
-        exclude = ("id",)
 
 
 class NimbusLocaleType(DjangoObjectType):
+    id = graphene.Int()
+    code = graphene.String()
+    name = graphene.String()
+
     class Meta:
         model = Locale
-        exclude = ("id",)
 
 
 class NimbusUser(DjangoObjectType):

--- a/app/experimenter/experiments/tests/api/v5/test_mutations.py
+++ b/app/experimenter/experiments/tests/api/v5/test_mutations.py
@@ -5,6 +5,7 @@ from django.conf import settings
 from django.urls import reverse
 from graphene_django.utils.testing import GraphQLTestCase
 
+from experimenter.base.tests.factories import CountryFactory, LocaleFactory
 from experimenter.experiments.constants.nimbus import NimbusConstants
 from experimenter.experiments.models.nimbus import NimbusExperiment, NimbusFeatureConfig
 from experimenter.experiments.tests.factories.nimbus import (
@@ -409,6 +410,8 @@ class TestMutations(GraphQLTestCase):
 
     def test_update_experiment_audience(self):
         user_email = "user@example.com"
+        country = CountryFactory.create()
+        locale = LocaleFactory.create()
         experiment = NimbusExperimentFactory.create(
             status=NimbusExperiment.Status.DRAFT,
             channel=NimbusExperiment.Channel.NO_CHANNEL,
@@ -435,6 +438,8 @@ class TestMutations(GraphQLTestCase):
                     ),
                     "totalEnrolledClients": 100,
                     "changelogMessage": "test changelog message",
+                    "countries": [country.id],
+                    "locales": [locale.id],
                 }
             },
             headers={settings.OPENIDC_EMAIL_HEADER: user_email},
@@ -453,6 +458,8 @@ class TestMutations(GraphQLTestCase):
             NimbusConstants.TargetingConfig.ALL_ENGLISH.value,
         )
         self.assertEqual(experiment.total_enrolled_clients, 100)
+        self.assertEqual(list(experiment.countries.all()), [country])
+        self.assertEqual(list(experiment.locales.all()), [locale])
 
     def test_update_experiment_audience_error(self):
         user_email = "user@example.com"

--- a/app/experimenter/experiments/tests/api/v5/test_serializers.py
+++ b/app/experimenter/experiments/tests/api/v5/test_serializers.py
@@ -5,6 +5,7 @@ from django.test import TestCase
 from django.utils.text import slugify
 from parameterized import parameterized
 
+from experimenter.base.tests.factories import CountryFactory, LocaleFactory
 from experimenter.experiments.api.v5.serializers import (
     NimbusBranchSerializer,
     NimbusExperimentSerializer,
@@ -775,6 +776,8 @@ class TestNimbusExperimentSerializer(TestCase):
             "targeting_config_slug": NimbusExperiment.TargetingConfig.NO_TARGETING,
             "total_enrolled_clients": 0,
             "changelog_message": "test changelog message",
+            "countries": [],
+            "locales": [],
         }
 
         serializer = NimbusExperimentSerializer(
@@ -806,6 +809,8 @@ class TestNimbusExperimentSerializer(TestCase):
             NimbusExperiment.TargetingConfig.NO_TARGETING,
         )
         self.assertEqual(experiment.total_enrolled_clients, 0)
+        self.assertEqual(list(experiment.countries.all()), [])
+        self.assertEqual(list(experiment.locales.all()), [])
 
     def test_serializer_creates_experiment_and_sets_slug_and_owner(self):
         data = {
@@ -933,6 +938,8 @@ class TestNimbusExperimentSerializer(TestCase):
         self.assertEqual(experiment.public_description, "New public description")
 
     def test_serializer_updates_audience_on_experiment(self):
+        country = CountryFactory.create()
+        locale = LocaleFactory.create()
         experiment = NimbusExperimentFactory(
             channel=NimbusExperiment.Channel.NO_CHANNEL,
             application=NimbusExperiment.Application.DESKTOP,
@@ -956,6 +963,8 @@ class TestNimbusExperimentSerializer(TestCase):
                 ),
                 "total_enrolled_clients": 100,
                 "changelog_message": "test changelog message",
+                "countries": [country.id],
+                "locales": [locale.id],
             },
             context={"user": self.user},
         )
@@ -975,6 +984,8 @@ class TestNimbusExperimentSerializer(TestCase):
             NimbusConstants.TargetingConfig.ALL_ENGLISH.value,
         )
         self.assertEqual(experiment.total_enrolled_clients, 100)
+        self.assertEqual(list(experiment.countries.all()), [country])
+        self.assertEqual(list(experiment.locales.all()), [locale])
 
     @parameterized.expand(
         [

--- a/app/experimenter/nimbus-ui/schema.graphql
+++ b/app/experimenter/nimbus-ui/schema.graphql
@@ -42,6 +42,8 @@ input ExperimentInput {
   riskPartnerRelated: Boolean
   riskRevenue: Boolean
   riskBrand: Boolean
+  countries: [Int]
+  locales: [Int]
 }
 
 scalar JSONString
@@ -138,8 +140,9 @@ type NimbusConfigurationType {
 }
 
 type NimbusCountryType {
-  code: String!
-  name: String!
+  id: Int
+  code: String
+  name: String
   nimbusexperimentSet: [NimbusExperimentType!]!
 }
 
@@ -385,8 +388,9 @@ type NimbusLabelValueType {
 }
 
 type NimbusLocaleType {
-  code: String!
-  name: String!
+  id: Int
+  code: String
+  name: String
   nimbusexperimentSet: [NimbusExperimentType!]!
 }
 

--- a/app/experimenter/nimbus-ui/src/types/globalTypes.ts
+++ b/app/experimenter/nimbus-ui/src/types/globalTypes.ts
@@ -184,6 +184,8 @@ export interface ExperimentInput {
   riskPartnerRelated?: boolean | null;
   riskRevenue?: boolean | null;
   riskBrand?: boolean | null;
+  countries?: (number | null)[] | null;
+  locales?: (number | null)[] | null;
 }
 
 export interface ReferenceBranchType {


### PR DESCRIPTION
Closes #5712

This PR adds Countries and Locales to the Nimbus experiment input and serializer classes. With this change an experiment's countries and locales can be updated via GraphQL mutations.