### PR TITLE
chore(project): update docker desktop docs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,25 +20,26 @@ jobs:
             cp .env.sample .env
             make check
 
-  publish_storybooks:
-    machine:
-      image: ubuntu-2004:202107-02 # Ubuntu 20.04, Docker v20.10.7, Docker Compose v1.29.2
-      docker_layer_caching: true
-    resource_class: medium
-    working_directory: ~/experimenter
-    steps:
-      - run:
-          name: Docker info
-          command: docker -v
-      - run:
-          name: Docker compose info
-          command: docker-compose -v
-      - checkout
-      - run:
-          name: Publish Storybooks
-          command: |
-            ./scripts/store_git_info.sh
-            make publish_storybooks
+  # Disabling due to failure and impending deprecation
+  # publish_storybooks:
+  #   machine:
+  #     image: ubuntu-2004:202107-02 # Ubuntu 20.04, Docker v20.10.7, Docker Compose v1.29.2
+  #     docker_layer_caching: true
+  #   resource_class: medium
+  #   working_directory: ~/experimenter
+  #   steps:
+  #     - run:
+  #         name: Docker info
+  #         command: docker -v
+  #     - run:
+  #         name: Docker compose info
+  #         command: docker-compose -v
+  #     - checkout
+  #     - run:
+  #         name: Publish Storybooks
+  #         command: |
+  #           ./scripts/store_git_info.sh
+  #           make publish_storybooks
 
   integration_nimbus:
     machine:
@@ -89,8 +90,8 @@ workflows:
     jobs:
       - check:
           name: check
-      - publish_storybooks:
-          name: publish_storybooks
+      # - publish_storybooks:
+      #     name: publish_storybooks
       - integration_nimbus:
           name: integration_nimbus
           filters:

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ On all platforms:
 - Install [Node](https://nodejs.org/en/) ^14.0.0
 - On Linux [setup docker to run as non-root](https://docs.docker.com/engine/security/rootless/)
 - On MacOS
-  - [Install Docker Desktop 3.3.2](https://docs.docker.com/docker-for-mac/release-notes/#docker-desktop-332) (Newer versions have been buggy)
+  - [Install Docker Desktop](https://www.docker.com/products/docker-desktop)
   - Adjust resource settings
     - CPU: Max number of cores
     - Memory: 50% of system memory


### PR DESCRIPTION
Because

* At some point we had to hard code a docker version in the docs because subsequent versions were broken
* This is no longer the case

This commit

* Updates docs to point to the latest docker desktop