### PR TITLE
fix #7274 #7279 #7280 feat(nimbus): Download CSV report

### DIFF
--- a/app/experimenter/docs/openapi-schema.json
+++ b/app/experimenter/docs/openapi-schema.json
@@ -1338,6 +1338,31 @@
         ]
       }
     },
+    "/api/v5/csv/": {
+      "get": {
+        "operationId": "listNimbusExperiments",
+        "description": "",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "text/csv": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/NimbusExperimentCSV"
+                  }
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "tags": [
+          "api"
+        ]
+      }
+    },
     "/api/v6/experiments/": {
       "get": {
         "operationId": "listNimbusExperiments",
@@ -2901,6 +2926,52 @@
             "nullable": true
           }
         }
+      },
+      "NimbusExperimentCSV": {
+        "type": "object",
+        "properties": {
+          "launch_month": {
+            "type": "string",
+            "readOnly": true
+          },
+          "product_area": {
+            "type": "string"
+          },
+          "experiment_name": {
+            "type": "string"
+          },
+          "owner": {
+            "type": "string",
+            "readOnly": true
+          },
+          "start_date": {
+            "type": "string",
+            "readOnly": true
+          },
+          "enrollment_duration": {
+            "type": "string",
+            "readOnly": true
+          },
+          "end_date": {
+            "type": "string",
+            "readOnly": true
+          },
+          "monitoring_dashboard_url": {
+            "type": "string",
+            "readOnly": true
+          },
+          "rollout": {
+            "type": "boolean"
+          },
+          "hypothesis": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "product_area",
+          "experiment_name",
+          "rollout"
+        ]
       },
       "NimbusExperiment": {
         "type": "object",

--- a/app/experimenter/docs/openapi-schema.json
+++ b/app/experimenter/docs/openapi-schema.json
@@ -2941,10 +2941,8 @@
             "type": "string"
           },
           "feature_configs": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
+            "type": "string",
+            "readOnly": true
           },
           "owner": {
             "type": "string",
@@ -2976,7 +2974,6 @@
         "required": [
           "product_area",
           "experiment_name",
-          "feature_configs",
           "rollout"
         ]
       },

--- a/app/experimenter/docs/openapi-schema.json
+++ b/app/experimenter/docs/openapi-schema.json
@@ -2965,12 +2965,19 @@
           },
           "hypothesis": {
             "type": "string"
+          },
+          "feature_configs": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
           }
         },
         "required": [
           "product_area",
           "experiment_name",
-          "rollout"
+          "rollout",
+          "feature_configs"
         ]
       },
       "NimbusExperiment": {

--- a/app/experimenter/docs/openapi-schema.json
+++ b/app/experimenter/docs/openapi-schema.json
@@ -2940,6 +2940,12 @@
           "experiment_name": {
             "type": "string"
           },
+          "feature_configs": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
           "owner": {
             "type": "string",
             "readOnly": true
@@ -2965,19 +2971,13 @@
           },
           "hypothesis": {
             "type": "string"
-          },
-          "feature_configs": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
           }
         },
         "required": [
           "product_area",
           "experiment_name",
-          "rollout",
-          "feature_configs"
+          "feature_configs",
+          "rollout"
         ]
       },
       "NimbusExperiment": {

--- a/app/experimenter/docs/openapi-schema.json
+++ b/app/experimenter/docs/openapi-schema.json
@@ -1350,7 +1350,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/NimbusExperimentCSV"
+                    "$ref": "#/components/schemas/NimbusExperimentCsv"
                   }
                 }
               }
@@ -2927,7 +2927,7 @@
           }
         }
       },
-      "NimbusExperimentCSV": {
+      "NimbusExperimentCsv": {
         "type": "object",
         "properties": {
           "launch_month": {
@@ -2940,11 +2940,11 @@
           "experiment_name": {
             "type": "string"
           },
-          "feature_configs": {
+          "owner": {
             "type": "string",
             "readOnly": true
           },
-          "owner": {
+          "feature_configs": {
             "type": "string",
             "readOnly": true
           },

--- a/app/experimenter/docs/swagger-ui.html
+++ b/app/experimenter/docs/swagger-ui.html
@@ -1362,7 +1362,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/NimbusExperimentCSV"
+                    "$ref": "#/components/schemas/NimbusExperimentCsv"
                   }
                 }
               }
@@ -2939,7 +2939,7 @@
           }
         }
       },
-      "NimbusExperimentCSV": {
+      "NimbusExperimentCsv": {
         "type": "object",
         "properties": {
           "launch_month": {
@@ -2952,11 +2952,11 @@
           "experiment_name": {
             "type": "string"
           },
-          "feature_configs": {
+          "owner": {
             "type": "string",
             "readOnly": true
           },
-          "owner": {
+          "feature_configs": {
             "type": "string",
             "readOnly": true
           },

--- a/app/experimenter/docs/swagger-ui.html
+++ b/app/experimenter/docs/swagger-ui.html
@@ -1350,6 +1350,31 @@
         ]
       }
     },
+    "/api/v5/csv/": {
+      "get": {
+        "operationId": "listNimbusExperiments",
+        "description": "",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "text/csv": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/NimbusExperimentCSV"
+                  }
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "tags": [
+          "api"
+        ]
+      }
+    },
     "/api/v6/experiments/": {
       "get": {
         "operationId": "listNimbusExperiments",
@@ -2913,6 +2938,52 @@
             "nullable": true
           }
         }
+      },
+      "NimbusExperimentCSV": {
+        "type": "object",
+        "properties": {
+          "launch_month": {
+            "type": "string",
+            "readOnly": true
+          },
+          "product_area": {
+            "type": "string"
+          },
+          "experiment_name": {
+            "type": "string"
+          },
+          "owner": {
+            "type": "string",
+            "readOnly": true
+          },
+          "start_date": {
+            "type": "string",
+            "readOnly": true
+          },
+          "enrollment_duration": {
+            "type": "string",
+            "readOnly": true
+          },
+          "end_date": {
+            "type": "string",
+            "readOnly": true
+          },
+          "monitoring_dashboard_url": {
+            "type": "string",
+            "readOnly": true
+          },
+          "rollout": {
+            "type": "boolean"
+          },
+          "hypothesis": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "product_area",
+          "experiment_name",
+          "rollout"
+        ]
       },
       "NimbusExperiment": {
         "type": "object",

--- a/app/experimenter/docs/swagger-ui.html
+++ b/app/experimenter/docs/swagger-ui.html
@@ -2952,6 +2952,12 @@
           "experiment_name": {
             "type": "string"
           },
+          "feature_configs": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
           "owner": {
             "type": "string",
             "readOnly": true
@@ -2977,19 +2983,13 @@
           },
           "hypothesis": {
             "type": "string"
-          },
-          "feature_configs": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
           }
         },
         "required": [
           "product_area",
           "experiment_name",
-          "rollout",
-          "feature_configs"
+          "feature_configs",
+          "rollout"
         ]
       },
       "NimbusExperiment": {

--- a/app/experimenter/docs/swagger-ui.html
+++ b/app/experimenter/docs/swagger-ui.html
@@ -2953,10 +2953,8 @@
             "type": "string"
           },
           "feature_configs": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
+            "type": "string",
+            "readOnly": true
           },
           "owner": {
             "type": "string",
@@ -2988,7 +2986,6 @@
         "required": [
           "product_area",
           "experiment_name",
-          "feature_configs",
           "rollout"
         ]
       },

--- a/app/experimenter/docs/swagger-ui.html
+++ b/app/experimenter/docs/swagger-ui.html
@@ -2977,12 +2977,19 @@
           },
           "hypothesis": {
             "type": "string"
+          },
+          "feature_configs": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
           }
         },
         "required": [
           "product_area",
           "experiment_name",
-          "rollout"
+          "rollout",
+          "feature_configs"
         ]
       },
       "NimbusExperiment": {

--- a/app/experimenter/experiments/api/v5/serializers.py
+++ b/app/experimenter/experiments/api/v5/serializers.py
@@ -805,6 +805,7 @@ class NimbusExperimentCSVSerializer(
 
     rollout = serializers.BooleanField(source="is_rollout")
     owner = serializers.SlugRelatedField(read_only=True, slug_field="email")
+    feature_configs = serializers.StringRelatedField(many=True)
 
     class Meta:
         model = NimbusExperiment
@@ -812,6 +813,7 @@ class NimbusExperimentCSVSerializer(
             "launch_month",
             "product_area",
             "experiment_name",
+            "feature_configs",
             "owner",
             "start_date",
             "enrollment_duration",

--- a/app/experimenter/experiments/api/v5/serializers.py
+++ b/app/experimenter/experiments/api/v5/serializers.py
@@ -805,7 +805,7 @@ class NimbusExperimentCSVSerializer(
 
     rollout = serializers.BooleanField(source="is_rollout")
     owner = serializers.SlugRelatedField(read_only=True, slug_field="email")
-    feature_configs = serializers.StringRelatedField(many=True)
+    feature_configs = serializers.SerializerMethodField()
 
     class Meta:
         model = NimbusExperiment
@@ -822,6 +822,11 @@ class NimbusExperimentCSVSerializer(
             "rollout",
             "hypothesis",
         ]
+
+    def get_feature_configs(self, obj):
+        return ", ".join(
+            [feature.name for feature in obj.feature_configs.order_by("name")]
+        )
 
 
 class NimbusBranchScreenshotReviewSerializer(NimbusBranchScreenshotSerializer):

--- a/app/experimenter/experiments/api/v5/serializers.py
+++ b/app/experimenter/experiments/api/v5/serializers.py
@@ -579,15 +579,15 @@ class NimbusExperimentSerializer(
         self.should_call_preview_task = instance and (
             (
                 instance.status == NimbusExperiment.Status.DRAFT
-                and data.get("status") == NimbusExperiment.Status.PREVIEW
+                and (data and data.get("status") == NimbusExperiment.Status.PREVIEW)
             )
             or (
                 instance.status == NimbusExperiment.Status.PREVIEW
-                and data.get("status") == NimbusExperiment.Status.DRAFT
+                and (data and data.get("status") == NimbusExperiment.Status.DRAFT)
             )
         )
         self.should_call_push_task = (
-            data.get("publish_status") == NimbusExperiment.PublishStatus.APPROVED
+            data and data.get("publish_status") == NimbusExperiment.PublishStatus.APPROVED
         )
         super().__init__(instance=instance, data=data, **kwargs)
 
@@ -790,6 +790,36 @@ class NimbusExperimentSerializer(
             )
 
             return experiment
+
+
+class NimbusExperimentCSVSerializer(
+    NimbusExperimentBranchMixin,
+    NimbusStatusValidationMixin,
+    NimbusExperimentDocumentationLinkMixin,
+    ExperimentNameValidatorMixin,
+    serializers.ModelSerializer,
+):
+    experiment_name = serializers.CharField(source="name")
+
+    product_area = serializers.CharField(source="application")
+
+    rollout = serializers.BooleanField(source="is_rollout")
+    owner = serializers.SlugRelatedField(read_only=True, slug_field="email")
+
+    class Meta:
+        model = NimbusExperiment
+        fields = [
+            "launch_month",
+            "product_area",
+            "experiment_name",
+            "owner",
+            "start_date",
+            "enrollment_duration",
+            "end_date",
+            "monitoring_dashboard_url",
+            "rollout",
+            "hypothesis",
+        ]
 
 
 class NimbusBranchScreenshotReviewSerializer(NimbusBranchScreenshotSerializer):

--- a/app/experimenter/experiments/api/v5/serializers.py
+++ b/app/experimenter/experiments/api/v5/serializers.py
@@ -579,15 +579,15 @@ class NimbusExperimentSerializer(
         self.should_call_preview_task = instance and (
             (
                 instance.status == NimbusExperiment.Status.DRAFT
-                and (data and data.get("status") == NimbusExperiment.Status.PREVIEW)
+                and (data.get("status") == NimbusExperiment.Status.PREVIEW)
             )
             or (
                 instance.status == NimbusExperiment.Status.PREVIEW
-                and (data and data.get("status") == NimbusExperiment.Status.DRAFT)
+                and (data.get("status") == NimbusExperiment.Status.DRAFT)
             )
         )
         self.should_call_push_task = (
-            data and data.get("publish_status") == NimbusExperiment.PublishStatus.APPROVED
+            data.get("publish_status") == NimbusExperiment.PublishStatus.APPROVED
         )
         super().__init__(instance=instance, data=data, **kwargs)
 

--- a/app/experimenter/experiments/api/v5/serializers.py
+++ b/app/experimenter/experiments/api/v5/serializers.py
@@ -792,7 +792,7 @@ class NimbusExperimentSerializer(
             return experiment
 
 
-class NimbusExperimentCSVSerializer(
+class NimbusExperimentCsvSerializer(
     NimbusExperimentBranchMixin,
     NimbusStatusValidationMixin,
     NimbusExperimentDocumentationLinkMixin,
@@ -813,8 +813,8 @@ class NimbusExperimentCSVSerializer(
             "launch_month",
             "product_area",
             "experiment_name",
-            "feature_configs",
             "owner",
+            "feature_configs",
             "start_date",
             "enrollment_duration",
             "end_date",

--- a/app/experimenter/experiments/api/v5/serializers.py
+++ b/app/experimenter/experiments/api/v5/serializers.py
@@ -792,13 +792,7 @@ class NimbusExperimentSerializer(
             return experiment
 
 
-class NimbusExperimentCsvSerializer(
-    NimbusExperimentBranchMixin,
-    NimbusStatusValidationMixin,
-    NimbusExperimentDocumentationLinkMixin,
-    ExperimentNameValidatorMixin,
-    serializers.ModelSerializer,
-):
+class NimbusExperimentCsvSerializer(serializers.ModelSerializer):
     experiment_name = serializers.CharField(source="name")
 
     product_area = serializers.CharField(source="application")

--- a/app/experimenter/experiments/api/v5/urls.py
+++ b/app/experimenter/experiments/api/v5/urls.py
@@ -2,10 +2,17 @@ from django.conf.urls import url
 from django.views.decorators.csrf import csrf_exempt
 from graphene_file_upload.django import FileUploadGraphQLView
 
+from experimenter.experiments.api.v5.views import NimbusExperimentCSVListView
+
 urlpatterns = [
     url(
         r"graphql",
         csrf_exempt(FileUploadGraphQLView.as_view(graphiql=True)),
         name="nimbus-api-graphql",
+    ),
+    url(
+        r"^csv/$",
+        NimbusExperimentCSVListView.as_view(),
+        name="nimbus-experiments-api-csv",
     ),
 ]

--- a/app/experimenter/experiments/api/v5/urls.py
+++ b/app/experimenter/experiments/api/v5/urls.py
@@ -2,7 +2,7 @@ from django.conf.urls import url
 from django.views.decorators.csrf import csrf_exempt
 from graphene_file_upload.django import FileUploadGraphQLView
 
-from experimenter.experiments.api.v5.views import NimbusExperimentCSVListView
+from experimenter.experiments.api.v5.views import NimbusExperimentCsvListView
 
 urlpatterns = [
     url(
@@ -12,7 +12,7 @@ urlpatterns = [
     ),
     url(
         r"^csv/$",
-        NimbusExperimentCSVListView.as_view(),
-        name="nimbus-experiments-api-csv",
+        NimbusExperimentCsvListView.as_view(),
+        name="nimbus-experiments-csv",
     ),
 ]

--- a/app/experimenter/experiments/api/v5/views.py
+++ b/app/experimenter/experiments/api/v5/views.py
@@ -1,17 +1,17 @@
 from rest_framework.generics import ListAPIView
 from rest_framework_csv.renderers import CSVRenderer
 
-from experimenter.experiments.api.v5.serializers import NimbusExperimentCSVSerializer
+from experimenter.experiments.api.v5.serializers import NimbusExperimentCsvSerializer
 from experimenter.experiments.models.nimbus import NimbusExperiment
 
 
-class NimbusExperimentCSVRenderer(CSVRenderer):
-    header = NimbusExperimentCSVSerializer.Meta.fields
+class NimbusExperimentCsvRenderer(CSVRenderer):
+    header = NimbusExperimentCsvSerializer.Meta.fields
     labels = dict(((field, field.replace("_", " ").title()) for field in header))
 
 
-class NimbusExperimentCSVListView(ListAPIView):
+class NimbusExperimentCsvListView(ListAPIView):
     queryset = NimbusExperiment.objects.all()
-    serializer_class = NimbusExperimentCSVSerializer
+    serializer_class = NimbusExperimentCsvSerializer
 
-    renderer_classes = (NimbusExperimentCSVRenderer,)
+    renderer_classes = (NimbusExperimentCsvRenderer,)

--- a/app/experimenter/experiments/api/v5/views.py
+++ b/app/experimenter/experiments/api/v5/views.py
@@ -1,0 +1,17 @@
+from rest_framework.generics import ListAPIView
+from rest_framework_csv.renderers import CSVRenderer
+
+from experimenter.experiments.api.v5.serializers import NimbusExperimentCSVSerializer
+from experimenter.experiments.models.nimbus import NimbusExperiment
+
+
+class NimbusExperimentCSVRenderer(CSVRenderer):
+    header = NimbusExperimentCSVSerializer.Meta.fields
+    labels = dict(((field, field.replace("_", " ").title()) for field in header))
+
+
+class NimbusExperimentCSVListView(ListAPIView):
+    queryset = NimbusExperiment.objects.all()
+    serializer_class = NimbusExperimentCSVSerializer
+
+    renderer_classes = (NimbusExperimentCSVRenderer,)

--- a/app/experimenter/experiments/models/nimbus.py
+++ b/app/experimenter/experiments/models/nimbus.py
@@ -349,6 +349,11 @@ class NimbusExperiment(NimbusConstants, FilterMixin, models.Model):
             ].changed_on.date()
 
     @property
+    def launch_month(self):
+        if self.start_date:
+            return self.start_date.strftime("%B")
+
+    @property
     def end_date(self):
         changes = self.changes.all()
         end_changelogs = [
@@ -391,6 +396,17 @@ class NimbusExperiment(NimbusConstants, FilterMixin, models.Model):
             return self.end_date
         else:
             return self.proposed_end_date
+
+    @property
+    def enrollment_duration(self):
+        if self.start_date:
+            return (
+                self.start_date.strftime("%Y-%m-%d")
+                + " to "
+                + self.computed_end_date.strftime("%Y-%m-%d")
+            )
+        else:
+            return self.proposed_duration
 
     @property
     def computed_duration_days(self):

--- a/app/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_experiment_csv_serializer.py
+++ b/app/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_experiment_csv_serializer.py
@@ -1,0 +1,34 @@
+from django.test import TestCase
+
+from experimenter.experiments.api.v5.serializers import NimbusExperimentCSVSerializer
+from experimenter.experiments.constants.nimbus import NimbusConstants
+from experimenter.experiments.tests.factories.nimbus import (
+    NimbusExperimentFactory,
+    NimbusFeatureConfigFactory,
+)
+
+
+class TestNimbusExperiment_Csv_Serializer(TestCase):
+    def test_serializer_outputs_expected_schema(self):
+        application = NimbusConstants.Application.DESKTOP
+        feature_config = NimbusFeatureConfigFactory.create(application=application)
+        experiment = NimbusExperimentFactory.create(
+            application=application, feature_configs=[feature_config]
+        )
+        serializer = NimbusExperimentCSVSerializer(experiment)
+        print(serializer)
+        self.assertDictEqual(
+            serializer.data,
+            {
+                "launch_month": experiment.launch_month,
+                "product_area": experiment.application.value,
+                "experiment_name": experiment.name,
+                "owner": experiment.owner.email,
+                "start_date": experiment.start_date,
+                "enrollment_duration": experiment.enrollment_duration,
+                "end_date": experiment.end_date,
+                "monitoring_dashboard_url": experiment.monitoring_dashboard_url,
+                "rollout": experiment.is_rollout,
+                "hypothesis": experiment.hypothesis,
+            },
+        )

--- a/app/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_experiment_csv_serializer.py
+++ b/app/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_experiment_csv_serializer.py
@@ -12,9 +12,9 @@ class TestNimbusExperiment_Csv_Serializer(TestCase):
     def test_serializer_outputs_expected_schema(self):
         application = NimbusConstants.Application.DESKTOP
         feature_config = NimbusFeatureConfigFactory.create(application=application)
-        feature_config2 = NimbusFeatureConfigFactory.create(application=application)
+
         experiment = NimbusExperimentFactory.create(
-            application=application, feature_configs=[feature_config, feature_config2]
+            application=application, feature_configs=[feature_config]
         )
         serializer = NimbusExperimentCSVSerializer(experiment)
         self.assertDictEqual(
@@ -23,9 +23,7 @@ class TestNimbusExperiment_Csv_Serializer(TestCase):
                 "launch_month": experiment.launch_month,
                 "product_area": experiment.application.value,
                 "experiment_name": experiment.name,
-                "feature_configs": ", ".join(
-                    [getattr(feature_config2, "name"), getattr(feature_config, "name")]
-                ),
+                "feature_configs": getattr(feature_config, "name"),
                 "owner": experiment.owner.email,
                 "start_date": experiment.start_date,
                 "enrollment_duration": experiment.enrollment_duration,

--- a/app/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_experiment_csv_serializer.py
+++ b/app/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_experiment_csv_serializer.py
@@ -1,6 +1,6 @@
 from django.test import TestCase
 
-from experimenter.experiments.api.v5.serializers import NimbusExperimentCSVSerializer
+from experimenter.experiments.api.v5.serializers import NimbusExperimentCsvSerializer
 from experimenter.experiments.constants.nimbus import NimbusConstants
 from experimenter.experiments.tests.factories.nimbus import (
     NimbusExperimentFactory,
@@ -8,7 +8,7 @@ from experimenter.experiments.tests.factories.nimbus import (
 )
 
 
-class TestNimbusExperiment_Csv_Serializer(TestCase):
+class TestNimbusExperimentCsvSerializer(TestCase):
     def test_serializer_outputs_expected_schema(self):
         application = NimbusConstants.Application.DESKTOP
         feature_config = NimbusFeatureConfigFactory.create(application=application)
@@ -16,15 +16,15 @@ class TestNimbusExperiment_Csv_Serializer(TestCase):
         experiment = NimbusExperimentFactory.create(
             application=application, feature_configs=[feature_config]
         )
-        serializer = NimbusExperimentCSVSerializer(experiment)
+        serializer = NimbusExperimentCsvSerializer(experiment)
         self.assertDictEqual(
             serializer.data,
             {
                 "launch_month": experiment.launch_month,
                 "product_area": experiment.application.value,
                 "experiment_name": experiment.name,
-                "feature_configs": getattr(feature_config, "name"),
                 "owner": experiment.owner.email,
+                "feature_configs": getattr(feature_config, "name"),
                 "start_date": experiment.start_date,
                 "enrollment_duration": experiment.enrollment_duration,
                 "end_date": experiment.end_date,

--- a/app/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_experiment_csv_serializer.py
+++ b/app/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_experiment_csv_serializer.py
@@ -16,7 +16,6 @@ class TestNimbusExperiment_Csv_Serializer(TestCase):
             application=application, feature_configs=[feature_config]
         )
         serializer = NimbusExperimentCSVSerializer(experiment)
-        print(serializer)
         self.assertDictEqual(
             serializer.data,
             {

--- a/app/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_experiment_csv_serializer.py
+++ b/app/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_experiment_csv_serializer.py
@@ -22,6 +22,7 @@ class TestNimbusExperiment_Csv_Serializer(TestCase):
                 "launch_month": experiment.launch_month,
                 "product_area": experiment.application.value,
                 "experiment_name": experiment.name,
+                "feature_configs": [getattr(feature_config, "name")],
                 "owner": experiment.owner.email,
                 "start_date": experiment.start_date,
                 "enrollment_duration": experiment.enrollment_duration,

--- a/app/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_experiment_csv_serializer.py
+++ b/app/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_experiment_csv_serializer.py
@@ -12,8 +12,9 @@ class TestNimbusExperiment_Csv_Serializer(TestCase):
     def test_serializer_outputs_expected_schema(self):
         application = NimbusConstants.Application.DESKTOP
         feature_config = NimbusFeatureConfigFactory.create(application=application)
+        feature_config2 = NimbusFeatureConfigFactory.create(application=application)
         experiment = NimbusExperimentFactory.create(
-            application=application, feature_configs=[feature_config]
+            application=application, feature_configs=[feature_config, feature_config2]
         )
         serializer = NimbusExperimentCSVSerializer(experiment)
         self.assertDictEqual(
@@ -22,7 +23,9 @@ class TestNimbusExperiment_Csv_Serializer(TestCase):
                 "launch_month": experiment.launch_month,
                 "product_area": experiment.application.value,
                 "experiment_name": experiment.name,
-                "feature_configs": [getattr(feature_config, "name")],
+                "feature_configs": ", ".join(
+                    [getattr(feature_config2, "name"), getattr(feature_config, "name")]
+                ),
                 "owner": experiment.owner.email,
                 "start_date": experiment.start_date,
                 "enrollment_duration": experiment.enrollment_duration,

--- a/app/experimenter/experiments/tests/api/v5/test_views.py
+++ b/app/experimenter/experiments/tests/api/v5/test_views.py
@@ -1,0 +1,37 @@
+from django.conf import settings
+from django.test import TestCase
+from django.urls import reverse
+
+from experimenter.experiments.api.v5.serializers import NimbusExperimentCSVSerializer
+from experimenter.experiments.api.v5.views import NimbusExperimentCSVRenderer
+from experimenter.experiments.constants.nimbus import NimbusConstants
+from experimenter.experiments.tests.factories.nimbus import (
+    NimbusExperimentFactory,
+    NimbusFeatureConfigFactory,
+)
+
+
+class TestNimbusExperimentCSVListView(TestCase):
+    def test_get_returns_csv_info(self):
+        user_email = "user@example.com"
+        application = NimbusConstants.Application.DESKTOP
+        feature_config = NimbusFeatureConfigFactory.create(application=application)
+        experiment_1 = NimbusExperimentFactory.create(
+            application=application, feature_configs=[feature_config]
+        )
+        experiment_2 = NimbusExperimentFactory.create(
+            application=application, feature_configs=[feature_config]
+        )
+        response = self.client.get(
+            reverse("nimbus-experiments-api-csv"),
+            **{settings.OPENIDC_EMAIL_HEADER: user_email},
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+        csv_data = response.content
+        expected_csv_data = NimbusExperimentCSVRenderer().render(
+            NimbusExperimentCSVSerializer([experiment_1, experiment_2], many=True).data,
+            renderer_context={"header": NimbusExperimentCSVSerializer.Meta.fields},
+        )
+        self.assertEqual(csv_data, expected_csv_data)

--- a/app/experimenter/experiments/tests/api/v5/test_views.py
+++ b/app/experimenter/experiments/tests/api/v5/test_views.py
@@ -2,8 +2,8 @@ from django.conf import settings
 from django.test import TestCase
 from django.urls import reverse
 
-from experimenter.experiments.api.v5.serializers import NimbusExperimentCSVSerializer
-from experimenter.experiments.api.v5.views import NimbusExperimentCSVRenderer
+from experimenter.experiments.api.v5.serializers import NimbusExperimentCsvSerializer
+from experimenter.experiments.api.v5.views import NimbusExperimentCsvRenderer
 from experimenter.experiments.constants.nimbus import NimbusConstants
 from experimenter.experiments.tests.factories.nimbus import (
     NimbusExperimentFactory,
@@ -11,7 +11,7 @@ from experimenter.experiments.tests.factories.nimbus import (
 )
 
 
-class TestNimbusExperimentCSVListView(TestCase):
+class TestNimbusExperimentCsvListView(TestCase):
     def test_get_returns_csv_info(self):
         user_email = "user@example.com"
         application = NimbusConstants.Application.DESKTOP
@@ -23,15 +23,15 @@ class TestNimbusExperimentCSVListView(TestCase):
             application=application, feature_configs=[feature_config]
         )
         response = self.client.get(
-            reverse("nimbus-experiments-api-csv"),
+            reverse("nimbus-experiments-csv"),
             **{settings.OPENIDC_EMAIL_HEADER: user_email},
         )
 
         self.assertEqual(response.status_code, 200)
 
         csv_data = response.content
-        expected_csv_data = NimbusExperimentCSVRenderer().render(
-            NimbusExperimentCSVSerializer([experiment_1, experiment_2], many=True).data,
-            renderer_context={"header": NimbusExperimentCSVSerializer.Meta.fields},
+        expected_csv_data = NimbusExperimentCsvRenderer().render(
+            NimbusExperimentCsvSerializer([experiment_1, experiment_2], many=True).data,
+            renderer_context={"header": NimbusExperimentCsvSerializer.Meta.fields},
         )
         self.assertEqual(csv_data, expected_csv_data)


### PR DESCRIPTION
Because

* We want data of the experiments to be exported in CSV file

This commit

* Add new API endpoint `api/v5/csv` and it will return csv file which includes the following fields
```json
            "launch_month",
            "product_area",
            "experiment_name",
            "owner",
            "feature_configs",
            "start_date",
            "enrollment_duration",
            "end_date",
            "monitoring_dashboard_url",
            "rollout",
            "hypothesis",
```
* Adds the test cases to validate new changes

Sample csv generated file:
<img width="972" alt="image" src="https://user-images.githubusercontent.com/104033388/169405131-0ec727f0-9fae-4254-b229-25b16f4c1e79.png">

closes #7279 #7280 