### PR TITLE
fix #9556 chore(project): add .ruff_cache to .dockerignore

### DIFF
--- a/experimenter/.dockerignore
+++ b/experimenter/.dockerignore
@@ -5,6 +5,7 @@
 **/.mypy
 **/.pycache
 **/.pytest_cache
+**/.ruff_cache/
 **/.vscode
 **/.vscode/
 **/coverage/


### PR DESCRIPTION
Because

* Tools can add new hidden dot paths to the project with junk data
* These paths can sneak into the container build process and slow builds down

This commit

* Adds .ruff_cache to the .dockerignore file


