### PR TITLE
fixes #5844 fix(nimbus): correctly set statuses on end approval and rejection

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/PageSummary/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageSummary/index.tsx
@@ -56,8 +56,10 @@ const PageContent: React.FC<{
       onLaunchToPreviewClicked,
       onBackToDraftClicked,
       onLaunchClicked,
-      onReviewApprovedClicked,
-      onReviewRejectedClicked,
+      onLaunchReviewApprovedClicked,
+      onLaunchReviewRejectedClicked,
+      onEndReviewApprovedClicked,
+      onEndReviewRejectedClicked,
     ],
   } = useChangeOperationMutation(
     experiment,
@@ -84,6 +86,16 @@ const PageContent: React.FC<{
     },
     {
       status: NimbusExperimentStatus.DRAFT,
+      statusNext: null,
+      publishStatus: NimbusExperimentPublishStatus.IDLE,
+    },
+    {
+      status: NimbusExperimentStatus.LIVE,
+      statusNext: NimbusExperimentStatus.COMPLETE,
+      publishStatus: NimbusExperimentPublishStatus.APPROVED,
+      changelogMessage: CHANGELOG_MESSAGES.REVIEW_APPROVED,
+    },
+    {
       statusNext: null,
       publishStatus: NimbusExperimentPublishStatus.IDLE,
     },
@@ -128,8 +140,12 @@ const PageContent: React.FC<{
             reviewRequestEvent,
             rejectionEvent,
             timeoutEvent,
-            rejectChange: onReviewRejectedClicked,
-            approveChange: onReviewApprovedClicked,
+            rejectChange: status.live
+              ? onEndReviewRejectedClicked
+              : onLaunchReviewRejectedClicked,
+            approveChange: status.live
+              ? onEndReviewApprovedClicked
+              : onLaunchReviewApprovedClicked,
             reviewUrl: experiment.reviewUrl!,
           }}
         >

--- a/app/experimenter/nimbus-ui/src/components/Summary/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/index.tsx
@@ -37,23 +37,11 @@ const Summary = ({ experiment, refetch }: SummaryProps) => {
     isLoading,
     submitError,
     callbacks: [onConfirmEndClicked],
-  } = useChangeOperationMutation(
-    experiment,
-    refetch,
-    {
-      publishStatus: NimbusExperimentPublishStatus.REVIEW,
-      statusNext: NimbusExperimentStatus.COMPLETE,
-      changelogMessage: CHANGELOG_MESSAGES.REQUESTED_REVIEW_END,
-    },
-    {
-      publishStatus: NimbusExperimentPublishStatus.APPROVED,
-      changelogMessage: CHANGELOG_MESSAGES.END_APPROVED,
-    },
-    {
-      publishStatus: NimbusExperimentPublishStatus.IDLE,
-      statusNext: null,
-    },
-  );
+  } = useChangeOperationMutation(experiment, refetch, {
+    publishStatus: NimbusExperimentPublishStatus.REVIEW,
+    statusNext: NimbusExperimentStatus.COMPLETE,
+    changelogMessage: CHANGELOG_MESSAGES.REQUESTED_REVIEW_END,
+  });
 
   return (
     <div data-testid="summary" className="mb-5">


### PR DESCRIPTION
Closes #5844

This PR adds "end"-specific mutation approval and rejection parameters, splitting it away from the "launch"-specific ones. As a result:

- Allows you to properly approve an experiment end request
- Displays the end flow component when an end request is rejected