### PR TITLE
fix #6420 fix(nimbus): reorder the migration from branch screenshot management

### DIFF
--- a/app/experimenter/experiments/migrations/0192_alter_nimbusbranchscreenshot_options.py
+++ b/app/experimenter/experiments/migrations/0192_alter_nimbusbranchscreenshot_options.py
@@ -6,7 +6,7 @@ from django.db import migrations
 class Migration(migrations.Migration):
 
     dependencies = [
-        ("experiments", "0188_auto_20210930_1549"),
+        ("experiments", "0191_auto_20211025_2014"),
     ]
 
     operations = [


### PR DESCRIPTION
Because:

* PR #6472 introduced a migration 0189 and there have already been
  several landed migrations since then

This commit:

* Renames and reorders that migration for screenshots