### PR TITLE
For #8416 feat(nimbus): Show the unpublished changes status pill when a live rollout is being approved

### DIFF
--- a/experimenter/experimenter/nimbus-ui/src/components/PageSummary/index.test.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageSummary/index.test.tsx
@@ -96,6 +96,7 @@ describe("PageSummary", () => {
     render(<Subject mocks={[mock]} />);
     await screen.findByText("Cancel Review");
   });
+
   it("verify cancel review doesn't change enrollment days", async () => {
     const { mock, experiment } = mockExperimentQuery("demo-slug", {
       status: NimbusExperimentStatusEnum.LIVE,
@@ -614,40 +615,22 @@ describe("PageSummary", () => {
 
   it.each([
     [
-      true,
       NimbusExperimentStatusEnum.LIVE,
+      null,
       NimbusExperimentPublishStatusEnum.DIRTY,
       NimbusExperimentPublishStatusEnum.DIRTY,
     ],
     [
-      true,
+      NimbusExperimentStatusEnum.LIVE,
       NimbusExperimentStatusEnum.LIVE,
       NimbusExperimentPublishStatusEnum.DIRTY,
       NimbusExperimentPublishStatusEnum.REVIEW,
     ],
-    [
-      true,
-      NimbusExperimentStatusEnum.LIVE,
-      NimbusExperimentPublishStatusEnum.DIRTY,
-      NimbusExperimentPublishStatusEnum.WAITING,
-    ],
-    [
-      false,
-      NimbusExperimentStatusEnum.LIVE,
-      NimbusExperimentPublishStatusEnum.IDLE,
-      NimbusExperimentPublishStatusEnum.IDLE,
-    ],
-    [
-      false,
-      NimbusExperimentStatusEnum.DRAFT,
-      NimbusExperimentPublishStatusEnum.IDLE,
-      NimbusExperimentPublishStatusEnum.IDLE,
-    ],
   ])(
-    "renders unpublished changes status pill when dirty",
+    "renders unpublished changes status pill when live update",
     async (
-      shouldShowPill: boolean,
       status: NimbusExperimentStatusEnum,
+      statusNext: NimbusExperimentStatusEnum | null,
       publishStatus: NimbusExperimentPublishStatusEnum,
       mutationPublishStatus: NimbusExperimentPublishStatusEnum,
     ) => {
@@ -661,21 +644,104 @@ describe("PageSummary", () => {
       const mutationMock = createFullStatusMutationMock(
         rollout.id!,
         status,
-        null,
+        statusNext,
         mutationPublishStatus,
         CHANGELOG_MESSAGES.REQUESTED_REVIEW,
       );
       render(<Subject mocks={[mockRollout, mutationMock]} />);
 
-      if (shouldShowPill) {
-        expect(
-          screen.queryByTestId("pill-dirty-unpublished"),
-        ).toBeInTheDocument();
-      } else {
-        expect(
-          screen.queryByTestId("pill-dirty-unpublished"),
-        ).not.toBeInTheDocument();
-      }
+      expect(
+        screen.queryByTestId("pill-dirty-unpublished"),
+      ).toBeInTheDocument();
+    },
+  );
+
+  it.each([
+    [
+      NimbusExperimentStatusEnum.LIVE,
+      NimbusExperimentPublishStatusEnum.REVIEW,
+      NimbusExperimentPublishStatusEnum.APPROVED,
+    ],
+    [
+      NimbusExperimentStatusEnum.LIVE,
+      NimbusExperimentPublishStatusEnum.APPROVED,
+      NimbusExperimentPublishStatusEnum.WAITING,
+    ],
+  ])(
+    "renders unpublished changes status pill when live update reviews",
+    async (
+      liveStatus: NimbusExperimentStatusEnum,
+      publishStatus: NimbusExperimentPublishStatusEnum,
+      mutationPublishStatus: NimbusExperimentPublishStatusEnum,
+    ) => {
+      const { mockRollout, rollout } = mockLiveRolloutQuery("demo-slug", {
+        status: liveStatus,
+        publishStatus: publishStatus,
+        statusNext: liveStatus,
+        isRollout: true,
+        isEnrollmentPaused: false,
+      });
+      const mutationMock = createFullStatusMutationMock(
+        rollout.id!,
+        liveStatus,
+        liveStatus,
+        mutationPublishStatus,
+        CHANGELOG_MESSAGES.REQUESTED_REVIEW,
+      );
+      render(<Subject mocks={[mockRollout, mutationMock]} />);
+
+      expect(
+        screen.queryByTestId("pill-dirty-unpublished"),
+      ).toBeInTheDocument();
+    },
+  );
+
+  it.each([
+    [
+      NimbusExperimentStatusEnum.DRAFT,
+      NimbusExperimentStatusEnum.LIVE,
+      NimbusExperimentPublishStatusEnum.REVIEW,
+      NimbusExperimentPublishStatusEnum.APPROVED,
+    ],
+    [
+      NimbusExperimentStatusEnum.DRAFT,
+      null,
+      NimbusExperimentPublishStatusEnum.IDLE,
+      NimbusExperimentPublishStatusEnum.IDLE,
+    ],
+    [
+      NimbusExperimentStatusEnum.LIVE,
+      null,
+      NimbusExperimentPublishStatusEnum.IDLE,
+      NimbusExperimentPublishStatusEnum.IDLE,
+    ],
+  ])(
+    "does not render unpublished changes status pill when not live update",
+    async (
+      status: NimbusExperimentStatusEnum,
+      statusNext: NimbusExperimentStatusEnum | null,
+      publishStatus: NimbusExperimentPublishStatusEnum,
+      mutationPublishStatus: NimbusExperimentPublishStatusEnum,
+    ) => {
+      const { mock, experiment } = mockExperimentQuery("demo-slug", {
+        status: status,
+        publishStatus: publishStatus,
+        statusNext: null,
+        isRollout: false,
+        isEnrollmentPaused: false,
+      });
+      const mutationMock = createFullStatusMutationMock(
+        experiment.id!,
+        status,
+        statusNext,
+        mutationPublishStatus,
+        CHANGELOG_MESSAGES.REQUESTED_REVIEW,
+      );
+      render(<Subject mocks={[mock, mutationMock]} />);
+
+      expect(
+        screen.queryByTestId("pill-dirty-unpublished"),
+      ).not.toBeInTheDocument();
     },
   );
 

--- a/experimenter/experimenter/nimbus-ui/src/components/PageSummary/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageSummary/index.tsx
@@ -309,6 +309,7 @@ const StatusPills = ({
     )}
     {(status.dirty ||
       status.updateRequested ||
+      status.updateRequestedApproved ||
       status.updateRequestedWaiting) && (
       <StatusPill
         testId="pill-dirty-unpublished"


### PR DESCRIPTION
Because

- We want to show the "Unpublished changes" status pill all through the review until it is live again (for updates to live rollouts)

This commit

- Adds a check for approval--in addition to the existing checks for dirty and waiting--when we are deciding to show the "Unpublished changes" status pill on the summary page
- Breaks up the tests into three parameterized ones (for brevity):
   - Tests for Dirty and for Dirty -> Review
   - Tests for Approve and Waiting -- I broke these out since they needed different starting parameters and it would have been too confusing/verbose to add to the original test 
   - Tests for non-live updates (which shouldn't show the pill)


<img width="2027" alt="image" src="https://user-images.githubusercontent.com/43795363/223587008-2c5eb2ee-f25d-4a48-9e90-4edab73b3f90.png">

