### PR TITLE
fix #8986 fix(schemas): update the make command to switch dirs properly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -265,6 +265,4 @@ schemas_build:
 	(cd schemas && poetry build)
 
 schemas_deploy_pypi: schemas_install schemas_build
-	cd schemas;
-	poetry run twine upload --skip-existing dist/*;
-	cd ..
+	cd schemas; poetry run twine upload --skip-existing dist/*;


### PR DESCRIPTION
Because

- the make command to deploy schemas uses the wrong syntax to change directories

This commit

- fixes the syntax in order to run the twine upload from the directory with the build is
