### PR TITLE
fixes #7845 fix(nimbus):change summary page to show total enrolled cl…

### DIFF
--- a/experimenter/experimenter/nimbus-ui/src/components/Summary/TableAudience/index.test.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/Summary/TableAudience/index.test.tsx
@@ -87,9 +87,9 @@ describe("TableAudience", () => {
         totalEnrolledClients: 0,
       });
       render(<Subject {...{ experiment }} />);
-      expect(
-        screen.queryByTestId("experiment-total-enrolled"),
-      ).not.toBeInTheDocument();
+      expect(screen.getByTestId("experiment-total-enrolled")).toHaveTextContent(
+        "0",
+      );
     });
   });
 

--- a/experimenter/experimenter/nimbus-ui/src/components/Summary/TableAudience/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/Summary/TableAudience/index.tsx
@@ -114,14 +114,13 @@ const TableAudience = ({ experiment }: TableAudienceProps) => {
               </td>
             </tr>
             <tr>
-              {experiment.totalEnrolledClients > 0 && (
-                <>
-                  <th>Expected enrolled clients</th>
-                  <td data-testid="experiment-total-enrolled">
-                    {experiment.totalEnrolledClients.toLocaleString()}
-                  </td>
-                </>
-              )}
+              <th>Expected enrolled clients</th>
+              <td data-testid="experiment-total-enrolled">
+                {experiment.totalEnrolledClients
+                  ? experiment.totalEnrolledClients.toLocaleString()
+                  : "0"}
+              </td>
+
               <th>Population %</th>
               <td data-testid="experiment-population">
                 {experiment.populationPercent ? (


### PR DESCRIPTION
…ients even if zero

Because

- the field doesn't render if the value is zero, which causes irregularity in the details layout

Before:
![image](https://user-images.githubusercontent.com/79744258/225552632-44dac03e-9b7e-4ecd-99bd-75f71865cc29.png)


This commit

- change audience section in summary page to allow the total enrolled clients field even if the value is zero so as to not break the layout of information

After:
![image](https://user-images.githubusercontent.com/79744258/225552559-5c22a084-24b6-4c9a-b6f2-9c171dd5bf1d.png)

