### PR TITLE
fixes #5781 refactor(nimbus): reorder middleware

### DIFF
--- a/app/experimenter/settings.py
+++ b/app/experimenter/settings.py
@@ -85,8 +85,8 @@ INSTALLED_APPS = [
 
 MIDDLEWARE = [
     "corsheaders.middleware.CorsMiddleware",
-    "whitenoise.middleware.WhiteNoiseMiddleware",
     "django.middleware.security.SecurityMiddleware",
+    "whitenoise.middleware.WhiteNoiseMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",


### PR DESCRIPTION
Because

* the whitenoise docs suggests putting the Django Security middleware above the whitenoise middleware

This commit

* reorders the middleware as suggested by whitenoise