### PR TITLE
fix #8650 bug(nimbus): use computed enrollment end date on landing page

### DIFF
--- a/experimenter/experimenter/experiments/api/v5/types.py
+++ b/experimenter/experimenter/experiments/api/v5/types.py
@@ -435,6 +435,7 @@ class NimbusExperimentType(DjangoObjectType):
     computed_duration_days = graphene.Int()
     computed_end_date = graphene.DateTime()
     computed_enrollment_days = graphene.Int()
+    computed_enrollment_end_date = graphene.DateTime()
     conclusion_recommendation = graphene.Field(
         NimbusExperimentConclusionRecommendationEnum
     )
@@ -500,6 +501,7 @@ class NimbusExperimentType(DjangoObjectType):
             "computed_duration_days",
             "computed_end_date",
             "computed_enrollment_days",
+            "computed_enrollment_end_date",
             "conclusion_recommendation",
             "countries",
             "documentation_links",

--- a/experimenter/experimenter/experiments/tests/api/v5/test_queries.py
+++ b/experimenter/experimenter/experiments/tests/api/v5/test_queries.py
@@ -90,6 +90,7 @@ class TestNimbusExperimentsQuery(GraphQLTestCase):
                     proposedDuration
                     proposedEnrollment
                     computedEndDate
+                    computedEnrollmentEndDate
                     status
                     statusNext
                     publishStatus
@@ -126,6 +127,11 @@ class TestNimbusExperimentsQuery(GraphQLTestCase):
                 "computedEndDate": (
                     str(experiment.computed_end_date)
                     if experiment.computed_end_date is not None
+                    else None
+                ),
+                "computedEnrollmentEndDate": (
+                    str(experiment.computed_enrollment_end_date)
+                    if experiment.computed_enrollment_end_date is not None
                     else None
                 ),
                 "featureConfig": {
@@ -736,9 +742,10 @@ class TestNimbusExperimentBySlugQuery(GraphQLTestCase):
                     }
 
                     startDate
+                    computedDurationDays
                     computedEndDate
                     computedEnrollmentDays
-                    computedDurationDays
+                    computedEnrollmentEndDate
 
                     riskMitigationLink
                     riskRevenue
@@ -827,6 +834,11 @@ class TestNimbusExperimentBySlugQuery(GraphQLTestCase):
                     else None
                 ),
                 "computedEnrollmentDays": experiment.computed_enrollment_days,
+                "computedEnrollmentEndDate": (
+                    str(experiment.computed_enrollment_end_date)
+                    if experiment.computed_enrollment_end_date
+                    else None
+                ),
                 "conclusionRecommendation": experiment.conclusion_recommendation,
                 "countries": [{"id": str(country.id), "name": country.name}],
                 "documentationLinks": [

--- a/experimenter/experimenter/nimbus-ui/schema.graphql
+++ b/experimenter/experimenter/nimbus-ui/schema.graphql
@@ -58,6 +58,7 @@ type NimbusExperimentType {
   computedDurationDays: Int
   computedEndDate: DateTime
   computedEnrollmentDays: Int
+  computedEnrollmentEndDate: DateTime
   enrollmentEndDate: DateTime
   featureConfig: NimbusFeatureConfigType
   isEnrollmentPausePending: Boolean

--- a/experimenter/experimenter/nimbus-ui/src/gql/experiments.ts
+++ b/experimenter/experimenter/nimbus-ui/src/gql/experiments.ts
@@ -131,9 +131,10 @@ export const GET_EXPERIMENT_QUERY = gql`
       }
 
       startDate
+      computedDurationDays
       computedEndDate
       computedEnrollmentDays
-      computedDurationDays
+      computedEnrollmentEndDate
 
       riskMitigationLink
       riskRevenue
@@ -238,6 +239,7 @@ export const GET_EXPERIMENTS_QUERY = gql`
       proposedDuration
       proposedEnrollment
       computedEndDate
+      computedEnrollmentEndDate
       status
       statusNext
       publishStatus

--- a/experimenter/experimenter/nimbus-ui/src/lib/dateUtils.test.ts
+++ b/experimenter/experimenter/nimbus-ui/src/lib/dateUtils.test.ts
@@ -2,14 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import {
-  addDaysToDate,
-  getProposedEnrollmentRange,
-  humanDate,
-} from "src/lib/dateUtils";
+import { getProposedEnrollmentRange, humanDate } from "src/lib/dateUtils";
 import { mockSingleDirectoryExperiment as expFactory } from "src/lib/mocks";
 
 const FAKE_DATE = "Sat Dec 12 2020";
+const FAKE_DATE_2 = "Mon Dec 14 2020";
 const FAKE_ISO_DATE = "2020-12-25T15:28:01.821657+00:00";
 
 describe("humanDate", () => {
@@ -24,21 +21,15 @@ describe("humanDate", () => {
   });
 });
 
-describe("addDaysToDate", () => {
-  it("should add days to a date and return a date string", () => {
-    expect(addDaysToDate(FAKE_DATE, 2)).toEqual("Mon Dec 14 2020");
-  });
-});
-
 describe("getProposedEnrollmentRange", () => {
   it("should render a date range if startDate and proposedEnrollment are set", () => {
     const actual = getProposedEnrollmentRange(
       expFactory({
         startDate: FAKE_DATE,
-        proposedEnrollment: 4,
+        computedEnrollmentEndDate: FAKE_DATE_2,
       }),
     );
-    expect(actual).toBe("Dec 12, 2020 - Dec 16, 2020");
+    expect(actual).toBe("Dec 12, 2020 - Dec 14, 2020");
   });
   it("should render the enrollment duration if no startDate is set", () => {
     const actual = getProposedEnrollmentRange(

--- a/experimenter/experimenter/nimbus-ui/src/lib/dateUtils.ts
+++ b/experimenter/experimenter/nimbus-ui/src/lib/dateUtils.ts
@@ -24,12 +24,6 @@ export function humanDate(date: string): string {
   return parsedDate.toLocaleString("en-US", options);
 }
 
-export function addDaysToDate(datestring: string, days: number): string {
-  const date = new Date(datestring);
-  date.setDate(date.getDate() + days);
-  return date.toDateString();
-}
-
 /**
  *  Renders period of enrollment depend on what's available
  *  If startDate is set, it will return a range of dates
@@ -40,11 +34,10 @@ export function addDaysToDate(datestring: string, days: number): string {
 export function getProposedEnrollmentRange(
   experiment: getExperiment_experimentBySlug | getAllExperiments_experiments,
 ): string {
-  const { startDate, proposedEnrollment } = experiment;
-  if (startDate) {
-    return `${humanDate(startDate)} - ${humanDate(
-      addDaysToDate(startDate, proposedEnrollment),
-    )}`;
+  const { startDate, computedEnrollmentEndDate, proposedEnrollment } =
+    experiment;
+  if (startDate && computedEnrollmentEndDate) {
+    return `${humanDate(startDate)} - ${humanDate(computedEnrollmentEndDate)}`;
   } else {
     return pluralize(proposedEnrollment, "day");
   }

--- a/experimenter/experimenter/nimbus-ui/src/lib/mocks.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/lib/mocks.tsx
@@ -837,6 +837,7 @@ export function mockSingleDirectoryExperiment(
   const now = Date.now();
   const oneDay = 1000 * 60 * 60 * 24;
   const startTime = now - oneDay * 60 - 21 * oneDay * Math.random();
+  const enrollmentEndTime = now - oneDay * 60 + 7 * oneDay * Math.random();
   const endTime = now - oneDay * 30 + 21 * oneDay * Math.random();
 
   return {
@@ -872,6 +873,7 @@ export function mockSingleDirectoryExperiment(
     proposedDuration: 28,
     startDate: new Date(startTime).toISOString(),
     computedEndDate: new Date(endTime).toISOString(),
+    computedEnrollmentEndDate: new Date(enrollmentEndTime).toISOString(),
     resultsReady: false,
     showResultsUrl: false,
     projects: [MOCK_CONFIG.projects![0]],

--- a/experimenter/experimenter/nimbus-ui/src/types/getAllExperiments.ts
+++ b/experimenter/experimenter/nimbus-ui/src/types/getAllExperiments.ts
@@ -63,6 +63,7 @@ export interface getAllExperiments_experiments {
   proposedDuration: number;
   proposedEnrollment: number;
   computedEndDate: DateTime | null;
+  computedEnrollmentEndDate: DateTime | null;
   status: NimbusExperimentStatusEnum | null;
   statusNext: NimbusExperimentStatusEnum | null;
   publishStatus: NimbusExperimentPublishStatusEnum | null;

--- a/experimenter/experimenter/nimbus-ui/src/types/getExperiment.ts
+++ b/experimenter/experimenter/nimbus-ui/src/types/getExperiment.ts
@@ -180,9 +180,10 @@ export interface getExperiment_experimentBySlug {
   proposedDuration: number;
   readyForReview: getExperiment_experimentBySlug_readyForReview | null;
   startDate: DateTime | null;
+  computedDurationDays: number | null;
   computedEndDate: DateTime | null;
   computedEnrollmentDays: number | null;
-  computedDurationDays: number | null;
+  computedEnrollmentEndDate: DateTime | null;
   riskMitigationLink: string | null;
   riskRevenue: boolean | null;
   riskBrand: boolean | null;


### PR DESCRIPTION
Because

* The frontend was using an incorrect calculation to display the enrollment period on the landing page table
* There is a property to compute the correct enrollment end date but it wasn't being used

This commit

* Updates the frontend to use the computed enrollment end date property

