### PR TITLE
fixes #8032 test(nimbus): Moves the browser actions of the pref-flip integration test to a specific file

### DIFF
--- a/app/tests/integration/nimbus/pages/browser/__init__.py
+++ b/app/tests/integration/nimbus/pages/browser/__init__.py
@@ -29,7 +29,7 @@ class AboutConfig(Page):
         self.wait.until(EC.presence_of_element_located(self._search_bar_locator))
         return self
 
-    def wait_for_pref_flip(self, pref=None, pref_value=None):
+    def wait_for_pref_flip(self, pref, pref_value):
         timeout = time.time() + 60 * 5
         while time.time() < timeout:
             try:
@@ -37,7 +37,7 @@ class AboutConfig(Page):
                 search_bar.send_keys(pref)
                 self.wait.until(EC.presence_of_element_located(self._row_locator))
                 elements = self.find_elements(*self._row_locator)
-                assert pref in [element.text for element in elements]
+                assert pref_value in [element.text for element in elements]
             except Exception:
                 time.sleep(2)
                 return False

--- a/app/tests/integration/nimbus/pages/browser/__init__.py
+++ b/app/tests/integration/nimbus/pages/browser/__init__.py
@@ -7,7 +7,6 @@ from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.ui import WebDriverWait
 
 
-
 class Browser:
     def execute_script(selenium, *args, script=None, context=None):
         if "chrome" in context:
@@ -15,6 +14,7 @@ class Browser:
                 return selenium.execute_script(script, *args)
         else:
             return selenium.execute_script
+
 
 class AboutConfig(Page):
 

--- a/app/tests/integration/nimbus/pages/browser/__init__.py
+++ b/app/tests/integration/nimbus/pages/browser/__init__.py
@@ -4,7 +4,6 @@ import time
 from pypom import Page
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as EC
-from selenium.webdriver.support.ui import WebDriverWait
 
 
 class Browser:

--- a/app/tests/integration/nimbus/pages/browser/__init__.py
+++ b/app/tests/integration/nimbus/pages/browser/__init__.py
@@ -1,4 +1,11 @@
 """Browser Model"""
+import time
+
+from pypom import Page
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.webdriver.support.ui import WebDriverWait
+
 
 
 class Browser:
@@ -8,3 +15,32 @@ class Browser:
                 return selenium.execute_script(script, *args)
         else:
             return selenium.execute_script
+
+class AboutConfig(Page):
+
+    URL_TEMPLATE = "about:config"
+
+    _search_bar_locator = (By.ID, "about-config-search")
+    _row_locator = (By.CSS_SELECTOR, "tr > td > span > span")
+
+    def __init__(self, selenium, **kwargs):
+        super().__init__(selenium, timeout=80, **kwargs)
+
+    def wait_for_page_to_load(self):
+        self.wait.until(EC.presence_of_element_located(self._search_bar_locator))
+        return self
+
+    def wait_for_pref_flip(self, pref=None):
+        timeout = time.time() + 60 * 5
+        while time.time() < timeout:
+            try:
+                search_bar = self.find_element(*self._search_bar_locator)
+                search_bar.send_keys("nimbus.qa.pref-1")
+                self.wait.until(EC.presence_of_element_located(self._row_locator))
+                elements = self.find_elements(*self._row_locator)
+                assert pref in [element.text for element in elements]
+            except Exception:
+                time.sleep(2)
+                return False
+            else:
+                return True

--- a/app/tests/integration/nimbus/pages/browser/__init__.py
+++ b/app/tests/integration/nimbus/pages/browser/__init__.py
@@ -29,12 +29,12 @@ class AboutConfig(Page):
         self.wait.until(EC.presence_of_element_located(self._search_bar_locator))
         return self
 
-    def wait_for_pref_flip(self, pref=None):
+    def wait_for_pref_flip(self, pref=None, pref_value=None):
         timeout = time.time() + 60 * 5
         while time.time() < timeout:
             try:
                 search_bar = self.find_element(*self._search_bar_locator)
-                search_bar.send_keys("nimbus.qa.pref-1")
+                search_bar.send_keys(pref)
                 self.wait.until(EC.presence_of_element_located(self._row_locator))
                 elements = self.find_elements(*self._row_locator)
                 assert pref in [element.text for element in elements]

--- a/app/tests/integration/nimbus/test_desktop_client_integrations.py
+++ b/app/tests/integration/nimbus/test_desktop_client_integrations.py
@@ -215,31 +215,6 @@ def test_check_telemetry_pref_flip(
     check_ping_for_experiment,
     telemetry_event_check,
 ):
-    # _row_locator = (By.CSS_SELECTOR, "tr > td > span > span")
-    # _search_bar_locator = (By.ID, "about-config-search")
-    # wait = WebDriverWait(selenium, 60)
-
-    # def wait_function(selenium, wait_string):
-    #     """This function refreshes about:config waiting for the pref to flip"""
-
-    #     def _wait_function(selenium=selenium, wait_string=wait_string):
-    #         try:
-    #             selenium.get("about:config")
-    #             search_bar = wait.until(
-    #                 EC.presence_of_element_located(_search_bar_locator)
-    #             )
-    #             search_bar.send_keys("nimbus.qa.pref-1")
-    #             wait.until(EC.presence_of_element_located(_row_locator))
-    #             elements = selenium.find_elements(*_row_locator)
-    #             assert wait_string in [element.text for element in elements]
-    #         except Exception:
-    #             time.sleep(2)
-    #             return False
-    #         else:
-    #             return True
-
-    #     return _wait_function
-
     about_config = AboutConfig(selenium)
 
     requests.delete("http://ping-server:5000/pings")

--- a/app/tests/integration/nimbus/test_desktop_client_integrations.py
+++ b/app/tests/integration/nimbus/test_desktop_client_integrations.py
@@ -6,9 +6,6 @@ import requests
 from nimbus.pages.browser import AboutConfig
 from nimbus.pages.experimenter.summary import SummaryPage
 from nimbus.utils import helpers
-from selenium.webdriver.common.by import By
-from selenium.webdriver.support import expected_conditions as EC
-from selenium.webdriver.support.ui import WebDriverWait
 
 
 @pytest.fixture

--- a/app/tests/integration/nimbus/test_desktop_client_integrations.py
+++ b/app/tests/integration/nimbus/test_desktop_client_integrations.py
@@ -243,7 +243,7 @@ def test_check_telemetry_pref_flip(
     )
 
     about_config = about_config.open().wait_for_page_to_load()
-    about_config.wait_for_pref_flip("default")
+    about_config.wait_for_pref_flip("nimbus.qa.pref-1", "default")
 
     summary = SummaryPage(selenium, urljoin(base_url, experiment_slug)).open()
     summary.launch_and_approve()
@@ -268,7 +268,7 @@ def test_check_telemetry_pref_flip(
     assert check_ping_for_experiment(experiment_slug), "Experiment not found in telemetry"
 
     about_config = about_config.open().wait_for_page_to_load()
-    about_config.wait_for_pref_flip("test_string_automation")
+    about_config.wait_for_pref_flip("nimbus.qa.pref-1", "test_string_automation")
 
     # unenroll
     summary = SummaryPage(selenium, urljoin(base_url, experiment_slug)).open()
@@ -288,4 +288,4 @@ def test_check_telemetry_pref_flip(
             assert False, "Experiment unenrollment was never seen in ping Data"
 
     about_config = about_config.open().wait_for_page_to_load()
-    about_config.wait_for_pref_flip("default")
+    about_config.wait_for_pref_flip("nimbus.qa.pref-1", "default")


### PR DESCRIPTION

Because:
* The pref flip integration test included browser steps directly in the test

This Commit:
* Moves them so they're more usable in other tests