### PR TITLE
fix #7201 feat(nimbus): import features for fenix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,7 @@ LOAD_DUMMY_EXPERIMENTS = [[ -z $$SKIP_DUMMY ]] && python manage.py load_dummy_ex
 
 JETSTREAM_CONFIG_URL = https://github.com/mozilla/jetstream-config/archive/main.zip
 FEATURE_MANIFEST_DESKTOP_URL = https://hg.mozilla.org/mozilla-central/raw-file/tip/toolkit/components/nimbus/FeatureManifest.yaml
+FEATURE_MANIFEST_FENIX_URL = https://raw.githubusercontent.com/mozilla-mobile/fenix/main/.experimenter.yaml
 
 ssl: nginx/key.pem nginx/cert.pem
 
@@ -69,6 +70,8 @@ jetstream_config:
 
 feature_manifests:
 	curl -LJ --create-dirs -o app/experimenter/features/manifests/firefox-desktop.yaml $(FEATURE_MANIFEST_DESKTOP_URL)
+	curl -LJ --create-dirs -o app/experimenter/features/manifests/fenix.yaml $(FEATURE_MANIFEST_FENIX_URL)
+
 
 fetch_external_resources: jetstream_config feature_manifests
 	echo "External Resources Fetched"


### PR DESCRIPTION
Because

* Fenix now exposes a feature manifest file

This commit

* Loads the Fenix feature manifests at build/startup time