### PR TITLE
fix #7732 feat(nimbus): Improve percentage data and dates data

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/PageHome/DirectoryTable/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageHome/DirectoryTable/index.test.tsx
@@ -143,7 +143,7 @@ describe("DirectoryColumnPopulationPercent", () => {
       </TestTable>,
     );
     expect(screen.getByTestId("directory-table-cell")).toHaveTextContent(
-      "100.0",
+      "100%",
     );
   });
 });

--- a/app/experimenter/nimbus-ui/src/components/PageHome/DirectoryTable/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageHome/DirectoryTable/index.tsx
@@ -81,7 +81,7 @@ export const DirectoryColumnPopulationPercent: ColumnComponent = (
   experiment,
 ) => (
   <td data-testid="directory-table-cell">
-    {experiment.populationPercent! || <NotSet />}
+    {Math.round(Number(experiment.populationPercent!)) + "%" || <NotSet />}
   </td>
 );
 

--- a/app/experimenter/nimbus-ui/src/lib/dateUtils.test.ts
+++ b/app/experimenter/nimbus-ui/src/lib/dateUtils.test.ts
@@ -38,7 +38,7 @@ describe("getProposedEnrollmentRange", () => {
         proposedEnrollment: 4,
       }),
     );
-    expect(actual).toBe("Dec 12, 2020 to Dec 16, 2020");
+    expect(actual).toBe("Dec 12, 2020 - Dec 16, 2020");
   });
   it("should render the enrollment duration if no startDate is set", () => {
     const actual = getProposedEnrollmentRange(

--- a/app/experimenter/nimbus-ui/src/lib/dateUtils.ts
+++ b/app/experimenter/nimbus-ui/src/lib/dateUtils.ts
@@ -33,7 +33,7 @@ export function addDaysToDate(datestring: string, days: number): string {
 /**
  *  Renders period of enrollment depend on what's available
  *  If startDate is set, it will return a range of dates
- *      e.g. Dec 2 - Dec 4
+ *      e.g. Dec 2, 2011 - Dec 4, 2011
  *  If startDate is not set, it will return a number of days
  *      e.g. 2 days
  */
@@ -42,7 +42,7 @@ export function getProposedEnrollmentRange(
 ): string {
   const { startDate, proposedEnrollment } = experiment;
   if (startDate) {
-    return `${humanDate(startDate)} to ${humanDate(
+    return `${humanDate(startDate)} - ${humanDate(
       addDaysToDate(startDate, proposedEnrollment),
     )}`;
   } else {

--- a/app/experimenter/nimbus-ui/src/lib/experiment.test.ts
+++ b/app/experimenter/nimbus-ui/src/lib/experiment.test.ts
@@ -112,7 +112,7 @@ describe("selectFromExperiment", () => {
       [computedEndDateSortSelector, experiment.computedEndDate],
       [firefoxMinVersionSortSelector, "FIREFOX_83"],
       [firefoxMaxVersionSortSelector, "FIREFOX_64"],
-      [populationPercentSortSelector, "100.0"],
+      [populationPercentSortSelector, "100"],
     ] as const;
     selectorCases.forEach(([selectBy, expected]) =>
       expect(selectFromExperiment(experiment, selectBy)).toEqual(expected),

--- a/app/experimenter/nimbus-ui/src/lib/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/lib/mocks.tsx
@@ -690,7 +690,7 @@ export function mockSingleDirectoryExperiment(
     name: "Open-architected background installation",
     status: NimbusExperimentStatusEnum.COMPLETE,
     statusNext: null,
-    populationPercent: "100.0",
+    populationPercent: "100",
     channel: NimbusExperimentChannelEnum.NIGHTLY,
     publishStatus: NimbusExperimentPublishStatusEnum.IDLE,
     featureConfig: MOCK_CONFIG.allFeatureConfigs![0],


### PR DESCRIPTION
Because

* On the landing page we show the percentage as `100.00000%` and Enrollment dates as` 27 June, 2022 to 1 July, 2022`

This commit

* Changes the way we show percentage as `100%` i.e. before decimal values and Enrollment dates as `27 June, 2022 - 1 July, 2022`

Screenshot:
<img width="1727" alt="image" src="https://user-images.githubusercontent.com/104033388/191394110-e8d3f8b4-13b4-4e1e-9e1b-46819555e4f9.png">

fix #7731 