### PR TITLE
fixes #6683 fix(Nimbus): hide edit button on takeaways section of arc…

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/PageSummary/Takeaways/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageSummary/Takeaways/index.test.tsx
@@ -48,6 +48,7 @@ describe("Takeaways", () => {
     expect(
       screen.queryByTestId("conclusion-recommendation-status"),
     ).not.toBeInTheDocument();
+    expect(screen.queryByTestId("edit-takeaways")).toBeInTheDocument();
     expect(
       screen.queryByTestId("takeaways-summary-rendered"),
     ).not.toBeInTheDocument();
@@ -64,6 +65,25 @@ describe("Takeaways", () => {
     expect(screen.getByTestId("takeaways-summary-rendered")).toContainHTML(
       "<p>sample <em>exciting</em> content</p>",
     );
+    expect(screen.queryByTestId("edit-takeaways")).toBeInTheDocument();
+    expect(screen.queryByTestId("not-set")).not.toBeInTheDocument();
+  });
+
+  it("renders takeaways without edit button when experiment is archived", () => {
+    render(
+      <Subject
+        {...{ takeawaysSummary, conclusionRecommendation, isArchived: true }}
+      />,
+    );
+    expect(screen.queryByTestId("Takeaways")).toBeInTheDocument();
+    expect(screen.queryByTestId("TakeawaysEditor")).not.toBeInTheDocument();
+    expect(
+      screen.getByTestId("conclusion-recommendation-status"),
+    ).toHaveTextContent(expectedConclusionRecommendationLabel);
+    expect(screen.getByTestId("takeaways-summary-rendered")).toContainHTML(
+      "<p>sample <em>exciting</em> content</p>",
+    );
+    expect(screen.queryByTestId("edit-takeaways")).not.toBeInTheDocument();
     expect(screen.queryByTestId("not-set")).not.toBeInTheDocument();
   });
 

--- a/app/experimenter/nimbus-ui/src/components/PageSummary/Takeaways/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageSummary/Takeaways/index.tsx
@@ -23,6 +23,7 @@ export const Takeaways = (props: TakeawaysProps) => {
     setShowEditor,
     conclusionRecommendation,
     takeawaysSummary,
+    isArchived,
   } = props;
 
   const { conclusionRecommendations } = useConfig();
@@ -56,15 +57,17 @@ export const Takeaways = (props: TakeawaysProps) => {
             )}
           </Col>
           <Col className="text-right">
-            <Button
-              onClick={onClickEdit}
-              variant="outline-primary"
-              size="sm"
-              className="mx-1"
-              data-testid="edit-takeaways"
-            >
-              Edit
-            </Button>
+            {!isArchived && (
+              <Button
+                onClick={onClickEdit}
+                variant="outline-primary"
+                size="sm"
+                className="mx-1"
+                data-testid="edit-takeaways"
+              >
+                Edit
+              </Button>
+            )}
           </Col>
         </Row>
       </h3>

--- a/app/experimenter/nimbus-ui/src/components/PageSummary/Takeaways/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageSummary/Takeaways/mocks.tsx
@@ -10,6 +10,7 @@ export const Subject = ({
   takeawaysSummary = null,
   conclusionRecommendation = null,
   isLoading = false,
+  isArchived = false,
   onSubmit = async (data) => {},
   ...props
 }: Partial<React.ComponentProps<typeof Takeaways>>) => {
@@ -31,6 +32,7 @@ export const Subject = ({
             takeawaysSummary,
             conclusionRecommendation,
             isLoading,
+            isArchived,
             onSubmit,
             showEditor,
             setShowEditor,

--- a/app/experimenter/nimbus-ui/src/components/PageSummary/Takeaways/useTakeaways.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageSummary/Takeaways/useTakeaways.tsx
@@ -17,7 +17,7 @@ import { updateExperiment_updateExperiment } from "../../../types/updateExperime
 // Params are a select subset of experiment properties
 export type UseTakeawaysExperimentSubset = Pick<
   getExperiment_experimentBySlug,
-  "id" | "conclusionRecommendation" | "takeawaysSummary"
+  "id" | "conclusionRecommendation" | "takeawaysSummary" | "isArchived"
 >;
 
 export type UseTakeawaysResult = UseTakeawaysExperimentSubset & {
@@ -49,7 +49,6 @@ export const useTakeaways = (
         const { conclusionRecommendation, takeawaysSummary } = data;
         try {
           setIsLoading(true);
-
           const variables = {
             input: {
               id,


### PR DESCRIPTION
…hived completed experiment

Because

* Takeaways section cannot be updated on archived experiments

This commit

* hides the edit takeaways button if the experiment is archived