### PR TITLE
fix #7500 feat(legacy): Revert "fix #7377 feat(legacy): remove create delivery button"

### DIFF
--- a/app/experimenter/legacy/legacy-ui/templates/experiments/list.html
+++ b/app/experimenter/legacy/legacy-ui/templates/experiments/list.html
@@ -66,6 +66,17 @@
   <a href="{% url "experiments-api-csv" %}?{{ request.GET.urlencode }}"><i class="fas fa-file-csv"></i> Export as CSV</a>
 {% endblock %}
 
+{% block header_sidebar %}
+  <div class="row">
+    <div class="col">
+      <a class="col btn btn-primary" href="{% url "experiments-create" %}">
+        <span class="fas fa-edit"></span>
+        Create Delivery
+      </a>
+    </div>
+  </div>
+{% endblock %}
+
 {% block main_content %}
   {% for experiment in experiments %}
     <a class="noanchorstyle hovershadow" href="{% url "experiments-detail" slug=experiment.slug %}">


### PR DESCRIPTION


Because

* Normandy will continue to be supported until Nimbus can take over for all of its capabilities

This commit

* Restores the create button in legacy
* This reverts commit b39379ecd0427759b01466937c15dc396ac4aa50.