### PR TITLE
For #7823 feat(nimbus): Add population percent and dirty to constants

### DIFF
--- a/app/experimenter/experiments/api/v5/serializers.py
+++ b/app/experimenter/experiments/api/v5/serializers.py
@@ -86,7 +86,9 @@ class TransitionConstants:
             NimbusExperiment.PublishStatus.IDLE,
         ],
         "experiments": [],
-        "rollouts": [],
+        "rollouts": [
+            NimbusExperiment.PublishStatus.DIRTY,
+        ],
     }
 
     STATUS_UPDATE_EXEMPT_FIELDS = {
@@ -99,7 +101,7 @@ class TransitionConstants:
             "conclusion_recommendation",
         ],
         "experiments": [],
-        "rollouts": [],
+        "rollouts": ["population_percent"],
     }
 
 


### PR DESCRIPTION
Because...

* We want to allow updates to dirty states and allow editing for population percent for live rollouts

This commit...

* updates the serializer constants to reflect that