### PR TITLE
fix #7891 feat(nimbus): update branch slug on every save

### DIFF
--- a/app/experimenter/experiments/api/v5/serializers.py
+++ b/app/experimenter/experiments/api/v5/serializers.py
@@ -387,10 +387,6 @@ class NimbusBranchSerializer(serializers.ModelSerializer):
 
         return data
 
-    def create(self, data):
-        data["slug"] = slugify(data["name"])
-        return super().create(data)
-
     def _save_feature_values(
         self, feature_enabled, feature_value, feature_values, branch
     ):
@@ -449,9 +445,10 @@ class NimbusBranchSerializer(serializers.ModelSerializer):
         feature_value = self.validated_data.pop("feature_value", None)
         feature_values = self.validated_data.pop("feature_values", None)
         screenshots = self.validated_data.pop("screenshots", None)
+        slug = slugify(self.validated_data["name"])
 
         with transaction.atomic():
-            branch = super().save(*args, **kwargs)
+            branch = super().save(*args, slug=slug, **kwargs)
 
             self._save_feature_values(
                 feature_enabled, feature_value, feature_values, branch

--- a/app/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_branch_serializer.py
+++ b/app/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_branch_serializer.py
@@ -90,6 +90,7 @@ class TestNimbusBranchSerializerSingleFeature(TestCase):
 
         branch = branch_serializer.save(experiment=experiment)
         self.assertEqual(branch.name, "new control")
+        self.assertEqual(branch.slug, "new-control")
         self.assertEqual(branch.description, "a new control")
         self.assertEqual(branch.ratio, 2)
 


### PR DESCRIPTION
Because

* Originally we set the branch slugs to only be set once at branch creation time
* An early version of the mobile client API allowed querying by branch so it was necessary to freeze branch slugs to keep them in sync
* That API is gone now and so there are no external consumers of branch slugs
* This allows branch slugs to be updated freely
* Having the branch names and slugs out of sync creates confusion for users

This commit

* Moves branch slug saving from create to every save