### PR TITLE
fix #7124 chore(nimbus): validate all jexl expressions using parser

### DIFF
--- a/app/experimenter/experiments/tests/__init__.py
+++ b/app/experimenter/experiments/tests/__init__.py
@@ -1,0 +1,12 @@
+from pyjexl.jexl import JEXLConfig
+from pyjexl.operators import default_binary_operators, default_unary_operators
+from pyjexl.parser import Parser, jexl_grammar
+
+jexl_config = JEXLConfig({}, default_unary_operators, default_binary_operators)
+
+
+class JEXLParser(Parser):
+    grammar = jexl_grammar(jexl_config)
+
+    def __init__(self):
+        super().__init__(jexl_config)

--- a/app/experimenter/experiments/tests/test_models/test_models_nimbus.py
+++ b/app/experimenter/experiments/tests/test_models/test_models_nimbus.py
@@ -22,6 +22,7 @@ from experimenter.experiments.models import (
     NimbusIsolationGroup,
 )
 from experimenter.experiments.models.nimbus import NimbusBucketRange
+from experimenter.experiments.tests import JEXLParser
 from experimenter.experiments.tests.factories import (
     NimbusBranchFactory,
     NimbusBucketRangeFactory,
@@ -224,6 +225,7 @@ class TestNimbusExperiment(TestCase):
                 "&& 'app.shield.optoutstudies.enabled'|preferenceValue"
             ),
         )
+        JEXLParser().parse(experiment.targeting)
 
     def test_empty_targeting_for_mobile(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
@@ -238,6 +240,7 @@ class TestNimbusExperiment(TestCase):
         )
 
         self.assertEqual(experiment.targeting, "true")
+        JEXLParser().parse(experiment.targeting)
 
     def test_targeting_without_firefox_min_version(
         self,
@@ -262,6 +265,7 @@ class TestNimbusExperiment(TestCase):
                 "&& 'app.shield.optoutstudies.enabled'|preferenceValue"
             ),
         )
+        JEXLParser().parse(experiment.targeting)
 
     def test_targeting_without_firefox_max_version(
         self,
@@ -286,6 +290,7 @@ class TestNimbusExperiment(TestCase):
                 "&& 'app.shield.optoutstudies.enabled'|preferenceValue"
             ),
         )
+        JEXLParser().parse(experiment.targeting)
 
     def test_targeting_without_channel_version(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
@@ -302,6 +307,7 @@ class TestNimbusExperiment(TestCase):
             experiment.targeting,
             "os.isMac && 'app.shield.optoutstudies.enabled'|preferenceValue",
         )
+        JEXLParser().parse(experiment.targeting)
 
     def test_targeting_with_locales(self):
         locale_ca = LocaleFactory.create(code="en-CA")
@@ -324,6 +330,7 @@ class TestNimbusExperiment(TestCase):
                 "&& locale in ['en-CA', 'en-US']"
             ),
         )
+        JEXLParser().parse(experiment.targeting)
 
     def test_targeting_with_countries(self):
         country_ca = CountryFactory.create(code="CA")
@@ -346,6 +353,7 @@ class TestNimbusExperiment(TestCase):
                 "&& region in ['CA', 'US']"
             ),
         )
+        JEXLParser().parse(experiment.targeting)
 
     def test_targeting_with_locales_and_countries(self):
         locale_ca = LocaleFactory.create(code="en-CA")
@@ -371,6 +379,7 @@ class TestNimbusExperiment(TestCase):
                 "&& region in ['CA', 'US']"
             ),
         )
+        JEXLParser().parse(experiment.targeting)
 
     def test_targeting_with_locales_and_countries_mobile(self):
         locale_ca = LocaleFactory.create(code="en-CA")
@@ -396,6 +405,7 @@ class TestNimbusExperiment(TestCase):
                 "|| 'ro' in locale)"
             ),
         )
+        JEXLParser().parse(experiment.targeting)
 
     def test_targeting_uses_published_targeting_string(self):
         published_targeting = "published targeting jexl"

--- a/app/experimenter/experiments/tests/test_targeting_configs.py
+++ b/app/experimenter/experiments/tests/test_targeting_configs.py
@@ -1,20 +1,9 @@
 from django.test import TestCase
 from parameterized import parameterized
 from parsimonious.exceptions import ParseError
-from pyjexl.jexl import JEXLConfig
-from pyjexl.operators import default_binary_operators, default_unary_operators
-from pyjexl.parser import Parser, jexl_grammar
 
 from experimenter.experiments.constants import NimbusConstants
-
-default_config = JEXLConfig({}, default_unary_operators, default_binary_operators)
-
-
-class DefaultParser(Parser):
-    grammar = jexl_grammar(default_config)
-
-    def __init__(self):
-        super().__init__(default_config)
+from experimenter.experiments.tests import JEXLParser
 
 
 class TestTargetingConfigs(TestCase):
@@ -30,6 +19,6 @@ class TestTargetingConfigs(TestCase):
     def test_targeting_config_has_valid_jexl(self, targeting_config):
         if targeting_config.targeting:
             try:
-                DefaultParser().parse(targeting_config.targeting)
+                JEXLParser().parse(targeting_config.targeting)
             except ParseError as e:
                 raise Exception(f"JEXL Parse error in {targeting_config.name}: {e}")


### PR DESCRIPTION
Because

* We have a Python JEXL parser available in the tests
* We were only using it to validate the targeting config expressions
* We should use it to validate all auto generated JEXL

This commit

* Adds the JEXL Parser to every test that validates auto generated JEXL