### PR TITLE
fixes #5542 fix(nimbus): Allow .0001 population_percent to be valid in ReadyForReview serializer

### DIFF
--- a/app/experimenter/experiments/api/v5/serializers.py
+++ b/app/experimenter/experiments/api/v5/serializers.py
@@ -560,7 +560,12 @@ class NimbusReadyForReviewSerializer(serializers.ModelSerializer):
     proposed_duration = serializers.IntegerField(required=True, min_value=1)
     proposed_enrollment = serializers.IntegerField(required=True, min_value=1)
     population_percent = serializers.DecimalField(
-        7, 4, min_value=0.0001, max_value=100.0, required=True
+        7,
+        4,
+        min_value=0.00009,
+        max_value=100.0,
+        required=True,
+        error_messages={"min_value": NimbusConstants.ERROR_POPULATION_PERCENT_MIN},
     )
     total_enrolled_clients = serializers.IntegerField(required=True, min_value=1)
     firefox_min_version = serializers.ChoiceField(

--- a/app/experimenter/experiments/constants/nimbus.py
+++ b/app/experimenter/experiments/constants/nimbus.py
@@ -418,6 +418,7 @@ Optional - We believe this outcome will <describe impact> on <core metric>
     ERROR_REQUIRED_FEATURE_CONFIG = (
         "You must select a feature configuration from the drop down."
     )
+    ERROR_POPULATION_PERCENT_MIN = "Ensure this value is greater than or equal to 0.0001."
 
     # Analysis can be computed starting the week after enrollment
     # completion for "week 1" of the experiment. However, an extra

--- a/app/experimenter/experiments/tests/api/v5/test_serializers.py
+++ b/app/experimenter/experiments/tests/api/v5/test_serializers.py
@@ -1608,6 +1608,21 @@ class TestNimbusReadyForReviewSerializer(TestCase):
             "Ensure this value is greater than or equal to 0.0001.",
         )
 
+    def test_valid_experiment_minimum_population_percent(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            population_percent=0.0001,
+        )
+        serializer = NimbusReadyForReviewSerializer(
+            experiment,
+            data=NimbusReadyForReviewSerializer(
+                experiment,
+                context={"user": self.user},
+            ).data,
+            context={"user": self.user},
+        )
+        self.assertTrue(serializer.is_valid())
+
     def test_invalid_experiment_treatment_branch_requires_description(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.CREATED,


### PR DESCRIPTION
fixes #5542

Because:
* 0.0001 is a valid value that users can save, but the "Ready for review" validation errors show this to be an error

This commit:
* Adds a custom population_percent validation method to check for a min value rather than rely on min_value

---

@jaredlockhart I fully expect you to be like "uhhh no" - totally up for an alternative here. 😉

If you print the value of `value` in `validate_population_percent` when `min_value=0.0001`, this new test never appears to hit the validator despite `experiment.population_percent` equaling `0.0001`. It just spits back the "Ensure this value is greater than 0.001" error.

If you print the value of `value` in `validate_population_percent` when `min_value=0.0`, it comes back as `0.0001` correctly. However, when I compare `if value < 0.0001`, the if statement is truthy somehow and `value == 0.0001` is `False`. I double checked both values are decimal types. Checking the value against something a smidge smaller than `0.0001` instead (like what was done here) works. 🙃

Is there some esoteric Python/Django stuff happening here?