### PR TITLE
fix #7035 fix(nimbus): ensure features are selected by ID and not selector index

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/index.test.tsx
@@ -318,6 +318,7 @@ describe("FormBranches", () => {
 
   it("supports adding feature config", async () => {
     const onSave = jest.fn();
+    const expectedFeatureId = MOCK_CONFIG.featureConfigs![1]!.id;
     render(
       <SubjectBranches
         {...{
@@ -329,11 +330,9 @@ describe("FormBranches", () => {
         }}
       />,
     );
-    selectFeatureConfig(1);
+    selectFeatureConfig(expectedFeatureId);
     await clickAndWaitForSave(onSave);
-    expect(onSave.mock.calls[0][0].featureConfigId).toEqual(
-      MOCK_CONFIG.featureConfigs![1]!.id,
-    );
+    expect(onSave.mock.calls[0][0].featureConfigId).toEqual(expectedFeatureId);
   });
 
   it("updates save result with edits", async () => {

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/index.tsx
@@ -126,13 +126,10 @@ export const FormBranches = ({
   };
 
   const onFeatureConfigChange = (ev: React.ChangeEvent<HTMLInputElement>) => {
-    const selectedIdx = parseInt(ev.target.value, 10);
-    if (isNaN(selectedIdx)) {
-      return handleFeatureConfigChange(null);
-    }
-    // featureConfig shouldn't ever be null in practice
-    const feature = featureConfigs![selectedIdx];
-    return handleFeatureConfigChange(feature?.id);
+    const selectedFeatureId = parseInt(ev.target.value, 10);
+    return handleFeatureConfigChange(
+      isNaN(selectedFeatureId) ? null : selectedFeatureId,
+    );
   };
 
   const handleAddScreenshot = (branchIdx: number) => () => {
@@ -210,9 +207,12 @@ export const FormBranches = ({
           >
             <option value="">Select...</option>
             {featureConfigs?.map(
-              (feature, idx) =>
+              (feature) =>
                 feature && (
-                  <option key={`feature-${feature.slug}-${idx}`} value={idx}>
+                  <option
+                    key={`feature-${feature.slug}-${feature.id!}`}
+                    value={feature.id!}
+                  >
                     {feature.name}
                   </option>
                 ),


### PR DESCRIPTION
Because:

- issue #6747 switched the branch editing reducer over to using the
  input type, which itself uses feature IDs

This commit:

- ensures that the feature selection drop down uses feature IDs rather
  than selection index