### PR TITLE
fix #9082 bug(nimbus): validate no floats in feature values

### DIFF
--- a/experimenter/experimenter/experiments/api/v5/serializers.py
+++ b/experimenter/experimenter/experiments/api/v5/serializers.py
@@ -1169,11 +1169,28 @@ class NimbusBranchFeatureValueReviewSerializer(NimbusBranchFeatureValueSerialize
         list_serializer_class = NimbusBranchFeatureValueListSerializer
 
     def validate_value(self, value):
+        data = None
         if value:
             try:
-                json.loads(value)
+                data = json.loads(value)
             except Exception as e:
                 raise serializers.ValidationError(f"Invalid JSON: {e.msg}") from e
+
+        def throw_on_float(item):
+            if isinstance(item, (list, tuple)):
+                for i in item:
+                    throw_on_float(i)
+            elif isinstance(item, dict):
+                for i in item.values():
+                    throw_on_float(i)
+            elif isinstance(item, float):
+                raise serializers.ValidationError(
+                    NimbusExperiment.ERROR_NO_FLOATS_IN_FEATURE_VALUE
+                )
+
+        if data is not None:
+            throw_on_float(data)
+
         return value
 
 

--- a/experimenter/experimenter/experiments/constants.py
+++ b/experimenter/experimenter/experiments/constants.py
@@ -449,6 +449,10 @@ Optional - We believe this outcome will <describe impact> on <core metric>
         "Are you missing your first run targeting?"
     )
 
+    ERROR_NO_FLOATS_IN_FEATURE_VALUE = (
+        "Feature values can not contain floats (ie numbers with decimal points)."
+    )
+
     # Analysis can be computed starting the week after enrollment
     # completion for "week 1" of the experiment. However, an extra
     # buffer day is added for Jetstream to compute the results.


### PR DESCRIPTION
Because

* We recently discovered that kinto does not support float values in json objects
* This is causing the preview sync task on stage to get stuck
* Luckily we have not seen it in production

This commit

* Adds a validation step to ensure there are no floats in any feature values before launching

