### PR TITLE
Fixes #8858 fix(nimbus) tests(nimbus): Do not set isEnrollmentPaused when canceling end experiment

### DIFF
--- a/experimenter/experimenter/nimbus-ui/src/components/Summary/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/Summary/index.tsx
@@ -67,7 +67,10 @@ const Summary = ({ experiment, refetch }: SummaryProps) => {
         experiment.status === NimbusExperimentStatusEnum.LIVE
           ? NimbusExperimentStatusEnum.LIVE
           : null,
-      isEnrollmentPaused: false,
+      isEnrollmentPaused:
+        experiment.statusNext === NimbusExperimentStatusEnum.COMPLETE
+          ? experiment.isEnrollmentPaused
+          : false,
     },
     {
       publishStatus: NimbusExperimentPublishStatusEnum.REVIEW,


### PR DESCRIPTION
Because

- We are using `onConfirmCancelReviewClicked` for canceling end experiment, end enrollment, and live updates
- And we were setting `isEnrollmentPaused: false` regardless of the cancellation reason (end experiment, enrollment, or update)

This commit

- Removed setting `isEnrollmentPaused` for all cancel scenarios. The value should stay the same for the following scenarios:
   - Live experiment/rollout - click end enrollment - cancel end enrollment:
      - `isEnrollmentPaused: false` -> `false`
   - Live experiment/rollout with ended enrollment - click end experiment - cancel end experiment:
      - `isEnrollmentPaused: true` -> `true`
   - Live experiment/rollout - click end experiment - cancel end experiment:
      - `isEnrollmentPaused: false` -> `false`
   - Live rollout with dirty changes - click update - cancel update:
      - `isEnrollmentPaused: false` -> `false`
   - Live rollout with dirty changes and ended enrollment - click update - cancel update:
      - `isEnrollmentPaused: true` -> `true`

----

1. Launch experiment
2. End enrollment `isEnrollmentPaused: true` & approve
3. Click "End experiment"
4. Click "Cancel"
5. See `isEnrollmentPaused: true`:
<img width="1494" alt="image" src="https://github.com/mozilla/experimenter/assets/43795363/1cf5abfe-33d5-48cc-a7eb-10cbcb3212bb">
