### PR TITLE
fix #6124 fix #5556 feat(nimbus-ui): preserve / restore search param state on navigation

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/PageHome/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageHome/index.tsx
@@ -36,7 +36,7 @@ type PageHomeProps = Record<string, any> & RouteComponentProps;
 
 export const Body = () => {
   const config = useConfig();
-  const [searchParams, updateSearchParams] = useSearchParamsState();
+  const [searchParams, updateSearchParams] = useSearchParamsState("PageHome");
   const { data, loading, error, refetch } = useQuery<{
     experiments: getAllExperiments_experiments[];
   }>(GET_EXPERIMENTS_QUERY);

--- a/app/experimenter/nimbus-ui/src/hooks/useSearchParamsState.test.tsx
+++ b/app/experimenter/nimbus-ui/src/hooks/useSearchParamsState.test.tsx
@@ -2,15 +2,45 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import { useNavigate } from "@reach/router";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import React from "react";
 import { RouterSlugProvider } from "../lib/test-utils";
-import useSearchParamsState from "./useSearchParamsState";
+import useSearchParamsState, { genStorageKey } from "./useSearchParamsState";
 
 // TODO: Work out how to test this stuff with @testing-library/react-hooks?
 // Depends on being wrapped by @reach/router, so that seems to make it difficult
 
 describe("hooks/useSearchParamsState", () => {
+  let originalSessionStorage: typeof window.sessionStorage;
+
+  beforeAll(() => {
+    originalSessionStorage = window.sessionStorage;
+    // @ts-ignore excuse this hackery for mocking sessionStorage
+    delete window.sessionStorage;
+    Object.defineProperty(window, "sessionStorage", {
+      writable: true,
+      value: {
+        getItem: jest.fn().mockName("getItem"),
+        setItem: jest.fn().mockName("setItem"),
+      },
+    });
+  });
+
+  beforeEach(() => {
+    // @ts-ignore excuse this hackery for mocking sessionStorage
+    sessionStorage.getItem.mockClear();
+    // @ts-ignore excuse this hackery for mocking sessionStorage
+    sessionStorage.setItem.mockClear();
+  });
+
+  afterAll(() => {
+    Object.defineProperty(window, "sessionStorage", {
+      writable: true,
+      value: originalSessionStorage,
+    });
+  });
+
   it("returns the current search parameters", async () => {
     const expected = { foo: "bar", baz: "quux" };
     const params = new URLSearchParams(expected);
@@ -38,11 +68,80 @@ describe("hooks/useSearchParamsState", () => {
     });
   });
 
+  it("preserves search parameters on navigation", async () => {
+    const storageSubKey = "PageFoo";
+    const expectedSearch = "wibble=wobble&beep=beep";
+    const path = `/xyzzy/edit?${expectedSearch}`;
+
+    render(<Subject {...{ path, storageSubKey, navigateTo: "/quux/edit" }} />);
+    fireEvent.click(screen.getByTestId("navigate"));
+
+    await waitFor(() => {
+      expect(window.sessionStorage.setItem).toHaveBeenCalledWith(
+        genStorageKey(storageSubKey),
+        expectedSearch,
+      );
+    });
+  });
+
+  it("restores search parameters on navigation with empty params", async () => {
+    const storageSubKey = "PageFoo";
+    const expectedSearch = "wibble=wobble&beep=beep";
+
+    // @ts-ignore excuse this hackery for mocking sessionStorage
+    window!.sessionStorage!.getItem.mockImplementation(() => expectedSearch);
+
+    render(
+      <Subject
+        {...{
+          storageSubKey,
+          path: "/xyzzy/edit?donot=restorethis",
+          navigateTo: "/quux/edit",
+        }}
+      />,
+    );
+    fireEvent.click(screen.getByTestId("navigate"));
+
+    await waitFor(() => {
+      expect(window.sessionStorage.getItem).toHaveBeenCalledWith(
+        genStorageKey(storageSubKey),
+      );
+      expect(screen.getByTestId("params").textContent).toEqual(expectedSearch);
+    });
+  });
+
+  it("does not restore empty search parameters", async () => {
+    const storageSubKey = "PageFoo";
+
+    // @ts-ignore excuse this hackery for mocking sessionStorage
+    window!.sessionStorage!.getItem.mockImplementation(() => null);
+
+    render(
+      <Subject
+        {...{
+          storageSubKey,
+          path: "/xyzzy/edit?donot=restorethis",
+          navigateTo: "/quux/edit",
+        }}
+      />,
+    );
+    fireEvent.click(screen.getByTestId("navigate"));
+
+    await waitFor(() => {
+      expect(window.sessionStorage.getItem).toHaveBeenCalledWith(
+        genStorageKey(storageSubKey),
+      );
+      expect(screen.getByTestId("params").textContent).toEqual("");
+    });
+  });
+
   interface SubjectProps {
     path: string;
     paramsToDelete?: Array<string>;
     // TODO: This should be Array<[string, string]> but current eslint version trips on it
     paramsToSet?: Array<string[]>;
+    storageSubKey?: string;
+    navigateTo?: string;
   }
   const Subject = (props: SubjectProps) => (
     <RouterSlugProvider path={props.path}>
@@ -50,8 +149,11 @@ describe("hooks/useSearchParamsState", () => {
     </RouterSlugProvider>
   );
   const SubjectInner = (props: SubjectProps) => {
-    const [params, setParams] = useSearchParamsState();
-    const onClick = () => {
+    const { storageSubKey, navigateTo } = props;
+    const navigate = useNavigate();
+    const [params, setParams] = useSearchParamsState(storageSubKey);
+
+    const onSetParamsClick = () => {
       const { paramsToDelete = [], paramsToSet = [] } = props;
       setParams((params) => {
         for (const name of paramsToDelete) {
@@ -62,11 +164,17 @@ describe("hooks/useSearchParamsState", () => {
         }
       });
     };
+
+    const onNavigateClick = () => navigateTo && navigate(navigateTo);
+
     return (
       <div>
         <code data-testid="params">{params.toString()}</code>
-        <button data-testid="setParams" onClick={onClick}>
+        <button data-testid="setParams" onClick={onSetParamsClick}>
           Set params
+        </button>
+        <button data-testid="navigate" onClick={onNavigateClick}>
+          Navigate
         </button>
       </div>
     );

--- a/app/experimenter/nimbus-ui/src/hooks/useSearchParamsState.ts
+++ b/app/experimenter/nimbus-ui/src/hooks/useSearchParamsState.ts
@@ -3,11 +3,29 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { useLocation, useNavigate } from "@reach/router";
-import { useMemo } from "react";
+import { useEffect, useMemo } from "react";
 
-export function useSearchParamsState() {
+export const genStorageKey = (subkey: string) => `searchParamState:${subkey}`;
+
+export function useSearchParamsState(storageSubKey?: string) {
   const location = useLocation();
   const navigate = useNavigate();
+
+  useEffect(() => {
+    if (!storageSubKey) return;
+    const storage = window.sessionStorage;
+    const storageKey = genStorageKey(storageSubKey);
+    if (location.search) {
+      const params = new URLSearchParams(location.search);
+      storage.setItem(storageKey, params.toString());
+    } else {
+      const savedParams = storage.getItem(storageKey);
+      if (savedParams) {
+        navigate(`${location.pathname}?${savedParams}`);
+      }
+    }
+  }, [storageSubKey, location.search]);
+
   return useMemo(() => {
     const params = new URLSearchParams(location.search);
     const setParams = (updaterFn: (params: URLSearchParams) => void) => {


### PR DESCRIPTION
Because:

* We want to update the homepage directory to “remember” the last tab
  you were on when you left.

This commit:

* adds the option to useSearchParamsState to preserve search params in
  session storage on navigation and to restore the params on return with
  an empty search string.

* uses the preserve / restore option on PageHome