### PR TITLE
fix #6629 feat(nimbus): set is_rollout=true for experiment cloned via "Promote to Rollout"

### DIFF
--- a/app/experimenter/experiments/models/nimbus.py
+++ b/app/experimenter/experiments/models/nimbus.py
@@ -526,6 +526,7 @@ class NimbusExperiment(NimbusConstants, FilterMixin, models.Model):
 
         if rollout_branch_slug:
             branch = self.branches.get(slug=rollout_branch_slug)
+            cloned.is_rollout = True
             cloned.reference_branch = branch.clone(cloned)
             cloned.proposed_duration = NimbusExperiment.DEFAULT_PROPOSED_DURATION
             cloned.proposed_enrollment = NimbusExperiment.DEFAULT_PROPOSED_ENROLLMENT

--- a/app/experimenter/experiments/tests/test_models/test_models_nimbus.py
+++ b/app/experimenter/experiments/tests/test_models/test_models_nimbus.py
@@ -1212,6 +1212,7 @@ class TestNimbusExperiment(TestCase):
         self.assertEqual(child.changes.all().count(), 1)
 
         if rollout_branch_slug:
+            self.assertTrue(child.is_rollout)
             self.assertEqual(
                 child.proposed_duration, NimbusExperiment.DEFAULT_PROPOSED_DURATION
             )


### PR DESCRIPTION
Because:

* we want to treat branches promoted to rollout experiments as rollouts

This commit:

* ensures is_rollout is True for an experiment cloned as a rollout