### PR TITLE
fix #5696 feat(nimbus): add locale and country to targeting

### DIFF
--- a/app/experimenter/experiments/models/nimbus.py
+++ b/app/experimenter/experiments/models/nimbus.py
@@ -216,6 +216,16 @@ class NimbusExperiment(NimbusConstants, FilterMixin, models.Model):
         if self.targeting_config and self.targeting_config.targeting:
             expressions.append(self.targeting_config.targeting)
 
+        if self.locales.count():
+            locales = [locale.code for locale in self.locales.all().order_by("code")]
+            expressions.append(f"locale in {locales}")
+
+        if self.countries.count():
+            countries = [
+                country.code for country in self.countries.all().order_by("code")
+            ]
+            expressions.append(f"region in {countries}")
+
         #  If there is no targeting defined all clients should match, so we return "true"
         if len(expressions) == 0:
             return "true"


### PR DESCRIPTION
Because

* We now have explicit fields for locale and country

This commit

* Adds locale and country to the targeting expression