### PR TITLE
fixes #8500 fix(nimbus): Replace Constants

### DIFF
--- a/experimenter/experimenter/experiments/admin.py
+++ b/experimenter/experimenter/experiments/admin.py
@@ -13,7 +13,6 @@ from experimenter.experiments.changelog_utils import (
     NimbusBranchChangeLogSerializer,
     NimbusChangeLogSerializer,
 )
-from experimenter.experiments.constants import NimbusConstants
 from experimenter.experiments.models import (
     NimbusBranch,
     NimbusBranchFeatureValue,
@@ -101,14 +100,14 @@ class NimbusExperimentResource(resources.ModelResource):
 
     def dehydrate_status_next(self, experiment):
         """Return None instead of empty string for nullable enums"""
-        if experiment.status_next not in dict(NimbusConstants.Status.choices):
+        if experiment.status_next not in dict(experiment.Status.choices):
             return None
         return experiment.status_next
 
     def dehydrate_conclusion_recommendation(self, experiment):
         """Return None instead of empty string for nullable enums"""
         if experiment.conclusion_recommendation not in dict(
-            NimbusConstants.ConclusionRecommendation.choices
+            experiment.ConclusionRecommendation.choices
         ):
             return None
         return experiment.conclusion_recommendation

--- a/experimenter/experimenter/experiments/api/v5/types.py
+++ b/experimenter/experimenter/experiments/api/v5/types.py
@@ -11,7 +11,6 @@ from experimenter.experiments.api.v5.serializers import (
     TransitionConstants,
 )
 from experimenter.experiments.api.v6.serializers import NimbusExperimentSerializer
-from experimenter.experiments.constants import NimbusConstants
 from experimenter.experiments.models import (
     NimbusBranch,
     NimbusBranchFeatureValue,
@@ -27,42 +26,42 @@ from experimenter.projects.models import Project
 
 class NimbusExperimentStatusEnum(graphene.Enum):
     class Meta:
-        enum = NimbusConstants.Status
+        enum = NimbusExperiment.Status
 
 
 class NimbusExperimentPublishStatusEnum(graphene.Enum):
     class Meta:
-        enum = NimbusConstants.PublishStatus
+        enum = NimbusExperiment.PublishStatus
 
 
 class NimbusExperimentFirefoxVersionEnum(graphene.Enum):
     class Meta:
-        enum = NimbusConstants.Version
+        enum = NimbusExperiment.Version
 
 
 class NimbusExperimentApplicationEnum(graphene.Enum):
     class Meta:
-        enum = NimbusConstants.Application
+        enum = NimbusExperiment.Application
 
 
 class NimbusTypeEnum(graphene.Enum):
     class Meta:
-        enum = NimbusConstants.Type
+        enum = NimbusExperiment.Type
 
 
 class NimbusExperimentChannelEnum(graphene.Enum):
     class Meta:
-        enum = NimbusConstants.Channel
+        enum = NimbusExperiment.Channel
 
 
 class NimbusExperimentConclusionRecommendationEnum(graphene.Enum):
     class Meta:
-        enum = NimbusConstants.ConclusionRecommendation
+        enum = NimbusExperiment.ConclusionRecommendation
 
 
 class NimbusExperimentDocumentationLinkEnum(graphene.Enum):
     class Meta:
-        enum = NimbusConstants.DocumentationLink
+        enum = NimbusExperiment.DocumentationLink
 
 
 class ObjectField(graphene.Scalar):
@@ -577,13 +576,13 @@ class NimbusExperimentType(DjangoObjectType):
 
     def resolve_reference_branch(self, info):
         return self.reference_branch or NimbusBranch(
-            name=NimbusConstants.DEFAULT_REFERENCE_BRANCH_NAME
+            name=NimbusExperiment.DEFAULT_REFERENCE_BRANCH_NAME
         )
 
     def resolve_treatment_branches(self, info):
         if self.branches.exists():
             return self.treatment_branches
-        return [NimbusBranch(name=NimbusConstants.DEFAULT_TREATMENT_BRANCH_NAME)]
+        return [NimbusBranch(name=NimbusExperiment.DEFAULT_TREATMENT_BRANCH_NAME)]
 
     def resolve_ready_for_review(self, info):
         serializer = NimbusReviewSerializer(

--- a/experimenter/experimenter/experiments/models.py
+++ b/experimenter/experimenter/experiments/models.py
@@ -668,7 +668,7 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
     def results_ready(self):
         if self.proposed_enrollment_end_date:
             resultsReadyDate = self.proposed_enrollment_end_date + datetime.timedelta(
-                days=NimbusConstants.DAYS_UNTIL_ANALYSIS
+                days=self.DAYS_UNTIL_ANALYSIS
             )
             return datetime.date.today() >= resultsReadyDate
 

--- a/experimenter/experimenter/experiments/tests/api/v5/test_mutations.py
+++ b/experimenter/experimenter/experiments/tests/api/v5/test_mutations.py
@@ -13,7 +13,6 @@ from experimenter.base.tests.factories import (
     LanguageFactory,
     LocaleFactory,
 )
-from experimenter.experiments.constants import NimbusConstants
 from experimenter.experiments.models import NimbusExperiment, NimbusFeatureConfig
 from experimenter.experiments.tests.factories import (
     TINY_PNG,
@@ -434,8 +433,8 @@ class TestUpdateExperimentMutationSingleFeature(
         experiment = NimbusExperiment.objects.get(id=experiment_id)
         self.assertTrue(experiment.is_rollout)
         self.assertEqual(experiment.population_percent, 50.0)
-        self.assertEqual(experiment.publish_status, NimbusConstants.PublishStatus.DIRTY)
-        self.assertEqual(experiment.status, NimbusConstants.Status.LIVE)
+        self.assertEqual(experiment.publish_status, NimbusExperiment.PublishStatus.DIRTY)
+        self.assertEqual(experiment.status, NimbusExperiment.Status.LIVE)
         self.assertEqual(experiment.status_next, None)
 
     @parameterized.expand(
@@ -479,7 +478,7 @@ class TestUpdateExperimentMutationSingleFeature(
         experiment = NimbusExperiment.objects.get(id=experiment_id)
         self.assertEqual(experiment.population_percent, 50.0)
         self.assertEqual(
-            experiment.publish_status == NimbusConstants.PublishStatus.DIRTY,
+            experiment.publish_status == NimbusExperiment.PublishStatus.DIRTY,
             is_dirty_expected,
         )
 
@@ -511,8 +510,8 @@ class TestUpdateExperimentMutationSingleFeature(
 
         experiment = NimbusExperiment.objects.get(id=experiment_id)
         self.assertEqual(experiment.population_percent, 40.0)
-        self.assertEqual(experiment.publish_status, NimbusConstants.PublishStatus.IDLE)
-        self.assertEqual(experiment.status, NimbusConstants.Status.LIVE)
+        self.assertEqual(experiment.publish_status, NimbusExperiment.PublishStatus.IDLE)
+        self.assertEqual(experiment.status, NimbusExperiment.Status.LIVE)
         self.assertEqual(experiment.status_next, None)
 
     def test_update_experiment_branches_without_feature_config(self):
@@ -763,7 +762,7 @@ class TestUpdateExperimentMutationSingleFeature(
         experiment = NimbusExperimentFactory.create(
             status=NimbusExperiment.Status.DRAFT,
             channel=NimbusExperiment.Channel.NO_CHANNEL,
-            application=NimbusConstants.Application.DESKTOP,
+            application=NimbusExperiment.Application.DESKTOP,
             firefox_min_version=NimbusExperiment.Version.NO_VERSION,
             firefox_max_version=NimbusExperiment.Version.NO_VERSION,
             population_percent=0.0,
@@ -778,9 +777,9 @@ class TestUpdateExperimentMutationSingleFeature(
             variables={
                 "input": {
                     "id": experiment.id,
-                    "channel": NimbusConstants.Channel.BETA.name,
-                    "firefoxMinVersion": NimbusConstants.Version.FIREFOX_83.name,
-                    "firefoxMaxVersion": NimbusConstants.Version.FIREFOX_95.name,
+                    "channel": NimbusExperiment.Channel.BETA.name,
+                    "firefoxMinVersion": NimbusExperiment.Version.FIREFOX_83.name,
+                    "firefoxMaxVersion": NimbusExperiment.Version.FIREFOX_95.name,
                     "populationPercent": "10",
                     "proposedDuration": "120",
                     "proposedEnrollment": "42",
@@ -801,12 +800,12 @@ class TestUpdateExperimentMutationSingleFeature(
         self.assertEqual(content["data"]["updateExperiment"]["message"], "success")
 
         experiment = NimbusExperiment.objects.get(id=experiment.id)
-        self.assertEqual(experiment.channel, NimbusConstants.Channel.BETA)
+        self.assertEqual(experiment.channel, NimbusExperiment.Channel.BETA)
         self.assertEqual(
-            experiment.firefox_min_version, NimbusConstants.Version.FIREFOX_83
+            experiment.firefox_min_version, NimbusExperiment.Version.FIREFOX_83
         )
         self.assertEqual(
-            experiment.firefox_max_version, NimbusConstants.Version.FIREFOX_95
+            experiment.firefox_max_version, NimbusExperiment.Version.FIREFOX_95
         )
         self.assertEqual(experiment.population_percent, 10.0)
         self.assertEqual(experiment.proposed_duration, 120)

--- a/experimenter/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_branch_serializer.py
+++ b/experimenter/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_branch_serializer.py
@@ -2,8 +2,7 @@ from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import TestCase
 
 from experimenter.experiments.api.v5.serializers import NimbusBranchSerializer
-from experimenter.experiments.constants import NimbusConstants
-from experimenter.experiments.models import NimbusBranch
+from experimenter.experiments.models import NimbusBranch, NimbusExperiment
 from experimenter.experiments.tests.factories import (
     TINY_PNG,
     NimbusBranchFactory,
@@ -38,7 +37,7 @@ class TestNimbusBranchSerializerSingleFeature(TestCase):
         )
 
     def test_serializer_saves_new_branch(self):
-        application = NimbusConstants.Application.DESKTOP
+        application = NimbusExperiment.Application.DESKTOP
         feature_config = NimbusFeatureConfigFactory.create(application=application)
         experiment = NimbusExperimentFactory.create(
             application=application, feature_configs=[feature_config]
@@ -65,7 +64,7 @@ class TestNimbusBranchSerializerSingleFeature(TestCase):
         self.assertEqual(branch_feature_value.value, "{}")
 
     def test_serializer_updates_existing_branch(self):
-        application = NimbusConstants.Application.DESKTOP
+        application = NimbusExperiment.Application.DESKTOP
         feature_config = NimbusFeatureConfigFactory.create(application=application)
         experiment = NimbusExperimentFactory.create(
             application=application, feature_configs=[feature_config]
@@ -177,12 +176,12 @@ class TestNimbusBranchSerializerMultiFeature(TestCase):
                 "feature_values": [
                     {
                         "feature_config": (
-                            NimbusConstants.ERROR_DUPLICATE_BRANCH_FEATURE_VALUE
+                            NimbusExperiment.ERROR_DUPLICATE_BRANCH_FEATURE_VALUE
                         )
                     },
                     {
                         "feature_config": (
-                            NimbusConstants.ERROR_DUPLICATE_BRANCH_FEATURE_VALUE
+                            NimbusExperiment.ERROR_DUPLICATE_BRANCH_FEATURE_VALUE
                         )
                     },
                 ]
@@ -190,7 +189,7 @@ class TestNimbusBranchSerializerMultiFeature(TestCase):
         )
 
     def test_serializer_saves_new_branch(self):
-        application = NimbusConstants.Application.DESKTOP
+        application = NimbusExperiment.Application.DESKTOP
         feature_config1 = NimbusFeatureConfigFactory.create(application=application)
         feature_config2 = NimbusFeatureConfigFactory.create(application=application)
         experiment = NimbusExperimentFactory.create(
@@ -225,7 +224,7 @@ class TestNimbusBranchSerializerMultiFeature(TestCase):
             self.assertEqual(branch_feature_value.value, "{}")
 
     def test_serializer_updates_existing_branch(self):
-        application = NimbusConstants.Application.DESKTOP
+        application = NimbusExperiment.Application.DESKTOP
         feature_config1 = NimbusFeatureConfigFactory.create(application=application)
         feature_config2 = NimbusFeatureConfigFactory.create(application=application)
         experiment = NimbusExperimentFactory.create(

--- a/experimenter/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_experiment_branch_mixin.py
+++ b/experimenter/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_experiment_branch_mixin.py
@@ -1,7 +1,6 @@
 from django.test import TestCase
 
 from experimenter.experiments.api.v5.serializers import NimbusExperimentSerializer
-from experimenter.experiments.constants import NimbusConstants
 from experimenter.experiments.models import NimbusExperiment
 from experimenter.experiments.tests.factories import (
     NimbusBranchFactory,
@@ -238,9 +237,11 @@ class TestNimbusExperimentBranchMixinSingleFeature(TestCase):
         self.assertEqual(
             serializer.errors,
             {
-                "reference_branch": {"name": NimbusConstants.ERROR_DUPLICATE_BRANCH_NAME},
+                "reference_branch": {
+                    "name": NimbusExperiment.ERROR_DUPLICATE_BRANCH_NAME
+                },
                 "treatment_branches": [
-                    {"name": NimbusConstants.ERROR_DUPLICATE_BRANCH_NAME}
+                    {"name": NimbusExperiment.ERROR_DUPLICATE_BRANCH_NAME}
                     for _ in (data.get("treatment_branches", []) or [])
                 ],
             },
@@ -303,9 +304,9 @@ class TestNimbusExperimentBranchMixinSingleFeature(TestCase):
         self.assertEqual(
             serializer.errors,
             {
-                "reference_branch": {"name": NimbusConstants.ERROR_BRANCH_SWAP},
+                "reference_branch": {"name": NimbusExperiment.ERROR_BRANCH_SWAP},
                 "treatment_branches": [
-                    {"name": NimbusConstants.ERROR_BRANCH_SWAP}
+                    {"name": NimbusExperiment.ERROR_BRANCH_SWAP}
                     for _ in (data.get("treatment_branches", []) or [])
                 ],
             },
@@ -368,9 +369,9 @@ class TestNimbusExperimentBranchMixinSingleFeature(TestCase):
         self.assertEqual(
             serializer.errors,
             {
-                "reference_branch": {"name": NimbusConstants.ERROR_BRANCH_SWAP},
+                "reference_branch": {"name": NimbusExperiment.ERROR_BRANCH_SWAP},
                 "treatment_branches": [
-                    {"name": NimbusConstants.ERROR_BRANCH_SWAP}
+                    {"name": NimbusExperiment.ERROR_BRANCH_SWAP}
                     for _ in (data.get("treatment_branches", []) or [])
                 ],
             },

--- a/experimenter/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_experiment_csv_serializer.py
+++ b/experimenter/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_experiment_csv_serializer.py
@@ -3,7 +3,6 @@ import datetime
 from django.test import TestCase
 
 from experimenter.experiments.api.v5.serializers import NimbusExperimentCsvSerializer
-from experimenter.experiments.constants import NimbusConstants
 from experimenter.experiments.models import NimbusExperiment
 from experimenter.experiments.tests.factories import (
     NimbusExperimentFactory,
@@ -13,7 +12,7 @@ from experimenter.experiments.tests.factories import (
 
 class TestNimbusExperimentCsvSerializer(TestCase):
     def test_serializer_outputs_expected_schema(self):
-        application = NimbusConstants.Application.DESKTOP
+        application = NimbusExperiment.Application.DESKTOP
         feature_config = NimbusFeatureConfigFactory.create(application=application)
 
         experiment = NimbusExperimentFactory.create(
@@ -40,7 +39,7 @@ class TestNimbusExperimentCsvSerializer(TestCase):
         )
 
     def test_serializer_outputs_expected_schema_with_results_link(self):
-        application = NimbusConstants.Application.DESKTOP
+        application = NimbusExperiment.Application.DESKTOP
         feature_config = NimbusFeatureConfigFactory.create(application=application)
 
         experiment = NimbusExperimentFactory.create_with_lifecycle(

--- a/experimenter/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_experiment_serializer.py
+++ b/experimenter/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_experiment_serializer.py
@@ -12,7 +12,6 @@ from experimenter.base.tests.factories import (
 )
 from experimenter.experiments.api.v5.serializers import NimbusExperimentSerializer
 from experimenter.experiments.changelog_utils import generate_nimbus_changelog
-from experimenter.experiments.constants import NimbusConstants
 from experimenter.experiments.models import NimbusBucketRange, NimbusExperiment
 from experimenter.experiments.tests.factories import (
     NimbusExperimentFactory,
@@ -465,8 +464,8 @@ class TestNimbusExperimentSerializer(TestCase):
         serializer = NimbusExperimentSerializer(
             experiment,
             {
-                "channel": NimbusConstants.Channel.BETA,
-                "firefox_min_version": NimbusConstants.Version.FIREFOX_83,
+                "channel": NimbusExperiment.Channel.BETA,
+                "firefox_min_version": NimbusExperiment.Version.FIREFOX_83,
                 "population_percent": 10,
                 "proposed_duration": 120,
                 "proposed_enrollment": 42,
@@ -485,9 +484,9 @@ class TestNimbusExperimentSerializer(TestCase):
         self.assertTrue(serializer.is_valid(), serializer.errors)
         experiment = serializer.save()
         self.assertEqual(experiment.changes.count(), 1)
-        self.assertEqual(experiment.channel, NimbusConstants.Channel.BETA)
+        self.assertEqual(experiment.channel, NimbusExperiment.Channel.BETA)
         self.assertEqual(
-            experiment.firefox_min_version, NimbusConstants.Version.FIREFOX_83
+            experiment.firefox_min_version, NimbusExperiment.Version.FIREFOX_83
         )
         self.assertEqual(experiment.population_percent, 10)
         self.assertEqual(experiment.proposed_duration, 120)
@@ -999,7 +998,7 @@ class TestNimbusExperimentSerializer(TestCase):
         self.assertIn("primary_outcomes", serializer.errors)
 
     def test_serializer_rejects_too_many_primary_outcomes(self):
-        NimbusConstants.MAX_PRIMARY_OUTCOMES = 1
+        NimbusExperiment.MAX_PRIMARY_OUTCOMES = 1
 
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.CREATED,

--- a/experimenter/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_ready_for_review_serializer.py
+++ b/experimenter/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_ready_for_review_serializer.py
@@ -5,7 +5,6 @@ from parameterized import parameterized
 
 from experimenter.base.tests.factories import CountryFactory, LanguageFactory
 from experimenter.experiments.api.v5.serializers import NimbusReviewSerializer
-from experimenter.experiments.constants import NimbusConstants
 from experimenter.experiments.models import NimbusExperiment
 from experimenter.experiments.tests.factories import (
     NimbusBranchFactory,
@@ -191,7 +190,11 @@ class TestNimbusReviewSerializerSingleFeature(TestCase):
         self.assertFalse(serializer.is_valid())
         self.assertEqual(
             serializer.errors,
-            {"reference_branch": {"description": [NimbusConstants.ERROR_REQUIRED_FIELD]}},
+            {
+                "reference_branch": {
+                    "description": [NimbusExperiment.ERROR_REQUIRED_FIELD]
+                }
+            },
         )
 
     def test_invalid_experiment_requires_min_version_less_than_max_version(self):
@@ -703,7 +706,7 @@ class TestNimbusReviewSerializerSingleFeature(TestCase):
         self.assertFalse(serializer.is_valid())
         self.assertEqual(
             serializer.errors["treatment_branches"][1],
-            {"description": [NimbusConstants.ERROR_REQUIRED_FIELD]},
+            {"description": [NimbusExperiment.ERROR_REQUIRED_FIELD]},
         )
 
     def test_invalid_experiment_missing_feature_config(self):
@@ -724,7 +727,7 @@ class TestNimbusReviewSerializerSingleFeature(TestCase):
         self.assertFalse(serializer.is_valid())
         self.assertEqual(
             serializer.errors["feature_config"],
-            [NimbusConstants.ERROR_REQUIRED_FEATURE_CONFIG],
+            [NimbusExperiment.ERROR_REQUIRED_FEATURE_CONFIG],
         )
 
     def test_invalid_experiment_risk_questions(self):
@@ -752,15 +755,15 @@ class TestNimbusReviewSerializerSingleFeature(TestCase):
         self.assertFalse(serializer.is_valid())
         self.assertEqual(
             str(serializer.errors["risk_partner_related"][0]),
-            NimbusConstants.ERROR_REQUIRED_QUESTION,
+            NimbusExperiment.ERROR_REQUIRED_QUESTION,
         )
         self.assertEqual(
             str(serializer.errors["risk_revenue"][0]),
-            NimbusConstants.ERROR_REQUIRED_QUESTION,
+            NimbusExperiment.ERROR_REQUIRED_QUESTION,
         )
         self.assertEqual(
             str(serializer.errors["risk_brand"][0]),
-            NimbusConstants.ERROR_REQUIRED_QUESTION,
+            NimbusExperiment.ERROR_REQUIRED_QUESTION,
         )
 
     @parameterized.expand(
@@ -1254,7 +1257,7 @@ class TestNimbusReviewSerializerSingleFeature(TestCase):
         self.assertFalse(serializer.is_valid())
         self.assertEqual(
             serializer.errors["treatment_branches"][0]["name"],
-            [NimbusConstants.ERROR_SINGLE_BRANCH_FOR_ROLLOUT],
+            [NimbusExperiment.ERROR_SINGLE_BRANCH_FOR_ROLLOUT],
         )
 
     @parameterized.expand(
@@ -1463,7 +1466,7 @@ class TestNimbusReviewSerializerSingleFeature(TestCase):
         self.assertTrue(serializer.is_valid())
         self.assertEqual(
             serializer.warnings["bucketing"],
-            [NimbusConstants.ERROR_BUCKET_EXISTS],
+            [NimbusExperiment.ERROR_BUCKET_EXISTS],
         )
 
     def test_bucket_namespace_warning_for_non_dupe_rollouts(self):

--- a/experimenter/experimenter/experiments/tests/api/v5/test_views.py
+++ b/experimenter/experimenter/experiments/tests/api/v5/test_views.py
@@ -10,7 +10,7 @@ from experimenter.experiments.api.v5.serializers import (
     NimbusExperimentCsvSerializer,
 )
 from experimenter.experiments.api.v5.views import NimbusExperimentCsvRenderer
-from experimenter.experiments.constants import NimbusConstants
+from experimenter.experiments.models import NimbusExperiment
 from experimenter.experiments.tests.factories import (
     NimbusExperimentFactory,
     NimbusFeatureConfigFactory,
@@ -20,7 +20,7 @@ from experimenter.experiments.tests.factories import (
 class TestNimbusExperimentCsvListView(TestCase):
     def test_get_returns_csv_info_sorted_by_start_date(self):
         user_email = "user@example.com"
-        application = NimbusConstants.Application.DESKTOP
+        application = NimbusExperiment.Application.DESKTOP
         feature_config = NimbusFeatureConfigFactory.create(application=application)
         experiment_1 = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE_APPROVE,
@@ -73,7 +73,7 @@ class TestNimbusExperimentCsvListView(TestCase):
 
     def test_get_returns_csv_filter_archived_experiments_info(self):
         user_email = "user@example.com"
-        application = NimbusConstants.Application.DESKTOP
+        application = NimbusExperiment.Application.DESKTOP
         feature_config = NimbusFeatureConfigFactory.create(application=application)
         experiment_1 = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.LIVE_ENROLLING,

--- a/experimenter/experimenter/experiments/tests/test_migrations.py
+++ b/experimenter/experimenter/experiments/tests/test_migrations.py
@@ -1,6 +1,5 @@
 from django_test_migrations.contrib.unittest_case import MigratorTestCase
 
-from experimenter.experiments.constants import NimbusConstants
 from experimenter.experiments.models import NimbusExperiment as Experiment
 
 
@@ -28,7 +27,7 @@ class TestMigration(MigratorTestCase):
             name="test experiment",
             slug="test-experiment",
             application=Experiment.Application.DESKTOP,
-            status=NimbusConstants.Status.DRAFT,
+            status=Experiment.Status.DRAFT,
             results_data={
                 "v1": {
                     "daily": {"all": {"control": [], "treatment": []}},
@@ -57,7 +56,7 @@ class TestMigration(MigratorTestCase):
             name="empty experiment",
             slug="empty-experiment",
             application=Experiment.Application.DESKTOP,
-            status=NimbusConstants.Status.DRAFT,
+            status=Experiment.Status.DRAFT,
         )
 
         # create experiment with empty results_data
@@ -66,7 +65,7 @@ class TestMigration(MigratorTestCase):
             name="empty results experiment",
             slug="empty-results-experiment",
             application=Experiment.Application.DESKTOP,
-            status=NimbusConstants.Status.DRAFT,
+            status=Experiment.Status.DRAFT,
             results_data={
                 "v2": {
                     "daily": None,

--- a/experimenter/experimenter/experiments/tests/test_models.py
+++ b/experimenter/experimenter/experiments/tests/test_models.py
@@ -18,7 +18,6 @@ from experimenter.base.tests.factories import (
     LocaleFactory,
 )
 from experimenter.experiments.changelog_utils import generate_nimbus_changelog
-from experimenter.experiments.constants import NimbusConstants
 from experimenter.experiments.models import (
     NimbusBranch,
     NimbusBranchScreenshot,
@@ -737,7 +736,7 @@ class TestNimbusExperiment(TestCase):
             prevent_pref_conflicts=True,
             feature_configs=[
                 NimbusFeatureConfig.objects.get(
-                    application=NimbusConstants.Application.DESKTOP,
+                    application=NimbusExperiment.Application.DESKTOP,
                     slug="prefSettingFeature",
                 )
             ],
@@ -773,7 +772,7 @@ class TestNimbusExperiment(TestCase):
             prevent_pref_conflicts=False,
             feature_configs=[
                 NimbusFeatureConfig.objects.get(
-                    application=NimbusConstants.Application.DESKTOP,
+                    application=NimbusExperiment.Application.DESKTOP,
                     slug="prefSettingFeature",
                 )
             ],

--- a/experimenter/experimenter/features/tests/test_features.py
+++ b/experimenter/experimenter/features/tests/test_features.py
@@ -5,7 +5,7 @@ import requests
 from django.core.checks import Error
 from django.test import TestCase
 
-from experimenter.experiments.constants import NimbusConstants
+from experimenter.experiments.models import NimbusExperiment
 from experimenter.features import (
     Feature,
     Features,
@@ -83,7 +83,7 @@ class TestFeatures(TestCase):
         )
 
     def test_load_features_by_application(self):
-        desktop_features = Features.by_application(NimbusConstants.Application.DESKTOP)
+        desktop_features = Features.by_application(NimbusExperiment.Application.DESKTOP)
         self.assertEqual(len(desktop_features), 3)
         self.assertIn(
             Feature(
@@ -118,7 +118,7 @@ class TestFeatures(TestCase):
         )
 
     def test_feature_generates_schema(self):
-        desktop_feature = Features.by_application(NimbusConstants.Application.DESKTOP)[0]
+        desktop_feature = Features.by_application(NimbusExperiment.Application.DESKTOP)[0]
         self.assertEqual(
             json.loads(desktop_feature.get_jsonschema()),
             {
@@ -183,7 +183,7 @@ class TestRemoteSchemaFeatures(TestCase):
     def test_loads_remote_schema(self):
         self.setup_valid_remote_schema()
 
-        desktop_feature = Features.by_application(NimbusConstants.Application.DESKTOP)[0]
+        desktop_feature = Features.by_application(NimbusExperiment.Application.DESKTOP)[0]
         remote_schema = desktop_feature.get_jsonschema()
 
         self.mock_requests_get.assert_called_once_with(
@@ -197,14 +197,14 @@ class TestRemoteSchemaFeatures(TestCase):
 
         with self.assertRaises(requests.ConnectionError):
             desktop_feature = Features.by_application(
-                NimbusConstants.Application.DESKTOP
+                NimbusExperiment.Application.DESKTOP
             )[0]
             desktop_feature.get_jsonschema()
 
     def test_returns_none_for_invalid_json(self):
         self.setup_json_error()
 
-        desktop_feature = Features.by_application(NimbusConstants.Application.DESKTOP)[0]
+        desktop_feature = Features.by_application(NimbusExperiment.Application.DESKTOP)[0]
         self.assertIsNone(desktop_feature.get_jsonschema())
 
 

--- a/experimenter/experimenter/features/tests/test_load_feature_configs.py
+++ b/experimenter/experimenter/features/tests/test_load_feature_configs.py
@@ -4,7 +4,6 @@ import mock
 from django.core.management import call_command
 from django.test import TestCase
 
-from experimenter.experiments.constants import NimbusConstants
 from experimenter.experiments.models import NimbusExperiment, NimbusFeatureConfig
 from experimenter.experiments.tests.factories import NimbusFeatureConfigFactory
 from experimenter.features import Features
@@ -137,7 +136,7 @@ class TestLoadFeatureConfigs(TestCase):
     def test_load_feature_set_features_slug_enabled_to_false_if_not_found_yaml(self):
         NimbusFeatureConfigFactory.create(
             slug="test-feature",
-            application=NimbusConstants.Application.DESKTOP,
+            application=NimbusExperiment.Application.DESKTOP,
             schema="{}",
             enabled=True,
         )
@@ -150,14 +149,14 @@ class TestLoadFeatureConfigs(TestCase):
     def test_load_feature_set_features_slug_enabled_to_false_with_duplicate_slug(self):
         feature_desktop = NimbusFeatureConfigFactory.create(
             slug="someFeature",
-            application=NimbusConstants.Application.DESKTOP,
+            application=NimbusExperiment.Application.DESKTOP,
             schema="{}",
             enabled=True,
         )
 
         feature_fenix = NimbusFeatureConfigFactory.create(
             slug="someFeature",
-            application=NimbusConstants.Application.FENIX,
+            application=NimbusExperiment.Application.FENIX,
             schema="{}",
             enabled=True,
         )
@@ -165,10 +164,10 @@ class TestLoadFeatureConfigs(TestCase):
         call_command("load_feature_configs")
 
         feature_desktop = NimbusFeatureConfig.objects.get(
-            slug="someFeature", application=NimbusConstants.Application.DESKTOP
+            slug="someFeature", application=NimbusExperiment.Application.DESKTOP
         )
         feature_fenix = NimbusFeatureConfig.objects.get(
-            slug="someFeature", application=NimbusConstants.Application.FENIX
+            slug="someFeature", application=NimbusExperiment.Application.FENIX
         )
         self.assertTrue(feature_desktop.enabled)
         self.assertFalse(feature_fenix.enabled)
@@ -194,7 +193,7 @@ class TestLoadInvalidRemoteSchemaFeatureConfigs(TestCase):
     def test_load_feature_config_ignores_invalid_remote_json(self):
         schema = "{}"
         NimbusFeatureConfigFactory.create(
-            slug="cfr", application=NimbusConstants.Application.DESKTOP, schema=schema
+            slug="cfr", application=NimbusExperiment.Application.DESKTOP, schema=schema
         )
 
         call_command("load_feature_configs")

--- a/experimenter/experimenter/jetstream/tasks.py
+++ b/experimenter/experimenter/jetstream/tasks.py
@@ -4,7 +4,6 @@ import markus
 from celery.utils.log import get_task_logger
 
 from experimenter.celery import app
-from experimenter.experiments.constants import NimbusConstants
 from experimenter.experiments.models import NimbusExperiment
 from experimenter.jetstream.client import get_experiment_data
 
@@ -47,7 +46,7 @@ def fetch_jetstream_data():
                     experiment.computed_end_date
                     and (
                         experiment.computed_end_date
-                        + dt.timedelta(days=NimbusConstants.DAYS_ANALYSIS_BUFFER)
+                        + dt.timedelta(days=NimbusExperiment.DAYS_ANALYSIS_BUFFER)
                     )
                     >= dt.date.today()
                 )

--- a/experimenter/experimenter/jetstream/tests/test_tasks.py
+++ b/experimenter/experimenter/jetstream/tests/test_tasks.py
@@ -5,7 +5,6 @@ from unittest.mock import patch
 from django.test import TestCase, override_settings
 from parameterized import parameterized
 
-from experimenter.experiments.constants import NimbusConstants
 from experimenter.experiments.models import NimbusExperiment
 from experimenter.experiments.tests.factories import NimbusExperimentFactory
 from experimenter.jetstream import tasks
@@ -1025,7 +1024,7 @@ class TestFetchJetstreamDataTask(TestCase):
     @patch("experimenter.jetstream.tasks.fetch_experiment_data.delay")
     def test_data_fetch_skip_preview(self, mock_delay):
         lifecycle = NimbusExperimentFactory.Lifecycles.PREVIEW
-        offset = NimbusConstants.DAYS_ANALYSIS_BUFFER + 1
+        offset = NimbusExperiment.DAYS_ANALYSIS_BUFFER + 1
         _ = NimbusExperimentFactory.create_with_lifecycle(
             lifecycle, end_date=datetime.date.today() - datetime.timedelta(days=offset)
         )
@@ -1035,7 +1034,7 @@ class TestFetchJetstreamDataTask(TestCase):
     @patch("experimenter.jetstream.tasks.fetch_experiment_data.delay")
     def test_data_expired_in_loop(self, mock_delay):
         lifecycle = NimbusExperimentFactory.Lifecycles.ENDING_APPROVE_APPROVE
-        offset = NimbusConstants.DAYS_ANALYSIS_BUFFER + 1
+        offset = NimbusExperiment.DAYS_ANALYSIS_BUFFER + 1
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             lifecycle, end_date=datetime.date.today() - datetime.timedelta(days=offset)
         )
@@ -1056,7 +1055,7 @@ class TestFetchJetstreamDataTask(TestCase):
     @patch("experimenter.jetstream.tasks.fetch_experiment_data.delay")
     def test_data_null_fetches(self, mock_delay):
         lifecycle = NimbusExperimentFactory.Lifecycles.ENDING_APPROVE_APPROVE
-        offset = NimbusConstants.DAYS_ANALYSIS_BUFFER + 1
+        offset = NimbusExperiment.DAYS_ANALYSIS_BUFFER + 1
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             lifecycle, end_date=datetime.date.today() - datetime.timedelta(days=offset)
         )

--- a/experimenter/experimenter/outcomes/README.md
+++ b/experimenter/experimenter/outcomes/README.md
@@ -19,7 +19,7 @@ Outcomes can be accessed by using the Outcome and Outcomes classes. An Outcome h
 - `slug: str` A unique identifier to include in the experiment DTO when deploying experiments
 
 ```py
-from experimenter.experiments.constants import NimbusConstants
+from experimenter.experiments.models import NimbusExperiment
 from experimenter.outcomes import Outcomes
 
 # All outcomes for all applications
@@ -27,7 +27,7 @@ for outcome in Outcomes.all():
     print(outcome.slug)
 
 # All outcomes for a given application
-for outcome in Outcomes.by_app_id(NimbusConstants.Application.FENIX):
+for outcome in Outcomes.by_app_id(NimbusExperiment.Application.FENIX):
     print(outcome.slug)
 ```
 

--- a/experimenter/experimenter/outcomes/tests/test_outcomes.py
+++ b/experimenter/experimenter/outcomes/tests/test_outcomes.py
@@ -1,7 +1,7 @@
 from django.core.checks import Error
 from django.test import TestCase
 
-from experimenter.experiments.constants import NimbusConstants
+from experimenter.experiments.models import NimbusExperiment
 from experimenter.outcomes import Metric, Outcome, Outcomes, check_outcome_tomls
 from experimenter.outcomes.tests import mock_invalid_outcomes, mock_valid_outcomes
 
@@ -18,7 +18,7 @@ class TestOutcomes(TestCase):
         self.assertEqual(len(outcomes), 4)
         self.assertIn(
             Outcome(
-                application=NimbusConstants.Application.FENIX,
+                application=NimbusExperiment.Application.FENIX,
                 description="Fenix config used for testing",
                 friendly_name="Fenix config",
                 slug="fenix_outcome",
@@ -36,7 +36,7 @@ class TestOutcomes(TestCase):
         for i in range(1, 4):
             self.assertIn(
                 Outcome(
-                    application=NimbusConstants.Application.DESKTOP,
+                    application=NimbusExperiment.Application.DESKTOP,
                     description="Firefox desktop config used for testing",
                     friendly_name=f"Desktop config {i}",
                     slug=f"desktop_outcome_{i}",
@@ -58,12 +58,12 @@ class TestOutcomes(TestCase):
             )
 
     def test_load_outcomes_by_application(self):
-        desktop_outcomes = Outcomes.by_application(NimbusConstants.Application.DESKTOP)
+        desktop_outcomes = Outcomes.by_application(NimbusExperiment.Application.DESKTOP)
         self.assertEqual(len(desktop_outcomes), 3)
         for i in range(1, 4):
             self.assertIn(
                 Outcome(
-                    application=NimbusConstants.Application.DESKTOP,
+                    application=NimbusExperiment.Application.DESKTOP,
                     description="Firefox desktop config used for testing",
                     friendly_name=f"Desktop config {i}",
                     slug=f"desktop_outcome_{i}",


### PR DESCRIPTION
Because

- NimbusExpriment model Inherits NimbusConstants we can replace NImbusConstants  with the NimbusExpriment model

This commit

-  replaces NimbusConstants with NimbusExpriment model

@yashikakhurana  i saw the issue was worked on but you can also check on these changes 
