### PR TITLE
fix #7954 feat(nimbus): fetch focus ios features

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,7 @@ FEATURE_MANIFEST_DESKTOP_URL = https://hg.mozilla.org/mozilla-central/raw-file/t
 FEATURE_MANIFEST_FENIX_URL = https://raw.githubusercontent.com/mozilla-mobile/fenix/main/.experimenter.yaml
 FEATURE_MANIFEST_FXIOS_URL = https://raw.githubusercontent.com/mozilla-mobile/firefox-ios/main/.experimenter.yaml
 FEATURE_MANIFEST_FOCUS_ANDROID = https://raw.githubusercontent.com/mozilla-mobile/focus-android/main/.experimenter.yaml
+FEATURE_MANIFEST_FOCUS_IOS = https://raw.githubusercontent.com/mozilla-mobile/focus-ios/main/.experimenter.yaml
 
 ssl: nginx/key.pem nginx/cert.pem
 
@@ -76,6 +77,7 @@ feature_manifests:
 	curl -LJ --create-dirs -o app/experimenter/features/manifests/fenix.yaml $(FEATURE_MANIFEST_FENIX_URL)
 	curl -LJ --create-dirs -o app/experimenter/features/manifests/ios.yaml $(FEATURE_MANIFEST_FXIOS_URL)
 	curl -LJ --create-dirs -o app/experimenter/features/manifests/focus-android.yaml $(FEATURE_MANIFEST_FOCUS_ANDROID)
+	curl -LJ --create-dirs -o app/experimenter/features/manifests/focus-ios.yaml $(FEATURE_MANIFEST_FOCUS_IOS)
 
 fetch_external_resources: jetstream_config feature_manifests
 	echo "External Resources Fetched"

--- a/app/experimenter/features/manifests/focus-ios.yaml
+++ b/app/experimenter/features/manifests/focus-ios.yaml
@@ -1,0 +1,17 @@
+---
+nimbus-validation:
+  description: A tiny feature to validate that Nimbus is working
+  hasExposure: true
+  exposureDescription: ""
+  variables:
+    bold-tip-title:
+      type: boolean
+      description: Make the tips title label bold
+onboarding-variables:
+  description: A collection of variables about onboarding
+  hasExposure: true
+  exposureDescription: ""
+  variables:
+    show-new-onboarding:
+      type: boolean
+      description: Should the v2 of the onboarding be shown.


### PR DESCRIPTION
Because

* Focus iOS now publishes a feature manifest

This commit

* Adds Focus iOS to the list of feature manifests to be periodically fetched