### PR TITLE
For #7983 test(nimbus): Add serializer tests for publish_status and status

### DIFF
--- a/app/experimenter/experiments/api/v5/serializers.py
+++ b/app/experimenter/experiments/api/v5/serializers.py
@@ -580,6 +580,11 @@ class NimbusExperimentDocumentationLinkMixin:
 
 
 class NimbusStatusValidationMixin:
+    """
+    This will only validate certain statuses, and the validation does not
+    cover status transitions made by Remote Settings.
+    """
+
     def validate(self, data):
         data = super().validate(data)
 
@@ -621,12 +626,19 @@ class NimbusStatusValidationMixin:
 
 
 class NimbusStatusTransitionValidator:
+    """
+    This will only validate certain status transitions, and the validation does not
+    cover status transitions made by Remote Settings.
+    """
+
     requires_context = True
 
     def __init__(self, transitions):
         self.transitions = transitions
 
     def __call__(self, value, serializer_field):
+        """Validates using `NimbusConstants.VALID_STATUS_TRANSITIONS"""
+
         field_name = serializer_field.source_attrs[-1]
         instance = getattr(serializer_field.parent, "instance", None)
 
@@ -877,6 +889,9 @@ class NimbusExperimentSerializer(
         return value
 
     def validate_status_next(self, value):
+        """This validation for `status_next` does not cover any
+        transitions made by Remote Settings."""
+
         valid_status_next = NimbusExperiment.VALID_STATUS_NEXT_VALUES.get(
             self.instance.status, ()
         )

--- a/app/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_status_next_transition_validator.py
+++ b/app/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_status_next_transition_validator.py
@@ -56,12 +56,8 @@ class TestNimbusStatusNextTransitionValidator(TestCase):
             ],
         ]
     )
-    def test_update_status_errors_for_status_next_live(
-        self, status, valid
-    ):
-        experiment = NimbusExperimentFactory.create(
-            status=status
-        )
+    def test_update_status_errors_for_status_next_live(self, status, valid):
+        experiment = NimbusExperimentFactory.create(status=status)
         serializer = NimbusExperimentSerializer(
             experiment,
             data={
@@ -71,7 +67,7 @@ class TestNimbusStatusNextTransitionValidator(TestCase):
             context={"user": self.user},
         )
         self.assertEquals(serializer.is_valid(), valid)
-    
+
     @parameterized.expand(
         [
             [
@@ -92,12 +88,8 @@ class TestNimbusStatusNextTransitionValidator(TestCase):
             ],
         ]
     )
-    def test_update_status_errors_for_status_next_complete(
-        self, status, valid
-    ):
-        experiment = NimbusExperimentFactory.create(
-            status=status
-        )
+    def test_update_status_errors_for_status_next_complete(self, status, valid):
+        experiment = NimbusExperimentFactory.create(status=status)
         serializer = NimbusExperimentSerializer(
             experiment,
             data={
@@ -107,7 +99,7 @@ class TestNimbusStatusNextTransitionValidator(TestCase):
             context={"user": self.user},
         )
         self.assertEquals(serializer.is_valid(), valid)
-        
+
     @parameterized.expand(
         [
             [
@@ -128,12 +120,8 @@ class TestNimbusStatusNextTransitionValidator(TestCase):
             ],
         ]
     )
-    def test_update_status_errors_for_status_next_draft(
-        self, status, valid
-    ):
-        experiment = NimbusExperimentFactory.create(
-            status=status
-        )
+    def test_update_status_errors_for_status_next_draft(self, status, valid):
+        experiment = NimbusExperimentFactory.create(status=status)
         serializer = NimbusExperimentSerializer(
             experiment,
             data={

--- a/app/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_status_next_transition_validator.py
+++ b/app/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_status_next_transition_validator.py
@@ -1,0 +1,196 @@
+from django.test import TestCase
+from parameterized import parameterized
+
+from experimenter.base.models import SiteFlag, SiteFlagNameChoices
+from experimenter.experiments.api.v5.serializers import NimbusExperimentSerializer
+from experimenter.experiments.models import NimbusExperiment
+from experimenter.experiments.tests.factories import NimbusExperimentFactory
+from experimenter.openidc.tests.factories import UserFactory
+
+
+class TestNimbusStatusNextTransitionValidator(TestCase):
+    maxDiff = None
+
+    def setUp(self):
+        super().setUp()
+        self.user = UserFactory()
+
+    def test_launch_request_while_disabled_error(self):
+        SiteFlag(name=SiteFlagNameChoices.LAUNCHING_DISABLED.name, value=True).save()
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED
+        )
+        serializer = NimbusExperimentSerializer(
+            experiment,
+            data={
+                "status": NimbusExperiment.Status.DRAFT,
+                "status_next": NimbusExperiment.Status.LIVE,
+                "publish_status": NimbusExperiment.PublishStatus.REVIEW,
+                "changelog_message": "Review Requested for Launch",
+            },
+            context={"user": self.user},
+        )
+        self.assertFalse(serializer.is_valid())
+        self.assertEqual(
+            serializer.errors["status_next"][0],
+            NimbusExperiment.ERROR_LAUNCHING_DISABLED,
+        )
+
+    @parameterized.expand(
+        [
+            [
+                NimbusExperiment.Status.DRAFT,
+                True,
+            ],
+            [
+                NimbusExperiment.Status.PREVIEW,
+                True,
+            ],
+            [
+                NimbusExperiment.Status.LIVE,
+                True,
+            ],
+            [
+                NimbusExperiment.Status.COMPLETE,
+                False,
+            ],
+        ]
+    )
+    def test_update_status_errors_for_status_next_live(
+        self, status, valid
+    ):
+        experiment = NimbusExperimentFactory.create(
+            status=status
+        )
+        serializer = NimbusExperimentSerializer(
+            experiment,
+            data={
+                "status_next": NimbusExperiment.Status.LIVE,
+                "changelog_message": "test changelog message",
+            },
+            context={"user": self.user},
+        )
+        self.assertEquals(serializer.is_valid(), valid)
+    
+    @parameterized.expand(
+        [
+            [
+                NimbusExperiment.Status.DRAFT,
+                False,
+            ],
+            [
+                NimbusExperiment.Status.PREVIEW,
+                False,
+            ],
+            [
+                NimbusExperiment.Status.LIVE,
+                True,
+            ],
+            [
+                NimbusExperiment.Status.COMPLETE,
+                False,
+            ],
+        ]
+    )
+    def test_update_status_errors_for_status_next_complete(
+        self, status, valid
+    ):
+        experiment = NimbusExperimentFactory.create(
+            status=status
+        )
+        serializer = NimbusExperimentSerializer(
+            experiment,
+            data={
+                "status_next": NimbusExperiment.Status.COMPLETE,
+                "changelog_message": "test changelog message",
+            },
+            context={"user": self.user},
+        )
+        self.assertEquals(serializer.is_valid(), valid)
+        
+    @parameterized.expand(
+        [
+            [
+                NimbusExperiment.Status.DRAFT,
+                False,
+            ],
+            [
+                NimbusExperiment.Status.PREVIEW,
+                False,
+            ],
+            [
+                NimbusExperiment.Status.LIVE,
+                False,
+            ],
+            [
+                NimbusExperiment.Status.COMPLETE,
+                False,
+            ],
+        ]
+    )
+    def test_update_status_errors_for_status_next_draft(
+        self, status, valid
+    ):
+        experiment = NimbusExperimentFactory.create(
+            status=status
+        )
+        serializer = NimbusExperimentSerializer(
+            experiment,
+            data={
+                "status_next": NimbusExperiment.Status.DRAFT,
+                "changelog_message": "test changelog message",
+            },
+            context={"user": self.user},
+        )
+        self.assertEquals(serializer.is_valid(), valid)
+
+    def test_allow_live_experiment_to_be_complete(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            lifecycle=NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE_APPROVE,
+            is_rollout=False,
+        )
+        serializer = NimbusExperimentSerializer(
+            experiment,
+            data={
+                "status": NimbusExperiment.Status.LIVE,
+                "publish_status": NimbusExperiment.PublishStatus.REVIEW,
+                "status_next": NimbusExperiment.Status.COMPLETE,
+                "changelog_message": "test changelog message",
+            },
+            context={"user": self.user},
+        )
+        self.assertTrue(serializer.is_valid())
+
+    def test_allow_live_experiment_to_be_dirty(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            lifecycle=NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE_APPROVE,
+            is_rollout=False,
+        )
+        serializer = NimbusExperimentSerializer(
+            experiment,
+            data={
+                "status": NimbusExperiment.Status.LIVE,
+                "publish_status": NimbusExperiment.PublishStatus.DIRTY,
+                "status_next": NimbusExperiment.Status.LIVE,
+                "changelog_message": "test changelog message",
+            },
+            context={"user": self.user},
+        )
+        self.assertTrue(serializer.is_valid())
+
+    def test_allow_live_rollout_to_be_dirty(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            lifecycle=NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE_APPROVE,
+            is_rollout=True,
+        )
+        serializer = NimbusExperimentSerializer(
+            experiment,
+            data={
+                "status": NimbusExperiment.Status.LIVE,
+                "publish_status": NimbusExperiment.PublishStatus.DIRTY,
+                "status_next": NimbusExperiment.Status.LIVE,
+                "changelog_message": "test changelog message",
+            },
+            context={"user": self.user},
+        )
+        self.assertTrue(serializer.is_valid())

--- a/app/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_status_transition_validator.py
+++ b/app/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_status_transition_validator.py
@@ -105,9 +105,7 @@ class TestNimbusStatusTransitionValidator(TestCase):
             ],
         ]
     )
-    def test_update_status_errors_for_status_draft(
-        self, new_status, valid
-    ):
+    def test_update_status_errors_for_status_draft(self, new_status, valid):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             lifecycle=NimbusExperimentFactory.Lifecycles.CREATED
         )
@@ -141,9 +139,7 @@ class TestNimbusStatusTransitionValidator(TestCase):
             ],
         ]
     )
-    def test_update_status_errors_for_status_preview(
-        self, new_status, valid
-    ):
+    def test_update_status_errors_for_status_preview(self, new_status, valid):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             lifecycle=NimbusExperimentFactory.Lifecycles.PREVIEW
         )
@@ -177,9 +173,7 @@ class TestNimbusStatusTransitionValidator(TestCase):
             ],
         ]
     )
-    def test_update_status_errors_for_status_live(
-        self, new_status, valid
-    ):
+    def test_update_status_errors_for_status_live(self, new_status, valid):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             lifecycle=NimbusExperimentFactory.Lifecycles.LIVE_APPROVE_APPROVE
         )
@@ -213,9 +207,7 @@ class TestNimbusStatusTransitionValidator(TestCase):
             ],
         ]
     )
-    def test_update_status_errors_for_status_complete(
-        self, new_status, valid
-    ):
+    def test_update_status_errors_for_status_complete(self, new_status, valid):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             lifecycle=NimbusExperimentFactory.Lifecycles.ENDING_APPROVE_APPROVE
         )

--- a/app/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_status_transition_validator.py
+++ b/app/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_status_transition_validator.py
@@ -51,27 +51,6 @@ class TestNimbusStatusTransitionValidator(TestCase):
             "Nimbus Experiment publish_status cannot transition from Approved to Review.",
         )
 
-    def test_launch_request_while_disabled_error(self):
-        SiteFlag(name=SiteFlagNameChoices.LAUNCHING_DISABLED.name, value=True).save()
-        experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperimentFactory.Lifecycles.CREATED
-        )
-        serializer = NimbusExperimentSerializer(
-            experiment,
-            data={
-                "status": NimbusExperiment.Status.DRAFT,
-                "status_next": NimbusExperiment.Status.LIVE,
-                "publish_status": NimbusExperiment.PublishStatus.REVIEW,
-                "changelog_message": "Review Requested for Launch",
-            },
-            context={"user": self.user},
-        )
-        self.assertFalse(serializer.is_valid())
-        self.assertEqual(
-            serializer.errors["status_next"][0],
-            NimbusExperiment.ERROR_LAUNCHING_DISABLED,
-        )
-
     def test_end_enrolment_request_while_disabled_error(self):
         SiteFlag(name=SiteFlagNameChoices.LAUNCHING_DISABLED.name, value=True).save()
         experiment = NimbusExperimentFactory.create_with_lifecycle(

--- a/app/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_status_transition_validator.py
+++ b/app/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_status_transition_validator.py
@@ -1,4 +1,5 @@
 from django.test import TestCase
+from parameterized import parameterized
 
 from experimenter.base.models import SiteFlag, SiteFlagNameChoices
 from experimenter.experiments.api.v5.serializers import NimbusExperimentSerializer
@@ -104,3 +105,147 @@ class TestNimbusStatusTransitionValidator(TestCase):
             context={"user": self.user},
         )
         self.assertTrue(serializer.is_valid())
+
+    @parameterized.expand(
+        [
+            [
+                NimbusExperiment.Status.DRAFT,
+                True,
+            ],
+            [
+                NimbusExperiment.Status.PREVIEW,
+                True,
+            ],
+            [
+                NimbusExperiment.Status.LIVE,
+                False,
+            ],
+            [
+                NimbusExperiment.Status.COMPLETE,
+                False,
+            ],
+        ]
+    )
+    def test_update_status_errors_for_status_draft(
+        self, new_status, valid
+    ):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            lifecycle=NimbusExperimentFactory.Lifecycles.CREATED
+        )
+        serializer = NimbusExperimentSerializer(
+            experiment,
+            data={
+                "status": new_status,
+                "changelog_message": "test changelog message",
+            },
+            context={"user": self.user},
+        )
+        self.assertEquals(serializer.is_valid(), valid)
+
+    @parameterized.expand(
+        [
+            [
+                NimbusExperiment.Status.DRAFT,
+                True,
+            ],
+            [
+                NimbusExperiment.Status.PREVIEW,
+                True,
+            ],
+            [
+                NimbusExperiment.Status.LIVE,
+                False,
+            ],
+            [
+                NimbusExperiment.Status.COMPLETE,
+                False,
+            ],
+        ]
+    )
+    def test_update_status_errors_for_status_preview(
+        self, new_status, valid
+    ):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            lifecycle=NimbusExperimentFactory.Lifecycles.PREVIEW
+        )
+        serializer = NimbusExperimentSerializer(
+            experiment,
+            data={
+                "status": new_status,
+                "changelog_message": "test changelog message",
+            },
+            context={"user": self.user},
+        )
+        self.assertEquals(serializer.is_valid(), valid)
+
+    @parameterized.expand(
+        [
+            [
+                NimbusExperiment.Status.DRAFT,
+                False,
+            ],
+            [
+                NimbusExperiment.Status.PREVIEW,
+                False,
+            ],
+            [
+                NimbusExperiment.Status.LIVE,
+                True,
+            ],
+            [
+                NimbusExperiment.Status.COMPLETE,
+                False,
+            ],
+        ]
+    )
+    def test_update_status_errors_for_status_live(
+        self, new_status, valid
+    ):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            lifecycle=NimbusExperimentFactory.Lifecycles.LIVE_APPROVE_APPROVE
+        )
+        serializer = NimbusExperimentSerializer(
+            experiment,
+            data={
+                "status": new_status,
+                "changelog_message": "test changelog message",
+            },
+            context={"user": self.user},
+        )
+        self.assertEquals(serializer.is_valid(), valid)
+
+    @parameterized.expand(
+        [
+            [
+                NimbusExperiment.Status.DRAFT,
+                False,
+            ],
+            [
+                NimbusExperiment.Status.PREVIEW,
+                False,
+            ],
+            [
+                NimbusExperiment.Status.LIVE,
+                False,
+            ],
+            [
+                NimbusExperiment.Status.COMPLETE,
+                True,
+            ],
+        ]
+    )
+    def test_update_status_errors_for_status_complete(
+        self, new_status, valid
+    ):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            lifecycle=NimbusExperimentFactory.Lifecycles.ENDING_APPROVE_APPROVE
+        )
+        serializer = NimbusExperimentSerializer(
+            experiment,
+            data={
+                "status": new_status,
+                "changelog_message": "test changelog message",
+            },
+            context={"user": self.user},
+        )
+        self.assertEquals(serializer.is_valid(), valid)

--- a/app/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_status_transition_validator.py
+++ b/app/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_status_transition_validator.py
@@ -51,7 +51,7 @@ class TestNimbusStatusTransitionValidator(TestCase):
             "Nimbus Experiment publish_status cannot transition from Approved to Review.",
         )
 
-    def test_end_enrolment_request_while_disabled_error(self):
+    def test_end_enrollment_request_while_disabled_error(self):
         SiteFlag(name=SiteFlagNameChoices.LAUNCHING_DISABLED.name, value=True).save()
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.LIVE_ENROLLING

--- a/app/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_status_validation_mixin.py
+++ b/app/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_status_validation_mixin.py
@@ -197,7 +197,7 @@ class TestNimbusStatusValidationMixin(TestCase):
             context={"user": self.user},
         )
         self.assertEquals(serializer.is_valid(), valid)
-        
+
     def test_allow_dirty_from_live_status(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             lifecycle=NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE_APPROVE

--- a/app/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_status_validation_mixin.py
+++ b/app/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_status_validation_mixin.py
@@ -30,8 +30,8 @@ class TestNimbusStatusValidationMixin(TestCase):
         self.assertIn("experiment", serializer.errors)
 
     def test_unable_to_update_experiment_in_publish_status(self):
-        experiment = NimbusExperimentFactory.create(
-            publish_status=NimbusExperiment.PublishStatus.REVIEW,
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            lifecycle=NimbusExperimentFactory.Lifecycles.LAUNCH_REVIEW_REQUESTED
         )
         serializer = NimbusExperimentSerializer(
             experiment,
@@ -71,8 +71,8 @@ class TestNimbusStatusValidationMixin(TestCase):
     def test_update_publish_status_errors_for_status_complete(
         self, publish_status, valid
     ):
-        experiment = NimbusExperimentFactory.create(
-            status=NimbusExperiment.Status.COMPLETE
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            lifecycle=NimbusExperimentFactory.Lifecycles.ENDING_APPROVE_APPROVE
         )
         serializer = NimbusExperimentSerializer(
             experiment,
@@ -109,7 +109,9 @@ class TestNimbusStatusValidationMixin(TestCase):
         ]
     )
     def test_update_publish_status_errors_for_status_live(self, publish_status, valid):
-        experiment = NimbusExperimentFactory.create(status=NimbusExperiment.Status.LIVE)
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            lifecycle=NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE_APPROVE
+        )
         serializer = NimbusExperimentSerializer(
             experiment,
             data={
@@ -145,8 +147,8 @@ class TestNimbusStatusValidationMixin(TestCase):
         ]
     )
     def test_update_publish_status_errors_for_status_preview(self, publish_status, valid):
-        experiment = NimbusExperimentFactory.create(
-            status=NimbusExperiment.Status.PREVIEW
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            lifecycle=NimbusExperimentFactory.Lifecycles.PREVIEW
         )
         serializer = NimbusExperimentSerializer(
             experiment,
@@ -183,8 +185,8 @@ class TestNimbusStatusValidationMixin(TestCase):
         ]
     )
     def test_update_publish_status_errors_for_status_draft(self, publish_status, valid):
-        experiment = NimbusExperimentFactory.create(
-            status=NimbusExperiment.Status.DRAFT,
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            lifecycle=NimbusExperimentFactory.Lifecycles.CREATED
         )
         serializer = NimbusExperimentSerializer(
             experiment,

--- a/app/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_status_validation_mixin.py
+++ b/app/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_status_validation_mixin.py
@@ -197,3 +197,19 @@ class TestNimbusStatusValidationMixin(TestCase):
             context={"user": self.user},
         )
         self.assertEquals(serializer.is_valid(), valid)
+        
+    def test_allow_dirty_from_live_status(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            lifecycle=NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE_APPROVE
+        )
+        serializer = NimbusExperimentSerializer(
+            experiment,
+            data={
+                "status": NimbusExperiment.Status.LIVE,
+                "publish_status": NimbusExperiment.PublishStatus.DIRTY,
+                "status_next": NimbusExperiment.Status.LIVE,
+                "changelog_message": "test changelog message",
+            },
+            context={"user": self.user},
+        )
+        self.assertTrue(serializer.is_valid())


### PR DESCRIPTION
Because...

* We are about to allow Live rollouts to be Dirty 👷 

This commit...

* Bulks up our existing tests for our serializers so that we can easily adjust these status and publish_status transitions for `DIRTY`