### PR TITLE
Fix weekly firefox builds.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -164,6 +164,7 @@ jobs:
           name: Check for Firefox Update
           command: |
             results=$(sudo ./.circleci/get_firefox_versions.sh)
+            diff /home/circleci/experimenter/new_versions.txt /home/circleci/experimenter/old_versions.txt
             if [ $? -eq 0 ]; then 
                 circleci-agent step halt
             fi


### PR DESCRIPTION
Because:
* The weekly builds for our firefox cache are broken

This commit:
* Adds the crucial step of comparing the version files created to see if we need to build firefox.