### PR TITLE
fix #7140 chore(nimbus): add firefox 98.3.0

### DIFF
--- a/app/experimenter/experiments/constants/nimbus.py
+++ b/app/experimenter/experiments/constants/nimbus.py
@@ -664,6 +664,7 @@ class NimbusConstants(object):
         FIREFOX_9602 = "96.0.2"
         FIREFOX_97 = "97.!"
         FIREFOX_98 = "98.!"
+        FIREFOX_9830 = "98.3.0"
         FIREFOX_99 = "99.!"
         FIREFOX_100 = "100.!"
         FIREFOX_101 = "101.!"

--- a/app/experimenter/nimbus-ui/schema.graphql
+++ b/app/experimenter/nimbus-ui/schema.graphql
@@ -340,6 +340,7 @@ enum NimbusExperimentFirefoxVersionEnum {
   FIREFOX_9602
   FIREFOX_97
   FIREFOX_98
+  FIREFOX_9830
   FIREFOX_99
   FIREFOX_100
   FIREFOX_101

--- a/app/experimenter/nimbus-ui/src/types/globalTypes.ts
+++ b/app/experimenter/nimbus-ui/src/types/globalTypes.ts
@@ -173,6 +173,7 @@ export enum NimbusExperimentFirefoxVersionEnum {
   FIREFOX_9602 = "FIREFOX_9602",
   FIREFOX_97 = "FIREFOX_97",
   FIREFOX_98 = "FIREFOX_98",
+  FIREFOX_9830 = "FIREFOX_9830",
   FIREFOX_99 = "FIREFOX_99",
   NO_VERSION = "NO_VERSION",
 }


### PR DESCRIPTION
Because

* We need to target Firefox 98.3.0 for some experiments

This commit

* Adds firefox version 98.3.0