### PR TITLE
fix #7753 type(chore): Update targeting integration tests to use graphQL API

### DIFF
--- a/app/tests/integration/nimbus/conftest.py
+++ b/app/tests/integration/nimbus/conftest.py
@@ -104,7 +104,7 @@ def application(request):
     Returns the current application to use for testing
     Will also parametrize the tests
     """
-    return request.param 
+    return request.param
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/app/tests/integration/nimbus/conftest.py
+++ b/app/tests/integration/nimbus/conftest.py
@@ -97,7 +97,7 @@ def firefox_options(firefox_options):
     # Use all applications as available parameters in parallel_pytest_args.txt
     params=list(BaseExperimentApplications),
     ids=[application.name for application in BaseExperimentApplications],
-    autouse=True
+    autouse=True,
 )
 def application(request):
     """

--- a/app/tests/integration/nimbus/models/base_dataclass.py
+++ b/app/tests/integration/nimbus/models/base_dataclass.py
@@ -4,7 +4,7 @@ from typing import List, Optional
 
 
 class BaseExperimentApplications(Enum):
-    DESKTOP = "DESKTOP"
+    FIREFOX_DESKTOP = "DESKTOP"
     FENIX = "FENIX"
     IOS = "IOS"
     FOCUS_ANDROID = "FOCUS_ANDROID"

--- a/app/tests/integration/nimbus/parallel_pytest_args.txt
+++ b/app/tests/integration/nimbus/parallel_pytest_args.txt
@@ -1,7 +1,7 @@
--k DESKTOP -m run_per_app
+-k FIREFOX_DESKTOP -m run_per_app
 -k FENIX -m run_per_app
 -k IOS -m run_per_app
 -k FOCUS_ANDROID -m run_per_app
 -k FOCUS_IOS -m run_per_app
--k DESKTOP -m run_once --dist=loadgroup -n=2
--k DESKTOP -m run_targeting -n 2
+-k FIREFOX_DESKTOP -m run_once --dist=loadgroup -n=2
+-k FIREFOX_DESKTOP -m run_targeting -n 2

--- a/app/tests/integration/nimbus/test_firefox_targeting.py
+++ b/app/tests/integration/nimbus/test_firefox_targeting.py
@@ -3,8 +3,8 @@ import time
 
 import pytest
 import requests
-from nimbus.models.base_dataclass import BaseExperimentApplications
 from nimbus.pages.browser import Browser
+from nimbus.utils import helpers
 
 LOAD_DATA_RETRIES = 10
 LOAD_DATA_RETRY_DELAY = 1.0
@@ -76,22 +76,49 @@ def targeting_config_slug(request):
 @pytest.mark.run_targeting
 def test_check_targeting(
     selenium,
-    default_data,
-    create_experiment,
+    slugify,
+    experiment_name,
     targeting_config_slug,
+    create_desktop_experiment,
 ):
-    # TODO #6791
-    # If the targeting config slug includes the word desktop it will cause this test
-    # to run against applications other than desktop, which will then fail.
-    # This check will prevent the test from executing fully but we should dig
-    # into preventing this case altogether when we have time.
-    if default_data.application != BaseExperimentApplications.DESKTOP:
-        return
-
-    default_data.audience.targeting = targeting_config_slug
-    experiment = create_experiment(selenium)
-
-    experiment_data = load_experiment_data(experiment.experiment_slug)
+    targeting = helpers.load_targeting_configs()[1]
+    experiment_slug = str(slugify(experiment_name))
+    data = {
+        "hypothesis": "Test Hypothesis",
+        "application": "DESKTOP",
+        "changelogMessage": "test updates",
+        "targetingConfigSlug": targeting,
+        "publicDescription": "Some sort of Fancy Words",
+        "riskRevenue": False,
+        "riskPartnerRelated": False,
+        "riskBrand": False,
+        "featureConfigId": 1,
+        "referenceBranch": {
+            "description": "reference branch",
+            "name": "Branch 1",
+            "ratio": 50,
+            "featureEnabled": True,
+            "featureValue": "{}",
+        },
+        "treatmentBranches": [
+            {
+                "description": "treatment branch",
+                "name": "Branch 2",
+                "ratio": 50,
+                "featureEnabled": False,
+                "featureValue": "",
+            }
+        ],
+        "populationPercent": "100",
+        "totalEnrolledClients": 55,
+    }
+    create_desktop_experiment(
+        experiment_slug,
+        "desktop",
+        targeting_config_slug,
+        data,
+    )
+    experiment_data = load_experiment_data(experiment_slug)
     targeting = experiment_data["data"]["experimentBySlug"]["jexlTargetingExpression"]
     recipe = experiment_data["data"]["experimentBySlug"]["recipeJson"]
 

--- a/app/tests/integration/nimbus/test_telemetry.py
+++ b/app/tests/integration/nimbus/test_telemetry.py
@@ -72,23 +72,24 @@ def test_check_telemetry_enrollment_unenrollment(
     requests.delete("http://ping-server:5000/pings")
     targeting = helpers.load_targeting_configs()[0]
     experiment_slug = str(slugify(experiment_name))
-    create_desktop_experiment(
-        experiment_slug,
-        "desktop",
-        targeting,
-        public_description="Some sort of words",
-        risk_revenue=False,
-        risk_partner_related=False,
-        risk_brand=False,
-        feature_config=1,
-        reference_branch={
+    data = {
+        "hypothesis": "Test Hypothesis",
+        "application": "DESKTOP",
+        "changelogMessage": "test updates",
+        "targetingConfigSlug": targeting,
+        "publicDescription": "Some sort of Fancy Words",
+        "riskRevenue": False,
+        "riskPartnerRelated": False,
+        "riskBrand": False,
+        "featureConfigId": 1,
+        "referenceBranch": {
             "description": "reference branch",
             "name": "Branch 1",
             "ratio": 50,
             "featureEnabled": True,
             "featureValue": "{}",
         },
-        treatement_branch=[
+        "treatmentBranches": [
             {
                 "description": "treatment branch",
                 "name": "Branch 2",
@@ -97,8 +98,14 @@ def test_check_telemetry_enrollment_unenrollment(
                 "featureValue": "",
             }
         ],
-        population_percent="100",
-        total_enrolled_clients=55,
+        "populationPercent": "100",
+        "totalEnrolledClients": 55,
+    }
+    create_desktop_experiment(
+        experiment_slug,
+        "desktop",
+        targeting,
+        data,
     )
     summary = SummaryPage(selenium, urljoin(base_url, experiment_slug)).open()
     summary.launch_and_approve()


### PR DESCRIPTION

Because:
* Using the UI to create experiments for the targeting tests can take a lot of time

This Commit:
* Switches to using the graphQL API to create experiments resulting in faster tests.

Also fixes #6791