### PR TITLE
For #8438 feat(nimbus): Add flag for isDirty on the v5 serializer

### DIFF
--- a/experimenter/experimenter/experiments/api/v5/inputs.py
+++ b/experimenter/experimenter/experiments/api/v5/inputs.py
@@ -54,6 +54,7 @@ class ExperimentInput(graphene.InputObjectType):
     hypothesis = graphene.String()
     id = graphene.Int()
     is_archived = graphene.Boolean()
+    is_dirty = graphene.Boolean()
     is_enrollment_paused = graphene.Boolean()
     is_first_run = graphene.Boolean()
     is_rollout = graphene.Boolean()

--- a/experimenter/experimenter/experiments/api/v5/serializers.py
+++ b/experimenter/experimenter/experiments/api/v5/serializers.py
@@ -754,7 +754,7 @@ class NimbusExperimentSerializer(
         min_length=0, max_length=1024, required=False, allow_blank=True
     )
     is_enrollment_paused = serializers.BooleanField(source="is_paused", required=False)
-    is_dirty = serializers.BooleanField(source="is_dirty", required=False)
+    is_dirty = serializers.BooleanField(required=False)
     risk_mitigation_link = serializers.URLField(
         min_length=0, max_length=255, required=False, allow_blank=True
     )

--- a/experimenter/experimenter/experiments/api/v5/serializers.py
+++ b/experimenter/experimenter/experiments/api/v5/serializers.py
@@ -754,6 +754,7 @@ class NimbusExperimentSerializer(
         min_length=0, max_length=1024, required=False, allow_blank=True
     )
     is_enrollment_paused = serializers.BooleanField(source="is_paused", required=False)
+    is_dirty = serializers.BooleanField(source="is_dirty", required=False)
     risk_mitigation_link = serializers.URLField(
         min_length=0, max_length=255, required=False, allow_blank=True
     )
@@ -852,6 +853,7 @@ class NimbusExperimentSerializer(
             "firefox_min_version",
             "hypothesis",
             "is_archived",
+            "is_dirty",
             "is_enrollment_paused",
             "is_first_run",
             "is_rollout",

--- a/experimenter/experimenter/experiments/api/v5/types.py
+++ b/experimenter/experimenter/experiments/api/v5/types.py
@@ -448,6 +448,7 @@ class NimbusExperimentType(DjangoObjectType):
     hypothesis = graphene.String()
     id = graphene.Int()
     is_archived = graphene.Boolean()
+    is_dirty = graphene.Boolean()
     is_enrollment_pause_pending = graphene.Boolean()
     is_enrollment_paused = graphene.Boolean()
     is_rollout = graphene.Boolean()
@@ -509,6 +510,7 @@ class NimbusExperimentType(DjangoObjectType):
             "hypothesis",
             "id",
             "is_archived",
+            "is_dirty",
             "is_enrollment_pause_pending",
             "is_enrollment_paused",
             "is_first_run",
@@ -667,3 +669,6 @@ class NimbusExperimentType(DjangoObjectType):
 
     def resolve_changes(self, info):
         return self.changes.all().order_by("changed_on")
+
+    def resolve_is_dirty(self, info):
+        return self.is_dirty

--- a/experimenter/experimenter/experiments/models.py
+++ b/experimenter/experimenter/experiments/models.py
@@ -138,6 +138,7 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
     public_description = models.TextField(default="")
     risk_mitigation_link = models.URLField(max_length=255, blank=True)
     is_paused = models.BooleanField(default=False)
+    is_dirty = models.BooleanField(default=False)
     proposed_duration = models.PositiveIntegerField(
         default=NimbusConstants.DEFAULT_PROPOSED_DURATION,
         validators=[MaxValueValidator(NimbusConstants.MAX_DURATION)],
@@ -547,6 +548,10 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
     @property
     def is_enrollment_pause_pending(self):
         return self.is_paused and not self.is_paused_published
+
+    @property
+    def is_dirty(self):
+        return self.is_dirty
 
     @property
     def monitoring_dashboard_url(self):

--- a/experimenter/experimenter/experiments/tests/api/v5/test_queries.py
+++ b/experimenter/experimenter/experiments/tests/api/v5/test_queries.py
@@ -84,6 +84,7 @@ class TestNimbusExperimentsQuery(GraphQLTestCase):
                     firefoxMinVersion
                     firefoxMaxVersion
                     startDate
+                    isDirty
                     isEnrollmentPausePending
                     isEnrollmentPaused
                     proposedDuration
@@ -150,6 +151,7 @@ class TestNimbusExperimentsQuery(GraphQLTestCase):
                     experiment.firefox_min_version
                 ).name,
                 "isArchived": experiment.is_archived,
+                "isDirty": experiment.is_dirty,
                 "isEnrollmentPausePending": experiment.is_enrollment_pause_pending,
                 "isEnrollmentPaused": experiment.is_paused_published,
                 "isRollout": experiment.is_rollout,
@@ -752,6 +754,7 @@ class TestNimbusExperimentBySlugQuery(GraphQLTestCase):
                         link
                     }
 
+                    isDirty
                     isEnrollmentPausePending
                     isEnrollmentPaused
                     enrollmentEndDate
@@ -859,6 +862,7 @@ class TestNimbusExperimentBySlugQuery(GraphQLTestCase):
                 "hypothesis": experiment.hypothesis,
                 "id": experiment.id,
                 "isArchived": experiment.is_archived,
+                "isDirty": experiment.is_dirty,
                 "isEnrollmentPausePending": experiment.is_enrollment_pause_pending,
                 "isEnrollmentPaused": experiment.is_paused_published,
                 "isFirstRun": experiment.is_first_run,

--- a/experimenter/experimenter/nimbus-ui/schema.graphql
+++ b/experimenter/experimenter/nimbus-ui/schema.graphql
@@ -59,6 +59,7 @@ type NimbusExperimentType {
   computedEnrollmentDays: Int
   enrollmentEndDate: DateTime
   featureConfig: NimbusFeatureConfigType
+  isDirty: Boolean
   isEnrollmentPausePending: Boolean
   isEnrollmentPaused: Boolean
   jexlTargetingExpression: String
@@ -459,6 +460,7 @@ input ExperimentInput {
   hypothesis: String
   id: Int
   isArchived: Boolean
+  isDirty: Boolean
   isEnrollmentPaused: Boolean
   isFirstRun: Boolean
   isRollout: Boolean

--- a/experimenter/experimenter/nimbus-ui/src/gql/experiments.ts
+++ b/experimenter/experimenter/nimbus-ui/src/gql/experiments.ts
@@ -195,6 +195,7 @@ export const GET_EXPERIMENT_QUERY = gql`
         id
         name
       }
+      isDirty
     }
   }
 `;
@@ -230,6 +231,7 @@ export const GET_EXPERIMENTS_QUERY = gql`
       firefoxMinVersion
       firefoxMaxVersion
       startDate
+      isDirty
       isEnrollmentPausePending
       isEnrollmentPaused
       proposedDuration

--- a/experimenter/experimenter/nimbus-ui/src/lib/mocks.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/lib/mocks.tsx
@@ -864,6 +864,7 @@ export function mockSingleDirectoryExperiment(
     targetingConfig: [MOCK_CONFIG.targetingConfigs![0]],
     isEnrollmentPaused: false,
     isEnrollmentPausePending: false,
+    isDirty: false,
     proposedEnrollment: 7,
     proposedDuration: 28,
     startDate: new Date(startTime).toISOString(),

--- a/experimenter/experimenter/nimbus-ui/src/types/getAllExperiments.ts
+++ b/experimenter/experimenter/nimbus-ui/src/types/getAllExperiments.ts
@@ -57,6 +57,7 @@ export interface getAllExperiments_experiments {
   firefoxMinVersion: NimbusExperimentFirefoxVersionEnum | null;
   firefoxMaxVersion: NimbusExperimentFirefoxVersionEnum | null;
   startDate: DateTime | null;
+  isDirty: boolean | null;
   isEnrollmentPausePending: boolean | null;
   isEnrollmentPaused: boolean | null;
   proposedDuration: number;

--- a/experimenter/experimenter/nimbus-ui/src/types/getExperiment.ts
+++ b/experimenter/experimenter/nimbus-ui/src/types/getExperiment.ts
@@ -201,6 +201,7 @@ export interface getExperiment_experimentBySlug {
   countries: getExperiment_experimentBySlug_countries[];
   languages: getExperiment_experimentBySlug_languages[];
   projects: (getExperiment_experimentBySlug_projects | null)[] | null;
+  isDirty: boolean | null;
 }
 
 export interface getExperiment {

--- a/experimenter/experimenter/nimbus-ui/src/types/globalTypes.ts
+++ b/experimenter/experimenter/nimbus-ui/src/types/globalTypes.ts
@@ -228,6 +228,7 @@ export interface ExperimentInput {
   hypothesis?: string | null;
   id?: number | null;
   isArchived?: boolean | null;
+  isDirty?: boolean | null;
   isEnrollmentPaused?: boolean | null;
   isFirstRun?: boolean | null;
   isRollout?: boolean | null;


### PR DESCRIPTION
Because

- We want a way to signal when a rollout has unpublished changes
- And the current way--using publish_status to signal when a rollout is dirty--does not account for publish status being used to signal the review flow for ending, launching, and publishing new changes, which causes confusion

This commit

- Adds a separate flag for `isDirty` to indicate that a rollout has unpublished changes
