### PR TITLE
fix #6023 fix(nimbus-ui): Skip lifecycles involving Remote Settings for dummy experiments

### DIFF
--- a/app/experimenter/base/management/commands/load_dummy_experiments.py
+++ b/app/experimenter/base/management/commands/load_dummy_experiments.py
@@ -21,7 +21,7 @@ class Command(BaseCommand):
             experiment = ExperimentFactory.create_with_status(status, type=random_type)
             logger.info("Created {}: {}".format(experiment, status))
 
-        for lifecycle in NimbusExperimentFactory.Lifecycles:
+        for lifecycle in NimbusExperimentFactory.LocalLifecycles:
             experiment = NimbusExperimentFactory.create_with_lifecycle(
                 lifecycle, with_random_timespan=True
             )

--- a/app/experimenter/base/tests/test_initial_data.py
+++ b/app/experimenter/base/tests/test_initial_data.py
@@ -14,7 +14,7 @@ class TestInitialData(TestCase):
         for status, _ in Experiment.STATUS_CHOICES:
             self.assertTrue(Experiment.objects.filter(status=status).exists())
 
-        for lifecycle in NimbusExperimentFactory.Lifecycles:
+        for lifecycle in NimbusExperimentFactory.LocalLifecycles:
             states = lifecycle.value
             final_state = states[-1].value
             self.assertTrue(NimbusExperiment.objects.filter(**final_state).exists())

--- a/app/experimenter/experiments/tests/factories/nimbus.py
+++ b/app/experimenter/experiments/tests/factories/nimbus.py
@@ -207,10 +207,22 @@ class NimbusExperimentFactory(factory.django.DjangoModelFactory):
 
     class Meta:
         model = NimbusExperiment
-        exclude = ("Lifecycles", "LifecycleStates")
+        exclude = ("Lifecycles", "LifecycleStates", "LocalLifecycles")
 
     Lifecycles = Lifecycles
     LifecycleStates = LifecycleStates
+
+    # EXP-1527: lifecycle states that do not assume an experiment currently
+    # exists in Remote Settings
+    LocalLifecycles = [
+        Lifecycles.CREATED,
+        # Preview should be okay because the Celery task will synchronize
+        Lifecycles.PREVIEW,
+        Lifecycles.LAUNCH_REVIEW_REQUESTED,
+        Lifecycles.LAUNCH_REJECT,
+        Lifecycles.LAUNCH_APPROVE_TIMEOUT,
+        Lifecycles.ENDING_APPROVE_APPROVE,
+    ]
 
     @factory.post_generation
     def projects(self, create, extracted, **kwargs):


### PR DESCRIPTION
Because:

* Some lifecycle states should only be reached when there is a
  corresponding record in Remote Settings.

* Loading dummy experiments doesn't update the local instance of Remote
  Settings

This commit:

* Only generates dummy experiments for lifecycle states that do not
  assume an corresponding experiment record exists in Remote Settings

* Preview is included as an exception because the synchronize task will
  push the experiment to Remote Settings shortly after generation