### PR TITLE
fix #9652 feat(nimbus): only run probe-scraper gh action on this repo

### DIFF
--- a/.github/workflows/glean-probe-scraper.yml
+++ b/.github/workflows/glean-probe-scraper.yml
@@ -3,4 +3,5 @@ name: Glean probe-scraper
 on: [push, pull_request]
 jobs:
   glean-probe-scraper:
+    if: github.repository == 'mozilla/experimenter'
     uses: mozilla/probe-scraper/.github/workflows/glean.yaml@main


### PR DESCRIPTION
Because

- We don't need to run the probe-scraper github action on forks

This commit

- checks the repo before running the action
