### PR TITLE
fix #7655 chore(nimbus): use application channel in nimbus experiment factory

### DIFF
--- a/app/experimenter/experiments/tests/factories.py
+++ b/app/experimenter/experiments/tests/factories.py
@@ -233,7 +233,11 @@ class NimbusExperimentFactory(factory.django.DjangoModelFactory):
     )
     application = NimbusExperiment.Application.DESKTOP
     channel = factory.LazyAttribute(
-        lambda o: random.choice(list(NimbusExperiment.Channel)).value
+        lambda o: random.choice(
+            list(
+                NimbusExperiment.APPLICATION_CONFIGS[o.application].channel_app_id.keys()
+            )
+        ).value
     )
     hypothesis = factory.LazyAttribute(lambda o: faker.text(1000))
     targeting_config_slug = factory.LazyAttribute(


### PR DESCRIPTION


Because

* We now have many application specific channels
* When we generate an experiment with the factories we have to be sure to select a valid channel for the application

This commit

* Filters the list of channels by the selected application in the NimbusExperimentFactory