### PR TITLE
fix #7120 chore(nimbus): wrap all JEXL expressions in parens

### DIFF
--- a/app/experimenter/experiments/models/nimbus.py
+++ b/app/experimenter/experiments/models/nimbus.py
@@ -284,7 +284,7 @@ class NimbusExperiment(NimbusConstants, FilterMixin, models.Model):
                 iso_locales_expression = " || ".join(
                     [f"'{language}' in locale" for language in sorted(iso_locales)]
                 )
-                expressions.append(f"({iso_locales_expression})")
+                expressions.append(iso_locales_expression)
 
         if self.countries.count():
             countries = [
@@ -296,7 +296,7 @@ class NimbusExperiment(NimbusConstants, FilterMixin, models.Model):
         if len(expressions) == 0:
             return "true"
 
-        return " && ".join(expressions)
+        return " && ".join([f"({expression})" for expression in expressions])
 
     @property
     def application_config(self):

--- a/app/experimenter/experiments/tests/api/v6/test_serializers.py
+++ b/app/experimenter/experiments/tests/api/v6/test_serializers.py
@@ -54,9 +54,9 @@ class TestNimbusExperimentSerializer(TestCase):
                 # DRF manually replaces the isoformat suffix so we have to do the same
                 "startDate": experiment.start_date.isoformat().replace("+00:00", "Z"),
                 "targeting": (
-                    'browserSettings.update.channel == "nightly" '
-                    "&& version|versionCompare('94.!') >= 0 "
-                    "&& 'app.shield.optoutstudies.enabled'|preferenceValue"
+                    '(browserSettings.update.channel == "nightly") '
+                    "&& (version|versionCompare('94.!') >= 0) "
+                    "&& ('app.shield.optoutstudies.enabled'|preferenceValue)"
                 ),
                 "userFacingDescription": experiment.public_description,
                 "userFacingName": experiment.name,
@@ -141,9 +141,9 @@ class TestNimbusExperimentSerializer(TestCase):
                 # DRF manually replaces the isoformat suffix so we have to do the same
                 "startDate": experiment.start_date.isoformat().replace("+00:00", "Z"),
                 "targeting": (
-                    'browserSettings.update.channel == "nightly" '
-                    "&& version|versionCompare('95.!') >= 0 "
-                    "&& 'app.shield.optoutstudies.enabled'|preferenceValue"
+                    '(browserSettings.update.channel == "nightly") '
+                    "&& (version|versionCompare('95.!') >= 0) "
+                    "&& ('app.shield.optoutstudies.enabled'|preferenceValue)"
                 ),
                 "userFacingDescription": experiment.public_description,
                 "userFacingName": experiment.name,

--- a/app/experimenter/experiments/tests/test_models/test_models_nimbus.py
+++ b/app/experimenter/experiments/tests/test_models/test_models_nimbus.py
@@ -218,10 +218,10 @@ class TestNimbusExperiment(TestCase):
         self.assertEqual(
             experiment.targeting,
             (
-                "os.isMac "
-                "&& version|versionCompare('83.!') >= 0 "
-                "&& version|versionCompare('95.*') < 0 "
-                "&& 'app.shield.optoutstudies.enabled'|preferenceValue"
+                "(os.isMac) "
+                "&& (version|versionCompare('83.!') >= 0) "
+                "&& (version|versionCompare('95.*') < 0) "
+                "&& ('app.shield.optoutstudies.enabled'|preferenceValue)"
             ),
         )
 
@@ -256,10 +256,10 @@ class TestNimbusExperiment(TestCase):
         self.assertEqual(
             experiment.targeting,
             (
-                "os.isMac "
-                '&& browserSettings.update.channel == "nightly" '
-                "&& version|versionCompare('95.*') < 0 "
-                "&& 'app.shield.optoutstudies.enabled'|preferenceValue"
+                "(os.isMac) "
+                '&& (browserSettings.update.channel == "nightly") '
+                "&& (version|versionCompare('95.*') < 0) "
+                "&& ('app.shield.optoutstudies.enabled'|preferenceValue)"
             ),
         )
 
@@ -280,10 +280,10 @@ class TestNimbusExperiment(TestCase):
         self.assertEqual(
             experiment.targeting,
             (
-                "os.isMac "
-                '&& browserSettings.update.channel == "nightly" '
-                "&& version|versionCompare('83.!') >= 0 "
-                "&& 'app.shield.optoutstudies.enabled'|preferenceValue"
+                "(os.isMac) "
+                '&& (browserSettings.update.channel == "nightly") '
+                "&& (version|versionCompare('83.!') >= 0) "
+                "&& ('app.shield.optoutstudies.enabled'|preferenceValue)"
             ),
         )
 
@@ -300,7 +300,7 @@ class TestNimbusExperiment(TestCase):
         )
         self.assertEqual(
             experiment.targeting,
-            "os.isMac && 'app.shield.optoutstudies.enabled'|preferenceValue",
+            "(os.isMac) && ('app.shield.optoutstudies.enabled'|preferenceValue)",
         )
 
     def test_targeting_with_locales(self):
@@ -319,9 +319,9 @@ class TestNimbusExperiment(TestCase):
         self.assertEqual(
             experiment.targeting,
             (
-                "os.isMac "
-                "&& 'app.shield.optoutstudies.enabled'|preferenceValue "
-                "&& locale in ['en-CA', 'en-US']"
+                "(os.isMac) "
+                "&& ('app.shield.optoutstudies.enabled'|preferenceValue) "
+                "&& (locale in ['en-CA', 'en-US'])"
             ),
         )
 
@@ -341,9 +341,9 @@ class TestNimbusExperiment(TestCase):
         self.assertEqual(
             experiment.targeting,
             (
-                "os.isMac "
-                "&& 'app.shield.optoutstudies.enabled'|preferenceValue "
-                "&& region in ['CA', 'US']"
+                "(os.isMac) "
+                "&& ('app.shield.optoutstudies.enabled'|preferenceValue) "
+                "&& (region in ['CA', 'US'])"
             ),
         )
 
@@ -365,10 +365,10 @@ class TestNimbusExperiment(TestCase):
         self.assertEqual(
             experiment.targeting,
             (
-                "os.isMac "
-                "&& 'app.shield.optoutstudies.enabled'|preferenceValue "
-                "&& locale in ['en-CA', 'en-US'] "
-                "&& region in ['CA', 'US']"
+                "(os.isMac) "
+                "&& ('app.shield.optoutstudies.enabled'|preferenceValue) "
+                "&& (locale in ['en-CA', 'en-US']) "
+                "&& (region in ['CA', 'US'])"
             ),
         )
 
@@ -391,7 +391,7 @@ class TestNimbusExperiment(TestCase):
         self.assertEqual(
             experiment.targeting,
             (
-                "is_already_enrolled || days_since_install < 7 "
+                "(is_already_enrolled || days_since_install < 7) "
                 "&& ('de' in locale || 'en' in locale || 'es' in locale "
                 "|| 'ro' in locale)"
             ),


### PR DESCRIPTION
Because

* Arbitrary JEXL expressions can contain arbitrary subclauses
* To ensure the JEXL evaluator groups them the way is intended by the subclause authors

This commit

* Wraps all JEXL subclauses in outer parens