### PR TITLE
fix #7351 chore(project): add make command for gcloud auth

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,10 @@ nginx/cert.pem: nginx/key.pem
 secretkey:
 	openssl rand -hex 24
 
+auth:
+	gcloud auth login
+	gcloud auth application-default login
+
 jetstream_config:
 	curl -LJ -o app/experimenter/outcomes/jetstream-config.zip $(JETSTREAM_CONFIG_URL)
 	unzip -o -d app/experimenter/outcomes app/experimenter/outcomes/jetstream-config.zip

--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ nginx/cert.pem: nginx/key.pem
 secretkey:
 	openssl rand -hex 24
 
-auth:
+auth_gcloud:
 	gcloud auth login
 	gcloud auth application-default login
 

--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ On certain pages an API endpoint is called to receive experiment analysis data f
       - If needed, ask in `#nimbus-dev` for a project admin to grant `storage.objects.list` permissions on the `moz-fx-data-experiments` project
 
 1. Authorize CLI with your account
-    - `make auth`
+    - `make auth_gcloud`
       - this will save your credentials locally to a well-known location for use by any library that requests ADC
       - **Note**: if this returns `Error saving Application Default Credentials: Unable to write file [...]: [Errno 21] Is a directory: ...`, delete the directory and try again (`rm -rf ~/.config/gcloud`)
 

--- a/README.md
+++ b/README.md
@@ -197,8 +197,7 @@ On certain pages an API endpoint is called to receive experiment analysis data f
       - If needed, ask in `#nimbus-dev` for a project admin to grant `storage.objects.list` permissions on the `moz-fx-data-experiments` project
 
 1. Authorize CLI with your account
-    - `gcloud auth login`
-    - `gcloud auth application-default login`
+    - `make auth`
       - this will save your credentials locally to a well-known location for use by any library that requests ADC
       - **Note**: if this returns `Error saving Application Default Credentials: Unable to write file [...]: [Errno 21] Is a directory: ...`, delete the directory and try again (`rm -rf ~/.config/gcloud`)
 


### PR DESCRIPTION
Because

* certain local dev requires authenticating to GCP
* GCP expires authentication periodically

This commit

* adds a helpful `make auth` command to run the required commands


**TESTING INFO**
- Follow [Google Credentials for Jetstream](https://github.com/mozilla/experimenter/blob/620d3a59dbd8ed04e8d90ff77334cc29ba2a29a1/README.md#google-credentials-for-jetstream) in the README