### PR TITLE
fix #5977 chore(project): only generate version.json on deploy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,6 +97,7 @@ jobs:
             docker login -u $DOCKER_USER -p $DOCKER_PASS
             make build_dev
             make build_test
+            ./scripts/store_git_info.sh
             make build_prod
             docker tag app:dev ${DOCKERHUB_REPO}:build_dev
             docker tag app:test ${DOCKERHUB_REPO}:build_test

--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,6 @@ build_test: jetstream_config ssl
 	DOCKER_BUILDKIT=1 docker build --target test -f app/Dockerfile -t app:test --build-arg BUILDKIT_INLINE_CACHE=1 --cache-from mozilla/experimenter:build_test $$([[ -z "$${CIRCLECI}" ]] || echo "--progress=plain") app/
 
 build_prod: jetstream_config ssl
-	./scripts/store_git_info.sh
 	DOCKER_BUILDKIT=1 docker build --target deploy -f app/Dockerfile -t app:deploy --build-arg BUILDKIT_INLINE_CACHE=1 --cache-from mozilla/experimenter:latest $$([[ -z "$${CIRCLECI}" ]] || echo "--progress=plain") app/
 
 compose_stop:


### PR DESCRIPTION
Because

* We recently reorganized our build steps
* We moved version.json generation from the deploy step to all builds
* version.json changes on every circle invocation which can invalidate shared docker caches

This commit

* Moves version.json generation back to only during deploy