### PR TITLE
fix #8958 bug(project): run experimenter unit tests in circle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,6 +40,7 @@ jobs:
           name: Run tests and linting
           command: |
             cp .env.sample .env
+            make check
 
 
   check_main:


### PR DESCRIPTION
Because

* We recently refactored the circleci config to update the path checks
* In the course of doing so we removed the command to actually run the experimenter unit tests.  Whoops!

This commit

* Restores the make check command to the experimenter unit tests in circle


