### PR TITLE
fix #6492 chore(nimbus): delete media files before loading new dummy experiments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,7 @@ CHECK_DOCS = python manage.py generate_docs --check=true
 GENERATE_DOCS = python manage.py generate_docs
 LOAD_COUNTRIES = python manage.py loaddata ./experimenter/base/fixtures/countries.json
 LOAD_LOCALES = python manage.py loaddata ./experimenter/base/fixtures/locales.json
+DELETE_MEDIA_FILES = rm -rvf ./experimenter/media/*
 LOAD_DUMMY_EXPERIMENTS = [[ -z $$SKIP_DUMMY ]] && python manage.py load_dummy_experiments || echo "skipping dummy experiments"
 PUBLISH_STORYBOOKS = npx github:mozilla-fxa/storybook-gcp-publisher --commit-summary commit-summary.txt --commit-description commit-description.txt --version-json experimenter/version.json
 
@@ -157,7 +158,7 @@ bash: build_dev
 	$(COMPOSE) run app bash
 
 refresh: kill build_dev
-	$(COMPOSE) run -e SKIP_DUMMY=$$SKIP_DUMMY app bash -c '$(WAIT_FOR_DB) $(PYTHON_MIGRATE)&&$(LOAD_LOCALES)&&$(LOAD_COUNTRIES)&&$(LOAD_DUMMY_EXPERIMENTS)'
+	$(COMPOSE) run -e SKIP_DUMMY=$$SKIP_DUMMY app bash -c '$(WAIT_FOR_DB) $(PYTHON_MIGRATE)&&$(LOAD_LOCALES)&&$(LOAD_COUNTRIES)&&$(DELETE_MEDIA_FILES)&&$(LOAD_DUMMY_EXPERIMENTS)'
 
 dependabot_approve:
 	echo "Install and configure the Github CLI https://github.com/cli/cli"


### PR DESCRIPTION
Because:

* `make refresh` generates new media files (i.e. branch screenshots)
  when loading dummy experiments, but never deletes them

This commit:

* deletes media files before loading dummy experiments in `make refresh`
  to avoid accumulating old orphaned files