### PR TITLE
feat(nimbus): Print graphql exceptions in debug mode

### DIFF
--- a/experimenter/experimenter/base/graphene.py
+++ b/experimenter/experimenter/base/graphene.py
@@ -1,0 +1,17 @@
+import traceback  # pragma: no cover
+
+
+class GrapheneExceptionMiddleware:  # pragma: no cover
+    """Print exceptions to the console instead of swallowing them.
+
+    The default behaviour for graphene-django when an exception occurs is to
+    produce an error page with the exception message. This middleware will also
+    log the traceback from the exception to the console to aid in debugging.
+    """
+
+    def resolve(self, next_middleware, root, info, **kwargs):
+        try:
+            return next_middleware(root, info, **kwargs)
+        except Exception:
+            traceback.print_exc()
+            raise

--- a/experimenter/experimenter/settings.py
+++ b/experimenter/experimenter/settings.py
@@ -164,6 +164,11 @@ DATABASES = {
 # Graphene Schema
 GRAPHENE = {"SCHEMA": "experimenter.experiments.api.v5.schema"}
 
+if DEBUG:  # pragma: no cover
+    GRAPHENE["MIDDLEWARE"] = [
+        "experimenter.base.graphene.GrapheneExceptionMiddleware",
+    ]
+
 
 # Password validation
 # https://docs.djangoproject.com/en/1.9/ref/settings/#auth-password-validators


### PR DESCRIPTION
Because:
- graphene-django swallows exceptions that occur during queries

this commit:
- adds a middleware in DEBUG mode that logs tracebacks from these exceptions to the console.
