### PR TITLE
fix #5958 feat(nimbus): directory view filters

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/PageHome/DirectoryTable/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageHome/DirectoryTable/index.test.tsx
@@ -176,6 +176,7 @@ describe("DirectoryTable", () => {
   });
 
   // TODO: not exhaustively testing all sort orders here, might be worth adding more?
+  // Sorting is more fully covered in lib/experiment.test.ts
   it("supports sorting by name", async () => {
     const experiments = mockDirectoryExperiments();
     const experimentNames = experiments.map((experiment) => experiment.name);

--- a/app/experimenter/nimbus-ui/src/components/PageHome/FilterBar/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageHome/FilterBar/index.stories.tsx
@@ -1,0 +1,25 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from "react";
+import FilterBar from ".";
+import { EVERYTHING_SELECTED_VALUE, Subject } from "../mocks";
+
+const withPadding = (Story: React.FC) => (
+  <div className="p-3">
+    <Story />
+  </div>
+);
+
+export default {
+  title: "pages/Home/FilterBar",
+  component: FilterBar,
+  decorators: [withPadding],
+};
+
+export const NothingSelected = () => <Subject />;
+
+export const EverythingSelected = () => (
+  <Subject value={EVERYTHING_SELECTED_VALUE} />
+);

--- a/app/experimenter/nimbus-ui/src/components/PageHome/FilterBar/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageHome/FilterBar/index.test.tsx
@@ -1,0 +1,13 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { render } from "@testing-library/react";
+import React from "react";
+import { EVERYTHING_SELECTED_VALUE, Subject } from "../mocks";
+
+describe("FilterBar", () => {
+  it("renders as expected", () => {
+    render(<Subject value={EVERYTHING_SELECTED_VALUE} />);
+  });
+});

--- a/app/experimenter/nimbus-ui/src/components/PageHome/FilterBar/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageHome/FilterBar/index.tsx
@@ -1,0 +1,133 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React, { useMemo } from "react";
+import Nav from "react-bootstrap/Nav";
+import Navbar from "react-bootstrap/Navbar";
+import Select, { OptionsType, OptionTypeBase } from "react-select";
+import { NullableObjectArray } from "../../../lib/types";
+import { FilterOptions, FilterValue } from "../types";
+
+export type FilterBarProps = {
+  options: FilterOptions;
+  value: FilterValue;
+  onChange: (value: FilterValue) => void;
+};
+
+export const FilterBar: React.FC<FilterBarProps> = ({
+  options,
+  value: filterValue,
+  onChange,
+}) => {
+  return (
+    <Navbar variant="light" bg="light" className="nav-fill mt-4 mb-4">
+      <Nav className="w-100">
+        <FilterSelect
+          fieldLabel="Feature"
+          fieldOptions={options.featureConfig!}
+          filterValueName="featureConfig"
+          optionLabelName="name"
+          optionValueName="slug"
+          {...{ filterValue, onChange }}
+        />
+        <FilterSelect
+          fieldLabel="Application"
+          fieldOptions={options.application!}
+          filterValueName="application"
+          optionLabelName="label"
+          optionValueName="value"
+          {...{ filterValue, onChange }}
+        />
+        <FilterSelect
+          fieldLabel="Owner"
+          fieldOptions={options.owners!}
+          filterValueName="owners"
+          optionLabelName="username"
+          optionValueName="username"
+          {...{ filterValue, onChange }}
+        />
+        <FilterSelect
+          fieldLabel="Version"
+          fieldOptions={options.firefoxMinVersion!}
+          filterValueName="firefoxMinVersion"
+          optionLabelName="label"
+          optionValueName="value"
+          {...{ filterValue, onChange }}
+        />
+      </Nav>
+    </Navbar>
+  );
+};
+
+type FilterSelectProps<T extends NullableObjectArray> = {
+  filterValue: FilterValue;
+  onChange: (value: FilterValue) => void;
+  filterValueName: keyof FilterOptions;
+  fieldLabel: string;
+  fieldOptions: T;
+  optionLabelName: keyof NonNullable<T[number]>;
+  optionValueName: keyof NonNullable<T[number]>;
+};
+
+const FilterSelect = <T extends NullableObjectArray>({
+  filterValue,
+  onChange,
+  filterValueName,
+  fieldLabel,
+  fieldOptions,
+  optionLabelName,
+  optionValueName,
+}: FilterSelectProps<T>) => {
+  const filterOptions = useMemo(
+    () =>
+      fieldOptions.filter(
+        (option): option is NonNullable<T[number]> => option !== null,
+      ),
+    [fieldOptions],
+  );
+  const fieldValue = filterValue[filterValueName];
+  const selectedOptions = useMemo(
+    () =>
+      filterOptions.filter(
+        (option) =>
+          typeof option[optionValueName] === "string" &&
+          fieldValue?.includes("" + option[optionValueName]),
+      ),
+    [fieldValue, filterOptions],
+  );
+
+  return (
+    <Nav.Item
+      className="m-1 text-left flex-grow-1 flex-shrink-1"
+      style={{ flexBasis: "0px" }}
+    >
+      <label className="ml-1 mr-1" htmlFor={`filter-${filterValueName}`}>
+        {fieldLabel}
+      </label>
+      <Select
+        {...{
+          name: `filter-${filterValueName}`,
+          inputId: `filter-${filterValueName}`,
+          isMulti: true,
+          value: selectedOptions,
+          getOptionLabel: (item: OptionTypeBase) =>
+            item[optionLabelName as string],
+          getOptionValue: (item: OptionTypeBase) =>
+            item[optionValueName as string],
+          options: filterOptions,
+          onChange: (fieldValue: OptionsType<OptionTypeBase>) => {
+            onChange({
+              ...filterValue,
+              [filterValueName]: fieldValue.map(
+                (item) => item[optionValueName as string],
+              ),
+            });
+          },
+        }}
+      />
+    </Nav.Item>
+  );
+};
+
+export default FilterBar;

--- a/app/experimenter/nimbus-ui/src/components/PageHome/filterExperiments.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageHome/filterExperiments.test.tsx
@@ -1,0 +1,71 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { getAllExperiments_experiments } from "../../types/getAllExperiments";
+import filterExperiments, {
+  getFilterValueFromParams,
+  updateParamsFromFilterValue,
+} from "./filterExperiments";
+import { EVERYTHING_SELECTED_VALUE, MOCK_EXPERIMENTS } from "./mocks";
+import { FilterValue } from "./types";
+
+const MOCK_FILTER_VALUE: FilterValue = {
+  owners: ["foo", "bar"],
+  application: ["baz", "quux"],
+};
+
+describe("getFilterValueFromParams", () => {
+  it("converts comma-separated list representation from filter params into a filter value", () => {
+    const params = new URLSearchParams();
+    params.set("owners", "foo,bar");
+    params.set("application", "baz,quux");
+    expect(getFilterValueFromParams(params)).toEqual(MOCK_FILTER_VALUE);
+  });
+});
+
+describe("updateParamsFromFilterValue", () => {
+  it("sets filter params to comma-separated list representations of filter values", () => {
+    const params = new URLSearchParams();
+    const updateSearchParams = jest.fn((cb) => cb(params));
+    updateParamsFromFilterValue(updateSearchParams, MOCK_FILTER_VALUE);
+    expect(params.get("owners")).toEqual("foo,bar");
+    expect(params.get("application")).toEqual("baz,quux");
+  });
+
+  it("handles a roundtrip encoding with everything filtered", () => {
+    const params = new URLSearchParams();
+    const updateSearchParams = jest.fn((cb) => cb(params));
+    updateParamsFromFilterValue(updateSearchParams, EVERYTHING_SELECTED_VALUE);
+    expect(getFilterValueFromParams(params)).toEqual(EVERYTHING_SELECTED_VALUE);
+  });
+});
+
+describe("filterExperiments", () => {
+  it("filters nothing if filter value is empty", () => {
+    expect(filterExperiments(MOCK_EXPERIMENTS, {})).toEqual(MOCK_EXPERIMENTS);
+  });
+
+  it("filters only an empty feature config if filter value has everything", () => {
+    expect(
+      filterExperiments(MOCK_EXPERIMENTS, EVERYTHING_SELECTED_VALUE),
+    ).toEqual(MOCK_EXPERIMENTS.filter((e) => e.featureConfig !== null));
+  });
+
+  it("filters per individual criteria as expected", () => {
+    let name: keyof FilterValue;
+    for (name in EVERYTHING_SELECTED_VALUE) {
+      const filterValue = {
+        [name]: EVERYTHING_SELECTED_VALUE[name]!.slice(0, 1),
+      };
+      const result = filterExperiments(MOCK_EXPERIMENTS, filterValue);
+      expect(
+        result.every((experiment) =>
+          filterValue[name].includes(
+            experiment![name as keyof getAllExperiments_experiments] as string,
+          ),
+        ),
+      );
+    }
+  });
+});

--- a/app/experimenter/nimbus-ui/src/components/PageHome/filterExperiments.ts
+++ b/app/experimenter/nimbus-ui/src/components/PageHome/filterExperiments.ts
@@ -1,0 +1,66 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { UpdateSearchParams } from "../../hooks";
+import { getAllExperiments_experiments } from "../../types/getAllExperiments";
+import { FilterValue, FilterValueKeys } from "./types";
+
+// TODO: split the ?filters param up into individual params, rather than use JSON?
+
+export function getFilterValueFromParams(params: URLSearchParams): FilterValue {
+  const filterValue: FilterValue = {};
+  for (const key of FilterValueKeys) {
+    const value = params.get(key);
+    if (value) {
+      filterValue[key] = value.split(",");
+    }
+  }
+  return filterValue;
+}
+
+export function updateParamsFromFilterValue(
+  updateSearchParams: UpdateSearchParams,
+  filterValue: FilterValue,
+) {
+  updateSearchParams((params) => {
+    for (const key of FilterValueKeys) {
+      params.delete(key);
+      const values = filterValue[key];
+      if (typeof values !== "undefined") {
+        params.set(key, values.join(","));
+      }
+    }
+  });
+}
+
+type FilterSelector = {
+  name: keyof FilterValue;
+  selector: (e: getAllExperiments_experiments) => string | null | undefined;
+};
+
+const FILTER_SELECTORS: FilterSelector[] = [
+  { name: "owners", selector: (e) => e.owner.username },
+  { name: "application", selector: (e) => e.application },
+  { name: "firefoxMinVersion", selector: (e) => e.firefoxMinVersion },
+  { name: "featureConfig", selector: (e) => e.featureConfig?.slug },
+];
+
+export function filterExperiments(
+  experiments: getAllExperiments_experiments[],
+  filterState: FilterValue,
+) {
+  let filteredExperiments = [...experiments];
+
+  for (const { name, selector } of FILTER_SELECTORS) {
+    if (!filterState[name]?.length) continue;
+    filteredExperiments = filteredExperiments.filter((e) => {
+      const value = selector(e);
+      return value && filterState[name]!.includes(value);
+    });
+  }
+
+  return filteredExperiments;
+}
+
+export default filterExperiments;

--- a/app/experimenter/nimbus-ui/src/components/PageHome/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageHome/index.test.tsx
@@ -12,6 +12,7 @@ import {
 } from "@testing-library/react";
 import { act } from "@testing-library/react-hooks";
 import React from "react";
+import selectEvent from "react-select-event";
 import PageHome from ".";
 import { REFETCH_DELAY } from "../../hooks";
 import {
@@ -102,6 +103,24 @@ describe("PageHome", () => {
     await screen.findByText("Draft (3)");
     expect(screen.queryByTestId("refetch-alert")).not.toBeInTheDocument();
     expect(screen.queryByTestId("apollo-error-alert")).not.toBeInTheDocument();
+  });
+
+  // TODO: not exhaustively testing all filters here, might be worth adding more?
+  // Filtering itself is more fully covered in filterExperiments.test.tsx
+  it("supports filtering by feature", async () => {
+    await renderAndWaitForLoaded();
+    const expectedFeatureConfigName = "Picture-in-Picture";
+    await selectEvent.select(screen.getByLabelText("Feature"), [
+      expectedFeatureConfigName,
+    ]);
+    await waitFor(() => {
+      const featureConfigNames = screen
+        .getAllByTestId("directory-feature-config-name")
+        .map((el) => el.textContent);
+      expect(
+        featureConfigNames.every((name) => name === expectedFeatureConfigName),
+      ).toBeTruthy();
+    });
   });
 });
 

--- a/app/experimenter/nimbus-ui/src/components/PageHome/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageHome/mocks.tsx
@@ -1,0 +1,52 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React, { useState } from "react";
+import { mockDirectoryExperiments, MOCK_CONFIG } from "../../lib/mocks";
+import { uniqueByProperty } from "../../lib/utils";
+import { FilterBar } from "./FilterBar";
+import { FilterOptions, FilterValue } from "./types";
+
+export const MOCK_EXPERIMENTS = mockDirectoryExperiments();
+
+export const DEFAULT_OPTIONS: FilterOptions = {
+  owners: uniqueByProperty(
+    "username",
+    MOCK_EXPERIMENTS.map((e) => e.owner),
+  ),
+  application: MOCK_CONFIG!.application!,
+  featureConfig: MOCK_CONFIG!.featureConfig!,
+  firefoxMinVersion: MOCK_CONFIG!.firefoxMinVersion!,
+};
+
+export const DEFAULT_VALUE: FilterValue = {
+  owners: [],
+  application: [],
+  featureConfig: [],
+  firefoxMinVersion: [],
+};
+
+export const EVERYTHING_SELECTED_VALUE: FilterValue = {
+  application: MOCK_CONFIG!.application!.map((a) => a!.value!),
+  firefoxMinVersion: MOCK_CONFIG!.firefoxMinVersion!.map((a) => a!.value!),
+  featureConfig: MOCK_CONFIG!.featureConfig!.map((a) => a!.slug!),
+  owners: DEFAULT_OPTIONS.owners.map((i) => i.username),
+};
+
+export const Subject = ({
+  options = DEFAULT_OPTIONS,
+  value = DEFAULT_VALUE,
+}: Partial<React.ComponentProps<typeof FilterBar>>) => {
+  const [filterState, setFilterState] = useState<FilterValue>(value);
+  const onChange = (newState: FilterValue) => setFilterState(newState);
+  return (
+    <div>
+      <FilterBar {...{ options, value: filterState, onChange }} />
+      <div>
+        <h3>Filter state</h3>
+        <pre>{JSON.stringify(filterState, null, "  ")}</pre>
+      </div>
+    </div>
+  );
+};

--- a/app/experimenter/nimbus-ui/src/components/PageHome/types.ts
+++ b/app/experimenter/nimbus-ui/src/components/PageHome/types.ts
@@ -1,0 +1,24 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { getAllExperiments_experiments_owner } from "../../types/getAllExperiments";
+import { getConfig_nimbusConfig } from "../../types/getConfig";
+
+export type FilterOptions = {
+  owners: Array<getAllExperiments_experiments_owner>;
+} & Pick<
+  getConfig_nimbusConfig,
+  "application" | "featureConfig" | "firefoxMinVersion"
+>;
+
+export const FilterValueKeys = [
+  "owners",
+  "application",
+  "featureConfig",
+  "firefoxMinVersion",
+] as const;
+
+export type FilterValue = Partial<
+  Record<typeof FilterValueKeys[number], string[]>
+>;

--- a/app/experimenter/nimbus-ui/src/gql/experiments.ts
+++ b/app/experimenter/nimbus-ui/src/gql/experiments.ts
@@ -157,7 +157,18 @@ export const GET_EXPERIMENTS_QUERY = gql`
       owner {
         username
       }
+      featureConfig {
+        id
+        slug
+        name
+        description
+        application
+        ownerEmail
+        schema
+      }
       slug
+      application
+      firefoxMinVersion
       startDate
       isEnrollmentPausePending
       isEnrollmentPaused

--- a/app/experimenter/nimbus-ui/src/lib/experiment.test.ts
+++ b/app/experimenter/nimbus-ui/src/lib/experiment.test.ts
@@ -91,7 +91,7 @@ describe("selectFromExperiment", () => {
 
   it("returns a property selected via function", () => {
     const selectorCases = [
-      [featureConfigNameSortSelector, "New tab"],
+      [featureConfigNameSortSelector, "Picture-in-Picture"],
       [ownerUsernameSortSelector, "example@mozilla.com"],
       [resultsReadySortSelector, "0"],
       [enrollmentSortSelector, "2021-07-07T00:00:00.000Z"],

--- a/app/experimenter/nimbus-ui/src/lib/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/lib/mocks.tsx
@@ -38,6 +38,7 @@ import {
   NimbusChangeLogOldStatusNext,
   NimbusDocumentationLinkTitle,
   NimbusExperimentApplication,
+  NimbusExperimentFirefoxMinVersion,
   NimbusExperimentPublishStatus,
   NimbusExperimentStatus,
 } from "../types/globalTypes";
@@ -172,6 +173,18 @@ export const MOCK_CONFIG: getConfig_nimbusConfig = {
     {
       label: "Firefox 80",
       value: "FIREFOX_83",
+    },
+    {
+      label: "Firefox 16",
+      value: "FIREFOX_16",
+    },
+    {
+      label: "Firefox 32",
+      value: "FIREFOX_32",
+    },
+    {
+      label: "Firefox 64",
+      value: "FIREFOX_64",
     },
   ],
   outcomes: [
@@ -565,16 +578,17 @@ export function mockSingleDirectoryExperiment(
     owner: {
       username: "example@mozilla.com",
     },
+    application: MOCK_CONFIG.application![0]!
+      .value as NimbusExperimentApplication,
+    firefoxMinVersion: MOCK_CONFIG.firefoxMinVersion![0]!
+      .value as NimbusExperimentFirefoxMinVersion,
     monitoringDashboardUrl:
       "https://grafana.telemetry.mozilla.org/d/XspgvdxZz/experiment-enrollment?orgId=1&var-experiment_id=bug-1668861-pref-measure-set-to-default-adoption-impact-of-chang-release-81-83",
     name: "Open-architected background installation",
     status: NimbusExperimentStatus.COMPLETE,
     statusNext: null,
     publishStatus: NimbusExperimentPublishStatus.IDLE,
-    featureConfig: {
-      slug: "newtab",
-      name: "New tab",
-    },
+    featureConfig: MOCK_CONFIG.featureConfig![0],
     isEnrollmentPaused: false,
     isEnrollmentPausePending: false,
     proposedEnrollment: 7,
@@ -599,7 +613,9 @@ export function mockDirectoryExperiments(
       name: "Ipsum dolor sit amet",
       status: NimbusExperimentStatus.DRAFT,
       owner: { username: "gamma-example@mozilla.com" },
-      featureConfig: { slug: "foo", name: "Foo" },
+      featureConfig: MOCK_CONFIG.featureConfig![0],
+      application: MOCK_CONFIG.application![1]!
+        .value as NimbusExperimentApplication,
       startDate: null,
       computedEndDate: null,
     },
@@ -607,7 +623,7 @@ export function mockDirectoryExperiments(
       name: "Dolor sit amet",
       status: NimbusExperimentStatus.DRAFT,
       owner: { username: "beta-example@mozilla.com" },
-      featureConfig: { slug: "bar", name: "Bar" },
+      featureConfig: MOCK_CONFIG.featureConfig![1],
       startDate: null,
       computedEndDate: null,
     },
@@ -615,32 +631,38 @@ export function mockDirectoryExperiments(
       name: "Consectetur adipiscing elit",
       status: NimbusExperimentStatus.PREVIEW,
       owner: { username: "alpha-example@mozilla.com" },
-      featureConfig: { slug: "baz", name: "Baz" },
+      featureConfig: MOCK_CONFIG.featureConfig![2],
+      application: MOCK_CONFIG.application![1]!
+        .value as NimbusExperimentApplication,
       computedEndDate: null,
     },
     {
       name: "Aliquam interdum ac lacus at dictum",
       publishStatus: NimbusExperimentPublishStatus.APPROVED,
       owner: { username: "beta-example@mozilla.com" },
-      featureConfig: { slug: "foo", name: "Foo" },
+      featureConfig: MOCK_CONFIG.featureConfig![0],
       computedEndDate: null,
     },
     {
       name: "Nam semper sit amet orci in imperdiet",
       publishStatus: NimbusExperimentPublishStatus.APPROVED,
+      application: MOCK_CONFIG.application![1]!
+        .value as NimbusExperimentApplication,
       owner: { username: "gamma-example@mozilla.com" },
     },
     {
       name: "Duis ornare mollis sem.",
       status: NimbusExperimentStatus.LIVE,
       owner: { username: "alpha-example@mozilla.com" },
-      featureConfig: { slug: "bar", name: "Bar" },
+      featureConfig: MOCK_CONFIG.featureConfig![1],
     },
     {
       name: "Nec suscipit mi accumsan id",
       status: NimbusExperimentStatus.LIVE,
       owner: { username: "beta-example@mozilla.com" },
-      featureConfig: { slug: "baz", name: "Baz" },
+      featureConfig: MOCK_CONFIG.featureConfig![2],
+      application: MOCK_CONFIG.application![1]!
+        .value as NimbusExperimentApplication,
       resultsReady: true,
     },
     {
@@ -652,19 +674,23 @@ export function mockDirectoryExperiments(
       name: "Nam gravida",
       status: NimbusExperimentStatus.COMPLETE,
       owner: { username: "alpha-example@mozilla.com" },
-      featureConfig: { slug: "foo", name: "Foo" },
+      featureConfig: MOCK_CONFIG.featureConfig![0],
+      application: MOCK_CONFIG.application![1]!
+        .value as NimbusExperimentApplication,
       resultsReady: false,
     },
     {
       name: "Quam quis volutpat ornare",
       status: NimbusExperimentStatus.DRAFT,
       publishStatus: NimbusExperimentPublishStatus.REVIEW,
-      featureConfig: { slug: "Baz", name: "Bar" },
+      featureConfig: MOCK_CONFIG.featureConfig![1],
       owner: { username: "beta-example@mozilla.com" },
     },
     {
       name: "Lorem arcu faucibus tortor",
       featureConfig: null,
+      application: MOCK_CONFIG.application![1]!
+        .value as NimbusExperimentApplication,
       owner: { username: "gamma-example@mozilla.com" },
     },
   ],

--- a/app/experimenter/nimbus-ui/src/lib/types.ts
+++ b/app/experimenter/nimbus-ui/src/lib/types.ts
@@ -7,3 +7,7 @@ import { getConfig_nimbusConfig_outcomes } from "../types/getConfig";
 export type OutcomeSlugs = (string | null)[] | null;
 export type Outcome = getConfig_nimbusConfig_outcomes | null | undefined;
 export type OutcomesList = Outcome[];
+
+// This roughly represents optional objects from GQL results
+export type NullableObject = Record<string, any> | null;
+export type NullableObjectArray = NullableObject[];

--- a/app/experimenter/nimbus-ui/src/lib/utils.test.ts
+++ b/app/experimenter/nimbus-ui/src/lib/utils.test.ts
@@ -2,7 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { optionalBoolString, optionalStringBool, pluralize } from "./utils";
+import {
+  optionalBoolString,
+  optionalStringBool,
+  pluralize,
+  uniqueByProperty,
+} from "./utils";
 
 describe("pluralize", () => {
   it("correctly return 0-count item", () => {
@@ -49,5 +54,29 @@ describe("optionalBoolString", () => {
   it("returns null if null or undefined is provided", () => {
     expect(optionalBoolString(null)).toBeNull();
     expect(optionalBoolString(undefined)).toBeNull();
+  });
+});
+
+describe("uniqueByProperty", () => {
+  it("produces a list whose elements are unique for a given property", () => {
+    const list = [
+      { a: "foo", b: "bar", c: 1 },
+      { a: "foo", b: "bar", c: 2 },
+      { a: "foo", b: "bar", c: 3 },
+      { a: "baz", b: "quux", c: 4 },
+      { a: "xyxxy", b: "fnord", c: 5 },
+      { a: "baz", b: "quux", c: 6 },
+      { a: "xyxxy", b: "fnord", c: 7 },
+      { a: "baz", b: "quux", c: 8 },
+      { a: "xyxxy", b: "fnord", c: 9 },
+      { a: "frotz", b: "barf", c: 10 },
+    ];
+    const expected = [
+      { a: "foo", b: "bar", c: 1 },
+      { a: "baz", b: "quux", c: 4 },
+      { a: "xyxxy", b: "fnord", c: 5 },
+      { a: "frotz", b: "barf", c: 10 },
+    ];
+    expect(uniqueByProperty("a", list)).toEqual(expected);
   });
 });

--- a/app/experimenter/nimbus-ui/src/lib/utils.ts
+++ b/app/experimenter/nimbus-ui/src/lib/utils.ts
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import { NullableObject } from "./types";
+
 export function pluralize(count: number, singular: string, plural?: string) {
   const pluralVal = plural ?? `${singular}s`;
   return `${count} ${count === 1 ? singular : pluralVal}`;
@@ -19,3 +21,16 @@ export const optionalBoolString = (
   }
   return String(value);
 };
+
+export function uniqueByProperty<InputType extends NullableObject>(
+  propertyName: string,
+  originalList: InputType[],
+) {
+  return originalList.filter(
+    (item, idx): item is NonNullable<InputType> =>
+      originalList.findIndex(
+        (cmpItem) =>
+          !!item && !!cmpItem && item[propertyName] === cmpItem[propertyName],
+      ) === idx,
+  );
+}

--- a/app/experimenter/nimbus-ui/src/types/getAllExperiments.ts
+++ b/app/experimenter/nimbus-ui/src/types/getAllExperiments.ts
@@ -3,7 +3,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import { NimbusExperimentStatus, NimbusExperimentPublishStatus } from "./globalTypes";
+import { NimbusExperimentApplication, NimbusExperimentFirefoxMinVersion, NimbusExperimentStatus, NimbusExperimentPublishStatus } from "./globalTypes";
 
 // ====================================================
 // GraphQL query operation: getAllExperiments
@@ -14,14 +14,22 @@ export interface getAllExperiments_experiments_owner {
 }
 
 export interface getAllExperiments_experiments_featureConfig {
+  id: number | null;
   slug: string;
   name: string;
+  description: string | null;
+  application: NimbusExperimentApplication | null;
+  ownerEmail: string | null;
+  schema: string | null;
 }
 
 export interface getAllExperiments_experiments {
   name: string;
   owner: getAllExperiments_experiments_owner;
+  featureConfig: getAllExperiments_experiments_featureConfig | null;
   slug: string;
+  application: NimbusExperimentApplication | null;
+  firefoxMinVersion: NimbusExperimentFirefoxMinVersion | null;
   startDate: DateTime | null;
   isEnrollmentPausePending: boolean | null;
   isEnrollmentPaused: boolean | null;
@@ -33,7 +41,6 @@ export interface getAllExperiments_experiments {
   publishStatus: NimbusExperimentPublishStatus | null;
   monitoringDashboardUrl: string | null;
   resultsReady: boolean | null;
-  featureConfig: getAllExperiments_experiments_featureConfig | null;
 }
 
 export interface getAllExperiments {


### PR DESCRIPTION
Because:

* We'd like to filter the directory view listing by various criteria

This commit:

* Adds a new FilterBar component to PageHome with multi-select boxes

* Adds utilities to manage search query parameters as filter state and
  applying filters to the list of fetched experiments

* Adds featureConfig, application, and firefoxMinVersion to the
  getAllExperiments query for directory view

* Further expands mock data to provide something a little more
  interesting to filter in stories