### PR TITLE
fix #7879 bug(project): update remote settings configuration

### DIFF
--- a/kinto/server.ini
+++ b/kinto/server.ini
@@ -135,7 +135,7 @@ plugin = dogstatsd
 keys = root, kinto
 
 [handlers]
-keys = console, sentry
+keys = console
 
 [formatters]
 keys = color, json, generic
@@ -155,12 +155,6 @@ args = (sys.stderr,)
 level = NOTSET
 formatter = color
 
-[handler_sentry]
-class = raven.handlers.logging.SentryHandler
-args = ('https://<key>:<secret>@app.getsentry.com/<project>',)
-level = ERROR
-formatter = generic
-
 [formatter_json]
 class = kinto.core.JsonLogFormatter
 
@@ -170,3 +164,6 @@ class = logging_color_formatter.ColorFormatter
 [formatter_generic]
 format = %(asctime)s,%(msecs)03d %(levelname)-5.5s [%(name)s] %(message)s
 datefmt = %H:%M:%S
+
+kinto.sentry_dsn = https://userid@o1.ingest.sentry.io/1
+kinto.sentry_env = prod


### PR DESCRIPTION
Because

* Remote Settings 30.0.0 introduced breaking configuration changes around removing sentry
* This was causing RS to fail to start locally/in CI

This commit

* Updates our Remote Settings configuration with the 30.0.0 changes described here https://github.com/mozilla/remote-settings/blob/main/CHANGELOG.rst#3000-2022-10-17