### PR TITLE
fix(nimbus): Add 'analysis' check back to analysisUnavailable

### DIFF
--- a/app/experimenter/nimbus-ui/src/lib/visualization/utils.tsx
+++ b/app/experimenter/nimbus-ui/src/lib/visualization/utils.tsx
@@ -20,7 +20,7 @@ export const analysisAvailable = (analysis: AnalysisData | undefined) =>
   analysis?.show_analysis && (analysis?.overall || analysis?.weekly);
 
 export const analysisUnavailable = (analysis: AnalysisData | undefined) =>
-  !analysisAvailable(analysis);
+  analysis && !analysisAvailable(analysis);
 
 export const getTableDisplayType = (
   metricKey: string,


### PR DESCRIPTION
Because:
* In production users are being rerouted from Results to Summary from a previous change, turns out we need this check in the function after all

This commit:
* Reverts a previous change that moved where analysis truthiness check was occurring

---

Originally changed this [here](https://github.com/mozilla/experimenter/pull/6231/files#r690539021) but turns out we do need it there, whoops! I am leaving the `!analysis` check on the Results page to keep the TS wins I mentioned in that comment.