### PR TITLE
fixes #7406 feat(nimbus): add custom targeting for Mozilla Rally users

### DIFF
--- a/app/experimenter/targeting/constants.py
+++ b/app/experimenter/targeting/constants.py
@@ -510,6 +510,15 @@ PIP_NEVER_USED_STICKY = NimbusTargetingConfig(
     application_choice_names=(Application.DESKTOP.name,),
 )
 
+RALLY_CORE_ADDON_USER = NimbusTargetingConfig(
+    name="Mozilla Rally Core Add-on User",
+    slug="rally_core_addon_user",
+    description="Users who have installed the Mozilla Rally Core Add-on",
+    targeting="addonsInfo.addons['rally-core@mozilla.org'] != null",
+    desktop_telemetry="",
+    application_choice_names=(Application.DESKTOP.name,),
+)
+
 
 class TargetingConstants:
     TARGETING_VERSION = "version|versionCompare('{version}') >= 0"


### PR DESCRIPTION
Because the Mozilla Rally team wants to run experiments on only existing users, this commit adds custom targeting that allows us to run experiments on only users who have installed the official Rally Core Add-on