### PR TITLE
fix #9063 bug(nimbus): add missing sizing metric to enum

### DIFF
--- a/experimenter/experimenter/jetstream/models.py
+++ b/experimenter/experimenter/jetstream/models.py
@@ -344,6 +344,7 @@ class SizingMetricName(str, Enum):
     ACTIVE_HOURS = "active_hours"
     SEARCH_COUNT = "search_count"
     DAYS_OF_USE = "days_of_use"
+    TAGGED_SEARCH_COUNT = "tagged_search_count"
 
 
 class SizingReleaseChannel(str, Enum):

--- a/experimenter/experimenter/jetstream/tests/test_tasks.py
+++ b/experimenter/experimenter/jetstream/tests/test_tasks.py
@@ -1177,7 +1177,7 @@ class TestFetchJetstreamDataTask(TestCase):
                                         "sample_size_per_branch": 100000.0,
                                         "population_percent_per_branch": 1000.0
                                     },
-                                    "search_count": {
+                                    "tagged_search_count": {
                                         "number_of_clients_targeted": 10000,
                                         "sample_size_per_branch": 100.0,
                                         "population_percent_per_branch": 1.0


### PR DESCRIPTION
Because

- one of the sizing targets has a different metric

This commit

- adds the missing metrics to the sizing metrics enum schema
