### PR TITLE
fixes #5451 feat(nimbus): All review_urls should link to simple-review

### DIFF
--- a/app/experimenter/experiments/models/nimbus.py
+++ b/app/experimenter/experiments/models/nimbus.py
@@ -335,8 +335,7 @@ class NimbusExperiment(NimbusConstants, FilterMixin, models.Model):
             base_url=settings.KINTO_ADMIN_URL,
             collection_path="#/buckets/main-workspace/collections",
             collection=self.application_config.rs_experiments_collection,
-            # TODO: Remove IS_STAGING https://github.com/mozilla/experimenter/issues/5451
-            review_path="simple-review" if settings.IS_STAGING else "records",
+            review_path="simple-review",
         )
 
     def delete_branches(self):

--- a/app/experimenter/experiments/tests/test_models/test_models_nimbus.py
+++ b/app/experimenter/experiments/tests/test_models/test_models_nimbus.py
@@ -500,9 +500,8 @@ class TestNimbusExperiment(TestCase):
             ),
         )
 
-    def test_review_url_stage_should_return_simple_review_url(self):
+    def test_review_url_should_return_simple_review_url(self):
         with override_settings(
-            IS_STAGING=True,
             KINTO_ADMIN_URL="https://settings-writer.stage.mozaws.net/v1/admin/",
         ):
             expected = "https://settings-writer.stage.mozaws.net/v1/admin/#/buckets/main-workspace/collections/nimbus-desktop-experiments/simple-review"  # noqa E501
@@ -514,25 +513,12 @@ class TestNimbusExperiment(TestCase):
 
     def test_review_url_stage_should_return_simple_review_url_without_slash(self):
         with override_settings(
-            IS_STAGING=True,
             KINTO_ADMIN_URL="http://localhost:8888/v1/admin",
         ):
             expected = "http://localhost:8888/v1/admin#/buckets/main-workspace/collections/nimbus-desktop-experiments/simple-review"  # noqa E501
             experiment = NimbusExperimentFactory.create_with_lifecycle(
                 NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE,
                 application=NimbusExperiment.Application.DESKTOP,
-            )
-            self.assertEqual(experiment.review_url, expected)
-
-    def test_review_url_prod_should_return_records_url(self):
-        with override_settings(
-            IS_STAGING=False,
-            KINTO_ADMIN_URL="https://settings-writer.prod.mozaws.net/v1/admin",
-        ):
-            expected = "https://settings-writer.prod.mozaws.net/v1/admin#/buckets/main-workspace/collections/nimbus-mobile-experiments/records"  # noqa E501
-            experiment = NimbusExperimentFactory.create_with_lifecycle(
-                NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE,
-                application=NimbusExperiment.Application.FENIX,
             )
             self.assertEqual(experiment.review_url, expected)
 


### PR DESCRIPTION
Because

* The simple-review UI is now on prod

This commit

* Changes the review_url to always return simple-review RS URL