### PR TITLE
fixes 8246 refactor (nimbus):  change changed_on to updated_date_time

### DIFF
--- a/experimenter/experimenter/docs/openapi-schema.json
+++ b/experimenter/experimenter/docs/openapi-schema.json
@@ -32,9 +32,7 @@
             "description": ""
           }
         },
-        "tags": [
-          "Core: Public"
-        ]
+        "tags": ["Core: Public"]
       }
     },
     "/api/v1/experiments/{slug}/": {
@@ -64,9 +62,7 @@
             "description": ""
           }
         },
-        "tags": [
-          "Core: Public"
-        ]
+        "tags": ["Core: Public"]
       }
     },
     "/api/v1/experiments/": {
@@ -108,9 +104,7 @@
             "description": ""
           }
         },
-        "tags": [
-          "Core: Public"
-        ]
+        "tags": ["Core: Public"]
       }
     },
     "/api/v2/experiments/csv/": {
@@ -133,9 +127,7 @@
             "description": ""
           }
         },
-        "tags": [
-          "Core: Private"
-        ]
+        "tags": ["Core: Private"]
       }
     },
     "/api/v2/experiments/{slug}/design-addon-rollout": {
@@ -165,9 +157,7 @@
             "description": ""
           }
         },
-        "tags": [
-          "Core: Private"
-        ]
+        "tags": ["Core: Private"]
       },
       "put": {
         "operationId": "updateExperiment",
@@ -214,9 +204,7 @@
             "description": ""
           }
         },
-        "tags": [
-          "Core: Private"
-        ]
+        "tags": ["Core: Private"]
       },
       "patch": {
         "operationId": "partialUpdateExperiment",
@@ -263,9 +251,7 @@
             "description": ""
           }
         },
-        "tags": [
-          "Core: Private"
-        ]
+        "tags": ["Core: Private"]
       }
     },
     "/api/v2/experiments/{slug}/design-addon": {
@@ -295,9 +281,7 @@
             "description": ""
           }
         },
-        "tags": [
-          "Core: Private"
-        ]
+        "tags": ["Core: Private"]
       },
       "put": {
         "operationId": "updateExperiment",
@@ -344,9 +328,7 @@
             "description": ""
           }
         },
-        "tags": [
-          "Core: Private"
-        ]
+        "tags": ["Core: Private"]
       },
       "patch": {
         "operationId": "partialUpdateExperiment",
@@ -393,9 +375,7 @@
             "description": ""
           }
         },
-        "tags": [
-          "Core: Private"
-        ]
+        "tags": ["Core: Private"]
       }
     },
     "/api/v2/experiments/{slug}/design-pref-rollout": {
@@ -425,9 +405,7 @@
             "description": ""
           }
         },
-        "tags": [
-          "Core: Private"
-        ]
+        "tags": ["Core: Private"]
       },
       "put": {
         "operationId": "updateExperiment",
@@ -474,9 +452,7 @@
             "description": ""
           }
         },
-        "tags": [
-          "Core: Private"
-        ]
+        "tags": ["Core: Private"]
       },
       "patch": {
         "operationId": "partialUpdateExperiment",
@@ -523,9 +499,7 @@
             "description": ""
           }
         },
-        "tags": [
-          "Core: Private"
-        ]
+        "tags": ["Core: Private"]
       }
     },
     "/api/v2/experiments/{slug}/design-pref": {
@@ -555,9 +529,7 @@
             "description": ""
           }
         },
-        "tags": [
-          "Core: Private"
-        ]
+        "tags": ["Core: Private"]
       },
       "put": {
         "operationId": "updateExperiment",
@@ -604,9 +576,7 @@
             "description": ""
           }
         },
-        "tags": [
-          "Core: Private"
-        ]
+        "tags": ["Core: Private"]
       },
       "patch": {
         "operationId": "partialUpdateExperiment",
@@ -653,9 +623,7 @@
             "description": ""
           }
         },
-        "tags": [
-          "Core: Private"
-        ]
+        "tags": ["Core: Private"]
       }
     },
     "/api/v2/experiments/{slug}/design-multi-pref": {
@@ -685,9 +653,7 @@
             "description": ""
           }
         },
-        "tags": [
-          "Core: Private"
-        ]
+        "tags": ["Core: Private"]
       },
       "put": {
         "operationId": "updateExperiment",
@@ -734,9 +700,7 @@
             "description": ""
           }
         },
-        "tags": [
-          "Core: Private"
-        ]
+        "tags": ["Core: Private"]
       },
       "patch": {
         "operationId": "partialUpdateExperiment",
@@ -783,9 +747,7 @@
             "description": ""
           }
         },
-        "tags": [
-          "Core: Private"
-        ]
+        "tags": ["Core: Private"]
       }
     },
     "/api/v2/experiments/{slug}/design-generic": {
@@ -815,9 +777,7 @@
             "description": ""
           }
         },
-        "tags": [
-          "Core: Private"
-        ]
+        "tags": ["Core: Private"]
       },
       "put": {
         "operationId": "updateExperiment",
@@ -864,9 +824,7 @@
             "description": ""
           }
         },
-        "tags": [
-          "Core: Private"
-        ]
+        "tags": ["Core: Private"]
       },
       "patch": {
         "operationId": "partialUpdateExperiment",
@@ -913,9 +871,7 @@
             "description": ""
           }
         },
-        "tags": [
-          "Core: Private"
-        ]
+        "tags": ["Core: Private"]
       }
     },
     "/api/v2/experiments/{slug}/design-branched-addon": {
@@ -945,9 +901,7 @@
             "description": ""
           }
         },
-        "tags": [
-          "Core: Private"
-        ]
+        "tags": ["Core: Private"]
       },
       "put": {
         "operationId": "updateExperiment",
@@ -994,9 +948,7 @@
             "description": ""
           }
         },
-        "tags": [
-          "Core: Private"
-        ]
+        "tags": ["Core: Private"]
       },
       "patch": {
         "operationId": "partialUpdateExperiment",
@@ -1043,9 +995,7 @@
             "description": ""
           }
         },
-        "tags": [
-          "Core: Private"
-        ]
+        "tags": ["Core: Private"]
       }
     },
     "/api/v2/experiments/{slug}/design-message": {
@@ -1075,9 +1025,7 @@
             "description": ""
           }
         },
-        "tags": [
-          "Core: Private"
-        ]
+        "tags": ["Core: Private"]
       },
       "put": {
         "operationId": "updateExperiment",
@@ -1124,9 +1072,7 @@
             "description": ""
           }
         },
-        "tags": [
-          "Core: Private"
-        ]
+        "tags": ["Core: Private"]
       },
       "patch": {
         "operationId": "partialUpdateExperiment",
@@ -1173,9 +1119,7 @@
             "description": ""
           }
         },
-        "tags": [
-          "Core: Private"
-        ]
+        "tags": ["Core: Private"]
       }
     },
     "/api/v2/experiments/{slug}/timeline-population": {
@@ -1205,9 +1149,7 @@
             "description": ""
           }
         },
-        "tags": [
-          "Core: Private"
-        ]
+        "tags": ["Core: Private"]
       },
       "put": {
         "operationId": "updateExperiment",
@@ -1254,9 +1196,7 @@
             "description": ""
           }
         },
-        "tags": [
-          "Core: Private"
-        ]
+        "tags": ["Core: Private"]
       },
       "patch": {
         "operationId": "partialUpdateExperiment",
@@ -1303,9 +1243,7 @@
             "description": ""
           }
         },
-        "tags": [
-          "Core: Private"
-        ]
+        "tags": ["Core: Private"]
       }
     },
     "/api/v3/visualization/{slug}/": {
@@ -1333,9 +1271,7 @@
             "description": ""
           }
         },
-        "tags": [
-          "api"
-        ]
+        "tags": ["api"]
       }
     },
     "/api/v5/csv/": {
@@ -1358,9 +1294,7 @@
             "description": ""
           }
         },
-        "tags": [
-          "api"
-        ]
+        "tags": ["api"]
       }
     },
     "/api/v5/config/": {
@@ -1380,9 +1314,7 @@
             "description": ""
           }
         },
-        "tags": [
-          "api"
-        ]
+        "tags": ["api"]
       }
     },
     "/api/v6/experiments/": {
@@ -1415,9 +1347,7 @@
             "description": ""
           }
         },
-        "tags": [
-          "Nimbus: Public"
-        ]
+        "tags": ["Nimbus: Public"]
       }
     },
     "/api/v6/experiments/{slug}/": {
@@ -1456,9 +1386,7 @@
             "description": ""
           }
         },
-        "tags": [
-          "Nimbus: Public"
-        ]
+        "tags": ["Nimbus: Public"]
       }
     },
     "/api/v6/experiments-first-run/": {
@@ -1491,9 +1419,7 @@
             "description": ""
           }
         },
-        "tags": [
-          "Nimbus: Public"
-        ]
+        "tags": ["Nimbus: Public"]
       }
     },
     "/api/v6/experiments-first-run/{slug}/": {
@@ -1532,9 +1458,7 @@
             "description": ""
           }
         },
-        "tags": [
-          "Nimbus: Public"
-        ]
+        "tags": ["Nimbus: Public"]
       }
     },
     "/api/v2/experiments/{slug}/intent-to-ship-email": {
@@ -1583,9 +1507,7 @@
             "description": ""
           }
         },
-        "tags": [
-          "Core: Private"
-        ]
+        "tags": ["Core: Private"]
       },
       "patch": {
         "operationId": "partialUpdateExperiment",
@@ -1632,9 +1554,7 @@
             "description": ""
           }
         },
-        "tags": [
-          "Core: Private"
-        ]
+        "tags": ["Core: Private"]
       }
     },
     "/api/v2/experiments/{slug}/clone": {
@@ -1683,9 +1603,7 @@
             "description": ""
           }
         },
-        "tags": [
-          "Core: Private"
-        ]
+        "tags": ["Core: Private"]
       },
       "patch": {
         "operationId": "partialUpdateExperiment",
@@ -1732,9 +1650,7 @@
             "description": ""
           }
         },
-        "tags": [
-          "Core: Private"
-        ]
+        "tags": ["Core: Private"]
       }
     }
   },
@@ -1768,9 +1684,7 @@
             "readOnly": true
           }
         },
-        "required": [
-          "name"
-        ]
+        "required": ["name"]
       },
       "Experiment": {
         "type": "object",
@@ -1780,13 +1694,7 @@
             "readOnly": true
           },
           "type": {
-            "enum": [
-              "pref",
-              "addon",
-              "generic",
-              "rollout",
-              "message"
-            ],
+            "enum": ["pref", "addon", "generic", "rollout", "message"],
             "type": "string"
           },
           "name": {
@@ -1832,10 +1740,7 @@
                   "maxLength": 255
                 }
               },
-              "required": [
-                "code",
-                "name"
-              ]
+              "required": ["code", "name"]
             }
           },
           "countries": {
@@ -1852,10 +1757,7 @@
                   "maxLength": 255
                 }
               },
-              "required": [
-                "code",
-                "name"
-              ]
+              "required": ["code", "name"]
             }
           },
           "platforms": {
@@ -1884,12 +1786,7 @@
             "nullable": true
           },
           "firefox_channel": {
-            "enum": [
-              null,
-              "Nightly",
-              "Beta",
-              "Release"
-            ],
+            "enum": [null, "Nightly", "Beta", "Release"],
             "nullable": true
           },
           "firefox_min_version": {
@@ -2049,11 +1946,7 @@
             "pattern": "^(?:[a-z0-9.+-]*)://(?:[^\\s:@/]+(?::[^\\s:@/]*)?@)?(?:(?:0|25[0-5]|2[0-4]\\d|1\\d?\\d?|[1-9]\\d?)(?:\\.(?:0|25[0-5]|2[0-4]\\d|1\\d?\\d?|[1-9]\\d?)){3}|\\[[0-9a-f:.]+\\]|([a-z\u00a1-\uffff0-9](?:[a-z\u00a1-\uffff0-9-]{0,61}[a-z\u00a1-\uffff0-9])?(?:\\.(?!-)[a-z\u00a1-\uffff0-9-]{1,63}(?<!-))*\\.(?!-)(?:[a-z\u00a1-\uffff-]{2,63}|xn--[a-z0-9]{1,59})(?<!-)\\.?|localhost))(?::\\d{2,5})?(?:[/?#][^\\s]*)?\\z"
           },
           "pref_branch": {
-            "enum": [
-              null,
-              "default",
-              "user"
-            ],
+            "enum": [null, "default", "user"],
             "nullable": true
           },
           "pref_name": {
@@ -2155,11 +2048,7 @@
                         ]
                       },
                       "pref_branch": {
-                        "enum": [
-                          null,
-                          "default",
-                          "user"
-                        ]
+                        "enum": [null, "default", "user"]
                       },
                       "pref_value": {
                         "type": "string",
@@ -2187,10 +2076,7 @@
                   "nullable": true
                 }
               },
-              "required": [
-                "name",
-                "slug"
-              ]
+              "required": ["name", "slug"]
             }
           },
           "results": {
@@ -2202,7 +2088,7 @@
             "items": {
               "type": "object",
               "properties": {
-                "changed_on": {
+                "updated_date_time": {
                   "type": "string",
                   "format": "date-time"
                 },
@@ -2236,9 +2122,7 @@
                   "nullable": true
                 }
               },
-              "required": [
-                "new_status"
-              ]
+              "required": ["new_status"]
             }
           },
           "projects": {
@@ -2297,13 +2181,7 @@
             "readOnly": true
           },
           "type": {
-            "enum": [
-              "pref",
-              "addon",
-              "generic",
-              "rollout",
-              "message"
-            ],
+            "enum": ["pref", "addon", "generic", "rollout", "message"],
             "type": "string"
           },
           "length": {
@@ -2357,10 +2235,7 @@
         "type": "object",
         "properties": {
           "rollout_type": {
-            "enum": [
-              "pref",
-              "addon"
-            ],
+            "enum": ["pref", "addon"],
             "type": "string"
           },
           "design": {
@@ -2375,10 +2250,7 @@
             "pattern": "^(?:[a-z0-9.+-]*)://(?:[^\\s:@/]+(?::[^\\s:@/]*)?@)?(?:(?:0|25[0-5]|2[0-4]\\d|1\\d?\\d?|[1-9]\\d?)(?:\\.(?:0|25[0-5]|2[0-4]\\d|1\\d?\\d?|[1-9]\\d?)){3}|\\[[0-9a-f:.]+\\]|([a-z\u00a1-\uffff0-9](?:[a-z\u00a1-\uffff0-9-]{0,61}[a-z\u00a1-\uffff0-9])?(?:\\.(?!-)[a-z\u00a1-\uffff0-9-]{1,63}(?<!-))*\\.(?!-)(?:[a-z\u00a1-\uffff-]{2,63}|xn--[a-z0-9]{1,59})(?<!-)\\.?|localhost))(?::\\d{2,5})?(?:[/?#][^\\s]*)?\\z"
           }
         },
-        "required": [
-          "rollout_type",
-          "addon_release_url"
-        ]
+        "required": ["rollout_type", "addon_release_url"]
       },
       "ExperimentDesignAddon": {
         "type": "object",
@@ -2411,32 +2283,20 @@
                   "type": "integer"
                 }
               },
-              "required": [
-                "description",
-                "is_control",
-                "name",
-                "ratio"
-              ]
+              "required": ["description", "is_control", "name", "ratio"]
             }
           },
           "is_branched_addon": {
             "type": "boolean"
           }
         },
-        "required": [
-          "addon_release_url",
-          "variants",
-          "is_branched_addon"
-        ]
+        "required": ["addon_release_url", "variants", "is_branched_addon"]
       },
       "ExperimentDesignPrefRollout": {
         "type": "object",
         "properties": {
           "rollout_type": {
-            "enum": [
-              "pref",
-              "addon"
-            ],
+            "enum": ["pref", "addon"],
             "type": "string"
           },
           "design": {
@@ -2456,31 +2316,18 @@
                   "maxLength": 255
                 },
                 "pref_type": {
-                  "enum": [
-                    null,
-                    "boolean",
-                    "integer",
-                    "string",
-                    "json string"
-                  ]
+                  "enum": [null, "boolean", "integer", "string", "json string"]
                 },
                 "pref_value": {
                   "type": "string",
                   "maxLength": 4096
                 }
               },
-              "required": [
-                "pref_name",
-                "pref_type",
-                "pref_value"
-              ]
+              "required": ["pref_name", "pref_type", "pref_value"]
             }
           }
         },
-        "required": [
-          "rollout_type",
-          "preferences"
-        ]
+        "required": ["rollout_type", "preferences"]
       },
       "ExperimentDesignPref": {
         "type": "object",
@@ -2592,11 +2439,7 @@
                         ]
                       },
                       "pref_branch": {
-                        "enum": [
-                          null,
-                          "default",
-                          "user"
-                        ]
+                        "enum": [null, "default", "user"]
                       },
                       "pref_value": {
                         "type": "string",
@@ -2622,10 +2465,7 @@
             }
           }
         },
-        "required": [
-          "is_multi_pref",
-          "variants"
-        ]
+        "required": ["is_multi_pref", "variants"]
       },
       "ExperimentDesignGeneric": {
         "type": "object",
@@ -2656,18 +2496,11 @@
                   "type": "integer"
                 }
               },
-              "required": [
-                "description",
-                "is_control",
-                "name",
-                "ratio"
-              ]
+              "required": ["description", "is_control", "name", "ratio"]
             }
           }
         },
-        "required": [
-          "variants"
-        ]
+        "required": ["variants"]
       },
       "ExperimentDesignBranchedAddon": {
         "type": "object",
@@ -2713,19 +2546,13 @@
             }
           }
         },
-        "required": [
-          "is_branched_addon",
-          "variants"
-        ]
+        "required": ["is_branched_addon", "variants"]
       },
       "ExperimentDesignMessage": {
         "type": "object",
         "properties": {
           "message_type": {
-            "enum": [
-              "cfr",
-              "about:welcome"
-            ],
+            "enum": ["cfr", "about:welcome"],
             "type": "string"
           },
           "message_template": {
@@ -2784,10 +2611,7 @@
             }
           }
         },
-        "required": [
-          "message_type",
-          "variants"
-        ]
+        "required": ["message_type", "variants"]
       },
       "ExperimentTimelinePop": {
         "type": "object",
@@ -2802,13 +2626,7 @@
             "nullable": true
           },
           "rollout_playbook": {
-            "enum": [
-              null,
-              "low_risk",
-              "high_risk",
-              "marketing",
-              "custom"
-            ],
+            "enum": [null, "low_risk", "high_risk", "marketing", "custom"],
             "nullable": true
           },
           "proposed_duration": {
@@ -2824,12 +2642,7 @@
             "nullable": true
           },
           "firefox_channel": {
-            "enum": [
-              null,
-              "Nightly",
-              "Beta",
-              "Release"
-            ],
+            "enum": [null, "Nightly", "Beta", "Release"],
             "nullable": true
           },
           "firefox_min_version": {
@@ -2988,10 +2801,7 @@
                   "type": "integer"
                 }
               },
-              "required": [
-                "label",
-                "value"
-              ]
+              "required": ["label", "value"]
             },
             "nullable": true
           },
@@ -3007,10 +2817,7 @@
                   "type": "integer"
                 }
               },
-              "required": [
-                "label",
-                "value"
-              ]
+              "required": ["label", "value"]
             },
             "nullable": true
           },
@@ -3113,10 +2920,7 @@
                   "type": "string"
                 }
               },
-              "required": [
-                "label",
-                "value"
-              ]
+              "required": ["label", "value"]
             }
           },
           "channels": {
@@ -3131,10 +2935,7 @@
                   "type": "string"
                 }
               },
-              "required": [
-                "label",
-                "value"
-              ]
+              "required": ["label", "value"]
             }
           },
           "applicationConfigs": {
@@ -3157,17 +2958,11 @@
                         "type": "string"
                       }
                     },
-                    "required": [
-                      "label",
-                      "value"
-                    ]
+                    "required": ["label", "value"]
                   }
                 }
               },
-              "required": [
-                "application",
-                "channels"
-              ]
+              "required": ["application", "channels"]
             }
           },
           "countries": {
@@ -3185,11 +2980,7 @@
                   "type": "string"
                 }
               },
-              "required": [
-                "id",
-                "name",
-                "code"
-              ]
+              "required": ["id", "name", "code"]
             }
           },
           "locales": {
@@ -3207,11 +2998,7 @@
                   "type": "string"
                 }
               },
-              "required": [
-                "id",
-                "name",
-                "code"
-              ]
+              "required": ["id", "name", "code"]
             }
           },
           "languages": {
@@ -3229,11 +3016,7 @@
                   "type": "string"
                 }
               },
-              "required": [
-                "id",
-                "name",
-                "code"
-              ]
+              "required": ["id", "name", "code"]
             }
           },
           "projects": {
@@ -3251,11 +3034,7 @@
                   "type": "string"
                 }
               },
-              "required": [
-                "id",
-                "name",
-                "slug"
-              ]
+              "required": ["id", "name", "slug"]
             }
           },
           "documentationLink": {
@@ -3270,10 +3049,7 @@
                   "type": "string"
                 }
               },
-              "required": [
-                "label",
-                "value"
-              ]
+              "required": ["label", "value"]
             }
           },
           "allFeatureConfigs": {
@@ -3337,10 +3113,7 @@
                   "type": "string"
                 }
               },
-              "required": [
-                "label",
-                "value"
-              ]
+              "required": ["label", "value"]
             }
           },
           "outcomes": {
@@ -3378,11 +3151,7 @@
                         "type": "string"
                       }
                     },
-                    "required": [
-                      "slug",
-                      "friendlyName",
-                      "description"
-                    ]
+                    "required": ["slug", "friendlyName", "description"]
                   }
                 }
               },
@@ -3405,9 +3174,7 @@
                   "type": "string"
                 }
               },
-              "required": [
-                "username"
-              ]
+              "required": ["username"]
             }
           },
           "targetingConfigs": {
@@ -3459,10 +3226,7 @@
                   "type": "string"
                 }
               },
-              "required": [
-                "label",
-                "value"
-              ]
+              "required": ["label", "value"]
             }
           },
           "types": {
@@ -3477,10 +3241,7 @@
                   "type": "string"
                 }
               },
-              "required": [
-                "label",
-                "value"
-              ]
+              "required": ["label", "value"]
             }
           },
           "hypothesisDefault": {
@@ -3597,10 +3358,7 @@
                 "readOnly": true
               }
             },
-            "required": [
-              "start",
-              "count"
-            ]
+            "required": ["start", "count"]
           },
           "featureIds": {
             "type": "string",
@@ -3673,9 +3431,7 @@
             "readOnly": true
           }
         },
-        "required": [
-          "name"
-        ]
+        "required": ["name"]
       }
     }
   }

--- a/experimenter/experimenter/docs/swagger-ui.html
+++ b/experimenter/experimenter/docs/swagger-ui.html
@@ -1,3706 +1,3709 @@
 <!DOCTYPE html>
 <html>
-  <head>
-    <title>Experimenter Api Docs</title>
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link rel="stylesheet" type="text/css" href="swagger-ui.css" />
-  </head>
-  <body>
-    <div id="swagger-ui"></div>
-    <script src="swagger-ui-bundle.js"></script>
-    <script>
-      const spec = {
-  "openapi": "3.0.2",
-  "info": {
-    "title": "Experimenter API",
-    "version": ""
-  },
-  "paths": {
-    "/api/v1/experiments/{slug}/recipe/": {
-      "get": {
-        "operationId": "retrieveExperiment",
-        "description": "",
-        "parameters": [
-          {
-            "name": "slug",
-            "in": "path",
-            "required": true,
+
+<head>
+  <title>Experimenter Api Docs</title>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link rel="stylesheet" type="text/css" href="swagger-ui.css" />
+</head>
+
+<body>
+  <div id="swagger-ui"></div>
+  <script src="swagger-ui-bundle.js"></script>
+  <script>
+    const spec = {
+      "openapi": "3.0.2",
+      "info": {
+        "title": "Experimenter API",
+        "version": ""
+      },
+      "paths": {
+        "/api/v1/experiments/{slug}/recipe/": {
+          "get": {
+            "operationId": "retrieveExperiment",
             "description": "",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
+            "parameters": [
+              {
+                "name": "slug",
+                "in": "path",
+                "required": true,
+                "description": "",
                 "schema": {
-                  "$ref": "#/components/schemas/ExperimentRecipe"
+                  "type": "string"
+                }
+              }
+            ],
+            "responses": {
+              "200": {
+                "content": {
+                  "application/json": {
+                    "schema": {
+                      "$ref": "#/components/schemas/ExperimentRecipe"
+                    }
+                  }
+                },
+                "description": ""
+              }
+            },
+            "tags": [
+              "Core: Public"
+            ]
+          }
+        },
+        "/api/v1/experiments/{slug}/": {
+          "get": {
+            "operationId": "retrieveExperiment",
+            "description": "",
+            "parameters": [
+              {
+                "name": "slug",
+                "in": "path",
+                "required": true,
+                "description": "",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            ],
+            "responses": {
+              "200": {
+                "content": {
+                  "application/json": {
+                    "schema": {
+                      "$ref": "#/components/schemas/Experiment"
+                    }
+                  }
+                },
+                "description": ""
+              }
+            },
+            "tags": [
+              "Core: Public"
+            ]
+          }
+        },
+        "/api/v1/experiments/": {
+          "get": {
+            "operationId": "listExperiments",
+            "description": "",
+            "parameters": [
+              {
+                "name": "status",
+                "required": false,
+                "in": "query",
+                "description": "status",
+                "schema": {
+                  "type": "string",
+                  "enum": [
+                    "Draft",
+                    "Review",
+                    "Ship",
+                    "Accepted",
+                    "Live",
+                    "Complete",
+                    "Rejected"
+                  ]
+                }
+              }
+            ],
+            "responses": {
+              "200": {
+                "content": {
+                  "application/json": {
+                    "schema": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Experiment"
+                      }
+                    }
+                  }
+                },
+                "description": ""
+              }
+            },
+            "tags": [
+              "Core: Public"
+            ]
+          }
+        },
+        "/api/v2/experiments/csv/": {
+          "get": {
+            "operationId": "listExperiments",
+            "description": "",
+            "parameters": [],
+            "responses": {
+              "200": {
+                "content": {
+                  "text/csv": {
+                    "schema": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/ExperimentCSV"
+                      }
+                    }
+                  }
+                },
+                "description": ""
+              }
+            },
+            "tags": [
+              "Core: Private"
+            ]
+          }
+        },
+        "/api/v2/experiments/{slug}/design-addon-rollout": {
+          "get": {
+            "operationId": "retrieveExperiment",
+            "description": "",
+            "parameters": [
+              {
+                "name": "slug",
+                "in": "path",
+                "required": true,
+                "description": "",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            ],
+            "responses": {
+              "200": {
+                "content": {
+                  "application/json": {
+                    "schema": {
+                      "$ref": "#/components/schemas/ExperimentDesignAddonRollout"
+                    }
+                  }
+                },
+                "description": ""
+              }
+            },
+            "tags": [
+              "Core: Private"
+            ]
+          },
+          "put": {
+            "operationId": "updateExperiment",
+            "description": "",
+            "parameters": [
+              {
+                "name": "slug",
+                "in": "path",
+                "required": true,
+                "description": "",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            ],
+            "requestBody": {
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ExperimentDesignAddonRollout"
+                  }
+                },
+                "application/x-www-form-urlencoded": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ExperimentDesignAddonRollout"
+                  }
+                },
+                "multipart/form-data": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ExperimentDesignAddonRollout"
+                  }
                 }
               }
             },
-            "description": ""
-          }
-        },
-        "tags": [
-          "Core: Public"
-        ]
-      }
-    },
-    "/api/v1/experiments/{slug}/": {
-      "get": {
-        "operationId": "retrieveExperiment",
-        "description": "",
-        "parameters": [
-          {
-            "name": "slug",
-            "in": "path",
-            "required": true,
+            "responses": {
+              "200": {
+                "content": {
+                  "application/json": {
+                    "schema": {
+                      "$ref": "#/components/schemas/ExperimentDesignAddonRollout"
+                    }
+                  }
+                },
+                "description": ""
+              }
+            },
+            "tags": [
+              "Core: Private"
+            ]
+          },
+          "patch": {
+            "operationId": "partialUpdateExperiment",
             "description": "",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
+            "parameters": [
+              {
+                "name": "slug",
+                "in": "path",
+                "required": true,
+                "description": "",
                 "schema": {
-                  "$ref": "#/components/schemas/Experiment"
+                  "type": "string"
+                }
+              }
+            ],
+            "requestBody": {
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ExperimentDesignAddonRollout"
+                  }
+                },
+                "application/x-www-form-urlencoded": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ExperimentDesignAddonRollout"
+                  }
+                },
+                "multipart/form-data": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ExperimentDesignAddonRollout"
+                  }
                 }
               }
             },
-            "description": ""
+            "responses": {
+              "200": {
+                "content": {
+                  "application/json": {
+                    "schema": {
+                      "$ref": "#/components/schemas/ExperimentDesignAddonRollout"
+                    }
+                  }
+                },
+                "description": ""
+              }
+            },
+            "tags": [
+              "Core: Private"
+            ]
           }
         },
-        "tags": [
-          "Core: Public"
-        ]
-      }
-    },
-    "/api/v1/experiments/": {
-      "get": {
-        "operationId": "listExperiments",
-        "description": "",
-        "parameters": [
-          {
-            "name": "status",
-            "required": false,
-            "in": "query",
-            "description": "status",
-            "schema": {
-              "type": "string",
-              "enum": [
-                "Draft",
-                "Review",
-                "Ship",
-                "Accepted",
-                "Live",
-                "Complete",
-                "Rejected"
-              ]
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
+        "/api/v2/experiments/{slug}/design-addon": {
+          "get": {
+            "operationId": "retrieveExperiment",
+            "description": "",
+            "parameters": [
+              {
+                "name": "slug",
+                "in": "path",
+                "required": true,
+                "description": "",
                 "schema": {
-                  "type": "array",
-                  "items": {
+                  "type": "string"
+                }
+              }
+            ],
+            "responses": {
+              "200": {
+                "content": {
+                  "application/json": {
+                    "schema": {
+                      "$ref": "#/components/schemas/ExperimentDesignAddon"
+                    }
+                  }
+                },
+                "description": ""
+              }
+            },
+            "tags": [
+              "Core: Private"
+            ]
+          },
+          "put": {
+            "operationId": "updateExperiment",
+            "description": "",
+            "parameters": [
+              {
+                "name": "slug",
+                "in": "path",
+                "required": true,
+                "description": "",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            ],
+            "requestBody": {
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ExperimentDesignAddon"
+                  }
+                },
+                "application/x-www-form-urlencoded": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ExperimentDesignAddon"
+                  }
+                },
+                "multipart/form-data": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ExperimentDesignAddon"
+                  }
+                }
+              }
+            },
+            "responses": {
+              "200": {
+                "content": {
+                  "application/json": {
+                    "schema": {
+                      "$ref": "#/components/schemas/ExperimentDesignAddon"
+                    }
+                  }
+                },
+                "description": ""
+              }
+            },
+            "tags": [
+              "Core: Private"
+            ]
+          },
+          "patch": {
+            "operationId": "partialUpdateExperiment",
+            "description": "",
+            "parameters": [
+              {
+                "name": "slug",
+                "in": "path",
+                "required": true,
+                "description": "",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            ],
+            "requestBody": {
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ExperimentDesignAddon"
+                  }
+                },
+                "application/x-www-form-urlencoded": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ExperimentDesignAddon"
+                  }
+                },
+                "multipart/form-data": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ExperimentDesignAddon"
+                  }
+                }
+              }
+            },
+            "responses": {
+              "200": {
+                "content": {
+                  "application/json": {
+                    "schema": {
+                      "$ref": "#/components/schemas/ExperimentDesignAddon"
+                    }
+                  }
+                },
+                "description": ""
+              }
+            },
+            "tags": [
+              "Core: Private"
+            ]
+          }
+        },
+        "/api/v2/experiments/{slug}/design-pref-rollout": {
+          "get": {
+            "operationId": "retrieveExperiment",
+            "description": "",
+            "parameters": [
+              {
+                "name": "slug",
+                "in": "path",
+                "required": true,
+                "description": "",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            ],
+            "responses": {
+              "200": {
+                "content": {
+                  "application/json": {
+                    "schema": {
+                      "$ref": "#/components/schemas/ExperimentDesignPrefRollout"
+                    }
+                  }
+                },
+                "description": ""
+              }
+            },
+            "tags": [
+              "Core: Private"
+            ]
+          },
+          "put": {
+            "operationId": "updateExperiment",
+            "description": "",
+            "parameters": [
+              {
+                "name": "slug",
+                "in": "path",
+                "required": true,
+                "description": "",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            ],
+            "requestBody": {
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ExperimentDesignPrefRollout"
+                  }
+                },
+                "application/x-www-form-urlencoded": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ExperimentDesignPrefRollout"
+                  }
+                },
+                "multipart/form-data": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ExperimentDesignPrefRollout"
+                  }
+                }
+              }
+            },
+            "responses": {
+              "200": {
+                "content": {
+                  "application/json": {
+                    "schema": {
+                      "$ref": "#/components/schemas/ExperimentDesignPrefRollout"
+                    }
+                  }
+                },
+                "description": ""
+              }
+            },
+            "tags": [
+              "Core: Private"
+            ]
+          },
+          "patch": {
+            "operationId": "partialUpdateExperiment",
+            "description": "",
+            "parameters": [
+              {
+                "name": "slug",
+                "in": "path",
+                "required": true,
+                "description": "",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            ],
+            "requestBody": {
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ExperimentDesignPrefRollout"
+                  }
+                },
+                "application/x-www-form-urlencoded": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ExperimentDesignPrefRollout"
+                  }
+                },
+                "multipart/form-data": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ExperimentDesignPrefRollout"
+                  }
+                }
+              }
+            },
+            "responses": {
+              "200": {
+                "content": {
+                  "application/json": {
+                    "schema": {
+                      "$ref": "#/components/schemas/ExperimentDesignPrefRollout"
+                    }
+                  }
+                },
+                "description": ""
+              }
+            },
+            "tags": [
+              "Core: Private"
+            ]
+          }
+        },
+        "/api/v2/experiments/{slug}/design-pref": {
+          "get": {
+            "operationId": "retrieveExperiment",
+            "description": "",
+            "parameters": [
+              {
+                "name": "slug",
+                "in": "path",
+                "required": true,
+                "description": "",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            ],
+            "responses": {
+              "200": {
+                "content": {
+                  "application/json": {
+                    "schema": {
+                      "$ref": "#/components/schemas/ExperimentDesignPref"
+                    }
+                  }
+                },
+                "description": ""
+              }
+            },
+            "tags": [
+              "Core: Private"
+            ]
+          },
+          "put": {
+            "operationId": "updateExperiment",
+            "description": "",
+            "parameters": [
+              {
+                "name": "slug",
+                "in": "path",
+                "required": true,
+                "description": "",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            ],
+            "requestBody": {
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ExperimentDesignPref"
+                  }
+                },
+                "application/x-www-form-urlencoded": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ExperimentDesignPref"
+                  }
+                },
+                "multipart/form-data": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ExperimentDesignPref"
+                  }
+                }
+              }
+            },
+            "responses": {
+              "200": {
+                "content": {
+                  "application/json": {
+                    "schema": {
+                      "$ref": "#/components/schemas/ExperimentDesignPref"
+                    }
+                  }
+                },
+                "description": ""
+              }
+            },
+            "tags": [
+              "Core: Private"
+            ]
+          },
+          "patch": {
+            "operationId": "partialUpdateExperiment",
+            "description": "",
+            "parameters": [
+              {
+                "name": "slug",
+                "in": "path",
+                "required": true,
+                "description": "",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            ],
+            "requestBody": {
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ExperimentDesignPref"
+                  }
+                },
+                "application/x-www-form-urlencoded": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ExperimentDesignPref"
+                  }
+                },
+                "multipart/form-data": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ExperimentDesignPref"
+                  }
+                }
+              }
+            },
+            "responses": {
+              "200": {
+                "content": {
+                  "application/json": {
+                    "schema": {
+                      "$ref": "#/components/schemas/ExperimentDesignPref"
+                    }
+                  }
+                },
+                "description": ""
+              }
+            },
+            "tags": [
+              "Core: Private"
+            ]
+          }
+        },
+        "/api/v2/experiments/{slug}/design-multi-pref": {
+          "get": {
+            "operationId": "retrieveExperiment",
+            "description": "",
+            "parameters": [
+              {
+                "name": "slug",
+                "in": "path",
+                "required": true,
+                "description": "",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            ],
+            "responses": {
+              "200": {
+                "content": {
+                  "application/json": {
+                    "schema": {
+                      "$ref": "#/components/schemas/ExperimentDesignMultiPref"
+                    }
+                  }
+                },
+                "description": ""
+              }
+            },
+            "tags": [
+              "Core: Private"
+            ]
+          },
+          "put": {
+            "operationId": "updateExperiment",
+            "description": "",
+            "parameters": [
+              {
+                "name": "slug",
+                "in": "path",
+                "required": true,
+                "description": "",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            ],
+            "requestBody": {
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ExperimentDesignMultiPref"
+                  }
+                },
+                "application/x-www-form-urlencoded": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ExperimentDesignMultiPref"
+                  }
+                },
+                "multipart/form-data": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ExperimentDesignMultiPref"
+                  }
+                }
+              }
+            },
+            "responses": {
+              "200": {
+                "content": {
+                  "application/json": {
+                    "schema": {
+                      "$ref": "#/components/schemas/ExperimentDesignMultiPref"
+                    }
+                  }
+                },
+                "description": ""
+              }
+            },
+            "tags": [
+              "Core: Private"
+            ]
+          },
+          "patch": {
+            "operationId": "partialUpdateExperiment",
+            "description": "",
+            "parameters": [
+              {
+                "name": "slug",
+                "in": "path",
+                "required": true,
+                "description": "",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            ],
+            "requestBody": {
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ExperimentDesignMultiPref"
+                  }
+                },
+                "application/x-www-form-urlencoded": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ExperimentDesignMultiPref"
+                  }
+                },
+                "multipart/form-data": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ExperimentDesignMultiPref"
+                  }
+                }
+              }
+            },
+            "responses": {
+              "200": {
+                "content": {
+                  "application/json": {
+                    "schema": {
+                      "$ref": "#/components/schemas/ExperimentDesignMultiPref"
+                    }
+                  }
+                },
+                "description": ""
+              }
+            },
+            "tags": [
+              "Core: Private"
+            ]
+          }
+        },
+        "/api/v2/experiments/{slug}/design-generic": {
+          "get": {
+            "operationId": "retrieveExperiment",
+            "description": "",
+            "parameters": [
+              {
+                "name": "slug",
+                "in": "path",
+                "required": true,
+                "description": "",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            ],
+            "responses": {
+              "200": {
+                "content": {
+                  "application/json": {
+                    "schema": {
+                      "$ref": "#/components/schemas/ExperimentDesignGeneric"
+                    }
+                  }
+                },
+                "description": ""
+              }
+            },
+            "tags": [
+              "Core: Private"
+            ]
+          },
+          "put": {
+            "operationId": "updateExperiment",
+            "description": "",
+            "parameters": [
+              {
+                "name": "slug",
+                "in": "path",
+                "required": true,
+                "description": "",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            ],
+            "requestBody": {
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ExperimentDesignGeneric"
+                  }
+                },
+                "application/x-www-form-urlencoded": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ExperimentDesignGeneric"
+                  }
+                },
+                "multipart/form-data": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ExperimentDesignGeneric"
+                  }
+                }
+              }
+            },
+            "responses": {
+              "200": {
+                "content": {
+                  "application/json": {
+                    "schema": {
+                      "$ref": "#/components/schemas/ExperimentDesignGeneric"
+                    }
+                  }
+                },
+                "description": ""
+              }
+            },
+            "tags": [
+              "Core: Private"
+            ]
+          },
+          "patch": {
+            "operationId": "partialUpdateExperiment",
+            "description": "",
+            "parameters": [
+              {
+                "name": "slug",
+                "in": "path",
+                "required": true,
+                "description": "",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            ],
+            "requestBody": {
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ExperimentDesignGeneric"
+                  }
+                },
+                "application/x-www-form-urlencoded": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ExperimentDesignGeneric"
+                  }
+                },
+                "multipart/form-data": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ExperimentDesignGeneric"
+                  }
+                }
+              }
+            },
+            "responses": {
+              "200": {
+                "content": {
+                  "application/json": {
+                    "schema": {
+                      "$ref": "#/components/schemas/ExperimentDesignGeneric"
+                    }
+                  }
+                },
+                "description": ""
+              }
+            },
+            "tags": [
+              "Core: Private"
+            ]
+          }
+        },
+        "/api/v2/experiments/{slug}/design-branched-addon": {
+          "get": {
+            "operationId": "retrieveExperiment",
+            "description": "",
+            "parameters": [
+              {
+                "name": "slug",
+                "in": "path",
+                "required": true,
+                "description": "",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            ],
+            "responses": {
+              "200": {
+                "content": {
+                  "application/json": {
+                    "schema": {
+                      "$ref": "#/components/schemas/ExperimentDesignBranchedAddon"
+                    }
+                  }
+                },
+                "description": ""
+              }
+            },
+            "tags": [
+              "Core: Private"
+            ]
+          },
+          "put": {
+            "operationId": "updateExperiment",
+            "description": "",
+            "parameters": [
+              {
+                "name": "slug",
+                "in": "path",
+                "required": true,
+                "description": "",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            ],
+            "requestBody": {
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ExperimentDesignBranchedAddon"
+                  }
+                },
+                "application/x-www-form-urlencoded": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ExperimentDesignBranchedAddon"
+                  }
+                },
+                "multipart/form-data": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ExperimentDesignBranchedAddon"
+                  }
+                }
+              }
+            },
+            "responses": {
+              "200": {
+                "content": {
+                  "application/json": {
+                    "schema": {
+                      "$ref": "#/components/schemas/ExperimentDesignBranchedAddon"
+                    }
+                  }
+                },
+                "description": ""
+              }
+            },
+            "tags": [
+              "Core: Private"
+            ]
+          },
+          "patch": {
+            "operationId": "partialUpdateExperiment",
+            "description": "",
+            "parameters": [
+              {
+                "name": "slug",
+                "in": "path",
+                "required": true,
+                "description": "",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            ],
+            "requestBody": {
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ExperimentDesignBranchedAddon"
+                  }
+                },
+                "application/x-www-form-urlencoded": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ExperimentDesignBranchedAddon"
+                  }
+                },
+                "multipart/form-data": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ExperimentDesignBranchedAddon"
+                  }
+                }
+              }
+            },
+            "responses": {
+              "200": {
+                "content": {
+                  "application/json": {
+                    "schema": {
+                      "$ref": "#/components/schemas/ExperimentDesignBranchedAddon"
+                    }
+                  }
+                },
+                "description": ""
+              }
+            },
+            "tags": [
+              "Core: Private"
+            ]
+          }
+        },
+        "/api/v2/experiments/{slug}/design-message": {
+          "get": {
+            "operationId": "retrieveExperiment",
+            "description": "",
+            "parameters": [
+              {
+                "name": "slug",
+                "in": "path",
+                "required": true,
+                "description": "",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            ],
+            "responses": {
+              "200": {
+                "content": {
+                  "application/json": {
+                    "schema": {
+                      "$ref": "#/components/schemas/ExperimentDesignMessage"
+                    }
+                  }
+                },
+                "description": ""
+              }
+            },
+            "tags": [
+              "Core: Private"
+            ]
+          },
+          "put": {
+            "operationId": "updateExperiment",
+            "description": "",
+            "parameters": [
+              {
+                "name": "slug",
+                "in": "path",
+                "required": true,
+                "description": "",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            ],
+            "requestBody": {
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ExperimentDesignMessage"
+                  }
+                },
+                "application/x-www-form-urlencoded": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ExperimentDesignMessage"
+                  }
+                },
+                "multipart/form-data": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ExperimentDesignMessage"
+                  }
+                }
+              }
+            },
+            "responses": {
+              "200": {
+                "content": {
+                  "application/json": {
+                    "schema": {
+                      "$ref": "#/components/schemas/ExperimentDesignMessage"
+                    }
+                  }
+                },
+                "description": ""
+              }
+            },
+            "tags": [
+              "Core: Private"
+            ]
+          },
+          "patch": {
+            "operationId": "partialUpdateExperiment",
+            "description": "",
+            "parameters": [
+              {
+                "name": "slug",
+                "in": "path",
+                "required": true,
+                "description": "",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            ],
+            "requestBody": {
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ExperimentDesignMessage"
+                  }
+                },
+                "application/x-www-form-urlencoded": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ExperimentDesignMessage"
+                  }
+                },
+                "multipart/form-data": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ExperimentDesignMessage"
+                  }
+                }
+              }
+            },
+            "responses": {
+              "200": {
+                "content": {
+                  "application/json": {
+                    "schema": {
+                      "$ref": "#/components/schemas/ExperimentDesignMessage"
+                    }
+                  }
+                },
+                "description": ""
+              }
+            },
+            "tags": [
+              "Core: Private"
+            ]
+          }
+        },
+        "/api/v2/experiments/{slug}/timeline-population": {
+          "get": {
+            "operationId": "retrieveExperiment",
+            "description": "",
+            "parameters": [
+              {
+                "name": "slug",
+                "in": "path",
+                "required": true,
+                "description": "",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            ],
+            "responses": {
+              "200": {
+                "content": {
+                  "application/json": {
+                    "schema": {
+                      "$ref": "#/components/schemas/ExperimentTimelinePop"
+                    }
+                  }
+                },
+                "description": ""
+              }
+            },
+            "tags": [
+              "Core: Private"
+            ]
+          },
+          "put": {
+            "operationId": "updateExperiment",
+            "description": "",
+            "parameters": [
+              {
+                "name": "slug",
+                "in": "path",
+                "required": true,
+                "description": "",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            ],
+            "requestBody": {
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ExperimentTimelinePop"
+                  }
+                },
+                "application/x-www-form-urlencoded": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ExperimentTimelinePop"
+                  }
+                },
+                "multipart/form-data": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ExperimentTimelinePop"
+                  }
+                }
+              }
+            },
+            "responses": {
+              "200": {
+                "content": {
+                  "application/json": {
+                    "schema": {
+                      "$ref": "#/components/schemas/ExperimentTimelinePop"
+                    }
+                  }
+                },
+                "description": ""
+              }
+            },
+            "tags": [
+              "Core: Private"
+            ]
+          },
+          "patch": {
+            "operationId": "partialUpdateExperiment",
+            "description": "",
+            "parameters": [
+              {
+                "name": "slug",
+                "in": "path",
+                "required": true,
+                "description": "",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            ],
+            "requestBody": {
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ExperimentTimelinePop"
+                  }
+                },
+                "application/x-www-form-urlencoded": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ExperimentTimelinePop"
+                  }
+                },
+                "multipart/form-data": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ExperimentTimelinePop"
+                  }
+                }
+              }
+            },
+            "responses": {
+              "200": {
+                "content": {
+                  "application/json": {
+                    "schema": {
+                      "$ref": "#/components/schemas/ExperimentTimelinePop"
+                    }
+                  }
+                },
+                "description": ""
+              }
+            },
+            "tags": [
+              "Core: Private"
+            ]
+          }
+        },
+        "/api/v3/visualization/{slug}/": {
+          "get": {
+            "operationId": "retrieveanalysis_results_view",
+            "description": "",
+            "parameters": [
+              {
+                "name": "slug",
+                "in": "path",
+                "required": true,
+                "description": "",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            ],
+            "responses": {
+              "200": {
+                "content": {
+                  "application/json": {
+                    "schema": {}
+                  }
+                },
+                "description": ""
+              }
+            },
+            "tags": [
+              "api"
+            ]
+          }
+        },
+        "/api/v5/csv/": {
+          "get": {
+            "operationId": "listNimbusExperiments",
+            "description": "",
+            "parameters": [],
+            "responses": {
+              "200": {
+                "content": {
+                  "text/csv": {
+                    "schema": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/NimbusExperimentCsv"
+                      }
+                    }
+                  }
+                },
+                "description": ""
+              }
+            },
+            "tags": [
+              "api"
+            ]
+          }
+        },
+        "/api/v5/config/": {
+          "get": {
+            "operationId": "retrieveNimbusConfiguration",
+            "description": "",
+            "parameters": [],
+            "responses": {
+              "200": {
+                "content": {
+                  "application/json": {
+                    "schema": {
+                      "$ref": "#/components/schemas/NimbusConfiguration"
+                    }
+                  }
+                },
+                "description": ""
+              }
+            },
+            "tags": [
+              "api"
+            ]
+          }
+        },
+        "/api/v6/experiments/": {
+          "get": {
+            "operationId": "listNimbusExperiments",
+            "description": "",
+            "parameters": [
+              {
+                "name": "is_first_run",
+                "required": false,
+                "in": "query",
+                "description": "is_first_run",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            ],
+            "responses": {
+              "200": {
+                "content": {
+                  "application/json": {
+                    "schema": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/NimbusExperiment"
+                      }
+                    }
+                  }
+                },
+                "description": ""
+              }
+            },
+            "tags": [
+              "Nimbus: Public"
+            ]
+          }
+        },
+        "/api/v6/experiments/{slug}/": {
+          "get": {
+            "operationId": "retrieveNimbusExperiment",
+            "description": "",
+            "parameters": [
+              {
+                "name": "slug",
+                "in": "path",
+                "required": true,
+                "description": "",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              {
+                "name": "is_first_run",
+                "required": false,
+                "in": "query",
+                "description": "is_first_run",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            ],
+            "responses": {
+              "200": {
+                "content": {
+                  "application/json": {
+                    "schema": {
+                      "$ref": "#/components/schemas/NimbusExperiment"
+                    }
+                  }
+                },
+                "description": ""
+              }
+            },
+            "tags": [
+              "Nimbus: Public"
+            ]
+          }
+        },
+        "/api/v6/experiments-first-run/": {
+          "get": {
+            "operationId": "listNimbusExperiments",
+            "description": "",
+            "parameters": [
+              {
+                "name": "is_first_run",
+                "required": false,
+                "in": "query",
+                "description": "is_first_run",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            ],
+            "responses": {
+              "200": {
+                "content": {
+                  "application/json": {
+                    "schema": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/NimbusExperiment"
+                      }
+                    }
+                  }
+                },
+                "description": ""
+              }
+            },
+            "tags": [
+              "Nimbus: Public"
+            ]
+          }
+        },
+        "/api/v6/experiments-first-run/{slug}/": {
+          "get": {
+            "operationId": "retrieveNimbusExperiment",
+            "description": "",
+            "parameters": [
+              {
+                "name": "slug",
+                "in": "path",
+                "required": true,
+                "description": "",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              {
+                "name": "is_first_run",
+                "required": false,
+                "in": "query",
+                "description": "is_first_run",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            ],
+            "responses": {
+              "200": {
+                "content": {
+                  "application/json": {
+                    "schema": {
+                      "$ref": "#/components/schemas/NimbusExperiment"
+                    }
+                  }
+                },
+                "description": ""
+              }
+            },
+            "tags": [
+              "Nimbus: Public"
+            ]
+          }
+        },
+        "/api/v2/experiments/{slug}/intent-to-ship-email": {
+          "put": {
+            "operationId": "updateExperiment",
+            "description": "",
+            "parameters": [
+              {
+                "name": "slug",
+                "in": "path",
+                "required": true,
+                "description": "",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            ],
+            "requestBody": {
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/Experiment"
+                  }
+                },
+                "application/x-www-form-urlencoded": {
+                  "schema": {
+                    "$ref": "#/components/schemas/Experiment"
+                  }
+                },
+                "multipart/form-data": {
+                  "schema": {
                     "$ref": "#/components/schemas/Experiment"
                   }
                 }
               }
             },
-            "description": ""
-          }
-        },
-        "tags": [
-          "Core: Public"
-        ]
-      }
-    },
-    "/api/v2/experiments/csv/": {
-      "get": {
-        "operationId": "listExperiments",
-        "description": "",
-        "parameters": [],
-        "responses": {
-          "200": {
-            "content": {
-              "text/csv": {
+            "responses": {
+              "200": {
+                "content": {
+                  "application/json": {
+                    "schema": {
+                      "$ref": "#/components/schemas/Experiment"
+                    }
+                  }
+                },
+                "description": ""
+              }
+            },
+            "tags": [
+              "Core: Private"
+            ]
+          },
+          "patch": {
+            "operationId": "partialUpdateExperiment",
+            "description": "",
+            "parameters": [
+              {
+                "name": "slug",
+                "in": "path",
+                "required": true,
+                "description": "",
                 "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/ExperimentCSV"
+                  "type": "string"
+                }
+              }
+            ],
+            "requestBody": {
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/Experiment"
+                  }
+                },
+                "application/x-www-form-urlencoded": {
+                  "schema": {
+                    "$ref": "#/components/schemas/Experiment"
+                  }
+                },
+                "multipart/form-data": {
+                  "schema": {
+                    "$ref": "#/components/schemas/Experiment"
                   }
                 }
               }
             },
-            "description": ""
+            "responses": {
+              "200": {
+                "content": {
+                  "application/json": {
+                    "schema": {
+                      "$ref": "#/components/schemas/Experiment"
+                    }
+                  }
+                },
+                "description": ""
+              }
+            },
+            "tags": [
+              "Core: Private"
+            ]
           }
         },
-        "tags": [
-          "Core: Private"
-        ]
-      }
-    },
-    "/api/v2/experiments/{slug}/design-addon-rollout": {
-      "get": {
-        "operationId": "retrieveExperiment",
-        "description": "",
-        "parameters": [
-          {
-            "name": "slug",
-            "in": "path",
-            "required": true,
+        "/api/v2/experiments/{slug}/clone": {
+          "put": {
+            "operationId": "updateExperiment",
             "description": "",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
+            "parameters": [
+              {
+                "name": "slug",
+                "in": "path",
+                "required": true,
+                "description": "",
                 "schema": {
-                  "$ref": "#/components/schemas/ExperimentDesignAddonRollout"
+                  "type": "string"
                 }
               }
-            },
-            "description": ""
-          }
-        },
-        "tags": [
-          "Core: Private"
-        ]
-      },
-      "put": {
-        "operationId": "updateExperiment",
-        "description": "",
-        "parameters": [
-          {
-            "name": "slug",
-            "in": "path",
-            "required": true,
-            "description": "",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ExperimentDesignAddonRollout"
-              }
-            },
-            "application/x-www-form-urlencoded": {
-              "schema": {
-                "$ref": "#/components/schemas/ExperimentDesignAddonRollout"
-              }
-            },
-            "multipart/form-data": {
-              "schema": {
-                "$ref": "#/components/schemas/ExperimentDesignAddonRollout"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ExperimentDesignAddonRollout"
-                }
-              }
-            },
-            "description": ""
-          }
-        },
-        "tags": [
-          "Core: Private"
-        ]
-      },
-      "patch": {
-        "operationId": "partialUpdateExperiment",
-        "description": "",
-        "parameters": [
-          {
-            "name": "slug",
-            "in": "path",
-            "required": true,
-            "description": "",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ExperimentDesignAddonRollout"
-              }
-            },
-            "application/x-www-form-urlencoded": {
-              "schema": {
-                "$ref": "#/components/schemas/ExperimentDesignAddonRollout"
-              }
-            },
-            "multipart/form-data": {
-              "schema": {
-                "$ref": "#/components/schemas/ExperimentDesignAddonRollout"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ExperimentDesignAddonRollout"
-                }
-              }
-            },
-            "description": ""
-          }
-        },
-        "tags": [
-          "Core: Private"
-        ]
-      }
-    },
-    "/api/v2/experiments/{slug}/design-addon": {
-      "get": {
-        "operationId": "retrieveExperiment",
-        "description": "",
-        "parameters": [
-          {
-            "name": "slug",
-            "in": "path",
-            "required": true,
-            "description": "",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ExperimentDesignAddon"
-                }
-              }
-            },
-            "description": ""
-          }
-        },
-        "tags": [
-          "Core: Private"
-        ]
-      },
-      "put": {
-        "operationId": "updateExperiment",
-        "description": "",
-        "parameters": [
-          {
-            "name": "slug",
-            "in": "path",
-            "required": true,
-            "description": "",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ExperimentDesignAddon"
-              }
-            },
-            "application/x-www-form-urlencoded": {
-              "schema": {
-                "$ref": "#/components/schemas/ExperimentDesignAddon"
-              }
-            },
-            "multipart/form-data": {
-              "schema": {
-                "$ref": "#/components/schemas/ExperimentDesignAddon"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ExperimentDesignAddon"
-                }
-              }
-            },
-            "description": ""
-          }
-        },
-        "tags": [
-          "Core: Private"
-        ]
-      },
-      "patch": {
-        "operationId": "partialUpdateExperiment",
-        "description": "",
-        "parameters": [
-          {
-            "name": "slug",
-            "in": "path",
-            "required": true,
-            "description": "",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ExperimentDesignAddon"
-              }
-            },
-            "application/x-www-form-urlencoded": {
-              "schema": {
-                "$ref": "#/components/schemas/ExperimentDesignAddon"
-              }
-            },
-            "multipart/form-data": {
-              "schema": {
-                "$ref": "#/components/schemas/ExperimentDesignAddon"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ExperimentDesignAddon"
-                }
-              }
-            },
-            "description": ""
-          }
-        },
-        "tags": [
-          "Core: Private"
-        ]
-      }
-    },
-    "/api/v2/experiments/{slug}/design-pref-rollout": {
-      "get": {
-        "operationId": "retrieveExperiment",
-        "description": "",
-        "parameters": [
-          {
-            "name": "slug",
-            "in": "path",
-            "required": true,
-            "description": "",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ExperimentDesignPrefRollout"
-                }
-              }
-            },
-            "description": ""
-          }
-        },
-        "tags": [
-          "Core: Private"
-        ]
-      },
-      "put": {
-        "operationId": "updateExperiment",
-        "description": "",
-        "parameters": [
-          {
-            "name": "slug",
-            "in": "path",
-            "required": true,
-            "description": "",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ExperimentDesignPrefRollout"
-              }
-            },
-            "application/x-www-form-urlencoded": {
-              "schema": {
-                "$ref": "#/components/schemas/ExperimentDesignPrefRollout"
-              }
-            },
-            "multipart/form-data": {
-              "schema": {
-                "$ref": "#/components/schemas/ExperimentDesignPrefRollout"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ExperimentDesignPrefRollout"
-                }
-              }
-            },
-            "description": ""
-          }
-        },
-        "tags": [
-          "Core: Private"
-        ]
-      },
-      "patch": {
-        "operationId": "partialUpdateExperiment",
-        "description": "",
-        "parameters": [
-          {
-            "name": "slug",
-            "in": "path",
-            "required": true,
-            "description": "",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ExperimentDesignPrefRollout"
-              }
-            },
-            "application/x-www-form-urlencoded": {
-              "schema": {
-                "$ref": "#/components/schemas/ExperimentDesignPrefRollout"
-              }
-            },
-            "multipart/form-data": {
-              "schema": {
-                "$ref": "#/components/schemas/ExperimentDesignPrefRollout"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ExperimentDesignPrefRollout"
-                }
-              }
-            },
-            "description": ""
-          }
-        },
-        "tags": [
-          "Core: Private"
-        ]
-      }
-    },
-    "/api/v2/experiments/{slug}/design-pref": {
-      "get": {
-        "operationId": "retrieveExperiment",
-        "description": "",
-        "parameters": [
-          {
-            "name": "slug",
-            "in": "path",
-            "required": true,
-            "description": "",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ExperimentDesignPref"
-                }
-              }
-            },
-            "description": ""
-          }
-        },
-        "tags": [
-          "Core: Private"
-        ]
-      },
-      "put": {
-        "operationId": "updateExperiment",
-        "description": "",
-        "parameters": [
-          {
-            "name": "slug",
-            "in": "path",
-            "required": true,
-            "description": "",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ExperimentDesignPref"
-              }
-            },
-            "application/x-www-form-urlencoded": {
-              "schema": {
-                "$ref": "#/components/schemas/ExperimentDesignPref"
-              }
-            },
-            "multipart/form-data": {
-              "schema": {
-                "$ref": "#/components/schemas/ExperimentDesignPref"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ExperimentDesignPref"
-                }
-              }
-            },
-            "description": ""
-          }
-        },
-        "tags": [
-          "Core: Private"
-        ]
-      },
-      "patch": {
-        "operationId": "partialUpdateExperiment",
-        "description": "",
-        "parameters": [
-          {
-            "name": "slug",
-            "in": "path",
-            "required": true,
-            "description": "",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ExperimentDesignPref"
-              }
-            },
-            "application/x-www-form-urlencoded": {
-              "schema": {
-                "$ref": "#/components/schemas/ExperimentDesignPref"
-              }
-            },
-            "multipart/form-data": {
-              "schema": {
-                "$ref": "#/components/schemas/ExperimentDesignPref"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ExperimentDesignPref"
-                }
-              }
-            },
-            "description": ""
-          }
-        },
-        "tags": [
-          "Core: Private"
-        ]
-      }
-    },
-    "/api/v2/experiments/{slug}/design-multi-pref": {
-      "get": {
-        "operationId": "retrieveExperiment",
-        "description": "",
-        "parameters": [
-          {
-            "name": "slug",
-            "in": "path",
-            "required": true,
-            "description": "",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ExperimentDesignMultiPref"
-                }
-              }
-            },
-            "description": ""
-          }
-        },
-        "tags": [
-          "Core: Private"
-        ]
-      },
-      "put": {
-        "operationId": "updateExperiment",
-        "description": "",
-        "parameters": [
-          {
-            "name": "slug",
-            "in": "path",
-            "required": true,
-            "description": "",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ExperimentDesignMultiPref"
-              }
-            },
-            "application/x-www-form-urlencoded": {
-              "schema": {
-                "$ref": "#/components/schemas/ExperimentDesignMultiPref"
-              }
-            },
-            "multipart/form-data": {
-              "schema": {
-                "$ref": "#/components/schemas/ExperimentDesignMultiPref"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ExperimentDesignMultiPref"
-                }
-              }
-            },
-            "description": ""
-          }
-        },
-        "tags": [
-          "Core: Private"
-        ]
-      },
-      "patch": {
-        "operationId": "partialUpdateExperiment",
-        "description": "",
-        "parameters": [
-          {
-            "name": "slug",
-            "in": "path",
-            "required": true,
-            "description": "",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ExperimentDesignMultiPref"
-              }
-            },
-            "application/x-www-form-urlencoded": {
-              "schema": {
-                "$ref": "#/components/schemas/ExperimentDesignMultiPref"
-              }
-            },
-            "multipart/form-data": {
-              "schema": {
-                "$ref": "#/components/schemas/ExperimentDesignMultiPref"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ExperimentDesignMultiPref"
-                }
-              }
-            },
-            "description": ""
-          }
-        },
-        "tags": [
-          "Core: Private"
-        ]
-      }
-    },
-    "/api/v2/experiments/{slug}/design-generic": {
-      "get": {
-        "operationId": "retrieveExperiment",
-        "description": "",
-        "parameters": [
-          {
-            "name": "slug",
-            "in": "path",
-            "required": true,
-            "description": "",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ExperimentDesignGeneric"
-                }
-              }
-            },
-            "description": ""
-          }
-        },
-        "tags": [
-          "Core: Private"
-        ]
-      },
-      "put": {
-        "operationId": "updateExperiment",
-        "description": "",
-        "parameters": [
-          {
-            "name": "slug",
-            "in": "path",
-            "required": true,
-            "description": "",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ExperimentDesignGeneric"
-              }
-            },
-            "application/x-www-form-urlencoded": {
-              "schema": {
-                "$ref": "#/components/schemas/ExperimentDesignGeneric"
-              }
-            },
-            "multipart/form-data": {
-              "schema": {
-                "$ref": "#/components/schemas/ExperimentDesignGeneric"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ExperimentDesignGeneric"
-                }
-              }
-            },
-            "description": ""
-          }
-        },
-        "tags": [
-          "Core: Private"
-        ]
-      },
-      "patch": {
-        "operationId": "partialUpdateExperiment",
-        "description": "",
-        "parameters": [
-          {
-            "name": "slug",
-            "in": "path",
-            "required": true,
-            "description": "",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ExperimentDesignGeneric"
-              }
-            },
-            "application/x-www-form-urlencoded": {
-              "schema": {
-                "$ref": "#/components/schemas/ExperimentDesignGeneric"
-              }
-            },
-            "multipart/form-data": {
-              "schema": {
-                "$ref": "#/components/schemas/ExperimentDesignGeneric"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ExperimentDesignGeneric"
-                }
-              }
-            },
-            "description": ""
-          }
-        },
-        "tags": [
-          "Core: Private"
-        ]
-      }
-    },
-    "/api/v2/experiments/{slug}/design-branched-addon": {
-      "get": {
-        "operationId": "retrieveExperiment",
-        "description": "",
-        "parameters": [
-          {
-            "name": "slug",
-            "in": "path",
-            "required": true,
-            "description": "",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ExperimentDesignBranchedAddon"
-                }
-              }
-            },
-            "description": ""
-          }
-        },
-        "tags": [
-          "Core: Private"
-        ]
-      },
-      "put": {
-        "operationId": "updateExperiment",
-        "description": "",
-        "parameters": [
-          {
-            "name": "slug",
-            "in": "path",
-            "required": true,
-            "description": "",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ExperimentDesignBranchedAddon"
-              }
-            },
-            "application/x-www-form-urlencoded": {
-              "schema": {
-                "$ref": "#/components/schemas/ExperimentDesignBranchedAddon"
-              }
-            },
-            "multipart/form-data": {
-              "schema": {
-                "$ref": "#/components/schemas/ExperimentDesignBranchedAddon"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ExperimentDesignBranchedAddon"
-                }
-              }
-            },
-            "description": ""
-          }
-        },
-        "tags": [
-          "Core: Private"
-        ]
-      },
-      "patch": {
-        "operationId": "partialUpdateExperiment",
-        "description": "",
-        "parameters": [
-          {
-            "name": "slug",
-            "in": "path",
-            "required": true,
-            "description": "",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ExperimentDesignBranchedAddon"
-              }
-            },
-            "application/x-www-form-urlencoded": {
-              "schema": {
-                "$ref": "#/components/schemas/ExperimentDesignBranchedAddon"
-              }
-            },
-            "multipart/form-data": {
-              "schema": {
-                "$ref": "#/components/schemas/ExperimentDesignBranchedAddon"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ExperimentDesignBranchedAddon"
-                }
-              }
-            },
-            "description": ""
-          }
-        },
-        "tags": [
-          "Core: Private"
-        ]
-      }
-    },
-    "/api/v2/experiments/{slug}/design-message": {
-      "get": {
-        "operationId": "retrieveExperiment",
-        "description": "",
-        "parameters": [
-          {
-            "name": "slug",
-            "in": "path",
-            "required": true,
-            "description": "",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ExperimentDesignMessage"
-                }
-              }
-            },
-            "description": ""
-          }
-        },
-        "tags": [
-          "Core: Private"
-        ]
-      },
-      "put": {
-        "operationId": "updateExperiment",
-        "description": "",
-        "parameters": [
-          {
-            "name": "slug",
-            "in": "path",
-            "required": true,
-            "description": "",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ExperimentDesignMessage"
-              }
-            },
-            "application/x-www-form-urlencoded": {
-              "schema": {
-                "$ref": "#/components/schemas/ExperimentDesignMessage"
-              }
-            },
-            "multipart/form-data": {
-              "schema": {
-                "$ref": "#/components/schemas/ExperimentDesignMessage"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ExperimentDesignMessage"
-                }
-              }
-            },
-            "description": ""
-          }
-        },
-        "tags": [
-          "Core: Private"
-        ]
-      },
-      "patch": {
-        "operationId": "partialUpdateExperiment",
-        "description": "",
-        "parameters": [
-          {
-            "name": "slug",
-            "in": "path",
-            "required": true,
-            "description": "",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ExperimentDesignMessage"
-              }
-            },
-            "application/x-www-form-urlencoded": {
-              "schema": {
-                "$ref": "#/components/schemas/ExperimentDesignMessage"
-              }
-            },
-            "multipart/form-data": {
-              "schema": {
-                "$ref": "#/components/schemas/ExperimentDesignMessage"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ExperimentDesignMessage"
-                }
-              }
-            },
-            "description": ""
-          }
-        },
-        "tags": [
-          "Core: Private"
-        ]
-      }
-    },
-    "/api/v2/experiments/{slug}/timeline-population": {
-      "get": {
-        "operationId": "retrieveExperiment",
-        "description": "",
-        "parameters": [
-          {
-            "name": "slug",
-            "in": "path",
-            "required": true,
-            "description": "",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ExperimentTimelinePop"
-                }
-              }
-            },
-            "description": ""
-          }
-        },
-        "tags": [
-          "Core: Private"
-        ]
-      },
-      "put": {
-        "operationId": "updateExperiment",
-        "description": "",
-        "parameters": [
-          {
-            "name": "slug",
-            "in": "path",
-            "required": true,
-            "description": "",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ExperimentTimelinePop"
-              }
-            },
-            "application/x-www-form-urlencoded": {
-              "schema": {
-                "$ref": "#/components/schemas/ExperimentTimelinePop"
-              }
-            },
-            "multipart/form-data": {
-              "schema": {
-                "$ref": "#/components/schemas/ExperimentTimelinePop"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ExperimentTimelinePop"
-                }
-              }
-            },
-            "description": ""
-          }
-        },
-        "tags": [
-          "Core: Private"
-        ]
-      },
-      "patch": {
-        "operationId": "partialUpdateExperiment",
-        "description": "",
-        "parameters": [
-          {
-            "name": "slug",
-            "in": "path",
-            "required": true,
-            "description": "",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ExperimentTimelinePop"
-              }
-            },
-            "application/x-www-form-urlencoded": {
-              "schema": {
-                "$ref": "#/components/schemas/ExperimentTimelinePop"
-              }
-            },
-            "multipart/form-data": {
-              "schema": {
-                "$ref": "#/components/schemas/ExperimentTimelinePop"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ExperimentTimelinePop"
-                }
-              }
-            },
-            "description": ""
-          }
-        },
-        "tags": [
-          "Core: Private"
-        ]
-      }
-    },
-    "/api/v3/visualization/{slug}/": {
-      "get": {
-        "operationId": "retrieveanalysis_results_view",
-        "description": "",
-        "parameters": [
-          {
-            "name": "slug",
-            "in": "path",
-            "required": true,
-            "description": "",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            },
-            "description": ""
-          }
-        },
-        "tags": [
-          "api"
-        ]
-      }
-    },
-    "/api/v5/csv/": {
-      "get": {
-        "operationId": "listNimbusExperiments",
-        "description": "",
-        "parameters": [],
-        "responses": {
-          "200": {
-            "content": {
-              "text/csv": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/NimbusExperimentCsv"
+            ],
+            "requestBody": {
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ExperimentClone"
+                  }
+                },
+                "application/x-www-form-urlencoded": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ExperimentClone"
+                  }
+                },
+                "multipart/form-data": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ExperimentClone"
                   }
                 }
               }
             },
-            "description": ""
-          }
-        },
-        "tags": [
-          "api"
-        ]
-      }
-    },
-    "/api/v5/config/": {
-      "get": {
-        "operationId": "retrieveNimbusConfiguration",
-        "description": "",
-        "parameters": [],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/NimbusConfiguration"
-                }
+            "responses": {
+              "200": {
+                "content": {
+                  "application/json": {
+                    "schema": {
+                      "$ref": "#/components/schemas/ExperimentClone"
+                    }
+                  }
+                },
+                "description": ""
               }
             },
-            "description": ""
-          }
-        },
-        "tags": [
-          "api"
-        ]
-      }
-    },
-    "/api/v6/experiments/": {
-      "get": {
-        "operationId": "listNimbusExperiments",
-        "description": "",
-        "parameters": [
-          {
-            "name": "is_first_run",
-            "required": false,
-            "in": "query",
-            "description": "is_first_run",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
+            "tags": [
+              "Core: Private"
+            ]
+          },
+          "patch": {
+            "operationId": "partialUpdateExperiment",
+            "description": "",
+            "parameters": [
+              {
+                "name": "slug",
+                "in": "path",
+                "required": true,
+                "description": "",
                 "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/NimbusExperiment"
+                  "type": "string"
+                }
+              }
+            ],
+            "requestBody": {
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ExperimentClone"
+                  }
+                },
+                "application/x-www-form-urlencoded": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ExperimentClone"
+                  }
+                },
+                "multipart/form-data": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ExperimentClone"
                   }
                 }
               }
             },
-            "description": ""
-          }
-        },
-        "tags": [
-          "Nimbus: Public"
-        ]
-      }
-    },
-    "/api/v6/experiments/{slug}/": {
-      "get": {
-        "operationId": "retrieveNimbusExperiment",
-        "description": "",
-        "parameters": [
-          {
-            "name": "slug",
-            "in": "path",
-            "required": true,
-            "description": "",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "is_first_run",
-            "required": false,
-            "in": "query",
-            "description": "is_first_run",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/NimbusExperiment"
-                }
-              }
-            },
-            "description": ""
-          }
-        },
-        "tags": [
-          "Nimbus: Public"
-        ]
-      }
-    },
-    "/api/v6/experiments-first-run/": {
-      "get": {
-        "operationId": "listNimbusExperiments",
-        "description": "",
-        "parameters": [
-          {
-            "name": "is_first_run",
-            "required": false,
-            "in": "query",
-            "description": "is_first_run",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/NimbusExperiment"
-                  }
-                }
-              }
-            },
-            "description": ""
-          }
-        },
-        "tags": [
-          "Nimbus: Public"
-        ]
-      }
-    },
-    "/api/v6/experiments-first-run/{slug}/": {
-      "get": {
-        "operationId": "retrieveNimbusExperiment",
-        "description": "",
-        "parameters": [
-          {
-            "name": "slug",
-            "in": "path",
-            "required": true,
-            "description": "",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "is_first_run",
-            "required": false,
-            "in": "query",
-            "description": "is_first_run",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/NimbusExperiment"
-                }
-              }
-            },
-            "description": ""
-          }
-        },
-        "tags": [
-          "Nimbus: Public"
-        ]
-      }
-    },
-    "/api/v2/experiments/{slug}/intent-to-ship-email": {
-      "put": {
-        "operationId": "updateExperiment",
-        "description": "",
-        "parameters": [
-          {
-            "name": "slug",
-            "in": "path",
-            "required": true,
-            "description": "",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/Experiment"
-              }
-            },
-            "application/x-www-form-urlencoded": {
-              "schema": {
-                "$ref": "#/components/schemas/Experiment"
-              }
-            },
-            "multipart/form-data": {
-              "schema": {
-                "$ref": "#/components/schemas/Experiment"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Experiment"
-                }
-              }
-            },
-            "description": ""
-          }
-        },
-        "tags": [
-          "Core: Private"
-        ]
-      },
-      "patch": {
-        "operationId": "partialUpdateExperiment",
-        "description": "",
-        "parameters": [
-          {
-            "name": "slug",
-            "in": "path",
-            "required": true,
-            "description": "",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/Experiment"
-              }
-            },
-            "application/x-www-form-urlencoded": {
-              "schema": {
-                "$ref": "#/components/schemas/Experiment"
-              }
-            },
-            "multipart/form-data": {
-              "schema": {
-                "$ref": "#/components/schemas/Experiment"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Experiment"
-                }
-              }
-            },
-            "description": ""
-          }
-        },
-        "tags": [
-          "Core: Private"
-        ]
-      }
-    },
-    "/api/v2/experiments/{slug}/clone": {
-      "put": {
-        "operationId": "updateExperiment",
-        "description": "",
-        "parameters": [
-          {
-            "name": "slug",
-            "in": "path",
-            "required": true,
-            "description": "",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ExperimentClone"
-              }
-            },
-            "application/x-www-form-urlencoded": {
-              "schema": {
-                "$ref": "#/components/schemas/ExperimentClone"
-              }
-            },
-            "multipart/form-data": {
-              "schema": {
-                "$ref": "#/components/schemas/ExperimentClone"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ExperimentClone"
-                }
-              }
-            },
-            "description": ""
-          }
-        },
-        "tags": [
-          "Core: Private"
-        ]
-      },
-      "patch": {
-        "operationId": "partialUpdateExperiment",
-        "description": "",
-        "parameters": [
-          {
-            "name": "slug",
-            "in": "path",
-            "required": true,
-            "description": "",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ExperimentClone"
-              }
-            },
-            "application/x-www-form-urlencoded": {
-              "schema": {
-                "$ref": "#/components/schemas/ExperimentClone"
-              }
-            },
-            "multipart/form-data": {
-              "schema": {
-                "$ref": "#/components/schemas/ExperimentClone"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ExperimentClone"
-                }
-              }
-            },
-            "description": ""
-          }
-        },
-        "tags": [
-          "Core: Private"
-        ]
-      }
-    }
-  },
-  "components": {
-    "schemas": {
-      "ExperimentRecipe": {
-        "type": "object",
-        "properties": {
-          "action_name": {
-            "type": "string",
-            "readOnly": true
-          },
-          "name": {
-            "type": "string",
-            "maxLength": 255
-          },
-          "filter_object": {
-            "type": "string",
-            "readOnly": true
-          },
-          "comment": {
-            "type": "string",
-            "readOnly": true
-          },
-          "arguments": {
-            "type": "string",
-            "readOnly": true
-          },
-          "experimenter_slug": {
-            "type": "string",
-            "readOnly": true
-          }
-        },
-        "required": [
-          "name"
-        ]
-      },
-      "Experiment": {
-        "type": "object",
-        "properties": {
-          "experiment_url": {
-            "type": "string",
-            "readOnly": true
-          },
-          "type": {
-            "enum": [
-              "pref",
-              "addon",
-              "generic",
-              "rollout",
-              "message"
-            ],
-            "type": "string"
-          },
-          "name": {
-            "type": "string",
-            "maxLength": 255
-          },
-          "slug": {
-            "type": "string",
-            "maxLength": 255,
-            "pattern": "^[-a-zA-Z0-9_]+$"
-          },
-          "public_description": {
-            "type": "string",
-            "nullable": true
-          },
-          "status": {
-            "enum": [
-              "Draft",
-              "Review",
-              "Ship",
-              "Accepted",
-              "Live",
-              "Complete",
-              "Rejected"
-            ],
-            "type": "string"
-          },
-          "client_matching": {
-            "type": "string",
-            "nullable": true
-          },
-          "locales": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "properties": {
-                "code": {
-                  "type": "string",
-                  "maxLength": 255
-                },
-                "name": {
-                  "type": "string",
-                  "maxLength": 255
-                }
-              },
-              "required": [
-                "code",
-                "name"
-              ]
-            }
-          },
-          "countries": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "properties": {
-                "code": {
-                  "type": "string",
-                  "maxLength": 255
-                },
-                "name": {
-                  "type": "string",
-                  "maxLength": 255
-                }
-              },
-              "required": [
-                "code",
-                "name"
-              ]
-            }
-          },
-          "platforms": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            },
-            "nullable": true
-          },
-          "start_date": {
-            "type": "string"
-          },
-          "end_date": {
-            "type": "string"
-          },
-          "population": {
-            "type": "string",
-            "readOnly": true
-          },
-          "population_percent": {
-            "type": "string",
-            "format": "decimal",
-            "multipleOf": 0.0001,
-            "maximum": 1000,
-            "minimum": -1000,
-            "nullable": true
-          },
-          "firefox_channel": {
-            "enum": [
-              null,
-              "Nightly",
-              "Beta",
-              "Release"
-            ],
-            "nullable": true
-          },
-          "firefox_min_version": {
-            "enum": [
-              "55.0",
-              "56.0",
-              "57.0",
-              "58.0",
-              "59.0",
-              "60.0",
-              "61.0",
-              "62.0",
-              "63.0",
-              "64.0",
-              "65.0",
-              "66.0",
-              "67.0",
-              "68.0",
-              "69.0",
-              "70.0",
-              "71.0",
-              "72.0",
-              "73.0",
-              "74.0",
-              "75.0",
-              "76.0",
-              "77.0",
-              "78.0",
-              "79.0",
-              "80.0",
-              "81.0",
-              "82.0",
-              "83.0",
-              "84.0",
-              "85.0",
-              "86.0",
-              "87.0",
-              "88.0",
-              "89.0",
-              "90.0",
-              "91.0",
-              "92.0",
-              "93.0",
-              "94.0",
-              "95.0",
-              "96.0",
-              "97.0",
-              "98.0",
-              "99.0",
-              "100.0",
-              "101.0",
-              "102.0",
-              "103.0",
-              "104.0",
-              "105.0",
-              "106.0",
-              "107.0",
-              "108.0",
-              "109.0",
-              "110.0",
-              "111.0",
-              "112.0",
-              "113.0",
-              "114.0",
-              "115.0",
-              "116.0",
-              "117.0",
-              "118.0",
-              "119.0",
-              "120.0"
-            ],
-            "type": "string",
-            "nullable": true
-          },
-          "firefox_max_version": {
-            "enum": [
-              "55.0",
-              "56.0",
-              "57.0",
-              "58.0",
-              "59.0",
-              "60.0",
-              "61.0",
-              "62.0",
-              "63.0",
-              "64.0",
-              "65.0",
-              "66.0",
-              "67.0",
-              "68.0",
-              "69.0",
-              "70.0",
-              "71.0",
-              "72.0",
-              "73.0",
-              "74.0",
-              "75.0",
-              "76.0",
-              "77.0",
-              "78.0",
-              "79.0",
-              "80.0",
-              "81.0",
-              "82.0",
-              "83.0",
-              "84.0",
-              "85.0",
-              "86.0",
-              "87.0",
-              "88.0",
-              "89.0",
-              "90.0",
-              "91.0",
-              "92.0",
-              "93.0",
-              "94.0",
-              "95.0",
-              "96.0",
-              "97.0",
-              "98.0",
-              "99.0",
-              "100.0",
-              "101.0",
-              "102.0",
-              "103.0",
-              "104.0",
-              "105.0",
-              "106.0",
-              "107.0",
-              "108.0",
-              "109.0",
-              "110.0",
-              "111.0",
-              "112.0",
-              "113.0",
-              "114.0",
-              "115.0",
-              "116.0",
-              "117.0",
-              "118.0",
-              "119.0",
-              "120.0"
-            ],
-            "type": "string",
-            "nullable": true
-          },
-          "addon_experiment_id": {
-            "type": "string",
-            "nullable": true,
-            "maxLength": 255
-          },
-          "addon_release_url": {
-            "type": "string",
-            "format": "uri",
-            "nullable": true,
-            "maxLength": 400,
-            "pattern": "^(?:[a-z0-9.+-]*)://(?:[^\\s:@/]+(?::[^\\s:@/]*)?@)?(?:(?:0|25[0-5]|2[0-4]\\d|1\\d?\\d?|[1-9]\\d?)(?:\\.(?:0|25[0-5]|2[0-4]\\d|1\\d?\\d?|[1-9]\\d?)){3}|\\[[0-9a-f:.]+\\]|([a-z\u00a1-\uffff0-9](?:[a-z\u00a1-\uffff0-9-]{0,61}[a-z\u00a1-\uffff0-9])?(?:\\.(?!-)[a-z\u00a1-\uffff0-9-]{1,63}(?<!-))*\\.(?!-)(?:[a-z\u00a1-\uffff-]{2,63}|xn--[a-z0-9]{1,59})(?<!-)\\.?|localhost))(?::\\d{2,5})?(?:[/?#][^\\s]*)?\\z"
-          },
-          "pref_branch": {
-            "enum": [
-              null,
-              "default",
-              "user"
-            ],
-            "nullable": true
-          },
-          "pref_name": {
-            "type": "string",
-            "nullable": true,
-            "maxLength": 255
-          },
-          "pref_type": {
-            "type": "string"
-          },
-          "proposed_start_date": {
-            "type": "string"
-          },
-          "proposed_enrollment": {
-            "type": "integer",
-            "maximum": 1000,
-            "nullable": true,
-            "minimum": 0
-          },
-          "proposed_duration": {
-            "type": "integer",
-            "maximum": 1000,
-            "nullable": true,
-            "minimum": 0
-          },
-          "normandy_slug": {
-            "type": "string"
-          },
-          "normandy_id": {
-            "type": "integer",
-            "maximum": 2147483647,
-            "nullable": true,
-            "minimum": 0
-          },
-          "other_normandy_ids": {
-            "type": "array",
-            "items": {
-              "type": "integer",
-              "maximum": 2147483647,
-              "minimum": -2147483648
-            },
-            "nullable": true
-          },
-          "is_high_population": {
-            "type": "boolean"
-          },
-          "variants": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "properties": {
-                "description": {
-                  "type": "string"
-                },
-                "is_control": {
-                  "type": "boolean"
-                },
-                "name": {
-                  "type": "string",
-                  "maxLength": 255
-                },
-                "ratio": {
-                  "type": "integer",
-                  "maximum": 2147483647,
-                  "minimum": 0
-                },
-                "slug": {
-                  "type": "string",
-                  "maxLength": 255,
-                  "pattern": "^[-a-zA-Z0-9_]+$"
-                },
-                "value": {
-                  "type": "string",
-                  "nullable": true
-                },
-                "addon_release_url": {
-                  "type": "string",
-                  "format": "uri",
-                  "nullable": true,
-                  "maxLength": 400,
-                  "pattern": "^(?:[a-z0-9.+-]*)://(?:[^\\s:@/]+(?::[^\\s:@/]*)?@)?(?:(?:0|25[0-5]|2[0-4]\\d|1\\d?\\d?|[1-9]\\d?)(?:\\.(?:0|25[0-5]|2[0-4]\\d|1\\d?\\d?|[1-9]\\d?)){3}|\\[[0-9a-f:.]+\\]|([a-z\u00a1-\uffff0-9](?:[a-z\u00a1-\uffff0-9-]{0,61}[a-z\u00a1-\uffff0-9])?(?:\\.(?!-)[a-z\u00a1-\uffff0-9-]{1,63}(?<!-))*\\.(?!-)(?:[a-z\u00a1-\uffff-]{2,63}|xn--[a-z0-9]{1,59})(?<!-)\\.?|localhost))(?::\\d{2,5})?(?:[/?#][^\\s]*)?\\z"
-                },
-                "preferences": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "pref_name": {
-                        "type": "string",
-                        "maxLength": 255
-                      },
-                      "pref_type": {
-                        "enum": [
-                          null,
-                          "boolean",
-                          "integer",
-                          "string",
-                          "json string"
-                        ]
-                      },
-                      "pref_branch": {
-                        "enum": [
-                          null,
-                          "default",
-                          "user"
-                        ]
-                      },
-                      "pref_value": {
-                        "type": "string",
-                        "maxLength": 4096
-                      }
-                    },
-                    "required": [
-                      "pref_name",
-                      "pref_type",
-                      "pref_branch",
-                      "pref_value"
-                    ]
+            "responses": {
+              "200": {
+                "content": {
+                  "application/json": {
+                    "schema": {
+                      "$ref": "#/components/schemas/ExperimentClone"
+                    }
                   }
                 },
-                "message_targeting": {
-                  "type": "string",
-                  "nullable": true
-                },
-                "message_threshold": {
-                  "type": "string",
-                  "nullable": true
-                },
-                "message_triggers": {
-                  "type": "string",
-                  "nullable": true
-                }
-              },
-              "required": [
-                "name",
-                "slug"
-              ]
-            }
-          },
-          "results": {
-            "type": "string",
-            "readOnly": true
-          },
-          "changes": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "properties": {
-                "changed_on": {
-                  "type": "string",
-                  "format": "date-time"
-                },
-                "pretty_status": {
-                  "type": "string",
-                  "readOnly": true
-                },
-                "new_status": {
-                  "enum": [
-                    "Draft",
-                    "Review",
-                    "Ship",
-                    "Accepted",
-                    "Live",
-                    "Complete",
-                    "Rejected"
-                  ],
-                  "type": "string"
-                },
-                "old_status": {
-                  "enum": [
-                    "Draft",
-                    "Review",
-                    "Ship",
-                    "Accepted",
-                    "Live",
-                    "Complete",
-                    "Rejected"
-                  ],
-                  "type": "string",
-                  "nullable": true
-                }
-              },
-              "required": [
-                "new_status"
-              ]
-            }
-          },
-          "projects": {
-            "type": "string",
-            "readOnly": true
-          }
-        },
-        "required": [
-          "name",
-          "slug",
-          "locales",
-          "countries",
-          "start_date",
-          "end_date",
-          "pref_type",
-          "proposed_start_date",
-          "normandy_slug",
-          "variants",
-          "changes"
-        ]
-      },
-      "ExperimentCSV": {
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "string",
-            "maxLength": 255
-          },
-          "status": {
-            "enum": [
-              "Draft",
-              "Review",
-              "Ship",
-              "Accepted",
-              "Live",
-              "Complete",
-              "Rejected"
-            ],
-            "type": "string"
-          },
-          "description": {
-            "type": "string"
-          },
-          "hypothesis": {
-            "type": "string"
-          },
-          "leading_indicators": {
-            "type": "string"
-          },
-          "experiment_url": {
-            "type": "string",
-            "readOnly": true
-          },
-          "start_date": {
-            "type": "string",
-            "readOnly": true
-          },
-          "type": {
-            "enum": [
-              "pref",
-              "addon",
-              "generic",
-              "rollout",
-              "message"
-            ],
-            "type": "string"
-          },
-          "length": {
-            "type": "string",
-            "readOnly": true
-          },
-          "channel": {
-            "type": "string"
-          },
-          "owner": {
-            "type": "string",
-            "readOnly": true
-          },
-          "data_scientist": {
-            "type": "string",
-            "readOnly": true
-          },
-          "enrolled_target": {
-            "type": "integer"
-          },
-          "results_url": {
-            "type": "string",
-            "format": "uri",
-            "nullable": true,
-            "maxLength": 200,
-            "pattern": "^(?:[a-z0-9.+-]*)://(?:[^\\s:@/]+(?::[^\\s:@/]*)?@)?(?:(?:0|25[0-5]|2[0-4]\\d|1\\d?\\d?|[1-9]\\d?)(?:\\.(?:0|25[0-5]|2[0-4]\\d|1\\d?\\d?|[1-9]\\d?)){3}|\\[[0-9a-f:.]+\\]|([a-z\u00a1-\uffff0-9](?:[a-z\u00a1-\uffff0-9-]{0,61}[a-z\u00a1-\uffff0-9])?(?:\\.(?!-)[a-z\u00a1-\uffff0-9-]{1,63}(?<!-))*\\.(?!-)(?:[a-z\u00a1-\uffff-]{2,63}|xn--[a-z0-9]{1,59})(?<!-)\\.?|localhost))(?::\\d{2,5})?(?:[/?#][^\\s]*)?\\z"
-          },
-          "projects": {
-            "type": "string",
-            "readOnly": true
-          },
-          "locales": {
-            "type": "string",
-            "readOnly": true
-          },
-          "countries": {
-            "type": "string",
-            "readOnly": true
-          }
-        },
-        "required": [
-          "name",
-          "description",
-          "hypothesis",
-          "leading_indicators",
-          "channel",
-          "enrolled_target"
-        ]
-      },
-      "ExperimentDesignAddonRollout": {
-        "type": "object",
-        "properties": {
-          "rollout_type": {
-            "enum": [
-              "pref",
-              "addon"
-            ],
-            "type": "string"
-          },
-          "design": {
-            "type": "string",
-            "nullable": true
-          },
-          "addon_release_url": {
-            "type": "string",
-            "format": "uri",
-            "nullable": true,
-            "maxLength": 400,
-            "pattern": "^(?:[a-z0-9.+-]*)://(?:[^\\s:@/]+(?::[^\\s:@/]*)?@)?(?:(?:0|25[0-5]|2[0-4]\\d|1\\d?\\d?|[1-9]\\d?)(?:\\.(?:0|25[0-5]|2[0-4]\\d|1\\d?\\d?|[1-9]\\d?)){3}|\\[[0-9a-f:.]+\\]|([a-z\u00a1-\uffff0-9](?:[a-z\u00a1-\uffff0-9-]{0,61}[a-z\u00a1-\uffff0-9])?(?:\\.(?!-)[a-z\u00a1-\uffff0-9-]{1,63}(?<!-))*\\.(?!-)(?:[a-z\u00a1-\uffff-]{2,63}|xn--[a-z0-9]{1,59})(?<!-)\\.?|localhost))(?::\\d{2,5})?(?:[/?#][^\\s]*)?\\z"
-          }
-        },
-        "required": [
-          "rollout_type",
-          "addon_release_url"
-        ]
-      },
-      "ExperimentDesignAddon": {
-        "type": "object",
-        "properties": {
-          "addon_release_url": {
-            "type": "string",
-            "format": "uri",
-            "maxLength": 400,
-            "pattern": "^(?:[a-z0-9.+-]*)://(?:[^\\s:@/]+(?::[^\\s:@/]*)?@)?(?:(?:0|25[0-5]|2[0-4]\\d|1\\d?\\d?|[1-9]\\d?)(?:\\.(?:0|25[0-5]|2[0-4]\\d|1\\d?\\d?|[1-9]\\d?)){3}|\\[[0-9a-f:.]+\\]|([a-z\u00a1-\uffff0-9](?:[a-z\u00a1-\uffff0-9-]{0,61}[a-z\u00a1-\uffff0-9])?(?:\\.(?!-)[a-z\u00a1-\uffff0-9-]{1,63}(?<!-))*\\.(?!-)(?:[a-z\u00a1-\uffff-]{2,63}|xn--[a-z0-9]{1,59})(?<!-)\\.?|localhost))(?::\\d{2,5})?(?:[/?#][^\\s]*)?\\z"
-          },
-          "variants": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "properties": {
-                "id": {
-                  "type": "integer"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "is_control": {
-                  "type": "boolean"
-                },
-                "name": {
-                  "type": "string",
-                  "maxLength": 255
-                },
-                "ratio": {
-                  "type": "integer"
-                }
-              },
-              "required": [
-                "description",
-                "is_control",
-                "name",
-                "ratio"
-              ]
-            }
-          },
-          "is_branched_addon": {
-            "type": "boolean"
-          }
-        },
-        "required": [
-          "addon_release_url",
-          "variants",
-          "is_branched_addon"
-        ]
-      },
-      "ExperimentDesignPrefRollout": {
-        "type": "object",
-        "properties": {
-          "rollout_type": {
-            "enum": [
-              "pref",
-              "addon"
-            ],
-            "type": "string"
-          },
-          "design": {
-            "type": "string",
-            "nullable": true
-          },
-          "preferences": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "properties": {
-                "id": {
-                  "type": "integer"
-                },
-                "pref_name": {
-                  "type": "string",
-                  "maxLength": 255
-                },
-                "pref_type": {
-                  "enum": [
-                    null,
-                    "boolean",
-                    "integer",
-                    "string",
-                    "json string"
-                  ]
-                },
-                "pref_value": {
-                  "type": "string",
-                  "maxLength": 4096
-                }
-              },
-              "required": [
-                "pref_name",
-                "pref_type",
-                "pref_value"
-              ]
-            }
-          }
-        },
-        "required": [
-          "rollout_type",
-          "preferences"
-        ]
-      },
-      "ExperimentDesignPref": {
-        "type": "object",
-        "properties": {
-          "is_multi_pref": {
-            "type": "boolean"
-          },
-          "pref_name": {
-            "type": "string",
-            "maxLength": 255
-          },
-          "pref_type": {
-            "type": "string",
-            "maxLength": 255
-          },
-          "pref_branch": {
-            "type": "string",
-            "maxLength": 255
-          },
-          "variants": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "properties": {
-                "id": {
-                  "type": "integer"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "is_control": {
-                  "type": "boolean"
-                },
-                "name": {
-                  "type": "string",
-                  "maxLength": 255
-                },
-                "ratio": {
-                  "type": "integer"
-                },
-                "value": {
-                  "type": "string"
-                }
-              },
-              "required": [
-                "description",
-                "is_control",
-                "name",
-                "ratio",
-                "value"
-              ]
-            }
-          }
-        },
-        "required": [
-          "is_multi_pref",
-          "pref_name",
-          "pref_type",
-          "pref_branch",
-          "variants"
-        ]
-      },
-      "ExperimentDesignMultiPref": {
-        "type": "object",
-        "properties": {
-          "is_multi_pref": {
-            "type": "boolean"
-          },
-          "variants": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "properties": {
-                "id": {
-                  "type": "integer"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "is_control": {
-                  "type": "boolean"
-                },
-                "name": {
-                  "type": "string",
-                  "maxLength": 255
-                },
-                "ratio": {
-                  "type": "integer"
-                },
-                "preferences": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "id": {
-                        "type": "integer"
-                      },
-                      "pref_name": {
-                        "type": "string",
-                        "maxLength": 255
-                      },
-                      "pref_type": {
-                        "enum": [
-                          null,
-                          "boolean",
-                          "integer",
-                          "string",
-                          "json string"
-                        ]
-                      },
-                      "pref_branch": {
-                        "enum": [
-                          null,
-                          "default",
-                          "user"
-                        ]
-                      },
-                      "pref_value": {
-                        "type": "string",
-                        "maxLength": 4096
-                      }
-                    },
-                    "required": [
-                      "pref_name",
-                      "pref_type",
-                      "pref_branch",
-                      "pref_value"
-                    ]
-                  }
-                }
-              },
-              "required": [
-                "description",
-                "is_control",
-                "name",
-                "ratio",
-                "preferences"
-              ]
-            }
-          }
-        },
-        "required": [
-          "is_multi_pref",
-          "variants"
-        ]
-      },
-      "ExperimentDesignGeneric": {
-        "type": "object",
-        "properties": {
-          "design": {
-            "type": "string",
-            "nullable": true
-          },
-          "variants": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "properties": {
-                "id": {
-                  "type": "integer"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "is_control": {
-                  "type": "boolean"
-                },
-                "name": {
-                  "type": "string",
-                  "maxLength": 255
-                },
-                "ratio": {
-                  "type": "integer"
-                }
-              },
-              "required": [
-                "description",
-                "is_control",
-                "name",
-                "ratio"
-              ]
-            }
-          }
-        },
-        "required": [
-          "variants"
-        ]
-      },
-      "ExperimentDesignBranchedAddon": {
-        "type": "object",
-        "properties": {
-          "is_branched_addon": {
-            "type": "boolean"
-          },
-          "variants": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "properties": {
-                "addon_release_url": {
-                  "type": "string",
-                  "format": "uri",
-                  "maxLength": 400,
-                  "pattern": "^(?:[a-z0-9.+-]*)://(?:[^\\s:@/]+(?::[^\\s:@/]*)?@)?(?:(?:0|25[0-5]|2[0-4]\\d|1\\d?\\d?|[1-9]\\d?)(?:\\.(?:0|25[0-5]|2[0-4]\\d|1\\d?\\d?|[1-9]\\d?)){3}|\\[[0-9a-f:.]+\\]|([a-z\u00a1-\uffff0-9](?:[a-z\u00a1-\uffff0-9-]{0,61}[a-z\u00a1-\uffff0-9])?(?:\\.(?!-)[a-z\u00a1-\uffff0-9-]{1,63}(?<!-))*\\.(?!-)(?:[a-z\u00a1-\uffff-]{2,63}|xn--[a-z0-9]{1,59})(?<!-)\\.?|localhost))(?::\\d{2,5})?(?:[/?#][^\\s]*)?\\z"
-                },
-                "id": {
-                  "type": "integer"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "is_control": {
-                  "type": "boolean"
-                },
-                "name": {
-                  "type": "string",
-                  "maxLength": 255
-                },
-                "ratio": {
-                  "type": "integer"
-                }
-              },
-              "required": [
-                "addon_release_url",
-                "description",
-                "is_control",
-                "name",
-                "ratio"
-              ]
-            }
-          }
-        },
-        "required": [
-          "is_branched_addon",
-          "variants"
-        ]
-      },
-      "ExperimentDesignMessage": {
-        "type": "object",
-        "properties": {
-          "message_type": {
-            "enum": [
-              "cfr",
-              "about:welcome"
-            ],
-            "type": "string"
-          },
-          "message_template": {
-            "enum": [
-              "cfr_doorhanger",
-              "cfr_urlbar_chiclet",
-              "milestone_message"
-            ],
-            "type": "string",
-            "nullable": true
-          },
-          "variants": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "properties": {
-                "description": {
-                  "type": "string"
-                },
-                "id": {
-                  "type": "integer"
-                },
-                "is_control": {
-                  "type": "boolean"
-                },
-                "message_targeting": {
-                  "type": "string",
-                  "nullable": true
-                },
-                "message_threshold": {
-                  "type": "string",
-                  "nullable": true
-                },
-                "message_triggers": {
-                  "type": "string",
-                  "nullable": true
-                },
-                "name": {
-                  "type": "string",
-                  "maxLength": 255
-                },
-                "ratio": {
-                  "type": "integer"
-                },
-                "value": {
-                  "type": "string"
-                }
-              },
-              "required": [
-                "description",
-                "is_control",
-                "name",
-                "ratio",
-                "value"
-              ]
-            }
-          }
-        },
-        "required": [
-          "message_type",
-          "variants"
-        ]
-      },
-      "ExperimentTimelinePop": {
-        "type": "object",
-        "properties": {
-          "proposed_start_date": {
-            "type": "string",
-            "format": "date",
-            "nullable": true
-          },
-          "proposed_enrollment": {
-            "type": "integer",
-            "nullable": true
-          },
-          "rollout_playbook": {
-            "enum": [
-              null,
-              "low_risk",
-              "high_risk",
-              "marketing",
-              "custom"
-            ],
-            "nullable": true
-          },
-          "proposed_duration": {
-            "type": "integer",
-            "nullable": true
-          },
-          "population_percent": {
-            "type": "string",
-            "format": "decimal",
-            "multipleOf": 0.0001,
-            "maximum": 100.0,
-            "minimum": 0,
-            "nullable": true
-          },
-          "firefox_channel": {
-            "enum": [
-              null,
-              "Nightly",
-              "Beta",
-              "Release"
-            ],
-            "nullable": true
-          },
-          "firefox_min_version": {
-            "enum": [
-              "55.0",
-              "56.0",
-              "57.0",
-              "58.0",
-              "59.0",
-              "60.0",
-              "61.0",
-              "62.0",
-              "63.0",
-              "64.0",
-              "65.0",
-              "66.0",
-              "67.0",
-              "68.0",
-              "69.0",
-              "70.0",
-              "71.0",
-              "72.0",
-              "73.0",
-              "74.0",
-              "75.0",
-              "76.0",
-              "77.0",
-              "78.0",
-              "79.0",
-              "80.0",
-              "81.0",
-              "82.0",
-              "83.0",
-              "84.0",
-              "85.0",
-              "86.0",
-              "87.0",
-              "88.0",
-              "89.0",
-              "90.0",
-              "91.0",
-              "92.0",
-              "93.0",
-              "94.0",
-              "95.0",
-              "96.0",
-              "97.0",
-              "98.0",
-              "99.0",
-              "100.0",
-              "101.0",
-              "102.0",
-              "103.0",
-              "104.0",
-              "105.0",
-              "106.0",
-              "107.0",
-              "108.0",
-              "109.0",
-              "110.0",
-              "111.0",
-              "112.0",
-              "113.0",
-              "114.0",
-              "115.0",
-              "116.0",
-              "117.0",
-              "118.0",
-              "119.0",
-              "120.0"
-            ],
-            "type": "string",
-            "nullable": true
-          },
-          "firefox_max_version": {
-            "enum": [
-              "55.0",
-              "56.0",
-              "57.0",
-              "58.0",
-              "59.0",
-              "60.0",
-              "61.0",
-              "62.0",
-              "63.0",
-              "64.0",
-              "65.0",
-              "66.0",
-              "67.0",
-              "68.0",
-              "69.0",
-              "70.0",
-              "71.0",
-              "72.0",
-              "73.0",
-              "74.0",
-              "75.0",
-              "76.0",
-              "77.0",
-              "78.0",
-              "79.0",
-              "80.0",
-              "81.0",
-              "82.0",
-              "83.0",
-              "84.0",
-              "85.0",
-              "86.0",
-              "87.0",
-              "88.0",
-              "89.0",
-              "90.0",
-              "91.0",
-              "92.0",
-              "93.0",
-              "94.0",
-              "95.0",
-              "96.0",
-              "97.0",
-              "98.0",
-              "99.0",
-              "100.0",
-              "101.0",
-              "102.0",
-              "103.0",
-              "104.0",
-              "105.0",
-              "106.0",
-              "107.0",
-              "108.0",
-              "109.0",
-              "110.0",
-              "111.0",
-              "112.0",
-              "113.0",
-              "114.0",
-              "115.0",
-              "116.0",
-              "117.0",
-              "118.0",
-              "119.0",
-              "120.0"
-            ],
-            "type": "string",
-            "nullable": true
-          },
-          "locales": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "properties": {
-                "label": {
-                  "type": "string"
-                },
-                "value": {
-                  "type": "integer"
-                }
-              },
-              "required": [
-                "label",
-                "value"
-              ]
+                "description": ""
+              }
             },
-            "nullable": true
-          },
-          "countries": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "properties": {
-                "label": {
-                  "type": "string"
-                },
-                "value": {
-                  "type": "integer"
-                }
-              },
-              "required": [
-                "label",
-                "value"
-              ]
-            },
-            "nullable": true
-          },
-          "platforms": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "properties": {}
-            }
-          },
-          "windows_versions": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "properties": {}
-            },
-            "nullable": true
-          },
-          "profile_age": {
-            "enum": [
-              "All Profiles",
-              "New Profiles Only",
-              "Existing Profiles Only"
-            ],
-            "type": "string",
-            "nullable": true
-          },
-          "client_matching": {
-            "type": "string",
-            "nullable": true
+            "tags": [
+              "Core: Private"
+            ]
           }
         }
       },
-      "NimbusExperimentCsv": {
-        "type": "object",
-        "properties": {
-          "launch_month": {
-            "type": "string",
-            "readOnly": true
-          },
-          "product_area": {
-            "type": "string"
-          },
-          "experiment_name": {
-            "type": "string"
-          },
-          "owner": {
-            "type": "string",
-            "readOnly": true
-          },
-          "feature_configs": {
-            "type": "string",
-            "readOnly": true
-          },
-          "start_date": {
-            "type": "string",
-            "readOnly": true
-          },
-          "enrollment_duration": {
-            "type": "string",
-            "readOnly": true
-          },
-          "end_date": {
-            "type": "string",
-            "readOnly": true
-          },
-          "results_url": {
-            "type": "string",
-            "readOnly": true
-          },
-          "experiment_summary": {
-            "type": "string"
-          },
-          "rollout": {
-            "type": "boolean"
-          },
-          "hypothesis": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "product_area",
-          "experiment_name",
-          "experiment_summary",
-          "rollout"
-        ]
-      },
-      "NimbusConfiguration": {
-        "type": "object",
-        "properties": {
-          "applications": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "properties": {
-                "label": {
-                  "type": "string"
-                },
-                "value": {
-                  "type": "string"
-                }
-              },
-              "required": [
-                "label",
-                "value"
-              ]
-            }
-          },
-          "channels": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "properties": {
-                "label": {
-                  "type": "string"
-                },
-                "value": {
-                  "type": "string"
-                }
-              },
-              "required": [
-                "label",
-                "value"
-              ]
-            }
-          },
-          "applicationConfigs": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "properties": {
-                "application": {
-                  "type": "string"
-                },
-                "channels": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "label": {
-                        "type": "string"
-                      },
-                      "value": {
-                        "type": "string"
-                      }
-                    },
-                    "required": [
-                      "label",
-                      "value"
-                    ]
-                  }
-                }
-              },
-              "required": [
-                "application",
-                "channels"
-              ]
-            }
-          },
-          "countries": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "properties": {
-                "id": {
-                  "type": "integer"
-                },
-                "name": {
-                  "type": "string"
-                },
-                "code": {
-                  "type": "string"
-                }
-              },
-              "required": [
-                "id",
-                "name",
-                "code"
-              ]
-            }
-          },
-          "locales": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "properties": {
-                "id": {
-                  "type": "integer"
-                },
-                "name": {
-                  "type": "string"
-                },
-                "code": {
-                  "type": "string"
-                }
-              },
-              "required": [
-                "id",
-                "name",
-                "code"
-              ]
-            }
-          },
-          "languages": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "properties": {
-                "id": {
-                  "type": "integer"
-                },
-                "name": {
-                  "type": "string"
-                },
-                "code": {
-                  "type": "string"
-                }
-              },
-              "required": [
-                "id",
-                "name",
-                "code"
-              ]
-            }
-          },
-          "projects": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "properties": {
-                "id": {
-                  "type": "integer"
-                },
-                "name": {
-                  "type": "string"
-                },
-                "slug": {
-                  "type": "string"
-                }
-              },
-              "required": [
-                "id",
-                "name",
-                "slug"
-              ]
-            }
-          },
-          "documentationLink": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "properties": {
-                "label": {
-                  "type": "string"
-                },
-                "value": {
-                  "type": "string"
-                }
-              },
-              "required": [
-                "label",
-                "value"
-              ]
-            }
-          },
-          "allFeatureConfigs": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "properties": {
-                "id": {
-                  "type": "integer"
-                },
-                "name": {
-                  "type": "string"
-                },
-                "slug": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string",
-                  "nullable": true
-                },
-                "application": {
-                  "type": "string"
-                },
-                "ownerEmail": {
-                  "type": "string",
-                  "nullable": true
-                },
-                "schema": {
-                  "type": "string",
-                  "nullable": true
-                },
-                "setsPrefs": {
-                  "type": "boolean"
-                },
-                "enabled": {
-                  "type": "boolean"
-                }
-              },
-              "required": [
-                "id",
-                "name",
-                "slug",
-                "description",
-                "application",
-                "ownerEmail",
-                "schema",
-                "setsPrefs",
-                "enabled"
-              ]
-            }
-          },
-          "firefoxVersions": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "properties": {
-                "label": {
-                  "type": "string"
-                },
-                "value": {
-                  "type": "string"
-                }
-              },
-              "required": [
-                "label",
-                "value"
-              ]
-            }
-          },
-          "outcomes": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "properties": {
-                "application": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "friendlyName": {
-                  "type": "string"
-                },
-                "slug": {
-                  "type": "string"
-                },
-                "isDefault": {
-                  "type": "boolean"
-                },
-                "metrics": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "slug": {
-                        "type": "string"
-                      },
-                      "friendlyName": {
-                        "type": "string"
-                      },
-                      "description": {
-                        "type": "string"
-                      }
-                    },
-                    "required": [
-                      "slug",
-                      "friendlyName",
-                      "description"
-                    ]
-                  }
-                }
-              },
-              "required": [
-                "application",
-                "description",
-                "friendlyName",
-                "slug",
-                "isDefault",
-                "metrics"
-              ]
-            }
-          },
-          "owners": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "properties": {
-                "username": {
-                  "type": "string"
-                }
-              },
-              "required": [
-                "username"
-              ]
-            }
-          },
-          "targetingConfigs": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "properties": {
-                "label": {
-                  "type": "string"
-                },
-                "value": {
-                  "type": "string"
-                },
-                "applicationValues": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                },
-                "description": {
-                  "type": "string"
-                },
-                "stickyRequired": {
-                  "type": "boolean"
-                },
-                "isFirstRunRequired": {
-                  "type": "boolean"
-                }
-              },
-              "required": [
-                "label",
-                "value",
-                "applicationValues",
-                "description",
-                "stickyRequired",
-                "isFirstRunRequired"
-              ]
-            }
-          },
-          "conclusionRecommendations": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "properties": {
-                "label": {
-                  "type": "string"
-                },
-                "value": {
-                  "type": "string"
-                }
-              },
-              "required": [
-                "label",
-                "value"
-              ]
-            }
-          },
-          "types": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "properties": {
-                "label": {
-                  "type": "string"
-                },
-                "value": {
-                  "type": "string"
-                }
-              },
-              "required": [
-                "label",
-                "value"
-              ]
-            }
-          },
-          "hypothesisDefault": {
-            "type": "string"
-          },
-          "maxPrimaryOutcomes": {
-            "type": "integer"
-          }
-        },
-        "required": [
-          "applications",
-          "channels",
-          "applicationConfigs",
-          "countries",
-          "locales",
-          "languages",
-          "projects",
-          "documentationLink",
-          "allFeatureConfigs",
-          "firefoxVersions",
-          "outcomes",
-          "owners",
-          "targetingConfigs",
-          "conclusionRecommendations",
-          "types"
-        ]
-      },
-      "NimbusExperiment": {
-        "type": "object",
-        "properties": {
-          "schemaVersion": {
-            "type": "string",
-            "readOnly": true,
-            "default": "1.10.0"
-          },
-          "slug": {
-            "type": "string",
-            "maxLength": 80,
-            "pattern": "^[-a-zA-Z0-9_]+$"
-          },
-          "id": {
-            "type": "string",
-            "readOnly": true
-          },
-          "arguments": {
-            "type": "string",
-            "readOnly": true,
-            "default": {}
-          },
-          "application": {
-            "type": "string",
-            "readOnly": true
-          },
-          "appName": {
-            "type": "string",
-            "readOnly": true
-          },
-          "appId": {
-            "type": "string",
-            "readOnly": true
-          },
-          "channel": {
-            "enum": [
-              "",
-              "default",
-              "nightly",
-              "beta",
-              "release",
-              "esr",
-              "testflight",
-              "aurora"
-            ],
-            "type": "string"
-          },
-          "userFacingName": {
-            "type": "string",
-            "readOnly": true
-          },
-          "userFacingDescription": {
-            "type": "string",
-            "readOnly": true
-          },
-          "isEnrollmentPaused": {
-            "type": "string",
-            "readOnly": true
-          },
-          "isRollout": {
-            "type": "string",
-            "readOnly": true
-          },
-          "bucketConfig": {
+      "components": {
+        "schemas": {
+          "ExperimentRecipe": {
             "type": "object",
             "properties": {
-              "randomizationUnit": {
+              "action_name": {
                 "type": "string",
                 "readOnly": true
               },
-              "namespace": {
+              "name": {
+                "type": "string",
+                "maxLength": 255
+              },
+              "filter_object": {
                 "type": "string",
                 "readOnly": true
               },
-              "start": {
-                "type": "integer",
-                "maximum": 2147483647,
-                "minimum": 0
+              "comment": {
+                "type": "string",
+                "readOnly": true
               },
-              "count": {
-                "type": "integer",
-                "maximum": 2147483647,
-                "minimum": 0
+              "arguments": {
+                "type": "string",
+                "readOnly": true
               },
-              "total": {
+              "experimenter_slug": {
                 "type": "string",
                 "readOnly": true
               }
             },
             "required": [
-              "start",
-              "count"
+              "name"
             ]
           },
-          "featureIds": {
-            "type": "string",
-            "readOnly": true
+          "Experiment": {
+            "type": "object",
+            "properties": {
+              "experiment_url": {
+                "type": "string",
+                "readOnly": true
+              },
+              "type": {
+                "enum": [
+                  "pref",
+                  "addon",
+                  "generic",
+                  "rollout",
+                  "message"
+                ],
+                "type": "string"
+              },
+              "name": {
+                "type": "string",
+                "maxLength": 255
+              },
+              "slug": {
+                "type": "string",
+                "maxLength": 255,
+                "pattern": "^[-a-zA-Z0-9_]+$"
+              },
+              "public_description": {
+                "type": "string",
+                "nullable": true
+              },
+              "status": {
+                "enum": [
+                  "Draft",
+                  "Review",
+                  "Ship",
+                  "Accepted",
+                  "Live",
+                  "Complete",
+                  "Rejected"
+                ],
+                "type": "string"
+              },
+              "client_matching": {
+                "type": "string",
+                "nullable": true
+              },
+              "locales": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "code": {
+                      "type": "string",
+                      "maxLength": 255
+                    },
+                    "name": {
+                      "type": "string",
+                      "maxLength": 255
+                    }
+                  },
+                  "required": [
+                    "code",
+                    "name"
+                  ]
+                }
+              },
+              "countries": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "code": {
+                      "type": "string",
+                      "maxLength": 255
+                    },
+                    "name": {
+                      "type": "string",
+                      "maxLength": 255
+                    }
+                  },
+                  "required": [
+                    "code",
+                    "name"
+                  ]
+                }
+              },
+              "platforms": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "nullable": true
+              },
+              "start_date": {
+                "type": "string"
+              },
+              "end_date": {
+                "type": "string"
+              },
+              "population": {
+                "type": "string",
+                "readOnly": true
+              },
+              "population_percent": {
+                "type": "string",
+                "format": "decimal",
+                "multipleOf": 0.0001,
+                "maximum": 1000,
+                "minimum": -1000,
+                "nullable": true
+              },
+              "firefox_channel": {
+                "enum": [
+                  null,
+                  "Nightly",
+                  "Beta",
+                  "Release"
+                ],
+                "nullable": true
+              },
+              "firefox_min_version": {
+                "enum": [
+                  "55.0",
+                  "56.0",
+                  "57.0",
+                  "58.0",
+                  "59.0",
+                  "60.0",
+                  "61.0",
+                  "62.0",
+                  "63.0",
+                  "64.0",
+                  "65.0",
+                  "66.0",
+                  "67.0",
+                  "68.0",
+                  "69.0",
+                  "70.0",
+                  "71.0",
+                  "72.0",
+                  "73.0",
+                  "74.0",
+                  "75.0",
+                  "76.0",
+                  "77.0",
+                  "78.0",
+                  "79.0",
+                  "80.0",
+                  "81.0",
+                  "82.0",
+                  "83.0",
+                  "84.0",
+                  "85.0",
+                  "86.0",
+                  "87.0",
+                  "88.0",
+                  "89.0",
+                  "90.0",
+                  "91.0",
+                  "92.0",
+                  "93.0",
+                  "94.0",
+                  "95.0",
+                  "96.0",
+                  "97.0",
+                  "98.0",
+                  "99.0",
+                  "100.0",
+                  "101.0",
+                  "102.0",
+                  "103.0",
+                  "104.0",
+                  "105.0",
+                  "106.0",
+                  "107.0",
+                  "108.0",
+                  "109.0",
+                  "110.0",
+                  "111.0",
+                  "112.0",
+                  "113.0",
+                  "114.0",
+                  "115.0",
+                  "116.0",
+                  "117.0",
+                  "118.0",
+                  "119.0",
+                  "120.0"
+                ],
+                "type": "string",
+                "nullable": true
+              },
+              "firefox_max_version": {
+                "enum": [
+                  "55.0",
+                  "56.0",
+                  "57.0",
+                  "58.0",
+                  "59.0",
+                  "60.0",
+                  "61.0",
+                  "62.0",
+                  "63.0",
+                  "64.0",
+                  "65.0",
+                  "66.0",
+                  "67.0",
+                  "68.0",
+                  "69.0",
+                  "70.0",
+                  "71.0",
+                  "72.0",
+                  "73.0",
+                  "74.0",
+                  "75.0",
+                  "76.0",
+                  "77.0",
+                  "78.0",
+                  "79.0",
+                  "80.0",
+                  "81.0",
+                  "82.0",
+                  "83.0",
+                  "84.0",
+                  "85.0",
+                  "86.0",
+                  "87.0",
+                  "88.0",
+                  "89.0",
+                  "90.0",
+                  "91.0",
+                  "92.0",
+                  "93.0",
+                  "94.0",
+                  "95.0",
+                  "96.0",
+                  "97.0",
+                  "98.0",
+                  "99.0",
+                  "100.0",
+                  "101.0",
+                  "102.0",
+                  "103.0",
+                  "104.0",
+                  "105.0",
+                  "106.0",
+                  "107.0",
+                  "108.0",
+                  "109.0",
+                  "110.0",
+                  "111.0",
+                  "112.0",
+                  "113.0",
+                  "114.0",
+                  "115.0",
+                  "116.0",
+                  "117.0",
+                  "118.0",
+                  "119.0",
+                  "120.0"
+                ],
+                "type": "string",
+                "nullable": true
+              },
+              "addon_experiment_id": {
+                "type": "string",
+                "nullable": true,
+                "maxLength": 255
+              },
+              "addon_release_url": {
+                "type": "string",
+                "format": "uri",
+                "nullable": true,
+                "maxLength": 400,
+                "pattern": "^(?:[a-z0-9.+-]*)://(?:[^\\s:@/]+(?::[^\\s:@/]*)?@)?(?:(?:0|25[0-5]|2[0-4]\\d|1\\d?\\d?|[1-9]\\d?)(?:\\.(?:0|25[0-5]|2[0-4]\\d|1\\d?\\d?|[1-9]\\d?)){3}|\\[[0-9a-f:.]+\\]|([a-z\u00a1-\uffff0-9](?:[a-z\u00a1-\uffff0-9-]{0,61}[a-z\u00a1-\uffff0-9])?(?:\\.(?!-)[a-z\u00a1-\uffff0-9-]{1,63}(?<!-))*\\.(?!-)(?:[a-z\u00a1-\uffff-]{2,63}|xn--[a-z0-9]{1,59})(?<!-)\\.?|localhost))(?::\\d{2,5})?(?:[/?#][^\\s]*)?\\z"
+              },
+              "pref_branch": {
+                "enum": [
+                  null,
+                  "default",
+                  "user"
+                ],
+                "nullable": true
+              },
+              "pref_name": {
+                "type": "string",
+                "nullable": true,
+                "maxLength": 255
+              },
+              "pref_type": {
+                "type": "string"
+              },
+              "proposed_start_date": {
+                "type": "string"
+              },
+              "proposed_enrollment": {
+                "type": "integer",
+                "maximum": 1000,
+                "nullable": true,
+                "minimum": 0
+              },
+              "proposed_duration": {
+                "type": "integer",
+                "maximum": 1000,
+                "nullable": true,
+                "minimum": 0
+              },
+              "normandy_slug": {
+                "type": "string"
+              },
+              "normandy_id": {
+                "type": "integer",
+                "maximum": 2147483647,
+                "nullable": true,
+                "minimum": 0
+              },
+              "other_normandy_ids": {
+                "type": "array",
+                "items": {
+                  "type": "integer",
+                  "maximum": 2147483647,
+                  "minimum": -2147483648
+                },
+                "nullable": true
+              },
+              "is_high_population": {
+                "type": "boolean"
+              },
+              "variants": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "description": {
+                      "type": "string"
+                    },
+                    "is_control": {
+                      "type": "boolean"
+                    },
+                    "name": {
+                      "type": "string",
+                      "maxLength": 255
+                    },
+                    "ratio": {
+                      "type": "integer",
+                      "maximum": 2147483647,
+                      "minimum": 0
+                    },
+                    "slug": {
+                      "type": "string",
+                      "maxLength": 255,
+                      "pattern": "^[-a-zA-Z0-9_]+$"
+                    },
+                    "value": {
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "addon_release_url": {
+                      "type": "string",
+                      "format": "uri",
+                      "nullable": true,
+                      "maxLength": 400,
+                      "pattern": "^(?:[a-z0-9.+-]*)://(?:[^\\s:@/]+(?::[^\\s:@/]*)?@)?(?:(?:0|25[0-5]|2[0-4]\\d|1\\d?\\d?|[1-9]\\d?)(?:\\.(?:0|25[0-5]|2[0-4]\\d|1\\d?\\d?|[1-9]\\d?)){3}|\\[[0-9a-f:.]+\\]|([a-z\u00a1-\uffff0-9](?:[a-z\u00a1-\uffff0-9-]{0,61}[a-z\u00a1-\uffff0-9])?(?:\\.(?!-)[a-z\u00a1-\uffff0-9-]{1,63}(?<!-))*\\.(?!-)(?:[a-z\u00a1-\uffff-]{2,63}|xn--[a-z0-9]{1,59})(?<!-)\\.?|localhost))(?::\\d{2,5})?(?:[/?#][^\\s]*)?\\z"
+                    },
+                    "preferences": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "pref_name": {
+                            "type": "string",
+                            "maxLength": 255
+                          },
+                          "pref_type": {
+                            "enum": [
+                              null,
+                              "boolean",
+                              "integer",
+                              "string",
+                              "json string"
+                            ]
+                          },
+                          "pref_branch": {
+                            "enum": [
+                              null,
+                              "default",
+                              "user"
+                            ]
+                          },
+                          "pref_value": {
+                            "type": "string",
+                            "maxLength": 4096
+                          }
+                        },
+                        "required": [
+                          "pref_name",
+                          "pref_type",
+                          "pref_branch",
+                          "pref_value"
+                        ]
+                      }
+                    },
+                    "message_targeting": {
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "message_threshold": {
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "message_triggers": {
+                      "type": "string",
+                      "nullable": true
+                    }
+                  },
+                  "required": [
+                    "name",
+                    "slug"
+                  ]
+                }
+              },
+              "results": {
+                "type": "string",
+                "readOnly": true
+              },
+              "changes": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "updated_date_time": {
+                      "type": "string",
+                      "format": "date-time"
+                    },
+                    "pretty_status": {
+                      "type": "string",
+                      "readOnly": true
+                    },
+                    "new_status": {
+                      "enum": [
+                        "Draft",
+                        "Review",
+                        "Ship",
+                        "Accepted",
+                        "Live",
+                        "Complete",
+                        "Rejected"
+                      ],
+                      "type": "string"
+                    },
+                    "old_status": {
+                      "enum": [
+                        "Draft",
+                        "Review",
+                        "Ship",
+                        "Accepted",
+                        "Live",
+                        "Complete",
+                        "Rejected"
+                      ],
+                      "type": "string",
+                      "nullable": true
+                    }
+                  },
+                  "required": [
+                    "new_status"
+                  ]
+                }
+              },
+              "projects": {
+                "type": "string",
+                "readOnly": true
+              }
+            },
+            "required": [
+              "name",
+              "slug",
+              "locales",
+              "countries",
+              "start_date",
+              "end_date",
+              "pref_type",
+              "proposed_start_date",
+              "normandy_slug",
+              "variants",
+              "changes"
+            ]
           },
-          "probeSets": {
-            "type": "string",
-            "readOnly": true,
-            "default": []
+          "ExperimentCSV": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "maxLength": 255
+              },
+              "status": {
+                "enum": [
+                  "Draft",
+                  "Review",
+                  "Ship",
+                  "Accepted",
+                  "Live",
+                  "Complete",
+                  "Rejected"
+                ],
+                "type": "string"
+              },
+              "description": {
+                "type": "string"
+              },
+              "hypothesis": {
+                "type": "string"
+              },
+              "leading_indicators": {
+                "type": "string"
+              },
+              "experiment_url": {
+                "type": "string",
+                "readOnly": true
+              },
+              "start_date": {
+                "type": "string",
+                "readOnly": true
+              },
+              "type": {
+                "enum": [
+                  "pref",
+                  "addon",
+                  "generic",
+                  "rollout",
+                  "message"
+                ],
+                "type": "string"
+              },
+              "length": {
+                "type": "string",
+                "readOnly": true
+              },
+              "channel": {
+                "type": "string"
+              },
+              "owner": {
+                "type": "string",
+                "readOnly": true
+              },
+              "data_scientist": {
+                "type": "string",
+                "readOnly": true
+              },
+              "enrolled_target": {
+                "type": "integer"
+              },
+              "results_url": {
+                "type": "string",
+                "format": "uri",
+                "nullable": true,
+                "maxLength": 200,
+                "pattern": "^(?:[a-z0-9.+-]*)://(?:[^\\s:@/]+(?::[^\\s:@/]*)?@)?(?:(?:0|25[0-5]|2[0-4]\\d|1\\d?\\d?|[1-9]\\d?)(?:\\.(?:0|25[0-5]|2[0-4]\\d|1\\d?\\d?|[1-9]\\d?)){3}|\\[[0-9a-f:.]+\\]|([a-z\u00a1-\uffff0-9](?:[a-z\u00a1-\uffff0-9-]{0,61}[a-z\u00a1-\uffff0-9])?(?:\\.(?!-)[a-z\u00a1-\uffff0-9-]{1,63}(?<!-))*\\.(?!-)(?:[a-z\u00a1-\uffff-]{2,63}|xn--[a-z0-9]{1,59})(?<!-)\\.?|localhost))(?::\\d{2,5})?(?:[/?#][^\\s]*)?\\z"
+              },
+              "projects": {
+                "type": "string",
+                "readOnly": true
+              },
+              "locales": {
+                "type": "string",
+                "readOnly": true
+              },
+              "countries": {
+                "type": "string",
+                "readOnly": true
+              }
+            },
+            "required": [
+              "name",
+              "description",
+              "hypothesis",
+              "leading_indicators",
+              "channel",
+              "enrolled_target"
+            ]
           },
-          "outcomes": {
-            "type": "string",
-            "readOnly": true
+          "ExperimentDesignAddonRollout": {
+            "type": "object",
+            "properties": {
+              "rollout_type": {
+                "enum": [
+                  "pref",
+                  "addon"
+                ],
+                "type": "string"
+              },
+              "design": {
+                "type": "string",
+                "nullable": true
+              },
+              "addon_release_url": {
+                "type": "string",
+                "format": "uri",
+                "nullable": true,
+                "maxLength": 400,
+                "pattern": "^(?:[a-z0-9.+-]*)://(?:[^\\s:@/]+(?::[^\\s:@/]*)?@)?(?:(?:0|25[0-5]|2[0-4]\\d|1\\d?\\d?|[1-9]\\d?)(?:\\.(?:0|25[0-5]|2[0-4]\\d|1\\d?\\d?|[1-9]\\d?)){3}|\\[[0-9a-f:.]+\\]|([a-z\u00a1-\uffff0-9](?:[a-z\u00a1-\uffff0-9-]{0,61}[a-z\u00a1-\uffff0-9])?(?:\\.(?!-)[a-z\u00a1-\uffff0-9-]{1,63}(?<!-))*\\.(?!-)(?:[a-z\u00a1-\uffff-]{2,63}|xn--[a-z0-9]{1,59})(?<!-)\\.?|localhost))(?::\\d{2,5})?(?:[/?#][^\\s]*)?\\z"
+              }
+            },
+            "required": [
+              "rollout_type",
+              "addon_release_url"
+            ]
           },
-          "branches": {
-            "type": "string",
-            "readOnly": true
+          "ExperimentDesignAddon": {
+            "type": "object",
+            "properties": {
+              "addon_release_url": {
+                "type": "string",
+                "format": "uri",
+                "maxLength": 400,
+                "pattern": "^(?:[a-z0-9.+-]*)://(?:[^\\s:@/]+(?::[^\\s:@/]*)?@)?(?:(?:0|25[0-5]|2[0-4]\\d|1\\d?\\d?|[1-9]\\d?)(?:\\.(?:0|25[0-5]|2[0-4]\\d|1\\d?\\d?|[1-9]\\d?)){3}|\\[[0-9a-f:.]+\\]|([a-z\u00a1-\uffff0-9](?:[a-z\u00a1-\uffff0-9-]{0,61}[a-z\u00a1-\uffff0-9])?(?:\\.(?!-)[a-z\u00a1-\uffff0-9-]{1,63}(?<!-))*\\.(?!-)(?:[a-z\u00a1-\uffff-]{2,63}|xn--[a-z0-9]{1,59})(?<!-)\\.?|localhost))(?::\\d{2,5})?(?:[/?#][^\\s]*)?\\z"
+              },
+              "variants": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "integer"
+                    },
+                    "description": {
+                      "type": "string"
+                    },
+                    "is_control": {
+                      "type": "boolean"
+                    },
+                    "name": {
+                      "type": "string",
+                      "maxLength": 255
+                    },
+                    "ratio": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "description",
+                    "is_control",
+                    "name",
+                    "ratio"
+                  ]
+                }
+              },
+              "is_branched_addon": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "addon_release_url",
+              "variants",
+              "is_branched_addon"
+            ]
           },
-          "targeting": {
-            "type": "string",
-            "readOnly": true
+          "ExperimentDesignPrefRollout": {
+            "type": "object",
+            "properties": {
+              "rollout_type": {
+                "enum": [
+                  "pref",
+                  "addon"
+                ],
+                "type": "string"
+              },
+              "design": {
+                "type": "string",
+                "nullable": true
+              },
+              "preferences": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "integer"
+                    },
+                    "pref_name": {
+                      "type": "string",
+                      "maxLength": 255
+                    },
+                    "pref_type": {
+                      "enum": [
+                        null,
+                        "boolean",
+                        "integer",
+                        "string",
+                        "json string"
+                      ]
+                    },
+                    "pref_value": {
+                      "type": "string",
+                      "maxLength": 4096
+                    }
+                  },
+                  "required": [
+                    "pref_name",
+                    "pref_type",
+                    "pref_value"
+                  ]
+                }
+              }
+            },
+            "required": [
+              "rollout_type",
+              "preferences"
+            ]
           },
-          "startDate": {
-            "type": "string",
-            "format": "date"
+          "ExperimentDesignPref": {
+            "type": "object",
+            "properties": {
+              "is_multi_pref": {
+                "type": "boolean"
+              },
+              "pref_name": {
+                "type": "string",
+                "maxLength": 255
+              },
+              "pref_type": {
+                "type": "string",
+                "maxLength": 255
+              },
+              "pref_branch": {
+                "type": "string",
+                "maxLength": 255
+              },
+              "variants": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "integer"
+                    },
+                    "description": {
+                      "type": "string"
+                    },
+                    "is_control": {
+                      "type": "boolean"
+                    },
+                    "name": {
+                      "type": "string",
+                      "maxLength": 255
+                    },
+                    "ratio": {
+                      "type": "integer"
+                    },
+                    "value": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "description",
+                    "is_control",
+                    "name",
+                    "ratio",
+                    "value"
+                  ]
+                }
+              }
+            },
+            "required": [
+              "is_multi_pref",
+              "pref_name",
+              "pref_type",
+              "pref_branch",
+              "variants"
+            ]
           },
-          "enrollmentEndDate": {
-            "type": "string",
-            "format": "date"
+          "ExperimentDesignMultiPref": {
+            "type": "object",
+            "properties": {
+              "is_multi_pref": {
+                "type": "boolean"
+              },
+              "variants": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "integer"
+                    },
+                    "description": {
+                      "type": "string"
+                    },
+                    "is_control": {
+                      "type": "boolean"
+                    },
+                    "name": {
+                      "type": "string",
+                      "maxLength": 255
+                    },
+                    "ratio": {
+                      "type": "integer"
+                    },
+                    "preferences": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "integer"
+                          },
+                          "pref_name": {
+                            "type": "string",
+                            "maxLength": 255
+                          },
+                          "pref_type": {
+                            "enum": [
+                              null,
+                              "boolean",
+                              "integer",
+                              "string",
+                              "json string"
+                            ]
+                          },
+                          "pref_branch": {
+                            "enum": [
+                              null,
+                              "default",
+                              "user"
+                            ]
+                          },
+                          "pref_value": {
+                            "type": "string",
+                            "maxLength": 4096
+                          }
+                        },
+                        "required": [
+                          "pref_name",
+                          "pref_type",
+                          "pref_branch",
+                          "pref_value"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "description",
+                    "is_control",
+                    "name",
+                    "ratio",
+                    "preferences"
+                  ]
+                }
+              }
+            },
+            "required": [
+              "is_multi_pref",
+              "variants"
+            ]
           },
-          "endDate": {
-            "type": "string",
-            "format": "date"
+          "ExperimentDesignGeneric": {
+            "type": "object",
+            "properties": {
+              "design": {
+                "type": "string",
+                "nullable": true
+              },
+              "variants": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "integer"
+                    },
+                    "description": {
+                      "type": "string"
+                    },
+                    "is_control": {
+                      "type": "boolean"
+                    },
+                    "name": {
+                      "type": "string",
+                      "maxLength": 255
+                    },
+                    "ratio": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "description",
+                    "is_control",
+                    "name",
+                    "ratio"
+                  ]
+                }
+              }
+            },
+            "required": [
+              "variants"
+            ]
           },
-          "proposedDuration": {
-            "type": "string",
-            "readOnly": true
+          "ExperimentDesignBranchedAddon": {
+            "type": "object",
+            "properties": {
+              "is_branched_addon": {
+                "type": "boolean"
+              },
+              "variants": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "addon_release_url": {
+                      "type": "string",
+                      "format": "uri",
+                      "maxLength": 400,
+                      "pattern": "^(?:[a-z0-9.+-]*)://(?:[^\\s:@/]+(?::[^\\s:@/]*)?@)?(?:(?:0|25[0-5]|2[0-4]\\d|1\\d?\\d?|[1-9]\\d?)(?:\\.(?:0|25[0-5]|2[0-4]\\d|1\\d?\\d?|[1-9]\\d?)){3}|\\[[0-9a-f:.]+\\]|([a-z\u00a1-\uffff0-9](?:[a-z\u00a1-\uffff0-9-]{0,61}[a-z\u00a1-\uffff0-9])?(?:\\.(?!-)[a-z\u00a1-\uffff0-9-]{1,63}(?<!-))*\\.(?!-)(?:[a-z\u00a1-\uffff-]{2,63}|xn--[a-z0-9]{1,59})(?<!-)\\.?|localhost))(?::\\d{2,5})?(?:[/?#][^\\s]*)?\\z"
+                    },
+                    "id": {
+                      "type": "integer"
+                    },
+                    "description": {
+                      "type": "string"
+                    },
+                    "is_control": {
+                      "type": "boolean"
+                    },
+                    "name": {
+                      "type": "string",
+                      "maxLength": 255
+                    },
+                    "ratio": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "addon_release_url",
+                    "description",
+                    "is_control",
+                    "name",
+                    "ratio"
+                  ]
+                }
+              }
+            },
+            "required": [
+              "is_branched_addon",
+              "variants"
+            ]
           },
-          "proposedEnrollment": {
-            "type": "string",
-            "readOnly": true
+          "ExperimentDesignMessage": {
+            "type": "object",
+            "properties": {
+              "message_type": {
+                "enum": [
+                  "cfr",
+                  "about:welcome"
+                ],
+                "type": "string"
+              },
+              "message_template": {
+                "enum": [
+                  "cfr_doorhanger",
+                  "cfr_urlbar_chiclet",
+                  "milestone_message"
+                ],
+                "type": "string",
+                "nullable": true
+              },
+              "variants": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "description": {
+                      "type": "string"
+                    },
+                    "id": {
+                      "type": "integer"
+                    },
+                    "is_control": {
+                      "type": "boolean"
+                    },
+                    "message_targeting": {
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "message_threshold": {
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "message_triggers": {
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "name": {
+                      "type": "string",
+                      "maxLength": 255
+                    },
+                    "ratio": {
+                      "type": "integer"
+                    },
+                    "value": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "description",
+                    "is_control",
+                    "name",
+                    "ratio",
+                    "value"
+                  ]
+                }
+              }
+            },
+            "required": [
+              "message_type",
+              "variants"
+            ]
           },
-          "referenceBranch": {
-            "type": "string",
-            "readOnly": true
+          "ExperimentTimelinePop": {
+            "type": "object",
+            "properties": {
+              "proposed_start_date": {
+                "type": "string",
+                "format": "date",
+                "nullable": true
+              },
+              "proposed_enrollment": {
+                "type": "integer",
+                "nullable": true
+              },
+              "rollout_playbook": {
+                "enum": [
+                  null,
+                  "low_risk",
+                  "high_risk",
+                  "marketing",
+                  "custom"
+                ],
+                "nullable": true
+              },
+              "proposed_duration": {
+                "type": "integer",
+                "nullable": true
+              },
+              "population_percent": {
+                "type": "string",
+                "format": "decimal",
+                "multipleOf": 0.0001,
+                "maximum": 100.0,
+                "minimum": 0,
+                "nullable": true
+              },
+              "firefox_channel": {
+                "enum": [
+                  null,
+                  "Nightly",
+                  "Beta",
+                  "Release"
+                ],
+                "nullable": true
+              },
+              "firefox_min_version": {
+                "enum": [
+                  "55.0",
+                  "56.0",
+                  "57.0",
+                  "58.0",
+                  "59.0",
+                  "60.0",
+                  "61.0",
+                  "62.0",
+                  "63.0",
+                  "64.0",
+                  "65.0",
+                  "66.0",
+                  "67.0",
+                  "68.0",
+                  "69.0",
+                  "70.0",
+                  "71.0",
+                  "72.0",
+                  "73.0",
+                  "74.0",
+                  "75.0",
+                  "76.0",
+                  "77.0",
+                  "78.0",
+                  "79.0",
+                  "80.0",
+                  "81.0",
+                  "82.0",
+                  "83.0",
+                  "84.0",
+                  "85.0",
+                  "86.0",
+                  "87.0",
+                  "88.0",
+                  "89.0",
+                  "90.0",
+                  "91.0",
+                  "92.0",
+                  "93.0",
+                  "94.0",
+                  "95.0",
+                  "96.0",
+                  "97.0",
+                  "98.0",
+                  "99.0",
+                  "100.0",
+                  "101.0",
+                  "102.0",
+                  "103.0",
+                  "104.0",
+                  "105.0",
+                  "106.0",
+                  "107.0",
+                  "108.0",
+                  "109.0",
+                  "110.0",
+                  "111.0",
+                  "112.0",
+                  "113.0",
+                  "114.0",
+                  "115.0",
+                  "116.0",
+                  "117.0",
+                  "118.0",
+                  "119.0",
+                  "120.0"
+                ],
+                "type": "string",
+                "nullable": true
+              },
+              "firefox_max_version": {
+                "enum": [
+                  "55.0",
+                  "56.0",
+                  "57.0",
+                  "58.0",
+                  "59.0",
+                  "60.0",
+                  "61.0",
+                  "62.0",
+                  "63.0",
+                  "64.0",
+                  "65.0",
+                  "66.0",
+                  "67.0",
+                  "68.0",
+                  "69.0",
+                  "70.0",
+                  "71.0",
+                  "72.0",
+                  "73.0",
+                  "74.0",
+                  "75.0",
+                  "76.0",
+                  "77.0",
+                  "78.0",
+                  "79.0",
+                  "80.0",
+                  "81.0",
+                  "82.0",
+                  "83.0",
+                  "84.0",
+                  "85.0",
+                  "86.0",
+                  "87.0",
+                  "88.0",
+                  "89.0",
+                  "90.0",
+                  "91.0",
+                  "92.0",
+                  "93.0",
+                  "94.0",
+                  "95.0",
+                  "96.0",
+                  "97.0",
+                  "98.0",
+                  "99.0",
+                  "100.0",
+                  "101.0",
+                  "102.0",
+                  "103.0",
+                  "104.0",
+                  "105.0",
+                  "106.0",
+                  "107.0",
+                  "108.0",
+                  "109.0",
+                  "110.0",
+                  "111.0",
+                  "112.0",
+                  "113.0",
+                  "114.0",
+                  "115.0",
+                  "116.0",
+                  "117.0",
+                  "118.0",
+                  "119.0",
+                  "120.0"
+                ],
+                "type": "string",
+                "nullable": true
+              },
+              "locales": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "label": {
+                      "type": "string"
+                    },
+                    "value": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "label",
+                    "value"
+                  ]
+                },
+                "nullable": true
+              },
+              "countries": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "label": {
+                      "type": "string"
+                    },
+                    "value": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "label",
+                    "value"
+                  ]
+                },
+                "nullable": true
+              },
+              "platforms": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {}
+                }
+              },
+              "windows_versions": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {}
+                },
+                "nullable": true
+              },
+              "profile_age": {
+                "enum": [
+                  "All Profiles",
+                  "New Profiles Only",
+                  "Existing Profiles Only"
+                ],
+                "type": "string",
+                "nullable": true
+              },
+              "client_matching": {
+                "type": "string",
+                "nullable": true
+              }
+            }
           },
-          "featureValidationOptOut": {
-            "type": "string",
-            "readOnly": true
+          "NimbusExperimentCsv": {
+            "type": "object",
+            "properties": {
+              "launch_month": {
+                "type": "string",
+                "readOnly": true
+              },
+              "product_area": {
+                "type": "string"
+              },
+              "experiment_name": {
+                "type": "string"
+              },
+              "owner": {
+                "type": "string",
+                "readOnly": true
+              },
+              "feature_configs": {
+                "type": "string",
+                "readOnly": true
+              },
+              "start_date": {
+                "type": "string",
+                "readOnly": true
+              },
+              "enrollment_duration": {
+                "type": "string",
+                "readOnly": true
+              },
+              "end_date": {
+                "type": "string",
+                "readOnly": true
+              },
+              "results_url": {
+                "type": "string",
+                "readOnly": true
+              },
+              "experiment_summary": {
+                "type": "string"
+              },
+              "rollout": {
+                "type": "boolean"
+              },
+              "hypothesis": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "product_area",
+              "experiment_name",
+              "experiment_summary",
+              "rollout"
+            ]
+          },
+          "NimbusConfiguration": {
+            "type": "object",
+            "properties": {
+              "applications": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "label": {
+                      "type": "string"
+                    },
+                    "value": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "label",
+                    "value"
+                  ]
+                }
+              },
+              "channels": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "label": {
+                      "type": "string"
+                    },
+                    "value": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "label",
+                    "value"
+                  ]
+                }
+              },
+              "applicationConfigs": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "application": {
+                      "type": "string"
+                    },
+                    "channels": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "label": {
+                            "type": "string"
+                          },
+                          "value": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "label",
+                          "value"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "application",
+                    "channels"
+                  ]
+                }
+              },
+              "countries": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "integer"
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "code": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "name",
+                    "code"
+                  ]
+                }
+              },
+              "locales": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "integer"
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "code": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "name",
+                    "code"
+                  ]
+                }
+              },
+              "languages": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "integer"
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "code": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "name",
+                    "code"
+                  ]
+                }
+              },
+              "projects": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "integer"
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "slug": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "name",
+                    "slug"
+                  ]
+                }
+              },
+              "documentationLink": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "label": {
+                      "type": "string"
+                    },
+                    "value": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "label",
+                    "value"
+                  ]
+                }
+              },
+              "allFeatureConfigs": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "integer"
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "slug": {
+                      "type": "string"
+                    },
+                    "description": {
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "application": {
+                      "type": "string"
+                    },
+                    "ownerEmail": {
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "schema": {
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "setsPrefs": {
+                      "type": "boolean"
+                    },
+                    "enabled": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "name",
+                    "slug",
+                    "description",
+                    "application",
+                    "ownerEmail",
+                    "schema",
+                    "setsPrefs",
+                    "enabled"
+                  ]
+                }
+              },
+              "firefoxVersions": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "label": {
+                      "type": "string"
+                    },
+                    "value": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "label",
+                    "value"
+                  ]
+                }
+              },
+              "outcomes": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "application": {
+                      "type": "string"
+                    },
+                    "description": {
+                      "type": "string"
+                    },
+                    "friendlyName": {
+                      "type": "string"
+                    },
+                    "slug": {
+                      "type": "string"
+                    },
+                    "isDefault": {
+                      "type": "boolean"
+                    },
+                    "metrics": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "slug": {
+                            "type": "string"
+                          },
+                          "friendlyName": {
+                            "type": "string"
+                          },
+                          "description": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "slug",
+                          "friendlyName",
+                          "description"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "application",
+                    "description",
+                    "friendlyName",
+                    "slug",
+                    "isDefault",
+                    "metrics"
+                  ]
+                }
+              },
+              "owners": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "username": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "username"
+                  ]
+                }
+              },
+              "targetingConfigs": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "label": {
+                      "type": "string"
+                    },
+                    "value": {
+                      "type": "string"
+                    },
+                    "applicationValues": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "description": {
+                      "type": "string"
+                    },
+                    "stickyRequired": {
+                      "type": "boolean"
+                    },
+                    "isFirstRunRequired": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "label",
+                    "value",
+                    "applicationValues",
+                    "description",
+                    "stickyRequired",
+                    "isFirstRunRequired"
+                  ]
+                }
+              },
+              "conclusionRecommendations": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "label": {
+                      "type": "string"
+                    },
+                    "value": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "label",
+                    "value"
+                  ]
+                }
+              },
+              "types": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "label": {
+                      "type": "string"
+                    },
+                    "value": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "label",
+                    "value"
+                  ]
+                }
+              },
+              "hypothesisDefault": {
+                "type": "string"
+              },
+              "maxPrimaryOutcomes": {
+                "type": "integer"
+              }
+            },
+            "required": [
+              "applications",
+              "channels",
+              "applicationConfigs",
+              "countries",
+              "locales",
+              "languages",
+              "projects",
+              "documentationLink",
+              "allFeatureConfigs",
+              "firefoxVersions",
+              "outcomes",
+              "owners",
+              "targetingConfigs",
+              "conclusionRecommendations",
+              "types"
+            ]
+          },
+          "NimbusExperiment": {
+            "type": "object",
+            "properties": {
+              "schemaVersion": {
+                "type": "string",
+                "readOnly": true,
+                "default": "1.10.0"
+              },
+              "slug": {
+                "type": "string",
+                "maxLength": 80,
+                "pattern": "^[-a-zA-Z0-9_]+$"
+              },
+              "id": {
+                "type": "string",
+                "readOnly": true
+              },
+              "arguments": {
+                "type": "string",
+                "readOnly": true,
+                "default": {}
+              },
+              "application": {
+                "type": "string",
+                "readOnly": true
+              },
+              "appName": {
+                "type": "string",
+                "readOnly": true
+              },
+              "appId": {
+                "type": "string",
+                "readOnly": true
+              },
+              "channel": {
+                "enum": [
+                  "",
+                  "default",
+                  "nightly",
+                  "beta",
+                  "release",
+                  "esr",
+                  "testflight",
+                  "aurora"
+                ],
+                "type": "string"
+              },
+              "userFacingName": {
+                "type": "string",
+                "readOnly": true
+              },
+              "userFacingDescription": {
+                "type": "string",
+                "readOnly": true
+              },
+              "isEnrollmentPaused": {
+                "type": "string",
+                "readOnly": true
+              },
+              "isRollout": {
+                "type": "string",
+                "readOnly": true
+              },
+              "bucketConfig": {
+                "type": "object",
+                "properties": {
+                  "randomizationUnit": {
+                    "type": "string",
+                    "readOnly": true
+                  },
+                  "namespace": {
+                    "type": "string",
+                    "readOnly": true
+                  },
+                  "start": {
+                    "type": "integer",
+                    "maximum": 2147483647,
+                    "minimum": 0
+                  },
+                  "count": {
+                    "type": "integer",
+                    "maximum": 2147483647,
+                    "minimum": 0
+                  },
+                  "total": {
+                    "type": "string",
+                    "readOnly": true
+                  }
+                },
+                "required": [
+                  "start",
+                  "count"
+                ]
+              },
+              "featureIds": {
+                "type": "string",
+                "readOnly": true
+              },
+              "probeSets": {
+                "type": "string",
+                "readOnly": true,
+                "default": []
+              },
+              "outcomes": {
+                "type": "string",
+                "readOnly": true
+              },
+              "branches": {
+                "type": "string",
+                "readOnly": true
+              },
+              "targeting": {
+                "type": "string",
+                "readOnly": true
+              },
+              "startDate": {
+                "type": "string",
+                "format": "date"
+              },
+              "enrollmentEndDate": {
+                "type": "string",
+                "format": "date"
+              },
+              "endDate": {
+                "type": "string",
+                "format": "date"
+              },
+              "proposedDuration": {
+                "type": "string",
+                "readOnly": true
+              },
+              "proposedEnrollment": {
+                "type": "string",
+                "readOnly": true
+              },
+              "referenceBranch": {
+                "type": "string",
+                "readOnly": true
+              },
+              "featureValidationOptOut": {
+                "type": "string",
+                "readOnly": true
+              }
+            },
+            "required": [
+              "slug",
+              "channel",
+              "bucketConfig",
+              "startDate",
+              "enrollmentEndDate",
+              "endDate"
+            ]
+          },
+          "ExperimentClone": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "maxLength": 255
+              },
+              "clone_url": {
+                "type": "string",
+                "readOnly": true
+              }
+            },
+            "required": [
+              "name"
+            ]
           }
-        },
-        "required": [
-          "slug",
-          "channel",
-          "bucketConfig",
-          "startDate",
-          "enrollmentEndDate",
-          "endDate"
-        ]
-      },
-      "ExperimentClone": {
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "string",
-            "maxLength": 255
-          },
-          "clone_url": {
-            "type": "string",
-            "readOnly": true
-          }
-        },
-        "required": [
-          "name"
-        ]
+        }
       }
-    }
-  }
-};
-      const ui = SwaggerUIBundle({
-        spec: spec,
-        dom_id: "#swagger-ui",
-        presets: [
-          SwaggerUIBundle.presets.apis,
-          SwaggerUIBundle.SwaggerUIStandalonePreset,
-        ],
-        layout: "BaseLayout",
-      });
-    </script>
-  </body>
+    };
+    const ui = SwaggerUIBundle({
+      spec: spec,
+      dom_id: "#swagger-ui",
+      presets: [
+        SwaggerUIBundle.presets.apis,
+        SwaggerUIBundle.SwaggerUIStandalonePreset,
+      ],
+      layout: "BaseLayout",
+    });
+  </script>
+</body>
+
 </html>

--- a/experimenter/experimenter/experiments/admin.py
+++ b/experimenter/experimenter/experiments/admin.py
@@ -156,7 +156,7 @@ class NimbusExperimentResource(resources.ModelResource):
 
         for change in import_changes:
             NimbusChangeLog.objects.get_or_create(
-                changed_on=change.get("changed_on"),
+                updated_date_time=change.get("updated_date_time"),
                 old_status=change.get("old_status"),
                 old_status_next=change.get("old_status_next"),
                 old_publish_status=change.get("old_publish_status"),

--- a/experimenter/experimenter/experiments/api/v5/types.py
+++ b/experimenter/experimenter/experiments/api/v5/types.py
@@ -252,7 +252,7 @@ class NimbusChangeLogType(DjangoObjectType):
         model = NimbusChangeLog
         fields = (
             "changed_by",
-            "changed_on",
+            "updated_date_time",
             "experiment_data",
             "message",
             "new_status_next",
@@ -666,4 +666,4 @@ class NimbusExperimentType(DjangoObjectType):
         return self.languages.all().order_by("name")
 
     def resolve_changes(self, info):
-        return self.changes.all().order_by("changed_on")
+        return self.changes.all().order_by("updated_date_time")

--- a/experimenter/experimenter/experiments/migrations/0002_auto_20171115_1918.py
+++ b/experimenter/experimenter/experiments/migrations/0002_auto_20171115_1918.py
@@ -111,7 +111,7 @@ class Migration(migrations.Migration):
                         verbose_name="ID",
                     ),
                 ),
-                ("changed_on", models.DateTimeField(auto_now_add=True)),
+                ("updated_date_time", models.DateTimeField(auto_now_add=True)),
                 (
                     "old_status",
                     models.CharField(
@@ -162,7 +162,7 @@ class Migration(migrations.Migration):
             options={
                 "verbose_name": "Experiment Change Log",
                 "verbose_name_plural": "Experiment Change Logs",
-                "ordering": ("changed_on",),
+                "ordering": ("updated_date_time",),
             },
         ),
         migrations.CreateModel(

--- a/experimenter/experimenter/experiments/migrations/0004_auto_20171205_2015.py
+++ b/experimenter/experimenter/experiments/migrations/0004_auto_20171205_2015.py
@@ -24,7 +24,7 @@ class Migration(migrations.Migration):
         ),
         migrations.AlterField(
             model_name="experimentchangelog",
-            name="changed_on",
+            name="updated_date_time",
             field=models.DateTimeField(
                 default=experimenter.legacy.legacy_experiments.models.ExperimentChangeLog.current_datetime
             ),

--- a/experimenter/experimenter/experiments/migrations/0006_auto_20180221_1939.py
+++ b/experimenter/experimenter/experiments/migrations/0006_auto_20180221_1939.py
@@ -13,7 +13,7 @@ def update_dates(apps, schema_editor):  # pragma: no cover
         try:
             start_date = ExperimentChangeLog.objects.get(
                 experiment=experiment, old_status="Accepted", new_status="Launched"
-            ).changed_on
+            ).updated_date_time
             experiment.proposed_start_date = start_date
         except:
             pass
@@ -21,7 +21,7 @@ def update_dates(apps, schema_editor):  # pragma: no cover
         try:
             end_date = ExperimentChangeLog.objects.get(
                 experiment=experiment, old_status="Launched", new_status="Complete"
-            ).changed_on
+            ).updated_date_time
             experiment.proposed_end_date = end_date
         except:
             pass

--- a/experimenter/experimenter/experiments/migrations/0072_changelog_pruning.py
+++ b/experimenter/experimenter/experiments/migrations/0072_changelog_pruning.py
@@ -20,7 +20,7 @@ class Migration(migrations.Migration):
 
         for experiment in Experiment.objects.all():
             change_logs = experiment.changes.filter(old_status=None).order_by(
-                "changed_on"
+                "updated_date_time"
             )[1:]
 
             for log in change_logs:
@@ -31,13 +31,13 @@ class Migration(migrations.Migration):
         for experiment in Experiment.objects.all():
             changes = experiment.changes.filter(
                 changed_values={}, old_status=F("new_status")
-            ).order_by("changed_on")
+            ).order_by("updated_date_time")
             seen_edits = set()
             current_date = None
             for change in changes:
-                if change.changed_on.date() != current_date:
+                if change.updated_date_time.date() != current_date:
                     seen_edits = set([change.changed_by.email])
-                    current_date = change.changed_on.date()
+                    current_date = change.updated_date_time.date()
                 elif change.changed_by.email in seen_edits:
                     change.delete()
                 else:

--- a/experimenter/experimenter/experiments/migrations/0127_add_changelogs.py
+++ b/experimenter/experimenter/experiments/migrations/0127_add_changelogs.py
@@ -30,7 +30,7 @@ class Migration(migrations.Migration):
                     ),
                 ),
                 (
-                    "changed_on",
+                    "updated_date_time",
                     models.DateTimeField(
                         default=experimenter.experiments.models.NimbusChangeLog.current_datetime
                     ),
@@ -91,7 +91,7 @@ class Migration(migrations.Migration):
             options={
                 "verbose_name": "Nimbus Experiment Change Log",
                 "verbose_name_plural": "Nimbus Experiment Change Logs",
-                "ordering": ("changed_on",),
+                "ordering": ("updated_date_time",),
             },
         ),
     ]

--- a/experimenter/experimenter/experiments/migrations/0170_restore_feature_configs.py
+++ b/experimenter/experimenter/experiments/migrations/0170_restore_feature_configs.py
@@ -13,7 +13,7 @@ def restore_feature_configs(apps, schema_editor):
             .exclude(experiment_data__feature_config__slug="no-feature-firefox-desktop")
             .exclude(experiment_data__feature_config__slug="no-feature-fenix")
             .exclude(experiment_data__feature_config__slug="no-feature-ios")
-            .order_by("-changed_on")
+            .order_by("-updated_date_time")
             .values_list("experiment_data__feature_config__slug", flat=True)
             .first()
         )

--- a/experimenter/experimenter/experiments/migrations/0225_nimbusexperiment__updated_date_time.py
+++ b/experimenter/experimenter/experiments/migrations/0225_nimbusexperiment__updated_date_time.py
@@ -4,15 +4,15 @@
 from django.db import migrations, models
 
 
-def update_updated_date_time_with_changelog_last_changed_on(apps, schema_editor):
+def update_updated_date_time_with_changelog_last_updated_date_time(apps, schema_editor):
     NimbusExperiment = apps.get_model("experiments", "NimbusExperiment")
     for experiment in NimbusExperiment.objects.all():
 
         # disabling auto_now
         experiment._meta.get_field("_updated_date_time").auto_now = False
 
-        if change := experiment.changes.all().order_by("-changed_on").first():
-            experiment._updated_date_time = change.changed_on
+        if change := experiment.changes.all().order_by("-updated_date_time").first():
+            experiment._updated_date_time = change.updated_date_time
             experiment.save()
         # Re-enabling auto_now
         experiment._meta.get_field("_updated_date_time").auto_now = True
@@ -30,5 +30,7 @@ class Migration(migrations.Migration):
             name="_updated_date_time",
             field=models.DateTimeField(auto_now=True),
         ),
-        migrations.RunPython(update_updated_date_time_with_changelog_last_changed_on),
+        migrations.RunPython(
+            update_updated_date_time_with_changelog_last_updated_date_time
+        ),
     ]

--- a/experimenter/experimenter/experiments/tests/api/v5/test_queries.py
+++ b/experimenter/experimenter/experiments/tests/api/v5/test_queries.py
@@ -612,6 +612,9 @@ class TestNimbusExperimentBySlugQuery(GraphQLTestCase):
         )
 
         review_request_change = experiment.changes.latest_review_request()
+        review_request_change_updated_date = (
+            review_request_change.updated_date_time.isoformat()
+        )
         rejection_change = experiment.changes.latest_rejection()
         timeout_change = experiment.changes.latest_timeout()
         reference_branch = experiment.reference_branch
@@ -758,7 +761,7 @@ class TestNimbusExperimentBySlugQuery(GraphQLTestCase):
 
                     canReview
                     reviewRequest {
-                        changedOn
+                        updatedDateTime
                         changedBy {
                             email
                         }
@@ -767,13 +770,13 @@ class TestNimbusExperimentBySlugQuery(GraphQLTestCase):
                         message
                         oldStatus
                         oldStatusNext
-                        changedOn
+                        updatedDateTime
                         changedBy {
                             email
                         }
                     }
                     timeout {
-                        changedOn
+                        updatedDateTime
                         changedBy {
                             email
                         }
@@ -914,7 +917,7 @@ class TestNimbusExperimentBySlugQuery(GraphQLTestCase):
                 "rejection": (
                     {
                         "changedBy": {"email": rejection_change.changed_by.email},
-                        "changedOn": rejection_change.changed_on.isoformat(),
+                        "updatedDateTime": rejection_change.updated_date_time.isoformat(),
                         "message": rejection_change.message,
                         "oldStatus": NimbusExperiment.Status(
                             rejection_change.old_status
@@ -930,7 +933,7 @@ class TestNimbusExperimentBySlugQuery(GraphQLTestCase):
                 "reviewRequest": (
                     {
                         "changedBy": {"email": review_request_change.changed_by.email},
-                        "changedOn": review_request_change.changed_on.isoformat(),
+                        "updatedDateTime": review_request_change_updated_date,
                     }
                     if review_request_change
                     else None
@@ -976,7 +979,7 @@ class TestNimbusExperimentBySlugQuery(GraphQLTestCase):
                 "timeout": (
                     {
                         "changedBy": {"email": timeout_change.changed_by.email},
-                        "changedOn": timeout_change.changed_on.isoformat(),
+                        "updatedDateTime": timeout_change.updated_date_time.isoformat(),
                     }
                     if timeout_change
                     else None
@@ -1893,7 +1896,7 @@ class TestNimbusExperimentBySlugQuery(GraphQLTestCase):
                         changedBy {
                             email
                         }
-                        changedOn
+                        updatedDateTime
                         message
                         oldStatusNext
                         oldStatus
@@ -1914,12 +1917,12 @@ class TestNimbusExperimentBySlugQuery(GraphQLTestCase):
             [
                 {
                     "changedBy": {"email": c.changed_by.email},
-                    "changedOn": c.changed_on.isoformat(),
+                    "updatedDateTime": c.updated_date_time.isoformat(),
                     "message": c.message,
                     "oldStatusNext": c.old_status_next,
                     "oldStatus": c.old_status,
                 }
-                for c in experiment.changes.all().order_by("changed_on")
+                for c in experiment.changes.all().order_by("updated_date_time")
             ],
         )
 

--- a/experimenter/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_experiment_csv_serializer.py
+++ b/experimenter/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_experiment_csv_serializer.py
@@ -52,7 +52,7 @@ class TestNimbusExperimentCsvSerializer(TestCase):
             old_status=NimbusExperiment.Status.DRAFT,
             new_status=NimbusExperiment.Status.LIVE,
         ).update(
-            changed_on=datetime.date(2019, 5, 1),
+            updated_date_time=datetime.date(2019, 5, 1),
         )
         serializer = NimbusExperimentCsvSerializer(experiment)
         self.assertDictEqual(

--- a/experimenter/experimenter/experiments/tests/factories.py
+++ b/experimenter/experimenter/experiments/tests/factories.py
@@ -471,13 +471,13 @@ class NimbusExperimentFactory(factory.django.DjangoModelFactory):
                 f"set lifecycle {lifecycle} state {state}",
             )
 
-            change.changed_on = current_datetime
+            change.updated_date_time = current_datetime
             change.save()
             current_datetime += datetime.timedelta(days=1)
 
         if with_latest_change_now:
             latest_change = experiment.changes.latest_change()
-            latest_change.changed_on = timezone.now()
+            latest_change.updated_date_time = timezone.now()
             latest_change.save()
 
         return NimbusExperiment.objects.get(id=experiment.id)

--- a/experimenter/experimenter/experiments/tests/test_admin.py
+++ b/experimenter/experimenter/experiments/tests/test_admin.py
@@ -262,7 +262,7 @@ class TestNimbusExperimentExport(TestCase):
             )
             changes.append(
                 {
-                    "changed_on": cl.changed_on,
+                    "updated_date_time": cl.updated_date_time,
                     "old_status": cl.old_status,
                     "old_status_next": cl.old_status_next,
                     "old_publish_status": cl.old_publish_status,

--- a/experimenter/experimenter/experiments/tests/test_models.py
+++ b/experimenter/experimenter/experiments/tests/test_models.py
@@ -49,10 +49,10 @@ class TestNimbusExperimentManager(TestCase):
         newer_experiment = NimbusExperimentFactory.create()
 
         NimbusChangeLogFactory.create(
-            experiment=older_experiment, changed_on=datetime.datetime(2021, 1, 1)
+            experiment=older_experiment, updated_date_time=datetime.datetime(2021, 1, 1)
         )
         NimbusChangeLogFactory.create(
-            experiment=newer_experiment, changed_on=datetime.datetime(2021, 1, 2)
+            experiment=newer_experiment, updated_date_time=datetime.datetime(2021, 1, 2)
         )
 
         self.assertEqual(
@@ -846,15 +846,15 @@ class TestNimbusExperiment(TestCase):
             experiment=experiment,
             old_status=NimbusExperiment.Status.DRAFT,
             new_status=NimbusExperiment.Status.LIVE,
-            changed_on=datetime.datetime.now() + datetime.timedelta(days=1),
+            updated_date_time=datetime.datetime.now() + datetime.timedelta(days=1),
         )
         start_change = NimbusChangeLogFactory(
             experiment=experiment,
             old_status=NimbusExperiment.Status.DRAFT,
             new_status=NimbusExperiment.Status.LIVE,
-            changed_on=datetime.datetime.now() + datetime.timedelta(days=2),
+            updated_date_time=datetime.datetime.now() + datetime.timedelta(days=2),
         )
-        self.assertEqual(experiment.start_date, start_change.changed_on.date())
+        self.assertEqual(experiment.start_date, start_change.updated_date_time.date())
 
     @parameterized.expand(
         [[NimbusExperiment.Status.LIVE], [NimbusExperiment.Status.COMPLETE]]
@@ -871,7 +871,7 @@ class TestNimbusExperiment(TestCase):
             experiment=experiment,
             old_status=NimbusExperiment.Status.DRAFT,
             new_status=NimbusExperiment.Status.LIVE,
-            changed_on=changelog_date,
+            updated_date_time=changelog_date,
         )
 
         self.assertEqual(experiment.start_date, cached_date)
@@ -884,15 +884,15 @@ class TestNimbusExperiment(TestCase):
             experiment=experiment,
             old_status=NimbusExperiment.Status.LIVE,
             new_status=NimbusExperiment.Status.COMPLETE,
-            changed_on=datetime.datetime.now() + datetime.timedelta(days=1),
+            updated_date_time=datetime.datetime.now() + datetime.timedelta(days=1),
         )
         end_change = NimbusChangeLogFactory(
             experiment=experiment,
             old_status=NimbusExperiment.Status.LIVE,
             new_status=NimbusExperiment.Status.COMPLETE,
-            changed_on=datetime.datetime.now() + datetime.timedelta(days=2),
+            updated_date_time=datetime.datetime.now() + datetime.timedelta(days=2),
         )
-        self.assertEqual(experiment.end_date, end_change.changed_on.date())
+        self.assertEqual(experiment.end_date, end_change.updated_date_time.date())
 
     def test_end_date_uses_cached_end_date(self):
         cached_date = datetime.date(2022, 1, 1)
@@ -908,7 +908,7 @@ class TestNimbusExperiment(TestCase):
             experiment=experiment,
             old_status=NimbusExperiment.Status.LIVE,
             new_status=NimbusExperiment.Status.COMPLETE,
-            changed_on=changelog_date,
+            updated_date_time=changelog_date,
         )
 
         self.assertEqual(experiment.end_date, cached_date)
@@ -942,15 +942,15 @@ class TestNimbusExperiment(TestCase):
             experiment=experiment,
             old_status=NimbusExperiment.Status.LIVE,
             new_status=NimbusExperiment.Status.COMPLETE,
-            changed_on=datetime.datetime.now() + datetime.timedelta(days=1),
+            updated_date_time=datetime.datetime.now() + datetime.timedelta(days=1),
         )
         end_change = NimbusChangeLogFactory(
             experiment=experiment,
             old_status=NimbusExperiment.Status.LIVE,
             new_status=NimbusExperiment.Status.COMPLETE,
-            changed_on=datetime.datetime.now() + datetime.timedelta(days=2),
+            updated_date_time=datetime.datetime.now() + datetime.timedelta(days=2),
         )
-        self.assertEqual(experiment.end_date, end_change.changed_on.date())
+        self.assertEqual(experiment.end_date, end_change.updated_date_time.date())
 
     def test_proposed_end_date_returns_None_for_not_started_experiment(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
@@ -1003,7 +1003,7 @@ class TestNimbusExperiment(TestCase):
         )
         self.assertTrue(experiment.should_end_enrollment)
 
-    def test_computed_enrollment_days_returns_changed_on_minus_start_date(self):
+    def test_computed_enrollment_days_returns_updated_date_time_minus_start_date(self):
         expected_days = 3
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.PAUSING_APPROVE_APPROVE,
@@ -1011,7 +1011,7 @@ class TestNimbusExperiment(TestCase):
         )
 
         experiment.changes.filter(experiment_data__is_paused=True).update(
-            changed_on=datetime.datetime.now()
+            updated_date_time=datetime.datetime.now()
         )
 
         self.assertEqual(
@@ -1062,7 +1062,7 @@ class TestNimbusExperiment(TestCase):
         )
 
         experiment.changes.filter(experiment_data__is_paused=True).update(
-            changed_on=datetime.datetime.now()
+            updated_date_time=datetime.datetime.now()
         )
         self.assertEqual(
             experiment.computed_enrollment_days,
@@ -1107,7 +1107,7 @@ class TestNimbusExperiment(TestCase):
         )
 
         experiment.changes.filter(experiment_data__is_paused=True).update(
-            changed_on=enrollment_end_date
+            updated_date_time=enrollment_end_date
         )
 
         self.assertEqual(
@@ -2291,7 +2291,7 @@ class TestNimbusChangeLog(TestCase):
         user = UserFactory.create()
         changelog = NimbusChangeLogFactory.create(
             changed_by=user,
-            changed_on=now,
+            updated_date_time=now,
             old_status=NimbusExperiment.Status.DRAFT,
             new_status=NimbusExperiment.Status.PREVIEW,
             message=None,

--- a/experimenter/experimenter/legacy/legacy-ui/templates/experiments/detail_base.html
+++ b/experimenter/experimenter/legacy/legacy-ui/templates/experiments/detail_base.html
@@ -240,7 +240,7 @@
                             <span aria-hidden="true">&times;</span>
                           </button>
                       </div>
-                      <p class="text-muted">{{user_change.changed_on}}</p>
+                      <p class="text-muted">{{user_change.updated_date_time}}</p>
                     </div>
 
                     <div class="modal-body">

--- a/experimenter/experimenter/legacy/legacy_experiments/admin.py
+++ b/experimenter/experimenter/legacy/legacy_experiments/admin.py
@@ -24,7 +24,7 @@ class ExperimentChangeLogInlineAdmin(admin.TabularInline):
 
     fields = (
         "changed_by",
-        "changed_on",
+        "updated_date_time",
         "old_status",
         "new_status",
         "message",

--- a/experimenter/experimenter/legacy/legacy_experiments/api/v1/serializers.py
+++ b/experimenter/experimenter/legacy/legacy_experiments/api/v1/serializers.py
@@ -75,7 +75,7 @@ class ExperimentVariantSerializer(serializers.ModelSerializer):
 class ExperimentChangeLogSerializer(serializers.ModelSerializer):
     class Meta:
         model = ExperimentChangeLog
-        fields = ("changed_on", "pretty_status", "new_status", "old_status")
+        fields = ("updated_date_time", "pretty_status", "new_status", "old_status")
 
 
 class ResultsSerializer(serializers.ModelSerializer):

--- a/experimenter/experimenter/legacy/legacy_experiments/migrations/0001_initial.py
+++ b/experimenter/experimenter/legacy/legacy_experiments/migrations/0001_initial.py
@@ -889,7 +889,7 @@ class Migration(migrations.Migration):
                             ),
                         ),
                         (
-                            "changed_on",
+                            "updated_date_time",
                             models.DateTimeField(
                                 default=experimenter.legacy.legacy_experiments.models.ExperimentChangeLog.current_datetime
                             ),
@@ -955,7 +955,7 @@ class Migration(migrations.Migration):
                         "verbose_name": "Experiment Change Log",
                         "verbose_name_plural": "Experiment Change Logs",
                         "db_table": "experiments_experimentchangelog",
-                        "ordering": ("changed_on",),
+                        "ordering": ("updated_date_time",),
                     },
                 ),
                 migrations.CreateModel(

--- a/experimenter/experimenter/legacy/legacy_experiments/tests/api/v1/test_serializers.py
+++ b/experimenter/experimenter/legacy/legacy_experiments/tests/api/v1/test_serializers.py
@@ -183,7 +183,9 @@ class TestExperimentSerializer(TestCase):
 class TestExperimentChangeLogSerializer(TestCase):
     def test_serializer_outputs_expected_schema(self):
         change_log = ExperimentChangeLogFactory.create(
-            changed_on="2019-08-02T18:19:26.267960Z"
+            updated_date_time="2019-08-02T18:19:26.267960Z"
         )
         serializer = ExperimentChangeLogSerializer(change_log)
-        self.assertEqual(serializer.data["changed_on"], change_log.changed_on)
+        self.assertEqual(
+            serializer.data["updated_date_time"], change_log.updated_date_time
+        )

--- a/experimenter/experimenter/legacy/legacy_experiments/tests/factories.py
+++ b/experimenter/experimenter/legacy/legacy_experiments/tests/factories.py
@@ -149,7 +149,7 @@ class ExperimentFactory(ExperimentConstants, factory.django.DjangoModelFactory):
                 experiment=experiment,
                 old_status=old_status,
                 new_status=status_value,
-                changed_on=now,
+                updated_date_time=now,
             )
 
             if status_value == Experiment.STATUS_SHIP:

--- a/experimenter/experimenter/legacy/legacy_experiments/tests/test_models.py
+++ b/experimenter/experimenter/legacy/legacy_experiments/tests/test_models.py
@@ -35,14 +35,14 @@ class TestExperimentManager(TestCase):
             experiment=experiment1,
             old_status=None,
             new_status=Experiment.STATUS_DRAFT,
-            changed_on=(now - datetime.timedelta(days=2)),
+            updated_date_time=(now - datetime.timedelta(days=2)),
         )
 
         ExperimentChangeLogFactory.create(
             experiment=experiment2,
             old_status=None,
             new_status=Experiment.STATUS_DRAFT,
-            changed_on=(now - datetime.timedelta(days=1)),
+            updated_date_time=(now - datetime.timedelta(days=1)),
         )
 
         self.assertEqual(
@@ -109,7 +109,7 @@ class TestExperimentModel(TestCase):
             experiment=experiment,
             old_status=Experiment.STATUS_ACCEPTED,
             new_status=Experiment.STATUS_LIVE,
-            changed_on=datetime.date(2019, 5, 1),
+            updated_date_time=datetime.date(2019, 5, 1),
         )
 
         from_date = datetime.date(2019, 4, 30)
@@ -136,14 +136,14 @@ class TestExperimentModel(TestCase):
             experiment=experiment,
             old_status=Experiment.STATUS_ACCEPTED,
             new_status=Experiment.STATUS_LIVE,
-            changed_on=datetime.date(2019, 5, 1),
+            updated_date_time=datetime.date(2019, 5, 1),
         )
 
         ExperimentChangeLogFactory.create(
             experiment=experiment,
             old_status=Experiment.STATUS_LIVE,
             new_status=Experiment.STATUS_COMPLETE,
-            changed_on=datetime.date(2019, 5, 10),
+            updated_date_time=datetime.date(2019, 5, 10),
         )
 
         from_date = datetime.date(2019, 4, 30)
@@ -170,7 +170,7 @@ class TestExperimentModel(TestCase):
             experiment=experiment,
             old_status=Experiment.STATUS_ACCEPTED,
             new_status=Experiment.STATUS_LIVE,
-            changed_on=datetime.date(2019, 5, 1),
+            updated_date_time=datetime.date(2019, 5, 1),
         )
 
         from_date = datetime.date(2019, 4, 30)
@@ -453,7 +453,7 @@ class TestExperimentModel(TestCase):
         change = ExperimentChangeLogFactory.create(
             old_status=Experiment.STATUS_ACCEPTED, new_status=Experiment.STATUS_LIVE
         )
-        self.assertEqual(change.experiment.start_date, change.changed_on.date())
+        self.assertEqual(change.experiment.start_date, change.updated_date_time.date())
 
     def test_observation_duration_returns_duration_minus_enrollment(self):
         experiment = ExperimentFactory.create_with_variants(
@@ -500,7 +500,7 @@ class TestExperimentModel(TestCase):
         change = ExperimentChangeLogFactory.create(
             old_status=Experiment.STATUS_LIVE, new_status=Experiment.STATUS_COMPLETE
         )
-        self.assertEqual(change.experiment.end_date, change.changed_on.date())
+        self.assertEqual(change.experiment.end_date, change.updated_date_time.date())
 
     def test_enrollment_end_date_uses_enrollment_duration(self):
         experiment = ExperimentFactory.create_with_variants(
@@ -602,7 +602,7 @@ class TestExperimentModel(TestCase):
             experiment=experiment,
             old_status=Experiment.STATUS_ACCEPTED,
             new_status=Experiment.STATUS_LIVE,
-            changed_on=four_days_ago,
+            updated_date_time=four_days_ago,
             changed_by=user,
         )
         ExperimentChangeLog.objects.create(
@@ -610,14 +610,14 @@ class TestExperimentModel(TestCase):
             old_status=Experiment.STATUS_LIVE,
             new_status=Experiment.STATUS_LIVE,
             message="Enrollment Complete",
-            changed_on=three_days_ago,
+            updated_date_time=three_days_ago,
             changed_by=user,
         )
         ExperimentChangeLog.objects.create(
             experiment=experiment,
             old_status=Experiment.STATUS_LIVE,
             new_status=Experiment.STATUS_COMPLETE,
-            changed_on=today,
+            updated_date_time=today,
             changed_by=user,
         )
 
@@ -704,39 +704,39 @@ class TestExperimentModel(TestCase):
         user3 = UserFactory.create()
 
         change1 = ExperimentChangeLogFactory.create(
-            experiment=experiment, changed_by=user1, changed_on=date1
+            experiment=experiment, changed_by=user1, updated_date_time=date1
         )
         change2 = ExperimentChangeLogFactory.create(
-            experiment=experiment, changed_by=user1, changed_on=date1
+            experiment=experiment, changed_by=user1, updated_date_time=date1
         )
         change3 = ExperimentChangeLogFactory.create(
-            experiment=experiment, changed_by=user1, changed_on=date1
+            experiment=experiment, changed_by=user1, updated_date_time=date1
         )
         change4 = ExperimentChangeLogFactory.create(
-            experiment=experiment, changed_by=user2, changed_on=date1
+            experiment=experiment, changed_by=user2, updated_date_time=date1
         )
 
         change5 = ExperimentChangeLogFactory.create(
-            experiment=experiment, changed_by=user2, changed_on=date2
+            experiment=experiment, changed_by=user2, updated_date_time=date2
         )
         change6 = ExperimentChangeLogFactory.create(
-            experiment=experiment, changed_by=user3, changed_on=date2
+            experiment=experiment, changed_by=user3, updated_date_time=date2
         )
         change7 = ExperimentChangeLogFactory.create(
-            experiment=experiment, changed_by=user3, changed_on=date2
+            experiment=experiment, changed_by=user3, updated_date_time=date2
         )
 
         change8 = ExperimentChangeLogFactory.create(
-            experiment=experiment, changed_by=user1, changed_on=date3
+            experiment=experiment, changed_by=user1, updated_date_time=date3
         )
         change9 = ExperimentChangeLogFactory.create(
-            experiment=experiment, changed_by=user1, changed_on=date3
+            experiment=experiment, changed_by=user1, updated_date_time=date3
         )
         change10 = ExperimentChangeLogFactory.create(
-            experiment=experiment, changed_by=user2, changed_on=date3
+            experiment=experiment, changed_by=user2, updated_date_time=date3
         )
         change11 = ExperimentChangeLogFactory.create(
-            experiment=experiment, changed_by=user3, changed_on=date3
+            experiment=experiment, changed_by=user3, updated_date_time=date3
         )
 
         self.assertEqual(
@@ -783,37 +783,37 @@ class TestExperimentModel(TestCase):
         user3 = UserFactory.create()
 
         a = ExperimentChangeLogFactory.create(
-            experiment=experiment, changed_by=user1, changed_on=date1, message="a"
+            experiment=experiment, changed_by=user1, updated_date_time=date1, message="a"
         )
         b = ExperimentChangeLogFactory.create(
-            experiment=experiment, changed_by=user1, changed_on=date1, message="b"
+            experiment=experiment, changed_by=user1, updated_date_time=date1, message="b"
         )
 
         c = ExperimentChangeLogFactory.create(
-            experiment=experiment, changed_by=user2, changed_on=date1, message="c"
+            experiment=experiment, changed_by=user2, updated_date_time=date1, message="c"
         )
 
         d = ExperimentChangeLogFactory.create(
-            experiment=experiment, changed_by=user2, changed_on=date2, message="d"
+            experiment=experiment, changed_by=user2, updated_date_time=date2, message="d"
         )
         e = ExperimentChangeLogFactory.create(
-            experiment=experiment, changed_by=user3, changed_on=date2, message="e"
+            experiment=experiment, changed_by=user3, updated_date_time=date2, message="e"
         )
         f = ExperimentChangeLogFactory.create(
-            experiment=experiment, changed_by=user3, changed_on=date2, message="f"
+            experiment=experiment, changed_by=user3, updated_date_time=date2, message="f"
         )
 
         g = ExperimentChangeLogFactory.create(
-            experiment=experiment, changed_by=user1, changed_on=date3, message="g"
+            experiment=experiment, changed_by=user1, updated_date_time=date3, message="g"
         )
         h = ExperimentChangeLogFactory.create(
-            experiment=experiment, changed_by=user1, changed_on=date3, message="h"
+            experiment=experiment, changed_by=user1, updated_date_time=date3, message="h"
         )
         i = ExperimentChangeLogFactory.create(
-            experiment=experiment, changed_by=user2, changed_on=date3, message="i"
+            experiment=experiment, changed_by=user2, updated_date_time=date3, message="i"
         )
         j = ExperimentChangeLogFactory.create(
-            experiment=experiment, changed_by=user3, changed_on=date3, message="j"
+            experiment=experiment, changed_by=user3, updated_date_time=date3, message="j"
         )
 
         expected_changes = {
@@ -1676,7 +1676,7 @@ class TestExperimentChangeLog(TestCase):
             experiment=experiment,
             old_status=None,
             new_status=Experiment.STATUS_DRAFT,
-            changed_on=(now - datetime.timedelta(days=2)),
+            updated_date_time=(now - datetime.timedelta(days=2)),
         )
 
         self.assertEqual(experiment.changes.latest(), changelog1)
@@ -1685,7 +1685,7 @@ class TestExperimentChangeLog(TestCase):
             experiment=experiment,
             old_status=Experiment.STATUS_DRAFT,
             new_status=Experiment.STATUS_REVIEW,
-            changed_on=(now - datetime.timedelta(days=1)),
+            updated_date_time=(now - datetime.timedelta(days=1)),
         )
 
         self.assertEqual(experiment.changes.latest(), changelog2)

--- a/experimenter/experimenter/nimbus-ui/schema.graphql
+++ b/experimenter/experimenter/nimbus-ui/schema.graphql
@@ -328,7 +328,7 @@ enum NimbusExperimentDocumentationLinkEnum {
 }
 
 type NimbusChangeLogType {
-  changedOn: DateTime!
+  updatedDateTime: DateTime!
   changedBy: NimbusUserType!
   oldStatus: NimbusExperimentStatusEnum
   oldStatusNext: NimbusExperimentStatusEnum

--- a/experimenter/experimenter/nimbus-ui/src/components/ChangeApprovalOperations/RejectionReason.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/ChangeApprovalOperations/RejectionReason.tsx
@@ -14,7 +14,7 @@ export const RejectionReason = ({
 }: {
   rejectionEvent: getExperiment_experimentBySlug["rejection"];
 }) => {
-  const { message, changedOn, changedBy, oldStatus, oldStatusNext } =
+  const { message, updatedDateTime, changedBy, oldStatus, oldStatusNext } =
     rejectionEvent!;
 
   const rejectionActionDescription = useMemo(() => {
@@ -37,7 +37,7 @@ export const RejectionReason = ({
           <strong>Rejected</strong> due to:
         </p>
         <p className="mb-2">
-          {changedBy!.email} on {humanDate(changedOn!)}:
+          {changedBy!.email} on {humanDate(updatedDateTime!)}:
         </p>
         <p className="bg-white rounded border p-2 mb-0">{message}</p>
       </div>

--- a/experimenter/experimenter/nimbus-ui/src/gql/experiments.ts
+++ b/experimenter/experimenter/nimbus-ui/src/gql/experiments.ts
@@ -156,7 +156,7 @@ export const GET_EXPERIMENT_QUERY = gql`
 
       canReview
       reviewRequest {
-        changedOn
+        updatedDateTime
         changedBy {
           email
         }
@@ -165,13 +165,13 @@ export const GET_EXPERIMENT_QUERY = gql`
         message
         oldStatus
         oldStatusNext
-        changedOn
+        updatedDateTime
         changedBy {
           email
         }
       }
       timeout {
-        changedOn
+        updatedDateTime
         changedBy {
           email
         }

--- a/experimenter/experimenter/nimbus-ui/src/lib/mocks.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/lib/mocks.tsx
@@ -1031,12 +1031,12 @@ export const mockUser = (email = "abc@mozilla.com"): NimbusUser => ({
 export const mockChangelog = (
   email = "abc@mozilla.com",
   message: string | null = null,
-  changedOn: DateTime = new Date().toISOString(),
+  updatedDateTime: DateTime = new Date().toISOString(),
 ): NimbusChangeLog => ({
   oldStatus: NimbusExperimentStatusEnum.LIVE,
   oldStatusNext: null,
   changedBy: mockUser(email),
-  changedOn,
+  updatedDateTime,
   message,
 });
 
@@ -1045,12 +1045,12 @@ export const mockRejectionChangelog = (
   message: string | null = null,
   oldStatus: NimbusExperimentStatusEnum = NimbusExperimentStatusEnum.LIVE,
   oldStatusNext: NimbusExperimentStatusEnum | null = null,
-  changedOn: DateTime = new Date().toISOString(),
+  updatedDateTime: DateTime = new Date().toISOString(),
 ): NimbusChangeLog => ({
   oldStatus,
   oldStatusNext,
   changedBy: mockUser(email),
-  changedOn,
+  updatedDateTime,
   message,
 });
 

--- a/experimenter/experimenter/nimbus-ui/src/types/getExperiment.ts
+++ b/experimenter/experimenter/nimbus-ui/src/types/getExperiment.ts
@@ -92,7 +92,7 @@ export interface getExperiment_experimentBySlug_reviewRequest_changedBy {
 }
 
 export interface getExperiment_experimentBySlug_reviewRequest {
-  changedOn: DateTime;
+  updatedDateTime: DateTime;
   changedBy: getExperiment_experimentBySlug_reviewRequest_changedBy;
 }
 
@@ -104,7 +104,7 @@ export interface getExperiment_experimentBySlug_rejection {
   message: string | null;
   oldStatus: NimbusExperimentStatusEnum | null;
   oldStatusNext: NimbusExperimentStatusEnum | null;
-  changedOn: DateTime;
+  updatedDateTime: DateTime;
   changedBy: getExperiment_experimentBySlug_rejection_changedBy;
 }
 
@@ -113,7 +113,7 @@ export interface getExperiment_experimentBySlug_timeout_changedBy {
 }
 
 export interface getExperiment_experimentBySlug_timeout {
-  changedOn: DateTime;
+  updatedDateTime: DateTime;
   changedBy: getExperiment_experimentBySlug_timeout_changedBy;
 }
 


### PR DESCRIPTION
Because
we are required to use updated_date_time instead of changed_on

This commit

changes all the  references of changed_on to updated_date_time
two tests are failing at the end  
FAILED experimenter/experiments/tests/api/v5/test_queries.py::TestNimbusExperimentBySlugQuery::test_get_experiment_by_slug_returns_experiment_data_00  

