### PR TITLE
fix #6338 fix(nimbus): use experiment duration as enrollment duration if experiment ends before pause

### DIFF
--- a/app/experimenter/experiments/models/nimbus.py
+++ b/app/experimenter/experiments/models/nimbus.py
@@ -318,8 +318,9 @@ class NimbusExperiment(NimbusConstants, FilterMixin, models.Model):
         )
         if paused_change:
             return (paused_change.changed_on.date() - self.start_date).days
-        else:
-            return self.proposed_enrollment
+        if self.end_date:
+            return self.computed_duration_days
+        return self.proposed_enrollment
 
     @property
     def computed_end_date(self):

--- a/app/experimenter/experiments/tests/factories/nimbus.py
+++ b/app/experimenter/experiments/tests/factories/nimbus.py
@@ -160,6 +160,12 @@ class Lifecycles(Enum):
     ENDING_APPROVE_TIMEOUT = ENDING_APPROVE_WAITING + (
         LifecycleStates.LIVE_REVIEW_ENDING,
     )
+    ENDING_APPROVE_APPROVE_WITHOUT_PAUSE = LIVE_ENROLLING + (
+        LifecycleStates.LIVE_REVIEW_ENDING,
+        LifecycleStates.LIVE_APPROVED_ENDING,
+        LifecycleStates.LIVE_WAITING_ENDING,
+        LifecycleStates.COMPLETE_IDLE,
+    )
 
 
 class NimbusExperimentFactory(factory.django.DjangoModelFactory):

--- a/app/experimenter/experiments/tests/test_models/test_models_nimbus.py
+++ b/app/experimenter/experiments/tests/test_models/test_models_nimbus.py
@@ -486,9 +486,30 @@ class TestNimbusExperiment(TestCase):
             3,
         )
 
+    def test_computed_enrollment_days_uses_end_date_without_pause(self):
+        expected_days = 5
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.ENDING_APPROVE_APPROVE_WITHOUT_PAUSE,
+            proposed_enrollment=99,
+        )
+        experiment.changes.filter(
+            old_status=NimbusExperiment.Status.DRAFT,
+            new_status=NimbusExperiment.Status.LIVE,
+        ).update(
+            changed_on=datetime.datetime.now() - datetime.timedelta(days=expected_days)
+        )
+        experiment.changes.filter(
+            old_status=NimbusExperiment.Status.LIVE,
+            new_status=NimbusExperiment.Status.COMPLETE,
+        ).update(changed_on=datetime.datetime.now())
+        self.assertEqual(
+            experiment.computed_enrollment_days,
+            expected_days,
+        )
+
     def test_computed_enrollment_days_returns_fallback(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperimentFactory.Lifecycles.CREATED
+            NimbusExperimentFactory.Lifecycles.CREATED,
         )
 
         self.assertEqual(


### PR DESCRIPTION
Because:

* experiments can be ended before enrollment is paused

This commit:

* switches to experiment duration rather than proposed duration if
  enrollment wasn't explicitly ended