### PR TITLE
fix #7965 feat(nimbus): Prepare backend to support team

### DIFF
--- a/app/experimenter/docs/openapi-schema.json
+++ b/app/experimenter/docs/openapi-schema.json
@@ -3236,6 +3236,28 @@
               ]
             }
           },
+          "projects": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "integer"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "slug": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "id",
+                "name",
+                "slug"
+              ]
+            }
+          },
           "documentationLink": {
             "type": "array",
             "items": {
@@ -3468,6 +3490,7 @@
           "countries",
           "locales",
           "languages",
+          "projects",
           "documentationLink",
           "allFeatureConfigs",
           "firefoxVersions",

--- a/app/experimenter/docs/swagger-ui.html
+++ b/app/experimenter/docs/swagger-ui.html
@@ -3248,6 +3248,28 @@
               ]
             }
           },
+          "projects": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "integer"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "slug": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "id",
+                "name",
+                "slug"
+              ]
+            }
+          },
           "documentationLink": {
             "type": "array",
             "items": {
@@ -3480,6 +3502,7 @@
           "countries",
           "locales",
           "languages",
+          "projects",
           "documentationLink",
           "allFeatureConfigs",
           "firefoxVersions",

--- a/app/experimenter/experiments/api/v5/inputs.py
+++ b/app/experimenter/experiments/api/v5/inputs.py
@@ -91,6 +91,7 @@ class ExperimentInput(graphene.InputObjectType):
     countries = graphene.List(graphene.Int)
     locales = graphene.List(graphene.Int)
     languages = graphene.List(graphene.Int)
+    projects = graphene.List(graphene.Int)
     conclusion_recommendation = NimbusExperimentConclusionRecommendationEnum()
     takeaways_summary = graphene.String()
 

--- a/app/experimenter/experiments/api/v5/types.py
+++ b/app/experimenter/experiments/api/v5/types.py
@@ -95,6 +95,15 @@ class NimbusLocaleType(DjangoObjectType):
         model = Locale
 
 
+class NimbusProjectType(DjangoObjectType):
+    id = graphene.Int()
+    slug = graphene.String()
+    name = graphene.String()
+
+    class Meta:
+        model = Project
+
+
 class NimbusLanguageType(DjangoObjectType):
     id = graphene.Int()
     code = graphene.String()
@@ -257,6 +266,7 @@ class NimbusConfigurationType(graphene.ObjectType):
     hypothesis_default = graphene.String()
     locales = graphene.List(NimbusLocaleType)
     languages = graphene.List(NimbusLanguageType)
+    projects = graphene.List(NimbusProjectType)
     max_primary_outcomes = graphene.Int()
     outcomes = graphene.List(NimbusOutcomeType)
     owners = graphene.List(NimbusUserType)
@@ -353,6 +363,9 @@ class NimbusConfigurationType(graphene.ObjectType):
 
     def resolve_languages(root, info):
         return Language.objects.all().order_by("name")
+
+    def resolve_projects(root, info):
+        return Project.objects.all().order_by("name")
 
     def resolve_types(root, info):
         return root._text_choices_to_label_value_list(NimbusExperiment.Type)

--- a/app/experimenter/experiments/models.py
+++ b/app/experimenter/experiments/models.py
@@ -732,6 +732,7 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
         if self.application == self.Application.DESKTOP:
             cloned.locales.add(*self.locales.all())
         cloned.languages.add(*self.languages.all())
+        cloned.projects.add(*self.projects.all())
 
         if rollout_branch_slug:
             generate_nimbus_changelog(

--- a/app/experimenter/experiments/tests/api/v5/test_mutations.py
+++ b/app/experimenter/experiments/tests/api/v5/test_mutations.py
@@ -21,6 +21,7 @@ from experimenter.experiments.tests.factories import (
 )
 from experimenter.outcomes import Outcomes
 from experimenter.outcomes.tests import mock_valid_outcomes
+from experimenter.projects.tests.factories import ProjectFactory
 from experimenter.targeting.constants import TargetingConstants
 
 CREATE_EXPERIMENT_MUTATION = """\
@@ -657,6 +658,7 @@ class TestUpdateExperimentMutationSingleFeature(
         country = CountryFactory.create()
         locale = LocaleFactory.create()
         language = LanguageFactory.create()
+        project = ProjectFactory.create()
         experiment = NimbusExperimentFactory.create(
             status=NimbusExperiment.Status.DRAFT,
             channel=NimbusExperiment.Channel.NO_CHANNEL,
@@ -687,6 +689,7 @@ class TestUpdateExperimentMutationSingleFeature(
                     "countries": [country.id],
                     "locales": [locale.id],
                     "languages": [language.id],
+                    "projects": [project.id],
                     "isSticky": True,
                     "isFirstRun": True,
                 }
@@ -716,6 +719,7 @@ class TestUpdateExperimentMutationSingleFeature(
         self.assertEqual(list(experiment.countries.all()), [country])
         self.assertEqual(list(experiment.locales.all()), [locale])
         self.assertEqual(list(experiment.languages.all()), [language])
+        self.assertEqual(list(experiment.projects.all()), [project])
         self.assertTrue(experiment.is_sticky)
 
     def test_update_experiment_audience_error(self):

--- a/app/experimenter/experiments/tests/api/v5/test_queries.py
+++ b/app/experimenter/experiments/tests/api/v5/test_queries.py
@@ -14,6 +14,7 @@ from experimenter.experiments.tests.factories import (
     NimbusFeatureConfigFactory,
 )
 from experimenter.outcomes import Outcomes
+from experimenter.projects.models import Project
 
 
 class TestNimbusExperimentsQuery(GraphQLTestCase):
@@ -429,6 +430,34 @@ class TestNimbusExperimentsQuery(GraphQLTestCase):
             self.assertIn(
                 {"code": language.code, "name": language.name},
                 experiment_data["languages"],
+            )
+
+    def test_experiment_returns_project(self):
+        user_email = "user@example.com"
+        NimbusExperimentFactory.create(publish_status=NimbusExperiment.PublishStatus.IDLE)
+
+        response = self.query(
+            """
+            query {
+                experiments {
+
+                    projects {
+                        slug
+                        name
+                    }
+                }
+            }
+            """,
+            headers={settings.OPENIDC_EMAIL_HEADER: user_email},
+        )
+        self.assertEqual(response.status_code, 200)
+        content = json.loads(response.content)
+        experiment_data = content["data"]["experiments"][0]
+
+        for project in Project.objects.all():
+            self.assertIn(
+                {"slug": project.slug, "name": project.name},
+                experiment_data["projects"],
             )
 
 
@@ -1368,6 +1397,10 @@ class TestNimbusConfigQuery(GraphQLTestCase):
                         id
                         name
                     }
+                    projects {
+                        id
+                        name
+                    }
                     types {
                         label
                         value
@@ -1483,3 +1516,5 @@ class TestNimbusConfigQuery(GraphQLTestCase):
             self.assertIn(
                 {"code": language.code, "name": language.name}, config["languages"]
             )
+        for project in Project.objects.all():
+            self.assertIn({"id": project.id, "name": project.name}, config["projects"])

--- a/app/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_configuration_serializer.py
+++ b/app/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_configuration_serializer.py
@@ -11,6 +11,7 @@ from experimenter.experiments.tests.factories import (
     NimbusFeatureConfigFactory,
 )
 from experimenter.outcomes import Outcomes
+from experimenter.projects.models import Project
 
 
 class TestNimbusConfigurationSerializer(TestCase):
@@ -130,3 +131,9 @@ class TestNimbusConfigurationSerializer(TestCase):
             self.assertIn(
                 {"code": language.code, "name": language.name}, config["languages"]
             )
+
+        for project in Project.objects.all():
+            self.assertIn(
+                {"id": project.id, "name": project.name, "slug": project.slug},
+                [dict(i) for i in config["projects"]],
+            ),

--- a/app/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_experiment_serializer.py
+++ b/app/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_experiment_serializer.py
@@ -21,6 +21,7 @@ from experimenter.experiments.tests.factories import (
 from experimenter.openidc.tests.factories import UserFactory
 from experimenter.outcomes import Outcomes
 from experimenter.outcomes.tests import mock_valid_outcomes
+from experimenter.projects.tests.factories import ProjectFactory
 from experimenter.targeting.constants import TargetingConstants
 
 
@@ -158,6 +159,7 @@ class TestNimbusExperimentSerializer(TestCase):
             "countries": [],
             "locales": [],
             "languages": [],
+            "projects": [],
         }
 
         serializer = NimbusExperimentSerializer(
@@ -192,6 +194,7 @@ class TestNimbusExperimentSerializer(TestCase):
         self.assertEqual(list(experiment.countries.all()), [])
         self.assertEqual(list(experiment.locales.all()), [])
         self.assertEqual(list(experiment.languages.all()), [])
+        self.assertEqual(list(experiment.projects.all()), [])
 
     def test_serializer_rejects_bad_name(self):
         data = {
@@ -456,6 +459,7 @@ class TestNimbusExperimentSerializer(TestCase):
         country = CountryFactory.create()
         locale = LocaleFactory.create()
         language = LanguageFactory.create()
+        project = ProjectFactory.create()
 
         experiment = NimbusExperimentFactory(
             channel=NimbusExperiment.Channel.NO_CHANNEL,
@@ -482,6 +486,7 @@ class TestNimbusExperimentSerializer(TestCase):
                 "countries": [country.id],
                 "locales": [locale.id],
                 "languages": [language.id],
+                "projects": [project.id],
                 "is_sticky": True,
             },
             context={"user": self.user},
@@ -505,6 +510,7 @@ class TestNimbusExperimentSerializer(TestCase):
         self.assertEqual(list(experiment.countries.all()), [country])
         self.assertEqual(list(experiment.locales.all()), [locale])
         self.assertEqual(list(experiment.languages.all()), [language])
+        self.assertEqual(list(experiment.projects.all()), [project])
         self.assertTrue(experiment.is_sticky)
 
     @parameterized.expand(

--- a/app/experimenter/experiments/tests/test_models.py
+++ b/app/experimenter/experiments/tests/test_models.py
@@ -562,7 +562,7 @@ class TestNimbusExperiment(TestCase):
         )
         JEXLParser().parse(experiment.targeting)
 
-    def test_with_projects(self):
+    def test_targeting_with_projects(self):
 
         project_mdn = ProjectFactory.create(slug="mdn")
 

--- a/app/experimenter/nimbus-ui/schema.graphql
+++ b/app/experimenter/nimbus-ui/schema.graphql
@@ -79,6 +79,7 @@ input ExperimentInput {
   countries: [Int]
   locales: [Int]
   languages: [Int]
+  projects: [Int]
   conclusionRecommendation: NimbusExperimentConclusionRecommendationEnum
   takeawaysSummary: String
 }
@@ -192,6 +193,7 @@ type NimbusConfigurationType {
   hypothesisDefault: String
   locales: [NimbusLocaleType]
   languages: [NimbusLanguageType]
+  projects: [NimbusProjectType]
   maxPrimaryOutcomes: Int
   outcomes: [NimbusOutcomeType]
   owners: [NimbusUserType]
@@ -547,6 +549,13 @@ type NimbusOutcomeType {
   description: String
   isDefault: Boolean
   metrics: [NimbusOutcomeMetricType]
+}
+
+type NimbusProjectType {
+  id: Int
+  name: String
+  slug: String
+  nimbusexperimentSet: [NimbusExperimentType!]!
 }
 
 type NimbusReviewType {

--- a/app/experimenter/nimbus-ui/src/gql/config.ts
+++ b/app/experimenter/nimbus-ui/src/gql/config.ts
@@ -81,6 +81,10 @@ export const GET_CONFIG_QUERY = gql`
         id
         name
       }
+      projects {
+        id
+        name
+      }
       types {
         label
         value

--- a/app/experimenter/nimbus-ui/src/gql/experiments.ts
+++ b/app/experimenter/nimbus-ui/src/gql/experiments.ts
@@ -192,6 +192,10 @@ export const GET_EXPERIMENT_QUERY = gql`
         id
         name
       }
+      projects {
+        id
+        name
+      }
     }
   }
 `;

--- a/app/experimenter/nimbus-ui/src/lib/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/lib/mocks.tsx
@@ -593,7 +593,7 @@ export const MOCK_EXPERIMENT: Partial<getExperiment["experimentBySlug"]> = {
   locales: [{ name: "Quebecois", id: 1 }],
   countries: [{ name: "Canada", id: 1 }],
   languages: [{ name: "English", id: 1 }],
-  projects: [{ name: "Pockets", id: 1 }],
+  projects: [{ name: "Pocket", id: 1 }],
 };
 
 export function mockExperiment<

--- a/app/experimenter/nimbus-ui/src/lib/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/lib/mocks.tsx
@@ -395,7 +395,7 @@ export const MOCK_CONFIG: getConfig_nimbusConfig = {
   ],
   projects: [
     {
-      name: "Pockets",
+      name: "Pocket",
       id: 1,
     },
     {

--- a/app/experimenter/nimbus-ui/src/lib/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/lib/mocks.tsx
@@ -393,6 +393,20 @@ export const MOCK_CONFIG: getConfig_nimbusConfig = {
       id: 3,
     },
   ],
+  projects: [
+    {
+      name: "Pockets",
+      id: 1,
+    },
+    {
+      name: "Mdn",
+      id: 2,
+    },
+    {
+      name: "VPN",
+      id: 3,
+    },
+  ],
 };
 
 // Disabling this rule for now because we'll eventually
@@ -579,6 +593,7 @@ export const MOCK_EXPERIMENT: Partial<getExperiment["experimentBySlug"]> = {
   locales: [{ name: "Quebecois", id: 1 }],
   countries: [{ name: "Canada", id: 1 }],
   languages: [{ name: "English", id: 1 }],
+  projects: [{ name: "Pockets", id: 1 }],
 };
 
 export function mockExperiment<

--- a/app/experimenter/nimbus-ui/src/types/getConfig.ts
+++ b/app/experimenter/nimbus-ui/src/types/getConfig.ts
@@ -98,6 +98,11 @@ export interface getConfig_nimbusConfig_languages {
   name: string | null;
 }
 
+export interface getConfig_nimbusConfig_projects {
+  id: number | null;
+  name: string | null;
+}
+
 export interface getConfig_nimbusConfig_types {
   label: string | null;
   value: string | null;
@@ -119,6 +124,7 @@ export interface getConfig_nimbusConfig {
   locales: (getConfig_nimbusConfig_locales | null)[] | null;
   countries: (getConfig_nimbusConfig_countries | null)[] | null;
   languages: (getConfig_nimbusConfig_languages | null)[] | null;
+  projects: (getConfig_nimbusConfig_projects | null)[] | null;
   types: (getConfig_nimbusConfig_types | null)[] | null;
 }
 

--- a/app/experimenter/nimbus-ui/src/types/getExperiment.ts
+++ b/app/experimenter/nimbus-ui/src/types/getExperiment.ts
@@ -133,6 +133,11 @@ export interface getExperiment_experimentBySlug_languages {
   name: string | null;
 }
 
+export interface getExperiment_experimentBySlug_projects {
+  id: number | null;
+  name: string;
+}
+
 export interface getExperiment_experimentBySlug {
   id: number | null;
   isRollout: boolean | null;
@@ -196,6 +201,7 @@ export interface getExperiment_experimentBySlug {
   locales: getExperiment_experimentBySlug_locales[];
   countries: getExperiment_experimentBySlug_countries[];
   languages: getExperiment_experimentBySlug_languages[];
+  projects: getExperiment_experimentBySlug_projects[];
 }
 
 export interface getExperiment {

--- a/app/experimenter/nimbus-ui/src/types/globalTypes.ts
+++ b/app/experimenter/nimbus-ui/src/types/globalTypes.ts
@@ -263,6 +263,7 @@ export interface ExperimentInput {
   countries?: (number | null)[] | null;
   locales?: (number | null)[] | null;
   languages?: (number | null)[] | null;
+  projects?: (number | null)[] | null;
   conclusionRecommendation?: NimbusExperimentConclusionRecommendationEnum | null;
   takeawaysSummary?: string | null;
 }


### PR DESCRIPTION
Because

* We want to allow users to select the Project team and link to experiments

This commit

* Add the capability to support choosing projects option in v5 Api- get experiment by slug and get nimbus config

screenshot of `an experiment by slug api`

<img width="838" alt="image" src="https://user-images.githubusercontent.com/104033388/204918992-2b3e40fc-37ae-4e23-abdc-4afc3d3ffdfa.png">

screenshot of `nimbus config api`

<img width="838" alt="image" src="https://user-images.githubusercontent.com/104033388/204919015-f3592dd7-9e7c-4f29-8988-3417a977c6b5.png">


fix #7965 