### PR TITLE
For #8321 feat(nimbus) test(nimbus): Definitions for update and update reviews in getStatus

### DIFF
--- a/app/experimenter/nimbus-ui/src/lib/experiment.test.ts
+++ b/app/experimenter/nimbus-ui/src/lib/experiment.test.ts
@@ -58,6 +58,21 @@ describe("getStatus", () => {
 
     experiment.publishStatus = NimbusExperimentPublishStatusEnum.WAITING;
     expect(getStatus(experiment).waiting).toBeTruthy();
+
+    experiment.publishStatus = NimbusExperimentPublishStatusEnum.DIRTY;
+    expect(getStatus(experiment).dirty).toBeTruthy();
+
+    experiment.publishStatus = NimbusExperimentPublishStatusEnum.REVIEW;
+    experiment.status = NimbusExperimentStatusEnum.LIVE;
+    experiment.statusNext = NimbusExperimentStatusEnum.LIVE;
+    experiment.isRollout = true;
+    expect(getStatus(experiment).updateRequested).toBeTruthy();
+
+    experiment.publishStatus = NimbusExperimentPublishStatusEnum.APPROVED;
+    expect(getStatus(experiment).updateRequestedApproved).toBeTruthy();
+
+    experiment.publishStatus = NimbusExperimentPublishStatusEnum.WAITING;
+    expect(getStatus(experiment).updateRequestedWaiting).toBeTruthy();
   });
 });
 

--- a/app/experimenter/nimbus-ui/src/lib/experiment.ts
+++ b/app/experimenter/nimbus-ui/src/lib/experiment.ts
@@ -20,6 +20,7 @@ export function getStatus(
     publishStatus,
     isEnrollmentPausePending,
     isArchived,
+    isRollout,
   } = experiment || {};
 
   // The experiment is or was out in the wild (live or complete)
@@ -48,8 +49,19 @@ export function getStatus(
       status === NimbusExperimentStatusEnum.LIVE &&
       statusNext === NimbusExperimentStatusEnum.COMPLETE,
     updateRequested:
+      isRollout === true &&
       status === NimbusExperimentStatusEnum.LIVE &&
       publishStatus === NimbusExperimentPublishStatusEnum.REVIEW &&
+      statusNext === NimbusExperimentStatusEnum.LIVE,
+    updateRequestedApproved:
+      isRollout === true &&
+      status === NimbusExperimentStatusEnum.LIVE &&
+      publishStatus === NimbusExperimentPublishStatusEnum.APPROVED &&
+      statusNext === NimbusExperimentStatusEnum.LIVE,
+    updateRequestedWaiting:
+      isRollout === true &&
+      status === NimbusExperimentStatusEnum.LIVE &&
+      publishStatus === NimbusExperimentPublishStatusEnum.WAITING &&
       statusNext === NimbusExperimentStatusEnum.LIVE,
     launched,
   };


### PR DESCRIPTION
Because...

* We want to signal to the user on PageSummary that a rollout has unpublished updates pending (DIRTY publish status) 
* And we want to use the `getStatus` definitions to determine if it's in the following states:
   * Dirty
   * Update requested
   * Update approved & waiting for remote settings approval

This commit...

* Updates the `getStatus` definitions to include `updateRequested` and `updatedRequestedWaiting`
* Not sure why the test coverage wasn't complaining, but I added tests in `experiment.test.ts`