### PR TITLE
fix #6739 feat(nimbus): support multifeature in v5 api

### DIFF
--- a/app/experimenter/experiments/api/v5/inputs.py
+++ b/app/experimenter/experiments/api/v5/inputs.py
@@ -18,6 +18,12 @@ class BranchScreenshotInput(graphene.InputObjectType):
     description = graphene.String()
 
 
+class BranchFeatureValueInput(graphene.InputObjectType):
+    feature_config = graphene.Int()
+    enabled = graphene.Boolean()
+    value = graphene.String()
+
+
 class BranchInput(graphene.InputObjectType):
     id = graphene.Int()
     name = graphene.String(required=True)
@@ -25,6 +31,7 @@ class BranchInput(graphene.InputObjectType):
     ratio = graphene.Int(required=True)
     feature_enabled = graphene.Boolean()
     feature_value = graphene.String()
+    feature_values = graphene.List(BranchFeatureValueInput)
     screenshots = graphene.List(BranchScreenshotInput)
 
 
@@ -58,6 +65,7 @@ class ExperimentInput(graphene.InputObjectType):
     is_enrollment_paused = graphene.Boolean()
     risk_mitigation_link = graphene.String()
     feature_config_id = graphene.Int()
+    feature_configs = graphene.List(graphene.Int)
     warn_feature_schema = graphene.Boolean()
     documentation_links = graphene.List(DocumentationLinkInput)
     reference_branch = graphene.Field(ReferenceBranchInput)

--- a/app/experimenter/experiments/constants/nimbus.py
+++ b/app/experimenter/experiments/constants/nimbus.py
@@ -784,6 +784,11 @@ Optional - We believe this outcome will <describe impact> on <core metric>
     # Serializer validation errors
     ERROR_DUPLICATE_BRANCH_NAME = "Branch names must be unique."
     ERROR_SINGLE_BRANCH_FOR_ROLLOUT = "A rollout may have only a single reference branch"
+    ERROR_DUPLICATE_BRANCH_FEATURE_VALUE = (
+        "A branch can not have multiple configurations for the same feature"
+    )
+    ERROR_BRANCH_NO_VALUE = "A value must be supplied for an enabled feature."
+    ERROR_BRANCH_NO_ENABLED = "Enabled must be specified to include a value."
     ERROR_REQUIRED_QUESTION = "This question may not be blank."
     ERROR_REQUIRED_FIELD = "This field may not be blank."
     ERROR_REQUIRED_FEATURE_CONFIG = (

--- a/app/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_ready_for_review_serializer.py
+++ b/app/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_ready_for_review_serializer.py
@@ -1,7 +1,7 @@
 from django.test import TestCase
 from parameterized import parameterized
 
-from experimenter.experiments.api.v5.serializers import NimbusReadyForReviewSerializer
+from experimenter.experiments.api.v5.serializers import NimbusReviewSerializer
 from experimenter.experiments.constants.nimbus import NimbusConstants
 from experimenter.experiments.models import NimbusExperiment
 from experimenter.experiments.tests.factories import (
@@ -11,24 +11,24 @@ from experimenter.experiments.tests.factories import (
 from experimenter.experiments.tests.factories.nimbus import NimbusFeatureConfigFactory
 from experimenter.openidc.tests.factories import UserFactory
 
-
-class TestNimbusReadyForReviewSerializer(TestCase):
-    maxDiff = None
-
-    BASIC_JSON_SCHEMA = """\
-    {
-    "$schema": "http://json-schema.org/draft-07/schema#",
-    "description": "Password autocomplete",
-    "type": "object",
-    "properties": {
-        "directMigrateSingleProfile": {
-        "description": "Should we directly migrate a single profile?",
-        "type": "boolean"
-        }
-    },
-    "additionalProperties": false
+BASIC_JSON_SCHEMA = """\
+{
+"$schema": "http://json-schema.org/draft-07/schema#",
+"description": "Password autocomplete",
+"type": "object",
+"properties": {
+    "directMigrateSingleProfile": {
+    "description": "Should we directly migrate a single profile?",
+    "type": "boolean"
     }
-    """
+},
+"additionalProperties": false
+}
+"""
+
+
+class TestNimbusReviewSerializerSingleFeature(TestCase):
+    maxDiff = None
 
     def setUp(self):
         super().setUp()
@@ -44,9 +44,9 @@ class TestNimbusReadyForReviewSerializer(TestCase):
                 )
             ],
         )
-        serializer = NimbusReadyForReviewSerializer(
+        serializer = NimbusReviewSerializer(
             experiment,
-            data=NimbusReadyForReviewSerializer(
+            data=NimbusReviewSerializer(
                 experiment,
                 context={"user": self.user},
             ).data,
@@ -67,9 +67,9 @@ class TestNimbusReadyForReviewSerializer(TestCase):
                 ),
             ],
         )
-        serializer = NimbusReadyForReviewSerializer(
+        serializer = NimbusReviewSerializer(
             experiment,
-            data=NimbusReadyForReviewSerializer(
+            data=NimbusReviewSerializer(
                 experiment,
                 context={"user": self.user},
             ).data,
@@ -89,9 +89,9 @@ class TestNimbusReadyForReviewSerializer(TestCase):
         )
         experiment.hypothesis = NimbusExperiment.HYPOTHESIS_DEFAULT
         experiment.save()
-        serializer = NimbusReadyForReviewSerializer(
+        serializer = NimbusReviewSerializer(
             experiment,
-            data=NimbusReadyForReviewSerializer(
+            data=NimbusReviewSerializer(
                 experiment,
                 context={"user": self.user},
             ).data,
@@ -115,9 +115,9 @@ class TestNimbusReadyForReviewSerializer(TestCase):
         )
         experiment.reference_branch = None
         experiment.save()
-        serializer = NimbusReadyForReviewSerializer(
+        serializer = NimbusReviewSerializer(
             experiment,
-            data=NimbusReadyForReviewSerializer(
+            data=NimbusReviewSerializer(
                 experiment,
                 context={"user": self.user},
             ).data,
@@ -141,9 +141,9 @@ class TestNimbusReadyForReviewSerializer(TestCase):
         )
         experiment.reference_branch.description = ""
         experiment.save()
-        serializer = NimbusReadyForReviewSerializer(
+        serializer = NimbusReviewSerializer(
             experiment,
-            data=NimbusReadyForReviewSerializer(
+            data=NimbusReviewSerializer(
                 experiment,
                 context={"user": self.user},
             ).data,
@@ -162,9 +162,9 @@ class TestNimbusReadyForReviewSerializer(TestCase):
             firefox_min_version=NimbusExperiment.Version.FIREFOX_95,
         )
         experiment.save()
-        serializer = NimbusReadyForReviewSerializer(
+        serializer = NimbusReviewSerializer(
             experiment,
-            data=NimbusReadyForReviewSerializer(
+            data=NimbusReviewSerializer(
                 experiment,
                 context={"user": self.user},
             ).data,
@@ -186,9 +186,9 @@ class TestNimbusReadyForReviewSerializer(TestCase):
             firefox_min_version=NimbusExperiment.Version.FIREFOX_83,
         )
         experiment.save()
-        serializer = NimbusReadyForReviewSerializer(
+        serializer = NimbusReviewSerializer(
             experiment,
-            data=NimbusReadyForReviewSerializer(
+            data=NimbusReviewSerializer(
                 experiment,
                 context={"user": self.user},
             ).data,
@@ -207,9 +207,9 @@ class TestNimbusReadyForReviewSerializer(TestCase):
                 )
             ],
         )
-        serializer = NimbusReadyForReviewSerializer(
+        serializer = NimbusReviewSerializer(
             experiment,
-            data=NimbusReadyForReviewSerializer(
+            data=NimbusReviewSerializer(
                 experiment,
                 context={"user": self.user},
             ).data,
@@ -232,9 +232,9 @@ class TestNimbusReadyForReviewSerializer(TestCase):
                 )
             ],
         )
-        serializer = NimbusReadyForReviewSerializer(
+        serializer = NimbusReviewSerializer(
             experiment,
-            data=NimbusReadyForReviewSerializer(
+            data=NimbusReviewSerializer(
                 experiment,
                 context={"user": self.user},
             ).data,
@@ -257,9 +257,9 @@ class TestNimbusReadyForReviewSerializer(TestCase):
         )
         experiment.branches.add(treatment_branch)
         experiment.save()
-        serializer = NimbusReadyForReviewSerializer(
+        serializer = NimbusReviewSerializer(
             experiment,
-            data=NimbusReadyForReviewSerializer(
+            data=NimbusReviewSerializer(
                 experiment,
                 context={"user": self.user},
             ).data,
@@ -277,9 +277,9 @@ class TestNimbusReadyForReviewSerializer(TestCase):
             application=NimbusExperiment.Application.DESKTOP,
             feature_configs=[],
         )
-        serializer = NimbusReadyForReviewSerializer(
+        serializer = NimbusReviewSerializer(
             experiment,
-            data=NimbusReadyForReviewSerializer(
+            data=NimbusReviewSerializer(
                 experiment,
                 context={"user": self.user},
             ).data,
@@ -304,9 +304,9 @@ class TestNimbusReadyForReviewSerializer(TestCase):
                 )
             ],
         )
-        serializer = NimbusReadyForReviewSerializer(
+        serializer = NimbusReviewSerializer(
             experiment,
-            data=NimbusReadyForReviewSerializer(
+            data=NimbusReviewSerializer(
                 experiment,
                 context={"user": self.user},
             ).data,
@@ -341,9 +341,9 @@ class TestNimbusReadyForReviewSerializer(TestCase):
             feature_configs=[NimbusFeatureConfigFactory(application=application)],
         )
 
-        serializer = NimbusReadyForReviewSerializer(
+        serializer = NimbusReviewSerializer(
             experiment,
-            data=NimbusReadyForReviewSerializer(
+            data=NimbusReviewSerializer(
                 experiment,
                 context={"user": self.user},
             ).data,
@@ -355,21 +355,22 @@ class TestNimbusReadyForReviewSerializer(TestCase):
             self.assertIn("channel", serializer.errors)
 
     def test_serializer_feature_config_validation_application_mismatches_error(self):
-        experiment = NimbusExperimentFactory(
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
             status=NimbusExperiment.Status.DRAFT,
             application=NimbusExperiment.Application.FENIX,
             channel=NimbusExperiment.Channel.RELEASE,
             feature_configs=[
                 NimbusFeatureConfigFactory.create(
-                    schema=self.BASIC_JSON_SCHEMA,
+                    schema=BASIC_JSON_SCHEMA,
                     application=NimbusExperiment.Application.IOS,
                 )
             ],
         )
 
-        serializer = NimbusReadyForReviewSerializer(
+        serializer = NimbusReviewSerializer(
             experiment,
-            data=NimbusReadyForReviewSerializer(
+            data=NimbusReviewSerializer(
                 experiment,
                 context={"user": self.user},
             ).data,
@@ -378,25 +379,24 @@ class TestNimbusReadyForReviewSerializer(TestCase):
 
         self.assertFalse(serializer.is_valid())
         self.assertEqual(
-            serializer.errors,
-            {
-                "feature_config": [
-                    "Feature Config application ios does not "
-                    "match experiment application fenix."
-                ]
-            },
+            serializer.errors["feature_config"],
+            [
+                "Feature Config application ios does not "
+                "match experiment application fenix."
+            ],
         )
 
     def test_serializer_feature_config_validation_missing_feature_config(self):
-        experiment = NimbusExperimentFactory(
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
             status=NimbusExperiment.Status.DRAFT,
             application=NimbusExperiment.Application.FENIX,
             feature_configs=[],
         )
 
-        serializer = NimbusReadyForReviewSerializer(
+        serializer = NimbusReviewSerializer(
             experiment,
-            data=NimbusReadyForReviewSerializer(
+            data=NimbusReviewSerializer(
                 experiment,
                 context={"user": self.user},
             ).data,
@@ -405,18 +405,19 @@ class TestNimbusReadyForReviewSerializer(TestCase):
 
         self.assertFalse(serializer.is_valid())
         self.assertEqual(
-            serializer.errors["feature_config"][0],
-            "You must select a feature configuration from the drop down.",
+            serializer.errors["feature_config"],
+            ["You must select a feature configuration from the drop down."],
         )
 
     def test_serializer_feature_config_validation_bad_json_value(self):
-        experiment = NimbusExperimentFactory(
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
             status=NimbusExperiment.Status.DRAFT,
             application=NimbusExperiment.Application.DESKTOP,
             channel=NimbusExperiment.Channel.NO_CHANNEL,
             feature_configs=[
                 NimbusFeatureConfigFactory.create(
-                    schema=self.BASIC_JSON_SCHEMA,
+                    schema=BASIC_JSON_SCHEMA,
                     application=NimbusExperiment.Application.DESKTOP,
                 )
             ],
@@ -434,9 +435,9 @@ class TestNimbusReadyForReviewSerializer(TestCase):
         """.strip()
         treatment_branch_value.save()
 
-        serializer = NimbusReadyForReviewSerializer(
+        serializer = NimbusReviewSerializer(
             experiment,
-            data=NimbusReadyForReviewSerializer(
+            data=NimbusReviewSerializer(
                 experiment,
                 context={"user": self.user},
             ).data,
@@ -451,13 +452,14 @@ class TestNimbusReadyForReviewSerializer(TestCase):
         self.assertEqual(len(serializer.errors), 1)
 
     def test_serializer_feature_config_validation_reference_value_schema_error(self):
-        experiment = NimbusExperimentFactory(
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
             status=NimbusExperiment.Status.DRAFT,
             application=NimbusExperiment.Application.DESKTOP,
             channel=NimbusExperiment.Channel.NO_CHANNEL,
             feature_configs=[
                 NimbusFeatureConfigFactory.create(
-                    schema=self.BASIC_JSON_SCHEMA,
+                    schema=BASIC_JSON_SCHEMA,
                     application=NimbusExperiment.Application.DESKTOP,
                 )
             ],
@@ -475,9 +477,9 @@ class TestNimbusReadyForReviewSerializer(TestCase):
         """.strip()
         treatment_feature_value.save()
 
-        serializer = NimbusReadyForReviewSerializer(
+        serializer = NimbusReviewSerializer(
             experiment,
-            data=NimbusReadyForReviewSerializer(
+            data=NimbusReviewSerializer(
                 experiment,
                 context={"user": self.user},
             ).data,
@@ -493,14 +495,15 @@ class TestNimbusReadyForReviewSerializer(TestCase):
         self.assertEqual(len(serializer.errors), 1)
 
     def test_serializer_feature_config_validation_reference_value_schema_warn(self):
-        experiment = NimbusExperimentFactory(
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
             status=NimbusExperiment.Status.DRAFT,
             application=NimbusExperiment.Application.DESKTOP,
             channel=NimbusExperiment.Channel.NO_CHANNEL,
             warn_feature_schema=True,
             feature_configs=[
                 NimbusFeatureConfigFactory.create(
-                    schema=self.BASIC_JSON_SCHEMA,
+                    schema=BASIC_JSON_SCHEMA,
                     application=NimbusExperiment.Application.DESKTOP,
                 )
             ],
@@ -518,9 +521,9 @@ class TestNimbusReadyForReviewSerializer(TestCase):
         """.strip()
         treatment_feature_value.save()
 
-        serializer = NimbusReadyForReviewSerializer(
+        serializer = NimbusReviewSerializer(
             experiment,
-            data=NimbusReadyForReviewSerializer(
+            data=NimbusReviewSerializer(
                 experiment,
                 context={"user": self.user},
             ).data,
@@ -536,13 +539,14 @@ class TestNimbusReadyForReviewSerializer(TestCase):
         self.assertEqual(len(serializer.warnings), 1, serializer.warnings)
 
     def test_serializer_feature_config_validation_treatment_value_schema_error(self):
-        experiment = NimbusExperimentFactory(
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
             status=NimbusExperiment.Status.DRAFT,
             application=NimbusExperiment.Application.DESKTOP,
             channel=NimbusExperiment.Channel.NO_CHANNEL,
             feature_configs=[
                 NimbusFeatureConfigFactory.create(
-                    schema=self.BASIC_JSON_SCHEMA,
+                    schema=BASIC_JSON_SCHEMA,
                     application=NimbusExperiment.Application.DESKTOP,
                 )
             ],
@@ -559,9 +563,9 @@ class TestNimbusReadyForReviewSerializer(TestCase):
         """.strip()
         treatment_feature_value.save()
 
-        serializer = NimbusReadyForReviewSerializer(
+        serializer = NimbusReviewSerializer(
             experiment,
-            data=NimbusReadyForReviewSerializer(
+            data=NimbusReviewSerializer(
                 experiment,
                 context={"user": self.user},
             ).data,
@@ -578,14 +582,15 @@ class TestNimbusReadyForReviewSerializer(TestCase):
         self.assertEqual(len(serializer.errors), 1)
 
     def test_serializer_feature_config_validation_treatment_value_schema_warn(self):
-        experiment = NimbusExperimentFactory(
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
             status=NimbusExperiment.Status.DRAFT,
             application=NimbusExperiment.Application.DESKTOP,
             channel=NimbusExperiment.Channel.NO_CHANNEL,
             warn_feature_schema=True,
             feature_configs=[
                 NimbusFeatureConfigFactory.create(
-                    schema=self.BASIC_JSON_SCHEMA,
+                    schema=BASIC_JSON_SCHEMA,
                     application=NimbusExperiment.Application.DESKTOP,
                 )
             ],
@@ -602,9 +607,9 @@ class TestNimbusReadyForReviewSerializer(TestCase):
         """.strip()
         treatment_feature_value.save()
 
-        serializer = NimbusReadyForReviewSerializer(
+        serializer = NimbusReviewSerializer(
             experiment,
-            data=NimbusReadyForReviewSerializer(
+            data=NimbusReviewSerializer(
                 experiment,
                 context={"user": self.user},
             ).data,
@@ -621,7 +626,8 @@ class TestNimbusReadyForReviewSerializer(TestCase):
         )
 
     def test_serializer_feature_config_validation_treatment_value_no_schema(self):
-        experiment = NimbusExperimentFactory(
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
             status=NimbusExperiment.Status.DRAFT,
             application=NimbusExperiment.Application.DESKTOP,
             channel=NimbusExperiment.Channel.NO_CHANNEL,
@@ -632,12 +638,375 @@ class TestNimbusReadyForReviewSerializer(TestCase):
                 )
             ],
         )
-        serializer = NimbusReadyForReviewSerializer(
+        serializer = NimbusReviewSerializer(
             experiment,
-            data=NimbusReadyForReviewSerializer(
+            data=NimbusReviewSerializer(
                 experiment,
                 context={"user": self.user},
             ).data,
             context={"user": self.user},
         )
         self.assertTrue(serializer.is_valid())
+
+
+class TestNimbusReviewSerializerMultiFeature(TestCase):
+    def setUp(self):
+        super().setUp()
+        self.user = UserFactory()
+        self.feature_without_schema = NimbusFeatureConfigFactory.create(
+            schema=None,
+            application=NimbusExperiment.Application.DESKTOP,
+        )
+        self.feature_with_schema = NimbusFeatureConfigFactory.create(
+            schema=BASIC_JSON_SCHEMA,
+            application=NimbusExperiment.Application.DESKTOP,
+        )
+
+    def test_serializer_feature_config_validation_application_mismatches_error(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            status=NimbusExperiment.Status.DRAFT,
+            application=NimbusExperiment.Application.FENIX,
+            channel=NimbusExperiment.Channel.RELEASE,
+            feature_configs=[
+                NimbusFeatureConfigFactory.create(
+                    schema=None,
+                    application=NimbusExperiment.Application.FENIX,
+                ),
+                NimbusFeatureConfigFactory.create(
+                    schema=None,
+                    application=NimbusExperiment.Application.IOS,
+                ),
+            ],
+        )
+
+        serializer = NimbusReviewSerializer(
+            experiment,
+            data=NimbusReviewSerializer(
+                experiment,
+                context={"user": self.user},
+            ).data,
+            context={"user": self.user},
+        )
+
+        self.assertFalse(serializer.is_valid())
+        self.assertEqual(
+            serializer.errors["feature_configs"],
+            [
+                "Feature Config application ios does not "
+                "match experiment application fenix."
+            ],
+        )
+
+    def test_serializer_feature_config_validation_missing_feature_config(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            status=NimbusExperiment.Status.DRAFT,
+            application=NimbusExperiment.Application.FENIX,
+            feature_configs=[],
+        )
+
+        serializer = NimbusReviewSerializer(
+            experiment,
+            data=NimbusReviewSerializer(
+                experiment,
+                context={"user": self.user},
+            ).data,
+            context={"user": self.user},
+        )
+
+        self.assertFalse(serializer.is_valid())
+        self.assertEqual(
+            serializer.errors["feature_configs"],
+            [
+                "You must select a feature configuration from the drop down.",
+            ],
+        )
+
+    def test_serializer_feature_config_validation_bad_json_value(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            status=NimbusExperiment.Status.DRAFT,
+            application=NimbusExperiment.Application.DESKTOP,
+            channel=NimbusExperiment.Channel.NO_CHANNEL,
+            feature_configs=[
+                self.feature_without_schema,
+                self.feature_with_schema,
+            ],
+        )
+
+        reference_feature_value = experiment.reference_branch.feature_values.get(
+            feature_config=self.feature_with_schema
+        )
+        reference_feature_value.value = """\
+            {"directMigrateSingleProfile: true
+        """.strip()
+        reference_feature_value.save()
+
+        treatment_branch_value = experiment.treatment_branches[0].feature_values.get(
+            feature_config=self.feature_with_schema
+        )
+        treatment_branch_value.value = """\
+            {"directMigrateSingleProfile": true}
+        """.strip()
+        treatment_branch_value.save()
+
+        serializer = NimbusReviewSerializer(
+            experiment,
+            data=NimbusReviewSerializer(
+                experiment,
+                context={"user": self.user},
+            ).data,
+            context={"user": self.user},
+        )
+
+        self.assertFalse(serializer.is_valid())
+        self.assertEqual(len(serializer.errors), 1)
+        feature_values_errors = [
+            e
+            for e in serializer.errors["reference_branch"]["feature_values"]
+            if "value" in e
+        ]
+        self.assertEqual(len(feature_values_errors), 1)
+        self.assertIn(
+            "Unterminated string",
+            feature_values_errors[0]["value"][0],
+        )
+
+    def test_serializer_feature_config_validation_reference_value_schema_error(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            status=NimbusExperiment.Status.DRAFT,
+            application=NimbusExperiment.Application.DESKTOP,
+            channel=NimbusExperiment.Channel.NO_CHANNEL,
+            feature_configs=[
+                self.feature_without_schema,
+                self.feature_with_schema,
+            ],
+        )
+
+        reference_feature_value = experiment.reference_branch.feature_values.get(
+            feature_config=self.feature_with_schema
+        )
+        reference_feature_value.value = """\
+            {"DDirectMigrateSingleProfile": true}
+        """.strip()
+        reference_feature_value.save()
+
+        treatment_feature_value = experiment.treatment_branches[0].feature_values.get(
+            feature_config=self.feature_with_schema
+        )
+        treatment_feature_value.value = """\
+            {"directMigrateSingleProfile": true}
+        """.strip()
+        treatment_feature_value.save()
+
+        serializer = NimbusReviewSerializer(
+            experiment,
+            data=NimbusReviewSerializer(
+                experiment,
+                context={"user": self.user},
+            ).data,
+            context={"user": self.user},
+        )
+
+        self.assertFalse(serializer.is_valid())
+        self.assertEqual(len(serializer.errors), 1)
+        feature_values_errors = [
+            e
+            for e in serializer.errors["reference_branch"]["feature_values"]
+            if "value" in e
+        ]
+        self.assertEqual(len(feature_values_errors), 1)
+        self.assertTrue(
+            feature_values_errors[0]["value"][0].startswith(
+                "Additional properties are not allowed"
+            ),
+            serializer.errors,
+        )
+
+    def test_serializer_feature_config_validation_treatment_value_schema_error(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            status=NimbusExperiment.Status.DRAFT,
+            application=NimbusExperiment.Application.DESKTOP,
+            channel=NimbusExperiment.Channel.NO_CHANNEL,
+            feature_configs=[
+                self.feature_without_schema,
+                self.feature_with_schema,
+            ],
+        )
+        reference_feature_value = experiment.reference_branch.feature_values.get(
+            feature_config=self.feature_with_schema
+        )
+        reference_feature_value.value = """\
+            {"directMigrateSingleProfile": true}
+        """.strip()
+        reference_feature_value.save()
+
+        treatment_feature_value = experiment.treatment_branches[0].feature_values.get(
+            feature_config=self.feature_with_schema
+        )
+        treatment_feature_value.value = """\
+            {"DDirectMigrateSingleProfile": true}
+        """.strip()
+        treatment_feature_value.save()
+
+        serializer = NimbusReviewSerializer(
+            experiment,
+            data=NimbusReviewSerializer(
+                experiment,
+                context={"user": self.user},
+            ).data,
+            context={"user": self.user},
+        )
+
+        self.assertFalse(serializer.is_valid())
+        self.assertEqual(len(serializer.errors), 1)
+        feature_values_errors = [
+            e
+            for e in serializer.errors["treatment_branches"][0]["feature_values"]
+            if "value" in e
+        ]
+        self.assertEqual(len(feature_values_errors), 1)
+        self.assertTrue(
+            feature_values_errors[0]["value"][0].startswith(
+                "Additional properties are not allowed"
+            ),
+            serializer.errors,
+        )
+
+    def test_serializer_feature_config_validation_treatment_value_no_schema(self):
+        feature1 = NimbusFeatureConfigFactory.create(
+            schema=None,
+            application=NimbusExperiment.Application.DESKTOP,
+        )
+        feature2 = NimbusFeatureConfigFactory.create(
+            schema=None,
+            application=NimbusExperiment.Application.DESKTOP,
+        )
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            status=NimbusExperiment.Status.DRAFT,
+            application=NimbusExperiment.Application.DESKTOP,
+            channel=NimbusExperiment.Channel.NO_CHANNEL,
+            feature_configs=[feature1, feature2],
+        )
+
+        reference_feature_value = experiment.reference_branch.feature_values.get(
+            feature_config=feature1
+        )
+        reference_feature_value.value = """\
+            {"directMigrateSingleProfile": true}
+        """.strip()
+        reference_feature_value.save()
+
+        treatment_feature_value = experiment.treatment_branches[0].feature_values.get(
+            feature_config=feature2
+        )
+        treatment_feature_value.value = """\
+            {"DDirectMigrateSingleProfile": true}
+        """.strip()
+        treatment_feature_value.save()
+
+        serializer = NimbusReviewSerializer(
+            experiment,
+            data=NimbusReviewSerializer(
+                experiment,
+                context={"user": self.user},
+            ).data,
+            context={"user": self.user},
+        )
+        self.assertTrue(serializer.is_valid())
+
+    # Add schema warn logic for multifeature in #7028
+    # def test_serializer_feature_config_validation_reference_value_schema_warn(self):
+    #     experiment = NimbusExperimentFactory.create_with_lifecycle(
+    #         NimbusExperimentFactory.Lifecycles.CREATED,
+    #         status=NimbusExperiment.Status.DRAFT,
+    #         application=NimbusExperiment.Application.DESKTOP,
+    #         channel=NimbusExperiment.Channel.NO_CHANNEL,
+    #         warn_feature_schema=True,
+    #         feature_configs=[
+    #             self.feature_without_schema,
+    #             self.feature_with_schema,
+    #         ],
+    #     )
+
+    #     reference_feature_value = experiment.reference_branch.feature_values.get(
+    #         feature_config=self.feature_with_schema
+    #     )
+    #     reference_feature_value.value = """\
+    #         {"DDirectMigrateSingleProfile": true}
+    #     """.strip()
+    #     reference_feature_value.save()
+
+    #     treatment_feature_value = experiment.treatment_branches[0].feature_values.get(
+    #         feature_config=self.feature_with_schema
+    #     )
+    #     treatment_feature_value.value = """\
+    #         {"directMigrateSingleProfile": true}
+    #     """.strip()
+    #     treatment_feature_value.save()
+
+    #     serializer = NimbusReviewSerializer(
+    #         experiment,
+    #         data=NimbusReviewSerializer(
+    #             experiment,
+    #             context={"user": self.user},
+    #         ).data,
+    #         context={"user": self.user},
+    #     )
+
+    #     self.assertTrue(serializer.is_valid())
+    #     self.assertTrue(
+    #         serializer.warnings["reference_branch"]["feature_values"][1]["value"][
+    #             0
+    #         ].startswith("Additional properties are not allowed"),
+    #         serializer.warnings,
+    #     )
+    #     self.assertEqual(len(serializer.warnings), 1, serializer.warnings)
+
+    # def test_serializer_feature_config_validation_treatment_value_schema_warn(self):
+    #     experiment = NimbusExperimentFactory.create_with_lifecycle(
+    #         NimbusExperimentFactory.Lifecycles.CREATED,
+    #         status=NimbusExperiment.Status.DRAFT,
+    #         application=NimbusExperiment.Application.DESKTOP,
+    #         channel=NimbusExperiment.Channel.NO_CHANNEL,
+    #         warn_feature_schema=True,
+    #         feature_configs=[
+    #             NimbusFeatureConfigFactory.create(
+    #                 schema=BASIC_JSON_SCHEMA,
+    #                 application=NimbusExperiment.Application.DESKTOP,
+    #             )
+    #         ],
+    #     )
+    #     reference_feature_value = experiment.reference_branch.feature_values.get()
+    #     reference_feature_value.value = """\
+    #         {"directMigrateSingleProfile": true}
+    #     """.strip()
+    #     reference_feature_value.save()
+
+    #     treatment_feature_value = experiment.treatment_branches[0].feature_values.get()
+    #     treatment_feature_value.value = """\
+    #         {"DDirectMigrateSingleProfile": true}
+    #     """.strip()
+    #     treatment_feature_value.save()
+
+    #     serializer = NimbusReviewSerializer(
+    #         experiment,
+    #         data=NimbusReviewSerializer(
+    #             experiment,
+    #             context={"user": self.user},
+    #         ).data,
+    #         context={"user": self.user},
+    #     )
+
+    #     self.assertTrue(serializer.is_valid())
+    #     self.assertEqual(len(serializer.warnings), 1, serializer.warnings)
+    #     self.assertTrue(
+    #         serializer.warnings["treatment_branches"][0]["feature_value"][0].startswith(
+    #             "Additional properties are not allowed"
+    #         ),
+    #         serializer.warnings,
+    #     )

--- a/app/experimenter/nimbus-ui/schema.graphql
+++ b/app/experimenter/nimbus-ui/schema.graphql
@@ -3,6 +3,12 @@ schema {
   mutation: Mutation
 }
 
+input BranchFeatureValueInput {
+  featureConfig: Int
+  enabled: Boolean
+  value: String
+}
+
 input BranchScreenshotInput {
   id: Int
   image: Upload
@@ -45,6 +51,7 @@ input ExperimentInput {
   isEnrollmentPaused: Boolean
   riskMitigationLink: String
   featureConfigId: Int
+  featureConfigs: [Int]
   warnFeatureSchema: Boolean
   documentationLinks: [DocumentationLinkInput]
   referenceBranch: ReferenceBranchInput
@@ -77,6 +84,14 @@ type Mutation {
   cloneExperiment(input: ExperimentCloneInput!): CloneExperiment
 }
 
+type NimbusBranchFeatureValueType {
+  id: Int
+  branch: NimbusBranchType!
+  featureConfig: NimbusFeatureConfigType
+  enabled: Boolean
+  value: String
+}
+
 type NimbusBranchScreenshotType {
   id: Int
   branch: NimbusBranchType!
@@ -90,6 +105,7 @@ type NimbusBranchType {
   slug: String!
   description: String!
   ratio: Int!
+  featureValues: [NimbusBranchFeatureValueType]
   screenshots: [NimbusBranchScreenshotType!]
   featureEnabled: Boolean!
   featureValue: String
@@ -393,7 +409,8 @@ type NimbusExperimentType {
   treatmentBranches: [NimbusBranchType]
   jexlTargetingExpression: String
   featureConfig: NimbusFeatureConfigType
-  readyForReview: NimbusReadyForReviewType
+  featureConfigs: [NimbusFeatureConfigType]
+  readyForReview: NimbusReviewType
   monitoringDashboardUrl: String
   resultsReady: Boolean
   startDate: DateTime
@@ -424,6 +441,7 @@ type NimbusFeatureConfigType {
   schema: String
   readOnly: Boolean!
   nimbusexperimentSet: [NimbusExperimentType!]!
+  nimbusbranchfeaturevalueSet: [NimbusBranchFeatureValueType!]!
 }
 
 enum NimbusIsolationGroupApplication {
@@ -471,7 +489,7 @@ type NimbusOutcomeType {
   metrics: [NimbusOutcomeMetricType]
 }
 
-type NimbusReadyForReviewType {
+type NimbusReviewType {
   message: ObjectField
   warnings: ObjectField
   ready: Boolean
@@ -513,6 +531,7 @@ input ReferenceBranchInput {
   ratio: Int!
   featureEnabled: Boolean
   featureValue: String
+  featureValues: [BranchFeatureValueInput]
   screenshots: [BranchScreenshotInput]
 }
 
@@ -523,6 +542,7 @@ input TreatmentBranchInput {
   ratio: Int!
   featureEnabled: Boolean
   featureValue: String
+  featureValues: [BranchFeatureValueInput]
   screenshots: [BranchScreenshotInput]
 }
 

--- a/app/experimenter/nimbus-ui/src/types/globalTypes.ts
+++ b/app/experimenter/nimbus-ui/src/types/globalTypes.ts
@@ -171,6 +171,12 @@ export enum NimbusExperimentStatusEnum {
   PREVIEW = "PREVIEW",
 }
 
+export interface BranchFeatureValueInput {
+  featureConfig?: number | null;
+  enabled?: boolean | null;
+  value?: string | null;
+}
+
 export interface BranchScreenshotInput {
   id?: number | null;
   image?: Upload | null;
@@ -201,6 +207,7 @@ export interface ExperimentInput {
   isEnrollmentPaused?: boolean | null;
   riskMitigationLink?: string | null;
   featureConfigId?: number | null;
+  featureConfigs?: (number | null)[] | null;
   warnFeatureSchema?: boolean | null;
   documentationLinks?: (DocumentationLinkInput | null)[] | null;
   referenceBranch?: ReferenceBranchInput | null;
@@ -232,6 +239,7 @@ export interface ReferenceBranchInput {
   ratio: number;
   featureEnabled?: boolean | null;
   featureValue?: string | null;
+  featureValues?: (BranchFeatureValueInput | null)[] | null;
   screenshots?: (BranchScreenshotInput | null)[] | null;
 }
 
@@ -242,6 +250,7 @@ export interface TreatmentBranchInput {
   ratio: number;
   featureEnabled?: boolean | null;
   featureValue?: string | null;
+  featureValues?: (BranchFeatureValueInput | null)[] | null;
   screenshots?: (BranchScreenshotInput | null)[] | null;
 }
 


### PR DESCRIPTION
Because

* We need to update the V5 API to support setting multiple features on the experiment and per branch
* We need to keep the single feature interface intact while we make the transition

This commit

* Adds featureConfigs and featureValues to the V5 API and updates tests as necessary