### PR TITLE
fixes #6697 feat(nimbus): Review validation errors for rollouts

### DIFF
--- a/app/experimenter/experiments/api/v5/serializers.py
+++ b/app/experimenter/experiments/api/v5/serializers.py
@@ -1384,7 +1384,10 @@ class NimbusReviewSerializer(serializers.ModelSerializer):
         rollout_version_supported = NimbusExperiment.ROLLOUT_SUPPORT_VERSION.get(
             self.instance.application
         )
-        if min_version < NimbusExperiment.Version.parse(rollout_version_supported):
+        if (
+            rollout_version_supported is not None
+            and min_version < NimbusExperiment.Version.parse(rollout_version_supported)
+        ):
             raise serializers.ValidationError(
                 {"is_rollout": NimbusConstants.ERROR_ROLLOUT_VERSION_SUPPORT}
             )

--- a/app/experimenter/experiments/api/v5/serializers.py
+++ b/app/experimenter/experiments/api/v5/serializers.py
@@ -1380,13 +1380,14 @@ class NimbusReviewSerializer(serializers.ModelSerializer):
         if not self.instance or not self.instance.is_rollout:
             return data
 
-        for support in NimbusExperiment.ROLLOUT_SUPPORT:
-            if NimbusExperiment.Version.parse(
-                self.instance.firefox_min_version
-            ) < NimbusExperiment.Version.parse(support.firefox_min_version):
-                raise serializers.ValidationError(
-                    {"is_rollout": NimbusConstants.ERROR_ROLLOUT_VERSION_SUPPORT}
-                )
+        min_version = NimbusExperiment.Version.parse(self.instance.firefox_min_version)
+        rollout_version_supported = NimbusExperiment.ROLLOUT_SUPPORT_VERSION.get(
+            self.instance.application
+        )
+        if min_version < NimbusExperiment.Version.parse(rollout_version_supported):
+            raise serializers.ValidationError(
+                {"is_rollout": NimbusConstants.ERROR_ROLLOUT_VERSION_SUPPORT}
+            )
 
         return data
 

--- a/app/experimenter/experiments/constants.py
+++ b/app/experimenter/experiments/constants.py
@@ -147,12 +147,6 @@ class Application(models.TextChoices):
     )
 
 
-@dataclass
-class RolloutSupport:
-    application: object
-    firefox_min_version: object
-
-
 class NimbusConstants(object):
     class Status(models.TextChoices):
         DRAFT = "Draft"
@@ -372,28 +366,13 @@ class NimbusConstants(object):
         Application.FOCUS_IOS: Version.FIREFOX_101,
     }
 
-    ROLLOUT_SUPPORT = (
-        RolloutSupport(
-            application=Application.DESKTOP,
-            firefox_min_version=Version.FIREFOX_105,
-        ),
-        RolloutSupport(
-            application=Application.FENIX,
-            firefox_min_version=Version.FIREFOX_105,
-        ),
-        RolloutSupport(
-            application=Application.IOS,
-            firefox_min_version=Version.FIREFOX_105,
-        ),
-        RolloutSupport(
-            application=Application.FOCUS_ANDROID,
-            firefox_min_version=Version.FIREFOX_105,
-        ),
-        RolloutSupport(
-            application=Application.FOCUS_IOS,
-            firefox_min_version=Version.FIREFOX_105,
-        ),
-    )
+    ROLLOUT_SUPPORT_VERSION = {
+        Application.DESKTOP: Version.FIREFOX_105,
+        Application.FENIX: Version.FIREFOX_105,
+        Application.FOCUS_ANDROID: Version.FIREFOX_105,
+        Application.IOS: Version.FIREFOX_105,
+        Application.FOCUS_IOS: Version.FIREFOX_105,
+    }
 
     # Telemetry systems including Firefox Desktop Telemetry v4 and Glean
     # have limits on the length of their unique identifiers, we should

--- a/app/experimenter/experiments/constants.py
+++ b/app/experimenter/experiments/constants.py
@@ -147,6 +147,12 @@ class Application(models.TextChoices):
     )
 
 
+@dataclass
+class RolloutSupport:
+    application: object
+    firefox_min_version: object
+
+
 class NimbusConstants(object):
     class Status(models.TextChoices):
         DRAFT = "Draft"
@@ -366,6 +372,29 @@ class NimbusConstants(object):
         Application.FOCUS_IOS: Version.FIREFOX_101,
     }
 
+    ROLLOUT_SUPPORT = (
+        RolloutSupport(
+            application=Application.DESKTOP,
+            firefox_min_version=Version.FIREFOX_105,
+        ),
+        RolloutSupport(
+            application=Application.FENIX,
+            firefox_min_version=Version.FIREFOX_105,
+        ),
+        RolloutSupport(
+            application=Application.IOS,
+            firefox_min_version=Version.FIREFOX_105,
+        ),
+        RolloutSupport(
+            application=Application.FOCUS_ANDROID,
+            firefox_min_version=Version.FIREFOX_105,
+        ),
+        RolloutSupport(
+            application=Application.FOCUS_IOS,
+            firefox_min_version=Version.FIREFOX_105,
+        ),
+    )
+
     # Telemetry systems including Firefox Desktop Telemetry v4 and Glean
     # have limits on the length of their unique identifiers, we should
     # limit the size of our slugs to the smallest limit, which is 80
@@ -390,6 +419,9 @@ Optional - We believe this outcome will <describe impact> on <core metric>
     # Serializer validation errors
     ERROR_DUPLICATE_BRANCH_NAME = "Branch names must be unique."
     ERROR_SINGLE_BRANCH_FOR_ROLLOUT = "A rollout may have only a single reference branch"
+    ERROR_ROLLOUT_VERSION_SUPPORT = (
+        "Rollouts are not supported for the given application and version number."
+    )
     ERROR_DUPLICATE_BRANCH_FEATURE_VALUE = (
         "A branch can not have multiple configurations for the same feature"
     )

--- a/app/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_experiment_branch_mixin.py
+++ b/app/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_experiment_branch_mixin.py
@@ -264,8 +264,17 @@ class TestNimbusExperimentBranchMixinSingleFeature(TestCase):
         )
 
     def test_no_treatment_branches_for_rollout(self):
-        experiment = NimbusExperimentFactory.create(
-            status=NimbusExperiment.Status.DRAFT,
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            application=NimbusExperiment.Application.DESKTOP,
+            channel=NimbusExperiment.Channel.NO_CHANNEL,
+            feature_configs=[
+                NimbusFeatureConfigFactory(
+                    application=NimbusExperiment.Application.DESKTOP
+                )
+            ],
+            is_sticky=True,
+            targeting_config_slug=NimbusExperiment.TargetingConfig.MAC_ONLY,
         )
         experiment.is_rollout = True
         experiment.save()
@@ -273,25 +282,54 @@ class TestNimbusExperimentBranchMixinSingleFeature(TestCase):
             branch.delete()
 
         data = {
+            "application": f"{NimbusExperiment.Application.DESKTOP}",
+            "is_sticky": "false",
+            "targeting_config_slug": f"{NimbusExperiment.TargetingConfig.MAC_ONLY}",
             "treatment_branches": [
                 {"name": "treatment A", "description": "desc1", "ratio": 1},
                 {"name": "treatment B", "description": "desc2", "ratio": 1},
             ],
             "changelog_message": "test changelog message",
+            "channel": "",
         }
         serializer = NimbusExperimentSerializer(
             experiment, data=data, partial=True, context={"user": self.user}
         )
+
         self.assertFalse(serializer.is_valid())
-        self.assertEqual(
-            serializer.errors,
-            {
-                "treatment_branches": [
-                    {"name": NimbusConstants.ERROR_SINGLE_BRANCH_FOR_ROLLOUT}
-                    for i in data["treatment_branches"]
-                ],
-            },
+        self.assertEqual(len(serializer.errors), 1)
+
+        error = serializer.errors["treatment_branches"][0].get("name")
+        self.assertEqual(error, NimbusConstants.ERROR_SINGLE_BRANCH_FOR_ROLLOUT)
+
+    def test_valid_branches_for_rollout(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            application=NimbusExperiment.Application.DESKTOP,
+            channel=NimbusExperiment.Channel.NO_CHANNEL,
+            firefox_min_version=NimbusExperiment.Version.FIREFOX_108,
+            is_sticky=True,
+            is_rollout=True,
+            targeting_config_slug=NimbusExperiment.TargetingConfig.MAC_ONLY,
         )
+        experiment.save()
+        for branch in experiment.treatment_branches:
+            branch.delete()
+        data = {
+            "application": f"{NimbusExperiment.Application.DESKTOP}",
+            "is_sticky": "true",
+            "is_rollout": "true",
+            "targeting_config_slug": f"{NimbusExperiment.TargetingConfig.MAC_ONLY}",
+            "firefox_min_version": f"{NimbusExperiment.Version.FIREFOX_108}",
+            "changelog_message": "test changelog message",
+            "channel": "",
+        }
+        serializer = NimbusExperimentSerializer(
+            experiment, data=data, partial=True, context={"user": self.user}
+        )
+
+        self.assertTrue(serializer.is_valid())
+        self.assertEqual(len(serializer.errors), 0)
 
 
 class TestNimbusExperimentBranchMixinMultiFeature(TestCase):

--- a/app/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_experiment_branch_mixin.py
+++ b/app/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_experiment_branch_mixin.py
@@ -282,9 +282,9 @@ class TestNimbusExperimentBranchMixinSingleFeature(TestCase):
             branch.delete()
 
         data = {
-            "application": f"{NimbusExperiment.Application.DESKTOP}",
+            "application": NimbusExperiment.Application.DESKTOP.value,
             "is_sticky": "false",
-            "targeting_config_slug": f"{NimbusExperiment.TargetingConfig.MAC_ONLY}",
+            "targeting_config_slug": NimbusExperiment.TargetingConfig.MAC_ONLY.value,
             "treatment_branches": [
                 {"name": "treatment A", "description": "desc1", "ratio": 1},
                 {"name": "treatment B", "description": "desc2", "ratio": 1},
@@ -300,6 +300,7 @@ class TestNimbusExperimentBranchMixinSingleFeature(TestCase):
         self.assertEqual(len(serializer.errors), 1)
 
         error = serializer.errors["treatment_branches"][0].get("name")
+        self.assertIsNotNone(error)
         self.assertEqual(error, NimbusConstants.ERROR_SINGLE_BRANCH_FOR_ROLLOUT)
 
     def test_valid_branches_for_rollout(self):
@@ -316,11 +317,11 @@ class TestNimbusExperimentBranchMixinSingleFeature(TestCase):
         for branch in experiment.treatment_branches:
             branch.delete()
         data = {
-            "application": f"{NimbusExperiment.Application.DESKTOP}",
+            "application": NimbusExperiment.Application.DESKTOP.value,
             "is_sticky": "true",
             "is_rollout": "true",
-            "targeting_config_slug": f"{NimbusExperiment.TargetingConfig.MAC_ONLY}",
-            "firefox_min_version": f"{NimbusExperiment.Version.FIREFOX_108}",
+            "targeting_config_slug": NimbusExperiment.TargetingConfig.MAC_ONLY.value,
+            "firefox_min_version": NimbusExperiment.Version.FIREFOX_108.value,
             "changelog_message": "test changelog message",
             "channel": "",
         }
@@ -329,7 +330,6 @@ class TestNimbusExperimentBranchMixinSingleFeature(TestCase):
         )
 
         self.assertTrue(serializer.is_valid())
-        self.assertEqual(len(serializer.errors), 0)
 
 
 class TestNimbusExperimentBranchMixinMultiFeature(TestCase):

--- a/app/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_ready_for_review_serializer.py
+++ b/app/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_ready_for_review_serializer.py
@@ -1147,13 +1147,13 @@ class TestNimbusReviewSerializerSingleFeature(TestCase):
             branch.delete()
 
         data = {
-            "application": f"{desktop}",
+            "application": str(desktop),
             "is_sticky": "false",
             "is_rollout": "true",
-            "targeting_config_slug": f"{NimbusExperiment.TargetingConfig.MAC_ONLY}",
+            "targeting_config_slug": NimbusExperiment.TargetingConfig.MAC_ONLY.value,
             "changelog_message": "test changelog message",
             "channel": "",
-            "firefox_min_version": f"{NimbusExperiment.Version.FIREFOX_108}",
+            "firefox_min_version": NimbusExperiment.Version.FIREFOX_108.value,
         }
         serializer = NimbusReviewSerializer(
             experiment, data=data, partial=True, context={"user": self.user}
@@ -1179,13 +1179,13 @@ class TestNimbusReviewSerializerSingleFeature(TestCase):
             branch.delete()
 
         data = {
-            "application": f"{desktop}",
+            "application": str(desktop),
             "is_sticky": "true",
             "is_rollout": "true",
-            "targeting_config_slug": f"{NimbusExperiment.TargetingConfig.MAC_ONLY}",
+            "targeting_config_slug": NimbusExperiment.TargetingConfig.MAC_ONLY.value,
             "changelog_message": "test changelog message",
             "channel": "",
-            "firefox_min_version": f"{NimbusExperiment.Version.FIREFOX_50}",
+            "firefox_min_version": NimbusExperiment.Version.FIREFOX_50.value,
         }
         serializer = NimbusReviewSerializer(
             experiment, data=data, partial=True, context={"user": self.user}

--- a/app/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_ready_for_review_serializer.py
+++ b/app/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_ready_for_review_serializer.py
@@ -1180,7 +1180,7 @@ class TestNimbusReviewSerializerSingleFeature(TestCase):
 
         data = {
             "application": f"{desktop}",
-            "is_sticky": "false",
+            "is_sticky": "true",
             "is_rollout": "true",
             "targeting_config_slug": f"{NimbusExperiment.TargetingConfig.MAC_ONLY}",
             "changelog_message": "test changelog message",

--- a/app/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_ready_for_review_serializer.py
+++ b/app/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_ready_for_review_serializer.py
@@ -608,7 +608,7 @@ class TestNimbusReviewSerializerSingleFeature(TestCase):
         if not serializer_result:
             self.assertIn("is_sticky", serializer.errors)
 
-    def test_alid_experiment_allows_min_version_equal_to_max_version(self):
+    def test_valid_experiment_allows_min_version_equal_to_max_version(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.CREATED,
             firefox_max_version=NimbusExperiment.Version.FIREFOX_83,
@@ -1129,6 +1129,74 @@ class TestNimbusReviewSerializerSingleFeature(TestCase):
             context={"user": self.user},
         )
         self.assertTrue(serializer.is_valid())
+
+    def test_rollout_valid_version_support(self):
+        desktop = NimbusExperiment.Application.DESKTOP
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            application=desktop,
+            channel=NimbusExperiment.Channel.NO_CHANNEL,
+            firefox_min_version=NimbusExperiment.Version.FIREFOX_108,
+            feature_configs=[NimbusFeatureConfigFactory(application=desktop)],
+            is_sticky=False,
+            is_rollout=True,
+            targeting_config_slug=NimbusExperiment.TargetingConfig.MAC_ONLY,
+        )
+        experiment.save()
+        for branch in experiment.treatment_branches:
+            branch.delete()
+
+        data = {
+            "application": f"{desktop}",
+            "is_sticky": "false",
+            "is_rollout": "true",
+            "targeting_config_slug": f"{NimbusExperiment.TargetingConfig.MAC_ONLY}",
+            "changelog_message": "test changelog message",
+            "channel": "",
+            "firefox_min_version": f"{NimbusExperiment.Version.FIREFOX_108}",
+        }
+        serializer = NimbusReviewSerializer(
+            experiment, data=data, partial=True, context={"user": self.user}
+        )
+
+        self.assertTrue(serializer.is_valid())
+        self.assertEqual(len(serializer.errors), 0)
+
+    def test_rollout_invalid_version_support(self):
+        desktop = NimbusExperiment.Application.DESKTOP
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            application=desktop,
+            channel=NimbusExperiment.Channel.NO_CHANNEL,
+            firefox_min_version=NimbusExperiment.Version.FIREFOX_50,
+            feature_configs=[NimbusFeatureConfigFactory(application=desktop)],
+            is_sticky=True,
+            is_rollout=True,
+            targeting_config_slug=NimbusExperiment.TargetingConfig.MAC_ONLY,
+        )
+        experiment.save()
+        for branch in experiment.treatment_branches:
+            branch.delete()
+
+        data = {
+            "application": f"{desktop}",
+            "is_sticky": "false",
+            "is_rollout": "true",
+            "targeting_config_slug": f"{NimbusExperiment.TargetingConfig.MAC_ONLY}",
+            "changelog_message": "test changelog message",
+            "channel": "",
+            "firefox_min_version": f"{NimbusExperiment.Version.FIREFOX_50}",
+        }
+        serializer = NimbusReviewSerializer(
+            experiment, data=data, partial=True, context={"user": self.user}
+        )
+
+        self.assertFalse(serializer.is_valid())
+        self.assertEqual(len(serializer.errors), 1)
+        self.assertEqual(
+            serializer.errors["is_rollout"][0],
+            NimbusConstants.ERROR_ROLLOUT_VERSION_SUPPORT,
+        )
 
 
 class TestNimbusReviewSerializerMultiFeature(TestCase):


### PR DESCRIPTION
For #6697

Because:

* not all clients supported by Nimbus support `isRollout`

This commit:

* adds a review validator error if the selected combination of application and min version does not support rollouts

* adds a list to NimbusConstants describing clients by application and min version combinations that support rollouts

* implements review validation of the experiment against the list of supported clients