### PR TITLE
fix #6129 refactor/feat(nimbus): Results page - refactor with context, reference metadata for control branch name

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/PageResults/GraphsWeekly/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/GraphsWeekly/index.stories.tsx
@@ -6,18 +6,19 @@ import { withLinks } from "@storybook/addon-links";
 import { storiesOf } from "@storybook/react";
 import React from "react";
 import GraphsWeekly from ".";
+import { MockResultsContextProvider } from "../../../lib/mocks";
 import { GROUP } from "../../../lib/visualization/constants";
-import { mockAnalysis } from "../../../lib/visualization/mocks";
 
 storiesOf("pages/Results/GraphsWeekly", module)
   .addDecorator(withLinks)
   .add("with two data points", () => {
     return (
-      <GraphsWeekly
-        weeklyResults={mockAnalysis().weekly}
-        outcomeSlug="feature_d"
-        outcomeName="Feature D"
-        group={GROUP.OTHER}
-      />
+      <MockResultsContextProvider>
+        <GraphsWeekly
+          outcomeSlug="feature_d"
+          outcomeName="Feature D"
+          group={GROUP.OTHER}
+        />
+      </MockResultsContextProvider>
     );
   });

--- a/app/experimenter/nimbus-ui/src/components/PageResults/GraphsWeekly/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/GraphsWeekly/index.test.tsx
@@ -5,10 +5,12 @@
 import { act, fireEvent, render, screen } from "@testing-library/react";
 import React from "react";
 import GraphsWeekly from ".";
-import { mockExperimentQuery } from "../../../lib/mocks";
+import {
+  mockExperimentQuery,
+  MockResultsContextProvider,
+} from "../../../lib/mocks";
 import { RouterSlugProvider } from "../../../lib/test-utils";
 import { GROUP } from "../../../lib/visualization/constants";
-import { mockAnalysis } from "../../../lib/visualization/mocks";
 
 describe("GraphsWeekly", () => {
   it("Displays 'Show Graphs' button and updates its label when clicked", async () => {
@@ -16,12 +18,13 @@ describe("GraphsWeekly", () => {
 
     render(
       <RouterSlugProvider mocks={[mock]}>
-        <GraphsWeekly
-          weeklyResults={mockAnalysis().weekly}
-          outcomeSlug="feature_d"
-          outcomeName="Feature D"
-          group={GROUP.OTHER}
-        />
+        <MockResultsContextProvider>
+          <GraphsWeekly
+            outcomeSlug="feature_d"
+            outcomeName="Feature D"
+            group={GROUP.OTHER}
+          />
+        </MockResultsContextProvider>
       </RouterSlugProvider>,
     );
     expect(screen.getByText("Show Graphs")).toBeInTheDocument();

--- a/app/experimenter/nimbus-ui/src/components/PageResults/GraphsWeekly/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/GraphsWeekly/index.tsx
@@ -1,18 +1,18 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-import React, { useState } from "react";
+import React, { useContext, useState } from "react";
 import Collapse from "react-bootstrap/Collapse";
 import vegaEmbed, { VisualizationSpec } from "vega-embed";
 import { ReactComponent as CollapseMinus } from "../../../images/minus.svg";
 import { ReactComponent as ExpandPlus } from "../../../images/plus.svg";
+import { ResultsContext } from "../../../lib/contexts";
 import {
   BRANCH_COMPARISON,
   BRANCH_COMPARISON_TITLE,
 } from "../../../lib/visualization/constants";
 import { lineGraphConfig } from "../../../lib/visualization/graphConfig";
 import {
-  AnalysisDataWeekly,
   BranchDescription,
   FormattedAnalysisPoint,
 } from "../../../lib/visualization/types";
@@ -84,18 +84,21 @@ const embedGraphs = (
 };
 
 type GraphsWeeklyProps = {
-  weeklyResults: AnalysisDataWeekly;
   outcomeSlug: string;
   outcomeName: string;
   group: string;
 };
 
 const GraphsWeekly = ({
-  weeklyResults = {},
   outcomeSlug,
   outcomeName,
   group,
 }: GraphsWeeklyProps) => {
+  const {
+    analysis: { weekly },
+  } = useContext(ResultsContext);
+  const weeklyResults = weekly!;
+
   const mergedBranchData = getMergedBranchData(
     outcomeSlug,
     group,
@@ -104,8 +107,8 @@ const GraphsWeekly = ({
 
   const [open, setOpen] = useState(false);
   const [embedded, setEmbedded] = useState(false);
-  const graphsVisibleClass = !open ? "d-none" : "";
-  const graphsHiddenClass = open ? "d-none" : "";
+  const graphsVisibleClass = !open ? "d-none" : undefined;
+  const graphsHiddenClass = open ? "d-none" : undefined;
 
   const handleCollapse = () => {
     setOpen(!open);

--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableHighlights/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableHighlights/index.stories.tsx
@@ -6,13 +6,11 @@ import { withLinks } from "@storybook/addon-links";
 import { storiesOf } from "@storybook/react";
 import React from "react";
 import TableHighlights from ".";
-import { mockExperimentQuery } from "../../../lib/mocks";
+import {
+  mockExperimentQuery,
+  MockResultsContextProvider,
+} from "../../../lib/mocks";
 import { RouterSlugProvider } from "../../../lib/test-utils";
-import { mockAnalysis } from "../../../lib/visualization/mocks";
-import { getSortedBranches } from "../../../lib/visualization/utils";
-
-const results = mockAnalysis();
-const sortedBranches = getSortedBranches(results);
 
 storiesOf("pages/Results/TableHighlights", module)
   .addDecorator(withLinks)
@@ -20,7 +18,9 @@ storiesOf("pages/Results/TableHighlights", module)
     const { mock, experiment } = mockExperimentQuery("demo-slug");
     return (
       <RouterSlugProvider mocks={[mock]}>
-        <TableHighlights {...{ experiment, results, sortedBranches }} />
+        <MockResultsContextProvider>
+          <TableHighlights {...{ experiment }} />
+        </MockResultsContextProvider>
       </RouterSlugProvider>
     );
   })
@@ -30,7 +30,9 @@ storiesOf("pages/Results/TableHighlights", module)
     });
     return (
       <RouterSlugProvider mocks={[mock]}>
-        <TableHighlights {...{ experiment, results, sortedBranches }} />
+        <MockResultsContextProvider>
+          <TableHighlights {...{ experiment }} />
+        </MockResultsContextProvider>
       </RouterSlugProvider>
     );
   });

--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableHighlights/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableHighlights/index.test.tsx
@@ -10,10 +10,47 @@ import {
   MockResultsContextProvider,
 } from "../../../lib/mocks";
 import { RouterSlugProvider } from "../../../lib/test-utils";
+import {
+  mockAnalysis,
+  MOCK_METADATA_NO_REF_BRANCH,
+} from "../../../lib/visualization/mocks";
 
 const { mock, experiment } = mockExperimentQuery("demo-slug");
 
 describe("TableHighlights", () => {
+  it("recieves correct controlBranchName from Context when metadata contains `reference_branch`", async () => {
+    const metadata = {
+      ...MOCK_METADATA_NO_REF_BRANCH,
+      reference_branch: "treatment",
+    };
+    const analysis = mockAnalysis({ metadata });
+    render(
+      <RouterSlugProvider mocks={[mock]}>
+        <MockResultsContextProvider {...{ analysis }}>
+          <TableHighlights {...{ experiment }} />
+        </MockResultsContextProvider>
+      </RouterSlugProvider>,
+    );
+
+    // branches get sorted with the control branch displayed first
+    await screen.findByText("treatment", {
+      selector: "table tr:first-of-type",
+    });
+  });
+
+  it("sets controlBranchName in Context correctly when metadata does not contain `reference_branch`", async () => {
+    const analysis = mockAnalysis({ metadata: MOCK_METADATA_NO_REF_BRANCH });
+    render(
+      <RouterSlugProvider mocks={[mock]}>
+        <MockResultsContextProvider {...{ analysis }}>
+          <TableHighlights {...{ experiment }} />
+        </MockResultsContextProvider>
+      </RouterSlugProvider>,
+    );
+
+    // branches get sorted with the control branch displayed first
+    await screen.findByText("control", { selector: "table tr:first-of-type" });
+  });
   it("has participants shown for each variant", () => {
     render(
       <RouterSlugProvider mocks={[mock]}>

--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableHighlights/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableHighlights/index.test.tsx
@@ -5,20 +5,21 @@
 import { render, screen } from "@testing-library/react";
 import React from "react";
 import TableHighlights from ".";
-import { mockExperimentQuery } from "../../../lib/mocks";
+import {
+  mockExperimentQuery,
+  MockResultsContextProvider,
+} from "../../../lib/mocks";
 import { RouterSlugProvider } from "../../../lib/test-utils";
-import { mockAnalysis } from "../../../lib/visualization/mocks";
-import { getSortedBranches } from "../../../lib/visualization/utils";
 
 const { mock, experiment } = mockExperimentQuery("demo-slug");
-const results = mockAnalysis();
-const sortedBranches = getSortedBranches(results);
 
 describe("TableHighlights", () => {
   it("has participants shown for each variant", () => {
     render(
       <RouterSlugProvider mocks={[mock]}>
-        <TableHighlights {...{ experiment, results, sortedBranches }} />
+        <MockResultsContextProvider>
+          <TableHighlights {...{ experiment }} />
+        </MockResultsContextProvider>
       </RouterSlugProvider>,
     );
 
@@ -33,7 +34,9 @@ describe("TableHighlights", () => {
     const branchDescription = experiment.referenceBranch!.description;
     render(
       <RouterSlugProvider mocks={[mock]}>
-        <TableHighlights {...{ experiment, results, sortedBranches }} />
+        <MockResultsContextProvider>
+          <TableHighlights {...{ experiment }} />
+        </MockResultsContextProvider>
       </RouterSlugProvider>,
     );
 
@@ -43,7 +46,9 @@ describe("TableHighlights", () => {
   it("has correctly labelled result significance", async () => {
     render(
       <RouterSlugProvider mocks={[mock]}>
-        <TableHighlights {...{ experiment, results, sortedBranches }} />
+        <MockResultsContextProvider>
+          <TableHighlights {...{ experiment }} />
+        </MockResultsContextProvider>
       </RouterSlugProvider>,
     );
 
@@ -55,7 +60,9 @@ describe("TableHighlights", () => {
   it("has the expected control and treatment labels", async () => {
     render(
       <RouterSlugProvider mocks={[mock]}>
-        <TableHighlights {...{ experiment, results, sortedBranches }} />
+        <MockResultsContextProvider>
+          <TableHighlights {...{ experiment }} />
+        </MockResultsContextProvider>
       </RouterSlugProvider>,
     );
 

--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableHighlights/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableHighlights/index.tsx
@@ -75,12 +75,9 @@ const TableHighlights = ({ experiment }: TableHighlightsProps) => {
   const {
     analysis: { metadata, overall },
     sortedBranches,
+    controlBranchName,
   } = useContext(ResultsContext);
   const overallResults = overall!;
-  // const controlBranchName = getControlBranchName(
-  //   results?.metadata!,
-  //   overallResults,
-  // );
 
   return (
     <table data-testid="table-highlights" className="table mt-4 mb-0">
@@ -92,6 +89,8 @@ const TableHighlights = ({ experiment }: TableHighlightsProps) => {
             ];
           const participantCount =
             userCountMetric[BRANCH_COMPARISON.ABSOLUTE]["first"]["point"];
+
+          const isControlBranch = branch === controlBranchName;
           return (
             <tr key={branch} className="border-top">
               <th className="align-middle p-1 p-lg-3" scope="row">
@@ -104,7 +103,7 @@ const TableHighlights = ({ experiment }: TableHighlightsProps) => {
               <td className="p-1 p-lg-3 col-md-4 align-middle">
                 {branchDescriptions[branch]}
               </td>
-              {overallResults[branch]["is_control"] ? (
+              {isControlBranch ? (
                 <td className="p-1 p-lg-3 align-middle">
                   <div className="font-italic align-middle">---baseline---</div>
                 </td>
@@ -115,7 +114,7 @@ const TableHighlights = ({ experiment }: TableHighlightsProps) => {
                     const displayType = getTableDisplayType(
                       metricKey,
                       TABLE_LABEL.HIGHLIGHTS,
-                      overallResults[branch]["is_control"],
+                      isControlBranch,
                     );
                     const tooltip =
                       metadata?.metrics[metricKey]?.description ||
@@ -127,7 +126,12 @@ const TableHighlights = ({ experiment }: TableHighlightsProps) => {
                         results={overallResults[branch]}
                         group={metric.group}
                         tableLabel={TABLE_LABEL.HIGHLIGHTS}
-                        {...{ metricKey, displayType, tooltip }}
+                        {...{
+                          metricKey,
+                          displayType,
+                          tooltip,
+                          isControlBranch,
+                        }}
                       />
                     );
                   })}

--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableHighlights/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableHighlights/index.tsx
@@ -2,8 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from "react";
+import React, { useContext } from "react";
 import { useOutcomes } from "../../../hooks";
+import { ResultsContext } from "../../../lib/contexts";
 import { OutcomesList } from "../../../lib/types";
 import {
   BRANCH_COMPARISON,
@@ -13,7 +14,6 @@ import {
   METRICS_TIPS,
   TABLE_LABEL,
 } from "../../../lib/visualization/constants";
-import { AnalysisData } from "../../../lib/visualization/types";
 import { getTableDisplayType } from "../../../lib/visualization/utils";
 import {
   getExperiment_experimentBySlug,
@@ -23,9 +23,7 @@ import {
 import TableVisualizationRow from "../TableVisualizationRow";
 
 type TableHighlightsProps = {
-  results: AnalysisData;
   experiment: getExperiment_experimentBySlug;
-  sortedBranches: string[];
 };
 
 type Branch =
@@ -67,24 +65,22 @@ const getBranchDescriptions = (
   );
 };
 
-const TableHighlights = ({
-  results = {
-    daily: [],
-    weekly: {},
-    overall: {},
-    metadata: { metrics: {}, outcomes: {} },
-    show_analysis: false,
-  },
-  experiment,
-  sortedBranches,
-}: TableHighlightsProps) => {
+const TableHighlights = ({ experiment }: TableHighlightsProps) => {
   const { primaryOutcomes } = useOutcomes(experiment);
   const highlightMetricsList = getHighlightMetrics(primaryOutcomes);
   const branchDescriptions = getBranchDescriptions(
     experiment.referenceBranch,
     experiment.treatmentBranches,
   );
-  const overallResults = results?.overall!;
+  const {
+    analysis: { metadata, overall },
+    sortedBranches,
+  } = useContext(ResultsContext);
+  const overallResults = overall!;
+  // const controlBranchName = getControlBranchName(
+  //   results?.metadata!,
+  //   overallResults,
+  // );
 
   return (
     <table data-testid="table-highlights" className="table mt-4 mb-0">
@@ -122,7 +118,7 @@ const TableHighlights = ({
                       overallResults[branch]["is_control"],
                     );
                     const tooltip =
-                      results.metadata?.metrics[metricKey]?.description ||
+                      metadata?.metrics[metricKey]?.description ||
                       metric.tooltip;
                     return (
                       <TableVisualizationRow

--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableMetricConversion/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableMetricConversion/index.stories.tsx
@@ -6,12 +6,11 @@ import { withLinks } from "@storybook/addon-links";
 import { storiesOf } from "@storybook/react";
 import React from "react";
 import TableMetricConversion from ".";
-import { mockExperimentQuery, mockOutcomeSets } from "../../../lib/mocks";
-import { mockAnalysis } from "../../../lib/visualization/mocks";
-import { getSortedBranches } from "../../../lib/visualization/utils";
-
-const results = mockAnalysis().overall;
-const sortedBranches = getSortedBranches(mockAnalysis());
+import {
+  mockExperimentQuery,
+  mockOutcomeSets,
+  MockResultsContextProvider,
+} from "../../../lib/mocks";
 
 storiesOf("pages/Results/TableMetricConversion", module)
   .addDecorator(withLinks)
@@ -22,10 +21,9 @@ storiesOf("pages/Results/TableMetricConversion", module)
     const { primaryOutcomes } = mockOutcomeSets(experiment);
 
     return (
-      <TableMetricConversion
-        {...{ results, sortedBranches }}
-        outcome={primaryOutcomes![0]!}
-      />
+      <MockResultsContextProvider>
+        <TableMetricConversion outcome={primaryOutcomes![0]!} />
+      </MockResultsContextProvider>
     );
   })
   .add("with negative primary metric", () => {
@@ -35,10 +33,9 @@ storiesOf("pages/Results/TableMetricConversion", module)
     const { primaryOutcomes } = mockOutcomeSets(experiment);
 
     return (
-      <TableMetricConversion
-        {...{ results, sortedBranches }}
-        outcome={primaryOutcomes![0]!}
-      />
+      <MockResultsContextProvider>
+        <TableMetricConversion outcome={primaryOutcomes![0]!} />
+      </MockResultsContextProvider>
     );
   })
   .add("with neutral primary metric", () => {
@@ -48,9 +45,8 @@ storiesOf("pages/Results/TableMetricConversion", module)
     const { primaryOutcomes } = mockOutcomeSets(experiment);
 
     return (
-      <TableMetricConversion
-        {...{ results, sortedBranches }}
-        outcome={primaryOutcomes![0]!}
-      />
+      <MockResultsContextProvider>
+        <TableMetricConversion outcome={primaryOutcomes![0]!} />
+      </MockResultsContextProvider>
     );
   });

--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableMetricConversion/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableMetricConversion/index.test.tsx
@@ -5,13 +5,12 @@
 import { render, screen } from "@testing-library/react";
 import React from "react";
 import TableMetricConversion from ".";
-import { mockExperimentQuery, mockOutcomeSets } from "../../../lib/mocks";
+import {
+  mockExperimentQuery,
+  mockOutcomeSets,
+  MockResultsContextProvider,
+} from "../../../lib/mocks";
 import { RouterSlugProvider } from "../../../lib/test-utils";
-import { mockAnalysis } from "../../../lib/visualization/mocks";
-import { getSortedBranches } from "../../../lib/visualization/utils";
-
-const results = mockAnalysis().overall;
-const sortedBranches = getSortedBranches(mockAnalysis());
 
 describe("TableMetricConversion", () => {
   it("has the correct headings", () => {
@@ -24,12 +23,12 @@ describe("TableMetricConversion", () => {
     const { primaryOutcomes } = mockOutcomeSets(experiment);
 
     render(
-      <RouterSlugProvider mocks={[mock]}>
-        <TableMetricConversion
-          {...{ results, sortedBranches }}
-          outcome={primaryOutcomes![0]!}
-        />
-      </RouterSlugProvider>,
+      <MockResultsContextProvider>
+        <RouterSlugProvider mocks={[mock]}>
+          <TableMetricConversion outcome={primaryOutcomes![0]!} />
+        </RouterSlugProvider>
+        ,
+      </MockResultsContextProvider>,
     );
 
     EXPECTED_HEADINGS.forEach((heading) => {
@@ -42,12 +41,12 @@ describe("TableMetricConversion", () => {
     const { primaryOutcomes } = mockOutcomeSets(experiment);
 
     render(
-      <RouterSlugProvider mocks={[mock]}>
-        <TableMetricConversion
-          {...{ results, sortedBranches }}
-          outcome={primaryOutcomes![0]!}
-        />
-      </RouterSlugProvider>,
+      <MockResultsContextProvider>
+        <RouterSlugProvider mocks={[mock]}>
+          <TableMetricConversion outcome={primaryOutcomes![0]!} />
+        </RouterSlugProvider>
+        ,
+      </MockResultsContextProvider>,
     );
 
     const negativeSignificance = screen.queryByTestId("negative-significance");
@@ -63,12 +62,12 @@ describe("TableMetricConversion", () => {
     const { primaryOutcomes } = mockOutcomeSets(experiment);
 
     render(
-      <RouterSlugProvider mocks={[mock]}>
-        <TableMetricConversion
-          {...{ results, sortedBranches }}
-          outcome={primaryOutcomes![0]!}
-        />
-      </RouterSlugProvider>,
+      <MockResultsContextProvider>
+        <RouterSlugProvider mocks={[mock]}>
+          <TableMetricConversion outcome={primaryOutcomes![0]!} />
+        </RouterSlugProvider>
+        ,
+      </MockResultsContextProvider>,
     );
 
     expect(screen.getAllByText("control")).toHaveLength(2);
@@ -80,12 +79,12 @@ describe("TableMetricConversion", () => {
     const { primaryOutcomes } = mockOutcomeSets(experiment);
 
     render(
-      <RouterSlugProvider mocks={[mock]}>
-        <TableMetricConversion
-          {...{ results, sortedBranches }}
-          outcome={primaryOutcomes![0]!}
-        />
-      </RouterSlugProvider>,
+      <MockResultsContextProvider>
+        <RouterSlugProvider mocks={[mock]}>
+          <TableMetricConversion outcome={primaryOutcomes![0]!} />
+        </RouterSlugProvider>
+        ,
+      </MockResultsContextProvider>,
     );
 
     const negativeBlock = screen.queryByTestId("negative-block");
@@ -103,12 +102,12 @@ describe("TableMetricConversion", () => {
     const { primaryOutcomes } = mockOutcomeSets(experiment);
 
     render(
-      <RouterSlugProvider mocks={[mock]}>
-        <TableMetricConversion
-          {...{ results, sortedBranches }}
-          outcome={primaryOutcomes![0]!}
-        />
-      </RouterSlugProvider>,
+      <MockResultsContextProvider>
+        <RouterSlugProvider mocks={[mock]}>
+          <TableMetricConversion outcome={primaryOutcomes![0]!} />
+        </RouterSlugProvider>
+        ,
+      </MockResultsContextProvider>,
     );
 
     const positiveBlock = screen.queryByTestId("positive-block");
@@ -126,12 +125,12 @@ describe("TableMetricConversion", () => {
     const { primaryOutcomes } = mockOutcomeSets(experiment);
 
     render(
-      <RouterSlugProvider mocks={[mock]}>
-        <TableMetricConversion
-          {...{ results, sortedBranches }}
-          outcome={primaryOutcomes![0]!}
-        />
-      </RouterSlugProvider>,
+      <MockResultsContextProvider>
+        <RouterSlugProvider mocks={[mock]}>
+          <TableMetricConversion outcome={primaryOutcomes![0]!} />
+        </RouterSlugProvider>
+        ,
+      </MockResultsContextProvider>,
     );
 
     const negativeBlock = screen.queryByTestId("negative-block");

--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableMetricConversion/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableMetricConversion/index.tsx
@@ -89,7 +89,13 @@ const TableMetricConversion = ({
                       results={results[branch]}
                       group={GROUP.OTHER}
                       tableLabel={TABLE_LABEL.PRIMARY_METRICS}
-                      {...{ metricKey, displayType, branchComparison, bounds }}
+                      // isControlBranch={branch === controlBranchName}
+                      {...{
+                        metricKey,
+                        displayType,
+                        branchComparison,
+                        bounds,
+                      }}
                     />
                   ),
                 )}

--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableMetricConversion/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableMetricConversion/index.tsx
@@ -2,14 +2,14 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from "react";
+import React, { useContext } from "react";
+import { ResultsContext } from "../../../lib/contexts";
 import {
   CONVERSION_METRIC_COLUMNS,
   DISPLAY_TYPE,
   GROUP,
   TABLE_LABEL,
 } from "../../../lib/visualization/constants";
-import { AnalysisDataOverall } from "../../../lib/visualization/types";
 import { getExtremeBounds } from "../../../lib/visualization/utils";
 import { getConfig_nimbusConfig_outcomes } from "../../../types/getConfig";
 import TableVisualizationRow from "../TableVisualizationRow";
@@ -22,9 +22,7 @@ type ConversionMetricStatistic = {
 };
 
 type TableMetricConversionProps = {
-  results: AnalysisDataOverall;
   outcome: getConfig_nimbusConfig_outcomes;
-  sortedBranches: string[];
 };
 
 const getStatistics = (slug: string): Array<ConversionMetricStatistic> => {
@@ -41,16 +39,18 @@ const getStatistics = (slug: string): Array<ConversionMetricStatistic> => {
   return conversionMetricStatisticsList;
 };
 
-const TableMetricConversion = ({
-  results = {},
-  outcome,
-  sortedBranches,
-}: TableMetricConversionProps) => {
+const TableMetricConversion = ({ outcome }: TableMetricConversionProps) => {
+  const {
+    analysis: { overall },
+    sortedBranches,
+    controlBranchName,
+  } = useContext(ResultsContext);
+  const overallResults = overall!;
   const conversionMetricStatistics = getStatistics(outcome.slug!);
   const metricKey = `${outcome.slug}_ever_used`;
   const bounds = getExtremeBounds(
     sortedBranches,
-    results,
+    overallResults,
     outcome.slug!,
     GROUP.OTHER,
   );
@@ -76,7 +76,7 @@ const TableMetricConversion = ({
           </tr>
         </thead>
         <tbody>
-          {Object.keys(results).map((branch) => {
+          {Object.keys(overallResults).map((branch) => {
             return (
               <tr key={branch}>
                 <th className="align-middle" scope="row">
@@ -86,10 +86,10 @@ const TableMetricConversion = ({
                   ({ displayType, branchComparison, value }) => (
                     <TableVisualizationRow
                       key={`${displayType}-${value}`}
-                      results={results[branch]}
+                      results={overallResults[branch]}
                       group={GROUP.OTHER}
                       tableLabel={TABLE_LABEL.PRIMARY_METRICS}
-                      // isControlBranch={branch === controlBranchName}
+                      isControlBranch={branch === controlBranchName}
                       {...{
                         metricKey,
                         displayType,

--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableMetricCount/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableMetricCount/index.stories.tsx
@@ -6,13 +6,12 @@ import { withLinks } from "@storybook/addon-links";
 import { storiesOf } from "@storybook/react";
 import React from "react";
 import TableMetricCount from ".";
-import { mockExperimentQuery, mockOutcomeSets } from "../../../lib/mocks";
+import {
+  mockExperimentQuery,
+  mockOutcomeSets,
+  MockResultsContextProvider,
+} from "../../../lib/mocks";
 import { GROUP, METRIC_TYPE } from "../../../lib/visualization/constants";
-import { mockAnalysis } from "../../../lib/visualization/mocks";
-import { getSortedBranches } from "../../../lib/visualization/utils";
-
-const results = mockAnalysis();
-const sortedBranches = getSortedBranches(results);
 
 storiesOf("pages/Results/TableMetricCount", module)
   .addDecorator(withLinks)
@@ -23,13 +22,14 @@ storiesOf("pages/Results/TableMetricCount", module)
     const { secondaryOutcomes } = mockOutcomeSets(experiment);
 
     return (
-      <TableMetricCount
-        {...{ results, sortedBranches }}
-        outcomeSlug={secondaryOutcomes![0]!.slug!}
-        outcomeDefaultName={secondaryOutcomes![0]!.friendlyName!}
-        group={GROUP.OTHER}
-        metricType={METRIC_TYPE.USER_SELECTED_SECONDARY}
-      />
+      <MockResultsContextProvider>
+        <TableMetricCount
+          outcomeSlug={secondaryOutcomes![0]!.slug!}
+          outcomeDefaultName={secondaryOutcomes![0]!.friendlyName!}
+          group={GROUP.OTHER}
+          metricType={METRIC_TYPE.USER_SELECTED_SECONDARY}
+        />
+      </MockResultsContextProvider>
     );
   })
   .add("with negative secondary metric", () => {
@@ -37,13 +37,14 @@ storiesOf("pages/Results/TableMetricCount", module)
     const { secondaryOutcomes } = mockOutcomeSets(experiment);
 
     return (
-      <TableMetricCount
-        {...{ results, sortedBranches }}
-        outcomeSlug={secondaryOutcomes![0]!.slug!}
-        outcomeDefaultName={secondaryOutcomes![0]!.friendlyName!}
-        group={GROUP.OTHER}
-        metricType={METRIC_TYPE.USER_SELECTED_SECONDARY}
-      />
+      <MockResultsContextProvider>
+        <TableMetricCount
+          outcomeSlug={secondaryOutcomes![0]!.slug!}
+          outcomeDefaultName={secondaryOutcomes![0]!.friendlyName!}
+          group={GROUP.OTHER}
+          metricType={METRIC_TYPE.USER_SELECTED_SECONDARY}
+        />
+      </MockResultsContextProvider>
     );
   })
   .add("with neutral secondary metric", () => {
@@ -53,12 +54,13 @@ storiesOf("pages/Results/TableMetricCount", module)
     const { secondaryOutcomes } = mockOutcomeSets(experiment);
 
     return (
-      <TableMetricCount
-        {...{ results, sortedBranches }}
-        outcomeSlug={secondaryOutcomes![0]!.slug!}
-        outcomeDefaultName={secondaryOutcomes![0]!.friendlyName!}
-        group={GROUP.OTHER}
-        metricType={METRIC_TYPE.USER_SELECTED_SECONDARY}
-      />
+      <MockResultsContextProvider>
+        <TableMetricCount
+          outcomeSlug={secondaryOutcomes![0]!.slug!}
+          outcomeDefaultName={secondaryOutcomes![0]!.friendlyName!}
+          group={GROUP.OTHER}
+          metricType={METRIC_TYPE.USER_SELECTED_SECONDARY}
+        />
+      </MockResultsContextProvider>
     );
   });

--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableMetricCount/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableMetricCount/index.test.tsx
@@ -5,14 +5,13 @@
 import { render, screen } from "@testing-library/react";
 import React from "react";
 import TableMetricCount from ".";
-import { mockExperimentQuery, mockOutcomeSets } from "../../../lib/mocks";
+import {
+  mockExperimentQuery,
+  mockOutcomeSets,
+  MockResultsContextProvider,
+} from "../../../lib/mocks";
 import { RouterSlugProvider } from "../../../lib/test-utils";
 import { GROUP, METRIC_TYPE } from "../../../lib/visualization/constants";
-import { mockAnalysis } from "../../../lib/visualization/mocks";
-import { getSortedBranches } from "../../../lib/visualization/utils";
-
-const results = mockAnalysis();
-const sortedBranches = getSortedBranches(results);
 
 describe("TableMetricCount", () => {
   it("has the correct headings", () => {
@@ -22,13 +21,14 @@ describe("TableMetricCount", () => {
 
     render(
       <RouterSlugProvider mocks={[mock]}>
-        <TableMetricCount
-          outcomeSlug={secondaryOutcomes![0]!.slug!}
-          outcomeDefaultName={secondaryOutcomes![0]!.friendlyName!}
-          metricType={METRIC_TYPE.USER_SELECTED_SECONDARY}
-          group={GROUP.OTHER}
-          {...{ results, sortedBranches }}
-        />
+        <MockResultsContextProvider>
+          <TableMetricCount
+            outcomeSlug={secondaryOutcomes![0]!.slug!}
+            outcomeDefaultName={secondaryOutcomes![0]!.friendlyName!}
+            metricType={METRIC_TYPE.USER_SELECTED_SECONDARY}
+            group={GROUP.OTHER}
+          />
+        </MockResultsContextProvider>
       </RouterSlugProvider>,
     );
 
@@ -43,13 +43,14 @@ describe("TableMetricCount", () => {
 
     render(
       <RouterSlugProvider mocks={[mock]}>
-        <TableMetricCount
-          outcomeSlug={secondaryOutcomes![0]!.slug!}
-          outcomeDefaultName={secondaryOutcomes![0]!.friendlyName!}
-          group={GROUP.OTHER}
-          metricType={METRIC_TYPE.USER_SELECTED_SECONDARY}
-          {...{ results, sortedBranches }}
-        />
+        <MockResultsContextProvider>
+          <TableMetricCount
+            outcomeSlug={secondaryOutcomes![0]!.slug!}
+            outcomeDefaultName={secondaryOutcomes![0]!.friendlyName!}
+            group={GROUP.OTHER}
+            metricType={METRIC_TYPE.USER_SELECTED_SECONDARY}
+          />
+        </MockResultsContextProvider>
       </RouterSlugProvider>,
     );
 
@@ -67,13 +68,14 @@ describe("TableMetricCount", () => {
 
     render(
       <RouterSlugProvider mocks={[mock]}>
-        <TableMetricCount
-          outcomeSlug={secondaryOutcomes![0]!.slug!}
-          outcomeDefaultName={secondaryOutcomes![0]!.friendlyName!}
-          group={GROUP.OTHER}
-          metricType={METRIC_TYPE.USER_SELECTED_SECONDARY}
-          {...{ results, sortedBranches }}
-        />
+        <MockResultsContextProvider>
+          <TableMetricCount
+            outcomeSlug={secondaryOutcomes![0]!.slug!}
+            outcomeDefaultName={secondaryOutcomes![0]!.friendlyName!}
+            group={GROUP.OTHER}
+            metricType={METRIC_TYPE.USER_SELECTED_SECONDARY}
+          />
+        </MockResultsContextProvider>
       </RouterSlugProvider>,
     );
 
@@ -87,13 +89,14 @@ describe("TableMetricCount", () => {
 
     render(
       <RouterSlugProvider mocks={[mock]}>
-        <TableMetricCount
-          outcomeSlug={secondaryOutcomes![0]!.slug!}
-          outcomeDefaultName={secondaryOutcomes![0]!.friendlyName!}
-          group={GROUP.OTHER}
-          metricType={METRIC_TYPE.USER_SELECTED_SECONDARY}
-          {...{ results, sortedBranches }}
-        />
+        <MockResultsContextProvider>
+          <TableMetricCount
+            outcomeSlug={secondaryOutcomes![0]!.slug!}
+            outcomeDefaultName={secondaryOutcomes![0]!.friendlyName!}
+            group={GROUP.OTHER}
+            metricType={METRIC_TYPE.USER_SELECTED_SECONDARY}
+          />
+        </MockResultsContextProvider>
       </RouterSlugProvider>,
     );
 
@@ -111,13 +114,14 @@ describe("TableMetricCount", () => {
 
     render(
       <RouterSlugProvider mocks={[mock]}>
-        <TableMetricCount
-          outcomeSlug={secondaryOutcomes![0]!.slug!}
-          outcomeDefaultName={secondaryOutcomes![0]!.friendlyName!}
-          group={GROUP.OTHER}
-          metricType={METRIC_TYPE.USER_SELECTED_SECONDARY}
-          {...{ results, sortedBranches }}
-        />
+        <MockResultsContextProvider>
+          <TableMetricCount
+            outcomeSlug={secondaryOutcomes![0]!.slug!}
+            outcomeDefaultName={secondaryOutcomes![0]!.friendlyName!}
+            group={GROUP.OTHER}
+            metricType={METRIC_TYPE.USER_SELECTED_SECONDARY}
+          />
+        </MockResultsContextProvider>
       </RouterSlugProvider>,
     );
 
@@ -131,13 +135,14 @@ describe("TableMetricCount", () => {
 
     render(
       <RouterSlugProvider mocks={[mock]}>
-        <TableMetricCount
-          outcomeSlug="feature_d"
-          outcomeDefaultName={secondaryOutcomes![0]!.friendlyName!}
-          group={GROUP.OTHER}
-          metricType={METRIC_TYPE.USER_SELECTED_SECONDARY}
-          {...{ results, sortedBranches }}
-        />
+        <MockResultsContextProvider>
+          <TableMetricCount
+            outcomeSlug="feature_d"
+            outcomeDefaultName={secondaryOutcomes![0]!.friendlyName!}
+            group={GROUP.OTHER}
+            metricType={METRIC_TYPE.USER_SELECTED_SECONDARY}
+          />
+        </MockResultsContextProvider>
       </RouterSlugProvider>,
     );
 

--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableMetricCount/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableMetricCount/index.tsx
@@ -2,15 +2,15 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from "react";
+import React, { useContext } from "react";
 import { ReactComponent as Info } from "../../../images/info.svg";
+import { ResultsContext } from "../../../lib/contexts";
 import {
   COUNT_METRIC_COLUMNS,
   DISPLAY_TYPE,
   METRIC_TYPE,
   TABLE_LABEL,
 } from "../../../lib/visualization/constants";
-import { AnalysisData } from "../../../lib/visualization/types";
 import { getExtremeBounds } from "../../../lib/visualization/utils";
 import GraphsWeekly from "../GraphsWeekly";
 import TableVisualizationRow from "../TableVisualizationRow";
@@ -30,12 +30,10 @@ type MetricTypes =
   | typeof METRIC_TYPE.GUARDRAIL;
 
 type TableMetricCountProps = {
-  results: AnalysisData;
   outcomeSlug: string;
   outcomeDefaultName: string;
   group: string;
   metricType?: MetricTypes;
-  sortedBranches: string[];
 };
 
 const getStatistics = (slug: string): Array<CountMetricStatistic> => {
@@ -51,22 +49,18 @@ const getStatistics = (slug: string): Array<CountMetricStatistic> => {
 };
 
 const TableMetricCount = ({
-  results = {
-    daily: [],
-    weekly: {},
-    overall: {},
-    metadata: { metrics: {}, outcomes: {} },
-    show_analysis: false,
-  },
   outcomeSlug,
   outcomeDefaultName,
   group,
   metricType = METRIC_TYPE.DEFAULT_SECONDARY,
-  sortedBranches,
 }: TableMetricCountProps) => {
   const countMetricStatistics = getStatistics(outcomeSlug);
+  const {
+    analysis: { metadata, overall, weekly },
+    sortedBranches,
+  } = useContext(ResultsContext);
+  const overallResults = overall!;
 
-  const overallResults = results?.overall!;
   const bounds = getExtremeBounds(
     sortedBranches,
     overallResults,
@@ -74,9 +68,9 @@ const TableMetricCount = ({
     group,
   );
   const outcomeName =
-    results.metadata?.metrics[outcomeSlug]?.friendly_name || outcomeDefaultName;
+    metadata?.metrics[outcomeSlug]?.friendly_name || outcomeDefaultName;
   const outcomeDescription =
-    results.metadata?.metrics[outcomeSlug]?.description || undefined;
+    metadata?.metrics[outcomeSlug]?.description || undefined;
 
   return (
     <div data-testid="table-metric-secondary" className="mb-5">
@@ -136,10 +130,9 @@ const TableMetricCount = ({
                         <TableVisualizationRow
                           key={`${displayType}-${value}`}
                           results={overallResults[branch]}
-                          group={group}
                           tableLabel={TABLE_LABEL.SECONDARY_METRICS}
                           metricKey={outcomeSlug}
-                          {...{ displayType, branchComparison, bounds }}
+                          {...{ displayType, branchComparison, bounds, group }}
                         />
                       ),
                     )}
@@ -149,13 +142,7 @@ const TableMetricCount = ({
             })}
         </tbody>
       </table>
-      {results?.weekly && (
-        <GraphsWeekly
-          weeklyResults={results.weekly}
-          {...{ outcomeSlug, outcomeName }}
-          group={group}
-        />
-      )}
+      {weekly && <GraphsWeekly {...{ outcomeSlug, outcomeName, group }} />}
     </div>
   );
 };

--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableMetricCount/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableMetricCount/index.tsx
@@ -58,6 +58,7 @@ const TableMetricCount = ({
   const {
     analysis: { metadata, overall, weekly },
     sortedBranches,
+    controlBranchName,
   } = useContext(ResultsContext);
   const overallResults = overall!;
 
@@ -132,6 +133,7 @@ const TableMetricCount = ({
                           results={overallResults[branch]}
                           tableLabel={TABLE_LABEL.SECONDARY_METRICS}
                           metricKey={outcomeSlug}
+                          isControlBranch={branch === controlBranchName}
                           {...{ displayType, branchComparison, bounds, group }}
                         />
                       ),

--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableResults/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableResults/index.stories.tsx
@@ -6,14 +6,13 @@ import { withLinks } from "@storybook/addon-links";
 import { storiesOf } from "@storybook/react";
 import React from "react";
 import TableResults from ".";
-import { mockExperimentQuery } from "../../../lib/mocks";
+import {
+  mockExperimentQuery,
+  MockResultsContextProvider,
+} from "../../../lib/mocks";
 import { RouterSlugProvider } from "../../../lib/test-utils";
 import { BRANCH_COMPARISON } from "../../../lib/visualization/constants";
-import { mockAnalysis } from "../../../lib/visualization/mocks";
-import { getSortedBranches } from "../../../lib/visualization/utils";
-
-const results = mockAnalysis();
-const sortedBranches = getSortedBranches(results);
+import { mockIncompleteAnalysis } from "../../../lib/visualization/mocks";
 
 storiesOf("pages/Results/TableResults", module)
   .addDecorator(withLinks)
@@ -21,7 +20,9 @@ storiesOf("pages/Results/TableResults", module)
     const { mock, experiment } = mockExperimentQuery("demo-slug");
     return (
       <RouterSlugProvider mocks={[mock]}>
-        <TableResults {...{ experiment, results, sortedBranches }} />
+        <MockResultsContextProvider>
+          <TableResults {...{ experiment }} />
+        </MockResultsContextProvider>
       </RouterSlugProvider>
     );
   })
@@ -31,7 +32,9 @@ storiesOf("pages/Results/TableResults", module)
     });
     return (
       <RouterSlugProvider mocks={[mock]}>
-        <TableResults {...{ experiment, results, sortedBranches }} />
+        <MockResultsContextProvider>
+          <TableResults {...{ experiment }} />
+        </MockResultsContextProvider>
       </RouterSlugProvider>
     );
   })
@@ -39,10 +42,12 @@ storiesOf("pages/Results/TableResults", module)
     const { mock, experiment } = mockExperimentQuery("demo-slug");
     return (
       <RouterSlugProvider mocks={[mock]}>
-        <TableResults
-          branchComparison={BRANCH_COMPARISON.ABSOLUTE}
-          {...{ experiment, results, sortedBranches }}
-        />
+        <MockResultsContextProvider>
+          <TableResults
+            branchComparison={BRANCH_COMPARISON.ABSOLUTE}
+            {...{ experiment }}
+          />
+        </MockResultsContextProvider>
       </RouterSlugProvider>
     );
   })
@@ -52,10 +57,22 @@ storiesOf("pages/Results/TableResults", module)
     });
     return (
       <RouterSlugProvider mocks={[mock]}>
-        <TableResults
-          branchComparison={BRANCH_COMPARISON.ABSOLUTE}
-          {...{ experiment, results, sortedBranches }}
-        />
+        <MockResultsContextProvider>
+          <TableResults
+            branchComparison={BRANCH_COMPARISON.ABSOLUTE}
+            {...{ experiment }}
+          />
+        </MockResultsContextProvider>
+      </RouterSlugProvider>
+    );
+  })
+  .add("missing retention with warning", () => {
+    const { mock, experiment } = mockExperimentQuery("demo-slug");
+    return (
+      <RouterSlugProvider mocks={[mock]}>
+        <MockResultsContextProvider analysis={mockIncompleteAnalysis()}>
+          <TableResults {...{ experiment }} />
+        </MockResultsContextProvider>
       </RouterSlugProvider>
     );
   });

--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableResults/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableResults/index.test.tsx
@@ -5,24 +5,23 @@
 import { render, screen } from "@testing-library/react";
 import React from "react";
 import TableResults from ".";
-import { mockExperimentQuery } from "../../../lib/mocks";
+import {
+  mockExperimentQuery,
+  MockResultsContextProvider,
+} from "../../../lib/mocks";
 import { RouterSlugProvider } from "../../../lib/test-utils";
 import { BRANCH_COMPARISON } from "../../../lib/visualization/constants";
-import {
-  mockAnalysis,
-  mockIncompleteAnalysis,
-} from "../../../lib/visualization/mocks";
-import { getSortedBranches } from "../../../lib/visualization/utils";
+import { mockIncompleteAnalysis } from "../../../lib/visualization/mocks";
 
 const { mock, experiment } = mockExperimentQuery("demo-slug");
-const results = mockAnalysis();
-const sortedBranches = getSortedBranches(results);
 
 describe("TableResults", () => {
   it("renders correct headings", () => {
     render(
       <RouterSlugProvider mocks={[mock]}>
-        <TableResults {...{ experiment, results, sortedBranches }} />
+        <MockResultsContextProvider>
+          <TableResults {...{ experiment }} />
+        </MockResultsContextProvider>
       </RouterSlugProvider>,
     );
     const EXPECTED_HEADINGS = [
@@ -40,7 +39,9 @@ describe("TableResults", () => {
   it("with relative comparison, renders the expected variant, comparison, and user count", () => {
     render(
       <RouterSlugProvider mocks={[mock]}>
-        <TableResults {...{ experiment, results, sortedBranches }} />
+        <MockResultsContextProvider>
+          <TableResults {...{ experiment }} />
+        </MockResultsContextProvider>
       </RouterSlugProvider>,
     );
 
@@ -58,10 +59,12 @@ describe("TableResults", () => {
   it("with absolute comparison, renders the expected variant, comparison, and user count", async () => {
     render(
       <RouterSlugProvider mocks={[mock]}>
-        <TableResults
-          branchComparison={BRANCH_COMPARISON.ABSOLUTE}
-          {...{ experiment, results, sortedBranches }}
-        />
+        <MockResultsContextProvider>
+          <TableResults
+            {...{ experiment }}
+            branchComparison={BRANCH_COMPARISON.ABSOLUTE}
+          />
+        </MockResultsContextProvider>
       </RouterSlugProvider>,
     );
     expect(screen.getByText("88.6%", { exact: false })).toBeInTheDocument();
@@ -77,7 +80,9 @@ describe("TableResults", () => {
   it("renders correctly labelled result significance", () => {
     render(
       <RouterSlugProvider mocks={[mock]}>
-        <TableResults {...{ experiment, results, sortedBranches }} />
+        <MockResultsContextProvider>
+          <TableResults {...{ experiment }} />
+        </MockResultsContextProvider>
       </RouterSlugProvider>,
     );
     expect(screen.getByTestId("positive-significance")).toBeInTheDocument();
@@ -86,12 +91,11 @@ describe("TableResults", () => {
   });
 
   it("renders missing retention with warning", () => {
-    const results = mockIncompleteAnalysis();
-    const sortedBranches = getSortedBranches(results);
-
     render(
       <RouterSlugProvider mocks={[mock]}>
-        <TableResults {...{ experiment, results, sortedBranches }} />
+        <MockResultsContextProvider analysis={mockIncompleteAnalysis()}>
+          <TableResults {...{ experiment }} />
+        </MockResultsContextProvider>
       </RouterSlugProvider>,
     );
 

--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableResults/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableResults/index.tsx
@@ -53,6 +53,7 @@ const TableResults = ({
   const {
     analysis: { metadata, overall },
     sortedBranches,
+    controlBranchName,
   } = useContext(ResultsContext);
   const overallResults = overall!;
 
@@ -91,6 +92,7 @@ const TableResults = ({
       </thead>
       <tbody>
         {sortedBranches.map((branch) => {
+          const isControlBranch = branch === controlBranchName;
           return (
             <tr key={branch}>
               <th className="align-middle" scope="row">
@@ -101,7 +103,7 @@ const TableResults = ({
                 const displayType = getTableDisplayType(
                   metricKey,
                   TABLE_LABEL.RESULTS,
-                  overallResults[branch]["is_control"],
+                  isControlBranch,
                 );
                 return (
                   <TableVisualizationRow
@@ -110,7 +112,12 @@ const TableResults = ({
                     results={overallResults[branch]}
                     group={metric.group}
                     tableLabel={TABLE_LABEL.RESULTS}
-                    {...{ metricKey, displayType, branchComparison }}
+                    {...{
+                      metricKey,
+                      displayType,
+                      branchComparison,
+                      isControlBranch,
+                    }}
                   />
                 );
               })}

--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableResults/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableResults/index.tsx
@@ -2,8 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from "react";
+import React, { useContext } from "react";
 import { useOutcomes } from "../../../hooks";
+import { ResultsContext } from "../../../lib/contexts";
 import { OutcomesList } from "../../../lib/types";
 import {
   BRANCH_COMPARISON,
@@ -13,10 +14,7 @@ import {
   RESULTS_METRICS_LIST,
   TABLE_LABEL,
 } from "../../../lib/visualization/constants";
-import {
-  AnalysisData,
-  BranchComparisonValues,
-} from "../../../lib/visualization/types";
+import { BranchComparisonValues } from "../../../lib/visualization/types";
 import { getTableDisplayType } from "../../../lib/visualization/utils";
 import { getExperiment_experimentBySlug } from "../../../types/getExperiment";
 import TableVisualizationRow from "../TableVisualizationRow";
@@ -24,8 +22,6 @@ import TooltipWithMarkdown from "../TooltipWithMarkdown";
 
 type TableResultsProps = {
   experiment: getExperiment_experimentBySlug;
-  results: AnalysisData;
-  sortedBranches: string[];
   branchComparison?: BranchComparisonValues;
 };
 
@@ -50,19 +46,15 @@ const getResultMetrics = (outcomes: OutcomesList) => {
 
 const TableResults = ({
   experiment,
-  results = {
-    daily: [],
-    weekly: {},
-    overall: {},
-    metadata: { metrics: {}, outcomes: {} },
-    show_analysis: false,
-  },
-  sortedBranches,
   branchComparison = BRANCH_COMPARISON.UPLIFT,
 }: TableResultsProps) => {
   const { primaryOutcomes } = useOutcomes(experiment);
   const resultsMetricsList = getResultMetrics(primaryOutcomes);
-  const overallResults = results?.overall!;
+  const {
+    analysis: { metadata, overall },
+    sortedBranches,
+  } = useContext(ResultsContext);
+  const overallResults = overall!;
 
   return (
     <table className="table-visualization-center" data-testid="table-results">
@@ -72,8 +64,7 @@ const TableResults = ({
           {resultsMetricsList.map((metric, index) => {
             const badgeClass = `badge ${metric.type?.badge}`;
             const outcomeDescription =
-              results.metadata?.metrics[metric.value]?.description ||
-              metric.tooltip;
+              metadata?.metrics[metric.value]?.description || metric.tooltip;
 
             return (
               <th

--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableResultsWeekly/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableResultsWeekly/index.stories.tsx
@@ -6,39 +6,28 @@ import { withLinks } from "@storybook/addon-links";
 import { storiesOf } from "@storybook/react";
 import React from "react";
 import TableResultsWeekly from ".";
+import { MockResultsContextProvider } from "../../../lib/mocks";
 import {
   BRANCH_COMPARISON,
   HIGHLIGHTS_METRICS_LIST,
 } from "../../../lib/visualization/constants";
-import { weeklyMockAnalysis } from "../../../lib/visualization/mocks";
-import { getSortedBranches } from "../../../lib/visualization/utils";
-
-const weeklyResults = weeklyMockAnalysis();
-const sortedBranches = getSortedBranches({
-  show_analysis: true,
-  daily: null,
-  weekly: weeklyResults,
-  overall: null,
-});
 
 storiesOf("pages/Results/TableResultsWeekly", module)
   .addDecorator(withLinks)
   .add("with relative uplift comparison", () => {
     return (
-      <TableResultsWeekly
-        {...{ weeklyResults, sortedBranches }}
-        hasOverallResults
-        metricsList={HIGHLIGHTS_METRICS_LIST}
-      />
+      <MockResultsContextProvider>
+        <TableResultsWeekly metricsList={HIGHLIGHTS_METRICS_LIST} />
+      </MockResultsContextProvider>
     );
   })
   .add("with absolute comparison", () => {
     return (
-      <TableResultsWeekly
-        {...{ weeklyResults, sortedBranches }}
-        hasOverallResults
-        metricsList={HIGHLIGHTS_METRICS_LIST}
-        branchComparison={BRANCH_COMPARISON.ABSOLUTE}
-      />
+      <MockResultsContextProvider>
+        <TableResultsWeekly
+          metricsList={HIGHLIGHTS_METRICS_LIST}
+          branchComparison={BRANCH_COMPARISON.ABSOLUTE}
+        />
+      </MockResultsContextProvider>
     );
   });

--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableResultsWeekly/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableResultsWeekly/index.test.tsx
@@ -5,29 +5,18 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import React from "react";
 import TableResultsWeekly from ".";
+import { MockResultsContextProvider } from "../../../lib/mocks";
 import {
   BRANCH_COMPARISON,
   HIGHLIGHTS_METRICS_LIST,
 } from "../../../lib/visualization/constants";
-import { weeklyMockAnalysis } from "../../../lib/visualization/mocks";
-import { getSortedBranches } from "../../../lib/visualization/utils";
-
-const weeklyResults = weeklyMockAnalysis();
-const sortedBranches = getSortedBranches({
-  show_analysis: true,
-  daily: null,
-  weekly: weeklyResults,
-  overall: null,
-});
 
 describe("TableResultsWeekly", () => {
   it("renders as expected with relative uplift branch comparison (default)", () => {
     render(
-      <TableResultsWeekly
-        hasOverallResults
-        metricsList={HIGHLIGHTS_METRICS_LIST}
-        {...{ weeklyResults, sortedBranches }}
-      />,
+      <MockResultsContextProvider>
+        <TableResultsWeekly metricsList={HIGHLIGHTS_METRICS_LIST} />,
+      </MockResultsContextProvider>,
     );
 
     const EXPECTED_HEADINGS = ["Retention", "Search", "Days of Use"];
@@ -51,12 +40,12 @@ describe("TableResultsWeekly", () => {
 
   it("renders as expected with absolute branch comparison", () => {
     render(
-      <TableResultsWeekly
-        hasOverallResults
-        metricsList={HIGHLIGHTS_METRICS_LIST}
-        branchComparison={BRANCH_COMPARISON.ABSOLUTE}
-        {...{ weeklyResults, sortedBranches }}
-      />,
+      <MockResultsContextProvider>
+        <TableResultsWeekly
+          metricsList={HIGHLIGHTS_METRICS_LIST}
+          branchComparison={BRANCH_COMPARISON.ABSOLUTE}
+        />
+      </MockResultsContextProvider>,
     );
 
     expect(
@@ -69,13 +58,12 @@ describe("TableResultsWeekly", () => {
     const SHOW_TEXT = "Show Weekly Data";
 
     render(
-      <TableResultsWeekly
-        hasOverallResults={false}
-        metricsList={HIGHLIGHTS_METRICS_LIST}
-        {...{ weeklyResults, sortedBranches }}
-      />,
+      <MockResultsContextProvider>
+        <TableResultsWeekly metricsList={HIGHLIGHTS_METRICS_LIST} />,
+      </MockResultsContextProvider>,
     );
 
+    fireEvent.click(screen.getByText(SHOW_TEXT));
     expect(screen.getByText(HIDE_TEXT)).toBeInTheDocument();
     fireEvent.click(screen.getByText(HIDE_TEXT));
     expect(screen.getByText(SHOW_TEXT)).toBeInTheDocument();

--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableResultsWeekly/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableResultsWeekly/index.tsx
@@ -1,40 +1,36 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-import React, { useState } from "react";
+import React, { useContext, useState } from "react";
 import Collapse from "react-bootstrap/Collapse";
 import { ReactComponent as CollapseMinus } from "../../../images/minus.svg";
 import { ReactComponent as ExpandPlus } from "../../../images/plus.svg";
+import { ResultsContext } from "../../../lib/contexts";
 import {
   BRANCH_COMPARISON,
   GENERAL_TIPS,
 } from "../../../lib/visualization/constants";
-import {
-  AnalysisDataWeekly,
-  BranchComparisonValues,
-} from "../../../lib/visualization/types";
+import { BranchComparisonValues } from "../../../lib/visualization/types";
 import TableWeekly from "../TableWeekly";
 
 type TableResultsWeeklyProps = {
-  weeklyResults: AnalysisDataWeekly;
-  hasOverallResults: boolean;
   metricsList: {
     value: string;
     name: string;
     tooltip: string;
     group: string;
   }[];
-  sortedBranches: string[];
   branchComparison?: BranchComparisonValues;
 };
 
 const TableResultsWeekly = ({
-  weeklyResults = {},
-  hasOverallResults = false,
   metricsList,
-  sortedBranches,
   branchComparison = BRANCH_COMPARISON.UPLIFT,
 }: TableResultsWeeklyProps) => {
+  const {
+    analysis: { overall },
+  } = useContext(ResultsContext);
+  const hasOverallResults = !!overall;
   const [open, setOpen] = useState(!hasOverallResults);
 
   return (
@@ -72,8 +68,7 @@ const TableResultsWeekly = ({
                   metricKey={metric.value}
                   metricName={metric.name}
                   group={metric.group}
-                  results={weeklyResults}
-                  {...{ sortedBranches, branchComparison }}
+                  {...{ branchComparison }}
                 />
               </div>
             );

--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableVisualizationRow/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableVisualizationRow/index.tsx
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 import React from "react";
 import ReactTooltip from "react-tooltip";
 import {

--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableVisualizationRow/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableVisualizationRow/index.tsx
@@ -41,7 +41,7 @@ const showSignificanceField = (
   name: string,
   tableLabel: string,
   tooltip: string,
-  isControl = false,
+  isControlBranch = false,
 ) => {
   let significanceIcon,
     changeText = "";
@@ -93,7 +93,8 @@ const showSignificanceField = (
   return (
     <>
       <span {...{ className }} data-testid={className}>
-        {significanceIcon}&nbsp;{interval}&nbsp;{isControl && BASELINE_TEXT}
+        {significanceIcon}&nbsp;{interval}&nbsp;
+        {isControlBranch && BASELINE_TEXT}
       </span>
       <ReactTooltip />
     </>
@@ -140,7 +141,7 @@ const countField = (
   metricName: string,
   tableLabel: string,
   tooltip: string,
-  isControl = false,
+  isControlBranch = false,
 ) => {
   const interval = `${lower.toFixed(2)} to ${upper.toFixed(2)}`;
   return showSignificanceField(
@@ -149,7 +150,7 @@ const countField = (
     metricName,
     tableLabel,
     tooltip,
-    isControl,
+    isControlBranch,
   );
 };
 
@@ -160,7 +161,7 @@ const percentField = (
   metricName: string,
   tableLabel: string,
   tooltip: string,
-  isControl = false,
+  isControlBranch = false,
 ) => {
   const interval = `${Math.round(lower * 1000) / 10}% to ${
     Math.round(upper * 1000) / 10
@@ -171,7 +172,7 @@ const percentField = (
     metricName,
     tableLabel,
     tooltip,
-    isControl,
+    isControlBranch,
   );
 };
 
@@ -190,6 +191,7 @@ const TableVisualizationRow: React.FC<{
   results: BranchDescription;
   group: string;
   tableLabel: string;
+  isControlBranch: boolean;
   metricName?: string;
   displayType?: DISPLAY_TYPE;
   branchComparison?: string;
@@ -201,6 +203,7 @@ const TableVisualizationRow: React.FC<{
   results,
   group,
   tableLabel,
+  isControlBranch,
   metricName = "",
   displayType,
   branchComparison,
@@ -208,7 +211,7 @@ const TableVisualizationRow: React.FC<{
   window = "overall",
   bounds = 0.05,
 }) => {
-  const { branch_data, is_control } = results;
+  const { branch_data } = results;
   const metricData = branch_data[group][metricKey];
   const fieldList = [];
 
@@ -221,7 +224,9 @@ const TableVisualizationRow: React.FC<{
     tooltipText = tooltip;
     field = <div>{BASELINE_TEXT}</div>;
     const percent = branch_data[GROUP.OTHER][METRIC.USER_COUNT]["percent"];
-    const branchType = is_control ? VARIANT_TYPE.CONTROL : VARIANT_TYPE.VARIANT;
+    const branchType = isControlBranch
+      ? VARIANT_TYPE.CONTROL
+      : VARIANT_TYPE.VARIANT;
     branchComparison =
       branchComparison || dataTypeMapping[tableLabel][branchType];
 
@@ -252,7 +257,7 @@ const TableVisualizationRow: React.FC<{
               metricName,
               tableLabel,
               tooltipText,
-              is_control,
+              isControlBranch,
             );
             break;
           case DISPLAY_TYPE.PERCENT:
@@ -264,7 +269,7 @@ const TableVisualizationRow: React.FC<{
               metricName,
               tableLabel,
               tooltipText,
-              is_control,
+              isControlBranch,
             );
             break;
           case DISPLAY_TYPE.CONVERSION_COUNT:

--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableWeekly/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableWeekly/index.test.tsx
@@ -5,20 +5,21 @@
 import { render, screen } from "@testing-library/react";
 import React from "react";
 import TableWeekly from ".";
+import { MockResultsContextProvider } from "../../../lib/mocks";
 import { RouterSlugProvider } from "../../../lib/test-utils";
 import { BRANCH_COMPARISON, GROUP } from "../../../lib/visualization/constants";
 import {
+  mockAnalysis,
   weeklyMockAnalysis,
   WEEKLY_IDENTITY,
   WEEKLY_TREATMENT,
   WONKY_WEEKLY_TREATMENT,
 } from "../../../lib/visualization/mocks";
-import { getSortedBranches } from "../../../lib/visualization/utils";
 
 describe("TableWeekly", () => {
   it("has the correct headings", () => {
     const EXPECTED_HEADINGS = ["Week 1", "Week 2", "Week 5"];
-    const modified_treatment = {
+    const modifications = {
       treatment: {
         is_control: false,
         branch_data: {
@@ -35,22 +36,19 @@ describe("TableWeekly", () => {
       },
     };
 
-    const results = weeklyMockAnalysis(modified_treatment);
-    const sortedBranches = getSortedBranches({
-      show_analysis: true,
-      daily: null,
-      weekly: results,
-      overall: null,
+    const analysis = mockAnalysis({
+      weekly: weeklyMockAnalysis(modifications),
     });
 
     render(
       <RouterSlugProvider>
-        <TableWeekly
-          metricKey="retained"
-          metricName="Retention"
-          group={GROUP.OTHER}
-          {...{ results, sortedBranches }}
-        />
+        <MockResultsContextProvider {...{ analysis }}>
+          <TableWeekly
+            metricKey="retained"
+            metricName="Retention"
+            group={GROUP.OTHER}
+          />
+        </MockResultsContextProvider>
       </RouterSlugProvider>,
     );
 
@@ -61,23 +59,17 @@ describe("TableWeekly", () => {
 
   it("shows error text when metric data isn't available", () => {
     const ERROR_TEXT = "Some Made Up Metric is not available";
-    const results = weeklyMockAnalysis();
-    const sortedBranches = getSortedBranches({
-      show_analysis: true,
-      daily: null,
-      weekly: results,
-      overall: null,
-    });
 
     render(
       <RouterSlugProvider>
-        <TableWeekly
-          metricKey="fake"
-          metricName="Some Made Up Metric"
-          branchComparison={BRANCH_COMPARISON.ABSOLUTE}
-          group={GROUP.OTHER}
-          {...{ results, sortedBranches }}
-        />
+        <MockResultsContextProvider>
+          <TableWeekly
+            metricKey="fake"
+            metricName="Some Made Up Metric"
+            branchComparison={BRANCH_COMPARISON.ABSOLUTE}
+            group={GROUP.OTHER}
+          />
+        </MockResultsContextProvider>
       </RouterSlugProvider>,
     );
 

--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableWeekly/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableWeekly/index.tsx
@@ -56,11 +56,11 @@ const TableWeekly = ({
   const {
     analysis: { weekly },
     sortedBranches,
+    controlBranchName,
   } = useContext(ResultsContext);
   const weeklyResults = weekly!;
   const weekIndexList = getWeekIndexList(metricKey, group, weeklyResults);
   const tableLabel = TABLE_LABEL.RESULTS;
-  // const controlBranchName = getControlBranchName(results.metadata, results);
 
   return (
     <table
@@ -83,12 +83,29 @@ const TableWeekly = ({
       </thead>
       <tbody>
         {sortedBranches.map((branch) => {
-          const isControlBranch = weeklyResults[branch]["is_control"];
+          const isControlBranch = branch === controlBranchName;
           const displayType = getTableDisplayType(
             metricKey,
             tableLabel,
             isControlBranch,
           );
+
+          const TableRow = ({ key }: { key: string }) => (
+            <TableVisualizationRow
+              results={weeklyResults[branch]}
+              {...{
+                key,
+                tableLabel,
+                group,
+                metricName,
+                metricKey,
+                displayType,
+                branchComparison,
+                isControlBranch,
+              }}
+            />
+          );
+
           return (
             <tr key={`${branch}-${metricKey}`}>
               <th className="align-middle" scope="row">
@@ -99,32 +116,10 @@ const TableWeekly = ({
               {isControlBranch &&
               branchComparison === BRANCH_COMPARISON.UPLIFT ? (
                 weekIndexList.map((weekIndex) => (
-                  <TableVisualizationRow
-                    key={`${displayType}-${metricKey}-${weekIndex}}`}
-                    results={weeklyResults[branch]}
-                    {...{
-                      tableLabel,
-                      group,
-                      metricName,
-                      metricKey,
-                      displayType,
-                      branchComparison,
-                    }}
-                  />
+                  <TableRow key={`${displayType}-${metricKey}-${weekIndex}}`} />
                 ))
               ) : (
-                <TableVisualizationRow
-                  key={`${displayType}-${metricKey}`}
-                  results={weeklyResults[branch]}
-                  {...{
-                    tableLabel,
-                    group,
-                    metricName,
-                    metricKey,
-                    displayType,
-                    branchComparison,
-                  }}
-                />
+                <TableRow key={`${displayType}-${metricKey}`} />
               )}
             </tr>
           );

--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableWeekly/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableWeekly/index.tsx
@@ -90,11 +90,10 @@ const TableWeekly = ({
             isControlBranch,
           );
 
-          const TableRow = ({ key }: { key: string }) => (
+          const TableRow = () => (
             <TableVisualizationRow
               results={weeklyResults[branch]}
               {...{
-                key,
                 tableLabel,
                 group,
                 metricName,

--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableWeekly/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableWeekly/index.tsx
@@ -2,13 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from "react";
+import React, { useContext } from "react";
+import { ResultsContext } from "../../../lib/contexts";
 import {
   BRANCH_COMPARISON,
   TABLE_LABEL,
 } from "../../../lib/visualization/constants";
 import {
-  AnalysisDataWeekly,
   BranchComparisonValues,
   BranchDescription,
   FormattedAnalysisPoint,
@@ -20,8 +20,6 @@ type TableWeeklyProps = {
   metricKey: string;
   metricName: string;
   group: string;
-  results: AnalysisDataWeekly;
-  sortedBranches: string[];
   branchComparison?: BranchComparisonValues;
 };
 
@@ -53,12 +51,16 @@ const TableWeekly = ({
   metricKey,
   metricName,
   group,
-  results = {},
-  sortedBranches,
   branchComparison = BRANCH_COMPARISON.UPLIFT,
 }: TableWeeklyProps) => {
-  const weekIndexList = getWeekIndexList(metricKey, group, results);
+  const {
+    analysis: { weekly },
+    sortedBranches,
+  } = useContext(ResultsContext);
+  const weeklyResults = weekly!;
+  const weekIndexList = getWeekIndexList(metricKey, group, weeklyResults);
   const tableLabel = TABLE_LABEL.RESULTS;
+  // const controlBranchName = getControlBranchName(results.metadata, results);
 
   return (
     <table
@@ -81,7 +83,7 @@ const TableWeekly = ({
       </thead>
       <tbody>
         {sortedBranches.map((branch) => {
-          const isControlBranch = results[branch]["is_control"];
+          const isControlBranch = weeklyResults[branch]["is_control"];
           const displayType = getTableDisplayType(
             metricKey,
             tableLabel,
@@ -99,7 +101,7 @@ const TableWeekly = ({
                 weekIndexList.map((weekIndex) => (
                   <TableVisualizationRow
                     key={`${displayType}-${metricKey}-${weekIndex}}`}
-                    results={results[branch]}
+                    results={weeklyResults[branch]}
                     {...{
                       tableLabel,
                       group,
@@ -113,7 +115,7 @@ const TableWeekly = ({
               ) : (
                 <TableVisualizationRow
                   key={`${displayType}-${metricKey}`}
-                  results={results[branch]}
+                  results={weeklyResults[branch]}
                   {...{
                     tableLabel,
                     group,

--- a/app/experimenter/nimbus-ui/src/components/PageResults/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/index.tsx
@@ -19,7 +19,7 @@ import { BranchComparisonValues } from "../../lib/visualization/types";
 import {
   analysisUnavailable,
   getControlBranchName,
-  getSortedBranches,
+  getSortedBranchNames,
 } from "../../lib/visualization/utils";
 import AppLayoutWithExperiment from "../AppLayoutWithExperiment";
 import LinkExternal from "../LinkExternal";
@@ -79,8 +79,8 @@ const PageResults: React.FunctionComponent<RouteComponentProps> = () => {
 
         const resultsContextValue: ResultsContextType = {
           analysis,
-          sortedBranches: getSortedBranches(analysis),
-          controlBranchName: getControlBranchName(analysis),
+          sortedBranches: getSortedBranchNames(analysis),
+          controlBranchName: getControlBranchName(analysis)!,
         };
 
         const slugUnderscored = experiment.slug.replace(/-/g, "_");

--- a/app/experimenter/nimbus-ui/src/components/PageResults/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/index.tsx
@@ -18,6 +18,7 @@ import {
 import { BranchComparisonValues } from "../../lib/visualization/types";
 import {
   analysisUnavailable,
+  getControlBranchName,
   getSortedBranches,
 } from "../../lib/visualization/utils";
 import AppLayoutWithExperiment from "../AppLayoutWithExperiment";
@@ -79,6 +80,7 @@ const PageResults: React.FunctionComponent<RouteComponentProps> = () => {
         const resultsContextValue: ResultsContextType = {
           analysis,
           sortedBranches: getSortedBranches(analysis),
+          controlBranchName: getControlBranchName(analysis),
         };
 
         const slugUnderscored = experiment.slug.replace(/-/g, "_");

--- a/app/experimenter/nimbus-ui/src/lib/contexts.ts
+++ b/app/experimenter/nimbus-ui/src/lib/contexts.ts
@@ -4,11 +4,12 @@
 
 import React from "react";
 import { AnalysisData } from "./visualization/types";
-import { getSortedBranches } from "./visualization/utils";
+import { getControlBranchName, getSortedBranches } from "./visualization/utils";
 
 export type ResultsContextType = {
   analysis: AnalysisData;
   sortedBranches: ReturnType<typeof getSortedBranches>;
+  controlBranchName: ReturnType<typeof getControlBranchName>;
 };
 
 export const defaultResultsContext = {
@@ -20,6 +21,7 @@ export const defaultResultsContext = {
     show_analysis: false,
   },
   sortedBranches: [],
+  controlBranchName: "",
 };
 
 export const ResultsContext = React.createContext<ResultsContextType>(

--- a/app/experimenter/nimbus-ui/src/lib/contexts.ts
+++ b/app/experimenter/nimbus-ui/src/lib/contexts.ts
@@ -1,0 +1,27 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from "react";
+import { AnalysisData } from "./visualization/types";
+import { getSortedBranches } from "./visualization/utils";
+
+export type ResultsContextType = {
+  analysis: AnalysisData;
+  sortedBranches: ReturnType<typeof getSortedBranches>;
+};
+
+export const defaultResultsContext = {
+  analysis: {
+    daily: [],
+    weekly: {},
+    overall: {},
+    metadata: { metrics: {}, outcomes: {} },
+    show_analysis: false,
+  },
+  sortedBranches: [],
+};
+
+export const ResultsContext = React.createContext<ResultsContextType>(
+  defaultResultsContext,
+);

--- a/app/experimenter/nimbus-ui/src/lib/contexts.ts
+++ b/app/experimenter/nimbus-ui/src/lib/contexts.ts
@@ -4,12 +4,13 @@
 
 import React from "react";
 import { AnalysisData } from "./visualization/types";
-import { getControlBranchName, getSortedBranches } from "./visualization/utils";
+import { getSortedBranchNames } from "./visualization/utils";
 
 export type ResultsContextType = {
   analysis: AnalysisData;
-  sortedBranches: ReturnType<typeof getSortedBranches>;
-  controlBranchName: ReturnType<typeof getControlBranchName>;
+  sortedBranches: ReturnType<typeof getSortedBranchNames>;
+  // getControlBranchName fn returns string | undefined, but will never be undefined in practice
+  controlBranchName: string;
 };
 
 export const defaultResultsContext = {

--- a/app/experimenter/nimbus-ui/src/lib/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/lib/mocks.tsx
@@ -46,7 +46,10 @@ import { getStatus } from "./experiment";
 import { OutcomesList, OutcomeSlugs } from "./types";
 import { mockAnalysis } from "./visualization/mocks";
 import { AnalysisData } from "./visualization/types";
-import { getControlBranchName, getSortedBranches } from "./visualization/utils";
+import {
+  getControlBranchName,
+  getSortedBranchNames,
+} from "./visualization/utils";
 
 export interface MockedProps {
   config?: Partial<typeof MOCK_CONFIG> | null;
@@ -758,7 +761,7 @@ export const MockResultsContextProvider = ({
 }) => {
   const value = {
     analysis,
-    sortedBranches: getSortedBranches(analysis),
+    sortedBranches: getSortedBranchNames(analysis),
     controlBranchName: getControlBranchName(analysis),
   };
 

--- a/app/experimenter/nimbus-ui/src/lib/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/lib/mocks.tsx
@@ -46,7 +46,7 @@ import { getStatus } from "./experiment";
 import { OutcomesList, OutcomeSlugs } from "./types";
 import { mockAnalysis } from "./visualization/mocks";
 import { AnalysisData } from "./visualization/types";
-import { getSortedBranches } from "./visualization/utils";
+import { getControlBranchName, getSortedBranches } from "./visualization/utils";
 
 export interface MockedProps {
   config?: Partial<typeof MOCK_CONFIG> | null;
@@ -759,6 +759,7 @@ export const MockResultsContextProvider = ({
   const value = {
     analysis,
     sortedBranches: getSortedBranches(analysis),
+    controlBranchName: getControlBranchName(analysis),
   };
 
   return (

--- a/app/experimenter/nimbus-ui/src/lib/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/lib/mocks.tsx
@@ -14,7 +14,7 @@ import { MockedResponse, MockLink } from "@apollo/client/testing";
 import { Observable } from "@apollo/client/utilities";
 import { equal } from "@wry/equality";
 import { DocumentNode, print } from "graphql";
-import React from "react";
+import React, { ReactNode } from "react";
 import { GET_CONFIG_QUERY } from "../gql/config";
 import {
   GET_EXPERIMENTS_QUERY,
@@ -41,8 +41,12 @@ import {
   NimbusExperimentPublishStatus,
   NimbusExperimentStatus,
 } from "../types/globalTypes";
+import { ResultsContext } from "./contexts";
 import { getStatus } from "./experiment";
 import { OutcomesList, OutcomeSlugs } from "./types";
+import { mockAnalysis } from "./visualization/mocks";
+import { AnalysisData } from "./visualization/types";
+import { getSortedBranches } from "./visualization/utils";
 
 export interface MockedProps {
   config?: Partial<typeof MOCK_CONFIG> | null;
@@ -744,3 +748,20 @@ export const mockRejectionChangelog = (
   changedOn,
   message,
 });
+
+export const MockResultsContextProvider = ({
+  children,
+  analysis = mockAnalysis(),
+}: {
+  children: ReactNode;
+  analysis?: AnalysisData;
+}) => {
+  const value = {
+    analysis,
+    sortedBranches: getSortedBranches(analysis),
+  };
+
+  return (
+    <ResultsContext.Provider {...{ value }}>{children}</ResultsContext.Provider>
+  );
+};

--- a/app/experimenter/nimbus-ui/src/lib/utils.ts
+++ b/app/experimenter/nimbus-ui/src/lib/utils.ts
@@ -19,10 +19,3 @@ export const optionalBoolString = (
   }
   return String(value);
 };
-
-// function getKeyByValue(
-//   object: { [key: string]: any },
-//   value: { [key: string]: any },
-// ) {
-//   return Object.keys(object).find((key) => object[key] === value);
-// }

--- a/app/experimenter/nimbus-ui/src/lib/utils.ts
+++ b/app/experimenter/nimbus-ui/src/lib/utils.ts
@@ -19,3 +19,10 @@ export const optionalBoolString = (
   }
   return String(value);
 };
+
+// function getKeyByValue(
+//   object: { [key: string]: any },
+//   value: { [key: string]: any },
+// ) {
+//   return Object.keys(object).find((key) => object[key] === value);
+// }

--- a/app/experimenter/nimbus-ui/src/lib/visualization/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/lib/visualization/mocks.tsx
@@ -13,7 +13,7 @@ export const MOCK_UNAVAILABLE_ANALYSIS = {
   },
 };
 
-export const MOCK_METADATA = {
+export const MOCK_METADATA_NO_REF_BRANCH = {
   metrics: {
     feature_b: {
       bigger_is_better: true,
@@ -35,6 +35,12 @@ export const MOCK_METADATA = {
     },
   },
   outcomes: {},
+  reference_branch: "control",
+};
+
+export const MOCK_METADATA = {
+  ...MOCK_METADATA_NO_REF_BRANCH,
+  reference_branch: "control",
 };
 
 export const CONTROL_NEUTRAL = {

--- a/app/experimenter/nimbus-ui/src/lib/visualization/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/lib/visualization/mocks.tsx
@@ -35,7 +35,6 @@ export const MOCK_METADATA_NO_REF_BRANCH = {
     },
   },
   outcomes: {},
-  reference_branch: "control",
 };
 
 export const MOCK_METADATA = {

--- a/app/experimenter/nimbus-ui/src/lib/visualization/types.ts
+++ b/app/experimenter/nimbus-ui/src/lib/visualization/types.ts
@@ -19,6 +19,7 @@ export type AnalysisDataWeekly = Exclude<AnalysisData["weekly"], null>;
 export interface Metadata {
   metrics: { [metric: string]: MetadataPoint };
   outcomes: { [outcome: string]: MetadataPoint };
+  reference_branch?: string;
 }
 
 export interface MetadataPoint {

--- a/app/experimenter/nimbus-ui/src/lib/visualization/utils.tsx
+++ b/app/experimenter/nimbus-ui/src/lib/visualization/utils.tsx
@@ -39,8 +39,6 @@ export const getControlBranchName = (analysis: AnalysisData) => {
       return branchName;
     }
   }
-  // we should never get here in practice
-  return "";
 };
 
 export const getTableDisplayType = (
@@ -68,8 +66,8 @@ export const getTableDisplayType = (
   return displayType;
 };
 
-// Returns [control branch name, reference branch names]
-export const getSortedBranches = (analysis: AnalysisData) => {
+// Returns [control/reference branch name, treatment branch names]
+export const getSortedBranchNames = (analysis: AnalysisData) => {
   const controlBranchName = getControlBranchName(analysis);
 
   const unshiftControlBranch = (


### PR DESCRIPTION
fixes #6129 

I'm opening this as a draft in case someone wants to take an early peak since this is a mid-large PR. I separated the commits to make it easier to see the refactor bits and the actual issue fix - at the time of writing, storybook + tests all work in the first commit, but I need to work on the stories + tests for the second commit, which shouldn't take too long tomorrow. I'm probably going to punt the story refactor-to-new-syntax to #6071.

The refactor felt necessary now because we were already prop-drilling several things down from `PageResults` into the tables, to fix this issue we would have needed another prop drill or to feed every table the entire `analysis` object where the `metadata` exists (which can be JSON 40k+ lines long), and then we would have needed yet another prop drilled down for #6071.