### PR TITLE
For #8050 feat(nimbus): Add Audience page to sidebar

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/App/ExperimentRoot/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/App/ExperimentRoot/index.tsx
@@ -74,15 +74,17 @@ export const ExperimentRoot = ({
   // after experiment has been loaded
   const useRedirectCondition = (redirect: RedirectCondition) => {
     let redirectPath: string | undefined, redirectResult: string | void;
-    if (
-      !loading &&
-      status &&
-      (redirectResult = redirect!({ status, analysis })) != null
-    ) {
-      redirectResult = redirectResult.length
-        ? `/${redirectResult}`
-        : redirectResult;
-      redirectPath = `${BASE_PATH}/${slug}${redirectResult}`;
+    if (!experiment.isRollout) {
+      if (
+        !loading &&
+        status &&
+        (redirectResult = redirect!({ status, analysis })) != null
+      ) {
+        redirectResult = redirectResult.length
+          ? `/${redirectResult}`
+          : redirectResult;
+        redirectPath = `${BASE_PATH}/${slug}${redirectResult}`;
+      }
     }
 
     useEffect(() => {

--- a/app/experimenter/nimbus-ui/src/components/App/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/App/index.tsx
@@ -23,7 +23,12 @@ type RootProps = {
   children: React.ReactNode;
 } & RouteComponentProps;
 
+type SummaryRootProps = {
+  children: React.ReactNode;
+} & RouteComponentProps;
+
 const Root = (props: RootProps) => <>{props.children}</>;
+const SummaryRoot = (props: SummaryRootProps) => <>{props.children}</>;
 
 const App = () => {
   const { loading, error, refetch } = useQuery(GET_CONFIG_QUERY);
@@ -43,7 +48,11 @@ const App = () => {
         <PageHome path="/" />
         <PageNew path="new" />
         <ExperimentRoot path=":slug">
-          <PageSummary path="/" />
+          <SummaryRoot path="/">
+            <Redirect from="/" to="summary" noThrow />
+            <PageSummary path="summary" />
+            <PageEditAudience path="audience" />
+          </SummaryRoot>
           <Root path="edit">
             <Redirect from="/" to="overview" noThrow />
             <PageEditOverview path="overview" />

--- a/app/experimenter/nimbus-ui/src/components/AppLayoutSidebarLaunched/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/AppLayoutSidebarLaunched/index.test.tsx
@@ -191,5 +191,23 @@ describe("AppLayoutSidebarLaunched", () => {
         expect(screen.getByText(item)).toBeInTheDocument();
       });
     });
+
+    it("when rollout show audience page", async () => {
+      const { experiment } = mockExperimentQuery("demo-slug");
+      experiment.isRollout = true;
+      render(<Subject withAnalysis {...{ experiment }} />);
+
+      expect(screen.queryByText("Summary")).toBeInTheDocument();
+      expect(screen.queryByText("Audience")).toBeInTheDocument();
+    });
+
+    it("when experiment do not show audience page", () => {
+      const { experiment } = mockExperimentQuery("demo-slug");
+      experiment.isRollout = false;
+      render(<Subject withAnalysis {...{ experiment }} />);
+
+      expect(screen.queryByText("Summary")).toBeInTheDocument();
+      expect(screen.queryByText("Audience")).not.toBeInTheDocument();
+    });
   });
 });

--- a/app/experimenter/nimbus-ui/src/components/AppLayoutSidebarLaunched/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/AppLayoutSidebarLaunched/index.tsx
@@ -192,13 +192,12 @@ export const AppLayoutSidebarLaunched = ({
                 canReview={experiment.canReview}
               />
 
-              {experiment &&
+              {experiment.isRollout &&
                 editPages.map((page, idx) => (
                   <LinkNav
                     key={`sidebar-${page.name}-${idx}`}
                     route={`${slug}/${page.slug}`}
-                    testid={`nav-edit-${page.slug}`}
-                    disabled={!experiment.isRollout}
+                    testid={`nav-edit-audience`}
                   >
                     {page.icon}
                     {page.name}

--- a/app/experimenter/nimbus-ui/src/components/AppLayoutSidebarLaunched/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/AppLayoutSidebarLaunched/index.tsx
@@ -198,7 +198,7 @@ export const AppLayoutSidebarLaunched = ({
                     key={`sidebar-${page.name}-${idx}`}
                     route={`${slug}/${page.slug}`}
                     testid={`nav-edit-${page.slug}`}
-                    // disabled={!experiment.canEdit}
+                    disabled={!experiment.isRollout}
                   >
                     {page.icon}
                     {page.name}

--- a/app/experimenter/nimbus-ui/src/components/AppLayoutSidebarLaunched/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/AppLayoutSidebarLaunched/index.tsx
@@ -15,6 +15,7 @@ import { OutcomesList } from "../../lib/types";
 import { AnalysisData, MetadataPoint } from "../../lib/visualization/types";
 import { analysisAvailable } from "../../lib/visualization/utils";
 import { getExperiment_experimentBySlug } from "../../types/getExperiment";
+import { ReactComponent as Person } from "../AppLayoutWithSidebar/person.svg";
 import { DisabledItem } from "../DisabledItem";
 import LinkExternal from "../LinkExternal";
 import { LinkNav } from "../LinkNav";
@@ -25,6 +26,14 @@ import { ReactComponent as BarChart } from "./bar-chart.svg";
 export const RESULTS_LOADING_TEXT = "Checking results availability...";
 export const RESULTS_WAITING_FOR_LAUNCH_TEXT =
   "Waiting for experiment to launch";
+
+export const editPages = [
+  {
+    name: "Audience",
+    slug: "audience",
+    icon: <Person className="sidebar-icon" />,
+  },
+];
 
 const analysisLinkProps = {
   textColor: "inherit-color",
@@ -182,6 +191,19 @@ export const AppLayoutSidebarLaunched = ({
                 {...{ status, slug }}
                 canReview={experiment.canReview}
               />
+
+              {experiment &&
+                editPages.map((page, idx) => (
+                  <LinkNav
+                    key={`sidebar-${page.name}-${idx}`}
+                    route={`${slug}/${page.slug}`}
+                    testid={`nav-edit-${page.slug}`}
+                    // disabled={!experiment.canEdit}
+                  >
+                    {page.icon}
+                    {page.name}
+                  </LinkNav>
+                ))}
 
               {analysisAvailable(analysis) ? (
                 <ResultsAvailableNav />


### PR DESCRIPTION
📢 Requires #8087 and #8086 to be merged first

Because...
* We want to reuse the Audience page to allow users to edit rollouts while live

This commit...
* Adds the Audience page to the sidebar **for both rollouts and experiments**
* **Hides** the audience link for experiments, **enables** it for rollouts
* Because of #8096, the fields on the audience page are **disabled** 
   * we will enable them once we implement the ability to send the edits through review - #7823

---- 

Rollout with fully disabled audience page:
<img width="1792" alt="image" src="https://user-images.githubusercontent.com/43795363/211891701-c91d1745-4dbc-4f09-b668-b08baa602c0f.png">

Experiment with no audience link in sidebar: 
   
<img width="1507" alt="image" src="https://user-images.githubusercontent.com/43795363/212999545-616e580f-87de-4563-b8a0-09b95fa7c77f.png">

<img width="248" alt="image" src="https://user-images.githubusercontent.com/43795363/212999435-6cd25723-2b93-488e-8e67-b8a4d07c9b66.png">
