### PR TITLE
fix #8223 bug(nimbus): increase max number of fields setting

### DIFF
--- a/app/experimenter/settings.py
+++ b/app/experimenter/settings.py
@@ -472,3 +472,4 @@ SKIP_REVIEW_ACCESS_CONTROL_FOR_DEV_USER = config(
 
 # Required to save large experiments in the admin
 DATA_UPLOAD_MAX_MEMORY_SIZE = 20971520  # 20mb
+DATA_UPLOAD_MAX_NUMBER_FIELDS = 5000


### PR DESCRIPTION
Because

* Django places a limit on the number of fields that may be submitted in a POST request as a security precaution against DOS attacks
* Some experiments in the admin will have a large number of inlines from its changelog history
* In aggregate this can exceed the default number of allowed fields which is 1000

This commit

* Increases the maximum number of POST fields to 5000