### PR TITLE
fixes #5746 feat(nimbus): add placeholder tips for public descriptions

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/FormOverview/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/FormOverview/index.tsx
@@ -13,6 +13,7 @@ import { useConfig } from "../../hooks/useConfig";
 import { ReactComponent as Info } from "../../images/info.svg";
 import {
   EXTERNAL_URLS,
+  PUBLIC_DESCRIPTION_PLACEHOLDER,
   REQUIRED_FIELD,
   RISK_QUESTIONS,
 } from "../../lib/constants";
@@ -231,6 +232,7 @@ const FormOverview = ({
               <Form.Control
                 as="textarea"
                 rows={3}
+                placeholder={PUBLIC_DESCRIPTION_PLACEHOLDER}
                 {...formControlAttrs("publicDescription")}
               />
               <Form.Text className="text-muted">

--- a/app/experimenter/nimbus-ui/src/lib/constants.ts
+++ b/app/experimenter/nimbus-ui/src/lib/constants.ts
@@ -126,6 +126,9 @@ export const FIELD_MESSAGES = {
   URL: "This field must be a URL.",
 };
 
+export const PUBLIC_DESCRIPTION_PLACEHOLDER =
+  "The public description should be descriptive and publicly appropriate in order to avoid user confusion if they were to see it. It should avoid being too technical or too detailed.";
+
 export const REQUIRED_FIELD = {
   required: FIELD_MESSAGES.REQUIRED,
 } as RegisterOptions;


### PR DESCRIPTION
Because

* there is some confusion about public descriptions

This Commit

* adds placeholder tips for public descriptions