### PR TITLE
fix #6588 bug(nimbus): do not validate json variables in feature manifests

### DIFF
--- a/app/experimenter/features/__init__.py
+++ b/app/experimenter/features/__init__.py
@@ -21,7 +21,6 @@ FEATURE_SCHEMA_TYPES = {
     FeatureVariableType.INT: "number",
     FeatureVariableType.STRING: "string",
     FeatureVariableType.BOOLEAN: "boolean",
-    FeatureVariableType.JSON: "string",
 }
 
 
@@ -50,9 +49,11 @@ class Feature(BaseModel):
 
         for variable_slug, variable in self.variables.items():
             variable_schema = {
-                "type": FEATURE_SCHEMA_TYPES[variable.type],
                 "description": variable.description,
             }
+
+            if variable.type in FEATURE_SCHEMA_TYPES:
+                variable_schema["type"] = FEATURE_SCHEMA_TYPES[variable.type]
 
             if variable.enum:
                 variable_schema["enum"] = variable.enum

--- a/app/experimenter/features/tests/fixtures/valid_features/firefox-desktop.json
+++ b/app/experimenter/features/tests/fixtures/valid_features/firefox-desktop.json
@@ -12,6 +12,10 @@
 					"v1",
 					"v2"
 				]
+			},
+			"config": {
+				"type": "json",
+				"description": "Arbitrary JSON config"
 			}
 		}
 	}

--- a/app/experimenter/features/tests/test_features.py
+++ b/app/experimenter/features/tests/test_features.py
@@ -40,7 +40,11 @@ class TestFeatures(TestCase):
                         enum=["v1", "v2"],
                         fallbackPref="reader.pocket.ctaVersion",
                         type=FeatureVariableType.STRING,
-                    )
+                    ),
+                    "config": FeatureVariable(
+                        description="Arbitrary JSON config",
+                        type="json",
+                    ),
                 },
             ),
             features,
@@ -83,7 +87,11 @@ class TestFeatures(TestCase):
                         enum=["v1", "v2"],
                         fallbackPref="reader.pocket.ctaVersion",
                         type=FeatureVariableType.STRING,
-                    )
+                    ),
+                    "config": FeatureVariable(
+                        description="Arbitrary JSON config",
+                        type="json",
+                    ),
                 },
             ),
             desktop_features,
@@ -105,7 +113,10 @@ class TestFeatures(TestCase):
                         ),
                         "type": "string",
                         "enum": ["v1", "v2"],
-                    }
+                    },
+                    "config": {
+                        "description": "Arbitrary JSON config",
+                    },
                 },
                 "type": "object",
             },

--- a/app/experimenter/features/tests/test_load_feature_configs.py
+++ b/app/experimenter/features/tests/test_load_feature_configs.py
@@ -40,7 +40,10 @@ class TestLoadFeatureConfigs(TestCase):
                         ),
                         "type": "string",
                         "enum": ["v1", "v2"],
-                    }
+                    },
+                    "config": {
+                        "description": "Arbitrary JSON config",
+                    },
                 },
                 "type": "object",
             },
@@ -75,7 +78,10 @@ class TestLoadFeatureConfigs(TestCase):
                         ),
                         "type": "string",
                         "enum": ["v1", "v2"],
-                    }
+                    },
+                    "config": {
+                        "description": "Arbitrary JSON config",
+                    },
                 },
                 "type": "object",
             },


### PR DESCRIPTION


Because

* The json type in a feature manifest means any arbitrary js type we should not validate it against any type, instead of validating it against string

This commit

* Removes the type from the auto generated schema altogether for variables of type json