### PR TITLE
fix #7186 chore(project): only copy outcomes from jetstream-config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,8 +64,12 @@ secretkey:
 	openssl rand -hex 24
 
 jetstream_config:
-	curl -LJ -o app/experimenter/outcomes/jetstream-config.zip $(JETSTREAM_CONFIG_URL)
-	unzip -o -d app/experimenter/outcomes app/experimenter/outcomes/jetstream-config.zip
+	curl -LJ -o /tmp/jetstream-config.zip $(JETSTREAM_CONFIG_URL)
+	unzip -o -d /tmp/ /tmp/jetstream-config.zip
+	mkdir -p app/experimenter/outcomes/jetstream-config-main/
+	cp -R /tmp/jetstream-config-main/outcomes/ app/experimenter/outcomes/jetstream-config-main/
+	echo "copied outcomes"
+	ls -R app/experimenter/outcomes/jetstream-config-main/outcomes/
 
 feature_manifests:
 	curl -LJ --create-dirs -o app/experimenter/features/manifests/firefox-desktop.yaml $(FEATURE_MANIFEST_DESKTOP_URL)


### PR DESCRIPTION
Because

* We copy jetstream-config repo into the local filesystem to collect the outcome definition TOMLs when we build the Docker containers
* The jetstream-config repo may contain python files which are superfluous to Experimenter's needs
* Those python fails may cause Experimenter's linting and other checks to fail

This commit

* Copies only the outcome TOMLs into the local repo rather than the entire jetstream-config repo