### PR TITLE
Add "not mac" as targeting option

### DIFF
--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -1077,6 +1077,7 @@ NOT_MAC = NimbusTargetingConfig(
     slug="not_mac_users",
     description="Clients not on mac",
     targeting="!os.isMac",
+    desktop_telemetry="",
     sticky_required=False,
     is_first_run_required=False,
     application_choice_names=(Application.DESKTOP.name,),

--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -1072,6 +1072,16 @@ FIVE_BOOKMARKS = NimbusTargetingConfig(
     application_choice_names=(Application.DESKTOP.name,),
 )
 
+NOT_MAC = NimbusTargetingConfig(
+    name="Not Mac Users",
+    slug="not_mac_users",
+    description="Clients not on mac",
+    targeting="!os.isMac",
+    sticky_required=False,
+    is_first_run_required=False,
+    application_choice_names=(Application.DESKTOP.name,),
+)
+
 
 class TargetingConstants:
     TARGETING_VERSION = "version|versionCompare('{version}') >= 0"


### PR DESCRIPTION
Because

- The new accessibility cache experiment needs to target "non-mac" users

This commit

- Adds an advanced targeting to exclude non-mac users
