### PR TITLE
fixes #8148 feat(nimbus): Change targeting from installed engines to …

### DIFF
--- a/app/experimenter/targeting/constants.py
+++ b/app/experimenter/targeting/constants.py
@@ -927,14 +927,14 @@ IOS_RECENTLY_LOGGED_IN_USER = NimbusTargetingConfig(
     application_choice_names=(Application.IOS.name, Application.FOCUS_IOS.name),
 )
 
-HAS_GOOGLE_BING_DDG_SEARCH_ENGINE = NimbusTargetingConfig(
-    name="Has Google, Bing, or DuckDuckGo search engine",
-    slug="has_search_engine_google_bing_or_ddg",
-    description="Users who have the Google, Bing, or DuckDuckGo search engines installed",
+HAS_GOOGLE_BING_DDG_AS_CURRENT_DEFAULT_SEARCH_ENGINE = NimbusTargetingConfig(
+    name="Has Google, Bing, or DuckDuckGo as current default search engine",
+    slug="has_google_bing_or_ddg_as_current_default_search_engine",
+    description="Users with Google, Bing, or DuckDuckGo as current default engine",
     targeting=(
-        "addonsInfo.addons['google@search.mozilla.org'] != null ||"
-        "addonsInfo.addons['bing@search.mozilla.org'] != null ||"
-        "addonsInfo.addons['ddg@search.mozilla.org'] != null"
+        "'google' in searchEngines.current ||"
+        "searchEngines.current == 'bing' ||"
+        "searchEngines.current == 'ddg'"
     ),
     desktop_telemetry="",
     sticky_required=False,


### PR DESCRIPTION
…current default engine

Because...

* The original implementation checked the client had Google, Bing, and DDG installed whereas the experiment wants to only apply to users with either of those search engines as the current default search engine.

This commit...

* Changes the targeting to default engines matching Google, Bing, and DDG.
* Google can have variety of names based off of telemetryId's hence the use of "in".
* Changes descriptors and variable name to match the behaviour.