### PR TITLE
For #9032 tests(nimbus): Non-happy path integration tests for first run release dates

### DIFF
--- a/experimenter/tests/integration/nimbus/pages/experimenter/audience.py
+++ b/experimenter/tests/integration/nimbus/pages/experimenter/audience.py
@@ -1,5 +1,6 @@
 from selenium.webdriver.common.by import By
 from selenium.webdriver.common.keys import Keys
+from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.select import Select
 
 from nimbus.pages.experimenter.base import ExperimenterBase
@@ -157,3 +158,15 @@ class AudiencePage(ExperimenterBase):
         for _ in text:
             el.send_keys(f"{_}")
             el.send_keys(Keys.TAB)
+
+    def wait_until_release_date_not_found(self):
+        self.wait.until_not(
+            EC.presence_of_element_located(self._release_date_locator),
+            message="Audience Page: could not find release date",
+        )
+
+    def wait_until_first_run_not_found(self):
+        self.wait.until_not(
+            EC.presence_of_element_located(self._first_run_checkbox_locator),
+            message="Audience Page: could not find first run checkbox",
+        )

--- a/experimenter/tests/integration/nimbus/pages/experimenter/summary.py
+++ b/experimenter/tests/integration/nimbus/pages/experimenter/summary.py
@@ -366,10 +366,22 @@ class SummaryPage(ExperimenterBase):
             message="Summary Page: could not find timeline",
         )
 
-    def wait_for_release_date(self):
+    def wait_for_timeline_release_date(self):
         self.wait.until(
             EC.presence_of_all_elements_located(
                 self._timeline_proposed_release_date_locator
             ),
+            message="Summary Page: could not find release date on timeline",
+        )
+
+    def wait_until_audience_section_release_date_not_found(self):
+        self.wait.until_not(
+            EC.presence_of_element_located(self._audience_proposed_release_date_locator),
+            message="Summary Page: could not find release date in Audience section",
+        )
+
+    def wait_until_timeline_release_date_not_found(self):
+        self.wait.until_not(
+            EC.presence_of_element_located(self._audience_proposed_release_date_locator),
             message="Summary Page: could not find release date on timeline",
         )

--- a/experimenter/tests/integration/nimbus/test_experimenter_ui.py
+++ b/experimenter/tests/integration/nimbus/test_experimenter_ui.py
@@ -296,8 +296,11 @@ def test_summary_timeline_release_date(
 
 @pytest.mark.nimbus_ui
 @pytest.mark.skipif(
-    os.getenv("PYTEST_ARGS") != "FIREFOX_DESKTOP",
-    reason="Only run for desktop",
+    any(
+        app in os.getenv("PYTEST_ARGS")
+        for app in ["FOCUS_IOS", "IOS", "FENIX", "FOCUS_ANDROID"]
+    ),
+    reason="Only run for non-mobile applications",
 )
 def test_audience_page_release_date_not_visible(
     selenium,

--- a/experimenter/tests/integration/nimbus/test_experimenter_ui.py
+++ b/experimenter/tests/integration/nimbus/test_experimenter_ui.py
@@ -292,3 +292,49 @@ def test_summary_timeline_release_date(
 
     summary.wait_for_timeline_visible()
     summary.wait_for_release_date()
+
+
+@pytest.mark.nimbus_ui
+@pytest.mark.skipif(
+    ("FOCUS_IOS" or "FIREFOX_IOS" or "FENIX" or "FOCUS_ANDROID")
+    in os.getenv("PYTEST_ARGS"),
+    reason="Only run for desktop",
+)
+def test_summary_release_date_not_visible(
+    selenium,
+    kinto_client,
+    create_experiment,
+    experiment_url,
+):
+    summary = create_experiment(selenium)
+    summary.launch_and_approve()
+
+    kinto_client.approve()
+
+    summary = SummaryPage(selenium, experiment_url).open()
+    summary.wait_for_live_status()
+
+    summary.wait_for_timeline_visible()
+    timeline_release_date = summary.wait_until_timeline_release_date_not_found()
+    assert not timeline_release_date
+    audience_release_date = summary.wait_until_audience_section_release_date_not_found()
+    assert not audience_release_date
+
+
+@pytest.mark.nimbus_ui
+@pytest.mark.skipif(
+    ("FOCUS_IOS" or "FIREFOX_IOS" or "FENIX" or "FOCUS_ANDROID")
+    in os.getenv("PYTEST_ARGS"),
+    reason="Only run for desktop",
+)
+def test_audience_page_release_date_not_visible(
+    selenium,
+    create_experiment,
+):
+    summary = create_experiment(selenium)
+    audience = summary.navigate_to_audience()
+
+    release_date = audience.wait_until_release_date_not_found()
+    assert not release_date
+    first_run = audience.wait_until_first_run_not_found()
+    assert not first_run

--- a/experimenter/tests/integration/nimbus/test_experimenter_ui.py
+++ b/experimenter/tests/integration/nimbus/test_experimenter_ui.py
@@ -296,35 +296,7 @@ def test_summary_timeline_release_date(
 
 @pytest.mark.nimbus_ui
 @pytest.mark.skipif(
-    ("FOCUS_IOS" or "FIREFOX_IOS" or "FENIX" or "FOCUS_ANDROID")
-    in os.getenv("PYTEST_ARGS"),
-    reason="Only run for desktop",
-)
-def test_summary_release_date_not_visible(
-    selenium,
-    kinto_client,
-    create_experiment,
-    experiment_url,
-):
-    summary = create_experiment(selenium)
-    summary.launch_and_approve()
-
-    kinto_client.approve()
-
-    summary = SummaryPage(selenium, experiment_url).open()
-    summary.wait_for_live_status()
-
-    summary.wait_for_timeline_visible()
-    timeline_release_date = summary.wait_until_timeline_release_date_not_found()
-    assert not timeline_release_date
-    audience_release_date = summary.wait_until_audience_section_release_date_not_found()
-    assert not audience_release_date
-
-
-@pytest.mark.nimbus_ui
-@pytest.mark.skipif(
-    ("FOCUS_IOS" or "FIREFOX_IOS" or "FENIX" or "FOCUS_ANDROID")
-    in os.getenv("PYTEST_ARGS"),
+    os.getenv("PYTEST_ARGS") != "FIREFOX_DESKTOP",
     reason="Only run for desktop",
 )
 def test_audience_page_release_date_not_visible(

--- a/experimenter/tests/integration/nimbus/test_remote_settings.py
+++ b/experimenter/tests/integration/nimbus/test_remote_settings.py
@@ -259,8 +259,11 @@ def test_rollout_live_update_reject_on_experimenter(
 
 @pytest.mark.remote_settings
 @pytest.mark.skipif(
-    os.getenv("PYTEST_ARGS") != "FIREFOX_DESKTOP",
-    reason="Only run for desktop",
+    any(
+        app in os.getenv("PYTEST_ARGS")
+        for app in ["FOCUS_IOS", "IOS", "FENIX", "FOCUS_ANDROID"]
+    ),
+    reason="Only run for non-mobile applications",
 )
 def test_summary_release_date_not_visible(
     selenium,

--- a/experimenter/tests/integration/nimbus/test_remote_settings.py
+++ b/experimenter/tests/integration/nimbus/test_remote_settings.py
@@ -1,3 +1,4 @@
+import os
 from urllib.parse import urljoin
 
 import pytest
@@ -254,3 +255,29 @@ def test_rollout_live_update_reject_on_experimenter(
     summary_page.set_rejection_reason()
     summary_page.submit_rejection()
     summary_page.wait_for_rejection_notice_visible()
+
+
+@pytest.mark.remote_settings
+@pytest.mark.skipif(
+    os.getenv("PYTEST_ARGS") != "FIREFOX_DESKTOP",
+    reason="Only run for desktop",
+)
+def test_summary_release_date_not_visible(
+    selenium,
+    kinto_client,
+    create_experiment,
+    experiment_url,
+):
+    summary = create_experiment(selenium)
+    summary.launch_and_approve()
+
+    kinto_client.approve()
+
+    summary = SummaryPage(selenium, experiment_url).open()
+    summary.wait_for_live_status()
+
+    summary.wait_for_timeline_visible()
+    timeline_release_date = summary.wait_until_timeline_release_date_not_found()
+    assert not timeline_release_date
+    audience_release_date = summary.wait_until_audience_section_release_date_not_found()
+    assert not audience_release_date


### PR DESCRIPTION
Because

- https://github.com/mozilla/experimenter/issues/8971 added some happy path tests

This commit

- Adds some more tests for first run release date:
   - When the application is `DESKTOP`, don't show release date on Summary page timeline or audience section
   - When the application is `DESKTOP`, don't show the first run checkbox or release date field on the Audience page
