### PR TITLE
fix #6740 chore(nimbus): update nimbus ui to use feature_configs

### DIFF
--- a/app/experimenter/experiments/api/v5/inputs.py
+++ b/app/experimenter/experiments/api/v5/inputs.py
@@ -65,7 +65,7 @@ class ExperimentInput(graphene.InputObjectType):
     is_enrollment_paused = graphene.Boolean()
     risk_mitigation_link = graphene.String()
     feature_config_id = graphene.Int()
-    feature_configs = graphene.List(graphene.Int)
+    feature_config_ids = graphene.List(graphene.Int)
     warn_feature_schema = graphene.Boolean()
     documentation_links = graphene.List(DocumentationLinkInput)
     reference_branch = graphene.Field(ReferenceBranchInput)

--- a/app/experimenter/experiments/api/v5/mutations.py
+++ b/app/experimenter/experiments/api/v5/mutations.py
@@ -62,6 +62,8 @@ class UpdateExperiment(graphene.Mutation):
         experiment = NimbusExperiment.objects.get(id=input.id)
         if "feature_config_id" in input:
             input["feature_config"] = input.pop("feature_config_id", None)
+        if "feature_config_ids" in input:
+            input["feature_configs"] = input.pop("feature_config_ids", None)
         serializer = NimbusExperimentSerializer(
             experiment, data=input, partial=True, context={"user": info.context.user}
         )

--- a/app/experimenter/experiments/api/v5/types.py
+++ b/app/experimenter/experiments/api/v5/types.py
@@ -231,7 +231,7 @@ class NimbusConfigurationType(graphene.ObjectType):
     channels = graphene.List(NimbusLabelValueType)
     countries = graphene.List(NimbusCountryType)
     documentation_link = graphene.List(NimbusLabelValueType)
-    feature_configs = graphene.List(NimbusFeatureConfigType)
+    all_feature_configs = graphene.List(NimbusFeatureConfigType)
     firefox_versions = graphene.List(NimbusLabelValueType)
     hypothesis_default = graphene.String()
     locales = graphene.List(NimbusLocaleType)
@@ -272,7 +272,7 @@ class NimbusConfigurationType(graphene.ObjectType):
             )
         return configs
 
-    def resolve_feature_configs(root, info):
+    def resolve_all_feature_configs(root, info):
         return NimbusFeatureConfig.objects.all().order_by("name")
 
     def resolve_firefox_versions(root, info):

--- a/app/experimenter/experiments/tests/api/v5/test_mutations.py
+++ b/app/experimenter/experiments/tests/api/v5/test_mutations.py
@@ -1031,7 +1031,7 @@ class TestUpdateExperimentMutationMultiFeature(GraphQLTestCase):
             variables={
                 "input": {
                     "id": experiment.id,
-                    "featureConfigs": [feature1.id, feature2.id],
+                    "featureConfigIds": [feature1.id, feature2.id],
                     "referenceBranch": reference_branch_data,
                     "treatmentBranches": treatment_branches_data,
                     "changelogMessage": "test changelog message",
@@ -1138,7 +1138,7 @@ class TestUpdateExperimentMutationMultiFeature(GraphQLTestCase):
             variables={
                 "input": {
                     "id": experiment.id,
-                    "featureConfigs": [invalid_feature_config_id],
+                    "featureConfigIds": [invalid_feature_config_id],
                     "referenceBranch": reference_branch,
                     "treatmentBranches": treatment_branches,
                     "changelogMessage": "test changelog message",

--- a/app/experimenter/experiments/tests/api/v5/test_queries.py
+++ b/app/experimenter/experiments/tests/api/v5/test_queries.py
@@ -1250,7 +1250,7 @@ class TestNimbusConfigQuery(GraphQLTestCase):
                         label
                         value
                     }
-                    featureConfigs {
+                    allFeatureConfigs {
                         name
                         slug
                         id
@@ -1306,7 +1306,7 @@ class TestNimbusConfigQuery(GraphQLTestCase):
         )
         assertChoices(config["firefoxVersions"], NimbusExperiment.Version)
         assertChoices(config["documentationLink"], NimbusExperiment.DocumentationLink)
-        self.assertEqual(len(config["featureConfigs"]), 18)
+        self.assertEqual(len(config["allFeatureConfigs"]), 18)
 
         for application_config_data in config["applicationConfigs"]:
             application_config = NimbusExperiment.APPLICATION_CONFIGS[
@@ -1343,7 +1343,7 @@ class TestNimbusConfigQuery(GraphQLTestCase):
                     "slug": feature_config.slug,
                     "description": feature_config.description,
                 },
-                config["featureConfigs"],
+                config["allFeatureConfigs"],
             )
 
         for choice in NimbusExperiment.TargetingConfig:

--- a/app/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_experiment_serializer.py
+++ b/app/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_experiment_serializer.py
@@ -301,7 +301,7 @@ class TestNimbusExperimentSerializer(TestCase):
         experiment.branches.all().delete()
 
         data = {
-            "feature_config": feature_config.id,
+            "feature_configs": [feature_config.id],
             "reference_branch": {
                 "name": "control",
                 "description": "a control",

--- a/app/experimenter/nimbus-ui/schema.graphql
+++ b/app/experimenter/nimbus-ui/schema.graphql
@@ -51,7 +51,7 @@ input ExperimentInput {
   isEnrollmentPaused: Boolean
   riskMitigationLink: String
   featureConfigId: Int
-  featureConfigs: [Int]
+  featureConfigIds: [Int]
   warnFeatureSchema: Boolean
   documentationLinks: [DocumentationLinkInput]
   referenceBranch: ReferenceBranchInput
@@ -180,7 +180,7 @@ type NimbusConfigurationType {
   channels: [NimbusLabelValueType]
   countries: [NimbusCountryType]
   documentationLink: [NimbusLabelValueType]
-  featureConfigs: [NimbusFeatureConfigType]
+  allFeatureConfigs: [NimbusFeatureConfigType]
   firefoxVersions: [NimbusLabelValueType]
   hypothesisDefault: String
   locales: [NimbusLocaleType]

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/index.stories.tsx
@@ -149,7 +149,7 @@ storiesOf("pages/EditBranches/FormBranches", module)
       {...commonFormBranchesProps}
       experiment={{
         ...MOCK_EXPERIMENT,
-        featureConfig: MOCK_FEATURE_CONFIG,
+        featureConfigs: [MOCK_FEATURE_CONFIG],
       }}
     />
   ))
@@ -158,7 +158,7 @@ storiesOf("pages/EditBranches/FormBranches", module)
       {...commonFormBranchesProps}
       experiment={{
         ...MOCK_EXPERIMENT,
-        featureConfig: MOCK_FEATURE_CONFIG_WITH_SCHEMA,
+        featureConfigs: [MOCK_FEATURE_CONFIG_WITH_SCHEMA],
       }}
     />
   ))
@@ -169,7 +169,7 @@ storiesOf("pages/EditBranches/FormBranches", module)
       }}
       experiment={{
         ...MOCK_EXPERIMENT,
-        featureConfig: MOCK_FEATURE_CONFIG_WITH_SCHEMA,
+        featureConfigs: [MOCK_FEATURE_CONFIG_WITH_SCHEMA],
         readyForReview: {
           ready: false,
           message: {
@@ -233,7 +233,7 @@ storiesOf("pages/EditBranches/FormBranches", module)
         }}
         experiment={{
           ...MOCK_EXPERIMENT,
-          featureConfig: MOCK_FEATURE_CONFIG_WITH_SCHEMA,
+          featureConfigs: [MOCK_FEATURE_CONFIG_WITH_SCHEMA],
         }}
       />
     );

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/index.test.tsx
@@ -52,7 +52,7 @@ describe("FormBranches", () => {
     await clickAndWaitForSave(onSave);
     const onSaveArgs = onSave.mock.calls[0];
     expect(onSaveArgs[0]).toEqual({
-      featureConfigId: undefined,
+      featureConfigIds: [],
       // @ts-ignore type mismatch covers discarded annotation properties
       referenceBranch: extractUpdateBranch(MOCK_EXPERIMENT.referenceBranch!),
       treatmentBranches: MOCK_EXPERIMENT.treatmentBranches!.map(
@@ -151,7 +151,7 @@ describe("FormBranches", () => {
     selectFeatureConfig(null);
     await clickAndWaitForSave(onSave);
     const saveResult = onSave.mock.calls[0][0];
-    expect(saveResult.featureConfigId).toEqual(null);
+    expect(saveResult.featureConfigIds).toEqual([]);
   });
 
   it("requires adding a valid control branch before save is completed", async () => {
@@ -318,21 +318,23 @@ describe("FormBranches", () => {
 
   it("supports adding feature config", async () => {
     const onSave = jest.fn();
-    const expectedFeatureId = MOCK_CONFIG.featureConfigs![1]!.id;
+    const expectedFeatureId = MOCK_CONFIG.allFeatureConfigs![1]!.id;
     render(
       <SubjectBranches
         {...{
           onSave,
           experiment: {
             ...MOCK_EXPERIMENT,
-            featureConfig: null,
+            featureConfigs: [],
           },
         }}
       />,
     );
     selectFeatureConfig(expectedFeatureId);
     await clickAndWaitForSave(onSave);
-    expect(onSave.mock.calls[0][0].featureConfigId).toEqual(expectedFeatureId);
+    expect(onSave.mock.calls[0][0].featureConfigIds).toEqual([
+      expectedFeatureId,
+    ]);
   });
 
   it("updates save result with edits", async () => {
@@ -343,7 +345,7 @@ describe("FormBranches", () => {
           onSave,
           experiment: {
             ...MOCK_EXPERIMENT,
-            featureConfig: MOCK_FEATURE_CONFIG_WITH_SCHEMA,
+            featureConfigs: [MOCK_FEATURE_CONFIG_WITH_SCHEMA],
           },
         }}
       />,
@@ -365,9 +367,9 @@ describe("FormBranches", () => {
     await clickAndWaitForSave(onSave);
     const saveResult = onSave.mock.calls[0][0];
 
-    expect(saveResult.featureConfigId).toEqual(
+    expect(saveResult.featureConfigIds).toEqual([
       MOCK_FEATURE_CONFIG_WITH_SCHEMA.id,
-    );
+    ]);
     expect(saveResult.referenceBranch).toEqual({
       id: MOCK_EXPERIMENT.referenceBranch!.id,
       screenshots: [],

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/index.tsx
@@ -19,12 +19,13 @@ import {
   REFERENCE_BRANCH_IDX,
   useFormBranchesReducer,
 } from "./reducer";
+import { FormBranchesState } from "./reducer/state";
 import { FormData } from "./reducer/update";
 
 type FormBranchesProps = {
   isLoading: boolean;
   experiment: getExperiment_experimentBySlug;
-  featureConfigs: getConfig_nimbusConfig["featureConfigs"];
+  allFeatureConfigs: getConfig_nimbusConfig["allFeatureConfigs"];
   onSave: (
     state: FormBranchesSaveState,
     setSubmitErrors: (submitErrors: any) => void,
@@ -36,14 +37,14 @@ type FormBranchesProps = {
 export const FormBranches = ({
   isLoading,
   experiment,
-  featureConfigs,
+  allFeatureConfigs,
   onSave,
 }: FormBranchesProps) => {
   const { fieldMessages, fieldWarnings } = useReviewCheck(experiment);
 
   const [
     {
-      featureConfigId: experimentFeatureConfigId,
+      featureConfigIds: experimentFeatureConfigIds,
       warnFeatureSchema,
       referenceBranch,
       treatmentBranches,
@@ -120,15 +121,17 @@ export const FormBranches = ({
     });
   };
 
-  const handleFeatureConfigChange = (value: number | null | undefined) => {
+  const handleFeatureConfigsChange = (
+    value: FormBranchesState["featureConfigIds"],
+  ) => {
     commitFormData();
-    dispatch({ type: "setFeatureConfig", value });
+    dispatch({ type: "setFeatureConfigs", value });
   };
 
   const onFeatureConfigChange = (ev: React.ChangeEvent<HTMLInputElement>) => {
     const selectedFeatureId = parseInt(ev.target.value, 10);
-    return handleFeatureConfigChange(
-      isNaN(selectedFeatureId) ? null : selectedFeatureId,
+    return handleFeatureConfigsChange(
+      isNaN(selectedFeatureId) ? [] : [selectedFeatureId],
     );
   };
 
@@ -203,10 +206,14 @@ export const FormBranches = ({
                 fieldWarnings.feature_config?.length > 0,
             })}
             onChange={onFeatureConfigChange}
-            value={experimentFeatureConfigId || undefined}
+            value={
+              experimentFeatureConfigIds?.length
+                ? experimentFeatureConfigIds[0] || undefined
+                : undefined
+            }
           >
             <option value="">Select...</option>
-            {featureConfigs?.map(
+            {allFeatureConfigs?.map(
               (feature) =>
                 feature && (
                   <option

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/mocks.tsx
@@ -13,7 +13,7 @@ import { formBranchesActionReducer } from "./reducer/actions";
 import { FormBranchesState } from "./reducer/state";
 
 export const MOCK_EXPERIMENT = mockExperimentQuery("demo-slug", {
-  featureConfig: null, //MOCK_CONFIG!.featureConfigs![0],
+  featureConfigs: [], //MOCK_CONFIG!.featureConfigs![0],
   referenceBranch: {
     id: 123,
     name: "User-centric mobile solution",
@@ -52,7 +52,7 @@ const MOCK_STATE: FormBranchesState = {
   equalRatio: true,
   lastId: 0,
   globalErrors: [],
-  featureConfigId: null,
+  featureConfigIds: [],
   warnFeatureSchema: false,
   referenceBranch: {
     ...MOCK_EXPERIMENT.referenceBranch!,
@@ -131,7 +131,7 @@ export const SubjectBranch = ({
 export const SubjectBranches = ({
   isLoading = false,
   experiment = MOCK_EXPERIMENT,
-  featureConfigs = MOCK_CONFIG.featureConfigs,
+  allFeatureConfigs = MOCK_CONFIG.allFeatureConfigs,
   onSave = () => {},
   saveOnInitialRender = false,
 }: Partial<React.ComponentProps<typeof FormBranches>> & {
@@ -153,7 +153,7 @@ export const SubjectBranches = ({
         {...{
           isLoading,
           experiment,
-          featureConfigs,
+          allFeatureConfigs,
           onSave,
         }}
       />
@@ -170,5 +170,6 @@ export const MOCK_ANNOTATED_BRANCH: AnnotatedBranch = {
   ...MOCK_BRANCH,
   screenshots: [],
 };
-export const MOCK_FEATURE_CONFIG = MOCK_CONFIG.featureConfigs![0]!;
-export const MOCK_FEATURE_CONFIG_WITH_SCHEMA = MOCK_CONFIG.featureConfigs![1]!;
+export const MOCK_FEATURE_CONFIG = MOCK_CONFIG.allFeatureConfigs![0]!;
+export const MOCK_FEATURE_CONFIG_WITH_SCHEMA =
+  MOCK_CONFIG.allFeatureConfigs![1]!;

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/reducer/actions.ts
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/reducer/actions.ts
@@ -21,8 +21,6 @@ export function formBranchesActionReducer(
       return addBranch(state);
     case "removeBranch":
       return removeBranch(state, action);
-    case "setFeatureConfig":
-      return setFeatureConfig(state, action);
     case "setFeatureConfigs":
       return setFeatureConfigs(state, action);
     case "setwarnFeatureSchema":
@@ -48,7 +46,6 @@ export type FormBranchesAction =
   | AddBranchAction
   | RemoveBranchAction
   | SetEqualRatioAction
-  | SetFeatureConfigAction
   | SetFeatureConfigsAction
   | SetwarnFeatureSchemaAction
   | SetSubmitErrorsAction
@@ -105,60 +102,18 @@ function removeBranch(
   };
 }
 
-function removeFeatureConfig(state: FormBranchesState): FormBranchesState {
-  let { referenceBranch, treatmentBranches } = state;
-
-  if (referenceBranch) {
-    referenceBranch = {
-      ...referenceBranch,
-      featureEnabled: false,
-      featureValue: null,
-    };
-  }
-
-  if (Array.isArray(treatmentBranches)) {
-    treatmentBranches = treatmentBranches.map(
-      (branch) =>
-        branch && { ...branch, featureEnabled: false, featureValue: null },
-    );
-  }
-
-  return {
-    ...state,
-    featureConfigId: null,
-    referenceBranch,
-    treatmentBranches,
-  };
-}
-
-type SetFeatureConfigAction = {
-  type: "setFeatureConfig";
-  value: FormBranchesState["featureConfigId"];
-};
-
-function setFeatureConfig(
-  state: FormBranchesState,
-  { value: featureConfigId }: SetFeatureConfigAction,
-): FormBranchesState {
-  if (!featureConfigId) return removeFeatureConfig(state);
-  return {
-    ...state,
-    featureConfigId,
-  };
-}
-
 type SetFeatureConfigsAction = {
   type: "setFeatureConfigs";
-  value: FormBranchesState["featureConfigs"];
+  value: FormBranchesState["featureConfigIds"];
 };
 
 function setFeatureConfigs(
   state: FormBranchesState,
-  { value: featureConfigs }: SetFeatureConfigsAction,
+  { value: featureConfigIds }: SetFeatureConfigsAction,
 ): FormBranchesState {
   return {
     ...state,
-    featureConfigs: featureConfigs || null,
+    featureConfigIds: featureConfigIds || null,
   };
 }
 
@@ -333,10 +288,10 @@ function branchUpdatedWithFormData(
       image,
     };
   });
-  const featureValues = state.featureConfigs?.map((featureConfig, idx) => {
+  const featureValues = state.featureConfigIds?.map((featureConfigId, idx) => {
     const { enabled, value } = formData?.featureValues?.[idx] || {};
     return {
-      featureConfig,
+      featureConfigId,
       enabled,
       value,
     };

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/reducer/index.test.ts
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/reducer/index.test.ts
@@ -12,7 +12,7 @@ const MOCK_STATE: FormBranchesState = {
   equalRatio: true,
   lastId: 0,
   globalErrors: [],
-  featureConfigId: null,
+  featureConfigIds: [],
   warnFeatureSchema: false,
   referenceBranch: {
     ...MOCK_EXPERIMENT.referenceBranch!,
@@ -239,7 +239,7 @@ describe("formBranchesReducer", () => {
 
     const newState = formBranchesActionReducer(oldState, action);
 
-    expect(newState.featureConfigId).toBeNull();
+    expect(newState.featureConfigIds).toBeNull();
     expect(newState.referenceBranch?.featureEnabled).toBe(false);
     expect(
       newState.treatmentBranches?.every(
@@ -248,16 +248,6 @@ describe("formBranchesReducer", () => {
     ).toEqual(true);
   };
 
-  describe("setFeatureConfig", () => {
-    it(
-      "disables any enabled features in branches when the config is set to null",
-      commonClearFeatureConfigTest({
-        type: "setFeatureConfig",
-        value: null,
-      }),
-    );
-  });
-
   describe("setFeatureConfigs", () => {
     const initialState = {
       ...MOCK_STATE,
@@ -265,27 +255,27 @@ describe("formBranchesReducer", () => {
     };
 
     it("accepts a null value to clear the list", () => {
-      const { featureConfigs } = formBranchesActionReducer(initialState, {
+      const { featureConfigIds } = formBranchesActionReducer(initialState, {
         type: "setFeatureConfigs",
         value: null,
       });
-      expect(featureConfigs).toEqual(null);
+      expect(featureConfigIds).toEqual(null);
     });
 
     it("accepts an undefined value to clear the list", () => {
-      const { featureConfigs } = formBranchesActionReducer(initialState, {
+      const { featureConfigIds } = formBranchesActionReducer(initialState, {
         type: "setFeatureConfigs",
         value: undefined,
       });
-      expect(featureConfigs).toEqual(null);
+      expect(featureConfigIds).toEqual(null);
     });
 
     it("accepts a list of ids to update the list", () => {
-      const { featureConfigs } = formBranchesActionReducer(initialState, {
+      const { featureConfigIds } = formBranchesActionReducer(initialState, {
         type: "setFeatureConfigs",
         value: [8, 6, 7, 5],
       });
-      expect(featureConfigs).toEqual([8, 6, 7, 5]);
+      expect(featureConfigIds).toEqual([8, 6, 7, 5]);
     });
   });
 
@@ -465,11 +455,14 @@ describe("formBranchesReducer", () => {
       expect(newState.treatmentBranches![1]!.description).toEqual(
         formData.treatmentBranches[1].description,
       );
-      expect(newState.treatmentBranches![1]!.featureValues).toBeUndefined();
+      expect(newState.treatmentBranches![1]!.featureValues).toEqual([]);
     });
 
     it("accepts feature configs per branch", () => {
-      const oldState = { ...MOCK_STATE, featureConfigs: [8, 6, 7, 5] };
+      const oldState: FormBranchesState = {
+        ...MOCK_STATE,
+        featureConfigIds: [8, 6, 7, 5],
+      };
       const newState = formBranchesActionReducer(oldState, {
         type: "commitFormData",
         formData,
@@ -485,20 +478,24 @@ describe("formBranchesReducer", () => {
       );
       expect(newState.treatmentBranches![1]!.featureValues).toEqual([
         {
-          featureConfig: 8,
+          featureConfigId: 8,
           enabled: true,
           value: "{ foo: true }",
         },
         {
-          featureConfig: 6,
+          featureConfigId: 6,
           enabled: false,
+          value: undefined,
         },
         {
-          featureConfig: 7,
+          featureConfigId: 7,
+          enabled: undefined,
           value: "{ bar: 123 }",
         },
         {
-          featureConfig: 5,
+          featureConfigId: 5,
+          enabled: undefined,
+          value: undefined,
         },
       ]);
     });

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/reducer/state.ts
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/reducer/state.ts
@@ -13,7 +13,7 @@ import {
 
 export type FormBranchesState = Pick<
   ExperimentInput,
-  "featureConfigId" | "featureConfigs" | "warnFeatureSchema"
+  "featureConfigIds" | "warnFeatureSchema"
 > & {
   referenceBranch: null | AnnotatedBranch;
   treatmentBranches: null | AnnotatedBranch[];
@@ -33,7 +33,7 @@ export type AnnotatedBranch = Omit<TreatmentBranchInput, "id"> & {
 };
 
 export function createInitialState({
-  featureConfig,
+  featureConfigs,
   warnFeatureSchema,
   referenceBranch,
   treatmentBranches,
@@ -60,7 +60,7 @@ export function createInitialState({
   return {
     lastId,
     equalRatio,
-    featureConfigId: featureConfig?.id,
+    featureConfigIds: featureConfigs?.map((f) => f?.id || null),
     warnFeatureSchema,
     globalErrors: [],
     referenceBranch: annotatedReferenceBranch,

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/reducer/update.ts
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/reducer/update.ts
@@ -11,7 +11,7 @@ import { AnnotatedBranch, FormBranchesState } from "./state";
 
 export type FormBranchesSaveState = Pick<
   ExperimentInput,
-  | "featureConfigId"
+  | "featureConfigIds"
   | "warnFeatureSchema"
   | "referenceBranch"
   | "treatmentBranches"
@@ -29,7 +29,7 @@ export function extractUpdateState(
   formData: FormData,
 ): FormBranchesSaveState {
   const {
-    featureConfigId,
+    featureConfigIds,
     warnFeatureSchema,
     referenceBranch,
     treatmentBranches,
@@ -40,7 +40,7 @@ export function extractUpdateState(
   }
 
   return {
-    featureConfigId,
+    featureConfigIds,
     warnFeatureSchema,
     referenceBranch: extractUpdateBranch(
       referenceBranch,

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/index.stories.tsx
@@ -12,15 +12,17 @@ import { RouterSlugProvider } from "../../lib/test-utils";
 import { getExperiment_experimentBySlug } from "../../types/getExperiment";
 import { NimbusExperimentApplicationEnum } from "../../types/globalTypes";
 
-const featureConfig = {
-  id: 2,
-  name: "Mauris odio erat",
-  slug: "mauris-odio-erat",
-  description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
-  application: NimbusExperimentApplicationEnum.FENIX,
-  ownerEmail: "dude23@yahoo.com",
-  schema: '{ "sample": "schema" }',
-};
+const featureConfigs = [
+  {
+    id: 2,
+    name: "Mauris odio erat",
+    slug: "mauris-odio-erat",
+    description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+    application: NimbusExperimentApplicationEnum.FENIX,
+    ownerEmail: "dude23@yahoo.com",
+    schema: '{ "sample": "schema" }',
+  },
+];
 
 const emptyBranches: Partial<getExperiment_experimentBySlug> = {
   referenceBranch: {
@@ -66,11 +68,11 @@ const storyWithExperiment = (
 
 export const Basic = () => storyWithExperiment(emptyBranches);
 
-export const FilledOutFields = () => storyWithExperiment({ featureConfig });
+export const FilledOutFields = () => storyWithExperiment({ featureConfigs });
 
 export const MissingFields = () =>
   storyWithExperiment({
-    featureConfig,
+    featureConfigs,
     ...emptyBranches,
     readyForReview: {
       ready: false,

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/index.test.tsx
@@ -55,7 +55,7 @@ describe("PageEditBranches", () => {
       EXTERNAL_URLS.BRANCHES_GOOGLE_DOC,
     );
 
-    for (const feature of MOCK_CONFIG!.featureConfigs!) {
+    for (const feature of MOCK_CONFIG!.allFeatureConfigs!) {
       const { name, application } = feature!;
       const configEl = screen.queryByText(name);
       if (application === experiment!.application) {
@@ -181,10 +181,9 @@ const mockClearSubmitErrors = jest.fn();
 let mockUpdateState: FormBranchesSaveState;
 
 function setMockUpdateState(experiment: getExperiment_experimentBySlug) {
-  const featureConfigId =
-    experiment.featureConfig === null ? null : experiment.featureConfig.id;
+  const featureConfigIds = experiment.featureConfigs?.map((f) => f?.id || null);
   mockUpdateState = {
-    featureConfigId,
+    featureConfigIds,
     // @ts-ignore type mismatch covers discarded annotation properties
     referenceBranch: extractUpdateBranch(experiment.referenceBranch!),
     treatmentBranches: experiment.treatmentBranches!.map(
@@ -199,7 +198,7 @@ jest.mock("./FormBranches", () => ({
   __esModule: true,
   default: ({
     experiment,
-    featureConfigs,
+    allFeatureConfigs,
     onSave,
   }: React.ComponentProps<typeof FormBranches>) => {
     return (
@@ -207,9 +206,9 @@ jest.mock("./FormBranches", () => ({
         {experiment && (
           <span data-testid="experiment-slug">{experiment.slug}</span>
         )}
-        {featureConfigs && (
+        {allFeatureConfigs && (
           <ul data-testid="feature-config">
-            {featureConfigs.map(
+            {allFeatureConfigs.map(
               (feature, idx) =>
                 feature && <li key={`feature-${idx}`}>{feature.name}</li>,
             )}

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/index.tsx
@@ -22,7 +22,7 @@ import FormBranches from "./FormBranches";
 import { FormBranchesSaveState } from "./FormBranches/reducer";
 
 const PageEditBranches: React.FunctionComponent<RouteComponentProps> = () => {
-  const { featureConfigs } = useConfig();
+  const { allFeatureConfigs } = useConfig();
   const { experiment, refetch, useRedirectCondition } =
     useContext(ExperimentContext)!;
   useRedirectCondition(editCommonRedirects);
@@ -33,14 +33,14 @@ const PageEditBranches: React.FunctionComponent<RouteComponentProps> = () => {
   >(UPDATE_EXPERIMENT_MUTATION);
 
   const applicationFeatureConfigs =
-    featureConfigs?.filter(
+    allFeatureConfigs?.filter(
       (config) => config?.application === experiment.application,
     ) || [];
 
   const onFormSave = useCallback(
     async (
       {
-        featureConfigId,
+        featureConfigIds,
         warnFeatureSchema,
         referenceBranch,
         treatmentBranches,
@@ -57,7 +57,7 @@ const PageEditBranches: React.FunctionComponent<RouteComponentProps> = () => {
             input: {
               id: nimbusExperimentId,
               changelogMessage: CHANGELOG_MESSAGES.UPDATED_BRANCHES,
-              featureConfigId,
+              featureConfigIds,
               warnFeatureSchema,
               referenceBranch,
               treatmentBranches,
@@ -102,7 +102,7 @@ const PageEditBranches: React.FunctionComponent<RouteComponentProps> = () => {
       <FormBranches
         {...{
           experiment,
-          featureConfigs: applicationFeatureConfigs,
+          allFeatureConfigs: applicationFeatureConfigs,
           isLoading: loading,
           onSave: onFormSave,
         }}

--- a/app/experimenter/nimbus-ui/src/components/PageHome/FilterBar/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageHome/FilterBar/index.tsx
@@ -31,8 +31,8 @@ export const FilterBar: React.FC<FilterBarProps> = ({
       <Nav className="w-100">
         <FilterSelect
           fieldLabel="Feature"
-          fieldOptions={options.featureConfigs!}
-          filterValueName="featureConfigs"
+          fieldOptions={options.allFeatureConfigs!}
+          filterValueName="allFeatureConfigs"
           optionLabelName="name"
           {...{ filterValue, onChange }}
         />

--- a/app/experimenter/nimbus-ui/src/components/PageHome/filterExperiments.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageHome/filterExperiments.test.tsx
@@ -14,18 +14,18 @@ import {
 } from "./mocks";
 import { filterValueKeys } from "./types";
 
-const { owners, applications, featureConfigs } = MOCK_CONFIG!;
+const { owners, applications, allFeatureConfigs } = MOCK_CONFIG!;
 
 describe("getFilterValueFromParams", () => {
   it("converts comma-separated list representation from filter params into a filter value", () => {
     const params = new URLSearchParams();
     params.set("owners", "alpha-example@mozilla.com,beta-example@mozilla.com");
     params.set("applications", "DESKTOP,FENIX");
-    params.set("featureConfigs", "IOS:foo-lila-sat");
+    params.set("allFeatureConfigs", "IOS:foo-lila-sat");
     expect(getFilterValueFromParams(MOCK_CONFIG, params)).toEqual({
       owners: [owners![0], owners![1]],
       applications: [applications![0], applications![3]],
-      featureConfigs: [featureConfigs![2]],
+      allFeatureConfigs: [allFeatureConfigs![2]],
     });
   });
 });
@@ -37,13 +37,13 @@ describe("updateParamsFromFilterValue", () => {
     updateParamsFromFilterValue(updateSearchParams, {
       owners: [owners![0], owners![1]],
       applications: [applications![0], applications![3]],
-      featureConfigs: [featureConfigs![2], featureConfigs![3]],
+      allFeatureConfigs: [allFeatureConfigs![2], allFeatureConfigs![3]],
     });
     expect(params.get("owners")).toEqual(
       "alpha-example@mozilla.com,beta-example@mozilla.com",
     );
     expect(params.get("applications")).toEqual("DESKTOP,FENIX");
-    expect(params.get("featureConfigs")).toEqual(
+    expect(params.get("allFeatureConfigs")).toEqual(
       "IOS:foo-lila-sat,FENIX:foo-lila-sat",
     );
   });
@@ -66,7 +66,9 @@ describe("filterExperiments", () => {
   it("filters only an empty feature config if filter value has everything", () => {
     expect(
       filterExperiments(MOCK_EXPERIMENTS, EVERYTHING_SELECTED_VALUE),
-    ).toEqual(MOCK_EXPERIMENTS.filter((e) => e.featureConfig !== null));
+    ).toEqual(
+      MOCK_EXPERIMENTS.filter((e) => (e.featureConfigs?.length || 0) > 0),
+    );
   });
 
   it("filters per individual criteria as expected", () => {
@@ -85,10 +87,10 @@ describe("filterExperiments", () => {
               MOCK_CONFIG!.applications![0]!.value,
             );
             break;
-          case "featureConfigs":
-            expect(experiment.featureConfig).toEqual(
-              MOCK_CONFIG!.featureConfigs![0]!,
-            );
+          case "allFeatureConfigs":
+            expect(experiment.featureConfigs).toEqual([
+              MOCK_CONFIG!.allFeatureConfigs![0]!,
+            ]);
             break;
           case "firefoxVersions":
             expect(experiment.firefoxMinVersion).toEqual(

--- a/app/experimenter/nimbus-ui/src/components/PageHome/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageHome/index.tsx
@@ -65,7 +65,7 @@ export const Body = () => {
 
   const filterOptions: FilterOptions = {
     applications: config!.applications!,
-    featureConfigs: config!.featureConfigs!,
+    allFeatureConfigs: config!.allFeatureConfigs!,
     firefoxVersions: config!.firefoxVersions!,
     owners: config!.owners!,
   };

--- a/app/experimenter/nimbus-ui/src/components/PageHome/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageHome/mocks.tsx
@@ -12,14 +12,14 @@ export const MOCK_EXPERIMENTS = mockDirectoryExperiments();
 export const DEFAULT_OPTIONS: FilterOptions = {
   owners: MOCK_CONFIG!.owners,
   applications: MOCK_CONFIG!.applications!,
-  featureConfigs: MOCK_CONFIG!.featureConfigs!,
+  allFeatureConfigs: MOCK_CONFIG!.allFeatureConfigs!,
   firefoxVersions: MOCK_CONFIG!.firefoxVersions!,
 };
 
 export const DEFAULT_VALUE: FilterValue = {
   owners: [],
   applications: [],
-  featureConfigs: [],
+  allFeatureConfigs: [],
   firefoxVersions: [],
 };
 

--- a/app/experimenter/nimbus-ui/src/components/PageHome/types.ts
+++ b/app/experimenter/nimbus-ui/src/components/PageHome/types.ts
@@ -7,7 +7,7 @@ import { getConfig_nimbusConfig } from "../../types/getConfig";
 export const filterValueKeys = [
   "owners",
   "applications",
-  "featureConfigs",
+  "allFeatureConfigs",
   "firefoxVersions",
 ] as const;
 

--- a/app/experimenter/nimbus-ui/src/components/Summary/TableBranches/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/TableBranches/index.stories.tsx
@@ -80,10 +80,10 @@ storiesOf("components/Summary/TableBranches", module)
     <Subject
       experiment={{
         ...MOCK_EXPERIMENT,
-        featureConfig: {
-          ...MOCK_EXPERIMENT.featureConfig!,
+        featureConfigs: MOCK_EXPERIMENT.featureConfigs!.map((f) => ({
+          ...f!,
           schema: null,
-        },
+        })),
       }}
     />
   ))
@@ -91,10 +91,10 @@ storiesOf("components/Summary/TableBranches", module)
     <Subject
       experiment={{
         ...MOCK_EXPERIMENT,
-        featureConfig: {
-          ...MOCK_EXPERIMENT.featureConfig!,
+        featureConfigs: MOCK_EXPERIMENT.featureConfigs!.map((f) => ({
+          ...f!,
           schema: "{}",
-        },
+        })),
         referenceBranch: {
           ...MOCK_EXPERIMENT.referenceBranch!,
           id: 456,

--- a/app/experimenter/nimbus-ui/src/components/Summary/TableBranches/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/TableBranches/index.test.tsx
@@ -77,10 +77,10 @@ describe("TableBranches", () => {
       <Subject
         experiment={{
           ...MOCK_EXPERIMENT,
-          featureConfig: {
-            ...MOCK_EXPERIMENT.featureConfig!,
+          featureConfigs: MOCK_EXPERIMENT.featureConfigs!.map((f) => ({
+            ...f!,
             schema: null,
-          },
+          })),
         }}
       />,
     );

--- a/app/experimenter/nimbus-ui/src/components/Summary/TableBranches/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/TableBranches/index.tsx
@@ -41,8 +41,6 @@ const TableBranches = ({
 }: {
   experiment: getExperiment_experimentBySlug;
 }) => {
-  const { featureConfig } = experiment;
-  const hasSchema = featureConfig?.schema !== null;
   const branches = [
     experiment.referenceBranch,
     ...(experiment.treatmentBranches || []),
@@ -59,7 +57,7 @@ const TableBranches = ({
       ) : (
         <>
           {savedBranches.map((branch, key) => (
-            <TableBranch key={key} {...{ hasSchema, experiment, branch }} />
+            <TableBranch key={key} {...{ experiment, branch }} />
           ))}
         </>
       )}
@@ -68,11 +66,9 @@ const TableBranches = ({
 };
 
 const TableBranch = ({
-  hasSchema,
   experiment,
   branch,
 }: {
-  hasSchema: boolean;
   experiment: getExperiment_experimentBySlug;
   branch: Branch;
 }) => {
@@ -141,7 +137,7 @@ const TableBranch = ({
             {featureEnabled ? "True" : "False"}
           </td>
         </tr>
-        {hasSchema && featureEnabled && (
+        {featureEnabled && (
           <tr>
             <th>Value</th>
             <td data-testid="branch-featureValue">

--- a/app/experimenter/nimbus-ui/src/components/Summary/TableBranches/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/TableBranches/mocks.tsx
@@ -6,17 +6,18 @@ import React from "react";
 import TableBranches from ".";
 import { mockExperimentQuery } from "../../../lib/mocks";
 import { RouterSlugProvider } from "../../../lib/test-utils";
+import { getExperiment_experimentBySlug } from "../../../types/getExperiment";
 import AppLayout from "../../AppLayout";
 
 type TableBranchesProps = React.ComponentProps<typeof TableBranches>;
 
 const { experiment } = mockExperimentQuery("demo-slug", {});
-export const MOCK_EXPERIMENT = {
+export const MOCK_EXPERIMENT: getExperiment_experimentBySlug = {
   ...experiment,
-  featureConfig: {
-    ...experiment.featureConfig!,
+  featureConfigs: experiment.featureConfigs!.map((f) => ({
+    ...f!,
     schema: "{}",
-  },
+  })),
 };
 
 export const Subject = ({

--- a/app/experimenter/nimbus-ui/src/components/Summary/TableOverview/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/TableOverview/index.stories.tsx
@@ -12,7 +12,7 @@ import AppLayout from "../../AppLayout";
 storiesOf("components/Summary/TableOverview", module)
   .add("all fields filled out", () => {
     const { experiment } = mockExperimentQuery("demo-slug", {
-      featureConfig: MOCK_CONFIG.featureConfigs![1],
+      featureConfigs: [MOCK_CONFIG.allFeatureConfigs![1]],
     });
     return (
       <Subject>
@@ -22,7 +22,7 @@ storiesOf("components/Summary/TableOverview", module)
   })
   .add("filled out with multiple outcomes", () => {
     const { experiment } = mockExperimentQuery("demo-slug", {
-      featureConfig: MOCK_CONFIG.featureConfigs![1],
+      featureConfigs: [MOCK_CONFIG.allFeatureConfigs![1]],
       primaryOutcomes: ["picture_in_picture", "feature_C"],
       secondaryOutcomes: ["feature_b", "feature_d"],
     });

--- a/app/experimenter/nimbus-ui/src/components/Summary/TableOverview/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/TableOverview/index.test.tsx
@@ -172,7 +172,7 @@ describe("TableOverview", () => {
   describe("renders 'Feature config' row as expected", () => {
     it("when set", () => {
       const { experiment } = mockExperimentQuery("demo-slug", {
-        featureConfig: MOCK_CONFIG.featureConfigs![1],
+        featureConfigs: [MOCK_CONFIG.allFeatureConfigs![1]],
       });
       render(<Subject {...{ experiment }} />);
       expect(screen.getByTestId("experiment-feature-config")).toHaveTextContent(

--- a/app/experimenter/nimbus-ui/src/components/Summary/TableOverview/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/TableOverview/index.tsx
@@ -102,8 +102,12 @@ const TableOverview = ({
             <tr>
               <th>Feature config</th>
               <td data-testid="experiment-feature-config">
-                {experiment.featureConfig?.name ? (
-                  experiment.featureConfig.name
+                {experiment.featureConfigs?.length ? (
+                  experiment.featureConfigs.map((f) => (
+                    <>
+                      <p>{f?.name}</p>
+                    </>
+                  ))
                 ) : (
                   <NotSet />
                 )}

--- a/app/experimenter/nimbus-ui/src/gql/config.ts
+++ b/app/experimenter/nimbus-ui/src/gql/config.ts
@@ -26,7 +26,7 @@ export const GET_CONFIG_QUERY = gql`
           value
         }
       }
-      featureConfigs {
+      allFeatureConfigs {
         id
         name
         slug

--- a/app/experimenter/nimbus-ui/src/gql/experiments.ts
+++ b/app/experimenter/nimbus-ui/src/gql/experiments.ts
@@ -87,7 +87,7 @@ export const GET_EXPERIMENT_QUERY = gql`
         }
       }
 
-      featureConfig {
+      featureConfigs {
         id
         slug
         name
@@ -187,7 +187,7 @@ export const GET_EXPERIMENTS_QUERY = gql`
       owner {
         username
       }
-      featureConfig {
+      featureConfigs {
         id
         slug
         name

--- a/app/experimenter/nimbus-ui/src/lib/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/lib/mocks.tsx
@@ -165,7 +165,7 @@ export const MOCK_CONFIG: getConfig_nimbusConfig = {
       ],
     },
   ],
-  featureConfigs: [
+  allFeatureConfigs: [
     {
       id: 1,
       name: "Picture-in-Picture",
@@ -474,7 +474,7 @@ export const MOCK_EXPERIMENT: Partial<getExperiment["experimentBySlug"]> = {
     featureEnabled: true,
     screenshots: [],
   },
-  featureConfig: null,
+  featureConfigs: [],
   treatmentBranches: [
     {
       id: 456,
@@ -657,7 +657,8 @@ export function mockSingleDirectoryExperiment(
     status: NimbusExperimentStatusEnum.COMPLETE,
     statusNext: null,
     publishStatus: NimbusExperimentPublishStatusEnum.IDLE,
-    featureConfig: MOCK_CONFIG.featureConfigs![0],
+    featureConfig: MOCK_CONFIG.allFeatureConfigs![0],
+    featureConfigs: [MOCK_CONFIG.allFeatureConfigs![0]],
     isEnrollmentPaused: false,
     isEnrollmentPausePending: false,
     proposedEnrollment: 7,
@@ -682,7 +683,7 @@ export function mockDirectoryExperiments(
       name: "Ipsum dolor sit amet",
       status: NimbusExperimentStatusEnum.DRAFT,
       owner: { username: "gamma-example@mozilla.com" },
-      featureConfig: MOCK_CONFIG.featureConfigs![0],
+      featureConfigs: [MOCK_CONFIG.allFeatureConfigs![0]],
       application: MOCK_CONFIG.applications![1]!
         .value as NimbusExperimentApplicationEnum,
       startDate: null,
@@ -692,7 +693,7 @@ export function mockDirectoryExperiments(
       name: "Dolor sit amet",
       status: NimbusExperimentStatusEnum.DRAFT,
       owner: { username: "beta-example@mozilla.com" },
-      featureConfig: MOCK_CONFIG.featureConfigs![1],
+      featureConfigs: [MOCK_CONFIG.allFeatureConfigs![1]],
       startDate: null,
       computedEndDate: null,
     },
@@ -700,7 +701,7 @@ export function mockDirectoryExperiments(
       name: "Consectetur adipiscing elit",
       status: NimbusExperimentStatusEnum.PREVIEW,
       owner: { username: "alpha-example@mozilla.com" },
-      featureConfig: MOCK_CONFIG.featureConfigs![2],
+      featureConfigs: [MOCK_CONFIG.allFeatureConfigs![2]],
       application: MOCK_CONFIG.applications![1]!
         .value as NimbusExperimentApplicationEnum,
       computedEndDate: null,
@@ -709,7 +710,7 @@ export function mockDirectoryExperiments(
       name: "Aliquam interdum ac lacus at dictum",
       publishStatus: NimbusExperimentPublishStatusEnum.APPROVED,
       owner: { username: "beta-example@mozilla.com" },
-      featureConfig: MOCK_CONFIG.featureConfigs![0],
+      featureConfigs: [MOCK_CONFIG.allFeatureConfigs![0]],
       computedEndDate: null,
     },
     {
@@ -723,13 +724,13 @@ export function mockDirectoryExperiments(
       name: "Duis ornare mollis sem.",
       status: NimbusExperimentStatusEnum.LIVE,
       owner: { username: "alpha-example@mozilla.com" },
-      featureConfig: MOCK_CONFIG.featureConfigs![1],
+      featureConfigs: [MOCK_CONFIG.allFeatureConfigs![1]],
     },
     {
       name: "Nec suscipit mi accumsan id",
       status: NimbusExperimentStatusEnum.LIVE,
       owner: { username: "beta-example@mozilla.com" },
-      featureConfig: MOCK_CONFIG.featureConfigs![2],
+      featureConfigs: [MOCK_CONFIG.allFeatureConfigs![2]],
       application: MOCK_CONFIG.applications![1]!
         .value as NimbusExperimentApplicationEnum,
       resultsReady: true,
@@ -743,7 +744,7 @@ export function mockDirectoryExperiments(
       name: "Nam gravida",
       status: NimbusExperimentStatusEnum.COMPLETE,
       owner: { username: "alpha-example@mozilla.com" },
-      featureConfig: MOCK_CONFIG.featureConfigs![0],
+      featureConfigs: [MOCK_CONFIG.allFeatureConfigs![0]],
       application: MOCK_CONFIG.applications![1]!
         .value as NimbusExperimentApplicationEnum,
       resultsReady: false,
@@ -752,12 +753,12 @@ export function mockDirectoryExperiments(
       name: "Quam quis volutpat ornare",
       status: NimbusExperimentStatusEnum.DRAFT,
       publishStatus: NimbusExperimentPublishStatusEnum.REVIEW,
-      featureConfig: MOCK_CONFIG.featureConfigs![1],
+      featureConfigs: [MOCK_CONFIG.allFeatureConfigs![1]],
       owner: { username: "beta-example@mozilla.com" },
     },
     {
       name: "Lorem arcu faucibus tortor",
-      featureConfig: null,
+      featureConfigs: null,
       application: MOCK_CONFIG.applications![1]!
         .value as NimbusExperimentApplicationEnum,
       owner: { username: "gamma-example@mozilla.com" },
@@ -765,7 +766,7 @@ export function mockDirectoryExperiments(
     {
       isArchived: true,
       name: "Archived Experiment",
-      featureConfig: null,
+      featureConfigs: null,
       application: MOCK_CONFIG.applications![1]!
         .value as NimbusExperimentApplicationEnum,
       owner: { username: "gamma-example@mozilla.com" },

--- a/app/experimenter/nimbus-ui/src/lib/test-utils.tsx
+++ b/app/experimenter/nimbus-ui/src/lib/test-utils.tsx
@@ -151,7 +151,7 @@ export const assertSerializerMessages = async (
   });
 
   const { experiment } = mockExperimentQuery("boo", {
-    featureConfig: null,
+    featureConfigs: [],
     readyForReview: {
       ready: false,
       message: messages,

--- a/app/experimenter/nimbus-ui/src/types/getAllExperiments.ts
+++ b/app/experimenter/nimbus-ui/src/types/getAllExperiments.ts
@@ -13,7 +13,7 @@ export interface getAllExperiments_experiments_owner {
   username: string;
 }
 
-export interface getAllExperiments_experiments_featureConfig {
+export interface getAllExperiments_experiments_featureConfigs {
   id: number | null;
   slug: string;
   name: string;
@@ -23,11 +23,16 @@ export interface getAllExperiments_experiments_featureConfig {
   schema: string | null;
 }
 
+export interface getAllExperiments_experiments_featureConfig {
+  slug: string;
+  name: string;
+}
+
 export interface getAllExperiments_experiments {
   isArchived: boolean | null;
   name: string;
   owner: getAllExperiments_experiments_owner;
-  featureConfig: getAllExperiments_experiments_featureConfig | null;
+  featureConfigs: (getAllExperiments_experiments_featureConfigs | null)[] | null;
   slug: string;
   application: NimbusExperimentApplicationEnum | null;
   firefoxMinVersion: NimbusExperimentFirefoxVersionEnum | null;
@@ -43,6 +48,7 @@ export interface getAllExperiments_experiments {
   publishStatus: NimbusExperimentPublishStatusEnum | null;
   monitoringDashboardUrl: string | null;
   resultsReady: boolean | null;
+  featureConfig: getAllExperiments_experiments_featureConfig | null;
 }
 
 export interface getAllExperiments {

--- a/app/experimenter/nimbus-ui/src/types/getConfig.ts
+++ b/app/experimenter/nimbus-ui/src/types/getConfig.ts
@@ -34,7 +34,7 @@ export interface getConfig_nimbusConfig_applicationConfigs {
   channels: (getConfig_nimbusConfig_applicationConfigs_channels | null)[] | null;
 }
 
-export interface getConfig_nimbusConfig_featureConfigs {
+export interface getConfig_nimbusConfig_allFeatureConfigs {
   id: number | null;
   name: string;
   slug: string;
@@ -94,7 +94,7 @@ export interface getConfig_nimbusConfig {
   channels: (getConfig_nimbusConfig_channels | null)[] | null;
   conclusionRecommendations: (getConfig_nimbusConfig_conclusionRecommendations | null)[] | null;
   applicationConfigs: (getConfig_nimbusConfig_applicationConfigs | null)[] | null;
-  featureConfigs: (getConfig_nimbusConfig_featureConfigs | null)[] | null;
+  allFeatureConfigs: (getConfig_nimbusConfig_allFeatureConfigs | null)[] | null;
   firefoxVersions: (getConfig_nimbusConfig_firefoxVersions | null)[] | null;
   outcomes: (getConfig_nimbusConfig_outcomes | null)[] | null;
   owners: (getConfig_nimbusConfig_owners | null)[] | null;

--- a/app/experimenter/nimbus-ui/src/types/getExperiment.ts
+++ b/app/experimenter/nimbus-ui/src/types/getExperiment.ts
@@ -52,7 +52,7 @@ export interface getExperiment_experimentBySlug_treatmentBranches {
   screenshots: getExperiment_experimentBySlug_treatmentBranches_screenshots[] | null;
 }
 
-export interface getExperiment_experimentBySlug_featureConfig {
+export interface getExperiment_experimentBySlug_featureConfigs {
   id: number | null;
   slug: string;
   name: string;
@@ -142,7 +142,7 @@ export interface getExperiment_experimentBySlug {
   warnFeatureSchema: boolean | null;
   referenceBranch: getExperiment_experimentBySlug_referenceBranch | null;
   treatmentBranches: (getExperiment_experimentBySlug_treatmentBranches | null)[] | null;
-  featureConfig: getExperiment_experimentBySlug_featureConfig | null;
+  featureConfigs: (getExperiment_experimentBySlug_featureConfigs | null)[] | null;
   primaryOutcomes: (string | null)[] | null;
   secondaryOutcomes: (string | null)[] | null;
   channel: NimbusExperimentChannelEnum | null;

--- a/app/experimenter/nimbus-ui/src/types/globalTypes.ts
+++ b/app/experimenter/nimbus-ui/src/types/globalTypes.ts
@@ -207,7 +207,7 @@ export interface ExperimentInput {
   isEnrollmentPaused?: boolean | null;
   riskMitigationLink?: string | null;
   featureConfigId?: number | null;
-  featureConfigs?: (number | null)[] | null;
+  featureConfigIds?: (number | null)[] | null;
   warnFeatureSchema?: boolean | null;
   documentationLinks?: (DocumentationLinkInput | null)[] | null;
   referenceBranch?: ReferenceBranchInput | null;


### PR DESCRIPTION
Because

* In anticipation of adding multifeature to nimbus ui, we should update the core nimbus ui infrastructure to use feature_configs instead of feature_config

This commit

* Updates the branches page to use and set feature_configs instead of feature_config