### PR TITLE
fix #7715 bug(nimbus): don't clone start/end dates

### DIFF
--- a/app/experimenter/experiments/models.py
+++ b/app/experimenter/experiments/models.py
@@ -683,6 +683,8 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
         cloned.results_data = None
         cloned.takeaways_summary = None
         cloned.conclusion_recommendation = None
+        cloned._start_date = None
+        cloned._end_date = None
         cloned.save()
 
         if rollout_branch_slug:

--- a/app/experimenter/experiments/tests/test_models.py
+++ b/app/experimenter/experiments/tests/test_models.py
@@ -1612,9 +1612,7 @@ class TestNimbusExperiment(TestCase):
         self.assertEqual(
             child.targeting_config_slug, NimbusExperiment.TargetingConfig.NO_TARGETING
         )
-        self.assertIsNone(child.reference_branch)
-        self.assertIsNone(child.published_dto)
-        self.assertIsNone(child.results_data)
+
         self.assertFalse(child.risk_partner_related)
         self.assertFalse(child.risk_revenue)
         self.assertFalse(child.risk_brand)
@@ -1662,15 +1660,24 @@ class TestNimbusExperiment(TestCase):
     ):
         child = parent.clone("Child Experiment", parent.owner, rollout_branch_slug)
 
-        self.assertEqual(child.parent, parent)
-        self.assertFalse(child.is_archived)
-        self.assertEqual(child.owner, parent.owner)
+        # Explicitly set fields
         self.assertEqual(child.status, NimbusExperiment.Status.DRAFT)
-        self.assertIsNone(child.status_next)
+        self.assertEqual(child.status_next, None)
         self.assertEqual(child.publish_status, NimbusExperiment.PublishStatus.IDLE)
+        self.assertEqual(child.owner, parent.owner)
+        self.assertEqual(child.parent, parent)
+        self.assertEqual(child.is_archived, False)
+        self.assertEqual(child.is_paused, False)
+        self.assertEqual(child.published_dto, None)
+        self.assertEqual(child.results_data, None)
+        self.assertEqual(child.takeaways_summary, None)
+        self.assertEqual(child.conclusion_recommendation, None)
+        self.assertEqual(child._start_date, None)
+        self.assertEqual(child._end_date, None)
+
+        # Cloned fields
         self.assertEqual(child.name, "Child Experiment")
         self.assertEqual(child.slug, "child-experiment")
-        self.assertFalse(child.is_paused)
         self.assertEqual(child.public_description, parent.public_description)
         self.assertEqual(child.application, parent.application)
         self.assertEqual(child.channel, parent.channel)
@@ -1680,14 +1687,13 @@ class TestNimbusExperiment(TestCase):
         self.assertEqual(child.risk_mitigation_link, parent.risk_mitigation_link)
         self.assertEqual(child.primary_outcomes, parent.primary_outcomes)
         self.assertEqual(child.secondary_outcomes, parent.secondary_outcomes)
-
         self.assertEqual(child.targeting_config_slug, parent.targeting_config_slug)
-        self.assertIsNone(child.published_dto)
-        self.assertIsNone(child.results_data)
         self.assertEqual(child.risk_partner_related, parent.risk_partner_related)
         self.assertEqual(child.risk_revenue, parent.risk_revenue)
         self.assertEqual(child.risk_brand, parent.risk_brand)
+
         self.assertFalse(NimbusBucketRange.objects.filter(experiment=child).exists())
+
         self.assertEqual(
             set(child.feature_configs.all().values_list("slug", flat=True)),
             set(parent.feature_configs.all().values_list("slug", flat=True)),


### PR DESCRIPTION
Because

* We recently added _start_date/_end_date fields to the NimbusExperiment model to cache the start/end dates for faster lookups in the API
* The clone method copies the entire NimbusExperiment object and requires explicitly setting to None any fields which should not be cloned
* This results in newly added fields being unintentionally cloned unless they're explicitly excluded

This commit

* Explicitly excludes the _start_date/_end_date fields from being cloned
* Reorganizes the clone test assertions to show which fields are being explicitly reset and which are being cloned