### PR TITLE
fix #6815 bug(nimbus): fix datetime tests

### DIFF
--- a/app/experimenter/nimbus-ui/src/lib/dateUtils.test.ts
+++ b/app/experimenter/nimbus-ui/src/lib/dateUtils.test.ts
@@ -26,9 +26,9 @@ describe("humanDate", () => {
   });
 
   it("normalizes time and timezone", () => {
-    expect(humanDate("2021-06-21T10:00:00Z")).toEqual("Jun 21");
-    expect(humanDate("2021-06-21T00:00:00Z")).toEqual("Jun 21");
-    expect(humanDate("2021-06-21")).toEqual("Jun 21");
+    expect(humanDate("2021-06-21T10:00:00Z")).toEqual("Jun 21, 2021");
+    expect(humanDate("2021-06-21T00:00:00Z")).toEqual("Jun 21, 2021");
+    expect(humanDate("2021-06-21")).toEqual("Jun 21, 2021");
   });
 });
 


### PR DESCRIPTION
Because

* It seems this js datetime util renders dates differently depending on what year it is

This commit

* Updates the expected output of the js datetime formatter in nimbus-ui