### PR TITLE
For #8439: use isRolloutDirty flag in addition to publishStatus

### DIFF
--- a/experimenter/experimenter/experiments/api/v5/serializers.py
+++ b/experimenter/experimenter/experiments/api/v5/serializers.py
@@ -1063,6 +1063,7 @@ class NimbusExperimentSerializer(
             # can be Live Update (Dirty), End Enrollment, or End Experiment
             # (including rejections) if we don't check validated_data
             validated_data["publish_status"] = NimbusConstants.PublishStatus.DIRTY
+            validated_data["is_dirty"] = True
 
         self.changelog_message = validated_data.pop("changelog_message")
         return super().update(experiment, validated_data)

--- a/experimenter/experimenter/experiments/api/v5/serializers.py
+++ b/experimenter/experimenter/experiments/api/v5/serializers.py
@@ -1063,7 +1063,7 @@ class NimbusExperimentSerializer(
             # can be Live Update (Dirty), End Enrollment, or End Experiment
             # (including rejections) if we don't check validated_data
             validated_data["publish_status"] = NimbusConstants.PublishStatus.DIRTY
-            validated_data["is_dirty"] = True
+            validated_data["is_rollout_dirty"] = True
 
         self.changelog_message = validated_data.pop("changelog_message")
         return super().update(experiment, validated_data)

--- a/experimenter/experimenter/experiments/tests/factories.py
+++ b/experimenter/experimenter/experiments/tests/factories.py
@@ -114,6 +114,7 @@ class LifecycleStates(Enum):
         "status": NimbusExperiment.Status.LIVE,
         "status_next": None,
         "publish_status": NimbusExperiment.PublishStatus.DIRTY,
+        "is_rollout_dirty": True,
     }
     LIVE_REVIEW = {
         "status": NimbusExperiment.Status.LIVE,

--- a/experimenter/experimenter/kinto/tasks.py
+++ b/experimenter/experimenter/kinto/tasks.py
@@ -188,7 +188,7 @@ def handle_updating_experiments(applications, records):
             experiment.publish_status = NimbusExperiment.PublishStatus.IDLE
             experiment.status_next = None
             experiment.published_dto = published_record
-            experiment.is_dirty = False
+            experiment.is_rollout_dirty = False
             experiment.save()
 
             generate_nimbus_changelog(
@@ -212,6 +212,7 @@ def handle_ending_experiments(applications, records):
             experiment.status = NimbusExperiment.Status.COMPLETE
             experiment.status_next = None
             experiment.publish_status = NimbusExperiment.PublishStatus.IDLE
+            experiment.is_rollout_dirty = False
             experiment.save()
 
             generate_nimbus_changelog(

--- a/experimenter/experimenter/kinto/tasks.py
+++ b/experimenter/experimenter/kinto/tasks.py
@@ -188,6 +188,7 @@ def handle_updating_experiments(applications, records):
             experiment.publish_status = NimbusExperiment.PublishStatus.IDLE
             experiment.status_next = None
             experiment.published_dto = published_record
+            experiment.is_dirty = False
             experiment.save()
 
             generate_nimbus_changelog(

--- a/experimenter/experimenter/kinto/tests/test_tasks.py
+++ b/experimenter/experimenter/kinto/tests/test_tasks.py
@@ -396,6 +396,7 @@ class TestNimbusCheckKintoPushQueueByCollection(MockKintoClientMixin, TestCase):
             NimbusExperimentFactory.Lifecycles.LIVE_APPROVE_WAITING,
             application=NimbusExperiment.Application.DESKTOP,
             is_rollout=True,
+            is_rollout_dirty=True,
         )
         self.setup_kinto_get_main_records([])
         self.setup_kinto_rejected_review()
@@ -415,6 +416,7 @@ class TestNimbusCheckKintoPushQueueByCollection(MockKintoClientMixin, TestCase):
         self.assertEqual(
             rejected_experiment.publish_status, NimbusExperiment.PublishStatus.DIRTY
         )
+        self.assertTrue(rejected_experiment.is_rollout_dirty)
         self.assertIsNone(rejected_experiment.status_next)
         self.assertFalse(rejected_experiment.is_paused)
 
@@ -509,6 +511,7 @@ class TestNimbusCheckKintoPushQueueByCollection(MockKintoClientMixin, TestCase):
                 new_publish_status=NimbusExperiment.PublishStatus.IDLE,
             ).exists()
         )
+        self.assertFalse(updated_experiment.is_rollout_dirty)
 
     def test_check_with_missing_review_and_queued_launch_rolls_back_and_pushes(self):
         launching_experiment = NimbusExperimentFactory.create_with_lifecycle(

--- a/experimenter/experimenter/nimbus-ui/src/components/PageSummary/index.test.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageSummary/index.test.tsx
@@ -360,6 +360,7 @@ describe("PageSummary", () => {
     const { mockRollout, rollout } = mockLiveRolloutQuery("demo-slug", {
       ...updateReviewRequestedBaseProps,
       canReview: true,
+      isRolloutDirty: true,
     });
     const mutationMock = createFullStatusMutationMock(
       rollout.id!,
@@ -383,6 +384,7 @@ describe("PageSummary", () => {
     const { mockRollout, rollout } = mockLiveRolloutQuery("demo-slug", {
       ...updateReviewRequestedBaseProps,
       canReview: true,
+      isRolloutDirty: true,
     });
     const mutationMock = createFullStatusMutationMock(
       rollout.id!,
@@ -582,6 +584,7 @@ describe("PageSummary", () => {
     const { mockRollout } = mockLiveRolloutQuery("demo-slug", {
       status: NimbusExperimentStatusEnum.LIVE,
       publishStatus: NimbusExperimentPublishStatusEnum.APPROVED,
+      isRolloutDirty: true,
     });
     render(<Subject mocks={[mockRollout]} />);
     await waitFor(() =>
@@ -640,6 +643,7 @@ describe("PageSummary", () => {
         statusNext: null,
         isRollout: true,
         isEnrollmentPaused: false,
+        isRolloutDirty: true,
       });
       const mutationMock = createFullStatusMutationMock(
         rollout.id!,
@@ -680,6 +684,7 @@ describe("PageSummary", () => {
         statusNext: liveStatus,
         isRollout: true,
         isEnrollmentPaused: false,
+        isRolloutDirty: true,
       });
       const mutationMock = createFullStatusMutationMock(
         rollout.id!,

--- a/experimenter/experimenter/nimbus-ui/src/components/Summary/index.test.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/Summary/index.test.tsx
@@ -88,6 +88,7 @@ describe("Summary", () => {
         props={{
           status: NimbusExperimentStatusEnum.LIVE,
           publishStatus: NimbusExperimentPublishStatusEnum.DIRTY,
+          isRolloutDirty: true,
         }}
       />,
     );
@@ -101,6 +102,7 @@ describe("Summary", () => {
           status: NimbusExperimentStatusEnum.LIVE,
           publishStatus: NimbusExperimentPublishStatusEnum.DIRTY,
           isEnrollmentPaused: false,
+          isRolloutDirty: true,
         }}
       />,
     );
@@ -330,6 +332,8 @@ describe("Summary", () => {
       status: NimbusExperimentStatusEnum.LIVE,
       publishStatus: NimbusExperimentPublishStatusEnum.DIRTY,
       statusNext: null,
+      isEnrollmentPaused: false,
+      isRolloutDirty: true,
     });
 
     const mutationMock = createMutationMock(
@@ -343,11 +347,16 @@ describe("Summary", () => {
       },
     );
     render(<Subject props={rollout} mocks={[mockRollout, mutationMock]} />);
-
     const requestUpdateButton = await screen.findByTestId(
       "update-live-to-review",
     );
-    expect(requestUpdateButton).toBeEnabled();
+    const endExperimentButton = await screen.findByTestId(
+      "end-experiment-start",
+    );
+    await waitFor(() => {
+      expect(requestUpdateButton).toBeInTheDocument();
+      expect(endExperimentButton).toBeInTheDocument();
+    });
     await act(async () => void fireEvent.click(requestUpdateButton));
   });
 
@@ -357,6 +366,7 @@ describe("Summary", () => {
       publishStatus: NimbusExperimentPublishStatusEnum.DIRTY,
       statusNext: null,
       isEnrollmentPaused: false,
+      isRolloutDirty: true,
     });
 
     const mutationMock = createMutationMock(
@@ -388,6 +398,7 @@ describe("Summary", () => {
       publishStatus: NimbusExperimentPublishStatusEnum.DIRTY,
       statusNext: null,
       isEnrollmentPaused: false,
+      isRolloutDirty: true,
     });
 
     const mutationMock = createMutationMock(

--- a/experimenter/experimenter/nimbus-ui/src/lib/experiment.test.ts
+++ b/experimenter/experimenter/nimbus-ui/src/lib/experiment.test.ts
@@ -61,6 +61,7 @@ describe("getStatus", () => {
     expect(getStatus(experiment).waiting).toBeTruthy();
 
     experiment.publishStatus = NimbusExperimentPublishStatusEnum.DIRTY;
+    experiment.isRolloutDirty = true;
     expect(getStatus(experiment).dirty).toBeTruthy();
 
     experiment.publishStatus = NimbusExperimentPublishStatusEnum.REVIEW;

--- a/experimenter/experimenter/nimbus-ui/src/lib/experiment.ts
+++ b/experimenter/experimenter/nimbus-ui/src/lib/experiment.ts
@@ -21,6 +21,7 @@ export function getStatus(
     isEnrollmentPausePending,
     isArchived,
     isRollout,
+    isDirty,
   } = experiment || {};
 
   // The experiment is or was out in the wild (live or complete)
@@ -39,7 +40,7 @@ export function getStatus(
     approved: publishStatus === NimbusExperimentPublishStatusEnum.APPROVED,
     review: publishStatus === NimbusExperimentPublishStatusEnum.REVIEW,
     waiting: publishStatus === NimbusExperimentPublishStatusEnum.WAITING,
-    dirty: publishStatus === NimbusExperimentPublishStatusEnum.DIRTY,
+    dirty: isDirty === true,
     // TODO: EXP-1325 Need to check something else here for end enrollment in particular?
     pauseRequested:
       status === NimbusExperimentStatusEnum.LIVE &&
@@ -50,16 +51,19 @@ export function getStatus(
       statusNext === NimbusExperimentStatusEnum.COMPLETE,
     updateRequested:
       isRollout === true &&
+      isDirty === true &&
       status === NimbusExperimentStatusEnum.LIVE &&
       publishStatus === NimbusExperimentPublishStatusEnum.REVIEW &&
       statusNext === NimbusExperimentStatusEnum.LIVE,
     updateRequestedApproved:
       isRollout === true &&
+      isDirty === true &&
       status === NimbusExperimentStatusEnum.LIVE &&
       publishStatus === NimbusExperimentPublishStatusEnum.APPROVED &&
       statusNext === NimbusExperimentStatusEnum.LIVE,
     updateRequestedWaiting:
       isRollout === true &&
+      isDirty === true &&
       status === NimbusExperimentStatusEnum.LIVE &&
       publishStatus === NimbusExperimentPublishStatusEnum.WAITING &&
       statusNext === NimbusExperimentStatusEnum.LIVE,

--- a/experimenter/experimenter/nimbus-ui/src/lib/experiment.ts
+++ b/experimenter/experimenter/nimbus-ui/src/lib/experiment.ts
@@ -21,7 +21,7 @@ export function getStatus(
     isEnrollmentPausePending,
     isArchived,
     isRollout,
-    isDirty,
+    isRolloutDirty,
   } = experiment || {};
 
   // The experiment is or was out in the wild (live or complete)
@@ -40,7 +40,9 @@ export function getStatus(
     approved: publishStatus === NimbusExperimentPublishStatusEnum.APPROVED,
     review: publishStatus === NimbusExperimentPublishStatusEnum.REVIEW,
     waiting: publishStatus === NimbusExperimentPublishStatusEnum.WAITING,
-    dirty: isDirty === true,
+    dirty:
+      publishStatus === NimbusExperimentPublishStatusEnum.DIRTY &&
+      isRolloutDirty === true,
     // TODO: EXP-1325 Need to check something else here for end enrollment in particular?
     pauseRequested:
       status === NimbusExperimentStatusEnum.LIVE &&
@@ -51,19 +53,19 @@ export function getStatus(
       statusNext === NimbusExperimentStatusEnum.COMPLETE,
     updateRequested:
       isRollout === true &&
-      isDirty === true &&
+      isRolloutDirty === true &&
       status === NimbusExperimentStatusEnum.LIVE &&
       publishStatus === NimbusExperimentPublishStatusEnum.REVIEW &&
       statusNext === NimbusExperimentStatusEnum.LIVE,
     updateRequestedApproved:
       isRollout === true &&
-      isDirty === true &&
+      isRolloutDirty === true &&
       status === NimbusExperimentStatusEnum.LIVE &&
       publishStatus === NimbusExperimentPublishStatusEnum.APPROVED &&
       statusNext === NimbusExperimentStatusEnum.LIVE,
     updateRequestedWaiting:
       isRollout === true &&
-      isDirty === true &&
+      isRolloutDirty === true &&
       status === NimbusExperimentStatusEnum.LIVE &&
       publishStatus === NimbusExperimentPublishStatusEnum.WAITING &&
       statusNext === NimbusExperimentStatusEnum.LIVE,

--- a/experimenter/experimenter/nimbus-ui/src/lib/mocks.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/lib/mocks.tsx
@@ -597,6 +597,7 @@ export const MOCK_EXPERIMENT: Partial<getExperiment["experimentBySlug"]> = {
     },
   ],
   isEnrollmentPaused: true,
+  isRolloutDirty: null,
   enrollmentEndDate: null,
   recipeJson:
     '{"schemaVersion": "1.5.0", "slug": "pre-emptive-zero-tolerance-data-warehouse", "id": "pre-emptive-zero-tolerance-data-warehouse", "arguments": {}, "application": "", "appName": "firefox_ios", "appId": "", "channel": "", "userFacingName": "Pre-emptive zero tolerance data-warehouse", "userFacingDescription": "Analysis art mean sort serve stuff. Scene alone current television up write company. Without admit she occur total generation by mother. Environmental remember account huge drive policy play strong.", "isEnrollmentPaused": false, "bucketConfig": null, "probeSets": [], "outcomes": [{"slug": "example_config", "priority": "primary"}, {"slug": "newtab_visibility", "priority": "primary"}, {"slug": "picture_in_picture", "priority": "secondary"}], "branches": [{"slug": "horizontal-well-modulated-conglomeration", "ratio": 1, "feature": {"featureId": "decentralized-solution-oriented-neural-net", "enabled": true, "value": {"trouble-left-back": "west-receive"}}}, {"slug": "fully-configurable-context-sensitive-local-area-network", "ratio": 1, "feature": {"featureId": "decentralized-solution-oriented-neural-net", "enabled": true, "value": {"financial-school": "peace-light-might"}}}], "targeting": "localeLanguageCode == \'en\' && ((isFirstStartup && !(\'trailhead.firstrun.didSeeAboutWelcome\'|preferenceValue)) || experiment.slug in activeExperiments)", "startDate": null, "endDate": null, "proposedDuration": 60, "proposedEnrollment": 45, "referenceBranch": "horizontal-well-modulated-conglomeration", "featureIds": ["decentralized-solution-oriented-neural-net"]}',
@@ -678,6 +679,7 @@ export const MOCK_LIVE_ROLLOUT: Partial<getExperiment["experimentBySlug"]> = {
     },
   ],
   isEnrollmentPaused: false,
+  isRolloutDirty: false,
   enrollmentEndDate: null,
   recipeJson:
     '{"schemaVersion": "1.5.0", "slug": "pre-emptive-zero-tolerance-data-warehouse", "id": "pre-emptive-zero-tolerance-data-warehouse", "arguments": {}, "application": "", "appName": "firefox_ios", "appId": "", "channel": "", "userFacingName": "Pre-emptive zero tolerance data-warehouse", "userFacingDescription": "Analysis art mean sort serve stuff. Scene alone current television up write company. Without admit she occur total generation by mother. Environmental remember account huge drive policy play strong.", "isEnrollmentPaused": false, "bucketConfig": null, "probeSets": [], "outcomes": [{"slug": "example_config", "priority": "primary"}, {"slug": "newtab_visibility", "priority": "primary"}, {"slug": "picture_in_picture", "priority": "secondary"}], "branches": [{"slug": "horizontal-well-modulated-conglomeration", "ratio": 1, "feature": {"featureId": "decentralized-solution-oriented-neural-net", "enabled": true, "value": {"trouble-left-back": "west-receive"}}}, {"slug": "fully-configurable-context-sensitive-local-area-network", "ratio": 1, "feature": {"featureId": "decentralized-solution-oriented-neural-net", "enabled": true, "value": {"financial-school": "peace-light-might"}}}], "targeting": "localeLanguageCode == \'en\' && ((isFirstStartup && !(\'trailhead.firstrun.didSeeAboutWelcome\'|preferenceValue)) || experiment.slug in activeExperiments)", "startDate": null, "endDate": null, "proposedDuration": 60, "proposedEnrollment": 45, "referenceBranch": "horizontal-well-modulated-conglomeration", "featureIds": ["decentralized-solution-oriented-neural-net"]}',
@@ -819,6 +821,7 @@ export const mockGetStatus = (
       | "isEnrollmentPausePending"
       | "isArchived"
       | "isRollout"
+      | "isRolloutDirty"
     >
   >,
 ) => {


### PR DESCRIPTION
Because

- We added `is_rollout_dirty` in #8850
- We are going to use this flag to determine whether a rollout is dirty **in addition to publish status** (for now.. publish status will be removed later, see https://github.com/mozilla/experimenter/issues/8559 and https://github.com/mozilla/experimenter/issues/8558)

This commit

- Both `publish_status=DIRTY` and `is_rollout_dirty=true` are being set to denote that the rollout has been edited (has unpublished updates)
- This is being used **only for** the "Unpublished changes" status pill and the "Request update" buttons

----
<img width="1221" alt="image" src="https://user-images.githubusercontent.com/43795363/226978028-686cf290-f9ce-4ea9-9939-a5a31fa1384c.png">

----

<img width="1220" alt="image" src="https://user-images.githubusercontent.com/43795363/226978084-af7abf04-24a9-4452-a336-caa88eaa493c.png">
