### PR TITLE
Add targeting for Sponsored TopSites on the newtab

### DIFF
--- a/app/experimenter/targeting/constants.py
+++ b/app/experimenter/targeting/constants.py
@@ -792,7 +792,9 @@ NEWTAB_SPONSORED_TOPSITES_ENABLED = NimbusTargetingConfig(
     name="Newtab has Sponsored TopSites enabled ",
     slug="newtab_sponsored_topsites_enabled",
     description="Users with Sponsored TopSites enabled on the newtab",
-    targeting="'browser.newtabpage.activity-stream.showSponsoredTopSites'|preferenceValue",
+    targeting="""
+        'browser.newtabpage.activity-stream.showSponsoredTopSites'|preferenceValue
+    """,
     desktop_telemetry="",
     sticky_required=False,
     is_first_run_required=False,

--- a/app/experimenter/targeting/constants.py
+++ b/app/experimenter/targeting/constants.py
@@ -788,6 +788,17 @@ WINDOWS_10_PLUS_BACKGROUND_TASK_NOTIFICATION_ = NimbusTargetingConfig(
     application_choice_names=(Application.DESKTOP.name,),
 )
 
+NEWTAB_SPONSORED_TOPSITES_ENABLED = NimbusTargetingConfig(
+    name="Newtab has Sponsored TopSites enabled ",
+    slug="newtab_sponsored_topsites_enabled",
+    description="Users with Sponsored TopSites enabled on the newtab",
+    targeting="'browser.newtabpage.activity-stream.showSponsoredTopSites'|preferenceValue",
+    desktop_telemetry="",
+    sticky_required=False,
+    is_first_run_required=False,
+    application_choice_names=(Application.DESKTOP.name,),
+)
+
 
 class TargetingConstants:
     TARGETING_VERSION = "version|versionCompare('{version}') >= 0"


### PR DESCRIPTION
This targeting is created for this [experiment](https://experimenter.services.mozilla.com/nimbus/sponsored-topsites-via-pocket).