### PR TITLE
fix 9128 feat(nimbus): add pop sizing data to graphql fetch

### DIFF
--- a/experimenter/experimenter/experiments/api/v5/types.py
+++ b/experimenter/experimenter/experiments/api/v5/types.py
@@ -2,6 +2,7 @@ import json
 
 import graphene
 from django.contrib.auth.models import User
+from django.core.cache import cache
 from graphene_django import DjangoListField
 from graphene_django.types import DjangoObjectType
 
@@ -23,6 +24,7 @@ from experimenter.experiments.models import (
 )
 from experimenter.outcomes import Outcomes
 from experimenter.projects.models import Project
+from experimenter.settings import SIZING_DATA_KEY
 
 
 class NimbusExperimentStatusEnum(graphene.Enum):
@@ -294,6 +296,7 @@ class NimbusConfigurationType(graphene.ObjectType):
     conclusion_recommendations = graphene.List(NimbusLabelValueType)
     types = graphene.List(NimbusLabelValueType)
     status_update_exempt_fields = graphene.List(NimbusStatusUpdateExemptFieldsType)
+    population_sizing_data = graphene.String()
 
     def _text_choices_to_label_value_list(self, text_choices):
         return [
@@ -336,6 +339,12 @@ class NimbusConfigurationType(graphene.ObjectType):
         return self._text_choices_to_label_value_list(
             NimbusExperiment.ConclusionRecommendation
         )
+
+    def resolve_population_sizing_data(self, info):
+        sizing_data = cache.get(SIZING_DATA_KEY)
+        if sizing_data:
+            return sizing_data.json()
+        return "Sizing data not available."
 
     @staticmethod
     def sort_version_choices(choices):

--- a/experimenter/experimenter/experiments/tests/api/v5/test_queries.py
+++ b/experimenter/experimenter/experiments/tests/api/v5/test_queries.py
@@ -2390,6 +2390,7 @@ class TestNimbusConfigQuery(GraphQLTestCase):
                         experiments
                         rollouts
                     }
+                    populationSizingData
                 }
             }
             """,

--- a/experimenter/experimenter/nimbus-ui/schema.graphql
+++ b/experimenter/experimenter/nimbus-ui/schema.graphql
@@ -410,6 +410,7 @@ type NimbusConfigurationType {
   conclusionRecommendations: [NimbusLabelValueType]
   types: [NimbusLabelValueType]
   statusUpdateExemptFields: [NimbusStatusUpdateExemptFieldsType]
+  populationSizingData: String
 }
 
 type NimbusExperimentApplicationConfigType {

--- a/experimenter/experimenter/nimbus-ui/src/gql/config.ts
+++ b/experimenter/experimenter/nimbus-ui/src/gql/config.ts
@@ -95,6 +95,7 @@ export const GET_CONFIG_QUERY = gql`
         experiments
         rollouts
       }
+      populationSizingData
     }
   }
 `;

--- a/experimenter/tests/integration/nimbus/utils/helpers.py
+++ b/experimenter/tests/integration/nimbus/utils/helpers.py
@@ -123,6 +123,7 @@ def load_config_data():
                             experiments
                             rollouts
                         }
+                        populationSizingData
                     }
                 }
                 """,


### PR DESCRIPTION
Because

- we want to display pre-computed population sizing data on the Audience config page

This commit

- gets the pop sizing data from graphql
