### PR TITLE
For #8962 feat(nimbus): Reorder the fields on Audience section of Summary page

### DIFF
--- a/experimenter/experimenter/nimbus-ui/src/components/NotSet/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/NotSet/index.tsx
@@ -7,11 +7,13 @@ import React from "react";
 const NotSet = ({
   copy = "Not set",
   "data-testid": testid = "not-set",
+  color = "text-danger",
 }: {
   copy?: string;
   "data-testid"?: string;
+  color?: string;
 }) => (
-  <span className="text-danger" data-testid={testid}>
+  <span className={color} data-testid={testid}>
     {copy}
   </span>
 );

--- a/experimenter/experimenter/nimbus-ui/src/components/Summary/TableAudience/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/Summary/TableAudience/index.tsx
@@ -144,7 +144,7 @@ const TableAudience = ({ experiment }: TableAudienceProps) => {
             </tr>
             <tr>
               <th>First Run Release Date</th>
-              <td data-testid="experiment-release-date">
+              <td colSpan={3} data-testid="experiment-release-date">
                 {experiment.proposedReleaseDate ? (
                   experiment.proposedReleaseDate
                 ) : (

--- a/experimenter/experimenter/nimbus-ui/src/components/Summary/TableAudience/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/Summary/TableAudience/index.tsx
@@ -37,17 +37,18 @@ const TableAudience = ({ experiment }: TableAudienceProps) => {
               <td data-testid="experiment-channel" className="border-top-0">
                 {displayConfigLabelOrNotSet(experiment.channel, channels)}
               </td>
-              <th className="border-top-0">First Run Release Date</th>
-              <td
-                data-testid="experiment-release-date"
-                className="border-top-0"
-              >
-                {experiment.proposedReleaseDate ? (
-                  experiment.proposedReleaseDate
-                ) : (
-                  <NotSet />
-                )}
-              </td>
+
+              {experiment.targetingConfigSlug && (
+                <>
+                  <th className="border-top-0">Advanced Targeting</th>
+                  <td data-testid="experiment-target" className="border-top-0">
+                    {displayConfigLabelOrNotSet(
+                      experiment.targetingConfigSlug,
+                      targetingConfigs,
+                    )}
+                  </td>
+                </>
+              )}
             </tr>
             <tr>
               <th>Minimum version</th>
@@ -142,18 +143,16 @@ const TableAudience = ({ experiment }: TableAudienceProps) => {
               </td>
             </tr>
             <tr>
-              {experiment.targetingConfigSlug && (
-                <>
-                  <th>Advanced Targeting</th>
-                  <td data-testid="experiment-target">
-                    {displayConfigLabelOrNotSet(
-                      experiment.targetingConfigSlug,
-                      targetingConfigs,
-                    )}
-                  </td>
-                </>
-              )}
+              <th>First Run Release Date</th>
+              <td data-testid="experiment-release-date">
+                {experiment.proposedReleaseDate ? (
+                  experiment.proposedReleaseDate
+                ) : (
+                  <NotSet color="primary" />
+                )}
+              </td>
             </tr>
+
             {experiment.jexlTargetingExpression &&
             experiment.jexlTargetingExpression !== "" ? (
               <tr>


### PR DESCRIPTION
Because

- We originally wanted the release date next to min/max version on the Audience page, but decided to move it down so that it's right next to the First Run checkbox
- And we want to do the same thing on the Summary page

This commit

- Moves the "Advanced Targeting" cell back up where it [used to be](https://github.com/mozilla/experimenter/pull/8934/files#diff-1d3f028202a4a17f30401d5ed82fa7c5681c53a664aba636f0f73355c07a648a)
- Puts the "First Run Release Date" cell at the bottom next to "First Run Experiment"
- Adds the ability to re-color `NotSet` -- we don't want release date to be red if it's not set, just plain black


<img width="1323" alt="Screen Shot 2023-06-13 at 2 39 10 PM" src="https://github.com/mozilla/experimenter/assets/43795363/a1ec9545-fe4c-44f2-9737-4d515042b651">

<img width="1321" alt="Screen Shot 2023-06-13 at 2 39 28 PM" src="https://github.com/mozilla/experimenter/assets/43795363/8d3cce90-388b-4c1e-a204-7e07fc9022c3">
