### PR TITLE
fix #9651 feat(nimbus): api v6 uses actual enrollment end date or null

### DIFF
--- a/experimenter/experimenter/experiments/api/v6/serializers.py
+++ b/experimenter/experimenter/experiments/api/v6/serializers.py
@@ -100,7 +100,7 @@ class NimbusExperimentSerializer(serializers.ModelSerializer):
     probeSets = serializers.ReadOnlyField(default=[])
     outcomes = serializers.SerializerMethodField()
     startDate = serializers.DateField(source="start_date")
-    enrollmentEndDate = serializers.DateField(source="computed_enrollment_end_date")
+    enrollmentEndDate = serializers.DateField(source="actual_enrollment_end_date")
     endDate = serializers.DateField(source="end_date")
     proposedDuration = serializers.ReadOnlyField(source="proposed_duration")
     proposedEnrollment = serializers.ReadOnlyField(source="proposed_enrollment")

--- a/experimenter/experimenter/experiments/models.py
+++ b/experimenter/experimenter/experiments/models.py
@@ -611,6 +611,10 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
             )
 
     @property
+    def actual_enrollment_end_date(self):
+        return self._enrollment_end_date or None
+
+    @property
     def computed_end_date(self):
         return self.end_date or self.proposed_end_date
 

--- a/experimenter/experimenter/experiments/tests/test_models.py
+++ b/experimenter/experimenter/experiments/tests/test_models.py
@@ -1237,6 +1237,28 @@ class TestNimbusExperiment(TestCase):
 
         self.assertIsNone(experiment.computed_enrollment_end_date)
 
+    def test_actual_enrollment_end_date_returns_none_before_enrollment_end(self):
+        start_date = datetime.date(2022, 1, 1)
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            start_date=start_date,
+            proposed_enrollment=2,
+        )
+
+        self.assertIsNone(experiment.actual_enrollment_end_date)
+
+    def test_actual_enrollment_end_date_returns_date_after_enrollment_end(self):
+        start_date = datetime.date(2022, 1, 1)
+        enrollment_end_date = datetime.date(2022, 1, 5)
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.LIVE_PAUSED,
+            start_date=start_date,
+            proposed_enrollment=2,
+            _enrollment_end_date=enrollment_end_date,
+        )
+
+        self.assertEqual(experiment.actual_enrollment_end_date, enrollment_end_date)
+
     def test_computed_duration_days_returns_end_date_minus_start_date(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.ENDING_APPROVE_APPROVE,


### PR DESCRIPTION
Because

- Cirrus uses continuous enrollment (i.e., enrollment can't end until the experiment does)
- Jetstream requires an end for enrollment before the experiment ends for analysis
- We can't set `isEnrollmentPaused` to true without prematurely ending the experiment in Cirrus context

This commit

- Adds an `actual_enrollment_end_date` field to the NimbusExperiment model
- uses `actual_enrollment_end_date` for the serialized `enrollmentEndDate` in API v6
