### PR TITLE
fix #7139 bug(nimbus): check min and max supported versions separately in targeting

### DIFF
--- a/app/experimenter/experiments/models/nimbus.py
+++ b/app/experimenter/experiments/models/nimbus.py
@@ -245,22 +245,24 @@ class NimbusExperiment(NimbusConstants, FilterMixin, models.Model):
         if self.application != self.Application.DESKTOP:
             version_key = "app_version"
 
-        version_supported = True
+        min_version_supported = True
+        max_version_supported = True
         if self.application in self.TARGETING_APPLICATION_SUPPORTED_VERSION:
             supported_version = self.TARGETING_APPLICATION_SUPPORTED_VERSION[
                 self.application
             ]
-            version_supported = self.firefox_min_version >= supported_version
+            min_version_supported = self.firefox_min_version >= supported_version
+            max_version_supported = self.firefox_max_version >= supported_version
 
-        if version_supported:
-            if self.firefox_min_version:
-                expressions.append(
-                    f"{version_key}|versionCompare('{self.firefox_min_version}') >= 0"
-                )
-            if self.firefox_max_version:
-                # HACK: tweak the min version to better match max version pattern
-                max_version = self.firefox_max_version.replace("!", "*")
-                expressions.append(f"{version_key}|versionCompare('{max_version}') < 0")
+        if min_version_supported and self.firefox_min_version:
+            expressions.append(
+                f"{version_key}|versionCompare('{self.firefox_min_version}') >= 0"
+            )
+
+        if max_version_supported and self.firefox_max_version:
+            # HACK: tweak the min version to better match max version pattern
+            max_version = self.firefox_max_version.replace("!", "*")
+            expressions.append(f"{version_key}|versionCompare('{max_version}') < 0")
 
         return expressions
 

--- a/app/experimenter/experiments/tests/api/v5/test_queries.py
+++ b/app/experimenter/experiments/tests/api/v5/test_queries.py
@@ -605,32 +605,6 @@ class TestNimbusExperimentBySlugQuery(GraphQLTestCase):
         experiment_data = content["data"]["experimentBySlug"]
         self.assertEqual(experiment_data["jexlTargetingExpression"], experiment.targeting)
 
-    def test_experiment_no_jexl_targeting_expression(self):
-        user_email = "user@example.com"
-        experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperimentFactory.Lifecycles.CREATED,
-            targeting_config_slug="",
-            application=NimbusExperiment.Application.FENIX,
-        )
-        response = self.query(
-            """
-            query experimentBySlug($slug: String!) {
-                experimentBySlug(slug: $slug) {
-                    jexlTargetingExpression
-                }
-            }
-            """,
-            variables={"slug": experiment.slug},
-            headers={settings.OPENIDC_EMAIL_HEADER: user_email},
-        )
-        self.assertEqual(response.status_code, 200, response.content)
-        content = json.loads(response.content)
-        experiment_data = content["data"]["experimentBySlug"]
-        self.assertEqual(
-            experiment_data["jexlTargetingExpression"],
-            "true",
-        )
-
     def test_experiment_computed_end_date_proposed(self):
         user_email = "user@example.com"
         experiment = NimbusExperimentFactory.create_with_lifecycle(

--- a/app/experimenter/experiments/tests/test_models/test_models_nimbus.py
+++ b/app/experimenter/experiments/tests/test_models/test_models_nimbus.py
@@ -278,7 +278,68 @@ class TestNimbusExperiment(TestCase):
             (NimbusExperiment.Application.FOCUS_IOS, NimbusExperiment.Version.FIREFOX_97),
         ]
     )
-    def test_targeting_includes_version_for_supported_clients(self, application, version):
+    def test_targeting_includes_min_version_for_supported_clients(
+        self, application, version
+    ):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE_APPROVE,
+            application=application,
+            firefox_min_version=version,
+            firefox_max_version=NimbusExperiment.Version.NO_VERSION,
+            targeting_config_slug=NimbusExperiment.TargetingConfig.NO_TARGETING,
+            channel=NimbusExperiment.Channel.NO_CHANNEL,
+            locales=[],
+            countries=[],
+        )
+
+        self.assertEqual(
+            experiment.targeting, f"(app_version|versionCompare('{version}') >= 0)"
+        )
+
+    @parameterized.expand(
+        [
+            (NimbusExperiment.Application.FENIX, NimbusExperiment.Version.FIREFOX_98),
+            (
+                NimbusExperiment.Application.FOCUS_ANDROID,
+                NimbusExperiment.Version.FIREFOX_98,
+            ),
+            (NimbusExperiment.Application.IOS, NimbusExperiment.Version.FIREFOX_97),
+            (NimbusExperiment.Application.FOCUS_IOS, NimbusExperiment.Version.FIREFOX_97),
+        ]
+    )
+    def test_targeting_includes_max_version_for_supported_clients(
+        self, application, version
+    ):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE_APPROVE,
+            application=application,
+            firefox_min_version=NimbusExperiment.Version.NO_VERSION,
+            firefox_max_version=version,
+            targeting_config_slug=NimbusExperiment.TargetingConfig.NO_TARGETING,
+            channel=NimbusExperiment.Channel.NO_CHANNEL,
+            locales=[],
+            countries=[],
+        )
+
+        self.assertEqual(
+            experiment.targeting,
+            f"(app_version|versionCompare('{version.replace('!', '*')}') < 0)",
+        )
+
+    @parameterized.expand(
+        [
+            (NimbusExperiment.Application.FENIX, NimbusExperiment.Version.FIREFOX_98),
+            (
+                NimbusExperiment.Application.FOCUS_ANDROID,
+                NimbusExperiment.Version.FIREFOX_98,
+            ),
+            (NimbusExperiment.Application.IOS, NimbusExperiment.Version.FIREFOX_97),
+            (NimbusExperiment.Application.FOCUS_IOS, NimbusExperiment.Version.FIREFOX_97),
+        ]
+    )
+    def test_targeting_includes_min_and_max_version_for_supported_clients(
+        self, application, version
+    ):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE_APPROVE,
             application=application,


### PR DESCRIPTION


Because

* We recently added checks to include version targeting for mobile based on which specific versions of each app supported version targeting
* We were only checking if the minimum version was supported to determine whether to include version targeting
* This prevented experiments that only target a max version from including version targeting if the max version is above the supported version

This commit

* Separately checks whether each of the min and max versions are supported and includes the relevant targeting string if they are