### PR TITLE
Fix #5886: fix(visualization) - only load primary or secondary outcomes when overall results are available.

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/PageResults/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/index.tsx
@@ -104,21 +104,22 @@ const PageResults: React.FunctionComponent<RouteComponentProps> = () => {
             </div>
 
             <div>
-              {experiment.primaryOutcomes?.map((slug) => {
-                const outcome = configOutcomes!.find((set) => {
-                  return set?.slug === slug;
-                });
+              {analysis?.overall &&
+                experiment.primaryOutcomes?.map((slug) => {
+                  const outcome = configOutcomes!.find((set) => {
+                    return set?.slug === slug;
+                  });
 
-                return (
-                  <TableMetricPrimary
-                    key={slug}
-                    results={analysis?.overall!}
-                    outcome={outcome!}
-                    {...{ sortedBranches }}
-                  />
-                );
-              })}
-              {analysis &&
+                  return (
+                    <TableMetricPrimary
+                      key={slug}
+                      results={analysis?.overall!}
+                      outcome={outcome!}
+                      {...{ sortedBranches }}
+                    />
+                  );
+                })}
+              {analysis?.overall &&
                 experiment.secondaryOutcomes?.map((slug) => {
                   const outcome = configOutcomes!.find((set) => {
                     return set?.slug === slug;


### PR DESCRIPTION
Because:
* Experiments with primary metrics fail to load the weekly view since overall data is required to show them

This commit:
* Only show primary and secondary metrics if overall data is available.

I tested this locally by confirming https://experimenter.services.mozilla.com/nimbus/default-browser-adoption-experiment-release/results works (it's currently broken on prod)