### PR TITLE
fix #7559 chore(nimbus): fail silently in external config circle task

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -165,16 +165,16 @@ jobs:
             git checkout main
             git pull origin main
             make fetch_external_resources
-            if git diff --name-only
+            if (($(git status --porcelain | wc -c) > 0))
               then
-                git checkout -B external-config
-                git add .
-                git commit -m 'chore(nimbus): Update External Configs'
-                git push origin external-config -f
-                gh pr create -t "chore(nimbus): Update External Configs" -b "" --base main --head external-config --repo mozilla/experimenter
+                git checkout -B external-config &&\
+                git add . &&\
+                git commit -m 'chore(nimbus): Update External Configs' &&\
+                git push origin external-config -f &&\
+                gh pr create -t "chore(nimbus): Update External Configs" -b "" --base main --head external-config --repo mozilla/experimenter ||\
+                echo "PR already exists, skipping"
               else
                 echo "No config changes, skipping"
-                circleci-agent step halt
             fi
 
   build_firefox_versions:


### PR DESCRIPTION
Because

* The hourly circle task to check for changes to external config files will fail if there are no changes
* The failures are logged and notified as circle failures
* This can mask an actual failure

This commit
* Changes the task to exit 0 if no changes are detected