### PR TITLE
fix #6660 bug(nimbus): allow null selection for takeaway conclusion recommendation

### DIFF
--- a/app/experimenter/experiments/api/v5/serializers.py
+++ b/app/experimenter/experiments/api/v5/serializers.py
@@ -401,7 +401,9 @@ class NimbusExperimentSerializer(
         many=True,
     )
     conclusion_recommendation = serializers.ChoiceField(
-        choices=NimbusExperiment.ConclusionRecommendation.choices, required=False
+        choices=NimbusExperiment.ConclusionRecommendation.choices,
+        allow_null=True,
+        required=False,
     )
 
     class Meta:

--- a/app/experimenter/experiments/api/v5/types.py
+++ b/app/experimenter/experiments/api/v5/types.py
@@ -331,7 +331,7 @@ class NimbusExperimentType(DjangoObjectType):
     signoff_recommendations = graphene.Field(NimbusSignoffRecommendationsType)
     recipe_json = graphene.String()
     review_url = graphene.String()
-    conclusion_recommendation = NimbusExperimentConclusionRecommendation()
+    conclusion_recommendation = graphene.Field(NimbusExperimentConclusionRecommendation)
 
     class Meta:
         model = NimbusExperiment

--- a/app/experimenter/nimbus-ui/src/components/PageSummary/Takeaways/TakeawaysEditor.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageSummary/Takeaways/TakeawaysEditor.tsx
@@ -123,6 +123,14 @@ export const TakeawaysEditor = ({
               >
                 Recommendation:
               </Form.Label>
+              <Form.Check
+                type="radio"
+                value=""
+                label="None"
+                title="None"
+                {...conclusionRadioAttrs}
+                id="conclusionRecommendation-none"
+              />
               {conclusionRecommendations!.map((option, idx) => (
                 <Form.Check
                   key={idx}

--- a/app/experimenter/nimbus-ui/src/components/PageSummary/Takeaways/useTakeaways.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageSummary/Takeaways/useTakeaways.tsx
@@ -53,7 +53,7 @@ export const useTakeaways = (
           const variables = {
             input: {
               id,
-              conclusionRecommendation,
+              conclusionRecommendation: conclusionRecommendation || null,
               takeawaysSummary,
               changelogMessage: CHANGELOG_MESSAGES.UPDATED_TAKEAWAYS,
             },


### PR DESCRIPTION
Because:

* submitting no selection for takeaway conclusion recommendation in a
  GraphQL type error

This commit:

* allows null for conclusion recommendation in the GQL API

* adds a "None" choice for recommendation in the UI and submits null
  rather than an empty string when it's selected