### PR TITLE
fix #6208 feat(nimbus): inform user why buttons are disabled

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/SidebarActions/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/SidebarActions/index.test.tsx
@@ -18,32 +18,32 @@ describe("SidebarActions", () => {
   it("renders a disabled archive button for unarchived experiment", () => {
     render(<Subject experiment={{ isArchived: false, canArchive: false }} />);
     expect(screen.getByTestId("action-archive")).toHaveClass("text-muted");
-    expect(screen.getByTestId("action-archive")).toHaveTextContent(
-      "Archive Experiment",
-    );
+    expect(screen.getByTestId("action-archive")).toHaveTextContent("Archive");
+    expect(screen.getByTestId("tooltip-archived-disabled")).toBeInTheDocument();
   });
 
   it("renders an enabled archive button for unarchived experiment", () => {
     render(<Subject experiment={{ isArchived: false, canArchive: true }} />);
     expect(screen.getByTestId("action-archive").tagName).toEqual("BUTTON");
-    expect(screen.getByTestId("action-archive")).toHaveTextContent(
-      "Archive Experiment",
-    );
+    expect(screen.getByTestId("action-archive")).toHaveTextContent("Archive");
+    expect(
+      screen.queryByTestId("tooltip-archived-disabled"),
+    ).not.toBeInTheDocument();
   });
   it("renders a disabled unarchive button for archived experiment", () => {
     render(<Subject experiment={{ isArchived: true, canArchive: false }} />);
     expect(screen.getByTestId("action-archive")).toHaveClass("text-muted");
-    expect(screen.getByTestId("action-archive")).toHaveTextContent(
-      "Unarchive Experiment",
-    );
+    expect(screen.getByTestId("action-archive")).toHaveTextContent("Unarchive");
+    expect(screen.getByTestId("tooltip-archived-disabled")).toBeInTheDocument();
   });
 
   it("renders an enabled archive button for unarchived experiment", () => {
     render(<Subject experiment={{ isArchived: true, canArchive: true }} />);
     expect(screen.getByTestId("action-archive").tagName).toEqual("BUTTON");
-    expect(screen.getByTestId("action-archive")).toHaveTextContent(
-      "Unarchive Experiment",
-    );
+    expect(screen.getByTestId("action-archive")).toHaveTextContent("Unarchive");
+    expect(
+      screen.queryByTestId("tooltip-archived-disabled"),
+    ).not.toBeInTheDocument();
   });
   it("calls update archive mutation when archive button is clicked", async () => {
     const experiment = mockExperiment({ isArchived: false, canArchive: true });

--- a/app/experimenter/nimbus-ui/src/components/SidebarActions/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/SidebarActions/index.tsx
@@ -4,8 +4,10 @@
 
 import { RouteComponentProps } from "@reach/router";
 import React from "react";
+import ReactTooltip from "react-tooltip";
 import { useChangeOperationMutation } from "../../hooks";
-import { CHANGELOG_MESSAGES } from "../../lib/constants";
+import { ReactComponent as Info } from "../../images/info.svg";
+import { ARCHIVE_DISABLED, CHANGELOG_MESSAGES } from "../../lib/constants";
 import { getExperiment_experimentBySlug } from "../../types/getExperiment";
 import { LinkNav } from "../LinkNav";
 import { ReactComponent as Trash } from "./trash.svg";
@@ -30,27 +32,43 @@ export const SidebarActions = ({
       : CHANGELOG_MESSAGES.UNARCHIVING_EXPERIMENT,
   });
 
+  const disabled = !experiment.canArchive || isLoading;
   return (
     <div data-testid={"SidebarActions"}>
-      <p className="edit-divider position-relative small my-2">
+      <div className="edit-divider position-relative small my-2">
         <span className="position-relative bg-light pl-1 pr-2 text-muted">
           Actions
         </span>
-      </p>
-      <p>
+      </div>
+      <div>
         <LinkNav
           useButton
           key="sidebar-actions-archive"
-          disabled={!experiment.canArchive || isLoading}
+          route={`${experiment.slug}/#`}
           testid="action-archive"
           onClick={onUpdateArchived}
+          {...{ disabled }}
         >
           <Trash className="sidebar-icon" />
-          {experiment.isArchived
-            ? "Unarchive Experiment"
-            : "Archive Experiment"}
+          <div>
+            <p className="m-0">
+              {experiment.isArchived ? "Unarchive" : "Archive"}
+              {disabled && (
+                <>
+                  <Info
+                    data-tip={ARCHIVE_DISABLED}
+                    data-testid="tooltip-archived-disabled"
+                    width="20"
+                    height="20"
+                    className="ml-1 text-muted"
+                  />
+                  <ReactTooltip />
+                </>
+              )}
+            </p>
+          </div>
         </LinkNav>
-      </p>
+      </div>
     </div>
   );
 };

--- a/app/experimenter/nimbus-ui/src/lib/constants.ts
+++ b/app/experimenter/nimbus-ui/src/lib/constants.ts
@@ -19,6 +19,9 @@ export const CONFIG_EMPTY_ERROR = "Configuration is empty";
 
 export const INVALID_CONFIG_ERROR = "Invalid configuration";
 
+export const ARCHIVE_DISABLED =
+  "Experiments can only be archived when in Draft or Complete.";
+
 export const SERVER_ERRORS = {
   REQUIRED_QUESTION: "This question may not be blank.",
   NULL_FIELD: "This field may not be null.",


### PR DESCRIPTION
Because

* We have several nav links that can be disabled at different stages of the experiment workflow
* It can be confusing to users to see a disabled button without specifying why it's diabled

This commit

* Adds info messages under disabled edit links and the archive button