### PR TITLE
fixes #8499 fix(nimbus) store and revisit search result with test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,6 +75,9 @@ target/
 # VS Code
 **/.vscode/*
 
+# WebStorm
+**/.idea/*
+
 # Hosted assets
 experimenter/experimenter/served/
 experimenter/experimenter/legacy/legacy-ui/assets/

--- a/experimenter/experimenter/nimbus-ui/src/components/PageHome/SearchBar/index.test.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageHome/SearchBar/index.test.tsx
@@ -39,6 +39,30 @@ describe("SearchBar", () => {
       expect(searchInput).toHaveValue("");
     });
   });
+
+  it("updates the component when search values are saved in localStorage", async () => {
+    // Mock localStorage to return a particular value
+    jest.spyOn(Storage.prototype, "getItem").mockImplementation((key) => {
+      return JSON.stringify({
+        searchValue: "Experiment",
+        results: [{ item: "Saved experiment details" }],
+      });
+    });
+
+    const onChange = jest.fn();
+    render(<Subject experiments={[]} onChange={onChange} />);
+
+    // wait for useEffect to complete
+    await waitFor(() => {
+      // check that the component has updated with the values from localStorage
+      const searchInput = screen.getByTestId("SearchExperiments");
+      expect(searchInput).toBeInTheDocument();
+      expect(searchInput).toHaveValue("Experiment");
+      expect(onChange).toHaveBeenCalledWith(["Saved experiment details"]);
+      const clear = screen.getByTestId("ClearSearchExperiments");
+      expect(clear).toBeInTheDocument();
+    });
+  });
 });
 
 const Subject = ({


### PR DESCRIPTION
Because

- the filtered search results are not retained after navigating away from the search page, we need to modify the behavior of the "back to experiment" button to retain the search term and filtered results.

This commit

- Modifies the behavior of the "back to experiment" button to retain the search term and filtered results when navigating back to the search page.
- Test to ensure new fix works properly
- exempts pycharm and webstorm (.idea) folders in .gitignore
