### PR TITLE
fix #7864 bug(project): lock remote settings version

### DIFF
--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -59,7 +59,7 @@ services:
       - "6379:6379"
 
   kinto:
-    image: mozilla/remote-settings:latest
+    image: mozilla/remote-settings:29.2.0
     environment:
       KINTO_INI: /etc/kinto.ini
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -86,7 +86,7 @@ services:
       - "6379:6379"
 
   kinto:
-    image: mozilla/remote-settings:latest
+    image: mozilla/remote-settings:29.2.0
     environment:
       KINTO_INI: /etc/kinto.ini
     ports:


### PR DESCRIPTION
Because

* It looks like something changed in remote settings and the latest version is reporting 'internal server error' in CI runs

This commit

* Locks the remote settings image to the last working version