### PR TITLE
fix #6243 fix(nimbus): do not display invalid pages alert for an archived experiment

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/ChangeApprovalOperations/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/ChangeApprovalOperations/index.stories.tsx
@@ -5,12 +5,14 @@
 import { action } from "@storybook/addon-actions";
 import { withLinks } from "@storybook/addon-links";
 import React from "react";
+import { getStatus } from "../../lib/experiment";
 import { mockChangelog } from "../../lib/mocks";
 import FormApproveOrReject from "./FormApproveOrReject";
 import FormRejectReason from "./FormRejectReason";
 import FormRemoteSettingsPending from "./FormRemoteSettingsPending";
 import {
   BaseSubject,
+  MOCK_EXPERIMENT,
   reviewPendingInRemoteSettingsBaseProps,
   reviewRejectedBaseProps,
   reviewRequestedBaseProps,
@@ -49,6 +51,26 @@ const storyWithProps = (
   if (storyName) story.storyName = storyName;
   return story;
 };
+
+export const WithInvalidPages = storyWithProps(
+  {
+    ...reviewRequestedBaseProps,
+    invalidPages: ["overview", "thingy", "frobnitz"],
+    InvalidPagesList: () => <span>overview, thingy, and frobnitz</span>,
+  },
+  "With invalid pages",
+);
+
+export const WithInvalidPagesAndArchived = storyWithProps(
+  {
+    ...reviewRequestedBaseProps,
+    status: { ...getStatus(MOCK_EXPERIMENT), archived: true, draft: true },
+    invalidPages: ["overview", "thingy", "frobnitz"],
+    InvalidPagesList: () => <span>overview, thingy, and frobnitz</span>,
+    children: <p>This space left intentionally blank.</p>,
+  },
+  "With invalid pages (archived)",
+);
 
 export const ReviewNotRequested = storyWithProps({}, "Review not requested");
 

--- a/app/experimenter/nimbus-ui/src/components/ChangeApprovalOperations/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/ChangeApprovalOperations/index.test.tsx
@@ -11,12 +11,14 @@ import {
 } from "@testing-library/react";
 import React from "react";
 import { LIFECYCLE_REVIEW_FLOWS } from "../../lib/constants";
+import { getStatus } from "../../lib/experiment";
 import {
   NimbusChangeLogOldStatus,
   NimbusChangeLogOldStatusNext,
 } from "../../types/globalTypes";
 import {
   BaseSubject,
+  MOCK_EXPERIMENT,
   reviewApprovedAfterTimeoutBaseProps,
   reviewPendingInRemoteSettingsBaseProps,
   reviewRejectedBaseProps,
@@ -44,6 +46,44 @@ describe("ChangeApprovalOperations", () => {
   it("renders as expected", async () => {
     render(<Subject />);
     await screen.findByTestId("action-button");
+  });
+
+  it("displays an invalid pages warning when details are missing", async () => {
+    const expectedInvalidPages = "overview, thingy, and frobnitz";
+    render(
+      <Subject
+        {...{
+          ...reviewRequestedBaseProps,
+          canReview: true,
+          invalidPages: ["overview", "thingy", "frobnitz"],
+          InvalidPagesList: () => <span>{expectedInvalidPages}</span>,
+        }}
+      />,
+    );
+    const invalidPagesAlert = screen.queryByTestId("invalid-pages");
+    expect(invalidPagesAlert).toBeInTheDocument();
+    expect(invalidPagesAlert!.textContent).toContain(expectedInvalidPages);
+  });
+
+  it("does not display an invalid pages warning when details are missing from an archived experiment", async () => {
+    const expectedInvalidPages = "overview, thingy, and frobnitz";
+    render(
+      <Subject
+        {...{
+          ...reviewRequestedBaseProps,
+          status: {
+            ...getStatus(MOCK_EXPERIMENT),
+            archived: true,
+            draft: true,
+          },
+          canReview: true,
+          invalidPages: ["overview", "thingy", "frobnitz"],
+          InvalidPagesList: () => <span>{expectedInvalidPages}</span>,
+        }}
+      />,
+    );
+    const invalidPagesAlert = screen.queryByTestId("invalid-pages");
+    expect(invalidPagesAlert).not.toBeInTheDocument();
   });
 
   it("when user can review, supports approval and opening remote settings", async () => {

--- a/app/experimenter/nimbus-ui/src/components/ChangeApprovalOperations/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/ChangeApprovalOperations/index.tsx
@@ -61,6 +61,11 @@ export const ChangeApprovalOperations: React.FC<
   children,
 }) => {
   const defaultUIState = useMemo(() => {
+    if (status.archived) {
+      // No changes to be approved with an archived experiment
+      return ChangeApprovalOperationsState.None;
+    }
+
     if (invalidPages.length > 0 && status.draft) {
       return ChangeApprovalOperationsState.InvalidPages;
     }
@@ -95,7 +100,7 @@ export const ChangeApprovalOperations: React.FC<
   switch (uiState) {
     case ChangeApprovalOperationsState.InvalidPages:
       return (
-        <Alert variant="warning">
+        <Alert variant="warning" data-testid="invalid-pages">
           Before this experiment can be reviewed or launched, all required
           fields must be completed. Fields on the <InvalidPagesList />{" "}
           {invalidPages.length === 1 ? "page" : "pages"} are missing details.

--- a/app/experimenter/nimbus-ui/src/components/ChangeApprovalOperations/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/components/ChangeApprovalOperations/mocks.tsx
@@ -24,14 +24,14 @@ type BaseSubjectProps = Partial<
 export const REVIEW_URL =
   "http://localhost:8888/v1/admin/#/buckets/main-workspace/collections/nimbus-mobile-experiments/records";
 
-const { experiment } = mockExperimentQuery("boo");
+export const { experiment: MOCK_EXPERIMENT } = mockExperimentQuery("boo");
 
 export const BaseSubject = ({
   actionButtonTitle = "Frobulate Thingy",
   actionDescription = "frobulate the thingy",
   isLoading = false,
   canReview = false,
-  status = getStatus(experiment),
+  status = getStatus(MOCK_EXPERIMENT),
   publishStatus = NimbusExperimentPublishStatus.IDLE,
   reviewRequestEvent,
   rejectionEvent,
@@ -40,6 +40,11 @@ export const BaseSubject = ({
   approveChange = () => {},
   invalidPages = [],
   InvalidPagesList = () => <span />,
+  children = (
+    <Button data-testid="action-button" className="mr-2 btn btn-success">
+      Frobulate Thingy
+    </Button>
+  ),
   ...props
 }: BaseSubjectProps) => (
   <ChangeApprovalOperations
@@ -61,9 +66,7 @@ export const BaseSubject = ({
       ...props,
     }}
   >
-    <Button data-testid="action-button" className="mr-2 btn btn-success">
-      Frobulate Thingy
-    </Button>
+    {children}
   </ChangeApprovalOperations>
 );
 


### PR DESCRIPTION
Because:

* archived experiments cannot be changed

This commit:

* prevents the display of the alert listing pages with missing details
  for an archived experiment