### PR TITLE
fix #7391 fix(nimbus): retrieve expected outcome metrics from jetstream and allow all stats types

### DIFF
--- a/app/experimenter/jetstream/client.py
+++ b/app/experimenter/jetstream/client.py
@@ -59,23 +59,19 @@ def get_results_metrics_map(
         )
     )
 
-    try:
-        valid_metrics = set(
-            chain.from_iterable(
-                [
-                    experiment_metadata["outcomes"][slug]["metrics"]
-                    + experiment_metadata["outcomes"][slug]["default_metrics"]
-                    for slug in experiment_metadata["outcomes"]
-                ]
-            )
+    metrics_set_from_jetstream = set(
+        chain.from_iterable(
+            [
+                experiment_metadata["outcomes"][slug]["metrics"]
+                + experiment_metadata["outcomes"][slug]["default_metrics"]
+                for slug in experiment_metadata["outcomes"]
+            ]
         )
-    except (TypeError, KeyError):
-        # could not retrieve metadata from Jetstream
-        valid_metrics = None
+    )
 
     for metric in primary_outcome_metrics:
         # validate against jetstream metadata unless we couldn't get it
-        if valid_metrics is None or metric.slug in valid_metrics:
+        if metric.slug in metrics_set_from_jetstream:
             RESULTS_METRICS_MAP[metric.slug] = set([Statistic.BINOMIAL])
             primary_metrics_set.add(metric.slug)
 

--- a/app/experimenter/jetstream/client.py
+++ b/app/experimenter/jetstream/client.py
@@ -18,6 +18,9 @@ from experimenter.outcomes import Outcomes
 BRANCH_DATA = "branch_data"
 STATISTICS_FOLDER = "statistics"
 METADATA_FOLDER = "metadata"
+ALL_STATISTICS = set(
+    [Statistic.BINOMIAL, Statistic.MEAN, Statistic.COUNT, Statistic.PERCENT]
+)
 
 
 def load_data_from_gcs(path):
@@ -59,8 +62,9 @@ def get_results_metrics_map(
         )
     )
 
+    bypass_jetstream_check = True
     if outcomes_metadata is not None:
-        BYPASS_JETSTREAM_CHECK = False
+        bypass_jetstream_check = False
         metrics_set_from_jetstream = set(
             chain.from_iterable(
                 [
@@ -70,21 +74,16 @@ def get_results_metrics_map(
                 ]
             )
         )
-    else:
-        BYPASS_JETSTREAM_CHECK = True
 
     for metric in primary_outcome_metrics:
         # validate against jetstream metadata unless we couldn't get it
-        if BYPASS_JETSTREAM_CHECK or metric.slug in metrics_set_from_jetstream:
-            RESULTS_METRICS_MAP[metric.slug] = set(
-                [Statistic.BINOMIAL, Statistic.MEAN, Statistic.COUNT, Statistic.PERCENT]
-            )
+        if bypass_jetstream_check or metric.slug in metrics_set_from_jetstream:
+            RESULTS_METRICS_MAP[metric.slug] = ALL_STATISTICS
+
             primary_metrics_set.add(metric.slug)
 
     for outcome_slug in secondary_outcome_slugs:
-        RESULTS_METRICS_MAP[outcome_slug] = set(
-            [Statistic.MEAN, Statistic.BINOMIAL, Statistic.COUNT, Statistic.PERCENT]
-        )
+        RESULTS_METRICS_MAP[outcome_slug] = ALL_STATISTICS
 
     other_metrics_map, other_metrics = get_other_metrics_names_and_map(
         data, RESULTS_METRICS_MAP

--- a/app/experimenter/jetstream/models.py
+++ b/app/experimenter/jetstream/models.py
@@ -198,7 +198,7 @@ class ResultsObjectModelBase(BaseModel):
             # For "overall" data, set window_index to 1 for uniformity
             window_index = 1 if window == "overall" else jetstream_data_point.window_index
 
-            if metric in result_metrics:
+            if metric in result_metrics and statistic in result_metrics[metric]:
                 branch_obj = getattr(self, branch)
                 branch_obj.is_control = experiment.reference_branch.slug == branch
                 group_obj = getattr(

--- a/app/experimenter/jetstream/models.py
+++ b/app/experimenter/jetstream/models.py
@@ -198,7 +198,7 @@ class ResultsObjectModelBase(BaseModel):
             # For "overall" data, set window_index to 1 for uniformity
             window_index = 1 if window == "overall" else jetstream_data_point.window_index
 
-            if metric in result_metrics and statistic in result_metrics[metric]:
+            if metric in result_metrics:
                 branch_obj = getattr(self, branch)
                 branch_obj.is_control = experiment.reference_branch.slug == branch
                 group_obj = getattr(

--- a/app/experimenter/jetstream/tests/constants.py
+++ b/app/experimenter/jetstream/tests/constants.py
@@ -189,6 +189,40 @@ class JetstreamTestData:
                 )
 
     @classmethod
+    def add_outcome_data_mean(cls, data, overall_data, weekly_data, primary_outcome):
+        primary_metrics = ["mozilla_default_browser"]
+        range_data = DataPoint(lower=0, point=0, upper=0)
+
+        for primary_metric in primary_metrics:
+            for branch in ["control", "variant"]:
+                if Group.OTHER not in overall_data[branch]["branch_data"]:
+                    overall_data[branch]["branch_data"][Group.OTHER] = {}
+                if Group.OTHER not in weekly_data[branch]["branch_data"]:
+                    weekly_data[branch]["branch_data"][Group.OTHER] = {}
+
+                data_point_overall = range_data.copy()
+                data_point_overall.count = 0.0
+                overall_data[branch]["branch_data"][Group.OTHER][
+                    primary_metric
+                ] = cls.get_metric_data(data_point_overall)
+
+                data_point_weekly = range_data.copy()
+                data_point_weekly.window_index = "1"
+                weekly_data[branch]["branch_data"][Group.OTHER][
+                    primary_metric
+                ] = cls.get_metric_data(data_point_weekly)
+
+                data.append(
+                    JetstreamDataPoint(
+                        **range_data.dict(exclude_none=True),
+                        metric=primary_metric,
+                        branch=branch,
+                        statistic="mean",
+                        window_index="1",
+                    ).dict(exclude_none=True)
+                )
+
+    @classmethod
     def add_all_outcome_data(
         cls,
         data,
@@ -198,6 +232,7 @@ class JetstreamTestData:
     ):
         for primary_outcome in primary_outcomes:
             cls.add_outcome_data(data, overall_data, weekly_data, primary_outcome)
+            cls.add_outcome_data_mean(data, overall_data, weekly_data, primary_outcome)
 
     @classmethod
     def get_test_data(cls, primary_outcomes):

--- a/app/experimenter/jetstream/tests/fixtures/valid_outcomes/firefox_desktop/default-browser.toml
+++ b/app/experimenter/jetstream/tests/fixtures/valid_outcomes/firefox_desktop/default-browser.toml
@@ -17,3 +17,5 @@ select_expression = "SUM(CASE WHEN engine like 'amazon%' then sap else 0 end)"
 data_source = "search_clients_daily"
 [metrics.default_browser_action.statistics.bootstrap_mean]
 [metrics.default_browser_action.statistics.deciles]
+
+[metrics.default_browser_null]

--- a/app/experimenter/jetstream/tests/test_tasks.py
+++ b/app/experimenter/jetstream/tests/test_tasks.py
@@ -159,10 +159,11 @@ class TestFetchJetstreamDataTask(TestCase):
             (NimbusExperimentFactory.Lifecycles.ENDING_APPROVE_APPROVE,),
         ]
     )
+    @patch("experimenter.jetstream.client.get_metadata")
     @patch("django.core.files.storage.default_storage.open")
     @patch("django.core.files.storage.default_storage.exists")
     def test_results_data_with_null_conversion_percent(
-        self, lifecycle, mock_exists, mock_open
+        self, lifecycle, mock_exists, mock_open, mock_get_metadata
     ):
         primary_outcomes = ["default-browser"]
         secondary_outcomes = ["secondary_outcome"]
@@ -200,6 +201,10 @@ class TestFetchJetstreamDataTask(TestCase):
 
         experiment = NimbusExperiment.objects.get(id=experiment.id)
         self.assertIsNone(experiment.results_data)
+
+        mock_get_metadata.return_value = {
+            "outcomes": {"default-browser": {"metrics": ["test"], "default_metrics": []}}
+        }
 
         tasks.fetch_experiment_data(experiment.id)
         experiment = NimbusExperiment.objects.get(id=experiment.id)

--- a/app/experimenter/jetstream/tests/test_tasks.py
+++ b/app/experimenter/jetstream/tests/test_tasks.py
@@ -67,7 +67,18 @@ class TestFetchJetstreamDataTask(TestCase):
                     "another_count": "Another Count",
                 },
             },
-            "metadata": {},
+            "metadata": {
+                "outcomes": {
+                    "default-browser": {
+                        "metrics": [
+                            "default_browser_action",
+                            "mozilla_default_browser",
+                            "default_browser_null",
+                        ],
+                        "default_metrics": [],
+                    }
+                }
+            },
             "show_analysis": False,
         }
 
@@ -77,7 +88,18 @@ class TestFetchJetstreamDataTask(TestCase):
 
             def read(self):
                 if "metadata" in self.name:
-                    return "{}"
+                    return """{
+                        "outcomes": {
+                            "default-browser": {
+                                "metrics": [
+                                    "default_browser_action",
+                                    "mozilla_default_browser",
+                                    "default_browser_null"
+                                ],
+                                "default_metrics": []
+                            }
+                        }
+                    }"""
                 return json.dumps(DAILY_DATA)
 
         def open_file(filename):


### PR DESCRIPTION
Because

- Nimbus could potentially expect different outcome metrics from what Jetstream actually processed and sends
- Nimbus was filtering out processed outcome metrics from results due to a too-restrictive filter on statistics options based on the type of metric (primary, default, etc)
- there is no reason that outcome metrics could not be any of the Statistic options

This commit

- requests Jetstream metadata to update the outcome metrics expected by Nimbus
- allows outcome metrics to be any of the Statistic options