### PR TITLE
fix #6366 bug(nimbus): validate clone name length

### DIFF
--- a/app/experimenter/experiments/api/v5/serializers.py
+++ b/app/experimenter/experiments/api/v5/serializers.py
@@ -310,7 +310,7 @@ class NimbusExperimentSerializer(
     serializers.ModelSerializer,
 ):
     name = serializers.CharField(
-        min_length=0, max_length=255, required=False, allow_blank=True
+        min_length=1, max_length=80, required=False, allow_blank=True
     )
     slug = serializers.ReadOnlyField()
     application = serializers.ChoiceField(
@@ -708,7 +708,7 @@ class NimbusExperimentCloneSerializer(
     parent_slug = serializers.SlugRelatedField(
         slug_field="slug", queryset=NimbusExperiment.objects.all()
     )
-    name = serializers.CharField(min_length=0, max_length=255, required=True)
+    name = serializers.CharField(min_length=1, max_length=80, required=True)
 
     class Meta:
         model = NimbusExperiment

--- a/app/experimenter/experiments/tests/api/v5/test_mutations.py
+++ b/app/experimenter/experiments/tests/api/v5/test_mutations.py
@@ -95,7 +95,7 @@ class TestCreateExperimentMutation(GraphQLTestCase):
             result["message"],
             {
                 "changelog_message": ["This field is required."],
-                "name": ["Ensure this field has no more than 255 characters."],
+                "name": ["Ensure this field has no more than 80 characters."],
             },
         )
 
@@ -182,7 +182,7 @@ class TestUpdateExperimentMutation(GraphQLTestCase):
         self.assertEqual(
             result["message"],
             {
-                "name": ["Ensure this field has no more than 255 characters."],
+                "name": ["Ensure this field has no more than 80 characters."],
             },
         )
 


### PR DESCRIPTION
Because

* We neglected to validate that the clone name can't exceed 80 characters

This commit

* Validates clone name is <= 80 characters
* Noticed we were only validating experiment length on the client side, not the server side, so added it in the serializer too