### PR TITLE
chore(nimbus): reduce margin in sidebar

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/LinkNav/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/LinkNav/index.tsx
@@ -28,7 +28,7 @@ export const LinkNav = ({
   disabled = false,
   storiesOf = "",
   testid = "nav-home",
-  className = "mx-1 my-3",
+  className = "mx-1 my-2",
   textColor,
   title,
   onClick,


### PR DESCRIPTION
Because

* We accidentally added a bit too much margin in the sidebar

This commit

* Brings it back down