### PR TITLE
fix #8338 chore(nimbus): refactor fetch logic

### DIFF
--- a/app/experimenter/jetstream/tests/test_tasks.py
+++ b/app/experimenter/jetstream/tests/test_tasks.py
@@ -840,6 +840,9 @@ class TestFetchJetstreamDataTask(TestCase):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             lifecycle, start_date=datetime.date(2020, 1, 1), proposed_enrollment=12
         )
+        experiment.results_data = {}
+        experiment.save()
+
         tasks.fetch_jetstream_data()
         mock_delay.assert_called_once_with(experiment.id)
 


### PR DESCRIPTION
Because

* the logic to fetch analysis results looks for the ones to skip, and then falls into fetch logic if we don't want to skip
* this flow may be confusing to parse

This commit

* seeks the experiments to fetch instead of the ones to skip
* makes the logic a little more explicit
* fixes a test that was passing in some cases it shouldn't