### PR TITLE
Teach cirrus about coenrolling features

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -55,4 +55,4 @@ REMOTE_SETTING_REFRESH_RATE_IN_SECONDS=10
 APP_ID=test_app_id
 APP_NAME=test_app_name
 CHANNEL=developer
-CIRRUS_FML_PATH=./tests/feature_manifest/sample.yml
+CIRRUS_FML_PATH=./tests/feature_manifest/sample.fml.yaml

--- a/cirrus/README.md
+++ b/cirrus/README.md
@@ -22,7 +22,7 @@ To set up the Cirrus environment, follow these steps:
    APP_ID=test_app_id
    APP_NAME=test_app_name
    CHANNEL=developer
-   CIRRUS_FML_PATH=./feature_manifest/sample.yml
+   CIRRUS_FML_PATH=./feature_manifest/sample.fml.yaml
    ```
 
    Here's what each variable represents:
@@ -32,7 +32,7 @@ To set up the Cirrus environment, follow these steps:
    - `APP_ID`: Replace `test_app_id` with the actual ID of your application for example `firefox-desktop`.
    - `APP_NAME`: Replace `test_app_name` with the desired name for your application for example `firefox_desktop`.
    - `CHANNEL`: Replace `developer` with the channel like `beta`, `release` etc.
-   - `CIRRUS_FML_PATH`: The file path to the feature manifest file. Set it to `./feature_manifest/sample.yml` or specify the correct path to your feature manifest file.
+   - `CIRRUS_FML_PATH`: The file path to the feature manifest file. Set it to `./feature_manifest/sample.fml.yaml` or specify the correct path to your feature manifest file.
 
    Adjust the values of these variables according to your specific configuration requirements.
 

--- a/cirrus/server/cirrus/feature_manifest.py
+++ b/cirrus/server/cirrus/feature_manifest.py
@@ -35,3 +35,6 @@ class FeatureManifestLanguage:
             )
 
         return json.loads(merged_res.json)
+
+    def get_coenrolling_feature_ids(self) -> List[str]:
+        return self.fml_client.get_coenrolling_feature_ids()

--- a/cirrus/server/cirrus/main.py
+++ b/cirrus/server/cirrus/main.py
@@ -35,9 +35,9 @@ class FeatureRequest(BaseModel):
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    app.state.sdk = create_sdk()
-    app.state.remote_setting = RemoteSettings(app.state.sdk)
     app.state.fml = create_fml()
+    app.state.sdk = create_sdk(app.state.fml.get_coenrolling_feature_ids())
+    app.state.remote_setting = RemoteSettings(app.state.sdk)
     app.state.scheduler = create_scheduler()
     start_and_set_initial_job()
     app.state.pings, app.state.metrics = initialize_glean()
@@ -55,9 +55,9 @@ def create_fml():
         sys.exit(1)
 
 
-def create_sdk():
+def create_sdk(coenrolling_feature_ids):
     try:
-        return SDK(context=context)
+        return SDK(context=context, coenrolling_feature_ids=coenrolling_feature_ids)
     except NimbusError as e:  # type: ignore
         logger.error(f"Error occurred during SDK creation: {e}")
         sys.exit(1)

--- a/cirrus/server/cirrus/main.py
+++ b/cirrus/server/cirrus/main.py
@@ -2,7 +2,7 @@ import logging
 import sys
 from contextlib import asynccontextmanager
 from pathlib import Path
-from typing import Any, NamedTuple
+from typing import Any, List, NamedTuple
 
 from apscheduler.schedulers.asyncio import AsyncIOScheduler  # type: ignore
 from cirrus_sdk import NimbusError  # type: ignore
@@ -55,7 +55,7 @@ def create_fml():
         sys.exit(1)
 
 
-def create_sdk(coenrolling_feature_ids):
+def create_sdk(coenrolling_feature_ids: List[str]):
     try:
         return SDK(context=context, coenrolling_feature_ids=coenrolling_feature_ids)
     except NimbusError as e:  # type: ignore

--- a/cirrus/server/cirrus/sdk.py
+++ b/cirrus/server/cirrus/sdk.py
@@ -1,6 +1,6 @@
 import json
 import logging
-from typing import Any, Dict
+from typing import Any, Dict, List
 
 from cirrus_sdk import CirrusClient, NimbusError  # type: ignore
 
@@ -8,8 +8,8 @@ logger = logging.getLogger(__name__)
 
 
 class SDK:
-    def __init__(self, context: str):
-        self.client = CirrusClient(context)  # does not match struct- throw an exception
+    def __init__(self, context: str, coenrolling_feature_ids: List[str]):
+        self.client = CirrusClient(context, coenrolling_feature_ids)
 
     def compute_enrollments(self, targeting_context: Dict[str, str]) -> Dict[str, Any]:
         try:

--- a/cirrus/server/tests/conftest.py
+++ b/cirrus/server/tests/conftest.py
@@ -37,7 +37,7 @@ def remote_settings(sdk):
 
 @fixture
 def sdk():
-    return SDK(context=context)
+    return SDK(context=context, coenrolling_feature_ids=[])
 
 
 @fixture

--- a/cirrus/server/tests/conftest.py
+++ b/cirrus/server/tests/conftest.py
@@ -1,3 +1,4 @@
+import json
 from unittest import mock
 
 from fastapi.testclient import TestClient
@@ -51,6 +52,16 @@ def fml():
 
 
 @fixture
+def fml_with_coenrolling_features_path():
+    return "./tests/feature_manifest/sample-with-coenrollment.fml.yaml"
+
+
+@fixture
+def fml_with_coenrolling_features(fml_with_coenrolling_features_path):
+    return FeatureManifestLanguage(fml_with_coenrolling_features_path, channel)
+
+
+@fixture
 def exception():
     return Exception("some error")
 
@@ -73,6 +84,7 @@ def create_recipe():
         app_name="test_app",
         channel="release",
         feature="test-feature",
+        value={"enabled": True},
         is_rollout=False,
         targeting="true",
         bucket_count=10000,
@@ -94,7 +106,7 @@ def create_recipe():
                     "ratio": 1,
                     "features": [
                         {
-                            "value": {"enabled": True},
+                            "value": value,
                             "featureId": feature,
                         }
                     ],
@@ -147,3 +159,20 @@ def recipes(create_recipe):
             ),
         ]
     }
+
+
+@fixture
+def recipes_with_coenrolling_features(create_recipe):
+    value = {"map": {"{experiment}": "{experiment}"}}
+    return json.dumps(
+        {
+            "data": [
+                create_recipe(
+                    slug="experiment-1", feature="coenrolling-feature", value=value
+                ),
+                create_recipe(
+                    slug="experiment-2", feature="coenrolling-feature", value=value
+                ),
+            ]
+        }
+    )

--- a/cirrus/server/tests/feature_manifest/sample-with-coenrollment.fml.yaml
+++ b/cirrus/server/tests/feature_manifest/sample-with-coenrollment.fml.yaml
@@ -1,0 +1,14 @@
+about:
+  description: Nimbus Feature Manifest with coenrolling features for Python Testing
+channels:
+  - nightly
+  - developer
+features:
+  coenrolling-feature:
+    description: A coenrolling feature
+    allow-coenrollment: true
+    variables:
+      map:
+        description: An extensible map
+        type: Map<String, String>
+        default: {}

--- a/cirrus/server/tests/feature_manifest/sample.fml.yaml
+++ b/cirrus/server/tests/feature_manifest/sample.fml.yaml
@@ -20,7 +20,4 @@ features:
         value: { "enabled": true }
       - channel: developer
         value: { "something": "wicked" }
-
-types:
-  objects: {}
-  enums: {}
+        

--- a/cirrus/server/tests/test_feature_manifest.py
+++ b/cirrus/server/tests/test_feature_manifest.py
@@ -179,3 +179,8 @@ def test_compute_feature_configurations_targeting_doesnt_match(fml_setup):
 
     assert result == {"example-feature": {"enabled": False, "something": "wicked"}}
     assert len(fml.merge_errors) == 0
+
+
+def test_coenrolling_feature_ids(fml_with_coenrolling_features):
+    fml = fml_with_coenrolling_features
+    assert fml.get_coenrolling_feature_ids() == ["coenrolling-feature"]

--- a/cirrus/server/tests/test_main.py
+++ b/cirrus/server/tests/test_main.py
@@ -29,7 +29,7 @@ def test_create_sdk_with_error():
     with patch.object(sys, "exit") as mock_exit, patch("cirrus.main.SDK") as mock_sdk:
         mock_sdk.side_effect = NimbusError("Error occurred during SDK creation")
 
-        sdk = create_sdk()
+        sdk = create_sdk([])
 
         mock_exit.assert_called_once_with(1)  # Assert that sys.exit(1) was called
         assert sdk is None

--- a/cirrus/server/tests/test_sdk.py
+++ b/cirrus/server/tests/test_sdk.py
@@ -108,3 +108,19 @@ def test_set_experiments_failure_invalid_malform_key(sdk, recipes):
         "enrollments": [],
         "events": [],
     }
+
+
+def test_coenrolling_feature_recipes(recipes_with_coenrolling_features):
+    targeting_context = {"clientId": "test", "requestContext": {}}
+    context = {"app_id": "org.mozilla.test", "app_name": "test_app", "channel": "release"}
+    feature_id = "coenrolling-feature"
+    sdk = SDK(context=json.dumps(context), coenrolling_feature_ids=[feature_id])
+    sdk.set_experiments(recipes_with_coenrolling_features)
+    result = sdk.compute_enrollments(targeting_context)
+
+    assert result["enrolledFeatureConfigMap"][feature_id]["feature"]["value"] == {
+        "map": {
+            "experiment-1": "experiment-1",
+            "experiment-2": "experiment-2",
+        }
+    }

--- a/cirrus/server/tests/test_sdk.py
+++ b/cirrus/server/tests/test_sdk.py
@@ -40,7 +40,7 @@ from cirrus.sdk import SDK
 )
 def test_invalid_context(context, expected_error_message):
     with pytest.raises(NimbusError) as e:
-        SDK(context=context)
+        SDK(context=context, coenrolling_feature_ids=[])
 
         assert str(e.value).startswith(expected_error_message)
 

--- a/cirrus/server/tests/test_telemetry.py
+++ b/cirrus/server/tests/test_telemetry.py
@@ -86,7 +86,7 @@ async def test_enrollment_metrics_recorded_with_compute_features(mocker, recipes
             "channel": "release",
         }
     )
-    sdk = SDK(context=context)
+    sdk = SDK(context=context, coenrolling_feature_ids=[])
 
     request = FeatureRequest(
         client_id="test_client_id", context={"user_id": "test-client-id"}


### PR DESCRIPTION
Fixes [EXP-3626](https://mozilla-hub.atlassian.net/browse/EXP-3626).

Because

- Coenrolling feature ids are required for constructing the Nimbus SDK, Cirrus is unable to run

This commit

- Gets the coenrolling feature ids from FML, and passes it to the SDK.
