### PR TITLE
fix #8803 feat(nimbus): Don't serialize invalid localization json

### DIFF
--- a/experimenter/experimenter/experiments/api/v6/serializers.py
+++ b/experimenter/experimenter/experiments/api/v6/serializers.py
@@ -203,4 +203,5 @@ class NimbusExperimentSerializer(serializers.ModelSerializer):
 
     def get_localizations(self, obj):
         if obj.is_localized:
-            return json.loads(obj.localizations)
+            with contextlib.suppress(json.JSONDecodeError):
+                return json.loads(obj.localizations)

--- a/experimenter/experimenter/experiments/tests/api/v6/test_serializers.py
+++ b/experimenter/experimenter/experiments/tests/api/v6/test_serializers.py
@@ -432,3 +432,25 @@ class TestNimbusExperimentSerializer(TestCase):
             serializer.data["localizations"], json.loads(TEST_LOCALIZATIONS)
         )
         check_schema("experiments/NimbusExperiment", serializer.data)
+
+    @parameterized.expand(
+        [
+            ("invalid json", None),
+            (json.dumps({}), {}),
+        ]
+    )
+    def test_localized_localizations_json(self, l10n_json, expected):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.ENDING_APPROVE_APPROVE,
+            application=NimbusExperiment.Application.DESKTOP,
+            is_localized=True,
+            localizations=l10n_json,
+        )
+
+        serializer = NimbusExperimentSerializer(experiment)
+
+        self.assertIn("localizations", serializer.data)
+        if expected is None:
+            self.assertIsNone(serializer.data["localizations"])
+        else:
+            self.assertEqual(serializer.data["localizations"], expected)


### PR DESCRIPTION
Because

- the localizations field can contain invalid JSON

this commit

- only serializes the localizations field when it is valid JSON.