### PR TITLE
fix #7966 feat(nimbus): Option to select team projects

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/FormOverview/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/FormOverview/index.test.tsx
@@ -6,7 +6,7 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import React from "react";
 import { DOCUMENTATION_LINKS_TOOLTIP } from ".";
 import { FIELD_MESSAGES, RISK_QUESTIONS } from "../../lib/constants";
-import { mockExperimentQuery } from "../../lib/mocks";
+import { mockExperimentQuery, MOCK_CONFIG } from "../../lib/mocks";
 import { assertSerializerMessages } from "../../lib/test-utils";
 import { optionalBoolString } from "../../lib/utils";
 import { NimbusDocumentationLinkTitle } from "../../types/globalTypes";
@@ -176,6 +176,7 @@ describe("FormOverview", () => {
       riskBrand: optionalBoolString(experiment.riskBrand),
       riskRevenue: optionalBoolString(experiment.riskRevenue),
       riskPartnerRelated: optionalBoolString(experiment.riskPartnerRelated),
+      projects: experiment.projects.map((v) => "" + v.id),
     };
 
     const { container } = render(<Subject {...{ onSubmit, experiment }} />);
@@ -224,6 +225,85 @@ describe("FormOverview", () => {
         [expected, true],
       ]);
     });
+  });
+
+  it("Renders selected single project value", async () => {
+    const { experiment } = mockExperimentQuery("boo", {
+      projects: [
+        {
+          name: "Pocket",
+          id: 1,
+        },
+      ],
+    });
+
+    const config = {
+      ...MOCK_CONFIG,
+      projects: [
+        {
+          name: "Pocket",
+          id: 1,
+        },
+        {
+          name: "Mdn",
+          id: 2,
+        },
+        {
+          name: "VPN",
+          id: 3,
+        },
+      ],
+    };
+
+    const onSubmit = jest.fn();
+    render(<Subject {...{ onSubmit, experiment, config }} />);
+
+    const projects = await screen.findByTestId("projects");
+    const display = projects.children[0];
+    expect(display.textContent).toBe("Team Projects");
+    expect(projects).toHaveTextContent("Pocket");
+  });
+
+  it("Renders selected multiple projects value", async () => {
+    const { experiment } = mockExperimentQuery("boo", {
+      projects: [
+        {
+          name: "Pocket",
+          id: 1,
+        },
+        {
+          name: "VPN",
+          id: 3,
+        },
+      ],
+    });
+
+    const config = {
+      ...MOCK_CONFIG,
+      projects: [
+        {
+          name: "Pocket",
+          id: 1,
+        },
+        {
+          name: "Mdn",
+          id: 2,
+        },
+        {
+          name: "VPN",
+          id: 3,
+        },
+      ],
+    };
+
+    const onSubmit = jest.fn();
+    render(<Subject {...{ onSubmit, experiment, config }} />);
+
+    const projects = await screen.findByTestId("projects");
+    const display = projects.children[0];
+    expect(display.textContent).toBe("Team Projects");
+    expect(projects).toHaveTextContent("Pocket");
+    expect(projects).toHaveTextContent("VPN");
   });
 
   it("with missing public description, still allows submit", async () => {

--- a/app/experimenter/nimbus-ui/src/components/FormOverview/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/FormOverview/index.tsx
@@ -19,6 +19,7 @@ import {
   RISK_QUESTIONS,
 } from "../../lib/constants";
 import { optionalBoolString } from "../../lib/utils";
+import { getConfig_nimbusConfig } from "../../types/getConfig";
 import { getExperiment } from "../../types/getExperiment";
 import InputRadios from "../InputRadios";
 import LinkExternal from "../LinkExternal";
@@ -42,10 +43,6 @@ type FormOverviewProps = {
 
 export const DOCUMENTATION_LINKS_TOOLTIP =
   "Any additional links you would like to add, for example, Jira DS Ticket, Jira QA ticket, or experiment brief.";
-type SelectIdItems = {
-  id: number;
-  name: string;
-}[];
 export const overviewFieldNames = [
   "name",
   "hypothesis",
@@ -58,10 +55,10 @@ export const overviewFieldNames = [
   "projects",
 ] as const;
 
-const selectOptions = (items: SelectIdItems) =>
+const selectOptions = (items: getConfig_nimbusConfig["projects"]) =>
   items?.map((item) => ({
-    label: item.name!,
-    value: item.id!,
+    label: item?.name!,
+    value: item?.id!,
   }));
 
 type OverviewFieldName = typeof overviewFieldNames[number];
@@ -89,7 +86,9 @@ const FormOverview = ({
     riskBrand: optionalBoolString(experiment?.riskBrand),
     riskRevenue: optionalBoolString(experiment?.riskRevenue),
     riskPartnerRelated: optionalBoolString(experiment?.riskPartnerRelated),
-    projects: selectOptions(experiment?.projects as SelectIdItems),
+    projects: selectOptions(
+      experiment?.projects as getConfig_nimbusConfig["projects"],
+    ),
   };
 
   const {
@@ -249,7 +248,9 @@ const FormOverview = ({
               placeholder="Select Team..."
               isMulti
               {...formSelectAttrs("projects", setProjects)}
-              options={selectOptions(config.projects as SelectIdItems)}
+              options={selectOptions(
+                config.projects as getConfig_nimbusConfig["projects"],
+              )}
             />
             <FormErrors name="projects" />
           </Form.Group>

--- a/app/experimenter/nimbus-ui/src/components/FormOverview/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/FormOverview/index.tsx
@@ -19,7 +19,7 @@ import {
   RISK_QUESTIONS,
 } from "../../lib/constants";
 import { optionalBoolString } from "../../lib/utils";
-import { getConfig_nimbusConfig } from "../../types/getConfig";
+import { getConfig_nimbusConfig_projects } from "../../types/getConfig";
 import { getExperiment } from "../../types/getExperiment";
 import InputRadios from "../InputRadios";
 import LinkExternal from "../LinkExternal";
@@ -40,6 +40,7 @@ type FormOverviewProps = {
   onSubmit: (data: Record<string, any>, next: boolean) => void;
   onCancel?: (ev: React.FormEvent) => void;
 };
+type SelectIdItems = (getConfig_nimbusConfig_projects | null)[];
 
 export const DOCUMENTATION_LINKS_TOOLTIP =
   "Any additional links you would like to add, for example, Jira DS Ticket, Jira QA ticket, or experiment brief.";
@@ -55,7 +56,7 @@ export const overviewFieldNames = [
   "projects",
 ] as const;
 
-const selectOptions = (items: getConfig_nimbusConfig["projects"]) =>
+const selectOptions = (items: SelectIdItems) =>
   items?.map((item) => ({
     label: item?.name!,
     value: item?.id!,
@@ -86,9 +87,7 @@ const FormOverview = ({
     riskBrand: optionalBoolString(experiment?.riskBrand),
     riskRevenue: optionalBoolString(experiment?.riskRevenue),
     riskPartnerRelated: optionalBoolString(experiment?.riskPartnerRelated),
-    projects: selectOptions(
-      experiment?.projects as getConfig_nimbusConfig["projects"],
-    ),
+    projects: selectOptions(experiment?.projects as SelectIdItems),
   };
 
   const {
@@ -248,9 +247,7 @@ const FormOverview = ({
               placeholder="Select Team..."
               isMulti
               {...formSelectAttrs("projects", setProjects)}
-              options={selectOptions(
-                config.projects as getConfig_nimbusConfig["projects"],
-              )}
+              options={selectOptions(config.projects as SelectIdItems)}
             />
             <FormErrors name="projects" />
           </Form.Group>

--- a/app/experimenter/nimbus-ui/src/components/FormOverview/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/components/FormOverview/mocks.tsx
@@ -4,7 +4,8 @@
 
 import React, { useState } from "react";
 import FormOverview from ".";
-import { MockedCache } from "../../lib/mocks";
+import { MockedCache, MOCK_CONFIG } from "../../lib/mocks";
+import { getConfig_nimbusConfig } from "../../types/getConfig";
 
 export const Subject = ({
   isLoading = false,
@@ -13,11 +14,14 @@ export const Subject = ({
   onSubmit = () => {},
   onCancel,
   experiment,
-}: Partial<React.ComponentProps<typeof FormOverview>>) => {
+  config = MOCK_CONFIG,
+}: {
+  config?: getConfig_nimbusConfig;
+} & Partial<React.ComponentProps<typeof FormOverview>>) => {
   const [submitErrorsDefault, setSubmitErrors] =
     useState<Record<string, any>>(submitErrors);
   return (
-    <MockedCache>
+    <MockedCache {...{ config }}>
       <FormOverview
         submitErrors={submitErrorsDefault}
         {...{

--- a/app/experimenter/nimbus-ui/src/components/PageEditOverview/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditOverview/index.test.tsx
@@ -57,6 +57,7 @@ describe("PageEditOverview", () => {
       riskBrand: experiment.riskBrand!,
       riskRevenue: experiment.riskRevenue!,
       riskPartnerRelated: experiment.riskPartnerRelated!,
+      projects: String(experiment.projects.map((v) => "" + v.id)),
     };
     mockSubmitData = {
       ...mockMutationData,

--- a/app/experimenter/nimbus-ui/src/components/PageEditOverview/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditOverview/index.tsx
@@ -44,6 +44,7 @@ const PageEditOverview: React.FunctionComponent<PageEditOverviewProps> = () => {
         riskBrand,
         riskRevenue,
         riskPartnerRelated,
+        projects,
       }: Record<string, any>,
       next: boolean,
     ) => {
@@ -57,6 +58,7 @@ const PageEditOverview: React.FunctionComponent<PageEditOverviewProps> = () => {
               hypothesis,
               publicDescription,
               documentationLinks,
+              projects,
               riskBrand: optionalStringBool(riskBrand),
               riskRevenue: optionalStringBool(riskRevenue),
               riskPartnerRelated: optionalStringBool(riskPartnerRelated),

--- a/app/experimenter/nimbus-ui/src/hooks/useCommonForm/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/hooks/useCommonForm/index.test.tsx
@@ -130,6 +130,7 @@ describe("hooks/useCommonForm", () => {
               "riskBrand",
               "riskRevenue",
               "riskPartnerRelated",
+              "projects",
             ].includes(name)
           ) {
             expect(

--- a/app/experimenter/nimbus-ui/src/types/getConfig.ts
+++ b/app/experimenter/nimbus-ui/src/types/getConfig.ts
@@ -104,7 +104,6 @@ export interface getConfig_nimbusConfig_projects {
   id: number | null;
   name: string | null;
 }
-[];
 
 export interface getConfig_nimbusConfig_types {
   label: string | null;

--- a/app/experimenter/nimbus-ui/src/types/getConfig.ts
+++ b/app/experimenter/nimbus-ui/src/types/getConfig.ts
@@ -31,7 +31,9 @@ export interface getConfig_nimbusConfig_applicationConfigs_channels {
 
 export interface getConfig_nimbusConfig_applicationConfigs {
   application: NimbusExperimentApplicationEnum | null;
-  channels: (getConfig_nimbusConfig_applicationConfigs_channels | null)[] | null;
+  channels:
+    | (getConfig_nimbusConfig_applicationConfigs_channels | null)[]
+    | null;
 }
 
 export interface getConfig_nimbusConfig_allFeatureConfigs {
@@ -102,6 +104,7 @@ export interface getConfig_nimbusConfig_projects {
   id: number | null;
   name: string | null;
 }
+[];
 
 export interface getConfig_nimbusConfig_types {
   label: string | null;
@@ -111,8 +114,12 @@ export interface getConfig_nimbusConfig_types {
 export interface getConfig_nimbusConfig {
   applications: (getConfig_nimbusConfig_applications | null)[] | null;
   channels: (getConfig_nimbusConfig_channels | null)[] | null;
-  conclusionRecommendations: (getConfig_nimbusConfig_conclusionRecommendations | null)[] | null;
-  applicationConfigs: (getConfig_nimbusConfig_applicationConfigs | null)[] | null;
+  conclusionRecommendations:
+    | (getConfig_nimbusConfig_conclusionRecommendations | null)[]
+    | null;
+  applicationConfigs:
+    | (getConfig_nimbusConfig_applicationConfigs | null)[]
+    | null;
   allFeatureConfigs: (getConfig_nimbusConfig_allFeatureConfigs | null)[] | null;
   firefoxVersions: (getConfig_nimbusConfig_firefoxVersions | null)[] | null;
   outcomes: (getConfig_nimbusConfig_outcomes | null)[] | null;


### PR DESCRIPTION
Because

* We want to map experiments to the project/team 

This commit

* Allows the option to `select team` on the `Overview page` and test cases to verify changes
<img width="1229" alt="Screenshot 2022-12-05 at 12 53 31 PM" src="https://user-images.githubusercontent.com/104033388/205740978-9b49586e-2167-49d9-a7f0-2bc2b6ad5e57.png">
<img width="1229" alt="Screenshot 2022-12-05 at 12 53 37 PM" src="https://user-images.githubusercontent.com/104033388/205740980-2d2f8671-5a9a-4a73-8ed7-0a4e05f3994e.png">

fix #7966 
