### PR TITLE
fixes #7403: Copy languages for cloned experiment

### DIFF
--- a/app/experimenter/experiments/models.py
+++ b/app/experimenter/experiments/models.py
@@ -611,6 +611,7 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
         cloned.feature_configs.add(*self.feature_configs.all())
         cloned.countries.add(*self.countries.all())
         cloned.locales.add(*self.locales.all())
+        cloned.languages.add(*self.languages.all())
 
         if rollout_branch_slug:
             generate_nimbus_changelog(

--- a/app/experimenter/experiments/tests/test_models.py
+++ b/app/experimenter/experiments/tests/test_models.py
@@ -1428,6 +1428,7 @@ class TestNimbusExperiment(TestCase):
         self.assertFalse(NimbusBucketRange.objects.filter(experiment=child).exists())
         self.assertEqual(child.locales.all().count(), 0)
         self.assertEqual(child.countries.all().count(), 0)
+        self.assertEqual(child.languages.all().count(), 0)
         self.assertEqual(child.branches.all().count(), 0)
         self.assertEqual(child.changes.all().count(), 1)
         self.assertIsNone(child.conclusion_recommendation)
@@ -1503,6 +1504,11 @@ class TestNimbusExperiment(TestCase):
         self.assertEqual(
             set(child.countries.all().values_list("code", flat=True)),
             set(parent.countries.all().values_list("code", flat=True)),
+        )
+
+        self.assertEqual(
+            set(child.languages.all().values_list("code", flat=True)),
+            set(parent.languages.all().values_list("code", flat=True)),
         )
 
         for parent_link in parent.documentation_links.all():


### PR DESCRIPTION

Because

* We added new languages field when creating new experiments, but not added to copy that field in case of cloning of the experiments

This commit

* Adds the languages field to clone experiments and test cases to verify changes

Screenshot for new changes:
![image](https://user-images.githubusercontent.com/104033388/173683898-28b462b6-8d2e-4c2f-a504-0e60d36a38b8.png)


fixes #7403 