### PR TITLE
chore(nimbus): move integration test logic to base classes

### DIFF
--- a/app/tests/integration/nimbus/conftest.py
+++ b/app/tests/integration/nimbus/conftest.py
@@ -156,7 +156,6 @@ def create_experiment():
         audience.targeting = data.audience.targeting.value
         audience.percentage = data.audience.percentage
         audience.expected_clients = data.audience.expected_clients
-        audience.save_btn()
         review = audience.save_and_continue()
 
         # Review

--- a/app/tests/integration/nimbus/pages/experimenter/audience.py
+++ b/app/tests/integration/nimbus/pages/experimenter/audience.py
@@ -1,7 +1,7 @@
 from nimbus.models.base_dataclass import BaseExperimentAudienceTargetingOptions
 from nimbus.pages.experimenter.base import ExperimenterBase
+from nimbus.pages.experimenter.summary import SummaryPage
 from selenium.webdriver.common.by import By
-from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.select import Select
 
 
@@ -17,18 +17,7 @@ class AudiencePage(ExperimenterBase):
     _enrollment_period_locator = (By.CSS_SELECTOR, "#proposedEnrollment")
     _duration_locator = (By.CSS_SELECTOR, "#proposedDuration")
     _page_wait_locator = (By.CSS_SELECTOR, "#PageEditAudience")
-    _save_continue_btn_locator = (By.CSS_SELECTOR, "#save-and-continue-button")
-
-    def wait_for_page_to_load(self):
-        self.wait.until(EC.presence_of_element_located(self._page_wait_locator))
-        return self
-
-    def save_and_continue(self):
-        element = self.selenium.find_element(*self._save_continue_btn_locator)
-        element.click()
-        from nimbus.pages.experimenter.summary import SummaryPage
-
-        return SummaryPage(self.driver, self.base_url).wait_for_page_to_load()
+    NEXT_PAGE = SummaryPage
 
     @property
     def channel(self):

--- a/app/tests/integration/nimbus/pages/experimenter/base.py
+++ b/app/tests/integration/nimbus/pages/experimenter/base.py
@@ -1,5 +1,3 @@
-import time
-
 from nimbus.pages.base import Base
 from selenium.webdriver.common.by import By
 
@@ -9,17 +7,9 @@ class ExperimenterBase(Base):
 
     _save_btn_locator = (By.CSS_SELECTOR, "#save-button")
     _save_continue_btn_locator = (By.CSS_SELECTOR, "#save-and-continue-button")
+    NEXT_PAGE = None
 
     def save_and_continue(self):
         element = self.selenium.find_element(*self._save_continue_btn_locator)
         element.click()
-
-    def save_btn(self):
-        self.find_element(*self._save_btn_locator).click()
-        time.sleep(1)
-
-    def next_btn(self):
-        pass
-
-    def cancel_btn(self):
-        pass
+        return self.NEXT_PAGE(self.driver, self.base_url).wait_for_page_to_load()

--- a/app/tests/integration/nimbus/pages/experimenter/branches.py
+++ b/app/tests/integration/nimbus/pages/experimenter/branches.py
@@ -1,6 +1,6 @@
 from nimbus.pages.experimenter.base import ExperimenterBase
+from nimbus.pages.experimenter.metrics import MetricsPage
 from selenium.webdriver.common.by import By
-from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.select import Select
 
 
@@ -15,19 +15,7 @@ class BranchesPage(ExperimenterBase):
     )
     _remove_branch_locator = (By.CSS_SELECTOR, ".bg-transparent")
     _feature_select_locator = (By.CSS_SELECTOR, "#referenceBranch-featureConfig")
-    _save_continue_btn_locator = (By.CSS_SELECTOR, "#save-and-continue-button")
-
-    def wait_for_page_to_load(self):
-        self.wait.until(EC.presence_of_element_located(self._page_wait_locator))
-
-        return self
-
-    def save_and_continue(self):
-        element = self.selenium.find_element(*self._save_continue_btn_locator)
-        element.click()
-        from nimbus.pages.experimenter.metrics import MetricsPage
-
-        return MetricsPage(self.driver, self.base_url).wait_for_page_to_load()
+    NEXT_PAGE = MetricsPage
 
     @property
     def reference_branch_name(self):

--- a/app/tests/integration/nimbus/pages/experimenter/home.py
+++ b/app/tests/integration/nimbus/pages/experimenter/home.py
@@ -1,17 +1,14 @@
-from pypom import Page, Region
+from nimbus.pages.experimenter.base import Base
+from pypom import Region
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as EC
 
 
-class HomePage(Page):
+class HomePage(Base):
     """Nimbus Home page."""
 
     _page_wait_locator = (By.CSS_SELECTOR, "#PageHome-page")
     _create_new_btn_locator = (By.CSS_SELECTOR, "#create-new-button")
-
-    def wait_for_page_to_load(self):
-        self.wait.until(EC.visibility_of_element_located(self._page_wait_locator))
-        return self
 
     @property
     def tables(self):

--- a/app/tests/integration/nimbus/pages/experimenter/metrics.py
+++ b/app/tests/integration/nimbus/pages/experimenter/metrics.py
@@ -1,22 +1,10 @@
+from nimbus.pages.experimenter.audience import AudiencePage
 from nimbus.pages.experimenter.base import ExperimenterBase
 from selenium.webdriver.common.by import By
-from selenium.webdriver.support import expected_conditions as EC
 
 
 class MetricsPage(ExperimenterBase):
     """Experiment Metrics Page.."""
 
     _page_wait_locator = (By.CSS_SELECTOR, "#PageEditMetrics")
-    _save_continue_btn_locator = (By.CSS_SELECTOR, "#save-and-continue-button")
-
-    def wait_for_page_to_load(self):
-        self.wait.until(EC.presence_of_element_located(self._page_wait_locator))
-
-        return self
-
-    def save_and_continue(self):
-        element = self.selenium.find_element(*self._save_continue_btn_locator)
-        element.click()
-        from nimbus.pages.experimenter.audience import AudiencePage
-
-        return AudiencePage(self.driver, self.base_url).wait_for_page_to_load()
+    NEXT_PAGE = AudiencePage

--- a/app/tests/integration/nimbus/pages/experimenter/new_experiment.py
+++ b/app/tests/integration/nimbus/pages/experimenter/new_experiment.py
@@ -1,6 +1,6 @@
 from nimbus.pages.experimenter.base import ExperimenterBase
+from nimbus.pages.experimenter.overview import OverviewPage
 from selenium.webdriver.common.by import By
-from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.select import Select
 
 
@@ -12,12 +12,8 @@ class NewExperiment(ExperimenterBase):
     _hypothesis_locator = (By.CSS_SELECTOR, "#hypothesis")
     _application_select_locator = (By.CSS_SELECTOR, "#application")
     _cancel_btn_locator = (By.CSS_SELECTOR, ".btn-light")
-    _next_btn_locator = (By.CSS_SELECTOR, "#submit-button")
-
-    def wait_for_page_to_load(self):
-        self.wait.until(EC.presence_of_element_located(self._page_wait_locator))
-
-        return self
+    _save_continue_btn_locator = (By.CSS_SELECTOR, "#submit-button")
+    NEXT_PAGE = OverviewPage
 
     @property
     def public_name(self):
@@ -46,10 +42,3 @@ class NewExperiment(ExperimenterBase):
         el = self.find_element(*self._application_select_locator)
         select = Select(el)
         select.select_by_value(app)
-
-    def save_and_continue(self):
-        el = self.find_element(*self._next_btn_locator)
-        el.click()
-        from nimbus.pages.experimenter.overview import OverviewPage
-
-        return OverviewPage(self.driver, self.base_url).wait_for_page_to_load()

--- a/app/tests/integration/nimbus/pages/experimenter/overview.py
+++ b/app/tests/integration/nimbus/pages/experimenter/overview.py
@@ -1,6 +1,6 @@
 from nimbus.pages.experimenter.base import ExperimenterBase
+from nimbus.pages.experimenter.branches import BranchesPage
 from selenium.webdriver.common.by import By
-from selenium.webdriver.support import expected_conditions as EC
 
 
 class OverviewPage(ExperimenterBase):
@@ -11,18 +11,7 @@ class OverviewPage(ExperimenterBase):
     _risk_brand_locator = (By.CSS_SELECTOR, "#riskBrand-false")
     _risk_revenue_locator = (By.CSS_SELECTOR, "#riskRevenue-false")
     _risk_partner_locator = (By.CSS_SELECTOR, "#riskPartnerRelated-false")
-
-    def wait_for_page_to_load(self):
-        self.wait.until(EC.presence_of_element_located(self._page_wait_locator))
-
-        return self
-
-    def save_and_continue(self):
-        element = self.selenium.find_element(*self._save_continue_btn_locator)
-        element.click()
-        from nimbus.pages.experimenter.branches import BranchesPage
-
-        return BranchesPage(self.driver, self.base_url).wait_for_page_to_load()
+    NEXT_PAGE = BranchesPage
 
     @property
     def public_description(self):

--- a/app/tests/integration/nimbus/pages/experimenter/summary.py
+++ b/app/tests/integration/nimbus/pages/experimenter/summary.py
@@ -26,10 +26,6 @@ class SummaryPage(ExperimenterBase):
         'span[data-testid="header-experiment-status-archived"]',
     )
 
-    def wait_for_page_to_load(self):
-        self.wait.until(EC.presence_of_element_located(self._page_wait_locator))
-        return self
-
     def wait_for_archive_label_visible(self):
         self.wait.until(
             EC.presence_of_all_elements_located(self._archive_label_locator),


### PR DESCRIPTION
Because

* Now that we have nice clear base classes for the integration tests
* We don't need to override some shared logic in the child page classes

This commit

* Moves all the shared page logic to the respective base classes