### PR TITLE
fixes #6165 feat(experimenter): add locales missing (according to moz-central) from locales fixture

### DIFF
--- a/app/experimenter/base/fixtures/locales.json
+++ b/app/experimenter/base/fixtures/locales.json
@@ -806,5 +806,69 @@
       "code": "zh-TW",
       "name": "Chinese (Traditional)"
     }
+  },
+  {
+    "model": "base.locale",
+    "pk": 160,
+    "fields": {
+      "code": "bo",
+      "name": "Tibetan"
+    }
+  },
+  {
+    "model": "base.locale",
+    "pk": 161,
+    "fields": {
+      "code": "ckb",
+      "name": "Central Kurdish"
+    }
+  },
+  {
+    "model": "base.locale",
+    "pk": 162,
+    "fields": {
+      "code": "hye",
+      "name": "Armenian Eastern Classic Orthography"
+    }
+  },
+  {
+    "model": "base.locale",
+    "pk": 163,
+    "fields": {
+      "code": "meh",
+      "name": "Mixteco Yucuhiti"
+    }
+  },
+  {
+    "model": "base.locale",
+    "pk": 164,
+    "fields": {
+      "code": "scn",
+      "name": "Sicilian"
+    }
+  },
+  {
+    "model": "base.locale",
+    "pk": 165,
+    "fields": {
+      "code": "sco",
+      "name": "Scots"
+    }
+  },
+  {
+    "model": "base.locale",
+    "pk": 166,
+    "fields": {
+      "code": "szl",
+      "name": "Silesian"
+    }
+  },
+  {
+    "model": "base.locale",
+    "pk": 167,
+    "fields": {
+      "code": "tg",
+      "name": "Tajik"
+    }
   }
 ]


### PR DESCRIPTION
Adds the "bo", "ckb", "hye", "meh", "scn", "sco", "szl", and "tg" locales to the base fixture.

To be proceeded by a Bugzilla ticket to reload the fixture in stage/prod

```shell
# before
root@6e5bd6403981:/app# ./manage.py loaddata ./experimenter/base/fixtures/locales.json
Installed 101 object(s) from 1 fixture(s)
# after
root@6e5bd6403981:/app# ./manage.py loaddata ./experimenter/base/fixtures/locales.json
Installed 109 object(s) from 1 fixture(s)
```