### PR TITLE
fix #7739 bug(nimbus): filter related entities (screenshots, documentation links) by parent

### DIFF
--- a/app/experimenter/experiments/api/v5/types.py
+++ b/app/experimenter/experiments/api/v5/types.py
@@ -2,7 +2,6 @@ import json
 
 import graphene
 from django.contrib.auth import get_user_model
-from graphene_django import DjangoListField
 from graphene_django.types import DjangoObjectType
 
 from experimenter.base.models import Country, Language, Locale
@@ -174,7 +173,7 @@ class NimbusBranchType(DjangoObjectType):
     featureEnabled = graphene.Boolean(required=True)
     featureValue = graphene.String(required=False)
     featureValues = graphene.List(NimbusBranchFeatureValueType)
-    screenshots = DjangoListField(NimbusBranchScreenshotType)
+    screenshots = graphene.List(NimbusBranchScreenshotType)
 
     class Meta:
         model = NimbusBranch
@@ -203,6 +202,9 @@ class NimbusBranchType(DjangoObjectType):
             root.feature_values.exists()
             and root.feature_values.all().order_by("feature_config__slug").first().value
         ) or ""
+
+    def resolve_screenshots(root, info):
+        return root.screenshots.all()
 
 
 class NimbusDocumentationLinkType(DjangoObjectType):
@@ -410,9 +412,7 @@ class NimbusExperimentType(DjangoObjectType):
     firefoxMaxVersion = NimbusExperimentFirefoxVersionEnum(source="firefox_min_version")
     populationPercent = graphene.String(source="population_percent")
     channel = NimbusExperimentChannelEnum()
-    documentationLinks = DjangoListField(
-        NimbusDocumentationLinkType, source="documentation_links"
-    )
+    documentationLinks = graphene.List(NimbusDocumentationLinkType)
     referenceBranch = graphene.Field(NimbusBranchType)
     treatmentBranches = graphene.List(NimbusBranchType)
     targetingConfigSlug = graphene.String()
@@ -601,3 +601,6 @@ class NimbusExperimentType(DjangoObjectType):
             indent=2,
             sort_keys=True,
         )
+
+    def resolve_documentationLinks(self, info):
+        return self.documentation_links.all()

--- a/app/experimenter/nimbus-ui/schema.graphql
+++ b/app/experimenter/nimbus-ui/schema.graphql
@@ -108,7 +108,7 @@ type NimbusBranchType {
   slug: String!
   description: String!
   ratio: Int!
-  screenshots: [NimbusBranchScreenshotType!]
+  screenshots: [NimbusBranchScreenshotType]
   id: Int
   featureEnabled: Boolean!
   featureValue: String
@@ -368,7 +368,7 @@ type NimbusExperimentType {
   firefoxMinVersion: NimbusExperimentFirefoxVersionEnum
   firefoxMaxVersion: NimbusExperimentFirefoxVersionEnum
   populationPercent: String
-  documentationLinks: [NimbusDocumentationLinkType!]
+  documentationLinks: [NimbusDocumentationLinkType]
   referenceBranch: NimbusBranchType
   treatmentBranches: [NimbusBranchType]
   targetingConfigSlug: String

--- a/app/experimenter/nimbus-ui/src/components/FormOverview/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/FormOverview/index.test.tsx
@@ -48,7 +48,7 @@ describe("FormOverview", () => {
         "option[selected]",
       ) as HTMLSelectElement;
       expect(selected.value).toEqual(
-        experiment.documentationLinks![index].title,
+        experiment.documentationLinks![index]!.title,
       );
     });
   });
@@ -259,7 +259,9 @@ describe("FormOverview", () => {
     const addButton = screen.getByText("+ Add Link");
 
     // Assert that the initial documentation link sets are rendered
-    experiment.documentationLinks!.map(assertDocumentationLinkFields);
+    experiment.documentationLinks!.map((documentationLink, index) =>
+      assertDocumentationLinkFields(documentationLink!, index),
+    );
 
     // The first remove button should not be present
     expect(getDocumentationLinkFields(0).removeButton).toBeNull();
@@ -290,7 +292,7 @@ describe("FormOverview", () => {
       title: NimbusDocumentationLinkTitle.DESIGN_DOC,
       link: "https://boingo.oingo",
     });
-    fillDocumentationLinkFields(experiment.documentationLinks![1], 1);
+    fillDocumentationLinkFields(experiment.documentationLinks![1]!, 1);
 
     // Add a new set and PARTIALLY populate it
     // This set should be filtered out and therefore will
@@ -306,7 +308,7 @@ describe("FormOverview", () => {
 
     // Add a new set, and populate it with the data from the second field
     fireEvent.click(addButton);
-    fillDocumentationLinkFields(experiment.documentationLinks![1], 3);
+    fillDocumentationLinkFields(experiment.documentationLinks![1]!, 3);
 
     // Now delete the second set
     fireEvent.click(getDocumentationLinkFields(1).removeButton);
@@ -322,10 +324,7 @@ describe("FormOverview", () => {
 
     await waitFor(() =>
       expect(onSubmit.mock.calls[0][0].documentationLinks).toEqual(
-        experiment.documentationLinks!.map(({ title, link }) => ({
-          title,
-          link,
-        })),
+        experiment.documentationLinks!,
       ),
     );
   });

--- a/app/experimenter/nimbus-ui/src/components/SidebarActions/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/SidebarActions/index.tsx
@@ -120,7 +120,7 @@ export const SidebarActions = ({
           documentationLinks?.length > 0 &&
           documentationLinks.map((documentationLink, idx) => (
             <LinkExternal
-              href={documentationLink.link}
+              href={documentationLink!.link}
               data-testid="experiment-additional-link"
               key={`doc-link-${idx}`}
               className="mx-1 my-2 nav-item d-block text-dark w-100 font-weight-normal"
@@ -128,7 +128,7 @@ export const SidebarActions = ({
               <ExternalIcon className="sidebar-icon-external-link" />
               {
                 configDocumentationLinks!.find(
-                  (d) => d?.value === documentationLink.title,
+                  (d) => d?.value === documentationLink!.title,
                 )?.label
               }
             </LinkExternal>

--- a/app/experimenter/nimbus-ui/src/components/Summary/TableBranches/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/TableBranches/index.tsx
@@ -155,12 +155,12 @@ const TableBranch = ({
                   className="d-block"
                   key={idx}
                 >
-                  <Figure.Caption>{screenshot.description}</Figure.Caption>
-                  {screenshot.image ? (
+                  <Figure.Caption>{screenshot!.description}</Figure.Caption>
+                  {screenshot!.image ? (
                     <Figure.Image
                       fluid
-                      src={screenshot.image}
-                      alt={screenshot.description || ""}
+                      src={screenshot!.image}
+                      alt={screenshot!.description || ""}
                     />
                   ) : (
                     <NotSet />

--- a/app/experimenter/nimbus-ui/src/types/getExperiment.ts
+++ b/app/experimenter/nimbus-ui/src/types/getExperiment.ts
@@ -32,7 +32,7 @@ export interface getExperiment_experimentBySlug_referenceBranch {
   ratio: number;
   featureValue: string | null;
   featureEnabled: boolean;
-  screenshots: getExperiment_experimentBySlug_referenceBranch_screenshots[] | null;
+  screenshots: (getExperiment_experimentBySlug_referenceBranch_screenshots | null)[] | null;
 }
 
 export interface getExperiment_experimentBySlug_treatmentBranches_screenshots {
@@ -49,7 +49,7 @@ export interface getExperiment_experimentBySlug_treatmentBranches {
   ratio: number;
   featureValue: string | null;
   featureEnabled: boolean;
-  screenshots: getExperiment_experimentBySlug_treatmentBranches_screenshots[] | null;
+  screenshots: (getExperiment_experimentBySlug_treatmentBranches_screenshots | null)[] | null;
 }
 
 export interface getExperiment_experimentBySlug_featureConfigs {
@@ -182,7 +182,7 @@ export interface getExperiment_experimentBySlug {
   riskBrand: boolean | null;
   riskPartnerRelated: boolean | null;
   signoffRecommendations: getExperiment_experimentBySlug_signoffRecommendations | null;
-  documentationLinks: getExperiment_experimentBySlug_documentationLinks[] | null;
+  documentationLinks: (getExperiment_experimentBySlug_documentationLinks | null)[] | null;
   isEnrollmentPausePending: boolean | null;
   isEnrollmentPaused: boolean | null;
   enrollmentEndDate: DateTime | null;


### PR DESCRIPTION


Because

* We are in the process of refactoring the graphql and rest apis
* This involves moving from implicitly converting snake_case to camelCase fields which requires explicitly mapping the serialized field back to its model field
* It seems that the DjangoListField that was being used falls back to returning all entities from a model rather than those that foreign key on to a parent
* The tests did not explicitly test against this so it was missed

This commit

* Changes from using the DjangoListField to resolve foreign keys to explicitly declaring a resolver that does
* Adds tests to ensure parent foreign keys are followed in related entities