### PR TITLE
fix #6522 feat(nimbus): enforce relationship between features and applications in filter bar

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/PageHome/FilterBar/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageHome/FilterBar/index.test.tsx
@@ -2,12 +2,57 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { render } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import React from "react";
+import selectEvent from "react-select-event";
 import { EVERYTHING_SELECTED_VALUE, Subject } from "../mocks";
 
 describe("FilterBar", () => {
   it("renders as expected", () => {
     render(<Subject value={EVERYTHING_SELECTED_VALUE} />);
+  });
+
+  it("reports a selection as expected", async () => {
+    const expectedFirefoxVersion = "Firefox 80";
+    const onChange = jest.fn();
+    render(<Subject onChange={onChange} />);
+    await selectEvent.select(screen.getByLabelText("Version"), [
+      expectedFirefoxVersion,
+    ]);
+    expect(onChange).toHaveBeenCalled();
+    const filterValue = onChange.mock.calls[0][0];
+    expect(filterValue.firefoxVersions).toEqual(["FIREFOX_83"]);
+  });
+
+  it("selects associated applications when a feature is selected", async () => {
+    const expectedFeatureConfigName = "Picture-in-Picture";
+    const onChange = jest.fn();
+    render(<Subject onChange={onChange} />);
+    await selectEvent.select(screen.getByLabelText("Feature"), [
+      expectedFeatureConfigName,
+    ]);
+    expect(onChange).toHaveBeenCalled();
+    const filterValue = onChange.mock.calls[0][0];
+    expect(filterValue.featureConfigs).toEqual(["picture-in-picture"]);
+    expect(filterValue.applications).toEqual(["FENIX"]);
+  });
+
+  it("deselects associated features when an application is deselected", async () => {
+    const onChange = jest.fn();
+    render(
+      <Subject
+        onChange={onChange}
+        value={{
+          applications: ["DESKTOP", "IOS"],
+          featureConfigs: ["maurius-odio-erat"],
+        }}
+      />,
+    );
+    await selectEvent.clearFirst(screen.getByLabelText("Application"));
+    expect(onChange).toHaveBeenCalled();
+    const filterValue = onChange.mock.calls[0][0];
+    expect(filterValue.applications).toContain("IOS");
+    expect(filterValue.applications).not.toContain("DESKTOP");
+    expect(filterValue.featureConfigs).not.toContain("maurius-odio-erat");
   });
 });

--- a/app/experimenter/nimbus-ui/src/components/PageHome/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageHome/mocks.tsx
@@ -33,12 +33,18 @@ export const EVERYTHING_SELECTED_VALUE: FilterValue = {
 export const Subject = ({
   options = DEFAULT_OPTIONS,
   value = DEFAULT_VALUE,
+  onChange = () => {},
 }: Partial<React.ComponentProps<typeof FilterBar>>) => {
   const [filterState, setFilterState] = useState<FilterValue>(value);
-  const onChange = (newState: FilterValue) => setFilterState(newState);
+  const onChangeWithState = (newState: FilterValue) => {
+    setFilterState(newState);
+    onChange(newState);
+  };
   return (
     <div>
-      <FilterBar {...{ options, value: filterState, onChange }} />
+      <FilterBar
+        {...{ options, value: filterState, onChange: onChangeWithState }}
+      />
       <div>
         <h3>Filter state</h3>
         <pre>{JSON.stringify(filterState, null, "  ")}</pre>

--- a/app/experimenter/nimbus-ui/src/lib/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/lib/mocks.tsx
@@ -66,11 +66,15 @@ export const MOCK_CONFIG: getConfig_nimbusConfig = {
   applications: [
     {
       label: "Desktop",
-      value: "DESKTOP",
+      value: NimbusExperimentApplication.DESKTOP,
     },
     {
-      label: "Toaster",
-      value: "TOASTER",
+      label: "Fenix",
+      value: NimbusExperimentApplication.FENIX,
+    },
+    {
+      label: "iOS",
+      value: NimbusExperimentApplication.IOS,
     },
   ],
   channels: [


### PR DESCRIPTION
Because:

* features depend on applications when filtering

This commit:

* adds the application for a feature when it's selected for filtering

* removes features when the associated application is deselected