### PR TITLE
For #8514 fix(nimbus): Check feature configs when looking for duplicate rollouts

### DIFF
--- a/experimenter/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_ready_for_review_serializer.py
+++ b/experimenter/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_ready_for_review_serializer.py
@@ -1358,12 +1358,14 @@ class TestNimbusReviewSerializerSingleFeature(TestCase):
         desktop = NimbusExperiment.Application.DESKTOP
         channel = NimbusExperiment.Channel.NIGHTLY
         targeting_config_slug = NimbusExperiment.TargetingConfig.MAC_ONLY
+        feature_configs = [NimbusFeatureConfigFactory(application=desktop)]
+
         experiment1 = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.LIVE_APPROVE_APPROVE,
             application=desktop,
             channel=channel,
             firefox_min_version=NimbusExperiment.Version.FIREFOX_108,
-            feature_configs=[NimbusFeatureConfigFactory(application=desktop)],
+            feature_configs=feature_configs,
             is_sticky=False,
             is_rollout=True,
             targeting_config_slug=targeting_config_slug,
@@ -1373,7 +1375,7 @@ class TestNimbusReviewSerializerSingleFeature(TestCase):
             application=desktop,
             channel=channel,
             firefox_min_version=NimbusExperiment.Version.FIREFOX_108,
-            feature_configs=[NimbusFeatureConfigFactory(application=desktop)],
+            feature_configs=feature_configs,
             is_sticky=False,
             is_rollout=True,
             targeting_config_slug=targeting_config_slug,
@@ -1397,16 +1399,7 @@ class TestNimbusReviewSerializerSingleFeature(TestCase):
             context={"user": self.user},
         )
 
-        count = NimbusExperiment.objects.filter(
-            status=NimbusExperiment.Status.LIVE,
-            channel=channel,
-            application=desktop,
-            targeting_config_slug=targeting_config_slug,
-            is_rollout=True,
-        ).count()
-
         self.assertTrue(experiment1.is_rollout and experiment2.is_rollout)
-        self.assertTrue(count > 0)
         self.assertTrue(serializer.is_valid())
         self.assertEqual(
             serializer.warnings["bucketing"],
@@ -1417,13 +1410,15 @@ class TestNimbusReviewSerializerSingleFeature(TestCase):
         lifecycle = NimbusExperimentFactory.Lifecycles.CREATED
         desktop = NimbusExperiment.Application.DESKTOP
         channel = NimbusExperiment.Channel.NIGHTLY
+        feature_configs = [NimbusFeatureConfigFactory(application=desktop)]
         targeting_config_slug = NimbusExperiment.TargetingConfig.MAC_ONLY
+
         experiment1 = NimbusExperimentFactory.create_with_lifecycle(
             lifecycle,
             application=NimbusExperiment.Application.FENIX,
             channel=channel,
             firefox_min_version=NimbusExperiment.Version.FIREFOX_108,
-            feature_configs=[NimbusFeatureConfigFactory(application=desktop)],
+            feature_configs=feature_configs,
             is_sticky=False,
             is_rollout=True,
             targeting_config_slug=targeting_config_slug,
@@ -1433,7 +1428,7 @@ class TestNimbusReviewSerializerSingleFeature(TestCase):
             application=desktop,
             channel=channel,
             firefox_min_version=NimbusExperiment.Version.FIREFOX_108,
-            feature_configs=[NimbusFeatureConfigFactory(application=desktop)],
+            feature_configs=feature_configs,
             is_sticky=False,
             is_rollout=True,
             targeting_config_slug=targeting_config_slug,
@@ -1457,16 +1452,7 @@ class TestNimbusReviewSerializerSingleFeature(TestCase):
             context={"user": self.user},
         )
 
-        count = NimbusExperiment.objects.filter(
-            status=NimbusExperiment.Status.LIVE,
-            channel=channel,
-            application=desktop,
-            targeting_config_slug=targeting_config_slug,
-            is_rollout=True,
-        ).count()
-
         self.assertTrue(experiment1.is_rollout and experiment2.is_rollout)
-        self.assertTrue(count == 0)
         self.assertTrue(serializer.is_valid())
         self.assertEqual(serializer.warnings, {})
 
@@ -1474,13 +1460,15 @@ class TestNimbusReviewSerializerSingleFeature(TestCase):
         lifecycle = NimbusExperimentFactory.Lifecycles.CREATED
         desktop = NimbusExperiment.Application.DESKTOP
         channel = NimbusExperiment.Channel.NIGHTLY
+        feature_configs = [NimbusFeatureConfigFactory(application=desktop)]
         targeting_config_slug = NimbusExperiment.TargetingConfig.MAC_ONLY
+
         experiment1 = NimbusExperimentFactory.create_with_lifecycle(
             lifecycle,
             application=desktop,
             channel=channel,
             firefox_min_version=NimbusExperiment.Version.FIREFOX_108,
-            feature_configs=[NimbusFeatureConfigFactory(application=desktop)],
+            feature_configs=feature_configs,
             is_sticky=False,
             is_rollout=False,
             targeting_config_slug=targeting_config_slug,
@@ -1490,7 +1478,7 @@ class TestNimbusReviewSerializerSingleFeature(TestCase):
             application=desktop,
             channel=channel,
             firefox_min_version=NimbusExperiment.Version.FIREFOX_108,
-            feature_configs=[NimbusFeatureConfigFactory(application=desktop)],
+            feature_configs=feature_configs,
             is_sticky=False,
             is_rollout=False,
             targeting_config_slug=targeting_config_slug,
@@ -1509,16 +1497,7 @@ class TestNimbusReviewSerializerSingleFeature(TestCase):
             context={"user": self.user},
         )
 
-        count = NimbusExperiment.objects.filter(
-            status=NimbusExperiment.Status.LIVE,
-            channel=channel,
-            application=desktop,
-            targeting_config_slug=targeting_config_slug,
-            is_rollout=True,
-        ).count()
-
         self.assertFalse(experiment1.is_rollout and experiment2.is_rollout)
-        self.assertTrue(count == 0)
         self.assertTrue(serializer.is_valid())
         self.assertEqual(serializer.warnings, {})
 


### PR DESCRIPTION
Because

- I forgot to add feature_configs to the check for the duplicate rollout warning in #8359 

This commit

- Adds the check for feature_configs in the serializer
- Fixes the tests
