### PR TITLE
Fixes ios version targeting version to be 98

### DIFF
--- a/app/experimenter/experiments/constants/nimbus.py
+++ b/app/experimenter/experiments/constants/nimbus.py
@@ -840,7 +840,7 @@ class NimbusConstants(object):
     TARGETING_APPLICATION_SUPPORTED_VERSION = {
         Application.FENIX: Version.FIREFOX_98,
         Application.FOCUS_ANDROID: Version.FIREFOX_98,
-        Application.IOS: Version.FIREFOX_97,
+        Application.IOS: Version.FIREFOX_98,
         Application.FOCUS_IOS: Version.FIREFOX_97,
     }
 

--- a/app/experimenter/experiments/tests/test_models/test_models_nimbus.py
+++ b/app/experimenter/experiments/tests/test_models/test_models_nimbus.py
@@ -249,7 +249,7 @@ class TestNimbusExperiment(TestCase):
                 NimbusExperiment.Application.FOCUS_ANDROID,
                 NimbusExperiment.Version.FIREFOX_97,
             ),
-            (NimbusExperiment.Application.IOS, NimbusExperiment.Version.FIREFOX_96),
+            (NimbusExperiment.Application.IOS, NimbusExperiment.Version.FIREFOX_97),
             (NimbusExperiment.Application.FOCUS_IOS, NimbusExperiment.Version.FIREFOX_96),
         ]
     )
@@ -274,7 +274,7 @@ class TestNimbusExperiment(TestCase):
                 NimbusExperiment.Application.FOCUS_ANDROID,
                 NimbusExperiment.Version.FIREFOX_98,
             ),
-            (NimbusExperiment.Application.IOS, NimbusExperiment.Version.FIREFOX_97),
+            (NimbusExperiment.Application.IOS, NimbusExperiment.Version.FIREFOX_98),
             (NimbusExperiment.Application.FOCUS_IOS, NimbusExperiment.Version.FIREFOX_97),
         ]
     )
@@ -335,7 +335,7 @@ class TestNimbusExperiment(TestCase):
                 NimbusExperiment.Application.FOCUS_ANDROID,
                 NimbusExperiment.Version.FIREFOX_98,
             ),
-            (NimbusExperiment.Application.IOS, NimbusExperiment.Version.FIREFOX_97),
+            (NimbusExperiment.Application.IOS, NimbusExperiment.Version.FIREFOX_98),
             (NimbusExperiment.Application.FOCUS_IOS, NimbusExperiment.Version.FIREFOX_97),
         ]
     )
@@ -365,7 +365,7 @@ class TestNimbusExperiment(TestCase):
                 NimbusExperiment.Application.FOCUS_ANDROID,
                 NimbusExperiment.Version.FIREFOX_98,
             ),
-            (NimbusExperiment.Application.IOS, NimbusExperiment.Version.FIREFOX_97),
+            (NimbusExperiment.Application.IOS, NimbusExperiment.Version.FIREFOX_98),
             (NimbusExperiment.Application.FOCUS_IOS, NimbusExperiment.Version.FIREFOX_97),
         ]
     )


### PR DESCRIPTION
I mistakingly thought the minimum supported version for the version targeting was 97, when it was actually shipped in 98. This fixes that to update the version to 98.

ref: https://mozilla-hub.atlassian.net/browse/EXP-2331