### PR TITLE
fix #9453 feat(nimbus): ignore unset fields during sizing data serialization

### DIFF
--- a/experimenter/experimenter/experiments/api/v5/serializers.py
+++ b/experimenter/experimenter/experiments/api/v5/serializers.py
@@ -302,7 +302,7 @@ class NimbusConfigurationDataClass:
 
     def _get_population_sizing_data(self):
         sizing_data = cache.get(SIZING_DATA_KEY)
-        return sizing_data.json() if sizing_data else "{}"
+        return sizing_data.json(exclude_unset=True) if sizing_data else "{}"
 
     def _get_owners(self):
         owners = (

--- a/experimenter/experimenter/experiments/tests/api/v5/test_queries.py
+++ b/experimenter/experimenter/experiments/tests/api/v5/test_queries.py
@@ -2442,7 +2442,9 @@ class TestNimbusConfigQuery(MockSizingDataMixin, GraphQLTestCase):
         )
 
         pop_sizing_data = self.get_cached_sizing_data()
-        self.assertEqual(config["populationSizingData"], pop_sizing_data.json())
+        self.assertEqual(
+            config["populationSizingData"], pop_sizing_data.json(exclude_unset=True)
+        )
 
         self.assertEqual(
             len(config["firefoxVersions"]), len(NimbusExperiment.Version.names)

--- a/experimenter/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_configuration_serializer.py
+++ b/experimenter/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_configuration_serializer.py
@@ -77,7 +77,9 @@ class TestNimbusConfigurationSerializer(MockSizingDataMixin, TestCase):
         self.assertEqual(config["owners"], [{"username": experiment.owner.username}])
 
         pop_sizing_data = self.get_cached_sizing_data()
-        self.assertEqual(config["populationSizingData"], pop_sizing_data.json())
+        self.assertEqual(
+            config["populationSizingData"], pop_sizing_data.json(exclude_unset=True)
+        )
 
         for outcome in Outcomes.all():
             self.assertIn(

--- a/experimenter/experimenter/jetstream/tests/test_tasks.py
+++ b/experimenter/experimenter/jetstream/tests/test_tasks.py
@@ -1137,7 +1137,10 @@ class TestFetchJetstreamDataTask(MockSizingDataMixin, TestCase):
         tasks.fetch_population_sizing_data()
         sizing_results = cache.get(SIZING_DATA_KEY)
 
-        self.assertEqual(json.dumps(json.loads(sizing_test_data)), sizing_results.json())
+        self.assertEqual(
+            json.dumps(json.loads(sizing_test_data)),
+            sizing_results.json(exclude_unset=True),
+        )
 
     @patch("django.core.files.storage.default_storage.open")
     @patch("django.core.files.storage.default_storage.exists")


### PR DESCRIPTION
Because

- the pop sizing UI shows the configured parameters that affect the precomputed sizing data
- mobile and desktop experiments have different parameters (locale vs language is what matters here)
- it would not be helpful to show, e.g., `locale: null, language: "EN"`

This commit

- ignores unset fields in the sizing data model during serialization so that the UI doesn't have to filter them out
