### PR TITLE
For #8714 feat(nimbus): Add serializer warning for desktop rollouts below v114

### DIFF
--- a/experimenter/experimenter/experiments/api/v5/serializers.py
+++ b/experimenter/experimenter/experiments/api/v5/serializers.py
@@ -1435,6 +1435,19 @@ class NimbusReviewSerializer(serializers.ModelSerializer):
     def _validate_versions(self, data):
         min_version = data.get("firefox_min_version", "")
         max_version = data.get("firefox_max_version", "")
+        is_rollout = data.get("is_rollout")
+        application = data.get("application")
+
+        if (
+            application == NimbusExperiment.Application.DESKTOP
+            and is_rollout
+            and NimbusExperiment.Version.parse(min_version)
+            < NimbusExperiment.Version.parse(NimbusExperiment.Version.FIREFOX_114)
+        ):
+            self.warnings["firefox_min_version"] = [
+                NimbusConstants.ERROR_DESKTOP_ROLLOUT_VERSION
+            ]
+
         if (
             min_version != ""
             and max_version != ""

--- a/experimenter/experimenter/experiments/api/v5/serializers.py
+++ b/experimenter/experimenter/experiments/api/v5/serializers.py
@@ -1442,7 +1442,9 @@ class NimbusReviewSerializer(serializers.ModelSerializer):
             application == NimbusExperiment.Application.DESKTOP
             and is_rollout
             and NimbusExperiment.Version.parse(min_version)
-            < NimbusExperiment.Version.parse(NimbusExperiment.Version.FIREFOX_114)
+            < NimbusExperiment.Version.parse(
+                NimbusConstants.DESKTOP_ROLLOUT_MIN_SUPPORTED_VERSION
+            )
         ):
             self.warnings["firefox_min_version"] = [
                 NimbusConstants.ERROR_DESKTOP_ROLLOUT_VERSION

--- a/experimenter/experimenter/experiments/constants.py
+++ b/experimenter/experimenter/experiments/constants.py
@@ -355,7 +355,9 @@ class NimbusConstants(object):
         Application.IOS: Version.FIREFOX_101,
         Application.FOCUS_IOS: Version.FIREFOX_101,
     }
+
     FEATURE_ENABLED_MIN_UNSUPPORTED_VERSION = Version.FIREFOX_104
+    DESKTOP_ROLLOUT_MIN_SUPPORTED_VERSION = Version.FIREFOX_114
 
     ROLLOUT_SUPPORT_VERSION = {
         Application.DESKTOP: Version.FIREFOX_105,

--- a/experimenter/experimenter/experiments/constants.py
+++ b/experimenter/experimenter/experiments/constants.py
@@ -416,6 +416,10 @@ Optional - We believe this outcome will <describe impact> on <core metric>
         will be enrolled in one and not the other and \
         you will not be able to adjust the sizing for this rollout."
 
+    ERROR_DESKTOP_ROLLOUT_VERSION = "WARNING: Decreasing the population size while live \
+        is not supported for Desktop versions under 114. You will still be able to \
+        increase the population size."
+
     # Analysis can be computed starting the week after enrollment
     # completion for "week 1" of the experiment. However, an extra
     # buffer day is added for Jetstream to compute the results.

--- a/experimenter/experimenter/experiments/constants.py
+++ b/experimenter/experimenter/experiments/constants.py
@@ -418,9 +418,9 @@ Optional - We believe this outcome will <describe impact> on <core metric>
         will be enrolled in one and not the other and \
         you will not be able to adjust the sizing for this rollout."
 
-    ERROR_DESKTOP_ROLLOUT_VERSION = "WARNING: Decreasing the population size while live \
-        is not supported for Desktop versions under 114. You will still be able to \
-        increase the population size."
+    ERROR_DESKTOP_ROLLOUT_VERSION = "WARNING: Decreasing the population size while the \
+        rollout is live is not supported for Desktop versions under 114. You will still \
+        be able to increase the population size."
 
     # Analysis can be computed starting the week after enrollment
     # completion for "week 1" of the experiment. However, an extra


### PR DESCRIPTION
Because

- We want to warn owners that below v114 they will not be able to reduce the population percentage on Desktop rollouts

This commit

- Adds a serializer warning
- Adds serializer tests

This commit _does not_...
- Add the warning on the frontend. This will be in a separate PR - #8730 
