### PR TITLE
fix #5813: fix(visualization): fix broken CI.

### DIFF
--- a/app/experimenter/jetstream/tasks.py
+++ b/app/experimenter/jetstream/tasks.py
@@ -41,7 +41,7 @@ def fetch_jetstream_data():
                 and (
                     experiment.computed_end_date
                     + datetime.timedelta(days=NimbusConstants.DAYS_ANALYSIS_BUFFER)
-                ).date()
+                )
                 < datetime.date.today()
             ):
                 metrics.incr("fetch_jetstream_data.skipped")


### PR DESCRIPTION
Because:
* CI is broken due to the usage of datetime

This commit:
* Addresses the breakage