### PR TITLE
fix #9048 feat(schemas): update AnalysisBasis enum to use conventiona…

### DIFF
--- a/schemas/mozilla_nimbus_schemas/jetstream/statistics.py
+++ b/schemas/mozilla_nimbus_schemas/jetstream/statistics.py
@@ -7,8 +7,8 @@ SCHEMA_VERSION = 4
 
 
 class AnalysisBasis(str, Enum):
-    enrollments = "enrollments"
-    exposures = "exposures"
+    ENROLLMENTS = "enrollments"
+    EXPOSURES = "exposures"
 
 
 class Statistic(BaseModel):

--- a/schemas/mozilla_nimbus_schemas/tests/jetstream/test_analysis_errors.py
+++ b/schemas/mozilla_nimbus_schemas/tests/jetstream/test_analysis_errors.py
@@ -15,7 +15,7 @@ Test cases for analysis errors schemas:
 
 def test_analysis_errors():
     ae0 = AnalysisError(
-        analysis_basis=AnalysisBasis.enrollments,
+        analysis_basis=AnalysisBasis.ENROLLMENTS,
         exception="(<class 'errors.TestException'>, TestException('err')",
         exception_type="EnrollmentNotCompleteException",
         experiment="test-experiment-slug",
@@ -29,7 +29,7 @@ def test_analysis_errors():
         timestamp="2023-05-17T06:42:31+00:00",
     )
     ae1 = AnalysisError(
-        analysis_basis=AnalysisBasis.exposures,
+        analysis_basis=AnalysisBasis.EXPOSURES,
         exception="(<class 'errors.TestException'>, TestException('err')",
         exception_type="EnrollmentNotCompleteException",
         experiment="test-experiment-slug",

--- a/schemas/mozilla_nimbus_schemas/tests/jetstream/test_statistics.py
+++ b/schemas/mozilla_nimbus_schemas/tests/jetstream/test_statistics.py
@@ -15,7 +15,7 @@ def test_statistics():
         point=1.0,
         lower=0.2,
         upper=1.2,
-        analysis_basis=AnalysisBasis.enrollments,
+        analysis_basis=AnalysisBasis.ENROLLMENTS,
         window_index="1",
     )
     s1 = Statistic(
@@ -26,7 +26,7 @@ def test_statistics():
         point=1.0,
         lower=0.2,
         upper=1.2,
-        analysis_basis=AnalysisBasis.enrollments,
+        analysis_basis=AnalysisBasis.ENROLLMENTS,
         window_index="1",
     )
     s2 = Statistic(
@@ -37,7 +37,7 @@ def test_statistics():
         point=1.0,
         lower=0.2,
         upper=1.2,
-        analysis_basis=AnalysisBasis.enrollments,
+        analysis_basis=AnalysisBasis.ENROLLMENTS,
         window_index="1",
     )
 

--- a/schemas/pyproject.toml
+++ b/schemas/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "mozilla-nimbus-schemas"
-version = "2023.6.5"
+version = "2023.6.6"
 description = "Schemas used by Mozilla Nimbus and related projects."
 authors = ["mikewilli"]
 license = "MPL 2.0"


### PR DESCRIPTION
…l member naming

Because

- other code using the soon-to-be-replaced schemas has AnalysisBasis enums with ALL CAPS members
- ALL CAPS is convention for enum members

This commit

- changes the new schemas package to use this convention
