### PR TITLE
Fixes #7694 fix(nimbus): Adds newline between looker and rollout dashboard

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/PageHome/DirectoryTable/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageHome/DirectoryTable/index.tsx
@@ -289,7 +289,6 @@ export const DirectoryLiveTable: React.FC<DirectoryTableProps> = (props) => (
               </LinkExternal>
             )}
             {experiment.monitoringDashboardUrl &&
-              experiment.resultsReady &&
               experiment.rolloutMonitoringDashboardUrl && <br />}
             {experiment.rolloutMonitoringDashboardUrl && (
               <LinkExternal


### PR DESCRIPTION
Because...

* We were checking if results were ready when we added the breakline

This commit...

* Adds a break between the Looker and rollout dashboard links for live experiments regardless of result readiness

<img width="425" alt="image" src="https://user-images.githubusercontent.com/43795363/188992671-40e8fa2b-47cc-4503-a7c0-17632f24f436.png">

<img width="818" alt="image" src="https://user-images.githubusercontent.com/43795363/188992749-fb92a386-1bd7-4a4c-96ea-1cd85275cbdc.png">


#7694 