### PR TITLE
fix #8270 bug(project): use last working remote settings tag

### DIFF
--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -59,7 +59,7 @@ services:
       - "6379:6379"
 
   kinto:
-    image: mozilla/remote-settings:latest
+    image: mozilla/remote-settings:30.1.1
     environment:
       KINTO_INI: /etc/kinto.ini
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -86,7 +86,7 @@ services:
       - "6379:6379"
 
   kinto:
-    image: mozilla/remote-settings:latest
+    image: mozilla/remote-settings:30.1.1
     environment:
       KINTO_INI: /etc/kinto.ini
     ports:


### PR DESCRIPTION
Because

* The latest dockerhub image for remote settings is breaking and won't start

This commit

* Hard codes the last working remote settings tag 30.1.1