### PR TITLE
fix #7628 fix(nimbus): Hide add branch button when creating a rollout

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/index.tsx
@@ -101,8 +101,10 @@ export const FormBranches = ({
   const clearSubmitErrors = () => dispatch({ type: "clearSubmitErrors" });
 
   const handleAddBranch = () => {
-    commitFormData();
-    dispatch({ type: "addBranch" });
+    if (!isRollout) {
+      commitFormData();
+      dispatch({ type: "addBranch" });
+    }
   };
 
   const handleRemoveBranch = (idx: number) => () => {
@@ -354,7 +356,7 @@ export const FormBranches = ({
               );
             })}
         </section>
-        {!experiment.isRollout && (
+        {!isRollout && (
           <Button
             data-testid="add-branch"
             variant="outline-primary"


### PR DESCRIPTION
Because...

* The "+ Add branch" button on the Branches page is still showing when we set the experiment to be a rollout
* `handleAddBranch` was still adding branches in the backend (if you unselect isRollout you see the hidden branches)

This commit...

* Checks the state of `isRollout` before adding a branch
* The "+ Add branch" button disappears as soon as rollout is clicked

<img width="1194" alt="image" src="https://user-images.githubusercontent.com/43795363/186525665-fa4a4bcb-5471-48ef-972f-eb014a1abcbf.png">

https://user-images.githubusercontent.com/43795363/186525718-26b12f4c-cc81-44b4-8d99-9f0d1f875f50.mov


#7628