### PR TITLE
fix #7213 feat(nimbus): show feature config description

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/index.tsx
@@ -221,6 +221,9 @@ export const FormBranches = ({
                     value={feature.id!}
                   >
                     {feature.name}
+                    {feature.description?.length
+                      ? `- ${feature.description}`
+                      : ""}
                   </option>
                 ),
             )}

--- a/app/experimenter/nimbus-ui/src/components/Summary/TableOverview/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/TableOverview/index.tsx
@@ -105,7 +105,10 @@ const TableOverview = ({
                 {experiment.featureConfigs?.length ? (
                   experiment.featureConfigs.map((f) => (
                     <>
-                      <p>{f?.name}</p>
+                      <p>
+                        {f?.name}
+                        {f?.description?.length ? `- ${f.description}` : ""}
+                      </p>
                     </>
                   ))
                 ) : (


### PR DESCRIPTION
Because

* We have feature config `description` but we are not showing to the user when they are selecting feature config
* On the overview page it is only showing name of feature config, missing description

This commit

* Adds the `feature config description` when users select the drop-down
* Display feature config description on the `Overview page `along with `feature config name`

Before changes
<img width="1628" alt="image" src="https://user-images.githubusercontent.com/104033388/164800394-2190ad75-93bb-429b-8cfc-5d7acf9d2e5b.png">
<img width="1628" alt="image" src="https://user-images.githubusercontent.com/104033388/164800637-41fbc472-82d4-4c67-950d-0dcfbaa60aaf.png">


After changes
<img width="1628" alt="image" src="https://user-images.githubusercontent.com/104033388/164800221-71010fea-1992-404a-8fe7-cb89131e795a.png">
<img width="1628" alt="image" src="https://user-images.githubusercontent.com/104033388/164800744-919f5e37-9324-45ac-be6a-5e0424c77e8f.png">

closes #7213 