### PR TITLE
fix #7380 feat(project): nimbus default landing page

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/PageHome/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageHome/index.tsx
@@ -153,6 +153,14 @@ const PageHome: React.FunctionComponent<PageHomeProps> = () => {
         .
       </Alert>
 
+      <Alert variant="warning" className="mb-4">
+        <span role="img" aria-label="magnifying emoji">
+          🔍
+        </span>{" "}
+        Looking for the old Experimenter?{" "}
+        <LinkExternal href="/legacy">It&lsquo;s still here!</LinkExternal>
+      </Alert>
+
       <Body />
     </AppLayout>
   );

--- a/app/experimenter/urls.py
+++ b/app/experimenter/urls.py
@@ -2,6 +2,7 @@ from django.conf import settings
 from django.conf.urls import include, re_path
 from django.conf.urls.static import static
 from django.contrib import admin
+from django.views.generic.base import RedirectView
 
 from experimenter.legacy.legacy_experiments.views import (
     ExperimentListView,
@@ -25,7 +26,12 @@ urlpatterns = [
     re_path(r"^experiments/", include("experimenter.legacy.legacy_experiments.urls")),
     re_path(r"^nimbus/", NimbusUIView.as_view(), name="nimbus-list"),
     re_path(r"^nimbus/(?P<slug>[\w-]+)/", NimbusUIView.as_view(), name="nimbus-detail"),
-    re_path(r"^$", ExperimentListView.as_view(), name="home"),
+    re_path(r"^legacy/$", ExperimentListView.as_view(), name="home"),
+    re_path(
+        r"^$",
+        RedirectView.as_view(pattern_name="nimbus-list"),
+        name="redirect-to-nimbus",
+    ),
 ]
 
 handler404 = PageNotFoundView.as_404_view()


### PR DESCRIPTION
Because

* We continue to transition away from Normandy towards Nimbus
* All new experiments/rollouts should be launched with Nimbus
* We are disabling the ability to launch Normandy deliveries in the Legacy UI

This commit

* Makes Nimbus the new default landing page
* Adds a link back to legacy in the Nimbus UI

<img width="1224" alt="Screen Shot 2022-06-08 at 11 22 53 AM" src="https://user-images.githubusercontent.com/119884/172656797-f00a7c04-8a4e-4f90-b143-863ccadef8c7.png">

