### PR TITLE
fix #5796 feat(nimbus): Update experiment header to link back to parent experiment

### DIFF
--- a/app/experimenter/experiments/api/v5/types.py
+++ b/app/experimenter/experiments/api/v5/types.py
@@ -259,7 +259,7 @@ class NimbusConfigurationType(graphene.ObjectType):
 
 class NimbusExperimentType(DjangoObjectType):
     id = graphene.Int()
-    parent = graphene.String()
+    parent = graphene.Field(lambda: NimbusExperimentType)
     is_archived = graphene.Boolean()
     status = NimbusExperimentStatus()
     status_next = NimbusExperimentStatus()
@@ -297,10 +297,6 @@ class NimbusExperimentType(DjangoObjectType):
     class Meta:
         model = NimbusExperiment
         exclude = ("branches",)
-
-    def resolve_parent(self, info):
-        if self.parent:
-            return self.parent.slug
 
     def resolve_reference_branch(self, info):
         return self.reference_branch

--- a/app/experimenter/experiments/tests/api/v5/test_queries.py
+++ b/app/experimenter/experiments/tests/api/v5/test_queries.py
@@ -260,7 +260,10 @@ class TestNimbusExperimentBySlugQuery(GraphQLTestCase):
             """
             query experimentBySlug($slug: String!) {
                 experimentBySlug(slug: $slug) {
-                    parent
+                    parent {
+                        slug
+                        name
+                    }
                 }
             }
             """,
@@ -270,7 +273,8 @@ class TestNimbusExperimentBySlugQuery(GraphQLTestCase):
         self.assertEqual(response.status_code, 200, response.content)
         content = json.loads(response.content)
         experiment_data = content["data"]["experimentBySlug"]
-        self.assertEqual(experiment_data["parent"], parent_experiment.slug)
+        self.assertEqual(experiment_data["parent"]["slug"], parent_experiment.slug)
+        self.assertEqual(experiment_data["parent"]["name"], parent_experiment.name)
 
     def test_experiment_by_slug_without_parent(self):
         user_email = "user@example.com"
@@ -282,7 +286,10 @@ class TestNimbusExperimentBySlugQuery(GraphQLTestCase):
             """
             query experimentBySlug($slug: String!) {
                 experimentBySlug(slug: $slug) {
-                    parent
+                    parent {
+                        name
+                        slug
+                    }
                 }
             }
             """,

--- a/app/experimenter/nimbus-ui/schema.graphql
+++ b/app/experimenter/nimbus-ui/schema.graphql
@@ -315,7 +315,7 @@ type NimbusExperimentTargetingConfigSlugChoice {
 
 type NimbusExperimentType {
   id: Int
-  parent: String
+  parent: NimbusExperimentType
   isArchived: Boolean
   owner: NimbusUser!
   status: NimbusExperimentStatus

--- a/app/experimenter/nimbus-ui/src/components/AppLayoutWithExperiment/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/AppLayoutWithExperiment/index.tsx
@@ -140,8 +140,14 @@ const AppLayoutWithExperiment = ({
     return <PageExperimentNotFound {...{ slug }} />;
   }
 
-  const { name, startDate, computedEndDate, computedDurationDays, isArchived } =
-    experiment;
+  const {
+    name,
+    parent,
+    startDate,
+    computedEndDate,
+    computedDurationDays,
+    isArchived,
+  } = experiment;
 
   return (
     <Layout
@@ -167,6 +173,7 @@ const AppLayoutWithExperiment = ({
           {...{
             slug,
             name,
+            parent,
             startDate,
             computedEndDate,
             status,

--- a/app/experimenter/nimbus-ui/src/components/HeaderExperiment/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/HeaderExperiment/index.stories.tsx
@@ -20,6 +20,25 @@ storiesOf("components/HeaderExperiment", module)
   .add("status: draft", () => (
     <AppLayout>
       <HeaderExperiment
+        parent={null}
+        name={experiment.name}
+        slug={experiment.slug}
+        startDate={experiment.startDate}
+        computedEndDate={experiment.computedEndDate}
+        computedDurationDays={experiment.computedDurationDays}
+        status={mockGetStatus(experiment)}
+        isArchived={false}
+      />
+    </AppLayout>
+  ))
+  .add("status: draft with parent", () => (
+    <AppLayout>
+      <HeaderExperiment
+        parent={{
+          ...experiment,
+          name: "Example Parent",
+          slug: "example-parent",
+        }}
         name={experiment.name}
         slug={experiment.slug}
         startDate={experiment.startDate}
@@ -33,6 +52,7 @@ storiesOf("components/HeaderExperiment", module)
   .add("status: preview", () => (
     <AppLayout>
       <HeaderExperiment
+        parent={null}
         name={experiment.name}
         slug={experiment.slug}
         startDate={experiment.startDate}
@@ -46,6 +66,7 @@ storiesOf("components/HeaderExperiment", module)
   .add("publish status: review", () => (
     <AppLayout>
       <HeaderExperiment
+        parent={null}
         name={experiment.name}
         slug={experiment.slug}
         startDate={experiment.startDate}
@@ -61,6 +82,7 @@ storiesOf("components/HeaderExperiment", module)
   .add("status: live", () => (
     <AppLayout>
       <HeaderExperiment
+        parent={null}
         name={experiment.name}
         slug={experiment.slug}
         startDate={experiment.startDate}
@@ -74,6 +96,7 @@ storiesOf("components/HeaderExperiment", module)
   .add("status: complete", () => (
     <AppLayout>
       <HeaderExperiment
+        parent={null}
         name={experiment.name}
         slug={experiment.slug}
         startDate={experiment.startDate}
@@ -87,6 +110,7 @@ storiesOf("components/HeaderExperiment", module)
   .add("archived", () => (
     <AppLayout>
       <HeaderExperiment
+        parent={null}
         name={experiment.name}
         slug={experiment.slug}
         startDate={experiment.startDate}

--- a/app/experimenter/nimbus-ui/src/components/HeaderExperiment/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/HeaderExperiment/index.tsx
@@ -4,6 +4,7 @@
 
 import classNames from "classnames";
 import React from "react";
+import { BASE_PATH } from "../../lib/constants";
 import { humanDate } from "../../lib/dateUtils";
 import { StatusCheck } from "../../lib/experiment";
 import { getExperiment_experimentBySlug } from "../../types/getExperiment";
@@ -13,6 +14,7 @@ type HeaderExperimentProps = Pick<
   getExperiment_experimentBySlug,
   | "name"
   | "slug"
+  | "parent"
   | "startDate"
   | "computedEndDate"
   | "computedDurationDays"
@@ -22,6 +24,7 @@ type HeaderExperimentProps = Pick<
 const HeaderExperiment = ({
   name,
   slug,
+  parent,
   startDate = "",
   computedEndDate = "",
   status,
@@ -50,6 +53,14 @@ const HeaderExperiment = ({
     >
       {slug}
     </p>
+    {parent && (
+      <p
+        className="text-secondary mb-1 small"
+        data-testid="header-experiment-parent"
+      >
+        Cloned from <a href={`${BASE_PATH}/${parent.slug}`}>{parent.name}</a>
+      </p>
+    )}
     <div className="row">
       <div className="col">
         <p className="header-experiment-status position-relative mt-2 d-inline-block">

--- a/app/experimenter/nimbus-ui/src/gql/experiments.ts
+++ b/app/experimenter/nimbus-ui/src/gql/experiments.ts
@@ -46,6 +46,11 @@ export const GET_EXPERIMENT_QUERY = gql`
         email
       }
 
+      parent {
+        name
+        slug
+      }
+
       referenceBranch {
         name
         slug

--- a/app/experimenter/nimbus-ui/src/types/getExperiment.ts
+++ b/app/experimenter/nimbus-ui/src/types/getExperiment.ts
@@ -13,6 +13,11 @@ export interface getExperiment_experimentBySlug_owner {
   email: string;
 }
 
+export interface getExperiment_experimentBySlug_parent {
+  name: string;
+  slug: string;
+}
+
 export interface getExperiment_experimentBySlug_referenceBranch {
   name: string;
   slug: string;
@@ -113,6 +118,7 @@ export interface getExperiment_experimentBySlug {
   application: NimbusExperimentApplication | null;
   publicDescription: string;
   owner: getExperiment_experimentBySlug_owner;
+  parent: getExperiment_experimentBySlug_parent | null;
   referenceBranch: getExperiment_experimentBySlug_referenceBranch | null;
   treatmentBranches: (getExperiment_experimentBySlug_treatmentBranches | null)[] | null;
   featureConfig: getExperiment_experimentBySlug_featureConfig | null;


### PR DESCRIPTION
Because:

* we want to place cloned experiments in context with the original

This commit:

* adds a line to HeaderExperiment component identifying the experiment as a
  clone with a link back to the original parent

* updates GQL query and API to expose full parent experiment data, mainly for
  slug & name needed for the link

* updates types & tests as necessary