### PR TITLE
fix #9633 feat(project): push docker images to gcr

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,7 @@
 version: 2.1
 orbs:
-  gh: circleci/github-cli@2.0
+  gh: circleci/github-cli@2.2
+  gcp-cli: circleci/gcp-cli@3.1.1
 commands:
   check_file_paths:
     description: "Check file paths"
@@ -448,16 +449,30 @@ jobs:
       - setup_docker:
           username: $DOCKER_USER
           password: $DOCKER_PASS
-      - deploy:
-          name: Deploy to latest
+      - run:
+          name: Build Multiarch Images
           command: |
             # # Build all images for aarch64 and x86_64 to hydrate build cache
             make BUILD_MULTIPLATFORM=1 build_dev build_test build_ui build_prod
             # Pull x86_64 and tag to dockerhub for deploy
+      - run:
+          name: Deploy to Dockerhub
+          command: |
             ./scripts/store_git_info.sh
             make build_prod
             docker tag experimenter:deploy ${DOCKERHUB_REPO}:latest
             docker push ${DOCKERHUB_REPO}:latest
+      - gcp-cli/setup
+      - run:
+          name: Deploy to Google Container Registry
+          command: |
+            echo $GCLOUD_SERVICE_KEY | gcloud auth activate-service-account --key-file=-
+            gcloud --quiet config set project ${GOOGLE_PROJECT_ID}
+            gcloud --quiet config set compute/zone ${GOOGLE_COMPUTE_ZONE}
+            gcloud auth configure-docker
+            DOCKER_IMAGE="gcr.io/${GOOGLE_PROJECT_ID}/experimenter"
+            docker tag experimenter:deploy ${DOCKER_IMAGE}:latest
+            docker push "${DOCKER_IMAGE}:latest"
 
   deploy_cirrus:
     working_directory: ~/cirrus
@@ -469,7 +484,7 @@ jobs:
       - setup_docker:
           username: $DOCKERHUB_CIRRUS_USER
           password: $DOCKERHUB_CIRRUS_PASS
-      - deploy:
+      - run:
           name: Deploy to latest
           command: |
             # Build all images for aarch64 and x86_64 to hydrate build cache
@@ -658,8 +673,7 @@ jobs:
             docker push ${DOCKERHUB_REPO}:nimbus-rust-image
 
 workflows:
-  version: 2
-  weekly:
+  build_firefox:
     triggers:
       - schedule:
           cron: "0 0 * * *"
@@ -671,7 +685,7 @@ workflows:
       - build_firefox_versions
       - build_rust_image
 
-  hourly:
+  update_configs:
     triggers:
       - schedule:
           cron: "0 * * * *"


### PR DESCRIPTION
Because

* We've been seeing consistent intermittent failures with pulling images from dockerhub
* An alternative is to use the Google Container Registry instead of Dockerhub
* If we have better luck with Google Container Registry then we can use that and deprecate Dockerhub

This commit

* Pushes to Google Container Registry in addition to Dockerhub


