### PR TITLE
fix #5912 chore(project): suppress errors from docker compose commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,14 +70,14 @@ compose_build: build_dev ssl
 	$(COMPOSE)  build
 
 compose_stop:
-	$(COMPOSE) kill
-	$(COMPOSE_INTEGRATION) kill
-	$(COMPOSE_PROD) kill
+	$(COMPOSE) kill || true
+	$(COMPOSE_INTEGRATION) kill || true
+	$(COMPOSE_PROD) kill || true
 
 compose_rm:
-	$(COMPOSE) rm -f -v
-	$(COMPOSE_INTEGRATION) rm -f -v
-	$(COMPOSE_PROD) rm -f -v
+	$(COMPOSE) rm -f -v || true
+	$(COMPOSE_INTEGRATION) rm -f -v || true
+	$(COMPOSE_PROD) rm -f -v || true
 
 volumes_rm:
 	docker volume prune -f


### PR DESCRIPTION
Because

* As Docker continues to update and change the semantics of its commands, we must update the Makefile to adapt
* Attempting to kill or remove already stopped/removed container entries can exit non-zero

This commit

* Suppresses non zero exit codes from kill/rm docker compose commands