### PR TITLE
fix #7152 feat(nimbus): Prevent country targeting below min version supported

### DIFF
--- a/app/experimenter/experiments/api/v5/serializers.py
+++ b/app/experimenter/experiments/api/v5/serializers.py
@@ -1118,6 +1118,25 @@ class NimbusReviewSerializer(serializers.ModelSerializer):
                 )
         return data
 
+    def _validate_countries_versions(self, data):
+        application = data.get("application")
+        min_version = data.get("firefox_min_version", "")
+
+        countries = data.get("countries", [])
+
+        if countries:
+
+            min_supported_version = (
+                NimbusConstants.COUNTRIES_APPLICATION_SUPPORTED_VERSION[application]
+            )
+            if NimbusExperiment.Version.parse(
+                min_version
+            ) < NimbusExperiment.Version.parse(min_supported_version):
+                raise serializers.ValidationError(
+                    {"countries": "Countries are not supported for this version."}
+                )
+        return data
+
     def validate(self, data):
         application = data.get("application")
         channel = data.get("channel")
@@ -1131,6 +1150,7 @@ class NimbusReviewSerializer(serializers.ModelSerializer):
         data = self._validate_versions(data)
         if application != NimbusExperiment.Application.DESKTOP:
             data = self._validate_languages_versions(data)
+            data = self._validate_countries_versions(data)
         return data
 
 

--- a/app/experimenter/experiments/constants.py
+++ b/app/experimenter/experiments/constants.py
@@ -358,6 +358,13 @@ class NimbusConstants(object):
         Application.FOCUS_IOS: Version.FIREFOX_101,
     }
 
+    COUNTRIES_APPLICATION_SUPPORTED_VERSION = {
+        Application.FENIX: Version.FIREFOX_102,
+        Application.FOCUS_ANDROID: Version.FIREFOX_102,
+        Application.IOS: Version.FIREFOX_101,
+        Application.FOCUS_IOS: Version.FIREFOX_101,
+    }
+
     # Telemetry systems including Firefox Desktop Telemetry v4 and Glean
     # have limits on the length of their unique identifiers, we should
     # limit the size of our slugs to the smallest limit, which is 80

--- a/app/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_ready_for_review_serializer.py
+++ b/app/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_ready_for_review_serializer.py
@@ -445,7 +445,9 @@ class TestNimbusReviewSerializerSingleFeature(TestCase):
             ),
         ]
     )
-    def test_valid_experiments_with_all_countries(self, application, firefox_version):
+    def test_valid_experiments_with_country_unsupported_version(
+        self, application, firefox_version
+    ):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.CREATED,
             application=application,

--- a/app/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_ready_for_review_serializer.py
+++ b/app/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_ready_for_review_serializer.py
@@ -360,7 +360,7 @@ class TestNimbusReviewSerializerSingleFeature(TestCase):
             ),
         ]
     )
-    def test_valid_experiments_supporting_countries_versions_selecting_all_countires_default(
+    def test_valid_experiments_supporting_countries_versions_default_as_all_countries(
         self, application, firefox_version
     ):
 
@@ -369,6 +369,7 @@ class TestNimbusReviewSerializerSingleFeature(TestCase):
             application=application,
             channel=NimbusExperiment.Channel.RELEASE,
             firefox_min_version=firefox_version,
+            countries=[],
         )
 
         serializer_1 = NimbusReviewSerializer(

--- a/app/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_ready_for_review_serializer.py
+++ b/app/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_ready_for_review_serializer.py
@@ -370,7 +370,7 @@ class TestNimbusReviewSerializerSingleFeature(TestCase):
             channel=NimbusExperiment.Channel.RELEASE,
             firefox_min_version=firefox_version,
         )
-        experiment_1.save()
+
         serializer_1 = NimbusReviewSerializer(
             experiment_1,
             data=NimbusReviewSerializer(
@@ -389,7 +389,7 @@ class TestNimbusReviewSerializerSingleFeature(TestCase):
             firefox_min_version=firefox_version,
             countries=[country.id],
         )
-        experiment_2.save()
+
         serializer_2 = NimbusReviewSerializer(
             experiment_2,
             data=NimbusReviewSerializer(
@@ -427,7 +427,7 @@ class TestNimbusReviewSerializerSingleFeature(TestCase):
             channel=NimbusExperiment.Channel.RELEASE,
             firefox_min_version=firefox_version,
         )
-        experiment.save()
+
         serializer = NimbusReviewSerializer(
             experiment,
             data=NimbusReviewSerializer(
@@ -469,7 +469,7 @@ class TestNimbusReviewSerializerSingleFeature(TestCase):
             firefox_min_version=firefox_version,
             countries=[country.id],
         )
-        experiment.save()
+
         serializer = NimbusReviewSerializer(
             experiment,
             data=NimbusReviewSerializer(

--- a/app/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_ready_for_review_serializer.py
+++ b/app/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_ready_for_review_serializer.py
@@ -1,7 +1,7 @@
 from django.test import TestCase
 from parameterized import parameterized
 
-from experimenter.base.tests.factories import LanguageFactory
+from experimenter.base.tests.factories import CountryFactory, LanguageFactory
 from experimenter.experiments.api.v5.serializers import NimbusReviewSerializer
 from experimenter.experiments.constants import NimbusConstants
 from experimenter.experiments.models import NimbusExperiment
@@ -339,6 +339,148 @@ class TestNimbusReviewSerializerSingleFeature(TestCase):
         self.assertFalse(serializer.is_valid())
 
         self.assertIn("languages", serializer.errors)
+
+    @parameterized.expand(
+        [
+            (
+                NimbusExperiment.Application.FOCUS_ANDROID,
+                NimbusExperiment.Version.FIREFOX_102,
+            ),
+            (
+                NimbusExperiment.Application.FENIX,
+                NimbusExperiment.Version.FIREFOX_102,
+            ),
+            (
+                NimbusExperiment.Application.IOS,
+                NimbusExperiment.Version.FIREFOX_101,
+            ),
+            (
+                NimbusExperiment.Application.FOCUS_IOS,
+                NimbusExperiment.Version.FIREFOX_101,
+            ),
+        ]
+    )
+    def test_valid_experiments_supporting_countries_versions(
+        self, application, firefox_version
+    ):
+
+        experiment_1 = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            application=application,
+            channel=NimbusExperiment.Channel.RELEASE,
+            firefox_min_version=firefox_version,
+        )
+        experiment_1.save()
+        serializer_1 = NimbusReviewSerializer(
+            experiment_1,
+            data=NimbusReviewSerializer(
+                experiment_1,
+                context={"user": self.user},
+            ).data,
+            context={"user": self.user},
+        )
+        self.assertTrue(serializer_1.is_valid())
+        # selected countries
+        country = CountryFactory.create()
+        experiment_2 = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            application=application,
+            channel=NimbusExperiment.Channel.RELEASE,
+            firefox_min_version=firefox_version,
+            countries=[country.id],
+        )
+        experiment_2.save()
+        serializer_2 = NimbusReviewSerializer(
+            experiment_2,
+            data=NimbusReviewSerializer(
+                experiment_2,
+                context={"user": self.user},
+            ).data,
+            context={"user": self.user},
+        )
+        self.assertTrue(serializer_2.is_valid())
+
+    @parameterized.expand(
+        [
+            (
+                NimbusExperiment.Application.FOCUS_ANDROID,
+                NimbusExperiment.Version.FIREFOX_101,
+            ),
+            (
+                NimbusExperiment.Application.FENIX,
+                NimbusExperiment.Version.FIREFOX_101,
+            ),
+            (
+                NimbusExperiment.Application.IOS,
+                NimbusExperiment.Version.FIREFOX_100,
+            ),
+            (
+                NimbusExperiment.Application.FOCUS_IOS,
+                NimbusExperiment.Version.FIREFOX_100,
+            ),
+        ]
+    )
+    def test_valid_experiments_with_all_countries(self, application, firefox_version):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            application=application,
+            channel=NimbusExperiment.Channel.RELEASE,
+            firefox_min_version=firefox_version,
+        )
+        experiment.save()
+        serializer = NimbusReviewSerializer(
+            experiment,
+            data=NimbusReviewSerializer(
+                experiment,
+                context={"user": self.user},
+            ).data,
+            context={"user": self.user},
+        )
+        self.assertTrue(serializer.is_valid())
+
+    @parameterized.expand(
+        [
+            (
+                NimbusExperiment.Application.FOCUS_ANDROID,
+                NimbusExperiment.Version.FIREFOX_101,
+            ),
+            (
+                NimbusExperiment.Application.FENIX,
+                NimbusExperiment.Version.FIREFOX_101,
+            ),
+            (
+                NimbusExperiment.Application.IOS,
+                NimbusExperiment.Version.FIREFOX_100,
+            ),
+            (
+                NimbusExperiment.Application.FOCUS_IOS,
+                NimbusExperiment.Version.FIREFOX_100,
+            ),
+        ]
+    )
+    def test_invalid_experiments_with_specific_countries(
+        self, application, firefox_version
+    ):
+        country = CountryFactory.create()
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            application=application,
+            channel=NimbusExperiment.Channel.RELEASE,
+            firefox_min_version=firefox_version,
+            countries=[country.id],
+        )
+        experiment.save()
+        serializer = NimbusReviewSerializer(
+            experiment,
+            data=NimbusReviewSerializer(
+                experiment,
+                context={"user": self.user},
+            ).data,
+            context={"user": self.user},
+        )
+        self.assertFalse(serializer.is_valid())
+
+        self.assertIn("countries", serializer.errors)
 
     def test_alid_experiment_allows_min_version_equal_to_max_version(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(

--- a/app/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_ready_for_review_serializer.py
+++ b/app/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_ready_for_review_serializer.py
@@ -360,7 +360,7 @@ class TestNimbusReviewSerializerSingleFeature(TestCase):
             ),
         ]
     )
-    def test_valid_experiments_supporting_countries_versions(
+    def test_valid_experiments_supporting_countries_versions_selecting_all_countires_default(
         self, application, firefox_version
     ):
 
@@ -380,9 +380,33 @@ class TestNimbusReviewSerializerSingleFeature(TestCase):
             context={"user": self.user},
         )
         self.assertTrue(serializer_1.is_valid())
+
+    @parameterized.expand(
+        [
+            (
+                NimbusExperiment.Application.FOCUS_ANDROID,
+                NimbusExperiment.Version.FIREFOX_102,
+            ),
+            (
+                NimbusExperiment.Application.FENIX,
+                NimbusExperiment.Version.FIREFOX_102,
+            ),
+            (
+                NimbusExperiment.Application.IOS,
+                NimbusExperiment.Version.FIREFOX_101,
+            ),
+            (
+                NimbusExperiment.Application.FOCUS_IOS,
+                NimbusExperiment.Version.FIREFOX_101,
+            ),
+        ]
+    )
+    def test_valid_experiments_supporting_countries_versions_selecting_specific_country(
+        self, application, firefox_version
+    ):
         # selected countries
         country = CountryFactory.create()
-        experiment_2 = NimbusExperimentFactory.create_with_lifecycle(
+        experiment_1 = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.CREATED,
             application=application,
             channel=NimbusExperiment.Channel.RELEASE,
@@ -390,15 +414,15 @@ class TestNimbusReviewSerializerSingleFeature(TestCase):
             countries=[country.id],
         )
 
-        serializer_2 = NimbusReviewSerializer(
-            experiment_2,
+        serializer_1 = NimbusReviewSerializer(
+            experiment_1,
             data=NimbusReviewSerializer(
-                experiment_2,
+                experiment_1,
                 context={"user": self.user},
             ).data,
             context={"user": self.user},
         )
-        self.assertTrue(serializer_2.is_valid())
+        self.assertTrue(serializer_1.is_valid())
 
     @parameterized.expand(
         [

--- a/app/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_ready_for_review_serializer.py
+++ b/app/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_ready_for_review_serializer.py
@@ -451,6 +451,7 @@ class TestNimbusReviewSerializerSingleFeature(TestCase):
             application=application,
             channel=NimbusExperiment.Channel.RELEASE,
             firefox_min_version=firefox_version,
+            countries=[],
         )
 
         serializer = NimbusReviewSerializer(


### PR DESCRIPTION
Because

* We want to prevent launching experiments targeting countries below minimum supported versions
 

This commit

*  Add the minimum version required to support countries

          FENIX: FIREFOX_102,
          FOCUS_ANDROID: FIREFOX_102,
          IOS: FIREFOX_101,
          FOCUS_IOS: FIREFOX_101,

-     Validation in NimbusReviewSerializer to support country targeting
-     Test cases to support new changes

fixes #7152 