### PR TITLE
fixes #8577 feat(nimbus): add slack link to tip on home page

### DIFF
--- a/experimenter/experimenter/nimbus-ui/src/components/PageHome/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageHome/index.tsx
@@ -152,6 +152,13 @@ const PageHome: React.FunctionComponent<PageHomeProps> = () => {
           Have feedback?{" "}
           <LinkExternal href="https://mozilla-hub.atlassian.net/secure/CreateIssueDetails!init.jspa?pid=10203&amp;issuetype=10097">
             Please file it here!
+          </LinkExternal>{" "}
+          <span role="img" aria-label="thinking_face emoji">
+            🤔
+          </span>{" "}
+          Have a question?{" "}
+          <LinkExternal href="https://mozilla.slack.com/archives/CF94YGE03">
+            Ask us here!.
           </LinkExternal>
         </div>
       </Alert>


### PR DESCRIPTION
Because

- We need a slack link to tip on home page

This commit

- adds a slack link to tip  on home page

![Screenshot from 2023-03-24 23-25-32](https://user-images.githubusercontent.com/77124492/227632267-665896de-398e-4d49-b858-2eed27f357db.png)
