### PR TITLE
fix #6544 feat(nimbus): delete empty isolation group in bucket allocation

### DIFF
--- a/app/experimenter/experiments/models/nimbus.py
+++ b/app/experimenter/experiments/models/nimbus.py
@@ -396,7 +396,11 @@ class NimbusExperiment(NimbusConstants, FilterMixin, models.Model):
     def allocate_bucket_range(self):
         existing_bucket_range = NimbusBucketRange.objects.filter(experiment=self)
         if existing_bucket_range.exists():
+            isolation_group = existing_bucket_range.get().isolation_group
             existing_bucket_range.delete()
+
+            if not isolation_group.bucket_ranges.exists():
+                NimbusIsolationGroup.objects.filter(id=isolation_group.id).delete()
 
         NimbusIsolationGroup.request_isolation_group_buckets(
             f"{self.application_config.slug}-{self.feature_config.slug}",


### PR DESCRIPTION


Because

* The bucket allocator will always use the highest numbered isolation group
* When an experiment is modified and buckets are reallocated, it will use that highest numbered isolation group even if there is available space in a previous isolation group

This commit

* Checks if removing allocated buckets from an isolation group would leave that isolation group empty and if so, deletes it