### PR TITLE
fix #7864 bug(project): freeze remote settings docker image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -86,7 +86,7 @@ services:
       - "6379:6379"
 
   kinto:
-    image: mozilla/remote-settings:latest
+    image: mozilla/remote-settings:29.1.1
     environment:
       KINTO_INI: /etc/kinto.ini
     ports:


### PR DESCRIPTION
Because

* A regression was recently introduced into the latest remote settings docker image
* This is breaking our CI runs

This commit

* Freezes the remote settings docker image to the last working tag