### PR TITLE
Revert "fix #7964 feat(nimbus): Filter by targeting"

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/PageHome/FilterBar/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageHome/FilterBar/index.tsx
@@ -79,13 +79,6 @@ export const FilterBar: React.FC<FilterBarProps> = ({
           optionLabelName="label"
           {...{ filterValue, onChange }}
         />
-        <FilterSelect
-          fieldLabel="Targeting"
-          fieldOptions={options.targetingConfigs!}
-          filterValueName="targetingConfigs"
-          optionLabelName="label"
-          {...{ filterValue, onChange }}
-        />
       </Nav>
     </Navbar>
   );

--- a/app/experimenter/nimbus-ui/src/components/PageHome/filterExperiments.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageHome/filterExperiments.test.tsx
@@ -14,14 +14,8 @@ import {
 } from "./mocks";
 import { filterValueKeys } from "./types";
 
-const {
-  owners,
-  applications,
-  allFeatureConfigs,
-  channels,
-  types,
-  targetingConfigs,
-} = MOCK_CONFIG!;
+const { owners, applications, allFeatureConfigs, channels, types } =
+  MOCK_CONFIG!;
 
 describe("getFilterValueFromParams", () => {
   it("converts comma-separated list representation from filter params into a filter value", () => {
@@ -31,15 +25,12 @@ describe("getFilterValueFromParams", () => {
     params.set("allFeatureConfigs", "IOS:foo-lila-sat");
     params.set("channels", "BETA");
     params.set("types", "EXPERIMENT");
-    params.set("targetingConfigs", "MAC_ONLY");
-
     expect(getFilterValueFromParams(MOCK_CONFIG, params)).toEqual({
       owners: [owners![0], owners![1]],
       applications: [applications![0], applications![3]],
       allFeatureConfigs: [allFeatureConfigs![2]],
       channels: [channels![0]],
       types: [types![0]],
-      targetingConfigs: [targetingConfigs![0]],
     });
   });
 });
@@ -54,7 +45,6 @@ describe("updateParamsFromFilterValue", () => {
       allFeatureConfigs: [allFeatureConfigs![2], allFeatureConfigs![3]],
       channels: [channels![0], channels![1]],
       types: [types![0], types![1]],
-      targetingConfigs: [targetingConfigs![0], targetingConfigs![1]],
     });
     expect(params.get("owners")).toEqual(
       "alpha-example@mozilla.com,beta-example@mozilla.com",
@@ -65,7 +55,6 @@ describe("updateParamsFromFilterValue", () => {
     );
     expect(params.get("channels")).toEqual("BETA,NIGHTLY");
     expect(params.get("types")).toEqual("EXPERIMENT,ROLLOUT");
-    expect(params.get("targetingConfigs")).toEqual("MAC_ONLY,WIN_ONLY");
   });
 
   it("handles a roundtrip encoding with everything filtered", () => {
@@ -124,54 +113,6 @@ describe("filterExperiments", () => {
             break;
           case "types":
             expect(experiment.isRollout).toEqual(false);
-            break;
-          case "targetingConfigs":
-            expect(experiment.targetingConfig).toEqual([
-              MOCK_CONFIG!.targetingConfigs![0]!,
-            ]);
-            break;
-        }
-      }
-    }
-  });
-  it("filters per individual criteria as expected", () => {
-    for (const key of filterValueKeys) {
-      const filterValue = {
-        [key]: [DEFAULT_OPTIONS[key]![0]!],
-      };
-      const result = filterExperiments(MOCK_EXPERIMENTS, filterValue);
-      for (const experiment of result) {
-        switch (key) {
-          case "owners":
-            expect(experiment.owner).toEqual(MOCK_CONFIG!.owners![0]!);
-            break;
-          case "applications":
-            expect(experiment.application).toEqual(
-              MOCK_CONFIG!.applications![0]!.value,
-            );
-            break;
-          case "allFeatureConfigs":
-            expect(experiment.featureConfigs).toEqual([
-              MOCK_CONFIG!.allFeatureConfigs![0]!,
-            ]);
-            break;
-          case "firefoxVersions":
-            expect(experiment.firefoxMinVersion).toEqual(
-              MOCK_CONFIG!.firefoxVersions![0]!.value,
-            );
-            break;
-          case "channels":
-            expect(experiment.channel).toEqual(
-              MOCK_CONFIG!.channels![0]!.value,
-            );
-            break;
-          case "types":
-            expect(experiment.isRollout).toEqual(false);
-            break;
-          case "targetingConfigs":
-            expect(experiment.targetingConfig).toEqual([
-              MOCK_CONFIG!.targetingConfigs![0]!,
-            ]);
             break;
         }
       }

--- a/app/experimenter/nimbus-ui/src/components/PageHome/filterExperiments.ts
+++ b/app/experimenter/nimbus-ui/src/components/PageHome/filterExperiments.ts
@@ -27,7 +27,6 @@ export const optionIndexKeys: {
   firefoxVersions: (option) => option.value,
   channels: (option) => option.value,
   types: (option) => option.value,
-  targetingConfigs: (option) => option.value,
 };
 
 type ExperimentFilter<K extends FilterValueKeys> = (
@@ -63,15 +62,6 @@ const experimentFilters: { [key in FilterValueKeys]: ExperimentFilter<key> } = {
       (experiment.isRollout && option.value === "ROLLOUT") ||
       (!experiment.isRollout && option.value === "EXPERIMENT")
     );
-  },
-  targetingConfigs: (option, experiment) => {
-    let targetingConfigMatch = false;
-    if (experiment.targetingConfig?.length) {
-      targetingConfigMatch =
-        experiment.targetingConfig.filter((f) => f?.value === option.value)
-          .length > 0;
-    }
-    return targetingConfigMatch;
   },
 };
 
@@ -122,13 +112,6 @@ export function getFilterValueFromParams(
         break;
       case "types":
         filterValue[key] = selectFilterOptions<"types">(
-          options[key],
-          optionIndexKeys[key],
-          values,
-        );
-        break;
-      case "targetingConfigs":
-        filterValue[key] = selectFilterOptions<"targetingConfigs">(
           options[key],
           optionIndexKeys[key],
           values,
@@ -199,12 +182,6 @@ export function updateParamsFromFilterValue(
             optionIndexKeys[key],
           );
           break;
-        case "targetingConfigs":
-          values = indexFilterOptions<"targetingConfigs">(
-            filterValue[key],
-            optionIndexKeys[key],
-          );
-          break;
       }
       if (values && values.length) {
         params.set(key, values.join(","));
@@ -268,13 +245,6 @@ export function filterExperiments(
         break;
       case "types":
         filteredExperiments = filterExperimentsByOptions<"types">(
-          filterState[key],
-          experimentFilters[key],
-          filteredExperiments,
-        );
-        break;
-      case "targetingConfigs":
-        filteredExperiments = filterExperimentsByOptions<"targetingConfigs">(
           filterState[key],
           experimentFilters[key],
           filteredExperiments,

--- a/app/experimenter/nimbus-ui/src/components/PageHome/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageHome/index.tsx
@@ -101,7 +101,6 @@ const PageHome: React.FunctionComponent<PageHomeProps> = () => {
     owners: config!.owners!,
     channels: config!.channels,
     types: config!.types,
-    targetingConfigs: config!.targetingConfigs,
   };
   return (
     <AppLayout testid="PageHome">

--- a/app/experimenter/nimbus-ui/src/components/PageHome/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageHome/mocks.tsx
@@ -16,7 +16,6 @@ export const DEFAULT_OPTIONS: FilterOptions = {
   firefoxVersions: MOCK_CONFIG!.firefoxVersions!,
   channels: MOCK_CONFIG!.channels!,
   types: MOCK_CONFIG!.types,
-  targetingConfigs: MOCK_CONFIG!.targetingConfigs,
 };
 
 export const DEFAULT_VALUE: FilterValue = {
@@ -26,7 +25,6 @@ export const DEFAULT_VALUE: FilterValue = {
   firefoxVersions: [],
   channels: [],
   types: [],
-  targetingConfigs: [],
 };
 
 export const EVERYTHING_SELECTED_VALUE: FilterValue = DEFAULT_OPTIONS;

--- a/app/experimenter/nimbus-ui/src/components/PageHome/types.ts
+++ b/app/experimenter/nimbus-ui/src/components/PageHome/types.ts
@@ -11,7 +11,6 @@ export const filterValueKeys = [
   "firefoxVersions",
   "channels",
   "types",
-  "targetingConfigs",
 ] as const;
 
 export type FilterValueKeys = typeof filterValueKeys[number];

--- a/app/experimenter/nimbus-ui/src/gql/experiments.ts
+++ b/app/experimenter/nimbus-ui/src/gql/experiments.ts
@@ -214,14 +214,6 @@ export const GET_EXPERIMENTS_QUERY = gql`
         ownerEmail
         schema
       }
-      targetingConfig {
-        label
-        value
-        description
-        applicationValues
-        stickyRequired
-        isFirstRunRequired
-      }
       slug
       application
       firefoxMinVersion

--- a/app/experimenter/nimbus-ui/src/lib/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/lib/mocks.tsx
@@ -713,7 +713,6 @@ export function mockSingleDirectoryExperiment(
     publishStatus: NimbusExperimentPublishStatusEnum.IDLE,
     featureConfig: MOCK_CONFIG.allFeatureConfigs![0],
     featureConfigs: [MOCK_CONFIG.allFeatureConfigs![0]],
-    targetingConfig: [MOCK_CONFIG.targetingConfigs![0]],
     isEnrollmentPaused: false,
     isEnrollmentPausePending: false,
     proposedEnrollment: 7,

--- a/app/experimenter/nimbus-ui/src/types/getAllExperiments.ts
+++ b/app/experimenter/nimbus-ui/src/types/getAllExperiments.ts
@@ -23,15 +23,6 @@ export interface getAllExperiments_experiments_featureConfigs {
   schema: string | null;
 }
 
-export interface getAllExperiments_experiments_targetingConfig {
-  label: string | null;
-  value: string | null;
-  description: string | null;
-  applicationValues: (string | null)[] | null;
-  stickyRequired: boolean | null;
-  isFirstRunRequired: boolean | null;
-}
-
 export interface getAllExperiments_experiments_featureConfig {
   slug: string;
   name: string;
@@ -43,7 +34,6 @@ export interface getAllExperiments_experiments {
   name: string;
   owner: getAllExperiments_experiments_owner;
   featureConfigs: (getAllExperiments_experiments_featureConfigs | null)[] | null;
-  targetingConfig: (getAllExperiments_experiments_targetingConfig | null)[] | null;
   slug: string;
   application: NimbusExperimentApplicationEnum | null;
   firefoxMinVersion: NimbusExperimentFirefoxVersionEnum | null;


### PR DESCRIPTION
Reverts mozilla/experimenter#7988 because some of the targeting doesn't exist 
<img width="838" alt="image" src="https://user-images.githubusercontent.com/104033388/204893719-c726c70c-7bb9-47fd-bd0d-992195510afe.png">
