### PR TITLE
Fix #8965 feat(nimbus): Only show first run fields on mobile

### DIFF
--- a/experimenter/experimenter/nimbus-ui/src/components/Summary/TableAudience/index.test.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/Summary/TableAudience/index.test.tsx
@@ -38,7 +38,9 @@ describe("TableAudience", () => {
     it("with proposed release date", () => {
       const expectedDate = "2023-12-12";
       const { experiment } = mockExperimentQuery("demo-slug", {
+        application: NimbusExperimentApplicationEnum.IOS,
         proposedReleaseDate: expectedDate,
+        isFirstRun: true,
       });
       render(<Subject {...{ experiment }} />);
       expect(screen.getByTestId("experiment-release-date")).toHaveTextContent(
@@ -46,11 +48,34 @@ describe("TableAudience", () => {
       );
     });
     it("when not set", () => {
-      const { experiment } = mockExperimentQuery("demo-slug");
+      const { experiment } = mockExperimentQuery("demo-slug", {
+        application: NimbusExperimentApplicationEnum.IOS,
+        isFirstRun: true,
+      });
       render(<Subject {...{ experiment }} />);
       expect(screen.getByTestId("experiment-release-date")).toHaveTextContent(
         "Not set",
       );
+    });
+  });
+
+  describe("render First Run fields based on application", () => {
+    it("when application is desktop", () => {
+      const { experiment } = mockExperimentQuery("demo-slug");
+      render(<Subject {...{ experiment }} />);
+      expect(screen.queryByTestId("experiment-is-first-run")).toBeNull();
+      expect(screen.queryByTestId("experiment-release-date")).toBeNull();
+    });
+    it("when application is mobile", () => {
+      const expectedDate = "2023-12-12";
+      const { experiment } = mockExperimentQuery("demo-slug", {
+        application: NimbusExperimentApplicationEnum.IOS,
+        proposedReleaseDate: expectedDate,
+        isFirstRun: true,
+      });
+      render(<Subject {...{ experiment }} />);
+      expect(screen.getByTestId("experiment-is-first-run")).toBeInTheDocument();
+      expect(screen.getByTestId("experiment-release-date")).toBeInTheDocument();
     });
   });
 
@@ -328,6 +353,7 @@ describe("TableAudience", () => {
   describe("renders 'First Run Experiment' row as expected", () => {
     it("with stick enrollment True", () => {
       const { experiment } = mockExperimentQuery("demo-slug", {
+        application: NimbusExperimentApplicationEnum.IOS,
         isFirstRun: true,
       });
       render(<Subject {...{ experiment }} />);
@@ -337,6 +363,7 @@ describe("TableAudience", () => {
     });
     it("when not set", () => {
       const { experiment } = mockExperimentQuery("demo-slug", {
+        application: NimbusExperimentApplicationEnum.IOS,
         isFirstRun: false,
       });
       render(<Subject {...{ experiment }} />);

--- a/experimenter/experimenter/nimbus-ui/src/components/Summary/TableAudience/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/Summary/TableAudience/index.tsx
@@ -137,21 +137,29 @@ const TableAudience = ({ experiment }: TableAudienceProps) => {
                 {experiment.isSticky ? "True" : "False"}
               </td>
 
-              <th>First Run Experiment</th>
-              <td data-testid="experiment-is-first-run">
-                {experiment.isFirstRun ? "True" : "False"}
-              </td>
+              {!isDesktop ? (
+                <>
+                  <th>First Run Experiment</th>
+                  <td data-testid="experiment-is-first-run">
+                    {experiment.isFirstRun ? "True" : "False"}
+                  </td>
+                </>
+              ) : (
+                <td colSpan={2}></td>
+              )}
             </tr>
-            <tr>
-              <th>First Run Release Date</th>
-              <td colSpan={3} data-testid="experiment-release-date">
-                {experiment.proposedReleaseDate ? (
-                  experiment.proposedReleaseDate
-                ) : (
-                  <NotSet color="primary" />
-                )}
-              </td>
-            </tr>
+            {!isDesktop && (
+              <tr>
+                <th>First Run Release Date</th>
+                <td colSpan={3} data-testid="experiment-release-date">
+                  {experiment.proposedReleaseDate ? (
+                    experiment.proposedReleaseDate
+                  ) : (
+                    <NotSet color="primary" />
+                  )}
+                </td>
+              </tr>
+            )}
 
             {experiment.jexlTargetingExpression &&
             experiment.jexlTargetingExpression !== "" ? (


### PR DESCRIPTION
Because

- First Run fields (isFirstRun and proposedReleaseDate) are only valid for mobile

This commit

- Only shows these on the Audience section of the Summary page if the application is not desktop

----
**Desktop:**
<img width="1161" alt="Screen Shot 2023-06-14 at 2 35 19 PM" src="https://github.com/mozilla/experimenter/assets/43795363/17afd1ba-22fc-4c1a-9561-d9a1eb00a9e7">

**Mobile:**
<img width="1190" alt="Screen Shot 2023-06-14 at 2 38 32 PM" src="https://github.com/mozilla/experimenter/assets/43795363/b8346d78-8f03-4592-a707-09e54fd6da2b">

