### PR TITLE
fix #7942 feat(nimbus): Move timeline up

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/PageSummary/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageSummary/index.tsx
@@ -4,6 +4,7 @@
 
 import { RouteComponentProps } from "@reach/router";
 import React, { useContext, useMemo, useState } from "react";
+import { Badge } from "react-bootstrap";
 import Alert from "react-bootstrap/Alert";
 import { useChangeOperationMutation, useReviewCheck } from "../../hooks";
 import { ReactComponent as InfoCircle } from "../../images/info-circle.svg";
@@ -14,6 +15,7 @@ import {
 } from "../../lib/constants";
 import { ExperimentContext } from "../../lib/contexts";
 import { getStatus, getSummaryAction } from "../../lib/experiment";
+import { getExperiment_experimentBySlug } from "../../types/getExperiment";
 import {
   NimbusExperimentPublishStatusEnum,
   NimbusExperimentStatusEnum,
@@ -22,6 +24,7 @@ import AppLayoutWithExperiment from "../AppLayoutWithExperiment";
 import ChangeApprovalOperations from "../ChangeApprovalOperations";
 import Head from "../Head";
 import Summary from "../Summary";
+import SummaryTimeline from "../Summary/SummaryTimeline";
 import FormLaunchDraftToPreview from "./FormLaunchDraftToPreview";
 import FormLaunchDraftToReview from "./FormLaunchDraftToReview";
 import FormLaunchPreviewToReview from "./FormLaunchPreviewToReview";
@@ -175,6 +178,12 @@ const PageSummary = (props: RouteComponentProps) => {
   return (
     <AppLayoutWithExperiment testId="PageSummary" setHead={false}>
       <Head title={`${experiment.name} – ${summaryTitle}`} />
+      <h5 className="mb-3">
+        Timeline
+        {status.live && <StatusPills {...{ experiment }} />}
+      </h5>
+
+      <SummaryTimeline {...{ experiment }} />
 
       {submitError && (
         <Alert data-testid="submit-error" variant="warning">
@@ -183,9 +192,9 @@ const PageSummary = (props: RouteComponentProps) => {
       )}
 
       {summaryAction && (
-        <h2 className="mt-3 mb-4 h4">
+        <h5 className="mt-3 mb-4 ml-3">
           {summaryAction} {launchDocs}
-        </h2>
+        </h5>
       )}
 
       <ChangeApprovalOperations
@@ -245,3 +254,33 @@ const PageSummary = (props: RouteComponentProps) => {
 };
 
 export default PageSummary;
+
+const StatusPills = ({
+  experiment,
+}: {
+  experiment: getExperiment_experimentBySlug;
+}) => (
+  <>
+    {experiment.isEnrollmentPaused === false && (
+      <StatusPill
+        testId="pill-enrolling-active"
+        label="Enrolling Users in Progress"
+      />
+    )}
+    {experiment.isEnrollmentPaused && experiment.enrollmentEndDate && (
+      <StatusPill
+        testId="pill-enrolling-complete"
+        label="Enrollment Complete"
+      />
+    )}
+  </>
+);
+
+const StatusPill = ({ label, testId }: { label: string; testId: string }) => (
+  <Badge
+    className="ml-2 border rounded-pill px-2 bg-white border-primary text-primary font-weight-normal"
+    data-testid={testId}
+  >
+    {label}
+  </Badge>
+);

--- a/app/experimenter/nimbus-ui/src/components/Summary/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/index.test.tsx
@@ -15,7 +15,7 @@ import { createMutationMock, Subject } from "./mocks";
 describe("Summary", () => {
   it("renders expected components", () => {
     render(<Subject />);
-    expect(screen.getByTestId("summary-timeline")).toBeInTheDocument();
+
     expect(screen.queryByTestId("experiment-end")).not.toBeInTheDocument();
     expect(
       screen.queryByTestId("link-monitoring-dashboard"),
@@ -62,31 +62,6 @@ describe("Summary", () => {
     expect(
       screen.queryByTestId("summary-page-signoff-not-launched"),
     ).toBeInTheDocument();
-  });
-
-  it("renders enrollment active badge if enrollment is not paused", async () => {
-    render(
-      <Subject
-        props={{
-          status: NimbusExperimentStatusEnum.LIVE,
-          isEnrollmentPaused: false,
-        }}
-      />,
-    );
-    await screen.findByTestId("pill-enrolling-active");
-  });
-
-  it("renders enrollment complete badge if enrollment is not paused", async () => {
-    render(
-      <Subject
-        props={{
-          status: NimbusExperimentStatusEnum.LIVE,
-          isEnrollmentPaused: true,
-          enrollmentEndDate: new Date().toISOString(),
-        }}
-      />,
-    );
-    await screen.findByTestId("pill-enrolling-complete");
   });
 
   it("renders the end experiment button if the experiment is live and idle", async () => {
@@ -190,36 +165,6 @@ describe("Summary", () => {
         expect(refetch).toHaveBeenCalled();
         expect(screen.queryByTestId("submit-error")).not.toBeInTheDocument();
       });
-    });
-
-    it("verify cancel review doesn't change enrollment days", async () => {
-      const refetch = jest.fn();
-      const { experiment } = mockExperimentQuery("demo-slug", {
-        status: NimbusExperimentStatusEnum.LIVE,
-        publishStatus: NimbusExperimentPublishStatusEnum.REVIEW,
-      });
-      const mutationMock = createMutationMock(
-        experiment.id!,
-        NimbusExperimentPublishStatusEnum.IDLE,
-        {
-          statusNext: NimbusExperimentStatusEnum.LIVE,
-          changelogMessage: CHANGELOG_MESSAGES.CANCEL_REVIEW,
-          isEnrollmentPaused: false,
-        },
-      );
-      render(
-        <Subject props={experiment} mocks={[mutationMock]} {...{ refetch }} />,
-      );
-
-      await screen.findByTestId("cancel-review-start");
-      fireEvent.click(screen.getByTestId("cancel-review-start"));
-      await waitFor(() => {
-        expect(refetch).toHaveBeenCalled();
-        expect(screen.queryByTestId("submit-error")).not.toBeInTheDocument();
-      });
-      expect(screen.queryByTestId("label-enrollment-days")).toHaveTextContent(
-        "1 day",
-      );
     });
 
     it("handles submission with server API error", async () => {

--- a/app/experimenter/nimbus-ui/src/components/Summary/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/index.tsx
@@ -5,7 +5,6 @@
 import React from "react";
 import { Card } from "react-bootstrap";
 import Alert from "react-bootstrap/Alert";
-import Badge from "react-bootstrap/Badge";
 import { useChangeOperationMutation } from "../../hooks";
 import { CHANGELOG_MESSAGES } from "../../lib/constants";
 import { getStatus } from "../../lib/experiment";
@@ -22,7 +21,6 @@ import PreviewURL from "../PreviewURL";
 import CancelReview from "./CancelReview";
 import EndEnrollment from "./EndEnrollment";
 import EndExperiment from "./EndExperiment";
-import SummaryTimeline from "./SummaryTimeline";
 import TableAudience from "./TableAudience";
 import TableBranches from "./TableBranches";
 import TableOverview from "./TableOverview";
@@ -73,13 +71,6 @@ const Summary = ({ experiment, refetch }: SummaryProps) => {
 
   return (
     <div data-testid="summary" className="mb-5">
-      <h3 className="h5 mb-3">
-        Timeline
-        {status.live && <StatusPills {...{ experiment }} />}
-      </h3>
-
-      <SummaryTimeline {...{ experiment }} />
-
       {submitError && (
         <Alert data-testid="submit-error" variant="warning">
           {submitError}
@@ -164,33 +155,3 @@ export const displayConfigLabelOrNotSet = (
 };
 
 export default Summary;
-
-const StatusPills = ({
-  experiment,
-}: {
-  experiment: getExperiment_experimentBySlug;
-}) => (
-  <>
-    {experiment.isEnrollmentPaused === false && (
-      <StatusPill
-        testId="pill-enrolling-active"
-        label="Enrolling Users in Progress"
-      />
-    )}
-    {experiment.isEnrollmentPaused && experiment.enrollmentEndDate && (
-      <StatusPill
-        testId="pill-enrolling-complete"
-        label="Enrollment Complete"
-      />
-    )}
-  </>
-);
-
-const StatusPill = ({ label, testId }: { label: string; testId: string }) => (
-  <Badge
-    className="ml-2 border rounded-pill px-2 bg-white border-primary text-primary font-weight-normal"
-    data-testid={testId}
-  >
-    {label}
-  </Badge>
-);


### PR DESCRIPTION
Because

* We want the timeline up on the top screen

This commit

* Moves the timeline up on the summary page

 Before changes
<img width="1695" alt="Screenshot 2022-11-10 at 10 50 46 AM" src="https://user-images.githubusercontent.com/104033388/201181275-0bb32efe-00f3-4ef2-bd76-ad8657b5d368.png">
After changes
<img width="1695" alt="Screenshot 2022-11-10 at 10 42 18 AM" src="https://user-images.githubusercontent.com/104033388/201181271-73d02b0e-3dcb-4398-bf3f-6ba358fd9883.png">


