### PR TITLE
fix #8624 fix(nimbus): clarify meaning of confusing control branch error

### DIFF
--- a/experimenter/experimenter/nimbus-ui/src/components/PageResults/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageResults/index.tsx
@@ -100,7 +100,8 @@ const PageResults: React.FunctionComponent<RouteComponentProps> = () => {
         errors={[
           {
             metric: null,
-            message: "No control branch found in analysis results.",
+            message:
+              "No control branch found in analysis results. Usually this error indicates that results are not available yet.",
             filename: null,
             exception: null,
             func_name: null,


### PR DESCRIPTION
Because

- this error message causes confusion

This commit

- explains the usual cause for the error
