### PR TITLE
fix #7475 feat(nimbus): Handle schema load failure

### DIFF
--- a/app/experimenter/features/__init__.py
+++ b/app/experimenter/features/__init__.py
@@ -53,7 +53,11 @@ class Feature(BaseModel):
     def load_remote_jsonschema(self):
         schema_url = urljoin(MC_ROOT, self.schema_paths.path)
         schema_data = requests.get(schema_url).content
-        return json.dumps(json.loads(schema_data), indent=2)
+
+        try:
+            return json.dumps(json.loads(schema_data), indent=2)
+        except json.JSONDecodeError:
+            return None
 
     def generate_jsonschema(self):
         schema = {

--- a/app/experimenter/features/management/commands/load_feature_configs.py
+++ b/app/experimenter/features/management/commands/load_feature_configs.py
@@ -1,4 +1,5 @@
 import logging
+from json import JSONDecodeError
 
 from django.core.management.base import BaseCommand
 
@@ -21,7 +22,10 @@ class Command(BaseCommand):
             )
             feature_config.name = feature.slug
             feature_config.description = feature.description
-            feature_config.schema = feature.get_jsonschema()
+            try:
+                feature_config.schema = feature.get_jsonschema()
+            except JSONDecodeError as error:
+                logger.info(f"Unable to load remote Feature: {error}")
             feature_config.read_only = True
             feature_config.save()
             logger.info(f"Feature Loaded: {feature.applicationSlug}/{feature.slug}")

--- a/app/experimenter/features/management/commands/load_feature_configs.py
+++ b/app/experimenter/features/management/commands/load_feature_configs.py
@@ -1,5 +1,4 @@
 import logging
-from json import JSONDecodeError
 
 from django.core.management.base import BaseCommand
 
@@ -22,11 +21,11 @@ class Command(BaseCommand):
             )
             feature_config.name = feature.slug
             feature_config.description = feature.description
-            try:
-                feature_config.schema = feature.get_jsonschema()
-            except JSONDecodeError as error:
-                logger.info(f"Unable to load remote Feature: {error}")
             feature_config.read_only = True
+
+            if (schema := feature.get_jsonschema()) is not None:
+                feature_config.schema = schema
+
             feature_config.save()
             logger.info(f"Feature Loaded: {feature.applicationSlug}/{feature.slug}")
 

--- a/app/experimenter/features/tests/__init__.py
+++ b/app/experimenter/features/tests/__init__.py
@@ -20,3 +20,11 @@ mock_remote_schema_features = override_settings(
         pathlib.Path(__file__).parent.absolute(), "fixtures", "remote_schema_features"
     )
 )
+
+mock_invalid_remote_schema_features = override_settings(
+    FEATURE_MANIFESTS_PATH=os.path.join(
+        pathlib.Path(__file__).parent.absolute(),
+        "fixtures",
+        "invalid_remote_schema_features",
+    )
+)

--- a/app/experimenter/features/tests/fixtures/invalid_remote_schema_features/firefox-desktop.yaml
+++ b/app/experimenter/features/tests/fixtures/invalid_remote_schema_features/firefox-desktop.yaml
@@ -1,0 +1,9 @@
+cfr:
+  description: "Doorhanger message template for Messaging System"
+  hasExposure: true
+  exposureDescription: "Exposure is sent if the message is about to be shown after trigger and targeting conditions on the message matched."
+  isEarlyStartup: false
+  schema:
+    uri: "resource://activity-stream/schemas/CFR/ExtensionDoorhanger.invalidSchema.json"
+    path: "path/to/invalidSchema.json"
+  variables: {}

--- a/app/experimenter/features/tests/fixtures/remote_schema_features/firefox-desktop.yaml
+++ b/app/experimenter/features/tests/fixtures/remote_schema_features/firefox-desktop.yaml
@@ -2,7 +2,7 @@ cfr:
   description: "Doorhanger message template for Messaging System"
   hasExposure: true
   exposureDescription: "Exposure is sent if the message is about to be shown after trigger and targeting conditions on the message matched."
-  isEarlyStartup: false
+  isEarlyStartup: true
   schema:
     uri: "resource://activity-stream/schemas/CFR/ExtensionDoorhanger.schema.json"
     path: "path/to/schema.json"

--- a/app/experimenter/features/tests/test_features.py
+++ b/app/experimenter/features/tests/test_features.py
@@ -195,14 +195,11 @@ class TestRemoteSchemaFeatures(TestCase):
             )[0]
             desktop_feature.get_jsonschema()
 
-    def test_raises_json_error(self):
+    def test_returns_none_for_invalid_json(self):
         self.setup_json_error()
 
-        with self.assertRaises(json.JSONDecodeError):
-            desktop_feature = Features.by_application(
-                NimbusConstants.Application.DESKTOP
-            )[0]
-            desktop_feature.get_jsonschema()
+        desktop_feature = Features.by_application(NimbusConstants.Application.DESKTOP)[0]
+        self.assertIsNone(desktop_feature.get_jsonschema())
 
 
 class TestCheckFeatures(TestCase):

--- a/app/experimenter/features/tests/test_load_feature_configs.py
+++ b/app/experimenter/features/tests/test_load_feature_configs.py
@@ -6,7 +6,10 @@ from django.test import TestCase
 from experimenter.experiments.models import NimbusExperiment, NimbusFeatureConfig
 from experimenter.experiments.tests.factories import NimbusFeatureConfigFactory
 from experimenter.features import Features
-from experimenter.features.tests import mock_valid_features
+from experimenter.features.tests import (
+    mock_invalid_remote_schema_features,
+    mock_valid_features,
+)
 
 
 @mock_valid_features
@@ -98,3 +101,18 @@ class TestLoadFeatureConfigs(TestCase):
             feature_config.description,
             "Some Firefox Feature",
         )
+
+
+@mock_invalid_remote_schema_features
+class TestLoadInvalidRemoteSchemaFeatureConfigs(TestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        Features.clear_cache()
+
+    def test_invalid_remote_schema_raises_json_error(self):
+        call_command("load_feature_configs")
+
+        for feature in Features.all():
+            with self.assertRaises(json.JSONDecodeError):
+                feature.get_jsonschema()


### PR DESCRIPTION
Because

* If we try to load a feature config schema from a path that doesn't resolve or results in a json decode error, we should just silently pass over it instead of failing to start all of experimenter. See failure here:

https://sentry.io/organizations/mozilla/issues/3392208353/?query=is%3Aunresolved 

Because this feature

https://hg.mozilla.org/mozilla-central/raw-file/default/toolkit/components/nimbus/FeatureManifest.yaml

is referring to this schema path

https://hg.mozilla.org/mozilla-central/raw-file/tip/browser/components/newtab/schemas/MessagingExperiment.schema.json

which is not found which is triggering a JSON decode error

This commit

* Adds the try/except block to deal with JSON decode error
* Test case to verify new changes 

fixes #7475 