### PR TITLE
Fixes #6696 fixes #6697 feat(nimbus): Add checkbox for isRollout and review validation

### DIFF
--- a/app/experimenter/experiments/api/v5/inputs.py
+++ b/app/experimenter/experiments/api/v5/inputs.py
@@ -54,6 +54,7 @@ class TreatmentBranchInput(BranchInput):
 
 class ExperimentInput(graphene.InputObjectType):
     id = graphene.Int()
+    is_rollout = graphene.Boolean()
     is_archived = graphene.Boolean()
     status = NimbusExperimentStatusEnum()
     status_next = NimbusExperimentStatusEnum()

--- a/app/experimenter/experiments/api/v5/serializers.py
+++ b/app/experimenter/experiments/api/v5/serializers.py
@@ -1379,9 +1379,9 @@ class NimbusReviewSerializer(serializers.ModelSerializer):
         self.warnings["is_rollout"] = [NimbusExperiment.WARNING_ROLLOUT_SUPPORT]
         return data
 
-    def validate(self, attrs):
-        application = attrs.get("application")
-        channel = attrs.get("channel")
+    def validate(self, data):
+        application = data.get("application")
+        channel = data.get("channel")
         if application != NimbusExperiment.Application.DESKTOP and not channel:
             raise serializers.ValidationError(
                 {"channel": "Channel is required for this application."}
@@ -1391,10 +1391,10 @@ class NimbusReviewSerializer(serializers.ModelSerializer):
         data = self._validate_feature_configs(data)
         data = self._validate_versions(data)
         data = self._validate_sticky_enrollment(data)
+        data = self._validate_rollout_support(data)
         if application != NimbusExperiment.Application.DESKTOP:
             data = self._validate_languages_versions(data)
             data = self._validate_countries_versions(data)
-        data = self._validate_rollout_support(data)
         return data
 
 

--- a/app/experimenter/experiments/api/v5/serializers.py
+++ b/app/experimenter/experiments/api/v5/serializers.py
@@ -470,7 +470,6 @@ class NimbusExperimentBranchMixin:
     def validate(self, data):
         data = super().validate(data)
         data = self._validate_duplicate_branch_names(data)
-        data = self._validate_single_branch_for_rollout(data)
         return data
 
     def _validate_duplicate_branch_names(self, data):
@@ -494,22 +493,6 @@ class NimbusExperimentBranchMixin:
                         ],
                     }
                 )
-        return data
-
-    def _validate_single_branch_for_rollout(self, data):
-        if (
-            self.instance
-            and self.instance.is_rollout
-            and len(data.get("treatment_branches", [])) > 0
-        ):
-            raise serializers.ValidationError(
-                {
-                    "treatment_branches": [
-                        {"name": NimbusConstants.ERROR_SINGLE_BRANCH_FOR_ROLLOUT}
-                        for i in data["treatment_branches"]
-                    ],
-                }
-            )
         return data
 
     def update(self, experiment, data):
@@ -1201,6 +1184,8 @@ class NimbusReviewSerializer(serializers.ModelSerializer):
         errors = []
         for branch in value:
             error = {}
+            if self.instance and self.instance.is_rollout:
+                error["name"] = [NimbusConstants.ERROR_SINGLE_BRANCH_FOR_ROLLOUT]
             if branch["description"] == "":
                 error["description"] = [NimbusConstants.ERROR_REQUIRED_FIELD]
             errors.append(error)

--- a/app/experimenter/experiments/constants.py
+++ b/app/experimenter/experiments/constants.py
@@ -31,10 +31,12 @@ class ApplicationConfig:
     kinto_collection: str
     randomization_unit: str
 
+
 @dataclass
 class RolloutSupport:
     application: object
     firefox_min_version: object
+
 
 APPLICATION_CONFIG_DESKTOP = ApplicationConfig(
     name="Firefox Desktop",
@@ -348,7 +350,6 @@ class NimbusConstants(object):
         FIREFOX_119 = "119.!"
         FIREFOX_120 = "120.!"
 
-
     ROLLOUT_SUPPORT = (
         RolloutSupport(
             application=Application.DESKTOP,
@@ -359,7 +360,7 @@ class NimbusConstants(object):
             firefox_min_version=Version.FIREFOX_102,
         ),
     )
-    
+
     class EmailType(models.TextChoices):
         EXPERIMENT_END = "experiment end"
         ENROLLMENT_END = "enrollment end"

--- a/app/experimenter/experiments/constants.py
+++ b/app/experimenter/experiments/constants.py
@@ -31,6 +31,10 @@ class ApplicationConfig:
     kinto_collection: str
     randomization_unit: str
 
+@dataclass
+class RolloutSupport:
+    application: object
+    firefox_min_version: object
 
 APPLICATION_CONFIG_DESKTOP = ApplicationConfig(
     name="Firefox Desktop",
@@ -344,6 +348,18 @@ class NimbusConstants(object):
         FIREFOX_119 = "119.!"
         FIREFOX_120 = "120.!"
 
+
+    ROLLOUT_SUPPORT = (
+        RolloutSupport(
+            application=Application.DESKTOP,
+            firefox_min_version=Version.FIREFOX_102,
+        ),
+        RolloutSupport(
+            application=Application.FENIX,
+            firefox_min_version=Version.FIREFOX_102,
+        ),
+    )
+    
     class EmailType(models.TextChoices):
         EXPERIMENT_END = "experiment end"
         ENROLLMENT_END = "enrollment end"
@@ -408,6 +424,11 @@ Optional - We believe this outcome will <describe impact> on <core metric>
     )
     ERROR_FIREFOX_VERSION_MAX = (
         "Ensure this value is greater than or equal to the minimum version"
+    )
+
+    WARNING_ROLLOUT_SUPPORT = (
+        "Rollouts may not be fully supported for the selected "
+        "application and minimum version"
     )
 
     # Analysis can be computed starting the week after enrollment

--- a/app/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_experiment_branch_mixin.py
+++ b/app/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_experiment_branch_mixin.py
@@ -263,36 +263,6 @@ class TestNimbusExperimentBranchMixinSingleFeature(TestCase):
             },
         )
 
-    def test_no_treatment_branches_for_rollout(self):
-        experiment = NimbusExperimentFactory.create(
-            status=NimbusExperiment.Status.DRAFT,
-        )
-        experiment.is_rollout = True
-        experiment.save()
-        for branch in experiment.treatment_branches:
-            branch.delete()
-
-        data = {
-            "treatment_branches": [
-                {"name": "treatment A", "description": "desc1", "ratio": 1},
-                {"name": "treatment B", "description": "desc2", "ratio": 1},
-            ],
-            "changelog_message": "test changelog message",
-        }
-        serializer = NimbusExperimentSerializer(
-            experiment, data=data, partial=True, context={"user": self.user}
-        )
-        self.assertFalse(serializer.is_valid())
-        self.assertEqual(
-            serializer.errors,
-            {
-                "treatment_branches": [
-                    {"name": NimbusConstants.ERROR_SINGLE_BRANCH_FOR_ROLLOUT}
-                    for i in data["treatment_branches"]
-                ],
-            },
-        )
-
 
 class TestNimbusExperimentBranchMixinMultiFeature(TestCase):
     maxDiff = None

--- a/app/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_ready_for_review_serializer.py
+++ b/app/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_ready_for_review_serializer.py
@@ -1407,6 +1407,29 @@ class TestNimbusReviewSerializerMultiFeature(TestCase):
         )
         self.assertTrue(serializer.is_valid())
 
+    def test_no_treatment_branches_for_rollout(self):
+        experiment = NimbusExperimentFactory.create(
+            status=NimbusExperiment.Status.DRAFT,
+        )
+        experiment.is_rollout = True
+        experiment.save()
+
+        serializer = NimbusReviewSerializer(
+            experiment,
+            data=NimbusReviewSerializer(
+                experiment,
+                context={"user": self.user},
+            ).data,
+            context={"user": self.user},
+        )
+
+        self.assertFalse(serializer.is_valid())
+        self.assertEqual(
+            serializer.errors["treatment_branches"][0]["name"][0],
+            NimbusConstants.ERROR_SINGLE_BRANCH_FOR_ROLLOUT,
+            serializer.errors,
+        )
+
     # Add schema warn logic for multifeature in #7028
     # def test_serializer_feature_config_validation_reference_value_schema_warn(self):
     #     experiment = NimbusExperimentFactory.create_with_lifecycle(

--- a/app/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_ready_for_review_serializer.py
+++ b/app/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_ready_for_review_serializer.py
@@ -1135,9 +1135,10 @@ class TestNimbusReviewSerializerSingleFeature(TestCase):
             status=NimbusExperiment.Status.DRAFT,
             application=NimbusExperiment.Application.DESKTOP,
             channel=NimbusExperiment.Channel.RELEASE,
-            firefox_min_version=NimbusExperiment.Version.FIREFOX_100,
+            firefox_min_version=NimbusExperiment.Version.FIREFOX_102,
         )
         experiment.is_rollout = True
+        experiment.is_sticky = True
         for branch in experiment.treatment_branches:
             branch.delete()
         experiment.save()
@@ -1162,6 +1163,7 @@ class TestNimbusReviewSerializerSingleFeature(TestCase):
             firefox_min_version=NimbusExperiment.Version.FIREFOX_50,
         )
         experiment.is_rollout = True
+        experiment.is_sticky = True
         for branch in experiment.treatment_branches:
             branch.delete()
         experiment.save()
@@ -1175,7 +1177,7 @@ class TestNimbusReviewSerializerSingleFeature(TestCase):
             context={"user": self.user},
         )
 
-        self.assertTrue(serializer.is_valid(), serializer.errors)
+        self.assertTrue(serializer.is_valid())
         self.assertEqual(
             serializer.warnings["is_rollout"][0],
             NimbusConstants.WARNING_ROLLOUT_SUPPORT,
@@ -1573,4 +1575,3 @@ class TestNimbusReviewSerializerMultiFeature(TestCase):
     #         ),
     #         serializer.warnings,
     #     )
-    

--- a/app/experimenter/nimbus-ui/schema.graphql
+++ b/app/experimenter/nimbus-ui/schema.graphql
@@ -40,6 +40,7 @@ input ExperimentCloneInput {
 
 input ExperimentInput {
   id: Int
+  isRollout: Boolean
   isArchived: Boolean
   status: NimbusExperimentStatusEnum
   statusNext: NimbusExperimentStatusEnum

--- a/app/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/index.tsx
@@ -208,6 +208,13 @@ export const FormAudience = ({
               <SelectOptions options={config.firefoxVersions} />
             </Form.Control>
             <FormErrors name="firefoxMinVersion" />
+            {fieldMessages.is_rollout?.length > 0 && (
+              // @ts-ignore This component doesn't technically support type="warning", but
+              // all it's doing is using the string in a class, so we can safely override.
+              <Form.Control.Feedback type="warning" data-for="minVersion">
+                {(fieldMessages.is_rollout as SerializerMessage).join(", ")}
+              </Form.Control.Feedback>
+            )}
           </Form.Group>
           <Form.Group as={Col} controlId="maxVersion">
             <Form.Label className="d-flex align-items-center">
@@ -220,6 +227,13 @@ export const FormAudience = ({
               <SelectOptions options={config.firefoxVersions} />
             </Form.Control>
             <FormErrors name="firefoxMaxVersion" />
+            {fieldMessages.is_rollout?.length > 0 && (
+              // @ts-ignore This component doesn't technically support type="warning", but
+              // all it's doing is using the string in a class, so we can safely override.
+              <Form.Control.Feedback type="warning" data-for="maxVersion">
+                {(fieldMessages.is_rollout as SerializerMessage).join(", ")}
+              </Form.Control.Feedback>
+            )}
           </Form.Group>
         </Form.Row>
         <Form.Row>

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/index.test.tsx
@@ -145,6 +145,15 @@ describe("FormBranches", () => {
     expect(saveResult.warnFeatureSchema).toBeTruthy();
   });
 
+  it("sets isRollout when checkbox enabled", async () => {
+    const onSave = jest.fn();
+    render(<SubjectBranches {...{ onSave }} />);
+    fireEvent.click(screen.getByTestId("is-rollout-checkbox"));
+    await clickAndWaitForSave(onSave);
+    const saveResult = onSave.mock.calls[0][0];
+    expect(saveResult.isRollout).toBeTruthy();
+  });
+
   it("gracefully handles selecting an invalid feature config", async () => {
     const onSave = jest.fn();
     render(<SubjectBranches {...{ onSave }} />);

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/index.tsx
@@ -261,7 +261,26 @@ export const FormBranches = ({
               checked={!!isRollout}
               type="checkbox"
               label="Handle this experiment as a single-branch rollout"
+              className={classNames({
+                "is-warning":
+                  fieldMessages.is_rollout?.length > 0 ||
+                  fieldWarnings.is_rollout?.length > 0,
+              })}
             />
+            {fieldMessages.is_rollout?.length > 0 && (
+              // @ts-ignore This component doesn't technically support type="warning", but
+              // all it's doing is using the string in a class, so we can safely override.
+              <Form.Control.Feedback type="warning" data-for="isRollout">
+                {(fieldMessages.is_rollout as SerializerMessage).join(", ")}
+              </Form.Control.Feedback>
+            )}
+            {fieldWarnings.is_rollout?.length > 0 && (
+              // @ts-ignore This component doesn't technically support type="warning", but
+              // all it's doing is using the string in a class, so we can safely override.
+              <Form.Control.Feedback type="warning" data-for="isRollout">
+                {(fieldWarnings.is_rollout as SerializerMessage).join(", ")}
+              </Form.Control.Feedback>
+            )}
           </Form.Group>
         </Form.Row>
 

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/index.tsx
@@ -46,6 +46,7 @@ export const FormBranches = ({
     {
       featureConfigIds: experimentFeatureConfigIds,
       warnFeatureSchema,
+      isRollout,
       referenceBranch,
       treatmentBranches,
       equalRatio,
@@ -126,6 +127,14 @@ export const FormBranches = ({
   ) => {
     commitFormData();
     dispatch({ type: "setFeatureConfigs", value });
+  };
+
+  const handleIsRollout = (ev: React.ChangeEvent<HTMLInputElement>) => {
+    commitFormData();
+    dispatch({
+      type: "setIsRollout",
+      value: ev.target.checked,
+    });
   };
 
   const onFeatureConfigChange = (ev: React.ChangeEvent<HTMLInputElement>) => {
@@ -243,6 +252,18 @@ export const FormBranches = ({
             </Form.Control.Feedback>
           )}
         </Form.Group>
+
+        <Form.Row>
+          <Form.Group as={Col} controlId="isRollout">
+            <Form.Check
+              data-testid="is-rollout-checkbox"
+              onChange={handleIsRollout}
+              checked={!!isRollout}
+              type="checkbox"
+              label="Handle this experiment as a single-branch rollout"
+            />
+          </Form.Group>
+        </Form.Row>
 
         <Form.Row>
           <Form.Group as={Col} controlId="warnFeatureSchema">

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/index.tsx
@@ -274,13 +274,6 @@ export const FormBranches = ({
                 {(fieldMessages.is_rollout as SerializerMessage).join(", ")}
               </Form.Control.Feedback>
             )}
-            {fieldWarnings.is_rollout?.length > 0 && (
-              // @ts-ignore This component doesn't technically support type="warning", but
-              // all it's doing is using the string in a class, so we can safely override.
-              <Form.Control.Feedback type="warning" data-for="isRollout">
-                {(fieldWarnings.is_rollout as SerializerMessage).join(", ")}
-              </Form.Control.Feedback>
-            )}
           </Form.Group>
         </Form.Row>
 

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/mocks.tsx
@@ -54,6 +54,7 @@ const MOCK_STATE: FormBranchesState = {
   globalErrors: [],
   featureConfigIds: [],
   warnFeatureSchema: false,
+  isRollout: false,
   referenceBranch: {
     ...MOCK_EXPERIMENT.referenceBranch!,
     screenshots: [],

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/reducer/actions.ts
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/reducer/actions.ts
@@ -23,6 +23,8 @@ export function formBranchesActionReducer(
       return removeBranch(state, action);
     case "setFeatureConfigs":
       return setFeatureConfigs(state, action);
+    case "setIsRollout":
+      return setIsRollout(state, action);
     case "setwarnFeatureSchema":
       return setwarnFeatureSchema(state, action);
     case "setEqualRatio":
@@ -47,6 +49,7 @@ export type FormBranchesAction =
   | RemoveBranchAction
   | SetEqualRatioAction
   | SetFeatureConfigsAction
+  | SetIsRolloutAction
   | SetwarnFeatureSchemaAction
   | SetSubmitErrorsAction
   | ClearSubmitErrorsAction
@@ -114,6 +117,21 @@ function setFeatureConfigs(
   return {
     ...state,
     featureConfigIds: featureConfigIds || null,
+  };
+}
+
+type SetIsRolloutAction = {
+  type: "setIsRollout";
+  value: FormBranchesState["isRollout"];
+};
+
+function setIsRollout(
+  state: FormBranchesState,
+  { value: isRollout }: SetIsRolloutAction,
+) {
+  return {
+    ...state,
+    isRollout,
   };
 }
 

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/reducer/index.test.ts
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/reducer/index.test.ts
@@ -14,6 +14,7 @@ const MOCK_STATE: FormBranchesState = {
   globalErrors: [],
   featureConfigIds: [],
   warnFeatureSchema: false,
+  isRollout: false,
   referenceBranch: {
     ...MOCK_EXPERIMENT.referenceBranch!,
     screenshots: [],

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/reducer/state.ts
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/reducer/state.ts
@@ -13,7 +13,7 @@ import {
 
 export type FormBranchesState = Pick<
   ExperimentInput,
-  "featureConfigIds" | "warnFeatureSchema"
+  "featureConfigIds" | "warnFeatureSchema" | "isRollout"
 > & {
   referenceBranch: null | AnnotatedBranch;
   treatmentBranches: null | AnnotatedBranch[];
@@ -35,6 +35,7 @@ export type AnnotatedBranch = Omit<TreatmentBranchInput, "id"> & {
 export function createInitialState({
   featureConfigs,
   warnFeatureSchema,
+  isRollout,
   referenceBranch,
   treatmentBranches,
 }: getExperiment_experimentBySlug): FormBranchesState {
@@ -62,6 +63,7 @@ export function createInitialState({
     equalRatio,
     featureConfigIds: featureConfigs?.map((f) => f?.id || null),
     warnFeatureSchema,
+    isRollout,
     globalErrors: [],
     referenceBranch: annotatedReferenceBranch,
     treatmentBranches: annotatedTreatmentBranches,

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/reducer/update.ts
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/reducer/update.ts
@@ -13,6 +13,7 @@ export type FormBranchesSaveState = Pick<
   ExperimentInput,
   | "featureConfigIds"
   | "warnFeatureSchema"
+  | "isRollout"
   | "referenceBranch"
   | "treatmentBranches"
 >;
@@ -31,6 +32,7 @@ export function extractUpdateState(
   const {
     featureConfigIds,
     warnFeatureSchema,
+    isRollout,
     referenceBranch,
     treatmentBranches,
   } = state;
@@ -42,6 +44,7 @@ export function extractUpdateState(
   return {
     featureConfigIds,
     warnFeatureSchema,
+    isRollout,
     referenceBranch: extractUpdateBranch(
       referenceBranch,
       formData.referenceBranch,

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/index.tsx
@@ -19,7 +19,6 @@ import { updateExperiment_updateExperiment as UpdateExperimentBranchesResult } f
 import AppLayoutWithExperiment from "../AppLayoutWithExperiment";
 import LinkExternal from "../LinkExternal";
 import FormBranches from "./FormBranches";
-import { FormBranchesSaveState } from "./FormBranches/reducer";
 
 const PageEditBranches: React.FunctionComponent<RouteComponentProps> = () => {
   const { allFeatureConfigs } = useConfig();
@@ -39,12 +38,7 @@ const PageEditBranches: React.FunctionComponent<RouteComponentProps> = () => {
 
   const onFormSave = useCallback(
     async (
-      {
-        featureConfigIds,
-        warnFeatureSchema,
-        referenceBranch,
-        treatmentBranches,
-      }: FormBranchesSaveState,
+      formBranchesSaveState,
       setSubmitErrors,
       clearSubmitErrors,
       next: boolean,
@@ -55,12 +49,9 @@ const PageEditBranches: React.FunctionComponent<RouteComponentProps> = () => {
         const result = await updateExperimentBranches({
           variables: {
             input: {
+              ...formBranchesSaveState,
               id: nimbusExperimentId,
               changelogMessage: CHANGELOG_MESSAGES.UPDATED_BRANCHES,
-              featureConfigIds,
-              warnFeatureSchema,
-              referenceBranch,
-              treatmentBranches,
             },
           },
         });

--- a/app/experimenter/nimbus-ui/src/types/globalTypes.ts
+++ b/app/experimenter/nimbus-ui/src/types/globalTypes.ts
@@ -220,6 +220,7 @@ export interface ExperimentCloneInput {
 
 export interface ExperimentInput {
   id?: number | null;
+  isRollout?: boolean | null;
   isArchived?: boolean | null;
   status?: NimbusExperimentStatusEnum | null;
   statusNext?: NimbusExperimentStatusEnum | null;


### PR DESCRIPTION
Fixes #6696 #6697 


------

Still todo: 
- [ ] the warning isn't showing up on the branches page or audience during initial creation 
- [ ] test for warning in [PageEditBranches/FormBranches/index.test.tsx](https://github.com/mozilla/experimenter/pull/7528/files#diff-bd25c9ba9585bc8a282be88a4a36415f53abf603ea224bcbde59f41acdcf8f29)
- [ ] test for warning in PageEditAudience/FormAudience/index.test.tsx

------
Because:

* not all clients supported by Nimbus support `isRollout`

This commit:

* adds a review validator warning if the selected combination of
  application, channel, and min version don't support rollouts

* adds a list to NimbusConstants describing clients by application,
  channel, and min version combinations that support rollouts

* implements review validation of the experiment against the list of
  supported clients

* tweaks the branch edit page UI and audience page UI to display errors & warning for
  isRollout