### PR TITLE
For #8625 fix(nimbus): Find rejection locators before using in integration tests

### DIFF
--- a/experimenter/tests/integration/nimbus/pages/experimenter/summary.py
+++ b/experimenter/tests/integration/nimbus/pages/experimenter/summary.py
@@ -106,6 +106,7 @@ class SummaryPage(ExperimenterBase):
         )
 
     def wait_for_rejected_alert(self):
+        self.wait.until(EC.presence_of_element_located(self._rejected_text_alert_locator))
         self.wait_with_refresh(
             self._rejected_text_alert_locator,
             "Summary Page: Unable to find rejected alert",
@@ -188,6 +189,9 @@ class SummaryPage(ExperimenterBase):
 
     def request_update_and_reject(self):
         self.request_update()
+        self.wait.until(
+            EC.presence_of_element_located(self._reject_request_button_locator)
+        )
         self.find_element(*self._reject_request_button_locator).click()
 
     @property

--- a/experimenter/tests/integration/nimbus/test_remote_settings.py
+++ b/experimenter/tests/integration/nimbus/test_remote_settings.py
@@ -49,6 +49,20 @@ def test_create_new_experiment_reject_remote_settings(
 
 
 @pytest.mark.remote_settings
+def test_create_new_rollout_reject_remote_settings(
+    selenium,
+    experiment_url,
+    create_experiment,
+    kinto_client,
+):
+    create_experiment(selenium, is_rollout=True).launch_and_approve()
+
+    kinto_client.reject()
+
+    SummaryPage(selenium, experiment_url).open().wait_for_rejected_alert()
+
+
+@pytest.mark.remote_settings
 def test_end_experiment_and_approve_end(
     selenium,
     experiment_url,


### PR DESCRIPTION
Because

- Tests were [failing to find](https://mozilla.sentry.io/issues/4052340208/?project=4504493871071232&referrer=github_integration) the reject locator

This commit

- Adds `self.wait.until(...)` for rejections
- Adds the test back for creating a rollout and rejecting in Remote Settings (removed in #8653)
