### PR TITLE
fix #9458 bug(cirrus): use cirrus credentials to log into dockerhub

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -365,6 +365,7 @@ jobs:
       - deploy:
           name: Deploy to latest
           command: |
+            docker login -u $DOCKERHUB_CIRRUS_USER -p $DOCKERHUB_CIRRUS_PASS
             # Build all images for arm64 and amd64 to hydrate build cache
             make BUILD_MULTIPLATFORM=1 cirrus_build
             # Pull amd64 and tag to dockerhub for deploy


### PR DESCRIPTION
Because

* The docker login step for deploying cirrus was removed in a previous pr
* This login step is necessary becuase cirrus uses different credentials than experimenter to deploy to dockerhub

This commit

* Restores the docker login command to the cirrus deploy step

