### PR TITLE
fix #8491 chore(nimbus): hard code schema version

### DIFF
--- a/experimenter/experimenter/docs/openapi-schema.json
+++ b/experimenter/experimenter/docs/openapi-schema.json
@@ -3514,7 +3514,7 @@
           "schemaVersion": {
             "type": "string",
             "readOnly": true,
-            "default": "2.0.0"
+            "default": "1.11.0"
           },
           "slug": {
             "type": "string",

--- a/experimenter/experimenter/docs/swagger-ui.html
+++ b/experimenter/experimenter/docs/swagger-ui.html
@@ -3526,7 +3526,7 @@
           "schemaVersion": {
             "type": "string",
             "readOnly": true,
-            "default": "2.0.0"
+            "default": "1.11.0"
           },
           "slug": {
             "type": "string",

--- a/experimenter/experimenter/settings.py
+++ b/experimenter/experimenter/settings.py
@@ -12,7 +12,6 @@ https://docs.djangoproject.com/en/1.9/ref/settings/
 import os
 from urllib.parse import urljoin
 
-import pkg_resources
 import sentry_sdk
 from decouple import config
 from django.contrib.admin import ModelAdmin, StackedInline, TabularInline
@@ -456,7 +455,10 @@ UPLOADS_GS_BUCKET_NAME = config("UPLOADS_GS_BUCKET_NAME", default=None)
 # Custom file storage override for user uploads (e.g. for testing)
 UPLOADS_FILE_STORAGE = config("UPLOADS_FILE_STORAGE", default=None)
 
-NIMBUS_SCHEMA_VERSION = pkg_resources.get_distribution("mozilla-nimbus-shared").version
+NIMBUS_SCHEMA_VERSION = (
+    # TODO: #8492
+    "1.11.0"  # pkg_resources.get_distribution("mozilla-nimbus-shared").version
+)
 
 
 # Jetstream config paths


### PR DESCRIPTION
Because

* We recently bumped the shared schema version to 2.0.0
* The SDK client hard codes a check for version 1.X.X
* We'll need to temporarily override the version until that check can be removed

This commit

* Hard codes a schema version of 1.11.0

Because

- Reason

This commit

- Change
