### PR TITLE
fixes #6550 fix(nimbus): fix inconsistent ordering of risk mitigation…

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/Summary/TableOverview/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/TableOverview/index.tsx
@@ -90,9 +90,9 @@ const TableOverview = ({ experiment }: TableOverviewProps) => {
         <tr>
           <th>Risk mitigation question (2):</th>
           <td>
-            {RISK_QUESTIONS.PARTNER} —{" "}
-            {experiment.riskPartnerRelated !== null ? (
-              getRiskLabel(experiment.riskPartnerRelated)
+            {RISK_QUESTIONS.REVENUE} —{" "}
+            {experiment.riskRevenue !== null ? (
+              getRiskLabel(experiment.riskRevenue)
             ) : (
               <NotSet />
             )}
@@ -101,9 +101,9 @@ const TableOverview = ({ experiment }: TableOverviewProps) => {
         <tr>
           <th>Risk mitigation question (3):</th>
           <td>
-            {RISK_QUESTIONS.REVENUE} —{" "}
-            {experiment.riskRevenue !== null ? (
-              getRiskLabel(experiment.riskRevenue)
+            {RISK_QUESTIONS.PARTNER} —{" "}
+            {experiment.riskPartnerRelated !== null ? (
+              getRiskLabel(experiment.riskPartnerRelated)
             ) : (
               <NotSet />
             )}


### PR DESCRIPTION
… questions

Because

* the order of risk mitigation questions between overview and summary page are inconsistent

This commit

* changes the order of risk mitigation questions on summary to match the overview form