### PR TITLE
fix #6536 bug(nimbus): lock remote settings version

### DIFF
--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -52,12 +52,12 @@ services:
       - db_volume:/var/lib/postgresql
 
   redis:
-    image: redis
+    image: redis:6.2.6
     ports:
       - "6379:6379"
 
   kinto:
-    image: mozilla/kinto-dist
+    image: mozilla/kinto-dist:23.3.1
     environment:
       KINTO_INI: /etc/kinto.ini
     ports:
@@ -68,7 +68,7 @@ services:
       - ./kinto/server.ini:/etc/kinto.ini
 
   autograph:
-    image: mozilla/autograph
+    image: mozilla/autograph:4.1.1
     ports:
       - "8000:8000"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -105,12 +105,12 @@ services:
       - db_volume:/var/lib/postgresql
 
   redis:
-    image: redis
+    image: redis:6.2.6
     ports:
       - "6379:6379"
 
   kinto:
-    image: mozilla/kinto-dist
+    image: mozilla/kinto-dist:23.3.1
     environment:
       KINTO_INI: /etc/kinto.ini
     ports:
@@ -121,7 +121,7 @@ services:
       - ./kinto/server.ini:/etc/kinto.ini
 
   autograph:
-    image: mozilla/autograph
+    image: mozilla/autograph:4.1.1
     ports:
       - "8000:8000"
 


### PR DESCRIPTION
Because

* Updates to remote settings can possibly break our integration tests

This commit

* Locks the remote settings docker image to the last working version