### PR TITLE
fix #7762 chore(nimbus): Add python script to aide in targeting expression testing (mobile)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,7 @@ LOAD_LOCALES = python manage.py loaddata ./experimenter/base/fixtures/locales.js
 LOAD_LANGUAGES = python manage.py loaddata ./experimenter/base/fixtures/languages.json
 LOAD_FEATURES = python manage.py load_feature_configs
 LOAD_DUMMY_EXPERIMENTS = [[ -z $$SKIP_DUMMY ]] && python manage.py load_dummy_experiments || echo "skipping dummy experiments"
+PYTHON_PATH_SDK = PYTHONPATH=/application-services/components/nimbus/src
 
 
 JETSTREAM_CONFIG_URL = https://github.com/mozilla/jetstream-config/archive/main.zip
@@ -174,7 +175,7 @@ integration_shell:
 	$(COMPOSE_INTEGRATION) run firefox bash
 
 integration_sdk_shell: build_prod
-	PYTHONPATH=/application-services/components/nimbus/src $(COMPOSE_INTEGRATION) run rust-sdk bash
+	$(PYTHON_PATH_SDK) $(COMPOSE_INTEGRATION) run rust-sdk bash
 
 integration_vnc_up: build_prod
 	$(COMPOSE_INTEGRATION) up

--- a/Makefile
+++ b/Makefile
@@ -174,7 +174,7 @@ integration_shell:
 	$(COMPOSE_INTEGRATION) run firefox bash
 
 integration_sdk_shell: build_prod
-	$(COMPOSE_INTEGRATION) run rust-sdk bash
+	PYTHONPATH=/application-services/components/nimbus/src $(COMPOSE_INTEGRATION) run rust-sdk bash
 
 integration_vnc_up: build_prod
 	$(COMPOSE_INTEGRATION) up

--- a/README.md
+++ b/README.md
@@ -437,7 +437,7 @@ To test a targeting expression, first add an app context named `app_context.json
 
 You can then invoke the script with the `--targeting-string` flag:
 ```bash
-python test_sdk_evals.py --targeting "(app_version|versionCompare('106.*') <= 0) && (is_already_enrolled)"
+python sdk_eval_check.py --targeting "(app_version|versionCompare('106.*') <= 0) && (is_already_enrolled)"
 ```
 The script should return the results, either `True`, `False`, or an error.
 

--- a/README.md
+++ b/README.md
@@ -437,7 +437,7 @@ To test a targeting expression, first add an app context named `app_context.json
 
 You can then invoke the script with the `--targeting-string` flag:
 ```bash
-python sdk_eval_check.py --targeting "(app_version|versionCompare('106.*') <= 0) && (is_already_enrolled)"
+python sdk_eval_check.py --targeting-string "(app_version|versionCompare('106.*') <= 0) && (is_already_enrolled)"
 ```
 The script should return the results, either `True`, `False`, or an error.
 

--- a/README.md
+++ b/README.md
@@ -427,6 +427,22 @@ An example using PYTEST_ARGS to run one test.
 make integration_test_legacy PYTEST_ARGS="-k test_addon_rollout_experiment_e2e"
 ```
 
+#### make integration_sdk_shell
+
+This builds and sets up the mobile sdk for use in testing.
+
+Navigate to `app/tests/tools`
+
+To test a targeting expression, first add an app context named `app_context.json` to the `app/tests/tools` directory.
+
+You can then invoke the script with the `--targeting-string` flag:
+```bash
+python test_sdk_evals.py --targeting "(app_version|versionCompare('106.*') <= 0) && (is_already_enrolled)"
+```
+The script should return the results, either `True`, `False`, or an error.
+
+Note that you can change the `app_context` live, and run the script again after.
+
 ## Accessing Remote Settings locally
 
 In development you may wish to approve or reject changes to experiments as if they were on Remote Settings. You can do so here: `http://localhost:8888/v1/admin/`

--- a/app/tests/tools/example_app_context.json
+++ b/app/tests/tools/example_app_context.json
@@ -1,0 +1,26 @@
+{
+"app_context": {
+    "app_name": "fenix",
+    "app_id": "org.mozilla.firefox",
+    "channel": "release",
+    "app_version": "100.1.2",
+    "app_build": "2015879543",
+    "architecture": "arm64-v8a",
+    "device_manufacturer": "samsung",
+    "device_model": "SM-G998U",
+    "locale": "en-US ",
+    "language":"en",
+    "os": "Android",
+    "os_version": "12",
+    "android_sdk_version": "31",
+    "debug_tag": null,
+    "installation_date": 1612674000,
+    "home_directory": null,
+    "custom_targeting_attributes": {},
+    "additional_targeting": {
+        "is_already_enrolled": true,
+        "days_since_install": 5,
+        "days_since_update": 2
+    }
+  }
+}

--- a/app/tests/tools/sdk_eval_check.py
+++ b/app/tests/tools/sdk_eval_check.py
@@ -7,7 +7,7 @@ import nimbus_rust as nimbus
 
 def load_parser():
     parser = argparse.ArgumentParser(description="Load configurations")
-    parser.add_argument("--targeting-string", type=str, action="store", nargs="+")
+    parser.add_argument("--targeting-string", type=str, action="store", nargs="?")
     return parser
 
 
@@ -52,4 +52,4 @@ if __name__ == "__main__":
 
     targeting_helper = client.create_targeting_helper(json.dumps(additional_targeting))
 
-    print(targeting_helper.eval_jexl(args.targeting_string[0]))
+    print(targeting_helper.eval_jexl(args.targeting_string))

--- a/app/tests/tools/sdk_eval_check.py
+++ b/app/tests/tools/sdk_eval_check.py
@@ -1,0 +1,55 @@
+import argparse
+import json
+import os
+
+import nimbus_rust as nimbus
+
+
+def load_parser():
+    parser = argparse.ArgumentParser(description="Load configurations")
+    parser.add_argument("--targeting-string", type=str, action="store", nargs="+")
+    return parser
+
+
+def load_context():
+    if os.path.exists("app_context.json"):
+        with open("app_context.json") as file:
+            data = json.loads(file.read())["app_context"]
+            return (
+                nimbus.AppContext(
+                    app_id=data["app_id"],
+                    app_name=data["app_name"],
+                    channel=data["channel"],
+                    app_version=data["app_version"],
+                    app_build=data["app_build"],
+                    architecture=data["architecture"],
+                    device_manufacturer=data["device_manufacturer"],
+                    device_model=data["device_model"],
+                    locale=data["locale"],
+                    os=data["os"],
+                    os_version=data["os_version"],
+                    android_sdk_version=data["android_sdk_version"],
+                    debug_tag=data["debug_tag"],
+                    installation_date=data["installation_date"],
+                    home_directory=data["home_directory"],
+                    custom_targeting_attributes=data["custom_targeting_attributes"],
+                ),
+                data["additional_targeting"],
+            )
+    else:
+        print("Please provide an app context file. Exiting...")
+        exit()
+
+
+if __name__ == "__main__":
+    args = load_parser().parse_args()
+
+    context, additional_targeting = load_context()
+
+    randomization_units = nimbus.AvailableRandomizationUnits(None, 0)
+
+    client = nimbus.NimbusClient(context, os.getcwd(), None, randomization_units)
+
+    targeting_helper = client.create_targeting_helper(json.dumps(additional_targeting))
+
+    print(targeting_helper.eval_jexl(args.targeting_string[0]))

--- a/docker-compose-integration-test.yml
+++ b/docker-compose-integration-test.yml
@@ -24,6 +24,8 @@ services:
   rust-sdk:
     image: b4handjr/nimbus-rust-image:latest
     env_file: .env
+    environment:
+      - PYTHONPATH
     volumes:
       - .:/code
       - /code/app/tests/integration/.tox


### PR DESCRIPTION
Because
* Testing targeting expressions can sometimes be quite cumbersome to do locally

This commit
* Adds a script to allow a user to input a custom context and targeting expression and see how they evaluate.