### PR TITLE
fixes #6184 feat(nimbus): add 80-character max validation to experiment name field

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/FormOverview/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/FormOverview/index.test.tsx
@@ -148,6 +148,15 @@ describe("FormOverview", () => {
 
     const submitButton = screen.getByTestId("submit-button");
     await fillOutNewForm(expected);
+
+    const publicName = screen.getByLabelText("Public name");
+    fireEvent.change(publicName, { target: { value: "x".repeat(81) } });
+    fireEvent.blur(publicName);
+    await waitFor(() => expect(publicName).toHaveClass("is-invalid"));
+    await screen.findByText("Cannot be greater than 80 characters");
+    fireEvent.change(publicName, { target: { value: expected.name } });
+    fireEvent.blur(publicName);
+
     fireEvent.click(submitButton);
 
     await waitFor(() => {

--- a/app/experimenter/nimbus-ui/src/components/FormOverview/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/FormOverview/index.tsx
@@ -142,7 +142,13 @@ const FormOverview = ({
         <Form.Group controlId="name">
           <Form.Label>Public name</Form.Label>
           <Form.Control
-            {...formControlAttrs("name", REQUIRED_FIELD)}
+            {...formControlAttrs("name", {
+              ...REQUIRED_FIELD,
+              maxLength: {
+                value: 80,
+                message: "Cannot be greater than 80 characters",
+              },
+            })}
             type="text"
             autoFocus={!experiment}
           />


### PR DESCRIPTION
Closes #6184

![Screen Shot 2021-08-18 at 11 31 40 AM](https://user-images.githubusercontent.com/6392049/129917112-cec749c9-eb40-4d3a-8c0c-3685c343f286.png)
