### PR TITLE
fix #5797 chore(nimbus): switch dependabot to minor only

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,13 +5,22 @@ updates:
   schedule:
     interval: weekly
   target-branch: main
+  ignore:
+    - dependency-name: "*"
+      update-types: ["version-update:semver-major", "version-update:semver-patch"]
 - package-ecosystem: pip
   directory: "/app"
   schedule:
     interval: weekly
   target-branch: main
+  ignore:
+    - dependency-name: "*"
+      update-types: ["version-update:semver-major", "version-update:semver-patch"]
 - package-ecosystem: pip
   directory: "/app/tests"
   schedule:
     interval: weekly
   target-branch: main
+  ignore:
+    - dependency-name: "*"
+      update-types: ["version-update:semver-major", "version-update:semver-patch"]


### PR DESCRIPTION
Because

* We want to reduce the number of dependabot prs while staying as up to date as possible
* We want to reduce the number of dependabot prs that break and require manual intervention

This commit

* Ignores patch/major updates, allowing only minor updates