### PR TITLE
feat(nimbus): add targeting opposite of new profile created

### DIFF
--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -76,6 +76,17 @@ NEW_PROFILE_CREATED = NimbusTargetingConfig(
     application_choice_names=(Application.DESKTOP.name,),
 )
 
+NOT_NEW_PROFILE_CREATED = NimbusTargetingConfig(
+    name="Not new profile created",
+    slug="not_new_profile_created",
+    description="Profile with creation date over 24 hours",
+    targeting=f"!({NEW_PROFILE_CREATED.targeting})",
+    desktop_telemetry=f"NOT ({NEW_PROFILE_CREATED.desktop_telemetry})",
+    sticky_required=False,
+    is_first_run_required=False,
+    application_choice_names=(Application.DESKTOP.name,),
+)
+
 FIRST_RUN = NimbusTargetingConfig(
     name="First start-up users",
     slug="first_run",


### PR DESCRIPTION
Because we want to roll out the winning branch from https://experimenter.services.mozilla.com/nimbus/new-import-interface-firefox-114-launch which implicitly relied on another concurrent experiment with targeting from #8470 to prevent new users.

This commit adds a negation of the targeting to explicitly exclude recent profile creation.

![not new targeting](https://github.com/mozilla/experimenter/assets/438537/68c36f27-3870-428f-9b9c-8227d3f71a0d)