### PR TITLE
fix #6201 refactor(nimbus-ui): use App-global storage for useSearchParamsState

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/App/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/App/index.tsx
@@ -6,7 +6,7 @@ import { useQuery } from "@apollo/client";
 import { Redirect, RouteComponentProps, Router } from "@reach/router";
 import React from "react";
 import { GET_CONFIG_QUERY } from "../../gql/config";
-import { useRefetchOnError } from "../../hooks";
+import { SearchParamsStateProvider, useRefetchOnError } from "../../hooks";
 import PageEditAudience from "../PageEditAudience";
 import PageEditBranches from "../PageEditBranches";
 import PageEditMetrics from "../PageEditMetrics";
@@ -36,19 +36,21 @@ const App = ({ basepath }: { basepath: string }) => {
   }
 
   return (
-    <Router {...{ basepath }}>
-      <PageHome path="/" />
-      <PageNew path="new" />
-      <PageSummary path=":slug" />
-      <Root path=":slug/edit">
-        <Redirect from="/" to="overview" noThrow />
-        <PageEditOverview path="overview" />
-        <PageEditBranches path="branches" />
-        <PageEditMetrics path="metrics" />
-        <PageEditAudience path="audience" />
-      </Root>
-      <PageResults path=":slug/results" />
-    </Router>
+    <SearchParamsStateProvider>
+      <Router {...{ basepath }}>
+        <PageHome path="/" />
+        <PageNew path="new" />
+        <PageSummary path=":slug" />
+        <Root path=":slug/edit">
+          <Redirect from="/" to="overview" noThrow />
+          <PageEditOverview path="overview" />
+          <PageEditBranches path="branches" />
+          <PageEditMetrics path="metrics" />
+          <PageEditAudience path="audience" />
+        </Root>
+        <PageResults path=":slug/results" />
+      </Router>
+    </SearchParamsStateProvider>
   );
 };
 

--- a/app/experimenter/nimbus-ui/src/hooks/useSearchParamsState.tsx
+++ b/app/experimenter/nimbus-ui/src/hooks/useSearchParamsState.tsx
@@ -3,28 +3,49 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { useLocation, useNavigate } from "@reach/router";
-import { useEffect, useMemo } from "react";
+import React, {
+  createContext,
+  MutableRefObject,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+} from "react";
 
-export const genStorageKey = (subkey: string) => `searchParamState:${subkey}`;
+export type SearchParamStorage = Record<string, string>;
+export type SearchParamsContextState =
+  | MutableRefObject<SearchParamStorage>
+  | undefined;
 
-export function useSearchParamsState(storageSubKey?: string) {
+export const SearchParamsContext =
+  createContext<SearchParamsContextState>(undefined);
+
+export const SearchParamsStateProvider: React.FC = ({ children }) => {
+  const storage = useRef<SearchParamStorage>({});
+  return (
+    <SearchParamsContext.Provider value={storage}>
+      {children}
+    </SearchParamsContext.Provider>
+  );
+};
+
+export function useSearchParamsState(storageKey?: string) {
+  const storage = useContext(SearchParamsContext);
   const location = useLocation();
   const navigate = useNavigate();
 
   useEffect(() => {
-    if (!storageSubKey) return;
-    const storage = window.sessionStorage;
-    const storageKey = genStorageKey(storageSubKey);
+    if (!storage?.current || !storageKey) return;
     if (location.search) {
       const params = new URLSearchParams(location.search);
-      storage.setItem(storageKey, params.toString());
+      storage.current[storageKey] = params.toString();
     } else {
-      const savedParams = storage.getItem(storageKey);
+      const savedParams = storage.current[storageKey];
       if (savedParams) {
         navigate(`${location.pathname}?${savedParams}`);
       }
     }
-  }, [storageSubKey, location.search]);
+  }, [navigate, storage, storageKey, location.pathname, location.search]);
 
   return useMemo(() => {
     const params = new URLSearchParams(location.search);
@@ -34,7 +55,7 @@ export function useSearchParamsState(storageSubKey?: string) {
       navigate(`${location.pathname}?${nextParams.toString()}`);
     };
     return [params, setParams] as const;
-  }, [navigate, location.search]);
+  }, [navigate, location.pathname, location.search]);
 }
 
 export type UpdateSearchParams = ReturnType<typeof useSearchParamsState>[1];

--- a/app/experimenter/nimbus-ui/src/lib/test-utils.tsx
+++ b/app/experimenter/nimbus-ui/src/lib/test-utils.tsx
@@ -13,6 +13,7 @@ import {
 } from "@reach/router";
 import { render, screen } from "@testing-library/react";
 import React from "react";
+import { SearchParamsStateProvider } from "../hooks";
 import { snakeToCamelCase } from "./caseConversions";
 import { MockedCache, mockExperimentQuery } from "./mocks";
 
@@ -39,15 +40,19 @@ export const RouterSlugProvider = ({
   const history = createHistory(source);
 
   return (
-    <LocationProvider {...{ history }}>
-      <Router>
-        <Route
-          path=":slug/edit"
-          data-testid="app"
-          component={() => <MockedCache {...{ mocks }}>{children}</MockedCache>}
-        />
-      </Router>
-    </LocationProvider>
+    <SearchParamsStateProvider>
+      <LocationProvider {...{ history }}>
+        <Router>
+          <Route
+            path=":slug/edit"
+            data-testid="app"
+            component={() => (
+              <MockedCache {...{ mocks }}>{children}</MockedCache>
+            )}
+          />
+        </Router>
+      </LocationProvider>
+    </SearchParamsStateProvider>
   );
 };
 


### PR DESCRIPTION
Because:

* sessionStorage may offer some undesirable properties for this hook

This commit:

* switches useSearchParamsState over to use state managed by an
  App-global Context provider