### PR TITLE
Fixes #7153 feat(nimbus): Revert disable country targeting for mobile

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/index.test.tsx
@@ -153,36 +153,6 @@ describe("FormAudience", () => {
     expect(screen.getByTestId("countries")).toHaveTextContent("All Countries");
   });
 
-  it("enables country field for desktop", async () => {
-    render(
-      <Subject
-        experiment={{
-          ...MOCK_EXPERIMENT,
-          application: NimbusExperimentApplicationEnum.DESKTOP,
-        }}
-      />,
-    );
-
-    expect(
-      screen.getByTestId("countries").querySelector("input"),
-    ).not.toHaveAttribute("disabled");
-  });
-
-  it("disables country field for mobile", async () => {
-    render(
-      <Subject
-        experiment={{
-          ...MOCK_EXPERIMENT,
-          application: NimbusExperimentApplicationEnum.FENIX,
-        }}
-      />,
-    );
-
-    expect(
-      screen.getByTestId("countries").querySelector("input"),
-    ).toHaveAttribute("disabled");
-  });
-
   it("calls onSubmit when save and next buttons are clicked", async () => {
     const onSubmit = jest.fn();
     const expected = {

--- a/app/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/index.tsx
@@ -22,7 +22,6 @@ import {
   getConfig_nimbusConfig_targetingConfigs,
 } from "../../../types/getConfig";
 import { getExperiment_experimentBySlug } from "../../../types/getExperiment";
-import { NimbusExperimentApplicationEnum } from "../../../types/globalTypes";
 import LinkExternal from "../../LinkExternal";
 
 type FormAudienceProps = {
@@ -140,9 +139,6 @@ export const FormAudience = ({
     [config, experiment],
   );
 
-  const isDesktop =
-    experiment.application === NimbusExperimentApplicationEnum.DESKTOP;
-
   return (
     <Form
       noValidate
@@ -208,15 +204,9 @@ export const FormAudience = ({
             <Select
               placeholder="All Countries"
               isMulti
-              isDisabled={!isDesktop}
               {...formSelectAttrs("countries", setCountries)}
               options={selectOptions(config.countries as SelectIdItems)}
             />
-            {!isDesktop ? (
-              <p className="text-secondary">
-                *Country filtering is not yet supported for mobile clients.
-              </p>
-            ) : null}
             <FormErrors name="countries" />
           </Form.Group>
         </Form.Row>


### PR DESCRIPTION
Because...

* Country targeting is now available on mobile

This commit...

* Reverts [this commit](https://github.com/mozilla/experimenter/commit/58a8a00d2c93db70d53d4839b8849c3fb1400e80). By reverting this, we are re-enabling country targeting for mobile.