### PR TITLE
fix #6522 fix(nimbus): ensure the feature multi-select uses the correct value encoding

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/PageHome/filterExperiments.ts
+++ b/app/experimenter/nimbus-ui/src/components/PageHome/filterExperiments.ts
@@ -18,7 +18,9 @@ type OptionIndexKey<K extends FilterValueKeys> = (
   option: NonNullFilterOption<K>,
 ) => OptionalString;
 
-const optionIndexKeys: { [key in FilterValueKeys]: OptionIndexKey<key> } = {
+export const optionIndexKeys: {
+  [key in FilterValueKeys]: OptionIndexKey<key>;
+} = {
   owners: (option) => option.username,
   applications: (option) => option.value,
   featureConfigs: (option) => `${option.application}:${option.slug}`,


### PR DESCRIPTION
Because:

* features are uniquely identified via slug and application

This commit:

* ensures that the multi-select widget also uses slug & application for
  determining which options have been selected