### PR TITLE
fix #7573 chore(nimbus): prefetch related entities for v6 api

### DIFF
--- a/app/experimenter/experiments/api/v6/views.py
+++ b/app/experimenter/experiments/api/v6/views.py
@@ -11,7 +11,7 @@ class NimbusExperimentViewSet(
     viewsets.GenericViewSet,
 ):
     lookup_field = "slug"
-    queryset = NimbusExperiment.objects.all().exclude(
+    queryset = NimbusExperiment.objects.with_related().exclude(
         status__in=[NimbusExperiment.Status.DRAFT]
     )
     serializer_class = NimbusExperimentSerializer


### PR DESCRIPTION
Because

* External callers depend on the V6 API for experiment metadata
* The V6 API was unoptimized for prefetching related entities and so was very slow

This commit

* Prefetches all related entities required for the V6 API
* Refactors methods to use the in memeory prefetched objects rather than creating additional database queries