### PR TITLE
fix #8209 bug(nimbus): prevent n+1 queries on get all experiments in v5 api

### DIFF
--- a/app/experimenter/experiments/api/v5/types.py
+++ b/app/experimenter/experiments/api/v5/types.py
@@ -450,6 +450,7 @@ class NimbusExperimentType(DjangoObjectType):
     locales = graphene.List(graphene.NonNull(NimbusLocaleType), required=True)
     monitoring_dashboard_url = graphene.String()
     name = graphene.String(required=True)
+    owner = graphene.Field(graphene.NonNull(NimbusUserType))
     parent = graphene.Field(lambda: NimbusExperimentType)
     population_percent = graphene.String()
     prevent_pref_conflicts = graphene.Boolean()


### PR DESCRIPTION


Because

* We recently updated to graphene 3.0
* This introduced an n+1 query regression in the get all experiments V5 API query

This commit

* Explicitly declares the owner field in the NimbusExperimentType
* For some reason this prevents the n+1 query issue