### PR TITLE
fix #5739 refactor(nimbus): remove pause timeout special case

### DIFF
--- a/app/experimenter/experiments/models/nimbus.py
+++ b/app/experimenter/experiments/models/nimbus.py
@@ -160,6 +160,7 @@ class NimbusExperiment(NimbusConstants, FilterMixin, models.Model):
         )
         IS_PAUSING = Q(
             status=NimbusConstants.Status.LIVE,
+            status_next=NimbusConstants.Status.LIVE,
             publish_status=NimbusConstants.PublishStatus.WAITING,
             is_paused=False,
         )
@@ -173,7 +174,7 @@ class NimbusExperiment(NimbusConstants, FilterMixin, models.Model):
             status_next=NimbusConstants.Status.COMPLETE,
             publish_status=NimbusConstants.PublishStatus.WAITING,
         )
-        SHOULD_TIMEOUT = Q(IS_LAUNCHING | IS_ENDING)
+        SHOULD_TIMEOUT = Q(IS_LAUNCHING | IS_ENDING | IS_PAUSING)
         SHOULD_ALLOCATE_BUCKETS = Q(
             Q(status=NimbusConstants.Status.PREVIEW)
             | Q(publish_status=NimbusConstants.PublishStatus.APPROVED)

--- a/app/experimenter/experiments/tests/factories/nimbus.py
+++ b/app/experimenter/experiments/tests/factories/nimbus.py
@@ -70,7 +70,7 @@ class LifecycleStates(Enum):
     }
     LIVE_WAITING_ENROLLING = {
         "status": NimbusExperiment.Status.LIVE,
-        "status_next": None,
+        "status_next": NimbusExperiment.Status.LIVE,
         "publish_status": NimbusExperiment.PublishStatus.WAITING,
         "is_paused": False,
     }

--- a/app/experimenter/experiments/tests/test_models/test_models_nimbus.py
+++ b/app/experimenter/experiments/tests/test_models/test_models_nimbus.py
@@ -794,10 +794,10 @@ class TestNimbusExperiment(TestCase):
 
     @parameterized.expand(
         [
-            [False, 0, NimbusExperimentFactory.Lifecycles.LIVE_ENROLLING_WAITING],
+            [False, 60, NimbusExperimentFactory.Lifecycles.LIVE_ENROLLING_WAITING],
             [False, 60, NimbusExperimentFactory.Lifecycles.ENDING_APPROVE_WAITING],
             [False, 60, NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE_WAITING],
-            [False, 60, NimbusExperimentFactory.Lifecycles.LIVE_ENROLLING_WAITING],
+            [True, 0, NimbusExperimentFactory.Lifecycles.LIVE_ENROLLING_WAITING],
             [True, 0, NimbusExperimentFactory.Lifecycles.ENDING_APPROVE_WAITING],
             [True, 0, NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE_WAITING],
         ]


### PR DESCRIPTION
Because:

* we want to make pausing enrollment a manual task soon

This commit:

* makes pausing enrollment in a live experiment subject to timeout in
  remote settings just like other updates