### PR TITLE
fix #6430 feat(nimbus): load desktop features from mozilla central

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,6 +103,9 @@ google-credentials.json
 # Jetstream config
 app/experimenter/outcomes/jetstream-config*
 
+# Feature Manifests
+app/experimenter/features/manifests*
+
 # Versioning assets generated on build
 **/commit-description.txt
 **/commit-summary.txt

--- a/README.md
+++ b/README.md
@@ -36,8 +36,11 @@ Check out the [🌩 **Nimbus Documentation Hub**](https://experimenter.info) or 
 
 ### General Setup
 
-1.  Install [docker](https://www.docker.com/) on your machine
+1.
 
+On all platforms:
+- Install [Docker](https://www.docker.com/)
+- Install [Node](https://nodejs.org/en/) ^14.0.0
 - On Linux [setup docker to run as non-root](https://docs.docker.com/engine/security/rootless/)
 - On MacOS
   - [Install Docker Desktop 3.3.2](https://docs.docker.com/docker-for-mac/release-notes/#docker-desktop-332) (Newer versions have been buggy)
@@ -89,8 +92,6 @@ One might choose the semi dockerized approach for:
 1. better ide integration
 
 Notes:
-
-- Node ^14.0.0 is required
 
 - [osx catalina, reinstall command line tools](https://medium.com/flawless-app-stories/gyp-no-xcode-or-clt-version-detected-macos-catalina-anansewaa-38b536389e8d)
 

--- a/app/experimenter/features/__init__.py
+++ b/app/experimenter/features/__init__.py
@@ -1,0 +1,83 @@
+import json
+import os
+from enum import Enum
+from typing import Literal, Optional, Union
+
+from django.conf import settings
+from django.core.checks import Error, register
+from pydantic import BaseModel
+
+from experimenter.experiments.constants import NimbusConstants
+
+
+class FeatureVariableType(Enum):
+    INT = "int"
+    STRING = "string"
+    BOOLEAN = "boolean"
+    JSON = "json"
+
+
+class FeatureVariable(BaseModel):
+    description: Optional[str]
+    enum: Optional[list[str]]
+    fallbackPref: Optional[str]
+    type: Optional[FeatureVariableType]
+
+
+class Feature(BaseModel):
+    applicationSlug: str
+    description: Optional[str]
+    exposureDescription: Optional[Union[Literal[False], str]]
+    isEarlyStartup: Optional[bool]
+    slug: str
+    variables: Optional[dict[str, FeatureVariable]]
+
+
+class Features:
+    _features = None
+
+    @classmethod
+    def _load_features(cls):
+        features = []
+
+        for application in NimbusConstants.APPLICATION_CONFIGS.values():
+            application_json_path = os.path.join(
+                settings.FEATURE_MANIFESTS_PATH, f"{application.slug}.json"
+            )
+
+            if os.path.exists(application_json_path):
+                with open(application_json_path) as application_json_file:
+                    application_json_data = json.loads(application_json_file.read())
+                    for feature_slug in application_json_data.keys():
+                        feature_data = application_json_data[feature_slug]
+                        feature_data["slug"] = feature_slug
+                        feature_data["applicationSlug"] = application.slug
+                        features.append(Feature.parse_obj(feature_data))
+
+        return features
+
+    @classmethod
+    def clear_cache(cls):
+        cls._features = None
+
+    @classmethod
+    def all(cls):
+        if cls._features is None:
+            cls._features = cls._load_features()
+
+        return cls._features
+
+    @classmethod
+    def by_application(cls, application):
+        return [f for f in cls.all() if f.applicationSlug == application]
+
+
+@register()
+def check_features(app_configs, **kwargs):
+    errors = []
+
+    try:
+        Features.all()
+    except Exception as e:
+        errors.append(Error(f"Error loading feature data {e}"))
+    return errors

--- a/app/experimenter/features/tests/__init__.py
+++ b/app/experimenter/features/tests/__init__.py
@@ -1,0 +1,16 @@
+import os
+import pathlib
+
+from django.test import override_settings
+
+mock_valid_features = override_settings(
+    FEATURE_MANIFESTS_PATH=os.path.join(
+        pathlib.Path(__file__).parent.absolute(), "fixtures", "valid_features"
+    )
+)
+
+mock_invalid_features = override_settings(
+    FEATURE_MANIFESTS_PATH=os.path.join(
+        pathlib.Path(__file__).parent.absolute(), "fixtures", "invalid_features"
+    )
+)

--- a/app/experimenter/features/tests/fixtures/invalid_features/firefox-desktop.json
+++ b/app/experimenter/features/tests/fixtures/invalid_features/firefox-desktop.json
@@ -1,0 +1,13 @@
+{
+	"readerMode": {
+		"description": "Firefox Reader Mode",
+		"exposureDescription": false,
+		"isEarlyStartup": true,
+		"variables": [
+			{
+				"fallbackPref": "reader.pocket.ctaVersion",
+				"description": "What version of Pocket CTA to show in Reader Mode (Empty string is no CTA)"
+			}
+		]
+	}
+}

--- a/app/experimenter/features/tests/fixtures/valid_features/fenix.json
+++ b/app/experimenter/features/tests/fixtures/valid_features/fenix.json
@@ -1,0 +1,12 @@
+{
+	"defaultBrowser": {
+		"description": "Default Android Browser",
+		"exposureDescription": false,
+		"variables": {
+			"default": {
+				"type": "boolean",
+				"description": "Default browser setting"
+			}
+		}
+	}
+}

--- a/app/experimenter/features/tests/fixtures/valid_features/firefox-desktop.json
+++ b/app/experimenter/features/tests/fixtures/valid_features/firefox-desktop.json
@@ -1,0 +1,18 @@
+{
+	"readerMode": {
+		"description": "Firefox Reader Mode",
+		"exposureDescription": "An exposure event",
+		"isEarlyStartup": true,
+		"variables": {
+			"pocketCTAVersion": {
+				"type": "string",
+				"fallbackPref": "reader.pocket.ctaVersion",
+				"description": "What version of Pocket CTA to show in Reader Mode (Empty string is no CTA)",
+				"enum": [
+					"v1",
+					"v2"
+				]
+			}
+		}
+	}
+}

--- a/app/experimenter/features/tests/test_features.py
+++ b/app/experimenter/features/tests/test_features.py
@@ -1,0 +1,114 @@
+from django.core.checks import Error
+from django.test import TestCase
+
+from experimenter.experiments.constants import NimbusConstants
+from experimenter.features import (
+    Feature,
+    Features,
+    FeatureVariable,
+    FeatureVariableType,
+    check_features,
+)
+from experimenter.features.tests import mock_invalid_features, mock_valid_features
+
+
+@mock_valid_features
+class TestFeatures(TestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        Features.clear_cache()
+
+    def test_load_all_features(self):
+        features = Features.all()
+        self.assertEqual(len(features), 2)
+        self.assertIn(
+            Feature(
+                applicationSlug="firefox-desktop",
+                description="Firefox Reader Mode",
+                exposureDescription="An exposure event",
+                isEarlyStartup=True,
+                slug="readerMode",
+                variables={
+                    "pocketCTAVersion": FeatureVariable(
+                        description=(
+                            "What version of Pocket CTA to show in Reader Mode "
+                            "(Empty string is no CTA)"
+                        ),
+                        enum=["v1", "v2"],
+                        fallbackPref="reader.pocket.ctaVersion",
+                        type=FeatureVariableType.STRING,
+                    )
+                },
+            ),
+            features,
+        )
+
+        self.assertIn(
+            Feature(
+                applicationSlug="fenix",
+                description="Default Android Browser",
+                exposureDescription=False,
+                isEarlyStartup=None,
+                slug="defaultBrowser",
+                variables={
+                    "default": FeatureVariable(
+                        description="Default browser setting",
+                        fallbackPref=None,
+                        type=FeatureVariableType.BOOLEAN,
+                    )
+                },
+            ),
+            features,
+        )
+
+    def test_load_features_by_application(self):
+        desktop_features = Features.by_application(NimbusConstants.Application.DESKTOP)
+        self.assertEqual(len(desktop_features), 1)
+        self.assertIn(
+            Feature(
+                applicationSlug="firefox-desktop",
+                description="Firefox Reader Mode",
+                exposureDescription="An exposure event",
+                isEarlyStartup=True,
+                slug="readerMode",
+                variables={
+                    "pocketCTAVersion": FeatureVariable(
+                        description=(
+                            "What version of Pocket CTA to show in Reader Mode "
+                            "(Empty string is no CTA)"
+                        ),
+                        enum=["v1", "v2"],
+                        fallbackPref="reader.pocket.ctaVersion",
+                        type=FeatureVariableType.STRING,
+                    )
+                },
+            ),
+            desktop_features,
+        )
+
+
+class TestCheckFeatures(TestCase):
+    def setUp(self):
+        Features.clear_cache()
+
+    @mock_valid_features
+    def test_valid_features_do_not_trigger_check_error(self):
+        errors = check_features(None)
+        self.assertEqual(errors, [])
+
+    @mock_invalid_features
+    def test_invalid_features_do_trigger_check_error(self):
+        errors = check_features(None)
+        self.assertEqual(
+            errors,
+            [
+                Error(
+                    msg=(
+                        "Error loading feature data 1 validation error for "
+                        "Feature\nvariables -> fallbackPref\n  value is "
+                        "not a valid dict (type=type_error.dict)"
+                    )
+                )
+            ],
+        )

--- a/app/experimenter/settings.py
+++ b/app/experimenter/settings.py
@@ -73,9 +73,10 @@ INSTALLED_APPS = [
     # Experimenter
     "experimenter.base",
     "experimenter.experiments",
+    "experimenter.features",
+    "experimenter.jetstream",
     "experimenter.kinto",
     "experimenter.normandy",
-    "experimenter.jetstream",
     "experimenter.notifications",
     "experimenter.openidc",
     "experimenter.outcomes",
@@ -439,6 +440,9 @@ NIMBUS_SCHEMA_VERSION = pkg_resources.get_distribution("mozilla-nimbus-shared").
 JETSTREAM_CONFIG_OUTCOMES_PATH = os.path.join(
     BASE_DIR, "outcomes", "jetstream-config-main", "outcomes"
 )
+
+# Feature Manifest path
+FEATURE_MANIFESTS_PATH = os.path.join(BASE_DIR, "features", "manifests")
 
 SKIP_REVIEW_ACCESS_CONTROL_FOR_DEV_USER = config(
     "SKIP_REVIEW_ACCESS_CONTROL_FOR_DEV_USER", default=False, cast=bool


### PR DESCRIPTION
Because

* We'd like to consume feature manifests directly from client repos instead of storing them in the database

This commit

* Downloads the desktop feature manifest at container build time
* Adds a features app that parses the desktop feature manifest into memory