### PR TITLE
fix #6476 bug(nimbus): wait for preview status in targeting tests

### DIFF
--- a/app/tests/integration/nimbus/pages/experimenter/summary.py
+++ b/app/tests/integration/nimbus/pages/experimenter/summary.py
@@ -18,6 +18,7 @@ class SummaryPage(ExperimenterBase):
     _rejected_text_alert_locator = (By.CSS_SELECTOR, '[data-testid="rejection-notice"]')
     _timeout_alert_locator = (By.CSS_SELECTOR, '[data-testid="timeout-notice"]')
     _status_live_locator = (By.CSS_SELECTOR, ".status-Live.border-primary")
+    _status_preview_locator = (By.CSS_SELECTOR, ".status-Preview.border-primary")
     _status_complete_locator = (By.CSS_SELECTOR, ".status-Complete.border-primary")
     _experiment_status_icon_locator = (
         By.CSS_SELECTOR,
@@ -56,6 +57,11 @@ class SummaryPage(ExperimenterBase):
             self._status_live_locator, "Summary Page: Unable to find live status"
         )
 
+    def wait_for_preview_status(self):
+        self.wait_with_refresh(
+            self._status_preview_locator, "Summary Page: Unable to find preview status"
+        )
+
     def wait_for_complete_status(self):
         self.wait_with_refresh(
             self._status_complete_locator, "Summary Page: Unable to find complete status"
@@ -88,6 +94,10 @@ class SummaryPage(ExperimenterBase):
         return self.find_element(*self._launch_without_preview_locator)
 
     def launch_to_preview(self):
+        self.wait.until(
+            EC.presence_of_all_elements_located(self._launch_to_preview_locator),
+            message="Summary Page: could not find preview button",
+        )
         self.find_element(*self._launch_to_preview_locator).click()
         return self
 

--- a/app/tests/integration/nimbus/test_remote_settings.py
+++ b/app/tests/integration/nimbus/test_remote_settings.py
@@ -134,11 +134,13 @@ def test_end_experiment_and_reject_end(
 
 @pytest.mark.run_parallel
 def test_check_targeting(
-    selenium, base_url, default_data, create_experiment, slugify, app_data, json_url
+    selenium, base_url, default_data, create_experiment, app_data, json_url
 ):
     default_data.audience.targeting = app_data
     default_data.public_name = default_data.public_name.replace("-", "", 1)
-    create_experiment(selenium).launch_to_preview()
+    experiment = create_experiment(selenium)
+    experiment.launch_to_preview()
+    experiment.wait_for_preview_status()
     json_url = json_url(base_url, default_data.public_name)
     # Get experiment JSON and parse
     experiment_json = requests.get(f"{json_url}", verify=False).json()


### PR DESCRIPTION
Because

* Integration tests can move really fast
* It's important to figure out where to insert waits so that the next step only happens after the page is ready
* It seems the targeting tests were requesting the API json before the server finished moving the experiment into preview

This commit

* Waits for the preview button to be available before clicking it
* Waits for the experiment to move into the preview status before requesting the API json