### PR TITLE
fix #6188 refactor(nimbus): split summary page into overview / detail views

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/App/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/App/index.tsx
@@ -16,6 +16,7 @@ import PageLoading from "../PageLoading";
 import PageNew from "../PageNew";
 import PageResults from "../PageResults";
 import PageSummary from "../PageSummary";
+import PageSummaryDetail from "../PageSummaryDetails";
 
 type RootProps = {
   children: React.ReactNode;
@@ -41,6 +42,7 @@ const App = ({ basepath }: { basepath: string }) => {
         <PageHome path="/" />
         <PageNew path="new" />
         <PageSummary path=":slug" />
+        <PageSummaryDetail path=":slug/details" />
         <Root path=":slug/edit">
           <Redirect from="/" to="overview" noThrow />
           <PageEditOverview path="overview" />

--- a/app/experimenter/nimbus-ui/src/components/AppLayoutSidebarLaunched/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/AppLayoutSidebarLaunched/index.tsx
@@ -255,6 +255,18 @@ export const AppLayoutSidebarLaunched = ({
                 canReview={experiment.canReview}
               />
 
+              <li>
+                <ul className="text-dark list-unstyled ml-4">
+                  <LinkNav
+                    className="mx-1 mb-2 ml-3"
+                    storiesOf="pages/SummaryDetails"
+                    route={`${slug}/details`}
+                  >
+                    Details
+                  </LinkNav>
+                </ul>
+              </li>
+
               {analysisAvailable(analysis) ? (
                 <ResultsAvailableNav />
               ) : (

--- a/app/experimenter/nimbus-ui/src/components/AppLayoutWithSidebar/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/AppLayoutWithSidebar/index.tsx
@@ -105,6 +105,19 @@ export const AppLayoutWithSidebar = ({
                 </div>
               )}
 
+              <li>
+                <ul className="text-dark list-unstyled ml-4">
+                  <LinkNav
+                    className="mx-1 mb-2 ml-3"
+                    storiesOf="pages/SummaryDetails"
+                    testid={"nav-details"}
+                    route={`${slug}/details`}
+                  >
+                    Details
+                  </LinkNav>
+                </ul>
+              </li>
+
               <p className="edit-divider position-relative small my-2">
                 <span className="position-relative bg-light pl-1 pr-2 text-muted">
                   Edit

--- a/app/experimenter/nimbus-ui/src/components/PageSummary/TableSignoff/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageSummary/TableSignoff/index.tsx
@@ -13,12 +13,10 @@ type TableSignoffProps = {
 };
 
 const TableSignoff = ({ signoffRecommendations }: TableSignoffProps) => (
-  <Table bordered data-testid="table-signoff" className="mb-4">
+  <Table data-testid="table-signoff" className="mb-4 border rounded">
     <tbody>
       <tr data-testid="table-signoff-qa">
-        <td>
-          <strong>QA Sign-off</strong>
-        </td>
+        <th className="w-25">QA Sign-off</th>
         <td>
           {signoffRecommendations?.qaSignoff && (
             <span className="text-success">Recommended: </span>
@@ -30,9 +28,7 @@ const TableSignoff = ({ signoffRecommendations }: TableSignoffProps) => (
         </td>
       </tr>
       <tr data-testid="table-signoff-vp">
-        <td>
-          <strong>VP Sign-off</strong>
-        </td>
+        <th>VP Sign-off</th>
         <td>
           {signoffRecommendations?.vpSignoff && (
             <span className="text-success">Recommended: </span>
@@ -44,9 +40,7 @@ const TableSignoff = ({ signoffRecommendations }: TableSignoffProps) => (
         </td>
       </tr>
       <tr data-testid="table-signoff-legal">
-        <td>
-          <strong>Legal Sign-off</strong>
-        </td>
+        <th>Legal Sign-off</th>
         <td>
           {signoffRecommendations?.legalSignoff && (
             <span className="text-success">Recommended: </span>

--- a/app/experimenter/nimbus-ui/src/components/PageSummary/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageSummary/index.tsx
@@ -248,7 +248,7 @@ const PageContent: React.FC<{
       )}
 
       <h2 className="mt-3 mb-4 h4">Summary</h2>
-      <Summary {...{ experiment, refetch }} />
+      <Summary {...{ experiment, refetch, withFullDetails: false }} />
     </>
   );
 };

--- a/app/experimenter/nimbus-ui/src/components/PageSummaryDetails/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageSummaryDetails/index.stories.tsx
@@ -1,0 +1,93 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { withLinks } from "@storybook/addon-links";
+import React from "react";
+import { mockExperimentQuery } from "../../lib/mocks";
+import { getExperiment_experimentBySlug } from "../../types/getExperiment";
+import {
+  NimbusExperimentPublishStatus,
+  NimbusExperimentStatus,
+} from "../../types/globalTypes";
+import { Subject } from "./mocks";
+
+const storyWithExperimentProps = (
+  props: Partial<getExperiment_experimentBySlug | null>,
+  storyName?: string,
+) => {
+  const story = () => {
+    const { mock } = mockExperimentQuery("demo-slug", props);
+    return <Subject {...{ mocks: [mock] }} />;
+  };
+  story.storyName = storyName;
+  return story;
+};
+
+export default {
+  title: "pages/SummaryDetails",
+  component: Subject,
+  decorators: [withLinks],
+};
+
+export const draftStatus = storyWithExperimentProps(
+  {
+    status: NimbusExperimentStatus.DRAFT,
+    publishStatus: NimbusExperimentPublishStatus.IDLE,
+  },
+  "Draft status, no missing fields",
+);
+
+export const draftArchived = storyWithExperimentProps(
+  {
+    isArchived: true,
+    canEdit: false,
+  },
+  "Draft status, archived",
+);
+
+export const previewStatus = storyWithExperimentProps(
+  {
+    status: NimbusExperimentStatus.PREVIEW,
+    publishStatus: NimbusExperimentPublishStatus.IDLE,
+    signoffRecommendations: {
+      qaSignoff: true,
+      vpSignoff: false,
+      legalSignoff: false,
+    },
+  },
+  "Preview status, one recommended signoff",
+);
+
+export const liveStatus = storyWithExperimentProps(
+  {
+    status: NimbusExperimentStatus.LIVE,
+    isEnrollmentPaused: false,
+  },
+  "Live status",
+);
+
+export const liveStatusPaused = storyWithExperimentProps(
+  {
+    status: NimbusExperimentStatus.LIVE,
+    isEnrollmentPaused: true,
+    enrollmentEndDate: new Date().toISOString(),
+  },
+  "Live status, enrollment paused",
+);
+
+export const completeStatus = storyWithExperimentProps(
+  {
+    status: NimbusExperimentStatus.COMPLETE,
+  },
+  "Complete status",
+);
+
+export const completeArchived = storyWithExperimentProps(
+  {
+    status: NimbusExperimentStatus.COMPLETE,
+    isArchived: true,
+    canEdit: false,
+  },
+  "Complete status, archived",
+);

--- a/app/experimenter/nimbus-ui/src/components/PageSummaryDetails/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageSummaryDetails/index.test.tsx
@@ -1,0 +1,23 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { render, screen } from "@testing-library/react";
+import React from "react";
+import { mockExperimentQuery } from "../../lib/mocks";
+import { Subject } from "./mocks";
+
+jest.mock("@reach/router", () => ({
+  ...(jest.requireActual("@reach/router") as any),
+  navigate: jest.fn(),
+}));
+
+describe("PageSummaryDetail", () => {
+  it("renders as expected", async () => {
+    const { mock } = mockExperimentQuery("demo-slug");
+    render(<Subject mocks={[mock]} />);
+    await screen.findByTestId("PageSummaryDetails");
+    expect(screen.getByTestId("summary")).toBeInTheDocument();
+    screen.getByRole("navigation");
+  });
+});

--- a/app/experimenter/nimbus-ui/src/components/PageSummaryDetails/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageSummaryDetails/index.tsx
@@ -1,0 +1,43 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { RouteComponentProps } from "@reach/router";
+import React from "react";
+import { getExperiment_experimentBySlug } from "../../types/getExperiment";
+import AppLayoutWithExperiment from "../AppLayoutWithExperiment";
+import Head from "../Head";
+import Summary from "../Summary";
+
+type PageSummaryProps = {
+  polling?: boolean;
+} & RouteComponentProps;
+
+const PageSummaryDetails = ({
+  /* istanbul ignore next - only used in tests & stories */
+  polling = true,
+}: PageSummaryProps) => (
+  <AppLayoutWithExperiment
+    testId="PageSummaryDetails"
+    setHead={false}
+    {...{ polling }}
+  >
+    {({ experiment, refetch }) => <PageContent {...{ experiment, refetch }} />}
+  </AppLayoutWithExperiment>
+);
+
+const PageContent: React.FC<{
+  experiment: getExperiment_experimentBySlug;
+  refetch: () => Promise<unknown>;
+}> = ({ experiment, refetch }) => {
+  return (
+    <>
+      <Head title={`${experiment.name} – Details`} />
+
+      <h2 className="mt-3 mb-4 h4">Details</h2>
+      <Summary {...{ experiment, refetch }} />
+    </>
+  );
+};
+
+export default PageSummaryDetails;

--- a/app/experimenter/nimbus-ui/src/components/PageSummaryDetails/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageSummaryDetails/mocks.tsx
@@ -1,0 +1,22 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from "react";
+import PageSummaryDetails from ".";
+import { mockExperimentQuery } from "../../lib/mocks";
+import { RouterSlugProvider } from "../../lib/test-utils";
+
+export const { mock, experiment } = mockExperimentQuery("demo-slug");
+
+export const Subject = ({
+  mocks = [mock],
+}: {
+  mocks?: React.ComponentProps<typeof RouterSlugProvider>["mocks"];
+}) => {
+  return (
+    <RouterSlugProvider {...{ mocks }}>
+      <PageSummaryDetails polling={false} />
+    </RouterSlugProvider>
+  );
+};

--- a/app/experimenter/nimbus-ui/src/components/Summary/TableAudience/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/TableAudience/index.test.tsx
@@ -149,6 +149,17 @@ describe("TableAudience", () => {
     });
   });
 
+  it("hides details when withFullDetails = false", () => {
+    const { experiment } = mockExperimentQuery("demo-slug");
+    render(<Subject {...{ experiment, withFullDetails: false }} />);
+    expect(
+      screen.queryByTestId("experiment-recipe-json"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("experiment-target-expression"),
+    ).not.toBeInTheDocument();
+  });
+
   describe("renders 'Locales' row as expected", () => {
     it("when locales exist, displays them", () => {
       const data = {
@@ -206,10 +217,12 @@ describe("TableAudience", () => {
 
 const Subject = ({
   experiment,
+  withFullDetails = true,
 }: {
   experiment: getExperiment_experimentBySlug;
+  withFullDetails?: boolean;
 }) => (
   <MockedCache>
-    <TableAudience {...{ experiment }} />
+    <TableAudience {...{ experiment, withFullDetails }} />
   </MockedCache>
 );

--- a/app/experimenter/nimbus-ui/src/components/Summary/TableAudience/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/TableAudience/index.tsx
@@ -12,18 +12,25 @@ import NotSet from "../../NotSet";
 
 type TableAudienceProps = {
   experiment: getExperiment_experimentBySlug;
+  withFullDetails?: boolean;
 };
 
 // `<tr>`s showing optional fields that are not set are not displayed.
 
-const TableAudience = ({ experiment }: TableAudienceProps) => {
+const TableAudience = ({
+  experiment,
+  withFullDetails = true,
+}: TableAudienceProps) => {
   const { firefoxVersions, channels, targetingConfigs } = useConfig();
 
   return (
-    <Table bordered data-testid="table-audience" className="mb-4 table-fixed">
+    <Table
+      data-testid="table-audience"
+      className="mb-4 table-fixed border rounded"
+    >
       <tbody>
         <tr>
-          <th className="w-33">Channel</th>
+          <th className="w-25">Channel</th>
           <td data-testid="experiment-channel">
             {displayConfigLabelOrNotSet(experiment.channel, channels)}
           </td>
@@ -94,7 +101,8 @@ const TableAudience = ({ experiment }: TableAudienceProps) => {
             )}
           </td>
         </tr>
-        {experiment.jexlTargetingExpression &&
+        {withFullDetails &&
+        experiment.jexlTargetingExpression &&
         experiment.jexlTargetingExpression !== "" ? (
           <tr>
             <th>Full targeting expression</th>
@@ -109,9 +117,11 @@ const TableAudience = ({ experiment }: TableAudienceProps) => {
             </td>
           </tr>
         ) : null}
-        {experiment.recipeJson && (
-          <tr>
-            <th>Recipe JSON</th>
+        {withFullDetails && experiment.recipeJson && (
+          <tr id="recipe-json">
+            <th>
+              Recipe JSON <a href={`#recipe-json`}>#</a>
+            </th>
             <td data-testid="experiment-recipe-json">
               <Code codeString={experiment.recipeJson} />
             </td>

--- a/app/experimenter/nimbus-ui/src/components/Summary/TableBranches/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/TableBranches/index.tsx
@@ -80,18 +80,17 @@ const TableBranch = ({
   const cloneDialogProps = useCloneDialog(experiment, branch);
   return (
     <Table
-      bordered
       data-testid="table-branch"
-      className="mb-4 table-fixed"
+      className="mb-4 table-fixed border rounded"
       id={slug}
     >
       <colgroup>
-        <col className="w-33" />
+        <col className="w-25" />
         <col />
       </colgroup>
       <thead className="thead-light">
         <tr>
-          <th colSpan={2} data-testid="branch-name">
+          <th colSpan={2} className="bg-light" data-testid="branch-name">
             <Container>
               <Row>
                 <Col>

--- a/app/experimenter/nimbus-ui/src/components/Summary/TableOverview/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/TableOverview/index.test.tsx
@@ -33,6 +33,26 @@ describe("TableOverview", () => {
     );
   });
 
+  it("hides details when withFullDetails = false", () => {
+    const { experiment } = mockExperimentQuery("demo-slug", {
+      primaryOutcomes: ["picture_in_picture", "feature_c"],
+      secondaryOutcomes: ["picture_in_picture", "feature_b"],
+    });
+    render(<Subject {...{ experiment, withFullDetails: false }} />);
+    const expectedMissingTestIDs = [
+      "experiment-risk-mitigation-link",
+      "experiment-additional-links",
+      "experiment-risk-mitigation-question-1",
+      "experiment-risk-mitigation-question-2",
+      "experiment-risk-mitigation-question-3",
+      "experiment-outcome-primary",
+      "experiment-outcome-secondary",
+    ];
+    for (const testid of expectedMissingTestIDs) {
+      expect(screen.queryByTestId(testid)).not.toBeInTheDocument();
+    }
+  });
+
   describe("renders 'Primary outcomes' row as expected", () => {
     it("with one outcome", () => {
       const { experiment } = mockExperimentQuery("demo-slug");
@@ -225,10 +245,12 @@ describe("TableOverview", () => {
 
 const Subject = ({
   experiment,
+  withFullDetails = true,
 }: {
   experiment: getExperiment_experimentBySlug;
+  withFullDetails?: boolean;
 }) => (
   <MockedCache>
-    <TableOverview {...{ experiment }} />
+    <TableOverview {...{ experiment, withFullDetails }} />
   </MockedCache>
 );

--- a/app/experimenter/nimbus-ui/src/components/Summary/TableOverview/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/TableOverview/index.tsx
@@ -15,22 +15,26 @@ import RichText from "../../RichText";
 
 type TableOverviewProps = {
   experiment: getExperiment_experimentBySlug;
+  withFullDetails?: boolean;
 };
 
 // `<tr>`s showing optional fields that are not set are not displayed.
 
 const getRiskLabel = (answer: boolean) => (answer ? "Yes" : "No");
 
-const TableOverview = ({ experiment }: TableOverviewProps) => {
+const TableOverview = ({
+  experiment,
+  withFullDetails = true,
+}: TableOverviewProps) => {
   const { applications, documentationLink: configDocumentationLinks } =
     useConfig();
   const { primaryOutcomes, secondaryOutcomes } = useOutcomes(experiment);
 
   return (
-    <Table bordered data-testid="table-overview" className="mb-4">
+    <Table data-testid="table-overview" className="mb-4 border rounded">
       <tbody>
         <tr>
-          <th className="w-33">Slug</th>
+          <th className="w-25">Slug</th>
           <td data-testid="experiment-slug" className="text-monospace">
             {experiment.slug}
           </td>
@@ -63,106 +67,112 @@ const TableOverview = ({ experiment }: TableOverviewProps) => {
             )}
           </td>
         </tr>
-        {experiment.riskMitigationLink && (
-          <tr>
-            <th>Risk mitigation checklist</th>
-            <td data-testid="experiment-risk-mitigation-link">
-              <LinkExternal href={experiment.riskMitigationLink}>
-                <span className="mr-1 align-middle">
-                  {experiment.riskMitigationLink}
-                </span>
-                <ExternalIcon />
-              </LinkExternal>
-            </td>
-          </tr>
-        )}
-        <tr>
-          <th>Risk mitigation question (1):</th>
-          <td>
-            {RISK_QUESTIONS.BRAND} —{" "}
-            {experiment.riskBrand !== null ? (
-              getRiskLabel(experiment.riskBrand)
-            ) : (
-              <NotSet />
-            )}
-          </td>
-        </tr>
-        <tr>
-          <th>Risk mitigation question (2):</th>
-          <td>
-            {RISK_QUESTIONS.REVENUE} —{" "}
-            {experiment.riskRevenue !== null ? (
-              getRiskLabel(experiment.riskRevenue)
-            ) : (
-              <NotSet />
-            )}
-          </td>
-        </tr>
-        <tr>
-          <th>Risk mitigation question (3):</th>
-          <td>
-            {RISK_QUESTIONS.PARTNER} —{" "}
-            {experiment.riskPartnerRelated !== null ? (
-              getRiskLabel(experiment.riskPartnerRelated)
-            ) : (
-              <NotSet />
-            )}
-          </td>
-        </tr>
-        {experiment.documentationLinks &&
-          experiment.documentationLinks?.length > 0 && (
-            <tr>
-              <th>Additional links</th>
-              <td data-testid="experiment-additional-links">
-                {experiment.documentationLinks.map((documentationLink, idx) => (
-                  <LinkExternal
-                    href={documentationLink.link}
-                    data-testid="experiment-additional-link"
-                    key={`doc-link-${idx}`}
-                    className="d-block"
-                  >
+        {withFullDetails && (
+          <>
+            {experiment.riskMitigationLink && (
+              <tr>
+                <th>Risk mitigation checklist</th>
+                <td data-testid="experiment-risk-mitigation-link">
+                  <LinkExternal href={experiment.riskMitigationLink}>
                     <span className="mr-1 align-middle">
-                      {
-                        configDocumentationLinks!.find(
-                          (d) => d?.value === documentationLink.title,
-                        )?.label
-                      }
+                      {experiment.riskMitigationLink}
                     </span>
                     <ExternalIcon />
                   </LinkExternal>
-                ))}
+                </td>
+              </tr>
+            )}
+            <tr>
+              <th>Risk mitigation question (1):</th>
+              <td data-testid="experiment-risk-mitigation-question-1">
+                {RISK_QUESTIONS.BRAND} —{" "}
+                {experiment.riskBrand !== null ? (
+                  getRiskLabel(experiment.riskBrand)
+                ) : (
+                  <NotSet />
+                )}
               </td>
             </tr>
-          )}
-        <tr>
-          <th>Feature config</th>
-          <td data-testid="experiment-feature-config">
-            {experiment.featureConfig?.name ? (
-              experiment.featureConfig.name
-            ) : (
-              <NotSet />
+            <tr>
+              <th>Risk mitigation question (2):</th>
+              <td data-testid="experiment-risk-mitigation-question-2">
+                {RISK_QUESTIONS.REVENUE} —{" "}
+                {experiment.riskRevenue !== null ? (
+                  getRiskLabel(experiment.riskRevenue)
+                ) : (
+                  <NotSet />
+                )}
+              </td>
+            </tr>
+            <tr>
+              <th>Risk mitigation question (3):</th>
+              <td data-testid="experiment-risk-mitigation-question-3">
+                {RISK_QUESTIONS.PARTNER} —{" "}
+                {experiment.riskPartnerRelated !== null ? (
+                  getRiskLabel(experiment.riskPartnerRelated)
+                ) : (
+                  <NotSet />
+                )}
+              </td>
+            </tr>
+            {experiment.documentationLinks &&
+              experiment.documentationLinks?.length > 0 && (
+                <tr>
+                  <th>Additional links</th>
+                  <td data-testid="experiment-additional-links">
+                    {experiment.documentationLinks.map(
+                      (documentationLink, idx) => (
+                        <LinkExternal
+                          href={documentationLink.link}
+                          data-testid="experiment-additional-link"
+                          key={`doc-link-${idx}`}
+                          className="d-block"
+                        >
+                          <span className="mr-1 align-middle">
+                            {
+                              configDocumentationLinks!.find(
+                                (d) => d?.value === documentationLink.title,
+                              )?.label
+                            }
+                          </span>
+                          <ExternalIcon />
+                        </LinkExternal>
+                      ),
+                    )}
+                  </td>
+                </tr>
+              )}
+            <tr>
+              <th>Feature config</th>
+              <td data-testid="experiment-feature-config">
+                {experiment.featureConfig?.name ? (
+                  experiment.featureConfig.name
+                ) : (
+                  <NotSet />
+                )}
+              </td>
+            </tr>
+            {primaryOutcomes.length > 0 && (
+              <tr>
+                <th>Primary outcomes</th>
+                <td data-testid="experiment-outcome-primary">
+                  {primaryOutcomes
+                    .map((outcome) => outcome?.friendlyName)
+                    .join(", ")}
+                </td>
+              </tr>
             )}
-          </td>
-        </tr>
-        {primaryOutcomes.length > 0 && (
-          <tr>
-            <th>Primary outcomes</th>
-            <td data-testid="experiment-outcome-primary">
-              {primaryOutcomes
-                .map((outcome) => outcome?.friendlyName)
-                .join(", ")}
-            </td>
-          </tr>
-        )}
-        {secondaryOutcomes.length > 0 && (
-          <tr>
-            <th>Secondary outcomes</th>
-            <td data-testid="experiment-outcome-secondary">
-              {secondaryOutcomes
-                .map((outcome) => outcome?.friendlyName)
-                .join(", ")}
-            </td>
-          </tr>
+            {secondaryOutcomes.length > 0 && (
+              <tr>
+                <th>Secondary outcomes</th>
+                <td data-testid="experiment-outcome-secondary">
+                  {secondaryOutcomes
+                    .map((outcome) => outcome?.friendlyName)
+                    .join(", ")}
+                </td>
+              </tr>
+            )}
+          </>
         )}
       </tbody>
     </Table>

--- a/app/experimenter/nimbus-ui/src/components/Summary/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/index.test.tsx
@@ -28,6 +28,18 @@ describe("Summary", () => {
     );
   });
 
+  it("hides expected content when withFullDetails = false", () => {
+    render(<Subject withFullDetails={false} />);
+    expect(screen.getByTestId("summary-timeline")).toBeInTheDocument();
+    expect(screen.queryByTestId("experiment-end")).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("link-monitoring-dashboard"),
+    ).not.toBeInTheDocument();
+    expect(screen.getByTestId("table-overview")).toBeInTheDocument();
+    expect(screen.getByTestId("table-audience")).toBeInTheDocument();
+    expect(screen.queryAllByTestId("table-branch")).toHaveLength(0);
+  });
+
   it("renders monitoring dashboard URL if experiment has been launched", async () => {
     render(
       <Subject

--- a/app/experimenter/nimbus-ui/src/components/Summary/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/index.tsx
@@ -28,9 +28,14 @@ import TableOverview from "./TableOverview";
 type SummaryProps = {
   experiment: getExperiment_experimentBySlug;
   refetch?: () => Promise<unknown>;
+  withFullDetails?: boolean;
 };
 
-const Summary = ({ experiment, refetch }: SummaryProps) => {
+const Summary = ({
+  experiment,
+  refetch,
+  withFullDetails = true,
+}: SummaryProps) => {
   const status = getStatus(experiment);
 
   const {
@@ -92,13 +97,13 @@ const Summary = ({ experiment, refetch }: SummaryProps) => {
       <div className="d-flex flex-row justify-content-between">
         <h3 className="h5 mb-3">Overview</h3>
       </div>
-      <TableOverview {...{ experiment }} />
+      <TableOverview {...{ experiment, withFullDetails }} />
 
       <h3 className="h5 mb-3">Audience</h3>
-      <TableAudience {...{ experiment }} />
+      <TableAudience {...{ experiment, withFullDetails }} />
 
       {/* Branches title is inside its table */}
-      <TableBranches {...{ experiment }} />
+      {withFullDetails && <TableBranches {...{ experiment }} />}
 
       {status.launched && (
         <>

--- a/app/experimenter/nimbus-ui/src/components/Summary/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/mocks.tsx
@@ -44,10 +44,12 @@ export function createMutationMock(
 export const Subject = ({
   props = {},
   mocks = [],
+  withFullDetails = true,
   refetch = () => Promise.resolve(),
 }: {
   props?: Partial<getExperiment_experimentBySlug | null>;
   mocks?: MockedResponse<Record<string, any>>[];
+  withFullDetails?: boolean;
   refetch?: () => Promise<unknown>;
 }) => {
   const { experiment, mock } = mockExperimentQuery("demo-slug", props);
@@ -55,7 +57,7 @@ export const Subject = ({
   return (
     <AppLayout>
       <RouterSlugProvider mocks={[mock, ...mocks]}>
-        <Summary {...{ experiment, refetch }} />
+        <Summary {...{ experiment, refetch, withFullDetails }} />
       </RouterSlugProvider>
     </AppLayout>
   );

--- a/app/tests/integration/nimbus/pages/experimenter/summary.py
+++ b/app/tests/integration/nimbus/pages/experimenter/summary.py
@@ -1,7 +1,5 @@
-import random
-import string
-
 from nimbus.pages.experimenter.base import ExperimenterBase
+from nimbus.pages.experimenter.summary_detail import SummaryDetailPage
 from pypom import Region
 from selenium.webdriver.common.by import By
 from selenium.webdriver.common.keys import Keys
@@ -38,7 +36,7 @@ class SummaryPage(ExperimenterBase):
     )
     _clone_save_locator = (By.CSS_SELECTOR, ".modal .btn-primary")
     _clone_parent_locator = (By.CSS_SELECTOR, 'p[data-testid="header-experiment-parent"]')
-    _promote_rollout_locator = (By.CSS_SELECTOR, 'button[data-testid="promote-rollout"]')
+    _sidebar_details_link = (By.CSS_SELECTOR, 'a[data-testid="nav-details"]')
 
     def wait_for_archive_label_visible(self):
         self.wait.until(
@@ -198,18 +196,7 @@ class SummaryPage(ExperimenterBase):
         self.clone_action.click()
         self.clone_save.click()
 
-    @property
-    def promote_to_rollout_buttons(self):
-        self.wait.until(
-            EC.presence_of_all_elements_located(self._clone_action_locator),
-            message="Summary Page: could not find promote to rollout buttons",
-        )
-        return self.find_elements(*self._promote_rollout_locator)
-
-    def promote_first_branch_to_rollout(self):
-        self.promote_to_rollout_buttons[0].click()
-        random_chars = "".join(
-            random.choices(string.ascii_uppercase + string.digits, k=6)
-        )
-        self.clone_name = f"Rollout {random_chars}"
-        self.clone_save.click()
+    def navigate_to_details(self):
+        element = self.selenium.find_element(*self._sidebar_details_link)
+        element.click()
+        return SummaryDetailPage(self.driver, self.base_url).wait_for_page_to_load()

--- a/app/tests/integration/nimbus/pages/experimenter/summary_detail.py
+++ b/app/tests/integration/nimbus/pages/experimenter/summary_detail.py
@@ -1,0 +1,68 @@
+import random
+import string
+
+from nimbus.pages.experimenter.base import ExperimenterBase
+from selenium.webdriver.common.by import By
+from selenium.webdriver.common.keys import Keys
+from selenium.webdriver.support import expected_conditions as EC
+
+
+class SummaryDetailPage(ExperimenterBase):
+    """Experiment Summary Detail Page."""
+
+    _page_wait_locator = (By.CSS_SELECTOR, "#PageSummaryDetails")
+    _promote_rollout_locator = (By.CSS_SELECTOR, 'button[data-testid="promote-rollout"]')
+    _clone_name_field_locator = (
+        By.CSS_SELECTOR,
+        'form[data-testid="FormClone"] input[name="name"]',
+    )
+    _clone_save_locator = (By.CSS_SELECTOR, ".modal .btn-primary")
+    _clone_parent_locator = (By.CSS_SELECTOR, 'p[data-testid="header-experiment-parent"]')
+
+    @property
+    def clone_name_field(self):
+        self.wait.until(
+            EC.presence_of_all_elements_located(self._clone_name_field_locator),
+            message="Summary Page: could not find clone name field",
+        )
+        return self.find_element(*self._clone_name_field_locator)
+
+    @property
+    def clone_name(self):
+        return self.clone_name_field.text
+
+    @clone_name.setter
+    def clone_name(self, text=None):
+        # Control-a before typing, in order to fully overwrite default value
+        self.clone_name_field.send_keys(Keys.CONTROL + "a")
+        self.clone_name_field.send_keys(f"{text}")
+
+    @property
+    def clone_save(self):
+        self.wait.until(
+            EC.presence_of_all_elements_located(self._clone_save_locator),
+            message="Summary Page: could not find clone save",
+        )
+        return self.find_element(*self._clone_save_locator)
+
+    @property
+    def promote_to_rollout_buttons(self):
+        self.wait.until(
+            EC.presence_of_all_elements_located(self._promote_rollout_locator),
+            message="Summary Page: could not find promote to rollout buttons",
+        )
+        return self.find_elements(*self._promote_rollout_locator)
+
+    def promote_first_branch_to_rollout(self):
+        self.promote_to_rollout_buttons[0].click()
+        random_chars = "".join(
+            random.choices(string.ascii_uppercase + string.digits, k=6)
+        )
+        self.clone_name = f"Rollout {random_chars}"
+        self.clone_save.click()
+
+    def wait_for_clone_parent_link_visible(self):
+        self.wait.until(
+            EC.presence_of_all_elements_located(self._clone_parent_locator),
+            message="Summary Page: could not find clone parent",
+        )

--- a/app/tests/integration/nimbus/test_experimenter.py
+++ b/app/tests/integration/nimbus/test_experimenter.py
@@ -49,5 +49,6 @@ def test_promote_to_rollout(
     create_experiment,
 ):
     summary = create_experiment(selenium)
-    summary.promote_first_branch_to_rollout()
-    summary.wait_for_clone_parent_link_visible()
+    summary_detail = summary.navigate_to_details()
+    summary_detail.promote_first_branch_to_rollout()
+    summary_detail.wait_for_clone_parent_link_visible()


### PR DESCRIPTION
Because:

* There's a desire to have a slimmer version of the Summary page for
  users such as stakeholders to be able to skim the most relevant pieces
  to them on the summary page.

This commit:

* Splits the summary page into an overview and a detail view

* Adds a withFullDetail flag to the Summary component to control what
  properties and subcomponents are rendered

* Reduces properties shown in Audience, Branches, and Overview for
  summary view.