### PR TITLE
fixes mozilla/jetstream#940 adjust date range for Looker link

### DIFF
--- a/app/experimenter/experiments/models/nimbus.py
+++ b/app/experimenter/experiments/models/nimbus.py
@@ -381,7 +381,8 @@ class NimbusExperiment(NimbusConstants, FilterMixin, models.Model):
         if self.end_date:
             end_date = self.end_date + datetime.timedelta(days=2)
         else:
-            end_date = datetime.date.today()
+            # add a day to account for Looker data being in UTC
+            end_date = datetime.date.today() + datetime.timedelta(days=1)
 
         return settings.MONITORING_URL.format(
             slug=self.slug,

--- a/app/experimenter/experiments/tests/test_models/test_models_nimbus.py
+++ b/app/experimenter/experiments/tests/test_models/test_models_nimbus.py
@@ -629,7 +629,7 @@ class TestNimbusExperiment(TestCase):
         )
 
         from_date = datetime.date.today() - datetime.timedelta(days=1)
-        to_date = datetime.date.today()
+        to_date = datetime.date.today() + datetime.timedelta(days=1)
 
         self.assertEqual(
             experiment.monitoring_dashboard_url,
@@ -654,7 +654,7 @@ class TestNimbusExperiment(TestCase):
         )
 
         from_date = datetime.date(2019, 4, 30)
-        to_date = datetime.date.today()
+        to_date = datetime.date.today() + datetime.timedelta(days=1)
 
         self.assertEqual(
             experiment.monitoring_dashboard_url,


### PR DESCRIPTION
Fixes https://github.com/mozilla/jetstream/issues/940

Data shown in the Looker dashboard is in UTC timezone. The Nimbus Experimenter Looker links don't account for timestamps being in UTC, so it looks like dashboards are missing data when clicking on them. This fixes this issue