### PR TITLE
feat(nimbus): add targeting for paidsearch attribution and also for firstrun/newprofile

### DIFF
--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -54,6 +54,17 @@ ATTRIBUTION_MEDIUM_EMAIL = NimbusTargetingConfig(
     application_choice_names=(Application.DESKTOP.name,),
 )
 
+ATTRIBUTION_MEDIUM_PAIDSEARCH = NimbusTargetingConfig(
+    name="Attribution Medium Paidsearch",
+    slug="attribution_medium_paidsearch",
+    description="Firefox installed with paidsearch attribution",
+    targeting="attributionData.medium == 'paidsearch'",
+    desktop_telemetry="environment.settings.attribution.medium = 'paidsearch'",
+    sticky_required=False,
+    is_first_run_required=False,
+    application_choice_names=(Application.DESKTOP.name,),
+)
+
 NEW_PROFILE_CREATED = NimbusTargetingConfig(
     name="New profile created",
     slug="new_profile_created",
@@ -74,6 +85,31 @@ FIRST_RUN = NimbusTargetingConfig(
         not_see_aw="!('trailhead.firstrun.didSeeAboutWelcome'|preferenceValue)",
     ),
     desktop_telemetry=("payload.info.profile_subsession_counter = 1"),
+    sticky_required=True,
+    is_first_run_required=False,
+    application_choice_names=(Application.DESKTOP.name,),
+)
+
+FIRST_RUN_NEW_PROFILE = NimbusTargetingConfig(
+    name="First start-up new users",
+    slug="first_run_new_profile",
+    description="First start-up users (e.g. for about:welcome) with a new profile",
+    targeting=f"{FIRST_RUN.targeting} && {NEW_PROFILE_CREATED.targeting}",
+    desktop_telemetry=f"{FIRST_RUN.desktop_telemetry} AND "
+    f"{NEW_PROFILE_CREATED.desktop_telemetry}",
+    sticky_required=True,
+    is_first_run_required=False,
+    application_choice_names=(Application.DESKTOP.name,),
+)
+
+FIRST_RUN_NEW_PROFILE_ATTRIBUTION_MEDIUM_PAIDSEARCH = NimbusTargetingConfig(
+    name="First start-up new users with paidsearch attribution",
+    slug="first_run_new_profile_attribution_medium_paidsearch",
+    description="First start-up new users installed with paidsearch attribution",
+    targeting=f"{FIRST_RUN_NEW_PROFILE.targeting} && "
+    f"{ATTRIBUTION_MEDIUM_PAIDSEARCH.targeting}",
+    desktop_telemetry=f"{FIRST_RUN_NEW_PROFILE.desktop_telemetry} AND "
+    f"{ATTRIBUTION_MEDIUM_PAIDSEARCH.desktop_telemetry}",
     sticky_required=True,
     is_first_run_required=False,
     application_choice_names=(Application.DESKTOP.name,),


### PR DESCRIPTION
Because like #8690 for OKR 4.1 experimenting with firefox attribution.

This commit adds advanced targeting for marketing paidsearch attribution individually and as part of firstrun newprofile.

Here's a screenshot of "First Run New Profile Attribution Medium Paidsearch" targeting:
![new profile paidsearch](https://user-images.githubusercontent.com/438537/235789296-d4c84117-3748-46d2-b597-046a7a996ff9.png)
