### PR TITLE
For #8361 refactor(nimbus): Remove unnecessary cancel button from update form

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/PageSummary/FormUpdateLiveToReview.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageSummary/FormUpdateLiveToReview.tsx
@@ -9,11 +9,9 @@ import Form from "react-bootstrap/Form";
 const FormUpdateLiveToReview = ({
   isLoading,
   onSubmit,
-  onCancel,
 }: {
   isLoading: boolean;
   onSubmit: () => void;
-  onCancel: () => void;
 }) => {
   return (
     <Alert
@@ -34,15 +32,6 @@ const FormUpdateLiveToReview = ({
               onClick={onSubmit}
             >
               Request Update
-            </button>
-            <button
-              data-testid="cancel"
-              type="button"
-              className="btn btn-secondary"
-              disabled={isLoading}
-              onClick={onCancel}
-            >
-              Cancel
             </button>
           </div>
         </div>

--- a/app/experimenter/nimbus-ui/src/components/PageSummary/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageSummary/index.test.tsx
@@ -257,23 +257,6 @@ describe("PageSummary", () => {
     await screen.findByTestId("launch-draft-to-preview");
   });
 
-  it("handles cancelled update Live to Review as expected", async () => {
-    const { mockRollout, rollout } = mockLiveRolloutQuery("demo-slug", {
-      status: NimbusExperimentStatusEnum.LIVE,
-      publishStatus: NimbusExperimentPublishStatusEnum.DIRTY,
-    });
-    const mutationMock = createStatusMutationMock(rollout.id!);
-    render(<Subject mocks={[mockRollout, mutationMock]} />);
-
-    const submitButton = await screen.findByTestId("update-live-to-review");
-    expect(submitButton!).toBeEnabled();
-    await act(async () => void fireEvent.click(submitButton));
-
-    const cancelButton = await screen.findByTestId("cancel");
-    fireEvent.click(cancelButton);
-    await screen.findByTestId("request-live-update-alert");
-  });
-
   it("handles Launch to Preview after reconsidering Launch to Review from Draft", async () => {
     const { mock, experiment } = mockExperimentQuery("demo-slug", {
       status: NimbusExperimentStatusEnum.DRAFT,

--- a/app/experimenter/nimbus-ui/src/components/PageSummary/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageSummary/index.tsx
@@ -291,7 +291,7 @@ const PageSummary = (props: RouteComponentProps) => {
             {...{
               isLoading,
               onSubmit: onUpdateClicked,
-              onCancel: onUpdateReviewRejectedClicked,
+              onCancel: () => {},
             }}
           />
         )}


### PR DESCRIPTION
Because

- We want live updates to have the option to update when they are Dirty
- We don't care about "cancelling" a dirty update 

This commit

- Removes the "cancel" button from the Update actions

<img width="703" alt="image" src="https://user-images.githubusercontent.com/43795363/222255774-130df214-5f92-423c-8a54-ec633f9b834b.png">

----

This commit _does not_...
* Put the update button down with the end enroll/end exp buttons