### PR TITLE
fix #9610 bug(nimbus): metrics key may be missing

### DIFF
--- a/experimenter/experimenter/outcomes/__init__.py
+++ b/experimenter/experimenter/outcomes/__init__.py
@@ -47,6 +47,21 @@ class Outcomes:
                         outcome_toml = outcome_file.read()
                         outcome_data = toml.loads(outcome_toml)
 
+                        metrics = []
+                        if "metrics" in outcome_data:
+                            metrics = [
+                                Metric(
+                                    slug=metric,
+                                    friendly_name=outcome_data["metrics"][metric].get(
+                                        "friendly_name"
+                                    ),
+                                    description=outcome_data["metrics"][metric].get(
+                                        "description"
+                                    ),
+                                )
+                                for metric in outcome_data["metrics"]
+                            ]
+
                         outcomes.append(
                             Outcome(
                                 application=app_name_application_config[app_name].slug,
@@ -54,18 +69,7 @@ class Outcomes:
                                 friendly_name=outcome_data["friendly_name"],
                                 slug=os.path.splitext(outcome_name)[0],
                                 is_default=False,
-                                metrics=[
-                                    Metric(
-                                        slug=metric,
-                                        friendly_name=outcome_data["metrics"][metric].get(
-                                            "friendly_name"
-                                        ),
-                                        description=outcome_data["metrics"][metric].get(
-                                            "description"
-                                        ),
-                                    )
-                                    for metric in outcome_data["metrics"]
-                                ],
+                                metrics=metrics,
                             )
                         )
 

--- a/experimenter/experimenter/outcomes/tests/fixtures/valid_outcomes/firefox_desktop/missing_metrics.toml
+++ b/experimenter/experimenter/outcomes/tests/fixtures/valid_outcomes/firefox_desktop/missing_metrics.toml
@@ -1,0 +1,2 @@
+friendly_name = "test outcome"
+description = "a test outcome missing metrics"

--- a/experimenter/experimenter/outcomes/tests/test_outcomes.py
+++ b/experimenter/experimenter/outcomes/tests/test_outcomes.py
@@ -15,7 +15,7 @@ class TestOutcomes(TestCase):
 
     def test_load_all_outcomes_and_ignore_examples(self):
         outcomes = Outcomes.all()
-        self.assertEqual(len(outcomes), 4)
+        self.assertEqual(len(outcomes), 5)
         self.assertIn(
             Outcome(
                 application=NimbusExperiment.Application.FENIX,
@@ -56,10 +56,21 @@ class TestOutcomes(TestCase):
                 ),
                 outcomes,
             )
+        self.assertIn(
+            Outcome(
+                application=NimbusExperiment.Application.DESKTOP,
+                description="a test outcome missing metrics",
+                friendly_name="test outcome",
+                slug="missing_metrics",
+                is_default=False,
+                metrics=[],
+            ),
+            outcomes,
+        )
 
     def test_load_outcomes_by_application(self):
         desktop_outcomes = Outcomes.by_application(NimbusExperiment.Application.DESKTOP)
-        self.assertEqual(len(desktop_outcomes), 3)
+        self.assertEqual(len(desktop_outcomes), 4)
         for i in range(1, 4):
             self.assertIn(
                 Outcome(
@@ -83,6 +94,17 @@ class TestOutcomes(TestCase):
                 ),
                 desktop_outcomes,
             )
+        self.assertIn(
+            Outcome(
+                application=NimbusExperiment.Application.DESKTOP,
+                description="a test outcome missing metrics",
+                friendly_name="test outcome",
+                slug="missing_metrics",
+                is_default=False,
+                metrics=[],
+            ),
+            desktop_outcomes,
+        )
 
 
 class TestCheckOutcomeTOMLs(TestCase):


### PR DESCRIPTION
Because

* The metrics key may be absent in an outcome file

This commit

* Checks for the presence of the metrics key before attempting to parse metrics


