### PR TITLE
fix #5773 chore(nimbus): ensure release version is supplied to Sentry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,3 +101,10 @@ google-credentials.json
 
 # Jetstream config
 app/experimenter/outcomes/jetstream-config*
+
+# Versioning assets generated on build
+app/commit-description.txt
+app/commit-summary.txt
+app/experimenter/version.json
+app/version.json
+

--- a/app/experimenter/base/__init__.py
+++ b/app/experimenter/base/__init__.py
@@ -1,0 +1,25 @@
+import json
+import os
+
+from django.conf import settings
+
+APP_VERSION = None
+
+
+def app_version():
+    global APP_VERSION
+
+    if APP_VERSION is None:
+        if settings.APP_VERSION:
+            APP_VERSION = settings.APP_VERSION
+        else:
+            try:
+                version_json_path = os.path.join(settings.BASE_DIR, "version.json")
+                with open(version_json_path) as version_json_file:
+                    version_json = json.load(version_json_file)
+                    APP_VERSION = version_json["commit"]
+            except IOError:
+                # EXP-1384: Preserve default blank version if version.json unavailable
+                APP_VERSION = ""
+
+    return APP_VERSION

--- a/app/experimenter/base/context_processors.py
+++ b/app/experimenter/base/context_processors.py
@@ -4,6 +4,8 @@ import urllib
 from django.conf import settings
 from django.urls import reverse
 
+from experimenter.base import app_version
+
 
 def google_analytics(request):
     """Context processor bits you need related to injecting Google Analytics
@@ -19,6 +21,7 @@ def features(request):
             json.dumps(
                 {
                     "sentry_dsn": settings.SENTRY_DSN_NIMBUS_UI,
+                    "version": app_version(),
                     "graphql_url": reverse("nimbus-api-graphql"),
                 }
             )

--- a/app/experimenter/base/tests/test_base.py
+++ b/app/experimenter/base/tests/test_base.py
@@ -1,0 +1,53 @@
+import os
+
+import mock
+from django.conf import settings
+from django.test import TestCase
+
+from experimenter.base import app_version
+
+
+class TestBase(TestCase):
+    def setUp(self):
+        self.version_json_path = os.path.join(settings.BASE_DIR, "version.json")
+
+    def test_app_version_file(self):
+        expected_version = "8675309"
+        version_json = f'{{"commit": "{expected_version}"}}'
+        with self.settings(APP_VERSION=None):
+            with mock.patch(
+                "builtins.open",
+                mock.mock_open(read_data=version_json),
+            ) as mf:
+                version = app_version()
+                self.assertEqual(version, expected_version)
+
+                version_again = app_version()
+                self.assertEqual(version_again, expected_version)
+
+                mf.assert_called_once_with(self.version_json_path)
+
+    def test_app_version_env_over_file(self):
+        expected_version = "thx1138"
+        version_json = '{"commit": "INCORRECT"}'
+
+        with self.settings(APP_VERSION=expected_version):
+            with mock.patch(
+                "builtins.open",
+                mock.mock_open(read_data=version_json),
+            ) as mf:
+                version = app_version()
+                mf.assert_not_called()
+                self.assertEqual(version, expected_version)
+
+    def test_app_version_file_error(self):
+        version_json = '{"commit": "INCORRECT"}'
+        with self.settings(APP_VERSION=None):
+            with mock.patch(
+                "builtins.open",
+                mock.mock_open(read_data=version_json),
+            ) as mf:
+                mf.side_effect = IOError()
+                version = app_version()
+                mf.assert_any_call(self.version_json_path)
+                self.assertEqual(version, "")

--- a/app/experimenter/settings.py
+++ b/app/experimenter/settings.py
@@ -19,6 +19,7 @@ from decouple import config
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 
+APP_VERSION = config("APP_VERSION", default=None)
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/1.9/howto/deployment/checklist/


### PR DESCRIPTION
Because:

* Sentry works better if it has context on the deployed release version

This commit:

* Ensures that the git commit included on build in version.json is
  available to Sentry error report calls for nimbus-ui