### PR TITLE
fix #8651 feat(nimbus): add expected date of results

### DIFF
--- a/experimenter/experimenter/experiments/api/v5/types.py
+++ b/experimenter/experimenter/experiments/api/v5/types.py
@@ -471,6 +471,7 @@ class NimbusExperimentType(DjangoObjectType):
     recipe_json = graphene.String()
     reference_branch = graphene.Field(NimbusBranchType)
     rejection = graphene.Field(NimbusChangeLogType)
+    results_expected_date = graphene.DateTime()
     results_ready = graphene.Boolean()
     review_request = graphene.Field(NimbusChangeLogType)
     review_url = graphene.String()
@@ -538,6 +539,7 @@ class NimbusExperimentType(DjangoObjectType):
             "recipe_json",
             "reference_branch",
             "rejection",
+            "results_expected_date",
             "results_ready",
             "review_request",
             "review_url",

--- a/experimenter/experimenter/experiments/models.py
+++ b/experimenter/experimenter/experiments/models.py
@@ -665,11 +665,16 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
     # Results are available if enrollment is complete and
     # more than a week has passed after that.
     @property
-    def results_ready(self):
+    def results_ready_date(self):
         if self.proposed_enrollment_end_date:
-            resultsReadyDate = self.proposed_enrollment_end_date + datetime.timedelta(
+            return self.proposed_enrollment_end_date + datetime.timedelta(
                 days=NimbusConstants.DAYS_UNTIL_ANALYSIS
             )
+
+    @property
+    def results_ready(self):
+        if self.proposed_enrollment_end_date:
+            resultsReadyDate = self.results_ready_date
             return datetime.date.today() >= resultsReadyDate
 
     @property
@@ -688,6 +693,16 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
     @property
     def show_results_url(self):
         return self.has_displayable_results and self.results_ready and not self.is_rollout
+
+    @property
+    def results_expected_date(self):
+        if not self.is_rollout:
+            if self._enrollment_end_date:
+                return self._enrollment_end_date + datetime.timedelta(
+                    days=NimbusConstants.DAYS_UNTIL_ANALYSIS
+                )
+            else:
+                return self.results_ready_date
 
     @property
     def signoff_recommendations(self):

--- a/experimenter/experimenter/experiments/tests/api/v5/test_queries.py
+++ b/experimenter/experimenter/experiments/tests/api/v5/test_queries.py
@@ -96,6 +96,7 @@ class TestNimbusExperimentsQuery(GraphQLTestCase):
                     publishStatus
                     monitoringDashboardUrl
                     rolloutMonitoringDashboardUrl
+                    resultsExpectedDate
                     resultsReady
                     showResultsUrl
                     featureConfig {
@@ -171,6 +172,11 @@ class TestNimbusExperimentsQuery(GraphQLTestCase):
                 "publishStatus": NimbusExperiment.PublishStatus(
                     experiment.publish_status
                 ).name,
+                "resultsExpectedDate": (
+                    str(experiment.results_expected_date)
+                    if experiment.results_expected_date is not None
+                    else None
+                ),
                 "resultsReady": experiment.results_ready,
                 "rolloutMonitoringDashboardUrl": (
                     experiment.rollout_monitoring_dashboard_url

--- a/experimenter/experimenter/experiments/tests/test_models.py
+++ b/experimenter/experimenter/experiments/tests/test_models.py
@@ -18,6 +18,7 @@ from experimenter.base.tests.factories import (
     LocaleFactory,
 )
 from experimenter.experiments.changelog_utils import generate_nimbus_changelog
+from experimenter.experiments.constants import NimbusConstants
 from experimenter.experiments.models import (
     NimbusBranch,
     NimbusBranchScreenshot,
@@ -1613,6 +1614,57 @@ class TestNimbusExperiment(TestCase):
         experiment.save()
 
         self.assertFalse(experiment.show_results_url)
+
+    @parameterized.expand(
+        [
+            (
+                NimbusExperimentFactory.Lifecycles.LIVE_APPROVE_APPROVE,
+                datetime.date(2020, 1, 1),
+                None,
+                False,
+            ),
+            (
+                NimbusExperimentFactory.Lifecycles.LIVE_APPROVE_APPROVE,
+                datetime.date.today(),
+                None,
+                False,
+            ),
+            (
+                NimbusExperimentFactory.Lifecycles.ENDING_APPROVE_APPROVE,
+                datetime.date(2020, 1, 1),
+                datetime.date(2020, 2, 3),
+                True,
+            ),
+        ]
+    )
+    def test_results_expected_date(
+        self, lifecycle, start_date, end_date, is_paused_published
+    ):
+        proposed_enrollment = 2
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            lifecycle=lifecycle,
+            start_date=start_date,
+            end_date=end_date,
+            proposed_enrollment=proposed_enrollment,
+            # is_paused_published=is_paused_published,
+        )
+
+        expected_date = (
+            start_date
+            + datetime.timedelta(days=proposed_enrollment)
+            + datetime.timedelta(days=NimbusConstants.DAYS_UNTIL_ANALYSIS)
+        )
+        self.assertEqual(experiment.results_expected_date, expected_date)
+
+    def test_results_expected_date_null(self):
+        lifecycle = NimbusExperimentFactory.Lifecycles.LIVE_APPROVE_APPROVE
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            lifecycle, start_date=datetime.date(2020, 1, 1), proposed_enrollment=2
+        )
+        experiment.is_rollout = True
+        experiment.save()
+
+        self.assertIsNone(experiment.results_expected_date)
 
     @parameterized.expand(
         [

--- a/experimenter/experimenter/nimbus-ui/schema.graphql
+++ b/experimenter/experimenter/nimbus-ui/schema.graphql
@@ -68,6 +68,7 @@ type NimbusExperimentType {
   readyForReview: NimbusReviewType
   recipeJson: String
   rejection: NimbusChangeLogType
+  resultsExpectedDate: DateTime
   resultsReady: Boolean
   reviewRequest: NimbusChangeLogType
   reviewUrl: String

--- a/experimenter/experimenter/nimbus-ui/src/components/AppLayoutSidebarLaunched/index.test.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/AppLayoutSidebarLaunched/index.test.tsx
@@ -79,7 +79,17 @@ const Subject = ({
 describe("AppLayoutSidebarLaunched", () => {
   describe("navigation links", () => {
     it("when live, hides edit links, displays summary link and disabled results item", () => {
-      render(<Subject status={NimbusExperimentStatusEnum.LIVE} />);
+      const expectedDate = "2023-01-01T00:00:00.000+0000";
+      render(
+        <Subject
+          status={NimbusExperimentStatusEnum.LIVE}
+          experiment={
+            mockExperimentQuery("my-special-slug/design", {
+              resultsExpectedDate: expectedDate,
+            }).experiment
+          }
+        />,
+      );
       ["Overview", "Branches", "Metrics", "Audience"].forEach((text) => {
         expect(
           screen.queryByText(text, { selector: navLinkSelector }),
@@ -94,7 +104,12 @@ describe("AppLayoutSidebarLaunched", () => {
         `${BASE_PATH}/my-special-slug`,
       );
 
-      screen.getByText("Experiment analysis not ready yet");
+      // screen.getByText("Experiment analysis not ready yet.");
+      screen.getByText(
+        `Experiment analysis not ready yet. Results expected ${new Date(
+          expectedDate,
+        ).toLocaleDateString()} (or 8 days after enrollment ends).`,
+      );
     });
 
     it("when complete and analysis results fetch errors", () => {

--- a/experimenter/experimenter/nimbus-ui/src/components/AppLayoutSidebarLaunched/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/AppLayoutSidebarLaunched/index.tsx
@@ -222,7 +222,13 @@ export const AppLayoutSidebarLaunched = ({
                   ) : analysis?.metadata?.external_config?.skip ? (
                     "Experiment analysis was skipped"
                   ) : (
-                    "Experiment analysis not ready yet"
+                    `Experiment analysis not ready yet. ${
+                      experiment.resultsExpectedDate
+                        ? `Results expected ${new Date(
+                            experiment.resultsExpectedDate,
+                          ).toLocaleDateString()} (or 8 days after enrollment ends).`
+                        : ""
+                    }`
                   )}
                 </DisabledItem>
               )}

--- a/experimenter/experimenter/nimbus-ui/src/gql/experiments.ts
+++ b/experimenter/experimenter/nimbus-ui/src/gql/experiments.ts
@@ -38,6 +38,7 @@ export const GET_EXPERIMENT_QUERY = gql`
       publishStatus
       monitoringDashboardUrl
       rolloutMonitoringDashboardUrl
+      resultsExpectedDate
       resultsReady
       showResultsUrl
 
@@ -245,6 +246,7 @@ export const GET_EXPERIMENTS_QUERY = gql`
       publishStatus
       monitoringDashboardUrl
       rolloutMonitoringDashboardUrl
+      resultsExpectedDate
       resultsReady
       showResultsUrl
       featureConfig {

--- a/experimenter/experimenter/nimbus-ui/src/lib/mocks.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/lib/mocks.tsx
@@ -839,6 +839,7 @@ export function mockSingleDirectoryExperiment(
   const startTime = now - oneDay * 60 - 21 * oneDay * Math.random();
   const enrollmentEndTime = now - oneDay * 60 + 7 * oneDay * Math.random();
   const endTime = now - oneDay * 30 + 21 * oneDay * Math.random();
+  const expectedResultsTime = enrollmentEndTime + 8 * oneDay;
 
   return {
     isArchived: false,
@@ -874,6 +875,7 @@ export function mockSingleDirectoryExperiment(
     startDate: new Date(startTime).toISOString(),
     computedEndDate: new Date(endTime).toISOString(),
     computedEnrollmentEndDate: new Date(enrollmentEndTime).toISOString(),
+    resultsExpectedDate: new Date(expectedResultsTime).toISOString(),
     resultsReady: false,
     showResultsUrl: false,
     projects: [MOCK_CONFIG.projects![0]],

--- a/experimenter/experimenter/nimbus-ui/src/types/getAllExperiments.ts
+++ b/experimenter/experimenter/nimbus-ui/src/types/getAllExperiments.ts
@@ -69,6 +69,7 @@ export interface getAllExperiments_experiments {
   publishStatus: NimbusExperimentPublishStatusEnum | null;
   monitoringDashboardUrl: string | null;
   rolloutMonitoringDashboardUrl: string | null;
+  resultsExpectedDate: DateTime | null;
   resultsReady: boolean | null;
   showResultsUrl: boolean | null;
   featureConfig: getAllExperiments_experiments_featureConfig | null;

--- a/experimenter/experimenter/nimbus-ui/src/types/getExperiment.ts
+++ b/experimenter/experimenter/nimbus-ui/src/types/getExperiment.ts
@@ -150,6 +150,7 @@ export interface getExperiment_experimentBySlug {
   publishStatus: NimbusExperimentPublishStatusEnum | null;
   monitoringDashboardUrl: string | null;
   rolloutMonitoringDashboardUrl: string | null;
+  resultsExpectedDate: DateTime | null;
   resultsReady: boolean | null;
   showResultsUrl: boolean | null;
   hypothesis: string | null;


### PR DESCRIPTION
Because

- we get a lot of questions about when users can expect to see analysis results in Experimenter

This commit

- computes the expected results date based on enrollment end date (or proposed enrollment end date if enrollment is not yet ended)
- adds this expected date for analysis results to the no results message

![image](https://user-images.githubusercontent.com/102263964/231199510-c7823df0-a6be-418e-83d9-a106596f1373.png)

