### PR TITLE
fix #7613 feat(nimbus):Cancel review enrollment bug

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/Summary/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/index.test.tsx
@@ -195,6 +195,37 @@ describe("Summary", () => {
       });
     });
 
+    it("verify cancel review doesn't change enrollment days", async () => {
+      const refetch = jest.fn();
+      const { experiment } = mockExperimentQuery("demo-slug", {
+        status: NimbusExperimentStatusEnum.LIVE,
+        publishStatus: NimbusExperimentPublishStatusEnum.REVIEW,
+      });
+      const mutationMock = createMutationMock(
+        experiment.id!,
+        NimbusExperimentPublishStatusEnum.IDLE,
+        {
+          statusNext: null,
+          changelogMessage: CHANGELOG_MESSAGES.CANCEL_REVIEW,
+        },
+      );
+      render(
+        <Subject props={experiment} mocks={[mutationMock]} {...{ refetch }} />,
+      );
+
+      await screen.findByTestId("cancel-review-start");
+      fireEvent.click(screen.getByTestId("cancel-review-start"));
+      await screen.findByTestId("cancel-review-alert");
+      fireEvent.click(screen.getByTestId("cancel-review-confirm"));
+      await waitFor(() => {
+        expect(refetch).toHaveBeenCalled();
+        expect(screen.queryByTestId("submit-error")).not.toBeInTheDocument();
+      });
+      expect(screen.queryByTestId("label-enrollment-days")).toHaveTextContent(
+        "1 day",
+      );
+    });
+
     it("handles submission with server API error", async () => {
       const { experiment } = mockExperimentQuery("demo-slug", {
         status: NimbusExperimentStatusEnum.LIVE,

--- a/app/experimenter/nimbus-ui/src/components/Summary/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/index.tsx
@@ -64,7 +64,9 @@ const Summary = ({
     {
       publishStatus: NimbusExperimentPublishStatusEnum.IDLE,
       changelogMessage: CHANGELOG_MESSAGES.CANCEL_REVIEW,
-      statusNext: null,
+      statusNext: NimbusExperimentStatusEnum.LIVE
+        ? null
+        : NimbusExperimentStatusEnum.DRAFT,
     },
   );
 


### PR DESCRIPTION
Because

* When the experiment is in a live state and we cancel the review request, it was changing the enrollment days (as it is a property and we compute this from the changelogs)

This commit

* fixes the issue regarding changing enrollment days and test cases to verify new changes

fix #7613 