### PR TITLE
fix #6475 chore(nimbus): move targeting config expression to front of whole targeting expression

### DIFF
--- a/app/experimenter/experiments/constants/nimbus.py
+++ b/app/experimenter/experiments/constants/nimbus.py
@@ -186,19 +186,6 @@ TARGETING_MOBILE_FIRST_RUN = NimbusTargetingConfig(
     application_choice_names=(Application.FENIX.name, Application.IOS.name),
 )
 
-TARGETING_HOMEPAGE_GOOGLE = NimbusTargetingConfig(
-    name="Homepage set to google.com",
-    slug="homepage_google_dot_com",
-    description="Users with their Homepage set to google.com",
-    targeting=(
-        "!homePageSettings.isDefault && "
-        "homePageSettings.isCustomUrl && "
-        "homePageSettings.urls[.host == 'google.com']|length > 0"
-    ),
-    desktop_telemetry="",
-    application_choice_names=(Application.DESKTOP.name,),
-)
-
 TARGETING_URLBAR_FIREFOX_SUGGEST = NimbusTargetingConfig(
     name="Urlbar (Firefox Suggest)",
     slug="urlbar_firefox_suggest",
@@ -483,7 +470,6 @@ class NimbusConstants(object):
         TARGETING_FIRST_RUN_WINDOWS_1903_NEWER.slug: (
             TARGETING_FIRST_RUN_WINDOWS_1903_NEWER
         ),
-        TARGETING_HOMEPAGE_GOOGLE.slug: TARGETING_HOMEPAGE_GOOGLE,
         TARGETING_URLBAR_FIREFOX_SUGGEST.slug: TARGETING_URLBAR_FIREFOX_SUGGEST,
         TARGETING_MAC_ONLY.slug: TARGETING_MAC_ONLY,
         TARGETING_NO_ENTERPRISE.slug: TARGETING_NO_ENTERPRISE,
@@ -503,14 +489,12 @@ class NimbusConstants(object):
         NO_TARGETING = TARGETING_NO_TARGETING.slug, TARGETING_NO_TARGETING.name
         TARGETING_FIRST_RUN = TARGETING_FIRST_RUN.slug, TARGETING_FIRST_RUN.name
         TARGETING_FIRST_RUN_CHROME_ATTRIBUTION = (
-            TARGETING_FIRST_RUN_CHROME_ATTRIBUTION.slug
-        ), TARGETING_FIRST_RUN_CHROME_ATTRIBUTION.name
+            TARGETING_FIRST_RUN_CHROME_ATTRIBUTION.slug,
+            TARGETING_FIRST_RUN_CHROME_ATTRIBUTION.name,
+        )
         TARGETING_FIRST_RUN_WINDOWS_1903_NEWER = (
-            TARGETING_FIRST_RUN_WINDOWS_1903_NEWER.slug
-        ), TARGETING_FIRST_RUN_WINDOWS_1903_NEWER.name
-        TARGETING_HOMEPAGE_GOOGLE = (
-            TARGETING_HOMEPAGE_GOOGLE.slug,
-            TARGETING_HOMEPAGE_GOOGLE.name,
+            TARGETING_FIRST_RUN_WINDOWS_1903_NEWER.slug,
+            TARGETING_FIRST_RUN_WINDOWS_1903_NEWER.name,
         )
         TARGETING_URLBAR_FIREFOX_SUGGEST = (
             TARGETING_URLBAR_FIREFOX_SUGGEST.slug,

--- a/app/experimenter/experiments/models/nimbus.py
+++ b/app/experimenter/experiments/models/nimbus.py
@@ -227,6 +227,9 @@ class NimbusExperiment(NimbusConstants, FilterMixin, models.Model):
 
         expressions = []
 
+        if self.targeting_config and self.targeting_config.targeting:
+            expressions.append(self.targeting_config.targeting)
+
         if self.application == self.Application.DESKTOP:
             if self.channel:
                 expressions.append(
@@ -243,9 +246,6 @@ class NimbusExperiment(NimbusConstants, FilterMixin, models.Model):
 
             # TODO: Remove opt-out after Firefox 84 is the earliest supported Desktop
             expressions.append("'app.shield.optoutstudies.enabled'|preferenceValue")
-
-        if self.targeting_config and self.targeting_config.targeting:
-            expressions.append(self.targeting_config.targeting)
 
         if self.locales.count():
             locales = [locale.code for locale in self.locales.all().order_by("code")]

--- a/app/experimenter/experiments/tests/test_models/test_models_nimbus.py
+++ b/app/experimenter/experiments/tests/test_models/test_models_nimbus.py
@@ -216,9 +216,9 @@ class TestNimbusExperiment(TestCase):
         self.assertEqual(
             experiment.targeting,
             (
-                "version|versionCompare('83.!') >= 0 "
-                "&& 'app.shield.optoutstudies.enabled'|preferenceValue "
-                "&& os.isMac"
+                "os.isMac "
+                "&& version|versionCompare('83.!') >= 0 "
+                "&& 'app.shield.optoutstudies.enabled'|preferenceValue"
             ),
         )
 
@@ -251,9 +251,9 @@ class TestNimbusExperiment(TestCase):
         self.assertEqual(
             experiment.targeting,
             (
-                'browserSettings.update.channel == "nightly" '
-                "&& 'app.shield.optoutstudies.enabled'|preferenceValue "
-                "&& os.isMac"
+                "os.isMac "
+                '&& browserSettings.update.channel == "nightly" '
+                "&& 'app.shield.optoutstudies.enabled'|preferenceValue"
             ),
         )
 
@@ -269,7 +269,7 @@ class TestNimbusExperiment(TestCase):
         )
         self.assertEqual(
             experiment.targeting,
-            "'app.shield.optoutstudies.enabled'|preferenceValue && os.isMac",
+            "os.isMac && 'app.shield.optoutstudies.enabled'|preferenceValue",
         )
 
     def test_targeting_with_locales(self):
@@ -287,8 +287,8 @@ class TestNimbusExperiment(TestCase):
         self.assertEqual(
             experiment.targeting,
             (
-                "'app.shield.optoutstudies.enabled'|preferenceValue "
-                "&& os.isMac "
+                "os.isMac "
+                "&& 'app.shield.optoutstudies.enabled'|preferenceValue "
                 "&& locale in ['en-CA', 'en-US']"
             ),
         )
@@ -308,8 +308,8 @@ class TestNimbusExperiment(TestCase):
         self.assertEqual(
             experiment.targeting,
             (
-                "'app.shield.optoutstudies.enabled'|preferenceValue "
-                "&& os.isMac "
+                "os.isMac "
+                "&& 'app.shield.optoutstudies.enabled'|preferenceValue "
                 "&& region in ['CA', 'US']"
             ),
         )
@@ -331,8 +331,8 @@ class TestNimbusExperiment(TestCase):
         self.assertEqual(
             experiment.targeting,
             (
-                "'app.shield.optoutstudies.enabled'|preferenceValue "
-                "&& os.isMac "
+                "os.isMac "
+                "&& 'app.shield.optoutstudies.enabled'|preferenceValue "
                 "&& locale in ['en-CA', 'en-US'] "
                 "&& region in ['CA', 'US']"
             ),


### PR DESCRIPTION


Because

* For our new integration tests to properly check the validity of targeting config jexl expressions, the targeting config expression must be the first expression otherwise the jexl evaluator might short circuit before it gets to the targeting config expression

This commit

* Moves the targeting config expression up to the front of whole expression
* This exposes that the homepage targeting config is no longer valid in the current Firefox, so it is removed