### PR TITLE
fix #6769 feat(nimbus): enable version targeting on mobile

### DIFF
--- a/app/experimenter/experiments/constants/nimbus.py
+++ b/app/experimenter/experiments/constants/nimbus.py
@@ -831,6 +831,13 @@ class NimbusConstants(object):
             TARGETING_PIP_NEVER_USED_STICKY.name,
         )
 
+    TARGETING_APPLICATION_SUPPORTED_VERSION = {
+        Application.FENIX: Version.FIREFOX_98,
+        Application.FOCUS_ANDROID: Version.FIREFOX_98,
+        Application.IOS: Version.FIREFOX_97,
+        Application.FOCUS_IOS: Version.FIREFOX_97,
+    }
+
     # Telemetry systems including Firefox Desktop Telemetry v4 and Glean
     # have limits on the length of their unique identifiers, we should
     # limit the size of our slugs to the smallest limit, which is 80

--- a/app/experimenter/experiments/models/nimbus.py
+++ b/app/experimenter/experiments/models/nimbus.py
@@ -238,6 +238,32 @@ class NimbusExperiment(NimbusConstants, FilterMixin, models.Model):
             "https://{host}".format(host=settings.HOSTNAME), self.get_absolute_url()
         )
 
+    def _get_targeting_versions(self):
+        expressions = []
+
+        version_key = "version"
+        if self.application != self.Application.DESKTOP:
+            version_key = "app_version"
+
+        version_supported = True
+        if self.application in self.TARGETING_APPLICATION_SUPPORTED_VERSION:
+            supported_version = self.TARGETING_APPLICATION_SUPPORTED_VERSION[
+                self.application
+            ]
+            version_supported = self.firefox_min_version >= supported_version
+
+        if version_supported:
+            if self.firefox_min_version:
+                expressions.append(
+                    f"{version_key}|versionCompare('{self.firefox_min_version}') >= 0"
+                )
+            if self.firefox_max_version:
+                # HACK: tweak the min version to better match max version pattern
+                max_version = self.firefox_max_version.replace("!", "*")
+                expressions.append(f"{version_key}|versionCompare('{max_version}') < 0")
+
+        return expressions
+
     # This is the full JEXL expression processed by clients
     @property
     def targeting(self):
@@ -251,28 +277,12 @@ class NimbusExperiment(NimbusConstants, FilterMixin, models.Model):
 
         if self.application == self.Application.DESKTOP:
             if self.channel:
-                expressions.append(
-                    'browserSettings.update.channel == "{channel}"'.format(
-                        channel=self.channel
-                    )
-                )
-            if self.firefox_min_version:
-                expressions.append(
-                    "version|versionCompare('{version}') >= 0".format(
-                        version=self.firefox_min_version
-                    )
-                )
-            if self.firefox_max_version:
-                # HACK: tweak the min version to better match max version pattern
-                max_version = self.firefox_max_version.replace("!", "*")
-                expressions.append(
-                    "version|versionCompare('{max_version}') < 0".format(
-                        max_version=max_version
-                    )
-                )
+                expressions.append(f'browserSettings.update.channel == "{self.channel}"')
 
             # TODO: Remove opt-out after Firefox 84 is the earliest supported Desktop
             expressions.append("'app.shield.optoutstudies.enabled'|preferenceValue")
+
+        expressions.extend(self._get_targeting_versions())
 
         if self.locales.count():
             locales = [locale.code for locale in self.locales.all().order_by("code")]

--- a/app/experimenter/experiments/tests/api/v6/test_serializers.py
+++ b/app/experimenter/experiments/tests/api/v6/test_serializers.py
@@ -55,8 +55,8 @@ class TestNimbusExperimentSerializer(TestCase):
                 "startDate": experiment.start_date.isoformat().replace("+00:00", "Z"),
                 "targeting": (
                     '(browserSettings.update.channel == "nightly") '
-                    "&& (version|versionCompare('94.!') >= 0) "
-                    "&& ('app.shield.optoutstudies.enabled'|preferenceValue)"
+                    "&& ('app.shield.optoutstudies.enabled'|preferenceValue) "
+                    "&& (version|versionCompare('94.!') >= 0)"
                 ),
                 "userFacingDescription": experiment.public_description,
                 "userFacingName": experiment.name,
@@ -142,8 +142,8 @@ class TestNimbusExperimentSerializer(TestCase):
                 "startDate": experiment.start_date.isoformat().replace("+00:00", "Z"),
                 "targeting": (
                     '(browserSettings.update.channel == "nightly") '
-                    "&& (version|versionCompare('95.!') >= 0) "
-                    "&& ('app.shield.optoutstudies.enabled'|preferenceValue)"
+                    "&& ('app.shield.optoutstudies.enabled'|preferenceValue) "
+                    "&& (version|versionCompare('95.!') >= 0)"
                 ),
                 "userFacingDescription": experiment.public_description,
                 "userFacingName": experiment.name,


### PR DESCRIPTION
Because

* Mobile clients now support version targeting

This commit

* Enables version targeting for mobile on supported clients
* Only includes version targeting for mobile clients above the minimum supported version