### PR TITLE
fix #5955 feat(nimbus): display number of experiments on each directory tab

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/PageHome/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageHome/index.test.tsx
@@ -46,6 +46,11 @@ describe("PageHome", () => {
   it("displays five Directory Tables (one for each status type)", async () => {
     await renderAndWaitForLoaded();
     expect(screen.queryAllByTestId("DirectoryTable")).toHaveLength(5);
+    expect(screen.getByText("Live (3)")).toBeInTheDocument();
+    expect(screen.getByText("Review (1)")).toBeInTheDocument();
+    expect(screen.getByText("Preview (1)")).toBeInTheDocument();
+    expect(screen.getByText("Completed (4)")).toBeInTheDocument();
+    expect(screen.getByText("Draft (1)")).toBeInTheDocument();
   });
 });
 

--- a/app/experimenter/nimbus-ui/src/components/PageHome/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageHome/index.tsx
@@ -44,19 +44,19 @@ export const Body = () => {
   );
   return (
     <Tabs defaultActiveKey="live">
-      <Tab eventKey="live" title="Live">
+      <Tab eventKey="live" title={`Live (${live.length})`}>
         <DirectoryLiveTable experiments={live} />
       </Tab>
-      <Tab eventKey="review" title="Review">
+      <Tab eventKey="review" title={`Review (${review.length})`}>
         <DirectoryTable experiments={review} />
       </Tab>
-      <Tab eventKey="preview" title="Preview">
+      <Tab eventKey="preview" title={`Preview (${preview.length})`}>
         <DirectoryTable experiments={preview} />
       </Tab>
-      <Tab eventKey="completed" title="Completed">
+      <Tab eventKey="completed" title={`Completed (${complete.length})`}>
         <DirectoryCompleteTable experiments={complete} />
       </Tab>
-      <Tab eventKey="drafts" title="Drafts">
+      <Tab eventKey="drafts" title={`Draft (${draft.length})`}>
         <DirectoryDraftsTable experiments={draft} />
       </Tab>
     </Tabs>


### PR DESCRIPTION


Because

* It would be nice to see how many experiments are in each status on the directory view
* This will become even more useful once we add dynamic filtering

This commit

* Displays the number of experiments in each status in the directory view