### PR TITLE
chore(nimbus): Correct release branches for Fenix and Focus

### DIFF
--- a/experimenter/experimenter/features/configs/apps.yaml
+++ b/experimenter/experimenter/features/configs/apps.yaml
@@ -5,16 +5,20 @@
 fenix:
   repo: @mozilla-mobile/firefox-android
   fml_path: fenix/app/nimbus.fml.yaml
-  branch_mapping: "v{version}"
-ios:
+  major_release_branch: "releases_v{major}"
+  minor_release_tag: "fenix-v{major}.{minor}.{patch}"
+firefox_ios:
   repo: @mozilla-mobile/firefox-ios
   fml_path: nimbus.fml.yaml
-  branch_mapping: "release/v{version}"
-focus-android:
+  major_release_branch: "release/v{major}"
+  minor_release_tag: "v{major}.{minor}"
+focus_android:
   repo: @mozilla-mobile/firefox-android
   fml_path: focus-android/app/nimbus.fml.yaml
-  branch_mapping: "v{version}"
-focus-ios:
+  major_release_branch: "releases_v{major}"
+  minor_release_tag: "focus-v{major}.{minor}.{patch}"
+focus_ios:
   repo: @mozilla-mobile/focus-ios
   fml_path: nimbus.fml.yaml
-  branch_mapping: "v{version}"
+  major_release_branch: "releases_v{major}"
+  minor_release_tag: "v{major}.{minor}"


### PR DESCRIPTION
Because
- we want to keep track of repositories that we ingest FML files from
this commit
- corrects the branch names for Fenix and Focus browsers.
