### PR TITLE
fix #6207 fix(nimbus-ui): replace history entry when restoring search query

### DIFF
--- a/app/experimenter/nimbus-ui/src/hooks/useSearchParamsState.tsx
+++ b/app/experimenter/nimbus-ui/src/hooks/useSearchParamsState.tsx
@@ -42,7 +42,7 @@ export function useSearchParamsState(storageKey?: string) {
     } else {
       const savedParams = storage.current[storageKey];
       if (savedParams) {
-        navigate(`${location.pathname}?${savedParams}`);
+        navigate(`${location.pathname}?${savedParams}`, { replace: true });
       }
     }
   }, [navigate, storage, storageKey, location.pathname, location.search]);

--- a/app/experimenter/nimbus-ui/src/lib/test-utils.tsx
+++ b/app/experimenter/nimbus-ui/src/lib/test-utils.tsx
@@ -6,6 +6,8 @@ import { MockedResponse } from "@apollo/client/testing";
 import {
   createHistory,
   createMemorySource,
+  History,
+  HistorySource,
   LocationProvider,
   RouteComponentProps,
   Router,
@@ -31,13 +33,17 @@ export const RouterSlugProvider = ({
   path = "/demo-slug/edit",
   mocks = [],
   children,
+  mockHistorySource,
+  mockHistory,
 }: {
   path?: string;
   mocks?: MockedResponse<Record<string, any>>[];
+  mockHistorySource?: HistorySource;
+  mockHistory?: History;
   children: React.ReactElement;
 }) => {
-  const source = createMemorySource(path);
-  const history = createHistory(source);
+  const source = mockHistorySource || createMemorySource(path);
+  const history = mockHistory || createHistory(source);
 
   return (
     <SearchParamsStateProvider>


### PR DESCRIPTION
Because:

* restoring search params interfered with back button navigation

This commit:

* switches to `{ replace: true }` when restoring search params so that
  an additional history entry is not created

* improves tests for useSearchParamsState to assert exact router
  navigation call parameters