### PR TITLE
fix #6189 fix #6191 fix #6192 feat(nimbus): add takeaways management …

### DIFF
--- a/app/experimenter/experiments/constants/nimbus.py
+++ b/app/experimenter/experiments/constants/nimbus.py
@@ -450,6 +450,8 @@ class NimbusConstants(object):
         "publish_status",
         "status_next",
         "status",
+        "takeaways_summary",
+        "conclusion_recommendation",
     )
 
     ARCHIVE_UPDATE_EXEMPT_FIELDS = (

--- a/app/experimenter/nimbus-ui/src/components/PageResults/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/index.stories.tsx
@@ -15,15 +15,19 @@ import {
   weeklyMockAnalysis,
 } from "../../lib/visualization/mocks";
 import { AnalysisData } from "../../lib/visualization/types";
+import { getExperiment_experimentBySlug } from "../../types/getExperiment";
 import { NimbusExperimentStatus } from "../../types/globalTypes";
 
 const Subject = ({
+  experiment = {},
   analysis = mockAnalysis(),
 }: {
+  experiment?: Partial<getExperiment_experimentBySlug>;
   analysis?: AnalysisData;
 }) => {
   const { mock } = mockExperimentQuery("demo-slug", {
     status: NimbusExperimentStatus.COMPLETE,
+    ...experiment,
   });
   fetchMock.restore().getOnce("/api/v3/visualization/demo-slug/", analysis);
   return (

--- a/app/experimenter/nimbus-ui/src/components/PageResults/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/index.tsx
@@ -85,6 +85,7 @@ const PageResults: React.FunctionComponent<RouteComponentProps> = () => {
                 Detailed Analysis <ExternalIcon />
               </LinkExternal>
             </p>
+
             <h3 className="h4 mb-3 mt-4" id="overview">
               Overview
             </h3>

--- a/app/experimenter/nimbus-ui/src/components/PageSummary/Takeaways/TakeawaysEditor.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageSummary/Takeaways/TakeawaysEditor.tsx
@@ -1,0 +1,155 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import classNames from "classnames";
+import React, { useCallback } from "react";
+import Alert from "react-bootstrap/Alert";
+import Button from "react-bootstrap/Button";
+import Col from "react-bootstrap/Col";
+import Form from "react-bootstrap/Form";
+import Row from "react-bootstrap/Row";
+import { FormProvider } from "react-hook-form";
+import { useCommonForm } from "../../../hooks";
+import { getConfig_nimbusConfig } from "../../../types/getConfig";
+import { UseTakeawaysResult } from "./useTakeaways";
+
+export const takeawaysEditorFieldNames = [
+  "conclusionRecommendation",
+  "takeawaysSummary",
+] as const;
+
+type TakeawaysEditorFieldName = typeof takeawaysEditorFieldNames[number];
+
+export type TakeawaysEditorProps = UseTakeawaysResult &
+  Pick<getConfig_nimbusConfig, "conclusionRecommendations"> & {
+    setShowEditor: (state: boolean) => void;
+  };
+
+export const TakeawaysEditor = ({
+  isLoading,
+  conclusionRecommendations,
+  conclusionRecommendation,
+  takeawaysSummary,
+  setShowEditor,
+  onSubmit,
+  submitErrors,
+  setSubmitErrors,
+  isServerValid,
+}: TakeawaysEditorProps) => {
+  const defaultValues = { conclusionRecommendation, takeawaysSummary };
+  type DefaultValues = typeof defaultValues;
+
+  const {
+    isValid,
+    isSubmitted,
+    FormErrors,
+    formControlAttrs,
+    handleSubmit,
+    formMethods,
+  } = useCommonForm<TakeawaysEditorFieldName>(
+    defaultValues,
+    isServerValid,
+    submitErrors,
+    setSubmitErrors,
+    {},
+  );
+
+  const onClickCancel = useCallback(
+    () => setShowEditor(false),
+    [setShowEditor],
+  );
+
+  const handleSave = handleSubmit(async (data: DefaultValues) => {
+    if (isLoading) return;
+    await onSubmit(data);
+  });
+
+  const conclusionRadioAttrs = formControlAttrs(
+    "conclusionRecommendation",
+    {},
+    false,
+  );
+
+  return (
+    <section id="takeaways-editor" data-testid="TakeawaysEditor">
+      <h3 className="h4 mb-3 mt-4">
+        <Row>
+          <Col>Takeaways</Col>
+          <Col className="text-right">
+            <Button
+              onClick={handleSave}
+              disabled={isLoading}
+              variant="primary"
+              size="sm"
+              className="mx-1"
+            >
+              Save
+            </Button>
+            <Button
+              onClick={onClickCancel}
+              disabled={isLoading}
+              variant="secondary"
+              size="sm"
+              className="mx-1"
+            >
+              Cancel
+            </Button>
+          </Col>
+        </Row>
+      </h3>
+      <FormProvider {...formMethods}>
+        <Form
+          noValidate
+          onSubmit={handleSave}
+          validated={isSubmitted && isValid}
+          data-testid="FormTakeaways"
+        >
+          {submitErrors["*"] && (
+            <Alert data-testid="submit-error" variant="warning">
+              {submitErrors["*"]}
+            </Alert>
+          )}
+          <Form.Group as={Row}>
+            <Form.Group
+              as={Col}
+              className="flex-grow-0"
+              controlId="conclusionRecommendation"
+            >
+              <Form.Label
+                className={classNames("font-weight-bold", {
+                  "is-invalid": !!submitErrors["conclusion_recommendation"],
+                })}
+              >
+                Recommendation:
+              </Form.Label>
+              {conclusionRecommendations!.map((option, idx) => (
+                <Form.Check
+                  key={idx}
+                  type="radio"
+                  value={option!.value!}
+                  label={option!.label!}
+                  title={option!.label!}
+                  {...conclusionRadioAttrs}
+                  id={`conclusionRecommendation-${option!.value!}}`}
+                />
+              ))}
+              <FormErrors name="conclusionRecommendation" />
+            </Form.Group>
+            <Form.Group as={Col} controlId="takeawaysSummary">
+              <Form.Label className="font-weight-bold">Summary:</Form.Label>
+              <Form.Control
+                as="textarea"
+                rows={5}
+                {...formControlAttrs("takeawaysSummary")}
+              />
+              <FormErrors name="takeawaysSummary" />
+            </Form.Group>
+          </Form.Group>
+        </Form>
+      </FormProvider>
+    </section>
+  );
+};
+
+export default TakeawaysEditor;

--- a/app/experimenter/nimbus-ui/src/components/PageSummary/Takeaways/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageSummary/Takeaways/index.stories.tsx
@@ -1,0 +1,56 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { action } from "@storybook/addon-actions";
+import React from "react";
+import Takeaways from ".";
+import { NimbusExperimentConclusionRecommendation } from "../../../types/globalTypes";
+import { Subject as BaseSubject, TAKEAWAYS_SUMMARY_LONG } from "./mocks";
+
+export default {
+  title: "pages/Results/Takeaways",
+  component: Takeaways,
+};
+
+const submitAction = action("submit");
+
+const Subject = ({
+  onSubmit = async (data) => submitAction(data),
+  ...props
+}: React.ComponentProps<typeof BaseSubject>) => (
+  <BaseSubject {...{ onSubmit, ...props }} />
+);
+
+export const Blank = () => <Subject />;
+
+const commonContent = {
+  takeawaysSummary: TAKEAWAYS_SUMMARY_LONG,
+  conclusionRecommendation:
+    NimbusExperimentConclusionRecommendation.CHANGE_COURSE,
+};
+
+export const WithContent = () => <Subject {...commonContent} />;
+
+export const Editor = () => (
+  <Subject {...{ ...commonContent, showEditor: true }} />
+);
+
+export const EditorIsLoading = () => (
+  <Subject {...{ ...commonContent, showEditor: true, isLoading: true }} />
+);
+
+export const WithSubmitErrors = () => (
+  <Subject
+    {...{
+      ...commonContent,
+      showEditor: true,
+      isServerValid: false,
+      submitErrors: {
+        "*": ["Meteor fell on the server!"],
+        takeaways_summary: ["Too many mentions of chickens!"],
+        conclusion_recommendation: ["'Ship it' is an invalid recommendation."],
+      },
+    }}
+  />
+);

--- a/app/experimenter/nimbus-ui/src/components/PageSummary/Takeaways/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageSummary/Takeaways/index.test.tsx
@@ -1,0 +1,417 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { MockedResponse } from "@apollo/client/testing";
+import { fireEvent } from "@testing-library/dom";
+import { render, screen } from "@testing-library/react";
+import {
+  act as hookAct,
+  renderHook,
+  RenderResult as HookRenderResult,
+} from "@testing-library/react-hooks";
+import React from "react";
+import { act } from "react-dom/test-utils";
+import { useTakeaways, UseTakeawaysResult } from ".";
+import { UPDATE_EXPERIMENT_MUTATION } from "../../../gql/experiments";
+import { CHANGELOG_MESSAGES, SUBMIT_ERROR } from "../../../lib/constants";
+import {
+  MockedCache,
+  mockExperimentMutation,
+  mockExperimentQuery,
+} from "../../../lib/mocks";
+import { getExperiment_experimentBySlug } from "../../../types/getExperiment";
+import { NimbusExperimentConclusionRecommendation } from "../../../types/globalTypes";
+import { Subject as BaseSubject } from "./mocks";
+
+const { experiment } = mockExperimentQuery("demo-slug", {
+  takeawaysSummary: "old content",
+  conclusionRecommendation: NimbusExperimentConclusionRecommendation.RERUN,
+});
+
+const Subject = ({
+  onSubmit = jest.fn(),
+  ...props
+}: React.ComponentProps<typeof BaseSubject>) => (
+  <BaseSubject {...{ onSubmit, ...props }} />
+);
+
+const takeawaysSummary = "sample *exciting* content";
+const conclusionRecommendation =
+  NimbusExperimentConclusionRecommendation.CHANGE_COURSE;
+const expectedConclusionRecommendationLabel = "Change course";
+
+describe("Takeaways", () => {
+  it("renders as expected when blank", () => {
+    render(<Subject />);
+    expect(screen.queryByTestId("Takeaways")).toBeInTheDocument();
+    expect(screen.queryByTestId("TakeawaysEditor")).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("conclusion-recommendation-status"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("takeaways-summary-rendered"),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByTestId("not-set")).toBeInTheDocument();
+  });
+
+  it("renders as expected with content", () => {
+    render(<Subject {...{ takeawaysSummary, conclusionRecommendation }} />);
+    expect(screen.queryByTestId("Takeaways")).toBeInTheDocument();
+    expect(screen.queryByTestId("TakeawaysEditor")).not.toBeInTheDocument();
+    expect(
+      screen.getByTestId("conclusion-recommendation-status"),
+    ).toHaveTextContent(expectedConclusionRecommendationLabel);
+    expect(screen.getByTestId("takeaways-summary-rendered")).toContainHTML(
+      "<p>sample <em>exciting</em> content</p>",
+    );
+    expect(screen.queryByTestId("not-set")).not.toBeInTheDocument();
+  });
+
+  it("sets showEditor to true when the edit button is clicked", () => {
+    const setShowEditor = jest.fn();
+    render(
+      <Subject
+        {...{ setShowEditor, takeawaysSummary, conclusionRecommendation }}
+      />,
+    );
+    const editButton = screen.getByTestId("edit-takeaways");
+    fireEvent.click(editButton);
+    expect(setShowEditor).toHaveBeenCalledWith(true);
+  });
+});
+
+describe("TakeawaysEditor", () => {
+  it("appears when showEditor is true", () => {
+    render(<Subject showEditor />);
+    expect(screen.queryByTestId("Takeaways")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("TakeawaysEditor")).toBeInTheDocument();
+  });
+
+  it("renders as expected with content", () => {
+    render(
+      <Subject
+        {...{ showEditor: true, takeawaysSummary, conclusionRecommendation }}
+      />,
+    );
+    expect(screen.queryByTestId("TakeawaysEditor")).toBeInTheDocument();
+    expect(screen.getByText("Save")).not.toBeDisabled();
+    expect(screen.getByText("Cancel")).not.toBeDisabled();
+    const editorForm = screen.getByTestId("FormTakeaways");
+    expect(editorForm).toHaveFormValues({
+      takeawaysSummary,
+      conclusionRecommendation,
+    });
+  });
+
+  it("disables buttons when loading", async () => {
+    const onSubmit = jest.fn();
+    render(
+      <Subject
+        {...{
+          onSubmit,
+          showEditor: true,
+          isLoading: true,
+          takeawaysSummary,
+          conclusionRecommendation,
+        }}
+      />,
+    );
+    expect(screen.getByText("Save")).toBeDisabled();
+    expect(screen.getByText("Cancel")).toBeDisabled();
+    await act(async () => {
+      fireEvent.submit(screen.getByTestId("FormTakeaways"));
+    });
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it("submits form data when save is clicked", async () => {
+    const onSubmit = jest.fn();
+    render(
+      <Subject
+        {...{
+          onSubmit,
+          showEditor: true,
+          takeawaysSummary,
+          conclusionRecommendation,
+        }}
+      />,
+    );
+    await act(async () => {
+      fireEvent.click(screen.getByText("Save"));
+    });
+    expect(onSubmit).toHaveBeenCalled();
+  });
+
+  it("hides the editor when cancel is clicked", async () => {
+    const setShowEditor = jest.fn();
+    render(
+      <Subject
+        {...{
+          setShowEditor,
+          showEditor: true,
+          takeawaysSummary,
+          conclusionRecommendation,
+        }}
+      />,
+    );
+    await act(async () => {
+      fireEvent.click(screen.getByText("Cancel"));
+    });
+    expect(setShowEditor).toHaveBeenCalledWith(false);
+  });
+
+  it("displays server submission errors", async () => {
+    const submitErrors = {
+      "*": ["Meteor fell on the server!"],
+      takeaways_summary: ["Too many mentions of chickens!"],
+      conclusion_recommendation: ["'Ship it' is an invalid recommendation."],
+    };
+    const { container } = render(
+      <Subject
+        {...{
+          showEditor: true,
+          takeawaysSummary,
+          conclusionRecommendation,
+          isServerValid: false,
+          submitErrors,
+        }}
+      />,
+    );
+    expect(screen.getByTestId("submit-error")).toHaveTextContent(
+      submitErrors["*"][0],
+    );
+    expect(
+      container.querySelector('.invalid-feedback[data-for="takeawaysSummary"]'),
+    ).toHaveTextContent(submitErrors.takeaways_summary[0]);
+    expect(
+      container.querySelector(
+        '.invalid-feedback[data-for="conclusionRecommendation"]',
+      ),
+    ).toHaveTextContent(submitErrors.conclusion_recommendation[0]);
+  });
+});
+
+describe("useTakeaways", () => {
+  const submitData = {
+    takeawaysSummary: "super exciting results",
+    conclusionRecommendation: NimbusExperimentConclusionRecommendation.STOP,
+  };
+  const mutationVariables = {
+    id: experiment.id,
+    takeawaysSummary: submitData.takeawaysSummary,
+    conclusionRecommendation: submitData.conclusionRecommendation,
+    changelogMessage: CHANGELOG_MESSAGES.UPDATED_TAKEAWAYS,
+  };
+  let refetch = jest.fn();
+
+  beforeEach(() => {
+    refetch = jest.fn();
+  });
+
+  it("returns expected initial props", () => {
+    const { result } = setupTestHook({ refetch });
+    const props = result.current;
+    expect(props).toMatchObject({
+      id: experiment.id,
+      takeawaysSummary: experiment.takeawaysSummary,
+      conclusionRecommendation: experiment.conclusionRecommendation,
+      showEditor: false,
+      isLoading: false,
+      submitErrors: {},
+      isServerValid: true,
+    });
+    const functionNames: (keyof UseTakeawaysResult)[] = [
+      "onSubmit",
+      "setShowEditor",
+      "setSubmitErrors",
+    ];
+    for (const name of functionNames) {
+      expect(typeof props[name]).toEqual("function");
+    }
+  });
+
+  it("performs a mutation as expected via onSubmit", async () => {
+    const { result } = setupTestHook({
+      refetch,
+      mocks: [
+        mockExperimentMutation(
+          UPDATE_EXPERIMENT_MUTATION,
+          mutationVariables,
+          "updateExperiment",
+          { experiment: mutationVariables },
+        ),
+      ],
+    });
+    await hookAct(async () => {
+      await result.current.setShowEditor(true);
+    });
+    await hookAct(async () => {
+      await result.current.onSubmit(submitData);
+    });
+    expect(refetch).toHaveBeenCalled();
+    assertHookSteps(
+      result,
+      ["isLoading", "isServerValid", "submitErrors", "showEditor"],
+      [
+        [false, true, {}, false],
+        [false, true, {}, true],
+        [true, true, {}, true],
+        [true, true, {}, true],
+        [true, true, {}, true],
+        [true, true, {}, true],
+        [true, true, {}, false],
+        [false, true, {}, false],
+      ],
+    );
+  });
+
+  it("handles submit error feedback as expected via onSubmit", async () => {
+    const mocks = [
+      mockExperimentMutation(
+        UPDATE_EXPERIMENT_MUTATION,
+        mutationVariables,
+        "updateExperiment",
+        { experiment: mutationVariables },
+      ),
+    ];
+    const submitErrors = {
+      "*": ["Meteor fell on the server!"],
+      takeaways_summary: ["Too many mentions of chickens!"],
+      conclusion_recommendation: ["'Ship it' is an invalid recommendation."],
+    };
+    mocks[0].result.data.updateExperiment.message = submitErrors;
+    const refetch = jest.fn();
+    const { result } = setupTestHook({ refetch, mocks });
+    await hookAct(async () => {
+      await result.current.setShowEditor(true);
+    });
+    await hookAct(async () => {
+      await result.current.onSubmit(submitData);
+    });
+    expect(refetch).not.toHaveBeenCalled();
+    assertHookSteps(
+      result,
+      ["isLoading", "isServerValid", "submitErrors", "showEditor"],
+      [
+        [false, true, {}, false],
+        [false, true, {}, true],
+        [true, true, {}, true],
+        [true, true, {}, true],
+        [true, false, {}, true],
+        [false, false, {}, true],
+        [false, false, submitErrors, true],
+      ],
+    );
+  });
+
+  it("handles exceptions as expected via onSubmit", async () => {
+    const mocks = [
+      mockExperimentMutation(
+        UPDATE_EXPERIMENT_MUTATION,
+        mutationVariables,
+        "updateExperiment",
+        { experiment: mutationVariables },
+      ),
+    ];
+    mocks[0].result.errors = [new Error("OOPSIE")];
+    const { result } = setupTestHook({ refetch, mocks });
+    await hookAct(async () => {
+      await result.current.setShowEditor(true);
+    });
+    await hookAct(async () => {
+      await result.current.onSubmit(submitData);
+    });
+    expect(refetch).not.toHaveBeenCalled();
+    assertHookSteps(
+      result,
+      ["isLoading", "isServerValid", "submitErrors", "showEditor"],
+      [
+        [false, true, {}, false],
+        [false, true, {}, true],
+        [true, true, {}, true],
+        [true, true, {}, true],
+        [true, false, {}, true],
+        [false, false, {}, true],
+        [false, false, { "*": SUBMIT_ERROR }, true],
+      ],
+    );
+  });
+
+  it("handles invalid server data as expected via onSubmit", async () => {
+    const mocks = [
+      mockExperimentMutation(
+        UPDATE_EXPERIMENT_MUTATION,
+        mutationVariables,
+        "updateExperiment",
+        { experiment: mutationVariables },
+      ),
+    ];
+    // @ts-ignore intentionally broken type
+    delete mocks[0].result.data;
+    const { result } = setupTestHook({ refetch, mocks });
+    await hookAct(async () => {
+      await result.current.setShowEditor(true);
+    });
+    await hookAct(async () => {
+      await result.current.onSubmit(submitData);
+    });
+    expect(refetch).not.toHaveBeenCalled();
+    assertHookSteps(
+      result,
+      ["isLoading", "isServerValid", "submitErrors", "showEditor"],
+      [
+        [false, true, {}, false],
+        [false, true, {}, true],
+        [true, true, {}, true],
+        [true, true, {}, true],
+        [true, false, {}, true],
+        [false, false, {}, true],
+        [false, false, { "*": SUBMIT_ERROR }, true],
+      ],
+    );
+  });
+
+  function assertHookSteps(
+    result: HookRenderResult<UseTakeawaysResult>,
+    expectedStepKeys: (keyof UseTakeawaysResult)[],
+    expectedSteps: any[],
+  ) {
+    for (let stepIdx = 0; stepIdx < expectedSteps.length; stepIdx++) {
+      expect(result.all[stepIdx]).not.toBeInstanceOf(Error);
+      const props = result.all[stepIdx] as UseTakeawaysResult;
+      // Zip together the expected step keys with values into expected object
+      const expected = expectedStepKeys.reduce(
+        (acc, key, idx) => ({ ...acc, [key]: expectedSteps[stepIdx][idx] }),
+        {},
+      );
+      expect(props).toMatchObject(expected);
+    }
+  }
+});
+
+const defaultMockExperiment = experiment;
+const setupTestHook = ({
+  experiment = defaultMockExperiment,
+  refetch = jest.fn(),
+  mocks = [],
+}: {
+  experiment?: getExperiment_experimentBySlug;
+  refetch?: () => Promise<void>;
+  mocks?: MockedResponse[];
+}) => {
+  return renderHook(() => useTakeaways(experiment, refetch), {
+    wrapper,
+    initialProps: { mocks },
+  });
+};
+
+const wrapper = ({
+  mocks = [],
+  children,
+}: {
+  mocks?: MockedResponse[];
+  children?: React.ReactNode;
+}) => (
+  <MockedCache {...{ mocks }}>{children as React.ReactElement}</MockedCache>
+);

--- a/app/experimenter/nimbus-ui/src/components/PageSummary/Takeaways/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageSummary/Takeaways/index.tsx
@@ -1,0 +1,82 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React, { useCallback } from "react";
+import Badge from "react-bootstrap/Badge";
+import Button from "react-bootstrap/Button";
+import Col from "react-bootstrap/Col";
+import Row from "react-bootstrap/Row";
+import ReactMarkdown from "react-markdown";
+import { useConfig } from "../../../hooks";
+import NotSet from "../../NotSet";
+import TakeawaysEditor from "./TakeawaysEditor";
+import { UseTakeawaysResult } from "./useTakeaways";
+
+export * from "./useTakeaways";
+
+export type TakeawaysProps = UseTakeawaysResult;
+
+export const Takeaways = (props: TakeawaysProps) => {
+  const {
+    showEditor,
+    setShowEditor,
+    conclusionRecommendation,
+    takeawaysSummary,
+  } = props;
+
+  const { conclusionRecommendations } = useConfig();
+  const onClickEdit = useCallback(() => setShowEditor(true), [setShowEditor]);
+
+  if (showEditor) {
+    return (
+      <TakeawaysEditor
+        {...{ ...props, conclusionRecommendations, setShowEditor }}
+      />
+    );
+  }
+
+  const conclusionRecommendationLabel = conclusionRecommendations?.find(
+    (item) => item!.value === conclusionRecommendation,
+  )?.label;
+
+  return (
+    <section id="takeaways" data-testid="Takeaways">
+      <h3 className="h4 mb-3 mt-4">
+        <Row>
+          <Col>
+            Takeaways
+            {conclusionRecommendationLabel && (
+              <Badge
+                className="ml-2 border rounded-pill px-2 bg-white border-primary text-primary font-weight-normal"
+                data-testid="conclusion-recommendation-status"
+              >
+                {conclusionRecommendationLabel}
+              </Badge>
+            )}
+          </Col>
+          <Col className="text-right">
+            <Button
+              onClick={onClickEdit}
+              variant="outline-primary"
+              size="sm"
+              className="mx-1"
+              data-testid="edit-takeaways"
+            >
+              Edit
+            </Button>
+          </Col>
+        </Row>
+      </h3>
+      {takeawaysSummary ? (
+        <div data-testid="takeaways-summary-rendered">
+          <ReactMarkdown source={takeawaysSummary} />
+        </div>
+      ) : (
+        <NotSet />
+      )}
+    </section>
+  );
+};
+
+export default Takeaways;

--- a/app/experimenter/nimbus-ui/src/components/PageSummary/Takeaways/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageSummary/Takeaways/mocks.tsx
@@ -1,0 +1,77 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+import React, { useState } from "react";
+import Takeaways from ".";
+import { RouterSlugProvider } from "../../../lib/test-utils";
+
+export const Subject = ({
+  id = 123,
+  takeawaysSummary = null,
+  conclusionRecommendation = null,
+  isLoading = false,
+  onSubmit = async (data) => {},
+  ...props
+}: Partial<React.ComponentProps<typeof Takeaways>>) => {
+  const [showEditor, setShowEditor] = useState(
+    typeof props.showEditor !== "undefined" ? props.showEditor : false,
+  );
+  const [submitErrors, setSubmitErrors] = useState<Record<string, any>>(
+    props.submitErrors || {},
+  );
+  const isServerValid =
+    typeof props.isServerValid !== "undefined" ? props.isServerValid : false;
+
+  return (
+    <RouterSlugProvider>
+      <div className="p-4">
+        <Takeaways
+          {...{
+            id,
+            takeawaysSummary,
+            conclusionRecommendation,
+            isLoading,
+            onSubmit,
+            showEditor,
+            setShowEditor,
+            submitErrors,
+            setSubmitErrors,
+            isServerValid,
+            ...props,
+          }}
+        />
+      </div>
+    </RouterSlugProvider>
+  );
+};
+
+export const TAKEAWAYS_SUMMARY_LONG = `
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec gravida est
+quis libero convallis, nec dictum urna semper. Pellentesque lacinia orci eget
+mi porta finibus. Phasellus gravida dui vel tellus interdum euismod. Nam
+molestie, arcu vitae efficitur ullamcorper, velit orci ultrices turpis, eget
+ullamcorper lacus risus nec mi. Nulla consectetur, urna quis efficitur
+imperdiet, eros mauris lacinia ligula, mollis vestibulum enim massa vel nisl.
+Donec nisi lorem, posuere sit amet mauris sed, pellentesque accumsan tortor.
+Nam sollicitudin vitae justo posuere elementum. Nullam aliquet ante sed ante
+dignissim porttitor. Fusce a pharetra mauris, nec facilisis urna. Fusce
+scelerisque nisl sed venenatis imperdiet.
+
+Vestibulum interdum suscipit eros a sodales. In suscipit turpis turpis. In
+volutpat molestie odio sit amet imperdiet. Morbi et risus sed magna venenatis
+pretium. Vestibulum congue, enim non faucibus tempor, lacus nulla blandit
+nulla, eu ultricies mauris libero vel eros. Vestibulum mollis aliquam nulla,
+at laoreet leo consectetur sed. Vestibulum ante ipsum primis in faucibus orci
+luctus et ultrices posuere cubilia curae; Donec mattis ipsum a elit accumsan
+mollis. Pellentesque a congue orci, vitae consequat lorem. Aenean vel auctor
+lorem, ut aliquet est. Morbi venenatis justo consequat mollis blandit. Donec
+cursus tempor rutrum. Sed sem massa, congue sed purus ac, vehicula hendrerit
+ex. Interdum et malesuada fames ac ante ipsum primis in faucibus. Etiam
+sagittis nec enim vitae rutrum.
+
+Pellentesque non urna metus. Phasellus ligula felis, laoreet sit amet nisi
+vitae, tempor ultricies metus. In metus odio, tincidunt sit amet eros ut,
+vehicula elementum dolor. Pellentesque quis mollis nulla. In efficitur a leo
+eu commodo. Maecenas finibus lectus et justo consequat condimentum. Morbi eu
+tellus porta nisi egestas tempor condimentum eget urna.
+`.trim();

--- a/app/experimenter/nimbus-ui/src/components/PageSummary/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageSummary/index.stories.tsx
@@ -10,6 +10,7 @@ import { mockExperimentQuery } from "../../lib/mocks";
 import { RouterSlugProvider } from "../../lib/test-utils";
 import { getExperiment_experimentBySlug } from "../../types/getExperiment";
 import {
+  NimbusExperimentConclusionRecommendation,
   NimbusExperimentPublishStatus,
   NimbusExperimentStatus,
 } from "../../types/globalTypes";
@@ -29,6 +30,7 @@ import {
   reviewTimedoutBaseProps,
   Subject,
 } from "./mocks";
+import { TAKEAWAYS_SUMMARY_LONG } from "./Takeaways/mocks";
 
 const storyWithExperimentProps = (
   props: Partial<getExperiment_experimentBySlug | null>,
@@ -220,6 +222,15 @@ export const completeStatus = storyWithExperimentProps(
     status: NimbusExperimentStatus.COMPLETE,
   },
   "Complete status",
+);
+
+export const completeStatusWithTakeaways = storyWithExperimentProps(
+  {
+    status: NimbusExperimentStatus.COMPLETE,
+    takeawaysSummary: TAKEAWAYS_SUMMARY_LONG,
+    conclusionRecommendation: NimbusExperimentConclusionRecommendation.RERUN,
+  },
+  "Complete status with takeaways",
 );
 
 export const error = () => (

--- a/app/experimenter/nimbus-ui/src/components/PageSummary/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageSummary/index.tsx
@@ -24,6 +24,7 @@ import FormLaunchDraftToPreview from "./FormLaunchDraftToPreview";
 import FormLaunchDraftToReview from "./FormLaunchDraftToReview";
 import FormLaunchPreviewToReview from "./FormLaunchPreviewToReview";
 import TableSignoff from "./TableSignoff";
+import Takeaways, { useTakeaways } from "./Takeaways";
 
 type PageSummaryProps = {
   polling?: boolean;
@@ -48,6 +49,7 @@ const PageContent: React.FC<{
 }> = ({ experiment, refetch }) => {
   const [showLaunchToReview, setShowLaunchToReview] = useState(false);
   const { invalidPages, InvalidPagesList } = useReviewCheck(experiment);
+  const takeawaysProps = useTakeaways(experiment, refetch);
 
   const status = getStatus(experiment);
 
@@ -173,6 +175,8 @@ const PageContent: React.FC<{
 
   return (
     <>
+      <Takeaways {...takeawaysProps} />
+
       <Head title={`${experiment.name} – ${summaryTitle}`} />
 
       {submitError && (

--- a/app/experimenter/nimbus-ui/src/components/Summary/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/index.stories.tsx
@@ -5,7 +5,11 @@
 import { withLinks } from "@storybook/addon-links";
 import React from "react";
 import { getExperiment_experimentBySlug } from "../../types/getExperiment";
-import { NimbusExperimentStatus } from "../../types/globalTypes";
+import {
+  NimbusExperimentConclusionRecommendation,
+  NimbusExperimentStatus,
+} from "../../types/globalTypes";
+import { TAKEAWAYS_SUMMARY_LONG } from "../PageSummary/Takeaways/mocks";
 import { reviewRequestedBaseProps, Subject } from "./mocks";
 
 const storyWithExperimentProps = (
@@ -44,6 +48,12 @@ export const enrollmentEnded = storyWithExperimentProps({
 export const endRequestedEnrollmentEnded = storyWithExperimentProps({
   ...reviewRequestedBaseProps,
   enrollmentEndDate: new Date().toISOString(),
+});
+
+export const completeStatusWithTakeaways = storyWithExperimentProps({
+  status: NimbusExperimentStatus.COMPLETE,
+  takeawaysSummary: TAKEAWAYS_SUMMARY_LONG,
+  conclusionRecommendation: NimbusExperimentConclusionRecommendation.GRADUATE,
 });
 
 export const noBranches = storyWithExperimentProps({

--- a/app/experimenter/nimbus-ui/src/gql/config.ts
+++ b/app/experimenter/nimbus-ui/src/gql/config.ts
@@ -15,6 +15,10 @@ export const GET_CONFIG_QUERY = gql`
         label
         value
       }
+      conclusionRecommendations {
+        label
+        value
+      }
       applicationConfigs {
         application
         channels {

--- a/app/experimenter/nimbus-ui/src/gql/experiments.ts
+++ b/app/experimenter/nimbus-ui/src/gql/experiments.ts
@@ -42,6 +42,9 @@ export const GET_EXPERIMENT_QUERY = gql`
       application
       publicDescription
 
+      conclusionRecommendation
+      takeawaysSummary
+
       owner {
         email
       }

--- a/app/experimenter/nimbus-ui/src/lib/constants.ts
+++ b/app/experimenter/nimbus-ui/src/lib/constants.ts
@@ -117,6 +117,7 @@ export const CHANGELOG_MESSAGES = {
   END_APPROVED: "End Review Approved",
   ARCHIVING_EXPERIMENT: "Archiving experiment",
   UNARCHIVING_EXPERIMENT: "Unarchiving experiment",
+  UPDATED_TAKEAWAYS: "Updated Takeaways",
 } as const;
 
 export const FIELD_MESSAGES = {

--- a/app/experimenter/nimbus-ui/src/lib/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/lib/mocks.tsx
@@ -96,6 +96,22 @@ export const MOCK_CONFIG: getConfig_nimbusConfig = {
       value: "PLATYPUS_DOORSTOP",
     },
   ],
+  conclusionRecommendations: [
+    { label: "Rerun", value: "RERUN" },
+    {
+      label: "Graduate",
+      value: "GRADUATE",
+    },
+    {
+      label: "Change course",
+      value: "CHANGE_COURSE",
+    },
+    { label: "Stop", value: "STOP" },
+    {
+      label: "Run follow ups",
+      value: "FOLLOWUP",
+    },
+  ],
   applicationConfigs: [
     {
       application: NimbusExperimentApplication.DESKTOP,

--- a/app/experimenter/nimbus-ui/src/types/getConfig.ts
+++ b/app/experimenter/nimbus-ui/src/types/getConfig.ts
@@ -19,6 +19,11 @@ export interface getConfig_nimbusConfig_channels {
   value: string | null;
 }
 
+export interface getConfig_nimbusConfig_conclusionRecommendations {
+  label: string | null;
+  value: string | null;
+}
+
 export interface getConfig_nimbusConfig_applicationConfigs_channels {
   label: string | null;
   value: string | null;
@@ -88,6 +93,7 @@ export interface getConfig_nimbusConfig_countries {
 export interface getConfig_nimbusConfig {
   applications: (getConfig_nimbusConfig_applications | null)[] | null;
   channels: (getConfig_nimbusConfig_channels | null)[] | null;
+  conclusionRecommendations: (getConfig_nimbusConfig_conclusionRecommendations | null)[] | null;
   applicationConfigs: (getConfig_nimbusConfig_applicationConfigs | null)[] | null;
   featureConfigs: (getConfig_nimbusConfig_featureConfigs | null)[] | null;
   firefoxVersions: (getConfig_nimbusConfig_firefoxVersions | null)[] | null;

--- a/app/experimenter/nimbus-ui/src/types/getExperiment.ts
+++ b/app/experimenter/nimbus-ui/src/types/getExperiment.ts
@@ -3,7 +3,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import { NimbusExperimentStatus, NimbusExperimentPublishStatus, NimbusExperimentApplication, NimbusExperimentChannel, NimbusExperimentFirefoxMinVersion, NimbusDocumentationLinkTitle, NimbusChangeLogOldStatus, NimbusChangeLogOldStatusNext } from "./globalTypes";
+import { NimbusExperimentStatus, NimbusExperimentPublishStatus, NimbusExperimentApplication, NimbusExperimentConclusionRecommendation, NimbusExperimentChannel, NimbusExperimentFirefoxMinVersion, NimbusDocumentationLinkTitle, NimbusChangeLogOldStatus, NimbusChangeLogOldStatusNext } from "./globalTypes";
 
 // ====================================================
 // GraphQL query operation: getExperiment
@@ -131,6 +131,8 @@ export interface getExperiment_experimentBySlug {
   hypothesis: string;
   application: NimbusExperimentApplication | null;
   publicDescription: string;
+  conclusionRecommendation: NimbusExperimentConclusionRecommendation | null;
+  takeawaysSummary: string | null;
   owner: getExperiment_experimentBySlug_owner;
   parent: getExperiment_experimentBySlug_parent | null;
   referenceBranch: getExperiment_experimentBySlug_referenceBranch | null;


### PR DESCRIPTION
Because:

* we want experiment owners to be able to document their learnings from an experiment

This commit:

* adds a new Takeaways subcomponent to PageResults with display & editing states managed by a hook

* implements GQL mutation to set takeawaysSummary and conclusionRecommendation for editing

* adds takeawaysSummary and conclusionRecommendation properties to GQL queries for experiment data

* enables editing of takeaways_summary and conclusion_recommendation across all experiment statuses