### PR TITLE
fix #9126 chore(project): update to postgres14

### DIFF
--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -45,7 +45,7 @@ services:
 
   db:
     restart: always
-    image: postgres:9.6.17
+    image: postgres:14.8
     environment:
       POSTGRES_PASSWORD: postgres
     ports:

--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -15,7 +15,7 @@ services:
 
   db:
     restart: always
-    image: postgres:9.6.17
+    image: postgres:14.8
     environment:
       POSTGRES_PASSWORD: postgres
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -73,7 +73,7 @@ services:
 
   db:
     restart: always
-    image: postgres:9.6.17
+    image: postgres:14.8
     environment:
       POSTGRES_PASSWORD: postgres
     ports:
@@ -112,7 +112,6 @@ services:
     working_dir: /cirrus
     ports:
       - "8001:8001"
-
 
 volumes:
   db_volume:


### PR DESCRIPTION
Because

* Django 4 requires postgres 14
* Postgres 9.6 is now EOL

This commit

* Updates to Postgres 14


