### PR TITLE
fix #9419 feat(nimbus): use qcdou instead of dou for desktop guardrail results

### DIFF
--- a/experimenter/experimenter/nimbus-ui/src/components/PageResults/TableHighlights/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageResults/TableHighlights/index.tsx
@@ -13,6 +13,7 @@ import {
   HIGHLIGHTS_METRICS_LIST,
   METRIC,
   METRICS_TIPS,
+  METRIC_TO_GROUP,
   TABLE_LABEL,
 } from "src/lib/visualization/constants";
 import {
@@ -25,6 +26,7 @@ import {
   getExperiment_experimentBySlug_referenceBranch,
   getExperiment_experimentBySlug_treatmentBranches,
 } from "src/types/getExperiment";
+import { NimbusExperimentApplicationEnum } from "src/types/globalTypes";
 
 export type TableHighlightsProps = {
   experiment: getExperiment_experimentBySlug;
@@ -37,9 +39,21 @@ type Branch =
   | getExperiment_experimentBySlug_referenceBranch
   | getExperiment_experimentBySlug_treatmentBranches;
 
-const getHighlightMetrics = (outcomes: OutcomesList) => {
+const getHighlightMetrics = (outcomes: OutcomesList, isDesktop = false) => {
   // Make a copy of `HIGHLIGHTS_METRICS_LIST` since we modify it.
-  const highlightMetricsList = [...HIGHLIGHTS_METRICS_LIST];
+  const highlightMetricsList = HIGHLIGHTS_METRICS_LIST.map(
+    (highlightMetric) => {
+      if (isDesktop && highlightMetric.value === METRIC.DAYS_OF_USE) {
+        return {
+          value: METRIC.QUALIFIED_CUMULATIVE_DAYS_OF_USE,
+          name: "Qualified Cumulative Days of Use",
+          tooltip: METRICS_TIPS.QUALIFIED_CUMULATIVE_DAYS_OF_USE,
+          group: METRIC_TO_GROUP[METRIC.QUALIFIED_CUMULATIVE_DAYS_OF_USE],
+        };
+      }
+      return highlightMetric;
+    },
+  );
   outcomes?.forEach((outcome) => {
     if (!outcome?.isDefault) {
       return;
@@ -79,7 +93,10 @@ const TableHighlights = ({
   segment = "all",
 }: TableHighlightsProps) => {
   const { primaryOutcomes } = useOutcomes(experiment);
-  const highlightMetricsList = getHighlightMetrics(primaryOutcomes);
+  const highlightMetricsList = getHighlightMetrics(
+    primaryOutcomes,
+    experiment.application === NimbusExperimentApplicationEnum.DESKTOP,
+  );
   const branchDescriptions = getBranchDescriptions(
     experiment.referenceBranch,
     experiment.treatmentBranches,

--- a/experimenter/experimenter/nimbus-ui/src/components/PageResults/TableResults/index.test.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageResults/TableResults/index.test.tsx
@@ -9,6 +9,7 @@ import { mockExperimentQuery, MockResultsContextProvider } from "src/lib/mocks";
 import { RouterSlugProvider } from "src/lib/test-utils";
 import { BRANCH_COMPARISON } from "src/lib/visualization/constants";
 import { mockIncompleteAnalysis } from "src/lib/visualization/mocks";
+import { NimbusExperimentApplicationEnum } from "src/types/globalTypes";
 
 const { mock, experiment } = mockExperimentQuery("demo-slug");
 
@@ -18,6 +19,29 @@ describe("TableResults", () => {
       <RouterSlugProvider mocks={[mock]}>
         <MockResultsContextProvider>
           <TableResults {...{ experiment }} />
+        </MockResultsContextProvider>
+      </RouterSlugProvider>,
+    );
+    const EXPECTED_HEADINGS = [
+      "2-Week Browser Retention",
+      "Mean Searches Per User",
+      "Qualified Cumulative Days of Use",
+      "Total Users",
+    ];
+
+    EXPECTED_HEADINGS.forEach((heading) => {
+      expect(screen.getByText(heading)).toBeInTheDocument();
+    });
+  });
+
+  it("renders correct headings for non-desktop experiments", () => {
+    const { experiment: ios_experiment } = mockExperimentQuery("demo-slug", {
+      application: NimbusExperimentApplicationEnum.IOS,
+    });
+    render(
+      <RouterSlugProvider mocks={[mock]}>
+        <MockResultsContextProvider>
+          <TableResults experiment={ios_experiment} />
         </MockResultsContextProvider>
       </RouterSlugProvider>,
     );

--- a/experimenter/experimenter/nimbus-ui/src/components/PageResults/TableResultsWeekly/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageResults/TableResultsWeekly/index.tsx
@@ -13,6 +13,9 @@ import {
   BRANCH_COMPARISON,
   GENERAL_TIPS,
   HIGHLIGHTS_METRICS_LIST,
+  METRIC,
+  METRICS_TIPS,
+  METRIC_TO_GROUP,
 } from "src/lib/visualization/constants";
 import {
   AnalysisBases,
@@ -23,12 +26,34 @@ export type TableResultsWeeklyProps = {
   branchComparison?: BranchComparisonValues;
   analysisBasis?: AnalysisBases;
   segment?: string;
+  isDesktop?: boolean;
+};
+
+const getHighlightMetrics = (isDesktop = false) => {
+  // Make a copy of `HIGHLIGHTS_METRICS_LIST` since we modify it.
+  if (isDesktop) {
+    const highlightMetricsList = [...HIGHLIGHTS_METRICS_LIST];
+    return highlightMetricsList.map((highlightMetric) => {
+      if (highlightMetric.value === METRIC.DAYS_OF_USE) {
+        return {
+          value: METRIC.QUALIFIED_CUMULATIVE_DAYS_OF_USE,
+          name: "Qualified Cumulative Days of Use",
+          tooltip: METRICS_TIPS.QUALIFIED_CUMULATIVE_DAYS_OF_USE,
+          group: METRIC_TO_GROUP[METRIC.QUALIFIED_CUMULATIVE_DAYS_OF_USE],
+        };
+      }
+      return highlightMetric;
+    });
+  }
+
+  return HIGHLIGHTS_METRICS_LIST;
 };
 
 const TableResultsWeekly = ({
   branchComparison = BRANCH_COMPARISON.UPLIFT,
   analysisBasis = "enrollments",
   segment = "all",
+  isDesktop = false,
 }: TableResultsWeeklyProps) => {
   const {
     analysis: { overall },
@@ -63,7 +88,7 @@ const TableResultsWeekly = ({
       </span>
       <Collapse in={open}>
         <div className="mt-2">
-          {HIGHLIGHTS_METRICS_LIST.map((metric, index) => {
+          {getHighlightMetrics(isDesktop).map((metric, index) => {
             return (
               <div key={`${metric.value}_weekly`}>
                 <h3

--- a/experimenter/experimenter/nimbus-ui/src/components/PageResults/TableWithTabComparison/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageResults/TableWithTabComparison/index.tsx
@@ -23,6 +23,7 @@ export type TableWithTabComparisonProps = {
   className?: string;
   analysisBasis?: AnalysisBases;
   segment?: string;
+  isDesktop?: boolean;
 };
 
 export const TableWithTabComparison = ({
@@ -31,6 +32,7 @@ export const TableWithTabComparison = ({
   className = "rounded-bottom mb-5",
   analysisBasis = "enrollments",
   segment = "all",
+  isDesktop = false,
 }: TableWithTabComparisonProps) => (
   <Tabs defaultActiveKey={BRANCH_COMPARISON.UPLIFT} className="border-bottom-0">
     <Tab eventKey={BRANCH_COMPARISON.UPLIFT} title="Relative uplift comparison">
@@ -43,7 +45,11 @@ export const TableWithTabComparison = ({
           />
         ) : (
           /* @ts-ignore - TODO, assert Table is TablesWithoutExperiment if `experiment` not provided */
-          <Table analysisBasis={analysisBasis} segment={segment} />
+          <Table
+            analysisBasis={analysisBasis}
+            segment={segment}
+            isDesktop={isDesktop}
+          />
         )}
       </div>
     </Tab>
@@ -63,6 +69,7 @@ export const TableWithTabComparison = ({
               branchComparison={BRANCH_COMPARISON.ABSOLUTE}
               analysisBasis={analysisBasis}
               segment={segment}
+              isDesktop={isDesktop}
             />
           </>
         )}

--- a/experimenter/experimenter/nimbus-ui/src/components/PageResults/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageResults/index.tsx
@@ -30,6 +30,7 @@ import {
 import { GROUP, METRIC_TYPE } from "src/lib/visualization/constants";
 import { AnalysisBases, AnalysisError } from "src/lib/visualization/types";
 import { getSortedBranchNames } from "src/lib/visualization/utils";
+import { NimbusExperimentApplicationEnum } from "src/types/globalTypes";
 
 const PageResults: React.FunctionComponent<RouteComponentProps> = () => {
   const { experiment, analysis, useRedirectCondition, useAnalysisRequired } =
@@ -337,6 +338,10 @@ const PageResults: React.FunctionComponent<RouteComponentProps> = () => {
                 className="rounded-bottom mb-3 border-top-0"
                 analysisBasis={selectedAnalysisBasis}
                 segment={selectedSegment}
+                isDesktop={
+                  experiment.application ===
+                  NimbusExperimentApplicationEnum.DESKTOP
+                }
               />
             )}
 
@@ -348,6 +353,10 @@ const PageResults: React.FunctionComponent<RouteComponentProps> = () => {
                 Table={TableResultsWeekly}
                 analysisBasis={selectedAnalysisBasis}
                 segment={selectedSegment}
+                isDesktop={
+                  experiment.application ===
+                  NimbusExperimentApplicationEnum.DESKTOP
+                }
               />
             )}
         </div>

--- a/experimenter/experimenter/nimbus-ui/src/lib/visualization/constants.ts
+++ b/experimenter/experimenter/nimbus-ui/src/lib/visualization/constants.ts
@@ -9,6 +9,8 @@ export const METRICS_TIPS = {
     "Total users in a variant and the % of users out of the entire experiment population",
   CONVERSION: "Percentage of users in the variant who used this feature",
   DAYS_OF_USE: "Average number of days each client sent a main ping",
+  QUALIFIED_CUMULATIVE_DAYS_OF_USE:
+    "Average number of days each client sent a main ping",
 };
 
 export const SEGMENT_TIPS = {
@@ -63,6 +65,7 @@ export const METRIC = {
   SEARCH: "search_count",
   DAYS_OF_USE: "days_of_use",
   USER_COUNT: "identity",
+  QUALIFIED_CUMULATIVE_DAYS_OF_USE: "qualified_cumulative_days_of_use",
 };
 
 export const METRIC_TYPE = {
@@ -130,11 +133,16 @@ const GROUPED_METRICS = [
   },
   {
     name: GROUP.OTHER,
-    metrics: ["retained", "identity", "days_of_use"],
+    metrics: [
+      "retained",
+      "identity",
+      "days_of_use",
+      "qualified_cumulative_days_of_use",
+    ],
   },
 ];
 
-const METRIC_TO_GROUP = GROUPED_METRICS.reduce((res, group) => {
+export const METRIC_TO_GROUP = GROUPED_METRICS.reduce((res, group) => {
   group.metrics.forEach((metric) => {
     res[metric] = group.name;
   });

--- a/experimenter/experimenter/nimbus-ui/src/lib/visualization/mocks.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/lib/visualization/mocks.tsx
@@ -697,6 +697,7 @@ export const mockAnalysis = (modifications = {}) =>
                     },
                   },
                   days_of_use: CONTROL_NEUTRAL,
+                  qualified_cumulative_days_of_use: CONTROL_NEUTRAL,
                 },
                 search_metrics: {
                   search_count: {
@@ -989,6 +990,7 @@ export const mockAnalysis = (modifications = {}) =>
                   },
                   feature_c: TREATMENT_NEUTRAL,
                   days_of_use: TREATMENT_NEUTRAL,
+                  qualified_cumulative_days_of_use: TREATMENT_NEUTRAL,
                   feature_d: {
                     absolute: {
                       first: {
@@ -1333,6 +1335,7 @@ export const mockAnalysisWithSegments = mockAnalysis({
                 },
               },
               days_of_use: CONTROL_NEUTRAL,
+              qualified_cumulative_days_of_use: CONTROL_NEUTRAL,
             },
             search_metrics: {
               search_count: {
@@ -1625,6 +1628,7 @@ export const mockAnalysisWithSegments = mockAnalysis({
               },
               feature_c: TREATMENT_NEUTRAL,
               days_of_use: TREATMENT_NEUTRAL,
+              qualified_cumulative_days_of_use: TREATMENT_NEUTRAL,
               feature_d: {
                 absolute: {
                   first: {
@@ -1960,6 +1964,7 @@ export const mockAnalysisWithSegments = mockAnalysis({
                 },
               },
               days_of_use: CONTROL_NEUTRAL,
+              qualified_cumulative_days_of_use: CONTROL_NEUTRAL,
             },
             search_metrics: {
               search_count: {
@@ -2252,6 +2257,7 @@ export const mockAnalysisWithSegments = mockAnalysis({
               },
               feature_c: TREATMENT_NEUTRAL,
               days_of_use: TREATMENT_NEUTRAL,
+              qualified_cumulative_days_of_use: TREATMENT_NEUTRAL,
               feature_d: {
                 absolute: {
                   first: {
@@ -2594,6 +2600,7 @@ export const mockAnalysisWithExposures = mockAnalysis({
                 },
               },
               days_of_use: CONTROL_NEUTRAL,
+              qualified_cumulative_days_of_use: CONTROL_NEUTRAL,
             },
             search_metrics: {
               search_count: {
@@ -2886,6 +2893,7 @@ export const mockAnalysisWithExposures = mockAnalysis({
               },
               feature_c: TREATMENT_NEUTRAL,
               days_of_use: TREATMENT_NEUTRAL,
+              qualified_cumulative_days_of_use: TREATMENT_NEUTRAL,
               feature_d: {
                 absolute: {
                   first: {
@@ -3223,6 +3231,7 @@ export const mockAnalysisWithExposures = mockAnalysis({
                 },
               },
               days_of_use: CONTROL_NEUTRAL,
+              qualified_cumulative_days_of_use: CONTROL_NEUTRAL,
             },
             search_metrics: {
               search_count: {
@@ -3515,6 +3524,7 @@ export const mockAnalysisWithExposures = mockAnalysis({
               },
               feature_c: TREATMENT_NEUTRAL,
               days_of_use: TREATMENT_NEUTRAL,
+              qualified_cumulative_days_of_use: TREATMENT_NEUTRAL,
               feature_d: {
                 absolute: {
                   first: {
@@ -4717,6 +4727,7 @@ export const mockAnalysisWithErrorsAndResults = (modifications = {}) =>
                     },
                   },
                   days_of_use: CONTROL_NEUTRAL,
+                  qualified_cumulative_days_of_use: CONTROL_NEUTRAL,
                 },
                 search_metrics: {
                   search_count: {
@@ -5009,6 +5020,7 @@ export const mockAnalysisWithErrorsAndResults = (modifications = {}) =>
                   },
                   feature_c: TREATMENT_NEUTRAL,
                   days_of_use: TREATMENT_NEUTRAL,
+                  qualified_cumulative_days_of_use: TREATMENT_NEUTRAL,
                   feature_d: {
                     absolute: {
                       first: {


### PR DESCRIPTION
Because

- DOU causes confusion vs DAU
- QCDOU is already calculated for desktop experiments

This commit

- puts QCDOU in the highlights/guardrails sections of the Results page for Desktop experiments
