### PR TITLE
fix #7967 feat(nimbus): Show teams on summary page

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/Summary/TableOverview/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/TableOverview/index.test.tsx
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import React from "react";
 import TableOverview from ".";
 import {
@@ -28,6 +28,9 @@ describe("TableOverview", () => {
     );
     expect(screen.getByTestId("experiment-hypothesis")).toHaveTextContent(
       "Realize material say pretty.",
+    );
+    expect(screen.getByTestId("experiment-team-projects")).toHaveTextContent(
+      "Pocket",
     );
   });
 
@@ -141,6 +144,39 @@ describe("TableOverview", () => {
       render(<Subject {...{ experiment }} />);
       expect(
         screen.getByTestId("experiment-targeting-config"),
+      ).toHaveTextContent("Not set");
+    });
+  });
+
+  describe("renders 'Team Projects' row as expected", () => {
+    it("with one team project", () => {
+      const { experiment } = mockExperimentQuery("demo-slug");
+      render(<Subject {...{ experiment }} />);
+      expect(screen.getByTestId("experiment-team-projects")).toHaveTextContent(
+        "Pocket",
+      );
+    });
+    it("with multiple projects", () => {
+      const { experiment } = mockExperimentQuery("demo-slug", {
+        projects: [
+          { id: 1, name: "Pocket" },
+          { id: 2, name: "VPN" },
+        ],
+      });
+      render(<Subject {...{ experiment }} />);
+      experiment.projects.forEach((team) =>
+        within(screen.getByTestId("experiment-team-projects")).findByText(
+          team.name,
+        ),
+      );
+    });
+    it("when not set", () => {
+      const { experiment } = mockExperimentQuery("demo-slug", {
+        projects: [],
+      });
+      render(<Subject {...{ experiment }} />);
+      expect(
+        screen.queryByTestId("experiment-team-projects"),
       ).toHaveTextContent("Not set");
     });
   });

--- a/app/experimenter/nimbus-ui/src/components/Summary/TableOverview/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/TableOverview/index.tsx
@@ -112,6 +112,21 @@ const TableOverview = ({ experiment }: TableOverviewProps) => {
                 </td>
               </tr>
             )}
+
+            <tr>
+              <th>Team Projects</th>
+              <td colSpan={3} data-testid="experiment-team-projects">
+                {experiment.projects.length > 0 ? (
+                  <ul className="list-unstyled mb-0">
+                    {experiment.projects.map((l) => (
+                      <li key={l.id}>{l.name}</li>
+                    ))}
+                  </ul>
+                ) : (
+                  <NotSet />
+                )}
+              </td>
+            </tr>
           </tbody>
         </Table>
       </Card.Body>


### PR DESCRIPTION
Because

* We want to show the selected team on the summary page

This commit

* Add the row to show the selected team on the Summary page
<img width="1241" alt="Screenshot 2022-12-06 at 12 23 48 PM" src="https://user-images.githubusercontent.com/104033388/206015244-03d8fd79-1929-465b-82b5-e6764b57958b.png">
<img width="1248" alt="Screenshot 2022-12-06 at 12 24 14 PM" src="https://user-images.githubusercontent.com/104033388/206015250-ef5f3505-9bd9-4cac-80e6-29060c8ce61b.png">

fix #7967 