### PR TITLE
fix #8051 bug(project): update node version

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -26,7 +26,7 @@ RUN chmod +x /app/bin/wait-for-it.sh
 
 
 # Install nvm with node and npm
-ENV NODE_VERSION=14.17.1
+ENV NODE_VERSION=16.19.0
 RUN curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.35.3/install.sh | bash
 ENV NVM_DIR=/root/.nvm
 RUN . "$NVM_DIR/nvm.sh" && nvm install ${NODE_VERSION}

--- a/app/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/index.test.tsx
@@ -1142,7 +1142,7 @@ describe("FormAudience", () => {
     });
 
     expect(
-      within(screen.queryByTestId("audience-values") as HTMLElement)
+      within(screen.queryByTestId("population-percent-top-row") as HTMLElement)
         .findByText(expectedValue, {
           selector: `[data-for={populationPercent}]`,
         })


### PR DESCRIPTION
Because

* We recently updated to Python 3.11
* This passed on CI but was broken locally on arm64 macs
* It seems to be related to the node-gyp package

This commit

* Updates to node 16.19.0 which updates node-gyp to support Python 3.11
* Fixes one broken test that was not passing after the update