### PR TITLE
fix #6546 bug(nimbus): query recipe json for targeting tests from v5 api instead of v6

### DIFF
--- a/app/tests/integration/nimbus/pages/experimenter/summary.py
+++ b/app/tests/integration/nimbus/pages/experimenter/summary.py
@@ -9,6 +9,7 @@ class SummaryPage(ExperimenterBase):
     """Experiment Summary Page."""
 
     _page_wait_locator = (By.CSS_SELECTOR, "#PageSummary")
+    _header_slug = (By.CSS_SELECTOR, 'p[data-testid="header-experiment-slug"]')
     _approve_request_button_locator = (By.CSS_SELECTOR, "#approve-request-button")
     _launch_to_preview_locator = (By.CSS_SELECTOR, "#launch-to-preview-button")
     _launch_without_preview_locator = (By.CSS_SELECTOR, "#launch-to-review-button")
@@ -100,6 +101,10 @@ class SummaryPage(ExperimenterBase):
             EC.presence_of_all_elements_located(self._clone_parent_locator),
             message="Summary Page: could not find clone parent",
         )
+
+    @property
+    def experiment_slug(self):
+        return self.wait_for_and_find_element(self._header_slug, "header slug").text
 
     @property
     def experiment_status(self):

--- a/app/tests/integration/nimbus/parallel_pytest_args.txt
+++ b/app/tests/integration/nimbus/parallel_pytest_args.txt
@@ -4,5 +4,4 @@
 -k KLAR -m run_per_app
 -k FOCUS -m run_per_app
 -k DESKTOP -m run_once
--k DESKTOP -m run_parallel -n 2
- 
+-k DESKTOP -m run_targeting -n 2

--- a/app/tests/integration/nimbus/test_firefox_targeting.py
+++ b/app/tests/integration/nimbus/test_firefox_targeting.py
@@ -1,0 +1,108 @@
+import json
+import time
+
+import pytest
+import requests
+from nimbus.models.base_dataclass import BaseExperimentApplications
+from nimbus.pages.browser import Browser
+
+LOAD_DATA_RETRIES = 10
+LOAD_DATA_RETRY_DELAY = 1.0
+
+
+def load_graphql_data(query):
+    for retry in range(LOAD_DATA_RETRIES):
+        try:
+            return requests.post(
+                "https://nginx/api/v5/graphql",
+                json=query,
+                verify=False,
+            ).json()
+        except json.JSONDecodeError:
+            if retry + 1 >= LOAD_DATA_RETRIES:
+                raise
+            else:
+                time.sleep(LOAD_DATA_RETRY_DELAY)
+
+
+def load_targeting_configs():
+    data = load_graphql_data(
+        {
+            "operationName": "getConfig",
+            "variables": {},
+            "query": """
+                    query getConfig {
+                        nimbusConfig {
+                            targetingConfigs {
+                                label
+                                value
+                                applicationValues
+                            }
+                        }
+                    }
+                    """,
+        }
+    )
+    targeting_configs = []
+    for item in data["data"]["nimbusConfig"]["targetingConfigs"]:
+        if "DESKTOP" in item["applicationValues"]:
+            targeting_configs.append(item["value"])
+    return targeting_configs
+
+
+def load_experiment_data(slug):
+    return load_graphql_data(
+        {
+            "operationName": "getExperiment",
+            "variables": {"slug": slug},
+            "query": """
+                    query getExperiment($slug: String!) {
+                        experimentBySlug(slug: $slug) {
+                            jexlTargetingExpression
+                            recipeJson
+                            __typename
+                        }
+                    }
+                    """,
+        }
+    )
+
+
+@pytest.fixture(params=load_targeting_configs())
+def targeting_config_slug(request):
+    return request.param
+
+
+@pytest.mark.run_targeting
+def test_check_targeting(
+    selenium,
+    default_data,
+    create_experiment,
+    targeting_config_slug,
+):
+    # TODO #6791
+    # If the targeting config slug includes the word desktop it will cause this test
+    # to run against applications other than desktop, which will then fail.
+    # This check will prevent the test from executing fully but we should dig
+    # into preventing this case altogether when we have time.
+    if default_data.application != BaseExperimentApplications.DESKTOP:
+        return
+
+    default_data.audience.targeting = targeting_config_slug
+    experiment = create_experiment(selenium)
+
+    experiment_data = load_experiment_data(experiment.experiment_slug)
+    targeting = experiment_data["data"]["experimentBySlug"]["jexlTargetingExpression"]
+    recipe = experiment_data["data"]["experimentBySlug"]["recipeJson"]
+
+    # Inject filter expression
+    selenium.get("about:blank")
+    with open("nimbus/utils/filter_expression.js") as js:
+        result = Browser.execute_script(
+            selenium,
+            targeting,
+            json.dumps({"experiment": recipe}),
+            script=js.read(),
+            context="chrome",
+        )
+    assert result is not None, "Invalid Targeting, or bad recipe"

--- a/app/tests/integration/nimbus/utils/filter_expression.js
+++ b/app/tests/integration/nimbus/utils/filter_expression.js
@@ -1,8 +1,3 @@
-Components.utils.import("resource://gre/modules/components-utils/FilterExpressions.jsm");
-Components.utils.import("resource://gre/modules/components-utils/ClientEnvironment.jsm");
-
-// Targeting
-
 async function remoteSettings(arguments) {
 
     /*

--- a/app/tests/integration/tox.ini
+++ b/app/tests/integration/tox.ini
@@ -21,4 +21,4 @@ markers =
     use_variables: marks tests that need to use pytest-variables
     run_once: only run a single instance of this test (rather than for each app)
     run_per_app: run this test for each application
-    run_parallel: run these tests in parallel
+    run_targeting: run jexl targeting tests in firefox


### PR DESCRIPTION


Because

* We test each JEXL targeting config in Firefox to make sure it's valid
* To do this we need to create an experiment with a given targeting config and query its full recipe
* We were querying this from the V6 API by pushing the experiment to preview
* Publishing to preview inside the integration tests has proven to be very unreliable
* We can also query this info from the V5 API without needing to interact with Remote Settings at all

This commit

* Calls the V5 API to get the experiment recipe instead of the V6 API
* Removes the dependency on Remote Settings from the targeting tests altogether