### PR TITLE
fix #6664 bug(nimbus): check for presence of keys in results ui

### DIFF
--- a/app/experimenter/nimbus-ui/src/lib/visualization/utils.tsx
+++ b/app/experimenter/nimbus-ui/src/lib/visualization/utils.tsx
@@ -71,14 +71,15 @@ export const getExtremeBounds = (
 ) => {
   let extreme = 0;
   sortedBranchNames.forEach((branch) => {
-    const branchComparison = BRANCH_COMPARISON.UPLIFT;
-    const metricDataList =
-      results[branch].branch_data[group][outcomeSlug][branchComparison]["all"];
-    metricDataList.forEach((dataPoint: FormattedAnalysisPoint) => {
-      const { lower, upper } = dataPoint;
-      const max = Math.max(Math.abs(lower!), Math.abs(upper!));
-      extreme = max > extreme ? max : extreme;
-    });
+    if (results[branch].branch_data[group][outcomeSlug]) {
+      results[branch].branch_data[group][outcomeSlug][BRANCH_COMPARISON.UPLIFT][
+        "all"
+      ].forEach((dataPoint: FormattedAnalysisPoint) => {
+        const { lower, upper } = dataPoint;
+        const max = Math.max(Math.abs(lower!), Math.abs(upper!));
+        extreme = max > extreme ? max : extreme;
+      });
+    }
   });
   return extreme;
 };


### PR DESCRIPTION
Because

* Not ever metric will be present in the data returned from jetstream

This commit

* checks for the presence of an outcome before iterating over it