### PR TITLE
fix #6819 bug(nimbus): support same min max firefox version

### DIFF
--- a/app/experimenter/experiments/api/v5/serializers.py
+++ b/app/experimenter/experiments/api/v5/serializers.py
@@ -892,7 +892,7 @@ class NimbusReadyForReviewSerializer(serializers.ModelSerializer):
         if (
             min_version != ""
             and max_version != ""
-            and version.parse(min_version) >= version.parse(max_version)
+            and version.parse(min_version) > version.parse(max_version)
         ):
             raise serializers.ValidationError(
                 {

--- a/app/experimenter/experiments/constants/nimbus.py
+++ b/app/experimenter/experiments/constants/nimbus.py
@@ -760,8 +760,12 @@ Optional - We believe this outcome will <describe impact> on <core metric>
         "Launching experiments has been temporarily disabled by the site administrators."
     )
     ERROR_POPULATION_PERCENT_MIN = "Ensure this value is greater than or equal to 0.0001."
-    ERROR_FIREFOX_VERSION_MIN = "Ensure this value is less than the maximum version"
-    ERROR_FIREFOX_VERSION_MAX = "Ensure this value is greater than the minimum version"
+    ERROR_FIREFOX_VERSION_MIN = (
+        "Ensure this value is less than or equal to the maximum version"
+    )
+    ERROR_FIREFOX_VERSION_MAX = (
+        "Ensure this value is greater than or equal to the minimum version"
+    )
 
     # Analysis can be computed starting the week after enrollment
     # completion for "week 1" of the experiment. However, an extra

--- a/app/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_ready_for_review_serializer.py
+++ b/app/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_ready_for_review_serializer.py
@@ -179,6 +179,23 @@ class TestNimbusReadyForReviewSerializer(TestCase):
             },
         )
 
+    def test_alid_experiment_allows_min_version_equal_to_max_version(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            firefox_max_version=NimbusExperiment.Version.FIREFOX_83,
+            firefox_min_version=NimbusExperiment.Version.FIREFOX_83,
+        )
+        experiment.save()
+        serializer = NimbusReadyForReviewSerializer(
+            experiment,
+            data=NimbusReadyForReviewSerializer(
+                experiment,
+                context={"user": self.user},
+            ).data,
+            context={"user": self.user},
+        )
+        self.assertTrue(serializer.is_valid())
+
     def test_invalid_experiment_requires_non_zero_population_percent(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.CREATED,


### PR DESCRIPTION
Because

* We recently added max firefox version
* We need to support min and max targeting the same version

This commit

* Updates the serializer to allow min and max being the same version