### PR TITLE
fix #8837 feat(nimbus): Do localization validation only when localized

### DIFF
--- a/experimenter/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_ready_for_review_serializer.py
+++ b/experimenter/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_ready_for_review_serializer.py
@@ -341,7 +341,6 @@ class TestNimbusReviewSerializerSingleFeature(TestCase):
     def test_valid_experiments_supporting_languages_versions(
         self, application, firefox_version
     ):
-
         experiment_1 = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.CREATED,
             application=application,
@@ -487,7 +486,6 @@ class TestNimbusReviewSerializerSingleFeature(TestCase):
     def test_valid_experiments_supporting_countries_versions_default_as_all_countries(
         self, application, firefox_version
     ):
-
         experiment_1 = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.CREATED,
             application=application,
@@ -2112,6 +2110,27 @@ class TestNimbusReviewSerializerSingleFeature(TestCase):
             serializer.errors,
             {"reference_branch": {"feature_value": [error_msg]}},
         )
+
+    def test_not_localized_with_localizations(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            application=NimbusExperiment.Application.DESKTOP,
+            is_sticky=True,
+            is_localized=False,
+            localizations="",
+        )
+
+        serializer = NimbusReviewSerializer(
+            experiment,
+            data=NimbusReviewSerializer(
+                experiment,
+                context={"user": self.user},
+            ).data,
+            context={"user", self.user},
+            partial=True,
+        )
+
+        self.assertTrue(serializer.is_valid(), serializer.errors)
 
 
 class TestNimbusReviewSerializerMultiFeature(TestCase):


### PR DESCRIPTION
Becuase:
- the localizations field is only considered in the case of localized experiments

this commit:
- only validates the localizations field for localized experiments.