### PR TITLE
fix #9545 bug(project): docker login necessary for deploy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,14 +50,15 @@ commands:
           curl --silent -L --output ~/.docker/cli-plugins/docker-compose << parameters.compose_url >>
           chmod a+x ~/.docker/cli-plugins/docker-buildx
           chmod a+x ~/.docker/cli-plugins/docker-compose
-          # TODO: https://github.com/mozilla/experimenter/issues/9536
-          # Disbled until Hydrobuild is functioning
-          # if [ -n "<< parameters.username >>" -a -n "<< parameters.password >>" ]; then
-          #   echo "<< parameters.password >>" | docker login --username << parameters.username >> --password-stdin
-          #   docker buildx create --use --driver cloud "mozilla/default"
-          # else
-          #   echo "username and password are empty, skipping docker login"
-          # fi
+
+          if [ -n "<< parameters.username >>" -a -n "<< parameters.password >>" ]; then
+            echo "<< parameters.password >>" | docker login --username << parameters.username >> --password-stdin
+            # TODO: https://github.com/mozilla/experimenter/issues/9536
+            # Disbled until Hydrobuild is functioning
+            # docker buildx create --use --driver cloud "mozilla/default"
+          else
+            echo "username and password are empty, skipping docker login"
+          fi
 
 jobs:
   check_experimenter_x86_64:


### PR DESCRIPTION
Because

* When we disabled hydrobuild we also disabled logging into docker
* Logging into docker is necessary at the deploy step

This commit

* Logs into docker if possible but disables hydrobuild


