### PR TITLE
fix #8049 bug(nimbus): fix missing whitespace typo

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/PageResults/ExternalConfigAlert/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/ExternalConfigAlert/index.tsx
@@ -17,8 +17,7 @@ export const ExternalConfigAlert = ({
     <Alert.Heading>Analysis has manual overrides in Jetstream</Alert.Heading>
     <p>
       The results shown on this page are from an analysis ran with at least one
-      experiment override that affects only the <em>analysis</em>. The original
-      {" "}
+      experiment override that affects only the <em>analysis</em>. The original{" "}
       <strong>
         experiment details and description on the Summary page will not reflect
         this.

--- a/app/experimenter/nimbus-ui/src/components/PageResults/ExternalConfigAlert/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageResults/ExternalConfigAlert/index.tsx
@@ -18,6 +18,7 @@ export const ExternalConfigAlert = ({
     <p>
       The results shown on this page are from an analysis ran with at least one
       experiment override that affects only the <em>analysis</em>. The original
+      {" "}
       <strong>
         experiment details and description on the Summary page will not reflect
         this.


### PR DESCRIPTION
Because

* #8049 pointed out a missing space between regular and **strong** tagged text

This commit

* adds the missing space explicitly

Before:
![image](https://user-images.githubusercontent.com/102263964/217645361-04bbf027-f06d-40fe-99d6-340dec0555d3.png)
After:
![image](https://user-images.githubusercontent.com/102263964/217645222-60c105cf-1d43-44ad-8eec-882bcd10fd6b.png)
