### PR TITLE
chore(deps): Security 'trim'

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -11,6 +11,7 @@
   },
   "devDependencies": {},
   "resolutions": {
+    "trim": "^0.0.3",
     "postcss": "^7.0.36",
     "trim-newlines": "^3.0.1",
     "glob-parent": "^5.1.2",

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -19206,10 +19206,10 @@ trim-trailing-lines@^1.0.0:
   resolved "https://registry.yarnpkg.com/trim-trailing-lines/-/trim-trailing-lines-1.1.4.tgz#bd4abbec7cc880462f10b2c8b5ce1d8d1ec7c2c0"
   integrity sha512-rjUWSqnfTNrjbB9NQWfPMH/xRK1deHeGsHoVfpxJ++XeYXE0d6B1En37AHfw3jtfTU7dzMzZL2jjpe8Qb5gLIQ==
 
-trim@0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/trim/-/trim-0.0.1.tgz#5858547f6b290757ee95cccc666fb50084c460dd"
-  integrity sha1-WFhUf2spB1fulczMZm+1AITEYN0=
+trim@0.0.1, trim@^0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/trim/-/trim-0.0.3.tgz#05243a47a3a4113e6b49367880a9cca59697a20b"
+  integrity sha512-h82ywcYhHK7veeelXrCScdH7HkWfbIT1D/CgYO+nmDarz3SGNssVBMws6jU16Ga60AJCRAvPV6w6RLuNerQqjg==
 
 trough@^1.0.0:
   version "1.0.5"


### PR DESCRIPTION
Because:
* Dependabot found that 'trim' has a security vulnerability

This commit:
* Updates the trim package to the recommended remediation version

Per our new [security warning docs](https://github.com/mozilla/experimenter/blob/main/contributing.md#security-warnings). 😎