### PR TITLE
Fixes #7281 chore(project): Add new google credentials to the setup instructions in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,13 @@ Check out the [🌩 **Nimbus Documentation Hub**](https://experimenter.info) or 
 	...
 	```
 
+1. Add Google credentials to your .env
+
+	```
+        GOOGLE_APPLICATION_CREDENTIALS=/tmp/keys/application_default_credentials.json
+        GOOGLE_ADC_FILE=~/.config/gcloud/application_default_credentials.json
+	```
+
 1. Run tests
 
         make check


### PR DESCRIPTION
Because...

* #7185 updated our google credentials
* these `.env` vars are used as the volume mount point for Docker

This commit...

* Updates the README setup instructions to include these credentials

