### PR TITLE
fix #7631 feat(nimbus): Improve error message background

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/ChangeApprovalOperations/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/ChangeApprovalOperations/index.tsx
@@ -100,7 +100,7 @@ export const ChangeApprovalOperations: React.FC<
   switch (uiState) {
     case ChangeApprovalOperationsState.InvalidPages:
       return (
-        <Alert variant="warning" data-testid="invalid-pages">
+        <Alert variant="danger" data-testid="invalid-pages">
           Before this experiment can be reviewed or launched, all required
           fields must be completed. Fields on the <InvalidPagesList />{" "}
           {invalidPages.length === 1 ? "page" : "pages"} are missing details.


### PR DESCRIPTION
Because

* Error message should pop up as a red signal

This commit

* Modifying the background of the error message to red

fix #7631 

Screenshot for the new changes
- Before
![image](https://user-images.githubusercontent.com/104033388/186201977-ca1d5cda-1b97-453e-86f1-12d85ca540d8.png)

- After
<img width="1728" alt="image" src="https://user-images.githubusercontent.com/104033388/186201829-74401358-c05c-40ca-be67-4cd119f6e1f8.png">

