### PR TITLE
fix #9202 bug(nimbus): prefetch feature config schemas

### DIFF
--- a/experimenter/experimenter/experiments/api/v5/types.py
+++ b/experimenter/experimenter/experiments/api/v5/types.py
@@ -2,7 +2,6 @@ import json
 
 import graphene
 from django.contrib.auth.models import User
-from django.db.models import Prefetch
 from graphene_django import DjangoListField
 from graphene_django.types import DjangoObjectType
 
@@ -21,7 +20,6 @@ from experimenter.experiments.models import (
     NimbusDocumentationLink,
     NimbusExperiment,
     NimbusFeatureConfig,
-    NimbusVersionedSchema,
 )
 from experimenter.outcomes import Outcomes
 from experimenter.projects.models import Project
@@ -157,19 +155,15 @@ class NimbusFeatureConfigType(DjangoObjectType):
             "enabled",
         )
 
-    @classmethod
-    def get_queryset(cls, queryset, info):
-        return queryset.prefetch_related(
-            Prefetch(
-                "schemas", queryset=NimbusVersionedSchema.objects.filter(version=None)
-            )
-        )
-
     def resolve_sets_prefs(self, info):
-        return bool(self.schemas.get().sets_prefs)
+        for schema in self.schemas.all():
+            if schema.version is None:
+                return bool(schema.sets_prefs)
 
     def resolve_schema(self, info):
-        return self.schemas.get().schema
+        for schema in self.schemas.all():
+            if schema.version is None:
+                return schema.schema
 
 
 class NimbusBranchScreenshotType(DjangoObjectType):
@@ -339,7 +333,9 @@ class NimbusConfigurationType(graphene.ObjectType):
         return configs
 
     def resolve_all_feature_configs(self, info):
-        return NimbusFeatureConfig.objects.all().order_by("name")
+        return (
+            NimbusFeatureConfig.objects.all().prefetch_related("schemas").order_by("name")
+        )
 
     def resolve_firefox_versions(self, info):
         return NimbusConfigurationType.sort_version_choices(NimbusExperiment.Version)

--- a/experimenter/experimenter/experiments/models.py
+++ b/experimenter/experimenter/experiments/models.py
@@ -58,7 +58,9 @@ class NimbusExperimentManager(models.Manager["NimbusExperiment"]):
     def with_owner_features(self):
         return (
             self.get_queryset()
-            .prefetch_related("owner", "feature_configs", "projects")
+            .prefetch_related(
+                "owner", "feature_configs", "feature_configs__schemas", "projects"
+            )
             .order_by("-_updated_date_time")
         )
 


### PR DESCRIPTION
Because

* We recently broke the feature config model apart into parent and child models for schemas
* This introduced an N+1 query regression which is degrading performance

This commit

* Prefetches feature config schemas in the V5 API


