### PR TITLE
fix #7377 feat(legacy): remove create delivery button

### DIFF
--- a/app/experimenter/legacy/legacy-ui/templates/experiments/list.html
+++ b/app/experimenter/legacy/legacy-ui/templates/experiments/list.html
@@ -66,17 +66,6 @@
   <a href="{% url "experiments-api-csv" %}?{{ request.GET.urlencode }}"><i class="fas fa-file-csv"></i> Export as CSV</a>
 {% endblock %}
 
-{% block header_sidebar %}
-  <div class="row">
-    <div class="col">
-      <a class="col btn btn-primary" href="{% url "experiments-create" %}">
-        <span class="fas fa-edit"></span>
-        Create Delivery
-      </a>
-    </div>
-  </div>
-{% endblock %}
-
 {% block main_content %}
   {% for experiment in experiments %}
     <a class="noanchorstyle hovershadow" href="{% url "experiments-detail" slug=experiment.slug %}">


### PR DESCRIPTION
Because

* We continue to transition away from Normandy towards Nimbus
* Any new experiment/rollout should be launched with Nimbus
* Any delivery that requires Normandy support can be created without needing Experimenter

This commit

* Removes the Create Delivery button in the Legacy UI

![Screenshot 2022-06-08 at 11-02-49 Mozilla Experimenter](https://user-images.githubusercontent.com/119884/172651715-192eba5d-bf2c-4e17-b04c-eacd0a369279.png)

