### PR TITLE
fix #7420 feat(nimbus): add sticky to audience page

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/index.test.tsx
@@ -34,6 +34,7 @@ describe("FormAudience", () => {
           ...MOCK_EXPERIMENT,
           application: NimbusExperimentApplicationEnum.DESKTOP,
           channel: NimbusExperimentChannelEnum.NIGHTLY,
+          isSticky: true,
         }}
         config={{
           ...MOCK_CONFIG,
@@ -105,6 +106,8 @@ describe("FormAudience", () => {
     expect(screen.getByTestId("countries")).toHaveTextContent(
       MOCK_EXPERIMENT.countries[0]!.name!,
     );
+
+    expect(screen.getByTestId("isSticky")).toBeChecked();
   });
 
   it("renders server errors", async () => {
@@ -198,6 +201,7 @@ describe("FormAudience", () => {
       countries: MOCK_EXPERIMENT.countries.map((v) => "" + v.id),
       locales: MOCK_EXPERIMENT.locales.map((v) => "" + v.id),
       languages: MOCK_EXPERIMENT.languages.map((v) => "" + v.id),
+      isSticky: MOCK_EXPERIMENT.isSticky,
     };
     render(<Subject {...{ onSubmit }} />);
     await screen.findByTestId("FormAudience");

--- a/app/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/index.tsx
@@ -52,6 +52,7 @@ export const audienceFieldNames = [
   "countries",
   "locales",
   "languages",
+  "isSticky",
 ] as const;
 
 const selectOptions = (items: SelectIdItems) =>
@@ -98,6 +99,7 @@ export const FormAudience = ({
     countries: selectOptions(experiment.countries as SelectIdItems),
     locales: selectOptions(experiment.locales as SelectIdItems),
     languages: selectOptions(experiment.languages as SelectIdItems),
+    isSticky: experiment.isSticky,
   };
 
   const {
@@ -247,6 +249,16 @@ export const FormAudience = ({
               <TargetConfigSelectOptions options={targetingConfigSlugOptions} />
             </Form.Control>
             <FormErrors name="targetingConfigSlug" />
+          </Form.Group>
+        </Form.Row>
+        <Form.Row>
+          <Form.Group as={Col} controlId="isSticky">
+            <Form.Check
+              {...formControlAttrs("isSticky")}
+              type="checkbox"
+              label="Sticky Enrollment (Clients remain enrolled until the experiment ends)"
+            />
+            <FormErrors name="isSticky" />
           </Form.Group>
         </Form.Row>
       </Form.Group>

--- a/app/experimenter/nimbus-ui/src/components/PageEditAudience/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditAudience/index.test.tsx
@@ -109,6 +109,7 @@ const MOCK_FORM_DATA = {
   countries: [1],
   locales: [1],
   languages: [1],
+  isSticky: true,
 };
 
 const Subject = ({

--- a/app/experimenter/nimbus-ui/src/components/PageEditAudience/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditAudience/index.tsx
@@ -41,6 +41,7 @@ const PageEditAudience: React.FunctionComponent<RouteComponentProps> = () => {
         countries,
         locales,
         languages,
+        isSticky,
       }: Record<string, any>,
       next: boolean,
     ) => {
@@ -63,6 +64,7 @@ const PageEditAudience: React.FunctionComponent<RouteComponentProps> = () => {
               countries,
               locales,
               languages,
+              isSticky,
             },
           },
         });

--- a/app/experimenter/nimbus-ui/src/gql/experiments.ts
+++ b/app/experimenter/nimbus-ui/src/gql/experiments.ts
@@ -110,6 +110,7 @@ export const GET_EXPERIMENT_QUERY = gql`
         applicationValues
         description
       }
+      isSticky
       jexlTargetingExpression
 
       populationPercent

--- a/app/experimenter/nimbus-ui/src/lib/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/lib/mocks.tsx
@@ -491,6 +491,7 @@ export const MOCK_EXPERIMENT: Partial<getExperiment["experimentBySlug"]> = {
   },
   featureConfigs: [],
   targetingConfig: [MOCK_CONFIG.targetingConfigs![0]],
+  isSticky: false,
   treatmentBranches: [
     {
       id: 456,

--- a/app/experimenter/nimbus-ui/src/types/getExperiment.ts
+++ b/app/experimenter/nimbus-ui/src/types/getExperiment.ts
@@ -162,6 +162,7 @@ export interface getExperiment_experimentBySlug {
   firefoxMaxVersion: NimbusExperimentFirefoxVersionEnum | null;
   targetingConfigSlug: string | null;
   targetingConfig: (getExperiment_experimentBySlug_targetingConfig | null)[] | null;
+  isSticky: boolean | null;
   jexlTargetingExpression: string | null;
   populationPercent: string | null;
   totalEnrolledClients: number;


### PR DESCRIPTION
Because

* Users should be able to select sticky enrollment on the audience page

This commit

* Adds a checkbox for sticky enrollment on the audience page