### PR TITLE
fix #7571 feat(nimbus): add analysis_bases to analysis results data

### DIFF
--- a/app/experimenter/jetstream/models.py
+++ b/app/experimenter/jetstream/models.py
@@ -33,6 +33,11 @@ class Segment:
     ALL = "all"
 
 
+class AnalysisBasis:
+    ENROLLMENTS = "enrollments"
+    EXPOSURES = "exposures"
+
+
 # TODO: Consider a "guardrail_metrics" group containing "days_of_use",
 # "retained", and "search_count".
 class Group:
@@ -75,6 +80,7 @@ class JetstreamDataPoint(BaseModel):
     window_index: str = None
     comparison: str = None
     segment: str = Segment.ALL
+    analysis_basis: str = AnalysisBasis.ENROLLMENTS
 
 
 class JetstreamData(BaseModel):

--- a/app/experimenter/jetstream/tests/constants.py
+++ b/app/experimenter/jetstream/tests/constants.py
@@ -1,4 +1,5 @@
 from experimenter.jetstream.models import (
+    AnalysisBasis,
     BranchComparison,
     BranchComparisonData,
     DataPoint,
@@ -46,6 +47,7 @@ class JetstreamTestData:
             statistic=Statistic.COUNT,
             window_index="1",
             segment=Segment.ALL,
+            analysis_basis=AnalysisBasis.ENROLLMENTS,
         )
 
     @classmethod
@@ -157,7 +159,9 @@ class JetstreamTestData:
         ).dict(exclude_none=True)
 
     @classmethod
-    def add_outcome_data(cls, data, overall_data, weekly_data, primary_outcome):
+    def add_outcome_data(
+        cls, data, overall_data, weekly_data, primary_outcome, analysis_basis
+    ):
         primary_metrics = ["default_browser_action"]
         range_data = DataPoint(lower=2, point=4, upper=8)
 
@@ -188,11 +192,14 @@ class JetstreamTestData:
                         statistic="binomial",
                         window_index="1",
                         segment=Segment.ALL,
+                        analysis_basis=analysis_basis,
                     ).dict(exclude_none=True)
                 )
 
     @classmethod
-    def add_outcome_data_mean(cls, data, overall_data, weekly_data, primary_outcome):
+    def add_outcome_data_mean(
+        cls, data, overall_data, weekly_data, primary_outcome, analysis_basis
+    ):
         primary_metrics = ["mozilla_default_browser"]
         range_data = DataPoint(lower=0, point=0, upper=0)
 
@@ -223,6 +230,7 @@ class JetstreamTestData:
                         statistic="mean",
                         window_index="1",
                         segment=Segment.ALL,
+                        analysis_basis=analysis_basis,
                     ).dict(exclude_none=True)
                 )
 
@@ -233,10 +241,15 @@ class JetstreamTestData:
         overall_data,
         weekly_data,
         primary_outcomes,
+        analysis_basis,
     ):
         for primary_outcome in primary_outcomes:
-            cls.add_outcome_data(data, overall_data, weekly_data, primary_outcome)
-            cls.add_outcome_data_mean(data, overall_data, weekly_data, primary_outcome)
+            cls.add_outcome_data(
+                data, overall_data, weekly_data, primary_outcome, analysis_basis
+            )
+            cls.add_outcome_data_mean(
+                data, overall_data, weekly_data, primary_outcome, analysis_basis
+            )
 
     @classmethod
     def get_test_data(cls, primary_outcomes):
@@ -274,6 +287,56 @@ class JetstreamTestData:
             CONTROL_NEUTRAL_SIGNIFICANCE_DATA_ROW,
         ) = cls.get_significance_data_row(VARIANT_POSITIVE_SIGNIFICANCE_DATA_ROW)
 
+        # exposures
+        EXPOSURES_CONTROL_DATA_ROW = DATA_IDENTITY_ROW.copy()
+        EXPOSURES_CONTROL_DATA_ROW.branch = "control"
+        EXPOSURES_CONTROL_DATA_ROW.analysis_basis = AnalysisBasis.EXPOSURES
+
+        EXPOSURES_VARIANT_DATA_ROW = DATA_IDENTITY_ROW.copy()
+        EXPOSURES_VARIANT_DATA_ROW.branch = "variant"
+        EXPOSURES_VARIANT_DATA_ROW.analysis_basis = AnalysisBasis.EXPOSURES
+
+        EXPOSURES_SEGMENTED_ROW_VARIANT = VARIANT_DATA_ROW.copy()
+        EXPOSURES_SEGMENTED_ROW_VARIANT.segment = "some_segment"
+        EXPOSURES_SEGMENTED_ROW_VARIANT.analysis_basis = AnalysisBasis.EXPOSURES
+        EXPOSURES_SEGMENTED_ROW_CONTROL = CONTROL_DATA_ROW.copy()
+        EXPOSURES_SEGMENTED_ROW_CONTROL.segment = "some_segment"
+        EXPOSURES_SEGMENTED_ROW_CONTROL.analysis_basis = AnalysisBasis.EXPOSURES
+
+        EXPOSURES_VARIANT_DATA_DEFAULT_METRIC_ROW_MEAN = DATA_IDENTITY_ROW.copy()
+        EXPOSURES_VARIANT_DATA_DEFAULT_METRIC_ROW_MEAN.metric = "some_count"
+        EXPOSURES_VARIANT_DATA_DEFAULT_METRIC_ROW_MEAN.statistic = Statistic.MEAN
+        EXPOSURES_VARIANT_DATA_DEFAULT_METRIC_ROW_MEAN.branch = "variant"
+        EXPOSURES_VARIANT_DATA_DEFAULT_METRIC_ROW_MEAN.analysis_basis = (
+            AnalysisBasis.EXPOSURES
+        )
+
+        EXPOSURES_VARIANT_DATA_DEFAULT_METRIC_ROW_BINOMIAL = DATA_IDENTITY_ROW.copy()
+        EXPOSURES_VARIANT_DATA_DEFAULT_METRIC_ROW_BINOMIAL.metric = "another_count"
+        EXPOSURES_VARIANT_DATA_DEFAULT_METRIC_ROW_BINOMIAL.statistic = Statistic.BINOMIAL
+        EXPOSURES_VARIANT_DATA_DEFAULT_METRIC_ROW_BINOMIAL.branch = "variant"
+        EXPOSURES_VARIANT_DATA_DEFAULT_METRIC_ROW_BINOMIAL.analysis_basis = (
+            AnalysisBasis.EXPOSURES
+        )
+
+        EXPOSURES_VARIANT_POSITIVE_SIGNIFICANCE_DATA_ROW = DATA_IDENTITY_ROW.copy()
+        EXPOSURES_VARIANT_POSITIVE_SIGNIFICANCE_DATA_ROW.comparison = (
+            BranchComparison.DIFFERENCE
+        )
+        EXPOSURES_VARIANT_POSITIVE_SIGNIFICANCE_DATA_ROW.metric = Metric.SEARCH
+        EXPOSURES_VARIANT_POSITIVE_SIGNIFICANCE_DATA_ROW.statistic = Statistic.MEAN
+        EXPOSURES_VARIANT_POSITIVE_SIGNIFICANCE_DATA_ROW.branch = "variant"
+        EXPOSURES_VARIANT_POSITIVE_SIGNIFICANCE_DATA_ROW.analysis_basis = (
+            AnalysisBasis.EXPOSURES
+        )
+
+        (
+            EXPOSURES_VARIANT_NEGATIVE_SIGNIFICANCE_DATA_ROW,
+            EXPOSURES_CONTROL_NEUTRAL_SIGNIFICANCE_DATA_ROW,
+        ) = cls.get_significance_data_row(
+            EXPOSURES_VARIANT_POSITIVE_SIGNIFICANCE_DATA_ROW
+        )
+
         DAILY_DATA = [
             CONTROL_DATA_ROW.dict(exclude_none=True),
             VARIANT_DATA_ROW.dict(exclude_none=True),
@@ -283,9 +346,22 @@ class JetstreamTestData:
             VARIANT_NEGATIVE_SIGNIFICANCE_DATA_ROW.dict(exclude_none=True),
             CONTROL_NEUTRAL_SIGNIFICANCE_DATA_ROW.dict(exclude_none=True),
         ]
+        DAILY_EXPOSURES_DATA = [
+            EXPOSURES_CONTROL_DATA_ROW.dict(exclude_none=True),
+            EXPOSURES_VARIANT_DATA_ROW.dict(exclude_none=True),
+            EXPOSURES_VARIANT_DATA_DEFAULT_METRIC_ROW_MEAN.dict(exclude_none=True),
+            EXPOSURES_VARIANT_DATA_DEFAULT_METRIC_ROW_BINOMIAL.dict(exclude_none=True),
+            EXPOSURES_VARIANT_POSITIVE_SIGNIFICANCE_DATA_ROW.dict(exclude_none=True),
+            EXPOSURES_VARIANT_NEGATIVE_SIGNIFICANCE_DATA_ROW.dict(exclude_none=True),
+            EXPOSURES_CONTROL_NEUTRAL_SIGNIFICANCE_DATA_ROW.dict(exclude_none=True),
+        ]
         SEGMENT_DATA = [
             SEGMENTED_ROW_VARIANT.dict(exclude_none=True),
             SEGMENTED_ROW_CONTROL.dict(exclude_none=True),
+        ]
+        SEGMENT_EXPOSURES_DATA = [
+            EXPOSURES_SEGMENTED_ROW_VARIANT.dict(exclude_none=True),
+            EXPOSURES_SEGMENTED_ROW_CONTROL.dict(exclude_none=True),
         ]
 
         (
@@ -458,9 +534,25 @@ class JetstreamTestData:
             OVERALL_DATA,
             WEEKLY_DATA,
             primary_outcomes,
+            AnalysisBasis.ENROLLMENTS,
+        )
+        cls.add_all_outcome_data(
+            DAILY_EXPOSURES_DATA,
+            OVERALL_DATA,
+            WEEKLY_DATA,
+            primary_outcomes,
+            AnalysisBasis.EXPOSURES,
         )
 
-        return (DAILY_DATA, WEEKLY_DATA, OVERALL_DATA, ERRORS, SEGMENT_DATA)
+        return (
+            DAILY_DATA,
+            WEEKLY_DATA,
+            OVERALL_DATA,
+            ERRORS,
+            SEGMENT_DATA,
+            DAILY_EXPOSURES_DATA,
+            SEGMENT_EXPOSURES_DATA,
+        )
 
 
 class ZeroJetstreamTestData(JetstreamTestData):
@@ -474,6 +566,7 @@ class ZeroJetstreamTestData(JetstreamTestData):
             statistic=Statistic.COUNT,
             window_index="1",
             segment=Segment.ALL,
+            analysis_basis=AnalysisBasis.ENROLLMENTS,
         )
 
     @classmethod
@@ -576,7 +669,9 @@ class ZeroJetstreamTestData(JetstreamTestData):
         )
 
     @classmethod
-    def add_outcome_data(cls, data, overall_data, weekly_data, primary_outcome):
+    def add_outcome_data(
+        cls, data, overall_data, weekly_data, primary_outcome, analysis_basis
+    ):
         primary_metrics = ["default_browser_action"]
         range_data = DataPoint(lower=0, point=0, upper=0)
 
@@ -607,6 +702,7 @@ class ZeroJetstreamTestData(JetstreamTestData):
                         statistic="binomial",
                         window_index="1",
                         segment=Segment.ALL,
+                        analysis_basis=analysis_basis,
                     ).dict(exclude_none=True)
                 )
 
@@ -622,6 +718,7 @@ class NonePointJetstreamTestData(ZeroJetstreamTestData):
             statistic=Statistic.COUNT,
             window_index=None,
             segment=Segment.ALL,
+            analysis_basis=AnalysisBasis.ENROLLMENTS,
         )
 
     @classmethod

--- a/app/experimenter/jetstream/tests/test_tasks.py
+++ b/app/experimenter/jetstream/tests/test_tasks.py
@@ -57,6 +57,8 @@ class TestFetchJetstreamDataTask(TestCase):
             OVERALL_DATA,
             ERRORS,
             SEGMENT_DATA,
+            DAILY_EXPOSURES_DATA,
+            SEGMENT_EXPOSURES_DATA,
         ) = JetstreamTestData.get_test_data(primary_outcomes)
 
         FULL_DATA = {
@@ -214,6 +216,298 @@ class TestFetchJetstreamDataTask(TestCase):
                 "show_analysis": False,
                 "errors": ERRORS,
             },
+            "v2": {
+                "daily": {
+                    "enrollments": {
+                        "all": DAILY_DATA,
+                        "some_segment": SEGMENT_DATA,
+                    },
+                    "exposures": {
+                        "all": DAILY_EXPOSURES_DATA,
+                        "some_segment": SEGMENT_EXPOSURES_DATA,
+                    },
+                },
+                "weekly": {
+                    "enrollments": {
+                        "all": WEEKLY_DATA,
+                        "some_segment": {
+                            "control": {
+                                "branch_data": {
+                                    "other_metrics": {
+                                        "identity": {
+                                            "absolute": {
+                                                "all": [
+                                                    {
+                                                        "lower": 10.0,
+                                                        "point": 12.0,
+                                                        "upper": 13.0,
+                                                        "window_index": "1",
+                                                    }
+                                                ],
+                                                "first": {
+                                                    "lower": 10.0,
+                                                    "point": 12.0,
+                                                    "upper": 13.0,
+                                                    "window_index": "1",
+                                                },
+                                            },
+                                            "difference": {"all": [], "first": {}},
+                                            "relative_uplift": {"all": [], "first": {}},
+                                            "significance": {"overall": {}, "weekly": {}},
+                                        }
+                                    },
+                                    "search_metrics": {},
+                                    "usage_metrics": {},
+                                },
+                                "is_control": True,
+                            },
+                            "variant": {
+                                "branch_data": {
+                                    "other_metrics": {
+                                        "identity": {
+                                            "absolute": {
+                                                "all": [
+                                                    {
+                                                        "lower": 10.0,
+                                                        "point": 12.0,
+                                                        "upper": 13.0,
+                                                        "window_index": "1",
+                                                    }
+                                                ],
+                                                "first": {
+                                                    "lower": 10.0,
+                                                    "point": 12.0,
+                                                    "upper": 13.0,
+                                                    "window_index": "1",
+                                                },
+                                            },
+                                            "difference": {"all": [], "first": {}},
+                                            "relative_uplift": {"all": [], "first": {}},
+                                            "significance": {"overall": {}, "weekly": {}},
+                                        }
+                                    },
+                                    "search_metrics": {},
+                                    "usage_metrics": {},
+                                },
+                                "is_control": False,
+                            },
+                        },
+                    },
+                    "exposures": {
+                        "all": WEEKLY_DATA,
+                        "some_segment": {
+                            "control": {
+                                "branch_data": {
+                                    "other_metrics": {
+                                        "identity": {
+                                            "absolute": {
+                                                "all": [
+                                                    {
+                                                        "lower": 10.0,
+                                                        "point": 12.0,
+                                                        "upper": 13.0,
+                                                        "window_index": "1",
+                                                    }
+                                                ],
+                                                "first": {
+                                                    "lower": 10.0,
+                                                    "point": 12.0,
+                                                    "upper": 13.0,
+                                                    "window_index": "1",
+                                                },
+                                            },
+                                            "difference": {"all": [], "first": {}},
+                                            "relative_uplift": {"all": [], "first": {}},
+                                            "significance": {"overall": {}, "weekly": {}},
+                                        }
+                                    },
+                                    "search_metrics": {},
+                                    "usage_metrics": {},
+                                },
+                                "is_control": True,
+                            },
+                            "variant": {
+                                "branch_data": {
+                                    "other_metrics": {
+                                        "identity": {
+                                            "absolute": {
+                                                "all": [
+                                                    {
+                                                        "lower": 10.0,
+                                                        "point": 12.0,
+                                                        "upper": 13.0,
+                                                        "window_index": "1",
+                                                    }
+                                                ],
+                                                "first": {
+                                                    "lower": 10.0,
+                                                    "point": 12.0,
+                                                    "upper": 13.0,
+                                                    "window_index": "1",
+                                                },
+                                            },
+                                            "difference": {"all": [], "first": {}},
+                                            "relative_uplift": {"all": [], "first": {}},
+                                            "significance": {"overall": {}, "weekly": {}},
+                                        }
+                                    },
+                                    "search_metrics": {},
+                                    "usage_metrics": {},
+                                },
+                                "is_control": False,
+                            },
+                        },
+                    },
+                },
+                "overall": {
+                    "enrollments": {
+                        "all": OVERALL_DATA,
+                        "some_segment": {
+                            "control": {
+                                "branch_data": {
+                                    "other_metrics": {
+                                        "identity": {
+                                            "absolute": {
+                                                "all": [
+                                                    {
+                                                        "lower": 10.0,
+                                                        "point": 12.0,
+                                                        "upper": 13.0,
+                                                    }
+                                                ],
+                                                "first": {
+                                                    "lower": 10.0,
+                                                    "point": 12.0,
+                                                    "upper": 13.0,
+                                                },
+                                            },
+                                            "difference": {"all": [], "first": {}},
+                                            "percent": 50.0,
+                                            "relative_uplift": {"all": [], "first": {}},
+                                            "significance": {"overall": {}, "weekly": {}},
+                                        }
+                                    },
+                                    "search_metrics": {},
+                                    "usage_metrics": {},
+                                },
+                                "is_control": True,
+                            },
+                            "variant": {
+                                "branch_data": {
+                                    "other_metrics": {
+                                        "identity": {
+                                            "absolute": {
+                                                "all": [
+                                                    {
+                                                        "lower": 10.0,
+                                                        "point": 12.0,
+                                                        "upper": 13.0,
+                                                    }
+                                                ],
+                                                "first": {
+                                                    "lower": 10.0,
+                                                    "point": 12.0,
+                                                    "upper": 13.0,
+                                                },
+                                            },
+                                            "difference": {"all": [], "first": {}},
+                                            "percent": 50.0,
+                                            "relative_uplift": {"all": [], "first": {}},
+                                            "significance": {"overall": {}, "weekly": {}},
+                                        }
+                                    },
+                                    "search_metrics": {},
+                                    "usage_metrics": {},
+                                },
+                                "is_control": False,
+                            },
+                        },
+                    },
+                    "exposures": {
+                        "all": OVERALL_DATA,
+                        "some_segment": {
+                            "control": {
+                                "branch_data": {
+                                    "other_metrics": {
+                                        "identity": {
+                                            "absolute": {
+                                                "all": [
+                                                    {
+                                                        "lower": 10.0,
+                                                        "point": 12.0,
+                                                        "upper": 13.0,
+                                                    }
+                                                ],
+                                                "first": {
+                                                    "lower": 10.0,
+                                                    "point": 12.0,
+                                                    "upper": 13.0,
+                                                },
+                                            },
+                                            "difference": {"all": [], "first": {}},
+                                            "percent": 50.0,
+                                            "relative_uplift": {"all": [], "first": {}},
+                                            "significance": {"overall": {}, "weekly": {}},
+                                        }
+                                    },
+                                    "search_metrics": {},
+                                    "usage_metrics": {},
+                                },
+                                "is_control": True,
+                            },
+                            "variant": {
+                                "branch_data": {
+                                    "other_metrics": {
+                                        "identity": {
+                                            "absolute": {
+                                                "all": [
+                                                    {
+                                                        "lower": 10.0,
+                                                        "point": 12.0,
+                                                        "upper": 13.0,
+                                                    }
+                                                ],
+                                                "first": {
+                                                    "lower": 10.0,
+                                                    "point": 12.0,
+                                                    "upper": 13.0,
+                                                },
+                                            },
+                                            "difference": {"all": [], "first": {}},
+                                            "percent": 50.0,
+                                            "relative_uplift": {"all": [], "first": {}},
+                                            "significance": {"overall": {}, "weekly": {}},
+                                        }
+                                    },
+                                    "search_metrics": {},
+                                    "usage_metrics": {},
+                                },
+                                "is_control": False,
+                            },
+                        },
+                    },
+                },
+                "other_metrics": {
+                    Group.OTHER: {
+                        "some_count": "Some Count",
+                        "another_count": "Another Count",
+                    },
+                },
+                "metadata": {
+                    "outcomes": {
+                        "default-browser": {
+                            "metrics": [
+                                "default_browser_action",
+                                "mozilla_default_browser",
+                                "default_browser_null",
+                            ],
+                            "default_metrics": [],
+                        }
+                    }
+                },
+                "show_analysis": False,
+                "errors": ERRORS,
+            },
         }
 
         class File:
@@ -273,7 +567,12 @@ class TestFetchJetstreamDataTask(TestCase):
                             "timestamp": "2022-08-31T04:32:03+00:00"
                         }
                     ]"""
-                return json.dumps(DAILY_DATA + SEGMENT_DATA)
+                return json.dumps(
+                    DAILY_DATA
+                    + SEGMENT_DATA
+                    + DAILY_EXPOSURES_DATA
+                    + SEGMENT_EXPOSURES_DATA
+                )
 
         def open_file(filename):
             return File(filename)
@@ -315,6 +614,8 @@ class TestFetchJetstreamDataTask(TestCase):
             OVERALL_DATA,
             _,
             SEGMENT_DATA,
+            _,
+            _,
         ) = ZeroJetstreamTestData.get_test_data(primary_outcomes)
 
         FULL_DATA = {
@@ -453,6 +754,155 @@ class TestFetchJetstreamDataTask(TestCase):
                 "show_analysis": False,
                 "errors": {"experiment": []},
             },
+            "v2": {
+                "daily": {
+                    "enrollments": {
+                        "all": DAILY_DATA,
+                        "some_segment": SEGMENT_DATA,
+                    },
+                },
+                "weekly": {
+                    "enrollments": {
+                        "all": WEEKLY_DATA,
+                        "some_segment": {
+                            "control": {
+                                "branch_data": {
+                                    "other_metrics": {
+                                        "identity": {
+                                            "absolute": {
+                                                "all": [
+                                                    {
+                                                        "lower": 0.0,
+                                                        "point": 0.0,
+                                                        "upper": 0.0,
+                                                        "window_index": "1",
+                                                    }
+                                                ],
+                                                "first": {
+                                                    "lower": 0.0,
+                                                    "point": 0.0,
+                                                    "upper": 0.0,
+                                                    "window_index": "1",
+                                                },
+                                            },
+                                            "difference": {"all": [], "first": {}},
+                                            "relative_uplift": {"all": [], "first": {}},
+                                            "significance": {"overall": {}, "weekly": {}},
+                                        }
+                                    },
+                                    "search_metrics": {},
+                                    "usage_metrics": {},
+                                },
+                                "is_control": True,
+                            },
+                            "variant": {
+                                "branch_data": {
+                                    "other_metrics": {
+                                        "identity": {
+                                            "absolute": {
+                                                "all": [
+                                                    {
+                                                        "lower": 0.0,
+                                                        "point": 0.0,
+                                                        "upper": 0.0,
+                                                        "window_index": "1",
+                                                    }
+                                                ],
+                                                "first": {
+                                                    "lower": 0.0,
+                                                    "point": 0.0,
+                                                    "upper": 0.0,
+                                                    "window_index": "1",
+                                                },
+                                            },
+                                            "difference": {"all": [], "first": {}},
+                                            "relative_uplift": {"all": [], "first": {}},
+                                            "significance": {"overall": {}, "weekly": {}},
+                                        }
+                                    },
+                                    "search_metrics": {},
+                                    "usage_metrics": {},
+                                },
+                                "is_control": False,
+                            },
+                        },
+                    },
+                },
+                "overall": {
+                    "enrollments": {
+                        "all": OVERALL_DATA,
+                        "some_segment": {
+                            "control": {
+                                "branch_data": {
+                                    "other_metrics": {
+                                        "identity": {
+                                            "absolute": {
+                                                "all": [
+                                                    {
+                                                        "lower": 0.0,
+                                                        "point": 0.0,
+                                                        "upper": 0.0,
+                                                    }
+                                                ],
+                                                "first": {
+                                                    "lower": 0.0,
+                                                    "point": 0.0,
+                                                    "upper": 0.0,
+                                                },
+                                            },
+                                            "difference": {"all": [], "first": {}},
+                                            "percent": 0.0,
+                                            "relative_uplift": {"all": [], "first": {}},
+                                            "significance": {"overall": {}, "weekly": {}},
+                                        }
+                                    },
+                                    "search_metrics": {},
+                                    "usage_metrics": {},
+                                },
+                                "is_control": True,
+                            },
+                            "variant": {
+                                "branch_data": {
+                                    "other_metrics": {
+                                        "identity": {
+                                            "absolute": {
+                                                "all": [
+                                                    {
+                                                        "lower": 0.0,
+                                                        "point": 0.0,
+                                                        "upper": 0.0,
+                                                    }
+                                                ],
+                                                "first": {
+                                                    "lower": 0.0,
+                                                    "point": 0.0,
+                                                    "upper": 0.0,
+                                                },
+                                            },
+                                            "difference": {"all": [], "first": {}},
+                                            "percent": 0.0,
+                                            "relative_uplift": {"all": [], "first": {}},
+                                            "significance": {"overall": {}, "weekly": {}},
+                                        }
+                                    },
+                                    "search_metrics": {},
+                                    "usage_metrics": {},
+                                },
+                                "is_control": False,
+                            },
+                        },
+                    },
+                },
+                "other_metrics": {
+                    Group.OTHER: {
+                        "some_count": "Some Count",
+                        "another_count": "Another Count",
+                    },
+                },
+                "metadata": {},
+                "show_analysis": False,
+                "errors": {"experiment": []},
+            },
         }
 
         class File:
@@ -505,6 +955,8 @@ class TestFetchJetstreamDataTask(TestCase):
             DAILY_DATA,
             WEEKLY_DATA,
             OVERALL_DATA,
+            _,
+            _,
             _,
             _,
         ) = NonePointJetstreamTestData.get_test_data(primary_outcomes)
@@ -564,6 +1016,14 @@ class TestFetchJetstreamDataTask(TestCase):
                     "weekly": {},
                     "errors": {"experiment": []},
                 },
+                "v2": {
+                    "daily": {},
+                    "metadata": None,
+                    "overall": {},
+                    "show_analysis": False,
+                    "weekly": {},
+                    "errors": {"experiment": []},
+                },
             },
         )
 
@@ -590,6 +1050,13 @@ class TestFetchJetstreamDataTask(TestCase):
         )
         experiment.results_data = {
             "v1": {
+                "daily": None,
+                "metadata": None,
+                "overall": None,
+                "show_analysis": False,
+                "weekly": None,
+            },
+            "v2": {
                 "daily": None,
                 "metadata": None,
                 "overall": None,


### PR DESCRIPTION
Because

* Jetstream can compute exposure events analysis
* Experimenter does not account for exposures analysis_basis

This commit
* adds analysis_basis to the visualization schema (alongside the existing schema)