### PR TITLE
fix #6048 feat(nimbus): admin action to trigger jetstream refresh

### DIFF
--- a/app/experimenter/experiments/tests/test_admin/test_admin_nimbus.py
+++ b/app/experimenter/experiments/tests/test_admin/test_admin_nimbus.py
@@ -1,3 +1,4 @@
+import mock
 from django.conf import settings
 from django.test import TestCase
 from django.urls import reverse
@@ -110,3 +111,20 @@ class TestNimbusExperimentAdmin(TestCase):
             **{settings.OPENIDC_EMAIL_HEADER: user.email}
         )
         self.assertEqual(response.status_code, 200)
+
+    @mock.patch("experimenter.experiments.admin.nimbus.tasks.fetch_experiment_data")
+    def test_admin_force_jetstream_fetch(self, mock_fetch_experiment_data):
+        user = UserFactory.create(is_staff=True, is_superuser=True)
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.ENDING_APPROVE_APPROVE
+        )
+        response = self.client.post(
+            reverse(
+                "admin:experiments_nimbusexperiment_changelist",
+            ),
+            {"action": "force_fetch_jetstream_data", "_selected_action": [experiment.id]},
+            follow=True,
+            **{settings.OPENIDC_EMAIL_HEADER: user.email}
+        )
+        self.assertEqual(response.status_code, 200)
+        mock_fetch_experiment_data.delay.assert_called_with(experiment.id)


### PR DESCRIPTION
Because

* We need a way to manually refresh the jetstream data for an experiment if we make changes to the parsing/display logic

This commit

* Adds an admin action to trigger the jetstream fetch task