### PR TITLE
Add new advanced desktop targeting for new users with infrequent use

### DIFF
--- a/app/experimenter/targeting/constants.py
+++ b/app/experimenter/targeting/constants.py
@@ -465,10 +465,7 @@ NEW_USERS_WITH_INFREQUENT_USE = NimbusTargetingConfig(
     name="New users with infrequent use",
     slug="new_users_with_infrequent_use",
     description="0 - 6 days activity in past 28 days and profile age <= 28 days",
-    targeting=(
-        f"{PROFILE28DAYS} "
-        "&& userMonthlyActivity|length <= 6"
-    ),
+    targeting=(f"{PROFILE28DAYS} " "&& userMonthlyActivity|length <= 6"),
     desktop_telemetry="",
     sticky_required=True,
     is_first_run_required=False,

--- a/app/experimenter/targeting/constants.py
+++ b/app/experimenter/targeting/constants.py
@@ -461,6 +461,20 @@ INFREQUENT_USER_FIVE_BOOKMARKS = NimbusTargetingConfig(
     application_choice_names=(Application.DESKTOP.name,),
 )
 
+NEW_USERS_WITH_INFREQUENT_USE = NimbusTargetingConfig(
+    name="New users with infrequent use",
+    slug="new_users_with_infrequent_use",
+    description="0 - 6 days activity in past 28 days and profile age <= 28 days",
+    targeting=(
+        f"{PROFILE28DAYS} "
+        "&& userMonthlyActivity|length <= 6"
+    ),
+    desktop_telemetry="",
+    sticky_required=True,
+    is_first_run_required=False,
+    application_choice_names=(Application.DESKTOP.name,),
+)
+
 CASUAL_USER_URIS = NimbusTargetingConfig(
     name="Casual user (uris)",
     slug="casual_user_uris",


### PR DESCRIPTION
This new targeting will support out follow up import bookmarks experiments. The goal is to target users who used Firefox 6 or fewer times over the past 28 days and who have a profile age of less than 28 days.