### PR TITLE
fix #8798 feat(nimbus): fetch remote schemas in circle task

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,8 @@ PYTHON_PATH_SDK = PYTHONPATH=/application-services/components/nimbus/src
 
 
 JETSTREAM_CONFIG_URL = https://github.com/mozilla/metric-hub/archive/main.zip
-FEATURE_MANIFEST_DESKTOP_URL = https://hg.mozilla.org/mozilla-central/raw-file/tip/toolkit/components/nimbus/FeatureManifest.yaml
+MOZILLA_CENTRAL_ROOT = https://hg.mozilla.org/mozilla-central/raw-file/tip
+FEATURE_MANIFEST_DESKTOP_URL = ${MOZILLA_CENTRAL_ROOT}/toolkit/components/nimbus/FeatureManifest.yaml
 FEATURE_MANIFEST_FENIX_URL = https://raw.githubusercontent.com/mozilla-mobile/firefox-android/main/fenix/app/.experimenter.yaml
 FEATURE_MANIFEST_FXIOS_URL = https://raw.githubusercontent.com/mozilla-mobile/firefox-ios/main/.experimenter.yaml
 FEATURE_MANIFEST_FOCUS_ANDROID = https://raw.githubusercontent.com/mozilla-mobile/firefox-android/main/focus-android/app/.experimenter.yaml
@@ -79,13 +80,14 @@ feature_manifests:
 	curl -LJ --create-dirs -o experimenter/experimenter/features/manifests/focus-android.yaml $(FEATURE_MANIFEST_FOCUS_ANDROID)
 	curl -LJ --create-dirs -o experimenter/experimenter/features/manifests/focus-ios.yaml $(FEATURE_MANIFEST_FOCUS_IOS)
 	cat experimenter/experimenter/features/manifests/firefox-desktop.yaml | grep path: | \
-	awk -F'"' '{print "https://hg.mozilla.org/mozilla-central/raw-file/tip/" $$2}' | sort -u | \
+	awk -F'"' '{print "$(MOZILLA_CENTRAL_ROOT)/" $$2}' | sort -u | \
 	while read -r url; do \
-		file=$$(echo $$url | sed 's|https://hg.mozilla.org/mozilla-central/raw-file/tip/||'); \
+		file=$$(echo $$url | sed 's|$(MOZILLA_CENTRAL_ROOT)/||'); \
 		file="experimenter/experimenter/features/manifests/schemas/$$file"; \
 		mkdir -p $$(dirname $$file); \
 		curl $$url -o $$file; \
 	done
+
 
 fetch_external_resources: jetstream_config feature_manifests
 	echo "External Resources Fetched"

--- a/Makefile
+++ b/Makefile
@@ -78,6 +78,14 @@ feature_manifests:
 	curl -LJ --create-dirs -o experimenter/experimenter/features/manifests/ios.yaml $(FEATURE_MANIFEST_FXIOS_URL)
 	curl -LJ --create-dirs -o experimenter/experimenter/features/manifests/focus-android.yaml $(FEATURE_MANIFEST_FOCUS_ANDROID)
 	curl -LJ --create-dirs -o experimenter/experimenter/features/manifests/focus-ios.yaml $(FEATURE_MANIFEST_FOCUS_IOS)
+	cat experimenter/experimenter/features/manifests/firefox-desktop.yaml | grep path: | \
+	awk -F'"' '{print "https://hg.mozilla.org/mozilla-central/raw-file/tip/" $$2}' | sort -u | \
+	while read -r url; do \
+		file=$$(echo $$url | sed 's|https://hg.mozilla.org/mozilla-central/raw-file/tip/||'); \
+		file="experimenter/experimenter/features/manifests/schemas/$$file"; \
+		mkdir -p $$(dirname $$file); \
+		curl $$url -o $$file; \
+	done
 
 fetch_external_resources: jetstream_config feature_manifests
 	echo "External Resources Fetched"

--- a/experimenter/experimenter/features/manifests/schemas/browser/components/newtab/content-src/asrouter/schemas/BackgroundTaskMessagingExperiment.schema.json
+++ b/experimenter/experimenter/features/manifests/schemas/browser/components/newtab/content-src/asrouter/schemas/BackgroundTaskMessagingExperiment.schema.json
@@ -1,0 +1,303 @@
+{
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "$id": "resource://activity-stream/schemas/BackgroundTaskMessagingExperiment.schema.json",
+  "title": "Messaging Experiment",
+  "description": "A Firefox Messaging System message.",
+  "oneOf": [
+    {
+      "$ref": "resource://activity-stream/schemas/BackgroundTaskMessagingExperiment.schema.json#/$defs/TemplatedMessage"
+    },
+    {
+      "$ref": "resource://activity-stream/schemas/BackgroundTaskMessagingExperiment.schema.json#/$defs/MultiMessage"
+    }
+  ],
+  "$defs": {
+    "ToastNotification": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "$id": "file:///ToastNotification.schema.json",
+      "title": "ToastNotification",
+      "description": "A template for toast notifications displayed by the Alert service.",
+      "allOf": [
+        {
+          "$ref": "resource://activity-stream/schemas/BackgroundTaskMessagingExperiment.schema.json#/$defs/Message"
+        }
+      ],
+      "type": "object",
+      "properties": {
+        "content": {
+          "type": "object",
+          "properties": {
+            "title": {
+              "$ref": "resource://activity-stream/schemas/BackgroundTaskMessagingExperiment.schema.json#/$defs/localizableText",
+              "description": "Id of localized string or message override of toast notification title"
+            },
+            "body": {
+              "$ref": "resource://activity-stream/schemas/BackgroundTaskMessagingExperiment.schema.json#/$defs/localizableText",
+              "description": "Id of localized string or message override of toast notification body"
+            },
+            "icon_url": {
+              "description": "The URL of the image used as an icon of the toast notification.",
+              "type": "string",
+              "format": "moz-url-format"
+            },
+            "image_url": {
+              "description": "The URL of an image to be displayed as part of the notification.",
+              "type": "string",
+              "format": "moz-url-format"
+            },
+            "launch_url": {
+              "description": "The URL to launch when the notification or an action button is clicked.",
+              "type": "string",
+              "format": "moz-url-format"
+            },
+            "requireInteraction": {
+              "type": "boolean",
+              "description": "Whether the toast notification should remain active until the user clicks or dismisses it, rather than closing automatically."
+            },
+            "tag": {
+              "type": "string",
+              "description": "An identifying tag for the toast notification."
+            },
+            "data": {
+              "type": "object",
+              "description": "Arbitrary data associated with the toast notification."
+            },
+            "actions": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "title": {
+                    "$ref": "resource://activity-stream/schemas/BackgroundTaskMessagingExperiment.schema.json#/$defs/localizableText",
+                    "description": "The action text to be shown to the user."
+                  },
+                  "action": {
+                    "type": "string",
+                    "description": "Opaque identifer that identifies action."
+                  },
+                  "iconURL": {
+                    "type": "string",
+                    "format": "uri",
+                    "description": "URL of an icon to display with the action."
+                  },
+                  "windowsSystemActivationType": {
+                    "type": "boolean",
+                    "description": "Whether to have Windows process the given `action`."
+                  }
+                },
+                "required": [
+                  "action",
+                  "title"
+                ],
+                "additionalProperties": true
+              }
+            }
+          },
+          "additionalProperties": true,
+          "required": [
+            "title",
+            "body"
+          ]
+        },
+        "template": {
+          "type": "string",
+          "const": "toast_notification"
+        }
+      },
+      "required": [
+        "content",
+        "targeting",
+        "template",
+        "trigger"
+      ],
+      "additionalProperties": true
+    },
+    "Message": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "The message identifier"
+        },
+        "groups": {
+          "description": "Array of preferences used to control `enabled` status of the group. If any is `false` the group is disabled.",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "description": "Preference name"
+          }
+        },
+        "template": {
+          "type": "string",
+          "description": "Which messaging template this message is using.",
+          "enum": [
+            "toast_notification"
+          ]
+        },
+        "frequency": {
+          "type": "object",
+          "description": "An object containing frequency cap information for a message.",
+          "properties": {
+            "lifetime": {
+              "type": "integer",
+              "description": "The maximum lifetime impressions for a message.",
+              "minimum": 1,
+              "maximum": 100
+            },
+            "custom": {
+              "type": "array",
+              "description": "An array of custom frequency cap definitions.",
+              "items": {
+                "description": "A frequency cap definition containing time and max impression information",
+                "type": "object",
+                "properties": {
+                  "period": {
+                    "type": "integer",
+                    "description": "Period of time in milliseconds (e.g. 86400000 for one day)"
+                  },
+                  "cap": {
+                    "type": "integer",
+                    "description": "The maximum impressions for the message within the defined period.",
+                    "minimum": 1,
+                    "maximum": 100
+                  }
+                },
+                "required": [
+                  "period",
+                  "cap"
+                ]
+              }
+            }
+          }
+        },
+        "priority": {
+          "description": "The priority of the message. If there are two competing messages to show, the one with the highest priority will be shown",
+          "type": "integer"
+        },
+        "order": {
+          "description": "The order in which messages should be shown. Messages will be shown in increasing order.",
+          "type": "integer"
+        },
+        "targeting": {
+          "description": "A JEXL expression representing targeting information",
+          "type": "string"
+        },
+        "trigger": {
+          "description": "An action to trigger potentially showing the message",
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "A string identifying the trigger action"
+            },
+            "params": {
+              "type": "array",
+              "description": "An optional array of string parameters for the trigger action",
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "string"
+                  }
+                ]
+              }
+            }
+          },
+          "required": [
+            "id"
+          ]
+        },
+        "provider": {
+          "description": "An identifier for the provider of this message, such as \"cfr\" or \"preview\".",
+          "type": "string"
+        }
+      },
+      "additionalProperties": true,
+      "dependentRequired": {
+        "content": [
+          "id",
+          "template"
+        ],
+        "template": [
+          "id",
+          "content"
+        ]
+      }
+    },
+    "localizedText": {
+      "type": "object",
+      "properties": {
+        "string_id": {
+          "description": "Id of localized string to be rendered.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "string_id"
+      ]
+    },
+    "localizableText": {
+      "description": "Either a raw string or an object containing the string_id of the localized text",
+      "oneOf": [
+        {
+          "type": "string",
+          "description": "The string to be rendered."
+        },
+        {
+          "$ref": "resource://activity-stream/schemas/BackgroundTaskMessagingExperiment.schema.json#/$defs/localizedText"
+        }
+      ]
+    },
+    "TemplatedMessage": {
+      "description": "An FxMS message of one of a variety of types.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "resource://activity-stream/schemas/BackgroundTaskMessagingExperiment.schema.json#/$defs/Message"
+        },
+        {
+          "if": {
+            "type": "object",
+            "properties": {
+              "template": {
+                "type": "string",
+                "enum": [
+                  "toast_notification"
+                ]
+              }
+            },
+            "required": [
+              "template"
+            ]
+          },
+          "then": {
+            "$ref": "resource://activity-stream/schemas/BackgroundTaskMessagingExperiment.schema.json#/$defs/ToastNotification"
+          }
+        }
+      ]
+    },
+    "MultiMessage": {
+      "description": "An object containing an array of messages.",
+      "type": "object",
+      "properties": {
+        "template": {
+          "type": "string",
+          "const": "multi"
+        },
+        "messages": {
+          "type": "array",
+          "description": "An array of messages.",
+          "items": {
+            "$ref": "resource://activity-stream/schemas/BackgroundTaskMessagingExperiment.schema.json#/$defs/TemplatedMessage"
+          }
+        }
+      },
+      "required": [
+        "template",
+        "messages"
+      ]
+    }
+  }
+}

--- a/experimenter/experimenter/features/manifests/schemas/browser/components/newtab/content-src/asrouter/schemas/MessagingExperiment.schema.json
+++ b/experimenter/experimenter/features/manifests/schemas/browser/components/newtab/content-src/asrouter/schemas/MessagingExperiment.schema.json
@@ -1,0 +1,1627 @@
+{
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "$id": "resource://activity-stream/schemas/MessagingExperiment.schema.json",
+  "title": "Messaging Experiment",
+  "description": "A Firefox Messaging System message.",
+  "oneOf": [
+    {
+      "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/TemplatedMessage"
+    },
+    {
+      "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/MultiMessage"
+    }
+  ],
+  "$defs": {
+    "CFRUrlbarChiclet": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "$id": "file:///CFRUrlbarChiclet.schema.json",
+      "title": "CFRUrlbarChiclet",
+      "description": "A template with a chiclet button with text.",
+      "allOf": [
+        {
+          "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/Message"
+        }
+      ],
+      "type": "object",
+      "properties": {
+        "content": {
+          "type": "object",
+          "properties": {
+            "category": {
+              "type": "string",
+              "description": "Attribute used for different groups of messages from the same provider"
+            },
+            "layout": {
+              "type": "string",
+              "description": "Describes how content should be displayed.",
+              "enum": [
+                "chiclet_open_url"
+              ]
+            },
+            "bucket_id": {
+              "type": "string",
+              "description": "A bucket identifier for the addon. This is used in order to anonymize telemetry for history-sensitive targeting."
+            },
+            "notification_text": {
+              "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/localizableText",
+              "description": "The text in the small blue chicklet that appears in the URL bar. This can be a reference to a localized string in Firefox or just a plain string."
+            },
+            "active_color": {
+              "type": "string",
+              "description": "Background color of the button"
+            },
+            "action": {
+              "type": "object",
+              "properties": {
+                "url": {
+                  "description": "The page to open when the button is clicked.",
+                  "type": "string",
+                  "format": "moz-url-format"
+                },
+                "where": {
+                  "description": "Should it open in a new tab or the current tab",
+                  "type": "string",
+                  "enum": [
+                    "current",
+                    "tabshifted"
+                  ]
+                }
+              },
+              "additionalProperties": true,
+              "required": [
+                "url",
+                "where"
+              ]
+            }
+          },
+          "additionalProperties": true,
+          "required": [
+            "layout",
+            "category",
+            "bucket_id",
+            "notification_text",
+            "action"
+          ]
+        },
+        "template": {
+          "type": "string",
+          "const": "cfr_urlbar_chiclet"
+        }
+      },
+      "required": [
+        "targeting",
+        "trigger"
+      ]
+    },
+    "ExtensionDoorhanger": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "$id": "file:///ExtensionDoorhanger.schema.json",
+      "title": "ExtensionDoorhanger",
+      "description": "A template with a heading, addon icon, title and description. No markup allowed.",
+      "allOf": [
+        {
+          "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/Message"
+        }
+      ],
+      "type": "object",
+      "properties": {
+        "content": {
+          "type": "object",
+          "properties": {
+            "category": {
+              "type": "string",
+              "description": "Attribute used for different groups of messages from the same provider"
+            },
+            "layout": {
+              "type": "string",
+              "description": "Attribute used for different groups of messages from the same provider",
+              "enum": [
+                "short_message",
+                "icon_and_message",
+                "addon_recommendation"
+              ]
+            },
+            "anchor_id": {
+              "type": "string",
+              "description": "A DOM element ID that the pop-over will be anchored."
+            },
+            "alt_anchor_id": {
+              "type": "string",
+              "description": "An alternate DOM element ID that the pop-over will be anchored."
+            },
+            "bucket_id": {
+              "type": "string",
+              "description": "A bucket identifier for the addon. This is used in order to anonymize telemetry for history-sensitive targeting."
+            },
+            "skip_address_bar_notifier": {
+              "type": "boolean",
+              "description": "Skip the 'Recommend' notifier and show directly."
+            },
+            "persistent_doorhanger": {
+              "type": "boolean",
+              "description": "Prevent the doorhanger from being dismissed if user interacts with the page or switches between applications."
+            },
+            "notification_text": {
+              "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/localizableText",
+              "description": "The text in the small blue chicklet that appears in the URL bar. This can be a reference to a localized string in Firefox or just a plain string."
+            },
+            "info_icon": {
+              "type": "object",
+              "description": "The small icon displayed in the top right corner of the pop-over. Should be 19x19px, svg or png. Defaults to a small question mark.",
+              "properties": {
+                "label": {
+                  "oneOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "attributes": {
+                          "type": "object",
+                          "properties": {
+                            "tooltiptext": {
+                              "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/localizableText",
+                              "description": "Text for button tooltip used to provide information about the doorhanger."
+                            }
+                          },
+                          "required": [
+                            "tooltiptext"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "attributes"
+                      ]
+                    },
+                    {
+                      "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/localizedText"
+                    }
+                  ]
+                },
+                "sumo_path": {
+                  "type": "string",
+                  "description": "Last part of the path in the URL to the support page with the information about the doorhanger.",
+                  "examples": [
+                    "extensionpromotions",
+                    "extensionrecommendations"
+                  ]
+                }
+              }
+            },
+            "learn_more": {
+              "type": "string",
+              "description": "Last part of the path in the SUMO URL to the support page with the information about the doorhanger.",
+              "examples": [
+                "extensionpromotions",
+                "extensionrecommendations"
+              ]
+            },
+            "heading_text": {
+              "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/localizableText",
+              "description": "The larger heading text displayed in the pop-over. This can be a reference to a localized string in Firefox or just a plain string."
+            },
+            "icon": {
+              "$ref": "file:///ExtensionDoorhanger.schema.json#/$defs/linkUrl",
+              "description": "The icon displayed in the pop-over. Should be 32x32px or 64x64px and png/svg."
+            },
+            "icon_dark_theme": {
+              "type": "string",
+              "description": "Pop-over icon, dark theme variant. Should be 32x32px or 64x64px and png/svg."
+            },
+            "icon_class": {
+              "type": "string",
+              "description": "CSS class of the pop-over icon."
+            },
+            "addon": {
+              "description": "Addon information including AMO URL.",
+              "type": "object",
+              "properties": {
+                "id": {
+                  "$ref": "file:///ExtensionDoorhanger.schema.json#/$defs/plainText",
+                  "description": "Unique addon ID"
+                },
+                "title": {
+                  "$ref": "file:///ExtensionDoorhanger.schema.json#/$defs/plainText",
+                  "description": "Addon name"
+                },
+                "author": {
+                  "$ref": "file:///ExtensionDoorhanger.schema.json#/$defs/plainText",
+                  "description": "Addon author"
+                },
+                "icon": {
+                  "$ref": "file:///ExtensionDoorhanger.schema.json#/$defs/linkUrl",
+                  "description": "The icon displayed in the pop-over. Should be 64x64px and png/svg."
+                },
+                "rating": {
+                  "type": "string",
+                  "description": "Star rating"
+                },
+                "users": {
+                  "type": "string",
+                  "description": "Installed users"
+                },
+                "amo_url": {
+                  "$ref": "file:///ExtensionDoorhanger.schema.json#/$defs/linkUrl",
+                  "description": "Link that offers more information related to the addon."
+                }
+              },
+              "required": [
+                "title",
+                "author",
+                "icon",
+                "amo_url"
+              ]
+            },
+            "text": {
+              "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/localizableText",
+              "description": "The body text displayed in the pop-over. This can be a reference to a localized string in Firefox or just a plain string."
+            },
+            "descriptionDetails": {
+              "description": "Additional information and steps on how to use",
+              "type": "object",
+              "properties": {
+                "steps": {
+                  "description": "Array of string_ids",
+                  "type": "array",
+                  "items": {
+                    "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/localizedText",
+                    "description": "Id of string to localized addon description"
+                  }
+                }
+              },
+              "required": [
+                "steps"
+              ]
+            },
+            "buttons": {
+              "description": "The label and functionality for the buttons in the pop-over.",
+              "type": "object",
+              "properties": {
+                "primary": {
+                  "type": "object",
+                  "properties": {
+                    "label": {
+                      "type": "object",
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "value": {
+                              "$ref": "file:///ExtensionDoorhanger.schema.json#/$defs/plainText",
+                              "description": "Button label override used when a localized version is not available."
+                            },
+                            "attributes": {
+                              "type": "object",
+                              "properties": {
+                                "accesskey": {
+                                  "type": "string",
+                                  "description": "A single character to be used as a shortcut key for the secondary button. This should be one of the characters that appears in the button label."
+                                }
+                              },
+                              "required": [
+                                "accesskey"
+                              ],
+                              "description": "Button attributes."
+                            }
+                          },
+                          "required": [
+                            "value",
+                            "attributes"
+                          ]
+                        },
+                        {
+                          "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/localizedText"
+                        }
+                      ],
+                      "description": "Id of localized string or message override."
+                    },
+                    "action": {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "description": "Action dispatched by the button."
+                        },
+                        "data": {
+                          "properties": {
+                            "url": {
+                              "type": "string",
+                              "$comment": "This is dynamically generated from the addon.id. See CFRPageActions.jsm",
+                              "description": "URL used in combination with the primary action dispatched."
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "secondary": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "label": {
+                        "type": "object",
+                        "oneOf": [
+                          {
+                            "properties": {
+                              "value": {
+                                "allOf": [
+                                  {
+                                    "$ref": "file:///ExtensionDoorhanger.schema.json#/$defs/plainText"
+                                  },
+                                  {
+                                    "description": "Button label override used when a localized version is not available."
+                                  }
+                                ]
+                              },
+                              "attributes": {
+                                "type": "object",
+                                "properties": {
+                                  "accesskey": {
+                                    "type": "string",
+                                    "description": "A single character to be used as a shortcut key for the secondary button. This should be one of the characters that appears in the button label."
+                                  }
+                                },
+                                "required": [
+                                  "accesskey"
+                                ],
+                                "description": "Button attributes."
+                              }
+                            },
+                            "required": [
+                              "value",
+                              "attributes"
+                            ]
+                          },
+                          {
+                            "properties": {
+                              "string_id": {
+                                "allOf": [
+                                  {
+                                    "$ref": "file:///ExtensionDoorhanger.schema.json#/$defs/plainText"
+                                  },
+                                  {
+                                    "description": "Id of localized string for button"
+                                  }
+                                ]
+                              }
+                            },
+                            "required": [
+                              "string_id"
+                            ]
+                          }
+                        ],
+                        "description": "Id of localized string or message override."
+                      },
+                      "action": {
+                        "type": "object",
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "description": "Action dispatched by the button."
+                          },
+                          "data": {
+                            "properties": {
+                              "url": {
+                                "allOf": [
+                                  {
+                                    "$ref": "file:///ExtensionDoorhanger.schema.json#/$defs/linkUrl"
+                                  },
+                                  {
+                                    "description": "URL used in combination with the primary action dispatched."
+                                  }
+                                ]
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "additionalProperties": true,
+          "required": [
+            "layout",
+            "bucket_id",
+            "heading_text",
+            "text",
+            "buttons"
+          ],
+          "if": {
+            "properties": {
+              "skip_address_bar_notifier": {
+                "anyOf": [
+                  {
+                    "const": "false"
+                  },
+                  {
+                    "const": null
+                  }
+                ]
+              }
+            }
+          },
+          "then": {
+            "required": [
+              "category",
+              "notification_text"
+            ]
+          }
+        },
+        "template": {
+          "type": "string",
+          "enum": [
+            "cfr_doorhanger",
+            "milestone_message"
+          ]
+        }
+      },
+      "additionalProperties": true,
+      "required": [
+        "targeting",
+        "trigger"
+      ],
+      "$defs": {
+        "plainText": {
+          "description": "Plain text (no HTML allowed)",
+          "type": "string"
+        },
+        "linkUrl": {
+          "description": "Target for links or buttons",
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "InfoBar": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "$id": "file:///InfoBar.schema.json",
+      "title": "InfoBar",
+      "description": "A template with an image, test and buttons.",
+      "allOf": [
+        {
+          "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/Message"
+        }
+      ],
+      "type": "object",
+      "properties": {
+        "content": {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "description": "Should the message be global (persisted across tabs) or local (disappear when switching to a different tab).",
+              "enum": [
+                "global",
+                "tab"
+              ]
+            },
+            "text": {
+              "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/localizableText",
+              "description": "The text show in the notification box."
+            },
+            "priority": {
+              "description": "Infobar priority level https://searchfox.org/mozilla-central/rev/3aef835f6cb12e607154d56d68726767172571e4/toolkit/content/widgets/notificationbox.js#387",
+              "type": "number",
+              "minumum": 0,
+              "exclusiveMaximum": 10
+            },
+            "buttons": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "label": {
+                    "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/localizableText",
+                    "description": "The text label of the button."
+                  },
+                  "primary": {
+                    "type": "boolean",
+                    "description": "Is this the primary button?"
+                  },
+                  "accessKey": {
+                    "type": "string",
+                    "description": "Keyboard shortcut letter."
+                  },
+                  "action": {
+                    "type": "object",
+                    "properties": {
+                      "type": {
+                        "type": "string",
+                        "description": "Action dispatched by the button."
+                      },
+                      "data": {
+                        "type": "object"
+                      }
+                    },
+                    "required": [
+                      "type"
+                    ],
+                    "additionalProperties": true
+                  },
+                  "supportPage": {
+                    "type": "string",
+                    "description": "A page title on SUMO to link to"
+                  }
+                },
+                "required": [
+                  "label",
+                  "action"
+                ],
+                "additionalProperties": true
+              }
+            }
+          },
+          "additionalProperties": true,
+          "required": [
+            "text",
+            "buttons"
+          ]
+        },
+        "template": {
+          "type": "string",
+          "const": "infobar"
+        }
+      },
+      "additionalProperties": true,
+      "required": [
+        "targeting",
+        "trigger"
+      ],
+      "$defs": {
+        "plainText": {
+          "description": "Plain text (no HTML allowed)",
+          "type": "string"
+        },
+        "linkUrl": {
+          "description": "Target for links or buttons",
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "NewtabPromoMessage": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "$id": "file:///NewtabPromoMessage.schema.json",
+      "title": "PBNewtabPromoMessage",
+      "description": "Message shown on the private browsing newtab page.",
+      "allOf": [
+        {
+          "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/Message"
+        }
+      ],
+      "type": "object",
+      "properties": {
+        "content": {
+          "type": "object",
+          "properties": {
+            "hideDefault": {
+              "type": "boolean",
+              "description": "Should we hide the default promo after the experiment promo is dismissed."
+            },
+            "infoEnabled": {
+              "type": "boolean",
+              "description": "Should we show the info section."
+            },
+            "infoIcon": {
+              "type": "string",
+              "description": "Icon shown in the left side of the info section. Default is the private browsing icon."
+            },
+            "infoTitle": {
+              "type": "string",
+              "description": "Is the title in the info section enabled."
+            },
+            "infoTitleEnabled": {
+              "type": "boolean",
+              "description": "Is the title in the info section enabled."
+            },
+            "infoBody": {
+              "type": "string",
+              "description": "Text content in the info section."
+            },
+            "infoLinkText": {
+              "type": "string",
+              "description": "Text for the link in the info section."
+            },
+            "infoLinkUrl": {
+              "type": "string",
+              "description": "URL for the info section link.",
+              "format": "moz-url-format"
+            },
+            "promoEnabled": {
+              "type": "boolean",
+              "description": "Should we show the promo section."
+            },
+            "promoType": {
+              "type": "string",
+              "description": "Promo type used to determine if promo should show to a given user",
+              "enum": [
+                "FOCUS",
+                "VPN",
+                "PIN",
+                "COOKIE_BANNERS",
+                "OTHER"
+              ]
+            },
+            "promoSectionStyle": {
+              "type": "string",
+              "description": "Sets the position of the promo section. Possible values are: top, below-search, bottom. Default bottom.",
+              "enum": [
+                "top",
+                "below-search",
+                "bottom"
+              ]
+            },
+            "promoTitle": {
+              "type": "string",
+              "description": "The text content of the promo section."
+            },
+            "promoTitleEnabled": {
+              "type": "boolean",
+              "description": "Should we show text content in the promo section."
+            },
+            "promoLinkText": {
+              "type": "string",
+              "description": "The text of the link in the promo box."
+            },
+            "promoHeader": {
+              "type": "string",
+              "description": "The title of the promo section."
+            },
+            "promoButton": {
+              "type": "object",
+              "properties": {
+                "action": {
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "description": "Action dispatched by the button."
+                    },
+                    "data": {
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "type"
+                  ],
+                  "additionalProperties": true
+                }
+              },
+              "required": [
+                "action"
+              ]
+            },
+            "promoLinkType": {
+              "type": "string",
+              "description": "Type of promo link type. Possible values: link, button. Default is link.",
+              "enum": [
+                "link",
+                "button"
+              ]
+            },
+            "promoImageLarge": {
+              "type": "string",
+              "description": "URL for image used on the left side of the promo box, larger, showcases some feature. Default off.",
+              "format": "uri"
+            },
+            "promoImageSmall": {
+              "type": "string",
+              "description": "URL for image used on the right side of the promo box, smaller, usually a logo. Default off.",
+              "format": "uri"
+            }
+          },
+          "additionalProperties": true,
+          "allOf": [
+            {
+              "if": {
+                "properties": {
+                  "promoEnabled": {
+                    "const": true
+                  }
+                },
+                "required": [
+                  "promoEnabled"
+                ]
+              },
+              "then": {
+                "required": [
+                  "promoButton"
+                ]
+              }
+            },
+            {
+              "if": {
+                "properties": {
+                  "infoEnabled": {
+                    "const": true
+                  }
+                },
+                "required": [
+                  "infoEnabled"
+                ]
+              },
+              "then": {
+                "required": [
+                  "infoLinkText"
+                ],
+                "if": {
+                  "properties": {
+                    "infoTitleEnabled": {
+                      "const": true
+                    }
+                  },
+                  "required": [
+                    "infoTitleEnabled"
+                  ]
+                },
+                "then": {
+                  "required": [
+                    "infoTitle"
+                  ]
+                }
+              }
+            }
+          ]
+        },
+        "template": {
+          "type": "string",
+          "const": "pb_newtab"
+        }
+      },
+      "additionalProperties": true,
+      "required": [
+        "targeting"
+      ]
+    },
+    "ProtectionsPanelMessage": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "$id": "file:///ProtectionsPanelMessage.schema.json",
+      "title": "ProtectionsPanelMessage",
+      "description": "A message shown in the protections panel.",
+      "allOf": [
+        {
+          "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/Message"
+        }
+      ],
+      "type": "object",
+      "properties": {
+        "content": {
+          "type": "object",
+          "properties": {
+            "title": {
+              "description": "The message title.",
+              "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/localizableText"
+            },
+            "body": {
+              "description": "The body of the message.",
+              "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/localizableText"
+            },
+            "link_text": {
+              "description": "The text of the call to action link.",
+              "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/localizableText"
+            },
+            "cta_type": {
+              "description": "The type of URL open action.",
+              "type": "string",
+              "enum": [
+                "OPEN_URL",
+                "OPEN_PROTECTION_REPORT",
+                "OPEN_ABOUT_PAGE"
+              ]
+            },
+            "cta_url": {
+              "description": "The URL to open when the call to action is clicked",
+              "type": "string",
+              "format": "moz-url-format"
+            },
+            "cta_where": {
+              "description": "How to open the cta.",
+              "type": "string",
+              "enum": [
+                "current",
+                "tabshifted",
+                "tab",
+                "save",
+                "window"
+              ]
+            }
+          },
+          "dependantSchemas": {
+            "link_text": [
+              "cta_type",
+              "cta_url"
+            ],
+            "cta_type": [
+              "link_text"
+            ],
+            "cta_url": [
+              "link_text"
+            ],
+            "cta_where": [
+              "link_text"
+            ]
+          },
+          "additionalProperties": false,
+          "required": [
+            "title",
+            "body"
+          ]
+        },
+        "template": {
+          "type": "string",
+          "const": "protections_panel"
+        },
+        "trigger": {
+          "description": "An action to trigger potentially showing the message. The action ID `protectionsPanelOpen` is required.",
+          "const": {
+            "id": "protectionsPanelOpen"
+          }
+        }
+      },
+      "required": [
+        "content",
+        "template",
+        "trigger"
+      ],
+      "additionalProperties": true
+    },
+    "Spotlight": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "$id": "file:///Spotlight.schema.json",
+      "title": "Spotlight",
+      "description": "A template with an image, title, content and two buttons.",
+      "allOf": [
+        {
+          "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/Message"
+        }
+      ],
+      "type": "object",
+      "properties": {
+        "content": {
+          "type": "object",
+          "properties": {
+            "template": {
+              "type": "string",
+              "description": "Specify the layout template for the Spotlight",
+              "const": "multistage"
+            },
+            "backdrop": {
+              "type": "string",
+              "description": "Background css behind modal content"
+            },
+            "logo": {
+              "type": "object",
+              "properties": {
+                "imageURL": {
+                  "type": "string",
+                  "description": "URL for image to use with the content"
+                },
+                "imageId": {
+                  "type": "string",
+                  "description": "The ID for a remotely hosted image"
+                },
+                "size": {
+                  "type": "string",
+                  "description": "The logo size."
+                }
+              },
+              "additionalProperties": true
+            },
+            "screens": {
+              "type": "array",
+              "description": "Collection of individual screen content"
+            },
+            "transitions": {
+              "type": "boolean",
+              "description": "Show transitions within and between screens"
+            },
+            "disableHistoryUpdates": {
+              "type": "boolean",
+              "description": "Don't alter the browser session's history stack - used with messaging surfaces like Feature Callouts"
+            },
+            "startScreen": {
+              "type": "integer",
+              "description": "Index of first screen to show from message, defaulting to 0"
+            }
+          },
+          "additionalProperties": true
+        },
+        "template": {
+          "type": "string",
+          "description": "Specify whether the surface is shown as a Spotlight modal or an in-surface Feature Callout dialog",
+          "enum": [
+            "spotlight",
+            "feature_callout"
+          ]
+        }
+      },
+      "additionalProperties": true,
+      "required": [
+        "targeting"
+      ]
+    },
+    "ToastNotification": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "$id": "file:///ToastNotification.schema.json",
+      "title": "ToastNotification",
+      "description": "A template for toast notifications displayed by the Alert service.",
+      "allOf": [
+        {
+          "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/Message"
+        }
+      ],
+      "type": "object",
+      "properties": {
+        "content": {
+          "type": "object",
+          "properties": {
+            "title": {
+              "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/localizableText",
+              "description": "Id of localized string or message override of toast notification title"
+            },
+            "body": {
+              "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/localizableText",
+              "description": "Id of localized string or message override of toast notification body"
+            },
+            "icon_url": {
+              "description": "The URL of the image used as an icon of the toast notification.",
+              "type": "string",
+              "format": "moz-url-format"
+            },
+            "image_url": {
+              "description": "The URL of an image to be displayed as part of the notification.",
+              "type": "string",
+              "format": "moz-url-format"
+            },
+            "launch_url": {
+              "description": "The URL to launch when the notification or an action button is clicked.",
+              "type": "string",
+              "format": "moz-url-format"
+            },
+            "requireInteraction": {
+              "type": "boolean",
+              "description": "Whether the toast notification should remain active until the user clicks or dismisses it, rather than closing automatically."
+            },
+            "tag": {
+              "type": "string",
+              "description": "An identifying tag for the toast notification."
+            },
+            "data": {
+              "type": "object",
+              "description": "Arbitrary data associated with the toast notification."
+            },
+            "actions": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "title": {
+                    "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/localizableText",
+                    "description": "The action text to be shown to the user."
+                  },
+                  "action": {
+                    "type": "string",
+                    "description": "Opaque identifer that identifies action."
+                  },
+                  "iconURL": {
+                    "type": "string",
+                    "format": "uri",
+                    "description": "URL of an icon to display with the action."
+                  },
+                  "windowsSystemActivationType": {
+                    "type": "boolean",
+                    "description": "Whether to have Windows process the given `action`."
+                  }
+                },
+                "required": [
+                  "action",
+                  "title"
+                ],
+                "additionalProperties": true
+              }
+            }
+          },
+          "additionalProperties": true,
+          "required": [
+            "title",
+            "body"
+          ]
+        },
+        "template": {
+          "type": "string",
+          "const": "toast_notification"
+        }
+      },
+      "required": [
+        "content",
+        "targeting",
+        "template",
+        "trigger"
+      ],
+      "additionalProperties": true
+    },
+    "ToolbarBadgeMessage": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "$id": "file:///ToolbarBadgeMessage.schema.json",
+      "title": "ToolbarBadgeMessage",
+      "description": "A template that specifies to which element in the browser toolbar to add a notification.",
+      "allOf": [
+        {
+          "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/Message"
+        }
+      ],
+      "type": "object",
+      "properties": {
+        "content": {
+          "type": "object",
+          "properties": {
+            "target": {
+              "type": "string"
+            },
+            "action": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": true,
+              "required": [
+                "id"
+              ],
+              "description": "Optional action to take in addition to showing the notification"
+            },
+            "delay": {
+              "type": "number",
+              "description": "Optional delay in ms after which to show the notification"
+            },
+            "badgeDescription": {
+              "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/localizedText",
+              "description": "This is used in combination with the badged button to offer a text based alternative to the visual badging. Example 'New Feature: What's New'"
+            }
+          },
+          "additionalProperties": true,
+          "required": [
+            "target"
+          ]
+        },
+        "template": {
+          "type": "string",
+          "const": "toolbar_badge"
+        }
+      },
+      "additionalProperties": true,
+      "required": [
+        "targeting"
+      ]
+    },
+    "UpdateAction": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "$id": "file:///UpdateAction.schema.json",
+      "title": "UpdateActionMessage",
+      "description": "A template for messages that execute predetermined actions.",
+      "allOf": [
+        {
+          "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/Message"
+        }
+      ],
+      "type": "object",
+      "properties": {
+        "content": {
+          "type": "object",
+          "properties": {
+            "action": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "data": {
+                  "type": "object",
+                  "description": "Additional data provided as argument when executing the action",
+                  "properties": {
+                    "url": {
+                      "type": "string",
+                      "description": "URL data to be used as argument to the action"
+                    },
+                    "expireDelta": {
+                      "type": "number",
+                      "description": "Expiration timestamp to be used as argument to the action"
+                    }
+                  }
+                }
+              },
+              "additionalProperties": true,
+              "description": "Optional action to take in addition to showing the notification",
+              "required": [
+                "id",
+                "data"
+              ]
+            }
+          },
+          "additionalProperties": true,
+          "required": [
+            "action"
+          ]
+        },
+        "template": {
+          "type": "string",
+          "const": "update_action"
+        }
+      },
+      "required": [
+        "targeting"
+      ]
+    },
+    "WhatsNewMessage": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "$id": "file:///WhatsNewMessage.schema.json",
+      "title": "WhatsNewMessage",
+      "description": "A template for the messages that appear in the What's New panel.",
+      "allOf": [
+        {
+          "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/Message"
+        }
+      ],
+      "type": "object",
+      "properties": {
+        "content": {
+          "type": "object",
+          "properties": {
+            "layout": {
+              "description": "Different message layouts",
+              "enum": [
+                "tracking-protections"
+              ]
+            },
+            "bucket_id": {
+              "type": "string",
+              "description": "A bucket identifier for the addon. This is used in order to anonymize telemetry for history-sensitive targeting."
+            },
+            "published_date": {
+              "type": "integer",
+              "description": "The date/time (number of milliseconds elapsed since January 1, 1970 00:00:00 UTC) the message was published."
+            },
+            "title": {
+              "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/localizableText",
+              "description": "Id of localized string or message override of What's New message title"
+            },
+            "subtitle": {
+              "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/localizableText",
+              "description": "Id of localized string or message override of What's New message subtitle"
+            },
+            "body": {
+              "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/localizableText",
+              "description": "Id of localized string or message override of What's New message body"
+            },
+            "link_text": {
+              "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/localizableText",
+              "description": "(optional) Id of localized string or message override of What's New message link text"
+            },
+            "cta_url": {
+              "description": "Target URL for the What's New message.",
+              "type": "string",
+              "format": "moz-url-format"
+            },
+            "cta_type": {
+              "description": "Type of url open action",
+              "enum": [
+                "OPEN_URL",
+                "OPEN_ABOUT_PAGE",
+                "OPEN_PROTECTION_REPORT"
+              ]
+            },
+            "cta_where": {
+              "description": "How to open the cta: new window, tab, focused, unfocused.",
+              "enum": [
+                "current",
+                "tabshifted",
+                "tab",
+                "save",
+                "window"
+              ]
+            },
+            "icon_url": {
+              "description": "(optional) URL for the What's New message icon.",
+              "type": "string",
+              "format": "uri"
+            },
+            "icon_alt": {
+              "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/localizableText",
+              "description": "Alt text for image."
+            }
+          },
+          "additionalProperties": true,
+          "required": [
+            "published_date",
+            "title",
+            "body",
+            "cta_url",
+            "bucket_id"
+          ]
+        },
+        "template": {
+          "type": "string",
+          "const": "whatsnew_panel_message"
+        }
+      },
+      "required": [
+        "order"
+      ],
+      "additionalProperties": true
+    },
+    "Message": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "The message identifier"
+        },
+        "groups": {
+          "description": "Array of preferences used to control `enabled` status of the group. If any is `false` the group is disabled.",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "description": "Preference name"
+          }
+        },
+        "template": {
+          "type": "string",
+          "description": "Which messaging template this message is using.",
+          "enum": [
+            "cfr_urlbar_chiclet",
+            "cfr_doorhanger",
+            "milestone_message",
+            "infobar",
+            "pb_newtab",
+            "protections_panel",
+            "spotlight",
+            "feature_callout",
+            "toast_notification",
+            "toolbar_badge",
+            "update_action",
+            "whatsnew_panel_message"
+          ]
+        },
+        "frequency": {
+          "type": "object",
+          "description": "An object containing frequency cap information for a message.",
+          "properties": {
+            "lifetime": {
+              "type": "integer",
+              "description": "The maximum lifetime impressions for a message.",
+              "minimum": 1,
+              "maximum": 100
+            },
+            "custom": {
+              "type": "array",
+              "description": "An array of custom frequency cap definitions.",
+              "items": {
+                "description": "A frequency cap definition containing time and max impression information",
+                "type": "object",
+                "properties": {
+                  "period": {
+                    "type": "integer",
+                    "description": "Period of time in milliseconds (e.g. 86400000 for one day)"
+                  },
+                  "cap": {
+                    "type": "integer",
+                    "description": "The maximum impressions for the message within the defined period.",
+                    "minimum": 1,
+                    "maximum": 100
+                  }
+                },
+                "required": [
+                  "period",
+                  "cap"
+                ]
+              }
+            }
+          }
+        },
+        "priority": {
+          "description": "The priority of the message. If there are two competing messages to show, the one with the highest priority will be shown",
+          "type": "integer"
+        },
+        "order": {
+          "description": "The order in which messages should be shown. Messages will be shown in increasing order.",
+          "type": "integer"
+        },
+        "targeting": {
+          "description": "A JEXL expression representing targeting information",
+          "type": "string"
+        },
+        "trigger": {
+          "description": "An action to trigger potentially showing the message",
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "A string identifying the trigger action"
+            },
+            "params": {
+              "type": "array",
+              "description": "An optional array of string parameters for the trigger action",
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "string"
+                  }
+                ]
+              }
+            }
+          },
+          "required": [
+            "id"
+          ]
+        },
+        "provider": {
+          "description": "An identifier for the provider of this message, such as \"cfr\" or \"preview\".",
+          "type": "string"
+        }
+      },
+      "additionalProperties": true,
+      "dependentRequired": {
+        "content": [
+          "id",
+          "template"
+        ],
+        "template": [
+          "id",
+          "content"
+        ]
+      }
+    },
+    "localizedText": {
+      "type": "object",
+      "properties": {
+        "string_id": {
+          "description": "Id of localized string to be rendered.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "string_id"
+      ]
+    },
+    "localizableText": {
+      "description": "Either a raw string or an object containing the string_id of the localized text",
+      "oneOf": [
+        {
+          "type": "string",
+          "description": "The string to be rendered."
+        },
+        {
+          "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/localizedText"
+        }
+      ]
+    },
+    "TemplatedMessage": {
+      "description": "An FxMS message of one of a variety of types.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/Message"
+        },
+        {
+          "if": {
+            "type": "object",
+            "properties": {
+              "template": {
+                "type": "string",
+                "enum": [
+                  "cfr_urlbar_chiclet"
+                ]
+              }
+            },
+            "required": [
+              "template"
+            ]
+          },
+          "then": {
+            "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/CFRUrlbarChiclet"
+          }
+        },
+        {
+          "if": {
+            "type": "object",
+            "properties": {
+              "template": {
+                "type": "string",
+                "enum": [
+                  "cfr_doorhanger",
+                  "milestone_message"
+                ]
+              }
+            },
+            "required": [
+              "template"
+            ]
+          },
+          "then": {
+            "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/ExtensionDoorhanger"
+          }
+        },
+        {
+          "if": {
+            "type": "object",
+            "properties": {
+              "template": {
+                "type": "string",
+                "enum": [
+                  "infobar"
+                ]
+              }
+            },
+            "required": [
+              "template"
+            ]
+          },
+          "then": {
+            "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/InfoBar"
+          }
+        },
+        {
+          "if": {
+            "type": "object",
+            "properties": {
+              "template": {
+                "type": "string",
+                "enum": [
+                  "pb_newtab"
+                ]
+              }
+            },
+            "required": [
+              "template"
+            ]
+          },
+          "then": {
+            "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/NewtabPromoMessage"
+          }
+        },
+        {
+          "if": {
+            "type": "object",
+            "properties": {
+              "template": {
+                "type": "string",
+                "enum": [
+                  "protections_panel"
+                ]
+              }
+            },
+            "required": [
+              "template"
+            ]
+          },
+          "then": {
+            "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/ProtectionsPanelMessage"
+          }
+        },
+        {
+          "if": {
+            "type": "object",
+            "properties": {
+              "template": {
+                "type": "string",
+                "enum": [
+                  "spotlight",
+                  "feature_callout"
+                ]
+              }
+            },
+            "required": [
+              "template"
+            ]
+          },
+          "then": {
+            "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/Spotlight"
+          }
+        },
+        {
+          "if": {
+            "type": "object",
+            "properties": {
+              "template": {
+                "type": "string",
+                "enum": [
+                  "toast_notification"
+                ]
+              }
+            },
+            "required": [
+              "template"
+            ]
+          },
+          "then": {
+            "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/ToastNotification"
+          }
+        },
+        {
+          "if": {
+            "type": "object",
+            "properties": {
+              "template": {
+                "type": "string",
+                "enum": [
+                  "toolbar_badge"
+                ]
+              }
+            },
+            "required": [
+              "template"
+            ]
+          },
+          "then": {
+            "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/ToolbarBadgeMessage"
+          }
+        },
+        {
+          "if": {
+            "type": "object",
+            "properties": {
+              "template": {
+                "type": "string",
+                "enum": [
+                  "update_action"
+                ]
+              }
+            },
+            "required": [
+              "template"
+            ]
+          },
+          "then": {
+            "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/UpdateAction"
+          }
+        },
+        {
+          "if": {
+            "type": "object",
+            "properties": {
+              "template": {
+                "type": "string",
+                "enum": [
+                  "whatsnew_panel_message"
+                ]
+              }
+            },
+            "required": [
+              "template"
+            ]
+          },
+          "then": {
+            "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/WhatsNewMessage"
+          }
+        }
+      ]
+    },
+    "MultiMessage": {
+      "description": "An object containing an array of messages.",
+      "type": "object",
+      "properties": {
+        "template": {
+          "type": "string",
+          "const": "multi"
+        },
+        "messages": {
+          "type": "array",
+          "description": "An array of messages.",
+          "items": {
+            "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/TemplatedMessage"
+          }
+        }
+      },
+      "required": [
+        "template",
+        "messages"
+      ]
+    }
+  }
+}

--- a/experimenter/experimenter/features/manifests/schemas/toolkit/components/normandy/schemas/LegacyHeartbeat.schema.json
+++ b/experimenter/experimenter/features/manifests/schemas/toolkit/components/normandy/schemas/LegacyHeartbeat.schema.json
@@ -1,0 +1,73 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Legacy (Normandy) Heartbeat, via Nimbus",
+  "description": "The schema for the Legacy Heartbeat Nimbus feature.",
+  "type": "object",
+  "properties": {
+    "survey": {
+      "$comment": "Hearbeat arguments are nested under survey to prevent simultaneous rollouts and experiments from overriding eachothers optional variables",
+      "type": "object",
+      "properties": {
+        "repeatOption": {
+          "type": "string",
+          "enum": ["once", "xdays", "nag"],
+          "description": "Determines how often a prompt is shown executes.",
+          "default": "once"
+        },
+        "repeatEvery": {
+          "description": "For repeatOption=xdays, how often (in days) the prompt is displayed.",
+          "default": null,
+          "type": ["number", "null"]
+        },
+        "includeTelemetryUUID": {
+          "type": "boolean",
+          "description": "Include unique user ID in post-answer-url and Telemetry",
+          "default": false
+        },
+        "surveyId": {
+          "description": "Slug uniquely identifying this survey in telemetry",
+          "type": "string"
+        },
+        "message": {
+          "description": "Message to show to the user",
+          "type": "string"
+        },
+        "engagementButtonLabel": {
+          "description": "Text for the engagement button. If specified, this button will be shown instead of rating stars.",
+          "default": null,
+          "type": ["string", "null"]
+        },
+        "thanksMessage": {
+          "description": "Thanks message to show to the user after they've rated Firefox",
+          "type": "string"
+        },
+        "postAnswerUrl": {
+          "description": "URL to redirect the user to after rating Firefox or clicking the engagement button",
+          "default": null,
+          "type": ["string", "null"]
+        },
+        "learnMoreMessage": {
+          "description": "Message to show to the user to learn more",
+          "default": null,
+          "type": ["string", "null"]
+        },
+        "learnMoreUrl": {
+          "description": "URL to show to the user when they click Learn More",
+          "default": null,
+          "type": ["string", "null"]
+        }
+      },
+      "required": [
+        "surveyId",
+        "message",
+        "thanksMessage",
+        "postAnswerUrl",
+        "learnMoreMessage",
+        "learnMoreUrl"
+      ],
+      "additionalProperties": false
+    }
+  },
+  "required": ["survey"],
+  "additionalProperties": false
+}

--- a/experimenter/experimenter/features/tests/__init__.py
+++ b/experimenter/experimenter/features/tests/__init__.py
@@ -15,16 +15,23 @@ mock_invalid_features = override_settings(
     )
 )
 
+MOCK_REMOTE_FEATURE_MANIFESTS_PATH = os.path.join(
+    pathlib.Path(__file__).parent.absolute(), "fixtures", "remote_schema_features"
+)
 mock_remote_schema_features = override_settings(
-    FEATURE_MANIFESTS_PATH=os.path.join(
-        pathlib.Path(__file__).parent.absolute(), "fixtures", "remote_schema_features"
-    )
+    FEATURE_MANIFESTS_PATH=MOCK_REMOTE_FEATURE_MANIFESTS_PATH,
+    FEATURE_SCHEMAS_PATH=os.path.join(MOCK_REMOTE_FEATURE_MANIFESTS_PATH, "schemas"),
+)
+
+MOCK_INVALID_REMOTE_FEATURE_MANIFESTS_PATH = os.path.join(
+    pathlib.Path(__file__).parent.absolute(),
+    "fixtures",
+    "invalid_remote_schema_features",
 )
 
 mock_invalid_remote_schema_features = override_settings(
-    FEATURE_MANIFESTS_PATH=os.path.join(
-        pathlib.Path(__file__).parent.absolute(),
-        "fixtures",
-        "invalid_remote_schema_features",
-    )
+    FEATURE_MANIFESTS_PATH=MOCK_INVALID_REMOTE_FEATURE_MANIFESTS_PATH,
+    FEATURE_SCHEMAS_PATH=os.path.join(
+        MOCK_INVALID_REMOTE_FEATURE_MANIFESTS_PATH, "schemas"
+    ),
 )

--- a/experimenter/experimenter/features/tests/fixtures/invalid_remote_schema_features/schemas/path/to/invalidSchema.json
+++ b/experimenter/experimenter/features/tests/fixtures/invalid_remote_schema_features/schemas/path/to/invalidSchema.json
@@ -1,0 +1,1 @@
+{invalid

--- a/experimenter/experimenter/features/tests/fixtures/remote_schema_features/schemas/path/to/schema.json
+++ b/experimenter/experimenter/features/tests/fixtures/remote_schema_features/schemas/path/to/schema.json
@@ -1,0 +1,3 @@
+{
+    "schema": true
+}

--- a/experimenter/experimenter/features/tests/test_features.py
+++ b/experimenter/experimenter/features/tests/test_features.py
@@ -1,7 +1,5 @@
 import json
 
-import mock
-import requests
 from django.core.checks import Error
 from django.test import TestCase
 
@@ -15,6 +13,7 @@ from experimenter.features import (
 )
 from experimenter.features.tests import (
     mock_invalid_features,
+    mock_invalid_remote_schema_features,
     mock_remote_schema_features,
     mock_valid_features,
 )
@@ -145,65 +144,18 @@ class TestFeatures(TestCase):
         )
 
 
-@mock_remote_schema_features
 class TestRemoteSchemaFeatures(TestCase):
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
+    def setUp(self):
         Features.clear_cache()
 
-    def setup_valid_remote_schema(self):
-        self.remote_schema = json.dumps({"schema": True})
-
-        mock_requests_get_patcher = mock.patch("experimenter.features.requests.get")
-        self.mock_requests_get = mock_requests_get_patcher.start()
-        self.addCleanup(mock_requests_get_patcher.stop)
-        mock_response = mock.MagicMock()
-        mock_response.content = self.remote_schema
-        self.mock_requests_get.return_value = mock_response
-
-    def setup_request_error(self):
-        self.remote_schema = json.dumps({"schema": True})
-
-        mock_requests_get_patcher = mock.patch("experimenter.features.requests.get")
-        self.mock_requests_get = mock_requests_get_patcher.start()
-        self.addCleanup(mock_requests_get_patcher.stop)
-        self.mock_requests_get.side_effect = requests.ConnectionError()
-
-    def setup_json_error(self):
-        self.remote_schema = "{invalid json"
-
-        mock_requests_get_patcher = mock.patch("experimenter.features.requests.get")
-        self.mock_requests_get = mock_requests_get_patcher.start()
-        self.addCleanup(mock_requests_get_patcher.stop)
-        mock_response = mock.MagicMock()
-        mock_response.content = self.remote_schema
-        self.mock_requests_get.return_value = mock_response
-
+    @mock_remote_schema_features
     def test_loads_remote_schema(self):
-        self.setup_valid_remote_schema()
-
         desktop_feature = Features.by_application(NimbusExperiment.Application.DESKTOP)[0]
         remote_schema = desktop_feature.get_jsonschema()
-
-        self.mock_requests_get.assert_called_once_with(
-            "https://hg.mozilla.org/mozilla-central/raw-file/tip/path/to/schema.json"
-        )
-
         self.assertEqual(json.loads(remote_schema), {"schema": True})
 
-    def test_raises_request_error(self):
-        self.setup_request_error()
-
-        with self.assertRaises(requests.ConnectionError):
-            desktop_feature = Features.by_application(
-                NimbusExperiment.Application.DESKTOP
-            )[0]
-            desktop_feature.get_jsonschema()
-
+    @mock_invalid_remote_schema_features
     def test_returns_none_for_invalid_json(self):
-        self.setup_json_error()
-
         desktop_feature = Features.by_application(NimbusExperiment.Application.DESKTOP)[0]
         self.assertIsNone(desktop_feature.get_jsonschema())
 

--- a/experimenter/experimenter/features/tests/test_load_feature_configs.py
+++ b/experimenter/experimenter/features/tests/test_load_feature_configs.py
@@ -1,6 +1,5 @@
 import json
 
-import mock
 from django.core.management import call_command
 from django.test import TestCase
 
@@ -179,16 +178,6 @@ class TestLoadInvalidRemoteSchemaFeatureConfigs(TestCase):
     def setUpClass(cls):
         super().setUpClass()
         Features.clear_cache()
-
-    def setUp(self):
-        self.remote_schema = "{invalid json"
-
-        mock_requests_get_patcher = mock.patch("experimenter.features.requests.get")
-        self.mock_requests_get = mock_requests_get_patcher.start()
-        self.addCleanup(mock_requests_get_patcher.stop)
-        mock_response = mock.MagicMock()
-        mock_response.content = self.remote_schema
-        self.mock_requests_get.return_value = mock_response
 
     def test_load_feature_config_ignores_invalid_remote_json(self):
         schema = "{}"

--- a/experimenter/experimenter/settings.py
+++ b/experimenter/experimenter/settings.py
@@ -470,6 +470,7 @@ JETSTREAM_CONFIG_OUTCOMES_PATH = os.path.join(
 
 # Feature Manifest path
 FEATURE_MANIFESTS_PATH = os.path.join(BASE_DIR, "features", "manifests")
+FEATURE_SCHEMAS_PATH = os.path.join(FEATURE_MANIFESTS_PATH, "schemas")
 
 SKIP_REVIEW_ACCESS_CONTROL_FOR_DEV_USER = config(
     "SKIP_REVIEW_ACCESS_CONTROL_FOR_DEV_USER", default=False, cast=bool


### PR DESCRIPTION
Because

* We have been prefetching feature manifests in a circle task and storing them in the repo
* Feature manifests can refer to remote feature schemas
* We have been remotely fetching those schemas at container startup time
* As the number of remote feature schemas increases, this can delay container startup and introduces the risk of remote schemas failing to fetch during container start
* We have been seeing intermittent deploy failures which may be caused by slow/failing remote schema fetches

This commit

* Fetches remote schemas as part of the circle ci task
* Stores remote schemas in the repo
* Loads remote schemas from disk at container startup time


