### PR TITLE
Add target for users with no autofill addresses

### DIFF
--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -553,6 +553,17 @@ NO_ENTERPRISE = NimbusTargetingConfig(
     application_choice_names=(Application.DESKTOP.name,),
 )
 
+NO_AUTOFILL_ADDRESSES = NimbusTargetingConfig(
+    name="No autofill addresses saved",
+    slug="no_autofill_addresses",
+    description="Only users who have 0 autofill addresses.",
+    targeting=("(addressesSaved == 0)"),
+    desktop_telemetry="",
+    sticky_required=False,
+    is_first_run_required=False,
+    application_choice_names=(Application.DESKTOP.name,),
+)
+
 RELAY_USER = NimbusTargetingConfig(
     name="Relay user",
     slug="relay_user",
@@ -569,6 +580,17 @@ NOT_RELAY_USER = NimbusTargetingConfig(
     slug="not_relay_user",
     description="Excludes users who have Relay",
     targeting=f"!({RELAY_USER.targeting}) && isFxAEnabled && usesFirefoxSync",
+    desktop_telemetry="",
+    sticky_required=False,
+    is_first_run_required=False,
+    application_choice_names=(Application.DESKTOP.name,),
+)
+
+NOT_RELAY_USER_WITH_NO_AUTOFILL_ADDRESSES = NimbusTargetingConfig(
+    name="FXA user without Relay & no autofill addresses saved",
+    slug="not_relay_user_no_autofill_addresses",
+    description="FXA user without Relay & no autofill addresses saved",
+    targeting=f"{NOT_RELAY_USER.targeting} && {NO_AUTOFILL_ADDRESSES}",
     desktop_telemetry="",
     sticky_required=False,
     is_first_run_required=False,
@@ -1460,7 +1482,8 @@ class TargetingConstants:
     TARGETING_CHANNEL = 'browserSettings.update.channel == "{channel}"'
 
     TARGETING_CONFIGS = {
-        targeting.slug: targeting for targeting in NimbusTargetingConfig.targeting_configs
+        targeting.slug: targeting
+        for targeting in NimbusTargetingConfig.targeting_configs
     }
 
     TargetingConfig = models.TextChoices(

--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -557,7 +557,7 @@ NO_AUTOFILL_ADDRESSES = NimbusTargetingConfig(
     name="No autofill addresses saved",
     slug="no_autofill_addresses",
     description="Only users who have 0 autofill addresses.",
-    targeting=("(addressesSaved == 0)"),
+    targeting="(addressesSaved == 0)",
     desktop_telemetry="",
     sticky_required=False,
     is_first_run_required=False,
@@ -590,7 +590,7 @@ NOT_RELAY_USER_WITH_NO_AUTOFILL_ADDRESSES = NimbusTargetingConfig(
     name="FXA user without Relay & no autofill addresses saved",
     slug="not_relay_user_no_autofill_addresses",
     description="FXA user without Relay & no autofill addresses saved",
-    targeting=f"{NOT_RELAY_USER.targeting} && {NO_AUTOFILL_ADDRESSES}",
+    targeting=f"{NOT_RELAY_USER.targeting} && {NO_AUTOFILL_ADDRESSES.targeting}",
     desktop_telemetry="",
     sticky_required=False,
     is_first_run_required=False,
@@ -1482,8 +1482,7 @@ class TargetingConstants:
     TARGETING_CHANNEL = 'browserSettings.update.channel == "{channel}"'
 
     TARGETING_CONFIGS = {
-        targeting.slug: targeting
-        for targeting in NimbusTargetingConfig.targeting_configs
+        targeting.slug: targeting for targeting in NimbusTargetingConfig.targeting_configs
     }
 
     TargetingConfig = models.TextChoices(


### PR DESCRIPTION
Because

- Form Autofill addresses degrade the Relay integration UX, we want to release the Relay integration only to FXA users who do NOT have Relay and do NOT have any autofill addresses saved, so ...

This commit

- adds `NO_AUTOFILL_ADDRESSES` and `NOT_RELAY_USER_WITH_NO_AUTOFILL_ADDRESSES` targeting configs.
