### PR TITLE
For #8361 feat(nimbus): Add changelog message for request update rejection

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/PageSummary/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageSummary/index.tsx
@@ -127,6 +127,7 @@ const PageSummary = (props: RouteComponentProps) => {
       status: NimbusExperimentStatusEnum.LIVE,
       statusNext: null,
       publishStatus: NimbusExperimentPublishStatusEnum.DIRTY,
+      changelogMessage: CHANGELOG_MESSAGES.RETURNED_TO_LIVE,
     },
   );
 

--- a/app/experimenter/nimbus-ui/src/lib/constants.ts
+++ b/app/experimenter/nimbus-ui/src/lib/constants.ts
@@ -119,6 +119,7 @@ export const CHANGELOG_MESSAGES = {
   UPDATED_OVERVIEW: "Updated Overview",
   LAUNCHED_TO_PREVIEW: "Launched to Preview",
   RETURNED_TO_DRAFT: "Returned to Draft Status",
+  RETURNED_TO_LIVE: "Returned to Live Dirty Status",
   REQUESTED_REVIEW: "Review Requested for Launch",
   REVIEW_APPROVED: "Launch Review Approved",
   REQUESTED_REVIEW_UPDATE: "Review Requested for Update",


### PR DESCRIPTION
Because

- We want to show a changelog message when a requested update is rejected in Experimenter

This commit

- Adds the changelog message
