### PR TITLE
fix #6093 bug(nimbus): look up targeting config name in v5 api if valid

### DIFF
--- a/app/experimenter/experiments/api/v5/types.py
+++ b/app/experimenter/experiments/api/v5/types.py
@@ -225,6 +225,11 @@ class NimbusExperimentType(DjangoObjectType):
         ready = serializer.is_valid()
         return NimbusReadyForReviewType(message=serializer.errors, ready=ready)
 
+    def resolve_targeting_config_slug(self, info):
+        if self.targeting_config_slug in self.TargetingConfig:
+            return self.TargetingConfig(self.targeting_config_slug).name
+        return self.targeting_config_slug
+
     def resolve_jexl_targeting_expression(self, info):
         return self.targeting
 


### PR DESCRIPTION
Because

* To support deprecated targeting configs we removed the enum slug/name conversion from the targeting_config_slug field in the V5 API
* This breaks the form since it can no longer map the stored slug to the name value in the options

This commit

* Optionally returns the enum name in the V5 API if it the stored slug maps to a currently valid enum value
* Split the V5 API query tests into separate test classes by query rather than having them all mixed together