### PR TITLE
fix #7525 feat(nimbus): force feature value for mobile experiments

### DIFF
--- a/app/experimenter/experiments/tests/api/v5/test_mutations.py
+++ b/app/experimenter/experiments/tests/api/v5/test_mutations.py
@@ -304,7 +304,7 @@ class TestUpdateExperimentMutationSingleFeature(
         experiment = NimbusExperiment.objects.first()
         self.assertEqual(experiment.feature_configs.get(), expected_feature_config)
 
-    def test_update_experiment_branches_with_feature_config(self):
+    def test_update_mobile_experiment_branches_with_feature_config(self):
         user_email = "user@example.com"
         feature = NimbusFeatureConfigFactory(
             schema="{}", application=NimbusExperiment.Application.FENIX
@@ -350,7 +350,7 @@ class TestUpdateExperimentMutationSingleFeature(
         self.assertEqual(experiment.feature_configs.get(), feature)
         self.assertEqual(experiment.branches.count(), 2)
         self.assertEqual(experiment.reference_branch.name, reference_branch_data["name"])
-        self.assertEqual(experiment.reference_branch.feature_values.get().enabled, False)
+        self.assertEqual(experiment.reference_branch.feature_values.get().enabled, True)
         self.assertEqual(experiment.reference_branch.feature_values.get().value, "")
         treatment_branch = experiment.treatment_branches[0]
         self.assertEqual(treatment_branch.name, treatment_branches_data[0]["name"])
@@ -431,7 +431,7 @@ class TestUpdateExperimentMutationSingleFeature(
         self.assertEqual(
             experiment.reference_branch.feature_values.get().feature_config, None
         )
-        self.assertEqual(experiment.reference_branch.feature_values.get().enabled, False)
+        self.assertEqual(experiment.reference_branch.feature_values.get().enabled, True)
         self.assertEqual(experiment.reference_branch.feature_values.get().value, "")
 
         treatment_branch = experiment.treatment_branches[0]

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/FormBranch.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/FormBranch.test.tsx
@@ -126,6 +126,14 @@ describe("FormBranch", () => {
     await assertInvalidField(container, "referenceBranch.description");
   });
 
+  it("should force feature value visible and display a warning for mobile experiments", async () => {
+    const { container } = render(<SubjectBranch isDesktop={false} />);
+    expect(
+      screen.queryByTestId("mobile-feature-value-warning"),
+    ).toBeInTheDocument();
+    expect(screen.queryByTestId("feature-value-edit")).toBeInTheDocument();
+  });
+
   const assertInvalidField = async (container: HTMLElement, testId: string) => {
     await waitFor(() => {
       expect(screen.getByTestId(testId)).toHaveClass("is-invalid");

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/FormBranch.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/FormBranch.tsx
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React from "react";
+import Alert from "react-bootstrap/Alert";
 import Badge from "react-bootstrap/Badge";
 import Button from "react-bootstrap/Button";
 import Col from "react-bootstrap/Col";
@@ -33,6 +34,7 @@ export const FormBranch = ({
   branch,
   equalRatio,
   isReference,
+  isDesktop,
   onAddScreenshot,
   onRemoveScreenshot,
   onRemove,
@@ -47,6 +49,7 @@ export const FormBranch = ({
   branch: AnnotatedBranch;
   equalRatio?: boolean;
   isReference?: boolean;
+  isDesktop: boolean;
   onAddScreenshot: () => void;
   onRemoveScreenshot: (screenshotIdx: number) => void;
   onRemove?: () => void;
@@ -160,28 +163,39 @@ export const FormBranch = ({
         </Form.Row>
       </Form.Group>
 
-      <Form.Group
-        className="p-1 mx-3 mt-2 mb-0"
-        data-testid="feature-config-edit"
-      >
-        <Form.Row>
-          <Col sm={1} md={1}>
-            Feature is
+      {isDesktop ? (
+        <Form.Group
+          className="p-1 mx-3 mt-2 mb-0"
+          data-testid="feature-config-edit"
+        >
+          <Form.Row>
+            <Col sm={1} md={1}>
+              Feature is
+            </Col>
+            <Form.Group as={Col} controlId={`${id}.featureEnabled`}>
+              <Form.Check
+                {...formControlAttrs("featureEnabled", {}, false)}
+                type="switch"
+                label={featureEnabled ? "On" : "Off"}
+              />
+            </Form.Group>
+          </Form.Row>
+        </Form.Group>
+      ) : (
+        <Form.Group>
+          <Col>
+            <Alert variant="warning" data-testid="mobile-feature-value-warning">
+              Mobile features require a value for every branch.
+            </Alert>
           </Col>
-          <Form.Group as={Col} controlId={`${id}.featureEnabled`}>
-            <Form.Check
-              {...formControlAttrs("featureEnabled", {}, false)}
-              type="switch"
-              label={featureEnabled ? "On" : "Off"}
-            />
-          </Form.Group>
-        </Form.Row>
-      </Form.Group>
+        </Form.Group>
+      )}
+
       <Form.Group
         className="p-1 mx-3 mt-2 mb-0"
         data-testid="feature-config-edit"
       >
-        {featureEnabled ? (
+        {featureEnabled || !isDesktop ? (
           <Form.Row data-testid="feature-value-edit">
             <Form.Group as={Col} controlId={`${id}-featureValue`}>
               <Form.Label>Value</Form.Label>

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/index.tsx
@@ -13,6 +13,7 @@ import { useExitWarning, useForm, useReviewCheck } from "../../../hooks";
 import { IsDirtyUnsaved } from "../../../hooks/useCommonForm/useCommonFormMethods";
 import { getConfig_nimbusConfig } from "../../../types/getConfig";
 import { getExperiment_experimentBySlug } from "../../../types/getExperiment";
+import { NimbusExperimentApplicationEnum } from "../../../types/globalTypes";
 import FormBranch from "./FormBranch";
 import {
   FormBranchesSaveState,
@@ -174,6 +175,9 @@ export const FormBranches = ({
 
   type FormBranchProps = React.ComponentProps<typeof FormBranch>;
 
+  const isDesktop =
+    experiment.application === NimbusExperimentApplicationEnum.DESKTOP;
+
   return (
     <FormProvider {...formMethods}>
       <Form
@@ -288,6 +292,7 @@ export const FormBranches = ({
                 onRemoveScreenshot:
                   handleRemoveScreenshot(REFERENCE_BRANCH_IDX),
                 defaultValues: defaultValues.referenceBranch || {},
+                isDesktop,
               }}
             />
           )}
@@ -319,6 +324,7 @@ export const FormBranches = ({
                     onAddScreenshot: handleAddScreenshot(idx),
                     onRemoveScreenshot: handleRemoveScreenshot(idx),
                     defaultValues: defaultValues.treatmentBranches?.[idx] || {},
+                    isDesktop,
                   }}
                 />
               );

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/mocks.tsx
@@ -7,12 +7,14 @@ import { FormProvider } from "react-hook-form";
 import FormBranches from ".";
 import { useForm } from "../../../hooks";
 import { mockExperimentQuery, MOCK_CONFIG } from "../../../lib/mocks";
+import { NimbusExperimentApplicationEnum } from "../../../types/globalTypes";
 import FormBranch from "./FormBranch";
 import { AnnotatedBranch } from "./reducer";
 import { formBranchesActionReducer } from "./reducer/actions";
 import { FormBranchesState } from "./reducer/state";
 
 export const MOCK_EXPERIMENT = mockExperimentQuery("demo-slug", {
+  application: NimbusExperimentApplicationEnum.DESKTOP,
   featureConfigs: [], //MOCK_CONFIG!.featureConfigs![0],
   referenceBranch: {
     id: 123,
@@ -82,6 +84,7 @@ export const SubjectBranch = ({
   onAddScreenshot = () => {},
   onRemoveScreenshot = () => {},
   onRemove = () => {},
+  isDesktop = true,
 }: Partial<React.ComponentProps<typeof FormBranch>>) => {
   const defaultValues = {
     referenceBranch: branch,
@@ -121,6 +124,7 @@ export const SubjectBranch = ({
             onRemoveScreenshot,
             defaultValues: defaultValues.referenceBranch || {},
             setSubmitErrors,
+            isDesktop,
           }}
         />
       </form>

--- a/app/tests/integration/nimbus/conftest.py
+++ b/app/tests/integration/nimbus/conftest.py
@@ -188,7 +188,12 @@ def create_experiment(base_url, default_data):
         branches.feature_config = default_data.feature_config_id
         branches.reference_branch_description = default_data.branches[0].description
         branches.treatment_branch_description = default_data.branches[1].description
-        branches.treatment_branch_enabled.click()
+
+        if default_data.application.value == "DESKTOP":
+            branches.reference_branch_enabled.click()
+            branches.treatment_branch_enabled.click()
+
+        branches.reference_branch_value = "{}"
         branches.treatment_branch_value = "{}"
 
         # Fill Metrics page

--- a/app/tests/integration/nimbus/pages/experimenter/branches.py
+++ b/app/tests/integration/nimbus/pages/experimenter/branches.py
@@ -13,6 +13,14 @@ class BranchesPage(ExperimenterBase):
         By.CSS_SELECTOR,
         "#referenceBranch-description",
     )
+    _reference_branch_enable_locator = (
+        By.CSS_SELECTOR,
+        'label[for="referenceBranch.featureEnabled"]',
+    )
+    _reference_branch_value_locator = (
+        By.CSS_SELECTOR,
+        "#referenceBranch-featureValue",
+    )
     _treatment_branch_name_locator = (By.CSS_SELECTOR, "#treatmentBranches\\[0\\]-name")
     _treatment_branch_description_locator = (
         By.CSS_SELECTOR,
@@ -54,6 +62,24 @@ class BranchesPage(ExperimenterBase):
     def reference_branch_description(self, text=None):
         self.wait_for_and_find_element(
             self._reference_branch_description_locator, "reference_branch description"
+        ).send_keys(f"{text}")
+
+    @property
+    def reference_branch_enabled(self):
+        return self.wait_for_and_find_element(
+            self._reference_branch_enable_locator, "reference branch enabled"
+        )
+
+    @property
+    def reference_branch_value(self):
+        return self.wait_for_and_find_element(
+            self._reference_branch_value_locator, "reference branch value"
+        ).text
+
+    @reference_branch_value.setter
+    def reference_branch_value(self, text=None):
+        self.wait_for_and_find_element(
+            self._reference_branch_value_locator, "reference branch value"
         ).send_keys(f"{text}")
 
     @property


### PR DESCRIPTION
Because

* The feature enabled flag was never implemented on mobile
* Allowing it in the UI creates the false impression that it has some meaning for mobile experiments
* We are deprecating it on desktop and eventually removing it altogether

This commit

* Removes the feature enabled flag for mobile experiments and forces them to specify a feature value for every branch, which may explicitly be an empty object

![Screenshot 2022-08-09 at 11-59-22 asdf – Branches Experimenter](https://user-images.githubusercontent.com/119884/183700999-8855ea6a-0775-4f6e-9800-39913fd11d21.png)

