### PR TITLE
For #8238 feat(nimbus): Add targeting slug to bucketing namespace

### DIFF
--- a/app/experimenter/experiments/models.py
+++ b/app/experimenter/experiments/models.py
@@ -601,10 +601,13 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
             feature_config.slug
             for feature_config in self.feature_configs.all().order_by("slug")
         )
+
         if self.channel:
             keys.append(self.channel)
 
         if self.is_rollout:
+            if self.targeting_config_slug:
+                keys.append(self.targeting_config_slug)
             keys.append("rollout")
 
         return "-".join(keys)

--- a/app/experimenter/experiments/tests/test_models.py
+++ b/app/experimenter/experiments/tests/test_models.py
@@ -1385,12 +1385,13 @@ class TestNimbusExperiment(TestCase):
             channel=NimbusExperiment.Channel.RELEASE,
             feature_configs=[feature],
             is_rollout=True,
+            targeting_config_slug=NimbusExperiment.TargetingConfig.MAC_ONLY,
         )
         experiment.allocate_bucket_range()
         self.assertEqual(experiment.bucket_range.count, 5000)
         self.assertEqual(
             experiment.bucket_range.isolation_group.name,
-            "firefox-desktop-feature-release-rollout",
+            "firefox-desktop-feature-release-mac_only-rollout",
         )
 
     def test_allocate_buckets_deletes_buckets_and_empty_isolation_group(self):
@@ -1462,6 +1463,7 @@ class TestNimbusExperiment(TestCase):
             application=NimbusExperiment.Application.DESKTOP,
             channel=NimbusExperiment.Channel.RELEASE,
             feature_configs=[feature],
+            targeting_config_slug=NimbusExperiment.TargetingConfig.MAC_ONLY,
             population_percent=Decimal("50.0"),
         )
         original_namespace = experiment.bucket_namespace
@@ -1472,7 +1474,7 @@ class TestNimbusExperiment(TestCase):
         self.assertNotEqual(original_namespace, experiment.bucket_namespace)
         self.assertEqual(
             experiment.bucket_namespace,
-            "firefox-desktop-feature-release-rollout",
+            "firefox-desktop-feature-release-mac_only-rollout",
         )
 
     def test_proposed_enrollment_end_date_without_start_date_is_None(self):


### PR DESCRIPTION
Because...

* We want rollouts to be consistently enrolled as the population percentage increases (not unenrolled when the value is changed)

This commit...

* Adds the`targeting_config_slug` to the bucketing namespace for rollouts
* Updates tests

---- 

This commit _does not_...
* Add a warning to `PageSummary` when you are attempting to create an experiment that would end up in the same bucket as an existing experiment -- this will be the next PR