### PR TITLE
fix #9538 bug(project): build dev container before running manifest tool

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ jetstream_config:
 	unzip -o -d experimenter/experimenter/outcomes experimenter/experimenter/outcomes/metric-hub.zip
 	rm -Rf experimenter/experimenter/outcomes/metric-hub-main/.script/
 
-feature_manifests:
+feature_manifests: build_dev
 	mkdir -p $(MANIFESTS_DIR)
 
 	$(COMPOSE) run experimenter /experimenter/bin/manifest-tool.py fetch-latest


### PR DESCRIPTION
Because

* We recently moved our FML parsing into the Experimenter Docker container
* This requires that the experimenter:dev container is built before running the make fetch_external_resources command
* This was ommitted and the hourly CircleCI task is broken

This commit

* Adds build_dev as a pre requisite to make fetch_external_resources


