### PR TITLE
fixes #5991 fix(reporting): Intermitten test test_tasks

### DIFF
--- a/app/experimenter/reporting/tests/test_tasks.py
+++ b/app/experimenter/reporting/tests/test_tasks.py
@@ -145,8 +145,9 @@ class TestTask(MockNormandyMixin, TestCase):
 
     def test_is_duplicate_recipe_change_returns_true(self):
         experiment = ExperimentFactory.create()
+        timestamp = timezone.datetime(2021, 8, 18, 8, 15, 12)
         report_log = ReportLogFactory.create(
-            timestamp=timezone.now(),
+            timestamp=timestamp,
             experiment_type="Normandy-Pref",
             experiment_name=experiment.name,
             experiment_old_status=Experiment.STATUS_LIVE,
@@ -155,7 +156,7 @@ class TestTask(MockNormandyMixin, TestCase):
             event_reason=ReportLogConstants.EventReason.RECIPE_CHANGE,
         )
 
-        later = timezone.now() + timezone.timedelta(hours=1)
+        later = timestamp + timezone.timedelta(hours=1)
         self.assertTrue(
             is_duplicate_recipe_change(later, experiment, report_log.event_reason)
         )


### PR DESCRIPTION
Because:
 * test previous uses timezone.now() and a time an hour later
 * this causes an edge case when a test is run near the end of a day and an hour later being the next day

This commit:
 * sets a specific date and time rather than relying on timezone.now()