### PR TITLE
fix #8231 chore(nimbus): use ruff for python linting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,8 @@ JS_TEST_LEGACY = yarn workspace @experimenter/core test
 JS_TEST_NIMBUS_UI = DEBUG_PRINT_LIMIT=999999 CI=yes yarn workspace @experimenter/nimbus-ui test:cov
 NIMBUS_SCHEMA_CHECK = python manage.py graphql_schema --out experimenter/nimbus-ui/test_schema.graphql&&diff experimenter/nimbus-ui/test_schema.graphql experimenter/nimbus-ui/schema.graphql || (echo GraphQL Schema is out of sync please run make generate_types;exit 1)
 NIMBUS_TYPES_GENERATE = python manage.py graphql_schema --out experimenter/nimbus-ui/schema.graphql&&yarn workspace @experimenter/nimbus-ui generate-types
-FLAKE8 = flake8 .
+RUFF_CHECK = ruff experimenter/
+RUFF_FIX = ruff --fix experimenter/
 BLACK_CHECK = black -l 90 --check --diff . --exclude node_modules
 BLACK_FIX = black -l 90 . --exclude node_modules
 CHECK_DOCS = python manage.py generate_docs --check=true
@@ -122,7 +123,7 @@ kill: compose_stop compose_rm volumes_rm
 	echo "All containers removed!"
 
 check: build_test
-	$(COMPOSE_TEST) run app sh -c '$(WAIT_FOR_DB) (${PARALLEL} "$(NIMBUS_SCHEMA_CHECK)" "$(PYTHON_CHECK_MIGRATIONS)" "$(CHECK_DOCS)" "${PY_IMPORT_CHECK}" "$(BLACK_CHECK)" "$(FLAKE8)" "$(ESLINT_LEGACY)" "$(ESLINT_NIMBUS_UI)" "$(TYPECHECK_NIMBUS_UI)" "$(PYTHON_TYPECHECK)" "$(PYTHON_TEST)" "$(JS_TEST_LEGACY)" "$(JS_TEST_NIMBUS_UI)" "$(JS_TEST_REPORTING)") ${COLOR_CHECK}'
+	$(COMPOSE_TEST) run app sh -c '$(WAIT_FOR_DB) (${PARALLEL} "$(NIMBUS_SCHEMA_CHECK)" "$(PYTHON_CHECK_MIGRATIONS)" "$(CHECK_DOCS)" "${PY_IMPORT_CHECK}" "$(BLACK_CHECK)" "$(RUFF_CHECK)" "$(ESLINT_LEGACY)" "$(ESLINT_NIMBUS_UI)" "$(TYPECHECK_NIMBUS_UI)" "$(PYTHON_TYPECHECK)" "$(PYTHON_TEST)" "$(JS_TEST_LEGACY)" "$(JS_TEST_NIMBUS_UI)" "$(JS_TEST_REPORTING)") ${COLOR_CHECK}'
 
 pytest: build_test
 	$(COMPOSE_TEST) run app sh -c '$(WAIT_FOR_DB) $(PYTHON_TEST)'
@@ -155,7 +156,7 @@ generate_types: build_dev
 	$(COMPOSE) run app sh -c "$(NIMBUS_TYPES_GENERATE)"
 
 code_format: build_dev
-	$(COMPOSE) run app sh -c '${PARALLEL} "${PY_IMPORT_SORT};$(BLACK_FIX)" "$(ESLINT_FIX_CORE)" "$(ESLINT_FIX_NIMBUS_UI)"'
+	$(COMPOSE) run app sh -c '${PARALLEL} "${PY_IMPORT_SORT};$(RUFF_FIX);$(BLACK_FIX)" "$(ESLINT_FIX_CORE)" "$(ESLINT_FIX_NIMBUS_UI)"'
 
 makemigrations: build_dev
 	$(COMPOSE) run app python manage.py makemigrations

--- a/app/.flake8
+++ b/app/.flake8
@@ -1,4 +1,0 @@
-[flake8]
-exclude=migrations,settings*,.tox,node_modules,legacy
-max-line-length = 90
-ignore = E203, W503, FS002, FS003, E741

--- a/app/experimenter/base/tests/test_base.py
+++ b/app/experimenter/base/tests/test_base.py
@@ -14,43 +14,40 @@ class TestAppVersion(TestCase):
     def test_app_version_file(self):
         expected_version = "8675309"
         version_json = f'{{"commit": "{expected_version}"}}'
-        with self.settings(APP_VERSION=None):
-            with mock.patch(
-                "experimenter.base.open",
-                mock.mock_open(read_data=version_json),
-            ) as mf:
-                version = app_version()
-                self.assertEqual(version, expected_version)
+        with self.settings(APP_VERSION=None), mock.patch(
+            "experimenter.base.open",
+            mock.mock_open(read_data=version_json),
+        ) as mf:
+            version = app_version()
+            self.assertEqual(version, expected_version)
 
-                version_again = app_version()
-                self.assertEqual(version_again, expected_version)
+            version_again = app_version()
+            self.assertEqual(version_again, expected_version)
 
-                mf.assert_called_once_with(settings.APP_VERSION_JSON_PATH)
+            mf.assert_called_once_with(settings.APP_VERSION_JSON_PATH)
 
     def test_app_version_env_over_file(self):
         expected_version = "thx1138"
         version_json = '{"commit": "INCORRECT"}'
 
-        with self.settings(APP_VERSION=expected_version):
-            with mock.patch(
-                "experimenter.base.open",
-                mock.mock_open(read_data=version_json),
-            ) as mf:
-                version = app_version()
-                mf.assert_not_called()
-                self.assertEqual(version, expected_version)
+        with self.settings(APP_VERSION=expected_version), mock.patch(
+            "experimenter.base.open",
+            mock.mock_open(read_data=version_json),
+        ) as mf:
+            version = app_version()
+            mf.assert_not_called()
+            self.assertEqual(version, expected_version)
 
     def test_app_version_file_error(self):
         version_json = '{"commit": "INCORRECT"}'
-        with self.settings(APP_VERSION=None):
-            with mock.patch(
-                "builtins.open",
-                mock.mock_open(read_data=version_json),
-            ) as mf:
-                mf.side_effect = IOError()
-                version = app_version()
-                mf.assert_called_once_with(settings.APP_VERSION_JSON_PATH)
-                self.assertEqual(version, "")
+        with self.settings(APP_VERSION=None), mock.patch(
+            "builtins.open",
+            mock.mock_open(read_data=version_json),
+        ) as mf:
+            mf.side_effect = IOError()
+            version = app_version()
+            mf.assert_called_once_with(settings.APP_VERSION_JSON_PATH)
+            self.assertEqual(version, "")
 
 
 class TestGetUploadsStorage(TestCase):

--- a/app/experimenter/base/tests/test_docs.py
+++ b/app/experimenter/base/tests/test_docs.py
@@ -29,9 +29,6 @@ class TestDocs(TestCase):
         with mock.patch(
             "experimenter.base.management.commands.generate_docs.open",
             mock.mock_open(read_data="{}"),
-        ):
-            with self.assertRaises(ValueError) as cm:
-                call_command("generate_docs", "--check=true")
-                self.assertIn(
-                    "Api Schemas have changed and have not been updated", cm.value
-                )
+        ), self.assertRaises(ValueError) as cm:
+            call_command("generate_docs", "--check=true")
+            self.assertIn("Api Schemas have changed and have not been updated", cm.value)

--- a/app/experimenter/experiments/api/v5/mutations.py
+++ b/app/experimenter/experiments/api/v5/mutations.py
@@ -43,7 +43,7 @@ class CreateExperiment(graphene.Mutation):
         input = ExperimentInput(required=True)
 
     @classmethod
-    def mutate(cls, root, info, input: ExperimentInput):
+    def mutate(cls, root, info, input: ExperimentInput):  # noqa: A002
         if "reference_branch" in input and input["reference_branch"] is None:
             input.pop("reference_branch")
 
@@ -61,7 +61,7 @@ class UpdateExperiment(graphene.Mutation):
         input = ExperimentInput(required=True)
 
     @classmethod
-    def mutate(cls, root, info, input: ExperimentInput):
+    def mutate(cls, root, info, input: ExperimentInput):  # noqa: A002
         experiment = NimbusExperiment.objects.get(id=input.id)
 
         if "reference_branch" in input and input["reference_branch"] is None:
@@ -87,7 +87,7 @@ class CloneExperiment(graphene.Mutation):
         input = ExperimentCloneInput(required=True)
 
     @classmethod
-    def mutate(cls, root, info, input: ExperimentInput):
+    def mutate(cls, root, info, input: ExperimentInput):  # noqa: A002
         serializer = NimbusExperimentCloneSerializer(
             data=input, context={"user": info.context.user}
         )

--- a/app/experimenter/experiments/api/v6/serializers.py
+++ b/app/experimenter/experiments/api/v6/serializers.py
@@ -1,3 +1,4 @@
+import contextlib
 import json
 
 from django.conf import settings
@@ -51,12 +52,11 @@ class NimbusBranchSerializerSingleFeature(serializers.ModelSerializer):
                     fv for fv in feature_values if fv.feature_config == feature_config
                 ][0]
                 feature_enabled = branch_feature_value.enabled
-                try:
-                    feature_value = json.loads(branch_feature_value.value)
-                except json.JSONDecodeError:
+
+                with contextlib.suppress(json.JSONDecodeError):
                     # feature_value may be invalid JSON while the experiment is
                     # still being drafted
-                    pass
+                    feature_value = json.loads(branch_feature_value.value)
 
         return {
             "featureId": feature_config_slug,
@@ -80,11 +80,11 @@ class NimbusBranchSerializerMultiFeature(serializers.ModelSerializer):
                 "enabled": fv.enabled,
                 "value": {},
             }
-            try:
-                feature_value["value"] = json.loads(fv.value)
-            except Exception:
+
+            with contextlib.suppress(Exception):
                 # The value may still be invalid at this time
-                pass
+                feature_value["value"] = json.loads(fv.value)
+
             features.append(feature_value)
         return features
 

--- a/app/experimenter/experiments/tests/api/v5/test_queries.py
+++ b/app/experimenter/experiments/tests/api/v5/test_queries.py
@@ -2072,7 +2072,7 @@ class TestNimbusConfigQuery(GraphQLTestCase):
             ]
             self.assertEqual(
                 set(channels),
-                {channel.name for channel in application_config.channel_app_id.keys()},
+                {channel.name for channel in application_config.channel_app_id},
             )
 
         self.assertEqual(

--- a/app/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_configuration_serializer.py
+++ b/app/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_configuration_serializer.py
@@ -54,7 +54,7 @@ class TestNimbusConfigurationSerializer(TestCase):
             ]
             self.assertEqual(
                 set(channels),
-                {channel.name for channel in application_config.channel_app_id.keys()},
+                {channel.name for channel in application_config.channel_app_id},
             )
 
         self.assertEqual(config["owners"], [{"username": experiment.owner.username}])

--- a/app/experimenter/features/__init__.py
+++ b/app/experimenter/features/__init__.py
@@ -107,7 +107,7 @@ class Features:
                     application_data = yaml.load(
                         application_yaml_file.read(), Loader=yaml.Loader
                     )
-                    for feature_slug in application_data.keys():
+                    for feature_slug in application_data:
                         feature_data = application_data[feature_slug]
                         feature_data["slug"] = feature_slug
                         feature_data["applicationSlug"] = application.slug

--- a/app/experimenter/jetstream/models.py
+++ b/app/experimenter/jetstream/models.py
@@ -241,7 +241,7 @@ class ResultsObjectModelBase(BaseModel):
                 comparison_data.all.append(data_point)
 
     def append_conversion_count(self, primary_metrics_set):
-        for branch_name in self.dict().keys():
+        for branch_name in self.dict():
             branch = getattr(self, branch_name)
             branch_data = branch.branch_data
             for primary_metric in primary_metrics_set:

--- a/app/experimenter/kinto/client.py
+++ b/app/experimenter/kinto/client.py
@@ -57,9 +57,9 @@ class KintoClient:
         )
         self._patch_collection()
 
-    def delete_record(self, id):
+    def delete_record(self, record_id):
         self.kinto_http_client.delete_record(
-            id=id,
+            id=record_id,
             collection=self.collection,
             bucket=settings.KINTO_BUCKET_WORKSPACE,
         )

--- a/app/experimenter/outcomes/__init__.py
+++ b/app/experimenter/outcomes/__init__.py
@@ -64,7 +64,7 @@ class Outcomes:
                                             "description"
                                         ),
                                     )
-                                    for metric in outcome_data["metrics"].keys()
+                                    for metric in outcome_data["metrics"]
                                 ],
                             )
                         )

--- a/app/experimenter/settings.py
+++ b/app/experimenter/settings.py
@@ -355,7 +355,9 @@ CELERY_BEAT_SCHEDULE = {
         "schedule": config("CELERY_SCHEDULE_INTERVAL", default=300, cast=int),
     },
     "nimbus_synchronize_preview_experiments_in_kinto": {
-        "task": "experimenter.kinto.tasks.nimbus_synchronize_preview_experiments_in_kinto",
+        "task": (
+            "experimenter.kinto.tasks.nimbus_synchronize_preview_experiments_in_kinto"
+        ),
         "schedule": config("CELERY_SCHEDULE_INTERVAL", default=300, cast=int),
     },
     "nimbus_send_emails": {

--- a/app/poetry.lock
+++ b/app/poetry.lock
@@ -824,57 +824,6 @@ files = [
 python-dateutil = ">=2.4"
 
 [[package]]
-name = "flake8"
-version = "6.0.0"
-description = "the modular source code checker: pep8 pyflakes and co"
-category = "main"
-optional = false
-python-versions = ">=3.8.1"
-files = [
-    {file = "flake8-6.0.0-py2.py3-none-any.whl", hash = "sha256:3833794e27ff64ea4e9cf5d410082a8b97ff1a06c16aa3d2027339cd0f1195c7"},
-    {file = "flake8-6.0.0.tar.gz", hash = "sha256:c61007e76655af75e6785a931f452915b371dc48f56efd765247c8fe68f2b181"},
-]
-
-[package.dependencies]
-mccabe = ">=0.7.0,<0.8.0"
-pycodestyle = ">=2.10.0,<2.11.0"
-pyflakes = ">=3.0.0,<3.1.0"
-
-[[package]]
-name = "flake8-comprehensions"
-version = "3.10.1"
-description = "A flake8 plugin to help you write better list/set/dict comprehensions."
-category = "main"
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "flake8-comprehensions-3.10.1.tar.gz", hash = "sha256:412052ac4a947f36b891143430fef4859705af11b2572fbb689f90d372cf26ab"},
-    {file = "flake8_comprehensions-3.10.1-py3-none-any.whl", hash = "sha256:d763de3c74bc18a79c039a7ec732e0a1985b0c79309ceb51e56401ad0a2cd44e"},
-]
-
-[package.dependencies]
-flake8 = ">=3.0,<3.2.0 || >3.2.0"
-
-[[package]]
-name = "flake8-use-fstring"
-version = "1.4"
-description = "Flake8 plugin for string formatting style."
-category = "main"
-optional = false
-python-versions = ">=3.6"
-files = [
-    {file = "flake8-use-fstring-1.4.tar.gz", hash = "sha256:6550bf722585eb97dffa8343b0f1c372101f5c4ab5b07ebf0edd1c79880cdd39"},
-]
-
-[package.dependencies]
-flake8 = ">=3"
-
-[package.extras]
-ci = ["coverage (>=4.0.0,<5.0.0)", "coveralls", "flake8-builtins", "flake8-commas", "flake8-fixme", "flake8-print", "flake8-quotes", "flake8-todo", "pytest (>=4)", "pytest-cov (>=2)"]
-dev = ["coverage (>=4.0.0,<5.0.0)", "flake8-builtins", "flake8-commas", "flake8-fixme", "flake8-print", "flake8-quotes", "flake8-todo", "pytest (>=4)", "pytest-cov (>=2)"]
-test = ["coverage (>=4.0.0,<5.0.0)", "flake8-builtins", "flake8-commas", "flake8-fixme", "flake8-print", "flake8-quotes", "flake8-todo", "pytest (>=4)", "pytest-cov (>=2)"]
-
-[[package]]
 name = "future"
 version = "0.18.3"
 description = "Clean single-source support for Python 3 and 2"
@@ -1454,18 +1403,6 @@ files = [
 traitlets = "*"
 
 [[package]]
-name = "mccabe"
-version = "0.7.0"
-description = "McCabe checker, plugin for flake8"
-category = "main"
-optional = false
-python-versions = ">=3.6"
-files = [
-    {file = "mccabe-0.7.0-py2.py3-none-any.whl", hash = "sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e"},
-    {file = "mccabe-0.7.0.tar.gz", hash = "sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325"},
-]
-
-[[package]]
 name = "mock"
 version = "4.0.3"
 description = "Rolling backport of unittest.mock for all Pythons"
@@ -1921,18 +1858,6 @@ files = [
 pyasn1 = ">=0.4.6,<0.5.0"
 
 [[package]]
-name = "pycodestyle"
-version = "2.10.0"
-description = "Python style guide checker"
-category = "main"
-optional = false
-python-versions = ">=3.6"
-files = [
-    {file = "pycodestyle-2.10.0-py2.py3-none-any.whl", hash = "sha256:8a4eaf0d0495c7395bdab3589ac2db602797d76207242c17d470186815706610"},
-    {file = "pycodestyle-2.10.0.tar.gz", hash = "sha256:347187bdb476329d98f695c213d7295a846d1152ff4fe9bacb8a9590b8ee7053"},
-]
-
-[[package]]
 name = "pydantic"
 version = "1.10.4"
 description = "Data validation and settings management using python type hints"
@@ -1984,18 +1909,6 @@ typing-extensions = ">=4.2.0"
 [package.extras]
 dotenv = ["python-dotenv (>=0.10.4)"]
 email = ["email-validator (>=1.0.3)"]
-
-[[package]]
-name = "pyflakes"
-version = "3.0.1"
-description = "passive checker of Python programs"
-category = "main"
-optional = false
-python-versions = ">=3.6"
-files = [
-    {file = "pyflakes-3.0.1-py2.py3-none-any.whl", hash = "sha256:ec55bf7fe21fff7f1ad2f7da62363d749e2a470500eab1b555334b67aa1ef8cf"},
-    {file = "pyflakes-3.0.1.tar.gz", hash = "sha256:ec8b276a6b60bd80defed25add7e439881c19e64850afd9b346283d4165fd0fd"},
-]
 
 [[package]]
 name = "pygments"
@@ -2485,6 +2398,32 @@ files = [
 pyasn1 = ">=0.1.3"
 
 [[package]]
+name = "ruff"
+version = "0.0.239"
+description = "An extremely fast Python linter, written in Rust."
+category = "main"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "ruff-0.0.239-py3-none-macosx_10_7_x86_64.whl", hash = "sha256:de9830cfcca81c5d25233bf4be6f2f95deb58a7eaf2295f91280de97a54240d7"},
+    {file = "ruff-0.0.239-py3-none-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl", hash = "sha256:71c05f627fb9efb0859af248fe00f61391266d14e9406c10236dec7db1b1bfe5"},
+    {file = "ruff-0.0.239-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3b1caea095c22067abc685b8452be5a9079ca27b88bffd80730f9e4ca8f81e7c"},
+    {file = "ruff-0.0.239-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:97293bae6da5bd82672473f6d43421de7dd27fe8a8b1b3c79ffeda37bcb492b4"},
+    {file = "ruff-0.0.239-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:25c3a84f8db9281385685041e98b67afd4a0bb5a872e897331af8229eb28b965"},
+    {file = "ruff-0.0.239-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:0056b7e1975a3ad7ef7eb9df4ca9f905661caf924c6843ecbe4e10719cd6cd0b"},
+    {file = "ruff-0.0.239-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b38916c62eb2587743d2ec8e1f03a43eb5889cf4a56cb55f5eb3bffee5260e32"},
+    {file = "ruff-0.0.239-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7afe3bc50339b916b75a587ed299859fae9c1056ed73d35531c0af610dbe67f6"},
+    {file = "ruff-0.0.239-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:daac673996ecbef77bccf8cd03189c60302568b7aec669e352aa2d8925b074b2"},
+    {file = "ruff-0.0.239-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:d3e4bb03333b0c8012ad7d27246a7a95dba3d6ec8796c172af055a179a86b61c"},
+    {file = "ruff-0.0.239-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:801a209887f777811caf9fd4513eec9b505e139d1b0844e1eacd1b4683b0eba2"},
+    {file = "ruff-0.0.239-py3-none-musllinux_1_2_i686.whl", hash = "sha256:216592db3bd93c260cc329d3237548f17fea1f43f87673ab5cdeb04d548fbea9"},
+    {file = "ruff-0.0.239-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:1e523edf92c5e888d93a145ef20ad548fca4da7cbd7a8321b3539967a03b7caf"},
+    {file = "ruff-0.0.239-py3-none-win32.whl", hash = "sha256:e54233e7d97d5b705582f673dc3184c7b16c42f7eac3be707c0adf716e457293"},
+    {file = "ruff-0.0.239-py3-none-win_amd64.whl", hash = "sha256:a1bdd3b5ea60b160d3ceb2f8fef4d88af58b7932d4ed46c85c586ef2f277b71d"},
+    {file = "ruff-0.0.239.tar.gz", hash = "sha256:bbb1fe64d4641ce7e5855bbebd9e81f6a596501bcb67842600186b3aa9b950cf"},
+]
+
+[[package]]
 name = "sentry-sdk"
 version = "1.9.0"
 description = "Python client for Sentry (https://sentry.io)"
@@ -2851,4 +2790,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "5941b045dfd06a5586a64b1bf49fcceed8d61d1c06a3bd7aaafe50eee47de1b4"
+content-hash = "bd11cbef156c462daf73637a3451c8b8a82add94c807e4540ce8c05e22cc280c"

--- a/app/pyproject.toml
+++ b/app/pyproject.toml
@@ -63,12 +63,10 @@ mozilla-nimbus-shared = "^1.10.0"
 django-import-export = "^2.9.0"
 sentry-sdk = "^1.9.0"
 djangorestframework-dataclasses = "^1.2.0"
-flake8 = "^6.0.0"
-flake8-comprehensions = "^3.10.1"
 graphene-django = "^3.0.0"
-flake8-use-fstring = "^1.4"
 pyright = "^1.1.291"
 django-types = "^0.16.0"
+ruff = "^0.0.239"
 
 [tool.poetry.dev-dependencies]
 rope = "^0.23.0"
@@ -118,3 +116,33 @@ reportUntypedBaseClass = false
 reportUntypedClassDecorator = true
 reportUntypedFunctionDecorator = false
 reportUnusedCallResult = false
+
+[tool.ruff]
+# # Enable Pyflakes `E` and `F` codes by default.
+select = ["F", "E", "W", "I", "N", "YTT", "A", "C4", "RET", "SIM"]
+ignore = [
+    # "A002",
+    "A003",
+    "E402",
+    "E741",
+    "F403",
+    "N802",
+    "N803",
+    "N806",
+    "N815",
+    "RET503",
+    "RET504",
+    "RET505",
+    "SIM102",
+]
+
+# Exclude a variety of commonly ignored directories.
+exclude = [
+    "migrations",
+    ".tox",
+    "node_modules",
+    "legacy",
+]
+
+# Same as Black.
+line-length = 90


### PR DESCRIPTION
Because

* There is a fancy new linter for Python called ruff
* It has many built in rules from other popular Python linters
* It also applies code fixes for some rules so you get some fancy autoformatting features
* It's also very fast

This commit

* Removes flake8
* Adds ruff
* Enables many of the builtin ruff rules
* Applies ruff fixes