### PR TITLE
fix #8557 chore(nimbus): Revert Nimbus UI search box content not stored in URL"

### DIFF
--- a/experimenter/experimenter/nimbus-ui/src/components/PageHome/SearchBar/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageHome/SearchBar/index.tsx
@@ -52,37 +52,12 @@ const SearchBar: React.FunctionComponent<SearchBarProps> = ({
     setClearIcon(false);
     onChange(experiments);
   };
-  const formRef = React.useRef<any>();
 
   const [timer, setTimer] = React.useState<NodeJS.Timeout | null>(null);
-
-  React.useEffect(() => {
-    const newtimer = setTimeout(() => {
-      // get search term from url history
-      const termFromURL = new URL(window.location as any).searchParams.get(
-        "search",
-      ) as string;
-
-      const nativeInputValueSetter = Object.getOwnPropertyDescriptor(
-        window.HTMLInputElement.prototype,
-        "value",
-      )?.set;
-      nativeInputValueSetter?.call(formRef.current, termFromURL);
-
-      const event = new Event("input", { bubbles: true });
-      formRef.current?.dispatchEvent(event);
-    }, 700);
-    return () => clearTimeout(newtimer);
-  }, []);
 
   const handleChange = (event: {
     target: { value: React.SetStateAction<string> };
   }) => {
-    // add the search query to history state
-    const url = new URL(`${window.location}`);
-    url.searchParams.set("search", event.target.value as string);
-    window.history.pushState({}, "", `${url}`);
-
     setSearchTerms(event.target.value);
     if (timer) {
       clearTimeout(timer);
@@ -91,7 +66,7 @@ const SearchBar: React.FunctionComponent<SearchBarProps> = ({
       setClearIcon(true);
 
       const newTimer = setTimeout(() => {
-        const results = fuse.search(event.target.value as string);
+        const results = fuse.search(searchTerms);
 
         const searchResults = results.map((character) => character.item);
         onChange(searchResults);
@@ -117,7 +92,6 @@ const SearchBar: React.FunctionComponent<SearchBarProps> = ({
         </InputGroup.Text>
       </InputGroup.Prepend>
       <FormControl
-        ref={formRef}
         aria-label="Default"
         aria-describedby="inputGroup-sizing-default"
         onChange={handleChange}

--- a/experimenter/experimenter/nimbus-ui/src/components/PageHome/index.test.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageHome/index.test.tsx
@@ -55,7 +55,7 @@ describe("PageHome", () => {
     [
       ["review", screen.getByText("Review (0)")],
       ["preview", screen.getByText("Preview (0)")],
-      ["completed", screen.getByText("Completed (1)")],
+      ["completed", screen.getByText("Completed (2)")],
       ["drafts", screen.getByText("Draft (0)")],
       ["live", screen.getByText("Live (0)")],
       ["archived", screen.getByText("Archived (0)")],


### PR DESCRIPTION
Because
- we are getting intermittent tests because of changes in the search- https://github.com/mozilla/experimenter/issues/8557

This Commit
 - Reverts this PR https://github.com/mozilla/experimenter/pull/8418