### PR TITLE
For #8882 feat(nimbus): Add serializer warning for proposed release date

### DIFF
--- a/experimenter/experimenter/experiments/api/v5/serializers.py
+++ b/experimenter/experimenter/experiments/api/v5/serializers.py
@@ -1747,6 +1747,19 @@ class NimbusReviewSerializer(serializers.ModelSerializer):
 
         return subbed
 
+    def _validate_proposed_release_date(self, data):
+        release_date = data.get("proposed_release_date")
+        first_run = data.get("is_first_run")
+
+        if not self.instance or not release_date:
+            return data
+
+        if not first_run and release_date is not None:
+            self.warnings["proposed_release_date"] = [
+                NimbusExperiment.ERROR_FIRST_RUN_RELEASE_DATE
+            ]
+        return data
+
     def validate(self, data):
         application = data.get("application")
         channel = data.get("channel")
@@ -1762,6 +1775,7 @@ class NimbusReviewSerializer(serializers.ModelSerializer):
         data = self._validate_sticky_enrollment(data)
         data = self._validate_rollout_version_support(data)
         data = self._validate_bucket_duplicates(data)
+        data = self._validate_proposed_release_date(data)
         if application != NimbusExperiment.Application.DESKTOP:
             data = self._validate_languages_versions(data)
             data = self._validate_countries_versions(data)

--- a/experimenter/experimenter/experiments/constants.py
+++ b/experimenter/experimenter/experiments/constants.py
@@ -430,6 +430,9 @@ Optional - We believe this outcome will <describe impact> on <core metric>
         "Firefox version must be at least 113 for localized experiments."
     )
 
+    ERROR_FIRST_RUN_RELEASE_DATE = "This field is for first run experiments only. \
+        Are you missing your first run targeting?"
+
     # Analysis can be computed starting the week after enrollment
     # completion for "week 1" of the experiment. However, an extra
     # buffer day is added for Jetstream to compute the results.

--- a/experimenter/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_experiment_clone_serializer.py
+++ b/experimenter/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_experiment_clone_serializer.py
@@ -119,3 +119,22 @@ class TestNimbusExperimentCloneSerializer(TestCase):
         self.assertTrue(serializer.is_valid())
         child = serializer.save()
         self.assertEqual(list(child.locales.all()), [])
+
+    def test_release_date_not_clone_for_mobile_application(self):
+        parent = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.ENDING_APPROVE_APPROVE,
+            application=NimbusExperiment.Application.FENIX,
+            proposed_release_date="2023-12-12",
+        )
+        serializer = NimbusExperimentCloneSerializer(
+            data={
+                "parent_slug": parent.slug,
+                "name": "New Name",
+            },
+            context={"user": parent.owner},
+        )
+        self.assertTrue(serializer.is_valid())
+        child = serializer.save()
+        self.assertIsNone(child.proposed_release_date)
+        self.assertIsNone(child.release_date)
+        self.assertIsNone(child.enrollment_start_date)

--- a/experimenter/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_experiment_serializer.py
+++ b/experimenter/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_experiment_serializer.py
@@ -1425,3 +1425,40 @@ class TestNimbusExperimentSerializer(TestCase):
         self.assertTrue(serializer.is_valid(), serializer.errors)
         experiment = serializer.save()
         self.assertFalse(experiment.is_archived)
+
+    def test_can_set_proposed_release_date(self):
+        release_date = datetime.date.today()
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            is_first_run=True,
+        )
+        serializer = NimbusExperimentSerializer(
+            experiment,
+            {
+                "proposed_release_date": release_date,
+                "changelog_message": "Test changelog",
+            },
+            context={"user": self.user},
+        )
+        self.assertTrue(serializer.is_valid())
+        experiment = serializer.save()
+        self.assertEquals(experiment.proposed_release_date, release_date)
+
+    def test_can_set_empty_proposed_release_date(self):
+        release_date = datetime.date.today()
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            is_first_run=True,
+            proposed_release_date=release_date,
+        )
+        serializer = NimbusExperimentSerializer(
+            experiment,
+            {
+                "proposed_release_date": None,
+                "changelog_message": "Test changelog",
+            },
+            context={"user": self.user},
+        )
+        self.assertTrue(serializer.is_valid())
+        experiment = serializer.save()
+        self.assertEquals(experiment.proposed_release_date, None)

--- a/experimenter/experimenter/nimbus-ui/src/lib/mocks.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/lib/mocks.tsx
@@ -583,6 +583,7 @@ export const MOCK_EXPERIMENT: Partial<getExperiment["experimentBySlug"]> = {
   totalEnrolledClients: 68000,
   proposedEnrollment: 1,
   proposedDuration: 28,
+  proposedReleaseDate: "",
   readyForReview: {
     ready: true,
     message: {},
@@ -594,7 +595,6 @@ export const MOCK_EXPERIMENT: Partial<getExperiment["experimentBySlug"]> = {
     legalSignoff: false,
   },
   startDate: new Date().toISOString(),
-  proposedReleaseDate: new Date().toISOString(),
   computedEndDate: new Date(Date.now() + 12096e5).toISOString(),
   computedDurationDays: 14,
   computedEnrollmentDays: 1,
@@ -668,6 +668,7 @@ export const MOCK_LIVE_ROLLOUT: Partial<getExperiment["experimentBySlug"]> = {
   totalEnrolledClients: 68000,
   proposedEnrollment: 1,
   proposedDuration: 28,
+  proposedReleaseDate: "",
   readyForReview: {
     ready: true,
     message: {},
@@ -679,7 +680,6 @@ export const MOCK_LIVE_ROLLOUT: Partial<getExperiment["experimentBySlug"]> = {
     legalSignoff: false,
   },
   startDate: new Date().toISOString(),
-  proposedReleaseDate: new Date(Date.now()).toISOString(),
   computedEndDate: new Date(Date.now() + 12096e5).toISOString(),
   computedDurationDays: 14,
   computedEnrollmentDays: 1,


### PR DESCRIPTION
Because

- We want to make sure that a proposed release date is only added for first run experiments

This commit

- Adds a serializer warning to make sure the user selects first run if they are entering a value in the proposed release date field
- Adds serializer tests
