### PR TITLE
For #7823 feat(nimbus): Handle approval/rejection for live rollout updates

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/PageEditAudience/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditAudience/index.tsx
@@ -86,7 +86,7 @@ const PageEditAudience: React.FunctionComponent<RouteComponentProps> = () => {
           setIsServerValid(true);
           setSubmitErrors({});
           // In practice this should be defined by the time we get here
-          refetch(); // do we need to refetch for live updates? 
+          refetch();
 
           if (next) {
             navigate("../");

--- a/app/experimenter/nimbus-ui/src/components/PageEditAudience/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditAudience/index.tsx
@@ -86,7 +86,7 @@ const PageEditAudience: React.FunctionComponent<RouteComponentProps> = () => {
           setIsServerValid(true);
           setSubmitErrors({});
           // In practice this should be defined by the time we get here
-          refetch();
+          refetch(); // do we need to refetch for live updates? 
 
           if (next) {
             navigate("../");

--- a/app/experimenter/nimbus-ui/src/components/PageSummary/FormUpdateLiveToReview.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageSummary/FormUpdateLiveToReview.tsx
@@ -6,7 +6,7 @@ import React from "react";
 import Alert from "react-bootstrap/Alert";
 import Form from "react-bootstrap/Form";
 
-const FormLaunchLiveToReview = ({
+const FormUpdateLiveToReview = ({
   isLoading,
   onSubmit,
   onCancel,
@@ -18,16 +18,16 @@ const FormLaunchLiveToReview = ({
   return (
     <Alert
       variant="secondary"
-      id="request-live-launch-alert"
-      data-testid="request-live-launch-alert"
+      id="request-live-update-alert"
+      data-testid="request-live-update-alert"
     >
       <Form className="text-body">
         <div className="d-flex bd-highlight">
           <div className="py-1">
             <p>Review and update live rollout:</p>
             <button
-              data-testid="launch-live-to-review"
-              id="request-launch-button"
+              data-testid="update-live-to-review"
+              id="request-update-button"
               type="button"
               className="mr-2 btn btn-primary"
               disabled={isLoading}
@@ -51,4 +51,4 @@ const FormLaunchLiveToReview = ({
   );
 };
 
-export default FormLaunchLiveToReview;
+export default FormUpdateLiveToReview;

--- a/app/experimenter/nimbus-ui/src/components/PageSummary/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageSummary/index.tsx
@@ -11,8 +11,8 @@ import ChangeApprovalOperations from "src/components/ChangeApprovalOperations";
 import Head from "src/components/Head";
 import FormLaunchDraftToPreview from "src/components/PageSummary/FormLaunchDraftToPreview";
 import FormLaunchDraftToReview from "src/components/PageSummary/FormLaunchDraftToReview";
-import FormLaunchLiveToReview from "src/components/PageSummary/FormLaunchLiveToReview";
 import FormLaunchPreviewToReview from "src/components/PageSummary/FormLaunchPreviewToReview";
+import FormUpdateLiveToReview from "src/components/PageSummary/FormUpdateLiveToReview";
 import Summary from "src/components/Summary";
 import SummaryTimeline from "src/components/Summary/SummaryTimeline";
 import { useChangeOperationMutation, useReviewCheck } from "src/hooks";
@@ -170,7 +170,6 @@ const PageSummary = (props: RouteComponentProps) => {
         ...LIFECYCLE_REVIEW_FLOWS.UPDATE,
       };
     }
-    
     // HACK: These values shouldn't end up being used, but it makes typechecking happy
     return {
       rejectChange: () => {},
@@ -278,7 +277,7 @@ const PageSummary = (props: RouteComponentProps) => {
         )}
 
         {status.live && status.dirty && (
-          <FormLaunchLiveToReview
+          <FormUpdateLiveToReview
             {...{
               isLoading,
               onSubmit: onUpdateClicked,

--- a/app/experimenter/nimbus-ui/src/components/PageSummary/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageSummary/index.tsx
@@ -53,6 +53,9 @@ const PageSummary = (props: RouteComponentProps) => {
       onEndReviewRejectedClicked,
       onPauseReviewApprovedClicked,
       onPauseReviewRejectedClicked,
+      onUpdateClicked,
+      onUpdateReviewApprovedClicked,
+      onUpdateReviewRejectedClicked,
     ],
   } = useChangeOperationMutation(
     experiment,
@@ -106,6 +109,23 @@ const PageSummary = (props: RouteComponentProps) => {
       isEnrollmentPaused: false,
       publishStatus: NimbusExperimentPublishStatusEnum.IDLE,
     },
+    {
+      status: NimbusExperimentStatusEnum.LIVE,
+      statusNext: NimbusExperimentStatusEnum.LIVE,
+      publishStatus: NimbusExperimentPublishStatusEnum.REVIEW,
+      changelogMessage: CHANGELOG_MESSAGES.REQUESTED_REVIEW_UPDATE,
+    },
+    {
+      status: NimbusExperimentStatusEnum.LIVE,
+      statusNext: NimbusExperimentStatusEnum.LIVE,
+      publishStatus: NimbusExperimentPublishStatusEnum.APPROVED,
+      changelogMessage: CHANGELOG_MESSAGES.REVIEW_APPROVED_UPDATE,
+    },
+    {
+      status: NimbusExperimentStatusEnum.LIVE,
+      statusNext: null,
+      publishStatus: NimbusExperimentPublishStatusEnum.DIRTY,
+    },
   );
 
   const {
@@ -143,7 +163,14 @@ const PageSummary = (props: RouteComponentProps) => {
         approveChange: onLaunchReviewApprovedClicked,
         ...LIFECYCLE_REVIEW_FLOWS.LAUNCH,
       };
+    } else if (status.updateRequested) {
+      return {
+        rejectChange: onUpdateReviewRejectedClicked,
+        approveChange: onUpdateReviewApprovedClicked,
+        ...LIFECYCLE_REVIEW_FLOWS.UPDATE,
+      };
     }
+    
     // HACK: These values shouldn't end up being used, but it makes typechecking happy
     return {
       rejectChange: () => {},
@@ -158,6 +185,8 @@ const PageSummary = (props: RouteComponentProps) => {
     onLaunchReviewRejectedClicked,
     onPauseReviewApprovedClicked,
     onPauseReviewRejectedClicked,
+    onUpdateReviewApprovedClicked,
+    onUpdateReviewRejectedClicked,
   ]);
 
   let launchDocs;
@@ -252,8 +281,8 @@ const PageSummary = (props: RouteComponentProps) => {
           <FormLaunchLiveToReview
             {...{
               isLoading,
-              onSubmit: onLaunchClicked,
-              onCancel: () => setShowLaunchToReview(false),
+              onSubmit: onUpdateClicked,
+              onCancel: onUpdateReviewRejectedClicked,
             }}
           />
         )}

--- a/app/experimenter/nimbus-ui/src/components/PageSummary/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageSummary/mocks.tsx
@@ -77,6 +77,13 @@ export const reviewRequestedBaseProps = {
   reviewRequest: mockChangelog(),
 };
 
+export const updateReviewRequestedBaseProps = {
+  status: NimbusExperimentStatusEnum.LIVE,
+  statusNext: NimbusExperimentStatusEnum.LIVE,
+  publishStatus: NimbusExperimentPublishStatusEnum.REVIEW,
+  reviewRequest: mockChangelog(),
+};
+
 export const reviewPendingBaseProps = {
   status: NimbusExperimentStatusEnum.DRAFT,
   statusNext: NimbusExperimentStatusEnum.LIVE,

--- a/app/experimenter/nimbus-ui/src/lib/constants.ts
+++ b/app/experimenter/nimbus-ui/src/lib/constants.ts
@@ -85,6 +85,12 @@ export const LIFECYCLE_REVIEW_FLOWS = {
     requestSummary: "Requested Launch",
     reviewSummary: "Review Launch Request",
   },
+  UPDATE: {
+    buttonTitle: "Update Rollout",
+    description: "update this rollout",
+    requestSummary: "Requested Update",
+    reviewSummary: "Review Update Request",
+  },
   PAUSE: {
     buttonTitle: "End Enrollment for Experiment",
     description: "end enrollment for this experiment",
@@ -115,6 +121,8 @@ export const CHANGELOG_MESSAGES = {
   RETURNED_TO_DRAFT: "Returned to Draft Status",
   REQUESTED_REVIEW: "Review Requested for Launch",
   REVIEW_APPROVED: "Launch Review Approved",
+  REQUESTED_REVIEW_UPDATE: "Review Requested for Update",
+  REVIEW_APPROVED_UPDATE: "Update Review Approved",
   REQUESTED_REVIEW_END_ENROLLMENT: "Requested Review to End Enrollment",
   END_ENROLLMENT_APPROVED: "End Enrollment Approved",
   REQUESTED_REVIEW_END: "Requested Review to End",

--- a/app/experimenter/nimbus-ui/src/lib/experiment.ts
+++ b/app/experimenter/nimbus-ui/src/lib/experiment.ts
@@ -47,6 +47,10 @@ export function getStatus(
     endRequested:
       status === NimbusExperimentStatusEnum.LIVE &&
       statusNext === NimbusExperimentStatusEnum.COMPLETE,
+    updateRequested:
+      status === NimbusExperimentStatusEnum.LIVE &&
+      publishStatus === NimbusExperimentPublishStatusEnum.REVIEW &&
+      statusNext === NimbusExperimentStatusEnum.LIVE,
     launched,
   };
 }


### PR DESCRIPTION
Because...

* We want to add the review flow for live rollout updates 

This commit...

* Adds callbacks for:
   * onUpdateClicked
   * onUpdateReviewApprovedClicked
   * onUpdateReviewRejectedClicked
* Defines rejection and approval for updates
* Renames things so all of the live rollout updates say "update" instead of "launch"
* Tests! --
   * handles approval of live update as expected
   * handles rejection of live update as expected
   * will not allow submitting live update if already in review