### PR TITLE
fix #8767 bug(nimbus): disable parallel for enrollment tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -222,7 +222,7 @@ jobs:
     working_directory: ~/experimenter
     environment:
       FIREFOX_VERSION: nimbus-firefox-release
-      PYTEST_ARGS: -k FIREFOX_DESKTOP -m desktop_enrollment --dist=loadgroup -n=2
+      PYTEST_ARGS: -k FIREFOX_DESKTOP -m desktop_enrollment
       UPDATE_FIREFOX_VERSION: true
     steps:
       - checkout

--- a/.gitignore
+++ b/.gitignore
@@ -88,6 +88,7 @@ experimenter/experimenter/reporting/reporting-ui/assets/
 .testmondata
 .tmontmp
 experimenter/coverage_html_report/
+experimenter/tests/integration/test-reports/
 
 # Dependencies
 node_modules


### PR DESCRIPTION
Because

* We've been seeing intermittent failures in the enrollment integration tests
* It may be caused by parallel tests colliding when they reset the ping server cache

This commit

* Disables parallel runs for the enrollment integration tests

