### PR TITLE
fixes #7608 feat(nimbus): change NimbusExperimentViewSet queryset to order experiments by slug

### DIFF
--- a/app/experimenter/experiments/api/v6/views.py
+++ b/app/experimenter/experiments/api/v6/views.py
@@ -11,8 +11,10 @@ class NimbusExperimentViewSet(
     viewsets.GenericViewSet,
 ):
     lookup_field = "slug"
-    queryset = NimbusExperiment.objects.with_related().exclude(
-        status__in=[NimbusExperiment.Status.DRAFT]
+    queryset = (
+        NimbusExperiment.objects.with_related()
+        .exclude(status__in=[NimbusExperiment.Status.DRAFT])
+        .order_by("slug")
     )
     serializer_class = NimbusExperimentSerializer
     filter_backends = [DjangoFilterBackend]

--- a/app/experimenter/experiments/tests/api/v6/test_views.py
+++ b/app/experimenter/experiments/tests/api/v6/test_views.py
@@ -25,14 +25,16 @@ class TestNimbusExperimentViewSet(TestCase):
                     )
                 )
 
+        experiments = sorted(experiments, key=lambda e: e.slug)
+
         response = self.client.get(
             reverse("nimbus-experiment-rest-list"),
         )
         self.assertEqual(response.status_code, 200)
 
         json_data = json.loads(response.content)
-        json_slugs = set([d["id"] for d in json_data])
-        expected_slugs = set(e.slug for e in experiments)
+        json_slugs = [d["id"] for d in json_data]
+        expected_slugs = [e.slug for e in experiments]
         self.assertEqual(json_slugs, expected_slugs)
 
     def test_get_nimbus_experiment_returns_expected_data(self):


### PR DESCRIPTION
Because

* NimbusExperimentViewSet experiment order was non-deterministic

This commit

* change NimbusExperimentViewSet queryset to order experiments by slug, making the response order deterministic

#7608