### PR TITLE
fix #6212 feat(nimbus): add conclusion recommendation choices to nimbus constants

### DIFF
--- a/app/experimenter/experiments/api/v5/types.py
+++ b/app/experimenter/experiments/api/v5/types.py
@@ -188,6 +188,7 @@ class NimbusConfigurationType(graphene.ObjectType):
     outcomes = graphene.List(NimbusOutcomeType)
     owners = graphene.List(NimbusUser)
     targeting_configs = graphene.List(NimbusExperimentTargetingConfig)
+    conclusion_recommendations = graphene.List(NimbusLabelValueType)
 
     def _text_choices_to_label_value_list(root, text_choices):
         return [
@@ -226,6 +227,11 @@ class NimbusConfigurationType(graphene.ObjectType):
 
     def resolve_firefox_versions(root, info):
         return root._text_choices_to_label_value_list(NimbusExperiment.Version)
+
+    def resolve_conclusion_recommendations(root, info):
+        return root._text_choices_to_label_value_list(
+            NimbusExperiment.ConclusionRecommendation
+        )
 
     def resolve_outcomes(root, info):
         return Outcomes.all()

--- a/app/experimenter/experiments/constants/nimbus.py
+++ b/app/experimenter/experiments/constants/nimbus.py
@@ -376,6 +376,13 @@ class NimbusConstants(object):
         APPROVED = "Approved"
         WAITING = "Waiting"
 
+    class ConclusionRecommendation(models.TextChoices):
+        RERUN = "RERUN", "Rerun"
+        GRADUATE = "GRADUATE", "Graduate"
+        CHANGE_COURSE = "CHANGE_COURSE", "Change course"
+        STOP = "STOP", "Stop"
+        FOLLOWUP = "FOLLOWUP", "Run follow ups"
+
     Application = Application
 
     VALID_STATUS_TRANSITIONS = {

--- a/app/experimenter/experiments/tests/api/v5/test_queries.py
+++ b/app/experimenter/experiments/tests/api/v5/test_queries.py
@@ -872,6 +872,10 @@ class TestNimbusConfigQuery(GraphQLTestCase):
                         label
                         value
                     }
+                    conclusionRecommendations {
+                        label
+                        value
+                    }
                     applicationConfigs {
                         application
                         channels {
@@ -935,6 +939,9 @@ class TestNimbusConfigQuery(GraphQLTestCase):
 
         assertChoices(config["applications"], NimbusExperiment.Application)
         assertChoices(config["channels"], NimbusExperiment.Channel)
+        assertChoices(
+            config["conclusionRecommendations"], NimbusExperiment.ConclusionRecommendation
+        )
         assertChoices(config["firefoxVersions"], NimbusExperiment.Version)
         assertChoices(config["documentationLink"], NimbusExperiment.DocumentationLink)
         self.assertEqual(len(config["featureConfigs"]), 16)

--- a/app/experimenter/nimbus-ui/schema.graphql
+++ b/app/experimenter/nimbus-ui/schema.graphql
@@ -159,6 +159,7 @@ type NimbusConfigurationType {
   outcomes: [NimbusOutcomeType]
   owners: [NimbusUser]
   targetingConfigs: [NimbusExperimentTargetingConfig]
+  conclusionRecommendations: [NimbusLabelValueType]
 }
 
 type NimbusCountryType {


### PR DESCRIPTION
Because:

* we want to support adding documentation about takeaways from
  experiment results

This commit:

* adds a new constant listing a set of conclusion recommendations

* adds the conclusion recommendations list to the config object served
  up via the GQL API