### PR TITLE
7777/css id overview page

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/FormOverview/FormDocumentationLink.tsx
+++ b/app/experimenter/nimbus-ui/src/components/FormOverview/FormDocumentationLink.tsx
@@ -56,7 +56,11 @@ export const FormDocumentationLink = ({
     );
 
   return (
-    <Form.Group className="mb-0" data-testid="DocumentationLink">
+    <Form.Group
+      className="mb-0"
+      data-testid="DocumentationLink"
+      id="documentation-link"
+    >
       <Form.Row>
         <Form.Group as={Col} sm={4} md={3}>
           <Form.Control as="select" {...formControlAttrs("title")}>

--- a/app/experimenter/nimbus-ui/src/components/FormOverview/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/FormOverview/index.tsx
@@ -270,7 +270,7 @@ const FormOverview = ({
               </LinkExternal>
             </InputRadios>
 
-            <Form.Group controlId="documentationLinks">
+            <Form.Group controlId="documentationLinks" id="documentation-links">
               <Form.Label>
                 Additional Links
                 <Info


### PR DESCRIPTION
Because

* Some of the sections eg. the `Additional Links section`, don’t have easy-to-access CSS attributes.

This commit

*  Add the` id` parameter which will help aide in our UI integration tests.
