### PR TITLE
fix #6469 fix(nimbus): use proposed enrollment duration until requested pause has been approved

### DIFF
--- a/app/experimenter/experiments/models/nimbus.py
+++ b/app/experimenter/experiments/models/nimbus.py
@@ -323,7 +323,7 @@ class NimbusExperiment(NimbusConstants, FilterMixin, models.Model):
     def computed_enrollment_days(self):
         paused_change = (
             self.changes.all()
-            .filter(experiment_data__is_paused=True)
+            .filter(NimbusChangeLog.Filters.IS_APPROVED_PAUSE)
             .order_by("changed_on")
             .first()
         )
@@ -792,6 +792,12 @@ class NimbusChangeLog(FilterMixin, models.Model):
             Q(old_status=F("new_status")),
             old_publish_status=NimbusExperiment.PublishStatus.WAITING,
             new_publish_status=NimbusExperiment.PublishStatus.REVIEW,
+        )
+        IS_APPROVED_PAUSE = Q(
+            experiment_data__is_paused=True,
+            new_status=NimbusExperiment.Status.LIVE,
+            new_status_next=None,
+            new_publish_status=NimbusExperiment.PublishStatus.IDLE,
         )
 
     class Messages:

--- a/app/experimenter/experiments/tests/test_models/test_models_nimbus.py
+++ b/app/experimenter/experiments/tests/test_models/test_models_nimbus.py
@@ -490,14 +490,17 @@ class TestNimbusExperiment(TestCase):
         self.assertTrue(experiment.should_end_enrollment)
 
     def test_computed_enrollment_days_returns_changed_on_minus_start_date(self):
+        expected_days = 3
         experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperimentFactory.Lifecycles.ENDING_APPROVE_APPROVE,
+            NimbusExperimentFactory.Lifecycles.PAUSING_APPROVE_APPROVE,
         )
 
         experiment.changes.filter(
             old_status=NimbusExperiment.Status.DRAFT,
             new_status=NimbusExperiment.Status.LIVE,
-        ).update(changed_on=datetime.datetime.now() - datetime.timedelta(days=3))
+        ).update(
+            changed_on=datetime.datetime.now() - datetime.timedelta(days=expected_days)
+        )
 
         experiment.changes.filter(experiment_data__is_paused=True).update(
             changed_on=datetime.datetime.now()
@@ -505,7 +508,7 @@ class TestNimbusExperiment(TestCase):
 
         self.assertEqual(
             experiment.computed_enrollment_days,
-            3,
+            expected_days,
         )
 
     def test_computed_enrollment_days_uses_end_date_without_pause(self):
@@ -537,6 +540,34 @@ class TestNimbusExperiment(TestCase):
         self.assertEqual(
             experiment.computed_enrollment_days,
             experiment.proposed_enrollment,
+        )
+
+    @parameterized.expand(
+        [
+            (NimbusExperimentFactory.Lifecycles.PAUSING_REVIEW_REQUESTED,),
+            (NimbusExperimentFactory.Lifecycles.PAUSING_APPROVE,),
+            (NimbusExperimentFactory.Lifecycles.PAUSING_APPROVE_WAITING,),
+        ]
+    )
+    def test_computed_enrollment_days_returns_fallback_while_pause_pending_approval(
+        self, lifecycle
+    ):
+        expected_days = 99
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            lifecycle,
+            proposed_enrollment=expected_days,
+        )
+        # Set the span to 5 days, but that shouldn't apply while pending approval
+        experiment.changes.filter(
+            old_status=NimbusExperiment.Status.DRAFT,
+            new_status=NimbusExperiment.Status.LIVE,
+        ).update(changed_on=datetime.datetime.now() - datetime.timedelta(days=5))
+        experiment.changes.filter(experiment_data__is_paused=True).update(
+            changed_on=datetime.datetime.now()
+        )
+        self.assertEqual(
+            experiment.computed_enrollment_days,
+            expected_days,
         )
 
     def test_computed_duration_days_returns_computed_end_date_minus_start_date(self):


### PR DESCRIPTION
Because:

* enrollment duration should only count after an end to enrollment has
  been approved

This commit:

* adds further qualifiers to the changelog query searching for an end to
  enrollment to specify a change after approval