### PR TITLE
fix #6039 fix(nimbus): Display warning for polling error, allow query refetch with useRefetchOnError hook

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/App/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/App/index.tsx
@@ -6,7 +6,7 @@ import { useQuery } from "@apollo/client";
 import { Redirect, RouteComponentProps, Router } from "@reach/router";
 import React from "react";
 import { GET_CONFIG_QUERY } from "../../gql/config";
-import ApolloErrorAlert from "../ApolloErrorAlert";
+import { useRefetchOnError } from "../../hooks";
 import PageEditAudience from "../PageEditAudience";
 import PageEditBranches from "../PageEditBranches";
 import PageEditMetrics from "../PageEditMetrics";
@@ -24,14 +24,15 @@ type RootProps = {
 const Root = (props: RootProps) => <>{props.children}</>;
 
 const App = ({ basepath }: { basepath: string }) => {
-  const { loading, error } = useQuery(GET_CONFIG_QUERY);
+  const { loading, error, refetch } = useQuery(GET_CONFIG_QUERY);
+  const ErrorAlert = useRefetchOnError(error, refetch, "mt-0");
 
   if (loading) {
     return <PageLoading />;
   }
 
   if (error) {
-    return <ApolloErrorAlert {...{ error }} />;
+    return ErrorAlert;
   }
 
   return (

--- a/app/experimenter/nimbus-ui/src/components/AppLayoutWithExperiment/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/AppLayoutWithExperiment/index.stories.tsx
@@ -3,9 +3,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { withLinks } from "@storybook/addon-links";
-import { storiesOf } from "@storybook/react";
 import React from "react";
-import AppLayoutWithExperiment from ".";
+import AppLayoutWithExperiment, { AppLayoutWithExperimentProps } from ".";
 import { mockExperimentQuery } from "../../lib/mocks";
 import { RouterSlugProvider } from "../../lib/test-utils";
 import {
@@ -13,63 +12,61 @@ import {
   NimbusExperimentStatus,
 } from "../../types/globalTypes";
 
-storiesOf("components/AppLayoutWithExperiment", module)
-  .addDecorator(withLinks)
-  .add("status: draft", () => {
-    const { mock } = mockExperimentQuery("demo-slug");
-    return (
-      <RouterSlugProvider mocks={[mock]}>
-        <AppLayoutWithExperiment
-          title="Howdy!"
-          testId="AppLayoutWithExperiment"
-        >
-          {({ experiment }) => <p>{experiment.name}</p>}
-        </AppLayoutWithExperiment>
-      </RouterSlugProvider>
-    );
-  })
-  .add("status: preview", () => {
-    const { mock } = mockExperimentQuery("demo-slug", {
-      status: NimbusExperimentStatus.PREVIEW,
-    });
-    return (
-      <RouterSlugProvider mocks={[mock]}>
-        <AppLayoutWithExperiment
-          title="Howdy!"
-          testId="AppLayoutWithExperiment"
-        >
-          {({ experiment }) => <p>{experiment.name}</p>}
-        </AppLayoutWithExperiment>
-      </RouterSlugProvider>
-    );
-  })
-  .add('status: launched ("live" or "complete")', () => {
-    const { mock } = mockExperimentQuery("demo-slug", {
-      status: NimbusExperimentStatus.LIVE,
-    });
-    return (
-      <RouterSlugProvider mocks={[mock]}>
-        <AppLayoutWithExperiment
-          title="Howdy!"
-          testId="AppLayoutWithExperiment"
-        >
-          {({ experiment }) => <p>{experiment.name}</p>}
-        </AppLayoutWithExperiment>
-      </RouterSlugProvider>
-    );
-  })
-  .add("publish status: review", () => {
-    const { mock } = mockExperimentQuery("demo-slug", {
-      publishStatus: NimbusExperimentPublishStatus.REVIEW,
-    });
-    return (
-      <RouterSlugProvider mocks={[mock]}>
-        <AppLayoutWithExperiment
-          title="Howdy!"
-          testId="AppLayoutWithExperiment"
-        >
-          {({ experiment }) => <p>{experiment.name}</p>}
-        </AppLayoutWithExperiment>
-      </RouterSlugProvider>
-    );
-  });
+const Subject = ({
+  ...props
+}: Omit<AppLayoutWithExperimentProps, "children">) => (
+  <AppLayoutWithExperiment title="Howdy!" {...props}>
+    {({ experiment }) => <p>{experiment.name}</p>}
+  </AppLayoutWithExperiment>
+);
+
+export default {
+  title: "components/AppLayoutWithExperiment",
+  component: Subject,
+  decorators: [withLinks],
+};
+
+const storyWithProps = (
+  { mock } = mockExperimentQuery("demo-slug"),
+  props: React.ComponentProps<typeof Subject> = {},
+  storyName?: string,
+) => {
+  const story = () => (
+    <RouterSlugProvider mocks={[mock]}>
+      <Subject {...props} />
+    </RouterSlugProvider>
+  );
+  if (storyName) story.storyName = storyName;
+  return story;
+};
+
+export const StatusDraft = storyWithProps();
+
+export const StatusPreview = storyWithProps(
+  mockExperimentQuery("demo-slug", {
+    status: NimbusExperimentStatus.PREVIEW,
+  }),
+);
+
+export const StatusLaunched = storyWithProps(
+  mockExperimentQuery("demo-slug", {
+    status: NimbusExperimentStatus.LIVE,
+  }),
+  {},
+  'Status: Launched ("Live" or "Complete")',
+);
+
+export const PublishStatusReview = storyWithProps(
+  mockExperimentQuery("demo-slug", {
+    publishStatus: NimbusExperimentPublishStatus.REVIEW,
+  }),
+);
+
+export const PollingError = storyWithProps(
+  mockExperimentQuery("demo-slug"),
+  {
+    polling: true,
+    pollInterval: 2000,
+  },
+  "Polling error (wait 2 seconds)",
+);

--- a/app/experimenter/nimbus-ui/src/components/PageHome/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageHome/index.stories.tsx
@@ -5,7 +5,7 @@
 import { withLinks } from "@storybook/addon-links";
 import React from "react";
 import PageHome from ".";
-import { mockDirectoryExperimentsQuery } from "../../lib/mocks";
+import { mockDirectoryExperimentsQuery, MockedCache } from "../../lib/mocks";
 import { CurrentLocation, RouterSlugProvider } from "../../lib/test-utils";
 import { NimbusExperimentStatus } from "../../types/globalTypes";
 
@@ -40,6 +40,20 @@ const storyTemplate = (mocks: StoryContext["args"]["mocks"]) => {
 export const Basic = storyTemplate([mockDirectoryExperimentsQuery()]);
 
 export const Loading = storyTemplate([]);
+
+export const QueryError = () => {
+  const mockWithError = {
+    ...mockDirectoryExperimentsQuery(),
+    error: new Error("boop, something's actually wrong"),
+  };
+  return (
+    <MockedCache mocks={[mockWithError, mockWithError]}>
+      <PageHome />
+    </MockedCache>
+  );
+};
+QueryError.storyName =
+  "Error on fetch with error after refetch (wait 5 seconds)";
 
 export const NoExperiments = storyTemplate([mockDirectoryExperimentsQuery([])]);
 

--- a/app/experimenter/nimbus-ui/src/components/PageHome/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageHome/index.test.tsx
@@ -10,9 +10,14 @@ import {
   waitFor,
   waitForElementToBeRemoved,
 } from "@testing-library/react";
+import { act } from "@testing-library/react-hooks";
 import React from "react";
 import PageHome from ".";
-import { mockDirectoryExperimentsQuery } from "../../lib/mocks";
+import { REFETCH_DELAY } from "../../hooks";
+import {
+  mockDirectoryExperiments,
+  mockDirectoryExperimentsQuery,
+} from "../../lib/mocks";
 import { CurrentLocation, RouterSlugProvider } from "../../lib/test-utils";
 import { getAllExperiments_experiments } from "../../types/getAllExperiments";
 
@@ -34,20 +39,9 @@ describe("PageHome", () => {
     expect(screen.queryByTestId("page-loading")).toBeInTheDocument();
   });
 
-  it("displays loading when experiments are still loading", async () => {
+  it("displays no experiments text when none are found", async () => {
     await renderAndWaitForLoaded([]);
     expect(screen.queryByText("No experiments found.")).toBeInTheDocument();
-  });
-
-  it("renders the error alert when an error occurs", () => {
-    const error = new Error("You done it now!");
-
-    (jest.spyOn(apollo, "useQuery") as jest.Mock).mockReturnValueOnce({
-      error,
-    });
-
-    render(<Subject />);
-    expect(screen.queryByTestId("apollo-error-alert")).toBeInTheDocument();
   });
 
   const findTabs = () =>
@@ -78,6 +72,36 @@ describe("PageHome", () => {
         );
       });
     }
+  });
+
+  it("renders the error warning and refetches when an error occurs querying experiments", async () => {
+    jest.useFakeTimers();
+    const experiments = mockDirectoryExperiments();
+    const mock = mockDirectoryExperimentsQuery(experiments);
+    const mockWithError = { ...mock, error: new Error("boop") };
+
+    render(
+      <RouterSlugProvider mocks={[mockWithError, mock]}>
+        <>
+          <CurrentLocation />
+          <PageHome {...{ experiments }} />
+        </>
+      </RouterSlugProvider>,
+    );
+
+    await screen.findByTestId("refetch-alert");
+    expect(
+      screen.queryByText("5 seconds", { exact: false }),
+    ).toBeInTheDocument();
+
+    act(() => {
+      jest.advanceTimersByTime(REFETCH_DELAY);
+    });
+
+    // error is hidden when refetching works as expected
+    await screen.findByText("Draft (3)");
+    expect(screen.queryByTestId("refetch-alert")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("apollo-error-alert")).not.toBeInTheDocument();
   });
 });
 

--- a/app/experimenter/nimbus-ui/src/components/PageHome/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageHome/index.tsx
@@ -7,9 +7,8 @@ import { Link, RouteComponentProps } from "@reach/router";
 import React, { useCallback } from "react";
 import { Alert, Tab, Tabs } from "react-bootstrap";
 import { GET_EXPERIMENTS_QUERY } from "../../gql/experiments";
-import { useSearchParamsState } from "../../hooks";
+import { useRefetchOnError, useSearchParamsState } from "../../hooks";
 import { getAllExperiments_experiments } from "../../types/getAllExperiments";
-import ApolloErrorAlert from "../ApolloErrorAlert";
 import AppLayout from "../AppLayout";
 import Head from "../Head";
 import LinkExternal from "../LinkExternal";
@@ -25,9 +24,10 @@ type PageHomeProps = Record<string, any> & RouteComponentProps;
 
 export const Body = () => {
   const [searchParams, updateSearchParams] = useSearchParamsState();
-  const { data, loading, error } = useQuery<{
+  const { data, loading, error, refetch } = useQuery<{
     experiments: getAllExperiments_experiments[];
   }>(GET_EXPERIMENTS_QUERY);
+  const ErrorAlert = useRefetchOnError(error, refetch);
 
   const selectedTab = searchParams.get("tab") || "live";
   const onSelectTab = useCallback(
@@ -40,7 +40,7 @@ export const Body = () => {
   }
 
   if (error) {
-    return <ApolloErrorAlert {...{ error }} />;
+    return ErrorAlert;
   }
 
   if (!data) {

--- a/app/experimenter/nimbus-ui/src/components/RefetchAlert/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/RefetchAlert/index.stories.tsx
@@ -1,0 +1,13 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from "react";
+import RefetchAlert from ".";
+
+export default {
+  title: "components/RefetchAlert",
+  component: RefetchAlert,
+};
+
+export const Basic = () => <RefetchAlert />;

--- a/app/experimenter/nimbus-ui/src/components/RefetchAlert/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/RefetchAlert/index.tsx
@@ -1,0 +1,23 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from "react";
+import { Alert } from "react-bootstrap";
+import { REFETCH_DELAY } from "../../hooks/useRefetchOnError";
+
+export const RefetchAlert = ({ className = "mt-4" }) => (
+  <Alert variant="warning" data-testid="refetch-alert" {...{ className }}>
+    <Alert.Heading>Fetch Error</Alert.Heading>
+    <p>
+      An error occured.{" "}
+      <b>This usually happens when Experimenter is mid-deploy.</b>
+    </p>
+    <p>
+      Refetching will occur one time automatically in {REFETCH_DELAY / 1000}{" "}
+      seconds.
+    </p>
+  </Alert>
+);
+
+export default RefetchAlert;

--- a/app/experimenter/nimbus-ui/src/hooks/index.ts
+++ b/app/experimenter/nimbus-ui/src/hooks/index.ts
@@ -12,5 +12,6 @@ export * from "./useExitWarning";
 export * from "./useExperiment";
 export * from "./useFakeMutation";
 export * from "./useOutcomes";
+export * from "./useRefetchOnError";
 export * from "./useReviewCheck";
 export * from "./useSearchParamsState";

--- a/app/experimenter/nimbus-ui/src/hooks/useRefetchOnError/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/hooks/useRefetchOnError/index.stories.tsx
@@ -1,0 +1,14 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from "react";
+import Subject from "./mocks";
+
+export default {
+  title: "hooks/useRefetchOnError",
+  component: Subject,
+};
+
+export const SingleError = () => <Subject />;
+export const ErrorAndRefetchError = () => <Subject noValidQueries />;

--- a/app/experimenter/nimbus-ui/src/hooks/useRefetchOnError/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/hooks/useRefetchOnError/index.test.tsx
@@ -1,0 +1,30 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { act, render, screen } from "@testing-library/react";
+import React from "react";
+import { REFETCH_DELAY } from ".";
+import Subject from "./mocks";
+
+describe("useRefetchOnError", () => {
+  it("returns RefetchAlert, then returns ApolloErrorAlert when an error occurs after refetch", async () => {
+    render(<Subject noValidQueries />);
+    await screen.findByTestId("refetch-alert");
+    act(() => {
+      jest.advanceTimersByTime(REFETCH_DELAY);
+    });
+    await screen.findByTestId("apollo-error-alert");
+  });
+
+  it("returns RefetchAlert, then renders expected content on success", async () => {
+    render(<Subject />);
+    await screen.findByTestId("refetch-alert");
+    act(() => {
+      jest.advanceTimersByTime(REFETCH_DELAY);
+    });
+    await screen.findByText("No errors!");
+  });
+});
+
+jest.useFakeTimers();

--- a/app/experimenter/nimbus-ui/src/hooks/useRefetchOnError/index.tsx
+++ b/app/experimenter/nimbus-ui/src/hooks/useRefetchOnError/index.tsx
@@ -1,0 +1,34 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { ApolloError, ApolloQueryResult } from "@apollo/client";
+import React, { ReactElement, useEffect, useState } from "react";
+import ApolloErrorAlert from "../../components/ApolloErrorAlert";
+import RefetchAlert from "../../components/RefetchAlert";
+
+export const REFETCH_DELAY = 5000;
+
+export const useRefetchOnError = (
+  error: ApolloError | undefined,
+  refetch: () => Promise<ApolloQueryResult<any>>,
+  refetchAlertClass = "",
+) => {
+  const [hasRefetched, setHasRefetched] = useState<boolean>(false);
+  const [ReactEl, setReactEl] = useState<ReactElement>(<></>);
+  useEffect(() => {
+    if (!error) return;
+    if (!hasRefetched) {
+      const timeout = setTimeout(() => {
+        refetch();
+        setHasRefetched(true);
+      }, REFETCH_DELAY);
+      setReactEl(<RefetchAlert className={refetchAlertClass} />);
+      // abort on component unmount (if users navigate before setTimeout completes)
+      return () => clearTimeout(timeout);
+    }
+    setReactEl(<ApolloErrorAlert {...{ error }} />);
+  }, [error, hasRefetched]);
+
+  return ReactEl;
+};

--- a/app/experimenter/nimbus-ui/src/hooks/useRefetchOnError/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/hooks/useRefetchOnError/mocks.tsx
@@ -1,0 +1,37 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from "react";
+import { useRefetchOnError } from ".";
+import { mockExperimentQuery } from "../../lib/mocks";
+import { RouterSlugProvider } from "../../lib/test-utils";
+import { useExperiment } from "../useExperiment";
+
+const ComponentWithHook = () => {
+  // this works with any GQL query, we just need to provide one with mocks for testing
+  const { error, refetch } = useExperiment("demo-slug");
+  const ErrorAlert = useRefetchOnError(error, refetch);
+
+  if (error) {
+    return ErrorAlert;
+  }
+  return <p>No errors!</p>;
+};
+
+export const Subject = ({ noValidQueries = false }) => {
+  const { mock } = mockExperimentQuery("demo-slug");
+  const mockWithError = {
+    ...mock,
+    error: new Error("boop, something's actually wrong"),
+  };
+  const secondMock = noValidQueries ? mockWithError : mock;
+
+  return (
+    <RouterSlugProvider mocks={[mockWithError, secondMock]}>
+      <ComponentWithHook />
+    </RouterSlugProvider>
+  );
+};
+
+export default Subject;


### PR DESCRIPTION
fixes #6039 

Because:
* When a polling error occurs, users are seeing the Apollo error alert on the entire page, and showing an alert is preferred since this error can happen when Experimenter is in mid-deploy
* Users are also sometimes seeing an error on the Home page that goes away after refresh, likely also due to Experimenter mid-deploy

This commit:
* Checks in AppLayoutWithExperiment for an apollo error after experiment data is present, signalling a polling error, and displays a warning-style alert above the rest of the page rather than only an alert. Polling is retried after the pollInterval passes.
* Adds useRefetchOnError hook and implements it on PageHome and App to cover getAllExperiments and the config query. This displays a warning-style alert informing the user the query will be retries, retries the query after a settimeout (5 seconds), and returns the Apollo error alert if an error occurs again
* Refactors AppLayoutWithExperiment stories and gives the component a default testId, adds tests for both pages