### PR TITLE
fix #9199 feat(schemas): remove min_version from sizing schemas

### DIFF
--- a/schemas/mozilla_nimbus_schemas/jetstream/population_sizing.py
+++ b/schemas/mozilla_nimbus_schemas/jetstream/population_sizing.py
@@ -43,7 +43,6 @@ class SizingRecipe(BaseModel):
     locale: str
     country: str
     new_or_existing: SizingUserType
-    minimum_version: str
 
 
 class SizingTarget(BaseModel):

--- a/schemas/mozilla_nimbus_schemas/tests/jetstream/test_population_sizing.py
+++ b/schemas/mozilla_nimbus_schemas/tests/jetstream/test_population_sizing.py
@@ -13,15 +13,14 @@ class TestPopulationSizing(TestCase):
         """Test against known good data."""
         sizing_test_data = """
         {
-            "firefox_desktop:release:['EN-US']:US:108": {
+            "firefox_desktop:release:['EN-US']:US": {
                 "new": {
                     "target_recipe": {
                         "app_id": "firefox_desktop",
                         "channel": "release",
                         "locale": "('EN-US')",
                         "country": "US",
-                        "new_or_existing": "new",
-                        "minimum_version": "108"
+                        "new_or_existing": "new"
                     },
                     "sample_sizes": {
                         "Power0.8EffectSize0.05": {
@@ -55,8 +54,7 @@ class TestPopulationSizing(TestCase):
                         "channel": "release",
                         "locale": "('EN-US')",
                         "country": "US",
-                        "new_or_existing": "existing",
-                        "minimum_version": "108"
+                        "new_or_existing": "existing"
                     },
                     "sample_sizes": {
                         "Power0.8EffectSize0.05": {

--- a/schemas/pyproject.toml
+++ b/schemas/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "mozilla-nimbus-schemas"
-version = "2023.7.1"
+version = "2023.8.1"
 description = "Schemas used by Mozilla Nimbus and related projects."
 authors = ["mikewilli"]
 license = "MPL 2.0"


### PR DESCRIPTION
Because

- the population sizing tool removed min_version from calculations

This commit

- removes min_version from the schemas
