### PR TITLE
fixes #6031 fix(nimbus): make results sidebar scroll with the page

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/AppLayoutSidebarLaunched/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/AppLayoutSidebarLaunched/index.tsx
@@ -233,10 +233,7 @@ export const AppLayoutSidebarLaunched = ({
           xl="2"
           className="bg-light pt-2 border-right shadow-sm"
         >
-          <nav
-            data-testid="nav-sidebar"
-            className="navbar fixed-top col-xl-2 col-lg-3 col-md-3 px-4 py-3"
-          >
+          <nav data-testid="nav-sidebar" className="navbar">
             <Nav
               className="flex-column font-weight-semibold mx-2 w-100"
               as="ul"


### PR DESCRIPTION
Closes #6031

Un-fix the results/launched sidebar so it scrolls with the page. This will stop Very Long Results menu items from being permanently out of view.

Look at it [here](https://storage.googleapis.com/mozilla-storybooks-experimenter/commits/fa71d7a2b62518a02120d019a21559c1d31a18b0/nimbus-ui/index.html?path=/story/components-applayoutsidebarlaunched--has-analysis-results) by making your window height smoller

Yeehaw