### PR TITLE
fixes #8451 feat(nimbus): change audience page so that numbers do not…

### DIFF
--- a/experimenter/experimenter/nimbus-ui/src/lib/constants.ts
+++ b/experimenter/experimenter/nimbus-ui/src/lib/constants.ts
@@ -137,8 +137,7 @@ export const CHANGELOG_MESSAGES = {
 export const FIELD_MESSAGES = {
   REQUIRED: "This field may not be blank.",
   NUMBER: "This field must be a number.",
-  POSITIVE_NUMBER:
-    "This field must be a positive number and leading number cannot be 0.",
+  POSITIVE_NUMBER: "This field must be a positive number.",
   URL: "This field must be a URL.",
 };
 
@@ -159,14 +158,12 @@ export const POSITIVE_NUMBER_FIELD = {
 } as RegisterOptions;
 
 export const POSITIVE_NUMBER_WITH_COMMAS_FIELD = {
-  pattern: {
-    value: /^(?!0\d)\d+$/,
-    message: FIELD_MESSAGES.POSITIVE_NUMBER,
-  },
   setValueAs: (value) =>
     parseFloat(("" + value).trim().replace(/[^\d.-]+/g, "")),
-  validate: (value) =>
-    (!isNaN(value) && value >= 0) || FIELD_MESSAGES.POSITIVE_NUMBER,
+  pattern: {
+    value: /^(?!0\d)(\d{1,3}(,\d{3})*|\d+)$/,
+    message: FIELD_MESSAGES.POSITIVE_NUMBER,
+  },
 } as RegisterOptions;
 
 export const URL_FIELD = {

--- a/experimenter/experimenter/nimbus-ui/src/lib/constants.ts
+++ b/experimenter/experimenter/nimbus-ui/src/lib/constants.ts
@@ -137,7 +137,8 @@ export const CHANGELOG_MESSAGES = {
 export const FIELD_MESSAGES = {
   REQUIRED: "This field may not be blank.",
   NUMBER: "This field must be a number.",
-  POSITIVE_NUMBER: "This field must be a positive number and leading number cannot be 0.",
+  POSITIVE_NUMBER:
+    "This field must be a positive number and leading number cannot be 0.",
   URL: "This field must be a URL.",
 };
 
@@ -160,7 +161,7 @@ export const POSITIVE_NUMBER_FIELD = {
 export const POSITIVE_NUMBER_WITH_COMMAS_FIELD = {
   pattern: {
     value: /^(?!0\d)\d+$/,
-    message: FIELD_MESSAGES.POSITIVE_NUMBER
+    message: FIELD_MESSAGES.POSITIVE_NUMBER,
   },
   setValueAs: (value) =>
     parseFloat(("" + value).trim().replace(/[^\d.-]+/g, "")),

--- a/experimenter/experimenter/nimbus-ui/src/lib/constants.ts
+++ b/experimenter/experimenter/nimbus-ui/src/lib/constants.ts
@@ -137,7 +137,7 @@ export const CHANGELOG_MESSAGES = {
 export const FIELD_MESSAGES = {
   REQUIRED: "This field may not be blank.",
   NUMBER: "This field must be a number.",
-  POSITIVE_NUMBER: "This field must be a positive number.",
+  POSITIVE_NUMBER: "This field must be a positive number and leading number cannot be 0.",
   URL: "This field must be a URL.",
 };
 
@@ -158,6 +158,10 @@ export const POSITIVE_NUMBER_FIELD = {
 } as RegisterOptions;
 
 export const POSITIVE_NUMBER_WITH_COMMAS_FIELD = {
+  pattern: {
+    value: /^(?!0\d)\d+$/,
+    message: FIELD_MESSAGES.POSITIVE_NUMBER
+  },
   setValueAs: (value) =>
     parseFloat(("" + value).trim().replace(/[^\d.-]+/g, "")),
   validate: (value) =>


### PR DESCRIPTION
… start with zero

Because

we do not want the user to enter any numbers on audience page in the expected number of clients input 

This commit

- change the form attribute POSITIVE_NUMBER_WITH_COMMAS to include the regex that adds the condition for the number to not start with a 0. This was done this way because I realised that the form inputs created by react-hook-form only allow one form control attribute this means that the extra condition had to be added to an existing one.
- <img width="921" alt="change_PR" src="https://user-images.githubusercontent.com/96398605/224615831-91e90a07-e084-4cc3-a29d-fc968c6c9b87.png">

