### PR TITLE
fix #9543 bug(project): disable multiplatform builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -452,10 +452,12 @@ jobs:
       - deploy:
           name: Deploy to latest
           command: |
-            ./scripts/store_git_info.sh
-            # Build all images for aarch64 and x86_64 to hydrate build cache
-            make BUILD_MULTIPLATFORM=1 build_dev build_test build_ui build_prod
+            # TODO: https://github.com/mozilla/experimenter/issues/9536
+            # Disbled until Hydrobuild is functioning
+            # # Build all images for aarch64 and x86_64 to hydrate build cache
+            # make BUILD_MULTIPLATFORM=1 build_dev build_test build_ui build_prod
             # Pull x86_64 and tag to dockerhub for deploy
+            ./scripts/store_git_info.sh
             make build_prod
             docker tag experimenter:deploy ${DOCKERHUB_REPO}:latest
             docker push ${DOCKERHUB_REPO}:latest
@@ -473,8 +475,10 @@ jobs:
       - deploy:
           name: Deploy to latest
           command: |
+            # TODO: https://github.com/mozilla/experimenter/issues/9536
+            # Disbled until Hydrobuild is functioning
             # Build all images for aarch64 and x86_64 to hydrate build cache
-            make BUILD_MULTIPLATFORM=1 cirrus_build
+            # make BUILD_MULTIPLATFORM=1 cirrus_build
             # Pull x86_64 and tag to dockerhub for deploy
             make cirrus_build
             docker tag cirrus:deploy ${DOCKERHUB_CIRRUS_REPO}:latest


### PR DESCRIPTION
Because

* We disabled Hydrobuild in #9535
* We must also disable the multiplatform builds in the deploy step if Hydrobuild is unavailable

This commit

* Disables multiplatform builds in the deploy steps of Experimenter and Cirrus

