### PR TITLE
fix #6424 fix(nimbus): ensure TestGetUploadsStorage passes even when UPLOADS_GS_BUCKET_NAME is configured locally

### DIFF
--- a/app/experimenter/base/tests/test_base.py
+++ b/app/experimenter/base/tests/test_base.py
@@ -54,7 +54,7 @@ class TestAppVersion(TestCase):
 
 
 class TestGetUploadsStorage(TestCase):
-    @override_settings(UPLOADS_GS_CREDENTIALS=None, UPLOADS_FILE_STORAGE=None)
+    @override_settings(UPLOADS_GS_BUCKET_NAME=None, UPLOADS_FILE_STORAGE=None)
     def test_get_uploads_storage_default(self):
         self.assertIsInstance(get_uploads_storage(), FileSystemStorage)
 


### PR DESCRIPTION

Because:

* UPLOADS_GS_BUCKET_NAME needs to be set to None to cause
  get_uploads_storage() to properly select FileSystemStorage

This commit:

* overrides UPLOADS_GS_BUCKET_NAME to None rather than
  UPLOADS_GS_CREDENTIALS