### PR TITLE
fix #6697 feat(nimbus): display warning if rollouts not supported by client

### DIFF
--- a/app/experimenter/experiments/api/v5/inputs.py
+++ b/app/experimenter/experiments/api/v5/inputs.py
@@ -47,6 +47,7 @@ class TreatmentBranchType(BranchType):
 
 class ExperimentInput(graphene.InputObjectType):
     id = graphene.Int()
+    is_rollout = graphene.Boolean()
     is_archived = graphene.Boolean()
     status = NimbusExperimentStatus()
     status_next = NimbusExperimentStatus()

--- a/app/experimenter/experiments/api/v5/serializers.py
+++ b/app/experimenter/experiments/api/v5/serializers.py
@@ -190,7 +190,6 @@ class NimbusExperimentBranchMixin:
     def validate(self, data):
         data = super().validate(data)
         data = self._validate_duplicate_branch_names(data)
-        data = self._validate_single_branch_for_rollout(data)
         return data
 
     def _validate_duplicate_branch_names(self, data):
@@ -214,22 +213,6 @@ class NimbusExperimentBranchMixin:
                         ],
                     }
                 )
-        return data
-
-    def _validate_single_branch_for_rollout(self, data):
-        if (
-            self.instance
-            and self.instance.is_rollout
-            and len(data.get("treatment_branches", [])) > 0
-        ):
-            raise serializers.ValidationError(
-                {
-                    "treatment_branches": [
-                        {"name": NimbusConstants.ERROR_SINGLE_BRANCH_FOR_ROLLOUT}
-                        for i in data["treatment_branches"]
-                    ],
-                }
-            )
         return data
 
     def update(self, experiment, data):
@@ -792,6 +775,8 @@ class NimbusReadyForReviewSerializer(serializers.ModelSerializer):
         errors = []
         for branch in value:
             error = {}
+            if self.instance and self.instance.is_rollout:
+                error["name"] = [NimbusConstants.ERROR_SINGLE_BRANCH_FOR_ROLLOUT]
             if branch["description"] == "":
                 error["description"] = [NimbusConstants.ERROR_REQUIRED_FIELD]
             errors.append(error)

--- a/app/experimenter/experiments/constants/nimbus.py
+++ b/app/experimenter/experiments/constants/nimbus.py
@@ -150,6 +150,101 @@ class Application(models.TextChoices):
     )
 
 
+class Version(models.TextChoices):
+    NO_VERSION = ""
+    FIREFOX_11 = "11.!"
+    FIREFOX_12 = "12.!"
+    FIREFOX_13 = "13.!"
+    FIREFOX_14 = "14.!"
+    FIREFOX_15 = "15.!"
+    FIREFOX_16 = "16.!"
+    FIREFOX_17 = "17.!"
+    FIREFOX_18 = "18.!"
+    FIREFOX_19 = "19.!"
+    FIREFOX_20 = "20.!"
+    FIREFOX_21 = "21.!"
+    FIREFOX_22 = "22.!"
+    FIREFOX_23 = "23.!"
+    FIREFOX_24 = "24.!"
+    FIREFOX_25 = "25.!"
+    FIREFOX_26 = "26.!"
+    FIREFOX_27 = "27.!"
+    FIREFOX_28 = "28.!"
+    FIREFOX_29 = "29.!"
+    FIREFOX_30 = "30.!"
+    FIREFOX_31 = "31.!"
+    FIREFOX_32 = "32.!"
+    FIREFOX_33 = "33.!"
+    FIREFOX_34 = "34.!"
+    FIREFOX_35 = "35.!"
+    FIREFOX_36 = "36.!"
+    FIREFOX_37 = "37.!"
+    FIREFOX_38 = "38.!"
+    FIREFOX_39 = "39.!"
+    FIREFOX_40 = "40.!"
+    FIREFOX_41 = "41.!"
+    FIREFOX_42 = "42.!"
+    FIREFOX_43 = "43.!"
+    FIREFOX_44 = "44.!"
+    FIREFOX_45 = "45.!"
+    FIREFOX_46 = "46.!"
+    FIREFOX_47 = "47.!"
+    FIREFOX_48 = "48.!"
+    FIREFOX_49 = "49.!"
+    FIREFOX_50 = "50.!"
+    FIREFOX_51 = "51.!"
+    FIREFOX_52 = "52.!"
+    FIREFOX_53 = "53.!"
+    FIREFOX_54 = "54.!"
+    FIREFOX_55 = "55.!"
+    FIREFOX_56 = "56.!"
+    FIREFOX_57 = "57.!"
+    FIREFOX_58 = "58.!"
+    FIREFOX_59 = "59.!"
+    FIREFOX_60 = "60.!"
+    FIREFOX_61 = "61.!"
+    FIREFOX_62 = "62.!"
+    FIREFOX_63 = "63.!"
+    FIREFOX_64 = "64.!"
+    FIREFOX_65 = "65.!"
+    FIREFOX_66 = "66.!"
+    FIREFOX_67 = "67.!"
+    FIREFOX_68 = "68.!"
+    FIREFOX_69 = "69.!"
+    FIREFOX_70 = "70.!"
+    FIREFOX_71 = "71.!"
+    FIREFOX_72 = "72.!"
+    FIREFOX_73 = "73.!"
+    FIREFOX_74 = "74.!"
+    FIREFOX_75 = "75.!"
+    FIREFOX_76 = "76.!"
+    FIREFOX_77 = "77.!"
+    FIREFOX_78 = "78.!"
+    FIREFOX_79 = "79.!"
+    FIREFOX_80 = "80.!"
+    FIREFOX_81 = "81.!"
+    FIREFOX_82 = "82.!"
+    FIREFOX_83 = "83.!"
+    FIREFOX_84 = "84.!"
+    FIREFOX_85 = "85.!"
+    FIREFOX_86 = "86.!"
+    FIREFOX_87 = "87.!"
+    FIREFOX_88 = "88.!"
+    FIREFOX_89 = "89.!"
+    FIREFOX_90 = "90.!"
+    FIREFOX_91 = "91.!"
+    FIREFOX_92 = "92.!"
+    FIREFOX_9201 = "92.0.1"
+    FIREFOX_93 = "93.!"
+    FIREFOX_94 = "94.!"
+    FIREFOX_95 = "95.!"
+    FIREFOX_96 = "96.!"
+    FIREFOX_97 = "97.!"
+    FIREFOX_98 = "98.!"
+    FIREFOX_99 = "99.!"
+    FIREFOX_100 = "100.!"
+
+
 @dataclass
 class NimbusTargetingConfig:
     name: str
@@ -425,7 +520,17 @@ TARGETING_POCKET_COMMON = NimbusTargetingConfig(
 )
 
 
+@dataclass
+class RolloutSupport:
+    application: object
+    firefox_min_version: object
+
+
 class NimbusConstants(object):
+    Application = Application
+    Channel = Channel
+    Version = Version
+
     class Status(models.TextChoices):
         DRAFT = "Draft"
         PREVIEW = "Preview"
@@ -445,7 +550,16 @@ class NimbusConstants(object):
         STOP = "STOP", "Stop"
         FOLLOWUP = "FOLLOWUP", "Run follow ups"
 
-    Application = Application
+    ROLLOUT_SUPPORT = (
+        RolloutSupport(
+            application=Application.DESKTOP,
+            firefox_min_version=Version.FIREFOX_97,
+        ),
+        RolloutSupport(
+            application=Application.FENIX,
+            firefox_min_version=Version.FIREFOX_95,
+        ),
+    )
 
     VALID_STATUS_TRANSITIONS = {
         Status.DRAFT: (Status.PREVIEW,),
@@ -493,106 +607,10 @@ class NimbusConstants(object):
         Application.KLAR_IOS: APPLICATION_CONFIG_KLAR_IOS,
     }
 
-    Channel = Channel
-
     class DocumentationLink(models.TextChoices):
         DS_JIRA = "DS_JIRA", "Data Science Jira Ticket"
         DESIGN_DOC = "DESIGN_DOC", "Experiment Design Document"
         ENG_TICKET = "ENG_TICKET", "Engineering Ticket (Bugzilla/Jira/GitHub)"
-
-    class Version(models.TextChoices):
-        NO_VERSION = ""
-        FIREFOX_11 = "11.!"
-        FIREFOX_12 = "12.!"
-        FIREFOX_13 = "13.!"
-        FIREFOX_14 = "14.!"
-        FIREFOX_15 = "15.!"
-        FIREFOX_16 = "16.!"
-        FIREFOX_17 = "17.!"
-        FIREFOX_18 = "18.!"
-        FIREFOX_19 = "19.!"
-        FIREFOX_20 = "20.!"
-        FIREFOX_21 = "21.!"
-        FIREFOX_22 = "22.!"
-        FIREFOX_23 = "23.!"
-        FIREFOX_24 = "24.!"
-        FIREFOX_25 = "25.!"
-        FIREFOX_26 = "26.!"
-        FIREFOX_27 = "27.!"
-        FIREFOX_28 = "28.!"
-        FIREFOX_29 = "29.!"
-        FIREFOX_30 = "30.!"
-        FIREFOX_31 = "31.!"
-        FIREFOX_32 = "32.!"
-        FIREFOX_33 = "33.!"
-        FIREFOX_34 = "34.!"
-        FIREFOX_35 = "35.!"
-        FIREFOX_36 = "36.!"
-        FIREFOX_37 = "37.!"
-        FIREFOX_38 = "38.!"
-        FIREFOX_39 = "39.!"
-        FIREFOX_40 = "40.!"
-        FIREFOX_41 = "41.!"
-        FIREFOX_42 = "42.!"
-        FIREFOX_43 = "43.!"
-        FIREFOX_44 = "44.!"
-        FIREFOX_45 = "45.!"
-        FIREFOX_46 = "46.!"
-        FIREFOX_47 = "47.!"
-        FIREFOX_48 = "48.!"
-        FIREFOX_49 = "49.!"
-        FIREFOX_50 = "50.!"
-        FIREFOX_51 = "51.!"
-        FIREFOX_52 = "52.!"
-        FIREFOX_53 = "53.!"
-        FIREFOX_54 = "54.!"
-        FIREFOX_55 = "55.!"
-        FIREFOX_56 = "56.!"
-        FIREFOX_57 = "57.!"
-        FIREFOX_58 = "58.!"
-        FIREFOX_59 = "59.!"
-        FIREFOX_60 = "60.!"
-        FIREFOX_61 = "61.!"
-        FIREFOX_62 = "62.!"
-        FIREFOX_63 = "63.!"
-        FIREFOX_64 = "64.!"
-        FIREFOX_65 = "65.!"
-        FIREFOX_66 = "66.!"
-        FIREFOX_67 = "67.!"
-        FIREFOX_68 = "68.!"
-        FIREFOX_69 = "69.!"
-        FIREFOX_70 = "70.!"
-        FIREFOX_71 = "71.!"
-        FIREFOX_72 = "72.!"
-        FIREFOX_73 = "73.!"
-        FIREFOX_74 = "74.!"
-        FIREFOX_75 = "75.!"
-        FIREFOX_76 = "76.!"
-        FIREFOX_77 = "77.!"
-        FIREFOX_78 = "78.!"
-        FIREFOX_79 = "79.!"
-        FIREFOX_80 = "80.!"
-        FIREFOX_81 = "81.!"
-        FIREFOX_82 = "82.!"
-        FIREFOX_83 = "83.!"
-        FIREFOX_84 = "84.!"
-        FIREFOX_85 = "85.!"
-        FIREFOX_86 = "86.!"
-        FIREFOX_87 = "87.!"
-        FIREFOX_88 = "88.!"
-        FIREFOX_89 = "89.!"
-        FIREFOX_90 = "90.!"
-        FIREFOX_91 = "91.!"
-        FIREFOX_92 = "92.!"
-        FIREFOX_9201 = "92.0.1"
-        FIREFOX_93 = "93.!"
-        FIREFOX_94 = "94.!"
-        FIREFOX_95 = "95.!"
-        FIREFOX_96 = "96.!"
-        FIREFOX_97 = "97.!"
-        FIREFOX_98 = "98.!"
-        FIREFOX_99 = "99.!"
-        FIREFOX_100 = "100.!"
 
     class EmailType(models.TextChoices):
         EXPERIMENT_END = "experiment end"
@@ -741,6 +759,11 @@ Optional - We believe this outcome will <describe impact> on <core metric>
         "You must select a feature configuration from the drop down."
     )
     ERROR_POPULATION_PERCENT_MIN = "Ensure this value is greater than or equal to 0.0001."
+
+    WARNING_ROLLOUT_SUPPORT = (
+        "Rollouts may not be fully supported for the selected "
+        "application and minimum version"
+    )
 
     # Analysis can be computed starting the week after enrollment
     # completion for "week 1" of the experiment. However, an extra

--- a/app/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_experiment_branch_mixin.py
+++ b/app/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_experiment_branch_mixin.py
@@ -260,33 +260,3 @@ class TestNimbusExperimentBranchMixin(TestCase):
                 ],
             },
         )
-
-    def test_no_treatment_branches_for_rollout(self):
-        experiment = NimbusExperimentFactory.create(
-            status=NimbusExperiment.Status.DRAFT,
-        )
-        experiment.is_rollout = True
-        experiment.save()
-        for branch in experiment.treatment_branches:
-            branch.delete()
-
-        data = {
-            "treatment_branches": [
-                {"name": "treatment A", "description": "desc1", "ratio": 1},
-                {"name": "treatment B", "description": "desc2", "ratio": 1},
-            ],
-            "changelog_message": "test changelog message",
-        }
-        serializer = NimbusExperimentSerializer(
-            experiment, data=data, partial=True, context={"user": self.user}
-        )
-        self.assertFalse(serializer.is_valid())
-        self.assertEqual(
-            serializer.errors,
-            {
-                "treatment_branches": [
-                    {"name": NimbusConstants.ERROR_SINGLE_BRANCH_FOR_ROLLOUT}
-                    for i in data["treatment_branches"]
-                ],
-            },
-        )

--- a/app/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_ready_for_review_serializer.py
+++ b/app/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_ready_for_review_serializer.py
@@ -577,3 +577,26 @@ class TestNimbusReadyForReviewSerializer(TestCase):
             context={"user": self.user},
         )
         self.assertTrue(serializer.is_valid())
+
+    def test_no_treatment_branches_for_rollout(self):
+        experiment = NimbusExperimentFactory.create(
+            status=NimbusExperiment.Status.DRAFT,
+        )
+        experiment.is_rollout = True
+        experiment.save()
+
+        serializer = NimbusReadyForReviewSerializer(
+            experiment,
+            data=NimbusReadyForReviewSerializer(
+                experiment,
+                context={"user": self.user},
+            ).data,
+            context={"user": self.user},
+        )
+
+        self.assertFalse(serializer.is_valid())
+        self.assertEqual(
+            serializer.errors["treatment_branches"][0]["name"][0],
+            NimbusConstants.ERROR_SINGLE_BRANCH_FOR_ROLLOUT,
+            serializer.errors,
+        )

--- a/app/experimenter/nimbus-ui/schema.graphql
+++ b/app/experimenter/nimbus-ui/schema.graphql
@@ -34,6 +34,7 @@ input ExperimentCloneInput {
 
 input ExperimentInput {
   id: Int
+  isRollout: Boolean
   isArchived: Boolean
   status: NimbusExperimentStatus
   statusNext: NimbusExperimentStatus

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/index.test.tsx
@@ -145,6 +145,15 @@ describe("FormBranches", () => {
     expect(saveResult.warnFeatureSchema).toBeTruthy();
   });
 
+  it("sets isRollout when checkbox enabled", async () => {
+    const onSave = jest.fn();
+    render(<SubjectBranches {...{ onSave }} />);
+    fireEvent.click(screen.getByTestId("is-rollout-checkbox"));
+    await clickAndWaitForSave(onSave);
+    const saveResult = onSave.mock.calls[0][0];
+    expect(saveResult.isRollout).toBeTruthy();
+  });
+
   it("gracefully handles selecting an invalid feature config", async () => {
     const onSave = jest.fn();
     render(<SubjectBranches {...{ onSave }} />);

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/index.tsx
@@ -259,7 +259,26 @@ export const FormBranches = ({
               checked={!!isRollout}
               type="checkbox"
               label="Handle this experiment as a single-branch rollout"
+              className={classNames({
+                "is-warning":
+                  fieldMessages.is_rollout?.length > 0 ||
+                  fieldWarnings.is_rollout?.length > 0,
+              })}
             />
+            {fieldMessages.is_rollout?.length > 0 && (
+              // @ts-ignore This component doesn't technically support type="warning", but
+              // all it's doing is using the string in a class, so we can safely override.
+              <Form.Control.Feedback type="warning" data-for="isRollout">
+                {(fieldMessages.is_rollout as SerializerMessage).join(", ")}
+              </Form.Control.Feedback>
+            )}
+            {fieldWarnings.is_rollout?.length > 0 && (
+              // @ts-ignore This component doesn't technically support type="warning", but
+              // all it's doing is using the string in a class, so we can safely override.
+              <Form.Control.Feedback type="warning" data-for="isRollout">
+                {(fieldWarnings.is_rollout as SerializerMessage).join(", ")}
+              </Form.Control.Feedback>
+            )}
           </Form.Group>
         </Form.Row>
 

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/index.tsx
@@ -48,6 +48,7 @@ export const FormBranches = ({
     {
       featureConfig: experimentFeatureConfig,
       warnFeatureSchema,
+      isRollout,
       referenceBranch,
       treatmentBranches,
       equalRatio,
@@ -119,6 +120,14 @@ export const FormBranches = ({
     commitFormData();
     dispatch({
       type: "setwarnFeatureSchema",
+      value: ev.target.checked,
+    });
+  };
+
+  const handleIsRollout = (ev: React.ChangeEvent<HTMLInputElement>) => {
+    commitFormData();
+    dispatch({
+      type: "setIsRollout",
       value: ev.target.checked,
     });
   };
@@ -241,6 +250,18 @@ export const FormBranches = ({
             </Form.Control.Feedback>
           )}
         </Form.Group>
+
+        <Form.Row>
+          <Form.Group as={Col} controlId="isRollout">
+            <Form.Check
+              data-testid="is-rollout-checkbox"
+              onChange={handleIsRollout}
+              checked={!!isRollout}
+              type="checkbox"
+              label="Handle this experiment as a single-branch rollout"
+            />
+          </Form.Group>
+        </Form.Row>
 
         <Form.Row>
           <Form.Group as={Col} controlId="warnFeatureSchema">

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/mocks.tsx
@@ -53,6 +53,7 @@ const MOCK_STATE: FormBranchesState = {
   globalErrors: [],
   featureConfig: MOCK_EXPERIMENT.featureConfig,
   warnFeatureSchema: false,
+  isRollout: false,
   referenceBranch: {
     ...MOCK_EXPERIMENT.referenceBranch!,
     screenshots: [],

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/reducer/actions.ts
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/reducer/actions.ts
@@ -23,6 +23,8 @@ export function formBranchesActionReducer(
       return removeBranch(state, action);
     case "setFeatureConfig":
       return setFeatureConfig(state, action);
+    case "setIsRollout":
+      return setIsRollout(state, action);
     case "setwarnFeatureSchema":
       return setwarnFeatureSchema(state, action);
     case "setEqualRatio":
@@ -47,6 +49,7 @@ export type FormBranchesAction =
   | RemoveBranchAction
   | SetEqualRatioAction
   | SetFeatureConfigAction
+  | SetIsRolloutAction
   | SetwarnFeatureSchemaAction
   | SetSubmitErrorsAction
   | ClearSubmitErrorsAction
@@ -138,6 +141,21 @@ function setFeatureConfig(
   return {
     ...state,
     featureConfig,
+  };
+}
+
+type SetIsRolloutAction = {
+  type: "setIsRollout";
+  value: FormBranchesState["isRollout"];
+};
+
+function setIsRollout(
+  state: FormBranchesState,
+  { value: isRollout }: SetIsRolloutAction,
+) {
+  return {
+    ...state,
+    isRollout,
   };
 }
 

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/reducer/index.test.ts
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/reducer/index.test.ts
@@ -14,6 +14,7 @@ const MOCK_STATE: FormBranchesState = {
   globalErrors: [],
   featureConfig: MOCK_EXPERIMENT.featureConfig,
   warnFeatureSchema: false,
+  isRollout: false,
   referenceBranch: {
     ...MOCK_EXPERIMENT.referenceBranch!,
     screenshots: [],

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/reducer/state.ts
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/reducer/state.ts
@@ -10,7 +10,7 @@ import { TreatmentBranchType } from "../../../../types/globalTypes";
 
 export type FormBranchesState = Pick<
   getExperiment_experimentBySlug,
-  "featureConfig" | "warnFeatureSchema"
+  "featureConfig" | "warnFeatureSchema" | "isRollout"
 > & {
   referenceBranch: null | AnnotatedBranch;
   treatmentBranches: null | AnnotatedBranch[];
@@ -32,6 +32,7 @@ export type AnnotatedBranch = Omit<TreatmentBranchType, "id"> & {
 export function createInitialState({
   featureConfig,
   warnFeatureSchema,
+  isRollout,
   referenceBranch,
   treatmentBranches,
 }: getExperiment_experimentBySlug): FormBranchesState {
@@ -59,6 +60,7 @@ export function createInitialState({
     equalRatio,
     featureConfig,
     warnFeatureSchema,
+    isRollout,
     globalErrors: [],
     referenceBranch: annotatedReferenceBranch,
     treatmentBranches: annotatedTreatmentBranches,

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/reducer/update.ts
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/reducer/update.ts
@@ -13,6 +13,7 @@ export type FormBranchesSaveState = Pick<
   ExperimentInput,
   | "featureConfigId"
   | "warnFeatureSchema"
+  | "isRollout"
   | "referenceBranch"
   | "treatmentBranches"
 >;
@@ -31,6 +32,7 @@ export function extractUpdateState(
   const {
     featureConfig,
     warnFeatureSchema,
+    isRollout,
     referenceBranch,
     treatmentBranches,
   } = state;
@@ -44,6 +46,7 @@ export function extractUpdateState(
   return {
     featureConfigId,
     warnFeatureSchema,
+    isRollout,
     referenceBranch: extractUpdateBranch(
       referenceBranch,
       formData.referenceBranch,

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/index.tsx
@@ -19,7 +19,6 @@ import { updateExperiment_updateExperiment as UpdateExperimentBranchesResult } f
 import AppLayoutWithExperiment from "../AppLayoutWithExperiment";
 import LinkExternal from "../LinkExternal";
 import FormBranches from "./FormBranches";
-import { FormBranchesSaveState } from "./FormBranches/reducer";
 
 const PageEditBranches: React.FunctionComponent<RouteComponentProps> = () => {
   const { featureConfigs } = useConfig();
@@ -34,12 +33,7 @@ const PageEditBranches: React.FunctionComponent<RouteComponentProps> = () => {
 
   const onFormSave = useCallback(
     async (
-      {
-        featureConfigId,
-        warnFeatureSchema,
-        referenceBranch,
-        treatmentBranches,
-      }: FormBranchesSaveState,
+      formBranchesSaveState,
       setSubmitErrors,
       clearSubmitErrors,
       next: boolean,
@@ -50,12 +44,9 @@ const PageEditBranches: React.FunctionComponent<RouteComponentProps> = () => {
         const result = await updateExperimentBranches({
           variables: {
             input: {
+              ...formBranchesSaveState,
               id: nimbusExperimentId,
               changelogMessage: CHANGELOG_MESSAGES.UPDATED_BRANCHES,
-              featureConfigId,
-              warnFeatureSchema,
-              referenceBranch,
-              treatmentBranches,
             },
           },
         });

--- a/app/experimenter/nimbus-ui/src/types/globalTypes.ts
+++ b/app/experimenter/nimbus-ui/src/types/globalTypes.ts
@@ -188,6 +188,7 @@ export interface ExperimentCloneInput {
 
 export interface ExperimentInput {
   id?: number | null;
+  isRollout?: boolean | null;
   isArchived?: boolean | null;
   status?: NimbusExperimentStatus | null;
   statusNext?: NimbusExperimentStatus | null;


### PR DESCRIPTION
I ended up branching this atop PR #6751 essentially to have a place to display the warning where it's actually actionable - i.e. a checkbox on the branches edit page controlling isRollout

Because:

* not all clients supported by Nimbus support `isRollout`

This commit:

* adds a review validator warning if the selected combination of
  application, channel, and min version don't support rollouts

* adds a list to NimbusConstants describing clients by application,
  channel, and min version combinations that support rollouts

* implements review validation of the experiment against the list of
  supported clients

* tweaks the branch edit page UI to display errors & warning for
  isRollout

* slightly refactors NimbusConstants