### PR TITLE
fixes #8210 feat(nimbus):Added link to metric hub documentation for r…

### DIFF
--- a/experimenter/experimenter/nimbus-ui/src/components/Summary/TableOverview/index.test.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/Summary/TableOverview/index.test.tsx
@@ -60,7 +60,7 @@ describe("TableOverview", () => {
       render(<Subject {...{ experiment }} />);
       expect(
         screen.getByTestId("experiment-outcome-primary"),
-      ).toHaveTextContent("Picture-in-Picture | Feature C");
+      ).toHaveTextContent("Picture-in-Picture , Feature C");
     });
     it("when not set", () => {
       const { experiment } = mockExperimentQuery("demo-slug", {
@@ -103,7 +103,7 @@ describe("TableOverview", () => {
       render(<Subject {...{ experiment }} />);
       expect(
         screen.getByTestId("experiment-outcome-secondary"),
-      ).toHaveTextContent("Picture-in-Picture | Feature B");
+      ).toHaveTextContent("Picture-in-Picture , Feature B");
     });
     it("when not set", () => {
       const { experiment } = mockExperimentQuery("demo-slug", {

--- a/experimenter/experimenter/nimbus-ui/src/components/Summary/TableOverview/index.test.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/Summary/TableOverview/index.test.tsx
@@ -38,6 +38,21 @@ describe("TableOverview", () => {
         screen.getByTestId("experiment-outcome-primary"),
       ).toHaveTextContent("Picture-in-Picture");
     });
+    it("with correct documentation URl", () => {
+      const { experiment } = mockExperimentQuery("demo-slug", {
+        primaryOutcomes: ["picture_in_picture"],
+      });
+      render(<Subject {...{ experiment }} />);
+      expect(
+        screen.getByTestId("primary-outcome-picture_in_picture"),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByTestId("primary-outcome-picture_in_picture"),
+      ).toHaveAttribute(
+        "href",
+        "https://mozilla.github.io/metric-hub/outcomes/firefox_desktop/picture_in_picture",
+      );
+    });
     it("with multiple outcomes", () => {
       const { experiment } = mockExperimentQuery("demo-slug", {
         primaryOutcomes: ["picture_in_picture", "feature_c"],
@@ -45,7 +60,7 @@ describe("TableOverview", () => {
       render(<Subject {...{ experiment }} />);
       expect(
         screen.getByTestId("experiment-outcome-primary"),
-      ).toHaveTextContent("Picture-in-Picture, Feature C");
+      ).toHaveTextContent("Picture-in-Picture | Feature C");
     });
     it("when not set", () => {
       const { experiment } = mockExperimentQuery("demo-slug", {
@@ -66,6 +81,21 @@ describe("TableOverview", () => {
         screen.getByTestId("experiment-outcome-secondary"),
       ).toHaveTextContent("Feature B");
     });
+    it("with correct documentation URl", () => {
+      const { experiment } = mockExperimentQuery("demo-slug", {
+        secondaryOutcomes: ["picture_in_picture"],
+      });
+      render(<Subject {...{ experiment }} />);
+      expect(
+        screen.getByTestId("secondary-outcome-picture_in_picture"),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByTestId("secondary-outcome-picture_in_picture"),
+      ).toHaveAttribute(
+        "href",
+        "https://mozilla.github.io/metric-hub/outcomes/firefox_desktop/picture_in_picture",
+      );
+    });
     it("with multiple outcomes", () => {
       const { experiment } = mockExperimentQuery("demo-slug", {
         secondaryOutcomes: ["picture_in_picture", "feature_b"],
@@ -73,7 +103,7 @@ describe("TableOverview", () => {
       render(<Subject {...{ experiment }} />);
       expect(
         screen.getByTestId("experiment-outcome-secondary"),
-      ).toHaveTextContent("Picture-in-Picture, Feature B");
+      ).toHaveTextContent("Picture-in-Picture | Feature B");
     });
     it("when not set", () => {
       const { experiment } = mockExperimentQuery("demo-slug", {

--- a/experimenter/experimenter/nimbus-ui/src/components/Summary/TableOverview/index.test.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/Summary/TableOverview/index.test.tsx
@@ -60,7 +60,7 @@ describe("TableOverview", () => {
       render(<Subject {...{ experiment }} />);
       expect(
         screen.getByTestId("experiment-outcome-primary"),
-      ).toHaveTextContent("Picture-in-Picture , Feature C");
+      ).toHaveTextContent("Picture-in-Picture, Feature C");
     });
     it("when not set", () => {
       const { experiment } = mockExperimentQuery("demo-slug", {
@@ -103,7 +103,7 @@ describe("TableOverview", () => {
       render(<Subject {...{ experiment }} />);
       expect(
         screen.getByTestId("experiment-outcome-secondary"),
-      ).toHaveTextContent("Picture-in-Picture , Feature B");
+      ).toHaveTextContent("Picture-in-Picture, Feature B");
     });
     it("when not set", () => {
       const { experiment } = mockExperimentQuery("demo-slug", {

--- a/experimenter/experimenter/nimbus-ui/src/components/Summary/TableOverview/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/Summary/TableOverview/index.tsx
@@ -48,7 +48,7 @@ const TableOverview = ({ experiment }: TableOverviewProps) => {
       ))
       .reduce((acc, curr) => (
         <>
-          {acc} | {curr}
+          {acc} , {curr}
         </>
       ));
 
@@ -70,7 +70,7 @@ const TableOverview = ({ experiment }: TableOverviewProps) => {
       ))
       .reduce((acc, curr) => (
         <>
-          {acc} | {curr}
+          {acc} , {curr}
         </>
       ));
 

--- a/experimenter/experimenter/nimbus-ui/src/components/Summary/TableOverview/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/Summary/TableOverview/index.tsx
@@ -30,7 +30,7 @@ const TableOverview = ({ experiment }: TableOverviewProps) => {
     IOS: "firefox_ios",
   };
 
-  const primaryOutcomeLinks =
+  const primaryOutcomeWithLinks =
     primaryOutcomes.length > 0 &&
     primaryOutcomes
       .map((outcome, index) => (
@@ -52,7 +52,7 @@ const TableOverview = ({ experiment }: TableOverviewProps) => {
         </>
       ));
 
-  const secondaryOutcomeLinks =
+  const secondaryOutcomeWithLinks =
     secondaryOutcomes.length > 0 &&
     secondaryOutcomes
       .map((outcome, index) => (
@@ -150,7 +150,7 @@ const TableOverview = ({ experiment }: TableOverviewProps) => {
               <tr>
                 <th>Primary outcomes</th>
                 <td colSpan={3} data-testid="experiment-outcome-primary">
-                  {primaryOutcomeLinks}
+                  {primaryOutcomeWithLinks}
                 </td>
               </tr>
             )}
@@ -158,7 +158,7 @@ const TableOverview = ({ experiment }: TableOverviewProps) => {
               <tr>
                 <th>Secondary outcomes</th>
                 <td colSpan={3} data-testid="experiment-outcome-secondary">
-                  {secondaryOutcomeLinks}
+                  {secondaryOutcomeWithLinks}
                 </td>
               </tr>
             )}

--- a/experimenter/experimenter/nimbus-ui/src/components/Summary/TableOverview/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/Summary/TableOverview/index.tsx
@@ -48,7 +48,7 @@ const TableOverview = ({ experiment }: TableOverviewProps) => {
       ))
       .reduce((acc, curr) => (
         <>
-          {acc} , {curr}
+          {acc}, {curr}
         </>
       ));
 
@@ -70,7 +70,7 @@ const TableOverview = ({ experiment }: TableOverviewProps) => {
       ))
       .reduce((acc, curr) => (
         <>
-          {acc} , {curr}
+          {acc}, {curr}
         </>
       ));
 

--- a/experimenter/experimenter/nimbus-ui/src/components/Summary/TableOverview/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/Summary/TableOverview/index.tsx
@@ -14,11 +14,65 @@ type TableOverviewProps = {
   experiment: getExperiment_experimentBySlug;
 };
 
+interface DocSlugs {
+  [key: string]: string;
+}
+
 // `<tr>`s showing optional fields that are not set are not displayed.
 
 const TableOverview = ({ experiment }: TableOverviewProps) => {
   const { applications } = useConfig();
   const { primaryOutcomes, secondaryOutcomes } = useOutcomes(experiment);
+
+  const docSlugs: DocSlugs = {
+    DESKTOP: "firefox_desktop",
+    FENIX: "fenix",
+    IOS: "firefox_ios",
+  };
+
+  const primaryOutcomeLinks =
+    primaryOutcomes.length > 0 &&
+    primaryOutcomes
+      .map((outcome, index) => (
+        <a
+          key={index}
+          target="_blank"
+          data-testid={`primary-outcome-${outcome?.slug}`}
+          href={`https://mozilla.github.io/metric-hub/outcomes/${
+            docSlugs[outcome?.application ?? ""]
+          }/${outcome?.slug}`}
+          rel="noreferrer"
+        >
+          {outcome?.friendlyName}
+        </a>
+      ))
+      .reduce((acc, curr) => (
+        <>
+          {acc} | {curr}
+        </>
+      ));
+
+  const secondaryOutcomeLinks =
+    secondaryOutcomes.length > 0 &&
+    secondaryOutcomes
+      .map((outcome, index) => (
+        <a
+          key={index}
+          target="_blank"
+          data-testid={`secondary-outcome-${outcome?.slug}`}
+          href={`https://mozilla.github.io/metric-hub/outcomes/${
+            docSlugs[outcome?.application ?? ""]
+          }/${outcome?.slug}`}
+          rel="noreferrer"
+        >
+          {outcome?.friendlyName}
+        </a>
+      ))
+      .reduce((acc, curr) => (
+        <>
+          {acc} | {curr}
+        </>
+      ));
 
   return (
     <Card className="my-4 border-left-0 border-right-0 border-bottom-0">
@@ -96,9 +150,7 @@ const TableOverview = ({ experiment }: TableOverviewProps) => {
               <tr>
                 <th>Primary outcomes</th>
                 <td colSpan={3} data-testid="experiment-outcome-primary">
-                  {primaryOutcomes
-                    .map((outcome) => outcome?.friendlyName)
-                    .join(", ")}
+                  {primaryOutcomeLinks}
                 </td>
               </tr>
             )}
@@ -106,9 +158,7 @@ const TableOverview = ({ experiment }: TableOverviewProps) => {
               <tr>
                 <th>Secondary outcomes</th>
                 <td colSpan={3} data-testid="experiment-outcome-secondary">
-                  {secondaryOutcomes
-                    .map((outcome) => outcome?.friendlyName)
-                    .join(", ")}
+                  {secondaryOutcomeLinks}
                 </td>
               </tr>
             )}


### PR DESCRIPTION
…espective outcomes

Because

- there are now nice auto generated docs for each outcome in metric hub

This commit

- adds links to each outcome, mapping it to its respective documentation in metric hub

[Video demo of the changes made](https://drive.google.com/file/d/1HLsLRKr1CsenhZ-scp13lzUVVTYAE8bV/view)
