### PR TITLE
Bar local history

### DIFF
--- a/experimenter/experimenter/nimbus-ui/src/components/AppLayoutSidebarLaunched/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/AppLayoutSidebarLaunched/index.tsx
@@ -181,6 +181,7 @@ export const AppLayoutSidebarLaunched = ({
               <LinkNav
                 className="mb-3 small font-weight-bold"
                 textColor="text-secondary"
+                route = {localStorage.getItem("nimbus-ui-search") ?? undefined}
               >
                 <ChevronLeft className="ml-n1" width="18" height="18" />
                 Back to Experiments

--- a/experimenter/experimenter/nimbus-ui/src/components/PageHome/SearchBar/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageHome/SearchBar/index.tsx
@@ -47,6 +47,11 @@ const SearchBar: React.FunctionComponent<SearchBarProps> = ({
   const fuse = new Fuse(experiments, options, myIndex);
   const [searchTerms, setSearchTerms] = React.useState("");
   const [clearIcon, setClearIcon] = React.useState(false);
+  const resetWindowLocation = () => {
+      const url = new URL(`${window.location}`);
+      url.searchParams.delete("search");
+      window.history.pushState({}, "", `${url.origin + url.pathname}`);
+  }
   const handleClick = () => {
     setSearchTerms("");
     setClearIcon(false);


### PR DESCRIPTION
Store Search result #8499 

Issue:
Search Bar in nimbus UI was not storing search data after **resetting** **window**.
There was no data structure or **local storge** initialized with it to store the search bar history in local storage.

Commit : 
1. Initailised a route to a local storage on line number (184)  "experimenter\experimenter\experimenter\nimbus-ui\src\components\AppLayoutSidebarLaunched\index.tsx"

2.Pushed URL State and URL parameter into local storage on line number (50 - 54) "experimenter\experimenter\experimenter\nimbus-ui\src\components\PageHome\SearchBar\index.tsx"

Changes :
1. Setup a route and intialised a local storage with it to store the search history data. So that it stores data of previous search.
3. Pushed the url state and url params into local storage.
