### PR TITLE
fix(nimbus): move validation requirements for branches into the review serializer

### DIFF
--- a/app/experimenter/experiments/api/v5/serializers.py
+++ b/app/experimenter/experiments/api/v5/serializers.py
@@ -85,14 +85,6 @@ class NimbusBranchSerializer(serializers.ModelSerializer):
             )
         return value
 
-    def validate_feature_value(self, value):
-        if value:
-            try:
-                json.loads(value)
-            except Exception as e:
-                raise serializers.ValidationError(f"Invalid JSON: {e.msg}")
-        return value
-
     def validate(self, data):
         data = super().validate(data)
         if data.get("feature_enabled") and not data.get("feature_value"):
@@ -158,101 +150,6 @@ class NimbusBranchSerializer(serializers.ModelSerializer):
 
 
 class NimbusExperimentBranchMixin:
-    def _validate_feature_value_against_schema(self, schema, value):
-        json_value = json.loads(value)
-        try:
-            jsonschema.validate(json_value, schema)
-        except jsonschema.ValidationError as exc:
-            return [exc.message]
-
-    def validate(self, data):
-        data = super().validate(data)
-        data = self._validate_duplicate_branch_names(data)
-        data = self._validate_feature_configs(data)
-        return data
-
-    def _validate_duplicate_branch_names(self, data):
-        if "reference_branch" in data and "treatment_branches" in data:
-            ref_branch_name = data["reference_branch"]["name"]
-            treatment_branch_names = [
-                branch["name"] for branch in data["treatment_branches"]
-            ]
-            all_names = [ref_branch_name, *treatment_branch_names]
-            unique_names = set(all_names)
-
-            if len(all_names) != len(unique_names):
-                raise serializers.ValidationError(
-                    {
-                        "reference_branch": {
-                            "name": NimbusConstants.ERROR_DUPLICATE_BRANCH_NAME
-                        },
-                        "treatment_branches": [
-                            {"name": NimbusConstants.ERROR_DUPLICATE_BRANCH_NAME}
-                            for i in data["treatment_branches"]
-                        ],
-                    }
-                )
-        return data
-
-    def _validate_feature_configs(self, data):
-        # Determine if we require a feature_config
-        feature_config_required = data.get("reference_branch", {}).get(
-            "feature_enabled", False
-        )
-        for branch in data.get("treatment_branches", []):
-            branch_required = branch.get("feature_enabled", False)
-            feature_config_required = feature_config_required or branch_required
-        feature_config = data.get("feature_config", None)
-        if feature_config_required and not feature_config:
-            raise serializers.ValidationError(
-                {
-                    "feature_config": [
-                        "Feature Config required when a branch has feature enabled."
-                    ]
-                }
-            )
-
-        if not feature_config or not feature_config.schema or not self.instance:
-            return data
-
-        if self.instance.application != feature_config.application:
-            raise serializers.ValidationError(
-                {
-                    "feature_config": [
-                        f"Feature Config application {feature_config.application} does "
-                        f"not match experiment application {self.instance.application}."
-                    ]
-                }
-            )
-
-        schema = json.loads(feature_config.schema)
-        error_result = {}
-        if data["reference_branch"].get("feature_enabled"):
-            errors = self._validate_feature_value_against_schema(
-                schema, data["reference_branch"]["feature_value"]
-            )
-            if errors:
-                error_result["reference_branch"] = {"feature_value": errors}
-
-        treatment_branches_errors = []
-        for branch_data in data["treatment_branches"]:
-            branch_error = None
-            if branch_data.get("feature_enabled", False):
-                errors = self._validate_feature_value_against_schema(
-                    schema, branch_data["feature_value"]
-                )
-                if errors:
-                    branch_error = {"feature_value": errors}
-            treatment_branches_errors.append(branch_error)
-
-        if any(x is not None for x in treatment_branches_errors):
-            error_result["treatment_branches"] = treatment_branches_errors
-
-        if error_result:
-            raise serializers.ValidationError(error_result)
-
-        return data
-
     def update(self, experiment, data):
         with transaction.atomic():
             reference_branch_data = data.pop("reference_branch", None)
@@ -700,6 +597,14 @@ class NimbusBranchReadyForReviewSerializer(NimbusBranchSerializer):
         many=True, required=False
     )
 
+    def validate_feature_value(self, value):
+        if value:
+            try:
+                json.loads(value)
+            except Exception as e:
+                raise serializers.ValidationError(f"Invalid JSON: {e.msg}")
+        return value
+
 
 class NimbusReadyForReviewSerializer(serializers.ModelSerializer):
     public_description = serializers.CharField(required=True)
@@ -782,6 +687,77 @@ class NimbusReadyForReviewSerializer(serializers.ModelSerializer):
             raise serializers.ValidationError("Hypothesis cannot be the default value.")
         return value
 
+    def _validate_feature_value_against_schema(self, schema, value):
+        json_value = json.loads(value)
+        try:
+            jsonschema.validate(json_value, schema)
+        except jsonschema.ValidationError as exc:
+            return [exc.message]
+
+    def _validate_duplicate_branch_names(self, data):
+        if "reference_branch" in data and "treatment_branches" in data:
+            ref_branch_name = data["reference_branch"]["name"]
+            treatment_branch_names = [
+                branch["name"] for branch in data["treatment_branches"]
+            ]
+            all_names = [ref_branch_name, *treatment_branch_names]
+            unique_names = set(all_names)
+
+            if len(all_names) != len(unique_names):
+                raise serializers.ValidationError(
+                    {
+                        "reference_branch": {
+                            "name": NimbusConstants.ERROR_DUPLICATE_BRANCH_NAME
+                        },
+                        "treatment_branches": [
+                            {"name": NimbusConstants.ERROR_DUPLICATE_BRANCH_NAME}
+                            for i in data["treatment_branches"]
+                        ],
+                    }
+                )
+        return data
+
+    def _validate_feature_configs(self, data):
+        feature_config = data.get("feature_config", None)
+
+        if self.instance.application != feature_config.application:
+            raise serializers.ValidationError(
+                {
+                    "feature_config": [
+                        f"Feature Config application {feature_config.application} does "
+                        f"not match experiment application {self.instance.application}."
+                    ]
+                }
+            )
+
+        schema = json.loads(feature_config.schema)
+        error_result = {}
+        if data["reference_branch"].get("feature_enabled"):
+            errors = self._validate_feature_value_against_schema(
+                schema, data["reference_branch"]["feature_value"]
+            )
+            if errors:
+                error_result["reference_branch"] = {"feature_value": errors}
+
+        treatment_branches_errors = []
+        for branch_data in data["treatment_branches"]:
+            branch_error = None
+            if branch_data.get("feature_enabled", False):
+                errors = self._validate_feature_value_against_schema(
+                    schema, branch_data["feature_value"]
+                )
+                if errors:
+                    branch_error = {"feature_value": errors}
+            treatment_branches_errors.append(branch_error)
+
+        if any(x is not None for x in treatment_branches_errors):
+            error_result["treatment_branches"] = treatment_branches_errors
+
+        if error_result:
+            raise serializers.ValidationError(error_result)
+
+        return data
+
     def validate(self, attrs):
         application = attrs.get("application")
         channel = attrs.get("channel")
@@ -789,7 +765,10 @@ class NimbusReadyForReviewSerializer(serializers.ModelSerializer):
             raise serializers.ValidationError(
                 {"channel": "Channel is required for this application."}
             )
-        return super().validate(attrs)
+        attrs = super().validate(attrs)
+        attrs = self._validate_duplicate_branch_names(attrs)
+        attrs = self._validate_feature_configs(attrs)
+        return attrs
 
 
 class NimbusExperimentCloneSerializer(

--- a/app/experimenter/experiments/api/v6/serializers.py
+++ b/app/experimenter/experiments/api/v6/serializers.py
@@ -36,12 +36,21 @@ class NimbusBranchSerializer(serializers.ModelSerializer):
         fields = ("slug", "ratio", "feature")
 
     def get_feature(self, obj):
+        feature_value = {}
+        if obj.feature_value:
+            try:
+                feature_value = json.loads(obj.feature_value)
+            except json.JSONDecodeError:
+                # feature_value may be invalid JSON while the experiment is
+                # still being drafted
+                pass
+
         return {
             "featureId": obj.experiment.feature_config.slug
             if obj.experiment.feature_config
             else None,
             "enabled": obj.feature_enabled,
-            "value": json.loads(obj.feature_value) if obj.feature_value else {},
+            "value": feature_value,
         }
 
 

--- a/app/experimenter/experiments/tests/api/v6/test_serializers.py
+++ b/app/experimenter/experiments/tests/api/v6/test_serializers.py
@@ -120,6 +120,17 @@ class TestNimbusExperimentSerializer(TestCase):
         serializer = NimbusExperimentSerializer(experiment)
         self.assertIsNone(serializer.data["branches"][0]["feature"]["featureId"])
 
+    def test_serializer_with_branch_invalid_feature_value(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+        )
+        experiment.reference_branch.feature_value = "this is not json"
+        experiment.reference_branch.save()
+        serializer = NimbusExperimentSerializer(experiment)
+        branch_slug = serializer.data["referenceBranch"]
+        branch = [x for x in serializer.data["branches"] if x["slug"] == branch_slug][0]
+        self.assertEqual(branch["feature"]["value"], {})
+
     @parameterized.expand(
         [
             (application, channel, channel_app_id)

--- a/app/experimenter/nimbus-ui/src/components/FormOverview/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/FormOverview/index.tsx
@@ -294,7 +294,7 @@ const FormOverview = ({
                           .documentation_links?.[index] || {},
                       reviewMessages:
                         (fieldMessages as SerializerMessages<SerializerSet[]>)
-                          .documentationLinks?.[index] || {},
+                          .documentation_links?.[index] || {},
                       //@ts-ignore react-hook-form types seem broken for nested fields
                       errors: (errors?.documentationLinks?.[index] ||
                         {}) as FormDocumentationLinkProps["errors"],

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/index.tsx
@@ -179,7 +179,7 @@ export const FormBranches = ({
             // Displaying the review-readiness error is handled here instead of `formControlAttrs`
             // due to a state conflict between `react-hook-form` and our internal branch state mangement
             className={classNames(
-              fieldMessages.featureConfig?.length > 0 && "is-warning",
+              fieldMessages.feature_config?.length > 0 && "is-warning",
             )}
             onChange={onFeatureConfigChange}
             value={featureConfigs!.findIndex(
@@ -196,11 +196,11 @@ export const FormBranches = ({
                 ),
             )}
           </Form.Control>
-          {fieldMessages.featureConfig?.length > 0 && (
+          {fieldMessages.feature_config?.length > 0 && (
             // @ts-ignore This component doesn't technically support type="warning", but
             // all it's doing is using the string in a class, so we can safely override.
             <Form.Control.Feedback type="warning" data-for="featureConfig">
-              {(fieldMessages.featureConfig as SerializerMessage).join(", ")}
+              {(fieldMessages.feature_config as SerializerMessage).join(", ")}
             </Form.Control.Feedback>
           )}
         </Form.Group>
@@ -231,7 +231,7 @@ export const FormBranches = ({
                   {}) as FormBranchProps["touched"],
                 isReference: true,
                 branch: { ...referenceBranch, key: "branch-reference" },
-                reviewErrors: fieldMessages.referenceBranch as SerializerSet,
+                reviewErrors: fieldMessages.reference_branch as SerializerSet,
                 defaultValues: defaultValues.referenceBranch || {},
               }}
             />
@@ -240,7 +240,7 @@ export const FormBranches = ({
             treatmentBranches.map((branch, idx) => {
               const reviewErrors = (
                 fieldMessages as SerializerMessages<SerializerSet[]>
-              ).treatmentBranches?.[idx];
+              ).treatment_branches?.[idx];
 
               return (
                 <FormBranch

--- a/app/experimenter/nimbus-ui/src/hooks/useCommonForm/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/hooks/useCommonForm/index.test.tsx
@@ -209,7 +209,7 @@ describe("hooks/useCommonForm", () => {
         },
       } = renderHook(() =>
         useCommonForm<"spiceLevel">({}, true, {}, jest.fn(), {
-          spiceLevel: [feedback],
+          spice_level: [feedback],
         }),
       );
 

--- a/app/experimenter/nimbus-ui/src/hooks/useCommonForm/useCommonFormMethods.tsx
+++ b/app/experimenter/nimbus-ui/src/hooks/useCommonForm/useCommonFormMethods.tsx
@@ -48,8 +48,9 @@ export function useCommonFormMethods<FieldNames extends string>(
     setDefaultValue = true,
     prefix?: string,
   ) => {
+    const snakeCaseName = camelToSnakeCase(name);
     const fieldName = prefix ? `${prefix}.${name}` : name;
-    const hasReviewMessage = (reviewMessages[name] || []).length > 0;
+    const hasReviewMessage = (reviewMessages[snakeCaseName] || []).length > 0;
     return {
       "data-testid": fieldName,
       name: fieldName,
@@ -62,13 +63,10 @@ export function useCommonFormMethods<FieldNames extends string>(
         defaultValue: defaultValues[name],
         onChange: () => hideSubmitError(name),
         isInvalid: Boolean(
-          submitErrors![camelToSnakeCase(name)] ||
-            (touched[name] && errors[name]),
+          submitErrors![snakeCaseName] || (touched[name] && errors[name]),
         ),
         isValid: Boolean(
-          !submitErrors![camelToSnakeCase(name)] &&
-            touched[name] &&
-            !errors[name],
+          !submitErrors![snakeCaseName] && touched[name] && !errors[name],
         ),
       }),
     };
@@ -81,13 +79,14 @@ export function useCommonFormMethods<FieldNames extends string>(
     name: K;
     prefix?: string;
   }) => {
+    const snakeCaseName = camelToSnakeCase(name);
     const fieldName = prefix ? `${prefix}.${name}` : name;
     const fieldReviewMessages =
       (
         reviewMessages as SerializerMessages<
           SerializerMessage | SerializerSet[]
         >
-      )[name] || [];
+      )[snakeCaseName] || [];
     return (
       <>
         {fieldReviewMessages.length > 0 && (
@@ -102,14 +101,14 @@ export function useCommonFormMethods<FieldNames extends string>(
             {(errors[name] as FieldError).message}
           </Form.Control.Feedback>
         )}
-        {submitErrors![camelToSnakeCase(name)] && (
+        {submitErrors![snakeCaseName] && (
           <Form.Control.Feedback type="invalid" data-for={fieldName}>
-            {submitErrors![camelToSnakeCase(name)]}
+            {submitErrors![snakeCaseName]}
           </Form.Control.Feedback>
         )}
         {/* for testing - can't wrap the errors in a container with a test ID
       because of Bootstrap's adjacent class CSS rules, error won't be shown */}
-        {!errors[name] && !submitErrors![camelToSnakeCase(name)] && (
+        {!errors[name] && !submitErrors![snakeCaseName] && (
           <span data-testid={`${fieldName}-form-errors`} />
         )}
       </>
@@ -136,7 +135,7 @@ export function useCommonFormMethods<FieldNames extends string>(
       (submitErrors![camelToSnakeCase(name)] ||
         (touched[name] && errors[name])) &&
         "is-invalid border border-danger rounded",
-      (reviewMessages[name] || []).length > 0 &&
+      (reviewMessages[camelToSnakeCase(name)] || []).length > 0 &&
         "is-warning border-feedback-warning rounded",
     ),
   });

--- a/app/experimenter/nimbus-ui/src/hooks/useReviewCheck.tsx
+++ b/app/experimenter/nimbus-ui/src/hooks/useReviewCheck.tsx
@@ -5,7 +5,6 @@
 import { Link } from "@reach/router";
 import React from "react";
 import { editPages } from "../components/AppLayoutWithSidebar";
-import { snakeToCamelCase } from "../lib/caseConversions";
 import { BASE_PATH } from "../lib/constants";
 import { getExperiment_experimentBySlug } from "../types/getExperiment";
 
@@ -13,33 +12,28 @@ export type ReviewCheck = ReturnType<typeof useReviewCheck>;
 
 const fieldPageMap: { [page: string]: string[] } = {
   overview: [
-    "publicDescription",
-    "riskBrand",
-    "riskRevenue",
-    "riskPartnerRelated",
+    "public_description",
+    "risk_brand",
+    "risk_revenue",
+    "risk_partner_related",
   ],
-  branches: ["referenceBranch", "treatmentBranches", "featureConfig"],
+  branches: ["reference_branch", "treatment_branches", "feature_config"],
   audience: [
     "channel",
-    "firefoxMinVersion",
-    "targetingConfigSlug",
-    "proposedEnrollment",
-    "proposedDuration",
-    "populationPercent",
-    "totalEnrolledClients",
+    "firefox_min_version",
+    "targeting_config_slug",
+    "proposed_enrollment",
+    "proposed_duration",
+    "population_percent",
+    "total_enrolled_clients",
   ],
 };
 
 export function useReviewCheck(
   experiment: getExperiment_experimentBySlug | null | undefined,
 ) {
-  let messages = (experiment?.readyForReview?.message ||
+  const messages = (experiment?.readyForReview?.message ||
     {}) as SerializerMessages;
-  messages = Object.keys(messages).reduce<SerializerMessages>((acc, cur) => {
-    acc[snakeToCamelCase(cur)] = messages[cur];
-    return acc;
-  }, {});
-
   const fieldMessages = window.location.search.includes("show-errors")
     ? messages
     : {};


### PR DESCRIPTION
Because:

* many branch fields (e.g. JSON feature config) are enforced at submit
  time, preventing saving in-progress work

This commit:

* moves most branch validation logic into the review-ready serializer,
  opting to enforce at review time