### PR TITLE
fix #6230 refactor(nimbus): Use Context on the Results page

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/PageResults/GraphsWeekly/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/GraphsWeekly/index.tsx
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+import classNames from "classnames";
 import React, { useState } from "react";
 import Collapse from "react-bootstrap/Collapse";
 import vegaEmbed, { VisualizationSpec } from "vega-embed";
@@ -104,8 +105,8 @@ const GraphsWeekly = ({
 
   const [open, setOpen] = useState(false);
   const [embedded, setEmbedded] = useState(false);
-  const graphsVisibleClass = !open ? "d-none" : "";
-  const graphsHiddenClass = open ? "d-none" : "";
+  const graphsVisibleClass = classNames(!open && "d-none");
+  const graphsHiddenClass = classNames(open && "d-none");
 
   const handleCollapse = () => {
     setOpen(!open);

--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableHighlights/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableHighlights/index.stories.tsx
@@ -6,13 +6,11 @@ import { withLinks } from "@storybook/addon-links";
 import { storiesOf } from "@storybook/react";
 import React from "react";
 import TableHighlights from ".";
-import { mockExperimentQuery } from "../../../lib/mocks";
+import {
+  mockExperimentQuery,
+  MockResultsContextProvider,
+} from "../../../lib/mocks";
 import { RouterSlugProvider } from "../../../lib/test-utils";
-import { mockAnalysis } from "../../../lib/visualization/mocks";
-import { getSortedBranches } from "../../../lib/visualization/utils";
-
-const results = mockAnalysis();
-const sortedBranches = getSortedBranches(results);
 
 storiesOf("pages/Results/TableHighlights", module)
   .addDecorator(withLinks)
@@ -20,7 +18,9 @@ storiesOf("pages/Results/TableHighlights", module)
     const { mock, experiment } = mockExperimentQuery("demo-slug");
     return (
       <RouterSlugProvider mocks={[mock]}>
-        <TableHighlights {...{ experiment, results, sortedBranches }} />
+        <MockResultsContextProvider>
+          <TableHighlights {...{ experiment }} />
+        </MockResultsContextProvider>
       </RouterSlugProvider>
     );
   })
@@ -30,7 +30,9 @@ storiesOf("pages/Results/TableHighlights", module)
     });
     return (
       <RouterSlugProvider mocks={[mock]}>
-        <TableHighlights {...{ experiment, results, sortedBranches }} />
+        <MockResultsContextProvider>
+          <TableHighlights {...{ experiment }} />
+        </MockResultsContextProvider>
       </RouterSlugProvider>
     );
   });

--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableHighlights/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableHighlights/index.test.tsx
@@ -5,20 +5,21 @@
 import { render, screen } from "@testing-library/react";
 import React from "react";
 import TableHighlights from ".";
-import { mockExperimentQuery } from "../../../lib/mocks";
+import {
+  mockExperimentQuery,
+  MockResultsContextProvider,
+} from "../../../lib/mocks";
 import { RouterSlugProvider } from "../../../lib/test-utils";
-import { mockAnalysis } from "../../../lib/visualization/mocks";
-import { getSortedBranches } from "../../../lib/visualization/utils";
 
 const { mock, experiment } = mockExperimentQuery("demo-slug");
-const results = mockAnalysis();
-const sortedBranches = getSortedBranches(results);
 
 describe("TableHighlights", () => {
   it("has participants shown for each variant", () => {
     render(
       <RouterSlugProvider mocks={[mock]}>
-        <TableHighlights {...{ experiment, results, sortedBranches }} />
+        <MockResultsContextProvider>
+          <TableHighlights {...{ experiment }} />
+        </MockResultsContextProvider>
       </RouterSlugProvider>,
     );
 
@@ -33,7 +34,9 @@ describe("TableHighlights", () => {
     const branchDescription = experiment.referenceBranch!.description;
     render(
       <RouterSlugProvider mocks={[mock]}>
-        <TableHighlights {...{ experiment, results, sortedBranches }} />
+        <MockResultsContextProvider>
+          <TableHighlights {...{ experiment }} />
+        </MockResultsContextProvider>
       </RouterSlugProvider>,
     );
 
@@ -43,7 +46,9 @@ describe("TableHighlights", () => {
   it("has correctly labelled result significance", async () => {
     render(
       <RouterSlugProvider mocks={[mock]}>
-        <TableHighlights {...{ experiment, results, sortedBranches }} />
+        <MockResultsContextProvider>
+          <TableHighlights {...{ experiment }} />
+        </MockResultsContextProvider>
       </RouterSlugProvider>,
     );
 
@@ -55,7 +60,9 @@ describe("TableHighlights", () => {
   it("has the expected control and treatment labels", async () => {
     render(
       <RouterSlugProvider mocks={[mock]}>
-        <TableHighlights {...{ experiment, results, sortedBranches }} />
+        <MockResultsContextProvider>
+          <TableHighlights {...{ experiment }} />
+        </MockResultsContextProvider>
       </RouterSlugProvider>,
     );
 

--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableHighlights/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableHighlights/index.tsx
@@ -2,8 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from "react";
+import React, { useContext } from "react";
 import { useOutcomes } from "../../../hooks";
+import { ResultsContext } from "../../../lib/contexts";
 import { OutcomesList } from "../../../lib/types";
 import {
   BRANCH_COMPARISON,
@@ -13,7 +14,6 @@ import {
   METRICS_TIPS,
   TABLE_LABEL,
 } from "../../../lib/visualization/constants";
-import { AnalysisData } from "../../../lib/visualization/types";
 import { getTableDisplayType } from "../../../lib/visualization/utils";
 import {
   getExperiment_experimentBySlug,
@@ -23,9 +23,7 @@ import {
 import TableVisualizationRow from "../TableVisualizationRow";
 
 type TableHighlightsProps = {
-  results: AnalysisData;
   experiment: getExperiment_experimentBySlug;
-  sortedBranches: string[];
 };
 
 type Branch =
@@ -67,24 +65,18 @@ const getBranchDescriptions = (
   );
 };
 
-const TableHighlights = ({
-  results = {
-    daily: [],
-    weekly: {},
-    overall: {},
-    metadata: { metrics: {}, outcomes: {} },
-    show_analysis: false,
-  },
-  experiment,
-  sortedBranches,
-}: TableHighlightsProps) => {
+const TableHighlights = ({ experiment }: TableHighlightsProps) => {
   const { primaryOutcomes } = useOutcomes(experiment);
   const highlightMetricsList = getHighlightMetrics(primaryOutcomes);
   const branchDescriptions = getBranchDescriptions(
     experiment.referenceBranch,
     experiment.treatmentBranches,
   );
-  const overallResults = results?.overall!;
+  const {
+    analysis: { metadata, overall },
+    sortedBranches,
+  } = useContext(ResultsContext);
+  const overallResults = overall!;
 
   return (
     <table data-testid="table-highlights" className="table mt-4 mb-0">
@@ -122,7 +114,7 @@ const TableHighlights = ({
                       overallResults[branch]["is_control"],
                     );
                     const tooltip =
-                      results.metadata?.metrics[metricKey]?.description ||
+                      metadata?.metrics[metricKey]?.description ||
                       metric.tooltip;
                     return (
                       <TableVisualizationRow

--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableMetricConversion/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableMetricConversion/index.stories.tsx
@@ -6,12 +6,11 @@ import { withLinks } from "@storybook/addon-links";
 import { storiesOf } from "@storybook/react";
 import React from "react";
 import TableMetricConversion from ".";
-import { mockExperimentQuery, mockOutcomeSets } from "../../../lib/mocks";
-import { mockAnalysis } from "../../../lib/visualization/mocks";
-import { getSortedBranches } from "../../../lib/visualization/utils";
-
-const results = mockAnalysis().overall;
-const sortedBranches = getSortedBranches(mockAnalysis());
+import {
+  mockExperimentQuery,
+  mockOutcomeSets,
+  MockResultsContextProvider,
+} from "../../../lib/mocks";
 
 storiesOf("pages/Results/TableMetricConversion", module)
   .addDecorator(withLinks)
@@ -22,10 +21,9 @@ storiesOf("pages/Results/TableMetricConversion", module)
     const { primaryOutcomes } = mockOutcomeSets(experiment);
 
     return (
-      <TableMetricConversion
-        {...{ results, sortedBranches }}
-        outcome={primaryOutcomes![0]!}
-      />
+      <MockResultsContextProvider>
+        <TableMetricConversion outcome={primaryOutcomes![0]!} />
+      </MockResultsContextProvider>
     );
   })
   .add("with negative primary metric", () => {
@@ -35,10 +33,9 @@ storiesOf("pages/Results/TableMetricConversion", module)
     const { primaryOutcomes } = mockOutcomeSets(experiment);
 
     return (
-      <TableMetricConversion
-        {...{ results, sortedBranches }}
-        outcome={primaryOutcomes![0]!}
-      />
+      <MockResultsContextProvider>
+        <TableMetricConversion outcome={primaryOutcomes![0]!} />
+      </MockResultsContextProvider>
     );
   })
   .add("with neutral primary metric", () => {
@@ -48,9 +45,8 @@ storiesOf("pages/Results/TableMetricConversion", module)
     const { primaryOutcomes } = mockOutcomeSets(experiment);
 
     return (
-      <TableMetricConversion
-        {...{ results, sortedBranches }}
-        outcome={primaryOutcomes![0]!}
-      />
+      <MockResultsContextProvider>
+        <TableMetricConversion outcome={primaryOutcomes![0]!} />
+      </MockResultsContextProvider>
     );
   });

--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableMetricConversion/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableMetricConversion/index.test.tsx
@@ -5,13 +5,12 @@
 import { render, screen } from "@testing-library/react";
 import React from "react";
 import TableMetricConversion from ".";
-import { mockExperimentQuery, mockOutcomeSets } from "../../../lib/mocks";
+import {
+  mockExperimentQuery,
+  mockOutcomeSets,
+  MockResultsContextProvider,
+} from "../../../lib/mocks";
 import { RouterSlugProvider } from "../../../lib/test-utils";
-import { mockAnalysis } from "../../../lib/visualization/mocks";
-import { getSortedBranches } from "../../../lib/visualization/utils";
-
-const results = mockAnalysis().overall;
-const sortedBranches = getSortedBranches(mockAnalysis());
 
 describe("TableMetricConversion", () => {
   it("has the correct headings", () => {
@@ -24,12 +23,11 @@ describe("TableMetricConversion", () => {
     const { primaryOutcomes } = mockOutcomeSets(experiment);
 
     render(
-      <RouterSlugProvider mocks={[mock]}>
-        <TableMetricConversion
-          {...{ results, sortedBranches }}
-          outcome={primaryOutcomes![0]!}
-        />
-      </RouterSlugProvider>,
+      <MockResultsContextProvider>
+        <RouterSlugProvider mocks={[mock]}>
+          <TableMetricConversion outcome={primaryOutcomes![0]!} />
+        </RouterSlugProvider>
+      </MockResultsContextProvider>,
     );
 
     EXPECTED_HEADINGS.forEach((heading) => {
@@ -42,12 +40,11 @@ describe("TableMetricConversion", () => {
     const { primaryOutcomes } = mockOutcomeSets(experiment);
 
     render(
-      <RouterSlugProvider mocks={[mock]}>
-        <TableMetricConversion
-          {...{ results, sortedBranches }}
-          outcome={primaryOutcomes![0]!}
-        />
-      </RouterSlugProvider>,
+      <MockResultsContextProvider>
+        <RouterSlugProvider mocks={[mock]}>
+          <TableMetricConversion outcome={primaryOutcomes![0]!} />
+        </RouterSlugProvider>
+      </MockResultsContextProvider>,
     );
 
     const negativeSignificance = screen.queryByTestId("negative-significance");
@@ -63,12 +60,11 @@ describe("TableMetricConversion", () => {
     const { primaryOutcomes } = mockOutcomeSets(experiment);
 
     render(
-      <RouterSlugProvider mocks={[mock]}>
-        <TableMetricConversion
-          {...{ results, sortedBranches }}
-          outcome={primaryOutcomes![0]!}
-        />
-      </RouterSlugProvider>,
+      <MockResultsContextProvider>
+        <RouterSlugProvider mocks={[mock]}>
+          <TableMetricConversion outcome={primaryOutcomes![0]!} />
+        </RouterSlugProvider>
+      </MockResultsContextProvider>,
     );
 
     expect(screen.getAllByText("control")).toHaveLength(2);
@@ -80,12 +76,11 @@ describe("TableMetricConversion", () => {
     const { primaryOutcomes } = mockOutcomeSets(experiment);
 
     render(
-      <RouterSlugProvider mocks={[mock]}>
-        <TableMetricConversion
-          {...{ results, sortedBranches }}
-          outcome={primaryOutcomes![0]!}
-        />
-      </RouterSlugProvider>,
+      <MockResultsContextProvider>
+        <RouterSlugProvider mocks={[mock]}>
+          <TableMetricConversion outcome={primaryOutcomes![0]!} />
+        </RouterSlugProvider>
+      </MockResultsContextProvider>,
     );
 
     const negativeBlock = screen.queryByTestId("negative-block");
@@ -103,12 +98,11 @@ describe("TableMetricConversion", () => {
     const { primaryOutcomes } = mockOutcomeSets(experiment);
 
     render(
-      <RouterSlugProvider mocks={[mock]}>
-        <TableMetricConversion
-          {...{ results, sortedBranches }}
-          outcome={primaryOutcomes![0]!}
-        />
-      </RouterSlugProvider>,
+      <MockResultsContextProvider>
+        <RouterSlugProvider mocks={[mock]}>
+          <TableMetricConversion outcome={primaryOutcomes![0]!} />
+        </RouterSlugProvider>
+      </MockResultsContextProvider>,
     );
 
     const positiveBlock = screen.queryByTestId("positive-block");
@@ -126,12 +120,11 @@ describe("TableMetricConversion", () => {
     const { primaryOutcomes } = mockOutcomeSets(experiment);
 
     render(
-      <RouterSlugProvider mocks={[mock]}>
-        <TableMetricConversion
-          {...{ results, sortedBranches }}
-          outcome={primaryOutcomes![0]!}
-        />
-      </RouterSlugProvider>,
+      <MockResultsContextProvider>
+        <RouterSlugProvider mocks={[mock]}>
+          <TableMetricConversion outcome={primaryOutcomes![0]!} />
+        </RouterSlugProvider>
+      </MockResultsContextProvider>,
     );
 
     const negativeBlock = screen.queryByTestId("negative-block");

--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableMetricConversion/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableMetricConversion/index.tsx
@@ -2,14 +2,14 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from "react";
+import React, { useContext } from "react";
+import { ResultsContext } from "../../../lib/contexts";
 import {
   CONVERSION_METRIC_COLUMNS,
   DISPLAY_TYPE,
   GROUP,
   TABLE_LABEL,
 } from "../../../lib/visualization/constants";
-import { AnalysisDataOverall } from "../../../lib/visualization/types";
 import { getExtremeBounds } from "../../../lib/visualization/utils";
 import { getConfig_nimbusConfig_outcomes } from "../../../types/getConfig";
 import TableVisualizationRow from "../TableVisualizationRow";
@@ -22,9 +22,7 @@ type ConversionMetricStatistic = {
 };
 
 type TableMetricConversionProps = {
-  results: AnalysisDataOverall;
   outcome: getConfig_nimbusConfig_outcomes;
-  sortedBranches: string[];
 };
 
 const getStatistics = (slug: string): Array<ConversionMetricStatistic> => {
@@ -41,16 +39,17 @@ const getStatistics = (slug: string): Array<ConversionMetricStatistic> => {
   return conversionMetricStatisticsList;
 };
 
-const TableMetricConversion = ({
-  results = {},
-  outcome,
-  sortedBranches,
-}: TableMetricConversionProps) => {
+const TableMetricConversion = ({ outcome }: TableMetricConversionProps) => {
+  const {
+    analysis: { overall },
+    sortedBranches,
+  } = useContext(ResultsContext);
+  const overallResults = overall!;
   const conversionMetricStatistics = getStatistics(outcome.slug!);
   const metricKey = `${outcome.slug}_ever_used`;
   const bounds = getExtremeBounds(
     sortedBranches,
-    results,
+    overallResults,
     outcome.slug!,
     GROUP.OTHER,
   );
@@ -76,7 +75,7 @@ const TableMetricConversion = ({
           </tr>
         </thead>
         <tbody>
-          {Object.keys(results).map((branch) => {
+          {Object.keys(overallResults).map((branch) => {
             return (
               <tr key={branch}>
                 <th className="align-middle" scope="row">
@@ -86,10 +85,15 @@ const TableMetricConversion = ({
                   ({ displayType, branchComparison, value }) => (
                     <TableVisualizationRow
                       key={`${displayType}-${value}`}
-                      results={results[branch]}
+                      results={overallResults[branch]}
                       group={GROUP.OTHER}
                       tableLabel={TABLE_LABEL.PRIMARY_METRICS}
-                      {...{ metricKey, displayType, branchComparison, bounds }}
+                      {...{
+                        metricKey,
+                        displayType,
+                        branchComparison,
+                        bounds,
+                      }}
                     />
                   ),
                 )}

--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableMetricCount/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableMetricCount/index.stories.tsx
@@ -6,13 +6,12 @@ import { withLinks } from "@storybook/addon-links";
 import { storiesOf } from "@storybook/react";
 import React from "react";
 import TableMetricCount from ".";
-import { mockExperimentQuery, mockOutcomeSets } from "../../../lib/mocks";
+import {
+  mockExperimentQuery,
+  mockOutcomeSets,
+  MockResultsContextProvider,
+} from "../../../lib/mocks";
 import { GROUP, METRIC_TYPE } from "../../../lib/visualization/constants";
-import { mockAnalysis } from "../../../lib/visualization/mocks";
-import { getSortedBranches } from "../../../lib/visualization/utils";
-
-const results = mockAnalysis();
-const sortedBranches = getSortedBranches(results);
 
 storiesOf("pages/Results/TableMetricCount", module)
   .addDecorator(withLinks)
@@ -23,13 +22,14 @@ storiesOf("pages/Results/TableMetricCount", module)
     const { secondaryOutcomes } = mockOutcomeSets(experiment);
 
     return (
-      <TableMetricCount
-        {...{ results, sortedBranches }}
-        outcomeSlug={secondaryOutcomes![0]!.slug!}
-        outcomeDefaultName={secondaryOutcomes![0]!.friendlyName!}
-        group={GROUP.OTHER}
-        metricType={METRIC_TYPE.USER_SELECTED_SECONDARY}
-      />
+      <MockResultsContextProvider>
+        <TableMetricCount
+          outcomeSlug={secondaryOutcomes![0]!.slug!}
+          outcomeDefaultName={secondaryOutcomes![0]!.friendlyName!}
+          group={GROUP.OTHER}
+          metricType={METRIC_TYPE.USER_SELECTED_SECONDARY}
+        />
+      </MockResultsContextProvider>
     );
   })
   .add("with negative secondary metric", () => {
@@ -37,13 +37,14 @@ storiesOf("pages/Results/TableMetricCount", module)
     const { secondaryOutcomes } = mockOutcomeSets(experiment);
 
     return (
-      <TableMetricCount
-        {...{ results, sortedBranches }}
-        outcomeSlug={secondaryOutcomes![0]!.slug!}
-        outcomeDefaultName={secondaryOutcomes![0]!.friendlyName!}
-        group={GROUP.OTHER}
-        metricType={METRIC_TYPE.USER_SELECTED_SECONDARY}
-      />
+      <MockResultsContextProvider>
+        <TableMetricCount
+          outcomeSlug={secondaryOutcomes![0]!.slug!}
+          outcomeDefaultName={secondaryOutcomes![0]!.friendlyName!}
+          group={GROUP.OTHER}
+          metricType={METRIC_TYPE.USER_SELECTED_SECONDARY}
+        />
+      </MockResultsContextProvider>
     );
   })
   .add("with neutral secondary metric", () => {
@@ -53,12 +54,13 @@ storiesOf("pages/Results/TableMetricCount", module)
     const { secondaryOutcomes } = mockOutcomeSets(experiment);
 
     return (
-      <TableMetricCount
-        {...{ results, sortedBranches }}
-        outcomeSlug={secondaryOutcomes![0]!.slug!}
-        outcomeDefaultName={secondaryOutcomes![0]!.friendlyName!}
-        group={GROUP.OTHER}
-        metricType={METRIC_TYPE.USER_SELECTED_SECONDARY}
-      />
+      <MockResultsContextProvider>
+        <TableMetricCount
+          outcomeSlug={secondaryOutcomes![0]!.slug!}
+          outcomeDefaultName={secondaryOutcomes![0]!.friendlyName!}
+          group={GROUP.OTHER}
+          metricType={METRIC_TYPE.USER_SELECTED_SECONDARY}
+        />
+      </MockResultsContextProvider>
     );
   });

--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableMetricCount/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableMetricCount/index.test.tsx
@@ -5,14 +5,13 @@
 import { render, screen } from "@testing-library/react";
 import React from "react";
 import TableMetricCount from ".";
-import { mockExperimentQuery, mockOutcomeSets } from "../../../lib/mocks";
+import {
+  mockExperimentQuery,
+  mockOutcomeSets,
+  MockResultsContextProvider,
+} from "../../../lib/mocks";
 import { RouterSlugProvider } from "../../../lib/test-utils";
 import { GROUP, METRIC_TYPE } from "../../../lib/visualization/constants";
-import { mockAnalysis } from "../../../lib/visualization/mocks";
-import { getSortedBranches } from "../../../lib/visualization/utils";
-
-const results = mockAnalysis();
-const sortedBranches = getSortedBranches(results);
 
 describe("TableMetricCount", () => {
   it("has the correct headings", () => {
@@ -22,13 +21,14 @@ describe("TableMetricCount", () => {
 
     render(
       <RouterSlugProvider mocks={[mock]}>
-        <TableMetricCount
-          outcomeSlug={secondaryOutcomes![0]!.slug!}
-          outcomeDefaultName={secondaryOutcomes![0]!.friendlyName!}
-          metricType={METRIC_TYPE.USER_SELECTED_SECONDARY}
-          group={GROUP.OTHER}
-          {...{ results, sortedBranches }}
-        />
+        <MockResultsContextProvider>
+          <TableMetricCount
+            outcomeSlug={secondaryOutcomes![0]!.slug!}
+            outcomeDefaultName={secondaryOutcomes![0]!.friendlyName!}
+            metricType={METRIC_TYPE.USER_SELECTED_SECONDARY}
+            group={GROUP.OTHER}
+          />
+        </MockResultsContextProvider>
       </RouterSlugProvider>,
     );
 
@@ -43,13 +43,14 @@ describe("TableMetricCount", () => {
 
     render(
       <RouterSlugProvider mocks={[mock]}>
-        <TableMetricCount
-          outcomeSlug={secondaryOutcomes![0]!.slug!}
-          outcomeDefaultName={secondaryOutcomes![0]!.friendlyName!}
-          group={GROUP.OTHER}
-          metricType={METRIC_TYPE.USER_SELECTED_SECONDARY}
-          {...{ results, sortedBranches }}
-        />
+        <MockResultsContextProvider>
+          <TableMetricCount
+            outcomeSlug={secondaryOutcomes![0]!.slug!}
+            outcomeDefaultName={secondaryOutcomes![0]!.friendlyName!}
+            group={GROUP.OTHER}
+            metricType={METRIC_TYPE.USER_SELECTED_SECONDARY}
+          />
+        </MockResultsContextProvider>
       </RouterSlugProvider>,
     );
 
@@ -67,13 +68,14 @@ describe("TableMetricCount", () => {
 
     render(
       <RouterSlugProvider mocks={[mock]}>
-        <TableMetricCount
-          outcomeSlug={secondaryOutcomes![0]!.slug!}
-          outcomeDefaultName={secondaryOutcomes![0]!.friendlyName!}
-          group={GROUP.OTHER}
-          metricType={METRIC_TYPE.USER_SELECTED_SECONDARY}
-          {...{ results, sortedBranches }}
-        />
+        <MockResultsContextProvider>
+          <TableMetricCount
+            outcomeSlug={secondaryOutcomes![0]!.slug!}
+            outcomeDefaultName={secondaryOutcomes![0]!.friendlyName!}
+            group={GROUP.OTHER}
+            metricType={METRIC_TYPE.USER_SELECTED_SECONDARY}
+          />
+        </MockResultsContextProvider>
       </RouterSlugProvider>,
     );
 
@@ -87,13 +89,14 @@ describe("TableMetricCount", () => {
 
     render(
       <RouterSlugProvider mocks={[mock]}>
-        <TableMetricCount
-          outcomeSlug={secondaryOutcomes![0]!.slug!}
-          outcomeDefaultName={secondaryOutcomes![0]!.friendlyName!}
-          group={GROUP.OTHER}
-          metricType={METRIC_TYPE.USER_SELECTED_SECONDARY}
-          {...{ results, sortedBranches }}
-        />
+        <MockResultsContextProvider>
+          <TableMetricCount
+            outcomeSlug={secondaryOutcomes![0]!.slug!}
+            outcomeDefaultName={secondaryOutcomes![0]!.friendlyName!}
+            group={GROUP.OTHER}
+            metricType={METRIC_TYPE.USER_SELECTED_SECONDARY}
+          />
+        </MockResultsContextProvider>
       </RouterSlugProvider>,
     );
 
@@ -111,13 +114,14 @@ describe("TableMetricCount", () => {
 
     render(
       <RouterSlugProvider mocks={[mock]}>
-        <TableMetricCount
-          outcomeSlug={secondaryOutcomes![0]!.slug!}
-          outcomeDefaultName={secondaryOutcomes![0]!.friendlyName!}
-          group={GROUP.OTHER}
-          metricType={METRIC_TYPE.USER_SELECTED_SECONDARY}
-          {...{ results, sortedBranches }}
-        />
+        <MockResultsContextProvider>
+          <TableMetricCount
+            outcomeSlug={secondaryOutcomes![0]!.slug!}
+            outcomeDefaultName={secondaryOutcomes![0]!.friendlyName!}
+            group={GROUP.OTHER}
+            metricType={METRIC_TYPE.USER_SELECTED_SECONDARY}
+          />
+        </MockResultsContextProvider>
       </RouterSlugProvider>,
     );
 
@@ -131,13 +135,14 @@ describe("TableMetricCount", () => {
 
     render(
       <RouterSlugProvider mocks={[mock]}>
-        <TableMetricCount
-          outcomeSlug="feature_d"
-          outcomeDefaultName={secondaryOutcomes![0]!.friendlyName!}
-          group={GROUP.OTHER}
-          metricType={METRIC_TYPE.USER_SELECTED_SECONDARY}
-          {...{ results, sortedBranches }}
-        />
+        <MockResultsContextProvider>
+          <TableMetricCount
+            outcomeSlug="feature_d"
+            outcomeDefaultName={secondaryOutcomes![0]!.friendlyName!}
+            group={GROUP.OTHER}
+            metricType={METRIC_TYPE.USER_SELECTED_SECONDARY}
+          />
+        </MockResultsContextProvider>
       </RouterSlugProvider>,
     );
 

--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableMetricCount/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableMetricCount/index.tsx
@@ -2,15 +2,15 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from "react";
+import React, { useContext } from "react";
 import { ReactComponent as Info } from "../../../images/info.svg";
+import { ResultsContext } from "../../../lib/contexts";
 import {
   COUNT_METRIC_COLUMNS,
   DISPLAY_TYPE,
   METRIC_TYPE,
   TABLE_LABEL,
 } from "../../../lib/visualization/constants";
-import { AnalysisData } from "../../../lib/visualization/types";
 import { getExtremeBounds } from "../../../lib/visualization/utils";
 import GraphsWeekly from "../GraphsWeekly";
 import TableVisualizationRow from "../TableVisualizationRow";
@@ -30,12 +30,10 @@ type MetricTypes =
   | typeof METRIC_TYPE.GUARDRAIL;
 
 type TableMetricCountProps = {
-  results: AnalysisData;
   outcomeSlug: string;
   outcomeDefaultName: string;
   group: string;
   metricType?: MetricTypes;
-  sortedBranches: string[];
 };
 
 const getStatistics = (slug: string): Array<CountMetricStatistic> => {
@@ -51,22 +49,18 @@ const getStatistics = (slug: string): Array<CountMetricStatistic> => {
 };
 
 const TableMetricCount = ({
-  results = {
-    daily: [],
-    weekly: {},
-    overall: {},
-    metadata: { metrics: {}, outcomes: {} },
-    show_analysis: false,
-  },
   outcomeSlug,
   outcomeDefaultName,
   group,
   metricType = METRIC_TYPE.DEFAULT_SECONDARY,
-  sortedBranches,
 }: TableMetricCountProps) => {
   const countMetricStatistics = getStatistics(outcomeSlug);
+  const {
+    analysis: { metadata, overall, weekly },
+    sortedBranches,
+  } = useContext(ResultsContext);
+  const overallResults = overall!;
 
-  const overallResults = results?.overall!;
   const bounds = getExtremeBounds(
     sortedBranches,
     overallResults,
@@ -74,9 +68,9 @@ const TableMetricCount = ({
     group,
   );
   const outcomeName =
-    results.metadata?.metrics[outcomeSlug]?.friendly_name || outcomeDefaultName;
+    metadata?.metrics[outcomeSlug]?.friendly_name || outcomeDefaultName;
   const outcomeDescription =
-    results.metadata?.metrics[outcomeSlug]?.description || undefined;
+    metadata?.metrics[outcomeSlug]?.description || undefined;
 
   return (
     <div data-testid="table-metric-secondary" className="mb-5">
@@ -136,10 +130,9 @@ const TableMetricCount = ({
                         <TableVisualizationRow
                           key={`${displayType}-${value}`}
                           results={overallResults[branch]}
-                          group={group}
                           tableLabel={TABLE_LABEL.SECONDARY_METRICS}
                           metricKey={outcomeSlug}
-                          {...{ displayType, branchComparison, bounds }}
+                          {...{ displayType, branchComparison, bounds, group }}
                         />
                       ),
                     )}
@@ -149,11 +142,10 @@ const TableMetricCount = ({
             })}
         </tbody>
       </table>
-      {results?.weekly && (
+      {weekly && (
         <GraphsWeekly
-          weeklyResults={results.weekly}
-          {...{ outcomeSlug, outcomeName }}
-          group={group}
+          weeklyResults={weekly}
+          {...{ outcomeSlug, outcomeName, group }}
         />
       )}
     </div>

--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableResults/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableResults/index.stories.tsx
@@ -6,14 +6,13 @@ import { withLinks } from "@storybook/addon-links";
 import { storiesOf } from "@storybook/react";
 import React from "react";
 import TableResults from ".";
-import { mockExperimentQuery } from "../../../lib/mocks";
+import {
+  mockExperimentQuery,
+  MockResultsContextProvider,
+} from "../../../lib/mocks";
 import { RouterSlugProvider } from "../../../lib/test-utils";
 import { BRANCH_COMPARISON } from "../../../lib/visualization/constants";
-import { mockAnalysis } from "../../../lib/visualization/mocks";
-import { getSortedBranches } from "../../../lib/visualization/utils";
-
-const results = mockAnalysis();
-const sortedBranches = getSortedBranches(results);
+import { mockIncompleteAnalysis } from "../../../lib/visualization/mocks";
 
 storiesOf("pages/Results/TableResults", module)
   .addDecorator(withLinks)
@@ -21,7 +20,9 @@ storiesOf("pages/Results/TableResults", module)
     const { mock, experiment } = mockExperimentQuery("demo-slug");
     return (
       <RouterSlugProvider mocks={[mock]}>
-        <TableResults {...{ experiment, results, sortedBranches }} />
+        <MockResultsContextProvider>
+          <TableResults {...{ experiment }} />
+        </MockResultsContextProvider>
       </RouterSlugProvider>
     );
   })
@@ -31,7 +32,9 @@ storiesOf("pages/Results/TableResults", module)
     });
     return (
       <RouterSlugProvider mocks={[mock]}>
-        <TableResults {...{ experiment, results, sortedBranches }} />
+        <MockResultsContextProvider>
+          <TableResults {...{ experiment }} />
+        </MockResultsContextProvider>
       </RouterSlugProvider>
     );
   })
@@ -39,10 +42,12 @@ storiesOf("pages/Results/TableResults", module)
     const { mock, experiment } = mockExperimentQuery("demo-slug");
     return (
       <RouterSlugProvider mocks={[mock]}>
-        <TableResults
-          branchComparison={BRANCH_COMPARISON.ABSOLUTE}
-          {...{ experiment, results, sortedBranches }}
-        />
+        <MockResultsContextProvider>
+          <TableResults
+            branchComparison={BRANCH_COMPARISON.ABSOLUTE}
+            {...{ experiment }}
+          />
+        </MockResultsContextProvider>
       </RouterSlugProvider>
     );
   })
@@ -52,10 +57,22 @@ storiesOf("pages/Results/TableResults", module)
     });
     return (
       <RouterSlugProvider mocks={[mock]}>
-        <TableResults
-          branchComparison={BRANCH_COMPARISON.ABSOLUTE}
-          {...{ experiment, results, sortedBranches }}
-        />
+        <MockResultsContextProvider>
+          <TableResults
+            branchComparison={BRANCH_COMPARISON.ABSOLUTE}
+            {...{ experiment }}
+          />
+        </MockResultsContextProvider>
+      </RouterSlugProvider>
+    );
+  })
+  .add("missing retention with warning", () => {
+    const { mock, experiment } = mockExperimentQuery("demo-slug");
+    return (
+      <RouterSlugProvider mocks={[mock]}>
+        <MockResultsContextProvider analysis={mockIncompleteAnalysis()}>
+          <TableResults {...{ experiment }} />
+        </MockResultsContextProvider>
       </RouterSlugProvider>
     );
   });

--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableResults/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableResults/index.test.tsx
@@ -5,24 +5,23 @@
 import { render, screen } from "@testing-library/react";
 import React from "react";
 import TableResults from ".";
-import { mockExperimentQuery } from "../../../lib/mocks";
+import {
+  mockExperimentQuery,
+  MockResultsContextProvider,
+} from "../../../lib/mocks";
 import { RouterSlugProvider } from "../../../lib/test-utils";
 import { BRANCH_COMPARISON } from "../../../lib/visualization/constants";
-import {
-  mockAnalysis,
-  mockIncompleteAnalysis,
-} from "../../../lib/visualization/mocks";
-import { getSortedBranches } from "../../../lib/visualization/utils";
+import { mockIncompleteAnalysis } from "../../../lib/visualization/mocks";
 
 const { mock, experiment } = mockExperimentQuery("demo-slug");
-const results = mockAnalysis();
-const sortedBranches = getSortedBranches(results);
 
 describe("TableResults", () => {
   it("renders correct headings", () => {
     render(
       <RouterSlugProvider mocks={[mock]}>
-        <TableResults {...{ experiment, results, sortedBranches }} />
+        <MockResultsContextProvider>
+          <TableResults {...{ experiment }} />
+        </MockResultsContextProvider>
       </RouterSlugProvider>,
     );
     const EXPECTED_HEADINGS = [
@@ -40,7 +39,9 @@ describe("TableResults", () => {
   it("with relative comparison, renders the expected variant, comparison, and user count", () => {
     render(
       <RouterSlugProvider mocks={[mock]}>
-        <TableResults {...{ experiment, results, sortedBranches }} />
+        <MockResultsContextProvider>
+          <TableResults {...{ experiment }} />
+        </MockResultsContextProvider>
       </RouterSlugProvider>,
     );
 
@@ -58,10 +59,12 @@ describe("TableResults", () => {
   it("with absolute comparison, renders the expected variant, comparison, and user count", async () => {
     render(
       <RouterSlugProvider mocks={[mock]}>
-        <TableResults
-          branchComparison={BRANCH_COMPARISON.ABSOLUTE}
-          {...{ experiment, results, sortedBranches }}
-        />
+        <MockResultsContextProvider>
+          <TableResults
+            {...{ experiment }}
+            branchComparison={BRANCH_COMPARISON.ABSOLUTE}
+          />
+        </MockResultsContextProvider>
       </RouterSlugProvider>,
     );
     expect(screen.getByText("88.6%", { exact: false })).toBeInTheDocument();
@@ -77,7 +80,9 @@ describe("TableResults", () => {
   it("renders correctly labelled result significance", () => {
     render(
       <RouterSlugProvider mocks={[mock]}>
-        <TableResults {...{ experiment, results, sortedBranches }} />
+        <MockResultsContextProvider>
+          <TableResults {...{ experiment }} />
+        </MockResultsContextProvider>
       </RouterSlugProvider>,
     );
     expect(screen.getByTestId("positive-significance")).toBeInTheDocument();
@@ -86,12 +91,11 @@ describe("TableResults", () => {
   });
 
   it("renders missing retention with warning", () => {
-    const results = mockIncompleteAnalysis();
-    const sortedBranches = getSortedBranches(results);
-
     render(
       <RouterSlugProvider mocks={[mock]}>
-        <TableResults {...{ experiment, results, sortedBranches }} />
+        <MockResultsContextProvider analysis={mockIncompleteAnalysis()}>
+          <TableResults {...{ experiment }} />
+        </MockResultsContextProvider>
       </RouterSlugProvider>,
     );
 

--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableResults/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableResults/index.tsx
@@ -2,8 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from "react";
+import React, { useContext } from "react";
 import { useOutcomes } from "../../../hooks";
+import { ResultsContext } from "../../../lib/contexts";
 import { OutcomesList } from "../../../lib/types";
 import {
   BRANCH_COMPARISON,
@@ -13,10 +14,7 @@ import {
   RESULTS_METRICS_LIST,
   TABLE_LABEL,
 } from "../../../lib/visualization/constants";
-import {
-  AnalysisData,
-  BranchComparisonValues,
-} from "../../../lib/visualization/types";
+import { BranchComparisonValues } from "../../../lib/visualization/types";
 import { getTableDisplayType } from "../../../lib/visualization/utils";
 import { getExperiment_experimentBySlug } from "../../../types/getExperiment";
 import TableVisualizationRow from "../TableVisualizationRow";
@@ -24,8 +22,6 @@ import TooltipWithMarkdown from "../TooltipWithMarkdown";
 
 type TableResultsProps = {
   experiment: getExperiment_experimentBySlug;
-  results: AnalysisData;
-  sortedBranches: string[];
   branchComparison?: BranchComparisonValues;
 };
 
@@ -50,19 +46,15 @@ const getResultMetrics = (outcomes: OutcomesList) => {
 
 const TableResults = ({
   experiment,
-  results = {
-    daily: [],
-    weekly: {},
-    overall: {},
-    metadata: { metrics: {}, outcomes: {} },
-    show_analysis: false,
-  },
-  sortedBranches,
   branchComparison = BRANCH_COMPARISON.UPLIFT,
 }: TableResultsProps) => {
   const { primaryOutcomes } = useOutcomes(experiment);
   const resultsMetricsList = getResultMetrics(primaryOutcomes);
-  const overallResults = results?.overall!;
+  const {
+    analysis: { metadata, overall },
+    sortedBranches,
+  } = useContext(ResultsContext);
+  const overallResults = overall!;
 
   return (
     <table className="table-visualization-center" data-testid="table-results">
@@ -72,8 +64,7 @@ const TableResults = ({
           {resultsMetricsList.map((metric, index) => {
             const badgeClass = `badge ${metric.type?.badge}`;
             const outcomeDescription =
-              results.metadata?.metrics[metric.value]?.description ||
-              metric.tooltip;
+              metadata?.metrics[metric.value]?.description || metric.tooltip;
 
             return (
               <th

--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableResultsWeekly/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableResultsWeekly/index.stories.tsx
@@ -6,39 +6,28 @@ import { withLinks } from "@storybook/addon-links";
 import { storiesOf } from "@storybook/react";
 import React from "react";
 import TableResultsWeekly from ".";
+import { MockResultsContextProvider } from "../../../lib/mocks";
 import {
   BRANCH_COMPARISON,
   HIGHLIGHTS_METRICS_LIST,
 } from "../../../lib/visualization/constants";
-import { weeklyMockAnalysis } from "../../../lib/visualization/mocks";
-import { getSortedBranches } from "../../../lib/visualization/utils";
-
-const weeklyResults = weeklyMockAnalysis();
-const sortedBranches = getSortedBranches({
-  show_analysis: true,
-  daily: null,
-  weekly: weeklyResults,
-  overall: null,
-});
 
 storiesOf("pages/Results/TableResultsWeekly", module)
   .addDecorator(withLinks)
   .add("with relative uplift comparison", () => {
     return (
-      <TableResultsWeekly
-        {...{ weeklyResults, sortedBranches }}
-        hasOverallResults
-        metricsList={HIGHLIGHTS_METRICS_LIST}
-      />
+      <MockResultsContextProvider>
+        <TableResultsWeekly metricsList={HIGHLIGHTS_METRICS_LIST} />
+      </MockResultsContextProvider>
     );
   })
   .add("with absolute comparison", () => {
     return (
-      <TableResultsWeekly
-        {...{ weeklyResults, sortedBranches }}
-        hasOverallResults
-        metricsList={HIGHLIGHTS_METRICS_LIST}
-        branchComparison={BRANCH_COMPARISON.ABSOLUTE}
-      />
+      <MockResultsContextProvider>
+        <TableResultsWeekly
+          metricsList={HIGHLIGHTS_METRICS_LIST}
+          branchComparison={BRANCH_COMPARISON.ABSOLUTE}
+        />
+      </MockResultsContextProvider>
     );
   });

--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableResultsWeekly/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableResultsWeekly/index.test.tsx
@@ -5,29 +5,18 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import React from "react";
 import TableResultsWeekly from ".";
+import { MockResultsContextProvider } from "../../../lib/mocks";
 import {
   BRANCH_COMPARISON,
   HIGHLIGHTS_METRICS_LIST,
 } from "../../../lib/visualization/constants";
-import { weeklyMockAnalysis } from "../../../lib/visualization/mocks";
-import { getSortedBranches } from "../../../lib/visualization/utils";
-
-const weeklyResults = weeklyMockAnalysis();
-const sortedBranches = getSortedBranches({
-  show_analysis: true,
-  daily: null,
-  weekly: weeklyResults,
-  overall: null,
-});
 
 describe("TableResultsWeekly", () => {
   it("renders as expected with relative uplift branch comparison (default)", () => {
     render(
-      <TableResultsWeekly
-        hasOverallResults
-        metricsList={HIGHLIGHTS_METRICS_LIST}
-        {...{ weeklyResults, sortedBranches }}
-      />,
+      <MockResultsContextProvider>
+        <TableResultsWeekly metricsList={HIGHLIGHTS_METRICS_LIST} />,
+      </MockResultsContextProvider>,
     );
 
     const EXPECTED_HEADINGS = ["Retention", "Search", "Days of Use"];
@@ -51,12 +40,12 @@ describe("TableResultsWeekly", () => {
 
   it("renders as expected with absolute branch comparison", () => {
     render(
-      <TableResultsWeekly
-        hasOverallResults
-        metricsList={HIGHLIGHTS_METRICS_LIST}
-        branchComparison={BRANCH_COMPARISON.ABSOLUTE}
-        {...{ weeklyResults, sortedBranches }}
-      />,
+      <MockResultsContextProvider>
+        <TableResultsWeekly
+          metricsList={HIGHLIGHTS_METRICS_LIST}
+          branchComparison={BRANCH_COMPARISON.ABSOLUTE}
+        />
+      </MockResultsContextProvider>,
     );
 
     expect(
@@ -69,13 +58,12 @@ describe("TableResultsWeekly", () => {
     const SHOW_TEXT = "Show Weekly Data";
 
     render(
-      <TableResultsWeekly
-        hasOverallResults={false}
-        metricsList={HIGHLIGHTS_METRICS_LIST}
-        {...{ weeklyResults, sortedBranches }}
-      />,
+      <MockResultsContextProvider>
+        <TableResultsWeekly metricsList={HIGHLIGHTS_METRICS_LIST} />,
+      </MockResultsContextProvider>,
     );
 
+    fireEvent.click(screen.getByText(SHOW_TEXT));
     expect(screen.getByText(HIDE_TEXT)).toBeInTheDocument();
     fireEvent.click(screen.getByText(HIDE_TEXT));
     expect(screen.getByText(SHOW_TEXT)).toBeInTheDocument();

--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableResultsWeekly/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableResultsWeekly/index.tsx
@@ -1,40 +1,36 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-import React, { useState } from "react";
+import React, { useContext, useState } from "react";
 import Collapse from "react-bootstrap/Collapse";
 import { ReactComponent as CollapseMinus } from "../../../images/minus.svg";
 import { ReactComponent as ExpandPlus } from "../../../images/plus.svg";
+import { ResultsContext } from "../../../lib/contexts";
 import {
   BRANCH_COMPARISON,
   GENERAL_TIPS,
 } from "../../../lib/visualization/constants";
-import {
-  AnalysisDataWeekly,
-  BranchComparisonValues,
-} from "../../../lib/visualization/types";
+import { BranchComparisonValues } from "../../../lib/visualization/types";
 import TableWeekly from "../TableWeekly";
 
 type TableResultsWeeklyProps = {
-  weeklyResults: AnalysisDataWeekly;
-  hasOverallResults: boolean;
   metricsList: {
     value: string;
     name: string;
     tooltip: string;
     group: string;
   }[];
-  sortedBranches: string[];
   branchComparison?: BranchComparisonValues;
 };
 
 const TableResultsWeekly = ({
-  weeklyResults = {},
-  hasOverallResults = false,
   metricsList,
-  sortedBranches,
   branchComparison = BRANCH_COMPARISON.UPLIFT,
 }: TableResultsWeeklyProps) => {
+  const {
+    analysis: { overall },
+  } = useContext(ResultsContext);
+  const hasOverallResults = !!overall;
   const [open, setOpen] = useState(!hasOverallResults);
 
   return (
@@ -72,8 +68,7 @@ const TableResultsWeekly = ({
                   metricKey={metric.value}
                   metricName={metric.name}
                   group={metric.group}
-                  results={weeklyResults}
-                  {...{ sortedBranches, branchComparison }}
+                  {...{ branchComparison }}
                 />
               </div>
             );

--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableWeekly/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableWeekly/index.test.tsx
@@ -5,20 +5,21 @@
 import { render, screen } from "@testing-library/react";
 import React from "react";
 import TableWeekly from ".";
+import { MockResultsContextProvider } from "../../../lib/mocks";
 import { RouterSlugProvider } from "../../../lib/test-utils";
 import { BRANCH_COMPARISON, GROUP } from "../../../lib/visualization/constants";
 import {
+  mockAnalysis,
   weeklyMockAnalysis,
   WEEKLY_IDENTITY,
   WEEKLY_TREATMENT,
   WONKY_WEEKLY_TREATMENT,
 } from "../../../lib/visualization/mocks";
-import { getSortedBranches } from "../../../lib/visualization/utils";
 
 describe("TableWeekly", () => {
   it("has the correct headings", () => {
     const EXPECTED_HEADINGS = ["Week 1", "Week 2", "Week 5"];
-    const modified_treatment = {
+    const modifications = {
       treatment: {
         is_control: false,
         branch_data: {
@@ -35,22 +36,19 @@ describe("TableWeekly", () => {
       },
     };
 
-    const results = weeklyMockAnalysis(modified_treatment);
-    const sortedBranches = getSortedBranches({
-      show_analysis: true,
-      daily: null,
-      weekly: results,
-      overall: null,
+    const analysis = mockAnalysis({
+      weekly: weeklyMockAnalysis(modifications),
     });
 
     render(
       <RouterSlugProvider>
-        <TableWeekly
-          metricKey="retained"
-          metricName="Retention"
-          group={GROUP.OTHER}
-          {...{ results, sortedBranches }}
-        />
+        <MockResultsContextProvider {...{ analysis }}>
+          <TableWeekly
+            metricKey="retained"
+            metricName="Retention"
+            group={GROUP.OTHER}
+          />
+        </MockResultsContextProvider>
       </RouterSlugProvider>,
     );
 
@@ -61,23 +59,17 @@ describe("TableWeekly", () => {
 
   it("shows error text when metric data isn't available", () => {
     const ERROR_TEXT = "Some Made Up Metric is not available";
-    const results = weeklyMockAnalysis();
-    const sortedBranches = getSortedBranches({
-      show_analysis: true,
-      daily: null,
-      weekly: results,
-      overall: null,
-    });
 
     render(
       <RouterSlugProvider>
-        <TableWeekly
-          metricKey="fake"
-          metricName="Some Made Up Metric"
-          branchComparison={BRANCH_COMPARISON.ABSOLUTE}
-          group={GROUP.OTHER}
-          {...{ results, sortedBranches }}
-        />
+        <MockResultsContextProvider>
+          <TableWeekly
+            metricKey="fake"
+            metricName="Some Made Up Metric"
+            branchComparison={BRANCH_COMPARISON.ABSOLUTE}
+            group={GROUP.OTHER}
+          />
+        </MockResultsContextProvider>
       </RouterSlugProvider>,
     );
 

--- a/app/experimenter/nimbus-ui/src/lib/contexts.ts
+++ b/app/experimenter/nimbus-ui/src/lib/contexts.ts
@@ -1,0 +1,27 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from "react";
+import { AnalysisData } from "./visualization/types";
+import { getSortedBranches } from "./visualization/utils";
+
+export type ResultsContextType = {
+  analysis: AnalysisData;
+  sortedBranches: ReturnType<typeof getSortedBranches>;
+};
+
+export const defaultResultsContext = {
+  analysis: {
+    daily: [],
+    weekly: {},
+    overall: {},
+    metadata: { metrics: {}, outcomes: {} },
+    show_analysis: false,
+  },
+  sortedBranches: [],
+};
+
+export const ResultsContext = React.createContext<ResultsContextType>(
+  defaultResultsContext,
+);

--- a/app/experimenter/nimbus-ui/src/lib/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/lib/mocks.tsx
@@ -14,7 +14,7 @@ import { MockedResponse, MockLink } from "@apollo/client/testing";
 import { Observable } from "@apollo/client/utilities";
 import { equal } from "@wry/equality";
 import { DocumentNode, print } from "graphql";
-import React from "react";
+import React, { ReactNode } from "react";
 import { GET_CONFIG_QUERY } from "../gql/config";
 import {
   GET_EXPERIMENTS_QUERY,
@@ -42,8 +42,12 @@ import {
   NimbusExperimentPublishStatus,
   NimbusExperimentStatus,
 } from "../types/globalTypes";
+import { ResultsContext } from "./contexts";
 import { getStatus } from "./experiment";
 import { OutcomesList, OutcomeSlugs } from "./types";
+import { mockAnalysis } from "./visualization/mocks";
+import { AnalysisData } from "./visualization/types";
+import { getSortedBranches } from "./visualization/utils";
 
 export interface MockedProps {
   config?: Partial<typeof MOCK_CONFIG> | null;
@@ -782,3 +786,20 @@ export const mockRejectionChangelog = (
   changedOn,
   message,
 });
+
+export const MockResultsContextProvider = ({
+  children,
+  analysis = mockAnalysis(),
+}: {
+  children: ReactNode;
+  analysis?: AnalysisData;
+}) => {
+  const value = {
+    analysis,
+    sortedBranches: getSortedBranches(analysis),
+  };
+
+  return (
+    <ResultsContext.Provider {...{ value }}>{children}</ResultsContext.Provider>
+  );
+};

--- a/app/experimenter/nimbus-ui/src/lib/visualization/utils.tsx
+++ b/app/experimenter/nimbus-ui/src/lib/visualization/utils.tsx
@@ -15,12 +15,12 @@ import {
 } from "./types";
 
 // `show_analysis` is the feature flag for turning visualization on/off.
-// `overall` will be `null` if the analysis isn't available yet.
+// `overall` and `weekly` will be `null` if the analysis isn't available yet.
 export const analysisAvailable = (analysis: AnalysisData | undefined) =>
   analysis?.show_analysis && (analysis?.overall || analysis?.weekly);
 
 export const analysisUnavailable = (analysis: AnalysisData | undefined) =>
-  analysis && !analysisAvailable(analysis);
+  !analysisAvailable(analysis);
 
 export const getTableDisplayType = (
   metricKey: string,
@@ -47,25 +47,14 @@ export const getTableDisplayType = (
   return displayType;
 };
 
+// Ensures the control branch is first
 export const getSortedBranches = (analysis: AnalysisData) => {
-  if (analysis?.overall) {
-    return Object.keys(analysis.overall)
-      .filter((branch) => analysis.overall?.[branch].is_control)
-      .concat(
-        Object.keys(analysis.overall).filter(
-          (branch) => !analysis.overall?.[branch].is_control,
-        ),
-      );
-  } else if (analysis?.weekly) {
-    return Object.keys(analysis.weekly)
-      .filter((branch) => analysis.weekly?.[branch].is_control)
-      .concat(
-        Object.keys(analysis.weekly).filter(
-          (branch) => !analysis.weekly?.[branch].is_control,
-        ),
-      );
-  }
-  return [];
+  const results = analysis.overall || analysis.weekly || {};
+  return Object.keys(results)
+    .filter((branch) => results[branch].is_control)
+    .concat(
+      Object.keys(results).filter((branch) => !results[branch].is_control),
+    );
 };
 
 /**


### PR DESCRIPTION
Because:
* We are already prop-driling several things down from PageResults into the tables, and at least two upcoming visualization fixes and tasks would need to do the same. This change cleans up the prop-drilling by adding ResultsContext referenced by tables on this page and sets us up for easier work in the future.

This commit:
* Creates a ResultsContext set in PageResults and consumes what's needed in each table
* Creates a mock context, updates stories and tests
* Contains other minor cleanups

---

Original PR for this was #6204. This was split up 1) for review purposes and 2) because we're discussing Jetstream metadata later today, I'll create a follow up PR for the remaining work in #6204 and will close that first PR at that time.