### PR TITLE
fix #6700 bug(nimbus): support null feature_config in multifeature migration

### DIFF
--- a/app/experimenter/experiments/models/nimbus.py
+++ b/app/experimenter/experiments/models/nimbus.py
@@ -14,6 +14,7 @@ from django.core.serializers.json import DjangoJSONEncoder
 from django.core.validators import MaxValueValidator
 from django.db import models
 from django.db.models import F, Max, Q
+from django.db.models.constraints import UniqueConstraint
 from django.urls import reverse
 from django.utils import timezone
 from django.utils.text import slugify
@@ -619,7 +620,13 @@ class NimbusBranchFeatureValue(models.Model):
     class Meta:
         verbose_name = "Nimbus Branch Feature Value"
         verbose_name_plural = "Nimbus Branch Feature Values"
-        unique_together = (("branch", "feature_config"),)
+        constraints = (
+            UniqueConstraint(
+                fields=("branch", "feature_config"),
+                name="unique_with_branch_and_feature",
+                condition=Q(feature_config__isnull=False),
+            ),
+        )
 
     def __str__(self):  # pragma: no cover
         return f"{self.branch}: {self.feature_config}"

--- a/app/experimenter/experiments/tests/api/v5/test_mutations.py
+++ b/app/experimenter/experiments/tests/api/v5/test_mutations.py
@@ -352,6 +352,65 @@ class TestUpdateExperimentMutation(GraphQLTestCase, GraphQLFileUploadTestCase):
             treatment_branches_data[0]["featureValue"],
         )
 
+    def test_update_experiment_branches_without_feature_config(self):
+        user_email = "user@example.com"
+        experiment = NimbusExperimentFactory.create(
+            status=NimbusExperiment.Status.DRAFT,
+            application=NimbusExperiment.Application.FENIX,
+            feature_configs=[],
+        )
+        experiment_id = experiment.id
+        reference_branch_data = {
+            "name": "control",
+            "description": "a control",
+            "ratio": 1,
+            "featureEnabled": False,
+            "featureValue": "",
+        }
+        treatment_branches_data = [
+            {
+                "name": "treatment1",
+                "description": "desc1",
+                "ratio": 1,
+                "featureEnabled": True,
+                "featureValue": '{"key": "value"}',
+            }
+        ]
+        response = self.query(
+            UPDATE_EXPERIMENT_MUTATION,
+            variables={
+                "input": {
+                    "id": experiment.id,
+                    "featureConfigId": None,
+                    "referenceBranch": reference_branch_data,
+                    "treatmentBranches": treatment_branches_data,
+                    "changelogMessage": "test changelog message",
+                }
+            },
+            headers={settings.OPENIDC_EMAIL_HEADER: user_email},
+        )
+        self.assertEqual(response.status_code, 200)
+
+        experiment = NimbusExperiment.objects.get(id=experiment_id)
+        self.assertEqual(experiment.feature_configs.count(), 0)
+        self.assertEqual(experiment.branches.count(), 2)
+
+        self.assertEqual(experiment.reference_branch.name, reference_branch_data["name"])
+        self.assertEqual(
+            experiment.reference_branch.feature_values.get().feature_config, None
+        )
+        self.assertEqual(experiment.reference_branch.feature_values.get().enabled, False)
+        self.assertEqual(experiment.reference_branch.feature_values.get().value, "")
+
+        treatment_branch = experiment.treatment_branches[0]
+        self.assertEqual(treatment_branch.name, treatment_branches_data[0]["name"])
+        self.assertEqual(treatment_branch.feature_values.get().feature_config, None)
+        self.assertEqual(treatment_branch.feature_values.get().enabled, True)
+        self.assertEqual(
+            treatment_branch.feature_values.get().value,
+            treatment_branches_data[0]["featureValue"],
+        )
+
     def test_update_experiment_branches_with_feature_config_error(self):
         user_email = "user@example.com"
         experiment = NimbusExperimentFactory.create(status=NimbusExperiment.Status.DRAFT)

--- a/app/experimenter/experiments/tests/test_migrations.py
+++ b/app/experimenter/experiments/tests/test_migrations.py
@@ -20,20 +20,44 @@ class TestMigration0181Forward(MigratorTestCase):
 
         self.feature_config = NimbusFeatureConfig.objects.create()
 
-        experiment = NimbusExperiment.objects.create(
-            owner=owner, slug="experiment", feature_config=self.feature_config
+        experiment_with_feature = NimbusExperiment.objects.create(
+            owner=owner,
+            name="experiment_with_feature",
+            slug="experiment_with_feature",
+            feature_config=self.feature_config,
         )
 
-        experiment.reference_branch = NimbusBranch.objects.create(
-            experiment=experiment,
+        experiment_with_feature.reference_branch = NimbusBranch.objects.create(
+            experiment=experiment_with_feature,
             slug="control",
             feature_enabled=False,
             feature_value="control",
         )
-        experiment.save()
+        experiment_with_feature.save()
 
         NimbusBranch.objects.create(
-            experiment=experiment,
+            experiment=experiment_with_feature,
+            slug="treatment",
+            feature_enabled=True,
+            feature_value="treatment",
+        )
+
+        experiment_without_feature = NimbusExperiment.objects.create(
+            owner=owner,
+            name="experiment_without_feature",
+            slug="experiment_without_feature",
+            feature_config=None,
+        )
+        experiment_without_feature.reference_branch = NimbusBranch.objects.create(
+            experiment=experiment_without_feature,
+            slug="control",
+            feature_enabled=False,
+            feature_value="control",
+        )
+        experiment_without_feature.save()
+
+        NimbusBranch.objects.create(
+            experiment=experiment_without_feature,
             slug="treatment",
             feature_enabled=True,
             feature_value="treatment",
@@ -45,22 +69,33 @@ class TestMigration0181Forward(MigratorTestCase):
             "experiments", "NimbusExperiment"
         )
 
-        experiment = NimbusExperiment.objects.get(slug="experiment")
-
-        self.assertEqual(experiment.feature_configs.get().id, self.feature_config.id)
-
-        reference_feature_value = experiment.reference_branch.feature_values.get()
-        self.assertEqual(
-            reference_feature_value.feature_config.id, self.feature_config.id
+        experiment_with_feature = NimbusExperiment.objects.get(
+            slug="experiment_with_feature"
         )
-        self.assertEqual(reference_feature_value.enabled, False)
-        self.assertEqual(reference_feature_value.value, "control")
-
-        treatment_feature_value = experiment.branches.get(
-            slug="treatment"
-        ).feature_values.get()
-        self.assertEqual(
-            treatment_feature_value.feature_config.id, self.feature_config.id
+        experiment_without_feature = NimbusExperiment.objects.get(
+            slug="experiment_without_feature"
         )
-        self.assertEqual(treatment_feature_value.enabled, True)
-        self.assertEqual(treatment_feature_value.value, "treatment")
+
+        for experiment in (experiment_with_feature, experiment_without_feature):
+            reference_feature_value = experiment.reference_branch.feature_values.get()
+
+            self.assertEqual(reference_feature_value.enabled, False)
+            self.assertEqual(reference_feature_value.value, "control")
+
+            treatment_feature_value = experiment.branches.get(
+                slug="treatment"
+            ).feature_values.get()
+
+            self.assertEqual(treatment_feature_value.enabled, True)
+            self.assertEqual(treatment_feature_value.value, "treatment")
+
+            if experiment.feature_configs.exists():
+                self.assertEqual(
+                    experiment.feature_configs.get().id, self.feature_config.id
+                )
+                self.assertEqual(
+                    reference_feature_value.feature_config.id, self.feature_config.id
+                )
+                self.assertEqual(
+                    treatment_feature_value.feature_config.id, self.feature_config.id
+                )


### PR DESCRIPTION


Because

* Not every experiment will have a feature_config set
* We need to handle that at the model level with the uniqueness constraint in NimbusBranchFeatureValue
* We need to handle that in the migration

This commit

* Updates the migration and test to cover the case where feature_config is null
* Updates the uniqueness constraint on the model to use a fancy Django constraint API I didn't know existed to make the uniqueness constraint conditional on feature_config being set
* Updates the mutation tests to cover the case where branches can be saved even though feature config is not set