### PR TITLE
fix #7496 feat(nimbus): load external configs hourly

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,6 @@
 version: 2.1
+orbs:
+  gh: circleci/github-cli@2.0
 jobs:
   check:
     machine:
@@ -46,7 +48,7 @@ jobs:
           command: |
             cp .env.integration-tests .env
             make refresh SKIP_DUMMY=1 up_prod_detached integration_test_nimbus PYTEST_ARGS="$PYTEST_ARGS"
-  
+
   integration_nimbus_desktop_beta:
     machine:
       image: ubuntu-2004:202107-02 # Ubuntu 20.04, Docker v20.10.7, Docker Compose v1.29.2
@@ -73,6 +75,7 @@ jobs:
           command: |
             cp .env.integration-tests .env
             make refresh SKIP_DUMMY=1 up_prod_detached integration_test_nimbus PYTEST_ARGS="$PYTEST_ARGS"
+
   integration_nimbus_desktop:
     machine:
       image: ubuntu-2004:202107-02 # Ubuntu 20.04, Docker v20.10.7, Docker Compose v1.29.2
@@ -90,6 +93,7 @@ jobs:
             PYTEST_ARGS=$(circleci tests split "app/tests/integration/nimbus/parallel_pytest_args.txt")
             cp .env.integration-tests .env
             make refresh SKIP_DUMMY=1 UPDATE_FIREFOX_VERSION="true" up_prod_detached integration_test_nimbus PYTEST_ARGS="$PYTEST_ARGS"
+
   integration_nimbus_sdk:
     machine:
       image: ubuntu-2004:202107-02 # Ubuntu 20.04, Docker v20.10.7, Docker Compose v1.29.2
@@ -136,7 +140,43 @@ jobs:
             docker push ${DOCKERHUB_REPO}:build_test
             docker push ${DOCKERHUB_REPO}:build_ui
             docker push ${DOCKERHUB_REPO}:latest
-  
+
+  update_external_configs:
+    working_directory: ~/experimenter
+    machine:
+      image: ubuntu-2004:202107-02 # Ubuntu 20.04, Docker v20.10.7, Docker Compose v1.29.2
+      docker_layer_caching: true
+    steps:
+      - add_ssh_keys:
+          fingerprints:
+            - "6f:26:1b:06:f2:32:62:65:bd:92:be:a9:2f:7b:65:59" # for git pushes from circleci, since relies on ssh
+      - checkout
+      - gh/setup:
+          token: GH_TOKEN # for gh commands from circleci, since relies on user token, since por que no los dos?
+      - run:
+          name: Setup Git
+          command: |
+            git config --local user.name "dataops-ci-bot"
+            git config --local user.email "dataops+ci-bot@mozilla.com"
+            gh config set git_protocol https
+      - run:
+          name: Check for External Config Update
+          command: |
+            git checkout main
+            git pull origin main
+            make fetch_external_resources
+            if git diff --name-only
+              then
+                git checkout -B external-config
+                git add .
+                git commit -m 'chore(nimbus): Update External Configs'
+                git push origin external-config -f
+                gh pr create -t "chore(nimbus): Update External Configs" -b "" --base main --head external-config --repo mozilla/experimenter
+              else
+                echo "No config changes, skipping"
+                circleci-agent step halt
+            fi
+
   build_firefox_versions:
     working_directory: ~/experimenter
     machine:
@@ -192,7 +232,7 @@ jobs:
             docker push ${DOCKERHUB_REPO}:nimbus-firefox-release
       - save_cache:
           key: version-cache-{{ checksum "old_versions.txt" }}
-          paths: 
+          paths:
             - /home/circleci/experimenter/old_versions.txt
 
 workflows:
@@ -207,7 +247,18 @@ workflows:
                 - main
     jobs:
       - build_firefox_versions
-              
+
+  hourly:
+    triggers:
+      - schedule:
+          cron: "0 * * * *"
+          filters:
+            branches:
+              only:
+                - main
+    jobs:
+      - update_external_configs
+
   build:
     jobs:
       - check:


### PR DESCRIPTION
Because

* We want to update the external configs for jetstream and features automatically
* We want updates to those files to be tested as part of CI

This commit

* Adds a new circle task to check for updates in external configs hourly
* If changes are detected, automatically create a PR