### PR TITLE
Fixes #8718 feat(nimbus): Add proposed release date to Summary page

### DIFF
--- a/experimenter/experimenter/nimbus-ui/src/components/Summary/TableAudience/index.test.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/Summary/TableAudience/index.test.tsx
@@ -33,6 +33,27 @@ describe("TableAudience", () => {
       );
     });
   });
+
+  describe("renders 'First Run Release Date' row as expected", () => {
+    it("with proposed release date", () => {
+      const expectedDate = "2023-12-12";
+      const { experiment } = mockExperimentQuery("demo-slug", {
+        proposedReleaseDate: expectedDate,
+      });
+      render(<Subject {...{ experiment }} />);
+      expect(screen.getByTestId("experiment-release-date")).toHaveTextContent(
+        expectedDate,
+      );
+    });
+    it("when not set", () => {
+      const { experiment } = mockExperimentQuery("demo-slug");
+      render(<Subject {...{ experiment }} />);
+      expect(screen.getByTestId("experiment-release-date")).toHaveTextContent(
+        "Not set",
+      );
+    });
+  });
+
   describe("renders 'Minimum version' row as expected", () => {
     it("when set", () => {
       const { experiment } = mockExperimentQuery("demo-slug");

--- a/experimenter/experimenter/nimbus-ui/src/components/Summary/TableAudience/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/Summary/TableAudience/index.tsx
@@ -37,18 +37,17 @@ const TableAudience = ({ experiment }: TableAudienceProps) => {
               <td data-testid="experiment-channel" className="border-top-0">
                 {displayConfigLabelOrNotSet(experiment.channel, channels)}
               </td>
-
-              {experiment.targetingConfigSlug && (
-                <>
-                  <th className="border-top-0">Advanced Targeting</th>
-                  <td data-testid="experiment-target" className="border-top-0">
-                    {displayConfigLabelOrNotSet(
-                      experiment.targetingConfigSlug,
-                      targetingConfigs,
-                    )}
-                  </td>
-                </>
-              )}
+              <th className="border-top-0">First Run Release Date</th>
+              <td
+                data-testid="experiment-release-date"
+                className="border-top-0"
+              >
+                {experiment.proposedReleaseDate ? (
+                  experiment.proposedReleaseDate
+                ) : (
+                  <NotSet />
+                )}
+              </td>
             </tr>
             <tr>
               <th>Minimum version</th>
@@ -141,6 +140,21 @@ const TableAudience = ({ experiment }: TableAudienceProps) => {
               <td data-testid="experiment-is-first-run">
                 {experiment.isFirstRun ? "True" : "False"}
               </td>
+            </tr>
+            <tr>
+              {experiment.targetingConfigSlug && (
+                <>
+                  <th>Advanced Targeting</th>
+                  <td data-testid="experiment-target">
+                    {displayConfigLabelOrNotSet(
+                      experiment.targetingConfigSlug,
+                      targetingConfigs,
+                    )}
+                  </td>
+                </>
+              )}
+              <th></th>
+              <td></td>
             </tr>
             {experiment.jexlTargetingExpression &&
             experiment.jexlTargetingExpression !== "" ? (


### PR DESCRIPTION
Because

- We added the proposed release date to the Audience page

This commit

- Adds a cell on the Summary page (when the experiment is in Draft) to show either the date or "Not Set"
- Moves the Advanced Targeting cell down so that it's next to the targeting expression, and puts release date up next to channel/min version to match the Audience page

<img width="1426" alt="Screen Shot 2023-06-06 at 5 43 09 PM" src="https://github.com/mozilla/experimenter/assets/43795363/32f2e5c3-b059-4190-b78b-fdb81c2652a9">
<img width="1410" alt="Screen Shot 2023-06-06 at 5 42 51 PM" src="https://github.com/mozilla/experimenter/assets/43795363/d11ce907-9513-491e-b4af-9d5dd9ea18b4">

