### PR TITLE
fix #7415 feat(nimbus): add feedback link to landing page

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/PageHome/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageHome/index.tsx
@@ -143,24 +143,28 @@ const PageHome: React.FunctionComponent<PageHomeProps> = () => {
       </div>
 
       <Alert variant="primary" className="mb-4">
-        <span role="img" aria-label="book emoji">
-          📖
-        </span>{" "}
-        Not sure where to start? Check out the{" "}
-        <LinkExternal href="https://experimenter.info">
-          Experimenter documentation hub
-        </LinkExternal>
-        .
+        <div>
+          <span role="img" aria-label="book emoji">
+            📖
+          </span>{" "}
+          Not sure where to start? Check out the{" "}
+          <LinkExternal href="https://experimenter.info">
+            Experimenter documentation hub.
+          </LinkExternal>
+        </div>
+        <div>
+          <span role="img" aria-label="magnifying emoji">
+            🔍
+          </span>{" "}
+          Looking for the old Experimenter?{" "}
+          <LinkExternal href="/legacy">It&lsquo;s still here!</LinkExternal>
+          <span role="img" aria-label="magnifying emoji">
+            💡
+          </span>{" "}
+          Have feedback?{" "}
+          <LinkExternal href="/legacy">Please file it here!</LinkExternal>
+        </div>
       </Alert>
-
-      <Alert variant="warning" className="mb-4">
-        <span role="img" aria-label="magnifying emoji">
-          🔍
-        </span>{" "}
-        Looking for the old Experimenter?{" "}
-        <LinkExternal href="/legacy">It&lsquo;s still here!</LinkExternal>
-      </Alert>
-
       <Body />
     </AppLayout>
   );


### PR DESCRIPTION
Because

* We have a feedback link on the detail page but not the landing page
* It would be helpful to have it on the landing page as well

This commit

* Adds a feedback link to the landing page