### PR TITLE
fix #8792 chore(nimbus): add wait to review buttons in tests

### DIFF
--- a/experimenter/tests/integration/nimbus/kinto/client.py
+++ b/experimenter/tests/integration/nimbus/kinto/client.py
@@ -14,6 +14,8 @@ KINTO_SIGN_STATUS = "to-sign"
 
 
 class KintoClient:
+    RETRIES = 60
+
     def __init__(self, collection):
         self.collection = collection
         self.kinto_http_client = kinto_http.Client(
@@ -30,7 +32,7 @@ class KintoClient:
         return self._fetch_collection_data()["status"] == KINTO_REVIEW_STATUS
 
     def approve(self):
-        for _ in range(60):
+        for _ in range(self.RETRIES):
             if self._has_pending_review():
                 try:
                     self.kinto_http_client.patch_collection(
@@ -48,7 +50,7 @@ class KintoClient:
         raise Exception("Unable to approve kinto review")
 
     def reject(self):
-        for _ in range(20):
+        for _ in range(self.RETRIES):
             if self._has_pending_review():
                 self.kinto_http_client.patch_collection(
                     id=self.collection,

--- a/experimenter/tests/integration/nimbus/pages/experimenter/summary.py
+++ b/experimenter/tests/integration/nimbus/pages/experimenter/summary.py
@@ -6,6 +6,7 @@ from selenium.webdriver.common.by import By
 from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.support import expected_conditions as EC
 
+from nimbus.pages.base import Base
 from nimbus.pages.experimenter.base import ExperimenterBase
 
 
@@ -108,7 +109,6 @@ class SummaryPage(ExperimenterBase):
         )
 
     def wait_for_rejected_alert(self):
-        self.wait.until(EC.presence_of_element_located(self._rejected_text_alert_locator))
         self.wait_with_refresh(
             self._rejected_text_alert_locator,
             "Summary Page: Unable to find rejected alert",
@@ -210,19 +210,20 @@ class SummaryPage(ExperimenterBase):
     def timeout_text(self):
         return self.selenium.wait_for_and_find_element(*self._timeout_alert_locator)
 
-    class RequestReview(Region):
+    class RequestReview(Region, Base):
+        PAGE_TITLE = "Review Region"
         _root_locator = (By.CSS_SELECTOR, "#request-launch-alert")
         _checkbox0_locator = (By.CSS_SELECTOR, "#checkbox-0")
         _checkbox1_locator = (By.CSS_SELECTOR, "#checkbox-1")
         _request_launch_locator = (By.CSS_SELECTOR, "#request-launch-button")
 
         def click_launch_checkboxes(self):
-            self.find_element(*self._checkbox0_locator).click()
-            self.find_element(*self._checkbox1_locator).click()
+            self.wait_for_and_find_element(*self._checkbox0_locator).click()
+            self.wait_for_and_find_element(*self._checkbox1_locator).click()
 
         @property
         def request_launch_button(self):
-            return self.find_element(*self._request_launch_locator)
+            return self.wait_for_and_find_element(*self._request_launch_locator)
 
     def archive(self):
         self.wait_for_and_find_element(*self._archive_button_locator).click()
@@ -301,6 +302,12 @@ class SummaryPage(ExperimenterBase):
     @property
     def takeaways_summary_text(self):
         return self.wait_for_and_find_element(*self._takeaways_summary_text).text
+
+    def set_takeaways(self, takeaways, recommendation):
+        self.takeaways_edit_button.click()
+        self.takeaways_summary_field = takeaways
+        self.takeaways_recommendation_radio_button(recommendation).click()
+        self.takeaways_save_button.click()
 
     @property
     def branch_screenshot_description(self):

--- a/experimenter/tests/integration/nimbus/test_remote_settings.py
+++ b/experimenter/tests/integration/nimbus/test_remote_settings.py
@@ -12,12 +12,17 @@ def test_create_new_experiment_approve_remote_settings(
     experiment_url,
     create_experiment,
     kinto_client,
+    base_url,
+    experiment_name,
 ):
     create_experiment(selenium, is_rollout=False).launch_and_approve()
 
     kinto_client.approve()
 
     SummaryPage(selenium, experiment_url).open().wait_for_live_status()
+
+    home = HomePage(selenium, base_url).open()
+    assert True in [experiment_name in item.text for item in home.tables[0].experiments]
 
 
 @pytest.mark.remote_settings
@@ -26,12 +31,17 @@ def test_create_new_rollout_approve_remote_settings(
     experiment_url,
     create_experiment,
     kinto_client,
+    base_url,
+    experiment_name,
 ):
     create_experiment(selenium, is_rollout=True).launch_and_approve()
 
     kinto_client.approve()
 
     SummaryPage(selenium, experiment_url).open().wait_for_live_status()
+
+    home = HomePage(selenium, base_url).open()
+    assert True in [experiment_name in item.text for item in home.tables[0].experiments]
 
 
 @pytest.mark.remote_settings
@@ -63,7 +73,7 @@ def test_create_new_rollout_reject_remote_settings(
 
 
 @pytest.mark.remote_settings
-def test_end_experiment_and_approve_end(
+def test_end_experiment_and_approve_end_set_takeaways(
     selenium,
     experiment_url,
     create_experiment,
@@ -79,11 +89,18 @@ def test_end_experiment_and_approve_end(
 
     kinto_client.approve()
 
-    SummaryPage(selenium, experiment_url).open().wait_for_complete_status()
+    summary = SummaryPage(selenium, experiment_url).open()
+    summary.wait_for_complete_status()
+
+    takeaways = "Example takeaways summary text"
+    summary.set_takeaways(takeaways, "CHANGE_COURSE")
+
+    assert summary.takeaways_summary_text == takeaways
+    assert summary.takeaways_recommendation_badge_text == "Change course"
 
 
 @pytest.mark.remote_settings
-def test_end_rollout_and_approve_end(
+def test_end_rollout_and_approve_end_set_takeaways(
     selenium,
     experiment_url,
     create_experiment,
@@ -99,7 +116,14 @@ def test_end_rollout_and_approve_end(
 
     kinto_client.approve()
 
-    SummaryPage(selenium, experiment_url).open().wait_for_complete_status()
+    summary = SummaryPage(selenium, experiment_url).open()
+    summary.wait_for_complete_status()
+
+    takeaways = "Example takeaways summary text"
+    summary.set_takeaways(takeaways, "CHANGE_COURSE")
+
+    assert summary.takeaways_summary_text == takeaways
+    assert summary.takeaways_recommendation_badge_text == "Change course"
 
 
 @pytest.mark.remote_settings
@@ -140,68 +164,6 @@ def test_end_rollout_and_reject_end(
     kinto_client.reject()
 
     SummaryPage(selenium, experiment_url).open().wait_for_rejected_alert()
-
-
-@pytest.mark.remote_settings
-@pytest.mark.xdist_group(name="group2")
-def test_takeaways(
-    selenium,
-    experiment_url,
-    create_experiment,
-    kinto_client,
-):
-    create_experiment(selenium).launch_and_approve()
-
-    kinto_client.approve()
-
-    summary = SummaryPage(selenium, experiment_url).open()
-    summary.wait_for_live_status()
-    summary.end_and_approve()
-
-    kinto_client.approve()
-
-    summary = SummaryPage(selenium, experiment_url).open()
-    summary.wait_for_complete_status()
-
-    expected_summary = "Example takeaways summary text"
-    summary.takeaways_edit_button.click()
-    summary.takeaways_summary_field = expected_summary
-    summary.takeaways_recommendation_radio_button("CHANGE_COURSE").click()
-    summary.takeaways_save_button.click()
-
-    assert summary.takeaways_summary_text == expected_summary
-    assert summary.takeaways_recommendation_badge_text == "Change course"
-
-
-@pytest.mark.remote_settings
-@pytest.mark.xdist_group(name="group2")
-def test_experiment_live_status_on_home_page(
-    selenium, base_url, create_experiment, kinto_client, experiment_name, slugify
-):
-    experiment_slug = str(slugify(experiment_name))
-
-    summary = create_experiment(selenium)
-    summary.launch_and_approve()
-    kinto_client.approve()
-    summary = SummaryPage(selenium, urljoin(base_url, experiment_slug)).open()
-    summary.wait_for_live_status()
-    home = HomePage(selenium, base_url).open()
-    assert True in [experiment_name in item.text for item in home.tables[0].experiments]
-
-
-@pytest.mark.remote_settings
-@pytest.mark.xdist_group(name="group2")
-def test_rollout_live_status_on_home_page(
-    selenium, base_url, create_experiment, kinto_client, experiment_name, slugify
-):
-    experiment_slug = str(slugify(experiment_name))
-
-    create_experiment(selenium, is_rollout=True).launch_and_approve()
-    kinto_client.approve()
-    summary = SummaryPage(selenium, urljoin(base_url, experiment_slug)).open()
-    summary.wait_for_live_status()
-    home = HomePage(selenium, base_url).open()
-    assert True in [experiment_name in item.text for item in home.tables[0].experiments]
 
 
 @pytest.mark.remote_settings
@@ -260,31 +222,6 @@ def test_rollout_live_update_approve_and_reject(
     kinto_client.reject()
 
     summary_page.wait_for_rejection_notice_visible()
-
-
-@pytest.mark.remote_settings
-def test_rollout_create_and_update(
-    selenium,
-    base_url,
-    create_experiment,
-    kinto_client,
-    experiment_name,
-    slugify,
-):
-    experiment_slug = str(slugify(experiment_name))
-    create_experiment(selenium, is_rollout=True).launch_and_approve()
-
-    kinto_client.approve()
-    summary = SummaryPage(selenium, urljoin(base_url, experiment_slug)).open()
-
-    summary.wait_for_live_status()
-    audience = summary.navigate_to_audience()
-
-    audience.percentage = "60"
-    audience.save_and_continue()
-
-    summary_page = SummaryPage(selenium, urljoin(base_url, experiment_slug)).open()
-    summary_page.wait_for_update_request_visible()
 
 
 @pytest.mark.remote_settings


### PR DESCRIPTION
Because

* We've been seeing some intermittent integration test failures in the remote settings tests
* The tests were attempting to click the review buttons without waiting for them to be rendered

This commit

* Adds waits to the review clicks
* Increase kinto retries
* Folds overlapping tests together to reduce test run time