### PR TITLE
fix #8130 feat(nimbus): Remove enrollment date to be cloned

### DIFF
--- a/app/experimenter/experiments/models.py
+++ b/app/experimenter/experiments/models.py
@@ -702,6 +702,7 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
         cloned.conclusion_recommendation = None
         cloned._start_date = None
         cloned._end_date = None
+        cloned._enrollment_end_date = None
         cloned.save()
 
         if rollout_branch_slug:

--- a/app/experimenter/experiments/tests/test_models.py
+++ b/app/experimenter/experiments/tests/test_models.py
@@ -1792,6 +1792,7 @@ class TestNimbusExperiment(TestCase):
         self.assertEqual(child.conclusion_recommendation, None)
         self.assertEqual(child._start_date, None)
         self.assertEqual(child._end_date, None)
+        self.assertEqual(child._enrollment_end_date, None)
 
         # Cloned fields
         self.assertEqual(child.name, "Child Experiment")


### PR DESCRIPTION
Because

* We recently added an` _enrollment_end_date `property to the NimbusExperiment model but neglected to exclude it from the clone method [here](https://github.com/mozilla/experimenter/blob/main/app/experimenter/experiments/models.py#L703-L704). 

This commit

* Set the` _enrollment_end_date = None `in the clone method and test case to support changes

fixes #8130 