### PR TITLE
fix #6345 feat(nimbus): implement promoting a branch to rollout via cloning

### DIFF
--- a/app/experimenter/experiments/api/v5/inputs.py
+++ b/app/experimenter/experiments/api/v5/inputs.py
@@ -69,5 +69,6 @@ class ExperimentInput(graphene.InputObjectType):
 
 
 class ExperimentCloneInput(graphene.InputObjectType):
-    parent_slug = graphene.String()
-    name = graphene.String()
+    parent_slug = graphene.String(required=True)
+    name = graphene.String(required=True)
+    rollout_branch_slug = graphene.String()

--- a/app/experimenter/nimbus-ui/schema.graphql
+++ b/app/experimenter/nimbus-ui/schema.graphql
@@ -21,8 +21,9 @@ input DocumentationLinkType {
 }
 
 input ExperimentCloneInput {
-  parentSlug: String
-  name: String
+  parentSlug: String!
+  name: String!
+  rolloutBranchSlug: String
 }
 
 input ExperimentInput {

--- a/app/experimenter/nimbus-ui/src/components/CloneDialog/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/CloneDialog/index.stories.tsx
@@ -6,10 +6,10 @@ import { action } from "@storybook/addon-actions";
 import { withLinks } from "@storybook/addon-links";
 import React from "react";
 import CloneDialog from ".";
-import { mockExperimentQuery } from "../../../lib/mocks";
+import { mockExperimentQuery } from "../../lib/mocks";
 
 export default {
-  title: "components/SidebarActions/CloneDialog",
+  title: "components/CloneDialog",
   component: CloneDialog,
   decorators: [withLinks],
 };
@@ -25,6 +25,32 @@ export const Shown = () => {
       <CloneDialog
         {...{
           experiment,
+          show: true,
+          onCancel: onClose,
+          onSave: onClone,
+          isLoading: false,
+          isServerValid: true,
+          submitErrors: {},
+          setSubmitErrors: () => {},
+        }}
+      />
+    </div>
+  );
+};
+
+export const ShownWithRolloutBranchSlug = () => {
+  const onClose = action("close");
+  const onClone = action("clone");
+  return (
+    <div>
+      <p>Background content.</p>
+      <CloneDialog
+        {...{
+          experiment,
+          rolloutBranch: {
+            slug: "very-important-branch",
+            name: "Very Important Branch",
+          },
           show: true,
           onCancel: onClose,
           onSave: onClone,

--- a/app/experimenter/nimbus-ui/src/components/SidebarActions/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/SidebarActions/index.tsx
@@ -16,10 +16,10 @@ import {
   EXTERNAL_URLS,
 } from "../../lib/constants";
 import { getExperiment_experimentBySlug } from "../../types/getExperiment";
+import CloneDialog, { useCloneDialog } from "../CloneDialog";
 import LinkExternal from "../LinkExternal";
 import { LinkNav } from "../LinkNav";
 import { ReactComponent as CloneIcon } from "./clone.svg";
-import CloneDialog, { useCloneDialog } from "./CloneDialog";
 import { ReactComponent as TrashIcon } from "./trash.svg";
 
 type SidebarModifyExperimentProps = {

--- a/app/experimenter/nimbus-ui/src/components/Summary/TableBranches/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/TableBranches/index.tsx
@@ -3,12 +3,17 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React from "react";
-import { Table } from "react-bootstrap";
+import Button from "react-bootstrap/Button";
+import Col from "react-bootstrap/Col";
+import Container from "react-bootstrap/Container";
+import Row from "react-bootstrap/Row";
+import Table from "react-bootstrap/Table";
 import {
   getExperiment_experimentBySlug,
   getExperiment_experimentBySlug_referenceBranch,
   getExperiment_experimentBySlug_treatmentBranches,
 } from "../../../types/getExperiment";
+import CloneDialog, { useCloneDialog } from "../../CloneDialog";
 import { Code } from "../../Code";
 import NotSet from "../../NotSet";
 
@@ -53,7 +58,7 @@ const TableBranches = ({
       ) : (
         <>
           {savedBranches.map((branch, key) => (
-            <TableBranch key={key} {...{ hasSchema, branch }} />
+            <TableBranch key={key} {...{ hasSchema, experiment, branch }} />
           ))}
         </>
       )}
@@ -63,11 +68,16 @@ const TableBranches = ({
 
 const TableBranch = ({
   hasSchema,
-  branch: { name, slug, description, ratio, featureValue, featureEnabled },
+  experiment,
+  branch,
 }: {
   hasSchema: boolean;
+  experiment: getExperiment_experimentBySlug;
   branch: Branch;
 }) => {
+  const { name, slug, description, ratio, featureValue, featureEnabled } =
+    branch;
+  const cloneDialogProps = useCloneDialog(experiment, branch);
   return (
     <Table
       bordered
@@ -82,7 +92,24 @@ const TableBranch = ({
       <thead className="thead-light">
         <tr>
           <th colSpan={2} data-testid="branch-name">
-            <a href={`#${slug}`}>#</a> {name}
+            <Container>
+              <Row>
+                <Col>
+                  <a href={`#${slug}`}>#</a> {name}
+                </Col>
+                <Col className="text-right">
+                  <Button
+                    data-testid="promote-rollout"
+                    variant="outline-primary"
+                    size="sm"
+                    onClick={cloneDialogProps.onShow}
+                  >
+                    Promote to Rollout
+                  </Button>
+                  <CloneDialog {...cloneDialogProps} />
+                </Col>
+              </Row>
+            </Container>
           </th>
         </tr>
       </thead>

--- a/app/experimenter/nimbus-ui/src/types/globalTypes.ts
+++ b/app/experimenter/nimbus-ui/src/types/globalTypes.ts
@@ -163,8 +163,9 @@ export interface DocumentationLinkType {
 }
 
 export interface ExperimentCloneInput {
-  parentSlug?: string | null;
-  name?: string | null;
+  parentSlug: string;
+  name: string;
+  rolloutBranchSlug?: string | null;
 }
 
 export interface ExperimentInput {

--- a/app/tests/integration/nimbus/test_experimenter.py
+++ b/app/tests/integration/nimbus/test_experimenter.py
@@ -41,3 +41,13 @@ def test_clone_experiment(
     summary = create_experiment(selenium)
     summary.clone()
     summary.wait_for_clone_parent_link_visible()
+
+
+@pytest.mark.run_once
+def test_promote_to_rollout(
+    selenium,
+    create_experiment,
+):
+    summary = create_experiment(selenium)
+    summary.promote_first_branch_to_rollout()
+    summary.wait_for_clone_parent_link_visible()


### PR DESCRIPTION
Because:

* we want to try an MVP of experiment rollouts via cloning an experiment
  with one branch

This commit:

* tweaks the experiment model clone method and tests to support rollout
  branch slug

* adds support for rollout_branch_slug to GQL clone mutation

* promotes CloneDialog to be a top-level shared component

* add support for rolloutBranchSlug parameter in cloning mutation

* adds "promote to rollout" buttons to branches that specify
  rolloutBranchSlug for CloneDialog