### PR TITLE
fix #5957 feat(nimbus-ui): sortable directory columns

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/PageHome/DirectoryTable/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageHome/DirectoryTable/index.stories.tsx
@@ -10,15 +10,25 @@ import DirectoryTable, {
   DirectoryLiveTable,
 } from ".";
 import { mockDirectoryExperiments } from "../../../lib/mocks";
+import { CurrentLocation, RouterSlugProvider } from "../../../lib/test-utils";
 import {
   NimbusExperimentPublishStatus,
   NimbusExperimentStatus,
 } from "../../../types/globalTypes";
 
+const withRouterAndCurrentUrl = (Story: React.FC) => (
+  <RouterSlugProvider mocks={[]}>
+    <div className="p-3">
+      <CurrentLocation />
+      <Story />
+    </div>
+  </RouterSlugProvider>
+);
+
 export default {
   title: "pages/Home/DirectoryTable",
   component: DirectoryTable,
-  decorators: [withLinks],
+  decorators: [withRouterAndCurrentUrl, withLinks],
 };
 
 const experiments = mockDirectoryExperiments();
@@ -56,6 +66,7 @@ export const CustomComponent = () => (
     columns={[
       {
         label: "Testing column",
+        sortBy: ({ status }) => `Hello ${status}`,
         component: ({ status }) => <td>Hello {status}</td>,
       },
     ]}

--- a/app/experimenter/nimbus-ui/src/components/PageHome/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageHome/index.stories.tsx
@@ -5,45 +5,49 @@
 import { withLinks } from "@storybook/addon-links";
 import React from "react";
 import PageHome from ".";
-import { mockDirectoryExperimentsQuery, MockedCache } from "../../lib/mocks";
-import { RouterSlugProvider } from "../../lib/test-utils";
+import { mockDirectoryExperimentsQuery } from "../../lib/mocks";
+import { CurrentLocation, RouterSlugProvider } from "../../lib/test-utils";
 import { NimbusExperimentStatus } from "../../types/globalTypes";
+
+interface StoryContext {
+  args: {
+    mocks: Parameters<typeof RouterSlugProvider>[0]["mocks"];
+  };
+}
+
+const withRouterAndCurrentUrl = (
+  Story: React.FC,
+  { args: { mocks = [mockDirectoryExperimentsQuery()] } }: StoryContext,
+) => (
+  <RouterSlugProvider mocks={mocks}>
+    <>
+      <CurrentLocation />
+      <Story />
+    </>
+  </RouterSlugProvider>
+);
 
 export default {
   title: "pages/Home",
   component: PageHome,
-  decorators: [withLinks],
+  decorators: [withRouterAndCurrentUrl, withLinks],
 };
 
-export const Basic = () => (
-  <RouterSlugProvider mocks={[mockDirectoryExperimentsQuery()]}>
-    <PageHome />
-  </RouterSlugProvider>
-);
+const storyTemplate = (mocks: StoryContext["args"]["mocks"]) => {
+  return Object.assign(() => <PageHome />, { args: { mocks } });
+};
 
-export const Loading = () => (
-  <RouterSlugProvider mocks={[]}>
-    <PageHome />
-  </RouterSlugProvider>
-);
+export const Basic = storyTemplate([mockDirectoryExperimentsQuery()]);
 
-export const NoExperiments = () => (
-  <MockedCache mocks={[mockDirectoryExperimentsQuery([])]}>
-    <PageHome />
-  </MockedCache>
-);
+export const Loading = storyTemplate([]);
 
-export const OnlyDrafts = () => (
-  <MockedCache
-    mocks={[
-      mockDirectoryExperimentsQuery([
-        { status: NimbusExperimentStatus.DRAFT },
-        { status: NimbusExperimentStatus.DRAFT },
-        { status: NimbusExperimentStatus.DRAFT },
-        { status: NimbusExperimentStatus.DRAFT },
-      ]),
-    ]}
-  >
-    <PageHome />
-  </MockedCache>
-);
+export const NoExperiments = storyTemplate([mockDirectoryExperimentsQuery([])]);
+
+export const OnlyDrafts = storyTemplate([
+  mockDirectoryExperimentsQuery([
+    { status: NimbusExperimentStatus.DRAFT },
+    { status: NimbusExperimentStatus.DRAFT },
+    { status: NimbusExperimentStatus.DRAFT },
+    { status: NimbusExperimentStatus.DRAFT },
+  ]),
+]);

--- a/app/experimenter/nimbus-ui/src/components/PageHome/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageHome/index.tsx
@@ -4,9 +4,10 @@
 
 import { useQuery } from "@apollo/client";
 import { Link, RouteComponentProps } from "@reach/router";
-import React from "react";
+import React, { useCallback } from "react";
 import { Alert, Tab, Tabs } from "react-bootstrap";
 import { GET_EXPERIMENTS_QUERY } from "../../gql/experiments";
+import { useSearchParamsState } from "../../hooks";
 import { getAllExperiments_experiments } from "../../types/getAllExperiments";
 import ApolloErrorAlert from "../ApolloErrorAlert";
 import AppLayout from "../AppLayout";
@@ -23,9 +24,16 @@ import sortByStatus from "./sortByStatus";
 type PageHomeProps = Record<string, any> & RouteComponentProps;
 
 export const Body = () => {
+  const [searchParams, updateSearchParams] = useSearchParamsState();
   const { data, loading, error } = useQuery<{
     experiments: getAllExperiments_experiments[];
   }>(GET_EXPERIMENTS_QUERY);
+
+  const selectedTab = searchParams.get("tab") || "live";
+  const onSelectTab = useCallback(
+    (nextTab) => updateSearchParams((params) => params.set("tab", nextTab)),
+    [updateSearchParams],
+  );
 
   if (loading) {
     return <PageLoading />;
@@ -43,7 +51,7 @@ export const Body = () => {
     data.experiments,
   );
   return (
-    <Tabs defaultActiveKey="live">
+    <Tabs activeKey={selectedTab} onSelect={onSelectTab}>
       <Tab eventKey="live" title={`Live (${live.length})`}>
         <DirectoryLiveTable experiments={live} />
       </Tab>

--- a/app/experimenter/nimbus-ui/src/hooks/index.ts
+++ b/app/experimenter/nimbus-ui/src/hooks/index.ts
@@ -13,3 +13,4 @@ export * from "./useExperiment";
 export * from "./useFakeMutation";
 export * from "./useOutcomes";
 export * from "./useReviewCheck";
+export * from "./useSearchParamsState";

--- a/app/experimenter/nimbus-ui/src/hooks/useSearchParamsState.test.tsx
+++ b/app/experimenter/nimbus-ui/src/hooks/useSearchParamsState.test.tsx
@@ -1,0 +1,74 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import React from "react";
+import { RouterSlugProvider } from "../lib/test-utils";
+import useSearchParamsState from "./useSearchParamsState";
+
+// TODO: Work out how to test this stuff with @testing-library/react-hooks?
+// Depends on being wrapped by @reach/router, so that seems to make it difficult
+
+describe("hooks/useSearchParamsState", () => {
+  it("returns the current search parameters", async () => {
+    const expected = { foo: "bar", baz: "quux" };
+    const params = new URLSearchParams(expected);
+    const path = `/xyzzy/edit?${params.toString()}`;
+    render(<Subject path={path} />);
+    expect(screen.getByTestId("params")).toHaveTextContent(params.toString());
+  });
+
+  it("updates the search parameters", async () => {
+    render(
+      <Subject
+        path="/xyzzy/edit?deleteme=now&wibble=wobble&deletemetoo=also&beep=beep"
+        paramsToDelete={["deleteme", "deletemetoo"]}
+        paramsToSet={[
+          ["three", "four"],
+          ["one", "two"],
+        ]}
+      />,
+    );
+    fireEvent.click(screen.getByTestId("setParams"));
+    await waitFor(() => {
+      expect(screen.getByTestId("params")).toHaveTextContent(
+        "wibble=wobble&beep=beep&three=four&one=two",
+      );
+    });
+  });
+
+  interface SubjectProps {
+    path: string;
+    paramsToDelete?: Array<string>;
+    // TODO: This should be Array<[string, string]> but current eslint version trips on it
+    paramsToSet?: Array<string[]>;
+  }
+  const Subject = (props: SubjectProps) => (
+    <RouterSlugProvider path={props.path}>
+      <SubjectInner {...props} />
+    </RouterSlugProvider>
+  );
+  const SubjectInner = (props: SubjectProps) => {
+    const [params, setParams] = useSearchParamsState();
+    const onClick = () => {
+      const { paramsToDelete = [], paramsToSet = [] } = props;
+      setParams((params) => {
+        for (const name of paramsToDelete) {
+          params.delete(name);
+        }
+        for (const [name, value] of paramsToSet) {
+          params.set(name, value);
+        }
+      });
+    };
+    return (
+      <div>
+        <code data-testid="params">{params.toString()}</code>
+        <button data-testid="setParams" onClick={onClick}>
+          Set params
+        </button>
+      </div>
+    );
+  };
+});

--- a/app/experimenter/nimbus-ui/src/hooks/useSearchParamsState.ts
+++ b/app/experimenter/nimbus-ui/src/hooks/useSearchParamsState.ts
@@ -1,0 +1,24 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { useLocation, useNavigate } from "@reach/router";
+import { useMemo } from "react";
+
+export function useSearchParamsState() {
+  const location = useLocation();
+  const navigate = useNavigate();
+  return useMemo(() => {
+    const params = new URLSearchParams(location.search);
+    const setParams = (updaterFn: (params: URLSearchParams) => void) => {
+      const nextParams = new URLSearchParams(location.search);
+      updaterFn(nextParams);
+      navigate(`${location.pathname}?${nextParams.toString()}`);
+    };
+    return [params, setParams] as const;
+  }, [navigate, location.search]);
+}
+
+export type UpdateSearchParams = ReturnType<typeof useSearchParamsState>[1];
+
+export default useSearchParamsState;

--- a/app/experimenter/nimbus-ui/src/lib/experiment.ts
+++ b/app/experimenter/nimbus-ui/src/lib/experiment.ts
@@ -77,3 +77,51 @@ export function getSummaryAction(
   }
   return "";
 }
+
+export type ExperimentSortSelector =
+  | keyof getAllExperiments_experiments
+  | ((experiment: getAllExperiments_experiments) => string | undefined);
+
+export const featureConfigNameSortSelector: ExperimentSortSelector = (
+  experiment,
+) => experiment.featureConfig?.name;
+
+export const ownerUsernameSortSelector: ExperimentSortSelector = (experiment) =>
+  experiment.owner?.username;
+
+export const enrollmentSortSelector: ExperimentSortSelector = ({
+  startDate,
+  proposedEnrollment,
+}) => {
+  if (startDate) {
+    const startTime = new Date(startDate).getTime();
+    const enrollmentMS = proposedEnrollment * (1000 * 60 * 60 * 24);
+    return new Date(startTime + enrollmentMS).toISOString();
+  } else {
+    return "" + proposedEnrollment;
+  }
+};
+
+export const resultsReadySortSelector: ExperimentSortSelector = (experiment) =>
+  experiment.resultsReady ? "1" : "0";
+
+export const selectFromExperiment = (
+  experiment: getAllExperiments_experiments,
+  selectBy: ExperimentSortSelector,
+) =>
+  "" +
+  (typeof selectBy === "function"
+    ? selectBy(experiment)
+    : experiment[selectBy]);
+
+export const experimentSortComparator =
+  (sortBy: ExperimentSortSelector, descending: boolean) =>
+  (
+    experimentA: getAllExperiments_experiments,
+    experimentB: getAllExperiments_experiments,
+  ) => {
+    const orderBy = descending ? -1 : 1;
+    const propertyA = selectFromExperiment(experimentA, sortBy);
+    const propertyB = selectFromExperiment(experimentB, sortBy);
+    return orderBy * propertyA.localeCompare(propertyB);
+  };

--- a/app/experimenter/nimbus-ui/src/lib/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/lib/mocks.tsx
@@ -494,14 +494,16 @@ export const mockGetStatus = (
   return getStatus(experiment);
 };
 
-const fiveDaysAgo = new Date();
-fiveDaysAgo.setDate(fiveDaysAgo.getDate() - 5);
-
 /** Creates a single mock experiment suitable for getAllExperiments queries.  */
 export function mockSingleDirectoryExperiment(
   overrides: Partial<getAllExperiments_experiments> = {},
   slugIndex: number = Math.round(Math.random() * 100),
 ): getAllExperiments_experiments {
+  const now = Date.now();
+  const oneDay = 1000 * 60 * 60 * 24;
+  const startTime = now - oneDay * 60 - 21 * oneDay * Math.random();
+  const endTime = now - oneDay * 30 + 21 * oneDay * Math.random();
+
   return {
     slug: `some-experiment-${slugIndex}`,
     owner: {
@@ -521,8 +523,8 @@ export function mockSingleDirectoryExperiment(
     isEnrollmentPausePending: false,
     proposedEnrollment: 7,
     proposedDuration: 28,
-    startDate: fiveDaysAgo.toISOString(),
-    computedEndDate: new Date(Date.now() + 12096e5).toISOString(),
+    startDate: new Date(startTime).toISOString(),
+    computedEndDate: new Date(endTime).toISOString(),
     resultsReady: false,
     ...overrides,
   };
@@ -531,42 +533,83 @@ export function mockSingleDirectoryExperiment(
 export function mockDirectoryExperiments(
   overrides: Partial<getAllExperiments_experiments>[] = [
     {
+      name: "Lorem ipsum dolor sit amet",
       status: NimbusExperimentStatus.DRAFT,
+      owner: { username: "alpha-example@mozilla.com" },
       startDate: null,
       computedEndDate: null,
     },
     {
+      name: "Ipsum dolor sit amet",
+      status: NimbusExperimentStatus.DRAFT,
+      owner: { username: "gamma-example@mozilla.com" },
+      featureConfig: { slug: "foo", name: "Foo" },
+      startDate: null,
+      computedEndDate: null,
+    },
+    {
+      name: "Dolor sit amet",
+      status: NimbusExperimentStatus.DRAFT,
+      owner: { username: "beta-example@mozilla.com" },
+      featureConfig: { slug: "bar", name: "Bar" },
+      startDate: null,
+      computedEndDate: null,
+    },
+    {
+      name: "Consectetur adipiscing elit",
       status: NimbusExperimentStatus.PREVIEW,
+      owner: { username: "alpha-example@mozilla.com" },
+      featureConfig: { slug: "baz", name: "Baz" },
       computedEndDate: null,
     },
     {
+      name: "Aliquam interdum ac lacus at dictum",
       publishStatus: NimbusExperimentPublishStatus.APPROVED,
+      owner: { username: "beta-example@mozilla.com" },
+      featureConfig: { slug: "foo", name: "Foo" },
       computedEndDate: null,
     },
     {
+      name: "Nam semper sit amet orci in imperdiet",
       publishStatus: NimbusExperimentPublishStatus.APPROVED,
+      owner: { username: "gamma-example@mozilla.com" },
     },
     {
+      name: "Duis ornare mollis sem.",
       status: NimbusExperimentStatus.LIVE,
-      computedEndDate: null,
+      owner: { username: "alpha-example@mozilla.com" },
+      featureConfig: { slug: "bar", name: "Bar" },
     },
     {
+      name: "Nec suscipit mi accumsan id",
       status: NimbusExperimentStatus.LIVE,
-      computedEndDate: null,
+      owner: { username: "beta-example@mozilla.com" },
+      featureConfig: { slug: "baz", name: "Baz" },
+      resultsReady: true,
     },
     {
+      name: "Etiam congue risus quis aliquet eleifend",
       status: NimbusExperimentStatus.LIVE,
-      computedEndDate: null,
+      owner: { username: "gamma-example@mozilla.com" },
     },
     {
+      name: "Nam gravida",
       status: NimbusExperimentStatus.COMPLETE,
+      owner: { username: "alpha-example@mozilla.com" },
+      featureConfig: { slug: "foo", name: "Foo" },
+      resultsReady: false,
     },
     {
+      name: "Quam quis volutpat ornare",
       status: NimbusExperimentStatus.DRAFT,
       publishStatus: NimbusExperimentPublishStatus.REVIEW,
+      featureConfig: { slug: "Baz", name: "Bar" },
+      owner: { username: "beta-example@mozilla.com" },
     },
     {
+      name: "Lorem arcu faucibus tortor",
       featureConfig: null,
+      owner: { username: "gamma-example@mozilla.com" },
     },
   ],
 ): getAllExperiments_experiments[] {

--- a/app/experimenter/nimbus-ui/src/lib/test-utils.tsx
+++ b/app/experimenter/nimbus-ui/src/lib/test-utils.tsx
@@ -9,6 +9,7 @@ import {
   LocationProvider,
   RouteComponentProps,
   Router,
+  useLocation,
 } from "@reach/router";
 import { render, screen } from "@testing-library/react";
 import React from "react";
@@ -115,4 +116,17 @@ export const assertSerializerMessages = async (
       }
     }
   }
+};
+
+export const CurrentLocation = () => {
+  const location = useLocation();
+  return (
+    <p className="p-3">
+      Location:{" "}
+      <code data-testid="location">
+        {location.pathname}
+        {location.search}
+      </code>
+    </p>
+  );
 };

--- a/app/tests/integration/nimbus/test_e2e_create_experiment.py
+++ b/app/tests/integration/nimbus/test_e2e_create_experiment.py
@@ -193,12 +193,12 @@ def test_create_new_experiment_remote_settings_reject(selenium, base_url):
     modal.decline_changes()
 
     # Load home page and wait for experiment to show in the Drafts tab
-    selenium.get(base_url)
+    drafts_tab_url = f"{base_url}?tab=drafts"
+    selenium.get(drafts_tab_url)
     experiment_found = False
     for attempt in range(45):
         try:
-            home = HomePage(selenium, base_url).wait_for_page_to_load()
-            home.tabs[-1].click()
+            home = HomePage(selenium, drafts_tab_url)
             new_experiments = home.tables[0].experiments
             for item in new_experiments:
                 if experiment_name in item.text:


### PR DESCRIPTION
Because:

* We want to make the directory view table sortable by each column

* Currently applied sorting should be reflected in the url query
  parameter.

This commit:

* Adds support for directory tab selection via query parameter

* Adds experiment sorting to DirectoryTable based on location query
  parameters

* Adds SortableColumnTitle component to DirectoryTable to cycle through
  column sorting modes and update location query parameters

* Updates column definitions in DirectoryTable components to support
  sorting criteria

* Adds sorting utilities to lib/experiment.ts

* Tweaks mock data to add more sortable variety

* Updates tests and stories with router context

* Adds useSearchParamsState hook to read and update location query
  parameters