### PR TITLE
fix #6541 feat(nimbus): include application in namespace key

### DIFF
--- a/app/experimenter/experiments/models/nimbus.py
+++ b/app/experimenter/experiments/models/nimbus.py
@@ -399,7 +399,7 @@ class NimbusExperiment(NimbusConstants, FilterMixin, models.Model):
             existing_bucket_range.delete()
 
         NimbusIsolationGroup.request_isolation_group_buckets(
-            self.feature_config.slug,
+            f"{self.application_config.slug}-{self.feature_config.slug}",
             self,
             int(
                 self.population_percent / Decimal("100.0") * NimbusExperiment.BUCKET_TOTAL


### PR DESCRIPTION
Because

* Feature slugs are no longer globally unique but only unique per application
* Isolation groups are keyed by feature slug and so will accidentally be shared across applications

This commit

* Keys isolation groups by application and feature slug