### PR TITLE
feat(nimbus): Explicitly require a manifest path in AppConfig

### DIFF
--- a/experimenter/manifesttool/appconfig.py
+++ b/experimenter/manifesttool/appconfig.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from typing import Any, Optional
 
 import yaml
-from pydantic import BaseModel
+from pydantic import BaseModel, root_validator
 
 
 class RepositoryType(Enum):
@@ -25,6 +25,19 @@ class AppConfig(BaseModel):
     experimenter_yaml_path: Optional[str]
     major_release_branch: Optional[str]
     minor_release_tag: Optional[str]
+
+    @root_validator(pre=True)
+    def validate_one_manifest_path(cls, values):
+        has_fml_path = values.get("fml_path") is not None
+        has_legacy_path = values.get("experimenter_yaml_path") is not None
+
+        if not has_fml_path and not has_legacy_path:
+            raise ValueError("one of fml_path and experimenter_yaml_path is required")
+
+        if has_fml_path and has_legacy_path:
+            raise ValueError("fml_path and experimenter_yaml_path are mutually exclusive")
+
+        return values
 
 
 class AppConfigs(BaseModel):

--- a/experimenter/manifesttool/tests/test_appconfig.py
+++ b/experimenter/manifesttool/tests/test_appconfig.py
@@ -1,0 +1,41 @@
+from unittest import TestCase
+
+from manifesttool.cli import MANIFESTS_DIR
+from manifesttool.appconfig import AppConfigs
+
+
+class AppConfigTests(TestCase):
+    def test_parse_apps_yaml(self):
+        """Testing that we can parse apps.yaml."""
+        apps_yaml_path = MANIFESTS_DIR / "apps.yaml"
+        AppConfigs.load_from_file(apps_yaml_path)
+
+    def test_parse_experimenter_and_fml_paths(self):
+        """Testing that parsing apps.yaml fails if an app contains both the
+        fml_path and experimenter_yaml_path keys.
+        """
+        with self.assertRaises(ValueError):
+            AppConfigs.parse_obj(
+                {
+                    "app": {
+                        "slug": "app",
+                        "repo": {"type": "github", "name": "owner/repo"},
+                        "fml_path": "nimbus.fml.yaml",
+                        "experimenter_yaml_path": "experimenter.yaml",
+                    },
+                }
+            )
+
+    def test_parse_no_paths(self):
+        """Testing that parsing apps.yaml fails if an app is missing both the
+        fml_path and experimenter_yaml_path keys.
+        """
+        with self.assertRaises(ValueError):
+            AppConfigs.parse_obj(
+                {
+                    "app": {
+                        "slug": "app",
+                        "repo": {"type": "github", "name": "owner/repo"},
+                    },
+                }
+            )


### PR DESCRIPTION
Because

- we want to ensure that apps.yaml is always valid; and
- we want to ensure that each app specifies exactly one manifest file

This commit

- adds a test that loads the production apps.yaml;
- updates the AppConfig model with a validator to ensure only one
  manifest path can be specified