### PR TITLE
fix #9451 chore(project): build multiple docker platforms in circle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -347,6 +347,9 @@ jobs:
           name: Deploy to latest
           command: |
             ./scripts/store_git_info.sh
+            # Build all images for arm64 and amd64 to hydrate build cache
+            make BUILD_MULTIPLATFORM=1 build_dev build_test build_ui build_prod
+            # Pull amd64 and tag to dockerhub for deploy
             make build_prod
             docker tag experimenter:deploy ${DOCKERHUB_REPO}:latest
             docker push ${DOCKERHUB_REPO}:latest
@@ -362,8 +365,10 @@ jobs:
       - deploy:
           name: Deploy to latest
           command: |
-            docker login -u $DOCKERHUB_CIRRUS_USER -p $DOCKERHUB_CIRRUS_PASS
-            make cirrus_build_prod
+            # Build all images for arm64 and amd64 to hydrate build cache
+            make BUILD_MULTIPLATFORM=1 cirrus_build
+            # Pull amd64 and tag to dockerhub for deploy
+            make cirrus_build
             docker tag cirrus:deploy ${DOCKERHUB_CIRRUS_REPO}:latest
             docker push ${DOCKERHUB_CIRRUS_REPO}:latest
 

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ COMPOSE_LEGACY = ${COMPOSE} -f docker-compose-legacy.yml
 COMPOSE_TEST = docker compose -f docker-compose-test.yml
 COMPOSE_PROD = docker compose -f docker-compose-prod.yml
 COMPOSE_INTEGRATION = ${COMPOSE_PROD} -f docker-compose-integration-test.yml
+DOCKER_BUILD = docker buildx build $$( [ $$BUILD_MULTIPLATFORM  ] && echo "--platform linux/amd64,linux/arm64 --output type=cacheonly" )
 
 JOBS = 4
 PARALLEL = parallel --halt now,fail=1 --jobs ${JOBS} {} :::
@@ -119,16 +120,16 @@ compose_build:
 	$(COMPOSE) build
 
 build_dev: ssl
-	docker buildx build --target dev -f experimenter/Dockerfile -t experimenter:dev experimenter/
+	$(DOCKER_BUILD) --target dev -f experimenter/Dockerfile -t experimenter:dev experimenter/
 
 build_test: ssl
-	docker buildx build --target test -f experimenter/Dockerfile -t experimenter:test experimenter/
+	$(DOCKER_BUILD) --target test -f experimenter/Dockerfile -t experimenter:test experimenter/
 
 build_ui: ssl
-	docker buildx build --target ui -f experimenter/Dockerfile -t experimenter:ui experimenter/
+	$(DOCKER_BUILD) --target ui -f experimenter/Dockerfile -t experimenter:ui experimenter/
 
-build_prod: build_ui ssl
-	docker buildx build --target deploy -f experimenter/Dockerfile -t experimenter:deploy experimenter/
+build_prod: ssl
+	$(DOCKER_BUILD) --target deploy -f experimenter/Dockerfile -t experimenter:deploy experimenter/
 
 compose_stop:
 	$(COMPOSE) kill || true
@@ -242,13 +243,7 @@ CIRRUS_PYTHON_TYPECHECK_CREATESTUB = pyright -p . --createstub cirrus
 CIRRUS_GENERATE_DOCS = python cirrus/generate_docs.py
 
 cirrus_build:
-	$(COMPOSE) build cirrus
-
-cirrus_build_test:
-	$(COMPOSE_TEST) build cirrus
-
-cirrus_build_prod:
-	docker buildx build --target deploy -f cirrus/server/Dockerfile -t cirrus:deploy cirrus/server/
+	$(DOCKER_BUILD) --target deploy -f cirrus/server/Dockerfile -t cirrus:deploy cirrus/server/
 
 cirrus_up: cirrus_build
 	$(COMPOSE) up cirrus
@@ -256,10 +251,10 @@ cirrus_up: cirrus_build
 cirrus_down: cirrus_build
 	$(COMPOSE) down cirrus
 
-cirrus_test: cirrus_build_test
+cirrus_test: cirrus_build
 	$(COMPOSE_TEST) run cirrus sh -c '$(CIRRUS_PYTEST)'
 
-cirrus_check: cirrus_build_test
+cirrus_check: cirrus_build
 	$(COMPOSE_TEST) run cirrus sh -c "$(CIRRUS_RUFF_CHECK) && $(CIRRUS_BLACK_CHECK) && $(CIRRUS_PYTHON_TYPECHECK) && $(CIRRUS_PYTEST) && $(CIRRUS_GENERATE_DOCS) --check"
 
 cirrus_code_format: cirrus_build

--- a/cirrus/README.md
+++ b/cirrus/README.md
@@ -48,10 +48,6 @@ The following are the available commands for working with Cirrus:
 
   - Usage: `make cirrus_build`
 
-- **cirrus_build_test**: Builds the Cirrus container for testing.
-
-  - Usage: `make cirrus_build_test`
-
 - **cirrus_up**: Starts the Cirrus container.
 
   - Usage: `make cirrus_up`


### PR DESCRIPTION
Because

* We can now target multiple platforms in our Docker builds in Circle

This commit

* Enables multiplatform builds for Docker in Circle

