### PR TITLE
fix #6542 chore(nimbus): store media files in docker volume

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,7 +81,6 @@ target/
 !.vscode/extensions.json
 
 # Hosted assets
-app/experimenter/media/
 app/experimenter/served/
 app/experimenter/legacy-ui/assets/
 app/experimenter/reporting/reporting-ui/assets/

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,6 @@ CHECK_DOCS = python manage.py generate_docs --check=true
 GENERATE_DOCS = python manage.py generate_docs
 LOAD_COUNTRIES = python manage.py loaddata ./experimenter/base/fixtures/countries.json
 LOAD_LOCALES = python manage.py loaddata ./experimenter/base/fixtures/locales.json
-DELETE_MEDIA_FILES = rm -rvf ./experimenter/media/*
 LOAD_DUMMY_EXPERIMENTS = [[ -z $$SKIP_DUMMY ]] && python manage.py load_dummy_experiments || echo "skipping dummy experiments"
 PUBLISH_STORYBOOKS = npx github:mozilla-fxa/storybook-gcp-publisher --commit-summary commit-summary.txt --commit-description commit-description.txt --version-json experimenter/version.json
 
@@ -158,7 +157,7 @@ bash: build_dev
 	$(COMPOSE) run app bash
 
 refresh: kill build_dev
-	$(COMPOSE) run -e SKIP_DUMMY=$$SKIP_DUMMY app bash -c '$(WAIT_FOR_DB) $(PYTHON_MIGRATE)&&$(LOAD_LOCALES)&&$(LOAD_COUNTRIES)&&$(DELETE_MEDIA_FILES)&&$(LOAD_DUMMY_EXPERIMENTS)'
+	$(COMPOSE) run -e SKIP_DUMMY=$$SKIP_DUMMY app bash -c '$(WAIT_FOR_DB) $(PYTHON_MIGRATE)&&$(LOAD_LOCALES)&&$(LOAD_COUNTRIES)&&$(LOAD_DUMMY_EXPERIMENTS)'
 
 dependabot_approve:
 	echo "Install and configure the Github CLI https://github.com/cli/cli"

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -15,6 +15,8 @@ services:
       - kinto
     ports:
       - "7001:7001"
+    volumes:
+      - media_volume:/app/experimenter/media
     command: bash -c "/app/bin/wait-for-it.sh kinto:8888 -- python bin/setup_kinto.py;/app/bin/wait-for-it.sh db:5432 -- python manage.py collectstatic --noinput&&gunicorn -w 4 -b 0.0.0.0:7001 experimenter.wsgi"
 
   worker:
@@ -74,3 +76,4 @@ services:
 
 volumes:
   db_volume:
+  media_volume:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,10 +14,11 @@ services:
       - "7001:7001"
     volumes:
       - ./app:/app
+      - media_volume:/app/experimenter/media
       - /app/experimenter/legacy-ui/core/.cache/
       - /app/experimenter/legacy-ui/core/node_modules/
-      - /app/experimenter/reporting/reporting-ui/node_modules/
       - /app/experimenter/nimbus-ui/node_modules/
+      - /app/experimenter/reporting/reporting-ui/node_modules/
       - /app/experimenter/served/
       - /app/node_modules/
     command: bash -c "/app/bin/wait-for-it.sh kinto:8888 -- python bin/setup_kinto.py;/app/bin/wait-for-it.sh db:5432 -- python /app/manage.py runserver 0:7001"
@@ -30,6 +31,7 @@ services:
       - "3000:3000"
     volumes:
       - ./app:/app
+      - media_volume:/app/experimenter/media
       - /app/experimenter/legacy-ui/core/.cache/
       - /app/experimenter/legacy-ui/core/node_modules/
       - /app/experimenter/nimbus-ui/node_modules/
@@ -44,6 +46,7 @@ services:
     tty: true
     volumes:
       - ./app:/app
+      - media_volume:/app/experimenter/media
       - /app/experimenter/legacy-ui/core/.cache/
       - /app/experimenter/legacy-ui/core/node_modules/
       - /app/experimenter/nimbus-ui/node_modules/
@@ -58,10 +61,11 @@ services:
     tty: true
     volumes:
       - ./app:/app
+      - media_volume:/app/experimenter/media
       - /app/experimenter/legacy-ui/core/.cache/
       - /app/experimenter/legacy-ui/core/node_modules/
-      - /app/experimenter/reporting/reporting-ui/node_modules/
       - /app/experimenter/nimbus-ui/node_modules/
+      - /app/experimenter/reporting/reporting-ui/node_modules/
       - /app/experimenter/served/
       - /app/node_modules/
     command: bash -c "yarn workspace @experimenter/reporting watch"
@@ -127,3 +131,4 @@ services:
 
 volumes:
   db_volume:
+  media_volume:


### PR DESCRIPTION
Because

* Running rm -Rf as part of your build process should be concerning for anyone

This commit

* Moves media files into a docker volume and never exposes them to the host filesystem, and they will get reset automatically in make refresh