### PR TITLE
For #8561 fix(nimbus) test(nimbus): End experiment for dirty rollouts can be rejected

### DIFF
--- a/experimenter/experimenter/experiments/tests/factories.py
+++ b/experimenter/experimenter/experiments/tests/factories.py
@@ -116,6 +116,11 @@ class LifecycleStates(Enum):
         "publish_status": NimbusExperiment.PublishStatus.DIRTY,
         "is_rollout_dirty": True,
     }
+    LIVE_DIRTY_REJECT = {
+        "status": NimbusExperiment.Status.LIVE,
+        "status_next": None,
+        "publish_status": NimbusExperiment.PublishStatus.DIRTY,
+    }
     LIVE_REVIEW = {
         "status": NimbusExperiment.Status.LIVE,
         "status_next": NimbusExperiment.Status.LIVE,
@@ -220,6 +225,7 @@ class Lifecycles(Enum):
 
     LIVE_ENROLLING = LAUNCH_APPROVE_APPROVE + (LifecycleStates.LIVE_IDLE,)
     LIVE_PAUSED = LIVE_ENROLLING + (LifecycleStates.LIVE_IDLE_PAUSED,)
+
     LIVE_DIRTY = LAUNCH_APPROVE_APPROVE + (LifecycleStates.LIVE_DIRTY,)
     LIVE_REVIEW_REQUESTED = LIVE_DIRTY + (LifecycleStates.LIVE_REVIEW,)
     LIVE_REJECT = LIVE_REVIEW_REQUESTED + (LifecycleStates.LIVE_DIRTY,)
@@ -229,6 +235,28 @@ class Lifecycles(Enum):
     LIVE_APPROVE_REJECT = LIVE_APPROVE_WAITING + (LifecycleStates.LIVE_DIRTY,)
     LIVE_APPROVE_TIMEOUT = LIVE_APPROVE_WAITING + (LifecycleStates.LIVE_DIRTY,)
     LIVE_REJECT_MANUAL_ROLLBACK = LIVE_APPROVE_REJECT + (LifecycleStates.LIVE_DIRTY,)
+
+    LIVE_DIRTY_ENDING_REVIEW_REQUESTED = LIVE_DIRTY + (
+        LifecycleStates.LIVE_REVIEW_ENDING,
+    )
+    LIVE_DIRTY_ENDING_APPROVE = LIVE_DIRTY_ENDING_REVIEW_REQUESTED + (
+        LifecycleStates.LIVE_APPROVED_ENDING,
+    )
+    LIVE_DIRTY_ENDING_REJECT = LIVE_DIRTY_ENDING_REVIEW_REQUESTED + (
+        LifecycleStates.LIVE_DIRTY_REJECT,
+    )
+    LIVE_DIRTY_ENDING_APPROVE_WAITING = LIVE_DIRTY_ENDING_APPROVE + (
+        LifecycleStates.LIVE_WAITING_ENDING,
+    )
+    LIVE_DIRTY_ENDING_APPROVE_REJECT = LIVE_DIRTY_ENDING_APPROVE + (
+        LifecycleStates.LIVE_DIRTY_REJECT,
+    )
+    LIVE_DIRTY_ENDING_APPROVE_TIMEOUT = LIVE_DIRTY_ENDING_APPROVE_WAITING + (
+        LifecycleStates.LIVE_REVIEW_ENDING,
+    )
+    LIVE_DIRTY_ENDING_REJECT_MANUAL_ROLLBACK = LIVE_DIRTY_ENDING_APPROVE_REJECT + (
+        LifecycleStates.LIVE_REVIEW_ENDING,
+    )
 
     PAUSING_REVIEW_REQUESTED = LIVE_ENROLLING + (LifecycleStates.LIVE_REVIEW_PAUSING,)
     PAUSING_REJECT = PAUSING_REVIEW_REQUESTED + (
@@ -245,7 +273,7 @@ class Lifecycles(Enum):
     )
 
     ENDING_REVIEW_REQUESTED = LIVE_PAUSED + (LifecycleStates.LIVE_REVIEW_ENDING,)
-    ENDING_REJECT = ENDING_REVIEW_REQUESTED + (LifecycleStates.LIVE_IDLE,)
+    ENDING_REJECT = ENDING_REVIEW_REQUESTED + (LifecycleStates.LIVE_IDLE_REJECT,)
     ENDING_APPROVE = ENDING_REVIEW_REQUESTED + (LifecycleStates.LIVE_APPROVED_ENDING,)
     ENDING_APPROVE_WAITING = ENDING_APPROVE + (LifecycleStates.LIVE_WAITING_ENDING,)
     ENDING_APPROVE_APPROVE = ENDING_APPROVE_WAITING + (LifecycleStates.COMPLETE_IDLE,)

--- a/experimenter/experimenter/kinto/tasks.py
+++ b/experimenter/experimenter/kinto/tasks.py
@@ -126,10 +126,14 @@ def handle_rejection(applications, kinto_client):
         if (
             experiment.is_rollout is True
             and experiment.status == NimbusExperiment.Status.LIVE
-            and experiment.status_next == NimbusExperiment.Status.LIVE
+            and (
+                experiment.status_next
+                in (NimbusExperiment.Status.LIVE, NimbusExperiment.Status.COMPLETE)
+            )
             and experiment.is_paused is False
         ):
             experiment.publish_status = NimbusExperiment.PublishStatus.DIRTY
+            experiment.is_rollout_dirty = True
         else:
             experiment.publish_status = NimbusExperiment.PublishStatus.IDLE
         experiment.status_next = None

--- a/experimenter/experimenter/nimbus-ui/src/components/PageSummary/index.test.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageSummary/index.test.tsx
@@ -166,6 +166,29 @@ describe("PageSummary", () => {
     screen.queryByTestId("update-live-to-review");
   });
 
+  it("can reject ending when dirty rollout is in the review state", async () => {
+    const { mockRollout, rollout } = mockLiveRolloutQuery("demo-slug", {
+      ...reviewRequestedBaseProps,
+      canReview: true,
+      isRolloutDirty: true,
+    });
+    const mutationMock = createFullStatusMutationMock(
+      rollout.id!,
+      NimbusExperimentStatusEnum.LIVE,
+      NimbusExperimentStatusEnum.COMPLETE,
+      NimbusExperimentPublishStatusEnum.REVIEW,
+      CHANGELOG_MESSAGES.CANCEL_REVIEW,
+    );
+    render(<Subject mocks={[mockRollout, mutationMock]} />);
+
+    screen.queryByTestId("pill-dirty-unpublished");
+
+    fireEvent.click(screen.getByTestId("reject-request"));
+
+    screen.queryByTestId("pill-dirty-unpublished");
+    screen.queryByTestId("update-live-to-review");
+  });
+
   it("hides takeaways section if experiment is not complete", async () => {
     const { mock } = mockExperimentQuery("demo-slug", {
       status: NimbusExperimentStatusEnum.DRAFT,

--- a/experimenter/experimenter/nimbus-ui/src/components/PageSummary/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageSummary/index.tsx
@@ -96,7 +96,9 @@ const PageSummary = (props: RouteComponentProps) => {
     {
       status: NimbusExperimentStatusEnum.LIVE,
       statusNext: null,
-      publishStatus: NimbusExperimentPublishStatusEnum.IDLE,
+      publishStatus: experiment.isRolloutDirty
+        ? NimbusExperimentPublishStatusEnum.DIRTY
+        : NimbusExperimentPublishStatusEnum.IDLE,
     },
     {
       status: NimbusExperimentStatusEnum.LIVE,

--- a/experimenter/experimenter/nimbus-ui/src/components/Summary/index.test.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/Summary/index.test.tsx
@@ -234,52 +234,6 @@ describe("Summary", () => {
       screen.queryByTestId("request-update-button");
     });
 
-    it("can cancel end experiment for live rollout", async () => {
-      const refetch = jest.fn();
-      const { rollout } = mockLiveRolloutQuery("demo-slug", {
-        status: NimbusExperimentStatusEnum.LIVE,
-        publishStatus: NimbusExperimentPublishStatusEnum.DIRTY,
-        statusNext: NimbusExperimentStatusEnum.LIVE,
-        isRollout: true,
-        isRolloutDirty: true,
-      });
-      // const mutationMock = createMutationMock(
-      //   rollout.id!,
-      //   NimbusExperimentPublishStatusEnum.DIRTY,
-      //   {
-      //     statusNext: NimbusExperimentStatusEnum.COMPLETE,
-      //     changelogMessage: CHANGELOG_MESSAGES.CANCEL_REVIEW,
-      //     isEnrollmentPaused: false,
-      //   },
-      // );
-      render(
-        <Subject props={rollout} {...{ refetch }} />,
-        // <Subject props={rollout} mocks={[mutationMock]} {...{ refetch }} />,
-      );
-
-      // click end experiment
-      const endExperimentButton = await screen.findByTestId("end-experiment-start");
-      fireEvent.click(endExperimentButton);
-
-      // cancel 
-      fireEvent.click(screen.getByTestId("review-cancel"));
-
-      // const requestUpdateButton = await screen.findByTestId(
-      //   "update-live-to-review",
-      // );
-      // // const endExperimentButton = await screen.findByTestId(
-      // //   "end-experiment-start",
-      // // );
-      // const unpublishedChangesPill = await screen.findByTestId(
-      //   "pill-dirty-unpublished",
-      // );
-      // await waitFor(() => {
-      //   expect(requestUpdateButton).toBeInTheDocument();
-      //   expect(endExperimentButton).toBeInTheDocument();
-      //   expect(unpublishedChangesPill).toBeInTheDocument();
-      // });
-    });
-
     it("handles submission with server API error", async () => {
       const { experiment } = mockExperimentQuery("demo-slug", {
         status: NimbusExperimentStatusEnum.LIVE,

--- a/experimenter/experimenter/nimbus-ui/src/components/Summary/index.test.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/Summary/index.test.tsx
@@ -234,6 +234,52 @@ describe("Summary", () => {
       screen.queryByTestId("request-update-button");
     });
 
+    it("can cancel end experiment for live rollout", async () => {
+      const refetch = jest.fn();
+      const { rollout } = mockLiveRolloutQuery("demo-slug", {
+        status: NimbusExperimentStatusEnum.LIVE,
+        publishStatus: NimbusExperimentPublishStatusEnum.DIRTY,
+        statusNext: NimbusExperimentStatusEnum.LIVE,
+        isRollout: true,
+        isRolloutDirty: true,
+      });
+      // const mutationMock = createMutationMock(
+      //   rollout.id!,
+      //   NimbusExperimentPublishStatusEnum.DIRTY,
+      //   {
+      //     statusNext: NimbusExperimentStatusEnum.COMPLETE,
+      //     changelogMessage: CHANGELOG_MESSAGES.CANCEL_REVIEW,
+      //     isEnrollmentPaused: false,
+      //   },
+      // );
+      render(
+        <Subject props={rollout} {...{ refetch }} />,
+        // <Subject props={rollout} mocks={[mutationMock]} {...{ refetch }} />,
+      );
+
+      // click end experiment
+      const endExperimentButton = await screen.findByTestId("end-experiment-start");
+      fireEvent.click(endExperimentButton);
+
+      // cancel 
+      fireEvent.click(screen.getByTestId("review-cancel"));
+
+      // const requestUpdateButton = await screen.findByTestId(
+      //   "update-live-to-review",
+      // );
+      // // const endExperimentButton = await screen.findByTestId(
+      // //   "end-experiment-start",
+      // // );
+      // const unpublishedChangesPill = await screen.findByTestId(
+      //   "pill-dirty-unpublished",
+      // );
+      // await waitFor(() => {
+      //   expect(requestUpdateButton).toBeInTheDocument();
+      //   expect(endExperimentButton).toBeInTheDocument();
+      //   expect(unpublishedChangesPill).toBeInTheDocument();
+      // });
+    });
+
     it("handles submission with server API error", async () => {
       const { experiment } = mockExperimentQuery("demo-slug", {
         status: NimbusExperimentStatusEnum.LIVE,

--- a/experimenter/experimenter/nimbus-ui/src/components/Summary/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/Summary/index.tsx
@@ -64,8 +64,9 @@ const Summary = ({ experiment, refetch }: SummaryProps) => {
       publishStatus:
         experiment.isRollout &&
         status.live &&
-        (experiment.statusNext === NimbusExperimentStatusEnum.LIVE ||
-          experiment.statusNext === NimbusExperimentStatusEnum.COMPLETE)
+        experiment.statusNext ===
+          (NimbusExperimentStatusEnum.LIVE ||
+            NimbusExperimentStatusEnum.COMPLETE)
           ? NimbusExperimentPublishStatusEnum.DIRTY
           : NimbusExperimentPublishStatusEnum.IDLE,
       changelogMessage: CHANGELOG_MESSAGES.CANCEL_REVIEW,

--- a/experimenter/experimenter/nimbus-ui/src/components/Summary/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/Summary/index.tsx
@@ -64,7 +64,8 @@ const Summary = ({ experiment, refetch }: SummaryProps) => {
       publishStatus:
         experiment.isRollout &&
         status.live &&
-        experiment.statusNext === NimbusExperimentStatusEnum.LIVE
+        (experiment.statusNext === NimbusExperimentStatusEnum.LIVE ||
+          experiment.statusNext === NimbusExperimentStatusEnum.COMPLETE)
           ? NimbusExperimentPublishStatusEnum.DIRTY
           : NimbusExperimentPublishStatusEnum.IDLE,
       changelogMessage: CHANGELOG_MESSAGES.CANCEL_REVIEW,


### PR DESCRIPTION
Because

- We want end experiment to be able to be approve, rejected, and canceled
- And dirty changes should be preserved if end experiment is rejected or canceled

This commit

- Adds `COMPLETE` when checking status_next
- Persists the dirty changes so that you can make more updates even after a rejection/cancellation
- Adds Lifecycle definitions for ending experiments once a rollout has been Dirty

-----

https://user-images.githubusercontent.com/43795363/228025784-3d9e5842-51cd-4ed0-a1a6-3f40fc3a1673.mov

----
Make an update, reject, make another update

https://user-images.githubusercontent.com/43795363/228025798-de031740-f445-4978-acf0-024ed5bcd039.mov
