### PR TITLE
fix #8168 test(nimbus): Add better rerun capability to integration tests

### DIFF
--- a/app/tests/integration/nimbus/conftest.py
+++ b/app/tests/integration/nimbus/conftest.py
@@ -93,6 +93,7 @@ def firefox_options(firefox_options):
     firefox_options.log.level = "trace"
     return firefox_options
 
+
 @pytest.fixture
 def selenium(selenium, experiment_name, kinto_client, base_url, slugify):
     yield selenium
@@ -108,8 +109,6 @@ def selenium(selenium, experiment_name, kinto_client, base_url, slugify):
         summary.wait_for_complete_status()
     except Exception as e:
         raise e
-    else:
-        pass
 
 
 @pytest.fixture(

--- a/app/tests/integration/nimbus/conftest.py
+++ b/app/tests/integration/nimbus/conftest.py
@@ -107,8 +107,8 @@ def selenium(selenium, experiment_name, kinto_client, base_url, slugify):
         kinto_client.approve()
         summary = SummaryPage(selenium, urljoin(base_url, experiment_slug)).open()
         summary.wait_for_complete_status()
-    except Exception as e:
-        raise e
+    except Exception:
+        pass
 
 
 @pytest.fixture(

--- a/app/tests/integration/nimbus/conftest.py
+++ b/app/tests/integration/nimbus/conftest.py
@@ -93,6 +93,24 @@ def firefox_options(firefox_options):
     firefox_options.log.level = "trace"
     return firefox_options
 
+@pytest.fixture
+def selenium(selenium, experiment_name, kinto_client, base_url, slugify):
+    yield selenium
+
+    from nimbus.pages.experimenter.summary import SummaryPage
+
+    experiment_slug = str(slugify(experiment_name))
+    try:
+        summary = SummaryPage(selenium, urljoin(base_url, experiment_slug)).open()
+        summary.end_and_approve()
+        kinto_client.approve()
+        summary = SummaryPage(selenium, urljoin(base_url, experiment_slug)).open()
+        summary.wait_for_complete_status()
+    except Exception as e:
+        raise e
+    else:
+        pass
+
 
 @pytest.fixture(
     # Use all applications as available parameters in parallel_pytest_args.txt

--- a/app/tests/integration/tox.ini
+++ b/app/tests/integration/tox.ini
@@ -13,14 +13,14 @@ passenv = *
 recreate = true
 commands =
     pip install -r ../requirements.txt
-    pytest --verify-base-url --base-url https://nginx/nimbus/ --self-contained-html --reruns 1 --driver Firefox nimbus/ {posargs} -vvv
+    pytest --verify-base-url --base-url https://nginx/nimbus/ --self-contained-html --reruns 1 --reruns-delay 15 --driver Firefox nimbus/ {posargs} -vvv
 
 [testenv:integration-test-nimbus-rust]
 passenv = *
 recreate = true
 commands =
     pip install -r ../requirements.txt
-    pytest --verify-base-url --base-url https://nginx/nimbus/ --self-contained-html --reruns 1 --driver Firefox nimbus/test_mobile_targeting.py {posargs} -vvv
+    pytest --verify-base-url --base-url https://nginx/nimbus/ --self-contained-html --reruns 1 --reruns-delay 5 --driver Firefox nimbus/test_mobile_targeting.py {posargs} -vvv
 setenv =
     PYTHONPATH=/application-services/components/nimbus/src
 

--- a/app/tests/integration/tox.ini
+++ b/app/tests/integration/tox.ini
@@ -13,7 +13,7 @@ passenv = *
 recreate = true
 commands =
     pip install -r ../requirements.txt
-    pytest --verify-base-url --base-url https://nginx/nimbus/ --self-contained-html --reruns 1 --reruns-delay 15 --driver Firefox nimbus/ {posargs} -vvv
+    pytest --verify-base-url --base-url https://nginx/nimbus/ --self-contained-html --reruns 1 --reruns-delay 30 --driver Firefox nimbus/ {posargs} -vvv
 
 [testenv:integration-test-nimbus-rust]
 passenv = *


### PR DESCRIPTION
Because:
* We have implemented reruns with pytest-sentry to help track intermittent failures.

This commit:
* Adds a clean up step to each test run so that the remote settings server is clean before each test run.

This mainly has to do with the enrollment tests.