### PR TITLE
fix #6096 feat(nimbus): branches with enabled features always have a value

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/FormBranch.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/FormBranch.test.tsx
@@ -14,7 +14,6 @@ import { FIELD_MESSAGES } from "../../../lib/constants";
 import { MOCK_CONFIG } from "../../../lib/mocks";
 import {
   MOCK_ANNOTATED_BRANCH,
-  MOCK_FEATURE_CONFIG,
   MOCK_FEATURE_CONFIG_WITH_SCHEMA,
   SubjectBranch,
 } from "./mocks";
@@ -55,18 +54,6 @@ describe("FormBranch", () => {
       'label[for="referenceBranch.featureEnabled"]',
     );
     expect(featureSwitchLabel).toHaveTextContent("Off");
-  });
-
-  it("hides feature value edit when schema is null", () => {
-    render(
-      <SubjectBranch
-        branch={{
-          ...MOCK_ANNOTATED_BRANCH,
-        }}
-        experimentFeatureConfig={MOCK_FEATURE_CONFIG}
-      />,
-    );
-    expect(screen.queryByTestId("feature-value-edit")).not.toBeInTheDocument();
   });
 
   it("hides feature value edit when feature disabled", () => {

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/FormBranch.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/FormBranch.tsx
@@ -214,9 +214,7 @@ export const FormBranch = ({
             />
           </Form.Group>
         </Form.Row>
-        {experimentFeatureConfig !== null &&
-        !!experimentFeatureConfig.schema &&
-        featureEnabled ? (
+        {experimentFeatureConfig !== null && featureEnabled ? (
           <Form.Row data-testid="feature-value-edit">
             <Form.Group as={Col} controlId={`${id}-featureValue`}>
               <Form.Label>Value</Form.Label>


### PR DESCRIPTION

Because

* In the original design, some branches would have a feature enabled but not specify a value
* Since then, the client has migrated towards always expecting a feature value rather than looking at the enabled bool
* Not all features specify a schema but should always expect a value

This commit

* Always shows the feature value input regardless of whether a schema is specified
* Always validate the feature value as json regardless of whether a schema is specified
* Continue to validate against the schema if one is specified