### PR TITLE
fix #6702 bug(nimbus): allow editing feature values without selecting feature

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/FormBranch.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/FormBranch.tsx
@@ -181,11 +181,10 @@ export const FormBranch = ({
         className="p-1 mx-3 mt-2 mb-0"
         data-testid="feature-config-edit"
       >
-        {experimentFeatureConfig !== null && featureEnabled ? (
+        {featureEnabled ? (
           <Form.Row data-testid="feature-value-edit">
             <Form.Group as={Col} controlId={`${id}-featureValue`}>
               <Form.Label>Value</Form.Label>
-              {/* TODO: EXP-732 Maybe do some JSON schema validation here client-side? */}
               <Form.Control
                 {...formControlAttrs("featureValue")}
                 as="textarea"


### PR DESCRIPTION


Because

* Some users input data in an arbitrary order
* We want to allow saving data before everything is filled in
* Feature value validation happens at review time now

This commit

* Removes the dependency to select a feature to edit feature value