### PR TITLE
fix #8275 bug(project): remove kinto_mailer

### DIFF
--- a/kinto/server.ini
+++ b/kinto/server.ini
@@ -14,7 +14,6 @@ kinto.includes = kinto.plugins.admin
                  kinto.plugins.accounts
                  kinto.plugins.history
                  kinto.plugins.flush
-                 kinto_emailer
                  kinto_attachment
                  kinto_remote_settings
 


### PR DESCRIPTION
Because

* The remote settings team recently pushed a new docker image
* It's having trouble starting on local dev, but not ci for some reason
* It's complaining about the mailer component
* We don't use the mailer component for local dev or ci
* It seems to start okay without it

This commit

* Removes the kinto_mailer component from kinto.ini