### PR TITLE
For #7823 feat(nimbus): Updates to live rollouts set dirty publish status

### DIFF
--- a/app/experimenter/experiments/api/v5/serializers.py
+++ b/app/experimenter/experiments/api/v5/serializers.py
@@ -1038,11 +1038,9 @@ class NimbusExperimentSerializer(
             and experiment.publish_status == NimbusExperiment.PublishStatus.IDLE
             and validated_data.get("publish_status")
             != NimbusConstants.PublishStatus.REVIEW
-            and validated_data.get("publish_status")
-            != NimbusConstants.PublishStatus.DIRTY
         ):
             # can be Live Update (Dirty), End Enrollment, or End Experiment
-            # if we don't check validated_data["publish_status"]
+            # (including rejections) if we don't check validated_data
             validated_data["publish_status"] = NimbusConstants.PublishStatus.DIRTY
 
         self.changelog_message = validated_data.pop("changelog_message")

--- a/app/experimenter/experiments/api/v5/serializers.py
+++ b/app/experimenter/experiments/api/v5/serializers.py
@@ -1030,6 +1030,21 @@ class NimbusExperimentSerializer(
         return data
 
     def update(self, experiment, validated_data):
+        if (
+            experiment.is_rollout
+            and not experiment.is_paused
+            and experiment.status == NimbusExperiment.Status.LIVE
+            and experiment.status_next is None
+            and experiment.publish_status == NimbusExperiment.PublishStatus.IDLE
+            and validated_data.get("publish_status")
+            != NimbusConstants.PublishStatus.REVIEW
+            and validated_data.get("publish_status")
+            != NimbusConstants.PublishStatus.DIRTY
+        ):
+            # can be Live Update (Dirty), End Enrollment, or End Experiment
+            # if we don't check validated_data["publish_status"]
+            validated_data["publish_status"] = NimbusConstants.PublishStatus.DIRTY
+
         self.changelog_message = validated_data.pop("changelog_message")
         return super().update(experiment, validated_data)
 

--- a/app/experimenter/experiments/tests/api/v5/test_mutations.py
+++ b/app/experimenter/experiments/tests/api/v5/test_mutations.py
@@ -433,7 +433,7 @@ class TestUpdateExperimentMutationSingleFeature(
         experiment = NimbusExperiment.objects.get(id=experiment_id)
         self.assertTrue(experiment.is_rollout)
         self.assertEqual(experiment.population_percent, 50.0)
-        self.assertEqual(experiment.publish_status, NimbusConstants.PublishStatus.IDLE)
+        self.assertEqual(experiment.publish_status, NimbusConstants.PublishStatus.DIRTY)
         self.assertEqual(experiment.status, NimbusConstants.Status.LIVE)
         self.assertEqual(experiment.status_next, None)
 


### PR DESCRIPTION
This commit...

* Updates publish status to `DIRTY` when a live update is made to a rollout
* Updates test_mutations

This commit _does not_...

* Enable the population percent field or the save/save & continue buttons on the audience page (#8239)