### PR TITLE
fix #6329 feat(nimbus): validate targeting config jexl syntax

### DIFF
--- a/app/experimenter/experiments/constants/nimbus.py
+++ b/app/experimenter/experiments/constants/nimbus.py
@@ -510,7 +510,6 @@ class NimbusConstants(object):
             TARGETING_CORE_USER_URIS.slug,
             TARGETING_CORE_USER_URIS.name,
         )
-
         TARGETING_NO_ENTERPRISE_OR_PAST_VPN = (
             TARGETING_NO_ENTERPRISE_OR_PAST_VPN.slug,
             TARGETING_NO_ENTERPRISE_OR_PAST_VPN.name,

--- a/app/experimenter/experiments/tests/test_targeting_configs.py
+++ b/app/experimenter/experiments/tests/test_targeting_configs.py
@@ -1,0 +1,35 @@
+from django.test import TestCase
+from parameterized import parameterized
+from parsimonious.exceptions import ParseError
+from pyjexl.jexl import JEXLConfig
+from pyjexl.operators import default_binary_operators, default_unary_operators
+from pyjexl.parser import Parser, jexl_grammar
+
+from experimenter.experiments.constants import NimbusConstants
+
+default_config = JEXLConfig({}, default_unary_operators, default_binary_operators)
+
+
+class DefaultParser(Parser):
+    grammar = jexl_grammar(default_config)
+
+    def __init__(self):
+        super().__init__(default_config)
+
+
+class TestTargetingConfigs(TestCase):
+    def test_all_targeting_configs_defined_in_constants(self):
+        self.assertEqual(
+            set([t.value for t in NimbusConstants.TargetingConfig]),
+            set(t for t in NimbusConstants.TARGETING_CONFIGS.keys()),
+            "Targeting Configs must be defined in both NimbusConstants.TargetingConfig "
+            "and NimbusConstants.TARGETING_CONFIGS",
+        )
+
+    @parameterized.expand([(t,) for t in NimbusConstants.TARGETING_CONFIGS.values()])
+    def test_targeting_config_has_valid_jexl(self, targeting_config):
+        if targeting_config.targeting:
+            try:
+                DefaultParser().parse(targeting_config.targeting)
+            except ParseError as e:
+                raise Exception(f"JEXL Parse error in {targeting_config.name}: {e}")

--- a/app/poetry.lock
+++ b/app/poetry.lock
@@ -493,6 +493,14 @@ pycodestyle = ">=2.7.0,<2.8.0"
 pyflakes = ">=2.3.0,<2.4.0"
 
 [[package]]
+name = "future"
+version = "0.18.2"
+description = "Clean single-source support for Python 3 and 2"
+category = "main"
+optional = false
+python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
+
+[[package]]
 name = "google-api-core"
 version = "1.31.0"
 description = "Google API client core library"
@@ -942,6 +950,17 @@ python-versions = "*"
 dev = ["jinja2"]
 
 [[package]]
+name = "parsimonious"
+version = "0.8.1"
+description = "(Soon to be) the fastest pure-Python PEG parser I could muster"
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+six = ">=1.9.0"
+
+[[package]]
 name = "parso"
 version = "0.8.2"
 description = "A Python Parser"
@@ -1128,6 +1147,18 @@ description = "Pygments is a syntax highlighting package written in Python."
 category = "main"
 optional = false
 python-versions = ">=3.5"
+
+[[package]]
+name = "pyjexl"
+version = "0.2.3"
+description = "A JEXL parser and evaluator."
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+future = "*"
+parsimonious = "*"
 
 [[package]]
 name = "pyparsing"
@@ -1437,14 +1468,6 @@ test = ["pytest"]
 
 [[package]]
 name = "typing-extensions"
-version = "3.10.0.0"
-description = "Backported and Experimental Type Hints for Python 3.5+"
-category = "main"
-optional = false
-python-versions = "*"
-
-[[package]]
-name = "typing-extensions"
 version = "3.10.0.2"
 description = "Backported and Experimental Type Hints for Python 3.5+"
 category = "main"
@@ -1529,7 +1552,7 @@ brotli = ["brotli"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9"
-content-hash = "ff26334982c958c480d081d82bedbdd983522c6efac5806571599b483a118e6d"
+content-hash = "2877929b729b524a7765c40cc3365d0b8219a57e5319ad95559c4e9ec96b0a7d"
 
 [metadata.files]
 amqp = [
@@ -1781,6 +1804,9 @@ flake8 = [
     {file = "flake8-3.9.2-py2.py3-none-any.whl", hash = "sha256:bf8fd333346d844f616e8d47905ef3a3384edae6b4e9beb0c5101e25e3110907"},
     {file = "flake8-3.9.2.tar.gz", hash = "sha256:07528381786f2a6237b061f6e96610a4167b226cb926e2aa2b6b1d78057c576b"},
 ]
+future = [
+    {file = "future-0.18.2.tar.gz", hash = "sha256:b1bead90b70cf6ec3f0710ae53a525360fa360d306a86583adc6bf83a4db537d"},
+]
 google-api-core = [
     {file = "google-api-core-1.31.0.tar.gz", hash = "sha256:7c8ba88e2b893ef4f67d67e229aade51a2db5053023b73b1394a5ee3dcdb561c"},
     {file = "google_api_core-1.31.0-py2.py3-none-any.whl", hash = "sha256:a9f979b5c6a9cad31a4120ca6be712df76adc32336a7bf4bc2f4331a1b527fe7"},
@@ -1931,6 +1957,9 @@ parameterized = [
     {file = "parameterized-0.8.1-py2.py3-none-any.whl", hash = "sha256:9cbb0b69a03e8695d68b3399a8a5825200976536fe1cb79db60ed6a4c8c9efe9"},
     {file = "parameterized-0.8.1.tar.gz", hash = "sha256:41bbff37d6186430f77f900d777e5bb6a24928a1c46fb1de692f8b52b8833b5c"},
 ]
+parsimonious = [
+    {file = "parsimonious-0.8.1.tar.gz", hash = "sha256:3add338892d580e0cb3b1a39e4a1b427ff9f687858fdd61097053742391a9f6b"},
+]
 parso = [
     {file = "parso-0.8.2-py2.py3-none-any.whl", hash = "sha256:a8c4922db71e4fdb90e0d0bc6e50f9b273d3397925e5e60a717e719201778d22"},
     {file = "parso-0.8.2.tar.gz", hash = "sha256:12b83492c6239ce32ff5eed6d3639d6a536170723c6f3f1506869f1ace413398"},
@@ -2079,6 +2108,10 @@ pyflakes = [
 pygments = [
     {file = "Pygments-2.9.0-py3-none-any.whl", hash = "sha256:d66e804411278594d764fc69ec36ec13d9ae9147193a1740cd34d272ca383b8e"},
     {file = "Pygments-2.9.0.tar.gz", hash = "sha256:a18f47b506a429f6f4b9df81bb02beab9ca21d0a5fee38ed15aef65f0545519f"},
+]
+pyjexl = [
+    {file = "pyjexl-0.2.3-py2.py3-none-any.whl", hash = "sha256:1369c08c3f1f6931bc3c3089f24e79902680b6022412ccfc5e818441cf0dca52"},
+    {file = "pyjexl-0.2.3.tar.gz", hash = "sha256:56eb1ab1bd78eb12d3c514b6e2f2c93fe7f2fdd00bd821873e3f089706452c51"},
 ]
 pyparsing = [
     {file = "pyparsing-2.4.7-py2.py3-none-any.whl", hash = "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"},
@@ -2260,9 +2293,6 @@ traitlets = [
     {file = "traitlets-5.0.5.tar.gz", hash = "sha256:178f4ce988f69189f7e523337a3e11d91c786ded9360174a3d9ca83e79bc5396"},
 ]
 typing-extensions = [
-    {file = "typing_extensions-3.10.0.0-py2-none-any.whl", hash = "sha256:0ac0f89795dd19de6b97debb0c6af1c70987fd80a2d62d1958f7e56fcc31b497"},
-    {file = "typing_extensions-3.10.0.0-py3-none-any.whl", hash = "sha256:779383f6086d90c99ae41cf0ff39aac8a7937a9283ce0a414e5dd782f4c94a84"},
-    {file = "typing_extensions-3.10.0.0.tar.gz", hash = "sha256:50b6f157849174217d0656f99dc82fe932884fb250826c18350e159ec6cdf342"},
     {file = "typing_extensions-3.10.0.2-py2-none-any.whl", hash = "sha256:d8226d10bc02a29bcc81df19a26e56a9647f8b0a6d4a83924139f4a8b01f17b7"},
     {file = "typing_extensions-3.10.0.2-py3-none-any.whl", hash = "sha256:f1d25edafde516b146ecd0613dabcc61409817af4766fbbcfb8d1ad4ec441a34"},
     {file = "typing_extensions-3.10.0.2.tar.gz", hash = "sha256:49f75d16ff11f1cd258e1b988ccff82a3ca5570217d7ad8c5f48205dd99a677e"},

--- a/app/pyproject.toml
+++ b/app/pyproject.toml
@@ -58,6 +58,7 @@ pydantic = "1.8.2"
 mozilla-nimbus-shared = "^1.5.0"
 django-test-migrations = "^1.1.0"
 django-admin-rangefilter = "0.8.0"
+pyjexl = "^0.2.3"
 
 [tool.poetry.dev-dependencies]
 rope = "^0.19.0"


### PR DESCRIPTION
Because

* We'd like to prevent targeting configs with invalid JEXL syntax from landing

This commit

* Uses the PyJEXL validator to validate the syntax of all targeting configs
* Adds an extra test to make sure new targeting configs are added to both constant classes