### PR TITLE
For #7823 feat(nimbus): Enable population percent and save buttons for live rollouts

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/index.test.tsx
@@ -14,6 +14,7 @@ import React from "react";
 import { filterAndSortTargetingConfigs } from "src/components/PageEditAudience/FormAudience";
 import {
   MOCK_EXPERIMENT,
+  MOCK_ROLLOUT,
   Subject,
 } from "src/components/PageEditAudience/FormAudience/mocks";
 import { snakeToCamelCase } from "src/lib/caseConversions";
@@ -1231,41 +1232,7 @@ describe("FormAudience", () => {
   });
 });
 
-it("disables fields when locked", async () => {
-  render(
-    <Subject
-      experiment={{
-        ...MOCK_EXPERIMENT,
-        application: NimbusExperimentApplicationEnum.FENIX,
-        isRollout: true,
-        status: NimbusExperimentStatusEnum.LIVE,
-        targetingConfig: [
-          {
-            label: "No Targeting",
-            value: "",
-            applicationValues: [
-              NimbusExperimentApplicationEnum.DESKTOP,
-              "TOASTER",
-            ],
-            description: "No targeting configuration",
-            stickyRequired: false,
-            isFirstRunRequired: false,
-          },
-        ],
-      }}
-    />,
-  );
-  // testing one checkbox, one dropdown, and one text field
-  expect(screen.getByTestId("isSticky")).toBeDisabled();
-  expect(screen.getByTestId("firefoxMinVersion")).toBeDisabled();
-  expect(
-    within(
-      screen.queryByTestId("population-percent-top-row") as HTMLElement,
-    ).getByTestId("population-percent-text"),
-  ).toBeDisabled();
-});
-
-it("enables fields when unlocked", async () => {
+it("fields should be enabled for draft experiments", async () => {
   render(
     <Subject
       experiment={{
@@ -1289,14 +1256,91 @@ it("enables fields when unlocked", async () => {
       }}
     />,
   );
-  // testing one checkbox, one dropdown, and one text field
   expect(screen.getByTestId("isSticky")).toBeEnabled();
   expect(screen.getByTestId("firefoxMinVersion")).toBeEnabled();
+  expect(screen.getByTestId("channel")).toBeEnabled();
+});
+
+it("enables fields and buttons for live rollouts", async () => {
+  render(
+    <Subject
+      experiment={{
+        ...MOCK_ROLLOUT,
+        application: NimbusExperimentApplicationEnum.FENIX,
+        isRollout: true,
+        status: NimbusExperimentStatusEnum.LIVE,
+        targetingConfig: [
+          {
+            label: "No Targeting",
+            value: "",
+            applicationValues: [
+              NimbusExperimentApplicationEnum.DESKTOP,
+              "TOASTER",
+            ],
+            description: "No targeting configuration",
+            stickyRequired: false,
+            isFirstRunRequired: false,
+          },
+        ],
+      }}
+    />,
+  );
+  expect(screen.getByTestId("submit-button")).toBeEnabled();
+  expect(screen.getByTestId("next-button")).toBeEnabled();
   expect(
     within(
       screen.queryByTestId("population-percent-top-row") as HTMLElement,
     ).getByTestId("population-percent-text"),
   ).toBeEnabled();
+  expect(
+    within(
+      screen.queryByTestId("population-percent-top-row") as HTMLElement,
+    ).getByTestId("population-percent-slider"),
+  ).toBeEnabled();
+  expect(screen.getByTestId("isSticky")).toBeDisabled();
+  expect(screen.getByTestId("firefoxMinVersion")).toBeDisabled();
+  expect(screen.getByTestId("channel")).toBeDisabled();
+});
+
+it("disables fields and buttons for live experiments", async () => {
+  render(
+    <Subject
+      experiment={{
+        ...MOCK_EXPERIMENT,
+        application: NimbusExperimentApplicationEnum.FENIX,
+        isRollout: false,
+        status: NimbusExperimentStatusEnum.LIVE,
+        targetingConfig: [
+          {
+            label: "No Targeting",
+            value: "",
+            applicationValues: [
+              NimbusExperimentApplicationEnum.DESKTOP,
+              "TOASTER",
+            ],
+            description: "No targeting configuration",
+            stickyRequired: false,
+            isFirstRunRequired: false,
+          },
+        ],
+      }}
+    />,
+  );
+  expect(screen.getByTestId("submit-button")).toBeDisabled();
+  expect(screen.getByTestId("next-button")).toBeDisabled();
+  expect(
+    within(
+      screen.queryByTestId("population-percent-top-row") as HTMLElement,
+    ).getByTestId("population-percent-text"),
+  ).toBeDisabled();
+  expect(
+    within(
+      screen.queryByTestId("population-percent-top-row") as HTMLElement,
+    ).getByTestId("population-percent-slider"),
+  ).toBeDisabled();
+  expect(screen.getByTestId("isSticky")).toBeDisabled();
+  expect(screen.getByTestId("firefoxMinVersion")).toBeDisabled();
+  expect(screen.getByTestId("channel")).toBeDisabled();
 });
 
 describe("filterAndSortTargetingConfigSlug", () => {

--- a/app/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/index.tsx
@@ -397,7 +397,7 @@ export const FormAudience = ({
                 value={populationPercent}
                 onChange={(e) => setPopulationPercent(e.target.value)}
                 data-testid="population-percent-slider"
-                disabled={isLocked!}
+                disabled={isLocked! && !isLiveRollout}
               />
               <Form.Control
                 aria-describedby="populationPercent-unit"
@@ -405,7 +405,7 @@ export const FormAudience = ({
                 value={populationPercent}
                 onChange={(e) => setPopulationPercent(e.target.value)}
                 data-testid="population-percent-text"
-                disabled={isLocked!}
+                disabled={isLocked! && !isLiveRollout}
               />
               <InputGroup.Append>
                 <InputGroup.Text id="populationPercent-unit">%</InputGroup.Text>
@@ -499,7 +499,7 @@ export const FormAudience = ({
             onClick={handleSaveNext}
             className="btn btn-secondary"
             id="save-and-continue-button"
-            disabled={isLoading || isLocked!}
+            disabled={isLoading || (isLocked! && !isLiveRollout)}
             data-testid="next-button"
             data-sb-kind="pages/Summary"
           >
@@ -513,7 +513,7 @@ export const FormAudience = ({
             onClick={handleSave}
             className="btn btn-primary"
             id="save-button"
-            disabled={isLoading || isLocked!}
+            disabled={isLoading || (isLocked! && !isLiveRollout)}
             data-sb-kind="pages/EditOverview"
           >
             <span>{isLoading ? "Saving" : "Save"}</span>

--- a/app/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/mocks.tsx
+++ b/app/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/mocks.tsx
@@ -4,7 +4,7 @@
 
 import React, { useState } from "react";
 import { FormAudience } from "src/components/PageEditAudience/FormAudience";
-import { MockedCache, mockExperimentQuery, MOCK_CONFIG } from "src/lib/mocks";
+import { MockedCache, mockExperimentQuery, mockLiveRolloutQuery, MOCK_CONFIG } from "src/lib/mocks";
 import { getConfig_nimbusConfig } from "src/types/getConfig";
 
 export const Subject = ({
@@ -38,3 +38,4 @@ export const Subject = ({
 };
 
 export const MOCK_EXPERIMENT = mockExperimentQuery("demo-slug").experiment;
+export const MOCK_ROLLOUT = mockLiveRolloutQuery("demo-slug").rollout;


### PR DESCRIPTION
Because

- We want to allow users to edit the population percentages for live rollouts

This commit

- Enables population percent for live rollouts

<img width="1341" alt="image" src="https://user-images.githubusercontent.com/43795363/222550966-0270257f-af5a-4631-a6ef-d0b231e8771a.png">

----
This commit _does not_...
- Add an integration test. This will be next in #8378 🎉 
