### PR TITLE
fix #7254 chore(project): reduce circle make duplication

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,9 +34,7 @@ jobs:
           command: |
             PYTEST_ARGS=$(circleci tests split "app/tests/integration/nimbus/parallel_pytest_args.txt")
             cp .env.integration-tests .env
-            make refresh SKIP_DUMMY=1
-            make up_prod_detached
-            make integration_test_nimbus PYTEST_ARGS="$PYTEST_ARGS"
+            make refresh SKIP_DUMMY=1 up_prod_detached integration_test_nimbus PYTEST_ARGS="$PYTEST_ARGS"
 
   deploy:
     working_directory: ~/experimenter
@@ -49,9 +47,7 @@ jobs:
           name: Deploy to latest
           command: |
             docker login -u $DOCKER_USER -p $DOCKER_PASS
-            make build_dev
-            make build_test
-            make build_ui
+            make build_dev build_test build_ui
             ./scripts/store_git_info.sh
             make build_prod
             docker tag app:dev ${DOCKERHUB_REPO}:build_dev


### PR DESCRIPTION
Because

* Each call to make will trigger many remote fetches
* Having multiple subsequent make calls will repeat those same fetches
* Combining multiple make calls into a single call will only make the fetches once

This commit

* Moves multiple make calls into a single make call in circle where possible