### PR TITLE
For #8574 fix(nimbus): Only updating population percent sets dirty publish status

### DIFF
--- a/experimenter/experimenter/experiments/api/v5/serializers.py
+++ b/experimenter/experimenter/experiments/api/v5/serializers.py
@@ -1053,17 +1053,20 @@ class NimbusExperimentSerializer(
     def update(self, experiment, validated_data):
         if (
             experiment.is_rollout
-            and not experiment.is_paused
-            and experiment.status == NimbusExperiment.Status.LIVE
-            and experiment.status_next is None
-            and experiment.publish_status == NimbusExperiment.PublishStatus.IDLE
-            and validated_data.get("publish_status")
-            != NimbusConstants.PublishStatus.REVIEW
+            and validated_data.get("population_percent") != experiment.population_percent
         ):
-            # can be Live Update (Dirty), End Enrollment, or End Experiment
-            # (including rejections) if we don't check validated_data
-            validated_data["publish_status"] = NimbusConstants.PublishStatus.DIRTY
-            validated_data["is_rollout_dirty"] = True
+            if (
+                not experiment.is_paused
+                and experiment.status == NimbusExperiment.Status.LIVE
+                and experiment.status_next is None
+                and experiment.publish_status == NimbusExperiment.PublishStatus.IDLE
+                and validated_data.get("publish_status")
+                != NimbusConstants.PublishStatus.REVIEW
+            ):
+                # can be Live Update (Dirty), End Enrollment, or End Experiment
+                # (including rejections) if we don't check validated_data
+                validated_data["publish_status"] = NimbusConstants.PublishStatus.DIRTY
+                validated_data["is_rollout_dirty"] = True
 
         self.changelog_message = validated_data.pop("changelog_message")
         return super().update(experiment, validated_data)


### PR DESCRIPTION
Because

- We only want to make our `publish_status=DIRTY` when a change has been made
- It was setting DIRTY every time `update` was called (when you click "Save and continue") even if there was no change

This commit

- Checks to see if the population percent value has changed on update
- Adds tests