### PR TITLE
Revert fix #8270 bug(project): use last working remote settings tag (#8271)

### DIFF
--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -59,7 +59,7 @@ services:
       - "6379:6379"
 
   kinto:
-    image: mozilla/remote-settings:30.1.1
+    image: mozilla/remote-settings:latest
     environment:
       KINTO_INI: /etc/kinto.ini
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -86,7 +86,7 @@ services:
       - "6379:6379"
 
   kinto:
-    image: mozilla/remote-settings:30.1.1
+    image: mozilla/remote-settings:latest
     environment:
       KINTO_INI: /etc/kinto.ini
     ports:


### PR DESCRIPTION


Because

* Remote settings latest tag is now functioning correctly

This commit

* Reverts fixing remote settings to the last known good tag