### PR TITLE
fix #7419 feat(nimbus): add is_sticky to v5 api

### DIFF
--- a/app/experimenter/experiments/api/v5/inputs.py
+++ b/app/experimenter/experiments/api/v5/inputs.py
@@ -78,6 +78,7 @@ class ExperimentInput(graphene.InputObjectType):
     population_percent = graphene.String()
     proposed_duration = graphene.Int()
     proposed_enrollment = graphene.String()
+    is_sticky = graphene.Boolean()
     targeting_config_slug = graphene.String()
     total_enrolled_clients = graphene.Int()
     changelog_message = graphene.String()

--- a/app/experimenter/experiments/api/v5/serializers.py
+++ b/app/experimenter/experiments/api/v5/serializers.py
@@ -551,6 +551,7 @@ class NimbusExperimentSerializer(
             "is_rollout",
             "is_archived",
             "is_enrollment_paused",
+            "is_sticky",
             "locales",
             "languages",
             "name",

--- a/app/experimenter/experiments/api/v5/types.py
+++ b/app/experimenter/experiments/api/v5/types.py
@@ -354,6 +354,7 @@ class NimbusExperimentType(DjangoObjectType):
     treatment_branches = graphene.List(NimbusBranchType)
     targeting_config_slug = graphene.String()
     targeting_config = graphene.List(NimbusExperimentTargetingConfigType)
+    is_sticky = graphene.Boolean()
     jexl_targeting_expression = graphene.String()
     primary_outcomes = graphene.List(graphene.String)
     secondary_outcomes = graphene.List(graphene.String)

--- a/app/experimenter/experiments/tests/api/v5/test_mutations.py
+++ b/app/experimenter/experiments/tests/api/v5/test_mutations.py
@@ -644,6 +644,7 @@ class TestUpdateExperimentMutationSingleFeature(
             proposed_enrollment=0,
             targeting_config_slug=NimbusExperiment.TargetingConfig.NO_TARGETING,
             total_enrolled_clients=0,
+            is_sticky=False,
         )
         response = self.query(
             UPDATE_EXPERIMENT_MUTATION,
@@ -662,6 +663,7 @@ class TestUpdateExperimentMutationSingleFeature(
                     "countries": [country.id],
                     "locales": [locale.id],
                     "languages": [language.id],
+                    "isSticky": True,
                 }
             },
             headers={settings.OPENIDC_EMAIL_HEADER: user_email},
@@ -689,6 +691,7 @@ class TestUpdateExperimentMutationSingleFeature(
         self.assertEqual(list(experiment.countries.all()), [country])
         self.assertEqual(list(experiment.locales.all()), [locale])
         self.assertEqual(list(experiment.languages.all()), [language])
+        self.assertTrue(experiment.is_sticky)
 
     def test_update_experiment_audience_error(self):
         user_email = "user@example.com"

--- a/app/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_experiment_serializer.py
+++ b/app/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_experiment_serializer.py
@@ -458,6 +458,7 @@ class TestNimbusExperimentSerializer(TestCase):
             proposed_enrollment=0,
             targeting_config_slug=NimbusExperiment.TargetingConfig.NO_TARGETING,
             total_enrolled_clients=0,
+            is_sticky=False,
         )
         serializer = NimbusExperimentSerializer(
             experiment,
@@ -473,6 +474,7 @@ class TestNimbusExperimentSerializer(TestCase):
                 "countries": [country.id],
                 "locales": [locale.id],
                 "languages": [language.id],
+                "is_sticky": True,
             },
             context={"user": self.user},
         )
@@ -495,6 +497,7 @@ class TestNimbusExperimentSerializer(TestCase):
         self.assertEqual(list(experiment.countries.all()), [country])
         self.assertEqual(list(experiment.locales.all()), [locale])
         self.assertEqual(list(experiment.languages.all()), [language])
+        self.assertTrue(experiment.is_sticky)
 
     @parameterized.expand(
         [

--- a/app/experimenter/nimbus-ui/schema.graphql
+++ b/app/experimenter/nimbus-ui/schema.graphql
@@ -64,6 +64,7 @@ input ExperimentInput {
   populationPercent: String
   proposedDuration: Int
   proposedEnrollment: String
+  isSticky: Boolean
   targetingConfigSlug: String
   totalEnrolledClients: Int
   changelogMessage: String
@@ -416,7 +417,7 @@ type NimbusExperimentType {
   locales: [NimbusLocaleType!]!
   countries: [NimbusCountryType!]!
   languages: [NimbusLanguageType!]!
-  isSticky: Boolean!
+  isSticky: Boolean
   projects: [ProjectType!]!
   hypothesis: String!
   primaryOutcomes: [String]

--- a/app/experimenter/nimbus-ui/src/types/globalTypes.ts
+++ b/app/experimenter/nimbus-ui/src/types/globalTypes.ts
@@ -244,6 +244,7 @@ export interface ExperimentInput {
   populationPercent?: string | null;
   proposedDuration?: number | null;
   proposedEnrollment?: string | null;
+  isSticky?: boolean | null;
   targetingConfigSlug?: string | null;
   totalEnrolledClients?: number | null;
   changelogMessage?: string | null;


### PR DESCRIPTION
Because
    
* We want to be able to edit the is_sticky field from the Nimbus UI
    
This commit
    
* Adds is_sticky to the V5 API