### PR TITLE
fixes #7294 fix(project): ignore parent during experiment import/export

### DIFF
--- a/app/experimenter/experiments/admin/nimbus.py
+++ b/app/experimenter/experiments/admin/nimbus.py
@@ -75,7 +75,7 @@ class NimbusExperimentResource(resources.ModelResource):
 
     class Meta:
         model = NimbusExperiment
-        exclude = ("id", "reference_branch")
+        exclude = ("id", "reference_branch", "parent")
         import_id_fields = ("slug",)
 
     def dehydrate_changes(self, experiment):


### PR DESCRIPTION
Because

* import fails if the parent experiment is defined and does not exist in the import environment
* the parent experiment is not important for our import/export use cases

This commit

* ignores the `parent` field on the experiment during export/import