### PR TITLE
Fixes #8721 refactor(nimbus): Change proposed_release_date to string

### DIFF
--- a/experimenter/experimenter/experiments/api/v5/inputs.py
+++ b/experimenter/experimenter/experiments/api/v5/inputs.py
@@ -69,7 +69,7 @@ class ExperimentInput(graphene.InputObjectType):
     projects = graphene.List(graphene.String)
     proposed_duration = graphene.String()
     proposed_enrollment = graphene.String()
-    proposed_release_date = graphene.DateTime()
+    proposed_release_date = graphene.String()
     public_description = graphene.String()
     publish_status = NimbusExperimentPublishStatusEnum()
     reference_branch = graphene.Field(BranchInput)

--- a/experimenter/experimenter/experiments/api/v5/types.py
+++ b/experimenter/experimenter/experiments/api/v5/types.py
@@ -467,7 +467,7 @@ class NimbusExperimentType(DjangoObjectType):
     prevent_pref_conflicts = graphene.Boolean()
     primary_outcomes = graphene.List(graphene.String)
     projects = graphene.List(NimbusProjectType)
-    proposed_release_date = graphene.DateTime()
+    proposed_release_date = graphene.String()
     public_description = graphene.String()
     publish_status = NimbusExperimentPublishStatusEnum()
     ready_for_review = graphene.Field(NimbusReviewType)

--- a/experimenter/experimenter/experiments/tests/api/v5/test_queries.py
+++ b/experimenter/experimenter/experiments/tests/api/v5/test_queries.py
@@ -740,6 +740,7 @@ class TestNimbusExperimentBySlugQuery(GraphQLTestCase):
                     totalEnrolledClients
                     proposedEnrollment
                     proposedDuration
+                    proposedReleaseDate
 
                     readyForReview {
                         ready
@@ -909,6 +910,7 @@ class TestNimbusExperimentBySlugQuery(GraphQLTestCase):
                 "projects": [{"id": str(project.id), "name": project.name}],
                 "proposedDuration": experiment.proposed_duration,
                 "proposedEnrollment": experiment.proposed_enrollment,
+                "proposedReleaseDate": experiment.proposed_release_date,
                 "publicDescription": experiment.public_description,
                 "publishStatus": NimbusExperiment.PublishStatus(
                     experiment.publish_status

--- a/experimenter/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_experiment_serializer.py
+++ b/experimenter/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_experiment_serializer.py
@@ -1,3 +1,4 @@
+import datetime
 from decimal import Decimal
 
 import mock
@@ -152,6 +153,7 @@ class TestNimbusExperimentSerializer(TestCase):
             "population_percent": "0.0",
             "proposed_duration": 0,
             "proposed_enrollment": 0,
+            "proposed_release_date": None,
             "targeting_config_slug": NimbusExperiment.TargetingConfig.NO_TARGETING,
             "total_enrolled_clients": 0,
             "changelog_message": "test changelog message",
@@ -185,6 +187,7 @@ class TestNimbusExperimentSerializer(TestCase):
         self.assertEqual(experiment.population_percent, 0.0)
         self.assertEqual(experiment.proposed_duration, 0)
         self.assertEqual(experiment.proposed_enrollment, 0)
+        self.assertEqual(experiment.proposed_release_date, None)
         self.assertEqual(
             experiment.targeting_config_slug,
             NimbusExperiment.TargetingConfig.NO_TARGETING,
@@ -457,6 +460,7 @@ class TestNimbusExperimentSerializer(TestCase):
             population_percent=0.0,
             proposed_duration=0,
             proposed_enrollment=0,
+            proposed_release_date=None,
             targeting_config_slug=NimbusExperiment.TargetingConfig.NO_TARGETING,
             total_enrolled_clients=0,
             is_sticky=False,
@@ -469,6 +473,7 @@ class TestNimbusExperimentSerializer(TestCase):
                 "population_percent": 10,
                 "proposed_duration": 120,
                 "proposed_enrollment": 42,
+                "proposed_release_date": "2023-12-12",
                 "targeting_config_slug": (TargetingConstants.TargetingConfig.FIRST_RUN),
                 "total_enrolled_clients": 100,
                 "changelog_message": "test changelog message",
@@ -491,6 +496,7 @@ class TestNimbusExperimentSerializer(TestCase):
         self.assertEqual(experiment.population_percent, 10)
         self.assertEqual(experiment.proposed_duration, 120)
         self.assertEqual(experiment.proposed_enrollment, 42)
+        self.assertEqual(experiment.proposed_release_date, datetime.date(2023, 12, 12))
         self.assertEqual(
             experiment.targeting_config_slug,
             TargetingConstants.TargetingConfig.FIRST_RUN,

--- a/experimenter/experimenter/nimbus-ui/schema.graphql
+++ b/experimenter/experimenter/nimbus-ui/schema.graphql
@@ -50,7 +50,7 @@ type NimbusExperimentType {
   takeawaysSummary: String
   isFirstRun: Boolean!
   preventPrefConflicts: Boolean
-  proposedReleaseDate: DateTime
+  proposedReleaseDate: String
   isLocalized: Boolean
   localizations: String
   documentationLinks: [NimbusDocumentationLinkType!]
@@ -323,13 +323,6 @@ enum NimbusExperimentConclusionRecommendationEnum {
   FOLLOWUP
 }
 
-"""
-The `DateTime` scalar type represents a DateTime
-value as specified by
-[iso8601](https://en.wikipedia.org/wiki/ISO_8601).
-"""
-scalar DateTime
-
 type NimbusDocumentationLinkType {
   title: NimbusExperimentDocumentationLinkEnum
   link: String!
@@ -351,6 +344,13 @@ type NimbusChangeLogType {
   message: String
   experimentData: JSONString
 }
+
+"""
+The `DateTime` scalar type represents a DateTime
+value as specified by
+[iso8601](https://en.wikipedia.org/wiki/ISO_8601).
+"""
+scalar DateTime
 
 """
 Allows use of a JSON String for input / output from the GraphQL schema.
@@ -481,7 +481,7 @@ input ExperimentInput {
   projects: [String]
   proposedDuration: String
   proposedEnrollment: String
-  proposedReleaseDate: DateTime
+  proposedReleaseDate: String
   publicDescription: String
   publishStatus: NimbusExperimentPublishStatusEnum
   referenceBranch: BranchInput = null

--- a/experimenter/experimenter/nimbus-ui/src/types/getAllExperiments.ts
+++ b/experimenter/experimenter/nimbus-ui/src/types/getAllExperiments.ts
@@ -62,7 +62,7 @@ export interface getAllExperiments_experiments {
   isEnrollmentPaused: boolean | null;
   proposedDuration: number;
   proposedEnrollment: number;
-  proposedReleaseDate: DateTime | null;
+  proposedReleaseDate: string | null;
   computedEndDate: DateTime | null;
   computedEnrollmentEndDate: DateTime | null;
   status: NimbusExperimentStatusEnum | null;

--- a/experimenter/experimenter/nimbus-ui/src/types/getExperiment.ts
+++ b/experimenter/experimenter/nimbus-ui/src/types/getExperiment.ts
@@ -179,7 +179,7 @@ export interface getExperiment_experimentBySlug {
   totalEnrolledClients: number;
   proposedEnrollment: number;
   proposedDuration: number;
-  proposedReleaseDate: DateTime | null;
+  proposedReleaseDate: string | null;
   readyForReview: getExperiment_experimentBySlug_readyForReview | null;
   startDate: DateTime | null;
   computedDurationDays: number | null;

--- a/experimenter/experimenter/nimbus-ui/src/types/globalTypes.ts
+++ b/experimenter/experimenter/nimbus-ui/src/types/globalTypes.ts
@@ -243,7 +243,7 @@ export interface ExperimentInput {
   projects?: (string | null)[] | null;
   proposedDuration?: string | null;
   proposedEnrollment?: string | null;
-  proposedReleaseDate?: DateTime | null;
+  proposedReleaseDate?: string | null;
   publicDescription?: string | null;
   publishStatus?: NimbusExperimentPublishStatusEnum | null;
   referenceBranch?: BranchInput | null;


### PR DESCRIPTION
Because

- We want to keep the `proposed_release_date` as a string on the front end, and only keep it as a `Date` on the model

This commit

- Changes the `proposed_release_date` to a string