### PR TITLE
fix #9288 feat(cirrus): Editable client id and context

### DIFF
--- a/demo-app/frontend/src/index.js
+++ b/demo-app/frontend/src/index.js
@@ -10,15 +10,32 @@ root.render(
 
 function App() {
   const [message, setMessage] = useState({});
+  const [clientId, setClientId] = useState('');
+  const [context, setContext] = useState('');
+  const [apiCallTriggered, setApiCallTriggered] = useState(false);
 
   useEffect(() => {
-    fetch('/api/data')
-      .then(response => response.json())
-      .then(data => {
-        setMessage(data);
+    if (apiCallTriggered) {
+      const apiUrl = '/api/data';
+
+      fetch(apiUrl, {
+        method: 'GET',
+        headers: {
+          'x-client-id': clientId,
+          'x-context': context,
+        },
       })
-      .catch(error => console.error('Error fetching data:', error));
-  }, []);
+        .then((response) => response.json())
+        .then((data) => {
+          setMessage(data);
+          setApiCallTriggered(false);
+        })
+        .catch((error) => {
+          console.error('Error fetching data:', error);
+          setApiCallTriggered(false);
+        });
+    }
+  }, [apiCallTriggered, clientId, context]);
 
   const displayText = message && message['example-feature'] && message['example-feature']['something']
     ? message['example-feature']['something']
@@ -27,6 +44,22 @@ function App() {
   return (
     <div className="App">
       <h1>{displayText}</h1>
+      <div>
+        <input
+          type="text"
+          placeholder="Client ID"
+          value={clientId}
+          onChange={(e) => setClientId(e.target.value)}
+        />
+        <input
+          type="text"
+          placeholder="Context"
+          value={context}
+          onChange={(e) => setContext(e.target.value)}
+        />
+        <button onClick={() => setApiCallTriggered(true)}>Send My Details</button>
+      </div>
     </div>
   );
 }
+

--- a/demo-app/server/index.js
+++ b/demo-app/server/index.js
@@ -4,26 +4,36 @@ const server = http.createServer(async (req, res) => {
   if (req.url === '/api/data' && req.method === 'GET') {
     res.setHeader('Content-Type', 'application/json');
 
-    const apiInput = {
-      "client_id": "4a1d71ab-29a2-4c5f-9e1d-9d9df2e6e449",
-      "context": {
-        "key1": "value1",
-        "key2": {
-          "key2.1": "value2",
-          "key2.2": "value3"
-        }
-      }
+    const defaultApiInput = {
+      client_id: '4a1d71ab-29a2-4c5f-9e1d-9d9df2e6e449',
+      context: {
+        key1: 'default-value1',
+        key2: {
+          'key2.1': 'default-value2',
+          'key2.2': 'default-value3',
+        },
+      },
     };
 
-const options = {
-  hostname: 'cirrus', // Use the service name
-  port: 8001,
-  path: '/v1/features/',
-  method: 'POST',
-  headers: {
-    'Content-Type': 'application/json'
-  }
-};
+    // Get client ID and context from request headers
+    const clientID = req.headers['x-client-id'] || defaultApiInput.client_id;
+    const contextJSON = req.headers['x-context'] || JSON.stringify(defaultApiInput.context);
+    const context = JSON.parse(contextJSON);
+
+    const apiInput = {
+      client_id: clientID,
+      context: context,
+    };
+
+    const options = {
+      hostname: 'cirrus', // Use the service name
+      port: 8001,
+      path: '/v1/features/',
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    };
 
     const reqToOtherAPI = http.request(options, responseFromAPI => {
       let responseData = '';


### PR DESCRIPTION
Because

- Currently, to test the demo app with Cirrus, we have a static client ID and context

This commit

- Provide a way so that we can dynamically pass the client ID and context to the demo app frontend, which will help us in the integration tests to test with different scenarios
- The above code is modified in such a way that if client id and context is provided, then it will override the default values
<img width="820" alt="Screenshot 2023-09-06 at 1 00 50 AM" src="https://github.com/mozilla/experimenter/assets/25848231/e1f8c394-55f9-4021-99fe-6becbccce170">

fixes #9288 