### PR TITLE
For #8012 feat(nimbus): Support rollouts and experiments for status validation

### DIFF
--- a/app/experimenter/experiments/api/v5/serializers.py
+++ b/app/experimenter/experiments/api/v5/serializers.py
@@ -588,14 +588,13 @@ class NimbusStatusValidationMixin:
             "publish_status": NimbusConstants.PUBLISH_STATUS_ALLOWS_UPDATE,
         }
         update_exempt_fields = NimbusExperiment.STATUS_UPDATE_EXEMPT_FIELDS
-
+        fields = ["all"]
         if self.instance:
             restrictive_statuses = set()
             exempt_fields = set()
-            if self.instance.is_rollout:
-                fields = ["all", "rollouts"]
-            else:
-                fields = ["all", "experiments"]
+            fields.append("rollouts") if self.instance.is_rollout else fields.append(
+                "experiments"
+            )
 
             for f in fields:
                 if update_exempt_fields[f] != []:

--- a/app/experimenter/experiments/constants.py
+++ b/app/experimenter/experiments/constants.py
@@ -211,7 +211,7 @@ class NimbusConstants(object):
         ],
         "experiments": [],
         "rollouts": [
-            Status.LIVE
+            Status.LIVE,
         ],
     }
 

--- a/app/experimenter/experiments/constants.py
+++ b/app/experimenter/experiments/constants.py
@@ -178,7 +178,6 @@ class NimbusConstants(object):
         Status.DRAFT: (Status.PREVIEW,),
         Status.PREVIEW: (Status.DRAFT,),
     }
-    STATUS_ALLOWS_UPDATE = (Status.DRAFT,)
 
     # Valid status_next values for given status values in the
     # UI only. This does not represent the full list of
@@ -191,7 +190,7 @@ class NimbusConstants(object):
 
     # Valid publish_status transitions for given status
     # values in the UI only. This does not represent the
-    #  full list of publish_status transitions.
+    # full list of publish_status transitions.
     VALID_PUBLISH_STATUS_TRANSITIONS = {
         PublishStatus.IDLE: (
             PublishStatus.DIRTY,
@@ -206,16 +205,36 @@ class NimbusConstants(object):
         ),
     }
 
-    PUBLISH_STATUS_ALLOWS_UPDATE = (PublishStatus.IDLE,)
+    STATUS_ALLOWS_UPDATE = {
+        "all": [
+            Status.DRAFT,
+        ],
+        "experiments": [],
+        "rollouts": [
+            Status.LIVE
+        ],
+    }
 
-    STATUS_UPDATE_EXEMPT_FIELDS = (
-        "is_archived",
-        "publish_status",
-        "status_next",
-        "status",
-        "takeaways_summary",
-        "conclusion_recommendation",
-    )
+    PUBLISH_STATUS_ALLOWS_UPDATE = {
+        "all": [
+            PublishStatus.IDLE,
+        ],
+        "experiments": [],
+        "rollouts": [],
+    }
+
+    STATUS_UPDATE_EXEMPT_FIELDS = {
+        "all": [
+            "is_archived",
+            "publish_status",
+            "status_next",
+            "status",
+            "takeaways_summary",
+            "conclusion_recommendation",
+        ],
+        "experiments": [],
+        "rollouts": [],
+    }
 
     ARCHIVE_UPDATE_EXEMPT_FIELDS = (
         "is_archived",

--- a/app/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_status_validation_mixin.py
+++ b/app/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_status_validation_mixin.py
@@ -46,6 +46,101 @@ class TestNimbusStatusValidationMixin(TestCase):
         self.assertFalse(serializer.is_valid())
         self.assertIn("experiment", serializer.errors)
 
+    def test_locked_fields_and_status_error(self):
+        fields = (
+            NimbusExperiment.STATUS_UPDATE_EXEMPT_FIELDS["all"]
+            + NimbusExperiment.STATUS_UPDATE_EXEMPT_FIELDS["experiments"]
+        )
+        status_allowed = (
+            NimbusExperiment.STATUS_ALLOWS_UPDATE["all"]
+            + NimbusExperiment.STATUS_ALLOWS_UPDATE["experiments"]
+        )
+
+        field_to_change = "public_description"
+        status = NimbusExperiment.Status.PREVIEW
+
+        experiment = NimbusExperimentFactory.create(
+            status=status,
+            is_rollout=True,
+        )
+
+        serializer = NimbusExperimentSerializer(
+            experiment,
+            data={
+                field_to_change: "who knows, really",
+                "changelog_message": "test changelog message",
+            },
+            context={"user": self.user},
+        )
+
+        self.assertFalse(field_to_change in fields)
+        self.assertFalse(status in status_allowed)
+
+        self.assertFalse(serializer.is_valid())
+        self.assertIn("experiment", serializer.errors)
+
+    def test_locked_fields_and_valid_status_does_not_error(self):
+        fields = (
+            NimbusExperiment.STATUS_UPDATE_EXEMPT_FIELDS["all"]
+            + NimbusExperiment.STATUS_UPDATE_EXEMPT_FIELDS["experiments"]
+        )
+        status_allowed = (
+            NimbusExperiment.STATUS_ALLOWS_UPDATE["all"]
+            + NimbusExperiment.STATUS_ALLOWS_UPDATE["experiments"]
+        )
+
+        field_to_change = "public_description"
+        status = NimbusExperiment.Status.DRAFT
+
+        experiment = NimbusExperimentFactory.create(
+            status=status,
+            is_rollout=True,
+        )
+
+        serializer = NimbusExperimentSerializer(
+            experiment,
+            data={
+                field_to_change: "who knows, really",
+                "changelog_message": "test changelog message",
+            },
+            context={"user": self.user},
+        )
+
+        self.assertFalse(field_to_change in fields)
+        self.assertTrue(status in status_allowed)
+        self.assertTrue(serializer.is_valid())
+
+    def test_unlocked_fields_and_valid_status_does_not_error(self):
+        fields = (
+            NimbusExperiment.STATUS_UPDATE_EXEMPT_FIELDS["all"]
+            + NimbusExperiment.STATUS_UPDATE_EXEMPT_FIELDS["experiments"]
+        )
+        status_allowed = (
+            NimbusExperiment.STATUS_ALLOWS_UPDATE["all"]
+            + NimbusExperiment.STATUS_ALLOWS_UPDATE["experiments"]
+        )
+
+        field_to_change = "takeaways_summary"
+        status = NimbusExperiment.Status.DRAFT
+
+        experiment = NimbusExperimentFactory.create(
+            status=status,
+            is_rollout=True,
+        )
+
+        serializer = NimbusExperimentSerializer(
+            experiment,
+            data={
+                field_to_change: "who knows, really",
+                "changelog_message": "test changelog message",
+            },
+            context={"user": self.user},
+        )
+
+        self.assertTrue(field_to_change in fields)
+        self.assertTrue(status in status_allowed)
+        self.assertTrue(serializer.is_valid())
+
     @parameterized.expand(
         [
             [

--- a/app/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_status_validation_mixin.py
+++ b/app/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_status_validation_mixin.py
@@ -17,6 +17,7 @@ class TestNimbusStatusValidationMixin(TestCase):
     def test_update_experiment_with_invalid_status_error(self):
         experiment = NimbusExperimentFactory.create(
             status=NimbusExperiment.Status.PREVIEW,
+            is_rollout=False,
         )
         serializer = NimbusExperimentSerializer(
             experiment,
@@ -29,9 +30,10 @@ class TestNimbusStatusValidationMixin(TestCase):
         self.assertFalse(serializer.is_valid())
         self.assertIn("experiment", serializer.errors)
 
-    def test_unable_to_update_experiment_in_publish_status(self):
+    def test_update_rollout_with_invalid_status_error(self):
         experiment = NimbusExperimentFactory.create(
-            publish_status=NimbusExperiment.PublishStatus.REVIEW,
+            status=NimbusExperiment.Status.PREVIEW,
+            is_rollout=True,
         )
         serializer = NimbusExperimentSerializer(
             experiment,


### PR DESCRIPTION
Because...

* Our v5 serializer validates which fields can be modified against "locked" statuses
* And we are going to be allowing Rollouts to be modified while `LIVE`

This commit...

* Changes `constants.py` to include lists for experiments, rollouts, and shared ("all") for:
   * status: `STATUS_ALLOWS_UPDATE`
   * publish status: `PUBLISH_STATUS_ALLOWS_UPDATE`
   * modification exempt fields: `STATUS_UPDATE_EXEMPT_FIELDS`
* Uses these new lists in the v5 serializer to check if an edit is valid
* Adds a new test for rollouts for serializer status mixin for codecov