### PR TITLE
fixes #6125 fix(nimbus): allow you to go back to draft from preview with invalid experiment details

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/ChangeApprovalOperations/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/ChangeApprovalOperations/index.tsx
@@ -61,7 +61,7 @@ export const ChangeApprovalOperations: React.FC<
   children,
 }) => {
   const defaultUIState = useMemo(() => {
-    if (invalidPages.length > 0 && (status.draft || status.preview)) {
+    if (invalidPages.length > 0 && status.draft) {
       return ChangeApprovalOperationsState.InvalidPages;
     }
 

--- a/app/experimenter/nimbus-ui/src/components/PageSummary/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageSummary/index.test.tsx
@@ -208,6 +208,22 @@ describe("PageSummary", () => {
     await act(async () => void fireEvent.click(launchButton));
   });
 
+  it("can go back to Draft from Preview with invalid experiment info", async () => {
+    const { mock } = mockExperimentQuery("demo-slug", {
+      status: NimbusExperimentStatus.PREVIEW,
+      readyForReview: {
+        ready: false,
+        message: {
+          targeting_config_slug: [
+            '"urlbar_firefox_suggest_us_en" is not a valid choice.',
+          ],
+        },
+      },
+    });
+    render(<Subject mocks={[mock]} />);
+    await screen.findByTestId("launch-preview-to-draft");
+  });
+
   it("handles approval of launch as expected", async () => {
     const { mock, experiment } = mockExperimentQuery("demo-slug", {
       ...reviewRequestedBaseProps,


### PR DESCRIPTION
closes #6125