### PR TITLE
fix #9043 feat(nimbus): Add inclusion and exclusion targeting UI

### DIFF
--- a/experimenter/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/mocks.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/mocks.tsx
@@ -9,24 +9,34 @@ import {
   mockExperimentQuery,
   mockLiveRolloutQuery,
   MOCK_CONFIG,
+  MOCK_EXPERIMENTS_BY_APPLICATION,
 } from "src/lib/mocks";
+import { getAllExperimentsByApplication_experimentsByApplication } from "src/types/getAllExperimentsByApplication";
 import { getConfig_nimbusConfig } from "src/types/getConfig";
+import { NimbusExperimentApplicationEnum } from "src/types/globalTypes";
 
 export const Subject = ({
   config = MOCK_CONFIG,
   experiment = MOCK_EXPERIMENT,
+  experimentsByApplication,
   submitErrors = {},
   isLoading = false,
   isServerValid = true,
   onSubmit = () => {},
 }: {
   config?: getConfig_nimbusConfig;
+  experimentsByApplication?: Partial<{
+    allExperiments?: typeof MOCK_EXPERIMENTS_BY_APPLICATION;
+    application?: NimbusExperimentApplicationEnum;
+  }>;
+  allExperimentMeta?: getAllExperimentsByApplication_experimentsByApplication[];
+  allExperimentMetaApplication?: NimbusExperimentApplicationEnum;
 } & Partial<React.ComponentProps<typeof FormAudience>>) => {
   const [submitErrorsDefault, setSubmitErrors] =
     useState<SerializerMessages>(submitErrors);
   return (
     <div className="p-5">
-      <MockedCache {...{ config }}>
+      <MockedCache {...{ config, experimentsByApplication }}>
         <FormAudience
           submitErrors={submitErrorsDefault}
           {...{

--- a/experimenter/experimenter/nimbus-ui/src/components/PageEditAudience/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageEditAudience/index.tsx
@@ -46,6 +46,8 @@ const PageEditAudience: React.FunctionComponent<RouteComponentProps> = () => {
         languages,
         isSticky,
         isFirstRun,
+        requiredExperiments,
+        excludedExperiments,
       }: Record<string, any>,
       next: boolean,
     ) => {
@@ -74,6 +76,8 @@ const PageEditAudience: React.FunctionComponent<RouteComponentProps> = () => {
               languages,
               isSticky,
               isFirstRun,
+              requiredExperiments,
+              excludedExperiments,
             },
           },
         });

--- a/experimenter/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/index.tsx
@@ -49,7 +49,6 @@ type FormBranchesProps = {
     next: boolean,
   ) => void;
 };
-
 export const FormBranches = ({
   isLoading,
   experiment,

--- a/experimenter/experimenter/nimbus-ui/src/components/Summary/TableAudience/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/Summary/TableAudience/index.tsx
@@ -10,7 +10,10 @@ import { displayConfigLabelOrNotSet } from "src/components/Summary";
 import { useConfig } from "src/hooks";
 import { ReactComponent as CollapseMinus } from "src/images/minus.svg";
 import { ReactComponent as ExpandPlus } from "src/images/plus.svg";
-import { getExperiment_experimentBySlug } from "src/types/getExperiment";
+import {
+  getExperiment_experimentBySlug,
+  getExperiment_experimentBySlug_excludedExperiments,
+} from "src/types/getExperiment";
 import { NimbusExperimentApplicationEnum } from "src/types/globalTypes";
 
 type TableAudienceProps = {
@@ -160,6 +163,16 @@ const TableAudience = ({ experiment }: TableAudienceProps) => {
                 </td>
               </tr>
             )}
+            <tr>
+              <th>Required Experiments</th>
+              <td>
+                <ExperimentList experiments={experiment.requiredExperiments} />
+              </td>
+              <th>Excluded Experiments</th>
+              <td>
+                <ExperimentList experiments={experiment.excludedExperiments} />
+              </td>
+            </tr>
 
             {experiment.jexlTargetingExpression &&
             experiment.jexlTargetingExpression !== "" ? (
@@ -229,5 +242,24 @@ const TableAudience = ({ experiment }: TableAudienceProps) => {
     </Card>
   );
 };
+
+interface ExperimentListProps {
+  experiments: getExperiment_experimentBySlug_excludedExperiments[];
+}
+function ExperimentList({ experiments }: ExperimentListProps) {
+  if (experiments.length === 0) {
+    return <span>None</span>;
+  }
+
+  return (
+    <>
+      {experiments.map((experiment) => (
+        <p key={experiment.slug}>
+          <a href={`/nimbus/${experiment.slug}/summary`}>{experiment.name}</a>
+        </p>
+      ))}
+    </>
+  );
+}
 
 export default TableAudience;

--- a/experimenter/experimenter/nimbus-ui/src/components/Summary/index.test.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/Summary/index.test.tsx
@@ -12,7 +12,12 @@ import {
 import React from "react";
 import { createMutationMock, Subject } from "src/components/Summary/mocks";
 import { CHANGELOG_MESSAGES, SUBMIT_ERROR } from "src/lib/constants";
-import { mockExperimentQuery, mockLiveRolloutQuery } from "src/lib/mocks";
+import {
+  mockExperimentQuery,
+  mockLiveRolloutQuery,
+  MOCK_EXPERIMENT,
+  MOCK_EXPERIMENTS_BY_APPLICATION,
+} from "src/lib/mocks";
 import {
   NimbusExperimentPublishStatusEnum,
   NimbusExperimentStatusEnum,
@@ -691,5 +696,17 @@ describe("Summary", () => {
         expect(requestUpdateButton).toBeDisabled();
       });
     });
+  });
+
+  it("render the required and excluded experiments", () => {
+    const experiment = {
+      ...MOCK_EXPERIMENT,
+      requiredExperiments: [MOCK_EXPERIMENTS_BY_APPLICATION[1]],
+      excludedExperiments: [MOCK_EXPERIMENTS_BY_APPLICATION[2]],
+    };
+    render(<Subject props={experiment} />);
+
+    screen.getByRole("link", { name: MOCK_EXPERIMENTS_BY_APPLICATION[1].name });
+    screen.getByRole("link", { name: MOCK_EXPERIMENTS_BY_APPLICATION[2].name });
   });
 });

--- a/experimenter/experimenter/nimbus-ui/src/gql/experiments.ts
+++ b/experimenter/experimenter/nimbus-ui/src/gql/experiments.ts
@@ -128,6 +128,16 @@ export const GET_EXPERIMENT_QUERY = gql`
       }
       isSticky
       isFirstRun
+      excludedExperiments {
+        id
+        slug
+        name
+      }
+      requiredExperiments {
+        id
+        slug
+        name
+      }
       jexlTargetingExpression
 
       populationPercent
@@ -271,6 +281,19 @@ export const GET_EXPERIMENTS_QUERY = gql`
         name
       }
       hypothesis
+    }
+  }
+`;
+
+export const GET_ALL_EXPERIMENTS_BY_APPLICATION_QUERY = gql`
+  query getAllExperimentsByApplication(
+    $application: NimbusExperimentApplicationEnum!
+  ) {
+    experimentsByApplication(application: $application) {
+      id
+      name
+      slug
+      publicDescription
     }
   }
 `;

--- a/experimenter/experimenter/nimbus-ui/src/hooks/useCommonForm/index.test.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/hooks/useCommonForm/index.test.tsx
@@ -153,9 +153,13 @@ describe("hooks/useCommonForm", () => {
       render(<AudienceSubject />);
       const filteredAudienceFieldNames = audienceFieldNames.filter(
         (e) =>
-          e !== "languages" &&
-          e !== "isFirstRun" &&
-          e !== "proposedReleaseDate",
+          ![
+            "languages",
+            "isFirstRun",
+            "proposedReleaseDate",
+            "requiredExperiments",
+            "excludedExperiments",
+          ].includes(e),
       );
       filteredAudienceFieldNames.forEach((name) => {
         expect(screen.queryByTestId(`${name}-form-errors`)).toBeInTheDocument();

--- a/experimenter/experimenter/nimbus-ui/src/hooks/useReviewCheck.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/hooks/useReviewCheck.tsx
@@ -35,6 +35,8 @@ const fieldPageMap: { [page: string]: string[] } = {
     "proposed_duration",
     "population_percent",
     "total_enrolled_clients",
+    "required_experiments",
+    "excluded_experiments",
   ],
 };
 

--- a/experimenter/experimenter/nimbus-ui/src/styles/index.scss
+++ b/experimenter/experimenter/nimbus-ui/src/styles/index.scss
@@ -204,3 +204,6 @@ select.form-control.is-warning {
     border-color: $red;
   }
 }
+.required-excluded-experiment-slug {
+  font-family: monospace;
+}

--- a/experimenter/experimenter/nimbus-ui/src/types/getAllExperimentsByApplication.ts
+++ b/experimenter/experimenter/nimbus-ui/src/types/getAllExperimentsByApplication.ts
@@ -1,0 +1,28 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+import { NimbusExperimentApplicationEnum } from "./globalTypes";
+
+// ====================================================
+// GraphQL query operation: getAllExperimentsByApplication
+// ====================================================
+
+export interface getAllExperimentsByApplication_experimentsByApplication {
+  id: number;
+  name: string;
+  slug: string;
+  publicDescription: string | null;
+}
+
+export interface getAllExperimentsByApplication {
+  /**
+   * List Nimbus Experiments by application.
+   */
+  experimentsByApplication: getAllExperimentsByApplication_experimentsByApplication[];
+}
+
+export interface getAllExperimentsByApplicationVariables {
+  application: NimbusExperimentApplicationEnum;
+}

--- a/experimenter/experimenter/nimbus-ui/src/types/getExperiment.ts
+++ b/experimenter/experimenter/nimbus-ui/src/types/getExperiment.ts
@@ -88,6 +88,18 @@ export interface getExperiment_experimentBySlug_targetingConfig {
   isFirstRunRequired: boolean | null;
 }
 
+export interface getExperiment_experimentBySlug_excludedExperiments {
+  id: number;
+  slug: string;
+  name: string;
+}
+
+export interface getExperiment_experimentBySlug_requiredExperiments {
+  id: number;
+  slug: string;
+  name: string;
+}
+
 export interface getExperiment_experimentBySlug_readyForReview {
   ready: boolean | null;
   message: ObjectField | null;
@@ -192,6 +204,8 @@ export interface getExperiment_experimentBySlug {
   targetingConfig: (getExperiment_experimentBySlug_targetingConfig | null)[] | null;
   isSticky: boolean | null;
   isFirstRun: boolean;
+  excludedExperiments: getExperiment_experimentBySlug_excludedExperiments[];
+  requiredExperiments: getExperiment_experimentBySlug_requiredExperiments[];
   jexlTargetingExpression: string | null;
   populationPercent: string | null;
   totalEnrolledClients: number;


### PR DESCRIPTION
Because:
- we want to target against past and present enrollments in other
  experiments and rollouts

this commit:
- adds UI to select multiple experiments to include and exclude in the
  generated targeting expression.