### PR TITLE
Fixes #8770 bug(cirrus): Fix docker volumes to allow for reloading during cirrus dev work

### DIFF
--- a/cirrus/server/Dockerfile
+++ b/cirrus/server/Dockerfile
@@ -2,7 +2,7 @@
 FROM python:3.11.2-slim-buster
 
 # Set working directory for the container
-WORKDIR /app/cirrus
+WORKDIR /cirrus
 
 # Install curl and bash utilities
 RUN apt-get update && \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -107,10 +107,11 @@ services:
       context: .
       dockerfile: cirrus/server/Dockerfile
     volumes:
-      - .:/cirrus/server
+      - ./cirrus:/cirrus
+    working_dir: /cirrus
     ports:
       - "8001:8001"
-    command: uvicorn cirrus.server.cirrus.main:app --reload --host 0.0.0.0 --port 8001
+    command: uvicorn server.cirrus.main:app --reload --host 0.0.0.0 --port 8001
 
 volumes:
   db_volume:


### PR DESCRIPTION
Because:
* Volumes weren't being updated to allow for fastAPIs reload feature to work correctly

This Commit:
* Fixes the docker-compose and Dockerfile so that volumes will update correctly.
