### PR TITLE
fix #6028 feat(nimbus): channel required for mobile

### DIFF
--- a/app/experimenter/experiments/api/v5/serializers.py
+++ b/app/experimenter/experiments/api/v5/serializers.py
@@ -637,3 +637,12 @@ class NimbusReadyForReviewSerializer(serializers.ModelSerializer):
         if value == NimbusExperiment.HYPOTHESIS_DEFAULT.strip():
             raise serializers.ValidationError("Hypothesis cannot be the default value.")
         return value
+
+    def validate(self, attrs):
+        application = attrs.get("application")
+        channel = attrs.get("channel")
+        if application != NimbusExperiment.Application.DESKTOP and not channel:
+            raise serializers.ValidationError(
+                {"channel": "Channel is required for this application."}
+            )
+        return super().validate(attrs)

--- a/app/experimenter/experiments/tests/api/v5/test_serializers.py
+++ b/app/experimenter/experiments/tests/api/v5/test_serializers.py
@@ -1699,6 +1699,33 @@ class TestNimbusReadyForReviewSerializer(TestCase):
             NimbusConstants.ERROR_REQUIRED_QUESTION,
         )
 
+    @parameterized.expand(
+        [
+            (True, NimbusExperiment.Application.DESKTOP),
+            (False, NimbusExperiment.Application.FENIX),
+            (False, NimbusExperiment.Application.IOS),
+        ]
+    )
+    def test_channel_required_for_mobile(self, expected_valid, application):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            application=application,
+            channel=NimbusExperiment.Channel.NO_CHANNEL,
+        )
+
+        serializer = NimbusReadyForReviewSerializer(
+            experiment,
+            data=NimbusReadyForReviewSerializer(
+                experiment,
+                context={"user": self.user},
+            ).data,
+            context={"user": self.user},
+        )
+
+        self.assertEqual(serializer.is_valid(), expected_valid)
+        if not expected_valid:
+            self.assertIn("channel", serializer.errors)
+
 
 class TestNimbusStatusTransitionValidator(TestCase):
     maxDiff = None


### PR DESCRIPTION


Because

* Mobile relies on the channel to supply the app_id which is used in mobile targeting

This commit

* Forces channel to be required for mobile applications

<img width="1171" alt="Screen Shot 2021-07-22 at 2 03 18 PM" src="https://user-images.githubusercontent.com/119884/126687326-46d9c9ee-2e4b-4f1a-aa6f-44c1f0b22478.png">