### PR TITLE
fix #8981 fix(schemas): use make commands for schemas deploy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -527,7 +527,6 @@ jobs:
   schemas_deploy:
     docker:
       - image: cimg/python:3.10.8 # poetry 1.2.2
-    working_directory: ~/schemas
     steps:
       - checkout
       - run:
@@ -543,7 +542,7 @@ jobs:
       - run:
           name: Create the distribution files
           command: |
-            poetry build
+            make schemas_build
       - run:
           name: Upload to PyPI
           command: |
@@ -551,7 +550,7 @@ jobs:
             #   https://app.circleci.com/settings/project/github/mozilla/experimenter/environment-variables
             # For more on twine, see:
             #   https://twine.readthedocs.io/en/latest/
-            poetry run twine upload --skip-existing dist/*
+            make schemas_deploy_pypi
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -527,6 +527,7 @@ jobs:
   schemas_deploy:
     docker:
       - image: cimg/python:3.10.8 # poetry 1.2.2
+    working_directory: ~/schemas
     steps:
       - checkout
       - run:

--- a/Makefile
+++ b/Makefile
@@ -260,3 +260,9 @@ schemas_check: schemas_install schemas_black schemas_ruff schemas_test
 
 schemas_code_format:
 	(cd schemas && poetry run black . && poetry run ruff --fix .)
+
+schemas_build:
+	(cd schemas && poetry build)
+
+schemas_deploy_pypi:
+	(cd schemas && poetry run twine upload --skip-existing dist/*)


### PR DESCRIPTION
Because

- the circle config was assuming package directory
- the circle working dir was not set
- the circle image could not find the package to build/deploy

This commit

- uses make commands that drop into the correct directory before building and deploying
