### PR TITLE
fix #7855 fix(nimbus): ensure branch keys exist before retrieval

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/PageResults/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/index.test.tsx
@@ -51,6 +51,20 @@ describe("PageResults", () => {
     });
   });
 
+  it("renders properly when results are empty", async () => {
+    render(
+      <Subject
+        mockAnalysisData={mockAnalysis({
+          weekly: { all: {} },
+          overall: { all: {} },
+        })}
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.queryByTestId("PageResults")).toBeInTheDocument();
+    });
+  });
+
   it("fetches analysis data and displays expected tables when analysis is ready", async () => {
     render(<Subject />);
 

--- a/app/experimenter/nimbus-ui/src/components/PageResults/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/index.tsx
@@ -61,8 +61,33 @@ const PageResults: React.FunctionComponent<RouteComponentProps> = () => {
   const resultsContextValue: ResultsContextType = {
     analysis,
     sortedBranchNames,
-    controlBranchName: sortedBranchNames[0],
+    controlBranchName:
+      sortedBranchNames.length > 0 ? sortedBranchNames[0] : undefined,
   };
+
+  const controlBranchError =
+    sortedBranchNames.length === 0 ? (
+      <AnalysisErrorAlert
+        errors={[
+          {
+            metric: null,
+            message: "Analysis could not be performed",
+            filename: null,
+            exception: null,
+            func_name: null,
+            log_level: null,
+            statistic: null,
+            timestamp: null,
+            experiment: null,
+            exception_type: null,
+          },
+        ]}
+      />
+    ) : (
+      false
+    );
+
+  console.log(controlBranchError);
 
   const { external_config: externalConfig } = analysis.metadata || {};
 
@@ -221,6 +246,7 @@ const PageResults: React.FunctionComponent<RouteComponentProps> = () => {
 
         <div>
           <h2 className="h4 mb-3">Outcome Metrics</h2>
+          {controlBranchError && controlBranchError}
           {analysis.overall?.[selectedSegment] &&
           Object.keys(analysis.overall?.[selectedSegment]).length > 0
             ? experiment.primaryOutcomes?.map((slug) => {

--- a/app/experimenter/nimbus-ui/src/components/PageResults/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/index.tsx
@@ -187,38 +187,42 @@ const PageResults: React.FunctionComponent<RouteComponentProps> = () => {
           <b>Hypothesis</b>: {experiment.hypothesis}
         </p>
 
-        {analysis.overall?.[selectedSegment] && (
-          <TableWithTabComparison
-            {...{ experiment }}
-            Table={TableHighlights}
-            className="mb-2 border-top-0"
-            segment={selectedSegment}
-          />
-        )}
+        {analysis.overall?.[selectedSegment] &&
+          Object.keys(analysis.overall?.[selectedSegment]).length > 0 && (
+            <TableWithTabComparison
+              {...{ experiment }}
+              Table={TableHighlights}
+              className="mb-2 border-top-0"
+              segment={selectedSegment}
+            />
+          )}
         <TableHighlightsOverview {...{ experiment }} />
 
         <div id="results_summary">
           <h2 className="h4 mb-3">Results Summary</h2>
-          {analysis.overall?.[selectedSegment] && (
-            <TableWithTabComparison
-              {...{ experiment }}
-              Table={TableResults}
-              className="rounded-bottom mb-3 border-top-0"
-              segment={selectedSegment}
-            />
-          )}
+          {analysis.overall?.[selectedSegment] &&
+            Object.keys(analysis.overall?.[selectedSegment]).length > 0 && (
+              <TableWithTabComparison
+                {...{ experiment }}
+                Table={TableResults}
+                className="rounded-bottom mb-3 border-top-0"
+                segment={selectedSegment}
+              />
+            )}
 
-          {analysis.weekly?.[selectedSegment] && (
-            <TableWithTabComparison
-              Table={TableResultsWeekly}
-              segment={selectedSegment}
-            />
-          )}
+          {analysis.weekly?.[selectedSegment] &&
+            Object.keys(analysis.weekly?.[selectedSegment]).length > 0 && (
+              <TableWithTabComparison
+                Table={TableResultsWeekly}
+                segment={selectedSegment}
+              />
+            )}
         </div>
 
         <div>
           <h2 className="h4 mb-3">Outcome Metrics</h2>
-          {analysis.overall?.[selectedSegment]
+          {analysis.overall?.[selectedSegment] &&
+          Object.keys(analysis.overall?.[selectedSegment]).length > 0
             ? experiment.primaryOutcomes?.map((slug) => {
                 const outcome = configOutcomes!.find((set) => {
                   return set?.slug === slug;
@@ -267,7 +271,8 @@ const PageResults: React.FunctionComponent<RouteComponentProps> = () => {
               analysis?.errors &&
               Object.keys(analysis.errors).length > 1 &&
               getErrorsForOutcomes(experiment.primaryOutcomes, true)}
-          {analysis.overall?.[selectedSegment]
+          {analysis.overall?.[selectedSegment] &&
+          Object.keys(analysis.overall?.[selectedSegment]).length > 0
             ? experiment.secondaryOutcomes?.map((slug) => {
                 const outcome = configOutcomes!.find((set) => {
                   return set?.slug === slug;
@@ -323,6 +328,8 @@ const PageResults: React.FunctionComponent<RouteComponentProps> = () => {
                   <Collapse in={open}>
                     <div>
                       {analysis.overall?.[selectedSegment] &&
+                        Object.keys(analysis.overall?.[selectedSegment])
+                          .length > 0 &&
                         analysis.other_metrics?.[group] &&
                         Object.keys(analysis.other_metrics[group]).map(
                           (metric: string) => (

--- a/app/experimenter/nimbus-ui/src/components/PageResults/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/index.tsx
@@ -71,7 +71,7 @@ const PageResults: React.FunctionComponent<RouteComponentProps> = () => {
         errors={[
           {
             metric: null,
-            message: "Analysis could not be performed",
+            message: "No control branch found in analysis results.",
             filename: null,
             exception: null,
             func_name: null,

--- a/app/experimenter/nimbus-ui/src/components/PageResults/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/index.tsx
@@ -83,11 +83,7 @@ const PageResults: React.FunctionComponent<RouteComponentProps> = () => {
           },
         ]}
       />
-    ) : (
-      false
-    );
-
-  console.log(controlBranchError);
+    ) : null;
 
   const { external_config: externalConfig } = analysis.metadata || {};
 
@@ -246,7 +242,7 @@ const PageResults: React.FunctionComponent<RouteComponentProps> = () => {
 
         <div>
           <h2 className="h4 mb-3">Outcome Metrics</h2>
-          {controlBranchError && controlBranchError}
+          {controlBranchError}
           {analysis.overall?.[selectedSegment] &&
           Object.keys(analysis.overall?.[selectedSegment]).length > 0
             ? experiment.primaryOutcomes?.map((slug) => {

--- a/app/experimenter/nimbus-ui/src/lib/visualization/utils.test.ts
+++ b/app/experimenter/nimbus-ui/src/lib/visualization/utils.test.ts
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { mockAnalysis, MOCK_METADATA_WITH_CONFIG } from "./mocks";
-import { getSortedBranchNames } from "./utils";
+import { getControlBranchName, getSortedBranchNames } from "./utils";
 
 describe("getSortedBranchNames", () => {
   const MOCK_OVERALL = {
@@ -56,5 +56,58 @@ describe("getSortedBranchNames", () => {
         }),
       ),
     ).toEqual(["englishman", "fee", "fi", "fo", "fum"]);
+  });
+});
+
+describe("getControlBranchName", () => {
+  const MOCK_ANALYSIS_DAILY = {
+    daily: {
+      all: [
+        {
+          point: 1,
+          branch: "test",
+          metric: "test_metric",
+          statistic: "count",
+        },
+      ],
+    },
+    weekly: { all: {} },
+    overall: { all: {} },
+    show_analysis: true,
+    errors: { experiment: [] },
+  };
+
+  it("returns the branch from daily if there are no other branches", () => {
+    expect(getControlBranchName(MOCK_ANALYSIS_DAILY)).toEqual("test");
+  });
+
+  it("throws an error if it cannot determine the control branch and there are multiple branches in daily", () => {
+    expect(() =>
+      getControlBranchName({
+        ...MOCK_ANALYSIS_DAILY,
+        daily: {
+          all: [
+            {
+              point: 1,
+              branch: "test",
+              metric: "test_metric",
+              statistic: "count",
+            },
+            {
+              point: 11,
+              branch: "not-test",
+              metric: "test_metric",
+              statistic: "binomial",
+            },
+          ],
+        },
+      }),
+    ).toThrow("no branch name");
+  });
+
+  it("throws an error if it cannot find a branch in the results", () => {
+    expect(() =>
+      getControlBranchName({ ...MOCK_ANALYSIS_DAILY, daily: { all: [] } }),
+    ).toThrow("no branch name");
   });
 });

--- a/app/experimenter/nimbus-ui/src/lib/visualization/utils.tsx
+++ b/app/experimenter/nimbus-ui/src/lib/visualization/utils.tsx
@@ -38,22 +38,41 @@ export const getControlBranchName = (analysis: AnalysisData) => {
   if (external_config?.reference_branch) {
     return external_config.reference_branch;
   }
-  const results = analysis.overall?.all || analysis.weekly?.all;
-  for (const [branchName, branchData] of Object.entries(results!)) {
-    if (branchData.is_control) {
-      return branchName;
+  const results = analysis.overall?.all || analysis.weekly?.all || {};
+  if (Object.keys(results).length > 0) {
+    for (const [branchName, branchData] of Object.entries(results)) {
+      if (branchData.is_control) {
+        return branchName;
+      }
     }
   }
+  // last option - try to find a unique branch name in the daily results
+  const daily = analysis.daily?.all || [];
+  if (daily.length > 0) {
+    const branches = new Set();
+    daily.forEach((point) => branches.add(point.branch));
+    if (branches.size === 1) {
+      return branches.values().next().value; // return the first and only value
+    }
+  }
+
+  throw new Error(
+    "Invalid argument 'analysis': no branch name could be found in the results.",
+  );
 };
 
 // Returns [control/reference branch name, treatment branch names]
 export const getSortedBranchNames = (analysis: AnalysisData) => {
-  const controlBranchName = getControlBranchName(analysis)!;
-  const results = analysis.overall?.all || analysis.weekly?.all || {};
-  return [
-    controlBranchName,
-    ...Object.keys(results).filter((branch) => branch !== controlBranchName),
-  ];
+  try {
+    const controlBranchName = getControlBranchName(analysis)!;
+    const results = analysis.overall?.all || analysis.weekly?.all || {};
+    return [
+      controlBranchName,
+      ...Object.keys(results).filter((branch) => branch !== controlBranchName),
+    ];
+  } catch (_e) {
+    return [];
+  }
 };
 
 /**


### PR DESCRIPTION
Because

* results may not be available when retrieving the control branch from `analysis`
* unavailable results error prevents the Results page from loading

This commit

* checks for valid results before retrieving control branch
* throws and handles an error when a control branch cannot be determined
* adds tests for this situation