### PR TITLE
fix #8372 feat(nimbus): add changelogs to v5 api

### DIFF
--- a/app/experimenter/experiments/api/v5/types.py
+++ b/app/experimenter/experiments/api/v5/types.py
@@ -245,10 +245,21 @@ class NimbusReviewType(graphene.ObjectType):
 class NimbusChangeLogType(DjangoObjectType):
     old_status = NimbusExperimentStatusEnum()
     old_status_next = NimbusExperimentStatusEnum()
+    new_status = NimbusExperimentStatusEnum()
+    new_status_next = NimbusExperimentStatusEnum()
 
     class Meta:
         model = NimbusChangeLog
-        fields = ("changed_on", "changed_by", "message", "old_status", "old_status_next")
+        fields = (
+            "changed_by",
+            "changed_on",
+            "experiment_data",
+            "message",
+            "new_status_next",
+            "new_status",
+            "old_status_next",
+            "old_status",
+        )
 
 
 class NimbusSignoffRecommendationsType(graphene.ObjectType):
@@ -419,6 +430,7 @@ class NimbusExperimentType(DjangoObjectType):
     can_archive = graphene.Boolean()
     can_edit = graphene.Boolean()
     can_review = graphene.Boolean()
+    changes = graphene.List(NimbusChangeLogType)
     channel = NimbusExperimentChannelEnum()
     computed_duration_days = graphene.Int()
     computed_end_date = graphene.DateTime()
@@ -481,6 +493,7 @@ class NimbusExperimentType(DjangoObjectType):
             "can_archive",
             "can_edit",
             "can_review",
+            "changes",
             "channel",
             "computed_duration_days",
             "computed_end_date",
@@ -651,3 +664,6 @@ class NimbusExperimentType(DjangoObjectType):
 
     def resolve_languages(self, info):
         return self.languages.all().order_by("name")
+
+    def resolve_changes(self, info):
+        return self.changes.all().order_by("changed_on")

--- a/app/experimenter/nimbus-ui/schema.graphql
+++ b/app/experimenter/nimbus-ui/schema.graphql
@@ -50,6 +50,7 @@ type NimbusExperimentType {
   isFirstRun: Boolean!
   preventPrefConflicts: Boolean
   documentationLinks: [NimbusDocumentationLinkType!]
+  changes: [NimbusChangeLogType]
   canArchive: Boolean
   canEdit: Boolean
   canReview: Boolean
@@ -326,12 +327,31 @@ enum NimbusExperimentDocumentationLinkEnum {
   ENG_TICKET
 }
 
+type NimbusChangeLogType {
+  changedOn: DateTime!
+  changedBy: NimbusUserType!
+  oldStatus: NimbusExperimentStatusEnum
+  oldStatusNext: NimbusExperimentStatusEnum
+  newStatus: NimbusExperimentStatusEnum
+  newStatusNext: NimbusExperimentStatusEnum
+  message: String
+  experimentData: JSONString
+}
+
 """
 The `DateTime` scalar type represents a DateTime
 value as specified by
 [iso8601](https://en.wikipedia.org/wiki/ISO_8601).
 """
 scalar DateTime
+
+"""
+Allows use of a JSON String for input / output from the GraphQL schema.
+
+Use of this type is *not recommended* as you lose the benefits of having a defined, static
+schema (one of the key benefits of GraphQL).
+"""
+scalar JSONString
 
 type NimbusReviewType {
   message: ObjectField
@@ -341,14 +361,6 @@ type NimbusReviewType {
 
 """Utilized to serialize out Serializer errors"""
 scalar ObjectField
-
-type NimbusChangeLogType {
-  changedOn: DateTime!
-  changedBy: NimbusUserType!
-  oldStatus: NimbusExperimentStatusEnum
-  oldStatusNext: NimbusExperimentStatusEnum
-  message: String
-}
 
 type NimbusSignoffRecommendationsType {
   qaSignoff: Boolean


### PR DESCRIPTION
Because

* We do not currently expose the changelogs in the UI anywhere
* The only way to inspect them presently is through the admin
* They can provide helpful information for inspecting and testing and debugging experiments
* There should be a way to inspect them without needing admin access
* They can contain confidential information and so they should still be behind an auth gateway

This commit
* Adds all experiment changelogs to the V5 API
* This allows them to be inspected via the graphql web ui
* The V5 API is behind the auth gate

