### PR TITLE
fixes (#8254) Filters have no effect when applied before the experiment loads

### DIFF
--- a/experimenter/experimenter/nimbus-ui/src/components/PageHome/FilterBar/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageHome/FilterBar/index.tsx
@@ -6,6 +6,7 @@ import React, { useMemo } from "react";
 import Nav from "react-bootstrap/Nav";
 import Navbar from "react-bootstrap/Navbar";
 import Select, { OptionsType, OptionTypeBase } from "react-select";
+import { GET_EXPERIMENTS_QUERY } from "src/gql/experiments";
 import { optionIndexKeys } from "src/components/PageHome/filterExperiments";
 import {
   FilterOptions,
@@ -16,6 +17,8 @@ import {
 } from "src/components/PageHome/types";
 import { displayConfigLabelOrNotSet } from "src/components/Summary";
 import { useConfig } from "src/hooks";
+import { useQuery } from "@apollo/client";
+import { getAllExperiments_experiments } from "src/types/getAllExperiments";
 
 export type FilterBarProps = {
   options: FilterOptions;
@@ -28,6 +31,7 @@ export const FilterBar: React.FC<FilterBarProps> = ({
   value: filterValue,
   onChange,
 }) => {
+    
   return (
     <Navbar
       variant="light"
@@ -130,7 +134,10 @@ const FilterSelect = <
 
   const fieldValue = filterValue[filterValueName];
   const { applications } = useConfig();
-
+  const { loading} = useQuery<{
+    experiments: getAllExperiments_experiments[];
+  }>(GET_EXPERIMENTS_QUERY, { fetchPolicy: "network-only" });
+  console.log(loading);
   return (
     <Nav.Item className="mb-2 text-left flex-basis-0 flex-grow-1 flex-shrink-1 w-100">
       <Select
@@ -139,6 +146,7 @@ const FilterSelect = <
           inputId: `filter-${filterValueName}`,
           isMulti: true,
           value: fieldValue,
+          isDisabled:loading,
           placeholder: "All " + fieldLabel + "s",
           getOptionLabel: (item: OptionTypeBase) =>
             fieldLabel === "Feature"

--- a/experimenter/experimenter/nimbus-ui/src/components/PageHome/FilterBar/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageHome/FilterBar/index.tsx
@@ -2,11 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import { useQuery } from "@apollo/client";
 import React, { useMemo } from "react";
 import Nav from "react-bootstrap/Nav";
 import Navbar from "react-bootstrap/Navbar";
 import Select, { OptionsType, OptionTypeBase } from "react-select";
-import { GET_EXPERIMENTS_QUERY } from "src/gql/experiments";
 import { optionIndexKeys } from "src/components/PageHome/filterExperiments";
 import {
   FilterOptions,
@@ -16,8 +16,8 @@ import {
   NonNullFilterOptions,
 } from "src/components/PageHome/types";
 import { displayConfigLabelOrNotSet } from "src/components/Summary";
+import { GET_EXPERIMENTS_QUERY } from "src/gql/experiments";
 import { useConfig } from "src/hooks";
-import { useQuery } from "@apollo/client";
 import { getAllExperiments_experiments } from "src/types/getAllExperiments";
 
 export type FilterBarProps = {
@@ -31,7 +31,6 @@ export const FilterBar: React.FC<FilterBarProps> = ({
   value: filterValue,
   onChange,
 }) => {
-    
   return (
     <Navbar
       variant="light"
@@ -134,7 +133,7 @@ const FilterSelect = <
 
   const fieldValue = filterValue[filterValueName];
   const { applications } = useConfig();
-  const { loading} = useQuery<{
+  const { loading } = useQuery<{
     experiments: getAllExperiments_experiments[];
   }>(GET_EXPERIMENTS_QUERY, { fetchPolicy: "network-only" });
   console.log(loading);
@@ -146,7 +145,7 @@ const FilterSelect = <
           inputId: `filter-${filterValueName}`,
           isMulti: true,
           value: fieldValue,
-          isDisabled:loading,
+          isDisabled: loading,
           placeholder: "All " + fieldLabel + "s",
           getOptionLabel: (item: OptionTypeBase) =>
             fieldLabel === "Feature"

--- a/experimenter/experimenter/nimbus-ui/src/components/PageHome/FilterBar/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageHome/FilterBar/index.tsx
@@ -136,7 +136,6 @@ const FilterSelect = <
   const { loading } = useQuery<{
     experiments: getAllExperiments_experiments[];
   }>(GET_EXPERIMENTS_QUERY, { fetchPolicy: "network-only" });
-  console.log(loading);
   return (
     <Nav.Item className="mb-2 text-left flex-basis-0 flex-grow-1 flex-shrink-1 w-100">
       <Select


### PR DESCRIPTION
### Because
-  Filters have no effect when applied before the experiment loads
### This commit
- Disabled the filters untill the all the experiments loads which resloves this issue 
- Fixes #8254 
### Screenshots
![Screenshot from 2023-04-01 22-00-35](https://user-images.githubusercontent.com/88829894/229304289-0c294265-a535-4e54-9bd9-b02e0a472b7d.png)
- As you can see the filters are disabled untill the experiments loads and gets enabled after loaded