### PR TITLE
For #8421 feat(nimbus): Don't show end enrollment button for live rollouts

### DIFF
--- a/app/experimenter/nimbus-ui/src/components/Summary/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/index.test.tsx
@@ -379,6 +379,29 @@ describe("Summary", () => {
     await waitFor(() => {
       expect(requestUpdateButton).toBeInTheDocument();
       expect(endExperimentButton).toBeInTheDocument();
+    });
+  });
+
+  it("do not show end enrollment button for live dirty rollout", async () => {
+    const { mockRollout, rollout } = mockLiveRolloutQuery("demo-slug", {
+      status: NimbusExperimentStatusEnum.LIVE,
+      publishStatus: NimbusExperimentPublishStatusEnum.DIRTY,
+      statusNext: null,
+      isEnrollmentPaused: false,
+    });
+
+    const mutationMock = createMutationMock(
+      rollout.id!,
+      NimbusExperimentPublishStatusEnum.DIRTY,
+      {
+        changelogMessage: CHANGELOG_MESSAGES.REQUESTED_REVIEW_UPDATE,
+        statusNext: null,
+        publishStatus: NimbusExperimentPublishStatusEnum.DIRTY,
+        status: NimbusExperimentStatusEnum.LIVE,
+      },
+    );
+    render(<Subject props={rollout} mocks={[mockRollout, mutationMock]} />);
+    await waitFor(() => {
       expect(
         screen.queryByTestId("end-enrollment-start"),
       ).not.toBeInTheDocument();

--- a/app/experimenter/nimbus-ui/src/components/Summary/index.test.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/index.test.tsx
@@ -351,7 +351,7 @@ describe("Summary", () => {
     await act(async () => void fireEvent.click(requestUpdateButton));
   });
 
-  it("shows update and end buttons for live dirty rollout", async () => {
+  it("shows update and end experiment button for live dirty rollout", async () => {
     const { mockRollout, rollout } = mockLiveRolloutQuery("demo-slug", {
       status: NimbusExperimentStatusEnum.LIVE,
       publishStatus: NimbusExperimentPublishStatusEnum.DIRTY,
@@ -376,13 +376,12 @@ describe("Summary", () => {
     const endExperimentButton = await screen.findByTestId(
       "end-experiment-start",
     );
-    const endEnrollmentButton = await screen.findByTestId(
-      "end-enrollment-start",
-    );
     await waitFor(() => {
       expect(requestUpdateButton).toBeInTheDocument();
-      expect(endEnrollmentButton).toBeInTheDocument();
       expect(endExperimentButton).toBeInTheDocument();
+      expect(
+        screen.queryByTestId("end-enrollment-start"),
+      ).not.toBeInTheDocument();
     });
   });
 });

--- a/app/experimenter/nimbus-ui/src/components/Summary/index.tsx
+++ b/app/experimenter/nimbus-ui/src/components/Summary/index.tsx
@@ -100,7 +100,8 @@ const Summary = ({ experiment, refetch }: SummaryProps) => {
               !status.review &&
               (status.idle || status.dirty) &&
               !status.pauseRequested &&
-              !experiment.isEnrollmentPaused && (
+              !experiment.isEnrollmentPaused &&
+              !experiment.isRollout && (
                 <EndEnrollment
                   {...{ isLoading, onSubmit: onConfirmEndEnrollmentClicked }}
                 />


### PR DESCRIPTION
Because

- Ending enrollment is at odds with updating live rollouts

This commit

- Removes the "End Enrollment" button for live rollouts
