### PR TITLE
feat(nimbus): add targeting to exclude import infrequent rollouts

### DIFF
--- a/experimenter/experimenter/experiments/tests/__init__.py
+++ b/experimenter/experimenter/experiments/tests/__init__.py
@@ -1,8 +1,15 @@
 from pyjexl.jexl import JEXLConfig
-from pyjexl.operators import default_binary_operators, default_unary_operators
+from pyjexl.operators import Operator, default_binary_operators, default_unary_operators
 from pyjexl.parser import Parser, jexl_grammar
 
-jexl_config = JEXLConfig({}, default_unary_operators, default_binary_operators)
+jexl_config = JEXLConfig(
+    {},
+    default_unary_operators,
+    {
+        **default_binary_operators,
+        "intersect": Operator("intersect", 40, lambda x, y: set(x).intersection(y)),
+    },
+)
 
 
 class JEXLParser(Parser):

--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -1156,6 +1156,22 @@ TRR_MODE_ZERO = NimbusTargetingConfig(
     application_choice_names=(Application.DESKTOP.name,),
 )
 
+NOT_IMPORT_INFREQUENT_ROLLOUT = NimbusTargetingConfig(
+    name="Not in Import Infrequent Rollouts",
+    slug="not_import_infrequent_rollout",
+    description="Exclude users in the import infrequent rollouts",
+    targeting=(
+        "(activeRollouts intersect ["
+        "   'import-infrequent-rollout-make-yourself-at-home',"
+        "   'updated-import-infrequent-rollout-make-yourself-at-home-copy'"
+        "])|length == 0"
+    ),
+    desktop_telemetry="",
+    sticky_required=False,
+    is_first_run_required=False,
+    application_choice_names=(Application.DESKTOP.name,),
+)
+
 
 class TargetingConstants:
     TARGETING_VERSION = "version|versionCompare('{version}') >= 0"


### PR DESCRIPTION
Because we want to exclude any user in either the original https://experimenter.services.mozilla.com/nimbus/import-infrequent-rollout-make-yourself-at-home or relaunched https://experimenter.services.mozilla.com/nimbus/updated-import-infrequent-rollout-make-yourself-at-home-copy so that a new experiment https://experimenter.services.mozilla.com/nimbus/new-import-interface-firefox-114-launch for a separate feature doesn't interact poorly (import spotlight modal could be stuck when some new wizard branches opens about:preferences in a tab)

This commit adds targeting to exclude (and unenroll -- i.e., don't want sticky) from the experiment anybody in the rollout. It's insufficient to add targeting that is opposite of the rollouts (i.e., `!(infrequent 5 bookmarks)`) because the rollouts have sticky enrollment.

This also updates the tests to handle "intersect" binary operator in the jexl tests to match https://searchfox.org/mozilla-central/rev/26790fecfcda622dab234b28859da721b80f3a35/toolkit/components/utils/FilterExpressions.sys.mjs#35,84-96

@dmose @jwayn 