### PR TITLE
refactor #8429 type(nimbus): add learn more link for rollouts checkbox

### DIFF
--- a/experimenter/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/index.tsx
@@ -298,7 +298,14 @@ export const FormBranches = ({
               type="checkbox"
               isInvalid={!!fieldMessages?.is_rollout}
               feedback={fieldMessages?.is_rollout}
-              label="This is a rollout (single branch)"
+              label={
+                <>
+                  This is a rollout (single branch). <a href="https://experimenter.info/deep-dives/experimenter/rollouts"
+                    target="_blank" rel="noopener noreferrer">
+                    Learn more
+                  </a>
+                </>
+              }
             />
           </Form.Group>
         </Form.Row>

--- a/experimenter/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/index.tsx
@@ -300,8 +300,12 @@ export const FormBranches = ({
               feedback={fieldMessages?.is_rollout}
               label={
                 <>
-                  This is a rollout (single branch). <a href="https://experimenter.info/deep-dives/experimenter/rollouts"
-                    target="_blank" rel="noopener noreferrer">
+                  This is a rollout (single branch).{" "}
+                  <a
+                    href="https://experimenter.info/deep-dives/experimenter/rollouts"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
                     Learn more
                   </a>
                 </>


### PR DESCRIPTION
Because

- On the branches page, there is a need to add a learn more link next to the rollouts checkbox. This link leads them here :  https://experimenter.info/deep-dives/experimenter/rollouts

This commit

- This commit modifies the first checkbox on the branches edit page by adding a learn more link to the label. 

![image](https://user-images.githubusercontent.com/21022645/223902610-ab82b2c2-79cf-46e7-b174-8097b1c6439d.png)
