### PR TITLE
fix #9172 chore(project): add cirrus and schemas to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,3 +27,21 @@ updates:
       - dependency-name: "*"
         update-types:
           ["version-update:semver-major", "version-update:semver-patch"]
+  - package-ecosystem: pip
+    directory: "/cirrus/server"
+    schedule:
+      interval: weekly
+    target-branch: main
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          ["version-update:semver-major", "version-update:semver-patch"]
+  - package-ecosystem: pip
+    directory: "/schemas"
+    schedule:
+      interval: weekly
+    target-branch: main
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          ["version-update:semver-major", "version-update:semver-patch"]


### PR DESCRIPTION
Because

* We now have cirrus and schemas projects living in this repo
* Everyone benefits from automated package updates

This commit

* Adds cirrus and schemas to the dependabot config

