### PR TITLE
For #8095 feat(nimbus): Add ability to disable fields on Audience page

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/index.test.tsx
@@ -24,6 +24,7 @@ import {
   NimbusExperimentApplicationEnum,
   NimbusExperimentChannelEnum,
   NimbusExperimentFirefoxVersionEnum,
+  NimbusExperimentStatusEnum,
 } from "../../../types/globalTypes";
 import { MOCK_EXPERIMENT, Subject } from "./mocks";
 
@@ -1225,6 +1226,74 @@ describe("FormAudience", () => {
       locales: ["We can shake it loose right away"],
     });
   });
+});
+
+it("disables fields when locked", async () => {
+  render(
+    <Subject
+      experiment={{
+        ...MOCK_EXPERIMENT,
+        application: NimbusExperimentApplicationEnum.FENIX,
+        isRollout: true,
+        status: NimbusExperimentStatusEnum.LIVE,
+        targetingConfig: [
+          {
+            label: "No Targeting",
+            value: "",
+            applicationValues: [
+              NimbusExperimentApplicationEnum.DESKTOP,
+              "TOASTER",
+            ],
+            description: "No targeting configuration",
+            stickyRequired: false,
+            isFirstRunRequired: false,
+          },
+        ],
+      }}
+    />,
+  );
+  // testing one checkbox, one dropdown, and one text field
+  expect(screen.getByTestId("isSticky")).toBeDisabled();
+  expect(screen.getByTestId("firefoxMinVersion")).toBeDisabled();
+  expect(
+    within(
+      screen.queryByTestId("population-percent-top-row") as HTMLElement,
+    ).getByTestId("population-percent-text"),
+  ).toBeDisabled();
+});
+
+it("enables fields when unlocked", async () => {
+  render(
+    <Subject
+      experiment={{
+        ...MOCK_EXPERIMENT,
+        application: NimbusExperimentApplicationEnum.FENIX,
+        isRollout: false,
+        status: NimbusExperimentStatusEnum.DRAFT,
+        targetingConfig: [
+          {
+            label: "No Targeting",
+            value: "",
+            applicationValues: [
+              NimbusExperimentApplicationEnum.DESKTOP,
+              "TOASTER",
+            ],
+            description: "No targeting configuration",
+            stickyRequired: false,
+            isFirstRunRequired: false,
+          },
+        ],
+      }}
+    />,
+  );
+  // testing one checkbox, one dropdown, and one text field
+  expect(screen.getByTestId("isSticky")).toBeEnabled();
+  expect(screen.getByTestId("firefoxMinVersion")).toBeEnabled();
+  expect(
+    within(
+      screen.queryByTestId("population-percent-top-row") as HTMLElement,
+    ).getByTestId("population-percent-text"),
+  ).toBeEnabled();
 });
 
 describe("filterAndSortTargetingConfigSlug", () => {

--- a/app/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/index.tsx
@@ -17,6 +17,7 @@ import {
   POSITIVE_NUMBER_WITH_COMMAS_FIELD,
   TOOLTIP_DURATION,
 } from "../../../lib/constants";
+import { getStatus } from "../../../lib/experiment";
 import {
   getConfig_nimbusConfig,
   getConfig_nimbusConfig_targetingConfigs,
@@ -197,6 +198,8 @@ export const FormAudience = ({
 
   const isDesktop =
     experiment.application === NimbusExperimentApplicationEnum.DESKTOP;
+  const isLiveRollout = experiment.isRollout && getStatus(experiment).live;
+  const isLocked = isLiveRollout && !getStatus(experiment).draft;
 
   return (
     <Form
@@ -217,7 +220,11 @@ export const FormAudience = ({
             <Form.Label className="d-flex align-items-center">
               Channel
             </Form.Label>
-            <Form.Control {...formControlAttrs("channel")} as="select">
+            <Form.Control
+              {...formControlAttrs("channel")}
+              as="select"
+              disabled={isLocked!}
+            >
               <SelectOptions options={applicationConfig!.channels!} />
             </Form.Control>
             <FormErrors name="channel" />
@@ -229,6 +236,7 @@ export const FormAudience = ({
             <Form.Control
               {...formControlAttrs("firefoxMinVersion")}
               as="select"
+              disabled={isLocked!}
             >
               <SelectOptions options={config.firefoxVersions} />
             </Form.Control>
@@ -241,6 +249,7 @@ export const FormAudience = ({
             <Form.Control
               {...formControlAttrs("firefoxMaxVersion")}
               as="select"
+              disabled={isLocked!}
             >
               <SelectOptions options={config.firefoxVersions} />
             </Form.Control>
@@ -256,6 +265,7 @@ export const FormAudience = ({
                 isMulti
                 {...formSelectAttrs("locales", setLocales)}
                 options={selectOptions(config.locales as SelectIdItems)}
+                isDisabled={isLocked!}
               />
               <FormErrors name="locales" />
             </Form.Group>
@@ -268,6 +278,7 @@ export const FormAudience = ({
                 isMulti
                 {...formSelectAttrs("languages", setLanguages)}
                 options={selectOptions(config.languages as SelectIdItems)}
+                isDisabled={isLocked!}
               />
               <FormErrors name="languages" />
             </Form.Group>
@@ -279,6 +290,7 @@ export const FormAudience = ({
               isMulti
               {...formSelectAttrs("countries", setCountries)}
               options={selectOptions(config.countries as SelectIdItems)}
+              isDisabled={isLocked!}
             />
 
             <FormErrors name="countries" />
@@ -293,6 +305,7 @@ export const FormAudience = ({
               {...formControlAttrs("targetingConfigSlug")}
               as="select"
               onChange={TargetingOnChange.bind(this)}
+              disabled={isLocked!}
             >
               <TargetConfigSelectOptions options={targetingConfigSlugOptions} />
             </Form.Control>
@@ -306,7 +319,7 @@ export const FormAudience = ({
               type="checkbox"
               checked={isSticky}
               onChange={(e) => setIsSticky(e.target.checked)}
-              disabled={stickyRequiredWarning}
+              disabled={stickyRequiredWarning || isLocked!}
               label="Sticky Enrollment (Clients remain enrolled until the experiment ends)"
             />
             {stickyRequiredWarning && (
@@ -324,7 +337,7 @@ export const FormAudience = ({
               type="checkbox"
               onChange={(e) => setIsFirstRun(e.target.checked)}
               checked={isFirstRun}
-              disabled={isFirstRunRequiredWarning}
+              disabled={isFirstRunRequiredWarning || isLocked!}
               label="First Run Experiment"
             />
             {isFirstRunRequiredWarning && (
@@ -384,6 +397,7 @@ export const FormAudience = ({
                 value={populationPercent}
                 onChange={(e) => setPopulationPercent(e.target.value)}
                 data-testid="population-percent-slider"
+                disabled={isLocked!}
               />
               <Form.Control
                 aria-describedby="populationPercent-unit"
@@ -391,6 +405,7 @@ export const FormAudience = ({
                 value={populationPercent}
                 onChange={(e) => setPopulationPercent(e.target.value)}
                 data-testid="population-percent-text"
+                disabled={isLocked!}
               />
               <InputGroup.Append>
                 <InputGroup.Text id="populationPercent-unit">%</InputGroup.Text>
@@ -412,6 +427,7 @@ export const FormAudience = ({
                 "totalEnrolledClients",
                 POSITIVE_NUMBER_WITH_COMMAS_FIELD,
               )}
+              disabled={isLocked!}
             />
             <FormErrors name="totalEnrolledClients" />
           </Form.Group>
@@ -431,6 +447,7 @@ export const FormAudience = ({
                 type="number"
                 min="0"
                 aria-describedby="proposedEnrollment-unit"
+                disabled={isLocked!}
               />
               <InputGroup.Append>
                 <InputGroup.Text id="proposedEnrollment-unit">
@@ -463,6 +480,7 @@ export const FormAudience = ({
                 type="number"
                 min="0"
                 aria-describedby="proposedDuration-unit"
+                disabled={isLocked!}
               />
               <InputGroup.Append>
                 <InputGroup.Text id="proposedDuration-unit">
@@ -481,7 +499,7 @@ export const FormAudience = ({
             onClick={handleSaveNext}
             className="btn btn-secondary"
             id="save-and-continue-button"
-            disabled={isLoading}
+            disabled={isLoading || isLocked!}
             data-testid="next-button"
             data-sb-kind="pages/Summary"
           >
@@ -495,7 +513,7 @@ export const FormAudience = ({
             onClick={handleSave}
             className="btn btn-primary"
             id="save-button"
-            disabled={isLoading}
+            disabled={isLoading || isLocked!}
             data-sb-kind="pages/EditOverview"
           >
             <span>{isLoading ? "Saving" : "Save"}</span>


### PR DESCRIPTION
Because...

* We are going to reuse the Audience page to allow Live rollouts to be edited
* And we want to disable fields on the Audience page that we don't want to be edited

This commit...

* Checks whether each field on the Audience page should be locked
* Adds tests for disabled fields

<img width="1637" alt="image" src="https://user-images.githubusercontent.com/43795363/208777279-8ce9da47-b70f-463a-9d0c-7ab6a325639c.png">

vs

<img width="1674" alt="image" src="https://user-images.githubusercontent.com/43795363/208777644-f2dd933a-5541-4ec5-8c5d-8ee8741a6d7b.png">

