### PR TITLE
fix #6381 feat(nimbus): sort directory view options

### DIFF
--- a/app/experimenter/experiments/api/v5/queries.py
+++ b/app/experimenter/experiments/api/v5/queries.py
@@ -24,7 +24,7 @@ class Query(graphene.ObjectType):
     )
 
     def resolve_experiments(root, info):
-        return NimbusExperiment.objects.with_related()
+        return NimbusExperiment.objects.latest_with_related()
 
     def resolve_experiment_by_slug(root, info, slug):
         try:

--- a/app/experimenter/experiments/api/v5/types.py
+++ b/app/experimenter/experiments/api/v5/types.py
@@ -186,6 +186,7 @@ class NimbusConfigurationType(graphene.ObjectType):
     locales = graphene.List(NimbusLocaleType)
     max_primary_outcomes = graphene.Int()
     outcomes = graphene.List(NimbusOutcomeType)
+    owners = graphene.List(NimbusUser)
     targeting_configs = graphene.List(NimbusExperimentTargetingConfig)
 
     def _text_choices_to_label_value_list(root, text_choices):
@@ -221,13 +222,20 @@ class NimbusConfigurationType(graphene.ObjectType):
         return configs
 
     def resolve_feature_configs(root, info):
-        return NimbusFeatureConfig.objects.all()
+        return NimbusFeatureConfig.objects.all().order_by("name")
 
     def resolve_firefox_versions(root, info):
         return root._text_choices_to_label_value_list(NimbusExperiment.Version)
 
     def resolve_outcomes(root, info):
         return Outcomes.all()
+
+    def resolve_owners(root, info):
+        return (
+            get_user_model()
+            .objects.filter(owned_nimbusexperiments__isnull=False)
+            .order_by("email")
+        )
 
     def resolve_targeting_configs(root, info):
         return [

--- a/app/experimenter/experiments/tests/api/v5/test_queries.py
+++ b/app/experimenter/experiments/tests/api/v5/test_queries.py
@@ -840,6 +840,7 @@ class TestNimbusConfigQuery(GraphQLTestCase):
     def test_nimbus_config(self):
         user_email = "user@example.com"
         feature_configs = NimbusFeatureConfigFactory.create_batch(10)
+        experiment = NimbusExperimentFactory.create()
 
         response = self.query(
             """
@@ -876,6 +877,9 @@ class TestNimbusConfigQuery(GraphQLTestCase):
                         slug
                         application
                         description
+                    }
+                    owners {
+                        username
                     }
                     targetingConfigs {
                         label
@@ -915,7 +919,7 @@ class TestNimbusConfigQuery(GraphQLTestCase):
         assertChoices(config["channels"], NimbusExperiment.Channel)
         assertChoices(config["firefoxVersions"], NimbusExperiment.Version)
         assertChoices(config["documentationLink"], NimbusExperiment.DocumentationLink)
-        self.assertEqual(len(config["featureConfigs"]), 15)
+        self.assertEqual(len(config["featureConfigs"]), 16)
 
         for application_config_data in config["applicationConfigs"]:
             application_config = NimbusExperiment.APPLICATION_CONFIGS[
@@ -934,6 +938,8 @@ class TestNimbusConfigQuery(GraphQLTestCase):
                 application_config_data["supportsLocaleCountry"],
                 application_config.supports_locale_country,
             )
+
+        self.assertEqual(config["owners"], [{"username": experiment.owner.username}])
 
         for outcome in Outcomes.all():
             self.assertIn(

--- a/app/experimenter/experiments/tests/test_models/test_models_nimbus.py
+++ b/app/experimenter/experiments/tests/test_models/test_models_nimbus.py
@@ -28,6 +28,22 @@ from experimenter.openidc.tests.factories import UserFactory
 
 
 class TestNimbusExperimentManager(TestCase):
+    def test_sorted_by_latest_change(self):
+        older_experiment = NimbusExperimentFactory.create()
+        newer_experiment = NimbusExperimentFactory.create()
+
+        NimbusChangeLogFactory.create(
+            experiment=older_experiment, changed_on=datetime.datetime(2021, 1, 1)
+        )
+        NimbusChangeLogFactory.create(
+            experiment=newer_experiment, changed_on=datetime.datetime(2021, 1, 2)
+        )
+
+        self.assertEqual(
+            list(NimbusExperiment.objects.latest_changed()),
+            [newer_experiment, older_experiment],
+        )
+
     def test_launch_queue_returns_queued_experiments_with_correct_application(self):
         experiment1 = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE,

--- a/app/experimenter/nimbus-ui/schema.graphql
+++ b/app/experimenter/nimbus-ui/schema.graphql
@@ -150,6 +150,7 @@ type NimbusConfigurationType {
   locales: [NimbusLocaleType]
   maxPrimaryOutcomes: Int
   outcomes: [NimbusOutcomeType]
+  owners: [NimbusUser]
   targetingConfigs: [NimbusExperimentTargetingConfig]
 }
 

--- a/app/experimenter/nimbus-ui/src/components/PageHome/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageHome/index.tsx
@@ -12,7 +12,6 @@ import {
   useRefetchOnError,
   useSearchParamsState,
 } from "../../hooks";
-import { uniqueByProperty } from "../../lib/utils";
 import { getAllExperiments_experiments } from "../../types/getAllExperiments";
 import AppLayout from "../AppLayout";
 import Head from "../Head";
@@ -68,12 +67,7 @@ export const Body = () => {
     applications: config!.applications!,
     featureConfigs: config!.featureConfigs!,
     firefoxVersions: config!.firefoxVersions!,
-    // Populating owners from fetched experiments since it might be expensive
-    // to fetch and manage a list of all users
-    owners: uniqueByProperty(
-      "username",
-      data.experiments.map((e) => e.owner),
-    ),
+    owners: config!.owners!,
   };
 
   const { live, complete, preview, review, draft, archived } = sortByStatus(

--- a/app/experimenter/nimbus-ui/src/components/PageHome/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageHome/mocks.tsx
@@ -4,17 +4,13 @@
 
 import React, { useState } from "react";
 import { mockDirectoryExperiments, MOCK_CONFIG } from "../../lib/mocks";
-import { uniqueByProperty } from "../../lib/utils";
 import { FilterBar } from "./FilterBar";
 import { FilterOptions, FilterValue } from "./types";
 
 export const MOCK_EXPERIMENTS = mockDirectoryExperiments();
 
 export const DEFAULT_OPTIONS: FilterOptions = {
-  owners: uniqueByProperty(
-    "username",
-    MOCK_EXPERIMENTS.map((e) => e.owner),
-  ),
+  owners: MOCK_CONFIG!.owners,
   applications: MOCK_CONFIG!.applications!,
   featureConfigs: MOCK_CONFIG!.featureConfigs!,
   firefoxVersions: MOCK_CONFIG!.firefoxVersions!,
@@ -28,10 +24,10 @@ export const DEFAULT_VALUE: FilterValue = {
 };
 
 export const EVERYTHING_SELECTED_VALUE: FilterValue = {
+  owners: MOCK_CONFIG!.owners!.map((a) => a!.username!),
   applications: MOCK_CONFIG!.applications!.map((a) => a!.value!),
   firefoxVersions: MOCK_CONFIG!.firefoxVersions!.map((a) => a!.value!),
   featureConfigs: MOCK_CONFIG!.featureConfigs!.map((a) => a!.slug!),
-  owners: DEFAULT_OPTIONS.owners.map((i) => i.username),
 };
 
 export const Subject = ({

--- a/app/experimenter/nimbus-ui/src/components/PageHome/types.ts
+++ b/app/experimenter/nimbus-ui/src/components/PageHome/types.ts
@@ -2,14 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { getAllExperiments_experiments_owner } from "../../types/getAllExperiments";
 import { getConfig_nimbusConfig } from "../../types/getConfig";
 
-export type FilterOptions = {
-  owners: Array<getAllExperiments_experiments_owner>;
-} & Pick<
+export type FilterOptions = Pick<
   getConfig_nimbusConfig,
-  "applications" | "featureConfigs" | "firefoxVersions"
+  "applications" | "featureConfigs" | "firefoxVersions" | "owners"
 >;
 
 export const FilterValueKeys = [

--- a/app/experimenter/nimbus-ui/src/gql/config.ts
+++ b/app/experimenter/nimbus-ui/src/gql/config.ts
@@ -48,6 +48,9 @@ export const GET_CONFIG_QUERY = gql`
           description
         }
       }
+      owners {
+        username
+      }
       targetingConfigs {
         label
         value

--- a/app/experimenter/nimbus-ui/src/lib/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/lib/mocks.tsx
@@ -263,6 +263,11 @@ export const MOCK_CONFIG: getConfig_nimbusConfig = {
       ],
     },
   ],
+  owners: [
+    { username: "alpha-example@mozilla.com" },
+    { username: "beta-example@mozilla.com" },
+    { username: "gamma-example@mozilla.com" },
+  ],
   targetingConfigs: [
     {
       label: "Mac Only",

--- a/app/experimenter/nimbus-ui/src/lib/utils.test.ts
+++ b/app/experimenter/nimbus-ui/src/lib/utils.test.ts
@@ -2,12 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import {
-  optionalBoolString,
-  optionalStringBool,
-  pluralize,
-  uniqueByProperty,
-} from "./utils";
+import { optionalBoolString, optionalStringBool, pluralize } from "./utils";
 
 describe("pluralize", () => {
   it("correctly return 0-count item", () => {
@@ -54,29 +49,5 @@ describe("optionalBoolString", () => {
   it("returns null if null or undefined is provided", () => {
     expect(optionalBoolString(null)).toBeNull();
     expect(optionalBoolString(undefined)).toBeNull();
-  });
-});
-
-describe("uniqueByProperty", () => {
-  it("produces a list whose elements are unique for a given property", () => {
-    const list = [
-      { a: "foo", b: "bar", c: 1 },
-      { a: "foo", b: "bar", c: 2 },
-      { a: "foo", b: "bar", c: 3 },
-      { a: "baz", b: "quux", c: 4 },
-      { a: "xyxxy", b: "fnord", c: 5 },
-      { a: "baz", b: "quux", c: 6 },
-      { a: "xyxxy", b: "fnord", c: 7 },
-      { a: "baz", b: "quux", c: 8 },
-      { a: "xyxxy", b: "fnord", c: 9 },
-      { a: "frotz", b: "barf", c: 10 },
-    ];
-    const expected = [
-      { a: "foo", b: "bar", c: 1 },
-      { a: "baz", b: "quux", c: 4 },
-      { a: "xyxxy", b: "fnord", c: 5 },
-      { a: "frotz", b: "barf", c: 10 },
-    ];
-    expect(uniqueByProperty("a", list)).toEqual(expected);
   });
 });

--- a/app/experimenter/nimbus-ui/src/lib/utils.ts
+++ b/app/experimenter/nimbus-ui/src/lib/utils.ts
@@ -2,8 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { NullableObject } from "./types";
-
 export function pluralize(count: number, singular: string, plural?: string) {
   const pluralVal = plural ?? `${singular}s`;
   return `${count} ${count === 1 ? singular : pluralVal}`;
@@ -21,16 +19,3 @@ export const optionalBoolString = (
   }
   return String(value);
 };
-
-export function uniqueByProperty<InputType extends NullableObject>(
-  propertyName: string,
-  originalList: InputType[],
-) {
-  return originalList.filter(
-    (item, idx): item is NonNullable<InputType> =>
-      originalList.findIndex(
-        (cmpItem) =>
-          !!item && !!cmpItem && item[propertyName] === cmpItem[propertyName],
-      ) === idx,
-  );
-}

--- a/app/experimenter/nimbus-ui/src/types/getConfig.ts
+++ b/app/experimenter/nimbus-ui/src/types/getConfig.ts
@@ -60,6 +60,10 @@ export interface getConfig_nimbusConfig_outcomes {
   metrics: (getConfig_nimbusConfig_outcomes_metrics | null)[] | null;
 }
 
+export interface getConfig_nimbusConfig_owners {
+  username: string;
+}
+
 export interface getConfig_nimbusConfig_targetingConfigs {
   label: string | null;
   value: string | null;
@@ -88,6 +92,7 @@ export interface getConfig_nimbusConfig {
   featureConfigs: (getConfig_nimbusConfig_featureConfigs | null)[] | null;
   firefoxVersions: (getConfig_nimbusConfig_firefoxVersions | null)[] | null;
   outcomes: (getConfig_nimbusConfig_outcomes | null)[] | null;
+  owners: (getConfig_nimbusConfig_owners | null)[] | null;
   targetingConfigs: (getConfig_nimbusConfig_targetingConfigs | null)[] | null;
   hypothesisDefault: string | null;
   documentationLink: (getConfig_nimbusConfig_documentationLink | null)[] | null;


### PR DESCRIPTION
Because

* Its easier to reason about options in a drop down when they're sorted

This commit

* Sorts the options in all the directory view filter drop downs
* Default sorts the experiment list by latest change before applying column specific sorting