### PR TITLE
fix #5708 feat(nimbus): show archived experiments on the directory view

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/PageHome/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageHome/index.test.tsx
@@ -52,11 +52,12 @@ describe("PageHome", () => {
       ["completed", screen.getByText("Completed (4)")],
       ["drafts", screen.getByText("Draft (3)")],
       ["live", screen.getByText("Live (3)")],
+      ["archived", screen.getByText("Archived (1)")],
     ] as const;
 
   it("displays five Directory Tables (one for each status type)", async () => {
     await renderAndWaitForLoaded();
-    expect(screen.queryAllByTestId("DirectoryTable")).toHaveLength(5);
+    expect(screen.queryAllByTestId("DirectoryTable")).toHaveLength(6);
     for (const [tabKey, tab] of findTabs()) {
       expect(tab).toBeInTheDocument();
     }

--- a/app/experimenter/nimbus-ui/src/components/PageHome/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageHome/index.tsx
@@ -76,7 +76,7 @@ export const Body = () => {
     ),
   };
 
-  const { live, complete, preview, review, draft } = sortByStatus(
+  const { live, complete, preview, review, draft, archived } = sortByStatus(
     filterExperiments(data.experiments, filterValue),
   );
 
@@ -104,6 +104,9 @@ export const Body = () => {
         </Tab>
         <Tab eventKey="drafts" title={`Draft (${draft.length})`}>
           <DirectoryDraftsTable experiments={draft} />
+        </Tab>
+        <Tab eventKey="archived" title={`Archived (${archived.length})`}>
+          <DirectoryDraftsTable experiments={archived} />
         </Tab>
       </Tabs>
     </>

--- a/app/experimenter/nimbus-ui/src/components/PageHome/sortByStatus.ts
+++ b/app/experimenter/nimbus-ui/src/components/PageHome/sortByStatus.ts
@@ -6,7 +6,7 @@ import { getStatus } from "../../lib/experiment";
 import { getAllExperiments_experiments } from "../../types/getAllExperiments";
 
 export type ExperimentCollector = Record<
-  "draft" | "preview" | "review" | "live" | "complete",
+  "draft" | "preview" | "review" | "live" | "complete" | "archived",
   getAllExperiments_experiments[]
 >;
 
@@ -14,7 +14,9 @@ function sortByStatus(experiments: getAllExperiments_experiments[] = []) {
   return experiments.reduce<ExperimentCollector>(
     (collector, experiment) => {
       const status = getStatus(experiment);
-      if (status.live) {
+      if (status.archived) {
+        collector.archived.push(experiment);
+      } else if (status.live) {
         collector.live.push(experiment);
       } else if (status.complete) {
         collector.complete.push(experiment);
@@ -33,6 +35,7 @@ function sortByStatus(experiments: getAllExperiments_experiments[] = []) {
       review: [],
       live: [],
       complete: [],
+      archived: [],
     },
   );
 }

--- a/app/experimenter/nimbus-ui/src/gql/experiments.ts
+++ b/app/experimenter/nimbus-ui/src/gql/experiments.ts
@@ -27,6 +27,7 @@ export const GET_EXPERIMENT_QUERY = gql`
   query getExperiment($slug: String!) {
     experimentBySlug(slug: $slug) {
       id
+      isArchived
       name
       slug
       status
@@ -153,6 +154,7 @@ export const GET_EXPERIMENT_QUERY = gql`
 export const GET_EXPERIMENTS_QUERY = gql`
   query getAllExperiments {
     experiments {
+      isArchived
       name
       owner {
         username

--- a/app/experimenter/nimbus-ui/src/lib/experiment.ts
+++ b/app/experimenter/nimbus-ui/src/lib/experiment.ts
@@ -14,8 +14,13 @@ import { LIFECYCLE_REVIEW_FLOWS } from "./constants";
 export function getStatus(
   experiment?: getExperiment_experimentBySlug | getAllExperiments_experiments,
 ) {
-  const { status, statusNext, publishStatus, isEnrollmentPausePending } =
-    experiment || {};
+  const {
+    status,
+    statusNext,
+    publishStatus,
+    isEnrollmentPausePending,
+    isArchived,
+  } = experiment || {};
 
   // The experiment is or was out in the wild (live or complete)
   const launched = [
@@ -24,6 +29,7 @@ export function getStatus(
   ].includes(status!);
 
   return {
+    archived: isArchived,
     draft: status === NimbusExperimentStatus.DRAFT,
     preview: status === NimbusExperimentStatus.PREVIEW,
     live: status === NimbusExperimentStatus.LIVE,

--- a/app/experimenter/nimbus-ui/src/lib/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/lib/mocks.tsx
@@ -574,6 +574,7 @@ export function mockSingleDirectoryExperiment(
   const endTime = now - oneDay * 30 + 21 * oneDay * Math.random();
 
   return {
+    isArchived: false,
     slug: `some-experiment-${slugIndex}`,
     owner: {
       username: "example@mozilla.com",
@@ -688,6 +689,14 @@ export function mockDirectoryExperiments(
     },
     {
       name: "Lorem arcu faucibus tortor",
+      featureConfig: null,
+      application: MOCK_CONFIG.application![1]!
+        .value as NimbusExperimentApplication,
+      owner: { username: "gamma-example@mozilla.com" },
+    },
+    {
+      isArchived: true,
+      name: "Archived Experiment",
       featureConfig: null,
       application: MOCK_CONFIG.application![1]!
         .value as NimbusExperimentApplication,

--- a/app/experimenter/nimbus-ui/src/types/getAllExperiments.ts
+++ b/app/experimenter/nimbus-ui/src/types/getAllExperiments.ts
@@ -24,6 +24,7 @@ export interface getAllExperiments_experiments_featureConfig {
 }
 
 export interface getAllExperiments_experiments {
+  isArchived: boolean | null;
   name: string;
   owner: getAllExperiments_experiments_owner;
   featureConfig: getAllExperiments_experiments_featureConfig | null;

--- a/app/experimenter/nimbus-ui/src/types/getExperiment.ts
+++ b/app/experimenter/nimbus-ui/src/types/getExperiment.ts
@@ -99,6 +99,7 @@ export interface getExperiment_experimentBySlug_countries {
 
 export interface getExperiment_experimentBySlug {
   id: number | null;
+  isArchived: boolean | null;
   name: string;
   slug: string;
   status: NimbusExperimentStatus | null;


### PR DESCRIPTION
Because

* We want to show archived experiments on a separate tab on the directory view

This commit

* Queries isArchived from V5 API
* Sorts archived experiments out from other statuses
* Adds an archived tab to the directory view