### PR TITLE
fixes #6075 fix(nimbus): removed "Targeted" text from /summary

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/Summary/TableAudience/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/TableAudience/index.test.tsx
@@ -149,7 +149,7 @@ describe("TableAudience", () => {
     });
   });
 
-  describe("renders 'Targeted Locales' row as expected", () => {
+  describe("renders 'Locales' row as expected", () => {
     it("when locales exist, displays them", () => {
       const data = {
         locales: [{ name: "Quebecois", id: 1 }],
@@ -171,7 +171,7 @@ describe("TableAudience", () => {
     });
   });
 
-  describe("renders 'Targeted Countries' row as expected", () => {
+  describe("renders 'Countries' row as expected", () => {
     it("when countries exist, displays them", async () => {
       const data = {
         locales: [{ name: "Canada", id: 1 }],

--- a/app/experimenter/nimbus-ui/src/components/Summary/TableAudience/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/TableAudience/index.tsx
@@ -67,7 +67,7 @@ const TableAudience = ({ experiment }: TableAudienceProps) => {
           </tr>
         )}
         <tr>
-          <th>Targeted Locales</th>
+          <th>Locales</th>
           <td data-testid="experiment-locales">
             {experiment.locales.length > 0
               ? experiment.locales.map((l) => l.name).join(", ")
@@ -75,7 +75,7 @@ const TableAudience = ({ experiment }: TableAudienceProps) => {
           </td>
         </tr>
         <tr>
-          <th>Targeted Countries</th>
+          <th>Countries</th>
           <td data-testid="experiment-countries">
             {experiment.countries.length > 0
               ? experiment.countries.map((c) => c.name).join(", ")


### PR DESCRIPTION
Because

* there is was an inconsistency between /audience and /summary

This commit

* removes the "Targeted" text before Locales and Countries to be consistent with /audience