### PR TITLE
fix #8259 chore(nimbus): use ruff for integration tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,8 +16,6 @@ RED = \033[0;31m
 GREEN = \033[0;32m
 PAD = -------------------------------------------------\n
 COLOR_CHECK = && echo "${GREEN}${PAD}All Checks Passed\n${PAD}${NOCOLOR}" || (echo "${RED}${PAD}Some Checks Failed\n${PAD}${NOCOLOR}";exit 1)
-PY_IMPORT_SORT =  python -m isort . --profile black
-PY_IMPORT_CHECK =  python -m isort . --profile black --check
 PYTHON_TEST = pytest --cov --cov-report term-missing
 PYTHON_TYPECHECK = pyright experimenter/
 PYTHON_CHECK_MIGRATIONS = python manage.py makemigrations --check --dry-run --noinput
@@ -32,8 +30,8 @@ JS_TEST_LEGACY = yarn workspace @experimenter/core test
 JS_TEST_NIMBUS_UI = DEBUG_PRINT_LIMIT=999999 CI=yes yarn workspace @experimenter/nimbus-ui test:cov
 NIMBUS_SCHEMA_CHECK = python manage.py graphql_schema --out experimenter/nimbus-ui/test_schema.graphql&&diff experimenter/nimbus-ui/test_schema.graphql experimenter/nimbus-ui/schema.graphql || (echo GraphQL Schema is out of sync please run make generate_types;exit 1)
 NIMBUS_TYPES_GENERATE = python manage.py graphql_schema --out experimenter/nimbus-ui/schema.graphql&&yarn workspace @experimenter/nimbus-ui generate-types
-RUFF_CHECK = ruff experimenter/
-RUFF_FIX = ruff --fix experimenter/
+RUFF_CHECK = ruff experimenter/ tests/
+RUFF_FIX = ruff --fix experimenter/ tests/
 BLACK_CHECK = black -l 90 --check --diff . --exclude node_modules
 BLACK_FIX = black -l 90 . --exclude node_modules
 CHECK_DOCS = python manage.py generate_docs --check=true
@@ -123,7 +121,7 @@ kill: compose_stop compose_rm volumes_rm
 	echo "All containers removed!"
 
 check: build_test
-	$(COMPOSE_TEST) run app sh -c '$(WAIT_FOR_DB) (${PARALLEL} "$(NIMBUS_SCHEMA_CHECK)" "$(PYTHON_CHECK_MIGRATIONS)" "$(CHECK_DOCS)" "${PY_IMPORT_CHECK}" "$(BLACK_CHECK)" "$(RUFF_CHECK)" "$(ESLINT_LEGACY)" "$(ESLINT_NIMBUS_UI)" "$(TYPECHECK_NIMBUS_UI)" "$(PYTHON_TYPECHECK)" "$(PYTHON_TEST)" "$(JS_TEST_LEGACY)" "$(JS_TEST_NIMBUS_UI)" "$(JS_TEST_REPORTING)") ${COLOR_CHECK}'
+	$(COMPOSE_TEST) run app sh -c '$(WAIT_FOR_DB) (${PARALLEL} "$(NIMBUS_SCHEMA_CHECK)" "$(PYTHON_CHECK_MIGRATIONS)" "$(CHECK_DOCS)" "$(BLACK_CHECK)" "$(RUFF_CHECK)" "$(ESLINT_LEGACY)" "$(ESLINT_NIMBUS_UI)" "$(TYPECHECK_NIMBUS_UI)" "$(PYTHON_TYPECHECK)" "$(PYTHON_TEST)" "$(JS_TEST_LEGACY)" "$(JS_TEST_NIMBUS_UI)" "$(JS_TEST_REPORTING)") ${COLOR_CHECK}'
 
 pytest: build_test
 	$(COMPOSE_TEST) run app sh -c '$(WAIT_FOR_DB) $(PYTHON_TEST)'
@@ -156,7 +154,7 @@ generate_types: build_dev
 	$(COMPOSE) run app sh -c "$(NIMBUS_TYPES_GENERATE)"
 
 code_format: build_dev
-	$(COMPOSE) run app sh -c '${PARALLEL} "${PY_IMPORT_SORT};$(RUFF_FIX);$(BLACK_FIX)" "$(ESLINT_FIX_CORE)" "$(ESLINT_FIX_NIMBUS_UI)"'
+	$(COMPOSE) run app sh -c '${PARALLEL} "$(RUFF_FIX);$(BLACK_FIX)" "$(ESLINT_FIX_CORE)" "$(ESLINT_FIX_NIMBUS_UI)"'
 
 makemigrations: build_dev
 	$(COMPOSE) run app python manage.py makemigrations

--- a/app/poetry.lock
+++ b/app/poetry.lock
@@ -1236,24 +1236,6 @@ test = ["pytest (<7.1)", "pytest-asyncio", "testpath"]
 test-extra = ["curio", "matplotlib (!=3.2.0)", "nbformat", "numpy (>=1.20)", "pandas", "pytest (<7.1)", "pytest-asyncio", "testpath", "trio"]
 
 [[package]]
-name = "isort"
-version = "5.12.0"
-description = "A Python utility / library to sort Python imports."
-category = "main"
-optional = false
-python-versions = ">=3.8.0"
-files = [
-    {file = "isort-5.12.0-py3-none-any.whl", hash = "sha256:f84c2818376e66cf843d497486ea8fed8700b340f308f076c6fb1229dff318b6"},
-    {file = "isort-5.12.0.tar.gz", hash = "sha256:8bef7dde241278824a6d83f44a544709b065191b95b6e50894bdc722fcba0504"},
-]
-
-[package.extras]
-colors = ["colorama (>=0.4.3)"]
-pipfile-deprecated-finder = ["pip-shims (>=0.5.2)", "pipreqs", "requirementslib"]
-plugins = ["setuptools"]
-requirements-deprecated-finder = ["pip-api", "pipreqs"]
-
-[[package]]
 name = "jedi"
 version = "0.18.2"
 description = "An autocompletion tool for Python that can be used for text editors."
@@ -2790,4 +2772,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "dd852283bcc0ee5707ded294baa0d4d7f3e6f409b33503fe2e10889e39fb4173"
+content-hash = "de235f11743e7dc6df35bf6c7f434bd9a7a3437823ec7092bf3bdad49066a7cd"

--- a/app/pyproject.toml
+++ b/app/pyproject.toml
@@ -47,7 +47,6 @@ djangorestframework-csv = "2.1.1"
 unicodecsv = "0.14.1"
 kinto-http = "10.8.0"
 jsonschema = "3.2.0"
-isort = "5.12.0"
 google-cloud-storage = "1.44.0"
 django-storages = "1.13.1"
 toml = "^0.10.2"
@@ -121,7 +120,6 @@ reportUnusedCallResult = false
 # # Enable Pyflakes `E` and `F` codes by default.
 select = ["F", "E", "W", "I", "N", "YTT", "A", "C4", "RET", "SIM"]
 ignore = [
-    # "A002",
     "A003",
     "E402",
     "E741",
@@ -129,6 +127,7 @@ ignore = [
     "N802",
     "N803",
     "N806",
+    "N812",
     "N815",
     "RET503",
     "RET504",

--- a/app/tests/integration/nimbus/conftest.py
+++ b/app/tests/integration/nimbus/conftest.py
@@ -5,6 +5,9 @@ from urllib.parse import urljoin, urlparse
 
 import pytest
 import requests
+from requests.adapters import HTTPAdapter
+from requests.packages.urllib3.util.retry import Retry
+
 from nimbus.kinto.client import (
     KINTO_COLLECTION_DESKTOP,
     KINTO_COLLECTION_MOBILE,
@@ -20,8 +23,6 @@ from nimbus.models.base_dataclass import (
 )
 from nimbus.pages.experimenter.home import HomePage
 from nimbus.utils import helpers
-from requests.adapters import HTTPAdapter
-from requests.packages.urllib3.util.retry import Retry
 
 APPLICATION_FEATURE_IDS = {
     BaseExperimentApplications.FIREFOX_DESKTOP: "1",
@@ -60,8 +61,8 @@ APPLICATION_KINTO_COLLECTION = {
 
 @pytest.fixture
 def slugify():
-    def _slugify(input):
-        return input.lower().replace(" ", "-").replace("[", "").replace("]", "")
+    def _slugify(name):
+        return name.lower().replace(" ", "-").replace("[", "").replace("]", "")
 
     return _slugify
 
@@ -365,7 +366,7 @@ def fixture_check_ping_for_experiment(trigger_experiment_loader):
                 if "experiments" in item["environment"]
             ]
             for item in experiments_data:
-                if experiment in item.keys():
+                if experiment in item:
                     return True
             time.sleep(5)
             trigger_experiment_loader()

--- a/app/tests/integration/nimbus/pages/experimenter/audience.py
+++ b/app/tests/integration/nimbus/pages/experimenter/audience.py
@@ -1,8 +1,9 @@
-from nimbus.pages.experimenter.base import ExperimenterBase
-from nimbus.pages.experimenter.summary import SummaryPage
 from selenium.webdriver.common.by import By
 from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.support.select import Select
+
+from nimbus.pages.experimenter.base import ExperimenterBase
+from nimbus.pages.experimenter.summary import SummaryPage
 
 
 class AudiencePage(ExperimenterBase):

--- a/app/tests/integration/nimbus/pages/experimenter/base.py
+++ b/app/tests/integration/nimbus/pages/experimenter/base.py
@@ -1,6 +1,7 @@
-from nimbus.pages.base import Base
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as EC
+
+from nimbus.pages.base import Base
 
 
 class ExperimenterBase(Base):

--- a/app/tests/integration/nimbus/pages/experimenter/branches.py
+++ b/app/tests/integration/nimbus/pages/experimenter/branches.py
@@ -1,7 +1,8 @@
-from nimbus.pages.experimenter.base import ExperimenterBase
-from nimbus.pages.experimenter.metrics import MetricsPage
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support.select import Select
+
+from nimbus.pages.experimenter.base import ExperimenterBase
+from nimbus.pages.experimenter.metrics import MetricsPage
 
 
 class BranchesPage(ExperimenterBase):

--- a/app/tests/integration/nimbus/pages/experimenter/home.py
+++ b/app/tests/integration/nimbus/pages/experimenter/home.py
@@ -1,7 +1,8 @@
-from nimbus.pages.experimenter.base import Base
 from pypom import Region
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as EC
+
+from nimbus.pages.experimenter.base import Base
 
 
 class HomePage(Base):

--- a/app/tests/integration/nimbus/pages/experimenter/metrics.py
+++ b/app/tests/integration/nimbus/pages/experimenter/metrics.py
@@ -1,7 +1,8 @@
-from nimbus.pages.experimenter.audience import AudiencePage
-from nimbus.pages.experimenter.base import ExperimenterBase
 from selenium.webdriver.common.by import By
 from selenium.webdriver.common.keys import Keys
+
+from nimbus.pages.experimenter.audience import AudiencePage
+from nimbus.pages.experimenter.base import ExperimenterBase
 
 
 class MetricsPage(ExperimenterBase):

--- a/app/tests/integration/nimbus/pages/experimenter/new_experiment.py
+++ b/app/tests/integration/nimbus/pages/experimenter/new_experiment.py
@@ -1,7 +1,8 @@
-from nimbus.pages.experimenter.base import ExperimenterBase
-from nimbus.pages.experimenter.overview import OverviewPage
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support.select import Select
+
+from nimbus.pages.experimenter.base import ExperimenterBase
+from nimbus.pages.experimenter.overview import OverviewPage
 
 
 class NewExperiment(ExperimenterBase):

--- a/app/tests/integration/nimbus/pages/experimenter/overview.py
+++ b/app/tests/integration/nimbus/pages/experimenter/overview.py
@@ -1,8 +1,9 @@
-from nimbus.pages.experimenter.base import ExperimenterBase
-from nimbus.pages.experimenter.branches import BranchesPage
 from selenium.webdriver.common.by import By
 from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.support.ui import Select
+
+from nimbus.pages.experimenter.base import ExperimenterBase
+from nimbus.pages.experimenter.branches import BranchesPage
 
 
 class OverviewPage(ExperimenterBase):

--- a/app/tests/integration/nimbus/pages/experimenter/summary.py
+++ b/app/tests/integration/nimbus/pages/experimenter/summary.py
@@ -1,11 +1,12 @@
 import random
 import string
 
-from nimbus.pages.experimenter.base import ExperimenterBase
 from pypom import Region
 from selenium.webdriver.common.by import By
 from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.support import expected_conditions as EC
+
+from nimbus.pages.experimenter.base import ExperimenterBase
 
 
 class SummaryPage(ExperimenterBase):

--- a/app/tests/integration/nimbus/test_desktop_client_integrations.py
+++ b/app/tests/integration/nimbus/test_desktop_client_integrations.py
@@ -3,6 +3,7 @@ from urllib.parse import urljoin
 
 import pytest
 import requests
+
 from nimbus.pages.browser import AboutConfig
 from nimbus.pages.experimenter.summary import SummaryPage
 from nimbus.utils import helpers
@@ -137,8 +138,6 @@ def test_check_telemetry_enrollment_unenrollment(
             for key in item["environment"]["experiments"]:
                 if experiment_slug in key:
                     break
-                else:
-                    continue
 
     # unenroll
     summary = SummaryPage(selenium, urljoin(base_url, experiment_slug)).open()

--- a/app/tests/integration/nimbus/test_desktop_targeting.py
+++ b/app/tests/integration/nimbus/test_desktop_targeting.py
@@ -1,6 +1,7 @@
 import json
 
 import pytest
+
 from nimbus.pages.browser import Browser
 from nimbus.utils import helpers
 

--- a/app/tests/integration/nimbus/test_experimenter_ui.py
+++ b/app/tests/integration/nimbus/test_experimenter_ui.py
@@ -1,6 +1,7 @@
 import os
 
 import pytest
+
 from nimbus.pages.experimenter.home import HomePage
 from nimbus.pages.experimenter.summary import SummaryPage
 

--- a/app/tests/integration/nimbus/test_mobile_targeting.py
+++ b/app/tests/integration/nimbus/test_mobile_targeting.py
@@ -2,6 +2,7 @@ import json
 import os
 
 import pytest
+
 from nimbus.jexl import collect_exprs
 from nimbus.models.base_app_context_dataclass import BaseAppContextDataClass
 from nimbus.utils import helpers

--- a/app/tests/integration/nimbus/test_remote_settings.py
+++ b/app/tests/integration/nimbus/test_remote_settings.py
@@ -1,6 +1,7 @@
 from urllib.parse import urljoin
 
 import pytest
+
 from nimbus.pages.experimenter.home import HomePage
 from nimbus.pages.experimenter.summary import SummaryPage
 

--- a/app/tests/integration/nimbus/utils/helpers.py
+++ b/app/tests/integration/nimbus/utils/helpers.py
@@ -19,8 +19,8 @@ def load_graphql_data(query):
         except json.JSONDecodeError:
             if retry + 1 >= LOAD_DATA_RETRIES:
                 raise
-            else:
-                time.sleep(LOAD_DATA_RETRY_DELAY)
+
+            time.sleep(LOAD_DATA_RETRY_DELAY)
 
 
 @lru_cache(maxsize=None)


### PR DESCRIPTION
Because

* We recently added a new python linter/formatter called ruff
* It is very nice
* It can also be used to lint and format the integration tests

This commit

* Enables ruff for the integration tests