### PR TITLE
fix #6229 fix(nimbus): use button for archive action

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/LinkNav/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/LinkNav/index.tsx
@@ -5,6 +5,7 @@
 import { Link } from "@reach/router";
 import classNames from "classnames";
 import React from "react";
+import { Button } from "react-bootstrap";
 import Nav from "react-bootstrap/Nav";
 import { BASE_PATH } from "../../lib/constants";
 
@@ -18,6 +19,7 @@ type LinkNavProps = {
   textColor?: string;
   title?: string;
   onClick?: () => void;
+  useButton?: boolean;
 };
 
 export const LinkNav = ({
@@ -30,6 +32,7 @@ export const LinkNav = ({
   textColor,
   title,
   onClick,
+  useButton = false,
 }: LinkNavProps) => {
   const to = route ? `${BASE_PATH}/${route}` : BASE_PATH;
   // an alternative to reach-router's `isCurrent` with identical
@@ -52,6 +55,20 @@ export const LinkNav = ({
         >
           {children}
         </span>
+      ) : useButton ? (
+        <Button
+          {...{ title }}
+          variant="link"
+          data-sb-kind={storiesOf}
+          className={classNames(
+            textColor,
+            "d-flex font-weight-semibold m-0 p-0 b-0 align-items-center",
+          )}
+          data-testid={testid}
+          onClick={onClick}
+        >
+          {children}
+        </Button>
       ) : (
         <Link
           {...{ to, title }}

--- a/app/experimenter/nimbus-ui/src/components/SidebarActions/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/SidebarActions/index.test.tsx
@@ -28,10 +28,7 @@ describe("SidebarActions", () => {
 
   it("renders an enabled archive button for unarchived experiment", () => {
     render(<Subject experiment={{ isArchived: false, canArchive: true }} />);
-    expect(screen.getByTestId("action-archive")).toHaveAttribute(
-      "href",
-      "/nimbus/my-special-slug/#",
-    );
+    expect(screen.getByTestId("action-archive").tagName).toEqual("BUTTON");
     expect(screen.getByTestId("action-archive")).toHaveTextContent(
       "Archive Experiment",
     );
@@ -46,10 +43,7 @@ describe("SidebarActions", () => {
 
   it("renders an enabled archive button for unarchived experiment", () => {
     render(<Subject experiment={{ isArchived: true, canArchive: true }} />);
-    expect(screen.getByTestId("action-archive")).toHaveAttribute(
-      "href",
-      "/nimbus/my-special-slug/#",
-    );
+    expect(screen.getByTestId("action-archive").tagName).toEqual("BUTTON");
     expect(screen.getByTestId("action-archive")).toHaveTextContent(
       "Unarchive Experiment",
     );

--- a/app/experimenter/nimbus-ui/src/components/SidebarActions/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/SidebarActions/index.tsx
@@ -33,8 +33,8 @@ export const SidebarActions = ({
       </p>
       <p>
         <LinkNav
+          useButton
           key="sidebar-actions-archive"
-          route={`${experiment.slug}/#`}
           disabled={!experiment.canArchive || isLoading}
           testid="action-archive"
           onClick={onUpdateArchived}

--- a/app/experimenter/nimbus-ui/src/hooks/useArchive.tsx
+++ b/app/experimenter/nimbus-ui/src/hooks/useArchive.tsx
@@ -59,7 +59,7 @@ export function useArchive(
       setIsLoading(false);
     },
 
-    [updateExperiment, experiment, refetch],
+    [updateExperiment, setSubmitError, setIsLoading, experiment, refetch],
   );
 
   return { callback, isLoading, submitError };


### PR DESCRIPTION
Because:

* Using a router `<Link>` component triggers undesired navigation events
  that sometimes foul up the experiment refetch post-archive

This commit:

* Adds the option to use a `<Button>` component in `<LinkNav>`

* Uses the button option for the archiving action in the sidebar