### PR TITLE
fix #6121 chore(nimbus): intermittent test test_experiment_with_timeout_returns_changelog

### DIFF
--- a/app/experimenter/experiments/tests/api/v5/test_queries.py
+++ b/app/experimenter/experiments/tests/api/v5/test_queries.py
@@ -417,7 +417,8 @@ class TestNimbusExperimentBySlugQuery(GraphQLTestCase):
     def test_experiment_no_rejection_data(self):
         user_email = "user@example.com"
         experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperimentFactory.Lifecycles.CREATED
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            with_random_timespan=True,
         )
 
         response = self.query(
@@ -443,7 +444,8 @@ class TestNimbusExperimentBySlugQuery(GraphQLTestCase):
     def test_experiment_with_rejection(self):
         user_email = "user@example.com"
         experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperimentFactory.Lifecycles.LAUNCH_REJECT
+            NimbusExperimentFactory.Lifecycles.LAUNCH_REJECT,
+            with_random_timespan=True,
         )
         response = self.query(
             """
@@ -470,7 +472,8 @@ class TestNimbusExperimentBySlugQuery(GraphQLTestCase):
     def test_experiment_no_review_request_data(self):
         user_email = "user@example.com"
         experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperimentFactory.Lifecycles.CREATED
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            with_random_timespan=True,
         )
 
         response = self.query(
@@ -496,7 +499,8 @@ class TestNimbusExperimentBySlugQuery(GraphQLTestCase):
     def test_experiment_with_review_request(self):
         user_email = "user@example.com"
         experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperimentFactory.Lifecycles.LAUNCH_REVIEW_REQUESTED
+            NimbusExperimentFactory.Lifecycles.LAUNCH_REVIEW_REQUESTED,
+            with_random_timespan=True,
         )
         response = self.query(
             """
@@ -523,7 +527,8 @@ class TestNimbusExperimentBySlugQuery(GraphQLTestCase):
     def test_experiment_without_timeout_returns_none(self):
         user_email = "user@example.com"
         experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE_WAITING
+            NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE_WAITING,
+            with_random_timespan=True,
         )
         response = self.query(
             """
@@ -548,7 +553,8 @@ class TestNimbusExperimentBySlugQuery(GraphQLTestCase):
     def test_experiment_with_timeout_returns_changelog(self):
         user_email = "user@example.com"
         experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE_TIMEOUT
+            NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE_TIMEOUT,
+            with_random_timespan=True,
         )
         response = self.query(
             """


### PR DESCRIPTION


Because

* Observed an intermittent failure in test_experiment_with_timeout_returns_changelog
* Turns out that rapidly generating sequential changelogs using the current datetime can sometimes randomly create them in the wrong order
* We could use the randomly spaced out timestamps as default behaviour on all tests but then we'd have to create a callout to NOT do that in some tests, basically inverting the current default behaviour
* Or we could explicitly use the random timestamps in the tests which need them, which so far looks like a small subset of tests

This commit

* Chooses the latter option and uses the random timestamps in tests involving the timeout changelogs
* This is a smaller change than the former option
* Maybe we'll need to revisit this but for now this is the simplest way to move forward