### PR TITLE
fix #8071 feat(nimbus): Project sql n+1 issue

### DIFF
--- a/app/experimenter/experiments/models.py
+++ b/app/experimenter/experiments/models.py
@@ -62,8 +62,7 @@ class NimbusExperimentManager(models.Manager):
 
     def with_owner_features(self):
         return self.get_queryset().prefetch_related(
-            "owner",
-            "feature_configs",
+            "owner", "feature_configs", "projects"
         )
 
     def launch_queue(self, applications):


### PR DESCRIPTION
Because

* Projects has many to many relationships with the experiments and we are seeing this error on [sentry](https://sentry.io/organizations/mozilla/performance/experimenter-prod:2cef3f53344e4c6fbc9650dc83f9193a/?project=6377199&query=transaction.duration%3A%3C15m&statsPeriod=24h&transaction=%2Fapi%2Fv5%2Fgraphql#span-af5a172ae0620a28) 

This commit

* Optimize the sql query 
* Before ⬇️ 
<img width="1172" alt="Screenshot 2023-01-11 at 2 54 14 PM" src="https://user-images.githubusercontent.com/104033388/211935800-c3622525-2335-4724-9d74-3d9376461400.png">
After changes 🌟 
<img width="1173" alt="Screenshot 2023-01-11 at 2 51 57 PM" src="https://user-images.githubusercontent.com/104033388/211935807-200d3ac1-8316-4fe1-aeaf-7e3b0b1a0dc6.png">

