### PR TITLE
fix #6570 bug(nimbus): handle loading existing features

### DIFF
--- a/app/experimenter/features/management/commands/load_feature_configs.py
+++ b/app/experimenter/features/management/commands/load_feature_configs.py
@@ -16,13 +16,11 @@ class Command(BaseCommand):
 
         for feature in Features.all():
             feature_config, _ = NimbusFeatureConfig.objects.get_or_create(
+                name=feature.slug,
                 slug=feature.slug,
                 application=feature.applicationSlug,
-                defaults={
-                    "name": feature.slug,
-                    "description": feature.description,
-                },
             )
+            feature_config.description = feature.description
             feature_config.schema = feature.schema
             feature_config.save()
             logger.info(f"Feature Loaded: {feature.applicationSlug}/{feature.slug}")

--- a/app/experimenter/features/tests/test_load_feature_configs.py
+++ b/app/experimenter/features/tests/test_load_feature_configs.py
@@ -3,7 +3,8 @@ import json
 from django.core.management import call_command
 from django.test import TestCase
 
-from experimenter.experiments.models import NimbusFeatureConfig
+from experimenter.experiments.models import NimbusExperiment, NimbusFeatureConfig
+from experimenter.experiments.tests.factories import NimbusFeatureConfigFactory
 from experimenter.features import Features
 from experimenter.features.tests import mock_valid_features
 
@@ -15,8 +16,43 @@ class TestLoadFeatureConfigs(TestCase):
         super().setUpClass()
         Features.clear_cache()
 
-    def test_load_feature_configs(self):
+    def test_loads_new_feature_configs(self):
         self.assertFalse(NimbusFeatureConfig.objects.filter(slug="readerMode").exists())
+        call_command("load_feature_configs")
+
+        feature_config = NimbusFeatureConfig.objects.get(slug="readerMode")
+        self.assertEqual(feature_config.name, "readerMode")
+        self.assertEqual(
+            feature_config.description,
+            "Firefox Reader Mode",
+        )
+        self.assertEqual(
+            json.loads(feature_config.schema),
+            {
+                "additionalProperties": True,
+                "properties": {
+                    "pocketCTAVersion": {
+                        "description": (
+                            "What version of Pocket "
+                            "CTA to show in Reader "
+                            "Mode (Empty string is no "
+                            "CTA)"
+                        ),
+                        "type": "string",
+                        "enum": ["v1", "v2"],
+                    }
+                },
+                "type": "object",
+            },
+        )
+
+    def test_updates_existing_feature_configs(self):
+        NimbusFeatureConfigFactory.create(
+            name="readerMode",
+            slug="readerMode",
+            application=NimbusExperiment.Application.DESKTOP,
+            schema="{}",
+        )
         call_command("load_feature_configs")
 
         feature_config = NimbusFeatureConfig.objects.get(slug="readerMode")


### PR DESCRIPTION
Because

* If a feature already exists in the database, we need to update it
* Because the name is globally unique, we need to include it in the get_or_create query

This commit

* Moves name from a create default to a get query parameter