### PR TITLE
fix #8983 fix(schemas): make schemas deploy dependent on install and build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -679,12 +679,6 @@ workflows:
                 - main
   deploy_schemas:
     jobs:
-      - schemas_check:
-          name: Check Schemas (main)
-          filters:
-            branches:
-              ignore:
-                - main
       - schemas_deploy:
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -527,6 +527,7 @@ jobs:
   schemas_deploy:
     docker:
       - image: cimg/python:3.10.8 # poetry 1.2.2
+    working_directory: ~/schemas
     steps:
       - checkout
       - run:
@@ -542,7 +543,7 @@ jobs:
       - run:
           name: Create the distribution files
           command: |
-            make schemas_build
+            poetry build
       - run:
           name: Install twine for PyPI publishing
           command: |
@@ -554,7 +555,6 @@ jobs:
             #   https://app.circleci.com/settings/project/github/mozilla/experimenter/environment-variables
             # For more on twine, see:
             #   https://twine.readthedocs.io/en/latest/
-            cd schemas
             twine upload --skip-existing dist/*
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -527,7 +527,7 @@ jobs:
   schemas_deploy:
     docker:
       - image: cimg/python:3.10.8 # poetry 1.2.2
-    working_directory: ~/schemas
+    working_directory: ./schemas
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -544,9 +544,9 @@ jobs:
           command: |
             make schemas_build
       - run:
-          name: Install twine
+          name: Install twine for PyPI publishing
           command: |
-            python -m pip install twine
+            pip install --upgrade twine
       - run:
           name: Upload to PyPI
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -554,7 +554,7 @@ jobs:
             #   https://app.circleci.com/settings/project/github/mozilla/experimenter/environment-variables
             # For more on twine, see:
             #   https://twine.readthedocs.io/en/latest/
-            twine upload --skip-existing dist/*
+            cd schemas && twine upload --skip-existing dist/*
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -544,13 +544,17 @@ jobs:
           command: |
             make schemas_build
       - run:
+          name: Install twine
+          command: |
+            python -m pip install twine
+      - run:
           name: Upload to PyPI
           command: |
             # Relies on the TWINE_USERNAME and TWINE_PASSWORD environment variables configured at:
             #   https://app.circleci.com/settings/project/github/mozilla/experimenter/environment-variables
             # For more on twine, see:
             #   https://twine.readthedocs.io/en/latest/
-            make schemas_deploy_pypi
+            twine upload --skip-existing dist/*
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -527,7 +527,6 @@ jobs:
   schemas_deploy:
     docker:
       - image: cimg/python:3.10.8 # poetry 1.2.2
-    working_directory: ./schemas
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -532,7 +532,7 @@ jobs:
       - run:
           name: Check for package version change in last commit before proceeding.
           command: |
-            if git diff main HEAD~1 schemas/pyproject.toml | grep 'version'
+            if git diff main HEAD schemas/pyproject.toml | grep 'version'
               then
                 echo "Found changes to package version dir, proceeding with deployment."
               else

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -554,7 +554,8 @@ jobs:
             #   https://app.circleci.com/settings/project/github/mozilla/experimenter/environment-variables
             # For more on twine, see:
             #   https://twine.readthedocs.io/en/latest/
-            cd schemas && twine upload --skip-existing dist/*
+            cd schemas
+            twine upload --skip-existing dist/*
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -542,7 +542,7 @@ jobs:
       - run:
           name: Create the distribution files
           command: |
-            poetry build
+            make schemas_build
       - run:
           name: Install twine for PyPI publishing
           command: |
@@ -554,7 +554,7 @@ jobs:
             #   https://app.circleci.com/settings/project/github/mozilla/experimenter/environment-variables
             # For more on twine, see:
             #   https://twine.readthedocs.io/en/latest/
-            twine upload --skip-existing dist/*
+            twine upload --skip-existing schemas/dist/*
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -683,5 +683,3 @@ workflows:
           filters:
             branches:
               ignore: main
-          requires:
-            - Check Schemas (main)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -532,7 +532,7 @@ jobs:
       - run:
           name: Check for package version change in last commit before proceeding.
           command: |
-            if git diff main HEAD schemas/pyproject.toml | grep 'version'
+            if git diff main HEAD~1 schemas/pyproject.toml | grep 'version'
               then
                 echo "Found changes to package version dir, proceeding with deployment."
               else
@@ -544,17 +544,13 @@ jobs:
           command: |
             make schemas_build
       - run:
-          name: Install twine for PyPI publishing
-          command: |
-            pip install --upgrade twine
-      - run:
           name: Upload to PyPI
           command: |
             # Relies on the TWINE_USERNAME and TWINE_PASSWORD environment variables configured at:
             #   https://app.circleci.com/settings/project/github/mozilla/experimenter/environment-variables
             # For more on twine, see:
             #   https://twine.readthedocs.io/en/latest/
-            twine upload --skip-existing schemas/dist/*
+            make schemas_deploy_pypi
 
 workflows:
   version: 2
@@ -686,4 +682,4 @@ workflows:
       - schemas_deploy:
           filters:
             branches:
-              ignore: main
+              only: main

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -683,11 +683,11 @@ workflows:
           name: Check Schemas (main)
           filters:
             branches:
-              only:
+              ignore:
                 - main
       - schemas_deploy:
           filters:
             branches:
-              only: main
+              ignore: main
           requires:
             - Check Schemas (main)

--- a/Makefile
+++ b/Makefile
@@ -265,4 +265,6 @@ schemas_build:
 	(cd schemas && poetry build)
 
 schemas_deploy_pypi: schemas_install schemas_build
-	cd schemas && poetry run twine upload --skip-existing dist/* && cd ..
+	cd schemas;
+	poetry run twine upload --skip-existing dist/*;
+	cd ..

--- a/Makefile
+++ b/Makefile
@@ -265,4 +265,4 @@ schemas_build:
 	(cd schemas && poetry build)
 
 schemas_deploy_pypi: schemas_install schemas_build
-	(cd schemas && twine upload --skip-existing dist/*)
+	(cd schemas && poetry config pypi-token.pypi ${TWINE_PASSWORD} && poetry publish --skip-existing --repository pypi)

--- a/Makefile
+++ b/Makefile
@@ -264,5 +264,5 @@ schemas_code_format:
 schemas_build:
 	(cd schemas && poetry build)
 
-schemas_deploy_pypi:
+schemas_deploy_pypi: schemas_install schemas_build
 	(cd schemas && poetry run twine upload --skip-existing dist/*)

--- a/Makefile
+++ b/Makefile
@@ -265,4 +265,4 @@ schemas_build:
 	(cd schemas && poetry build)
 
 schemas_deploy_pypi: schemas_install schemas_build
-	(cd schemas && poetry config pypi-token.pypi ${TWINE_PASSWORD} && poetry publish --skip-existing --repository pypi)
+	cd schemas && poetry run twine upload --skip-existing dist/* && cd ..

--- a/Makefile
+++ b/Makefile
@@ -265,4 +265,4 @@ schemas_build:
 	(cd schemas && poetry build)
 
 schemas_deploy_pypi: schemas_install schemas_build
-	(cd schemas && poetry run twine upload --skip-existing dist/*)
+	(cd schemas && twine upload --skip-existing dist/*)

--- a/schemas/pyproject.toml
+++ b/schemas/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "mozilla-nimbus-schemas"
-version = "2023.6.2"
+version = "2023.6.3"
 description = "Schemas used by Mozilla Nimbus and related projects."
 authors = ["mikewilli"]
 license = "MPL 2.0"


### PR DESCRIPTION
Because

- twine isn't installed until poetry installs dependencies
- `poetry build` doesn't install dependencies

This commit

- adds the `schemas_install` to the deploy's prereqs
