### PR TITLE
fixes #5760 feat(nimbus): Show relative comparison for Results tables, add comparison toggle

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableResults/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableResults/index.stories.tsx
@@ -8,6 +8,7 @@ import React from "react";
 import TableResults from ".";
 import { mockExperimentQuery } from "../../../lib/mocks";
 import { RouterSlugProvider } from "../../../lib/test-utils";
+import { BRANCH_COMPARISON } from "../../../lib/visualization/constants";
 import { mockAnalysis } from "../../../lib/visualization/mocks";
 import { getSortedBranches } from "../../../lib/visualization/utils";
 
@@ -16,7 +17,7 @@ const sortedBranches = getSortedBranches(results);
 
 storiesOf("pages/Results/TableResults", module)
   .addDecorator(withLinks)
-  .add("basic, with one primary outcome", () => {
+  .add("relative uplift comparison, with one primary outcome", () => {
     const { mock, experiment } = mockExperimentQuery("demo-slug");
     return (
       <RouterSlugProvider mocks={[mock]}>
@@ -24,13 +25,37 @@ storiesOf("pages/Results/TableResults", module)
       </RouterSlugProvider>
     );
   })
-  .add("with multiple primary outcomes", () => {
+  .add("relative uplift comparison, with multiple primary outcomes", () => {
     const { mock, experiment } = mockExperimentQuery("demo-slug", {
       primaryOutcomes: ["picture_in_picture", "feature_b", "feature_c"],
     });
     return (
       <RouterSlugProvider mocks={[mock]}>
         <TableResults {...{ experiment, results, sortedBranches }} />
+      </RouterSlugProvider>
+    );
+  })
+  .add("absolute uplift comparison, with one primary outcome", () => {
+    const { mock, experiment } = mockExperimentQuery("demo-slug");
+    return (
+      <RouterSlugProvider mocks={[mock]}>
+        <TableResults
+          branchComparison={BRANCH_COMPARISON.ABSOLUTE}
+          {...{ experiment, results, sortedBranches }}
+        />
+      </RouterSlugProvider>
+    );
+  })
+  .add("absolute uplift comparison, with multiple primary outcomes", () => {
+    const { mock, experiment } = mockExperimentQuery("demo-slug", {
+      primaryOutcomes: ["picture_in_picture", "feature_b", "feature_c"],
+    });
+    return (
+      <RouterSlugProvider mocks={[mock]}>
+        <TableResults
+          branchComparison={BRANCH_COMPARISON.ABSOLUTE}
+          {...{ experiment, results, sortedBranches }}
+        />
       </RouterSlugProvider>
     );
   });

--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableResults/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableResults/index.test.tsx
@@ -7,6 +7,7 @@ import React from "react";
 import TableResults from ".";
 import { mockExperimentQuery } from "../../../lib/mocks";
 import { RouterSlugProvider } from "../../../lib/test-utils";
+import { BRANCH_COMPARISON } from "../../../lib/visualization/constants";
 import {
   mockAnalysis,
   mockIncompleteAnalysis,
@@ -36,16 +37,41 @@ describe("TableResults", () => {
     });
   });
 
-  it("renders the expected variant and user count", () => {
+  it("with relative comparison, renders the expected variant, comparison, and user count", () => {
     render(
       <RouterSlugProvider mocks={[mock]}>
         <TableResults {...{ experiment, results, sortedBranches }} />
       </RouterSlugProvider>,
     );
 
+    expect(screen.getAllByText("-45.5% to 51%", { exact: false })).toHaveLength(
+      2,
+    );
+    expect(screen.getByText("198")).toBeInTheDocument();
+    expect(screen.getByText("45%")).toBeInTheDocument();
+    expect(screen.getByText("200")).toBeInTheDocument();
+    expect(screen.getByText("55%")).toBeInTheDocument();
     expect(screen.getByText("control")).toBeInTheDocument();
     expect(screen.getByText("treatment")).toBeInTheDocument();
+  });
+
+  it("with absolute comparison, renders the expected variant, comparison, and user count", async () => {
+    render(
+      <RouterSlugProvider mocks={[mock]}>
+        <TableResults
+          branchComparison={BRANCH_COMPARISON.ABSOLUTE}
+          {...{ experiment, results, sortedBranches }}
+        />
+      </RouterSlugProvider>,
+    );
+    expect(screen.getByText("88.6%", { exact: false })).toBeInTheDocument();
     expect(screen.getByText("198")).toBeInTheDocument();
+    expect(screen.getByText("200")).toBeInTheDocument();
+    expect(
+      screen.getByText("2.4% to 8.4% (baseline)", { exact: false }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("control")).toBeInTheDocument();
+    expect(screen.getByText("treatment")).toBeInTheDocument();
   });
 
   it("renders correctly labelled result significance", () => {
@@ -54,7 +80,6 @@ describe("TableResults", () => {
         <TableResults {...{ experiment, results, sortedBranches }} />
       </RouterSlugProvider>,
     );
-
     expect(screen.getByTestId("positive-significance")).toBeInTheDocument();
     expect(screen.getByTestId("negative-significance")).toBeInTheDocument();
     expect(screen.queryAllByTestId("neutral-significance")).toHaveLength(2);

--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableResults/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableResults/index.tsx
@@ -6,13 +6,17 @@ import React from "react";
 import { useOutcomes } from "../../../hooks";
 import { OutcomesList } from "../../../lib/types";
 import {
+  BRANCH_COMPARISON,
   GROUP,
   METRICS_TIPS,
   METRIC_TYPE,
   RESULTS_METRICS_LIST,
   TABLE_LABEL,
 } from "../../../lib/visualization/constants";
-import { AnalysisData } from "../../../lib/visualization/types";
+import {
+  AnalysisData,
+  BranchComparisonValues,
+} from "../../../lib/visualization/types";
 import { getTableDisplayType } from "../../../lib/visualization/utils";
 import { getExperiment_experimentBySlug } from "../../../types/getExperiment";
 import TableVisualizationRow from "../TableVisualizationRow";
@@ -22,6 +26,7 @@ type TableResultsProps = {
   experiment: getExperiment_experimentBySlug;
   results: AnalysisData;
   sortedBranches: string[];
+  branchComparison?: BranchComparisonValues;
 };
 
 const getResultMetrics = (outcomes: OutcomesList) => {
@@ -53,6 +58,7 @@ const TableResults = ({
     show_analysis: false,
   },
   sortedBranches,
+  branchComparison = BRANCH_COMPARISON.UPLIFT,
 }: TableResultsProps) => {
   const { primaryOutcomes } = useOutcomes(experiment);
   const resultsMetricsList = getResultMetrics(primaryOutcomes);
@@ -113,8 +119,7 @@ const TableResults = ({
                     results={overallResults[branch]}
                     group={metric.group}
                     tableLabel={TABLE_LABEL.RESULTS}
-                    {...{ metricKey }}
-                    {...{ displayType }}
+                    {...{ metricKey, displayType, branchComparison }}
                   />
                 );
               })}

--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableResultsWeekly/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableResultsWeekly/index.stories.tsx
@@ -6,7 +6,10 @@ import { withLinks } from "@storybook/addon-links";
 import { storiesOf } from "@storybook/react";
 import React from "react";
 import TableResultsWeekly from ".";
-import { HIGHLIGHTS_METRICS_LIST } from "../../../lib/visualization/constants";
+import {
+  BRANCH_COMPARISON,
+  HIGHLIGHTS_METRICS_LIST,
+} from "../../../lib/visualization/constants";
 import { weeklyMockAnalysis } from "../../../lib/visualization/mocks";
 import { getSortedBranches } from "../../../lib/visualization/utils";
 
@@ -20,12 +23,22 @@ const sortedBranches = getSortedBranches({
 
 storiesOf("pages/Results/TableResultsWeekly", module)
   .addDecorator(withLinks)
-  .add("basic", () => {
+  .add("with relative uplift comparison", () => {
     return (
       <TableResultsWeekly
         {...{ weeklyResults, sortedBranches }}
         hasOverallResults
         metricsList={HIGHLIGHTS_METRICS_LIST}
+      />
+    );
+  })
+  .add("with absolute comparison", () => {
+    return (
+      <TableResultsWeekly
+        {...{ weeklyResults, sortedBranches }}
+        hasOverallResults
+        metricsList={HIGHLIGHTS_METRICS_LIST}
+        branchComparison={BRANCH_COMPARISON.ABSOLUTE}
       />
     );
   });

--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableResultsWeekly/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableResultsWeekly/index.test.tsx
@@ -5,8 +5,10 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import React from "react";
 import TableResultsWeekly from ".";
-import { RouterSlugProvider } from "../../../lib/test-utils";
-import { HIGHLIGHTS_METRICS_LIST } from "../../../lib/visualization/constants";
+import {
+  BRANCH_COMPARISON,
+  HIGHLIGHTS_METRICS_LIST,
+} from "../../../lib/visualization/constants";
 import { weeklyMockAnalysis } from "../../../lib/visualization/mocks";
 import { getSortedBranches } from "../../../lib/visualization/utils";
 
@@ -19,22 +21,47 @@ const sortedBranches = getSortedBranches({
 });
 
 describe("TableResultsWeekly", () => {
-  it("has the correct headings", () => {
-    const EXPECTED_HEADINGS = ["Retention", "Search", "Days of Use"];
-
+  it("renders as expected with relative uplift branch comparison (default)", () => {
     render(
-      <RouterSlugProvider>
-        <TableResultsWeekly
-          hasOverallResults
-          metricsList={HIGHLIGHTS_METRICS_LIST}
-          {...{ weeklyResults, sortedBranches }}
-        />
-      </RouterSlugProvider>,
+      <TableResultsWeekly
+        hasOverallResults
+        metricsList={HIGHLIGHTS_METRICS_LIST}
+        {...{ weeklyResults, sortedBranches }}
+      />,
     );
+
+    const EXPECTED_HEADINGS = ["Retention", "Search", "Days of Use"];
+    const EXPECTED_WEEKS = ["Week 1", "Week 2"];
 
     EXPECTED_HEADINGS.forEach((heading) => {
       expect(screen.getByText(heading)).toBeInTheDocument();
     });
+    EXPECTED_WEEKS.forEach((week) => {
+      expect(screen.getAllByText(week)).toHaveLength(EXPECTED_HEADINGS.length);
+    });
+
+    // control branches have this text for every week
+    expect(screen.getAllByText("(baseline)")).toHaveLength(
+      EXPECTED_HEADINGS.length * EXPECTED_WEEKS.length,
+    );
+    expect(screen.getAllByText("-45.5% to 51%", { exact: false })).toHaveLength(
+      2,
+    );
+  });
+
+  it("renders as expected with absolute branch comparison", () => {
+    render(
+      <TableResultsWeekly
+        hasOverallResults
+        metricsList={HIGHLIGHTS_METRICS_LIST}
+        branchComparison={BRANCH_COMPARISON.ABSOLUTE}
+        {...{ weeklyResults, sortedBranches }}
+      />,
+    );
+
+    expect(
+      screen.getAllByText("2.4% to 8.4% (baseline)", { exact: false }),
+    ).toHaveLength(2);
   });
 
   it("behaves as expected when clicked", () => {
@@ -42,13 +69,11 @@ describe("TableResultsWeekly", () => {
     const SHOW_TEXT = "Show Weekly Data";
 
     render(
-      <RouterSlugProvider>
-        <TableResultsWeekly
-          hasOverallResults={false}
-          metricsList={HIGHLIGHTS_METRICS_LIST}
-          {...{ weeklyResults, sortedBranches }}
-        />
-      </RouterSlugProvider>,
+      <TableResultsWeekly
+        hasOverallResults={false}
+        metricsList={HIGHLIGHTS_METRICS_LIST}
+        {...{ weeklyResults, sortedBranches }}
+      />,
     );
 
     expect(screen.getByText(HIDE_TEXT)).toBeInTheDocument();

--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableResultsWeekly/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableResultsWeekly/index.tsx
@@ -5,8 +5,14 @@ import React, { useState } from "react";
 import Collapse from "react-bootstrap/Collapse";
 import { ReactComponent as CollapseMinus } from "../../../images/minus.svg";
 import { ReactComponent as ExpandPlus } from "../../../images/plus.svg";
-import { GENERAL_TIPS } from "../../../lib/visualization/constants";
-import { AnalysisDataWeekly } from "../../../lib/visualization/types";
+import {
+  BRANCH_COMPARISON,
+  GENERAL_TIPS,
+} from "../../../lib/visualization/constants";
+import {
+  AnalysisDataWeekly,
+  BranchComparisonValues,
+} from "../../../lib/visualization/types";
 import TableWeekly from "../TableWeekly";
 
 type TableResultsWeeklyProps = {
@@ -19,6 +25,7 @@ type TableResultsWeeklyProps = {
     group: string;
   }[];
   sortedBranches: string[];
+  branchComparison?: BranchComparisonValues;
 };
 
 const TableResultsWeekly = ({
@@ -26,6 +33,7 @@ const TableResultsWeekly = ({
   hasOverallResults = false,
   metricsList,
   sortedBranches,
+  branchComparison = BRANCH_COMPARISON.UPLIFT,
 }: TableResultsWeeklyProps) => {
   const [open, setOpen] = useState(!hasOverallResults);
 
@@ -63,9 +71,9 @@ const TableResultsWeekly = ({
                 <TableWeekly
                   metricKey={metric.value}
                   metricName={metric.name}
-                  metricGroup={metric.group}
+                  group={metric.group}
                   results={weeklyResults}
-                  {...{ sortedBranches }}
+                  {...{ sortedBranches, branchComparison }}
                 />
               </div>
             );

--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableVisualizationRow/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableVisualizationRow/index.tsx
@@ -24,10 +24,6 @@ import { ReactComponent as SignificancePositive } from "./significance-positive.
 // This is a mapping for which view on the analysis
 // to display given the branch and table type.
 const dataTypeMapping = {
-  [TABLE_LABEL.RESULTS]: {
-    [VARIANT_TYPE.CONTROL]: BRANCH_COMPARISON.ABSOLUTE,
-    [VARIANT_TYPE.VARIANT]: BRANCH_COMPARISON.ABSOLUTE,
-  },
   [TABLE_LABEL.HIGHLIGHTS]: {
     [VARIANT_TYPE.CONTROL]: BRANCH_COMPARISON.ABSOLUTE,
     [VARIANT_TYPE.VARIANT]: BRANCH_COMPARISON.UPLIFT,
@@ -238,55 +234,66 @@ const TableVisualizationRow: React.FC<{
     userCountsList.sort(formattedAnalysisPointComparator);
     metricDataList.sort(formattedAnalysisPointComparator);
 
-    metricDataList.forEach((dataPoint: FormattedAnalysisPoint, i: number) => {
-      const { lower, upper, point, count } = dataPoint;
-      const userCountMetric = userCountsList[i]["point"];
-      const significance = metricData["significance"]?.[window][i + 1];
+    if (metricDataList.length > 0) {
+      metricDataList.forEach((dataPoint: FormattedAnalysisPoint, i: number) => {
+        const { lower, upper, point, count } = dataPoint;
+        const userCountMetric = userCountsList[i]["point"];
+        const significance = metricData["significance"]?.[window][i + 1];
 
-      switch (displayType) {
-        case DISPLAY_TYPE.POPULATION:
-          field = populationField(point!, percent);
-          break;
-        case DISPLAY_TYPE.COUNT:
-          field = countField(
-            lower!,
-            upper!,
-            significance,
-            metricName,
-            tableLabel,
-            tooltipText,
-            is_control,
-          );
-          break;
-        case DISPLAY_TYPE.PERCENT:
-        case DISPLAY_TYPE.CONVERSION_RATE:
-          field = percentField(
-            lower!,
-            upper!,
-            significance,
-            metricName,
-            tableLabel,
-            tooltipText,
-            is_control,
-          );
-          break;
-        case DISPLAY_TYPE.CONVERSION_COUNT:
-          field = conversionCountField(count!, userCountMetric);
-          break;
-        case DISPLAY_TYPE.CONVERSION_CHANGE:
-          field = conversionChangeField(lower!, upper!, bounds, significance);
-          break;
-      }
-      fieldList.push({ field, tooltipText, className });
-    });
+        switch (displayType) {
+          case DISPLAY_TYPE.POPULATION:
+            field = populationField(point!, percent);
+            break;
+          case DISPLAY_TYPE.COUNT:
+            field = countField(
+              lower!,
+              upper!,
+              significance,
+              metricName,
+              tableLabel,
+              tooltipText,
+              is_control,
+            );
+            break;
+          case DISPLAY_TYPE.PERCENT:
+          case DISPLAY_TYPE.CONVERSION_RATE:
+            field = percentField(
+              lower!,
+              upper!,
+              significance,
+              metricName,
+              tableLabel,
+              tooltipText,
+              is_control,
+            );
+            break;
+          case DISPLAY_TYPE.CONVERSION_COUNT:
+            field = conversionCountField(count!, userCountMetric!);
+            break;
+          case DISPLAY_TYPE.CONVERSION_CHANGE:
+            field = conversionChangeField(lower!, upper!, bounds, significance);
+            break;
+        }
+        fieldList.push({ field, tooltipText, className });
+      });
+      // Total number of users is present in the absolute branch comparison data. This displays
+      // that number on the results table even if comparison is to the relative uplift.
+    } else if (
+      tableLabel == TABLE_LABEL.RESULTS &&
+      branchComparison === BRANCH_COMPARISON.UPLIFT &&
+      displayType === DISPLAY_TYPE.POPULATION
+    ) {
+      const { point } = userCountsList[0];
+      field = populationField(point!, percent);
+    }
   }
   /**
-   * If fieldList is still empty then we either had no metric
-   * data at all, or no metric data for the specific branchComparison requested.
+   * If fieldList is still empty then we either had no metric data at all, or no
+   * metric data for the specific branchComparison requested.
    *
    * The former happens when there is not enough data for retention, for example.
-   * The latter happens when we try to look at uplift for control and this should
-   * fall back to "baseline".
+   * The latter happens when we try to look at relative uplift for control and this
+   * should fall back to "baseline".
    *
    * In either case, we need to push the current values below to be displayed.
    **/

--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableWeekly/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableWeekly/index.test.tsx
@@ -6,7 +6,7 @@ import { render, screen } from "@testing-library/react";
 import React from "react";
 import TableWeekly from ".";
 import { RouterSlugProvider } from "../../../lib/test-utils";
-import { GROUP } from "../../../lib/visualization/constants";
+import { BRANCH_COMPARISON, GROUP } from "../../../lib/visualization/constants";
 import {
   weeklyMockAnalysis,
   WEEKLY_IDENTITY,
@@ -48,7 +48,7 @@ describe("TableWeekly", () => {
         <TableWeekly
           metricKey="retained"
           metricName="Retention"
-          metricGroup={GROUP.OTHER}
+          group={GROUP.OTHER}
           {...{ results, sortedBranches }}
         />
       </RouterSlugProvider>,
@@ -74,7 +74,8 @@ describe("TableWeekly", () => {
         <TableWeekly
           metricKey="fake"
           metricName="Some Made Up Metric"
-          metricGroup={GROUP.OTHER}
+          branchComparison={BRANCH_COMPARISON.ABSOLUTE}
+          group={GROUP.OTHER}
           {...{ results, sortedBranches }}
         />
       </RouterSlugProvider>,

--- a/app/experimenter/nimbus-ui/src/components/PageResults/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/index.test.tsx
@@ -118,6 +118,26 @@ it("displays grouped metrics via onClick", async () => {
   expect(screen.getByText("Show other metrics")).toBeInTheDocument();
 });
 
+it("toggles between absolute and relative branch comparisons", async () => {
+  mockExperiment = mockExperimentQuery("demo-slug").experiment;
+  render(<Subject />);
+
+  expect(screen.getAllByText("-0.46 to 0.51", { exact: false })).toHaveLength(
+    6,
+  );
+  expect(screen.queryByText("88.6%", { exact: false })).not.toBeInTheDocument();
+
+  fireEvent.click(screen.getByText("See absolute comparison"));
+  await screen.findByText("88.6%", { exact: false });
+  expect(
+    screen.queryByText("-0.46 to 0.51", { exact: false }),
+  ).not.toBeInTheDocument();
+
+  fireEvent.click(screen.getByText("See relative comparison"));
+  await screen.findAllByText("-0.46 to 0.51", { exact: false });
+  expect(screen.queryByText("88.6%", { exact: false })).not.toBeInTheDocument();
+});
+
 // Mocking form component because validation is exercised in its own tests.
 jest.mock("../AppLayoutWithExperiment", () => ({
   __esModule: true,

--- a/app/experimenter/nimbus-ui/src/components/PageResults/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/index.tsx
@@ -9,10 +9,12 @@ import { useConfig } from "../../hooks";
 import { ReactComponent as CollapseMinus } from "../../images/minus.svg";
 import { ReactComponent as ExpandPlus } from "../../images/plus.svg";
 import {
+  BRANCH_COMPARISON,
   GROUP,
   HIGHLIGHTS_METRICS_LIST,
   METRIC_TYPE,
 } from "../../lib/visualization/constants";
+import { BranchComparisonValues } from "../../lib/visualization/types";
 import {
   analysisUnavailable,
   getSortedBranches,
@@ -33,6 +35,23 @@ const PageResults: React.FunctionComponent<RouteComponentProps> = () => {
     search_metrics: useState(true),
     other_metrics: useState(true),
   };
+
+  // show relative comparison by default
+  // TODO: expand this functionality to other tables, EXP-1551
+  const [branchComparison, setBranchComparison] =
+    useState<BranchComparisonValues>(BRANCH_COMPARISON.UPLIFT);
+  const branchComparisonIsRelative =
+    branchComparison === BRANCH_COMPARISON.UPLIFT;
+  const toggleBranchComparison = () => {
+    if (branchComparisonIsRelative) {
+      setBranchComparison(BRANCH_COMPARISON.ABSOLUTE);
+    } else {
+      setBranchComparison(BRANCH_COMPARISON.UPLIFT);
+    }
+  };
+  const toggleBranchComparisonText = branchComparisonIsRelative
+    ? "absolute"
+    : "relative";
 
   return (
     <AppLayoutWithExperiment
@@ -85,10 +104,19 @@ const PageResults: React.FunctionComponent<RouteComponentProps> = () => {
             <TableHighlightsOverview {...{ experiment }} />
 
             <div id="results_summary">
-              <h2 className="h5 mb-3">Results Summary</h2>
+              <div className="d-flex justify-content-between mb-3">
+                <h2 className="h5">Results Summary</h2>
+                <button
+                  data-testid="toggle-branch-comparison"
+                  className="btn btn-secondary"
+                  onClick={toggleBranchComparison}
+                >
+                  <small>See {toggleBranchComparisonText} comparison </small>
+                </button>
+              </div>
               {analysis?.overall && (
                 <TableResults
-                  {...{ experiment, sortedBranches }}
+                  {...{ experiment, sortedBranches, branchComparison }}
                   results={analysis!}
                 />
               )}
@@ -98,7 +126,7 @@ const PageResults: React.FunctionComponent<RouteComponentProps> = () => {
                   weeklyResults={analysis.weekly}
                   hasOverallResults={!!analysis?.overall}
                   metricsList={HIGHLIGHTS_METRICS_LIST}
-                  {...{ sortedBranches }}
+                  {...{ sortedBranches, branchComparison }}
                 />
               )}
             </div>

--- a/app/experimenter/nimbus-ui/src/lib/visualization/constants.ts
+++ b/app/experimenter/nimbus-ui/src/lib/visualization/constants.ts
@@ -92,7 +92,7 @@ export const BRANCH_COMPARISON = {
   ABSOLUTE: "absolute",
   DIFFERENCE: "difference",
   UPLIFT: "relative_uplift",
-};
+} as const;
 
 export const BRANCH_COMPARISON_TITLE = {
   ABSOLUTE: "Absolute",

--- a/app/experimenter/nimbus-ui/src/lib/visualization/types.ts
+++ b/app/experimenter/nimbus-ui/src/lib/visualization/types.ts
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import { BRANCH_COMPARISON } from "./constants";
+
 export interface AnalysisData {
   daily: AnalysisPoint[] | null;
   weekly: { [branch: string]: BranchDescription } | null;
@@ -71,3 +73,7 @@ export interface BranchDescription {
     };
   };
 }
+
+type BranchComparison = typeof BRANCH_COMPARISON;
+type BranchComparisons = keyof BranchComparison;
+export type BranchComparisonValues = BranchComparison[BranchComparisons];


### PR DESCRIPTION
fixes #5760

Because:
* User feedback informed us that relative values are more useful for our users in this section

This commit:
* Shows relative uplift branch comparison values by default in TableResults and weekly results tables
* Shows user count in TableResults even when showing relative comparison
* Allows users to toggle between the comparison types via a button in PageResults
* Improves test coverage

===

7/28 comment: Marina's comment below should be addressed.

Storybook links of interest:
* https://storage.googleapis.com/mozilla-storybooks-experimenter/commits/2eac11e65bbbeae5c9040de41dc71f65eed4a51b/nimbus-ui/index.html?path=/story/pages-results--basic (note that the toggling occurs here, since in #6071, we'll toggle the values for the other tables as well)
* https://storage.googleapis.com/mozilla-storybooks-experimenter/commits/2eac11e65bbbeae5c9040de41dc71f65eed4a51b/nimbus-ui/index.html?path=/story/pages-results-tableresults--relative-uplift-comparison-with-one-primary-outcome + https://storage.googleapis.com/mozilla-storybooks-experimenter/commits/2eac11e65bbbeae5c9040de41dc71f65eed4a51b/nimbus-ui/index.html?path=/story/pages-results-tableresults--absolute-uplift-comparison-with-one-primary-outcome
* https://storage.googleapis.com/mozilla-storybooks-experimenter/commits/2eac11e65bbbeae5c9040de41dc71f65eed4a51b/nimbus-ui/index.html?path=/story/pages-results-tableresultsweekly--with-relative-uplift-comparison + https://storage.googleapis.com/mozilla-storybooks-experimenter/commits/2eac11e65bbbeae5c9040de41dc71f65eed4a51b/nimbus-ui/index.html?path=/story/pages-results-tableresultsweekly--with-absolute-comparison