### PR TITLE
Fixes #7249 chore(project): Add 99.1 to min version targeting

### DIFF
--- a/app/experimenter/experiments/constants/nimbus.py
+++ b/app/experimenter/experiments/constants/nimbus.py
@@ -708,6 +708,7 @@ class NimbusConstants(object):
         FIREFOX_98 = "98.!"
         FIREFOX_9830 = "98.3.0"
         FIREFOX_99 = "99.!"
+        FIREFOX_9910 = "99.1.0"
         FIREFOX_100 = "100.!"
         FIREFOX_101 = "101.!"
         FIREFOX_102 = "102.!"

--- a/app/experimenter/nimbus-ui/schema.graphql
+++ b/app/experimenter/nimbus-ui/schema.graphql
@@ -342,6 +342,7 @@ enum NimbusExperimentFirefoxVersionEnum {
   FIREFOX_98
   FIREFOX_9830
   FIREFOX_99
+  FIREFOX_9910
   FIREFOX_100
   FIREFOX_101
   FIREFOX_102

--- a/app/experimenter/nimbus-ui/src/types/globalTypes.ts
+++ b/app/experimenter/nimbus-ui/src/types/globalTypes.ts
@@ -175,6 +175,7 @@ export enum NimbusExperimentFirefoxVersionEnum {
   FIREFOX_98 = "FIREFOX_98",
   FIREFOX_9830 = "FIREFOX_9830",
   FIREFOX_99 = "FIREFOX_99",
+  FIREFOX_9910 = "FIREFOX_9910",
   NO_VERSION = "NO_VERSION",
 }
 


### PR DESCRIPTION
Because...

* The iOS would like to target a minimum version of 99.1

This commit...

* Adds the constants for v99.1

<img width="360" alt="image" src="https://user-images.githubusercontent.com/43795363/166523947-bfad7a3c-139e-42c1-9baa-716af306c123.png">
