### PR TITLE
fix #8242 chore(nimbus): use graphql types in usemutation

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/CloneDialog/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/CloneDialog/index.tsx
@@ -14,13 +14,15 @@ import { SlugTextControl } from "src/components/SlugTextControl";
 import { CLONE_EXPERIMENT_MUTATION } from "src/gql/experiments";
 import { useCommonForm } from "src/hooks";
 import { BASE_PATH, SUBMIT_ERROR } from "src/lib/constants";
-import { cloneExperiment_cloneExperiment } from "src/types/cloneExperiment";
+import {
+  cloneExperiment,
+  cloneExperimentVariables,
+} from "src/types/cloneExperiment";
 import {
   getExperiment_experimentBySlug,
   getExperiment_experimentBySlug_referenceBranch,
   getExperiment_experimentBySlug_treatmentBranches,
 } from "src/types/getExperiment";
-import { ExperimentCloneInput } from "src/types/globalTypes";
 
 // Relaxed type, since we only use these two properties
 export type RolloutBranch = Pick<
@@ -156,8 +158,8 @@ export const useCloneDialog = (
   const onCancel = () => setShowDialog(false);
 
   const [cloneExperiment] = useMutation<
-    { cloneExperiment: cloneExperiment_cloneExperiment },
-    { input: ExperimentCloneInput }
+    cloneExperiment,
+    cloneExperimentVariables
   >(CLONE_EXPERIMENT_MUTATION);
 
   const [isLoading, cloneSetIsLoading] = useState(false);

--- a/app/experimenter/nimbus-ui/src/components/PageEditAudience/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditAudience/index.tsx
@@ -11,8 +11,10 @@ import { UPDATE_EXPERIMENT_MUTATION } from "src/gql/experiments";
 import { CHANGELOG_MESSAGES, SUBMIT_ERROR } from "src/lib/constants";
 import { ExperimentContext } from "src/lib/contexts";
 import { editCommonRedirects } from "src/lib/experiment";
-import { ExperimentInput } from "src/types/globalTypes";
-import { updateExperiment_updateExperiment as UpdateExperimentAudienceResult } from "src/types/updateExperiment";
+import {
+  updateExperiment,
+  updateExperimentVariables,
+} from "src/types/updateExperiment";
 
 const PageEditAudience: React.FunctionComponent<RouteComponentProps> = () => {
   const { experiment, refetch, useRedirectCondition } =
@@ -20,8 +22,8 @@ const PageEditAudience: React.FunctionComponent<RouteComponentProps> = () => {
   useRedirectCondition(editCommonRedirects);
 
   const [updateExperimentAudience, { loading }] = useMutation<
-    { updateExperiment: UpdateExperimentAudienceResult },
-    { input: ExperimentInput }
+    updateExperiment,
+    updateExperimentVariables
   >(UPDATE_EXPERIMENT_MUTATION);
 
   const [submitErrors, setSubmitErrors] = useState<Record<string, any>>({});

--- a/app/experimenter/nimbus-ui/src/components/PageEditBranches/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditBranches/index.tsx
@@ -18,8 +18,10 @@ import {
 } from "src/lib/constants";
 import { ExperimentContext } from "src/lib/contexts";
 import { editCommonRedirects } from "src/lib/experiment";
-import { ExperimentInput } from "src/types/globalTypes";
-import { updateExperiment_updateExperiment as UpdateExperimentBranchesResult } from "src/types/updateExperiment";
+import {
+  updateExperiment,
+  updateExperimentVariables,
+} from "src/types/updateExperiment";
 
 const PageEditBranches: React.FunctionComponent<RouteComponentProps> = () => {
   const { allFeatureConfigs } = useConfig();
@@ -28,8 +30,8 @@ const PageEditBranches: React.FunctionComponent<RouteComponentProps> = () => {
   useRedirectCondition(editCommonRedirects);
 
   const [updateExperimentBranches, { loading }] = useMutation<
-    { updateExperiment: UpdateExperimentBranchesResult },
-    { input: ExperimentInput }
+    updateExperiment,
+    updateExperimentVariables
   >(UPDATE_EXPERIMENT_MUTATION);
 
   const applicationFeatureConfigs =

--- a/app/experimenter/nimbus-ui/src/components/PageEditMetrics/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditMetrics/index.tsx
@@ -16,8 +16,10 @@ import {
 } from "src/lib/constants";
 import { ExperimentContext } from "src/lib/contexts";
 import { editCommonRedirects } from "src/lib/experiment";
-import { ExperimentInput } from "src/types/globalTypes";
-import { updateExperiment_updateExperiment as UpdateExperimentOutcomesResult } from "src/types/updateExperiment";
+import {
+  updateExperiment,
+  updateExperimentVariables,
+} from "src/types/updateExperiment";
 
 const PageEditMetrics: React.FunctionComponent<RouteComponentProps> = () => {
   const { experiment, refetch, useRedirectCondition } =
@@ -25,8 +27,8 @@ const PageEditMetrics: React.FunctionComponent<RouteComponentProps> = () => {
   useRedirectCondition(editCommonRedirects);
 
   const [updateExperimentOutcomes, { loading }] = useMutation<
-    { updateExperiment: UpdateExperimentOutcomesResult },
-    { input: ExperimentInput }
+    updateExperiment,
+    updateExperimentVariables
   >(UPDATE_EXPERIMENT_MUTATION);
 
   const [submitErrors, setSubmitErrors] = useState<Record<string, any>>({});

--- a/app/experimenter/nimbus-ui/src/components/PageEditOverview/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditOverview/index.tsx
@@ -16,8 +16,10 @@ import {
 import { ExperimentContext } from "src/lib/contexts";
 import { editCommonRedirects } from "src/lib/experiment";
 import { optionalStringBool } from "src/lib/utils";
-import { ExperimentInput } from "src/types/globalTypes";
-import { updateExperiment_updateExperiment as UpdateExperimentOverviewResult } from "src/types/updateExperiment";
+import {
+  updateExperiment,
+  updateExperimentVariables,
+} from "src/types/updateExperiment";
 
 type PageEditOverviewProps = Record<string, any> & RouteComponentProps;
 
@@ -27,8 +29,8 @@ const PageEditOverview: React.FunctionComponent<PageEditOverviewProps> = () => {
   useRedirectCondition(editCommonRedirects);
 
   const [updateExperimentOverview, { loading }] = useMutation<
-    { updateExperiment: UpdateExperimentOverviewResult },
-    { input: ExperimentInput }
+    updateExperiment,
+    updateExperimentVariables
   >(UPDATE_EXPERIMENT_MUTATION);
 
   const [submitErrors, setSubmitErrors] = useState<Record<string, any>>({});

--- a/app/experimenter/nimbus-ui/src/components/PageNew/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageNew/index.tsx
@@ -17,15 +17,17 @@ import {
   SAVE_FAILED_NO_ERROR,
   SUBMIT_ERROR,
 } from "src/lib/constants";
-import { createExperiment_createExperiment as CreateExperimentResult } from "src/types/createExperiment";
-import { ExperimentInput } from "src/types/globalTypes";
+import {
+  createExperiment,
+  createExperimentVariables,
+} from "src/types/createExperiment";
 
 type PageNewProps = Record<string, any> & RouteComponentProps;
 
 const PageNew: React.FunctionComponent<PageNewProps> = () => {
   const [createExperiment, { loading }] = useMutation<
-    { createExperiment: CreateExperimentResult },
-    { input: ExperimentInput }
+    createExperiment,
+    createExperimentVariables
   >(CREATE_EXPERIMENT_MUTATION);
 
   const [submitErrors, setSubmitErrors] = useState<Record<string, any>>({});

--- a/app/experimenter/nimbus-ui/src/components/PageSummary/Takeaways/useTakeaways.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageSummary/Takeaways/useTakeaways.tsx
@@ -11,8 +11,10 @@ import {
   SUBMIT_ERROR,
 } from "src/lib/constants";
 import { getExperiment_experimentBySlug } from "src/types/getExperiment";
-import { ExperimentInput } from "src/types/globalTypes";
-import { updateExperiment_updateExperiment } from "src/types/updateExperiment";
+import {
+  updateExperiment,
+  updateExperimentVariables,
+} from "src/types/updateExperiment";
 
 // Params are a select subset of experiment properties
 export type UseTakeawaysExperimentSubset = Pick<
@@ -39,8 +41,8 @@ export const useTakeaways = (
   const [submitErrors, setSubmitErrors] = useState<Record<string, any>>({});
   const [isServerValid, setIsServerValid] = useState(true);
   const [updateExperiment] = useMutation<
-    { updateExperiment: updateExperiment_updateExperiment },
-    { input: ExperimentInput }
+    updateExperiment,
+    updateExperimentVariables
   >(UPDATE_EXPERIMENT_MUTATION);
 
   const onSubmit = useCallback(

--- a/app/experimenter/nimbus-ui/src/hooks/useChangeOperationMutation.tsx
+++ b/app/experimenter/nimbus-ui/src/hooks/useChangeOperationMutation.tsx
@@ -8,7 +8,10 @@ import { UPDATE_EXPERIMENT_MUTATION } from "src/gql/experiments";
 import { SUBMIT_ERROR } from "src/lib/constants";
 import { getExperiment_experimentBySlug as Experiment } from "src/types/getExperiment";
 import { ExperimentInput } from "src/types/globalTypes";
-import { updateExperiment_updateExperiment as UpdateExperiment } from "src/types/updateExperiment";
+import {
+  updateExperiment,
+  updateExperimentVariables,
+} from "src/types/updateExperiment";
 
 const CHANGE_MUTATION_DISPLAY_ERROR_FIELDS = ["status", "status_next"];
 
@@ -21,8 +24,8 @@ export function useChangeOperationMutation(
   const [isLoading, setIsLoading] = useState(false);
 
   const [updateExperiment] = useMutation<
-    { updateExperiment: UpdateExperiment },
-    { input: ExperimentInput }
+    updateExperiment,
+    updateExperimentVariables
   >(UPDATE_EXPERIMENT_MUTATION);
 
   const callbacks = useMemo(


### PR DESCRIPTION
Because

* GraphQL exposes auto generated types for mutation interfaces
* They were not being used by the useMutation hook
* This allows someone to change the interface of a mutation without failing any typechecks or tests

This commit

* Updates all the useMutation hooks to use the auto generated types