### PR TITLE
fixes #5954 feat(nimbus): group home page experiment tabs by all statuses

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/PageHome/DirectoryTable/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageHome/DirectoryTable/index.stories.tsx
@@ -3,7 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { withLinks } from "@storybook/addon-links";
-import { storiesOf } from "@storybook/react";
 import React from "react";
 import DirectoryTable, {
   DirectoryCompleteTable,
@@ -12,59 +11,42 @@ import DirectoryTable, {
 } from ".";
 import { mockDirectoryExperiments } from "../../../lib/mocks";
 
-storiesOf("pages/Home/DirectoryTable", module)
-  .addDecorator(withLinks)
-  .add("basic", () => {
-    return (
-      <DirectoryTable
-        title="Mocked Experiments"
-        experiments={mockDirectoryExperiments()}
-      />
-    );
-  })
-  .add("live", () => {
-    return (
-      <DirectoryLiveTable
-        title="Mocked Experiments"
-        experiments={mockDirectoryExperiments()}
-      />
-    );
-  })
-  .add("complete", () => {
-    return (
-      <DirectoryCompleteTable
-        title="Mocked Experiments"
-        experiments={mockDirectoryExperiments()}
-      />
-    );
-  })
-  .add("drafts", () => {
-    return (
-      <DirectoryDraftsTable
-        title="Mocked Experiments"
-        experiments={mockDirectoryExperiments()}
-      />
-    );
-  })
-  .add("custom components", () => {
-    return (
-      <DirectoryTable
-        title="Mocked Experiments"
-        experiments={mockDirectoryExperiments()}
-        columns={[
-          {
-            label: "Testing column",
-            component: ({ status }) => <td>Hello {status}</td>,
-          },
-        ]}
-      />
-    );
-  })
-  .add("no feature", () => {
-    return (
-      <DirectoryTable
-        title="Mocked Experiments"
-        experiments={mockDirectoryExperiments([{ featureConfig: null }])}
-      />
-    );
-  });
+export default {
+  title: "pages/Home/DirectoryTable",
+  component: DirectoryTable,
+  decorators: [withLinks],
+};
+
+export const Basic = () => (
+  <DirectoryTable experiments={mockDirectoryExperiments()} />
+);
+
+export const Live = () => (
+  <DirectoryLiveTable experiments={mockDirectoryExperiments()} />
+);
+
+export const Completed = () => (
+  <DirectoryCompleteTable experiments={mockDirectoryExperiments()} />
+);
+
+export const Drafts = () => (
+  <DirectoryDraftsTable experiments={mockDirectoryExperiments()} />
+);
+
+export const CustomComponent = () => (
+  <DirectoryTable
+    experiments={mockDirectoryExperiments()}
+    columns={[
+      {
+        label: "Testing column",
+        component: ({ status }) => <td>Hello {status}</td>,
+      },
+    ]}
+  />
+);
+
+export const NoFeature = () => (
+  <DirectoryTable
+    experiments={mockDirectoryExperiments([{ featureConfig: null }])}
+  />
+);

--- a/app/experimenter/nimbus-ui/src/components/PageHome/DirectoryTable/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageHome/DirectoryTable/index.test.tsx
@@ -107,12 +107,8 @@ function expectTableCells(testId: string, cellTexts: string[]) {
 describe("DirectoryTable", () => {
   it("renders as expected with default columns", () => {
     const experiments = [experiment];
-    render(<DirectoryTable title="Woozle Wuzzle" {...{ experiments }} />);
-    expectTableCells("directory-table-header", [
-      "Woozle Wuzzle",
-      "Owner",
-      "Feature",
-    ]);
+    render(<DirectoryTable {...{ experiments }} />);
+    expectTableCells("directory-table-header", ["Name", "Owner", "Feature"]);
     expectTableCells("directory-table-cell", [
       experiment.name,
       experiment.owner!.username,
@@ -124,17 +120,13 @@ describe("DirectoryTable", () => {
   });
 
   it("renders as expected without experiments", () => {
-    render(<DirectoryTable title="Sweet Pea" experiments={[]} />);
-    expectTableCells("directory-table-header", ["Sweet Pea"]);
-    expect(
-      screen.getByTestId("directory-table-no-experiments"),
-    ).toBeInTheDocument();
+    render(<DirectoryTable experiments={[]} />);
+    expect(screen.getByTestId("no-experiments")).toBeInTheDocument();
   });
 
   it("renders as expected with custom columns", () => {
     render(
       <DirectoryTable
-        title="Record Numbers"
         experiments={[experiment]}
         columns={[
           { label: "Cant think", component: DirectoryColumnTitle },
@@ -157,14 +149,9 @@ describe("DirectoryTable", () => {
 
 describe("DirectoryLiveTable", () => {
   it("renders as expected with custom columns", () => {
-    render(
-      <DirectoryLiveTable
-        title="Live Experiments"
-        experiments={[experiment]}
-      />,
-    );
+    render(<DirectoryLiveTable experiments={[experiment]} />);
     expectTableCells("directory-table-header", [
-      "Live Experiments",
+      "Name",
       "Owner",
       "Feature",
       "Enrolling",
@@ -186,11 +173,9 @@ describe("DirectoryLiveTable", () => {
 
 describe("DirectoryCompleteTable", () => {
   it("renders as expected with custom columns", () => {
-    render(
-      <DirectoryCompleteTable title="Completed" experiments={[experiment]} />,
-    );
+    render(<DirectoryCompleteTable experiments={[experiment]} />);
     expectTableCells("directory-table-header", [
-      "Completed",
+      "Name",
       "Owner",
       "Feature",
       "Started",
@@ -210,8 +195,8 @@ describe("DirectoryCompleteTable", () => {
 
 describe("DirectoryDraftsTable", () => {
   it("renders as expected with custom columns", () => {
-    render(<DirectoryDraftsTable title="Drafts" experiments={[experiment]} />);
-    expectTableCells("directory-table-header", ["Drafts", "Owner", "Feature"]);
+    render(<DirectoryDraftsTable experiments={[experiment]} />);
+    expectTableCells("directory-table-header", ["Name", "Owner", "Feature"]);
     expectTableCells("directory-table-cell", [
       experiment.name,
       experiment.owner!.username,

--- a/app/experimenter/nimbus-ui/src/components/PageHome/DirectoryTable/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageHome/DirectoryTable/index.tsx
@@ -71,70 +71,49 @@ interface Column {
 }
 
 interface DirectoryTableProps {
-  title: string;
   experiments: getAllExperiments_experiments[];
   columns?: Column[];
 }
 
 const DirectoryTable: React.FunctionComponent<DirectoryTableProps> = ({
-  title,
   experiments,
   columns: customColumns,
 }) => {
   const columns = customColumns || [
-    { label: title, component: DirectoryColumnTitle },
+    { label: "Name", component: DirectoryColumnTitle },
     { label: "Owner", component: DirectoryColumnOwner },
     { label: "Feature", component: DirectoryColumnFeature },
   ];
   return (
-    <div className="directory-table pb-2" data-testid="DirectoryTable">
-      <table className="table">
-        <thead>
-          <tr>
-            {experiments.length ? (
-              columns.map(({ label }, i) => (
+    <div className="directory-table pb-2 mt-4">
+      {experiments.length ? (
+        <table className="table" data-testid="DirectoryTable">
+          <thead>
+            <tr>
+              {columns.map(({ label }, i) => (
                 <th
-                  className={`border-top-0 ${
-                    i === 0 ? "font-weight-bold" : "font-weight-normal"
-                  }`}
+                  className="border-top-0"
                   key={label}
                   data-testid="directory-table-header"
                 >
                   {label}
                 </th>
-              ))
-            ) : (
-              <th
-                colSpan={columns.length}
-                className="border-top-0 font-weight-bold"
-                data-testid="directory-table-header"
-              >
-                {columns[0].label}
-              </th>
-            )}
-          </tr>
-        </thead>
-        <tbody>
-          {experiments.length ? (
-            experiments.map((experiment) => (
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {experiments.map((experiment) => (
               <tr key={experiment.slug} data-testid="directory-table-row">
                 {columns.map(({ label, component: ColumnComponent }, i) => {
                   return <ColumnComponent key={label + i} {...experiment} />;
                 })}
               </tr>
-            ))
-          ) : (
-            <tr data-testid="directory-table-row">
-              <td
-                colSpan={columns.length}
-                data-testid="directory-table-no-experiments"
-              >
-                No experiments found.
-              </td>
-            </tr>
-          )}
-        </tbody>
-      </table>
+            ))}
+          </tbody>
+        </table>
+      ) : (
+        <p data-testid="no-experiments">No experiments found.</p>
+      )}
     </div>
   );
 };
@@ -143,7 +122,7 @@ export const DirectoryLiveTable: React.FC<DirectoryTableProps> = (props) => (
   <DirectoryTable
     {...props}
     columns={[
-      { label: props.title, component: DirectoryColumnTitle },
+      { label: "Name", component: DirectoryColumnTitle },
       { label: "Owner", component: DirectoryColumnOwner },
       { label: "Feature", component: DirectoryColumnFeature },
       {
@@ -204,7 +183,7 @@ export const DirectoryCompleteTable: React.FC<DirectoryTableProps> = (
   <DirectoryTable
     {...props}
     columns={[
-      { label: props.title, component: DirectoryColumnTitle },
+      { label: "Name", component: DirectoryColumnTitle },
       { label: "Owner", component: DirectoryColumnOwner },
       { label: "Feature", component: DirectoryColumnFeature },
       {
@@ -238,7 +217,7 @@ export const DirectoryDraftsTable: React.FC<DirectoryTableProps> = (props) => (
     {...props}
     columns={[
       {
-        label: props.title,
+        label: "Name",
         component: (experiment) => <DirectoryColumnTitle {...experiment} />,
       },
       { label: "Owner", component: DirectoryColumnOwner },

--- a/app/experimenter/nimbus-ui/src/components/PageHome/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageHome/index.stories.tsx
@@ -3,41 +3,47 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { withLinks } from "@storybook/addon-links";
-import { storiesOf } from "@storybook/react";
 import React from "react";
 import PageHome from ".";
 import { mockDirectoryExperimentsQuery, MockedCache } from "../../lib/mocks";
 import { RouterSlugProvider } from "../../lib/test-utils";
 import { NimbusExperimentStatus } from "../../types/globalTypes";
 
-storiesOf("pages/Home", module)
-  .addDecorator(withLinks)
-  .add("basic", () => (
-    <RouterSlugProvider mocks={[mockDirectoryExperimentsQuery()]}>
-      <PageHome />
-    </RouterSlugProvider>
-  ))
-  .add("loading", () => (
-    <RouterSlugProvider mocks={[]}>
-      <PageHome />
-    </RouterSlugProvider>
-  ))
-  .add("no experiments", () => (
-    <MockedCache mocks={[mockDirectoryExperimentsQuery([])]}>
-      <PageHome />
-    </MockedCache>
-  ))
-  .add("only drafts", () => (
-    <MockedCache
-      mocks={[
-        mockDirectoryExperimentsQuery([
-          { status: NimbusExperimentStatus.DRAFT },
-          { status: NimbusExperimentStatus.DRAFT },
-          { status: NimbusExperimentStatus.DRAFT },
-          { status: NimbusExperimentStatus.DRAFT },
-        ]),
-      ]}
-    >
-      <PageHome />
-    </MockedCache>
-  ));
+export default {
+  title: "pages/Home",
+  component: PageHome,
+  decorators: [withLinks],
+};
+
+export const Basic = () => (
+  <RouterSlugProvider mocks={[mockDirectoryExperimentsQuery()]}>
+    <PageHome />
+  </RouterSlugProvider>
+);
+
+export const Loading = () => (
+  <RouterSlugProvider mocks={[]}>
+    <PageHome />
+  </RouterSlugProvider>
+);
+
+export const NoExperiments = () => (
+  <MockedCache mocks={[mockDirectoryExperimentsQuery([])]}>
+    <PageHome />
+  </MockedCache>
+);
+
+export const OnlyDrafts = () => (
+  <MockedCache
+    mocks={[
+      mockDirectoryExperimentsQuery([
+        { status: NimbusExperimentStatus.DRAFT },
+        { status: NimbusExperimentStatus.DRAFT },
+        { status: NimbusExperimentStatus.DRAFT },
+        { status: NimbusExperimentStatus.DRAFT },
+      ]),
+    ]}
+  >
+    <PageHome />
+  </MockedCache>
+);

--- a/app/experimenter/nimbus-ui/src/components/PageHome/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageHome/index.tsx
@@ -46,23 +46,21 @@ export const Body = () => {
     data.experiments,
   );
   return (
-    <Tabs defaultActiveKey="active">
-      <Tab eventKey="active" title="Active">
-        <div className="mt-4">
-          <DirectoryLiveTable title="Live Experiments" experiments={live} />
-          <DirectoryTable title="In Review" experiments={review} />
-          <DirectoryTable title="In Preview" experiments={preview} />
-        </div>
+    <Tabs defaultActiveKey="live">
+      <Tab eventKey="live" title="Live">
+        <DirectoryLiveTable experiments={live} />
+      </Tab>
+      <Tab eventKey="review" title="Review">
+        <DirectoryTable experiments={review} />
+      </Tab>
+      <Tab eventKey="preview" title="Preview">
+        <DirectoryTable experiments={preview} />
       </Tab>
       <Tab eventKey="completed" title="Completed">
-        <div className="mt-4">
-          <DirectoryCompleteTable title="Completed" experiments={complete} />
-        </div>
+        <DirectoryCompleteTable experiments={complete} />
       </Tab>
       <Tab eventKey="drafts" title="Drafts">
-        <div className="mt-4">
-          <DirectoryDraftsTable title="Drafts" experiments={draft} />
-        </div>
+        <DirectoryDraftsTable experiments={draft} />
       </Tab>
     </Tabs>
   );

--- a/app/tests/integration/nimbus/pages/home.py
+++ b/app/tests/integration/nimbus/pages/home.py
@@ -7,7 +7,7 @@ class HomePage(Page):
     """Nimbus Home page."""
 
     _create_new_btn_locator = (By.CSS_SELECTOR, "#create-new-button")
-    _page_wait_locator = (By.CSS_SELECTOR, ".table")
+    _page_wait_locator = (By.CSS_SELECTOR, ".directory-table")
 
     def __init__(self, selenium, base_url, **kwargs):
         super(HomePage, self).__init__(selenium, base_url, timeout=30, **kwargs)
@@ -19,7 +19,7 @@ class HomePage(Page):
 
     @property
     def tables(self):
-        _table_locator = (By.CSS_SELECTOR, ".active .directory-table .table")
+        _table_locator = (By.CSS_SELECTOR, ".active .directory-table")
         self.wait.until(EC.presence_of_element_located(_table_locator))
         tables = self.find_elements(*_table_locator)
         return [self.Tables(self, el) for el in tables]
@@ -28,6 +28,12 @@ class HomePage(Page):
     def tabs(self):
         _tabs_locator = (By.CSS_SELECTOR, ".nav-item")
         return self.find_elements(*_tabs_locator)
+
+    @property
+    def active_tab_text(self):
+        _active_tab_locator = (By.CSS_SELECTOR, ".nav-item.active")
+        el = self.find_element(*_active_tab_locator)
+        return el.text
 
     def create_new_button(self):
         el = self.find_element(*self._create_new_btn_locator)
@@ -38,13 +44,7 @@ class HomePage(Page):
 
     class Tables(Region):
 
-        _table_name_locator = (By.CSS_SELECTOR, ".font-weight-bold")
         _experiment_link_locator = (By.CSS_SELECTOR, "tr a")
-
-        @property
-        def table_name(self):
-            el = self.find_element(*self._table_name_locator)
-            return el.text
 
         @property
         def experiments(self):

--- a/app/tests/integration/nimbus/test_e2e_create_experiment.py
+++ b/app/tests/integration/nimbus/test_e2e_create_experiment.py
@@ -124,7 +124,7 @@ def test_create_new_experiment_remote_settings(selenium, base_url):
     # Check it's live
     home = HomePage(selenium, base_url).wait_for_page_to_load()
     live_experiments = home.tables[0]
-    assert "live experiments" in live_experiments.table_name.lower()
+    assert "Live" in home.active_tab_text
     for item in live_experiments.experiments:
         if experiment_name in item.text:
             item.click()


### PR DESCRIPTION
Closes #5954 

This PR changes the directory/home page view to display for _all_ experiment lifecycle statuses, instead of grouping them together.

As a bonus, I also added a mechanism to remember which tab you were last on.