### PR TITLE
fixes #5716 feat(nimbus): add UI for setting locale and country

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/index.stories.tsx
@@ -16,6 +16,8 @@ storiesOf("pages/EditAudience/FormAudience", module)
         "*": ["Big bad server thing happened"],
         channel: ["Cannot tune in this channel"],
         firefox_min_version: ["Bad min version"],
+        countries: ["This place doesn't even exist"],
+        locales: ["We don't have that locale"],
         targeting_config_slug: ["This slug is icky"],
         population_percent: ["This is not a percentage"],
         total_enrolled_clients: ["Need a number here, bud."],

--- a/app/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/index.tsx
@@ -2,11 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React, { useMemo } from "react";
+import React, { useMemo, useState } from "react";
 import Alert from "react-bootstrap/Alert";
 import Col from "react-bootstrap/Col";
 import Form from "react-bootstrap/Form";
 import InputGroup from "react-bootstrap/InputGroup";
+import Select from "react-select";
 import ReactTooltip from "react-tooltip";
 import { useCommonForm, useConfig, useReviewCheck } from "../../../hooks";
 import { ReactComponent as Info } from "../../../images/info.svg";
@@ -33,6 +34,10 @@ type FormAudienceProps = {
 };
 
 type AudienceFieldName = typeof audienceFieldNames[number];
+type SelectCodeItems = {
+  code: string;
+  name: string;
+}[];
 
 export const audienceFieldNames = [
   "channel",
@@ -42,7 +47,15 @@ export const audienceFieldNames = [
   "totalEnrolledClients",
   "proposedEnrollment",
   "proposedDuration",
+  "countries",
+  "locales",
 ] as const;
+
+const selectOptions = (items: SelectCodeItems) =>
+  items.map((item) => ({
+    label: item.name!,
+    value: item.code!,
+  }));
 
 export const FormAudience = ({
   experiment,
@@ -55,6 +68,13 @@ export const FormAudience = ({
   const config = useConfig();
   const { fieldMessages } = useReviewCheck(experiment);
 
+  const [locales, setLocales] = useState<string[]>(
+    experiment!.locales.map((v) => v.code!),
+  );
+  const [countries, setCountries] = useState<string[]>(
+    experiment!.countries.map((v) => v.code!),
+  );
+
   const defaultValues = {
     channel: experiment.channel,
     firefoxMinVersion: experiment.firefoxMinVersion,
@@ -63,16 +83,24 @@ export const FormAudience = ({
     totalEnrolledClients: experiment.totalEnrolledClients,
     proposedEnrollment: experiment.proposedEnrollment,
     proposedDuration: experiment.proposedDuration,
+    countries: selectOptions(experiment.countries as SelectCodeItems),
+    locales: selectOptions(experiment.locales as SelectCodeItems),
   };
 
-  const { FormErrors, formControlAttrs, isValid, handleSubmit, isSubmitted } =
-    useCommonForm<AudienceFieldName>(
-      defaultValues,
-      isServerValid,
-      submitErrors,
-      setSubmitErrors,
-      fieldMessages,
-    );
+  const {
+    FormErrors,
+    formControlAttrs,
+    formSelectAttrs,
+    isValid,
+    handleSubmit,
+    isSubmitted,
+  } = useCommonForm<AudienceFieldName>(
+    defaultValues,
+    isServerValid,
+    submitErrors,
+    setSubmitErrors,
+    fieldMessages,
+  );
 
   type DefaultValues = typeof defaultValues;
   const [handleSave, handleSaveNext] = useMemo(
@@ -129,6 +157,36 @@ export const FormAudience = ({
               <SelectOptions options={config.firefoxMinVersion} />
             </Form.Control>
             <FormErrors name="firefoxMinVersion" />
+          </Form.Group>
+        </Form.Row>
+        <Form.Row>
+          <Form.Group as={Col} controlId="locales" data-testid="locales">
+            <Form.Label>Locales</Form.Label>
+            <Select
+              placeholder="All Locales"
+              isMulti
+              {...formSelectAttrs("locales", setLocales)}
+              options={selectOptions(config.locales as SelectCodeItems)}
+            />
+            <Form.Text className="text-muted">
+              In development - this field does not save selections yet.
+            </Form.Text>
+            <FormErrors name="locales" />
+          </Form.Group>
+        </Form.Row>
+        <Form.Row>
+          <Form.Group as={Col} controlId="countries" data-testid="countries">
+            <Form.Label>Countries</Form.Label>
+            <Select
+              placeholder="All Countries"
+              isMulti
+              {...formSelectAttrs("countries", setCountries)}
+              options={selectOptions(config.countries as SelectCodeItems)}
+            />
+            <Form.Text className="text-muted">
+              In development - this field does not save selections yet.
+            </Form.Text>
+            <FormErrors name="countries" />
           </Form.Group>
         </Form.Row>
         <Form.Row>

--- a/app/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/index.tsx
@@ -137,7 +137,7 @@ export const FormAudience = ({
 
       <Form.Group>
         <Form.Row>
-          <Form.Group as={Col} controlId="channel" md={8} lg={8}>
+          <Form.Group as={Col} controlId="channel">
             <Form.Label className="d-flex align-items-center">
               Channel
             </Form.Label>
@@ -173,8 +173,6 @@ export const FormAudience = ({
             </Form.Text>
             <FormErrors name="locales" />
           </Form.Group>
-        </Form.Row>
-        <Form.Row>
           <Form.Group as={Col} controlId="countries" data-testid="countries">
             <Form.Label>Countries</Form.Label>
             <Select

--- a/app/experimenter/nimbus-ui/src/components/PageEditAudience/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditAudience/index.stories.tsx
@@ -47,7 +47,8 @@ export const MissingFields = () =>
           "Well, I know a place",
           "Where we can dance the whole night away",
         ],
-        channel: ["Underneath the electric stars."],
+        countries: ["Just come with me"],
+        locales: ["We can shake it loose right away"],
       },
     },
   });

--- a/app/experimenter/nimbus-ui/src/gql/config.ts
+++ b/app/experimenter/nimbus-ui/src/gql/config.ts
@@ -45,6 +45,14 @@ export const GET_CONFIG_QUERY = gql`
         value
       }
       maxPrimaryOutcomes
+      locales {
+        code
+        name
+      }
+      countries {
+        code
+        name
+      }
     }
   }
 `;

--- a/app/experimenter/nimbus-ui/src/lib/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/lib/mocks.tsx
@@ -167,6 +167,34 @@ export const MOCK_CONFIG: getConfig_nimbusConfig = {
     },
   ],
   maxPrimaryOutcomes: 2,
+  locales: [
+    {
+      code: "ach",
+      name: "Acholi",
+    },
+    {
+      code: "af",
+      name: "Afrikaans",
+    },
+    {
+      code: "sq",
+      name: "Albanian",
+    },
+  ],
+  countries: [
+    {
+      code: "ER",
+      name: "Eritrea",
+    },
+    {
+      code: "EE",
+      name: "Estonia",
+    },
+    {
+      code: "SZ",
+      name: "Eswatini",
+    },
+  ],
 };
 
 // Disabling this rule for now because we'll eventually

--- a/app/experimenter/nimbus-ui/src/types/getConfig.ts
+++ b/app/experimenter/nimbus-ui/src/types/getConfig.ts
@@ -52,6 +52,16 @@ export interface getConfig_nimbusConfig_documentationLink {
   value: string | null;
 }
 
+export interface getConfig_nimbusConfig_locales {
+  code: string | null;
+  name: string | null;
+}
+
+export interface getConfig_nimbusConfig_countries {
+  code: string | null;
+  name: string | null;
+}
+
 export interface getConfig_nimbusConfig {
   application: (getConfig_nimbusConfig_application | null)[] | null;
   channel: (getConfig_nimbusConfig_channel | null)[] | null;
@@ -62,6 +72,8 @@ export interface getConfig_nimbusConfig {
   hypothesisDefault: string | null;
   documentationLink: (getConfig_nimbusConfig_documentationLink | null)[] | null;
   maxPrimaryOutcomes: number | null;
+  locales: (getConfig_nimbusConfig_locales | null)[] | null;
+  countries: (getConfig_nimbusConfig_countries | null)[] | null;
 }
 
 export interface getConfig {


### PR DESCRIPTION
Closes #5716

This PR adds the two fields for setting locales and countries on an experiment. It does not hook up the mutation yet.

Storybook [here](https://storage.googleapis.com/mozilla-storybooks-experimenter/commits/592a3c67f2e6f2581dcb54eaf06080a5aa553e67/nimbus-ui/index.html?path=/story/pages-editaudience-formaudience--basic)