### PR TITLE
fixes #5604 fix(nimbus) adjusted sidebar text back button text from Experiments -> Back to Experiments

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/AppLayoutSidebarLaunched/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/AppLayoutSidebarLaunched/index.tsx
@@ -247,7 +247,7 @@ export const AppLayoutSidebarLaunched = ({
                 textColor="text-secondary"
               >
                 <ChevronLeft className="ml-n1" width="18" height="18" />
-                Experiments
+                Back to Experiments
               </LinkNav>
 
               <LinkNavSummary

--- a/app/experimenter/nimbus-ui/src/components/AppLayoutWithSidebar/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/AppLayoutWithSidebar/index.tsx
@@ -77,7 +77,7 @@ export const AppLayoutWithSidebar = ({
                 textColor="text-secondary"
               >
                 <ChevronLeft className="ml-n1" width="18" height="18" />
-                Experiments
+                Back to Experiments
               </LinkNav>
 
               <LinkNavSummary


### PR DESCRIPTION
Because

* because "Back to Experiments" is preferred 

This commit 
* changes the back button text of the side bar to say "Back to Experiments" to match 