### PR TITLE
For #8361 feat(nimbus): Put request update button alongside end buttons on Summary

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/PageSummary/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageSummary/index.test.tsx
@@ -225,20 +225,6 @@ describe("PageSummary", () => {
     await launchFromDraftToReview();
   });
 
-  it("handles dirty Live to Review as expected", async () => {
-    const { mockRollout, rollout } = mockLiveRolloutQuery("demo-slug", {
-      status: NimbusExperimentStatusEnum.LIVE,
-      publishStatus: NimbusExperimentPublishStatusEnum.DIRTY,
-    });
-    const mutationMock = createStatusMutationMock(rollout.id!);
-
-    render(<Subject mocks={[mockRollout, mutationMock]} />);
-
-    const submitButton = await screen.findByTestId("update-live-to-review");
-    expect(submitButton!).toBeEnabled();
-    await act(async () => void fireEvent.click(submitButton));
-  });
-
   it("handles cancelled Launch to Review as expected", async () => {
     const { mock, experiment } = mockExperimentQuery("demo-slug", {
       status: NimbusExperimentStatusEnum.DRAFT,

--- a/app/experimenter/nimbus-ui/src/components/PageSummary/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageSummary/index.tsx
@@ -13,7 +13,6 @@ import Head from "src/components/Head";
 import FormLaunchDraftToPreview from "src/components/PageSummary/FormLaunchDraftToPreview";
 import FormLaunchDraftToReview from "src/components/PageSummary/FormLaunchDraftToReview";
 import FormLaunchPreviewToReview from "src/components/PageSummary/FormLaunchPreviewToReview";
-import FormUpdateLiveToReview from "src/components/PageSummary/FormUpdateLiveToReview";
 import Summary from "src/components/Summary";
 import SummaryTimeline from "src/components/Summary/SummaryTimeline";
 import { useChangeOperationMutation, useReviewCheck } from "src/hooks";
@@ -55,7 +54,6 @@ const PageSummary = (props: RouteComponentProps) => {
       onEndReviewRejectedClicked,
       onPauseReviewApprovedClicked,
       onPauseReviewRejectedClicked,
-      onUpdateClicked,
       onUpdateReviewApprovedClicked,
       onUpdateReviewRejectedClicked,
     ],
@@ -110,12 +108,6 @@ const PageSummary = (props: RouteComponentProps) => {
       statusNext: null,
       isEnrollmentPaused: false,
       publishStatus: NimbusExperimentPublishStatusEnum.IDLE,
-    },
-    {
-      status: NimbusExperimentStatusEnum.LIVE,
-      statusNext: NimbusExperimentStatusEnum.LIVE,
-      publishStatus: NimbusExperimentPublishStatusEnum.REVIEW,
-      changelogMessage: CHANGELOG_MESSAGES.REQUESTED_REVIEW_UPDATE,
     },
     {
       status: NimbusExperimentStatusEnum.LIVE,
@@ -282,16 +274,6 @@ const PageSummary = (props: RouteComponentProps) => {
               isLoading,
               onSubmit: onLaunchClicked,
               onBackToDraft: onBackToDraftClicked,
-            }}
-          />
-        )}
-
-        {status.live && status.dirty && (
-          <FormUpdateLiveToReview
-            {...{
-              isLoading,
-              onSubmit: onUpdateClicked,
-              onCancel: () => {},
             }}
           />
         )}

--- a/app/experimenter/nimbus-ui/src/components/Summary/RequestLiveUpdate.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/RequestLiveUpdate.tsx
@@ -6,7 +6,7 @@ import React from "react";
 import Alert from "react-bootstrap/Alert";
 import Form from "react-bootstrap/Form";
 
-const FormUpdateLiveToReview = ({
+const RequestLiveUpdate = ({
   isLoading,
   onSubmit,
 }: {
@@ -40,4 +40,4 @@ const FormUpdateLiveToReview = ({
   );
 };
 
-export default FormUpdateLiveToReview;
+export default RequestLiveUpdate;

--- a/app/experimenter/nimbus-ui/src/components/Summary/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/index.test.tsx
@@ -350,4 +350,38 @@ describe("Summary", () => {
     expect(requestUpdateButton).toBeEnabled();
     await act(async () => void fireEvent.click(requestUpdateButton));
   });
+
+  it("shows update and end buttons for live dirty rollout", async () => {
+    const { mockRollout, rollout } = mockLiveRolloutQuery("demo-slug", {
+      status: NimbusExperimentStatusEnum.LIVE,
+      publishStatus: NimbusExperimentPublishStatusEnum.DIRTY,
+      statusNext: null,
+    });
+
+    const mutationMock = createMutationMock(
+      rollout.id!,
+      NimbusExperimentPublishStatusEnum.DIRTY,
+      {
+        changelogMessage: CHANGELOG_MESSAGES.REQUESTED_REVIEW_UPDATE,
+        statusNext: null,
+        publishStatus: NimbusExperimentPublishStatusEnum.DIRTY,
+        status: NimbusExperimentStatusEnum.LIVE,
+      },
+    );
+    render(<Subject props={rollout} mocks={[mockRollout, mutationMock]} />);
+    const requestUpdateButton = await screen.findByTestId(
+      "request-live-update-alert",
+    );
+    const endExperimentButton = await screen.findByTestId(
+      "end-experiment-start",
+    );
+    const endEnrollmentButton = await screen.findByTestId(
+      "end-enrollment-start",
+    );
+    await waitFor(() => {
+      expect(requestUpdateButton).toBeInTheDocument();
+      expect(endEnrollmentButton).toBeInTheDocument();
+      expect(endExperimentButton).toBeInTheDocument();
+    });
+  });
 });

--- a/app/experimenter/nimbus-ui/src/components/Summary/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/index.test.tsx
@@ -2,11 +2,17 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import React from "react";
 import { createMutationMock, Subject } from "src/components/Summary/mocks";
 import { CHANGELOG_MESSAGES, SUBMIT_ERROR } from "src/lib/constants";
-import { mockExperimentQuery } from "src/lib/mocks";
+import { mockExperimentQuery, mockLiveRolloutQuery } from "src/lib/mocks";
 import {
   NimbusExperimentPublishStatusEnum,
   NimbusExperimentStatusEnum,
@@ -317,5 +323,31 @@ describe("Summary", () => {
       const errorContainer = await screen.findByTestId("submit-error");
       expect(errorContainer).toHaveTextContent(errorMessage);
     });
+  });
+
+  it("handles dirty Live to Review as expected", async () => {
+    const { mockRollout, rollout } = mockLiveRolloutQuery("demo-slug", {
+      status: NimbusExperimentStatusEnum.LIVE,
+      publishStatus: NimbusExperimentPublishStatusEnum.DIRTY,
+      statusNext: null,
+    });
+
+    const mutationMock = createMutationMock(
+      rollout.id!,
+      NimbusExperimentPublishStatusEnum.DIRTY,
+      {
+        changelogMessage: CHANGELOG_MESSAGES.REQUESTED_REVIEW_UPDATE,
+        statusNext: null,
+        publishStatus: NimbusExperimentPublishStatusEnum.DIRTY,
+        status: NimbusExperimentStatusEnum.LIVE,
+      },
+    );
+    render(<Subject props={rollout} mocks={[mockRollout, mutationMock]} />);
+
+    const requestUpdateButton = await screen.findByTestId(
+      "request-live-update-alert",
+    );
+    expect(requestUpdateButton).toBeEnabled();
+    await act(async () => void fireEvent.click(requestUpdateButton));
   });
 });

--- a/app/experimenter/nimbus-ui/src/components/Summary/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/index.tsx
@@ -12,6 +12,7 @@ import PreviewURL from "src/components/PreviewURL";
 import CancelReview from "src/components/Summary/CancelReview";
 import EndEnrollment from "src/components/Summary/EndEnrollment";
 import EndExperiment from "src/components/Summary/EndExperiment";
+import RequestLiveUpdate from "src/components/Summary/RequestLiveUpdate";
 import TableAudience from "src/components/Summary/TableAudience";
 import TableBranches from "src/components/Summary/TableBranches";
 import TableOverview from "src/components/Summary/TableOverview";
@@ -41,6 +42,7 @@ const Summary = ({ experiment, refetch }: SummaryProps) => {
       onConfirmEndClicked,
       onConfirmEndEnrollmentClicked,
       onConfirmCancelReviewClicked,
+      onRequestUpdateClicked,
     ],
   } = useChangeOperationMutation(
     experiment,
@@ -67,6 +69,12 @@ const Summary = ({ experiment, refetch }: SummaryProps) => {
           : null,
       isEnrollmentPaused: false,
     },
+    {
+      publishStatus: NimbusExperimentPublishStatusEnum.REVIEW,
+      status: NimbusExperimentStatusEnum.LIVE,
+      statusNext: NimbusExperimentStatusEnum.LIVE,
+      changelogMessage: CHANGELOG_MESSAGES.REQUESTED_REVIEW_UPDATE,
+    },
   );
 
   return (
@@ -76,6 +84,13 @@ const Summary = ({ experiment, refetch }: SummaryProps) => {
           {submitError}
         </Alert>
       )}
+
+      {status.dirty && (
+        <RequestLiveUpdate
+          {...{ isLoading, onSubmit: onRequestUpdateClicked }}
+        />
+      )}
+
       {!status.complete && (
         <Card className="border-left-0 border-right-0 border-bottom-0">
           <Card.Header as="h5">Actions</Card.Header>

--- a/app/experimenter/nimbus-ui/src/lib/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/lib/mocks.tsx
@@ -645,17 +645,6 @@ export const MOCK_LIVE_ROLLOUT: Partial<getExperiment["experimentBySlug"]> = {
   targetingConfig: [MOCK_CONFIG.targetingConfigs![0]],
   isSticky: false,
   isFirstRun: false,
-  treatmentBranches: [
-    {
-      id: 456,
-      name: "Managed zero baby projection",
-      slug: "treatment",
-      description: "Next ask then he in degree order.",
-      ratio: 1,
-      featureValue: '{"effect-effect-whole": "close-teach-exactly"}',
-      screenshots: [],
-    },
-  ],
   primaryOutcomes: ["picture_in_picture", "feature_c", "feature_nodata"],
   secondaryOutcomes: ["feature_b", "feature_d"],
   channel: NimbusExperimentChannelEnum.NIGHTLY,
@@ -688,7 +677,7 @@ export const MOCK_LIVE_ROLLOUT: Partial<getExperiment["experimentBySlug"]> = {
       link: "https://bingo.bongo",
     },
   ],
-  isEnrollmentPaused: true,
+  isEnrollmentPaused: false,
   enrollmentEndDate: null,
   recipeJson:
     '{"schemaVersion": "1.5.0", "slug": "pre-emptive-zero-tolerance-data-warehouse", "id": "pre-emptive-zero-tolerance-data-warehouse", "arguments": {}, "application": "", "appName": "firefox_ios", "appId": "", "channel": "", "userFacingName": "Pre-emptive zero tolerance data-warehouse", "userFacingDescription": "Analysis art mean sort serve stuff. Scene alone current television up write company. Without admit she occur total generation by mother. Environmental remember account huge drive policy play strong.", "isEnrollmentPaused": false, "bucketConfig": null, "probeSets": [], "outcomes": [{"slug": "example_config", "priority": "primary"}, {"slug": "newtab_visibility", "priority": "primary"}, {"slug": "picture_in_picture", "priority": "secondary"}], "branches": [{"slug": "horizontal-well-modulated-conglomeration", "ratio": 1, "feature": {"featureId": "decentralized-solution-oriented-neural-net", "enabled": true, "value": {"trouble-left-back": "west-receive"}}}, {"slug": "fully-configurable-context-sensitive-local-area-network", "ratio": 1, "feature": {"featureId": "decentralized-solution-oriented-neural-net", "enabled": true, "value": {"financial-school": "peace-light-might"}}}], "targeting": "localeLanguageCode == \'en\' && ((isFirstStartup && !(\'trailhead.firstrun.didSeeAboutWelcome\'|preferenceValue)) || experiment.slug in activeExperiments)", "startDate": null, "endDate": null, "proposedDuration": 60, "proposedEnrollment": 45, "referenceBranch": "horizontal-well-modulated-conglomeration", "featureIds": ["decentralized-solution-oriented-neural-net"]}',


### PR DESCRIPTION
Because

- We want the "Request update" buttons to appear in the same place as "request launch"
- And we want the end experiment and end enrollment buttons to still be available under "Actions"

This commit

- Moves the "Request update" button from PageSummary →  Summary
   - ~This puts the Update button in the same place that the Launch button is for drafts (see screenshots)~
   - Put the Update button in the Actions section next to end enrollment and end experiment
- Moves tests from PageSummary -> Summary
- Renames the "Request update" from `FormUpdateLiveToReview` → `RequestLiveUpdate`
- Removes `treatmentBranches` and `enrollmentPaused=true` from the test mock for Live Rollouts (this was an oversight)

----

Note: the position of "update" is the same as "launch" buttons for Drafts (above the "actions" section in the grey box)

<img width="1156" alt="image" src="https://user-images.githubusercontent.com/43795363/222268459-984fcb10-60e9-4272-86a1-d170503fed09.png">

vs Draft: 

<img width="1131" alt="image" src="https://user-images.githubusercontent.com/43795363/222268560-c36ace65-fbed-4eb7-8cae-e5b8392d870e.png">
