### PR TITLE
fixes #6129 feat(nimbus): Get control branch from metadata config, display in alert

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/PageResults/ExternalConfigAlert/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/ExternalConfigAlert/index.test.tsx
@@ -1,0 +1,28 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { render, screen } from "@testing-library/react";
+import React from "react";
+import ExternalConfigAlert from ".";
+import { MOCK_METADATA_EXTERNAL_CONFIG } from "../../../lib/visualization/mocks";
+
+describe("ExternalConfigAlert", () => {
+  it("renders as expected", () => {
+    render(
+      <ExternalConfigAlert
+        externalConfig={{
+          ...MOCK_METADATA_EXTERNAL_CONFIG,
+        }}
+      />,
+    );
+    expect(
+      screen.getByTestId("external-config-reference-branch"),
+    ).toHaveTextContent("treatment");
+
+    expect(screen.getByTestId("external-config-url")).toHaveProperty(
+      "href",
+      "https://github.com/mozilla/jetstream-config/",
+    );
+  });
+});

--- a/app/experimenter/nimbus-ui/src/components/PageResults/ExternalConfigAlert/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/ExternalConfigAlert/index.tsx
@@ -1,0 +1,46 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from "react";
+import { Alert } from "react-bootstrap";
+import { MetadataExternalConfig } from "../../../lib/visualization/types";
+import LinkExternal from "../../LinkExternal";
+
+export const ExternalConfigAlert = ({
+  externalConfig,
+}: {
+  externalConfig: MetadataExternalConfig;
+}) => (
+  <Alert variant="warning" data-testid="external-config-alert">
+    <Alert.Heading>Analysis has manual overrides in Jetstream</Alert.Heading>
+    <p>
+      The results shown on this page are from an analysis ran with at least one
+      experiment override that affects only the <em>analysis</em>, meaning{" "}
+      <strong>
+        experiment data on the Summary page will not reflect this.
+      </strong>
+    </p>
+    <ul className="pl-0">
+      Overrides (
+      <LinkExternal href={externalConfig.url} data-testid="external-config-url">
+        click here
+      </LinkExternal>{" "}
+      to view the config file):
+      {externalConfig.reference_branch && (
+        <li className="ml-3" data-testid="external-config-reference-branch">
+          Baseline branch → <strong>{externalConfig.reference_branch}</strong>
+        </li>
+      )}
+    </ul>
+    <p>
+      If you have questions about this, please ask data science in{" "}
+      <LinkExternal href="https://mozilla.slack.com/archives/C0149JH7C1M">
+        #cirrus
+      </LinkExternal>
+      .
+    </p>
+  </Alert>
+);
+
+export default ExternalConfigAlert;

--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableHighlights/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableHighlights/index.tsx
@@ -74,20 +74,23 @@ const TableHighlights = ({ experiment }: TableHighlightsProps) => {
   );
   const {
     analysis: { metadata, overall },
-    sortedBranches,
+    sortedBranchNames,
+    controlBranchName,
   } = useContext(ResultsContext);
   const overallResults = overall!;
 
   return (
     <table data-testid="table-highlights" className="table mt-4 mb-0">
       <tbody>
-        {sortedBranches.map((branch) => {
+        {sortedBranchNames.map((branch) => {
           const userCountMetric =
             overallResults[branch]["branch_data"][GROUP.OTHER][
               METRIC.USER_COUNT
             ];
           const participantCount =
             userCountMetric[BRANCH_COMPARISON.ABSOLUTE]["first"]["point"];
+          const isControlBranch = branch === controlBranchName;
+
           return (
             <tr key={branch} className="border-top">
               <th className="align-middle p-1 p-lg-3" scope="row">
@@ -100,7 +103,7 @@ const TableHighlights = ({ experiment }: TableHighlightsProps) => {
               <td className="p-1 p-lg-3 col-md-4 align-middle">
                 {branchDescriptions[branch]}
               </td>
-              {overallResults[branch]["is_control"] ? (
+              {isControlBranch ? (
                 <td className="p-1 p-lg-3 align-middle">
                   <div className="font-italic align-middle">---baseline---</div>
                 </td>
@@ -111,7 +114,7 @@ const TableHighlights = ({ experiment }: TableHighlightsProps) => {
                     const displayType = getTableDisplayType(
                       metricKey,
                       TABLE_LABEL.HIGHLIGHTS,
-                      overallResults[branch]["is_control"],
+                      isControlBranch,
                     );
                     const tooltip =
                       metadata?.metrics[metricKey]?.description ||
@@ -123,7 +126,12 @@ const TableHighlights = ({ experiment }: TableHighlightsProps) => {
                         results={overallResults[branch]}
                         group={metric.group}
                         tableLabel={TABLE_LABEL.HIGHLIGHTS}
-                        {...{ metricKey, displayType, tooltip }}
+                        {...{
+                          metricKey,
+                          displayType,
+                          tooltip,
+                          isControlBranch,
+                        }}
                       />
                     );
                   })}

--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableMetricConversion/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableMetricConversion/index.tsx
@@ -42,13 +42,14 @@ const getStatistics = (slug: string): Array<ConversionMetricStatistic> => {
 const TableMetricConversion = ({ outcome }: TableMetricConversionProps) => {
   const {
     analysis: { overall },
-    sortedBranches,
+    sortedBranchNames,
+    controlBranchName,
   } = useContext(ResultsContext);
   const overallResults = overall!;
   const conversionMetricStatistics = getStatistics(outcome.slug!);
   const metricKey = `${outcome.slug}_ever_used`;
   const bounds = getExtremeBounds(
-    sortedBranches,
+    sortedBranchNames,
     overallResults,
     outcome.slug!,
     GROUP.OTHER,
@@ -76,6 +77,7 @@ const TableMetricConversion = ({ outcome }: TableMetricConversionProps) => {
         </thead>
         <tbody>
           {Object.keys(overallResults).map((branch) => {
+            const isControlBranch = branch === controlBranchName;
             return (
               <tr key={branch}>
                 <th className="align-middle" scope="row">
@@ -93,6 +95,7 @@ const TableMetricConversion = ({ outcome }: TableMetricConversionProps) => {
                         displayType,
                         branchComparison,
                         bounds,
+                        isControlBranch,
                       }}
                     />
                   ),

--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableMetricCount/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableMetricCount/index.tsx
@@ -57,12 +57,13 @@ const TableMetricCount = ({
   const countMetricStatistics = getStatistics(outcomeSlug);
   const {
     analysis: { metadata, overall, weekly },
-    sortedBranches,
+    sortedBranchNames,
+    controlBranchName,
   } = useContext(ResultsContext);
   const overallResults = overall!;
 
   const bounds = getExtremeBounds(
-    sortedBranches,
+    sortedBranchNames,
     overallResults,
     outcomeSlug,
     group,
@@ -118,7 +119,8 @@ const TableMetricCount = ({
         </thead>
         <tbody>
           {group &&
-            sortedBranches.map((branch) => {
+            sortedBranchNames.map((branch) => {
+              const isControlBranch = branch === controlBranchName;
               return (
                 overallResults[branch].branch_data[group] && (
                   <tr key={`${branch}-${group}`}>
@@ -132,7 +134,13 @@ const TableMetricCount = ({
                           results={overallResults[branch]}
                           tableLabel={TABLE_LABEL.SECONDARY_METRICS}
                           metricKey={outcomeSlug}
-                          {...{ displayType, branchComparison, bounds, group }}
+                          {...{
+                            displayType,
+                            branchComparison,
+                            bounds,
+                            group,
+                            isControlBranch,
+                          }}
                         />
                       ),
                     )}

--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableResults/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableResults/index.tsx
@@ -52,7 +52,8 @@ const TableResults = ({
   const resultsMetricsList = getResultMetrics(primaryOutcomes);
   const {
     analysis: { metadata, overall },
-    sortedBranches,
+    sortedBranchNames,
+    controlBranchName,
   } = useContext(ResultsContext);
   const overallResults = overall!;
 
@@ -90,7 +91,8 @@ const TableResults = ({
         </tr>
       </thead>
       <tbody>
-        {sortedBranches.map((branch) => {
+        {sortedBranchNames.map((branch) => {
+          const isControlBranch = branch === controlBranchName;
           return (
             <tr key={branch}>
               <th className="align-middle" scope="row">
@@ -101,7 +103,7 @@ const TableResults = ({
                 const displayType = getTableDisplayType(
                   metricKey,
                   TABLE_LABEL.RESULTS,
-                  overallResults[branch]["is_control"],
+                  isControlBranch,
                 );
                 return (
                   <TableVisualizationRow
@@ -110,7 +112,12 @@ const TableResults = ({
                     results={overallResults[branch]}
                     group={metric.group}
                     tableLabel={TABLE_LABEL.RESULTS}
-                    {...{ metricKey, displayType, branchComparison }}
+                    {...{
+                      metricKey,
+                      displayType,
+                      branchComparison,
+                      isControlBranch,
+                    }}
                   />
                 );
               })}

--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableVisualizationRow/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableVisualizationRow/index.stories.tsx
@@ -29,6 +29,7 @@ storiesOf("pages/Results/TableVisualizationRow", module)
       metricKey="retained"
       displayType={DISPLAY_TYPE.POPULATION}
       group={GROUP.OTHER}
+      isControlBranch
     />
   ))
   .add("Count field", () => (
@@ -38,6 +39,7 @@ storiesOf("pages/Results/TableVisualizationRow", module)
       metricKey="retained"
       displayType={DISPLAY_TYPE.COUNT}
       group={GROUP.OTHER}
+      isControlBranch
     />
   ))
   .add("Percent field", () => (
@@ -47,6 +49,7 @@ storiesOf("pages/Results/TableVisualizationRow", module)
       metricKey="retained"
       displayType={DISPLAY_TYPE.PERCENT}
       group={GROUP.OTHER}
+      isControlBranch
     />
   ))
   .add("Conversion count field", () => (
@@ -57,6 +60,7 @@ storiesOf("pages/Results/TableVisualizationRow", module)
       tableLabel={TABLE_LABEL.PRIMARY_METRICS}
       metricKey="picture_in_picture_ever_used"
       group={GROUP.OTHER}
+      isControlBranch
     />
   ))
   .add("Conversion change field (positive)", () => (
@@ -67,6 +71,7 @@ storiesOf("pages/Results/TableVisualizationRow", module)
       tableLabel={TABLE_LABEL.PRIMARY_METRICS}
       metricKey="picture_in_picture_ever_used"
       group={GROUP.OTHER}
+      isControlBranch
     />
   ))
   .add("Conversion change field (negative)", () => (
@@ -77,6 +82,7 @@ storiesOf("pages/Results/TableVisualizationRow", module)
       tableLabel={TABLE_LABEL.PRIMARY_METRICS}
       metricKey="feature_b_ever_used"
       group={GROUP.OTHER}
+      isControlBranch
     />
   ))
   .add("Conversion change field (neutral)", () => (
@@ -87,6 +93,7 @@ storiesOf("pages/Results/TableVisualizationRow", module)
       tableLabel={TABLE_LABEL.PRIMARY_METRICS}
       metricKey="feature_c_ever_used"
       group={GROUP.OTHER}
+      isControlBranch
     />
   ))
   .add("Count field missing values", () => (
@@ -97,5 +104,6 @@ storiesOf("pages/Results/TableVisualizationRow", module)
       metricKey="retained"
       displayType={DISPLAY_TYPE.PERCENT}
       group={GROUP.OTHER}
+      isControlBranch
     />
   ));

--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableVisualizationRow/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableVisualizationRow/index.tsx
@@ -41,7 +41,7 @@ const showSignificanceField = (
   name: string,
   tableLabel: string,
   tooltip: string,
-  isControl = false,
+  isControlBranch: boolean,
 ) => {
   let significanceIcon,
     changeText = "";
@@ -93,7 +93,8 @@ const showSignificanceField = (
   return (
     <>
       <span {...{ className }} data-testid={className}>
-        {significanceIcon}&nbsp;{interval}&nbsp;{isControl && BASELINE_TEXT}
+        {significanceIcon}&nbsp;{interval}&nbsp;
+        {isControlBranch && BASELINE_TEXT}
       </span>
       <ReactTooltip />
     </>
@@ -140,7 +141,7 @@ const countField = (
   metricName: string,
   tableLabel: string,
   tooltip: string,
-  isControl = false,
+  isControlBranch: boolean,
 ) => {
   const interval = `${lower.toFixed(2)} to ${upper.toFixed(2)}`;
   return showSignificanceField(
@@ -149,7 +150,7 @@ const countField = (
     metricName,
     tableLabel,
     tooltip,
-    isControl,
+    isControlBranch,
   );
 };
 
@@ -160,7 +161,7 @@ const percentField = (
   metricName: string,
   tableLabel: string,
   tooltip: string,
-  isControl = false,
+  isControlBranch: boolean,
 ) => {
   const interval = `${Math.round(lower * 1000) / 10}% to ${
     Math.round(upper * 1000) / 10
@@ -171,7 +172,7 @@ const percentField = (
     metricName,
     tableLabel,
     tooltip,
-    isControl,
+    isControlBranch,
   );
 };
 
@@ -190,6 +191,7 @@ const TableVisualizationRow: React.FC<{
   results: BranchDescription;
   group: string;
   tableLabel: string;
+  isControlBranch: boolean;
   metricName?: string;
   displayType?: DISPLAY_TYPE;
   branchComparison?: string;
@@ -201,6 +203,7 @@ const TableVisualizationRow: React.FC<{
   results,
   group,
   tableLabel,
+  isControlBranch,
   metricName = "",
   displayType,
   branchComparison,
@@ -208,7 +211,7 @@ const TableVisualizationRow: React.FC<{
   window = "overall",
   bounds = 0.05,
 }) => {
-  const { branch_data, is_control } = results;
+  const { branch_data } = results;
   const metricData = branch_data[group][metricKey];
   const fieldList = [];
 
@@ -221,7 +224,9 @@ const TableVisualizationRow: React.FC<{
     tooltipText = tooltip;
     field = <div>{BASELINE_TEXT}</div>;
     const percent = branch_data[GROUP.OTHER][METRIC.USER_COUNT]["percent"];
-    const branchType = is_control ? VARIANT_TYPE.CONTROL : VARIANT_TYPE.VARIANT;
+    const branchType = isControlBranch
+      ? VARIANT_TYPE.CONTROL
+      : VARIANT_TYPE.VARIANT;
     branchComparison =
       branchComparison || dataTypeMapping[tableLabel][branchType];
 
@@ -252,7 +257,7 @@ const TableVisualizationRow: React.FC<{
               metricName,
               tableLabel,
               tooltipText,
-              is_control,
+              isControlBranch,
             );
             break;
           case DISPLAY_TYPE.PERCENT:
@@ -264,7 +269,7 @@ const TableVisualizationRow: React.FC<{
               metricName,
               tableLabel,
               tooltipText,
-              is_control,
+              isControlBranch,
             );
             break;
           case DISPLAY_TYPE.CONVERSION_COUNT:

--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableWeekly/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableWeekly/index.tsx
@@ -55,7 +55,8 @@ const TableWeekly = ({
 }: TableWeeklyProps) => {
   const {
     analysis: { weekly },
-    sortedBranches,
+    sortedBranchNames,
+    controlBranchName,
   } = useContext(ResultsContext);
   const weeklyResults = weekly!;
   const weekIndexList = getWeekIndexList(metricKey, group, weeklyResults);
@@ -81,8 +82,8 @@ const TableWeekly = ({
         </tr>
       </thead>
       <tbody>
-        {sortedBranches.map((branch) => {
-          const isControlBranch = weeklyResults[branch]["is_control"];
+        {sortedBranchNames.map((branch) => {
+          const isControlBranch = branch === controlBranchName;
           const displayType = getTableDisplayType(
             metricKey,
             tableLabel,

--- a/app/experimenter/nimbus-ui/src/components/PageResults/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/index.stories.tsx
@@ -9,7 +9,10 @@ import React from "react";
 import PageResults from ".";
 import { mockExperimentQuery } from "../../lib/mocks";
 import { RouterSlugProvider } from "../../lib/test-utils";
-import { mockAnalysis } from "../../lib/visualization/mocks";
+import {
+  mockAnalysis,
+  MOCK_METADATA_WITH_CONFIG,
+} from "../../lib/visualization/mocks";
 import { NimbusExperimentStatus } from "../../types/globalTypes";
 
 const { mock } = mockExperimentQuery("demo-slug", {
@@ -22,6 +25,19 @@ storiesOf("pages/Results", module)
     fetchMock
       .restore()
       .getOnce("/api/v3/visualization/demo-slug/", mockAnalysis());
+    return (
+      <RouterSlugProvider mocks={[mock]}>
+        <PageResults />
+      </RouterSlugProvider>
+    );
+  })
+  .add("with external config overrides", () => {
+    fetchMock
+      .restore()
+      .getOnce(
+        "/api/v3/visualization/demo-slug/",
+        mockAnalysis({ metadata: MOCK_METADATA_WITH_CONFIG }),
+      );
     return (
       <RouterSlugProvider mocks={[mock]}>
         <PageResults />

--- a/app/experimenter/nimbus-ui/src/components/PageResults/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/index.test.tsx
@@ -12,6 +12,7 @@ import { mockExperimentQuery } from "../../lib/mocks";
 import { RouterSlugProvider } from "../../lib/test-utils";
 import {
   mockAnalysis,
+  MOCK_METADATA_WITH_CONFIG,
   MOCK_UNAVAILABLE_ANALYSIS,
 } from "../../lib/visualization/mocks";
 import { AnalysisData } from "../../lib/visualization/types";
@@ -63,6 +64,14 @@ describe("PageResults", () => {
       "href",
       "https://protosaur.dev/partybal/demo_slug.html",
     );
+  });
+
+  it("displays the external config alert when an override exists", async () => {
+    mockExperiment = mockExperimentQuery("demo-slug").experiment;
+    mockAnalysisData = mockAnalysis({ metadata: MOCK_METADATA_WITH_CONFIG });
+    render(<Subject />);
+
+    await screen.findByTestId("external-config-alert");
   });
 
   it("displays the monitoring dashboard link", async () => {

--- a/app/experimenter/nimbus-ui/src/components/PageResults/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/index.tsx
@@ -18,11 +18,12 @@ import {
 import { BranchComparisonValues } from "../../lib/visualization/types";
 import {
   analysisUnavailable,
-  getSortedBranches,
+  getSortedBranchNames,
 } from "../../lib/visualization/utils";
 import AppLayoutWithExperiment from "../AppLayoutWithExperiment";
 import LinkExternal from "../LinkExternal";
 import LinkMonitoring from "../LinkMonitoring";
+import ExternalConfigAlert from "./ExternalConfigAlert";
 import TableHighlights from "./TableHighlights";
 import TableHighlightsOverview from "./TableHighlightsOverview";
 import TableMetricCount from "./TableMetricCount";
@@ -76,15 +77,20 @@ const PageResults: React.FunctionComponent<RouteComponentProps> = () => {
         // analysis.overall is expected to be an object (EXP-800)
         if (!analysis || analysisUnavailable(analysis)) return;
 
+        const sortedBranchNames = getSortedBranchNames(analysis);
         const resultsContextValue: ResultsContextType = {
           analysis,
-          sortedBranches: getSortedBranches(analysis),
+          sortedBranchNames,
+          controlBranchName: sortedBranchNames[0],
         };
 
+        const { external_config: externalConfig } = analysis.metadata || {};
         const slugUnderscored = experiment.slug.replace(/-/g, "_");
 
         return (
           <ResultsContext.Provider value={resultsContextValue}>
+            {externalConfig && <ExternalConfigAlert {...{ externalConfig }} />}
+
             <LinkMonitoring {...experiment} />
             <h3 className="h5 mb-3 mt-4" id="overview">
               Overview

--- a/app/experimenter/nimbus-ui/src/lib/contexts.ts
+++ b/app/experimenter/nimbus-ui/src/lib/contexts.ts
@@ -4,11 +4,12 @@
 
 import React from "react";
 import { AnalysisData } from "./visualization/types";
-import { getSortedBranches } from "./visualization/utils";
+import { getSortedBranchNames } from "./visualization/utils";
 
 export type ResultsContextType = {
   analysis: AnalysisData;
-  sortedBranches: ReturnType<typeof getSortedBranches>;
+  sortedBranchNames: ReturnType<typeof getSortedBranchNames>;
+  controlBranchName: string;
 };
 
 export const defaultResultsContext = {
@@ -16,10 +17,11 @@ export const defaultResultsContext = {
     daily: [],
     weekly: {},
     overall: {},
-    metadata: { metrics: {}, outcomes: {} },
+    metadata: { metrics: {}, outcomes: {}, external_config: null },
     show_analysis: false,
   },
-  sortedBranches: [],
+  sortedBranchNames: [],
+  controlBranchName: "",
 };
 
 export const ResultsContext = React.createContext<ResultsContextType>(

--- a/app/experimenter/nimbus-ui/src/lib/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/lib/mocks.tsx
@@ -47,7 +47,7 @@ import { getStatus } from "./experiment";
 import { OutcomesList, OutcomeSlugs } from "./types";
 import { mockAnalysis } from "./visualization/mocks";
 import { AnalysisData } from "./visualization/types";
-import { getSortedBranches } from "./visualization/utils";
+import { getSortedBranchNames } from "./visualization/utils";
 
 export interface MockedProps {
   config?: Partial<typeof MOCK_CONFIG> | null;
@@ -794,9 +794,11 @@ export const MockResultsContextProvider = ({
   children: ReactNode;
   analysis?: AnalysisData;
 }) => {
+  const sortedBranchNames = getSortedBranchNames(analysis);
   const value = {
     analysis,
-    sortedBranches: getSortedBranches(analysis),
+    sortedBranchNames,
+    controlBranchName: sortedBranchNames[0],
   };
 
   return (

--- a/app/experimenter/nimbus-ui/src/lib/visualization/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/lib/visualization/mocks.tsx
@@ -37,6 +37,32 @@ export const MOCK_METADATA = {
   outcomes: {},
 };
 
+/**
+ * Certain experiment properties can be overridden in the Jetstream config which are exposed in
+ * the metadata via an `external_config` object in schema version 4+. If overrides exist, they
+ * don't impact an experiment beyond analysis data, and should be referenced as the "true"
+ * properties used when the analysis occurs.
+ *
+ * `external_config` will be `undefined` prior to schema version 4. It will be `null` if no
+ * overrides are present.
+ */
+export const MOCK_METADATA_EXTERNAL_CONFIG = {
+  // TODO: account for the rest of these, EXP-1628
+  end_date: null,
+  enrollment_period: null,
+  reference_branch: "treatment",
+  skip: false,
+  start_date: null,
+  url: "https://github.com/mozilla/jetstream-config/",
+};
+
+export const MOCK_METADATA_WITH_CONFIG = {
+  ...MOCK_METADATA,
+  external_config: {
+    ...MOCK_METADATA_EXTERNAL_CONFIG,
+  },
+};
+
 export const CONTROL_NEUTRAL = {
   absolute: {
     first: {

--- a/app/experimenter/nimbus-ui/src/lib/visualization/types.ts
+++ b/app/experimenter/nimbus-ui/src/lib/visualization/types.ts
@@ -19,6 +19,16 @@ export type AnalysisDataWeekly = Exclude<AnalysisData["weekly"], null>;
 export interface Metadata {
   metrics: { [metric: string]: MetadataPoint };
   outcomes: { [outcome: string]: MetadataPoint };
+  external_config?: MetadataExternalConfig | null;
+}
+
+export interface MetadataExternalConfig {
+  end_date: string | null;
+  enrollment_period: string | null;
+  reference_branch: string | null;
+  skip: boolean;
+  start_date: string | null;
+  url: string;
 }
 
 export interface MetadataPoint {

--- a/app/experimenter/nimbus-ui/src/lib/visualization/utils.test.ts
+++ b/app/experimenter/nimbus-ui/src/lib/visualization/utils.test.ts
@@ -1,0 +1,60 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { mockAnalysis, MOCK_METADATA_WITH_CONFIG } from "./mocks";
+import { getSortedBranchNames } from "./utils";
+
+describe("getSortedBranchNames", () => {
+  const MOCK_OVERALL = {
+    fee: {
+      is_control: false,
+    },
+    fi: {
+      is_control: false,
+    },
+    fo: {
+      is_control: false,
+    },
+    fum: {
+      is_control: true,
+    },
+    englishman: {
+      is_control: false,
+    },
+  };
+
+  it("returns a list of branch names, the control branch first", () => {
+    expect(getSortedBranchNames(mockAnalysis())).toEqual([
+      "control",
+      "treatment",
+    ]);
+  });
+
+  it("accounts for external config control branch override", () => {
+    expect(
+      getSortedBranchNames(
+        mockAnalysis({
+          metadata: MOCK_METADATA_WITH_CONFIG,
+        }),
+      ),
+    ).toEqual(["treatment", "control"]);
+  });
+
+  it("returns a list of branch names with many branches, the control branch first", () => {
+    expect(
+      getSortedBranchNames(mockAnalysis({ overall: MOCK_OVERALL })),
+    ).toEqual(["fum", "fee", "fi", "fo", "englishman"]);
+  });
+
+  it("accounts for external config control branch override with many branches", () => {
+    expect(
+      getSortedBranchNames(
+        mockAnalysis({
+          overall: MOCK_OVERALL,
+          metadata: { external_config: { reference_branch: "englishman" } },
+        }),
+      ),
+    ).toEqual(["englishman", "fee", "fi", "fo", "fum"]);
+  });
+});


### PR DESCRIPTION
fixes #6129, and will fix the bug described in #6120

Because:
* The control/reference branch, along with other properties that will be accounted for in a separate PR, can be overridden in the Jetstream config for that experiment which affects only the analysis and Results page

This commit:
* Adds a getControlBranchName fn to return the reference branch from the Jetstream metadata if it exists, or returns the control branch from analysis data
* Adds the new external_config property to the metadata for tests/Storybook and fills in the reference_branch property
* Displays an alert for users on the Results page if any overrides exist

---

Note: I'd like to test this locally with the experiment noted in #6120. Will do before merging (if you see this comment I haven't done that yet - ~~looks like we need the metadata reuploaded, will ping relevant folks~~ pinged Anna S. and she reuploaded it). Our "viewing analysis data locally" docs for any prod experiment are out of date, I may put in another PR up for doc updates there...