### PR TITLE
fix #7215 bug(nimbus): handle existing features with different names

### DIFF
--- a/app/experimenter/features/management/commands/load_feature_configs.py
+++ b/app/experimenter/features/management/commands/load_feature_configs.py
@@ -16,10 +16,10 @@ class Command(BaseCommand):
 
         for feature in Features.all():
             feature_config, _ = NimbusFeatureConfig.objects.get_or_create(
-                name=feature.slug,
                 slug=feature.slug,
                 application=feature.applicationSlug,
             )
+            feature_config.name = feature.slug
             feature_config.description = feature.description
             feature_config.schema = feature.schema
             feature_config.read_only = True

--- a/app/experimenter/features/tests/test_load_feature_configs.py
+++ b/app/experimenter/features/tests/test_load_feature_configs.py
@@ -86,3 +86,19 @@ class TestLoadFeatureConfigs(TestCase):
                 "type": "object",
             },
         )
+
+    def test_handles_existing_features_with_same_slug_different_name(self):
+        NimbusFeatureConfigFactory.create(
+            name="readerMode different name",
+            slug="readerMode",
+            application=NimbusExperiment.Application.DESKTOP,
+            schema="{}",
+        )
+        call_command("load_feature_configs")
+
+        feature_config = NimbusFeatureConfig.objects.get(slug="readerMode")
+        self.assertEqual(feature_config.name, "readerMode")
+        self.assertEqual(
+            feature_config.description,
+            "Firefox Reader Mode",
+        )


### PR DESCRIPTION
Because

* A feature config may already exist in the database when attempting to load from a remote feature manifest
* If the existing feature has the same slug but a different name then the loader would attempt to create a new feature and then violate the slug uniqueness constraint

This commit

* Looks existing features up only by (slug, applicationSlug) and then resets the name