### PR TITLE
For #9268 fix(nimbus): Update filter name to DaU gain

### DIFF
--- a/experimenter/experimenter/experiments/constants.py
+++ b/experimenter/experimenter/experiments/constants.py
@@ -217,7 +217,7 @@ class NimbusConstants(object):
 
     class Takeaways(models.TextChoices):
         QBR_LEARNING = "QBR Learning"
-        METRIC_GAIN = "Metric Gain"
+        DAU_GAIN = "DAU Gain"
 
     ARCHIVE_UPDATE_EXEMPT_FIELDS = (
         "is_archived",

--- a/experimenter/experimenter/nimbus-ui/src/components/PageHome/filterExperiments.ts
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageHome/filterExperiments.ts
@@ -86,7 +86,7 @@ const experimentFilters: { [key in FilterValueKeys]: ExperimentFilter<key> } = {
   takeaways: (option, experiment) => {
     return (
       (experiment.takeawaysQbrLearning && option.value === "QBR_LEARNING") ||
-      (experiment.takeawaysMetricGain && option.value === "METRIC_GAIN")
+      (experiment.takeawaysMetricGain && option.value === "DAU_GAIN")
     );
   },
 };

--- a/experimenter/experimenter/nimbus-ui/src/lib/mocks.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/lib/mocks.tsx
@@ -87,7 +87,7 @@ export const MOCK_CONFIG: getConfig_nimbusConfig = {
     },
   ],
   takeaways: [
-    { label: "Metric Gain", value: "METRIC_GAIN" },
+    { label: "DAU Gain", value: "DAU_GAIN" },
     { label: "QBR Learning", value: "QBR_LEARNING" },
   ],
   types: [


### PR DESCRIPTION
Because

- We want to update the filter name from "Metric Gain" to "DAU Gain"

This commit

- Updates the name!

<img width="453" alt="image" src="https://github.com/mozilla/experimenter/assets/43795363/702fd2b2-781e-412e-ace2-c251fccc77d2">

