### PR TITLE
fix #9460 chore(project): split experimenter dockerfile into separate stages

### DIFF
--- a/experimenter/Dockerfile
+++ b/experimenter/Dockerfile
@@ -1,3 +1,4 @@
+#-------------------------
 FROM alpine:3.12.0 as file-loader
 
 # To preserve layer caching across machines which may have different local file properties
@@ -10,41 +11,76 @@ RUN chmod -R 555 /experimenter \
     && find /experimenter -exec touch -a -m -t 201512180130.09 {} \;
 
 
-# Dev image
-FROM python:3.11.1 AS dev
+#-------------------------
+# System packages
+FROM python:3.11.1 AS system-builder
 
-WORKDIR /experimenter
-
-
-# Disable python pyc files
-ENV PYTHONDONTWRITEBYTECODE 1
-
-
-# Scripts for waiting for the db and setting up kinto
-COPY --from=file-loader /experimenter/bin/ /experimenter/bin/
-RUN chmod +x /experimenter/bin/wait-for-it.sh
-
-
-# Install nvm with node and npm
-ENV NODE_VERSION=16.19.0
-RUN curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.35.3/install.sh | bash
-ENV NVM_DIR=/root/.nvm
-RUN . "$NVM_DIR/nvm.sh" && nvm install ${NODE_VERSION}
-RUN . "$NVM_DIR/nvm.sh" && nvm use v${NODE_VERSION}
-RUN . "$NVM_DIR/nvm.sh" && nvm alias default v${NODE_VERSION}
-ENV PATH="/root/.nvm/versions/node/v${NODE_VERSION}/bin/:${PATH}"
-
-
-# System  packages
 RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
 RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
 RUN apt-get update
 RUN apt-get --no-install-recommends install -y apt-utils ca-certificates postgresql-client yarn parallel
 
+# Install nvm with node and npm
+ENV NODE_VERSION=16.19.0
+ENV NVM_DIR=/root/.nvm
+ENV PATH="/root/.nvm/versions/node/v${NODE_VERSION}/bin/:${PATH}"
+RUN curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.35.3/install.sh | bash
+RUN . "$NVM_DIR/nvm.sh" && nvm install ${NODE_VERSION}
+RUN . "$NVM_DIR/nvm.sh" && nvm use v${NODE_VERSION}
+RUN . "$NVM_DIR/nvm.sh" && nvm alias default v${NODE_VERSION}
+
+# Disable python pyc files
+ENV PYTHONDONTWRITEBYTECODE 1
+
+# Python packages
+RUN curl -sSL https://install.python-poetry.org | python3 -
+ENV PATH "/root/.local/bin:$PATH"
+RUN poetry config virtualenvs.create false
+
+# Rust cargo
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | /bin/sh -s -- -y --profile minimal
+ENV PATH "/root/.cargo/bin:$PATH"
+
+# Python image
+#-------------------------
+FROM system-builder AS python-builder
+WORKDIR /experimenter
+
+COPY --from=file-loader /experimenter/pyproject.toml /experimenter/pyproject.toml
+COPY --from=file-loader /experimenter/poetry.lock /experimenter/poetry.lock
+RUN poetry install
+
+# If any package is installed, that is incompatible by version, this command
+# will exit non-zero and print what is usually just a warning in `poetry install`
+RUN poetry check
+
+
+# Node image
+#-------------------------
+FROM system-builder AS node-builder
+WORKDIR /experimenter
+
+# Node packages for legacy and nimbus ui
+COPY --from=file-loader /experimenter/package.json /experimenter/package.json
+COPY --from=file-loader /experimenter/yarn.lock /experimenter/yarn.lock
+COPY --from=file-loader /experimenter/experimenter/legacy/legacy-ui/core/package.json /experimenter/experimenter/legacy/legacy-ui/core/package.json
+COPY --from=file-loader /experimenter/experimenter/nimbus-ui/package.json /experimenter/experimenter/nimbus-ui/package.json
+RUN yarn install --frozen-lockfile
+
+# Node packages for htmx ui
+COPY --from=file-loader /experimenter/experimenter/theme/static_src/package.json /experimenter/experimenter/theme/static_src/package.json
+COPY --from=file-loader /experimenter/experimenter/theme/static_src/yarn.lock /experimenter/experimenter/theme/static_src/yarn.lock
+RUN yarn install --frozen-lockfile --cwd /experimenter/experimenter/theme/static_src
+
+
+
+# Rust image
+#-------------------------
+FROM system-builder AS rust-builder
+WORKDIR /application-services
 
 # Rust packages
 # This is temporary while megazord packaging is pending.
-WORKDIR /application-services
 ARG as_version
 
 RUN git clone https://github.com/mozilla/application-services.git .
@@ -57,52 +93,42 @@ RUN if [[ -z "${as_version}" ]] ; then \
 RUN git submodule init
 RUN git submodule update --recursive
 
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | /bin/sh -s -- -y --profile minimal
-ENV PATH "/root/.cargo/bin:$PATH"
 RUN mkdir -p /application-services/megazord
 
 RUN cargo build --manifest-path /application-services/megazords/nimbus-experimenter/Cargo.toml --release
 RUN cargo uniffi-bindgen generate --library /application-services/target/release/libnimbus_experimenter.so --language python --out-dir /application-services/megazord
 
-RUN mv /application-services/megazord/fml.py /application-services/megazord/rust_fml.py
-RUN mv /application-services/megazord/nimbus.py /application-services/megazord/rust_sdk.py
-RUN mv /application-services/megazord/errorsupport.py /application-services/megazord/rust_errorsupport.py
-RUN mv /application-services/megazord/remote_settings.py /application-services/megazord/rust_remote_settings.py
+# Dev image
+#-------------------------
+FROM system-builder AS dev
+WORKDIR /experimenter
 
-# The uniffi.toml file setting cdylib_name is set to "cirrus", which means the generated python is expecting
-# the library to be called libcirrus.so.
-RUN cp /application-services/target/release/libnimbus_experimenter.so /application-services/megazord/libcirrus.so
-# RUN cp /application-services/target/release/libnimbus_experimenter.so /application-services/megazord/libnimbus_experimenter.so
-ENV PYTHONPATH=$PYTHONPATH:/application-services/megazord
+# Scripts for waiting for the db and setting up kinto
+COPY --from=file-loader /experimenter/bin/ /experimenter/bin/
+RUN chmod +x /experimenter/bin/wait-for-it.sh
 
 # Python packages
-WORKDIR /experimenter
-RUN curl -sSL https://install.python-poetry.org | python3 -
-ENV PATH "/root/.local/bin:$PATH"
-RUN poetry config virtualenvs.create false
-COPY --from=file-loader /experimenter/pyproject.toml /experimenter/pyproject.toml
-COPY --from=file-loader /experimenter/poetry.lock /experimenter/poetry.lock
-RUN poetry install
-
-# If any package is installed, that is incompatible by version, this command
-# will exit non-zero and print what is usually just a warning in `poetry install`
-RUN poetry check
-
+COPY --from=python-builder /usr/local/bin/ /usr/local/bin/
+COPY --from=python-builder /usr/local/lib/python3.11/site-packages/ /usr/local/lib/python3.11/site-packages/
 
 # Node packages
-COPY --from=file-loader /experimenter/package.json /experimenter/package.json
-COPY --from=file-loader /experimenter/yarn.lock /experimenter/yarn.lock
-COPY --from=file-loader /experimenter/experimenter/legacy/legacy-ui/core/package.json /experimenter/experimenter/legacy/legacy-ui/core/package.json
-RUN yarn install --frozen-lockfile
+COPY --from=node-builder /experimenter/experimenter/legacy/legacy-ui/core/node_modules/ /experimenter/experimenter/legacy/legacy-ui/core/node_modules/
+COPY --from=node-builder /experimenter/experimenter/theme/static_src/node_modules/ /experimenter/experimenter/theme/static_src/node_modules/
+COPY --from=node-builder /experimenter/experimenter/nimbus-ui/node_modules/ /experimenter/experimenter/nimbus-ui/node_modules/
+COPY --from=node-builder /experimenter/node_modules/ /experimenter/node_modules/
 
-COPY --from=file-loader /experimenter/experimenter/theme/static_src/package.json /experimenter/experimenter/theme/static_src/package.json
-COPY --from=file-loader /experimenter/experimenter/theme/static_src/yarn.lock /experimenter/experimenter/theme/static_src/yarn.lock
-RUN yarn install --frozen-lockfile --cwd /experimenter/experimenter/theme/static_src
+# Rust packages
+COPY --from=rust-builder /application-services/megazord/fml.py /application-services/megazord/rust_fml.py
+COPY --from=rust-builder /application-services/megazord/nimbus.py /application-services/megazord/rust_sdk.py
+COPY --from=rust-builder /application-services/megazord/errorsupport.py /application-services/megazord/rust_errorsupport.py
+COPY --from=rust-builder /application-services/megazord/remote_settings.py /application-services/megazord/rust_remote_settings.py
+# The uniffi.toml file setting cdylib_name is set to "cirrus", which means the generated python is expecting
+# the library to be called libcirrus.so.
+COPY --from=rust-builder /application-services/target/release/libnimbus_experimenter.so /application-services/megazord/libcirrus.so
+ENV PYTHONPATH=$PYTHONPATH:/application-services/megazord
 
-COPY --from=file-loader /experimenter/experimenter/nimbus-ui/package.json /experimenter/experimenter/nimbus-ui/package.json
-RUN yarn install --frozen-lockfile
 
-
+#-------------------------
 FROM dev AS test
 
 # Copy source
@@ -110,19 +136,25 @@ COPY --from=file-loader /experimenter/ /experimenter/
 
 
 # Build image
-FROM dev AS ui
+#-------------------------
+FROM test AS ui
 
-
-# Build assets
-COPY --from=file-loader /experimenter/experimenter/legacy/legacy-ui/ /experimenter/experimenter/legacy/legacy-ui/
+# Build legacy assets
+COPY --from=file-loader /experimenter/experimenter/legacy/legacy-ui/* /experimenter/experimenter/legacy/legacy-ui/
 RUN yarn workspace @experimenter/core build
+
+# Build nimbus ui assets
 COPY --from=file-loader /experimenter/experimenter/nimbus-ui/ /experimenter/experimenter/nimbus-ui/
 RUN yarn workspace @experimenter/nimbus-ui build
+
+# Build static assets
 COPY --from=file-loader /experimenter/experimenter/theme/ /experimenter/experimenter/theme/
 COPY --from=file-loader /experimenter/experimenter/templates/ /experimenter/experimenter/templates/
 RUN yarn --cwd /experimenter/experimenter/theme/static_src build
 
+
 # Deploy image
+#-------------------------
 FROM python:3.11.1-slim AS deploy
 
 WORKDIR /experimenter
@@ -131,15 +163,12 @@ EXPOSE 7001
 # Disable python pyc files
 ENV PYTHONDONTWRITEBYTECODE 1
 
-
 # Add poetry to path
 ENV PATH "/root/.poetry/bin:${PATH}"
-
 
 # System packages
 RUN apt-get update
 RUN apt-get --no-install-recommends install -y apt-utils ca-certificates postgresql-client
-
 
 # Copy source from previously built containers
 COPY --from=dev /usr/local/bin/ /usr/local/bin/


### PR DESCRIPTION


Because

* Docker buildx will build stages in parallel
* This can reduce build times and improve cache hit rates
* This may allow reusing base stages across different nimbus modules

This commit

* Splits the Experimenter dockerfile into separate stages for Python, Node, and Rust packages


