### PR TITLE
fix #6247 bug(nimbus): redirect to summary after archive

### DIFF
--- a/app/experimenter/nimbus-ui/src/lib/experiment.ts
+++ b/app/experimenter/nimbus-ui/src/lib/experiment.ts
@@ -56,7 +56,7 @@ export type StatusCheck = ReturnType<typeof getStatus>;
 export function editCommonRedirects({ status }: RedirectCheck) {
   // If experiment is launched or the user can't edit the experiment,
   // send them to the summary page
-  if (status.launched || !status.idle || status.preview) {
+  if (status.launched || !status.idle || status.preview || status.archived) {
     return "";
   }
 }


### PR DESCRIPTION
Because

* Archived experiments aren't editable

This commit

* Redirects to the summary page for an archived experiment