### PR TITLE
feat(nimbus): check Remote Settings connectivity in heartbeat

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,8 +18,8 @@ PAD = -------------------------------------------------\n
 COLOR_CHECK = && echo "${GREEN}${PAD}All Checks Passed\n${PAD}${NOCOLOR}" || (echo "${RED}${PAD}Some Checks Failed\n${PAD}${NOCOLOR}";exit 1)
 PYTHON_TEST = pytest --cov --cov-report term-missing
 PYTHON_TYPECHECK = pyright experimenter/
-PYTHON_CHECK_MIGRATIONS = python manage.py makemigrations --check --dry-run --noinput
-PYTHON_MIGRATE = python manage.py migrate
+PYTHON_CHECK_MIGRATIONS = python manage.py makemigrations --check --dry-run --noinput --skip-checks
+PYTHON_MIGRATE = python manage.py migrate --skip-checks
 ESLINT_LEGACY = yarn workspace @experimenter/core lint
 ESLINT_FIX_CORE = yarn workspace @experimenter/core lint-fix
 ESLINT_NIMBUS_UI = yarn workspace @experimenter/nimbus-ui lint
@@ -34,13 +34,13 @@ RUFF_CHECK = ruff experimenter/ tests/
 RUFF_FIX = ruff --fix experimenter/ tests/
 BLACK_CHECK = black -l 90 --check --diff . --exclude node_modules
 BLACK_FIX = black -l 90 . --exclude node_modules
-CHECK_DOCS = python manage.py generate_docs --check=true
-GENERATE_DOCS = python manage.py generate_docs
-LOAD_COUNTRIES = python manage.py loaddata ./experimenter/base/fixtures/countries.json
-LOAD_LOCALES = python manage.py loaddata ./experimenter/base/fixtures/locales.json
-LOAD_LANGUAGES = python manage.py loaddata ./experimenter/base/fixtures/languages.json
-LOAD_FEATURES = python manage.py load_feature_configs
-LOAD_DUMMY_EXPERIMENTS = [[ -z $$SKIP_DUMMY ]] && python manage.py load_dummy_experiments || python manage.py load_dummy_projects
+CHECK_DOCS = python manage.py generate_docs --check=true --skip-checks
+GENERATE_DOCS = python manage.py generate_docs --skip-checks
+LOAD_COUNTRIES = python manage.py loaddata ./experimenter/base/fixtures/countries.json --skip-checks
+LOAD_LOCALES = python manage.py loaddata ./experimenter/base/fixtures/locales.json --skip-checks
+LOAD_LANGUAGES = python manage.py loaddata ./experimenter/base/fixtures/languages.json --skip-checks
+LOAD_FEATURES = python manage.py load_feature_configs --skip-checks
+LOAD_DUMMY_EXPERIMENTS = [[ -z $$SKIP_DUMMY ]] && python manage.py load_dummy_experiments --skip-checks || python manage.py load_dummy_projects --skip-checks
 PYTHON_PATH_SDK = PYTHONPATH=/application-services/components/nimbus/src
 
 
@@ -160,7 +160,7 @@ code_format: build_dev
 	$(COMPOSE) run experimenter sh -c '${PARALLEL} "$(RUFF_FIX);$(BLACK_FIX)" "$(ESLINT_FIX_CORE)" "$(ESLINT_FIX_NIMBUS_UI)"'
 
 makemigrations: build_dev
-	$(COMPOSE) run experimenter python manage.py makemigrations
+	$(COMPOSE) run experimenter python manage.py makemigrations --skip-checks
 
 migrate: build_dev
 	$(COMPOSE) run experimenter sh -c "$(WAIT_FOR_DB) $(PYTHON_MIGRATE)"

--- a/experimenter/experimenter/base/tests/test_views.py
+++ b/experimenter/experimenter/base/tests/test_views.py
@@ -1,13 +1,36 @@
+import requests
 from django.conf import settings
 from django.test import TestCase, override_settings
 from django.urls import reverse
 
+from experimenter.kinto.tests.mixins import MockKintoClientMixin
+
 
 @override_settings(DEBUG=False)
-class TestHeartbeats(TestCase):
+class TestHeartbeats(MockKintoClientMixin, TestCase):
     def test_heartbeat(self):
+        self.mock_kinto_client.server_info.return_value = {
+            "user": {"id": "account:experimenter"}
+        }
+        self.mock_kinto_client.session.request.return_value = {}  # heartbeat
+
         response = self.client.get("/__heartbeat__")
         self.assertEqual(response.status_code, 200)
+
+    def test_heartbeat_remote_settings_failing(self):
+        self.mock_kinto_client.session.request.side_effect = requests.ConnectionError()
+
+        response = self.client.get("/__heartbeat__")
+        self.assertTrue(response.status_code >= 500)
+        self.assertEqual(response.json()["checks"]["remote_settings_check"], "error")
+
+    def test_heartbeat_remote_settings_bad_auth(self):
+        self.mock_kinto_client.server_info.return_value = {}
+        self.mock_kinto_client.session.request.return_value = {}  # heartbeat
+
+        response = self.client.get("/__heartbeat__")
+        self.assertTrue(response.status_code >= 500)
+        self.assertEqual(response.json()["checks"]["remote_settings_check"], "error")
 
     def test_lbheartbeat(self):
         response = self.client.get("/__lbheartbeat__")

--- a/experimenter/experimenter/experiments/apps.py
+++ b/experimenter/experimenter/experiments/apps.py
@@ -1,6 +1,9 @@
 import markus
 from django.apps import AppConfig
 from django.conf import settings
+from django.core.checks import register as check_register
+
+from experimenter.kinto.checks import remote_settings_check
 
 
 class ExperimentsConfig(AppConfig):
@@ -8,3 +11,5 @@ class ExperimentsConfig(AppConfig):
 
     def ready(self):
         markus.configure(settings.MARKUS_BACKEND)
+
+        check_register(remote_settings_check)

--- a/experimenter/experimenter/kinto/checks.py
+++ b/experimenter/experimenter/kinto/checks.py
@@ -1,0 +1,32 @@
+from django.conf import settings
+from django.core.checks import Error
+
+from experimenter.kinto.client import KintoClient
+
+
+def remote_settings_check(app_configs, **kwargs):
+    errors = []
+
+    client = KintoClient(settings.KINTO_COLLECTION_NIMBUS_PREVIEW)
+
+    try:
+        client.heartbeat()
+    except Exception as e:
+        errors.append(
+            Error(
+                f"Remote Settings connection is unhealthy: {e}",
+                hint="Verify connectivity and server status.",
+                id="experimenter.remotesettings.E001",
+            )
+        )
+
+    if not errors and not client.authenticated():
+        errors.append(
+            Error(
+                "Invalid credentials for Remote Settings",
+                hint="Contact administrators.",
+                id="experimenter.remotesettings.E002",
+            )
+        )
+
+    return errors

--- a/experimenter/experimenter/kinto/client.py
+++ b/experimenter/experimenter/kinto/client.py
@@ -17,6 +17,13 @@ class KintoClient:
         self.review = review
         self.collection_data = None
 
+    def heartbeat(self):
+        return self.kinto_http_client.session.request("GET", "/__heartbeat__")
+
+    def authenticated(self):
+        server_info = self.kinto_http_client.server_info()
+        return "id" in server_info.get("user", {})
+
     def _fetch_collection_data(self):
         self.collection_data = (
             self.collection_data


### PR DESCRIPTION
Because

- We want to discover Remote Settings connectivity issue before the background tasks fail

This commit

- Registers a new check
- Checks heartbeat
- Checks credentials
