### PR TITLE
fix #8649 feat(nimbus): add enrollment end date to summary timeline

### DIFF
--- a/experimenter/experimenter/nimbus-ui/src/components/Summary/SummaryTimeline/index.test.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/Summary/SummaryTimeline/index.test.tsx
@@ -28,6 +28,9 @@ describe("SummaryTimeline", () => {
 
       expect(screen.queryByTestId("label-not-launched")).toBeInTheDocument();
       expect(screen.queryByTestId("label-start-date")).not.toBeInTheDocument();
+      expect(
+        screen.queryByTestId("label-enrollment-end-date"),
+      ).not.toBeInTheDocument();
       expect(screen.queryByTestId("label-end-date")).not.toBeInTheDocument();
       expect(screen.queryByTestId("label-duration-days")).toBeInTheDocument();
       expect(screen.queryByTestId("label-enrollment-days")).toBeInTheDocument();
@@ -44,6 +47,9 @@ describe("SummaryTimeline", () => {
 
     expect(screen.queryByTestId("label-not-launched")).not.toBeInTheDocument();
     expect(screen.queryByTestId("label-start-date")).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("label-enrollment-end-date"),
+    ).toBeInTheDocument();
     expect(screen.queryByTestId("label-end-date")).toBeInTheDocument();
     expect(screen.queryByTestId("label-duration-days")).toBeInTheDocument();
     expect(screen.queryByTestId("label-enrollment-days")).toBeInTheDocument();
@@ -59,6 +65,9 @@ describe("SummaryTimeline", () => {
 
     expect(screen.queryByTestId("label-not-launched")).not.toBeInTheDocument();
     expect(screen.queryByTestId("label-start-date")).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("label-enrollment-end-date"),
+    ).toBeInTheDocument();
     expect(screen.queryByTestId("label-end-date")).toBeInTheDocument();
     expect(screen.queryByTestId("label-duration-days")).toBeInTheDocument();
     expect(screen.queryByTestId("label-enrollment-days")).toBeInTheDocument();

--- a/experimenter/experimenter/nimbus-ui/src/components/Summary/SummaryTimeline/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/Summary/SummaryTimeline/index.tsx
@@ -26,6 +26,7 @@ const SummaryTimeline = ({
         {...{
           status,
           startDate: experiment.startDate,
+          computedEnrollmentEndDate: experiment.computedEnrollmentEndDate,
           computedEndDate: experiment.computedEndDate,
         }}
       />
@@ -51,10 +52,12 @@ const SummaryTimeline = ({
 const StartEnd = ({
   status,
   startDate,
+  computedEnrollmentEndDate,
   computedEndDate,
 }: {
   status: StatusCheck;
   startDate: string | null;
+  computedEnrollmentEndDate: string | null;
   computedEndDate: string | null;
 }) => (
   <div className="d-flex">
@@ -65,11 +68,19 @@ const StartEnd = ({
     ) : (
       <>
         <span className="flex-fill" data-testid="label-start-date">
-          {humanDate(startDate!)}
+          Start: <b>{humanDate(startDate!)}</b>
         </span>
+        {computedEnrollmentEndDate && (
+          <span
+            className="flex-fill text-center"
+            data-testid="label-enrollment-end-date"
+          >
+            Enrollment End: <b>{humanDate(computedEnrollmentEndDate!)}</b>
+          </span>
+        )}
         {computedEndDate && (
           <span className="flex-fill text-right" data-testid="label-end-date">
-            {humanDate(computedEndDate!)}
+            End: <b>{humanDate(computedEndDate!)}</b>
           </span>
         )}
       </>

--- a/experimenter/experimenter/nimbus-ui/src/components/Summary/SummaryTimeline/mocks.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/Summary/SummaryTimeline/mocks.tsx
@@ -12,6 +12,7 @@ import {
 
 export const Subject = ({
   startDate = "2020-11-28T14:52:44.704811+00:00",
+  computedEnrollmentEndDate = "2020-12-02T14:52:44.704811+00:00",
   computedEndDate = "2020-12-08T14:52:44.704811+00:00",
   computedDurationDays = 10,
   computedEnrollmentDays = 1,
@@ -19,17 +20,19 @@ export const Subject = ({
   publishStatus = NimbusExperimentPublishStatusEnum.IDLE,
 }: {
   startDate?: string;
-  computedEndDate?: string;
   computedDurationDays?: number;
+  computedEndDate?: string;
   computedEnrollmentDays?: number;
+  computedEnrollmentEndDate?: string;
   status?: NimbusExperimentStatusEnum;
   publishStatus?: NimbusExperimentPublishStatusEnum;
 }) => {
   const { experiment } = mockExperimentQuery("something-vague", {
     startDate,
-    computedEndDate,
     computedDurationDays,
+    computedEndDate,
     computedEnrollmentDays,
+    computedEnrollmentEndDate,
     status,
     publishStatus,
   });


### PR DESCRIPTION
Because
    
* We don't show the enrollment end date anywhere on the summary page
* This is important information to know when reviewing a completed experiment
    
This commit
    
* Adds the enrollment end date to the summary page timeline

![image](https://user-images.githubusercontent.com/119884/229914093-59cef002-9170-466e-b9cb-c7633d1031f8.png)

