### PR TITLE
Fixes #8869 feat(nimbus): Add proposed release date to timeline on summary

### DIFF
--- a/experimenter/experimenter/nimbus-ui/src/components/Summary/SummaryTimeline/index.test.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/Summary/SummaryTimeline/index.test.tsx
@@ -28,6 +28,7 @@ describe("SummaryTimeline", () => {
 
       expect(screen.queryByTestId("label-not-launched")).toBeInTheDocument();
       expect(screen.queryByTestId("label-start-date")).not.toBeInTheDocument();
+      expect(screen.queryByTestId("label-release-date")).not.toBeInTheDocument();
       expect(
         screen.queryByTestId("label-enrollment-end-date"),
       ).not.toBeInTheDocument();
@@ -46,6 +47,7 @@ describe("SummaryTimeline", () => {
     expect(innerBar().classList).toContain("progress-bar-striped");
 
     expect(screen.queryByTestId("label-not-launched")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("label-release-date")).not.toBeInTheDocument();
     expect(screen.queryByTestId("label-start-date")).toBeInTheDocument();
     expect(
       screen.queryByTestId("label-enrollment-end-date"),
@@ -68,6 +70,34 @@ describe("SummaryTimeline", () => {
 
     expect(screen.queryByTestId("label-not-launched")).not.toBeInTheDocument();
     expect(screen.queryByTestId("label-start-date")).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("label-enrollment-end-date"),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByTestId("label-end-date")).toBeInTheDocument();
+    expect(screen.queryByTestId("label-duration-days")).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("label-enrollment-days"),
+    ).not.toBeInTheDocument();
+    expect(
+      await screen.findByTestId("tooltip-duration-summary"),
+    ).toHaveAttribute("data-tip", TOOLTIP_DURATION);
+  });
+
+  it("renders with a live first run experiment", async () => {
+    render(
+      <Subject
+        status={NimbusExperimentStatusEnum.LIVE}
+        isFirstRun={true} 
+        proposedReleaseDate="2023-12-12"
+      />,
+    );
+
+    expect(innerBar().classList).toContain("progress-bar-animated");
+    expect(innerBar().classList).toContain("progress-bar-striped");
+
+    expect(screen.queryByTestId("label-not-launched")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("label-start-date")).toBeInTheDocument();
+    expect(screen.queryByTestId("label-release-date")).toBeInTheDocument();
     expect(
       screen.queryByTestId("label-enrollment-end-date"),
     ).not.toBeInTheDocument();

--- a/experimenter/experimenter/nimbus-ui/src/components/Summary/SummaryTimeline/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/Summary/SummaryTimeline/index.tsx
@@ -26,6 +26,7 @@ const SummaryTimeline = ({
         {...{
           status,
           startDate: experiment.startDate,
+          proposedReleaseDate: experiment.isFirstRun ? experiment.proposedReleaseDate : null,
           computedEnrollmentEndDate: experiment.computedEnrollmentEndDate,
           computedEndDate: experiment.computedEndDate,
           isRollout: experiment.isRollout,
@@ -54,12 +55,14 @@ const SummaryTimeline = ({
 const StartEnd = ({
   status,
   startDate,
+  proposedReleaseDate,
   computedEnrollmentEndDate,
   computedEndDate,
   isRollout,
 }: {
   status: StatusCheck;
   startDate: string | null;
+  proposedReleaseDate: string | null;
   computedEnrollmentEndDate: string | null;
   computedEndDate: string | null;
   isRollout: boolean | null;
@@ -74,6 +77,14 @@ const StartEnd = ({
         <span className="flex-fill" data-testid="label-start-date">
           Start: <b>{humanDate(startDate!)}</b>
         </span>
+        {proposedReleaseDate && (
+          <span
+            className="flex-fill text-center"
+            data-testid="label-release-date"
+          >
+            Release date: <b>{humanDate(proposedReleaseDate!)}</b>
+          </span>
+        )}
         {computedEnrollmentEndDate && !isRollout && (
           <span
             className="flex-fill text-center"

--- a/experimenter/experimenter/nimbus-ui/src/components/Summary/SummaryTimeline/mocks.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/Summary/SummaryTimeline/mocks.tsx
@@ -16,18 +16,22 @@ export const Subject = ({
   computedEndDate = "2020-12-08T14:52:44.704811+00:00",
   computedDurationDays = 10,
   computedEnrollmentDays = 1,
+  proposedReleaseDate = "",
   status = NimbusExperimentStatusEnum.DRAFT,
   publishStatus = NimbusExperimentPublishStatusEnum.IDLE,
   isRollout = false,
+  isFirstRun = false,
 }: {
   startDate?: string;
   computedDurationDays?: number;
   computedEndDate?: string;
   computedEnrollmentDays?: number;
   computedEnrollmentEndDate?: string;
+  proposedReleaseDate?: string;
   status?: NimbusExperimentStatusEnum;
   publishStatus?: NimbusExperimentPublishStatusEnum;
   isRollout?: boolean;
+  isFirstRun?: boolean;
 }) => {
   const { experiment } = mockExperimentQuery("something-vague", {
     startDate,
@@ -35,9 +39,11 @@ export const Subject = ({
     computedEndDate,
     computedEnrollmentDays,
     computedEnrollmentEndDate,
+    proposedReleaseDate,
     status,
     publishStatus,
     isRollout,
+    isFirstRun,
   });
   return <SummaryTimeline {...{ experiment }} />;
 };


### PR DESCRIPTION
Because

- We added proposed release date for first run experiments

This commit

- Adds the field to the timeline on the Summary page (only for mobile!)
- Only shows the field on the timeline if it is not empty

----
**First run experiment with release date**
<img width="1625" alt="Screen Shot 2023-06-12 at 4 28 30 PM" src="https://github.com/mozilla/experimenter/assets/43795363/7a5a6c38-8f1b-4966-98f5-31e6122cd61f">

**Same experiment with ended enrollment**

<img width="1633" alt="Screen Shot 2023-06-12 at 4 29 31 PM" src="https://github.com/mozilla/experimenter/assets/43795363/787a9dd0-f785-4b0e-8ee6-065883ce18f9">

**First run experiment with NO release date**
<img width="1621" alt="Screen Shot 2023-06-12 at 4 30 08 PM" src="https://github.com/mozilla/experimenter/assets/43795363/b4831f53-a80b-4f4b-b610-93b3ce68da5a">
