### PR TITLE
Fixes #9429 feat(project): Create FML loader and access yaml file for application paths

### DIFF
--- a/experimenter/experimenter/features/manifests/apps.yaml
+++ b/experimenter/experimenter/features/manifests/apps.yaml
@@ -3,22 +3,22 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 ---
 fenix:
-  repo: @mozilla-mobile/firefox-android
+  repo: \@mozilla-mobile/firefox-android
   fml_path: fenix/app/nimbus.fml.yaml
   major_release_branch: "releases_v{major}"
   minor_release_tag: "fenix-v{major}.{minor}.{patch}"
 firefox_ios:
-  repo: @mozilla-mobile/firefox-ios
+  repo: \@mozilla-mobile/firefox-ios
   fml_path: nimbus.fml.yaml
   major_release_branch: "release/v{major}"
   minor_release_tag: "v{major}.{minor}"
 focus_android:
-  repo: @mozilla-mobile/firefox-android
+  repo: \@mozilla-mobile/firefox-android
   fml_path: focus-android/app/nimbus.fml.yaml
   major_release_branch: "releases_v{major}"
   minor_release_tag: "focus-v{major}.{minor}.{patch}"
 focus_ios:
-  repo: @mozilla-mobile/focus-ios
+  repo: \@mozilla-mobile/focus-ios
   fml_path: nimbus.fml.yaml
   major_release_branch: "releases_v{major}"
   minor_release_tag: "v{major}.{minor}"

--- a/experimenter/experimenter/features/manifests/nimbus_fml_loader.py
+++ b/experimenter/experimenter/features/manifests/nimbus_fml_loader.py
@@ -1,0 +1,40 @@
+import logging
+import os
+
+import yaml
+
+from experimenter.settings import BASE_DIR
+
+# Todo: Connect FML https://mozilla-hub.atlassian.net/browse/EXP-3791
+# from nimbus-experimenter import Fml
+
+logger = logging.getLogger()
+
+
+class NimbusFmlLoader:
+    def __init__(self, application: str, channel: str):
+        self.application: str = application
+        self.channel: str = channel
+
+        path = os.path.join(BASE_DIR, "features", "manifests", "apps.yaml")
+        fml_local = ""
+        if os.path.exists(path):
+            with open(path) as application_yaml_file:
+                application_data = yaml.load(
+                    application_yaml_file.read(), Loader=yaml.Loader
+                )
+                for feature_slug in application_data:
+                    if feature_slug in application:
+                        fml_local = application_data[feature_slug]["fml_path"]
+                        logger.info(str(fml_local))
+                        break
+        if fml_local != "":
+            self.fml_loader = self.create(path, channel)
+            logger.info("FML loader created")
+        else:
+            logger.error("Failed to find fml path for application: " + application)
+
+    def create(self, path: str, channel: str):
+        return "success"
+        # Todo: Connect FML https://mozilla-hub.atlassian.net/browse/EXP-3791
+        # return Fml.new(path, channel)

--- a/experimenter/experimenter/features/tests/test_nimbus_fml_loader.py
+++ b/experimenter/experimenter/features/tests/test_nimbus_fml_loader.py
@@ -1,0 +1,46 @@
+from unittest import mock
+
+from django.test import TestCase
+
+from experimenter.features.manifests.nimbus_fml_loader import NimbusFmlLoader
+
+
+class TestNimbusFmlLoader(TestCase):
+    def test_intiate_new_fml_client_no_error(self):
+        application = "fenix"
+        channel = "production"
+
+        with mock.patch(
+            "experimenter.features.manifests.nimbus_fml_loader.NimbusFmlLoader.create",
+        ) as create:
+            loader = NimbusFmlLoader(application, channel)
+
+            self.assertEqual(loader.application, application)
+            self.assertEqual(loader.channel, channel)
+            create.assert_called_once()
+
+    def test_intiate_invalid_fml_client_errors(self):
+        application = "rats"
+        channel = "production"
+
+        with self.assertLogs(level="ERROR") as log:
+            with mock.patch(
+                "experimenter.features.manifests.nimbus_fml_loader.NimbusFmlLoader.create",
+            ) as create:
+                loader = NimbusFmlLoader(application, channel)
+                self.assertIn(
+                    "Failed to find fml path for application: rats", log.output[0]
+                )
+
+            self.assertEqual(loader.application, application)
+            self.assertEqual(loader.channel, channel)
+            create.assert_not_called()
+
+    def test_create(self):
+        application = "fenix"
+        channel = "production"
+
+        loader = NimbusFmlLoader(application, channel)
+        response = loader.create("my/favorite/path", "ziggy")
+        # Todo: Connect FML https://mozilla-hub.atlassian.net/browse/EXP-3791
+        self.assertEqual(response, "success")


### PR DESCRIPTION
Because

- We want to incorporate the FML into Experimenter
- And we need a way to use the FML to load feature manifests into memory

This commit

- Creates a `NimbusFmlLoader`
- Based on the application name given, finds the config yaml file and gets the path to the correct application yaml file to pass into the FML
- Adds tests

----

This commit _does not_:
- Connect the `NimbusFmlLoader` to the FML: #9343 and #9430
- Load the manifests into memory and get features: #9388
