### PR TITLE
For #7823 test(nimbus): Add tests for live updates for mutations and frontend

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/ChangeApprovalOperations/FormApproveOrReject.tsx
+++ b/app/experimenter/nimbus-ui/src/components/ChangeApprovalOperations/FormApproveOrReject.tsx
@@ -38,7 +38,7 @@ const FormApproveOrReject = ({
           </p>
         </Alert>
       )}
-      <Alert variant="secondary">
+      <Alert variant="secondary" data-testid="review-request-alert">
         <Form className="text-body">
           <p>
             <strong>{reviewRequestEvent!.changedBy!.email}</strong> requested to{" "}

--- a/app/experimenter/nimbus-ui/src/components/ChangeApprovalOperations/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/ChangeApprovalOperations/index.test.tsx
@@ -13,6 +13,7 @@ import React from "react";
 import {
   BaseSubject,
   MOCK_EXPERIMENT,
+  MOCK_LIVE_ROLLOUT,
   reviewApprovedAfterTimeoutBaseProps,
   reviewPendingInRemoteSettingsBaseProps,
   reviewRejectedBaseProps,
@@ -94,11 +95,50 @@ describe("ChangeApprovalOperations", () => {
         }}
       />,
     );
+    const reviewAlertTitle = await screen.findByTestId("review-request-alert");
+    await waitFor(() => {
+      expect(reviewAlertTitle).toBeInTheDocument();
+    });
     const approveButton = await screen.findByTestId("approve-request");
     fireEvent.click(approveButton);
     await waitFor(() => {
       expect(approveChange).toHaveBeenCalled();
     });
+    const openRemoteSettingsButton = await screen.findByTestId(
+      "open-remote-settings",
+    );
+    expect(openRemoteSettingsButton).toHaveProperty("href", REVIEW_URL);
+  });
+
+  it("when user can review for live updates, supports approval and opening remote settings", async () => {
+    const approveChange = jest.fn();
+    render(
+      <Subject
+        {...{
+          ...reviewRequestedBaseProps,
+          canReview: true,
+          approveChange,
+          status: {
+            ...getStatus(MOCK_LIVE_ROLLOUT),
+            draft: false,
+            dirty: true,
+            live: true,
+          },
+        }}
+      />,
+    );
+    const reviewAlertTitle = await screen.findByTestId("review-request-alert");
+    await waitFor(() => {
+      expect(reviewAlertTitle).toBeInTheDocument();
+    });
+
+    const approveButton = await screen.findByTestId("approve-request");
+    fireEvent.click(approveButton);
+
+    await waitFor(() => {
+      expect(approveChange).toHaveBeenCalled();
+    });
+
     const openRemoteSettingsButton = await screen.findByTestId(
       "open-remote-settings",
     );

--- a/app/experimenter/nimbus-ui/src/components/ChangeApprovalOperations/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/components/ChangeApprovalOperations/mocks.tsx
@@ -9,6 +9,7 @@ import { getStatus } from "src/lib/experiment";
 import {
   mockChangelog,
   mockExperimentQuery,
+  mockLiveRolloutQuery,
   mockRejectionChangelog,
 } from "src/lib/mocks";
 import {
@@ -24,6 +25,7 @@ export const REVIEW_URL =
   "http://localhost:8888/v1/admin/#/buckets/main-workspace/collections/nimbus-mobile-experiments/records";
 
 export const { experiment: MOCK_EXPERIMENT } = mockExperimentQuery("boo");
+export const { rollout: MOCK_LIVE_ROLLOUT } = mockLiveRolloutQuery("boop");
 
 export const BaseSubject = ({
   actionButtonTitle = "Frobulate Thingy",


### PR DESCRIPTION
Because...

* We are adding the ability to make live edits to rollouts

This commit...

* Adds tests for updating rollouts and experiments (test_mutations)
* Adds tests for approval in Change Operations (rejection will be handled separately)