### PR TITLE
For #9388 feat(project): Get manifest paths and release versions in fml loader

### DIFF
--- a/experimenter/experimenter/features/manifests/nimbus_fml_loader.py
+++ b/experimenter/experimenter/features/manifests/nimbus_fml_loader.py
@@ -1,78 +1,61 @@
 import os
 
 import yaml
-from packaging import version
+from packaging import version as Version
+from rust_fml import FmlClient
 
 from experimenter.settings import BASE_DIR
-
-from rust_fml import FmlClient
 
 
 class NimbusFmlLoader:
     __base_path = os.path.join(BASE_DIR, "features", "manifests", "apps.yaml")
-    __major_release = "major_release_branch"
-    __minor_release = "minor_release_tag"
 
-    def __init__(self, application: str, channel: str):
+    def __init__(self, application: str, channel: str, file_location=__base_path):
         self.application: str = application
         self.channel: str = channel
+        self.application_data = self.get_application_data(application, file_location)
+        # Todo: Connect FML paths and channels https://mozilla-hub.atlassian.net/browse/EXP-3845
+        self.fml_client = self.create("", "")
 
     @staticmethod
-    def parse_version(version_str: str):
-        return version.parse(version_str)
-
-    def create(self, path: str, channel: str) -> FmlClient:
-        return FmlClient.new_with_ref(
-            "@mozilla-mobile/firefox-android/fenix/app/nimbus.fml.yaml", "release", "main"
-        )
-
-    @staticmethod
-    def load_yaml(file):
-        return yaml.load(file.read(), Loader=yaml.Loader)
-
-    def get_repo_location(self, file_location=__base_path):
+    def get_application_data(app, file_location=__base_path):
         if os.path.exists(file_location):
             with open(file_location) as application_yaml_file:
-                application_data = self.load_yaml(application_yaml_file)
-                for feature_slug in application_data:
-                    if feature_slug in self.application:
-                        return application_data[feature_slug]["repo"]
-
-    def get_fm_path(self, file_location=__base_path):
-        if os.path.exists(file_location):
-            with open(file_location) as application_yaml_file:
-                application_data = self.load_yaml(application_yaml_file)
-                for feature_slug in application_data:
-                    if feature_slug in self.application:
-                        return application_data[feature_slug]["fml_path"]
+                file = yaml.load(application_yaml_file.read(), Loader=yaml.Loader)
+                for app_name in file:
+                    if app_name in app:
+                        return file[app_name]
 
     def get_manifest_paths(self, versions: list[str]):
         manifest_paths = []
         for v in versions:
-            version = self.parse_version(v)
-            if os.path.exists(self.__base_path):
-                with open(self.__base_path) as application_yaml_file:
-                    application_data = self.load_yaml(application_yaml_file)
-
-                    for feature_slug in application_data:
-                        if feature_slug in self.application:
-                            # Todo: this can be expanded later to fetch both the
-                            # branch/major version and the tagged minor version.
-                            manifest_path_minor = self.get_minor_release_path(
-                                version, application_data, feature_slug
-                            )
-                            manifest_paths.append(manifest_path_minor)
-                            break
+            version = Version.parse(v)
+            # Todo: this can be expanded later to fetch both the
+            # branch/major version and the tagged minor version.
+            manifest_path_minor = self.get_minor_release_path(
+                version,
+            )
+            manifest_paths.append(manifest_path_minor)
         return manifest_paths
 
-    def get_major_release_path(self, version, application_data, feature_slug):
-        return application_data[feature_slug][self.__major_release].format(
-            major=version.major
+    def get_major_release_path(self, version):
+        if not self.application_data:
+            return None
+        return self.application_data["major_release_branch"].format(
+            major=version.major,
         )
 
-    def get_minor_release_path(self, version, application_data, feature_slug):
-        return application_data[feature_slug][self.__minor_release].format(
+    def get_minor_release_path(self, version):
+        if not self.application_data:
+            return None
+        return self.application_data["minor_release_tag"].format(
             major=version.major,
             minor=version.minor,
             patch=version.micro,
+        )
+
+    # Todo: Connect FML paths and channels https://mozilla-hub.atlassian.net/browse/EXP-3845
+    def create(self, path: str, channel: str) -> FmlClient:
+        return FmlClient.new_with_ref(
+            "@mozilla-mobile/firefox-android/fenix/app/nimbus.fml.yaml", "release", "main"
         )

--- a/experimenter/experimenter/features/manifests/nimbus_fml_loader.py
+++ b/experimenter/experimenter/features/manifests/nimbus_fml_loader.py
@@ -1,51 +1,65 @@
 import os
+from pathlib import Path
 
 import yaml
-from packaging import version as Version
+from packaging import version as version_packaging
 from rust_fml import FmlClient
 
 from experimenter.settings import BASE_DIR
 
 
 class NimbusFmlLoader:
-    __base_path = os.path.join(BASE_DIR, "features", "manifests", "apps.yaml")
+    BASE_PATH = Path(BASE_DIR) / "features" / "manifests" / "apps.yaml"
 
-    def __init__(self, application: str, channel: str, file_location=__base_path):
+    def __init__(self, application: str, channel: str, file_location=BASE_PATH):
         self.application: str = application
         self.channel: str = channel
         self.application_data = self.get_application_data(application, file_location)
-        # Todo: Connect FML paths and channels https://mozilla-hub.atlassian.net/browse/EXP-3845
-        self.fml_client = self.create("", "")
+
+    def get_fml_clients(self, versions: list[str]) -> list[FmlClient]:
+        if not self.application_data:
+            return None
+        refs = self.get_version_refs(versions)
+        file_path = self.get_file_path()
+        return [self.create_client(file_path, self.channel, r) for r in refs]
 
     @staticmethod
-    def get_application_data(app, file_location=__base_path):
+    def get_application_data(application_name, file_location=BASE_PATH):
         if os.path.exists(file_location):
             with open(file_location) as application_yaml_file:
-                file = yaml.load(application_yaml_file.read(), Loader=yaml.Loader)
-                for app_name in file:
-                    if app_name in app:
-                        return file[app_name]
+                file = yaml.safe_load(application_yaml_file.read())
+                if application_name in file:
+                    return file[application_name]
+                else:
+                    return None
 
-    def get_manifest_paths(self, versions: list[str]):
-        manifest_paths = []
+    def get_file_path(self):
+        if not self.application_data:
+            return None
+        return Path(self.application_data["repo"]) / self.application_data["fml_path"]
+
+    def get_version_refs(self, versions):
+        if versions == []:
+            return ["main"]
+        refs = []
         for v in versions:
-            version = Version.parse(v)
+            version = version_packaging.parse(v)
             # Todo: this can be expanded later to fetch both the
             # branch/major version and the tagged minor version.
-            manifest_path_minor = self.get_minor_release_path(
+            version_ref_minor = self.get_minor_version_ref(
                 version,
             )
-            manifest_paths.append(manifest_path_minor)
-        return manifest_paths
+            refs.append(version_ref_minor)
+        return refs
 
-    def get_major_release_path(self, version):
+    def get_major_version_ref(self, version):
         if not self.application_data:
             return None
         return self.application_data["major_release_branch"].format(
             major=version.major,
         )
 
-    def get_minor_release_path(self, version):
+    def get_minor_version_ref(self, version):
         if not self.application_data:
             return None
         return self.application_data["minor_release_tag"].format(
@@ -54,8 +68,5 @@ class NimbusFmlLoader:
             patch=version.micro,
         )
 
-    # Todo: Connect FML paths and channels https://mozilla-hub.atlassian.net/browse/EXP-3845
-    def create(self, path: str, channel: str) -> FmlClient:
-        return FmlClient.new_with_ref(
-            "@mozilla-mobile/firefox-android/fenix/app/nimbus.fml.yaml", "release", "main"
-        )
+    def create_client(self, path: str, channel: str, ref: str) -> FmlClient:
+        return FmlClient.new_with_ref(path, channel, ref)

--- a/experimenter/experimenter/features/manifests/nimbus_fml_loader.py
+++ b/experimenter/experimenter/features/manifests/nimbus_fml_loader.py
@@ -1,38 +1,78 @@
-import logging
 import os
 
 import yaml
-from rust_fml import FmlClient
+from packaging import version
 
 from experimenter.settings import BASE_DIR
 
-logger = logging.getLogger()
+from rust_fml import FmlClient
 
 
 class NimbusFmlLoader:
+    __base_path = os.path.join(BASE_DIR, "features", "manifests", "apps.yaml")
+    __major_release = "major_release_branch"
+    __minor_release = "minor_release_tag"
+
     def __init__(self, application: str, channel: str):
         self.application: str = application
         self.channel: str = channel
 
-        path = os.path.join(BASE_DIR, "features", "manifests", "apps.yaml")
-        fml_local = ""
-        if os.path.exists(path):
-            with open(path) as application_yaml_file:
-                application_data = yaml.load(
-                    application_yaml_file.read(), Loader=yaml.Loader
-                )
-                for feature_slug in application_data:
-                    if feature_slug in application:
-                        fml_local = application_data[feature_slug]["fml_path"]
-                        logger.info(str(fml_local))
-                        break
-        if fml_local != "":
-            self.fml_loader = self.create(path, channel)
-            logger.info("FML loader created")
-        else:
-            logger.error("Failed to find fml path for application: " + application)
+    @staticmethod
+    def parse_version(version_str: str):
+        return version.parse(version_str)
 
     def create(self, path: str, channel: str) -> FmlClient:
         return FmlClient.new_with_ref(
             "@mozilla-mobile/firefox-android/fenix/app/nimbus.fml.yaml", "release", "main"
+        )
+
+    @staticmethod
+    def load_yaml(file):
+        return yaml.load(file.read(), Loader=yaml.Loader)
+
+    def get_repo_location(self, file_location=__base_path):
+        if os.path.exists(file_location):
+            with open(file_location) as application_yaml_file:
+                application_data = self.load_yaml(application_yaml_file)
+                for feature_slug in application_data:
+                    if feature_slug in self.application:
+                        return application_data[feature_slug]["repo"]
+
+    def get_fm_path(self, file_location=__base_path):
+        if os.path.exists(file_location):
+            with open(file_location) as application_yaml_file:
+                application_data = self.load_yaml(application_yaml_file)
+                for feature_slug in application_data:
+                    if feature_slug in self.application:
+                        return application_data[feature_slug]["fml_path"]
+
+    def get_manifest_paths(self, versions: list[str]):
+        manifest_paths = []
+        for v in versions:
+            version = self.parse_version(v)
+            if os.path.exists(self.__base_path):
+                with open(self.__base_path) as application_yaml_file:
+                    application_data = self.load_yaml(application_yaml_file)
+
+                    for feature_slug in application_data:
+                        if feature_slug in self.application:
+                            # Todo: this can be expanded later to fetch both the
+                            # branch/major version and the tagged minor version.
+                            manifest_path_minor = self.get_minor_release_path(
+                                version, application_data, feature_slug
+                            )
+                            manifest_paths.append(manifest_path_minor)
+                            break
+        return manifest_paths
+
+    def get_major_release_path(self, version, application_data, feature_slug):
+        return application_data[feature_slug][self.__major_release].format(
+            major=version.major
+        )
+
+    def get_minor_release_path(self, version, application_data, feature_slug):
+        return application_data[feature_slug][self.__minor_release].format(
+            major=version.major,
+            minor=version.minor,
+            patch=version.micro,
         )

--- a/experimenter/experimenter/features/tests/test.yaml
+++ b/experimenter/experimenter/features/tests/test.yaml
@@ -1,0 +1,9 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+---
+fenix:
+  repo: \@mozilla-mobile/firefox-android
+  fml_path: fenix/app/nimbus.fml.yaml
+  major_release_branch: "releases_v{major}"
+  minor_release_tag: "fenix-v{major}.{minor}.{patch}"

--- a/experimenter/experimenter/features/tests/test_nimbus_fml_loader.py
+++ b/experimenter/experimenter/features/tests/test_nimbus_fml_loader.py
@@ -1,46 +1,127 @@
-from unittest import mock
+import os
 
 from django.test import TestCase
 
 from experimenter.features.manifests.nimbus_fml_loader import NimbusFmlLoader
+from experimenter.settings import BASE_DIR
 
 
 class TestNimbusFmlLoader(TestCase):
-    def test_intiate_new_fml_client_no_error(self):
-        application = "fenix"
-        channel = "production"
+    @staticmethod
+    def create_loader(
+        application: str = "fenix",
+        channel: str = "production",
+    ):
+        return NimbusFmlLoader(application, channel)
 
-        with mock.patch(
-            "experimenter.features.manifests.nimbus_fml_loader.NimbusFmlLoader.create",
-        ) as create:
-            loader = NimbusFmlLoader(application, channel)
-
-            self.assertEqual(loader.application, application)
-            self.assertEqual(loader.channel, channel)
-            create.assert_called_once()
-
-    def test_intiate_invalid_fml_client_errors(self):
-        application = "rats"
-        channel = "production"
-
-        with self.assertLogs(level="ERROR") as log:
-            with mock.patch(
-                "experimenter.features.manifests.nimbus_fml_loader.NimbusFmlLoader.create",
-            ) as create:
-                loader = NimbusFmlLoader(application, channel)
-                self.assertIn(
-                    "Failed to find fml path for application: rats", log.output[0]
-                )
-
-            self.assertEqual(loader.application, application)
-            self.assertEqual(loader.channel, channel)
-            create.assert_not_called()
-
-    def test_create(self):
-        application = "fenix"
+    def test_intiate_new_fml_loader(self):
+        application = "firefox_ios"
         channel = "production"
 
         loader = NimbusFmlLoader(application, channel)
-        response = loader.create("my/favorite/path", "ziggy")
-        # Todo: Connect FML https://mozilla-hub.atlassian.net/browse/EXP-3791
-        self.assertIsNotNone(response)
+
+        self.assertEqual(loader.application, application)
+        self.assertEqual(loader.channel, channel)
+
+    def test_parse_versions(self):
+        version = "112.1.0"
+        parse = NimbusFmlLoader.parse_version(version)
+        self.assertEqual(str(parse), version)
+        self.assertEqual(parse.major, 112)
+        self.assertEqual(parse.minor, 1)
+        self.assertEqual(parse.micro, 0)
+
+    def test_load_yaml(self):
+        path = os.path.join(BASE_DIR, "features", "tests", "test.yaml")
+        loader = self.create_loader()
+
+        if os.path.exists(path):
+            with open(path) as file:
+                yaml = loader.load_yaml(file)
+                self.assertIsNotNone(yaml)
+
+    def test_get_repo_location(self):
+        path = os.path.join(BASE_DIR, "features", "tests", "test.yaml")
+        expected = r"\@mozilla-mobile/firefox-android"
+
+        loader = self.create_loader()
+        result = loader.get_repo_location(path)
+        self.assertEqual(result, expected)
+
+    def test_get_fm_path(self):
+        path = os.path.join(BASE_DIR, "features", "tests", "test.yaml")
+        expected = "fenix/app/nimbus.fml.yaml"
+
+        loader = self.create_loader()
+        result = loader.get_fm_path(path)
+        self.assertEqual(result, expected)
+
+    def test_fetch_single_manifest_version(self):
+        application = "firefox_ios"
+        channel = "release"
+        version = ["112.1.0"]
+
+        client = self.create_loader(application, channel)
+        manifests = client.get_manifest_paths(version)
+
+        self.assertEqual(client.application, application)
+        self.assertEqual(client.channel, channel)
+        self.assertEqual(len(manifests), 1)
+
+    def test_fetch_multiple_manifest_versions(self):
+        application = "firefox_ios"
+        channel = "release"
+        versions = [
+            "112.1.0",
+            "112.1.1",
+            "113.0.0",
+            "118.7.3",
+        ]
+
+        client = self.create_loader(application, channel)
+        manifests = client.get_manifest_paths(versions)
+
+        self.assertEqual(client.application, application)
+        self.assertEqual(client.channel, channel)
+        self.assertEqual(len(manifests), 4)
+
+    def test_get_major_version_fml_paths(self):
+        path = os.path.join(BASE_DIR, "features", "tests", "test.yaml")
+        loader = self.create_loader()
+        version = loader.parse_version("112.1.0")
+        expected = "releases_v112"
+
+        if os.path.exists(path):
+            with open(path) as application_yaml_file:
+                application_data = loader.load_yaml(application_yaml_file)
+                result = loader.get_major_release_path(
+                    version,
+                    application_data,
+                    "fenix",
+                )
+                self.assertEqual(result, expected)
+
+    def test_get_minor_version_fml_paths(self):
+        path = os.path.join(BASE_DIR, "features", "tests", "test.yaml")
+        loader = self.create_loader()
+        version = loader.parse_version("112.1.0")
+        expected = "fenix-v112.1.0"
+
+        if os.path.exists(path):
+            with open(path) as application_yaml_file:
+                application_data = loader.load_yaml(application_yaml_file)
+                result = loader.get_minor_release_path(
+                    version,
+                    application_data,
+                    "fenix",
+                )
+
+                self.assertEqual(result, expected)
+
+    def test_create(self):
+        loader = self.create_loader()
+        fml_path = "fenix/app/nimbus.fml.yaml"
+        release_version = "v112.1.0"
+
+        result = loader.create(fml_path, release_version, loader.channel)
+        self.assertIsNotNone(result)

--- a/experimenter/experimenter/features/tests/test_nimbus_fml_loader.py
+++ b/experimenter/experimenter/features/tests/test_nimbus_fml_loader.py
@@ -1,4 +1,5 @@
-import os
+from pathlib import Path
+from unittest import mock
 
 from django.test import TestCase
 from packaging import version
@@ -8,13 +9,13 @@ from experimenter.settings import BASE_DIR
 
 
 class TestNimbusFmlLoader(TestCase):
-    __base_path = os.path.join(BASE_DIR, "features", "manifests", "apps.yaml")
+    TEST_BASE_PATH = Path(BASE_DIR) / "features" / "tests" / "test.yaml"
 
     @staticmethod
     def create_loader(
         application: str = "fenix",
         channel: str = "release",
-        path=__base_path,
+        path=TEST_BASE_PATH,
     ):
         return NimbusFmlLoader(
             application=application,
@@ -26,52 +27,66 @@ class TestNimbusFmlLoader(TestCase):
         application = "fenix"
         channel = "release"
         expected_repo = r"\@mozilla-mobile/firefox-android"
-        path = os.path.join(BASE_DIR, "features", "tests", "test.yaml")
 
-        loader = NimbusFmlLoader(application, channel, path)
+        loader = NimbusFmlLoader(application, channel, self.TEST_BASE_PATH)
 
         self.assertEqual(loader.application, application)
         self.assertEqual(loader.channel, channel)
         self.assertEqual(loader.application_data["repo"], expected_repo)
-        self.assertIsNotNone(loader.fml_client)
 
     def test_get_application_data_from_file(self):
         application = "fenix"
-        path = os.path.join(BASE_DIR, "features", "tests", "test.yaml")
         expected_repo = r"\@mozilla-mobile/firefox-android"
         expected_fml = "fenix/app/nimbus.fml.yaml"
 
-        data = NimbusFmlLoader.get_application_data(app=application, file_location=path)
+        data = NimbusFmlLoader.get_application_data(
+            application_name=application, file_location=self.TEST_BASE_PATH
+        )
         self.assertEqual(data["repo"], expected_repo)
         self.assertEqual(data["fml_path"], expected_fml)
 
     def test_get_application_data_does_not_exist(self):
         application = "garfield"
-        path = os.path.join(BASE_DIR, "features", "tests", "test.yaml")
 
-        data = NimbusFmlLoader.get_application_data(app=application, file_location=path)
+        data = NimbusFmlLoader.get_application_data(
+            application_name=application, file_location=self.TEST_BASE_PATH
+        )
         self.assertIsNone(data)
 
     def test_get_application_path_does_not_exist(self):
         application = "garfield"
-        path = os.path.join(BASE_DIR, "features", "garfield", "bingo.yaml")
+        path = Path(BASE_DIR) / "features" / "garfield" / "bingo.yaml"
 
-        data = NimbusFmlLoader.get_application_data(app=application, file_location=path)
+        data = NimbusFmlLoader.get_application_data(
+            application_name=application, file_location=path
+        )
         self.assertIsNone(data)
 
-    def test_fetch_single_manifest_version(self):
+    def test_get_ref_no_versions(self):
+        application = "fenix"
+        channel = "release"
+        no_version = []
+
+        client = self.create_loader()
+        refs = client.get_version_refs(no_version)
+
+        self.assertEqual(client.application, application)
+        self.assertEqual(client.channel, channel)
+        self.assertEqual(refs, ["main"])
+
+    def test_get_ref_for_single_version(self):
         application = "fenix"
         channel = "release"
         version = ["112.1.0"]
 
         client = self.create_loader()
-        manifests = client.get_manifest_paths(version)
+        refs = client.get_version_refs(version)
 
         self.assertEqual(client.application, application)
         self.assertEqual(client.channel, channel)
-        self.assertEqual(len(manifests), 1)
+        self.assertEqual(len(refs), 1)
 
-    def test_fetch_multiple_manifest_versions(self):
+    def test_get_refs_for_multiple_versions(self):
         application = "fenix"
         channel = "release"
         expected_repo = r"\@mozilla-mobile/firefox-android"
@@ -85,45 +100,106 @@ class TestNimbusFmlLoader(TestCase):
         client = self.create_loader()
         self.assertEqual(client.application_data["repo"], expected_repo)
 
-        manifests = client.get_manifest_paths(versions)
+        refs = client.get_version_refs(versions)
 
         self.assertEqual(client.application, application)
         self.assertEqual(client.channel, channel)
-        self.assertEqual(len(manifests), 4)
+        self.assertEqual(len(refs), 4)
 
-    def test_get_major_version_fml_paths(self):
+    def test_get_major_version_refs(self):
         loader = self.create_loader()
         v = version.parse("112.1.0")
         expected = "releases_v112"
 
-        result = loader.get_major_release_path(v)
+        result = loader.get_major_version_ref(v)
         self.assertEqual(result, expected)
 
-    def test_get_minor_version_fml_paths(self):
+    def test_get_minor_version_refs(self):
         loader = self.create_loader()
         v = version.parse("112.1.0")
         expected = "fenix-v112.1.0"
 
-        result = loader.get_minor_release_path(v)
+        result = loader.get_minor_version_ref(v)
         self.assertEqual(result, expected)
 
-    def test_get_major_version_paths_application_is_none(self):
+    def test_get_major_version_refs_application_is_none(self):
         v = version.parse("112.1.0")
         loader = self.create_loader()
         loader.application_data = None
-        result = loader.get_major_release_path(version=v)
+        result = loader.get_major_version_ref(version=v)
         self.assertIsNone(result)
 
-    def test_get_minor_version_paths_application_is_none(self):
+    def test_get_minor_version_refs_application_is_none(self):
         v = version.parse("112.1.0")
         loader = self.create_loader()
         loader.application_data = None
-        result = loader.get_minor_release_path(version=v)
+        result = loader.get_minor_version_ref(version=v)
         self.assertIsNone(result)
 
-    def test_create(self):
+    def test_get_fml_clients(self):
+        versions = [
+            "112.1.0",
+            "112.1.1",
+            "113.0.0",
+            "118.7.3",
+        ]
         loader = self.create_loader()
-        fml_path = "fenix/app/nimbus.fml.yaml"
 
-        result = loader.create(fml_path, loader.channel)
-        self.assertIsNotNone(result)
+        with mock.patch(
+            "experimenter.features.manifests.nimbus_fml_loader.NimbusFmlLoader.create_client",
+        ) as create:
+            result = loader.get_fml_clients(versions)
+            self.assertEqual(len(result), 4)
+            create.assert_called()
+
+    def test_get_fml_client_no_versions(self):
+        no_version = []
+        loader = self.create_loader()
+        path = Path(r"\@mozilla-mobile/firefox-android/fenix/app/nimbus.fml.yaml")
+        with mock.patch(
+            "experimenter.features.manifests.nimbus_fml_loader.NimbusFmlLoader.create_client",
+        ) as create:
+            result = loader.get_fml_clients(no_version)
+            self.assertEqual(len(result), 1)
+            create.assert_called()
+            create.assert_called_with(path, "release", "main")
+
+    def test_get_fml_client_no_app_config(self):
+        loader = self.create_loader()
+        loader.application = None
+        loader.channel = None
+        loader.application_data = None
+
+        with mock.patch(
+            "rust_fml.FmlClient.new_with_ref",
+        ) as new_with_ref:
+            result = loader.get_fml_clients(versions=[])
+            self.assertIsNone(result)
+            new_with_ref.assert_not_called()
+
+    def test_create_fml_client(self):
+        application = "fenix"
+        path = r"\@mozilla-mobile/firefox-android/fenix/app/nimbus.fml.yaml"
+        ref = "fenix-v120.2.1"
+        channel = "release"
+        loader = self.create_loader(application, channel)
+
+        with mock.patch(
+            "rust_fml.FmlClient.new_with_ref",
+        ) as new_with_ref:
+            loader.create_client(path, channel, ref)
+            new_with_ref.assert_called()
+
+    def test_get_file_path(self):
+        expected_path = Path(
+            r"\@mozilla-mobile/firefox-android/fenix/app/nimbus.fml.yaml",
+        )
+        loader = self.create_loader()
+        file_path = loader.get_file_path()
+        self.assertEqual(file_path, expected_path)
+
+    def test_get_file_path_no_application_data(self):
+        loader = self.create_loader()
+        loader.application_data = None
+        file_path = loader.get_file_path()
+        self.assertIsNone(file_path)


### PR DESCRIPTION
Because

- We want to get the repos, fml paths, and formatted versions from the `apps.yaml` file

This commit

- Adds methods to the loader that:
   - Gets the repo paths from the yaml file
   - Gets the manifest path from the yaml file
   - Formats the versions according to the format in the yaml file
   - Sets up the loader methods to be hooked up to the FML 
