### PR TITLE
fix #6596 feat(nimbus): add channel to namespace

### DIFF
--- a/app/experimenter/experiments/models/nimbus.py
+++ b/app/experimenter/experiments/models/nimbus.py
@@ -399,6 +399,18 @@ class NimbusExperiment(NimbusConstants, FilterMixin, models.Model):
         self.save()
         self.branches.all().delete()
 
+    @property
+    def bucket_namespace(self):
+        keys = [
+            self.application_config.slug,
+            self.feature_config.slug,
+        ]
+
+        if self.channel:
+            keys.append(self.channel)
+
+        return "-".join(keys)
+
     def allocate_bucket_range(self):
         existing_bucket_range = NimbusBucketRange.objects.filter(experiment=self)
         if existing_bucket_range.exists():
@@ -409,7 +421,7 @@ class NimbusExperiment(NimbusConstants, FilterMixin, models.Model):
                 NimbusIsolationGroup.objects.filter(id=isolation_group.id).delete()
 
         NimbusIsolationGroup.request_isolation_group_buckets(
-            f"{self.application_config.slug}-{self.feature_config.slug}",
+            self.bucket_namespace,
             self,
             int(
                 self.population_percent / Decimal("100.0") * NimbusExperiment.BUCKET_TOTAL

--- a/app/experimenter/experiments/tests/test_models/test_models_nimbus.py
+++ b/app/experimenter/experiments/tests/test_models/test_models_nimbus.py
@@ -739,13 +739,15 @@ class TestNimbusExperiment(TestCase):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.CREATED,
             application=NimbusExperiment.Application.DESKTOP,
+            channel=NimbusExperiment.Channel.RELEASE,
             feature_config=feature,
             population_percent=Decimal("50.0"),
         )
         experiment.allocate_bucket_range()
         self.assertEqual(experiment.bucket_range.count, 5000)
         self.assertEqual(
-            experiment.bucket_range.isolation_group.name, "firefox-desktop-feature"
+            experiment.bucket_range.isolation_group.name,
+            "firefox-desktop-feature-release",
         )
 
     def test_allocate_buckets_creates_new_bucket_range_if_population_changes(self):
@@ -765,6 +767,7 @@ class TestNimbusExperiment(TestCase):
         experiment1 = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.CREATED,
             application=NimbusExperiment.Application.DESKTOP,
+            channel=NimbusExperiment.Channel.RELEASE,
             feature_config=feature,
             population_percent=Decimal("50.0"),
         )
@@ -773,6 +776,7 @@ class TestNimbusExperiment(TestCase):
         experiment2 = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.CREATED,
             application=NimbusExperiment.Application.DESKTOP,
+            channel=NimbusExperiment.Channel.RELEASE,
             feature_config=feature,
             population_percent=Decimal("100.0"),
         )
@@ -794,6 +798,7 @@ class TestNimbusExperiment(TestCase):
         experiment1 = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.CREATED,
             application=NimbusExperiment.Application.DESKTOP,
+            channel=NimbusExperiment.Channel.RELEASE,
             feature_config=feature,
             population_percent=Decimal("50.0"),
         )
@@ -802,6 +807,7 @@ class TestNimbusExperiment(TestCase):
         experiment2 = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.CREATED,
             application=NimbusExperiment.Application.DESKTOP,
+            channel=NimbusExperiment.Channel.RELEASE,
             feature_config=feature,
             population_percent=Decimal("25.0"),
         )


### PR DESCRIPTION
Because

* Experiments targeting different channels can not collide
* If they share the same namespace then they'll accidentally consume each others buckets unnecessarily

This commit

* Adds channel to bucket namespaces