### PR TITLE
For #7823 feat(nimbus): Add dirty to update requests and rejection filters in models

### DIFF
--- a/app/experimenter/experiments/models.py
+++ b/app/experimenter/experiments/models.py
@@ -1021,13 +1021,19 @@ class NimbusChangeLogManager(models.Manager["NimbusChangeLog"]):
     def latest_review_request(self):
         return (
             self.all()
-            .filter(NimbusChangeLog.Filters.IS_REVIEW_REQUEST)
+            .filter(
+                NimbusChangeLog.Filters.IS_REVIEW_REQUEST
+                | NimbusChangeLog.Filters.IS_UPDATE_REVIEW_REQUEST
+            )
             .order_by("-changed_on")
         ).first()
 
     def latest_rejection(self):
         change = self.latest_change()
-        if change and change.has_filter(NimbusChangeLog.Filters.IS_REJECTION):
+        if change and change.has_filter(
+            NimbusChangeLog.Filters.IS_REJECTION
+            | NimbusChangeLog.Filters.IS_UPDATE_REJECTION
+        ):
             return change
 
     def latest_timeout(self):
@@ -1084,13 +1090,30 @@ class NimbusChangeLog(FilterMixin, models.Model):
             old_publish_status=NimbusExperiment.PublishStatus.IDLE,
             new_publish_status=NimbusExperiment.PublishStatus.REVIEW,
         )
+        IS_UPDATE_REVIEW_REQUEST = Q(
+            old_publish_status=NimbusExperiment.PublishStatus.DIRTY,
+            new_publish_status=NimbusExperiment.PublishStatus.REVIEW,
+        )
         IS_REJECTION = Q(
             Q(old_status=F("new_status")),
             old_publish_status__in=(
                 NimbusExperiment.PublishStatus.REVIEW,
                 NimbusExperiment.PublishStatus.WAITING,
             ),
-            new_publish_status=NimbusExperiment.PublishStatus.IDLE,
+            new_publish_status=(NimbusExperiment.PublishStatus.IDLE),
+            new_status__in=(
+                NimbusExperiment.Status.DRAFT,
+                NimbusExperiment.Status.LIVE,
+            ),
+            published_dto_changed=False,
+        )
+        IS_UPDATE_REJECTION = Q(
+            Q(old_status=F("new_status")),
+            old_publish_status__in=(
+                NimbusExperiment.PublishStatus.REVIEW,
+                NimbusExperiment.PublishStatus.WAITING,
+            ),
+            new_publish_status__in=(NimbusExperiment.PublishStatus.DIRTY,),
             published_dto_changed=False,
         )
         IS_TIMEOUT = Q(

--- a/app/experimenter/experiments/tests/api/v5/test_mutations.py
+++ b/app/experimenter/experiments/tests/api/v5/test_mutations.py
@@ -826,7 +826,8 @@ class TestUpdateExperimentMutationSingleFeature(
     def test_reject_ending_experiment(self):
         user_email = "user@example.com"
         experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperimentFactory.Lifecycles.ENDING_REVIEW_REQUESTED
+            NimbusExperimentFactory.Lifecycles.ENDING_REVIEW_REQUESTED,
+            is_rollout=False,
         )
         response = self.query(
             UPDATE_EXPERIMENT_MUTATION,
@@ -834,7 +835,8 @@ class TestUpdateExperimentMutationSingleFeature(
                 "input": {
                     "id": experiment.id,
                     "publishStatus": NimbusExperiment.PublishStatus.IDLE.name,
-                    "statusNext": NimbusExperiment.Status.COMPLETE.name,
+                    "statusNext": None,
+                    "status": NimbusExperiment.Status.LIVE.name,
                     "changelogMessage": "This is not good",
                 }
             },
@@ -847,7 +849,7 @@ class TestUpdateExperimentMutationSingleFeature(
 
         experiment = NimbusExperiment.objects.get(id=experiment.id)
         self.assertEqual(experiment.publish_status, NimbusExperiment.PublishStatus.IDLE)
-        self.assertEqual(experiment.status_next, NimbusExperiment.Status.COMPLETE)
+        self.assertEqual(experiment.status_next, None)
         rejection = experiment.changes.latest_rejection()
         self.assertEqual(rejection.changed_by.email, user_email)
         self.assertEqual(rejection.message, "This is not good")


### PR DESCRIPTION
Because...

* We want to be able to approve/reject update requests for live rollouts the same way we do for experiments

This commit...

* Updates the definition of `latest_review_request` to include update review requests
* Adds `PublishStatus.DIRTY` to the review rejection definition 
* Tests!
   * The test_mutations file has some checks for ending experiments/rejection, so I updated that too