### PR TITLE
fix #7003 chore(nimbus): move graphql tests to serializer tests

### DIFF
--- a/app/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_experiment_clone_serializer.py
+++ b/app/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_experiment_clone_serializer.py
@@ -62,3 +62,18 @@ class TestNimbusExperimentCloneSerializer(TestCase):
         )
         self.assertFalse(serializer.is_valid())
         self.assertIn("name", serializer.errors)
+
+    def test_invalid_rollout_branch_slug(self):
+        parent = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.ENDING_APPROVE_APPROVE
+        )
+        serializer = NimbusExperimentCloneSerializer(
+            data={
+                "parent_slug": parent.slug,
+                "name": "New Experiment",
+                "rollout_branch_slug": "BAD SLUG NOPE",
+            },
+            context={"user": parent.owner},
+        )
+        self.assertFalse(serializer.is_valid())
+        self.assertIn("rollout_branch_slug", serializer.errors)

--- a/app/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_experiment_serializer.py
+++ b/app/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_experiment_serializer.py
@@ -410,6 +410,30 @@ class TestNimbusExperimentSerializer(TestCase):
             serializer.errors,
         )
 
+    def test_status_with_invalid_target_status_next(self):
+        experiment = NimbusExperimentFactory(status=NimbusExperiment.Status.DRAFT)
+        serializer = NimbusExperimentSerializer(
+            experiment,
+            data={
+                "publish_status": NimbusExperiment.PublishStatus.REVIEW,
+                "status_next": NimbusExperiment.Status.COMPLETE,
+                "changelog_message": "test changelog message",
+            },
+            context={"user": self.user},
+        )
+        self.assertEqual(experiment.changes.count(), 0)
+        self.assertFalse(serializer.is_valid())
+        self.assertEqual(
+            serializer.errors,
+            {
+                "status_next": [
+                    "Invalid choice for status_next: 'Complete' - with status 'Draft',"
+                    " the only valid choices are 'None, Live'"
+                ]
+            },
+            serializer.errors,
+        )
+
     def test_status_restriction(self):
         experiment = NimbusExperimentFactory(status=NimbusExperiment.Status.LIVE)
         serializer = NimbusExperimentSerializer(


### PR DESCRIPTION
Because

* Some core serializer logic was being tested at the graphql layer
* This made it difficult to reason about test coverage for major serializer changes

This commit

* Moves tests from graphql to serializer that test core serializer logic
* Deprecates some redundant graphql tests
* Preserves graphql tests for integration purposes