### PR TITLE
Fixes #7835 feat(nimbus): Add ops mon dashboard to sidebar for rollouts

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/SidebarActions/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/SidebarActions/index.test.tsx
@@ -55,6 +55,27 @@ describe("SidebarActions", () => {
     ).toHaveAttribute("href", expect.stringContaining("https://mozilla.org"));
   });
 
+  it("displays ops mon link when rollout and launched", async () => {
+    render(
+      <Subject
+        {...{
+          experiment: {
+            slug: "demo-slug-1",
+            status: NimbusExperimentStatusEnum.LIVE,
+            isRollout: true,
+            rolloutMonitoringDashboardUrl: "https://mozilla.org/linklinklink",
+          },
+        }}
+      />,
+    );
+    expect(
+      screen.queryByTestId("link-rollout-monitoring-dashboard"),
+    ).toHaveAttribute(
+      "href",
+      expect.stringContaining("https://mozilla.org/linklinklink"),
+    );
+  });
+
   it("does not render risk mitigation link when not set", () => {
     render(<Subject {...{ experiment: { riskMitigationLink: undefined } }} />);
     expect(
@@ -72,6 +93,20 @@ describe("SidebarActions", () => {
     );
     expect(
       screen.queryByTestId("link-monitoring-dashboard"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("does not render ops mon URL if experiment has not been launched and not rollout", () => {
+    render(
+      <Subject
+        experiment={{
+          status: NimbusExperimentStatusEnum.DRAFT,
+          isRollout: false,
+        }}
+      />,
+    );
+    expect(
+      screen.queryByTestId("link-rollout-monitoring-dashboard"),
     ).not.toBeInTheDocument();
   });
 

--- a/app/experimenter/nimbus-ui/src/components/SidebarActions/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/SidebarActions/index.tsx
@@ -156,6 +156,17 @@ export const SidebarActions = ({
           </LinkExternal>
         )}
 
+        {status.launched && experiment.rolloutMonitoringDashboardUrl && (
+          <LinkExternal
+            href={experiment.rolloutMonitoringDashboardUrl!}
+            data-testid="link-rollout-monitoring-dashboard"
+            className="mx-1 my-2 nav-item d-block text-dark w-100 font-weight-normal"
+          >
+            <ExternalIcon className="sidebar-icon-external-link" />
+            Rollouts OpsMon Dashboard
+          </LinkExternal>
+        )}
+
         {status.launched && !analysisUnavailable(analysis) && (
           <LinkExternal
             href={EXTERNAL_URLS.DETAILED_ANALYSIS_TEMPLATE(slug)}


### PR DESCRIPTION
#7835 

Because..

* We already added the OpsMon link to the homepage for rollouts
* And I forgot to add it to the Sidebar 🙃 

This commit...

* Adds the OpsMon link to the sidebar

Rollout (left) vs regular experiment (right)
<img width="268" alt="image" src="https://user-images.githubusercontent.com/43795363/195150721-27034a59-e483-4711-bd3d-f0991ab5fb2b.png">    <img width="270" alt="image" src="https://user-images.githubusercontent.com/43795363/195150978-2c0bfe2e-cc3d-4b0a-92fc-17d1979e94b1.png">

