### PR TITLE
fix #6071 feat(nimbus): Enable relative/absolute tab for tables + Highlights, cosmetic tweaks

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/PageResults/ConfidenceInterval/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/ConfidenceInterval/index.tsx
@@ -80,7 +80,7 @@ const ConfidenceInterval: React.FC<{
   const line = renderLine(leftPercent, barWidth, significance);
 
   return (
-    <div className="container">
+    <div className="pr-5">
       <div className="row w-100 float-right position-relative">{bounds}</div>
 
       <div

--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableHighlights/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableHighlights/index.stories.tsx
@@ -11,6 +11,7 @@ import {
   MockResultsContextProvider,
 } from "../../../lib/mocks";
 import { RouterSlugProvider } from "../../../lib/test-utils";
+import { BRANCH_COMPARISON } from "../../../lib/visualization/constants";
 
 storiesOf("pages/Results/TableHighlights", module)
   .addDecorator(withLinks)
@@ -32,6 +33,19 @@ storiesOf("pages/Results/TableHighlights", module)
       <RouterSlugProvider mocks={[mock]}>
         <MockResultsContextProvider>
           <TableHighlights {...{ experiment }} />
+        </MockResultsContextProvider>
+      </RouterSlugProvider>
+    );
+  })
+  .add("with absolute comparison", () => {
+    const { mock, experiment } = mockExperimentQuery("demo-slug");
+    return (
+      <RouterSlugProvider mocks={[mock]}>
+        <MockResultsContextProvider>
+          <TableHighlights
+            {...{ experiment }}
+            branchComparison={BRANCH_COMPARISON.ABSOLUTE}
+          />
         </MockResultsContextProvider>
       </RouterSlugProvider>
     );

--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableHighlights/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableHighlights/index.test.tsx
@@ -10,6 +10,7 @@ import {
   MockResultsContextProvider,
 } from "../../../lib/mocks";
 import { RouterSlugProvider } from "../../../lib/test-utils";
+import { BRANCH_COMPARISON } from "../../../lib/visualization/constants";
 
 const { mock, experiment } = mockExperimentQuery("demo-slug");
 
@@ -68,5 +69,38 @@ describe("TableHighlights", () => {
 
     expect(screen.getByText("control")).toBeInTheDocument();
     expect(screen.getByText("treatment")).toBeInTheDocument();
+  });
+
+  it("with relative comparison, renders expected values", () => {
+    render(
+      <RouterSlugProvider mocks={[mock]}>
+        <MockResultsContextProvider>
+          <TableHighlights {...{ experiment }} />
+        </MockResultsContextProvider>
+      </RouterSlugProvider>,
+    );
+    expect(screen.getAllByText("-45.5% to 51%", { exact: false })).toHaveLength(
+      4,
+    );
+  });
+
+  it("with absolute comparison, renders expected values", () => {
+    render(
+      <RouterSlugProvider mocks={[mock]}>
+        <MockResultsContextProvider>
+          <TableHighlights
+            {...{ experiment }}
+            branchComparison={BRANCH_COMPARISON.ABSOLUTE}
+          />
+        </MockResultsContextProvider>
+      </RouterSlugProvider>,
+    );
+
+    expect(
+      screen.getAllByText("(2.4% to 8.2%)", { exact: false }),
+    ).toHaveLength(1);
+    expect(screen.getAllByText("0.02 to 0.08", { exact: false })).toHaveLength(
+      5,
+    );
   });
 });

--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableHighlights/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableHighlights/index.tsx
@@ -14,6 +14,7 @@ import {
   METRICS_TIPS,
   TABLE_LABEL,
 } from "../../../lib/visualization/constants";
+import { BranchComparisonValues } from "../../../lib/visualization/types";
 import { getTableDisplayType } from "../../../lib/visualization/utils";
 import {
   getExperiment_experimentBySlug,
@@ -22,8 +23,9 @@ import {
 } from "../../../types/getExperiment";
 import TableVisualizationRow from "../TableVisualizationRow";
 
-type TableHighlightsProps = {
+export type TableHighlightsProps = {
   experiment: getExperiment_experimentBySlug;
+  branchComparison?: BranchComparisonValues;
 };
 
 type Branch =
@@ -65,7 +67,10 @@ const getBranchDescriptions = (
   );
 };
 
-const TableHighlights = ({ experiment }: TableHighlightsProps) => {
+const TableHighlights = ({
+  experiment,
+  branchComparison = BRANCH_COMPARISON.UPLIFT,
+}: TableHighlightsProps) => {
   const { primaryOutcomes } = useOutcomes(experiment);
   const highlightMetricsList = getHighlightMetrics(primaryOutcomes);
   const branchDescriptions = getBranchDescriptions(
@@ -80,7 +85,7 @@ const TableHighlights = ({ experiment }: TableHighlightsProps) => {
   const overallResults = overall!;
 
   return (
-    <table data-testid="table-highlights" className="table mt-4 mb-0">
+    <table data-testid="table-highlights" className="table mb-0 pt-2">
       <tbody>
         {sortedBranchNames.map((branch) => {
           const userCountMetric =
@@ -93,18 +98,19 @@ const TableHighlights = ({ experiment }: TableHighlightsProps) => {
 
           return (
             <tr key={branch} className="border-top">
-              <th className="align-middle p-1 p-lg-3" scope="row">
+              <th className="align-middle p-3" scope="row">
                 <p>{branch}</p>
                 <p className="h6">
                   {participantCount} participants ({userCountMetric["percent"]}
                   %)
                 </p>
               </th>
-              <td className="p-1 p-lg-3 col-md-4 align-middle">
+              <td className="p-3 col-md-4 align-middle">
                 {branchDescriptions[branch]}
               </td>
-              {isControlBranch ? (
-                <td className="p-1 p-lg-3 align-middle">
+              {isControlBranch &&
+              branchComparison === BRANCH_COMPARISON.UPLIFT ? (
+                <td className="p-3 align-middle">
                   <div className="font-italic align-middle">---baseline---</div>
                 </td>
               ) : (
@@ -113,8 +119,7 @@ const TableHighlights = ({ experiment }: TableHighlightsProps) => {
                     const metricKey = metric.value;
                     const displayType = getTableDisplayType(
                       metricKey,
-                      TABLE_LABEL.HIGHLIGHTS,
-                      isControlBranch,
+                      branchComparison,
                     );
                     const tooltip =
                       metadata?.metrics[metricKey]?.description ||
@@ -131,6 +136,7 @@ const TableHighlights = ({ experiment }: TableHighlightsProps) => {
                           displayType,
                           tooltip,
                           isControlBranch,
+                          branchComparison,
                         }}
                       />
                     );

--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableHighlightsOverview/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableHighlightsOverview/index.tsx
@@ -18,39 +18,45 @@ const TableHighlightsOverview = ({
   const { primaryOutcomes } = useOutcomes(experiment);
 
   return (
-    <table
-      className="table text-left mb-5 border-bottom"
-      data-testid="table-overview"
-    >
-      <tbody>
-        <tr>
-          <td>
-            <h3 className="h6">Targeting</h3>
-            <div>
-              {getConfigLabel(experiment.firefoxMinVersion, firefoxMinVersion)}+
-            </div>
-            <div>{getConfigLabel(experiment.channel, channel)}</div>
-            <div>
-              {getConfigLabel(
-                experiment.targetingConfigSlug,
-                targetingConfigSlug,
-              )}
-            </div>
-          </td>
-          <td>
-            <h3 className="h6">Outcomes</h3>
-            {primaryOutcomes.length > 0 &&
-              primaryOutcomes.map((outcome) => (
-                <div key={outcome!.slug!}>{outcome?.friendlyName}</div>
-              ))}
-          </td>
-          <td>
-            <h3 className="h6">Owner</h3>
-            <span>{experiment.owner?.email}</span>
-          </td>
-        </tr>
-      </tbody>
-    </table>
+    <div className="mb-5 border-right border-bottom border-left rounded-bottom">
+      <table
+        className="table text-left"
+        data-testid="table-highlights-overview"
+      >
+        <tbody>
+          <tr>
+            <td className="p-3">
+              <h3 className="h6">Targeting</h3>
+              <div>
+                {getConfigLabel(
+                  experiment.firefoxMinVersion,
+                  firefoxMinVersion,
+                )}
+                +
+              </div>
+              <div>{getConfigLabel(experiment.channel, channel)}</div>
+              <div>
+                {getConfigLabel(
+                  experiment.targetingConfigSlug,
+                  targetingConfigSlug,
+                )}
+              </div>
+            </td>
+            <td className="p-3">
+              <h3 className="h6">Outcomes</h3>
+              {primaryOutcomes.length > 0 &&
+                primaryOutcomes.map((outcome) => (
+                  <div key={outcome!.slug!}>{outcome?.friendlyName}</div>
+                ))}
+            </td>
+            <td className="p-3">
+              <h3 className="h6">Owner</h3>
+              <span>{experiment.owner?.email}</span>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
   );
 };
 

--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableMetricConversion/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableMetricConversion/index.test.tsx
@@ -16,7 +16,7 @@ describe("TableMetricConversion", () => {
   it("has the correct headings", () => {
     const EXPECTED_HEADINGS = [
       "Conversions / Total Users",
-      "Conversion Rate",
+      "Absolute Conversion Rate",
       "Relative Improvement",
     ];
     const { mock, experiment } = mockExperimentQuery("demo-slug");

--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableMetricConversion/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableMetricConversion/index.tsx
@@ -10,6 +10,7 @@ import {
   GROUP,
   TABLE_LABEL,
 } from "../../../lib/visualization/constants";
+import { BranchComparisonValues } from "../../../lib/visualization/types";
 import { getExtremeBounds } from "../../../lib/visualization/utils";
 import { getConfig_nimbusConfig_outcomes } from "../../../types/getConfig";
 import TableVisualizationRow from "../TableVisualizationRow";
@@ -17,7 +18,7 @@ import TableVisualizationRow from "../TableVisualizationRow";
 type ConversionMetricStatistic = {
   name: string;
   displayType: DISPLAY_TYPE;
-  branchComparison?: string;
+  branchComparison: BranchComparisonValues;
   value?: string;
 };
 
@@ -57,10 +58,10 @@ const TableMetricConversion = ({ outcome }: TableMetricConversionProps) => {
 
   return (
     <div data-testid="table-metric-primary" className="mb-5">
-      <h2 className="h5 mb-3" id={outcome.slug!}>
+      <h3 className="h6 mb-3" id={outcome.slug!}>
         {outcome.friendlyName}
-      </h2>
-      <table className="table-visualization-center">
+      </h3>
+      <table className="table-visualization-center border">
         <thead>
           <tr>
             <th scope="col" className="border-bottom-0 bg-light" />
@@ -84,7 +85,7 @@ const TableMetricConversion = ({ outcome }: TableMetricConversionProps) => {
                   {branch}
                 </th>
                 {conversionMetricStatistics.map(
-                  ({ displayType, branchComparison, value }) => (
+                  ({ displayType, value, branchComparison }) => (
                     <TableVisualizationRow
                       key={`${displayType}-${value}`}
                       results={overallResults[branch]}

--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableMetricCount/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableMetricCount/index.test.tsx
@@ -15,7 +15,7 @@ import { GROUP, METRIC_TYPE } from "../../../lib/visualization/constants";
 
 describe("TableMetricCount", () => {
   it("has the correct headings", () => {
-    const EXPECTED_HEADINGS = ["Count", "Relative Improvement"];
+    const EXPECTED_HEADINGS = ["Absolute Count", "Relative Improvement"];
     const { mock, experiment } = mockExperimentQuery("demo-slug");
     const { secondaryOutcomes } = mockOutcomeSets(experiment);
 

--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableMetricCount/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableMetricCount/index.tsx
@@ -11,6 +11,7 @@ import {
   METRIC_TYPE,
   TABLE_LABEL,
 } from "../../../lib/visualization/constants";
+import { BranchComparisonValues } from "../../../lib/visualization/types";
 import { getExtremeBounds } from "../../../lib/visualization/utils";
 import GraphsWeekly from "../GraphsWeekly";
 import TableVisualizationRow from "../TableVisualizationRow";
@@ -19,7 +20,7 @@ import TooltipWithMarkdown from "../TooltipWithMarkdown";
 type CountMetricStatistic = {
   name: string;
   displayType: DISPLAY_TYPE;
-  branchComparison?: string;
+  branchComparison: BranchComparisonValues;
   value?: string;
 };
 
@@ -75,34 +76,34 @@ const TableMetricCount = ({
 
   return (
     <div data-testid="table-metric-secondary" className="mb-5">
-      <h2 className="h5 mb-3" id={outcomeSlug}>
-        <div>
-          <div className="d-inline-block">
-            {outcomeName}{" "}
-            {outcomeDescription && (
-              <>
+      <h3 className="h5 mb-3" id={outcomeSlug}>
+        <span className="mr-2">
+          {outcomeName}{" "}
+          {outcomeDescription && (
+            <>
+              <span className="align-middle">
                 <Info
+                  className="align-baseline"
                   data-tip
                   data-for={outcomeSlug}
-                  className="align-baseline"
                 />
-                <TooltipWithMarkdown
-                  tooltipId={outcomeSlug}
-                  markdown={outcomeDescription}
-                />
-              </>
-            )}
-          </div>
-        </div>
-        <div
+              </span>
+              <TooltipWithMarkdown
+                tooltipId={outcomeSlug}
+                markdown={outcomeDescription}
+              />
+            </>
+          )}
+        </span>
+        <span
           className={`badge ${metricType.badge}`}
           data-tip={metricType.tooltip}
         >
           {metricType.label}
-        </div>
-      </h2>
+        </span>
+      </h3>
 
-      <table className="table-visualization-center">
+      <table className="table-visualization-center border">
         <thead>
           <tr>
             <th scope="col" className="border-bottom-0 bg-light" />
@@ -128,7 +129,7 @@ const TableMetricCount = ({
                       {branch}
                     </th>
                     {countMetricStatistics.map(
-                      ({ displayType, branchComparison, value }) => (
+                      ({ displayType, value, branchComparison }) => (
                         <TableVisualizationRow
                           key={`${displayType}-${value}`}
                           results={overallResults[branch]}

--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableResults/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableResults/index.stories.tsx
@@ -38,7 +38,7 @@ storiesOf("pages/Results/TableResults", module)
       </RouterSlugProvider>
     );
   })
-  .add("absolute uplift comparison, with one primary outcome", () => {
+  .add("absolute comparison, with one primary outcome", () => {
     const { mock, experiment } = mockExperimentQuery("demo-slug");
     return (
       <RouterSlugProvider mocks={[mock]}>
@@ -51,7 +51,7 @@ storiesOf("pages/Results/TableResults", module)
       </RouterSlugProvider>
     );
   })
-  .add("absolute uplift comparison, with multiple primary outcomes", () => {
+  .add("absolute comparison, with multiple primary outcomes", () => {
     const { mock, experiment } = mockExperimentQuery("demo-slug", {
       primaryOutcomes: ["picture_in_picture", "feature_b", "feature_c"],
     });

--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableResults/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableResults/index.test.tsx
@@ -46,7 +46,7 @@ describe("TableResults", () => {
     );
 
     expect(screen.getAllByText("-45.5% to 51%", { exact: false })).toHaveLength(
-      2,
+      4,
     );
     expect(screen.getByText("198")).toBeInTheDocument();
     expect(screen.getByText("45%")).toBeInTheDocument();
@@ -71,8 +71,8 @@ describe("TableResults", () => {
     expect(screen.getByText("198")).toBeInTheDocument();
     expect(screen.getByText("200")).toBeInTheDocument();
     expect(
-      screen.getByText("2.4% to 8.4% (baseline)", { exact: false }),
-    ).toBeInTheDocument();
+      screen.getAllByText("0.02 to 0.08 (baseline)", { exact: false }),
+    ).toHaveLength(2);
     expect(screen.getByText("control")).toBeInTheDocument();
     expect(screen.getByText("treatment")).toBeInTheDocument();
   });
@@ -81,7 +81,10 @@ describe("TableResults", () => {
     render(
       <RouterSlugProvider mocks={[mock]}>
         <MockResultsContextProvider>
-          <TableResults {...{ experiment }} />
+          <TableResults
+            {...{ experiment }}
+            branchComparison={BRANCH_COMPARISON.ABSOLUTE}
+          />
         </MockResultsContextProvider>
       </RouterSlugProvider>,
     );

--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableResults/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableResults/index.tsx
@@ -20,7 +20,7 @@ import { getExperiment_experimentBySlug } from "../../../types/getExperiment";
 import TableVisualizationRow from "../TableVisualizationRow";
 import TooltipWithMarkdown from "../TooltipWithMarkdown";
 
-type TableResultsProps = {
+export type TableResultsProps = {
   experiment: getExperiment_experimentBySlug;
   branchComparison?: BranchComparisonValues;
 };
@@ -58,7 +58,10 @@ const TableResults = ({
   const overallResults = overall!;
 
   return (
-    <table className="table-visualization-center" data-testid="table-results">
+    <table
+      className="table-visualization-center mb-0 border-bottom-0"
+      data-testid="table-results"
+    >
       <thead>
         <tr>
           <th scope="col" className="border-bottom-0 bg-light" />
@@ -102,8 +105,7 @@ const TableResults = ({
                 const metricKey = metric.value;
                 const displayType = getTableDisplayType(
                   metricKey,
-                  TABLE_LABEL.RESULTS,
-                  isControlBranch,
+                  branchComparison,
                 );
                 return (
                   <TableVisualizationRow

--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableResultsWeekly/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableResultsWeekly/index.stories.tsx
@@ -7,27 +7,21 @@ import { storiesOf } from "@storybook/react";
 import React from "react";
 import TableResultsWeekly from ".";
 import { MockResultsContextProvider } from "../../../lib/mocks";
-import {
-  BRANCH_COMPARISON,
-  HIGHLIGHTS_METRICS_LIST,
-} from "../../../lib/visualization/constants";
+import { BRANCH_COMPARISON } from "../../../lib/visualization/constants";
 
 storiesOf("pages/Results/TableResultsWeekly", module)
   .addDecorator(withLinks)
   .add("with relative uplift comparison", () => {
     return (
       <MockResultsContextProvider>
-        <TableResultsWeekly metricsList={HIGHLIGHTS_METRICS_LIST} />
+        <TableResultsWeekly />
       </MockResultsContextProvider>
     );
   })
   .add("with absolute comparison", () => {
     return (
       <MockResultsContextProvider>
-        <TableResultsWeekly
-          metricsList={HIGHLIGHTS_METRICS_LIST}
-          branchComparison={BRANCH_COMPARISON.ABSOLUTE}
-        />
+        <TableResultsWeekly branchComparison={BRANCH_COMPARISON.ABSOLUTE} />
       </MockResultsContextProvider>
     );
   });

--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableResultsWeekly/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableResultsWeekly/index.test.tsx
@@ -6,16 +6,13 @@ import { fireEvent, render, screen } from "@testing-library/react";
 import React from "react";
 import TableResultsWeekly from ".";
 import { MockResultsContextProvider } from "../../../lib/mocks";
-import {
-  BRANCH_COMPARISON,
-  HIGHLIGHTS_METRICS_LIST,
-} from "../../../lib/visualization/constants";
+import { BRANCH_COMPARISON } from "../../../lib/visualization/constants";
 
 describe("TableResultsWeekly", () => {
   it("renders as expected with relative uplift branch comparison (default)", () => {
     render(
       <MockResultsContextProvider>
-        <TableResultsWeekly metricsList={HIGHLIGHTS_METRICS_LIST} />,
+        <TableResultsWeekly />,
       </MockResultsContextProvider>,
     );
 
@@ -34,17 +31,14 @@ describe("TableResultsWeekly", () => {
       EXPECTED_HEADINGS.length * EXPECTED_WEEKS.length,
     );
     expect(screen.getAllByText("-45.5% to 51%", { exact: false })).toHaveLength(
-      2,
+      6,
     );
   });
 
   it("renders as expected with absolute branch comparison", () => {
     render(
       <MockResultsContextProvider>
-        <TableResultsWeekly
-          metricsList={HIGHLIGHTS_METRICS_LIST}
-          branchComparison={BRANCH_COMPARISON.ABSOLUTE}
-        />
+        <TableResultsWeekly branchComparison={BRANCH_COMPARISON.ABSOLUTE} />
       </MockResultsContextProvider>,
     );
 
@@ -59,7 +53,7 @@ describe("TableResultsWeekly", () => {
 
     render(
       <MockResultsContextProvider>
-        <TableResultsWeekly metricsList={HIGHLIGHTS_METRICS_LIST} />,
+        <TableResultsWeekly />,
       </MockResultsContextProvider>,
     );
 

--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableResultsWeekly/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableResultsWeekly/index.tsx
@@ -1,6 +1,8 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import classNames from "classnames";
 import React, { useContext, useState } from "react";
 import Collapse from "react-bootstrap/Collapse";
 import { ReactComponent as CollapseMinus } from "../../../images/minus.svg";
@@ -9,22 +11,16 @@ import { ResultsContext } from "../../../lib/contexts";
 import {
   BRANCH_COMPARISON,
   GENERAL_TIPS,
+  HIGHLIGHTS_METRICS_LIST,
 } from "../../../lib/visualization/constants";
 import { BranchComparisonValues } from "../../../lib/visualization/types";
 import TableWeekly from "../TableWeekly";
 
-type TableResultsWeeklyProps = {
-  metricsList: {
-    value: string;
-    name: string;
-    tooltip: string;
-    group: string;
-  }[];
+export type TableResultsWeeklyProps = {
   branchComparison?: BranchComparisonValues;
 };
 
 const TableResultsWeekly = ({
-  metricsList,
   branchComparison = BRANCH_COMPARISON.UPLIFT,
 }: TableResultsWeeklyProps) => {
   const {
@@ -46,7 +42,7 @@ const TableResultsWeekly = ({
         }}
         aria-controls="weekly"
         aria-expanded={open}
-        className="text-primary btn mb-5"
+        className="text-primary btn mb-3 mt-2"
       >
         {open ? (
           <>
@@ -59,11 +55,20 @@ const TableResultsWeekly = ({
         )}
       </span>
       <Collapse in={open}>
-        <div className="ml-3">
-          {metricsList.map((metric) => {
+        <div className="mt-2">
+          {HIGHLIGHTS_METRICS_LIST.map((metric, index) => {
             return (
               <div key={`${metric.value}_weekly`}>
-                <h3 className="h5 mb-3">{metric.name}</h3>
+                <h3
+                  className={classNames(
+                    "h5",
+                    "mb-3",
+                    "ml-3",
+                    index === 0 ? "mt-0" : "mt-4",
+                  )}
+                >
+                  {metric.name}
+                </h3>
                 <TableWeekly
                   metricKey={metric.value}
                   metricName={metric.name}

--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableVisualizationRow/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableVisualizationRow/index.stories.tsx
@@ -30,6 +30,7 @@ storiesOf("pages/Results/TableVisualizationRow", module)
       displayType={DISPLAY_TYPE.POPULATION}
       group={GROUP.OTHER}
       isControlBranch
+      branchComparison={BRANCH_COMPARISON.UPLIFT}
     />
   ))
   .add("Count field", () => (
@@ -40,6 +41,7 @@ storiesOf("pages/Results/TableVisualizationRow", module)
       displayType={DISPLAY_TYPE.COUNT}
       group={GROUP.OTHER}
       isControlBranch
+      branchComparison={BRANCH_COMPARISON.UPLIFT}
     />
   ))
   .add("Percent field", () => (
@@ -50,6 +52,7 @@ storiesOf("pages/Results/TableVisualizationRow", module)
       displayType={DISPLAY_TYPE.PERCENT}
       group={GROUP.OTHER}
       isControlBranch
+      branchComparison={BRANCH_COMPARISON.UPLIFT}
     />
   ))
   .add("Conversion count field", () => (
@@ -105,5 +108,6 @@ storiesOf("pages/Results/TableVisualizationRow", module)
       displayType={DISPLAY_TYPE.PERCENT}
       group={GROUP.OTHER}
       isControlBranch
+      branchComparison={BRANCH_COMPARISON.UPLIFT}
     />
   ));

--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableWeekly/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableWeekly/index.test.tsx
@@ -47,6 +47,7 @@ describe("TableWeekly", () => {
             metricKey="retained"
             metricName="Retention"
             group={GROUP.OTHER}
+            branchComparison={BRANCH_COMPARISON.UPLIFT}
           />
         </MockResultsContextProvider>
       </RouterSlugProvider>,
@@ -64,9 +65,9 @@ describe("TableWeekly", () => {
       <RouterSlugProvider>
         <MockResultsContextProvider>
           <TableWeekly
+            branchComparison={BRANCH_COMPARISON.ABSOLUTE}
             metricKey="fake"
             metricName="Some Made Up Metric"
-            branchComparison={BRANCH_COMPARISON.ABSOLUTE}
             group={GROUP.OTHER}
           />
         </MockResultsContextProvider>

--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableWeekly/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableWeekly/index.tsx
@@ -20,7 +20,7 @@ type TableWeeklyProps = {
   metricKey: string;
   metricName: string;
   group: string;
-  branchComparison?: BranchComparisonValues;
+  branchComparison: BranchComparisonValues;
 };
 
 const getWeekIndexList = (
@@ -51,7 +51,7 @@ const TableWeekly = ({
   metricKey,
   metricName,
   group,
-  branchComparison = BRANCH_COMPARISON.UPLIFT,
+  branchComparison,
 }: TableWeeklyProps) => {
   const {
     analysis: { weekly },
@@ -63,10 +63,7 @@ const TableWeekly = ({
   const tableLabel = TABLE_LABEL.RESULTS;
 
   return (
-    <table
-      className="table-visualization-center mb-5"
-      data-testid="table-weekly"
-    >
+    <table className="table-visualization-center" data-testid="table-weekly">
       <thead>
         <tr>
           <th scope="col" className="border-bottom-0 bg-light" />
@@ -84,11 +81,7 @@ const TableWeekly = ({
       <tbody>
         {sortedBranchNames.map((branch) => {
           const isControlBranch = branch === controlBranchName;
-          const displayType = getTableDisplayType(
-            metricKey,
-            tableLabel,
-            isControlBranch,
-          );
+          const displayType = getTableDisplayType(metricKey, branchComparison);
 
           const TableRow = () => (
             <TableVisualizationRow

--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableWithTabComparison/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableWithTabComparison/index.stories.tsx
@@ -1,0 +1,38 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from "react";
+import TableWithTabComparison from ".";
+import { mockExperimentQuery } from "../../../lib/mocks";
+import TableHighlights from "../TableHighlights";
+import TableResults from "../TableResults";
+import TableResultsWeekly from "../TableResultsWeekly";
+import { Subject } from "./mocks";
+
+export default {
+  title: "pages/Results/TableWithTabComparison",
+  component: TableWithTabComparison,
+};
+
+const { experiment } = mockExperimentQuery("demo-slug");
+
+export const WithHighlightsTable = () => (
+  <Subject
+    Table={TableHighlights}
+    {...{ experiment }}
+    className="mb-2 border-top-0"
+  />
+);
+
+export const WithResultsTable = () => (
+  <Subject
+    Table={TableResults}
+    {...{ experiment }}
+    className="rounded-bottom mb-3 border-top-0"
+  />
+);
+
+export const WithResultsWeeklyTable = () => (
+  <Subject Table={TableResultsWeekly} />
+);

--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableWithTabComparison/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableWithTabComparison/index.test.tsx
@@ -1,0 +1,29 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import React from "react";
+import { mockExperimentQuery } from "../../../lib/mocks";
+import TableHighlights from "../TableHighlights";
+import { Subject } from "./mocks";
+
+describe("TableWithTabComparison", () => {
+  // This test exists to test that the relative comparison shows by default and
+  // to test the tab text. Comparison value tests are in table tests.
+  it("toggles between absolute and relative branch comparisons", async () => {
+    const { experiment } = mockExperimentQuery("demo-slug");
+    render(<Subject Table={TableHighlights} {...{ experiment }} />);
+
+    const relativeTab = screen.getByText("Relative uplift comparison");
+    const absoluteTab = screen.getByText("Absolute comparison");
+
+    expect(relativeTab).toHaveAttribute("aria-selected", "true");
+    expect(absoluteTab).toHaveAttribute("aria-selected", "false");
+
+    fireEvent.click(absoluteTab);
+
+    expect(relativeTab).toHaveAttribute("aria-selected", "false");
+    expect(absoluteTab).toHaveAttribute("aria-selected", "true");
+  });
+});

--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableWithTabComparison/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableWithTabComparison/index.tsx
@@ -1,0 +1,55 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React, { ComponentType } from "react";
+import { Tab, Tabs } from "react-bootstrap";
+import { BRANCH_COMPARISON } from "../../../lib/visualization/constants";
+import { getExperiment_experimentBySlug } from "../../../types/getExperiment";
+import { TableHighlightsProps } from "../TableHighlights";
+import { TableResultsProps } from "../TableResults";
+import { TableResultsWeeklyProps } from "../TableResultsWeekly";
+
+type TablesWithExperiment =
+  | ComponentType<TableHighlightsProps>
+  | ComponentType<TableResultsProps>;
+
+type TablesWithoutExperiment = ComponentType<TableResultsWeeklyProps>;
+
+export type TableWithTabComparisonProps = {
+  experiment?: getExperiment_experimentBySlug;
+  Table: TablesWithExperiment | TablesWithoutExperiment;
+  className?: string;
+};
+
+export const TableWithTabComparison = ({
+  experiment,
+  Table,
+  className = "rounded-bottom mb-5",
+}: TableWithTabComparisonProps) => (
+  <Tabs defaultActiveKey={BRANCH_COMPARISON.UPLIFT} className="border-bottom-0">
+    <Tab eventKey={BRANCH_COMPARISON.UPLIFT} title="Relative uplift comparison">
+      <div className={`border ${className}`}>
+        {/* @ts-ignore - TODO, assert Table is TablesWithoutExperiment if `experiment` not provided */}
+        {experiment ? <Table {...{ experiment }} /> : <Table />}
+      </div>
+    </Tab>
+    <Tab eventKey={BRANCH_COMPARISON.ABSOLUTE} title="Absolute comparison">
+      <div className={`border ${className}`}>
+        {experiment ? (
+          <Table
+            {...{ experiment }}
+            branchComparison={BRANCH_COMPARISON.ABSOLUTE}
+          />
+        ) : (
+          <>
+            {/* @ts-ignore - TODO, assert Table is TablesWithoutExperiment if `experiment` not provided */}
+            <Table branchComparison={BRANCH_COMPARISON.ABSOLUTE} />
+          </>
+        )}
+      </div>
+    </Tab>
+  </Tabs>
+);
+
+export default TableWithTabComparison;

--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableWithTabComparison/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableWithTabComparison/mocks.tsx
@@ -1,0 +1,26 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from "react";
+import TableWithTabComparison, { TableWithTabComparisonProps } from ".";
+import {
+  mockExperimentQuery,
+  MockResultsContextProvider,
+} from "../../../lib/mocks";
+import { RouterSlugProvider } from "../../../lib/test-utils";
+
+export const Subject = ({
+  Table,
+  className,
+  experiment,
+}: TableWithTabComparisonProps) => {
+  const { mock } = mockExperimentQuery("demo-slug");
+  return (
+    <RouterSlugProvider mocks={[mock]}>
+      <MockResultsContextProvider>
+        <TableWithTabComparison {...{ experiment, Table, className }} />
+      </MockResultsContextProvider>
+    </RouterSlugProvider>
+  );
+};

--- a/app/experimenter/nimbus-ui/src/components/PageResults/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/index.test.tsx
@@ -56,9 +56,12 @@ describe("PageResults", () => {
       expect(screen.queryByTestId("PageResults")).toBeInTheDocument();
     });
     expect(screen.queryByTestId("summary")).not.toBeInTheDocument();
-    expect(screen.queryByTestId("table-highlights")).toBeInTheDocument();
-    expect(screen.queryByTestId("table-overview")).toBeInTheDocument();
-    expect(screen.queryByTestId("table-results")).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("table-highlights-overview"),
+    ).toBeInTheDocument();
+    // length of 2 due to two sets of tabs per table
+    expect(screen.queryAllByTestId("table-highlights")).toHaveLength(2);
+    expect(screen.queryAllByTestId("table-results")).toHaveLength(2);
     expect(screen.getAllByTestId("table-metric-secondary")).toHaveLength(4);
     expect(screen.queryByTestId("link-external-results")).toHaveAttribute(
       "href",
@@ -125,26 +128,6 @@ it("displays grouped metrics via onClick", async () => {
     fireEvent.click(screen.getByText("Hide other metrics"));
   });
   expect(screen.getByText("Show other metrics")).toBeInTheDocument();
-});
-
-it("toggles between absolute and relative branch comparisons", async () => {
-  mockExperiment = mockExperimentQuery("demo-slug").experiment;
-  render(<Subject />);
-
-  expect(screen.getAllByText("-0.46 to 0.51", { exact: false })).toHaveLength(
-    6,
-  );
-  expect(screen.queryByText("88.6%", { exact: false })).not.toBeInTheDocument();
-
-  fireEvent.click(screen.getByText("See absolute comparison"));
-  await screen.findByText("88.6%", { exact: false });
-  expect(
-    screen.queryByText("-0.46 to 0.51", { exact: false }),
-  ).not.toBeInTheDocument();
-
-  fireEvent.click(screen.getByText("See relative comparison"));
-  await screen.findAllByText("-0.46 to 0.51", { exact: false });
-  expect(screen.queryByText("88.6%", { exact: false })).not.toBeInTheDocument();
 });
 
 // Mocking form component because validation is exercised in its own tests.

--- a/app/experimenter/nimbus-ui/src/lib/visualization/constants.ts
+++ b/app/experimenter/nimbus-ui/src/lib/visualization/constants.ts
@@ -202,9 +202,10 @@ export const CONVERSION_METRIC_COLUMNS = [
   {
     name: "Conversions / Total Users",
     displayType: DISPLAY_TYPE.CONVERSION_COUNT,
+    branchComparison: BRANCH_COMPARISON.ABSOLUTE,
   },
   {
-    name: "Conversion Rate",
+    name: "Absolute Conversion Rate",
     displayType: DISPLAY_TYPE.CONVERSION_RATE,
     branchComparison: BRANCH_COMPARISON.ABSOLUTE,
   },
@@ -219,7 +220,7 @@ export const CONVERSION_METRIC_COLUMNS = [
 // display in the count metric table from left to right.
 export const COUNT_METRIC_COLUMNS = [
   {
-    name: "Count",
+    name: "Absolute Count",
     displayType: DISPLAY_TYPE.COUNT,
     branchComparison: BRANCH_COMPARISON.ABSOLUTE,
   },

--- a/app/experimenter/nimbus-ui/src/lib/visualization/utils.tsx
+++ b/app/experimenter/nimbus-ui/src/lib/visualization/utils.tsx
@@ -2,15 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import {
-  BRANCH_COMPARISON,
-  DISPLAY_TYPE,
-  METRIC,
-  TABLE_LABEL,
-} from "./constants";
+import { BRANCH_COMPARISON, DISPLAY_TYPE, METRIC } from "./constants";
 import {
   AnalysisData,
   AnalysisDataOverall,
+  BranchComparisonValues,
   FormattedAnalysisPoint,
 } from "./types";
 
@@ -24,27 +20,17 @@ export const analysisUnavailable = (analysis: AnalysisData | undefined) =>
 
 export const getTableDisplayType = (
   metricKey: string,
-  tableLabel: string,
-  isControl: boolean,
+  branchComparison: BranchComparisonValues,
 ): DISPLAY_TYPE => {
-  let displayType;
-  switch (metricKey) {
-    case METRIC.USER_COUNT:
-      displayType = DISPLAY_TYPE.POPULATION;
-      break;
-    case METRIC.SEARCH:
-    case METRIC.DAYS_OF_USE:
-      if (tableLabel === TABLE_LABEL.RESULTS || isControl) {
-        displayType = DISPLAY_TYPE.COUNT;
-        break;
-      }
-
-    // fall through
-    default:
-      displayType = DISPLAY_TYPE.PERCENT;
+  // User count metrics always display as "population" and retention metrics
+  // always display as "percent" despite the branch comparison.
+  if (metricKey === METRIC.USER_COUNT) return DISPLAY_TYPE.POPULATION;
+  if (metricKey === METRIC.RETENTION) return DISPLAY_TYPE.PERCENT;
+  if (branchComparison === BRANCH_COMPARISON.ABSOLUTE) {
+    return DISPLAY_TYPE.COUNT;
+  } else {
+    return DISPLAY_TYPE.PERCENT;
   }
-
-  return displayType;
 };
 
 export const getControlBranchName = (analysis: AnalysisData) => {


### PR DESCRIPTION
fixes #6071, but see [this comment](https://github.com/mozilla/experimenter/pull/6313#issuecomment-908799275) on why we're not extending for the "entire page" but just for tables that make sense

Because:
* Users would like to toggle between relative and absolute branch comparison values - functionality was previously implemented for two tables deemed most important, this change allows the toggle to switch in sets of tabs containing these tables plus, now, the highlights table

This commit:
* Enables the highlights table to toggle between absolute/relative comparison
* Removes the branch comparison button, uses Bootstrap's Tabs component instead for applicable tables since the toggle is not useful for the metric tables
* Contains cosmetic tweaks, including spacing updates, updating heading levels and adding a metrics heading, combining monitoring/analysis sections, and aligning tooltips horizontally