### PR TITLE
Fix EXP-2239: super rough draft of reporting dashboard

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
   "python.linting.enabled": true,
-  "python.linting.flake8Enabled": true,
+  "python.linting.flake8Enabled": false,
   "python.linting.flake8Args": [
     "--config=app/.flake8"
   ],
@@ -9,5 +9,6 @@
     "--line-length",
     "90"
   ],
-  "jest.jestCommandLine": "yarn workspace @experimenter/nimbus-ui test:cov"
+  "jest.jestCommandLine": "yarn workspace @experimenter/nimbus-ui test:cov",
+  "python.linting.pylintEnabled": true
 }

--- a/app/experimenter/nimbus-ui/src/components/App/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/App/index.tsx
@@ -16,6 +16,7 @@ import PageHome from "../PageHome";
 import PageLoading from "../PageLoading";
 import PageNew from "../PageNew";
 import PageResults from "../PageResults";
+import PageReporting from "../PageReporting";
 import PageSummary from "../PageSummary";
 import PageSummaryDetail from "../PageSummaryDetails";
 import ExperimentRoot from "./ExperimentRoot";
@@ -43,6 +44,7 @@ const App = () => {
       <Router basepath={BASE_PATH}>
         <PageHome path="/" />
         <PageNew path="new" />
+        <PageReporting path="reporting" />
         <ExperimentRoot path=":slug">
           <PageSummary path="/" />
           <PageSummaryDetail path="details" />

--- a/app/experimenter/nimbus-ui/src/components/PageHome/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageHome/index.tsx
@@ -116,6 +116,16 @@ const PageHome: React.FunctionComponent<PageHomeProps> = () => {
         <h2 className="mb-0 mr-1">Nimbus Experiments </h2>
         <div>
           <Link
+            to="reporting"
+            data-sb-kind="pages/Reporting"
+            className="btn btn-primary btn-small ml-2"
+            id="reporting-button"
+          >
+            Reporting
+          </Link>
+        </div>
+        <div>
+          <Link
             to="new"
             data-sb-kind="pages/New"
             className="btn btn-primary btn-small ml-2"

--- a/app/experimenter/nimbus-ui/src/components/PageReporting/DirectoryTable/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageReporting/DirectoryTable/index.stories.tsx
@@ -1,0 +1,80 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { withLinks } from "@storybook/addon-links";
+import React from "react";
+import DirectoryTable, {
+  DirectoryCompleteTable,
+  DirectoryDraftsTable,
+  DirectoryLiveTable,
+} from ".";
+import { mockDirectoryExperiments } from "../../../lib/mocks";
+import { CurrentLocation, RouterSlugProvider } from "../../../lib/test-utils";
+import {
+  NimbusExperimentPublishStatusEnum,
+  NimbusExperimentStatusEnum,
+} from "../../../types/globalTypes";
+
+const withRouterAndCurrentUrl = (Story: React.FC) => (
+  <RouterSlugProvider mocks={[]}>
+    <div className="p-3">
+      <CurrentLocation />
+      <Story />
+    </div>
+  </RouterSlugProvider>
+);
+
+export default {
+  title: "pages/Home/DirectoryTable",
+  component: DirectoryTable,
+  decorators: [withRouterAndCurrentUrl, withLinks],
+};
+
+const experiments = mockDirectoryExperiments();
+const draftExperiments = experiments.filter(
+  ({ status, publishStatus }) =>
+    status === NimbusExperimentStatusEnum.DRAFT &&
+    publishStatus === NimbusExperimentPublishStatusEnum.IDLE,
+);
+const liveExperiments = experiments.filter(
+  ({ status, publishStatus }) =>
+    status === NimbusExperimentStatusEnum.LIVE &&
+    publishStatus === NimbusExperimentPublishStatusEnum.IDLE,
+);
+const completedExperiments = experiments.filter(
+  ({ status, publishStatus }) =>
+    status === NimbusExperimentStatusEnum.COMPLETE &&
+    publishStatus === NimbusExperimentPublishStatusEnum.IDLE,
+);
+
+export const Basic = () => <DirectoryTable experiments={experiments} />;
+
+export const Live = () => <DirectoryLiveTable experiments={liveExperiments} />;
+
+export const Completed = () => (
+  <DirectoryCompleteTable experiments={completedExperiments} />
+);
+
+export const Drafts = () => (
+  <DirectoryDraftsTable experiments={draftExperiments} />
+);
+
+export const CustomComponent = () => (
+  <DirectoryTable
+    experiments={mockDirectoryExperiments()}
+    columns={[
+      {
+        label: "Testing column",
+        sortBy: ({ status }) => `Hello ${status}`,
+        component: ({ status }) => <td>Hello {status}</td>,
+      },
+    ]}
+  />
+);
+
+export const NoFeature = () => (
+  <DirectoryTable
+    experiments={mockDirectoryExperiments([{ featureConfig: null }])}
+  />
+);

--- a/app/experimenter/nimbus-ui/src/components/PageReporting/DirectoryTable/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageReporting/DirectoryTable/index.test.tsx
@@ -1,0 +1,394 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import React from "react";
+import DirectoryTable, {
+  Column,
+  ColumnComponent,
+  ColumnSortOrder,
+  DirectoryColumnFeature,
+  DirectoryColumnOwner,
+  DirectoryColumnTitle,
+  DirectoryCompleteTable,
+  DirectoryDraftsTable,
+  DirectoryLiveTable,
+  SortableColumnTitle,
+} from ".";
+import { UpdateSearchParams } from "../../../hooks/useSearchParamsState";
+import { getProposedEnrollmentRange, humanDate } from "../../../lib/dateUtils";
+import {
+  mockDirectoryExperiments,
+  mockSingleDirectoryExperiment,
+} from "../../../lib/mocks";
+import { RouterSlugProvider } from "../../../lib/test-utils";
+import { getAllExperiments_experiments } from "../../../types/getAllExperiments";
+
+const experiment = mockSingleDirectoryExperiment();
+
+const TestTable = ({ children }: { children: React.ReactNode }) => {
+  return (
+    <RouterSlugProvider>
+      <table>
+        <tbody>
+          <tr>{children}</tr>
+        </tbody>
+      </table>
+    </RouterSlugProvider>
+  );
+};
+
+describe("DirectoryColumnTitle", () => {
+  it("renders the experiment name and slug", () => {
+    render(
+      <TestTable>
+        <DirectoryColumnTitle {...experiment} />
+      </TestTable>,
+    );
+    expect(screen.getByTestId("directory-title-name")).toHaveTextContent(
+      experiment.name,
+    );
+    expect(screen.getByTestId("directory-title-slug")).toHaveTextContent(
+      experiment.slug,
+    );
+  });
+});
+
+describe("DirectoryColumnOwner", () => {
+  it("renders the experiment owner if present", () => {
+    render(
+      <TestTable>
+        <DirectoryColumnOwner {...experiment} />
+      </TestTable>,
+    );
+    expect(screen.getByTestId("directory-table-cell")).toHaveTextContent(
+      experiment.owner!.username,
+    );
+  });
+
+  it("renders the NotSet label if owner is not present", () => {
+    render(
+      <TestTable>
+        {/**
+         * Intentionally disable ts check because we can still possibly
+         * have no owner on older experiments that didn't assign one
+         * @ts-ignore */}
+        <DirectoryColumnOwner {...experiment} owner={null} />
+      </TestTable>,
+    );
+    expect(screen.getByTestId("directory-table-cell")).toHaveTextContent(
+      "Not set",
+    );
+  });
+});
+
+describe("DirectoryColumnFeature", () => {
+  it("renders the feature config if present", () => {
+    render(
+      <TestTable>
+        <DirectoryColumnFeature {...experiment} />
+      </TestTable>,
+    );
+    expect(
+      screen.getByTestId("directory-feature-config-name"),
+    ).toHaveTextContent(experiment.featureConfig!.name);
+    expect(
+      screen.getByTestId("directory-feature-config-slug"),
+    ).toHaveTextContent(experiment.featureConfig!.slug);
+  });
+
+  it("renders the None label if feature config is not present", () => {
+    render(
+      <TestTable>
+        <DirectoryColumnFeature {...experiment} featureConfig={null} />
+      </TestTable>,
+    );
+    expect(
+      screen.getByTestId("directory-feature-config-none"),
+    ).toBeInTheDocument();
+  });
+});
+
+function expectTableCells(testId: string, cellTexts: string[]) {
+  const cells = screen.getAllByTestId(testId);
+  expect(cells).toHaveLength(cellTexts.length);
+  cellTexts.forEach((text, index) => {
+    expect(cells[index].textContent).toEqual(expect.stringContaining(text));
+  });
+}
+
+describe("DirectoryTable", () => {
+  it("renders as expected with default columns", () => {
+    const experiments = [experiment];
+    render(
+      <RouterSlugProvider>
+        <DirectoryTable {...{ experiments }} />
+      </RouterSlugProvider>,
+    );
+    expectTableCells("directory-table-header", ["Name", "Owner", "Feature"]);
+    expectTableCells("directory-table-cell", [
+      experiment.name,
+      experiment.owner!.username,
+      experiment.featureConfig!.name,
+    ]);
+    expect(screen.getAllByTestId("directory-table-row")).toHaveLength(
+      experiments.length,
+    );
+  });
+
+  it("renders as expected without experiments", () => {
+    render(
+      <RouterSlugProvider>
+        <DirectoryTable experiments={[]} />
+      </RouterSlugProvider>,
+    );
+    expect(screen.getByTestId("no-experiments")).toBeInTheDocument();
+  });
+
+  it("renders as expected with custom columns", () => {
+    render(
+      <RouterSlugProvider>
+        <DirectoryTable
+          experiments={[experiment]}
+          columns={[
+            {
+              label: "Cant think",
+              sortBy: "name",
+              component: DirectoryColumnTitle,
+            },
+            {
+              label: "Of a title",
+              sortBy: "status",
+              component: ({ status }) => (
+                <td data-testid="directory-table-cell">{status}</td>
+              ),
+            },
+          ]}
+        />
+      </RouterSlugProvider>,
+    );
+    expectTableCells("directory-table-header", ["Cant think", "Of a title"]);
+    expectTableCells("directory-table-cell", [
+      experiment.name,
+      experiment.status!,
+    ]);
+  });
+
+  // TODO: not exhaustively testing all sort orders here, might be worth adding more?
+  // Sorting is more fully covered in lib/experiment.test.ts
+  it("supports sorting by name", async () => {
+    const experiments = mockDirectoryExperiments();
+    const experimentNames = experiments.map((experiment) => experiment.name);
+    const getExperimentNamesFromTable = () =>
+      screen.getAllByTestId("directory-title-name").map((el) => el.textContent);
+
+    render(
+      <RouterSlugProvider>
+        <DirectoryTable {...{ experiments }} />
+      </RouterSlugProvider>,
+    );
+
+    expect(getExperimentNamesFromTable()).toEqual(experimentNames);
+
+    const nameSortButton = screen
+      .getAllByTestId("sort-select")
+      .find((el) => el.title === "Name")!;
+    expect(nameSortButton).toBeDefined();
+
+    fireEvent.click(nameSortButton);
+    await waitFor(() =>
+      expect(getExperimentNamesFromTable()).toEqual(
+        [...experimentNames].sort((a, b) => a.localeCompare(b)),
+      ),
+    );
+
+    fireEvent.click(nameSortButton);
+    await waitFor(() =>
+      expect(getExperimentNamesFromTable()).toEqual(
+        [...experimentNames].sort((a, b) => b.localeCompare(a)),
+      ),
+    );
+
+    fireEvent.click(nameSortButton);
+    await waitFor(() =>
+      expect(getExperimentNamesFromTable()).toEqual(experimentNames),
+    );
+  });
+});
+
+describe("DirectoryLiveTable", () => {
+  it.each([
+    ["looker link is present", experiment, "Looker"],
+    [
+      "results are ready",
+      { ...experiment, resultsReady: true, monitoringDashboardUrl: null },
+      "Results",
+    ],
+    [
+      "neither is present",
+      { ...experiment, monitoringDashboardUrl: null },
+      "N/A",
+    ],
+    [
+      "both are present",
+      { ...experiment, resultsReady: true },
+      "LookerOpens in new windowResults",
+    ],
+  ])(
+    "renders as expected with custom columns when %s",
+    (_, experiment: getAllExperiments_experiments, expectedResult: string) => {
+      render(
+        <RouterSlugProvider>
+          <DirectoryLiveTable experiments={[experiment]} />
+        </RouterSlugProvider>,
+      );
+      expectTableCells("directory-table-header", [
+        "Name",
+        "Owner",
+        "Feature",
+        "Started",
+        "Enrolling",
+        "Ending",
+        "Results",
+      ]);
+      expectTableCells("directory-table-cell", [
+        experiment.name,
+        experiment.owner!.username,
+        experiment.featureConfig!.name,
+        humanDate(experiment.startDate!),
+        getProposedEnrollmentRange(experiment) as string,
+        humanDate(experiment.computedEndDate!),
+        expectedResult,
+      ]);
+    },
+  );
+});
+
+describe("DirectoryCompleteTable", () => {
+  it("renders as expected with custom columns", () => {
+    render(
+      <RouterSlugProvider>
+        <DirectoryCompleteTable experiments={[experiment]} />
+      </RouterSlugProvider>,
+    );
+    expectTableCells("directory-table-header", [
+      "Name",
+      "Owner",
+      "Feature",
+      "Started",
+      "Ended",
+      "Results",
+    ]);
+    const header = screen
+      .getAllByTestId("directory-table-header")
+      .find((el) => el.textContent === "Results");
+    expect(header!.tagName).not.toEqual("BUTTON");
+    expectTableCells("directory-table-cell", [
+      experiment.name,
+      experiment.owner!.username,
+      experiment.featureConfig!.name,
+      humanDate(experiment.startDate!),
+      humanDate(experiment.computedEndDate!),
+      "Results",
+    ]);
+  });
+});
+
+describe("DirectoryDraftsTable", () => {
+  it("renders as expected with custom columns", () => {
+    render(
+      <RouterSlugProvider>
+        <DirectoryDraftsTable experiments={[experiment]} />
+      </RouterSlugProvider>,
+    );
+    expectTableCells("directory-table-header", ["Name", "Owner", "Feature"]);
+    expectTableCells("directory-table-cell", [
+      experiment.name,
+      experiment.owner!.username,
+      experiment.featureConfig!.name,
+    ]);
+  });
+});
+
+describe("SortableColumnTitle", () => {
+  const columnComponent: ColumnComponent = ({ name }) => (
+    <td data-testid="directory-table-cell">{name}</td>
+  );
+
+  const column: Column = {
+    label: "Name",
+    sortBy: "name",
+    component: columnComponent,
+  };
+
+  let nextParams: URLSearchParams, updateSearchParams: UpdateSearchParams;
+
+  beforeEach(() => {
+    nextParams = new URLSearchParams();
+    updateSearchParams = jest.fn((updaterFn) => updaterFn(nextParams));
+  });
+
+  const Subject = (props: { columnSortOrder: ColumnSortOrder }) => (
+    <TestTable>
+      <SortableColumnTitle {...{ ...props, column, updateSearchParams }} />
+    </TestTable>
+  );
+
+  const expectClass = (element: HTMLElement, cls: string, toHave = true) => {
+    const matcher = toHave ? expect(element) : expect(element).not;
+    matcher.toHaveClass(cls);
+  };
+
+  const commonTestCase =
+    (
+      initiallySelected = false,
+      initiallyDescending = false,
+      paramsWillHaveSelected = true,
+      paramsWillHaveDescending = false,
+    ) =>
+    () => {
+      render(
+        <Subject
+          columnSortOrder={{
+            column: initiallySelected ? column : undefined,
+            descending: initiallyDescending,
+          }}
+        />,
+      );
+
+      const header = screen.getByTestId("directory-table-header");
+      expectClass(header, "sort-selected", initiallySelected);
+      expectClass(header, "sort-descending", initiallyDescending);
+
+      const button = screen.getByTestId("sort-select");
+      expect(button).toHaveTextContent(column.label);
+
+      fireEvent.click(button);
+      expect(updateSearchParams).toHaveBeenCalled();
+
+      if (paramsWillHaveSelected) {
+        expect(nextParams.get("sortByLabel")).toEqual(column.label);
+      } else {
+        expect(nextParams.has("sortByLabel")).toBeFalsy();
+      }
+      expect(nextParams.has("descending"))[
+        paramsWillHaveDescending ? "toBeTruthy" : "toBeFalsy"
+      ]();
+    };
+
+  it(
+    "renders default as expected and supports ascending sort selection",
+    commonTestCase(false, false, true, false),
+  );
+
+  it(
+    "renders ascending sort as expected and support descending sort selection",
+    commonTestCase(true, false, true, true),
+  );
+
+  it(
+    "renders descending sort as expected and support sort reset",
+    commonTestCase(true, true, false, false),
+  );
+});

--- a/app/experimenter/nimbus-ui/src/components/PageReporting/DirectoryTable/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageReporting/DirectoryTable/index.tsx
@@ -1,0 +1,389 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { Link } from "@reach/router";
+import classNames from "classnames";
+import React, { useCallback, useMemo } from "react";
+import { Button } from "react-bootstrap";
+import { UpdateSearchParams, useSearchParamsState } from "../../../hooks";
+import { getProposedEnrollmentRange, humanDate } from "../../../lib/dateUtils";
+import {
+  enrollmentSortSelector,
+  experimentSortComparator,
+  ExperimentSortSelector,
+  featureConfigNameSortSelector,
+  ownerUsernameSortSelector,
+  resultsReadySortSelector,
+} from "../../../lib/experiment";
+import { getAllExperiments_experiments } from "../../../types/getAllExperiments";
+import LinkExternal from "../../LinkExternal";
+import NotSet from "../../NotSet";
+
+// These are all render functions for column types in the table.
+export type ColumnComponent = React.FC<getAllExperiments_experiments>;
+
+export const DirectoryColumnTitle: React.FC<getAllExperiments_experiments> = ({
+  slug,
+  name,
+}) => {
+  return (
+    <td className="w-33" data-testid="directory-table-cell">
+      <Link
+        to={slug}
+        data-sb-kind="pages/Summary"
+        data-testid="directory-title-name"
+      >
+        {name}
+      </Link>
+      <br />
+      <span
+        className="text-monospace text-secondary small"
+        data-testid="directory-title-slug"
+      >
+        {slug}
+      </span>
+    </td>
+  );
+};
+
+export const DirectoryColumnOwner: ColumnComponent = (experiment) => (
+  // #4380 made it so owner is never null, but we have experiments pre-this
+  // that may be absent an owner, so keep this fallback in place.
+  <td data-testid="directory-table-cell">
+    {experiment.owner?.username || <NotSet />}
+  </td>
+);
+
+export const DirectoryColumnFeature: ColumnComponent = ({ featureConfig }) => (
+  <td data-testid="directory-table-cell">
+    {featureConfig ? (
+      <>
+        <span data-testid="directory-feature-config-name">
+          {featureConfig.name}
+        </span>
+        <br />
+        <span
+          className="text-monospace text-secondary small"
+          data-testid="directory-feature-config-slug"
+        >
+          {featureConfig.slug}
+        </span>
+      </>
+    ) : (
+      <span data-testid="directory-feature-config-none">(None)</span>
+    )}
+  </td>
+);
+
+export const DirectoryColumnApplication: ColumnComponent = ({ featureConfig }) => (
+  <td data-testid="directory-table-cell">
+    {featureConfig ? (
+      <>
+        <span data-testid="directory-application-config-name">
+          {featureConfig.name}
+        </span>
+      </>
+    ) : (
+      <span data-testid="directory-feature-config-none">(None)</span>
+    )}
+  </td>
+);
+
+export const DirectoryColumnChannel: ColumnComponent = ({ featureConfig }) => (
+  <td data-testid="directory-table-cell">
+    {featureConfig ? (
+      <>
+        <span data-testid="directory-channel-config-name">
+          {featureConfig.name}
+        </span>
+      </>
+    ) : (
+      <span data-testid="directory-feature-config-none">(None)</span>
+    )}
+  </td>
+);
+
+export interface Column {
+  /** The label of the column, which shows up in <th/> */
+  label: string;
+  /** Experiment property selector used for sorting the column */
+  sortBy?: ExperimentSortSelector;
+  /** A component that renders a <td/> given the experiment data */
+  component: ColumnComponent;
+}
+
+export interface ColumnSortOrder {
+  column: Column | undefined;
+  descending: boolean;
+}
+
+interface ColumnTitleProps {
+  column: Column;
+}
+
+export const ColumnTitle: React.FunctionComponent<ColumnTitleProps> = ({
+  column: { label },
+}) => (
+  <th
+    className="border-top-0 font-weight-normal"
+    key={label}
+    data-testid="directory-table-header"
+  >
+    {label}
+  </th>
+);
+
+interface SortableColumnTitleProps {
+  column: Column;
+  columnSortOrder: ColumnSortOrder;
+  updateSearchParams: UpdateSearchParams;
+}
+
+export const SortableColumnTitle: React.FunctionComponent<
+  SortableColumnTitleProps
+> = ({ column, columnSortOrder, updateSearchParams }) => {
+  const { label } = column;
+  const { descending } = columnSortOrder;
+  const selected = columnSortOrder.column === column;
+
+  const onClick = useCallback(() => {
+    updateSearchParams((params) => {
+      // tri-state sort: ascending -> descending -> reset
+      if (!selected) {
+        // 1) ascending
+        params.set("sortByLabel", label);
+        params.delete("descending");
+      } else {
+        if (!descending) {
+          // 2) descending
+          params.set("sortByLabel", label);
+          params.set("descending", "1");
+        } else {
+          // 3) reset
+          params.delete("sortByLabel");
+          params.delete("descending");
+        }
+      }
+    });
+  }, [label, descending, selected, updateSearchParams]);
+
+  return (
+    <th
+      className={classNames("border-top-0", {
+        "sort-selected": selected,
+        "sort-descending": selected && descending,
+      })}
+      key={label}
+      data-testid="directory-table-header"
+    >
+      <Button
+        variant="link"
+        className="p-0 border-0"
+        style={{ whiteSpace: "nowrap" }}
+        onClick={onClick}
+        title={label}
+        data-testid="sort-select"
+      >
+        {label}
+        <span style={{ display: "inline-block", width: "2em" }}>
+          {selected ? (descending ? "▼" : "▲") : " "}
+        </span>
+      </Button>
+    </th>
+  );
+};
+
+interface DirectoryTableProps {
+  experiments: getAllExperiments_experiments[];
+  columns?: Column[];
+}
+// const { application, num_in_release, num_with_kpi_impact, cdou, other_business_goals } = sortByStatus(
+
+const commonColumns: Column[] = [
+  { 
+    label: "Application", 
+    component: DirectoryColumnApplication 
+  },
+  {
+    label: "# in Release",
+    component: DirectoryColumnOwner,
+  },
+  {
+    label: "# with KPI impact",
+    component: DirectoryColumnFeature,
+  },
+  {
+    label: "CDoU",
+    component: DirectoryColumnFeature,
+  },
+  {
+    label: "Other business goals",
+    component: DirectoryColumnFeature,
+  },
+];
+
+const DirectoryTable: React.FunctionComponent<DirectoryTableProps> = ({
+  experiments,
+  columns = commonColumns,
+}) => {
+  const [searchParams, updateSearchParams] = useSearchParamsState();
+  const columnSortOrder = useMemo(
+    () => ({
+      column: columns.find(
+        (column) => column.label === searchParams.get("sortByLabel"),
+      ),
+      descending: searchParams.get("descending") === "1",
+    }),
+    [searchParams, columns],
+  );
+
+  const sortedExperiments = [...experiments];
+  if (columnSortOrder.column && columnSortOrder.column.sortBy) {
+    sortedExperiments.sort(
+      experimentSortComparator(
+        columnSortOrder.column.sortBy,
+        columnSortOrder.descending,
+      ),
+    );
+  }
+
+  return (
+    <div className="directory-table pb-2 mt-4">
+      {experiments.length ? (
+        <table className="table" data-testid="DirectoryTable">
+          <thead>
+            <tr>
+              {columns.map((column, i) =>
+                column.sortBy ? (
+                  <SortableColumnTitle
+                    key={column.label + i}
+                    {...{ column, columnSortOrder, updateSearchParams }}
+                  />
+                ) : (
+                  <ColumnTitle key={column.label + i} {...{ column }} />
+                ),
+              )}
+            </tr>
+          </thead>
+          <tbody>
+            {sortedExperiments.map((experiment) => (
+              <tr key={experiment.slug} data-testid="directory-table-row">
+                {columns.map(({ label, component: ColumnComponent }, i) => {
+                  return <ColumnComponent key={label + i} {...experiment} />;
+                })}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      ) : (
+        <p data-testid="no-experiments">No experiments found.</p>
+      )}
+    </div>
+  );
+};
+
+export const DirectoryLiveTable: React.FC<DirectoryTableProps> = (props) => (
+  <DirectoryTable
+    {...props}
+    columns={[
+      ...commonColumns,
+      {
+        label: "Started",
+        sortBy: "startDate",
+        component: ({ startDate: d }) => (
+          <td data-testid="directory-table-cell">{d && humanDate(d)}</td>
+        ),
+      },
+      {
+        label: "Enrolling",
+        sortBy: enrollmentSortSelector,
+        component: (experiment) => (
+          <td data-testid="directory-table-cell">
+            {getProposedEnrollmentRange(experiment)}
+          </td>
+        ),
+      },
+      {
+        label: "Ending",
+        sortBy: "computedEndDate",
+        component: (experiment) => (
+          <td data-testid="directory-table-cell">
+            {humanDate(experiment.computedEndDate!)}
+          </td>
+        ),
+      },
+      {
+        label: "Results",
+        sortBy: resultsReadySortSelector,
+        component: (experiment) => (
+          <td data-testid="directory-table-cell">
+            {experiment.monitoringDashboardUrl && (
+              <LinkExternal
+                href={experiment.monitoringDashboardUrl!}
+                data-testid="link-monitoring-dashboard"
+              >
+                Looker
+              </LinkExternal>
+            )}
+            {experiment.monitoringDashboardUrl && experiment.resultsReady && (
+              <br />
+            )}
+            {experiment.resultsReady && (
+              <Link
+                to={`${experiment.slug}/results`}
+                data-sb-kind="pages/Results"
+              >
+                Results
+              </Link>
+            )}
+            {!experiment.monitoringDashboardUrl &&
+              !experiment.resultsReady &&
+              "N/A"}
+          </td>
+        ),
+      },
+    ]}
+  />
+);
+
+export const DirectoryCompleteTable: React.FC<DirectoryTableProps> = (
+  props,
+) => (
+  <DirectoryTable
+    {...props}
+    columns={[
+      ...commonColumns,
+      {
+        label: "Started",
+        sortBy: "startDate",
+        component: ({ startDate: d }) => (
+          <td data-testid="directory-table-cell">{d && humanDate(d)}</td>
+        ),
+      },
+      {
+        label: "Ended",
+        sortBy: "computedEndDate",
+        component: ({ computedEndDate: d }) => (
+          <td data-testid="directory-table-cell">{d && humanDate(d)}</td>
+        ),
+      },
+      {
+        label: "Results",
+        component: ({ slug }) => (
+          <td data-testid="directory-table-cell">
+            <Link to={`${slug}/results`} data-sb-kind="pages/Results">
+              Results
+            </Link>
+          </td>
+        ),
+      },
+    ]}
+  />
+);
+
+export const DirectoryDraftsTable: React.FC<DirectoryTableProps> = (props) => (
+  <DirectoryTable {...props} />
+);
+
+export default DirectoryTable;

--- a/app/experimenter/nimbus-ui/src/components/PageReporting/DirectoryTable/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageReporting/DirectoryTable/index.tsx
@@ -17,6 +17,7 @@ import {
   resultsReadySortSelector,
 } from "../../../lib/experiment";
 import { getAllExperiments_experiments } from "../../../types/getAllExperiments";
+import { getReporting_totals } from "../../../types/getReporting";
 import LinkExternal from "../../LinkExternal";
 import NotSet from "../../NotSet";
 
@@ -87,6 +88,66 @@ export const DirectoryColumnApplication: ColumnComponent = ({ featureConfig }) =
     ) : (
       <span data-testid="directory-feature-config-none">(None)</span>
     )}
+  </td>
+);
+
+export const DirectoryColumnStartDate: ColumnComponent = (experiment) => (
+  <td data-testid="directory-table-cell">
+    {experiment.startDate || <NotSet />}
+  </td>
+);
+
+export const DirectoryColumnEndDate: ColumnComponent = (experiment) => (
+  <td data-testid="directory-table-cell">
+    {experiment.computedEndDate || <NotSet />}
+  </td>
+);
+
+export const DirectoryColumnDuration: ColumnComponent = (experiment) => (
+  <td data-testid="directory-table-cell">
+    {experiment.proposedDuration || <NotSet />}
+  </td>
+);
+
+export const DirectoryColumnName: ColumnComponent = (experiment) => (
+  <td data-testid="directory-table-cell">{experiment.name || <NotSet />}</td>
+);
+
+export const DirectoryColumnFeatureName: ColumnComponent = ({ featureConfig }) => (
+  <td data-testid="directory-table-cell">
+    {featureConfig ? (
+      <>
+        <span data-testid="directory-application-config-name">
+          {featureConfig.name}
+        </span>
+      </>
+    ) : (
+      <span data-testid="directory-feature-config-none">(None)</span>
+    )}
+  </td>
+);
+
+export const DirectoryColumnProductArea: ColumnComponent = (experiment) => (
+  <td data-testid="directory-table-cell">
+    {experiment.application || <NotSet />}
+  </td>
+);
+
+export const DirectoryColumnResults: ColumnComponent = (experiment) => (
+  <td data-testid="directory-table-cell">
+    {experiment.monitoringDashboardUrl || <NotSet />}
+  </td>
+);
+
+export const DirectoryColumnTakeaways: ColumnComponent = (experiment) => (
+  <td data-testid="directory-table-cell">
+    {experiment.conclusionRecommendation || <NotSet />}
+  </td>
+);
+
+export const DirectoryColumnRollout: ColumnComponent = (experiment) => (
+  <td data-testid="directory-table-cell">
+    {experiment.conclusionRecommendation || <NotSet />}
   </td>
 );
 
@@ -198,28 +259,71 @@ interface DirectoryTableProps {
   experiments: getAllExperiments_experiments[];
   columns?: Column[];
 }
-// const { application, num_in_release, num_with_kpi_impact, cdou, other_business_goals } = sortByStatus(
 
 const commonColumns: Column[] = [
-  { 
-    label: "Application", 
-    component: DirectoryColumnApplication 
+  {
+    label: "Start Date",
+    component: DirectoryColumnStartDate,
   },
   {
-    label: "# in Release",
+    label: "CDoU improve goals",
+    component: DirectoryColumnStartDate,
+  },
+  {
+    label: "CDoU stat sig",
+    component: DirectoryColumnStartDate,
+  },
+  {
+    label: "Leading indicator stat sig",
+    component: DirectoryColumnStartDate,
+  },
+  {
+    label: "A/A test",
+    component: DirectoryColumnStartDate,
+  },
+  {
+    label: "Op Mon/Do no harm",
+    component: DirectoryColumnStartDate,
+  },
+  {
+    label: "Product area",
+    component: DirectoryColumnProductArea,
+  },
+  {
+    label: "Experiment name",
+    component: DirectoryColumnName,
+  },
+  {
+    label: "Owner",
     component: DirectoryColumnOwner,
   },
   {
-    label: "# with KPI impact",
-    component: DirectoryColumnFeature,
+    label: "Feature",
+    component: DirectoryColumnFeatureName,
   },
   {
-    label: "CDoU",
-    component: DirectoryColumnFeature,
+    label: "Started",
+    component: DirectoryColumnStartDate,
   },
   {
-    label: "Other business goals",
-    component: DirectoryColumnFeature,
+    label: "Duration",
+    component: DirectoryColumnDuration,
+  },
+  {
+    label: "Ended",
+    component: DirectoryColumnEndDate,
+  },
+  {
+    label: "Results",
+    component: DirectoryColumnResults,
+  },
+  {
+    label: "Takeaway recommendation",
+    component: DirectoryColumnTakeaways,
+  },
+  {
+    label: "Rollout/Promotion",
+    component: DirectoryColumnRollout,
   },
 ];
 

--- a/app/experimenter/nimbus-ui/src/components/PageReporting/filterExperiments.ts
+++ b/app/experimenter/nimbus-ui/src/components/PageReporting/filterExperiments.ts
@@ -1,0 +1,144 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { UpdateSearchParams } from "../../hooks";
+import { getAllExperiments_experiments } from "../../types/getAllExperiments";
+import {
+  FilterOptions,
+  FilterValue,
+  FilterValueKeys,
+  filterValueKeys,
+  NonNullFilterOption,
+  NonNullFilterOptions,
+  OptionalString,
+} from "./types";
+
+type OptionIndexKey<K extends FilterValueKeys> = (
+  option: NonNullFilterOption<K>,
+) => OptionalString;
+
+type ExperimentFilter<K extends FilterValueKeys> = (
+  option: NonNullFilterOption<K>,
+  experiment: getAllExperiments_experiments,
+) => boolean;
+
+export function getFilterValueFromParams(
+  options: FilterOptions
+ ): FilterValue {
+  const filterValue: FilterValue = {};
+  for (const key of filterValueKeys) {
+    // Verbose switch that seems to make types happier
+    switch (key) {
+      case "channels":
+        break;
+      // case "applications":
+        // filterValue[key] = selectFilterOptions<"channels">(
+        //   options[key],
+        //   optionIndexKeys[key],
+        //   values,
+        // );
+        // break;
+      // case "allFeatureConfigs":
+      //   filterValue[key] = selectFilterOptions<"allFeatureConfigs">(
+      //     options[key],
+      //     optionIndexKeys[key],
+      //     values,
+      //   );
+      //   break;
+      // case "firefoxVersions":
+      //   filterValue[key] = selectFilterOptions<"firefoxVersions">(
+      //     options[key],
+      //     optionIndexKeys[key],
+      //     values,
+      //   );
+      //   break;
+    }
+  }
+  return filterValue;
+}
+
+// function selectFilterOptions<K extends FilterValueKeys>(
+//   fieldOptions: FilterOptions[K],
+//   optionKey: OptionIndexKey<K>,
+//   values: string[],
+// ) {
+//   if (!fieldOptions) return [];
+//   return (fieldOptions as NonNullFilterOptions<K>).filter((option) => {
+//     if (option === null) return false;
+//     const key = optionKey(option as NonNullable<typeof option>);
+//     if (!key) return false;
+//     return values.includes(key);
+//   });
+// }
+
+export function updateParamsFromFilterValue(
+  updateSearchParams: UpdateSearchParams,
+  filterValue: FilterValue,
+) {}
+
+function indexFilterOptions<K extends FilterValueKeys>(
+  selectedOptions: FilterOptions[K] | undefined,
+  optionKey: OptionIndexKey<K>,
+) {
+  if (!selectedOptions) return;
+  return (selectedOptions as NonNullFilterOptions<K>)
+    .filter((option): option is NonNullable<typeof option> => !!option)
+    .map(optionKey);
+}
+
+export function filterExperiments(
+  experiments: getAllExperiments_experiments[],
+  filterState: FilterValue,
+) {
+  let filteredExperiments = [...experiments];
+  for (const key of filterValueKeys) {
+    // Verbose switch that seems to make types happier
+    switch (key) {
+      // case "channels":
+      //   filteredExperiments = filterExperimentsByOptions<"channels">(
+      //     filterState[key],
+      //     experimentFilters[key],
+      //     filteredExperiments,
+      //   );
+      //   break;
+      // case "applications":
+      //   filteredExperiments = filterExperimentsByOptions<"applications">(
+      //     filterState[key],
+      //     experimentFilters[key],
+      //     filteredExperiments,
+      //   );
+      //   break;
+      // case "allFeatureConfigs":
+      //   filteredExperiments = filterExperimentsByOptions<"allFeatureConfigs">(
+      //     filterState[key],
+      //     experimentFilters[key],
+      //     filteredExperiments,
+      //   );
+      //   break;
+      // case "firefoxVersions":
+      //   filteredExperiments = filterExperimentsByOptions<"firefoxVersions">(
+      //     filterState[key],
+      //     experimentFilters[key],
+      //     filteredExperiments,
+      //   );
+      //   break;
+    }
+  }
+  return filteredExperiments;
+}
+
+function filterExperimentsByOptions<K extends FilterValueKeys>(
+  selectedOptions: FilterOptions[K] | undefined,
+  experimentFilter: ExperimentFilter<K>,
+  experiments: getAllExperiments_experiments[],
+) {
+  return experiments.filter((experiment) => {
+    if (!selectedOptions) return true;
+    return (selectedOptions as NonNullFilterOptions<K>)
+      .filter((option): option is NonNullable<typeof option> => !!option)
+      .some((option) => experimentFilter(option, experiment));
+  });
+}
+
+export default filterExperiments;

--- a/app/experimenter/nimbus-ui/src/components/PageReporting/index.stories.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageReporting/index.stories.tsx
@@ -1,0 +1,54 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { Operation } from "@apollo/client";
+import { action } from "@storybook/addon-actions";
+import { withLinks } from "@storybook/addon-links";
+import { storiesOf } from "@storybook/react";
+import React from "react";
+import PageReporting from ".";
+import { CREATE_EXPERIMENT_MUTATION } from "../../gql/experiments";
+import { MockedCache, SimulatedMockLink } from "../../lib/mocks";
+
+storiesOf("pages/New", module)
+  .addDecorator(withLinks)
+  .add("basic", () => <Subject />);
+
+const actionCreateExperiment = action("createExperiment");
+
+const mkSimulatedQueries = ({
+  message = "success" as string | Record<string, any>,
+  status = 200,
+  nimbusExperiment = { slug: "foo-bar-baz" },
+} = {}) => [
+  {
+    request: {
+      query: CREATE_EXPERIMENT_MUTATION,
+    },
+    delay: 1000,
+    result: (operation: Operation) => {
+      const { name, application, hypothesis, changelogMessage } =
+        operation.variables.input;
+      actionCreateExperiment(name, application, hypothesis, changelogMessage);
+      return {
+        data: {
+          createExperiment: {
+            message,
+            status,
+            nimbusExperiment,
+          },
+        },
+      };
+    },
+  },
+];
+
+const Subject = ({ simulatedQueries = mkSimulatedQueries() }) => {
+  const mockLink = new SimulatedMockLink(simulatedQueries, false);
+  return (
+    <MockedCache link={mockLink}>
+      <PageReporting />
+    </MockedCache>
+  );
+};

--- a/app/experimenter/nimbus-ui/src/components/PageReporting/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageReporting/index.tsx
@@ -1,0 +1,85 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { navigate, RouteComponentProps } from "@reach/router";
+import React, { useCallback, useState } from "react";
+import AppLayout from "../AppLayout";
+import Head from "../Head";
+import { useQuery } from "@apollo/client";
+import { Alert, Tab, Tabs } from "react-bootstrap";
+import { GET_EXPERIMENTS_QUERY } from "../../gql/experiments";
+import {
+  useConfig,
+  useRefetchOnError,
+  useSearchParamsState,
+} from "../../hooks";
+import DirectoryTable, {
+  DirectoryCompleteTable,
+  DirectoryDraftsTable,
+  DirectoryLiveTable,
+} from "./DirectoryTable";
+import { getAllExperiments_experiments } from "../../types/getAllExperiments";
+import PageLoading from "../PageLoading";
+import {
+  filterExperiments,
+  getFilterValueFromParams,
+  updateParamsFromFilterValue,
+} from "./filterExperiments";
+import sortByStatus from "./sortByStatus";
+import { FilterOptions, FilterValue } from "./types";
+
+const PageReporting: React.FunctionComponent<RouteComponentProps> = () => {
+  return (
+    <AppLayout testid="PageReporting">
+      <Head title="Reporting!" />
+
+      <div className="d-flex justify-content-between">
+        <h1 className="h2">Reporting!</h1>
+
+      </div>
+
+      <Body />
+
+    </AppLayout>
+  );
+};
+
+// const { application, num_in_release, num_with_kpi_impact, cdou, other_business_goals } = sortByStatus(
+  // filterExperiments(data.experiments, filterValue),
+// );
+
+
+
+export const Body = () => {
+  const { data, loading, error, refetch } = useQuery<{
+    experiments: getAllExperiments_experiments[];
+  }>(GET_EXPERIMENTS_QUERY, { fetchPolicy: "network-only" });
+
+  // const filterValue = getFilterValueFromParams(config, searchParams);
+  // const onFilterChange = (newFilterValue: FilterValue) =>
+  //   updateParamsFromFilterValue(updateSearchParams, newFilterValue);
+
+  if (!data) {
+    return <div>No experiments found.</div>;
+  }
+  const { complete } = sortByStatus(
+    data.experiments
+  );
+  // const filterOptions: FilterOptions = {
+  //   channels: config!.channels!
+  // };
+  // const filterValue = getFilterValueFromParams(config);
+
+  return (
+    <>
+      <Tabs >
+        <Tab eventKey="drafts" title={`Application`}>
+          <DirectoryTable experiments={complete} />
+        </Tab>
+      </Tabs>
+    </>
+  );
+};
+
+export default PageReporting;

--- a/app/experimenter/nimbus-ui/src/components/PageReporting/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageReporting/index.tsx
@@ -28,6 +28,7 @@ import {
 } from "./filterExperiments";
 import sortByStatus from "./sortByStatus";
 import { FilterOptions, FilterValue } from "./types";
+import { Link } from "@reach/router";
 
 const PageReporting: React.FunctionComponent<RouteComponentProps> = () => {
   return (
@@ -36,11 +37,18 @@ const PageReporting: React.FunctionComponent<RouteComponentProps> = () => {
 
       <div className="d-flex justify-content-between">
         <h1 className="h2">Reporting!</h1>
-
+        <div>
+          <Link
+            to="new"
+            data-sb-kind="pages/New"
+            className="btn btn-primary btn-small ml-2"
+            id="create-new-button"
+          >
+            Download CSV
+          </Link>
+        </div>
       </div>
-
       <Body />
-
     </AppLayout>
   );
 };
@@ -48,8 +56,6 @@ const PageReporting: React.FunctionComponent<RouteComponentProps> = () => {
 // const { application, num_in_release, num_with_kpi_impact, cdou, other_business_goals } = sortByStatus(
   // filterExperiments(data.experiments, filterValue),
 // );
-
-
 
 export const Body = () => {
   const { data, loading, error, refetch } = useQuery<{
@@ -63,9 +69,7 @@ export const Body = () => {
   if (!data) {
     return <div>No experiments found.</div>;
   }
-  const { complete } = sortByStatus(
-    data.experiments
-  );
+  const { complete } = sortByStatus(data.experiments);
   // const filterOptions: FilterOptions = {
   //   channels: config!.channels!
   // };

--- a/app/experimenter/nimbus-ui/src/components/PageReporting/reporting.py
+++ b/app/experimenter/nimbus-ui/src/components/PageReporting/reporting.py
@@ -1,0 +1,117 @@
+import csv
+
+from django.contrib import admin
+from django.db.models import Q
+from django.http import HttpResponse
+from rangefilter.filters import DateTimeRangeFilter
+
+from experimenter.reporting.models import ReportLog
+
+
+def download_csv(modeladmin, request, queryset):
+    response = HttpResponse(content_type="text/csv")
+    response["Content-Disposition"] = "attachment; filename=reportlog.csv"
+    writer = csv.writer(response)
+    writer.writerow(
+        [
+            "Launch month",
+            "CDoU Improve Goals",
+            "CDoU Stat Sig",
+            "Leading Indicator Stat Sig",
+            "A/A Test",
+            "Op Mon/Do No Harm",
+            "Product Area",
+            "Experiment Name",
+            "Owner",
+            "Feature",
+            "Started",
+            "Duration",
+            "Ended",
+            "Results",
+            "Takeaway Recommendation",
+            "Rollout/Promotion"
+        ]
+    )
+
+    for e in queryset:
+        projects = list(e.projects.values_list("name", flat=True).order_by("name"))
+        writer.writerow(
+            [
+                e.startDate,
+                e.startDate,
+                e.startDate,
+                e.startDate,
+                e.startDate,
+                e.startDate,
+                e.application,
+                e.name,
+                e.owner.username,
+                e.featureConfigs.name,
+                e.startDate,
+                e.proposedDuration,
+                e.computedEndDate,
+                e.monitoringDashboardUrl,
+                e.takeawaySummary,
+                e.startDate
+            ]
+        )
+
+    return response
+
+
+class CPRReportListFilter(admin.SimpleListFilter):
+    title = "Normandy Launch Update Report Log Filter"
+    parameter_name = "Normandy Launch Update ReportLogs"
+
+    def lookups(self, request, model_admin):
+        return [("Normandy Launch Updates", "Normandy Launch Updates Only")]
+
+    def queryset(self, request, queryset):
+        if self.value() == "Normandy Launch Updates":
+            return queryset.filter(
+                Q(experiment_type__startswith="Normandy")
+                & Q(
+                    Q(
+                        experiment_old_status=ReportLog.ExperimentStatus.ACCEPTED,
+                        experiment_new_status=ReportLog.ExperimentStatus.ACCEPTED,
+                    )
+                    | Q(
+                        experiment_old_status=ReportLog.ExperimentStatus.ACCEPTED,
+                        experiment_new_status=ReportLog.ExperimentStatus.LIVE,
+                    )
+                    | Q(
+                        experiment_old_status=ReportLog.ExperimentStatus.LIVE,
+                        experiment_new_status=ReportLog.ExperimentStatus.LIVE,
+                    )
+                    | Q(
+                        experiment_old_status=ReportLog.ExperimentStatus.LIVE,
+                        experiment_new_status=ReportLog.ExperimentStatus.COMPLETE,
+                    )
+                )
+            )
+        return queryset
+
+
+class ReportLogAdmin(admin.ModelAdmin):
+    field_sets = (
+        "timestamp",
+        "experiment_slug",
+        "experiment_name",
+        "experiment_type",
+        "experiment_old_status",
+        "experiment_new_status",
+        "event",
+        "event_reason",
+        "comment",
+        "projects",
+    )
+    list_filter = (
+        ("timestamp", DateTimeRangeFilter),
+        "event_reason",
+        CPRReportListFilter,
+    )
+
+    actions = [download_csv]
+
+
+admin.site.register(ReportLog, ReportLogAdmin)

--- a/app/experimenter/nimbus-ui/src/components/PageReporting/sortByStatus.ts
+++ b/app/experimenter/nimbus-ui/src/components/PageReporting/sortByStatus.ts
@@ -1,0 +1,43 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { getStatus } from "../../lib/experiment";
+import { getAllExperiments_experiments } from "../../types/getAllExperiments";
+
+export type ExperimentCollector = Record<
+  "draft" | "preview" | "review" | "live" | "complete" | "archived",
+  getAllExperiments_experiments[]
+>;
+
+function sortByStatus(experiments: getAllExperiments_experiments[] = []) {
+  return experiments.reduce<ExperimentCollector>(
+    (collector, experiment) => {
+      const status = getStatus(experiment);
+      if (status.archived) {
+        collector.archived.push(experiment);
+      } else if (status.live) {
+        collector.live.push(experiment);
+      } else if (status.complete) {
+        collector.complete.push(experiment);
+      } else if (status.draft && !status.idle) {
+        collector.review.push(experiment);
+      } else if (status.preview) {
+        collector.preview.push(experiment);
+      } else {
+        collector.draft.push(experiment);
+      }
+      return collector;
+    },
+    {
+      draft: [],
+      preview: [],
+      review: [],
+      live: [],
+      complete: [],
+      archived: [],
+    },
+  );
+}
+
+export default sortByStatus;

--- a/app/experimenter/nimbus-ui/src/components/PageReporting/types.ts
+++ b/app/experimenter/nimbus-ui/src/components/PageReporting/types.ts
@@ -1,0 +1,27 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { getConfig_nimbusConfig } from "../../types/getConfig";
+
+export const filterValueKeys = [
+  "channels",
+] as const;
+
+export type FilterValueKeys = typeof filterValueKeys[number];
+
+export type FilterOptions = Pick<getConfig_nimbusConfig, FilterValueKeys>;
+
+export type FilterValue = Partial<FilterOptions>;
+
+export type OptionalString = string | null | undefined;
+
+// Very awkward type representing a property of FilterOptions that has been
+// verified as not null. Typescript does not infer this, for some reason.
+export type NonNullFilterOptions<K extends FilterValueKeys> = NonNullable<
+  FilterOptions[K]
+>[number][];
+
+export type NonNullFilterOption<K extends FilterValueKeys> = NonNullable<
+  NonNullFilterOptions<K>[number]
+>;

--- a/app/experimenter/nimbus-ui/src/gql/experiments.ts
+++ b/app/experimenter/nimbus-ui/src/gql/experiments.ts
@@ -219,6 +219,29 @@ export const GET_EXPERIMENTS_QUERY = gql`
   }
 `;
 
+export const GET_REPORTING_QUERY = gql`
+  query getAllExperiments {
+    experiments {
+      application
+      name
+      owner {
+        username
+      }
+      featureConfigs {
+        name
+        application
+        ownerEmail
+      }
+      startDate
+      proposedDuration
+      computedEndDate
+      monitoringDashboardUrl
+      resultsReady
+      takeawaysSummary
+    }
+  }
+`;
+
 export const CLONE_EXPERIMENT_MUTATION = gql`
   mutation cloneExperiment($input: ExperimentCloneInput!) {
     cloneExperiment(input: $input) {

--- a/app/experimenter/nimbus-ui/src/types/getReporting.ts
+++ b/app/experimenter/nimbus-ui/src/types/getReporting.ts
@@ -1,0 +1,60 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+import { NimbusExperimentApplicationEnum, NimbusExperimentFirefoxVersionEnum, NimbusExperimentStatusEnum, NimbusExperimentPublishStatusEnum } from "./globalTypes";
+
+// ====================================================
+// GraphQL query operation: getAllExperiments
+// ====================================================
+
+export interface getAllExperiments_experiments_owner {
+  username: string;
+}
+
+export interface getAllExperiments_experiments_featureConfigs {
+  id: number | null;
+  slug: string;
+  name: string;
+  description: string | null;
+  application: NimbusExperimentApplicationEnum | null;
+  ownerEmail: string | null;
+  schema: string | null;
+}
+
+export interface getAllExperiments_experiments_featureConfig {
+  slug: string;
+  name: string;
+}
+
+const { live, complete, preview, review, draft, archived } = sortByStatus(
+  filterExperiments(data.experiments, filterValue),
+);
+
+export interface getReporting_totals {
+  isArchived: boolean | null;
+  name: string;
+  owner: getAllExperiments_experiments_owner;
+  featureConfigs: (getAllExperiments_experiments_featureConfigs | null)[] | null;
+  slug: string;
+  application: NimbusExperimentApplicationEnum | null;
+  firefoxMinVersion: NimbusExperimentFirefoxVersionEnum | null;
+  firefoxMaxVersion: NimbusExperimentFirefoxVersionEnum | null;
+  startDate: DateTime | null;
+  isEnrollmentPausePending: boolean | null;
+  isEnrollmentPaused: boolean | null;
+  proposedDuration: number;
+  proposedEnrollment: number;
+  computedEndDate: DateTime | null;
+  status: NimbusExperimentStatusEnum | null;
+  statusNext: NimbusExperimentStatusEnum | null;
+  publishStatus: NimbusExperimentPublishStatusEnum | null;
+  monitoringDashboardUrl: string | null;
+  resultsReady: boolean | null;
+  featureConfig: getAllExperiments_experiments_featureConfig | null;
+}
+
+export interface getAllExperiments {
+  experiments: (getAllExperiments_experiments | null)[] | null;
+}


### PR DESCRIPTION
For [EXP-2239](https://mozilla-hub.atlassian.net/browse/EXP-2239)

**This does NOT need review right now**

Messing around with a lot of copy/paste here. I'll probably open a new PR once this is cleaned up, this is just helpful for me to see the full view of what I've done so far.

The intention of this is:
- Add a new button to Home for reporting
- New page where reporting data is visible (see jira ticket for more info)
- Button on this reporting page to export to CSV

https://user-images.githubusercontent.com/43795363/159380391-f2ade8e7-e7a8-4d78-82f1-89b4648bc888.mov


