### PR TITLE
fix #6526 fix(nimbus): move validation requirements for branch feature configs into the review serializer

### DIFF
--- a/app/experimenter/experiments/api/v6/serializers.py
+++ b/app/experimenter/experiments/api/v6/serializers.py
@@ -36,12 +36,21 @@ class NimbusBranchSerializer(serializers.ModelSerializer):
         fields = ("slug", "ratio", "feature")
 
     def get_feature(self, obj):
+        feature_value = {}
+        if obj.feature_value:
+            try:
+                feature_value = json.loads(obj.feature_value)
+            except json.JSONDecodeError:
+                # feature_value may be invalid JSON while the experiment is
+                # still being drafted
+                pass
+
         return {
             "featureId": obj.experiment.feature_config.slug
             if obj.experiment.feature_config
             else None,
             "enabled": obj.feature_enabled,
-            "value": json.loads(obj.feature_value) if obj.feature_value else {},
+            "value": feature_value,
         }
 
 

--- a/app/experimenter/experiments/tests/api/v5/test_queries.py
+++ b/app/experimenter/experiments/tests/api/v5/test_queries.py
@@ -227,7 +227,11 @@ class TestNimbusExperimentBySlugQuery(GraphQLTestCase):
     def test_experiment_by_slug_ready_for_review(self):
         user_email = "user@example.com"
         experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperimentFactory.Lifecycles.CREATED
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            application=NimbusExperiment.Application.DESKTOP,
+            feature_config=NimbusFeatureConfigFactory(
+                application=NimbusExperiment.Application.DESKTOP
+            ),
         )
 
         response = self.query(
@@ -316,6 +320,10 @@ class TestNimbusExperimentBySlugQuery(GraphQLTestCase):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.CREATED,
             hypothesis=NimbusExperiment.HYPOTHESIS_DEFAULT,
+            application=NimbusExperiment.Application.DESKTOP,
+            feature_config=NimbusFeatureConfigFactory(
+                application=NimbusExperiment.Application.DESKTOP
+            ),
         )
 
         response = self.query(

--- a/app/experimenter/experiments/tests/api/v6/test_serializers.py
+++ b/app/experimenter/experiments/tests/api/v6/test_serializers.py
@@ -120,6 +120,17 @@ class TestNimbusExperimentSerializer(TestCase):
         serializer = NimbusExperimentSerializer(experiment)
         self.assertIsNone(serializer.data["branches"][0]["feature"]["featureId"])
 
+    def test_serializer_with_branch_invalid_feature_value(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+        )
+        experiment.reference_branch.feature_value = "this is not json"
+        experiment.reference_branch.save()
+        serializer = NimbusExperimentSerializer(experiment)
+        branch_slug = serializer.data["referenceBranch"]
+        branch = [x for x in serializer.data["branches"] if x["slug"] == branch_slug][0]
+        self.assertEqual(branch["feature"]["value"], {})
+
     @parameterized.expand(
         [
             (application, channel, channel_app_id)

--- a/app/experimenter/nimbus-ui/src/components/FormOverview/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/FormOverview/index.tsx
@@ -294,7 +294,7 @@ const FormOverview = ({
                           .documentation_links?.[index] || {},
                       reviewMessages:
                         (fieldMessages as SerializerMessages<SerializerSet[]>)
-                          .documentationLinks?.[index] || {},
+                          .documentation_links?.[index] || {},
                       //@ts-ignore react-hook-form types seem broken for nested fields
                       errors: (errors?.documentationLinks?.[index] ||
                         {}) as FormDocumentationLinkProps["errors"],

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/index.tsx
@@ -179,7 +179,7 @@ export const FormBranches = ({
             // Displaying the review-readiness error is handled here instead of `formControlAttrs`
             // due to a state conflict between `react-hook-form` and our internal branch state mangement
             className={classNames(
-              fieldMessages.featureConfig?.length > 0 && "is-warning",
+              fieldMessages.feature_config?.length > 0 && "is-warning",
             )}
             onChange={onFeatureConfigChange}
             value={featureConfigs!.findIndex(
@@ -196,11 +196,11 @@ export const FormBranches = ({
                 ),
             )}
           </Form.Control>
-          {fieldMessages.featureConfig?.length > 0 && (
+          {fieldMessages.feature_config?.length > 0 && (
             // @ts-ignore This component doesn't technically support type="warning", but
             // all it's doing is using the string in a class, so we can safely override.
             <Form.Control.Feedback type="warning" data-for="featureConfig">
-              {(fieldMessages.featureConfig as SerializerMessage).join(", ")}
+              {(fieldMessages.feature_config as SerializerMessage).join(", ")}
             </Form.Control.Feedback>
           )}
         </Form.Group>
@@ -231,7 +231,7 @@ export const FormBranches = ({
                   {}) as FormBranchProps["touched"],
                 isReference: true,
                 branch: { ...referenceBranch, key: "branch-reference" },
-                reviewErrors: fieldMessages.referenceBranch as SerializerSet,
+                reviewErrors: fieldMessages.reference_branch as SerializerSet,
                 defaultValues: defaultValues.referenceBranch || {},
               }}
             />
@@ -240,7 +240,7 @@ export const FormBranches = ({
             treatmentBranches.map((branch, idx) => {
               const reviewErrors = (
                 fieldMessages as SerializerMessages<SerializerSet[]>
-              ).treatmentBranches?.[idx];
+              ).treatment_branches?.[idx];
 
               return (
                 <FormBranch

--- a/app/experimenter/nimbus-ui/src/hooks/useCommonForm/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/hooks/useCommonForm/index.test.tsx
@@ -209,7 +209,7 @@ describe("hooks/useCommonForm", () => {
         },
       } = renderHook(() =>
         useCommonForm<"spiceLevel">({}, true, {}, jest.fn(), {
-          spiceLevel: [feedback],
+          spice_level: [feedback],
         }),
       );
 

--- a/app/experimenter/nimbus-ui/src/hooks/useCommonForm/useCommonFormMethods.tsx
+++ b/app/experimenter/nimbus-ui/src/hooks/useCommonForm/useCommonFormMethods.tsx
@@ -48,8 +48,9 @@ export function useCommonFormMethods<FieldNames extends string>(
     setDefaultValue = true,
     prefix?: string,
   ) => {
+    const snakeCaseName = camelToSnakeCase(name);
     const fieldName = prefix ? `${prefix}.${name}` : name;
-    const hasReviewMessage = (reviewMessages[name] || []).length > 0;
+    const hasReviewMessage = (reviewMessages[snakeCaseName] || []).length > 0;
     return {
       "data-testid": fieldName,
       name: fieldName,
@@ -62,13 +63,10 @@ export function useCommonFormMethods<FieldNames extends string>(
         defaultValue: defaultValues[name],
         onChange: () => hideSubmitError(name),
         isInvalid: Boolean(
-          submitErrors![camelToSnakeCase(name)] ||
-            (touched[name] && errors[name]),
+          submitErrors![snakeCaseName] || (touched[name] && errors[name]),
         ),
         isValid: Boolean(
-          !submitErrors![camelToSnakeCase(name)] &&
-            touched[name] &&
-            !errors[name],
+          !submitErrors![snakeCaseName] && touched[name] && !errors[name],
         ),
       }),
     };
@@ -81,13 +79,14 @@ export function useCommonFormMethods<FieldNames extends string>(
     name: K;
     prefix?: string;
   }) => {
+    const snakeCaseName = camelToSnakeCase(name);
     const fieldName = prefix ? `${prefix}.${name}` : name;
     const fieldReviewMessages =
       (
         reviewMessages as SerializerMessages<
           SerializerMessage | SerializerSet[]
         >
-      )[name] || [];
+      )[snakeCaseName] || [];
     return (
       <>
         {fieldReviewMessages.length > 0 && (
@@ -102,14 +101,14 @@ export function useCommonFormMethods<FieldNames extends string>(
             {(errors[name] as FieldError).message}
           </Form.Control.Feedback>
         )}
-        {submitErrors![camelToSnakeCase(name)] && (
+        {submitErrors![snakeCaseName] && (
           <Form.Control.Feedback type="invalid" data-for={fieldName}>
-            {submitErrors![camelToSnakeCase(name)]}
+            {submitErrors![snakeCaseName]}
           </Form.Control.Feedback>
         )}
         {/* for testing - can't wrap the errors in a container with a test ID
       because of Bootstrap's adjacent class CSS rules, error won't be shown */}
-        {!errors[name] && !submitErrors![camelToSnakeCase(name)] && (
+        {!errors[name] && !submitErrors![snakeCaseName] && (
           <span data-testid={`${fieldName}-form-errors`} />
         )}
       </>
@@ -136,7 +135,7 @@ export function useCommonFormMethods<FieldNames extends string>(
       (submitErrors![camelToSnakeCase(name)] ||
         (touched[name] && errors[name])) &&
         "is-invalid border border-danger rounded",
-      (reviewMessages[name] || []).length > 0 &&
+      (reviewMessages[camelToSnakeCase(name)] || []).length > 0 &&
         "is-warning border-feedback-warning rounded",
     ),
   });

--- a/app/experimenter/nimbus-ui/src/hooks/useReviewCheck.tsx
+++ b/app/experimenter/nimbus-ui/src/hooks/useReviewCheck.tsx
@@ -5,7 +5,6 @@
 import { Link } from "@reach/router";
 import React from "react";
 import { editPages } from "../components/AppLayoutWithSidebar";
-import { snakeToCamelCase } from "../lib/caseConversions";
 import { BASE_PATH } from "../lib/constants";
 import { getExperiment_experimentBySlug } from "../types/getExperiment";
 
@@ -13,33 +12,28 @@ export type ReviewCheck = ReturnType<typeof useReviewCheck>;
 
 const fieldPageMap: { [page: string]: string[] } = {
   overview: [
-    "publicDescription",
-    "riskBrand",
-    "riskRevenue",
-    "riskPartnerRelated",
+    "public_description",
+    "risk_brand",
+    "risk_revenue",
+    "risk_partner_related",
   ],
-  branches: ["referenceBranch", "treatmentBranches", "featureConfig"],
+  branches: ["reference_branch", "treatment_branches", "feature_config"],
   audience: [
     "channel",
-    "firefoxMinVersion",
-    "targetingConfigSlug",
-    "proposedEnrollment",
-    "proposedDuration",
-    "populationPercent",
-    "totalEnrolledClients",
+    "firefox_min_version",
+    "targeting_config_slug",
+    "proposed_enrollment",
+    "proposed_duration",
+    "population_percent",
+    "total_enrolled_clients",
   ],
 };
 
 export function useReviewCheck(
   experiment: getExperiment_experimentBySlug | null | undefined,
 ) {
-  let messages = (experiment?.readyForReview?.message ||
+  const messages = (experiment?.readyForReview?.message ||
     {}) as SerializerMessages;
-  messages = Object.keys(messages).reduce<SerializerMessages>((acc, cur) => {
-    acc[snakeToCamelCase(cur)] = messages[cur];
-    return acc;
-  }, {});
-
   const fieldMessages = window.location.search.includes("show-errors")
     ? messages
     : {};


### PR DESCRIPTION
Because:

* well-formed and valid feature config JSON is required to save
  branches, thus complicating the save of in-progress work

This commit:

* moves feature config value JSON parse check into review serializer

* moves feature config value JSON schema validation into review
  serializer

* moves feature validation against expected application into review
  serializer

* fixes some confusion in nimbus-ui over snake_case vs camelCase that
  prevented review messages from being displayed

* tweaks v6 serializer to produce `{}` for feature value if JSON fails
  to parse, which is possible up until the point of review readiness