### PR TITLE
fixes #9294 bug(nimbus): Use correct channel for monitor-web fml

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,7 +99,7 @@ convert_feature_manifests:
 	git submodule init;\
 	git submodule update --recursive;\
 	cd components/support/nimbus-fml;\
-	cargo run "../../../../monitor-web.fml.yaml" experimenter --output "../../../../monitor-web.yaml" --channel developer;
+	cargo run generate-experimenter --channel beta "../../../../monitor-web.fml.yaml" "../../../../monitor-web.yaml";
 
 fetch_external_resources: jetstream_config feature_manifests convert_feature_manifests
 	echo "External Resources Fetched"


### PR DESCRIPTION
Because

- monitor changed their channels in
  https://github.com/mozilla/blurts-server/pull/3320, which caused
  `make convert_feature_manifests` to fail;
- as a result, we have not merged feature manifests since the break

This commit

- updates `make convert_feature_manifests` to use the correct channel; and
- merges the updated feature manifests from monitor and desktop.
