### PR TITLE
fix #6421 feat(nimbus): add support for screenshot upload and in-place update for branches

### DIFF
--- a/app/experimenter/base/tests/test_base.py
+++ b/app/experimenter/base/tests/test_base.py
@@ -2,8 +2,9 @@ import mock
 from django.conf import settings
 from django.core.files.storage import FileSystemStorage
 from django.test import TestCase, override_settings
+from inmemorystorage import InMemoryStorage
 
-from experimenter.base import app_version, get_uploads_storage
+from experimenter.base import UploadsStorage, app_version, get_uploads_storage
 
 
 class TestAppVersion(TestCase):
@@ -53,36 +54,42 @@ class TestAppVersion(TestCase):
 
 
 class TestGetUploadsStorage(TestCase):
-    def setUp(self):
-        get_uploads_storage.cache_clear()
+    @override_settings(UPLOADS_GS_CREDENTIALS=None, UPLOADS_FILE_STORAGE=None)
+    def test_get_uploads_storage_default(self):
+        self.assertIsInstance(get_uploads_storage(), FileSystemStorage)
 
-    @override_settings(UPLOADS_GS_CREDENTIALS=None)
-    def test_get_uploads_storage_file(self):
-        storage = get_uploads_storage()
-        self.assertIsInstance(storage, FileSystemStorage)
+    @override_settings(
+        UPLOADS_GS_CREDENTIALS="should-be-ignored-for-testing.json",
+        UPLOADS_FILE_STORAGE="inmemorystorage.InMemoryStorage",
+    )
+    def test_get_uploads_storage_custom(self):
+        self.assertIsInstance(get_uploads_storage(), InMemoryStorage)
 
+    @override_settings(
+        UPLOADS_GS_CREDENTIALS="/app/uploads-credentials.json",
+        UPLOADS_GS_BUCKET_NAME="bazquux",
+        UPLOADS_FILE_STORAGE=None,
+    )
     @mock.patch("experimenter.base.service_account")
     @mock.patch("experimenter.base.GoogleCloudStorage")
     def test_get_uploads_storage_gcp(self, MockGoogleCloudStorage, mock_service_account):
-        expected_bucket_name = "bazquux"
-        expected_credentials = "/app/uploads-credentials.json"
+        storage = get_uploads_storage()
+        self.assertEqual(storage, MockGoogleCloudStorage.return_value)
 
-        with self.settings(
-            UPLOADS_GS_BUCKET_NAME=expected_bucket_name,
-            UPLOADS_GS_CREDENTIALS=expected_credentials,
-        ):
-            storage = get_uploads_storage()
-            self.assertEqual(storage, MockGoogleCloudStorage.return_value)
+        from_service_account_file = (
+            mock_service_account.Credentials.from_service_account_file
+        )
+        from_service_account_file.assert_called_with(
+            "/app/uploads-credentials.json",
+        )
+        mock_credentials = from_service_account_file.return_value
+        MockGoogleCloudStorage.assert_called_with(
+            credentials=mock_credentials,
+            project_id=mock_credentials.project_id,
+            bucket_name="bazquux",
+        )
 
-            from_service_account_file = (
-                mock_service_account.Credentials.from_service_account_file
-            )
-            from_service_account_file.assert_called_with(
-                expected_credentials,
-            )
-            mock_credentials = from_service_account_file.return_value
-            MockGoogleCloudStorage.assert_called_with(
-                credentials=mock_credentials,
-                project_id=mock_credentials.project_id,
-                bucket_name=expected_bucket_name,
-            )
+    @mock.patch("experimenter.base.get_uploads_storage")
+    def test_uploads_storage_class(self, mock_get_uploads_storage):
+        storage = UploadsStorage()
+        self.assertTrue(storage._wrapped, mock_get_uploads_storage.return_value)

--- a/app/experimenter/experiments/api/v5/inputs.py
+++ b/app/experimenter/experiments/api/v5/inputs.py
@@ -1,4 +1,5 @@
 import graphene
+from graphene_file_upload.scalars import Upload
 
 from experimenter.experiments.api.v5.types import (
     NimbusExperimentApplication,
@@ -10,12 +11,19 @@ from experimenter.experiments.api.v5.types import (
 )
 
 
+class BranchScreenshotType(graphene.InputObjectType):
+    image = Upload(required=True)
+    description = graphene.String(required=True)
+
+
 class BranchType(graphene.InputObjectType):
+    id = graphene.Int()
     name = graphene.String(required=True)
     description = graphene.String(required=True)
     ratio = graphene.Int(required=True)
     feature_enabled = graphene.Boolean()
     feature_value = graphene.String()
+    screenshots = graphene.List(BranchScreenshotType)
 
 
 class DocumentationLinkType(graphene.InputObjectType):

--- a/app/experimenter/experiments/api/v5/types.py
+++ b/app/experimenter/experiments/api/v5/types.py
@@ -106,7 +106,7 @@ class NimbusExperimentDocumentationLink(graphene.Enum):
 class NimbusBranchType(DjangoObjectType):
     class Meta:
         model = NimbusBranch
-        exclude = ("id", "experiment", "nimbusexperiment")
+        exclude = ("experiment", "nimbusexperiment")
 
 
 class NimbusDocumentationLinkType(DjangoObjectType):

--- a/app/experimenter/experiments/api/v5/urls.py
+++ b/app/experimenter/experiments/api/v5/urls.py
@@ -1,11 +1,11 @@
 from django.conf.urls import url
 from django.views.decorators.csrf import csrf_exempt
-from graphene_django.views import GraphQLView
+from graphene_file_upload.django import FileUploadGraphQLView
 
 urlpatterns = [
     url(
         r"graphql",
-        csrf_exempt(GraphQLView.as_view(graphiql=True)),
+        csrf_exempt(FileUploadGraphQLView.as_view(graphiql=True)),
         name="nimbus-api-graphql",
     ),
 ]

--- a/app/experimenter/experiments/migrations/0185_nimbusbranchscreenshot.py
+++ b/app/experimenter/experiments/migrations/0185_nimbusbranchscreenshot.py
@@ -28,7 +28,7 @@ class Migration(migrations.Migration):
                 (
                     "image",
                     models.ImageField(
-                        storage=experimenter.experiments.models.nimbus.nimbus_branch_screenshot_storage,
+                        storage=experimenter.base.UploadsStorage,
                         upload_to=experimenter.experiments.models.nimbus.nimbus_branch_screenshot_upload_to,
                     ),
                 ),

--- a/app/experimenter/experiments/models/nimbus.py
+++ b/app/experimenter/experiments/models/nimbus.py
@@ -17,7 +17,7 @@ from django.urls import reverse
 from django.utils import timezone
 from django.utils.text import slugify
 
-from experimenter.base import get_uploads_storage
+from experimenter.base import UploadsStorage
 from experimenter.base.models import Country, Locale
 from experimenter.experiments.constants import NimbusConstants
 from experimenter.projects.models import Project
@@ -559,14 +559,7 @@ class NimbusBranch(models.Model):
 def nimbus_branch_screenshot_upload_to(screenshot, filename):
     id = uuid4()
     ext = filename.split(".")[-1].lower()
-    return os.path.join(
-        screenshot.branch.experiment.slug, screenshot.branch.slug, f"{id}.{ext}"
-    )
-
-
-# Helper that Django can serialize into a migration, cannot serialize functools.cache
-def nimbus_branch_screenshot_storage():
-    return get_uploads_storage()
+    return os.path.join(screenshot.branch.experiment.slug, f"{id}.{ext}")
 
 
 class NimbusBranchScreenshot(models.Model):
@@ -576,7 +569,7 @@ class NimbusBranchScreenshot(models.Model):
         on_delete=models.CASCADE,
     )
     image = models.ImageField(
-        storage=nimbus_branch_screenshot_storage,
+        storage=UploadsStorage,
         upload_to=nimbus_branch_screenshot_upload_to,
     )
     description = models.TextField(blank=True, default="")

--- a/app/experimenter/experiments/tests/factories/__init__.py
+++ b/app/experimenter/experiments/tests/factories/__init__.py
@@ -9,7 +9,9 @@ from experimenter.experiments.tests.factories.legacy import (  # noqa: F401
     VariantPreferencesFactory,
 )
 from experimenter.experiments.tests.factories.nimbus import (  # noqa: F401
+    TINY_PNG,
     NimbusBranchFactory,
+    NimbusBranchScreenshotFactory,
     NimbusBucketRangeFactory,
     NimbusChangeLogFactory,
     NimbusDocumentationLinkFactory,

--- a/app/experimenter/nimbus-ui/schema.graphql
+++ b/app/experimenter/nimbus-ui/schema.graphql
@@ -3,6 +3,11 @@ schema {
   mutation: Mutation
 }
 
+input BranchScreenshotType {
+  image: Upload!
+  description: String!
+}
+
 type CloneExperiment {
   nimbusExperiment: NimbusExperimentType
   message: ObjectField
@@ -68,6 +73,7 @@ type Mutation {
 }
 
 type NimbusBranchType {
+  id: ID!
   name: String!
   slug: String!
   description: String!
@@ -465,22 +471,28 @@ type Query {
 }
 
 input ReferenceBranchType {
+  id: Int
   name: String!
   description: String!
   ratio: Int!
   featureEnabled: Boolean
   featureValue: String
+  screenshots: [BranchScreenshotType]
 }
 
 input TreatmentBranchType {
+  id: Int
   name: String!
   description: String!
   ratio: Int!
   featureEnabled: Boolean
   featureValue: String
+  screenshots: [BranchScreenshotType]
 }
 
 type UpdateExperiment {
   nimbusExperiment: NimbusExperimentType
   message: ObjectField
 }
+
+scalar Upload

--- a/app/experimenter/nimbus-ui/src/react-app-env.d.ts
+++ b/app/experimenter/nimbus-ui/src/react-app-env.d.ts
@@ -12,3 +12,6 @@ type SerializerSet = Record<string, SerializerMessage>;
 type SerializerMessages<
   T = SerializerMessage | SerializerSet | SerializerSet[],
 > = Record<string, T>;
+
+// TODO: implement the correct type here for EXP-1766
+type Upload = any;

--- a/app/experimenter/nimbus-ui/src/types/globalTypes.ts
+++ b/app/experimenter/nimbus-ui/src/types/globalTypes.ts
@@ -157,6 +157,11 @@ export enum NimbusExperimentStatus {
   PREVIEW = "PREVIEW",
 }
 
+export interface BranchScreenshotType {
+  image: Upload;
+  description: string;
+}
+
 export interface DocumentationLinkType {
   title: NimbusExperimentDocumentationLink;
   link: string;
@@ -202,19 +207,23 @@ export interface ExperimentInput {
 }
 
 export interface ReferenceBranchType {
+  id?: number | null;
   name: string;
   description: string;
   ratio: number;
   featureEnabled?: boolean | null;
   featureValue?: string | null;
+  screenshots?: (BranchScreenshotType | null)[] | null;
 }
 
 export interface TreatmentBranchType {
+  id?: number | null;
   name: string;
   description: string;
   ratio: number;
   featureEnabled?: boolean | null;
   featureValue?: string | null;
+  screenshots?: (BranchScreenshotType | null)[] | null;
 }
 
 //==============================================================

--- a/app/experimenter/settings.py
+++ b/app/experimenter/settings.py
@@ -432,6 +432,9 @@ GS_BUCKET_NAME = "mozanalysis"
 UPLOADS_GS_CREDENTIALS = config("UPLOADS_GS_CREDENTIALS", default=None)
 UPLOADS_GS_BUCKET_NAME = config("UPLOADS_GS_BUCKET_NAME", default=None)
 
+# Custom file storage override for user uploads (e.g. for testing)
+UPLOADS_FILE_STORAGE = config("UPLOADS_FILE_STORAGE", default=None)
+
 NIMBUS_SCHEMA_VERSION = pkg_resources.get_distribution("mozilla-nimbus-shared").version
 
 

--- a/app/experimenter/settings_test.py
+++ b/app/experimenter/settings_test.py
@@ -1,0 +1,3 @@
+from .settings import *
+
+UPLOADS_FILE_STORAGE = "inmemorystorage.InMemoryStorage"

--- a/app/poetry.lock
+++ b/app/poetry.lock
@@ -275,6 +275,18 @@ optional = false
 python-versions = ">=3.5"
 
 [[package]]
+name = "dj-inmemorystorage"
+version = "2.1.0"
+description = "A non-persistent in-memory data storage backend for Django."
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+Django = ">=1.11"
+six = ">=1.10"
+
+[[package]]
 name = "django"
 version = "3.2.5"
 description = "A high-level Python Web framework that encourages rapid development and clean, pragmatic design."
@@ -656,6 +668,23 @@ text-unidecode = "*"
 dev = ["black (==19.10b0)", "flake8 (==3.7.9)", "flake8-black (==0.1.1)", "flake8-bugbear (==20.1.4)", "pytest (>=3.6.3)", "pytest-cov", "coveralls", "mock", "pytz", "pytest-django (>=3.3.2)", "djangorestframework (>=3.6.3)", "django-filter (<2)", "django-filter (>=2)"]
 rest_framework = ["djangorestframework (>=3.6.3)"]
 test = ["pytest (>=3.6.3)", "pytest-cov", "coveralls", "mock", "pytz", "pytest-django (>=3.3.2)", "djangorestframework (>=3.6.3)", "django-filter (<2)", "django-filter (>=2)"]
+
+[[package]]
+name = "graphene-file-upload"
+version = "1.3.0"
+description = "Lib for adding file upload functionality to GraphQL mutations in Graphene Django and Flask-Graphql"
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+six = ">=1.11.0"
+
+[package.extras]
+all = ["Flask (>=1.0.2)", "graphene (>=2.1.2)", "Flask-Graphql (>=2.0.0)", "graphene-django (>=2.0.0)"]
+django = ["graphene-django (>=2.0.0)"]
+flask = ["Flask (>=1.0.2)", "graphene (>=2.1.2)", "Flask-Graphql (>=2.0.0)"]
+tests = ["coverage", "pytest", "pytest-cov", "pytest-django"]
 
 [[package]]
 name = "graphql-core"
@@ -1560,7 +1589,7 @@ brotli = ["brotli"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9"
-content-hash = "7e9c8e42586ae0ceaf9984526059485f945ed7c9fc00a4875c27ae53c8df44d2"
+content-hash = "8c7f5e9506f60556be7c9e2c6a25250f858f7eafd1a04ab322ff5d9db3a0dd03"
 
 [metadata.files]
 amqp = [
@@ -1743,6 +1772,10 @@ decorator = [
     {file = "decorator-5.0.9-py3-none-any.whl", hash = "sha256:6e5c199c16f7a9f0e3a61a4a54b3d27e7dad0dbdde92b944426cb20914376323"},
     {file = "decorator-5.0.9.tar.gz", hash = "sha256:72ecfba4320a893c53f9706bebb2d55c270c1e51a28789361aa93e4a21319ed5"},
 ]
+dj-inmemorystorage = [
+    {file = "dj-inmemorystorage-2.1.0.tar.gz", hash = "sha256:1771801613414262803a1a1e97dafd2b7a563e78fbcbfa2b6f841c9d8e7b872a"},
+    {file = "dj_inmemorystorage-2.1.0-py2.py3-none-any.whl", hash = "sha256:81aa007a7cdb1899b3cd92404f656c82cd690a831b8698a43045f859d7276945"},
+]
 django = [
     {file = "Django-3.2.5-py3-none-any.whl", hash = "sha256:c58b5f19c5ae0afe6d75cbdd7df561e6eb929339985dbbda2565e1cabb19a62e"},
     {file = "Django-3.2.5.tar.gz", hash = "sha256:3da05fea54fdec2315b54a563d5b59f3b4e2b1e69c3a5841dda35019c01855cd"},
@@ -1877,6 +1910,10 @@ graphene = [
 graphene-django = [
     {file = "graphene-django-2.15.0.tar.gz", hash = "sha256:b78c9b05bc899016b9cc5bf13faa1f37fe1faa8c5407552c6ddd1a28f46fc31a"},
     {file = "graphene_django-2.15.0-py2.py3-none-any.whl", hash = "sha256:02671d195f0c09c8649acff2a8f4ad4f297d0f7d98ea6e6cdf034b81bab92880"},
+]
+graphene-file-upload = [
+    {file = "graphene_file_upload-1.3.0-py3-none-any.whl", hash = "sha256:5afe50f409f50e3d198fd92c883d98d868e6c6aaadf5df3a3f4d88ecad90ed97"},
+    {file = "graphene_file_upload-1.3.0.tar.gz", hash = "sha256:6898480b0556826472c80971032917c01968ade5800d84054008fe598795b063"},
 ]
 graphql-core = [
     {file = "graphql-core-2.3.2.tar.gz", hash = "sha256:aac46a9ac524c9855910c14c48fc5d60474def7f99fd10245e76608eba7af746"},

--- a/app/pyproject.toml
+++ b/app/pyproject.toml
@@ -60,6 +60,8 @@ django-test-migrations = "^1.1.0"
 django-admin-rangefilter = "0.8.0"
 pyjexl = "^0.2.3"
 Pillow = "^8.3.2"
+graphene-file-upload = "^1.3.0"
+dj-inmemorystorage = "^2.1.0"
 
 [tool.poetry.dev-dependencies]
 rope = "^0.19.0"

--- a/app/pytest.ini
+++ b/app/pytest.ini
@@ -1,6 +1,6 @@
 # -- FILE: pytest.ini (or tox.ini)
 [pytest]
-DJANGO_SETTINGS_MODULE = experimenter.settings
+DJANGO_SETTINGS_MODULE = experimenter.settings_test
 # -- recommended but optional:
 addopts = -vvvv --ignore=tests/integration --show-capture=no --disable-warnings -n 4
 python_files = tests.py test_*.py *_tests.py


### PR DESCRIPTION
Because:

* we want to support uploading and managing screenshots associated with
  branches

This commit:

* switches from GraphQLView to FileUploadGraphQLView in v5 API urls to
  add support for multipart file uploads

* reduces length of screenshot filenames by removing the branch slug

* adds BranchScreenshotType under BranchType for GQL experiment input

* enhancements to NimbusBranchSerializer to support for specifying
  branch ID to perform in-place update

* adds NimbusBranchScreenshotSerializer to handle screenshot management

* adds NimbusBranchReadyForReviewSerializer to validate screenshots for
  review readiness without requiring screenshot content

* sets up a new settings_test.py module for testing-specific overrides
  to Django settings

* adds UPLOADS_FILE_STORAGE setting to override file storage for uploads
  with a named class (e.g. inmemorystorage.InMemoryStorage)

* adds NimbusBranchScreenshotFactory to generate screenshots

* updated GQL types to account for new screenshots model, with temporary
  stub for Upload type in nimbus-ui (to be defined in EXP-1766)

* adds graphene-file-upload and dj-inmemorystorage dependencies