### PR TITLE
fix #7129 feat(nimbus): load remote json schemas

### DIFF
--- a/app/experimenter/features/management/commands/load_feature_configs.py
+++ b/app/experimenter/features/management/commands/load_feature_configs.py
@@ -21,7 +21,7 @@ class Command(BaseCommand):
             )
             feature_config.name = feature.slug
             feature_config.description = feature.description
-            feature_config.schema = feature.schema
+            feature_config.schema = feature.get_jsonschema()
             feature_config.read_only = True
             feature_config.save()
             logger.info(f"Feature Loaded: {feature.applicationSlug}/{feature.slug}")

--- a/app/experimenter/features/tests/__init__.py
+++ b/app/experimenter/features/tests/__init__.py
@@ -14,3 +14,9 @@ mock_invalid_features = override_settings(
         pathlib.Path(__file__).parent.absolute(), "fixtures", "invalid_features"
     )
 )
+
+mock_remote_schema_features = override_settings(
+    FEATURE_MANIFESTS_PATH=os.path.join(
+        pathlib.Path(__file__).parent.absolute(), "fixtures", "remote_schema_features"
+    )
+)

--- a/app/experimenter/features/tests/fixtures/remote_schema_features/firefox-desktop.yaml
+++ b/app/experimenter/features/tests/fixtures/remote_schema_features/firefox-desktop.yaml
@@ -1,0 +1,9 @@
+cfr:
+  description: "Doorhanger message template for Messaging System"
+  hasExposure: true
+  exposureDescription: "Exposure is sent if the message is about to be shown after trigger and targeting conditions on the message matched."
+  isEarlyStartup: false
+  schema:
+    uri: "resource://activity-stream/schemas/CFR/ExtensionDoorhanger.schema.json"
+    path: "path/to/schema.json"
+  variables: {}


### PR DESCRIPTION
Because

* Some features define a rich json schema for their value types
* We can load and use those json schemas instead of generating them from the variables

This commit

* Looks for remotely defined feature schemas
* Loads and stores them if they're defined