### PR TITLE
fix #8340 chore(nimbus): remove vscode dir exceptions from gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,10 +74,6 @@ target/
 
 # VS Code
 **/.vscode/*
-!.vscode/settings.json
-!.vscode/tasks.json
-!.vscode/launch.json
-!.vscode/extensions.json
 
 # Hosted assets
 app/experimenter/served/


### PR DESCRIPTION
Because

* we removed the `.vscode` dir from the repo
* the `.gitignore` file has exceptions for files in this dir
* developers may want these files to exist locally but not commit them to the repo

This commit

* removes exceptions from the `.gitignore` file for `.vscode`