### PR TITLE
fixes #9600 fix(nimbus): fix targeting config for Firefox Suggest sponsored suggestions enabled

### DIFF
--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -501,8 +501,15 @@ URLBAR_FIREFOX_SUGGEST_DATA_COLLECTION_DISABLED = NimbusTargetingConfig(
 URLBAR_FIREFOX_SUGGEST_SPONSORED_ENABLED = NimbusTargetingConfig(
     name="Urlbar (Firefox Suggest) - Sponsored Suggestions Enabled",
     slug="urlbar_firefox_suggest_sponsored_enabled",
-    description="Users with sponsored Firefox Suggest suggestions enabled",
-    targeting="'browser.urlbar.suggest.quicksuggest.sponsored'|preferenceValue",
+    description=(
+        "Users with sponsored Firefox Suggest suggestions enabled "
+        "(IMPORTANT: You must restrict 'Locales' to one or more Suggest "
+        "locales when using this!)"
+    ),
+    targeting=(
+        "!('browser.urlbar.suggest.quicksuggest.sponsored'|preferenceIsUserSet) || "
+        "'browser.urlbar.suggest.quicksuggest.sponsored'|preferenceValue"
+    ),
     desktop_telemetry="",
     sticky_required=False,
     is_first_run_required=False,


### PR DESCRIPTION
Because

The targeting config for "Firefox Suggest sponsored suggestions enabled" doesn't work properly

This commit

Changes the targeting expression to the following (in English):

1. `browser.urlbar.suggest.quicksuggest.sponsored` is either not set on the user branch, or
2. it's true.

Nitty gritty details:

This pref is exposed to the user in about:preferences. In addition, there are two unique things about it:

* Its default value is false in firefox.js. For users in the Firefox Suggest audience (currently U.S. users), Firefox programmatically sets it to true on the default branch shortly after startup as part of Firefox Suggest initialization.
* It's sticky, so once the user changes the value at all, it will always have a user-branch value even when that value is the same as the value on the default branch.

So each part of this new targeting expression matches the following users:

1. `browser.urlbar.suggest.quicksuggest.sponsored` is not set on the user branch: Users who didn't touch the pref at all.
2. `browser.urlbar.suggest.quicksuggest.sponsored` is true: Users who changed the pref and left it on. (Or possibly, considering that on startup Nimbus initialization races Firefox Suggest initialization, this will also match users who didn't touch the pref if Suggest init finishes first, which is fine.)

The first part will also match users who are not in the Suggest audience at all (non-U.S. users), so it's important for experiments to target U.S. users when they use this targeting expression.
