### PR TITLE
fixes #5590 refactor(nimbus): consolidate error msg strings

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/reducer/update.ts
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/reducer/update.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import { CONTROL_BRANCH_REQUIRED_ERROR } from "../../../../lib/constants";
 import { ExperimentInput } from "../../../../types/globalTypes";
 import { AnnotatedBranch, FormBranchesState } from "./state";
 
@@ -24,7 +25,7 @@ export function extractUpdateState(
   const { featureConfig, referenceBranch, treatmentBranches } = state;
 
   if (!referenceBranch) {
-    throw new UpdateStateError("Control branch is required");
+    throw new UpdateStateError(CONTROL_BRANCH_REQUIRED_ERROR);
   }
 
   const featureConfigId = featureConfig === null ? null : featureConfig.id;

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/index.test.tsx
@@ -6,9 +6,13 @@ import { navigate } from "@reach/router";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import fetchMock from "jest-fetch-mock";
 import React from "react";
-import PageEditBranches, { SUBMIT_ERROR_MESSAGE } from ".";
+import PageEditBranches from ".";
 import { UPDATE_EXPERIMENT_MUTATION } from "../../gql/experiments";
-import { CHANGELOG_MESSAGES, EXTERNAL_URLS } from "../../lib/constants";
+import {
+  CHANGELOG_MESSAGES,
+  EXTERNAL_URLS,
+  SUBMIT_ERROR,
+} from "../../lib/constants";
 import { mockExperimentQuery, MOCK_CONFIG } from "../../lib/mocks";
 import { RouterSlugProvider } from "../../lib/test-utils";
 import { getExperiment_experimentBySlug } from "../../types/getExperiment";
@@ -119,7 +123,7 @@ describe("PageEditBranches", () => {
 
     await waitFor(() =>
       expect(mockSetSubmitErrors).toHaveBeenCalledWith({
-        "*": [SUBMIT_ERROR_MESSAGE],
+        "*": [SUBMIT_ERROR],
       }),
     );
   });

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/index.tsx
@@ -7,7 +7,11 @@ import { navigate, RouteComponentProps } from "@reach/router";
 import React, { useCallback, useRef } from "react";
 import { UPDATE_EXPERIMENT_MUTATION } from "../../gql/experiments";
 import { useConfig } from "../../hooks";
-import { CHANGELOG_MESSAGES, EXTERNAL_URLS } from "../../lib/constants";
+import {
+  CHANGELOG_MESSAGES,
+  EXTERNAL_URLS,
+  SUBMIT_ERROR,
+} from "../../lib/constants";
 import { editCommonRedirects } from "../../lib/experiment";
 import { getExperiment_experimentBySlug } from "../../types/getExperiment";
 import { ExperimentInput } from "../../types/globalTypes";
@@ -16,8 +20,6 @@ import AppLayoutWithExperiment from "../AppLayoutWithExperiment";
 import LinkExternal from "../LinkExternal";
 import FormBranches from "./FormBranches";
 import { FormBranchesSaveState } from "./FormBranches/reducer";
-
-export const SUBMIT_ERROR_MESSAGE = "Save failed, no error available";
 
 const PageEditBranches: React.FunctionComponent<RouteComponentProps> = () => {
   const { featureConfig } = useConfig();
@@ -57,7 +59,7 @@ const PageEditBranches: React.FunctionComponent<RouteComponentProps> = () => {
         });
 
         if (!result.data?.updateExperiment) {
-          throw new Error(SUBMIT_ERROR_MESSAGE);
+          throw new Error(SUBMIT_ERROR);
         }
 
         const { message } = result.data.updateExperiment;

--- a/app/experimenter/nimbus-ui/src/components/PageEditOverview/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditOverview/index.tsx
@@ -6,7 +6,11 @@ import { useMutation } from "@apollo/client";
 import { navigate, RouteComponentProps } from "@reach/router";
 import React, { useCallback, useRef, useState } from "react";
 import { UPDATE_EXPERIMENT_MUTATION } from "../../gql/experiments";
-import { CHANGELOG_MESSAGES, SUBMIT_ERROR } from "../../lib/constants";
+import {
+  CHANGELOG_MESSAGES,
+  SAVE_FAILED_NO_ERROR,
+  SUBMIT_ERROR,
+} from "../../lib/constants";
 import { editCommonRedirects } from "../../lib/experiment";
 import { optionalStringBool } from "../../lib/utils";
 import { getExperiment_experimentBySlug } from "../../types/getExperiment";
@@ -59,7 +63,7 @@ const PageEditOverview: React.FunctionComponent<PageEditOverviewProps> = () => {
         });
 
         if (!result.data?.updateExperiment) {
-          throw new Error("Save failed, no error available");
+          throw new Error(SAVE_FAILED_NO_ERROR);
         }
 
         const { message } = result.data.updateExperiment;

--- a/app/experimenter/nimbus-ui/src/components/PageNew/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageNew/index.tsx
@@ -10,6 +10,7 @@ import { ReactComponent as DeleteIcon } from "../../images/x.svg";
 import {
   CHANGELOG_MESSAGES,
   EXTERNAL_URLS,
+  SAVE_FAILED_NO_ERROR,
   SUBMIT_ERROR,
 } from "../../lib/constants";
 import { createExperiment_createExperiment as CreateExperimentResult } from "../../types/createExperiment";
@@ -48,7 +49,7 @@ const PageNew: React.FunctionComponent<PageNewProps> = () => {
           },
         });
         if (!result.data?.createExperiment) {
-          throw new Error("Save failed, no error available");
+          throw new Error(SAVE_FAILED_NO_ERROR);
         }
         const { message, nimbusExperiment } = result.data.createExperiment;
 

--- a/app/experimenter/nimbus-ui/src/lib/constants.ts
+++ b/app/experimenter/nimbus-ui/src/lib/constants.ts
@@ -11,6 +11,14 @@ export const UNKNOWN_ERROR =
 export const SUBMIT_ERROR =
   "Sorry, an error occurred while submitting. Please try again.";
 
+export const CONTROL_BRANCH_REQUIRED_ERROR = "Control branch is required";
+
+export const SAVE_FAILED_NO_ERROR = "Save failed, no error available";
+
+export const CONFIG_EMPTY_ERROR = "Configuration is empty";
+
+export const INVALID_CONFIG_ERROR = "Invalid configuration";
+
 export const SERVER_ERRORS = {
   REQUIRED_QUESTION: "This question may not be blank.",
   NULL_FIELD: "This field may not be null.",

--- a/app/experimenter/nimbus-ui/src/services/config.ts
+++ b/app/experimenter/nimbus-ui/src/services/config.ts
@@ -2,6 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import {
+  CONFIG_EMPTY_ERROR,
+  INVALID_CONFIG_ERROR,
+} from "../../src/lib/constants";
+
 export function getDefault() {
   return {
     graphql_url: "",
@@ -25,7 +30,7 @@ export function decode(content?: string) {
     if (isDev) {
       console.warn("Nimbus is missing server config");
     } else {
-      throw new Error("Configuration is empty");
+      throw new Error(CONFIG_EMPTY_ERROR);
     }
   }
 
@@ -38,7 +43,7 @@ export function decode(content?: string) {
       console.warn("Nimbus server config is invalid");
     } else {
       throw new Error(
-        `Invalid configuration ${JSON.stringify(content)}: ${decoded}`,
+        `${INVALID_CONFIG_ERROR} ${JSON.stringify(content)}: ${decoded}`,
       );
     }
   }


### PR DESCRIPTION
Because

* there were two strings with the same message in multiple places

This commit

* consolidates the error messages.
* also adds constants for other hardcoded error strings mentioned in #4568