### PR TITLE
7635/remove confirm intermittent state

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/PageSummary/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageSummary/index.test.tsx
@@ -91,7 +91,7 @@ describe("PageSummary", () => {
       canReview: true,
     });
     render(<Subject mocks={[mock]} />);
-    await screen.findByText("Cancel Review Request");
+    await screen.findByText("Cancel Review");
   });
 
   it("can cancel review when the experiment is in the review state", async () => {

--- a/app/experimenter/nimbus-ui/src/components/PageSummary/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageSummary/index.test.tsx
@@ -110,8 +110,6 @@ describe("PageSummary", () => {
 
     await screen.findByTestId("cancel-review-start");
     fireEvent.click(screen.getByTestId("cancel-review-start"));
-    await screen.findByTestId("cancel-review-alert");
-    fireEvent.click(screen.getByTestId("cancel-review-confirm"));
     await waitFor(() => {
       expect(screen.queryByTestId("submit-error")).not.toBeInTheDocument();
     });

--- a/app/experimenter/nimbus-ui/src/components/Summary/CancelReview.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/CancelReview.tsx
@@ -2,8 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React, { useCallback, useState } from "react";
-import { Alert, Button } from "react-bootstrap";
+import React from "react";
+import { Button } from "react-bootstrap";
 
 const CancelReview = ({
   onSubmit,
@@ -12,50 +12,16 @@ const CancelReview = ({
   isLoading: boolean;
   onSubmit: () => void;
 }) => {
-  const [showCancelConfirmation, setShowCancelConfirmation] = useState(false);
-
-  const toggleShowCancelConfirmation = useCallback(
-    () => setShowCancelConfirmation(!showCancelConfirmation),
-    [showCancelConfirmation, setShowCancelConfirmation],
-  );
-
   return (
     <div className="mb-4" data-testid="review-cancel">
-      {showCancelConfirmation ? (
-        <Alert variant="secondary" data-testid="cancel-review-alert">
-          <p>Are you sure you want to Cancel Review for your experiment?</p>
-
-          <div>
-            <Button
-              variant="primary"
-              onClick={onSubmit}
-              disabled={isLoading}
-              data-testid="cancel-review-confirm"
-            >
-              Yes, Cancel Review Request
-            </Button>
-
-            <Button
-              variant="secondary"
-              className="ml-2"
-              onClick={toggleShowCancelConfirmation}
-              disabled={isLoading}
-              data-testid="cancel-review-cancel"
-            >
-              Cancel
-            </Button>
-          </div>
-        </Alert>
-      ) : (
-        <Button
-          variant="primary"
-          onClick={toggleShowCancelConfirmation}
-          disabled={isLoading}
-          data-testid="cancel-review-start"
-        >
-          Cancel Review Request
-        </Button>
-      )}
+      <Button
+        variant="primary"
+        onClick={onSubmit}
+        disabled={isLoading}
+        data-testid="cancel-review-start"
+      >
+        Cancel Review Request
+      </Button>
     </div>
   );
 };

--- a/app/experimenter/nimbus-ui/src/components/Summary/CancelReview.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/CancelReview.tsx
@@ -20,7 +20,7 @@ const CancelReview = ({
         disabled={isLoading}
         data-testid="cancel-review-start"
       >
-        Cancel Review Request
+        Cancel Review
       </Button>
     </div>
   );

--- a/app/experimenter/nimbus-ui/src/components/Summary/EndEnrollment.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/EndEnrollment.tsx
@@ -2,8 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React, { useCallback, useState } from "react";
-import { Alert, Button } from "react-bootstrap";
+import React from "react";
+import { Button } from "react-bootstrap";
 
 const EndEnrollment = ({
   onSubmit,
@@ -12,50 +12,16 @@ const EndEnrollment = ({
   isLoading: boolean;
   onSubmit: () => void;
 }) => {
-  const [showEndConfirmation, setShowEndConfirmation] = useState(false);
-
-  const toggleShowEndConfirmation = useCallback(
-    () => setShowEndConfirmation(!showEndConfirmation),
-    [showEndConfirmation, setShowEndConfirmation],
-  );
-
   return (
     <div className="mb-4" data-testid="enrollment-end">
-      {showEndConfirmation ? (
-        <Alert variant="secondary" data-testid="end-enrollment-alert">
-          <p>Are you sure you want to end enrollment for your experiment?</p>
-
-          <div>
-            <Button
-              variant="primary"
-              onClick={onSubmit}
-              disabled={isLoading}
-              data-testid="end-enrollment-confirm"
-            >
-              Yes, end enrollment for the experiment
-            </Button>
-
-            <Button
-              variant="secondary"
-              className="ml-2"
-              onClick={toggleShowEndConfirmation}
-              disabled={isLoading}
-              data-testid="end-enrollment-cancel"
-            >
-              Cancel
-            </Button>
-          </div>
-        </Alert>
-      ) : (
-        <Button
-          variant="primary"
-          onClick={toggleShowEndConfirmation}
-          disabled={isLoading}
-          data-testid="end-enrollment-start"
-        >
-          End Enrollment for Experiment
-        </Button>
-      )}
+      <Button
+        variant="primary"
+        onClick={onSubmit}
+        disabled={isLoading}
+        data-testid="end-enrollment-start"
+      >
+        End Enrollment for Experiment
+      </Button>
     </div>
   );
 };

--- a/app/experimenter/nimbus-ui/src/components/Summary/EndEnrollment.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/EndEnrollment.tsx
@@ -20,7 +20,7 @@ const EndEnrollment = ({
         disabled={isLoading}
         data-testid="end-enrollment-start"
       >
-        End Enrollment for Experiment
+        End Enrollment
       </Button>
     </div>
   );

--- a/app/experimenter/nimbus-ui/src/components/Summary/EndExperiment/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/EndExperiment/index.test.tsx
@@ -12,29 +12,12 @@ describe("EndExperiment", () => {
     await screen.findByTestId("end-experiment-start");
   });
 
-  it("can start to but then cancel ending an experiment", async () => {
-    render(<Subject />);
-
-    const startEnd = await screen.findByTestId("end-experiment-start");
-    fireEvent.click(startEnd);
-    await screen.findByTestId("end-experiment-alert");
-
-    const cancelEnd = await screen.findByTestId("end-experiment-cancel");
-    fireEvent.click(cancelEnd);
-
-    await screen.findByTestId("end-experiment-start");
-  });
-
   it("calls onSubmit when ending an experiment", async () => {
     const onSubmit = jest.fn();
     render(<Subject {...{ onSubmit }} />);
 
     const startEnd = await screen.findByTestId("end-experiment-start");
     fireEvent.click(startEnd);
-    await screen.findByTestId("end-experiment-alert");
-
-    const confirmEnd = await screen.findByTestId("end-experiment-confirm");
-    fireEvent.click(confirmEnd);
     expect(onSubmit).toHaveBeenCalled();
   });
 

--- a/app/experimenter/nimbus-ui/src/components/Summary/EndExperiment/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/EndExperiment/index.tsx
@@ -2,8 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React, { useCallback, useState } from "react";
-import { Alert, Button } from "react-bootstrap";
+import React from "react";
+import { Button } from "react-bootstrap";
 
 const EndExperiment = ({
   onSubmit,
@@ -12,55 +12,19 @@ const EndExperiment = ({
   isLoading: boolean;
   onSubmit: () => void;
 }) => {
-  const [showEndConfirmation, setShowEndConfirmation] = useState(false);
-
-  const toggleShowEndConfirmation = useCallback(
-    () => setShowEndConfirmation(!showEndConfirmation),
-    [showEndConfirmation, setShowEndConfirmation],
-  );
-
   return (
     <div className="mb-4" data-testid="experiment-end">
-      {showEndConfirmation ? (
-        <Alert variant="secondary" data-testid="end-experiment-alert">
-          <p>
-            Are you sure you want to end your experiment? It will turn off the
-            experiment for all users in production.
-          </p>
-
-          <div>
-            <Button
-              variant="primary"
-              onClick={onSubmit}
-              className="end-experiment-confirm-button"
-              disabled={isLoading}
-              data-testid="end-experiment-confirm"
-            >
-              Yes, end the experiment
-            </Button>
-
-            <Button
-              variant="secondary"
-              className="ml-2"
-              onClick={toggleShowEndConfirmation}
-              disabled={isLoading}
-              data-testid="end-experiment-cancel"
-            >
-              Cancel
-            </Button>
-          </div>
-        </Alert>
-      ) : (
+      {
         <Button
           variant="primary"
-          onClick={toggleShowEndConfirmation}
+          onClick={onSubmit}
           className="end-experiment-start-button"
-          disabled={isLoading}
           data-testid="end-experiment-start"
+          disabled={isLoading}
         >
           End Experiment
         </Button>
-      )}
+      }
     </div>
   );
 };

--- a/app/experimenter/nimbus-ui/src/components/Summary/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/index.test.tsx
@@ -110,7 +110,7 @@ describe("Summary", () => {
         }}
       />,
     );
-    await screen.findByText("Cancel Review Request");
+    await screen.findByText("Cancel Review");
   });
 
   it("does not renders the end experiment button if the experiment is live and not idle", async () => {

--- a/app/experimenter/nimbus-ui/src/components/Summary/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/index.test.tsx
@@ -159,8 +159,6 @@ describe("Summary", () => {
         <Subject props={experiment} mocks={[mutationMock]} {...{ refetch }} />,
       );
       fireEvent.click(screen.getByTestId("end-experiment-start"));
-      await screen.findByTestId("end-experiment-alert");
-      fireEvent.click(screen.getByTestId("end-experiment-confirm"));
       await waitFor(() => {
         expect(refetch).toHaveBeenCalled();
         expect(screen.queryByTestId("submit-error")).not.toBeInTheDocument();
@@ -188,8 +186,6 @@ describe("Summary", () => {
 
       await screen.findByTestId("cancel-review-start");
       fireEvent.click(screen.getByTestId("cancel-review-start"));
-      await screen.findByTestId("cancel-review-alert");
-      fireEvent.click(screen.getByTestId("cancel-review-confirm"));
       await waitFor(() => {
         expect(refetch).toHaveBeenCalled();
         expect(screen.queryByTestId("submit-error")).not.toBeInTheDocument();
@@ -217,8 +213,6 @@ describe("Summary", () => {
 
       await screen.findByTestId("cancel-review-start");
       fireEvent.click(screen.getByTestId("cancel-review-start"));
-      await screen.findByTestId("cancel-review-alert");
-      fireEvent.click(screen.getByTestId("cancel-review-confirm"));
       await waitFor(() => {
         expect(refetch).toHaveBeenCalled();
         expect(screen.queryByTestId("submit-error")).not.toBeInTheDocument();
@@ -240,8 +234,6 @@ describe("Summary", () => {
       mutationMock.result.errors = [new Error("Boo")];
       render(<Subject props={experiment} mocks={[mutationMock]} />);
       fireEvent.click(screen.getByTestId("end-experiment-start"));
-      await screen.findByTestId("end-experiment-alert");
-      fireEvent.click(screen.getByTestId("end-experiment-confirm"));
       const errorContainer = await screen.findByTestId("submit-error");
       expect(errorContainer).toHaveTextContent(SUBMIT_ERROR);
     });
@@ -265,8 +257,6 @@ describe("Summary", () => {
       };
       render(<Subject props={experiment} mocks={[mutationMock]} />);
       fireEvent.click(screen.getByTestId("end-experiment-start"));
-      await screen.findByTestId("end-experiment-alert");
-      fireEvent.click(screen.getByTestId("end-experiment-confirm"));
       const errorContainer = await screen.findByTestId("submit-error");
       expect(errorContainer).toHaveTextContent(errorMessage);
     });
@@ -306,8 +296,6 @@ describe("Summary", () => {
         <Subject props={experiment} mocks={[mutationMock]} {...{ refetch }} />,
       );
       fireEvent.click(screen.getByTestId("end-enrollment-start"));
-      await screen.findByTestId("end-enrollment-alert");
-      fireEvent.click(screen.getByTestId("end-enrollment-confirm"));
       await waitFor(() => {
         expect(refetch).toHaveBeenCalled();
         expect(screen.queryByTestId("submit-error")).not.toBeInTheDocument();
@@ -330,8 +318,6 @@ describe("Summary", () => {
       mutationMock.result.errors = [new Error("Boo")];
       render(<Subject props={experiment} mocks={[mutationMock]} />);
       fireEvent.click(screen.getByTestId("end-enrollment-start"));
-      await screen.findByTestId("end-enrollment-alert");
-      fireEvent.click(screen.getByTestId("end-enrollment-confirm"));
       const errorContainer = await screen.findByTestId("submit-error");
       expect(errorContainer).toHaveTextContent(SUBMIT_ERROR);
     });
@@ -358,8 +344,6 @@ describe("Summary", () => {
       };
       render(<Subject props={experiment} mocks={[mutationMock]} />);
       fireEvent.click(screen.getByTestId("end-enrollment-start"));
-      await screen.findByTestId("end-enrollment-alert");
-      fireEvent.click(screen.getByTestId("end-enrollment-confirm"));
       const errorContainer = await screen.findByTestId("submit-error");
       expect(errorContainer).toHaveTextContent(errorMessage);
     });


### PR DESCRIPTION
Because

* We have a redundant state in between when the user clicks on `End Enrollment/End Experiment or Cancel Review` which asks the user to confirm-` Are you sure you want to confirm?`
* 

This commit

* Removes the intermittent state in between button confirmation and test cases to verify

fix #7635, 