### PR TITLE
feat(nimbus): Enforce constraints on localization string IDs

### DIFF
--- a/experimenter/experimenter/experiments/constants.py
+++ b/experimenter/experimenter/experiments/constants.py
@@ -442,3 +442,5 @@ Optional - We believe this outcome will <describe impact> on <core metric>
 
     DEFAULT_REFERENCE_BRANCH_NAME = "Control"
     DEFAULT_TREATMENT_BRANCH_NAME = "Treatment A"
+
+    L10N_MIN_STRING_ID_LEN = 9

--- a/experimenter/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_ready_for_review_serializer.py
+++ b/experimenter/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_ready_for_review_serializer.py
@@ -1645,11 +1645,17 @@ class TestNimbusReviewSerializerSingleFeature(TestCase):
 
     def test_substitute_localizations(self):
         value = {
-            "foo": {"$l10n": {"id": "foo", "text": "foo text", "comment": "foo comment"}},
+            "foo": {
+                "$l10n": {
+                    "id": "foo-string",
+                    "text": "foo text",
+                    "comment": "foo comment",
+                }
+            },
             "bar": [
                 {
                     "$l10n": {
-                        "id": "bar",
+                        "id": "bar-string",
                         "text": "bar text",
                         "comment": "bar comment",
                     },
@@ -1659,7 +1665,7 @@ class TestNimbusReviewSerializerSingleFeature(TestCase):
             "qux": {
                 "quux": {
                     "$l10n": {
-                        "id": "quux",
+                        "id": "quux-string",
                         "text": "quux text",
                         "comment": "quux comment",
                     }
@@ -1671,9 +1677,9 @@ class TestNimbusReviewSerializerSingleFeature(TestCase):
         }
 
         substitutions = {
-            "foo": "localized foo",
-            "bar": "localized bar",
-            "quux": "localized quux",
+            "foo-string": "localized foo",
+            "bar-string": "localized bar",
+            "quux-string": "localized quux",
         }
 
         result = NimbusReviewSerializer._substitute_localizations(
@@ -1715,11 +1721,15 @@ class TestNimbusReviewSerializerSingleFeature(TestCase):
         feature_value.value = json.dumps(
             {
                 "foo": {
-                    "$l10n": {"id": "foo", "text": "foo text", "comment": "foo comment"}
+                    "$l10n": {
+                        "id": "foo-string",
+                        "text": "foo text",
+                        "comment": "foo comment",
+                    }
                 },
                 "bar": {
                     "$l10n": {
-                        "id": "bar",
+                        "id": "bar-string",
                         "text": "bar text",
                         "comment": "bar comment",
                     }
@@ -1956,11 +1966,15 @@ class TestNimbusReviewSerializerSingleFeature(TestCase):
         feature_value.value = json.dumps(
             {
                 "foo": {
-                    "$l10n": {"id": "foo", "text": "foo text", "comment": "foo comment"}
+                    "$l10n": {
+                        "id": "foo-string",
+                        "text": "foo text",
+                        "comment": "foo comment",
+                    }
                 },
                 "bar": {
                     "$l10n": {
-                        "id": "bar",
+                        "id": "bar-string",
                         "text": "bar text",
                         "comment": "bar comment",
                     }
@@ -1984,7 +1998,8 @@ class TestNimbusReviewSerializerSingleFeature(TestCase):
             serializer.errors,
             {
                 "localizations": [
-                    "Locale en-US is missing substitutions for IDs: bar, foo"
+                    "Locale en-US is missing substitutions for IDs: bar-string, "
+                    "foo-string"
                 ]
             },
         )
@@ -2001,7 +2016,7 @@ class TestNimbusReviewSerializerSingleFeature(TestCase):
             localizations=json.dumps(
                 {
                     "en-US": {
-                        "foo": "foo text",
+                        "foo-string": "foo text",
                     }
                 }
             ),
@@ -2020,7 +2035,11 @@ class TestNimbusReviewSerializerSingleFeature(TestCase):
         feature_value.value = json.dumps(
             {
                 "directMigrateSingleProfile": {
-                    "$l10n": {"id": "foo", "text": "foo text", "comment": "foo comment"}
+                    "$l10n": {
+                        "id": "foo-string",
+                        "text": "foo text",
+                        "comment": "foo comment",
+                    }
                 }
             }
         )
@@ -2060,11 +2079,20 @@ class TestNimbusReviewSerializerSingleFeature(TestCase):
             ),
             (
                 {"id": "foo"},
-                "$l10n object with id 'foo' is missing 'text'",
+                "$l10n id 'foo' must be at least 9 characters long",
             ),
             (
-                {"id": "foo", "text": "foo text"},
-                "$l10n object with id 'foo' is missing 'comment'",
+                {"id": "&&&&&&&&&"},
+                "$l10n id '&&&&&&&&&' contains invalid characters; only alphanumeric "
+                "characters and dashes are permitted",
+            ),
+            (
+                {"id": "foo-string"},
+                "$l10n object with id 'foo-string' is missing 'text'",
+            ),
+            (
+                {"id": "foo-string", "text": "foo text"},
+                "$l10n object with id 'foo-string' is missing 'comment'",
             ),
         ]
     )
@@ -2109,6 +2137,7 @@ class TestNimbusReviewSerializerSingleFeature(TestCase):
         self.assertEqual(
             serializer.errors,
             {"reference_branch": {"feature_value": [error_msg]}},
+            serializer.errors,
         )
 
     def test_not_localized_with_localizations(self):
@@ -2605,7 +2634,7 @@ class TestNimbusReviewSerializerMultiFeature(TestCase):
             {
                 "foo": {
                     "$l10n": {
-                        "id": "foo",
+                        "id": "foo-string",
                         "text": "foo text",
                         "comment": "foo comment",
                     }
@@ -2621,7 +2650,7 @@ class TestNimbusReviewSerializerMultiFeature(TestCase):
             {
                 "bar": {
                     "$l10n": {
-                        "id": "bar",
+                        "id": "bar-string",
                         "text": "bar text",
                         "comment": "bar comment",
                     }

--- a/experimenter/experimenter/experiments/tests/factories.py
+++ b/experimenter/experimenter/experiments/tests/factories.py
@@ -59,16 +59,16 @@ FAKER_JSON_SCHEMA = """\
 TEST_LOCALIZATIONS = """\
 {
     "en-US": {
-        "foo": "More en-US text",
-        "bar": "en-US text"
+        "foo-string": "More en-US text",
+        "bar-string": "en-US text"
     },
     "en-CA": {
-        "foo": "en-CA text",
-        "bar": "More en-CA text"
+        "foo-string": "en-CA text",
+        "bar-string": "More en-CA text"
     },
     "fr": {
-        "foo": "fr text",
-        "bar": "More fr text"
+        "foo-string": "fr text",
+        "bar-string": "More fr text"
     }
 }
 """
@@ -450,18 +450,14 @@ class NimbusExperimentFactory(factory.django.DjangoModelFactory):
 
     @factory.post_generation
     def languages(self, create, extracted, **kwargs):
-
         if not create:
-
             # Simple build, do nothing.
             return
 
         if extracted is None and Language.objects.exists():
-
             extracted = Language.objects.all()[:3]
 
         if extracted:
-
             self.languages.add(*extracted)
 
     @classmethod


### PR DESCRIPTION
Because:
- we want users to write usable, informative string IDs in their
  experiments

this commit:
- adds validation logic that requires l10n string IDs are at least 9
  characters long and only contain alphanumeric characters and hyphens.