### PR TITLE
fixes #8886 feat(nimbus):change adds fontawesome support to the project

### DIFF
--- a/experimenter/experimenter/settings.py
+++ b/experimenter/experimenter/settings.py
@@ -101,6 +101,8 @@ INSTALLED_APPS = [
     "experimenter.outcomes",
     "experimenter.projects",
     "experimenter.reporting",
+    # fontawesome
+    "fontawesomefree",
 ]
 
 MIDDLEWARE = [

--- a/experimenter/experimenter/templates/changelog/overview.html
+++ b/experimenter/experimenter/templates/changelog/overview.html
@@ -10,8 +10,8 @@
     {% for changelog in experiment.get_changelogs %}
     <div>
         <h2>{{ changelog.changed_on }}</h2>
-        <p>Change made: {{ changelog.message }}</p>  
-        <p>Changed by: {{ changelog.changed_by }}</p>
+        <p><i class="fa-regular fa-pen-to-square"></i> : {{ changelog.message }}</p>  
+        <p><i class="fa-regular fa-user"></i> : {{ changelog.changed_by }}</p>
     </div>
   {% endfor %}
 {% endblock %}

--- a/experimenter/experimenter/templates/experimenter_base.html
+++ b/experimenter/experimenter/templates/experimenter_base.html
@@ -1,3 +1,5 @@
+{% load static %}
+
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -5,6 +7,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{% block title %}{% endblock %}</title>
+    <script src="{% static 'fontawesomefree/js/all.min.js' %}"></script>
 </head>
 <body>
     {% block content %}

--- a/experimenter/poetry.lock
+++ b/experimenter/poetry.lock
@@ -808,6 +808,16 @@ files = [
 python-dateutil = ">=2.4"
 
 [[package]]
+name = "fontawesomefree"
+version = "6.4.0"
+description = "Font Awesome Free"
+optional = false
+python-versions = "*"
+files = [
+    {file = "fontawesomefree-6.4.0-py3-none-any.whl", hash = "sha256:e12edad71b6cf6993fc7c6aea6367e131f2f247b6435faca99b12329bacd2b27"},
+]
+
+[[package]]
 name = "future"
 version = "0.18.3"
 description = "Clean single-source support for Python 3 and 2"
@@ -2682,4 +2692,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "b5ff5bb9a292d5bd088fe1edb729325a75af063ac5a2db0123ef2103b7359670"
+content-hash = "a40679c1357ac70b571d09315e04ae776f7329431ef018277acd5881360ce3c3"

--- a/experimenter/pyproject.toml
+++ b/experimenter/pyproject.toml
@@ -68,6 +68,7 @@ ruff = "^0.0.239"
 mozilla-nimbus-shared = "^2.4.0"
 mozilla-nimbus-schemas = "^2023.6.5"
 django-redis = "^5.3.0"
+fontawesomefree = "6.4.0"
 
 [tool.poetry.dev-dependencies]
 rope = "^0.23.0"


### PR DESCRIPTION
Because

- the new 'history' page implementation requires this dependency

This commit

- adds fontawesome 6.4.0 to the project

**Screenshot**

![image](https://github.com/mozilla/experimenter/assets/79744258/02bfaeb4-ba9c-4a7c-95f5-6cc9db99dcf8)
