### PR TITLE
fixes #8079 bug(nimbus): Update circleci desktop targeting tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ jobs:
     working_directory: ~/experimenter
     environment:
       FIREFOX_VERSION: nimbus-firefox-release
-      PYTEST_ARGS: -k DESKTOP -m run_targeting -n 2
+      PYTEST_ARGS: -k FIREFOX_DESKTOP -m run_targeting -n 4
       MOZ_REMOTE_SETTINGS_DEVTOOLS: 1 # allows us to override and set the remote settings URL
     steps:
       - checkout
@@ -57,7 +57,7 @@ jobs:
     working_directory: ~/experimenter
     environment:
       FIREFOX_VERSION: nimbus-firefox-beta
-      PYTEST_ARGS: -k DESKTOP -m run_targeting -n 2
+      PYTEST_ARGS: -k FIREFOX_DESKTOP -m run_targeting -n 4
       MOZ_REMOTE_SETTINGS_DEVTOOLS: 1 # allows us to override and set the remote settings URL
     steps:
       - checkout


### PR DESCRIPTION
Because:
* I noticed the desktop targeting tests were running tests against non-desktop targeting configs.

This Commit:
* Changes the tests to run only on desktop
* Updates the amount of parallel test runs that are ran