### PR TITLE
fix #7146 bug(nimbus): max version should be less than or equal check

### DIFF
--- a/app/experimenter/experiments/models/nimbus.py
+++ b/app/experimenter/experiments/models/nimbus.py
@@ -267,7 +267,7 @@ class NimbusExperiment(NimbusConstants, FilterMixin, models.Model):
         if max_version_supported and self.firefox_max_version:
             # HACK: tweak the min version to better match max version pattern
             max_version = self.firefox_max_version.replace("!", "*")
-            expressions.append(f"{version_key}|versionCompare('{max_version}') < 0")
+            expressions.append(f"{version_key}|versionCompare('{max_version}') <= 0")
 
         return expressions
 

--- a/app/experimenter/experiments/tests/test_models/test_models_nimbus.py
+++ b/app/experimenter/experiments/tests/test_models/test_models_nimbus.py
@@ -222,7 +222,7 @@ class TestNimbusExperiment(TestCase):
                 "(os.isMac) "
                 "&& ('app.shield.optoutstudies.enabled'|preferenceValue) "
                 "&& (version|versionCompare('83.!') >= 0) "
-                "&& (version|versionCompare('95.*') < 0)"
+                "&& (version|versionCompare('95.*') <= 0)"
             ),
         )
         JEXLParser().parse(experiment.targeting)
@@ -325,7 +325,7 @@ class TestNimbusExperiment(TestCase):
         )
 
         self.assertEqual(
-            experiment.targeting, "(app_version|versionCompare('100.*') < 0)"
+            experiment.targeting, "(app_version|versionCompare('100.*') <= 0)"
         )
 
     @parameterized.expand(
@@ -355,7 +355,7 @@ class TestNimbusExperiment(TestCase):
 
         self.assertEqual(
             experiment.targeting,
-            f"(app_version|versionCompare('{version.replace('!', '*')}') < 0)",
+            f"(app_version|versionCompare('{version.replace('!', '*')}') <= 0)",
         )
 
     @parameterized.expand(
@@ -386,7 +386,7 @@ class TestNimbusExperiment(TestCase):
         self.assertEqual(
             experiment.targeting,
             f"(app_version|versionCompare('{version}') >= 0) "
-            f"&& (app_version|versionCompare('{version.replace('!', '*')}') < 0)",
+            f"&& (app_version|versionCompare('{version.replace('!', '*')}') <= 0)",
         )
 
     def test_targeting_without_firefox_min_version(
@@ -409,7 +409,7 @@ class TestNimbusExperiment(TestCase):
                 "(os.isMac) "
                 '&& (browserSettings.update.channel == "nightly") '
                 "&& ('app.shield.optoutstudies.enabled'|preferenceValue) "
-                "&& (version|versionCompare('95.*') < 0)"
+                "&& (version|versionCompare('95.*') <= 0)"
             ),
         )
         JEXLParser().parse(experiment.targeting)


### PR DESCRIPTION
Because

* We have a JEXL expression for checking against a max version of Firefox
* This check should be less than or equal so an experiment can be created that sets both min and max to the same version and targets only that version

This commit

* Changes the max version check to be less than or equal