### PR TITLE
fix #7410 feat(nimbus): add enrollmentEndDate to V6 API

### DIFF
--- a/app/experimenter/docs/openapi-schema.json
+++ b/app/experimenter/docs/openapi-schema.json
@@ -3096,6 +3096,10 @@
             "type": "string",
             "format": "date"
           },
+          "enrollmentEndDate": {
+            "type": "string",
+            "format": "date"
+          },
           "endDate": {
             "type": "string",
             "format": "date"
@@ -3118,6 +3122,7 @@
           "channel",
           "bucketConfig",
           "startDate",
+          "enrollmentEndDate",
           "endDate"
         ]
       },

--- a/app/experimenter/docs/swagger-ui.html
+++ b/app/experimenter/docs/swagger-ui.html
@@ -3108,6 +3108,10 @@
             "type": "string",
             "format": "date"
           },
+          "enrollmentEndDate": {
+            "type": "string",
+            "format": "date"
+          },
           "endDate": {
             "type": "string",
             "format": "date"
@@ -3130,6 +3134,7 @@
           "channel",
           "bucketConfig",
           "startDate",
+          "enrollmentEndDate",
           "endDate"
         ]
       },

--- a/app/experimenter/experiments/api/v6/serializers.py
+++ b/app/experimenter/experiments/api/v6/serializers.py
@@ -118,6 +118,7 @@ class NimbusExperimentSerializer(serializers.ModelSerializer):
     probeSets = serializers.ReadOnlyField(default=[])
     outcomes = serializers.SerializerMethodField()
     startDate = serializers.DateField(source="start_date")
+    enrollmentEndDate = serializers.DateField(source="computed_enrollment_end_date")
     endDate = serializers.DateField(source="end_date")
     proposedDuration = serializers.ReadOnlyField(source="proposed_duration")
     proposedEnrollment = serializers.ReadOnlyField(source="proposed_enrollment")
@@ -144,6 +145,7 @@ class NimbusExperimentSerializer(serializers.ModelSerializer):
             "branches",
             "targeting",
             "startDate",
+            "enrollmentEndDate",
             "endDate",
             "proposedDuration",
             "proposedEnrollment",

--- a/app/experimenter/experiments/models.py
+++ b/app/experimenter/experiments/models.py
@@ -398,6 +398,13 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
         return self.proposed_enrollment
 
     @property
+    def computed_enrollment_end_date(self):
+        start_date = self.start_date
+        computed_enrollment_days = self.computed_enrollment_days
+        if None not in (start_date, computed_enrollment_days):
+            return start_date + datetime.timedelta(days=computed_enrollment_days)
+
+    @property
     def computed_end_date(self):
         if self.end_date:
             return self.end_date

--- a/app/experimenter/experiments/tests/api/v6/test_serializers.py
+++ b/app/experimenter/experiments/tests/api/v6/test_serializers.py
@@ -42,6 +42,12 @@ class TestNimbusExperimentSerializer(TestCase):
                 "appId": "firefox-desktop",
                 "channel": "nightly",
                 # DRF manually replaces the isoformat suffix so we have to do the same
+                "startDate": experiment.start_date.isoformat().replace("+00:00", "Z"),
+                "enrollmentEndDate": (
+                    experiment.computed_enrollment_end_date.isoformat().replace(
+                        "+00:00", "Z"
+                    )
+                ),
                 "endDate": experiment.end_date.isoformat().replace("+00:00", "Z"),
                 "id": experiment.slug,
                 "isEnrollmentPaused": True,
@@ -50,8 +56,6 @@ class TestNimbusExperimentSerializer(TestCase):
                 "referenceBranch": experiment.reference_branch.slug,
                 "schemaVersion": settings.NIMBUS_SCHEMA_VERSION,
                 "slug": experiment.slug,
-                # DRF manually replaces the isoformat suffix so we have to do the same
-                "startDate": experiment.start_date.isoformat().replace("+00:00", "Z"),
                 "targeting": (
                     '(browserSettings.update.channel == "nightly") '
                     "&& ('app.shield.optoutstudies.enabled'|preferenceValue) "
@@ -129,6 +133,12 @@ class TestNimbusExperimentSerializer(TestCase):
                 "appId": "firefox-desktop",
                 "channel": "nightly",
                 # DRF manually replaces the isoformat suffix so we have to do the same
+                "startDate": experiment.start_date.isoformat().replace("+00:00", "Z"),
+                "enrollmentEndDate": (
+                    experiment.computed_enrollment_end_date.isoformat().replace(
+                        "+00:00", "Z"
+                    )
+                ),
                 "endDate": experiment.end_date.isoformat().replace("+00:00", "Z"),
                 "id": experiment.slug,
                 "isEnrollmentPaused": True,
@@ -137,8 +147,6 @@ class TestNimbusExperimentSerializer(TestCase):
                 "referenceBranch": experiment.reference_branch.slug,
                 "schemaVersion": settings.NIMBUS_SCHEMA_VERSION,
                 "slug": experiment.slug,
-                # DRF manually replaces the isoformat suffix so we have to do the same
-                "startDate": experiment.start_date.isoformat().replace("+00:00", "Z"),
                 "targeting": (
                     '(browserSettings.update.channel == "nightly") '
                     "&& ('app.shield.optoutstudies.enabled'|preferenceValue) "


### PR DESCRIPTION
Because

* We currently expose the proposed enrollment period in the V6 API
* Jetstream uses this to determine the enrollment window to collect the set of enrolled clients
* Some experiments enrollment period will vary from the proposed enrollment period depending on the enrollment characteristics
* Jetstream has no way to determine the actual enrollment period and so may miss some clients in its analysis

This commit

* Adds a computed_enrollment_end_date property to NimbusExperiment model
* Exposes that property in the V6 API as enrollmentEndDate