### PR TITLE
fix #7275 bug(nimbus): remove required fields from feature schemas

### DIFF
--- a/app/experimenter/features/__init__.py
+++ b/app/experimenter/features/__init__.py
@@ -60,7 +60,6 @@ class Feature(BaseModel):
             "type": "object",
             "properties": {},
             "additionalProperties": False,
-            "required": [],
         }
 
         for variable_slug, variable in self.variables.items():
@@ -75,7 +74,6 @@ class Feature(BaseModel):
                 variable_schema["enum"] = variable.enum
 
             schema["properties"][variable_slug] = variable_schema
-            schema["required"].append(variable_slug)
 
         return json.dumps(schema, indent=2)
 

--- a/app/experimenter/features/tests/test_features.py
+++ b/app/experimenter/features/tests/test_features.py
@@ -135,12 +135,6 @@ class TestFeatures(TestCase):
                     "jsonProperty": {"description": "Arbitrary JSON Property"},
                 },
                 "additionalProperties": False,
-                "required": [
-                    "stringEnumProperty",
-                    "boolProperty",
-                    "intProperty",
-                    "jsonProperty",
-                ],
             },
         )
 

--- a/app/experimenter/features/tests/test_load_feature_configs.py
+++ b/app/experimenter/features/tests/test_load_feature_configs.py
@@ -44,12 +44,6 @@ class TestLoadFeatureConfigs(TestCase):
                     "jsonProperty": {"description": "Arbitrary JSON Property"},
                 },
                 "additionalProperties": False,
-                "required": [
-                    "stringEnumProperty",
-                    "boolProperty",
-                    "intProperty",
-                    "jsonProperty",
-                ],
             },
         )
 
@@ -86,12 +80,6 @@ class TestLoadFeatureConfigs(TestCase):
                     "jsonProperty": {"description": "Arbitrary JSON Property"},
                 },
                 "additionalProperties": False,
-                "required": [
-                    "stringEnumProperty",
-                    "boolProperty",
-                    "intProperty",
-                    "jsonProperty",
-                ],
             },
         )
 


### PR DESCRIPTION
Because

* We recently increased the strictness of the auto generated feature value schemas to force all fields to be required
* Some variables are optional for some features
* Requiring all fields for features with some optional fields can lead to awkward errors

This commit

* Removes the required field list from the feature value schemas