### PR TITLE
fix #6134 fix(nimbus-ui): always fetch experiments when navigating to directory view

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/PageHome/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageHome/index.tsx
@@ -39,7 +39,7 @@ export const Body = () => {
   const [searchParams, updateSearchParams] = useSearchParamsState();
   const { data, loading, error, refetch } = useQuery<{
     experiments: getAllExperiments_experiments[];
-  }>(GET_EXPERIMENTS_QUERY);
+  }>(GET_EXPERIMENTS_QUERY, { fetchPolicy: "network-only" });
   const ErrorAlert = useRefetchOnError(error, refetch);
 
   const selectedTab = searchParams.get("tab") || "live";


### PR DESCRIPTION
Because:

* we want to see the directory view updated after performing an action
  that changes an experiment's status

This commit:

* uses the "network-only" fetch policy for the query fetching
  experiments for the directory view, which should cause a fresh fetch
  every time navigation to the page happens