### PR TITLE
fixes #6082 fix(nimbus): Address ConfidenceInterval overlapping text

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/PageResults/ConfidenceInterval/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/ConfidenceInterval/index.stories.tsx
@@ -11,50 +11,170 @@ import { SIGNIFICANCE } from "../../../lib/visualization/constants";
 storiesOf("pages/Results/ConfidenceInterval", module)
   .addDecorator(withLinks)
   .add("with positive significance", () => (
-    <ConfidenceInterval
-      upper={65}
-      lower={45}
-      range={65}
-      significance={SIGNIFICANCE.POSITIVE}
-    />
+    <div className="w-25">
+      <div className="w-75">
+        <ConfidenceInterval
+          upper={65}
+          lower={45}
+          range={65}
+          significance={SIGNIFICANCE.POSITIVE}
+        />
+      </div>
+    </div>
   ))
   .add("with neutral significance", () => (
-    <ConfidenceInterval
-      upper={65}
-      lower={-45}
-      range={65}
-      significance={SIGNIFICANCE.NEUTRAL}
-    />
+    <div className="w-25">
+      <div className="w-75">
+        <ConfidenceInterval
+          upper={65}
+          lower={-45}
+          range={65}
+          significance={SIGNIFICANCE.NEUTRAL}
+        />
+      </div>
+    </div>
   ))
   .add("with negative significance", () => (
-    <ConfidenceInterval
-      upper={-45}
-      lower={-65}
-      range={65}
-      significance={SIGNIFICANCE.NEGATIVE}
-    />
+    <div className="w-25">
+      <div className="w-75">
+        <ConfidenceInterval
+          upper={-45}
+          lower={-65}
+          range={65}
+          significance={SIGNIFICANCE.NEGATIVE}
+        />
+      </div>
+    </div>
   ))
   .add("with small positive significance", () => (
-    <ConfidenceInterval
-      upper={50}
-      lower={45}
-      range={50}
-      significance={SIGNIFICANCE.POSITIVE}
-    />
+    <div className="w-25">
+      <div className="w-75">
+        <ConfidenceInterval
+          upper={50}
+          lower={45}
+          range={50}
+          significance={SIGNIFICANCE.POSITIVE}
+        />
+      </div>
+    </div>
   ))
   .add("with small neutral significance", () => (
-    <ConfidenceInterval
-      upper={2}
-      lower={-2}
-      range={2}
-      significance={SIGNIFICANCE.NEUTRAL}
-    />
+    <div className="w-25">
+      <div className="w-75">
+        <ConfidenceInterval
+          upper={2}
+          lower={-2}
+          range={2}
+          significance={SIGNIFICANCE.NEUTRAL}
+        />
+      </div>
+    </div>
   ))
   .add("with small negative significance", () => (
-    <ConfidenceInterval
-      upper={-45}
-      lower={-50}
-      range={50}
-      significance={SIGNIFICANCE.NEGATIVE}
-    />
+    <div className="w-25">
+      <div className="w-75">
+        <ConfidenceInterval
+          upper={-45}
+          lower={-50}
+          range={50}
+          significance={SIGNIFICANCE.NEGATIVE}
+        />
+      </div>
+    </div>
+  ))
+  .add("with 3-digit total bounds", () => (
+    <div className="w-25">
+      <div className="w-75">
+        <ConfidenceInterval
+          upper={100}
+          lower={-100}
+          range={100}
+          significance={SIGNIFICANCE.POSITIVE}
+        />
+      </div>
+    </div>
+  ))
+  .add("with 3-digit total bounds", () => (
+    <div className="w-25">
+      <div className="w-75">
+        <ConfidenceInterval
+          upper={15}
+          lower={9}
+          range={20}
+          significance={SIGNIFICANCE.POSITIVE}
+        />
+      </div>
+    </div>
+  ))
+  .add("with 4-digit total bounds and small significance", () => (
+    <div className="w-25">
+      <div className="w-75">
+        <ConfidenceInterval
+          upper={9.5}
+          lower={4.5}
+          range={200}
+          significance={SIGNIFICANCE.POSITIVE}
+        />
+      </div>
+    </div>
+  ))
+  .add("with 5-digit total bounds", () => (
+    <div className="w-25">
+      <div className="w-75">
+        <ConfidenceInterval
+          upper={123}
+          lower={90}
+          range={123}
+          significance={SIGNIFICANCE.POSITIVE}
+        />
+      </div>
+    </div>
+  ))
+  .add("with 6-digit total bounds and small significance", () => (
+    <div className="w-25">
+      <div className="w-75">
+        <ConfidenceInterval
+          upper={123}
+          lower={90.5}
+          range={1234}
+          significance={SIGNIFICANCE.POSITIVE}
+        />
+      </div>
+    </div>
+  ))
+  .add("with 10-digit total bounds", () => (
+    <div className="w-25">
+      <div className="w-75">
+        <ConfidenceInterval
+          upper={9999.9}
+          lower={3333.3}
+          range={9999.9}
+          significance={SIGNIFICANCE.POSITIVE}
+        />
+      </div>
+    </div>
+  ))
+  .add("with 10-digit total bounds and small significance", () => (
+    <div className="w-25">
+      <div className="w-75">
+        <ConfidenceInterval
+          upper={1234.5}
+          lower={1100.5}
+          range={1234.5}
+          significance={SIGNIFICANCE.POSITIVE}
+        />
+      </div>
+    </div>
+  ))
+  .add("with 12-digit total bounds", () => (
+    <div className="w-25">
+      <div className="w-75">
+        <ConfidenceInterval
+          upper={64858.6}
+          lower={11854.4}
+          range={64858.6}
+          significance={SIGNIFICANCE.POSITIVE}
+        />
+      </div>
+    </div>
   ));

--- a/app/experimenter/nimbus-ui/src/components/PageResults/ConfidenceInterval/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/ConfidenceInterval/index.tsx
@@ -7,7 +7,6 @@
 
 import React from "react";
 
-const BUFFER = 5;
 const MIN_BOUNDS_WIDTH = 22;
 
 const renderBounds = (
@@ -16,6 +15,7 @@ const renderBounds = (
   leftPercent: number,
   barWidth: number,
   significance: string,
+  buffer: number,
 ) => {
   if (barWidth < MIN_BOUNDS_WIDTH) {
     leftPercent -= (MIN_BOUNDS_WIDTH - barWidth) / 2;
@@ -26,8 +26,8 @@ const renderBounds = (
       className="position-absolute"
       style={{
         // Add some buffer to space out the rendered bound values.
-        left: `${leftPercent - BUFFER * 2}%`,
-        width: `${Math.max(barWidth, MIN_BOUNDS_WIDTH) + BUFFER * 3}%`,
+        left: `${leftPercent - buffer * 1.5}%`,
+        width: `${Math.max(barWidth, MIN_BOUNDS_WIDTH) + buffer * 3}%`,
       }}
     >
       <div
@@ -67,7 +67,15 @@ const ConfidenceInterval: React.FC<{
   range: number;
   significance: string;
 }> = ({ upper, lower, range, significance }) => {
-  range += BUFFER;
+  // number of total digits
+  let buffer =
+    Math.abs(upper).toString().replace(".", "").length +
+    Math.abs(lower).toString().replace(".", "").length;
+  // give additional buffer if there's 4+ digits and a small significance
+  if (buffer >= 4 && lower / upper > 0.5) {
+    buffer += (lower / upper) * 2;
+  }
+  range += buffer;
   const fullWidth = range * 2;
   const barWidth = ((upper - lower) / fullWidth) * 100;
   const leftPercent = (Math.abs(lower - range * -1) / fullWidth) * 100;
@@ -78,6 +86,7 @@ const ConfidenceInterval: React.FC<{
     leftPercent,
     barWidth,
     significance,
+    buffer,
   );
   const line = renderLine(leftPercent, barWidth, significance);
 


### PR DESCRIPTION
fixes #6082

Because:
* When there are a large number of digits in upper/lower bounds, confidence interval numbers overlapped

This commit:
* Updates the space buffer from a static 5 to calculate based on number of digits + 3

===

This is one of those things where I tried several different values (including the values on the page) and things LGTM with this calculation, but it's possible it may need tweaking later when there's another edge case. Could maybe use a test, but we've got test coverage and this is just for a visual change so I added some stories instead.  

<img width="336" alt="image" src="https://user-images.githubusercontent.com/13018240/127563377-debc356b-d7ad-4a7e-806b-36a3a6aee420.png">
