### PR TITLE
fix #5981 chore(nimbus): remove deprecated update celery task

### DIFF
--- a/app/experimenter/settings.py
+++ b/app/experimenter/settings.py
@@ -333,10 +333,6 @@ CELERY_BEAT_SCHEDULE = {
         "task": "experimenter.kinto.tasks.nimbus_check_experiments_are_live",
         "schedule": config("CELERY_SCHEDULE_INTERVAL", default=300, cast=int),
     },
-    "nimbus_check_experiments_are_updated": {
-        "task": "experimenter.kinto.tasks.nimbus_check_experiments_are_updated",
-        "schedule": config("CELERY_SCHEDULE_INTERVAL", default=300, cast=int),
-    },
     "nimbus_check_experiments_are_complete": {
         "task": "experimenter.kinto.tasks.nimbus_check_experiments_are_complete",
         "schedule": config("CELERY_SCHEDULE_INTERVAL", default=300, cast=int),


### PR DESCRIPTION
Because

* We recently refactored the live update/pause kinto tasks
* We removed the separate update task and folded that logic into the check collection task
* We neglected to remove the reference to it from the beat scheduler

This commit

* Removes the deprecated reference