### PR TITLE
fix #5961 chore(nimbus): update qa sign off link

### DIFF
--- a/app/experimenter/nimbus-ui/src/lib/constants.ts
+++ b/app/experimenter/nimbus-ui/src/lib/constants.ts
@@ -39,7 +39,7 @@ export const EXTERNAL_URLS = {
   RISK_REVENUE:
     "https://mana.mozilla.org/wiki/display/FIREFOX/Pref-Flip+and+Add-On+Experiments#PrefFlipandAddOnExperiments-riskREV",
   SIGNOFF_QA:
-    "https://mana.mozilla.org/wiki/display/FIREFOX/Pref-Flip+and+Add-On+Experiments#PrefFlipandAddOnExperiments-QAsign-offsignQA",
+    "https://docs.google.com/document/d/1oz1YyaaBI-oHUDsktWA-dLtX7WzhYqs7C121yOPKo2w/edit",
   SIGNOFF_VP:
     "https://mana.mozilla.org/wiki/display/FIREFOX/Pref-Flip+and+Add-On+Experiments#PrefFlipandAddOnExperiments-VPSign-offsignVP",
   SIGNOFF_LEGAL:


### PR DESCRIPTION
Because

* The qa signoff link pointed to an out of date mana page

This commit

* Updates the link to the currently maintained qa pi filing process doc