### PR TITLE
Fixes #8933 feat(nimbus): Only show release date for mobile

### DIFF
--- a/experimenter/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/index.test.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/index.test.tsx
@@ -904,7 +904,6 @@ describe("FormAudience", () => {
       totalEnrolledClients: MOCK_EXPERIMENT.totalEnrolledClients,
       proposedEnrollment: "" + MOCK_EXPERIMENT.proposedEnrollment,
       proposedDuration: "" + MOCK_EXPERIMENT.proposedDuration,
-      proposedReleaseDate: MOCK_EXPERIMENT.proposedReleaseDate,
       countries: MOCK_EXPERIMENT.countries.map((v) => "" + v.id),
       locales: MOCK_EXPERIMENT.locales.map((v) => "" + v.id),
       languages: MOCK_EXPERIMENT.languages.map((v) => "" + v.id),
@@ -978,7 +977,16 @@ describe("FormAudience", () => {
     const enteredDate = "2023-05-12";
 
     const onSubmit = jest.fn();
-    renderSubjectWithDefaultValues(onSubmit);
+    render(
+      <Subject
+        {...{ onSubmit }}
+        experiment={{
+          ...MOCK_EXPERIMENT,
+          application: NimbusExperimentApplicationEnum.FENIX,
+          isFirstRun: true,
+        }}
+      />,
+    );
     await waitFor(() => {
       expect(screen.queryByTestId("FormAudience")).toBeInTheDocument();
     });
@@ -996,11 +1004,22 @@ describe("FormAudience", () => {
 
   it("changing proposed release date to empty sets form value", async () => {
     const expectedDate = "";
-
     const onSubmit = jest.fn();
-    renderSubjectWithDefaultValues(onSubmit);
+
+    render(
+      <Subject
+        {...{ onSubmit }}
+        experiment={{
+          ...MOCK_EXPERIMENT,
+          application: NimbusExperimentApplicationEnum.FENIX,
+          isFirstRun: true,
+        }}
+      />,
+    );
+
     await waitFor(() => {
       expect(screen.queryByTestId("FormAudience")).toBeInTheDocument();
+      expect(screen.queryByTestId("proposedReleaseDate")).toBeInTheDocument();
     });
 
     const submitButton = screen.getByTestId("submit-button");
@@ -1012,9 +1031,52 @@ describe("FormAudience", () => {
     expect(onSubmit.mock.calls[0][0].proposedReleaseDate).toEqual(expectedDate);
   });
 
+  it("only access proposed release date field for mobile applications", async () => {
+    render(
+      <Subject
+        experiment={{
+          ...MOCK_EXPERIMENT,
+          application: NimbusExperimentApplicationEnum.FENIX,
+          isFirstRun: true,
+        }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("isFirstRun")).toBeInTheDocument();
+      expect(screen.queryByTestId("proposedReleaseDate")).toBeInTheDocument();
+    });
+  });
+
+  it("cannot access proposed release date field for desktop applications", async () => {
+    render(
+      <Subject
+        experiment={{
+          ...MOCK_EXPERIMENT,
+          application: NimbusExperimentApplicationEnum.DESKTOP,
+        }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("isFirstRun")).not.toBeInTheDocument();
+      expect(
+        screen.queryByTestId("proposedReleaseDate"),
+      ).not.toBeInTheDocument();
+    });
+  });
+
   it("clicking proposed release date title takes you to whattrainisit", async () => {
     const onSubmit = jest.fn();
-    renderSubjectWithDefaultValues(onSubmit);
+    render(
+      <Subject
+        experiment={{
+          ...MOCK_EXPERIMENT,
+          application: NimbusExperimentApplicationEnum.FENIX,
+          isFirstRun: true,
+        }}
+      />,
+    );
     await waitFor(() => {
       expect(screen.queryByTestId("FormAudience")).toBeInTheDocument();
     });

--- a/experimenter/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/index.tsx
@@ -119,7 +119,9 @@ export const FormAudience = ({
     totalEnrolledClients: experiment.totalEnrolledClients,
     proposedEnrollment: experiment.proposedEnrollment,
     proposedDuration: experiment.proposedDuration,
-    proposedReleaseDate: experiment.proposedReleaseDate,
+    proposedReleaseDate: experiment.isFirstRun
+      ? experiment.proposedReleaseDate
+      : "",
     countries: selectOptions(experiment.countries as SelectIdItems),
     locales: selectOptions(experiment.locales as SelectIdItems),
     languages: selectOptions(experiment.languages as SelectIdItems),
@@ -235,26 +237,6 @@ export const FormAudience = ({
             </Form.Control>
             <FormErrors name="channel" />
           </Form.Group>
-        </Form.Row>
-        <Form.Row>
-          <Form.Group as={Col} controlId="proposedReleaseDate">
-            <Form.Label className="d-flex align-items-center">
-              Release Date
-              <Info
-                data-tip={TOOLTIP_RELEASE_DATE}
-                data-testid="tooltip-proposed-release-date"
-                width="20"
-                height="20"
-                className="ml-1"
-                onClick={() => window.open(EXTERNAL_URLS.WHAT_TRAIN_IS_IT)}
-              />
-            </Form.Label>
-            <Form.Control
-              {...formControlAttrs("proposedReleaseDate")}
-              type="date"
-            />
-            <FormErrors name="proposedReleaseDate" />
-          </Form.Group>
           <Form.Group as={Col} controlId="minVersion">
             <Form.Label className="d-flex align-items-center">
               Min Version
@@ -368,27 +350,50 @@ export const FormAudience = ({
           </Form.Group>
         </Form.Row>
         {!isDesktop && (
-          <Form.Row>
-            <Form.Group as={Col} controlId="isFirstRun">
-              <Form.Check
-                {...formControlAttrs("isFirstRun")}
-                type="checkbox"
-                onChange={(e) => setIsFirstRun(e.target.checked)}
-                checked={isFirstRun}
-                disabled={isFirstRunRequiredWarning || isLocked!}
-                label="First Run Experiment"
-              />
-              {isFirstRunRequiredWarning && (
-                <Alert
-                  data-testid="is-first-run-required-warning"
-                  variant="warning"
-                >
-                  First run is required for this targeting configuration.
-                </Alert>
-              )}
-              <FormErrors name="isFirstRun" />
-            </Form.Group>
-          </Form.Row>
+          <Form.Group>
+            <Form.Row>
+              <Form.Group as={Col} controlId="isFirstRun">
+                <Form.Check
+                  {...formControlAttrs("isFirstRun")}
+                  type="checkbox"
+                  onChange={(e) => setIsFirstRun(e.target.checked)}
+                  checked={isFirstRun}
+                  disabled={isFirstRunRequiredWarning || isLocked!}
+                  label="First Run Experiment"
+                />
+                {isFirstRunRequiredWarning && (
+                  <Alert
+                    data-testid="is-first-run-required-warning"
+                    variant="warning"
+                  >
+                    First run is required for this targeting configuration.
+                  </Alert>
+                )}
+                <FormErrors name="isFirstRun" />
+              </Form.Group>
+            </Form.Row>
+            <Form.Row>
+              <Form.Group as={Col} controlId="proposedReleaseDate">
+                <Form.Label className="d-flex align-items-center">
+                  First Run Release Date
+                  <Info
+                    data-tip={TOOLTIP_RELEASE_DATE}
+                    data-testid="tooltip-proposed-release-date"
+                    width="20"
+                    height="20"
+                    className="ml-1"
+                    onClick={() => window.open(EXTERNAL_URLS.WHAT_TRAIN_IS_IT)}
+                  />
+                </Form.Label>
+                <Form.Control
+                  {...formControlAttrs("proposedReleaseDate")}
+                  type="date"
+                  disabled={!isFirstRun}
+                />
+                <FormErrors name="proposedReleaseDate" />
+              </Form.Group>
+            </Form.Row>
+          </Form.Group>
         )}
       </Form.Group>
 

--- a/experimenter/experimenter/nimbus-ui/src/components/PageEditAudience/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageEditAudience/index.tsx
@@ -53,7 +53,8 @@ const PageEditAudience: React.FunctionComponent<RouteComponentProps> = () => {
         // issue #3954: Need to parse string IDs into numbers
         const nimbusExperimentId = experiment.id;
         const releaseDate =
-          proposedReleaseDate !== "" ? proposedReleaseDate : null;
+          isFirstRun && proposedReleaseDate !== "" ? proposedReleaseDate : null;
+
         const result = await updateExperimentAudience({
           variables: {
             input: {

--- a/experimenter/experimenter/nimbus-ui/src/components/Summary/TableAudience/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/Summary/TableAudience/index.tsx
@@ -153,8 +153,6 @@ const TableAudience = ({ experiment }: TableAudienceProps) => {
                   </td>
                 </>
               )}
-              <th></th>
-              <td></td>
             </tr>
             {experiment.jexlTargetingExpression &&
             experiment.jexlTargetingExpression !== "" ? (

--- a/experimenter/experimenter/nimbus-ui/src/hooks/useCommonForm/index.test.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/hooks/useCommonForm/index.test.tsx
@@ -152,7 +152,10 @@ describe("hooks/useCommonForm", () => {
     it("FormAudience", () => {
       render(<AudienceSubject />);
       const filteredAudienceFieldNames = audienceFieldNames.filter(
-        (e) => e !== "languages" && e !== "isFirstRun",
+        (e) =>
+          e !== "languages" &&
+          e !== "isFirstRun" &&
+          e !== "proposedReleaseDate",
       );
       filteredAudienceFieldNames.forEach((name) => {
         expect(screen.queryByTestId(`${name}-form-errors`)).toBeInTheDocument();


### PR DESCRIPTION
Because

- We only want the proposed release date field to be used if it is a first run experiment

This commit

* Renames the field to "First Run Release Date"
* Disables the field entirely if first run is not checked
* Hides the field (with the first run checkbox) if application is not mobile
* Moves it down with the first run checkbox

----

<img width="711" alt="Screen Shot 2023-06-12 at 1 10 00 PM" src="https://github.com/mozilla/experimenter/assets/43795363/cf34c920-e58d-4e65-9d92-98a7f55cb433">


https://github.com/mozilla/experimenter/assets/43795363/a7c13716-c59c-4d21-a05b-201115199457


<img width="2004" alt="Screen Shot 2023-06-12 at 1 10 29 PM" src="https://github.com/mozilla/experimenter/assets/43795363/2197723d-d81d-4332-bd8e-db8fe3a917a4">

