### PR TITLE
Add targeting needed for the Easy Setup pt.4 experiment

### DIFF
--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -236,7 +236,7 @@ FIRST_RUN_NEW_PROFILE_NEED_DEFAULT_WINDOWS_1903_PREFER_MOTION = NimbusTargetingC
     application_choice_names=(Application.DESKTOP.name,),
 )
 
-FIRST_RUN_NEED_DEFAULT_NEED_PIN_WINDOWS_1903 = NimbusTargetingConfig(
+FIRST_RUN_NEW_PROFILE_NEED_DEFAULT_NEED_PIN_WINDOWS_1903 = NimbusTargetingConfig(
     name=(
         "First start-up users on Windows 10 1903 (build 18362) or newer, with a "
         "new profile, needing default & pin"

--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -211,6 +211,33 @@ FIRST_RUN_NEW_PROFILE_NEED_DEFAULT_WINDOWS_1903 = NimbusTargetingConfig(
     application_choice_names=(Application.DESKTOP.name,),
 )
 
+FIRST_RUN_NEED_DEFAULT_NEED_PIN_WINDOWS_1903 = NimbusTargetingConfig(
+    name=(
+        "First start-up users on Windows 10 1903 (build 18362) or newer, with a "
+        "new profile, needing default & pin"
+    ),
+    slug="first_run_need_default_need_pin",
+    description=(
+        "First start-up users (e.g. for about:welcome) on Windows 1903+, "
+        "with a new profile, needing default & pin"
+    ),
+    targeting=(
+        "{first_run} && os.windowsBuildNumber >= 18362 && {new_profile} && "
+        "{need_default} && doesAppNeedPin".format(
+            first_run=FIRST_RUN.targeting,
+            new_profile=NEW_PROFILE,
+            need_default=NEED_DEFAULT,
+        )
+    ),
+    desktop_telemetry=(
+        "{first_run} AND environment.system.os.windows_build_number >= 18362 AND "
+        "!isDefaultBrowser AND doesAppNeedPin AND {new_profile}"
+    ).format(first_run=FIRST_RUN.desktop_telemetry, new_profile=NEW_PROFILE),
+    sticky_required=True,
+    is_first_run_required=False,
+    application_choice_names=(Application.DESKTOP.name,),
+)
+
 FIRST_RUN_NEW_PROFILE_NEED_DEFAULT_WINDOWS_1903_PREFER_MOTION = NimbusTargetingConfig(
     name=(
         "First start-up users on Windows 10 1903 needing default and no prefer "

--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -211,33 +211,6 @@ FIRST_RUN_NEW_PROFILE_NEED_DEFAULT_WINDOWS_1903 = NimbusTargetingConfig(
     application_choice_names=(Application.DESKTOP.name,),
 )
 
-FIRST_RUN_NEED_DEFAULT_NEED_PIN_WINDOWS_1903 = NimbusTargetingConfig(
-    name=(
-        "First start-up users on Windows 10 1903 (build 18362) or newer, with a "
-        "new profile, needing default & pin"
-    ),
-    slug="first_run_need_default_need_pin",
-    description=(
-        "First start-up users (e.g. for about:welcome) on Windows 1903+, "
-        "with a new profile, needing default & pin"
-    ),
-    targeting=(
-        "{first_run} && os.windowsBuildNumber >= 18362 && {new_profile} && "
-        "{need_default} && doesAppNeedPin".format(
-            first_run=FIRST_RUN.targeting,
-            new_profile=NEW_PROFILE,
-            need_default=NEED_DEFAULT,
-        )
-    ),
-    desktop_telemetry=(
-        "{first_run} AND environment.system.os.windows_build_number >= 18362 AND "
-        "!isDefaultBrowser AND doesAppNeedPin AND {new_profile}"
-    ).format(first_run=FIRST_RUN.desktop_telemetry, new_profile=NEW_PROFILE),
-    sticky_required=True,
-    is_first_run_required=False,
-    application_choice_names=(Application.DESKTOP.name,),
-)
-
 FIRST_RUN_NEW_PROFILE_NEED_DEFAULT_WINDOWS_1903_PREFER_MOTION = NimbusTargetingConfig(
     name=(
         "First start-up users on Windows 10 1903 needing default and no prefer "
@@ -258,6 +231,31 @@ FIRST_RUN_NEW_PROFILE_NEED_DEFAULT_WINDOWS_1903_PREFER_MOTION = NimbusTargetingC
             first_run=FIRST_RUN_NEW_PROFILE_NEED_DEFAULT_WINDOWS_1903.desktop_telemetry,
         )
     ).format(first_run=FIRST_RUN.desktop_telemetry),
+    sticky_required=True,
+    is_first_run_required=False,
+    application_choice_names=(Application.DESKTOP.name,),
+)
+
+FIRST_RUN_NEED_DEFAULT_NEED_PIN_WINDOWS_1903 = NimbusTargetingConfig(
+    name=(
+        "First start-up users on Windows 10 1903 (build 18362) or newer, with a "
+        "new profile, needing default & pin"
+    ),
+    slug="first_run_need_default_need_pin",
+    description=(
+        "First start-up users (e.g. for about:welcome) on Windows 1903+, "
+        "with a new profile, needing default & pin"
+    ),
+    targeting=(
+        "{first_run} && doesAppNeedPin".format(
+            first_run=FIRST_RUN_NEW_PROFILE_NEED_DEFAULT_WINDOWS_1903.targeting,
+        )
+    ),
+    desktop_telemetry=(
+        "{first_run} AND doesAppNeedPin".format(
+            first_run=FIRST_RUN_NEW_PROFILE_NEED_DEFAULT_WINDOWS_1903.desktop_telemetry,
+        )
+    ),
     sticky_required=True,
     is_first_run_required=False,
     application_choice_names=(Application.DESKTOP.name,),


### PR DESCRIPTION

This commit adds targeting for users that opt out of pinning Firefox during installation (or otherwise are not pinned), for use by the Easy setup pt.4 experiment.

First start-up users on Windows 10 1903 (build 18362) or newer, with a new profile, needing default needing pin 


