### PR TITLE
fix #9112 chore(cirrus): reduce cirrus deploy image size

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -225,6 +225,9 @@ cirrus_build:
 cirrus_build_test:
 	$(COMPOSE_TEST) build cirrus
 
+cirrus_build_prod:
+	DOCKER_BUILDKIT=1 docker build --target deploy -f cirrus/server/Dockerfile -t cirrus:deploy --build-arg BUILDKIT_INLINE_CACHE=1 cirrus/server/
+
 cirrus_up: cirrus_build
 	$(COMPOSE) up cirrus
 

--- a/cirrus/server/Dockerfile
+++ b/cirrus/server/Dockerfile
@@ -1,4 +1,5 @@
-FROM rust:buster AS builder
+# First stage: Build the Rust components
+FROM rust:buster AS rust-builder
 
 ARG as_version
 
@@ -30,20 +31,11 @@ RUN cargo build --manifest-path megazords/cirrus/Cargo.toml --release
 RUN cargo uniffi-bindgen generate components/nimbus/src/cirrus.udl --language python
 RUN cargo uniffi-bindgen generate components/support/nimbus-fml/src/fml.udl --language python
 
-# Use official Python runtime as a parent image
-FROM python:3.11.2-slim-buster
+# Second stage: Build Python environment with dependencies
+FROM python:3.11.2-slim-buster as python-builder
 
 # Set working directory for the container
 WORKDIR /cirrus
-
-# cirrus
-COPY --from=builder /application-services/components/nimbus/src/cirrus.py /application-services/cirrus_sdk.py
-# megazord
-COPY --from=builder /application-services/target/release/libcirrus.so /application-services/libcirrus.so
-# fml
-COPY --from=builder /application-services/components/support/nimbus-fml/src/fml.py /application-services/fml_sdk.py
-
-ENV PYTHONPATH=$PYTHONPATH:/application-services
 
 # Install curl and bash utilities
 RUN apt-get update && \
@@ -63,10 +55,25 @@ ENV PATH "/root/.local/bin:$PATH"
 COPY pyproject.toml /cirrus/
 COPY poetry.lock /cirrus/
 
-
 # Configure poetry and install dependencies
 RUN poetry config virtualenvs.create false && \
     poetry install --only=main --no-interaction --no-ansi
+
+# Third stage: Deploy stage
+FROM python:3.11.2-slim-buster as deploy
+
+WORKDIR /cirrus
+
+# Copy specific Rust components
+COPY --from=rust-builder /application-services/components/nimbus/src/cirrus.py /application-services/cirrus_sdk.py
+COPY --from=rust-builder /application-services/target/release/libcirrus.so /application-services/libcirrus.so
+COPY --from=rust-builder /application-services/components/support/nimbus-fml/src/fml.py /application-services/fml_sdk.py
+
+# Copy Python site packages and scripts
+COPY --from=python-builder /usr/local/lib/python3.11/site-packages /usr/local/lib/python3.11/site-packages
+COPY --from=python-builder /usr/local/bin /usr/local/bin
+
+ENV PYTHONPATH=$PYTHONPATH:/application-services
 
 # Copy all other files into the container's working directory
 COPY . .


### PR DESCRIPTION
Because

* Smaller docker images are easier to deploy
* The current cirrus docker image is 2gb

This commit

* Splits the cirrus docker file into three layers, one for building rust components, one for building python packages, and a third that copies them into a deploy container


