### PR TITLE
fixes #8204 fix(nimbus): added condition to not render 'Audience' lin…

### DIFF
--- a/experimenter/experimenter/nimbus-ui/src/components/AppLayoutSidebarLaunched/index.test.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/AppLayoutSidebarLaunched/index.test.tsx
@@ -212,5 +212,15 @@ describe("AppLayoutSidebarLaunched", () => {
       expect(screen.queryByText("Summary")).toBeInTheDocument();
       expect(screen.queryByText("Audience")).not.toBeInTheDocument();
     });
+
+    it("when a completed rollout do not show audience page", () => {
+      const { experiment } = mockExperimentQuery("demo-slug");
+      experiment.isRollout = true;
+      experiment.status = NimbusExperimentStatusEnum.COMPLETE;
+      render(<Subject withAnalysis {...{ experiment }} />);
+
+      expect(screen.queryByText("Summary")).toBeInTheDocument();
+      expect(screen.queryByText("Audience")).not.toBeInTheDocument();
+    });
   });
 });

--- a/experimenter/experimenter/nimbus-ui/src/components/AppLayoutSidebarLaunched/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/AppLayoutSidebarLaunched/index.tsx
@@ -193,6 +193,7 @@ export const AppLayoutSidebarLaunched = ({
               />
 
               {experiment.isRollout &&
+                experiment.status !== "COMPLETE" &&
                 editPages.map((page, idx) => (
                   <LinkNav
                     key={`sidebar-${page.name}-${idx}`}


### PR DESCRIPTION
…k if a Rollout has status 'COMPLETE'

Because

- previously the rollouts that are completed also had a link to the "Audience" page which shouldn't be the case.

Before:

![image](https://user-images.githubusercontent.com/79744258/226738950-a8be719f-aca5-47de-85da-78eb9d890b19.png)


This commit

- change the conditional rendering for the "Audience" page link so that completed rollouts do not have it rendered.

After:

![image](https://user-images.githubusercontent.com/79744258/226739077-76ac78ce-22ca-461e-ae1d-3a45b4434eed.png)

