### PR TITLE
For #8504 feat(nimbus): Cancel review puts you back in dirty for live rollouts

### DIFF
--- a/experimenter/experimenter/nimbus-ui/src/components/PageSummary/index.test.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageSummary/index.test.tsx
@@ -144,6 +144,28 @@ describe("PageSummary", () => {
     });
   });
 
+  it("can cancel review when dirty rollout is in the review state", async () => {
+    const { mockRollout, rollout } = mockLiveRolloutQuery("demo-slug", {
+      ...reviewRequestedBaseProps,
+      canReview: true,
+      isRolloutDirty: true,
+    });
+    const mutationMock = createFullStatusMutationMock(
+      rollout.id!,
+      NimbusExperimentStatusEnum.LIVE,
+      NimbusExperimentStatusEnum.LIVE,
+      NimbusExperimentPublishStatusEnum.REVIEW,
+      CHANGELOG_MESSAGES.CANCEL_REVIEW,
+    );
+    render(<Subject mocks={[mockRollout, mutationMock]} />);
+
+    await screen.findByTestId("cancel-review-start");
+    fireEvent.click(screen.getByTestId("cancel-review-start"));
+
+    screen.queryByTestId("pill-dirty-unpublished");
+    screen.queryByTestId("update-live-to-review");
+  });
+
   it("hides takeaways section if experiment is not complete", async () => {
     const { mock } = mockExperimentQuery("demo-slug", {
       status: NimbusExperimentStatusEnum.DRAFT,

--- a/experimenter/experimenter/nimbus-ui/src/components/Summary/index.test.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/Summary/index.test.tsx
@@ -200,6 +200,40 @@ describe("Summary", () => {
       });
     });
 
+    it("can cancel review for live rollout", async () => {
+      const refetch = jest.fn();
+      const { mockRollout, rollout } = mockLiveRolloutQuery("demo-slug", {
+        status: NimbusExperimentStatusEnum.LIVE,
+        publishStatus: NimbusExperimentPublishStatusEnum.REVIEW,
+        statusNext: null,
+        isEnrollmentPaused: false,
+        isRolloutDirty: true,
+      });
+
+      const mutationMock = createMutationMock(
+        rollout.id!,
+        NimbusExperimentPublishStatusEnum.REVIEW,
+        {
+          statusNext: NimbusExperimentStatusEnum.LIVE,
+          changelogMessage: CHANGELOG_MESSAGES.CANCEL_REVIEW,
+          isEnrollmentPaused: false,
+        },
+      );
+
+      render(
+        <Subject
+          props={rollout}
+          mocks={[mockRollout, mutationMock]}
+          {...{ refetch }}
+        />,
+      );
+
+      await screen.findByTestId("cancel-review-start");
+      fireEvent.click(screen.getByTestId("cancel-review-start"));
+
+      screen.queryByTestId("request-update-button");
+    });
+
     it("handles submission with server API error", async () => {
       const { experiment } = mockExperimentQuery("demo-slug", {
         status: NimbusExperimentStatusEnum.LIVE,

--- a/experimenter/experimenter/nimbus-ui/src/components/Summary/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/Summary/index.tsx
@@ -61,7 +61,9 @@ const Summary = ({ experiment, refetch }: SummaryProps) => {
       changelogMessage: CHANGELOG_MESSAGES.REQUESTED_REVIEW_END_ENROLLMENT,
     },
     {
-      publishStatus: NimbusExperimentPublishStatusEnum.IDLE,
+      publishStatus: (
+        experiment.isRollout && status.live && experiment.statusNext === NimbusExperimentStatusEnum.LIVE
+        ) ? NimbusExperimentPublishStatusEnum.DIRTY : NimbusExperimentPublishStatusEnum.IDLE,
       changelogMessage: CHANGELOG_MESSAGES.CANCEL_REVIEW,
       statusNext:
         experiment.status === NimbusExperimentStatusEnum.LIVE

--- a/experimenter/experimenter/nimbus-ui/src/components/Summary/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/Summary/index.tsx
@@ -61,9 +61,12 @@ const Summary = ({ experiment, refetch }: SummaryProps) => {
       changelogMessage: CHANGELOG_MESSAGES.REQUESTED_REVIEW_END_ENROLLMENT,
     },
     {
-      publishStatus: (
-        experiment.isRollout && status.live && experiment.statusNext === NimbusExperimentStatusEnum.LIVE
-        ) ? NimbusExperimentPublishStatusEnum.DIRTY : NimbusExperimentPublishStatusEnum.IDLE,
+      publishStatus:
+        experiment.isRollout &&
+        status.live &&
+        experiment.statusNext === NimbusExperimentStatusEnum.LIVE
+          ? NimbusExperimentPublishStatusEnum.DIRTY
+          : NimbusExperimentPublishStatusEnum.IDLE,
       changelogMessage: CHANGELOG_MESSAGES.CANCEL_REVIEW,
       statusNext:
         experiment.status === NimbusExperimentStatusEnum.LIVE


### PR DESCRIPTION
Because

- A rollout with dirty updates that haven't been published yet should be able to be canceled
- Canceling an update should put the rollout back in the dirty state instead of idle

This commit

- Puts rollouts back in dirty if they were trying to cancel a live update

https://user-images.githubusercontent.com/43795363/227630369-fd25e911-641a-49f1-9dd1-a7041675ad1f.mov
