### PR TITLE
fixes #8744 chore(Nimbus): Add HTML report generation and gathering for integration tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,6 +56,8 @@ jobs:
           command: |
             cp .env.integration-tests .env
             make refresh SKIP_DUMMY=1 PYTEST_SENTRY_DSN=$PYTEST_SENTRY_DSN CIRCLECI=$CIRCLECI up_prod_detached integration_test_nimbus PYTEST_ARGS="$PYTEST_ARGS"
+      - store_artifacts:
+          path: /experimenter/tests/integration/test-reports/report.htm
 
   integration_nimbus_desktop_beta_targeting:
     machine:
@@ -84,6 +86,8 @@ jobs:
           command: |
             cp .env.integration-tests .env
             make refresh SKIP_DUMMY=1 PYTEST_SENTRY_DSN=$PYTEST_SENTRY_DSN CIRCLECI=$CIRCLECI up_prod_detached integration_test_nimbus PYTEST_ARGS="$PYTEST_ARGS"
+      - store_artifacts:
+          path: /experimenter/tests/integration/test-reports/report.htm
 
   integration_nimbus_desktop_nightly_targeting:
     machine:
@@ -112,6 +116,8 @@ jobs:
           command: |
             cp .env.integration-tests .env
             make refresh SKIP_DUMMY=1 PYTEST_SENTRY_DSN=$PYTEST_SENTRY_DSN CIRCLECI=$CIRCLECI up_prod_detached integration_test_nimbus PYTEST_ARGS="$PYTEST_ARGS"
+      - store_artifacts:
+          path: /experimenter/tests/integration/test-reports/report.htm
 
   integration_nimbus_desktop_remote_settings:
     machine:
@@ -129,6 +135,8 @@ jobs:
           command: |
             cp .env.integration-tests .env
             make refresh SKIP_DUMMY=1 PYTEST_SENTRY_DSN=$PYTEST_SENTRY_DSN CIRCLECI=$CIRCLECI up_prod_detached integration_test_nimbus PYTEST_ARGS="$PYTEST_ARGS"
+      - store_artifacts:
+          path: /experimenter/tests/integration/test-reports/report.htm
 
   integration_nimbus_fenix_remote_settings:
     machine:
@@ -146,6 +154,8 @@ jobs:
           command: |
             cp .env.integration-tests .env
             make refresh SKIP_DUMMY=1 PYTEST_SENTRY_DSN=$PYTEST_SENTRY_DSN CIRCLECI=$CIRCLECI up_prod_detached integration_test_nimbus PYTEST_ARGS="$PYTEST_ARGS"
+      - store_artifacts:
+          path: /experimenter/tests/integration/test-reports/report.htm
 
   integration_nimbus_ios_remote_settings:
     machine:
@@ -163,6 +173,8 @@ jobs:
           command: |
             cp .env.integration-tests .env
             make refresh SKIP_DUMMY=1 PYTEST_SENTRY_DSN=$PYTEST_SENTRY_DSN CIRCLECI=$CIRCLECI up_prod_detached integration_test_nimbus PYTEST_ARGS="$PYTEST_ARGS"
+      - store_artifacts:
+          path: /experimenter/tests/integration/test-reports/report.htm
 
   integration_nimbus_focus_android_remote_settings:
     machine:
@@ -180,6 +192,8 @@ jobs:
           command: |
             cp .env.integration-tests .env
             make refresh SKIP_DUMMY=1 PYTEST_SENTRY_DSN=$PYTEST_SENTRY_DSN CIRCLECI=$CIRCLECI up_prod_detached integration_test_nimbus PYTEST_ARGS="$PYTEST_ARGS"
+      - store_artifacts:
+          path: /experimenter/tests/integration/test-reports/report.htm
 
   integration_nimbus_focus_ios_remote_settings:
     machine:
@@ -197,6 +211,8 @@ jobs:
           command: |
             cp .env.integration-tests .env
             make refresh SKIP_DUMMY=1 PYTEST_SENTRY_DSN=$PYTEST_SENTRY_DSN CIRCLECI=$CIRCLECI up_prod_detached integration_test_nimbus PYTEST_ARGS="$PYTEST_ARGS"
+      - store_artifacts:
+          path: /experimenter/tests/integration/test-reports/report.htm
 
   integration_nimbus_desktop_enrollment:
     machine:
@@ -216,6 +232,8 @@ jobs:
             cp .env.integration-tests .env
             make refresh SKIP_DUMMY=1 PYTEST_SENTRY_DSN=$PYTEST_SENTRY_DSN CIRCLECI=$CIRCLECI up_prod_detached integration_test_nimbus PYTEST_ARGS="$PYTEST_ARGS"
           no_output_timeout: 30m
+      - store_artifacts:
+          path: /experimenter/tests/integration/test-reports/report.htm
 
   integration_nimbus_desktop_ui:
     machine:
@@ -233,6 +251,8 @@ jobs:
           command: |
             cp .env.integration-tests .env
             make refresh SKIP_DUMMY=1 PYTEST_SENTRY_DSN=$PYTEST_SENTRY_DSN CIRCLECI=$CIRCLECI up_prod_detached integration_test_nimbus PYTEST_ARGS="$PYTEST_ARGS"
+      - store_artifacts:
+          path: /experimenter/tests/integration/test-reports/report.htm
 
   integration_nimbus_sdk_targeting:
     machine:
@@ -257,6 +277,8 @@ jobs:
           command: |
             cp .env.integration-tests .env
             make refresh SKIP_DUMMY=1 PYTEST_SENTRY_DSN=$PYTEST_SENTRY_DSN CIRCLECI=$CIRCLECI up_prod_detached integration_test_nimbus_rust PYTEST_ARGS="$PYTEST_ARGS"
+      - store_artifacts:
+          path: /experimenter/tests/integration/test-reports/report.htm
 
   integration_legacy:
     machine:
@@ -279,6 +301,8 @@ jobs:
           command: |
             cp .env.sample .env
             make refresh up_prod_detached integration_test_legacy
+      - store_artifacts:
+          path: /experimenter/tests/integration/test-reports/report.htm
 
   deploy:
     working_directory: ~/experimenter

--- a/Makefile
+++ b/Makefile
@@ -189,13 +189,13 @@ integration_vnc_up_detached: build_prod
 	$(COMPOSE_INTEGRATION) up -d firefox
 
 integration_test_legacy: build_prod
-	MOZ_HEADLESS=1 $(COMPOSE_INTEGRATION) run firefox sh -c "sudo apt-get -qqy update && sudo apt-get -qqy install tox;sudo chmod a+rwx /code/experimenter/tests/integration/.tox;tox -c experimenter/tests/integration -e integration-test-legacy $(TOX_ARGS) -- -n 2 $(PYTEST_ARGS)"
+	MOZ_HEADLESS=1 $(COMPOSE_INTEGRATION) run firefox sh -c "sudo apt-get -qqy update && sudo apt-get -qqy install tox;sudo chmod -R a+rwx /code/experimenter/tests/integration/;sudo mkdir -m a+rwx /code/experimenter/tests/integration/test-reports;tox -c experimenter/tests/integration -e integration-test-legacy $(TOX_ARGS) -- -n 2 $(PYTEST_ARGS)"
 
 integration_test_nimbus: build_prod
-	MOZ_HEADLESS=1 $(COMPOSE_INTEGRATION) run firefox sh -c "if [ "$$UPDATE_FIREFOX_VERSION" = "true" ]; then sudo ./experimenter/tests/integration/nimbus/utils/nightly-install.sh; fi; firefox -V; sudo apt-get -qqy update && sudo apt-get -qqy install tox;sudo chmod a+rwx /code/experimenter/tests/integration/.tox;PYTEST_SENTRY_DSN=$(PYTEST_SENTRY_DSN) PYTEST_SENTRY_ALWAYS_REPORT=$(PYTEST_SENTRY_ALWAYS_REPORT) CIRCLECI=$(CIRCLECI) tox -c experimenter/tests/integration -e integration-test-nimbus $(TOX_ARGS) -- $(PYTEST_ARGS)"
+	MOZ_HEADLESS=1 $(COMPOSE_INTEGRATION) run firefox sh -c "if [ "$$UPDATE_FIREFOX_VERSION" = "true" ]; then sudo ./experimenter/tests/integration/nimbus/utils/nightly-install.sh; fi; firefox -V; sudo apt-get -qqy update && sudo apt-get -qqy install tox;sudo chmod a+rwx /code/experimenter/tests/integration/.tox;sudo mkdir -m a+rwx /code/experimenter/tests/integration/test-reports;PYTEST_SENTRY_DSN=$(PYTEST_SENTRY_DSN) PYTEST_SENTRY_ALWAYS_REPORT=$(PYTEST_SENTRY_ALWAYS_REPORT) CIRCLECI=$(CIRCLECI) tox -c experimenter/tests/integration -e integration-test-nimbus $(TOX_ARGS) -- $(PYTEST_ARGS)"
 
 integration_test_nimbus_rust: build_prod
-	MOZ_HEADLESS=1 $(COMPOSE_INTEGRATION) run rust-sdk sh -c "chmod a+rwx /code/experimenter/tests/integration/.tox;tox -c experimenter/tests/integration -e integration-test-nimbus-rust $(TOX_ARGS) -- -n 2 $(PYTEST_ARGS)"
+	MOZ_HEADLESS=1 $(COMPOSE_INTEGRATION) run rust-sdk sh -c "chmod -R a+rwx /code/experimenter/tests/integration/;sudo mkdir -m a+rwx /code/experimenter/tests/integration/test-reports;tox -c experimenter/tests/integration -e integration-test-nimbus-rust $(TOX_ARGS) -- -n 2 $(PYTEST_ARGS)"
 
 # cirrus
 CIRRUS_BLACK_CHECK = black -l 90 --check --diff cirrus/server

--- a/experimenter/tests/integration/tox.ini
+++ b/experimenter/tests/integration/tox.ini
@@ -6,21 +6,21 @@ passenv = *
 recreate = true
 commands =
     pip install -r ../requirements.txt
-    pytest --verify-base-url --base-url https://nginx/ --self-contained-html --driver Firefox legacy/ {posargs} -vvv
+    pytest --verify-base-url --base-url https://nginx/ --html=test-reports/report.htm --self-contained-html --driver Firefox legacy/ {posargs} -vvv
 
 [testenv:integration-test-nimbus]
 passenv = *
 recreate = true
 commands =
     pip install -r ../requirements.txt
-    pytest --verify-base-url --base-url https://nginx/nimbus/ --self-contained-html --reruns-delay 30 --driver Firefox nimbus/ {posargs} -vvv
+    pytest --verify-base-url --base-url https://nginx/nimbus/ --html=test-reports/report.htm --self-contained-html --reruns-delay 30 --driver Firefox nimbus/ {posargs} -vvv
 
 [testenv:integration-test-nimbus-rust]
 passenv = *
 recreate = true
 commands =
     pip install -r ../requirements.txt
-    pytest --verify-base-url --base-url https://nginx/nimbus/ --self-contained-html --driver Firefox nimbus/test_mobile_targeting.py {posargs} -vvv
+    pytest --verify-base-url --base-url https://nginx/nimbus/ --html=test-reports/report.htm --self-contained-html --driver Firefox nimbus/test_mobile_targeting.py {posargs} -vvv
 setenv =
     PYTHONPATH=/application-services/components/nimbus/src
 


### PR DESCRIPTION
Because:

* Diagnosing errors on CI can be hard without seeing what the page looks like

This Commit:

* Adds HTML reporting which will include screenshots for debugging errors.

