### PR TITLE
fixes #6446 feat(Nimbus): include public name in rollout promotion

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/CloneDialog/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/CloneDialog/index.tsx
@@ -58,7 +58,7 @@ export const CloneDialog = ({
 }: CloneDialogProps) => {
   const defaultValues: CloneParams = {
     name: rolloutBranch
-      ? `${rolloutBranch.name} Rollout`
+      ? `${experiment!.name} - ${rolloutBranch.name} Rollout`
       : `${experiment!.name} Copy`,
   };
 


### PR DESCRIPTION
Because

* branch names are not great rollout names

This Commit

* adds public name to rollout promotion