### PR TITLE
fix #7750 chore(nimbus): add env var for printing more DOM during testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ ESLINT_FIX_NIMBUS_UI = yarn workspace @experimenter/nimbus-ui lint-fix
 TYPECHECK_NIMBUS_UI = yarn workspace @experimenter/nimbus-ui lint:tsc
 
 JS_TEST_LEGACY = yarn workspace @experimenter/core test
-JS_TEST_NIMBUS_UI = CI=yes yarn workspace @experimenter/nimbus-ui test:cov
+JS_TEST_NIMBUS_UI = DEBUG_PRINT_LIMIT=7000 CI=yes yarn workspace @experimenter/nimbus-ui test:cov
 NIMBUS_SCHEMA_CHECK = python manage.py graphql_schema --out experimenter/nimbus-ui/test_schema.graphql&&diff experimenter/nimbus-ui/test_schema.graphql experimenter/nimbus-ui/schema.graphql || (echo GraphQL Schema is out of sync please run make generate_types;exit 1)
 NIMBUS_TYPES_GENERATE = python manage.py graphql_schema --out experimenter/nimbus-ui/schema.graphql&&yarn workspace @experimenter/nimbus-ui generate-types
 FLAKE8 = flake8 .

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ ESLINT_FIX_NIMBUS_UI = yarn workspace @experimenter/nimbus-ui lint-fix
 TYPECHECK_NIMBUS_UI = yarn workspace @experimenter/nimbus-ui lint:tsc
 
 JS_TEST_LEGACY = yarn workspace @experimenter/core test
-JS_TEST_NIMBUS_UI = DEBUG_PRINT_LIMIT=7000 CI=yes yarn workspace @experimenter/nimbus-ui test:cov
+JS_TEST_NIMBUS_UI = DEBUG_PRINT_LIMIT=999999 CI=yes yarn workspace @experimenter/nimbus-ui test:cov
 NIMBUS_SCHEMA_CHECK = python manage.py graphql_schema --out experimenter/nimbus-ui/test_schema.graphql&&diff experimenter/nimbus-ui/test_schema.graphql experimenter/nimbus-ui/schema.graphql || (echo GraphQL Schema is out of sync please run make generate_types;exit 1)
 NIMBUS_TYPES_GENERATE = python manage.py graphql_schema --out experimenter/nimbus-ui/schema.graphql&&yarn workspace @experimenter/nimbus-ui generate-types
 FLAKE8 = flake8 .

--- a/README.md
+++ b/README.md
@@ -296,6 +296,10 @@ Pull in the latest Kinto Docker image. Kinto is not automatically updated when n
 
 Run all test and lint suites, this is run in CI on all PRs and deploys.
 
+##### Helpful UI Testing Tips
+If you have a test failing to find an element (or finding too many, etc.) and the DOM is being cut off in the console output,
+you can increase how much is printed by locally editing the `DEBUG_PRINT_LIMIT=7000` in the `Makefile` (line starts with `JS_TEST_NIMBUS_UI`).
+
 #### make py_test
 
 Run only the python test suite.


### PR DESCRIPTION
Because

* it can be difficult to figure out why new tests fail to find DOM elements as expected
* the testing library defaults to only printing 7000 DOM characters

This commit

* adds the environment variable explicitly to the Makefile so that it is easier to change for local testing
* documents this change in the README