### PR TITLE
fix #7847 fix(nimbus): check for None before updating schema

### DIFF
--- a/app/experimenter/experiments/migrations/0218_update_results_data_schema.py
+++ b/app/experimenter/experiments/migrations/0218_update_results_data_schema.py
@@ -10,7 +10,7 @@ def update_results_data_schema(apps, schema_editor):
         data = experiment.results_data
         if data is not None:
             for key, value in data.items():
-                if key in windows and "all" not in value:
+                if value is not None and key in windows and "all" not in value:
                     data[key] = {}
                     data[key]["all"] = value
                 else:

--- a/app/experimenter/experiments/tests/test_migrations.py
+++ b/app/experimenter/experiments/tests/test_migrations.py
@@ -67,6 +67,22 @@ class TestMigration(MigratorTestCase):
             status=NimbusConstants.Status.DRAFT,
         )
 
+        # create experiment with empty results_data
+        NimbusExperiment.objects.create(
+            owner=user,
+            name="empty experiment",
+            slug="empty-experiment",
+            application=Experiment.Application.DESKTOP,
+            status=NimbusConstants.Status.DRAFT,
+            results_data={
+                "daily": None,
+                "weekly": None,
+                "overall": None,
+                "metadata": None,
+                "show_analysis": True,
+            },
+        )
+
     def test_migration(self):
         """Run the test itself."""
         NimbusExperiment = self.new_state.apps.get_model(

--- a/app/experimenter/experiments/tests/test_migrations.py
+++ b/app/experimenter/experiments/tests/test_migrations.py
@@ -70,8 +70,8 @@ class TestMigration(MigratorTestCase):
         # create experiment with empty results_data
         NimbusExperiment.objects.create(
             owner=user,
-            name="empty experiment",
-            slug="empty-experiment",
+            name="empty results experiment",
+            slug="empty-results-experiment",
             application=Experiment.Application.DESKTOP,
             status=NimbusConstants.Status.DRAFT,
             results_data={
@@ -110,3 +110,14 @@ class TestMigration(MigratorTestCase):
         empty_data = NimbusExperiment.objects.get(slug="empty-experiment")
 
         self.assertIsNone(empty_data.results_data)
+
+        empty_results_data = NimbusExperiment.objects.get(slug="empty-results-experiment")
+
+        results = {
+            "daily": None,
+            "weekly": None,
+            "overall": None,
+            "metadata": None,
+            "show_analysis": True,
+        }
+        self.assertEquals(empty_results_data.results_data, results)


### PR DESCRIPTION
Because

* experiments can have `None` for values in `results_data`

This commit

* checks for `None` in these values when performing the data migration