### PR TITLE
fixes #6135 fix(nimbus): remove second request text from error message

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/ChangeApprovalOperations/FormApproveOrReject.tsx
+++ b/app/experimenter/nimbus-ui/src/components/ChangeApprovalOperations/FormApproveOrReject.tsx
@@ -33,8 +33,8 @@ const FormApproveOrReject = ({
             <span role="img" aria-label="red X emoji">
               ❌
             </span>{" "}
-            Remote Settings request has timed out, please go through the request{" "}
-            and approval flow to {actionDescription} again.
+            Remote Settings request has timed out, please go through the
+            approval flow to {actionDescription} again.
           </p>
         </Alert>
       )}


### PR DESCRIPTION
Because

* the "request part" of the message is not needed

This commit

* removes text from the error message telling the user to go through the request flow again