### PR TITLE
fix #6343 fix(nimbus): include documentation links in cloning

### DIFF
--- a/app/experimenter/experiments/models/nimbus.py
+++ b/app/experimenter/experiments/models/nimbus.py
@@ -482,6 +482,11 @@ class NimbusExperiment(NimbusConstants, FilterMixin, models.Model):
             branch.experiment = cloned
             branch.save()
 
+        for link in self.documentation_links.all():
+            link.id = None
+            link.experiment = cloned
+            link.save()
+
         if self.reference_branch:
             cloned.reference_branch = cloned.branches.get(slug=self.reference_branch.slug)
             cloned.save()

--- a/app/experimenter/experiments/tests/test_models/test_models_nimbus.py
+++ b/app/experimenter/experiments/tests/test_models/test_models_nimbus.py
@@ -1025,6 +1025,9 @@ class TestNimbusExperiment(TestCase):
             self.assertEqual(child_branch.description, parent_branch.description)
             self.assertEqual(child_branch.ratio, parent_branch.ratio)
             self.assertEqual(child_branch.feature_value, parent_branch.feature_value)
+        for parent_link in parent.documentation_links.all():
+            child_link = child.documentation_links.get(title=parent_link.title)
+            self.assertEqual(child_link.link, parent_link.link)
         self.assertEqual(child.changes.all().count(), 1)
 
 


### PR DESCRIPTION
Because:

* documentation links should be copied during cloning

This commit:

* ensures that the links are copied