### PR TITLE
fix #6287 bug(nimbus): dynamically look up kinto collection for application

### DIFF
--- a/app/experimenter/experiments/api/v5/serializers.py
+++ b/app/experimenter/experiments/api/v5/serializers.py
@@ -596,9 +596,7 @@ class NimbusExperimentSerializer(
                 nimbus_synchronize_preview_experiments_in_kinto.apply_async(countdown=5)
 
             if self.should_call_push_task:
-                collection = NimbusExperiment.KINTO_APPLICATION_COLLECTION[
-                    experiment.application
-                ]
+                collection = experiment.application_config.kinto_collection
                 nimbus_check_kinto_push_queue_by_collection.apply_async(
                     countdown=5, args=[collection]
                 )

--- a/app/experimenter/experiments/constants/nimbus.py
+++ b/app/experimenter/experiments/constants/nimbus.py
@@ -24,7 +24,7 @@ class ApplicationConfig:
     slug: str
     app_name: str
     channel_app_id: Dict[str, str]
-    rs_experiments_collection: str
+    kinto_collection: str
     randomization_unit: str
     supports_locale_country: bool
 
@@ -40,7 +40,7 @@ APPLICATION_CONFIG_DESKTOP = ApplicationConfig(
         Channel.BETA: "firefox-desktop",
         Channel.RELEASE: "firefox-desktop",
     },
-    rs_experiments_collection=settings.KINTO_COLLECTION_NIMBUS_DESKTOP,
+    kinto_collection=settings.KINTO_COLLECTION_NIMBUS_DESKTOP,
     randomization_unit=BucketRandomizationUnit.NORMANDY,
     supports_locale_country=True,
 )
@@ -54,7 +54,7 @@ APPLICATION_CONFIG_FENIX = ApplicationConfig(
         Channel.BETA: "org.mozilla.firefox_beta",
         Channel.RELEASE: "org.mozilla.firefox",
     },
-    rs_experiments_collection=settings.KINTO_COLLECTION_NIMBUS_MOBILE,
+    kinto_collection=settings.KINTO_COLLECTION_NIMBUS_MOBILE,
     randomization_unit=BucketRandomizationUnit.NIMBUS,
     supports_locale_country=False,
 )
@@ -68,7 +68,7 @@ APPLICATION_CONFIG_IOS = ApplicationConfig(
         Channel.BETA: "org.mozilla.ios.FirefoxBeta",
         Channel.RELEASE: "org.mozilla.ios.Firefox",
     },
-    rs_experiments_collection=settings.KINTO_COLLECTION_NIMBUS_MOBILE,
+    kinto_collection=settings.KINTO_COLLECTION_NIMBUS_MOBILE,
     randomization_unit=BucketRandomizationUnit.NIMBUS,
     supports_locale_country=False,
 )
@@ -82,7 +82,7 @@ APPLICATION_CONFIG_FOCUS_ANDROID = ApplicationConfig(
         Channel.BETA: "org.mozilla.focus.beta",
         Channel.RELEASE: "org.mozilla.focus",
     },
-    rs_experiments_collection=settings.KINTO_COLLECTION_NIMBUS_MOBILE,
+    kinto_collection=settings.KINTO_COLLECTION_NIMBUS_MOBILE,
     randomization_unit=BucketRandomizationUnit.NIMBUS,
     supports_locale_country=False,
 )
@@ -94,7 +94,7 @@ APPLICATION_CONFIG_KLAR_ANDROID = ApplicationConfig(
     channel_app_id={
         Channel.RELEASE: "org.mozilla.klar",
     },
-    rs_experiments_collection=settings.KINTO_COLLECTION_NIMBUS_MOBILE,
+    kinto_collection=settings.KINTO_COLLECTION_NIMBUS_MOBILE,
     randomization_unit=BucketRandomizationUnit.NIMBUS,
     supports_locale_country=False,
 )
@@ -493,21 +493,5 @@ Optional - We believe this outcome will <describe impact> on <core metric>
     # As a buffer, continue to pull in analysis from Jetstream
     # for 3 days after an experiment is complete.
     DAYS_ANALYSIS_BUFFER = 3
-
-    KINTO_COLLECTION_APPLICATIONS = {
-        settings.KINTO_COLLECTION_NIMBUS_DESKTOP: [
-            APPLICATION_CONFIG_DESKTOP.slug,
-        ],
-        settings.KINTO_COLLECTION_NIMBUS_MOBILE: [
-            APPLICATION_CONFIG_FENIX.slug,
-            APPLICATION_CONFIG_IOS.slug,
-        ],
-    }
-
-    KINTO_APPLICATION_COLLECTION = {
-        application: collection
-        for (collection, applications) in KINTO_COLLECTION_APPLICATIONS.items()
-        for application in applications
-    }
 
     PUBLISHED_TARGETING_MISSING = "Published targeting JEXL not found"

--- a/app/experimenter/experiments/models/nimbus.py
+++ b/app/experimenter/experiments/models/nimbus.py
@@ -367,7 +367,7 @@ class NimbusExperiment(NimbusConstants, FilterMixin, models.Model):
         return "{base_url}{collection_path}/{collection}/{review_path}".format(
             base_url=settings.KINTO_ADMIN_URL,
             collection_path="#/buckets/main-workspace/collections",
-            collection=self.application_config.rs_experiments_collection,
+            collection=self.application_config.kinto_collection,
             review_path="simple-review",
         )
 

--- a/app/experimenter/experiments/tests/api/v5/test_serializers.py
+++ b/app/experimenter/experiments/tests/api/v5/test_serializers.py
@@ -1236,9 +1236,11 @@ class TestNimbusExperimentSerializer(TestCase):
         self.assertEqual(experiment.publish_status, publish_status)
         self.mock_preview_task.apply_async.assert_not_called()
 
-    def test_update_publish_status_to_approved_invokes_push_task(self):
+    @parameterized.expand(list(NimbusExperiment.Application))
+    def test_update_publish_status_to_approved_invokes_push_task(self, application):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperimentFactory.Lifecycles.LAUNCH_REVIEW_REQUESTED
+            NimbusExperimentFactory.Lifecycles.LAUNCH_REVIEW_REQUESTED,
+            application=application,
         )
 
         serializer = NimbusExperimentSerializer(
@@ -1257,7 +1259,7 @@ class TestNimbusExperimentSerializer(TestCase):
         )
         self.mock_push_task.apply_async.assert_called_with(
             countdown=5,
-            args=[NimbusExperiment.KINTO_APPLICATION_COLLECTION[experiment.application]],
+            args=[experiment.application_config.kinto_collection],
         )
 
     def test_serializer_updates_outcomes_on_experiment(self):

--- a/app/experimenter/kinto/tasks.py
+++ b/app/experimenter/kinto/tasks.py
@@ -32,7 +32,10 @@ def nimbus_check_kinto_push_queue():
     A scheduled task that passes each application to a new scheduled
     task for working with kinto
     """
-    for collection in NimbusExperiment.KINTO_COLLECTION_APPLICATIONS.keys():
+    for collection in (
+        settings.KINTO_COLLECTION_NIMBUS_DESKTOP,
+        settings.KINTO_COLLECTION_NIMBUS_MOBILE,
+    ):
         nimbus_check_kinto_push_queue_by_collection.delay(collection)
 
 
@@ -54,7 +57,11 @@ def nimbus_check_kinto_push_queue_by_collection(collection):
       collection and marks them as paused and updates the record in the collection.
     """
     metrics.incr(f"check_kinto_push_queue_by_collection:{collection}.started")
-    applications = NimbusExperiment.KINTO_COLLECTION_APPLICATIONS[collection]
+    applications = [
+        application.slug
+        for application in NimbusExperiment.APPLICATION_CONFIGS.values()
+        if application.kinto_collection == collection
+    ]
     kinto_client = KintoClient(collection)
 
     should_rollback = False

--- a/app/experimenter/kinto/tests/test_tasks.py
+++ b/app/experimenter/kinto/tests/test_tasks.py
@@ -27,7 +27,10 @@ class TestNimbusCheckKintoPushQueue(MockKintoClientMixin, TestCase):
 
     def test_dispatches_check_push_queue(self):
         tasks.nimbus_check_kinto_push_queue()
-        for collection in NimbusExperiment.KINTO_COLLECTION_APPLICATIONS.keys():
+        for collection in (
+            settings.KINTO_COLLECTION_NIMBUS_DESKTOP,
+            settings.KINTO_COLLECTION_NIMBUS_MOBILE,
+        ):
             self.mock_dispatchee_task.assert_any_call(collection)
 
 


### PR DESCRIPTION


Because

* We have new applications coming in
* We had a hard coded mapping of application to collection
* It can be easy to forget to update that mapping
* We also don't need it since each application config references its target collection

This commit

* Removes that mapping altogether
* Looks up the relevant collection from the application config
* Parameterizes the V5 serializer kinto integration test to test all applications