### PR TITLE
chore(project): update circle image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 jobs:
   check:
     machine:
-      image: ubuntu-2004:202104-01 # Ubuntu 20.04, Docker v20.10.6, Docker Compose v1.29.1
+      image: ubuntu-2004:202107-02 # Ubuntu 20.04, Docker v20.10.7, Docker Compose v1.29.2
       docker_layer_caching: true
     resource_class: large
     working_directory: ~/experimenter
@@ -22,7 +22,7 @@ jobs:
 
   publish_storybooks:
     machine:
-      image: ubuntu-2004:202104-01 # Ubuntu 20.04, Docker v20.10.6, Docker Compose v1.29.1
+      image: ubuntu-2004:202107-02 # Ubuntu 20.04, Docker v20.10.7, Docker Compose v1.29.2
       docker_layer_caching: true
     resource_class: medium
     working_directory: ~/experimenter
@@ -42,7 +42,7 @@ jobs:
 
   integration_legacy:
     machine:
-      image: ubuntu-2004:202104-01 # Ubuntu 20.04, Docker v20.10.6, Docker Compose v1.29.1
+      image: ubuntu-2004:202107-02 # Ubuntu 20.04, Docker v20.10.7, Docker Compose v1.29.2
       docker_layer_caching: true
     resource_class: large
     working_directory: ~/experimenter
@@ -64,7 +64,7 @@ jobs:
 
   integration_nimbus:
     machine:
-      image: ubuntu-2004:202104-01 # Ubuntu 20.04, Docker v20.10.6, Docker Compose v1.29.1
+      image: ubuntu-2004:202107-02 # Ubuntu 20.04, Docker v20.10.7, Docker Compose v1.29.2
       docker_layer_caching: true
     resource_class: xlarge
     working_directory: ~/experimenter
@@ -83,7 +83,7 @@ jobs:
   deploy:
     working_directory: ~/experimenter
     machine:
-      image: ubuntu-2004:202104-01 # Ubuntu 20.04, Docker v20.10.6, Docker Compose v1.29.1
+      image: ubuntu-2004:202107-02 # Ubuntu 20.04, Docker v20.10.7, Docker Compose v1.29.2
       docker_layer_caching: true
     steps:
       - checkout


### PR DESCRIPTION
Because

* There is a new circle image with latest ubuntu/docker versions

This commit

* Updates to the latest circle image