### PR TITLE
Fixes #8834 feat(nimbus): Compute fields based on release date or start date

### DIFF
--- a/experimenter/experimenter/experiments/models.py
+++ b/experimenter/experimenter/experiments/models.py
@@ -441,7 +441,7 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
 
     @property
     def launch_month(self):
-        if self.proposed_release_date:
+        if self.is_first_run and self.proposed_release_date:
             return self.proposed_release_date.strftime("%B")
         elif self.start_date:
             return self.start_date.strftime("%B")
@@ -465,7 +465,7 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
     @property
     def proposed_enrollment_end_date(self):
         if self.proposed_enrollment is not None:
-            if self.proposed_release_date:
+            if self.is_first_run and self.proposed_release_date:
                 return self.proposed_release_date + datetime.timedelta(
                     days=self.proposed_enrollment
                 )
@@ -475,7 +475,7 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
     @property
     def proposed_end_date(self):
         if self.proposed_duration is not None:
-            if self.proposed_release_date:
+            if self.is_first_run and self.proposed_release_date:
                 return self.proposed_release_date + datetime.timedelta(
                     days=self.proposed_duration
                 )
@@ -484,7 +484,8 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
 
     @property
     def computed_enrollment_days(self):
-        if self.proposed_release_date is not None:
+        begin_date = None
+        if self.is_first_run and self.proposed_release_date:
             begin_date = self.proposed_release_date
         elif self.start_date is not None:
             begin_date = self.start_date
@@ -511,8 +512,6 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
                 self.save()
                 if begin_date:
                     return (paused_change.changed_on.date() - begin_date).days
-                else:
-                    return (paused_change.changed_on.date() - self.start_date).days
 
         if self.end_date:
             return self.computed_duration_days
@@ -525,7 +524,7 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
         release_date = self.proposed_release_date
         computed_enrollment_days = self.computed_enrollment_days
         if computed_enrollment_days is not None:
-            if release_date is not None:
+            if self.is_first_run and release_date is not None:
                 return release_date + datetime.timedelta(days=computed_enrollment_days)
             elif start_date is not None:
                 return start_date + datetime.timedelta(days=computed_enrollment_days)
@@ -537,7 +536,7 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
     @property
     def enrollment_duration(self):
         if self.computed_end_date:
-            if self.proposed_release_date:
+            if self.is_first_run and self.proposed_release_date:
                 return (
                     self.proposed_release_date.strftime("%Y-%m-%d")
                     + " to "
@@ -555,7 +554,7 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
     @property
     def computed_duration_days(self):
         if self.computed_end_date:
-            if self.proposed_release_date:
+            if self.is_first_run and self.proposed_release_date:
                 return (self.computed_end_date - self.proposed_release_date).days
             if self.start_date:
                 return (self.computed_end_date - self.start_date).days
@@ -777,6 +776,7 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
         cloned.is_paused = False
         cloned.is_rollout_dirty = False
         cloned.reference_branch = None
+        cloned.proposed_release_date = None
         cloned.published_dto = None
         cloned.results_data = None
         cloned.takeaways_summary = None

--- a/experimenter/experimenter/experiments/tests/test_models.py
+++ b/experimenter/experimenter/experiments/tests/test_models.py
@@ -1072,7 +1072,6 @@ class TestNimbusExperiment(TestCase):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE_APPROVE,
             start_date=datetime.date.today() - datetime.timedelta(days=10),
-            proposed_release_date=None,
             proposed_enrollment=10,
         )
         self.assertTrue(experiment.should_end_enrollment)
@@ -1122,6 +1121,40 @@ class TestNimbusExperiment(TestCase):
             experiment.computed_enrollment_days,
             expected_days,
         )
+
+    def test_has_valid_release_date_for_first_run_experiment(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE_APPROVE,
+            is_first_run=True,
+            proposed_release_date=datetime.date.today(),
+        )
+
+        self.assertTrue(experiment.has_valid_release_date())
+
+    def test_has_empty_release_date_for_first_run_experiment(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE_APPROVE,
+            is_first_run=True,
+        )
+
+        self.assertFalse(experiment.has_valid_release_date())
+
+    def test_not_valid_release_date_for_non_first_run_experiment(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE_APPROVE,
+            is_first_run=False,
+            proposed_release_date=datetime.date.today(),
+        )
+
+        self.assertFalse(experiment.has_valid_release_date())
+
+    def test_not_valid_release_date_for_empty_release_date_experiment(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE_APPROVE,
+            is_first_run=False,
+        )
+
+        self.assertFalse(experiment.has_valid_release_date())
 
     def test_computed_enrollment_days_returns_fallback(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(

--- a/experimenter/experimenter/experiments/tests/test_models.py
+++ b/experimenter/experimenter/experiments/tests/test_models.py
@@ -823,15 +823,31 @@ class TestNimbusExperiment(TestCase):
         )
         self.assertIsNone(experiment.start_date)
 
+    def test_proposed_release_date_returns_None_for_not_started_experiment(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+        )
+        self.assertIsNone(experiment.proposed_release_date)
+
     def test_end_date_returns_None_for_not_ended_experiment(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.CREATED,
         )
         self.assertIsNone(experiment.end_date)
 
-    def test_launch_month_returns_month_for_started_experiment(self):
+    def test_launch_month_returns_release_date_month_for_started_experiment(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.LIVE_ENROLLING,
+            proposed_release_date=datetime.date.today() + datetime.timedelta(days=1),
+        )
+
+        assert experiment.proposed_release_date
+        self.assertEqual(experiment.launch_month, experiment.proposed_release_date.strftime("%B"))
+
+    def test_launch_month_returns_start_date_month_for_started_experiment_with_no_release_date(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.LIVE_ENROLLING,
+            proposed_release_date=None,
             start_date=datetime.date.today() + datetime.timedelta(days=1),
         )
 
@@ -917,6 +933,21 @@ class TestNimbusExperiment(TestCase):
     def test_enrollment_duration_for_ended_experiment(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.LIVE_ENROLLING,
+            proposed_release_date=datetime.date.today() + datetime.timedelta(days=1),
+        )
+
+        assert experiment.proposed_release_date
+        assert experiment.computed_end_date
+        expected_enrollment_duration = "{start} to {end}".format(
+            start=experiment.proposed_release_date.strftime("%Y-%m-%d"),
+            end=experiment.computed_end_date.strftime("%Y-%m-%d"),
+        )
+        self.assertEqual(experiment.enrollment_duration, expected_enrollment_duration)
+
+    def test_enrollment_duration_for_ended_experiment_with_no_release_date(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.LIVE_ENROLLING,
+            proposed_release_date=None,
             start_date=datetime.date.today() + datetime.timedelta(days=1),
         )
 
@@ -981,7 +1012,16 @@ class TestNimbusExperiment(TestCase):
     def test_should_end_returns_True_after_proposed_end_date(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE_APPROVE,
+            proposed_release_date=datetime.date.today() - datetime.timedelta(days=10),
+            proposed_duration=10,
+        )
+        self.assertTrue(experiment.should_end)
+
+    def test_should_end_returns_True_after_proposed_end_date_no_release_date(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE_APPROVE,
             start_date=datetime.date.today() - datetime.timedelta(days=10),
+            proposed_release_date=None,
             proposed_duration=10,
         )
         self.assertTrue(experiment.should_end)
@@ -996,10 +1036,19 @@ class TestNimbusExperiment(TestCase):
         )
         self.assertFalse(experiment.should_end_enrollment)
 
-    def test_should_end_enrollment_returns_True_after_proposed_enrollment_end_date(self):
+    def test_end_enrollment_returns_True_after_proposed_enrollment_end_date(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE_APPROVE,
+            proposed_release_date=datetime.date.today() - datetime.timedelta(days=10),
+            proposed_enrollment=10,
+        )
+        self.assertTrue(experiment.should_end_enrollment)
+
+    def test_end_enrollment_returns_True_after_proposed_enrollment_end_date_no_release_date(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE_APPROVE,
             start_date=datetime.date.today() - datetime.timedelta(days=10),
+            proposed_release_date=None,
             proposed_enrollment=10,
         )
         self.assertTrue(experiment.should_end_enrollment)
@@ -1020,12 +1069,26 @@ class TestNimbusExperiment(TestCase):
             expected_days,
         )
 
-    def test_computed_enrollment_days_uses_end_date_without_pause(self):
+    def test_computed_enrollment_days_uses_end_date_without_pause_with_start_date(self):
         expected_days = 5
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.ENDING_APPROVE_APPROVE_WITHOUT_PAUSE,
             proposed_enrollment=99,
             start_date=datetime.date.today() - datetime.timedelta(days=expected_days),
+            end_date=datetime.date.today(),
+        )
+
+        self.assertEqual(
+            experiment.computed_enrollment_days,
+            expected_days,
+        )
+
+    def test_computed_enrollment_days_uses_end_date_without_pause_with_release_date(self):
+        expected_days = 5
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.ENDING_APPROVE_APPROVE_WITHOUT_PAUSE,
+            proposed_enrollment=99,
+            proposed_release_date=datetime.date.today() - datetime.timedelta(days=expected_days),
             end_date=datetime.date.today(),
         )
 
@@ -1046,19 +1109,47 @@ class TestNimbusExperiment(TestCase):
 
     @parameterized.expand(
         [
-            (NimbusExperimentFactory.Lifecycles.PAUSING_REVIEW_REQUESTED,),
-            (NimbusExperimentFactory.Lifecycles.PAUSING_APPROVE,),
-            (NimbusExperimentFactory.Lifecycles.PAUSING_APPROVE_WAITING,),
+            (
+                NimbusExperimentFactory.Lifecycles.PAUSING_REVIEW_REQUESTED,
+                datetime.date.today() - datetime.timedelta(days=5),
+                None,
+            ),
+            (
+                NimbusExperimentFactory.Lifecycles.PAUSING_APPROVE,
+                datetime.date.today() - datetime.timedelta(days=5),
+                None,
+            ),
+            (
+                NimbusExperimentFactory.Lifecycles.PAUSING_APPROVE_WAITING,
+                datetime.date.today() - datetime.timedelta(days=5),
+                None,
+            ),
+            (
+                NimbusExperimentFactory.Lifecycles.PAUSING_REVIEW_REQUESTED,
+                datetime.date.today() - datetime.timedelta(days=5),
+                datetime.date.today() - datetime.timedelta(days=5),
+            ),
+            (
+                NimbusExperimentFactory.Lifecycles.PAUSING_APPROVE,
+                datetime.date.today(),
+                datetime.date.today() - datetime.timedelta(days=5),
+            ),
+            (
+                NimbusExperimentFactory.Lifecycles.PAUSING_APPROVE_WAITING,
+                datetime.date.today(),
+                datetime.date.today() - datetime.timedelta(days=5),
+            ),
         ]
     )
     def test_computed_enrollment_days_returns_fallback_while_pause_pending_approval(
-        self, lifecycle
+        self, lifecycle, start_date, release_date
     ):
         expected_days = 99
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             lifecycle,
-            # Set the span to 5 days, but that shouldn't apply while pending approval
-            start_date=datetime.date.today() - datetime.timedelta(days=5),
+            # Setting the span shouldn't apply while pending approval
+            start_date=start_date,
+            proposed_release_date=release_date,
             proposed_enrollment=expected_days,
         )
 
@@ -1098,12 +1189,31 @@ class TestNimbusExperiment(TestCase):
             expected_days,
         )
 
+    def test_computed_enrollment_end_date_returns_release_date_plus_enrollment_days(self):
+        release_date = datetime.date(2022, 1, 1)
+        enrollment_end_date = release_date + datetime.timedelta(days=3)
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.PAUSING_APPROVE_APPROVE,
+            proposed_release_date=release_date,
+            proposed_enrollment=7,
+        )
+
+        experiment.changes.filter(experiment_data__is_paused=True).update(
+            changed_on=enrollment_end_date
+        )
+
+        self.assertEqual(
+            experiment.computed_enrollment_end_date,
+            enrollment_end_date,
+        )
+
     def test_computed_enrollment_end_date_returns_start_date_plus_enrollment_days(self):
         start_date = datetime.date(2022, 1, 1)
         enrollment_end_date = start_date + datetime.timedelta(days=3)
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.PAUSING_APPROVE_APPROVE,
             start_date=start_date,
+            proposed_release_date=None,
             proposed_enrollment=7,
         )
 
@@ -1128,6 +1238,20 @@ class TestNimbusExperiment(TestCase):
             NimbusExperimentFactory.Lifecycles.ENDING_APPROVE_APPROVE,
             proposed_duration=10,
             start_date=datetime.date.today() - datetime.timedelta(days=7),
+            proposed_release_date=None,
+            end_date=datetime.date.today(),
+        )
+
+        self.assertEqual(
+            experiment.computed_duration_days,
+            7,
+        )
+
+    def test_computed_duration_days_returns_computed_end_date_minus_release_date(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.ENDING_APPROVE_APPROVE,
+            proposed_duration=10,
+            proposed_release_date=datetime.date.today() - datetime.timedelta(days=7),
             end_date=datetime.date.today(),
         )
 


### PR DESCRIPTION
Because

- If an experiment is first run, we might have a release date
- And the following fields on the model are calculated using start date:
   - Launch month
   - Proposed enrollment end date
   - Proposed end date
   - Computed enrollment days
   - Computed enrollment end date
   - Enrollment duration
   - Computed duration days

This commit

- Add `release_date` field, which checks if the experiment is first run (`is_first_run`) before checking if `proposed_release_date` exists
- Add `enrollment_start_date` field, which returns `proposed_release_date` if it exists on a first run experiment and `start_date` otherwise
- DOES NOT change the `start_date` calculations
- `start_date` will still be used in all calculations where the experiment is not first-run and has no proposed release date
