### PR TITLE
fix #6154 feat(nimbus): Tweak useRefetchOnError to only refetch if not in dev

### DIFF
--- a/app/experimenter/nimbus-ui/src/hooks/useRefetchOnError/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/hooks/useRefetchOnError/index.test.tsx
@@ -25,6 +25,14 @@ describe("useRefetchOnError", () => {
     });
     await screen.findByText("No errors!");
   });
+
+  it("does not refetch in development env", async () => {
+    Object.defineProperty(process.env, "NODE_ENV", {
+      value: "development",
+    });
+    render(<Subject />);
+    await screen.findByTestId("apollo-error-alert");
+  });
 });
 
 jest.useFakeTimers();

--- a/app/experimenter/nimbus-ui/src/hooks/useRefetchOnError/index.tsx
+++ b/app/experimenter/nimbus-ui/src/hooks/useRefetchOnError/index.tsx
@@ -8,6 +8,8 @@ import ApolloErrorAlert from "../../components/ApolloErrorAlert";
 import RefetchAlert from "../../components/RefetchAlert";
 
 export const REFETCH_DELAY = 5000;
+const IS_DEV =
+  process.env.NODE_ENV === "development" && process.env.STORYBOOK !== "true";
 
 export const useRefetchOnError = (
   error: ApolloError | undefined,
@@ -18,7 +20,7 @@ export const useRefetchOnError = (
   const [ReactEl, setReactEl] = useState<ReactElement>(<></>);
   useEffect(() => {
     if (!error) return;
-    if (!hasRefetched) {
+    if (!hasRefetched && !IS_DEV) {
       const timeout = setTimeout(() => {
         refetch();
         setHasRefetched(true);


### PR DESCRIPTION
fixes #6154, this is a quick follow up to #6107 that I thought about after the fact

Because:
* In development, if an error occurs where this hook is used, devs will have to wait the refetch time to see the helpful error message (ApolloErrorAlert)

This commit:
* Skips refetching in useRefetchOnError if the environment is development and just returns ApolloErrorAlert