### PR TITLE
fixes #5924 fix(nimbus): remove usage of act in component test to address flakiness

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/PageEditAudience/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditAudience/index.test.tsx
@@ -4,13 +4,7 @@
 
 import { MockedResponse } from "@apollo/client/testing";
 import { navigate } from "@reach/router";
-import {
-  act,
-  fireEvent,
-  render,
-  screen,
-  waitFor,
-} from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import fetchMock from "jest-fetch-mock";
 import React from "react";
 import PageEditAudience from ".";
@@ -55,24 +49,24 @@ describe("PageEditAudience", () => {
 
   it("renders as expected", async () => {
     render(<Subject />);
-    await waitFor(() => {
-      expect(screen.queryByTestId("PageEditAudience")).toBeInTheDocument();
-    });
+    await screen.findByTestId("PageEditAudience");
   });
 
   it("handles form next button", async () => {
     render(<Subject mocks={[mock, mutationMock]} />);
     await screen.findByTestId("PageEditAudience");
-    await act(async () => void fireEvent.click(screen.getByTestId("next")));
-    expect(mockSubmit).toHaveBeenCalled();
-    expect(navigate).toHaveBeenCalledWith("../");
+    fireEvent.click(screen.getByTestId("next"));
+    await waitFor(() => {
+      expect(mockSubmit).toHaveBeenCalled();
+      expect(navigate).toHaveBeenCalledWith("../");
+    });
   });
 
   it("handles form submission", async () => {
     render(<Subject mocks={[mock, mutationMock]} />);
     await screen.findByTestId("PageEditAudience");
-    await act(async () => void fireEvent.click(screen.getByTestId("submit")));
-    expect(mockSubmit).toHaveBeenCalled();
+    fireEvent.click(screen.getByTestId("submit"));
+    await waitFor(() => expect(mockSubmit).toHaveBeenCalled());
   });
 
   it("handles experiment form submission with server-side validation errors", async () => {
@@ -81,15 +75,12 @@ describe("PageEditAudience", () => {
     };
     mutationMock.result.data.updateExperiment.message = expectedErrors;
     render(<Subject mocks={[mock, mutationMock]} />);
-    let submitButton: HTMLButtonElement;
-    await waitFor(() => {
-      submitButton = screen.getByTestId("submit") as HTMLButtonElement;
-    });
-    await act(async () => {
-      fireEvent.click(submitButton);
-    });
-    expect(screen.getByTestId("submitErrors")).toHaveTextContent(
-      JSON.stringify(expectedErrors),
+    const submitButton = await screen.findByTestId("submit");
+    fireEvent.click(submitButton);
+    await waitFor(() =>
+      expect(screen.getByTestId("submitErrors")).toHaveTextContent(
+        JSON.stringify(expectedErrors),
+      ),
     );
   });
 
@@ -97,15 +88,12 @@ describe("PageEditAudience", () => {
     // @ts-ignore - intentionally breaking this type for error handling
     delete mutationMock.result.data.updateExperiment;
     render(<Subject mocks={[mock, mutationMock]} />);
-    let submitButton: HTMLButtonElement;
-    await waitFor(() => {
-      submitButton = screen.getByTestId("submit") as HTMLButtonElement;
-    });
-    await act(async () => {
-      fireEvent.click(submitButton);
-    });
-    expect(screen.getByTestId("submitErrors")).toHaveTextContent(
-      JSON.stringify({ "*": SUBMIT_ERROR }),
+    const submitButton = await screen.findByTestId("submit");
+    fireEvent.click(submitButton);
+    await waitFor(() =>
+      expect(screen.getByTestId("submitErrors")).toHaveTextContent(
+        JSON.stringify({ "*": SUBMIT_ERROR }),
+      ),
     );
   });
 });


### PR DESCRIPTION
Closes #5924

Removes all usage of `act` in `PageEditAudience` tests as it is mostly redundant and is making things flaky.