### PR TITLE
fix #6522 fix(nimbus): encode feature filter selection with both application and feature slugs

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/index.test.tsx
@@ -56,8 +56,8 @@ describe("PageEditBranches", () => {
     );
 
     for (const feature of MOCK_CONFIG!.featureConfigs!) {
-      const { slug, application } = feature!;
-      const configEl = screen.queryByText(slug);
+      const { name, application } = feature!;
+      const configEl = screen.queryByText(name);
       if (application === experiment!.application) {
         expect(configEl).toBeInTheDocument();
       } else {
@@ -211,7 +211,7 @@ jest.mock("./FormBranches", () => ({
           <ul data-testid="feature-config">
             {featureConfigs.map(
               (feature, idx) =>
-                feature && <li key={`feature-${idx}`}>{feature.slug}</li>,
+                feature && <li key={`feature-${idx}`}>{feature.name}</li>,
             )}
           </ul>
         )}

--- a/app/experimenter/nimbus-ui/src/components/PageHome/FilterBar/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageHome/FilterBar/index.tsx
@@ -87,15 +87,6 @@ const FilterSelect = <T extends NullableObjectArray>({
     [fieldOptions],
   );
   const fieldValue = filterValue[filterValueName];
-  const selectedOptions = useMemo(
-    () =>
-      filterOptions.filter(
-        (option) =>
-          typeof option[optionValueName] === "string" &&
-          fieldValue?.includes("" + option[optionValueName]),
-      ),
-    [fieldValue, filterOptions, optionValueName],
-  );
 
   return (
     <Nav.Item className="m-1 mw-25 text-left flex-basis-0 flex-grow-1 flex-shrink-1">
@@ -107,7 +98,7 @@ const FilterSelect = <T extends NullableObjectArray>({
           name: `filter-${filterValueName}`,
           inputId: `filter-${filterValueName}`,
           isMulti: true,
-          value: selectedOptions,
+          value: fieldValue,
           getOptionLabel: (item: OptionTypeBase) =>
             item[optionLabelName as string],
           getOptionValue: (item: OptionTypeBase) =>
@@ -116,9 +107,7 @@ const FilterSelect = <T extends NullableObjectArray>({
           onChange: (fieldValue: OptionsType<OptionTypeBase>) => {
             onChange({
               ...filterValue,
-              [filterValueName]: fieldValue.map(
-                (item) => item[optionValueName as string],
-              ),
+              [filterValueName]: fieldValue,
             });
           },
         }}

--- a/app/experimenter/nimbus-ui/src/components/PageHome/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageHome/index.tsx
@@ -47,7 +47,7 @@ export const Body = () => {
     [updateSearchParams],
   );
 
-  const filterValue = getFilterValueFromParams(searchParams);
+  const filterValue = getFilterValueFromParams(config, searchParams);
   const onFilterChange = (newFilterValue: FilterValue) =>
     updateParamsFromFilterValue(updateSearchParams, newFilterValue);
 

--- a/app/experimenter/nimbus-ui/src/components/PageHome/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageHome/mocks.tsx
@@ -23,12 +23,7 @@ export const DEFAULT_VALUE: FilterValue = {
   firefoxVersions: [],
 };
 
-export const EVERYTHING_SELECTED_VALUE: FilterValue = {
-  owners: MOCK_CONFIG!.owners!.map((a) => a!.username!),
-  applications: MOCK_CONFIG!.applications!.map((a) => a!.value!),
-  firefoxVersions: MOCK_CONFIG!.firefoxVersions!.map((a) => a!.value!),
-  featureConfigs: MOCK_CONFIG!.featureConfigs!.map((a) => a!.slug!),
-};
+export const EVERYTHING_SELECTED_VALUE: FilterValue = DEFAULT_OPTIONS;
 
 export const Subject = ({
   options = DEFAULT_OPTIONS,

--- a/app/experimenter/nimbus-ui/src/components/PageHome/types.ts
+++ b/app/experimenter/nimbus-ui/src/components/PageHome/types.ts
@@ -4,18 +4,27 @@
 
 import { getConfig_nimbusConfig } from "../../types/getConfig";
 
-export type FilterOptions = Pick<
-  getConfig_nimbusConfig,
-  "applications" | "featureConfigs" | "firefoxVersions" | "owners"
->;
-
-export const FilterValueKeys = [
+export const filterValueKeys = [
   "owners",
   "applications",
   "featureConfigs",
   "firefoxVersions",
 ] as const;
 
-export type FilterValue = Partial<
-  Record<typeof FilterValueKeys[number], string[]>
+export type FilterValueKeys = typeof filterValueKeys[number];
+
+export type FilterOptions = Pick<getConfig_nimbusConfig, FilterValueKeys>;
+
+export type FilterValue = Partial<FilterOptions>;
+
+export type OptionalString = string | null | undefined;
+
+// Very awkward type representing a property of FilterOptions that has been
+// verified as not null. Typescript does not infer this, for some reason.
+export type NonNullFilterOptions<K extends FilterValueKeys> = NonNullable<
+  FilterOptions[K]
+>[number][];
+
+export type NonNullFilterOption<K extends FilterValueKeys> = NonNullable<
+  NonNullFilterOptions<K>[number]
 >;

--- a/app/experimenter/nimbus-ui/src/lib/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/lib/mocks.tsx
@@ -66,11 +66,19 @@ export const MOCK_CONFIG: getConfig_nimbusConfig = {
   applications: [
     {
       label: "Desktop",
-      value: "DESKTOP",
+      value: NimbusExperimentApplication.DESKTOP,
     },
     {
       label: "Toaster",
       value: "TOASTER",
+    },
+    {
+      label: "iOS",
+      value: NimbusExperimentApplication.IOS,
+    },
+    {
+      label: "Android",
+      value: NimbusExperimentApplication.FENIX,
     },
   ],
   channels: [
@@ -165,10 +173,19 @@ export const MOCK_CONFIG: getConfig_nimbusConfig = {
     },
     {
       id: 3,
-      name: "Foo lila sat",
+      name: "Foo lila sat (iOS)",
       slug: "foo-lila-sat",
       description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
       application: NimbusExperimentApplication.IOS,
+      ownerEmail: "dude23@yahoo.com",
+      schema: '{ "sample": "schema" }',
+    },
+    {
+      id: 4,
+      name: "Foo lila sat (Android)",
+      slug: "foo-lila-sat",
+      description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+      application: NimbusExperimentApplication.FENIX,
       ownerEmail: "dude23@yahoo.com",
       schema: '{ "sample": "schema" }',
     },


### PR DESCRIPTION
Because:

* features are uniquely identified via slug and application

This commit:

* refactors the code involved in encoding & decoding filter selections
  and experiment filter application

* defines new functions for indexing filter operations by strings
  * features are indexed by application:feature

* defines new functions for filtering experiments by config data objects