### PR TITLE
For #8378 test(nimbus): Add integration tests for updating a live rollout

### DIFF
--- a/experimenter/experimenter/nimbus-ui/src/components/ChangeApprovalOperations/FormApproveOrReject.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/ChangeApprovalOperations/FormApproveOrReject.tsx
@@ -58,6 +58,7 @@ const FormApproveOrReject = ({
               </Button>
               <Button
                 data-testid="reject-request"
+                id="reject-request-button"
                 className="btn btn-danger"
                 disabled={isLoading}
                 onClick={onReject}

--- a/experimenter/tests/integration/nimbus/pages/experimenter/base.py
+++ b/experimenter/tests/integration/nimbus/pages/experimenter/base.py
@@ -12,6 +12,7 @@ class ExperimenterBase(Base):
     _sidebar_summary_link = (By.CSS_SELECTOR, 'a[data-testid="nav-summary"]')
     _sidebar_edit_overview_link = (By.CSS_SELECTOR, 'a[data-testid="nav-edit-overview"]')
     _sidebar_edit_branches_link = (By.CSS_SELECTOR, 'a[data-testid="nav-edit-branches"]')
+    _sidebar_edit_audience_link = (By.CSS_SELECTOR, 'a[data-testid="nav-edit-audience"]')
 
     NEXT_PAGE = None
     PAGE_TITLE = ""
@@ -70,3 +71,13 @@ class ExperimenterBase(Base):
         )
         element.click()
         return BranchesPage(self.driver, self.base_url).wait_for_page_to_load()
+
+    def navigate_to_audience(self):
+        # Avoid circular import
+        from nimbus.pages.experimenter.audience import AudiencePage
+
+        element = self.wait_for_and_find_element(
+            self._sidebar_edit_audience_link, "audience link"
+        )
+        element.click()
+        return AudiencePage(self.driver, self.base_url).wait_for_page_to_load()

--- a/experimenter/tests/integration/nimbus/pages/experimenter/summary.py
+++ b/experimenter/tests/integration/nimbus/pages/experimenter/summary.py
@@ -17,7 +17,10 @@ class SummaryPage(ExperimenterBase):
     _header_slug = (By.CSS_SELECTOR, 'p[data-testid="header-experiment-slug"]')
     _approve_request_button_locator = (By.CSS_SELECTOR, "#approve-request-button")
     _reject_request_button_locator = (By.CSS_SELECTOR, "#reject-request-button")
-    _reject_input_text_locator = (By.CSS_SELECTOR, 'textarea[data-testid="reject-reason"]')
+    _reject_input_text_locator = (
+        By.CSS_SELECTOR,
+        'textarea[data-testid="reject-reason"]',
+    )
     _reject_input_text_submit_locator = (By.CSS_SELECTOR, '[data-testid="reject-submit"]')
     _rejection_notice_locator = (By.CSS_SELECTOR, '[data-testid="rejection-notice"]')
     _launch_to_preview_locator = (By.CSS_SELECTOR, "#launch-to-preview-button")
@@ -138,7 +141,7 @@ class SummaryPage(ExperimenterBase):
 
     def set_rejection_reason(self):
         text_area = self.find_element(*self._reject_input_text_locator)
-        text_area.send_keys(f"oh no")
+        text_area.send_keys("oh no")
 
     def submit_rejection(self):
         button = self.find_element(*self._reject_input_text_submit_locator)
@@ -182,7 +185,7 @@ class SummaryPage(ExperimenterBase):
     def request_update_and_approve(self):
         self.request_update()
         self.find_element(*self._approve_request_button_locator).click()
-        
+
     def request_update_and_reject(self):
         self.request_update()
         self.find_element(*self._reject_request_button_locator).click()
@@ -194,7 +197,7 @@ class SummaryPage(ExperimenterBase):
             message="Summary Page: could not find update request button",
         )
         return self.find_element(*self._update_request_locator)
-  
+
     def request_update(self):
         self.request_update_action.click()
 

--- a/experimenter/tests/integration/nimbus/pages/experimenter/summary.py
+++ b/experimenter/tests/integration/nimbus/pages/experimenter/summary.py
@@ -16,6 +16,10 @@ class SummaryPage(ExperimenterBase):
     _promote_rollout_locator = (By.CSS_SELECTOR, 'button[data-testid="promote-rollout"]')
     _header_slug = (By.CSS_SELECTOR, 'p[data-testid="header-experiment-slug"]')
     _approve_request_button_locator = (By.CSS_SELECTOR, "#approve-request-button")
+    _reject_request_button_locator = (By.CSS_SELECTOR, "#reject-request-button")
+    _reject_input_text_locator = (By.CSS_SELECTOR, 'textarea[data-testid="reject-reason"]')
+    _reject_input_text_submit_locator = (By.CSS_SELECTOR, '[data-testid="reject-submit"]')
+    _rejection_notice_locator = (By.CSS_SELECTOR, '[data-testid="rejection-notice"]')
     _launch_to_preview_locator = (By.CSS_SELECTOR, "#launch-to-preview-button")
     _launch_without_preview_locator = (By.CSS_SELECTOR, "#launch-to-review-button")
     _rejected_text_alert_locator = (By.CSS_SELECTOR, '[data-testid="rejection-notice"]')
@@ -23,6 +27,7 @@ class SummaryPage(ExperimenterBase):
     _status_live_locator = (By.CSS_SELECTOR, ".status-Live.border-primary")
     _status_preview_locator = (By.CSS_SELECTOR, ".status-Preview.border-primary")
     _status_complete_locator = (By.CSS_SELECTOR, ".status-Complete.border-primary")
+    _update_request_locator = (By.CSS_SELECTOR, "#request-update-button")
     _experiment_status_icon_locator = (
         By.CSS_SELECTOR,
         ".header-experiment-status .border-primary",
@@ -114,6 +119,31 @@ class SummaryPage(ExperimenterBase):
             message="Summary Page: could not find clone parent",
         )
 
+    def wait_for_update_request_visible(self):
+        self.wait_with_refresh(
+            self._update_request_locator, "Summary Page: Unable to find update request"
+        )
+
+    def wait_for_rejection_reason_text_input_visible(self):
+        self.wait.until(
+            EC.presence_of_all_elements_located(self._reject_input_text_locator),
+            message="Summary Page: could not find rejection reason text input",
+        )
+
+    def wait_for_rejection_notice_visible(self):
+        self.wait.until(
+            EC.presence_of_all_elements_located(self._rejection_notice_locator),
+            message="Summary Page: could not find rejection notice",
+        )
+
+    def set_rejection_reason(self):
+        text_area = self.find_element(*self._reject_input_text_locator)
+        text_area.send_keys(f"oh no")
+
+    def submit_rejection(self):
+        button = self.find_element(*self._reject_input_text_submit_locator)
+        button.click()
+
     @property
     def experiment_slug(self):
         return self.wait_for_and_find_element(self._header_slug, "header slug").text
@@ -148,6 +178,25 @@ class SummaryPage(ExperimenterBase):
             EC.presence_of_element_located(self._approve_request_button_locator)
         )
         self.find_element(*self._approve_request_button_locator).click()
+
+    def request_update_and_approve(self):
+        self.request_update()
+        self.find_element(*self._approve_request_button_locator).click()
+        
+    def request_update_and_reject(self):
+        self.request_update()
+        self.find_element(*self._reject_request_button_locator).click()
+
+    @property
+    def request_update_action(self):
+        self.wait.until(
+            EC.presence_of_all_elements_located(self._update_request_locator),
+            message="Summary Page: could not find update request button",
+        )
+        return self.find_element(*self._update_request_locator)
+  
+    def request_update(self):
+        self.request_update_action.click()
 
     def launch_and_approve(self):
         self.launch_without_preview.click()

--- a/experimenter/tests/integration/nimbus/test_experimenter_ui.py
+++ b/experimenter/tests/integration/nimbus/test_experimenter_ui.py
@@ -109,7 +109,7 @@ def test_every_form_page_can_be_resaved(
     assert summary.experiment_slug is not None
 
 
-@pytest.mark.remote_settings
+@pytest.mark.nimbus_ui
 def test_rollout_create_and_update(
     selenium,
     base_url,
@@ -134,7 +134,7 @@ def test_rollout_create_and_update(
     summary_page.wait_for_update_request_visible()
 
 
-@pytest.mark.remote_settings
+@pytest.mark.nimbus_ui
 def test_rollout_live_update_reject_on_experimenter(
     selenium,
     base_url,

--- a/experimenter/tests/integration/nimbus/test_experimenter_ui.py
+++ b/experimenter/tests/integration/nimbus/test_experimenter_ui.py
@@ -1,5 +1,4 @@
 import os
-from urllib.parse import urljoin
 
 import pytest
 
@@ -107,60 +106,3 @@ def test_every_form_page_can_be_resaved(
     audience = metrics.save_and_continue()
     summary = audience.save_and_continue()
     assert summary.experiment_slug is not None
-
-
-@pytest.mark.nimbus_ui
-def test_rollout_create_and_update(
-    selenium,
-    base_url,
-    create_experiment,
-    kinto_client,
-    experiment_name,
-    slugify,
-):
-    experiment_slug = str(slugify(experiment_name))
-    create_experiment(selenium, is_rollout=True).launch_and_approve()
-
-    kinto_client.approve()
-    summary = SummaryPage(selenium, urljoin(base_url, experiment_slug)).open()
-
-    summary.wait_for_live_status()
-    audience = summary.navigate_to_audience()
-
-    audience.percentage = "60"
-    audience.save_and_continue()
-
-    summary_page = SummaryPage(selenium, urljoin(base_url, experiment_slug)).open()
-    summary_page.wait_for_update_request_visible()
-
-
-@pytest.mark.nimbus_ui
-def test_rollout_live_update_reject_on_experimenter(
-    selenium,
-    base_url,
-    create_experiment,
-    kinto_client,
-    experiment_name,
-    slugify,
-):
-    experiment_slug = str(slugify(experiment_name))
-    create_experiment(selenium, is_rollout=True).launch_and_approve()
-
-    kinto_client.approve()
-    summary = SummaryPage(selenium, urljoin(base_url, experiment_slug)).open()
-
-    summary.wait_for_live_status()
-    audience = summary.navigate_to_audience()
-
-    audience.percentage = "60"
-    audience.save_and_continue()
-
-    summary_page = SummaryPage(selenium, urljoin(base_url, experiment_slug)).open()
-    summary_page.wait_for_update_request_visible()
-
-    summary_page.request_update_and_reject()
-    summary_page.wait_for_rejection_reason_text_input_visible()
-
-    summary_page.set_rejection_reason()
-    summary_page.submit_rejection()
-    summary_page.wait_for_rejection_notice_visible()

--- a/experimenter/tests/integration/nimbus/test_remote_settings.py
+++ b/experimenter/tests/integration/nimbus/test_remote_settings.py
@@ -260,3 +260,60 @@ def test_rollout_live_update_approve_and_reject(
     kinto_client.reject()
 
     summary_page.wait_for_rejection_notice_visible()
+
+
+@pytest.mark.remote_settings
+def test_rollout_create_and_update(
+    selenium,
+    base_url,
+    create_experiment,
+    kinto_client,
+    experiment_name,
+    slugify,
+):
+    experiment_slug = str(slugify(experiment_name))
+    create_experiment(selenium, is_rollout=True).launch_and_approve()
+
+    kinto_client.approve()
+    summary = SummaryPage(selenium, urljoin(base_url, experiment_slug)).open()
+
+    summary.wait_for_live_status()
+    audience = summary.navigate_to_audience()
+
+    audience.percentage = "60"
+    audience.save_and_continue()
+
+    summary_page = SummaryPage(selenium, urljoin(base_url, experiment_slug)).open()
+    summary_page.wait_for_update_request_visible()
+
+
+@pytest.mark.remote_settings
+def test_rollout_live_update_reject_on_experimenter(
+    selenium,
+    base_url,
+    create_experiment,
+    kinto_client,
+    experiment_name,
+    slugify,
+):
+    experiment_slug = str(slugify(experiment_name))
+    create_experiment(selenium, is_rollout=True).launch_and_approve()
+
+    kinto_client.approve()
+    summary = SummaryPage(selenium, urljoin(base_url, experiment_slug)).open()
+
+    summary.wait_for_live_status()
+    audience = summary.navigate_to_audience()
+
+    audience.percentage = "60"
+    audience.save_and_continue()
+
+    summary_page = SummaryPage(selenium, urljoin(base_url, experiment_slug)).open()
+    summary_page.wait_for_update_request_visible()
+
+    summary_page.request_update_and_reject()
+    summary_page.wait_for_rejection_reason_text_input_visible()
+
+    summary_page.set_rejection_reason()
+    summary_page.submit_rejection()
+    summary_page.wait_for_rejection_notice_visible()

--- a/experimenter/tests/integration/nimbus/test_remote_settings.py
+++ b/experimenter/tests/integration/nimbus/test_remote_settings.py
@@ -202,3 +202,61 @@ def test_rollout_live_status_on_home_page(
     summary.wait_for_live_status()
     home = HomePage(selenium, base_url).open()
     assert True in [experiment_name in item.text for item in home.tables[0].experiments]
+
+
+@pytest.mark.remote_settings
+def test_rollout_live_update_approve(
+    selenium,
+    base_url,
+    create_experiment,
+    kinto_client,
+    experiment_name,
+    slugify,
+):
+    experiment_slug = str(slugify(experiment_name))
+    create_experiment(selenium, is_rollout=True).launch_and_approve()
+
+    kinto_client.approve()
+    summary = SummaryPage(selenium, urljoin(base_url, experiment_slug)).open()
+
+    summary.wait_for_live_status()
+    audience = summary.navigate_to_audience()
+
+    audience.percentage = "60"
+    audience.save_and_continue()
+
+    summary_page = SummaryPage(selenium, urljoin(base_url, experiment_slug)).open()
+    summary_page.wait_for_update_request_visible()
+
+    summary_page.request_update_and_approve()
+    kinto_client.approve()
+
+
+@pytest.mark.remote_settings
+def test_rollout_live_update_approve_and_reject(
+    selenium,
+    base_url,
+    create_experiment,
+    kinto_client,
+    experiment_name,
+    slugify,
+):
+    experiment_slug = str(slugify(experiment_name))
+    create_experiment(selenium, is_rollout=True).launch_and_approve()
+
+    kinto_client.approve()
+    summary = SummaryPage(selenium, urljoin(base_url, experiment_slug)).open()
+
+    summary.wait_for_live_status()
+    audience = summary.navigate_to_audience()
+
+    audience.percentage = "60"
+    audience.save_and_continue()
+
+    summary_page = SummaryPage(selenium, urljoin(base_url, experiment_slug)).open()
+    summary_page.wait_for_update_request_visible()
+
+    summary_page.request_update_and_approve()
+    kinto_client.reject()
+
+    summary_page.wait_for_rejection_notice_visible()


### PR DESCRIPTION
Because

- We want to have integration tests to cover the new live rollout update workflows

This commit

- Adds integration tests for the following:
   * Live rollout → Edit population % → Request update → Approve in Exp → Approve in RS 
      * The summary page for the experiment should show Live status
   * Live rollout → Edit population % → Request update → Approve in Exp → Reject in RS
      * The summary page for the experiment should show Live status, and the rejection reason from RS
   * Live rollout → Edit population % → Request update → Reject in Exp
      * The summary page for the experiment should show Live status, and the rejection reason


----

This commit _does not_...
- Test whether the "Unpublished changes" status pill is visible in these states. That can be added once #8433 is merged.
  
