### PR TITLE
For #8311 test(nimbus): Add integration tests for rollouts in remote settings

### DIFF
--- a/app/tests/integration/nimbus/conftest.py
+++ b/app/tests/integration/nimbus/conftest.py
@@ -220,7 +220,7 @@ def default_data(application, experiment_name, load_experiment_outcomes):
         metrics=outcomes[str(application).lower().rsplit(".")[-1]],
         audience=BaseExperimentAudienceDataClass(
             channel=BaseExperimentAudienceChannels.RELEASE,
-            min_version=102,
+            min_version=106,
             targeting="test_targeting",
             percentage="50",
             expected_clients=50,
@@ -228,12 +228,13 @@ def default_data(application, experiment_name, load_experiment_outcomes):
             countries=None,
             languages=None,
         ),
+        is_rollout=False,
     )
 
 
 @pytest.fixture
 def create_experiment(base_url, default_data):
-    def _create_experiment(selenium):
+    def _create_experiment(selenium, is_rollout=False):
         home = HomePage(selenium, base_url).open()
         experiment = home.create_new_button()
         experiment.public_name = default_data.public_name
@@ -259,9 +260,13 @@ def create_experiment(base_url, default_data):
         branches = overview.save_and_continue()
         branches.feature_config = default_data.feature_config_id
         branches.reference_branch_description = default_data.branches[0].description
-        branches.treatment_branch_description = default_data.branches[1].description
         branches.reference_branch_value = "{}"
-        branches.treatment_branch_value = "{}"
+
+        if is_rollout:
+            branches.make_rollout()
+        else:
+            branches.treatment_branch_description = default_data.branches[1].description
+            branches.treatment_branch_value = "{}"
 
         # Fill Metrics page
         metrics = branches.save_and_continue()

--- a/app/tests/integration/nimbus/models/base_dataclass.py
+++ b/app/tests/integration/nimbus/models/base_dataclass.py
@@ -52,3 +52,4 @@ class BaseExperimentDataClass:
     metrics: BaseExperimentMetricsDataClass
     audience: BaseExperimentAudienceDataClass
     feature_config_id: str
+    is_rollout: bool

--- a/app/tests/integration/nimbus/pages/experimenter/branches.py
+++ b/app/tests/integration/nimbus/pages/experimenter/branches.py
@@ -30,6 +30,7 @@ class BranchesPage(ExperimenterBase):
     _remove_branch_locator = (By.CSS_SELECTOR, ".bg-transparent")
     _feature_select_locator = (By.CSS_SELECTOR, '[data-testid="feature-config-select"]')
     _add_screenshot_buttons_locator = (By.CSS_SELECTOR, '[data-testid="add-screenshot"]')
+    _rollout_checkbox_locator = (By.CSS_SELECTOR, '[data-testid="is-rollout-checkbox"]')
     NEXT_PAGE = MetricsPage
     PAGE_TITLE = "Edit Branches Page"
 
@@ -123,6 +124,17 @@ class BranchesPage(ExperimenterBase):
         )
         select = Select(el)
         select.select_by_value(feature_config_id)
+
+    @property
+    def is_rollout(self):
+        return self.wait_for_and_find_element(
+            self._rollout_checkbox_locator, "is rollout"
+        )
+
+    def make_rollout(self):
+        self.wait_for_and_find_element(
+            self._rollout_checkbox_locator, "is_rollout"
+        ).click()
 
     @property
     def add_screenshot_buttons(self):

--- a/app/tests/integration/nimbus/test_remote_settings.py
+++ b/app/tests/integration/nimbus/test_remote_settings.py
@@ -13,7 +13,21 @@ def test_create_new_experiment_approve_remote_settings(
     create_experiment,
     kinto_client,
 ):
-    create_experiment(selenium).launch_and_approve()
+    create_experiment(selenium, is_rollout=False).launch_and_approve()
+
+    kinto_client.approve()
+
+    SummaryPage(selenium, experiment_url).open().wait_for_live_status()
+
+
+@pytest.mark.remote_settings
+def test_create_new_rollout_approve_remote_settings(
+    selenium,
+    experiment_url,
+    create_experiment,
+    kinto_client,
+):
+    create_experiment(selenium, is_rollout=True).launch_and_approve()
 
     kinto_client.approve()
 
@@ -28,6 +42,20 @@ def test_create_new_experiment_reject_remote_settings(
     kinto_client,
 ):
     create_experiment(selenium).launch_and_approve()
+
+    kinto_client.reject()
+
+    SummaryPage(selenium, experiment_url).open().wait_for_rejected_alert()
+
+
+@pytest.mark.remote_settings
+def test_create_new_rollout_reject_remote_settings(
+    selenium,
+    experiment_url,
+    create_experiment,
+    kinto_client,
+):
+    create_experiment(selenium, is_rollout=True).launch_and_approve()
 
     kinto_client.reject()
 
@@ -55,6 +83,26 @@ def test_end_experiment_and_approve_end(
 
 
 @pytest.mark.remote_settings
+def test_end_rollout_and_approve_end(
+    selenium,
+    experiment_url,
+    create_experiment,
+    kinto_client,
+):
+    create_experiment(selenium, is_rollout=True).launch_and_approve()
+
+    kinto_client.approve()
+
+    summary = SummaryPage(selenium, experiment_url).open()
+    summary.wait_for_live_status()
+    summary.end_and_approve()
+
+    kinto_client.approve()
+
+    SummaryPage(selenium, experiment_url).open().wait_for_complete_status()
+
+
+@pytest.mark.remote_settings
 def test_end_experiment_and_reject_end(
     selenium,
     experiment_url,
@@ -62,6 +110,26 @@ def test_end_experiment_and_reject_end(
     kinto_client,
 ):
     create_experiment(selenium).launch_and_approve()
+
+    kinto_client.approve()
+
+    summary = SummaryPage(selenium, experiment_url).open()
+    summary.wait_for_live_status()
+    summary.end_and_approve()
+
+    kinto_client.reject()
+
+    SummaryPage(selenium, experiment_url).open().wait_for_rejected_alert()
+
+
+@pytest.mark.remote_settings
+def test_end_rollout_and_reject_end(
+    selenium,
+    experiment_url,
+    create_experiment,
+    kinto_client,
+):
+    create_experiment(selenium, is_rollout=True).launch_and_approve()
 
     kinto_client.approve()
 
@@ -107,13 +175,28 @@ def test_takeaways(
 
 @pytest.mark.remote_settings
 @pytest.mark.xdist_group(name="group2")
-def test_check_live_status_on_home_page(
+def test_experiment_live_status_on_home_page(
     selenium, base_url, create_experiment, kinto_client, experiment_name, slugify
 ):
     experiment_slug = str(slugify(experiment_name))
 
     summary = create_experiment(selenium)
     summary.launch_and_approve()
+    kinto_client.approve()
+    summary = SummaryPage(selenium, urljoin(base_url, experiment_slug)).open()
+    summary.wait_for_live_status()
+    home = HomePage(selenium, base_url).open()
+    assert True in [experiment_name in item.text for item in home.tables[0].experiments]
+
+
+@pytest.mark.remote_settings
+@pytest.mark.xdist_group(name="group2")
+def test_rollout_live_status_on_home_page(
+    selenium, base_url, create_experiment, kinto_client, experiment_name, slugify
+):
+    experiment_slug = str(slugify(experiment_name))
+
+    create_experiment(selenium, is_rollout=True).launch_and_approve()
     kinto_client.approve()
     summary = SummaryPage(selenium, urljoin(base_url, experiment_slug)).open()
     summary.wait_for_live_status()


### PR DESCRIPTION
Because..

* We are messing with the publish status for live updates

This commit...

* Adds the rollout checkbox to our integration tests on the branches page
* Up's the default minimum version to 106 (min for rollouts is 105)
* Adds specific integration tests for rollouts 
   * We want to make sure that adding the DIRTY publish status doesn't mess with ending experiments or ending enrollment, in both the approve and reject cases
   * In #8253 our current tests caught bugs with the reject cases, so this will expand that coverage