### PR TITLE
For #7885 fix(nimbus): Link the preview json button in the sidebar to the correct place

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/SidebarActions/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/SidebarActions/index.test.tsx
@@ -235,4 +235,20 @@ describe("SidebarActions", () => {
       expect(screen.queryByTestId("CloneDialog")).not.toBeInTheDocument();
     });
   });
+
+  it("scrolls to json when preview recipe json button is clicked", async () => {
+    const experiment = mockExperiment({ isArchived: false, canArchive: true });
+    const refetch = jest.fn();
+    render(<Subject {...{ experiment, refetch }} />);
+
+    const jsonButton = await screen.findByTestId("button-recipe-json");
+
+    fireEvent.click(jsonButton);
+
+    await waitFor(() => {
+      expect(
+        screen.queryByTestId("button-recipe-json"),
+      ).not.toBeInTheDocument();
+    });
+  });
 });

--- a/app/experimenter/nimbus-ui/src/components/SidebarActions/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/SidebarActions/index.tsx
@@ -5,7 +5,11 @@
 import { Link, RouteComponentProps } from "@reach/router";
 import React from "react";
 import ReactTooltip from "react-tooltip";
-import { useChangeOperationMutation, useConfig } from "../../hooks";
+import {
+  useChangeOperationMutation,
+  useConfig,
+  useScrollToLocationHash,
+} from "../../hooks";
 import { ReactComponent as BookIcon } from "../../images/book.svg";
 import { ReactComponent as FeedbackIcon } from "../../images/chat-square-text.svg";
 import { ReactComponent as ExternalIcon } from "../../images/external.svg";
@@ -51,7 +55,7 @@ export const SidebarActions = ({
     riskMitigationLink,
   } = experiment;
   const { documentationLink: configDocumentationLinks } = useConfig();
-
+  const scrollIntoView = useScrollToLocationHash();
   const {
     isLoading: archiveIsLoading,
     callbacks: [onUpdateArchived],
@@ -180,8 +184,10 @@ export const SidebarActions = ({
 
         {recipeJson && (
           <Link
-            to={`${BASE_PATH}/${slug}/details#recipe-json`}
+            to={`${BASE_PATH}/${slug}#recipe-json`}
+            onClick={() => scrollIntoView}
             className="mx-1 my-2 nav-item d-block text-dark w-100 font-weight-normal"
+            data-testid="button-recipe-json"
           >
             <CogIcon className="sidebar-icon" />
             Preview Recipe JSON


### PR DESCRIPTION
#7885

Because...

* The preview recipe json button in the sidebar was still linking to the details page

This commit...

* Updates the link to navigate to the json on the summary page
* Adds a test :)