### PR TITLE
fix #9267 feat(nimbus): convert monitor web fml to experimenter format

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -601,6 +601,11 @@ workflows:
 
   build:
     jobs:
+      - update_external_configs:
+          filters:
+            branches:
+              ignore:
+                - main
       - check_experimenter_branch:
           name: Check Experimenter (Branch)
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -601,11 +601,6 @@ workflows:
 
   build:
     jobs:
-      - update_external_configs:
-          filters:
-            branches:
-              ignore:
-                - main
       - check_experimenter_branch:
           name: Check Experimenter (Branch)
           filters:

--- a/.gitignore
+++ b/.gitignore
@@ -110,3 +110,6 @@ experimenter/experimenter/outcomes/metric-hub.zip
 
 # Cirrus
 cirrus/server/app/__pycache__
+
+# Application Services for processing FML files
+experimenter/experimenter/features/manifests/application-services/

--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ feature_manifests:
 	curl -LJ --create-dirs -o experimenter/experimenter/features/manifests/ios.yaml $(FEATURE_MANIFEST_FXIOS_URL)
 	curl -LJ --create-dirs -o experimenter/experimenter/features/manifests/focus-android.yaml $(FEATURE_MANIFEST_FOCUS_ANDROID)
 	curl -LJ --create-dirs -o experimenter/experimenter/features/manifests/focus-ios.yaml $(FEATURE_MANIFEST_FOCUS_IOS)
-	curl -LJ --create-dirs -o experimenter/experimenter/features/manifests/monitor-web.yaml $(FEATURE_MANIFEST_MONITOR)
+	curl -LJ --create-dirs -o experimenter/experimenter/features/manifests/monitor-web.fml.yaml $(FEATURE_MANIFEST_MONITOR)
 	cat experimenter/experimenter/features/manifests/firefox-desktop.yaml | grep path: | \
 	awk -F'"' '{print "$(MOZILLA_CENTRAL_ROOT)/" $$2}' | sort -u | \
 	while read -r url; do \
@@ -90,8 +90,19 @@ feature_manifests:
 		curl $$url -o $$file; \
 	done
 
+convert_feature_manifests:
+	cd experimenter/experimenter/features/manifests/;\
+	curl --proto '=https' --tlsv1.2 https://sh.rustup.rs -sSf | sh -s -- -y;\
+	source "$HOME/.cargo/env";\
+	git clone git@github.com:mozilla/application-services.git;\
+	cd application-services;\
+	git submodule init;\
+	git submodule update --recursive;\
+	cd components/support/nimbus-fml;\
+	cargo build;\
+	cargo run "../../../../monitor-web.fml.yaml" experimenter --output "../../../../monitor-web.yaml" --channel developer;
 
-fetch_external_resources: jetstream_config feature_manifests
+fetch_external_resources: jetstream_config feature_manifests convert_feature_manifests
 	echo "External Resources Fetched"
 
 update_kinto:

--- a/Makefile
+++ b/Makefile
@@ -99,7 +99,6 @@ convert_feature_manifests:
 	git submodule init;\
 	git submodule update --recursive;\
 	cd components/support/nimbus-fml;\
-	cargo build;\
 	cargo run "../../../../monitor-web.fml.yaml" experimenter --output "../../../../monitor-web.yaml" --channel developer;
 
 fetch_external_resources: jetstream_config feature_manifests convert_feature_manifests

--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,7 @@ feature_manifests:
 convert_feature_manifests:
 	cd experimenter/experimenter/features/manifests/;\
 	curl --proto '=https' --tlsv1.2 https://sh.rustup.rs -sSf | sh -s -- -y;\
-	source "$HOME/.cargo/env";\
+	source "$$HOME/.cargo/env";\
 	git clone git@github.com:mozilla/application-services.git;\
 	cd application-services;\
 	git submodule init;\

--- a/experimenter/experimenter/features/manifests/monitor-web.fml.yaml
+++ b/experimenter/experimenter/features/manifests/monitor-web.fml.yaml
@@ -1,0 +1,26 @@
+about:
+  description: Nimbus Feature Manifest for Python Testing
+channels:
+  - nightly
+  - developer
+features:
+  example-feature:
+    description: An example feature
+    variables:
+      enabled:
+        description: If the feature is enabled
+        type: Boolean
+        default: false
+      something:
+        description: Another variable
+        type: Option<String>
+        default: null
+    defaults:
+      - channel: nightly
+        value: { "enabled": true }
+      - channel: developer
+        value: { "something": "wicked" }
+
+types:
+  objects: {}
+  enums: {}

--- a/experimenter/experimenter/features/manifests/monitor-web.yaml
+++ b/experimenter/experimenter/features/manifests/monitor-web.yaml
@@ -1,0 +1,12 @@
+---
+example-feature:
+  description: An example feature
+  hasExposure: true
+  exposureDescription: ""
+  variables:
+    enabled:
+      type: boolean
+      description: If the feature is enabled
+    something:
+      type: string
+      description: Another variable


### PR DESCRIPTION
Becuase
    
* The FML format that lives in an applications repo is not parseable by Experimenter
* The FML command line tool will convert it into the format expected by Experimenter
* Currently supported applications do this as part of their build chain
* New applications, particularly web, may not do this so we should do this conversion on our end as part of the external resource fetch step
    
This commit
    
* Adds a step to the fetch_external_resources make command to download and build the FML tool and convert the FML files into a format Experimenter can parse