### PR TITLE
fixes #6140 fix(nimbus): removes second japanese locale option

### DIFF
--- a/app/experimenter/base/fixtures/locales.json
+++ b/app/experimenter/base/fixtures/locales.json
@@ -417,14 +417,6 @@
   },
   {
     "model": "base.locale",
-    "pk": 78,
-    "fields": {
-      "code": "ja-JP-mac",
-      "name": "Japanese"
-    }
-  },
-  {
-    "model": "base.locale",
     "pk": 79,
     "fields": {
       "code": "ka",


### PR DESCRIPTION
Because

* there are two japanese locales

This commit

* removes the japenese locale with the local code (ja-JP-mac)