### PR TITLE
 fix #7207 chore(nimbus): remove python scripts from jetstream config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,12 +63,9 @@ secretkey:
 	openssl rand -hex 24
 
 jetstream_config:
-	curl -LJ -o /tmp/jetstream-config.zip $(JETSTREAM_CONFIG_URL)
-	unzip -o -d /tmp/ /tmp/jetstream-config.zip
-	mkdir -p app/experimenter/outcomes/jetstream-config-main/
-	cp -R /tmp/jetstream-config-main/outcomes/ app/experimenter/outcomes/jetstream-config-main/
-	echo "copied outcomes"
-	ls -R app/experimenter/outcomes/jetstream-config-main/outcomes/
+	curl -LJ -o app/experimenter/outcomes/jetstream-config.zip $(JETSTREAM_CONFIG_URL)
+	unzip -o -d app/experimenter/outcomes app/experimenter/outcomes/jetstream-config.zip
+	rm -Rf app/experimenter/outcomes/jetstream-config-main/.scripts/
 
 feature_manifests:
 	curl -LJ --create-dirs -o app/experimenter/features/manifests/firefox-desktop.yaml $(FEATURE_MANIFEST_DESKTOP_URL)


### PR DESCRIPTION
 Because

 * Jetstream config added some python scripts recently
 * We import the jetstream config repo to load outcomes
 * The jetstream config python scripts were causing experimenter's linting to fail
 * We landed an attempt a fix that ended up working in circle but not locally

 This commit

 * Reverts the previous attempt at a fix
 * Removes the python scripts explicitly