### PR TITLE
fixes #5390 feat(legacy): add cta to encourage usage of nimbus

### DIFF
--- a/app/experimenter/legacy-ui/templates/base.html
+++ b/app/experimenter/legacy-ui/templates/base.html
@@ -79,10 +79,10 @@
     <div class="container">
       <div class="row py-3">
         <div class="col-9">
-          <h5 class="font-bold">
+          <p class="font-bold h5">
             <span class="fas fa-gift"></span>
             Nimbus is now available!
-          </h5>
+          </p>
           <p class="mb-0">You are encouraged to start using the all-new Nimbus Console for creating and evaluating experiments.</p>
         </div>
 

--- a/app/experimenter/legacy-ui/templates/base.html
+++ b/app/experimenter/legacy-ui/templates/base.html
@@ -75,6 +75,27 @@
     </div>
   </div>
 
+  <div id="nimbus-cta">
+    <div class="container">
+      <div class="row py-3">
+        <div class="col-9">
+          <h5 class="font-bold">
+            <span class="fas fa-gift"></span>
+            Nimbus is now available!
+          </h5>
+          <p class="mb-0">You are encouraged to start using the all-new Nimbus Console for creating and evaluating experiments.</p>
+        </div>
+
+        <div class="col-3 text-right">
+          <a class="col btn btn-success" href="/nimbus" target="_blank" rel="noopener noreferrer">
+            <span class="fas fa-external-link-alt"></span>
+            Go to Nimbus
+          </a>
+        </div>
+      </div>
+    </div>
+  </div>
+
   <div id="sub-header">
     <div class="container">
       <div class="row py-3">

--- a/app/tests/integration/legacy/pages/experiment_detail.py
+++ b/app/tests/integration/legacy/pages/experiment_detail.py
@@ -13,7 +13,7 @@ class DetailPage(Base):
     _confirm_ship_btn_locator = (By.CSS_SELECTOR, ".proceed-status-color")
     _edit_branches_btn_locator = (By.CSS_SELECTOR, "#branches-edit-btn")
     _required_checklist_locator = (By.CSS_SELECTOR, ".checkbox")
-    _save_signoffs_btn_locator = (By.CSS_SELECTOR, ".btn-success")
+    _save_signoffs_btn_locator = (By.CSS_SELECTOR, "form .btn-success")
     _send_to_normandy_btn_locator = (By.CSS_SELECTOR, ".btn-danger")
 
     _page_wait_locator = (By.CSS_SELECTOR, "body.page-detail-view")


### PR DESCRIPTION
Closes #5390

This PR adds a big ol banner to the top of the Legacy site encouraging folks to use Nimbus. Open to feedback on the appearance and placement. Is it too much? I just winged it.

<img width="1307" alt="Screen Shot 2021-06-14 at 12 50 12 PM" src="https://user-images.githubusercontent.com/6392049/121962045-95cf7680-cd3e-11eb-9850-fb077a443e44.png">

---

This PR was originally opened and approved here pre-Jira migration: https://github.com/mozilla/experimenter/pull/5432
