### PR TITLE
fixes #7445 fix(nimbus): change External Link from #cirrus line 56, change wording in <p> element starting on line 18

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/PageResults/ExternalConfigAlert/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/ExternalConfigAlert/index.tsx
@@ -53,7 +53,7 @@ export const ExternalConfigAlert = ({
     </ul>
     <p>
       If you have questions about this, please ask data science in{" "}
-      <LinkExternal href="https://mozilla.slack.com/archives/C0149JH7C1M">
+      <LinkExternal href="https://mozilla.slack.com/archives/CF94YGE03">
         #ask-experimenter
       </LinkExternal>
       .

--- a/app/experimenter/nimbus-ui/src/components/PageResults/ExternalConfigAlert/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/ExternalConfigAlert/index.tsx
@@ -17,9 +17,9 @@ export const ExternalConfigAlert = ({
     <Alert.Heading>Analysis has manual overrides in Jetstream</Alert.Heading>
     <p>
       The results shown on this page are from an analysis ran with at least one
-      experiment override that affects only the <em>analysis</em>, meaning{" "}
+      experiment override that affects only the <em>analysis</em>. The original
       <strong>
-        experiment data on the Summary page will not reflect this.
+        experiment details and description on the Summary page will not reflect this.
       </strong>
     </p>
     <ul className="pl-0">
@@ -53,7 +53,7 @@ export const ExternalConfigAlert = ({
     <p>
       If you have questions about this, please ask data science in{" "}
       <LinkExternal href="https://mozilla.slack.com/archives/C0149JH7C1M">
-        #cirrus
+        #ask-experimenter
       </LinkExternal>
       .
     </p>

--- a/app/experimenter/nimbus-ui/src/components/PageResults/ExternalConfigAlert/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/ExternalConfigAlert/index.tsx
@@ -19,7 +19,8 @@ export const ExternalConfigAlert = ({
       The results shown on this page are from an analysis ran with at least one
       experiment override that affects only the <em>analysis</em>. The original
       <strong>
-        experiment details and description on the Summary page will not reflect this.
+        experiment details and description on the Summary page will not reflect
+        this.
       </strong>
     </p>
     <ul className="pl-0">


### PR DESCRIPTION
Because 

- The warning on the results page about a jetstream override points to #cirrus which is now defunct. It should point to #ask-experimenter.  The wording was also requested to be changed.

Commit

- change External Link from #cirrus to #ask-experimenter on line 56
-  change wording in <p> element starting on line 18(replaced "data" with "details and description")