### PR TITLE
For #8714 feat(nimbus): Add warning on summary page for draft/preview desktop rollouts below v114

### DIFF
--- a/experimenter/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/index.test.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/index.test.tsx
@@ -177,6 +177,7 @@ describe("FormAudience", () => {
 
     expect(screen.getByTestId("isSticky")).not.toBeChecked();
   });
+
   it("expect sticky enrollment to be selected as sticky is required for the selected targeting", async () => {
     render(
       <Subject
@@ -244,6 +245,40 @@ describe("FormAudience", () => {
     await expect(
       screen.getByTestId("sticky-required-warning"),
     ).toBeInTheDocument();
+  });
+
+  it("expect desktop version warning when under 114", async () => {
+    render(
+      <Subject
+        experiment={{
+          ...MOCK_ROLLOUT,
+          application: NimbusExperimentApplicationEnum.DESKTOP,
+          channel: NimbusExperimentChannelEnum.NIGHTLY,
+          status: NimbusExperimentStatusEnum.DRAFT,
+          isRollout: true,
+          isSticky: true,
+          firefoxMinVersion: NimbusExperimentFirefoxVersionEnum.FIREFOX_107,
+        }}
+      />,
+    );
+    screen.queryByText("WARNING", { selector: `[data-for=firefoxMinVersion]` });
+  });
+
+  it("expect no desktop version warning when over 114", async () => {
+    render(
+      <Subject
+        experiment={{
+          ...MOCK_ROLLOUT,
+          application: NimbusExperimentApplicationEnum.DESKTOP,
+          channel: NimbusExperimentChannelEnum.NIGHTLY,
+          status: NimbusExperimentStatusEnum.DRAFT,
+          isRollout: true,
+          isSticky: true,
+          firefoxMinVersion: NimbusExperimentFirefoxVersionEnum.FIREFOX_118,
+        }}
+      />,
+    );
+    screen.queryByText("", { selector: `[data-for=firefoxMinVersion]` });
   });
 
   it("expect sticky enrollment to be optional as changing targeting from sticky required to sticky not required", async () => {

--- a/experimenter/experimenter/nimbus-ui/src/components/PageSummary/index.test.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageSummary/index.test.tsx
@@ -838,4 +838,68 @@ describe("PageSummary", () => {
     render(<Subject mocks={[mock]} />);
     expect(screen.queryByTestId("bucketing-warning")).not.toBeInTheDocument();
   });
+
+  it("displays a warning for desktop rollouts under v114", async () => {
+    const WARNING = "WARNING: Decreasing the population size while live";
+    const { mockRollout } = mockLiveRolloutQuery("demo-slug", {
+      readyForReview: {
+        ready: true,
+        message: {},
+        warnings: {
+          firefox_min_version: [WARNING],
+        },
+      },
+      isRollout: true,
+      application: NimbusExperimentApplicationEnum.DESKTOP,
+      channel: NimbusExperimentChannelEnum.NIGHTLY,
+      status: NimbusExperimentStatusEnum.DRAFT,
+      targetingConfigSlug: "OH_NO",
+    });
+    render(<Subject mocks={[mockRollout]} />);
+    await waitFor(() =>
+      expect(
+        screen.queryByTestId("desktop-min-version-warning"),
+      ).toBeInTheDocument(),
+    );
+  });
+
+  it("displays no warning for desktop rollouts above v113", async () => {
+    const { mockRollout } = mockLiveRolloutQuery("demo-slug", {
+      readyForReview: {
+        ready: true,
+        message: {},
+        warnings: {},
+      },
+      isRollout: true,
+      application: NimbusExperimentApplicationEnum.DESKTOP,
+      firefoxMinVersion: NimbusExperimentFirefoxVersionEnum.FIREFOX_116,
+      channel: NimbusExperimentChannelEnum.NIGHTLY,
+      status: NimbusExperimentStatusEnum.DRAFT,
+      targetingConfigSlug: "OH_NO",
+    });
+    render(<Subject mocks={[mockRollout]} />);
+    expect(
+      screen.queryByTestId("desktop-min-version-warning"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("displays no min version warning for non-desktop rollouts", async () => {
+    const { mock } = mockExperimentQuery("demo-slug", {
+      readyForReview: {
+        ready: true,
+        message: {},
+        warnings: {},
+      },
+      isRollout: true,
+      application: NimbusExperimentApplicationEnum.FENIX,
+      firefoxMinVersion: NimbusExperimentFirefoxVersionEnum.FIREFOX_106,
+      channel: NimbusExperimentChannelEnum.NIGHTLY,
+      status: NimbusExperimentStatusEnum.DRAFT,
+      targetingConfigSlug: "OH_NO",
+    });
+    render(<Subject mocks={[mock]} />);
+    expect(
+      screen.queryByTestId("desktop-min-version-warning"),
+    ).not.toBeInTheDocument();
+  });
 });

--- a/experimenter/experimenter/nimbus-ui/src/components/PageSummary/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageSummary/index.tsx
@@ -235,8 +235,9 @@ const PageSummary = (props: RouteComponentProps) => {
           </Alert>
         )}
 
-      {(experiment.status === NimbusExperimentStatusEnum.DRAFT ||
-        experiment.status === NimbusExperimentStatusEnum.PREVIEW) &&
+      {experiment.isRollout &&
+        (experiment.status === NimbusExperimentStatusEnum.DRAFT ||
+          experiment.status === NimbusExperimentStatusEnum.PREVIEW) &&
         fieldWarnings.firefox_min_version?.length > 0 && (
           <Alert data-testid="desktop-min-version-warning" variant="warning">
             {fieldWarnings.firefox_min_version as SerializerMessage}

--- a/experimenter/experimenter/nimbus-ui/src/components/PageSummary/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageSummary/index.tsx
@@ -235,6 +235,14 @@ const PageSummary = (props: RouteComponentProps) => {
           </Alert>
         )}
 
+      {(experiment.status === NimbusExperimentStatusEnum.DRAFT ||
+        experiment.status === NimbusExperimentStatusEnum.PREVIEW) &&
+        fieldWarnings.firefox_min_version?.length > 0 && (
+          <Alert data-testid="desktop-min-version-warning" variant="warning">
+            {fieldWarnings.firefox_min_version as SerializerMessage}
+          </Alert>
+        )}
+
       {summaryAction && (
         <h5 className="mt-3 mb-4 ml-3">
           {summaryAction} {launchDocs}


### PR DESCRIPTION
~📢 do not land before #8726~ done

Because

- We want to warn users that desktop rollouts below v114 cannot lower their population percentage
- And we added a serializer warning (#8726)

This commit

- Shows the warning on the summary page for rollouts that are in Draft/Preview
- Shows the warning on the Min Version field in the Audience page (this will be viewable ALL the time, not just in Draft/Preview. We want users to know that this is still a limitation when they go to change the population size while it's Live).

https://user-images.githubusercontent.com/43795363/233487186-1e69f8e5-e6e6-44f2-8423-878d4c826e9c.mov

<img width="1360" alt="image" src="https://user-images.githubusercontent.com/43795363/234112769-6729c485-76c9-4ece-80f9-89b6a532da6b.png">


<img width="1342" alt="image" src="https://user-images.githubusercontent.com/43795363/234112664-92150f72-f4d9-4fa4-b63b-b759d3237d9c.png">
