### PR TITLE
fix #7365 bug(nimbus): don't clone takeaways

### DIFF
--- a/app/experimenter/experiments/models.py
+++ b/app/experimenter/experiments/models.py
@@ -581,6 +581,8 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
         cloned.reference_branch = None
         cloned.published_dto = None
         cloned.results_data = None
+        cloned.takeaways_summary = None
+        cloned.conclusion_recommendation = None
         cloned.save()
 
         if rollout_branch_slug:

--- a/app/experimenter/experiments/tests/test_models.py
+++ b/app/experimenter/experiments/tests/test_models.py
@@ -1392,6 +1392,8 @@ class TestNimbusExperiment(TestCase):
             name="Parent Experiment",
             slug="parent-experiment",
             application=NimbusExperiment.Application.DESKTOP,
+            conclusion_recommendation="RERUN",
+            takeaways_summary="takeaway",
         )
         child = self._clone_experiment_and_assert_common_expectations(parent)
 
@@ -1428,6 +1430,8 @@ class TestNimbusExperiment(TestCase):
         self.assertEqual(child.countries.all().count(), 0)
         self.assertEqual(child.branches.all().count(), 0)
         self.assertEqual(child.changes.all().count(), 1)
+        self.assertIsNone(child.conclusion_recommendation)
+        self.assertIsNone(child.takeaways_summary)
 
     def test_clone_completed_experiment(self):
         parent = NimbusExperimentFactory.create_with_lifecycle(


### PR DESCRIPTION
Because

* Takeaways are always unique to an experiment
* They should never be cloned

This commit

* Sets takeaways to None when cloning