### PR TITLE
fix #6828 chore(project): disable legacy tests and dev services

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,28 +40,6 @@ jobs:
             ./scripts/store_git_info.sh
             make publish_storybooks
 
-  integration_legacy:
-    machine:
-      image: ubuntu-2004:202107-02 # Ubuntu 20.04, Docker v20.10.7, Docker Compose v1.29.2
-      docker_layer_caching: true
-    resource_class: large
-    working_directory: ~/experimenter
-    steps:
-      - run:
-          name: Docker info
-          command: docker -v
-      - run:
-          name: Docker compose info
-          command: docker-compose -v
-      - checkout
-      - run:
-          name: Run integration tests
-          command: |
-            cp .env.sample .env
-            make refresh
-            make up_prod_detached
-            make integration_test_legacy
-
   integration_nimbus:
     machine:
       image: ubuntu-2004:202107-02 # Ubuntu 20.04, Docker v20.10.7, Docker Compose v1.29.2
@@ -113,12 +91,6 @@ workflows:
           name: check
       - publish_storybooks:
           name: publish_storybooks
-      - integration_legacy:
-          name: integration_legacy
-          filters:
-            branches:
-              ignore:
-                - main
       - integration_nimbus:
           name: integration_nimbus
           filters:

--- a/docker-compose-legacy.yml
+++ b/docker-compose-legacy.yml
@@ -1,0 +1,35 @@
+version: "3"
+
+services:
+  yarn-legacy:
+    image: app:dev
+    env_file: .env
+    tty: true
+    volumes:
+      - ./app:/app
+      - media_volume:/app/experimenter/media
+      - /app/experimenter/legacy-ui/core/.cache/
+      - /app/experimenter/legacy-ui/core/node_modules/
+      - /app/experimenter/nimbus-ui/node_modules/
+      - /app/experimenter/reporting/reporting-ui/node_modules/
+      - /app/experimenter/served/
+      - /app/node_modules/
+    command: bash -c "yarn workspace @experimenter/core watch"
+
+  yarn-reporting:
+    image: app:dev
+    env_file: .env
+    tty: true
+    volumes:
+      - ./app:/app
+      - media_volume:/app/experimenter/media
+      - /app/experimenter/legacy-ui/core/.cache/
+      - /app/experimenter/legacy-ui/core/node_modules/
+      - /app/experimenter/nimbus-ui/node_modules/
+      - /app/experimenter/reporting/reporting-ui/node_modules/
+      - /app/experimenter/served/
+      - /app/node_modules/
+    command: bash -c "yarn workspace @experimenter/reporting watch"
+
+volumes:
+  media_volume:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,36 +40,6 @@ services:
       - /app/node_modules/
     command: bash -c "FORCE_COLOR=true yarn workspace @experimenter/nimbus-ui start | cat"
 
-  yarn-core:
-    image: app:dev
-    env_file: .env
-    tty: true
-    volumes:
-      - ./app:/app
-      - media_volume:/app/experimenter/media
-      - /app/experimenter/legacy-ui/core/.cache/
-      - /app/experimenter/legacy-ui/core/node_modules/
-      - /app/experimenter/nimbus-ui/node_modules/
-      - /app/experimenter/reporting/reporting-ui/node_modules/
-      - /app/experimenter/served/
-      - /app/node_modules/
-    command: bash -c "yarn workspace @experimenter/core watch"
-
-  yarn-reporting:
-    image: app:dev
-    env_file: .env
-    tty: true
-    volumes:
-      - ./app:/app
-      - media_volume:/app/experimenter/media
-      - /app/experimenter/legacy-ui/core/.cache/
-      - /app/experimenter/legacy-ui/core/node_modules/
-      - /app/experimenter/nimbus-ui/node_modules/
-      - /app/experimenter/reporting/reporting-ui/node_modules/
-      - /app/experimenter/served/
-      - /app/node_modules/
-    command: bash -c "yarn workspace @experimenter/reporting watch"
-
   worker:
     image: app:dev
     env_file: .env


### PR DESCRIPTION
Because

* The legacy workflow is in maintenance only mode and has not had any changes or failures in over a year

This commit

* Moves the legacy tests out of make check but preserves them in make check_legacy
* Moves the legacy dev services out of make up but preserves them in make up_legacy
* Removes the integration_legacy job from circle