### PR TITLE
fix #9168 bug(nimbus): clone required and excluded experiments

### DIFF
--- a/experimenter/experimenter/experiments/models.py
+++ b/experimenter/experimenter/experiments/models.py
@@ -817,6 +817,9 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
             link.experiment = cloned
             link.save()
 
+        cloned.required_experiments.add(*self.required_experiments.all())
+        cloned.excluded_experiments.add(*self.excluded_experiments.all())
+
         cloned.feature_configs.add(*self.feature_configs.all())
         cloned.countries.add(*self.countries.all())
         if self.application == self.Application.DESKTOP:


### PR DESCRIPTION
Because

* We recently added required and excluded experiments fields
* These are part of targeting and should be included when cloned

This commit

* Adds required and excluded experiments to cloned experiments


