### PR TITLE
For #8107 feat(nimbus): add advanced targeting options for mobile behavioral targeting

### DIFF
--- a/app/experimenter/targeting/constants.py
+++ b/app/experimenter/targeting/constants.py
@@ -29,6 +29,8 @@ PROFILELESSTHAN28DAYS = "(currentDate|date - profileAgeCreated|date) / 86400000 
 PROFILEMORETHAN7DAYS = "(currentDate|date - profileAgeCreated|date) / 86400000 > 7"
 NEW_PROFILE = "(currentDate|date - profileAgeCreated|date) / 3600000 <= 24"
 WIN1903 = "os.windowsBuildNumber >= 18362"
+CORE_ACTIVE_USERS_TARGETING = "'{event}'|eventCountNonZero('Days', 28, 0) >= 21"
+RECENTLY_LOGGED_IN_USERS_TARGETING = "'{event}'|eventCountNonZero('Weeks', 12, 0) >= 1"
 
 NO_TARGETING = NimbusTargetingConfig(
     name="No Targeting",
@@ -866,6 +868,52 @@ TEST_STICKY_TARGETING = NimbusTargetingConfig(
     sticky_required=True,
     is_first_run_required=False,
     application_choice_names=[a.name for a in Application],
+)
+
+ANDROID_CORE_ACTIVE_USER = NimbusTargetingConfig(
+    name="Core Active Users",
+    slug="android_core_active_users",
+    description="Users who have been active at least 21 out of the last 28 days",
+    targeting=CORE_ACTIVE_USERS_TARGETING.format(event="events.app_opened"),
+    desktop_telemetry="",
+    sticky_required=True,
+    is_first_run_required=False,
+    application_choice_names=(Application.FENIX.name, Application.FOCUS_ANDROID.name),
+)
+
+IOS_CORE_ACTIVE_USER = NimbusTargetingConfig(
+    name="Core Active Users",
+    slug="ios_core_active_users",
+    description="Users who have been active at least 21 out of the last 28 days",
+    targeting=CORE_ACTIVE_USERS_TARGETING.format(event="app_cycle.foreground"),
+    desktop_telemetry="",
+    sticky_required=True,
+    is_first_run_required=False,
+    application_choice_names=(Application.IOS.name, Application.FOCUS_IOS.name),
+)
+
+ANDROID_RECENTLY_LOGGED_IN_USER = NimbusTargetingConfig(
+    name="Recently Logged In Users",
+    slug="android_recently_logged_in_users",
+    description="Users who have completed a Sync login within the last 12 weeks",
+    targeting=RECENTLY_LOGGED_IN_USERS_TARGETING.format(event="sync_auth.sign_in"),
+    desktop_telemetry="",
+    sticky_required=True,
+    is_first_run_required=False,
+    application_choice_names=(Application.FENIX.name, Application.FOCUS_ANDROID.name),
+)
+
+IOS_RECENTLY_LOGGED_IN_USER = NimbusTargetingConfig(
+    name="Recently Logged In Users",
+    slug="ios_recently_logged_in_users",
+    description="Users who have completed a Sync login within the last 12 weeks",
+    targeting=RECENTLY_LOGGED_IN_USERS_TARGETING.format(
+        event="sync.login_completed_view"
+    ),
+    desktop_telemetry="",
+    sticky_required=True,
+    is_first_run_required=False,
+    application_choice_names=(Application.IOS.name, Application.FOCUS_IOS.name),
 )
 
 

--- a/app/tests/integration/nimbus/conftest.py
+++ b/app/tests/integration/nimbus/conftest.py
@@ -141,7 +141,7 @@ def experiment_url(base_url, default_data, slugify):
 
 @pytest.fixture
 def experiment_name(request):
-    return f"{request.node.name[:75]}-{str(uuid.uuid4())[:4]}"
+    return f"{request.node.name[:75]}{str(uuid.uuid4())[:4]}"
 
 
 @pytest.fixture(name="load_experiment_outcomes")


### PR DESCRIPTION
Because...

    The behavioral event store now exists within Firefox iOS and Android

This commit...

    Adds advanced targeting options that leverage the events being recorded.

**A note:** We need two distinct targeting configs for each behavior, one for iOS and one for Android. These are required because the same event is named differently across the two apps. Something I noticed is Experimenter seems to be using the targeting config `slug` field split+capitalized for displaying the config, and I don't think we'd want "Android" and "Ios" showing up in the list. If we do, something worth noting is that "Ios" should be "iOS".

iOS set as the app
<img width="833" alt="image" src="https://user-images.githubusercontent.com/4909307/210440025-b098f24c-9dbd-40e1-bf27-f817a32a2be8.png">

Android set as the app
<img width="846" alt="image" src="https://user-images.githubusercontent.com/4909307/210440084-200ce92d-0ed4-42cf-a118-bf07056d8c13.png">
