### PR TITLE
fix #6097 fix(nimbus): Position ConfidenceInterval numbers relatively

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/PageResults/ConfidenceInterval/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/ConfidenceInterval/index.stories.tsx
@@ -3,178 +3,132 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { withLinks } from "@storybook/addon-links";
-import { storiesOf } from "@storybook/react";
 import React from "react";
 import ConfidenceInterval from ".";
 import { SIGNIFICANCE } from "../../../lib/visualization/constants";
 
-storiesOf("pages/Results/ConfidenceInterval", module)
-  .addDecorator(withLinks)
-  .add("with positive significance", () => (
-    <div className="w-25">
-      <div className="w-75">
-        <ConfidenceInterval
-          upper={65}
-          lower={45}
-          range={65}
-          significance={SIGNIFICANCE.POSITIVE}
-        />
+const Subject = ({
+  ...props
+}: React.ComponentProps<typeof ConfidenceInterval>) => (
+  <ConfidenceInterval {...props} />
+);
+
+export default {
+  title: "pages/Results/ConfidenceInterval",
+  component: Subject,
+  decorators: [
+    withLinks,
+    (story: () => React.ReactNode) => (
+      <div className="w-25">
+        <div className="w-75">{story()}</div>
       </div>
-    </div>
-  ))
-  .add("with neutral significance", () => (
-    <div className="w-25">
-      <div className="w-75">
-        <ConfidenceInterval
-          upper={65}
-          lower={-45}
-          range={65}
-          significance={SIGNIFICANCE.NEUTRAL}
-        />
-      </div>
-    </div>
-  ))
-  .add("with negative significance", () => (
-    <div className="w-25">
-      <div className="w-75">
-        <ConfidenceInterval
-          upper={-45}
-          lower={-65}
-          range={65}
-          significance={SIGNIFICANCE.NEGATIVE}
-        />
-      </div>
-    </div>
-  ))
-  .add("with small positive significance", () => (
-    <div className="w-25">
-      <div className="w-75">
-        <ConfidenceInterval
-          upper={50}
-          lower={45}
-          range={50}
-          significance={SIGNIFICANCE.POSITIVE}
-        />
-      </div>
-    </div>
-  ))
-  .add("with small neutral significance", () => (
-    <div className="w-25">
-      <div className="w-75">
-        <ConfidenceInterval
-          upper={2}
-          lower={-2}
-          range={2}
-          significance={SIGNIFICANCE.NEUTRAL}
-        />
-      </div>
-    </div>
-  ))
-  .add("with small negative significance", () => (
-    <div className="w-25">
-      <div className="w-75">
-        <ConfidenceInterval
-          upper={-45}
-          lower={-50}
-          range={50}
-          significance={SIGNIFICANCE.NEGATIVE}
-        />
-      </div>
-    </div>
-  ))
-  .add("with 3-digit total bounds", () => (
-    <div className="w-25">
-      <div className="w-75">
-        <ConfidenceInterval
-          upper={100}
-          lower={-100}
-          range={100}
-          significance={SIGNIFICANCE.POSITIVE}
-        />
-      </div>
-    </div>
-  ))
-  .add("with 3-digit total bounds", () => (
-    <div className="w-25">
-      <div className="w-75">
-        <ConfidenceInterval
-          upper={15}
-          lower={9}
-          range={20}
-          significance={SIGNIFICANCE.POSITIVE}
-        />
-      </div>
-    </div>
-  ))
-  .add("with 4-digit total bounds and small significance", () => (
-    <div className="w-25">
-      <div className="w-75">
-        <ConfidenceInterval
-          upper={9.5}
-          lower={4.5}
-          range={200}
-          significance={SIGNIFICANCE.POSITIVE}
-        />
-      </div>
-    </div>
-  ))
-  .add("with 5-digit total bounds", () => (
-    <div className="w-25">
-      <div className="w-75">
-        <ConfidenceInterval
-          upper={123}
-          lower={90}
-          range={123}
-          significance={SIGNIFICANCE.POSITIVE}
-        />
-      </div>
-    </div>
-  ))
-  .add("with 6-digit total bounds and small significance", () => (
-    <div className="w-25">
-      <div className="w-75">
-        <ConfidenceInterval
-          upper={123}
-          lower={90.5}
-          range={1234}
-          significance={SIGNIFICANCE.POSITIVE}
-        />
-      </div>
-    </div>
-  ))
-  .add("with 10-digit total bounds", () => (
-    <div className="w-25">
-      <div className="w-75">
-        <ConfidenceInterval
-          upper={9999.9}
-          lower={3333.3}
-          range={9999.9}
-          significance={SIGNIFICANCE.POSITIVE}
-        />
-      </div>
-    </div>
-  ))
-  .add("with 10-digit total bounds and small significance", () => (
-    <div className="w-25">
-      <div className="w-75">
-        <ConfidenceInterval
-          upper={1234.5}
-          lower={1100.5}
-          range={1234.5}
-          significance={SIGNIFICANCE.POSITIVE}
-        />
-      </div>
-    </div>
-  ))
-  .add("with 12-digit total bounds", () => (
-    <div className="w-25">
-      <div className="w-75">
-        <ConfidenceInterval
-          upper={64858.6}
-          lower={11854.4}
-          range={64858.6}
-          significance={SIGNIFICANCE.POSITIVE}
-        />
-      </div>
-    </div>
-  ));
+    ),
+  ],
+};
+
+const storyWithProps = (
+  props: React.ComponentProps<typeof Subject>,
+  storyName?: string,
+) => {
+  const story = () => <Subject {...props} />;
+  if (storyName) story.storyName = storyName;
+  return story;
+};
+
+export const WithPositiveSignificance = storyWithProps({
+  upper: 65,
+  lower: 25,
+  range: 65,
+  significance: SIGNIFICANCE.POSITIVE,
+});
+
+export const WithNeutralSignificance = storyWithProps({
+  upper: 65,
+  lower: -45,
+  range: 65,
+  significance: SIGNIFICANCE.NEUTRAL,
+});
+
+export const WithNegativeSignificance = storyWithProps({
+  upper: 65,
+  lower: -45,
+  range: 65,
+  significance: SIGNIFICANCE.NEGATIVE,
+});
+
+export const WithSmallPositiveSignificance = storyWithProps({
+  upper: 50,
+  lower: 45,
+  range: 50,
+  significance: SIGNIFICANCE.POSITIVE,
+});
+
+export const WithSmallNeturalSignificance = storyWithProps({
+  upper: 50,
+  lower: 45,
+  range: 50,
+  significance: SIGNIFICANCE.NEUTRAL,
+});
+
+export const With3DigitBounds = storyWithProps({
+  upper: 15,
+  lower: 9,
+  range: 20,
+  significance: SIGNIFICANCE.POSITIVE,
+});
+
+export const With4DigitBoundsAndSmallNegativeSignificance = storyWithProps({
+  upper: -8,
+  lower: -11.8,
+  range: 80,
+  significance: SIGNIFICANCE.NEGATIVE,
+});
+
+export const With4DigitBoundsAndPositiveSignificance = storyWithProps({
+  upper: 123,
+  lower: 90,
+  range: 123,
+  significance: SIGNIFICANCE.POSITIVE,
+});
+
+export const With5DigitBoundsAndSmallNeutralSignificance = storyWithProps({
+  upper: -10.9,
+  lower: -15.1,
+  range: 15.1,
+  significance: SIGNIFICANCE.NEUTRAL,
+});
+
+export const With6DigitBoundsAndSmallPositiveSignificance = storyWithProps({
+  upper: 123,
+  lower: 90.5,
+  range: 123,
+  significance: SIGNIFICANCE.POSITIVE,
+});
+
+export const With8DigitBoundsAndPositiveSignificance = storyWithProps({
+  upper: 1000,
+  lower: 500.5,
+  range: 1200,
+  significance: SIGNIFICANCE.POSITIVE,
+});
+
+export const With10DigitBoundsAndSmallPositiveSignificance = storyWithProps({
+  upper: 1234.5,
+  lower: 1100.5,
+  range: 1234.5,
+  significance: SIGNIFICANCE.POSITIVE,
+});
+
+export const With10DigitBoundsAndLargeNegativeSignificance = storyWithProps({
+  upper: -1000.5,
+  lower: -7000,
+  range: 7000,
+  significance: SIGNIFICANCE.NEGATIVE,
+});
+
+export const With12DigitBounds = storyWithProps({
+  upper: 64858.6,
+  lower: 11854.4,
+  range: 64858.6,
+  significance: SIGNIFICANCE.POSITIVE,
+});

--- a/app/experimenter/nimbus-ui/src/components/PageResults/ConfidenceInterval/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/ConfidenceInterval/index.tsx
@@ -15,31 +15,30 @@ const renderBounds = (
   leftPercent: number,
   barWidth: number,
   significance: string,
-  buffer: number,
 ) => {
+  const numberOfDigits =
+    Math.abs(upper).toString().replace(".", "").length +
+    Math.abs(lower).toString().replace(".", "").length;
+
   if (barWidth < MIN_BOUNDS_WIDTH) {
     leftPercent -= (MIN_BOUNDS_WIDTH - barWidth) / 2;
   }
 
   return (
     <div
-      className="position-absolute"
+      className="position-absolute d-flex justify-content-between"
       style={{
-        // Add some buffer to space out the rendered bound values.
-        left: `${leftPercent - buffer * 1.5}%`,
-        width: `${Math.max(barWidth, MIN_BOUNDS_WIDTH) + buffer * 3}%`,
+        left: `${leftPercent - numberOfDigits * 1.5}%`,
+        width: `${Math.max(barWidth, MIN_BOUNDS_WIDTH) + numberOfDigits * 3}%`,
       }}
     >
-      <div
-        className={`${significance}-significance text-left p-0 h6 font-weight-normal position-absolute`}
-      >
+      <span className={`${significance}-significance h6 font-weight-normal`}>
         {lower}%
-      </div>
-      <div
-        className={`${significance}-significance text-right p-0 h6 font-weight-normal`}
-      >
+      </span>
+      &nbsp;&nbsp;&nbsp;
+      <span className={`${significance}-significance h6 font-weight-normal`}>
         {upper}%
-      </div>
+      </span>
     </div>
   );
 };
@@ -67,15 +66,6 @@ const ConfidenceInterval: React.FC<{
   range: number;
   significance: string;
 }> = ({ upper, lower, range, significance }) => {
-  // number of total digits
-  let buffer =
-    Math.abs(upper).toString().replace(".", "").length +
-    Math.abs(lower).toString().replace(".", "").length;
-  // give additional buffer if there's 4+ digits and a small significance
-  if (buffer >= 4 && lower / upper > 0.5) {
-    buffer += (lower / upper) * 2;
-  }
-  range += buffer;
   const fullWidth = range * 2;
   const barWidth = ((upper - lower) / fullWidth) * 100;
   const leftPercent = (Math.abs(lower - range * -1) / fullWidth) * 100;
@@ -86,7 +76,6 @@ const ConfidenceInterval: React.FC<{
     leftPercent,
     barWidth,
     significance,
-    buffer,
   );
   const line = renderLine(leftPercent, barWidth, significance);
 

--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableVisualizationRow/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableVisualizationRow/index.tsx
@@ -279,7 +279,7 @@ const TableVisualizationRow: React.FC<{
       // Total number of users is present in the absolute branch comparison data. This displays
       // that number on the results table even if comparison is to the relative uplift.
     } else if (
-      tableLabel == TABLE_LABEL.RESULTS &&
+      tableLabel === TABLE_LABEL.RESULTS &&
       branchComparison === BRANCH_COMPARISON.UPLIFT &&
       displayType === DISPLAY_TYPE.POPULATION
     ) {


### PR DESCRIPTION
fixes #6097

Because:
* The previous fix for overlapping numbers was causing other wonky edgecases

This commit:
* Tweaks the ConfidenceInterval to position numbers relatively instead of absolute with non-breaking spaces to account for small significances so they'll never be squished