### PR TITLE
fix #7197 feat(nimbus): fix typo in post preview message

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/PageSummary/FormLaunchPreviewToReview.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageSummary/FormLaunchPreviewToReview.tsx
@@ -37,7 +37,7 @@ const FormLaunchPreviewToReview = ({
           <p className="my-1">
             This experiment is currently <strong>live for testing</strong>, but
             you will need to let QA know in your PI request. When you have
-            recieved a sign-off, click “Request launch” to launch the
+            received a sign-off, click “Request launch” to launch the
             experiment.
           </p>
 


### PR DESCRIPTION
Because

* After launching an experiment to preview, the post Preview message contains a typo 

This commit

* fixes the typo `received ` in the message