### PR TITLE
chore(nimbus): use page.open in integration tests

### DIFF
--- a/app/tests/integration/nimbus/pages/experimenter/home.py
+++ b/app/tests/integration/nimbus/pages/experimenter/home.py
@@ -35,6 +35,19 @@ class HomePage(Base):
 
         return NewExperiment(self.driver, self.base_url).wait_for_page_to_load()
 
+    def find_in_table(self, table_name, experiment_name):
+        table_experiments = self.tables[0]
+        assert (
+            table_name in self.active_tab_text
+        ), f"Home Page: Table {table_name} not found in {self.active_tab_text}"
+        experiment_names = [
+            experiment.text for experiment in table_experiments.experiments
+        ]
+        assert experiment_name in experiment_names, (
+            f"Home Page: Experiment {experiment_name} not found in "
+            "{table_name} experiments: {experiment_names}"
+        )
+
     class Tables(Region):
 
         _experiment_link_locator = (By.CSS_SELECTOR, "tr a")

--- a/app/tests/integration/nimbus/pages/experimenter/summary.py
+++ b/app/tests/integration/nimbus/pages/experimenter/summary.py
@@ -78,7 +78,13 @@ class SummaryPage(ExperimenterBase):
         )
         self.find_element(*self._approve_request_button_locator).click()
 
-    def end_experiment(self, action="End"):
+    def launch_and_approve(self):
+        self.launch_without_preview.click()
+        self.request_review.click_launch_checkboxes()
+        self.request_review.request_launch_button.click()
+        self.approve()
+
+    def end_and_approve(self, action="End"):
         el = self.find_element(*self._end_experiment_button_locator)
         el.click()
         if action == "End":
@@ -89,6 +95,7 @@ class SummaryPage(ExperimenterBase):
             el.click()
         else:
             pass
+        self.approve()
 
     @property
     def rejected_text(self):
@@ -113,9 +120,8 @@ class SummaryPage(ExperimenterBase):
         def request_launch_button(self):
             return self.find_element(*self._request_launch_locator)
 
-    @property
-    def archive_button(self):
-        return self.find_element(*self._archive_button_locator)
+    def archive(self):
+        self.find_element(*self._archive_button_locator).click()
 
     @property
     def archive_label(self):

--- a/app/tests/integration/nimbus/test_experimenter.py
+++ b/app/tests/integration/nimbus/test_experimenter.py
@@ -6,48 +6,28 @@ from nimbus.pages.experimenter.summary import SummaryPage
 @pytest.mark.run_once
 def test_archive_experiment(
     selenium,
-    base_url,
     default_data,
     create_experiment,
+    archived_tab_url,
+    drafts_tab_url,
+    experiment_url,
 ):
-    selenium.get(base_url)
-    home = HomePage(selenium, base_url).wait_for_page_to_load()
+    # Archive the experiment
+    summary = create_experiment(selenium)
+    summary.archive()
+    summary.wait_for_archive_label_visible()
 
-    # Create experiment
-    summary_page = create_experiment(selenium, home, default_data)
+    # Check it's archived on the home page
+    HomePage(selenium, archived_tab_url).open().find_in_table(
+        "Archived", default_data.public_name
+    )
 
-    # Archive it on the summary page
-    summary_page.archive_button.click()
+    # Unarchive the experiment
+    summary = SummaryPage(selenium, experiment_url).open()
+    summary.archive()
+    summary.wait_for_archive_label_not_visible()
 
-    # Check it's archived on the summary page
-    summary_page.wait_for_archive_label_visible()
-
-    # Check it's archived on the directory page
-    archived_tab_url = f"{base_url}?tab=archived"
-    selenium.get(archived_tab_url)
-    home = HomePage(selenium, archived_tab_url).wait_for_page_to_load()
-    archived_experiments = home.tables[0]
-    assert "Archived" in home.active_tab_text
-    for archived_experiment in archived_experiments.experiments:
-        if default_data.public_name in archived_experiment.text:
-            archived_experiment.click()
-            summary_page = SummaryPage(selenium, base_url).wait_for_page_to_load()
-            break
-
-    # Unarchive it on the summary page
-    summary_page.archive_button.click()
-
-    # Check it's unarchived on the summary page
-    summary_page.wait_for_archive_label_not_visible()
-
-    # Check it's in draft on the directory page
-    draft_tab_url = f"{base_url}?tab=drafts"
-    selenium.get(draft_tab_url)
-    home = HomePage(selenium, draft_tab_url).wait_for_page_to_load()
-    draft_experiments = home.tables[0]
-    assert "Draft" in home.active_tab_text
-    for draft_experiment in draft_experiments.experiments:
-        if default_data.public_name in draft_experiment.text:
-            break
-    else:
-        raise Exception("Experiment was not found in draft list")
+    # Check it's in drafts on the home page
+    HomePage(selenium, drafts_tab_url).open().find_in_table(
+        "Draft", default_data.public_name
+    )

--- a/app/tests/integration/nimbus/test_remote_settings.py
+++ b/app/tests/integration/nimbus/test_remote_settings.py
@@ -1,5 +1,4 @@
 import pytest
-from nimbus.pages.experimenter.home import HomePage
 from nimbus.pages.experimenter.summary import SummaryPage
 from nimbus.pages.remote_settings.dashboard import Dashboard
 from nimbus.pages.remote_settings.login import Login
@@ -15,158 +14,79 @@ def test_create_new_experiment_approve_remote_settings(
     default_data,
     create_experiment,
 ):
-    selenium.get(base_url)
-    home = HomePage(selenium, base_url).wait_for_page_to_load()
+    create_experiment(selenium).launch_and_approve()
 
-    summary = create_experiment(selenium, home, default_data)
-    summary.launch_without_preview.click()
-    summary.request_review.click_launch_checkboxes()
-    summary.request_review.request_launch_button.click()
-    summary.approve()
+    Login(selenium, kinto_url).open().login()
+    Dashboard(selenium, kinto_review_url).open().approve()
 
-    selenium.get(kinto_url)
-    kinto_login = Login(selenium, kinto_url).wait_for_page_to_load()
-    kinto_login.login()
-
-    selenium.get(kinto_review_url)
-    kinto_dashboard = Dashboard(selenium, kinto_review_url).wait_for_page_to_load()
-    kinto_dashboard.approve()
-
-    selenium.get(experiment_url)
-    summary = SummaryPage(selenium, experiment_url).wait_for_page_to_load()
-    summary.wait_for_live_status()
+    SummaryPage(selenium, experiment_url).open().wait_for_live_status()
 
 
 @pytest.mark.run_once
 def test_create_new_experiment_reject_remote_settings(
     selenium,
-    base_url,
     kinto_url,
     kinto_review_url,
     experiment_url,
-    default_data,
     create_experiment,
 ):
-    selenium.get(base_url)
-    home = HomePage(selenium, base_url).wait_for_page_to_load()
+    create_experiment(selenium).launch_and_approve()
 
-    summary = create_experiment(selenium, home, default_data)
-    summary.launch_without_preview.click()
-    summary.request_review.click_launch_checkboxes()
-    summary.request_review.request_launch_button.click()
-    summary.approve()
+    Login(selenium, kinto_url).open().login()
+    Dashboard(selenium, kinto_review_url).open().reject()
 
-    selenium.get(kinto_url)
-    kinto_login = Login(selenium, kinto_url).wait_for_page_to_load()
-    kinto_login.login()
-
-    selenium.get(kinto_review_url)
-    kinto_dashboard = Dashboard(selenium, kinto_review_url).wait_for_page_to_load()
-    kinto_dashboard.reject()
-
-    selenium.get(experiment_url)
-    summary = SummaryPage(selenium, experiment_url).wait_for_page_to_load()
-    summary.wait_for_rejected_alert()
+    SummaryPage(selenium, experiment_url).open().wait_for_rejected_alert()
 
 
 @pytest.mark.run_once
 def test_create_new_experiment_timeout_remote_settings(
     selenium,
-    base_url,
-    default_data,
     create_experiment,
 ):
-    selenium.get(base_url)
-    home = HomePage(selenium, base_url).wait_for_page_to_load()
-
-    summary = create_experiment(selenium, home, default_data)
-    summary.launch_without_preview.click()
-    summary.request_review.click_launch_checkboxes()
-    summary.request_review.request_launch_button.click()
-    summary.approve()
-
+    summary = create_experiment(selenium)
+    summary.launch_and_approve()
     summary.wait_for_timeout_alert()
 
 
 @pytest.mark.run_once
 def test_end_experiment_and_approve_end(
     selenium,
-    base_url,
     kinto_url,
     kinto_review_url,
     experiment_url,
-    default_data,
     create_experiment,
 ):
-    selenium.get(base_url)
-    home = HomePage(selenium, base_url).wait_for_page_to_load()
+    create_experiment(selenium).launch_and_approve()
 
-    summary = create_experiment(selenium, home, default_data)
-    summary.launch_without_preview.click()
-    summary.request_review.click_launch_checkboxes()
-    summary.request_review.request_launch_button.click()
-    summary.approve()
+    Login(selenium, kinto_url).open().login()
+    Dashboard(selenium, kinto_review_url).open().approve()
 
-    selenium.get(kinto_url)
-    kinto_login = Login(selenium, kinto_url).wait_for_page_to_load()
-    kinto_login.login()
-
-    selenium.get(kinto_review_url)
-    kinto_dashboard = Dashboard(selenium, kinto_review_url).wait_for_page_to_load()
-    kinto_dashboard.approve()
-
-    selenium.get(experiment_url)
-    summary = SummaryPage(selenium, experiment_url).wait_for_page_to_load()
+    summary = SummaryPage(selenium, experiment_url).open()
     summary.wait_for_live_status()
-    summary.end_experiment()
-    summary.approve()
+    summary.end_and_approve()
 
-    selenium.get(kinto_review_url)
-    kinto_dashboard = Dashboard(selenium, kinto_review_url).wait_for_page_to_load()
-    kinto_dashboard.approve()
+    Dashboard(selenium, kinto_review_url).open().approve()
 
-    selenium.get(experiment_url)
-    summary = SummaryPage(selenium, experiment_url).wait_for_page_to_load()
-    summary.wait_for_complete_status()
+    SummaryPage(selenium, experiment_url).open().wait_for_complete_status()
 
 
 @pytest.mark.run_once
 def test_end_experiment_and_reject_end(
     selenium,
-    base_url,
     kinto_url,
     kinto_review_url,
     experiment_url,
-    default_data,
     create_experiment,
 ):
-    selenium.get(base_url)
-    home = HomePage(selenium, base_url).wait_for_page_to_load()
+    create_experiment(selenium).launch_and_approve()
 
-    summary = create_experiment(selenium, home, default_data)
-    summary.launch_without_preview.click()
-    summary.request_review.click_launch_checkboxes()
-    summary.request_review.request_launch_button.click()
-    summary.approve()
+    Login(selenium, kinto_url).open().login()
+    Dashboard(selenium, kinto_review_url).open().approve()
 
-    selenium.get(kinto_url)
-    kinto_login = Login(selenium, kinto_url).wait_for_page_to_load()
-    kinto_login.login()
-
-    selenium.get(kinto_review_url)
-    kinto_dashboard = Dashboard(selenium, kinto_review_url).wait_for_page_to_load()
-    kinto_dashboard.approve()
-
-    selenium.get(experiment_url)
-    summary = SummaryPage(selenium, experiment_url).wait_for_page_to_load()
+    summary = SummaryPage(selenium, experiment_url).open()
     summary.wait_for_live_status()
-    summary.end_experiment()
-    summary.approve()
+    summary.end_and_approve()
 
-    selenium.get(kinto_review_url)
-    kinto_dashboard = Dashboard(selenium, kinto_review_url).wait_for_page_to_load()
-    kinto_dashboard.reject()
+    Dashboard(selenium, kinto_review_url).open().reject()
 
-    selenium.get(experiment_url)
-    summary = SummaryPage(selenium, experiment_url).wait_for_page_to_load()
-    summary.wait_for_rejected_alert()
+    SummaryPage(selenium, experiment_url).open().wait_for_rejected_alert()


### PR DESCRIPTION
Because

* The integration test PyPom library provides a handy .open method that opens the page and waits for it to load
* This can clean up a lot of code in the tests

This commit

* Uses .open in all the integration tests