### PR TITLE
For #8522 fix(nimbus): Check if approved or waiting for update constants

### DIFF
--- a/experimenter/experimenter/nimbus-ui/src/components/PageSummary/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageSummary/index.tsx
@@ -162,7 +162,11 @@ const PageSummary = (props: RouteComponentProps) => {
         approveChange: onLaunchReviewApprovedClicked,
         ...LIFECYCLE_REVIEW_FLOWS.LAUNCH,
       };
-    } else if (status.updateRequested) {
+    } else if (
+      status.updateRequested ||
+      status.updateRequestedApproved ||
+      status.updateRequestedWaiting
+    ) {
       return {
         rejectChange: onUpdateReviewRejectedClicked,
         approveChange: onUpdateReviewApprovedClicked,


### PR DESCRIPTION
Because

- We were only checking if we went from [Dirty -> Review](https://github.com/mozilla/experimenter/blob/77401cdbf9f12003c1bab39e16fb609604abd705/experimenter/experimenter/nimbus-ui/src/components/PageSummary/index.tsx#L165), [FormRemoteSettingsPending](https://github.com/mozilla/experimenter/blob/77401cdbf9f12003c1bab39e16fb609604abd705/experimenter/experimenter/nimbus-ui/src/components/ChangeApprovalOperations/FormRemoteSettingsPending.tsx#L25) had partial text

This commit

- Adds checks for Review -> Approved and Approved -> Waiting so that we are passing the right constants to the forms

----

before vs after:
<img width="660" alt="image" src="https://user-images.githubusercontent.com/43795363/228915722-72d20949-764a-4fcf-b4e9-a30e3f6686fb.png">

<img width="785" alt="image" src="https://user-images.githubusercontent.com/43795363/228915616-48a206d5-b8dd-4bb3-aa89-94da4d908199.png">

