### PR TITLE
fix #6804 bug(nimbus): handle missing feature config in v6 serializer

### DIFF
--- a/app/experimenter/experiments/api/v6/serializers.py
+++ b/app/experimenter/experiments/api/v6/serializers.py
@@ -75,7 +75,7 @@ class NimbusBranchSerializerMultiFeature(serializers.ModelSerializer):
         features = []
         for fv in obj.feature_values.all():
             feature_value = {
-                "featureId": fv.feature_config.slug,
+                "featureId": fv.feature_config and fv.feature_config.slug or "",
                 "enabled": fv.enabled,
                 "value": {},
             }

--- a/app/experimenter/experiments/tests/api/v6/test_serializers.py
+++ b/app/experimenter/experiments/tests/api/v6/test_serializers.py
@@ -267,7 +267,7 @@ class TestNimbusExperimentSerializer(TestCase):
         self.assertEqual(serializer.data["branches"][0]["feature"]["value"], {})
         check_schema("experiments/NimbusExperiment", serializer.data)
 
-    def test_serializer_with_branches_no_feature(self):
+    def test_serializer_with_branches_no_feature_94(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.CREATED,
             application=NimbusExperiment.Application.DESKTOP,
@@ -277,6 +277,26 @@ class TestNimbusExperimentSerializer(TestCase):
         experiment.save()
         serializer = NimbusExperimentSerializer(experiment)
         self.assertIsNone(serializer.data["branches"][0]["feature"]["featureId"])
+
+    def test_serializer_with_branches_no_feature_95(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            application=NimbusExperiment.Application.DESKTOP,
+            firefox_min_version=NimbusExperiment.Version.FIREFOX_95,
+            feature_configs=[],
+        )
+        experiment.save()
+        NimbusBranchFeatureValue.objects.create(
+            branch=experiment.reference_branch,
+            feature_config=None,
+            enabled=False,
+            value="",
+        )
+        serializer = NimbusExperimentSerializer(experiment)
+        self.assertEqual(
+            serializer.data["branches"][0]["features"],
+            [{"featureId": "", "enabled": False, "value": {}}],
+        )
 
     def test_serializer_with_branch_invalid_single_feature_value(self):
         application = NimbusExperiment.Application.DESKTOP


### PR DESCRIPTION
Because

* When an experiment is created, branches can be saved without selecting a feature config
* This will create a feature value on the branch with no feature config
* The v6 serializer expected this to be not None and throws

This commit

* Updates the v6 serializer to handle the case that a feature value has no feature config
* Adds a relevant test