### PR TITLE
fix #7709 feat(nimbus): add first run v6 api endpoint

### DIFF
--- a/app/experimenter/docs/openapi-schema.json
+++ b/app/experimenter/docs/openapi-schema.json
@@ -1461,6 +1461,82 @@
         ]
       }
     },
+    "/api/v6/experiments-first-run/": {
+      "get": {
+        "operationId": "listNimbusExperiments",
+        "description": "",
+        "parameters": [
+          {
+            "name": "is_first_run",
+            "required": false,
+            "in": "query",
+            "description": "is_first_run",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/NimbusExperiment"
+                  }
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "tags": [
+          "Nimbus: Public"
+        ]
+      }
+    },
+    "/api/v6/experiments-first-run/{slug}/": {
+      "get": {
+        "operationId": "retrieveNimbusExperiment",
+        "description": "",
+        "parameters": [
+          {
+            "name": "slug",
+            "in": "path",
+            "required": true,
+            "description": "",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "is_first_run",
+            "required": false,
+            "in": "query",
+            "description": "is_first_run",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NimbusExperiment"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "tags": [
+          "Nimbus: Public"
+        ]
+      }
+    },
     "/api/v2/experiments/{slug}/intent-to-ship-email": {
       "put": {
         "operationId": "updateExperiment",

--- a/app/experimenter/docs/swagger-ui.html
+++ b/app/experimenter/docs/swagger-ui.html
@@ -1473,6 +1473,82 @@
         ]
       }
     },
+    "/api/v6/experiments-first-run/": {
+      "get": {
+        "operationId": "listNimbusExperiments",
+        "description": "",
+        "parameters": [
+          {
+            "name": "is_first_run",
+            "required": false,
+            "in": "query",
+            "description": "is_first_run",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/NimbusExperiment"
+                  }
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "tags": [
+          "Nimbus: Public"
+        ]
+      }
+    },
+    "/api/v6/experiments-first-run/{slug}/": {
+      "get": {
+        "operationId": "retrieveNimbusExperiment",
+        "description": "",
+        "parameters": [
+          {
+            "name": "slug",
+            "in": "path",
+            "required": true,
+            "description": "",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "is_first_run",
+            "required": false,
+            "in": "query",
+            "description": "is_first_run",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NimbusExperiment"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "tags": [
+          "Nimbus: Public"
+        ]
+      }
+    },
     "/api/v2/experiments/{slug}/intent-to-ship-email": {
       "put": {
         "operationId": "updateExperiment",

--- a/app/experimenter/experiments/api/v6/urls.py
+++ b/app/experimenter/experiments/api/v6/urls.py
@@ -1,7 +1,15 @@
 from rest_framework.routers import SimpleRouter
 
-from experimenter.experiments.api.v6.views import NimbusExperimentViewSet
+from experimenter.experiments.api.v6.views import (
+    NimbusExperimentFirstRunViewSet,
+    NimbusExperimentViewSet,
+)
 
 router = SimpleRouter()
 router.register(r"experiments", NimbusExperimentViewSet, "nimbus-experiment-rest")
+router.register(
+    r"experiments-first-run",
+    NimbusExperimentFirstRunViewSet,
+    "nimbus-experiment-rest-first-run",
+)
 urlpatterns = router.urls

--- a/app/experimenter/experiments/api/v6/views.py
+++ b/app/experimenter/experiments/api/v6/views.py
@@ -19,3 +19,12 @@ class NimbusExperimentViewSet(
     serializer_class = NimbusExperimentSerializer
     filter_backends = [DjangoFilterBackend]
     filterset_fields = ["is_first_run"]
+
+
+class NimbusExperimentFirstRunViewSet(NimbusExperimentViewSet):
+    queryset = (
+        NimbusExperiment.objects.with_related()
+        .filter(status=NimbusExperiment.Status.LIVE)
+        .filter(is_first_run=True)
+        .order_by("slug")
+    )

--- a/app/experimenter/settings.py
+++ b/app/experimenter/settings.py
@@ -165,6 +165,7 @@ OPENIDC_AUTH_WHITELIST = (
     "experiments-api-detail",
     "nimbus-experiment-rest-list",
     "nimbus-experiment-rest-detail",
+    "nimbus-experiment-rest-first-run-list",
 )
 
 # Internationalization


### PR DESCRIPTION
Because

* The mobile first run workflow depends on syncing live experiments into relevant mobile repos
* When the experiment ends it must be unpublished from the API so it can be removed from the repo
* The existing V6 api includes both live and complete experiments so we need a new endpoint

This commit

* Adds a new endpoint to V6 API specifically for live first run experiments