### PR TITLE
fix #8171 chore(nimbus): increase file upload size

### DIFF
--- a/app/experimenter/settings.py
+++ b/app/experimenter/settings.py
@@ -455,3 +455,6 @@ FEATURE_MANIFESTS_PATH = os.path.join(BASE_DIR, "features", "manifests")
 SKIP_REVIEW_ACCESS_CONTROL_FOR_DEV_USER = config(
     "SKIP_REVIEW_ACCESS_CONTROL_FOR_DEV_USER", default=False, cast=bool
 )
+
+# Required to save large experiments in the admin
+DATA_UPLOAD_MAX_MEMORY_SIZE = 20971520  # 20mb


### PR DESCRIPTION
Because

* Django defaults to a 2.5mb upload file size limit as a security precaution
* Saving a large experiment from the admin requires more than 2.5mb
* With the default setting, some experiments can not be edited from the admin

This commit

* Increases the max upload size to 20mb which should be sufficient to support editing experiments in the admin