### PR TITLE
fix #8240 feat(nimbus): Fix none branch

### DIFF
--- a/app/experimenter/experiments/api/v5/serializers.py
+++ b/app/experimenter/experiments/api/v5/serializers.py
@@ -1394,8 +1394,8 @@ class NimbusReviewSerializer(serializers.ModelSerializer):
         treatment_branches_errors = []
         treatment_branches_warnings = []
         for branch_data in data["treatment_branches"]:
-            branch_error = None
-            branch_warning = None
+            branch_error = {}
+            branch_warning = {}
 
             if branch_data.get("feature_enabled", False):
                 if errors := self._validate_feature_value_against_schema(


### PR DESCRIPTION
Because

* We are getting this error https://github.com/mozilla/experimenter/issues/8240, The main issue was that from the backend we initiated the warning and errors as `None`, which leads to null in the frontend. 
* The warning needs an object inside so that we also maintain the warning no. as to which treatment branch it is referring to. for example, if we have warning in treatment branch b, then we need something like that 0-{}, 1-{"warning in treatment branch b"}  so that we can show the warning appropriately too.

This commit

* Instead of null/None returns an empty object
before fix screenshot
<img width="539" alt="Screenshot 2023-02-03 at 3 10 08 PM" src="https://user-images.githubusercontent.com/25848231/216727974-1a1b044a-d20a-4b48-85f2-aa38867ce377.png">

After fix 
<img width="539" alt="Screenshot 2023-02-03 at 3 10 17 PM" src="https://user-images.githubusercontent.com/25848231/216727972-7e9d5d14-b0f5-40b7-8464-12773470b87d.png">
