### PR TITLE
#8604  docs(nimbus): Update documentation to include how to update fork with main

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,18 +60,6 @@ Check out the [🌩 **Nimbus Documentation Hub**](https://experimenter.info) or 
 
         git clone <your fork>
 
-1.  Go to your cloned directory and add the main repository as your upstream
-
-        git remote add upstream  https://github.com/mozilla/experimenter
-
-1.  Fetch the latest changes from the main repository
-
-        git fetch upstream
-
-1.  Merge the changes from the main repository into your forked branch
-
-        git merge upstream/main
-
 1.  Copy the sample env file
 
         cp .env.sample .env

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Check out the [🌩 **Nimbus Documentation Hub**](https://experimenter.info) or 
 
         git clone <your fork>
 
-1.  Go to your cloned directory and add main the main repository as your upstream
+1.  Go to your cloned directory and add the main repository as your upstream
 
         git remote add upstream  https://github.com/mozilla/experimenter
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,18 @@ Check out the [🌩 **Nimbus Documentation Hub**](https://experimenter.info) or 
 
         git clone <your fork>
 
+1.  Go to your cloned directory and add main the main repository as your upstream
+
+        git remote add upstream  https://github.com/mozilla/experimenter
+
+1.  Fetch the latest changes from the main repository
+
+        git fetch upstream
+
+1.  Merge the changes from the main repository into your forked branch
+
+        git merge upstream/main
+
 1.  Copy the sample env file
 
         cp .env.sample .env

--- a/contributing.md
+++ b/contributing.md
@@ -206,10 +206,10 @@ Because all changes will go to stage and prod automatically, you can use stage t
 
         git remote add upstream  https://github.com/mozilla/experimenter
 
-1.  Fetch the latest changes from the main repository
+2.  Fetch the latest changes from the main repository
 
         git fetch upstream
 
-1.  Merge the changes from the main repository into your forked branch
+3.  Merge the changes from the main repository into your forked branch
 
         git merge upstream/main

--- a/contributing.md
+++ b/contributing.md
@@ -199,3 +199,17 @@ If the deployment succeeds but the change inadvertently breaks stage/production,
 - Fix the change following the normal issue/PR processes above
 
 Because all changes will go to stage and prod automatically, you can use stage to validate your changes.
+
+## Updating an existing fork
+
+1.  Go to your cloned directory and add the main repository as your upstream
+
+        git remote add upstream  https://github.com/mozilla/experimenter
+
+1.  Fetch the latest changes from the main repository
+
+        git fetch upstream
+
+1.  Merge the changes from the main repository into your forked branch
+
+        git merge upstream/main


### PR DESCRIPTION
Because

- We have not specified how to updat the fork with changes on the main branch

This commit

- Updates the read me with how to add an upstream remote
- Updates the read me to include how to update the fork with the latest changes on the main repository.
