### PR TITLE
For #7983 feat(nimbus) test(nimbus): Serializer validation for publish status and tests

### DIFF
--- a/app/experimenter/experiments/api/v5/serializers.py
+++ b/app/experimenter/experiments/api/v5/serializers.py
@@ -580,6 +580,11 @@ class NimbusExperimentDocumentationLinkMixin:
 
 
 class NimbusStatusValidationMixin:
+    """
+    This will only validate certain statuses, and the validation does not
+    cover status transitions made by Remote Settings.
+    """
+
     def validate(self, data):
         data = super().validate(data)
 
@@ -633,12 +638,19 @@ class NimbusStatusValidationMixin:
 
 
 class NimbusStatusTransitionValidator:
+    """
+    This will only validate certain statuses, and the validation does not
+    cover status transitions made by Remote Settings.
+    """
+
     requires_context = True
 
     def __init__(self, transitions):
         self.transitions = transitions
 
     def __call__(self, value, serializer_field):
+        """Validates using `NimbusConstants.VALID_STATUS_TRANSITIONS`"""
+
         field_name = serializer_field.source_attrs[-1]
         instance = getattr(serializer_field.parent, "instance", None)
 
@@ -837,6 +849,8 @@ class NimbusExperimentSerializer(
         return is_archived
 
     def validate_publish_status(self, publish_status):
+        """Validates using `NimbusConstants.VALID_PUBLISH_STATUS_TRANSITIONS`"""
+
         if publish_status == NimbusExperiment.PublishStatus.APPROVED and (
             self.instance.publish_status != NimbusExperiment.PublishStatus.IDLE
             and not self.instance.can_review(self.context["user"])
@@ -889,6 +903,9 @@ class NimbusExperimentSerializer(
         return value
 
     def validate_status_next(self, value):
+        """This validation for `status_next` does not cover any
+        transitions made by Remote Settings."""
+
         valid_status_next = NimbusExperiment.VALID_STATUS_NEXT_VALUES.get(
             self.instance.status, ()
         )

--- a/app/experimenter/experiments/api/v5/serializers.py
+++ b/app/experimenter/experiments/api/v5/serializers.py
@@ -852,7 +852,11 @@ class NimbusExperimentSerializer(
         """Validates using `NimbusConstants.VALID_PUBLISH_STATUS_TRANSITIONS`"""
 
         if publish_status == NimbusExperiment.PublishStatus.APPROVED and (
-            self.instance.publish_status != NimbusExperiment.PublishStatus.IDLE
+            self.instance.publish_status
+            not in (
+                NimbusExperiment.PublishStatus.IDLE,
+                NimbusExperiment.PublishStatus.DIRTY,
+            )
             and not self.instance.can_review(self.context["user"])
         ):
             raise serializers.ValidationError(

--- a/app/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_experiment_serializer.py
+++ b/app/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_experiment_serializer.py
@@ -747,9 +747,39 @@ class TestNimbusExperimentSerializer(TestCase):
             [NimbusExperiment.PublishStatus.REVIEW],
         ]
     )
-    def test_update_publish_status_doesnt_invoke_push_task(self, publish_status):
+    def test_update_experiment_publish_status_doesnt_invoke_push_task(
+        self, publish_status
+    ):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperimentFactory.Lifecycles.CREATED
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            is_rollout=False,
+        )
+
+        serializer = NimbusExperimentSerializer(
+            experiment,
+            data={
+                "publish_status": publish_status,
+                "changelog_message": "test changelog message",
+            },
+            context={"user": self.user},
+        )
+        self.assertTrue(serializer.is_valid())
+
+        experiment = serializer.save()
+        self.assertEqual(experiment.publish_status, publish_status)
+        self.mock_preview_task.apply_async.assert_not_called()
+
+    @parameterized.expand(
+        [
+            [NimbusExperiment.PublishStatus.IDLE],
+            [NimbusExperiment.PublishStatus.DIRTY],
+            [NimbusExperiment.PublishStatus.REVIEW],
+        ]
+    )
+    def test_update_rollout_publish_status_doesnt_invoke_push_task(self, publish_status):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            is_rollout=True,
         )
 
         serializer = NimbusExperimentSerializer(
@@ -941,6 +971,65 @@ class TestNimbusExperimentSerializer(TestCase):
         self.assertEqual(experiment.status, NimbusExperiment.Status.DRAFT)
         self.assertEqual(experiment.publish_status, NimbusExperiment.PublishStatus.REVIEW)
 
+    def test_rollout_can_request_review_from_live(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE_APPROVE,
+            is_rollout=True,
+        )
+
+        serializer = NimbusExperimentSerializer(
+            experiment,
+            data={
+                "status": NimbusExperiment.Status.LIVE,
+                "publish_status": NimbusExperiment.PublishStatus.REVIEW,
+                "changelog_message": "test changelog message",
+            },
+            context={"user": self.user},
+        )
+
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+        experiment = serializer.save()
+        self.assertEqual(experiment.status, NimbusExperiment.Status.LIVE)
+        self.assertEqual(experiment.publish_status, NimbusExperiment.PublishStatus.REVIEW)
+
+    def test_rollout_can_request_review_from_live_dirty(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.LIVE_DIRTY,
+            is_rollout=True,
+        )
+
+        serializer = NimbusExperimentSerializer(
+            experiment,
+            data={
+                "status": NimbusExperiment.Status.LIVE,
+                "publish_status": NimbusExperiment.PublishStatus.REVIEW,
+                "changelog_message": "test changelog message",
+            },
+            context={"user": self.user},
+        )
+
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+        experiment = serializer.save()
+        self.assertEqual(experiment.status, NimbusExperiment.Status.LIVE)
+        self.assertEqual(experiment.publish_status, NimbusExperiment.PublishStatus.REVIEW)
+
+    def test_allow_live_rollout_to_be_dirty(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            lifecycle=NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE_APPROVE,
+            is_rollout=True,
+        )
+        serializer = NimbusExperimentSerializer(
+            experiment,
+            data={
+                "status": NimbusExperiment.Status.LIVE,
+                "publish_status": NimbusExperiment.PublishStatus.DIRTY,
+                "status_next": NimbusExperiment.Status.LIVE,
+                "changelog_message": "test changelog message",
+            },
+            context={"user": self.user},
+        )
+        self.assertTrue(serializer.is_valid())
+
     def test_can_review_for_non_requesting_user(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.LAUNCH_REVIEW_REQUESTED,
@@ -983,9 +1072,46 @@ class TestNimbusExperimentSerializer(TestCase):
         self.assertFalse(serializer.is_valid(), serializer.errors)
         self.assertIn("publish_status", serializer.errors)
 
-    def test_can_review_for_requesting_user_when_idle(self):
+    def test_cant_review_for_requesting_user_dirty(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.LIVE_DIRTY,
+        )
+
+        serializer = NimbusExperimentSerializer(
+            experiment,
+            data={
+                "publish_status": NimbusExperiment.PublishStatus.APPROVED,
+                "changelog_message": "test changelog message",
+            },
+            context={"user": experiment.owner},
+        )
+
+        self.assertFalse(serializer.is_valid(), serializer.errors)
+        self.assertIn("publish_status", serializer.errors)
+
+    @parameterized.expand([[True], [False]])
+    def test_can_review_for_requesting_user_when_idle(self, is_rollout):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.CREATED,
+            is_rollout=is_rollout,
+        )
+
+        serializer = NimbusExperimentSerializer(
+            experiment,
+            data={
+                "publish_status": NimbusExperiment.PublishStatus.REVIEW,
+                "changelog_message": "test changelog message",
+            },
+            context={"user": experiment.owner},
+        )
+
+        self.assertTrue(serializer.is_valid())
+
+    @parameterized.expand([[True], [False]])
+    def test_can_review_for_requesting_user_when_dirty(self, is_rollout):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.LIVE_DIRTY,
+            is_rollout=is_rollout,
         )
 
         serializer = NimbusExperimentSerializer(

--- a/app/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_status_transition_validator.py
+++ b/app/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_status_transition_validator.py
@@ -17,6 +17,26 @@ class TestNimbusStatusTransitionValidator(TestCase):
     def test_update_experiment_status_error(self):
         experiment = NimbusExperimentFactory.create(
             status=NimbusExperiment.Status.DRAFT,
+            is_rollout=False,
+        )
+        serializer = NimbusExperimentSerializer(
+            experiment,
+            data={
+                "status": NimbusExperiment.Status.LIVE,
+                "changelog_message": "test changelog message",
+            },
+            context={"user": self.user},
+        )
+        self.assertFalse(serializer.is_valid())
+        self.assertEqual(
+            serializer.errors["status"][0],
+            "Nimbus Experiment status cannot transition from Draft to Live.",
+        )
+
+    def test_update_rollout_status_error(self):
+        experiment = NimbusExperimentFactory.create(
+            status=NimbusExperiment.Status.DRAFT,
+            is_rollout=True,
         )
         serializer = NimbusExperimentSerializer(
             experiment,
@@ -35,6 +55,7 @@ class TestNimbusStatusTransitionValidator(TestCase):
     def test_update_publish_status_from_approved_to_review_error(self):
         experiment = NimbusExperimentFactory.create(
             publish_status=NimbusExperiment.PublishStatus.APPROVED,
+            is_rollout=False,
         )
         serializer = NimbusExperimentSerializer(
             experiment,
@@ -71,7 +92,7 @@ class TestNimbusStatusTransitionValidator(TestCase):
             NimbusExperiment.ERROR_LAUNCHING_DISABLED,
         )
 
-    def test_end_enrolment_request_while_disabled_error(self):
+    def test_end_enrollment_request_while_disabled_error(self):
         SiteFlag(name=SiteFlagNameChoices.LAUNCHING_DISABLED.name, value=True).save()
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.LIVE_ENROLLING

--- a/app/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_status_transition_validator.py
+++ b/app/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_status_transition_validator.py
@@ -1,4 +1,5 @@
 from django.test import TestCase
+from parameterized import parameterized
 
 from experimenter.base.models import SiteFlag, SiteFlagNameChoices
 from experimenter.experiments.api.v5.serializers import NimbusExperimentSerializer
@@ -14,29 +15,11 @@ class TestNimbusStatusTransitionValidator(TestCase):
         super().setUp()
         self.user = UserFactory()
 
-    def test_update_experiment_status_error(self):
+    @parameterized.expand([[True], [False]])
+    def test_update_status_error(self, is_rollout):
         experiment = NimbusExperimentFactory.create(
             status=NimbusExperiment.Status.DRAFT,
-            is_rollout=False,
-        )
-        serializer = NimbusExperimentSerializer(
-            experiment,
-            data={
-                "status": NimbusExperiment.Status.LIVE,
-                "changelog_message": "test changelog message",
-            },
-            context={"user": self.user},
-        )
-        self.assertFalse(serializer.is_valid())
-        self.assertEqual(
-            serializer.errors["status"][0],
-            "Nimbus Experiment status cannot transition from Draft to Live.",
-        )
-
-    def test_update_rollout_status_error(self):
-        experiment = NimbusExperimentFactory.create(
-            status=NimbusExperiment.Status.DRAFT,
-            is_rollout=True,
+            is_rollout=is_rollout,
         )
         serializer = NimbusExperimentSerializer(
             experiment,


### PR DESCRIPTION
📢 Requires #8081 to be merged first 

Because...

* We are allowing `LIVE` rollouts to have `DIRTY` publish status and go through review

This commit...

* Checks for `DIRTY` status when the v5 serializer validates `publish_status`
* Adds some tests to the serializer: expanding what we already have to include tests for both experiments and rollouts, and adding some tests for dirty publish status:
   * `[...]publish_status_doesnt_invoke_push_task` - for rollouts and experiments
   * `test_rollout_can_request_review_from_live`
   * `test_rollout_can_request_review_from_live_dirty`
   * `test_allow_live_rollout_to_be_dirty`
   * `test_cant_review_for_requesting_user_dirty`
   * `test_can_review_for_requesting_user_when_idle` - for rollouts and experiments
   * `test_can_review_for_requesting_user_when_dirty` - for rollouts and experiments