### PR TITLE
fix #6740 feat(nimbus): switch nimbus ui to multifeature api

### DIFF
--- a/experimenter/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/FormBranch.test.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/FormBranch.test.tsx
@@ -45,11 +45,13 @@ describe("FormBranch", () => {
       <SubjectBranch
         branch={{
           ...MOCK_ANNOTATED_BRANCH,
-          featureValue: "this is a default value",
+          featureValues: [{ value: "this is a default value" }],
         }}
       />,
     );
-    expect(screen.queryByTestId("feature-value-edit")).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("referenceBranch.featureValues[0].value"),
+    ).toBeInTheDocument();
   });
 
   it("calls onRemove when the branch remove button is clicked", async () => {

--- a/experimenter/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/FormBranch.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/FormBranch.tsx
@@ -8,6 +8,9 @@ import Button from "react-bootstrap/Button";
 import Col from "react-bootstrap/Col";
 import Form from "react-bootstrap/Form";
 import { FieldError } from "react-hook-form";
+import FormFeatureValue, {
+  FormFeatureValueProps,
+} from "src/components/PageEditBranches/FormBranches/FormFeatureValue";
 import FormScreenshot, {
   FormScreenshotProps,
 } from "src/components/PageEditBranches/FormBranches/FormScreenshot";
@@ -61,7 +64,12 @@ export const FormBranch = ({
 
   const { FormErrors, formControlAttrs, watch } =
     useCommonNestedForm<BranchFieldName>(
-      defaultValues,
+      (defaultValues = {
+        ...defaultValues,
+        featureValue: defaultValues.featureValues.length
+          ? defaultValues.featureValues[0].value
+          : "",
+      }),
       setSubmitErrors,
       fieldNamePrefix,
       submitErrors,
@@ -89,10 +97,10 @@ export const FormBranch = ({
 
   return (
     <div
-      className="mb-3 border border-secondary rounded"
+      className="mb-3 border border-secondary rounded p-3"
       data-testid="FormBranch"
     >
-      <Form.Group className="p-1 mx-3 mt-2 mb-0">
+      <Form.Group>
         <Form.Row>
           <Form.Group as={Col} controlId={`${id}-name`} sm={4} md={3}>
             <Form.Label>
@@ -161,27 +169,41 @@ export const FormBranch = ({
         </Form.Row>
       </Form.Group>
 
-      <Form.Group
-        className="p-1 mx-3 mt-2 mb-0"
-        data-testid="feature-config-edit"
-      >
-        <Form.Row data-testid="feature-value-edit">
-          <Form.Group as={Col} controlId={`${id}-featureValue`}>
-            <Form.Label>Value</Form.Label>
-            <Form.Control
-              {...formControlAttrs("featureValue")}
-              as="textarea"
-              rows={4}
-            />
-            <FormErrors name="featureValue" />
+      <Form.Group data-testid="feature-values-edit">
+        <Form.Row>
+          <Form.Group as={Col}>
+            {branch.featureValues?.map((featureValue, idx) => (
+              <div key={idx}>
+                <FormFeatureValue
+                  {...{
+                    fieldNamePrefix: `${fieldNamePrefix}.featureValues[${idx}]`,
+                    defaultValues: defaultValues.featureValues?.[idx] || {},
+                    setSubmitErrors,
+                    //@ts-ignore react-hook-form types seem broken for nested fields
+                    submitErrors: (submitErrors?.featureValues?.[idx] ||
+                      {}) as FormFeatureValueProps["submitErrors"],
+                    //@ts-ignore react-hook-form types seem broken for nested fields
+                    errors: (errors?.featureValues?.[idx] ||
+                      {}) as FormFeatureValueProps["errors"],
+                    //@ts-ignore react-hook-form types seem broken for nested fields
+                    touched: (touched?.featureValues?.[idx] ||
+                      {}) as FormFeatureValueProps["touched"],
+                    //@ts-ignore react-hook-form types seem broken for nested fields
+                    reviewErrors: (reviewErrors?.feature_values?.[idx] ||
+                      {}) as FormFeatureValueProps["reviewErrors"],
+                    //@ts-ignore react-hook-form types seem broken for nested fields
+                    reviewWarnings: (reviewWarnings?.feature_values?.[idx] ||
+                      {}) as FormFeatureValueProps["reviewWarnings"],
+                  }}
+                />
+              </div>
+            ))}
           </Form.Group>
         </Form.Row>
       </Form.Group>
-      <Form.Group
-        className="px-3 pt-2 border-top"
-        data-testid="screenshots-edit"
-      >
-        <Form.Row className="my-3">
+
+      <Form.Group className="pt-2 border-top" data-testid="screenshots-edit">
+        <Form.Row>
           <Col>Screenshots</Col>
           {!addScreenshotButtonAtEnd && (
             <Form.Group

--- a/experimenter/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/FormFeatureValue/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/FormFeatureValue/index.tsx
@@ -1,0 +1,66 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from "react";
+import Col from "react-bootstrap/Col";
+import Form from "react-bootstrap/Form";
+import Row from "react-bootstrap/Row";
+import { FieldError } from "react-hook-form";
+import { useCommonNestedForm } from "src/hooks";
+
+export const featureValueFieldNames = ["featureConfig", "value"] as const;
+
+type FeatureValueFieldName = typeof featureValueFieldNames[number];
+
+export type FormFeatureValueProps = {
+  defaultValues: Record<string, any>;
+  errors: Record<string, FieldError>;
+  fieldNamePrefix: string;
+  reviewErrors: SerializerSet;
+  reviewWarnings: SerializerSet;
+  setSubmitErrors: React.Dispatch<React.SetStateAction<Record<string, any>>>;
+  submitErrors: { [x: string]: SerializerMessage };
+  touched: Record<string, boolean>;
+};
+
+export const FormFeatureValue = ({
+  defaultValues,
+  errors,
+  fieldNamePrefix,
+  reviewErrors,
+  reviewWarnings,
+  setSubmitErrors,
+  submitErrors,
+  touched,
+}: FormFeatureValueProps) => {
+  const { FormErrors, formControlAttrs } =
+    useCommonNestedForm<FeatureValueFieldName>(
+      defaultValues,
+      setSubmitErrors,
+      fieldNamePrefix,
+      submitErrors,
+      errors,
+      touched,
+      reviewErrors,
+      reviewWarnings,
+    );
+
+  return (
+    <Form.Group data-testid="FormFeatureValue">
+      <Form.Control {...formControlAttrs("featureConfig")} hidden />
+
+      <Form.Group controlId={`${fieldNamePrefix}-value`}>
+        <Form.Label className="w-100">
+          <Row className="w-100">
+            <Col>Value</Col>
+          </Row>
+        </Form.Label>
+        <Form.Control {...formControlAttrs("value")} as="textarea" rows={4} />
+        <FormErrors name="value" />
+      </Form.Group>
+    </Form.Group>
+  );
+};
+
+export default FormFeatureValue;

--- a/experimenter/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/FormScreenshot/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/FormScreenshot/index.tsx
@@ -56,12 +56,12 @@ export const FormScreenshot = ({
   const imageProps = formControlAttrs("image");
 
   return (
-    <Form.Group className="mx-4 mb-5" data-testid="FormScreenshot">
-      <Form.Group as={Row} controlId={`${fieldNamePrefix}-description`}>
+    <Form.Group className="mt-2" data-testid="FormScreenshot">
+      <Form.Group controlId={`${fieldNamePrefix}-description`}>
         <Form.Label className="w-100">
-          <Row className="w-100 m-0">
-            <Col className="p-0">Description</Col>
-            <Col className="p-0 text-right">
+          <Row className="w-100">
+            <Col>Description</Col>
+            <Col className="text-right">
               <Button
                 data-testid="remove-screenshot"
                 variant="light"
@@ -81,7 +81,7 @@ export const FormScreenshot = ({
         />
         <FormErrors name="description" />
       </Form.Group>
-      <Form.Group as={Row} controlId={`${fieldNamePrefix}-image`}>
+      <Form.Group controlId={`${fieldNamePrefix}-image`}>
         <Form.Label>Image</Form.Label>
         <Controller
           name={imageProps.name}

--- a/experimenter/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/index.test.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/index.test.tsx
@@ -57,7 +57,7 @@ describe("FormBranches", () => {
     render(<SubjectBranches {...{ onSave }} />);
     await clickAndWaitForSave(onSave);
     const onSaveArgs = onSave.mock.calls[0];
-    expect(onSaveArgs[0]).toEqual({
+    const expectedData = {
       featureConfigIds: [],
       // @ts-ignore type mismatch covers discarded annotation properties
       referenceBranch: extractUpdateBranch(MOCK_EXPERIMENT.referenceBranch!),
@@ -68,7 +68,8 @@ describe("FormBranches", () => {
       isRollout: false,
       preventPrefConflicts: false,
       warnFeatureSchema: false,
-    });
+    };
+    expect(onSaveArgs[0]).toEqual(expectedData);
     expect(typeof onSaveArgs[1]).toEqual("function");
     expect(typeof onSaveArgs[2]).toEqual("function");
   });
@@ -178,7 +179,7 @@ describe("FormBranches", () => {
                 slug: "",
                 description: "",
                 ratio: 0,
-                featureValue: null,
+                featureValues: [],
                 screenshots: [],
               },
             ],
@@ -221,7 +222,7 @@ describe("FormBranches", () => {
           experiment: {
             ...MOCK_EXPERIMENT,
             referenceBranch: null,
-            treatmentBranches: null,
+            treatmentBranches: [],
           },
         }}
       />,
@@ -259,7 +260,7 @@ describe("FormBranches", () => {
               slug: "",
               description: "",
               ratio: 1,
-              featureValue: null,
+              featureValues: [],
               screenshots: [],
             },
             treatmentBranches: null,
@@ -333,7 +334,7 @@ describe("FormBranches", () => {
           onSave,
           experiment: {
             ...MOCK_EXPERIMENT,
-            treatmentBranches: null,
+            treatmentBranches: [],
           },
         }}
       />,
@@ -386,7 +387,7 @@ describe("FormBranches", () => {
               slug: "",
               description: "test",
               ratio: 1,
-              featureValue: null,
+              featureValues: [],
               screenshots: [],
             },
             treatmentBranches: null,
@@ -452,14 +453,27 @@ describe("FormBranches", () => {
     const branchIdx = 1;
 
     const expectedData = {
-      name: "example name",
       description: "example description",
+      featureValues: [
+        {
+          featureConfig: "1",
+          value: "example value",
+        },
+      ],
+      id: 123,
+      name: "example name",
       ratio: 42,
-      featureValue: "example value",
+      screenshots: [],
     };
+    const inputData = [
+      ["name", expectedData.name],
+      ["description", expectedData.description],
+      ["ratio", expectedData.ratio],
+      ["featureValues[0].value", expectedData.featureValues[0].value],
+    ];
 
     for (const id of ["referenceBranch", `treatmentBranches[${branchIdx}]`]) {
-      await fillInBranch(container, id, expectedData);
+      await fillInBranch(container, id, inputData);
     }
 
     await clickAndWaitForSave(onSave);
@@ -469,14 +483,12 @@ describe("FormBranches", () => {
       MOCK_FEATURE_CONFIG_WITH_SCHEMA.id,
     ]);
     expect(saveResult.referenceBranch).toEqual({
-      id: MOCK_EXPERIMENT.referenceBranch!.id,
-      screenshots: [],
       ...expectedData,
+      id: MOCK_EXPERIMENT.referenceBranch!.id,
     });
     expect(saveResult.treatmentBranches[1]).toEqual({
-      id: MOCK_EXPERIMENT.treatmentBranches![1]!.id,
-      screenshots: [],
       ...expectedData,
+      id: MOCK_EXPERIMENT.treatmentBranches![1]!.id,
     });
   });
 
@@ -527,7 +539,7 @@ describe("FormBranches", () => {
               },
               warnings: {
                 reference_branch: {
-                  feature_value: [FEATURE_VALUE_WARNING],
+                  feature_values: [{ value: [FEATURE_VALUE_WARNING] }],
                 },
               },
             },
@@ -543,7 +555,7 @@ describe("FormBranches", () => {
                 slug: "",
                 description: "",
                 ratio: 0,
-                featureValue: null,
+                featureValues: [],
                 screenshots: [],
               },
             ],
@@ -696,14 +708,14 @@ const clickAndWaitForSave = async (pendingOnSave: jest.Mock<any, any>) => {
 async function fillInBranch(
   container: HTMLElement,
   fieldNamePrefix: string,
-  expectedData = {
-    name: "example name",
-    description: "example description",
-    ratio: 42,
-    featureValue: "example value",
-  },
+  expectedData = [
+    ["name", "example name"],
+    ["description", "example description"],
+    ["ratio", 42],
+    ["featureValues[0].value", '{"key": "value"}'],
+  ],
 ) {
-  for (const [name, value] of Object.entries(expectedData)) {
+  for (const [name, value] of expectedData) {
     const field = container.querySelector(
       `[name="${fieldNamePrefix}.${name}"]`,
     ) as HTMLInputElement;

--- a/experimenter/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/mocks.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/mocks.tsx
@@ -24,7 +24,12 @@ export const MOCK_EXPERIMENT = mockExperimentQuery("demo-slug", {
     slug: "control",
     description: "Behind almost radio result personal none future current.",
     ratio: 1,
-    featureValue: '{"environmental-fact": "really-citizen"}',
+    featureValues: [
+      {
+        featureConfig: { id: 1 },
+        value: '{"environmental-fact": "really-citizen"}',
+      },
+    ],
     screenshots: [],
   },
   treatmentBranches: [
@@ -34,7 +39,12 @@ export const MOCK_EXPERIMENT = mockExperimentQuery("demo-slug", {
       slug: "managed-zero-tolerance-projection",
       description: "Next ask then he in degree order.",
       ratio: 1,
-      featureValue: '{"effect-effect-whole": "close-teach-exactly"}',
+      featureValues: [
+        {
+          featureConfig: { id: 1 },
+          value: '{"effect-effect-whole": "close-teach-exactly"}',
+        },
+      ],
       screenshots: [],
     },
     {
@@ -43,7 +53,12 @@ export const MOCK_EXPERIMENT = mockExperimentQuery("demo-slug", {
       slug: "salt-way-link",
       description: "Flame the dark true.",
       ratio: 2,
-      featureValue: '{"frosted-wake": "simple-hesitation"}',
+      featureValues: [
+        {
+          featureConfig: { id: 1 },
+          value: '{"frosted-wake": "simple-hesitation"}',
+        },
+      ],
       screenshots: [],
     },
   ],
@@ -64,6 +79,12 @@ const MOCK_STATE: FormBranchesState = {
     errors: {},
     isValid: true,
     isDirty: false,
+    featureValues: MOCK_EXPERIMENT.referenceBranch?.featureValues?.map(
+      (fv) => ({
+        featureConfig: fv?.featureConfig?.id?.toString(),
+        value: fv?.value,
+      }),
+    ),
   },
   treatmentBranches: MOCK_EXPERIMENT.treatmentBranches!.map((branch, idx) => ({
     ...branch!,
@@ -72,6 +93,10 @@ const MOCK_STATE: FormBranchesState = {
     errors: {},
     isValid: true,
     isDirty: false,
+    featureValues: branch?.featureValues?.map((fv) => ({
+      featureConfig: fv?.featureConfig?.id?.toString(),
+      value: fv?.value,
+    })),
   })),
 };
 
@@ -174,6 +199,10 @@ export const MOCK_ANNOTATED_BRANCH: AnnotatedBranch = {
   errors: {},
   ...MOCK_BRANCH,
   screenshots: [],
+  featureValues: MOCK_BRANCH.featureValues?.map((fv) => ({
+    featureConfig: fv?.featureConfig?.id?.toString(),
+    value: fv?.value,
+  })),
 };
 export const MOCK_FEATURE_CONFIG = MOCK_CONFIG.allFeatureConfigs![0]!;
 export const MOCK_FEATURE_CONFIG_WITH_SCHEMA =

--- a/experimenter/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/reducer/actions.ts
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/reducer/actions.ts
@@ -69,7 +69,11 @@ function addBranch(state: FormBranchesState): FormBranchesState {
   lastId++;
 
   if (referenceBranch === null) {
-    referenceBranch = createAnnotatedBranch(lastId, "control");
+    referenceBranch = createAnnotatedBranch(
+      lastId,
+      "control",
+      state.featureConfigIds,
+    );
   } else {
     treatmentBranches = [
       ...(treatmentBranches || []),
@@ -77,6 +81,7 @@ function addBranch(state: FormBranchesState): FormBranchesState {
         state.lastId,
         // 65 is A, but we generate a control, so start at 64
         `Treatment ${String.fromCharCode(64 + lastId)}`,
+        state.featureConfigIds,
       ),
     ];
   }
@@ -120,6 +125,24 @@ function setFeatureConfigs(
   return {
     ...state,
     featureConfigIds: featureConfigIds || null,
+    referenceBranch: {
+      ...state.referenceBranch,
+      featureValues: featureConfigIds?.map((featureConfigId) => ({
+        featureConfig: featureConfigId,
+        value: state.referenceBranch?.featureValues?.length
+          ? state.referenceBranch?.featureValues?.reduce((fv, acc) => fv)?.value
+          : [],
+      })),
+    } as AnnotatedBranch,
+    treatmentBranches: state.treatmentBranches?.map((treatmentBranch) => ({
+      ...treatmentBranch,
+      featureValues: featureConfigIds?.map((featureConfigId) => ({
+        featureConfig: featureConfigId,
+        value: treatmentBranch.featureValues?.length
+          ? treatmentBranch?.featureValues?.reduce((fv, acc) => fv)?.value
+          : [],
+      })),
+    })) as AnnotatedBranch[],
   };
 }
 
@@ -330,9 +353,9 @@ function branchUpdatedWithFormData(
     };
   });
   const featureValues = state.featureConfigIds?.map((featureConfigId, idx) => {
-    const { value } = formData?.featureValues?.[idx] || {};
+    const { featureConfig, value } = formData?.featureValues?.[idx] || {};
     return {
-      featureConfigId,
+      featureConfig,
       value,
     };
   });

--- a/experimenter/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/reducer/index.test.ts
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/reducer/index.test.ts
@@ -32,6 +32,12 @@ const MOCK_STATE: FormBranchesState = {
     errors: {},
     isValid: true,
     isDirty: false,
+    featureValues: MOCK_EXPERIMENT.referenceBranch!.featureValues?.map(
+      (fv) => ({
+        featureConfig: fv?.featureConfig?.id?.toString(),
+        value: fv?.value,
+      }),
+    ),
   },
   treatmentBranches: MOCK_EXPERIMENT.treatmentBranches!.map((branch, idx) => ({
     ...branch!,
@@ -40,6 +46,10 @@ const MOCK_STATE: FormBranchesState = {
     errors: {},
     isValid: true,
     isDirty: false,
+    featureValues: branch!.featureValues?.map((fv) => ({
+      featureConfig: fv?.featureConfig?.id?.toString(),
+      value: fv?.value,
+    })),
   })),
 };
 

--- a/experimenter/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/reducer/state.ts
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/reducer/state.ts
@@ -81,12 +81,17 @@ export function annotateExperimentBranch(
     isDirty: false,
     errors: {},
     reviewMessages: {},
+    featureValues: branch.featureValues?.map((fv) => ({
+      featureConfig: fv?.featureConfig?.id?.toString(),
+      value: fv?.value,
+    })),
   };
 }
 
 export function createAnnotatedBranch(
   lastId: number,
   name: string,
+  featureConfigIds: FormBranchesState["featureConfigIds"],
 ): AnnotatedBranch {
   return {
     key: `branch-${lastId}`,
@@ -96,6 +101,9 @@ export function createAnnotatedBranch(
     name,
     description: "",
     ratio: 1,
-    featureValue: null,
+    featureValues: featureConfigIds?.map((featureConfigId) => ({
+      featureConfig: featureConfigId?.toString(),
+      value: "",
+    })),
   };
 }

--- a/experimenter/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/reducer/update.ts
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/reducer/update.ts
@@ -7,7 +7,11 @@ import {
   FormBranchesState,
 } from "src/components/PageEditBranches/FormBranches/reducer/state";
 import { CONTROL_BRANCH_REQUIRED_ERROR } from "src/lib/constants";
-import { BranchScreenshotInput, ExperimentInput } from "src/types/globalTypes";
+import {
+  BranchFeatureValueInput,
+  BranchScreenshotInput,
+  ExperimentInput,
+} from "src/types/globalTypes";
 
 export type FormBranchesSaveState = Pick<
   ExperimentInput,
@@ -43,7 +47,7 @@ export function extractUpdateState(
     throw new UpdateStateError(CONTROL_BRANCH_REQUIRED_ERROR);
   }
 
-  return {
+  const extractedState = {
     featureConfigIds,
     warnFeatureSchema,
     isRollout,
@@ -60,6 +64,7 @@ export function extractUpdateState(
           ),
     preventPrefConflicts,
   };
+  return extractedState;
 }
 
 export function extractUpdateBranch(
@@ -70,14 +75,30 @@ export function extractUpdateBranch(
   const screenshots = branch.screenshots?.map((branchScreenshot, idx) =>
     extractUpdateScreenshot(branchScreenshot!, formBranch!.screenshots![idx]!),
   );
+  const featureValues = branch.featureValues?.map((branchFeatureValue, idx) =>
+    extractUpdateFeatureValue(
+      branchFeatureValue!,
+      formBranch!.featureValues![idx]!,
+    ),
+  );
   return {
     // Branch ID should be read-only with respect to the form data
     id: branch.id,
     name: merged.name,
     description: merged.description,
     ratio: merged.ratio,
-    featureValue: merged.featureValue,
+    featureValues,
     screenshots,
+  };
+}
+
+export function extractUpdateFeatureValue(
+  branchFeatureValue: BranchFeatureValueInput,
+  { featureConfig, value }: BranchFeatureValueInput,
+): BranchFeatureValueInput {
+  return {
+    featureConfig,
+    value,
   };
 }
 

--- a/experimenter/experimenter/nimbus-ui/src/components/PageHome/DirectoryTable/index.test.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageHome/DirectoryTable/index.test.tsx
@@ -96,13 +96,18 @@ describe("DirectoryColumnFeature", () => {
     );
     expect(
       screen.getByTestId("directory-feature-config-name"),
-    ).toHaveTextContent(experiment.featureConfig!.name);
+    ).toHaveTextContent(
+      experiment
+        .featureConfigs!.map((fc) => fc?.name)
+        .sort()
+        .join(", "),
+    );
   });
 
   it("renders the None label if feature config is not present", () => {
     render(
       <TestTable>
-        <DirectoryColumnFeature {...experiment} featureConfig={null} />
+        <DirectoryColumnFeature {...experiment} featureConfigs={[]} />
       </TestTable>,
     );
     expect(
@@ -413,7 +418,10 @@ describe("DirectoryTable", () => {
       expectTableCells("directory-table-cell", [
         experiment.name,
         experiment.owner!.username,
-        experiment.featureConfig!.name,
+        experiment
+          .featureConfigs!.map((fc) => fc?.name)
+          .sort()
+          .join(", "),
         "Desktop",
         "Desktop Nightly",
         experiment.populationPercent!.toString(),

--- a/experimenter/experimenter/nimbus-ui/src/components/PageHome/DirectoryTable/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageHome/DirectoryTable/index.tsx
@@ -110,12 +110,15 @@ export const DirectoryColumnFirefoxMaxVersion: ColumnComponent = (
   );
 };
 
-export const DirectoryColumnFeature: ColumnComponent = ({ featureConfig }) => (
+export const DirectoryColumnFeature: ColumnComponent = ({ featureConfigs }) => (
   <td data-testid="directory-table-cell">
-    {featureConfig ? (
+    {featureConfigs?.length ? (
       <>
         <span data-testid="directory-feature-config-name">
-          {featureConfig.name}
+          {featureConfigs
+            .map((fc) => fc?.name)
+            .sort()
+            .join(", ")}
         </span>
       </>
     ) : (

--- a/experimenter/experimenter/nimbus-ui/src/components/Summary/TableBranches/index.test.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/Summary/TableBranches/index.test.tsx
@@ -60,7 +60,7 @@ describe("TableBranches", () => {
               slug: "",
               description: "",
               ratio: 0,
-              featureValue: null,
+              featureValues: [],
               screenshots: [],
             },
           ],
@@ -90,12 +90,13 @@ describe("TableBranches", () => {
   });
 
   it("renders expected content", () => {
+    const featureValue = '{ "thing": true }';
     const expected = {
       name: "expected name",
       slug: "expected slug",
       description: "expected description",
       ratio: 42,
-      featureValue: '{ "thing": true }',
+      featureValue,
     };
 
     render(
@@ -107,6 +108,9 @@ describe("TableBranches", () => {
               ...expected,
               id: 456,
               screenshots: [],
+              featureValues: [
+                { featureConfig: { id: 1 }, value: featureValue },
+              ],
             },
             ...MOCK_EXPERIMENT.treatmentBranches!,
           ],
@@ -157,7 +161,9 @@ describe("TableBranches", () => {
               slug: "expected slug",
               description: "expected description",
               ratio: 42,
-              featureValue: '{ "thing": true }',
+              featureValues: [
+                { featureConfig: { id: 1 }, value: '{ "thing": true }' },
+              ],
               screenshots: expectedScreenshots,
             },
             ...MOCK_EXPERIMENT.treatmentBranches!,
@@ -197,7 +203,7 @@ describe("TableBranches", () => {
       slug: "expected-slug",
       description: "expected description",
       ratio: 42,
-      featureValue: '{ "thing": true }',
+      featureValues: [{ featureConfig: { id: 1 }, value: '{ "thing": true }' }],
       screenshots: [],
     };
 
@@ -235,7 +241,7 @@ describe("TableBranches", () => {
       slug: "expected-slug",
       description: "expected description",
       ratio: 42,
-      featureValue: '{ "thing": true }',
+      featureValues: [{ featureConfig: { id: 1 }, value: '{ "thing": true }' }],
       screenshots: [],
     };
 
@@ -265,7 +271,7 @@ describe("TableBranches", () => {
       slug: "expected-slug",
       description: "expected description",
       ratio: 42,
-      featureValue: '{ "thing": true }',
+      featureValues: [{ featureConfig: { id: 1 }, value: '{ "thing": true }' }],
       screenshots: [],
     };
 
@@ -300,7 +306,7 @@ describe("TableBranches", () => {
               slug: "treatment-1",
               description: "",
               ratio: 0,
-              featureValue: null,
+              featureValues: [],
               screenshots: [],
             },
             {
@@ -309,7 +315,7 @@ describe("TableBranches", () => {
               slug: "",
               description: "",
               ratio: 0,
-              featureValue: null,
+              featureValues: [],
               screenshots: [],
             },
           ],

--- a/experimenter/experimenter/nimbus-ui/src/components/Summary/TableBranches/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/Summary/TableBranches/index.tsx
@@ -85,7 +85,7 @@ const TableBranch = ({
   experiment: getExperiment_experimentBySlug;
   branch: Branch;
 }) => {
-  const { name, slug, description, ratio, featureValue, screenshots } = branch;
+  const { name, slug, description, ratio, featureValues, screenshots } = branch;
   const cloneDialogProps = useCloneDialog(experiment, branch);
   return (
     <Table data-testid="table-branch" className="table-fixed " id={slug}>
@@ -126,12 +126,23 @@ const TableBranch = ({
             {description ? description : <NotSet />}
           </td>
         </tr>
-        <tr>
-          <th>Value</th>
-          <td colSpan={3} data-testid="branch-featureValue">
-            {featureValue ? <Code codeString={featureValue} /> : <NotSet />}
-          </td>
-        </tr>
+        {featureValues ? (
+          featureValues.map((featureValue, idx) => (
+            <tr key={idx}>
+              <th>Value</th>
+              <td colSpan={3} data-testid="branch-featureValue">
+                {featureValue ? (
+                  <Code codeString={featureValue.value!} />
+                ) : (
+                  <NotSet />
+                )}
+              </td>
+            </tr>
+          ))
+        ) : (
+          <></>
+        )}
+
         {screenshots && screenshots.length > 0 && (
           <tr>
             <th>Screenshots</th>

--- a/experimenter/experimenter/nimbus-ui/src/gql/experiments.ts
+++ b/experimenter/experimenter/nimbus-ui/src/gql/experiments.ts
@@ -66,7 +66,12 @@ export const GET_EXPERIMENT_QUERY = gql`
         slug
         description
         ratio
-        featureValue
+        featureValues {
+          featureConfig {
+            id
+          }
+          value
+        }
         screenshots {
           id
           description
@@ -80,7 +85,12 @@ export const GET_EXPERIMENT_QUERY = gql`
         slug
         description
         ratio
-        featureValue
+        featureValues {
+          featureConfig {
+            id
+          }
+          value
+        }
         screenshots {
           id
           description
@@ -251,10 +261,6 @@ export const GET_EXPERIMENTS_QUERY = gql`
       resultsExpectedDate
       resultsReady
       showResultsUrl
-      featureConfig {
-        slug
-        name
-      }
       channel
       populationPercent
       projects {

--- a/experimenter/experimenter/nimbus-ui/src/lib/experiment.ts
+++ b/experimenter/experimenter/nimbus-ui/src/lib/experiment.ts
@@ -115,7 +115,11 @@ export type ExperimentSortSelector =
 
 export const featureConfigNameSortSelector: ExperimentSortSelector = (
   experiment,
-) => experiment.featureConfig?.name;
+) =>
+  experiment.featureConfigs
+    ?.map((fc) => fc?.name)
+    .sort()
+    .join(", ");
 
 export const ownerUsernameSortSelector: ExperimentSortSelector = (experiment) =>
   experiment.owner?.username;

--- a/experimenter/experimenter/nimbus-ui/src/lib/mocks.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/lib/mocks.tsx
@@ -554,7 +554,12 @@ export const MOCK_EXPERIMENT: Partial<getExperiment["experimentBySlug"]> = {
     slug: "control",
     description: "Behind almost radio result personal none future current.",
     ratio: 1,
-    featureValue: '{"environmental-fact": "really-citizen"}',
+    featureValues: [
+      {
+        featureConfig: { id: 1 },
+        value: '{"environmental-fact": "really-citizen"}',
+      },
+    ],
     screenshots: [],
   },
   featureConfigs: [],
@@ -568,7 +573,12 @@ export const MOCK_EXPERIMENT: Partial<getExperiment["experimentBySlug"]> = {
       slug: "treatment",
       description: "Next ask then he in degree order.",
       ratio: 1,
-      featureValue: '{"effect-effect-whole": "close-teach-exactly"}',
+      featureValues: [
+        {
+          featureConfig: { id: 1 },
+          value: '{"effect-effect-whole": "close-teach-exactly"}',
+        },
+      ],
       screenshots: [],
     },
   ],
@@ -648,13 +658,34 @@ export const MOCK_LIVE_ROLLOUT: Partial<getExperiment["experimentBySlug"]> = {
     description:
       "Policy success score. Education clear write. Where same create matter natural.",
     ratio: 1,
-    featureValue: '{"environmental-fact": "bingo-bongo"}',
+    featureValues: [
+      {
+        featureConfig: { id: 1 },
+        value: '{"environmental-fact": "bingo-bongo"}',
+      },
+    ],
     screenshots: [],
   },
   featureConfigs: [],
   targetingConfig: [MOCK_CONFIG.targetingConfigs![0]],
   isSticky: false,
   isFirstRun: false,
+  treatmentBranches: [
+    {
+      id: 456,
+      name: "Managed zero baby projection",
+      slug: "treatment",
+      description: "Next ask then he in degree order.",
+      ratio: 1,
+      featureValues: [
+        {
+          featureConfig: { id: 1 },
+          value: '{"effect-effect-whole": "close-teach-exactly"}',
+        },
+      ],
+      screenshots: [],
+    },
+  ],
   primaryOutcomes: ["picture_in_picture", "feature_c", "feature_nodata"],
   secondaryOutcomes: ["feature_b", "feature_d"],
   channel: NimbusExperimentChannelEnum.NIGHTLY,
@@ -874,7 +905,6 @@ export function mockSingleDirectoryExperiment(
     populationPercent: "100",
     channel: NimbusExperimentChannelEnum.NIGHTLY,
     publishStatus: NimbusExperimentPublishStatusEnum.IDLE,
-    featureConfig: MOCK_CONFIG.allFeatureConfigs![0],
     featureConfigs: [MOCK_CONFIG.allFeatureConfigs![0]],
     targetingConfig: [MOCK_CONFIG.targetingConfigs![0]],
     isEnrollmentPaused: false,

--- a/experimenter/experimenter/nimbus-ui/src/types/getAllExperiments.ts
+++ b/experimenter/experimenter/nimbus-ui/src/types/getAllExperiments.ts
@@ -35,11 +35,6 @@ export interface getAllExperiments_experiments_targetingConfig {
   isFirstRunRequired: boolean | null;
 }
 
-export interface getAllExperiments_experiments_featureConfig {
-  slug: string;
-  name: string;
-}
-
 export interface getAllExperiments_experiments_projects {
   id: string | null;
   name: string | null;
@@ -73,7 +68,6 @@ export interface getAllExperiments_experiments {
   resultsExpectedDate: DateTime | null;
   resultsReady: boolean | null;
   showResultsUrl: boolean | null;
-  featureConfig: getAllExperiments_experiments_featureConfig | null;
   channel: NimbusExperimentChannelEnum | null;
   populationPercent: string | null;
   projects: (getAllExperiments_experiments_projects | null)[] | null;

--- a/experimenter/experimenter/nimbus-ui/src/types/getExperiment.ts
+++ b/experimenter/experimenter/nimbus-ui/src/types/getExperiment.ts
@@ -18,6 +18,15 @@ export interface getExperiment_experimentBySlug_parent {
   slug: string;
 }
 
+export interface getExperiment_experimentBySlug_referenceBranch_featureValues_featureConfig {
+  id: number | null;
+}
+
+export interface getExperiment_experimentBySlug_referenceBranch_featureValues {
+  featureConfig: getExperiment_experimentBySlug_referenceBranch_featureValues_featureConfig | null;
+  value: string | null;
+}
+
 export interface getExperiment_experimentBySlug_referenceBranch_screenshots {
   id: number | null;
   description: string | null;
@@ -30,8 +39,17 @@ export interface getExperiment_experimentBySlug_referenceBranch {
   slug: string;
   description: string;
   ratio: number;
-  featureValue: string | null;
+  featureValues: (getExperiment_experimentBySlug_referenceBranch_featureValues | null)[] | null;
   screenshots: getExperiment_experimentBySlug_referenceBranch_screenshots[] | null;
+}
+
+export interface getExperiment_experimentBySlug_treatmentBranches_featureValues_featureConfig {
+  id: number | null;
+}
+
+export interface getExperiment_experimentBySlug_treatmentBranches_featureValues {
+  featureConfig: getExperiment_experimentBySlug_treatmentBranches_featureValues_featureConfig | null;
+  value: string | null;
 }
 
 export interface getExperiment_experimentBySlug_treatmentBranches_screenshots {
@@ -46,7 +64,7 @@ export interface getExperiment_experimentBySlug_treatmentBranches {
   slug: string;
   description: string;
   ratio: number;
-  featureValue: string | null;
+  featureValues: (getExperiment_experimentBySlug_treatmentBranches_featureValues | null)[] | null;
   screenshots: getExperiment_experimentBySlug_treatmentBranches_screenshots[] | null;
 }
 


### PR DESCRIPTION
Because

* In preparation for changing Nimbus UI to support multifeature, we can switch the API code in the frontend to use the multifeature fields

This commit

* Etc

