### PR TITLE
fix #7153 feat(nimbus): Enable country targeting button for mobile client

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/index.test.tsx
@@ -156,36 +156,6 @@ describe("FormAudience", () => {
     expect(screen.getByTestId("countries")).toHaveTextContent("All Countries");
   });
 
-  it("enables country field for desktop", async () => {
-    render(
-      <Subject
-        experiment={{
-          ...MOCK_EXPERIMENT,
-          application: NimbusExperimentApplicationEnum.DESKTOP,
-        }}
-      />,
-    );
-
-    expect(
-      screen.getByTestId("countries").querySelector("input"),
-    ).not.toHaveAttribute("disabled");
-  });
-
-  it("disables country field for mobile", async () => {
-    render(
-      <Subject
-        experiment={{
-          ...MOCK_EXPERIMENT,
-          application: NimbusExperimentApplicationEnum.FENIX,
-        }}
-      />,
-    );
-
-    expect(
-      screen.getByTestId("countries").querySelector("input"),
-    ).toHaveAttribute("disabled");
-  });
-
   it("enables language field for mobile", async () => {
     render(
       <Subject

--- a/app/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/index.tsx
@@ -228,15 +228,10 @@ export const FormAudience = ({
             <Select
               placeholder="All Countries"
               isMulti
-              isDisabled={!isDesktop}
               {...formSelectAttrs("countries", setCountries)}
               options={selectOptions(config.countries as SelectIdItems)}
             />
-            {!isDesktop ? (
-              <p className="text-secondary">
-                *Country filtering is not yet supported for mobile clients.
-              </p>
-            ) : null}
+
             <FormErrors name="countries" />
           </Form.Group>
         </Form.Row>

--- a/app/experimenter/nimbus-ui/src/hooks/useReviewCheck.tsx
+++ b/app/experimenter/nimbus-ui/src/hooks/useReviewCheck.tsx
@@ -22,6 +22,7 @@ const fieldPageMap: { [page: string]: string[] } = {
     "channel",
     "firefox_min_version",
     "languages",
+    "countries",
     "targeting_config_slug",
     "proposed_enrollment",
     "proposed_duration",


### PR DESCRIPTION
Because

* Since country targeting is supported for the mobile client, we can enable it in nimbus UI

This commit

* Reverts country disable button for mobile client and its test cases

**Note: This PR is blocked until we land this https://github.com/mozilla/experimenter/pull/7389** 

fixes #7153 