### PR TITLE
fix #8705 chore(project): check file paths in nightly targeting tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,6 +98,16 @@ jobs:
     steps:
       - checkout
       - run:
+          name: Check file paths
+          command: |
+            if git diff --name-only main HEAD | grep -E 'experimenter/experimenter/targeting|experimenter/experimenter/experiments|experimenter/tests'
+              then
+                echo "Continuing"
+              else
+                echo "No targeting changes, skipping"
+                circleci-agent step halt
+            fi
+      - run:
           name: Run integration tests
           command: |
             cp .env.integration-tests .env


### PR DESCRIPTION
Because

* We only need to run the targeting tests for changes in the experiments or targeting apps
* We were checking those file paths in the release and beta circle runs but not nightly

This commit

* Adds the correct file path checks to the nightly targeting run

Because

- Reason

This commit

- Change
