### PR TITLE
fix #8997 chore(project): remove unused containers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -120,7 +120,9 @@ compose_rm:
 	$(COMPOSE_INTEGRATION) rm -f -v || true
 	$(COMPOSE_PROD) rm -f -v || true
 
-volumes_rm:
+docker_prune:
+	docker container prune -f
+	docker image prune -f
 	docker volume prune -f
 
 static_rm:
@@ -130,7 +132,7 @@ static_rm:
 	rm -Rf experimenter/experimenter/legacy/legacy-ui/assets/
 	rm -Rf experimenter/experimenter/nimbus-ui/build/
 
-kill: compose_stop compose_rm volumes_rm
+kill: compose_stop compose_rm docker_prune
 	echo "All containers removed!"
 
 check: build_test


### PR DESCRIPTION
Because

* Starting, stopping, and rebuilding docker containers can result in a growing number of old images, containers, and volumes
* Eventually this can fill the disk allocated to docker and prevent new containers from starting
* We have commands built into the Makefile for removing old and unused images and containers but it doesn't catch everything

This commit

* Updates the Makefile to remove more old and unused containers and images without impacting the build cache
