### PR TITLE
Fetch Jetstream data more frequently.

### DIFF
--- a/app/experimenter/settings.py
+++ b/app/experimenter/settings.py
@@ -345,7 +345,7 @@ CELERY_BEAT_SCHEDULE = {
     },
     "fetch_jetstream_data": {
         "task": "experimenter.jetstream.tasks.fetch_jetstream_data",
-        "schedule": 86400,
+        "schedule": 28800,
     },
 }
 


### PR DESCRIPTION
Because
* We only fetch Jetstream data once per day and this is causing delays for catching up on unprocessed data

This commit
* Fetches 3 times per day (ever 8 hours) instead of once