### PR TITLE
fix #6312 feat(nimbus): Connect Clone modal to mutation

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/SidebarActions/CloneDialog/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/SidebarActions/CloneDialog/index.test.tsx
@@ -2,6 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import { MockedResponse } from "@apollo/client/testing";
+import {
+  createHistory,
+  createMemorySource,
+  History,
+  HistorySource,
+} from "@reach/router";
 import {
   act,
   fireEvent,
@@ -10,8 +17,12 @@ import {
   waitFor,
 } from "@testing-library/react";
 import React from "react";
-import CloneDialog from ".";
+import CloneDialog, { useCloneDialog } from ".";
+import { CLONE_EXPERIMENT_MUTATION } from "../../../gql/experiments";
+import { BASE_PATH, SUBMIT_ERROR } from "../../../lib/constants";
 import { mockExperimentQuery } from "../../../lib/mocks";
+import { RouterSlugProvider } from "../../../lib/test-utils";
+import { MemoryHistorySource } from "../../../lib/types";
 
 describe("CloneDialog", () => {
   it("renders, cancels, and saves as expected", async () => {
@@ -68,6 +79,143 @@ describe("CloneDialog", () => {
   });
 });
 
+describe("CloneDialog with useCloneDialog props", () => {
+  let mockHistory: History;
+  let mockHistorySource: MemoryHistorySource;
+  let navigateSpy: jest.SpyInstance<Promise<void>, any>;
+
+  beforeEach(() => {
+    mockHistorySource = createMemorySource(
+      "/xyzzy/edit",
+    ) as MemoryHistorySource;
+    mockHistory = createHistory(mockHistorySource);
+    navigateSpy = jest.spyOn(mockHistory, "navigate");
+  });
+
+  it("reveals dialog with onShow, hides with onCancel calls", async () => {
+    render(<SubjectWithHook />);
+    const showButton = screen.getByTestId("show-dialog");
+
+    expect(screen.queryByTestId("CloneDialog")).not.toBeInTheDocument();
+
+    act(() => void fireEvent.click(showButton));
+    await waitFor(
+      () =>
+        void expect(screen.queryByTestId("CloneDialog")).toBeInTheDocument(),
+    );
+
+    act(() => void fireEvent.click(screen.getByText("Cancel")));
+    await waitFor(
+      () =>
+        void expect(
+          screen.queryByTestId("CloneDialog"),
+        ).not.toBeInTheDocument(),
+    );
+  });
+
+  const expectedName = "Hello world";
+  const expectedSlug = "hello-world";
+
+  const mockCloneMutation = () => ({
+    request: {
+      query: CLONE_EXPERIMENT_MUTATION,
+      variables: {
+        input: {
+          parentSlug: mockExperiment.slug,
+          name: expectedName,
+        },
+      },
+    },
+    result: {
+      data: {
+        cloneExperiment: {
+          message: "success" as string | Record<string, any>,
+          nimbusExperiment: {
+            slug: expectedSlug,
+          } as Record<string, string> | undefined,
+        },
+      },
+    },
+  });
+
+  const baseCloneTest = async (
+    mocks?: MockedResponse<Record<string, any>>[],
+  ) => {
+    render(<SubjectWithHook {...{ mocks, mockHistorySource, mockHistory }} />);
+
+    const showButton = screen.getByTestId("show-dialog");
+    act(() => void fireEvent.click(showButton));
+    await waitFor(
+      () =>
+        void expect(screen.queryByTestId("CloneDialog")).toBeInTheDocument(),
+    );
+
+    const nameField = screen.getByLabelText("Public name");
+    const slugField = screen.getByTestId("SlugTextControl") as HTMLInputElement;
+    const saveButton = screen.getByText("Save");
+
+    fireEvent.change(nameField!, { target: { value: expectedName } });
+    await waitFor(() => {
+      expect(slugField.value).toEqual(expectedSlug);
+    });
+
+    fireEvent.click(saveButton);
+    await waitFor(
+      () =>
+        void expect(
+          screen.queryByTestId("loading-dialog"),
+        ).not.toBeInTheDocument(),
+    );
+  };
+
+  it("submits the clone request as expected", async () => {
+    await baseCloneTest([mockCloneMutation()]);
+    await waitFor(
+      () =>
+        void expect(
+          screen.queryByTestId("CloneDialog"),
+        ).not.toBeInTheDocument(),
+    );
+    expect(navigateSpy).toHaveBeenCalledWith(`${BASE_PATH}/${expectedSlug}`);
+  });
+
+  it("handles malformed data from server", async () => {
+    const mutation = mockCloneMutation();
+    // @ts-ignore breaking the type on purpose
+    delete mutation.result.data.cloneExperiment;
+
+    await baseCloneTest([mutation]);
+
+    await waitFor(
+      () => void expect(screen.queryByText(SUBMIT_ERROR)).toBeInTheDocument(),
+    );
+    expect(screen.queryByTestId("CloneDialog")).toBeInTheDocument();
+    expect(navigateSpy).not.toHaveBeenCalledWith(
+      `${BASE_PATH}/${expectedSlug}`,
+    );
+  });
+
+  it("handles errors reported from the server", async () => {
+    const expectedSubmitError = "This name is garbage";
+    const mutation = mockCloneMutation();
+    mutation.result.data.cloneExperiment.message = {
+      name: expectedSubmitError,
+    };
+
+    await baseCloneTest([mutation]);
+
+    await waitFor(() =>
+      expect(
+        screen.getByTestId("CloneDialog").querySelector(".invalid-feedback"),
+      ).toHaveTextContent(expectedSubmitError),
+    );
+    expect(screen.queryByTestId("CloneDialog")).toBeInTheDocument();
+    expect(navigateSpy).not.toHaveBeenCalledWith(
+      `${BASE_PATH}/${expectedSlug}`,
+    );
+  });
+});
+
 type SubjectProps = Partial<React.ComponentProps<typeof CloneDialog>>;
 
 const { experiment: mockExperiment } = mockExperimentQuery("my-special-slug");
@@ -95,3 +243,34 @@ const Subject = ({
     }}
   />
 );
+
+const SubjectWithHook = ({
+  mocks,
+  mockHistorySource,
+  mockHistory,
+  ...innerProps
+}: {
+  mocks?: MockedResponse<Record<string, any>>[];
+  mockHistorySource?: HistorySource;
+  mockHistory?: History;
+} & Pick<SubjectProps, "experiment">) => (
+  <RouterSlugProvider {...{ mocks, mockHistorySource, mockHistory }}>
+    <SubjectWithHookInner {...innerProps} />
+  </RouterSlugProvider>
+);
+
+const SubjectWithHookInner = ({
+  experiment = mockExperiment,
+}: Pick<SubjectProps, "experiment">) => {
+  const cloneDialogProps = useCloneDialog(experiment);
+  const { onShow, isLoading } = cloneDialogProps;
+  return (
+    <div>
+      <button data-testid="show-dialog" onClick={onShow}>
+        Show
+      </button>
+      {isLoading && <div data-testid="loading-dialog">Loading...</div>}
+      <CloneDialog {...cloneDialogProps} />
+    </div>
+  );
+};

--- a/app/experimenter/nimbus-ui/src/components/SidebarActions/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/SidebarActions/index.tsx
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { RouteComponentProps } from "@reach/router";
-import React, { useState } from "react";
+import React from "react";
 import ReactTooltip from "react-tooltip";
 import { useChangeOperationMutation } from "../../hooks";
 import { ReactComponent as Info } from "../../images/info.svg";
@@ -11,7 +11,7 @@ import { ARCHIVE_DISABLED, CHANGELOG_MESSAGES } from "../../lib/constants";
 import { getExperiment_experimentBySlug } from "../../types/getExperiment";
 import { LinkNav } from "../LinkNav";
 import { ReactComponent as CloneIcon } from "./clone.svg";
-import CloneDialog, { CloneParams } from "./CloneDialog";
+import CloneDialog, { useCloneDialog } from "./CloneDialog";
 import { ReactComponent as TrashIcon } from "./trash.svg";
 
 type SidebarModifyExperimentProps = {
@@ -34,24 +34,9 @@ export const SidebarActions = ({
       : CHANGELOG_MESSAGES.UNARCHIVING_EXPERIMENT,
   });
 
-  const disabled = !experiment.canArchive || isLoading;
+  const archiveDisabled = !experiment.canArchive || isLoading;
 
-  const [cloneShowDialog, cloneSetShowDialog] = useState(false);
-  const cloneOnShow = () => cloneSetShowDialog(true);
-  const cloneOnCancel = () => cloneSetShowDialog(false);
-
-  // TODO: EXP-1138 replace this next block when clone mutation is available
-  const canClone = true;
-  const cloneIsLoading = false;
-  const cloneIsServerValid = true;
-  const cloneSubmitErrors = {};
-  /* istanbul ignore next EXP-1138 - pending mutation implementation */
-  const cloneSetSubmitErrors = () => {};
-  /* istanbul ignore next EXP-1138 - pending mutation implementation */
-  const cloneOnSave = (data: CloneParams) => {
-    cloneOnCancel();
-    window.alert("Sorry, experiment cloning is not yet implemented.");
-  };
+  const cloneDialogProps = useCloneDialog(experiment);
 
   return (
     <div data-testid={"SidebarActions"}>
@@ -64,25 +49,14 @@ export const SidebarActions = ({
         <LinkNav
           useButton
           key="sidebar-actions-clone"
-          disabled={!canClone || isLoading}
+          disabled={cloneDialogProps.disabled}
           testid="action-clone"
-          onClick={cloneOnShow}
+          onClick={cloneDialogProps.onShow}
         >
           <CloneIcon className="sidebar-icon" />
           Clone
         </LinkNav>
-        <CloneDialog
-          {...{
-            experiment,
-            show: cloneShowDialog,
-            onCancel: cloneOnCancel,
-            onSave: cloneOnSave,
-            isLoading: cloneIsLoading,
-            isServerValid: cloneIsServerValid,
-            submitErrors: cloneSubmitErrors,
-            setSubmitErrors: cloneSetSubmitErrors,
-          }}
-        />
+        <CloneDialog {...cloneDialogProps} />
       </div>
       <div>
         <LinkNav
@@ -91,11 +65,11 @@ export const SidebarActions = ({
           route={`${experiment.slug}/#`}
           testid="action-archive"
           onClick={onUpdateArchived}
-          {...{ disabled }}
+          {...{ disabled: archiveDisabled }}
         >
           <TrashIcon className="sidebar-icon" />
           {experiment.isArchived ? "Unarchive" : "Archive"}
-          {disabled && (
+          {archiveDisabled && (
             <>
               <Info
                 data-tip={ARCHIVE_DISABLED}

--- a/app/experimenter/nimbus-ui/src/gql/experiments.ts
+++ b/app/experimenter/nimbus-ui/src/gql/experiments.ts
@@ -191,3 +191,14 @@ export const GET_EXPERIMENTS_QUERY = gql`
     }
   }
 `;
+
+export const CLONE_EXPERIMENT_MUTATION = gql`
+  mutation cloneExperiment($input: ExperimentCloneInput!) {
+    cloneExperiment(input: $input) {
+      message
+      nimbusExperiment {
+        slug
+      }
+    }
+  }
+`;

--- a/app/experimenter/nimbus-ui/src/lib/types.ts
+++ b/app/experimenter/nimbus-ui/src/lib/types.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import { HistorySource } from "@reach/router";
 import { getConfig_nimbusConfig_outcomes } from "../types/getConfig";
 
 export type OutcomeSlugs = (string | null)[] | null;
@@ -11,3 +12,12 @@ export type OutcomesList = Outcome[];
 // This roughly represents optional objects from GQL results
 export type NullableObject = Record<string, any> | null;
 export type NullableObjectArray = NullableObject[];
+
+// HACK: the types don't cover these properties exposed by the mock
+// memory history source, but they're useful for tests
+export type MemoryHistorySource = HistorySource & {
+  history: HistorySource["history"] & {
+    entries: { pathname: string; search: string }[];
+    index: number;
+  };
+};

--- a/app/experimenter/nimbus-ui/src/types/cloneExperiment.ts
+++ b/app/experimenter/nimbus-ui/src/types/cloneExperiment.ts
@@ -1,0 +1,27 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+import { ExperimentCloneInput } from "./globalTypes";
+
+// ====================================================
+// GraphQL mutation operation: cloneExperiment
+// ====================================================
+
+export interface cloneExperiment_cloneExperiment_nimbusExperiment {
+  slug: string;
+}
+
+export interface cloneExperiment_cloneExperiment {
+  message: ObjectField | null;
+  nimbusExperiment: cloneExperiment_cloneExperiment_nimbusExperiment | null;
+}
+
+export interface cloneExperiment {
+  cloneExperiment: cloneExperiment_cloneExperiment | null;
+}
+
+export interface cloneExperimentVariables {
+  input: ExperimentCloneInput;
+}

--- a/app/experimenter/nimbus-ui/src/types/globalTypes.ts
+++ b/app/experimenter/nimbus-ui/src/types/globalTypes.ts
@@ -162,6 +162,11 @@ export interface DocumentationLinkType {
   link: string;
 }
 
+export interface ExperimentCloneInput {
+  parentSlug?: string | null;
+  name?: string | null;
+}
+
 export interface ExperimentInput {
   id?: number | null;
   isArchived?: boolean | null;


### PR DESCRIPTION
Because:

* we want to enable cloning of experiments

This commit:

* adds the clone experiment GQL mutation in front end

* creates a useCloneDialog hook with CloneDialog display and mutation logic that can be partially controlled and watched from SidebarActions

* adds display of general submit errors to CloneDialog

* updates types & tests as necessary