### PR TITLE
fix #7577 bug(nimbus): check for is_paused in changelog in computed enrollment days

### DIFF
--- a/app/experimenter/experiments/models.py
+++ b/app/experimenter/experiments/models.py
@@ -437,7 +437,8 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
         paused_changelogs = [
             c
             for c in changes
-            if c.experiment_data["is_paused"]
+            if "is_paused" in c.experiment_data
+            and c.experiment_data["is_paused"]
             and c.new_status == NimbusExperiment.Status.LIVE
             and c.new_status_next is None
             and c.new_publish_status == NimbusExperiment.PublishStatus.IDLE
@@ -449,6 +450,7 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
 
         if self.end_date:
             return self.computed_duration_days
+
         return self.proposed_enrollment
 
     @property

--- a/app/experimenter/experiments/tests/test_models.py
+++ b/app/experimenter/experiments/tests/test_models.py
@@ -932,6 +932,20 @@ class TestNimbusExperiment(TestCase):
             expected_days,
         )
 
+    def test_computed_enrollment_days_returns_duration_if_is_paused_missing(self):
+        expected_days = 99
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.LIVE_PAUSED,
+            proposed_enrollment=expected_days,
+        )
+        experiment.changes.filter(experiment_data__is_paused=True).update(
+            experiment_data={}
+        )
+        self.assertEqual(
+            experiment.computed_enrollment_days,
+            expected_days,
+        )
+
     def test_computed_enrollment_end_date_returns_start_date_plus_enrollment_days(self):
         start_date = datetime.date(2022, 1, 1)
         enrollment_end_date = start_date + datetime.timedelta(days=3)


### PR DESCRIPTION


Because

* To compute the enrollment days we must first find the changelog when is_paused became True
* The is_paused field may not be present in very old changelogs
* We must check for the keys presence before looking it up

This commit

* Checks that the is_paused key is present in the changelog data before accessing it