### PR TITLE
fix #6424 feat(nimbus): ensure the UPLOADS_GS_BUCKET_NAME settings uses the correct env var

### DIFF
--- a/app/experimenter/settings.py
+++ b/app/experimenter/settings.py
@@ -430,7 +430,7 @@ GS_PROJECT_ID = "experiments-analysis"
 GS_BUCKET_NAME = "mozanalysis"
 
 # GCS bucket for user uploads, e.g. branch screenshots
-UPLOADS_GS_BUCKET_NAME = config("MEDIA_BUCKET", default=None)
+UPLOADS_GS_BUCKET_NAME = config("UPLOADS_GS_BUCKET_NAME", default=None)
 
 # Custom file storage override for user uploads (e.g. for testing)
 UPLOADS_FILE_STORAGE = config("UPLOADS_FILE_STORAGE", default=None)


### PR DESCRIPTION
Because:

* Django settings is incorrectly looking for MEDIA_BUCKET env var for
  the UPLOADS_GS_BUCKET_NAME setting

This commit:

* changes the setting to use the correct env var name