### PR TITLE
fixes (#8179) The invalid image error text overlaps the screenshot added to one of the branches

### DIFF
--- a/experimenter/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/FormScreenshot/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/FormScreenshot/index.tsx
@@ -152,7 +152,7 @@ const UploadPreviewImage = ({ upload }: { upload: Upload | null }) => {
     <Image
       data-testid="upload-preview"
       fluid
-      className="mt-3"
+      className="mt-4"
       alt={`${uploadToLabel(upload)} preview`}
       src={previewUrl}
     />


### PR DESCRIPTION
Because
- The error message getting merged inside the image

This commit
- Increased margin so that it increases the space between the image and the error message which resolves this issue 

Screenshots
![Screenshot from 2023-04-08 02-44-01](https://user-images.githubusercontent.com/88829894/230932388-27a48255-6150-4778-9132-ffc6f1cbe9a0.png)
