### PR TITLE
fix #7388 feat(nimbus): Show locale field for the older experiments

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/Summary/TableAudience/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/TableAudience/index.test.tsx
@@ -192,6 +192,35 @@ describe("TableAudience", () => {
       );
     });
   });
+
+  describe("renders 'Locales' row as expected for old experiments", () => {
+    it("when locales exist, displays them", () => {
+      const data = {
+        locales: [
+          { name: "Quebecois", id: 1 },
+          { name: "Acholi", id: 2 },
+        ],
+        application: NimbusExperimentApplicationEnum.FENIX,
+      };
+      const { experiment } = mockExperimentQuery("demo-slug", data);
+      render(<Subject {...{ experiment }} />);
+      data.locales.forEach((locale) =>
+        within(screen.getByTestId("experiment-locales")).findByText(
+          locale.name,
+        ),
+      );
+    });
+    it("when locales don't exist for old experiments, displays all", async () => {
+      const { experiment } = mockExperimentQuery("demo-slug", {
+        locales: [],
+      });
+      render(<Subject {...{ experiment }} />);
+      await within(screen.getByTestId("experiment-locales")).findByText(
+        "All locales",
+      );
+    });
+  });
+
   describe("renders 'Languages' row as expected", () => {
     it("when languages exist, displays them", () => {
       const data = {

--- a/app/experimenter/nimbus-ui/src/components/Summary/TableAudience/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/TableAudience/index.tsx
@@ -85,7 +85,7 @@ const TableAudience = ({
             </td>
           </tr>
         )}
-        {isDesktop && (
+        {(isDesktop || experiment.locales.length > 0) && (
           <tr>
             <th>Locales</th>
             <td data-testid="experiment-locales">


### PR DESCRIPTION
Because

* Since we added the languages field for the mobile client, but still, we have use of locales in older experiments

This commit

* Adds the locales field back for the older experiments

Screenshots for the new changes made:

<img width="1312" alt="image" src="https://user-images.githubusercontent.com/104033388/173129390-5c03df5e-eb40-49ce-9438-08986ae71bb0.png">

fixes #7388 
