### PR TITLE
fix #9133 chore(project): fix make check schemas command in circle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -535,7 +535,7 @@ jobs:
       - run:
           name: Run Schemas tests and linting
           command: |
-            make check_schemas
+            make schemas_check
 
   schemas_deploy:
     docker:


### PR DESCRIPTION
Because

* We recently renamed some commands in the circle config for consistency
* We accidentally broke the make command for checking the schemas
* It was missed because they didn't run becuase they failed the path check

This commit

* Fixes the make check schemas command in the circle config


