### PR TITLE
fix #8686 feat(cirrus): Fail ci to generate openapi.json

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -205,7 +205,7 @@ CIRRUS_RUFF_FIX = ruff --fix cirrus/server
 CIRRUS_PYTEST = pytest cirrus/server --cov=cirrus
 CIRRUS_PYTHON_TYPECHECK = pyright -p cirrus/server
 CIRRUS_PYTHON_TYPECHECK_CREATESTUB = pyright -p cirrus/server --createstub cirrus
-CIRRUS_GENERATE_DOCS = python cirrus/server/cirrus/generate_docs.py
+CIRRUS_GENERATE_DOCS = python cirrus/server/cirrus/generate_docs.py --check=true
 
 cirrus_up:
 	$(COMPOSE) up cirrus

--- a/Makefile
+++ b/Makefile
@@ -205,7 +205,7 @@ CIRRUS_RUFF_FIX = ruff --fix cirrus/server
 CIRRUS_PYTEST = pytest cirrus/server --cov=cirrus
 CIRRUS_PYTHON_TYPECHECK = pyright -p cirrus/server
 CIRRUS_PYTHON_TYPECHECK_CREATESTUB = pyright -p cirrus/server --createstub cirrus
-CIRRUS_GENERATE_DOCS = python cirrus/server/cirrus/generate_docs.py --check=true
+CIRRUS_GENERATE_DOCS = python cirrus/server/cirrus/generate_docs.py
 
 cirrus_up:
 	$(COMPOSE) up cirrus
@@ -218,11 +218,14 @@ cirrus_test:
 
 cirrus_check:
 	$(COMPOSE_TEST) build cirrus_test
-	$(COMPOSE_TEST) run cirrus_test sh -c "$(CIRRUS_BLACK_CHECK) && $(CIRRUS_RUFF_CHECK)&& $(CIRRUS_PYTHON_TYPECHECK) && $(CIRRUS_PYTEST) && $(CIRRUS_GENERATE_DOCS)"
+	$(COMPOSE_TEST) run cirrus_test sh -c "$(CIRRUS_BLACK_CHECK) && $(CIRRUS_RUFF_CHECK)&& $(CIRRUS_PYTHON_TYPECHECK) && $(CIRRUS_PYTEST) && $(CIRRUS_GENERATE_DOCS) --check"
 
 cirrus_code_format:
 	$(COMPOSE_TEST) run cirrus_test sh -c '$(CIRRUS_BLACK_FIX) && $(CIRRUS_RUFF_FIX)'
 
 cirrus_typecheck_createstub:
 	$(COMPOSE_TEST) run cirrus_test sh -c '$(CIRRUS_PYTHON_TYPECHECK_CREATESTUB)'
+
+cirrus_generate_docs:
+	$(COMPOSE_TEST) run cirrus_test sh -c '$(CIRRUS_GENERATE_DOCS)'
 

--- a/cirrus/server/cirrus/generate_docs.py
+++ b/cirrus/server/cirrus/generate_docs.py
@@ -1,5 +1,7 @@
+import argparse
 import json
 import os
+import sys
 
 from fastapi.openapi.utils import get_openapi
 from main import app
@@ -8,7 +10,7 @@ DOCS_DIR = "cirrus/server/cirrus/docs"
 OPENAPI_PATH = os.path.join(DOCS_DIR, "openapi.json")
 
 
-def generate_openapi_schema():
+def generate_or_check_openapi(check_docs: bool) -> None:
     # Generate new OpenAPI schema
     openapi_schema = get_openapi(
         title=app.title,
@@ -17,16 +19,35 @@ def generate_openapi_schema():
         routes=app.routes,
     )
 
-    with open(OPENAPI_PATH, "r") as f:
-        if not os.path.isfile(OPENAPI_PATH) or openapi_schema != json.load(f):
-            with open(OPENAPI_PATH, "w") as f:
-                json.dump(openapi_schema, f)
-            print("openapi.json has been updated!")
-            return False
-        else:
-            print("openapi.json is already up-to-date.")
-            return False
+    if check_docs:
+        # Check if openapi.json is up-to-date
+        try:
+            with open(OPENAPI_PATH, "r") as f:
+                if openapi_schema != json.load(f):
+                    print("openapi.json is not up-to-date.")
+                    print("Please update the docs using `make cirrus_generate_docs`.")
+                    sys.exit(1)
+                else:
+                    print("openapi.json is already up-to-date.")
+        except FileNotFoundError:
+            print("openapi.json not found.")
+            print("Please generate the docs using `make cirrus_generate_docs`.")
+            sys.exit(1)
+    else:
+        # Update openapi.json
+        with open(OPENAPI_PATH, "w") as f:
+            json.dump(openapi_schema, f)
+        print("openapi.json has been updated!")
 
 
 if __name__ == "__main__":
-    generate_openapi_schema()
+    parser = argparse.ArgumentParser(description="Generates OpenAPI schema")
+    parser.add_argument(
+        "--check",
+        dest="check_docs",
+        action="store_true",
+        help="Check if openapi.json is up-to-date",
+    )
+    args = parser.parse_args()
+
+    generate_or_check_openapi(args.check_docs)

--- a/cirrus/server/cirrus/generate_docs.py
+++ b/cirrus/server/cirrus/generate_docs.py
@@ -22,8 +22,10 @@ def generate_openapi_schema():
             with open(OPENAPI_PATH, "w") as f:
                 json.dump(openapi_schema, f)
             print("openapi.json has been updated!")
+            return False
         else:
             print("openapi.json is already up-to-date.")
+            return False
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Because

- We don't want to silently make ci update the open API schema for Cirrus

This commit

- Informs the user to update the schema
- Make command to update open API schema `make cirrus_generate_docs`
<img width="1225" alt="image" src="https://user-images.githubusercontent.com/25848231/232618015-2d4c55c6-e41a-4cd5-945a-f7b760756e94.png">

fixes #8686 