### PR TITLE
fix #8308 bug(nimbus): parse feature variable enum values into correct type

### DIFF
--- a/app/experimenter/features/__init__.py
+++ b/app/experimenter/features/__init__.py
@@ -28,6 +28,12 @@ FEATURE_SCHEMA_TYPES = {
     FeatureVariableType.BOOLEAN: "boolean",
 }
 
+FEATURE_PYTHON_TYPES = {
+    FeatureVariableType.INT: int,
+    FeatureVariableType.STRING: str,
+    FeatureVariableType.BOOLEAN: bool,
+}
+
 
 class FeatureVariable(BaseModel):
     description: Optional[str]
@@ -78,7 +84,8 @@ class Feature(BaseModel):
                     variable_schema["type"] = FEATURE_SCHEMA_TYPES[variable.type]
 
                 if variable.enum:
-                    variable_schema["enum"] = variable.enum
+                    python_type = FEATURE_PYTHON_TYPES[variable.type]
+                    variable_schema["enum"] = [python_type(e) for e in variable.enum]
 
                 schema["properties"][variable_slug] = variable_schema
 

--- a/app/experimenter/features/tests/fixtures/valid_features/firefox-desktop.yaml
+++ b/app/experimenter/features/tests/fixtures/valid_features/firefox-desktop.yaml
@@ -16,6 +16,10 @@ someFeature:
     intProperty:
       type: int
       description: Integer Property
+      enum:
+        - 1
+        - 2
+        - 3
     jsonProperty:
       type: json
       description: Arbitrary JSON Property

--- a/app/experimenter/features/tests/test_features.py
+++ b/app/experimenter/features/tests/test_features.py
@@ -52,6 +52,7 @@ class TestFeatures(TestCase):
                     ),
                     "intProperty": FeatureVariable(
                         description="Integer Property",
+                        enum=[1, 2, 3],
                         type="int",
                     ),
                     "jsonProperty": FeatureVariable(
@@ -105,6 +106,7 @@ class TestFeatures(TestCase):
                     "intProperty": FeatureVariable(
                         description="Integer Property",
                         type="int",
+                        enum=[1, 2, 3],
                     ),
                     "jsonProperty": FeatureVariable(
                         description="Arbitrary JSON Property",
@@ -131,7 +133,11 @@ class TestFeatures(TestCase):
                         "description": "Boolean Property",
                         "type": "boolean",
                     },
-                    "intProperty": {"description": "Integer Property", "type": "integer"},
+                    "intProperty": {
+                        "description": "Integer Property",
+                        "type": "integer",
+                        "enum": [1, 2, 3],
+                    },
                     "jsonProperty": {"description": "Arbitrary JSON Property"},
                 },
                 "additionalProperties": False,

--- a/app/experimenter/features/tests/test_load_feature_configs.py
+++ b/app/experimenter/features/tests/test_load_feature_configs.py
@@ -16,6 +16,8 @@ from experimenter.features.tests import (
 
 @mock_valid_features
 class TestLoadFeatureConfigs(TestCase):
+    maxDiff = None
+
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
@@ -45,7 +47,11 @@ class TestLoadFeatureConfigs(TestCase):
                         "description": "Boolean Property",
                         "type": "boolean",
                     },
-                    "intProperty": {"description": "Integer Property", "type": "integer"},
+                    "intProperty": {
+                        "description": "Integer Property",
+                        "type": "integer",
+                        "enum": [1, 2, 3],
+                    },
                     "jsonProperty": {"description": "Arbitrary JSON Property"},
                 },
                 "additionalProperties": False,
@@ -94,7 +100,11 @@ class TestLoadFeatureConfigs(TestCase):
                         "description": "Boolean Property",
                         "type": "boolean",
                     },
-                    "intProperty": {"description": "Integer Property", "type": "integer"},
+                    "intProperty": {
+                        "description": "Integer Property",
+                        "type": "integer",
+                        "enum": [1, 2, 3],
+                    },
                     "jsonProperty": {"description": "Arbitrary JSON Property"},
                 },
                 "additionalProperties": False,


### PR DESCRIPTION


Because

* The YAML loader will default parse all values as strings
* In the case where enum values are specified for a feature variable, the enum values should be of the same type as the variable
* In the case of an integer field, we were parsing the integer enum values as strings so no value would validate for that field

This commit

* Parses feature variable enum values into the correct type for the field