### PR TITLE
fix #7273 feat(nimbus) test(nimbus): Add new opMon link for rollout dashboards

### DIFF
--- a/app/experimenter/experiments/api/v5/types.py
+++ b/app/experimenter/experiments/api/v5/types.py
@@ -367,6 +367,7 @@ class NimbusExperimentType(DjangoObjectType):
     warn_feature_schema = graphene.Boolean()
     ready_for_review = graphene.Field(NimbusReviewType)
     monitoring_dashboard_url = graphene.String()
+    rollout_monitoring_dashboard_url = graphene.String()
     results_ready = graphene.Boolean()
     start_date = graphene.DateTime()
     computed_end_date = graphene.DateTime()

--- a/app/experimenter/experiments/models.py
+++ b/app/experimenter/experiments/models.py
@@ -522,6 +522,13 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
         )
 
     @property
+    def rollout_monitoring_dashboard_url(self):
+        if self.start_date and ((datetime.date.today() - self.start_date).days >= 1):
+            return settings.ROLLOUT_MONITORING_URL.format(
+                slug=self.slug.replace("-", "_")
+            )
+
+    @property
     def review_url(self):
         return "{base_url}{collection_path}/{collection}/{review_path}".format(
             base_url=settings.KINTO_ADMIN_URL,

--- a/app/experimenter/experiments/models.py
+++ b/app/experimenter/experiments/models.py
@@ -523,7 +523,7 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
 
     @property
     def rollout_monitoring_dashboard_url(self):
-        if self.start_date and ((datetime.date.today() - self.start_date).days >= 1):
+        if self.status == (NimbusExperiment.Status.LIVE or NimbusExperiment.Status.COMPLETE):
             return settings.ROLLOUT_MONITORING_URL.format(
                 slug=self.slug.replace("-", "_")
             )

--- a/app/experimenter/experiments/models.py
+++ b/app/experimenter/experiments/models.py
@@ -525,7 +525,7 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
     def rollout_monitoring_dashboard_url(self):
         if self.is_rollout and (
             self.status
-            == (NimbusExperiment.Status.LIVE or NimbusExperiment.Status.COMPLETE)
+            in (NimbusExperiment.Status.LIVE, NimbusExperiment.Status.COMPLETE)
         ):
             return settings.ROLLOUT_MONITORING_URL.format(
                 slug=self.slug.replace("-", "_")

--- a/app/experimenter/experiments/models.py
+++ b/app/experimenter/experiments/models.py
@@ -523,7 +523,10 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
 
     @property
     def rollout_monitoring_dashboard_url(self):
-        if self.status == (NimbusExperiment.Status.LIVE or NimbusExperiment.Status.COMPLETE):
+        if self.is_rollout and (
+            self.status
+            == (NimbusExperiment.Status.LIVE or NimbusExperiment.Status.COMPLETE)
+        ):
             return settings.ROLLOUT_MONITORING_URL.format(
                 slug=self.slug.replace("-", "_")
             )

--- a/app/experimenter/experiments/tests/test_models.py
+++ b/app/experimenter/experiments/tests/test_models.py
@@ -1040,10 +1040,30 @@ class TestNimbusExperiment(TestCase):
             experiment.end_date,
         )
 
-    def test_monitoring_dashboard_url_is_when_experiment_not_begun(self):
+    def test_monitoring_dashboard_url_is_valid_when_experiment_not_begun(self):
         experiment = NimbusExperimentFactory.create(
             slug="experiment",
             status=NimbusExperiment.Status.DRAFT,
+            is_rollout=False,
+        )
+
+        from_date = datetime.date.today() - datetime.timedelta(days=1)
+        to_date = datetime.date.today() + datetime.timedelta(days=1)
+
+        self.assertEqual(
+            experiment.monitoring_dashboard_url,
+            settings.MONITORING_URL.format(
+                slug=experiment.slug,
+                from_date=from_date.strftime("%Y-%m-%d"),
+                to_date=to_date.strftime("%Y-%m-%d"),
+            ),
+        )
+
+    def test_monitoring_dashboard_returns_url_when_rollout(self):
+        experiment = NimbusExperimentFactory.create(
+            slug="experiment",
+            status=NimbusExperiment.Status.DRAFT,
+            is_rollout=True,
         )
 
         from_date = datetime.date.today() - datetime.timedelta(days=1)
@@ -1062,6 +1082,7 @@ class TestNimbusExperiment(TestCase):
         experiment = NimbusExperimentFactory.create(
             slug="experiment",
             status=NimbusExperiment.Status.LIVE,
+            is_rollout=False,
         )
 
         NimbusChangeLogFactory.create(
@@ -1087,6 +1108,7 @@ class TestNimbusExperiment(TestCase):
         experiment = NimbusExperimentFactory.create(
             slug="experiment",
             status=NimbusExperiment.Status.COMPLETE,
+            is_rollout=False,
         )
 
         NimbusChangeLogFactory.create(

--- a/app/experimenter/experiments/tests/test_models.py
+++ b/app/experimenter/experiments/tests/test_models.py
@@ -1123,59 +1123,14 @@ class TestNimbusExperiment(TestCase):
         )
         self.assertIsNone(experiment.rollout_monitoring_dashboard_url)
 
-    def test_rollouts_monitoring_dashboard_url_is_none_on_first_day(self):
-        experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperimentFactory.Lifecycles.CREATED,
-            slug="rollout-1-slug",
-            status=NimbusExperiment.Status.DRAFT,
-        )
-
-        NimbusChangeLogFactory.create(
-            experiment=experiment,
-            old_status=NimbusExperiment.Status.DRAFT,
-            new_status=NimbusExperiment.Status.LIVE,
-            changed_on=datetime.date.today(),
-        )
-
-        self.assertIsNone(experiment.rollout_monitoring_dashboard_url)
-
-    def test_rollouts_monitoring_dashboard_returns_url_one_day_after_start(self):
-        yesterday = datetime.date.today() - datetime.timedelta(days=1)
-        experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperimentFactory.Lifecycles.CREATED,
-            slug="rollout-1-slug",
-            status=NimbusExperiment.Status.DRAFT,
-        )
-        NimbusChangeLogFactory.create(
-            experiment=experiment,
-            old_status=NimbusExperiment.Status.DRAFT,
-            new_status=NimbusExperiment.Status.LIVE,
-            changed_on=yesterday,
-        )
-
-        expected_slug = experiment.slug.replace("-", "_")
-        self.assertEqual(
-            experiment.rollout_monitoring_dashboard_url,
-            settings.ROLLOUT_MONITORING_URL.format(
-                slug=expected_slug,
-            ),
-        )
-
     def test_rollouts_monitoring_dashboard_returns_correct_formatted_url(self):
-        yesterday = datetime.date.today() - datetime.timedelta(days=1)
         experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperimentFactory.Lifecycles.CREATED,
+            NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE_APPROVE,
             slug="rollout-1-slug",
-            status=NimbusExperiment.Status.DRAFT,
-        )
-        NimbusChangeLogFactory.create(
-            experiment=experiment,
-            old_status=NimbusExperiment.Status.DRAFT,
-            new_status=NimbusExperiment.Status.LIVE,
-            changed_on=yesterday,
+            status=NimbusExperiment.Status.LIVE,
         )
 
-        expected_slug = experiment.slug.replace("-", "_")
+        expected_slug = "rollout_1_slug"
         url = experiment.rollout_monitoring_dashboard_url
         actual_slug = url[(url.index("::") + 2) :]  # take a slice of the url after '::'
         self.assertEqual(expected_slug, actual_slug)
@@ -1188,26 +1143,12 @@ class TestNimbusExperiment(TestCase):
         )
 
     def test_rollouts_monitoring_dashboard_returns_url_when_rollout_is_complete(self):
-        yesterday = datetime.date.today() - datetime.timedelta(days=1)
         experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperimentFactory.Lifecycles.ENDING_APPROVE_APPROVE,
+            NimbusExperimentFactory.Lifecycles.ENDING_APPROVE,
             slug="rollout-1-slug",
             status=NimbusExperiment.Status.COMPLETE,
         )
-        NimbusChangeLogFactory.create(
-            experiment=experiment,
-            old_status=NimbusExperiment.Status.DRAFT,
-            new_status=NimbusExperiment.Status.LIVE,
-            changed_on=yesterday,
-        )
-
-        NimbusChangeLogFactory.create(
-            experiment=experiment,
-            old_status=NimbusExperiment.Status.LIVE,
-            new_status=NimbusExperiment.Status.COMPLETE,
-            changed_on=datetime.date.today(),
-        )
-        expected_slug = experiment.slug.replace("-", "_")
+        expected_slug = "rollout_1_slug"
         self.assertEqual(
             experiment.rollout_monitoring_dashboard_url,
             settings.ROLLOUT_MONITORING_URL.format(

--- a/app/experimenter/experiments/tests/test_models.py
+++ b/app/experimenter/experiments/tests/test_models.py
@@ -1119,6 +1119,7 @@ class TestNimbusExperiment(TestCase):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.CREATED,
             slug="rollout-1-slug",
+            is_rollout=True,
             status=NimbusExperiment.Status.DRAFT,
         )
         self.assertIsNone(experiment.rollout_monitoring_dashboard_url)
@@ -1127,6 +1128,7 @@ class TestNimbusExperiment(TestCase):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE_APPROVE,
             slug="rollout-1-slug",
+            is_rollout=True,
             status=NimbusExperiment.Status.LIVE,
         )
 
@@ -1146,6 +1148,7 @@ class TestNimbusExperiment(TestCase):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.ENDING_APPROVE,
             slug="rollout-1-slug",
+            is_rollout=True,
             status=NimbusExperiment.Status.COMPLETE,
         )
         expected_slug = "rollout_1_slug"
@@ -1155,6 +1158,15 @@ class TestNimbusExperiment(TestCase):
                 slug=expected_slug,
             ),
         )
+
+    def test_rollouts_monitoring_dashboard_returns_none_when_not_rollout(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.ENDING_APPROVE,
+            slug="rollout-1-slug",
+            is_rollout=False,
+            status=NimbusExperiment.Status.COMPLETE,
+        )
+        self.assertIsNone(experiment.rollout_monitoring_dashboard_url)
 
     def test_review_url_should_return_simple_review_url(self):
         with override_settings(

--- a/app/experimenter/nimbus-ui/schema.graphql
+++ b/app/experimenter/nimbus-ui/schema.graphql
@@ -448,6 +448,7 @@ type NimbusExperimentType {
   featureConfigs: [NimbusFeatureConfigType]
   readyForReview: NimbusReviewType
   monitoringDashboardUrl: String
+  rolloutMonitoringDashboardUrl: String
   resultsReady: Boolean
   startDate: DateTime
   computedEndDate: DateTime

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/index.test.tsx
@@ -63,6 +63,8 @@ describe("FormBranches", () => {
         // @ts-ignore type mismatch covers discarded annotation properties
         (branch) => extractUpdateBranch(branch!),
       ),
+      isRollout: false,
+      warnFeatureSchema: false,
     });
     expect(typeof onSaveArgs[1]).toEqual("function");
     expect(typeof onSaveArgs[2]).toEqual("function");

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/mocks.tsx
@@ -16,6 +16,8 @@ import { FormBranchesState } from "./reducer/state";
 export const MOCK_EXPERIMENT = mockExperimentQuery("demo-slug", {
   application: NimbusExperimentApplicationEnum.DESKTOP,
   featureConfigs: [], //MOCK_CONFIG!.featureConfigs![0],
+  isRollout: false,
+  warnFeatureSchema: false,
   referenceBranch: {
     id: 123,
     name: "User-centric mobile solution",

--- a/app/experimenter/nimbus-ui/src/components/PageHome/DirectoryTable/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageHome/DirectoryTable/index.test.tsx
@@ -221,19 +221,36 @@ describe("DirectoryLiveTable", () => {
   it.each([
     ["looker link is present", experiment, "Looker"],
     [
+      "rollouts link is present",
+      {
+        ...experiment,
+        rolloutMonitoringDashboardUrl: "https",
+      },
+      "Rollout dashboard",
+    ],
+    [
       "results are ready",
-      { ...experiment, resultsReady: true, monitoringDashboardUrl: null },
+      {
+        ...experiment,
+        resultsReady: true,
+        monitoringDashboardUrl: null,
+        rolloutMonitoringDashboardUrl: null,
+      },
       "Results",
     ],
     [
       "neither is present",
-      { ...experiment, monitoringDashboardUrl: null },
+      {
+        ...experiment,
+        monitoringDashboardUrl: null,
+        rolloutMonitoringDashboardUrl: null,
+      },
       "N/A",
     ],
     [
-      "both are present",
+      "all are present",
       { ...experiment, resultsReady: true },
-      "LookerOpens in new windowResults",
+      "LookerOpens in new windowRollout dashboardOpens in new windowResults",
     ],
   ])(
     "renders as expected with custom columns when %s",

--- a/app/experimenter/nimbus-ui/src/components/PageHome/DirectoryTable/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageHome/DirectoryTable/index.tsx
@@ -288,10 +288,21 @@ export const DirectoryLiveTable: React.FC<DirectoryTableProps> = (props) => (
                 Looker
               </LinkExternal>
             )}
+            {experiment.monitoringDashboardUrl &&
+              experiment.resultsReady &&
+              experiment.rolloutMonitoringDashboardUrl && <br />}
+            {experiment.rolloutMonitoringDashboardUrl && (
+              <LinkExternal
+                href={experiment.rolloutMonitoringDashboardUrl!}
+                data-testid="link-rollout-monitoring-dashboard"
+              >
+                Rollout dashboard
+              </LinkExternal>
+            )}
             {experiment.monitoringDashboardUrl && experiment.resultsReady && (
               <br />
             )}
-            {experiment.resultsReady && (
+            {!experiment.isRollout && experiment.resultsReady && (
               <Link
                 to={`${experiment.slug}/results`}
                 data-sb-kind="pages/Results"
@@ -300,6 +311,7 @@ export const DirectoryLiveTable: React.FC<DirectoryTableProps> = (props) => (
               </Link>
             )}
             {!experiment.monitoringDashboardUrl &&
+              !experiment.rolloutMonitoringDashboardUrl &&
               !experiment.resultsReady &&
               "N/A"}
           </td>

--- a/app/experimenter/nimbus-ui/src/gql/experiments.ts
+++ b/app/experimenter/nimbus-ui/src/gql/experiments.ts
@@ -197,6 +197,7 @@ export const GET_EXPERIMENTS_QUERY = gql`
   query getAllExperiments {
     experiments {
       isArchived
+      isRollout
       name
       owner {
         username

--- a/app/experimenter/nimbus-ui/src/gql/experiments.ts
+++ b/app/experimenter/nimbus-ui/src/gql/experiments.ts
@@ -37,6 +37,7 @@ export const GET_EXPERIMENT_QUERY = gql`
       statusNext
       publishStatus
       monitoringDashboardUrl
+      rolloutMonitoringDashboardUrl
       resultsReady
 
       hypothesis
@@ -223,6 +224,7 @@ export const GET_EXPERIMENTS_QUERY = gql`
       statusNext
       publishStatus
       monitoringDashboardUrl
+      rolloutMonitoringDashboardUrl
       resultsReady
       featureConfig {
         slug

--- a/app/experimenter/nimbus-ui/src/lib/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/lib/mocks.tsx
@@ -473,6 +473,7 @@ export class SimulatedMockLink extends ApolloLink {
 export const MOCK_EXPERIMENT: Partial<getExperiment["experimentBySlug"]> = {
   id: 1,
   isArchived: false,
+  isRollout: false,
   canEdit: true,
   canArchive: true,
   owner: {
@@ -484,6 +485,7 @@ export const MOCK_EXPERIMENT: Partial<getExperiment["experimentBySlug"]> = {
   statusNext: null,
   publishStatus: NimbusExperimentPublishStatusEnum.IDLE,
   monitoringDashboardUrl: "https://mozilla.cloud.looker.com",
+  rolloutMonitoringDashboardUrl: "https://mozilla.cloud.looker.com",
   hypothesis: "Realize material say pretty.",
   application: NimbusExperimentApplicationEnum.DESKTOP,
   publicDescription: "Official approach present industry strategy dream piece.",
@@ -668,6 +670,7 @@ export function mockSingleDirectoryExperiment(
 
   return {
     isArchived: false,
+    isRollout: false,
     slug: `some-experiment-${slugIndex}`,
     owner: {
       username: "example@mozilla.com",
@@ -680,6 +683,8 @@ export function mockSingleDirectoryExperiment(
       .value as NimbusExperimentFirefoxVersionEnum,
     monitoringDashboardUrl:
       "https://mozilla.cloud.looker.com/dashboards-next/216?Experiment=bug-1668861-pref-measure-set-to-default-adoption-impact-of-chang-release-81-83",
+    rolloutMonitoringDashboardUrl:
+      "https://mozilla.cloud.looker.com/dashboards/operational_monitoring::experiment_slug",
     name: "Open-architected background installation",
     status: NimbusExperimentStatusEnum.COMPLETE,
     statusNext: null,

--- a/app/experimenter/nimbus-ui/src/types/getAllExperiments.ts
+++ b/app/experimenter/nimbus-ui/src/types/getAllExperiments.ts
@@ -47,6 +47,7 @@ export interface getAllExperiments_experiments {
   statusNext: NimbusExperimentStatusEnum | null;
   publishStatus: NimbusExperimentPublishStatusEnum | null;
   monitoringDashboardUrl: string | null;
+  rolloutMonitoringDashboardUrl: string | null;
   resultsReady: boolean | null;
   featureConfig: getAllExperiments_experiments_featureConfig | null;
 }

--- a/app/experimenter/nimbus-ui/src/types/getAllExperiments.ts
+++ b/app/experimenter/nimbus-ui/src/types/getAllExperiments.ts
@@ -30,6 +30,7 @@ export interface getAllExperiments_experiments_featureConfig {
 
 export interface getAllExperiments_experiments {
   isArchived: boolean | null;
+  isRollout: boolean | null;
   name: string;
   owner: getAllExperiments_experiments_owner;
   featureConfigs: (getAllExperiments_experiments_featureConfigs | null)[] | null;

--- a/app/experimenter/nimbus-ui/src/types/getExperiment.ts
+++ b/app/experimenter/nimbus-ui/src/types/getExperiment.ts
@@ -144,6 +144,7 @@ export interface getExperiment_experimentBySlug {
   statusNext: NimbusExperimentStatusEnum | null;
   publishStatus: NimbusExperimentPublishStatusEnum | null;
   monitoringDashboardUrl: string | null;
+  rolloutMonitoringDashboardUrl: string | null;
   resultsReady: boolean | null;
   hypothesis: string;
   application: NimbusExperimentApplicationEnum | null;

--- a/app/experimenter/settings.py
+++ b/app/experimenter/settings.py
@@ -362,6 +362,9 @@ MONITORING_URL = (
     "https://mozilla.cloud.looker.com/dashboards-next/216?"
     "Experiment={slug}&Time+Range={from_date}+to+{to_date}"
 )
+ROLLOUTS_MONITORING_URL = (
+    "https://mozilla.cloud.looker.com/dashboards/operational_monitoring::{slug}"
+)
 
 # Statsd via Markus
 STATSD_BACKEND = config(

--- a/app/experimenter/settings.py
+++ b/app/experimenter/settings.py
@@ -362,7 +362,7 @@ MONITORING_URL = (
     "https://mozilla.cloud.looker.com/dashboards-next/216?"
     "Experiment={slug}&Time+Range={from_date}+to+{to_date}"
 )
-ROLLOUTS_MONITORING_URL = (
+ROLLOUT_MONITORING_URL = (
     "https://mozilla.cloud.looker.com/dashboards/operational_monitoring::{slug}"
 )
 


### PR DESCRIPTION
Because...

* Rollout dashboards live in a different place than the experiment looker dashboards

This commit...

* Adds the new rollout link format (with underscores instead of dashes in the slug)
* Adds the rollout dashboard to models
* Only shows the rollout dashboard after the rollout is Live
* Shows rollout dashboards for rollouts and experiment dashboards for experiments

<img width="1161" alt="image" src="https://user-images.githubusercontent.com/43795363/186968756-385e2e8a-ae52-453e-ae7e-d35564fb6bc1.png">

#7273 
