### PR TITLE
fix #6303 fix(nimbus): do not flash archive tooltip during mutation query request

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/SidebarActions/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/SidebarActions/index.test.tsx
@@ -30,6 +30,7 @@ describe("SidebarActions", () => {
       screen.queryByTestId("tooltip-archived-disabled"),
     ).not.toBeInTheDocument();
   });
+
   it("renders a disabled unarchive button for archived experiment", () => {
     render(<Subject experiment={{ isArchived: true, canArchive: false }} />);
     expect(screen.getByTestId("action-archive")).toHaveClass("text-muted");
@@ -45,6 +46,7 @@ describe("SidebarActions", () => {
       screen.queryByTestId("tooltip-archived-disabled"),
     ).not.toBeInTheDocument();
   });
+
   it("calls update archive mutation when archive button is clicked", async () => {
     const experiment = mockExperiment({ isArchived: false, canArchive: true });
     const refetch = jest.fn();
@@ -64,12 +66,21 @@ describe("SidebarActions", () => {
     render(<Subject {...{ experiment, refetch }} mocks={[mutationMock]} />);
 
     const archiveButton = await screen.findByTestId("action-archive");
-
     fireEvent.click(archiveButton);
+
+    // Issue #6303: Expect disable button during loading, but not the tooltip
+    await waitFor(() => {
+      expect(screen.getByTestId("action-archive")).toHaveClass("text-muted");
+      expect(
+        screen.queryByTestId("tooltip-archived-disabled"),
+      ).not.toBeInTheDocument();
+    });
+
     await waitFor(() => {
       expect(refetch).toHaveBeenCalled();
     });
   });
+
   it("calls update archive mutation when unarchive button is clicked", async () => {
     const experiment = mockExperiment({ isArchived: true, canArchive: true });
     const refetch = jest.fn();

--- a/app/experimenter/nimbus-ui/src/components/SidebarActions/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/SidebarActions/index.tsx
@@ -25,7 +25,7 @@ export const SidebarActions = ({
   refetch,
 }: SidebarModifyExperimentProps) => {
   const {
-    isLoading,
+    isLoading: archiveIsLoading,
     callbacks: [onUpdateArchived],
   } = useChangeOperationMutation(experiment, refetch, {
     isArchived: !experiment.isArchived,
@@ -34,7 +34,7 @@ export const SidebarActions = ({
       : CHANGELOG_MESSAGES.UNARCHIVING_EXPERIMENT,
   });
 
-  const archiveDisabled = !experiment.canArchive || isLoading;
+  const archiveDisabled = !experiment.canArchive;
 
   const cloneDialogProps = useCloneDialog(experiment);
 
@@ -65,7 +65,7 @@ export const SidebarActions = ({
           route={`${experiment.slug}/#`}
           testid="action-archive"
           onClick={onUpdateArchived}
-          {...{ disabled: archiveDisabled }}
+          {...{ disabled: archiveDisabled || archiveIsLoading }}
         >
           <TrashIcon className="sidebar-icon" />
           {experiment.isArchived ? "Unarchive" : "Archive"}


### PR DESCRIPTION
Because:

* the archive button is disabled during loading, but this is not the
  same as the archive action being disabled altogether

This commit:

* separates archive disabled state from archive query loading state,
  only showing the explanatory tooltip during the former state