### PR TITLE
For #9342 feat(project): Add configuration folder with yaml files for each mobile application

### DIFF
--- a/experimenter/experimenter/features/configs/apps.yaml
+++ b/experimenter/experimenter/features/configs/apps.yaml
@@ -1,0 +1,20 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+---
+fenix:
+  repo: @mozilla-mobile/firefox-android
+  fml_path: fenix/app/nimbus.fml.yaml
+  branch_mapping: "v{version}"
+ios:
+  repo: @mozilla-mobile/firefox-ios
+  fml_path: nimbus.fml.yaml
+  branch_mapping: "release/v{version}"
+focus-android:
+  repo: @mozilla-mobile/firefox-android
+  fml_path: focus-android/app/nimbus.fml.yaml
+  branch_mapping: "v{version}"
+focus-ios:
+  repo: @mozilla-mobile/focus-ios
+  fml_path: nimbus.fml.yaml
+  branch_mapping: "v{version}"


### PR DESCRIPTION
Because

- We want to specify the following for each of the mobile apps:
   - repo link
   - path to the fml file for the repo
   - a mapping for the version tags (so that we can find the appropriate FML for a specific version)

This commit

- Adds a new folder, `/experimenter/features/configs` that contains a file for each mobile application
   - This locations--`/features`--also contains the feature definitions that map to the `NimbusFeature` API
- Adds files for: 
   - ios
   - focus ios
   - fenix
   - focus android

----
We don't need anything for Klar, do we?