### PR TITLE
fix #9119 feat(nimbus): Update minimum version warning to new version and add warning to mobile apps

### DIFF
--- a/experimenter/experimenter/experiments/api/v5/serializers.py
+++ b/experimenter/experimenter/experiments/api/v5/serializers.py
@@ -1482,17 +1482,20 @@ class NimbusReviewSerializer(serializers.ModelSerializer):
                 }
             )
 
-        if (
-            application == NimbusExperiment.Application.DESKTOP
-            and is_rollout
-            and parsed_min_version
-            < NimbusExperiment.Version.parse(
-                NimbusConstants.DESKTOP_ROLLOUT_MIN_SUPPORTED_VERSION
+        rollout_live_resize_min_app_version = (
+            NimbusConstants.ROLLOUT_LIVE_RESIZE_MIN_SUPPORTED_VERSION.get(application)
+        )
+        if rollout_live_resize_min_app_version:
+            parsed_min_app_version = NimbusExperiment.Version.parse(
+                rollout_live_resize_min_app_version
             )
-        ):
-            self.warnings["firefox_min_version"] = [
-                NimbusConstants.ERROR_DESKTOP_ROLLOUT_VERSION
-            ]
+            if is_rollout and parsed_min_version < parsed_min_app_version:
+                self.warnings["firefox_min_version"] = [
+                    NimbusConstants.ERROR_ROLLOUT_VERSION.format(
+                        application=NimbusExperiment.Application(application).label,
+                        version=parsed_min_app_version,
+                    )
+                ]
 
         excluded_experiments = data.get("excluded_experiments")
         required_experiments = data.get("required_experiments")

--- a/experimenter/experimenter/experiments/constants.py
+++ b/experimenter/experimenter/experiments/constants.py
@@ -371,7 +371,13 @@ class NimbusConstants(object):
     }
 
     FEATURE_ENABLED_MIN_UNSUPPORTED_VERSION = Version.FIREFOX_104
-    DESKTOP_ROLLOUT_MIN_SUPPORTED_VERSION = Version.FIREFOX_114
+    ROLLOUT_LIVE_RESIZE_MIN_SUPPORTED_VERSION = {
+        Application.DESKTOP: Version.FIREFOX_115,
+        Application.FENIX: Version.FIREFOX_116,
+        Application.FOCUS_ANDROID: Version.FIREFOX_116,
+        Application.IOS: Version.FIREFOX_116,
+        Application.FOCUS_IOS: Version.FIREFOX_116,
+    }
 
     ROLLOUT_SUPPORT_VERSION = {
         Application.DESKTOP: Version.FIREFOX_105,
@@ -437,9 +443,10 @@ Optional - We believe this outcome will <describe impact> on <core metric>
         will be enrolled in one and not the other and \
         you will not be able to adjust the sizing for this rollout."
 
-    ERROR_DESKTOP_ROLLOUT_VERSION = "WARNING: Decreasing the population size while the \
-        rollout is live is not supported for Desktop versions under 114. You will still \
-        be able to increase the population size."
+    ERROR_ROLLOUT_VERSION = (
+        "WARNING: Adjusting the population size while the"
+        "rollout is live is not supported for {application} versions under {version}."
+    )
 
     ERROR_DESKTOP_LOCALIZATION_VERSION = (
         "Firefox version must be at least 113 for localized experiments."

--- a/experimenter/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_ready_for_review_serializer.py
+++ b/experimenter/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_ready_for_review_serializer.py
@@ -232,10 +232,20 @@ class TestNimbusReviewSerializerSingleFeature(TestCase):
             },
         )
 
-    def test_desktop_min_version_under_113_shows_warning(self):
+    @parameterized.expand(
+        [
+            NimbusExperiment.Application.DESKTOP,
+            NimbusExperiment.Application.FENIX,
+            NimbusExperiment.Application.FOCUS_ANDROID,
+            NimbusExperiment.Application.IOS,
+            NimbusExperiment.Application.FOCUS_IOS,
+        ]
+    )
+    def test_rollout_min_version_under_115_shows_warning(self, application):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.CREATED,
-            firefox_min_version=NimbusExperiment.Version.FIREFOX_106,
+            firefox_min_version=NimbusExperiment.Version.FIREFOX_114,
+            application=application,
             is_rollout=True,
             is_sticky=True,
         )
@@ -254,15 +264,30 @@ class TestNimbusReviewSerializerSingleFeature(TestCase):
         self.assertEqual(
             serializer.warnings,
             {
-                "firefox_min_version": [NimbusExperiment.ERROR_DESKTOP_ROLLOUT_VERSION],
+                "firefox_min_version": [
+                    NimbusExperiment.ERROR_ROLLOUT_VERSION.format(
+                        application=NimbusExperiment.Application(application).label,
+                        version=NimbusExperiment.Version.parse(
+                            NimbusConstants.ROLLOUT_LIVE_RESIZE_MIN_SUPPORTED_VERSION[
+                                application
+                            ]
+                        ),
+                    )
+                ],
             },
         )
 
-    def test_desktop_min_version_over_113_no_warning(self):
+    @parameterized.expand(
+        [
+            NimbusExperiment.Application.KLAR_IOS,
+            NimbusExperiment.Application.KLAR_IOS,
+        ]
+    )
+    def test_rollout_klar_min_version_under_115_no_warning(self, application):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.CREATED,
-            application=NimbusExperiment.Application.DESKTOP,
-            firefox_min_version=NimbusExperiment.Version.FIREFOX_118,
+            application=application,
+            firefox_min_version=NimbusExperiment.Version.FIREFOX_106,
             is_rollout=True,
             is_sticky=True,
         )
@@ -280,11 +305,20 @@ class TestNimbusReviewSerializerSingleFeature(TestCase):
         self.assertTrue(serializer.is_valid())
         self.assertEqual(serializer.warnings, {})
 
-    def test_mobile_min_version_under_113_no_warning(self):
+    @parameterized.expand(
+        [
+            NimbusExperiment.Application.DESKTOP,
+            NimbusExperiment.Application.FENIX,
+            NimbusExperiment.Application.FOCUS_ANDROID,
+            NimbusExperiment.Application.IOS,
+            NimbusExperiment.Application.FOCUS_IOS,
+        ]
+    )
+    def test_rollout_min_version_over_115_no_warning(self, application):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.CREATED,
-            application=NimbusExperiment.Application.FENIX,
-            firefox_min_version=NimbusExperiment.Version.FIREFOX_106,
+            application=application,
+            firefox_min_version=NimbusExperiment.Version.FIREFOX_116,
             is_rollout=True,
             is_sticky=True,
         )
@@ -1575,7 +1609,7 @@ class TestNimbusReviewSerializerSingleFeature(TestCase):
             lifecycle,
             application=NimbusExperiment.Application.FENIX,
             channel=channel,
-            firefox_min_version=NimbusExperiment.Version.FIREFOX_108,
+            firefox_min_version=NimbusExperiment.Version.FIREFOX_116,
             feature_configs=feature_configs_fenix,
             is_sticky=False,
             is_rollout=True,
@@ -1585,7 +1619,7 @@ class TestNimbusReviewSerializerSingleFeature(TestCase):
             lifecycle,
             application=NimbusExperiment.Application.IOS,
             channel=channel,
-            firefox_min_version=NimbusExperiment.Version.FIREFOX_108,
+            firefox_min_version=NimbusExperiment.Version.FIREFOX_116,
             feature_configs=feature_configs_ios,
             is_sticky=False,
             is_rollout=True,


### PR DESCRIPTION
Because

- Rollout un-enrollment and re-enrollment issues were recently fixed in the desktop and mobile versions of Firefox

This commit

- Updates the rollout min-version warning to show for mobile applications with a version lower than fx116
- Updates the rollout min-version warning to show for fx desktop versions lower than fx115
