### PR TITLE
fix #5967 chore(project): set shell in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+SHELL = /bin/bash
+
 WAIT_FOR_DB = /app/bin/wait-for-it.sh -t 30 db:5432 &&
 WAIT_FOR_RUNSERVER = /app/bin/wait-for-it.sh -t 30 localhost:7001 &&
 


### PR DESCRIPTION
Because

* The makefile depends on /bin/bash to run correctly
* That is not the default on all environments

This commit

* Explicitly sets SHELL = /bin/bash in the Makefile