### PR TITLE
fixes #7119 fix(Nimbus): Hide end experiment when experiment is not idle

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/Summary/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/index.test.tsx
@@ -89,6 +89,30 @@ describe("Summary", () => {
     await screen.findByTestId("pill-enrolling-complete");
   });
 
+  it("renders the end experiment button if the experiment is live and idle", async () => {
+    render(
+      <Subject
+        props={{
+          status: NimbusExperimentStatusEnum.LIVE,
+          publishStatus: NimbusExperimentPublishStatusEnum.IDLE,
+        }}
+      />,
+    );
+    await screen.findByText("End Experiment");
+  });
+
+  it("does not renders the end experiment button if the experiment is live and not idle", async () => {
+    render(
+      <Subject
+        props={{
+          status: NimbusExperimentStatusEnum.LIVE,
+          publishStatus: NimbusExperimentPublishStatusEnum.APPROVED,
+        }}
+      />,
+    );
+    expect(screen.queryByText("End Experiment")).not.toBeInTheDocument();
+  });
+
   describe("ending an experiment request", () => {
     const origWindowOpen = global.window.open;
     let mockWindowOpen: any;

--- a/app/experimenter/nimbus-ui/src/components/Summary/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/index.tsx
@@ -36,7 +36,6 @@ const Summary = ({
   withFullDetails = true,
 }: SummaryProps) => {
   const status = getStatus(experiment);
-
   const {
     isLoading,
     submitError,
@@ -83,10 +82,9 @@ const Summary = ({
           />
         )}
 
-      {status.live && !status.review && !status.endRequested && (
+      {status.live && !status.review && !status.endRequested && status.idle && (
         <EndExperiment {...{ isLoading, onSubmit: onConfirmEndClicked }} />
       )}
-
       {(status.live || status.preview) && (
         <PreviewURL {...experiment} status={status} />
       )}


### PR DESCRIPTION
Because

* end experiment button should not be available unless the experiment is idle

This commit

* adds a condition to only show the end experiment button when the experiment is idle