### PR TITLE
fixes mozilla#9517 feat(nimbus): land advanced targeting for the Stat…

### DIFF
--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -1080,6 +1080,32 @@ REVIEW_CHECKER_SIDEBAR_RECOMMENDATION = NimbusTargetingConfig(
     application_choice_names=(Application.DESKTOP.name,),
 )
 
+EARLY_DAY_USER_REVIEW_CHECKER_SIDEBAR_RECOMMENDATION = NimbusTargetingConfig(
+    name="Early Day User Review Checker Sidebar Recommendation",
+    slug="early_day_user_review_checker_sidebar_recommendation",
+    description="Exclude early day users who have the Fakespot extension installed, "
+    "or who have the CFR pref set to false",
+    targeting=(
+        f"{PROFILELESSTHAN28DAYS} && {REVIEW_CHECKER_SIDEBAR_RECOMMENDATION.targeting}"
+    ),
+    desktop_telemetry="",
+    sticky_required=False,
+    is_first_run_required=False,
+    application_choice_names=(Application.DESKTOP.name,),
+)
+
+EXISTING_USER_REVIEW_CHECKER_SIDEBAR_RECOMMENDATION = NimbusTargetingConfig(
+    name="Existing User Review Checker Sidebar Recommendation",
+    slug="existing_user_review_checker_sidebar_recommendation",
+    description="Exclude existing users who have the Fakespot extension installed, "
+    "or who have the CFR pref set to false",
+    targeting=(f"{PROFILE28DAYS} && {REVIEW_CHECKER_SIDEBAR_RECOMMENDATION.targeting}"),
+    desktop_telemetry="",
+    sticky_required=False,
+    is_first_run_required=False,
+    application_choice_names=(Application.DESKTOP.name,),
+)
+
 BACKGROUND_TASK_NOTIFICATION = NimbusTargetingConfig(
     name="Background task notification",
     slug="Background_task_notification",


### PR DESCRIPTION
Land advanced targeting for the Stat sig Review checker faksepot experiment

Because

We want to add additional targeting for existing and early day users

This commit adds
* Early Days Review Checker Sidebar Recommendation. Users with <28 days and excluding users who have the Fakespot extension installed, or who have the CFR pref set to false
* Later Days(Existing user) Review Checker Sidebar Recommendation. Users with =>28 days and excluding users who have the Fakespot extension installed, or who have the CFR pref set to false

