### PR TITLE
fix #9287 chore(project): remove anonymous volumes in make kill

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -136,6 +136,7 @@ docker_prune:
 	docker container prune -f
 	docker image prune -f
 	docker volume prune -f
+	docker volume rm $$(docker volume ls -qf dangling=true) || true
 
 static_rm:
 	rm -Rf experimenter/node_modules


### PR DESCRIPTION
Becuase

* Restarting docker containers can cause images, containers, volumes, etc to start piling up
* Eventually you run out of disk space and have to docker system prune -a
* We added some prune commands to remove temporary data on refresh
* This was catching a bunch of things but missing 'anonymous volumes'

This commit

* Adds an additional step to docker_prune to remove anonymous volumes and prevent them from filling the disk


