### PR TITLE
fix #7863 feat(nimbus): support sticky clause for rollouts

### DIFF
--- a/app/experimenter/experiments/models.py
+++ b/app/experimenter/experiments/models.py
@@ -357,6 +357,8 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
             sticky_clause = "is_already_enrolled"
             if is_desktop:
                 sticky_clause = "experiment.slug in activeExperiments"
+                if self.is_rollout:
+                    sticky_clause = "experiment.slug in activeRollouts"
 
             sticky_expressions_joined = " && ".join(
                 [f"({expression})" for expression in sticky_expressions]


### PR DESCRIPTION
Becuase

* On desktop, the list of actively enrolled rollouts is available under a different JEXL variable than experiments

This commit

* Uses `experiment.slug in activeRollouts` for sticky targeting for desktop rollouts