### PR TITLE
fixes #9619 feat(nimbus): soft fail when fetches fail

### DIFF
--- a/experimenter/manifesttool/cli.py
+++ b/experimenter/manifesttool/cli.py
@@ -1,13 +1,10 @@
-import sys
 from dataclasses import dataclass
 from pathlib import Path
 
 import click
-import yaml
-from mozilla_nimbus_schemas import FeatureManifest
 
-from manifesttool import github_api, hgmo_api, nimbus_cli
-from manifesttool.appconfig import AppConfig, AppConfigs, RepositoryType
+from manifesttool.appconfig import AppConfigs
+from manifesttool.fetch import fetch_fml_app, fetch_legacy_app
 
 MANIFESTS_DIR = Path(__file__).parent.parent / "experimenter" / "features" / "manifests"
 
@@ -46,108 +43,11 @@ def fetch_latest(ctx: click.Context):
         context.manifest_dir.joinpath(app_config.slug).mkdir(exist_ok=True)
 
         if app_config.fml_path is not None:
-            fetch_fml_app(context, app_name, app_config)
+            fetch_fml_app(context.manifest_dir, app_name, app_config)
         elif app_config.experimenter_yaml_path is not None:
-            fetch_legacy_app(context, app_name, app_config)
+            fetch_legacy_app(context.manifest_dir, app_name, app_config)
         else:  # pragma: no cover
             assert False, "unreachable"
 
 
-def fetch_fml_app(context: Context, app_name: str, app_config: AppConfig):
-    if app_config.repo.type == RepositoryType.HGMO:
-        raise Exception("FML-based apps on hg.mozilla.org are not supported.")
 
-    # We could operate against "main" for all these calls, but the repository
-    # state might change between subsequent calls. That would mean the generated
-    # single file manifests could differ because they were based on different
-    # commits.
-    ref = github_api.get_main_ref(app_config.repo.name)
-    print(f"fetch-latest: {app_name}: main is {ref}")
-
-    channels = nimbus_cli.get_channels(app_config, ref)
-    print(f"fetch-latest: {app_name}: channels are {', '.join(channels)}")
-
-    if not channels:
-        print(
-            f"WARNING: Application {app_name} does not have any channels!",
-            file=sys.stderr,
-        )
-        return
-
-    for channel in channels:
-        print(f"fetch-latest: {app_name}: download {channel} manifest")
-        nimbus_cli.download_single_file(
-            app_config,
-            channel,
-            context.manifest_dir,
-            ref,
-        )
-
-    print(f"fetch-latest: {app_name}: generate experimenter.yaml")
-    # The single-file fml file for each channel will generate the same
-    # experimenter.yaml, so we can pick any here.
-    nimbus_cli.generate_experimenter_yaml(
-        app_config,
-        channels[0],
-        context.manifest_dir,
-    )
-
-
-def fetch_legacy_app(context: Context, app_name: str, app_config: AppConfig):
-    if app_config.repo.type == RepositoryType.GITHUB:
-        raise Exception("Legacy experimenter.yaml apps on GitHub are not supported.")
-
-    # We could operate against "main" for all these calls, but the repository
-    # state might change between subsequent calls. That would mean the fetched
-    # feature schemas could differ or not be present if they were removed in a
-    # subsequent commit.
-    rev = hgmo_api.get_tip_rev(app_config.repo.name)
-    print(f"fetch-latest: {app_name}: tip is {rev}")
-
-    manifest_path = context.manifest_dir / app_config.slug / "experimenter.yaml"
-    print(f"fetch-latest: {app_name}: downloading experimenter.yaml")
-    hgmo_api.fetch_file(
-        app_config.repo.name,
-        app_config.experimenter_yaml_path,
-        rev,
-        context.manifest_dir / app_config.slug / "experimenter.yaml",
-    )
-
-    with manifest_path.open() as f:
-        raw_manifest = yaml.safe_load(f)
-        manifest = FeatureManifest.parse_obj(raw_manifest)
-
-    schema_dir = context.manifest_dir / app_config.slug / "schemas"
-    schema_dir.mkdir(exist_ok=True)
-
-    # Some features may re-use the same schemas, so we only have to fetch them
-    # once.
-    fetched_schemas = set()
-
-    for feature_slug, feature in manifest.__root__.items():
-        feature = feature.__root__
-
-        if feature.json_schema is not None:
-            if feature.json_schema.path in fetched_schemas:
-                print(
-                    f"fetch-latest: {app_name}: already fetched schema for "
-                    f"feature {feature_slug} ({feature.json_schema.path})"
-                )
-                continue
-
-            print(
-                f"fetch-latest: {app_name}: fetching schema for feature {feature_slug} "
-                f"({feature.json_schema.path})"
-            )
-
-            schema_path = schema_dir.joinpath(*feature.json_schema.path.split("/"))
-            schema_path.parent.mkdir(exist_ok=True, parents=True)
-
-            hgmo_api.fetch_file(
-                app_config.repo.name,
-                feature.json_schema.path,
-                rev,
-                schema_path,
-            )
-
-            fetched_schemas.add(feature.json_schema.path)

--- a/experimenter/manifesttool/cli.py
+++ b/experimenter/manifesttool/cli.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import click
 
 from manifesttool.appconfig import AppConfigs
-from manifesttool.fetch import fetch_fml_app, fetch_legacy_app
+from manifesttool.fetch import fetch_fml_app, fetch_legacy_app, summarize_results
 
 MANIFESTS_DIR = Path(__file__).parent.parent / "experimenter" / "features" / "manifests"
 
@@ -39,15 +39,16 @@ def fetch_latest(ctx: click.Context):
     """Fetch the latest FML manifests and generate experimenter.yaml files."""
     context = ctx.find_object(Context)
 
+    results = []
+
     for app_name, app_config in context.app_configs.__root__.items():
         context.manifest_dir.joinpath(app_config.slug).mkdir(exist_ok=True)
 
         if app_config.fml_path is not None:
-            fetch_fml_app(context.manifest_dir, app_name, app_config)
+            results.append(fetch_fml_app(context.manifest_dir, app_name, app_config))
         elif app_config.experimenter_yaml_path is not None:
-            fetch_legacy_app(context.manifest_dir, app_name, app_config)
+            results.append(fetch_legacy_app(context.manifest_dir, app_name, app_config))
         else:  # pragma: no cover
             assert False, "unreachable"
 
-
-
+    summarize_results(results)

--- a/experimenter/manifesttool/fetch.py
+++ b/experimenter/manifesttool/fetch.py
@@ -1,0 +1,108 @@
+import sys
+from pathlib import Path
+
+import yaml
+from mozilla_nimbus_schemas import FeatureManifest
+
+from manifesttool import github_api, hgmo_api, nimbus_cli
+from manifesttool.appconfig import AppConfig, RepositoryType
+
+
+def fetch_fml_app(manifest_dir: Path, app_name: str, app_config: AppConfig):
+    if app_config.repo.type == RepositoryType.HGMO:
+        raise Exception("FML-based apps on hg.mozilla.org are not supported.")
+
+    # We could operate against "main" for all these calls, but the repository
+    # state might change between subsequent calls. That would mean the generated
+    # single file manifests could differ because they were based on different
+    # commits.
+    ref = github_api.get_main_ref(app_config.repo.name)
+    print(f"fetch-latest: {app_name}: main is {ref}")
+
+    channels = nimbus_cli.get_channels(app_config, ref)
+    print(f"fetch-latest: {app_name}: channels are {', '.join(channels)}")
+
+    if not channels:
+        print(
+            f"WARNING: Application {app_name} does not have any channels!",
+            file=sys.stderr,
+        )
+        return
+
+    for channel in channels:
+        print(f"fetch-latest: {app_name}: download {channel} manifest")
+        nimbus_cli.download_single_file(
+            app_config,
+            channel,
+            manifest_dir,
+            ref,
+        )
+
+    print(f"fetch-latest: {app_name}: generate experimenter.yaml")
+    # The single-file fml file for each channel will generate the same
+    # experimenter.yaml, so we can pick any here.
+    nimbus_cli.generate_experimenter_yaml(
+        app_config,
+        channels[0],
+        manifest_dir,
+    )
+
+
+def fetch_legacy_app(manifest_dir: Path, app_name: str, app_config: AppConfig):
+    if app_config.repo.type == RepositoryType.GITHUB:
+        raise Exception("Legacy experimenter.yaml apps on GitHub are not supported.")
+
+    # We could operate against "main" for all these calls, but the repository
+    # state might change between subsequent calls. That would mean the fetched
+    # feature schemas could differ or not be present if they were removed in a
+    # subsequent commit.
+    rev = hgmo_api.get_tip_rev(app_config.repo.name)
+    print(f"fetch-latest: {app_name}: tip is {rev}")
+
+    manifest_path = manifest_dir / app_config.slug / "experimenter.yaml"
+    print(f"fetch-latest: {app_name}: downloading experimenter.yaml")
+    hgmo_api.fetch_file(
+        app_config.repo.name,
+        app_config.experimenter_yaml_path,
+        rev,
+        manifest_dir / app_config.slug / "experimenter.yaml",
+    )
+
+    with manifest_path.open() as f:
+        raw_manifest = yaml.safe_load(f)
+        manifest = FeatureManifest.parse_obj(raw_manifest)
+
+    schema_dir = manifest_dir / app_config.slug / "schemas"
+    schema_dir.mkdir(exist_ok=True)
+
+    # Some features may re-use the same schemas, so we only have to fetch them
+    # once.
+    fetched_schemas = set()
+
+    for feature_slug, feature in manifest.__root__.items():
+        feature = feature.__root__
+
+        if feature.json_schema is not None:
+            if feature.json_schema.path in fetched_schemas:
+                print(
+                    f"fetch-latest: {app_name}: already fetched schema for "
+                    f"feature {feature_slug} ({feature.json_schema.path})"
+                )
+                continue
+
+            print(
+                f"fetch-latest: {app_name}: fetching schema for feature {feature_slug} "
+                f"({feature.json_schema.path})"
+            )
+
+            schema_path = schema_dir.joinpath(*feature.json_schema.path.split("/"))
+            schema_path.parent.mkdir(exist_ok=True, parents=True)
+
+            hgmo_api.fetch_file(
+                app_config.repo.name,
+                feature.json_schema.path,
+                rev,
+                schema_path,
+            )
+
+            fetched_schemas.add(feature.json_schema.path)

--- a/experimenter/manifesttool/fetch.py
+++ b/experimenter/manifesttool/fetch.py
@@ -43,7 +43,7 @@ def fetch_fml_app(
                 f"WARNING: Application {app_name} does not have any channels!",
                 file=sys.stderr,
             )
-            return
+            raise Exception("No channels found")
 
         for channel in channels:
             print(f"fetch-latest: {app_name}: download {channel} manifest")

--- a/experimenter/manifesttool/fetch.py
+++ b/experimenter/manifesttool/fetch.py
@@ -1,5 +1,8 @@
 import sys
+from dataclasses import dataclass
 from pathlib import Path
+from typing import Optional
+from traceback import print_exception
 
 import yaml
 from mozilla_nimbus_schemas import FeatureManifest
@@ -8,101 +11,146 @@ from manifesttool import github_api, hgmo_api, nimbus_cli
 from manifesttool.appconfig import AppConfig, RepositoryType
 
 
-def fetch_fml_app(manifest_dir: Path, app_name: str, app_config: AppConfig):
+@dataclass
+class FetchResult:
+    app_name: str
+    ref_name: str
+    ref: Optional[str] = None
+    exc: Optional[Exception] = None
+
+
+def fetch_fml_app(
+    manifest_dir: Path, app_name: str, app_config: AppConfig
+) -> FetchResult:
     if app_config.repo.type == RepositoryType.HGMO:
         raise Exception("FML-based apps on hg.mozilla.org are not supported.")
 
-    # We could operate against "main" for all these calls, but the repository
-    # state might change between subsequent calls. That would mean the generated
-    # single file manifests could differ because they were based on different
-    # commits.
-    ref = github_api.get_main_ref(app_config.repo.name)
-    print(f"fetch-latest: {app_name}: main is {ref}")
+    result = FetchResult(app_name=app_name, ref_name="main")
 
-    channels = nimbus_cli.get_channels(app_config, ref)
-    print(f"fetch-latest: {app_name}: channels are {', '.join(channels)}")
+    try:
+        # We could operate against "main" for all these calls, but the repository
+        # state might change between subsequent calls. That would mean the generated
+        # single file manifests could differ because they were based on different
+        # commits.
+        ref = result.ref = github_api.get_main_ref(app_config.repo.name)
+        print(f"fetch-latest: {app_name}: main is {ref}")
 
-    if not channels:
-        print(
-            f"WARNING: Application {app_name} does not have any channels!",
-            file=sys.stderr,
-        )
-        return
+        channels = nimbus_cli.get_channels(app_config, ref)
+        print(f"fetch-latest: {app_name}: channels are {', '.join(channels)}")
 
-    for channel in channels:
-        print(f"fetch-latest: {app_name}: download {channel} manifest")
-        nimbus_cli.download_single_file(
+        if not channels:
+            print(
+                f"WARNING: Application {app_name} does not have any channels!",
+                file=sys.stderr,
+            )
+            return
+
+        for channel in channels:
+            print(f"fetch-latest: {app_name}: download {channel} manifest")
+            nimbus_cli.download_single_file(
+                app_config,
+                channel,
+                manifest_dir,
+                ref,
+            )
+
+        print(f"fetch-latest: {app_name}: generate experimenter.yaml")
+        # The single-file fml file for each channel will generate the same
+        # experimenter.yaml, so we can pick any here.
+        nimbus_cli.generate_experimenter_yaml(
             app_config,
-            channel,
+            channels[0],
             manifest_dir,
-            ref,
         )
+    except Exception as e:
+        print_exception(e, file=sys.stderr)
+        result.exc = e
 
-    print(f"fetch-latest: {app_name}: generate experimenter.yaml")
-    # The single-file fml file for each channel will generate the same
-    # experimenter.yaml, so we can pick any here.
-    nimbus_cli.generate_experimenter_yaml(
-        app_config,
-        channels[0],
-        manifest_dir,
-    )
+    return result
 
 
-def fetch_legacy_app(manifest_dir: Path, app_name: str, app_config: AppConfig):
+def fetch_legacy_app(
+    manifest_dir: Path, app_name: str, app_config: AppConfig
+) -> FetchResult:
     if app_config.repo.type == RepositoryType.GITHUB:
         raise Exception("Legacy experimenter.yaml apps on GitHub are not supported.")
 
-    # We could operate against "main" for all these calls, but the repository
-    # state might change between subsequent calls. That would mean the fetched
-    # feature schemas could differ or not be present if they were removed in a
-    # subsequent commit.
-    rev = hgmo_api.get_tip_rev(app_config.repo.name)
-    print(f"fetch-latest: {app_name}: tip is {rev}")
+    result = FetchResult(app_name=app_name, ref_name="tip")
 
-    manifest_path = manifest_dir / app_config.slug / "experimenter.yaml"
-    print(f"fetch-latest: {app_name}: downloading experimenter.yaml")
-    hgmo_api.fetch_file(
-        app_config.repo.name,
-        app_config.experimenter_yaml_path,
-        rev,
-        manifest_dir / app_config.slug / "experimenter.yaml",
-    )
+    try:
+        # We could operate against "main" for all these calls, but the repository
+        # state might change between subsequent calls. That would mean the fetched
+        # feature schemas could differ or not be present if they were removed in a
+        # subsequent commit.
+        rev = result.ref = hgmo_api.get_tip_rev(app_config.repo.name)
+        print(f"fetch-latest: {app_name}: tip is {rev}")
 
-    with manifest_path.open() as f:
-        raw_manifest = yaml.safe_load(f)
-        manifest = FeatureManifest.parse_obj(raw_manifest)
+        manifest_path = manifest_dir / app_config.slug / "experimenter.yaml"
+        print(f"fetch-latest: {app_name}: downloading experimenter.yaml")
+        hgmo_api.fetch_file(
+            app_config.repo.name,
+            app_config.experimenter_yaml_path,
+            rev,
+            manifest_dir / app_config.slug / "experimenter.yaml",
+        )
 
-    schema_dir = manifest_dir / app_config.slug / "schemas"
-    schema_dir.mkdir(exist_ok=True)
+        with manifest_path.open() as f:
+            raw_manifest = yaml.safe_load(f)
+            manifest = FeatureManifest.parse_obj(raw_manifest)
 
-    # Some features may re-use the same schemas, so we only have to fetch them
-    # once.
-    fetched_schemas = set()
+        schema_dir = manifest_dir / app_config.slug / "schemas"
+        schema_dir.mkdir(exist_ok=True)
 
-    for feature_slug, feature in manifest.__root__.items():
-        feature = feature.__root__
+        # Some features may re-use the same schemas, so we only have to fetch them
+        # once.
+        fetched_schemas = set()
 
-        if feature.json_schema is not None:
-            if feature.json_schema.path in fetched_schemas:
+        for feature_slug, feature in manifest.__root__.items():
+            feature = feature.__root__
+
+            if feature.json_schema is not None:
+                if feature.json_schema.path in fetched_schemas:
+                    print(
+                        f"fetch-latest: {app_name}: already fetched schema for "
+                        f"feature {feature_slug} ({feature.json_schema.path})"
+                    )
+                    continue
+
                 print(
-                    f"fetch-latest: {app_name}: already fetched schema for "
-                    f"feature {feature_slug} ({feature.json_schema.path})"
+                    f"fetch-latest: {app_name}: fetching schema for feature {feature_slug} "
+                    f"({feature.json_schema.path})"
                 )
-                continue
 
-            print(
-                f"fetch-latest: {app_name}: fetching schema for feature {feature_slug} "
-                f"({feature.json_schema.path})"
-            )
+                schema_path = schema_dir.joinpath(*feature.json_schema.path.split("/"))
+                schema_path.parent.mkdir(exist_ok=True, parents=True)
 
-            schema_path = schema_dir.joinpath(*feature.json_schema.path.split("/"))
-            schema_path.parent.mkdir(exist_ok=True, parents=True)
+                hgmo_api.fetch_file(
+                    app_config.repo.name,
+                    feature.json_schema.path,
+                    rev,
+                    schema_path,
+                )
 
-            hgmo_api.fetch_file(
-                app_config.repo.name,
-                feature.json_schema.path,
-                rev,
-                schema_path,
-            )
+                fetched_schemas.add(feature.json_schema.path)
+    except Exception as e:
+        print_exception(e, file=sys.stderr)
+        result.exc = e
 
-            fetched_schemas.add(feature.json_schema.path)
+    return result
+
+
+def summarize_results(results: list[FetchResult]):
+    print("\n\nSUMMARY:\n")
+
+    if any(result.exc is None for result in results):
+        print("SUCCESS:\n")
+        for result in results:
+            if result.exc is None:
+                print(f"{result.app_name} at {result.ref_name} ({result.ref})")
+
+    print("")
+    if any(result.exc is not None for result in results):
+        print("FAILURES:\n")
+        for result in results:
+            if result.exc is not None:
+                print(f"{result.app_name} at {result.ref_name} ({result.ref})")


### PR DESCRIPTION
Because

- a single fetch failure currently breaks the entire fetch task; and
- we are about to drastically increase the number of fetches per task

This commit

- makes fetch failures not cause the tool to exit; and
- reports a summary of all successes and failures at the end of the task.
