### PR TITLE
fix #7259 feat(nimbus): load focus android features

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,7 @@ JETSTREAM_CONFIG_URL = https://github.com/mozilla/jetstream-config/archive/main.
 FEATURE_MANIFEST_DESKTOP_URL = https://hg.mozilla.org/mozilla-central/raw-file/tip/toolkit/components/nimbus/FeatureManifest.yaml
 FEATURE_MANIFEST_FENIX_URL = https://raw.githubusercontent.com/mozilla-mobile/fenix/main/.experimenter.yaml
 FEATURE_MANIFEST_FXIOS_URL = https://raw.githubusercontent.com/mozilla-mobile/firefox-ios/main/.experimenter.yaml
+FEATURE_MANIFEST_FOCUS_ANDROID = https://raw.githubusercontent.com/mozilla-mobile/focus-android/main/.experimenter.yaml
 
 ssl: nginx/key.pem nginx/cert.pem
 
@@ -70,6 +71,7 @@ feature_manifests:
 	curl -LJ --create-dirs -o app/experimenter/features/manifests/firefox-desktop.yaml $(FEATURE_MANIFEST_DESKTOP_URL)
 	curl -LJ --create-dirs -o app/experimenter/features/manifests/fenix.yaml $(FEATURE_MANIFEST_FENIX_URL)
 	curl -LJ --create-dirs -o app/experimenter/features/manifests/ios.yaml $(FEATURE_MANIFEST_FXIOS_URL)
+	curl -LJ --create-dirs -o app/experimenter/features/manifests/focus-android.yaml $(FEATURE_MANIFEST_FOCUS_ANDROID)
 
 fetch_external_resources: jetstream_config feature_manifests
 	echo "External Resources Fetched"


### PR DESCRIPTION
Because

* Focus for Android now publishes a feature manifest

This commit

* Loads the Focus for Android feature manifest