### PR TITLE
fix #8364 feat(nimbus): Add a draft experiments API

### DIFF
--- a/docs/experimenter/openapi-schema.json
+++ b/docs/experimenter/openapi-schema.json
@@ -1537,6 +1537,82 @@
         ]
       }
     },
+    "/api/v6/draft-experiments/": {
+      "get": {
+        "operationId": "listNimbusExperiments",
+        "description": "",
+        "parameters": [
+          {
+            "name": "is_localized",
+            "required": false,
+            "in": "query",
+            "description": "is_localized",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/NimbusExperiment"
+                  }
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "tags": [
+          "Nimbus: Public"
+        ]
+      }
+    },
+    "/api/v6/draft-experiments/{slug}/": {
+      "get": {
+        "operationId": "retrieveNimbusExperiment",
+        "description": "",
+        "parameters": [
+          {
+            "name": "slug",
+            "in": "path",
+            "required": true,
+            "description": "",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "is_localized",
+            "required": false,
+            "in": "query",
+            "description": "is_localized",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NimbusExperiment"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "tags": [
+          "Nimbus: Public"
+        ]
+      }
+    },
     "/api/v2/experiments/{slug}/intent-to-ship-email": {
       "put": {
         "operationId": "updateExperiment",

--- a/docs/experimenter/swagger-ui.html
+++ b/docs/experimenter/swagger-ui.html
@@ -1549,6 +1549,82 @@
         ]
       }
     },
+    "/api/v6/draft-experiments/": {
+      "get": {
+        "operationId": "listNimbusExperiments",
+        "description": "",
+        "parameters": [
+          {
+            "name": "is_localized",
+            "required": false,
+            "in": "query",
+            "description": "is_localized",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/NimbusExperiment"
+                  }
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "tags": [
+          "Nimbus: Public"
+        ]
+      }
+    },
+    "/api/v6/draft-experiments/{slug}/": {
+      "get": {
+        "operationId": "retrieveNimbusExperiment",
+        "description": "",
+        "parameters": [
+          {
+            "name": "slug",
+            "in": "path",
+            "required": true,
+            "description": "",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "is_localized",
+            "required": false,
+            "in": "query",
+            "description": "is_localized",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NimbusExperiment"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "tags": [
+          "Nimbus: Public"
+        ]
+      }
+    },
     "/api/v2/experiments/{slug}/intent-to-ship-email": {
       "put": {
         "operationId": "updateExperiment",

--- a/experimenter/experimenter/experiments/api/v6/urls.py
+++ b/experimenter/experimenter/experiments/api/v6/urls.py
@@ -1,6 +1,7 @@
 from rest_framework.routers import SimpleRouter
 
 from experimenter.experiments.api.v6.views import (
+    NimbusExperimentDraftViewSet,
     NimbusExperimentFirstRunViewSet,
     NimbusExperimentViewSet,
 )
@@ -11,5 +12,10 @@ router.register(
     r"experiments-first-run",
     NimbusExperimentFirstRunViewSet,
     "nimbus-experiment-rest-first-run",
+)
+router.register(
+    r"draft-experiments",
+    NimbusExperimentDraftViewSet,
+    "nimbus-experiment-draft-rest",
 )
 urlpatterns = router.urls

--- a/experimenter/experimenter/experiments/api/v6/views.py
+++ b/experimenter/experimenter/experiments/api/v6/views.py
@@ -21,6 +21,15 @@ class NimbusExperimentViewSet(
     filterset_fields = ["is_first_run"]
 
 
+class NimbusExperimentDraftViewSet(NimbusExperimentViewSet):
+    queryset = (
+        NimbusExperiment.objects.with_related()
+        .filter(status=NimbusExperiment.Status.DRAFT)
+        .order_by("slug")
+    )
+    filterset_fields = ["is_localized"]
+
+
 class NimbusExperimentFirstRunViewSet(NimbusExperimentViewSet):
     queryset = (
         NimbusExperiment.objects.with_related()

--- a/experimenter/experimenter/experiments/tests/api/v6/test_views.py
+++ b/experimenter/experimenter/experiments/tests/api/v6/test_views.py
@@ -74,6 +74,82 @@ class TestNimbusExperimentViewSet(TestCase):
         self.assertEqual(json_data[0]["slug"], first_run_experiment.slug)
 
 
+class TestNimbusExperimentDraftViewSet(TestCase):
+    maxDiff = None
+
+    def test_detail_view_serializes_draft_experiments(self):
+        draft_slugs = []
+        non_draft_slugs = []
+
+        for lifecycle in NimbusExperimentFactory.Lifecycles:
+            experiment = NimbusExperimentFactory.create_with_lifecycle(
+                lifecycle,
+                slug=lifecycle.name,
+            )
+
+            if experiment.status == NimbusExperiment.Status.DRAFT:
+                draft_slugs.append(experiment.slug)
+            else:
+                non_draft_slugs.append(experiment.slug)
+
+        for slug in draft_slugs:
+            response = self.client.get(
+                reverse("nimbus-experiment-draft-rest-detail", kwargs={"slug": slug})
+            )
+            self.assertEqual(response.status_code, 200)
+
+        for slug in non_draft_slugs:
+            response = self.client.get(
+                reverse("nimbus-experiment-draft-rest-detail", kwargs={"slug": slug})
+            )
+            self.assertEqual(response.status_code, 404)
+
+    def test_list_view_serializes_draft_experiments(self):
+        expected_slugs = []
+
+        for lifecycle in NimbusExperimentFactory.Lifecycles:
+            experiment = NimbusExperimentFactory.create_with_lifecycle(
+                lifecycle,
+                slug=lifecycle.name,
+            )
+
+            if experiment.status == NimbusExperiment.Status.DRAFT:
+                expected_slugs.append(experiment.slug)
+
+        response = self.client.get(reverse("nimbus-experiment-draft-rest-list"))
+        self.assertEqual(response.status_code, 200)
+
+        json_data = json.loads(response.content)
+        slugs = [recipe["slug"] for recipe in json_data]
+        self.assertEqual(set(slugs), set(expected_slugs))
+
+    def test_list_view_filter_localized(self):
+        NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED, slug="experiment"
+        )
+
+        NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            slug="localized_experiment",
+            is_localized=True,
+            localizations=json.dumps(
+                {
+                    "en-US": {},
+                    "en-CA": {},
+                }
+            ),
+        )
+
+        response = self.client.get(
+            f"{reverse('nimbus-experiment-draft-rest-list')}?is_localized=1"
+        )
+        self.assertEqual(response.status_code, 200)
+
+        json_data = json.loads(response.content)
+        slugs = [recipe["slug"] for recipe in json_data]
+        self.assertEqual(slugs, ["localized_experiment"])
+
+
 class TestNimbusExperimentFirstRunViewSet(TestCase):
     maxDiff = None
 

--- a/experimenter/experimenter/settings.py
+++ b/experimenter/experimenter/settings.py
@@ -180,6 +180,8 @@ OPENIDC_AUTH_WHITELIST = (
     "nimbus-experiment-rest-list",
     "nimbus-experiment-rest-detail",
     "nimbus-experiment-rest-first-run-list",
+    "nimbus-experiment-draft-rest-list",
+    "nimbus-experiment-draft-rest-detail",
 )
 
 # Internationalization
@@ -243,7 +245,11 @@ LOGGING = {
             "level": "DEBUG",
             "propagate": False,
         },
-        "django.request": {"handlers": ["console"], "level": "DEBUG", "propagate": False},
+        "django.request": {
+            "handlers": ["console"],
+            "level": "DEBUG",
+            "propagate": False,
+        },
     },
     "root": {"handlers": ["console"], "level": "DEBUG"},
 }
@@ -419,7 +425,8 @@ NORMANDY_DEVTOOLS_RECIPE_IMPORT_URL = "{root}{import_url}".format(
 
 # Jira URL
 JIRA_URL = config(
-    "JIRA_URL", default="https://moz-pi-test.atlassian.net/servicedesk/customer/portal/9"
+    "JIRA_URL",
+    default="https://moz-pi-test.atlassian.net/servicedesk/customer/portal/9",
 )
 
 


### PR DESCRIPTION
Because

- we need to expose draft experiments for several reasons (generating previews for jetstream, integration with automation for localized experiments, ...)

this commit

- adds a new API endpoint to return draft experiments, optionally filtered by the `is_localized` field.