### PR TITLE
fix #8333 bug(nimbus): fix logic for whether to fetch analysis results

### DIFF
--- a/app/experimenter/jetstream/tasks.py
+++ b/app/experimenter/jetstream/tasks.py
@@ -36,7 +36,7 @@ def fetch_jetstream_data():
             status__in=[NimbusExperiment.Status.DRAFT, NimbusExperiment.Status.PREVIEW]
         ):
             if (
-                experiment.status is not NimbusExperiment.Status.LIVE  # always fetch LIVE
+                experiment.status != NimbusExperiment.Status.LIVE  # always fetch LIVE
                 and experiment.results_data is not None
                 and experiment.computed_end_date
                 and (


### PR DESCRIPTION
Because

* #8290 had a bug in it
* we want to always fetch Live experimenters

This commit

* fixes the bug checking if experiment status is Live