### PR TITLE
For #8237 fix(nimbus): Disable save buttons when experiment is archived

### DIFF
--- a/experimenter/experimenter/nimbus-ui/src/components/FormOverview/index.test.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/FormOverview/index.test.tsx
@@ -445,6 +445,26 @@ describe("FormOverview", () => {
     });
   });
 
+  it("disables save buttons when archived", async () => {
+    const { experiment } = mockExperimentQuery("hellooooo", {
+      isArchived: true,
+    });
+    const onSubmit = jest.fn();
+    render(<Subject {...{ onSubmit, experiment }} />);
+
+    expect(screen.getByTestId("submit-button")).toBeDisabled();
+    expect(screen.getByTestId("next-button")).toBeDisabled();
+  });
+
+  it("enables save buttons when not archived", async () => {
+    const { experiment } = mockExperimentQuery("hellooooo");
+    const onSubmit = jest.fn();
+    render(<Subject {...{ onSubmit, experiment }} />);
+
+    expect(screen.getByTestId("submit-button")).toBeEnabled();
+    expect(screen.getByTestId("next-button")).toBeEnabled();
+  });
+
   it("displays an alert for overall submit error", async () => {
     const submitErrors = {
       "*": ["Big bad happened"],

--- a/experimenter/experimenter/nimbus-ui/src/components/FormOverview/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/FormOverview/index.tsx
@@ -27,6 +27,7 @@ import {
   REQUIRED_FIELD,
   RISK_QUESTIONS,
 } from "src/lib/constants";
+import { getStatus } from "src/lib/experiment";
 import { optionalBoolString } from "src/lib/utils";
 import { getConfig_nimbusConfig_projects } from "src/types/getConfig";
 import { getExperiment } from "src/types/getExperiment";
@@ -111,6 +112,8 @@ const FormOverview = ({
     fieldMessages,
     fieldWarnings,
   );
+
+  const isArchivedOrComplete = experiment ? (experiment?.isArchived || getStatus(experiment).complete) : false;
 
   const { documentationLinks, addDocumentationLink, removeDocumentationLink } =
     useDocumentationLinks(experiment, control, setValue);
@@ -362,7 +365,7 @@ const FormOverview = ({
                 onClick={handleSaveNext}
                 className="btn btn-secondary"
                 id="save-and-continue-button"
-                disabled={isLoading}
+                disabled={isLoading || isArchivedOrComplete}
                 data-sb-kind="pages/EditBranches"
               >
                 Save and Continue
@@ -376,7 +379,7 @@ const FormOverview = ({
               onClick={handleSave}
               className="btn btn-primary"
               id="submit-button"
-              disabled={isLoading}
+              disabled={isLoading || isArchivedOrComplete}
               data-sb-kind="pages/EditOverview"
             >
               {isLoading ? (

--- a/experimenter/experimenter/nimbus-ui/src/components/FormOverview/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/FormOverview/index.tsx
@@ -27,7 +27,6 @@ import {
   REQUIRED_FIELD,
   RISK_QUESTIONS,
 } from "src/lib/constants";
-import { getStatus } from "src/lib/experiment";
 import { optionalBoolString } from "src/lib/utils";
 import { getConfig_nimbusConfig_projects } from "src/types/getConfig";
 import { getExperiment } from "src/types/getExperiment";
@@ -113,7 +112,8 @@ const FormOverview = ({
     fieldWarnings,
   );
 
-  const isArchivedOrComplete = experiment ? (experiment?.isArchived || getStatus(experiment).complete) : false;
+  const isArchived =
+    experiment?.isArchived != null ? experiment.isArchived : false;
 
   const { documentationLinks, addDocumentationLink, removeDocumentationLink } =
     useDocumentationLinks(experiment, control, setValue);
@@ -365,7 +365,7 @@ const FormOverview = ({
                 onClick={handleSaveNext}
                 className="btn btn-secondary"
                 id="save-and-continue-button"
-                disabled={isLoading || isArchivedOrComplete}
+                disabled={isLoading || isArchived}
                 data-sb-kind="pages/EditBranches"
               >
                 Save and Continue
@@ -379,7 +379,7 @@ const FormOverview = ({
               onClick={handleSave}
               className="btn btn-primary"
               id="submit-button"
-              disabled={isLoading || isArchivedOrComplete}
+              disabled={isLoading || isArchived}
               data-sb-kind="pages/EditOverview"
             >
               {isLoading ? (

--- a/experimenter/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/index.test.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/index.test.tsx
@@ -1363,6 +1363,64 @@ it("enables fields when unlocked", async () => {
   expect(screen.queryByTestId("channel")).toBeEnabled();
 });
 
+it("disables save buttons when archived", async () => {
+  render(
+    <Subject
+      experiment={{
+        ...MOCK_EXPERIMENT,
+        application: NimbusExperimentApplicationEnum.FENIX,
+        isRollout: false,
+        status: NimbusExperimentStatusEnum.DRAFT,
+        targetingConfig: [
+          {
+            label: "No Targeting",
+            value: "",
+            applicationValues: [
+              NimbusExperimentApplicationEnum.DESKTOP,
+              "TOASTER",
+            ],
+            description: "No targeting configuration",
+            stickyRequired: false,
+            isFirstRunRequired: false,
+          },
+        ],
+        isArchived: true,
+      }}
+    />,
+  );
+  expect(screen.getByTestId("submit-button")).toBeDisabled();
+  expect(screen.getByTestId("next-button")).toBeDisabled();
+});
+
+it("enables save buttons when not archived", async () => {
+  render(
+    <Subject
+      experiment={{
+        ...MOCK_EXPERIMENT,
+        application: NimbusExperimentApplicationEnum.FENIX,
+        isRollout: false,
+        status: NimbusExperimentStatusEnum.DRAFT,
+        targetingConfig: [
+          {
+            label: "No Targeting",
+            value: "",
+            applicationValues: [
+              NimbusExperimentApplicationEnum.DESKTOP,
+              "TOASTER",
+            ],
+            description: "No targeting configuration",
+            stickyRequired: false,
+            isFirstRunRequired: false,
+          },
+        ],
+        isArchived: false,
+      }}
+    />,
+  );
+  expect(screen.getByTestId("submit-button")).toBeEnabled();
+  expect(screen.getByTestId("next-button")).toBeEnabled();
+});
+
 describe("filterAndSortTargetingConfigSlug", () => {
   it("filters for experiment application and sorts them as expected", () => {
     const expectedNoTargetingLabel = "No Targeting";

--- a/experimenter/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/index.tsx
@@ -200,7 +200,8 @@ export const FormAudience = ({
     experiment.application === NimbusExperimentApplicationEnum.DESKTOP;
   const isLiveRollout = experiment.isRollout && getStatus(experiment).live;
   const isLocked = isLiveRollout && !getStatus(experiment).draft;
-  const isArchivedOrComplete = experiment.isArchived || getStatus(experiment).complete;
+  const isArchived =
+    experiment?.isArchived != null ? experiment.isArchived : false;
 
   return (
     <Form
@@ -512,11 +513,7 @@ export const FormAudience = ({
             onClick={handleSaveNext}
             className="btn btn-secondary"
             id="save-and-continue-button"
-            disabled={
-              isLoading ||
-              (isLocked! && !isLiveRollout) ||
-              isArchivedOrComplete
-            }
+            disabled={isLoading || (isLocked! && !isLiveRollout) || isArchived}
             data-testid="next-button"
             data-sb-kind="pages/Summary"
           >
@@ -530,7 +527,7 @@ export const FormAudience = ({
             onClick={handleSave}
             className="btn btn-primary"
             id="save-button"
-            disabled={isLoading || (isLocked! && !isLiveRollout) || isArchivedOrComplete}
+            disabled={isLoading || (isLocked! && !isLiveRollout) || isArchived}
             data-sb-kind="pages/EditOverview"
           >
             <span>{isLoading ? "Saving" : "Save"}</span>

--- a/experimenter/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/index.tsx
@@ -200,6 +200,7 @@ export const FormAudience = ({
     experiment.application === NimbusExperimentApplicationEnum.DESKTOP;
   const isLiveRollout = experiment.isRollout && getStatus(experiment).live;
   const isLocked = isLiveRollout && !getStatus(experiment).draft;
+  const isArchivedOrComplete = experiment.isArchived || getStatus(experiment).complete;
 
   return (
     <Form
@@ -511,7 +512,11 @@ export const FormAudience = ({
             onClick={handleSaveNext}
             className="btn btn-secondary"
             id="save-and-continue-button"
-            disabled={isLoading || (isLocked! && !isLiveRollout)}
+            disabled={
+              isLoading ||
+              (isLocked! && !isLiveRollout) ||
+              isArchivedOrComplete
+            }
             data-testid="next-button"
             data-sb-kind="pages/Summary"
           >
@@ -525,7 +530,7 @@ export const FormAudience = ({
             onClick={handleSave}
             className="btn btn-primary"
             id="save-button"
-            disabled={isLoading || (isLocked! && !isLiveRollout)}
+            disabled={isLoading || (isLocked! && !isLiveRollout) || isArchivedOrComplete}
             data-sb-kind="pages/EditOverview"
           >
             <span>{isLoading ? "Saving" : "Save"}</span>

--- a/experimenter/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/index.test.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/index.test.tsx
@@ -558,6 +558,47 @@ describe("FormBranches", () => {
     });
   });
 
+  it("disables save buttons when archived", async () => {
+    const onSave = jest.fn();
+    render(
+      <SubjectBranches
+        {...{
+          onSave,
+          experiment: {
+            ...MOCK_EXPERIMENT,
+            referenceBranch: {
+              ...MOCK_EXPERIMENT.referenceBranch!,
+              screenshots: [],
+            },
+            isArchived: true,
+          },
+        }}
+      />,
+    );
+    expect(screen.getByTestId("save-button")).toBeDisabled();
+    expect(screen.getByTestId("next-button")).toBeDisabled();
+  });
+
+  it("enables save buttons when not archived", async () => {
+    const onSave = jest.fn();
+    render(
+      <SubjectBranches
+        {...{
+          onSave,
+          experiment: {
+            ...MOCK_EXPERIMENT,
+            referenceBranch: {
+              ...MOCK_EXPERIMENT.referenceBranch!,
+              screenshots: [],
+            },
+          },
+        }}
+      />,
+    );
+    expect(screen.getByTestId("save-button")).toBeEnabled();
+    expect(screen.getByTestId("next-button")).toBeEnabled();
+  });
+
   describe("preventPrefConflicts checkbox", () => {
     it("doesn't render if no feature config set", () => {
       render(

--- a/experimenter/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/index.tsx
@@ -19,6 +19,7 @@ import { FormBranchesState } from "src/components/PageEditBranches/FormBranches/
 import { FormData } from "src/components/PageEditBranches/FormBranches/reducer/update";
 import { useExitWarning, useForm, useReviewCheck } from "src/hooks";
 import { IsDirtyUnsaved } from "src/hooks/useCommonForm/useCommonFormMethods";
+import { getStatus } from "src/lib/experiment";
 import { getConfig_nimbusConfig } from "src/types/getConfig";
 import { getExperiment_experimentBySlug } from "src/types/getExperiment";
 import { NimbusExperimentApplicationEnum } from "src/types/globalTypes";
@@ -231,6 +232,8 @@ export const FormBranches = ({
     experimentFeatureConfigIds &&
     doFeaturesSetPrefs(experimentFeatureConfigIds);
 
+  const isArchivedOrComplete = experiment.isArchived || getStatus(experiment).complete;
+  
   return (
     <FormProvider {...formMethods}>
       <Form
@@ -442,7 +445,7 @@ export const FormBranches = ({
               data-testid="next-button"
               className="btn btn-secondary"
               id="save-and-continue-button"
-              disabled={isNextDisabled}
+              disabled={isNextDisabled || isArchivedOrComplete}
               onClick={handleSaveNext}
             >
               Save and Continue
@@ -454,7 +457,7 @@ export const FormBranches = ({
               type="submit"
               className="btn btn-primary"
               id="save-button"
-              disabled={isSaveDisabled}
+              disabled={isSaveDisabled || isArchivedOrComplete}
               onClick={handleSave}
             >
               <span>{isLoading ? "Saving" : "Save"}</span>

--- a/experimenter/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/index.tsx
@@ -19,7 +19,6 @@ import { FormBranchesState } from "src/components/PageEditBranches/FormBranches/
 import { FormData } from "src/components/PageEditBranches/FormBranches/reducer/update";
 import { useExitWarning, useForm, useReviewCheck } from "src/hooks";
 import { IsDirtyUnsaved } from "src/hooks/useCommonForm/useCommonFormMethods";
-import { getStatus } from "src/lib/experiment";
 import { getConfig_nimbusConfig } from "src/types/getConfig";
 import { getExperiment_experimentBySlug } from "src/types/getExperiment";
 import { NimbusExperimentApplicationEnum } from "src/types/globalTypes";
@@ -232,8 +231,9 @@ export const FormBranches = ({
     experimentFeatureConfigIds &&
     doFeaturesSetPrefs(experimentFeatureConfigIds);
 
-  const isArchivedOrComplete = experiment.isArchived || getStatus(experiment).complete;
-  
+  const isArchived =
+    experiment?.isArchived != null ? experiment.isArchived : false;
+
   return (
     <FormProvider {...formMethods}>
       <Form
@@ -445,7 +445,7 @@ export const FormBranches = ({
               data-testid="next-button"
               className="btn btn-secondary"
               id="save-and-continue-button"
-              disabled={isNextDisabled || isArchivedOrComplete}
+              disabled={isNextDisabled || isArchived}
               onClick={handleSaveNext}
             >
               Save and Continue
@@ -457,7 +457,7 @@ export const FormBranches = ({
               type="submit"
               className="btn btn-primary"
               id="save-button"
-              disabled={isSaveDisabled || isArchivedOrComplete}
+              disabled={isSaveDisabled || isArchived}
               onClick={handleSave}
             >
               <span>{isLoading ? "Saving" : "Save"}</span>

--- a/experimenter/experimenter/nimbus-ui/src/components/PageEditMetrics/FormMetrics/index.test.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageEditMetrics/FormMetrics/index.test.tsx
@@ -68,6 +68,26 @@ describe("FormMetrics", () => {
     expect(onSave).not.toHaveBeenCalled();
   });
 
+  it("disables save buttons when archived", async () => {
+    const { experiment } = mockExperimentQuery("helloooo", {
+      isArchived: true,
+    });
+    const onSave = jest.fn();
+    render(<Subject {...{ onSave, experiment }} />);
+
+    expect(screen.getByTestId("submit-button")).toBeDisabled();
+    expect(screen.getByTestId("next-button")).toBeDisabled();
+  });
+
+  it("enables save buttons when not archived", async () => {
+    const { experiment } = mockExperimentQuery("helloooo");
+    const onSave = jest.fn();
+    render(<Subject {...{ onSave, experiment }} />);
+
+    expect(screen.getByTestId("submit-button")).toBeEnabled();
+    expect(screen.getByTestId("next-button")).toBeEnabled();
+  });
+
   it("displays saving button when loading", async () => {
     const { experiment } = mockExperimentQuery("boo");
     const onSave = jest.fn();

--- a/experimenter/experimenter/nimbus-ui/src/components/PageEditMetrics/FormMetrics/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageEditMetrics/FormMetrics/index.tsx
@@ -16,7 +16,6 @@ import {
 } from "src/hooks";
 import { SelectOption } from "src/hooks/useCommonForm/useCommonFormMethods";
 import { ReactComponent as Info } from "src/images/info.svg";
-import { getStatus } from "src/lib/experiment";
 import { getConfig_nimbusConfig_outcomes } from "src/types/getConfig";
 import { getExperiment } from "src/types/getExperiment";
 
@@ -129,7 +128,8 @@ const FormMetrics = ({
     [isLoading, onSave, handleSubmit, primaryOutcomes, secondaryOutcomes],
   );
 
-  const isArchivedOrComplete = experiment ? (experiment?.isArchived || getStatus(experiment).complete) : false;
+  const isArchived =
+    experiment?.isArchived != null ? experiment.isArchived : false;
 
   return (
     <Form
@@ -202,7 +202,7 @@ const FormMetrics = ({
             data-testid="next-button"
             id="save-and-continue-button"
             className="btn btn-secondary"
-            disabled={isLoading || isArchivedOrComplete}
+            disabled={isLoading || isArchived}
             data-sb-kind="pages/EditMetrics"
           >
             Save and Continue
@@ -215,7 +215,7 @@ const FormMetrics = ({
             onClick={handleSave}
             className="btn btn-primary"
             id="save-button"
-            disabled={isLoading || isArchivedOrComplete}
+            disabled={isLoading || isArchived}
             data-sb-kind="pages/EditMetrics"
           >
             {isLoading ? <span>Saving</span> : <span>Save</span>}

--- a/experimenter/experimenter/nimbus-ui/src/components/PageEditMetrics/FormMetrics/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageEditMetrics/FormMetrics/index.tsx
@@ -16,6 +16,7 @@ import {
 } from "src/hooks";
 import { SelectOption } from "src/hooks/useCommonForm/useCommonFormMethods";
 import { ReactComponent as Info } from "src/images/info.svg";
+import { getStatus } from "src/lib/experiment";
 import { getConfig_nimbusConfig_outcomes } from "src/types/getConfig";
 import { getExperiment } from "src/types/getExperiment";
 
@@ -128,6 +129,8 @@ const FormMetrics = ({
     [isLoading, onSave, handleSubmit, primaryOutcomes, secondaryOutcomes],
   );
 
+  const isArchivedOrComplete = experiment ? (experiment?.isArchived || getStatus(experiment).complete) : false;
+
   return (
     <Form
       noValidate
@@ -199,7 +202,7 @@ const FormMetrics = ({
             data-testid="next-button"
             id="save-and-continue-button"
             className="btn btn-secondary"
-            disabled={isLoading}
+            disabled={isLoading || isArchivedOrComplete}
             data-sb-kind="pages/EditMetrics"
           >
             Save and Continue
@@ -212,7 +215,7 @@ const FormMetrics = ({
             onClick={handleSave}
             className="btn btn-primary"
             id="save-button"
-            disabled={isLoading}
+            disabled={isLoading || isArchivedOrComplete}
             data-sb-kind="pages/EditMetrics"
           >
             {isLoading ? <span>Saving</span> : <span>Save</span>}


### PR DESCRIPTION
Because

- Archived experiments aren't disabling the save buttons

This commit

- Disables the save buttons on the Overview, Branches, Audience, and Metrics pages when an experiment is archived


https://user-images.githubusercontent.com/43795363/228928512-4a3a9041-92cc-4e6a-98b3-c6346bb2625a.mov


