### PR TITLE
fix #5894 chore(project): auto merge dependabot prs

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,11 @@
+name: auto-merge
+on: [push, pull_request]
+
+jobs:
+  automerge:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: fastify/github-action-merge-dependabot@v2.1.1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          approve-only: true


### PR DESCRIPTION
Because

* It would be handy if dependabot prs that pass CI could be automatically merged

This commit

* Adds a github action that will automatically approve dependabot prs