### PR TITLE
fix #6628 feat(nimbus): experiments flagged as rollouts should use a separate bucket namespace

### DIFF
--- a/app/experimenter/experiments/models/nimbus.py
+++ b/app/experimenter/experiments/models/nimbus.py
@@ -410,6 +410,9 @@ class NimbusExperiment(NimbusConstants, FilterMixin, models.Model):
         if self.channel:
             keys.append(self.channel)
 
+        if self.is_rollout:
+            keys.append("rollout")
+
         return "-".join(keys)
 
     def allocate_bucket_range(self):

--- a/app/experimenter/experiments/tests/test_models/test_models_nimbus.py
+++ b/app/experimenter/experiments/tests/test_models/test_models_nimbus.py
@@ -823,6 +823,26 @@ class TestNimbusExperiment(TestCase):
         self.assertEqual(NimbusBucketRange.objects.count(), 2)
         self.assertEqual(NimbusIsolationGroup.objects.count(), 1)
 
+    def test_bucket_namespace_changes_for_rollout(self):
+        feature = NimbusFeatureConfigFactory(slug="feature")
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            application=NimbusExperiment.Application.DESKTOP,
+            channel=NimbusExperiment.Channel.RELEASE,
+            feature_config=feature,
+            population_percent=Decimal("50.0"),
+        )
+        original_namespace = experiment.bucket_namespace
+
+        experiment.is_rollout = True
+        experiment.save()
+
+        self.assertNotEqual(original_namespace, experiment.bucket_namespace)
+        self.assertEqual(
+            experiment.bucket_namespace,
+            "firefox-desktop-feature-release-rollout",
+        )
+
     def test_proposed_enrollment_end_date_without_start_date_is_None(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.CREATED,


### PR DESCRIPTION
Because:

* we want rollouts to live in separate buckets than general experiments

This commit:

* adds "-rollout" to the bucket namespace when is_rollout=True

* leaves non-rollout experiment namespace formulation alone to constrain
  the impact of this change