### PR TITLE
fixes #5744 feat(nimbus): update change approval message, add copy-able link

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/ChangeApprovalOperations/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/ChangeApprovalOperations/index.test.tsx
@@ -2,7 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
 import React from "react";
 import {
   BaseSubject,
@@ -58,6 +64,12 @@ describe("ChangeApprovalOperations", () => {
   });
 
   it("when user cannot review, an approval pending notice is displayed", async () => {
+    Object.assign(navigator, {
+      clipboard: {
+        writeText: jest.fn(),
+      },
+    });
+
     render(
       <Subject
         {...{
@@ -66,9 +78,13 @@ describe("ChangeApprovalOperations", () => {
         }}
       />,
     );
-    await screen.findByTestId("approval-pending");
+    const pendingMessage = await screen.findByTestId("approval-pending");
     expect(screen.queryByTestId("approve-request")).not.toBeInTheDocument();
     expect(screen.queryByTestId("reject-request")).not.toBeInTheDocument();
+
+    const copyLink = within(pendingMessage).getByText("Click here");
+    fireEvent.click(copyLink);
+    expect(navigator.clipboard.writeText).toHaveBeenCalled();
   });
 
   it("when user can review and review has been approved, button to open remote settings is offered", async () => {

--- a/app/experimenter/nimbus-ui/src/components/ChangeApprovalOperations/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/ChangeApprovalOperations/index.tsx
@@ -4,10 +4,11 @@
 
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import Alert from "react-bootstrap/Alert";
-import { ReactComponent as Check } from "../../images/check.svg";
+import { EXTERNAL_URLS } from "../../lib/constants";
 import { humanDate } from "../../lib/dateUtils";
 import { getExperiment_experimentBySlug } from "../../types/getExperiment";
 import { NimbusExperimentPublishStatus } from "../../types/globalTypes";
+import LinkExternal from "../LinkExternal";
 import FormApproveOrReject from "./FormApproveOrReject";
 import FormRejectReason from "./FormRejectReason";
 import FormRemoteSettingsPending from "./FormRemoteSettingsPending";
@@ -85,8 +86,22 @@ export const ChangeApprovalOperations: React.FC<
           className="bg-transparent text-success"
         >
           <p className="my-1" data-testid="in-review-label">
-            <Check className="align-top" /> All set! This experiment will{" "}
-            {actionDescription} as soon as it is approved.
+            Please ask someone on your team with review privileges, or a{" "}
+            <LinkExternal href={EXTERNAL_URLS.EXPERIMENTER_REVIEWERS}>
+              qualified reviewer
+            </LinkExternal>
+            , to review and {actionDescription} your experiment.{" "}
+            <a
+              href="#copy"
+              className="cursor-copy"
+              onClick={(event) => {
+                event.preventDefault();
+                navigator.clipboard.writeText(window.location.toString());
+              }}
+            >
+              Click here
+            </a>{" "}
+            to copy the URL to send them.
           </p>
         </Alert>
       );

--- a/app/experimenter/nimbus-ui/src/lib/constants.ts
+++ b/app/experimenter/nimbus-ui/src/lib/constants.ts
@@ -44,6 +44,8 @@ export const EXTERNAL_URLS = {
     "https://mana.mozilla.org/wiki/display/FIREFOX/Pref-Flip+and+Add-On+Experiments#PrefFlipandAddOnExperiments-VPSign-offsignVP",
   SIGNOFF_LEGAL:
     "https://mana.mozilla.org/wiki/display/FIREFOX/Pref-Flip+and+Add-On+Experiments#PrefFlipandAddOnExperiments-signLEGAL",
+  EXPERIMENTER_REVIEWERS:
+    "https://mana.mozilla.org/wiki/display/FJT/Nimbus+Reviewers",
 };
 
 export const RISK_QUESTIONS = {


### PR DESCRIPTION
Closes #5744 

This PR updates the change approval message from:

> All set! This experiment will launch as soon as it is approved.

To:

> Please ask someone on your team with review privileges, or a qualified [reviewer](https://mana.mozilla.org/wiki/display/FJT/Nimbus+Reviewers), to review and launch your experiment. [Click here](#) to copy the URL to send them.

The "Click here" text can be clicked to copy the current experiment's address to your clipboard.

---

The ticket's original ask was for the following text (with experiment-specific URL):

> Please ask someone on your team with review privileges or a qualified [reviewer](https://mana.mozilla.org/wiki/display/FJT/Nimbus+Reviewers) to review and launch your experiment. You should send them this URL: [https://experimenter.services.mozilla.com/nimbus/android-keystore-reliability-experiment-v3](https://experimenter.services.mozilla.com/nimbus/android-keystore-reliability-experiment-v3)

Which is fine, but I figured a full URL would look a little unwieldy inside the message banner, plus the copy link button is nice and handy. Open to pushback, though!

---

![Screen Shot 2021-07-07 at 4 23 57 PM](https://user-images.githubusercontent.com/6392049/124927179-b654be80-dfd4-11eb-897a-090a49dfae83.png)
