### PR TITLE
fix #7514 bug(nimbus): add correct feedback link

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/PageHome/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageHome/index.tsx
@@ -162,7 +162,9 @@ const PageHome: React.FunctionComponent<PageHomeProps> = () => {
             💡
           </span>{" "}
           Have feedback?{" "}
-          <LinkExternal href="/legacy">Please file it here!</LinkExternal>
+          <LinkExternal href="https://mozilla-hub.atlassian.net/secure/CreateIssueDetails!init.jspa?pid=10203&amp;issuetype=10097">
+            Please file it here!
+          </LinkExternal>
         </div>
       </Alert>
       <Body />


### PR DESCRIPTION
Because

* We accidentally forgot to put the correct url in the new feedback link

This commit

* Puts the correct url in