### PR TITLE
fix #8812 feat(cirrus): Test and coverage fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -202,7 +202,7 @@ CIRRUS_BLACK_CHECK = black -l 90 --check --diff cirrus/server
 CIRRUS_BLACK_FIX = black -l 90 cirrus/server
 CIRRUS_RUFF_CHECK = ruff cirrus/server
 CIRRUS_RUFF_FIX = ruff --fix cirrus/server
-CIRRUS_PYTEST = pytest cirrus/server --cov=cirrus
+CIRRUS_PYTEST = pytest cirrus/server --cov-config=cirrus/server/.coveragerc --cov=cirrus/server/cirrus
 CIRRUS_PYTHON_TYPECHECK = pyright -p cirrus/server
 CIRRUS_PYTHON_TYPECHECK_CREATESTUB = pyright -p cirrus/server --createstub cirrus
 CIRRUS_GENERATE_DOCS = python cirrus/server/cirrus/generate_docs.py

--- a/cirrus/server/.coveragerc
+++ b/cirrus/server/.coveragerc
@@ -1,0 +1,3 @@
+[run]
+omit =
+    cirrus/server/cirrus/generate_docs.py

--- a/cirrus/server/cirrus/sdk.py
+++ b/cirrus/server/cirrus/sdk.py
@@ -2,7 +2,7 @@ from typing import Any, Dict, List
 
 
 class SDK:
-
-    def compute_enrollments(self, recipes: List[Dict[str, Any]],
-                            targeting_context: Dict[str, str]) -> List[Dict[str, str]]:
+    def compute_enrollments(
+        self, recipes: List[Dict[str, Any]], targeting_context: Dict[str, str]
+    ) -> List[Dict[str, str]]:
         return []

--- a/cirrus/server/tests/test_feature_manifest.py
+++ b/cirrus/server/tests/test_feature_manifest.py
@@ -1,0 +1,23 @@
+import unittest
+
+from ..cirrus.feature_manifest import FeatureManifestLanguage
+
+
+class FeatureManifestLanguageTestCase(unittest.TestCase):
+    def test_compute_feature_configurations(self):
+        fml = FeatureManifestLanguage()
+
+        enrolled_partial_configuration = [
+            {"id": 1, "name": "test1", "value": "true"},
+            {"id": 2, "name": "test2", "value": "false"},
+        ]
+        feature_configurations = [
+            {"id": 1, "name": "feature1", "value": "true"},
+            {"id": 2, "name": "feature2", "value": "false"},
+        ]
+
+        result = fml.compute_feature_configurations(
+            enrolled_partial_configuration, feature_configurations
+        )
+
+        self.assertEqual(result, {"feature": "test"})

--- a/cirrus/server/tests/test_sdk.py
+++ b/cirrus/server/tests/test_sdk.py
@@ -1,0 +1,16 @@
+import unittest
+
+from ..cirrus.sdk import SDK
+
+
+class SDKTestCase(unittest.TestCase):
+    def test_compute_enrollments(self):
+        sdk = SDK()
+        recipes = [
+            {"id": 1, "name": "recipe1"},
+            {"id": 2, "name": "recipe2"},
+        ]
+        targeting_context = {"client_id": "testid"}
+
+        result = sdk.compute_enrollments(recipes, targeting_context)
+        self.assertEqual(result, [])

--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -25,6 +25,6 @@ services:
       context: .
       dockerfile: cirrus/server/Dockerfile
     volumes:
-      - .:/app/cirrus
+      - .:/cirrus
 
 


### PR DESCRIPTION
Because

- We are missing tests for SDK and fml

This commit

- Add tests for SDK and fml
- Uses coverage config to run only tests folder
- Skips generate_docs file from the coverage
- Fixes test docker image volume, because changes in this PR https://github.com/mozilla/experimenter/pull/8771
fixes #8812 