### PR TITLE
For #8346 feat(nimbus): Add visual form validation on Metrics page

### DIFF
--- a/experimenter/experimenter/nimbus-ui/src/components/PageEditMetrics/FormMetrics/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageEditMetrics/FormMetrics/index.tsx
@@ -160,7 +160,7 @@ const FormMetrics = ({
     const valueContainerDiv = primaryContainerDiv.querySelector(
       "#primary-outcomes > div",
     );
-    const valueContainer = valueContainerDiv.querySelector("div");
+    const valueContainer = valueContainerDiv?.querySelector("div");
     if (valueContainer && valueContainerDiv) {
       const isValid = primaryOutcomes.length > 0;
       toggleClasses(valueContainer, isValid);
@@ -182,7 +182,7 @@ const FormMetrics = ({
     const valueContainerDiv = secondaryContainerDiv.querySelector(
       "#secondary-outcomes > div",
     );
-    const valueContainer = valueContainerDiv.querySelector("div");
+    const valueContainer = valueContainerDiv?.querySelector("div");
     if (valueContainer && valueContainerDiv) {
       const isValid = secondaryOutcomes.length > 0;
       toggleClasses(valueContainer, isValid);
@@ -195,6 +195,18 @@ const FormMetrics = ({
       validateSecondary();
     }
   }, [validateSecondary, hasInteracted.secondary]);
+
+  const handlePrimaryBlur = () => {
+    if (!hasInteracted.primary) {
+      setHasInteracted((prevState) => ({ ...prevState, primary: true }));
+    }
+  };
+
+  const handleSecondaryBlur = () => {
+    if (!hasInteracted.secondary) {
+      setHasInteracted((prevState) => ({ ...prevState, secondary: true }));
+    }
+  };
 
   return (
     <Form
@@ -231,7 +243,7 @@ const FormMetrics = ({
           {...formSelectAttrs("primaryOutcomes", setPrimaryOutcomes)}
           options={primaryOutcomeOptions}
           isOptionDisabled={() => primaryOutcomes.length >= maxPrimaryOutcomes!}
-          onBlur={() => setHasInteracted({ ...hasInteracted, primary: true })}
+          onBlur={handlePrimaryBlur}
         />
         <Form.Text className="text-muted">
           Select the user action or feature that you are measuring with this
@@ -260,7 +272,7 @@ const FormMetrics = ({
           id="secondary-outcomes"
           {...formSelectAttrs("secondaryOutcomes", setSecondaryOutcomes)}
           options={secondaryOutcomeOptions}
-          onBlur={() => setHasInteracted({ ...hasInteracted, secondary: true })}
+          onBlur={handleSecondaryBlur}
         />
         <Form.Text className="text-muted">
           Select the user action or feature that you are measuring with this

--- a/experimenter/experimenter/nimbus-ui/src/components/PageEditMetrics/FormMetrics/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageEditMetrics/FormMetrics/index.tsx
@@ -2,7 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React, { useEffect, useMemo, useState } from "react";
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import Alert from "react-bootstrap/Alert";
 import Form from "react-bootstrap/Form";
 import Select from "react-select";
@@ -131,6 +137,65 @@ const FormMetrics = ({
   const isArchived =
     experiment?.isArchived != null ? experiment.isArchived : false;
 
+  // Add state to check if user has chosen option
+  const [hasInteracted, setHasInteracted] = useState({
+    primary: false,
+    secondary: false,
+  });
+
+  const primaryContainerDivRef = useRef<HTMLDivElement>(null);
+  const secondaryContainerDivRef = useRef<HTMLDivElement>(null);
+
+  const toggleClasses = (valueContainer: HTMLElement, isValid: boolean) => {
+    valueContainer.classList.toggle("form-control", isValid);
+    valueContainer.classList.toggle("is-valid", isValid);
+    valueContainer.classList.toggle("border-0", isValid);
+  };
+
+  const validatePrimary = useCallback(() => {
+    const primaryContainerDiv = primaryContainerDivRef.current;
+    if (!primaryContainerDiv) {
+      return;
+    }
+    const valueContainerDiv = primaryContainerDiv.querySelector(
+      "#primary-outcomes > div",
+    );
+    const valueContainer = valueContainerDiv.querySelector("div");
+    if (valueContainer && valueContainerDiv) {
+      const isValid = primaryOutcomes.length > 0;
+      toggleClasses(valueContainer, isValid);
+      valueContainerDiv.classList.toggle("border-success", isValid);
+    }
+  }, [primaryOutcomes]);
+
+  useEffect(() => {
+    if (hasInteracted.primary) {
+      validatePrimary();
+    }
+  }, [validatePrimary, hasInteracted.primary]);
+
+  const validateSecondary = useCallback(() => {
+    const secondaryContainerDiv = secondaryContainerDivRef.current;
+    if (!secondaryContainerDiv) {
+      return;
+    }
+    const valueContainerDiv = secondaryContainerDiv.querySelector(
+      "#secondary-outcomes > div",
+    );
+    const valueContainer = valueContainerDiv.querySelector("div");
+    if (valueContainer && valueContainerDiv) {
+      const isValid = secondaryOutcomes.length > 0;
+      toggleClasses(valueContainer, isValid);
+      valueContainerDiv.classList.toggle("border-success", isValid);
+    }
+  }, [secondaryOutcomes]);
+
+  useEffect(() => {
+    if (hasInteracted.secondary) {
+      validateSecondary();
+    }
+  }, [validateSecondary, hasInteracted.secondary]);
+
   return (
     <Form
       noValidate
@@ -144,7 +209,11 @@ const FormMetrics = ({
         </Alert>
       )}
 
-      <Form.Group controlId="primaryOutcomes" data-testid="primary-outcomes">
+      <Form.Group
+        controlId="primaryOutcomes"
+        data-testid="primary-outcomes"
+        ref={primaryContainerDivRef}
+      >
         <Form.Label>
           Primary Outcomes{" "}
           <Info
@@ -158,9 +227,11 @@ const FormMetrics = ({
         </Form.Label>
         <Select
           isMulti
+          id="primary-outcomes"
           {...formSelectAttrs("primaryOutcomes", setPrimaryOutcomes)}
           options={primaryOutcomeOptions}
           isOptionDisabled={() => primaryOutcomes.length >= maxPrimaryOutcomes!}
+          onBlur={() => setHasInteracted({ ...hasInteracted, primary: true })}
         />
         <Form.Text className="text-muted">
           Select the user action or feature that you are measuring with this
@@ -172,6 +243,7 @@ const FormMetrics = ({
       <Form.Group
         controlId="secondaryOutcomes"
         data-testid="secondary-outcomes"
+        ref={secondaryContainerDivRef}
       >
         <Form.Label>
           Secondary Outcomes{" "}
@@ -185,8 +257,10 @@ const FormMetrics = ({
         </Form.Label>
         <Select
           isMulti
+          id="secondary-outcomes"
           {...formSelectAttrs("secondaryOutcomes", setSecondaryOutcomes)}
           options={secondaryOutcomeOptions}
+          onBlur={() => setHasInteracted({ ...hasInteracted, secondary: true })}
         />
         <Form.Text className="text-muted">
           Select the user action or feature that you are measuring with this


### PR DESCRIPTION
Because

- The overview and audience pages highlight all the fields in the green border and checkmark after saving to show that they were validated and saved, but the metrics page does not. We should fix that so that we show the valid fields as green when saving, it's just a nice UI signal that your stuff was saved properly.

This commit

- I declared React functional component hooks (`useRef` and `useState`) and two functions (`toggleClasses`, `validatePrimary`, and `validateSecondary`).

- The `primaryContainerDivRef` and `secondaryContainerDivRef` are used to store references to the `primary` and `secondary` container div elements, respectively.

- The `toggleClasses` is a function that takes two arguments: `valueContainer`, which is an `HTMLElement` to toggle classes on, and `isValid`, which is a boolean indicating whether or not the `valueContainer` is valid. This function toggles the `.form-control`, `.is-valid`, and `.border-0` classes on `valueContainer` depending on the value of `isValid`.

- The `validatePrimary` and `validateSecondary` are functions that validate the content of `primaryContainerDivRef` and `secondaryContainerDivRef`, respectively. These functions first check if the container div element exists and then select the appropriate child div element based on its ID. If the child div element exists, `toggleClasses` is called with the appropriate arguments to toggle the classes on the child div. The `border-success` class is also toggled on the parent div element if the child div element exists.

- I called `validatePrimary` and `validateSecondary` in their respective `select` components using an `onBlur` method so the validation can only happen when the user is done selecting.

- Additionally, I used two `useEffect` hooks to validate the `primary` and `secondary` containers if their respective `hasInteracted` values are `true`. This ensures that validation only occurs if the user has interacted with the form fields. The `useEffect` hooks also include dependencies for the `validatePrimary` and `validateSecondary` functions to ensure they are re-evaluated when changes occur.

### Video for;

- Before change;

https://user-images.githubusercontent.com/105272189/230250383-edfdff01-9c1f-484f-b684-680fc58b7b67.mp4


- After change;


https://user-images.githubusercontent.com/105272189/230250447-d13315bf-8a42-4591-b217-42341731008d.mp4





### This pull request was generated from [this](https://github.com/mozilla/experimenter/issues/8346) issue.