### PR TITLE
fix #6634 feat(nimbus): add "rollout" indicator to HeaderExperiment

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/AppLayoutWithExperiment/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/AppLayoutWithExperiment/index.tsx
@@ -147,6 +147,7 @@ const AppLayoutWithExperiment = ({
     computedEndDate,
     computedDurationDays,
     isArchived,
+    isRollout,
   } = experiment;
 
   return (
@@ -179,6 +180,7 @@ const AppLayoutWithExperiment = ({
             status,
             computedDurationDays,
             isArchived,
+            isRollout,
           }}
         />
         {hasPollError && (

--- a/app/experimenter/nimbus-ui/src/components/HeaderExperiment/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/HeaderExperiment/index.stories.tsx
@@ -28,6 +28,7 @@ storiesOf("components/HeaderExperiment", module)
         computedDurationDays={experiment.computedDurationDays}
         status={mockGetStatus(experiment)}
         isArchived={false}
+        isRollout={false}
       />
     </AppLayout>
   ))
@@ -46,6 +47,7 @@ storiesOf("components/HeaderExperiment", module)
         computedDurationDays={experiment.computedDurationDays}
         status={mockGetStatus(experiment)}
         isArchived={false}
+        isRollout={false}
       />
     </AppLayout>
   ))
@@ -60,6 +62,7 @@ storiesOf("components/HeaderExperiment", module)
         computedDurationDays={experiment.computedDurationDays}
         status={mockGetStatus({ status: NimbusExperimentStatus.PREVIEW })}
         isArchived={false}
+        isRollout={false}
       />
     </AppLayout>
   ))
@@ -76,6 +79,7 @@ storiesOf("components/HeaderExperiment", module)
           publishStatus: NimbusExperimentPublishStatus.REVIEW,
         })}
         isArchived={false}
+        isRollout={false}
       />
     </AppLayout>
   ))
@@ -90,6 +94,7 @@ storiesOf("components/HeaderExperiment", module)
         computedDurationDays={experiment.computedDurationDays}
         status={mockGetStatus({ status: NimbusExperimentStatus.LIVE })}
         isArchived={false}
+        isRollout={false}
       />
     </AppLayout>
   ))
@@ -104,6 +109,7 @@ storiesOf("components/HeaderExperiment", module)
         computedDurationDays={experiment.computedDurationDays}
         status={mockGetStatus({ status: NimbusExperimentStatus.COMPLETE })}
         isArchived={false}
+        isRollout={false}
       />
     </AppLayout>
   ))
@@ -118,6 +124,37 @@ storiesOf("components/HeaderExperiment", module)
         computedDurationDays={experiment.computedDurationDays}
         status={mockGetStatus({ status: NimbusExperimentStatus.COMPLETE })}
         isArchived={true}
+        isRollout={false}
+      />
+    </AppLayout>
+  ))
+  .add("rollout", () => (
+    <AppLayout>
+      <HeaderExperiment
+        parent={null}
+        name={experiment.name}
+        slug={experiment.slug}
+        startDate={experiment.startDate}
+        computedEndDate={experiment.computedEndDate}
+        computedDurationDays={experiment.computedDurationDays}
+        status={mockGetStatus({ status: NimbusExperimentStatus.COMPLETE })}
+        isArchived={false}
+        isRollout={true}
+      />
+    </AppLayout>
+  ))
+  .add("archived rollout", () => (
+    <AppLayout>
+      <HeaderExperiment
+        parent={null}
+        name={experiment.name}
+        slug={experiment.slug}
+        startDate={experiment.startDate}
+        computedEndDate={experiment.computedEndDate}
+        computedDurationDays={experiment.computedDurationDays}
+        status={mockGetStatus({ status: NimbusExperimentStatus.COMPLETE })}
+        isArchived={true}
+        isRollout={true}
       />
     </AppLayout>
   ));

--- a/app/experimenter/nimbus-ui/src/components/HeaderExperiment/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/HeaderExperiment/index.test.tsx
@@ -23,6 +23,7 @@ describe("HeaderExperiment", () => {
         computedDurationDays={experiment.computedDurationDays}
         status={mockGetStatus(experiment)}
         isArchived={false}
+        isRollout={false}
       />,
     );
     expect(
@@ -54,6 +55,7 @@ describe("HeaderExperiment", () => {
         computedDurationDays={experiment.computedDurationDays}
         status={mockGetStatus(experiment)}
         isArchived={false}
+        isRollout={false}
       />,
     );
 
@@ -81,6 +83,7 @@ describe("HeaderExperiment", () => {
         computedDurationDays={experiment.computedDurationDays}
         status={mockGetStatus(experiment)}
         isArchived={false}
+        isRollout={false}
       />,
     );
     expect(
@@ -107,8 +110,27 @@ describe("HeaderExperiment", () => {
         computedDurationDays={experiment.computedDurationDays}
         status={mockGetStatus(experiment)}
         isArchived={true}
+        isRollout={false}
       />,
     );
     expect(screen.queryByText("Archived")).toBeInTheDocument();
+  });
+
+  it("renders with rollout", () => {
+    const { experiment } = mockExperimentQuery("demo-slug", {});
+    render(
+      <HeaderExperiment
+        parent={null}
+        name={experiment.name}
+        slug={experiment.slug}
+        startDate={experiment.startDate}
+        computedEndDate={experiment.computedEndDate}
+        computedDurationDays={experiment.computedDurationDays}
+        status={mockGetStatus(experiment)}
+        isArchived={false}
+        isRollout={true}
+      />,
+    );
+    expect(screen.queryByText("Rollout")).toBeInTheDocument();
   });
 });

--- a/app/experimenter/nimbus-ui/src/components/HeaderExperiment/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/HeaderExperiment/index.tsx
@@ -19,6 +19,7 @@ type HeaderExperimentProps = Pick<
   | "computedEndDate"
   | "computedDurationDays"
   | "isArchived"
+  | "isRollout"
 > & { status: StatusCheck };
 
 const HeaderExperiment = ({
@@ -30,20 +31,32 @@ const HeaderExperiment = ({
   status,
   computedDurationDays,
   isArchived,
+  isRollout,
 }: HeaderExperimentProps) => (
   <header className="border-bottom" data-testid="header-experiment">
     <h1
-      className="h5 font-weight-normal d-inline"
+      className="h5 font-weight-normal d-inline mr-2"
       data-testid="header-experiment-name"
     >
       {name}
     </h1>
+    {isRollout && (
+      <StatusPill
+        label="Rollout"
+        color="info"
+        active={true}
+        padded={false}
+        className="mr-2"
+        testid="header-experiment-status-rollout"
+      />
+    )}
     {isArchived && (
       <StatusPill
-        className="ml-2"
         label="Archived"
         color="danger"
         active={true}
+        padded={false}
+        className="mr-2"
         testid="header-experiment-status-archived"
       />
     )}

--- a/app/experimenter/nimbus-ui/src/gql/experiments.ts
+++ b/app/experimenter/nimbus-ui/src/gql/experiments.ts
@@ -27,6 +27,7 @@ export const GET_EXPERIMENT_QUERY = gql`
   query getExperiment($slug: String!) {
     experimentBySlug(slug: $slug) {
       id
+      isRollout
       isArchived
       canEdit
       canArchive

--- a/app/experimenter/nimbus-ui/src/types/getExperiment.ts
+++ b/app/experimenter/nimbus-ui/src/types/getExperiment.ts
@@ -118,6 +118,7 @@ export interface getExperiment_experimentBySlug_countries {
 
 export interface getExperiment_experimentBySlug {
   id: number | null;
+  isRollout: boolean | null;
   isArchived: boolean | null;
   canEdit: boolean | null;
   canArchive: boolean | null;


### PR DESCRIPTION
Branched from PR #6635 as a quick follow-on.

Because:

* we want to distinguish rollouts from normal experiments

This commit:

* adds a "Rollout" badge to the header of an experiment with
  is_rollout=True

* adds is_rollout to GQL query and frontend experiment type