### PR TITLE
fixes #6195 feat(reporting): add link to legacy to get to reporting

### DIFF
--- a/app/experimenter/legacy-ui/templates/base.html
+++ b/app/experimenter/legacy-ui/templates/base.html
@@ -69,7 +69,7 @@
               {{ request.user.subscribed_experiments.count }} Subscribed
               Deliver{{ request.user.subscribed_experiments.count|pluralize:"y,ies" }}
             </a>
-            <a class="nocolorstyle d-block" href="{% url "home" %}reporting">
+            <a class="nocolorstyle d-block" href="{% url "reporting" %}">
               <span class="fas fa-table"></span>
               Go to Reporting
             </a>

--- a/app/experimenter/legacy-ui/templates/base.html
+++ b/app/experimenter/legacy-ui/templates/base.html
@@ -69,6 +69,10 @@
               {{ request.user.subscribed_experiments.count }} Subscribed
               Deliver{{ request.user.subscribed_experiments.count|pluralize:"y,ies" }}
             </a>
+            <a class="nocolorstyle d-block" href="{% url "home" %}reporting">
+              <span class="fas fa-table"></span>
+              Go to Reporting
+            </a>
           </div>
         </div>
       </div>


### PR DESCRIPTION
Because

* It would allow users to navigate to reporting

This commit:

* adds a link to legacy home page to reporting