### PR TITLE
fix #8063 feat(nimbus): enable analysis bases in results page

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/AppLayoutSidebarLaunched/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/AppLayoutSidebarLaunched/index.test.tsx
@@ -47,8 +47,8 @@ const Subject = ({
     (withAnalysis
       ? {
           show_analysis: true,
-          daily: { all: [] },
-          weekly: { all: {} },
+          daily: { enrollments: { all: [] } },
+          weekly: { enrollments: { all: {} } },
           overall: mockAnalysis().overall,
           errors: mockAnalysis().errors,
           metadata: mockAnalysis().metadata,

--- a/app/experimenter/nimbus-ui/src/components/PageResults/GraphsWeekly/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/GraphsWeekly/index.test.tsx
@@ -17,7 +17,7 @@ describe("GraphsWeekly", () => {
     render(
       <RouterSlugProvider mocks={[mock]}>
         <GraphsWeekly
-          weeklyResults={mockAnalysis().weekly}
+          weeklyResults={mockAnalysis().weekly.enrollments}
           outcomeSlug="feature_d"
           outcomeName="Feature D"
           group={GROUP.OTHER}

--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableHighlights/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableHighlights/index.tsx
@@ -14,7 +14,10 @@ import {
   METRICS_TIPS,
   TABLE_LABEL,
 } from "../../../lib/visualization/constants";
-import { BranchComparisonValues } from "../../../lib/visualization/types";
+import {
+  AnalysisBases,
+  BranchComparisonValues,
+} from "../../../lib/visualization/types";
 import { getTableDisplayType } from "../../../lib/visualization/utils";
 import {
   getExperiment_experimentBySlug,
@@ -26,6 +29,7 @@ import TableVisualizationRow from "../TableVisualizationRow";
 export type TableHighlightsProps = {
   experiment: getExperiment_experimentBySlug;
   branchComparison?: BranchComparisonValues;
+  analysisBasis?: AnalysisBases;
   segment?: string;
 };
 
@@ -71,6 +75,7 @@ const getBranchDescriptions = (
 const TableHighlights = ({
   experiment,
   branchComparison = BRANCH_COMPARISON.UPLIFT,
+  analysisBasis = "enrollments",
   segment = "all",
 }: TableHighlightsProps) => {
   const { primaryOutcomes } = useOutcomes(experiment);
@@ -84,7 +89,7 @@ const TableHighlights = ({
     sortedBranchNames,
     controlBranchName,
   } = useContext(ResultsContext);
-  const overallResults = overall![segment]!;
+  const overallResults = overall![analysisBasis]?.[segment]!;
 
   return (
     <table data-testid="table-highlights" className="table mb-0 pt-2">

--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableMetricConversion/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableMetricConversion/index.tsx
@@ -10,7 +10,10 @@ import {
   GROUP,
   TABLE_LABEL,
 } from "../../../lib/visualization/constants";
-import { BranchComparisonValues } from "../../../lib/visualization/types";
+import {
+  AnalysisBases,
+  BranchComparisonValues,
+} from "../../../lib/visualization/types";
 import { getExtremeBounds } from "../../../lib/visualization/utils";
 import { getConfig_nimbusConfig_outcomes } from "../../../types/getConfig";
 import TableVisualizationRow from "../TableVisualizationRow";
@@ -24,6 +27,7 @@ type ConversionMetricStatistic = {
 
 type TableMetricConversionProps = {
   outcome: getConfig_nimbusConfig_outcomes;
+  analysisBasis?: AnalysisBases;
   segment?: string;
 };
 
@@ -43,6 +47,7 @@ const getStatistics = (slug: string): Array<ConversionMetricStatistic> => {
 
 const TableMetricConversion = ({
   outcome,
+  analysisBasis = "enrollments",
   segment = "all",
 }: TableMetricConversionProps) => {
   const {
@@ -50,12 +55,12 @@ const TableMetricConversion = ({
     sortedBranchNames,
     controlBranchName,
   } = useContext(ResultsContext);
-  const overallResults = overall![segment]!;
+  const overallResults = overall![analysisBasis]?.[segment]!;
   const conversionMetricStatistics = getStatistics(outcome.slug!);
   const metricKey = `${outcome.slug}_ever_used`;
   const bounds = getExtremeBounds(
     sortedBranchNames,
-    overall!,
+    overall![analysisBasis]!,
     outcome.slug!,
     GROUP.OTHER,
     segment,

--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableMetricCount/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableMetricCount/index.tsx
@@ -10,7 +10,10 @@ import {
   METRIC_TYPE,
   TABLE_LABEL,
 } from "../../../lib/visualization/constants";
-import { BranchComparisonValues } from "../../../lib/visualization/types";
+import {
+  AnalysisBases,
+  BranchComparisonValues,
+} from "../../../lib/visualization/types";
 import { getExtremeBounds } from "../../../lib/visualization/utils";
 import GraphsWeekly from "../GraphsWeekly";
 import TableVisualizationRow from "../TableVisualizationRow";
@@ -34,6 +37,7 @@ type TableMetricCountProps = {
   outcomeDefaultName: string;
   group: string;
   metricType?: MetricTypes;
+  analysisBasis?: AnalysisBases;
   segment?: string;
 };
 
@@ -54,6 +58,7 @@ const TableMetricCount = ({
   outcomeDefaultName,
   group,
   metricType = METRIC_TYPE.DEFAULT_SECONDARY,
+  analysisBasis = "enrollments",
   segment = "all",
 }: TableMetricCountProps) => {
   const countMetricStatistics = getStatistics(outcomeSlug);
@@ -62,11 +67,12 @@ const TableMetricCount = ({
     sortedBranchNames,
     controlBranchName,
   } = useContext(ResultsContext);
-  const overallResults = overall![segment]!;
+  const overallResults = overall![analysisBasis]?.[segment]!;
+  const weeklyBasis = weekly![analysisBasis];
 
   const bounds = getExtremeBounds(
     sortedBranchNames,
-    overall!,
+    overall![analysisBasis]!,
     outcomeSlug,
     group,
     segment,
@@ -130,9 +136,9 @@ const TableMetricCount = ({
             })}
         </tbody>
       </table>
-      {weekly?.all && (
+      {weeklyBasis?.all && (
         <GraphsWeekly
-          weeklyResults={weekly}
+          weeklyResults={weeklyBasis}
           {...{ outcomeSlug, outcomeName, group }}
         />
       )}

--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableResults/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableResults/index.tsx
@@ -14,7 +14,10 @@ import {
   RESULTS_METRICS_LIST,
   TABLE_LABEL,
 } from "../../../lib/visualization/constants";
-import { BranchComparisonValues } from "../../../lib/visualization/types";
+import {
+  AnalysisBases,
+  BranchComparisonValues,
+} from "../../../lib/visualization/types";
 import { getTableDisplayType } from "../../../lib/visualization/utils";
 import { getExperiment_experimentBySlug } from "../../../types/getExperiment";
 import TableVisualizationRow from "../TableVisualizationRow";
@@ -23,6 +26,7 @@ import TooltipWithMarkdown from "../TooltipWithMarkdown";
 export type TableResultsProps = {
   experiment: getExperiment_experimentBySlug;
   branchComparison?: BranchComparisonValues;
+  analysisBasis?: AnalysisBases;
   segment?: string;
 };
 
@@ -48,6 +52,7 @@ const getResultMetrics = (outcomes: OutcomesList) => {
 const TableResults = ({
   experiment,
   branchComparison = BRANCH_COMPARISON.UPLIFT,
+  analysisBasis = "enrollments",
   segment = "all",
 }: TableResultsProps) => {
   const { primaryOutcomes } = useOutcomes(experiment);
@@ -57,7 +62,7 @@ const TableResults = ({
     sortedBranchNames,
     controlBranchName,
   } = useContext(ResultsContext);
-  const overallResults = overall![segment]!;
+  const overallResults = overall![analysisBasis]?.[segment]!;
 
   return (
     <table

--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableResultsWeekly/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableResultsWeekly/index.tsx
@@ -13,22 +13,27 @@ import {
   GENERAL_TIPS,
   HIGHLIGHTS_METRICS_LIST,
 } from "../../../lib/visualization/constants";
-import { BranchComparisonValues } from "../../../lib/visualization/types";
+import {
+  AnalysisBases,
+  BranchComparisonValues,
+} from "../../../lib/visualization/types";
 import TableWeekly from "../TableWeekly";
 
 export type TableResultsWeeklyProps = {
   branchComparison?: BranchComparisonValues;
+  analysisBasis?: AnalysisBases;
   segment?: string;
 };
 
 const TableResultsWeekly = ({
   branchComparison = BRANCH_COMPARISON.UPLIFT,
+  analysisBasis = "enrollments",
   segment = "all",
 }: TableResultsWeeklyProps) => {
   const {
     analysis: { overall },
   } = useContext(ResultsContext);
-  const hasOverallResults = !!overall?.all;
+  const hasOverallResults = !!overall?.[analysisBasis]?.all;
   const [open, setOpen] = useState(!hasOverallResults);
 
   return (
@@ -76,6 +81,7 @@ const TableResultsWeekly = ({
                   metricName={metric.name}
                   group={metric.group}
                   {...{ branchComparison }}
+                  analysisBasis={analysisBasis}
                   segment={segment}
                 />
               </div>

--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableWeekly/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableWeekly/index.test.tsx
@@ -37,7 +37,7 @@ describe("TableWeekly", () => {
     };
 
     const analysis = mockAnalysis({
-      weekly: { all: weeklyMockAnalysis(modifications) },
+      weekly: { enrollments: { all: weeklyMockAnalysis(modifications) } },
     });
 
     render(

--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableWeekly/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableWeekly/index.tsx
@@ -9,6 +9,7 @@ import {
   TABLE_LABEL,
 } from "../../../lib/visualization/constants";
 import {
+  AnalysisBases,
   BranchComparisonValues,
   BranchDescription,
   FormattedAnalysisPoint,
@@ -21,6 +22,7 @@ type TableWeeklyProps = {
   metricName: string;
   group: string;
   branchComparison: BranchComparisonValues;
+  analysisBasis?: AnalysisBases;
   segment?: string;
 };
 
@@ -53,6 +55,7 @@ const TableWeekly = ({
   metricName,
   group,
   branchComparison,
+  analysisBasis = "enrollments",
   segment = "all",
 }: TableWeeklyProps) => {
   const {
@@ -60,7 +63,7 @@ const TableWeekly = ({
     sortedBranchNames,
     controlBranchName,
   } = useContext(ResultsContext);
-  const weeklyResults = weekly![segment]!;
+  const weeklyResults = weekly![analysisBasis]![segment]!;
   const weekIndexList = getWeekIndexList(metricKey, group, weeklyResults);
   const tableLabel = TABLE_LABEL.RESULTS;
 

--- a/app/experimenter/nimbus-ui/src/components/PageResults/TableWithTabComparison/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/TableWithTabComparison/index.tsx
@@ -5,6 +5,7 @@
 import React, { ComponentType } from "react";
 import { Tab, Tabs } from "react-bootstrap";
 import { BRANCH_COMPARISON } from "../../../lib/visualization/constants";
+import { AnalysisBases } from "../../../lib/visualization/types";
 import { getExperiment_experimentBySlug } from "../../../types/getExperiment";
 import { TableHighlightsProps } from "../TableHighlights";
 import { TableResultsProps } from "../TableResults";
@@ -20,6 +21,7 @@ export type TableWithTabComparisonProps = {
   experiment?: getExperiment_experimentBySlug;
   Table: TablesWithExperiment | TablesWithoutExperiment;
   className?: string;
+  analysisBasis?: AnalysisBases;
   segment?: string;
 };
 
@@ -27,16 +29,21 @@ export const TableWithTabComparison = ({
   experiment,
   Table,
   className = "rounded-bottom mb-5",
+  analysisBasis = "enrollments",
   segment = "all",
 }: TableWithTabComparisonProps) => (
   <Tabs defaultActiveKey={BRANCH_COMPARISON.UPLIFT} className="border-bottom-0">
     <Tab eventKey={BRANCH_COMPARISON.UPLIFT} title="Relative uplift comparison">
       <div className={`border ${className}`}>
         {experiment ? (
-          <Table {...{ experiment }} segment={segment} />
+          <Table
+            {...{ experiment }}
+            analysisBasis={analysisBasis}
+            segment={segment}
+          />
         ) : (
           /* @ts-ignore - TODO, assert Table is TablesWithoutExperiment if `experiment` not provided */
-          <Table segment={segment} />
+          <Table analysisBasis={analysisBasis} segment={segment} />
         )}
       </div>
     </Tab>
@@ -46,6 +53,7 @@ export const TableWithTabComparison = ({
           <Table
             {...{ experiment }}
             branchComparison={BRANCH_COMPARISON.ABSOLUTE}
+            analysisBasis={analysisBasis}
             segment={segment}
           />
         ) : (
@@ -53,6 +61,7 @@ export const TableWithTabComparison = ({
             {/* @ts-ignore - TODO, assert Table is TablesWithoutExperiment if `experiment` not provided */}
             <Table
               branchComparison={BRANCH_COMPARISON.ABSOLUTE}
+              analysisBasis={analysisBasis}
               segment={segment}
             />
           </>

--- a/app/experimenter/nimbus-ui/src/components/PageResults/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/index.test.tsx
@@ -24,6 +24,7 @@ import {
   mockAnalysis,
   mockAnalysisWithErrors,
   mockAnalysisWithErrorsAndResults,
+  mockAnalysisWithExposures,
   mockAnalysisWithSegments,
   MOCK_METADATA_WITH_CONFIG,
   MOCK_UNAVAILABLE_ANALYSIS,
@@ -55,8 +56,8 @@ describe("PageResults", () => {
     render(
       <Subject
         mockAnalysisData={mockAnalysis({
-          weekly: { all: {} },
-          overall: { all: {} },
+          weekly: { enrollments: { all: {} } },
+          overall: { enrollments: { all: {} } },
         })}
       />,
     );
@@ -144,6 +145,47 @@ describe("PageResults", () => {
     curSegment = container.getElementsByClassName("segmentation__single-value");
     expect(curSegment).toHaveLength(1);
     expect(curSegment[0]).toHaveTextContent(otherSegment);
+  });
+
+  it("hides the analysis basis selector when there are no exposures", async () => {
+    render(<Subject />);
+
+    expect(screen.queryByText("Analysis Basis")).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("analysis-basis-results-selector"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("displays the analysis basis options properly", async () => {
+    const { container } = render(
+      <Subject mockAnalysisData={mockAnalysisWithExposures} />,
+    );
+
+    const defaultBasis = "enrollments";
+    const otherBasis = "exposures";
+
+    expect(screen.getByText("Analysis Basis"));
+    const analysisBasisSelectParent = screen.getByTestId(
+      "analysis-basis-results-selector",
+    );
+
+    // both exist
+    expect(within(analysisBasisSelectParent).getByText(defaultBasis));
+    expect(within(analysisBasisSelectParent).getByText(otherBasis));
+
+    // enrollments checked by default
+    expect(
+      within(analysisBasisSelectParent).getByTestId(`${defaultBasis}-radio`),
+    ).toBeChecked();
+
+    fireEvent.click(
+      within(analysisBasisSelectParent).getByTestId(`${otherBasis}-radio`),
+    );
+
+    // exposures checked after click
+    expect(
+      within(analysisBasisSelectParent).getByTestId(`${otherBasis}-radio`),
+    ).toBeChecked();
   });
 
   it("displays analysis errors", async () => {

--- a/app/experimenter/nimbus-ui/src/lib/contexts.ts
+++ b/app/experimenter/nimbus-ui/src/lib/contexts.ts
@@ -16,9 +16,9 @@ export type ResultsContextType = {
 
 export const defaultResultsContext = {
   analysis: {
-    daily: { all: [] },
-    weekly: { all: {} },
-    overall: { all: {} },
+    daily: { enrollments: { all: [] } },
+    weekly: { enrollments: { all: {} } },
+    overall: { enrollments: { all: {} } },
     errors: { experiment: [] },
     metadata: { metrics: {}, outcomes: {}, external_config: null },
     show_analysis: false,

--- a/app/experimenter/nimbus-ui/src/lib/visualization/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/lib/visualization/mocks.tsx
@@ -453,632 +453,634 @@ export const mockAnalysis = (modifications = {}) =>
           },
         ],
       },
-      daily: { all: [] },
-      weekly: { all: weeklyMockAnalysis() },
+      daily: { enrollments: { all: [] } },
+      weekly: { enrollments: { all: weeklyMockAnalysis() } },
       overall: {
-        all: {
-          control: {
-            is_control: true,
-            branch_data: {
-              other_metrics: {
-                identity: {
-                  absolute: {
-                    all: [
-                      {
+        enrollments: {
+          all: {
+            control: {
+              is_control: true,
+              branch_data: {
+                other_metrics: {
+                  identity: {
+                    absolute: {
+                      all: [
+                        {
+                          point: 198,
+                        },
+                      ],
+                      first: {
                         point: 198,
                       },
-                    ],
-                    first: {
-                      point: 198,
                     },
-                  },
-                  difference: {
-                    first: {},
-                    all: [],
-                  },
-                  relative_uplift: {
-                    first: {},
-                    all: [],
-                  },
-                  percent: 45,
-                },
-                retained: {
-                  absolute: {
-                    all: [
-                      {
-                        point: 0.9261083743842364,
-                        lower: 0.8864481497569532,
-                        upper: 0.9578449264993547,
-                      },
-                    ],
-                    first: {
-                      point: 14.967359019193298,
-                      lower: 10.534758870048162,
-                      upper: 20.754349791764547,
+                    difference: {
+                      first: {},
+                      all: [],
                     },
-                  },
-                  difference: {
-                    first: {},
-                    all: [],
-                  },
-                  relative_uplift: {
-                    first: {},
-                    all: [],
-                  },
-                },
-                picture_in_picture_ever_used: {
-                  absolute: {
-                    first: {
-                      point: 0.05,
-                      count: 10,
-                      lower: 0.024357271316207685,
-                      upper: 0.08411463700173483,
+                    relative_uplift: {
+                      first: {},
+                      all: [],
                     },
-                    all: [
-                      {
-                        point: 0.05,
-                        count: 10,
-                        lower: 0.024357271316207685,
-                        upper: 0.08411463700173483,
-                      },
-                    ],
+                    percent: 45,
                   },
-                  difference: {
-                    first: {},
-                    all: [],
-                  },
-                  relative_uplift: {
-                    first: {},
-                    all: [],
-                  },
-                },
-                picture_in_picture: {
-                  absolute: {
-                    first: {
-                      point: 0.05,
-                      count: 10,
-                      lower: 0.024357271316207685,
-                      upper: 0.08411463700173483,
-                    },
-                    all: [
-                      {
-                        point: 0.05,
-                        count: 10,
-                        lower: 0.024357271316207685,
-                        upper: 0.08411463700173483,
-                      },
-                    ],
-                  },
-                  difference: {
-                    first: {},
-                    all: [],
-                  },
-                  relative_uplift: {
-                    first: {},
-                    all: [],
-                  },
-                },
-                feature_b_ever_used: {
-                  absolute: {
-                    first: {
-                      point: 0.05,
-                      count: 10,
-                      lower: 0.024357271316207685,
-                      upper: 0.08411463700173483,
-                    },
-                    all: [
-                      {
-                        point: 0.05,
-                        count: 10,
-                        lower: 0.024357271316207685,
-                        upper: 0.08411463700173483,
-                      },
-                    ],
-                  },
-                  difference: {
-                    first: {},
-                    all: [],
-                  },
-                  relative_uplift: {
-                    first: {},
-                    all: [],
-                  },
-                },
-                feature_b: {
-                  absolute: {
-                    first: {
-                      point: 0.05,
-                      count: 10,
-                      lower: 0.024357271316207685,
-                      upper: 0.08411463700173483,
-                    },
-                    all: [
-                      {
-                        point: 0.05,
-                        count: 10,
-                        lower: 0.024357271316207685,
-                        upper: 0.08411463700173483,
-                      },
-                    ],
-                  },
-                  difference: {
-                    first: {},
-                    all: [],
-                  },
-                  relative_uplift: {
-                    first: {},
-                    all: [],
-                  },
-                },
-                feature_c_ever_used: {
-                  absolute: {
-                    first: {
-                      point: 0.05,
-                      count: 10,
-                      lower: 0.024357271316207685,
-                      upper: 0.08411463700173483,
-                    },
-                    all: [
-                      {
-                        point: 0.05,
-                        count: 10,
-                        lower: 0.024357271316207685,
-                        upper: 0.08411463700173483,
-                      },
-                    ],
-                  },
-                  difference: {
-                    first: {},
-                    all: [],
-                  },
-                  relative_uplift: {
-                    first: {},
-                    all: [],
-                  },
-                },
-                feature_c: CONTROL_NEUTRAL,
-                feature_d: {
-                  absolute: {
-                    first: {
-                      point: 0.05,
-                      count: 10,
-                      lower: 0.024357271316207685,
-                      upper: 0.08411463700173483,
-                    },
-                    all: [
-                      {
-                        point: 0.05,
-                        count: 10,
-                        lower: 0.024357271316207685,
-                        upper: 0.08411463700173483,
-                      },
-                    ],
-                  },
-                  difference: {
-                    first: {},
-                    all: [],
-                  },
-                  relative_uplift: {
-                    first: {},
-                    all: [],
-                  },
-                },
-                outcome_d: {
-                  absolute: {
-                    first: {
-                      point: 0.05,
-                      count: 10,
-                      lower: 0.024357271316207685,
-                      upper: 0.08411463700173483,
-                    },
-                    all: [
-                      {
-                        point: 0.05,
-                        count: 10,
-                        lower: 0.024357271316207685,
-                        upper: 0.08411463700173483,
-                      },
-                    ],
-                  },
-                  difference: {
-                    first: {},
-                    all: [],
-                  },
-                  relative_uplift: {
-                    first: {},
-                    all: [],
-                  },
-                },
-                days_of_use: CONTROL_NEUTRAL,
-              },
-              search_metrics: {
-                search_count: {
-                  absolute: {
-                    all: [
-                      {
+                  retained: {
+                    absolute: {
+                      all: [
+                        {
+                          point: 0.9261083743842364,
+                          lower: 0.8864481497569532,
+                          upper: 0.9578449264993547,
+                        },
+                      ],
+                      first: {
                         point: 14.967359019193298,
                         lower: 10.534758870048162,
                         upper: 20.754349791764547,
                       },
-                    ],
-                    first: {
-                      point: 14.967359019193298,
-                      lower: 10.534758870048162,
-                      upper: 20.754349791764547,
+                    },
+                    difference: {
+                      first: {},
+                      all: [],
+                    },
+                    relative_uplift: {
+                      first: {},
+                      all: [],
                     },
                   },
-                  difference: {
-                    first: {},
-                    all: [],
+                  picture_in_picture_ever_used: {
+                    absolute: {
+                      first: {
+                        point: 0.05,
+                        count: 10,
+                        lower: 0.024357271316207685,
+                        upper: 0.08411463700173483,
+                      },
+                      all: [
+                        {
+                          point: 0.05,
+                          count: 10,
+                          lower: 0.024357271316207685,
+                          upper: 0.08411463700173483,
+                        },
+                      ],
+                    },
+                    difference: {
+                      first: {},
+                      all: [],
+                    },
+                    relative_uplift: {
+                      first: {},
+                      all: [],
+                    },
                   },
-                  relative_uplift: {
-                    first: {},
-                    all: [],
+                  picture_in_picture: {
+                    absolute: {
+                      first: {
+                        point: 0.05,
+                        count: 10,
+                        lower: 0.024357271316207685,
+                        upper: 0.08411463700173483,
+                      },
+                      all: [
+                        {
+                          point: 0.05,
+                          count: 10,
+                          lower: 0.024357271316207685,
+                          upper: 0.08411463700173483,
+                        },
+                      ],
+                    },
+                    difference: {
+                      first: {},
+                      all: [],
+                    },
+                    relative_uplift: {
+                      first: {},
+                      all: [],
+                    },
+                  },
+                  feature_b_ever_used: {
+                    absolute: {
+                      first: {
+                        point: 0.05,
+                        count: 10,
+                        lower: 0.024357271316207685,
+                        upper: 0.08411463700173483,
+                      },
+                      all: [
+                        {
+                          point: 0.05,
+                          count: 10,
+                          lower: 0.024357271316207685,
+                          upper: 0.08411463700173483,
+                        },
+                      ],
+                    },
+                    difference: {
+                      first: {},
+                      all: [],
+                    },
+                    relative_uplift: {
+                      first: {},
+                      all: [],
+                    },
+                  },
+                  feature_b: {
+                    absolute: {
+                      first: {
+                        point: 0.05,
+                        count: 10,
+                        lower: 0.024357271316207685,
+                        upper: 0.08411463700173483,
+                      },
+                      all: [
+                        {
+                          point: 0.05,
+                          count: 10,
+                          lower: 0.024357271316207685,
+                          upper: 0.08411463700173483,
+                        },
+                      ],
+                    },
+                    difference: {
+                      first: {},
+                      all: [],
+                    },
+                    relative_uplift: {
+                      first: {},
+                      all: [],
+                    },
+                  },
+                  feature_c_ever_used: {
+                    absolute: {
+                      first: {
+                        point: 0.05,
+                        count: 10,
+                        lower: 0.024357271316207685,
+                        upper: 0.08411463700173483,
+                      },
+                      all: [
+                        {
+                          point: 0.05,
+                          count: 10,
+                          lower: 0.024357271316207685,
+                          upper: 0.08411463700173483,
+                        },
+                      ],
+                    },
+                    difference: {
+                      first: {},
+                      all: [],
+                    },
+                    relative_uplift: {
+                      first: {},
+                      all: [],
+                    },
+                  },
+                  feature_c: CONTROL_NEUTRAL,
+                  feature_d: {
+                    absolute: {
+                      first: {
+                        point: 0.05,
+                        count: 10,
+                        lower: 0.024357271316207685,
+                        upper: 0.08411463700173483,
+                      },
+                      all: [
+                        {
+                          point: 0.05,
+                          count: 10,
+                          lower: 0.024357271316207685,
+                          upper: 0.08411463700173483,
+                        },
+                      ],
+                    },
+                    difference: {
+                      first: {},
+                      all: [],
+                    },
+                    relative_uplift: {
+                      first: {},
+                      all: [],
+                    },
+                  },
+                  outcome_d: {
+                    absolute: {
+                      first: {
+                        point: 0.05,
+                        count: 10,
+                        lower: 0.024357271316207685,
+                        upper: 0.08411463700173483,
+                      },
+                      all: [
+                        {
+                          point: 0.05,
+                          count: 10,
+                          lower: 0.024357271316207685,
+                          upper: 0.08411463700173483,
+                        },
+                      ],
+                    },
+                    difference: {
+                      first: {},
+                      all: [],
+                    },
+                    relative_uplift: {
+                      first: {},
+                      all: [],
+                    },
+                  },
+                  days_of_use: CONTROL_NEUTRAL,
+                },
+                search_metrics: {
+                  search_count: {
+                    absolute: {
+                      all: [
+                        {
+                          point: 14.967359019193298,
+                          lower: 10.534758870048162,
+                          upper: 20.754349791764547,
+                        },
+                      ],
+                      first: {
+                        point: 14.967359019193298,
+                        lower: 10.534758870048162,
+                        upper: 20.754349791764547,
+                      },
+                    },
+                    difference: {
+                      first: {},
+                      all: [],
+                    },
+                    relative_uplift: {
+                      first: {},
+                      all: [],
+                    },
                   },
                 },
               },
             },
-          },
-          treatment: {
-            is_control: false,
-            branch_data: {
-              other_metrics: {
-                identity: {
-                  absolute: {
-                    first: {
-                      point: 200,
-                    },
-                    all: [
-                      {
+            treatment: {
+              is_control: false,
+              branch_data: {
+                other_metrics: {
+                  identity: {
+                    absolute: {
+                      first: {
                         point: 200,
                       },
-                    ],
-                  },
-                  difference: {
-                    first: {},
-                    all: [],
-                  },
-                  relative_uplift: {
-                    first: {},
-                    all: [],
-                  },
-                  percent: 55,
-                },
-                retained: TREATMENT_NEUTRAL,
-                picture_in_picture_ever_used: {
-                  absolute: {
-                    first: {
-                      point: 0.049019607843137254,
-                      count: 10,
-                      lower: 0.023872203557007872,
-                      upper: 0.08249069209461024,
+                      all: [
+                        {
+                          point: 200,
+                        },
+                      ],
                     },
-                    all: [
-                      {
+                    difference: {
+                      first: {},
+                      all: [],
+                    },
+                    relative_uplift: {
+                      first: {},
+                      all: [],
+                    },
+                    percent: 55,
+                  },
+                  retained: TREATMENT_NEUTRAL,
+                  picture_in_picture_ever_used: {
+                    absolute: {
+                      first: {
                         point: 0.049019607843137254,
                         count: 10,
                         lower: 0.023872203557007872,
                         upper: 0.08249069209461024,
                       },
-                    ],
-                  },
-                  difference: {
-                    first: {
-                      point: -0.0006569487628876534,
-                      upper: 0.04316381736512019,
-                      lower: 0.04175095963994029,
+                      all: [
+                        {
+                          point: 0.049019607843137254,
+                          count: 10,
+                          lower: 0.023872203557007872,
+                          upper: 0.08249069209461024,
+                        },
+                      ],
                     },
-                    all: [
-                      {
+                    difference: {
+                      first: {
                         point: -0.0006569487628876534,
                         upper: 0.04316381736512019,
                         lower: 0.04175095963994029,
                       },
-                    ],
-                  },
-                  relative_uplift: {
-                    first: {
-                      lower: -0.455210299676828,
-                      upper: 0.5104985718410426,
-                      point: -0.06233954570562385,
+                      all: [
+                        {
+                          point: -0.0006569487628876534,
+                          upper: 0.04316381736512019,
+                          lower: 0.04175095963994029,
+                        },
+                      ],
                     },
-                    all: [
-                      {
+                    relative_uplift: {
+                      first: {
                         lower: -0.455210299676828,
                         upper: 0.5104985718410426,
                         point: -0.06233954570562385,
                       },
-                    ],
-                  },
-                  significance: { overall: { "1": "positive" }, weekly: {} },
-                },
-                picture_in_picture: {
-                  absolute: {
-                    first: {
-                      point: 0.049019607843137254,
-                      count: 10,
-                      lower: 0.023872203557007872,
-                      upper: 0.08249069209461024,
+                      all: [
+                        {
+                          lower: -0.455210299676828,
+                          upper: 0.5104985718410426,
+                          point: -0.06233954570562385,
+                        },
+                      ],
                     },
-                    all: [
-                      {
+                    significance: { overall: { "1": "positive" }, weekly: {} },
+                  },
+                  picture_in_picture: {
+                    absolute: {
+                      first: {
                         point: 0.049019607843137254,
                         count: 10,
                         lower: 0.023872203557007872,
                         upper: 0.08249069209461024,
                       },
-                    ],
-                  },
-                  difference: {
-                    first: {
-                      point: -0.0006569487628876534,
-                      upper: 0.04316381736512019,
-                      lower: 0.04175095963994029,
+                      all: [
+                        {
+                          point: 0.049019607843137254,
+                          count: 10,
+                          lower: 0.023872203557007872,
+                          upper: 0.08249069209461024,
+                        },
+                      ],
                     },
-                    all: [
-                      {
+                    difference: {
+                      first: {
                         point: -0.0006569487628876534,
                         upper: 0.04316381736512019,
                         lower: 0.04175095963994029,
                       },
-                    ],
-                  },
-                  relative_uplift: {
-                    first: {
-                      lower: -0.455210299676828,
-                      upper: 0.5104985718410426,
-                      point: -0.06233954570562385,
+                      all: [
+                        {
+                          point: -0.0006569487628876534,
+                          upper: 0.04316381736512019,
+                          lower: 0.04175095963994029,
+                        },
+                      ],
                     },
-                    all: [
-                      {
+                    relative_uplift: {
+                      first: {
                         lower: -0.455210299676828,
                         upper: 0.5104985718410426,
                         point: -0.06233954570562385,
                       },
-                    ],
-                  },
-                  significance: { overall: { "1": "positive" }, weekly: {} },
-                },
-                feature_b_ever_used: {
-                  absolute: {
-                    first: {
-                      point: 0.049019607843137254,
-                      count: 10,
-                      lower: 0.023872203557007872,
-                      upper: 0.08249069209461024,
+                      all: [
+                        {
+                          lower: -0.455210299676828,
+                          upper: 0.5104985718410426,
+                          point: -0.06233954570562385,
+                        },
+                      ],
                     },
-                    all: [
-                      {
+                    significance: { overall: { "1": "positive" }, weekly: {} },
+                  },
+                  feature_b_ever_used: {
+                    absolute: {
+                      first: {
                         point: 0.049019607843137254,
                         count: 10,
                         lower: 0.023872203557007872,
                         upper: 0.08249069209461024,
                       },
-                    ],
-                  },
-                  difference: {
-                    first: {
-                      point: -0.0006569487628876534,
-                      upper: 0.04316381736512019,
-                      lower: 0.04175095963994029,
+                      all: [
+                        {
+                          point: 0.049019607843137254,
+                          count: 10,
+                          lower: 0.023872203557007872,
+                          upper: 0.08249069209461024,
+                        },
+                      ],
                     },
-                    all: [
-                      {
+                    difference: {
+                      first: {
                         point: -0.0006569487628876534,
                         upper: 0.04316381736512019,
                         lower: 0.04175095963994029,
                       },
-                    ],
-                  },
-                  relative_uplift: {
-                    first: {
-                      lower: -0.455210299676828,
-                      upper: 0.5104985718410426,
-                      point: -0.06233954570562385,
+                      all: [
+                        {
+                          point: -0.0006569487628876534,
+                          upper: 0.04316381736512019,
+                          lower: 0.04175095963994029,
+                        },
+                      ],
                     },
-                    all: [
-                      {
+                    relative_uplift: {
+                      first: {
                         lower: -0.455210299676828,
                         upper: 0.5104985718410426,
                         point: -0.06233954570562385,
                       },
-                    ],
-                  },
-                  significance: { overall: { "1": "negative" }, weekly: {} },
-                },
-                feature_b: {
-                  absolute: {
-                    first: {
-                      point: 0.049019607843137254,
-                      count: 10,
-                      lower: 0.023872203557007872,
-                      upper: 0.08249069209461024,
+                      all: [
+                        {
+                          lower: -0.455210299676828,
+                          upper: 0.5104985718410426,
+                          point: -0.06233954570562385,
+                        },
+                      ],
                     },
-                    all: [
-                      {
+                    significance: { overall: { "1": "negative" }, weekly: {} },
+                  },
+                  feature_b: {
+                    absolute: {
+                      first: {
                         point: 0.049019607843137254,
                         count: 10,
                         lower: 0.023872203557007872,
                         upper: 0.08249069209461024,
                       },
-                    ],
-                  },
-                  difference: {
-                    first: {
-                      point: -0.0006569487628876534,
-                      upper: 0.04316381736512019,
-                      lower: 0.04175095963994029,
+                      all: [
+                        {
+                          point: 0.049019607843137254,
+                          count: 10,
+                          lower: 0.023872203557007872,
+                          upper: 0.08249069209461024,
+                        },
+                      ],
                     },
-                    all: [
-                      {
+                    difference: {
+                      first: {
                         point: -0.0006569487628876534,
                         upper: 0.04316381736512019,
                         lower: 0.04175095963994029,
                       },
-                    ],
-                  },
-                  relative_uplift: {
-                    first: {
-                      lower: -0.455210299676828,
-                      upper: 0.5104985718410426,
-                      point: -0.06233954570562385,
+                      all: [
+                        {
+                          point: -0.0006569487628876534,
+                          upper: 0.04316381736512019,
+                          lower: 0.04175095963994029,
+                        },
+                      ],
                     },
-                    all: [
-                      {
+                    relative_uplift: {
+                      first: {
                         lower: -0.455210299676828,
                         upper: 0.5104985718410426,
                         point: -0.06233954570562385,
                       },
-                    ],
-                  },
-                  significance: { overall: { "1": "negative" }, weekly: {} },
-                },
-                feature_c_ever_used: {
-                  absolute: {
-                    first: {
-                      point: 0.049019607843137254,
-                      count: 10,
-                      lower: 0.023872203557007872,
-                      upper: 0.08249069209461024,
+                      all: [
+                        {
+                          lower: -0.455210299676828,
+                          upper: 0.5104985718410426,
+                          point: -0.06233954570562385,
+                        },
+                      ],
                     },
-                    all: [
-                      {
+                    significance: { overall: { "1": "negative" }, weekly: {} },
+                  },
+                  feature_c_ever_used: {
+                    absolute: {
+                      first: {
                         point: 0.049019607843137254,
                         count: 10,
                         lower: 0.023872203557007872,
                         upper: 0.08249069209461024,
                       },
-                    ],
-                  },
-                  difference: {
-                    first: {
-                      point: -0.0006569487628876534,
-                      upper: 0.04316381736512019,
-                      lower: 0.04175095963994029,
+                      all: [
+                        {
+                          point: 0.049019607843137254,
+                          count: 10,
+                          lower: 0.023872203557007872,
+                          upper: 0.08249069209461024,
+                        },
+                      ],
                     },
-                    all: [
-                      {
+                    difference: {
+                      first: {
                         point: -0.0006569487628876534,
                         upper: 0.04316381736512019,
                         lower: 0.04175095963994029,
                       },
-                    ],
-                  },
-                  relative_uplift: {
-                    first: {
-                      lower: -0.455210299676828,
-                      upper: 0.5104985718410426,
-                      point: -0.06233954570562385,
+                      all: [
+                        {
+                          point: -0.0006569487628876534,
+                          upper: 0.04316381736512019,
+                          lower: 0.04175095963994029,
+                        },
+                      ],
                     },
-                    all: [
-                      {
+                    relative_uplift: {
+                      first: {
                         lower: -0.455210299676828,
                         upper: 0.5104985718410426,
                         point: -0.06233954570562385,
                       },
-                    ],
-                  },
-                  significance: { overall: { "1": "neutral" }, weekly: {} },
-                },
-                feature_c: TREATMENT_NEUTRAL,
-                days_of_use: TREATMENT_NEUTRAL,
-                feature_d: {
-                  absolute: {
-                    first: {
-                      point: 0.049019607843137254,
-                      count: 10,
-                      lower: 0.023872203557007872,
-                      upper: 0.08249069209461024,
+                      all: [
+                        {
+                          lower: -0.455210299676828,
+                          upper: 0.5104985718410426,
+                          point: -0.06233954570562385,
+                        },
+                      ],
                     },
-                    all: [
-                      {
+                    significance: { overall: { "1": "neutral" }, weekly: {} },
+                  },
+                  feature_c: TREATMENT_NEUTRAL,
+                  days_of_use: TREATMENT_NEUTRAL,
+                  feature_d: {
+                    absolute: {
+                      first: {
                         point: 0.049019607843137254,
                         count: 10,
                         lower: 0.023872203557007872,
                         upper: 0.08249069209461024,
                       },
-                    ],
-                  },
-                  difference: {
-                    first: {
-                      point: -0.0006569487628876534,
-                      upper: 0.04316381736512019,
-                      lower: 0.04175095963994029,
+                      all: [
+                        {
+                          point: 0.049019607843137254,
+                          count: 10,
+                          lower: 0.023872203557007872,
+                          upper: 0.08249069209461024,
+                        },
+                      ],
                     },
-                    all: [
-                      {
+                    difference: {
+                      first: {
                         point: -0.0006569487628876534,
                         upper: 0.04316381736512019,
                         lower: 0.04175095963994029,
                       },
-                    ],
-                  },
-                  relative_uplift: {
-                    first: {
-                      lower: -0.455210299676828,
-                      upper: 0.5104985718410426,
-                      point: -0.06233954570562385,
+                      all: [
+                        {
+                          point: -0.0006569487628876534,
+                          upper: 0.04316381736512019,
+                          lower: 0.04175095963994029,
+                        },
+                      ],
                     },
-                    all: [
-                      {
+                    relative_uplift: {
+                      first: {
                         lower: -0.455210299676828,
                         upper: 0.5104985718410426,
                         point: -0.06233954570562385,
                       },
-                    ],
-                  },
-                  significance: { overall: { "1": "positive" }, weekly: {} },
-                },
-                outcome_d: {
-                  absolute: {
-                    first: {
-                      point: 0.049019607843137254,
-                      count: 10,
-                      lower: 0.023872203557007872,
-                      upper: 0.08249069209461024,
+                      all: [
+                        {
+                          lower: -0.455210299676828,
+                          upper: 0.5104985718410426,
+                          point: -0.06233954570562385,
+                        },
+                      ],
                     },
-                    all: [
-                      {
+                    significance: { overall: { "1": "positive" }, weekly: {} },
+                  },
+                  outcome_d: {
+                    absolute: {
+                      first: {
                         point: 0.049019607843137254,
                         count: 10,
                         lower: 0.023872203557007872,
                         upper: 0.08249069209461024,
                       },
-                    ],
-                  },
-                  difference: {
-                    first: {
-                      point: -0.0006569487628876534,
-                      upper: 0.04316381736512019,
-                      lower: 0.04175095963994029,
+                      all: [
+                        {
+                          point: 0.049019607843137254,
+                          count: 10,
+                          lower: 0.023872203557007872,
+                          upper: 0.08249069209461024,
+                        },
+                      ],
                     },
-                    all: [
-                      {
+                    difference: {
+                      first: {
                         point: -0.0006569487628876534,
                         upper: 0.04316381736512019,
                         lower: 0.04175095963994029,
                       },
-                    ],
-                  },
-                  relative_uplift: {
-                    first: {
-                      lower: -0.455210299676828,
-                      upper: 0.5104985718410426,
-                      point: -0.06233954570562385,
+                      all: [
+                        {
+                          point: -0.0006569487628876534,
+                          upper: 0.04316381736512019,
+                          lower: 0.04175095963994029,
+                        },
+                      ],
                     },
-                    all: [
-                      {
+                    relative_uplift: {
+                      first: {
                         lower: -0.455210299676828,
                         upper: 0.5104985718410426,
                         point: -0.06233954570562385,
                       },
-                    ],
+                      all: [
+                        {
+                          lower: -0.455210299676828,
+                          upper: 0.5104985718410426,
+                          point: -0.06233954570562385,
+                        },
+                      ],
+                    },
+                    significance: { overall: { "1": "positive" }, weekly: {} },
                   },
-                  significance: { overall: { "1": "positive" }, weekly: {} },
                 },
-              },
-              search_metrics: {
-                search_count: TREATMENT_NEGATIVE,
+                search_metrics: {
+                  search_count: TREATMENT_NEGATIVE,
+                },
               },
             },
           },
@@ -1090,1256 +1092,2521 @@ export const mockAnalysis = (modifications = {}) =>
 
 export const mockAnalysisWithSegments = mockAnalysis({
   overall: {
-    all: {
-      control: {
-        is_control: true,
-        branch_data: {
-          other_metrics: {
-            identity: {
-              absolute: {
-                all: [
-                  {
+    enrollments: {
+      all: {
+        control: {
+          is_control: true,
+          branch_data: {
+            other_metrics: {
+              identity: {
+                absolute: {
+                  all: [
+                    {
+                      point: 198,
+                    },
+                  ],
+                  first: {
                     point: 198,
                   },
-                ],
-                first: {
-                  point: 198,
                 },
-              },
-              difference: {
-                first: {},
-                all: [],
-              },
-              relative_uplift: {
-                first: {},
-                all: [],
-              },
-              percent: 45,
-            },
-            retained: {
-              absolute: {
-                all: [
-                  {
-                    point: 0.9261083743842364,
-                    lower: 0.8864481497569532,
-                    upper: 0.9578449264993547,
-                  },
-                ],
-                first: {
-                  point: 14.967359019193298,
-                  lower: 10.534758870048162,
-                  upper: 20.754349791764547,
+                difference: {
+                  first: {},
+                  all: [],
                 },
-              },
-              difference: {
-                first: {},
-                all: [],
-              },
-              relative_uplift: {
-                first: {},
-                all: [],
-              },
-            },
-            picture_in_picture_ever_used: {
-              absolute: {
-                first: {
-                  point: 0.05,
-                  count: 10,
-                  lower: 0.024357271316207685,
-                  upper: 0.08411463700173483,
+                relative_uplift: {
+                  first: {},
+                  all: [],
                 },
-                all: [
-                  {
-                    point: 0.05,
-                    count: 10,
-                    lower: 0.024357271316207685,
-                    upper: 0.08411463700173483,
-                  },
-                ],
+                percent: 45,
               },
-              difference: {
-                first: {},
-                all: [],
-              },
-              relative_uplift: {
-                first: {},
-                all: [],
-              },
-            },
-            picture_in_picture: {
-              absolute: {
-                first: {
-                  point: 0.05,
-                  count: 10,
-                  lower: 0.024357271316207685,
-                  upper: 0.08411463700173483,
-                },
-                all: [
-                  {
-                    point: 0.05,
-                    count: 10,
-                    lower: 0.024357271316207685,
-                    upper: 0.08411463700173483,
-                  },
-                ],
-              },
-              difference: {
-                first: {},
-                all: [],
-              },
-              relative_uplift: {
-                first: {},
-                all: [],
-              },
-            },
-            feature_b_ever_used: {
-              absolute: {
-                first: {
-                  point: 0.05,
-                  count: 10,
-                  lower: 0.024357271316207685,
-                  upper: 0.08411463700173483,
-                },
-                all: [
-                  {
-                    point: 0.05,
-                    count: 10,
-                    lower: 0.024357271316207685,
-                    upper: 0.08411463700173483,
-                  },
-                ],
-              },
-              difference: {
-                first: {},
-                all: [],
-              },
-              relative_uplift: {
-                first: {},
-                all: [],
-              },
-            },
-            feature_b: {
-              absolute: {
-                first: {
-                  point: 0.05,
-                  count: 10,
-                  lower: 0.024357271316207685,
-                  upper: 0.08411463700173483,
-                },
-                all: [
-                  {
-                    point: 0.05,
-                    count: 10,
-                    lower: 0.024357271316207685,
-                    upper: 0.08411463700173483,
-                  },
-                ],
-              },
-              difference: {
-                first: {},
-                all: [],
-              },
-              relative_uplift: {
-                first: {},
-                all: [],
-              },
-            },
-            feature_c_ever_used: {
-              absolute: {
-                first: {
-                  point: 0.05,
-                  count: 10,
-                  lower: 0.024357271316207685,
-                  upper: 0.08411463700173483,
-                },
-                all: [
-                  {
-                    point: 0.05,
-                    count: 10,
-                    lower: 0.024357271316207685,
-                    upper: 0.08411463700173483,
-                  },
-                ],
-              },
-              difference: {
-                first: {},
-                all: [],
-              },
-              relative_uplift: {
-                first: {},
-                all: [],
-              },
-            },
-            feature_c: CONTROL_NEUTRAL,
-            feature_d: {
-              absolute: {
-                first: {
-                  point: 0.05,
-                  count: 10,
-                  lower: 0.024357271316207685,
-                  upper: 0.08411463700173483,
-                },
-                all: [
-                  {
-                    point: 0.05,
-                    count: 10,
-                    lower: 0.024357271316207685,
-                    upper: 0.08411463700173483,
-                  },
-                ],
-              },
-              difference: {
-                first: {},
-                all: [],
-              },
-              relative_uplift: {
-                first: {},
-                all: [],
-              },
-            },
-            outcome_d: {
-              absolute: {
-                first: {
-                  point: 0.05,
-                  count: 10,
-                  lower: 0.024357271316207685,
-                  upper: 0.08411463700173483,
-                },
-                all: [
-                  {
-                    point: 0.05,
-                    count: 10,
-                    lower: 0.024357271316207685,
-                    upper: 0.08411463700173483,
-                  },
-                ],
-              },
-              difference: {
-                first: {},
-                all: [],
-              },
-              relative_uplift: {
-                first: {},
-                all: [],
-              },
-            },
-            days_of_use: CONTROL_NEUTRAL,
-          },
-          search_metrics: {
-            search_count: {
-              absolute: {
-                all: [
-                  {
+              retained: {
+                absolute: {
+                  all: [
+                    {
+                      point: 0.9261083743842364,
+                      lower: 0.8864481497569532,
+                      upper: 0.9578449264993547,
+                    },
+                  ],
+                  first: {
                     point: 14.967359019193298,
                     lower: 10.534758870048162,
                     upper: 20.754349791764547,
                   },
-                ],
-                first: {
-                  point: 14.967359019193298,
-                  lower: 10.534758870048162,
-                  upper: 20.754349791764547,
+                },
+                difference: {
+                  first: {},
+                  all: [],
+                },
+                relative_uplift: {
+                  first: {},
+                  all: [],
                 },
               },
-              difference: {
-                first: {},
-                all: [],
+              picture_in_picture_ever_used: {
+                absolute: {
+                  first: {
+                    point: 0.05,
+                    count: 10,
+                    lower: 0.024357271316207685,
+                    upper: 0.08411463700173483,
+                  },
+                  all: [
+                    {
+                      point: 0.05,
+                      count: 10,
+                      lower: 0.024357271316207685,
+                      upper: 0.08411463700173483,
+                    },
+                  ],
+                },
+                difference: {
+                  first: {},
+                  all: [],
+                },
+                relative_uplift: {
+                  first: {},
+                  all: [],
+                },
               },
-              relative_uplift: {
-                first: {},
-                all: [],
+              picture_in_picture: {
+                absolute: {
+                  first: {
+                    point: 0.05,
+                    count: 10,
+                    lower: 0.024357271316207685,
+                    upper: 0.08411463700173483,
+                  },
+                  all: [
+                    {
+                      point: 0.05,
+                      count: 10,
+                      lower: 0.024357271316207685,
+                      upper: 0.08411463700173483,
+                    },
+                  ],
+                },
+                difference: {
+                  first: {},
+                  all: [],
+                },
+                relative_uplift: {
+                  first: {},
+                  all: [],
+                },
+              },
+              feature_b_ever_used: {
+                absolute: {
+                  first: {
+                    point: 0.05,
+                    count: 10,
+                    lower: 0.024357271316207685,
+                    upper: 0.08411463700173483,
+                  },
+                  all: [
+                    {
+                      point: 0.05,
+                      count: 10,
+                      lower: 0.024357271316207685,
+                      upper: 0.08411463700173483,
+                    },
+                  ],
+                },
+                difference: {
+                  first: {},
+                  all: [],
+                },
+                relative_uplift: {
+                  first: {},
+                  all: [],
+                },
+              },
+              feature_b: {
+                absolute: {
+                  first: {
+                    point: 0.05,
+                    count: 10,
+                    lower: 0.024357271316207685,
+                    upper: 0.08411463700173483,
+                  },
+                  all: [
+                    {
+                      point: 0.05,
+                      count: 10,
+                      lower: 0.024357271316207685,
+                      upper: 0.08411463700173483,
+                    },
+                  ],
+                },
+                difference: {
+                  first: {},
+                  all: [],
+                },
+                relative_uplift: {
+                  first: {},
+                  all: [],
+                },
+              },
+              feature_c_ever_used: {
+                absolute: {
+                  first: {
+                    point: 0.05,
+                    count: 10,
+                    lower: 0.024357271316207685,
+                    upper: 0.08411463700173483,
+                  },
+                  all: [
+                    {
+                      point: 0.05,
+                      count: 10,
+                      lower: 0.024357271316207685,
+                      upper: 0.08411463700173483,
+                    },
+                  ],
+                },
+                difference: {
+                  first: {},
+                  all: [],
+                },
+                relative_uplift: {
+                  first: {},
+                  all: [],
+                },
+              },
+              feature_c: CONTROL_NEUTRAL,
+              feature_d: {
+                absolute: {
+                  first: {
+                    point: 0.05,
+                    count: 10,
+                    lower: 0.024357271316207685,
+                    upper: 0.08411463700173483,
+                  },
+                  all: [
+                    {
+                      point: 0.05,
+                      count: 10,
+                      lower: 0.024357271316207685,
+                      upper: 0.08411463700173483,
+                    },
+                  ],
+                },
+                difference: {
+                  first: {},
+                  all: [],
+                },
+                relative_uplift: {
+                  first: {},
+                  all: [],
+                },
+              },
+              outcome_d: {
+                absolute: {
+                  first: {
+                    point: 0.05,
+                    count: 10,
+                    lower: 0.024357271316207685,
+                    upper: 0.08411463700173483,
+                  },
+                  all: [
+                    {
+                      point: 0.05,
+                      count: 10,
+                      lower: 0.024357271316207685,
+                      upper: 0.08411463700173483,
+                    },
+                  ],
+                },
+                difference: {
+                  first: {},
+                  all: [],
+                },
+                relative_uplift: {
+                  first: {},
+                  all: [],
+                },
+              },
+              days_of_use: CONTROL_NEUTRAL,
+            },
+            search_metrics: {
+              search_count: {
+                absolute: {
+                  all: [
+                    {
+                      point: 14.967359019193298,
+                      lower: 10.534758870048162,
+                      upper: 20.754349791764547,
+                    },
+                  ],
+                  first: {
+                    point: 14.967359019193298,
+                    lower: 10.534758870048162,
+                    upper: 20.754349791764547,
+                  },
+                },
+                difference: {
+                  first: {},
+                  all: [],
+                },
+                relative_uplift: {
+                  first: {},
+                  all: [],
+                },
               },
             },
           },
         },
-      },
-      treatment: {
-        is_control: false,
-        branch_data: {
-          other_metrics: {
-            identity: {
-              absolute: {
-                first: {
-                  point: 200,
-                },
-                all: [
-                  {
+        treatment: {
+          is_control: false,
+          branch_data: {
+            other_metrics: {
+              identity: {
+                absolute: {
+                  first: {
                     point: 200,
                   },
-                ],
-              },
-              difference: {
-                first: {},
-                all: [],
-              },
-              relative_uplift: {
-                first: {},
-                all: [],
-              },
-              percent: 55,
-            },
-            retained: TREATMENT_NEUTRAL,
-            picture_in_picture_ever_used: {
-              absolute: {
-                first: {
-                  point: 0.049019607843137254,
-                  count: 10,
-                  lower: 0.023872203557007872,
-                  upper: 0.08249069209461024,
+                  all: [
+                    {
+                      point: 200,
+                    },
+                  ],
                 },
-                all: [
-                  {
+                difference: {
+                  first: {},
+                  all: [],
+                },
+                relative_uplift: {
+                  first: {},
+                  all: [],
+                },
+                percent: 55,
+              },
+              retained: TREATMENT_NEUTRAL,
+              picture_in_picture_ever_used: {
+                absolute: {
+                  first: {
                     point: 0.049019607843137254,
                     count: 10,
                     lower: 0.023872203557007872,
                     upper: 0.08249069209461024,
                   },
-                ],
-              },
-              difference: {
-                first: {
-                  point: -0.0006569487628876534,
-                  upper: 0.04316381736512019,
-                  lower: 0.04175095963994029,
+                  all: [
+                    {
+                      point: 0.049019607843137254,
+                      count: 10,
+                      lower: 0.023872203557007872,
+                      upper: 0.08249069209461024,
+                    },
+                  ],
                 },
-                all: [
-                  {
+                difference: {
+                  first: {
                     point: -0.0006569487628876534,
                     upper: 0.04316381736512019,
                     lower: 0.04175095963994029,
                   },
-                ],
-              },
-              relative_uplift: {
-                first: {
-                  lower: -0.455210299676828,
-                  upper: 0.5104985718410426,
-                  point: -0.06233954570562385,
+                  all: [
+                    {
+                      point: -0.0006569487628876534,
+                      upper: 0.04316381736512019,
+                      lower: 0.04175095963994029,
+                    },
+                  ],
                 },
-                all: [
-                  {
+                relative_uplift: {
+                  first: {
                     lower: -0.455210299676828,
                     upper: 0.5104985718410426,
                     point: -0.06233954570562385,
                   },
-                ],
-              },
-              significance: { overall: { "1": "positive" }, weekly: {} },
-            },
-            picture_in_picture: {
-              absolute: {
-                first: {
-                  point: 0.049019607843137254,
-                  count: 10,
-                  lower: 0.023872203557007872,
-                  upper: 0.08249069209461024,
+                  all: [
+                    {
+                      lower: -0.455210299676828,
+                      upper: 0.5104985718410426,
+                      point: -0.06233954570562385,
+                    },
+                  ],
                 },
-                all: [
-                  {
+                significance: { overall: { "1": "positive" }, weekly: {} },
+              },
+              picture_in_picture: {
+                absolute: {
+                  first: {
                     point: 0.049019607843137254,
                     count: 10,
                     lower: 0.023872203557007872,
                     upper: 0.08249069209461024,
                   },
-                ],
-              },
-              difference: {
-                first: {
-                  point: -0.0006569487628876534,
-                  upper: 0.04316381736512019,
-                  lower: 0.04175095963994029,
+                  all: [
+                    {
+                      point: 0.049019607843137254,
+                      count: 10,
+                      lower: 0.023872203557007872,
+                      upper: 0.08249069209461024,
+                    },
+                  ],
                 },
-                all: [
-                  {
+                difference: {
+                  first: {
                     point: -0.0006569487628876534,
                     upper: 0.04316381736512019,
                     lower: 0.04175095963994029,
                   },
-                ],
-              },
-              relative_uplift: {
-                first: {
-                  lower: -0.455210299676828,
-                  upper: 0.5104985718410426,
-                  point: -0.06233954570562385,
+                  all: [
+                    {
+                      point: -0.0006569487628876534,
+                      upper: 0.04316381736512019,
+                      lower: 0.04175095963994029,
+                    },
+                  ],
                 },
-                all: [
-                  {
+                relative_uplift: {
+                  first: {
                     lower: -0.455210299676828,
                     upper: 0.5104985718410426,
                     point: -0.06233954570562385,
                   },
-                ],
-              },
-              significance: { overall: { "1": "positive" }, weekly: {} },
-            },
-            feature_b_ever_used: {
-              absolute: {
-                first: {
-                  point: 0.049019607843137254,
-                  count: 10,
-                  lower: 0.023872203557007872,
-                  upper: 0.08249069209461024,
+                  all: [
+                    {
+                      lower: -0.455210299676828,
+                      upper: 0.5104985718410426,
+                      point: -0.06233954570562385,
+                    },
+                  ],
                 },
-                all: [
-                  {
+                significance: { overall: { "1": "positive" }, weekly: {} },
+              },
+              feature_b_ever_used: {
+                absolute: {
+                  first: {
                     point: 0.049019607843137254,
                     count: 10,
                     lower: 0.023872203557007872,
                     upper: 0.08249069209461024,
                   },
-                ],
-              },
-              difference: {
-                first: {
-                  point: -0.0006569487628876534,
-                  upper: 0.04316381736512019,
-                  lower: 0.04175095963994029,
+                  all: [
+                    {
+                      point: 0.049019607843137254,
+                      count: 10,
+                      lower: 0.023872203557007872,
+                      upper: 0.08249069209461024,
+                    },
+                  ],
                 },
-                all: [
-                  {
+                difference: {
+                  first: {
                     point: -0.0006569487628876534,
                     upper: 0.04316381736512019,
                     lower: 0.04175095963994029,
                   },
-                ],
-              },
-              relative_uplift: {
-                first: {
-                  lower: -0.455210299676828,
-                  upper: 0.5104985718410426,
-                  point: -0.06233954570562385,
+                  all: [
+                    {
+                      point: -0.0006569487628876534,
+                      upper: 0.04316381736512019,
+                      lower: 0.04175095963994029,
+                    },
+                  ],
                 },
-                all: [
-                  {
+                relative_uplift: {
+                  first: {
                     lower: -0.455210299676828,
                     upper: 0.5104985718410426,
                     point: -0.06233954570562385,
                   },
-                ],
-              },
-              significance: { overall: { "1": "negative" }, weekly: {} },
-            },
-            feature_b: {
-              absolute: {
-                first: {
-                  point: 0.049019607843137254,
-                  count: 10,
-                  lower: 0.023872203557007872,
-                  upper: 0.08249069209461024,
+                  all: [
+                    {
+                      lower: -0.455210299676828,
+                      upper: 0.5104985718410426,
+                      point: -0.06233954570562385,
+                    },
+                  ],
                 },
-                all: [
-                  {
+                significance: { overall: { "1": "negative" }, weekly: {} },
+              },
+              feature_b: {
+                absolute: {
+                  first: {
                     point: 0.049019607843137254,
                     count: 10,
                     lower: 0.023872203557007872,
                     upper: 0.08249069209461024,
                   },
-                ],
-              },
-              difference: {
-                first: {
-                  point: -0.0006569487628876534,
-                  upper: 0.04316381736512019,
-                  lower: 0.04175095963994029,
+                  all: [
+                    {
+                      point: 0.049019607843137254,
+                      count: 10,
+                      lower: 0.023872203557007872,
+                      upper: 0.08249069209461024,
+                    },
+                  ],
                 },
-                all: [
-                  {
+                difference: {
+                  first: {
                     point: -0.0006569487628876534,
                     upper: 0.04316381736512019,
                     lower: 0.04175095963994029,
                   },
-                ],
-              },
-              relative_uplift: {
-                first: {
-                  lower: -0.455210299676828,
-                  upper: 0.5104985718410426,
-                  point: -0.06233954570562385,
+                  all: [
+                    {
+                      point: -0.0006569487628876534,
+                      upper: 0.04316381736512019,
+                      lower: 0.04175095963994029,
+                    },
+                  ],
                 },
-                all: [
-                  {
+                relative_uplift: {
+                  first: {
                     lower: -0.455210299676828,
                     upper: 0.5104985718410426,
                     point: -0.06233954570562385,
                   },
-                ],
-              },
-              significance: { overall: { "1": "negative" }, weekly: {} },
-            },
-            feature_c_ever_used: {
-              absolute: {
-                first: {
-                  point: 0.049019607843137254,
-                  count: 10,
-                  lower: 0.023872203557007872,
-                  upper: 0.08249069209461024,
+                  all: [
+                    {
+                      lower: -0.455210299676828,
+                      upper: 0.5104985718410426,
+                      point: -0.06233954570562385,
+                    },
+                  ],
                 },
-                all: [
-                  {
+                significance: { overall: { "1": "negative" }, weekly: {} },
+              },
+              feature_c_ever_used: {
+                absolute: {
+                  first: {
                     point: 0.049019607843137254,
                     count: 10,
                     lower: 0.023872203557007872,
                     upper: 0.08249069209461024,
                   },
-                ],
-              },
-              difference: {
-                first: {
-                  point: -0.0006569487628876534,
-                  upper: 0.04316381736512019,
-                  lower: 0.04175095963994029,
+                  all: [
+                    {
+                      point: 0.049019607843137254,
+                      count: 10,
+                      lower: 0.023872203557007872,
+                      upper: 0.08249069209461024,
+                    },
+                  ],
                 },
-                all: [
-                  {
+                difference: {
+                  first: {
                     point: -0.0006569487628876534,
                     upper: 0.04316381736512019,
                     lower: 0.04175095963994029,
                   },
-                ],
-              },
-              relative_uplift: {
-                first: {
-                  lower: -0.455210299676828,
-                  upper: 0.5104985718410426,
-                  point: -0.06233954570562385,
+                  all: [
+                    {
+                      point: -0.0006569487628876534,
+                      upper: 0.04316381736512019,
+                      lower: 0.04175095963994029,
+                    },
+                  ],
                 },
-                all: [
-                  {
+                relative_uplift: {
+                  first: {
                     lower: -0.455210299676828,
                     upper: 0.5104985718410426,
                     point: -0.06233954570562385,
                   },
-                ],
-              },
-              significance: { overall: { "1": "neutral" }, weekly: {} },
-            },
-            feature_c: TREATMENT_NEUTRAL,
-            days_of_use: TREATMENT_NEUTRAL,
-            feature_d: {
-              absolute: {
-                first: {
-                  point: 0.049019607843137254,
-                  count: 10,
-                  lower: 0.023872203557007872,
-                  upper: 0.08249069209461024,
+                  all: [
+                    {
+                      lower: -0.455210299676828,
+                      upper: 0.5104985718410426,
+                      point: -0.06233954570562385,
+                    },
+                  ],
                 },
-                all: [
-                  {
+                significance: { overall: { "1": "neutral" }, weekly: {} },
+              },
+              feature_c: TREATMENT_NEUTRAL,
+              days_of_use: TREATMENT_NEUTRAL,
+              feature_d: {
+                absolute: {
+                  first: {
                     point: 0.049019607843137254,
                     count: 10,
                     lower: 0.023872203557007872,
                     upper: 0.08249069209461024,
                   },
-                ],
-              },
-              difference: {
-                first: {
-                  point: -0.0006569487628876534,
-                  upper: 0.04316381736512019,
-                  lower: 0.04175095963994029,
+                  all: [
+                    {
+                      point: 0.049019607843137254,
+                      count: 10,
+                      lower: 0.023872203557007872,
+                      upper: 0.08249069209461024,
+                    },
+                  ],
                 },
-                all: [
-                  {
+                difference: {
+                  first: {
                     point: -0.0006569487628876534,
                     upper: 0.04316381736512019,
                     lower: 0.04175095963994029,
                   },
-                ],
-              },
-              relative_uplift: {
-                first: {
-                  lower: -0.455210299676828,
-                  upper: 0.5104985718410426,
-                  point: -0.06233954570562385,
+                  all: [
+                    {
+                      point: -0.0006569487628876534,
+                      upper: 0.04316381736512019,
+                      lower: 0.04175095963994029,
+                    },
+                  ],
                 },
-                all: [
-                  {
+                relative_uplift: {
+                  first: {
                     lower: -0.455210299676828,
                     upper: 0.5104985718410426,
                     point: -0.06233954570562385,
                   },
-                ],
-              },
-              significance: { overall: { "1": "positive" }, weekly: {} },
-            },
-            outcome_d: {
-              absolute: {
-                first: {
-                  point: 0.049019607843137254,
-                  count: 10,
-                  lower: 0.023872203557007872,
-                  upper: 0.08249069209461024,
+                  all: [
+                    {
+                      lower: -0.455210299676828,
+                      upper: 0.5104985718410426,
+                      point: -0.06233954570562385,
+                    },
+                  ],
                 },
-                all: [
-                  {
+                significance: { overall: { "1": "positive" }, weekly: {} },
+              },
+              outcome_d: {
+                absolute: {
+                  first: {
                     point: 0.049019607843137254,
                     count: 10,
                     lower: 0.023872203557007872,
                     upper: 0.08249069209461024,
                   },
-                ],
-              },
-              difference: {
-                first: {
-                  point: -0.0006569487628876534,
-                  upper: 0.04316381736512019,
-                  lower: 0.04175095963994029,
+                  all: [
+                    {
+                      point: 0.049019607843137254,
+                      count: 10,
+                      lower: 0.023872203557007872,
+                      upper: 0.08249069209461024,
+                    },
+                  ],
                 },
-                all: [
-                  {
+                difference: {
+                  first: {
                     point: -0.0006569487628876534,
                     upper: 0.04316381736512019,
                     lower: 0.04175095963994029,
                   },
-                ],
-              },
-              relative_uplift: {
-                first: {
-                  lower: -0.455210299676828,
-                  upper: 0.5104985718410426,
-                  point: -0.06233954570562385,
+                  all: [
+                    {
+                      point: -0.0006569487628876534,
+                      upper: 0.04316381736512019,
+                      lower: 0.04175095963994029,
+                    },
+                  ],
                 },
-                all: [
-                  {
+                relative_uplift: {
+                  first: {
                     lower: -0.455210299676828,
                     upper: 0.5104985718410426,
                     point: -0.06233954570562385,
                   },
-                ],
+                  all: [
+                    {
+                      lower: -0.455210299676828,
+                      upper: 0.5104985718410426,
+                      point: -0.06233954570562385,
+                    },
+                  ],
+                },
+                significance: { overall: { "1": "positive" }, weekly: {} },
               },
-              significance: { overall: { "1": "positive" }, weekly: {} },
             },
-          },
-          search_metrics: {
-            search_count: TREATMENT_NEGATIVE,
+            search_metrics: {
+              search_count: TREATMENT_NEGATIVE,
+            },
           },
         },
       },
-    },
-    a_different_segment: {
-      control: {
-        is_control: true,
-        branch_data: {
-          other_metrics: {
-            identity: {
-              absolute: {
-                all: [
-                  {
+      a_different_segment: {
+        control: {
+          is_control: true,
+          branch_data: {
+            other_metrics: {
+              identity: {
+                absolute: {
+                  all: [
+                    {
+                      point: 90,
+                    },
+                  ],
+                  first: {
                     point: 90,
                   },
-                ],
-                first: {
-                  point: 90,
                 },
-              },
-              difference: {
-                first: {},
-                all: [],
-              },
-              relative_uplift: {
-                first: {},
-                all: [],
-              },
-              percent: 45,
-            },
-            retained: {
-              absolute: {
-                all: [
-                  {
-                    point: 0.9361083743842364,
-                    lower: 0.8874481497569532,
-                    upper: 0.9778449264993547,
-                  },
-                ],
-                first: {
-                  point: 13.967359019193298,
-                  lower: 9.534758870048162,
-                  upper: 19.754349791764547,
+                difference: {
+                  first: {},
+                  all: [],
                 },
-              },
-              difference: {
-                first: {},
-                all: [],
-              },
-              relative_uplift: {
-                first: {},
-                all: [],
-              },
-            },
-            picture_in_picture_ever_used: {
-              absolute: {
-                first: {
-                  point: 0.06,
-                  count: 4,
-                  lower: 0.034357271316207685,
-                  upper: 0.09411463700173483,
+                relative_uplift: {
+                  first: {},
+                  all: [],
                 },
-                all: [
-                  {
-                    point: 0.06,
-                    count: 4,
-                    lower: 0.034357271316207685,
-                    upper: 0.09411463700173483,
-                  },
-                ],
+                percent: 45,
               },
-              difference: {
-                first: {},
-                all: [],
-              },
-              relative_uplift: {
-                first: {},
-                all: [],
-              },
-            },
-            picture_in_picture: {
-              absolute: {
-                first: {
-                  point: 0.06,
-                  count: 4,
-                  lower: 0.034357271316207685,
-                  upper: 0.09411463700173483,
-                },
-                all: [
-                  {
-                    point: 0.06,
-                    count: 4,
-                    lower: 0.034357271316207685,
-                    upper: 0.09411463700173483,
-                  },
-                ],
-              },
-              difference: {
-                first: {},
-                all: [],
-              },
-              relative_uplift: {
-                first: {},
-                all: [],
-              },
-            },
-            feature_b_ever_used: {
-              absolute: {
-                first: {
-                  point: 0.06,
-                  count: 4,
-                  lower: 0.034357271316207685,
-                  upper: 0.09411463700173483,
-                },
-                all: [
-                  {
-                    point: 0.06,
-                    count: 4,
-                    lower: 0.034357271316207685,
-                    upper: 0.09411463700173483,
-                  },
-                ],
-              },
-              difference: {
-                first: {},
-                all: [],
-              },
-              relative_uplift: {
-                first: {},
-                all: [],
-              },
-            },
-            feature_b: {
-              absolute: {
-                first: {
-                  point: 0.06,
-                  count: 4,
-                  lower: 0.034357271316207685,
-                  upper: 0.09411463700173483,
-                },
-                all: [
-                  {
-                    point: 0.06,
-                    count: 4,
-                    lower: 0.034357271316207685,
-                    upper: 0.09411463700173483,
-                  },
-                ],
-              },
-              difference: {
-                first: {},
-                all: [],
-              },
-              relative_uplift: {
-                first: {},
-                all: [],
-              },
-            },
-            feature_c_ever_used: {
-              absolute: {
-                first: {
-                  point: 0.06,
-                  count: 4,
-                  lower: 0.034357271316207685,
-                  upper: 0.09411463700173483,
-                },
-                all: [
-                  {
-                    point: 0.06,
-                    count: 4,
-                    lower: 0.034357271316207685,
-                    upper: 0.09411463700173483,
-                  },
-                ],
-              },
-              difference: {
-                first: {},
-                all: [],
-              },
-              relative_uplift: {
-                first: {},
-                all: [],
-              },
-            },
-            feature_c: CONTROL_NEUTRAL,
-            feature_d: {
-              absolute: {
-                first: {
-                  point: 0.06,
-                  count: 4,
-                  lower: 0.034357271316207685,
-                  upper: 0.09411463700173483,
-                },
-                all: [
-                  {
-                    point: 0.06,
-                    count: 4,
-                    lower: 0.034357271316207685,
-                    upper: 0.09411463700173483,
-                  },
-                ],
-              },
-              difference: {
-                first: {},
-                all: [],
-              },
-              relative_uplift: {
-                first: {},
-                all: [],
-              },
-            },
-            outcome_d: {
-              absolute: {
-                first: {
-                  point: 0.06,
-                  count: 4,
-                  lower: 0.034357271316207685,
-                  upper: 0.09411463700173483,
-                },
-                all: [
-                  {
-                    point: 0.06,
-                    count: 4,
-                    lower: 0.034357271316207685,
-                    upper: 0.09411463700173483,
-                  },
-                ],
-              },
-              difference: {
-                first: {},
-                all: [],
-              },
-              relative_uplift: {
-                first: {},
-                all: [],
-              },
-            },
-            days_of_use: CONTROL_NEUTRAL,
-          },
-          search_metrics: {
-            search_count: {
-              absolute: {
-                all: [
-                  {
+              retained: {
+                absolute: {
+                  all: [
+                    {
+                      point: 0.9361083743842364,
+                      lower: 0.8874481497569532,
+                      upper: 0.9778449264993547,
+                    },
+                  ],
+                  first: {
                     point: 13.967359019193298,
                     lower: 9.534758870048162,
                     upper: 19.754349791764547,
                   },
-                ],
-                first: {
-                  point: 13.967359019193298,
-                  lower: 9.534758870048162,
-                  upper: 19.754349791764547,
+                },
+                difference: {
+                  first: {},
+                  all: [],
+                },
+                relative_uplift: {
+                  first: {},
+                  all: [],
                 },
               },
-              difference: {
-                first: {},
-                all: [],
+              picture_in_picture_ever_used: {
+                absolute: {
+                  first: {
+                    point: 0.06,
+                    count: 4,
+                    lower: 0.034357271316207685,
+                    upper: 0.09411463700173483,
+                  },
+                  all: [
+                    {
+                      point: 0.06,
+                      count: 4,
+                      lower: 0.034357271316207685,
+                      upper: 0.09411463700173483,
+                    },
+                  ],
+                },
+                difference: {
+                  first: {},
+                  all: [],
+                },
+                relative_uplift: {
+                  first: {},
+                  all: [],
+                },
               },
-              relative_uplift: {
-                first: {},
-                all: [],
+              picture_in_picture: {
+                absolute: {
+                  first: {
+                    point: 0.06,
+                    count: 4,
+                    lower: 0.034357271316207685,
+                    upper: 0.09411463700173483,
+                  },
+                  all: [
+                    {
+                      point: 0.06,
+                      count: 4,
+                      lower: 0.034357271316207685,
+                      upper: 0.09411463700173483,
+                    },
+                  ],
+                },
+                difference: {
+                  first: {},
+                  all: [],
+                },
+                relative_uplift: {
+                  first: {},
+                  all: [],
+                },
+              },
+              feature_b_ever_used: {
+                absolute: {
+                  first: {
+                    point: 0.06,
+                    count: 4,
+                    lower: 0.034357271316207685,
+                    upper: 0.09411463700173483,
+                  },
+                  all: [
+                    {
+                      point: 0.06,
+                      count: 4,
+                      lower: 0.034357271316207685,
+                      upper: 0.09411463700173483,
+                    },
+                  ],
+                },
+                difference: {
+                  first: {},
+                  all: [],
+                },
+                relative_uplift: {
+                  first: {},
+                  all: [],
+                },
+              },
+              feature_b: {
+                absolute: {
+                  first: {
+                    point: 0.06,
+                    count: 4,
+                    lower: 0.034357271316207685,
+                    upper: 0.09411463700173483,
+                  },
+                  all: [
+                    {
+                      point: 0.06,
+                      count: 4,
+                      lower: 0.034357271316207685,
+                      upper: 0.09411463700173483,
+                    },
+                  ],
+                },
+                difference: {
+                  first: {},
+                  all: [],
+                },
+                relative_uplift: {
+                  first: {},
+                  all: [],
+                },
+              },
+              feature_c_ever_used: {
+                absolute: {
+                  first: {
+                    point: 0.06,
+                    count: 4,
+                    lower: 0.034357271316207685,
+                    upper: 0.09411463700173483,
+                  },
+                  all: [
+                    {
+                      point: 0.06,
+                      count: 4,
+                      lower: 0.034357271316207685,
+                      upper: 0.09411463700173483,
+                    },
+                  ],
+                },
+                difference: {
+                  first: {},
+                  all: [],
+                },
+                relative_uplift: {
+                  first: {},
+                  all: [],
+                },
+              },
+              feature_c: CONTROL_NEUTRAL,
+              feature_d: {
+                absolute: {
+                  first: {
+                    point: 0.06,
+                    count: 4,
+                    lower: 0.034357271316207685,
+                    upper: 0.09411463700173483,
+                  },
+                  all: [
+                    {
+                      point: 0.06,
+                      count: 4,
+                      lower: 0.034357271316207685,
+                      upper: 0.09411463700173483,
+                    },
+                  ],
+                },
+                difference: {
+                  first: {},
+                  all: [],
+                },
+                relative_uplift: {
+                  first: {},
+                  all: [],
+                },
+              },
+              outcome_d: {
+                absolute: {
+                  first: {
+                    point: 0.06,
+                    count: 4,
+                    lower: 0.034357271316207685,
+                    upper: 0.09411463700173483,
+                  },
+                  all: [
+                    {
+                      point: 0.06,
+                      count: 4,
+                      lower: 0.034357271316207685,
+                      upper: 0.09411463700173483,
+                    },
+                  ],
+                },
+                difference: {
+                  first: {},
+                  all: [],
+                },
+                relative_uplift: {
+                  first: {},
+                  all: [],
+                },
+              },
+              days_of_use: CONTROL_NEUTRAL,
+            },
+            search_metrics: {
+              search_count: {
+                absolute: {
+                  all: [
+                    {
+                      point: 13.967359019193298,
+                      lower: 9.534758870048162,
+                      upper: 19.754349791764547,
+                    },
+                  ],
+                  first: {
+                    point: 13.967359019193298,
+                    lower: 9.534758870048162,
+                    upper: 19.754349791764547,
+                  },
+                },
+                difference: {
+                  first: {},
+                  all: [],
+                },
+                relative_uplift: {
+                  first: {},
+                  all: [],
+                },
               },
             },
           },
         },
-      },
-      treatment: {
-        is_control: false,
-        branch_data: {
-          other_metrics: {
-            identity: {
-              absolute: {
-                first: {
-                  point: 200,
-                },
-                all: [
-                  {
+        treatment: {
+          is_control: false,
+          branch_data: {
+            other_metrics: {
+              identity: {
+                absolute: {
+                  first: {
                     point: 200,
                   },
-                ],
-              },
-              difference: {
-                first: {},
-                all: [],
-              },
-              relative_uplift: {
-                first: {},
-                all: [],
-              },
-              percent: 55,
-            },
-            retained: TREATMENT_NEUTRAL,
-            picture_in_picture_ever_used: {
-              absolute: {
-                first: {
-                  point: 0.059019607843137254,
-                  count: 4,
-                  lower: 0.033872203557007872,
-                  upper: 0.09249069209461024,
+                  all: [
+                    {
+                      point: 200,
+                    },
+                  ],
                 },
-                all: [
-                  {
+                difference: {
+                  first: {},
+                  all: [],
+                },
+                relative_uplift: {
+                  first: {},
+                  all: [],
+                },
+                percent: 55,
+              },
+              retained: TREATMENT_NEUTRAL,
+              picture_in_picture_ever_used: {
+                absolute: {
+                  first: {
                     point: 0.059019607843137254,
                     count: 4,
                     lower: 0.033872203557007872,
                     upper: 0.09249069209461024,
                   },
-                ],
-              },
-              difference: {
-                first: {
-                  point: -0.0007569487628876534,
-                  upper: 0.04416381736512019,
-                  lower: 0.04075095963994029,
+                  all: [
+                    {
+                      point: 0.059019607843137254,
+                      count: 4,
+                      lower: 0.033872203557007872,
+                      upper: 0.09249069209461024,
+                    },
+                  ],
                 },
-                all: [
-                  {
+                difference: {
+                  first: {
                     point: -0.0007569487628876534,
                     upper: 0.04416381736512019,
                     lower: 0.04075095963994029,
                   },
-                ],
-              },
-              relative_uplift: {
-                first: {
-                  lower: -0.465210299676828,
-                  upper: 0.5204985718410426,
-                  point: -0.07233954570562385,
+                  all: [
+                    {
+                      point: -0.0007569487628876534,
+                      upper: 0.04416381736512019,
+                      lower: 0.04075095963994029,
+                    },
+                  ],
                 },
-                all: [
-                  {
+                relative_uplift: {
+                  first: {
                     lower: -0.465210299676828,
                     upper: 0.5204985718410426,
                     point: -0.07233954570562385,
                   },
-                ],
-              },
-              significance: { overall: { "1": "positive" }, weekly: {} },
-            },
-            picture_in_picture: {
-              absolute: {
-                first: {
-                  point: 0.059019607843137254,
-                  count: 4,
-                  lower: 0.033872203557007872,
-                  upper: 0.09249069209461024,
+                  all: [
+                    {
+                      lower: -0.465210299676828,
+                      upper: 0.5204985718410426,
+                      point: -0.07233954570562385,
+                    },
+                  ],
                 },
-                all: [
-                  {
+                significance: { overall: { "1": "positive" }, weekly: {} },
+              },
+              picture_in_picture: {
+                absolute: {
+                  first: {
                     point: 0.059019607843137254,
                     count: 4,
                     lower: 0.033872203557007872,
                     upper: 0.09249069209461024,
                   },
-                ],
-              },
-              difference: {
-                first: {
-                  point: -0.0007569487628876534,
-                  upper: 0.04416381736512019,
-                  lower: 0.04075095963994029,
+                  all: [
+                    {
+                      point: 0.059019607843137254,
+                      count: 4,
+                      lower: 0.033872203557007872,
+                      upper: 0.09249069209461024,
+                    },
+                  ],
                 },
-                all: [
-                  {
+                difference: {
+                  first: {
                     point: -0.0007569487628876534,
                     upper: 0.04416381736512019,
                     lower: 0.04075095963994029,
                   },
-                ],
-              },
-              relative_uplift: {
-                first: {
-                  lower: -0.465210299676828,
-                  upper: 0.5204985718410426,
-                  point: -0.07233954570562385,
+                  all: [
+                    {
+                      point: -0.0007569487628876534,
+                      upper: 0.04416381736512019,
+                      lower: 0.04075095963994029,
+                    },
+                  ],
                 },
-                all: [
-                  {
+                relative_uplift: {
+                  first: {
                     lower: -0.465210299676828,
                     upper: 0.5204985718410426,
                     point: -0.07233954570562385,
                   },
-                ],
-              },
-              significance: { overall: { "1": "positive" }, weekly: {} },
-            },
-            feature_b_ever_used: {
-              absolute: {
-                first: {
-                  point: 0.059019607843137254,
-                  count: 4,
-                  lower: 0.033872203557007872,
-                  upper: 0.09249069209461024,
+                  all: [
+                    {
+                      lower: -0.465210299676828,
+                      upper: 0.5204985718410426,
+                      point: -0.07233954570562385,
+                    },
+                  ],
                 },
-                all: [
-                  {
+                significance: { overall: { "1": "positive" }, weekly: {} },
+              },
+              feature_b_ever_used: {
+                absolute: {
+                  first: {
                     point: 0.059019607843137254,
                     count: 4,
                     lower: 0.033872203557007872,
                     upper: 0.09249069209461024,
                   },
-                ],
-              },
-              difference: {
-                first: {
-                  point: -0.0007569487628876534,
-                  upper: 0.04416381736512019,
-                  lower: 0.04075095963994029,
+                  all: [
+                    {
+                      point: 0.059019607843137254,
+                      count: 4,
+                      lower: 0.033872203557007872,
+                      upper: 0.09249069209461024,
+                    },
+                  ],
                 },
-                all: [
-                  {
+                difference: {
+                  first: {
                     point: -0.0007569487628876534,
                     upper: 0.04416381736512019,
                     lower: 0.04075095963994029,
                   },
-                ],
-              },
-              relative_uplift: {
-                first: {
-                  lower: -0.465210299676828,
-                  upper: 0.5204985718410426,
-                  point: -0.07233954570562385,
+                  all: [
+                    {
+                      point: -0.0007569487628876534,
+                      upper: 0.04416381736512019,
+                      lower: 0.04075095963994029,
+                    },
+                  ],
                 },
-                all: [
-                  {
+                relative_uplift: {
+                  first: {
                     lower: -0.465210299676828,
                     upper: 0.5204985718410426,
                     point: -0.07233954570562385,
                   },
-                ],
-              },
-              significance: { overall: { "1": "negative" }, weekly: {} },
-            },
-            feature_b: {
-              absolute: {
-                first: {
-                  point: 0.059019607843137254,
-                  count: 4,
-                  lower: 0.033872203557007872,
-                  upper: 0.09249069209461024,
+                  all: [
+                    {
+                      lower: -0.465210299676828,
+                      upper: 0.5204985718410426,
+                      point: -0.07233954570562385,
+                    },
+                  ],
                 },
-                all: [
-                  {
+                significance: { overall: { "1": "negative" }, weekly: {} },
+              },
+              feature_b: {
+                absolute: {
+                  first: {
                     point: 0.059019607843137254,
                     count: 4,
                     lower: 0.033872203557007872,
                     upper: 0.09249069209461024,
                   },
-                ],
-              },
-              difference: {
-                first: {
-                  point: -0.0007569487628876534,
-                  upper: 0.04416381736512019,
-                  lower: 0.04075095963994029,
+                  all: [
+                    {
+                      point: 0.059019607843137254,
+                      count: 4,
+                      lower: 0.033872203557007872,
+                      upper: 0.09249069209461024,
+                    },
+                  ],
                 },
-                all: [
-                  {
+                difference: {
+                  first: {
                     point: -0.0007569487628876534,
                     upper: 0.04416381736512019,
                     lower: 0.04075095963994029,
                   },
-                ],
-              },
-              relative_uplift: {
-                first: {
-                  lower: -0.465210299676828,
-                  upper: 0.5204985718410426,
-                  point: -0.07233954570562385,
+                  all: [
+                    {
+                      point: -0.0007569487628876534,
+                      upper: 0.04416381736512019,
+                      lower: 0.04075095963994029,
+                    },
+                  ],
                 },
-                all: [
-                  {
+                relative_uplift: {
+                  first: {
                     lower: -0.465210299676828,
                     upper: 0.5204985718410426,
                     point: -0.07233954570562385,
                   },
-                ],
-              },
-              significance: { overall: { "1": "negative" }, weekly: {} },
-            },
-            feature_c_ever_used: {
-              absolute: {
-                first: {
-                  point: 0.059019607843137254,
-                  count: 4,
-                  lower: 0.033872203557007872,
-                  upper: 0.09249069209461024,
+                  all: [
+                    {
+                      lower: -0.465210299676828,
+                      upper: 0.5204985718410426,
+                      point: -0.07233954570562385,
+                    },
+                  ],
                 },
-                all: [
-                  {
+                significance: { overall: { "1": "negative" }, weekly: {} },
+              },
+              feature_c_ever_used: {
+                absolute: {
+                  first: {
                     point: 0.059019607843137254,
                     count: 4,
                     lower: 0.033872203557007872,
                     upper: 0.09249069209461024,
                   },
-                ],
-              },
-              difference: {
-                first: {
-                  point: -0.0007569487628876534,
-                  upper: 0.04416381736512019,
-                  lower: 0.04075095963994029,
+                  all: [
+                    {
+                      point: 0.059019607843137254,
+                      count: 4,
+                      lower: 0.033872203557007872,
+                      upper: 0.09249069209461024,
+                    },
+                  ],
                 },
-                all: [
-                  {
+                difference: {
+                  first: {
                     point: -0.0007569487628876534,
                     upper: 0.04416381736512019,
                     lower: 0.04075095963994029,
                   },
-                ],
-              },
-              relative_uplift: {
-                first: {
-                  lower: -0.465210299676828,
-                  upper: 0.5204985718410426,
-                  point: -0.07233954570562385,
+                  all: [
+                    {
+                      point: -0.0007569487628876534,
+                      upper: 0.04416381736512019,
+                      lower: 0.04075095963994029,
+                    },
+                  ],
                 },
-                all: [
-                  {
+                relative_uplift: {
+                  first: {
                     lower: -0.465210299676828,
                     upper: 0.5204985718410426,
                     point: -0.07233954570562385,
                   },
-                ],
-              },
-              significance: { overall: { "1": "neutral" }, weekly: {} },
-            },
-            feature_c: TREATMENT_NEUTRAL,
-            days_of_use: TREATMENT_NEUTRAL,
-            feature_d: {
-              absolute: {
-                first: {
-                  point: 0.059019607843137254,
-                  count: 4,
-                  lower: 0.033872203557007872,
-                  upper: 0.09249069209461024,
+                  all: [
+                    {
+                      lower: -0.465210299676828,
+                      upper: 0.5204985718410426,
+                      point: -0.07233954570562385,
+                    },
+                  ],
                 },
-                all: [
-                  {
+                significance: { overall: { "1": "neutral" }, weekly: {} },
+              },
+              feature_c: TREATMENT_NEUTRAL,
+              days_of_use: TREATMENT_NEUTRAL,
+              feature_d: {
+                absolute: {
+                  first: {
                     point: 0.059019607843137254,
                     count: 4,
                     lower: 0.033872203557007872,
                     upper: 0.09249069209461024,
                   },
-                ],
-              },
-              difference: {
-                first: {
-                  point: -0.0007569487628876534,
-                  upper: 0.04416381736512019,
-                  lower: 0.04075095963994029,
+                  all: [
+                    {
+                      point: 0.059019607843137254,
+                      count: 4,
+                      lower: 0.033872203557007872,
+                      upper: 0.09249069209461024,
+                    },
+                  ],
                 },
-                all: [
-                  {
+                difference: {
+                  first: {
                     point: -0.0007569487628876534,
                     upper: 0.04416381736512019,
                     lower: 0.04075095963994029,
                   },
-                ],
-              },
-              relative_uplift: {
-                first: {
-                  lower: -0.465210299676828,
-                  upper: 0.5204985718410426,
-                  point: -0.07233954570562385,
+                  all: [
+                    {
+                      point: -0.0007569487628876534,
+                      upper: 0.04416381736512019,
+                      lower: 0.04075095963994029,
+                    },
+                  ],
                 },
-                all: [
-                  {
+                relative_uplift: {
+                  first: {
                     lower: -0.465210299676828,
                     upper: 0.5204985718410426,
                     point: -0.07233954570562385,
                   },
-                ],
-              },
-              significance: { overall: { "1": "positive" }, weekly: {} },
-            },
-            outcome_d: {
-              absolute: {
-                first: {
-                  point: 0.059019607843137254,
-                  count: 4,
-                  lower: 0.033872203557007872,
-                  upper: 0.09249069209461024,
+                  all: [
+                    {
+                      lower: -0.465210299676828,
+                      upper: 0.5204985718410426,
+                      point: -0.07233954570562385,
+                    },
+                  ],
                 },
-                all: [
-                  {
+                significance: { overall: { "1": "positive" }, weekly: {} },
+              },
+              outcome_d: {
+                absolute: {
+                  first: {
                     point: 0.059019607843137254,
                     count: 4,
                     lower: 0.033872203557007872,
                     upper: 0.09249069209461024,
                   },
-                ],
-              },
-              difference: {
-                first: {
-                  point: -0.0007569487628876534,
-                  upper: 0.04416381736512019,
-                  lower: 0.04075095963994029,
+                  all: [
+                    {
+                      point: 0.059019607843137254,
+                      count: 4,
+                      lower: 0.033872203557007872,
+                      upper: 0.09249069209461024,
+                    },
+                  ],
                 },
-                all: [
-                  {
+                difference: {
+                  first: {
                     point: -0.0007569487628876534,
                     upper: 0.04416381736512019,
                     lower: 0.04075095963994029,
                   },
-                ],
-              },
-              relative_uplift: {
-                first: {
-                  lower: -0.465210299676828,
-                  upper: 0.5204985718410426,
-                  point: -0.07233954570562385,
+                  all: [
+                    {
+                      point: -0.0007569487628876534,
+                      upper: 0.04416381736512019,
+                      lower: 0.04075095963994029,
+                    },
+                  ],
                 },
-                all: [
-                  {
+                relative_uplift: {
+                  first: {
                     lower: -0.465210299676828,
                     upper: 0.5204985718410426,
                     point: -0.07233954570562385,
                   },
-                ],
+                  all: [
+                    {
+                      lower: -0.465210299676828,
+                      upper: 0.5204985718410426,
+                      point: -0.07233954570562385,
+                    },
+                  ],
+                },
+                significance: { overall: { "1": "positive" }, weekly: {} },
               },
-              significance: { overall: { "1": "positive" }, weekly: {} },
+            },
+            search_metrics: {
+              search_count: TREATMENT_NEGATIVE,
             },
           },
-          search_metrics: {
-            search_count: TREATMENT_NEGATIVE,
+        },
+      },
+    },
+  },
+});
+
+export const mockAnalysisWithExposures = mockAnalysis({
+  overall: {
+    enrollments: {
+      all: {
+        control: {
+          is_control: true,
+          branch_data: {
+            other_metrics: {
+              identity: {
+                absolute: {
+                  all: [
+                    {
+                      point: 198,
+                    },
+                  ],
+                  first: {
+                    point: 198,
+                  },
+                },
+                difference: {
+                  first: {},
+                  all: [],
+                },
+                relative_uplift: {
+                  first: {},
+                  all: [],
+                },
+                percent: 45,
+              },
+              retained: {
+                absolute: {
+                  all: [
+                    {
+                      point: 0.9261083743842364,
+                      lower: 0.8864481497569532,
+                      upper: 0.9578449264993547,
+                    },
+                  ],
+                  first: {
+                    point: 14.967359019193298,
+                    lower: 10.534758870048162,
+                    upper: 20.754349791764547,
+                  },
+                },
+                difference: {
+                  first: {},
+                  all: [],
+                },
+                relative_uplift: {
+                  first: {},
+                  all: [],
+                },
+              },
+              picture_in_picture_ever_used: {
+                absolute: {
+                  first: {
+                    point: 0.05,
+                    count: 10,
+                    lower: 0.024357271316207685,
+                    upper: 0.08411463700173483,
+                  },
+                  all: [
+                    {
+                      point: 0.05,
+                      count: 10,
+                      lower: 0.024357271316207685,
+                      upper: 0.08411463700173483,
+                    },
+                  ],
+                },
+                difference: {
+                  first: {},
+                  all: [],
+                },
+                relative_uplift: {
+                  first: {},
+                  all: [],
+                },
+              },
+              picture_in_picture: {
+                absolute: {
+                  first: {
+                    point: 0.05,
+                    count: 10,
+                    lower: 0.024357271316207685,
+                    upper: 0.08411463700173483,
+                  },
+                  all: [
+                    {
+                      point: 0.05,
+                      count: 10,
+                      lower: 0.024357271316207685,
+                      upper: 0.08411463700173483,
+                    },
+                  ],
+                },
+                difference: {
+                  first: {},
+                  all: [],
+                },
+                relative_uplift: {
+                  first: {},
+                  all: [],
+                },
+              },
+              feature_b_ever_used: {
+                absolute: {
+                  first: {
+                    point: 0.05,
+                    count: 10,
+                    lower: 0.024357271316207685,
+                    upper: 0.08411463700173483,
+                  },
+                  all: [
+                    {
+                      point: 0.05,
+                      count: 10,
+                      lower: 0.024357271316207685,
+                      upper: 0.08411463700173483,
+                    },
+                  ],
+                },
+                difference: {
+                  first: {},
+                  all: [],
+                },
+                relative_uplift: {
+                  first: {},
+                  all: [],
+                },
+              },
+              feature_b: {
+                absolute: {
+                  first: {
+                    point: 0.05,
+                    count: 10,
+                    lower: 0.024357271316207685,
+                    upper: 0.08411463700173483,
+                  },
+                  all: [
+                    {
+                      point: 0.05,
+                      count: 10,
+                      lower: 0.024357271316207685,
+                      upper: 0.08411463700173483,
+                    },
+                  ],
+                },
+                difference: {
+                  first: {},
+                  all: [],
+                },
+                relative_uplift: {
+                  first: {},
+                  all: [],
+                },
+              },
+              feature_c_ever_used: {
+                absolute: {
+                  first: {
+                    point: 0.05,
+                    count: 10,
+                    lower: 0.024357271316207685,
+                    upper: 0.08411463700173483,
+                  },
+                  all: [
+                    {
+                      point: 0.05,
+                      count: 10,
+                      lower: 0.024357271316207685,
+                      upper: 0.08411463700173483,
+                    },
+                  ],
+                },
+                difference: {
+                  first: {},
+                  all: [],
+                },
+                relative_uplift: {
+                  first: {},
+                  all: [],
+                },
+              },
+              feature_c: CONTROL_NEUTRAL,
+              feature_d: {
+                absolute: {
+                  first: {
+                    point: 0.05,
+                    count: 10,
+                    lower: 0.024357271316207685,
+                    upper: 0.08411463700173483,
+                  },
+                  all: [
+                    {
+                      point: 0.05,
+                      count: 10,
+                      lower: 0.024357271316207685,
+                      upper: 0.08411463700173483,
+                    },
+                  ],
+                },
+                difference: {
+                  first: {},
+                  all: [],
+                },
+                relative_uplift: {
+                  first: {},
+                  all: [],
+                },
+              },
+              outcome_d: {
+                absolute: {
+                  first: {
+                    point: 0.05,
+                    count: 10,
+                    lower: 0.024357271316207685,
+                    upper: 0.08411463700173483,
+                  },
+                  all: [
+                    {
+                      point: 0.05,
+                      count: 10,
+                      lower: 0.024357271316207685,
+                      upper: 0.08411463700173483,
+                    },
+                  ],
+                },
+                difference: {
+                  first: {},
+                  all: [],
+                },
+                relative_uplift: {
+                  first: {},
+                  all: [],
+                },
+              },
+              days_of_use: CONTROL_NEUTRAL,
+            },
+            search_metrics: {
+              search_count: {
+                absolute: {
+                  all: [
+                    {
+                      point: 14.967359019193298,
+                      lower: 10.534758870048162,
+                      upper: 20.754349791764547,
+                    },
+                  ],
+                  first: {
+                    point: 14.967359019193298,
+                    lower: 10.534758870048162,
+                    upper: 20.754349791764547,
+                  },
+                },
+                difference: {
+                  first: {},
+                  all: [],
+                },
+                relative_uplift: {
+                  first: {},
+                  all: [],
+                },
+              },
+            },
+          },
+        },
+        treatment: {
+          is_control: false,
+          branch_data: {
+            other_metrics: {
+              identity: {
+                absolute: {
+                  first: {
+                    point: 200,
+                  },
+                  all: [
+                    {
+                      point: 200,
+                    },
+                  ],
+                },
+                difference: {
+                  first: {},
+                  all: [],
+                },
+                relative_uplift: {
+                  first: {},
+                  all: [],
+                },
+                percent: 55,
+              },
+              retained: TREATMENT_NEUTRAL,
+              picture_in_picture_ever_used: {
+                absolute: {
+                  first: {
+                    point: 0.049019607843137254,
+                    count: 10,
+                    lower: 0.023872203557007872,
+                    upper: 0.08249069209461024,
+                  },
+                  all: [
+                    {
+                      point: 0.049019607843137254,
+                      count: 10,
+                      lower: 0.023872203557007872,
+                      upper: 0.08249069209461024,
+                    },
+                  ],
+                },
+                difference: {
+                  first: {
+                    point: -0.0006569487628876534,
+                    upper: 0.04316381736512019,
+                    lower: 0.04175095963994029,
+                  },
+                  all: [
+                    {
+                      point: -0.0006569487628876534,
+                      upper: 0.04316381736512019,
+                      lower: 0.04175095963994029,
+                    },
+                  ],
+                },
+                relative_uplift: {
+                  first: {
+                    lower: -0.455210299676828,
+                    upper: 0.5104985718410426,
+                    point: -0.06233954570562385,
+                  },
+                  all: [
+                    {
+                      lower: -0.455210299676828,
+                      upper: 0.5104985718410426,
+                      point: -0.06233954570562385,
+                    },
+                  ],
+                },
+                significance: { overall: { "1": "positive" }, weekly: {} },
+              },
+              picture_in_picture: {
+                absolute: {
+                  first: {
+                    point: 0.049019607843137254,
+                    count: 10,
+                    lower: 0.023872203557007872,
+                    upper: 0.08249069209461024,
+                  },
+                  all: [
+                    {
+                      point: 0.049019607843137254,
+                      count: 10,
+                      lower: 0.023872203557007872,
+                      upper: 0.08249069209461024,
+                    },
+                  ],
+                },
+                difference: {
+                  first: {
+                    point: -0.0006569487628876534,
+                    upper: 0.04316381736512019,
+                    lower: 0.04175095963994029,
+                  },
+                  all: [
+                    {
+                      point: -0.0006569487628876534,
+                      upper: 0.04316381736512019,
+                      lower: 0.04175095963994029,
+                    },
+                  ],
+                },
+                relative_uplift: {
+                  first: {
+                    lower: -0.455210299676828,
+                    upper: 0.5104985718410426,
+                    point: -0.06233954570562385,
+                  },
+                  all: [
+                    {
+                      lower: -0.455210299676828,
+                      upper: 0.5104985718410426,
+                      point: -0.06233954570562385,
+                    },
+                  ],
+                },
+                significance: { overall: { "1": "positive" }, weekly: {} },
+              },
+              feature_b_ever_used: {
+                absolute: {
+                  first: {
+                    point: 0.049019607843137254,
+                    count: 10,
+                    lower: 0.023872203557007872,
+                    upper: 0.08249069209461024,
+                  },
+                  all: [
+                    {
+                      point: 0.049019607843137254,
+                      count: 10,
+                      lower: 0.023872203557007872,
+                      upper: 0.08249069209461024,
+                    },
+                  ],
+                },
+                difference: {
+                  first: {
+                    point: -0.0006569487628876534,
+                    upper: 0.04316381736512019,
+                    lower: 0.04175095963994029,
+                  },
+                  all: [
+                    {
+                      point: -0.0006569487628876534,
+                      upper: 0.04316381736512019,
+                      lower: 0.04175095963994029,
+                    },
+                  ],
+                },
+                relative_uplift: {
+                  first: {
+                    lower: -0.455210299676828,
+                    upper: 0.5104985718410426,
+                    point: -0.06233954570562385,
+                  },
+                  all: [
+                    {
+                      lower: -0.455210299676828,
+                      upper: 0.5104985718410426,
+                      point: -0.06233954570562385,
+                    },
+                  ],
+                },
+                significance: { overall: { "1": "negative" }, weekly: {} },
+              },
+              feature_b: {
+                absolute: {
+                  first: {
+                    point: 0.049019607843137254,
+                    count: 10,
+                    lower: 0.023872203557007872,
+                    upper: 0.08249069209461024,
+                  },
+                  all: [
+                    {
+                      point: 0.049019607843137254,
+                      count: 10,
+                      lower: 0.023872203557007872,
+                      upper: 0.08249069209461024,
+                    },
+                  ],
+                },
+                difference: {
+                  first: {
+                    point: -0.0006569487628876534,
+                    upper: 0.04316381736512019,
+                    lower: 0.04175095963994029,
+                  },
+                  all: [
+                    {
+                      point: -0.0006569487628876534,
+                      upper: 0.04316381736512019,
+                      lower: 0.04175095963994029,
+                    },
+                  ],
+                },
+                relative_uplift: {
+                  first: {
+                    lower: -0.455210299676828,
+                    upper: 0.5104985718410426,
+                    point: -0.06233954570562385,
+                  },
+                  all: [
+                    {
+                      lower: -0.455210299676828,
+                      upper: 0.5104985718410426,
+                      point: -0.06233954570562385,
+                    },
+                  ],
+                },
+                significance: { overall: { "1": "negative" }, weekly: {} },
+              },
+              feature_c_ever_used: {
+                absolute: {
+                  first: {
+                    point: 0.049019607843137254,
+                    count: 10,
+                    lower: 0.023872203557007872,
+                    upper: 0.08249069209461024,
+                  },
+                  all: [
+                    {
+                      point: 0.049019607843137254,
+                      count: 10,
+                      lower: 0.023872203557007872,
+                      upper: 0.08249069209461024,
+                    },
+                  ],
+                },
+                difference: {
+                  first: {
+                    point: -0.0006569487628876534,
+                    upper: 0.04316381736512019,
+                    lower: 0.04175095963994029,
+                  },
+                  all: [
+                    {
+                      point: -0.0006569487628876534,
+                      upper: 0.04316381736512019,
+                      lower: 0.04175095963994029,
+                    },
+                  ],
+                },
+                relative_uplift: {
+                  first: {
+                    lower: -0.455210299676828,
+                    upper: 0.5104985718410426,
+                    point: -0.06233954570562385,
+                  },
+                  all: [
+                    {
+                      lower: -0.455210299676828,
+                      upper: 0.5104985718410426,
+                      point: -0.06233954570562385,
+                    },
+                  ],
+                },
+                significance: { overall: { "1": "neutral" }, weekly: {} },
+              },
+              feature_c: TREATMENT_NEUTRAL,
+              days_of_use: TREATMENT_NEUTRAL,
+              feature_d: {
+                absolute: {
+                  first: {
+                    point: 0.049019607843137254,
+                    count: 10,
+                    lower: 0.023872203557007872,
+                    upper: 0.08249069209461024,
+                  },
+                  all: [
+                    {
+                      point: 0.049019607843137254,
+                      count: 10,
+                      lower: 0.023872203557007872,
+                      upper: 0.08249069209461024,
+                    },
+                  ],
+                },
+                difference: {
+                  first: {
+                    point: -0.0006569487628876534,
+                    upper: 0.04316381736512019,
+                    lower: 0.04175095963994029,
+                  },
+                  all: [
+                    {
+                      point: -0.0006569487628876534,
+                      upper: 0.04316381736512019,
+                      lower: 0.04175095963994029,
+                    },
+                  ],
+                },
+                relative_uplift: {
+                  first: {
+                    lower: -0.455210299676828,
+                    upper: 0.5104985718410426,
+                    point: -0.06233954570562385,
+                  },
+                  all: [
+                    {
+                      lower: -0.455210299676828,
+                      upper: 0.5104985718410426,
+                      point: -0.06233954570562385,
+                    },
+                  ],
+                },
+                significance: { overall: { "1": "positive" }, weekly: {} },
+              },
+              outcome_d: {
+                absolute: {
+                  first: {
+                    point: 0.049019607843137254,
+                    count: 10,
+                    lower: 0.023872203557007872,
+                    upper: 0.08249069209461024,
+                  },
+                  all: [
+                    {
+                      point: 0.049019607843137254,
+                      count: 10,
+                      lower: 0.023872203557007872,
+                      upper: 0.08249069209461024,
+                    },
+                  ],
+                },
+                difference: {
+                  first: {
+                    point: -0.0006569487628876534,
+                    upper: 0.04316381736512019,
+                    lower: 0.04175095963994029,
+                  },
+                  all: [
+                    {
+                      point: -0.0006569487628876534,
+                      upper: 0.04316381736512019,
+                      lower: 0.04175095963994029,
+                    },
+                  ],
+                },
+                relative_uplift: {
+                  first: {
+                    lower: -0.455210299676828,
+                    upper: 0.5104985718410426,
+                    point: -0.06233954570562385,
+                  },
+                  all: [
+                    {
+                      lower: -0.455210299676828,
+                      upper: 0.5104985718410426,
+                      point: -0.06233954570562385,
+                    },
+                  ],
+                },
+                significance: { overall: { "1": "positive" }, weekly: {} },
+              },
+            },
+            search_metrics: {
+              search_count: TREATMENT_NEGATIVE,
+            },
+          },
+        },
+      },
+    },
+    exposures: {
+      all: {
+        control: {
+          is_control: true,
+          branch_data: {
+            other_metrics: {
+              identity: {
+                absolute: {
+                  all: [
+                    {
+                      point: 90,
+                    },
+                  ],
+                  first: {
+                    point: 90,
+                  },
+                },
+                difference: {
+                  first: {},
+                  all: [],
+                },
+                relative_uplift: {
+                  first: {},
+                  all: [],
+                },
+                percent: 45,
+              },
+              retained: {
+                absolute: {
+                  all: [
+                    {
+                      point: 0.9361083743842364,
+                      lower: 0.8874481497569532,
+                      upper: 0.9778449264993547,
+                    },
+                  ],
+                  first: {
+                    point: 13.967359019193298,
+                    lower: 9.534758870048162,
+                    upper: 19.754349791764547,
+                  },
+                },
+                difference: {
+                  first: {},
+                  all: [],
+                },
+                relative_uplift: {
+                  first: {},
+                  all: [],
+                },
+              },
+              picture_in_picture_ever_used: {
+                absolute: {
+                  first: {
+                    point: 0.06,
+                    count: 4,
+                    lower: 0.034357271316207685,
+                    upper: 0.09411463700173483,
+                  },
+                  all: [
+                    {
+                      point: 0.06,
+                      count: 4,
+                      lower: 0.034357271316207685,
+                      upper: 0.09411463700173483,
+                    },
+                  ],
+                },
+                difference: {
+                  first: {},
+                  all: [],
+                },
+                relative_uplift: {
+                  first: {},
+                  all: [],
+                },
+              },
+              picture_in_picture: {
+                absolute: {
+                  first: {
+                    point: 0.06,
+                    count: 4,
+                    lower: 0.034357271316207685,
+                    upper: 0.09411463700173483,
+                  },
+                  all: [
+                    {
+                      point: 0.06,
+                      count: 4,
+                      lower: 0.034357271316207685,
+                      upper: 0.09411463700173483,
+                    },
+                  ],
+                },
+                difference: {
+                  first: {},
+                  all: [],
+                },
+                relative_uplift: {
+                  first: {},
+                  all: [],
+                },
+              },
+              feature_b_ever_used: {
+                absolute: {
+                  first: {
+                    point: 0.06,
+                    count: 4,
+                    lower: 0.034357271316207685,
+                    upper: 0.09411463700173483,
+                  },
+                  all: [
+                    {
+                      point: 0.06,
+                      count: 4,
+                      lower: 0.034357271316207685,
+                      upper: 0.09411463700173483,
+                    },
+                  ],
+                },
+                difference: {
+                  first: {},
+                  all: [],
+                },
+                relative_uplift: {
+                  first: {},
+                  all: [],
+                },
+              },
+              feature_b: {
+                absolute: {
+                  first: {
+                    point: 0.06,
+                    count: 4,
+                    lower: 0.034357271316207685,
+                    upper: 0.09411463700173483,
+                  },
+                  all: [
+                    {
+                      point: 0.06,
+                      count: 4,
+                      lower: 0.034357271316207685,
+                      upper: 0.09411463700173483,
+                    },
+                  ],
+                },
+                difference: {
+                  first: {},
+                  all: [],
+                },
+                relative_uplift: {
+                  first: {},
+                  all: [],
+                },
+              },
+              feature_c_ever_used: {
+                absolute: {
+                  first: {
+                    point: 0.06,
+                    count: 4,
+                    lower: 0.034357271316207685,
+                    upper: 0.09411463700173483,
+                  },
+                  all: [
+                    {
+                      point: 0.06,
+                      count: 4,
+                      lower: 0.034357271316207685,
+                      upper: 0.09411463700173483,
+                    },
+                  ],
+                },
+                difference: {
+                  first: {},
+                  all: [],
+                },
+                relative_uplift: {
+                  first: {},
+                  all: [],
+                },
+              },
+              feature_c: CONTROL_NEUTRAL,
+              feature_d: {
+                absolute: {
+                  first: {
+                    point: 0.06,
+                    count: 4,
+                    lower: 0.034357271316207685,
+                    upper: 0.09411463700173483,
+                  },
+                  all: [
+                    {
+                      point: 0.06,
+                      count: 4,
+                      lower: 0.034357271316207685,
+                      upper: 0.09411463700173483,
+                    },
+                  ],
+                },
+                difference: {
+                  first: {},
+                  all: [],
+                },
+                relative_uplift: {
+                  first: {},
+                  all: [],
+                },
+              },
+              outcome_d: {
+                absolute: {
+                  first: {
+                    point: 0.06,
+                    count: 4,
+                    lower: 0.034357271316207685,
+                    upper: 0.09411463700173483,
+                  },
+                  all: [
+                    {
+                      point: 0.06,
+                      count: 4,
+                      lower: 0.034357271316207685,
+                      upper: 0.09411463700173483,
+                    },
+                  ],
+                },
+                difference: {
+                  first: {},
+                  all: [],
+                },
+                relative_uplift: {
+                  first: {},
+                  all: [],
+                },
+              },
+              days_of_use: CONTROL_NEUTRAL,
+            },
+            search_metrics: {
+              search_count: {
+                absolute: {
+                  all: [
+                    {
+                      point: 13.967359019193298,
+                      lower: 9.534758870048162,
+                      upper: 19.754349791764547,
+                    },
+                  ],
+                  first: {
+                    point: 13.967359019193298,
+                    lower: 9.534758870048162,
+                    upper: 19.754349791764547,
+                  },
+                },
+                difference: {
+                  first: {},
+                  all: [],
+                },
+                relative_uplift: {
+                  first: {},
+                  all: [],
+                },
+              },
+            },
+          },
+        },
+        treatment: {
+          is_control: false,
+          branch_data: {
+            other_metrics: {
+              identity: {
+                absolute: {
+                  first: {
+                    point: 200,
+                  },
+                  all: [
+                    {
+                      point: 200,
+                    },
+                  ],
+                },
+                difference: {
+                  first: {},
+                  all: [],
+                },
+                relative_uplift: {
+                  first: {},
+                  all: [],
+                },
+                percent: 55,
+              },
+              retained: TREATMENT_NEUTRAL,
+              picture_in_picture_ever_used: {
+                absolute: {
+                  first: {
+                    point: 0.059019607843137254,
+                    count: 4,
+                    lower: 0.033872203557007872,
+                    upper: 0.09249069209461024,
+                  },
+                  all: [
+                    {
+                      point: 0.059019607843137254,
+                      count: 4,
+                      lower: 0.033872203557007872,
+                      upper: 0.09249069209461024,
+                    },
+                  ],
+                },
+                difference: {
+                  first: {
+                    point: -0.0007569487628876534,
+                    upper: 0.04416381736512019,
+                    lower: 0.04075095963994029,
+                  },
+                  all: [
+                    {
+                      point: -0.0007569487628876534,
+                      upper: 0.04416381736512019,
+                      lower: 0.04075095963994029,
+                    },
+                  ],
+                },
+                relative_uplift: {
+                  first: {
+                    lower: -0.465210299676828,
+                    upper: 0.5204985718410426,
+                    point: -0.07233954570562385,
+                  },
+                  all: [
+                    {
+                      lower: -0.465210299676828,
+                      upper: 0.5204985718410426,
+                      point: -0.07233954570562385,
+                    },
+                  ],
+                },
+                significance: { overall: { "1": "positive" }, weekly: {} },
+              },
+              picture_in_picture: {
+                absolute: {
+                  first: {
+                    point: 0.059019607843137254,
+                    count: 4,
+                    lower: 0.033872203557007872,
+                    upper: 0.09249069209461024,
+                  },
+                  all: [
+                    {
+                      point: 0.059019607843137254,
+                      count: 4,
+                      lower: 0.033872203557007872,
+                      upper: 0.09249069209461024,
+                    },
+                  ],
+                },
+                difference: {
+                  first: {
+                    point: -0.0007569487628876534,
+                    upper: 0.04416381736512019,
+                    lower: 0.04075095963994029,
+                  },
+                  all: [
+                    {
+                      point: -0.0007569487628876534,
+                      upper: 0.04416381736512019,
+                      lower: 0.04075095963994029,
+                    },
+                  ],
+                },
+                relative_uplift: {
+                  first: {
+                    lower: -0.465210299676828,
+                    upper: 0.5204985718410426,
+                    point: -0.07233954570562385,
+                  },
+                  all: [
+                    {
+                      lower: -0.465210299676828,
+                      upper: 0.5204985718410426,
+                      point: -0.07233954570562385,
+                    },
+                  ],
+                },
+                significance: { overall: { "1": "positive" }, weekly: {} },
+              },
+              feature_b_ever_used: {
+                absolute: {
+                  first: {
+                    point: 0.059019607843137254,
+                    count: 4,
+                    lower: 0.033872203557007872,
+                    upper: 0.09249069209461024,
+                  },
+                  all: [
+                    {
+                      point: 0.059019607843137254,
+                      count: 4,
+                      lower: 0.033872203557007872,
+                      upper: 0.09249069209461024,
+                    },
+                  ],
+                },
+                difference: {
+                  first: {
+                    point: -0.0007569487628876534,
+                    upper: 0.04416381736512019,
+                    lower: 0.04075095963994029,
+                  },
+                  all: [
+                    {
+                      point: -0.0007569487628876534,
+                      upper: 0.04416381736512019,
+                      lower: 0.04075095963994029,
+                    },
+                  ],
+                },
+                relative_uplift: {
+                  first: {
+                    lower: -0.465210299676828,
+                    upper: 0.5204985718410426,
+                    point: -0.07233954570562385,
+                  },
+                  all: [
+                    {
+                      lower: -0.465210299676828,
+                      upper: 0.5204985718410426,
+                      point: -0.07233954570562385,
+                    },
+                  ],
+                },
+                significance: { overall: { "1": "negative" }, weekly: {} },
+              },
+              feature_b: {
+                absolute: {
+                  first: {
+                    point: 0.059019607843137254,
+                    count: 4,
+                    lower: 0.033872203557007872,
+                    upper: 0.09249069209461024,
+                  },
+                  all: [
+                    {
+                      point: 0.059019607843137254,
+                      count: 4,
+                      lower: 0.033872203557007872,
+                      upper: 0.09249069209461024,
+                    },
+                  ],
+                },
+                difference: {
+                  first: {
+                    point: -0.0007569487628876534,
+                    upper: 0.04416381736512019,
+                    lower: 0.04075095963994029,
+                  },
+                  all: [
+                    {
+                      point: -0.0007569487628876534,
+                      upper: 0.04416381736512019,
+                      lower: 0.04075095963994029,
+                    },
+                  ],
+                },
+                relative_uplift: {
+                  first: {
+                    lower: -0.465210299676828,
+                    upper: 0.5204985718410426,
+                    point: -0.07233954570562385,
+                  },
+                  all: [
+                    {
+                      lower: -0.465210299676828,
+                      upper: 0.5204985718410426,
+                      point: -0.07233954570562385,
+                    },
+                  ],
+                },
+                significance: { overall: { "1": "negative" }, weekly: {} },
+              },
+              feature_c_ever_used: {
+                absolute: {
+                  first: {
+                    point: 0.059019607843137254,
+                    count: 4,
+                    lower: 0.033872203557007872,
+                    upper: 0.09249069209461024,
+                  },
+                  all: [
+                    {
+                      point: 0.059019607843137254,
+                      count: 4,
+                      lower: 0.033872203557007872,
+                      upper: 0.09249069209461024,
+                    },
+                  ],
+                },
+                difference: {
+                  first: {
+                    point: -0.0007569487628876534,
+                    upper: 0.04416381736512019,
+                    lower: 0.04075095963994029,
+                  },
+                  all: [
+                    {
+                      point: -0.0007569487628876534,
+                      upper: 0.04416381736512019,
+                      lower: 0.04075095963994029,
+                    },
+                  ],
+                },
+                relative_uplift: {
+                  first: {
+                    lower: -0.465210299676828,
+                    upper: 0.5204985718410426,
+                    point: -0.07233954570562385,
+                  },
+                  all: [
+                    {
+                      lower: -0.465210299676828,
+                      upper: 0.5204985718410426,
+                      point: -0.07233954570562385,
+                    },
+                  ],
+                },
+                significance: { overall: { "1": "neutral" }, weekly: {} },
+              },
+              feature_c: TREATMENT_NEUTRAL,
+              days_of_use: TREATMENT_NEUTRAL,
+              feature_d: {
+                absolute: {
+                  first: {
+                    point: 0.059019607843137254,
+                    count: 4,
+                    lower: 0.033872203557007872,
+                    upper: 0.09249069209461024,
+                  },
+                  all: [
+                    {
+                      point: 0.059019607843137254,
+                      count: 4,
+                      lower: 0.033872203557007872,
+                      upper: 0.09249069209461024,
+                    },
+                  ],
+                },
+                difference: {
+                  first: {
+                    point: -0.0007569487628876534,
+                    upper: 0.04416381736512019,
+                    lower: 0.04075095963994029,
+                  },
+                  all: [
+                    {
+                      point: -0.0007569487628876534,
+                      upper: 0.04416381736512019,
+                      lower: 0.04075095963994029,
+                    },
+                  ],
+                },
+                relative_uplift: {
+                  first: {
+                    lower: -0.465210299676828,
+                    upper: 0.5204985718410426,
+                    point: -0.07233954570562385,
+                  },
+                  all: [
+                    {
+                      lower: -0.465210299676828,
+                      upper: 0.5204985718410426,
+                      point: -0.07233954570562385,
+                    },
+                  ],
+                },
+                significance: { overall: { "1": "positive" }, weekly: {} },
+              },
+              outcome_d: {
+                absolute: {
+                  first: {
+                    point: 0.059019607843137254,
+                    count: 4,
+                    lower: 0.033872203557007872,
+                    upper: 0.09249069209461024,
+                  },
+                  all: [
+                    {
+                      point: 0.059019607843137254,
+                      count: 4,
+                      lower: 0.033872203557007872,
+                      upper: 0.09249069209461024,
+                    },
+                  ],
+                },
+                difference: {
+                  first: {
+                    point: -0.0007569487628876534,
+                    upper: 0.04416381736512019,
+                    lower: 0.04075095963994029,
+                  },
+                  all: [
+                    {
+                      point: -0.0007569487628876534,
+                      upper: 0.04416381736512019,
+                      lower: 0.04075095963994029,
+                    },
+                  ],
+                },
+                relative_uplift: {
+                  first: {
+                    lower: -0.465210299676828,
+                    upper: 0.5204985718410426,
+                    point: -0.07233954570562385,
+                  },
+                  all: [
+                    {
+                      lower: -0.465210299676828,
+                      upper: 0.5204985718410426,
+                      point: -0.07233954570562385,
+                    },
+                  ],
+                },
+                significance: { overall: { "1": "positive" }, weekly: {} },
+              },
+            },
+            search_metrics: {
+              search_count: TREATMENT_NEGATIVE,
+            },
           },
         },
       },
@@ -2356,709 +3623,711 @@ export const mockIncompleteAnalysis = (modifications = {}) =>
       metadata: MOCK_METADATA,
       show_analysis: true,
       errors: { experiment: [] },
-      daily: { all: [] },
-      weekly: { all: {} },
+      daily: { enrollments: { all: [] } },
+      weekly: { enrollments: { all: {} } },
       overall: {
-        all: {
-          control: {
-            is_control: true,
-            branch_data: {
-              other_metrics: {
-                identity: {
-                  absolute: {
-                    all: [
-                      {
+        enrollments: {
+          all: {
+            control: {
+              is_control: true,
+              branch_data: {
+                other_metrics: {
+                  identity: {
+                    absolute: {
+                      all: [
+                        {
+                          point: 198,
+                        },
+                      ],
+                      first: {
                         point: 198,
                       },
-                    ],
-                    first: {
-                      point: 198,
                     },
-                  },
-                  difference: {
-                    first: {},
-                    all: [],
-                  },
-                  relative_uplift: {
-                    first: {},
-                    all: [],
-                  },
-                  percent: 45,
-                },
-                picture_in_picture_ever_used: {
-                  absolute: {
-                    first: {
-                      point: 0.05,
-                      count: 10,
-                      lower: 0.024357271316207685,
-                      upper: 0.08411463700173483,
+                    difference: {
+                      first: {},
+                      all: [],
                     },
-                    all: [
-                      {
+                    relative_uplift: {
+                      first: {},
+                      all: [],
+                    },
+                    percent: 45,
+                  },
+                  picture_in_picture_ever_used: {
+                    absolute: {
+                      first: {
                         point: 0.05,
                         count: 10,
                         lower: 0.024357271316207685,
                         upper: 0.08411463700173483,
                       },
-                    ],
-                  },
-                  difference: {
-                    first: {},
-                    all: [],
-                  },
-                  relative_uplift: {
-                    first: {},
-                    all: [],
-                  },
-                },
-                picture_in_picture: {
-                  absolute: {
-                    first: {
-                      point: 0.05,
-                      count: 10,
-                      lower: 0.024357271316207685,
-                      upper: 0.08411463700173483,
+                      all: [
+                        {
+                          point: 0.05,
+                          count: 10,
+                          lower: 0.024357271316207685,
+                          upper: 0.08411463700173483,
+                        },
+                      ],
                     },
-                    all: [
-                      {
+                    difference: {
+                      first: {},
+                      all: [],
+                    },
+                    relative_uplift: {
+                      first: {},
+                      all: [],
+                    },
+                  },
+                  picture_in_picture: {
+                    absolute: {
+                      first: {
                         point: 0.05,
                         count: 10,
                         lower: 0.024357271316207685,
                         upper: 0.08411463700173483,
                       },
-                    ],
-                  },
-                  difference: {
-                    first: {},
-                    all: [],
-                  },
-                  relative_uplift: {
-                    first: {},
-                    all: [],
-                  },
-                },
-                feature_b_ever_used: {
-                  absolute: {
-                    first: {
-                      point: 0.05,
-                      count: 10,
-                      lower: 0.024357271316207685,
-                      upper: 0.08411463700173483,
+                      all: [
+                        {
+                          point: 0.05,
+                          count: 10,
+                          lower: 0.024357271316207685,
+                          upper: 0.08411463700173483,
+                        },
+                      ],
                     },
-                    all: [
-                      {
+                    difference: {
+                      first: {},
+                      all: [],
+                    },
+                    relative_uplift: {
+                      first: {},
+                      all: [],
+                    },
+                  },
+                  feature_b_ever_used: {
+                    absolute: {
+                      first: {
                         point: 0.05,
                         count: 10,
                         lower: 0.024357271316207685,
                         upper: 0.08411463700173483,
                       },
-                    ],
-                  },
-                  difference: {
-                    first: {},
-                    all: [],
-                  },
-                  relative_uplift: {
-                    first: {},
-                    all: [],
-                  },
-                },
-                feature_b: {
-                  absolute: {
-                    first: {
-                      point: 0.05,
-                      count: 10,
-                      lower: 0.024357271316207685,
-                      upper: 0.08411463700173483,
+                      all: [
+                        {
+                          point: 0.05,
+                          count: 10,
+                          lower: 0.024357271316207685,
+                          upper: 0.08411463700173483,
+                        },
+                      ],
                     },
-                    all: [
-                      {
+                    difference: {
+                      first: {},
+                      all: [],
+                    },
+                    relative_uplift: {
+                      first: {},
+                      all: [],
+                    },
+                  },
+                  feature_b: {
+                    absolute: {
+                      first: {
                         point: 0.05,
                         count: 10,
                         lower: 0.024357271316207685,
                         upper: 0.08411463700173483,
                       },
-                    ],
-                  },
-                  difference: {
-                    first: {},
-                    all: [],
-                  },
-                  relative_uplift: {
-                    first: {},
-                    all: [],
-                  },
-                },
-                feature_c_ever_used: {
-                  absolute: {
-                    first: {
-                      point: 0.05,
-                      count: 10,
-                      lower: 0.024357271316207685,
-                      upper: 0.08411463700173483,
+                      all: [
+                        {
+                          point: 0.05,
+                          count: 10,
+                          lower: 0.024357271316207685,
+                          upper: 0.08411463700173483,
+                        },
+                      ],
                     },
-                    all: [
-                      {
+                    difference: {
+                      first: {},
+                      all: [],
+                    },
+                    relative_uplift: {
+                      first: {},
+                      all: [],
+                    },
+                  },
+                  feature_c_ever_used: {
+                    absolute: {
+                      first: {
                         point: 0.05,
                         count: 10,
                         lower: 0.024357271316207685,
                         upper: 0.08411463700173483,
                       },
-                    ],
-                  },
-                  difference: {
-                    first: {},
-                    all: [],
-                  },
-                  relative_uplift: {
-                    first: {},
-                    all: [],
-                  },
-                },
-                feature_c: {
-                  absolute: {
-                    first: {
-                      point: 0.05,
-                      count: 10,
-                      lower: 0.024357271316207685,
-                      upper: 0.08411463700173483,
+                      all: [
+                        {
+                          point: 0.05,
+                          count: 10,
+                          lower: 0.024357271316207685,
+                          upper: 0.08411463700173483,
+                        },
+                      ],
                     },
-                    all: [
-                      {
+                    difference: {
+                      first: {},
+                      all: [],
+                    },
+                    relative_uplift: {
+                      first: {},
+                      all: [],
+                    },
+                  },
+                  feature_c: {
+                    absolute: {
+                      first: {
                         point: 0.05,
                         count: 10,
                         lower: 0.024357271316207685,
                         upper: 0.08411463700173483,
                       },
-                    ],
-                  },
-                  difference: {
-                    first: {},
-                    all: [],
-                  },
-                  relative_uplift: {
-                    first: {},
-                    all: [],
-                  },
-                },
-                feature_d: {
-                  absolute: {
-                    first: {
-                      point: 0.05,
-                      count: 10,
-                      lower: 0.024357271316207685,
-                      upper: 0.08411463700173483,
+                      all: [
+                        {
+                          point: 0.05,
+                          count: 10,
+                          lower: 0.024357271316207685,
+                          upper: 0.08411463700173483,
+                        },
+                      ],
                     },
-                    all: [
-                      {
+                    difference: {
+                      first: {},
+                      all: [],
+                    },
+                    relative_uplift: {
+                      first: {},
+                      all: [],
+                    },
+                  },
+                  feature_d: {
+                    absolute: {
+                      first: {
                         point: 0.05,
                         count: 10,
                         lower: 0.024357271316207685,
                         upper: 0.08411463700173483,
                       },
-                    ],
-                  },
-                  difference: {
-                    first: {},
-                    all: [],
-                  },
-                  relative_uplift: {
-                    first: {},
-                    all: [],
-                  },
-                },
-                outcome_d: {
-                  absolute: {
-                    first: {
-                      point: 0.05,
-                      count: 10,
-                      lower: 0.024357271316207685,
-                      upper: 0.08411463700173483,
+                      all: [
+                        {
+                          point: 0.05,
+                          count: 10,
+                          lower: 0.024357271316207685,
+                          upper: 0.08411463700173483,
+                        },
+                      ],
                     },
-                    all: [
-                      {
+                    difference: {
+                      first: {},
+                      all: [],
+                    },
+                    relative_uplift: {
+                      first: {},
+                      all: [],
+                    },
+                  },
+                  outcome_d: {
+                    absolute: {
+                      first: {
                         point: 0.05,
                         count: 10,
                         lower: 0.024357271316207685,
                         upper: 0.08411463700173483,
                       },
-                    ],
-                  },
-                  difference: {
-                    first: {},
-                    all: [],
-                  },
-                  relative_uplift: {
-                    first: {},
-                    all: [],
+                      all: [
+                        {
+                          point: 0.05,
+                          count: 10,
+                          lower: 0.024357271316207685,
+                          upper: 0.08411463700173483,
+                        },
+                      ],
+                    },
+                    difference: {
+                      first: {},
+                      all: [],
+                    },
+                    relative_uplift: {
+                      first: {},
+                      all: [],
+                    },
                   },
                 },
-              },
-              search_metrics: {
-                search_count: {
-                  absolute: {
-                    all: [
-                      {
+                search_metrics: {
+                  search_count: {
+                    absolute: {
+                      all: [
+                        {
+                          point: 14.967359019193298,
+                          lower: 10.534758870048162,
+                          upper: 20.754349791764547,
+                        },
+                      ],
+                      first: {
                         point: 14.967359019193298,
                         lower: 10.534758870048162,
                         upper: 20.754349791764547,
                       },
-                    ],
-                    first: {
-                      point: 14.967359019193298,
-                      lower: 10.534758870048162,
-                      upper: 20.754349791764547,
                     },
-                  },
-                  difference: {
-                    first: {},
-                    all: [],
-                  },
-                  relative_uplift: {
-                    first: {},
-                    all: [],
+                    difference: {
+                      first: {},
+                      all: [],
+                    },
+                    relative_uplift: {
+                      first: {},
+                      all: [],
+                    },
                   },
                 },
               },
             },
-          },
-          treatment: {
-            is_control: false,
-            branch_data: {
-              other_metrics: {
-                identity: {
-                  absolute: {
-                    first: {
-                      point: 200,
-                    },
-                    all: [
-                      {
+            treatment: {
+              is_control: false,
+              branch_data: {
+                other_metrics: {
+                  identity: {
+                    absolute: {
+                      first: {
                         point: 200,
                       },
-                    ],
-                  },
-                  difference: {
-                    first: {},
-                    all: [],
-                  },
-                  relative_uplift: {
-                    first: {},
-                    all: [],
-                  },
-                  percent: 55,
-                },
-                picture_in_picture_ever_used: {
-                  absolute: {
-                    first: {
-                      point: 0.049019607843137254,
-                      count: 10,
-                      lower: 0.023872203557007872,
-                      upper: 0.08249069209461024,
+                      all: [
+                        {
+                          point: 200,
+                        },
+                      ],
                     },
-                    all: [
-                      {
+                    difference: {
+                      first: {},
+                      all: [],
+                    },
+                    relative_uplift: {
+                      first: {},
+                      all: [],
+                    },
+                    percent: 55,
+                  },
+                  picture_in_picture_ever_used: {
+                    absolute: {
+                      first: {
                         point: 0.049019607843137254,
                         count: 10,
                         lower: 0.023872203557007872,
                         upper: 0.08249069209461024,
                       },
-                    ],
-                  },
-                  difference: {
-                    first: {
-                      point: -0.0006569487628876534,
-                      upper: 0.04316381736512019,
-                      lower: 0.04175095963994029,
+                      all: [
+                        {
+                          point: 0.049019607843137254,
+                          count: 10,
+                          lower: 0.023872203557007872,
+                          upper: 0.08249069209461024,
+                        },
+                      ],
                     },
-                    all: [
-                      {
+                    difference: {
+                      first: {
                         point: -0.0006569487628876534,
                         upper: 0.04316381736512019,
                         lower: 0.04175095963994029,
                       },
-                    ],
-                  },
-                  relative_uplift: {
-                    first: {
-                      lower: -0.455210299676828,
-                      upper: 0.5104985718410426,
-                      point: -0.06233954570562385,
+                      all: [
+                        {
+                          point: -0.0006569487628876534,
+                          upper: 0.04316381736512019,
+                          lower: 0.04175095963994029,
+                        },
+                      ],
                     },
-                    all: [
-                      {
+                    relative_uplift: {
+                      first: {
                         lower: -0.455210299676828,
                         upper: 0.5104985718410426,
                         point: -0.06233954570562385,
                       },
-                    ],
-                  },
-                  significance: { overall: { "1": "positive" }, weekly: {} },
-                },
-                picture_in_picture: {
-                  absolute: {
-                    first: {
-                      point: 0.049019607843137254,
-                      count: 10,
-                      lower: 0.023872203557007872,
-                      upper: 0.08249069209461024,
+                      all: [
+                        {
+                          lower: -0.455210299676828,
+                          upper: 0.5104985718410426,
+                          point: -0.06233954570562385,
+                        },
+                      ],
                     },
-                    all: [
-                      {
+                    significance: { overall: { "1": "positive" }, weekly: {} },
+                  },
+                  picture_in_picture: {
+                    absolute: {
+                      first: {
                         point: 0.049019607843137254,
                         count: 10,
                         lower: 0.023872203557007872,
                         upper: 0.08249069209461024,
                       },
-                    ],
-                  },
-                  difference: {
-                    first: {
-                      point: -0.0006569487628876534,
-                      upper: 0.04316381736512019,
-                      lower: 0.04175095963994029,
+                      all: [
+                        {
+                          point: 0.049019607843137254,
+                          count: 10,
+                          lower: 0.023872203557007872,
+                          upper: 0.08249069209461024,
+                        },
+                      ],
                     },
-                    all: [
-                      {
+                    difference: {
+                      first: {
                         point: -0.0006569487628876534,
                         upper: 0.04316381736512019,
                         lower: 0.04175095963994029,
                       },
-                    ],
-                  },
-                  relative_uplift: {
-                    first: {
-                      lower: -0.455210299676828,
-                      upper: 0.5104985718410426,
-                      point: -0.06233954570562385,
+                      all: [
+                        {
+                          point: -0.0006569487628876534,
+                          upper: 0.04316381736512019,
+                          lower: 0.04175095963994029,
+                        },
+                      ],
                     },
-                    all: [
-                      {
+                    relative_uplift: {
+                      first: {
                         lower: -0.455210299676828,
                         upper: 0.5104985718410426,
                         point: -0.06233954570562385,
                       },
-                    ],
-                  },
-                  significance: { overall: { "1": "positive" }, weekly: {} },
-                },
-                feature_b_ever_used: {
-                  absolute: {
-                    first: {
-                      point: 0.049019607843137254,
-                      count: 10,
-                      lower: 0.023872203557007872,
-                      upper: 0.08249069209461024,
+                      all: [
+                        {
+                          lower: -0.455210299676828,
+                          upper: 0.5104985718410426,
+                          point: -0.06233954570562385,
+                        },
+                      ],
                     },
-                    all: [
-                      {
+                    significance: { overall: { "1": "positive" }, weekly: {} },
+                  },
+                  feature_b_ever_used: {
+                    absolute: {
+                      first: {
                         point: 0.049019607843137254,
                         count: 10,
                         lower: 0.023872203557007872,
                         upper: 0.08249069209461024,
                       },
-                    ],
-                  },
-                  difference: {
-                    first: {
-                      point: -0.0006569487628876534,
-                      upper: 0.04316381736512019,
-                      lower: 0.04175095963994029,
+                      all: [
+                        {
+                          point: 0.049019607843137254,
+                          count: 10,
+                          lower: 0.023872203557007872,
+                          upper: 0.08249069209461024,
+                        },
+                      ],
                     },
-                    all: [
-                      {
+                    difference: {
+                      first: {
                         point: -0.0006569487628876534,
                         upper: 0.04316381736512019,
                         lower: 0.04175095963994029,
                       },
-                    ],
-                  },
-                  relative_uplift: {
-                    first: {
-                      lower: -0.455210299676828,
-                      upper: 0.5104985718410426,
-                      point: -0.06233954570562385,
+                      all: [
+                        {
+                          point: -0.0006569487628876534,
+                          upper: 0.04316381736512019,
+                          lower: 0.04175095963994029,
+                        },
+                      ],
                     },
-                    all: [
-                      {
+                    relative_uplift: {
+                      first: {
                         lower: -0.455210299676828,
                         upper: 0.5104985718410426,
                         point: -0.06233954570562385,
                       },
-                    ],
-                  },
-                  significance: { overall: { "1": "negative" }, weekly: {} },
-                },
-                feature_b: {
-                  absolute: {
-                    first: {
-                      point: 0.049019607843137254,
-                      count: 10,
-                      lower: 0.023872203557007872,
-                      upper: 0.08249069209461024,
+                      all: [
+                        {
+                          lower: -0.455210299676828,
+                          upper: 0.5104985718410426,
+                          point: -0.06233954570562385,
+                        },
+                      ],
                     },
-                    all: [
-                      {
+                    significance: { overall: { "1": "negative" }, weekly: {} },
+                  },
+                  feature_b: {
+                    absolute: {
+                      first: {
                         point: 0.049019607843137254,
                         count: 10,
                         lower: 0.023872203557007872,
                         upper: 0.08249069209461024,
                       },
-                    ],
-                  },
-                  difference: {
-                    first: {
-                      point: -0.0006569487628876534,
-                      upper: 0.04316381736512019,
-                      lower: 0.04175095963994029,
+                      all: [
+                        {
+                          point: 0.049019607843137254,
+                          count: 10,
+                          lower: 0.023872203557007872,
+                          upper: 0.08249069209461024,
+                        },
+                      ],
                     },
-                    all: [
-                      {
+                    difference: {
+                      first: {
                         point: -0.0006569487628876534,
                         upper: 0.04316381736512019,
                         lower: 0.04175095963994029,
                       },
-                    ],
-                  },
-                  relative_uplift: {
-                    first: {
-                      lower: -0.455210299676828,
-                      upper: 0.5104985718410426,
-                      point: -0.06233954570562385,
+                      all: [
+                        {
+                          point: -0.0006569487628876534,
+                          upper: 0.04316381736512019,
+                          lower: 0.04175095963994029,
+                        },
+                      ],
                     },
-                    all: [
-                      {
+                    relative_uplift: {
+                      first: {
                         lower: -0.455210299676828,
                         upper: 0.5104985718410426,
                         point: -0.06233954570562385,
                       },
-                    ],
-                  },
-                  significance: { overall: { "1": "negative" }, weekly: {} },
-                },
-                feature_c_ever_used: {
-                  absolute: {
-                    first: {
-                      point: 0.049019607843137254,
-                      count: 10,
-                      lower: 0.023872203557007872,
-                      upper: 0.08249069209461024,
+                      all: [
+                        {
+                          lower: -0.455210299676828,
+                          upper: 0.5104985718410426,
+                          point: -0.06233954570562385,
+                        },
+                      ],
                     },
-                    all: [
-                      {
+                    significance: { overall: { "1": "negative" }, weekly: {} },
+                  },
+                  feature_c_ever_used: {
+                    absolute: {
+                      first: {
                         point: 0.049019607843137254,
                         count: 10,
                         lower: 0.023872203557007872,
                         upper: 0.08249069209461024,
                       },
-                    ],
-                  },
-                  difference: {
-                    first: {
-                      point: -0.0006569487628876534,
-                      upper: 0.04316381736512019,
-                      lower: 0.04175095963994029,
+                      all: [
+                        {
+                          point: 0.049019607843137254,
+                          count: 10,
+                          lower: 0.023872203557007872,
+                          upper: 0.08249069209461024,
+                        },
+                      ],
                     },
-                    all: [
-                      {
+                    difference: {
+                      first: {
                         point: -0.0006569487628876534,
                         upper: 0.04316381736512019,
                         lower: 0.04175095963994029,
                       },
-                    ],
-                  },
-                  relative_uplift: {
-                    first: {
-                      lower: -0.455210299676828,
-                      upper: 0.5104985718410426,
-                      point: -0.06233954570562385,
+                      all: [
+                        {
+                          point: -0.0006569487628876534,
+                          upper: 0.04316381736512019,
+                          lower: 0.04175095963994029,
+                        },
+                      ],
                     },
-                    all: [
-                      {
+                    relative_uplift: {
+                      first: {
                         lower: -0.455210299676828,
                         upper: 0.5104985718410426,
                         point: -0.06233954570562385,
                       },
-                    ],
-                  },
-                  significance: { overall: { "1": "neutral" }, weekly: {} },
-                },
-                feature_c: {
-                  absolute: {
-                    first: {
-                      point: 0.049019607843137254,
-                      count: 10,
-                      lower: 0.023872203557007872,
-                      upper: 0.08249069209461024,
+                      all: [
+                        {
+                          lower: -0.455210299676828,
+                          upper: 0.5104985718410426,
+                          point: -0.06233954570562385,
+                        },
+                      ],
                     },
-                    all: [
-                      {
+                    significance: { overall: { "1": "neutral" }, weekly: {} },
+                  },
+                  feature_c: {
+                    absolute: {
+                      first: {
                         point: 0.049019607843137254,
                         count: 10,
                         lower: 0.023872203557007872,
                         upper: 0.08249069209461024,
                       },
-                    ],
-                  },
-                  difference: {
-                    first: {
-                      point: -0.0006569487628876534,
-                      upper: 0.04316381736512019,
-                      lower: 0.04175095963994029,
+                      all: [
+                        {
+                          point: 0.049019607843137254,
+                          count: 10,
+                          lower: 0.023872203557007872,
+                          upper: 0.08249069209461024,
+                        },
+                      ],
                     },
-                    all: [
-                      {
+                    difference: {
+                      first: {
                         point: -0.0006569487628876534,
                         upper: 0.04316381736512019,
                         lower: 0.04175095963994029,
                       },
-                    ],
-                  },
-                  relative_uplift: {
-                    first: {
-                      lower: -0.455210299676828,
-                      upper: 0.5104985718410426,
-                      point: -0.06233954570562385,
+                      all: [
+                        {
+                          point: -0.0006569487628876534,
+                          upper: 0.04316381736512019,
+                          lower: 0.04175095963994029,
+                        },
+                      ],
                     },
-                    all: [
-                      {
+                    relative_uplift: {
+                      first: {
                         lower: -0.455210299676828,
                         upper: 0.5104985718410426,
                         point: -0.06233954570562385,
                       },
-                    ],
-                  },
-                  significance: { overall: { "1": "neutral" }, weekly: {} },
-                },
-                feature_d: {
-                  absolute: {
-                    first: {
-                      point: 0.049019607843137254,
-                      count: 10,
-                      lower: 0.023872203557007872,
-                      upper: 0.08249069209461024,
+                      all: [
+                        {
+                          lower: -0.455210299676828,
+                          upper: 0.5104985718410426,
+                          point: -0.06233954570562385,
+                        },
+                      ],
                     },
-                    all: [
-                      {
+                    significance: { overall: { "1": "neutral" }, weekly: {} },
+                  },
+                  feature_d: {
+                    absolute: {
+                      first: {
                         point: 0.049019607843137254,
                         count: 10,
                         lower: 0.023872203557007872,
                         upper: 0.08249069209461024,
                       },
-                    ],
-                  },
-                  difference: {
-                    first: {
-                      point: -0.0006569487628876534,
-                      upper: 0.04316381736512019,
-                      lower: 0.04175095963994029,
+                      all: [
+                        {
+                          point: 0.049019607843137254,
+                          count: 10,
+                          lower: 0.023872203557007872,
+                          upper: 0.08249069209461024,
+                        },
+                      ],
                     },
-                    all: [
-                      {
+                    difference: {
+                      first: {
                         point: -0.0006569487628876534,
                         upper: 0.04316381736512019,
                         lower: 0.04175095963994029,
                       },
-                    ],
-                  },
-                  relative_uplift: {
-                    first: {
-                      lower: -0.455210299676828,
-                      upper: 0.5104985718410426,
-                      point: -0.06233954570562385,
+                      all: [
+                        {
+                          point: -0.0006569487628876534,
+                          upper: 0.04316381736512019,
+                          lower: 0.04175095963994029,
+                        },
+                      ],
                     },
-                    all: [
-                      {
+                    relative_uplift: {
+                      first: {
                         lower: -0.455210299676828,
                         upper: 0.5104985718410426,
                         point: -0.06233954570562385,
                       },
-                    ],
-                  },
-                  significance: { overall: { "1": "positive" }, weekly: {} },
-                },
-                outcome_d: {
-                  absolute: {
-                    first: {
-                      point: 0.049019607843137254,
-                      count: 10,
-                      lower: 0.023872203557007872,
-                      upper: 0.08249069209461024,
+                      all: [
+                        {
+                          lower: -0.455210299676828,
+                          upper: 0.5104985718410426,
+                          point: -0.06233954570562385,
+                        },
+                      ],
                     },
-                    all: [
-                      {
+                    significance: { overall: { "1": "positive" }, weekly: {} },
+                  },
+                  outcome_d: {
+                    absolute: {
+                      first: {
                         point: 0.049019607843137254,
                         count: 10,
                         lower: 0.023872203557007872,
                         upper: 0.08249069209461024,
                       },
-                    ],
-                  },
-                  difference: {
-                    first: {
-                      point: -0.0006569487628876534,
-                      upper: 0.04316381736512019,
-                      lower: 0.04175095963994029,
+                      all: [
+                        {
+                          point: 0.049019607843137254,
+                          count: 10,
+                          lower: 0.023872203557007872,
+                          upper: 0.08249069209461024,
+                        },
+                      ],
                     },
-                    all: [
-                      {
+                    difference: {
+                      first: {
                         point: -0.0006569487628876534,
                         upper: 0.04316381736512019,
                         lower: 0.04175095963994029,
                       },
-                    ],
-                  },
-                  relative_uplift: {
-                    first: {
-                      lower: -0.455210299676828,
-                      upper: 0.5104985718410426,
-                      point: -0.06233954570562385,
+                      all: [
+                        {
+                          point: -0.0006569487628876534,
+                          upper: 0.04316381736512019,
+                          lower: 0.04175095963994029,
+                        },
+                      ],
                     },
-                    all: [
-                      {
+                    relative_uplift: {
+                      first: {
                         lower: -0.455210299676828,
                         upper: 0.5104985718410426,
                         point: -0.06233954570562385,
                       },
-                    ],
-                  },
-                  significance: { overall: { "1": "positive" }, weekly: {} },
-                },
-              },
-              search_metrics: {
-                search_count: {
-                  absolute: {
-                    first: {
-                      point: 25.456361412643364,
-                      lower: 18.998951440573688,
-                      upper: 33.54929175463715,
+                      all: [
+                        {
+                          lower: -0.455210299676828,
+                          upper: 0.5104985718410426,
+                          point: -0.06233954570562385,
+                        },
+                      ],
                     },
-                    all: [
-                      {
+                    significance: { overall: { "1": "positive" }, weekly: {} },
+                  },
+                },
+                search_metrics: {
+                  search_count: {
+                    absolute: {
+                      first: {
                         point: 25.456361412643364,
                         lower: 18.998951440573688,
                         upper: 33.54929175463715,
                       },
-                    ],
-                  },
-                  difference: {
-                    first: {
-                      point: 5.075852767646001,
-                      upper: -5.63685604594333,
-                      lower: -15.289651027022447,
+                      all: [
+                        {
+                          point: 25.456361412643364,
+                          lower: 18.998951440573688,
+                          upper: 33.54929175463715,
+                        },
+                      ],
                     },
-                    all: [
-                      {
+                    difference: {
+                      first: {
                         point: 5.075852767646001,
                         upper: -5.63685604594333,
                         lower: -15.289651027022447,
                       },
-                    ],
+                      all: [
+                        {
+                          point: 5.075852767646001,
+                          upper: -5.63685604594333,
+                          lower: -15.289651027022447,
+                        },
+                      ],
+                    },
+                    relative_uplift: {
+                      first: {},
+                      all: [],
+                    },
+                    significance: { overall: { "1": "negative" }, weekly: {} },
                   },
-                  relative_uplift: {
-                    first: {},
-                    all: [],
-                  },
-                  significance: { overall: { "1": "negative" }, weekly: {} },
                 },
               },
             },
@@ -3124,8 +4393,8 @@ export const mockAnalysisWithErrors = (modifications = {}) =>
           },
         ],
       },
-      daily: { all: [] },
-      weekly: { all: weeklyMockAnalysis() },
+      daily: { enrollments: { all: [] } },
+      weekly: { enrollments: { all: weeklyMockAnalysis() } },
       overall: null,
     },
     modifications,
@@ -3186,606 +4455,608 @@ export const mockAnalysisWithErrorsAndResults = (modifications = {}) =>
           },
         ],
       },
-      daily: { all: [] },
-      weekly: { all: weeklyMockAnalysis() },
+      daily: { enrollments: { all: [] } },
+      weekly: { enrollments: { all: weeklyMockAnalysis() } },
       overall: {
-        all: {
-          control: {
-            is_control: true,
-            branch_data: {
-              other_metrics: {
-                identity: {
-                  absolute: {
-                    all: [
-                      {
+        enrollments: {
+          all: {
+            control: {
+              is_control: true,
+              branch_data: {
+                other_metrics: {
+                  identity: {
+                    absolute: {
+                      all: [
+                        {
+                          point: 198,
+                        },
+                      ],
+                      first: {
                         point: 198,
                       },
-                    ],
-                    first: {
-                      point: 198,
                     },
-                  },
-                  difference: {
-                    first: {},
-                    all: [],
-                  },
-                  relative_uplift: {
-                    first: {},
-                    all: [],
-                  },
-                  percent: 45,
-                },
-                retained: {
-                  absolute: {
-                    all: [
-                      {
-                        point: 0.9261083743842364,
-                        lower: 0.8864481497569532,
-                        upper: 0.9578449264993547,
-                      },
-                    ],
-                    first: {
-                      point: 14.967359019193298,
-                      lower: 10.534758870048162,
-                      upper: 20.754349791764547,
+                    difference: {
+                      first: {},
+                      all: [],
                     },
-                  },
-                  difference: {
-                    first: {},
-                    all: [],
-                  },
-                  relative_uplift: {
-                    first: {},
-                    all: [],
-                  },
-                },
-                picture_in_picture_ever_used: {
-                  absolute: {
-                    first: {
-                      point: 0.05,
-                      count: 10,
-                      lower: 0.024357271316207685,
-                      upper: 0.08411463700173483,
+                    relative_uplift: {
+                      first: {},
+                      all: [],
                     },
-                    all: [
-                      {
-                        point: 0.05,
-                        count: 10,
-                        lower: 0.024357271316207685,
-                        upper: 0.08411463700173483,
-                      },
-                    ],
+                    percent: 45,
                   },
-                  difference: {
-                    first: {},
-                    all: [],
-                  },
-                  relative_uplift: {
-                    first: {},
-                    all: [],
-                  },
-                },
-                feature_b_ever_used: {
-                  absolute: {
-                    first: {
-                      point: 0.05,
-                      count: 10,
-                      lower: 0.024357271316207685,
-                      upper: 0.08411463700173483,
-                    },
-                    all: [
-                      {
-                        point: 0.05,
-                        count: 10,
-                        lower: 0.024357271316207685,
-                        upper: 0.08411463700173483,
-                      },
-                    ],
-                  },
-                  difference: {
-                    first: {},
-                    all: [],
-                  },
-                  relative_uplift: {
-                    first: {},
-                    all: [],
-                  },
-                },
-                feature_b: {
-                  absolute: {
-                    first: {
-                      point: 0.05,
-                      count: 10,
-                      lower: 0.024357271316207685,
-                      upper: 0.08411463700173483,
-                    },
-                    all: [
-                      {
-                        point: 0.05,
-                        count: 10,
-                        lower: 0.024357271316207685,
-                        upper: 0.08411463700173483,
-                      },
-                    ],
-                  },
-                  difference: {
-                    first: {},
-                    all: [],
-                  },
-                  relative_uplift: {
-                    first: {},
-                    all: [],
-                  },
-                },
-                feature_c_ever_used: {
-                  absolute: {
-                    first: {
-                      point: 0.05,
-                      count: 10,
-                      lower: 0.024357271316207685,
-                      upper: 0.08411463700173483,
-                    },
-                    all: [
-                      {
-                        point: 0.05,
-                        count: 10,
-                        lower: 0.024357271316207685,
-                        upper: 0.08411463700173483,
-                      },
-                    ],
-                  },
-                  difference: {
-                    first: {},
-                    all: [],
-                  },
-                  relative_uplift: {
-                    first: {},
-                    all: [],
-                  },
-                },
-                feature_c: CONTROL_NEUTRAL,
-                feature_d: {
-                  absolute: {
-                    first: {
-                      point: 0.05,
-                      count: 10,
-                      lower: 0.024357271316207685,
-                      upper: 0.08411463700173483,
-                    },
-                    all: [
-                      {
-                        point: 0.05,
-                        count: 10,
-                        lower: 0.024357271316207685,
-                        upper: 0.08411463700173483,
-                      },
-                    ],
-                  },
-                  difference: {
-                    first: {},
-                    all: [],
-                  },
-                  relative_uplift: {
-                    first: {},
-                    all: [],
-                  },
-                },
-                outcome_d: {
-                  absolute: {
-                    first: {
-                      point: 0.05,
-                      count: 10,
-                      lower: 0.024357271316207685,
-                      upper: 0.08411463700173483,
-                    },
-                    all: [
-                      {
-                        point: 0.05,
-                        count: 10,
-                        lower: 0.024357271316207685,
-                        upper: 0.08411463700173483,
-                      },
-                    ],
-                  },
-                  difference: {
-                    first: {},
-                    all: [],
-                  },
-                  relative_uplift: {
-                    first: {},
-                    all: [],
-                  },
-                },
-                days_of_use: CONTROL_NEUTRAL,
-              },
-              search_metrics: {
-                search_count: {
-                  absolute: {
-                    all: [
-                      {
+                  retained: {
+                    absolute: {
+                      all: [
+                        {
+                          point: 0.9261083743842364,
+                          lower: 0.8864481497569532,
+                          upper: 0.9578449264993547,
+                        },
+                      ],
+                      first: {
                         point: 14.967359019193298,
                         lower: 10.534758870048162,
                         upper: 20.754349791764547,
                       },
-                    ],
-                    first: {
-                      point: 14.967359019193298,
-                      lower: 10.534758870048162,
-                      upper: 20.754349791764547,
+                    },
+                    difference: {
+                      first: {},
+                      all: [],
+                    },
+                    relative_uplift: {
+                      first: {},
+                      all: [],
                     },
                   },
-                  difference: {
-                    first: {},
-                    all: [],
+                  picture_in_picture_ever_used: {
+                    absolute: {
+                      first: {
+                        point: 0.05,
+                        count: 10,
+                        lower: 0.024357271316207685,
+                        upper: 0.08411463700173483,
+                      },
+                      all: [
+                        {
+                          point: 0.05,
+                          count: 10,
+                          lower: 0.024357271316207685,
+                          upper: 0.08411463700173483,
+                        },
+                      ],
+                    },
+                    difference: {
+                      first: {},
+                      all: [],
+                    },
+                    relative_uplift: {
+                      first: {},
+                      all: [],
+                    },
                   },
-                  relative_uplift: {
-                    first: {},
-                    all: [],
+                  feature_b_ever_used: {
+                    absolute: {
+                      first: {
+                        point: 0.05,
+                        count: 10,
+                        lower: 0.024357271316207685,
+                        upper: 0.08411463700173483,
+                      },
+                      all: [
+                        {
+                          point: 0.05,
+                          count: 10,
+                          lower: 0.024357271316207685,
+                          upper: 0.08411463700173483,
+                        },
+                      ],
+                    },
+                    difference: {
+                      first: {},
+                      all: [],
+                    },
+                    relative_uplift: {
+                      first: {},
+                      all: [],
+                    },
+                  },
+                  feature_b: {
+                    absolute: {
+                      first: {
+                        point: 0.05,
+                        count: 10,
+                        lower: 0.024357271316207685,
+                        upper: 0.08411463700173483,
+                      },
+                      all: [
+                        {
+                          point: 0.05,
+                          count: 10,
+                          lower: 0.024357271316207685,
+                          upper: 0.08411463700173483,
+                        },
+                      ],
+                    },
+                    difference: {
+                      first: {},
+                      all: [],
+                    },
+                    relative_uplift: {
+                      first: {},
+                      all: [],
+                    },
+                  },
+                  feature_c_ever_used: {
+                    absolute: {
+                      first: {
+                        point: 0.05,
+                        count: 10,
+                        lower: 0.024357271316207685,
+                        upper: 0.08411463700173483,
+                      },
+                      all: [
+                        {
+                          point: 0.05,
+                          count: 10,
+                          lower: 0.024357271316207685,
+                          upper: 0.08411463700173483,
+                        },
+                      ],
+                    },
+                    difference: {
+                      first: {},
+                      all: [],
+                    },
+                    relative_uplift: {
+                      first: {},
+                      all: [],
+                    },
+                  },
+                  feature_c: CONTROL_NEUTRAL,
+                  feature_d: {
+                    absolute: {
+                      first: {
+                        point: 0.05,
+                        count: 10,
+                        lower: 0.024357271316207685,
+                        upper: 0.08411463700173483,
+                      },
+                      all: [
+                        {
+                          point: 0.05,
+                          count: 10,
+                          lower: 0.024357271316207685,
+                          upper: 0.08411463700173483,
+                        },
+                      ],
+                    },
+                    difference: {
+                      first: {},
+                      all: [],
+                    },
+                    relative_uplift: {
+                      first: {},
+                      all: [],
+                    },
+                  },
+                  outcome_d: {
+                    absolute: {
+                      first: {
+                        point: 0.05,
+                        count: 10,
+                        lower: 0.024357271316207685,
+                        upper: 0.08411463700173483,
+                      },
+                      all: [
+                        {
+                          point: 0.05,
+                          count: 10,
+                          lower: 0.024357271316207685,
+                          upper: 0.08411463700173483,
+                        },
+                      ],
+                    },
+                    difference: {
+                      first: {},
+                      all: [],
+                    },
+                    relative_uplift: {
+                      first: {},
+                      all: [],
+                    },
+                  },
+                  days_of_use: CONTROL_NEUTRAL,
+                },
+                search_metrics: {
+                  search_count: {
+                    absolute: {
+                      all: [
+                        {
+                          point: 14.967359019193298,
+                          lower: 10.534758870048162,
+                          upper: 20.754349791764547,
+                        },
+                      ],
+                      first: {
+                        point: 14.967359019193298,
+                        lower: 10.534758870048162,
+                        upper: 20.754349791764547,
+                      },
+                    },
+                    difference: {
+                      first: {},
+                      all: [],
+                    },
+                    relative_uplift: {
+                      first: {},
+                      all: [],
+                    },
                   },
                 },
               },
             },
-          },
-          treatment: {
-            is_control: false,
-            branch_data: {
-              other_metrics: {
-                identity: {
-                  absolute: {
-                    first: {
-                      point: 200,
-                    },
-                    all: [
-                      {
+            treatment: {
+              is_control: false,
+              branch_data: {
+                other_metrics: {
+                  identity: {
+                    absolute: {
+                      first: {
                         point: 200,
                       },
-                    ],
-                  },
-                  difference: {
-                    first: {},
-                    all: [],
-                  },
-                  relative_uplift: {
-                    first: {},
-                    all: [],
-                  },
-                  percent: 55,
-                },
-                retained: TREATMENT_NEUTRAL,
-                picture_in_picture_ever_used: {
-                  absolute: {
-                    first: {
-                      point: 0.049019607843137254,
-                      count: 10,
-                      lower: 0.023872203557007872,
-                      upper: 0.08249069209461024,
+                      all: [
+                        {
+                          point: 200,
+                        },
+                      ],
                     },
-                    all: [
-                      {
+                    difference: {
+                      first: {},
+                      all: [],
+                    },
+                    relative_uplift: {
+                      first: {},
+                      all: [],
+                    },
+                    percent: 55,
+                  },
+                  retained: TREATMENT_NEUTRAL,
+                  picture_in_picture_ever_used: {
+                    absolute: {
+                      first: {
                         point: 0.049019607843137254,
                         count: 10,
                         lower: 0.023872203557007872,
                         upper: 0.08249069209461024,
                       },
-                    ],
-                  },
-                  difference: {
-                    first: {
-                      point: -0.0006569487628876534,
-                      upper: 0.04316381736512019,
-                      lower: 0.04175095963994029,
+                      all: [
+                        {
+                          point: 0.049019607843137254,
+                          count: 10,
+                          lower: 0.023872203557007872,
+                          upper: 0.08249069209461024,
+                        },
+                      ],
                     },
-                    all: [
-                      {
+                    difference: {
+                      first: {
                         point: -0.0006569487628876534,
                         upper: 0.04316381736512019,
                         lower: 0.04175095963994029,
                       },
-                    ],
-                  },
-                  relative_uplift: {
-                    first: {
-                      lower: -0.455210299676828,
-                      upper: 0.5104985718410426,
-                      point: -0.06233954570562385,
+                      all: [
+                        {
+                          point: -0.0006569487628876534,
+                          upper: 0.04316381736512019,
+                          lower: 0.04175095963994029,
+                        },
+                      ],
                     },
-                    all: [
-                      {
+                    relative_uplift: {
+                      first: {
                         lower: -0.455210299676828,
                         upper: 0.5104985718410426,
                         point: -0.06233954570562385,
                       },
-                    ],
-                  },
-                  significance: { overall: { "1": "positive" }, weekly: {} },
-                },
-                picture_in_picture: {
-                  absolute: {
-                    first: {
-                      point: 0.049019607843137254,
-                      count: 10,
-                      lower: 0.023872203557007872,
-                      upper: 0.08249069209461024,
+                      all: [
+                        {
+                          lower: -0.455210299676828,
+                          upper: 0.5104985718410426,
+                          point: -0.06233954570562385,
+                        },
+                      ],
                     },
-                    all: [
-                      {
+                    significance: { overall: { "1": "positive" }, weekly: {} },
+                  },
+                  picture_in_picture: {
+                    absolute: {
+                      first: {
                         point: 0.049019607843137254,
                         count: 10,
                         lower: 0.023872203557007872,
                         upper: 0.08249069209461024,
                       },
-                    ],
-                  },
-                  difference: {
-                    first: {
-                      point: -0.0006569487628876534,
-                      upper: 0.04316381736512019,
-                      lower: 0.04175095963994029,
+                      all: [
+                        {
+                          point: 0.049019607843137254,
+                          count: 10,
+                          lower: 0.023872203557007872,
+                          upper: 0.08249069209461024,
+                        },
+                      ],
                     },
-                    all: [
-                      {
+                    difference: {
+                      first: {
                         point: -0.0006569487628876534,
                         upper: 0.04316381736512019,
                         lower: 0.04175095963994029,
                       },
-                    ],
-                  },
-                  relative_uplift: {
-                    first: {
-                      lower: -0.455210299676828,
-                      upper: 0.5104985718410426,
-                      point: -0.06233954570562385,
+                      all: [
+                        {
+                          point: -0.0006569487628876534,
+                          upper: 0.04316381736512019,
+                          lower: 0.04175095963994029,
+                        },
+                      ],
                     },
-                    all: [
-                      {
+                    relative_uplift: {
+                      first: {
                         lower: -0.455210299676828,
                         upper: 0.5104985718410426,
                         point: -0.06233954570562385,
                       },
-                    ],
-                  },
-                  significance: { overall: { "1": "positive" }, weekly: {} },
-                },
-                feature_b_ever_used: {
-                  absolute: {
-                    first: {
-                      point: 0.049019607843137254,
-                      count: 10,
-                      lower: 0.023872203557007872,
-                      upper: 0.08249069209461024,
+                      all: [
+                        {
+                          lower: -0.455210299676828,
+                          upper: 0.5104985718410426,
+                          point: -0.06233954570562385,
+                        },
+                      ],
                     },
-                    all: [
-                      {
+                    significance: { overall: { "1": "positive" }, weekly: {} },
+                  },
+                  feature_b_ever_used: {
+                    absolute: {
+                      first: {
                         point: 0.049019607843137254,
                         count: 10,
                         lower: 0.023872203557007872,
                         upper: 0.08249069209461024,
                       },
-                    ],
-                  },
-                  difference: {
-                    first: {
-                      point: -0.0006569487628876534,
-                      upper: 0.04316381736512019,
-                      lower: 0.04175095963994029,
+                      all: [
+                        {
+                          point: 0.049019607843137254,
+                          count: 10,
+                          lower: 0.023872203557007872,
+                          upper: 0.08249069209461024,
+                        },
+                      ],
                     },
-                    all: [
-                      {
+                    difference: {
+                      first: {
                         point: -0.0006569487628876534,
                         upper: 0.04316381736512019,
                         lower: 0.04175095963994029,
                       },
-                    ],
-                  },
-                  relative_uplift: {
-                    first: {
-                      lower: -0.455210299676828,
-                      upper: 0.5104985718410426,
-                      point: -0.06233954570562385,
+                      all: [
+                        {
+                          point: -0.0006569487628876534,
+                          upper: 0.04316381736512019,
+                          lower: 0.04175095963994029,
+                        },
+                      ],
                     },
-                    all: [
-                      {
+                    relative_uplift: {
+                      first: {
                         lower: -0.455210299676828,
                         upper: 0.5104985718410426,
                         point: -0.06233954570562385,
                       },
-                    ],
-                  },
-                  significance: { overall: { "1": "negative" }, weekly: {} },
-                },
-                feature_b: {
-                  absolute: {
-                    first: {
-                      point: 0.049019607843137254,
-                      count: 10,
-                      lower: 0.023872203557007872,
-                      upper: 0.08249069209461024,
+                      all: [
+                        {
+                          lower: -0.455210299676828,
+                          upper: 0.5104985718410426,
+                          point: -0.06233954570562385,
+                        },
+                      ],
                     },
-                    all: [
-                      {
+                    significance: { overall: { "1": "negative" }, weekly: {} },
+                  },
+                  feature_b: {
+                    absolute: {
+                      first: {
                         point: 0.049019607843137254,
                         count: 10,
                         lower: 0.023872203557007872,
                         upper: 0.08249069209461024,
                       },
-                    ],
-                  },
-                  difference: {
-                    first: {
-                      point: -0.0006569487628876534,
-                      upper: 0.04316381736512019,
-                      lower: 0.04175095963994029,
+                      all: [
+                        {
+                          point: 0.049019607843137254,
+                          count: 10,
+                          lower: 0.023872203557007872,
+                          upper: 0.08249069209461024,
+                        },
+                      ],
                     },
-                    all: [
-                      {
+                    difference: {
+                      first: {
                         point: -0.0006569487628876534,
                         upper: 0.04316381736512019,
                         lower: 0.04175095963994029,
                       },
-                    ],
-                  },
-                  relative_uplift: {
-                    first: {
-                      lower: -0.455210299676828,
-                      upper: 0.5104985718410426,
-                      point: -0.06233954570562385,
+                      all: [
+                        {
+                          point: -0.0006569487628876534,
+                          upper: 0.04316381736512019,
+                          lower: 0.04175095963994029,
+                        },
+                      ],
                     },
-                    all: [
-                      {
+                    relative_uplift: {
+                      first: {
                         lower: -0.455210299676828,
                         upper: 0.5104985718410426,
                         point: -0.06233954570562385,
                       },
-                    ],
-                  },
-                  significance: { overall: { "1": "negative" }, weekly: {} },
-                },
-                feature_c_ever_used: {
-                  absolute: {
-                    first: {
-                      point: 0.049019607843137254,
-                      count: 10,
-                      lower: 0.023872203557007872,
-                      upper: 0.08249069209461024,
+                      all: [
+                        {
+                          lower: -0.455210299676828,
+                          upper: 0.5104985718410426,
+                          point: -0.06233954570562385,
+                        },
+                      ],
                     },
-                    all: [
-                      {
+                    significance: { overall: { "1": "negative" }, weekly: {} },
+                  },
+                  feature_c_ever_used: {
+                    absolute: {
+                      first: {
                         point: 0.049019607843137254,
                         count: 10,
                         lower: 0.023872203557007872,
                         upper: 0.08249069209461024,
                       },
-                    ],
-                  },
-                  difference: {
-                    first: {
-                      point: -0.0006569487628876534,
-                      upper: 0.04316381736512019,
-                      lower: 0.04175095963994029,
+                      all: [
+                        {
+                          point: 0.049019607843137254,
+                          count: 10,
+                          lower: 0.023872203557007872,
+                          upper: 0.08249069209461024,
+                        },
+                      ],
                     },
-                    all: [
-                      {
+                    difference: {
+                      first: {
                         point: -0.0006569487628876534,
                         upper: 0.04316381736512019,
                         lower: 0.04175095963994029,
                       },
-                    ],
-                  },
-                  relative_uplift: {
-                    first: {
-                      lower: -0.455210299676828,
-                      upper: 0.5104985718410426,
-                      point: -0.06233954570562385,
+                      all: [
+                        {
+                          point: -0.0006569487628876534,
+                          upper: 0.04316381736512019,
+                          lower: 0.04175095963994029,
+                        },
+                      ],
                     },
-                    all: [
-                      {
+                    relative_uplift: {
+                      first: {
                         lower: -0.455210299676828,
                         upper: 0.5104985718410426,
                         point: -0.06233954570562385,
                       },
-                    ],
-                  },
-                  significance: { overall: { "1": "neutral" }, weekly: {} },
-                },
-                feature_c: TREATMENT_NEUTRAL,
-                days_of_use: TREATMENT_NEUTRAL,
-                feature_d: {
-                  absolute: {
-                    first: {
-                      point: 0.049019607843137254,
-                      count: 10,
-                      lower: 0.023872203557007872,
-                      upper: 0.08249069209461024,
+                      all: [
+                        {
+                          lower: -0.455210299676828,
+                          upper: 0.5104985718410426,
+                          point: -0.06233954570562385,
+                        },
+                      ],
                     },
-                    all: [
-                      {
+                    significance: { overall: { "1": "neutral" }, weekly: {} },
+                  },
+                  feature_c: TREATMENT_NEUTRAL,
+                  days_of_use: TREATMENT_NEUTRAL,
+                  feature_d: {
+                    absolute: {
+                      first: {
                         point: 0.049019607843137254,
                         count: 10,
                         lower: 0.023872203557007872,
                         upper: 0.08249069209461024,
                       },
-                    ],
-                  },
-                  difference: {
-                    first: {
-                      point: -0.0006569487628876534,
-                      upper: 0.04316381736512019,
-                      lower: 0.04175095963994029,
+                      all: [
+                        {
+                          point: 0.049019607843137254,
+                          count: 10,
+                          lower: 0.023872203557007872,
+                          upper: 0.08249069209461024,
+                        },
+                      ],
                     },
-                    all: [
-                      {
+                    difference: {
+                      first: {
                         point: -0.0006569487628876534,
                         upper: 0.04316381736512019,
                         lower: 0.04175095963994029,
                       },
-                    ],
-                  },
-                  relative_uplift: {
-                    first: {
-                      lower: -0.455210299676828,
-                      upper: 0.5104985718410426,
-                      point: -0.06233954570562385,
+                      all: [
+                        {
+                          point: -0.0006569487628876534,
+                          upper: 0.04316381736512019,
+                          lower: 0.04175095963994029,
+                        },
+                      ],
                     },
-                    all: [
-                      {
+                    relative_uplift: {
+                      first: {
                         lower: -0.455210299676828,
                         upper: 0.5104985718410426,
                         point: -0.06233954570562385,
                       },
-                    ],
-                  },
-                  significance: { overall: { "1": "positive" }, weekly: {} },
-                },
-                outcome_d: {
-                  absolute: {
-                    first: {
-                      point: 0.049019607843137254,
-                      count: 10,
-                      lower: 0.023872203557007872,
-                      upper: 0.08249069209461024,
+                      all: [
+                        {
+                          lower: -0.455210299676828,
+                          upper: 0.5104985718410426,
+                          point: -0.06233954570562385,
+                        },
+                      ],
                     },
-                    all: [
-                      {
+                    significance: { overall: { "1": "positive" }, weekly: {} },
+                  },
+                  outcome_d: {
+                    absolute: {
+                      first: {
                         point: 0.049019607843137254,
                         count: 10,
                         lower: 0.023872203557007872,
                         upper: 0.08249069209461024,
                       },
-                    ],
-                  },
-                  difference: {
-                    first: {
-                      point: -0.0006569487628876534,
-                      upper: 0.04316381736512019,
-                      lower: 0.04175095963994029,
+                      all: [
+                        {
+                          point: 0.049019607843137254,
+                          count: 10,
+                          lower: 0.023872203557007872,
+                          upper: 0.08249069209461024,
+                        },
+                      ],
                     },
-                    all: [
-                      {
+                    difference: {
+                      first: {
                         point: -0.0006569487628876534,
                         upper: 0.04316381736512019,
                         lower: 0.04175095963994029,
                       },
-                    ],
-                  },
-                  relative_uplift: {
-                    first: {
-                      lower: -0.455210299676828,
-                      upper: 0.5104985718410426,
-                      point: -0.06233954570562385,
+                      all: [
+                        {
+                          point: -0.0006569487628876534,
+                          upper: 0.04316381736512019,
+                          lower: 0.04175095963994029,
+                        },
+                      ],
                     },
-                    all: [
-                      {
+                    relative_uplift: {
+                      first: {
                         lower: -0.455210299676828,
                         upper: 0.5104985718410426,
                         point: -0.06233954570562385,
                       },
-                    ],
+                      all: [
+                        {
+                          lower: -0.455210299676828,
+                          upper: 0.5104985718410426,
+                          point: -0.06233954570562385,
+                        },
+                      ],
+                    },
+                    significance: { overall: { "1": "positive" }, weekly: {} },
                   },
-                  significance: { overall: { "1": "positive" }, weekly: {} },
                 },
-              },
-              search_metrics: {
-                search_count: TREATMENT_NEGATIVE,
+                search_metrics: {
+                  search_count: TREATMENT_NEGATIVE,
+                },
               },
             },
           },

--- a/app/experimenter/nimbus-ui/src/lib/visualization/types.ts
+++ b/app/experimenter/nimbus-ui/src/lib/visualization/types.ts
@@ -5,34 +5,40 @@
 import { BRANCH_COMPARISON } from "./constants";
 
 export interface AnalysisData {
-  daily: {
-    [segment: string]: AnalysisPoint[] | null;
-    all: AnalysisPoint[] | null;
-  } | null;
-  weekly: {
-    [segment: string]: {
-      [branch: string]: BranchDescription;
-    };
-    all: {
-      [branch: string]: BranchDescription;
-    };
-  } | null;
-  overall: {
-    [segment: string]: {
-      [branch: string]: BranchDescription;
-    };
-    all: {
-      [branch: string]: BranchDescription;
-    };
-  } | null;
+  daily: AnalysisBasisData | null;
+  weekly: AggregatedAnalysisBasisData | null;
+  overall: AggregatedAnalysisBasisData | null;
   show_analysis: boolean;
   errors: AnalysisErrorGroup | null;
   metadata?: Metadata;
   other_metrics?: { [group: string]: { [metric: string]: string } };
 }
 
-export type AnalysisDataOverall = Exclude<AnalysisData["overall"], null>;
-export type AnalysisDataWeekly = Exclude<AnalysisData["weekly"], null>;
+interface AnalysisWindow {
+  [segment: string]: AnalysisPoint[] | null;
+  all: AnalysisPoint[] | null;
+}
+interface AggregatedAnalysisWindow {
+  [segment: string]: {
+    [branch: string]: BranchDescription;
+  };
+  all: {
+    [branch: string]: BranchDescription;
+  };
+}
+
+export type AnalysisBases = keyof AggregatedAnalysisBasisData;
+interface AggregatedAnalysisBasisData {
+  enrollments: AggregatedAnalysisWindow;
+  exposures?: AggregatedAnalysisWindow;
+}
+interface AnalysisBasisData {
+  enrollments: AnalysisWindow;
+  exposures?: AnalysisWindow;
+}
+
+export type AnalysisDataOverall = AggregatedAnalysisWindow;
+export type AnalysisDataWeekly = AggregatedAnalysisWindow;
 
 /**
  * Contains the analysis errors grouped by metric name, with any errors

--- a/app/experimenter/nimbus-ui/src/lib/visualization/utils.test.ts
+++ b/app/experimenter/nimbus-ui/src/lib/visualization/utils.test.ts
@@ -43,7 +43,9 @@ describe("getSortedBranchNames", () => {
 
   it("returns a list of branch names with many branches, the control branch first", () => {
     expect(
-      getSortedBranchNames(mockAnalysis({ overall: { all: MOCK_OVERALL } })),
+      getSortedBranchNames(
+        mockAnalysis({ overall: { enrollments: { all: MOCK_OVERALL } } }),
+      ),
     ).toEqual(["fum", "fee", "fi", "fo", "englishman"]);
   });
 
@@ -51,7 +53,7 @@ describe("getSortedBranchNames", () => {
     expect(
       getSortedBranchNames(
         mockAnalysis({
-          overall: { all: MOCK_OVERALL },
+          overall: { enrollments: { all: MOCK_OVERALL } },
           metadata: { external_config: { reference_branch: "englishman" } },
         }),
       ),
@@ -62,17 +64,19 @@ describe("getSortedBranchNames", () => {
 describe("getControlBranchName", () => {
   const MOCK_ANALYSIS_DAILY = {
     daily: {
-      all: [
-        {
-          point: 1,
-          branch: "test",
-          metric: "test_metric",
-          statistic: "count",
-        },
-      ],
+      enrollments: {
+        all: [
+          {
+            point: 1,
+            branch: "test",
+            metric: "test_metric",
+            statistic: "count",
+          },
+        ],
+      },
     },
-    weekly: { all: {} },
-    overall: { all: {} },
+    weekly: { enrollments: { all: {} } },
+    overall: { enrollments: { all: {} } },
     show_analysis: true,
     errors: { experiment: [] },
   };
@@ -86,20 +90,22 @@ describe("getControlBranchName", () => {
       getControlBranchName({
         ...MOCK_ANALYSIS_DAILY,
         daily: {
-          all: [
-            {
-              point: 1,
-              branch: "test",
-              metric: "test_metric",
-              statistic: "count",
-            },
-            {
-              point: 11,
-              branch: "not-test",
-              metric: "test_metric",
-              statistic: "binomial",
-            },
-          ],
+          enrollments: {
+            all: [
+              {
+                point: 1,
+                branch: "test",
+                metric: "test_metric",
+                statistic: "count",
+              },
+              {
+                point: 11,
+                branch: "not-test",
+                metric: "test_metric",
+                statistic: "binomial",
+              },
+            ],
+          },
         },
       }),
     ).toThrow("no branch name");
@@ -107,7 +113,10 @@ describe("getControlBranchName", () => {
 
   it("throws an error if it cannot find a branch in the results", () => {
     expect(() =>
-      getControlBranchName({ ...MOCK_ANALYSIS_DAILY, daily: { all: [] } }),
+      getControlBranchName({
+        ...MOCK_ANALYSIS_DAILY,
+        daily: { enrollments: { all: [] } },
+      }),
     ).toThrow("no branch name");
   });
 });

--- a/app/experimenter/nimbus-ui/src/lib/visualization/utils.tsx
+++ b/app/experimenter/nimbus-ui/src/lib/visualization/utils.tsx
@@ -38,7 +38,10 @@ export const getControlBranchName = (analysis: AnalysisData) => {
   if (external_config?.reference_branch) {
     return external_config.reference_branch;
   }
-  const results = analysis.overall?.all || analysis.weekly?.all || {};
+  const results =
+    analysis.overall?.enrollments?.all ||
+    analysis.weekly?.enrollments?.all ||
+    {};
   if (Object.keys(results).length > 0) {
     for (const [branchName, branchData] of Object.entries(results)) {
       if (branchData.is_control) {
@@ -47,7 +50,7 @@ export const getControlBranchName = (analysis: AnalysisData) => {
     }
   }
   // last option - try to find a unique branch name in the daily results
-  const daily = analysis.daily?.all || [];
+  const daily = analysis.daily?.enrollments?.all || [];
   if (daily.length > 0) {
     const branches = new Set(daily.map((point) => point.branch));
     if (branches.size === 1) {
@@ -64,7 +67,10 @@ export const getControlBranchName = (analysis: AnalysisData) => {
 export const getSortedBranchNames = (analysis: AnalysisData) => {
   try {
     const controlBranchName = getControlBranchName(analysis)!;
-    const results = analysis.overall?.all || analysis.weekly?.all || {};
+    const results =
+      analysis.overall?.enrollments?.all ||
+      analysis.weekly?.enrollments?.all ||
+      {};
     return [
       controlBranchName,
       ...Object.keys(results).filter((branch) => branch !== controlBranchName),

--- a/app/experimenter/visualization/api/v3/views.py
+++ b/app/experimenter/visualization/api/v3/views.py
@@ -8,7 +8,7 @@ from experimenter.experiments.models import NimbusExperiment
 @api_view()
 def analysis_results_view(request, slug):
     experiment = get_object_or_404(NimbusExperiment.objects.filter(slug=slug))
-    if experiment.results_data is not None and "v1" in experiment.results_data:
-        return Response(experiment.results_data["v1"])
+    if experiment.results_data is not None and "v2" in experiment.results_data:
+        return Response(experiment.results_data["v2"])
 
     return Response(None)

--- a/app/experimenter/visualization/tests/api/test_views.py
+++ b/app/experimenter/visualization/tests/api/test_views.py
@@ -39,7 +39,7 @@ class TestVisualizationView(TestCase):
         self.assertEqual(response.content, b"")
 
         # test with results_data object
-        experiment.results_data = {"v1": {}}
+        experiment.results_data = {"v2": {}}
         experiment.save()
 
         response = self.client.get(


### PR DESCRIPTION
Because

* Jetstream is able to calculate exposures analysis for configured experiments

This commit

* allows the user to view results by exposures only for experiments with these results available

Screenshot from Results page:
![image](https://user-images.githubusercontent.com/102263964/208159570-4ba8c450-a2ba-46b0-86b6-f3008804a394.png)
