### PR TITLE
Add check to circleci skip job if no changes are detected.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,16 +99,6 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Check file paths
-          command: |
-            if git diff --name-only main HEAD | grep -E 'app/experimenter/integration'
-              then
-                echo "Continuing"
-              else
-                echo "No targeting changes, skipping"
-                circleci-agent step halt
-            fi
-      - run:
           name: Run integration tests
           command: |
             PYTEST_ARGS=$(circleci tests split "app/tests/integration/nimbus/parallel_pytest_args.txt")


### PR DESCRIPTION
Because

* With our extended test suite we are using a lot of circleci credits now.

This commit

* Will check the git diff against the main branch to see which file paths have changes and run the needed tests
* The default check step is always run in full (for now).