### PR TITLE
For #8581 fix(nimbus) test(nimbus): Dirty rollouts should not be dirty when cloned

### DIFF
--- a/experimenter/experimenter/experiments/models.py
+++ b/experimenter/experimenter/experiments/models.py
@@ -723,6 +723,7 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
         cloned.parent = self
         cloned.is_archived = False
         cloned.is_paused = False
+        cloned.is_rollout_dirty = None
         cloned.reference_branch = None
         cloned.published_dto = None
         cloned.results_data = None

--- a/experimenter/experimenter/experiments/tests/test_models.py
+++ b/experimenter/experimenter/experiments/tests/test_models.py
@@ -1877,6 +1877,7 @@ class TestNimbusExperiment(TestCase):
         self.assertEqual(child.changes.all().count(), 1)
         self.assertIsNone(child.conclusion_recommendation)
         self.assertIsNone(child.takeaways_summary)
+        self.assertIsNone(child.is_rollout_dirty)
 
     def test_clone_completed_experiment(self):
         parent = NimbusExperimentFactory.create_with_lifecycle(
@@ -1908,6 +1909,19 @@ class TestNimbusExperiment(TestCase):
         with self.assertRaises(NimbusBranch.DoesNotExist):
             self._clone_experiment_and_assert_common_expectations(parent, "BAD SLUG")
 
+    def test_clone_dirty_rollout(self):
+        parent = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.LIVE_DIRTY,
+            is_rollout=True,
+            is_rollout_dirty=True,
+        )
+        rollout_branch = parent.branches.first()
+        child = self._clone_experiment_and_assert_common_expectations(
+            parent,
+            rollout_branch.slug,
+        )
+        self.assertIsNone(child.is_rollout_dirty)
+
     def _clone_experiment_and_assert_common_expectations(
         self, parent, rollout_branch_slug=None
     ):
@@ -1921,6 +1935,7 @@ class TestNimbusExperiment(TestCase):
         self.assertEqual(child.parent, parent)
         self.assertEqual(child.is_archived, False)
         self.assertEqual(child.is_paused, False)
+        self.assertEqual(child.is_rollout_dirty, None)
         self.assertEqual(child.published_dto, None)
         self.assertEqual(child.results_data, None)
         self.assertEqual(child.takeaways_summary, None)


### PR DESCRIPTION
Because

- A cloned rollout should not persist the `is_rollout_dirty` value

This commit

- Explicitly sets `is_rollout_dirty` back to `None` when a rollout is cloned
- Adds tests
