### PR TITLE
For #8558 feat(nimbus): Add dirty flag to experiment inputs

### DIFF
--- a/experimenter/experimenter/experiments/api/v5/inputs.py
+++ b/experimenter/experimenter/experiments/api/v5/inputs.py
@@ -57,6 +57,7 @@ class ExperimentInput(graphene.InputObjectType):
     is_enrollment_paused = graphene.Boolean()
     is_first_run = graphene.Boolean()
     is_rollout = graphene.Boolean()
+    is_rollout_dirty = graphene.Boolean()
     is_sticky = graphene.Boolean()
     languages = graphene.List(graphene.String)
     locales = graphene.List(graphene.String)

--- a/experimenter/experimenter/experiments/tests/api/v5/test_mutations.py
+++ b/experimenter/experimenter/experiments/tests/api/v5/test_mutations.py
@@ -384,6 +384,57 @@ class TestUpdateExperimentMutationSingleFeature(
         experiment = NimbusExperiment.objects.get(id=experiment_id)
         self.assertTrue(experiment.warn_feature_schema)
 
+    def test_update_experiment_is_rollout_dirty(self):
+        user_email = "user@example.com"
+        experiment = NimbusExperimentFactory.create(
+            status=NimbusExperiment.Status.DRAFT,
+            application=NimbusExperiment.Application.FENIX,
+            is_rollout=True,
+            is_rollout_dirty=False,
+        )
+        experiment_id = experiment.id
+        response = self.query(
+            UPDATE_EXPERIMENT_MUTATION,
+            variables={
+                "input": {
+                    "id": experiment.id,
+                    "isRolloutDirty": True,
+                    "changelogMessage": "test changelog message",
+                }
+            },
+            headers={settings.OPENIDC_EMAIL_HEADER: user_email},
+        )
+        self.assertEqual(response.status_code, 200)
+
+        experiment = NimbusExperiment.objects.get(id=experiment_id)
+        self.assertTrue(experiment.is_rollout)
+        self.assertTrue(experiment.is_rollout_dirty)
+
+    def test_update_experiment_add_is_rollout_dirty(self):
+        user_email = "user@example.com"
+        experiment = NimbusExperimentFactory.create(
+            status=NimbusExperiment.Status.DRAFT,
+            application=NimbusExperiment.Application.FENIX,
+            is_rollout=True,
+        )
+        experiment_id = experiment.id
+        response = self.query(
+            UPDATE_EXPERIMENT_MUTATION,
+            variables={
+                "input": {
+                    "id": experiment.id,
+                    "isRolloutDirty": True,
+                    "changelogMessage": "test changelog message",
+                }
+            },
+            headers={settings.OPENIDC_EMAIL_HEADER: user_email},
+        )
+        self.assertEqual(response.status_code, 200)
+
+        experiment = NimbusExperiment.objects.get(id=experiment_id)
+        self.assertTrue(experiment.is_rollout)
+        self.assertTrue(experiment.is_rollout_dirty)
+
     def test_update_draft_experiment_to_rollout(self):
         user_email = "user@example.com"
         experiment = NimbusExperimentFactory.create_with_lifecycle(

--- a/experimenter/experimenter/nimbus-ui/schema.graphql
+++ b/experimenter/experimenter/nimbus-ui/schema.graphql
@@ -466,6 +466,7 @@ input ExperimentInput {
   isEnrollmentPaused: Boolean
   isFirstRun: Boolean
   isRollout: Boolean
+  isRolloutDirty: Boolean
   isSticky: Boolean
   languages: [String]
   locales: [String]

--- a/experimenter/experimenter/nimbus-ui/src/types/globalTypes.ts
+++ b/experimenter/experimenter/nimbus-ui/src/types/globalTypes.ts
@@ -232,6 +232,7 @@ export interface ExperimentInput {
   isEnrollmentPaused?: boolean | null;
   isFirstRun?: boolean | null;
   isRollout?: boolean | null;
+  isRolloutDirty?: boolean | null;
   isSticky?: boolean | null;
   languages?: (string | null)[] | null;
   locales?: (string | null)[] | null;


### PR DESCRIPTION
Because

- We want to use the new `is_rollout_dirty` flag instead of dirty publish status

This commit

- Adds `is_rollout_dirty` to `ExperimentInput` so that it can be used [here](https://github.com/mozilla/experimenter/blob/8d46516b281ef1c9e352634c6ea9113eca0712be/experimenter/experimenter/nimbus-ui/src/components/Summary/index.tsx#L70) 
