### PR TITLE
fix #6038 chore(project): cache docker ui layer

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,13 +92,16 @@ jobs:
             docker login -u $DOCKER_USER -p $DOCKER_PASS
             make build_dev
             make build_test
+            make build_ui
             ./scripts/store_git_info.sh
             make build_prod
             docker tag app:dev ${DOCKERHUB_REPO}:build_dev
             docker tag app:test ${DOCKERHUB_REPO}:build_test
+            docker tag app:ui ${DOCKERHUB_REPO}:build_ui
             docker tag app:deploy ${DOCKERHUB_REPO}:latest
             docker push ${DOCKERHUB_REPO}:build_dev
             docker push ${DOCKERHUB_REPO}:build_test
+            docker push ${DOCKERHUB_REPO}:build_ui
             docker push ${DOCKERHUB_REPO}:latest
 
 workflows:

--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,10 @@ build_dev: jetstream_config ssl
 build_test: jetstream_config ssl
 	DOCKER_BUILDKIT=1 docker build --target test -f app/Dockerfile -t app:test --build-arg BUILDKIT_INLINE_CACHE=1 --cache-from mozilla/experimenter:build_test $$([[ -z "$${CIRCLECI}" ]] || echo "--progress=plain") app/
 
-build_prod: jetstream_config ssl
+build_ui: jetstream_config ssl
+	DOCKER_BUILDKIT=1 docker build --target ui -f app/Dockerfile -t app:ui --build-arg BUILDKIT_INLINE_CACHE=1 --cache-from mozilla/experimenter:build_ui $$([[ -z "$${CIRCLECI}" ]] || echo "--progress=plain") app/
+
+build_prod: build_ui jetstream_config ssl
 	DOCKER_BUILDKIT=1 docker build --target deploy -f app/Dockerfile -t app:deploy --build-arg BUILDKIT_INLINE_CACHE=1 --cache-from mozilla/experimenter:latest $$([[ -z "$${CIRCLECI}" ]] || echo "--progress=plain") app/
 
 compose_stop:

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -72,7 +72,7 @@ COPY --from=file-loader /app/ /app/
 
 
 # Build image
-FROM dev AS build
+FROM dev AS ui
 
 
 # Build assets
@@ -107,5 +107,5 @@ COPY --from=dev /usr/local/lib/python3.9/site-packages/ /usr/local/lib/python3.9
 COPY --from=dev /app/bin/ /app/bin/
 COPY --from=file-loader /app/manage.py /app/manage.py
 COPY --from=file-loader /app/experimenter/ /app/experimenter/
-COPY --from=build /app/experimenter/legacy-ui/assets/ /app/experimenter/legacy-ui/assets/
-COPY --from=build /app/experimenter/nimbus-ui/build/ /app/experimenter/nimbus-ui/build/
+COPY --from=ui /app/experimenter/legacy-ui/assets/ /app/experimenter/legacy-ui/assets/
+COPY --from=ui /app/experimenter/nimbus-ui/build/ /app/experimenter/nimbus-ui/build/


### PR DESCRIPTION
Because

* We have a fourth layer in our Dockerfile that we're not remotely caching which slows down local builds/ci

This commit

* Builds and pushes the ui build target in our Dockerfile in circle