### PR TITLE
For #8238 feat(nimbus): Extend bucketing to include targeting

### DIFF
--- a/app/experimenter/experiments/api/v5/serializers.py
+++ b/app/experimenter/experiments/api/v5/serializers.py
@@ -1074,7 +1074,10 @@ class NimbusExperimentSerializer(
             experiment = super().save()
 
             if experiment.has_filter(experiment.Filters.SHOULD_ALLOCATE_BUCKETS):
+                if experiment.bucket_range_exists(): 
+                    experiment.warnings["bucketing"] = [NimbusExperiment.ERROR_BUCKET_EXISTS]
                 experiment.allocate_bucket_range()
+
 
             if self.should_call_preview_task:
                 nimbus_synchronize_preview_experiments_in_kinto.apply_async(countdown=5)

--- a/app/experimenter/experiments/constants.py
+++ b/app/experimenter/experiments/constants.py
@@ -406,6 +406,9 @@ Optional - We believe this outcome will <describe impact> on <core metric>
     ERROR_FIREFOX_VERSION_MAX = (
         "Ensure this value is greater than or equal to the minimum version"
     )
+    ERROR_BUCKET_EXISTS = (
+        "A rollout already exists for this combination of rollout, feature, channel, and advanced targeting."
+    )
 
     # Analysis can be computed starting the week after enrollment
     # completion for "week 1" of the experiment. However, an extra

--- a/app/experimenter/experiments/models.py
+++ b/app/experimenter/experiments/models.py
@@ -600,8 +600,12 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
             feature_config.slug
             for feature_config in self.feature_configs.all().order_by("slug")
         )
+
         if self.channel:
             keys.append(self.channel)
+
+        if self.targeting_config_slug:
+            keys.append(self.targeting_config_slug)
 
         if self.is_rollout:
             keys.append("rollout")

--- a/app/experimenter/experiments/models.py
+++ b/app/experimenter/experiments/models.py
@@ -256,6 +256,11 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
                 status=NimbusConstants.Status.DRAFT,
                 publish_status=NimbusConstants.PublishStatus.APPROVED,
             )
+            | Q(
+                status=NimbusConstants.Status.LIVE,
+                status_next=NimbusConstants.Status.LIVE,
+                publish_status=NimbusConstants.PublishStatus.APPROVED,
+            )
         )
 
     def __str__(self):

--- a/app/experimenter/experiments/models.py
+++ b/app/experimenter/experiments/models.py
@@ -604,10 +604,9 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
         if self.channel:
             keys.append(self.channel)
 
-        if self.targeting_config_slug:
-            keys.append(self.targeting_config_slug)
-
         if self.is_rollout:
+            if self.targeting_config_slug:
+                keys.append(self.targeting_config_slug.replace("_", "-"))
             keys.append("rollout")
 
         return "-".join(keys)

--- a/app/experimenter/experiments/models.py
+++ b/app/experimenter/experiments/models.py
@@ -628,6 +628,10 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
             ),
         )
 
+    def bucket_range_exists(self):
+        existing_bucket_range = NimbusBucketRange.objects.filter(experiment=self)
+        return existing_bucket_range.exists()
+
     @property
     def can_edit(self):
         return (

--- a/app/experimenter/experiments/tests/test_models.py
+++ b/app/experimenter/experiments/tests/test_models.py
@@ -1356,12 +1356,13 @@ class TestNimbusExperiment(TestCase):
             channel=NimbusExperiment.Channel.RELEASE,
             feature_configs=[feature],
             population_percent=Decimal("50.0"),
+            targeting_config_slug=NimbusExperiment.TargetingConfig.MAC_ONLY,
         )
         experiment.allocate_bucket_range()
         self.assertEqual(experiment.bucket_range.count, 5000)
         self.assertEqual(
             experiment.bucket_range.isolation_group.name,
-            "firefox-desktop-feature-release",
+            "firefox-desktop-feature-release-mac_only",
         )
 
     def test_allocate_buckets_creates_new_bucket_range_if_population_changes(self):
@@ -1384,6 +1385,7 @@ class TestNimbusExperiment(TestCase):
             channel=NimbusExperiment.Channel.RELEASE,
             feature_configs=[feature],
             population_percent=Decimal("50.0"),
+            targeting_config_slug=NimbusExperiment.TargetingConfig.MAC_ONLY,
         )
         experiment1.allocate_bucket_range()
 
@@ -1393,6 +1395,7 @@ class TestNimbusExperiment(TestCase):
             channel=NimbusExperiment.Channel.RELEASE,
             feature_configs=[feature],
             population_percent=Decimal("100.0"),
+            targeting_config_slug=NimbusExperiment.TargetingConfig.MAC_ONLY,
         )
         experiment2.allocate_bucket_range()
 
@@ -1415,6 +1418,7 @@ class TestNimbusExperiment(TestCase):
             channel=NimbusExperiment.Channel.RELEASE,
             feature_configs=[feature],
             population_percent=Decimal("50.0"),
+            targeting_config_slug=NimbusExperiment.TargetingConfig.MAC_ONLY,
         )
         experiment1.allocate_bucket_range()
 
@@ -1424,6 +1428,7 @@ class TestNimbusExperiment(TestCase):
             channel=NimbusExperiment.Channel.RELEASE,
             feature_configs=[feature],
             population_percent=Decimal("25.0"),
+            targeting_config_slug=NimbusExperiment.TargetingConfig.MAC_ONLY,
         )
         experiment2.allocate_bucket_range()
 
@@ -1444,6 +1449,7 @@ class TestNimbusExperiment(TestCase):
             application=NimbusExperiment.Application.DESKTOP,
             channel=NimbusExperiment.Channel.RELEASE,
             feature_configs=[feature],
+            targeting_config_slug=NimbusExperiment.TargetingConfig.MAC_ONLY,
             population_percent=Decimal("50.0"),
         )
         original_namespace = experiment.bucket_namespace
@@ -1454,7 +1460,7 @@ class TestNimbusExperiment(TestCase):
         self.assertNotEqual(original_namespace, experiment.bucket_namespace)
         self.assertEqual(
             experiment.bucket_namespace,
-            "firefox-desktop-feature-release-rollout",
+            "firefox-desktop-feature-release-mac_only-rollout",
         )
 
     def test_proposed_enrollment_end_date_without_start_date_is_None(self):

--- a/app/experimenter/experiments/tests/test_models.py
+++ b/app/experimenter/experiments/tests/test_models.py
@@ -1352,6 +1352,7 @@ class TestNimbusExperiment(TestCase):
         feature = NimbusFeatureConfigFactory(slug="feature")
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.CREATED,
+            is_rollout=False,
             application=NimbusExperiment.Application.DESKTOP,
             channel=NimbusExperiment.Channel.RELEASE,
             feature_configs=[feature],
@@ -1362,7 +1363,7 @@ class TestNimbusExperiment(TestCase):
         self.assertEqual(experiment.bucket_range.count, 5000)
         self.assertEqual(
             experiment.bucket_range.isolation_group.name,
-            "firefox-desktop-feature-release-mac_only",
+            "firefox-desktop-feature-release",
         )
 
     def test_allocate_buckets_creates_new_bucket_range_if_population_changes(self):
@@ -1460,7 +1461,7 @@ class TestNimbusExperiment(TestCase):
         self.assertNotEqual(original_namespace, experiment.bucket_namespace)
         self.assertEqual(
             experiment.bucket_namespace,
-            "firefox-desktop-feature-release-mac_only-rollout",
+            "firefox-desktop-feature-release-mac-only-rollout",
         )
 
     def test_proposed_enrollment_end_date_without_start_date_is_None(self):

--- a/app/experimenter/nimbus-ui/src/components/PageSummary/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageSummary/index.tsx
@@ -36,7 +36,7 @@ const PageSummary = (props: RouteComponentProps) => {
   useExperimentPolling();
 
   const [showLaunchToReview, setShowLaunchToReview] = useState(false);
-  const { invalidPages, InvalidPagesList } = useReviewCheck(experiment);
+  const { invalidPages, InvalidPagesList, fieldWarnings } = useReviewCheck(experiment);
 
   const status = getStatus(experiment);
 
@@ -224,6 +224,14 @@ const PageSummary = (props: RouteComponentProps) => {
         <h5 className="mt-3 mb-4 ml-3">
           {summaryAction} {launchDocs}
         </h5>
+      )}
+
+      {status.draft || status.preview &&
+        !experiment.isArchived && 
+        (fieldWarnings["bucketing"].values.length > 0) && (
+          <Alert data-testid="bucketing-warning" variant="danger">
+            "A rollout already exists for this combination of rollout, feature, channel, and advanced targeting."
+          </Alert>
       )}
 
       <ChangeApprovalOperations


### PR DESCRIPTION
Because...

* We want rollouts to be consistently enrolled as the population percentage increases (not unenrolled when the value is changed)

This commit...

* Extends the bucketing definition to include targeting
* Parses the targeting slug so that it follows the hyphenated format of the rest of the bucket name
* Adds a warning to `PageSummary` when you are attempting to create an experiment that would end up in the same bucket as an existing experiment