### PR TITLE
fixes #6054 fix(nimbus): Make TootipWithMarkdown tips visible when they're in pre/code tags

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/PageResults/TooltipWithMarkdown/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TooltipWithMarkdown/index.stories.tsx
@@ -1,0 +1,39 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from "react";
+import TooltipWithMarkdown from ".";
+import { ReactComponent as Info } from "../../../images/info.svg";
+import { MOCK_METADATA } from "../../../lib/visualization/mocks";
+
+const Subject = ({ id, description }: { id: string; description: string }) => (
+  <div className="p-5">
+    <Info data-tip data-for={id} />
+    <TooltipWithMarkdown tooltipId={id} markdown={description} />
+  </div>
+);
+
+export default {
+  title: "components/TooltipWithMarkdown",
+  component: Subject,
+};
+
+const storyWithProps = (
+  props: React.ComponentProps<typeof Subject>,
+  storyName?: string,
+) => {
+  const story = () => <Subject {...props} />;
+  if (storyName) story.storyName = storyName;
+  return story;
+};
+
+export const WithStringAndMarkdownLink = storyWithProps({
+  id: MOCK_METADATA.metrics.feature_b.friendly_name,
+  description: MOCK_METADATA.metrics.feature_b.description,
+});
+
+export const WithIndentation = storyWithProps({
+  id: MOCK_METADATA.metrics.feature_b.friendly_name,
+  description: "        This gets wrapped in <pre> and <code>.",
+});

--- a/app/experimenter/nimbus-ui/src/styles/index.scss
+++ b/app/experimenter/nimbus-ui/src/styles/index.scss
@@ -135,8 +135,15 @@ select.form-control.is-warning {
   height: 18px;
 }
 
-.__react_component_tooltip > p:last-child {
-  margin-bottom: 0;
+.__react_component_tooltip {
+  pre {
+    @extend .text-white;
+    margin-bottom: 0;
+  }
+
+  > p:last-child {
+    margin-bottom: 0;
+  }
 }
 
 .cursor-copy {


### PR DESCRIPTION
fixes #6054 

Because:
* Some tooltips appeared to not be displaying

This commit:
* Sets text in tooltips rendering as code to white