### PR TITLE
Fixes #7232 fix(project): Test locale factory should reference locale instead of country

### DIFF
--- a/app/experimenter/base/tests/factories.py
+++ b/app/experimenter/base/tests/factories.py
@@ -16,7 +16,7 @@ class CountryFactory(factory.django.DjangoModelFactory):
 
 
 class LocaleFactory(factory.django.DjangoModelFactory):
-    name = factory.LazyAttribute(lambda o: faker.country())
+    name = factory.LazyAttribute(lambda o: faker.locale())
     code = factory.LazyAttribute(lambda o: o.name[:2])
 
     class Meta:


### PR DESCRIPTION
Because...

* The locale factory was incorrectly referencing `country`

This commit...

* Uses the correct field, `locale`, instead