### PR TITLE
fix #8261 feat(nimbus): add timezone to analysis timestamp

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/PageResults/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/index.test.tsx
@@ -99,7 +99,7 @@ describe("PageResults", () => {
       screen.getByText(
         new Date(MOCK_METADATA_WITH_CONFIG.analysis_start_time).toLocaleString(
           undefined,
-          { timeZone: "UTC", timeZoneName:"short" },
+          { timeZone: "UTC", timeZoneName: "short" },
         ),
       ),
     );

--- a/app/experimenter/nimbus-ui/src/components/PageResults/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/index.test.tsx
@@ -99,7 +99,7 @@ describe("PageResults", () => {
       screen.getByText(
         new Date(MOCK_METADATA_WITH_CONFIG.analysis_start_time).toLocaleString(
           undefined,
-          { timeZone: "UTC" },
+          { timeZone: "UTC", timeZoneName:"short" },
         ),
       ),
     );

--- a/app/experimenter/nimbus-ui/src/components/PageResults/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/index.tsx
@@ -221,7 +221,7 @@ const PageResults: React.FunctionComponent<RouteComponentProps> = () => {
             <b>
               {new Date(analysis?.metadata?.analysis_start_time).toLocaleString(
                 undefined,
-                { timeZone: "UTC", timeZoneName:"short" },
+                { timeZone: "UTC", timeZoneName: "short" },
               )}
             </b>
           </p>

--- a/app/experimenter/nimbus-ui/src/components/PageResults/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/index.tsx
@@ -221,7 +221,7 @@ const PageResults: React.FunctionComponent<RouteComponentProps> = () => {
             <b>
               {new Date(analysis?.metadata?.analysis_start_time).toLocaleString(
                 undefined,
-                { timeZone: "UTC" },
+                { timeZone: "UTC", timeZoneName:"short" },
               )}
             </b>
           </p>


### PR DESCRIPTION
Because

* we show the analysis timestamp without a timezone

This commit

* adds the timezone to remove ambiguity

![image](https://user-images.githubusercontent.com/102263964/217292531-3d9885c4-e782-4f94-bc2f-6851c44cfa6d.png)