### PR TITLE
For #7479 docs(nimbus): Fix file name for state diagram

### DIFF
--- a/app/experimenter/kinto/README.md
+++ b/app/experimenter/kinto/README.md
@@ -82,7 +82,7 @@ An experiment now has two distinct states:
 - Its lifecycle state
 - Its publish state
 
-![](diagrams/states-v2.png)
+![](diagrams/states-v2.svg)
 
 ### Lifecycle States
 


### PR DESCRIPTION
Whoops, forgot to change this from `.png` to `.svg`