### PR TITLE
Add targeting for VPN spotlight experiment

### DIFF
--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -468,6 +468,23 @@ NO_ENTERPRISE_OR_PAST_VPN = NimbusTargetingConfig(
     application_choice_names=(Application.DESKTOP.name,),
 )
 
+EXISTING_WINDOWS_USER_NO_ENTERPRISE_OR_PAST_VPN = NimbusTargetingConfig(
+    name="Existing users, with no enterprise or past VPN use, on Windows 10+",
+    slug="existing_windows_user_no_enterprise_or_past_vpn",
+    description="Exclude users who have used Mozilla VPN or who are enterprise users",
+    targeting=(
+        f"{NO_ENTERPRISE.targeting} && "
+        f"{PROFILE28DAYS} && "
+        "os.windowsBuildNumber >= 18362 && "
+        "userMonthlyActivity|length >= 1 && "
+        "!('e6eb0d1e856335fc' in attachedFxAOAuthClients|mapToProperty('id'))"
+    ),
+    desktop_telemetry="",
+    sticky_required=False,
+    is_first_run_required=False,
+    application_choice_names=(Application.DESKTOP.name,),
+)
+
 NO_ENTERPRISE_OR_RECENT_VPN = NimbusTargetingConfig(
     name="No enterprise and no VPN connection in the last 30 days",
     slug="no_enterprise_or_last_30d_vpn_use",


### PR DESCRIPTION
Adding targeting to support https://mozilla-hub.atlassian.net/browse/OMC-419: Existing users >28 days old, at least 1 day of use in the past 28 days, on Windows 10+, no Enterprise policy or VPN use.

See design doc [here](https://docs.google.com/document/d/1isGOuvjrEB_s4koaDJOl-WCt1Gk00KCMNV8tfUYSvFY/edit?disco=AAAAuipv6tQ) for detailed targeting criteria)
