### PR TITLE
Revert "fixes #8498 fix(nimbus): change the search bar to check if input contains space at the end, if input does not have space add space at the end and also change the test cases"

### DIFF
--- a/experimenter/experimenter/nimbus-ui/src/components/PageHome/SearchBar/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageHome/SearchBar/index.tsx
@@ -78,19 +78,9 @@ const SearchBar: React.FunctionComponent<SearchBarProps> = ({
   const handleChange = (event: {
     target: { value: React.SetStateAction<string> };
   }) => {
-    let inputValue = event.target.value as string;
-    // Check if the input value already has a space at the end
-    if (
-      inputValue.length > 0 &&
-      inputValue.charAt(inputValue.length - 1) !== " "
-    ) {
-      // If not, add a space at the end
-      inputValue = inputValue + " ";
-    }
-
     // add the search query to history state
     const url = new URL(`${window.location}`);
-    url.searchParams.set("search", inputValue);
+    url.searchParams.set("search", event.target.value as string);
     window.history.pushState({}, "", `${url}`);
 
     setSearchTerms(event.target.value);
@@ -101,7 +91,7 @@ const SearchBar: React.FunctionComponent<SearchBarProps> = ({
       setClearIcon(true);
 
       const newTimer = setTimeout(() => {
-        const results = fuse.search(inputValue);
+        const results = fuse.search(event.target.value as string);
 
         const searchResults = results.map((character) => character.item);
         onChange(searchResults);

--- a/experimenter/experimenter/nimbus-ui/src/components/PageHome/index.test.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageHome/index.test.tsx
@@ -53,9 +53,9 @@ describe("PageHome", () => {
 
   const findSearchTabs = () =>
     [
-      ["review", screen.getByText("Review (1)")],
+      ["review", screen.getByText("Review (0)")],
       ["preview", screen.getByText("Preview (0)")],
-      ["completed", screen.getByText("Completed (2)")],
+      ["completed", screen.getByText("Completed (1)")],
       ["drafts", screen.getByText("Draft (0)")],
       ["live", screen.getByText("Live (0)")],
       ["archived", screen.getByText("Archived (0)")],


### PR DESCRIPTION
Because
- we are getting intermittent tests because of changes in the search- https://github.com/mozilla/experimenter/issues/8557

This Commit
 - Reverts this PR https://github.com/mozilla/experimenter/pull/8547 because this PR is build on top of this pr changes-https://github.com/mozilla/experimenter/pull/8418
