### PR TITLE
fix #8707 bug(project): check not running on main

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -537,11 +537,13 @@ workflows:
   build:
     jobs:
       - check_branch:
+          name: Check Experimenter (Branch)
           filters:
             branches:
               ignore:
                 - main
       - check_main:
+          name: Check Experimenter (Main)
           filters:
             branches:
               only: main
@@ -550,7 +552,7 @@ workflows:
             branches:
               only: main
           requires:
-            - check_main
+            - Check Experimenter (Main)
       - integration_nimbus_desktop_release_targeting:
           name: Test Desktop Targeting (Release Firefox)
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -548,6 +548,7 @@ workflows:
             branches:
               only: main
       - deploy:
+          name: Deploy Experimenter
           filters:
             branches:
               only: main

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 orbs:
   gh: circleci/github-cli@2.0
 jobs:
-  check:
+  check_branch:
     machine:
       image: ubuntu-2004:202107-02 # Ubuntu 20.04, Docker v20.10.7, Docker Compose v1.29.2
       docker_layer_caching: true
@@ -28,6 +28,27 @@ jobs:
                 echo "No changes in /experimenter directory. Skipping tests and linting."
                 circleci-agent step halt
             fi
+
+  check_main:
+    machine:
+      image: ubuntu-2004:202107-02 # Ubuntu 20.04, Docker v20.10.7, Docker Compose v1.29.2
+      docker_layer_caching: true
+    resource_class: large
+    working_directory: ~/experimenter
+    steps:
+      - run:
+          name: Docker info
+          command: docker -v
+      - run:
+          name: Docker compose info
+          command: docker-compose -v
+      - checkout
+      - run:
+          name: Run tests and linting
+          command: |
+            cp .env.sample .env
+            make check
+
 
   integration_nimbus_desktop_release_targeting:
     machine:
@@ -515,8 +536,21 @@ workflows:
 
   build:
     jobs:
-      - check:
-          name: check
+      - check_branch:
+          filters:
+            branches:
+              ignore:
+                - main
+      - check_main:
+          filters:
+            branches:
+              only: main
+      - deploy:
+          filters:
+            branches:
+              only: main
+          requires:
+            - check_main
       - integration_nimbus_desktop_release_targeting:
           name: Test Desktop Targeting (Release Firefox)
           filters:
@@ -589,11 +623,5 @@ workflows:
             branches:
               ignore:
                 - main
-      - deploy:
-          filters:
-            branches:
-              only: main
-          requires:
-            - check
       - cirrus_check:
-          name: Cirrus Check
+          name: Check Cirrus


### PR DESCRIPTION
Because

* We run make check on each branch but also on main before deploys
* This last check is to make sure that main is still in a healthy state before it is deployed
* We added path filters to prevent certain circle tasks from running depending on which files were changed
* This path filter was preventing make check from running on main

This commit

* Splits the check job into two, one for branches that includes the path check, and one for main that excludes it

