### PR TITLE
For #8315 feat(nimbus) test(nimbus): Save buttons navigate to summary for live rollouts

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/PageEditAudience/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditAudience/index.tsx
@@ -10,7 +10,7 @@ import FormAudience from "src/components/PageEditAudience/FormAudience";
 import { UPDATE_EXPERIMENT_MUTATION } from "src/gql/experiments";
 import { CHANGELOG_MESSAGES, SUBMIT_ERROR } from "src/lib/constants";
 import { ExperimentContext } from "src/lib/contexts";
-import { editCommonRedirects } from "src/lib/experiment";
+import { editCommonRedirects, getStatus } from "src/lib/experiment";
 import {
   updateExperiment,
   updateExperimentVariables,
@@ -89,7 +89,11 @@ const PageEditAudience: React.FunctionComponent<RouteComponentProps> = () => {
           refetch();
 
           if (next) {
-            navigate("../");
+            if (getStatus(experiment).live) {
+              navigate("summary");
+            } else {
+              navigate("../");
+            }
           }
         }
       } catch (error) {

--- a/app/experimenter/nimbus-ui/src/lib/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/lib/mocks.tsx
@@ -829,6 +829,7 @@ export const mockGetStatus = (
       | "statusNext"
       | "isEnrollmentPausePending"
       | "isArchived"
+      | "isRollout"
     >
   >,
 ) => {


### PR DESCRIPTION
Because...

* We are re-using the Audience page for live rollouts
* And we want the "save and continue" button to take us to the summary page in that case

This commit...

* Adds navigation to summary page for live rollouts
* Adds tests!