### PR TITLE
7150/add languages field nimbus UI

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/index.test.tsx
@@ -186,6 +186,32 @@ describe("FormAudience", () => {
     ).toHaveAttribute("disabled");
   });
 
+  it("enables language field for mobile", async () => {
+    render(
+      <Subject
+        experiment={{
+          ...MOCK_EXPERIMENT,
+          application: NimbusExperimentApplicationEnum.FENIX,
+        }}
+      />,
+    );
+
+    expect(screen.queryByTestId("languages")).toBeInTheDocument();
+  });
+
+  it("disables language field for desktop", async () => {
+    render(
+      <Subject
+        experiment={{
+          ...MOCK_EXPERIMENT,
+          application: NimbusExperimentApplicationEnum.DESKTOP,
+        }}
+      />,
+    );
+
+    expect(screen.queryByTestId("languages")).not.toBeInTheDocument();
+  });
+
   it("calls onSubmit when save and next buttons are clicked", async () => {
     const onSubmit = jest.fn();
     const expected = {
@@ -199,6 +225,7 @@ describe("FormAudience", () => {
       proposedDuration: "" + MOCK_EXPERIMENT.proposedDuration,
       countries: MOCK_EXPERIMENT.countries.map((v) => "" + v.id),
       locales: MOCK_EXPERIMENT.locales.map((v) => "" + v.id),
+      languages: MOCK_EXPERIMENT.languages.map((v) => "" + v.id),
     };
     render(<Subject {...{ onSubmit }} />);
     await screen.findByTestId("FormAudience");
@@ -446,6 +473,7 @@ const renderSubjectWithDefaultValues = (onSubmit = () => {}) =>
         targetingConfigSlug: "",
         countries: [],
         locales: [],
+        languages: [],
       }}
     />,
   );

--- a/app/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/index.tsx
@@ -76,6 +76,9 @@ export const FormAudience = ({
   const [countries, setCountries] = useState<string[]>(
     experiment!.countries.map((v) => "" + v.id!),
   );
+  const [languages, setLanguages] = useState<string[]>(
+    experiment!.languages.map((v) => "" + v.id!),
+  );
 
   const applicationConfig = config.applicationConfigs?.find(
     (applicationConfig) =>
@@ -93,6 +96,7 @@ export const FormAudience = ({
     proposedDuration: experiment.proposedDuration,
     countries: selectOptions(experiment.countries as SelectIdItems),
     locales: selectOptions(experiment.locales as SelectIdItems),
+    languages: selectOptions(experiment.languages as SelectIdItems),
   };
 
   const {
@@ -123,12 +127,13 @@ export const FormAudience = ({
                 ...dataIn,
                 locales,
                 countries,
+                languages,
               },
               next,
             ),
         ),
       ),
-    [isLoading, onSubmit, handleSubmit, locales, countries],
+    [isLoading, onSubmit, handleSubmit, locales, countries, languages],
   );
 
   const targetingConfigSlugOptions = useMemo(
@@ -193,16 +198,28 @@ export const FormAudience = ({
           </Form.Group>
         </Form.Row>
         <Form.Row>
-          <Form.Group as={Col} controlId="locales" data-testid="locales">
-            <Form.Label>Locales</Form.Label>
-            <Select
-              placeholder="All Locales"
-              isMulti
-              {...formSelectAttrs("locales", setLocales)}
-              options={selectOptions(config.locales as SelectIdItems)}
-            />
-            <FormErrors name="locales" />
-          </Form.Group>
+          {isDesktop && (
+            <Form.Group as={Col} controlId="locales" data-testid="locales">
+              <Form.Label>Locales</Form.Label>
+              <Select
+                placeholder="All Locales"
+                isMulti
+                {...formSelectAttrs("locales", setLocales)}
+                options={selectOptions(config.locales as SelectIdItems)}
+              />
+              <FormErrors name="locales" />
+            </Form.Group>
+          )}
+          {!isDesktop && (
+            <Form.Group as={Col} controlId="languages" data-testid="languages">
+              <Form.Label>Languages</Form.Label>
+              <Select
+                placeholder="All Languages"
+                isMulti
+                options={selectOptions(config.languages as SelectIdItems)}
+              />
+            </Form.Group>
+          )}
           <Form.Group as={Col} controlId="countries" data-testid="countries">
             <Form.Label>Countries</Form.Label>
             <Select

--- a/app/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/index.tsx
@@ -51,6 +51,7 @@ export const audienceFieldNames = [
   "proposedDuration",
   "countries",
   "locales",
+  "languages",
 ] as const;
 
 const selectOptions = (items: SelectIdItems) =>
@@ -216,6 +217,7 @@ export const FormAudience = ({
               <Select
                 placeholder="All Languages"
                 isMulti
+                {...formSelectAttrs("languages", setLanguages)}
                 options={selectOptions(config.languages as SelectIdItems)}
               />
             </Form.Group>

--- a/app/experimenter/nimbus-ui/src/components/PageEditAudience/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditAudience/index.test.tsx
@@ -108,6 +108,7 @@ const MOCK_FORM_DATA = {
   proposedDuration: 28,
   countries: [1],
   locales: [1],
+  languages: [1],
 };
 
 const Subject = ({

--- a/app/experimenter/nimbus-ui/src/components/PageEditAudience/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditAudience/index.tsx
@@ -40,6 +40,7 @@ const PageEditAudience: React.FunctionComponent<RouteComponentProps> = () => {
         proposedDuration,
         countries,
         locales,
+        languages,
       }: Record<string, any>,
       next: boolean,
     ) => {
@@ -61,6 +62,7 @@ const PageEditAudience: React.FunctionComponent<RouteComponentProps> = () => {
               proposedDuration,
               countries,
               locales,
+              languages,
             },
           },
         });

--- a/app/experimenter/nimbus-ui/src/components/Summary/TableAudience/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/TableAudience/index.test.tsx
@@ -7,7 +7,10 @@ import React from "react";
 import TableAudience from ".";
 import { MockedCache, mockExperimentQuery } from "../../../lib/mocks";
 import { getExperiment_experimentBySlug } from "../../../types/getExperiment";
-import { NimbusExperimentChannelEnum } from "../../../types/globalTypes";
+import {
+  NimbusExperimentApplicationEnum,
+  NimbusExperimentChannelEnum,
+} from "../../../types/globalTypes";
 
 describe("TableAudience", () => {
   describe("renders 'Channel' row as expected", () => {
@@ -189,7 +192,46 @@ describe("TableAudience", () => {
       );
     });
   });
-
+  describe("renders 'Languages' row as expected", () => {
+    it("when languages exist, displays them", () => {
+      const data = {
+        languages: [
+          { name: "English", id: 1 },
+          { name: "French", id: 2 },
+        ],
+        application: NimbusExperimentApplicationEnum.FENIX,
+      };
+      const { experiment } = mockExperimentQuery("demo-slug", data);
+      render(
+        <Subject
+          {...{
+            experiment,
+          }}
+        />,
+      );
+      data.languages.forEach((language) =>
+        within(screen.getByTestId("experiment-languages")).findByText(
+          language.name,
+        ),
+      );
+    });
+    it("when languages don't exist, displays all", async () => {
+      const { experiment } = mockExperimentQuery("demo-slug", {
+        languages: [],
+        application: NimbusExperimentApplicationEnum.FENIX,
+      });
+      render(
+        <Subject
+          {...{
+            experiment,
+          }}
+        />,
+      );
+      await within(screen.getByTestId("experiment-languages")).findByText(
+        "All Languages",
+      );
+    });
+  });
   describe("renders 'Countries' row as expected", () => {
     it("when countries exist, displays them", async () => {
       const data = {

--- a/app/experimenter/nimbus-ui/src/components/Summary/TableAudience/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/TableAudience/index.tsx
@@ -7,6 +7,7 @@ import { Table } from "react-bootstrap";
 import { displayConfigLabelOrNotSet } from "..";
 import { useConfig } from "../../../hooks";
 import { getExperiment_experimentBySlug } from "../../../types/getExperiment";
+import { NimbusExperimentApplicationEnum } from "../../../types/globalTypes";
 import { Code } from "../../Code";
 import NotSet from "../../NotSet";
 
@@ -22,6 +23,8 @@ const TableAudience = ({
   withFullDetails = true,
 }: TableAudienceProps) => {
   const { firefoxVersions, channels, targetingConfigs } = useConfig();
+  const isDesktop =
+    experiment.application === NimbusExperimentApplicationEnum.DESKTOP;
 
   return (
     <Table
@@ -82,20 +85,38 @@ const TableAudience = ({
             </td>
           </tr>
         )}
-        <tr>
-          <th>Locales</th>
-          <td data-testid="experiment-locales">
-            {experiment.locales.length > 0 ? (
-              <ul className="list-unstyled mb-0">
-                {experiment.locales.map((l) => (
-                  <li key={l.id}>{l.name}</li>
-                ))}
-              </ul>
-            ) : (
-              "All locales"
-            )}
-          </td>
-        </tr>
+        {isDesktop && (
+          <tr>
+            <th>Locales</th>
+            <td data-testid="experiment-locales">
+              {experiment.locales.length > 0 ? (
+                <ul className="list-unstyled mb-0">
+                  {experiment.locales.map((l) => (
+                    <li key={l.id}>{l.name}</li>
+                  ))}
+                </ul>
+              ) : (
+                "All locales"
+              )}
+            </td>
+          </tr>
+        )}
+        {!isDesktop && (
+          <tr>
+            <th>Languages</th>
+            <td data-testid="experiment-languages">
+              {experiment.languages.length > 0 ? (
+                <ul className="list-unstyled mb-0">
+                  {experiment.languages.map((l) => (
+                    <li key={l.id}>{l.name}</li>
+                  ))}
+                </ul>
+              ) : (
+                "All Languages"
+              )}
+            </td>
+          </tr>
+        )}
         <tr>
           <th>Countries</th>
           <td data-testid="experiment-countries">

--- a/app/experimenter/nimbus-ui/src/hooks/useCommonForm/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/hooks/useCommonForm/index.test.tsx
@@ -153,8 +153,10 @@ describe("hooks/useCommonForm", () => {
 
     it("FormAudience", () => {
       render(<AudienceSubject />);
-
-      audienceFieldNames.forEach((name) => {
+      const filteredAudienceFieldNames = audienceFieldNames.filter(
+        (e) => e !== "languages",
+      );
+      filteredAudienceFieldNames.forEach((name) => {
         expect(screen.queryByTestId(`${name}-form-errors`)).toBeInTheDocument();
         expect(screen.queryByTestId(name)).toBeInTheDocument();
       });

--- a/app/experimenter/nimbus-ui/src/lib/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/lib/mocks.tsx
@@ -546,6 +546,7 @@ export const MOCK_EXPERIMENT: Partial<getExperiment["experimentBySlug"]> = {
     "https://kinto.example.com/v1/admin/#/buckets/main-workspace/collections/nimbus-desktop-experiments/simple-review",
   locales: [{ name: "Quebecois", id: 1 }],
   countries: [{ name: "Canada", id: 1 }],
+  languages: [{ name: "English", id: 1 }],
 };
 
 export function mockExperiment<


### PR DESCRIPTION
Because

* Desktop Firefox uses a ‘locale’ to determine its language, and Experimenter includes a locale field to target desktop clients based on that locale/language.  However these locales do not match the locale/language codes used by mobile clients.  Rather than attempting to repurpose/mutate the locale field in Experimenter to support both desktop and mobile clients=> so now for the `Mobile Client`  we are enabling `languages` field 

Change
- Add the option to select languages  and remove option to select locales for mobile client
- Add the option to select locales  and remove option to select languages for Desktop client
- Show language field in summary if the application is Mobile, else show locales
- Test cases to support new changes

Refer to screenshot below to see new changes: 

For mobile client- Language field is enabled, and locale removed and user can choose option from dropdown
![image](https://user-images.githubusercontent.com/104033388/167213498-d5b4acb8-4fa0-4877-9ff2-c37df2034958.png)

Languages selected option for Mobile client
![image](https://user-images.githubusercontent.com/104033388/167213618-7701981e-2257-427c-97dc-57b3db7470a8.png)

If no language is selected, it will show All languages for mobile client
![image](https://user-images.githubusercontent.com/104033388/167213719-1bf88ab9-a12f-42da-a25b-8b496c9535b9.png)


For the desktop
![image](https://user-images.githubusercontent.com/104033388/167213864-88c6a34b-21f7-4b7b-90b2-35ccf800d6f9.png)

![image](https://user-images.githubusercontent.com/104033388/167213805-8761ea6f-5529-42df-9c20-d96b8be78ed7.png)


