### PR TITLE
fix #5709 feat(nimbus): display archived pill on experiment page

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/AppLayoutWithExperiment/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/AppLayoutWithExperiment/index.tsx
@@ -140,7 +140,8 @@ const AppLayoutWithExperiment = ({
     return <PageExperimentNotFound {...{ slug }} />;
   }
 
-  const { name, startDate, computedEndDate, computedDurationDays } = experiment;
+  const { name, startDate, computedEndDate, computedDurationDays, isArchived } =
+    experiment;
 
   return (
     <Layout
@@ -169,6 +170,7 @@ const AppLayoutWithExperiment = ({
             computedEndDate,
             status,
             computedDurationDays,
+            isArchived,
           }}
         />
         {hasPollError && (

--- a/app/experimenter/nimbus-ui/src/components/HeaderExperiment/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/HeaderExperiment/index.stories.tsx
@@ -26,6 +26,7 @@ storiesOf("components/HeaderExperiment", module)
         computedEndDate={experiment.computedEndDate}
         computedDurationDays={experiment.computedDurationDays}
         status={mockGetStatus(experiment)}
+        isArchived={false}
       />
     </AppLayout>
   ))
@@ -38,6 +39,7 @@ storiesOf("components/HeaderExperiment", module)
         computedEndDate={experiment.computedEndDate}
         computedDurationDays={experiment.computedDurationDays}
         status={mockGetStatus({ status: NimbusExperimentStatus.PREVIEW })}
+        isArchived={false}
       />
     </AppLayout>
   ))
@@ -52,6 +54,7 @@ storiesOf("components/HeaderExperiment", module)
         status={mockGetStatus({
           publishStatus: NimbusExperimentPublishStatus.REVIEW,
         })}
+        isArchived={false}
       />
     </AppLayout>
   ))
@@ -64,6 +67,7 @@ storiesOf("components/HeaderExperiment", module)
         computedEndDate={null}
         computedDurationDays={experiment.computedDurationDays}
         status={mockGetStatus({ status: NimbusExperimentStatus.LIVE })}
+        isArchived={false}
       />
     </AppLayout>
   ))
@@ -76,6 +80,20 @@ storiesOf("components/HeaderExperiment", module)
         computedEndDate={experiment.computedEndDate}
         computedDurationDays={experiment.computedDurationDays}
         status={mockGetStatus({ status: NimbusExperimentStatus.COMPLETE })}
+        isArchived={false}
+      />
+    </AppLayout>
+  ))
+  .add("archived", () => (
+    <AppLayout>
+      <HeaderExperiment
+        name={experiment.name}
+        slug={experiment.slug}
+        startDate={experiment.startDate}
+        computedEndDate={experiment.computedEndDate}
+        computedDurationDays={experiment.computedDurationDays}
+        status={mockGetStatus({ status: NimbusExperimentStatus.COMPLETE })}
+        isArchived={true}
       />
     </AppLayout>
   ));

--- a/app/experimenter/nimbus-ui/src/components/HeaderExperiment/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/HeaderExperiment/index.test.tsx
@@ -20,6 +20,7 @@ describe("HeaderExperiment", () => {
         computedEndDate={experiment.computedEndDate}
         computedDurationDays={experiment.computedDurationDays}
         status={mockGetStatus(experiment)}
+        isArchived={false}
       />,
     );
     expect(screen.getByTestId("header-experiment-name")).toHaveTextContent(
@@ -45,6 +46,7 @@ describe("HeaderExperiment", () => {
         computedEndDate={experiment.computedEndDate}
         computedDurationDays={experiment.computedDurationDays}
         status={mockGetStatus(experiment)}
+        isArchived={false}
       />,
     );
     expect(
@@ -57,5 +59,20 @@ describe("HeaderExperiment", () => {
       humanDate(experiment.computedEndDate!),
     );
     expect(screen.getByTestId("header-dates")).toHaveTextContent("(14 days)");
+  });
+  it("renders with archived", () => {
+    const { experiment } = mockExperimentQuery("demo-slug", {});
+    render(
+      <HeaderExperiment
+        name={experiment.name}
+        slug={experiment.slug}
+        startDate={experiment.startDate}
+        computedEndDate={experiment.computedEndDate}
+        computedDurationDays={experiment.computedDurationDays}
+        status={mockGetStatus(experiment)}
+        isArchived={true}
+      />,
+    );
+    expect(screen.queryByText("Archived")).toBeInTheDocument();
   });
 });

--- a/app/experimenter/nimbus-ui/src/components/HeaderExperiment/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/HeaderExperiment/index.tsx
@@ -11,7 +11,12 @@ import "./index.scss";
 
 type HeaderExperimentProps = Pick<
   getExperiment_experimentBySlug,
-  "name" | "slug" | "startDate" | "computedEndDate" | "computedDurationDays"
+  | "name"
+  | "slug"
+  | "startDate"
+  | "computedEndDate"
+  | "computedDurationDays"
+  | "isArchived"
 > & { status: StatusCheck };
 
 const HeaderExperiment = ({
@@ -21,11 +26,23 @@ const HeaderExperiment = ({
   computedEndDate = "",
   status,
   computedDurationDays,
+  isArchived,
 }: HeaderExperimentProps) => (
   <header className="border-bottom" data-testid="header-experiment">
-    <h1 className="h5 font-weight-normal" data-testid="header-experiment-name">
+    <h1
+      className="h5 font-weight-normal d-inline"
+      data-testid="header-experiment-name"
+    >
       {name}
     </h1>
+    {isArchived && (
+      <StatusPill
+        className="ml-2"
+        label="Archived"
+        color="danger"
+        active={true}
+      />
+    )}
     <p
       className="text-monospace text-secondary mb-1 small"
       data-testid="header-experiment-slug"
@@ -74,17 +91,25 @@ const StatusPill = ({
   label,
   active,
   padded = true,
+  color = "primary",
+  className = "",
 }: {
   label: string;
   active: boolean;
   padded?: boolean;
+  color?: string;
+  className?: string;
 }) => (
   <span
-    className={classNames(
-      "border rounded-pill px-2 bg-white position-relative",
-      active ? "border-primary text-primary" : "border-muted text-muted",
-      padded && "mr-3",
-    )}
+    className={
+      classNames(
+        "border rounded-pill px-2 bg-white position-relative",
+        active ? `border-${color} text-${color}` : "border-muted text-muted",
+        padded && "mr-3",
+      ) +
+      " " +
+      className
+    }
     data-testid={
       active ? "header-experiment-status-active" : "header-experiment-status"
     }


### PR DESCRIPTION
Because

* We need a way to show experiments that are archived

This commit

* Adds a red Archived pill on the experiment summary page for experiments that are archived