### PR TITLE
fixes #5718 feat(nimbus): save countries and locales in experiment form

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/index.test.tsx
@@ -153,23 +153,26 @@ describe("FormAudience", () => {
       totalEnrolledClients: MOCK_EXPERIMENT.totalEnrolledClients,
       proposedEnrollment: "" + MOCK_EXPERIMENT.proposedEnrollment,
       proposedDuration: "" + MOCK_EXPERIMENT.proposedDuration,
+      countries: MOCK_EXPERIMENT.countries.map((v) => "" + v.id),
+      locales: MOCK_EXPERIMENT.locales.map((v) => "" + v.id),
     };
     render(<Subject {...{ onSubmit }} />);
     await screen.findByTestId("FormAudience");
     const submitButton = screen.getByTestId("submit-button");
     const nextButton = screen.getByTestId("next-button");
 
-    await act(async () => {
-      fireEvent.click(submitButton);
-      fireEvent.click(nextButton);
+    fireEvent.click(submitButton);
+    fireEvent.click(nextButton);
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledTimes(2);
+      expect(onSubmit.mock.calls).toEqual([
+        // Save button just saves
+        [expected, false],
+        // Next button advances to next page
+        [expected, true],
+      ]);
     });
-    expect(onSubmit).toHaveBeenCalledTimes(2);
-    expect(onSubmit.mock.calls).toEqual([
-      // Save button just saves
-      [expected, false],
-      // Next button advances to next page
-      [expected, true],
-    ]);
   });
 
   it("accepts commas in the expected number of clients field (EXP-761)", async () => {

--- a/app/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/index.tsx
@@ -34,8 +34,8 @@ type FormAudienceProps = {
 };
 
 type AudienceFieldName = typeof audienceFieldNames[number];
-type SelectCodeItems = {
-  code: string;
+type SelectIdItems = {
+  id: number;
   name: string;
 }[];
 
@@ -51,10 +51,10 @@ export const audienceFieldNames = [
   "locales",
 ] as const;
 
-const selectOptions = (items: SelectCodeItems) =>
+const selectOptions = (items: SelectIdItems) =>
   items.map((item) => ({
     label: item.name!,
-    value: item.code!,
+    value: item.id!,
   }));
 
 export const FormAudience = ({
@@ -69,10 +69,10 @@ export const FormAudience = ({
   const { fieldMessages } = useReviewCheck(experiment);
 
   const [locales, setLocales] = useState<string[]>(
-    experiment!.locales.map((v) => v.code!),
+    experiment!.locales.map((v) => "" + v.id!),
   );
   const [countries, setCountries] = useState<string[]>(
-    experiment!.countries.map((v) => v.code!),
+    experiment!.countries.map((v) => "" + v.id!),
   );
 
   const defaultValues = {
@@ -83,8 +83,8 @@ export const FormAudience = ({
     totalEnrolledClients: experiment.totalEnrolledClients,
     proposedEnrollment: experiment.proposedEnrollment,
     proposedDuration: experiment.proposedDuration,
-    countries: selectOptions(experiment.countries as SelectCodeItems),
-    locales: selectOptions(experiment.locales as SelectCodeItems),
+    countries: selectOptions(experiment.countries as SelectIdItems),
+    locales: selectOptions(experiment.locales as SelectIdItems),
   };
 
   const {
@@ -107,10 +107,19 @@ export const FormAudience = ({
     () =>
       [false, true].map((next) =>
         handleSubmit(
-          (dataIn: DefaultValues) => !isLoading && onSubmit(dataIn, next),
+          (dataIn: DefaultValues) =>
+            !isLoading &&
+            onSubmit(
+              {
+                ...dataIn,
+                locales,
+                countries,
+              },
+              next,
+            ),
         ),
       ),
-    [isLoading, onSubmit, handleSubmit],
+    [isLoading, onSubmit, handleSubmit, locales, countries],
   );
 
   const targetingConfigSlugOptions = useMemo(
@@ -166,11 +175,8 @@ export const FormAudience = ({
               placeholder="All Locales"
               isMulti
               {...formSelectAttrs("locales", setLocales)}
-              options={selectOptions(config.locales as SelectCodeItems)}
+              options={selectOptions(config.locales as SelectIdItems)}
             />
-            <Form.Text className="text-muted">
-              In development - this field does not save selections yet.
-            </Form.Text>
             <FormErrors name="locales" />
           </Form.Group>
           <Form.Group as={Col} controlId="countries" data-testid="countries">
@@ -179,11 +185,8 @@ export const FormAudience = ({
               placeholder="All Countries"
               isMulti
               {...formSelectAttrs("countries", setCountries)}
-              options={selectOptions(config.countries as SelectCodeItems)}
+              options={selectOptions(config.countries as SelectIdItems)}
             />
-            <Form.Text className="text-muted">
-              In development - this field does not save selections yet.
-            </Form.Text>
             <FormErrors name="countries" />
           </Form.Group>
         </Form.Row>

--- a/app/experimenter/nimbus-ui/src/components/PageEditAudience/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditAudience/index.test.tsx
@@ -106,6 +106,8 @@ const MOCK_FORM_DATA = {
   totalEnrolledClients: 68000,
   proposedEnrollment: "1.0",
   proposedDuration: 28,
+  countries: [1],
+  locales: [1],
 };
 
 const Subject = ({

--- a/app/experimenter/nimbus-ui/src/components/PageEditAudience/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditAudience/index.tsx
@@ -35,6 +35,8 @@ const PageEditAudience: React.FunctionComponent<RouteComponentProps> = () => {
         totalEnrolledClients,
         proposedEnrollment,
         proposedDuration,
+        countries,
+        locales,
       }: Record<string, any>,
       next: boolean,
     ) => {
@@ -53,6 +55,8 @@ const PageEditAudience: React.FunctionComponent<RouteComponentProps> = () => {
               totalEnrolledClients,
               proposedEnrollment,
               proposedDuration,
+              countries,
+              locales,
             },
           },
         });

--- a/app/experimenter/nimbus-ui/src/components/Summary/TableAudience/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/TableAudience/index.test.tsx
@@ -143,7 +143,7 @@ describe("TableAudience", () => {
   describe("renders 'Targeted Locales' row as expected", () => {
     it("when locales exist, displays them", () => {
       const data = {
-        locales: [{ name: "Quebecois", code: "qc" }],
+        locales: [{ name: "Quebecois", id: 1 }],
       };
       const { experiment } = mockExperimentQuery("demo-slug", data);
       render(<Subject {...{ experiment }} />);
@@ -165,7 +165,7 @@ describe("TableAudience", () => {
   describe("renders 'Targeted Countries' row as expected", () => {
     it("when countries exist, displays them", async () => {
       const data = {
-        locales: [{ name: "Canada", code: "ca" }],
+        locales: [{ name: "Canada", id: 1 }],
       };
       const { experiment } = mockExperimentQuery("demo-slug", data);
       render(<Subject {...{ experiment }} />);

--- a/app/experimenter/nimbus-ui/src/gql/config.ts
+++ b/app/experimenter/nimbus-ui/src/gql/config.ts
@@ -46,11 +46,11 @@ export const GET_CONFIG_QUERY = gql`
       }
       maxPrimaryOutcomes
       locales {
-        code
+        id
         name
       }
       countries {
-        code
+        id
         name
       }
     }

--- a/app/experimenter/nimbus-ui/src/gql/experiments.ts
+++ b/app/experimenter/nimbus-ui/src/gql/experiments.ts
@@ -139,11 +139,11 @@ export const GET_EXPERIMENT_QUERY = gql`
       reviewUrl
 
       locales {
-        code
+        id
         name
       }
       countries {
-        code
+        id
         name
       }
     }

--- a/app/experimenter/nimbus-ui/src/lib/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/lib/mocks.tsx
@@ -169,30 +169,30 @@ export const MOCK_CONFIG: getConfig_nimbusConfig = {
   maxPrimaryOutcomes: 2,
   locales: [
     {
-      code: "ach",
       name: "Acholi",
+      id: 1,
     },
     {
-      code: "af",
       name: "Afrikaans",
+      id: 2,
     },
     {
-      code: "sq",
       name: "Albanian",
+      id: 3,
     },
   ],
   countries: [
     {
-      code: "ER",
       name: "Eritrea",
+      id: 1,
     },
     {
-      code: "EE",
       name: "Estonia",
+      id: 2,
     },
     {
-      code: "SZ",
       name: "Eswatini",
+      id: 3,
     },
   ],
 };
@@ -369,8 +369,8 @@ export function mockExperiment<
       riskPartnerRelated: false,
       reviewUrl:
         "https://kinto.example.com/v1/admin/#/buckets/main-workspace/collections/nimbus-desktop-experiments/simple-review",
-      locales: [{ name: "Quebecois", code: "qc" }],
-      countries: [{ name: "Canada", code: "ca" }],
+      locales: [{ name: "Quebecois", id: 1 }],
+      countries: [{ name: "Canada", id: 1 }],
     },
     modifications,
   ) as T;

--- a/app/experimenter/nimbus-ui/src/types/getConfig.ts
+++ b/app/experimenter/nimbus-ui/src/types/getConfig.ts
@@ -53,12 +53,12 @@ export interface getConfig_nimbusConfig_documentationLink {
 }
 
 export interface getConfig_nimbusConfig_locales {
-  code: string | null;
+  id: number | null;
   name: string | null;
 }
 
 export interface getConfig_nimbusConfig_countries {
-  code: string | null;
+  id: number | null;
   name: string | null;
 }
 

--- a/app/experimenter/nimbus-ui/src/types/getExperiment.ts
+++ b/app/experimenter/nimbus-ui/src/types/getExperiment.ts
@@ -88,12 +88,12 @@ export interface getExperiment_experimentBySlug_timeout {
 }
 
 export interface getExperiment_experimentBySlug_locales {
-  code: string | null;
+  id: number | null;
   name: string | null;
 }
 
 export interface getExperiment_experimentBySlug_countries {
-  code: string | null;
+  id: number | null;
   name: string | null;
 }
 


### PR DESCRIPTION
Closes #5718

This PR adds locales and countries to the mutation call that saves experiment data.

Also, I forgot that we were saving countries/locales by their `id`, not their `code`, so I swapped that around.