### PR TITLE
fix #7565 chore(nimbus): only suppress exit code for pr creation in external config task

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -167,12 +167,11 @@ jobs:
             make fetch_external_resources
             if (($(git status --porcelain | wc -c) > 0))
               then
-                git checkout -B external-config &&\
-                git add . &&\
-                git commit -m 'chore(nimbus): Update External Configs' &&\
-                git push origin external-config -f &&\
-                gh pr create -t "chore(nimbus): Update External Configs" -b "" --base main --head external-config --repo mozilla/experimenter ||\
-                echo "PR already exists, skipping"
+                git checkout -B external-config
+                git add .
+                git commit -m 'chore(nimbus): Update External Configs'
+                git push origin external-config -f
+                gh pr create -t "chore(nimbus): Update External Configs" -b "" --base main --head external-config --repo mozilla/experimenter || echo "PR already exists, skipping"
               else
                 echo "No config changes, skipping"
             fi


### PR DESCRIPTION


Because

* We only need to suppress the error code of the pr creation command in the external config circle task
* If we suppress the others they could fail for some unexpected reason and we'd never be notified

This commit

* Only suppresses the exit code of the pr creation command