### PR TITLE
fix #9362 chore(project): add schemas to codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,4 @@
-experimenter/tests @jrbenny35
-experimenter/experimenter/ @jaredlockhart @yashikakhurana @eliserichards @brennie
 cirrus/ @jaredlockhart @yashikakhurana @jeddai
+experimenter/experimenter/ @jaredlockhart @yashikakhurana @eliserichards @brennie
+experimenter/schemas/ @jaredlockhart @mikewilli
+experimenter/tests @jrbenny35

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 cirrus/ @jaredlockhart @yashikakhurana @jeddai
 experimenter/experimenter/ @jaredlockhart @yashikakhurana @eliserichards @brennie
-experimenter/schemas/ @jaredlockhart @mikewilli
+schemas/ @jaredlockhart @mikewilli
 experimenter/tests @jrbenny35


### PR DESCRIPTION
Because

* We now have the schemas package
* We should set some default codeowners for reviews

This commit

* Adds jaredlockhart and mikewilli as codeowners for the schemas package


