### PR TITLE
fixes #9379 bug(nimbus): use correct bounds when reporting rich json parse errors

### DIFF
--- a/experimenter/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/FormFeatureValue/schema.ts
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/FormFeatureValue/schema.ts
@@ -101,7 +101,7 @@ export function schemaLinter(schema: Record<string, unknown>) {
       rootNode = jsonToAst(text);
     } catch (e: unknown) {
       const err = parseError.parse(e);
-      const pos = documentPosition(view.state.doc, err.line, err.column);
+      const pos = documentPosition(view.state.doc, err.line, err.column - 1);
 
       return [
         {


### PR DESCRIPTION
Because:
- the editor component would cause the experimenter page to crash if there was invalid JSON (e.g., missing a trailing }) due to an off-by-one error in the error location

this commit:
- updates the error reporting to use the correct end position.