### PR TITLE
fixes #9201 bug(nimbus): Do not use negation in targeting expressions

### DIFF
--- a/experimenter/experimenter/experiments/models.py
+++ b/experimenter/experimenter/experiments/models.py
@@ -386,8 +386,9 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
         if excluded_experiments := self.excluded_experiments.order_by("id").values_list(
             "slug", flat=True
         ):
+            # Mobile does not support ! in expressions.
             sticky_expressions.extend(
-                f"!('{slug}' in enrollments)" for slug in excluded_experiments
+                f"('{slug}' in enrollments) == false" for slug in excluded_experiments
             )
         if required_experiments := self.required_experiments.order_by("id").values_list(
             "slug", flat=True

--- a/experimenter/experimenter/experiments/tests/test_models.py
+++ b/experimenter/experimenter/experiments/tests/test_models.py
@@ -794,12 +794,12 @@ class TestNimbusExperiment(TestCase):
                 [
                     ([], [], "true"),
                     (["foo"], [], "('foo' in enrollments)"),
-                    ([], ["bar"], "(!('bar' in enrollments))"),
+                    ([], ["bar"], "(('bar' in enrollments) == false)"),
                     (
                         ["foo", "bar"],
                         ["baz"],
                         (
-                            "(!('baz' in enrollments)) && "
+                            "(('baz' in enrollments) == false) && "
                             "('foo' in enrollments) && "
                             "('bar' in enrollments)"
                         ),


### PR DESCRIPTION
Because:
- the JEXL evaluator in mobile does not support negation (`!expr`)

this commit:
- updates the generated exclusion targeting not to use negation and use comparison instead.