### PR TITLE
fix #9466 chore(project): add top level dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+**/__pycache__
+**/.cache
+**/.coverage
+**/.DS_Store
+**/.mypy
+**/.pycache
+**/.pytest_cache
+**/.vscode
+**/.vscode/
+**/coverage/
+**/node_modules
+**/yarn-error.log


### PR DESCRIPTION
Because

* We are now dockerizing new Nimbus components like schemas
* We need a top level docker ignore to prevent the build context from including things like node_modules

This commit

* Adds a top level dockerignore file


