### PR TITLE
Add vpn spotlight targeting

### DIFF
--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -191,17 +191,17 @@ FIRST_RUN_NEW_PROFILE_WINDOWS_1903_EXCLUDE_RTAMO = NimbusTargetingConfig(
         "with a new profile, needing default w/ pin, excluding RTAMO"
     ),
     targeting=(
-        "{first_run} && {has_pin} && attributionData.source !== 'addons.mozilla.org'"
-        .format(
+        "{first_run} && {has_pin} && {attribution}".format(
             first_run=FIRST_RUN_NEW_PROFILE_NEED_DEFAULT_WINDOWS_1903.targeting,
             has_pin=HAS_PIN,
+            attribution="attributionData.source != 'addons.mozilla.org'",
         )
     ),
     desktop_telemetry=(
-        "{first_run} AND {has_pin} AND attributionData.source !== 'addons.mozilla.org'"
-        .format(
+        "{first_run} AND {has_pin} AND {attribution}".format(
             first_run=FIRST_RUN_NEW_PROFILE_NEED_DEFAULT_WINDOWS_1903.desktop_telemetry,
             has_pin=HAS_PIN,
+            attribution="attributionData.source != 'addons.mozilla.org'",
         )
     ),
     sticky_required=True,

--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -191,17 +191,17 @@ FIRST_RUN_NEW_PROFILE_WINDOWS_1903_EXCLUDE_RTAMO = NimbusTargetingConfig(
         "with a new profile, needing default w/ pin, excluding RTAMO"
     ),
     targeting=(
-        "{first_run} && {has_pin} && {exclude_rtamo}".format(
+        "{first_run} && {has_pin} && attributionData.source !== 'addons.mozilla.org'"
+        .format(
             first_run=FIRST_RUN_NEW_PROFILE_NEED_DEFAULT_WINDOWS_1903.targeting,
             has_pin=HAS_PIN,
-            exclude_rtamo="attributionData.source !== ‘addons.mozilla.org’",
         )
     ),
     desktop_telemetry=(
-        "{first_run} AND {has_pin} AND {exclude_rtamo}".format(
+        "{first_run} AND {has_pin} AND attributionData.source !== 'addons.mozilla.org'"
+        .format(
             first_run=FIRST_RUN_NEW_PROFILE_NEED_DEFAULT_WINDOWS_1903.desktop_telemetry,
             has_pin=HAS_PIN,
-            exclude_rtamo="attributionData.source !== ‘addons.mozilla.org’",
         )
     ),
     sticky_required=True,
@@ -1118,8 +1118,7 @@ class TargetingConstants:
     TARGETING_CHANNEL = 'browserSettings.update.channel == "{channel}"'
 
     TARGETING_CONFIGS = {
-        targeting.slug: targeting
-        for targeting in NimbusTargetingConfig.targeting_configs
+        targeting.slug: targeting for targeting in NimbusTargetingConfig.targeting_configs
     }
 
     TargetingConfig = models.TextChoices(

--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -421,6 +421,23 @@ NO_ENTERPRISE_OR_PAST_VPN = NimbusTargetingConfig(
     application_choice_names=(Application.DESKTOP.name,),
 )
 
+EXISTING_WINDOWS_USER_NO_ENTERPRISE_OR_PAST_VPN = NimbusTargetingConfig(
+    name="Existing users, with no enterprise or past VPN use, on Windows 10+",
+    slug="existing_windows_user_no_enterprise_or_past_vpn",
+    description="Exclude users who have used Mozilla VPN or who are enterprise users",
+    targeting=(
+        f"{NO_ENTERPRISE.targeting} && "
+        f"{PROFILE28DAYS} && "
+        "os.windowsBuildNumber >= 18362 && "
+        "userMonthlyActivity|length >= 1 && "
+        '!("e6eb0d1e856335fc" in attachedFxAOAuthClients|mapToProperty("id"))'
+    ),
+    desktop_telemetry="",
+    sticky_required=False,
+    is_first_run_required=False,
+    application_choice_names=(Application.DESKTOP.name,),
+)
+
 NO_ENTERPRISE_OR_RECENT_VPN = NimbusTargetingConfig(
     name="No enterprise and no VPN connection in the last 30 days",
     slug="no_enterprise_or_last_30d_vpn_use",

--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -180,26 +180,28 @@ FIRST_RUN_NEW_PROFILE_HAS_PIN_NEED_DEFAULT_WINDOWS_1903 = NimbusTargetingConfig(
     application_choice_names=(Application.DESKTOP.name,),
 )
 
-FIRST_RUN_NEW_PROFILE_HAS_PIN_NEED_DEFAULT_WINDOWS_1903_EXCLUDE_RTAMO = NimbusTargetingConfig(
+FIRST_RUN_NEW_PROFILE_WINDOWS_1903_EXCLUDE_RTAMO = NimbusTargetingConfig(
     name=(
         "First start-up users on Windows 10 1903 (build 18362) or newer, with a "
         "new profile, needing default w/ pin, excluding users coming from RTAMO"
     ),
-    slug="first_run_new_profile_need_default_has_pin_exclude_rtamo",
+    slug="first_run_new_profile_exclude_rtamo",
     description=(
         "First start-up users (e.g. for about:welcome) on Windows 1903+, "
         "with a new profile, needing default w/ pin, excluding RTAMO"
     ),
     targeting=(
-        "{first_run} && {has_pin} && attributionData.source !== ‘addons.mozilla.org’".format(
+        "{first_run} && {has_pin} && {exclude_rtamo}".format(
             first_run=FIRST_RUN_NEW_PROFILE_NEED_DEFAULT_WINDOWS_1903.targeting,
             has_pin=HAS_PIN,
+            exclude_rtamo="attributionData.source !== ‘addons.mozilla.org’",
         )
     ),
     desktop_telemetry=(
-        "{first_run} AND {has_pin} AND attributionData.source !== ‘addons.mozilla.org’".format(
+        "{first_run} AND {has_pin} AND {exclude_rtamo}".format(
             first_run=FIRST_RUN_NEW_PROFILE_NEED_DEFAULT_WINDOWS_1903.desktop_telemetry,
             has_pin=HAS_PIN,
+            exclude_rtamo="attributionData.source !== ‘addons.mozilla.org’",
         )
     ),
     sticky_required=True,

--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -180,6 +180,33 @@ FIRST_RUN_NEW_PROFILE_HAS_PIN_NEED_DEFAULT_WINDOWS_1903 = NimbusTargetingConfig(
     application_choice_names=(Application.DESKTOP.name,),
 )
 
+FIRST_RUN_NEW_PROFILE_HAS_PIN_NEED_DEFAULT_WINDOWS_1903_EXCLUDE_RTAMO = NimbusTargetingConfig(
+    name=(
+        "First start-up users on Windows 10 1903 (build 18362) or newer, with a "
+        "new profile, needing default w/ pin, excluding users coming from RTAMO"
+    ),
+    slug="first_run_new_profile_need_default_has_pin_exclude_rtamo",
+    description=(
+        "First start-up users (e.g. for about:welcome) on Windows 1903+, "
+        "with a new profile, needing default w/ pin, excluding RTAMO"
+    ),
+    targeting=(
+        "{first_run} && {has_pin} && attributionData.source !== ‘addons.mozilla.org’".format(
+            first_run=FIRST_RUN_NEW_PROFILE_NEED_DEFAULT_WINDOWS_1903.targeting,
+            has_pin=HAS_PIN,
+        )
+    ),
+    desktop_telemetry=(
+        "{first_run} AND {has_pin} AND attributionData.source !== ‘addons.mozilla.org’".format(
+            first_run=FIRST_RUN_NEW_PROFILE_NEED_DEFAULT_WINDOWS_1903.desktop_telemetry,
+            has_pin=HAS_PIN,
+        )
+    ),
+    sticky_required=True,
+    is_first_run_required=False,
+    application_choice_names=(Application.DESKTOP.name,),
+)
+
 NOT_TCP_STUDY = NimbusTargetingConfig(
     name="Exclude users in the TCP revenue study",
     slug="not_tcp_study",
@@ -1089,7 +1116,8 @@ class TargetingConstants:
     TARGETING_CHANNEL = 'browserSettings.update.channel == "{channel}"'
 
     TARGETING_CONFIGS = {
-        targeting.slug: targeting for targeting in NimbusTargetingConfig.targeting_configs
+        targeting.slug: targeting
+        for targeting in NimbusTargetingConfig.targeting_configs
     }
 
     TargetingConfig = models.TextChoices(


### PR DESCRIPTION
Targeting to support https://mozilla-hub.atlassian.net/browse/OMC-419 - Existing users with a profile >28 days old, at least 1 day of use in the last 28 days, on Windows 10+, no VPN or Enterprise policy

(See design doc [here](https://docs.google.com/document/d/1isGOuvjrEB_s4koaDJOl-WCt1Gk00KCMNV8tfUYSvFY/edit?disco=AAAAuipv6tQ) for targeting criteria)