### PR TITLE
fix #8799(nimbus): typo in slug for EXISTING_USER_UNSUPPORTED_WINDOWS_VERSION

### DIFF
--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -986,7 +986,7 @@ EXISTING_WINDOWS_USER_NO_FX_ACCOUNT = NimbusTargetingConfig(
 
 EXISTING_USER_UNSUPPORTED_WINDOWS_VERSION = NimbusTargetingConfig(
     name="Existing Windows <10 version user",
-    slug="existing_user_usupported_windows_version",
+    slug="existing_user_unsupported_windows_version",
     description="Users on Windows <10 with profiles older than 28 days",
     targeting=f"{PROFILE28DAYS} && os.isWindows && os.windowsVersion < 10",
     desktop_telemetry="",


### PR DESCRIPTION
Because 
* There's a typo `EXISTING_USER_UNSUPPORTED_WINDOWS_VERSION` targeting slug (`usupported` vs `unsupported`)

This commit
* Fixes the typo I introduced 😅 


