### PR TITLE
fix #5922 chore(nimbus): use cache instead of global for loading app version

### DIFF
--- a/app/experimenter/base/__init__.py
+++ b/app/experimenter/base/__init__.py
@@ -1,25 +1,20 @@
 import json
-import os
+from functools import cache
 
 from django.conf import settings
 
-APP_VERSION = None
 
-
+@cache
 def app_version():
-    global APP_VERSION
+    app_version = settings.APP_VERSION
 
-    if APP_VERSION is None:
-        if settings.APP_VERSION:
-            APP_VERSION = settings.APP_VERSION
-        else:
-            try:
-                version_json_path = os.path.join(settings.BASE_DIR, "version.json")
-                with open(version_json_path) as version_json_file:
-                    version_json = json.load(version_json_file)
-                    APP_VERSION = version_json["commit"]
-            except IOError:
-                # EXP-1384: Preserve default blank version if version.json unavailable
-                APP_VERSION = ""
+    if app_version is None:
+        try:
+            with open(settings.APP_VERSION_JSON_PATH) as version_json_file:
+                version_json = json.load(version_json_file)
+                app_version = version_json["commit"]
+        except IOError:
+            # EXP-1384: Preserve default blank version if version.json unavailable
+            app_version = ""
 
-    return APP_VERSION
+    return app_version

--- a/app/experimenter/base/tests/test_base.py
+++ b/app/experimenter/base/tests/test_base.py
@@ -1,5 +1,3 @@
-import os
-
 import mock
 from django.conf import settings
 from django.test import TestCase
@@ -9,14 +7,14 @@ from experimenter.base import app_version
 
 class TestBase(TestCase):
     def setUp(self):
-        self.version_json_path = os.path.join(settings.BASE_DIR, "version.json")
+        app_version.cache_clear()
 
     def test_app_version_file(self):
         expected_version = "8675309"
         version_json = f'{{"commit": "{expected_version}"}}'
         with self.settings(APP_VERSION=None):
             with mock.patch(
-                "builtins.open",
+                "experimenter.base.open",
                 mock.mock_open(read_data=version_json),
             ) as mf:
                 version = app_version()
@@ -25,7 +23,7 @@ class TestBase(TestCase):
                 version_again = app_version()
                 self.assertEqual(version_again, expected_version)
 
-                mf.assert_called_once_with(self.version_json_path)
+                mf.assert_called_once_with(settings.APP_VERSION_JSON_PATH)
 
     def test_app_version_env_over_file(self):
         expected_version = "thx1138"
@@ -33,7 +31,7 @@ class TestBase(TestCase):
 
         with self.settings(APP_VERSION=expected_version):
             with mock.patch(
-                "builtins.open",
+                "experimenter.base.open",
                 mock.mock_open(read_data=version_json),
             ) as mf:
                 version = app_version()
@@ -49,5 +47,5 @@ class TestBase(TestCase):
             ) as mf:
                 mf.side_effect = IOError()
                 version = app_version()
-                mf.assert_any_call(self.version_json_path)
+                mf.assert_called_once_with(settings.APP_VERSION_JSON_PATH)
                 self.assertEqual(version, "")

--- a/app/experimenter/settings.py
+++ b/app/experimenter/settings.py
@@ -19,6 +19,7 @@ from decouple import config
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 
+APP_VERSION_JSON_PATH = os.path.join(BASE_DIR, "version.json")
 APP_VERSION = config("APP_VERSION", default=None)
 
 # Quick-start development settings - unsuitable for production


### PR DESCRIPTION


Because

* Using a global to store the version so we don't load the file twice can lead to non deterministic stateful behaviour such as state persisting across tests
* Manifests in the Django test runner but not the pytest runner, but I suspect that might be related to the thread scheduling and memory locality

This commit

* Uses the builtin python functools cache which explicitly allows clearing between tests