### PR TITLE
Fixes #9258 feat(nimbus): Cleanup UI for Takeaways fields

### DIFF
--- a/experimenter/experimenter/nimbus-ui/src/components/PageSummary/Takeaways/TakeawaysEditor.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageSummary/Takeaways/TakeawaysEditor.tsx
@@ -133,10 +133,42 @@ export const TakeawaysEditor = ({
               {submitErrors["*"]}
             </Alert>
           )}
+
+          <Form.Group
+            as={Row}
+            controlId="takeawaysQbrLearning"
+            className="mb-0 pl-1"
+          >
+            <Form.Group data-testid="takeaways-qbr" className="ml-3">
+              <Form.Check
+                type="checkbox"
+                label="QBR Notable Learning"
+                defaultChecked={isQbrLearning ? isQbrLearning : false}
+                onChange={(e) => setIsQbrLearning(e.target.checked)}
+                onSubmit={handleSave}
+                id="takeawaysQbrLearning"
+                {...{ "data-testid": "takeawaysQbrLearning" }}
+              />
+            </Form.Group>
+          </Form.Group>
+          <Form.Group as={Row} controlId="takeawaysMetricGain" className="pl-1">
+            <Form.Group data-testid="takeaways-metric" className="ml-3">
+              <Form.Check
+                type="checkbox"
+                label="Statistically Significant DAU Gain"
+                defaultChecked={isMetricGain ? isMetricGain : false}
+                onChange={(e) => setIsMetricGain(e.target.checked)}
+                onSubmit={handleSave}
+                id="takeawaysMetricGain"
+                {...{ "data-testid": "takeawaysMetricGain" }}
+              />
+            </Form.Group>
+          </Form.Group>
+
           <Form.Group as={Row}>
             <Form.Group
               as={Col}
-              className="flex-grow-0"
+              className="col-sm-2 col-md-2 ml-1"
               controlId="conclusionRecommendation"
             >
               <Form.Label
@@ -177,32 +209,7 @@ export const TakeawaysEditor = ({
               <FormErrors name="takeawaysSummary" />
             </Form.Group>
           </Form.Group>
-          <Form.Group as={Row} controlId="takeawaysQbrLearning">
-            <Form.Group data-testid="takeaways-qbr" className="ml-3">
-              <Form.Check
-                type="checkbox"
-                label="QBR Notable Learning"
-                defaultChecked={isQbrLearning ? isQbrLearning : false}
-                onChange={(e) => setIsQbrLearning(e.target.checked)}
-                onSubmit={handleSave}
-                id="takeawaysQbrLearning"
-                {...{ "data-testid": "takeawaysQbrLearning" }}
-              />
-            </Form.Group>
-          </Form.Group>
-          <Form.Group as={Row} controlId="takeawaysMetricGain">
-            <Form.Group data-testid="takeaways-metric" className="ml-3">
-              <Form.Check
-                type="checkbox"
-                label="Statistically Significant DAU Gain"
-                defaultChecked={isMetricGain ? isMetricGain : false}
-                onChange={(e) => setIsMetricGain(e.target.checked)}
-                onSubmit={handleSave}
-                id="takeawaysMetricGain"
-                {...{ "data-testid": "takeawaysMetricGain" }}
-              />
-            </Form.Group>
-          </Form.Group>
+
           <Form.Group as={Row} controlId="takeaways-gain" className="ml-1">
             <Form.Label className="font-weight-bold">Gain Amount:</Form.Label>
             <Form.Control

--- a/experimenter/experimenter/nimbus-ui/src/components/PageSummary/Takeaways/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageSummary/Takeaways/index.tsx
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React, { useCallback } from "react";
-import { Card } from "react-bootstrap";
+import { Card, Table } from "react-bootstrap";
 import Badge from "react-bootstrap/Badge";
 import Button from "react-bootstrap/Button";
 import Col from "react-bootstrap/Col";
@@ -45,6 +45,10 @@ export const Takeaways = (props: TakeawaysProps) => {
     (item) => item!.value === conclusionRecommendation,
   )?.label;
 
+  const setTextColor = (field: boolean | null) => {
+    return field ? "text-success font-weight-bold" : "text-body";
+  };
+
   return (
     <Card className="border-left-0 border-right-0 border-bottom-0 my-4">
       <section id="takeaways" data-testid="Takeaways">
@@ -77,33 +81,50 @@ export const Takeaways = (props: TakeawaysProps) => {
           </Row>
         </Card.Header>
         <Card.Body>
-          <div data-testid="summary">
-            <b>Summary: </b>
-            {takeawaysSummary ? (
-              <div data-testid="takeaways-summary-rendered">
-                <ReactMarkdown>{takeawaysSummary}</ReactMarkdown>
-              </div>
-            ) : (
-              <NotSet />
-            )}
-          </div>
-          <div>
-            <b>QBR Learning: </b> {takeawaysQbrLearning ? "True" : "False"}
-          </div>
-          <div>
-            <b>Statistically Significant DAU Gain: </b>{" "}
-            {takeawaysMetricGain ? "True" : "False"}
-          </div>
-          <div data-testid="gain-amount">
-            <b>Gain Amount: </b>
-            {takeawaysGainAmount ? (
-              <div data-testid="takeaways-gain-amount-rendered">
-                <ReactMarkdown>{takeawaysGainAmount}</ReactMarkdown>
-              </div>
-            ) : (
-              <NotSet />
-            )}
-          </div>
+          <Table data-testid="table-takeaway-summary">
+            <tr data-testid="qbr-learning">
+              <th className="border-top-0 mr-3">QBR Learning</th>
+              <td className="border-top-0 table-fixed col-sm-4 col-md-4 align-items-start justify-content-start">
+                <span className={setTextColor(takeawaysQbrLearning)}>
+                  {takeawaysQbrLearning ? "True" : "False"}
+                </span>
+              </td>
+              <th className="border-top-0 mr-2">
+                Statistically Significant DAU Gain
+              </th>
+              <td className="border-top-0 table-fixed col-sm-3 col-md-3">
+                <span className={setTextColor(takeawaysMetricGain)}>
+                  {takeawaysMetricGain ? "True" : "False"}
+                </span>
+              </td>
+            </tr>
+
+            <tr data-testid="summary">
+              <th className="mr-auto col-sm-2">Summary</th>
+              <td colSpan={3}>
+                {takeawaysSummary ? (
+                  <div data-testid="takeaways-summary-rendered">
+                    <ReactMarkdown>{takeawaysSummary}</ReactMarkdown>
+                  </div>
+                ) : (
+                  <NotSet />
+                )}
+              </td>
+            </tr>
+
+            <tr data-testid="gain-amount">
+              <th>Gain Amount</th>
+              <td colSpan={3}>
+                {takeawaysGainAmount ? (
+                  <div data-testid="takeaways-gain-amount-rendered">
+                    <ReactMarkdown>{takeawaysGainAmount}</ReactMarkdown>
+                  </div>
+                ) : (
+                  <NotSet />
+                )}
+              </td>
+            </tr>
+          </Table>
         </Card.Body>
       </section>
     </Card>


### PR DESCRIPTION
Because

- We want to make the UI for the takeaways section easier to use/cleaner

This commit

- Changes the order of the fields, formats them a bit better, makes the text for "QBR Notable Learning"/"Statistically Significant DAU Gain" green and bold if it's True and plain body text if it's False

<img width="1352" alt="Screen Shot 2023-08-11 at 11 50 40 AM" src="https://github.com/mozilla/experimenter/assets/43795363/e45ba0c3-3280-473e-a443-3e576f544570">
<img width="1664" alt="Screen Shot 2023-08-11 at 11 47 35 AM" src="https://github.com/mozilla/experimenter/assets/43795363/a2a2df5c-e74d-4a97-95c3-972044100a22">

