### PR TITLE
fix #6114 bug(nimbus): proposed enrollment should not be higher than duration

### DIFF
--- a/app/experimenter/experiments/api/v5/serializers.py
+++ b/app/experimenter/experiments/api/v5/serializers.py
@@ -519,6 +519,21 @@ class NimbusExperimentSerializer(
                     }
                 )
 
+        proposed_enrollment = data.get("proposed_enrollment")
+        proposed_duration = data.get("proposed_duration")
+        if (
+            None not in (proposed_enrollment, proposed_duration)
+            and proposed_enrollment > proposed_duration
+        ):
+            raise serializers.ValidationError(
+                {
+                    "proposed_enrollment": (
+                        "The enrollment duration must be less than or "
+                        "equal to the experiment duration."
+                    )
+                }
+            )
+
         return data
 
     def update(self, experiment, validated_data):

--- a/app/experimenter/experiments/tests/api/v5/test_mutations.py
+++ b/app/experimenter/experiments/tests/api/v5/test_mutations.py
@@ -423,7 +423,7 @@ class TestMutations(GraphQLTestCase):
             targeting_config_slug=NimbusExperiment.TargetingConfig.NO_TARGETING,
             total_enrolled_clients=0,
         )
-        self.query(
+        response = self.query(
             UPDATE_EXPERIMENT_MUTATION,
             variables={
                 "input": {
@@ -431,8 +431,8 @@ class TestMutations(GraphQLTestCase):
                     "channel": NimbusConstants.Channel.BETA.name,
                     "firefoxMinVersion": NimbusConstants.Version.FIREFOX_83.name,
                     "populationPercent": "10",
-                    "proposedDuration": 42,
-                    "proposedEnrollment": 120,
+                    "proposedDuration": 120,
+                    "proposedEnrollment": 42,
                     "targetingConfigSlug": (
                         NimbusConstants.TargetingConfig.TARGETING_FIRST_RUN.name
                     ),
@@ -444,6 +444,9 @@ class TestMutations(GraphQLTestCase):
             },
             headers={settings.OPENIDC_EMAIL_HEADER: user_email},
         )
+        self.assertEqual(response.status_code, 200, response.content)
+        content = json.loads(response.content)
+        self.assertEqual(content["data"]["updateExperiment"]["message"], "success")
 
         experiment = NimbusExperiment.objects.get(id=experiment.id)
         self.assertEqual(experiment.channel, NimbusConstants.Channel.BETA)
@@ -451,8 +454,8 @@ class TestMutations(GraphQLTestCase):
             experiment.firefox_min_version, NimbusConstants.Version.FIREFOX_83
         )
         self.assertEqual(experiment.population_percent, 10.0)
-        self.assertEqual(experiment.proposed_duration, 42)
-        self.assertEqual(experiment.proposed_enrollment, 120)
+        self.assertEqual(experiment.proposed_duration, 120)
+        self.assertEqual(experiment.proposed_enrollment, 42)
         self.assertEqual(
             experiment.targeting_config_slug,
             NimbusConstants.TargetingConfig.TARGETING_FIRST_RUN,

--- a/app/experimenter/experiments/tests/api/v5/test_serializers.py
+++ b/app/experimenter/experiments/tests/api/v5/test_serializers.py
@@ -998,8 +998,8 @@ class TestNimbusExperimentSerializer(TestCase):
                 "channel": NimbusConstants.Channel.BETA,
                 "firefox_min_version": NimbusConstants.Version.FIREFOX_83,
                 "population_percent": 10,
-                "proposed_duration": 42,
-                "proposed_enrollment": 120,
+                "proposed_duration": 120,
+                "proposed_enrollment": 42,
                 "targeting_config_slug": (
                     NimbusConstants.TargetingConfig.TARGETING_FIRST_RUN
                 ),
@@ -1019,8 +1019,8 @@ class TestNimbusExperimentSerializer(TestCase):
             experiment.firefox_min_version, NimbusConstants.Version.FIREFOX_83
         )
         self.assertEqual(experiment.population_percent, 10)
-        self.assertEqual(experiment.proposed_duration, 42)
-        self.assertEqual(experiment.proposed_enrollment, 120)
+        self.assertEqual(experiment.proposed_duration, 120)
+        self.assertEqual(experiment.proposed_enrollment, 42)
         self.assertEqual(
             experiment.targeting_config_slug,
             NimbusConstants.TargetingConfig.TARGETING_FIRST_RUN,
@@ -1530,6 +1530,29 @@ class TestNimbusExperimentSerializer(TestCase):
                 "Targeting config 'First start-up users on Windows 10 1903 "
                 "(build 18362) or newer' is not available for application "
                 "'Firefox for iOS'",
+            ],
+        )
+
+    def test_enrollment_must_be_less_or_equal_experiment_duration(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED
+        )
+        data = {
+            "proposed_duration": 3,
+            "proposed_enrollment": 4,
+            "changelog_message": "updating durations",
+        }
+        serializer = NimbusExperimentSerializer(
+            experiment,
+            data,
+            context={"user": self.user},
+        )
+        self.assertFalse(serializer.is_valid())
+        self.assertEqual(
+            serializer.errors["proposed_enrollment"],
+            [
+                "The enrollment duration must be less than or "
+                "equal to the experiment duration."
             ],
         )
 


### PR DESCRIPTION


Because

* It shouldn't be valid for the proposed enrollment to be higher than the proposed duration

This commit

* Validates that enrollment is less than or equal to duration