### PR TITLE
fix #7519 chore(project): Re-enable Legacy Integration and JS tests on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ jobs:
           name: Run tests and linting
           command: |
             cp .env.sample .env
-            make check
+            make check_legacy
 
   integration_nimbus_desktop_release:
     machine:
@@ -117,6 +117,28 @@ jobs:
           command: |
             cp .env.integration-tests .env
             make refresh SKIP_DUMMY=1 up_prod_detached integration_test_nimbus_rust PYTEST_ARGS="$PYTEST_ARGS"
+  
+  integration_legacy:
+    machine:
+      image: ubuntu-2004:202107-02 # Ubuntu 20.04, Docker v20.10.7, Docker Compose v1.29.2
+      docker_layer_caching: true
+    resource_class: large
+    working_directory: ~/experimenter
+    steps:
+      - run:
+          name: Docker info
+          command: docker -v
+      - run:
+          name: Docker compose info
+          command: docker-compose -v
+      - checkout
+      - run:
+          name: Run integration tests
+          command: |
+            cp .env.sample .env
+            make refresh
+            make up_prod_detached
+            make integration_test_legacy
 
   deploy:
     working_directory: ~/experimenter
@@ -282,6 +304,12 @@ workflows:
                 - main
       - integration_nimbus_sdk:
           name: integration_nimbus_sdk
+          filters:
+            branches:
+              ignore:
+                - main
+      - integration_legacy:
+          name: integration_legacy
           filters:
             branches:
               ignore:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -124,6 +124,8 @@ jobs:
       docker_layer_caching: true
     resource_class: large
     working_directory: ~/experimenter
+    environment:
+      FIREFOX_VERSION: nimbus-firefox-release
     steps:
       - run:
           name: Docker info

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ jobs:
           name: Run tests and linting
           command: |
             cp .env.sample .env
-            make check_legacy
+            make check
 
   integration_nimbus_desktop_release:
     machine:

--- a/Makefile
+++ b/Makefile
@@ -186,7 +186,7 @@ integration_vnc_up_detached:
 	$(COMPOSE_INTEGRATION) up -d firefox
 
 integration_test_legacy:
-	MOZ_HEADLESS=1 $(COMPOSE_INTEGRATION) run firefox sh -c "sudo chmod a+rwx /code/app/tests/integration/.tox;tox -c app/tests/integration -e integration-test-legacy $(TOX_ARGS) -- -n 2 $(PYTEST_ARGS)"
+	MOZ_HEADLESS=1 $(COMPOSE_INTEGRATION) run firefox sh -c "sudo apt-get -qqy update && sudo apt-get -qqy install tox;sudo chmod a+rwx /code/app/tests/integration/.tox;tox -c app/tests/integration -e integration-test-legacy $(TOX_ARGS) -- -n 2 $(PYTEST_ARGS)"
 
 integration_test_nimbus:
 	MOZ_HEADLESS=1 $(COMPOSE_INTEGRATION) run firefox sh -c "if [ "$$UPDATE_FIREFOX_VERSION" = "true" ]; then sudo ./app/tests/integration/nimbus/utils/nightly-install.sh; fi; firefox -V; sudo apt-get -qqy update && sudo apt-get -qqy install tox;sudo chmod a+rwx /code/app/tests/integration/.tox;tox -c app/tests/integration -e integration-test-nimbus $(TOX_ARGS) -- $(PYTEST_ARGS)"

--- a/Makefile
+++ b/Makefile
@@ -118,9 +118,6 @@ kill: compose_stop compose_rm volumes_rm
 	echo "All containers removed!"
 
 check: build_test
-	$(COMPOSE_TEST) run app sh -c '$(WAIT_FOR_DB) (${PARALLEL} "$(NIMBUS_SCHEMA_CHECK)" "$(PYTHON_CHECK_MIGRATIONS)" "$(CHECK_DOCS)" "${PY_IMPORT_CHECK}" "$(BLACK_CHECK)" "$(FLAKE8)" "$(ESLINT_NIMBUS_UI)" "$(TYPECHECK_NIMBUS_UI)" "$(JS_TEST_NIMBUS_UI)" "$(PYTHON_TEST)") ${COLOR_CHECK}'
-
-check_legacy: build_test
 	$(COMPOSE_TEST) run app sh -c '$(WAIT_FOR_DB) (${PARALLEL} "$(NIMBUS_SCHEMA_CHECK)" "$(PYTHON_CHECK_MIGRATIONS)" "$(CHECK_DOCS)" "${PY_IMPORT_CHECK}" "$(BLACK_CHECK)" "$(FLAKE8)" "$(ESLINT_LEGACY)" "$(ESLINT_NIMBUS_UI)" "$(TYPECHECK_NIMBUS_UI)" "$(JS_TEST_LEGACY)" "$(JS_TEST_NIMBUS_UI)" "$(JS_TEST_REPORTING)" "$(PYTHON_TEST)") ${COLOR_CHECK}'
 
 pytest: build_test

--- a/app/experimenter/nimbus-ui/src/components/LinkExternal/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/LinkExternal/index.tsx
@@ -9,6 +9,7 @@ type LinkExternalProps = {
   href: string;
   children: React.ReactNode;
   title?: string;
+  id?: string;
   "data-testid"?: string;
 };
 
@@ -17,6 +18,7 @@ export const LinkExternal = ({
   href,
   children,
   title,
+  id,
   "data-testid": testid = "link-external",
 }: LinkExternalProps) => (
   <a
@@ -27,6 +29,7 @@ export const LinkExternal = ({
       className,
       href,
       title,
+      id,
     }}
   >
     {children}

--- a/app/experimenter/nimbus-ui/src/components/PageHome/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageHome/index.tsx
@@ -157,7 +157,12 @@ const PageHome: React.FunctionComponent<PageHomeProps> = () => {
             🔍
           </span>{" "}
           Looking for the old Experimenter?{" "}
-          <LinkExternal href="/legacy">It&lsquo;s still here!</LinkExternal>
+          <LinkExternal
+            href="/legacy"
+            id="legacy_page_link"
+            >
+              It&lsquo;s still here!
+          </LinkExternal>
           <span role="img" aria-label="magnifying emoji">
             💡
           </span>{" "}

--- a/app/experimenter/nimbus-ui/src/components/PageHome/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageHome/index.tsx
@@ -157,11 +157,8 @@ const PageHome: React.FunctionComponent<PageHomeProps> = () => {
             🔍
           </span>{" "}
           Looking for the old Experimenter?{" "}
-          <LinkExternal
-            href="/legacy"
-            id="legacy_page_link"
-            >
-              It&lsquo;s still here!
+          <LinkExternal href="/legacy" id="legacy_page_link">
+            It&lsquo;s still here!
           </LinkExternal>
           <span role="img" aria-label="magnifying emoji">
             💡

--- a/app/tests/integration/legacy/pages/home.py
+++ b/app/tests/integration/legacy/pages/home.py
@@ -10,7 +10,8 @@ class Home(Base):
 
     def wait_for_page_to_load(self):
         self.wait.until(
-            lambda _: self.find_element(*self._load_legacy_page).is_displayed())
+            lambda _: self.find_element(*self._load_legacy_page).is_displayed()
+        )
         self.find_element(*self._load_legacy_page).click()
         # wait for new tab
         original_window = self.selenium.current_window_handle

--- a/app/tests/integration/legacy/pages/home.py
+++ b/app/tests/integration/legacy/pages/home.py
@@ -6,8 +6,19 @@ class Home(Base):
 
     _create_experiment_btn_locator = (By.CSS_SELECTOR, "a.col.btn-primary")
     _page_wait_locator = (By.CSS_SELECTOR, "body.page-list-view")
+    _load_legacy_page = (By.CSS_SELECTOR, "#legacy_page_link")
 
     def wait_for_page_to_load(self):
+        self.wait.until(
+            lambda _: self.find_element(*self._load_legacy_page).is_displayed())
+        self.find_element(*self._load_legacy_page).click()
+        # wait for new tab
+        original_window = self.selenium.current_window_handle
+        for window_handle in self.selenium.window_handles:
+            if window_handle != original_window:
+                self.selenium.switch_to.window(window_handle)
+                break
+
         self.wait.until(
             lambda _: self.find_element(*self._page_wait_locator).is_displayed()
         )

--- a/app/tests/integration/legacy/test_filter_expression_validation.py
+++ b/app/tests/integration/legacy/test_filter_expression_validation.py
@@ -10,5 +10,5 @@ def test_filter_expressions_with_mismatching_firefox_versions(base_url, selenium
     selenium.get("about:blank")
     with open("legacy/utils/filter_expression.js") as js:
         with selenium.context(selenium.CONTEXT_CHROME):
-            script = selenium.execute_script(js.read(), 80.1, 99)
+            script = selenium.execute_script(js.read(), 80.1, 150)
     assert script is False


### PR DESCRIPTION
Because

* We are still supporting the use of legacy for the foreseeable future, so we should make sure that changes added to the code base don't affect legacy in a negative way.

This commit

* Re-enables legacy integration tests on CI.
* Re-enables legacy JS tests as part of the check job on CI.