### PR TITLE
Fixes #8971 tests(nimbus): Happy path tests for first run proposed release date

### DIFF
--- a/docker-compose-integration-test.yml
+++ b/docker-compose-integration-test.yml
@@ -7,6 +7,7 @@ services:
     environment:
       - MOZ_HEADLESS
       - FIREFOX_VERSION
+      - PYTEST_ARGS
     volumes:
       - .:/code
       - /code/experimenter/tests/integration/.tox

--- a/experimenter/tests/integration/nimbus/pages/experimenter/audience.py
+++ b/experimenter/tests/integration/nimbus/pages/experimenter/audience.py
@@ -38,6 +38,9 @@ class AudiencePage(ExperimenterBase):
         "div[data-testid='languages'] > div:nth-child(1)",
     )
     _page_wait_locator = (By.CSS_SELECTOR, "#PageEditAudience")
+    _first_run_checkbox_locator = (By.CSS_SELECTOR, '[data-testid="isFirstRun"]')
+    _release_date_locator = (By.CSS_SELECTOR, '[data-testid="proposedReleaseDate"]')
+
     NEXT_PAGE = SummaryPage
 
     @property
@@ -131,3 +134,26 @@ class AudiencePage(ExperimenterBase):
         for _ in text:
             el.send_keys(f"{_}")
             el.send_keys(Keys.ENTER)
+
+    @property
+    def is_first_run(self):
+        return self.wait_for_and_find_element(
+            *self._first_run_checkbox_locator, "is first run"
+        )
+
+    def make_first_run(self):
+        self.wait_for_and_find_element(
+            *self._first_run_checkbox_locator, "is_first_run"
+        ).click()
+
+    @property
+    def proposed_release_date(self):
+        el = self.wait_for_and_find_element(*self._release_date_locator)
+        return el.get_attribute("value")
+
+    @proposed_release_date.setter
+    def proposed_release_date(self, text=None):
+        el = self.wait_for_and_find_element(*self._languages_input_locator)
+        for _ in text:
+            el.send_keys(f"{_}")
+            el.send_keys(Keys.TAB)

--- a/experimenter/tests/integration/nimbus/pages/experimenter/summary.py
+++ b/experimenter/tests/integration/nimbus/pages/experimenter/summary.py
@@ -80,6 +80,26 @@ class SummaryPage(ExperimenterBase):
         By.CSS_SELECTOR,
         'span[data-testid="conclusion-recommendation-status"]',
     )
+    _audience_section_locator = (
+        By.CSS_SELECTOR,
+        "#audience",
+    )
+    _audience_is_first_run_locator = (
+        By.CSS_SELECTOR,
+        '[data-testid="experiment-is-first-run"]',
+    )
+    _audience_proposed_release_date_locator = (
+        By.CSS_SELECTOR,
+        '[data-testid="experiment-release-date"]',
+    )
+    _timeline_locator = (
+        By.CSS_SELECTOR,
+        '[data-testid="summary-timeline"]',
+    )
+    _timeline_proposed_release_date_locator = (
+        By.CSS_SELECTOR,
+        '[data-testid="label-release-date"]',
+    )
 
     def wait_for_archive_label_visible(self):
         self.wait.until(
@@ -320,3 +340,36 @@ class SummaryPage(ExperimenterBase):
         return self.wait_for_and_find_elements(
             *self._branch_screenshot_image_locator, "branch screenshot image"
         )[0]
+
+    @property
+    def audience_table(self):
+        return self.wait_for_and_find_element(
+            *self._audience_section_locator, "audience table"
+        )
+
+    @property
+    def first_run(self):
+        return self.wait_for_and_find_elements(
+            *self._audience_is_first_run_locator, "audience table first run"
+        )[0].text
+
+    @property
+    def proposed_release_date(self):
+        return self.wait_for_and_find_elements(
+            *self._audience_proposed_release_date_locator,
+            "audience table proposed release date",
+        )[0].text
+
+    def wait_for_timeline_visible(self):
+        self.wait.until(
+            EC.presence_of_all_elements_located(self._timeline_locator),
+            message="Summary Page: could not find timeline",
+        )
+
+    def wait_for_release_date(self):
+        self.wait.until(
+            EC.presence_of_all_elements_located(
+                self._timeline_proposed_release_date_locator
+            ),
+            message="Summary Page: could not find release date on timeline",
+        )

--- a/experimenter/tests/integration/nimbus/test_desktop_client_integrations.py
+++ b/experimenter/tests/integration/nimbus/test_desktop_client_integrations.py
@@ -100,7 +100,7 @@ def test_check_telemetry_enrollment_unenrollment(
         "totalEnrolledClients": 55,
         "firefoxMinVersion": "FIREFOX_96",
     }
-    helpers.create_desktop_experiment(
+    helpers.create_experiment(
         experiment_slug,
         "desktop",
         targeting,
@@ -185,7 +185,7 @@ def test_check_telemetry_pref_flip(
         ],
     }
     experiment_default_data["treatmentBranches"] = []
-    helpers.create_desktop_experiment(
+    helpers.create_experiment(
         experiment_slug,
         "desktop",
         targeting,
@@ -280,7 +280,7 @@ def test_check_telemetry_sticky_targeting(
     }
     experiment_default_data["treatmentBranches"] = []
     experiment_default_data["isSticky"] = True
-    helpers.create_desktop_experiment(
+    helpers.create_experiment(
         experiment_slug,
         "desktop",
         targeting_config_slug,

--- a/experimenter/tests/integration/nimbus/test_desktop_targeting.py
+++ b/experimenter/tests/integration/nimbus/test_desktop_targeting.py
@@ -57,7 +57,7 @@ def test_check_advanced_targeting(
         "populationPercent": "100",
         "totalEnrolledClients": 55,
     }
-    helpers.create_desktop_experiment(
+    helpers.create_experiment(
         experiment_slug,
         "desktop",
         targeting_config_slug,
@@ -111,7 +111,7 @@ def test_check_audience_targeting(
 ):
     experiment_slug = str(slugify(experiment_name))
     experiment_default_data.update(audience_field)
-    helpers.create_desktop_experiment(
+    helpers.create_experiment(
         experiment_slug,
         "desktop",
         "no_targeting",

--- a/experimenter/tests/integration/nimbus/test_experimenter_ui.py
+++ b/experimenter/tests/integration/nimbus/test_experimenter_ui.py
@@ -111,14 +111,18 @@ def test_every_form_page_can_be_resaved(
 
 
 @pytest.mark.nimbus_ui
+@pytest.mark.skipif(
+    "FIREFOX_DESKTOP" in os.getenv("PYTEST_ARGS"),
+    reason="Only run for mobile applications",
+)
 def test_first_run_release_date(
     base_url,
     selenium,
     kinto_client,
     slugify,
     experiment_name,
+    application,
 ):
-    application = "FENIX"
     experiment_slug = str(slugify(experiment_name))
     targeting = helpers.load_targeting_configs(app=application)[0]
     data = {
@@ -169,6 +173,10 @@ def test_first_run_release_date(
 
 
 @pytest.mark.nimbus_ui
+@pytest.mark.skipif(
+    "FIREFOX_DESKTOP" in os.getenv("PYTEST_ARGS"),
+    reason="Only run for mobile applications",
+)
 def test_audience_page_release_date(
     base_url,
     selenium,
@@ -225,6 +233,10 @@ def test_audience_page_release_date(
 
 
 @pytest.mark.nimbus_ui
+@pytest.mark.skipif(
+    "FIREFOX_DESKTOP" in os.getenv("PYTEST_ARGS"),
+    reason="Only run for mobile applications",
+)
 def test_summary_timeline_release_date(
     base_url,
     selenium,

--- a/experimenter/tests/integration/nimbus/test_experimenter_ui.py
+++ b/experimenter/tests/integration/nimbus/test_experimenter_ui.py
@@ -1,9 +1,11 @@
 import os
+from urllib.parse import urljoin
 
 import pytest
 
 from nimbus.pages.experimenter.home import HomePage
 from nimbus.pages.experimenter.summary import SummaryPage
+from nimbus.utils import helpers
 
 
 @pytest.mark.nimbus_ui
@@ -106,3 +108,175 @@ def test_every_form_page_can_be_resaved(
     audience = metrics.save_and_continue()
     summary = audience.save_and_continue()
     assert summary.experiment_slug is not None
+
+
+@pytest.mark.nimbus_ui
+def test_first_run_release_date(
+    base_url,
+    selenium,
+    kinto_client,
+    slugify,
+    experiment_name,
+):
+    application = "FENIX"
+    experiment_slug = str(slugify(experiment_name))
+    targeting = helpers.load_targeting_configs(app=application)[0]
+    data = {
+        "hypothesis": "Test Hypothesis",
+        "application": application,
+        "changelogMessage": "test updates",
+        "targetingConfigSlug": targeting,
+        "publicDescription": "Some sort of Fancy Words",
+        "riskRevenue": False,
+        "riskPartnerRelated": False,
+        "riskBrand": False,
+        "featureConfigIds": [2],
+        "referenceBranch": {
+            "description": "reference branch",
+            "name": "Branch 1",
+            "ratio": 50,
+            "featureValues": [
+                {
+                    "featureConfig": "1",
+                    "value": "{}",
+                },
+            ],
+        },
+        "treatmentBranches": [],
+        "firefoxMinVersion": "FIREFOX_120",
+        "populationPercent": "100",
+        "totalEnrolledClients": 55,
+        "isFirstRun": True,
+        "proposedReleaseDate": "2023-12-12",
+    }
+    helpers.create_experiment(
+        experiment_slug,
+        app=application,
+        targeting=targeting,
+        data=data,
+    )
+
+    summary = SummaryPage(selenium, urljoin(base_url, experiment_slug)).open()
+    summary.launch_and_approve()
+
+    kinto_client.approve()
+
+    summary = SummaryPage(selenium, urljoin(base_url, experiment_slug)).open()
+    summary.wait_for_live_status()
+
+    assert summary.first_run
+    assert summary.proposed_release_date == "2023-12-12"
+
+
+@pytest.mark.nimbus_ui
+def test_audience_page_release_date(
+    base_url,
+    selenium,
+    slugify,
+    experiment_name,
+):
+    application = "FENIX"
+    experiment_slug = str(slugify(experiment_name))
+    targeting = helpers.load_targeting_configs(app=application)[0]
+    data = {
+        "hypothesis": "Test Hypothesis",
+        "application": application,
+        "changelogMessage": "test updates",
+        "targetingConfigSlug": targeting,
+        "publicDescription": "Some sort of Fancy Words",
+        "riskRevenue": False,
+        "riskPartnerRelated": False,
+        "riskBrand": False,
+        "featureConfigIds": [2],
+        "referenceBranch": {
+            "description": "reference branch",
+            "name": "Branch 1",
+            "ratio": 50,
+            "featureValues": [
+                {
+                    "featureConfig": "1",
+                    "value": "{}",
+                },
+            ],
+        },
+        "treatmentBranches": [],
+        "firefoxMinVersion": "FIREFOX_120",
+        "populationPercent": "100",
+        "totalEnrolledClients": 55,
+        "isFirstRun": True,
+        "proposedReleaseDate": "2023-12-12",
+    }
+    helpers.create_experiment(
+        experiment_slug,
+        app=application,
+        targeting=targeting,
+        data=data,
+    )
+    summary = SummaryPage(selenium, urljoin(base_url, experiment_slug)).open()
+
+    audience = summary.navigate_to_audience()
+    assert audience.is_first_run
+    assert audience.proposed_release_date == "2023-12-12"
+
+    audience.make_first_run()
+    summary = audience.save_and_continue()
+
+    assert summary.proposed_release_date == "Not set"
+
+
+@pytest.mark.nimbus_ui
+def test_summary_timeline_release_date(
+    base_url,
+    selenium,
+    kinto_client,
+    slugify,
+    experiment_name,
+):
+    application = "FENIX"
+    experiment_slug = str(slugify(experiment_name))
+    targeting = helpers.load_targeting_configs(app=application)[0]
+    data = {
+        "hypothesis": "Test Hypothesis",
+        "application": application,
+        "changelogMessage": "test updates",
+        "targetingConfigSlug": targeting,
+        "publicDescription": "Some sort of Fancy Words",
+        "riskRevenue": False,
+        "riskPartnerRelated": False,
+        "riskBrand": False,
+        "featureConfigIds": [2],
+        "referenceBranch": {
+            "description": "reference branch",
+            "name": "Branch 1",
+            "ratio": 50,
+            "featureValues": [
+                {
+                    "featureConfig": "1",
+                    "value": "{}",
+                },
+            ],
+        },
+        "treatmentBranches": [],
+        "firefoxMinVersion": "FIREFOX_120",
+        "populationPercent": "100",
+        "totalEnrolledClients": 55,
+        "isFirstRun": True,
+        "proposedReleaseDate": "2023-12-12",
+    }
+    helpers.create_experiment(
+        experiment_slug,
+        app=application,
+        targeting=targeting,
+        data=data,
+    )
+
+    summary = SummaryPage(selenium, urljoin(base_url, experiment_slug)).open()
+    summary.launch_and_approve()
+
+    kinto_client.approve()
+
+    summary = SummaryPage(selenium, urljoin(base_url, experiment_slug)).open()
+    summary.wait_for_live_status()
+
+    summary.wait_for_timeline_visible()
+    summary.wait_for_release_date()

--- a/experimenter/tests/integration/nimbus/utils/helpers.py
+++ b/experimenter/tests/integration/nimbus/utils/helpers.py
@@ -189,7 +189,7 @@ def create_basic_experiment(name, app, targeting, languages=[]):
     )
 
 
-def create_desktop_experiment(slug, app, targeting, data):
+def create_experiment(slug, app, targeting, data):
     # create a basic experiment via graphql so we can get an ID
     create_basic_experiment(
         slug,


### PR DESCRIPTION
Because

- We want to test the happy paths for the first run proposed release date field

This commit

- Create a new test file for mobile first run: `test_mobile_first_run.py`
- Tests the following:
   - A first run fenix experiment is launched with `isFirstRun` = true and a valid value for `proposedReleaseDate`, and these values show up on the Summary page
   - A first run fenix experiment is created; the audience page shows `isFirstRun` = true and a valid value for `proposedReleaseDate`; toggle `isFirstRun` to false on Audience; and the Summary page shows "Not set" for `proposedReleaseDate`
   - A first run fenix experiment is launched with `isFirstRun` = true and a valid value for `proposedReleaseDate`, and the release date is visible on the Summary page timeline

This commit _does not_:
- Test the non-happy paths. That will be in a separate PR 👍 (https://mozilla-hub.atlassian.net/browse/EXP-3636)
