### PR TITLE
fix #7601 bug(nimbus): check for remote and local diff in external config task

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -194,7 +194,7 @@ jobs:
                 git checkout -B external-config
                 git add .
                 git commit -m 'chore(nimbus): Update External Configs'
-                if (($(git diff external-config origin/external-config | wc -c) > 0))
+                if (($((git diff external-config origin/external-config || git diff HEAD~1) | wc -c) > 0))
                   then
                     git push origin external-config -f
                     gh pr create -t "chore(nimbus): Update External Configs" -b "" --base main --head external-config --repo mozilla/experimenter || echo "PR already exists, skipping"


### PR DESCRIPTION


Because

* The circle task to update external configs was repeatedly force pushing the same changes and triggering redundant CI runs
* We added a fix to check whether the local commit is different from the latest remote commit in the same branch
* However, after an external config PR is merged, its branch is deleted
* Later when the circle task wakes up and tries to detect if there's a change, it will fail when it tries to diff against the remote branch which was previously deleted

This commit

* Attempts to diff against the remote branch and if that fails, checks for a local diff
* This should prevent it from pushing duplicate commits when a pr exists, but still allow it to create a pr when none exists