### PR TITLE
fix #6115 feat(nimbus): use published_dto in preview

### DIFF
--- a/app/experimenter/experiments/api/v5/types.py
+++ b/app/experimenter/experiments/api/v5/types.py
@@ -345,4 +345,8 @@ class NimbusExperimentType(DjangoObjectType):
         return self.changes.latest_timeout()
 
     def resolve_recipe_json(self, info):
-        return json.dumps(NimbusExperimentSerializer(self).data, indent=2, sort_keys=True)
+        return json.dumps(
+            self.published_dto or NimbusExperimentSerializer(self).data,
+            indent=2,
+            sort_keys=True,
+        )

--- a/app/experimenter/kinto/tasks.py
+++ b/app/experimenter/kinto/tasks.py
@@ -361,6 +361,8 @@ def nimbus_synchronize_preview_experiments_in_kinto():
         for experiment in should_publish_experiments:
             data = NimbusExperimentSerializer(experiment).data
             kinto_client.create_record(data)
+            experiment.published_dto = data
+            experiment.save()
             logger.info(f"{experiment.slug} is being pushed to preview")
 
         should_unpublish_experiments = NimbusExperiment.objects.filter(
@@ -369,6 +371,8 @@ def nimbus_synchronize_preview_experiments_in_kinto():
 
         for experiment in should_unpublish_experiments:
             kinto_client.delete_record(experiment.slug)
+            experiment.published_dto = None
+            experiment.save()
             logger.info(f"{experiment.slug} is being removed from preview")
 
         metrics.incr("nimbus_synchronize_preview_experiments_in_kinto.completed")

--- a/app/experimenter/kinto/tests/test_tasks.py
+++ b/app/experimenter/kinto/tests/test_tasks.py
@@ -750,6 +750,16 @@ class TestNimbusSynchronizePreviewExperimentsInKinto(MockKintoClientMixin, TestC
 
         data = NimbusExperimentSerializer(should_publish_experiment).data
 
+        should_publish_experiment = NimbusExperiment.objects.get(
+            id=should_publish_experiment.id
+        )
+        self.assertEqual(should_publish_experiment.published_dto, data)
+
+        should_unpublish_experiment = NimbusExperiment.objects.get(
+            id=should_unpublish_experiment.id
+        )
+        self.assertIsNone(should_unpublish_experiment.published_dto)
+
         self.mock_kinto_client.create_record.assert_called_with(
             data=data,
             collection=settings.KINTO_COLLECTION_NIMBUS_PREVIEW,


### PR DESCRIPTION
Because

* Even though an experiment is not editable while it's in a published state ie preview/live, things can change on the backend that affect the dto serialization ie targeting configs, application configs
* By using a dynamic rendering of the dto, this can lead to a case where the summary page shows a dto that doesn't match what's published in remote settings
* This was observed recently with changes to targeting configs for preview/live experiments

This commit

* Sets the published_dto for preview experiments
* Uses the published_dto for recipeJson on the summary page