### PR TITLE
fix #8988 chore(schemas): bump schemas version for deploy

### DIFF
--- a/schemas/pyproject.toml
+++ b/schemas/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "mozilla-nimbus-schemas"
-version = "2023.6.3"
+version = "2023.6.4"
 description = "Schemas used by Mozilla Nimbus and related projects."
 authors = ["mikewilli"]
 license = "MPL 2.0"


### PR DESCRIPTION
Because

- schemas doesn't deploy without a version change

This commit

- updates the version so schemas will deploy
