### PR TITLE
fixes #8142 feat(nimbus): add new android 13 users targeting config and update test context

### DIFF
--- a/app/experimenter/targeting/constants.py
+++ b/app/experimenter/targeting/constants.py
@@ -942,6 +942,17 @@ HAS_GOOGLE_BING_DDG_AS_CURRENT_DEFAULT_SEARCH_ENGINE = NimbusTargetingConfig(
     application_choice_names=(Application.DESKTOP.name,),
 )
 
+NEW_ANDROID_13_USERS = NimbusTargetingConfig(
+    name="New Android 13 Users",
+    slug="new_android_13_users",
+    description="Users who have Android 13 and are on their first run of the application",
+    targeting="(android_sdk_version|versionCompare('33') >= 0) && is_first_run",
+    desktop_telemetry="",
+    sticky_required=True,
+    is_first_run_required=True,
+    application_choice_names=(Application.FENIX.name,),
+)
+
 
 class TargetingConstants:
     TARGETING_VERSION = "version|versionCompare('{version}') >= 0"

--- a/app/tests/integration/nimbus/test_mobile_targeting.py
+++ b/app/tests/integration/nimbus/test_mobile_targeting.py
@@ -78,6 +78,7 @@ def test_check_mobile_targeting(
             "days_since_update": 1,
             "days_since_install": 1,
             "isFirstRun": "true",
+            "is_first_run": True,
         }
     )
     client = sdk_client(load_app_context(context))


### PR DESCRIPTION
Because
    
- New targeting is needed for [this Android experiment](https://docs.google.com/document/d/1yPqTWGtJ8DPrlUoVqtX8AOtpMCoE7WGdb7R4l9BqYT4/edit#heading=h.j0lsegsodnsd)

This commit
   
- Adds the required targeting
- Adds a value to the test targeting context based on its [value in the Fenix repo](https://github.com/mozilla-mobile/fenix/blob/main/app/src/main/java/org/mozilla/fenix/gleanplumb/CustomAttributeProvider.kt#L36)