### PR TITLE
For #7982 test(nimbus): Add tests for status transitions and publish states

### DIFF
--- a/app/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_experiment_serializer.py
+++ b/app/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_experiment_serializer.py
@@ -603,7 +603,7 @@ class TestNimbusExperimentSerializer(TestCase):
             serializer.errors,
         )
 
-    def test_status_restriction(self):
+    def test_status_restrictions(self):
         experiment = NimbusExperimentFactory(status=NimbusExperiment.Status.LIVE)
         serializer = NimbusExperimentSerializer(
             experiment,
@@ -984,7 +984,7 @@ class TestNimbusExperimentSerializer(TestCase):
         serializer = NimbusExperimentSerializer(
             experiment,
             data={
-                "publish_status": NimbusExperiment.PublishStatus.APPROVED,
+                "publish_status": NimbusExperiment.PublishStatus.REVIEW,
                 "changelog_message": "test changelog message",
             },
             context={"user": experiment.owner},

--- a/app/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_status_validation_mixin.py
+++ b/app/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_status_validation_mixin.py
@@ -1,4 +1,5 @@
 from django.test import TestCase
+from parameterized import parameterized
 
 from experimenter.experiments.api.v5.serializers import NimbusExperimentSerializer
 from experimenter.experiments.models import NimbusExperiment
@@ -12,20 +13,6 @@ class TestNimbusStatusValidationMixin(TestCase):
     def setUp(self):
         super().setUp()
         self.user = UserFactory()
-
-    def test_update_experiment_publish_status_while_in_preview(self):
-        experiment = NimbusExperimentFactory.create(
-            status=NimbusExperiment.Status.PREVIEW,
-        )
-        serializer = NimbusExperimentSerializer(
-            experiment,
-            data={
-                "publish_status": NimbusExperiment.PublishStatus.APPROVED,
-                "changelog_message": "test changelog message",
-            },
-            context={"user": self.user},
-        )
-        self.assertTrue(serializer.is_valid())
 
     def test_update_experiment_with_invalid_status_error(self):
         experiment = NimbusExperimentFactory.create(
@@ -42,7 +29,7 @@ class TestNimbusStatusValidationMixin(TestCase):
         self.assertFalse(serializer.is_valid())
         self.assertIn("experiment", serializer.errors)
 
-    def test_update_experiment_with_invalid_publish_status_error(self):
+    def test_unable_to_update_experiment_in_publish_status(self):
         experiment = NimbusExperimentFactory.create(
             publish_status=NimbusExperiment.PublishStatus.REVIEW,
         )
@@ -56,3 +43,139 @@ class TestNimbusStatusValidationMixin(TestCase):
         )
         self.assertFalse(serializer.is_valid())
         self.assertIn("experiment", serializer.errors)
+
+    @parameterized.expand(
+        [
+            [
+                NimbusExperiment.PublishStatus.IDLE,
+                True,
+            ],
+            [
+                NimbusExperiment.PublishStatus.REVIEW,
+                True,
+            ],
+            [
+                NimbusExperiment.PublishStatus.APPROVED,
+                True,
+            ],
+            [
+                NimbusExperiment.PublishStatus.WAITING,
+                False,
+            ],
+        ]
+    )
+    def test_update_publish_status_errors_for_status_complete(
+        self, publish_status, valid
+    ):
+        experiment = NimbusExperimentFactory.create(
+            status=NimbusExperiment.Status.COMPLETE
+        )
+        serializer = NimbusExperimentSerializer(
+            experiment,
+            data={
+                "publish_status": publish_status,
+                "changelog_message": "test changelog message",
+            },
+            context={"user": self.user},
+        )
+        self.assertEquals(serializer.is_valid(), valid)
+
+    @parameterized.expand(
+        [
+            [
+                NimbusExperiment.PublishStatus.IDLE,
+                True,
+            ],
+            [
+                NimbusExperiment.PublishStatus.REVIEW,
+                True,
+            ],
+            [
+                NimbusExperiment.PublishStatus.APPROVED,
+                True,
+            ],
+            [
+                NimbusExperiment.PublishStatus.WAITING,
+                False,
+            ],
+        ]
+    )
+    def test_update_publish_status_errors_for_status_live(self, publish_status, valid):
+        experiment = NimbusExperimentFactory.create(status=NimbusExperiment.Status.LIVE)
+        serializer = NimbusExperimentSerializer(
+            experiment,
+            data={
+                "publish_status": publish_status,
+                "changelog_message": "test changelog message",
+            },
+            context={"user": self.user},
+        )
+        self.assertEquals(serializer.is_valid(), valid)
+
+    @parameterized.expand(
+        [
+            [
+                NimbusExperiment.PublishStatus.IDLE,
+                True,
+            ],
+            [
+                NimbusExperiment.PublishStatus.REVIEW,
+                True,
+            ],
+            [
+                NimbusExperiment.PublishStatus.APPROVED,
+                True,
+            ],
+            [
+                NimbusExperiment.PublishStatus.WAITING,
+                False,
+            ],
+        ]
+    )
+    def test_update_publish_status_errors_for_status_preview(self, publish_status, valid):
+        experiment = NimbusExperimentFactory.create(
+            status=NimbusExperiment.Status.PREVIEW
+        )
+        serializer = NimbusExperimentSerializer(
+            experiment,
+            data={
+                "publish_status": publish_status,
+                "changelog_message": "test changelog message",
+            },
+            context={"user": self.user},
+        )
+        self.assertEquals(serializer.is_valid(), valid)
+
+    @parameterized.expand(
+        [
+            [
+                NimbusExperiment.PublishStatus.IDLE,
+                True,
+            ],
+            [
+                NimbusExperiment.PublishStatus.REVIEW,
+                True,
+            ],
+            [
+                NimbusExperiment.PublishStatus.APPROVED,
+                True,
+            ],
+            [
+                NimbusExperiment.PublishStatus.WAITING,
+                False,
+            ],
+        ]
+    )
+    def test_update_publish_status_errors_for_status_draft(self, publish_status, valid):
+        experiment = NimbusExperimentFactory.create(
+            status=NimbusExperiment.Status.DRAFT,
+        )
+        serializer = NimbusExperimentSerializer(
+            experiment,
+            data={
+                "publish_status": publish_status,
+                "changelog_message": "test changelog message",
+            },
+            context={"user": self.user},
+        )
+        self.assertEquals(serializer.is_valid(), valid)


### PR DESCRIPTION
For #7982

Because...

* We aren't fully testing the state transitions that are defined in the state diagram and sequence diagrams

This commit...

* Adds serializer tests to help boost our surety that we are allowing the correct state changes