### PR TITLE
fix #6805 feat(nimbus): disable launches should not prevent ending enrolment

### DIFF
--- a/app/experimenter/experiments/api/v5/serializers.py
+++ b/app/experimenter/experiments/api/v5/serializers.py
@@ -340,6 +340,15 @@ class NimbusStatusValidationMixin:
                         }
                     )
 
+            if (
+                SiteFlag.objects.value(SiteFlagNameChoices.LAUNCHING_DISABLED)
+                and self.instance.status == NimbusExperiment.Status.DRAFT
+                and data.get("status_next") == NimbusExperiment.Status.LIVE
+            ):
+                raise serializers.ValidationError(
+                    {"status_next": NimbusExperiment.ERROR_LAUNCHING_DISABLED}
+                )
+
         return data
 
 
@@ -584,12 +593,6 @@ class NimbusExperimentSerializer(
                 f"'{self.instance.status}', the only valid choices are "
                 f"'{choices_str}'"
             )
-
-        if (
-            SiteFlag.objects.value(SiteFlagNameChoices.LAUNCHING_DISABLED)
-            and value == NimbusExperiment.Status.LIVE
-        ):
-            raise serializers.ValidationError(NimbusExperiment.ERROR_LAUNCHING_DISABLED)
 
         return value
 


### PR DESCRIPTION


Becuase

* We want to be able to disable any new launches without preventing people from ending enrolment or experiments

This commit

* Checks that an experiment is moving from draft to live when using the launch disabled check