### PR TITLE
fix #5972 chore(project): revert cache docker layers in dockerhub 😢 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,24 @@
 version: 2.1
 jobs:
+  build:
+    machine:
+      docker_layer_caching: true
+      image: ubuntu-2004:202104-01 # Ubuntu 20.04, Docker v20.10.6, Docker Compose v1.29.1
+    resource_class: large
+    working_directory: ~/experimenter
+    steps:
+      - run:
+          name: Docker info
+          command: docker -v
+      - run:
+          name: Docker compose info
+          command: docker-compose -v
+      - checkout
+      - run:
+          name: Build docker images
+          command: |
+            make build_prod
+
   check:
     machine:
       docker_layer_caching: true
@@ -94,37 +113,44 @@ jobs:
       - deploy:
           name: Deploy to latest
           command: |
-            docker login -u $DOCKER_USER -p $DOCKER_PASS
-            make build_dev
-            make build_test
+            ./scripts/store_git_info.sh
             make build_prod
-            docker tag app:dev ${DOCKERHUB_REPO}:build_dev
-            docker tag app:test ${DOCKERHUB_REPO}:build_test
+            docker login -u $DOCKER_USER -p $DOCKER_PASS
             docker tag app:deploy ${DOCKERHUB_REPO}:latest
-            docker push ${DOCKERHUB_REPO}:build_dev
-            docker push ${DOCKERHUB_REPO}:build_test
             docker push ${DOCKERHUB_REPO}:latest
 
 workflows:
   version: 2
   build:
     jobs:
+      - build:
+          name: build
       - check:
           name: check
+          requires:
+            - build
       - publish_storybooks:
           name: publish_storybooks
+          requires:
+            - build
       - integration_legacy:
           name: integration_legacy
+          requires:
+            - build
           filters:
             branches:
               ignore:
                 - main
+
       - integration_nimbus:
           name: integration_nimbus
+          requires:
+            - build
           filters:
             branches:
               ignore:
                 - main
+
       - deploy:
           filters:
             branches:

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -1,15 +1,3 @@
-FROM alpine:3.12.0 as file-loader
-
-# To preserve layer caching across machines which may have different local file properties
-# such as permissions, timestamps, etc, all files are copied into a container and their
-# permissions and timestamps are reset to consistent values
-# Credit: https://gist.github.com/kekru/8ac61cd87536a4355220b56ae2f4b0a9
-COPY . /app/
-RUN chmod -R 555 /app \
- && chown -R root:root /app \
- && find /app -exec touch -a -m -t 201512180130.09 {} \;
-
-
 # Dev image
 FROM python:3.9 AS dev
 
@@ -21,7 +9,7 @@ ENV PYTHONDONTWRITEBYTECODE 1
 
 
 # Scripts for waiting for the db and setting up kinto
-COPY --from=file-loader /app/bin/ /app/bin/
+COPY bin/ /app/bin/
 RUN chmod +x /app/bin/wait-for-it.sh
 
 
@@ -46,8 +34,7 @@ RUN apt-get --no-install-recommends install -y apt-utils ca-certificates postgre
 RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python
 ENV PATH "/root/.poetry/bin:${PATH}"
 RUN poetry config virtualenvs.create false
-COPY --from=file-loader /app/pyproject.toml /app/pyproject.toml
-COPY --from=file-loader /app/poetry.lock /app/poetry.lock
+COPY poetry.lock pyproject.toml ./
 RUN poetry install
 
 # If any package is installed, that is incompatible by version, this command
@@ -56,19 +43,19 @@ RUN poetry check
 
 
 # Node packages
-COPY --from=file-loader /app/package.json /app/package.json
-COPY --from=file-loader /app/yarn.lock /app/yarn.lock
-COPY --from=file-loader /app/experimenter/legacy-ui/core/package.json /app/experimenter/legacy-ui/core/package.json
+COPY ./package.json /app/package.json
+COPY ./yarn.lock /app/yarn.lock
+COPY ./experimenter/legacy-ui/core/package.json /app/experimenter/legacy-ui/core/package.json
 RUN yarn install --frozen-lockfile
 
-COPY --from=file-loader /app/experimenter/nimbus-ui/package.json /app/experimenter/nimbus-ui/package.json
+COPY ./experimenter/nimbus-ui/package.json /app/experimenter/nimbus-ui/package.json
 RUN yarn install --frozen-lockfile
 
 
 FROM dev AS test
 
 # Copy source
-COPY --from=file-loader /app/ /app/
+COPY . /app
 
 
 # Build image
@@ -76,9 +63,9 @@ FROM dev AS build
 
 
 # Build assets
-COPY --from=file-loader /app/experimenter/legacy-ui/ /app/experimenter/legacy-ui/
+COPY ./experimenter/legacy-ui/ /app/experimenter/legacy-ui/
+COPY ./experimenter/nimbus-ui/ /app/experimenter/nimbus-ui/
 RUN yarn workspace @experimenter/core build
-COPY --from=file-loader /app/experimenter/nimbus-ui/ /app/experimenter/nimbus-ui/
 RUN yarn workspace @experimenter/nimbus-ui build
 
 
@@ -90,22 +77,16 @@ EXPOSE 7001
 
 # Disable python pyc files
 ENV PYTHONDONTWRITEBYTECODE 1
-
-
 # Add poetry to path
 ENV PATH "/root/.poetry/bin:${PATH}"
 
-
-# System packages
 RUN apt-get update
 RUN apt-get --no-install-recommends install -y apt-utils ca-certificates postgresql-client
 
-
-# Copy source from previously built containers
 COPY --from=dev /usr/local/bin/ /usr/local/bin/
 COPY --from=dev /usr/local/lib/python3.9/site-packages/ /usr/local/lib/python3.9/site-packages/
 COPY --from=dev /app/bin/ /app/bin/
-COPY --from=file-loader /app/manage.py /app/manage.py
-COPY --from=file-loader /app/experimenter/ /app/experimenter/
+COPY ./manage.py /app/manage.py
+COPY ./experimenter/ /app/experimenter/
 COPY --from=build /app/experimenter/legacy-ui/assets/ /app/experimenter/legacy-ui/assets/
 COPY --from=build /app/experimenter/nimbus-ui/build/ /app/experimenter/nimbus-ui/build/


### PR DESCRIPTION
Becuase

* After digging into it I find that even if the file contents and visible metadata (owner, group, timestamp) are identical between circle and local, docker will generate different layer hashes, which means the layers built on circle won't be reused locally
* Something else about the file metadata/host environment is contributing to different hashing
* So while layers built on circle can be reused within circle, they can't be reused locally, and we already have shared layer caching within circle using the circle docker build cache

This commit

* This reverts commit 4c0df6b262508a21fa67c1251b79eb13e2f964d8.