### PR TITLE
fix #7394 feat(nimbus): Show full date

### DIFF
--- a/app/experimenter/nimbus-ui/src/lib/dateUtils.test.ts
+++ b/app/experimenter/nimbus-ui/src/lib/dateUtils.test.ts
@@ -13,16 +13,8 @@ const FAKE_DATE = "Sat Dec 12 2020";
 const FAKE_ISO_DATE = "2020-12-25T15:28:01.821657+00:00";
 
 describe("humanDate", () => {
-  it("should produce the date and month", () => {
-    expect(humanDate(FAKE_ISO_DATE, false)).toEqual("Dec 25");
-  });
-
-  it("with year explicitly enabled, should produce the date, month, and year", () => {
-    expect(humanDate(FAKE_ISO_DATE, true)).toEqual("Dec 25, 2020");
-  });
-
-  it("with year set to 'past', should produce the date, month, and year", () => {
-    expect(humanDate(FAKE_ISO_DATE, "past")).toEqual("Dec 25, 2020");
+  it("should produce the date, month and year", () => {
+    expect(humanDate(FAKE_ISO_DATE)).toEqual("Dec 25, 2020");
   });
 
   it("normalizes time and timezone", () => {

--- a/app/experimenter/nimbus-ui/src/lib/dateUtils.ts
+++ b/app/experimenter/nimbus-ui/src/lib/dateUtils.ts
@@ -6,11 +6,7 @@ import { getAllExperiments_experiments } from "../types/getAllExperiments";
 import { getExperiment_experimentBySlug } from "../types/getExperiment";
 import { pluralize } from "./utils";
 
-export function humanDate(
-  date: string,
-  year: boolean | "past" = "past",
-): string {
-  const today = new Date();
+export function humanDate(date: string): string {
   const parsedDate = new Date(date);
   // Dates currently arrive both with and without time and
   // timezone, so reset time to start of day and force GMT
@@ -22,16 +18,8 @@ export function humanDate(
     month: "short",
     day: "numeric",
     timeZone: "GMT",
+    year: "numeric",
   };
-
-  // Only show the year if the date's year is not the current
-  // year, or if the option is explicitly enabled
-  if (
-    (year === "past" && today.getFullYear() !== parsedDate.getFullYear()) ||
-    year === true
-  ) {
-    options.year = "numeric";
-  }
 
   return parsedDate.toLocaleString("en-US", options);
 }


### PR DESCRIPTION
Because

* We only show the year in the experiment's date when it is not a current year

This commit

* Adds year to all date

fix #7394 
Before changes:
<img width="1728" alt="image" src="https://user-images.githubusercontent.com/104033388/186230226-e14255b9-d960-4636-a98f-886d32cd91fd.png">
After changes
<img width="1728" alt="image" src="https://user-images.githubusercontent.com/104033388/186230309-bbb5de3c-30e1-4721-a828-f655767b4551.png">
