### PR TITLE
For #8238 feat(nimbus): Allocate buckets for rollouts

### DIFF
--- a/app/experimenter/experiments/models.py
+++ b/app/experimenter/experiments/models.py
@@ -256,6 +256,12 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
                 status=NimbusConstants.Status.DRAFT,
                 publish_status=NimbusConstants.PublishStatus.APPROVED,
             )
+            | Q(
+                is_rollout=True,
+                status=NimbusConstants.Status.LIVE,
+                status_next=NimbusConstants.Status.LIVE,
+                publish_status=NimbusConstants.PublishStatus.APPROVED,
+            )
         )
 
     def __str__(self):


### PR DESCRIPTION
Because...

* We want rollouts to be consistently enrolled as the population percentage increases (not unenrolled when the value is changed)

This commit...

* Allocates buckets for live approved rollouts


---- 

This commit _does not_...
* Add a warning to `PageSummary` when you are attempting to create an experiment that would end up in the same bucket as an existing experiment -- this will be the next PR