### PR TITLE
fix #7595 bug(nimbus): variables are optional for features

### DIFF
--- a/app/experimenter/features/__init__.py
+++ b/app/experimenter/features/__init__.py
@@ -66,18 +66,19 @@ class Feature(BaseModel):
             "additionalProperties": False,
         }
 
-        for variable_slug, variable in self.variables.items():
-            variable_schema = {
-                "description": variable.description,
-            }
+        if self.variables:
+            for variable_slug, variable in self.variables.items():
+                variable_schema = {
+                    "description": variable.description,
+                }
 
-            if variable.type in FEATURE_SCHEMA_TYPES:
-                variable_schema["type"] = FEATURE_SCHEMA_TYPES[variable.type]
+                if variable.type in FEATURE_SCHEMA_TYPES:
+                    variable_schema["type"] = FEATURE_SCHEMA_TYPES[variable.type]
 
-            if variable.enum:
-                variable_schema["enum"] = variable.enum
+                if variable.enum:
+                    variable_schema["enum"] = variable.enum
 
-            schema["properties"][variable_slug] = variable_schema
+                schema["properties"][variable_slug] = variable_schema
 
         return json.dumps(schema, indent=2)
 

--- a/app/experimenter/features/tests/fixtures/valid_features/firefox-desktop.yaml
+++ b/app/experimenter/features/tests/fixtures/valid_features/firefox-desktop.yaml
@@ -19,3 +19,7 @@ someFeature:
     jsonProperty:
       type: json
       description: Arbitrary JSON Property
+missingVariables:
+  description: Some Firefox Feature
+  exposureDescription: An exposure event
+  isEarlyStartup: true

--- a/app/experimenter/features/tests/test_features.py
+++ b/app/experimenter/features/tests/test_features.py
@@ -31,7 +31,7 @@ class TestFeatures(TestCase):
 
     def test_load_all_features(self):
         features = Features.all()
-        self.assertEqual(len(features), 2)
+        self.assertEqual(len(features), 3)
         self.assertIn(
             Feature(
                 applicationSlug="firefox-desktop",
@@ -83,7 +83,7 @@ class TestFeatures(TestCase):
 
     def test_load_features_by_application(self):
         desktop_features = Features.by_application(NimbusConstants.Application.DESKTOP)
-        self.assertEqual(len(desktop_features), 1)
+        self.assertEqual(len(desktop_features), 2)
         self.assertIn(
             Feature(
                 applicationSlug="firefox-desktop",


### PR DESCRIPTION
Because

* The current feature manifest schema allows for variables to be optional
* The feature parser does not handle features that are missing variables altogether

This commit

* Checks that variables are set before attempting to parse them