### PR TITLE
fixes #5719 feat(nimbus): display countries and locales on summary table

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/Summary/TableAudience/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/TableAudience/index.stories.tsx
@@ -25,6 +25,8 @@ storiesOf("components/Summary/TableAudience", module)
     const { experiment } = mockExperimentQuery("demo-slug", {
       totalEnrolledClients: 0,
       targetingConfigSlug: null,
+      locales: [],
+      countries: [],
     });
     return (
       <Subject>

--- a/app/experimenter/nimbus-ui/src/components/Summary/TableAudience/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/TableAudience/index.test.tsx
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import React from "react";
 import TableAudience from ".";
 import { MockedCache, mockExperimentQuery } from "../../../lib/mocks";
@@ -137,6 +137,50 @@ describe("TableAudience", () => {
       expect(
         screen.queryByTestId("experiment-recipe-json"),
       ).not.toBeInTheDocument();
+    });
+  });
+
+  describe("renders 'Targeted Locales' row as expected", () => {
+    it("when locales exist, displays them", () => {
+      const data = {
+        locales: [{ name: "Quebecois", code: "qc" }],
+      };
+      const { experiment } = mockExperimentQuery("demo-slug", data);
+      render(<Subject {...{ experiment }} />);
+      within(screen.getByTestId("experiment-locales")).findByText(
+        data.locales.map((l) => l.name).join(", "),
+      );
+    });
+    it("when locales don't exist, displays all", () => {
+      const { experiment } = mockExperimentQuery("demo-slug", {
+        locales: [],
+      });
+      render(<Subject {...{ experiment }} />);
+      within(screen.getByTestId("experiment-locales")).findByText(
+        "All locales",
+      );
+    });
+  });
+
+  describe("renders 'Targeted Countries' row as expected", () => {
+    it("when countries exist, displays them", async () => {
+      const data = {
+        locales: [{ name: "Canada", code: "ca" }],
+      };
+      const { experiment } = mockExperimentQuery("demo-slug", data);
+      render(<Subject {...{ experiment }} />);
+      await within(screen.getByTestId("experiment-countries")).findByText(
+        data.locales.map((l) => l.name).join(", "),
+      );
+    });
+    it("when countries don't exist, displays all", async () => {
+      const { experiment } = mockExperimentQuery("demo-slug", {
+        countries: [],
+      });
+      render(<Subject {...{ experiment }} />);
+      await within(screen.getByTestId("experiment-countries")).findByText(
+        "All countries",
+      );
     });
   });
 });

--- a/app/experimenter/nimbus-ui/src/components/Summary/TableAudience/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/TableAudience/index.tsx
@@ -66,6 +66,22 @@ const TableAudience = ({ experiment }: TableAudienceProps) => {
             </td>
           </tr>
         )}
+        <tr>
+          <th>Targeted Locales</th>
+          <td data-testid="experiment-locales">
+            {experiment.locales.length > 0
+              ? experiment.locales.map((l) => l.name).join(", ")
+              : "All locales"}
+          </td>
+        </tr>
+        <tr>
+          <th>Targeted Countries</th>
+          <td data-testid="experiment-countries">
+            {experiment.countries.length > 0
+              ? experiment.countries.map((c) => c.name).join(", ")
+              : "All countries"}
+          </td>
+        </tr>
         {experiment.jexlTargetingExpression &&
         experiment.jexlTargetingExpression !== "" ? (
           <tr>

--- a/app/experimenter/nimbus-ui/src/gql/experiments.ts
+++ b/app/experimenter/nimbus-ui/src/gql/experiments.ts
@@ -134,6 +134,15 @@ export const GET_EXPERIMENT_QUERY = gql`
       }
       recipeJson
       reviewUrl
+
+      locales {
+        code
+        name
+      }
+      countries {
+        code
+        name
+      }
     }
   }
 `;

--- a/app/experimenter/nimbus-ui/src/lib/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/lib/mocks.tsx
@@ -334,6 +334,8 @@ export function mockExperiment<
       riskPartnerRelated: false,
       reviewUrl:
         "https://kinto.example.com/v1/admin/#/buckets/main-workspace/collections/nimbus-desktop-experiments/simple-review",
+      locales: [{ name: "Quebecois", code: "qc" }],
+      countries: [{ name: "Canada", code: "ca" }],
     },
     modifications,
   ) as T;

--- a/app/experimenter/nimbus-ui/src/types/getExperiment.ts
+++ b/app/experimenter/nimbus-ui/src/types/getExperiment.ts
@@ -85,6 +85,16 @@ export interface getExperiment_experimentBySlug_timeout {
   changedBy: getExperiment_experimentBySlug_timeout_changedBy;
 }
 
+export interface getExperiment_experimentBySlug_locales {
+  code: string | null;
+  name: string | null;
+}
+
+export interface getExperiment_experimentBySlug_countries {
+  code: string | null;
+  name: string | null;
+}
+
 export interface getExperiment_experimentBySlug {
   id: number | null;
   name: string;
@@ -130,6 +140,8 @@ export interface getExperiment_experimentBySlug {
   timeout: getExperiment_experimentBySlug_timeout | null;
   recipeJson: string | null;
   reviewUrl: string | null;
+  locales: getExperiment_experimentBySlug_locales[];
+  countries: getExperiment_experimentBySlug_countries[];
 }
 
 export interface getExperiment {


### PR DESCRIPTION
Closes #5719

This PR adds countries and locales to an experiment's summary page

Storybook for when values [are set](https://storage.googleapis.com/mozilla-storybooks-experimenter/commits/b73eec70db20a66c63f1bb3df4a06436ed07ca18/nimbus-ui/index.html?path=/story/components-summary-tableaudience--all-fields-filled-out), and when they [aren't set](https://storage.googleapis.com/mozilla-storybooks-experimenter/commits/b73eec70db20a66c63f1bb3df4a06436ed07ca18/nimbus-ui/index.html?path=/story/components-summary-tableaudience--only-required-fields-filled-out) ("all").