### PR TITLE
fix #7607 feat(nimbus): add analysis timestamp to Results

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/PageResults/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/index.test.tsx
@@ -68,6 +68,19 @@ describe("PageResults", () => {
     await screen.findByTestId("external-config-alert");
   });
 
+  it("displays the analysis_start_time", async () => {
+    render(<Subject />);
+
+    expect(
+      screen.getByText(
+        new Date(MOCK_METADATA_WITH_CONFIG.analysis_start_time).toLocaleString(
+          undefined,
+          { timeZone: "UTC" },
+        ),
+      ),
+    );
+  });
+
   it("redirects to the edit overview page if the experiment status is draft", async () => {
     expect(
       redirectTestCommon({

--- a/app/experimenter/nimbus-ui/src/components/PageResults/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/index.tsx
@@ -66,9 +66,10 @@ const PageResults: React.FunctionComponent<RouteComponentProps> = () => {
           <p>
             Results last calculated:{" "}
             <b>
-              {new Date(
-                analysis?.metadata?.analysis_start_time,
-              ).toLocaleString(undefined, { timeZone: "UTC" })}
+              {new Date(analysis?.metadata?.analysis_start_time).toLocaleString(
+                undefined,
+                { timeZone: "UTC" },
+              )}
             </b>
           </p>
         )}

--- a/app/experimenter/nimbus-ui/src/components/PageResults/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/index.tsx
@@ -62,6 +62,16 @@ const PageResults: React.FunctionComponent<RouteComponentProps> = () => {
   return (
     <AppLayoutWithExperiment title="Analysis" testId="PageResults">
       <ResultsContext.Provider value={resultsContextValue}>
+        {analysis?.metadata?.analysis_start_time && (
+          <p>
+            Results last calculated:{" "}
+            <b>
+              {new Date(
+                analysis?.metadata?.analysis_start_time,
+              ).toLocaleString(undefined, { timeZone: "UTC" })}
+            </b>
+          </p>
+        )}
         {externalConfig && <ExternalConfigAlert {...{ externalConfig }} />}
 
         <h3 className="h4 mb-3 mt-4" id="overview">

--- a/app/experimenter/nimbus-ui/src/lib/visualization/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/lib/visualization/mocks.tsx
@@ -14,6 +14,7 @@ export const MOCK_UNAVAILABLE_ANALYSIS = {
 };
 
 export const MOCK_METADATA = {
+  analysis_start_time: "2022-08-11 20:06:30.309647+00:00",
   metrics: {
     feature_b: {
       bigger_is_better: true,

--- a/app/experimenter/nimbus-ui/src/lib/visualization/types.ts
+++ b/app/experimenter/nimbus-ui/src/lib/visualization/types.ts
@@ -20,6 +20,7 @@ export interface Metadata {
   metrics: { [metric: string]: MetadataPoint };
   outcomes: { [outcome: string]: MetadataPoint };
   external_config?: MetadataExternalConfig | null;
+  analysis_start_time?: string;
 }
 
 export interface MetadataExternalConfig {


### PR DESCRIPTION
Because

* it is currently unclear when Jetstream has last produced experiment results
* Jetstream was updated to add an analysis start time to the experiment metadata

This commit

* displays the new `analysis_start_time` on the Results page (when it is available)

![image](https://user-images.githubusercontent.com/102263964/185634378-798bb109-71b8-4fee-83b4-28ab29b008fe.png)
