### PR TITLE
Fix #6361: fix(visualization) Skip over outcome metrics with no data.

### DIFF
--- a/app/experimenter/jetstream/models.py
+++ b/app/experimenter/jetstream/models.py
@@ -236,7 +236,11 @@ class ResultsObjectModelBase(BaseModel):
                 primary_metric_data = getattr(
                     getattr(branch_data, METRIC_GROUP.get(primary_metric, Group.OTHER)),
                     primary_metric,
+                    None,
                 )
+                if primary_metric_data is None:
+                    continue
+
                 absolute_primary_metric_vals = getattr(
                     primary_metric_data, BranchComparison.ABSOLUTE
                 )

--- a/app/experimenter/jetstream/tests/constants.py
+++ b/app/experimenter/jetstream/tests/constants.py
@@ -202,9 +202,6 @@ class TestConstants:
                         ),
                         "some_count": EMPTY_METRIC_DATA.dict(exclude_none=True),
                         "another_count": EMPTY_METRIC_DATA.dict(exclude_none=True),
-                        "mozilla_default_browser": EMPTY_METRIC_DATA.dict(
-                            exclude_none=True
-                        ),
                         "default_browser_action": EMPTY_METRIC_DATA.dict(
                             exclude_none=True
                         ),

--- a/app/experimenter/jetstream/tests/test_tasks.py
+++ b/app/experimenter/jetstream/tests/test_tasks.py
@@ -39,7 +39,7 @@ class TestFetchJetstreamDataTask(TestCase):
         ).dict(exclude_none=True)
 
     def add_outcome_data(self, data, overall_data, weekly_data, primary_outcome):
-        primary_metrics = ["mozilla_default_browser", "default_browser_action"]
+        primary_metrics = ["default_browser_action"]
         range_data = DataPoint(lower=2, point=4, upper=8)
 
         for primary_metric in primary_metrics:

--- a/app/experimenter/nimbus-ui/src/components/PageResults/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/index.tsx
@@ -123,15 +123,24 @@ const PageResults: React.FunctionComponent<RouteComponentProps> = () => {
                   const outcome = configOutcomes!.find((set) => {
                     return set?.slug === slug;
                   });
-                  return outcome?.metrics?.map((metric) => (
-                    <TableMetricCount
-                      key={metric?.slug}
-                      outcomeSlug={metric?.slug!}
-                      outcomeDefaultName={metric?.friendlyName!}
-                      group={GROUP.OTHER}
-                      metricType={METRIC_TYPE.PRIMARY}
-                    />
-                  ));
+                  return outcome?.metrics?.map((metric) => {
+                    if (
+                      !analysis!.overall![resultsContextValue.controlBranchName]
+                        .branch_data[GROUP.OTHER][metric?.slug!]
+                    ) {
+                      // Primary metric does not have data to display.
+                      return;
+                    }
+                    return (
+                      <TableMetricCount
+                        key={metric?.slug}
+                        outcomeSlug={metric?.slug!}
+                        outcomeDefaultName={metric?.friendlyName!}
+                        group={GROUP.OTHER}
+                        metricType={METRIC_TYPE.PRIMARY}
+                      />
+                    );
+                  });
                 })}
               {analysis.overall &&
                 experiment.secondaryOutcomes?.map((slug) => {

--- a/app/experimenter/nimbus-ui/src/lib/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/lib/mocks.tsx
@@ -235,6 +235,20 @@ export const MOCK_CONFIG: getConfig_nimbusConfig = {
       ],
     },
     {
+      friendlyName: "Feature No Data",
+      slug: "feature_nodata",
+      application: NimbusExperimentApplication.DESKTOP,
+      description: "meep",
+      isDefault: false,
+      metrics: [
+        {
+          slug: "feature_nodata",
+          friendlyName: "Feature No Data",
+          description: "Test",
+        },
+      ],
+    },
+    {
       friendlyName: "Feature D",
       slug: "feature_d",
       application: NimbusExperimentApplication.FENIX,
@@ -438,7 +452,7 @@ export function mockExperiment<
           featureEnabled: true,
         },
       ],
-      primaryOutcomes: ["picture_in_picture", "feature_c"],
+      primaryOutcomes: ["picture_in_picture", "feature_c", "feature_nodata"],
       secondaryOutcomes: ["feature_b"],
       channel: "NIGHTLY",
       firefoxMinVersion: "FIREFOX_83",


### PR DESCRIPTION
Because:
* Results pages were failing to load if a metric was listed as an outcome metric but it had no data

This commit:
* Will gracefully ignore outcome metrics that don't have data.