### PR TITLE
fix #7712 feat(nimbus): Add first run required in targeting

### DIFF
--- a/app/experimenter/docs/openapi-schema.json
+++ b/app/experimenter/docs/openapi-schema.json
@@ -3399,6 +3399,9 @@
                 },
                 "stickyRequired": {
                   "type": "boolean"
+                },
+                "isFirstRunRequired": {
+                  "type": "boolean"
                 }
               },
               "required": [
@@ -3406,7 +3409,8 @@
                 "value",
                 "applicationValues",
                 "description",
-                "stickyRequired"
+                "stickyRequired",
+                "isFirstRunRequired"
               ]
             }
           },

--- a/app/experimenter/docs/swagger-ui.html
+++ b/app/experimenter/docs/swagger-ui.html
@@ -3411,6 +3411,9 @@
                 },
                 "stickyRequired": {
                   "type": "boolean"
+                },
+                "isFirstRunRequired": {
+                  "type": "boolean"
                 }
               },
               "required": [
@@ -3418,7 +3421,8 @@
                 "value",
                 "applicationValues",
                 "description",
-                "stickyRequired"
+                "stickyRequired",
+                "isFirstRunRequired"
               ]
             }
           },

--- a/app/experimenter/experiments/api/v5/serializers.py
+++ b/app/experimenter/experiments/api/v5/serializers.py
@@ -91,6 +91,7 @@ class TargetingConfigDataClass:
     applicationValues: typing.List[str]
     description: str
     stickyRequired: bool
+    isFirstRunRequired: bool
 
 
 @dataclass
@@ -214,6 +215,9 @@ class NimbusConfigurationDataClass:
                 stickyRequired=NimbusExperiment.TARGETING_CONFIGS[
                     choice.value
                 ].sticky_required,
+                isFirstRunRequired=NimbusExperiment.TARGETING_CONFIGS[
+                    choice.value
+                ].is_first_run_required,
             )
             for choice in NimbusExperiment.TargetingConfig
         ]

--- a/app/experimenter/experiments/api/v5/types.py
+++ b/app/experimenter/experiments/api/v5/types.py
@@ -118,6 +118,7 @@ class NimbusExperimentTargetingConfigType(graphene.ObjectType):
     application_values = graphene.List(graphene.String)
     description = graphene.String()
     sticky_required = graphene.Boolean()
+    is_first_run_required = graphene.Boolean()
 
 
 class NimbusFeatureConfigType(DjangoObjectType):
@@ -318,6 +319,9 @@ class NimbusConfigurationType(graphene.ObjectType):
                 sticky_required=NimbusExperiment.TARGETING_CONFIGS[
                     choice.value
                 ].sticky_required,
+                is_first_run_required=NimbusExperiment.TARGETING_CONFIGS[
+                    choice.value
+                ].is_first_run_required,
             )
             for choice in NimbusExperiment.TargetingConfig
         ]
@@ -445,6 +449,9 @@ class NimbusExperimentType(DjangoObjectType):
                 sticky_required=NimbusExperiment.TARGETING_CONFIGS[
                     self.targeting_config_slug
                 ].sticky_required,
+                is_first_run_required=NimbusExperiment.TARGETING_CONFIGS[
+                    self.targeting_config_slug
+                ].is_first_run_required,
             )
         ]
 

--- a/app/experimenter/experiments/tests/api/v5/test_queries.py
+++ b/app/experimenter/experiments/tests/api/v5/test_queries.py
@@ -1031,6 +1031,7 @@ class TestNimbusExperimentBySlugQuery(GraphQLTestCase):
                         description
                         applicationValues
                         stickyRequired
+                        isFirstRunRequired
                     }
                 }
             }
@@ -1060,6 +1061,9 @@ class TestNimbusExperimentBySlugQuery(GraphQLTestCase):
                     "stickyRequired": NimbusExperiment.TARGETING_CONFIGS[
                         NimbusExperiment.TargetingConfig.FIRST_RUN.value
                     ].sticky_required,
+                    "isFirstRunRequired": NimbusExperiment.TARGETING_CONFIGS[
+                        NimbusExperiment.TargetingConfig.FIRST_RUN.value
+                    ].is_first_run_required,
                 }
             ],
         )
@@ -1313,6 +1317,7 @@ class TestNimbusConfigQuery(GraphQLTestCase):
                         description
                         applicationValues
                         stickyRequired
+                        isFirstRunRequired
                     }
                     hypothesisDefault
                     documentationLink {
@@ -1419,6 +1424,7 @@ class TestNimbusConfigQuery(GraphQLTestCase):
                     "description": targeting_config.description,
                     "stickyRequired": targeting_config.sticky_required,
                     "applicationValues": list(targeting_config.application_choice_names),
+                    "isFirstRunRequired": targeting_config.is_first_run_required,
                 },
                 config["targetingConfigs"],
             )

--- a/app/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_configuration_serializer.py
+++ b/app/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_configuration_serializer.py
@@ -98,6 +98,7 @@ class TestNimbusConfigurationSerializer(TestCase):
                     "description": targeting_config.description,
                     "stickyRequired": targeting_config.sticky_required,
                     "applicationValues": list(targeting_config.application_choice_names),
+                    "isFirstRunRequired": targeting_config.is_first_run_required,
                 },
                 config["targetingConfigs"],
             )

--- a/app/experimenter/nimbus-ui/schema.graphql
+++ b/app/experimenter/nimbus-ui/schema.graphql
@@ -396,6 +396,7 @@ type NimbusExperimentTargetingConfigType {
   applicationValues: [String]
   description: String
   stickyRequired: Boolean
+  isFirstRunRequired: Boolean
 }
 
 type NimbusExperimentType {

--- a/app/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/index.test.tsx
@@ -59,6 +59,7 @@ describe("FormAudience", () => {
               ],
               description: "No Targeting configuration",
               stickyRequired: false,
+              isFirstRunRequired: false,
             },
             {
               label: "Mac Only",
@@ -66,6 +67,7 @@ describe("FormAudience", () => {
               applicationValues: [NimbusExperimentApplicationEnum.DESKTOP],
               description: "Mac Only configuration",
               stickyRequired: true,
+              isFirstRunRequired: false,
             },
             {
               label: "Toaster thing",
@@ -73,6 +75,7 @@ describe("FormAudience", () => {
               applicationValues: ["TOASTER"],
               description: "Toaster thing description",
               stickyRequired: false,
+              isFirstRunRequired: false,
             },
           ],
         }}
@@ -136,6 +139,7 @@ describe("FormAudience", () => {
               ],
               description: "No Targeting configuration",
               stickyRequired: false,
+              isFirstRunRequired: false,
             },
             {
               label: "Mac Only",
@@ -143,6 +147,7 @@ describe("FormAudience", () => {
               applicationValues: [NimbusExperimentApplicationEnum.DESKTOP],
               description: "Mac Only configuration",
               stickyRequired: true,
+              isFirstRunRequired: false,
             },
             {
               label: "Toaster thing",
@@ -150,6 +155,7 @@ describe("FormAudience", () => {
               applicationValues: ["TOASTER"],
               description: "Toaster thing description",
               stickyRequired: false,
+              isFirstRunRequired: false,
             },
           ],
         }}
@@ -180,6 +186,7 @@ describe("FormAudience", () => {
               applicationValues: [NimbusExperimentApplicationEnum.DESKTOP],
               description: "Win Only configuration",
               stickyRequired: true,
+              isFirstRunRequired: false,
             },
           ],
           isSticky: true,
@@ -196,6 +203,7 @@ describe("FormAudience", () => {
               ],
               description: "No Targeting configuration",
               stickyRequired: false,
+              isFirstRunRequired: false,
             },
             {
               label: "Win Only",
@@ -203,6 +211,7 @@ describe("FormAudience", () => {
               applicationValues: [NimbusExperimentApplicationEnum.DESKTOP],
               description: "Win Only configuration",
               stickyRequired: true,
+              isFirstRunRequired: false,
             },
             {
               label: "Toaster thing",
@@ -210,6 +219,7 @@ describe("FormAudience", () => {
               applicationValues: ["TOASTER"],
               description: "Toaster thing description",
               stickyRequired: false,
+              isFirstRunRequired: false,
             },
           ],
         }}
@@ -245,6 +255,7 @@ describe("FormAudience", () => {
               applicationValues: [NimbusExperimentApplicationEnum.DESKTOP],
               description: "Win Only configuration",
               stickyRequired: true,
+              isFirstRunRequired: false,
             },
           ],
           isSticky: true,
@@ -261,6 +272,7 @@ describe("FormAudience", () => {
               ],
               description: "No Targeting configuration",
               stickyRequired: false,
+              isFirstRunRequired: false,
             },
             {
               label: "Win Only",
@@ -268,6 +280,7 @@ describe("FormAudience", () => {
               applicationValues: [NimbusExperimentApplicationEnum.DESKTOP],
               description: "Win Only configuration",
               stickyRequired: true,
+              isFirstRunRequired: false,
             },
             {
               label: "Toaster thing",
@@ -275,6 +288,7 @@ describe("FormAudience", () => {
               applicationValues: ["TOASTER"],
               description: "Toaster thing description",
               stickyRequired: false,
+              isFirstRunRequired: false,
             },
           ],
         }}
@@ -322,6 +336,7 @@ describe("FormAudience", () => {
               ],
               description: "No Targeting configuration",
               stickyRequired: false,
+              isFirstRunRequired: false,
             },
             {
               label: "Mac Only",
@@ -329,6 +344,7 @@ describe("FormAudience", () => {
               applicationValues: [NimbusExperimentApplicationEnum.DESKTOP],
               description: "Mac Only configuration",
               stickyRequired: true,
+              isFirstRunRequired: false,
             },
             {
               label: "Toaster thing",
@@ -336,6 +352,7 @@ describe("FormAudience", () => {
               applicationValues: ["TOASTER"],
               description: "Toaster thing description",
               stickyRequired: false,
+              isFirstRunRequired: false,
             },
           ],
         }}
@@ -380,6 +397,7 @@ describe("FormAudience", () => {
               ],
               description: "No Targeting configuration",
               stickyRequired: false,
+              isFirstRunRequired: false,
             },
             {
               label: "Mac Only",
@@ -387,6 +405,7 @@ describe("FormAudience", () => {
               applicationValues: [NimbusExperimentApplicationEnum.DESKTOP],
               description: "Mac Only configuration",
               stickyRequired: true,
+              isFirstRunRequired: false,
             },
             {
               label: "Toaster thing",
@@ -394,6 +413,7 @@ describe("FormAudience", () => {
               applicationValues: ["TOASTER"],
               description: "Toaster thing description",
               stickyRequired: false,
+              isFirstRunRequired: false,
             },
           ],
         }}
@@ -413,6 +433,151 @@ describe("FormAudience", () => {
       fireEvent.click(submitandContinueButton);
     });
     expect(screen.getByTestId("isSticky")).toBeChecked();
+  });
+
+  it("expect first run to be selected as first run is required for the selected targeting", async () => {
+    render(
+      <Subject
+        experiment={{
+          ...MOCK_EXPERIMENT,
+          application: NimbusExperimentApplicationEnum.DESKTOP,
+          channel: NimbusExperimentChannelEnum.NIGHTLY,
+          targetingConfigSlug: "WIN_ONLY",
+          targetingConfig: [
+            {
+              label: "Win Only",
+              value: "WIN_ONLY",
+              applicationValues: [NimbusExperimentApplicationEnum.DESKTOP],
+              description: "Win Only configuration",
+              stickyRequired: true,
+              isFirstRunRequired: true,
+            },
+          ],
+          isSticky: true,
+          isFirstRun: true,
+        }}
+        config={{
+          ...MOCK_CONFIG,
+          targetingConfigs: [
+            {
+              label: "No Targeting",
+              value: "",
+              applicationValues: [
+                NimbusExperimentApplicationEnum.DESKTOP,
+                "TOASTER",
+              ],
+              description: "No Targeting configuration",
+              stickyRequired: false,
+              isFirstRunRequired: false,
+            },
+            {
+              label: "Win Only",
+              value: "WIN_ONLY",
+              applicationValues: [NimbusExperimentApplicationEnum.DESKTOP],
+              description: "Win Only configuration",
+              stickyRequired: true,
+              isFirstRunRequired: true,
+            },
+            {
+              label: "Toaster thing",
+              value: "TOASTER_THING",
+              applicationValues: ["TOASTER"],
+              description: "Toaster thing description",
+              stickyRequired: false,
+              isFirstRunRequired: false,
+            },
+          ],
+        }}
+      />,
+    );
+
+    const targetingConfigSlug = (await screen.findByTestId(
+      "targetingConfigSlug",
+    )) as HTMLSelectElement;
+
+    expect(targetingConfigSlug.value).toEqual(
+      MOCK_CONFIG!.targetingConfigs![1]!.value,
+    );
+    expect(screen.getByTestId("isFirstRun")).toHaveProperty("checked", true);
+    expect(screen.getByTestId("isFirstRun")).toBeDisabled();
+    await expect(
+      screen.getByTestId("is-first-run-required-warning"),
+    ).toBeInTheDocument();
+  });
+
+  it("expect sticky enrollment to be optional as changing targeting from sticky required to sticky not required", async () => {
+    render(
+      <Subject
+        experiment={{
+          ...MOCK_EXPERIMENT,
+          application: NimbusExperimentApplicationEnum.DESKTOP,
+          channel: NimbusExperimentChannelEnum.NIGHTLY,
+          targetingConfigSlug: "WIN_ONLY",
+          targetingConfig: [
+            {
+              label: "Win Only",
+              value: "WIN_ONLY",
+              applicationValues: [NimbusExperimentApplicationEnum.DESKTOP],
+              description: "Win Only configuration",
+              stickyRequired: true,
+              isFirstRunRequired: true,
+            },
+          ],
+          isSticky: true,
+          isFirstRun: true,
+        }}
+        config={{
+          ...MOCK_CONFIG,
+          targetingConfigs: [
+            {
+              label: "No Targeting",
+              value: "",
+              applicationValues: [
+                NimbusExperimentApplicationEnum.DESKTOP,
+                "TOASTER",
+              ],
+              description: "No Targeting configuration",
+              stickyRequired: false,
+              isFirstRunRequired: false,
+            },
+            {
+              label: "Win Only",
+              value: "WIN_ONLY",
+              applicationValues: [NimbusExperimentApplicationEnum.DESKTOP],
+              description: "Win Only configuration",
+              stickyRequired: true,
+              isFirstRunRequired: true,
+            },
+            {
+              label: "Toaster thing",
+              value: "TOASTER_THING",
+              applicationValues: ["TOASTER"],
+              description: "Toaster thing description",
+              stickyRequired: false,
+              isFirstRunRequired: false,
+            },
+          ],
+        }}
+      />,
+    );
+    const targetingConfigSlug = (await screen.findByTestId(
+      "targetingConfigSlug",
+    )) as HTMLSelectElement;
+
+    expect(targetingConfigSlug.value).toEqual(
+      MOCK_CONFIG!.targetingConfigs![1]!.value,
+    );
+    fireEvent.change(screen.getByTestId("targetingConfigSlug"), {
+      target: { value: MOCK_CONFIG!.targetingConfigs![0]!.value },
+    });
+    fireEvent.click(screen.getByTestId("isFirstRun"), {
+      target: { checked: false },
+    });
+    expect(screen.getByTestId("isFirstRun")).toHaveProperty("checked", true);
+    expect(screen.getByTestId("isFirstRun")).not.toBeDisabled();
+    await expect(
+      screen.queryByTestId("is-first-run-required-warning"),
+    ).not.toBeInTheDocument();
   });
 
   it("expect First Run to be  unchecked", async () => {
@@ -734,6 +899,7 @@ describe("filterAndSortTargetingConfigSlug", () => {
         applicationValues: [application, NimbusExperimentApplicationEnum.IOS],
         description: "",
         stickyRequired: false,
+        isFirstRunRequired: false,
       },
       {
         label: expectedLastLabel,
@@ -741,6 +907,7 @@ describe("filterAndSortTargetingConfigSlug", () => {
         applicationValues: [application],
         description: "",
         stickyRequired: false,
+        isFirstRunRequired: false,
       },
       {
         label: expectedLabel,
@@ -748,6 +915,7 @@ describe("filterAndSortTargetingConfigSlug", () => {
         applicationValues: [application],
         description: "",
         stickyRequired: false,
+        isFirstRunRequired: false,
       },
       {
         label: expectedMissingLabel,
@@ -755,6 +923,7 @@ describe("filterAndSortTargetingConfigSlug", () => {
         applicationValues: [NimbusExperimentApplicationEnum.IOS],
         description: "",
         stickyRequired: false,
+        isFirstRunRequired: false,
       },
     ];
     const result = filterAndSortTargetingConfigs(
@@ -791,6 +960,7 @@ const renderSubjectWithDefaultValues = (onSubmit = () => {}) =>
             ],
             description: "No targeting configuration",
             stickyRequired: false,
+            isFirstRunRequired: false,
           },
           {
             label: "Mac Only",
@@ -798,6 +968,7 @@ const renderSubjectWithDefaultValues = (onSubmit = () => {}) =>
             applicationValues: [NimbusExperimentApplicationEnum.DESKTOP],
             description: "Mac only configuration",
             stickyRequired: true,
+            isFirstRunRequired: false,
           },
           {
             label: "Some toaster thing",
@@ -805,6 +976,7 @@ const renderSubjectWithDefaultValues = (onSubmit = () => {}) =>
             applicationValues: ["TOASTER"],
             description: "Some toaster thing configuration",
             stickyRequired: false,
+            isFirstRunRequired: false,
           },
         ],
         firefoxVersions: [

--- a/app/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/index.tsx
@@ -87,10 +87,16 @@ export const FormAudience = ({
     experiment.isSticky ?? false,
   );
 
-  const [isFirstRun, setIsFirstRun] = useState<boolean>(experiment.isFirstRun);
+  const [isFirstRun, setIsFirstRun] = useState<boolean>(
+    experiment.isFirstRun ?? false,
+  );
   const [stickyRequiredWarning, setStickyRequiredWarning] = useState<boolean>(
     experiment.targetingConfig![0]?.stickyRequired ?? false,
   );
+  const [isFirstRunRequiredWarning, setisFirstRunRequiredRequiredWarning] =
+    useState<boolean>(
+      experiment.targetingConfig![0]?.isFirstRunRequired ?? false,
+    );
 
   const applicationConfig = config.applicationConfigs?.find(
     (applicationConfig) =>
@@ -171,11 +177,15 @@ export const FormAudience = ({
   );
 
   const TargetingOnChange = (ev: React.ChangeEvent<HTMLInputElement>) => {
-    const checkStickyRequired = targetingConfigSlugOptions.find(
+    const checkRequired = targetingConfigSlugOptions.find(
       (config) => config.value === ev.target.value,
     );
-    setIsSticky(checkStickyRequired?.stickyRequired || false);
-    setStickyRequiredWarning(!!checkStickyRequired?.stickyRequired);
+    setIsSticky(checkRequired?.stickyRequired || false);
+    setStickyRequiredWarning(!!checkRequired?.stickyRequired);
+    setIsFirstRun(
+      checkRequired?.isFirstRunRequired || experiment.isFirstRun || false,
+    );
+    setisFirstRunRequiredRequiredWarning(!!checkRequired?.isFirstRunRequired);
   };
 
   const isDesktop =
@@ -307,8 +317,17 @@ export const FormAudience = ({
               type="checkbox"
               onChange={(e) => setIsFirstRun(e.target.checked)}
               checked={isFirstRun}
+              disabled={isFirstRunRequiredWarning}
               label="First Run Experiment"
             />
+            {isFirstRunRequiredWarning && (
+              <Alert
+                data-testid="is-first-run-required-warning"
+                variant="warning"
+              >
+                First run is required for this targeting configuration.
+              </Alert>
+            )}
             <FormErrors name="isFirstRun" />
           </Form.Group>
         </Form.Row>

--- a/app/experimenter/nimbus-ui/src/gql/config.ts
+++ b/app/experimenter/nimbus-ui/src/gql/config.ts
@@ -60,6 +60,7 @@ export const GET_CONFIG_QUERY = gql`
         description
         applicationValues
         stickyRequired
+        isFirstRunRequired
       }
       hypothesisDefault
       documentationLink {

--- a/app/experimenter/nimbus-ui/src/gql/experiments.ts
+++ b/app/experimenter/nimbus-ui/src/gql/experiments.ts
@@ -111,6 +111,7 @@ export const GET_EXPERIMENT_QUERY = gql`
         applicationValues
         description
         stickyRequired
+        isFirstRunRequired
       }
       isSticky
       isFirstRun

--- a/app/experimenter/nimbus-ui/src/lib/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/lib/mocks.tsx
@@ -306,6 +306,7 @@ export const MOCK_CONFIG: getConfig_nimbusConfig = {
       applicationValues: ["DESKTOP"],
       description: "Mac only configuration",
       stickyRequired: false,
+      isFirstRunRequired: false,
     },
     {
       label: "Win Only",
@@ -313,6 +314,7 @@ export const MOCK_CONFIG: getConfig_nimbusConfig = {
       applicationValues: ["DESKTOP"],
       description: "Win only configuration",
       stickyRequired: true,
+      isFirstRunRequired: false,
     },
   ],
   hypothesisDefault: "Enter a hypothesis",

--- a/app/experimenter/nimbus-ui/src/lib/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/lib/mocks.tsx
@@ -690,7 +690,7 @@ export function mockSingleDirectoryExperiment(
     name: "Open-architected background installation",
     status: NimbusExperimentStatusEnum.COMPLETE,
     statusNext: null,
-    populationPercent: 100.0,
+    populationPercent: "100.0",
     channel: NimbusExperimentChannelEnum.NIGHTLY,
     publishStatus: NimbusExperimentPublishStatusEnum.IDLE,
     featureConfig: MOCK_CONFIG.allFeatureConfigs![0],

--- a/app/experimenter/nimbus-ui/src/types/getAllExperiments.ts
+++ b/app/experimenter/nimbus-ui/src/types/getAllExperiments.ts
@@ -3,7 +3,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import { NimbusExperimentApplicationEnum, NimbusExperimentFirefoxVersionEnum, NimbusExperimentStatusEnum, NimbusExperimentPublishStatusEnum } from "./globalTypes";
+import { NimbusExperimentApplicationEnum, NimbusExperimentFirefoxVersionEnum, NimbusExperimentStatusEnum, NimbusExperimentPublishStatusEnum, NimbusExperimentChannelEnum } from "./globalTypes";
 
 // ====================================================
 // GraphQL query operation: getAllExperiments
@@ -51,7 +51,7 @@ export interface getAllExperiments_experiments {
   rolloutMonitoringDashboardUrl: string | null;
   resultsReady: boolean | null;
   featureConfig: getAllExperiments_experiments_featureConfig | null;
-  channel: string | null;
+  channel: NimbusExperimentChannelEnum | null;
   populationPercent: number | null;
 }
 

--- a/app/experimenter/nimbus-ui/src/types/getAllExperiments.ts
+++ b/app/experimenter/nimbus-ui/src/types/getAllExperiments.ts
@@ -52,7 +52,7 @@ export interface getAllExperiments_experiments {
   resultsReady: boolean | null;
   featureConfig: getAllExperiments_experiments_featureConfig | null;
   channel: NimbusExperimentChannelEnum | null;
-  populationPercent: number | null;
+  populationPercent: string | null;
 }
 
 export interface getAllExperiments {

--- a/app/experimenter/nimbus-ui/src/types/getConfig.ts
+++ b/app/experimenter/nimbus-ui/src/types/getConfig.ts
@@ -74,6 +74,7 @@ export interface getConfig_nimbusConfig_targetingConfigs {
   description: string | null;
   applicationValues: (string | null)[] | null;
   stickyRequired: boolean | null;
+  isFirstRunRequired: boolean | null;
 }
 
 export interface getConfig_nimbusConfig_documentationLink {

--- a/app/experimenter/nimbus-ui/src/types/getExperiment.ts
+++ b/app/experimenter/nimbus-ui/src/types/getExperiment.ts
@@ -68,6 +68,7 @@ export interface getExperiment_experimentBySlug_targetingConfig {
   applicationValues: (string | null)[] | null;
   description: string | null;
   stickyRequired: boolean | null;
+  isFirstRunRequired: boolean | null;
 }
 
 export interface getExperiment_experimentBySlug_readyForReview {

--- a/app/experimenter/targeting/constants.py
+++ b/app/experimenter/targeting/constants.py
@@ -13,6 +13,7 @@ class NimbusTargetingConfig:
     targeting: str
     desktop_telemetry: str
     sticky_required: bool
+    is_first_run_required: bool
     application_choice_names: list[str]
 
     targeting_configs = []
@@ -33,6 +34,7 @@ NO_TARGETING = NimbusTargetingConfig(
     targeting="",
     desktop_telemetry="",
     sticky_required=False,
+    is_first_run_required=False,
     application_choice_names=[a.name for a in Application],
 )
 
@@ -46,6 +48,7 @@ FIRST_RUN = NimbusTargetingConfig(
     ),
     desktop_telemetry=("payload.info.profile_subsession_counter = 1"),
     sticky_required=True,
+    is_first_run_required=False,
     application_choice_names=(Application.DESKTOP.name,),
 )
 
@@ -63,6 +66,7 @@ FIRST_RUN_CHROME_ATTRIBUTION = NimbusTargetingConfig(
         "{first_run} AND environment.settings.attribution.ua = 'chrome'"
     ).format(first_run=FIRST_RUN.desktop_telemetry),
     sticky_required=True,
+    is_first_run_required=False,
     application_choice_names=(Application.DESKTOP.name,),
 )
 
@@ -77,6 +81,7 @@ FIRST_RUN_WINDOWS_1903_NEWER = NimbusTargetingConfig(
         "{first_run} AND environment.system.os.windows_build_number >= 18362"
     ).format(first_run=FIRST_RUN.desktop_telemetry),
     sticky_required=True,
+    is_first_run_required=False,
     application_choice_names=(Application.DESKTOP.name,),
 )
 
@@ -91,6 +96,7 @@ NOT_TCP_STUDY = NimbusTargetingConfig(
     ),
     desktop_telemetry="",
     sticky_required=False,
+    is_first_run_required=False,
     application_choice_names=(Application.DESKTOP.name,),
 )
 
@@ -104,6 +110,7 @@ NOT_TCP_STUDY_FIRST_RUN = NimbusTargetingConfig(
     ),
     desktop_telemetry="",
     sticky_required=True,
+    is_first_run_required=False,
     application_choice_names=(Application.DESKTOP.name,),
 )
 
@@ -116,6 +123,7 @@ WINDOWS_WITH_USERCHOICE = NimbusTargetingConfig(
     targeting="os.windowsBuildNumber >= 17763",
     desktop_telemetry="environment.system.os.windows_build_number >= 17763",
     sticky_required=False,
+    is_first_run_required=False,
     application_choice_names=(Application.DESKTOP.name,),
 )
 
@@ -135,6 +143,7 @@ WINDOWS_WITH_USERCHOICE_FIRST_RUN = NimbusTargetingConfig(
         user_choice=WINDOWS_WITH_USERCHOICE.desktop_telemetry,
     ),
     sticky_required=True,
+    is_first_run_required=False,
     application_choice_names=(Application.DESKTOP.name,),
 )
 
@@ -147,6 +156,7 @@ FX95_DESKTOP_USERS = NimbusTargetingConfig(
     ),
     desktop_telemetry="",
     sticky_required=False,
+    is_first_run_required=False,
     application_choice_names=(Application.DESKTOP.name,),
 )
 
@@ -157,6 +167,7 @@ MOBILE_NEW_USER = NimbusTargetingConfig(
     targeting="days_since_install < 7",
     desktop_telemetry="",
     sticky_required=True,
+    is_first_run_required=False,
     application_choice_names=(
         Application.FENIX.name,
         Application.IOS.name,
@@ -177,6 +188,7 @@ MOBILE_RECENTLY_UPDATED = NimbusTargetingConfig(
     targeting="days_since_update < 7 && days_since_install >= 7",
     desktop_telemetry="",
     sticky_required=True,
+    is_first_run_required=False,
     application_choice_names=(
         Application.FENIX.name,
         Application.IOS.name,
@@ -199,6 +211,7 @@ HOMEPAGE_GOOGLE = NimbusTargetingConfig(
     ),
     desktop_telemetry="",
     sticky_required=False,
+    is_first_run_required=False,
     application_choice_names=(Application.DESKTOP.name,),
 )
 
@@ -209,6 +222,7 @@ URLBAR_FIREFOX_SUGGEST = NimbusTargetingConfig(
     targeting="'browser.urlbar.showSearchSuggestionsFirst'|preferenceValue",
     desktop_telemetry="",
     sticky_required=False,
+    is_first_run_required=False,
     application_choice_names=(Application.DESKTOP.name,),
 )
 
@@ -219,6 +233,7 @@ MAC_ONLY = NimbusTargetingConfig(
     targeting="os.isMac",
     desktop_telemetry="environment.system.os.name = 'Darwin'",
     sticky_required=False,
+    is_first_run_required=False,
     application_choice_names=(Application.DESKTOP.name,),
 )
 
@@ -229,6 +244,7 @@ NO_ENTERPRISE = NimbusTargetingConfig(
     targeting="!hasActiveEnterprisePolicies",
     desktop_telemetry="",
     sticky_required=False,
+    is_first_run_required=False,
     application_choice_names=(Application.DESKTOP.name,),
 )
 
@@ -242,6 +258,7 @@ NO_ENTERPRISE_OR_PAST_VPN = NimbusTargetingConfig(
     ),
     desktop_telemetry="",
     sticky_required=False,
+    is_first_run_required=False,
     application_choice_names=(Application.DESKTOP.name,),
 )
 
@@ -257,6 +274,7 @@ NO_ENTERPRISE_OR_RECENT_VPN = NimbusTargetingConfig(
     ),
     desktop_telemetry="",
     sticky_required=False,
+    is_first_run_required=False,
     application_choice_names=(Application.DESKTOP.name,),
 )
 
@@ -271,6 +289,7 @@ INFREQUENT_USER_URIS = NimbusTargetingConfig(
     ),
     desktop_telemetry="",
     sticky_required=True,
+    is_first_run_required=False,
     application_choice_names=(Application.DESKTOP.name,),
 )
 
@@ -281,6 +300,7 @@ INFREQUENT_USER_NEED_PIN = NimbusTargetingConfig(
     targeting=f"{INFREQUENT_USER_URIS.targeting} && doesAppNeedPin",
     desktop_telemetry="",
     sticky_required=True,
+    is_first_run_required=False,
     application_choice_names=(Application.DESKTOP.name,),
 )
 
@@ -291,6 +311,7 @@ INFREQUENT_USER_NEED_DEFAULT = NimbusTargetingConfig(
     targeting=f"{INFREQUENT_USER_URIS.targeting} && {NEED_DEFAULT}",
     desktop_telemetry="",
     sticky_required=True,
+    is_first_run_required=False,
     application_choice_names=(Application.DESKTOP.name,),
 )
 
@@ -301,6 +322,7 @@ INFREQUENT_USER_NEED_DEFAULT_HAS_PIN = NimbusTargetingConfig(
     targeting=f"{INFREQUENT_USER_NEED_DEFAULT.targeting} && {HAS_PIN}",
     desktop_telemetry="",
     sticky_required=True,
+    is_first_run_required=False,
     application_choice_names=(Application.DESKTOP.name,),
 )
 
@@ -311,6 +333,7 @@ INFREQUENT_USER_HAS_DEFAULT_NEED_PIN = NimbusTargetingConfig(
     targeting=f"{INFREQUENT_USER_NEED_PIN.targeting} && isDefaultBrowser",
     desktop_telemetry="",
     sticky_required=True,
+    is_first_run_required=False,
     application_choice_names=(Application.DESKTOP.name,),
 )
 
@@ -321,6 +344,7 @@ INFREQUENT_WIN_USER_NEED_PIN = NimbusTargetingConfig(
     targeting=f"{INFREQUENT_USER_NEED_PIN.targeting} && os.isWindows",
     desktop_telemetry="",
     sticky_required=True,
+    is_first_run_required=False,
     application_choice_names=(Application.DESKTOP.name,),
 )
 
@@ -331,6 +355,7 @@ INFREQUENT_WIN_USER_URIS = NimbusTargetingConfig(
     targeting=f"{INFREQUENT_USER_NEED_DEFAULT.targeting} && {WIN1903}",
     desktop_telemetry="",
     sticky_required=True,
+    is_first_run_required=False,
     application_choice_names=(Application.DESKTOP.name,),
 )
 
@@ -344,6 +369,7 @@ INFREQUENT_USER_FIVE_BOOKMARKS = NimbusTargetingConfig(
     targeting=f"{INFREQUENT_USER_URIS.targeting} && totalBookmarksCount == 5",
     desktop_telemetry="",
     sticky_required=True,
+    is_first_run_required=False,
     application_choice_names=(Application.DESKTOP.name,),
 )
 
@@ -358,6 +384,7 @@ CASUAL_USER_URIS = NimbusTargetingConfig(
     ),
     desktop_telemetry="",
     sticky_required=True,
+    is_first_run_required=False,
     application_choice_names=(Application.DESKTOP.name,),
 )
 
@@ -368,6 +395,7 @@ CASUAL_USER_NEED_PIN = NimbusTargetingConfig(
     targeting=f"{CASUAL_USER_URIS.targeting} && doesAppNeedPin",
     desktop_telemetry="",
     sticky_required=True,
+    is_first_run_required=False,
     application_choice_names=(Application.DESKTOP.name,),
 )
 
@@ -378,6 +406,7 @@ CASUAL_USER_NEED_DEFAULT = NimbusTargetingConfig(
     targeting=f"{CASUAL_USER_URIS.targeting} && {NEED_DEFAULT}",
     desktop_telemetry="",
     sticky_required=True,
+    is_first_run_required=False,
     application_choice_names=(Application.DESKTOP.name,),
 )
 
@@ -388,6 +417,7 @@ CASUAL_USER_NEED_DEFAULT_HAS_PIN = NimbusTargetingConfig(
     targeting=f"{CASUAL_USER_NEED_DEFAULT.targeting} && {HAS_PIN}",
     desktop_telemetry="",
     sticky_required=True,
+    is_first_run_required=False,
     application_choice_names=(Application.DESKTOP.name,),
 )
 
@@ -398,6 +428,7 @@ CASUAL_USER_HAS_DEFAULT_NEED_PIN = NimbusTargetingConfig(
     targeting=f"{CASUAL_USER_NEED_PIN.targeting} && isDefaultBrowser",
     desktop_telemetry="",
     sticky_required=True,
+    is_first_run_required=False,
     application_choice_names=(Application.DESKTOP.name,),
 )
 
@@ -412,6 +443,7 @@ REGULAR_USER_URIS = NimbusTargetingConfig(
     ),
     desktop_telemetry="",
     sticky_required=True,
+    is_first_run_required=False,
     application_choice_names=(Application.DESKTOP.name,),
 )
 
@@ -422,6 +454,7 @@ REGULAR_USER_NEED_PIN = NimbusTargetingConfig(
     targeting=f"{REGULAR_USER_URIS.targeting} && doesAppNeedPin",
     desktop_telemetry="",
     sticky_required=True,
+    is_first_run_required=False,
     application_choice_names=(Application.DESKTOP.name,),
 )
 
@@ -432,6 +465,7 @@ REGULAR_USER_NEED_DEFAULT = NimbusTargetingConfig(
     targeting=f"{REGULAR_USER_URIS.targeting} && {NEED_DEFAULT}",
     desktop_telemetry="",
     sticky_required=True,
+    is_first_run_required=False,
     application_choice_names=(Application.DESKTOP.name,),
 )
 
@@ -442,6 +476,7 @@ REGULAR_USER_NEED_DEFAULT_HAS_PIN = NimbusTargetingConfig(
     targeting=f"{REGULAR_USER_NEED_DEFAULT.targeting} && {HAS_PIN}",
     desktop_telemetry="",
     sticky_required=True,
+    is_first_run_required=False,
     application_choice_names=(Application.DESKTOP.name,),
 )
 
@@ -452,6 +487,7 @@ REGULAR_USER_HAS_DEFAULT_NEED_PIN = NimbusTargetingConfig(
     targeting=f"{REGULAR_USER_NEED_PIN.targeting} && isDefaultBrowser",
     desktop_telemetry="",
     sticky_required=True,
+    is_first_run_required=False,
     application_choice_names=(Application.DESKTOP.name,),
 )
 
@@ -462,6 +498,7 @@ REGULAR_USER_USES_FXA = NimbusTargetingConfig(
     targeting=f"{REGULAR_USER_URIS.targeting} && isFxAEnabled && usesFirefoxSync",
     desktop_telemetry="",
     sticky_required=True,
+    is_first_run_required=False,
     application_choice_names=(Application.DESKTOP.name,),
 )
 
@@ -472,6 +509,7 @@ CORE_USER_URIS = NimbusTargetingConfig(
     targeting=f"{PROFILE28DAYS} && userMonthlyActivity|length >= 21",
     desktop_telemetry="",
     sticky_required=True,
+    is_first_run_required=False,
     application_choice_names=(Application.DESKTOP.name,),
 )
 
@@ -482,6 +520,7 @@ CORE_USER_NEED_PIN = NimbusTargetingConfig(
     targeting=f"{CORE_USER_URIS.targeting} && doesAppNeedPin",
     desktop_telemetry="",
     sticky_required=False,
+    is_first_run_required=False,
     application_choice_names=(Application.DESKTOP.name,),
 )
 
@@ -492,6 +531,7 @@ CORE_USER_NEED_DEFAULT = NimbusTargetingConfig(
     targeting=f"{CORE_USER_URIS.targeting} && {NEED_DEFAULT}",
     desktop_telemetry="",
     sticky_required=False,
+    is_first_run_required=False,
     application_choice_names=(Application.DESKTOP.name,),
 )
 
@@ -502,6 +542,7 @@ CORE_USER_NEED_DEFAULT_HAS_PIN = NimbusTargetingConfig(
     targeting=f"{CORE_USER_NEED_DEFAULT.targeting} && {HAS_PIN}",
     desktop_telemetry="",
     sticky_required=False,
+    is_first_run_required=False,
     application_choice_names=(Application.DESKTOP.name,),
 )
 
@@ -512,6 +553,7 @@ CORE_USER_HAS_DEFAULT_NEED_PIN = NimbusTargetingConfig(
     targeting=f"{CORE_USER_NEED_PIN.targeting} && isDefaultBrowser",
     desktop_telemetry="",
     sticky_required=False,
+    is_first_run_required=False,
     application_choice_names=(Application.DESKTOP.name,),
 )
 
@@ -540,6 +582,7 @@ POCKET_COMMON = NimbusTargetingConfig(
     """,
     desktop_telemetry="",
     sticky_required=False,
+    is_first_run_required=False,
     application_choice_names=(Application.DESKTOP.name,),
 )
 
@@ -558,6 +601,7 @@ PIP_NEVER_USED = NimbusTargetingConfig(
     """,
     desktop_telemetry="",
     sticky_required=True,
+    is_first_run_required=False,
     application_choice_names=(Application.DESKTOP.name,),
 )
 
@@ -569,6 +613,7 @@ RALLY_CORE_ADDON_USER = NimbusTargetingConfig(
     targeting="addonsInfo.addons['rally-core@mozilla.org'] != null",
     desktop_telemetry="",
     sticky_required=False,
+    is_first_run_required=False,
     application_choice_names=(Application.DESKTOP.name,),
 )
 


### PR DESCRIPTION
Because

* We want to support first run experiments and auto enable based on targeting selected

This commit

* Add another property to the Targeting Configs called` is_first_run_required` that if it is true, we force to set the Is First Run checkbox on the audience page
* Test cases to verify changes

fix #7712 

Screenshot for new changes (temporary enabled first run required for the targeting)
![image](https://user-images.githubusercontent.com/104033388/189421983-55b77fdc-f299-4129-82ee-1d828eaf8195.png)
