### PR TITLE
Fixes #7629 fix(nimbus): Remove treatment branches when setting is_rollout on branches page

### DIFF
--- a/app/experimenter/experiments/api/v5/serializers.py
+++ b/app/experimenter/experiments/api/v5/serializers.py
@@ -1348,6 +1348,8 @@ class NimbusReviewSerializer(serializers.ModelSerializer):
 
         for branch in value:
             error = {}
+            if self.instance and self.instance.is_rollout:
+                error["name"] = [NimbusConstants.ERROR_SINGLE_BRANCH_FOR_ROLLOUT]
             if branch["description"] == "":
                 error["description"] = [NimbusConstants.ERROR_REQUIRED_FIELD]
             errors.append(error)

--- a/app/experimenter/experiments/models.py
+++ b/app/experimenter/experiments/models.py
@@ -387,13 +387,10 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
 
     @property
     def treatment_branches(self):
-        if self.is_rollout:
-            return []
-        else:
-            branches = self.branches.order_by("id")
-            if self.reference_branch:
-                branches = branches.exclude(id=self.reference_branch.id)
-            return list(branches)
+        branches = self.branches.order_by("id")
+        if self.reference_branch:
+            branches = branches.exclude(id=self.reference_branch.id)
+        return list(branches)
 
     @property
     def is_started(self):

--- a/app/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_ready_for_review_serializer.py
+++ b/app/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_ready_for_review_serializer.py
@@ -1158,24 +1158,6 @@ class TestNimbusReviewSerializerSingleFeature(TestCase):
 
         self.assertTrue(serializer.is_valid())
 
-    def test_no_treatment_branches_for_rollout(self):
-        experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperimentFactory.Lifecycles.CREATED,
-            application=NimbusExperiment.Application.DESKTOP,
-            channel=NimbusExperiment.Channel.NO_CHANNEL,
-            feature_configs=[
-                NimbusFeatureConfigFactory(
-                    application=NimbusExperiment.Application.DESKTOP
-                )
-            ],
-            is_sticky=True,
-            targeting_config_slug=NimbusExperiment.TargetingConfig.MAC_ONLY,
-        )
-        self.assertNotEqual(experiment.treatment_branches, [])
-        experiment.is_rollout = True
-        experiment.save()
-        self.assertEqual(experiment.treatment_branches, [])
-
     def test_rollout_valid_version_support(self):
         desktop = NimbusExperiment.Application.DESKTOP
         experiment = NimbusExperimentFactory.create_with_lifecycle(

--- a/app/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_ready_for_review_serializer.py
+++ b/app/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_ready_for_review_serializer.py
@@ -1196,7 +1196,7 @@ class TestNimbusReviewSerializerSingleFeature(TestCase):
         self.assertFalse(serializer.is_valid())
         self.assertEqual(
             serializer.errors["treatment_branches"][0]["name"],
-            [NimbusConstants.ERROR_SINGLE_BRANCH_FOR_ROLLOUT]
+            [NimbusConstants.ERROR_SINGLE_BRANCH_FOR_ROLLOUT],
         )
 
     def test_rollout_valid_version_support(self):

--- a/app/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_ready_for_review_serializer.py
+++ b/app/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_ready_for_review_serializer.py
@@ -1180,14 +1180,14 @@ class TestNimbusReviewSerializerSingleFeature(TestCase):
 
         data = {
             "application": NimbusExperiment.Application.DESKTOP,
-            "is_sticky": "false",
-            "is_rollout": "true",
-            "targeting_config_slug": NimbusExperiment.TargetingConfig.MAC_ONLY,
-            "treatment_branches": [
+            "isSticky": "false",
+            "isRollout": "true",
+            "targetingConfigSlug": NimbusExperiment.TargetingConfig.MAC_ONLY,
+            "treatmentBranches": [
                 {"name": "treatment A", "description": "desc1", "ratio": 1},
                 {"name": "treatment B", "description": "desc2", "ratio": 1},
             ],
-            "changelog_message": "test changelog message",
+            "changelogMessage": "test changelog message",
             "channel": "",
         }
         serializer = NimbusReviewSerializer(
@@ -1195,7 +1195,7 @@ class TestNimbusReviewSerializerSingleFeature(TestCase):
         )
         self.assertFalse(serializer.is_valid())
         self.assertEqual(
-            serializer.errors["treatment_branches"][0]["name"],
+            serializer.errors["treatmentBranches"][0]["name"],
             [NimbusConstants.ERROR_SINGLE_BRANCH_FOR_ROLLOUT],
         )
 

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/index.test.tsx
@@ -160,6 +160,40 @@ describe("FormBranches", () => {
     expect(saveResult.isRollout).toBeTruthy();
   });
 
+  it("removes treatment branches when isRollout checkbox enabled", async () => {
+    const onSave = jest.fn();
+    const { container } = render(
+      <SubjectBranches
+        {...{
+          onSave,
+          experiment: {
+            ...MOCK_EXPERIMENT,
+            treatmentBranches: [
+              {
+                id: null,
+                name: "",
+                slug: "",
+                description: "",
+                ratio: 0,
+                featureValue: null,
+                featureEnabled: false,
+                screenshots: [],
+              },
+            ],
+          },
+        }}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId("is-rollout-checkbox"));
+    await clickAndWaitForSave(onSave);
+
+    const saveResult = onSave.mock.calls[0][0];
+    await waitFor(() => {
+      expect(saveResult.treatmentBranches).toEqual([]);
+    });
+  });
+
   it("gracefully handles selecting an invalid feature config", async () => {
     const onSave = jest.fn();
     render(<SubjectBranches {...{ onSave }} />);

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/reducer/actions.ts
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/reducer/actions.ts
@@ -134,9 +134,14 @@ function setIsRollout(
   state: FormBranchesState,
   { value: isRollout }: SetIsRolloutAction,
 ) {
+  let { treatmentBranches } = state;
+  if (isRollout) {
+    treatmentBranches = [];
+  }
   return {
     ...state,
     isRollout,
+    treatmentBranches,
   };
 }
 


### PR DESCRIPTION
Because...

* Not changing the treatment branch state in the db when `is_rollout=True` on the Branches page

This commit...

* Updates the is_rollout action to remove treatment branches when `is_rollout=True`

https://user-images.githubusercontent.com/43795363/189236842-2f383cb8-b8b4-4e4d-a4c9-d9a9703ba460.mov

#7629 