### PR TITLE
fix #5715 feat(nimbus): attach archive button to mutation

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/AppLayoutSidebarLaunched/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/AppLayoutSidebarLaunched/index.test.tsx
@@ -53,6 +53,7 @@ const Subject = ({
             }
           : undefined,
         experiment,
+        refetch: async () => {},
       }}
     >
       <p data-testid="test-child">Hello, world!</p>

--- a/app/experimenter/nimbus-ui/src/components/AppLayoutSidebarLaunched/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/AppLayoutSidebarLaunched/index.tsx
@@ -68,6 +68,7 @@ type AppLayoutSidebarLaunchedProps = {
   analysisLoadingInSidebar?: boolean; // only the sidebar needs analysis data & is loading
   analysisError?: Error;
   experiment: getExperiment_experimentBySlug;
+  refetch?: () => Promise<any>;
 } & RouteComponentProps;
 
 export const AppLayoutSidebarLaunched = ({
@@ -79,6 +80,7 @@ export const AppLayoutSidebarLaunched = ({
   analysisLoadingInSidebar = false,
   analysisError,
   experiment,
+  refetch = async () => {},
 }: AppLayoutSidebarLaunchedProps) => {
   const { slug } = useParams();
   const { primaryOutcomes, secondaryOutcomes } = useOutcomes(experiment);
@@ -275,7 +277,7 @@ export const AppLayoutSidebarLaunched = ({
                   )}
                 </DisabledItem>
               )}
-              <SidebarActions {...{ experiment }} />
+              <SidebarActions {...{ experiment, refetch }} />
             </Nav>
           </nav>
         </Col>

--- a/app/experimenter/nimbus-ui/src/components/AppLayoutWithExperiment/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/AppLayoutWithExperiment/index.tsx
@@ -153,6 +153,7 @@ const AppLayoutWithExperiment = ({
         analysisError,
         status,
         experiment,
+        refetch,
       }}
     >
       <section data-testid={testId} id={testId}>
@@ -208,6 +209,7 @@ type LayoutProps = {
   analysisLoadingInSidebar: boolean;
   analysisError?: Error;
   experiment: getExperiment_experimentBySlug;
+  refetch: () => Promise<any>;
 };
 
 const Layout = ({
@@ -218,6 +220,7 @@ const Layout = ({
   analysisLoadingInSidebar,
   analysisError,
   experiment,
+  refetch,
 }: LayoutProps) =>
   status?.launched ? (
     <AppLayoutSidebarLaunched
@@ -228,12 +231,15 @@ const Layout = ({
         analysisLoadingInSidebar,
         analysisError,
         experiment,
+        refetch,
       }}
     >
       {children}
     </AppLayoutSidebarLaunched>
   ) : (
-    <AppLayoutWithSidebar {...{ experiment }}>{children}</AppLayoutWithSidebar>
+    <AppLayoutWithSidebar {...{ experiment, refetch }}>
+      {children}
+    </AppLayoutWithSidebar>
   );
 
 export default AppLayoutWithExperiment;

--- a/app/experimenter/nimbus-ui/src/components/AppLayoutWithSidebar/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/AppLayoutWithSidebar/index.tsx
@@ -25,6 +25,7 @@ type AppLayoutWithSidebarProps = {
   testid?: string;
   children: React.ReactNode;
   experiment: getExperiment_experimentBySlug;
+  refetch?: () => Promise<any>;
 } & RouteComponentProps;
 
 export const editPages = [
@@ -54,6 +55,7 @@ export const AppLayoutWithSidebar = ({
   children,
   testid = "AppLayoutWithSidebar",
   experiment,
+  refetch = async () => {},
 }: AppLayoutWithSidebarProps) => {
   const { slug } = useParams();
   const { invalidPages, InvalidPagesList } = useReviewCheck(experiment);
@@ -127,7 +129,7 @@ export const AppLayoutWithSidebar = ({
                 </LinkNav>
               ))}
 
-              <SidebarActions {...{ experiment }} />
+              <SidebarActions {...{ experiment, refetch }} />
             </Nav>
           </nav>
         </Col>

--- a/app/experimenter/nimbus-ui/src/components/LinkNav/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/LinkNav/index.tsx
@@ -17,6 +17,7 @@ type LinkNavProps = {
   className?: string;
   textColor?: string;
   title?: string;
+  onClick?: () => void;
 };
 
 export const LinkNav = ({
@@ -28,6 +29,7 @@ export const LinkNav = ({
   className = "mx-1 my-2",
   textColor,
   title,
+  onClick,
 }: LinkNavProps) => {
   const to = route ? `${BASE_PATH}/${route}` : BASE_PATH;
   // an alternative to reach-router's `isCurrent` with identical
@@ -56,6 +58,7 @@ export const LinkNav = ({
           data-sb-kind={storiesOf}
           className={classNames(textColor, "d-flex align-items-center")}
           data-testid={testid}
+          onClick={onClick}
         >
           {children}
         </Link>

--- a/app/experimenter/nimbus-ui/src/components/SidebarActions/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/SidebarActions/index.test.tsx
@@ -2,8 +2,14 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import React from "react";
+import { UPDATE_EXPERIMENT_MUTATION } from "../../gql/experiments";
+import {
+  ARCHIVING_EXPERIMENT,
+  UNARCHIVING_EXPERIMENT,
+} from "../../hooks/useArchive";
+import { mockExperiment, mockExperimentMutation } from "../../lib/mocks";
 import { Subject } from "./mocks";
 
 describe("SidebarActions", () => {
@@ -12,16 +18,90 @@ describe("SidebarActions", () => {
     expect(screen.getByTestId("SidebarActions")).toBeInTheDocument();
   });
 
-  it("renders a disabled archive button", () => {
-    render(<Subject experiment={{ canArchive: false }} />);
+  it("renders a disabled archive button for unarchived experiment", () => {
+    render(<Subject experiment={{ isArchived: false, canArchive: false }} />);
     expect(screen.getByTestId("action-archive")).toHaveClass("text-muted");
+    expect(screen.getByTestId("action-archive")).toHaveTextContent(
+      "Archive Experiment",
+    );
   });
 
-  it("renders an enabled archive button", () => {
-    render(<Subject experiment={{ canArchive: true }} />);
+  it("renders an enabled archive button for unarchived experiment", () => {
+    render(<Subject experiment={{ isArchived: false, canArchive: true }} />);
     expect(screen.getByTestId("action-archive")).toHaveAttribute(
       "href",
       "/nimbus/my-special-slug/#",
     );
+    expect(screen.getByTestId("action-archive")).toHaveTextContent(
+      "Archive Experiment",
+    );
+  });
+  it("renders a disabled unarchive button for archived experiment", () => {
+    render(<Subject experiment={{ isArchived: true, canArchive: false }} />);
+    expect(screen.getByTestId("action-archive")).toHaveClass("text-muted");
+    expect(screen.getByTestId("action-archive")).toHaveTextContent(
+      "Unarchive Experiment",
+    );
+  });
+
+  it("renders an enabled archive button for unarchived experiment", () => {
+    render(<Subject experiment={{ isArchived: true, canArchive: true }} />);
+    expect(screen.getByTestId("action-archive")).toHaveAttribute(
+      "href",
+      "/nimbus/my-special-slug/#",
+    );
+    expect(screen.getByTestId("action-archive")).toHaveTextContent(
+      "Unarchive Experiment",
+    );
+  });
+  it("calls update archive mutation when archive button is clicked", async () => {
+    const experiment = mockExperiment({ isArchived: false, canArchive: true });
+    const refetch = jest.fn();
+    const mutationMock = mockExperimentMutation(
+      UPDATE_EXPERIMENT_MUTATION,
+      {
+        id: experiment.id,
+        isArchived: true,
+        changelogMessage: ARCHIVING_EXPERIMENT,
+      },
+      "updateExperiment",
+      {
+        message: "success",
+      },
+    );
+
+    render(<Subject {...{ experiment, refetch }} mocks={[mutationMock]} />);
+
+    const archiveButton = await screen.findByTestId("action-archive");
+
+    fireEvent.click(archiveButton);
+    await waitFor(() => {
+      expect(refetch).toHaveBeenCalled();
+    });
+  });
+  it("calls update archive mutation when unarchive button is clicked", async () => {
+    const experiment = mockExperiment({ isArchived: true, canArchive: true });
+    const refetch = jest.fn();
+    const mutationMock = mockExperimentMutation(
+      UPDATE_EXPERIMENT_MUTATION,
+      {
+        id: experiment.id,
+        isArchived: false,
+        changelogMessage: UNARCHIVING_EXPERIMENT,
+      },
+      "updateExperiment",
+      {
+        message: "success",
+      },
+    );
+
+    render(<Subject {...{ experiment, refetch }} mocks={[mutationMock]} />);
+
+    const archiveButton = await screen.findByTestId("action-archive");
+
+    fireEvent.click(archiveButton);
+    await waitFor(() => {
+      expect(refetch).toHaveBeenCalled();
+    });
   });
 });

--- a/app/experimenter/nimbus-ui/src/components/SidebarActions/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/SidebarActions/index.tsx
@@ -4,6 +4,7 @@
 
 import { RouteComponentProps } from "@reach/router";
 import React from "react";
+import { useArchive } from "../../hooks/useArchive";
 import { getExperiment_experimentBySlug } from "../../types/getExperiment";
 import { LinkNav } from "../LinkNav";
 import { ReactComponent as Trash } from "./trash.svg";
@@ -11,11 +12,18 @@ import { ReactComponent as Trash } from "./trash.svg";
 type SidebarModifyExperimentProps = {
   testid?: string;
   experiment: getExperiment_experimentBySlug;
+  refetch: () => Promise<any>;
 } & RouteComponentProps;
 
 export const SidebarActions = ({
   experiment,
+  refetch,
 }: SidebarModifyExperimentProps) => {
+  const { isLoading, callback: onUpdateArchived } = useArchive(
+    experiment,
+    refetch,
+  );
+
   return (
     <div data-testid={"SidebarActions"}>
       <p className="edit-divider position-relative small my-2">
@@ -27,8 +35,9 @@ export const SidebarActions = ({
         <LinkNav
           key="sidebar-actions-archive"
           route={`${experiment.slug}/#`}
-          disabled={!experiment.canArchive}
+          disabled={!experiment.canArchive || isLoading}
           testid="action-archive"
+          onClick={onUpdateArchived}
         >
           <Trash className="sidebar-icon" />
           {experiment.isArchived

--- a/app/experimenter/nimbus-ui/src/components/SidebarActions/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/components/SidebarActions/mocks.tsx
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import { MockedResponse } from "@apollo/client/testing";
 import { RouteComponentProps } from "@reach/router";
 import React from "react";
 import { SidebarActions } from ".";
@@ -11,8 +12,12 @@ import { getExperiment_experimentBySlug } from "../../types/getExperiment";
 
 export const Subject = ({
   experiment: overrides,
+  refetch = async () => {},
+  mocks = [],
 }: RouteComponentProps & {
   experiment?: Partial<getExperiment_experimentBySlug>;
+  refetch?: () => Promise<any>;
+  mocks?: MockedResponse[];
 }) => {
   const { mock, experiment } = mockExperimentQuery(
     "my-special-slug",
@@ -20,8 +25,8 @@ export const Subject = ({
   );
 
   return (
-    <RouterSlugProvider mocks={[mock]} path="/my-special-slug/edit">
-      <SidebarActions {...{ experiment }} />
+    <RouterSlugProvider mocks={[mock, ...mocks]} path="/my-special-slug/edit">
+      <SidebarActions {...{ experiment, refetch }} />
     </RouterSlugProvider>
   );
 };

--- a/app/experimenter/nimbus-ui/src/hooks/useArchive.test.tsx
+++ b/app/experimenter/nimbus-ui/src/hooks/useArchive.test.tsx
@@ -1,0 +1,119 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { MockedResponse } from "@apollo/client/testing";
+import { act, renderHook } from "@testing-library/react-hooks";
+import React from "react";
+import { UPDATE_EXPERIMENT_MUTATION } from "../gql/experiments";
+import { SUBMIT_ERROR } from "../lib/constants";
+import {
+  MockedCache,
+  mockExperiment,
+  mockExperimentMutation,
+} from "../lib/mocks";
+import { getExperiment_experimentBySlug } from "../types/getExperiment";
+import { ExperimentInput } from "../types/globalTypes";
+import { ARCHIVING_EXPERIMENT, useArchive } from "./useArchive";
+
+describe("hooks/useArchive", () => {
+  const experiment = mockExperiment();
+
+  it("handles success", async () => {
+    const refetch = jest.fn();
+    const { result } = setupTestHook(
+      experiment,
+      refetch,
+      "updateExperiment",
+      {
+        id: experiment.id,
+        isArchived: true,
+        changelogMessage: ARCHIVING_EXPERIMENT,
+      },
+      {
+        message: "success",
+      },
+    );
+    await act(result.current.callback);
+    expect(result.current.isLoading).toEqual(false);
+    expect(result.current.submitError).toBeNull();
+    expect(refetch).toHaveBeenCalled();
+  });
+
+  it("handles error message", async () => {
+    const refetch = jest.fn();
+    const { result } = setupTestHook(
+      experiment,
+      refetch,
+      "updateExperiment",
+      {
+        id: experiment.id,
+        isArchived: true,
+        changelogMessage: ARCHIVING_EXPERIMENT,
+      },
+      {
+        message: { isArchived: "something wrong" },
+      },
+    );
+    await act(result.current.callback);
+    expect(result.current.isLoading).toEqual(false);
+    expect(result.current.submitError).toEqual(
+      '{"isArchived":"something wrong"}',
+    );
+    expect(refetch).not.toHaveBeenCalled();
+  });
+
+  it("handles missing response", async () => {
+    const refetch = jest.fn();
+    const { result } = setupTestHook(
+      experiment,
+      refetch,
+      "missingResponse",
+      {
+        id: experiment.id,
+        isArchived: true,
+        changelogMessage: ARCHIVING_EXPERIMENT,
+      },
+      {
+        message: { isArchived: "something wrong" },
+      },
+    );
+    await act(result.current.callback);
+    expect(result.current.isLoading).toEqual(false);
+    expect(result.current.submitError).toEqual(SUBMIT_ERROR);
+
+    expect(refetch).not.toHaveBeenCalled();
+  });
+});
+
+export const setupTestHook = (
+  experiment: Partial<getExperiment_experimentBySlug>,
+  refetch: () => Promise<unknown>,
+  mutationResponseName: string,
+  input: ExperimentInput,
+  response: {
+    message: string | Record<string, any>;
+  },
+) => {
+  const mock = mockExperimentMutation(
+    UPDATE_EXPERIMENT_MUTATION,
+    input,
+    mutationResponseName,
+    response,
+  );
+
+  return renderHook(() => useArchive(experiment, refetch), {
+    wrapper,
+    initialProps: { mocks: [mock] },
+  });
+};
+
+export const wrapper = ({
+  mocks,
+  children,
+}: {
+  mocks?: MockedResponse[];
+  children?: React.ReactNode;
+}) => (
+  <MockedCache {...{ mocks }}>{children as React.ReactElement}</MockedCache>
+);

--- a/app/experimenter/nimbus-ui/src/hooks/useArchive.tsx
+++ b/app/experimenter/nimbus-ui/src/hooks/useArchive.tsx
@@ -1,0 +1,66 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { useMutation } from "@apollo/client";
+import { useMemo, useState } from "react";
+import { UPDATE_EXPERIMENT_MUTATION } from "../gql/experiments";
+import { SUBMIT_ERROR } from "../lib/constants";
+import { getExperiment_experimentBySlug as Experiment } from "../types/getExperiment";
+import { ExperimentInput } from "../types/globalTypes";
+import { updateExperiment_updateExperiment as UpdateExperiment } from "../types/updateExperiment";
+
+export const ARCHIVING_EXPERIMENT = "Archiving experiment";
+export const UNARCHIVING_EXPERIMENT = "Unarchiving experiment";
+
+export function useArchive(
+  experiment: Partial<Experiment>,
+  refetch: () => Promise<unknown>,
+) {
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState<boolean>(false);
+  const [updateExperiment, {}] = useMutation<
+    { updateExperiment: UpdateExperiment },
+    { input: ExperimentInput }
+  >(UPDATE_EXPERIMENT_MUTATION);
+
+  const callback = useMemo(
+    () => async () => {
+      setIsLoading(true);
+      setSubmitError(null);
+
+      try {
+        const result = await updateExperiment({
+          variables: {
+            input: {
+              id: experiment?.id,
+              isArchived: !experiment.isArchived,
+              changelogMessage: !experiment.isArchived
+                ? ARCHIVING_EXPERIMENT
+                : UNARCHIVING_EXPERIMENT,
+            },
+          },
+        });
+
+        if (!result.data?.updateExperiment) {
+          throw new Error(SUBMIT_ERROR);
+        }
+
+        const { message } = result.data.updateExperiment;
+
+        if (message && message !== "success" && typeof message === "object") {
+          throw new Error(JSON.stringify(message));
+        }
+
+        await refetch();
+      } catch (error) {
+        setSubmitError(error.message);
+      }
+      setIsLoading(false);
+    },
+
+    [updateExperiment, experiment],
+  );
+
+  return { callback, isLoading, submitError };
+}


### PR DESCRIPTION
Because

* We want the archive button to do the archiving!

This commit

* Adds a useArchive hook to wrap the mutation
* Attaches the useArchive hook to the button in the SidebarActions
* Tests tests tests