### PR TITLE
fix #8198 chore(project): create dummy projects for integration tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ LOAD_COUNTRIES = python manage.py loaddata ./experimenter/base/fixtures/countrie
 LOAD_LOCALES = python manage.py loaddata ./experimenter/base/fixtures/locales.json
 LOAD_LANGUAGES = python manage.py loaddata ./experimenter/base/fixtures/languages.json
 LOAD_FEATURES = python manage.py load_feature_configs
-LOAD_DUMMY_EXPERIMENTS = [[ -z $$SKIP_DUMMY ]] && python manage.py load_dummy_experiments || echo "skipping dummy experiments"
+LOAD_DUMMY_EXPERIMENTS = [[ -z $$SKIP_DUMMY ]] && python manage.py load_dummy_experiments || python manage.py load_dummy_projects
 PYTHON_PATH_SDK = PYTHONPATH=/application-services/components/nimbus/src
 
 

--- a/app/experimenter/base/management/commands/load_dummy_projects.py
+++ b/app/experimenter/base/management/commands/load_dummy_projects.py
@@ -1,0 +1,15 @@
+import logging
+
+from django.core.management.base import BaseCommand
+
+from experimenter.projects.tests.factories import ProjectFactory
+
+logger = logging.getLogger()
+
+
+class Command(BaseCommand):
+    help = "Generates dummy project data"
+
+    def handle(self, *args, **options):
+        for _ in range(3):
+            ProjectFactory.create()

--- a/app/experimenter/base/tests/test_load_dummy_projects.py
+++ b/app/experimenter/base/tests/test_load_dummy_projects.py
@@ -1,0 +1,11 @@
+from django.core.management import call_command
+from django.test import TestCase
+
+from experimenter.projects.models import Project
+
+
+class TestInitialData(TestCase):
+    def test_load_dummy_projects(self):
+        self.assertFalse(Project.objects.exists())
+        call_command("load_dummy_projects")
+        self.assertEqual(Project.objects.all().count(), 3)


### PR DESCRIPTION
Because

* Nimbus now integrates with the Projects models
* We need to test these in the integration tests
* The integration tests skip creating dummy experiments which will then not create any projects

This commit

* Adds a new management command to create dummy projects when SKIP_DUMMY is true for the integration tests