### PR TITLE
chore(nimbus): prefetch related to optimize directory view query

### DIFF
--- a/app/experimenter/experiments/api/v5/queries.py
+++ b/app/experimenter/experiments/api/v5/queries.py
@@ -24,7 +24,7 @@ class Query(graphene.ObjectType):
     )
 
     def resolve_experiments(root, info):
-        return NimbusExperiment.objects.all()
+        return NimbusExperiment.objects.with_related()
 
     def resolve_experiment_by_slug(root, info, slug):
         try:

--- a/app/experimenter/experiments/tests/test_models/test_models_nimbus.py
+++ b/app/experimenter/experiments/tests/test_models/test_models_nimbus.py
@@ -374,11 +374,13 @@ class TestNimbusExperiment(TestCase):
             experiment=experiment,
             old_status=NimbusExperiment.Status.DRAFT,
             new_status=NimbusExperiment.Status.LIVE,
+            changed_on=timezone.now() + datetime.timedelta(days=1),
         )
         start_change = NimbusChangeLogFactory(
             experiment=experiment,
             old_status=NimbusExperiment.Status.DRAFT,
             new_status=NimbusExperiment.Status.LIVE,
+            changed_on=timezone.now() + datetime.timedelta(days=2),
         )
         self.assertEqual(experiment.start_date, start_change.changed_on.date())
 
@@ -397,11 +399,13 @@ class TestNimbusExperiment(TestCase):
             experiment=experiment,
             old_status=NimbusExperiment.Status.LIVE,
             new_status=NimbusExperiment.Status.COMPLETE,
+            changed_on=timezone.now() + datetime.timedelta(days=1),
         )
         end_change = NimbusChangeLogFactory(
             experiment=experiment,
             old_status=NimbusExperiment.Status.LIVE,
             new_status=NimbusExperiment.Status.COMPLETE,
+            changed_on=timezone.now() + datetime.timedelta(days=2),
         )
         self.assertEqual(experiment.end_date, end_change.changed_on.date())
 


### PR DESCRIPTION
Because

* Now that we fetch the directory view on every load
* And we are starting to have many experiments in the database
* We should optimize the queries for that page

This commit

* Prefetches the related entities for the experiments directory view