### PR TITLE
For #8357 feat(nimbus): Add column to homepage for Unpublished Updates

### DIFF
--- a/experimenter/experimenter/nimbus-ui/src/components/PageHome/DirectoryTable/index.test.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageHome/DirectoryTable/index.test.tsx
@@ -19,6 +19,7 @@ import DirectoryTable, {
   DirectoryColumnPopulationPercent,
   DirectoryColumnStartDate,
   DirectoryColumnTitle,
+  DirectoryColumnUnpublishedUpdates,
   SortableColumnTitle,
 } from "src/components/PageHome/DirectoryTable";
 import { UpdateSearchParams } from "src/hooks/useSearchParamsState";
@@ -29,6 +30,7 @@ import {
 } from "src/lib/mocks";
 import { RouterSlugProvider } from "src/lib/test-utils";
 import { getAllExperiments_experiments } from "src/types/getAllExperiments";
+import { NimbusExperimentPublishStatusEnum } from "src/types/globalTypes";
 
 const experiment = mockSingleDirectoryExperiment();
 
@@ -160,6 +162,7 @@ describe("DirectoryColumnFirefoxMinVersion", () => {
     );
   });
 });
+
 describe("DirectoryColumnFirefoxMaxVersion", () => {
   it("renders the firefox max version", () => {
     render(
@@ -208,6 +211,7 @@ describe("DirectoryColumneEnrollmentDate", () => {
     );
   });
 });
+
 describe("DirectoryColumnStartDate", () => {
   it("renders the start date", () => {
     render(
@@ -251,6 +255,36 @@ describe("DirectoryColumnEndDate", () => {
     expect(screen.getByTestId("directory-table-cell")).toHaveTextContent(
       "Not set",
     );
+  });
+});
+
+describe("DirectoryColumnUnpublishedUpdates", () => {
+  it("renders unpublished updates badge when dirty", () => {
+    render(
+      <TestTable>
+        <DirectoryColumnUnpublishedUpdates
+          {...experiment}
+          publishStatus={NimbusExperimentPublishStatusEnum.DIRTY}
+        />
+      </TestTable>,
+    );
+    expect(
+      screen.getByTestId("directory-unpublished-updates"),
+    ).toHaveTextContent("YES");
+  });
+
+  it("renders blank unpublished updates when not dirty", () => {
+    render(
+      <TestTable>
+        <DirectoryColumnUnpublishedUpdates
+          {...experiment}
+          publishStatus={NimbusExperimentPublishStatusEnum.IDLE}
+        />
+      </TestTable>,
+    );
+    expect(
+      screen.getByTestId("directory-unpublished-updates"),
+    ).toHaveTextContent("");
   });
 });
 
@@ -370,6 +404,7 @@ describe("DirectoryTable", () => {
         "Enroll",
         "End",
         "Results",
+        "Unpublished Updates",
       ]);
       expectTableCells("directory-table-cell", [
         experiment.name,
@@ -384,6 +419,7 @@ describe("DirectoryTable", () => {
         getProposedEnrollmentRange(experiment) as string,
         humanDate(experiment.computedEndDate!),
         expectedResult,
+        "",
       ]);
     },
   );

--- a/experimenter/experimenter/nimbus-ui/src/components/PageHome/DirectoryTable/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageHome/DirectoryTable/index.tsx
@@ -5,7 +5,7 @@
 import { Link } from "@reach/router";
 import classNames from "classnames";
 import React, { useCallback, useMemo } from "react";
-import { Button, Table } from "react-bootstrap";
+import { Badge, Button, Table } from "react-bootstrap";
 import LinkExternal from "src/components/LinkExternal";
 import NotSet from "src/components/NotSet";
 import { displayConfigLabelOrNotSet } from "src/components/Summary";
@@ -25,8 +25,10 @@ import {
   populationPercentSortSelector,
   resultsReadySortSelector,
   startDateSortSelector,
+  unpublishedUpdatesSortSelector,
 } from "src/lib/experiment";
 import { getAllExperiments_experiments } from "src/types/getAllExperiments";
+import { NimbusExperimentPublishStatusEnum } from "src/types/globalTypes";
 
 // These are all render functions for column types in the table.
 export type ColumnComponent = React.FC<getAllExperiments_experiments>;
@@ -137,6 +139,16 @@ export const DirectoryColumnEndDate: ColumnComponent = ({
 }) => (
   <td data-testid="directory-table-cell">
     {(d && humanDate(d)) || <NotSet />}
+  </td>
+);
+export const DirectoryColumnUnpublishedUpdates: ColumnComponent = (experiment) => (
+  <td data-testid="directory-table-cell">
+    <Badge
+      className={"ml-2 border rounded-pill px-2 bg-white font-weight-normal border-danger text-danger"}
+      data-testid="directory-table-cell"
+    >
+      {experiment.publishStatus === NimbusExperimentPublishStatusEnum.DIRTY ? "YES" : ""}
+    </Badge>
   </td>
 );
 
@@ -307,6 +319,11 @@ const commonColumns: Column[] = [
     label: "Results",
     sortBy: resultsReadySortSelector,
     component: DirectoryColumnResults,
+  },
+  {
+    label: "Unpublished updates",
+    sortBy: unpublishedUpdatesSortSelector,
+    component: DirectoryColumnUnpublishedUpdates,
   },
 ];
 

--- a/experimenter/experimenter/nimbus-ui/src/components/PageHome/DirectoryTable/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageHome/DirectoryTable/index.tsx
@@ -129,11 +129,13 @@ export const DirectoryColumnStartDate: ColumnComponent = ({ startDate: d }) => (
     {(d && humanDate(d)) || <NotSet />}
   </td>
 );
+
 export const DirectoryColumnEnrollmentDate: ColumnComponent = (experiment) => (
   <td data-testid="directory-table-cell">
     {getProposedEnrollmentRange(experiment) || <NotSet />}
   </td>
 );
+
 export const DirectoryColumnEndDate: ColumnComponent = ({
   computedEndDate: d,
 }) => (
@@ -141,14 +143,25 @@ export const DirectoryColumnEndDate: ColumnComponent = ({
     {(d && humanDate(d)) || <NotSet />}
   </td>
 );
-export const DirectoryColumnUnpublishedUpdates: ColumnComponent = (experiment) => (
+
+export const DirectoryColumnUnpublishedUpdates: ColumnComponent = ({
+  publishStatus: p,
+}) => (
   <td data-testid="directory-table-cell">
-    <Badge
-      className={"ml-2 border rounded-pill px-2 bg-white font-weight-normal border-danger text-danger"}
-      data-testid="directory-table-cell"
-    >
-      {experiment.publishStatus === NimbusExperimentPublishStatusEnum.DIRTY ? "YES" : ""}
-    </Badge>
+    {p ? (
+      <>
+        <Badge
+          className={
+            "ml-2 border rounded-pill px-2 bg-white font-weight-normal border-danger text-danger"
+          }
+          data-testid="directory-unpublished-updates"
+        >
+          {p === NimbusExperimentPublishStatusEnum.DIRTY ? "YES" : ""}
+        </Badge>
+      </>
+    ) : (
+      ""
+    )}
   </td>
 );
 
@@ -321,7 +334,7 @@ const commonColumns: Column[] = [
     component: DirectoryColumnResults,
   },
   {
-    label: "Unpublished updates",
+    label: "Unpublished Updates",
     sortBy: unpublishedUpdatesSortSelector,
     component: DirectoryColumnUnpublishedUpdates,
   },

--- a/experimenter/experimenter/nimbus-ui/src/lib/experiment.test.ts
+++ b/experimenter/experimenter/nimbus-ui/src/lib/experiment.test.ts
@@ -18,6 +18,7 @@ import {
   resultsReadySortSelector,
   selectFromExperiment,
   startDateSortSelector,
+  unpublishedUpdatesSortSelector,
 } from "src/lib/experiment";
 import {
   mockDirectoryExperiments,
@@ -128,6 +129,7 @@ describe("selectFromExperiment", () => {
       [firefoxMinVersionSortSelector, "FIREFOX_83"],
       [firefoxMaxVersionSortSelector, "FIREFOX_64"],
       [populationPercentSortSelector, "100"],
+      [unpublishedUpdatesSortSelector, "0"],
     ] as const;
     selectorCases.forEach(([selectBy, expected]) =>
       expect(selectFromExperiment(experiment, selectBy)).toEqual(expected),
@@ -139,6 +141,15 @@ describe("selectFromExperiment", () => {
         enrollmentSortSelector,
       ),
     ).toEqual("8");
+    expect(
+      selectFromExperiment(
+        {
+          ...experiment,
+          publishStatus: NimbusExperimentPublishStatusEnum.IDLE,
+        },
+        unpublishedUpdatesSortSelector,
+      ),
+    ).toEqual("0");
     expect(
       selectFromExperiment(
         { ...experiment, resultsReady: true },

--- a/experimenter/experimenter/nimbus-ui/src/lib/experiment.ts
+++ b/experimenter/experimenter/nimbus-ui/src/lib/experiment.ts
@@ -155,8 +155,12 @@ export const enrollmentSortSelector: ExperimentSortSelector = ({
 export const resultsReadySortSelector: ExperimentSortSelector = (experiment) =>
   experiment.resultsReady ? "1" : "0";
 
-export const unpublishedUpdatesSortSelector: ExperimentSortSelector = (experiment) =>
-  experiment.publishStatus === NimbusExperimentPublishStatusEnum.DIRTY ? "1" : "0";
+export const unpublishedUpdatesSortSelector: ExperimentSortSelector = (
+  experiment,
+) =>
+  experiment.publishStatus === NimbusExperimentPublishStatusEnum.DIRTY
+    ? "1"
+    : "0";
 
 export const selectFromExperiment = (
   experiment: getAllExperiments_experiments,

--- a/experimenter/experimenter/nimbus-ui/src/lib/experiment.ts
+++ b/experimenter/experimenter/nimbus-ui/src/lib/experiment.ts
@@ -155,6 +155,9 @@ export const enrollmentSortSelector: ExperimentSortSelector = ({
 export const resultsReadySortSelector: ExperimentSortSelector = (experiment) =>
   experiment.resultsReady ? "1" : "0";
 
+export const unpublishedUpdatesSortSelector: ExperimentSortSelector = (experiment) =>
+  experiment.publishStatus === NimbusExperimentPublishStatusEnum.DIRTY ? "1" : "0";
+
 export const selectFromExperiment = (
   experiment: getAllExperiments_experiments,
   selectBy: ExperimentSortSelector,


### PR DESCRIPTION
Because

- We want users to be able to tell if their rollouts have been edited and have unpublished changes
- And we already can tell from the detail summary of the rollout (#8321)

This commit

- Adds a new column to the end of the home page for Unpublished Updates
- Adds a sort selector for it
- Shows a red "YES" badge if there are unpublished changes (publish_status=DIRTY) 
- Shows empty if there are no unpublished changes

<img width="1637" alt="Screen Shot 2023-03-14 at 3 29 16 PM" src="https://user-images.githubusercontent.com/43795363/225121576-88f566a7-db6d-4f6f-b65c-7f3a2c05c5b3.png">

Note: I confirmed that this is the correct place for the column with Shell.