### PR TITLE
fix #9564, #9640 feature(nimbus): add targeting for new and later users for Firefox iOS and Android

### DIFF
--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -1669,6 +1669,54 @@ WINDOWS_10_PLUS = NimbusTargetingConfig(
 )
 
 
+IOS_EARLY_DAY_USERS_IPHONE_ONLY = NimbusTargetingConfig(
+    name="Early day users iPhone only",
+    slug="ios_early_day_users_iphone_only",
+    description="Targeting users under 28 since install with iPhones",
+    targeting="is_phone && days_since_install < 28",
+    desktop_telemetry="",
+    sticky_required=True,
+    is_first_run_required=False,
+    application_choice_names=(Application.IOS.name,),
+)
+
+
+IOS_LATER_DAY_USERS_IPHONE_ONLY = NimbusTargetingConfig(
+    name="Later day users iPhone only",
+    slug="ios_later_day_users_iphone_only",
+    description="Targeting users equal to or greater than 28 since install with iPhones",
+    targeting="is_phone && days_since_install >= 28",
+    desktop_telemetry="",
+    sticky_required=True,
+    is_first_run_required=False,
+    application_choice_names=(Application.IOS.name,),
+)
+
+
+ANDROID_EARLY_DAY_USERS_ONLY = NimbusTargetingConfig(
+    name="Early day users only",
+    slug="android_early_day_users_only",
+    description="Targeting users under 28 since install",
+    targeting="days_since_install < 28",
+    desktop_telemetry="",
+    sticky_required=True,
+    is_first_run_required=False,
+    application_choice_names=(Application.FENIX.name,),
+)
+
+
+ANDROID_LATER_DAY_USERS_ONLY = NimbusTargetingConfig(
+    name="Later day users only",
+    slug="android_later_day_users_only",
+    description="Targeting users equal to or greater than 28 since install",
+    targeting="days_since_install >= 28",
+    desktop_telemetry="",
+    sticky_required=True,
+    is_first_run_required=False,
+    application_choice_names=(Application.FENIX.name,),
+)
+
+
 class TargetingConstants:
     TARGETING_VERSION = "version|versionCompare('{version}') >= 0"
     TARGETING_CHANNEL = 'browserSettings.update.channel == "{channel}"'

--- a/experimenter/tests/integration/nimbus/test_mobile_targeting.py
+++ b/experimenter/tests/integration/nimbus/test_mobile_targeting.py
@@ -78,6 +78,7 @@ def test_check_mobile_targeting(
             "days_since_install": 1,
             "isFirstRun": "true",
             "is_first_run": True,
+            "is_phone": True,
         }
     )
     client = sdk_client(load_app_context(context))


### PR DESCRIPTION
Because

- New advanced targeting configurations are needed for Fakespot experiments

This commit

- Adds the four advanced targeting options required
