### PR TITLE
    fix #7142 bug(nimbus): use version comparators for supported version checks

### DIFF
--- a/app/experimenter/experiments/models/nimbus.py
+++ b/app/experimenter/experiments/models/nimbus.py
@@ -18,6 +18,7 @@ from django.db.models.constraints import UniqueConstraint
 from django.urls import reverse
 from django.utils import timezone
 from django.utils.text import slugify
+from packaging import version
 
 from experimenter.base import UploadsStorage
 from experimenter.base.models import Country, Locale
@@ -251,8 +252,12 @@ class NimbusExperiment(NimbusConstants, FilterMixin, models.Model):
             supported_version = self.TARGETING_APPLICATION_SUPPORTED_VERSION[
                 self.application
             ]
-            min_version_supported = self.firefox_min_version >= supported_version
-            max_version_supported = self.firefox_max_version >= supported_version
+            min_version_supported = version.parse(
+                self.firefox_min_version
+            ) >= version.parse(supported_version)
+            max_version_supported = version.parse(
+                self.firefox_max_version
+            ) >= version.parse(supported_version)
 
         if min_version_supported and self.firefox_min_version:
             expressions.append(

--- a/app/experimenter/experiments/tests/test_models/test_models_nimbus.py
+++ b/app/experimenter/experiments/tests/test_models/test_models_nimbus.py
@@ -296,6 +296,38 @@ class TestNimbusExperiment(TestCase):
             experiment.targeting, f"(app_version|versionCompare('{version}') >= 0)"
         )
 
+    def test_targeting_min_version_check_supports_semver_comparison(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE_APPROVE,
+            application=NimbusExperiment.Application.FENIX,
+            firefox_min_version=NimbusExperiment.Version.FIREFOX_100,
+            firefox_max_version=NimbusExperiment.Version.NO_VERSION,
+            targeting_config_slug=NimbusExperiment.TargetingConfig.NO_TARGETING,
+            channel=NimbusExperiment.Channel.NO_CHANNEL,
+            locales=[],
+            countries=[],
+        )
+
+        self.assertEqual(
+            experiment.targeting, "(app_version|versionCompare('100.!') >= 0)"
+        )
+
+    def test_targeting_max_version_check_supports_semver_comparison(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE_APPROVE,
+            application=NimbusExperiment.Application.FENIX,
+            firefox_min_version=NimbusExperiment.Version.NO_VERSION,
+            firefox_max_version=NimbusExperiment.Version.FIREFOX_100,
+            targeting_config_slug=NimbusExperiment.TargetingConfig.NO_TARGETING,
+            channel=NimbusExperiment.Channel.NO_CHANNEL,
+            locales=[],
+            countries=[],
+        )
+
+        self.assertEqual(
+            experiment.targeting, "(app_version|versionCompare('100.*') < 0)"
+        )
+
     @parameterized.expand(
         [
             (NimbusExperiment.Application.FENIX, NimbusExperiment.Version.FIREFOX_98),


### PR DESCRIPTION
Because
    
* We recently added checks for the minimum supported version for version targeting on mobile
* Any version comparison needs to use package.version to compare rather than string comparisons
    
This commit
    
* Uses package.version to compare minimum supported mobile targeting versions