### PR TITLE
fix #7469 chore(nimbus): simplify google auth process for local jetstream dev

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,8 +63,7 @@ secretkey:
 	openssl rand -hex 24
 
 auth_gcloud:
-	gcloud auth login
-	gcloud auth application-default login
+	gcloud auth login --update-adc
 
 jetstream_config:
 	curl -LJ -o app/experimenter/outcomes/jetstream-config.zip $(JETSTREAM_CONFIG_URL)


### PR DESCRIPTION
Because

* `make auth_gcloud` launches two separate browser tabs
* there is a simpler gcloud command to consolidate the authentication

This commit

* consolidates the commands run by `make auth_gcloud` into a single command that launches a single tab