### PR TITLE
fix #7155 bug(nimbus): replace ! with 0 in version parsing

### DIFF
--- a/app/experimenter/experiments/api/v5/serializers.py
+++ b/app/experimenter/experiments/api/v5/serializers.py
@@ -4,7 +4,6 @@ from collections import defaultdict
 import jsonschema
 from django.db import transaction
 from django.utils.text import slugify
-from packaging import version
 from rest_framework import serializers
 
 from experimenter.base.models import Country, Locale, SiteFlag, SiteFlagNameChoices
@@ -1033,7 +1032,10 @@ class NimbusReviewSerializer(serializers.ModelSerializer):
         if (
             min_version != ""
             and max_version != ""
-            and version.parse(min_version) > version.parse(max_version)
+            and (
+                NimbusExperiment.Version.parse(min_version)
+                > NimbusExperiment.Version.parse(max_version)
+            )
         ):
             raise serializers.ValidationError(
                 {

--- a/app/experimenter/experiments/api/v6/serializers.py
+++ b/app/experimenter/experiments/api/v6/serializers.py
@@ -1,7 +1,6 @@
 import json
 
 from django.conf import settings
-from packaging import version
 from rest_framework import serializers
 
 from experimenter.experiments.models import (
@@ -161,9 +160,11 @@ class NimbusExperimentSerializer(serializers.ModelSerializer):
         return obj.application_config.channel_app_id.get(obj.channel, "")
 
     def get_branches(self, obj):
-        if obj.application == NimbusExperiment.Application.DESKTOP and version.parse(
-            obj.firefox_min_version
-        ) >= version.parse(NimbusExperiment.Version.FIREFOX_95):
+        if (
+            obj.application == NimbusExperiment.Application.DESKTOP
+            and NimbusExperiment.Version.parse(obj.firefox_min_version)
+            >= NimbusExperiment.Version.parse(NimbusExperiment.Version.FIREFOX_95)
+        ):
             return NimbusBranchSerializerMultiFeatureDesktop(
                 obj.branches.all(), many=True
             ).data

--- a/app/experimenter/experiments/constants/nimbus.py
+++ b/app/experimenter/experiments/constants/nimbus.py
@@ -3,6 +3,7 @@ from typing import Dict
 
 from django.conf import settings
 from django.db import models
+from packaging import version
 
 
 class Channel(models.TextChoices):
@@ -572,6 +573,10 @@ class NimbusConstants(object):
         ENG_TICKET = "ENG_TICKET", "Engineering Ticket (Bugzilla/Jira/GitHub)"
 
     class Version(models.TextChoices):
+        @staticmethod
+        def parse(version_str):
+            return version.parse(version_str.replace("!", "0"))
+
         NO_VERSION = ""
         FIREFOX_11 = "11.!"
         FIREFOX_12 = "12.!"

--- a/app/experimenter/experiments/models/nimbus.py
+++ b/app/experimenter/experiments/models/nimbus.py
@@ -18,7 +18,6 @@ from django.db.models.constraints import UniqueConstraint
 from django.urls import reverse
 from django.utils import timezone
 from django.utils.text import slugify
-from packaging import version
 
 from experimenter.base import UploadsStorage
 from experimenter.base.models import Country, Locale
@@ -252,12 +251,12 @@ class NimbusExperiment(NimbusConstants, FilterMixin, models.Model):
             supported_version = self.TARGETING_APPLICATION_SUPPORTED_VERSION[
                 self.application
             ]
-            min_version_supported = version.parse(
+            min_version_supported = NimbusExperiment.Version.parse(
                 self.firefox_min_version
-            ) >= version.parse(supported_version)
-            max_version_supported = version.parse(
+            ) >= NimbusExperiment.Version.parse(supported_version)
+            max_version_supported = NimbusExperiment.Version.parse(
                 self.firefox_max_version
-            ) >= version.parse(supported_version)
+            ) >= NimbusExperiment.Version.parse(supported_version)
 
         if min_version_supported and self.firefox_min_version:
             expressions.append(

--- a/app/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_ready_for_review_serializer.py
+++ b/app/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_ready_for_review_serializer.py
@@ -179,6 +179,24 @@ class TestNimbusReviewSerializerSingleFeature(TestCase):
             },
         )
 
+    def test_valid_experiment_min_dot_version_less_than_max_version(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            application=NimbusExperiment.Application.DESKTOP,
+            firefox_min_version=NimbusExperiment.Version.FIREFOX_9830,
+            firefox_max_version=NimbusExperiment.Version.FIREFOX_99,
+        )
+        experiment.save()
+        serializer = NimbusReviewSerializer(
+            experiment,
+            data=NimbusReviewSerializer(
+                experiment,
+                context={"user": self.user},
+            ).data,
+            context={"user": self.user},
+        )
+        self.assertTrue(serializer.is_valid())
+
     def test_alid_experiment_allows_min_version_equal_to_max_version(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.CREATED,


### PR DESCRIPTION
Because

* We store version strings as they will appear in JEXL which includes a ! character
* The python packaging version parser does not recognize the ! which can lead to incorrect version comparisons

This commit

* Creates a reusable version parsing method
* Replaces ! with 0 in all parses
* Updates existing parse calls