### PR TITLE
fixes #9373 bug(nimbus): Show warning messages for feature config input

### DIFF
--- a/experimenter/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/index.tsx
@@ -339,7 +339,7 @@ export const FormBranches = ({
         ))}
 
         <Form.Group>
-          <Row>
+          <Row className={selectIsWarning ? "is-warning" : ""}>
             <Col>
               <Select<FeatureConfigOption, true>
                 isMulti
@@ -351,8 +351,6 @@ export const FormBranches = ({
                 instanceId="feature-configs"
                 classNames={{
                   control: () => classNames({ "is-valid": selectValid }),
-                  container: () =>
-                    classNames({ "is-warning": selectIsWarning }),
                 }}
                 classNamePrefix="react-select"
                 getOptionLabel={(option: FeatureConfigOption) =>


### PR DESCRIPTION
Because:
- the feature_configs field had errors that weren't showing due to mis-applied classes

this commit:
- updates the component to add the "is-warning" class in the correct location to render the warning messages.
