### PR TITLE
For #8359 feat(nimbus): Show warning on pagesummary when a rollout has dupe bucket

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/PageSummary/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageSummary/index.test.tsx
@@ -24,6 +24,9 @@ import { createMutationMock } from "src/components/Summary/mocks";
 import { CHANGELOG_MESSAGES, SERVER_ERRORS } from "src/lib/constants";
 import { mockExperimentQuery, mockLiveRolloutQuery } from "src/lib/mocks";
 import {
+  NimbusExperimentApplicationEnum,
+  NimbusExperimentChannelEnum,
+  NimbusExperimentFirefoxVersionEnum,
   NimbusExperimentPublishStatusEnum,
   NimbusExperimentStatusEnum,
 } from "src/types/globalTypes";
@@ -706,4 +709,48 @@ describe("PageSummary", () => {
       }
     },
   );
+
+  it("displays a warning for rollouts that will be in the same bucket", async () => {
+    const BUCKET_WARNING =
+      "A rollout already exists for this combination of rollout, ...";
+    const { mock } = mockExperimentQuery("demo-slug", {
+      readyForReview: {
+        ready: true,
+        message: {},
+        warnings: {
+          bucketing: [BUCKET_WARNING],
+        },
+      },
+      isRollout: true,
+      application: NimbusExperimentApplicationEnum.DESKTOP,
+      firefoxMinVersion: NimbusExperimentFirefoxVersionEnum.FIREFOX_106,
+      channel: NimbusExperimentChannelEnum.NIGHTLY,
+      status: NimbusExperimentStatusEnum.DRAFT,
+      targetingConfigSlug: "OH_NO",
+    });
+    render(<Subject mocks={[mock]} />);
+    expect(screen.queryByTestId("bucketing-warning")).toBeInTheDocument();
+  });
+
+  it("displays no duplicate rollout warning for experiments", async () => {
+    const BUCKET_WARNING =
+      "A rollout already exists for this combination of rollout, ...";
+    const { mock } = mockExperimentQuery("demo-slug", {
+      readyForReview: {
+        ready: true,
+        message: {},
+        warnings: {
+          bucketing: [BUCKET_WARNING],
+        },
+      },
+      isRollout: false,
+      application: NimbusExperimentApplicationEnum.DESKTOP,
+      firefoxMinVersion: NimbusExperimentFirefoxVersionEnum.FIREFOX_106,
+      channel: NimbusExperimentChannelEnum.NIGHTLY,
+      status: NimbusExperimentStatusEnum.DRAFT,
+      targetingConfigSlug: "OH_NO",
+    });
+    render(<Subject mocks={[mock]} />);
+    expect(screen.queryByTestId("bucketing-warning")).not.toBeInTheDocument();
+  });
 });

--- a/app/experimenter/nimbus-ui/src/components/PageSummary/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageSummary/index.tsx
@@ -224,7 +224,6 @@ const PageSummary = (props: RouteComponentProps) => {
 
       {experiment.isRollout &&
         (status.draft || status.preview) &&
-        !experiment.isArchived &&
         fieldWarnings.bucketing?.length > 0 && (
           <Alert data-testid="bucketing-warning" variant="danger">
             {fieldWarnings.bucketing as SerializerMessage}

--- a/app/experimenter/nimbus-ui/src/components/PageSummary/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageSummary/index.tsx
@@ -38,6 +38,7 @@ const PageSummary = (props: RouteComponentProps) => {
 
   const [showLaunchToReview, setShowLaunchToReview] = useState(false);
   const { invalidPages, InvalidPagesList } = useReviewCheck(experiment);
+  const { fieldWarnings } = useReviewCheck(experiment);
 
   const status = getStatus(experiment);
 
@@ -220,6 +221,15 @@ const PageSummary = (props: RouteComponentProps) => {
           {submitError}
         </Alert>
       )}
+
+      {experiment.isRollout &&
+        (status.draft || status.preview) &&
+        !experiment.isArchived &&
+        fieldWarnings.bucketing?.length > 0 && (
+          <Alert data-testid="bucketing-warning" variant="danger">
+            {fieldWarnings.bucketing as SerializerMessage}
+          </Alert>
+        )}
 
       {summaryAction && (
         <h5 className="mt-3 mb-4 ml-3">


### PR DESCRIPTION
Because

- We want to warn a user if they are about to launch a rollout that has the same **channel, feature, application, and advanced targeting** as another existing rollout 
- And we only want to warn them, not throw an error

This commit

- Shows the user a warning message before they launch their rollout and meets the following criteria:
   - status is Draft or Preview
   - the experiment is a rollout
   - there is at least one other live rollout existing that has the same channel, feature, application, and advanced targeting 

<img width="810" alt="image" src="https://user-images.githubusercontent.com/43795363/222236748-d732b027-2f4d-4fd0-a44b-e45e7375483c.png">
