### PR TITLE
fix #7372 bug(nimbus): fix intermittent integration test failure

### DIFF
--- a/app/tests/integration/nimbus/pages/base.py
+++ b/app/tests/integration/nimbus/pages/base.py
@@ -7,7 +7,7 @@ class Base(Page):
     """Base page."""
 
     def __init__(self, selenium, base_url, **kwargs):
-        super().__init__(selenium, base_url, timeout=60, **kwargs)
+        super().__init__(selenium, base_url, timeout=80, **kwargs)
 
     def wait_for_page_to_load(self):
         self.wait.until(EC.presence_of_element_located(self._page_wait_locator))


### PR DESCRIPTION
Because

* After we decoupled the review timeout window from the worker schedule, we introduced the possibility that the timeout window could overlap arbitrarily with the worker refresh cycle
* Looking at the failure locally, we see that the experiment timed out 60s after it was pushed
* The test timeout was set to 60s so the expected timeout may just miss the max refresh window in the test

This commit

* Increases the test refresh window to 80s to give ample room for the timeout to occur