### PR TITLE
fixes #8058 tests(nimbus): Update enrollment telemetry integration test

### DIFF
--- a/app/tests/integration/nimbus/pages/browser/__init__.py
+++ b/app/tests/integration/nimbus/pages/browser/__init__.py
@@ -38,8 +38,8 @@ class AboutConfig(Page):
                 search_bar.send_keys(pref)
                 self.wait.until(EC.presence_of_element_located(self._row_locator))
                 elements = self.find_elements(*self._row_locator)
-                assert pref_value in [element.text for element in elements]
-            except Exception as e:
+                assert pref_value in [element.text for element in elements], "Pref not found"
+            except (Exception, AssertionError) as e:
                 time.sleep(2)
                 error = e
             else:

--- a/app/tests/integration/nimbus/pages/browser/__init__.py
+++ b/app/tests/integration/nimbus/pages/browser/__init__.py
@@ -38,7 +38,9 @@ class AboutConfig(Page):
                 search_bar.send_keys(pref)
                 self.wait.until(EC.presence_of_element_located(self._row_locator))
                 elements = self.find_elements(*self._row_locator)
-                assert pref_value in [element.text for element in elements], "Pref not found"
+                assert pref_value in [
+                    element.text for element in elements
+                ], "Pref not found"
             except (Exception, AssertionError) as e:
                 time.sleep(2)
                 error = e

--- a/app/tests/integration/nimbus/pages/browser/__init__.py
+++ b/app/tests/integration/nimbus/pages/browser/__init__.py
@@ -31,6 +31,7 @@ class AboutConfig(Page):
 
     def wait_for_pref_flip(self, pref, pref_value):
         timeout = time.time() + 60 * 5
+        error = None
         while time.time() < timeout:
             try:
                 search_bar = self.find_element(*self._search_bar_locator)
@@ -38,8 +39,9 @@ class AboutConfig(Page):
                 self.wait.until(EC.presence_of_element_located(self._row_locator))
                 elements = self.find_elements(*self._row_locator)
                 assert pref_value in [element.text for element in elements]
-            except Exception:
+            except Exception as e:
                 time.sleep(2)
-                return False
+                error = e
             else:
                 return True
+        raise(error)

--- a/app/tests/integration/nimbus/pages/browser/__init__.py
+++ b/app/tests/integration/nimbus/pages/browser/__init__.py
@@ -44,4 +44,4 @@ class AboutConfig(Page):
                 error = e
             else:
                 return True
-        raise(error)
+        raise (error)

--- a/app/tests/integration/nimbus/test_desktop_client_integrations.py
+++ b/app/tests/integration/nimbus/test_desktop_client_integrations.py
@@ -121,7 +121,7 @@ def test_check_telemetry_enrollment_unenrollment(
     time.sleep(5)
 
     # Check their was a telemetry event for the enrollment
-    control = True
+    control = False
     timeout = time.time() + 60 * 5
     while control is not True:
         control = telemetry_event_check(experiment_slug, "enroll")
@@ -150,14 +150,12 @@ def test_check_telemetry_enrollment_unenrollment(
     requests.get("http://ping-server:5000/pings")
     time.sleep(5)
 
-    control = True
+    control = False
     timeout = time.time() + 60 * 5
     while control is not True:
         control = telemetry_event_check(experiment_slug, "unenroll")
         if time.time() > timeout:
             assert False, "Experiment enrollment was never seen in ping Data"
-    # check experiment exists, this means it is enrolled
-    assert check_ping_for_experiment(experiment_slug), "Experiment not found in telemetry"
 
 
 @pytest.mark.nimbus_integration


### PR DESCRIPTION
Because:
* With the new pref-flip integration test, we found ways to improve on a few things

This commit:
* Adds those changes to the old test
* Updates the logic for the pref flip test helper a bit