### PR TITLE
fixes #8499 fix(nimbus): Revert retain and display search result when `back to experiment` button is clicked"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,9 +75,6 @@ target/
 # VS Code
 **/.vscode/*
 
-# WebStorm
-**/.idea/*
-
 # Hosted assets
 experimenter/experimenter/served/
 experimenter/experimenter/legacy/legacy-ui/assets/

--- a/experimenter/experimenter/nimbus-ui/src/components/PageHome/SearchBar/index.test.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageHome/SearchBar/index.test.tsx
@@ -39,55 +39,6 @@ describe("SearchBar", () => {
       expect(searchInput).toHaveValue("");
     });
   });
-
-  it("updates the component when search values are saved in localStorage", async () => {
-    // Mock localStorage to return a particular value
-    jest.spyOn(Storage.prototype, "getItem").mockImplementation((key) => {
-      return JSON.stringify({
-        searchValue: "Experiment",
-        results: [{ item: "Saved experiment details" }],
-      });
-    });
-
-    const onChange = jest.fn();
-    render(<Subject experiments={[]} onChange={onChange} />);
-
-    // wait for useEffect to complete
-    await waitFor(() => {
-      // check that the component has updated with the values from localStorage
-      const searchInput = screen.getByTestId("SearchExperiments");
-      expect(searchInput).toBeInTheDocument();
-      expect(searchInput).toHaveValue("Experiment");
-      expect(onChange).toHaveBeenCalledWith(["Saved experiment details"]);
-      const clear = screen.getByTestId("ClearSearchExperiments");
-      expect(clear).toBeInTheDocument();
-    });
-  });
-
-  it("ensure localstorage is cleared when searchbar is emptied", async () => {
-    const onChange = jest.fn();
-    const setClearIcon = jest.fn();
-    const localStorageMock = jest.spyOn(Storage.prototype, "removeItem");
-    render(<Subject experiments={[]} onChange={onChange} />);
-
-    const searchInput = screen.getByTestId("SearchExperiments");
-
-    // once user type something and users backspace, Icon would be set to false
-    userEvent.type(searchInput, "a");
-
-    // Use backspace to clear input
-    userEvent.type(searchInput, "{backspace}");
-    await waitFor(() => {
-      expect(searchInput).toHaveValue("");
-    });
-
-    await (async () => {
-      await new Promise((resolve) => setTimeout(resolve, 0)); // Wait for state update to be processed
-      expect(onChange).toHaveBeenCalledWith([]);
-      expect(setClearIcon).toHaveBeenCalledWith(false);
-      expect(localStorageMock).toHaveBeenCalledWith("nimbus-ui-search");
-    });
-  });
 });
 
 const Subject = ({

--- a/experimenter/experimenter/nimbus-ui/src/components/PageHome/SearchBar/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageHome/SearchBar/index.tsx
@@ -51,37 +51,9 @@ const SearchBar: React.FunctionComponent<SearchBarProps> = ({
     setSearchTerms("");
     setClearIcon(false);
     onChange(experiments);
-
-    // clear stored search value
-    localStorage.removeItem("nimbus-ui-search");
   };
 
   const [timer, setTimer] = React.useState<NodeJS.Timeout | null>(null);
-
-  React.useEffect(() => {
-    let isMounted = true;
-    setTimeout(() => {
-      // get search term from localStorage
-      let fetchedValues = localStorage.getItem("nimbus-ui-search");
-      if (fetchedValues !== null) {
-        fetchedValues = JSON.parse(fetchedValues);
-        const searchValue = (fetchedValues as any)["searchValue"] as string;
-        const results = (fetchedValues as any)["results"] as any[];
-        const searchResults = results.map((character) => character.item);
-
-        // Update components
-        if (isMounted) {
-          onChange(searchResults);
-          setSearchTerms(searchValue);
-          setClearIcon(true);
-        }
-      }
-    }, 300);
-    // Clean-up:
-    return () => {
-      isMounted = false;
-    };
-  }, [onChange]);
 
   const handleChange = (event: {
     target: { value: React.SetStateAction<string> };
@@ -91,7 +63,6 @@ const SearchBar: React.FunctionComponent<SearchBarProps> = ({
       clearTimeout(timer);
     }
     if (event.target.value) {
-      const searchValue = event.target.value as string;
       setClearIcon(true);
 
       const newTimer = setTimeout(() => {
@@ -108,22 +79,12 @@ const SearchBar: React.FunctionComponent<SearchBarProps> = ({
 
         const searchResults = results.map((character) => character.item);
         onChange(searchResults);
-
-        // Store search query and results
-        if (results.length > 0) {
-          const nimbusResults = { searchValue, results };
-          localStorage.setItem(
-            "nimbus-ui-search",
-            JSON.stringify(nimbusResults),
-          );
-        }
       }, 700);
 
       setTimer(newTimer);
     } else {
       setClearIcon(false);
       onChange(experiments);
-      localStorage.removeItem("nimbus-ui-search");
     }
   };
 


### PR DESCRIPTION
Because
- We got this error on sentry- https://github.com/mozilla/experimenter/issues/8646

This Commit
- Reverts this pr - https://github.com/mozilla/experimenter/pull/8630