### PR TITLE
fixes #6593 feat(Nimbus): add separator between screenshots in branches

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/FormBranch.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/FormBranch.tsx
@@ -199,27 +199,31 @@ export const FormBranch = ({
           )}
         </Form.Row>
         {branch.screenshots?.map((screenshot, idx) => (
-          <FormScreenshot
-            key={idx}
-            {...{
-              fieldNamePrefix: `${fieldNamePrefix}.screenshots[${idx}]`,
-              onRemove: () => onRemoveScreenshot!(idx),
-              defaultValues: defaultValues.screenshots?.[idx] || {},
-              setSubmitErrors,
-              //@ts-ignore react-hook-form types seem broken for nested fields
-              submitErrors: (submitErrors?.screenshots?.[idx] ||
-                {}) as FormScreenshotProps["submitErrors"],
-              //@ts-ignore react-hook-form types seem broken for nested fields
-              errors: (errors?.screenshots?.[idx] ||
-                {}) as FormScreenshotProps["errors"],
-              //@ts-ignore react-hook-form types seem broken for nested fields
-              touched: (touched?.screenshots?.[idx] ||
-                {}) as FormScreenshotProps["touched"],
-              //@ts-ignore react-hook-form types seem broken for nested fields
-              reviewErrors: (reviewErrors?.screenshots?.[idx] ||
-                {}) as FormScreenshotProps["reviewErrors"],
-            }}
-          />
+          <div key={idx}>
+            <FormScreenshot
+              {...{
+                fieldNamePrefix: `${fieldNamePrefix}.screenshots[${idx}]`,
+                onRemove: () => onRemoveScreenshot!(idx),
+                defaultValues: defaultValues.screenshots?.[idx] || {},
+                setSubmitErrors,
+                //@ts-ignore react-hook-form types seem broken for nested fields
+                submitErrors: (submitErrors?.screenshots?.[idx] ||
+                  {}) as FormScreenshotProps["submitErrors"],
+                //@ts-ignore react-hook-form types seem broken for nested fields
+                errors: (errors?.screenshots?.[idx] ||
+                  {}) as FormScreenshotProps["errors"],
+                //@ts-ignore react-hook-form types seem broken for nested fields
+                touched: (touched?.screenshots?.[idx] ||
+                  {}) as FormScreenshotProps["touched"],
+                //@ts-ignore react-hook-form types seem broken for nested fields
+                reviewErrors: (reviewErrors?.screenshots?.[idx] ||
+                  {}) as FormScreenshotProps["reviewErrors"],
+              }}
+            />
+            {branch?.screenshots && idx !== branch.screenshots.length - 1 && (
+              <hr />
+            )}
+          </div>
         ))}
         {addScreenshotButtonAtEnd && (
           <Form.Row


### PR DESCRIPTION
Because

* there is some confusion when determining if a description is for the screenshot above or below

This commit

* adds a separator between screenshots