### PR TITLE
feat(nimbus): add targeting for email attribution

### DIFF
--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -43,6 +43,17 @@ NO_TARGETING = NimbusTargetingConfig(
     application_choice_names=[a.name for a in Application],
 )
 
+ATTRIBUTION_MEDIUM_EMAIL = NimbusTargetingConfig(
+    name="Attribution Medium Email",
+    slug="attribution_medium_email",
+    description="Firefox installed with email attribution",
+    targeting="attributionData.medium == 'email'",
+    desktop_telemetry="environment.settings.attribution.medium = 'email'",
+    sticky_required=False,
+    is_first_run_required=False,
+    application_choice_names=(Application.DESKTOP.name,),
+)
+
 NEW_PROFILE_CREATED = NimbusTargetingConfig(
     name="New profile created",
     slug="new_profile_created",


### PR DESCRIPTION
Because Firefox OKR4.1 wants to experiment with whole lifecycle including before installation through desktop usage.

This commit adds advanced targeting for marketing email attribution.

![nimbus attribution](https://user-images.githubusercontent.com/438537/231832380-85df9120-f8f6-4158-bc78-cf0d49939a3e.png)
![jexl attribution](https://user-images.githubusercontent.com/438537/231832401-eb89b8de-2ca8-49d1-838d-353e1c5a67bf.png)

