### PR TITLE
fix #6626 feat(nimbus): lock experiment to single branch when isRollout=true

### DIFF
--- a/app/experimenter/experiments/api/v5/serializers.py
+++ b/app/experimenter/experiments/api/v5/serializers.py
@@ -153,6 +153,7 @@ class NimbusExperimentBranchMixin:
     def validate(self, data):
         data = super().validate(data)
         data = self._validate_duplicate_branch_names(data)
+        data = self._validate_single_branch_for_rollout(data)
         return data
 
     def _validate_duplicate_branch_names(self, data):
@@ -176,6 +177,22 @@ class NimbusExperimentBranchMixin:
                         ],
                     }
                 )
+        return data
+
+    def _validate_single_branch_for_rollout(self, data):
+        if (
+            self.instance
+            and self.instance.is_rollout
+            and len(data.get("treatment_branches", [])) > 0
+        ):
+            raise serializers.ValidationError(
+                {
+                    "treatment_branches": [
+                        {"name": NimbusConstants.ERROR_SINGLE_BRANCH_FOR_ROLLOUT}
+                        for i in data["treatment_branches"]
+                    ],
+                }
+            )
         return data
 
     def update(self, experiment, data):

--- a/app/experimenter/experiments/constants/nimbus.py
+++ b/app/experimenter/experiments/constants/nimbus.py
@@ -700,6 +700,7 @@ Optional - We believe this outcome will <describe impact> on <core metric>
 
     # Serializer validation errors
     ERROR_DUPLICATE_BRANCH_NAME = "Branch names must be unique."
+    ERROR_SINGLE_BRANCH_FOR_ROLLOUT = "A rollout may have only a single reference branch"
     ERROR_REQUIRED_QUESTION = "This question may not be blank."
     ERROR_REQUIRED_FIELD = "This field may not be blank."
     ERROR_REQUIRED_FEATURE_CONFIG = (

--- a/app/experimenter/experiments/tests/api/v5/test_serializers.py
+++ b/app/experimenter/experiments/tests/api/v5/test_serializers.py
@@ -700,6 +700,36 @@ class TestNimbusExperimentBranchMixin(TestCase):
             },
         )
 
+    def test_no_treatment_branches_for_rollout(self):
+        experiment = NimbusExperimentFactory.create(
+            status=NimbusExperiment.Status.DRAFT,
+        )
+        experiment.is_rollout = True
+        experiment.save()
+        for branch in experiment.treatment_branches:
+            branch.delete()
+
+        data = {
+            "treatment_branches": [
+                {"name": "treatment A", "description": "desc1", "ratio": 1},
+                {"name": "treatment B", "description": "desc2", "ratio": 1},
+            ],
+            "changelog_message": "test changelog message",
+        }
+        serializer = NimbusExperimentSerializer(
+            experiment, data=data, partial=True, context={"user": self.user}
+        )
+        self.assertFalse(serializer.is_valid())
+        self.assertEqual(
+            serializer.errors,
+            {
+                "treatment_branches": [
+                    {"name": NimbusConstants.ERROR_SINGLE_BRANCH_FOR_ROLLOUT}
+                    for i in data["treatment_branches"]
+                ],
+            },
+        )
+
 
 @mock_valid_outcomes
 class TestNimbusExperimentSerializer(TestCase):

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/index.test.tsx
@@ -19,10 +19,19 @@ describe("FormBranches", () => {
   it("renders as expected", async () => {
     render(<SubjectBranches />);
     expect(screen.getByTestId("FormBranches")).toBeInTheDocument();
+    expect(screen.getByTestId("add-branch")).toBeInTheDocument();
     const branches = screen.queryAllByTestId("FormBranch");
     expect(branches.length).toEqual(
       MOCK_EXPERIMENT!.treatmentBranches!.length + 1,
     );
+  });
+
+  it("hides the add branch button for a rollout", async () => {
+    render(
+      <SubjectBranches experiment={{ ...MOCK_EXPERIMENT, isRollout: true }} />,
+    );
+    expect(screen.getByTestId("FormBranches")).toBeInTheDocument();
+    expect(screen.queryByTestId("add-branch")).not.toBeInTheDocument();
   });
 
   it("renders as expected while loading", async () => {

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/index.tsx
@@ -287,14 +287,16 @@ export const FormBranches = ({
               );
             })}
         </section>
-        <Button
-          data-testid="add-branch"
-          variant="outline-primary"
-          size="sm"
-          onClick={handleAddBranch}
-        >
-          + Add branch
-        </Button>
+        {!experiment.isRollout && (
+          <Button
+            data-testid="add-branch"
+            variant="outline-primary"
+            size="sm"
+            onClick={handleAddBranch}
+          >
+            + Add branch
+          </Button>
+        )}
         <div className="d-flex flex-row-reverse bd-highlight">
           <div className="p-2">
             <button


### PR DESCRIPTION
Because:

* An experiment flagged as a rollout should only have a single branch

This commit:

* Adds v5 API serializer validation enforcement of a single branch when
  experiment.is_rollout = True

* Hides the "+ Add branch" button in the UI when isRollout = true