### PR TITLE
fix #7579 bug(nimbus): check for None in changelog experiment data when computing enrollment days

### DIFF
--- a/app/experimenter/experiments/models.py
+++ b/app/experimenter/experiments/models.py
@@ -437,7 +437,8 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
         paused_changelogs = [
             c
             for c in changes
-            if "is_paused" in c.experiment_data
+            if c.experiment_data is not None
+            and "is_paused" in c.experiment_data
             and c.experiment_data["is_paused"]
             and c.new_status == NimbusExperiment.Status.LIVE
             and c.new_status_next is None

--- a/app/experimenter/experiments/tests/test_models.py
+++ b/app/experimenter/experiments/tests/test_models.py
@@ -946,6 +946,20 @@ class TestNimbusExperiment(TestCase):
             expected_days,
         )
 
+    def test_computed_enrollment_days_returns_duration_if_experiment_data_is_none(self):
+        expected_days = 99
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.LIVE_PAUSED,
+            proposed_enrollment=expected_days,
+        )
+        experiment.changes.filter(experiment_data__is_paused=True).update(
+            experiment_data=None
+        )
+        self.assertEqual(
+            experiment.computed_enrollment_days,
+            expected_days,
+        )
+
     def test_computed_enrollment_end_date_returns_start_date_plus_enrollment_days(self):
         start_date = datetime.date(2022, 1, 1)
         enrollment_end_date = start_date + datetime.timedelta(days=3)


### PR DESCRIPTION


Because

* We changed the computed_enrollment_days method to do filters in memory rather than in the database for performance reasons
* Not only must we check that the key 'is_paused' is in the experiment_data dict, we must also check that the experiment_data field is not None

This commit

* Adds a None check to the 'is_paused' key lookup in changelog.experiment_data