### PR TITLE
fix #7244 chore(nimbus): add targeting for Fx100+, Win10+

### DIFF
--- a/app/experimenter/experiments/constants/nimbus.py
+++ b/app/experimenter/experiments/constants/nimbus.py
@@ -206,6 +206,32 @@ TARGETING_FIRST_RUN_WINDOWS_1903_NEWER = NimbusTargetingConfig(
     application_choice_names=(Application.DESKTOP.name,),
 )
 
+TARGETING_WINDOWS_WITH_USERCHOICE = NimbusTargetingConfig(
+    name="Users on Windows with UserChoice support (Windows build 15063 or newer)",
+    slug="windows_userchoice",
+    description="Users on Windows with UserChoice support (i.e., Windows build 15063+)",
+    targeting="os.windowsBuildNumber >= 15063",
+    desktop_telemetry="environment.system.os.windows_build_number >= 15063",
+    application_choice_names=(Application.DESKTOP.name,),
+)
+
+TARGETING_WINDOWS_WITH_USERCHOICE_FIRST_RUN = NimbusTargetingConfig(
+    name="First start-up users on Windows with UserChoice support "
+    "(Windows build 15063 or newer)",
+    slug="windows_userchoice_first_run",
+    description="First start-up users (e.g. for about:welcome) on Windows with "
+    "UserChoice support (i.e., Windows build 15063+)",
+    targeting="{first_run} && {user_choice}".format(
+        first_run=TARGETING_FIRST_RUN.targeting,
+        user_choice=TARGETING_WINDOWS_WITH_USERCHOICE.targeting,
+    ),
+    desktop_telemetry=("{first_run} AND {user_choice}").format(
+        first_run=TARGETING_FIRST_RUN.desktop_telemetry,
+        user_choice=TARGETING_WINDOWS_WITH_USERCHOICE.desktop_telemetry,
+    ),
+    application_choice_names=(Application.DESKTOP.name,),
+)
+
 TARGETING_FX95_DESKTOP_USERS = NimbusTargetingConfig(
     name="Desktop Users on Fx95",
     slug="fx95_desktop_users",
@@ -728,6 +754,10 @@ class NimbusConstants(object):
         TARGETING_MAC_ONLY.slug: TARGETING_MAC_ONLY,
         TARGETING_NO_ENTERPRISE.slug: TARGETING_NO_ENTERPRISE,
         TARGETING_FX95_DESKTOP_USERS.slug: TARGETING_FX95_DESKTOP_USERS,
+        TARGETING_WINDOWS_WITH_USERCHOICE.slug: TARGETING_WINDOWS_WITH_USERCHOICE,
+        TARGETING_WINDOWS_WITH_USERCHOICE_FIRST_RUN.slug: (
+            TARGETING_WINDOWS_WITH_USERCHOICE_FIRST_RUN
+        ),
         TARGETING_MOBILE_NEW_USER.slug: TARGETING_MOBILE_NEW_USER,
         TARGETING_MOBILE_RECENTLY_UPDATED.slug: TARGETING_MOBILE_RECENTLY_UPDATED,
         TARGETING_NO_ENTERPRISE_OR_PAST_VPN.slug: TARGETING_NO_ENTERPRISE_OR_PAST_VPN,
@@ -779,6 +809,14 @@ class NimbusConstants(object):
         TARGETING_FX95_DESKTOP_USERS = (
             TARGETING_FX95_DESKTOP_USERS.slug,
             TARGETING_FX95_DESKTOP_USERS.name,
+        )
+        TARGETING_WINDOWS_WITH_USERCHOICE = (
+            TARGETING_WINDOWS_WITH_USERCHOICE.slug,
+            TARGETING_WINDOWS_WITH_USERCHOICE.name,
+        )
+        TARGETING_WINDOWS_WITH_USERCHOICE_FIRST_RUN = (
+            TARGETING_WINDOWS_WITH_USERCHOICE_FIRST_RUN.slug,
+            TARGETING_WINDOWS_WITH_USERCHOICE_FIRST_RUN.name,
         )
         TARGETING_MOBILE_NEW_USER = (
             TARGETING_MOBILE_NEW_USER.slug,


### PR DESCRIPTION
Because

* Some experiments need to target Firefox 100+ but only apply to
  Windows 10+, and in fact only build 15063 plus.

This commit

* Adds targeting for Fx100+, Windows build number 15063+.

Notes:

* The build number was chosen because the `UserChoice` Windows feature
  changed in that build, see [this
  comment](https://searchfox.org/mozilla-central/rev/87ecd21d3ca517f8d90e49b32bf042a754ed8f18/browser/components/shell/WindowsUserChoice.cpp#86).

* It's not clear to me why there's no version comparison in the
  `desktop_telemetry` section of my model,
  `TARGETING_FX95_DESKTOP_USERS`, but I followed suit.

Fix #7244