### PR TITLE
fix #6069 feat(nimbus): support deprecated targeting configs

### DIFF
--- a/app/experimenter/experiments/api/v5/types.py
+++ b/app/experimenter/experiments/api/v5/types.py
@@ -183,7 +183,7 @@ class NimbusExperimentType(DjangoObjectType):
     channel = NimbusExperimentChannel()
     documentation_links = DjangoListField(NimbusDocumentationLinkType)
     treatment_branches = graphene.List(NimbusBranchType)
-    targeting_config_slug = NimbusExperimentTargetingConfigSlug()
+    targeting_config_slug = graphene.String()
     jexl_targeting_expression = graphene.String()
     primary_outcomes = graphene.List(graphene.String)
     secondary_outcomes = graphene.List(graphene.String)

--- a/app/experimenter/experiments/constants/nimbus.py
+++ b/app/experimenter/experiments/constants/nimbus.py
@@ -471,3 +471,5 @@ Optional - We believe this outcome will <describe impact> on <core metric>
         for (collection, applications) in KINTO_COLLECTION_APPLICATIONS.items()
         for application in applications
     }
+
+    PUBLISHED_TARGETING_MISSING = "Published targeting JEXL not found"

--- a/app/experimenter/experiments/models/nimbus.py
+++ b/app/experimenter/experiments/models/nimbus.py
@@ -199,6 +199,9 @@ class NimbusExperiment(NimbusConstants, FilterMixin, models.Model):
     # This is the full JEXL expression processed by clients
     @property
     def targeting(self):
+        if self.published_dto:
+            return self.published_dto.get("targeting", self.PUBLISHED_TARGETING_MISSING)
+
         expressions = []
 
         if self.application == self.Application.DESKTOP:
@@ -244,7 +247,10 @@ class NimbusExperiment(NimbusConstants, FilterMixin, models.Model):
 
     @property
     def targeting_config(self):
-        if self.targeting_config_slug:
+        if (
+            self.targeting_config_slug is not None
+            and self.targeting_config_slug in self.TARGETING_CONFIGS
+        ):
             return self.TARGETING_CONFIGS[self.targeting_config_slug]
 
     @property

--- a/app/experimenter/experiments/tests/test_models/test_models_nimbus.py
+++ b/app/experimenter/experiments/tests/test_models/test_models_nimbus.py
@@ -310,6 +310,38 @@ class TestNimbusExperiment(TestCase):
             ),
         )
 
+    def test_targeting_uses_published_targeting_string(self):
+        published_targeting = "published targeting jexl"
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.LIVE_ENROLLING,
+            published_dto={"targeting": published_targeting},
+        )
+        self.assertEqual(experiment.targeting, published_targeting)
+
+    def test_targeting_with_missing_published_targeting(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.LIVE_ENROLLING,
+            published_dto={"other_field": "some value"},
+        )
+        self.assertEqual(
+            experiment.targeting, NimbusExperiment.PUBLISHED_TARGETING_MISSING
+        )
+
+    def test_targeting_config_returns_config_with_valid_slug(self):
+        experiment = NimbusExperimentFactory.create(
+            targeting_config_slug=NimbusExperiment.TargetingConfig.NO_TARGETING
+        )
+        self.assertEqual(
+            experiment.targeting_config,
+            NimbusExperiment.TARGETING_CONFIGS[
+                NimbusExperiment.TargetingConfig.NO_TARGETING
+            ],
+        )
+
+    def test_targeting_config_returns_None_with_invalid_slug(self):
+        experiment = NimbusExperimentFactory.create(targeting_config_slug="invalid slug")
+        self.assertIsNone(experiment.targeting_config)
+
     def test_start_date_returns_None_for_not_started_experiment(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.CREATED,

--- a/app/experimenter/nimbus-ui/schema.graphql
+++ b/app/experimenter/nimbus-ui/schema.graphql
@@ -330,7 +330,7 @@ type NimbusExperimentType {
   primaryOutcomes: [String]
   secondaryOutcomes: [String]
   featureConfig: NimbusFeatureConfigType
-  targetingConfigSlug: NimbusExperimentTargetingConfigSlug
+  targetingConfigSlug: String
   referenceBranch: NimbusBranchType
   publishedDto: JSONString
   resultsData: JSONString

--- a/app/experimenter/nimbus-ui/src/components/Summary/TableAudience/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/TableAudience/index.test.tsx
@@ -102,6 +102,15 @@ describe("TableAudience", () => {
       render(<Subject {...{ experiment }} />);
       expect(screen.queryByTestId("experiment-target")).not.toBeInTheDocument();
     });
+    it("when set with deprecated value", () => {
+      const { experiment } = mockExperimentQuery("demo-slug", {
+        targetingConfigSlug: "deprecated_slug",
+      });
+      render(<Subject {...{ experiment }} />);
+      expect(screen.getByTestId("experiment-target")).toHaveTextContent(
+        "Deprecated: deprecated_slug",
+      );
+    });
   });
 
   describe("renders 'Full targeting expression' row as expected", () => {

--- a/app/experimenter/nimbus-ui/src/lib/getConfigLabel.ts
+++ b/app/experimenter/nimbus-ui/src/lib/getConfigLabel.ts
@@ -13,4 +13,6 @@ export type ConfigOptions =
 export const getConfigLabel = (
   value: string | null,
   configOptions: ConfigOptions,
-) => configOptions?.find((option: any) => option.value === value)?.label;
+) =>
+  configOptions?.find((option: any) => option.value === value)?.label ||
+  `Deprecated: ${value}`;

--- a/app/experimenter/nimbus-ui/src/types/getExperiment.ts
+++ b/app/experimenter/nimbus-ui/src/types/getExperiment.ts
@@ -3,7 +3,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import { NimbusExperimentStatus, NimbusExperimentPublishStatus, NimbusExperimentApplication, NimbusExperimentChannel, NimbusExperimentFirefoxMinVersion, NimbusExperimentTargetingConfigSlug, NimbusDocumentationLinkTitle, NimbusChangeLogOldStatus, NimbusChangeLogOldStatusNext } from "./globalTypes";
+import { NimbusExperimentStatus, NimbusExperimentPublishStatus, NimbusExperimentApplication, NimbusExperimentChannel, NimbusExperimentFirefoxMinVersion, NimbusDocumentationLinkTitle, NimbusChangeLogOldStatus, NimbusChangeLogOldStatusNext } from "./globalTypes";
 
 // ====================================================
 // GraphQL query operation: getExperiment
@@ -117,7 +117,7 @@ export interface getExperiment_experimentBySlug {
   secondaryOutcomes: (string | null)[] | null;
   channel: NimbusExperimentChannel | null;
   firefoxMinVersion: NimbusExperimentFirefoxMinVersion | null;
-  targetingConfigSlug: NimbusExperimentTargetingConfigSlug | null;
+  targetingConfigSlug: string | null;
   jexlTargetingExpression: string | null;
   populationPercent: string | null;
   totalEnrolledClients: number;


### PR DESCRIPTION
Because

* Targeting configs can come, change, and go
* We need to be able to render completed experiments with targeting configs that no longer exist
* We need to be able to edit draft experiments that were saved with a suddenly deprecated targeting config

This commit

* Removes the enum choices from the targeting config slug field in the V5 API
* Valid choices will still be validated by the serializer validation layer
* The frontend will display deprecated targeting configs with a Deprecated label
* Published experiments will use their published targeting string in the UI instead of attempting to regenerate it