### PR TITLE
issue #6740 feat(nimbus): add featureConfigs action to branch edit reducer

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/reducer/actions.ts
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/reducer/actions.ts
@@ -23,6 +23,8 @@ export function formBranchesActionReducer(
       return removeBranch(state, action);
     case "setFeatureConfig":
       return setFeatureConfig(state, action);
+    case "setFeatureConfigs":
+      return setFeatureConfigs(state, action);
     case "setwarnFeatureSchema":
       return setwarnFeatureSchema(state, action);
     case "setEqualRatio":
@@ -47,6 +49,7 @@ export type FormBranchesAction =
   | RemoveBranchAction
   | SetEqualRatioAction
   | SetFeatureConfigAction
+  | SetFeatureConfigsAction
   | SetwarnFeatureSchemaAction
   | SetSubmitErrorsAction
   | ClearSubmitErrorsAction
@@ -141,6 +144,21 @@ function setFeatureConfig(
   return {
     ...state,
     featureConfigId,
+  };
+}
+
+type SetFeatureConfigsAction = {
+  type: "setFeatureConfigs";
+  value: FormBranchesState["featureConfigs"];
+};
+
+function setFeatureConfigs(
+  state: FormBranchesState,
+  { value: featureConfigs }: SetFeatureConfigsAction,
+): FormBranchesState {
+  return {
+    ...state,
+    featureConfigs: featureConfigs || null,
   };
 }
 
@@ -279,6 +297,7 @@ function commitFormData(
 
   if (referenceBranch) {
     referenceBranch = branchUpdatedWithFormData(
+      state,
       referenceBranch,
       formData.referenceBranch,
     );
@@ -287,6 +306,7 @@ function commitFormData(
   if (treatmentBranches) {
     treatmentBranches = treatmentBranches.map((treatmentBranch, idx) =>
       branchUpdatedWithFormData(
+        state,
         treatmentBranch,
         formData.treatmentBranches?.[idx],
       ),
@@ -301,9 +321,10 @@ function commitFormData(
 }
 
 function branchUpdatedWithFormData(
+  state: FormBranchesState,
   branch: AnnotatedBranch,
   formData: Partial<AnnotatedBranch> | null | undefined,
-) {
+): AnnotatedBranch {
   const screenshots = branch.screenshots?.map((screenshot, idx) => {
     const { description, image } = formData?.screenshots?.[idx] || {};
     return {
@@ -312,10 +333,19 @@ function branchUpdatedWithFormData(
       image,
     };
   });
+  const featureValues = state.featureConfigs?.map((featureConfig, idx) => {
+    const { enabled, value } = formData?.featureValues?.[idx] || {};
+    return {
+      featureConfig,
+      enabled,
+      value,
+    };
+  });
   return {
     ...branch,
     ...formData,
     screenshots,
+    featureValues,
   };
 }
 

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/reducer/index.test.ts
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/reducer/index.test.ts
@@ -258,6 +258,37 @@ describe("formBranchesReducer", () => {
     );
   });
 
+  describe("setFeatureConfigs", () => {
+    const initialState = {
+      ...MOCK_STATE,
+      featureConfigs: [1, 2, 3, 4, 5],
+    };
+
+    it("accepts a null value to clear the list", () => {
+      const { featureConfigs } = formBranchesActionReducer(initialState, {
+        type: "setFeatureConfigs",
+        value: null,
+      });
+      expect(featureConfigs).toEqual(null);
+    });
+
+    it("accepts an undefined value to clear the list", () => {
+      const { featureConfigs } = formBranchesActionReducer(initialState, {
+        type: "setFeatureConfigs",
+        value: undefined,
+      });
+      expect(featureConfigs).toEqual(null);
+    });
+
+    it("accepts a list of ids to update the list", () => {
+      const { featureConfigs } = formBranchesActionReducer(initialState, {
+        type: "setFeatureConfigs",
+        value: [8, 6, 7, 5],
+      });
+      expect(featureConfigs).toEqual([8, 6, 7, 5]);
+    });
+  });
+
   describe("setSubmitErrors", () => {
     const submitErrors = {
       "*": ["This is bad"],
@@ -408,7 +439,14 @@ describe("formBranchesReducer", () => {
       referenceBranch: { name: "Name from form" },
       treatmentBranches: [
         { description: "Description 1" },
-        { description: "Description 2" },
+        {
+          description: "Description 2",
+          featureValues: [
+            { enabled: true, value: "{ foo: true }" },
+            { enabled: false },
+            { value: "{ bar: 123 }" },
+          ],
+        },
       ],
     };
 
@@ -427,6 +465,42 @@ describe("formBranchesReducer", () => {
       expect(newState.treatmentBranches![1]!.description).toEqual(
         formData.treatmentBranches[1].description,
       );
+      expect(newState.treatmentBranches![1]!.featureValues).toBeUndefined();
+    });
+
+    it("accepts feature configs per branch", () => {
+      const oldState = { ...MOCK_STATE, featureConfigs: [8, 6, 7, 5] };
+      const newState = formBranchesActionReducer(oldState, {
+        type: "commitFormData",
+        formData,
+      });
+      expect(newState.referenceBranch!.name).toEqual(
+        formData.referenceBranch.name,
+      );
+      expect(newState.treatmentBranches![0]!.description).toEqual(
+        formData.treatmentBranches[0].description,
+      );
+      expect(newState.treatmentBranches![1]!.description).toEqual(
+        formData.treatmentBranches[1].description,
+      );
+      expect(newState.treatmentBranches![1]!.featureValues).toEqual([
+        {
+          featureConfig: 8,
+          enabled: true,
+          value: "{ foo: true }",
+        },
+        {
+          featureConfig: 6,
+          enabled: false,
+        },
+        {
+          featureConfig: 7,
+          value: "{ bar: 123 }",
+        },
+        {
+          featureConfig: 5,
+        },
+      ]);
     });
 
     it("does not fail when missing data", () => {

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/reducer/state.ts
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/reducer/state.ts
@@ -13,7 +13,7 @@ import {
 
 export type FormBranchesState = Pick<
   ExperimentInput,
-  "featureConfigId" | "warnFeatureSchema"
+  "featureConfigId" | "featureConfigs" | "warnFeatureSchema"
 > & {
   referenceBranch: null | AnnotatedBranch;
   treatmentBranches: null | AnnotatedBranch[];


### PR DESCRIPTION
Because:

- we want to support multiple features in branches

This commit:

- adds the basics of managing selection of multiple features and
  multiple per-branch feature configs to the branch editing reducer