### PR TITLE
fix #7766 nimbus(chore): Update integration test ping server for Mobile clients

### DIFF
--- a/app/tests/integration/nimbus/utils/ping_server/ping_server.py
+++ b/app/tests/integration/nimbus/utils/ping_server/ping_server.py
@@ -25,10 +25,10 @@ def pings():
 
 
 @app.route(
-    "/submit/telemetry/<uuid>/<type>/<browser>/<version>/<browser_type>/<date>/",
+    "/submit/<path:telemetry>",
     methods=["POST"],
 )
-def submit(uuid, type, browser, version, browser_type, date):
+def submit_desktop(telemetry):
 
     if request.method == "POST":
         request_data = request.get_data()

--- a/app/tests/integration/nimbus/utils/ping_server/ping_server.py
+++ b/app/tests/integration/nimbus/utils/ping_server/ping_server.py
@@ -28,7 +28,7 @@ def pings():
     "/submit/<path:telemetry>",
     methods=["POST"],
 )
-def submit_desktop(telemetry):
+def submit(telemetry):
 
     if request.method == "POST":
         request_data = request.get_data()


### PR DESCRIPTION

Because
* Our current implementation of the Ping server used to capture telemetry is quite specific to Desktop clients

This Commit
* Expands the implementation to allow for both Desktop and Mobile clients to submit pings to the server.