### PR TITLE
fix #6467 fix(nimbus): ensure correct labels displayed for risk management questions

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/FormOverview/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/FormOverview/index.tsx
@@ -249,8 +249,8 @@ const FormOverview = ({
               ]}
               {...{ FormErrors, formControlAttrs }}
             >
-              {RISK_QUESTIONS.PARTNER}{" "}
-              <LinkExternal href={EXTERNAL_URLS.RISK_PARTNER}>
+              {RISK_QUESTIONS.REVENUE}{" "}
+              <LinkExternal href={EXTERNAL_URLS.RISK_REVENUE}>
                 Learn more
               </LinkExternal>
             </InputRadios>
@@ -263,8 +263,8 @@ const FormOverview = ({
               ]}
               {...{ FormErrors, formControlAttrs }}
             >
-              {RISK_QUESTIONS.REVENUE}{" "}
-              <LinkExternal href={EXTERNAL_URLS.RISK_REVENUE}>
+              {RISK_QUESTIONS.PARTNER}{" "}
+              <LinkExternal href={EXTERNAL_URLS.RISK_PARTNER}>
                 Learn more
               </LinkExternal>
             </InputRadios>


### PR DESCRIPTION
Because:

* the label text for the revenue & partner risk management questions
  were swapped

This commit:

* adds a test that exercises the radio buttons as located by label text

* switches the label text as appropriate