### PR TITLE
feat/ Hide the first run checkbox for desktop

### DIFF
--- a/experimenter/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/index.tsx
@@ -342,27 +342,29 @@ export const FormAudience = ({
             <FormErrors name="isSticky" />
           </Form.Group>
         </Form.Row>
-        <Form.Row>
-          <Form.Group as={Col} controlId="isFirstRun">
-            <Form.Check
-              {...formControlAttrs("isFirstRun")}
-              type="checkbox"
-              onChange={(e) => setIsFirstRun(e.target.checked)}
-              checked={isFirstRun}
-              disabled={isFirstRunRequiredWarning || isLocked!}
-              label="First Run Experiment"
-            />
-            {isFirstRunRequiredWarning && (
-              <Alert
-                data-testid="is-first-run-required-warning"
-                variant="warning"
-              >
-                First run is required for this targeting configuration.
-              </Alert>
-            )}
-            <FormErrors name="isFirstRun" />
-          </Form.Group>
-        </Form.Row>
+        {!isDesktop && (
+          <Form.Row>
+            <Form.Group as={Col} controlId="isFirstRun">
+              <Form.Check
+                {...formControlAttrs("isFirstRun")}
+                type="checkbox"
+                onChange={(e) => setIsFirstRun(e.target.checked)}
+                checked={isFirstRun}
+                disabled={isFirstRunRequiredWarning || isLocked!}
+                label="First Run Experiment"
+              />
+              {isFirstRunRequiredWarning && (
+                <Alert
+                  data-testid="is-first-run-required-warning"
+                  variant="warning"
+                >
+                  First run is required for this targeting configuration.
+                </Alert>
+              )}
+              <FormErrors name="isFirstRun" />
+            </Form.Group>
+          </Form.Row>
+        )}
       </Form.Group>
 
       <Form.Group className="bg-light p-4">


### PR DESCRIPTION
To implement this change, I added a conditional statement to check whether the application is desktop or mobile. If the application is desktop, the First Run Experiment checkbox is hidden.

Because

As discussed in the comments, the checkbox only applies to mobile experiments, so it should be hidden altogether for desktop experiments.
This commit

hides the First Run Experiment checkbox for desktop applications to prevent confusion.
I also updated the code to remove any unnecessary CSS changes and to ensure that the checkbox is hidden only for desktop applications.

Please let me know if you have any feedback or suggestions for improvement. Thank you for your time and consideration.

This PR addresses the issue #7843 