### PR TITLE
fix #9509 bug(nimbus): add env file to fetch external configs in circle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -538,6 +538,7 @@ jobs:
           command: |
             git checkout main
             git pull origin main
+            cp .env.sample .env
             make fetch_external_resources
             if (($(git status --porcelain | wc -c) > 0))
               then


### PR DESCRIPTION
Because

* We recently moved the FML parsing into the Experimenter container as part of fetching external configs
* The Experimenter container requires an environment file to start

This commit

* Uses the .env.sample file as part of the fetch_external_configs circle task


