### PR TITLE
fix #6206 fix(nimbus-ui): constrain max width of filter bar selectors

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/PageHome/FilterBar/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageHome/FilterBar/index.tsx
@@ -98,10 +98,7 @@ const FilterSelect = <T extends NullableObjectArray>({
   );
 
   return (
-    <Nav.Item
-      className="m-1 text-left flex-grow-1 flex-shrink-1"
-      style={{ flexBasis: "0px" }}
-    >
+    <Nav.Item className="m-1 mw-25 text-left flex-basis-0 flex-grow-1 flex-shrink-1">
       <label className="ml-1 mr-1" htmlFor={`filter-${filterValueName}`}>
         {fieldLabel}
       </label>

--- a/app/experimenter/nimbus-ui/src/styles/index.scss
+++ b/app/experimenter/nimbus-ui/src/styles/index.scss
@@ -71,6 +71,14 @@ select.form-control.is-warning {
   font-weight: 600;
 }
 
+.flex-basis-0 {
+  flex-basis: 0px;
+}
+
+.mw-25 {
+  max-width: 25%;
+}
+
 .w-33 {
   width: 33.33%;
 }


### PR DESCRIPTION
Because:

* a filter bar selector with extremely wide contents wrecks the layout
 of the overall bar

This commit:

* applies a max-width of 25% to each filter bar selector