### PR TITLE
fixes #5921 fix(nimbus): allow refetching after end experiment, disable buttons while waiting

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/PageSummary/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageSummary/index.tsx
@@ -195,7 +195,7 @@ const PageContent: React.FC<{
       )}
 
       <h2 className="mt-3 mb-4 h4">Summary</h2>
-      <Summary {...{ experiment }} />
+      <Summary {...{ experiment, refetch }} />
     </>
   );
 };

--- a/app/experimenter/nimbus-ui/src/components/Summary/EndExperiment/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/EndExperiment/index.test.tsx
@@ -35,6 +35,7 @@ describe("EndExperiment", () => {
 
     const confirmEnd = await screen.findByTestId("end-experiment-confirm");
     fireEvent.click(confirmEnd);
+    expect(confirmEnd).toBeDisabled();
     expect(onSubmit).toHaveBeenCalled();
   });
 

--- a/app/experimenter/nimbus-ui/src/components/Summary/EndExperiment/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/EndExperiment/index.tsx
@@ -13,6 +13,7 @@ const EndExperiment = ({
   onSubmit: () => void;
 }) => {
   const [showEndConfirmation, setShowEndConfirmation] = useState(false);
+  const [isLoadingOverride, setIsLoadingOverride] = useState(false);
 
   const toggleShowEndConfirmation = useCallback(
     () => setShowEndConfirmation(!showEndConfirmation),
@@ -31,8 +32,11 @@ const EndExperiment = ({
           <div>
             <Button
               variant="primary"
-              onClick={onSubmit}
-              disabled={isLoading}
+              onClick={() => {
+                setIsLoadingOverride(true);
+                onSubmit();
+              }}
+              disabled={isLoading || isLoadingOverride}
               data-testid="end-experiment-confirm"
             >
               Yes, end the experiment
@@ -42,7 +46,7 @@ const EndExperiment = ({
               variant="secondary"
               className="ml-2"
               onClick={toggleShowEndConfirmation}
-              disabled={isLoading}
+              disabled={isLoading || isLoadingOverride}
               data-testid="end-experiment-cancel"
             >
               Cancel


### PR DESCRIPTION
Closes #5921 

This PR updates the flow for ending an experiment to immediately reload the experiment after the request to end confirmation button is clicked.

**What was happening?** We actually try to refetch experiment data after one of the change approval operation mutations is called, but only if the refetch function is provided. In this case it wasn't being provided, so we were falling back to the regular polling interval, which is why it was taking a varying amount of time to update the UI.

I also added a faux loading state when this button is clicked. It's not really waiting on anything to finish (like a network request), but when the reftehc occurs it's going to result in the UI updating anyway, so it can't hurt to making things look "loading".