### PR TITLE
fix #5722 feat(nimbus): disable editing/launching for archived experiments

### DIFF
--- a/app/experimenter/experiments/api/v5/types.py
+++ b/app/experimenter/experiments/api/v5/types.py
@@ -288,6 +288,7 @@ class NimbusExperimentType(DjangoObjectType):
     enrollment_end_date = graphene.DateTime()
     computed_enrollment_days = graphene.Int()
     computed_duration_days = graphene.Int()
+    can_edit = graphene.Boolean()
     can_review = graphene.Boolean()
     review_request = graphene.Field(NimbusChangeLogType)
     rejection = graphene.Field(NimbusChangeLogType)
@@ -332,6 +333,9 @@ class NimbusExperimentType(DjangoObjectType):
 
     def resolve_enrollment_end_date(self, info):
         return self.proposed_enrollment_end_date
+
+    def resolve_can_edit(self, info):
+        return self.can_edit
 
     def resolve_can_review(self, info):
         return self.can_review(info.context.user)

--- a/app/experimenter/experiments/models/nimbus.py
+++ b/app/experimenter/experiments/models/nimbus.py
@@ -373,6 +373,14 @@ class NimbusExperiment(NimbusConstants, FilterMixin, models.Model):
             ),
         )
 
+    @property
+    def can_edit(self):
+        return (
+            self.status == self.Status.DRAFT
+            and self.publish_status == self.PublishStatus.IDLE
+            and not self.is_archived
+        )
+
     def can_review(self, reviewer):
         if (
             settings.SKIP_REVIEW_ACCESS_CONTROL_FOR_DEV_USER

--- a/app/experimenter/experiments/tests/api/v5/test_queries.py
+++ b/app/experimenter/experiments/tests/api/v5/test_queries.py
@@ -28,6 +28,7 @@ class TestNimbusExperimentsQuery(GraphQLTestCase):
             query {
                 experiments {
                     isArchived
+                    canEdit
                     name
                     slug
                     publicDescription
@@ -51,6 +52,7 @@ class TestNimbusExperimentsQuery(GraphQLTestCase):
         self.assertEqual(
             experiment_data["riskMitigationLink"], experiment.risk_mitigation_link
         )
+        self.assertEqual(experiment_data["canEdit"], experiment.can_edit)
 
     def test_experiments_with_no_branches_returns_empty_treatment_values(self):
         user_email = "user@example.com"

--- a/app/experimenter/experiments/tests/test_models/test_models_nimbus.py
+++ b/app/experimenter/experiments/tests/test_models/test_models_nimbus.py
@@ -732,6 +732,21 @@ class TestNimbusExperiment(TestCase):
         )
         self.assertFalse(experiment.results_ready)
 
+    @parameterized.expand(
+        [
+            (True, NimbusExperimentFactory.Lifecycles.CREATED),
+            (False, NimbusExperimentFactory.Lifecycles.PREVIEW),
+            (False, NimbusExperimentFactory.Lifecycles.LAUNCH_REVIEW_REQUESTED),
+            (False, NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE),
+            (False, NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE_WAITING),
+            (False, NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE_APPROVE),
+            (False, NimbusExperimentFactory.Lifecycles.ENDING_APPROVE_APPROVE),
+        ]
+    )
+    def test_can_edit(self, expected_can_edit, lifecycle):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(lifecycle)
+        self.assertEqual(experiment.can_edit, expected_can_edit)
+
     @parameterized.expand([(settings.DEV_USER_EMAIL, True), ("jdoe@mozilla.org", False)])
     @override_settings(SKIP_REVIEW_ACCESS_CONTROL_FOR_DEV_USER=True)
     def test_can_review_for_requesting_user_if_dev_user_and_setting_enabled(

--- a/app/experimenter/nimbus-ui/schema.graphql
+++ b/app/experimenter/nimbus-ui/schema.graphql
@@ -361,6 +361,7 @@ type NimbusExperimentType {
   enrollmentEndDate: DateTime
   computedEnrollmentDays: Int
   computedDurationDays: Int
+  canEdit: Boolean
   canReview: Boolean
   reviewRequest: NimbusChangeLogType
   rejection: NimbusChangeLogType

--- a/app/experimenter/nimbus-ui/src/components/AppLayoutWithSidebar/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/AppLayoutWithSidebar/index.test.tsx
@@ -7,18 +7,8 @@ import React from "react";
 import { BASE_PATH, SERVER_ERRORS } from "../../lib/constants";
 import { MockedCache, mockExperimentQuery } from "../../lib/mocks";
 import { renderWithRouter } from "../../lib/test-utils";
-import {
-  NimbusExperimentPublishStatus,
-  NimbusExperimentStatus,
-} from "../../types/globalTypes";
 import App from "../App";
 import { Subject } from "./mocks";
-
-const assertDisabledNav = () => {
-  for (const slug of ["overview", "branches", "metrics", "audience"]) {
-    expect(screen.getByTestId(`nav-edit-${slug}`).tagName).toEqual("SPAN");
-  }
-};
 
 describe("AppLayoutWithSidebar", () => {
   it("renders app layout content with children", () => {
@@ -111,42 +101,13 @@ describe("AppLayoutWithSidebar", () => {
       await screen.findByText(/Missing details in:/);
     });
 
-    it("when in preview, disables all edit page links", async () => {
-      render(
-        <Subject experiment={{ status: NimbusExperimentStatus.PREVIEW }} />,
-      );
+    it("when canEdit false, disables all edit page links", async () => {
+      render(<Subject experiment={{ canEdit: false }} />);
 
       // In preview these should all not be <a> tags, but instead <span>s
       ["overview", "branches", "metrics", "audience"].forEach((slug) => {
         expect(screen.getByTestId(`nav-edit-${slug}`).tagName).toEqual("SPAN");
       });
-    });
-
-    it("when in draft and publish status review, disables all edit page links", async () => {
-      render(
-        <Subject
-          experiment={{ publishStatus: NimbusExperimentPublishStatus.REVIEW }}
-        />,
-      );
-      assertDisabledNav();
-    });
-
-    it("when in draft and publish status approved, disables all edit page links", async () => {
-      render(
-        <Subject
-          experiment={{ publishStatus: NimbusExperimentPublishStatus.APPROVED }}
-        />,
-      );
-      assertDisabledNav();
-    });
-
-    it("when in in draft and publish status waiting, disables all edit page links", async () => {
-      render(
-        <Subject
-          experiment={{ publishStatus: NimbusExperimentPublishStatus.WAITING }}
-        />,
-      );
-      assertDisabledNav();
     });
   });
 });

--- a/app/experimenter/nimbus-ui/src/components/AppLayoutWithSidebar/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/AppLayoutWithSidebar/index.tsx
@@ -57,8 +57,15 @@ export const AppLayoutWithSidebar = ({
   const { slug } = useParams();
   const { invalidPages, InvalidPagesList } = useReviewCheck(experiment);
   const status = getStatus(experiment);
-  const reviewOrPreview = !status?.idle || status?.preview;
-  const hasMissingDetails = invalidPages.length > 0 && !reviewOrPreview;
+  const hasMissingDetails = invalidPages.length > 0 && experiment.canEdit;
+  let lockedReason: string;
+  if (status.review) {
+    lockedReason = "in Review";
+  } else if (status.preview) {
+    lockedReason = "in Preview";
+  } else if (experiment.isArchived) {
+    lockedReason = "Archived";
+  }
 
   return (
     <Container fluid className="h-100vh" data-testid={testid}>
@@ -108,11 +115,11 @@ export const AppLayoutWithSidebar = ({
                   storiesOf={`pages/Edit${page.name}`}
                   testid={`nav-edit-${page.slug}`}
                   title={
-                    reviewOrPreview
-                      ? "Experiments cannot be edited while in Review or Preview"
-                      : undefined
+                    experiment.canEdit
+                      ? undefined
+                      : `Experiments cannot be edited while ${lockedReason}`
                   }
-                  disabled={reviewOrPreview}
+                  disabled={!experiment.canEdit}
                 >
                   {page.icon}
                   {page.name}

--- a/app/experimenter/nimbus-ui/src/components/PageSummary/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageSummary/index.stories.tsx
@@ -69,6 +69,14 @@ export const draftStatus = storyWithExperimentProps(
   "Draft status, no missing fields",
 );
 
+export const draftArchived = storyWithExperimentProps(
+  {
+    isArchived: true,
+    canEdit: false,
+  },
+  "Draft status, archived",
+);
+
 export const previewStatus = storyWithExperimentProps(
   {
     status: NimbusExperimentStatus.PREVIEW,

--- a/app/experimenter/nimbus-ui/src/components/PageSummary/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageSummary/index.test.tsx
@@ -76,6 +76,15 @@ describe("PageSummary", () => {
     screen.getByRole("navigation");
   });
 
+  it("renders without launch controls when archived", async () => {
+    const { mock } = mockExperimentQuery("demo-slug", { isArchived: true });
+    render(<Subject mocks={[mock]} />);
+    await screen.findByTestId("PageSummary");
+    expect(
+      await screen.queryByTestId("start-launch-draft-to-review"),
+    ).not.toBeInTheDocument();
+  });
+
   it("hides signoff section if experiment is launched", async () => {
     // this table is shown in the Summary component instead
     const { mock } = mockExperimentQuery("demo-slug", {

--- a/app/experimenter/nimbus-ui/src/components/PageSummary/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageSummary/index.tsx
@@ -203,6 +203,7 @@ const PageContent: React.FC<{
         }}
       >
         {status.draft &&
+          !experiment.isArchived &&
           (showLaunchToReview ? (
             <FormLaunchDraftToReview
               {...{

--- a/app/experimenter/nimbus-ui/src/gql/experiments.ts
+++ b/app/experimenter/nimbus-ui/src/gql/experiments.ts
@@ -28,6 +28,7 @@ export const GET_EXPERIMENT_QUERY = gql`
     experimentBySlug(slug: $slug) {
       id
       isArchived
+      canEdit
       name
       slug
       status

--- a/app/experimenter/nimbus-ui/src/lib/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/lib/mocks.tsx
@@ -399,6 +399,8 @@ export function mockExperiment<
   return Object.assign(
     {
       id: 1,
+      isArchived: false,
+      canEdit: true,
       owner: {
         email: "example@mozilla.com",
       },

--- a/app/experimenter/nimbus-ui/src/types/getExperiment.ts
+++ b/app/experimenter/nimbus-ui/src/types/getExperiment.ts
@@ -3,7 +3,16 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import { NimbusExperimentStatus, NimbusExperimentPublishStatus, NimbusExperimentApplication, NimbusExperimentChannel, NimbusExperimentFirefoxMinVersion, NimbusDocumentationLinkTitle, NimbusChangeLogOldStatus, NimbusChangeLogOldStatusNext } from "./globalTypes";
+import {
+  NimbusChangeLogOldStatus,
+  NimbusChangeLogOldStatusNext,
+  NimbusDocumentationLinkTitle,
+  NimbusExperimentApplication,
+  NimbusExperimentChannel,
+  NimbusExperimentFirefoxMinVersion,
+  NimbusExperimentPublishStatus,
+  NimbusExperimentStatus,
+} from "./globalTypes";
 
 // ====================================================
 // GraphQL query operation: getExperiment
@@ -100,6 +109,7 @@ export interface getExperiment_experimentBySlug_countries {
 export interface getExperiment_experimentBySlug {
   id: number | null;
   isArchived: boolean | null;
+  canEdit: boolean | null;
   name: string;
   slug: string;
   status: NimbusExperimentStatus | null;
@@ -112,7 +122,9 @@ export interface getExperiment_experimentBySlug {
   publicDescription: string;
   owner: getExperiment_experimentBySlug_owner;
   referenceBranch: getExperiment_experimentBySlug_referenceBranch | null;
-  treatmentBranches: (getExperiment_experimentBySlug_treatmentBranches | null)[] | null;
+  treatmentBranches:
+    | (getExperiment_experimentBySlug_treatmentBranches | null)[]
+    | null;
   featureConfig: getExperiment_experimentBySlug_featureConfig | null;
   primaryOutcomes: (string | null)[] | null;
   secondaryOutcomes: (string | null)[] | null;
@@ -134,7 +146,9 @@ export interface getExperiment_experimentBySlug {
   riskBrand: boolean | null;
   riskPartnerRelated: boolean | null;
   signoffRecommendations: getExperiment_experimentBySlug_signoffRecommendations | null;
-  documentationLinks: getExperiment_experimentBySlug_documentationLinks[] | null;
+  documentationLinks:
+    | getExperiment_experimentBySlug_documentationLinks[]
+    | null;
   isEnrollmentPausePending: boolean | null;
   isEnrollmentPaused: boolean | null;
   enrollmentEndDate: DateTime | null;


### PR DESCRIPTION


Because

* Archived experiments can't be edited or launched

This commit

* Moves canEdit check to the backend
* Disables edit links when canEdit is false
* Disables launch controls when isArchived is true