### PR TITLE
fixes (#8634) Green check merging with input arrow

### DIFF
--- a/experimenter/experimenter/nimbus-ui/src/components/FormOverview/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/FormOverview/index.tsx
@@ -224,7 +224,7 @@ const FormOverview = ({
             <Form.Control
               {...formControlAttrs("application", REQUIRED_FIELD)}
               as="select"
-              className="custom-select"
+              custom
             >
               <option value="">Select...</option>
               {applications!.map((app, idx) => (

--- a/experimenter/experimenter/nimbus-ui/src/components/FormOverview/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/FormOverview/index.tsx
@@ -224,6 +224,7 @@ const FormOverview = ({
             <Form.Control
               {...formControlAttrs("application", REQUIRED_FIELD)}
               as="select"
+              className="custom-select"
             >
               <option value="">Select...</option>
               {applications!.map((app, idx) => (

--- a/experimenter/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/index.tsx
@@ -268,8 +268,8 @@ export const FormBranches = ({
                   fieldMessages.feature_config?.length > 0 ||
                   fieldWarnings.feature_config?.length > 0,
               },
-              "custom-select",
             )}
+            custom
             onChange={onFeatureConfigChange}
             value={
               experimentFeatureConfigIds?.length

--- a/experimenter/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/index.tsx
@@ -262,13 +262,11 @@ export const FormBranches = ({
             data-testid="feature-config-select"
             // Displaying the review-readiness error is handled here instead of `formControlAttrs`
             // due to a state conflict between `react-hook-form` and our internal branch state mangement
-            className={classNames(
-              {
-                "is-warning":
-                  fieldMessages.feature_config?.length > 0 ||
-                  fieldWarnings.feature_config?.length > 0,
-              },
-            )}
+            className={classNames({
+              "is-warning":
+                fieldMessages.feature_config?.length > 0 ||
+                fieldWarnings.feature_config?.length > 0,
+            })}
             custom
             onChange={onFeatureConfigChange}
             value={

--- a/experimenter/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/index.tsx
@@ -262,11 +262,14 @@ export const FormBranches = ({
             data-testid="feature-config-select"
             // Displaying the review-readiness error is handled here instead of `formControlAttrs`
             // due to a state conflict between `react-hook-form` and our internal branch state mangement
-            className={classNames({
-              "is-warning":
-                fieldMessages.feature_config?.length > 0 ||
-                fieldWarnings.feature_config?.length > 0,
-            })}
+            className={classNames(
+              {
+                "is-warning":
+                  fieldMessages.feature_config?.length > 0 ||
+                  fieldWarnings.feature_config?.length > 0,
+              },
+              "custom-select",
+            )}
             onChange={onFeatureConfigChange}
             value={
               experimentFeatureConfigIds?.length


### PR DESCRIPTION
### Because
 Green check merging with input arrow

### This commit
- Added respective classes to rectify this issue 

### Screenshots

![Screenshot from 2023-04-02 22-30-57](
https://user-images.githubusercontent.com/88829894/229367758-0e696303-619b-45d7-b757-b18f3655c747.png)


![Screenshot from 2023-04-02 22-31-15](https://user-images.githubusercontent.com/88829894/229367764-119ef192-df33-4cc7-8b8e-54da2c9928f1.png)
