### PR TITLE
fix #7267 feat(nimbus): increase feature schema strictness

### DIFF
--- a/app/experimenter/features/__init__.py
+++ b/app/experimenter/features/__init__.py
@@ -23,7 +23,7 @@ class FeatureVariableType(Enum):
 
 
 FEATURE_SCHEMA_TYPES = {
-    FeatureVariableType.INT: "number",
+    FeatureVariableType.INT: "integer",
     FeatureVariableType.STRING: "string",
     FeatureVariableType.BOOLEAN: "boolean",
 }
@@ -59,7 +59,8 @@ class Feature(BaseModel):
         schema = {
             "type": "object",
             "properties": {},
-            "additionalProperties": True,
+            "additionalProperties": False,
+            "required": [],
         }
 
         for variable_slug, variable in self.variables.items():
@@ -74,6 +75,7 @@ class Feature(BaseModel):
                 variable_schema["enum"] = variable.enum
 
             schema["properties"][variable_slug] = variable_schema
+            schema["required"].append(variable_slug)
 
         return json.dumps(schema, indent=2)
 

--- a/app/experimenter/features/tests/fixtures/valid_features/firefox-desktop.yaml
+++ b/app/experimenter/features/tests/fixtures/valid_features/firefox-desktop.yaml
@@ -1,17 +1,21 @@
-readerMode:
-  description: Firefox Reader Mode
+someFeature:
+  description: Some Firefox Feature
   exposureDescription: An exposure event
   isEarlyStartup: true
   variables:
-    pocketCTAVersion:
+    stringEnumProperty:
       type: string
-      fallbackPref: reader.pocket.ctaVersion
-      description: >-
-        What version of Pocket CTA to show in Reader Mode
-        (Empty string is no CTA)
+      fallbackPref: browser.somePref
+      description: String Property
       enum:
         - v1
         - v2
-    config:
+    boolProperty:
+      type: boolean
+      description: Boolean Property
+    intProperty:
+      type: int
+      description: Integer Property
+    jsonProperty:
       type: json
-      description: Arbitrary JSON config
+      description: Arbitrary JSON Property

--- a/app/experimenter/features/tests/test_features.py
+++ b/app/experimenter/features/tests/test_features.py
@@ -22,6 +22,8 @@ from experimenter.features.tests import (
 
 @mock_valid_features
 class TestFeatures(TestCase):
+    maxDiff = None
+
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
@@ -33,22 +35,27 @@ class TestFeatures(TestCase):
         self.assertIn(
             Feature(
                 applicationSlug="firefox-desktop",
-                description="Firefox Reader Mode",
+                description="Some Firefox Feature",
                 exposureDescription="An exposure event",
                 isEarlyStartup=True,
-                slug="readerMode",
+                slug="someFeature",
                 variables={
-                    "pocketCTAVersion": FeatureVariable(
-                        description=(
-                            "What version of Pocket CTA to show in Reader Mode "
-                            "(Empty string is no CTA)"
-                        ),
+                    "stringEnumProperty": FeatureVariable(
+                        description="String Property",
                         enum=["v1", "v2"],
-                        fallbackPref="reader.pocket.ctaVersion",
+                        fallbackPref="browser.somePref",
                         type=FeatureVariableType.STRING,
                     ),
-                    "config": FeatureVariable(
-                        description="Arbitrary JSON config",
+                    "boolProperty": FeatureVariable(
+                        description="Boolean Property",
+                        type="boolean",
+                    ),
+                    "intProperty": FeatureVariable(
+                        description="Integer Property",
+                        type="int",
+                    ),
+                    "jsonProperty": FeatureVariable(
+                        description="Arbitrary JSON Property",
                         type="json",
                     ),
                 },
@@ -80,22 +87,27 @@ class TestFeatures(TestCase):
         self.assertIn(
             Feature(
                 applicationSlug="firefox-desktop",
-                description="Firefox Reader Mode",
+                description="Some Firefox Feature",
                 exposureDescription="An exposure event",
                 isEarlyStartup=True,
-                slug="readerMode",
+                slug="someFeature",
                 variables={
-                    "pocketCTAVersion": FeatureVariable(
-                        description=(
-                            "What version of Pocket CTA to show in Reader Mode "
-                            "(Empty string is no CTA)"
-                        ),
+                    "stringEnumProperty": FeatureVariable(
+                        description="String Property",
                         enum=["v1", "v2"],
-                        fallbackPref="reader.pocket.ctaVersion",
+                        fallbackPref="browser.somePref",
                         type=FeatureVariableType.STRING,
                     ),
-                    "config": FeatureVariable(
-                        description="Arbitrary JSON config",
+                    "boolProperty": FeatureVariable(
+                        description="Boolean Property",
+                        type="boolean",
+                    ),
+                    "intProperty": FeatureVariable(
+                        description="Integer Property",
+                        type="int",
+                    ),
+                    "jsonProperty": FeatureVariable(
+                        description="Arbitrary JSON Property",
                         type="json",
                     ),
                 },
@@ -108,23 +120,27 @@ class TestFeatures(TestCase):
         self.assertEqual(
             json.loads(desktop_feature.get_jsonschema()),
             {
-                "additionalProperties": True,
+                "type": "object",
                 "properties": {
-                    "pocketCTAVersion": {
-                        "description": (
-                            "What version of Pocket "
-                            "CTA to show in Reader "
-                            "Mode (Empty string is no "
-                            "CTA)"
-                        ),
+                    "stringEnumProperty": {
+                        "description": "String Property",
                         "type": "string",
                         "enum": ["v1", "v2"],
                     },
-                    "config": {
-                        "description": "Arbitrary JSON config",
+                    "boolProperty": {
+                        "description": "Boolean Property",
+                        "type": "boolean",
                     },
+                    "intProperty": {"description": "Integer Property", "type": "integer"},
+                    "jsonProperty": {"description": "Arbitrary JSON Property"},
                 },
-                "type": "object",
+                "additionalProperties": False,
+                "required": [
+                    "stringEnumProperty",
+                    "boolProperty",
+                    "intProperty",
+                    "jsonProperty",
+                ],
             },
         )
 

--- a/app/experimenter/features/tests/test_load_feature_configs.py
+++ b/app/experimenter/features/tests/test_load_feature_configs.py
@@ -17,88 +17,96 @@ class TestLoadFeatureConfigs(TestCase):
         Features.clear_cache()
 
     def test_loads_new_feature_configs(self):
-        self.assertFalse(NimbusFeatureConfig.objects.filter(slug="readerMode").exists())
+        self.assertFalse(NimbusFeatureConfig.objects.filter(slug="someFeature").exists())
         call_command("load_feature_configs")
 
-        feature_config = NimbusFeatureConfig.objects.get(slug="readerMode")
-        self.assertEqual(feature_config.name, "readerMode")
+        feature_config = NimbusFeatureConfig.objects.get(slug="someFeature")
+        self.assertEqual(feature_config.name, "someFeature")
         self.assertEqual(
             feature_config.description,
-            "Firefox Reader Mode",
+            "Some Firefox Feature",
         )
         self.assertEqual(
             json.loads(feature_config.schema),
             {
-                "additionalProperties": True,
+                "type": "object",
                 "properties": {
-                    "pocketCTAVersion": {
-                        "description": (
-                            "What version of Pocket "
-                            "CTA to show in Reader "
-                            "Mode (Empty string is no "
-                            "CTA)"
-                        ),
+                    "stringEnumProperty": {
+                        "description": "String Property",
                         "type": "string",
                         "enum": ["v1", "v2"],
                     },
-                    "config": {
-                        "description": "Arbitrary JSON config",
+                    "boolProperty": {
+                        "description": "Boolean Property",
+                        "type": "boolean",
                     },
+                    "intProperty": {"description": "Integer Property", "type": "integer"},
+                    "jsonProperty": {"description": "Arbitrary JSON Property"},
                 },
-                "type": "object",
+                "additionalProperties": False,
+                "required": [
+                    "stringEnumProperty",
+                    "boolProperty",
+                    "intProperty",
+                    "jsonProperty",
+                ],
             },
         )
 
     def test_updates_existing_feature_configs(self):
         NimbusFeatureConfigFactory.create(
-            name="readerMode",
-            slug="readerMode",
+            name="someFeature",
+            slug="someFeature",
             application=NimbusExperiment.Application.DESKTOP,
             schema="{}",
         )
         call_command("load_feature_configs")
 
-        feature_config = NimbusFeatureConfig.objects.get(slug="readerMode")
-        self.assertEqual(feature_config.name, "readerMode")
+        feature_config = NimbusFeatureConfig.objects.get(slug="someFeature")
+        self.assertEqual(feature_config.name, "someFeature")
         self.assertEqual(
             feature_config.description,
-            "Firefox Reader Mode",
+            "Some Firefox Feature",
         )
         self.assertEqual(
             json.loads(feature_config.schema),
             {
-                "additionalProperties": True,
+                "type": "object",
                 "properties": {
-                    "pocketCTAVersion": {
-                        "description": (
-                            "What version of Pocket "
-                            "CTA to show in Reader "
-                            "Mode (Empty string is no "
-                            "CTA)"
-                        ),
+                    "stringEnumProperty": {
+                        "description": "String Property",
                         "type": "string",
                         "enum": ["v1", "v2"],
                     },
-                    "config": {
-                        "description": "Arbitrary JSON config",
+                    "boolProperty": {
+                        "description": "Boolean Property",
+                        "type": "boolean",
                     },
+                    "intProperty": {"description": "Integer Property", "type": "integer"},
+                    "jsonProperty": {"description": "Arbitrary JSON Property"},
                 },
-                "type": "object",
+                "additionalProperties": False,
+                "required": [
+                    "stringEnumProperty",
+                    "boolProperty",
+                    "intProperty",
+                    "jsonProperty",
+                ],
             },
         )
 
     def test_handles_existing_features_with_same_slug_different_name(self):
         NimbusFeatureConfigFactory.create(
-            name="readerMode different name",
-            slug="readerMode",
+            name="Some Firefox Feature different name",
+            slug="someFeature",
             application=NimbusExperiment.Application.DESKTOP,
             schema="{}",
         )
         call_command("load_feature_configs")
 
-        feature_config = NimbusFeatureConfig.objects.get(slug="readerMode")
-        self.assertEqual(feature_config.name, "readerMode")
+        feature_config = NimbusFeatureConfig.objects.get(slug="someFeature")
+        self.assertEqual(feature_config.name, "someFeature")
         self.assertEqual(
             feature_config.description,
-            "Firefox Reader Mode",
+            "Some Firefox Feature",
         )


### PR DESCRIPTION
Because

* We now have the ability to disable schema validation failure preventing launches
* As our customer base grows, the possibility for error is increasing
* We have seen recent cases where invalid feature data can cause difficult to trace errors

This commit

* Uses the correct integer type for numbers instead of Number
* Increases the strictness of the auto generated feature value schemas