### PR TITLE
fix #7382 chore(nimbus): update no-feature-firefox-desktop in integration tests

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/index.tsx
@@ -222,7 +222,7 @@ export const FormBranches = ({
                   >
                     {feature.name}
                     {feature.description?.length
-                      ? `- ${feature.description}`
+                      ? ` - ${feature.description}`
                       : ""}
                   </option>
                 ),

--- a/app/tests/integration/nimbus/conftest.py
+++ b/app/tests/integration/nimbus/conftest.py
@@ -20,12 +20,12 @@ from nimbus.pages.experimenter.home import HomePage
 from requests.adapters import HTTPAdapter
 from requests.packages.urllib3.util.retry import Retry
 
-APPLICATION_FEATURES = {
-    BaseExperimentApplications.DESKTOP: "No Feature Firefox Desktop",
-    BaseExperimentApplications.FENIX: "No Feature Fenix",
-    BaseExperimentApplications.IOS: "No Feature iOS",
-    BaseExperimentApplications.FOCUS_ANDROID: "No Feature Focus for Android",
-    BaseExperimentApplications.FOCUS_IOS: "No Feature Focus for iOS",
+APPLICATION_FEATURE_IDS = {
+    BaseExperimentApplications.DESKTOP: "1",
+    BaseExperimentApplications.FENIX: "2",
+    BaseExperimentApplications.IOS: "3",
+    BaseExperimentApplications.FOCUS_ANDROID: "4",
+    BaseExperimentApplications.FOCUS_IOS: "6",
 }
 
 APPLICATION_KINTO_REVIEW_PATH = {
@@ -133,14 +133,14 @@ def experiment_name(request):
 )
 def default_data(request, experiment_name):
     application = request.param
-    feature_config = APPLICATION_FEATURES[application]
+    feature_config_id = APPLICATION_FEATURE_IDS[application]
 
     return BaseExperimentDataClass(
         public_name=experiment_name,
         hypothesis="smart stuff here",
         application=application,
         public_description="description stuff",
-        feature_config=feature_config,
+        feature_config_id=feature_config_id,
         branches=[
             BaseExperimentBranchDataClass(
                 name="control",
@@ -184,11 +184,11 @@ def create_experiment(base_url, default_data):
 
         # Fill Branches page
         branches = overview.save_and_continue()
-        branches.feature_config = default_data.feature_config
+        branches.feature_config = default_data.feature_config_id
         branches.reference_branch_description = default_data.branches[0].description
-        branches.treatment_branch_description = default_data.branches[0].description
+        branches.treatment_branch_description = default_data.branches[1].description
         branches.treatment_branch_enabled.click()
-        branches.treatment_branch_value = '{"value": true}'
+        branches.treatment_branch_value = "{}"
 
         # Fill Metrics page
         metrics = branches.save_and_continue()

--- a/app/tests/integration/nimbus/models/base_dataclass.py
+++ b/app/tests/integration/nimbus/models/base_dataclass.py
@@ -50,4 +50,4 @@ class BaseExperimentDataClass:
     branches: Optional[List[BaseExperimentBranchDataClass]]
     metrics: BaseExperimentMetricsDataClass
     audience: BaseExperimentAudienceDataClass
-    feature_config: str
+    feature_config_id: str

--- a/app/tests/integration/nimbus/pages/experimenter/branches.py
+++ b/app/tests/integration/nimbus/pages/experimenter/branches.py
@@ -110,12 +110,12 @@ class BranchesPage(ExperimenterBase):
         ).text
 
     @feature_config.setter
-    def feature_config(self, feature_config="No Feature Firefox Desktop"):
+    def feature_config(self, feature_config_id):
         el = self.wait_for_and_find_element(
             self._feature_select_locator, "feature_config"
         )
         select = Select(el)
-        select.select_by_visible_text(feature_config)
+        select.select_by_value(feature_config_id)
 
     @property
     def add_screenshot_buttons(self):


### PR DESCRIPTION
Because

* We moved the No Feature Firefox Desktop into the desktop feature manifest
* It now appears as no-feature-firefox-desktop in the feature drop down
* Unfortunately this string seems to confuse or break the select value method

This commit

* Updates the integration tests to use the feature id instead of the name
* The ids are set in database fixtures so they should be stable across test runs