### PR TITLE
For #8627 fix(nimbus): Add remote settings test for approving rollout updates

### DIFF
--- a/experimenter/tests/integration/nimbus/test_remote_settings.py
+++ b/experimenter/tests/integration/nimbus/test_remote_settings.py
@@ -205,6 +205,34 @@ def test_rollout_live_status_on_home_page(
 
 
 @pytest.mark.remote_settings
+def test_rollout_live_update_approve(
+    selenium,
+    base_url,
+    create_experiment,
+    kinto_client,
+    experiment_name,
+    slugify,
+):
+    experiment_slug = str(slugify(experiment_name))
+    create_experiment(selenium, is_rollout=True).launch_and_approve()
+
+    kinto_client.approve()
+    summary = SummaryPage(selenium, urljoin(base_url, experiment_slug)).open()
+
+    summary.wait_for_live_status()
+    audience = summary.navigate_to_audience()
+
+    audience.percentage = "60"
+    audience.save_and_continue()
+
+    summary_page = SummaryPage(selenium, urljoin(base_url, experiment_slug)).open()
+    summary_page.wait_for_update_request_visible()
+
+    summary_page.request_update_and_approve()
+    kinto_client.approve()
+
+
+@pytest.mark.remote_settings
 def test_rollout_live_update_approve_and_reject(
     selenium,
     base_url,


### PR DESCRIPTION
Because

- We [removed](https://github.com/mozilla/experimenter/pull/8653) this test until https://github.com/mozilla/experimenter/pull/8666 could be landed

This commit

- Adds the remote settings test back for approving rollout updates
