### PR TITLE
fixes #5783 feat(nimbus): Add duration tooltip to Audience & Summary

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/index.test.tsx
@@ -12,7 +12,11 @@ import {
 import React from "react";
 import { filterTargetingConfigSlug } from ".";
 import { snakeToCamelCase } from "../../../lib/caseConversions";
-import { EXTERNAL_URLS, FIELD_MESSAGES } from "../../../lib/constants";
+import {
+  EXTERNAL_URLS,
+  FIELD_MESSAGES,
+  TOOLTIP_DURATION,
+} from "../../../lib/constants";
 import { MOCK_CONFIG } from "../../../lib/mocks";
 import { assertSerializerMessages } from "../../../lib/test-utils";
 import {
@@ -80,6 +84,10 @@ describe("FormAudience", () => {
       const { label } = channel!;
       expect(screen.getByText(label!)).toBeInTheDocument();
     }
+
+    expect(
+      await screen.findByTestId("tooltip-duration-audience"),
+    ).toHaveAttribute("data-tip", TOOLTIP_DURATION);
   });
 
   it("renders server errors", async () => {

--- a/app/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/index.tsx
@@ -7,11 +7,14 @@ import Alert from "react-bootstrap/Alert";
 import Col from "react-bootstrap/Col";
 import Form from "react-bootstrap/Form";
 import InputGroup from "react-bootstrap/InputGroup";
+import ReactTooltip from "react-tooltip";
 import { useCommonForm, useConfig, useReviewCheck } from "../../../hooks";
+import { ReactComponent as Info } from "../../../images/info.svg";
 import {
   EXTERNAL_URLS,
   POSITIVE_NUMBER_FIELD,
   POSITIVE_NUMBER_WITH_COMMAS_FIELD,
+  TOOLTIP_DURATION,
 } from "../../../lib/constants";
 import {
   getConfig_nimbusConfig,
@@ -220,6 +223,14 @@ export const FormAudience = ({
           <Form.Group as={Col} className="mx-5" controlId="proposedDuration">
             <Form.Label className="d-flex align-items-center">
               Experiment duration
+              <Info
+                data-tip={TOOLTIP_DURATION}
+                data-testid="tooltip-duration-audience"
+                width="20"
+                height="20"
+                className="ml-1"
+              />
+              <ReactTooltip />
             </Form.Label>
             <InputGroup className="mb-3">
               <Form.Control

--- a/app/experimenter/nimbus-ui/src/components/Summary/SummaryTimeline/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/SummaryTimeline/index.test.tsx
@@ -4,6 +4,7 @@
 
 import { cleanup, render, screen } from "@testing-library/react";
 import React from "react";
+import { TOOLTIP_DURATION } from "../../../lib/constants";
 import {
   NimbusExperimentPublishStatus,
   NimbusExperimentStatus,
@@ -35,7 +36,7 @@ describe("SummaryTimeline", () => {
     });
   });
 
-  it("renders with a live experiment", () => {
+  it("renders with a live experiment", async () => {
     render(<Subject status={NimbusExperimentStatus.LIVE} />);
 
     expect(innerBar().classList).toContain("progress-bar-animated");
@@ -46,6 +47,9 @@ describe("SummaryTimeline", () => {
     expect(screen.queryByTestId("label-end-date")).toBeInTheDocument();
     expect(screen.queryByTestId("label-duration-days")).toBeInTheDocument();
     expect(screen.queryByTestId("label-enrollment-days")).toBeInTheDocument();
+    expect(
+      await screen.findByTestId("tooltip-duration-summary"),
+    ).toHaveAttribute("data-tip", TOOLTIP_DURATION);
   });
 
   it("renders with a completed experiment", () => {

--- a/app/experimenter/nimbus-ui/src/components/Summary/SummaryTimeline/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/SummaryTimeline/index.tsx
@@ -4,6 +4,9 @@
 
 import React from "react";
 import ProgressBar from "react-bootstrap/ProgressBar";
+import ReactTooltip from "react-tooltip";
+import { ReactComponent as Info } from "../../../images/info.svg";
+import { TOOLTIP_DURATION } from "../../../lib/constants";
 import { humanDate } from "../../../lib/dateUtils";
 import { getStatus, StatusCheck } from "../../../lib/experiment";
 import { pluralize } from "../../../lib/utils";
@@ -116,7 +119,17 @@ const Duration = ({
   <span>
     Total duration:{" "}
     {duration !== null ? (
-      <b data-testid="label-duration-days">{pluralize(duration, "day")}</b>
+      <>
+        <b data-testid="label-duration-days">{pluralize(duration, "day")}</b>
+        <Info
+          data-tip={TOOLTIP_DURATION}
+          data-testid="tooltip-duration-summary"
+          width="20"
+          height="20"
+          className="ml-1"
+        />
+        <ReactTooltip />
+      </>
     ) : (
       <NotSet data-testid="label-duration-not-set" />
     )}{" "}

--- a/app/experimenter/nimbus-ui/src/lib/constants.ts
+++ b/app/experimenter/nimbus-ui/src/lib/constants.ts
@@ -57,6 +57,9 @@ export const RISK_QUESTIONS = {
     "Does this experiment have a risk to negatively impact revenue (e.g. search, Pocket revenue)?",
 };
 
+export const TOOLTIP_DURATION =
+  "This is the total duration of the experiment, including the enrollment period.";
+
 export const CHANGELOG_MESSAGES = {
   CREATED_EXPERIMENT: "Created Experiment",
   UPDATED_BRANCHES: "Updated Branches",


### PR DESCRIPTION
Because:
* Users were not sure if total duration included the enrollment period

This commit:
* Adds a tooltip displaying the same copy for "Experiment duration" on the Audience page and "Total duration" in SummaryTimeline