### PR TITLE
fix #6026 chore(nimbus): rename custom audience to advanced targeting

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/Summary/TableAudience/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/TableAudience/index.test.tsx
@@ -87,7 +87,7 @@ describe("TableAudience", () => {
     });
   });
 
-  describe("renders 'Custom audience' row as expected", () => {
+  describe("renders 'Advanced Targeting' row as expected", () => {
     it("when set", () => {
       const { experiment } = mockExperimentQuery("demo-slug");
       render(<Subject {...{ experiment }} />);

--- a/app/experimenter/nimbus-ui/src/components/Summary/TableAudience/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/TableAudience/index.tsx
@@ -57,7 +57,7 @@ const TableAudience = ({ experiment }: TableAudienceProps) => {
         )}
         {experiment.targetingConfigSlug && (
           <tr>
-            <th>Custom audience</th>
+            <th>Advanced Targeting</th>
             <td data-testid="experiment-target">
               {displayConfigLabelOrNotSet(
                 experiment.targetingConfigSlug,


### PR DESCRIPTION
Because

* We refer to this field as Advanced Targeting in the form

This commit

* Updates the summary page to also call it Advanced Targeting