### PR TITLE
fix #6198 bug(nimbus): support old changelog data

### DIFF
--- a/app/experimenter/experiments/changelog_utils/nimbus.py
+++ b/app/experimenter/experiments/changelog_utils/nimbus.py
@@ -50,10 +50,9 @@ def generate_nimbus_changelog(experiment, changed_by, message):
         old_status = latest_change.new_status
         old_status_next = latest_change.new_status_next
         old_publish_status = latest_change.new_publish_status
-        published_dto_changed = (
-            latest_change.experiment_data["published_dto"]
-            != experiment_data["published_dto"]
-        )
+        published_dto_changed = latest_change.experiment_data.get(
+            "published_dto"
+        ) != experiment_data.get("published_dto")
 
     return NimbusChangeLog.objects.create(
         experiment=experiment,

--- a/app/experimenter/experiments/tests/test_changelog_utils/test_changelog_utils_nimbus.py
+++ b/app/experimenter/experiments/tests/test_changelog_utils/test_changelog_utils_nimbus.py
@@ -7,7 +7,10 @@ from experimenter.experiments.changelog_utils import (
 )
 from experimenter.experiments.models import NimbusExperiment
 from experimenter.experiments.tests.factories import NimbusExperimentFactory
-from experimenter.experiments.tests.factories.nimbus import NimbusFeatureConfigFactory
+from experimenter.experiments.tests.factories.nimbus import (
+    NimbusChangeLogFactory,
+    NimbusFeatureConfigFactory,
+)
 from experimenter.openidc.tests.factories import UserFactory
 from experimenter.outcomes import Outcomes
 from experimenter.outcomes.tests import mock_valid_outcomes
@@ -251,3 +254,12 @@ class TestGenerateNimbusChangeLog(TestCase):
         change = generate_nimbus_changelog(experiment, self.user, "test message")
 
         self.assertTrue(change.published_dto_changed)
+
+    def test_generates_changelog_with_out_of_date_latest_change(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED
+        )
+        NimbusChangeLogFactory.create(
+            experiment=experiment, experiment_data={"some_old": "data"}
+        )
+        generate_nimbus_changelog(experiment, self.user, "test message")


### PR DESCRIPTION
Because

* We store a serialization of the experiment on each changelog
* As we introduce new fields, those old serializations will not contain them
* If we build logic that inspects these fields, we have to be careful that some field may not exist on old changelogs

This commit

* Changes key lookups to expect they may not exist