### PR TITLE
feat(nimbus): add targeting for new profiles

### DIFF
--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -43,6 +43,17 @@ NO_TARGETING = NimbusTargetingConfig(
     application_choice_names=[a.name for a in Application],
 )
 
+NEW_PROFILE_CREATED = NimbusTargetingConfig(
+    name="New profile created",
+    slug="new_profile_created",
+    description="Profile with creation date within 24 hours",
+    targeting=NEW_PROFILE,
+    desktop_telemetry="environment.profile.creation_date",
+    sticky_required=True,
+    is_first_run_required=False,
+    application_choice_names=(Application.DESKTOP.name,),
+)
+
 FIRST_RUN = NimbusTargetingConfig(
     name="First start-up users",
     slug="first_run",


### PR DESCRIPTION
r?@jaredlockhart /@AllegroFox /@punamdahiya  Because https://experimenter.services.mozilla.com/nimbus/firefox-accounts-toolbar-button-default-visibility needs a version only for new profiles but broader than `isFirstStartup`

This reuses the existing `NEW_PROFILE` targeting as the only targeting.

![new profile created](https://user-images.githubusercontent.com/438537/224429347-f7d55cca-c0ff-4ec0-a510-75a5e556a860.png)

cc @mikeconley