### PR TITLE
fix #6747 refactor(nimbus): Refactor nimbus-ui branch reducer to use Input type

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/FormBranch.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/FormBranch.test.tsx
@@ -11,11 +11,7 @@ import {
 } from "@testing-library/react";
 import React from "react";
 import { FIELD_MESSAGES } from "../../../lib/constants";
-import {
-  MOCK_ANNOTATED_BRANCH,
-  MOCK_FEATURE_CONFIG_WITH_SCHEMA,
-  SubjectBranch,
-} from "./mocks";
+import { MOCK_ANNOTATED_BRANCH, SubjectBranch } from "./mocks";
 
 describe("FormBranch", () => {
   it("renders as expected", () => {
@@ -58,7 +54,6 @@ describe("FormBranch", () => {
     render(
       <SubjectBranch
         branch={{ ...MOCK_ANNOTATED_BRANCH, featureEnabled: false }}
-        experimentFeatureConfig={MOCK_FEATURE_CONFIG_WITH_SCHEMA}
       />,
     );
     expect(screen.queryByTestId("feature-value-edit")).not.toBeInTheDocument();
@@ -72,7 +67,6 @@ describe("FormBranch", () => {
           featureValue: "this is a default value",
           featureEnabled: true,
         }}
-        experimentFeatureConfig={MOCK_FEATURE_CONFIG_WITH_SCHEMA}
       />,
     );
     expect(screen.queryByTestId("feature-value-edit")).toBeInTheDocument();

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/FormBranch.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/FormBranch.tsx
@@ -11,7 +11,6 @@ import { FieldError } from "react-hook-form";
 import { useCommonNestedForm } from "../../../hooks";
 import { ReactComponent as DeleteIcon } from "../../../images/x.svg";
 import { NUMBER_FIELD, REQUIRED_FIELD } from "../../../lib/constants";
-import { getExperiment_experimentBySlug } from "../../../types/getExperiment";
 import FormScreenshot, { FormScreenshotProps } from "./FormScreenshot";
 import { AnnotatedBranch } from "./reducer";
 
@@ -34,7 +33,6 @@ export const FormBranch = ({
   branch,
   equalRatio,
   isReference,
-  experimentFeatureConfig,
   onAddScreenshot,
   onRemoveScreenshot,
   onRemove,
@@ -49,7 +47,6 @@ export const FormBranch = ({
   branch: AnnotatedBranch;
   equalRatio?: boolean;
   isReference?: boolean;
-  experimentFeatureConfig: getExperiment_experimentBySlug["featureConfig"];
   onAddScreenshot: () => void;
   onRemoveScreenshot: (screenshotIdx: number) => void;
   onRemove?: () => void;

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/index.stories.tsx
@@ -61,7 +61,6 @@ storiesOf("pages/EditBranches/FormBranches/FormBranch", module)
   .add("with feature", () => (
     <SubjectBranch
       {...commonFormBranchProps}
-      experimentFeatureConfig={MOCK_FEATURE_CONFIG}
       branch={{
         ...MOCK_ANNOTATED_BRANCH,
         featureEnabled: false,
@@ -72,7 +71,6 @@ storiesOf("pages/EditBranches/FormBranches/FormBranch", module)
   .add("with feature value", () => (
     <SubjectBranch
       {...commonFormBranchProps}
-      experimentFeatureConfig={MOCK_FEATURE_CONFIG_WITH_SCHEMA}
       branch={{
         ...MOCK_ANNOTATED_BRANCH,
         featureEnabled: true,
@@ -83,7 +81,6 @@ storiesOf("pages/EditBranches/FormBranches/FormBranch", module)
   .add("with several screenshots", () => (
     <SubjectBranch
       {...commonFormBranchProps}
-      experimentFeatureConfig={MOCK_FEATURE_CONFIG_WITH_SCHEMA}
       branch={{
         ...MOCK_ANNOTATED_BRANCH,
         featureEnabled: true,

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/index.test.tsx
@@ -52,7 +52,7 @@ describe("FormBranches", () => {
     await clickAndWaitForSave(onSave);
     const onSaveArgs = onSave.mock.calls[0];
     expect(onSaveArgs[0]).toEqual({
-      featureConfigId: null,
+      featureConfigId: undefined,
       // @ts-ignore type mismatch covers discarded annotation properties
       referenceBranch: extractUpdateBranch(MOCK_EXPERIMENT.referenceBranch!),
       treatmentBranches: MOCK_EXPERIMENT.treatmentBranches!.map(
@@ -329,7 +329,7 @@ describe("FormBranches", () => {
         }}
       />,
     );
-    selectFeatureConfig();
+    selectFeatureConfig(1);
     await clickAndWaitForSave(onSave);
     expect(onSave.mock.calls[0][0].featureConfigId).toEqual(
       MOCK_CONFIG.featureConfigs![1]!.id,

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/index.tsx
@@ -11,10 +11,7 @@ import Form from "react-bootstrap/Form";
 import { FormProvider } from "react-hook-form";
 import { useExitWarning, useForm, useReviewCheck } from "../../../hooks";
 import { IsDirtyUnsaved } from "../../../hooks/useCommonForm/useCommonFormMethods";
-import {
-  getConfig_nimbusConfig,
-  getConfig_nimbusConfig_featureConfigs,
-} from "../../../types/getConfig";
+import { getConfig_nimbusConfig } from "../../../types/getConfig";
 import { getExperiment_experimentBySlug } from "../../../types/getExperiment";
 import FormBranch from "./FormBranch";
 import {
@@ -46,7 +43,7 @@ export const FormBranches = ({
 
   const [
     {
-      featureConfig: experimentFeatureConfig,
+      featureConfigId: experimentFeatureConfigId,
       warnFeatureSchema,
       referenceBranch,
       treatmentBranches,
@@ -123,9 +120,7 @@ export const FormBranches = ({
     });
   };
 
-  const handleFeatureConfigChange = (
-    value: getConfig_nimbusConfig_featureConfigs | null,
-  ) => {
+  const handleFeatureConfigChange = (value: number | null | undefined) => {
     commitFormData();
     dispatch({ type: "setFeatureConfig", value });
   };
@@ -137,7 +132,7 @@ export const FormBranches = ({
     }
     // featureConfig shouldn't ever be null in practice
     const feature = featureConfigs![selectedIdx];
-    return handleFeatureConfigChange(feature);
+    return handleFeatureConfigChange(feature?.id);
   };
 
   const handleAddScreenshot = (branchIdx: number) => () => {
@@ -174,7 +169,6 @@ export const FormBranches = ({
 
   const commonBranchProps = {
     equalRatio,
-    experimentFeatureConfig,
     setSubmitErrors,
   };
 
@@ -212,9 +206,7 @@ export const FormBranches = ({
                 fieldWarnings.feature_config?.length > 0,
             })}
             onChange={onFeatureConfigChange}
-            value={featureConfigs!.findIndex(
-              (feature) => feature?.slug === experimentFeatureConfig?.slug,
-            )}
+            value={experimentFeatureConfigId || undefined}
           >
             <option value="">Select...</option>
             {featureConfigs?.map(

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/mocks.tsx
@@ -13,6 +13,7 @@ import { formBranchesActionReducer } from "./reducer/actions";
 import { FormBranchesState } from "./reducer/state";
 
 export const MOCK_EXPERIMENT = mockExperimentQuery("demo-slug", {
+  featureConfig: null, //MOCK_CONFIG!.featureConfigs![0],
   referenceBranch: {
     id: 123,
     name: "User-centric mobile solution",
@@ -51,7 +52,7 @@ const MOCK_STATE: FormBranchesState = {
   equalRatio: true,
   lastId: 0,
   globalErrors: [],
-  featureConfig: MOCK_EXPERIMENT.featureConfig,
+  featureConfigId: null,
   warnFeatureSchema: false,
   referenceBranch: {
     ...MOCK_EXPERIMENT.referenceBranch!,
@@ -78,7 +79,6 @@ export const SubjectBranch = ({
   branch = MOCK_ANNOTATED_BRANCH,
   equalRatio = false,
   isReference = false,
-  experimentFeatureConfig = MOCK_FEATURE_CONFIG,
   onAddScreenshot = () => {},
   onRemoveScreenshot = () => {},
   onRemove = () => {},
@@ -116,7 +116,6 @@ export const SubjectBranch = ({
             branch,
             isReference,
             equalRatio,
-            experimentFeatureConfig,
             onRemove,
             onAddScreenshot,
             onRemoveScreenshot,

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/reducer/actions.ts
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/reducer/actions.ts
@@ -58,7 +58,7 @@ type AddBranchAction = {
   type: "addBranch";
 };
 
-function addBranch(state: FormBranchesState) {
+function addBranch(state: FormBranchesState): FormBranchesState {
   let { lastId, referenceBranch, treatmentBranches } = state;
   lastId++;
 
@@ -88,7 +88,10 @@ type RemoveBranchAction = {
   idx: number;
 };
 
-function removeBranch(state: FormBranchesState, { idx }: RemoveBranchAction) {
+function removeBranch(
+  state: FormBranchesState,
+  { idx }: RemoveBranchAction,
+): FormBranchesState {
   const treatmentBranches = state.treatmentBranches || [];
   return {
     ...state,
@@ -99,7 +102,7 @@ function removeBranch(state: FormBranchesState, { idx }: RemoveBranchAction) {
   };
 }
 
-function removeFeatureConfig(state: FormBranchesState) {
+function removeFeatureConfig(state: FormBranchesState): FormBranchesState {
   let { referenceBranch, treatmentBranches } = state;
 
   if (referenceBranch) {
@@ -119,7 +122,7 @@ function removeFeatureConfig(state: FormBranchesState) {
 
   return {
     ...state,
-    featureConfig: null,
+    featureConfigId: null,
     referenceBranch,
     treatmentBranches,
   };
@@ -127,17 +130,17 @@ function removeFeatureConfig(state: FormBranchesState) {
 
 type SetFeatureConfigAction = {
   type: "setFeatureConfig";
-  value: FormBranchesState["featureConfig"];
+  value: FormBranchesState["featureConfigId"];
 };
 
 function setFeatureConfig(
   state: FormBranchesState,
-  { value: featureConfig }: SetFeatureConfigAction,
-) {
-  if (!featureConfig) return removeFeatureConfig(state);
+  { value: featureConfigId }: SetFeatureConfigAction,
+): FormBranchesState {
+  if (!featureConfigId) return removeFeatureConfig(state);
   return {
     ...state,
-    featureConfig,
+    featureConfigId,
   };
 }
 
@@ -149,7 +152,7 @@ type SetwarnFeatureSchemaAction = {
 function setwarnFeatureSchema(
   state: FormBranchesState,
   { value: warnFeatureSchema }: SetwarnFeatureSchemaAction,
-) {
+): FormBranchesState {
   return {
     ...state,
     warnFeatureSchema,
@@ -164,7 +167,7 @@ type SetEqualRatioAction = {
 function setEqualRatio(
   state: FormBranchesState,
   { value: equalRatio }: SetEqualRatioAction,
-) {
+): FormBranchesState {
   let { referenceBranch, treatmentBranches } = state;
   if (equalRatio) {
     if (referenceBranch !== null) {
@@ -196,7 +199,7 @@ type SetSubmitErrorsAction = {
 function setSubmitErrors(
   state: FormBranchesState,
   action: SetSubmitErrorsAction,
-) {
+): FormBranchesState {
   let { referenceBranch, treatmentBranches } = state;
   const { submitErrors } = action;
   const globalErrors = [];
@@ -239,7 +242,7 @@ type ClearSubmitErrorsAction = {
   type: "clearSubmitErrors";
 };
 
-function clearSubmitErrors(state: FormBranchesState) {
+function clearSubmitErrors(state: FormBranchesState): FormBranchesState {
   let { referenceBranch, treatmentBranches } = state;
   const globalErrors = [] as string[];
 
@@ -270,7 +273,7 @@ type CommitFormDataAction = {
 function commitFormData(
   state: FormBranchesState,
   action: CommitFormDataAction,
-) {
+): FormBranchesState {
   const { formData } = action;
   let { referenceBranch, treatmentBranches } = state;
 
@@ -324,7 +327,7 @@ type AddScreenshotToBranchAction = {
 function addScreenshotToBranch(
   state: FormBranchesState,
   action: AddScreenshotToBranchAction,
-) {
+): FormBranchesState {
   const { branchIdx } = action;
   let { referenceBranch, treatmentBranches } = state;
 
@@ -362,7 +365,7 @@ type RemoveScreenshotFromBranchAction = {
 function removeScreenshotFromBranch(
   state: FormBranchesState,
   action: RemoveScreenshotFromBranchAction,
-) {
+): FormBranchesState {
   const { branchIdx, screenshotIdx } = action;
   let { referenceBranch, treatmentBranches } = state;
 

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/reducer/index.test.ts
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/reducer/index.test.ts
@@ -12,7 +12,7 @@ const MOCK_STATE: FormBranchesState = {
   equalRatio: true,
   lastId: 0,
   globalErrors: [],
-  featureConfig: MOCK_EXPERIMENT.featureConfig,
+  featureConfigId: null,
   warnFeatureSchema: false,
   referenceBranch: {
     ...MOCK_EXPERIMENT.referenceBranch!,
@@ -226,6 +226,7 @@ describe("formBranchesReducer", () => {
   const commonClearFeatureConfigTest = (action: FormBranchesAction) => () => {
     const oldState = {
       ...MOCK_STATE,
+      featureConfigId: null,
       referenceBranch: {
         ...MOCK_STATE.referenceBranch!,
         featureEnabled: true,
@@ -238,7 +239,7 @@ describe("formBranchesReducer", () => {
 
     const newState = formBranchesActionReducer(oldState, action);
 
-    expect(newState.featureConfig).toBeNull();
+    expect(newState.featureConfigId).toBeNull();
     expect(newState.referenceBranch?.featureEnabled).toBe(false);
     expect(
       newState.treatmentBranches?.every(

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/reducer/state.ts
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/reducer/state.ts
@@ -6,11 +6,14 @@ import {
   getExperiment_experimentBySlug,
   getExperiment_experimentBySlug_treatmentBranches,
 } from "../../../../types/getExperiment";
-import { TreatmentBranchInput } from "../../../../types/globalTypes";
+import {
+  ExperimentInput,
+  TreatmentBranchInput,
+} from "../../../../types/globalTypes";
 
 export type FormBranchesState = Pick<
-  getExperiment_experimentBySlug,
-  "featureConfig" | "warnFeatureSchema"
+  ExperimentInput,
+  "featureConfigId" | "warnFeatureSchema"
 > & {
   referenceBranch: null | AnnotatedBranch;
   treatmentBranches: null | AnnotatedBranch[];
@@ -57,7 +60,7 @@ export function createInitialState({
   return {
     lastId,
     equalRatio,
-    featureConfig,
+    featureConfigId: featureConfig?.id,
     warnFeatureSchema,
     globalErrors: [],
     referenceBranch: annotatedReferenceBranch,

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/reducer/update.ts
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/reducer/update.ts
@@ -29,7 +29,7 @@ export function extractUpdateState(
   formData: FormData,
 ): FormBranchesSaveState {
   const {
-    featureConfig,
+    featureConfigId,
     warnFeatureSchema,
     referenceBranch,
     treatmentBranches,
@@ -38,8 +38,6 @@ export function extractUpdateState(
   if (!referenceBranch) {
     throw new UpdateStateError(CONTROL_BRANCH_REQUIRED_ERROR);
   }
-
-  const featureConfigId = featureConfig === null ? null : featureConfig.id;
 
   return {
     featureConfigId,

--- a/app/experimenter/nimbus-ui/src/hooks/useCommonForm/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/hooks/useCommonForm/index.test.tsx
@@ -20,10 +20,7 @@ import { Subject as OverviewSubject } from "../../components/FormOverview/mocks"
 import { audienceFieldNames } from "../../components/PageEditAudience/FormAudience";
 import { Subject as AudienceSubject } from "../../components/PageEditAudience/FormAudience/mocks";
 import { branchFieldNames } from "../../components/PageEditBranches/FormBranches/FormBranch";
-import {
-  MOCK_FEATURE_CONFIG_WITH_SCHEMA,
-  SubjectBranch as BranchSubject,
-} from "../../components/PageEditBranches/FormBranches/mocks";
+import { SubjectBranch as BranchSubject } from "../../components/PageEditBranches/FormBranches/mocks";
 import { metricsFieldNames } from "../../components/PageEditMetrics/FormMetrics";
 import { Subject as MetricsSubject } from "../../components/PageEditMetrics/FormMetrics/mocks";
 import { mockExperimentQuery } from "../../lib/mocks";
@@ -164,11 +161,7 @@ describe("hooks/useCommonForm", () => {
     });
 
     it("FormBranch", () => {
-      const { container } = render(
-        <BranchSubject
-          experimentFeatureConfig={MOCK_FEATURE_CONFIG_WITH_SCHEMA}
-        />,
-      );
+      const { container } = render(<BranchSubject />);
 
       branchFieldNames.forEach((name) => {
         const fieldName = `referenceBranch.${name}`;


### PR DESCRIPTION
Because:

- the branch editing reducer uses the experiment schema type for
  internal state, rather than the ExperimentInput type that's the ultimate
  product of the reducer

This commit:

- switches over to the ExperimentInput type so that the reducer can more
  correctly handle the data it will eventually produce for submission to
  the GQL API