### PR TITLE
fix #6393 bug(nimbus): remove duplicates from owners drop down

### DIFF
--- a/app/experimenter/experiments/api/v5/types.py
+++ b/app/experimenter/experiments/api/v5/types.py
@@ -234,6 +234,7 @@ class NimbusConfigurationType(graphene.ObjectType):
         return (
             get_user_model()
             .objects.filter(owned_nimbusexperiments__isnull=False)
+            .distinct()
             .order_by("email")
         )
 


### PR DESCRIPTION
Because

* Whenever you filter by a related entity in django you'll always get duplicates in the results set so you have to add a .distinct() to the end of it

This commit

* Adds the necessary distinct filter to the owners queryset