### PR TITLE
fix #6746 chore(nimbus): rename gql types with input/type/enum

### DIFF
--- a/app/experimenter/experiments/api/v5/inputs.py
+++ b/app/experimenter/experiments/api/v5/inputs.py
@@ -2,43 +2,43 @@ import graphene
 from graphene_file_upload.scalars import Upload
 
 from experimenter.experiments.api.v5.types import (
-    NimbusExperimentApplication,
-    NimbusExperimentChannel,
-    NimbusExperimentConclusionRecommendation,
-    NimbusExperimentDocumentationLink,
-    NimbusExperimentFirefoxVersion,
-    NimbusExperimentPublishStatus,
-    NimbusExperimentStatus,
+    NimbusExperimentApplicationEnum,
+    NimbusExperimentChannelEnum,
+    NimbusExperimentConclusionRecommendationEnum,
+    NimbusExperimentDocumentationLinkEnum,
+    NimbusExperimentFirefoxVersionEnum,
+    NimbusExperimentPublishStatusEnum,
+    NimbusExperimentStatusEnum,
 )
 
 
-class BranchScreenshotType(graphene.InputObjectType):
+class BranchScreenshotInput(graphene.InputObjectType):
     id = graphene.Int()
     image = Upload()
     description = graphene.String()
 
 
-class BranchType(graphene.InputObjectType):
+class BranchInput(graphene.InputObjectType):
     id = graphene.Int()
     name = graphene.String(required=True)
     description = graphene.String(required=True)
     ratio = graphene.Int(required=True)
     feature_enabled = graphene.Boolean()
     feature_value = graphene.String()
-    screenshots = graphene.List(BranchScreenshotType)
+    screenshots = graphene.List(BranchScreenshotInput)
 
 
-class DocumentationLinkType(graphene.InputObjectType):
-    title = NimbusExperimentDocumentationLink(required=True)
+class DocumentationLinkInput(graphene.InputObjectType):
+    title = NimbusExperimentDocumentationLinkEnum(required=True)
     link = graphene.String(required=True)
 
 
-class ReferenceBranchType(BranchType):
+class ReferenceBranchInput(BranchInput):
     class Meta:
         description = "The control branch"
 
 
-class TreatmentBranchType(BranchType):
+class TreatmentBranchInput(BranchInput):
     class Meta:
         description = (
             "The treatment branch that should be in this position on the experiment."
@@ -48,25 +48,25 @@ class TreatmentBranchType(BranchType):
 class ExperimentInput(graphene.InputObjectType):
     id = graphene.Int()
     is_archived = graphene.Boolean()
-    status = NimbusExperimentStatus()
-    status_next = NimbusExperimentStatus()
-    publish_status = NimbusExperimentPublishStatus()
+    status = NimbusExperimentStatusEnum()
+    status_next = NimbusExperimentStatusEnum()
+    publish_status = NimbusExperimentPublishStatusEnum()
     name = graphene.String()
     hypothesis = graphene.String()
-    application = NimbusExperimentApplication()
+    application = NimbusExperimentApplicationEnum()
     public_description = graphene.String()
     is_enrollment_paused = graphene.Boolean()
     risk_mitigation_link = graphene.String()
     feature_config_id = graphene.Int()
     warn_feature_schema = graphene.Boolean()
-    documentation_links = graphene.List(DocumentationLinkType)
-    reference_branch = graphene.Field(ReferenceBranchType)
-    treatment_branches = graphene.List(TreatmentBranchType)
+    documentation_links = graphene.List(DocumentationLinkInput)
+    reference_branch = graphene.Field(ReferenceBranchInput)
+    treatment_branches = graphene.List(TreatmentBranchInput)
     primary_outcomes = graphene.List(graphene.String)
     secondary_outcomes = graphene.List(graphene.String)
-    channel = NimbusExperimentChannel()
-    firefox_min_version = NimbusExperimentFirefoxVersion()
-    firefox_max_version = NimbusExperimentFirefoxVersion()
+    channel = NimbusExperimentChannelEnum()
+    firefox_min_version = NimbusExperimentFirefoxVersionEnum()
+    firefox_max_version = NimbusExperimentFirefoxVersionEnum()
     population_percent = graphene.String()
     proposed_duration = graphene.Int()
     proposed_enrollment = graphene.String()
@@ -78,7 +78,7 @@ class ExperimentInput(graphene.InputObjectType):
     risk_brand = graphene.Boolean()
     countries = graphene.List(graphene.Int)
     locales = graphene.List(graphene.Int)
-    conclusion_recommendation = NimbusExperimentConclusionRecommendation()
+    conclusion_recommendation = NimbusExperimentConclusionRecommendationEnum()
     takeaways_summary = graphene.String()
 
 

--- a/app/experimenter/experiments/api/v5/types.py
+++ b/app/experimenter/experiments/api/v5/types.py
@@ -23,6 +23,41 @@ from experimenter.outcomes import Outcomes
 from experimenter.projects.models import Project
 
 
+class NimbusExperimentStatusEnum(graphene.Enum):
+    class Meta:
+        enum = NimbusConstants.Status
+
+
+class NimbusExperimentPublishStatusEnum(graphene.Enum):
+    class Meta:
+        enum = NimbusConstants.PublishStatus
+
+
+class NimbusExperimentFirefoxVersionEnum(graphene.Enum):
+    class Meta:
+        enum = NimbusConstants.Version
+
+
+class NimbusExperimentApplicationEnum(graphene.Enum):
+    class Meta:
+        enum = NimbusConstants.Application
+
+
+class NimbusExperimentChannelEnum(graphene.Enum):
+    class Meta:
+        enum = NimbusConstants.Channel
+
+
+class NimbusExperimentConclusionRecommendationEnum(graphene.Enum):
+    class Meta:
+        enum = NimbusConstants.ConclusionRecommendation
+
+
+class NimbusExperimentDocumentationLinkEnum(graphene.Enum):
+    class Meta:
+        enum = NimbusConstants.DocumentationLink
+
+
 class ObjectField(graphene.Scalar):
     """Utilized to serialize out Serializer errors"""
 
@@ -54,7 +89,7 @@ class NimbusLocaleType(DjangoObjectType):
         model = Locale
 
 
-class NimbusUser(DjangoObjectType):
+class NimbusUserType(DjangoObjectType):
     id = graphene.Int()
 
     class Meta:
@@ -62,51 +97,16 @@ class NimbusUser(DjangoObjectType):
         fields = ("id", "username", "first_name", "last_name", "email")
 
 
-class NimbusExperimentStatus(graphene.Enum):
-    class Meta:
-        enum = NimbusConstants.Status
-
-
-class NimbusExperimentPublishStatus(graphene.Enum):
-    class Meta:
-        enum = NimbusConstants.PublishStatus
-
-
-class NimbusExperimentFirefoxVersion(graphene.Enum):
-    class Meta:
-        enum = NimbusConstants.Version
-
-
-class NimbusExperimentApplication(graphene.Enum):
-    class Meta:
-        enum = NimbusConstants.Application
-
-
-class NimbusExperimentChannel(graphene.Enum):
-    class Meta:
-        enum = NimbusConstants.Channel
-
-
-class NimbusExperimentConclusionRecommendation(graphene.Enum):
-    class Meta:
-        enum = NimbusConstants.ConclusionRecommendation
-
-
-class NimbusExperimentApplicationConfig(graphene.ObjectType):
-    application = NimbusExperimentApplication()
+class NimbusExperimentApplicationConfigType(graphene.ObjectType):
+    application = NimbusExperimentApplicationEnum()
     channels = graphene.List(NimbusLabelValueType)
     supports_locale_country = graphene.Boolean()
 
 
-class NimbusExperimentTargetingConfig(graphene.ObjectType):
+class NimbusExperimentTargetingConfigType(graphene.ObjectType):
     label = graphene.String()
     value = graphene.String()
     application_values = graphene.List(graphene.String)
-
-
-class NimbusExperimentDocumentationLink(graphene.Enum):
-    class Meta:
-        enum = NimbusConstants.DocumentationLink
 
 
 class NimbusBranchScreenshotType(DjangoObjectType):
@@ -153,7 +153,7 @@ class NimbusDocumentationLinkType(DjangoObjectType):
 
 class NimbusFeatureConfigType(DjangoObjectType):
     id = graphene.Int()
-    application = NimbusExperimentApplication()
+    application = NimbusExperimentApplicationEnum()
 
     class Meta:
         model = NimbusFeatureConfig
@@ -187,7 +187,7 @@ class NimbusOutcomeMetricType(graphene.ObjectType):
 class NimbusOutcomeType(graphene.ObjectType):
     friendly_name = graphene.String()
     slug = graphene.String()
-    application = NimbusExperimentApplication()
+    application = NimbusExperimentApplicationEnum()
     description = graphene.String()
     isDefault = graphene.Boolean()
     metrics = graphene.List(NimbusOutcomeMetricType)
@@ -212,7 +212,7 @@ class NimbusSignoffRecommendationsType(graphene.ObjectType):
 
 
 class NimbusConfigurationType(graphene.ObjectType):
-    application_configs = graphene.List(NimbusExperimentApplicationConfig)
+    application_configs = graphene.List(NimbusExperimentApplicationConfigType)
     applications = graphene.List(NimbusLabelValueType)
     channels = graphene.List(NimbusLabelValueType)
     countries = graphene.List(NimbusCountryType)
@@ -223,8 +223,8 @@ class NimbusConfigurationType(graphene.ObjectType):
     locales = graphene.List(NimbusLocaleType)
     max_primary_outcomes = graphene.Int()
     outcomes = graphene.List(NimbusOutcomeType)
-    owners = graphene.List(NimbusUser)
-    targeting_configs = graphene.List(NimbusExperimentTargetingConfig)
+    owners = graphene.List(NimbusUserType)
+    targeting_configs = graphene.List(NimbusExperimentTargetingConfigType)
     conclusion_recommendations = graphene.List(NimbusLabelValueType)
 
     def _text_choices_to_label_value_list(root, text_choices):
@@ -247,7 +247,7 @@ class NimbusConfigurationType(graphene.ObjectType):
         for application in NimbusExperiment.Application:
             application_config = NimbusExperiment.APPLICATION_CONFIGS[application]
             configs.append(
-                NimbusExperimentApplicationConfig(
+                NimbusExperimentApplicationConfigType(
                     application=application,
                     channels=[
                         NimbusLabelValueType(label=channel.label, value=channel.name)
@@ -283,7 +283,7 @@ class NimbusConfigurationType(graphene.ObjectType):
 
     def resolve_targeting_configs(root, info):
         return [
-            NimbusExperimentTargetingConfig(
+            NimbusExperimentTargetingConfigType(
                 label=choice.label,
                 value=choice.value,
                 application_values=NimbusExperiment.TARGETING_CONFIGS[
@@ -314,14 +314,14 @@ class NimbusExperimentType(DjangoObjectType):
     parent = graphene.Field(lambda: NimbusExperimentType)
     is_rollout = graphene.Boolean()
     is_archived = graphene.Boolean()
-    status = NimbusExperimentStatus()
-    status_next = NimbusExperimentStatus()
-    publish_status = NimbusExperimentPublishStatus()
-    application = NimbusExperimentApplication()
-    firefox_min_version = NimbusExperimentFirefoxVersion()
-    firefox_max_version = NimbusExperimentFirefoxVersion()
+    status = NimbusExperimentStatusEnum()
+    status_next = NimbusExperimentStatusEnum()
+    publish_status = NimbusExperimentPublishStatusEnum()
+    application = NimbusExperimentApplicationEnum()
+    firefox_min_version = NimbusExperimentFirefoxVersionEnum()
+    firefox_max_version = NimbusExperimentFirefoxVersionEnum()
     population_percent = graphene.String()
-    channel = NimbusExperimentChannel()
+    channel = NimbusExperimentChannelEnum()
     documentation_links = DjangoListField(NimbusDocumentationLinkType)
     treatment_branches = graphene.List(NimbusBranchType)
     targeting_config_slug = graphene.String()
@@ -349,7 +349,9 @@ class NimbusExperimentType(DjangoObjectType):
     signoff_recommendations = graphene.Field(NimbusSignoffRecommendationsType)
     recipe_json = graphene.String()
     review_url = graphene.String()
-    conclusion_recommendation = graphene.Field(NimbusExperimentConclusionRecommendation)
+    conclusion_recommendation = graphene.Field(
+        NimbusExperimentConclusionRecommendationEnum
+    )
 
     class Meta:
         model = NimbusExperiment

--- a/app/experimenter/nimbus-ui/schema.graphql
+++ b/app/experimenter/nimbus-ui/schema.graphql
@@ -3,7 +3,7 @@ schema {
   mutation: Mutation
 }
 
-input BranchScreenshotType {
+input BranchScreenshotInput {
   id: Int
   image: Upload
   description: String
@@ -21,8 +21,8 @@ type CreateExperiment {
 
 scalar DateTime
 
-input DocumentationLinkType {
-  title: NimbusExperimentDocumentationLink!
+input DocumentationLinkInput {
+  title: NimbusExperimentDocumentationLinkEnum!
   link: String!
 }
 
@@ -35,25 +35,25 @@ input ExperimentCloneInput {
 input ExperimentInput {
   id: Int
   isArchived: Boolean
-  status: NimbusExperimentStatus
-  statusNext: NimbusExperimentStatus
-  publishStatus: NimbusExperimentPublishStatus
+  status: NimbusExperimentStatusEnum
+  statusNext: NimbusExperimentStatusEnum
+  publishStatus: NimbusExperimentPublishStatusEnum
   name: String
   hypothesis: String
-  application: NimbusExperimentApplication
+  application: NimbusExperimentApplicationEnum
   publicDescription: String
   isEnrollmentPaused: Boolean
   riskMitigationLink: String
   featureConfigId: Int
   warnFeatureSchema: Boolean
-  documentationLinks: [DocumentationLinkType]
-  referenceBranch: ReferenceBranchType
-  treatmentBranches: [TreatmentBranchType]
+  documentationLinks: [DocumentationLinkInput]
+  referenceBranch: ReferenceBranchInput
+  treatmentBranches: [TreatmentBranchInput]
   primaryOutcomes: [String]
   secondaryOutcomes: [String]
-  channel: NimbusExperimentChannel
-  firefoxMinVersion: NimbusExperimentFirefoxVersion
-  firefoxMaxVersion: NimbusExperimentFirefoxVersion
+  channel: NimbusExperimentChannelEnum
+  firefoxMinVersion: NimbusExperimentFirefoxVersionEnum
+  firefoxMaxVersion: NimbusExperimentFirefoxVersionEnum
   populationPercent: String
   proposedDuration: Int
   proposedEnrollment: String
@@ -65,7 +65,7 @@ input ExperimentInput {
   riskBrand: Boolean
   countries: [Int]
   locales: [Int]
-  conclusionRecommendation: NimbusExperimentConclusionRecommendation
+  conclusionRecommendation: NimbusExperimentConclusionRecommendationEnum
   takeawaysSummary: String
 }
 
@@ -146,7 +146,7 @@ enum NimbusChangeLogOldStatusNext {
 type NimbusChangeLogType {
   experiment: NimbusExperimentType!
   changedOn: DateTime!
-  changedBy: NimbusUser!
+  changedBy: NimbusUserType!
   oldStatus: NimbusChangeLogOldStatus
   oldStatusNext: NimbusChangeLogOldStatusNext
   oldPublishStatus: NimbusChangeLogOldPublishStatus
@@ -159,7 +159,7 @@ type NimbusChangeLogType {
 }
 
 type NimbusConfigurationType {
-  applicationConfigs: [NimbusExperimentApplicationConfig]
+  applicationConfigs: [NimbusExperimentApplicationConfigType]
   applications: [NimbusLabelValueType]
   channels: [NimbusLabelValueType]
   countries: [NimbusCountryType]
@@ -170,8 +170,8 @@ type NimbusConfigurationType {
   locales: [NimbusLocaleType]
   maxPrimaryOutcomes: Int
   outcomes: [NimbusOutcomeType]
-  owners: [NimbusUser]
-  targetingConfigs: [NimbusExperimentTargetingConfig]
+  owners: [NimbusUserType]
+  targetingConfigs: [NimbusExperimentTargetingConfigType]
   conclusionRecommendations: [NimbusLabelValueType]
 }
 
@@ -193,7 +193,13 @@ type NimbusDocumentationLinkType {
   link: String!
 }
 
-enum NimbusExperimentApplication {
+type NimbusExperimentApplicationConfigType {
+  application: NimbusExperimentApplicationEnum
+  channels: [NimbusLabelValueType]
+  supportsLocaleCountry: Boolean
+}
+
+enum NimbusExperimentApplicationEnum {
   DESKTOP
   FENIX
   IOS
@@ -203,13 +209,7 @@ enum NimbusExperimentApplication {
   KLAR_IOS
 }
 
-type NimbusExperimentApplicationConfig {
-  application: NimbusExperimentApplication
-  channels: [NimbusLabelValueType]
-  supportsLocaleCountry: Boolean
-}
-
-enum NimbusExperimentChannel {
+enum NimbusExperimentChannelEnum {
   NO_CHANNEL
   UNBRANDED
   NIGHTLY
@@ -218,7 +218,7 @@ enum NimbusExperimentChannel {
   TESTFLIGHT
 }
 
-enum NimbusExperimentConclusionRecommendation {
+enum NimbusExperimentConclusionRecommendationEnum {
   RERUN
   GRADUATE
   CHANGE_COURSE
@@ -226,13 +226,13 @@ enum NimbusExperimentConclusionRecommendation {
   FOLLOWUP
 }
 
-enum NimbusExperimentDocumentationLink {
+enum NimbusExperimentDocumentationLinkEnum {
   DS_JIRA
   DESIGN_DOC
   ENG_TICKET
 }
 
-enum NimbusExperimentFirefoxVersion {
+enum NimbusExperimentFirefoxVersionEnum {
   NO_VERSION
   FIREFOX_11
   FIREFOX_12
@@ -327,21 +327,21 @@ enum NimbusExperimentFirefoxVersion {
   FIREFOX_100
 }
 
-enum NimbusExperimentPublishStatus {
+enum NimbusExperimentPublishStatusEnum {
   IDLE
   REVIEW
   APPROVED
   WAITING
 }
 
-enum NimbusExperimentStatus {
+enum NimbusExperimentStatusEnum {
   DRAFT
   PREVIEW
   LIVE
   COMPLETE
 }
 
-type NimbusExperimentTargetingConfig {
+type NimbusExperimentTargetingConfigType {
   label: String
   value: String
   applicationValues: [String]
@@ -352,10 +352,10 @@ type NimbusExperimentType {
   parent: NimbusExperimentType
   isRollout: Boolean
   isArchived: Boolean
-  owner: NimbusUser!
-  status: NimbusExperimentStatus
-  statusNext: NimbusExperimentStatus
-  publishStatus: NimbusExperimentPublishStatus
+  owner: NimbusUserType!
+  status: NimbusExperimentStatusEnum
+  statusNext: NimbusExperimentStatusEnum
+  publishStatus: NimbusExperimentPublishStatusEnum
   name: String!
   slug: String!
   publicDescription: String!
@@ -365,10 +365,10 @@ type NimbusExperimentType {
   proposedEnrollment: Int!
   populationPercent: String
   totalEnrolledClients: Int!
-  firefoxMinVersion: NimbusExperimentFirefoxVersion
-  firefoxMaxVersion: NimbusExperimentFirefoxVersion
-  application: NimbusExperimentApplication
-  channel: NimbusExperimentChannel
+  firefoxMinVersion: NimbusExperimentFirefoxVersionEnum
+  firefoxMaxVersion: NimbusExperimentFirefoxVersionEnum
+  application: NimbusExperimentApplicationEnum
+  channel: NimbusExperimentChannelEnum
   locales: [NimbusLocaleType!]!
   countries: [NimbusCountryType!]!
   projects: [ProjectType!]!
@@ -383,7 +383,7 @@ type NimbusExperimentType {
   riskPartnerRelated: Boolean
   riskRevenue: Boolean
   riskBrand: Boolean
-  conclusionRecommendation: NimbusExperimentConclusionRecommendation
+  conclusionRecommendation: NimbusExperimentConclusionRecommendationEnum
   takeawaysSummary: String
   nimbusexperimentSet: [NimbusExperimentType!]!
   documentationLinks: [NimbusDocumentationLinkType!]
@@ -418,7 +418,7 @@ type NimbusFeatureConfigType {
   name: String!
   slug: String!
   description: String
-  application: NimbusExperimentApplication
+  application: NimbusExperimentApplicationEnum
   ownerEmail: String
   schema: String
   readOnly: Boolean!
@@ -464,7 +464,7 @@ type NimbusOutcomeMetricType {
 type NimbusOutcomeType {
   friendlyName: String
   slug: String
-  application: NimbusExperimentApplication
+  application: NimbusExperimentApplicationEnum
   description: String
   isDefault: Boolean
   metrics: [NimbusOutcomeMetricType]
@@ -482,7 +482,7 @@ type NimbusSignoffRecommendationsType {
   legalSignoff: Boolean
 }
 
-type NimbusUser {
+type NimbusUserType {
   id: Int
   username: String!
   firstName: String!
@@ -505,24 +505,24 @@ type Query {
   nimbusConfig: NimbusConfigurationType
 }
 
-input ReferenceBranchType {
+input ReferenceBranchInput {
   id: Int
   name: String!
   description: String!
   ratio: Int!
   featureEnabled: Boolean
   featureValue: String
-  screenshots: [BranchScreenshotType]
+  screenshots: [BranchScreenshotInput]
 }
 
-input TreatmentBranchType {
+input TreatmentBranchInput {
   id: Int
   name: String!
   description: String!
   ratio: Int!
   featureEnabled: Boolean
   featureValue: String
-  screenshots: [BranchScreenshotType]
+  screenshots: [BranchScreenshotInput]
 }
 
 type UpdateExperiment {

--- a/app/experimenter/nimbus-ui/src/components/AppLayoutSidebarLaunched/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/AppLayoutSidebarLaunched/index.stories.tsx
@@ -12,7 +12,7 @@ import {
   MOCK_METADATA_WITH_CONFIG,
 } from "../../lib/visualization/mocks";
 import { AnalysisData } from "../../lib/visualization/types";
-import { NimbusExperimentStatus } from "../../types/globalTypes";
+import { NimbusExperimentStatusEnum } from "../../types/globalTypes";
 
 const Subject = ({
   analysisLoadingInSidebar,
@@ -27,7 +27,7 @@ const Subject = ({
   return (
     <RouterSlugProvider>
       <AppLayoutSidebarLaunched
-        status={mockGetStatus({ status: NimbusExperimentStatus.LIVE })}
+        status={mockGetStatus({ status: NimbusExperimentStatusEnum.LIVE })}
         {...{ analysisLoadingInSidebar, experiment, analysisError, analysis }}
       >
         <p>App contents go here</p>

--- a/app/experimenter/nimbus-ui/src/components/AppLayoutSidebarLaunched/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/AppLayoutSidebarLaunched/index.test.tsx
@@ -20,8 +20,8 @@ import {
 import { AnalysisData } from "../../lib/visualization/types";
 import { getExperiment_experimentBySlug } from "../../types/getExperiment";
 import {
-  NimbusExperimentPublishStatus,
-  NimbusExperimentStatus,
+  NimbusExperimentPublishStatusEnum,
+  NimbusExperimentStatusEnum,
 } from "../../types/globalTypes";
 
 const { mock, experiment: defaultExperiment } = mockExperimentQuery(
@@ -30,8 +30,8 @@ const { mock, experiment: defaultExperiment } = mockExperimentQuery(
 const navLinkSelector = ".navbar a";
 
 const Subject = ({
-  status = NimbusExperimentStatus.COMPLETE,
-  publishStatus = NimbusExperimentPublishStatus.IDLE,
+  status = NimbusExperimentStatusEnum.COMPLETE,
+  publishStatus = NimbusExperimentPublishStatusEnum.IDLE,
   withAnalysis = false,
   analysisError,
   analysis,
@@ -39,8 +39,8 @@ const Subject = ({
   analysisRequired = true,
   experiment = defaultExperiment,
 }: RouteComponentProps & {
-  status?: NimbusExperimentStatus;
-  publishStatus?: NimbusExperimentPublishStatus;
+  status?: NimbusExperimentStatusEnum;
+  publishStatus?: NimbusExperimentPublishStatusEnum;
   withAnalysis?: boolean;
   analysis?: AnalysisData;
   analysisError?: boolean;
@@ -82,7 +82,7 @@ const Subject = ({
 describe("AppLayoutSidebarLaunched", () => {
   describe("navigation links", () => {
     it("when live, hides edit links, displays summary link and disabled results item", () => {
-      render(<Subject status={NimbusExperimentStatus.LIVE} />);
+      render(<Subject status={NimbusExperimentStatusEnum.LIVE} />);
       ["Overview", "Branches", "Metrics", "Audience"].forEach((text) => {
         expect(
           screen.queryByText(text, { selector: navLinkSelector }),
@@ -121,8 +121,8 @@ describe("AppLayoutSidebarLaunched", () => {
     it("does not display waiting to launch message when pending end", () => {
       render(
         <Subject
-          status={NimbusExperimentStatus.COMPLETE}
-          publishStatus={NimbusExperimentPublishStatus.WAITING}
+          status={NimbusExperimentStatusEnum.COMPLETE}
+          publishStatus={NimbusExperimentPublishStatusEnum.WAITING}
         />,
       );
       expect(

--- a/app/experimenter/nimbus-ui/src/components/AppLayoutWithExperiment/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/AppLayoutWithExperiment/index.stories.tsx
@@ -8,8 +8,8 @@ import AppLayoutWithExperiment, { AppLayoutWithExperimentProps } from ".";
 import { mockExperimentQuery } from "../../lib/mocks";
 import { RouterSlugProvider } from "../../lib/test-utils";
 import {
-  NimbusExperimentPublishStatus,
-  NimbusExperimentStatus,
+  NimbusExperimentPublishStatusEnum,
+  NimbusExperimentStatusEnum,
 } from "../../types/globalTypes";
 
 const Subject = ({
@@ -44,13 +44,13 @@ export const StatusDraft = storyWithProps();
 
 export const StatusPreview = storyWithProps(
   mockExperimentQuery("demo-slug", {
-    status: NimbusExperimentStatus.PREVIEW,
+    status: NimbusExperimentStatusEnum.PREVIEW,
   }),
 );
 
 export const StatusLaunched = storyWithProps(
   mockExperimentQuery("demo-slug", {
-    status: NimbusExperimentStatus.LIVE,
+    status: NimbusExperimentStatusEnum.LIVE,
   }),
   {},
   'Status: Launched ("Live" or "Complete")',
@@ -58,7 +58,7 @@ export const StatusLaunched = storyWithProps(
 
 export const PublishStatusReview = storyWithProps(
   mockExperimentQuery("demo-slug", {
-    publishStatus: NimbusExperimentPublishStatus.REVIEW,
+    publishStatus: NimbusExperimentPublishStatusEnum.REVIEW,
   }),
 );
 

--- a/app/experimenter/nimbus-ui/src/components/AppLayoutWithExperiment/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/AppLayoutWithExperiment/index.test.tsx
@@ -11,7 +11,7 @@ import AppLayoutWithExperiment, { POLL_INTERVAL, RedirectCheck } from ".";
 import { BASE_PATH } from "../../lib/constants";
 import { mockExperimentQuery } from "../../lib/mocks";
 import { renderWithRouter, RouterSlugProvider } from "../../lib/test-utils";
-import { NimbusExperimentPublishStatus } from "../../types/globalTypes";
+import { NimbusExperimentPublishStatusEnum } from "../../types/globalTypes";
 
 describe("AppLayoutWithExperiment", () => {
   it("renders as expected with default props", async () => {
@@ -57,7 +57,7 @@ describe("AppLayoutWithExperiment", () => {
     jest.useFakeTimers();
     const { mock: initialMock } = mockExperimentQuery("demo-slug");
     const { mock: updatedMock } = mockExperimentQuery("demo-slug", {
-      publishStatus: NimbusExperimentPublishStatus.WAITING,
+      publishStatus: NimbusExperimentPublishStatusEnum.WAITING,
     });
 
     it("polls useExperiment when the prop is passed in", async () => {
@@ -121,7 +121,7 @@ describe("AppLayoutWithExperiment", () => {
 
   it("can redirect you somewhere else", async () => {
     const { mock, experiment } = mockExperimentQuery("demo-slug", {
-      publishStatus: NimbusExperimentPublishStatus.REVIEW,
+      publishStatus: NimbusExperimentPublishStatusEnum.REVIEW,
     });
 
     render(

--- a/app/experimenter/nimbus-ui/src/components/AppLayoutWithSidebar/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/AppLayoutWithSidebar/index.stories.tsx
@@ -9,8 +9,8 @@ import { SERVER_ERRORS } from "../../lib/constants";
 import { mockChangelog } from "../../lib/mocks";
 import { getExperiment_experimentBySlug } from "../../types/getExperiment";
 import {
-  NimbusExperimentPublishStatus,
-  NimbusExperimentStatus,
+  NimbusExperimentPublishStatusEnum,
+  NimbusExperimentStatusEnum,
 } from "../../types/globalTypes";
 import { Subject } from "./mocks";
 
@@ -45,20 +45,20 @@ export const MissingDetails = storyWithExperimentProps(
 
 export const DraftStatus = storyWithExperimentProps(
   {
-    status: NimbusExperimentStatus.DRAFT,
+    status: NimbusExperimentStatusEnum.DRAFT,
   },
   "Draft status, filled out",
 );
 
 export const PreviewStatus = storyWithExperimentProps({
-  status: NimbusExperimentStatus.PREVIEW,
+  status: NimbusExperimentStatusEnum.PREVIEW,
 });
 
 export const ReviewRequestedCannotReview = storyWithExperimentProps(
   {
-    status: NimbusExperimentStatus.DRAFT,
-    statusNext: NimbusExperimentStatus.LIVE,
-    publishStatus: NimbusExperimentPublishStatus.REVIEW,
+    status: NimbusExperimentStatusEnum.DRAFT,
+    statusNext: NimbusExperimentStatusEnum.LIVE,
+    publishStatus: NimbusExperimentPublishStatusEnum.REVIEW,
     reviewRequest: mockChangelog(),
     canArchive: false,
   },
@@ -67,9 +67,9 @@ export const ReviewRequestedCannotReview = storyWithExperimentProps(
 
 export const ReviewRequestedCanReview = storyWithExperimentProps(
   {
-    status: NimbusExperimentStatus.DRAFT,
-    statusNext: NimbusExperimentStatus.LIVE,
-    publishStatus: NimbusExperimentPublishStatus.REVIEW,
+    status: NimbusExperimentStatusEnum.DRAFT,
+    statusNext: NimbusExperimentStatusEnum.LIVE,
+    publishStatus: NimbusExperimentPublishStatusEnum.REVIEW,
     reviewRequest: mockChangelog(),
     canReview: true,
     canArchive: false,
@@ -79,7 +79,7 @@ export const ReviewRequestedCanReview = storyWithExperimentProps(
 
 export const LiveStatus = storyWithExperimentProps(
   {
-    status: NimbusExperimentStatus.LIVE,
+    status: NimbusExperimentStatusEnum.LIVE,
     canArchive: false,
   },
   "Live status",

--- a/app/experimenter/nimbus-ui/src/components/ChangeApprovalOperations/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/ChangeApprovalOperations/index.tsx
@@ -7,7 +7,7 @@ import Alert from "react-bootstrap/Alert";
 import { EXTERNAL_URLS } from "../../lib/constants";
 import { StatusCheck } from "../../lib/experiment";
 import { getExperiment_experimentBySlug } from "../../types/getExperiment";
-import { NimbusExperimentPublishStatus } from "../../types/globalTypes";
+import { NimbusExperimentPublishStatusEnum } from "../../types/globalTypes";
 import LinkExternal from "../LinkExternal";
 import FormApproveOrReject from "./FormApproveOrReject";
 import FormRejectReason from "./FormRejectReason";
@@ -71,12 +71,12 @@ export const ChangeApprovalOperations: React.FC<
     }
 
     switch (publishStatus) {
-      case NimbusExperimentPublishStatus.APPROVED:
-      case NimbusExperimentPublishStatus.WAITING:
+      case NimbusExperimentPublishStatusEnum.APPROVED:
+      case NimbusExperimentPublishStatusEnum.WAITING:
         return canReview
           ? ChangeApprovalOperationsState.ShowRemoteSettingsPending
           : ChangeApprovalOperationsState.ApprovalPending;
-      case NimbusExperimentPublishStatus.REVIEW:
+      case NimbusExperimentPublishStatusEnum.REVIEW:
         return canReview
           ? ChangeApprovalOperationsState.ShowFormApproveOrReject
           : ChangeApprovalOperationsState.ApprovalPending;

--- a/app/experimenter/nimbus-ui/src/components/ChangeApprovalOperations/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/components/ChangeApprovalOperations/mocks.tsx
@@ -14,7 +14,7 @@ import {
 import {
   NimbusChangeLogOldStatus,
   NimbusChangeLogOldStatusNext,
-  NimbusExperimentPublishStatus,
+  NimbusExperimentPublishStatusEnum,
 } from "../../types/globalTypes";
 
 type BaseSubjectProps = Partial<
@@ -32,7 +32,7 @@ export const BaseSubject = ({
   isLoading = false,
   canReview = false,
   status = getStatus(MOCK_EXPERIMENT),
-  publishStatus = NimbusExperimentPublishStatus.IDLE,
+  publishStatus = NimbusExperimentPublishStatusEnum.IDLE,
   reviewRequestEvent,
   rejectionEvent,
   timeoutEvent,
@@ -71,7 +71,7 @@ export const BaseSubject = ({
 );
 
 export const reviewRequestedBaseProps: BaseSubjectProps = {
-  publishStatus: NimbusExperimentPublishStatus.REVIEW,
+  publishStatus: NimbusExperimentPublishStatusEnum.REVIEW,
   reviewRequestEvent: mockChangelog(
     "abc@def.com",
     null,
@@ -80,7 +80,7 @@ export const reviewRequestedBaseProps: BaseSubjectProps = {
 };
 
 export const reviewApprovedBaseProps: BaseSubjectProps = {
-  publishStatus: NimbusExperimentPublishStatus.APPROVED,
+  publishStatus: NimbusExperimentPublishStatusEnum.APPROVED,
   reviewRequestEvent: mockChangelog(
     "abc@def.com",
     null,
@@ -89,7 +89,7 @@ export const reviewApprovedBaseProps: BaseSubjectProps = {
 };
 
 export const reviewPendingInRemoteSettingsBaseProps: BaseSubjectProps = {
-  publishStatus: NimbusExperimentPublishStatus.WAITING,
+  publishStatus: NimbusExperimentPublishStatusEnum.WAITING,
   reviewRequestEvent: mockChangelog(
     "abc@def.com",
     null,
@@ -98,7 +98,7 @@ export const reviewPendingInRemoteSettingsBaseProps: BaseSubjectProps = {
 };
 
 export const reviewTimedOutBaseProps: BaseSubjectProps = {
-  publishStatus: NimbusExperimentPublishStatus.REVIEW,
+  publishStatus: NimbusExperimentPublishStatusEnum.REVIEW,
   reviewRequestEvent: mockChangelog(
     "abc@def.com",
     null,
@@ -108,7 +108,7 @@ export const reviewTimedOutBaseProps: BaseSubjectProps = {
 };
 
 export const reviewRejectedBaseProps: BaseSubjectProps = {
-  publishStatus: NimbusExperimentPublishStatus.IDLE,
+  publishStatus: NimbusExperimentPublishStatusEnum.IDLE,
   reviewRequestEvent: mockChangelog(
     "abc@def.com",
     null,
@@ -125,7 +125,7 @@ export const reviewRejectedBaseProps: BaseSubjectProps = {
 
 export const reviewRequestedAfterRejectionBaseProps: BaseSubjectProps = {
   ...reviewRejectedBaseProps,
-  publishStatus: NimbusExperimentPublishStatus.REVIEW,
+  publishStatus: NimbusExperimentPublishStatusEnum.REVIEW,
   reviewRequestEvent: mockChangelog(
     "abc@def.com",
     null,
@@ -135,5 +135,5 @@ export const reviewRequestedAfterRejectionBaseProps: BaseSubjectProps = {
 
 export const reviewApprovedAfterTimeoutBaseProps: BaseSubjectProps = {
   ...reviewTimedOutBaseProps,
-  publishStatus: NimbusExperimentPublishStatus.APPROVED,
+  publishStatus: NimbusExperimentPublishStatusEnum.APPROVED,
 };

--- a/app/experimenter/nimbus-ui/src/components/HeaderExperiment/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/HeaderExperiment/index.stories.tsx
@@ -8,8 +8,8 @@ import React from "react";
 import HeaderExperiment from ".";
 import { mockExperimentQuery, mockGetStatus } from "../../lib/mocks";
 import {
-  NimbusExperimentPublishStatus,
-  NimbusExperimentStatus,
+  NimbusExperimentPublishStatusEnum,
+  NimbusExperimentStatusEnum,
 } from "../../types/globalTypes";
 import AppLayout from "../AppLayout";
 
@@ -60,7 +60,7 @@ storiesOf("components/HeaderExperiment", module)
         startDate={experiment.startDate}
         computedEndDate={experiment.computedEndDate}
         computedDurationDays={experiment.computedDurationDays}
-        status={mockGetStatus({ status: NimbusExperimentStatus.PREVIEW })}
+        status={mockGetStatus({ status: NimbusExperimentStatusEnum.PREVIEW })}
         isArchived={false}
         isRollout={false}
       />
@@ -76,7 +76,7 @@ storiesOf("components/HeaderExperiment", module)
         computedEndDate={experiment.computedEndDate}
         computedDurationDays={experiment.computedDurationDays}
         status={mockGetStatus({
-          publishStatus: NimbusExperimentPublishStatus.REVIEW,
+          publishStatus: NimbusExperimentPublishStatusEnum.REVIEW,
         })}
         isArchived={false}
         isRollout={false}
@@ -92,7 +92,7 @@ storiesOf("components/HeaderExperiment", module)
         startDate={experiment.startDate}
         computedEndDate={null}
         computedDurationDays={experiment.computedDurationDays}
-        status={mockGetStatus({ status: NimbusExperimentStatus.LIVE })}
+        status={mockGetStatus({ status: NimbusExperimentStatusEnum.LIVE })}
         isArchived={false}
         isRollout={false}
       />
@@ -107,7 +107,7 @@ storiesOf("components/HeaderExperiment", module)
         startDate={experiment.startDate}
         computedEndDate={experiment.computedEndDate}
         computedDurationDays={experiment.computedDurationDays}
-        status={mockGetStatus({ status: NimbusExperimentStatus.COMPLETE })}
+        status={mockGetStatus({ status: NimbusExperimentStatusEnum.COMPLETE })}
         isArchived={false}
         isRollout={false}
       />
@@ -122,7 +122,7 @@ storiesOf("components/HeaderExperiment", module)
         startDate={experiment.startDate}
         computedEndDate={experiment.computedEndDate}
         computedDurationDays={experiment.computedDurationDays}
-        status={mockGetStatus({ status: NimbusExperimentStatus.COMPLETE })}
+        status={mockGetStatus({ status: NimbusExperimentStatusEnum.COMPLETE })}
         isArchived={true}
         isRollout={false}
       />
@@ -137,7 +137,7 @@ storiesOf("components/HeaderExperiment", module)
         startDate={experiment.startDate}
         computedEndDate={experiment.computedEndDate}
         computedDurationDays={experiment.computedDurationDays}
-        status={mockGetStatus({ status: NimbusExperimentStatus.COMPLETE })}
+        status={mockGetStatus({ status: NimbusExperimentStatusEnum.COMPLETE })}
         isArchived={false}
         isRollout={true}
       />
@@ -152,7 +152,7 @@ storiesOf("components/HeaderExperiment", module)
         startDate={experiment.startDate}
         computedEndDate={experiment.computedEndDate}
         computedDurationDays={experiment.computedDurationDays}
-        status={mockGetStatus({ status: NimbusExperimentStatus.COMPLETE })}
+        status={mockGetStatus({ status: NimbusExperimentStatusEnum.COMPLETE })}
         isArchived={true}
         isRollout={true}
       />

--- a/app/experimenter/nimbus-ui/src/components/HeaderExperiment/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/HeaderExperiment/index.test.tsx
@@ -8,7 +8,7 @@ import HeaderExperiment from ".";
 import { BASE_PATH } from "../../lib/constants";
 import { humanDate } from "../../lib/dateUtils";
 import { mockExperimentQuery, mockGetStatus } from "../../lib/mocks";
-import { NimbusExperimentStatus } from "../../types/globalTypes";
+import { NimbusExperimentStatusEnum } from "../../types/globalTypes";
 
 describe("HeaderExperiment", () => {
   it("renders as expected", () => {
@@ -71,7 +71,7 @@ describe("HeaderExperiment", () => {
 
   it("displays expected dates", () => {
     const { experiment } = mockExperimentQuery("demo-slug", {
-      status: NimbusExperimentStatus.LIVE,
+      status: NimbusExperimentStatusEnum.LIVE,
     });
     render(
       <HeaderExperiment

--- a/app/experimenter/nimbus-ui/src/components/LinkNavSummary/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/LinkNavSummary/index.test.tsx
@@ -7,14 +7,14 @@ import React from "react";
 import LinkNavSummary from ".";
 import { mockGetStatus } from "../../lib/mocks";
 import {
-  NimbusExperimentPublishStatus,
-  NimbusExperimentStatus,
+  NimbusExperimentPublishStatusEnum,
+  NimbusExperimentStatusEnum,
 } from "../../types/globalTypes";
 
 type SubjectProps = {
-  status?: NimbusExperimentStatus;
-  statusNext?: NimbusExperimentStatus | null;
-  publishStatus?: NimbusExperimentPublishStatus;
+  status?: NimbusExperimentStatusEnum;
+  statusNext?: NimbusExperimentStatusEnum | null;
+  publishStatus?: NimbusExperimentPublishStatusEnum;
   isEnrollmentPausePending?: boolean;
   canReview?: boolean;
   showSummaryAction?: boolean;
@@ -22,9 +22,9 @@ type SubjectProps = {
 };
 
 const Subject = ({
-  status = NimbusExperimentStatus.DRAFT,
+  status = NimbusExperimentStatusEnum.DRAFT,
   statusNext = null,
-  publishStatus = NimbusExperimentPublishStatus.IDLE,
+  publishStatus = NimbusExperimentPublishStatusEnum.IDLE,
   isEnrollmentPausePending = false,
   showSummaryAction = true,
   canReview = false,
@@ -64,16 +64,18 @@ describe("LinkNavSummary", () => {
 
   describe("user cannot review", () => {
     it("renders 'Requested Launch' when expected", () => {
-      render(<Subject publishStatus={NimbusExperimentPublishStatus.REVIEW} />);
+      render(
+        <Subject publishStatus={NimbusExperimentPublishStatusEnum.REVIEW} />,
+      );
       expect(screen.queryByText("Requested Launch")).toBeInTheDocument();
     });
 
     it("renders 'Requested End' when expected", () => {
       render(
         <Subject
-          status={NimbusExperimentStatus.LIVE}
-          statusNext={NimbusExperimentStatus.COMPLETE}
-          publishStatus={NimbusExperimentPublishStatus.REVIEW}
+          status={NimbusExperimentStatusEnum.LIVE}
+          statusNext={NimbusExperimentStatusEnum.COMPLETE}
+          publishStatus={NimbusExperimentPublishStatusEnum.REVIEW}
         />,
       );
       expect(screen.queryByText("Requested End")).toBeInTheDocument();
@@ -82,9 +84,9 @@ describe("LinkNavSummary", () => {
     it("renders 'Requested End Enrollment' when expected", () => {
       render(
         <Subject
-          status={NimbusExperimentStatus.LIVE}
-          statusNext={NimbusExperimentStatus.LIVE}
-          publishStatus={NimbusExperimentPublishStatus.REVIEW}
+          status={NimbusExperimentStatusEnum.LIVE}
+          statusNext={NimbusExperimentStatusEnum.LIVE}
+          publishStatus={NimbusExperimentPublishStatusEnum.REVIEW}
           isEnrollmentPausePending={true}
         />,
       );
@@ -98,9 +100,9 @@ describe("LinkNavSummary", () => {
     it("renders 'Review End Request' when expected", () => {
       render(
         <Subject
-          status={NimbusExperimentStatus.LIVE}
-          statusNext={NimbusExperimentStatus.COMPLETE}
-          publishStatus={NimbusExperimentPublishStatus.REVIEW}
+          status={NimbusExperimentStatusEnum.LIVE}
+          statusNext={NimbusExperimentStatusEnum.COMPLETE}
+          publishStatus={NimbusExperimentPublishStatusEnum.REVIEW}
           canReview
         />,
       );
@@ -110,7 +112,7 @@ describe("LinkNavSummary", () => {
     it("renders 'Review Launch Request' when expected", () => {
       render(
         <Subject
-          publishStatus={NimbusExperimentPublishStatus.REVIEW}
+          publishStatus={NimbusExperimentPublishStatusEnum.REVIEW}
           canReview
         />,
       );
@@ -120,9 +122,9 @@ describe("LinkNavSummary", () => {
     it("renders 'Review End Enrollment Request' when expected", () => {
       render(
         <Subject
-          status={NimbusExperimentStatus.LIVE}
-          statusNext={NimbusExperimentStatus.LIVE}
-          publishStatus={NimbusExperimentPublishStatus.REVIEW}
+          status={NimbusExperimentStatusEnum.LIVE}
+          statusNext={NimbusExperimentStatusEnum.LIVE}
+          publishStatus={NimbusExperimentPublishStatusEnum.REVIEW}
           isEnrollmentPausePending={true}
           canReview
         />,

--- a/app/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/index.test.tsx
@@ -20,9 +20,9 @@ import {
 import { MOCK_CONFIG } from "../../../lib/mocks";
 import { assertSerializerMessages } from "../../../lib/test-utils";
 import {
-  NimbusExperimentApplication,
-  NimbusExperimentChannel,
-  NimbusExperimentFirefoxVersion,
+  NimbusExperimentApplicationEnum,
+  NimbusExperimentChannelEnum,
+  NimbusExperimentFirefoxVersionEnum,
 } from "../../../types/globalTypes";
 import { MOCK_EXPERIMENT, Subject } from "./mocks";
 
@@ -32,8 +32,8 @@ describe("FormAudience", () => {
       <Subject
         experiment={{
           ...MOCK_EXPERIMENT,
-          application: NimbusExperimentApplication.DESKTOP,
-          channel: NimbusExperimentChannel.NIGHTLY,
+          application: NimbusExperimentApplicationEnum.DESKTOP,
+          channel: NimbusExperimentChannelEnum.NIGHTLY,
         }}
         config={{
           ...MOCK_CONFIG,
@@ -43,7 +43,7 @@ describe("FormAudience", () => {
           ],
           applicationConfigs: [
             {
-              application: NimbusExperimentApplication.DESKTOP,
+              application: NimbusExperimentApplicationEnum.DESKTOP,
               channels: [{ label: "Nightly", value: "NIGHTLY" }],
               supportsLocaleCountry: true,
             },
@@ -53,14 +53,14 @@ describe("FormAudience", () => {
               label: "No Targeting",
               value: "NO_TARGETING",
               applicationValues: [
-                NimbusExperimentApplication.DESKTOP,
+                NimbusExperimentApplicationEnum.DESKTOP,
                 "TOASTER",
               ],
             },
             {
               label: "Mac Only",
               value: "MAC_ONLY",
-              applicationValues: [NimbusExperimentApplication.DESKTOP],
+              applicationValues: [NimbusExperimentApplicationEnum.DESKTOP],
             },
             {
               label: "Toaster thing",
@@ -110,13 +110,13 @@ describe("FormAudience", () => {
       <Subject
         experiment={{
           ...MOCK_EXPERIMENT,
-          application: NimbusExperimentApplication.DESKTOP,
+          application: NimbusExperimentApplicationEnum.DESKTOP,
         }}
         config={{
           ...MOCK_CONFIG,
           applicationConfigs: [
             {
-              application: NimbusExperimentApplication.DESKTOP,
+              application: NimbusExperimentApplicationEnum.DESKTOP,
               channels: [{ label: "Nightly", value: "NIGHTLY" }],
               supportsLocaleCountry: false,
             },
@@ -174,8 +174,8 @@ describe("FormAudience", () => {
     await screen.findByTestId("FormAudience");
 
     for (const [fieldName, expected] of [
-      ["firefoxMinVersion", NimbusExperimentFirefoxVersion.NO_VERSION],
-      ["firefoxMaxVersion", NimbusExperimentFirefoxVersion.NO_VERSION],
+      ["firefoxMinVersion", NimbusExperimentFirefoxVersionEnum.NO_VERSION],
+      ["firefoxMaxVersion", NimbusExperimentFirefoxVersionEnum.NO_VERSION],
       ["populationPercent", "0.0"],
       ["proposedDuration", "0"],
       ["proposedEnrollment", "0"],
@@ -350,12 +350,12 @@ describe("filterTargetingConfigSlug", () => {
     const expectedNoTargetingLabel = "No Targeting";
     const expectedLabel = "Foo Bar";
     const expectedMissingLabel = "Baz Quux";
-    const application = NimbusExperimentApplication.DESKTOP;
+    const application = NimbusExperimentApplicationEnum.DESKTOP;
     const targetingConfigSlug = [
       {
         label: expectedNoTargetingLabel,
         value: "NO_TARGETING",
-        applicationValues: [application, NimbusExperimentApplication.IOS],
+        applicationValues: [application, NimbusExperimentApplicationEnum.IOS],
       },
       {
         label: expectedLabel,
@@ -365,7 +365,7 @@ describe("filterTargetingConfigSlug", () => {
       {
         label: expectedMissingLabel,
         value: "BAZ_QUUX",
-        applicationValues: [NimbusExperimentApplication.IOS],
+        applicationValues: [NimbusExperimentApplicationEnum.IOS],
       },
     ];
     const result = filterTargetingConfigs(targetingConfigSlug, application);
@@ -390,12 +390,15 @@ const renderSubjectWithDefaultValues = (onSubmit = () => {}) =>
           {
             label: "No Targeting",
             value: "NO_TARGETING",
-            applicationValues: [NimbusExperimentApplication.DESKTOP, "TOASTER"],
+            applicationValues: [
+              NimbusExperimentApplicationEnum.DESKTOP,
+              "TOASTER",
+            ],
           },
           {
             label: "Mac Only",
             value: "MAC_ONLY",
-            applicationValues: [NimbusExperimentApplication.DESKTOP],
+            applicationValues: [NimbusExperimentApplicationEnum.DESKTOP],
           },
           {
             label: "Some toaster thing",
@@ -405,23 +408,23 @@ const renderSubjectWithDefaultValues = (onSubmit = () => {}) =>
         ],
         firefoxVersions: [
           {
-            label: NimbusExperimentFirefoxVersion.NO_VERSION,
-            value: NimbusExperimentFirefoxVersion.NO_VERSION,
+            label: NimbusExperimentFirefoxVersionEnum.NO_VERSION,
+            value: NimbusExperimentFirefoxVersionEnum.NO_VERSION,
           },
         ],
         channels: [
           {
-            label: NimbusExperimentChannel.NO_CHANNEL,
-            value: NimbusExperimentChannel.NO_CHANNEL,
+            label: NimbusExperimentChannelEnum.NO_CHANNEL,
+            value: NimbusExperimentChannelEnum.NO_CHANNEL,
           },
         ],
       }}
       experiment={{
         ...MOCK_EXPERIMENT,
-        application: NimbusExperimentApplication.DESKTOP,
-        firefoxMinVersion: NimbusExperimentFirefoxVersion.NO_VERSION,
-        firefoxMaxVersion: NimbusExperimentFirefoxVersion.NO_VERSION,
-        channel: NimbusExperimentChannel.NO_CHANNEL,
+        application: NimbusExperimentApplicationEnum.DESKTOP,
+        firefoxMinVersion: NimbusExperimentFirefoxVersionEnum.NO_VERSION,
+        firefoxMaxVersion: NimbusExperimentFirefoxVersionEnum.NO_VERSION,
+        channel: NimbusExperimentChannelEnum.NO_CHANNEL,
         populationPercent: "0.0",
         proposedDuration: 0,
         proposedEnrollment: 0,

--- a/app/experimenter/nimbus-ui/src/components/PageEditAudience/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditAudience/index.test.tsx
@@ -14,8 +14,8 @@ import { mockExperimentQuery } from "../../lib/mocks";
 import { RouterSlugProvider } from "../../lib/test-utils";
 import {
   ExperimentInput,
-  NimbusExperimentChannel,
-  NimbusExperimentFirefoxVersion,
+  NimbusExperimentChannelEnum,
+  NimbusExperimentFirefoxVersionEnum,
 } from "../../types/globalTypes";
 import { updateExperiment_updateExperiment } from "../../types/updateExperiment";
 import FormAudience from "./FormAudience";
@@ -98,9 +98,9 @@ describe("PageEditAudience", () => {
 });
 
 const MOCK_FORM_DATA = {
-  channel: NimbusExperimentChannel.NIGHTLY,
-  firefoxMinVersion: NimbusExperimentFirefoxVersion.FIREFOX_83,
-  firefoxMaxVersion: NimbusExperimentFirefoxVersion.FIREFOX_95,
+  channel: NimbusExperimentChannelEnum.NIGHTLY,
+  firefoxMinVersion: NimbusExperimentFirefoxVersionEnum.FIREFOX_83,
+  firefoxMaxVersion: NimbusExperimentFirefoxVersionEnum.FIREFOX_95,
   targetingConfigSlug: "TARGETING_FIRST_RUN",
   populationPercent: "40",
   totalEnrolledClients: 68000,

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/FormScreenshot/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/FormScreenshot/mocks.tsx
@@ -6,9 +6,9 @@ import React from "react";
 import { FormProvider } from "react-hook-form";
 import FormScreenshot from ".";
 import { useForm } from "../../../../hooks";
-import { BranchScreenshotType } from "../../../../types/globalTypes";
+import { BranchScreenshotInput } from "../../../../types/globalTypes";
 
-export const MOCK_SCREENSHOT: BranchScreenshotType = {
+export const MOCK_SCREENSHOT: BranchScreenshotInput = {
   id: 123,
   description: "This is a screenshot",
   image: "/image/that/was/uploaded",

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/reducer/actions.ts
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/reducer/actions.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { BranchScreenshotType } from "../../../../types/globalTypes";
+import { BranchScreenshotInput } from "../../../../types/globalTypes";
 import {
   AnnotatedBranch,
   createAnnotatedBranch,
@@ -328,7 +328,7 @@ function addScreenshotToBranch(
   const { branchIdx } = action;
   let { referenceBranch, treatmentBranches } = state;
 
-  const newScreenshot: BranchScreenshotType = { description: "", image: null };
+  const newScreenshot: BranchScreenshotInput = { description: "", image: null };
 
   if (branchIdx === REFERENCE_BRANCH_IDX && referenceBranch) {
     referenceBranch = {
@@ -412,7 +412,7 @@ function withModifiedBranch(
 }
 
 function withoutScreenshot(
-  screenshots: (BranchScreenshotType | null)[] | null | undefined,
+  screenshots: (BranchScreenshotInput | null)[] | null | undefined,
   idx: number,
 ) {
   if (!screenshots) return [];

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/reducer/state.ts
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/reducer/state.ts
@@ -6,7 +6,7 @@ import {
   getExperiment_experimentBySlug,
   getExperiment_experimentBySlug_treatmentBranches,
 } from "../../../../types/getExperiment";
-import { TreatmentBranchType } from "../../../../types/globalTypes";
+import { TreatmentBranchInput } from "../../../../types/globalTypes";
 
 export type FormBranchesState = Pick<
   getExperiment_experimentBySlug,
@@ -19,7 +19,7 @@ export type FormBranchesState = Pick<
   globalErrors: string[];
 };
 
-export type AnnotatedBranch = Omit<TreatmentBranchType, "id"> & {
+export type AnnotatedBranch = Omit<TreatmentBranchInput, "id"> & {
   id?: number | null;
   key: string;
   isValid: boolean;

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/reducer/update.ts
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/reducer/update.ts
@@ -4,7 +4,7 @@
 
 import { CONTROL_BRANCH_REQUIRED_ERROR } from "../../../../lib/constants";
 import {
-  BranchScreenshotType,
+  BranchScreenshotInput,
   ExperimentInput,
 } from "../../../../types/globalTypes";
 import { AnnotatedBranch, FormBranchesState } from "./state";
@@ -81,9 +81,9 @@ export function extractUpdateBranch(
 }
 
 export function extractUpdateScreenshot(
-  branchScreenshot: BranchScreenshotType,
-  { description, image }: BranchScreenshotType,
-): BranchScreenshotType {
+  branchScreenshot: BranchScreenshotInput,
+  { description, image }: BranchScreenshotInput,
+): BranchScreenshotInput {
   return {
     // Branch screenshot ID should be read-only with respect to the form data
     id: branchScreenshot!.id,

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/index.stories.tsx
@@ -10,14 +10,14 @@ import { SERVER_ERRORS } from "../../lib/constants";
 import { mockExperimentQuery } from "../../lib/mocks";
 import { RouterSlugProvider } from "../../lib/test-utils";
 import { getExperiment_experimentBySlug } from "../../types/getExperiment";
-import { NimbusExperimentApplication } from "../../types/globalTypes";
+import { NimbusExperimentApplicationEnum } from "../../types/globalTypes";
 
 const featureConfig = {
   id: 2,
   name: "Mauris odio erat",
   slug: "mauris-odio-erat",
   description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
-  application: NimbusExperimentApplication.FENIX,
+  application: NimbusExperimentApplicationEnum.FENIX,
   ownerEmail: "dude23@yahoo.com",
   schema: '{ "sample": "schema" }',
 };

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/index.test.tsx
@@ -18,7 +18,7 @@ import { RouterSlugProvider } from "../../lib/test-utils";
 import { getExperiment_experimentBySlug } from "../../types/getExperiment";
 import {
   ExperimentInput,
-  NimbusExperimentApplication,
+  NimbusExperimentApplicationEnum,
 } from "../../types/globalTypes";
 import { updateExperiment_updateExperiment } from "../../types/updateExperiment";
 import FormBranches from "./FormBranches";
@@ -41,7 +41,7 @@ describe("PageEditBranches", () => {
 
   it("renders as expected with experiment data", async () => {
     const { mock, experiment } = mockExperimentQuery("demo-slug", {
-      application: NimbusExperimentApplication.FENIX,
+      application: NimbusExperimentApplicationEnum.FENIX,
     });
     render(<Subject mocks={[mock]} />);
     await waitFor(() => {

--- a/app/experimenter/nimbus-ui/src/components/PageHome/DirectoryTable/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageHome/DirectoryTable/index.stories.tsx
@@ -12,8 +12,8 @@ import DirectoryTable, {
 import { mockDirectoryExperiments } from "../../../lib/mocks";
 import { CurrentLocation, RouterSlugProvider } from "../../../lib/test-utils";
 import {
-  NimbusExperimentPublishStatus,
-  NimbusExperimentStatus,
+  NimbusExperimentPublishStatusEnum,
+  NimbusExperimentStatusEnum,
 } from "../../../types/globalTypes";
 
 const withRouterAndCurrentUrl = (Story: React.FC) => (
@@ -34,18 +34,18 @@ export default {
 const experiments = mockDirectoryExperiments();
 const draftExperiments = experiments.filter(
   ({ status, publishStatus }) =>
-    status === NimbusExperimentStatus.DRAFT &&
-    publishStatus === NimbusExperimentPublishStatus.IDLE,
+    status === NimbusExperimentStatusEnum.DRAFT &&
+    publishStatus === NimbusExperimentPublishStatusEnum.IDLE,
 );
 const liveExperiments = experiments.filter(
   ({ status, publishStatus }) =>
-    status === NimbusExperimentStatus.LIVE &&
-    publishStatus === NimbusExperimentPublishStatus.IDLE,
+    status === NimbusExperimentStatusEnum.LIVE &&
+    publishStatus === NimbusExperimentPublishStatusEnum.IDLE,
 );
 const completedExperiments = experiments.filter(
   ({ status, publishStatus }) =>
-    status === NimbusExperimentStatus.COMPLETE &&
-    publishStatus === NimbusExperimentPublishStatus.IDLE,
+    status === NimbusExperimentStatusEnum.COMPLETE &&
+    publishStatus === NimbusExperimentPublishStatusEnum.IDLE,
 );
 
 export const Basic = () => <DirectoryTable experiments={experiments} />;

--- a/app/experimenter/nimbus-ui/src/components/PageHome/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageHome/index.stories.tsx
@@ -7,7 +7,7 @@ import React from "react";
 import PageHome from ".";
 import { mockDirectoryExperimentsQuery, MockedCache } from "../../lib/mocks";
 import { CurrentLocation, RouterSlugProvider } from "../../lib/test-utils";
-import { NimbusExperimentStatus } from "../../types/globalTypes";
+import { NimbusExperimentStatusEnum } from "../../types/globalTypes";
 
 interface StoryContext {
   args: {
@@ -59,9 +59,9 @@ export const NoExperiments = storyTemplate([mockDirectoryExperimentsQuery([])]);
 
 export const OnlyDrafts = storyTemplate([
   mockDirectoryExperimentsQuery([
-    { status: NimbusExperimentStatus.DRAFT },
-    { status: NimbusExperimentStatus.DRAFT },
-    { status: NimbusExperimentStatus.DRAFT },
-    { status: NimbusExperimentStatus.DRAFT },
+    { status: NimbusExperimentStatusEnum.DRAFT },
+    { status: NimbusExperimentStatusEnum.DRAFT },
+    { status: NimbusExperimentStatusEnum.DRAFT },
+    { status: NimbusExperimentStatusEnum.DRAFT },
   ]),
 ]);

--- a/app/experimenter/nimbus-ui/src/components/PageResults/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/index.stories.tsx
@@ -16,7 +16,7 @@ import {
 } from "../../lib/visualization/mocks";
 import { AnalysisData } from "../../lib/visualization/types";
 import { getExperiment_experimentBySlug } from "../../types/getExperiment";
-import { NimbusExperimentStatus } from "../../types/globalTypes";
+import { NimbusExperimentStatusEnum } from "../../types/globalTypes";
 
 const Subject = ({
   experiment = {},
@@ -26,7 +26,7 @@ const Subject = ({
   analysis?: AnalysisData;
 }) => {
   const { mock } = mockExperimentQuery("demo-slug", {
-    status: NimbusExperimentStatus.COMPLETE,
+    status: NimbusExperimentStatusEnum.COMPLETE,
     ...experiment,
   });
   fetchMock.restore().getOnce("/api/v3/visualization/demo-slug/", analysis);

--- a/app/experimenter/nimbus-ui/src/components/PageResults/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/index.test.tsx
@@ -17,7 +17,7 @@ import {
 } from "../../lib/visualization/mocks";
 import { AnalysisData } from "../../lib/visualization/types";
 import { getExperiment_experimentBySlug } from "../../types/getExperiment";
-import { NimbusExperimentStatus } from "../../types/globalTypes";
+import { NimbusExperimentStatusEnum } from "../../types/globalTypes";
 import AppLayoutWithExperiment from "../AppLayoutWithExperiment";
 
 const Subject = () => (
@@ -75,7 +75,7 @@ describe("PageResults", () => {
 
   it("redirects to the edit overview page if the experiment status is draft", async () => {
     mockExperiment = mockExperimentQuery("demo-slug", {
-      status: NimbusExperimentStatus.DRAFT,
+      status: NimbusExperimentStatusEnum.DRAFT,
     }).experiment;
     render(<Subject />);
     expect(redirectPath).toEqual("edit/overview");
@@ -84,7 +84,7 @@ describe("PageResults", () => {
   it("redirects to the summary page if the visualization flag is set to false", async () => {
     mockAnalysisData = mockAnalysis({ show_analysis: false });
     mockExperiment = mockExperimentQuery("demo-slug", {
-      status: NimbusExperimentStatus.COMPLETE,
+      status: NimbusExperimentStatusEnum.COMPLETE,
     }).experiment;
     render(<Subject />);
     expect(redirectPath).toEqual("");
@@ -93,7 +93,7 @@ describe("PageResults", () => {
   it("redirects to the summary page if the visualization results are not ready", async () => {
     mockAnalysisData = MOCK_UNAVAILABLE_ANALYSIS;
     mockExperiment = mockExperimentQuery("demo-slug", {
-      status: NimbusExperimentStatus.COMPLETE,
+      status: NimbusExperimentStatusEnum.COMPLETE,
     }).experiment;
     render(<Subject />);
     expect(redirectPath).toEqual("");

--- a/app/experimenter/nimbus-ui/src/components/PageSummary/Takeaways/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageSummary/Takeaways/index.stories.tsx
@@ -5,7 +5,7 @@
 import { action } from "@storybook/addon-actions";
 import React from "react";
 import Takeaways from ".";
-import { NimbusExperimentConclusionRecommendation } from "../../../types/globalTypes";
+import { NimbusExperimentConclusionRecommendationEnum } from "../../../types/globalTypes";
 import { Subject as BaseSubject, TAKEAWAYS_SUMMARY_LONG } from "./mocks";
 
 export default {
@@ -27,7 +27,7 @@ export const Blank = () => <Subject />;
 const commonContent = {
   takeawaysSummary: TAKEAWAYS_SUMMARY_LONG,
   conclusionRecommendation:
-    NimbusExperimentConclusionRecommendation.CHANGE_COURSE,
+    NimbusExperimentConclusionRecommendationEnum.CHANGE_COURSE,
 };
 
 export const WithContent = () => <Subject {...commonContent} />;

--- a/app/experimenter/nimbus-ui/src/components/PageSummary/Takeaways/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageSummary/Takeaways/index.test.tsx
@@ -20,12 +20,12 @@ import {
   mockExperimentQuery,
 } from "../../../lib/mocks";
 import { getExperiment_experimentBySlug } from "../../../types/getExperiment";
-import { NimbusExperimentConclusionRecommendation } from "../../../types/globalTypes";
+import { NimbusExperimentConclusionRecommendationEnum } from "../../../types/globalTypes";
 import { Subject as BaseSubject } from "./mocks";
 
 const { experiment } = mockExperimentQuery("demo-slug", {
   takeawaysSummary: "old content",
-  conclusionRecommendation: NimbusExperimentConclusionRecommendation.RERUN,
+  conclusionRecommendation: NimbusExperimentConclusionRecommendationEnum.RERUN,
 });
 
 const Subject = ({
@@ -37,7 +37,7 @@ const Subject = ({
 
 const takeawaysSummary = "sample *exciting* content";
 const conclusionRecommendation =
-  NimbusExperimentConclusionRecommendation.CHANGE_COURSE;
+  NimbusExperimentConclusionRecommendationEnum.CHANGE_COURSE;
 const expectedConclusionRecommendationLabel = "Change course";
 
 describe("Takeaways", () => {
@@ -214,7 +214,7 @@ describe("TakeawaysEditor", () => {
 describe("useTakeaways", () => {
   const submitData = {
     takeawaysSummary: "super exciting results",
-    conclusionRecommendation: NimbusExperimentConclusionRecommendation.STOP,
+    conclusionRecommendation: NimbusExperimentConclusionRecommendationEnum.STOP,
   };
   const mutationVariables = {
     id: experiment.id,

--- a/app/experimenter/nimbus-ui/src/components/PageSummary/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageSummary/index.stories.tsx
@@ -10,9 +10,9 @@ import { mockExperimentQuery } from "../../lib/mocks";
 import { RouterSlugProvider } from "../../lib/test-utils";
 import { getExperiment_experimentBySlug } from "../../types/getExperiment";
 import {
-  NimbusExperimentConclusionRecommendation,
-  NimbusExperimentPublishStatus,
-  NimbusExperimentStatus,
+  NimbusExperimentConclusionRecommendationEnum,
+  NimbusExperimentPublishStatusEnum,
+  NimbusExperimentStatusEnum,
 } from "../../types/globalTypes";
 import {
   endPendingBaseProps,
@@ -66,8 +66,8 @@ export const missingRequiredFields = storyWithExperimentProps(
 
 export const draftStatus = storyWithExperimentProps(
   {
-    status: NimbusExperimentStatus.DRAFT,
-    publishStatus: NimbusExperimentPublishStatus.IDLE,
+    status: NimbusExperimentStatusEnum.DRAFT,
+    publishStatus: NimbusExperimentPublishStatusEnum.IDLE,
   },
   "Draft status, no missing fields",
 );
@@ -82,8 +82,8 @@ export const draftArchived = storyWithExperimentProps(
 
 export const previewStatus = storyWithExperimentProps(
   {
-    status: NimbusExperimentStatus.PREVIEW,
-    publishStatus: NimbusExperimentPublishStatus.IDLE,
+    status: NimbusExperimentStatusEnum.PREVIEW,
+    publishStatus: NimbusExperimentPublishStatusEnum.IDLE,
     signoffRecommendations: {
       qaSignoff: true,
       vpSignoff: false,
@@ -142,7 +142,7 @@ export const reviewRejected = storyWithExperimentProps(
 
 export const liveStatus = storyWithExperimentProps(
   {
-    status: NimbusExperimentStatus.LIVE,
+    status: NimbusExperimentStatusEnum.LIVE,
     isEnrollmentPaused: false,
   },
   "Live status",
@@ -220,16 +220,17 @@ export const endTimedoutCannotReview = storyWithExperimentProps(
 
 export const completeStatus = storyWithExperimentProps(
   {
-    status: NimbusExperimentStatus.COMPLETE,
+    status: NimbusExperimentStatusEnum.COMPLETE,
   },
   "Complete status",
 );
 
 export const completeStatusWithTakeaways = storyWithExperimentProps(
   {
-    status: NimbusExperimentStatus.COMPLETE,
+    status: NimbusExperimentStatusEnum.COMPLETE,
     takeawaysSummary: TAKEAWAYS_SUMMARY_LONG,
-    conclusionRecommendation: NimbusExperimentConclusionRecommendation.RERUN,
+    conclusionRecommendation:
+      NimbusExperimentConclusionRecommendationEnum.RERUN,
   },
   "Complete status with takeaways",
 );

--- a/app/experimenter/nimbus-ui/src/components/PageSummary/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageSummary/index.test.tsx
@@ -14,8 +14,8 @@ import React from "react";
 import { CHANGELOG_MESSAGES, SERVER_ERRORS } from "../../lib/constants";
 import { mockExperimentQuery } from "../../lib/mocks";
 import {
-  NimbusExperimentPublishStatus,
-  NimbusExperimentStatus,
+  NimbusExperimentPublishStatusEnum,
+  NimbusExperimentStatusEnum,
 } from "../../types/globalTypes";
 import { createMutationMock } from "../Summary/mocks";
 import {
@@ -88,7 +88,7 @@ describe("PageSummary", () => {
   it("hides signoff section if experiment is launched", async () => {
     // this table is shown in the Summary component instead
     const { mock } = mockExperimentQuery("demo-slug", {
-      status: NimbusExperimentStatus.LIVE,
+      status: NimbusExperimentStatusEnum.LIVE,
     });
     render(<Subject mocks={[mock]} />);
     await waitFor(() => {
@@ -100,7 +100,7 @@ describe("PageSummary", () => {
 
   it("hides takeaways section if experiment is not complete", async () => {
     const { mock } = mockExperimentQuery("demo-slug", {
-      status: NimbusExperimentStatus.DRAFT,
+      status: NimbusExperimentStatusEnum.DRAFT,
     });
     render(<Subject mocks={[mock]} />);
     await screen.findByTestId("PageSummary");
@@ -109,7 +109,7 @@ describe("PageSummary", () => {
 
   it("reveals takeaways section if experiment is complete", async () => {
     const { mock } = mockExperimentQuery("demo-slug", {
-      status: NimbusExperimentStatus.COMPLETE,
+      status: NimbusExperimentStatusEnum.COMPLETE,
     });
     render(<Subject mocks={[mock]} />);
     await screen.findByTestId("PageSummary");
@@ -133,7 +133,7 @@ describe("PageSummary", () => {
 
   it("indicates status in review", async () => {
     const { mock } = mockExperimentQuery("demo-slug", {
-      publishStatus: NimbusExperimentPublishStatus.APPROVED,
+      publishStatus: NimbusExperimentPublishStatusEnum.APPROVED,
     });
     render(<Subject mocks={[mock]} />);
     await waitFor(() =>
@@ -143,7 +143,7 @@ describe("PageSummary", () => {
 
   it("indicates status in preview", async () => {
     const { mock } = mockExperimentQuery("demo-slug", {
-      status: NimbusExperimentStatus.PREVIEW,
+      status: NimbusExperimentStatusEnum.PREVIEW,
     });
     render(<Subject mocks={[mock]} />);
     await screen.findByTestId("in-preview-label");
@@ -151,11 +151,11 @@ describe("PageSummary", () => {
 
   it("handles Launch to Preview from Draft as expected", async () => {
     const { mock, experiment } = mockExperimentQuery("demo-slug", {
-      status: NimbusExperimentStatus.DRAFT,
+      status: NimbusExperimentStatusEnum.DRAFT,
     });
     const mutationMock = createStatusMutationMock(
       experiment.id!,
-      NimbusExperimentStatus.PREVIEW,
+      NimbusExperimentStatusEnum.PREVIEW,
       CHANGELOG_MESSAGES.LAUNCHED_TO_PREVIEW,
     );
     render(<Subject mocks={[mock, mutationMock]} />);
@@ -167,13 +167,13 @@ describe("PageSummary", () => {
 
   it("handles Launch without Preview from Draft as expected", async () => {
     const { mock, experiment } = mockExperimentQuery("demo-slug", {
-      status: NimbusExperimentStatus.DRAFT,
+      status: NimbusExperimentStatusEnum.DRAFT,
     });
     const mutationMock = createFullStatusMutationMock(
       experiment.id!,
-      NimbusExperimentStatus.DRAFT,
-      NimbusExperimentStatus.LIVE,
-      NimbusExperimentPublishStatus.REVIEW,
+      NimbusExperimentStatusEnum.DRAFT,
+      NimbusExperimentStatusEnum.LIVE,
+      NimbusExperimentPublishStatusEnum.REVIEW,
       CHANGELOG_MESSAGES.REQUESTED_REVIEW,
     );
     render(<Subject mocks={[mock, mutationMock]} />);
@@ -182,7 +182,7 @@ describe("PageSummary", () => {
 
   it("handles cancelled Launch to Review as expected", async () => {
     const { mock, experiment } = mockExperimentQuery("demo-slug", {
-      status: NimbusExperimentStatus.DRAFT,
+      status: NimbusExperimentStatusEnum.DRAFT,
     });
     const mutationMock = createStatusMutationMock(experiment.id!);
     render(<Subject mocks={[mock, mutationMock]} />);
@@ -200,11 +200,11 @@ describe("PageSummary", () => {
 
   it("handles Launch to Preview after reconsidering Launch to Review from Draft", async () => {
     const { mock, experiment } = mockExperimentQuery("demo-slug", {
-      status: NimbusExperimentStatus.DRAFT,
+      status: NimbusExperimentStatusEnum.DRAFT,
     });
     const mutationMock = createStatusMutationMock(
       experiment.id!,
-      NimbusExperimentStatus.PREVIEW,
+      NimbusExperimentStatusEnum.PREVIEW,
       CHANGELOG_MESSAGES.LAUNCHED_TO_PREVIEW,
     );
     render(<Subject mocks={[mock, mutationMock]} />);
@@ -222,11 +222,11 @@ describe("PageSummary", () => {
 
   it("handles Back to Draft from Preview", async () => {
     const { mock, experiment } = mockExperimentQuery("demo-slug", {
-      status: NimbusExperimentStatus.PREVIEW,
+      status: NimbusExperimentStatusEnum.PREVIEW,
     });
     const mutationMock = createStatusMutationMock(
       experiment.id!,
-      NimbusExperimentStatus.DRAFT,
+      NimbusExperimentStatusEnum.DRAFT,
       CHANGELOG_MESSAGES.RETURNED_TO_DRAFT,
     );
     render(<Subject mocks={[mock, mutationMock]} />);
@@ -238,7 +238,7 @@ describe("PageSummary", () => {
 
   it("can go back to Draft from Preview with invalid experiment info", async () => {
     const { mock } = mockExperimentQuery("demo-slug", {
-      status: NimbusExperimentStatus.PREVIEW,
+      status: NimbusExperimentStatusEnum.PREVIEW,
       readyForReview: {
         ready: false,
         message: {
@@ -260,9 +260,9 @@ describe("PageSummary", () => {
     });
     const mutationMock = createFullStatusMutationMock(
       experiment.id!,
-      NimbusExperimentStatus.DRAFT,
-      NimbusExperimentStatus.LIVE,
-      NimbusExperimentPublishStatus.APPROVED,
+      NimbusExperimentStatusEnum.DRAFT,
+      NimbusExperimentStatusEnum.LIVE,
+      NimbusExperimentPublishStatusEnum.APPROVED,
       CHANGELOG_MESSAGES.REVIEW_APPROVED,
     );
     render(<Subject mocks={[mock, mock, mutationMock]} />);
@@ -286,9 +286,9 @@ describe("PageSummary", () => {
     });
     const mutationMock = createFullStatusMutationMock(
       experiment.id!,
-      NimbusExperimentStatus.DRAFT,
+      NimbusExperimentStatusEnum.DRAFT,
       null,
-      NimbusExperimentPublishStatus.IDLE,
+      NimbusExperimentPublishStatusEnum.IDLE,
       expectedReason,
     );
     render(<Subject mocks={[mock, mutationMock]} />);
@@ -306,7 +306,7 @@ describe("PageSummary", () => {
 
   it("handles submission with server API error", async () => {
     const { mock, experiment } = mockExperimentQuery("demo-slug", {
-      status: NimbusExperimentStatus.DRAFT,
+      status: NimbusExperimentStatusEnum.DRAFT,
     });
     const mutationMock = createStatusMutationMock(experiment.id!);
     mutationMock.result.errors = [new Error("Boo")];
@@ -320,13 +320,13 @@ describe("PageSummary", () => {
   // TODO: #6802
   // it("handles submission with server-side validation errors", async () => {
   //   const { mock, experiment } = mockExperimentQuery("demo-slug", {
-  //     status: NimbusExperimentStatus.DRAFT,
+  //     status: NimbusExperimentStatusEnum.DRAFT,
   //   });
   //   const mutationMock = createFullStatusMutationMock(
   //     experiment.id!,
-  //     NimbusExperimentStatus.DRAFT,
-  //     NimbusExperimentStatus.LIVE,
-  //     NimbusExperimentPublishStatus.REVIEW,
+  //     NimbusExperimentStatusEnum.DRAFT,
+  //     NimbusExperimentStatusEnum.LIVE,
+  //     NimbusExperimentPublishStatusEnum.REVIEW,
   //     CHANGELOG_MESSAGES.REQUESTED_REVIEW,
   //   );
   //   const errorMessage = "Something went very wrong.";
@@ -351,7 +351,7 @@ describe("PageSummary", () => {
     });
     const mutationMock = createMutationMock(
       experiment.id!,
-      NimbusExperimentPublishStatus.IDLE,
+      NimbusExperimentPublishStatusEnum.IDLE,
       { statusNext: null, changelogMessage: expectedReason },
     );
     render(<Subject mocks={[mock, mutationMock]} />);
@@ -377,7 +377,7 @@ describe("PageSummary", () => {
     });
     const mutationMock = createMutationMock(
       experiment.id!,
-      NimbusExperimentPublishStatus.APPROVED,
+      NimbusExperimentPublishStatusEnum.APPROVED,
       { changelogMessage: CHANGELOG_MESSAGES.END_APPROVED },
     );
     render(<Subject mocks={[mock, mutationMock]} />);
@@ -402,7 +402,7 @@ describe("PageSummary", () => {
     });
     const mutationMock = createMutationMock(
       experiment.id!,
-      NimbusExperimentPublishStatus.IDLE,
+      NimbusExperimentPublishStatusEnum.IDLE,
       { statusNext: null, changelogMessage: expectedReason },
     );
     render(<Subject mocks={[mock, mutationMock]} />);
@@ -428,7 +428,7 @@ describe("PageSummary", () => {
     });
     const mutationMock = createMutationMock(
       experiment.id!,
-      NimbusExperimentPublishStatus.APPROVED,
+      NimbusExperimentPublishStatusEnum.APPROVED,
       { changelogMessage: CHANGELOG_MESSAGES.END_APPROVED },
     );
     render(<Subject mocks={[mock, mutationMock]} />);
@@ -463,7 +463,7 @@ describe("PageSummary", () => {
 
   it("will not allow submitting if already in review", async () => {
     const { mock } = mockExperimentQuery("demo-slug", {
-      publishStatus: NimbusExperimentPublishStatus.APPROVED,
+      publishStatus: NimbusExperimentPublishStatusEnum.APPROVED,
     });
     render(<Subject mocks={[mock]} />);
     await waitFor(() =>

--- a/app/experimenter/nimbus-ui/src/components/PageSummary/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageSummary/index.tsx
@@ -13,8 +13,8 @@ import {
 import { getStatus, getSummaryAction } from "../../lib/experiment";
 import { getExperiment_experimentBySlug } from "../../types/getExperiment";
 import {
-  NimbusExperimentPublishStatus,
-  NimbusExperimentStatus,
+  NimbusExperimentPublishStatusEnum,
+  NimbusExperimentStatusEnum,
 } from "../../types/globalTypes";
 import AppLayoutWithExperiment from "../AppLayoutWithExperiment";
 import ChangeApprovalOperations from "../ChangeApprovalOperations";
@@ -71,53 +71,53 @@ const PageContent: React.FC<{
     experiment,
     refetch,
     {
-      status: NimbusExperimentStatus.PREVIEW,
+      status: NimbusExperimentStatusEnum.PREVIEW,
       changelogMessage: CHANGELOG_MESSAGES.LAUNCHED_TO_PREVIEW,
     },
     {
-      status: NimbusExperimentStatus.DRAFT,
+      status: NimbusExperimentStatusEnum.DRAFT,
       changelogMessage: CHANGELOG_MESSAGES.RETURNED_TO_DRAFT,
     },
     {
-      status: NimbusExperimentStatus.DRAFT,
-      statusNext: NimbusExperimentStatus.LIVE,
-      publishStatus: NimbusExperimentPublishStatus.REVIEW,
+      status: NimbusExperimentStatusEnum.DRAFT,
+      statusNext: NimbusExperimentStatusEnum.LIVE,
+      publishStatus: NimbusExperimentPublishStatusEnum.REVIEW,
       changelogMessage: CHANGELOG_MESSAGES.REQUESTED_REVIEW,
     },
     {
-      status: NimbusExperimentStatus.DRAFT,
-      statusNext: NimbusExperimentStatus.LIVE,
-      publishStatus: NimbusExperimentPublishStatus.APPROVED,
+      status: NimbusExperimentStatusEnum.DRAFT,
+      statusNext: NimbusExperimentStatusEnum.LIVE,
+      publishStatus: NimbusExperimentPublishStatusEnum.APPROVED,
       changelogMessage: CHANGELOG_MESSAGES.REVIEW_APPROVED,
     },
     {
-      status: NimbusExperimentStatus.DRAFT,
+      status: NimbusExperimentStatusEnum.DRAFT,
       statusNext: null,
-      publishStatus: NimbusExperimentPublishStatus.IDLE,
+      publishStatus: NimbusExperimentPublishStatusEnum.IDLE,
     },
     {
-      status: NimbusExperimentStatus.LIVE,
-      statusNext: NimbusExperimentStatus.COMPLETE,
-      publishStatus: NimbusExperimentPublishStatus.APPROVED,
+      status: NimbusExperimentStatusEnum.LIVE,
+      statusNext: NimbusExperimentStatusEnum.COMPLETE,
+      publishStatus: NimbusExperimentPublishStatusEnum.APPROVED,
       changelogMessage: CHANGELOG_MESSAGES.END_APPROVED,
     },
     {
-      status: NimbusExperimentStatus.LIVE,
+      status: NimbusExperimentStatusEnum.LIVE,
       statusNext: null,
-      publishStatus: NimbusExperimentPublishStatus.IDLE,
+      publishStatus: NimbusExperimentPublishStatusEnum.IDLE,
     },
     {
-      status: NimbusExperimentStatus.LIVE,
-      statusNext: NimbusExperimentStatus.LIVE,
-      publishStatus: NimbusExperimentPublishStatus.APPROVED,
+      status: NimbusExperimentStatusEnum.LIVE,
+      statusNext: NimbusExperimentStatusEnum.LIVE,
+      publishStatus: NimbusExperimentPublishStatusEnum.APPROVED,
       isEnrollmentPaused: true,
       changelogMessage: CHANGELOG_MESSAGES.END_ENROLLMENT_APPROVED,
     },
     {
-      status: NimbusExperimentStatus.LIVE,
+      status: NimbusExperimentStatusEnum.LIVE,
       statusNext: null,
       isEnrollmentPaused: false,
-      publishStatus: NimbusExperimentPublishStatus.IDLE,
+      publishStatus: NimbusExperimentPublishStatusEnum.IDLE,
     },
   );
 

--- a/app/experimenter/nimbus-ui/src/components/PageSummary/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageSummary/mocks.tsx
@@ -16,15 +16,15 @@ import { RouterSlugProvider } from "../../lib/test-utils";
 import {
   NimbusChangeLogOldStatus,
   NimbusChangeLogOldStatusNext,
-  NimbusExperimentPublishStatus,
-  NimbusExperimentStatus,
+  NimbusExperimentPublishStatusEnum,
+  NimbusExperimentStatusEnum,
 } from "../../types/globalTypes";
 
 export const { mock, experiment } = mockExperimentQuery("demo-slug");
 
 export function createStatusMutationMock(
   id: number,
-  status = NimbusExperimentStatus.DRAFT,
+  status = NimbusExperimentStatusEnum.DRAFT,
   changelogMessage = CHANGELOG_MESSAGES.RETURNED_TO_DRAFT as string,
 ) {
   return mockExperimentMutation(
@@ -45,9 +45,9 @@ export function createStatusMutationMock(
 
 export function createFullStatusMutationMock(
   id: number,
-  status = NimbusExperimentStatus.DRAFT,
-  statusNext = null as NimbusExperimentStatus | null,
-  publishStatus = NimbusExperimentPublishStatus.IDLE,
+  status = NimbusExperimentStatusEnum.DRAFT,
+  statusNext = null as NimbusExperimentStatusEnum | null,
+  publishStatus = NimbusExperimentPublishStatusEnum.IDLE,
   changelogMessage?: string,
 ) {
   return mockExperimentMutation(
@@ -71,31 +71,31 @@ export const Subject = ({
 };
 
 export const reviewRequestedBaseProps = {
-  status: NimbusExperimentStatus.DRAFT,
-  statusNext: NimbusExperimentStatus.LIVE,
-  publishStatus: NimbusExperimentPublishStatus.REVIEW,
+  status: NimbusExperimentStatusEnum.DRAFT,
+  statusNext: NimbusExperimentStatusEnum.LIVE,
+  publishStatus: NimbusExperimentPublishStatusEnum.REVIEW,
   reviewRequest: mockChangelog(),
 };
 
 export const reviewPendingBaseProps = {
-  status: NimbusExperimentStatus.DRAFT,
-  statusNext: NimbusExperimentStatus.LIVE,
-  publishStatus: NimbusExperimentPublishStatus.WAITING,
+  status: NimbusExperimentStatusEnum.DRAFT,
+  statusNext: NimbusExperimentStatusEnum.LIVE,
+  publishStatus: NimbusExperimentPublishStatusEnum.WAITING,
   reviewRequest: mockChangelog(),
 };
 
 export const reviewTimedoutBaseProps = {
-  status: NimbusExperimentStatus.DRAFT,
-  statusNext: NimbusExperimentStatus.LIVE,
-  publishStatus: NimbusExperimentPublishStatus.REVIEW,
+  status: NimbusExperimentStatusEnum.DRAFT,
+  statusNext: NimbusExperimentStatusEnum.LIVE,
+  publishStatus: NimbusExperimentPublishStatusEnum.REVIEW,
   reviewRequest: mockChangelog(),
   timeout: mockChangelog("def@mozilla.com"),
 };
 
 export const reviewRejectedBaseProps = {
-  status: NimbusExperimentStatus.DRAFT,
+  status: NimbusExperimentStatusEnum.DRAFT,
   statusNext: null,
-  publishStatus: NimbusExperimentPublishStatus.IDLE,
+  publishStatus: NimbusExperimentPublishStatusEnum.IDLE,
   reviewRequest: mockChangelog(),
   rejection: mockRejectionChangelog(
     "def@mozilla.com",
@@ -107,25 +107,25 @@ export const reviewRejectedBaseProps = {
 
 export const endReviewRequestedBaseProps = {
   ...reviewRequestedBaseProps,
-  status: NimbusExperimentStatus.LIVE,
-  statusNext: NimbusExperimentStatus.COMPLETE,
+  status: NimbusExperimentStatusEnum.LIVE,
+  statusNext: NimbusExperimentStatusEnum.COMPLETE,
 };
 
 export const endPendingBaseProps = {
   ...reviewPendingBaseProps,
-  status: NimbusExperimentStatus.LIVE,
-  statusNext: NimbusExperimentStatus.COMPLETE,
+  status: NimbusExperimentStatusEnum.LIVE,
+  statusNext: NimbusExperimentStatusEnum.COMPLETE,
 };
 
 export const endTimedoutBaseProps = {
   ...reviewTimedoutBaseProps,
-  status: NimbusExperimentStatus.LIVE,
-  statusNext: NimbusExperimentStatus.COMPLETE,
+  status: NimbusExperimentStatusEnum.LIVE,
+  statusNext: NimbusExperimentStatusEnum.COMPLETE,
 };
 
 export const endRejectedBaseProps = {
   ...reviewRejectedBaseProps,
-  status: NimbusExperimentStatus.LIVE,
+  status: NimbusExperimentStatusEnum.LIVE,
   rejection: mockRejectionChangelog(
     "def@mozilla.com",
     "Let this run a bit longer",
@@ -136,31 +136,31 @@ export const endRejectedBaseProps = {
 
 export const enrollmentPauseReviewRequestedBaseProps = {
   ...reviewRequestedBaseProps,
-  status: NimbusExperimentStatus.LIVE,
-  statusNext: NimbusExperimentStatus.LIVE,
+  status: NimbusExperimentStatusEnum.LIVE,
+  statusNext: NimbusExperimentStatusEnum.LIVE,
   isEnrollmentPaused: false,
   isEnrollmentPausePending: true,
 };
 
 export const enrollmentPausePendingBaseProps = {
   ...reviewPendingBaseProps,
-  status: NimbusExperimentStatus.LIVE,
-  statusNext: NimbusExperimentStatus.LIVE,
+  status: NimbusExperimentStatusEnum.LIVE,
+  statusNext: NimbusExperimentStatusEnum.LIVE,
   isEnrollmentPaused: false,
   isEnrollmentPausePending: true,
 };
 
 export const enrollmentPauseTimedoutBaseProps = {
   ...reviewTimedoutBaseProps,
-  status: NimbusExperimentStatus.LIVE,
-  statusNext: NimbusExperimentStatus.LIVE,
+  status: NimbusExperimentStatusEnum.LIVE,
+  statusNext: NimbusExperimentStatusEnum.LIVE,
   isEnrollmentPaused: false,
   isEnrollmentPausePending: true,
 };
 
 export const enrollmentPauseRejectedBaseProps = {
   ...reviewRejectedBaseProps,
-  status: NimbusExperimentStatus.LIVE,
+  status: NimbusExperimentStatusEnum.LIVE,
   statusNext: null,
   isEnrollmentPaused: false,
   isEnrollmentPausePending: false,

--- a/app/experimenter/nimbus-ui/src/components/PageSummaryDetails/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageSummaryDetails/index.stories.tsx
@@ -7,8 +7,8 @@ import React from "react";
 import { mockExperimentQuery } from "../../lib/mocks";
 import { getExperiment_experimentBySlug } from "../../types/getExperiment";
 import {
-  NimbusExperimentPublishStatus,
-  NimbusExperimentStatus,
+  NimbusExperimentPublishStatusEnum,
+  NimbusExperimentStatusEnum,
 } from "../../types/globalTypes";
 import { Subject } from "./mocks";
 
@@ -32,8 +32,8 @@ export default {
 
 export const draftStatus = storyWithExperimentProps(
   {
-    status: NimbusExperimentStatus.DRAFT,
-    publishStatus: NimbusExperimentPublishStatus.IDLE,
+    status: NimbusExperimentStatusEnum.DRAFT,
+    publishStatus: NimbusExperimentPublishStatusEnum.IDLE,
   },
   "Draft status, no missing fields",
 );
@@ -48,8 +48,8 @@ export const draftArchived = storyWithExperimentProps(
 
 export const previewStatus = storyWithExperimentProps(
   {
-    status: NimbusExperimentStatus.PREVIEW,
-    publishStatus: NimbusExperimentPublishStatus.IDLE,
+    status: NimbusExperimentStatusEnum.PREVIEW,
+    publishStatus: NimbusExperimentPublishStatusEnum.IDLE,
     signoffRecommendations: {
       qaSignoff: true,
       vpSignoff: false,
@@ -61,7 +61,7 @@ export const previewStatus = storyWithExperimentProps(
 
 export const liveStatus = storyWithExperimentProps(
   {
-    status: NimbusExperimentStatus.LIVE,
+    status: NimbusExperimentStatusEnum.LIVE,
     isEnrollmentPaused: false,
   },
   "Live status",
@@ -69,7 +69,7 @@ export const liveStatus = storyWithExperimentProps(
 
 export const liveStatusPaused = storyWithExperimentProps(
   {
-    status: NimbusExperimentStatus.LIVE,
+    status: NimbusExperimentStatusEnum.LIVE,
     isEnrollmentPaused: true,
     enrollmentEndDate: new Date().toISOString(),
   },
@@ -78,14 +78,14 @@ export const liveStatusPaused = storyWithExperimentProps(
 
 export const completeStatus = storyWithExperimentProps(
   {
-    status: NimbusExperimentStatus.COMPLETE,
+    status: NimbusExperimentStatusEnum.COMPLETE,
   },
   "Complete status",
 );
 
 export const completeArchived = storyWithExperimentProps(
   {
-    status: NimbusExperimentStatus.COMPLETE,
+    status: NimbusExperimentStatusEnum.COMPLETE,
     isArchived: true,
     canEdit: false,
   },

--- a/app/experimenter/nimbus-ui/src/components/PreviewURL/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PreviewURL/index.test.tsx
@@ -7,7 +7,7 @@ import React from "react";
 import selectEvent from "react-select-event";
 import PreviewURL from ".";
 import { mockExperimentQuery, mockGetStatus } from "../../lib/mocks";
-import { NimbusExperimentStatus } from "../../types/globalTypes";
+import { NimbusExperimentStatusEnum } from "../../types/globalTypes";
 
 const { experiment } = mockExperimentQuery("preview-url-slug");
 
@@ -24,7 +24,7 @@ describe("PreviewURL", () => {
     render(
       <PreviewURL
         {...experiment}
-        status={mockGetStatus({ status: NimbusExperimentStatus.LIVE })}
+        status={mockGetStatus({ status: NimbusExperimentStatusEnum.LIVE })}
       />,
     );
 
@@ -34,7 +34,7 @@ describe("PreviewURL", () => {
     render(
       <PreviewURL
         {...experiment}
-        status={mockGetStatus({ status: NimbusExperimentStatus.PREVIEW })}
+        status={mockGetStatus({ status: NimbusExperimentStatusEnum.PREVIEW })}
       />,
     );
 
@@ -45,7 +45,7 @@ describe("PreviewURL", () => {
       <PreviewURL
         {...experiment}
         application={null}
-        status={mockGetStatus({ status: NimbusExperimentStatus.LIVE })}
+        status={mockGetStatus({ status: NimbusExperimentStatusEnum.LIVE })}
       />,
     );
 
@@ -56,7 +56,7 @@ describe("PreviewURL", () => {
       <PreviewURL
         {...experiment}
         referenceBranch={null}
-        status={mockGetStatus({ status: NimbusExperimentStatus.LIVE })}
+        status={mockGetStatus({ status: NimbusExperimentStatusEnum.LIVE })}
       />,
     );
 
@@ -66,7 +66,7 @@ describe("PreviewURL", () => {
     render(
       <PreviewURL
         {...experiment}
-        status={mockGetStatus({ status: NimbusExperimentStatus.LIVE })}
+        status={mockGetStatus({ status: NimbusExperimentStatusEnum.LIVE })}
       />,
     );
 
@@ -80,7 +80,7 @@ describe("PreviewURL", () => {
     render(
       <PreviewURL
         {...experiment}
-        status={mockGetStatus({ status: NimbusExperimentStatus.PREVIEW })}
+        status={mockGetStatus({ status: NimbusExperimentStatusEnum.PREVIEW })}
       />,
     );
 
@@ -94,7 +94,7 @@ describe("PreviewURL", () => {
     render(
       <PreviewURL
         {...experiment}
-        status={mockGetStatus({ status: NimbusExperimentStatus.LIVE })}
+        status={mockGetStatus({ status: NimbusExperimentStatusEnum.LIVE })}
       />,
     );
 
@@ -112,7 +112,7 @@ describe("PreviewURL", () => {
     render(
       <PreviewURL
         {...experiment}
-        status={mockGetStatus({ status: NimbusExperimentStatus.LIVE })}
+        status={mockGetStatus({ status: NimbusExperimentStatusEnum.LIVE })}
       />,
     );
     const previewArea = await screen.findByText(

--- a/app/experimenter/nimbus-ui/src/components/PreviewURL/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PreviewURL/index.tsx
@@ -7,7 +7,7 @@ import Select from "react-select";
 import { SelectOption } from "../../hooks/useCommonForm/useCommonFormMethods";
 import { StatusCheck } from "../../lib/experiment";
 import { getExperiment_experimentBySlug } from "../../types/getExperiment";
-import { NimbusExperimentApplication } from "../../types/globalTypes";
+import { NimbusExperimentApplicationEnum } from "../../types/globalTypes";
 
 type CopyableURLProps = {
   experimentSlug: string;
@@ -49,7 +49,7 @@ export const PreviewURL: React.FC<
   const slugs: SelectOption[] = [];
 
   if (
-    application !== NimbusExperimentApplication.DESKTOP ||
+    application !== NimbusExperimentApplicationEnum.DESKTOP ||
     !referenceBranch ||
     !Array.isArray(treatmentBranches)
   ) {

--- a/app/experimenter/nimbus-ui/src/components/SidebarActions/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/SidebarActions/index.test.tsx
@@ -9,7 +9,7 @@ import { CHANGELOG_MESSAGES } from "../../lib/constants";
 import { mockExperiment, mockExperimentMutation } from "../../lib/mocks";
 import {
   NimbusDocumentationLinkTitle,
-  NimbusExperimentStatus,
+  NimbusExperimentStatusEnum,
 } from "../../types/globalTypes";
 import { Subject } from "./mocks";
 
@@ -25,7 +25,7 @@ describe("SidebarActions", () => {
         {...{
           experiment: {
             slug: "demo-slug",
-            status: NimbusExperimentStatus.LIVE,
+            status: NimbusExperimentStatusEnum.LIVE,
             riskMitigationLink: "https://mozilla.org",
             documentationLinks: [
               {
@@ -66,7 +66,7 @@ describe("SidebarActions", () => {
     render(
       <Subject
         experiment={{
-          status: NimbusExperimentStatus.DRAFT,
+          status: NimbusExperimentStatusEnum.DRAFT,
         }}
       />,
     );

--- a/app/experimenter/nimbus-ui/src/components/Summary/EndExperiment/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/EndExperiment/mocks.tsx
@@ -6,7 +6,7 @@ import React from "react";
 import EndExperiment from ".";
 import { mockExperimentQuery } from "../../../lib/mocks";
 import { getExperiment } from "../../../types/getExperiment";
-import { NimbusExperimentStatus } from "../../../types/globalTypes";
+import { NimbusExperimentStatusEnum } from "../../../types/globalTypes";
 
 export const Subject = ({
   experiment: overrides = {},
@@ -18,7 +18,7 @@ export const Subject = ({
   onSubmit?: () => void;
 }) => {
   const { experiment } = mockExperimentQuery("demo-slug", {
-    status: NimbusExperimentStatus.LIVE,
+    status: NimbusExperimentStatusEnum.LIVE,
     ...overrides,
   });
 

--- a/app/experimenter/nimbus-ui/src/components/Summary/SummaryTimeline/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/SummaryTimeline/index.stories.tsx
@@ -5,7 +5,7 @@
 import { storiesOf } from "@storybook/react";
 import MockDate from "mockdate";
 import React from "react";
-import { NimbusExperimentStatus } from "../../../types/globalTypes";
+import { NimbusExperimentStatusEnum } from "../../../types/globalTypes";
 import { Subject } from "./mocks";
 
 storiesOf("components/Summary/SummaryTimeline", module)
@@ -15,9 +15,11 @@ storiesOf("components/Summary/SummaryTimeline", module)
   .add("draft, review, accepted", () => <Subject />)
   .add("live", () => {
     MockDate.set("2020-12-06T14:52:44.704811+00:00");
-    return <Subject status={NimbusExperimentStatus.LIVE} />;
+    return <Subject status={NimbusExperimentStatusEnum.LIVE} />;
   })
-  .add("complete", () => <Subject status={NimbusExperimentStatus.COMPLETE} />)
+  .add("complete", () => (
+    <Subject status={NimbusExperimentStatusEnum.COMPLETE} />
+  ))
   .add("missing details", () => (
     <Subject computedDurationDays={0} computedEnrollmentDays={0} />
   ));

--- a/app/experimenter/nimbus-ui/src/components/Summary/SummaryTimeline/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/SummaryTimeline/index.test.tsx
@@ -6,8 +6,8 @@ import { cleanup, render, screen } from "@testing-library/react";
 import React from "react";
 import { TOOLTIP_DURATION } from "../../../lib/constants";
 import {
-  NimbusExperimentPublishStatus,
-  NimbusExperimentStatus,
+  NimbusExperimentPublishStatusEnum,
+  NimbusExperimentStatusEnum,
 } from "../../../types/globalTypes";
 import { Subject } from "./mocks";
 
@@ -20,9 +20,9 @@ const innerBar = () => {
 describe("SummaryTimeline", () => {
   it("renders with a draft, in-review, and accepted/waiting experiment", () => {
     [
-      { status: NimbusExperimentStatus.DRAFT },
-      { publishStatus: NimbusExperimentPublishStatus.REVIEW },
-      { publishStatus: NimbusExperimentPublishStatus.WAITING },
+      { status: NimbusExperimentStatusEnum.DRAFT },
+      { publishStatus: NimbusExperimentPublishStatusEnum.REVIEW },
+      { publishStatus: NimbusExperimentPublishStatusEnum.WAITING },
     ].forEach((set) => {
       render(<Subject {...set} />);
 
@@ -37,7 +37,7 @@ describe("SummaryTimeline", () => {
   });
 
   it("renders with a live experiment", async () => {
-    render(<Subject status={NimbusExperimentStatus.LIVE} />);
+    render(<Subject status={NimbusExperimentStatusEnum.LIVE} />);
 
     expect(innerBar().classList).toContain("progress-bar-animated");
     expect(innerBar().classList).toContain("progress-bar-striped");
@@ -53,7 +53,7 @@ describe("SummaryTimeline", () => {
   });
 
   it("renders with a completed experiment", () => {
-    render(<Subject status={NimbusExperimentStatus.COMPLETE} />);
+    render(<Subject status={NimbusExperimentStatusEnum.COMPLETE} />);
 
     expect(innerBar().classList).toContain("bg-success");
 

--- a/app/experimenter/nimbus-ui/src/components/Summary/SummaryTimeline/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/SummaryTimeline/mocks.tsx
@@ -6,8 +6,8 @@ import React from "react";
 import SummaryTimeline from ".";
 import { mockExperimentQuery } from "../../../lib/mocks";
 import {
-  NimbusExperimentPublishStatus,
-  NimbusExperimentStatus,
+  NimbusExperimentPublishStatusEnum,
+  NimbusExperimentStatusEnum,
 } from "../../../types/globalTypes";
 
 export const Subject = ({
@@ -15,15 +15,15 @@ export const Subject = ({
   computedEndDate = "2020-12-08T14:52:44.704811+00:00",
   computedDurationDays = 10,
   computedEnrollmentDays = 1,
-  status = NimbusExperimentStatus.DRAFT,
-  publishStatus = NimbusExperimentPublishStatus.IDLE,
+  status = NimbusExperimentStatusEnum.DRAFT,
+  publishStatus = NimbusExperimentPublishStatusEnum.IDLE,
 }: {
   startDate?: string;
   computedEndDate?: string;
   computedDurationDays?: number;
   computedEnrollmentDays?: number;
-  status?: NimbusExperimentStatus;
-  publishStatus?: NimbusExperimentPublishStatus;
+  status?: NimbusExperimentStatusEnum;
+  publishStatus?: NimbusExperimentPublishStatusEnum;
 }) => {
   const { experiment } = mockExperimentQuery("something-vague", {
     startDate,

--- a/app/experimenter/nimbus-ui/src/components/Summary/TableAudience/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/TableAudience/index.stories.tsx
@@ -7,13 +7,13 @@ import React from "react";
 import TableAudience from ".";
 import { mockExperimentQuery } from "../../../lib/mocks";
 import { RouterSlugProvider } from "../../../lib/test-utils";
-import { NimbusExperimentChannel } from "../../../types/globalTypes";
+import { NimbusExperimentChannelEnum } from "../../../types/globalTypes";
 import AppLayout from "../../AppLayout";
 
 storiesOf("components/Summary/TableAudience", module)
   .add("all fields filled out", () => {
     const { experiment } = mockExperimentQuery("demo-slug", {
-      channel: NimbusExperimentChannel.BETA,
+      channel: NimbusExperimentChannelEnum.BETA,
     });
     return (
       <Subject>

--- a/app/experimenter/nimbus-ui/src/components/Summary/TableAudience/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/TableAudience/index.test.tsx
@@ -7,13 +7,13 @@ import React from "react";
 import TableAudience from ".";
 import { MockedCache, mockExperimentQuery } from "../../../lib/mocks";
 import { getExperiment_experimentBySlug } from "../../../types/getExperiment";
-import { NimbusExperimentChannel } from "../../../types/globalTypes";
+import { NimbusExperimentChannelEnum } from "../../../types/globalTypes";
 
 describe("TableAudience", () => {
   describe("renders 'Channel' row as expected", () => {
     it("with one channel", () => {
       const { experiment } = mockExperimentQuery("demo-slug", {
-        channel: NimbusExperimentChannel.BETA,
+        channel: NimbusExperimentChannelEnum.BETA,
       });
       render(<Subject {...{ experiment }} />);
       expect(screen.getByTestId("experiment-channel")).toHaveTextContent(

--- a/app/experimenter/nimbus-ui/src/components/Summary/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/index.stories.tsx
@@ -6,8 +6,8 @@ import { withLinks } from "@storybook/addon-links";
 import React from "react";
 import { getExperiment_experimentBySlug } from "../../types/getExperiment";
 import {
-  NimbusExperimentConclusionRecommendation,
-  NimbusExperimentStatus,
+  NimbusExperimentConclusionRecommendationEnum,
+  NimbusExperimentStatusEnum,
 } from "../../types/globalTypes";
 import { TAKEAWAYS_SUMMARY_LONG } from "../PageSummary/Takeaways/mocks";
 import { reviewRequestedBaseProps, Subject } from "./mocks";
@@ -32,16 +32,16 @@ export default {
 export const draftStatus = storyWithExperimentProps();
 
 export const liveStatus = storyWithExperimentProps({
-  status: NimbusExperimentStatus.LIVE,
+  status: NimbusExperimentStatusEnum.LIVE,
 });
 
 export const enrollmentActive = storyWithExperimentProps({
-  status: NimbusExperimentStatus.LIVE,
+  status: NimbusExperimentStatusEnum.LIVE,
   isEnrollmentPaused: false,
 });
 
 export const enrollmentEnded = storyWithExperimentProps({
-  status: NimbusExperimentStatus.LIVE,
+  status: NimbusExperimentStatusEnum.LIVE,
   enrollmentEndDate: new Date().toISOString(),
 });
 
@@ -51,9 +51,10 @@ export const endRequestedEnrollmentEnded = storyWithExperimentProps({
 });
 
 export const completeStatusWithTakeaways = storyWithExperimentProps({
-  status: NimbusExperimentStatus.COMPLETE,
+  status: NimbusExperimentStatusEnum.COMPLETE,
   takeawaysSummary: TAKEAWAYS_SUMMARY_LONG,
-  conclusionRecommendation: NimbusExperimentConclusionRecommendation.GRADUATE,
+  conclusionRecommendation:
+    NimbusExperimentConclusionRecommendationEnum.GRADUATE,
 });
 
 export const noBranches = storyWithExperimentProps({

--- a/app/experimenter/nimbus-ui/src/components/Summary/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/index.test.tsx
@@ -7,8 +7,8 @@ import React from "react";
 import { CHANGELOG_MESSAGES, SUBMIT_ERROR } from "../../lib/constants";
 import { mockExperimentQuery } from "../../lib/mocks";
 import {
-  NimbusExperimentPublishStatus,
-  NimbusExperimentStatus,
+  NimbusExperimentPublishStatusEnum,
+  NimbusExperimentStatusEnum,
 } from "../../types/globalTypes";
 import { createMutationMock, Subject } from "./mocks";
 
@@ -44,7 +44,7 @@ describe("Summary", () => {
     render(
       <Subject
         props={{
-          status: NimbusExperimentStatus.LIVE,
+          status: NimbusExperimentStatusEnum.LIVE,
         }}
       />,
     );
@@ -56,7 +56,7 @@ describe("Summary", () => {
     render(
       <Subject
         props={{
-          status: NimbusExperimentStatus.DRAFT,
+          status: NimbusExperimentStatusEnum.DRAFT,
         }}
       />,
     );
@@ -68,7 +68,7 @@ describe("Summary", () => {
     render(
       <Subject
         props={{
-          status: NimbusExperimentStatus.LIVE,
+          status: NimbusExperimentStatusEnum.LIVE,
           isEnrollmentPaused: false,
         }}
       />,
@@ -80,7 +80,7 @@ describe("Summary", () => {
     render(
       <Subject
         props={{
-          status: NimbusExperimentStatus.LIVE,
+          status: NimbusExperimentStatusEnum.LIVE,
           isEnrollmentPaused: true,
           enrollmentEndDate: new Date().toISOString(),
         }}
@@ -105,15 +105,15 @@ describe("Summary", () => {
     it("can mark the experiment as requesting review on end confirmation", async () => {
       const refetch = jest.fn();
       const { experiment } = mockExperimentQuery("demo-slug", {
-        status: NimbusExperimentStatus.LIVE,
+        status: NimbusExperimentStatusEnum.LIVE,
       });
       const mutationMock = createMutationMock(
         experiment.id!,
-        NimbusExperimentPublishStatus.REVIEW,
+        NimbusExperimentPublishStatusEnum.REVIEW,
         {
           changelogMessage: CHANGELOG_MESSAGES.REQUESTED_REVIEW_END,
-          status: NimbusExperimentStatus.LIVE,
-          statusNext: NimbusExperimentStatus.COMPLETE,
+          status: NimbusExperimentStatusEnum.LIVE,
+          statusNext: NimbusExperimentStatusEnum.COMPLETE,
         },
       );
       render(
@@ -130,11 +130,11 @@ describe("Summary", () => {
 
     it("handles submission with server API error", async () => {
       const { experiment } = mockExperimentQuery("demo-slug", {
-        status: NimbusExperimentStatus.LIVE,
+        status: NimbusExperimentStatusEnum.LIVE,
       });
       const mutationMock = createMutationMock(
         experiment.id!,
-        NimbusExperimentPublishStatus.REVIEW,
+        NimbusExperimentPublishStatusEnum.REVIEW,
         { changelogMessage: CHANGELOG_MESSAGES.REQUESTED_REVIEW_END },
       );
       mutationMock.result.errors = [new Error("Boo")];
@@ -148,15 +148,15 @@ describe("Summary", () => {
 
     it("handles submission with server-side validation errors", async () => {
       const { experiment } = mockExperimentQuery("demo-slug", {
-        status: NimbusExperimentStatus.LIVE,
+        status: NimbusExperimentStatusEnum.LIVE,
       });
       const mutationMock = createMutationMock(
         experiment.id!,
-        NimbusExperimentPublishStatus.REVIEW,
+        NimbusExperimentPublishStatusEnum.REVIEW,
         {
           changelogMessage: CHANGELOG_MESSAGES.REQUESTED_REVIEW_END,
-          statusNext: NimbusExperimentStatus.COMPLETE,
-          status: NimbusExperimentStatus.LIVE,
+          statusNext: NimbusExperimentStatusEnum.COMPLETE,
+          status: NimbusExperimentStatusEnum.LIVE,
         },
       );
       const errorMessage = "Something went very wrong.";
@@ -188,17 +188,17 @@ describe("Summary", () => {
     it("can mark the experiment as requesting review on enrollment end confirmation", async () => {
       const refetch = jest.fn();
       const { experiment } = mockExperimentQuery("demo-slug", {
-        status: NimbusExperimentStatus.LIVE,
+        status: NimbusExperimentStatusEnum.LIVE,
         statusNext: null,
         isEnrollmentPaused: false,
       });
       const mutationMock = createMutationMock(
         experiment.id!,
-        NimbusExperimentPublishStatus.REVIEW,
+        NimbusExperimentPublishStatusEnum.REVIEW,
         {
           changelogMessage: CHANGELOG_MESSAGES.REQUESTED_REVIEW_END_ENROLLMENT,
-          status: NimbusExperimentStatus.LIVE,
-          statusNext: NimbusExperimentStatus.LIVE,
+          status: NimbusExperimentStatusEnum.LIVE,
+          statusNext: NimbusExperimentStatusEnum.LIVE,
           isEnrollmentPaused: true,
         },
       );
@@ -216,13 +216,13 @@ describe("Summary", () => {
 
     it("handles submission with server API error", async () => {
       const { experiment } = mockExperimentQuery("demo-slug", {
-        status: NimbusExperimentStatus.LIVE,
+        status: NimbusExperimentStatusEnum.LIVE,
         isEnrollmentPaused: false,
         statusNext: null,
       });
       const mutationMock = createMutationMock(
         experiment.id!,
-        NimbusExperimentPublishStatus.REVIEW,
+        NimbusExperimentPublishStatusEnum.REVIEW,
         {
           changelogMessage: CHANGELOG_MESSAGES.REQUESTED_REVIEW_END_ENROLLMENT,
         },
@@ -238,17 +238,17 @@ describe("Summary", () => {
 
     it("handles submission with server-side validation errors", async () => {
       const { experiment } = mockExperimentQuery("demo-slug", {
-        status: NimbusExperimentStatus.LIVE,
+        status: NimbusExperimentStatusEnum.LIVE,
         isEnrollmentPaused: false,
         statusNext: null,
       });
       const mutationMock = createMutationMock(
         experiment.id!,
-        NimbusExperimentPublishStatus.REVIEW,
+        NimbusExperimentPublishStatusEnum.REVIEW,
         {
           changelogMessage: CHANGELOG_MESSAGES.REQUESTED_REVIEW_END_ENROLLMENT,
-          statusNext: NimbusExperimentStatus.LIVE,
-          status: NimbusExperimentStatus.LIVE,
+          statusNext: NimbusExperimentStatusEnum.LIVE,
+          status: NimbusExperimentStatusEnum.LIVE,
           isEnrollmentPaused: true,
         },
       );

--- a/app/experimenter/nimbus-ui/src/components/Summary/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/index.tsx
@@ -11,8 +11,8 @@ import { getStatus } from "../../lib/experiment";
 import { ConfigOptions, getConfigLabel } from "../../lib/getConfigLabel";
 import { getExperiment_experimentBySlug } from "../../types/getExperiment";
 import {
-  NimbusExperimentPublishStatus,
-  NimbusExperimentStatus,
+  NimbusExperimentPublishStatusEnum,
+  NimbusExperimentStatusEnum,
 } from "../../types/globalTypes";
 import NotSet from "../NotSet";
 import TableSignoff from "../PageSummary/TableSignoff";
@@ -45,15 +45,15 @@ const Summary = ({
     experiment,
     refetch,
     {
-      publishStatus: NimbusExperimentPublishStatus.REVIEW,
-      status: NimbusExperimentStatus.LIVE,
-      statusNext: NimbusExperimentStatus.COMPLETE,
+      publishStatus: NimbusExperimentPublishStatusEnum.REVIEW,
+      status: NimbusExperimentStatusEnum.LIVE,
+      statusNext: NimbusExperimentStatusEnum.COMPLETE,
       changelogMessage: CHANGELOG_MESSAGES.REQUESTED_REVIEW_END,
     },
     {
-      publishStatus: NimbusExperimentPublishStatus.REVIEW,
-      status: NimbusExperimentStatus.LIVE,
-      statusNext: NimbusExperimentStatus.LIVE,
+      publishStatus: NimbusExperimentPublishStatusEnum.REVIEW,
+      status: NimbusExperimentStatusEnum.LIVE,
+      statusNext: NimbusExperimentStatusEnum.LIVE,
       isEnrollmentPaused: true,
       changelogMessage: CHANGELOG_MESSAGES.REQUESTED_REVIEW_END_ENROLLMENT,
     },

--- a/app/experimenter/nimbus-ui/src/components/Summary/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/mocks.tsx
@@ -14,14 +14,14 @@ import {
 import { RouterSlugProvider } from "../../lib/test-utils";
 import { getExperiment_experimentBySlug } from "../../types/getExperiment";
 import {
-  NimbusExperimentPublishStatus,
-  NimbusExperimentStatus,
+  NimbusExperimentPublishStatusEnum,
+  NimbusExperimentStatusEnum,
 } from "../../types/globalTypes";
 import AppLayout from "../AppLayout";
 
 export function createMutationMock(
   id: number,
-  publishStatus: NimbusExperimentPublishStatus,
+  publishStatus: NimbusExperimentPublishStatusEnum,
   additionalProps: Record<string, any> = {},
 ) {
   return mockExperimentMutation(
@@ -64,32 +64,32 @@ export const Subject = ({
 };
 
 export const reviewRequestedBaseProps = {
-  status: NimbusExperimentStatus.LIVE,
-  statusNext: NimbusExperimentStatus.COMPLETE,
-  publishStatus: NimbusExperimentPublishStatus.REVIEW,
+  status: NimbusExperimentStatusEnum.LIVE,
+  statusNext: NimbusExperimentStatusEnum.COMPLETE,
+  publishStatus: NimbusExperimentPublishStatusEnum.REVIEW,
   canReview: false,
   reviewRequest: mockChangelog(),
 };
 
 export const reviewPendingBaseProps = {
-  status: NimbusExperimentStatus.LIVE,
-  statusNext: NimbusExperimentStatus.COMPLETE,
-  publishStatus: NimbusExperimentPublishStatus.WAITING,
+  status: NimbusExperimentStatusEnum.LIVE,
+  statusNext: NimbusExperimentStatusEnum.COMPLETE,
+  publishStatus: NimbusExperimentPublishStatusEnum.WAITING,
   reviewRequest: mockChangelog(),
 };
 
 export const reviewTimedoutBaseProps = {
-  status: NimbusExperimentStatus.LIVE,
-  statusNext: NimbusExperimentStatus.COMPLETE,
-  publishStatus: NimbusExperimentPublishStatus.REVIEW,
+  status: NimbusExperimentStatusEnum.LIVE,
+  statusNext: NimbusExperimentStatusEnum.COMPLETE,
+  publishStatus: NimbusExperimentPublishStatusEnum.REVIEW,
   reviewRequest: mockChangelog(),
   timeout: mockChangelog("def@mozilla.com"),
 };
 
 export const reviewRejectedBaseProps = {
-  status: NimbusExperimentStatus.LIVE,
+  status: NimbusExperimentStatusEnum.LIVE,
   statusNext: null,
-  publishStatus: NimbusExperimentPublishStatus.IDLE,
+  publishStatus: NimbusExperimentPublishStatusEnum.IDLE,
   reviewRequest: mockChangelog(),
   rejection: mockChangelog("def@mozilla.com", "It's bad. Just start over."),
 };

--- a/app/experimenter/nimbus-ui/src/hooks/useChangeOperationMutation.test.tsx
+++ b/app/experimenter/nimbus-ui/src/hooks/useChangeOperationMutation.test.tsx
@@ -12,8 +12,8 @@ import {
   mockExperimentMutation,
 } from "../lib/mocks";
 import {
-  NimbusExperimentPublishStatus,
-  NimbusExperimentStatus,
+  NimbusExperimentPublishStatusEnum,
+  NimbusExperimentStatusEnum,
 } from "../types/globalTypes";
 import { useChangeOperationMutation } from "./useChangeOperationMutation";
 
@@ -70,15 +70,15 @@ const setupTestHook = (refetch?: () => Promise<unknown>) => {
   const experiment = mockExperiment();
   const mutationSets = [
     {
-      statusNext: NimbusExperimentStatus.COMPLETE,
-      publishStatus: NimbusExperimentPublishStatus.APPROVED,
+      statusNext: NimbusExperimentStatusEnum.COMPLETE,
+      publishStatus: NimbusExperimentPublishStatusEnum.APPROVED,
     },
     {
-      status: NimbusExperimentStatus.LIVE,
+      status: NimbusExperimentStatusEnum.LIVE,
     },
     {
-      status: NimbusExperimentStatus.DRAFT,
-      publishStatus: NimbusExperimentPublishStatus.APPROVED,
+      status: NimbusExperimentStatusEnum.DRAFT,
+      publishStatus: NimbusExperimentPublishStatusEnum.APPROVED,
     },
   ];
 

--- a/app/experimenter/nimbus-ui/src/hooks/useOutcomes.test.tsx
+++ b/app/experimenter/nimbus-ui/src/hooks/useOutcomes.test.tsx
@@ -12,7 +12,7 @@ import {
   mockOutcomeSets,
   MOCK_CONFIG,
 } from "../lib/mocks";
-import { NimbusExperimentApplication } from "../types/globalTypes";
+import { NimbusExperimentApplicationEnum } from "../types/globalTypes";
 
 describe("hooks/useOutcomes", () => {
   it("matches experiment outcome slugs to available configuration outcomes", () => {
@@ -61,7 +61,7 @@ describe("hooks/useOutcomes", () => {
 
   it("returns an array of outcomes that are eligible for that experiment based on application", () => {
     const { mock, experiment } = mockExperimentQuery("howdy", {
-      application: NimbusExperimentApplication.FENIX,
+      application: NimbusExperimentApplicationEnum.FENIX,
     });
     const { result } = renderHook(() => useOutcomes(experiment), {
       wrapper,
@@ -72,13 +72,14 @@ describe("hooks/useOutcomes", () => {
       expect.arrayContaining(
         MOCK_CONFIG.outcomes!.filter(
           (outcome) =>
-            outcome?.application === NimbusExperimentApplication.DESKTOP,
+            outcome?.application === NimbusExperimentApplicationEnum.DESKTOP,
         ),
       ),
     );
     expect(result.current.available).toEqual(
       MOCK_CONFIG.outcomes!.filter(
-        (outcome) => outcome?.application === NimbusExperimentApplication.FENIX,
+        (outcome) =>
+          outcome?.application === NimbusExperimentApplicationEnum.FENIX,
       ),
     );
   });

--- a/app/experimenter/nimbus-ui/src/lib/experiment.test.ts
+++ b/app/experimenter/nimbus-ui/src/lib/experiment.test.ts
@@ -3,8 +3,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import {
-  NimbusExperimentPublishStatus,
-  NimbusExperimentStatus,
+  NimbusExperimentPublishStatusEnum,
+  NimbusExperimentStatusEnum,
 } from "../types/globalTypes";
 import {
   editCommonRedirects,
@@ -26,30 +26,30 @@ const { experiment } = mockExperimentQuery("boo");
 
 describe("getStatus", () => {
   it("correctly returns available experiment states", () => {
-    experiment.status = NimbusExperimentStatus.DRAFT;
+    experiment.status = NimbusExperimentStatusEnum.DRAFT;
     expect(getStatus(experiment).draft).toBeTruthy();
 
-    experiment.status = NimbusExperimentStatus.PREVIEW;
+    experiment.status = NimbusExperimentStatusEnum.PREVIEW;
     expect(getStatus(experiment).preview).toBeTruthy();
 
-    experiment.status = NimbusExperimentStatus.LIVE;
+    experiment.status = NimbusExperimentStatusEnum.LIVE;
     expect(getStatus(experiment).live).toBeTruthy();
     expect(getStatus(experiment).launched).toBeTruthy();
 
-    experiment.status = NimbusExperimentStatus.COMPLETE;
+    experiment.status = NimbusExperimentStatusEnum.COMPLETE;
     expect(getStatus(experiment).complete).toBeTruthy();
     expect(getStatus(experiment).launched).toBeTruthy();
 
-    experiment.publishStatus = NimbusExperimentPublishStatus.IDLE;
+    experiment.publishStatus = NimbusExperimentPublishStatusEnum.IDLE;
     expect(getStatus(experiment).idle).toBeTruthy();
 
-    experiment.publishStatus = NimbusExperimentPublishStatus.APPROVED;
+    experiment.publishStatus = NimbusExperimentPublishStatusEnum.APPROVED;
     expect(getStatus(experiment).approved).toBeTruthy();
 
-    experiment.publishStatus = NimbusExperimentPublishStatus.REVIEW;
+    experiment.publishStatus = NimbusExperimentPublishStatusEnum.REVIEW;
     expect(getStatus(experiment).review).toBeTruthy();
 
-    experiment.publishStatus = NimbusExperimentPublishStatus.WAITING;
+    experiment.publishStatus = NimbusExperimentPublishStatusEnum.WAITING;
     expect(getStatus(experiment).waiting).toBeTruthy();
   });
 });
@@ -59,8 +59,8 @@ describe("editCommonRedirects", () => {
     status,
     publishStatus,
   }: {
-    status?: NimbusExperimentStatus;
-    publishStatus?: NimbusExperimentPublishStatus;
+    status?: NimbusExperimentStatusEnum;
+    publishStatus?: NimbusExperimentPublishStatusEnum;
   }) => {
     const { experiment } = mockExperimentQuery("boo", {
       status,
@@ -70,12 +70,16 @@ describe("editCommonRedirects", () => {
   };
 
   it("returns '' (root) if the experiment is in a launched, non-idle, or preview state", () => {
-    expect(mockedCall({ status: NimbusExperimentStatus.LIVE })).toEqual("");
-    expect(mockedCall({ status: NimbusExperimentStatus.COMPLETE })).toEqual("");
+    expect(mockedCall({ status: NimbusExperimentStatusEnum.LIVE })).toEqual("");
+    expect(mockedCall({ status: NimbusExperimentStatusEnum.COMPLETE })).toEqual(
+      "",
+    );
     expect(
-      mockedCall({ publishStatus: NimbusExperimentPublishStatus.WAITING }),
+      mockedCall({ publishStatus: NimbusExperimentPublishStatusEnum.WAITING }),
     ).toEqual("");
-    expect(mockedCall({ status: NimbusExperimentStatus.PREVIEW })).toEqual("");
+    expect(mockedCall({ status: NimbusExperimentStatusEnum.PREVIEW })).toEqual(
+      "",
+    );
   });
 });
 

--- a/app/experimenter/nimbus-ui/src/lib/experiment.ts
+++ b/app/experimenter/nimbus-ui/src/lib/experiment.ts
@@ -6,8 +6,8 @@ import { RedirectCheck } from "../components/AppLayoutWithExperiment";
 import { getAllExperiments_experiments } from "../types/getAllExperiments";
 import { getExperiment_experimentBySlug } from "../types/getExperiment";
 import {
-  NimbusExperimentPublishStatus,
-  NimbusExperimentStatus,
+  NimbusExperimentPublishStatusEnum,
+  NimbusExperimentStatusEnum,
 } from "../types/globalTypes";
 import { LIFECYCLE_REVIEW_FLOWS } from "./constants";
 
@@ -24,28 +24,28 @@ export function getStatus(
 
   // The experiment is or was out in the wild (live or complete)
   const launched = [
-    NimbusExperimentStatus.LIVE,
-    NimbusExperimentStatus.COMPLETE,
+    NimbusExperimentStatusEnum.LIVE,
+    NimbusExperimentStatusEnum.COMPLETE,
   ].includes(status!);
 
   return {
     archived: isArchived,
-    draft: status === NimbusExperimentStatus.DRAFT,
-    preview: status === NimbusExperimentStatus.PREVIEW,
-    live: status === NimbusExperimentStatus.LIVE,
-    complete: status === NimbusExperimentStatus.COMPLETE,
-    idle: publishStatus === NimbusExperimentPublishStatus.IDLE,
-    approved: publishStatus === NimbusExperimentPublishStatus.APPROVED,
-    review: publishStatus === NimbusExperimentPublishStatus.REVIEW,
-    waiting: publishStatus === NimbusExperimentPublishStatus.WAITING,
+    draft: status === NimbusExperimentStatusEnum.DRAFT,
+    preview: status === NimbusExperimentStatusEnum.PREVIEW,
+    live: status === NimbusExperimentStatusEnum.LIVE,
+    complete: status === NimbusExperimentStatusEnum.COMPLETE,
+    idle: publishStatus === NimbusExperimentPublishStatusEnum.IDLE,
+    approved: publishStatus === NimbusExperimentPublishStatusEnum.APPROVED,
+    review: publishStatus === NimbusExperimentPublishStatusEnum.REVIEW,
+    waiting: publishStatus === NimbusExperimentPublishStatusEnum.WAITING,
     // TODO: EXP-1325 Need to check something else here for end enrollment in particular?
     pauseRequested:
-      status === NimbusExperimentStatus.LIVE &&
-      statusNext === NimbusExperimentStatus.LIVE &&
+      status === NimbusExperimentStatusEnum.LIVE &&
+      statusNext === NimbusExperimentStatusEnum.LIVE &&
       isEnrollmentPausePending === true,
     endRequested:
-      status === NimbusExperimentStatus.LIVE &&
-      statusNext === NimbusExperimentStatus.COMPLETE,
+      status === NimbusExperimentStatusEnum.LIVE &&
+      statusNext === NimbusExperimentStatusEnum.COMPLETE,
     launched,
   };
 }

--- a/app/experimenter/nimbus-ui/src/lib/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/lib/mocks.tsx
@@ -37,11 +37,11 @@ import {
   NimbusChangeLogOldStatus,
   NimbusChangeLogOldStatusNext,
   NimbusDocumentationLinkTitle,
-  NimbusExperimentApplication,
-  NimbusExperimentChannel,
-  NimbusExperimentFirefoxVersion,
-  NimbusExperimentPublishStatus,
-  NimbusExperimentStatus,
+  NimbusExperimentApplicationEnum,
+  NimbusExperimentChannelEnum,
+  NimbusExperimentFirefoxVersionEnum,
+  NimbusExperimentPublishStatusEnum,
+  NimbusExperimentStatusEnum,
 } from "../types/globalTypes";
 import { ResultsContext } from "./contexts";
 import { getStatus } from "./experiment";
@@ -67,7 +67,7 @@ export const MOCK_CONFIG: getConfig_nimbusConfig = {
   applications: [
     {
       label: "Desktop",
-      value: NimbusExperimentApplication.DESKTOP,
+      value: NimbusExperimentApplicationEnum.DESKTOP,
     },
     {
       label: "Toaster",
@@ -75,11 +75,11 @@ export const MOCK_CONFIG: getConfig_nimbusConfig = {
     },
     {
       label: "iOS",
-      value: NimbusExperimentApplication.IOS,
+      value: NimbusExperimentApplicationEnum.IOS,
     },
     {
       label: "Android",
-      value: NimbusExperimentApplication.FENIX,
+      value: NimbusExperimentApplicationEnum.FENIX,
     },
   ],
   channels: [
@@ -114,7 +114,7 @@ export const MOCK_CONFIG: getConfig_nimbusConfig = {
   ],
   applicationConfigs: [
     {
-      application: NimbusExperimentApplication.DESKTOP,
+      application: NimbusExperimentApplicationEnum.DESKTOP,
       channels: [
         {
           label: "Desktop Beta",
@@ -132,7 +132,7 @@ export const MOCK_CONFIG: getConfig_nimbusConfig = {
       supportsLocaleCountry: true,
     },
     {
-      application: NimbusExperimentApplication.FENIX,
+      application: NimbusExperimentApplicationEnum.FENIX,
       channels: [
         {
           label: "Desktop Beta",
@@ -150,7 +150,7 @@ export const MOCK_CONFIG: getConfig_nimbusConfig = {
       supportsLocaleCountry: false,
     },
     {
-      application: NimbusExperimentApplication.IOS,
+      application: NimbusExperimentApplicationEnum.IOS,
       channels: [
         {
           label: "Desktop Beta",
@@ -175,7 +175,7 @@ export const MOCK_CONFIG: getConfig_nimbusConfig = {
       slug: "picture-in-picture",
       description:
         "Quickly above also mission action. Become thing item institution plan.\nImpact friend wonder. Interview strategy nature question. Admit room without impact its enter forward.",
-      application: NimbusExperimentApplication.FENIX,
+      application: NimbusExperimentApplicationEnum.FENIX,
       ownerEmail: "sheila43@yahoo.com",
       schema: null,
     },
@@ -184,7 +184,7 @@ export const MOCK_CONFIG: getConfig_nimbusConfig = {
       name: "Mauris odio erat",
       slug: "mauris-odio-erat",
       description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
-      application: NimbusExperimentApplication.DESKTOP,
+      application: NimbusExperimentApplicationEnum.DESKTOP,
       ownerEmail: "dude23@yahoo.com",
       schema: '{ "sample": "schema" }',
     },
@@ -193,7 +193,7 @@ export const MOCK_CONFIG: getConfig_nimbusConfig = {
       name: "Foo lila sat (iOS)",
       slug: "foo-lila-sat",
       description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
-      application: NimbusExperimentApplication.IOS,
+      application: NimbusExperimentApplicationEnum.IOS,
       ownerEmail: "dude23@yahoo.com",
       schema: '{ "sample": "schema" }',
     },
@@ -202,7 +202,7 @@ export const MOCK_CONFIG: getConfig_nimbusConfig = {
       name: "Foo lila sat (Android)",
       slug: "foo-lila-sat",
       description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
-      application: NimbusExperimentApplication.FENIX,
+      application: NimbusExperimentApplicationEnum.FENIX,
       ownerEmail: "dude23@yahoo.com",
       schema: '{ "sample": "schema" }',
     },
@@ -229,7 +229,7 @@ export const MOCK_CONFIG: getConfig_nimbusConfig = {
     {
       friendlyName: "Picture-in-Picture",
       slug: "picture_in_picture",
-      application: NimbusExperimentApplication.DESKTOP,
+      application: NimbusExperimentApplicationEnum.DESKTOP,
       description: "foo",
       isDefault: true,
       metrics: [
@@ -243,7 +243,7 @@ export const MOCK_CONFIG: getConfig_nimbusConfig = {
     {
       friendlyName: "Feature B",
       slug: "feature_b",
-      application: NimbusExperimentApplication.DESKTOP,
+      application: NimbusExperimentApplicationEnum.DESKTOP,
       description: "bar",
       isDefault: false,
       metrics: [
@@ -257,7 +257,7 @@ export const MOCK_CONFIG: getConfig_nimbusConfig = {
     {
       friendlyName: "Feature C",
       slug: "feature_c",
-      application: NimbusExperimentApplication.DESKTOP,
+      application: NimbusExperimentApplicationEnum.DESKTOP,
       description: "baz",
       isDefault: false,
       metrics: [
@@ -271,7 +271,7 @@ export const MOCK_CONFIG: getConfig_nimbusConfig = {
     {
       friendlyName: "Feature No Data",
       slug: "feature_nodata",
-      application: NimbusExperimentApplication.DESKTOP,
+      application: NimbusExperimentApplicationEnum.DESKTOP,
       description: "meep",
       isDefault: false,
       metrics: [
@@ -285,7 +285,7 @@ export const MOCK_CONFIG: getConfig_nimbusConfig = {
     {
       friendlyName: "Feature D",
       slug: "feature_d",
-      application: NimbusExperimentApplication.FENIX,
+      application: NimbusExperimentApplicationEnum.FENIX,
       description: "feature_d",
       isDefault: false,
       metrics: [
@@ -460,12 +460,12 @@ export const MOCK_EXPERIMENT: Partial<getExperiment["experimentBySlug"]> = {
   },
   name: "Open-architected background installation",
   slug: "open-architected-background-installation",
-  status: NimbusExperimentStatus.DRAFT,
+  status: NimbusExperimentStatusEnum.DRAFT,
   statusNext: null,
-  publishStatus: NimbusExperimentPublishStatus.IDLE,
+  publishStatus: NimbusExperimentPublishStatusEnum.IDLE,
   monitoringDashboardUrl: "https://mozilla.cloud.looker.com",
   hypothesis: "Realize material say pretty.",
-  application: NimbusExperimentApplication.DESKTOP,
+  application: NimbusExperimentApplicationEnum.DESKTOP,
   publicDescription: "Official approach present industry strategy dream piece.",
   referenceBranch: {
     id: 123,
@@ -492,9 +492,9 @@ export const MOCK_EXPERIMENT: Partial<getExperiment["experimentBySlug"]> = {
   ],
   primaryOutcomes: ["picture_in_picture", "feature_c", "feature_nodata"],
   secondaryOutcomes: ["feature_b"],
-  channel: NimbusExperimentChannel.NIGHTLY,
-  firefoxMinVersion: NimbusExperimentFirefoxVersion.FIREFOX_16,
-  firefoxMaxVersion: NimbusExperimentFirefoxVersion.FIREFOX_64,
+  channel: NimbusExperimentChannelEnum.NIGHTLY,
+  firefoxMinVersion: NimbusExperimentFirefoxVersionEnum.FIREFOX_16,
+  firefoxMaxVersion: NimbusExperimentFirefoxVersionEnum.FIREFOX_64,
   targetingConfigSlug: "MAC_ONLY",
   jexlTargetingExpression: "localeLanguageCode == 'en' && region == 'US'",
   populationPercent: "40",
@@ -649,17 +649,17 @@ export function mockSingleDirectoryExperiment(
       username: "example@mozilla.com",
     },
     application: MOCK_CONFIG.applications![0]!
-      .value as NimbusExperimentApplication,
+      .value as NimbusExperimentApplicationEnum,
     firefoxMinVersion: MOCK_CONFIG.firefoxVersions![0]!
-      .value as NimbusExperimentFirefoxVersion,
+      .value as NimbusExperimentFirefoxVersionEnum,
     firefoxMaxVersion: MOCK_CONFIG.firefoxVersions![3]!
-      .value as NimbusExperimentFirefoxVersion,
+      .value as NimbusExperimentFirefoxVersionEnum,
     monitoringDashboardUrl:
       "https://mozilla.cloud.looker.com/dashboards-next/216?Experiment=bug-1668861-pref-measure-set-to-default-adoption-impact-of-chang-release-81-83",
     name: "Open-architected background installation",
-    status: NimbusExperimentStatus.COMPLETE,
+    status: NimbusExperimentStatusEnum.COMPLETE,
     statusNext: null,
-    publishStatus: NimbusExperimentPublishStatus.IDLE,
+    publishStatus: NimbusExperimentPublishStatusEnum.IDLE,
     featureConfig: MOCK_CONFIG.featureConfigs![0],
     isEnrollmentPaused: false,
     isEnrollmentPausePending: false,
@@ -676,24 +676,24 @@ export function mockDirectoryExperiments(
   overrides: Partial<getAllExperiments_experiments>[] = [
     {
       name: "Lorem ipsum dolor sit amet",
-      status: NimbusExperimentStatus.DRAFT,
+      status: NimbusExperimentStatusEnum.DRAFT,
       owner: { username: "alpha-example@mozilla.com" },
       startDate: null,
       computedEndDate: null,
     },
     {
       name: "Ipsum dolor sit amet",
-      status: NimbusExperimentStatus.DRAFT,
+      status: NimbusExperimentStatusEnum.DRAFT,
       owner: { username: "gamma-example@mozilla.com" },
       featureConfig: MOCK_CONFIG.featureConfigs![0],
       application: MOCK_CONFIG.applications![1]!
-        .value as NimbusExperimentApplication,
+        .value as NimbusExperimentApplicationEnum,
       startDate: null,
       computedEndDate: null,
     },
     {
       name: "Dolor sit amet",
-      status: NimbusExperimentStatus.DRAFT,
+      status: NimbusExperimentStatusEnum.DRAFT,
       owner: { username: "beta-example@mozilla.com" },
       featureConfig: MOCK_CONFIG.featureConfigs![1],
       startDate: null,
@@ -701,60 +701,60 @@ export function mockDirectoryExperiments(
     },
     {
       name: "Consectetur adipiscing elit",
-      status: NimbusExperimentStatus.PREVIEW,
+      status: NimbusExperimentStatusEnum.PREVIEW,
       owner: { username: "alpha-example@mozilla.com" },
       featureConfig: MOCK_CONFIG.featureConfigs![2],
       application: MOCK_CONFIG.applications![1]!
-        .value as NimbusExperimentApplication,
+        .value as NimbusExperimentApplicationEnum,
       computedEndDate: null,
     },
     {
       name: "Aliquam interdum ac lacus at dictum",
-      publishStatus: NimbusExperimentPublishStatus.APPROVED,
+      publishStatus: NimbusExperimentPublishStatusEnum.APPROVED,
       owner: { username: "beta-example@mozilla.com" },
       featureConfig: MOCK_CONFIG.featureConfigs![0],
       computedEndDate: null,
     },
     {
       name: "Nam semper sit amet orci in imperdiet",
-      publishStatus: NimbusExperimentPublishStatus.APPROVED,
+      publishStatus: NimbusExperimentPublishStatusEnum.APPROVED,
       application: MOCK_CONFIG.applications![1]!
-        .value as NimbusExperimentApplication,
+        .value as NimbusExperimentApplicationEnum,
       owner: { username: "gamma-example@mozilla.com" },
     },
     {
       name: "Duis ornare mollis sem.",
-      status: NimbusExperimentStatus.LIVE,
+      status: NimbusExperimentStatusEnum.LIVE,
       owner: { username: "alpha-example@mozilla.com" },
       featureConfig: MOCK_CONFIG.featureConfigs![1],
     },
     {
       name: "Nec suscipit mi accumsan id",
-      status: NimbusExperimentStatus.LIVE,
+      status: NimbusExperimentStatusEnum.LIVE,
       owner: { username: "beta-example@mozilla.com" },
       featureConfig: MOCK_CONFIG.featureConfigs![2],
       application: MOCK_CONFIG.applications![1]!
-        .value as NimbusExperimentApplication,
+        .value as NimbusExperimentApplicationEnum,
       resultsReady: true,
     },
     {
       name: "Etiam congue risus quis aliquet eleifend",
-      status: NimbusExperimentStatus.LIVE,
+      status: NimbusExperimentStatusEnum.LIVE,
       owner: { username: "gamma-example@mozilla.com" },
     },
     {
       name: "Nam gravida",
-      status: NimbusExperimentStatus.COMPLETE,
+      status: NimbusExperimentStatusEnum.COMPLETE,
       owner: { username: "alpha-example@mozilla.com" },
       featureConfig: MOCK_CONFIG.featureConfigs![0],
       application: MOCK_CONFIG.applications![1]!
-        .value as NimbusExperimentApplication,
+        .value as NimbusExperimentApplicationEnum,
       resultsReady: false,
     },
     {
       name: "Quam quis volutpat ornare",
-      status: NimbusExperimentStatus.DRAFT,
-      publishStatus: NimbusExperimentPublishStatus.REVIEW,
+      status: NimbusExperimentStatusEnum.DRAFT,
+      publishStatus: NimbusExperimentPublishStatusEnum.REVIEW,
       featureConfig: MOCK_CONFIG.featureConfigs![1],
       owner: { username: "beta-example@mozilla.com" },
     },
@@ -762,7 +762,7 @@ export function mockDirectoryExperiments(
       name: "Lorem arcu faucibus tortor",
       featureConfig: null,
       application: MOCK_CONFIG.applications![1]!
-        .value as NimbusExperimentApplication,
+        .value as NimbusExperimentApplicationEnum,
       owner: { username: "gamma-example@mozilla.com" },
     },
     {
@@ -770,7 +770,7 @@ export function mockDirectoryExperiments(
       name: "Archived Experiment",
       featureConfig: null,
       application: MOCK_CONFIG.applications![1]!
-        .value as NimbusExperimentApplication,
+        .value as NimbusExperimentApplicationEnum,
       owner: { username: "gamma-example@mozilla.com" },
     },
   ],

--- a/app/experimenter/nimbus-ui/src/types/getAllExperiments.ts
+++ b/app/experimenter/nimbus-ui/src/types/getAllExperiments.ts
@@ -3,7 +3,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import { NimbusExperimentApplication, NimbusExperimentFirefoxVersion, NimbusExperimentStatus, NimbusExperimentPublishStatus } from "./globalTypes";
+import { NimbusExperimentApplicationEnum, NimbusExperimentFirefoxVersionEnum, NimbusExperimentStatusEnum, NimbusExperimentPublishStatusEnum } from "./globalTypes";
 
 // ====================================================
 // GraphQL query operation: getAllExperiments
@@ -18,7 +18,7 @@ export interface getAllExperiments_experiments_featureConfig {
   slug: string;
   name: string;
   description: string | null;
-  application: NimbusExperimentApplication | null;
+  application: NimbusExperimentApplicationEnum | null;
   ownerEmail: string | null;
   schema: string | null;
 }
@@ -29,18 +29,18 @@ export interface getAllExperiments_experiments {
   owner: getAllExperiments_experiments_owner;
   featureConfig: getAllExperiments_experiments_featureConfig | null;
   slug: string;
-  application: NimbusExperimentApplication | null;
-  firefoxMinVersion: NimbusExperimentFirefoxVersion | null;
-  firefoxMaxVersion: NimbusExperimentFirefoxVersion | null;
+  application: NimbusExperimentApplicationEnum | null;
+  firefoxMinVersion: NimbusExperimentFirefoxVersionEnum | null;
+  firefoxMaxVersion: NimbusExperimentFirefoxVersionEnum | null;
   startDate: DateTime | null;
   isEnrollmentPausePending: boolean | null;
   isEnrollmentPaused: boolean | null;
   proposedDuration: number;
   proposedEnrollment: number;
   computedEndDate: DateTime | null;
-  status: NimbusExperimentStatus | null;
-  statusNext: NimbusExperimentStatus | null;
-  publishStatus: NimbusExperimentPublishStatus | null;
+  status: NimbusExperimentStatusEnum | null;
+  statusNext: NimbusExperimentStatusEnum | null;
+  publishStatus: NimbusExperimentPublishStatusEnum | null;
   monitoringDashboardUrl: string | null;
   resultsReady: boolean | null;
 }

--- a/app/experimenter/nimbus-ui/src/types/getConfig.ts
+++ b/app/experimenter/nimbus-ui/src/types/getConfig.ts
@@ -3,7 +3,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import { NimbusExperimentApplication } from "./globalTypes";
+import { NimbusExperimentApplicationEnum } from "./globalTypes";
 
 // ====================================================
 // GraphQL query operation: getConfig
@@ -30,7 +30,7 @@ export interface getConfig_nimbusConfig_applicationConfigs_channels {
 }
 
 export interface getConfig_nimbusConfig_applicationConfigs {
-  application: NimbusExperimentApplication | null;
+  application: NimbusExperimentApplicationEnum | null;
   channels: (getConfig_nimbusConfig_applicationConfigs_channels | null)[] | null;
   supportsLocaleCountry: boolean | null;
 }
@@ -40,7 +40,7 @@ export interface getConfig_nimbusConfig_featureConfigs {
   name: string;
   slug: string;
   description: string | null;
-  application: NimbusExperimentApplication | null;
+  application: NimbusExperimentApplicationEnum | null;
   ownerEmail: string | null;
   schema: string | null;
 }
@@ -59,7 +59,7 @@ export interface getConfig_nimbusConfig_outcomes_metrics {
 export interface getConfig_nimbusConfig_outcomes {
   friendlyName: string | null;
   slug: string | null;
-  application: NimbusExperimentApplication | null;
+  application: NimbusExperimentApplicationEnum | null;
   description: string | null;
   isDefault: boolean | null;
   metrics: (getConfig_nimbusConfig_outcomes_metrics | null)[] | null;

--- a/app/experimenter/nimbus-ui/src/types/getExperiment.ts
+++ b/app/experimenter/nimbus-ui/src/types/getExperiment.ts
@@ -3,7 +3,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import { NimbusExperimentStatus, NimbusExperimentPublishStatus, NimbusExperimentApplication, NimbusExperimentConclusionRecommendation, NimbusExperimentChannel, NimbusExperimentFirefoxVersion, NimbusDocumentationLinkTitle, NimbusChangeLogOldStatus, NimbusChangeLogOldStatusNext } from "./globalTypes";
+import { NimbusExperimentStatusEnum, NimbusExperimentPublishStatusEnum, NimbusExperimentApplicationEnum, NimbusExperimentConclusionRecommendationEnum, NimbusExperimentChannelEnum, NimbusExperimentFirefoxVersionEnum, NimbusDocumentationLinkTitle, NimbusChangeLogOldStatus, NimbusChangeLogOldStatusNext } from "./globalTypes";
 
 // ====================================================
 // GraphQL query operation: getExperiment
@@ -57,7 +57,7 @@ export interface getExperiment_experimentBySlug_featureConfig {
   slug: string;
   name: string;
   description: string | null;
-  application: NimbusExperimentApplication | null;
+  application: NimbusExperimentApplicationEnum | null;
   ownerEmail: string | null;
   schema: string | null;
 }
@@ -127,15 +127,15 @@ export interface getExperiment_experimentBySlug {
   canArchive: boolean | null;
   name: string;
   slug: string;
-  status: NimbusExperimentStatus | null;
-  statusNext: NimbusExperimentStatus | null;
-  publishStatus: NimbusExperimentPublishStatus | null;
+  status: NimbusExperimentStatusEnum | null;
+  statusNext: NimbusExperimentStatusEnum | null;
+  publishStatus: NimbusExperimentPublishStatusEnum | null;
   monitoringDashboardUrl: string | null;
   resultsReady: boolean | null;
   hypothesis: string;
-  application: NimbusExperimentApplication | null;
+  application: NimbusExperimentApplicationEnum | null;
   publicDescription: string;
-  conclusionRecommendation: NimbusExperimentConclusionRecommendation | null;
+  conclusionRecommendation: NimbusExperimentConclusionRecommendationEnum | null;
   takeawaysSummary: string | null;
   owner: getExperiment_experimentBySlug_owner;
   parent: getExperiment_experimentBySlug_parent | null;
@@ -145,9 +145,9 @@ export interface getExperiment_experimentBySlug {
   featureConfig: getExperiment_experimentBySlug_featureConfig | null;
   primaryOutcomes: (string | null)[] | null;
   secondaryOutcomes: (string | null)[] | null;
-  channel: NimbusExperimentChannel | null;
-  firefoxMinVersion: NimbusExperimentFirefoxVersion | null;
-  firefoxMaxVersion: NimbusExperimentFirefoxVersion | null;
+  channel: NimbusExperimentChannelEnum | null;
+  firefoxMinVersion: NimbusExperimentFirefoxVersionEnum | null;
+  firefoxMaxVersion: NimbusExperimentFirefoxVersionEnum | null;
   targetingConfigSlug: string | null;
   jexlTargetingExpression: string | null;
   populationPercent: string | null;

--- a/app/experimenter/nimbus-ui/src/types/globalTypes.ts
+++ b/app/experimenter/nimbus-ui/src/types/globalTypes.ts
@@ -27,7 +27,7 @@ export enum NimbusDocumentationLinkTitle {
   ENG_TICKET = "ENG_TICKET",
 }
 
-export enum NimbusExperimentApplication {
+export enum NimbusExperimentApplicationEnum {
   DESKTOP = "DESKTOP",
   FENIX = "FENIX",
   FOCUS_ANDROID = "FOCUS_ANDROID",
@@ -37,7 +37,7 @@ export enum NimbusExperimentApplication {
   KLAR_IOS = "KLAR_IOS",
 }
 
-export enum NimbusExperimentChannel {
+export enum NimbusExperimentChannelEnum {
   BETA = "BETA",
   NIGHTLY = "NIGHTLY",
   NO_CHANNEL = "NO_CHANNEL",
@@ -46,7 +46,7 @@ export enum NimbusExperimentChannel {
   UNBRANDED = "UNBRANDED",
 }
 
-export enum NimbusExperimentConclusionRecommendation {
+export enum NimbusExperimentConclusionRecommendationEnum {
   CHANGE_COURSE = "CHANGE_COURSE",
   FOLLOWUP = "FOLLOWUP",
   GRADUATE = "GRADUATE",
@@ -54,13 +54,13 @@ export enum NimbusExperimentConclusionRecommendation {
   STOP = "STOP",
 }
 
-export enum NimbusExperimentDocumentationLink {
+export enum NimbusExperimentDocumentationLinkEnum {
   DESIGN_DOC = "DESIGN_DOC",
   DS_JIRA = "DS_JIRA",
   ENG_TICKET = "ENG_TICKET",
 }
 
-export enum NimbusExperimentFirefoxVersion {
+export enum NimbusExperimentFirefoxVersionEnum {
   FIREFOX_100 = "FIREFOX_100",
   FIREFOX_11 = "FIREFOX_11",
   FIREFOX_12 = "FIREFOX_12",
@@ -155,28 +155,28 @@ export enum NimbusExperimentFirefoxVersion {
   NO_VERSION = "NO_VERSION",
 }
 
-export enum NimbusExperimentPublishStatus {
+export enum NimbusExperimentPublishStatusEnum {
   APPROVED = "APPROVED",
   IDLE = "IDLE",
   REVIEW = "REVIEW",
   WAITING = "WAITING",
 }
 
-export enum NimbusExperimentStatus {
+export enum NimbusExperimentStatusEnum {
   COMPLETE = "COMPLETE",
   DRAFT = "DRAFT",
   LIVE = "LIVE",
   PREVIEW = "PREVIEW",
 }
 
-export interface BranchScreenshotType {
+export interface BranchScreenshotInput {
   id?: number | null;
   image?: Upload | null;
   description?: string | null;
 }
 
-export interface DocumentationLinkType {
-  title: NimbusExperimentDocumentationLink;
+export interface DocumentationLinkInput {
+  title: NimbusExperimentDocumentationLinkEnum;
   link: string;
 }
 
@@ -189,25 +189,25 @@ export interface ExperimentCloneInput {
 export interface ExperimentInput {
   id?: number | null;
   isArchived?: boolean | null;
-  status?: NimbusExperimentStatus | null;
-  statusNext?: NimbusExperimentStatus | null;
-  publishStatus?: NimbusExperimentPublishStatus | null;
+  status?: NimbusExperimentStatusEnum | null;
+  statusNext?: NimbusExperimentStatusEnum | null;
+  publishStatus?: NimbusExperimentPublishStatusEnum | null;
   name?: string | null;
   hypothesis?: string | null;
-  application?: NimbusExperimentApplication | null;
+  application?: NimbusExperimentApplicationEnum | null;
   publicDescription?: string | null;
   isEnrollmentPaused?: boolean | null;
   riskMitigationLink?: string | null;
   featureConfigId?: number | null;
   warnFeatureSchema?: boolean | null;
-  documentationLinks?: (DocumentationLinkType | null)[] | null;
-  referenceBranch?: ReferenceBranchType | null;
-  treatmentBranches?: (TreatmentBranchType | null)[] | null;
+  documentationLinks?: (DocumentationLinkInput | null)[] | null;
+  referenceBranch?: ReferenceBranchInput | null;
+  treatmentBranches?: (TreatmentBranchInput | null)[] | null;
   primaryOutcomes?: (string | null)[] | null;
   secondaryOutcomes?: (string | null)[] | null;
-  channel?: NimbusExperimentChannel | null;
-  firefoxMinVersion?: NimbusExperimentFirefoxVersion | null;
-  firefoxMaxVersion?: NimbusExperimentFirefoxVersion | null;
+  channel?: NimbusExperimentChannelEnum | null;
+  firefoxMinVersion?: NimbusExperimentFirefoxVersionEnum | null;
+  firefoxMaxVersion?: NimbusExperimentFirefoxVersionEnum | null;
   populationPercent?: string | null;
   proposedDuration?: number | null;
   proposedEnrollment?: string | null;
@@ -219,28 +219,28 @@ export interface ExperimentInput {
   riskBrand?: boolean | null;
   countries?: (number | null)[] | null;
   locales?: (number | null)[] | null;
-  conclusionRecommendation?: NimbusExperimentConclusionRecommendation | null;
+  conclusionRecommendation?: NimbusExperimentConclusionRecommendationEnum | null;
   takeawaysSummary?: string | null;
 }
 
-export interface ReferenceBranchType {
+export interface ReferenceBranchInput {
   id?: number | null;
   name: string;
   description: string;
   ratio: number;
   featureEnabled?: boolean | null;
   featureValue?: string | null;
-  screenshots?: (BranchScreenshotType | null)[] | null;
+  screenshots?: (BranchScreenshotInput | null)[] | null;
 }
 
-export interface TreatmentBranchType {
+export interface TreatmentBranchInput {
   id?: number | null;
   name: string;
   description: string;
   ratio: number;
   featureEnabled?: boolean | null;
   featureValue?: string | null;
-  screenshots?: (BranchScreenshotType | null)[] | null;
+  screenshots?: (BranchScreenshotInput | null)[] | null;
 }
 
 //==============================================================


### PR DESCRIPTION
Because

* Not all of our graphql types were consistently named
* Sometimes it can be hard to tell whether something is a read type, a write input, or an enum just from the name without a suffix

This commit

* Renames all the v5 api graphql types to have either type, input, or enum as a suffix