### PR TITLE
fix #6311 bug(nimbus): make test change datetimes deterministic

### DIFF
--- a/app/experimenter/base/management/commands/load_dummy_experiments.py
+++ b/app/experimenter/base/management/commands/load_dummy_experiments.py
@@ -22,7 +22,5 @@ class Command(BaseCommand):
             logger.info("Created {}: {}".format(experiment, status))
 
         for lifecycle in NimbusExperimentFactory.LocalLifecycles:
-            experiment = NimbusExperimentFactory.create_with_lifecycle(
-                lifecycle, with_random_timespan=True
-            )
+            experiment = NimbusExperimentFactory.create_with_lifecycle(lifecycle)
             logger.info("Created {}: {}".format(experiment, lifecycle))

--- a/app/experimenter/experiments/tests/api/v5/test_queries.py
+++ b/app/experimenter/experiments/tests/api/v5/test_queries.py
@@ -473,7 +473,6 @@ class TestNimbusExperimentBySlugQuery(GraphQLTestCase):
         user_email = "user@example.com"
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.CREATED,
-            with_random_timespan=True,
         )
 
         response = self.query(
@@ -500,7 +499,6 @@ class TestNimbusExperimentBySlugQuery(GraphQLTestCase):
         user_email = "user@example.com"
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.LAUNCH_REJECT,
-            with_random_timespan=True,
         )
         response = self.query(
             """
@@ -528,7 +526,6 @@ class TestNimbusExperimentBySlugQuery(GraphQLTestCase):
         user_email = "user@example.com"
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.CREATED,
-            with_random_timespan=True,
         )
 
         response = self.query(
@@ -555,7 +552,6 @@ class TestNimbusExperimentBySlugQuery(GraphQLTestCase):
         user_email = "user@example.com"
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.LAUNCH_REVIEW_REQUESTED,
-            with_random_timespan=True,
         )
         response = self.query(
             """
@@ -583,7 +579,6 @@ class TestNimbusExperimentBySlugQuery(GraphQLTestCase):
         user_email = "user@example.com"
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE_WAITING,
-            with_random_timespan=True,
         )
         response = self.query(
             """
@@ -609,7 +604,6 @@ class TestNimbusExperimentBySlugQuery(GraphQLTestCase):
         user_email = "user@example.com"
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE_TIMEOUT,
-            with_random_timespan=True,
         )
         response = self.query(
             """

--- a/app/experimenter/kinto/tests/test_tasks.py
+++ b/app/experimenter/kinto/tests/test_tasks.py
@@ -100,6 +100,7 @@ class TestNimbusCheckKintoPushQueueByCollection(MockKintoClientMixin, TestCase):
         NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE_WAITING,
             application=NimbusExperiment.Application.DESKTOP,
+            with_latest_change_now=True,
         )
 
         self.setup_kinto_get_main_records([])
@@ -781,7 +782,7 @@ class TestNimbusSynchronizePreviewExperimentsInKinto(MockKintoClientMixin, TestC
             tasks.nimbus_synchronize_preview_experiments_in_kinto()
 
 
-class TestNimbusSendEndEnrollmentEmail(MockKintoClientMixin, TestCase):
+class TestNimbusSendEmails(MockKintoClientMixin, TestCase):
     def test_enrollment_ending_email_not_sent_for_experiments_before_enrollment_end_date(
         self,
     ):
@@ -789,6 +790,7 @@ class TestNimbusSendEndEnrollmentEmail(MockKintoClientMixin, TestCase):
             NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE_APPROVE,
             proposed_enrollment=10,
             proposed_duration=20,
+            with_latest_change_now=True,
         )
 
         tasks.nimbus_send_emails()
@@ -801,6 +803,7 @@ class TestNimbusSendEndEnrollmentEmail(MockKintoClientMixin, TestCase):
             NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE_APPROVE,
             proposed_enrollment=0,
             proposed_duration=20,
+            with_latest_change_now=True,
         )
 
         NimbusEmail.objects.create(
@@ -819,6 +822,7 @@ class TestNimbusSendEndEnrollmentEmail(MockKintoClientMixin, TestCase):
             NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE_APPROVE,
             proposed_enrollment=0,
             proposed_duration=20,
+            with_latest_change_now=True,
         )
 
         tasks.nimbus_send_emails()
@@ -838,6 +842,7 @@ class TestNimbusSendEndEnrollmentEmail(MockKintoClientMixin, TestCase):
             NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE_APPROVE,
             proposed_enrollment=10,
             proposed_duration=20,
+            with_latest_change_now=True,
         )
 
         tasks.nimbus_send_emails()
@@ -850,6 +855,7 @@ class TestNimbusSendEndEnrollmentEmail(MockKintoClientMixin, TestCase):
             NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE_APPROVE,
             proposed_enrollment=10,
             proposed_duration=0,
+            with_latest_change_now=True,
         )
 
         NimbusEmail.objects.create(
@@ -868,6 +874,7 @@ class TestNimbusSendEndEnrollmentEmail(MockKintoClientMixin, TestCase):
             NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE_APPROVE,
             proposed_enrollment=10,
             proposed_duration=0,
+            with_latest_change_now=True,
         )
 
         tasks.nimbus_send_emails()


### PR DESCRIPTION
Because

* We've had this issue for a little while where creating multiple changelogs in tests with timezone.now() can result in multiple changes having the same change datetime
* Several bits of logic depend on using the 'latest' change to understand the state of the experiment
* Multiple changes with the same change datetime can randomly invert the expected ordering and intermittently fail tests

This commit

* Changes the NimbusExperimentFactory to always use the same starting date and then create each change 1 day later
* For tests that are sensitive to timeouts, provide the ability to set the latest change to the current time
* For tests that require more detailed change date logic, explicitly set those dates in the test
* This should hopefully prevent this kind of intermittency from happening in the future