### PR TITLE
fix #5765 feat(nimbus): Display more detailed error output across pages in alert

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/ApolloErrorAlert/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/ApolloErrorAlert/index.stories.tsx
@@ -1,0 +1,33 @@
+import React from "react";
+import { ApolloErrorAlert } from ".";
+import {
+  GQL_ERROR,
+  GQL_ERROR_MULTIPLE,
+  NETWORK_SERVER_ERROR,
+  NETWORK_SERVER_PARSE_ERROR,
+} from "./mocks";
+
+export default {
+  title: "components/ApolloErrorAlert",
+  component: ApolloErrorAlert,
+};
+
+export const withError = () => (
+  <ApolloErrorAlert
+    error={new Error("Uh oh. You made the app crashy crash.")}
+  />
+);
+
+export const withNetworkServerError = () => (
+  <ApolloErrorAlert error={NETWORK_SERVER_ERROR} />
+);
+
+export const withNetworkServerParseError = () => (
+  <ApolloErrorAlert error={NETWORK_SERVER_PARSE_ERROR} />
+);
+
+export const withGQLError = () => <ApolloErrorAlert error={GQL_ERROR} />;
+
+export const withMultipleGQLErrors = () => (
+  <ApolloErrorAlert error={GQL_ERROR_MULTIPLE} />
+);

--- a/app/experimenter/nimbus-ui/src/components/ApolloErrorAlert/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/ApolloErrorAlert/index.test.tsx
@@ -1,0 +1,59 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { ServerError, ServerParseError } from "@apollo/client";
+import { render, screen } from "@testing-library/react";
+import React from "react";
+import ApolloErrorAlert from ".";
+import {
+  GQL_ERROR,
+  NETWORK_ERROR,
+  NETWORK_SERVER_ERROR,
+  NETWORK_SERVER_PARSE_ERROR,
+} from "./mocks";
+
+describe("ApolloErrorAlert", () => {
+  it("handles a standard error", () => {
+    render(<ApolloErrorAlert error={new Error("boop")} />);
+    screen.getByText("General GQL Error");
+    screen.getByText("boop");
+  });
+
+  it("handles a network server error", () => {
+    render(<ApolloErrorAlert error={NETWORK_SERVER_ERROR} />);
+    screen.getByText("Network Error");
+    screen.getByText(NETWORK_SERVER_ERROR.message);
+    screen.getByText(
+      (NETWORK_SERVER_ERROR.networkError! as ServerError).result!.errors[0]
+        .message,
+    );
+  });
+
+  it("handles a network server parse error", () => {
+    render(<ApolloErrorAlert error={NETWORK_SERVER_PARSE_ERROR} />);
+    screen.getByText("Network Error");
+    screen.getByText(NETWORK_SERVER_PARSE_ERROR.message);
+    screen.getByText(
+      (NETWORK_SERVER_PARSE_ERROR.networkError! as ServerParseError).statusCode,
+    );
+    // an actual bodyText response is difficult to test for; just check for error details
+    screen.getByText("Request URL:", { exact: false });
+  });
+
+  it("handles a network error", () => {
+    render(<ApolloErrorAlert error={NETWORK_ERROR} />);
+    screen.getByText("Network Error");
+    screen.getByText(NETWORK_ERROR.message);
+    screen.getByText(
+      (NETWORK_ERROR.networkError! as ServerError).result.errors[0].message,
+    );
+  });
+
+  it("handles a graphQL error", () => {
+    render(<ApolloErrorAlert error={GQL_ERROR} />);
+    screen.getByText("GraphQL Apollo Error");
+    // in this case, `GQL_ERROR.message` matches `GQL_ERROR.graphQLErrors[0].message`
+    expect(screen.getAllByText(GQL_ERROR.message)).toHaveLength(2);
+  });
+});

--- a/app/experimenter/nimbus-ui/src/components/ApolloErrorAlert/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/ApolloErrorAlert/index.tsx
@@ -1,0 +1,86 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { ApolloError, ServerError, ServerParseError } from "@apollo/client";
+import { GraphQLError } from "graphql";
+import React from "react";
+import { Alert } from "react-bootstrap";
+import sentryMetrics from "../../services/sentry";
+
+export type NetworkError = ApolloError["networkError"];
+
+// Type guards - If the `networkError` is a `ServerError`, we want to display its `result.errors`
+// array containing extra info
+function isNetworkServerError(
+  networkError: NetworkError,
+): networkError is ServerError {
+  return (networkError as ServerError)?.result !== undefined;
+}
+
+// If the `networkError` is a `ServerParseError`, we want to display `bodyText` and `statusCode`
+function isNetworkServerParseError(
+  networkError: NetworkError,
+): networkError is ServerParseError {
+  return (
+    (networkError as ServerParseError)?.bodyText !== undefined &&
+    (networkError as ServerParseError)?.statusCode !== undefined
+  );
+}
+
+export const ApolloErrorAlert = ({ error }: { error: ApolloError | Error }) => {
+  const { graphQLErrors = [], networkError } = error as ApolloError;
+  const networkServerErrors =
+    networkError && isNetworkServerError(networkError)
+      ? networkError.result.errors
+      : [];
+
+  // Report Errors and NetworkErrors, graphQLErrors should be captured server-side
+  if (networkError || error instanceof Error) {
+    sentryMetrics.captureException(error);
+  }
+
+  let heading = "General GQL Error";
+  if (graphQLErrors.length) {
+    heading = "GraphQL Apollo Error";
+  } else if (networkError) {
+    heading = "Network Error";
+  }
+
+  return (
+    <Alert variant="danger" data-testid="apollo-error-alert">
+      <Alert.Heading>{heading}</Alert.Heading>
+      <p className="mb-6">Something went wrong. Please try again later.</p>
+      <hr />
+      {error.message && (
+        <p>
+          <b>Message:</b> {error.message}
+        </p>
+      )}
+      {graphQLErrors.length > 0 &&
+        graphQLErrors.map((gqlError: GraphQLError) => (
+          <p key={gqlError.message}>
+            <b>graphQL error:</b> {gqlError.message}
+          </p>
+        ))}
+      {networkServerErrors.length > 0 &&
+        networkServerErrors.map((serverError: ServerError) => (
+          <p key={serverError.message}>
+            <b>Network error:</b> {serverError.message}
+          </p>
+        ))}
+      {networkError && isNetworkServerParseError(networkError) && (
+        <>
+          <p>
+            <b>Status code:</b> {networkError.statusCode}
+          </p>
+          <p>
+            <b>Body text:</b> {networkError.bodyText}
+          </p>
+        </>
+      )}
+    </Alert>
+  );
+};
+
+export default ApolloErrorAlert;

--- a/app/experimenter/nimbus-ui/src/components/ApolloErrorAlert/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/components/ApolloErrorAlert/mocks.tsx
@@ -1,0 +1,79 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { ApolloError } from "@apollo/client";
+import { GraphQLError } from "graphql";
+
+export const NETWORK_SERVER_ERROR = new ApolloError({
+  graphQLErrors: [],
+  networkError: {
+    name: "ServerError",
+    message: "Response not successful: Received status code 400",
+    response: new Response(),
+    statusCode: 400,
+    result: {
+      errors: [
+        {
+          message: 'Cannot query field "WOOT" on type "NimbusExperimentType".',
+          locations: [
+            {
+              line: 3,
+              column: 5,
+            },
+          ],
+        },
+      ],
+    },
+  },
+});
+
+export const NETWORK_SERVER_PARSE_ERROR = new ApolloError({
+  graphQLErrors: [],
+  networkError: {
+    name: "ServerParseError",
+    message:
+      "JSON.parse: unexpected character at line 1 column 1 of the JSON data",
+    response: new Response(),
+    statusCode: 404,
+    bodyText:
+      '<!DOCTYPE html>\n<html lang="en">\n<head>\n  <meta http-equiv="content-type" content="text/html; charset=utf-8">\n  <title>Page not found at /graphql</title>\n  <meta name="robots" content="NONE,NOARCHIVE">\n  <style type="text/css">\n    html * { padding:0; margin:0; }\n    body * { padding:10px 20px; }\n    body * * { padding:0; }\n    body { font:small sans-serif; background:#eee; color:#000; }\n    body>div { border-bottom:1px solid #ddd; }\n    h1 { font-weight:normal; margin-bottom:.4em; }\n    h1 span { font-size:60%; color:#666; font-weight:normal; }\n    table { border:none; border-collapse: collapse; width:100%; }\n    td, th { vertical-align:top; padding:2px 3px; }\n    th { width:12em; text-align:right; color:#666; padding-right:.5em; }\n    #info { background:#f6f6f6; }\n    #info ol { margin: 0.5em 4em; }\n    #info ol li { font-family: monospace; }\n    #summary { background: #ffc; }\n    #explanation { background:#eee; border-bottom: 0px none; }\n    pre.exception_value { font-family: sans-serif; color: #575757; font-size: 1.5em; margin: 10px 0 10px 0; }\n  </style>\n</head>\n<body>\n  <div id="summary">\n    <h1>Page not found <span>(404)</span></h1>\n    \n    <table class="meta">\n      <tr>\n        <th>Request Method:</th>\n        <td>POST</td>\n      </tr>\n      <tr>\n        <th>Request URL:</th>\n        <td>https://localhost/graphql</td>\n      </tr>\n      \n    </table>\n  </div>\n  <div id="info">\n    \n      <p>\n      Using the URLconf defined in <code>experimenter.urls</code>,\n      Django tried these URL patterns, in this order:\n      </p>\n      <ol>\n        \n          <li>\n            \n                ^media/(?P&lt;path&gt;.*)$\n                \n            \n          </li>\n        \n          <li>\n            \n                ^api/v1/experiments/\n                \n            \n          </li>\n        \n          <li>\n            \n                ^api/v2/experiments/\n                \n            \n          </li>\n        \n          <li>\n            \n                ^api/v3/\n                \n            \n          </li>\n        \n          <li>\n            \n                ^api/v5/\n                \n            \n          </li>\n        \n          <li>\n            \n                ^api/v6/\n                \n            \n          </li>\n        \n          <li>\n            \n                ^admin/\n                \n            \n          </li>\n        \n          <li>\n            \n                ^experiments/\n                \n            \n          </li>\n        \n          <li>\n            \n                ^nimbus/\n                [name=\'nimbus-list\']\n            \n          </li>\n        \n          <li>\n            \n                ^nimbus/(?P&lt;slug&gt;[\\w-]+)/\n                [name=\'nimbus-detail\']\n            \n          </li>\n        \n          <li>\n            \n                ^$\n                [name=\'home\']\n            \n          </li>\n        \n          <li>\n            \n                ^404/\n                \n            \n          </li>\n        \n      </ol>\n      <p>\n        \n          The current path, <code>graphql</code>,\n        \n        didn’t match any of these.\n      </p>\n    \n  </div>\n\n  <div id="explanation">\n    <p>\n      You’re seeing this error because you have <code>DEBUG = True</code> in\n      your Django settings file. Change that to <code>False</code>, and Django\n      will display a standard 404 page.\n    </p>\n  </div>\n</body>\n</html>\n',
+  },
+});
+
+export const NETWORK_ERROR = new ApolloError({
+  graphQLErrors: [],
+  networkError: {
+    name: "Error",
+    message: "Response not successful: Received status code 400",
+    response: new Response(),
+    statusCode: 400,
+    result: {
+      errors: [
+        {
+          message: 'Cannot query field "WOOT" on type "NimbusExperimentType".',
+          locations: [
+            {
+              line: 3,
+              column: 5,
+            },
+          ],
+        },
+      ],
+    },
+  },
+});
+
+export const GQL_ERROR = new ApolloError({
+  graphQLErrors: [new GraphQLError('Received incompatible instance "WOOT".')],
+  networkError: null,
+});
+
+export const GQL_ERROR_MULTIPLE = new ApolloError({
+  graphQLErrors: [
+    new GraphQLError('Received incompatible instance "b".'),
+    new GraphQLError('Received incompatible instance "a".'),
+    new GraphQLError('Received incompatible instance "d".'),
+  ],
+  networkError: null,
+});

--- a/app/experimenter/nimbus-ui/src/components/App/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/App/index.test.tsx
@@ -25,6 +25,21 @@ describe("App", () => {
     expect(screen.getByTestId("page-loading")).toBeInTheDocument();
   });
 
+  it("renders the error alert when an error occurs querying the config", () => {
+    const error = new Error("boop");
+
+    (jest.spyOn(apollo, "useQuery") as jest.Mock).mockReturnValueOnce({
+      error,
+    });
+
+    renderWithRouter(
+      <MockedCache mocks={[]}>
+        <App basepath="/" />
+      </MockedCache>,
+    );
+    expect(screen.queryByTestId("apollo-error-alert")).toBeInTheDocument();
+  });
+
   it("routes to PageHome page", () => {
     renderWithRouter(
       <MockedCache>

--- a/app/experimenter/nimbus-ui/src/components/App/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/App/index.tsx
@@ -6,6 +6,7 @@ import { useQuery } from "@apollo/client";
 import { Redirect, RouteComponentProps, Router } from "@reach/router";
 import React from "react";
 import { GET_CONFIG_QUERY } from "../../gql/config";
+import ApolloErrorAlert from "../ApolloErrorAlert";
 import PageEditAudience from "../PageEditAudience";
 import PageEditBranches from "../PageEditBranches";
 import PageEditMetrics from "../PageEditMetrics";
@@ -23,10 +24,14 @@ type RootProps = {
 const Root = (props: RootProps) => <>{props.children}</>;
 
 const App = ({ basepath }: { basepath: string }) => {
-  const { loading } = useQuery(GET_CONFIG_QUERY);
+  const { loading, error } = useQuery(GET_CONFIG_QUERY);
 
   if (loading) {
     return <PageLoading />;
+  }
+
+  if (error) {
+    return <ApolloErrorAlert {...{ error }} />;
   }
 
   return (

--- a/app/experimenter/nimbus-ui/src/components/AppErrorBoundary/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/AppErrorBoundary/index.stories.tsx
@@ -1,7 +1,13 @@
-import { storiesOf } from "@storybook/react";
 import React from "react";
 import { AppErrorAlert } from ".";
 
-storiesOf("components/AppErrorAlert", module).add("basic", () => (
-  <AppErrorAlert />
-));
+export default {
+  title: "components/AppErrorAlert",
+  component: AppErrorAlert,
+};
+
+export const withoutErrorMessage = () => <AppErrorAlert error={new Error()} />;
+
+export const withErrorMessage = () => (
+  <AppErrorAlert error={new Error("Uh oh. You made the app crashy crash.")} />
+);

--- a/app/experimenter/nimbus-ui/src/components/AppErrorBoundary/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/AppErrorBoundary/index.test.tsx
@@ -7,9 +7,12 @@ import React from "react";
 import AppErrorBoundary, { AppErrorAlert } from ".";
 
 describe("AppErrorAlert", () => {
-  it("renders a general error dialog", () => {
-    const { queryByTestId } = render(<AppErrorAlert />);
+  it("renders a general error dialog", async () => {
+    const { queryByTestId } = render(
+      <AppErrorAlert error={new Error("boop")} />,
+    );
     expect(queryByTestId("error-loading-app")).toBeInTheDocument();
+    await screen.findByText("boop");
   });
 });
 
@@ -37,7 +40,7 @@ describe("AppErrorBoundary", () => {
     expect(screen.queryByTestId("error-loading-app")).not.toBeInTheDocument();
   });
 
-  it("renders a general error dialog on exception in child component", () => {
+  it("renders a general error dialog on exception in child component", async () => {
     const BadComponent = () => {
       throw new Error("bad");
     };
@@ -49,5 +52,6 @@ describe("AppErrorBoundary", () => {
     );
 
     expect(screen.queryByTestId("error-loading-app")).toBeInTheDocument();
+    await screen.findByText("bad");
   });
 });

--- a/app/experimenter/nimbus-ui/src/components/AppErrorBoundary/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/AppErrorBoundary/index.tsx
@@ -26,17 +26,21 @@ class AppErrorBoundary extends React.Component {
 
   render() {
     const { error } = this.state;
-    return error ? <AppErrorAlert /> : this.props.children;
+    return error ? <AppErrorAlert {...{ error }} /> : this.props.children;
   }
 }
 
-export const AppErrorAlert = () => {
-  return (
-    <Alert variant="warning" data-testid="error-loading-app">
-      <Alert.Heading>General application error</Alert.Heading>
-      <p>Something went wrong. Please try again later.</p>
-    </Alert>
-  );
-};
+export const AppErrorAlert = ({ error }: { error: Error }) => (
+  <Alert variant="danger" data-testid="error-loading-app">
+    <Alert.Heading>General application error</Alert.Heading>
+    <p>Something went wrong. Please try again later.</p>
+    {error?.message && (
+      <>
+        <hr />
+        <small>{"" + error.message}</small>
+      </>
+    )}
+  </Alert>
+);
 
 export default AppErrorBoundary;

--- a/app/experimenter/nimbus-ui/src/components/AppLayoutWithExperiment/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/AppLayoutWithExperiment/index.test.tsx
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import * as apollo from "@apollo/client";
 import { MockedResponse } from "@apollo/client/testing";
 import { navigate } from "@reach/router";
 import { act, render, screen, waitFor } from "@testing-library/react";
@@ -30,6 +31,20 @@ describe("AppLayoutWithExperiment", () => {
   it("renders loading screen to start", async () => {
     render(<Subject />);
     await screen.findByText("Loading...");
+  });
+
+  it("renders the error alert when an error occurs querying the experiment", async () => {
+    const { mock } = mockExperimentQuery("demo-slug");
+    const error = new Error("boop");
+    const stopPolling = jest.fn();
+
+    (jest.spyOn(apollo, "useQuery") as jest.Mock).mockReturnValueOnce({
+      error,
+      stopPolling,
+    });
+
+    render(<Subject mocks={[mock]} />);
+    expect(screen.queryByTestId("apollo-error-alert")).toBeInTheDocument();
   });
 
   it("renders not found if an experiment isn't found", async () => {

--- a/app/experimenter/nimbus-ui/src/components/AppLayoutWithExperiment/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/AppLayoutWithExperiment/index.tsx
@@ -9,6 +9,7 @@ import { BASE_PATH } from "../../lib/constants";
 import { getStatus, StatusCheck } from "../../lib/experiment";
 import { AnalysisData } from "../../lib/visualization/types";
 import { getExperiment_experimentBySlug } from "../../types/getExperiment";
+import ApolloErrorAlert from "../ApolloErrorAlert";
 import AppLayoutSidebarLaunched from "../AppLayoutSidebarLaunched";
 import AppLayoutWithSidebar from "../AppLayoutWithSidebar";
 import Head from "../Head";
@@ -62,8 +63,16 @@ const AppLayoutWithExperiment = ({
   redirect,
 }: AppLayoutWithExperimentProps) => {
   const { slug } = useParams();
-  const { experiment, notFound, loading, startPolling, stopPolling, refetch } =
-    useExperiment(slug);
+  const {
+    experiment,
+    notFound,
+    loading,
+    startPolling,
+    stopPolling,
+    refetch,
+    error,
+  } = useExperiment(slug);
+
   const {
     execute: fetchAnalysis,
     result: analysis,
@@ -110,6 +119,10 @@ const AppLayoutWithExperiment = ({
       stopPolling();
     };
   }, [startPolling, stopPolling, experiment, polling]);
+
+  if (error) {
+    return <ApolloErrorAlert {...{ error }} />;
+  }
 
   // If the analysis is required for the sidebar and page, show the loader
   // until experiment data and analysis data have finished fetching

--- a/app/experimenter/nimbus-ui/src/components/PageHome/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageHome/index.test.tsx
@@ -33,7 +33,7 @@ describe("PageHome", () => {
     await renderAndWaitForLoaded([]);
     expect(screen.queryByText("No experiments found.")).toBeInTheDocument();
   });
-  it("displays an error message when there is one", async () => {
+  it("renders the error alert when an error occurs", () => {
     const error = new Error("You done it now!");
 
     (jest.spyOn(apollo, "useQuery") as jest.Mock).mockReturnValueOnce({
@@ -41,8 +41,7 @@ describe("PageHome", () => {
     });
 
     render(<Subject />);
-
-    await screen.findByText(error.message, { exact: false });
+    expect(screen.queryByTestId("apollo-error-alert")).toBeInTheDocument();
   });
   it("displays five Directory Tables (one for each status type)", async () => {
     await renderAndWaitForLoaded();

--- a/app/experimenter/nimbus-ui/src/components/PageHome/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageHome/index.tsx
@@ -8,6 +8,7 @@ import React from "react";
 import { Alert, Tab, Tabs } from "react-bootstrap";
 import { GET_EXPERIMENTS_QUERY } from "../../gql/experiments";
 import { getAllExperiments_experiments } from "../../types/getAllExperiments";
+import ApolloErrorAlert from "../ApolloErrorAlert";
 import AppLayout from "../AppLayout";
 import Head from "../Head";
 import LinkExternal from "../LinkExternal";
@@ -31,11 +32,7 @@ export const Body = () => {
   }
 
   if (error) {
-    return (
-      <Alert variant="warning">
-        An error occurred while looking up experiments: {error.message}
-      </Alert>
-    );
+    return <ApolloErrorAlert {...{ error }} />;
   }
 
   if (!data) {

--- a/app/experimenter/nimbus-ui/src/components/PageSummary/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageSummary/index.test.tsx
@@ -220,7 +220,7 @@ describe("PageSummary", () => {
       NimbusExperimentPublishStatus.APPROVED,
       CHANGELOG_MESSAGES.REVIEW_APPROVED,
     );
-    render(<Subject mocks={[mock, mutationMock]} />);
+    render(<Subject mocks={[mock, mock, mutationMock]} />);
     const approveButton = await screen.findByTestId("approve-request");
     expect(approveButton).toHaveTextContent("Approve and Launch Experiment");
     fireEvent.click(approveButton);

--- a/app/experimenter/nimbus-ui/src/hooks/useExperiment.tsx
+++ b/app/experimenter/nimbus-ui/src/hooks/useExperiment.tsx
@@ -29,16 +29,18 @@ import { getExperiment } from "../types/getExperiment";
  */
 
 export function useExperiment(slug: string) {
-  const { data, loading, startPolling, stopPolling, refetch } = useQuery<{
-    experimentBySlug: getExperiment["experimentBySlug"];
-  }>(GET_EXPERIMENT_QUERY, {
-    variables: { slug },
-    fetchPolicy: "network-only",
-  });
+  const { data, loading, startPolling, stopPolling, refetch, error } =
+    useQuery<{
+      experimentBySlug: getExperiment["experimentBySlug"];
+    }>(GET_EXPERIMENT_QUERY, {
+      variables: { slug },
+      fetchPolicy: "network-only",
+    });
 
   const experiment = data?.experimentBySlug;
 
   return {
+    error,
     experiment: experiment!,
     notFound: !loading && experiment === null,
     loading,


### PR DESCRIPTION
fixes #5765 

Because:
* We want to display more detailed error messaging where an error would break the app for handiness across envs

This commit:
* Adds a new ApolloErrorAlert component to parse through various ApolloErrors and display helpful output, displays this if an error occured when querying an experiment in PageHome and AppLayoutWithExperiment, as well as if the config query errors
* Adjusts AppErrorBoundary to display an error.message if there is one

---

This was slightly trickier than expected. I wanted to create a more universal handler so we wouldn't need to `return <ApolloErrorAlert ...` every time, but:
* using an ApolloError version [ErrorBoundary](https://reactjs.org/docs/error-boundaries.html) would be awkward since you have to rethrow the error for it to catch (plus it seems one `ErrorBoundary` is typical per the docs)
* we wouldn't want to do all this error message parsing in the `AppErrorBoundary` since any error within that render would be uncaught
* using [`link`](https://www.apollographql.com/docs/react/api/link/introduction/) for our errors is hit per GQL mutation and doesn’t appear to be a way to access that anyway inside components (see [this related issue](https://github.com/apollographql/apollo-link/issues/1022))

Added Storybook states to account for the various kinds of `ApolloError`. ~Also, might change the name to `ApolloErrorAlert`. 🤔~ Updated to `ApolloErrorAlert.

👉 [Storybook link](https://storage.googleapis.com/mozilla-storybooks-experimenter/commits/82490fdc534d01381fc269672add106e4ff4d154/nimbus-ui/index.html?path=/story/components-apolloerroralert--with-error)