### PR TITLE
fix #7502 bug(nimbus): only include sticky expression if other targeting defined

### DIFF
--- a/app/experimenter/experiments/models.py
+++ b/app/experimenter/experiments/models.py
@@ -327,7 +327,7 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
             ]
             sticky_expressions.append(f"region in {countries}")
 
-        if self.is_sticky:
+        if self.is_sticky and sticky_expressions:
             sticky_clause = "is_already_enrolled"
             if is_desktop:
                 sticky_clause = "experiment.slug in activeExperiments"

--- a/app/experimenter/experiments/tests/test_models.py
+++ b/app/experimenter/experiments/tests/test_models.py
@@ -607,6 +607,7 @@ class TestNimbusExperiment(TestCase):
                 f"&& {sticky_expression}"
             ),
         )
+        JEXLParser().parse(experiment.targeting)
 
     def test_targeting_with_sticky_mobile(self):
         language_en = LanguageFactory.create(code="en")
@@ -640,6 +641,32 @@ class TestNimbusExperiment(TestCase):
             experiment.targeting,
             ("(app_version|versionCompare('101.*') <= 0) " f"&& {sticky_expression}"),
         )
+        JEXLParser().parse(experiment.targeting)
+
+    def test_targeting_with_sticky_and_no_advanced_targeting_omits_sticky_expression(
+        self,
+    ):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            application=NimbusExperiment.Application.DESKTOP,
+            firefox_min_version=NimbusExperiment.Version.NO_VERSION,
+            firefox_max_version=NimbusExperiment.Version.NO_VERSION,
+            targeting_config_slug=NimbusExperiment.TargetingConfig.NO_TARGETING,
+            channel=NimbusExperiment.Channel.RELEASE,
+            languages=[],
+            locales=[],
+            countries=[],
+            is_sticky=True,
+        )
+
+        self.assertEqual(
+            experiment.targeting,
+            (
+                '(browserSettings.update.channel == "release") '
+                "&& ('app.shield.optoutstudies.enabled'|preferenceValue)"
+            ),
+        )
+        JEXLParser().parse(experiment.targeting)
 
     def test_targeting_uses_published_targeting_string(self):
         published_targeting = "published targeting jexl"


### PR DESCRIPTION


Because

* Including an empty expression like () is invalid JEXL
* If no targeting parameters are specified that would be ORed with a sticky clause, then there's nothing to OR against

This commit

* Only includes the sticky expression if there are other targeting parameters to OR it against