### PR TITLE
fix #8844 chore(project): mozilla-nimbus-shared-2.2.0

### DIFF
--- a/experimenter/poetry.lock
+++ b/experimenter/poetry.lock
@@ -1413,14 +1413,14 @@ test = ["pytest (<5.4)", "pytest-cov"]
 
 [[package]]
 name = "mozilla-nimbus-shared"
-version = "2.1.0"
+version = "2.2.0"
 description = "Shared data and schemas for Project Nimbus"
 category = "main"
 optional = false
 python-versions = ">=3.7,<4.0"
 files = [
-    {file = "mozilla_nimbus_shared-2.1.0-py3-none-any.whl", hash = "sha256:4ded1701f3fa4503bf86f2d30d2f172a8d0e119901092a12b86fd254db8d5710"},
-    {file = "mozilla_nimbus_shared-2.1.0.tar.gz", hash = "sha256:29e2a8d55f98ece8ed7c0ed5e6d2527eada46e21ea7a84a6d364db67ffcee63a"},
+    {file = "mozilla_nimbus_shared-2.2.0-py3-none-any.whl", hash = "sha256:ea24ed49f2032f3f2420d82adf80652c092404819c036527910a3df25931ec0a"},
+    {file = "mozilla_nimbus_shared-2.2.0.tar.gz", hash = "sha256:0c44d9e245a70e92f0db6155443e1989028ddc86ba50848dfd467dd986791247"},
 ]
 
 [package.dependencies]
@@ -2780,4 +2780,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "541eac2ae3e5a3534e30858a2cc34424f1a7448ab56da2352a3a18b9ead6c6eb"
+content-hash = "fd4ca69fc107dd33de7ea662ac24b9171ce7be234ecc93e8f9ee22b3a7c0f3d5"

--- a/experimenter/pyproject.toml
+++ b/experimenter/pyproject.toml
@@ -65,7 +65,7 @@ graphene-django = "^3.0.0"
 pyright = "^1.1.291"
 django-types = "^0.17.0"
 ruff = "^0.0.239"
-mozilla-nimbus-shared = "^2.1.0"
+mozilla-nimbus-shared = "^2.2.0"
 
 [tool.poetry.dev-dependencies]
 rope = "^0.23.0"


### PR DESCRIPTION
Because
    
* There's an updated nimbus shared package that includes the locales field
    
This commit
    
* Updates to mozilla-nimbus-shared-2.2.0