### PR TITLE
Add targeting for Firefox Suggest data collection

### DIFF
--- a/app/experimenter/targeting/constants.py
+++ b/app/experimenter/targeting/constants.py
@@ -242,6 +242,17 @@ URLBAR_FIREFOX_SUGGEST = NimbusTargetingConfig(
     application_choice_names=(Application.DESKTOP.name,),
 )
 
+URLBAR_FIREFOX_SUGGEST_DATA_COLLECTION_ENABLED = NimbusTargetingConfig(
+    name="Urlbar (Firefox Suggest) - Data Collection Enabled",
+    slug="urlbar_firefox_suggest_data_collection_enabled",
+    description="Users with Firefox Suggest data collection enabled",
+    targeting="'browser.urlbar.quicksuggest.dataCollection.enabled'|preferenceValue",
+    desktop_telemetry="",
+    sticky_required=True,
+    is_first_run_required=False,
+    application_choice_names=(Application.DESKTOP.name,),
+)
+
 MAC_ONLY = NimbusTargetingConfig(
     name="Mac OS users only",
     slug="mac_only",


### PR DESCRIPTION
We need this targeting for the upcoming experiments / rollouts of Firefox Suggest.