### PR TITLE
fix #8682: Add new targeting for first run non-RTAMO users

### DIFF
--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -191,17 +191,17 @@ FIRST_RUN_NEW_PROFILE_WINDOWS_1903_EXCLUDE_RTAMO = NimbusTargetingConfig(
         "with a new profile, needing default w/ pin, excluding RTAMO"
     ),
     targeting=(
-        "{first_run} && {has_pin} && attributionData.source !== 'addons.mozilla.org'"
-        .format(
+        "{first_run} && {has_pin} && {attribution}".format(
             first_run=FIRST_RUN_NEW_PROFILE_NEED_DEFAULT_WINDOWS_1903.targeting,
             has_pin=HAS_PIN,
+            attribution="attributionData.source != 'addons.mozilla.org'",
         )
     ),
     desktop_telemetry=(
-        "{first_run} AND {has_pin} AND attributionData.source !== 'addons.mozilla.org'"
-        .format(
+        "{first_run} AND {has_pin} AND {attribution}".format(
             first_run=FIRST_RUN_NEW_PROFILE_NEED_DEFAULT_WINDOWS_1903.desktop_telemetry,
             has_pin=HAS_PIN,
+            attribution="attributionData.source != 'addons.mozilla.org'",
         )
     ),
     sticky_required=True,

--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -191,17 +191,17 @@ FIRST_RUN_NEW_PROFILE_WINDOWS_1903_EXCLUDE_RTAMO = NimbusTargetingConfig(
         "with a new profile, needing default w/ pin, excluding RTAMO"
     ),
     targeting=(
-        "{first_run} && {has_pin} && {exclude_rtamo}".format(
+        "{first_run} && {has_pin} && attributionData.source !== 'addons.mozilla.org'"
+        .format(
             first_run=FIRST_RUN_NEW_PROFILE_NEED_DEFAULT_WINDOWS_1903.targeting,
             has_pin=HAS_PIN,
-            exclude_rtamo="attributionData.source !== ‘addons.mozilla.org’",
         )
     ),
     desktop_telemetry=(
-        "{first_run} AND {has_pin} AND {exclude_rtamo}".format(
+        "{first_run} AND {has_pin} AND attributionData.source !== 'addons.mozilla.org'"
+        .format(
             first_run=FIRST_RUN_NEW_PROFILE_NEED_DEFAULT_WINDOWS_1903.desktop_telemetry,
             has_pin=HAS_PIN,
-            exclude_rtamo="attributionData.source !== ‘addons.mozilla.org’",
         )
     ),
     sticky_required=True,
@@ -1118,8 +1118,7 @@ class TargetingConstants:
     TARGETING_CHANNEL = 'browserSettings.update.channel == "{channel}"'
 
     TARGETING_CONFIGS = {
-        targeting.slug: targeting
-        for targeting in NimbusTargetingConfig.targeting_configs
+        targeting.slug: targeting for targeting in NimbusTargetingConfig.targeting_configs
     }
 
     TargetingConfig = models.TextChoices(

--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -180,26 +180,28 @@ FIRST_RUN_NEW_PROFILE_HAS_PIN_NEED_DEFAULT_WINDOWS_1903 = NimbusTargetingConfig(
     application_choice_names=(Application.DESKTOP.name,),
 )
 
-FIRST_RUN_NEW_PROFILE_HAS_PIN_NEED_DEFAULT_WINDOWS_1903_EXCLUDE_RTAMO = NimbusTargetingConfig(
+FIRST_RUN_NEW_PROFILE_WINDOWS_1903_EXCLUDE_RTAMO = NimbusTargetingConfig(
     name=(
         "First start-up users on Windows 10 1903 (build 18362) or newer, with a "
         "new profile, needing default w/ pin, excluding users coming from RTAMO"
     ),
-    slug="first_run_new_profile_need_default_has_pin_exclude_rtamo",
+    slug="first_run_new_profile_exclude_rtamo",
     description=(
         "First start-up users (e.g. for about:welcome) on Windows 1903+, "
         "with a new profile, needing default w/ pin, excluding RTAMO"
     ),
     targeting=(
-        "{first_run} && {has_pin} && attributionData.source !== ‘addons.mozilla.org’".format(
+        "{first_run} && {has_pin} && {exclude_rtamo}".format(
             first_run=FIRST_RUN_NEW_PROFILE_NEED_DEFAULT_WINDOWS_1903.targeting,
             has_pin=HAS_PIN,
+            exclude_rtamo="attributionData.source !== ‘addons.mozilla.org’",
         )
     ),
     desktop_telemetry=(
-        "{first_run} AND {has_pin} AND attributionData.source !== ‘addons.mozilla.org’".format(
+        "{first_run} AND {has_pin} AND {exclude_rtamo}".format(
             first_run=FIRST_RUN_NEW_PROFILE_NEED_DEFAULT_WINDOWS_1903.desktop_telemetry,
             has_pin=HAS_PIN,
+            exclude_rtamo="attributionData.source !== ‘addons.mozilla.org’",
         )
     ),
     sticky_required=True,

--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -180,6 +180,33 @@ FIRST_RUN_NEW_PROFILE_HAS_PIN_NEED_DEFAULT_WINDOWS_1903 = NimbusTargetingConfig(
     application_choice_names=(Application.DESKTOP.name,),
 )
 
+FIRST_RUN_NEW_PROFILE_HAS_PIN_NEED_DEFAULT_WINDOWS_1903_EXCLUDE_RTAMO = NimbusTargetingConfig(
+    name=(
+        "First start-up users on Windows 10 1903 (build 18362) or newer, with a "
+        "new profile, needing default w/ pin, excluding users coming from RTAMO"
+    ),
+    slug="first_run_new_profile_need_default_has_pin_exclude_rtamo",
+    description=(
+        "First start-up users (e.g. for about:welcome) on Windows 1903+, "
+        "with a new profile, needing default w/ pin, excluding RTAMO"
+    ),
+    targeting=(
+        "{first_run} && {has_pin} && attributionData.source !== ‘addons.mozilla.org’".format(
+            first_run=FIRST_RUN_NEW_PROFILE_NEED_DEFAULT_WINDOWS_1903.targeting,
+            has_pin=HAS_PIN,
+        )
+    ),
+    desktop_telemetry=(
+        "{first_run} AND {has_pin} AND attributionData.source !== ‘addons.mozilla.org’".format(
+            first_run=FIRST_RUN_NEW_PROFILE_NEED_DEFAULT_WINDOWS_1903.desktop_telemetry,
+            has_pin=HAS_PIN,
+        )
+    ),
+    sticky_required=True,
+    is_first_run_required=False,
+    application_choice_names=(Application.DESKTOP.name,),
+)
+
 NOT_TCP_STUDY = NimbusTargetingConfig(
     name="Exclude users in the TCP revenue study",
     slug="not_tcp_study",
@@ -1089,7 +1116,8 @@ class TargetingConstants:
     TARGETING_CHANNEL = 'browserSettings.update.channel == "{channel}"'
 
     TARGETING_CONFIGS = {
-        targeting.slug: targeting for targeting in NimbusTargetingConfig.targeting_configs
+        targeting.slug: targeting
+        for targeting in NimbusTargetingConfig.targeting_configs
     }
 
     TargetingConfig = models.TextChoices(


### PR DESCRIPTION
Because

This targeting will be used in the Window vs Tab modal with Easy Setup screen experiment, intended for Fx112

This commit

Duplicates the `FIRST_RUN_NEW_PROFILE_HAS_PIN_NEED_DEFAULT_WINDOWS_1903` targeting, with an added check for `attributionData.source !== ‘addons.mozilla.org’`
