### PR TITLE
fix #6696 feat(nimbus): add a checkbox to branches page to control rollout status

### DIFF
--- a/app/experimenter/experiments/api/v5/inputs.py
+++ b/app/experimenter/experiments/api/v5/inputs.py
@@ -54,6 +54,7 @@ class TreatmentBranchInput(BranchInput):
 
 class ExperimentInput(graphene.InputObjectType):
     id = graphene.Int()
+    is_rollout = graphene.Boolean()
     is_archived = graphene.Boolean()
     status = NimbusExperimentStatusEnum()
     status_next = NimbusExperimentStatusEnum()

--- a/app/experimenter/experiments/api/v5/serializers.py
+++ b/app/experimenter/experiments/api/v5/serializers.py
@@ -256,7 +256,6 @@ class NimbusExperimentBranchMixin:
     def validate(self, data):
         data = super().validate(data)
         data = self._validate_duplicate_branch_names(data)
-        data = self._validate_single_branch_for_rollout(data)
         return data
 
     def _validate_duplicate_branch_names(self, data):
@@ -280,22 +279,6 @@ class NimbusExperimentBranchMixin:
                         ],
                     }
                 )
-        return data
-
-    def _validate_single_branch_for_rollout(self, data):
-        if (
-            self.instance
-            and self.instance.is_rollout
-            and len(data.get("treatment_branches", [])) > 0
-        ):
-            raise serializers.ValidationError(
-                {
-                    "treatment_branches": [
-                        {"name": NimbusConstants.ERROR_SINGLE_BRANCH_FOR_ROLLOUT}
-                        for i in data["treatment_branches"]
-                    ],
-                }
-            )
         return data
 
     def update(self, experiment, data):
@@ -986,6 +969,8 @@ class NimbusReviewSerializer(serializers.ModelSerializer):
         errors = []
         for branch in value:
             error = {}
+            if self.instance and self.instance.is_rollout:
+                error["name"] = [NimbusConstants.ERROR_SINGLE_BRANCH_FOR_ROLLOUT]
             if branch["description"] == "":
                 error["description"] = [NimbusConstants.ERROR_REQUIRED_FIELD]
             errors.append(error)

--- a/app/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_experiment_branch_mixin.py
+++ b/app/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_experiment_branch_mixin.py
@@ -263,37 +263,6 @@ class TestNimbusExperimentBranchMixinSingleFeature(TestCase):
             },
         )
 
-    def test_no_treatment_branches_for_rollout(self):
-        experiment = NimbusExperimentFactory.create(
-            status=NimbusExperiment.Status.DRAFT,
-        )
-        experiment.is_rollout = True
-        experiment.save()
-        for branch in experiment.treatment_branches:
-            branch.delete()
-
-        data = {
-            "treatment_branches": [
-                {"name": "treatment A", "description": "desc1", "ratio": 1},
-                {"name": "treatment B", "description": "desc2", "ratio": 1},
-            ],
-            "changelog_message": "test changelog message",
-        }
-        serializer = NimbusExperimentSerializer(
-            experiment, data=data, partial=True, context={"user": self.user}
-        )
-        self.assertFalse(serializer.is_valid())
-        self.assertEqual(
-            serializer.errors,
-            {
-                "treatment_branches": [
-                    {"name": NimbusConstants.ERROR_SINGLE_BRANCH_FOR_ROLLOUT}
-                    for i in data["treatment_branches"]
-                ],
-            },
-        )
-
-
 class TestNimbusExperimentBranchMixinMultiFeature(TestCase):
     maxDiff = None
 

--- a/app/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_ready_for_review_serializer.py
+++ b/app/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_ready_for_review_serializer.py
@@ -1250,6 +1250,29 @@ class TestNimbusReviewSerializerMultiFeature(TestCase):
         )
         self.assertTrue(serializer.is_valid())
 
+    def test_no_treatment_branches_for_rollout(self):
+        experiment = NimbusExperimentFactory.create(
+            status=NimbusExperiment.Status.DRAFT,
+        )
+        experiment.is_rollout = True
+        experiment.save()
+
+        serializer = NimbusReviewSerializer(
+            experiment,
+            data=NimbusReviewSerializer(
+                experiment,
+                context={"user": self.user},
+            ).data,
+            context={"user": self.user},
+        )
+
+        self.assertFalse(serializer.is_valid())
+        self.assertEqual(
+            serializer.errors["treatment_branches"][0]["name"][0],
+            NimbusConstants.ERROR_SINGLE_BRANCH_FOR_ROLLOUT,
+            serializer.errors,
+        )
+
     # Add schema warn logic for multifeature in #7028
     # def test_serializer_feature_config_validation_reference_value_schema_warn(self):
     #     experiment = NimbusExperimentFactory.create_with_lifecycle(

--- a/app/experimenter/nimbus-ui/schema.graphql
+++ b/app/experimenter/nimbus-ui/schema.graphql
@@ -40,6 +40,7 @@ input ExperimentCloneInput {
 
 input ExperimentInput {
   id: Int
+  isRollout: Boolean
   isArchived: Boolean
   status: NimbusExperimentStatusEnum
   statusNext: NimbusExperimentStatusEnum

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/index.test.tsx
@@ -145,6 +145,15 @@ describe("FormBranches", () => {
     expect(saveResult.warnFeatureSchema).toBeTruthy();
   });
 
+  it("sets isRollout when checkbox enabled", async () => {
+    const onSave = jest.fn();
+    render(<SubjectBranches {...{ onSave }} />);
+    fireEvent.click(screen.getByTestId("is-rollout-checkbox"));
+    await clickAndWaitForSave(onSave);
+    const saveResult = onSave.mock.calls[0][0];
+    expect(saveResult.isRollout).toBeTruthy();
+  });
+
   it("gracefully handles selecting an invalid feature config", async () => {
     const onSave = jest.fn();
     render(<SubjectBranches {...{ onSave }} />);

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/index.tsx
@@ -46,6 +46,7 @@ export const FormBranches = ({
     {
       featureConfigIds: experimentFeatureConfigIds,
       warnFeatureSchema,
+      isRollout,
       referenceBranch,
       treatmentBranches,
       equalRatio,
@@ -126,6 +127,14 @@ export const FormBranches = ({
   ) => {
     commitFormData();
     dispatch({ type: "setFeatureConfigs", value });
+  };
+
+  const handleIsRollout = (ev: React.ChangeEvent<HTMLInputElement>) => {
+    commitFormData();
+    dispatch({
+      type: "setIsRollout",
+      value: ev.target.checked,
+    });
   };
 
   const onFeatureConfigChange = (ev: React.ChangeEvent<HTMLInputElement>) => {
@@ -243,6 +252,18 @@ export const FormBranches = ({
             </Form.Control.Feedback>
           )}
         </Form.Group>
+
+        <Form.Row>
+          <Form.Group as={Col} controlId="isRollout">
+            <Form.Check
+              data-testid="is-rollout-checkbox"
+              onChange={handleIsRollout}
+              checked={!!isRollout}
+              type="checkbox"
+              label="Handle this experiment as a single-branch rollout"
+            />
+          </Form.Group>
+        </Form.Row>
 
         <Form.Row>
           <Form.Group as={Col} controlId="warnFeatureSchema">

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/mocks.tsx
@@ -54,6 +54,7 @@ const MOCK_STATE: FormBranchesState = {
   globalErrors: [],
   featureConfigIds: [],
   warnFeatureSchema: false,
+  isRollout: false,
   referenceBranch: {
     ...MOCK_EXPERIMENT.referenceBranch!,
     screenshots: [],

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/reducer/actions.ts
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/reducer/actions.ts
@@ -23,6 +23,8 @@ export function formBranchesActionReducer(
       return removeBranch(state, action);
     case "setFeatureConfigs":
       return setFeatureConfigs(state, action);
+    case "setIsRollout":
+      return setIsRollout(state, action);
     case "setwarnFeatureSchema":
       return setwarnFeatureSchema(state, action);
     case "setEqualRatio":
@@ -47,6 +49,7 @@ export type FormBranchesAction =
   | RemoveBranchAction
   | SetEqualRatioAction
   | SetFeatureConfigsAction
+  | SetIsRolloutAction
   | SetwarnFeatureSchemaAction
   | SetSubmitErrorsAction
   | ClearSubmitErrorsAction
@@ -114,6 +117,21 @@ function setFeatureConfigs(
   return {
     ...state,
     featureConfigIds: featureConfigIds || null,
+  };
+}
+
+type SetIsRolloutAction = {
+  type: "setIsRollout";
+  value: FormBranchesState["isRollout"];
+};
+
+function setIsRollout(
+  state: FormBranchesState,
+  { value: isRollout }: SetIsRolloutAction,
+) {
+  return {
+    ...state,
+    isRollout,
   };
 }
 

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/reducer/index.test.ts
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/reducer/index.test.ts
@@ -14,6 +14,7 @@ const MOCK_STATE: FormBranchesState = {
   globalErrors: [],
   featureConfigIds: [],
   warnFeatureSchema: false,
+  isRollout: false,
   referenceBranch: {
     ...MOCK_EXPERIMENT.referenceBranch!,
     screenshots: [],

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/reducer/state.ts
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/reducer/state.ts
@@ -13,7 +13,7 @@ import {
 
 export type FormBranchesState = Pick<
   ExperimentInput,
-  "featureConfigIds" | "warnFeatureSchema"
+  "featureConfigIds" | "warnFeatureSchema" | "isRollout"
 > & {
   referenceBranch: null | AnnotatedBranch;
   treatmentBranches: null | AnnotatedBranch[];
@@ -35,6 +35,7 @@ export type AnnotatedBranch = Omit<TreatmentBranchInput, "id"> & {
 export function createInitialState({
   featureConfigs,
   warnFeatureSchema,
+  isRollout,
   referenceBranch,
   treatmentBranches,
 }: getExperiment_experimentBySlug): FormBranchesState {
@@ -62,6 +63,7 @@ export function createInitialState({
     equalRatio,
     featureConfigIds: featureConfigs?.map((f) => f?.id || null),
     warnFeatureSchema,
+    isRollout,
     globalErrors: [],
     referenceBranch: annotatedReferenceBranch,
     treatmentBranches: annotatedTreatmentBranches,

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/reducer/update.ts
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/reducer/update.ts
@@ -13,6 +13,7 @@ export type FormBranchesSaveState = Pick<
   ExperimentInput,
   | "featureConfigIds"
   | "warnFeatureSchema"
+  | "isRollout"
   | "referenceBranch"
   | "treatmentBranches"
 >;
@@ -31,6 +32,7 @@ export function extractUpdateState(
   const {
     featureConfigIds,
     warnFeatureSchema,
+    isRollout,
     referenceBranch,
     treatmentBranches,
   } = state;
@@ -42,6 +44,7 @@ export function extractUpdateState(
   return {
     featureConfigIds,
     warnFeatureSchema,
+    isRollout,
     referenceBranch: extractUpdateBranch(
       referenceBranch,
       formData.referenceBranch,

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/index.tsx
@@ -19,7 +19,6 @@ import { updateExperiment_updateExperiment as UpdateExperimentBranchesResult } f
 import AppLayoutWithExperiment from "../AppLayoutWithExperiment";
 import LinkExternal from "../LinkExternal";
 import FormBranches from "./FormBranches";
-import { FormBranchesSaveState } from "./FormBranches/reducer";
 
 const PageEditBranches: React.FunctionComponent<RouteComponentProps> = () => {
   const { allFeatureConfigs } = useConfig();
@@ -39,12 +38,7 @@ const PageEditBranches: React.FunctionComponent<RouteComponentProps> = () => {
 
   const onFormSave = useCallback(
     async (
-      {
-        featureConfigIds,
-        warnFeatureSchema,
-        referenceBranch,
-        treatmentBranches,
-      }: FormBranchesSaveState,
+      formBranchesSaveState,
       setSubmitErrors,
       clearSubmitErrors,
       next: boolean,
@@ -55,12 +49,9 @@ const PageEditBranches: React.FunctionComponent<RouteComponentProps> = () => {
         const result = await updateExperimentBranches({
           variables: {
             input: {
+              ...formBranchesSaveState,
               id: nimbusExperimentId,
               changelogMessage: CHANGELOG_MESSAGES.UPDATED_BRANCHES,
-              featureConfigIds,
-              warnFeatureSchema,
-              referenceBranch,
-              treatmentBranches,
             },
           },
         });

--- a/app/experimenter/nimbus-ui/src/types/globalTypes.ts
+++ b/app/experimenter/nimbus-ui/src/types/globalTypes.ts
@@ -220,6 +220,7 @@ export interface ExperimentCloneInput {
 
 export interface ExperimentInput {
   id?: number | null;
+  isRollout?: boolean | null;
   isArchived?: boolean | null;
   status?: NimbusExperimentStatusEnum | null;
   statusNext?: NimbusExperimentStatusEnum | null;


### PR DESCRIPTION
Refreshed @lmorchard 's PR #6751

Because:

* we want to be able to switch an experiment to being handled as a
  single-branch rollout

This commit:

* adds a checkbox to the branches page to control isRollout

* adds isRollout to the form reducer for FormBranches

* adds isRollout to the GQL ExperimentInput type

* slightly refactors onFormSave in PageEditBranches to handle whatever
  new properties might be added to the FormBranches reducer

* moves the single-branch enforcement to the ready-for-review serializer

-----

<img width="1171" alt="Screen Shot 2022-06-14 at 2 53 26 PM" src="https://user-images.githubusercontent.com/43795363/173697077-9c6a580b-4957-453d-8ebd-4b2cba5701bb.png">
