### PR TITLE
For #7823 feat(nimbus): Update publish status on live update

### DIFF
--- a/app/experimenter/experiments/api/v5/serializers.py
+++ b/app/experimenter/experiments/api/v5/serializers.py
@@ -1030,6 +1030,19 @@ class NimbusExperimentSerializer(
         return data
 
     def update(self, experiment, validated_data):
+        if (
+            experiment.is_rollout
+            and not experiment.is_paused
+            and experiment.status == NimbusExperiment.Status.LIVE
+            and experiment.status_next is None
+            and experiment.publish_status == NimbusExperiment.PublishStatus.IDLE
+            and validated_data.get("publish_status")
+            != NimbusConstants.PublishStatus.REVIEW
+        ):
+            # can be Live Update (Dirty), End Enrollment, or End Experiment
+            # if we don't check validated_data["publish_status"]
+            validated_data["publish_status"] = NimbusConstants.PublishStatus.DIRTY
+
         self.changelog_message = validated_data.pop("changelog_message")
         return super().update(experiment, validated_data)
 

--- a/app/experimenter/experiments/tests/api/v5/test_mutations.py
+++ b/app/experimenter/experiments/tests/api/v5/test_mutations.py
@@ -433,7 +433,7 @@ class TestUpdateExperimentMutationSingleFeature(
         experiment = NimbusExperiment.objects.get(id=experiment_id)
         self.assertTrue(experiment.is_rollout)
         self.assertEqual(experiment.population_percent, 50.0)
-        self.assertEqual(experiment.publish_status, NimbusConstants.PublishStatus.IDLE)
+        self.assertEqual(experiment.publish_status, NimbusConstants.PublishStatus.DIRTY)
         self.assertEqual(experiment.status, NimbusConstants.Status.LIVE)
         self.assertEqual(experiment.status_next, None)
 
@@ -458,6 +458,10 @@ class TestUpdateExperimentMutationSingleFeature(
             headers={settings.OPENIDC_EMAIL_HEADER: user_email},
         )
         self.assertEqual(response.status_code, 200)
+        content = json.loads(response.content)
+        result = content["data"]["updateExperiment"]
+
+        self.assertEqual(result["message"].keys(), {"experiment"})
 
         content = json.loads(response.content)
         result = content["data"]["updateExperiment"]

--- a/app/experimenter/nimbus-ui/src/components/ChangeApprovalOperations/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/ChangeApprovalOperations/index.test.tsx
@@ -145,6 +145,42 @@ describe("ChangeApprovalOperations", () => {
     expect(openRemoteSettingsButton).toHaveProperty("href", REVIEW_URL);
   });
 
+  it("when user can review for live updates, supports approval and opening remote settings", async () => {
+    const approveChange = jest.fn();
+    render(
+      <Subject
+        {...{
+          ...reviewRequestedBaseProps,
+          canReview: true,
+          approveChange,
+          status: {
+            ...getStatus(MOCK_LIVE_ROLLOUT),
+            draft: false,
+            dirty: true,
+            live: true,
+          },
+        }}
+      />,
+    );
+
+    const reviewAlertTitle = await screen.findByTestId("review-request-alert");
+    await waitFor(() => {
+      expect(reviewAlertTitle).toBeInTheDocument();
+    });
+
+    const approveButton = await screen.findByTestId("approve-request");
+    fireEvent.click(approveButton);
+
+    await waitFor(() => {
+      expect(approveChange).toHaveBeenCalled();
+    });
+
+    const openRemoteSettingsButton = await screen.findByTestId(
+      "open-remote-settings",
+    );
+    expect(openRemoteSettingsButton).toHaveProperty("href", REVIEW_URL);
+  });
+
   it("when user cannot review, an approval pending notice is displayed", async () => {
     Object.assign(navigator, {
       clipboard: {

--- a/app/experimenter/nimbus-ui/src/components/LinkNavSummary/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/LinkNavSummary/index.test.tsx
@@ -10,6 +10,7 @@ import {
 import { render, screen } from "@testing-library/react";
 import React from "react";
 import LinkNavSummary from "src/components/LinkNavSummary";
+import { LIFECYCLE_REVIEW_FLOWS } from "src/lib/constants";
 import { mockGetStatus } from "src/lib/mocks";
 import {
   NimbusExperimentPublishStatusEnum,
@@ -24,6 +25,7 @@ type SubjectProps = {
   canReview?: boolean;
   showSummaryAction?: boolean;
   isArchived?: boolean;
+  isRollout?: boolean;
 };
 
 const Subject = ({
@@ -34,6 +36,7 @@ const Subject = ({
   showSummaryAction = true,
   canReview = false,
   isArchived = false,
+  isRollout = false,
 }: SubjectProps) => {
   // Create a LocationProvider context since LinkNav uses `useLocation()`
   // to detect current page
@@ -122,14 +125,32 @@ describe("LinkNavSummary", () => {
       expect(screen.queryByText("Review End Request")).toBeInTheDocument();
     });
 
-    it("renders 'Review Launch Request' when expected", () => {
+    it("renders review launch request title when expected", () => {
       render(
         <Subject
+          status={NimbusExperimentStatusEnum.DRAFT}
           publishStatus={NimbusExperimentPublishStatusEnum.REVIEW}
           canReview
         />,
       );
-      expect(screen.queryByText("Review Launch Request")).toBeInTheDocument();
+      expect(
+        screen.queryByText(LIFECYCLE_REVIEW_FLOWS.LAUNCH.reviewSummary),
+      ).toBeInTheDocument();
+    });
+
+    it("renders update launch request title when expected", () => {
+      render(
+        <Subject
+          status={NimbusExperimentStatusEnum.LIVE}
+          statusNext={NimbusExperimentStatusEnum.LIVE}
+          publishStatus={NimbusExperimentPublishStatusEnum.REVIEW}
+          canReview
+          isRollout={true}
+        />,
+      );
+      expect(
+        screen.queryByText(LIFECYCLE_REVIEW_FLOWS.UPDATE.reviewSummary),
+      ).toBeInTheDocument();
     });
 
     it("renders 'Review End Enrollment Request' when expected", () => {

--- a/app/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/index.test.tsx
@@ -176,6 +176,7 @@ describe("FormAudience", () => {
 
     expect(screen.getByTestId("isSticky")).not.toBeChecked();
   });
+
   it("expect sticky enrollment to be selected as sticky is required for the selected targeting", async () => {
     render(
       <Subject

--- a/app/experimenter/nimbus-ui/src/components/PageEditAudience/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditAudience/index.test.tsx
@@ -33,6 +33,11 @@ let rolloutMutationMock: ReturnType<
   typeof mockUpdateExperimentAudienceMutation
 >;
 
+let mockDirtyRolloutSubmitData: Partial<ExperimentInput>;
+let dirtyRolloutMutationMock: ReturnType<
+  typeof mockUpdateExperimentAudienceMutation
+>;
+
 describe("PageEditAudience", () => {
   beforeAll(() => {
     fetchMock.enableMocks();
@@ -45,6 +50,9 @@ describe("PageEditAudience", () => {
 
   beforeEach(() => {
     mockSubmitData = { ...MOCK_FORM_DATA };
+    mockRolloutSubmitData = { ...MOCK_ROLLOUT_FORM_DATA };
+    mockDirtyRolloutSubmitData = { ...MOCK_DIRTY_ROLLOUT_FORM_DATA };
+
     mutationMock = mockUpdateExperimentAudienceMutation(
       {
         ...mockSubmitData,
@@ -57,6 +65,15 @@ describe("PageEditAudience", () => {
     rolloutMutationMock = mockUpdateExperimentAudienceMutation(
       {
         ...mockRolloutSubmitData,
+        id: rollout.id,
+        changelogMessage: CHANGELOG_MESSAGES.UPDATED_AUDIENCE,
+      },
+      {},
+    );
+
+    dirtyRolloutMutationMock = mockUpdateExperimentAudienceMutation(
+      {
+        ...mockDirtyRolloutSubmitData,
         id: rollout.id,
         changelogMessage: CHANGELOG_MESSAGES.UPDATED_AUDIENCE,
       },
@@ -161,6 +178,22 @@ const MOCK_ROLLOUT_FORM_DATA = {
   firefoxMaxVersion: NimbusExperimentFirefoxVersionEnum.FIREFOX_95,
   targetingConfigSlug: "FIRST_RUN",
   populationPercent: "40",
+  totalEnrolledClients: 68000,
+  proposedEnrollment: "7",
+  proposedDuration: "28",
+  countries: ["1"],
+  locales: ["1"],
+  languages: ["1"],
+  isSticky: true,
+  isFirstRun: true,
+};
+
+const MOCK_DIRTY_ROLLOUT_FORM_DATA = {
+  channel: NimbusExperimentChannelEnum.NIGHTLY,
+  firefoxMinVersion: NimbusExperimentFirefoxVersionEnum.FIREFOX_83,
+  firefoxMaxVersion: NimbusExperimentFirefoxVersionEnum.FIREFOX_95,
+  targetingConfigSlug: "FIRST_RUN",
+  populationPercent: "60",
   totalEnrolledClients: 68000,
   proposedEnrollment: "7",
   proposedDuration: "28",

--- a/app/experimenter/nimbus-ui/src/components/PageEditAudience/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditAudience/index.tsx
@@ -48,6 +48,7 @@ const PageEditAudience: React.FunctionComponent<RouteComponentProps> = () => {
       }: Record<string, any>,
       next: boolean,
     ) => {
+      
       try {
         // issue #3954: Need to parse string IDs into numbers
         const nimbusExperimentId = experiment.id;

--- a/app/experimenter/nimbus-ui/src/components/PageSummary/FormUpdateLiveToReview.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageSummary/FormUpdateLiveToReview.tsx
@@ -9,11 +9,11 @@ import Form from "react-bootstrap/Form";
 const FormUpdateLiveToReview = ({
   isLoading,
   onSubmit,
-  onCancel,
+  onRevert,
 }: {
   isLoading: boolean;
   onSubmit: () => void;
-  onCancel: () => void;
+  onRevert: () => void;
 }) => {
   return (
     <Alert
@@ -36,13 +36,13 @@ const FormUpdateLiveToReview = ({
               Request Update
             </button>
             <button
-              data-testid="cancel"
+              data-testid="revert"
               type="button"
               className="btn btn-secondary"
-              disabled={isLoading}
-              onClick={onCancel}
+              disabled={true}
+              onClick={onRevert}
             >
-              Cancel
+              Revert update
             </button>
           </div>
         </div>

--- a/app/experimenter/nimbus-ui/src/components/PageSummary/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageSummary/index.tsx
@@ -55,7 +55,7 @@ const PageSummary = (props: RouteComponentProps) => {
       onPauseReviewRejectedClicked,
       onUpdateClicked,
       onUpdateReviewApprovedClicked,
-      onUpdateReviewRejectedClicked,
+      onUpdateRevertedClicked,
     ],
   } = useChangeOperationMutation(
     experiment,
@@ -163,9 +163,15 @@ const PageSummary = (props: RouteComponentProps) => {
         approveChange: onLaunchReviewApprovedClicked,
         ...LIFECYCLE_REVIEW_FLOWS.LAUNCH,
       };
+    } else if (status.dirty) {
+      return {
+        rejectChange: onUpdateRevertedClicked,
+        approveChange: onUpdateReviewApprovedClicked,
+        ...LIFECYCLE_REVIEW_FLOWS.UPDATE,
+      };
     } else if (status.updateRequested) {
       return {
-        rejectChange: onUpdateReviewRejectedClicked,
+        rejectChange: onUpdateRevertedClicked,
         approveChange: onUpdateReviewApprovedClicked,
         ...LIFECYCLE_REVIEW_FLOWS.UPDATE,
       };
@@ -185,7 +191,7 @@ const PageSummary = (props: RouteComponentProps) => {
     onPauseReviewApprovedClicked,
     onPauseReviewRejectedClicked,
     onUpdateReviewApprovedClicked,
-    onUpdateReviewRejectedClicked,
+    onUpdateRevertedClicked,
   ]);
 
   let launchDocs;
@@ -221,7 +227,7 @@ const PageSummary = (props: RouteComponentProps) => {
       )}
 
       {summaryAction && (
-        <h5 className="mt-3 mb-4 ml-3">
+        <h5 className="mt-3 mb-4 ml-3" data-testid="summary-action-title">
           {summaryAction} {launchDocs}
         </h5>
       )}
@@ -281,7 +287,7 @@ const PageSummary = (props: RouteComponentProps) => {
             {...{
               isLoading,
               onSubmit: onUpdateClicked,
-              onCancel: onUpdateReviewRejectedClicked,
+              onRevert: onUpdateRevertedClicked,
             }}
           />
         )}

--- a/app/experimenter/nimbus-ui/src/components/Summary/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/index.test.tsx
@@ -5,7 +5,11 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import React from "react";
 import { createMutationMock, Subject } from "src/components/Summary/mocks";
-import { CHANGELOG_MESSAGES, SUBMIT_ERROR } from "src/lib/constants";
+import {
+  CHANGELOG_MESSAGES,
+  LIFECYCLE_REVIEW_FLOWS,
+  SUBMIT_ERROR,
+} from "src/lib/constants";
 import { mockExperimentQuery } from "src/lib/mocks";
 import {
   NimbusExperimentPublishStatusEnum,
@@ -100,6 +104,23 @@ describe("Summary", () => {
     expect(screen.queryByText("End Experiment")).not.toBeInTheDocument();
     expect(
       screen.queryByText("End Enrollment for Experiment"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("does not renders the update button if the experiment is live and not dirty", async () => {
+    render(
+      <Subject
+        props={{
+          status: NimbusExperimentStatusEnum.LIVE,
+          publishStatus: NimbusExperimentPublishStatusEnum.IDLE,
+        }}
+      />,
+    );
+    expect(
+      screen.queryByText(LIFECYCLE_REVIEW_FLOWS.UPDATE.reviewSummary),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(LIFECYCLE_REVIEW_FLOWS.UPDATE.buttonTitle),
     ).not.toBeInTheDocument();
   });
 

--- a/app/experimenter/nimbus-ui/src/lib/experiment.ts
+++ b/app/experimenter/nimbus-ui/src/lib/experiment.ts
@@ -72,20 +72,25 @@ export function getSummaryAction(
   status: StatusCheck,
   canReview: boolean | null,
 ) {
+  const stringName = !canReview ? "requestSummary" : "reviewSummary";
   // has pending review approval
   if (status.review || status.approved || status.waiting) {
-    const stringName = !canReview ? "requestSummary" : "reviewSummary";
     if (status.pauseRequested) {
       return LIFECYCLE_REVIEW_FLOWS.PAUSE[stringName];
     }
     if (status.endRequested) {
       return LIFECYCLE_REVIEW_FLOWS.END[stringName];
+    }
+    if (status.dirty || status.updateRequested) {
+      return LIFECYCLE_REVIEW_FLOWS.UPDATE[stringName];
     } else {
       return LIFECYCLE_REVIEW_FLOWS.LAUNCH[stringName];
     }
+  } else if (status.dirty) {
+    return LIFECYCLE_REVIEW_FLOWS.UPDATE[stringName];
   }
 
-  if (!status.launched && !status.archived) {
+  if (!status.launched && !status.archived && !status.live) {
     return "Request Launch";
   }
   return "";


### PR DESCRIPTION

⭐ **For testing...** ⭐ 

Since this PR doesn't enable the population fields for editing, you can cherry-pick [this commit](https://github.com/mozilla/experimenter/commit/f788820d022187978385584d1bb7d9753b42b10f) for local testing


----

This commit...

* Updates publish status to `DIRTY` when a live update is made to a rollout
* Navigates to the summary page instead of `../` for live saves
* Adds lots of tests for the review workflow
   * test_mutations
   * ChangeApprovalOperations/index.test.tsx
   * LinkNavSummary/index.test.tsx
   * PageEditAudience/index.test.tsx
   * PageSummary/index.test.tsx
   * Summary/index.test.tsx
* Adds some mock infrastructure so testing live/dirty rollouts is easier in these files

This commit _does not_...

* Enable the population percent field or the save/save & continue buttons on the audience page (#8239)
* Add functionality for the cancel buttons (#TBD)

--- 

https://user-images.githubusercontent.com/43795363/216703509-b7c0f474-b43f-4cf5-a3a0-6286a783fa91.mov

https://user-images.githubusercontent.com/43795363/216703597-a20f353d-d7a9-41d9-85f0-d74f59f18839.mov

<img width="616" alt="image" src="https://user-images.githubusercontent.com/43795363/217669929-ef333afb-231e-4ba7-b252-dc1dd728910c.png">
<img width="389" alt="image" src="https://user-images.githubusercontent.com/43795363/217343882-279b6b9d-7835-4de4-8044-eccc565e722b.png">

<img width="362" alt="image" src="https://user-images.githubusercontent.com/43795363/217343922-6cea4d95-4f73-411a-a38d-73a53edd99d4.png">
