### PR TITLE
fix #9487 chore(project): use faker.unique to prevent uniqueness errors

### DIFF
--- a/experimenter/experimenter/base/tests/factories.py
+++ b/experimenter/experimenter/base/tests/factories.py
@@ -1,9 +1,9 @@
 import factory
-from faker import Factory as FakerFactory
+from faker import Faker
 
 from experimenter.base.models import Country, Language, Locale
 
-faker = FakerFactory.create()
+faker = Faker()
 
 
 class CountryFactory(factory.django.DjangoModelFactory):

--- a/experimenter/experimenter/experiments/tests/factories.py
+++ b/experimenter/experimenter/experiments/tests/factories.py
@@ -10,7 +10,7 @@ import factory
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.utils import timezone
 from django.utils.text import slugify
-from faker import Factory as FakerFactory
+from faker import Faker
 
 from experimenter.base.models import Country, Language, Locale
 from experimenter.experiments.api.v6.serializers import NimbusExperimentSerializer
@@ -34,7 +34,7 @@ from experimenter.openidc.tests.factories import UserFactory
 from experimenter.outcomes import Outcomes
 from experimenter.projects.tests.factories import ProjectFactory
 
-faker = FakerFactory.create()
+faker = Faker()
 
 
 # TODO: assemble a directory of sample screenshot images?
@@ -76,7 +76,7 @@ TEST_LOCALIZATIONS = """\
 
 
 class NimbusFeatureConfigFactory(factory.django.DjangoModelFactory):
-    name = factory.LazyAttribute(lambda o: faker.catch_phrase())
+    name = factory.LazyAttribute(lambda o: faker.unique.catch_phrase())
     slug = factory.LazyAttribute(
         lambda o: slugify(o.name)[: NimbusExperiment.MAX_SLUG_LEN]
     )
@@ -365,7 +365,7 @@ class Lifecycles(Enum):
 class NimbusExperimentFactory(factory.django.DjangoModelFactory):
     publish_status = NimbusExperiment.PublishStatus.IDLE
     owner = factory.SubFactory(UserFactory)
-    name = factory.LazyAttribute(lambda o: faker.catch_phrase())
+    name = factory.LazyAttribute(lambda o: faker.unique.catch_phrase())
     slug = factory.LazyAttribute(
         lambda o: slugify(o.name)[: NimbusExperiment.MAX_SLUG_LEN]
     )
@@ -597,7 +597,7 @@ class NimbusExperimentFactory(factory.django.DjangoModelFactory):
 class NimbusBranchFactory(factory.django.DjangoModelFactory):
     ratio = 1
     experiment = factory.SubFactory(NimbusExperimentFactory)
-    name = factory.LazyAttribute(lambda o: faker.catch_phrase())
+    name = factory.LazyAttribute(lambda o: faker.unique.catch_phrase())
     slug = factory.LazyAttribute(
         lambda o: slugify(o.name)[: NimbusExperiment.MAX_SLUG_LEN]
     )
@@ -672,7 +672,7 @@ class NimbusDocumentationLinkFactory(factory.django.DjangoModelFactory):
 
 
 class NimbusIsolationGroupFactory(factory.django.DjangoModelFactory):
-    name = factory.LazyAttribute(lambda o: slugify(faker.catch_phrase()))
+    name = factory.LazyAttribute(lambda o: slugify(faker.unique.catch_phrase()))
     instance = factory.Sequence(lambda n: n)
 
     class Meta:
@@ -694,7 +694,7 @@ class NimbusChangeLogFactory(factory.django.DjangoModelFactory):
     changed_by = factory.SubFactory(UserFactory)
     old_status = NimbusExperiment.Status.DRAFT
     new_status = NimbusExperiment.Status.DRAFT
-    message = factory.LazyAttribute(lambda o: faker.catch_phrase())
+    message = factory.LazyAttribute(lambda o: faker.unique.catch_phrase())
     experiment_data = factory.LazyAttribute(
         lambda o: dict(NimbusExperimentChangeLogSerializer(o.experiment).data)
     )

--- a/experimenter/experimenter/legacy/legacy_experiments/tests/factories.py
+++ b/experimenter/experimenter/legacy/legacy_experiments/tests/factories.py
@@ -7,7 +7,7 @@ import factory
 from django.conf import settings
 from django.utils import timezone
 from django.utils.text import slugify
-from faker import Factory as FakerFactory
+from faker import Faker
 
 from experimenter.base.models import Country, Locale
 from experimenter.legacy.legacy_experiments.constants import ExperimentConstants
@@ -21,7 +21,7 @@ from experimenter.legacy.legacy_experiments.models import (
 from experimenter.openidc.tests.factories import UserFactory
 from experimenter.projects.tests.factories import ProjectFactory
 
-faker = FakerFactory.create()
+faker = Faker()
 NORMANDY_STATUS_CHOICES = Experiment.STATUS_CHOICES[:-1]
 
 
@@ -30,7 +30,7 @@ class ExperimentFactory(ExperimentConstants, factory.django.DjangoModelFactory):
     owner = factory.SubFactory(UserFactory)
     analysis_owner = factory.SubFactory(UserFactory)
     engineering_owner = factory.LazyAttribute(lambda o: faker.name())
-    name = factory.LazyAttribute(lambda o: faker.catch_phrase())
+    name = factory.LazyAttribute(lambda o: faker.unique.catch_phrase())
     slug = factory.LazyAttribute(lambda o: "{}_".format(slugify(o.name)))
     archived = False
     short_description = factory.LazyAttribute(lambda o: faker.text(200))
@@ -73,7 +73,9 @@ class ExperimentFactory(ExperimentConstants, factory.django.DjangoModelFactory):
     firefox_channel = factory.LazyAttribute(
         lambda o: random.choice(Experiment.CHANNEL_CHOICES[1:])[0]
     )
-    addon_experiment_id = factory.LazyAttribute(lambda o: slugify(faker.catch_phrase()))
+    addon_experiment_id = factory.LazyAttribute(
+        lambda o: slugify(faker.unique.catch_phrase())
+    )
     addon_release_url = factory.LazyAttribute(
         lambda o: "https://www.example.com/{}-release.xpi".format(o.addon_experiment_id)
     )
@@ -217,11 +219,11 @@ class ExperimentFactory(ExperimentConstants, factory.django.DjangoModelFactory):
 class BaseExperimentVariantFactory(factory.django.DjangoModelFactory):
     description = factory.LazyAttribute(lambda o: faker.text())
     experiment = factory.SubFactory(ExperimentFactory)
-    name = factory.LazyAttribute(lambda o: faker.catch_phrase())
+    name = factory.LazyAttribute(lambda o: faker.unique.catch_phrase())
     slug = factory.LazyAttribute(lambda o: slugify(o.name))
-    message_targeting = factory.LazyAttribute(lambda o: faker.catch_phrase())
-    message_threshold = factory.LazyAttribute(lambda o: faker.catch_phrase())
-    message_triggers = factory.LazyAttribute(lambda o: faker.catch_phrase())
+    message_targeting = factory.LazyAttribute(lambda o: faker.unique.catch_phrase())
+    message_threshold = factory.LazyAttribute(lambda o: faker.unique.catch_phrase())
+    message_triggers = factory.LazyAttribute(lambda o: faker.unique.catch_phrase())
 
     @factory.lazy_attribute
     def addon_release_url(self):
@@ -241,7 +243,7 @@ class ExperimentVariantFactory(BaseExperimentVariantFactory):
         if self.experiment.pref_type == Experiment.PREF_TYPE_INT:
             value = 10
         elif self.experiment.pref_type == Experiment.PREF_TYPE_STR:
-            value = slugify(faker.catch_phrase())
+            value = slugify(faker.unique.catch_phrase())
         return json.dumps(value)
 
 
@@ -251,7 +253,7 @@ class ExperimentControlFactory(ExperimentVariantFactory):
 
 class VariantPreferencesFactory(factory.django.DjangoModelFactory):
     variant = factory.SubFactory(ExperimentVariantFactory)
-    pref_name = factory.LazyAttribute(lambda o: faker.catch_phrase())
+    pref_name = factory.LazyAttribute(lambda o: faker.unique.catch_phrase())
     pref_type = "string"
     pref_branch = factory.LazyAttribute(
         lambda o: random.choice(Experiment.PREF_BRANCH_CHOICES[1:])[0]
@@ -263,7 +265,6 @@ class VariantPreferencesFactory(factory.django.DjangoModelFactory):
 
 
 class ExperimentChangeLogFactory(factory.django.DjangoModelFactory):
-
     experiment = factory.SubFactory(ExperimentFactory)
     changed_by = factory.SubFactory(UserFactory)
     old_status = factory.LazyAttribute(

--- a/experimenter/experimenter/legacy/legacy_experiments/tests/test_forms.py
+++ b/experimenter/experimenter/legacy/legacy_experiments/tests/test_forms.py
@@ -7,7 +7,7 @@ from django.contrib.auth.models import Permission
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ValidationError
 from django.test import TestCase, override_settings
-from faker import Factory as FakerFactory
+from faker import Faker
 
 from experimenter.base.tests.factories import CountryFactory, LocaleFactory
 from experimenter.base.tests.mixins import MockRequestMixin
@@ -40,7 +40,7 @@ from experimenter.legacy.notifications.models import Notification
 from experimenter.openidc.tests.factories import UserFactory
 from experimenter.projects.tests.factories import ProjectFactory
 
-faker = FakerFactory.create()
+faker = Faker()
 
 
 class TestJSONField(TestCase):
@@ -146,7 +146,6 @@ class TestChangeLogMixin(MockRequestMixin, TestCase):
         self.assertEqual(change.new_status, new_status)
 
     def test_changelog_not_produced_when_no_change(self):
-
         experiment = ExperimentFactory.create_with_status(
             target_status=Experiment.STATUS_DRAFT
         )
@@ -442,7 +441,6 @@ class TestExperimentObjectivesForm(MockRequestMixin, TestCase):
 
 
 class TestExperimentRisksForm(MockRequestMixin, TestCase):
-
     valid_data = {
         "risk_partner_related": RADIO_NO,
         "risk_brand": RADIO_YES,
@@ -522,7 +520,6 @@ class TestExperimentRisksForm(MockRequestMixin, TestCase):
 
 
 class TestExperimentResultsForm(MockRequestMixin, TestCase):
-
     valid_data = {
         "results_url": "https://example.com",
         "results_initial": "Initially, all went well.",
@@ -962,7 +959,6 @@ class TestExperimentCommentForm(MockRequestMixin, TestCase):
 
 class TestExperimentArchiveForm(MockRequestMixin, MockBugzillaTasksMixin, TestCase):
     def test_form_flips_archive_bool(self):
-
         experiment = ExperimentFactory.create(archived=False)
 
         form = ExperimentArchiveForm(self.request, instance=experiment, data={})

--- a/experimenter/experimenter/legacy/notifications/tests/factories.py
+++ b/experimenter/experimenter/legacy/notifications/tests/factories.py
@@ -1,15 +1,15 @@
 import factory
-from faker import Factory as FakerFactory
+from faker import Faker
 
 from experimenter.legacy.notifications.models import Notification
 from experimenter.openidc.tests.factories import UserFactory
 
-faker = FakerFactory.create()
+faker = Faker()
 
 
 class NotificationFactory(factory.django.DjangoModelFactory):
     user = factory.SubFactory(UserFactory)
-    message = faker.catch_phrase()
+    message = faker.unique.catch_phrase()
 
     class Meta:
         model = Notification

--- a/experimenter/experimenter/openidc/tests/factories.py
+++ b/experimenter/experimenter/openidc/tests/factories.py
@@ -1,8 +1,8 @@
 import factory
 from django.contrib.auth.models import User
-from faker import Factory as FakerFactory
+from faker import Faker
 
-faker = FakerFactory.create()
+faker = Faker()
 
 
 class UserFactory(factory.django.DjangoModelFactory):

--- a/experimenter/experimenter/projects/tests/factories.py
+++ b/experimenter/experimenter/projects/tests/factories.py
@@ -1,14 +1,14 @@
 import factory
 from django.utils.text import slugify
-from faker import Factory as FakerFactory
+from faker import Faker
 
 from experimenter.projects.models import Project
 
-faker = FakerFactory.create()
+faker = Faker()
 
 
 class ProjectFactory(factory.django.DjangoModelFactory):
-    name = factory.LazyAttribute(lambda o: faker.catch_phrase())
+    name = factory.LazyAttribute(lambda o: faker.unique.catch_phrase())
     slug = factory.LazyAttribute(lambda o: f"{slugify(o.name)}_")
 
     class Meta:


### PR DESCRIPTION
Because

* We use Faker in our unit tests to generate slugs for test factories
* Sometimes it will generate the same value twice and cause a database uniqueness violation
* Faker includes a unique feature that will prevent this

This commit

* Updates all factories to use faker.unique for all unique fields like names/slugs

