### PR TITLE
fixes #6027 feat(nimbus): allow target expression code to flow to new line

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/Code/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Code/index.tsx
@@ -6,13 +6,19 @@ import React from "react";
 import JSONPretty from "react-json-pretty";
 import "../../styles/react-json-pretty-theme.scss";
 
-export const Code = ({ codeString }: { codeString: string }) => {
+export const Code = ({
+  codeString,
+  className,
+}: {
+  codeString: string;
+  className?: string;
+}) => {
   try {
     JSON.parse(codeString);
   } catch (e) {
     return (
       <pre className="mb-0 code-color">
-        <code>{codeString}</code>
+        <code {...{ className }}>{codeString}</code>
       </pre>
     );
   }

--- a/app/experimenter/nimbus-ui/src/components/Summary/TableAudience/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/TableAudience/index.tsx
@@ -90,7 +90,10 @@ const TableAudience = ({ experiment }: TableAudienceProps) => {
               data-testid="experiment-target-expression"
               className="text-monospace"
             >
-              <Code codeString={experiment.jexlTargetingExpression} />
+              <Code
+                className="text-wrap"
+                codeString={experiment.jexlTargetingExpression}
+              />
             </td>
           </tr>
         ) : null}


### PR DESCRIPTION
Closes #6027

Allow full targeting expression on Summary page to flow to new line so it doesn't get obscured by macOS magic scroll bars.