### PR TITLE
fix #7770 feat(nimbus): Enhance rollouts error message

### DIFF
--- a/app/experimenter/experiments/api/v5/serializers.py
+++ b/app/experimenter/experiments/api/v5/serializers.py
@@ -1425,7 +1425,10 @@ class NimbusReviewSerializer(serializers.ModelSerializer):
             and min_version < NimbusExperiment.Version.parse(rollout_version_supported)
         ):
             raise serializers.ValidationError(
-                {"is_rollout": NimbusConstants.ERROR_ROLLOUT_VERSION_SUPPORT}
+                {
+                    "is_rollout": f"Rollouts are not supported for this application \
+                                below version {rollout_version_supported}"
+                }
             )
 
         return data

--- a/app/experimenter/experiments/constants.py
+++ b/app/experimenter/experiments/constants.py
@@ -399,9 +399,6 @@ Optional - We believe this outcome will <describe impact> on <core metric>
     # Serializer validation errors
     ERROR_DUPLICATE_BRANCH_NAME = "Branch names must be unique."
     ERROR_SINGLE_BRANCH_FOR_ROLLOUT = "A rollout may have only a single reference branch"
-    ERROR_ROLLOUT_VERSION_SUPPORT = (
-        "Rollouts are not supported for the given application and version number."
-    )
     ERROR_DUPLICATE_BRANCH_FEATURE_VALUE = (
         "A branch can not have multiple configurations for the same feature"
     )

--- a/app/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_ready_for_review_serializer.py
+++ b/app/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_ready_for_review_serializer.py
@@ -1261,10 +1261,7 @@ class TestNimbusReviewSerializerSingleFeature(TestCase):
 
         self.assertFalse(serializer.is_valid())
         self.assertEqual(len(serializer.errors), 1)
-        self.assertEqual(
-            serializer.errors["is_rollout"][0],
-            NimbusConstants.ERROR_ROLLOUT_VERSION_SUPPORT,
-        )
+        self.assertIn("is_rollout", serializer.errors)
 
     def test_invalid_experiment_with_branch_missing_feature_value(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(


### PR DESCRIPTION
Because

* Rollouts error message was not clear about the version it supports

This commit

* Adds version no. in the error message and test cases to verify new changes

Before:
![image](https://user-images.githubusercontent.com/104033388/191604431-104358ec-610a-441c-a2a8-039da24a6f25.png)

After:
![image](https://user-images.githubusercontent.com/104033388/191604253-50343ebe-fd05-4f6e-821e-1b33c7e6d8e3.png)

fix #7770 
