### PR TITLE
Revert Revert fix #8270 bug(project): use last working remote settings tag (#8271) (#8274)

### DIFF
--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -59,7 +59,7 @@ services:
       - "6379:6379"
 
   kinto:
-    image: mozilla/remote-settings:latest
+    image: mozilla/remote-settings:30.1.1
     environment:
       KINTO_INI: /etc/kinto.ini
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -86,7 +86,7 @@ services:
       - "6379:6379"
 
   kinto:
-    image: mozilla/remote-settings:latest
+    image: mozilla/remote-settings:30.1.1
     environment:
       KINTO_INI: /etc/kinto.ini
     ports:


### PR DESCRIPTION


Because

* Remote settings is having a bad day
* It's still not starting properly

This commit

* Goes back to 30.1.1