### PR TITLE
For #8012 refactor(nimbus): Move transition constants into serializer

### DIFF
--- a/app/experimenter/experiments/api/v5/serializers.py
+++ b/app/experimenter/experiments/api/v5/serializers.py
@@ -614,13 +614,14 @@ class NimbusStatusValidationMixin:
                 is_locked = current_status not in restrictive_statuses
                 modifying_fields = set(data.keys()) - exempt_fields
                 is_modifying_locked_fields = set(data.keys()).issubset(modifying_fields)
+
                 if is_locked and is_modifying_locked_fields:
                     raise serializers.ValidationError(
                         {
                             "experiment": [
                                 f"Nimbus Experiment has {status_field} "
                                 f"'{current_status}', only "
-                                f"{NimbusExperiment.STATUS_UPDATE_EXEMPT_FIELDS} "
+                                f"{update_exempt_fields} "
                                 f"can be changed, not: {modifying_fields}"
                             ]
                         }

--- a/app/experimenter/experiments/constants.py
+++ b/app/experimenter/experiments/constants.py
@@ -174,68 +174,6 @@ class NimbusConstants(object):
         EXPERIMENT = "Experiment"
         ROLLOUT = "Rollout"
 
-    VALID_STATUS_TRANSITIONS = {
-        Status.DRAFT: (Status.PREVIEW,),
-        Status.PREVIEW: (Status.DRAFT,),
-    }
-
-    # Valid status_next values for given status values in the
-    # UI only. This does not represent the full list of
-    # status_next values.
-    VALID_STATUS_NEXT_VALUES = {
-        Status.DRAFT: (None, Status.LIVE),
-        Status.PREVIEW: (None, Status.LIVE),
-        Status.LIVE: (None, Status.LIVE, Status.COMPLETE),
-    }
-
-    # Valid publish_status transitions for given status
-    # values in the UI only. This does not represent the
-    # full list of publish_status transitions.
-    VALID_PUBLISH_STATUS_TRANSITIONS = {
-        PublishStatus.IDLE: (
-            PublishStatus.DIRTY,
-            PublishStatus.REVIEW,
-            PublishStatus.APPROVED,
-        ),
-        PublishStatus.DIRTY: (PublishStatus.REVIEW,),
-        PublishStatus.REVIEW: (
-            PublishStatus.IDLE,
-            PublishStatus.DIRTY,
-            PublishStatus.APPROVED,
-        ),
-    }
-
-    STATUS_ALLOWS_UPDATE = {
-        "all": [
-            Status.DRAFT,
-        ],
-        "experiments": [],
-        "rollouts": [
-            Status.LIVE,
-        ],
-    }
-
-    PUBLISH_STATUS_ALLOWS_UPDATE = {
-        "all": [
-            PublishStatus.IDLE,
-        ],
-        "experiments": [],
-        "rollouts": [],
-    }
-
-    STATUS_UPDATE_EXEMPT_FIELDS = {
-        "all": [
-            "is_archived",
-            "publish_status",
-            "status_next",
-            "status",
-            "takeaways_summary",
-            "conclusion_recommendation",
-        ],
-        "experiments": [],
-        "rollouts": [],
-    }
-
     ARCHIVE_UPDATE_EXEMPT_FIELDS = (
         "is_archived",
         "changelog_message",

--- a/app/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_status_validation_mixin.py
+++ b/app/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_status_validation_mixin.py
@@ -1,7 +1,10 @@
 from django.test import TestCase
 from parameterized import parameterized
 
-from experimenter.experiments.api.v5.serializers import NimbusExperimentSerializer
+from experimenter.experiments.api.v5.serializers import (
+    NimbusExperimentSerializer,
+    TransitionConstants,
+)
 from experimenter.experiments.models import NimbusExperiment
 from experimenter.experiments.tests.factories import NimbusExperimentFactory
 from experimenter.openidc.tests.factories import UserFactory
@@ -57,12 +60,12 @@ class TestNimbusStatusValidationMixin(TestCase):
         self, field_to_change, status, field_valid, status_valid, serializer_valid
     ):
         fields = (
-            NimbusExperiment.STATUS_UPDATE_EXEMPT_FIELDS["all"]
-            + NimbusExperiment.STATUS_UPDATE_EXEMPT_FIELDS["experiments"]
+            TransitionConstants.STATUS_UPDATE_EXEMPT_FIELDS["all"]
+            + TransitionConstants.STATUS_UPDATE_EXEMPT_FIELDS["experiments"]
         )
         status_allowed = (
-            NimbusExperiment.STATUS_ALLOWS_UPDATE["all"]
-            + NimbusExperiment.STATUS_ALLOWS_UPDATE["experiments"]
+            TransitionConstants.STATUS_ALLOWS_UPDATE["all"]
+            + TransitionConstants.STATUS_ALLOWS_UPDATE["experiments"]
         )
 
         experiment = NimbusExperimentFactory.create(


### PR DESCRIPTION
📢 Requires #8081 and #8086 to be merged first

This is a small refactor to move some constants for status and publish status out of the `NimbusExperiments` constants.py file into the v5 serializer where they are being used.

This commit...

* Creates `TransitionConstants` class in the v5 serializer
* Moves the following constants into the class:
   * `VALID_STATUS_TRANSITIONS`
   * `VALID_STATUS_NEXT_VALUES`
   * `VALID_PUBLISH_STATUS_TRANSITIONS`
   * `STATUS_ALLOWS_UPDATE`
   * `PUBLISH_STATUS_ALLOWS_UPDATE`
   * `STATUS_UPDATE_EXEMPT_FIELDS`
