### PR TITLE
chore(nimbus): rename config api fields

### DIFF
--- a/app/experimenter/experiments/api/v5/types.py
+++ b/app/experimenter/experiments/api/v5/types.py
@@ -92,7 +92,7 @@ class NimbusExperimentApplicationConfig(graphene.ObjectType):
     supports_locale_country = graphene.Boolean()
 
 
-class NimbusExperimentTargetingConfigSlugChoice(graphene.ObjectType):
+class NimbusExperimentTargetingConfig(graphene.ObjectType):
     label = graphene.String()
     value = graphene.String()
     application_values = graphene.List(graphene.String)
@@ -175,18 +175,18 @@ class NimbusSignoffRecommendationsType(graphene.ObjectType):
 
 
 class NimbusConfigurationType(graphene.ObjectType):
-    application = graphene.List(NimbusLabelValueType)
-    channel = graphene.List(NimbusLabelValueType)
     application_configs = graphene.List(NimbusExperimentApplicationConfig)
-    feature_config = graphene.List(NimbusFeatureConfigType)
-    firefox_min_version = graphene.List(NimbusLabelValueType)
-    outcomes = graphene.List(NimbusOutcomeType)
-    targeting_config_slug = graphene.List(NimbusExperimentTargetingConfigSlugChoice)
-    hypothesis_default = graphene.String()
-    max_primary_outcomes = graphene.Int()
-    documentation_link = graphene.List(NimbusLabelValueType)
-    locales = graphene.List(NimbusLocaleType)
+    applications = graphene.List(NimbusLabelValueType)
+    channels = graphene.List(NimbusLabelValueType)
     countries = graphene.List(NimbusCountryType)
+    documentation_link = graphene.List(NimbusLabelValueType)
+    feature_configs = graphene.List(NimbusFeatureConfigType)
+    firefox_versions = graphene.List(NimbusLabelValueType)
+    hypothesis_default = graphene.String()
+    locales = graphene.List(NimbusLocaleType)
+    max_primary_outcomes = graphene.Int()
+    outcomes = graphene.List(NimbusOutcomeType)
+    targeting_configs = graphene.List(NimbusExperimentTargetingConfig)
 
     def _text_choices_to_label_value_list(root, text_choices):
         return [
@@ -197,10 +197,10 @@ class NimbusConfigurationType(graphene.ObjectType):
             for name in text_choices.names
         ]
 
-    def resolve_application(root, info):
+    def resolve_applications(root, info):
         return root._text_choices_to_label_value_list(NimbusExperiment.Application)
 
-    def resolve_channel(root, info):
+    def resolve_channels(root, info):
         return root._text_choices_to_label_value_list(NimbusExperiment.Channel)
 
     def resolve_application_configs(root, info):
@@ -220,18 +220,18 @@ class NimbusConfigurationType(graphene.ObjectType):
             )
         return configs
 
-    def resolve_feature_config(root, info):
+    def resolve_feature_configs(root, info):
         return NimbusFeatureConfig.objects.all()
 
-    def resolve_firefox_min_version(root, info):
+    def resolve_firefox_versions(root, info):
         return root._text_choices_to_label_value_list(NimbusExperiment.Version)
 
     def resolve_outcomes(root, info):
         return Outcomes.all()
 
-    def resolve_targeting_config_slug(root, info):
+    def resolve_targeting_configs(root, info):
         return [
-            NimbusExperimentTargetingConfigSlugChoice(
+            NimbusExperimentTargetingConfig(
                 label=choice.label,
                 value=choice.value,
                 application_values=NimbusExperiment.TARGETING_CONFIGS[

--- a/app/experimenter/experiments/tests/api/v5/test_queries.py
+++ b/app/experimenter/experiments/tests/api/v5/test_queries.py
@@ -845,11 +845,11 @@ class TestNimbusConfigQuery(GraphQLTestCase):
             """
             query{
                 nimbusConfig{
-                    application {
+                    applications {
                         label
                         value
                     }
-                    channel {
+                    channels {
                         label
                         value
                     }
@@ -861,11 +861,11 @@ class TestNimbusConfigQuery(GraphQLTestCase):
                         }
                         supportsLocaleCountry
                     }
-                    firefoxMinVersion {
+                    firefoxVersions {
                         label
                         value
                     }
-                    featureConfig {
+                    featureConfigs {
                         name
                         slug
                         id
@@ -877,7 +877,7 @@ class TestNimbusConfigQuery(GraphQLTestCase):
                         application
                         description
                     }
-                    targetingConfigSlug {
+                    targetingConfigs {
                         label
                         value
                         applicationValues
@@ -911,11 +911,11 @@ class TestNimbusConfigQuery(GraphQLTestCase):
                 self.assertEqual(data[index]["label"], text_choices[name].label)
                 self.assertEqual(data[index]["value"], name)
 
-        assertChoices(config["application"], NimbusExperiment.Application)
-        assertChoices(config["channel"], NimbusExperiment.Channel)
-        assertChoices(config["firefoxMinVersion"], NimbusExperiment.Version)
+        assertChoices(config["applications"], NimbusExperiment.Application)
+        assertChoices(config["channels"], NimbusExperiment.Channel)
+        assertChoices(config["firefoxVersions"], NimbusExperiment.Version)
         assertChoices(config["documentationLink"], NimbusExperiment.DocumentationLink)
-        self.assertEqual(len(config["featureConfig"]), 15)
+        self.assertEqual(len(config["featureConfigs"]), 15)
 
         for application_config_data in config["applicationConfigs"]:
             application_config = NimbusExperiment.APPLICATION_CONFIGS[
@@ -947,14 +947,14 @@ class TestNimbusConfigQuery(GraphQLTestCase):
             )
 
         for feature_config in feature_configs:
-            config_feature_config = next(
-                filter(lambda f: f["id"] == feature_config.id, config["featureConfig"])
-            )
-            self.assertEqual(config_feature_config["id"], feature_config.id)
-            self.assertEqual(config_feature_config["name"], feature_config.name)
-            self.assertEqual(config_feature_config["slug"], feature_config.slug)
-            self.assertEqual(
-                config_feature_config["description"], feature_config.description
+            self.assertIn(
+                {
+                    "id": feature_config.id,
+                    "name": feature_config.name,
+                    "slug": feature_config.slug,
+                    "description": feature_config.description,
+                },
+                config["featureConfigs"],
             )
 
         for choice in NimbusExperiment.TargetingConfig:
@@ -968,7 +968,7 @@ class TestNimbusConfigQuery(GraphQLTestCase):
                         ].application_choice_names
                     ),
                 },
-                config["targetingConfigSlug"],
+                config["targetingConfigs"],
             )
 
         self.assertEqual(config["hypothesisDefault"], NimbusExperiment.HYPOTHESIS_DEFAULT)

--- a/app/experimenter/nimbus-ui/schema.graphql
+++ b/app/experimenter/nimbus-ui/schema.graphql
@@ -139,18 +139,18 @@ type NimbusChangeLogType {
 }
 
 type NimbusConfigurationType {
-  application: [NimbusLabelValueType]
-  channel: [NimbusLabelValueType]
   applicationConfigs: [NimbusExperimentApplicationConfig]
-  featureConfig: [NimbusFeatureConfigType]
-  firefoxMinVersion: [NimbusLabelValueType]
-  outcomes: [NimbusOutcomeType]
-  targetingConfigSlug: [NimbusExperimentTargetingConfigSlugChoice]
-  hypothesisDefault: String
-  maxPrimaryOutcomes: Int
-  documentationLink: [NimbusLabelValueType]
-  locales: [NimbusLocaleType]
+  applications: [NimbusLabelValueType]
+  channels: [NimbusLabelValueType]
   countries: [NimbusCountryType]
+  documentationLink: [NimbusLabelValueType]
+  featureConfigs: [NimbusFeatureConfigType]
+  firefoxVersions: [NimbusLabelValueType]
+  hypothesisDefault: String
+  locales: [NimbusLocaleType]
+  maxPrimaryOutcomes: Int
+  outcomes: [NimbusOutcomeType]
+  targetingConfigs: [NimbusExperimentTargetingConfig]
 }
 
 type NimbusCountryType {
@@ -307,7 +307,7 @@ enum NimbusExperimentStatus {
   COMPLETE
 }
 
-type NimbusExperimentTargetingConfigSlugChoice {
+type NimbusExperimentTargetingConfig {
   label: String
   value: String
   applicationValues: [String]

--- a/app/experimenter/nimbus-ui/src/components/FormOverview/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/FormOverview/index.tsx
@@ -63,7 +63,7 @@ const FormOverview = ({
   onSubmit,
   onCancel,
 }: FormOverviewProps) => {
-  const { application, hypothesisDefault } = useConfig();
+  const { applications, hypothesisDefault } = useConfig();
   const { fieldMessages } = useReviewCheck(experiment);
 
   const defaultValues = {
@@ -193,7 +193,7 @@ const FormOverview = ({
             <Form.Control
               as="input"
               value={
-                application!.find((a) => a?.value === experiment.application)
+                applications!.find((a) => a?.value === experiment.application)
                   ?.label as string
               }
               readOnly
@@ -204,7 +204,7 @@ const FormOverview = ({
               as="select"
             >
               <option value="">Select...</option>
-              {application!.map((app, idx) => (
+              {applications!.map((app, idx) => (
                 <option key={`application-${idx}`} value={app!.value as string}>
                   {app!.label}
                 </option>

--- a/app/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/index.test.tsx
@@ -10,7 +10,7 @@ import {
   waitFor,
 } from "@testing-library/react";
 import React from "react";
-import { filterTargetingConfigSlug } from ".";
+import { filterTargetingConfigs } from ".";
 import { snakeToCamelCase } from "../../../lib/caseConversions";
 import {
   EXTERNAL_URLS,
@@ -37,7 +37,7 @@ describe("FormAudience", () => {
         }}
         config={{
           ...MOCK_CONFIG,
-          channel: [
+          channels: [
             { label: "Nightly", value: "NIGHTLY" },
             { label: "Release", value: "RELEASE" },
           ],
@@ -48,7 +48,7 @@ describe("FormAudience", () => {
               supportsLocaleCountry: true,
             },
           ],
-          targetingConfigSlug: [
+          targetingConfigs: [
             {
               label: "No Targeting",
               value: "NO_TARGETING",
@@ -80,7 +80,7 @@ describe("FormAudience", () => {
       "targetingConfigSlug",
     )) as HTMLSelectElement;
     expect(targetingConfigSlug.value).toEqual(
-      MOCK_CONFIG!.targetingConfigSlug![0]!.value,
+      MOCK_CONFIG!.targetingConfigs![0]!.value,
     );
 
     // Assert that the targeting choices are filtered for application
@@ -365,7 +365,7 @@ describe("filterTargetingConfigSlug", () => {
         applicationValues: [NimbusExperimentApplication.IOS],
       },
     ];
-    const result = filterTargetingConfigSlug(targetingConfigSlug, application);
+    const result = filterTargetingConfigs(targetingConfigSlug, application);
     expect(result).toHaveLength(2);
     expect(
       result.find((item) => item.label === expectedNoTargetingLabel),
@@ -383,7 +383,7 @@ const renderSubjectWithDefaultValues = (onSubmit = () => {}) =>
       {...{ onSubmit }}
       config={{
         ...MOCK_CONFIG,
-        targetingConfigSlug: [
+        targetingConfigs: [
           {
             label: "No Targeting",
             value: "NO_TARGETING",
@@ -400,13 +400,13 @@ const renderSubjectWithDefaultValues = (onSubmit = () => {}) =>
             applicationValues: ["TOASTER"],
           },
         ],
-        firefoxMinVersion: [
+        firefoxVersions: [
           {
             label: NimbusExperimentFirefoxMinVersion.NO_VERSION,
             value: NimbusExperimentFirefoxMinVersion.NO_VERSION,
           },
         ],
-        channel: [
+        channels: [
           {
             label: NimbusExperimentChannel.NO_CHANNEL,
             value: NimbusExperimentChannel.NO_CHANNEL,

--- a/app/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/index.tsx
@@ -19,7 +19,7 @@ import {
 } from "../../../lib/constants";
 import {
   getConfig_nimbusConfig,
-  getConfig_nimbusConfig_targetingConfigSlug,
+  getConfig_nimbusConfig_targetingConfigs,
 } from "../../../types/getConfig";
 import { getExperiment_experimentBySlug } from "../../../types/getExperiment";
 import LinkExternal from "../../LinkExternal";
@@ -129,10 +129,7 @@ export const FormAudience = ({
 
   const targetingConfigSlugOptions = useMemo(
     () =>
-      filterTargetingConfigSlug(
-        config.targetingConfigSlug,
-        experiment.application,
-      ),
+      filterTargetingConfigs(config.targetingConfigs, experiment.application),
     [config, experiment],
   );
 
@@ -168,7 +165,7 @@ export const FormAudience = ({
               {...formControlAttrs("firefoxMinVersion")}
               as="select"
             >
-              <SelectOptions options={config.firefoxMinVersion} />
+              <SelectOptions options={config.firefoxVersions} />
             </Form.Control>
             <FormErrors name="firefoxMinVersion" />
           </Form.Group>
@@ -375,8 +372,8 @@ const SelectOptions = ({
   </>
 );
 
-export const filterTargetingConfigSlug = (
-  targetingConfigs: getConfig_nimbusConfig["targetingConfigSlug"],
+export const filterTargetingConfigs = (
+  targetingConfigs: getConfig_nimbusConfig["targetingConfigs"],
   application: getExperiment_experimentBySlug["application"],
 ) =>
   targetingConfigs == null
@@ -384,7 +381,7 @@ export const filterTargetingConfigSlug = (
     : targetingConfigs.filter(
         (
           targetingConfig,
-        ): targetingConfig is getConfig_nimbusConfig_targetingConfigSlug =>
+        ): targetingConfig is getConfig_nimbusConfig_targetingConfigs =>
           targetingConfig !== null &&
           Array.isArray(targetingConfig.applicationValues) &&
           targetingConfig.applicationValues.includes(application),

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/FormBranch.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/FormBranch.test.tsx
@@ -88,7 +88,7 @@ describe("FormBranch", () => {
       target: { value: featureIdx },
     });
     expect(onFeatureConfigChange).toHaveBeenCalledWith(
-      MOCK_CONFIG!.featureConfig![featureIdx],
+      MOCK_CONFIG!.featureConfigs![featureIdx],
     );
   });
 

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/FormBranch.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/FormBranch.tsx
@@ -14,7 +14,7 @@ import { ReactComponent as DeleteIcon } from "../../../images/x.svg";
 import { NUMBER_FIELD, REQUIRED_FIELD } from "../../../lib/constants";
 import {
   getConfig_nimbusConfig,
-  getConfig_nimbusConfig_featureConfig,
+  getConfig_nimbusConfig_featureConfigs,
 } from "../../../types/getConfig";
 import { getExperiment_experimentBySlug } from "../../../types/getExperiment";
 import { AnnotatedBranch } from "./reducer";
@@ -39,7 +39,7 @@ export const FormBranch = ({
   equalRatio,
   isReference,
   experimentFeatureConfig,
-  featureConfig,
+  featureConfigs,
   onRemove,
   onFeatureConfigChange,
   defaultValues,
@@ -53,10 +53,10 @@ export const FormBranch = ({
   equalRatio?: boolean;
   isReference?: boolean;
   experimentFeatureConfig: getExperiment_experimentBySlug["featureConfig"];
-  featureConfig: getConfig_nimbusConfig["featureConfig"];
+  featureConfigs: getConfig_nimbusConfig["featureConfigs"];
   onRemove?: () => void;
   onFeatureConfigChange: (
-    featureConfig: getConfig_nimbusConfig_featureConfig | null,
+    featureConfig: getConfig_nimbusConfig_featureConfigs | null,
   ) => void;
   defaultValues: Record<string, any>;
   setSubmitErrors: React.Dispatch<React.SetStateAction<Record<string, any>>>;
@@ -85,7 +85,7 @@ export const FormBranch = ({
       return onFeatureConfigChange(null);
     }
     // featureConfig shouldn't ever be null in practice
-    const feature = featureConfig![selectedIdx];
+    const feature = featureConfigs![selectedIdx];
     return onFeatureConfigChange(feature);
   };
 
@@ -187,12 +187,12 @@ export const FormBranch = ({
                 reviewErrors.featureConfig?.length > 0 && "is-warning",
               )}
               onChange={handleFeatureConfigChange}
-              value={featureConfig!.findIndex(
+              value={featureConfigs!.findIndex(
                 (feature) => feature?.slug === experimentFeatureConfig?.slug,
               )}
             >
               <option value="">Select...</option>
-              {featureConfig?.map(
+              {featureConfigs?.map(
                 (feature, idx) =>
                   feature && (
                     <option key={`feature-${feature.slug}-${idx}`} value={idx}>

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/index.test.tsx
@@ -283,7 +283,7 @@ describe("FormBranches", () => {
     selectFeatureConfig();
     await clickAndWaitForSave(onSave);
     expect(onSave.mock.calls[0][0].featureConfigId).toEqual(
-      MOCK_CONFIG.featureConfig![1]!.id,
+      MOCK_CONFIG.featureConfigs![1]!.id,
     );
   });
 

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/index.tsx
@@ -12,7 +12,7 @@ import { useExitWarning, useForm, useReviewCheck } from "../../../hooks";
 import { IsDirtyUnsaved } from "../../../hooks/useCommonForm/useCommonFormMethods";
 import {
   getConfig_nimbusConfig,
-  getConfig_nimbusConfig_featureConfig,
+  getConfig_nimbusConfig_featureConfigs,
 } from "../../../types/getConfig";
 import { getExperiment_experimentBySlug } from "../../../types/getExperiment";
 import FormBranch from "./FormBranch";
@@ -22,7 +22,7 @@ import { FormData } from "./reducer/update";
 type FormBranchesProps = {
   isLoading: boolean;
   experiment: getExperiment_experimentBySlug;
-  featureConfig: getConfig_nimbusConfig["featureConfig"];
+  featureConfigs: getConfig_nimbusConfig["featureConfigs"];
   onSave: (
     state: FormBranchesSaveState,
     setSubmitErrors: (submitErrors: any) => void,
@@ -34,7 +34,7 @@ type FormBranchesProps = {
 export const FormBranches = ({
   isLoading,
   experiment,
-  featureConfig,
+  featureConfigs,
   onSave,
 }: FormBranchesProps) => {
   const { fieldMessages } = useReviewCheck(experiment);
@@ -127,7 +127,7 @@ export const FormBranches = ({
   };
 
   const handleFeatureConfigChange = (
-    value: getConfig_nimbusConfig_featureConfig | null,
+    value: getConfig_nimbusConfig_featureConfigs | null,
   ) => {
     commitFormData();
     dispatch({ type: "setFeatureConfig", value });
@@ -152,7 +152,7 @@ export const FormBranches = ({
 
   const commonBranchProps = {
     equalRatio,
-    featureConfig,
+    featureConfigs,
     experimentFeatureConfig,
     onFeatureConfigChange: handleFeatureConfigChange,
     setSubmitErrors,

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/mocks.tsx
@@ -62,7 +62,7 @@ export const SubjectBranch = ({
   equalRatio = false,
   isReference = false,
   experimentFeatureConfig = MOCK_FEATURE_CONFIG,
-  featureConfig = MOCK_CONFIG.featureConfig,
+  featureConfigs = MOCK_CONFIG.featureConfigs,
   onRemove = () => {},
   onFeatureConfigChange = () => {},
 }: Partial<React.ComponentProps<typeof FormBranch>>) => {
@@ -98,7 +98,7 @@ export const SubjectBranch = ({
             branch,
             isReference,
             equalRatio,
-            featureConfig,
+            featureConfigs,
             experimentFeatureConfig,
             onRemove,
             onFeatureConfigChange,
@@ -114,7 +114,7 @@ export const SubjectBranch = ({
 export const SubjectBranches = ({
   isLoading = false,
   experiment = MOCK_EXPERIMENT,
-  featureConfig = MOCK_CONFIG.featureConfig,
+  featureConfigs = MOCK_CONFIG.featureConfigs,
   onSave = () => {},
   saveOnInitialRender = false,
 }: Partial<React.ComponentProps<typeof FormBranches>> & {
@@ -136,7 +136,7 @@ export const SubjectBranches = ({
         {...{
           isLoading,
           experiment,
-          featureConfig,
+          featureConfigs,
           onSave,
         }}
       />
@@ -152,5 +152,5 @@ export const MOCK_ANNOTATED_BRANCH: AnnotatedBranch = {
   errors: {},
   ...MOCK_BRANCH,
 };
-export const MOCK_FEATURE_CONFIG = MOCK_CONFIG.featureConfig![0]!;
-export const MOCK_FEATURE_CONFIG_WITH_SCHEMA = MOCK_CONFIG.featureConfig![1]!;
+export const MOCK_FEATURE_CONFIG = MOCK_CONFIG.featureConfigs![0]!;
+export const MOCK_FEATURE_CONFIG_WITH_SCHEMA = MOCK_CONFIG.featureConfigs![1]!;

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/index.test.tsx
@@ -55,7 +55,7 @@ describe("PageEditBranches", () => {
       EXTERNAL_URLS.BRANCHES_GOOGLE_DOC,
     );
 
-    for (const feature of MOCK_CONFIG!.featureConfig!) {
+    for (const feature of MOCK_CONFIG!.featureConfigs!) {
       const { slug, application } = feature!;
       const configEl = screen.queryByText(slug);
       if (application === experiment!.application) {
@@ -199,7 +199,7 @@ jest.mock("./FormBranches", () => ({
   __esModule: true,
   default: ({
     experiment,
-    featureConfig,
+    featureConfigs,
     onSave,
   }: React.ComponentProps<typeof FormBranches>) => {
     return (
@@ -207,9 +207,9 @@ jest.mock("./FormBranches", () => ({
         {experiment && (
           <span data-testid="experiment-slug">{experiment.slug}</span>
         )}
-        {featureConfig && (
+        {featureConfigs && (
           <ul data-testid="feature-config">
-            {featureConfig.map(
+            {featureConfigs.map(
               (feature, idx) =>
                 feature && <li key={`feature-${idx}`}>{feature.slug}</li>,
             )}

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/index.tsx
@@ -22,7 +22,7 @@ import FormBranches from "./FormBranches";
 import { FormBranchesSaveState } from "./FormBranches/reducer";
 
 const PageEditBranches: React.FunctionComponent<RouteComponentProps> = () => {
-  const { featureConfig } = useConfig();
+  const { featureConfigs } = useConfig();
 
   const [updateExperimentBranches, { loading }] = useMutation<
     { updateExperiment: UpdateExperimentBranchesResult },
@@ -91,7 +91,7 @@ const PageEditBranches: React.FunctionComponent<RouteComponentProps> = () => {
         refetchReview.current = refetch;
 
         const applicationFeatureConfigs =
-          featureConfig?.filter(
+          featureConfigs?.filter(
             (config) => config?.application === experiment.application,
           ) || [];
 
@@ -110,7 +110,7 @@ const PageEditBranches: React.FunctionComponent<RouteComponentProps> = () => {
             <FormBranches
               {...{
                 experiment,
-                featureConfig: applicationFeatureConfigs,
+                featureConfigs: applicationFeatureConfigs,
                 isLoading: loading,
                 onSave: onFormSave,
               }}

--- a/app/experimenter/nimbus-ui/src/components/PageHome/FilterBar/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageHome/FilterBar/index.tsx
@@ -25,16 +25,16 @@ export const FilterBar: React.FC<FilterBarProps> = ({
       <Nav className="w-100">
         <FilterSelect
           fieldLabel="Feature"
-          fieldOptions={options.featureConfig!}
-          filterValueName="featureConfig"
+          fieldOptions={options.featureConfigs!}
+          filterValueName="featureConfigs"
           optionLabelName="name"
           optionValueName="slug"
           {...{ filterValue, onChange }}
         />
         <FilterSelect
           fieldLabel="Application"
-          fieldOptions={options.application!}
-          filterValueName="application"
+          fieldOptions={options.applications!}
+          filterValueName="applications"
           optionLabelName="label"
           optionValueName="value"
           {...{ filterValue, onChange }}
@@ -49,8 +49,8 @@ export const FilterBar: React.FC<FilterBarProps> = ({
         />
         <FilterSelect
           fieldLabel="Version"
-          fieldOptions={options.firefoxMinVersion!}
-          filterValueName="firefoxMinVersion"
+          fieldOptions={options.firefoxVersions!}
+          filterValueName="firefoxVersions"
           optionLabelName="label"
           optionValueName="value"
           {...{ filterValue, onChange }}

--- a/app/experimenter/nimbus-ui/src/components/PageHome/filterExperiments.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageHome/filterExperiments.test.tsx
@@ -12,14 +12,14 @@ import { FilterValue } from "./types";
 
 const MOCK_FILTER_VALUE: FilterValue = {
   owners: ["foo", "bar"],
-  application: ["baz", "quux"],
+  applications: ["baz", "quux"],
 };
 
 describe("getFilterValueFromParams", () => {
   it("converts comma-separated list representation from filter params into a filter value", () => {
     const params = new URLSearchParams();
     params.set("owners", "foo,bar");
-    params.set("application", "baz,quux");
+    params.set("applications", "baz,quux");
     expect(getFilterValueFromParams(params)).toEqual(MOCK_FILTER_VALUE);
   });
 });
@@ -30,7 +30,7 @@ describe("updateParamsFromFilterValue", () => {
     const updateSearchParams = jest.fn((cb) => cb(params));
     updateParamsFromFilterValue(updateSearchParams, MOCK_FILTER_VALUE);
     expect(params.get("owners")).toEqual("foo,bar");
-    expect(params.get("application")).toEqual("baz,quux");
+    expect(params.get("applications")).toEqual("baz,quux");
   });
 
   it("handles a roundtrip encoding with everything filtered", () => {

--- a/app/experimenter/nimbus-ui/src/components/PageHome/filterExperiments.ts
+++ b/app/experimenter/nimbus-ui/src/components/PageHome/filterExperiments.ts
@@ -41,9 +41,9 @@ type FilterSelector = {
 
 const FILTER_SELECTORS: FilterSelector[] = [
   { name: "owners", selector: (e) => e.owner.username },
-  { name: "application", selector: (e) => e.application },
-  { name: "firefoxMinVersion", selector: (e) => e.firefoxMinVersion },
-  { name: "featureConfig", selector: (e) => e.featureConfig?.slug },
+  { name: "applications", selector: (e) => e.application },
+  { name: "firefoxVersions", selector: (e) => e.firefoxMinVersion },
+  { name: "featureConfigs", selector: (e) => e.featureConfig?.slug },
 ];
 
 export function filterExperiments(

--- a/app/experimenter/nimbus-ui/src/components/PageHome/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageHome/index.tsx
@@ -65,9 +65,9 @@ export const Body = () => {
   }
 
   const filterOptions: FilterOptions = {
-    application: config!.application!,
-    featureConfig: config!.featureConfig!,
-    firefoxMinVersion: config!.firefoxMinVersion!,
+    applications: config!.applications!,
+    featureConfigs: config!.featureConfigs!,
+    firefoxVersions: config!.firefoxVersions!,
     // Populating owners from fetched experiments since it might be expensive
     // to fetch and manage a list of all users
     owners: uniqueByProperty(

--- a/app/experimenter/nimbus-ui/src/components/PageHome/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageHome/mocks.tsx
@@ -15,22 +15,22 @@ export const DEFAULT_OPTIONS: FilterOptions = {
     "username",
     MOCK_EXPERIMENTS.map((e) => e.owner),
   ),
-  application: MOCK_CONFIG!.application!,
-  featureConfig: MOCK_CONFIG!.featureConfig!,
-  firefoxMinVersion: MOCK_CONFIG!.firefoxMinVersion!,
+  applications: MOCK_CONFIG!.applications!,
+  featureConfigs: MOCK_CONFIG!.featureConfigs!,
+  firefoxVersions: MOCK_CONFIG!.firefoxVersions!,
 };
 
 export const DEFAULT_VALUE: FilterValue = {
   owners: [],
-  application: [],
-  featureConfig: [],
-  firefoxMinVersion: [],
+  applications: [],
+  featureConfigs: [],
+  firefoxVersions: [],
 };
 
 export const EVERYTHING_SELECTED_VALUE: FilterValue = {
-  application: MOCK_CONFIG!.application!.map((a) => a!.value!),
-  firefoxMinVersion: MOCK_CONFIG!.firefoxMinVersion!.map((a) => a!.value!),
-  featureConfig: MOCK_CONFIG!.featureConfig!.map((a) => a!.slug!),
+  applications: MOCK_CONFIG!.applications!.map((a) => a!.value!),
+  firefoxVersions: MOCK_CONFIG!.firefoxVersions!.map((a) => a!.value!),
+  featureConfigs: MOCK_CONFIG!.featureConfigs!.map((a) => a!.slug!),
   owners: DEFAULT_OPTIONS.owners.map((i) => i.username),
 };
 

--- a/app/experimenter/nimbus-ui/src/components/PageHome/types.ts
+++ b/app/experimenter/nimbus-ui/src/components/PageHome/types.ts
@@ -9,14 +9,14 @@ export type FilterOptions = {
   owners: Array<getAllExperiments_experiments_owner>;
 } & Pick<
   getConfig_nimbusConfig,
-  "application" | "featureConfig" | "firefoxMinVersion"
+  "applications" | "featureConfigs" | "firefoxVersions"
 >;
 
 export const FilterValueKeys = [
   "owners",
-  "application",
-  "featureConfig",
-  "firefoxMinVersion",
+  "applications",
+  "featureConfigs",
+  "firefoxVersions",
 ] as const;
 
 export type FilterValue = Partial<

--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableHighlightsOverview/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableHighlightsOverview/index.tsx
@@ -14,7 +14,7 @@ type TableHighlightsOverviewProps = {
 const TableHighlightsOverview = ({
   experiment,
 }: TableHighlightsOverviewProps) => {
-  const { firefoxMinVersion, channel, targetingConfigSlug } = useConfig();
+  const { firefoxVersions, channels, targetingConfigs } = useConfig();
   const { primaryOutcomes } = useOutcomes(experiment);
 
   return (
@@ -28,17 +28,13 @@ const TableHighlightsOverview = ({
             <td className="p-3">
               <h3 className="h6">Targeting</h3>
               <div>
-                {getConfigLabel(
-                  experiment.firefoxMinVersion,
-                  firefoxMinVersion,
-                )}
-                +
+                {getConfigLabel(experiment.firefoxMinVersion, firefoxVersions)}+
               </div>
-              <div>{getConfigLabel(experiment.channel, channel)}</div>
+              <div>{getConfigLabel(experiment.channel, channels)}</div>
               <div>
                 {getConfigLabel(
                   experiment.targetingConfigSlug,
-                  targetingConfigSlug,
+                  targetingConfigs,
                 )}
               </div>
             </td>

--- a/app/experimenter/nimbus-ui/src/components/Summary/TableAudience/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/TableAudience/index.tsx
@@ -17,7 +17,7 @@ type TableAudienceProps = {
 // `<tr>`s showing optional fields that are not set are not displayed.
 
 const TableAudience = ({ experiment }: TableAudienceProps) => {
-  const { firefoxMinVersion, channel, targetingConfigSlug } = useConfig();
+  const { firefoxVersions, channels, targetingConfigs } = useConfig();
 
   return (
     <Table bordered data-testid="table-audience" className="mb-4 table-fixed">
@@ -25,7 +25,7 @@ const TableAudience = ({ experiment }: TableAudienceProps) => {
         <tr>
           <th className="w-33">Channel</th>
           <td data-testid="experiment-channel">
-            {displayConfigLabelOrNotSet(experiment.channel, channel)}
+            {displayConfigLabelOrNotSet(experiment.channel, channels)}
           </td>
         </tr>
         <tr>
@@ -33,7 +33,7 @@ const TableAudience = ({ experiment }: TableAudienceProps) => {
           <td data-testid="experiment-ff-min">
             {displayConfigLabelOrNotSet(
               experiment.firefoxMinVersion,
-              firefoxMinVersion,
+              firefoxVersions,
             )}
           </td>
         </tr>
@@ -61,7 +61,7 @@ const TableAudience = ({ experiment }: TableAudienceProps) => {
             <td data-testid="experiment-target">
               {displayConfigLabelOrNotSet(
                 experiment.targetingConfigSlug,
-                targetingConfigSlug,
+                targetingConfigs,
               )}
             </td>
           </tr>

--- a/app/experimenter/nimbus-ui/src/components/Summary/TableOverview/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/TableOverview/index.stories.tsx
@@ -12,7 +12,7 @@ import AppLayout from "../../AppLayout";
 storiesOf("components/Summary/TableOverview", module)
   .add("all fields filled out", () => {
     const { experiment } = mockExperimentQuery("demo-slug", {
-      featureConfig: MOCK_CONFIG.featureConfig![1],
+      featureConfig: MOCK_CONFIG.featureConfigs![1],
     });
     return (
       <Subject>
@@ -22,7 +22,7 @@ storiesOf("components/Summary/TableOverview", module)
   })
   .add("filled out with multiple outcomes", () => {
     const { experiment } = mockExperimentQuery("demo-slug", {
-      featureConfig: MOCK_CONFIG.featureConfig![1],
+      featureConfig: MOCK_CONFIG.featureConfigs![1],
       primaryOutcomes: ["picture_in_picture", "feature_C"],
       secondaryOutcomes: ["feature_b", "feature_d"],
     });

--- a/app/experimenter/nimbus-ui/src/components/Summary/TableOverview/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/TableOverview/index.test.tsx
@@ -153,7 +153,7 @@ describe("TableOverview", () => {
   describe("renders 'Feature config' row as expected", () => {
     it("when set", () => {
       const { experiment } = mockExperimentQuery("demo-slug", {
-        featureConfig: MOCK_CONFIG.featureConfig![1],
+        featureConfig: MOCK_CONFIG.featureConfigs![1],
       });
       render(<Subject {...{ experiment }} />);
       expect(screen.getByTestId("experiment-feature-config")).toHaveTextContent(

--- a/app/experimenter/nimbus-ui/src/components/Summary/TableOverview/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/TableOverview/index.tsx
@@ -22,7 +22,7 @@ type TableOverviewProps = {
 const getRiskLabel = (answer: boolean) => (answer ? "Yes" : "No");
 
 const TableOverview = ({ experiment }: TableOverviewProps) => {
-  const { application, documentationLink: configDocumentationLinks } =
+  const { applications, documentationLink: configDocumentationLinks } =
     useConfig();
   const { primaryOutcomes, secondaryOutcomes } = useOutcomes(experiment);
 
@@ -44,7 +44,7 @@ const TableOverview = ({ experiment }: TableOverviewProps) => {
         <tr>
           <th>Application</th>
           <td data-testid="experiment-application">
-            {displayConfigLabelOrNotSet(experiment.application, application)}
+            {displayConfigLabelOrNotSet(experiment.application, applications)}
           </td>
         </tr>
         <tr>

--- a/app/experimenter/nimbus-ui/src/gql/config.ts
+++ b/app/experimenter/nimbus-ui/src/gql/config.ts
@@ -7,11 +7,11 @@ import { gql } from "@apollo/client";
 export const GET_CONFIG_QUERY = gql`
   query getConfig {
     nimbusConfig {
-      application {
+      applications {
         label
         value
       }
-      channel {
+      channels {
         label
         value
       }
@@ -23,7 +23,7 @@ export const GET_CONFIG_QUERY = gql`
         }
         supportsLocaleCountry
       }
-      featureConfig {
+      featureConfigs {
         id
         name
         slug
@@ -32,7 +32,7 @@ export const GET_CONFIG_QUERY = gql`
         ownerEmail
         schema
       }
-      firefoxMinVersion {
+      firefoxVersions {
         label
         value
       }
@@ -48,7 +48,7 @@ export const GET_CONFIG_QUERY = gql`
           description
         }
       }
-      targetingConfigSlug {
+      targetingConfigs {
         label
         value
         applicationValues

--- a/app/experimenter/nimbus-ui/src/lib/getConfigLabel.ts
+++ b/app/experimenter/nimbus-ui/src/lib/getConfigLabel.ts
@@ -5,10 +5,10 @@
 import { getConfig_nimbusConfig } from "../types/getConfig";
 
 export type ConfigOptions =
-  | getConfig_nimbusConfig["application"]
-  | getConfig_nimbusConfig["firefoxMinVersion"]
-  | getConfig_nimbusConfig["channel"]
-  | getConfig_nimbusConfig["targetingConfigSlug"];
+  | getConfig_nimbusConfig["applications"]
+  | getConfig_nimbusConfig["firefoxVersions"]
+  | getConfig_nimbusConfig["channels"]
+  | getConfig_nimbusConfig["targetingConfigs"];
 
 export const getConfigLabel = (
   value: string | null,

--- a/app/experimenter/nimbus-ui/src/lib/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/lib/mocks.tsx
@@ -63,7 +63,7 @@ export interface MockedState {
 }
 
 export const MOCK_CONFIG: getConfig_nimbusConfig = {
-  application: [
+  applications: [
     {
       label: "Desktop",
       value: "DESKTOP",
@@ -73,7 +73,7 @@ export const MOCK_CONFIG: getConfig_nimbusConfig = {
       value: "TOASTER",
     },
   ],
-  channel: [
+  channels: [
     {
       label: "Desktop Beta",
       value: "BETA",
@@ -143,7 +143,7 @@ export const MOCK_CONFIG: getConfig_nimbusConfig = {
       supportsLocaleCountry: false,
     },
   ],
-  featureConfig: [
+  featureConfigs: [
     {
       id: 1,
       name: "Picture-in-Picture",
@@ -173,7 +173,7 @@ export const MOCK_CONFIG: getConfig_nimbusConfig = {
       schema: '{ "sample": "schema" }',
     },
   ],
-  firefoxMinVersion: [
+  firefoxVersions: [
     {
       label: "Firefox 80",
       value: "FIREFOX_83",
@@ -263,7 +263,7 @@ export const MOCK_CONFIG: getConfig_nimbusConfig = {
       ],
     },
   ],
-  targetingConfigSlug: [
+  targetingConfigs: [
     {
       label: "Mac Only",
       value: "MAC_ONLY",
@@ -604,9 +604,9 @@ export function mockSingleDirectoryExperiment(
     owner: {
       username: "example@mozilla.com",
     },
-    application: MOCK_CONFIG.application![0]!
+    application: MOCK_CONFIG.applications![0]!
       .value as NimbusExperimentApplication,
-    firefoxMinVersion: MOCK_CONFIG.firefoxMinVersion![0]!
+    firefoxMinVersion: MOCK_CONFIG.firefoxVersions![0]!
       .value as NimbusExperimentFirefoxMinVersion,
     monitoringDashboardUrl:
       "https://grafana.telemetry.mozilla.org/d/XspgvdxZz/experiment-enrollment?orgId=1&var-experiment_id=bug-1668861-pref-measure-set-to-default-adoption-impact-of-chang-release-81-83",
@@ -614,7 +614,7 @@ export function mockSingleDirectoryExperiment(
     status: NimbusExperimentStatus.COMPLETE,
     statusNext: null,
     publishStatus: NimbusExperimentPublishStatus.IDLE,
-    featureConfig: MOCK_CONFIG.featureConfig![0],
+    featureConfig: MOCK_CONFIG.featureConfigs![0],
     isEnrollmentPaused: false,
     isEnrollmentPausePending: false,
     proposedEnrollment: 7,
@@ -639,8 +639,8 @@ export function mockDirectoryExperiments(
       name: "Ipsum dolor sit amet",
       status: NimbusExperimentStatus.DRAFT,
       owner: { username: "gamma-example@mozilla.com" },
-      featureConfig: MOCK_CONFIG.featureConfig![0],
-      application: MOCK_CONFIG.application![1]!
+      featureConfig: MOCK_CONFIG.featureConfigs![0],
+      application: MOCK_CONFIG.applications![1]!
         .value as NimbusExperimentApplication,
       startDate: null,
       computedEndDate: null,
@@ -649,7 +649,7 @@ export function mockDirectoryExperiments(
       name: "Dolor sit amet",
       status: NimbusExperimentStatus.DRAFT,
       owner: { username: "beta-example@mozilla.com" },
-      featureConfig: MOCK_CONFIG.featureConfig![1],
+      featureConfig: MOCK_CONFIG.featureConfigs![1],
       startDate: null,
       computedEndDate: null,
     },
@@ -657,8 +657,8 @@ export function mockDirectoryExperiments(
       name: "Consectetur adipiscing elit",
       status: NimbusExperimentStatus.PREVIEW,
       owner: { username: "alpha-example@mozilla.com" },
-      featureConfig: MOCK_CONFIG.featureConfig![2],
-      application: MOCK_CONFIG.application![1]!
+      featureConfig: MOCK_CONFIG.featureConfigs![2],
+      application: MOCK_CONFIG.applications![1]!
         .value as NimbusExperimentApplication,
       computedEndDate: null,
     },
@@ -666,13 +666,13 @@ export function mockDirectoryExperiments(
       name: "Aliquam interdum ac lacus at dictum",
       publishStatus: NimbusExperimentPublishStatus.APPROVED,
       owner: { username: "beta-example@mozilla.com" },
-      featureConfig: MOCK_CONFIG.featureConfig![0],
+      featureConfig: MOCK_CONFIG.featureConfigs![0],
       computedEndDate: null,
     },
     {
       name: "Nam semper sit amet orci in imperdiet",
       publishStatus: NimbusExperimentPublishStatus.APPROVED,
-      application: MOCK_CONFIG.application![1]!
+      application: MOCK_CONFIG.applications![1]!
         .value as NimbusExperimentApplication,
       owner: { username: "gamma-example@mozilla.com" },
     },
@@ -680,14 +680,14 @@ export function mockDirectoryExperiments(
       name: "Duis ornare mollis sem.",
       status: NimbusExperimentStatus.LIVE,
       owner: { username: "alpha-example@mozilla.com" },
-      featureConfig: MOCK_CONFIG.featureConfig![1],
+      featureConfig: MOCK_CONFIG.featureConfigs![1],
     },
     {
       name: "Nec suscipit mi accumsan id",
       status: NimbusExperimentStatus.LIVE,
       owner: { username: "beta-example@mozilla.com" },
-      featureConfig: MOCK_CONFIG.featureConfig![2],
-      application: MOCK_CONFIG.application![1]!
+      featureConfig: MOCK_CONFIG.featureConfigs![2],
+      application: MOCK_CONFIG.applications![1]!
         .value as NimbusExperimentApplication,
       resultsReady: true,
     },
@@ -700,8 +700,8 @@ export function mockDirectoryExperiments(
       name: "Nam gravida",
       status: NimbusExperimentStatus.COMPLETE,
       owner: { username: "alpha-example@mozilla.com" },
-      featureConfig: MOCK_CONFIG.featureConfig![0],
-      application: MOCK_CONFIG.application![1]!
+      featureConfig: MOCK_CONFIG.featureConfigs![0],
+      application: MOCK_CONFIG.applications![1]!
         .value as NimbusExperimentApplication,
       resultsReady: false,
     },
@@ -709,13 +709,13 @@ export function mockDirectoryExperiments(
       name: "Quam quis volutpat ornare",
       status: NimbusExperimentStatus.DRAFT,
       publishStatus: NimbusExperimentPublishStatus.REVIEW,
-      featureConfig: MOCK_CONFIG.featureConfig![1],
+      featureConfig: MOCK_CONFIG.featureConfigs![1],
       owner: { username: "beta-example@mozilla.com" },
     },
     {
       name: "Lorem arcu faucibus tortor",
       featureConfig: null,
-      application: MOCK_CONFIG.application![1]!
+      application: MOCK_CONFIG.applications![1]!
         .value as NimbusExperimentApplication,
       owner: { username: "gamma-example@mozilla.com" },
     },
@@ -723,7 +723,7 @@ export function mockDirectoryExperiments(
       isArchived: true,
       name: "Archived Experiment",
       featureConfig: null,
-      application: MOCK_CONFIG.application![1]!
+      application: MOCK_CONFIG.applications![1]!
         .value as NimbusExperimentApplication,
       owner: { username: "gamma-example@mozilla.com" },
     },

--- a/app/experimenter/nimbus-ui/src/types/getConfig.ts
+++ b/app/experimenter/nimbus-ui/src/types/getConfig.ts
@@ -9,12 +9,12 @@ import { NimbusExperimentApplication } from "./globalTypes";
 // GraphQL query operation: getConfig
 // ====================================================
 
-export interface getConfig_nimbusConfig_application {
+export interface getConfig_nimbusConfig_applications {
   label: string | null;
   value: string | null;
 }
 
-export interface getConfig_nimbusConfig_channel {
+export interface getConfig_nimbusConfig_channels {
   label: string | null;
   value: string | null;
 }
@@ -30,7 +30,7 @@ export interface getConfig_nimbusConfig_applicationConfigs {
   supportsLocaleCountry: boolean | null;
 }
 
-export interface getConfig_nimbusConfig_featureConfig {
+export interface getConfig_nimbusConfig_featureConfigs {
   id: number | null;
   name: string;
   slug: string;
@@ -40,7 +40,7 @@ export interface getConfig_nimbusConfig_featureConfig {
   schema: string | null;
 }
 
-export interface getConfig_nimbusConfig_firefoxMinVersion {
+export interface getConfig_nimbusConfig_firefoxVersions {
   label: string | null;
   value: string | null;
 }
@@ -60,7 +60,7 @@ export interface getConfig_nimbusConfig_outcomes {
   metrics: (getConfig_nimbusConfig_outcomes_metrics | null)[] | null;
 }
 
-export interface getConfig_nimbusConfig_targetingConfigSlug {
+export interface getConfig_nimbusConfig_targetingConfigs {
   label: string | null;
   value: string | null;
   applicationValues: (string | null)[] | null;
@@ -82,13 +82,13 @@ export interface getConfig_nimbusConfig_countries {
 }
 
 export interface getConfig_nimbusConfig {
-  application: (getConfig_nimbusConfig_application | null)[] | null;
-  channel: (getConfig_nimbusConfig_channel | null)[] | null;
+  applications: (getConfig_nimbusConfig_applications | null)[] | null;
+  channels: (getConfig_nimbusConfig_channels | null)[] | null;
   applicationConfigs: (getConfig_nimbusConfig_applicationConfigs | null)[] | null;
-  featureConfig: (getConfig_nimbusConfig_featureConfig | null)[] | null;
-  firefoxMinVersion: (getConfig_nimbusConfig_firefoxMinVersion | null)[] | null;
+  featureConfigs: (getConfig_nimbusConfig_featureConfigs | null)[] | null;
+  firefoxVersions: (getConfig_nimbusConfig_firefoxVersions | null)[] | null;
   outcomes: (getConfig_nimbusConfig_outcomes | null)[] | null;
-  targetingConfigSlug: (getConfig_nimbusConfig_targetingConfigSlug | null)[] | null;
+  targetingConfigs: (getConfig_nimbusConfig_targetingConfigs | null)[] | null;
   hypothesisDefault: string | null;
   documentationLink: (getConfig_nimbusConfig_documentationLink | null)[] | null;
   maxPrimaryOutcomes: number | null;


### PR DESCRIPTION
Because

* Some of the config API fields were inconsistently singular or plural
* Some fields names didn't reflect the type of data they contained

This commit

* Renames fields that return a collection to pluralized
* Renames fields to match the type of data they return