### PR TITLE
fix #7122 bug(project): disable reporting task

### DIFF
--- a/app/experimenter/settings.py
+++ b/app/experimenter/settings.py
@@ -345,10 +345,10 @@ CELERY_BEAT_SCHEDULE = {
         "task": "experimenter.jetstream.tasks.fetch_jetstream_data",
         "schedule": 28800,
     },
-    "reporting_generate_report_logs": {
-        "task": "experimenter.reporting.tasks.generate_reportlogs",
-        "schedule": config("CELERY_REPORTING_INTERVAL", default=86400, cast=int),
-    },
+    # "reporting_generate_report_logs": {
+    #     "task": "experimenter.reporting.tasks.generate_reportlogs",
+    #     "schedule": config("CELERY_REPORTING_INTERVAL", default=86400, cast=int),
+    # },
 }
 
 # Recipe Configuration


### PR DESCRIPTION
Because

* We're seeing intermittent database load spikes that are preventing Experimenter from loading
* The spikes are happening on queries to the changelog table
* It may be the reporting task hitting that table that is causing the issue

This commit

* Disables the reporting task