### PR TITLE
fix #5698 feat(nimbus): disable locale/country for fenix/ios

### DIFF
--- a/app/experimenter/experiments/constants/nimbus.py
+++ b/app/experimenter/experiments/constants/nimbus.py
@@ -27,6 +27,7 @@ class ApplicationConfig:
     default_app_id: str
     rs_experiments_collection: str
     randomization_unit: str
+    supports_locale_country: bool
 
 
 APPLICATION_CONFIG_DESKTOP = ApplicationConfig(
@@ -43,6 +44,7 @@ APPLICATION_CONFIG_DESKTOP = ApplicationConfig(
     default_app_id="firefox-desktop",
     rs_experiments_collection=settings.KINTO_COLLECTION_NIMBUS_DESKTOP,
     randomization_unit=BucketRandomizationUnit.NORMANDY,
+    supports_locale_country=True,
 )
 
 APPLICATION_CONFIG_FENIX = ApplicationConfig(
@@ -57,6 +59,7 @@ APPLICATION_CONFIG_FENIX = ApplicationConfig(
     default_app_id="",
     rs_experiments_collection=settings.KINTO_COLLECTION_NIMBUS_MOBILE,
     randomization_unit=BucketRandomizationUnit.NIMBUS,
+    supports_locale_country=False,
 )
 
 APPLICATION_CONFIG_IOS = ApplicationConfig(
@@ -71,6 +74,7 @@ APPLICATION_CONFIG_IOS = ApplicationConfig(
     default_app_id="",
     rs_experiments_collection=settings.KINTO_COLLECTION_NIMBUS_MOBILE,
     randomization_unit=BucketRandomizationUnit.NIMBUS,
+    supports_locale_country=False,
 )
 
 

--- a/app/experimenter/experiments/tests/api/v5/test_queries.py
+++ b/app/experimenter/experiments/tests/api/v5/test_queries.py
@@ -766,12 +766,13 @@ class TestNimbusConfigQuery(GraphQLTestCase):
                         label
                         value
                     }
-                    applicationChannels {
+                    applicationConfigs {
                         application
                         channels {
                             label
                             value
                         }
+                        supportsLocaleCountry
                     }
                     firefoxMinVersion {
                         label
@@ -829,16 +830,22 @@ class TestNimbusConfigQuery(GraphQLTestCase):
         assertChoices(config["documentationLink"], NimbusExperiment.DocumentationLink)
         self.assertEqual(len(config["featureConfig"]), 13)
 
-        for application_channels in config["applicationChannels"]:
+        for application_config_data in config["applicationConfigs"]:
             application_config = NimbusExperiment.APPLICATION_CONFIGS[
-                NimbusExperiment.Application[application_channels["application"]]
+                NimbusExperiment.Application[application_config_data["application"]]
             ]
-            channels = [channel["value"] for channel in application_channels["channels"]]
+            channels = [
+                channel["value"] for channel in application_config_data["channels"]
+            ]
             self.assertEqual(
                 set(channels),
                 set(
                     [channel.name for channel in application_config.channel_app_id.keys()]
                 ),
+            )
+            self.assertEqual(
+                application_config_data["supportsLocaleCountry"],
+                application_config.supports_locale_country,
             )
 
         for outcome in Outcomes.all():

--- a/app/experimenter/nimbus-ui/schema.graphql
+++ b/app/experimenter/nimbus-ui/schema.graphql
@@ -129,7 +129,7 @@ type NimbusChangeLogType {
 type NimbusConfigurationType {
   application: [NimbusLabelValueType]
   channel: [NimbusLabelValueType]
-  applicationChannels: [NimbusExperimentApplicationChannels]
+  applicationConfigs: [NimbusExperimentApplicationConfig]
   featureConfig: [NimbusFeatureConfigType]
   firefoxMinVersion: [NimbusLabelValueType]
   outcomes: [NimbusOutcomeType]
@@ -165,9 +165,10 @@ enum NimbusExperimentApplication {
   IOS
 }
 
-type NimbusExperimentApplicationChannels {
+type NimbusExperimentApplicationConfig {
   application: NimbusExperimentApplication
   channels: [NimbusLabelValueType]
+  supportsLocaleCountry: Boolean
 }
 
 enum NimbusExperimentChannel {

--- a/app/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/index.test.tsx
@@ -42,10 +42,11 @@ describe("FormAudience", () => {
             { label: "Nightly", value: "NIGHTLY" },
             { label: "Release", value: "RELEASE" },
           ],
-          applicationChannels: [
+          applicationConfigs: [
             {
               application: NimbusExperimentApplication.DESKTOP,
               channels: [{ label: "Nightly", value: "NIGHTLY" }],
+              supportsLocaleCountry: true,
             },
           ],
           targetingConfigSlug: [
@@ -103,6 +104,42 @@ describe("FormAudience", () => {
     expect(screen.getByTestId("countries")).toHaveTextContent(
       MOCK_EXPERIMENT.countries[0]!.name!,
     );
+  });
+
+  it("renders with disabled locale/country for applications that don't support them", async () => {
+    render(
+      <Subject
+        experiment={{
+          ...MOCK_EXPERIMENT,
+          application: NimbusExperimentApplication.DESKTOP,
+        }}
+        config={{
+          ...MOCK_CONFIG,
+          applicationConfigs: [
+            {
+              application: NimbusExperimentApplication.DESKTOP,
+              channels: [{ label: "Nightly", value: "NIGHTLY" }],
+              supportsLocaleCountry: false,
+            },
+          ],
+        }}
+      />,
+    );
+    await screen.findByTestId("FormAudience");
+    expect(screen.getByTestId("locales").querySelector("input")).toBeDisabled();
+    expect(
+      screen.getByTestId("countries").querySelector("input"),
+    ).toBeDisabled();
+    expect(
+      screen.getByText(
+        "This application does not currently support targeting by locale.",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "This application does not currently support targeting by country.",
+      ),
+    ).toBeInTheDocument();
   });
 
   it("renders server errors", async () => {

--- a/app/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/index.tsx
@@ -75,8 +75,9 @@ export const FormAudience = ({
     experiment!.countries.map((v) => "" + v.id!),
   );
 
-  const applicationConfig = config.applicationChannels?.find(
-    (application) => application?.application === experiment.application,
+  const applicationConfig = config.applicationConfigs?.find(
+    (applicationConfig) =>
+      applicationConfig?.application === experiment.application,
   );
 
   const defaultValues = {
@@ -180,7 +181,13 @@ export const FormAudience = ({
               isMulti
               {...formSelectAttrs("locales", setLocales)}
               options={selectOptions(config.locales as SelectIdItems)}
+              isDisabled={!applicationConfig?.supportsLocaleCountry}
             />
+            {!applicationConfig?.supportsLocaleCountry && (
+              <p className="text-secondary">
+                This application does not currently support targeting by locale.
+              </p>
+            )}
             <FormErrors name="locales" />
           </Form.Group>
           <Form.Group as={Col} controlId="countries" data-testid="countries">
@@ -190,7 +197,14 @@ export const FormAudience = ({
               isMulti
               {...formSelectAttrs("countries", setCountries)}
               options={selectOptions(config.countries as SelectIdItems)}
+              isDisabled={!applicationConfig?.supportsLocaleCountry}
             />
+            {!applicationConfig?.supportsLocaleCountry && (
+              <p className="text-secondary">
+                This application does not currently support targeting by
+                country.
+              </p>
+            )}
             <FormErrors name="countries" />
           </Form.Group>
         </Form.Row>

--- a/app/experimenter/nimbus-ui/src/gql/config.ts
+++ b/app/experimenter/nimbus-ui/src/gql/config.ts
@@ -15,12 +15,13 @@ export const GET_CONFIG_QUERY = gql`
         label
         value
       }
-      applicationChannels {
+      applicationConfigs {
         application
         channels {
           label
           value
         }
+        supportsLocaleCountry
       }
       featureConfig {
         id

--- a/app/experimenter/nimbus-ui/src/lib/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/lib/mocks.tsx
@@ -82,7 +82,7 @@ export const MOCK_CONFIG: getConfig_nimbusConfig = {
       value: "PLATYPUS_DOORSTOP",
     },
   ],
-  applicationChannels: [
+  applicationConfigs: [
     {
       application: NimbusExperimentApplication.DESKTOP,
       channels: [
@@ -99,6 +99,7 @@ export const MOCK_CONFIG: getConfig_nimbusConfig = {
           value: "PLATYPUS_DOORSTOP",
         },
       ],
+      supportsLocaleCountry: true,
     },
     {
       application: NimbusExperimentApplication.FENIX,
@@ -116,6 +117,7 @@ export const MOCK_CONFIG: getConfig_nimbusConfig = {
           value: "PLATYPUS_DOORSTOP",
         },
       ],
+      supportsLocaleCountry: false,
     },
     {
       application: NimbusExperimentApplication.IOS,
@@ -133,6 +135,7 @@ export const MOCK_CONFIG: getConfig_nimbusConfig = {
           value: "PLATYPUS_DOORSTOP",
         },
       ],
+      supportsLocaleCountry: false,
     },
   ],
   featureConfig: [

--- a/app/experimenter/nimbus-ui/src/types/getConfig.ts
+++ b/app/experimenter/nimbus-ui/src/types/getConfig.ts
@@ -19,14 +19,15 @@ export interface getConfig_nimbusConfig_channel {
   value: string | null;
 }
 
-export interface getConfig_nimbusConfig_applicationChannels_channels {
+export interface getConfig_nimbusConfig_applicationConfigs_channels {
   label: string | null;
   value: string | null;
 }
 
-export interface getConfig_nimbusConfig_applicationChannels {
+export interface getConfig_nimbusConfig_applicationConfigs {
   application: NimbusExperimentApplication | null;
-  channels: (getConfig_nimbusConfig_applicationChannels_channels | null)[] | null;
+  channels: (getConfig_nimbusConfig_applicationConfigs_channels | null)[] | null;
+  supportsLocaleCountry: boolean | null;
 }
 
 export interface getConfig_nimbusConfig_featureConfig {
@@ -83,7 +84,7 @@ export interface getConfig_nimbusConfig_countries {
 export interface getConfig_nimbusConfig {
   application: (getConfig_nimbusConfig_application | null)[] | null;
   channel: (getConfig_nimbusConfig_channel | null)[] | null;
-  applicationChannels: (getConfig_nimbusConfig_applicationChannels | null)[] | null;
+  applicationConfigs: (getConfig_nimbusConfig_applicationConfigs | null)[] | null;
   featureConfig: (getConfig_nimbusConfig_featureConfig | null)[] | null;
   firefoxMinVersion: (getConfig_nimbusConfig_firefoxMinVersion | null)[] | null;
   outcomes: (getConfig_nimbusConfig_outcomes | null)[] | null;


### PR DESCRIPTION
Because

* Fenix/iOS do not currently support locale/country filtering

This commit

* Disables the locale/country inputs for fenix/ios

![Screenshot 2021-08-03 at 16-43-06 fenix – Audience Experimenter](https://user-images.githubusercontent.com/119884/128087293-73a78555-905b-4161-a115-9718e0ed36a4.png)
