### PR TITLE
For #8361 feat(nimbus): End enroll and end experiment buttons appear when dirty

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/Summary/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/index.test.tsx
@@ -76,6 +76,31 @@ describe("Summary", () => {
     await screen.findByText("End Experiment");
   });
 
+  it("renders the end experiment button if dirty", async () => {
+    render(
+      <Subject
+        props={{
+          status: NimbusExperimentStatusEnum.LIVE,
+          publishStatus: NimbusExperimentPublishStatusEnum.DIRTY,
+        }}
+      />,
+    );
+    await screen.findByText("End Experiment");
+  });
+
+  it("renders the end enrollment button if dirty", async () => {
+    render(
+      <Subject
+        props={{
+          status: NimbusExperimentStatusEnum.LIVE,
+          publishStatus: NimbusExperimentPublishStatusEnum.DIRTY,
+          isEnrollmentPaused: false,
+        }}
+      />,
+    );
+    await screen.findByTestId("end-enrollment-start");
+  });
+
   it("renders the cancel review button if the experiment is in review state", async () => {
     render(
       <Subject

--- a/app/experimenter/nimbus-ui/src/components/Summary/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/index.tsx
@@ -83,7 +83,7 @@ const Summary = ({ experiment, refetch }: SummaryProps) => {
             {status.live &&
               !status.approved &&
               !status.review &&
-              status.idle &&
+              (status.idle || status.dirty) &&
               !status.pauseRequested &&
               !experiment.isEnrollmentPaused && (
                 <EndEnrollment
@@ -94,7 +94,7 @@ const Summary = ({ experiment, refetch }: SummaryProps) => {
             {status.live &&
               !status.review &&
               !status.endRequested &&
-              status.idle && (
+              (status.idle || status.dirty) && (
                 <EndExperiment
                   {...{ isLoading, onSubmit: onConfirmEndClicked }}
                 />


### PR DESCRIPTION
Because

- We want live updates to have the option to end enrollment and end experiment when they are Dirty

This commit

- Adds `status.dirty` check to the end enrollment and end experiment buttons

<img width="697" alt="image" src="https://user-images.githubusercontent.com/43795363/222246666-72265d91-8b4a-4aa8-826b-82842fa67b0b.png">

----

This commit _does not_...
* Remove the "cancel" button from the Update actions
* Put the update button down with the end enroll/end exp buttons