### PR TITLE
fix #8386 chore(nimbus): Add ruff and circle ci check for cirrus ✅ 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,8 +19,15 @@ jobs:
       - run:
           name: Run tests and linting
           command: |
-            cp .env.sample .env
-            make check
+            if git diff --name-only main HEAD | grep -E 'experimenter/'
+              then
+                echo "Changes detected in /experimenter directory. Running Experimenter tests and linting."
+                cp .env.sample .env
+                make check
+              else
+                echo "No changes in /experimenter directory. Skipping tests and linting."
+                circleci-agent step halt
+            fi
 
   integration_nimbus_desktop_release_targeting:
     machine:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -427,6 +427,10 @@ jobs:
       docker_layer_caching: true
     resource_class: large
     working_directory: ~/cirrus
+    filters:
+      paths:
+        only:
+          - /cirrus
     steps:
       - run:
           name: Docker info

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -438,7 +438,14 @@ jobs:
       - run:
           name: Run Cirrus tests and linting
           command: |
-            make cirrus_check
+            if git diff --name-only main HEAD | grep -E 'cirrus/'
+              then
+                echo "Changes detected in /cirrus directory. Running Cirrus tests and linting."
+                make cirrus_check
+              else
+                echo "No changes in /cirrus directory. Skipping tests and linting."
+                circleci-agent step halt
+            fi
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -427,10 +427,6 @@ jobs:
       docker_layer_caching: true
     resource_class: large
     working_directory: ~/cirrus
-    filters:
-      paths:
-        only:
-          - /cirrus
     steps:
       - run:
           name: Docker info

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -421,6 +421,27 @@ jobs:
             docker commit $docker_id ${DOCKERHUB_REPO}:nimbus-rust-image
             docker login -u $DOCKER_USER -p $DOCKER_PASS
             docker push ${DOCKERHUB_REPO}:nimbus-rust-image
+  cirrus_check:
+    machine:
+      image: ubuntu-2004:202107-02 # Ubuntu 20.04, Docker v20.10.7, Docker Compose v1.29.2
+      docker_layer_caching: true
+    resource_class: large
+    working_directory: ~/cirrus
+    steps:
+      - run:
+          name: Docker info
+          command: docker -v
+      - run:
+          name: Docker compose info
+          command: docker-compose -v
+      - checkout
+      - run:
+          name: Run Cirrus tests and linting
+          command: |
+            make cirrus_check
+    filters:
+      paths:
+        - "/cirrus/*"
 
 workflows:
   version: 2
@@ -529,3 +550,5 @@ workflows:
               only: main
           requires:
             - check
+      - cirrus_check:
+          name: Cirrus Check

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -439,9 +439,6 @@ jobs:
           name: Run Cirrus tests and linting
           command: |
             make cirrus_check
-    filters:
-      paths:
-        - "/cirrus/*"
 
 workflows:
   version: 2

--- a/Makefile
+++ b/Makefile
@@ -209,7 +209,7 @@ cirrus_up: cirrus_build
 cirrus_down:
 	$(COMPOSE) down cirrus
 
-cirrus_test:
+cirrus_test: cirrus_build
 	$(COMPOSE_TEST) up cirrus_test
 
 cirrus_check: cirrus_test

--- a/Makefile
+++ b/Makefile
@@ -200,7 +200,10 @@ integration_test_nimbus_rust: build_prod
 # cirrus
 CIRRUS_RUFF_CHECK = ruff cirrus/server
 CIRRUS_RUFF_FIX = ruff --fix cirrus/server
-cirrus_up:
+cirrus_build:
+	$(COMPOSE) build cirrus
+
+cirrus_up: cirrus_build
 	$(COMPOSE) up cirrus
 
 cirrus_down:

--- a/Makefile
+++ b/Makefile
@@ -198,8 +198,8 @@ integration_test_nimbus_rust: build_prod
 	MOZ_HEADLESS=1 $(COMPOSE_INTEGRATION) run rust-sdk sh -c "chmod a+rwx /code/experimenter/tests/integration/.tox;tox -c experimenter/tests/integration -e integration-test-nimbus-rust $(TOX_ARGS) -- -n 2 $(PYTEST_ARGS)"
 
 # cirrus
-CIRRUS_RUFF_CHECK = ruff cirrus/server
-CIRRUS_RUFF_FIX = ruff --fix cirrus/server
+CIRRUS_RUFF_CHECK = /usr/local/bin/ruff cirrus/server
+CIRRUS_RUFF_FIX = /usr/local/bin/ruff --fix cirrus/server
 cirrus_build:
 	$(COMPOSE) build cirrus
 

--- a/Makefile
+++ b/Makefile
@@ -198,6 +198,8 @@ integration_test_nimbus_rust: build_prod
 	MOZ_HEADLESS=1 $(COMPOSE_INTEGRATION) run rust-sdk sh -c "chmod a+rwx /code/experimenter/tests/integration/.tox;tox -c experimenter/tests/integration -e integration-test-nimbus-rust $(TOX_ARGS) -- -n 2 $(PYTEST_ARGS)"
 	
 # cirrus
+CIRRUS_RUFF_CHECK = ruff cirrus/server
+CIRRUS_RUFF_FIX = ruff --fix cirrus/server
 cirrus_up:
 	$(COMPOSE) up cirrus
 
@@ -207,3 +209,8 @@ cirrus_down:
 cirrus_test:
 	$(COMPOSE_TEST) up cirrus_test
 
+cirrus_check: cirrus_test
+	$(CIRRUS_RUFF_CHECK)
+
+cirrus_code_format:
+	$(CIRRUS_RUFF_FIX)

--- a/Makefile
+++ b/Makefile
@@ -196,7 +196,7 @@ integration_test_nimbus: build_prod
 
 integration_test_nimbus_rust: build_prod
 	MOZ_HEADLESS=1 $(COMPOSE_INTEGRATION) run rust-sdk sh -c "chmod a+rwx /code/experimenter/tests/integration/.tox;tox -c experimenter/tests/integration -e integration-test-nimbus-rust $(TOX_ARGS) -- -n 2 $(PYTEST_ARGS)"
-	
+
 # cirrus
 CIRRUS_RUFF_CHECK = ruff cirrus/server
 CIRRUS_RUFF_FIX = ruff --fix cirrus/server
@@ -210,7 +210,7 @@ cirrus_test:
 	$(COMPOSE_TEST) up cirrus_test
 
 cirrus_check: cirrus_test
-	$(CIRRUS_RUFF_CHECK)
+	$(COMPOSE_TEST) run cirrus_test sh -c "$(CIRRUS_RUFF_CHECK)"
 
 cirrus_code_format:
-	$(CIRRUS_RUFF_FIX)
+	$(COMPOSE) run cirrus sh -c "$(CIRRUS_RUFF_FIX)"

--- a/Makefile
+++ b/Makefile
@@ -198,8 +198,8 @@ integration_test_nimbus_rust: build_prod
 	MOZ_HEADLESS=1 $(COMPOSE_INTEGRATION) run rust-sdk sh -c "chmod a+rwx /code/experimenter/tests/integration/.tox;tox -c experimenter/tests/integration -e integration-test-nimbus-rust $(TOX_ARGS) -- -n 2 $(PYTEST_ARGS)"
 
 # cirrus
-CIRRUS_RUFF_CHECK = /usr/local/bin/ruff cirrus/server
-CIRRUS_RUFF_FIX = /usr/local/bin/ruff --fix cirrus/server
+CIRRUS_RUFF_CHECK = ruff cirrus/server
+CIRRUS_RUFF_FIX = ruff --fix cirrus/server
 cirrus_build:
 	$(COMPOSE) build cirrus
 

--- a/cirrus/server/Dockerfile
+++ b/cirrus/server/Dockerfile
@@ -1,6 +1,7 @@
 FROM python:3.11.2-slim-buster
 WORKDIR /usr/src/cirrus
 COPY cirrus/server/requirements.txt ./
+RUN pip install ruff==0.0.254
 RUN pip install -r requirements.txt
 COPY . .
 CMD ["uvicorn", "cirrus.main:app", "--host", "0.0.0.0", "--port", "8001"]

--- a/cirrus/server/Dockerfile
+++ b/cirrus/server/Dockerfile
@@ -1,7 +1,6 @@
 FROM python:3.11.2-slim-buster
 WORKDIR /usr/src/cirrus
 COPY cirrus/server/requirements.txt ./
-RUN pip install ruff==0.0.254
 RUN pip install -r requirements.txt
 COPY . .
 CMD ["uvicorn", "cirrus.main:app", "--host", "0.0.0.0", "--port", "8001"]

--- a/cirrus/server/Dockerfile
+++ b/cirrus/server/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.11.2-slim-buster
 WORKDIR /usr/src/cirrus
 COPY cirrus/server/requirements.txt ./
-RUN pip install --no-cache-dir -r requirements.txt
+RUN pip install -r requirements.txt
 COPY . .
 CMD ["uvicorn", "cirrus.main:app", "--host", "0.0.0.0", "--port", "8001"]

--- a/cirrus/server/cirrus/main.py
+++ b/cirrus/server/cirrus/main.py
@@ -1,3 +1,4 @@
+
 from fastapi import FastAPI
 
 app = FastAPI()

--- a/cirrus/server/pyproject.toml
+++ b/cirrus/server/pyproject.toml
@@ -1,0 +1,21 @@
+[tool.ruff]
+# # Enable Pyflakes `E` and `F` codes by default.
+select = ["F", "E", "W", "I", "N", "YTT", "A", "C4", "RET", "SIM"]
+ignore = [
+    "A003",
+    "E402",
+    "E741",
+    "F403",
+    "N802",
+    "N803",
+    "N806",
+    "N812",
+    "N815",
+    "RET503",
+    "RET504",
+    "RET505",
+    "SIM102",
+]
+
+# Same as Black.
+line-length = 90

--- a/cirrus/server/requirements.txt
+++ b/cirrus/server/requirements.txt
@@ -5,3 +5,6 @@ uvicorn==0.20.0
 pytest==7.2.2
 httpx==0.23.3
 pytest-cov==4.0.0
+
+#linter
+ruff==0.0.254

--- a/cirrus/server/tests/conftest.py
+++ b/cirrus/server/tests/conftest.py
@@ -1,5 +1,6 @@
-from pytest import fixture
 from fastapi.testclient import TestClient
+from pytest import fixture
+
 from cirrus.main import app
 
 


### PR DESCRIPTION
Because

- We want to add a linter on the Cirrus service and wanted to have CI runs the cirrus check

This commit

- Add [Ruff linter](https://pypi.org/project/ruff/) 💪 
- New circle ci job for `cirrus_check`
- Cirrus check - runs the test case and ruff linting
- New make command for check `make cirrus_check`
- New make command to fix  formatting issues using `make cirrus_code_format`
- Circle ci cirrus check will only run if the changes are in `/cirrus` directory
