### PR TITLE
For #8877 docs(nimbus): Adding cancel workflows to the state transition docs

### DIFF
--- a/docs/experimenter/README.md
+++ b/docs/experimenter/README.md
@@ -22,21 +22,25 @@
     - [Publish (Approve/Reject)](#publish-approvereject)
     - [Publish (Approve/Reject+Rollback)](#publish-approvereject--manual-rollback)
     - [Publish (Approve/Timeout)](#publish-approvetimeout)
+    - [Publish (Cancel ------/------)](#publish-cancel-------------)
     - [Update (Approve/Approve)](#update-approveapprove)
     - [Update (Reject/------)](#update-reject------)
     - [Update (Approve/Reject)](#update-approvereject)
     - [Update (Approve/Reject+Rollback)](#update-approvereject--manual-rollback)
     - [Update (Approve/Timeout)](#update-approvetimeout)
+    - [Update (Cancel ------/------)](#update-cancel-------------)
     - [End Enrollment (Approve/Approve)](#end-enrollment-approveapprove)
     - [End Enrollment (Reject/------)](#end-enrollment-reject------)
     - [End Enrollment (Approve/Reject)](#end-enrollment-approvereject)
     - [End Enrollment (Approve/Reject+Rollback)](#end-enrollment-approverejectmanual-rollback)
     - [End Enrollment (Approve/Timeout)](#end-enrollment-approvetimeout)
+    - [End Enrollment (Cancel ------/------)](#end-enrollment-cancel-------------)
     - [End (Approve/Approve)](#end-approveapprove)
     - [End (Reject/------)](#end-reject------)
     - [End (Approve/Reject)](#end-approvereject)
     - [End (Approve/Reject+Rollback)](#end-approverejectmanual-rollback)
     - [End (Approve/Timeout)](#end-approvetimeout)
+    - [End (Cancel ------/------)](#end-cancel-------------)
   - [Maintaining These Docs](#maintaining-these-docs)
 
 ## Overview
@@ -255,7 +259,7 @@ A draft experiment/rollout that has been validly completed (no errors) is reject
     participant Experimenter Worker
     participant Remote Settings UI
     participant Remote Settings Backend
-    title Publish (Reject/----)
+    title Publish (Reject/------)
     Note over Experiment Owner: An owner is ready to launch <br/> their draft experiment/rollout <br/> from draft and clicks the <br/> Launch button
     
     rect rgb(255,204,255) 
@@ -450,7 +454,7 @@ A draft experiment/rollout that has been validly completed is reviewed and appro
 %%{init:{'themeCSS':'g:nth-of-type(1) .note { stroke: purple ;fill: white; };'}}%%
 ```
 
-### Publish (Cancel ----/----)
+### Publish (Cancel ------/------)
 
 When a draft experiment/rollout has requested review in Experimenter, the review can also be canceled in Experimenter. The review can only be canceled before it has been reviewed in Experimenter.
 
@@ -463,7 +467,7 @@ When a draft experiment/rollout has requested review in Experimenter, the review
         participant Experimenter Worker
         participant Remote Settings UI
         participant Remote Settings Backend
-        title Cancel from Draft (Cancel ----/----)
+        title Cancel from Draft (Cancel ------/------)
         Note over Experiment Owner: An owner is ready to launch <br/> their draft experiment/rollout <br/> from draft and clicks the <br/> Review button
 
         rect rgb(255,204,255)
@@ -492,7 +496,7 @@ This can also be canceled when an experiment/rollout is in the Preview state and
         participant Experimenter Worker
         participant Remote Settings UI
         participant Remote Settings Backend
-        title Cancel from Preview (Cancel ----/----)
+        title Cancel from Preview (Cancel ------/------)
         
         Note over Experiment Owner: An owner is ready to publish <br/> their draft experiment/rollout <br/> to Preview
     
@@ -506,7 +510,7 @@ This can also be canceled when an experiment/rollout is in the Preview state and
         rect rgb(255,204,255)
             Note right of Experiment Owner: Owner launches in Experimenter
             Experiment Owner->>Experimenter UI: Send to Review
-            Experimenter UI->>Experimenter Backend: Status: Preview <br/> Publish status: Review <br/> Status next: Live <br/> + changelog
+            Experimenter UI->>Experimenter Backend: Status: Draft <br/> Publish status: Review <br/> Status next: Live <br/> + changelog
         end
 
         Experimenter Backend-->>Reviewer: To review
@@ -840,7 +844,7 @@ A live rollout that has valid changes (making it "dirty") is reviewed and approv
     end 
 ```
 
-### Update (Cancel ----/----)
+### Update (Cancel ------/------)
 
 A live rollout can have updates pushed to its state while remaining Live. These updated changes must be reviewed in order to be published to the user, following the same flow to be approved in both Experimenter and Remote Settings. Like the publish flow, these reviews can be canceled from Experimenter.
 
@@ -853,7 +857,7 @@ A live rollout can have updates pushed to its state while remaining Live. These 
     participant Experimenter Worker
     participant Remote Settings UI
     participant Remote Settings Backend
-    title Update (Cancel ----/----)
+    title Update (Cancel ------/------)
     
     Note over Experiment Owner: An owner is ready to update <br/> their live rollout
     
@@ -1151,7 +1155,7 @@ A live experiment that is published in Remote Settings has passed its planned en
     end 
 ```
 
-### End Enrollment (Cancel ----/----)
+### End Enrollment (Cancel ------/------)
 
 A live experiment that is published in Remote Settings has passed its planned end enrollment date and the owner requests to end the enrollment. The end enrollment request can be canceled before it is approved in Experimenter.
 
@@ -1164,7 +1168,7 @@ A live experiment that is published in Remote Settings has passed its planned en
         participant Experimenter Worker
         participant Remote Settings UI
         participant Remote Settings Backend
-        title End enrollment (Cancel ----/----)
+        title End enrollment (Cancel ------/------)
         
         Note over Experiment Owner: An owner is ready to end <br/> enrollment for their live experiment <br/> and clicks the end enrollment button
         
@@ -1444,7 +1448,7 @@ Note over Experiment Owner: An owner is ready to end <br/> their live experiment
     end 
 ```
 
-### End (Cancel ----/----)
+### End (Cancel ------/------)
 
 A live experiment/rollout that is published in Remote Settings is requested to end by the owner. This end request must be reviewed in similar fashion to launching, end enrollment, and updating, and thus can be canceled before approval on the Experimenter side.
 
@@ -1457,7 +1461,7 @@ A live experiment/rollout that is published in Remote Settings is requested to e
     participant Experimenter Worker
     participant Remote Settings UI
     participant Remote Settings Backend
-    title End experiment (Cancel ----/----)
+    title End experiment (Cancel ------/------)
     
     Note over Experiment Owner: An owner is ready to end <br/> their live experiment/rollout and <br/> clicks the end experiment button
     

--- a/docs/experimenter/README.md
+++ b/docs/experimenter/README.md
@@ -450,6 +450,74 @@ A draft experiment/rollout that has been validly completed is reviewed and appro
 %%{init:{'themeCSS':'g:nth-of-type(1) .note { stroke: purple ;fill: white; };'}}%%
 ```
 
+### Publish (Cancel ----/----)
+
+When a draft experiment/rollout has requested review in Experimenter, the review can also be canceled in Experimenter. The review can only be canceled before it has been reviewed in Experimenter.
+
+```mermaid
+    sequenceDiagram
+        participant Reviewer
+        participant Experiment Owner
+        participant Experimenter UI
+        participant Experimenter Backend
+        participant Experimenter Worker
+        participant Remote Settings UI
+        participant Remote Settings Backend
+        title Cancel from Draft (Cancel ----/----)
+        Note over Experiment Owner: An owner is ready to launch <br/> their draft experiment/rollout <br/> from draft and clicks the <br/> Review button
+
+        rect rgb(255,204,255)
+            Note right of Experiment Owner: Owner launches in Experimenter
+            Experiment Owner->>Experimenter UI: Send to Review
+            Experimenter UI->>Experimenter Backend: Status: Draft <br/> Publish status: Review <br/> Status next: Live <br/> + changelog
+        end
+
+        Experimenter Backend-->>Reviewer: To review
+        
+        rect rgb(255,204,255)
+            Note right of Experiment Owner: Owner cancels the review request <br/> in Experimenter
+            Experiment Owner->>Experimenter UI: Cancel the Review
+            Experimenter UI->>Experimenter Backend: Status: Draft <br/> Publish status: Idle <br/> Status next: <none> <br/> + changelog
+        end
+```
+
+This can also be canceled when an experiment/rollout is in the Preview state and requests to be Launched. When the review is canceled, the Preview experiment is sent back to Draft.
+
+```mermaid
+    sequenceDiagram
+        participant Reviewer
+        participant Experiment Owner
+        participant Experimenter UI
+        participant Experimenter Backend
+        participant Experimenter Worker
+        participant Remote Settings UI
+        participant Remote Settings Backend
+        title Cancel from Preview (Cancel ----/----)
+        
+        Note over Experiment Owner: An owner is ready to publish <br/> their draft experiment/rollout <br/> to Preview
+    
+        rect rgb(255,204,255) 
+            Experiment Owner->>Experimenter UI: Send to Preview
+            Experimenter UI->>Experimenter Backend: Update to Preview <br/> Status: Preview <br/> Publish status: Idle <br/> Status next: <none>
+        end 
+        
+        Note over Experiment Owner: An owner is ready to launch <br/> their experiment/rollout <br/> from preview and clicks the <br/> Launch button
+
+        rect rgb(255,204,255)
+            Note right of Experiment Owner: Owner launches in Experimenter
+            Experiment Owner->>Experimenter UI: Send to Review
+            Experimenter UI->>Experimenter Backend: Status: Preview <br/> Publish status: Review <br/> Status next: Live <br/> + changelog
+        end
+
+        Experimenter Backend-->>Reviewer: To review
+        
+        rect rgb(255,204,255)
+            Note right of Experiment Owner: Owner cancels the review request <br/> in Experimenter
+            Experiment Owner->>Experimenter UI: Cancel the Review
+            Experimenter UI->>Experimenter Backend: Status: Draft <br/> Publish status: Idle <br/> Status next: <none> <br/> + changelog
+        end
+```
+
 ### Update (Approve/Approve)
 
 A live rollout can have updates pushed to its state while remaining Live. These updated changes must be reviewed in order to be published to the user, following the same flow to be approved in both Experimenter and Remote Settings.
@@ -772,6 +840,49 @@ A live rollout that has valid changes (making it "dirty") is reviewed and approv
     end 
 ```
 
+### Update (Cancel ----/----)
+
+A live rollout can have updates pushed to its state while remaining Live. These updated changes must be reviewed in order to be published to the user, following the same flow to be approved in both Experimenter and Remote Settings. Like the publish flow, these reviews can be canceled from Experimenter.
+
+```mermaid
+  sequenceDiagram
+    participant Reviewer
+    participant Experiment Owner
+    participant Experimenter UI
+    participant Experimenter Backend
+    participant Experimenter Worker
+    participant Remote Settings UI
+    participant Remote Settings Backend
+    title Update (Cancel ----/----)
+    
+    Note over Experiment Owner: An owner is ready to update <br/> their live rollout
+    
+    rect rgb(255,204,255) 
+        Note right of Experiment Owner: Owner makes changes in Experimenter
+        Experiment Owner->>Experimenter UI: Make updates to live rollout
+        Note over Experimenter Backend: The experiment is updated and is <br/> marked as dirty on the backend
+        Experimenter UI->>Experimenter Backend: Status: Live <br/> Publish status: Idle <br/> Status next: <none>  <br/> + changelog
+        Experimenter Backend->>Experimenter Backend: is_dirty: True 
+    end 
+
+    Note over Experiment Owner: The owner clicks the Request <br/> Update button
+    
+    rect rgb(255,204,255) 
+        Note right of Experiment Owner: Owner requests update in Experimenter
+        Experiment Owner->>Experimenter UI: Send to Review
+        Experimenter UI->>Experimenter Backend: Status: Live <br/> Publish status: Review <br/> Status next: Live <br/> + changelog
+    end 
+    
+    Experimenter Backend-->>Reviewer: To review
+
+    rect rgb(255,204,255)
+        Note right of Experiment Owner: Owner cancels the review request <br/> in Experimenter
+        Experiment Owner->>Experimenter UI: Cancel the Review
+        Experimenter UI->>Experimenter Backend: Status: Live <br/> Publish status: Idle <br/> Status next: <none> <br/> + changelog
+    end
+    
+```
+
 ### End Enrollment (Approve/Approve)
 
 A live experiment that is published in Remote Settings has passed its planned end enrollment date and the owner requests that enrollment ends. The request is reviewed and approved in Experimenter and then Remote Settings, the record is updated, and no new clients will be enrolled in the experiment.
@@ -1040,6 +1151,37 @@ A live experiment that is published in Remote Settings has passed its planned en
     end 
 ```
 
+### End Enrollment (Cancel ----/----)
+
+A live experiment that is published in Remote Settings has passed its planned end enrollment date and the owner requests to end the enrollment. The end enrollment request can be canceled before it is approved in Experimenter.
+
+```mermaid
+    sequenceDiagram
+        participant Reviewer
+        participant Experiment Owner
+        participant Experimenter UI
+        participant Experimenter Backend
+        participant Experimenter Worker
+        participant Remote Settings UI
+        participant Remote Settings Backend
+        title End enrollment (Cancel ----/----)
+        
+        Note over Experiment Owner: An owner is ready to end <br/> enrollment for their live experiment <br/> and clicks the end enrollment button
+        
+        rect rgb(255,204,255) 
+            Experiment Owner->>Experimenter UI: End enrollment for experiment
+            Experimenter UI->>Experimenter Backend: Status: Live <br/> Publish status: Review <br/> Status next: Live <br/> is_paused: True <br/> + changelog
+        end 
+
+        Experimenter Backend-->>Reviewer: To review
+
+        rect rgb(255,204,255)
+                Note right of Experiment Owner: Owner cancels the review request <br/> in Experimenter
+                Experiment Owner->>Experimenter UI: Cancel the Review
+                Experimenter UI->>Experimenter Backend: Status: Live <br/> Publish status: Idle <br/> Status next: <none> <br/> is_paused: False <br/> + changelog
+        end
+```
+
 ### End (Approve/Approve)
 
 A live experiment that is published in Remote Settings is requested to end by the owner, reviewed and approved in Experimenter, reviewed and approved in Remote Settings, is deleted from the collection, and is then no longer accessible by clients.
@@ -1300,6 +1442,37 @@ Note over Experiment Owner: An owner is ready to end <br/> their live experiment
         Experimenter Worker->>Remote Settings Backend: Check collection (timeout) <br/> RS status: to-rollback
         Experimenter Worker->>Experimenter Backend:  Status: Live <br/> Publish status: Review <br/> Status next: Complete <br/> + changelog
     end 
+```
+
+### End (Cancel ----/----)
+
+A live experiment/rollout that is published in Remote Settings is requested to end by the owner. This end request must be reviewed in similar fashion to launching, end enrollment, and updating, and thus can be canceled before approval on the Experimenter side.
+
+```mermaid
+  sequenceDiagram
+    participant Reviewer
+    participant Experiment Owner
+    participant Experimenter UI
+    participant Experimenter Backend
+    participant Experimenter Worker
+    participant Remote Settings UI
+    participant Remote Settings Backend
+    title End experiment (Cancel ----/----)
+    
+    Note over Experiment Owner: An owner is ready to end <br/> their live experiment/rollout and <br/> clicks the end experiment button
+    
+    rect rgb(255,204,255) 
+        Experiment Owner->>Experimenter UI: End experiment/rollout
+        Experimenter UI->>Experimenter Backend: Status: Live <br/> Publish status: Review <br/> Status next: Complete <br/> + changelog
+    end 
+
+    Experimenter Backend-->>Reviewer: To review
+    
+    rect rgb(255,204,255)
+        Note right of Experiment Owner: Owner cancels the review request <br/> in Experimenter
+        Experiment Owner->>Experimenter UI: Cancel the Review
+        Experimenter UI->>Experimenter Backend: Status: Live <br/> Publish status: Idle <br/> Status next: <none> <br/> + changelog
+    end
 ```
 
 ## Maintaining These Docs


### PR DESCRIPTION
Because

- We don't have transition diagrams for the cancel states

This commit

- Adds mermaid diagrams for the following:
   - Draft -> Publish -> Cancel
   - Preview -> Publish -> Cancel
   - Live rollout -> Update -> Cancel
   - Live experiment -> End enrollment -> Cancel
   - Live -> End -> Cancel
