### PR TITLE
fix #5917 chore(nimbus): display bucketing/isolation groups in admin as read only

### DIFF
--- a/app/experimenter/experiments/admin/nimbus.py
+++ b/app/experimenter/experiments/admin/nimbus.py
@@ -4,6 +4,7 @@ from django.contrib.postgres.forms import SimpleArrayField
 
 from experimenter.experiments.models import (
     NimbusBranch,
+    NimbusBucketRange,
     NimbusChangeLog,
     NimbusDocumentationLink,
     NimbusExperiment,
@@ -24,6 +25,40 @@ class NimbusDocumentationLinkInlineAdmin(admin.TabularInline):
 class NimbusExperimentChangeLogInlineAdmin(admin.StackedInline):
     model = NimbusChangeLog
     extra = 1
+
+
+class NimbusExperimentBucketRangeInlineAdmin(admin.StackedInline):
+    model = NimbusBucketRange
+    extra = 0
+    fields = (
+        "isolation_group_name",
+        "isolation_group_instance",
+        "isolation_group_total",
+        "start",
+        "count",
+    )
+    readonly_fields = (
+        "isolation_group_name",
+        "isolation_group_instance",
+        "isolation_group_total",
+        "start",
+        "count",
+    )
+
+    @admin.display(description="Isolation Group Name")
+    def isolation_group_name(self, instance):
+        return instance.isolation_group.name
+
+    @admin.display(description="Isolation Group Instance")
+    def isolation_group_instance(self, instance):
+        return instance.isolation_group.instance
+
+    @admin.display(description="Isolation Group Total")
+    def isolation_group_total(self, instance):
+        return instance.isolation_group.total
+
+    def has_add_permission(self, request, obj):
+        return False
 
 
 class NimbusExperimentAdminForm(forms.ModelForm):
@@ -60,6 +95,7 @@ class NimbusExperimentAdmin(admin.ModelAdmin):
     inlines = (
         NimbusDocumentationLinkInlineAdmin,
         NimbusBranchInlineAdmin,
+        NimbusExperimentBucketRangeInlineAdmin,
         NimbusExperimentChangeLogInlineAdmin,
     )
     list_display = (

--- a/app/experimenter/experiments/tests/test_admin/test_admin_nimbus.py
+++ b/app/experimenter/experiments/tests/test_admin/test_admin_nimbus.py
@@ -1,4 +1,6 @@
+from django.conf import settings
 from django.test import TestCase
+from django.urls import reverse
 
 from experimenter.experiments.admin.nimbus import NimbusExperimentAdminForm
 from experimenter.experiments.models import NimbusExperiment
@@ -92,3 +94,19 @@ class TestNimbusExperimentAdminForm(TestCase):
         )
         self.assertFalse(form.is_valid())
         self.assertNotIn("reference_branch", form.errors)
+
+
+class TestNimbusExperimentAdmin(TestCase):
+    def test_admin_form_renders(self):
+        user = UserFactory.create(is_staff=True, is_superuser=True)
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.ENDING_APPROVE_APPROVE
+        )
+        response = self.client.get(
+            reverse(
+                "admin:experiments_nimbusexperiment_change",
+                args=(experiment.pk,),
+            ),
+            **{settings.OPENIDC_EMAIL_HEADER: user.email}
+        )
+        self.assertEqual(response.status_code, 200)


### PR DESCRIPTION


Because

* It will be helpful in some cases to inspect the assigned bucket ranges/isolation groups for an experiment
* They should never be edited by hand since they are always automatically assigned by the bucket allocator

This commit

* Displays the bucket and isolation groups assigned to an experiment in the nimbus experiment admin as read only