### PR TITLE
fix #6044 chore(nimbus): set desktop as default experiment factory application

### DIFF
--- a/app/experimenter/experiments/tests/factories/nimbus.py
+++ b/app/experimenter/experiments/tests/factories/nimbus.py
@@ -184,9 +184,7 @@ class NimbusExperimentFactory(factory.django.DjangoModelFactory):
     firefox_min_version = factory.LazyAttribute(
         lambda o: random.choice(list(NimbusExperiment.Version)).value
     )
-    application = factory.LazyAttribute(
-        lambda o: random.choice(list(NimbusExperiment.Application)).value
-    )
+    application = NimbusExperiment.Application.DESKTOP
     channel = factory.LazyAttribute(
         lambda o: random.choice(list(NimbusExperiment.Channel)).value
     )

--- a/app/experimenter/experiments/tests/test_changelog_utils/test_changelog_utils_nimbus.py
+++ b/app/experimenter/experiments/tests/test_changelog_utils/test_changelog_utils_nimbus.py
@@ -166,6 +166,8 @@ class TestNimbusExperimentChangeLogSerializer(TestCase):
 
 
 class TestGenerateNimbusChangeLog(TestCase):
+    maxDiff = None
+
     def setUp(self):
         self.user = UserFactory.create()
 


### PR DESCRIPTION


Because

* Experiments have different required fields/values per application, so randomly choosing an application can result in intermittent test failures

This commit

* Sets the default application in the NimbusExperimentFactory to Desktop
* Individual tests that are explicitly testing a specific application should set them explicitly