### PR TITLE
fix #6394 bug(nimbus): set default branches on backend

### DIFF
--- a/app/experimenter/experiments/api/v5/serializers.py
+++ b/app/experimenter/experiments/api/v5/serializers.py
@@ -186,14 +186,6 @@ class NimbusExperimentBranchMixin:
 
         return data
 
-    def create(self, validated_data):
-        experiment = super().create(validated_data)
-        experiment.reference_branch = NimbusBranch.objects.create(
-            experiment=experiment, name="Control", feature_enabled=False
-        )
-        experiment.save()
-        return experiment
-
     def update(self, experiment, data):
         with transaction.atomic():
             if set(data.keys()).intersection({"reference_branch", "treatment_branches"}):

--- a/app/experimenter/experiments/api/v5/types.py
+++ b/app/experimenter/experiments/api/v5/types.py
@@ -307,12 +307,20 @@ class NimbusExperimentType(DjangoObjectType):
         exclude = ("branches",)
 
     def resolve_reference_branch(self, info):
-        return self.reference_branch
+        if self.reference_branch:
+            return self.reference_branch
+        return NimbusBranch(
+            name=NimbusConstants.DEFAULT_REFERENCE_BRANCH_NAME, feature_enabled=False
+        )
 
     def resolve_treatment_branches(self, info):
-        if self.treatment_branches:
+        if self.branches.exists():
             return self.treatment_branches
-        return [NimbusBranch(feature_enabled=False)]
+        return [
+            NimbusBranch(
+                name=NimbusConstants.DEFAULT_TREATMENT_BRANCH_NAME, feature_enabled=False
+            )
+        ]
 
     def resolve_ready_for_review(self, info):
         serializer = NimbusReadyForReviewSerializer(

--- a/app/experimenter/experiments/constants/nimbus.py
+++ b/app/experimenter/experiments/constants/nimbus.py
@@ -555,3 +555,6 @@ Optional - We believe this outcome will <describe impact> on <core metric>
     DAYS_ANALYSIS_BUFFER = 3
 
     PUBLISHED_TARGETING_MISSING = "Published targeting JEXL not found"
+
+    DEFAULT_REFERENCE_BRANCH_NAME = "Control"
+    DEFAULT_TREATMENT_BRANCH_NAME = "Treatment A"

--- a/app/experimenter/experiments/tests/api/v5/test_mutations.py
+++ b/app/experimenter/experiments/tests/api/v5/test_mutations.py
@@ -72,7 +72,8 @@ class TestCreateExperimentMutation(GraphQLTestCase):
         self.assertEqual(experiment.name, "Test 1234")
         self.assertEqual(experiment.slug, "test-1234")
         self.assertEqual(experiment.application, NimbusExperiment.Application.DESKTOP)
-        self.assertEqual(experiment.reference_branch.name, "Control")
+        self.assertIsNone(experiment.reference_branch)
+        self.assertEqual(experiment.treatment_branches, [])
 
     def test_create_experiment_error(self):
         user_email = "user@example.com"

--- a/app/experimenter/experiments/tests/api/v5/test_queries.py
+++ b/app/experimenter/experiments/tests/api/v5/test_queries.py
@@ -56,7 +56,7 @@ class TestNimbusExperimentsQuery(GraphQLTestCase):
         )
         self.assertEqual(experiment_data["canEdit"], experiment.can_edit)
 
-    def test_experiments_with_no_branches_returns_empty_treatment_values(self):
+    def test_experiments_with_no_branches_returns_empty_reference_treatment_values(self):
         user_email = "user@example.com"
         NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.CREATED, branches=[]
@@ -66,6 +66,12 @@ class TestNimbusExperimentsQuery(GraphQLTestCase):
             """
             query {
                 experiments {
+                    referenceBranch {
+                        name
+                        slug
+                        description
+                        ratio
+                    }
                     treatmentBranches {
                         name
                         slug
@@ -81,8 +87,12 @@ class TestNimbusExperimentsQuery(GraphQLTestCase):
         content = json.loads(response.content)
         experiment_data = content["data"]["experiments"][0]
         self.assertEqual(
+            experiment_data["referenceBranch"],
+            {"name": "Control", "slug": "", "description": "", "ratio": 1},
+        )
+        self.assertEqual(
             experiment_data["treatmentBranches"],
-            [{"name": "", "slug": "", "description": "", "ratio": 1}],
+            [{"name": "Treatment A", "slug": "", "description": "", "ratio": 1}],
         )
 
     def test_experiments_with_branches_returns_branch_data(self):

--- a/app/experimenter/experiments/tests/api/v5/test_serializers.py
+++ b/app/experimenter/experiments/tests/api/v5/test_serializers.py
@@ -73,6 +73,7 @@ class TestCreateNimbusExperimentOverviewSerializer(TestCase):
         self.assertEqual(experiment.public_description, data["public_description"])
         # Owner should match the email of the user who created the experiment
         self.assertEqual(experiment.owner, self.user)
+        self.assertFalse(experiment.branches.exists())
 
     @parameterized.expand(list(NimbusExperiment.Application))
     def test_serializer_sets_channel_to_application_channel(self, application):

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/index.test.tsx
@@ -38,37 +38,6 @@ describe("FormBranches", () => {
     expect(onNext).not.toHaveBeenCalled();
   });
 
-  it("sets expected default treatment name", async () => {
-    render(
-      <SubjectBranches
-        {...{
-          experiment: {
-            ...MOCK_EXPERIMENT,
-            referenceBranch: {
-              ...MOCK_EXPERIMENT.referenceBranch!,
-              name: "",
-              slug: "",
-            },
-            treatmentBranches: [
-              {
-                name: "",
-                slug: "",
-                description: "",
-                ratio: 0,
-                featureValue: null,
-                featureEnabled: false,
-              },
-            ],
-          },
-        }}
-      />,
-    );
-    const treatmentBranchName = (await screen.findByTestId(
-      "treatmentBranches[0].name",
-    )) as HTMLInputElement;
-    expect(treatmentBranchName.value).toEqual("Treatment A");
-  });
-
   it("calls onSave with extracted update when save button clicked", async () => {
     const onSave = jest.fn();
     render(<SubjectBranches {...{ onSave }} />);

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/index.tsx
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useEffect, useMemo } from "react";
 import Alert from "react-bootstrap/Alert";
 import Button from "react-bootstrap/Button";
 import Col from "react-bootstrap/Col";
@@ -94,26 +94,9 @@ export const FormBranches = ({
 
   const clearSubmitErrors = () => dispatch({ type: "clearSubmitErrors" });
 
-  // We show two branches by default, an empty control/reference branch and treatment
-  // branch, which are given a default branch name. If a branch slug is not set, it means
-  // that branch hasn't been saved by the user. If only a reference branch was previously
-  // saved we _don't_ show a new treatment branch by default and instead, if "handleAddBranch"
-  // is called, we show the empty treatment branch instead of creating a new one.
-  const [showFirstTreatmentBranch, setShowFirstTreatmentBranch] = useState(
-    !defaultValues.referenceBranch?.slug ||
-      (defaultValues.treatmentBranches &&
-        defaultValues.treatmentBranches[0]?.slug),
-  );
-
   const handleAddBranch = () => {
     commitFormData();
-    if (
-      showFirstTreatmentBranch ||
-      (!showFirstTreatmentBranch && defaultValues.treatmentBranches === null)
-    ) {
-      dispatch({ type: "addBranch" });
-    }
-    if (!showFirstTreatmentBranch) setShowFirstTreatmentBranch(true);
+    dispatch({ type: "addBranch" });
   };
 
   const handleRemoveBranch = (idx: number) => () => {
@@ -227,7 +210,6 @@ export const FormBranches = ({
             />
           )}
           {treatmentBranches &&
-            showFirstTreatmentBranch &&
             treatmentBranches.map((branch, idx) => {
               const treatmentBranchFieldMessages = (
                 fieldMessages as SerializerMessages<SerializerSet[]>

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/reducer/state.ts
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/reducer/state.ts
@@ -67,10 +67,6 @@ export function annotateExperimentBranch(
 ) {
   return {
     ...branch,
-    // Set default treatment branch name - reference branch is set by the server
-    ...(branch.name === "" && {
-      name: lastId === 0 ? "Treatment A" : "",
-    }),
     key: `branch-${lastId}`,
     isValid: true,
     isDirty: false,


### PR DESCRIPTION
Because

* We recently found a bug where an experiment with 1 branch keeps inserting a second branch, even if it's not visible in the UI
* This will become extra critical when we start launching more rollouts since they only have a single branch
* We persistently had issues like this in legacy, where we'd try to populate empty defaults in the frontend, especially for branches, and the pattern we ended up landing on was removing all special cases from the frontend and letting the frontend treat everything passed from the backend verbatim and then passing empty default values back from the backend

This commit

* Removes the special "Treatment A" cases from the frontend
* Removes creating an empty control branch at creation time
* Passes an empty reference branch from the API if no reference branch exists
* Passes an empty treatment branch from the API if no branches exist (so we pass no empty treatment if only a reference branch does exist)