### PR TITLE
fixes #5768 fix(nimbus): changed percent of clients step increment to one

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/index.tsx
@@ -248,7 +248,7 @@ export const FormAudience = ({
                 type="number"
                 min="0"
                 max="100"
-                step="0.0001"
+                step="1"
               />
               <InputGroup.Append>
                 <InputGroup.Text id="populationPercent-unit">%</InputGroup.Text>


### PR DESCRIPTION
Because

* the percent of clients step increment of 1 is preferred over .0001

This commit 

* changes the percent of clients step increment to 1