### PR TITLE
Fixes #9507 fix(nimbus): Fix experimenter docs links

### DIFF
--- a/experimenter/experimenter/nimbus-ui/src/lib/constants.ts
+++ b/experimenter/experimenter/nimbus-ui/src/lib/constants.ts
@@ -68,7 +68,7 @@ export const EXTERNAL_URLS = {
   BUCKET_WARNING_EXPLANATION:
     "https://experimenter.info/rollouts/rollouts-bucketing-warning",
   CUSTOM_AUDIENCES_EXPLANATION:
-    "https://experimenter.info/workflow/custom-audiences",
+    "https://experimenter.info/workflow/implementing/custom-audiences",
   WHAT_TRAIN_IS_IT: "https://whattrainisitnow.com",
 };
 

--- a/experimenter/experimenter/nimbus-ui/src/lib/constants.ts
+++ b/experimenter/experimenter/nimbus-ui/src/lib/constants.ts
@@ -66,7 +66,7 @@ export const EXTERNAL_URLS = {
   LAUNCH_DOCUMENTATION:
     "https://experimenter.info/access#onboarding-for-new-reviewers-l3",
   BUCKET_WARNING_EXPLANATION:
-    "https://experimenter.info/rollouts-and-experiments#question-2",
+    "https://experimenter.info/rollouts/rollouts-bucketing-warning",
   CUSTOM_AUDIENCES_EXPLANATION:
     "https://experimenter.info/workflow/custom-audiences",
   WHAT_TRAIN_IS_IT: "https://whattrainisitnow.com",


### PR DESCRIPTION
Because

- We had a few broken links to experimenter.info

This commit

- Fixes links for:
   - [Rollout bucketing warning](https://experimenter.info/rollouts/rollouts-bucketing-warning)
   - [Custom audiences](https://experimenter.info/workflow/implementing/custom-audiences)
