### PR TITLE
fix #7362 feat(nimbus): filter archived experiments

### DIFF
--- a/app/experimenter/experiments/api/v5/views.py
+++ b/app/experimenter/experiments/api/v5/views.py
@@ -12,14 +12,20 @@ class NimbusExperimentCsvRenderer(CSVRenderer):
 
 class NimbusExperimentCsvListView(ListAPIView):
 
-    queryset = NimbusExperiment.objects.select_related("owner").prefetch_related(
-        "feature_configs", "changes"
+    queryset = (
+        NimbusExperiment.objects.select_related("owner")
+        .prefetch_related("feature_configs", "changes")
+        .filter(is_archived=False)
     )
 
     def get_queryset(self):
         return sorted(
             super().get_queryset(),
-            key=lambda experiment: str(experiment.start_date) or "",
+            key=lambda experiment: (
+                experiment.start_date and experiment.start_date.strftime("%Y-%m-%d")
+            )
+            or "",
+            reverse=True,
         )
 
     serializer_class = NimbusExperimentCsvSerializer


### PR DESCRIPTION
Because

    We want to see experiments that are not archived

This commit

-     Modifies the query to get non-archived experiments
-     Test to verify new changes

fixes #7362 