### PR TITLE
fix #6769 feat(nimbus): enable version targeting on mobile

### DIFF
--- a/app/experimenter/experiments/api/v5/serializers.py
+++ b/app/experimenter/experiments/api/v5/serializers.py
@@ -1043,6 +1043,42 @@ class NimbusReviewSerializer(serializers.ModelSerializer):
             )
         return data
 
+    def _validate_versions_mobile(self, data):
+        application = data.get("application")
+        min_version = data.get("firefox_min_version")
+        max_version = data.get("firefox_max_version")
+
+        supported_versions = {
+            NimbusExperiment.Application.FENIX: NimbusExperiment.Version.FIREFOX_98,
+            NimbusExperiment.Application.FOCUS_ANDROID: (
+                NimbusExperiment.Version.FIREFOX_98
+            ),
+            NimbusExperiment.Application.IOS: NimbusExperiment.Version.FIREFOX_97,
+            NimbusExperiment.Application.FOCUS_IOS: NimbusExperiment.Version.FIREFOX_97,
+        }
+
+        errors = {}
+
+        if application in supported_versions:
+            supported_version = supported_versions[application]
+
+            if min_version and min_version < supported_version:
+
+                errors["firefox_min_version"] = [
+                    NimbusExperiment.ERROR_FIREFOX_VERSION_MOBILE
+                ]
+
+            if max_version and max_version < supported_version:
+
+                errors["firefox_max_version"] = [
+                    NimbusExperiment.ERROR_FIREFOX_VERSION_MOBILE
+                ]
+
+        if errors:
+            raise serializers.ValidationError(errors)
+
+        return data
+
     def validate(self, data):
         application = data.get("application")
         channel = data.get("channel")
@@ -1054,6 +1090,7 @@ class NimbusReviewSerializer(serializers.ModelSerializer):
         data = self._validate_feature_config(data)
         data = self._validate_feature_configs(data)
         data = self._validate_versions(data)
+        data = self._validate_versions_mobile(data)
         return data
 
 

--- a/app/experimenter/experiments/constants/nimbus.py
+++ b/app/experimenter/experiments/constants/nimbus.py
@@ -875,6 +875,9 @@ Optional - We believe this outcome will <describe impact> on <core metric>
     ERROR_FIREFOX_VERSION_MAX = (
         "Ensure this value is greater than or equal to the minimum version"
     )
+    ERROR_FIREFOX_VERSION_MOBILE = (
+        "Version targeting is not supported on this application for this version"
+    )
 
     # Analysis can be computed starting the week after enrollment
     # completion for "week 1" of the experiment. However, an extra

--- a/app/experimenter/experiments/models/nimbus.py
+++ b/app/experimenter/experiments/models/nimbus.py
@@ -256,23 +256,24 @@ class NimbusExperiment(NimbusConstants, FilterMixin, models.Model):
                         channel=self.channel
                     )
                 )
-            if self.firefox_min_version:
-                expressions.append(
-                    "version|versionCompare('{version}') >= 0".format(
-                        version=self.firefox_min_version
-                    )
-                )
-            if self.firefox_max_version:
-                # HACK: tweak the min version to better match max version pattern
-                max_version = self.firefox_max_version.replace("!", "*")
-                expressions.append(
-                    "version|versionCompare('{max_version}') < 0".format(
-                        max_version=max_version
-                    )
-                )
 
             # TODO: Remove opt-out after Firefox 84 is the earliest supported Desktop
             expressions.append("'app.shield.optoutstudies.enabled'|preferenceValue")
+
+        if self.firefox_min_version:
+            expressions.append(
+                "version|versionCompare('{version}') >= 0".format(
+                    version=self.firefox_min_version
+                )
+            )
+        if self.firefox_max_version:
+            # HACK: tweak the min version to better match max version pattern
+            max_version = self.firefox_max_version.replace("!", "*")
+            expressions.append(
+                "version|versionCompare('{max_version}') < 0".format(
+                    max_version=max_version
+                )
+            )
 
         if self.locales.count():
             locales = [locale.code for locale in self.locales.all().order_by("code")]

--- a/app/experimenter/experiments/tests/api/v5/test_queries.py
+++ b/app/experimenter/experiments/tests/api/v5/test_queries.py
@@ -611,6 +611,8 @@ class TestNimbusExperimentBySlugQuery(GraphQLTestCase):
             NimbusExperimentFactory.Lifecycles.CREATED,
             targeting_config_slug="",
             application=NimbusExperiment.Application.FENIX,
+            firefox_min_version=NimbusExperiment.Version.NO_VERSION,
+            firefox_max_version=NimbusExperiment.Version.NO_VERSION,
         )
         response = self.query(
             """

--- a/app/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_ready_for_review_serializer.py
+++ b/app/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_ready_for_review_serializer.py
@@ -97,7 +97,7 @@ class TestNimbusReviewSerializerSingleFeature(TestCase):
             ).data,
             context={"user": self.user},
         )
-        self.assertFalse(serializer.is_valid())
+        self.assertFalse(serializer.is_valid(), serializer.errors)
         self.assertEqual(
             serializer.errors,
             {"hypothesis": ["Hypothesis cannot be the default value."]},
@@ -123,7 +123,7 @@ class TestNimbusReviewSerializerSingleFeature(TestCase):
             ).data,
             context={"user": self.user},
         )
-        self.assertFalse(serializer.is_valid())
+        self.assertFalse(serializer.is_valid(), serializer.errors)
         self.assertEqual(
             serializer.errors,
             {"reference_branch": ["This field may not be null."]},
@@ -149,7 +149,7 @@ class TestNimbusReviewSerializerSingleFeature(TestCase):
             ).data,
             context={"user": self.user},
         )
-        self.assertFalse(serializer.is_valid())
+        self.assertFalse(serializer.is_valid(), serializer.errors)
         self.assertEqual(
             serializer.errors,
             {"reference_branch": {"description": [NimbusConstants.ERROR_REQUIRED_FIELD]}},
@@ -170,7 +170,7 @@ class TestNimbusReviewSerializerSingleFeature(TestCase):
             ).data,
             context={"user": self.user},
         )
-        self.assertFalse(serializer.is_valid())
+        self.assertFalse(serializer.is_valid(), serializer.errors)
         self.assertEqual(
             serializer.errors,
             {
@@ -215,7 +215,7 @@ class TestNimbusReviewSerializerSingleFeature(TestCase):
             ).data,
             context={"user": self.user},
         )
-        self.assertFalse(serializer.is_valid())
+        self.assertFalse(serializer.is_valid(), serializer.errors)
         self.assertEqual(
             str(serializer.errors["population_percent"][0]),
             "Ensure this value is greater than or equal to 0.0001.",
@@ -265,7 +265,7 @@ class TestNimbusReviewSerializerSingleFeature(TestCase):
             ).data,
             context={"user": self.user},
         )
-        self.assertFalse(serializer.is_valid())
+        self.assertFalse(serializer.is_valid(), serializer.errors)
         self.assertEqual(
             serializer.errors["treatment_branches"][1],
             {"description": [NimbusConstants.ERROR_REQUIRED_FIELD]},
@@ -285,7 +285,7 @@ class TestNimbusReviewSerializerSingleFeature(TestCase):
             ).data,
             context={"user": self.user},
         )
-        self.assertFalse(serializer.is_valid())
+        self.assertFalse(serializer.is_valid(), serializer.errors)
         self.assertEqual(
             serializer.errors["feature_config"],
             [NimbusConstants.ERROR_REQUIRED_FEATURE_CONFIG],
@@ -312,7 +312,7 @@ class TestNimbusReviewSerializerSingleFeature(TestCase):
             ).data,
             context={"user": self.user},
         )
-        self.assertFalse(serializer.is_valid())
+        self.assertFalse(serializer.is_valid(), serializer.errors)
         self.assertEqual(
             str(serializer.errors["risk_partner_related"][0]),
             NimbusConstants.ERROR_REQUIRED_QUESTION,
@@ -357,7 +357,6 @@ class TestNimbusReviewSerializerSingleFeature(TestCase):
     def test_serializer_feature_config_validation_application_mismatches_error(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.CREATED,
-            status=NimbusExperiment.Status.DRAFT,
             application=NimbusExperiment.Application.FENIX,
             channel=NimbusExperiment.Channel.RELEASE,
             feature_configs=[
@@ -377,7 +376,7 @@ class TestNimbusReviewSerializerSingleFeature(TestCase):
             context={"user": self.user},
         )
 
-        self.assertFalse(serializer.is_valid())
+        self.assertFalse(serializer.is_valid(), serializer.errors)
         self.assertEqual(
             serializer.errors["feature_config"],
             [
@@ -389,7 +388,6 @@ class TestNimbusReviewSerializerSingleFeature(TestCase):
     def test_serializer_feature_config_validation_missing_feature_config(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.CREATED,
-            status=NimbusExperiment.Status.DRAFT,
             application=NimbusExperiment.Application.FENIX,
             feature_configs=[],
         )
@@ -403,7 +401,7 @@ class TestNimbusReviewSerializerSingleFeature(TestCase):
             context={"user": self.user},
         )
 
-        self.assertFalse(serializer.is_valid())
+        self.assertFalse(serializer.is_valid(), serializer.errors)
         self.assertEqual(
             serializer.errors["feature_config"],
             ["You must select a feature configuration from the drop down."],
@@ -412,7 +410,6 @@ class TestNimbusReviewSerializerSingleFeature(TestCase):
     def test_serializer_feature_config_validation_bad_json_value(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.CREATED,
-            status=NimbusExperiment.Status.DRAFT,
             application=NimbusExperiment.Application.DESKTOP,
             channel=NimbusExperiment.Channel.NO_CHANNEL,
             feature_configs=[
@@ -444,7 +441,7 @@ class TestNimbusReviewSerializerSingleFeature(TestCase):
             context={"user": self.user},
         )
 
-        self.assertFalse(serializer.is_valid())
+        self.assertFalse(serializer.is_valid(), serializer.errors)
         self.assertIn(
             "Unterminated string",
             serializer.errors["reference_branch"]["feature_value"][0],
@@ -454,7 +451,6 @@ class TestNimbusReviewSerializerSingleFeature(TestCase):
     def test_serializer_feature_config_validation_reference_value_schema_error(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.CREATED,
-            status=NimbusExperiment.Status.DRAFT,
             application=NimbusExperiment.Application.DESKTOP,
             channel=NimbusExperiment.Channel.NO_CHANNEL,
             feature_configs=[
@@ -485,7 +481,7 @@ class TestNimbusReviewSerializerSingleFeature(TestCase):
             ).data,
             context={"user": self.user},
         )
-        self.assertFalse(serializer.is_valid())
+        self.assertFalse(serializer.is_valid(), serializer.errors)
         self.assertTrue(
             serializer.errors["reference_branch"]["feature_value"][0].startswith(
                 "Additional properties are not allowed"
@@ -497,7 +493,6 @@ class TestNimbusReviewSerializerSingleFeature(TestCase):
     def test_serializer_feature_config_validation_reference_value_schema_warn(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.CREATED,
-            status=NimbusExperiment.Status.DRAFT,
             application=NimbusExperiment.Application.DESKTOP,
             channel=NimbusExperiment.Channel.NO_CHANNEL,
             warn_feature_schema=True,
@@ -541,7 +536,6 @@ class TestNimbusReviewSerializerSingleFeature(TestCase):
     def test_serializer_feature_config_validation_treatment_value_schema_error(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.CREATED,
-            status=NimbusExperiment.Status.DRAFT,
             application=NimbusExperiment.Application.DESKTOP,
             channel=NimbusExperiment.Channel.NO_CHANNEL,
             feature_configs=[
@@ -572,7 +566,7 @@ class TestNimbusReviewSerializerSingleFeature(TestCase):
             context={"user": self.user},
         )
 
-        self.assertFalse(serializer.is_valid())
+        self.assertFalse(serializer.is_valid(), serializer.errors)
         self.assertTrue(
             serializer.errors["treatment_branches"][0]["feature_value"][0].startswith(
                 "Additional properties are not allowed"
@@ -584,7 +578,6 @@ class TestNimbusReviewSerializerSingleFeature(TestCase):
     def test_serializer_feature_config_validation_treatment_value_schema_warn(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.CREATED,
-            status=NimbusExperiment.Status.DRAFT,
             application=NimbusExperiment.Application.DESKTOP,
             channel=NimbusExperiment.Channel.NO_CHANNEL,
             warn_feature_schema=True,
@@ -628,7 +621,6 @@ class TestNimbusReviewSerializerSingleFeature(TestCase):
     def test_serializer_feature_config_validation_treatment_value_no_schema(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.CREATED,
-            status=NimbusExperiment.Status.DRAFT,
             application=NimbusExperiment.Application.DESKTOP,
             channel=NimbusExperiment.Channel.NO_CHANNEL,
             feature_configs=[
@@ -648,6 +640,156 @@ class TestNimbusReviewSerializerSingleFeature(TestCase):
         )
         self.assertTrue(serializer.is_valid())
 
+    @parameterized.expand(
+        [
+            (NimbusExperiment.Application.FENIX,),
+            (NimbusExperiment.Application.FOCUS_ANDROID,),
+        ]
+    )
+    def test_serializer_valid_min_version_android_above_98(self, application):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            application=application,
+            channel=NimbusExperiment.Channel.RELEASE,
+            firefox_min_version=NimbusExperiment.Version.FIREFOX_98,
+            firefox_max_version=NimbusExperiment.Version.NO_VERSION,
+        )
+        serializer = NimbusReviewSerializer(
+            experiment,
+            data=NimbusReviewSerializer(
+                experiment,
+                context={"user": self.user},
+            ).data,
+            context={"user": self.user},
+        )
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+
+    @parameterized.expand(
+        [
+            (NimbusExperiment.Application.FENIX,),
+            (NimbusExperiment.Application.FOCUS_ANDROID,),
+        ]
+    )
+    def test_serializer_no_min_version_android_below_98(self, application):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            application=application,
+            channel=NimbusExperiment.Channel.RELEASE,
+            firefox_min_version=NimbusExperiment.Version.FIREFOX_97,
+            firefox_max_version=NimbusExperiment.Version.NO_VERSION,
+        )
+        serializer = NimbusReviewSerializer(
+            experiment,
+            data=NimbusReviewSerializer(
+                experiment,
+                context={"user": self.user},
+            ).data,
+            context={"user": self.user},
+        )
+        self.assertFalse(serializer.is_valid(), serializer.errors)
+        self.assertIn("firefox_min_version", serializer.errors)
+
+    @parameterized.expand(
+        [
+            (NimbusExperiment.Application.FENIX,),
+            (NimbusExperiment.Application.FOCUS_ANDROID,),
+        ]
+    )
+    def test_serializer_no_max_version_android_below_98(self, application):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            application=application,
+            channel=NimbusExperiment.Channel.RELEASE,
+            firefox_min_version=NimbusExperiment.Version.FIREFOX_96,
+            firefox_max_version=NimbusExperiment.Version.FIREFOX_97,
+        )
+        serializer = NimbusReviewSerializer(
+            experiment,
+            data=NimbusReviewSerializer(
+                experiment,
+                context={"user": self.user},
+            ).data,
+            context={"user": self.user},
+        )
+        self.assertFalse(serializer.is_valid(), serializer.errors)
+        self.assertIn("firefox_min_version", serializer.errors)
+        self.assertIn("firefox_max_version", serializer.errors)
+
+    @parameterized.expand(
+        [
+            (NimbusExperiment.Application.IOS,),
+            (NimbusExperiment.Application.FOCUS_IOS,),
+        ]
+    )
+    def test_serializer_valid_min_version_ios_above_97(self, application):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            application=application,
+            channel=NimbusExperiment.Channel.RELEASE,
+            firefox_min_version=NimbusExperiment.Version.FIREFOX_97,
+            firefox_max_version=NimbusExperiment.Version.NO_VERSION,
+        )
+        serializer = NimbusReviewSerializer(
+            experiment,
+            data=NimbusReviewSerializer(
+                experiment,
+                context={"user": self.user},
+            ).data,
+            context={"user": self.user},
+        )
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+
+    @parameterized.expand(
+        [
+            (NimbusExperiment.Application.IOS,),
+            (NimbusExperiment.Application.FOCUS_IOS,),
+        ]
+    )
+    def test_serializer_no_min_version_ios_below_97(self, application):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            application=application,
+            channel=NimbusExperiment.Channel.RELEASE,
+            firefox_min_version=NimbusExperiment.Version.FIREFOX_96,
+            firefox_max_version=NimbusExperiment.Version.NO_VERSION,
+        )
+        serializer = NimbusReviewSerializer(
+            experiment,
+            data=NimbusReviewSerializer(
+                experiment,
+                context={"user": self.user},
+            ).data,
+            context={"user": self.user},
+        )
+        self.assertFalse(serializer.is_valid(), serializer.errors)
+        self.assertIn("firefox_min_version", serializer.errors)
+
+    @parameterized.expand(
+        [
+            (NimbusExperiment.Application.IOS,),
+            (NimbusExperiment.Application.FOCUS_IOS,),
+        ]
+    )
+    def test_serializer_no_max_version_ios_below_97(self, application):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            application=application,
+            channel=NimbusExperiment.Channel.RELEASE,
+            firefox_min_version=NimbusExperiment.Version.FIREFOX_95,
+            firefox_max_version=NimbusExperiment.Version.FIREFOX_96,
+        )
+        serializer = NimbusReviewSerializer(
+            experiment,
+            data=NimbusReviewSerializer(
+                experiment,
+                context={"user": self.user},
+            ).data,
+            context={"user": self.user},
+        )
+        self.assertFalse(serializer.is_valid(), serializer.errors)
+        self.assertIn("firefox_min_version", serializer.errors)
+        self.assertIn("firefox_max_version", serializer.errors)
+
 
 class TestNimbusReviewSerializerMultiFeature(TestCase):
     def setUp(self):
@@ -665,7 +807,6 @@ class TestNimbusReviewSerializerMultiFeature(TestCase):
     def test_serializer_feature_config_validation_application_mismatches_error(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.CREATED,
-            status=NimbusExperiment.Status.DRAFT,
             application=NimbusExperiment.Application.FENIX,
             channel=NimbusExperiment.Channel.RELEASE,
             feature_configs=[
@@ -689,7 +830,7 @@ class TestNimbusReviewSerializerMultiFeature(TestCase):
             context={"user": self.user},
         )
 
-        self.assertFalse(serializer.is_valid())
+        self.assertFalse(serializer.is_valid(), serializer.errors)
         self.assertEqual(
             serializer.errors["feature_configs"],
             [
@@ -701,7 +842,6 @@ class TestNimbusReviewSerializerMultiFeature(TestCase):
     def test_serializer_feature_config_validation_missing_feature_config(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.CREATED,
-            status=NimbusExperiment.Status.DRAFT,
             application=NimbusExperiment.Application.FENIX,
             feature_configs=[],
         )
@@ -715,7 +855,7 @@ class TestNimbusReviewSerializerMultiFeature(TestCase):
             context={"user": self.user},
         )
 
-        self.assertFalse(serializer.is_valid())
+        self.assertFalse(serializer.is_valid(), serializer.errors)
         self.assertEqual(
             serializer.errors["feature_configs"],
             [
@@ -726,7 +866,6 @@ class TestNimbusReviewSerializerMultiFeature(TestCase):
     def test_serializer_feature_config_validation_bad_json_value(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.CREATED,
-            status=NimbusExperiment.Status.DRAFT,
             application=NimbusExperiment.Application.DESKTOP,
             channel=NimbusExperiment.Channel.NO_CHANNEL,
             feature_configs=[
@@ -760,7 +899,7 @@ class TestNimbusReviewSerializerMultiFeature(TestCase):
             context={"user": self.user},
         )
 
-        self.assertFalse(serializer.is_valid())
+        self.assertFalse(serializer.is_valid(), serializer.errors)
         self.assertEqual(len(serializer.errors), 1)
         feature_values_errors = [
             e
@@ -776,7 +915,6 @@ class TestNimbusReviewSerializerMultiFeature(TestCase):
     def test_serializer_feature_config_validation_reference_value_schema_error(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.CREATED,
-            status=NimbusExperiment.Status.DRAFT,
             application=NimbusExperiment.Application.DESKTOP,
             channel=NimbusExperiment.Channel.NO_CHANNEL,
             feature_configs=[
@@ -810,7 +948,7 @@ class TestNimbusReviewSerializerMultiFeature(TestCase):
             context={"user": self.user},
         )
 
-        self.assertFalse(serializer.is_valid())
+        self.assertFalse(serializer.is_valid(), serializer.errors)
         self.assertEqual(len(serializer.errors), 1)
         feature_values_errors = [
             e
@@ -828,7 +966,6 @@ class TestNimbusReviewSerializerMultiFeature(TestCase):
     def test_serializer_feature_config_validation_treatment_value_schema_error(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.CREATED,
-            status=NimbusExperiment.Status.DRAFT,
             application=NimbusExperiment.Application.DESKTOP,
             channel=NimbusExperiment.Channel.NO_CHANNEL,
             feature_configs=[
@@ -861,7 +998,7 @@ class TestNimbusReviewSerializerMultiFeature(TestCase):
             context={"user": self.user},
         )
 
-        self.assertFalse(serializer.is_valid())
+        self.assertFalse(serializer.is_valid(), serializer.errors)
         self.assertEqual(len(serializer.errors), 1)
         feature_values_errors = [
             e
@@ -887,7 +1024,6 @@ class TestNimbusReviewSerializerMultiFeature(TestCase):
         )
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.CREATED,
-            status=NimbusExperiment.Status.DRAFT,
             application=NimbusExperiment.Application.DESKTOP,
             channel=NimbusExperiment.Channel.NO_CHANNEL,
             feature_configs=[feature1, feature2],

--- a/app/experimenter/experiments/tests/api/v6/test_serializers.py
+++ b/app/experimenter/experiments/tests/api/v6/test_serializers.py
@@ -55,8 +55,8 @@ class TestNimbusExperimentSerializer(TestCase):
                 "startDate": experiment.start_date.isoformat().replace("+00:00", "Z"),
                 "targeting": (
                     'browserSettings.update.channel == "nightly" '
-                    "&& version|versionCompare('94.!') >= 0 "
-                    "&& 'app.shield.optoutstudies.enabled'|preferenceValue"
+                    "&& 'app.shield.optoutstudies.enabled'|preferenceValue "
+                    "&& version|versionCompare('94.!') >= 0"
                 ),
                 "userFacingDescription": experiment.public_description,
                 "userFacingName": experiment.name,
@@ -142,8 +142,8 @@ class TestNimbusExperimentSerializer(TestCase):
                 "startDate": experiment.start_date.isoformat().replace("+00:00", "Z"),
                 "targeting": (
                     'browserSettings.update.channel == "nightly" '
-                    "&& version|versionCompare('95.!') >= 0 "
-                    "&& 'app.shield.optoutstudies.enabled'|preferenceValue"
+                    "&& 'app.shield.optoutstudies.enabled'|preferenceValue "
+                    "&& version|versionCompare('95.!') >= 0"
                 ),
                 "userFacingDescription": experiment.public_description,
                 "userFacingName": experiment.name,
@@ -382,7 +382,8 @@ class TestNimbusExperimentSerializer(TestCase):
             publish_status=NimbusExperiment.PublishStatus.APPROVED,
             targeting_config_slug=NimbusExperiment.TargetingConfig.NO_TARGETING,
             application=NimbusExperiment.Application.FENIX,
-            firefox_min_version=NimbusExperiment.Version.FIREFOX_94,
+            firefox_min_version=NimbusExperiment.Version.NO_VERSION,
+            firefox_max_version=NimbusExperiment.Version.NO_VERSION,
         )
 
         serializer = NimbusExperimentSerializer(experiment)

--- a/app/experimenter/experiments/tests/test_models/test_models_nimbus.py
+++ b/app/experimenter/experiments/tests/test_models/test_models_nimbus.py
@@ -204,6 +204,19 @@ class TestNimbusExperiment(TestCase):
         experiment = NimbusExperimentFactory.create(slug="experiment-slug")
         self.assertEqual(str(experiment), experiment.name)
 
+    def test_empty_targeting(self):
+        experiment = NimbusExperimentFactory.create(
+            firefox_min_version=NimbusExperiment.Version.NO_VERSION,
+            firefox_max_version=NimbusExperiment.Version.NO_VERSION,
+            targeting_config_slug=NimbusExperiment.TargetingConfig.NO_TARGETING,
+            application=NimbusExperiment.Application.FENIX,
+            channel=NimbusExperiment.Channel.NO_CHANNEL,
+            locales=[],
+            countries=[],
+        )
+
+        self.assertEqual(experiment.targeting, "true")
+
     def test_targeting_for_experiment_without_channels(self):
         experiment = NimbusExperimentFactory.create(
             firefox_min_version=NimbusExperiment.Version.FIREFOX_83,
@@ -219,13 +232,13 @@ class TestNimbusExperiment(TestCase):
             experiment.targeting,
             (
                 "os.isMac "
+                "&& 'app.shield.optoutstudies.enabled'|preferenceValue "
                 "&& version|versionCompare('83.!') >= 0 "
-                "&& version|versionCompare('95.*') < 0 "
-                "&& 'app.shield.optoutstudies.enabled'|preferenceValue"
+                "&& version|versionCompare('95.*') < 0"
             ),
         )
 
-    def test_empty_targeting_for_mobile(self):
+    def test_targeting_for_mobile_includes_version(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE_APPROVE,
             firefox_min_version=NimbusExperiment.Version.FIREFOX_83,
@@ -237,7 +250,10 @@ class TestNimbusExperiment(TestCase):
             countries=[],
         )
 
-        self.assertEqual(experiment.targeting, "true")
+        self.assertEqual(
+            experiment.targeting,
+            "version|versionCompare('83.!') >= 0 && version|versionCompare('95.*') < 0",
+        )
 
     def test_targeting_without_firefox_min_version(
         self,
@@ -258,8 +274,8 @@ class TestNimbusExperiment(TestCase):
             (
                 "os.isMac "
                 '&& browserSettings.update.channel == "nightly" '
-                "&& version|versionCompare('95.*') < 0 "
-                "&& 'app.shield.optoutstudies.enabled'|preferenceValue"
+                "&& 'app.shield.optoutstudies.enabled'|preferenceValue "
+                "&& version|versionCompare('95.*') < 0"
             ),
         )
 
@@ -282,8 +298,8 @@ class TestNimbusExperiment(TestCase):
             (
                 "os.isMac "
                 '&& browserSettings.update.channel == "nightly" '
-                "&& version|versionCompare('83.!') >= 0 "
-                "&& 'app.shield.optoutstudies.enabled'|preferenceValue"
+                "&& 'app.shield.optoutstudies.enabled'|preferenceValue "
+                "&& version|versionCompare('83.!') >= 0"
             ),
         )
 


### PR DESCRIPTION
Because

* Mobile clients now support version targeting

This commit

* Exposes version targetin JEXL for mobile clients
* Restricts its use to versions which support it:
  * Fenix 98+
  * Focus Android 98+
  * iOS 97+
  * Focus iOS 97+