### PR TITLE
For #8359 feat(nimbus): Add serializer warning when there is bucket duplication

### DIFF
--- a/app/experimenter/experiments/api/v5/serializers.py
+++ b/app/experimenter/experiments/api/v5/serializers.py
@@ -1506,6 +1506,22 @@ class NimbusReviewSerializer(serializers.ModelSerializer):
 
         return data
 
+    def _validate_bucket_duplicates(self, data):
+        if not self.instance or not self.instance.is_rollout:
+            return data
+        is_rollout = self.instance.is_rollout
+        count = NimbusExperiment.objects.filter(
+            channel=self.instance.channel,
+            application=self.instance.application,
+            targeting_config_slug=self.instance.targeting_config_slug,
+            is_rollout=is_rollout,
+        ).count()
+
+        if is_rollout and count > 1:
+            self.warnings["bucketing"] = [NimbusConstants.ERROR_BUCKET_EXISTS]
+
+        return data
+
     def validate(self, data):
         application = data.get("application")
         channel = data.get("channel")
@@ -1519,6 +1535,7 @@ class NimbusReviewSerializer(serializers.ModelSerializer):
         data = self._validate_versions(data)
         data = self._validate_sticky_enrollment(data)
         data = self._validate_rollout_version_support(data)
+        data = self._validate_bucket_duplicates(data)
         if application != NimbusExperiment.Application.DESKTOP:
             data = self._validate_languages_versions(data)
             data = self._validate_countries_versions(data)

--- a/app/experimenter/experiments/api/v5/serializers.py
+++ b/app/experimenter/experiments/api/v5/serializers.py
@@ -1511,13 +1511,14 @@ class NimbusReviewSerializer(serializers.ModelSerializer):
             return data
         is_rollout = self.instance.is_rollout
         count = NimbusExperiment.objects.filter(
+            status=NimbusExperiment.Status.LIVE,
             channel=self.instance.channel,
             application=self.instance.application,
             targeting_config_slug=self.instance.targeting_config_slug,
             is_rollout=is_rollout,
         ).count()
 
-        if is_rollout and count > 1:
+        if is_rollout and count > 0:
             self.warnings["bucketing"] = [NimbusConstants.ERROR_BUCKET_EXISTS]
 
         return data

--- a/app/experimenter/experiments/constants.py
+++ b/app/experimenter/experiments/constants.py
@@ -409,6 +409,9 @@ Optional - We believe this outcome will <describe impact> on <core metric>
     ERROR_BRANCH_SWAP = "You are trying to swap branch names. \
         Please choose another name for the branches."
 
+    ERROR_BUCKET_EXISTS = "A rollout already exists for this combination \
+        of rollout, feature, channel, and advanced targeting."
+
     # Analysis can be computed starting the week after enrollment
     # completion for "week 1" of the experiment. However, an extra
     # buffer day is added for Jetstream to compute the results.

--- a/app/experimenter/experiments/constants.py
+++ b/app/experimenter/experiments/constants.py
@@ -409,8 +409,11 @@ Optional - We believe this outcome will <describe impact> on <core metric>
     ERROR_BRANCH_SWAP = "You are trying to swap branch names. \
         Please choose another name for the branches."
 
-    ERROR_BUCKET_EXISTS = "A rollout already exists for this combination \
-        of rollout, feature, channel, and advanced targeting."
+    ERROR_BUCKET_EXISTS = "WARNING: A rollout already exists for this combination \
+        of application, feature, channel, and advanced targeting! \
+        If this rollout is launched, a client meeting the advanced targeting criteria \
+        will be enrolled in one and not the other and \
+        you will not be able to adjust the sizing for this rollout."
 
     # Analysis can be computed starting the week after enrollment
     # completion for "week 1" of the experiment. However, an extra

--- a/app/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_ready_for_review_serializer.py
+++ b/app/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_ready_for_review_serializer.py
@@ -1352,6 +1352,172 @@ class TestNimbusReviewSerializerSingleFeature(TestCase):
             {"reference_branch": {"feature_value": ["This field may not be blank."]}},
         )
 
+    def test_bucket_namespace_warning_for_dupe_rollouts(self):
+        lifecycle = NimbusExperimentFactory.Lifecycles.CREATED
+        desktop = NimbusExperiment.Application.DESKTOP
+        channel = NimbusExperiment.Channel.NIGHTLY
+        targeting_config_slug = NimbusExperiment.TargetingConfig.MAC_ONLY
+        experiment1 = NimbusExperimentFactory.create_with_lifecycle(
+            lifecycle,
+            application=desktop,
+            channel=channel,
+            firefox_min_version=NimbusExperiment.Version.FIREFOX_108,
+            feature_configs=[NimbusFeatureConfigFactory(application=desktop)],
+            is_sticky=False,
+            is_rollout=True,
+            targeting_config_slug=targeting_config_slug,
+        )
+        experiment2 = NimbusExperimentFactory.create_with_lifecycle(
+            lifecycle,
+            application=desktop,
+            channel=channel,
+            firefox_min_version=NimbusExperiment.Version.FIREFOX_108,
+            feature_configs=[NimbusFeatureConfigFactory(application=desktop)],
+            is_sticky=False,
+            is_rollout=True,
+            targeting_config_slug=targeting_config_slug,
+        )
+
+        for branch in experiment1.treatment_branches:
+            branch.delete()
+        for branch in experiment2.treatment_branches:
+            branch.delete()
+
+        experiment1.save()
+        experiment2.save()
+
+        serializer = NimbusReviewSerializer(
+            experiment2,
+            data=NimbusReviewSerializer(
+                experiment2,
+                context={"user": self.user},
+            ).data,
+            partial=True,
+            context={"user": self.user},
+        )
+
+        count = NimbusExperiment.objects.filter(
+            channel=channel,
+            application=desktop,
+            targeting_config_slug=targeting_config_slug,
+            is_rollout=True,
+        ).count()
+
+        self.assertTrue(experiment1.is_rollout and experiment2.is_rollout)
+        self.assertTrue(count > 1)
+        self.assertTrue(serializer.is_valid())
+        self.assertEqual(
+            serializer.warnings["bucketing"],
+            [NimbusConstants.ERROR_BUCKET_EXISTS],
+        )
+
+    def test_bucket_namespace_warning_for_non_dupe_rollouts(self):
+        lifecycle = NimbusExperimentFactory.Lifecycles.CREATED
+        desktop = NimbusExperiment.Application.DESKTOP
+        channel = NimbusExperiment.Channel.NIGHTLY
+        targeting_config_slug = NimbusExperiment.TargetingConfig.MAC_ONLY
+        experiment1 = NimbusExperimentFactory.create_with_lifecycle(
+            lifecycle,
+            application=NimbusExperiment.Application.FENIX,
+            channel=channel,
+            firefox_min_version=NimbusExperiment.Version.FIREFOX_108,
+            feature_configs=[NimbusFeatureConfigFactory(application=desktop)],
+            is_sticky=False,
+            is_rollout=True,
+            targeting_config_slug=targeting_config_slug,
+        )
+        experiment2 = NimbusExperimentFactory.create_with_lifecycle(
+            lifecycle,
+            application=desktop,
+            channel=channel,
+            firefox_min_version=NimbusExperiment.Version.FIREFOX_108,
+            feature_configs=[NimbusFeatureConfigFactory(application=desktop)],
+            is_sticky=False,
+            is_rollout=True,
+            targeting_config_slug=targeting_config_slug,
+        )
+
+        for branch in experiment1.treatment_branches:
+            branch.delete()
+        for branch in experiment2.treatment_branches:
+            branch.delete()
+
+        experiment1.save()
+        experiment2.save()
+
+        serializer = NimbusReviewSerializer(
+            experiment2,
+            data=NimbusReviewSerializer(
+                experiment2,
+                context={"user": self.user},
+            ).data,
+            partial=True,
+            context={"user": self.user},
+        )
+
+        count = NimbusExperiment.objects.filter(
+            channel=channel,
+            application=desktop,
+            targeting_config_slug=targeting_config_slug,
+            is_rollout=True,
+        ).count()
+
+        self.assertTrue(experiment1.is_rollout and experiment2.is_rollout)
+        self.assertTrue(count == 1)
+        self.assertTrue(serializer.is_valid())
+        self.assertEqual(serializer.warnings, {})
+
+    def test_bucket_namespace_warning_for_experiments(self):
+        lifecycle = NimbusExperimentFactory.Lifecycles.CREATED
+        desktop = NimbusExperiment.Application.DESKTOP
+        channel = NimbusExperiment.Channel.NIGHTLY
+        targeting_config_slug = NimbusExperiment.TargetingConfig.MAC_ONLY
+        experiment1 = NimbusExperimentFactory.create_with_lifecycle(
+            lifecycle,
+            application=desktop,
+            channel=channel,
+            firefox_min_version=NimbusExperiment.Version.FIREFOX_108,
+            feature_configs=[NimbusFeatureConfigFactory(application=desktop)],
+            is_sticky=False,
+            is_rollout=False,
+            targeting_config_slug=targeting_config_slug,
+        )
+        experiment2 = NimbusExperimentFactory.create_with_lifecycle(
+            lifecycle,
+            application=desktop,
+            channel=channel,
+            firefox_min_version=NimbusExperiment.Version.FIREFOX_108,
+            feature_configs=[NimbusFeatureConfigFactory(application=desktop)],
+            is_sticky=False,
+            is_rollout=False,
+            targeting_config_slug=targeting_config_slug,
+        )
+
+        experiment1.save()
+        experiment2.save()
+
+        serializer = NimbusReviewSerializer(
+            experiment2,
+            data=NimbusReviewSerializer(
+                experiment2,
+                context={"user": self.user},
+            ).data,
+            partial=True,
+            context={"user": self.user},
+        )
+
+        count = NimbusExperiment.objects.filter(
+            channel=channel,
+            application=desktop,
+            targeting_config_slug=targeting_config_slug,
+            is_rollout=True,
+        ).count()
+
+        self.assertFalse(experiment1.is_rollout and experiment2.is_rollout)
+        self.assertTrue(count == 0)
+        self.assertTrue(serializer.is_valid())
+        self.assertEqual(serializer.warnings, {})
+
 
 class TestNimbusReviewSerializerMultiFeature(TestCase):
     def setUp(self):

--- a/app/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_ready_for_review_serializer.py
+++ b/app/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_ready_for_review_serializer.py
@@ -1466,7 +1466,7 @@ class TestNimbusReviewSerializerSingleFeature(TestCase):
         ).count()
 
         self.assertTrue(experiment1.is_rollout and experiment2.is_rollout)
-        self.assertTrue(count == 1)
+        self.assertTrue(count == 0)
         self.assertTrue(serializer.is_valid())
         self.assertEqual(serializer.warnings, {})
 
@@ -1510,6 +1510,7 @@ class TestNimbusReviewSerializerSingleFeature(TestCase):
         )
 
         count = NimbusExperiment.objects.filter(
+            status=NimbusExperiment.Status.LIVE,
             channel=channel,
             application=desktop,
             targeting_config_slug=targeting_config_slug,


### PR DESCRIPTION
Because...

* We want to warn a user if they are about to launch a rollout that has the same **channel, application, and advanced targeting** as another existing rollout 
* And we only want to warn them, not throw an error

This commit...

* Adds a serializer warning to the NimbusReviewSerializer

<img width="552" alt="image" src="https://user-images.githubusercontent.com/43795363/221939619-4e80d55f-f2cb-4ff4-8de5-6a5573973f99.png">

new message:
<img width="546" alt="image" src="https://user-images.githubusercontent.com/43795363/222234122-ce9fbe47-f3de-4c91-8895-405f72de10bf.png">

---- 
This commit _does not_...
* Add the warning to the summary page. That will be the next PR :D