### PR TITLE
fixes #7840 test(nimbus): Adds tests for outcomes on the Metrics Page.

### DIFF
--- a/app/tests/integration/nimbus/conftest.py
+++ b/app/tests/integration/nimbus/conftest.py
@@ -177,6 +177,8 @@ def default_data(application, experiment_name, load_experiment_outcomes):
             primary_outcomes=[load_experiment_outcomes["firefox_ios"][0]],
             secondary_outcomes=[load_experiment_outcomes["firefox_ios"][1]],
         )
+    else:
+        metrics_data = BaseExperimentMetricsDataClass(primary_outcomes=[],secondary_outcomes=[])
 
     return BaseExperimentDataClass(
         public_name=experiment_name,
@@ -209,7 +211,7 @@ def default_data(application, experiment_name, load_experiment_outcomes):
 
 
 @pytest.fixture
-def create_experiment(base_url, default_data):
+def create_experiment(base_url, application, default_data):
     def _create_experiment(selenium):
         home = HomePage(selenium, base_url).open()
         experiment = home.create_new_button()
@@ -246,10 +248,11 @@ def create_experiment(base_url, default_data):
 
         # Fill Metrics page
         metrics = branches.save_and_continue()
-        metrics.set_primary_outcomes(values=default_data.metrics.primary_outcomes[0])
-        assert metrics.primary_outcomes.text != "", "The primary outcome was not set"
-        metrics.set_secondary_outcomes(values=default_data.metrics.secondary_outcomes[0])
-        assert metrics.secondary_outcomes.text != "", "The seconday outcome was not set"
+        if "focus" not in str(application).lower():
+            metrics.set_primary_outcomes(values=default_data.metrics.primary_outcomes[0])
+            assert metrics.primary_outcomes.text != "", "The primary outcome was not set"
+            metrics.set_secondary_outcomes(values=default_data.metrics.secondary_outcomes[0])
+            assert metrics.secondary_outcomes.text != "", "The seconday outcome was not set"
 
         # Fill Audience page
         audience = metrics.save_and_continue()

--- a/app/tests/integration/nimbus/conftest.py
+++ b/app/tests/integration/nimbus/conftest.py
@@ -143,9 +143,40 @@ def experiment_name(request):
     return f"{request.node.name[:75]}-{str(uuid.uuid4())[:4]}"
 
 
+@pytest.fixture(name="load_experiment_outcomes")
+def fixture_load_experiment_outcomes():
+    """Fixture to create a list of outcomes based on the current configs."""
+    outcomes = {"firefox_desktop": "", "fenix": "", "firefox_ios": ""}
+    base_path = "/code/app/experimenter/outcomes/jetstream-config-main/outcomes"
+
+    for k in list(outcomes):
+        outcomes[k] = [
+            name.split("_")[0].rsplit(".")[0]
+            for name in os.listdir(f"{base_path}/{k}")
+            if "example" not in name
+        ]
+    return outcomes
+
+
 @pytest.fixture
-def default_data(application, experiment_name):
+def default_data(application, experiment_name, load_experiment_outcomes):
     feature_config_id = APPLICATION_FEATURE_IDS[application]
+
+    if "firefox_desktop" in str(application).lower():
+        metrics_data = BaseExperimentMetricsDataClass(
+            primary_outcomes=[load_experiment_outcomes["firefox_desktop"][0]],
+            secondary_outcomes=[load_experiment_outcomes["firefox_desktop"][1]],
+        )
+    elif "fenix" in str(application).lower():
+        metrics_data = BaseExperimentMetricsDataClass(
+            primary_outcomes=[load_experiment_outcomes["fenix"][0]],
+            secondary_outcomes=[load_experiment_outcomes["fenix"][1]],
+        )
+    elif "ios" in str(application).lower():
+        metrics_data = BaseExperimentMetricsDataClass(
+            primary_outcomes=[load_experiment_outcomes["firefox_ios"][0]],
+            secondary_outcomes=[load_experiment_outcomes["firefox_ios"][1]],
+        )
 
     return BaseExperimentDataClass(
         public_name=experiment_name,
@@ -163,9 +194,7 @@ def default_data(application, experiment_name):
                 description="treatment description",
             ),
         ],
-        metrics=BaseExperimentMetricsDataClass(
-            primary_outcomes=[], secondary_outcomes=[]
-        ),
+        metrics=metrics_data,
         audience=BaseExperimentAudienceDataClass(
             channel=BaseExperimentAudienceChannels.RELEASE,
             min_version=80,
@@ -217,6 +246,10 @@ def create_experiment(base_url, default_data):
 
         # Fill Metrics page
         metrics = branches.save_and_continue()
+        metrics.set_primary_outcomes(values=default_data.metrics.primary_outcomes[0])
+        assert metrics.primary_outcomes.text != "", "The primary outcome was not set"
+        metrics.set_secondary_outcomes(values=default_data.metrics.secondary_outcomes[0])
+        assert metrics.secondary_outcomes.text != "", "The seconday outcome was not set"
 
         # Fill Audience page
         audience = metrics.save_and_continue()

--- a/app/tests/integration/nimbus/conftest.py
+++ b/app/tests/integration/nimbus/conftest.py
@@ -178,7 +178,9 @@ def default_data(application, experiment_name, load_experiment_outcomes):
             secondary_outcomes=[load_experiment_outcomes["firefox_ios"][1]],
         )
     else:
-        metrics_data = BaseExperimentMetricsDataClass(primary_outcomes=[],secondary_outcomes=[])
+        metrics_data = BaseExperimentMetricsDataClass(
+            primary_outcomes=[], secondary_outcomes=[]
+        )
 
     return BaseExperimentDataClass(
         public_name=experiment_name,
@@ -251,8 +253,12 @@ def create_experiment(base_url, application, default_data):
         if "focus" not in str(application).lower():
             metrics.set_primary_outcomes(values=default_data.metrics.primary_outcomes[0])
             assert metrics.primary_outcomes.text != "", "The primary outcome was not set"
-            metrics.set_secondary_outcomes(values=default_data.metrics.secondary_outcomes[0])
-            assert metrics.secondary_outcomes.text != "", "The seconday outcome was not set"
+            metrics.set_secondary_outcomes(
+                values=default_data.metrics.secondary_outcomes[0]
+            )
+            assert (
+                metrics.secondary_outcomes.text != ""
+            ), "The seconday outcome was not set"
 
         # Fill Audience page
         audience = metrics.save_and_continue()

--- a/app/tests/integration/nimbus/conftest.py
+++ b/app/tests/integration/nimbus/conftest.py
@@ -162,21 +162,27 @@ def fixture_load_experiment_outcomes():
 def default_data(application, experiment_name, load_experiment_outcomes):
     feature_config_id = APPLICATION_FEATURE_IDS[application]
 
-    if "firefox_desktop" in str(application).lower():
-        metrics_data = BaseExperimentMetricsDataClass(
+    outcomes = {
+        "firefox_desktop": BaseExperimentMetricsDataClass(
             primary_outcomes=[load_experiment_outcomes["firefox_desktop"][0]],
             secondary_outcomes=[load_experiment_outcomes["firefox_desktop"][1]],
-        )
-    elif "fenix" in str(application).lower():
-        metrics_data = BaseExperimentMetricsDataClass(
+        ),
+        "fenix": BaseExperimentMetricsDataClass(
             primary_outcomes=[load_experiment_outcomes["fenix"][0]],
             secondary_outcomes=[load_experiment_outcomes["fenix"][1]],
-        )
-    elif "ios" in str(application).lower():
-        metrics_data = BaseExperimentMetricsDataClass(
+        ),
+        "ios": BaseExperimentMetricsDataClass(
             primary_outcomes=[load_experiment_outcomes["firefox_ios"][0]],
             secondary_outcomes=[load_experiment_outcomes["firefox_ios"][1]],
-        )
+        ),
+    }
+
+    application_str = str(application).lower()
+
+    for _ in list(outcomes):
+        if _ in application_str and "focus" not in application_str:
+            metrics_data = outcomes[_]
+            break
     else:
         metrics_data = BaseExperimentMetricsDataClass(
             primary_outcomes=[], secondary_outcomes=[]
@@ -250,7 +256,7 @@ def create_experiment(base_url, application, default_data):
 
         # Fill Metrics page
         metrics = branches.save_and_continue()
-        if "focus" not in str(application).lower():
+        if default_data.metrics.primary_outcomes:
             metrics.set_primary_outcomes(values=default_data.metrics.primary_outcomes[0])
             assert metrics.primary_outcomes.text != "", "The primary outcome was not set"
             metrics.set_secondary_outcomes(

--- a/app/tests/integration/nimbus/conftest.py
+++ b/app/tests/integration/nimbus/conftest.py
@@ -219,7 +219,7 @@ def default_data(application, experiment_name, load_experiment_outcomes):
 
 
 @pytest.fixture
-def create_experiment(base_url, application, default_data):
+def create_experiment(base_url, default_data):
     def _create_experiment(selenium):
         home = HomePage(selenium, base_url).open()
         experiment = home.create_new_button()

--- a/app/tests/integration/nimbus/conftest.py
+++ b/app/tests/integration/nimbus/conftest.py
@@ -175,18 +175,13 @@ def default_data(application, experiment_name, load_experiment_outcomes):
             primary_outcomes=[load_experiment_outcomes["firefox_ios"][0]],
             secondary_outcomes=[load_experiment_outcomes["firefox_ios"][1]],
         ),
-    }
-
-    application_str = str(application).lower()
-
-    for _ in list(outcomes):
-        if _ in application_str and "focus" not in application_str:
-            metrics_data = outcomes[_]
-            break
-    else:
-        metrics_data = BaseExperimentMetricsDataClass(
+        "focus_ios": BaseExperimentMetricsDataClass(
             primary_outcomes=[], secondary_outcomes=[]
-        )
+        ),
+        "focus_android": BaseExperimentMetricsDataClass(
+            primary_outcomes=[], secondary_outcomes=[]
+        ),
+    }
 
     return BaseExperimentDataClass(
         public_name=experiment_name,
@@ -204,7 +199,7 @@ def default_data(application, experiment_name, load_experiment_outcomes):
                 description="treatment description",
             ),
         ],
-        metrics=metrics_data,
+        metrics=outcomes[str(application).lower().rsplit(".")[-1]],
         audience=BaseExperimentAudienceDataClass(
             channel=BaseExperimentAudienceChannels.RELEASE,
             min_version=80,

--- a/app/tests/integration/nimbus/pages/experimenter/metrics.py
+++ b/app/tests/integration/nimbus/pages/experimenter/metrics.py
@@ -1,10 +1,43 @@
 from nimbus.pages.experimenter.audience import AudiencePage
 from nimbus.pages.experimenter.base import ExperimenterBase
 from selenium.webdriver.common.by import By
+from selenium.webdriver.common.keys import Keys
 
 
 class MetricsPage(ExperimenterBase):
     """Experiment Metrics Page.."""
 
     _page_wait_locator = (By.CSS_SELECTOR, "#PageEditMetrics")
+    _outcomes_selector_locator = (By.CSS_SELECTOR, "#PageEditMetrics .form-group input")
+    _primary_outcome_root_locator = (
+        By.CSS_SELECTOR,
+        "div[data-testid='primary-outcomes']",
+    )
+    _secondary_outcome_root_locator = (
+        By.CSS_SELECTOR,
+        "div[data-testid='secondary-outcomes']",
+    )
+    _multifeature_element_locator = (By.CSS_SELECTOR, "div[class$='-multiValue']")
     NEXT_PAGE = AudiencePage
+
+    @property
+    def primary_outcomes(self):
+        root_locator = self.find_element(*self._outcome_root_locator)
+        multifeature_el = root_locator.find_element(*self._multifeature_element_locator)
+        return multifeature_el.find_element(By.CSS_SELECTOR, "div")
+
+    def set_primary_outcomes(self, values=None):
+        els = self.find_elements(*self._outcomes_selector_locator)
+        els[0].send_keys(values)
+        els[0].send_keys(Keys.RETURN)
+
+    @property
+    def secondary_outcomes(self):
+        root_locator = self.find_element(*self._secondary_outcome_root_locator)
+        multifeature_el = root_locator.find_element(*self._multifeature_element_locator)
+        return multifeature_el.find_element(By.CSS_SELECTOR, "div")
+
+    def set_secondary_outcomes(self, values=None):
+        els = self.find_elements(*self._outcomes_selector_locator)
+        els[1].send_keys(values)
+        els[1].send_keys(Keys.RETURN)

--- a/app/tests/integration/nimbus/pages/experimenter/metrics.py
+++ b/app/tests/integration/nimbus/pages/experimenter/metrics.py
@@ -22,7 +22,7 @@ class MetricsPage(ExperimenterBase):
 
     @property
     def primary_outcomes(self):
-        root_locator = self.find_element(*self._outcome_root_locator)
+        root_locator = self.find_element(*self._primary_outcome_root_locator)
         multifeature_el = root_locator.find_element(*self._multifeature_element_locator)
         return multifeature_el.find_element(By.CSS_SELECTOR, "div")
 


### PR DESCRIPTION
Because
* We have been skipping adding anything on the metrics page within the integration tests because it isn't needed to create a valid experiment

This commit
* Adds the capability to set metrics within the integration tests
* Asserts the metrics are set and are not empty.