### PR TITLE
fix #6621 fix(nimbus): takeaways revealed only for complete status

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/PageSummary/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageSummary/index.test.tsx
@@ -98,6 +98,24 @@ describe("PageSummary", () => {
     });
   });
 
+  it("hides takeaways section if experiment is not complete", async () => {
+    const { mock } = mockExperimentQuery("demo-slug", {
+      status: NimbusExperimentStatus.DRAFT,
+    });
+    render(<Subject mocks={[mock]} />);
+    await screen.findByTestId("PageSummary");
+    expect(screen.queryByTestId("Takeaways")).not.toBeInTheDocument();
+  });
+
+  it("reveals takeaways section if experiment is complete", async () => {
+    const { mock } = mockExperimentQuery("demo-slug", {
+      status: NimbusExperimentStatus.COMPLETE,
+    });
+    render(<Subject mocks={[mock]} />);
+    await screen.findByTestId("PageSummary");
+    expect(screen.queryByTestId("Takeaways")).toBeInTheDocument();
+  });
+
   it("displays a banner for pages missing fields required for review", async () => {
     const { mock } = mockExperimentQuery("demo-slug", {
       readyForReview: {

--- a/app/experimenter/nimbus-ui/src/components/PageSummary/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageSummary/index.tsx
@@ -175,7 +175,7 @@ const PageContent: React.FC<{
 
   return (
     <>
-      <Takeaways {...takeawaysProps} />
+      {status.complete && <Takeaways {...takeawaysProps} />}
 
       <Head title={`${experiment.name} – ${summaryTitle}`} />
 


### PR DESCRIPTION
Because:

* takeaways only really make sense after experiment completion

This commit:

* ensures the takeaways section on the summary page is only shown for
  completed experiments