### PR TITLE
fix #8890 feat(nimbus): don't send enrollment end email for rollouts

### DIFF
--- a/experimenter/experimenter/kinto/tasks.py
+++ b/experimenter/experimenter/kinto/tasks.py
@@ -417,6 +417,7 @@ def nimbus_send_emails():
     for experiment in experiments:
         if (
             experiment.should_end_enrollment
+            and not experiment.is_rollout
             and not experiment.emails.filter(
                 type=NimbusExperiment.EmailType.ENROLLMENT_END
             ).exists()


### PR DESCRIPTION
Because

* We removed all the enrollment ending workflows for rollouts
* We were still sending the enrollment end reminder email for rollouts

This commit

* Disables the enrollment ending reminder email for rollouts


