### PR TITLE
fix #9672 chore(project): add author to pyproject.toml

### DIFF
--- a/cirrus/server/pyproject.toml
+++ b/cirrus/server/pyproject.toml
@@ -1,8 +1,8 @@
 [tool.poetry]
-name = "cirrus"
+name = "mozilla-nimbus-cirrus"
 version = "0.1.0"
 description = ""
-authors = [""]
+authors = ["project-nimbus@mozilla.com"]
 
 [tool.poetry.dependencies]
 python = "^3.10.10"
@@ -26,10 +26,7 @@ sentry-sdk = "^1.34.0"
 [tool.pyright]
 typeCheckingMode = "strict"
 include = ["cirrus"]
-exclude = [
-    "**/__pycache__",
-    "cirrus/generate_docs.py",
-]
+exclude = ["**/__pycache__", "cirrus/generate_docs.py"]
 reportUnnecessaryTypeIgnoreComment = "warning"
 pythonVersion = "3.10"
 
@@ -55,4 +52,3 @@ ignore = [
 
 # Same as Black.
 line-length = 90
-

--- a/experimenter/pyproject.toml
+++ b/experimenter/pyproject.toml
@@ -2,7 +2,7 @@
 name = "app"
 version = "0.1.0"
 description = ""
-authors = [""]
+authors = ["project-nimbus@mozilla.com"]
 
 [tool.poetry.dependencies]
 python = "^3.10"

--- a/schemas/pyproject.toml
+++ b/schemas/pyproject.toml
@@ -2,7 +2,7 @@
 name = "mozilla-nimbus-schemas"
 version = "2023.10.3"
 description = "Schemas used by Mozilla Nimbus and related projects."
-authors = ["mikewilli"]
+authors = ["project-nimbus@mozilla.com"]
 license = "MPL 2.0"
 readme = "README.md"
 packages = [{ include = "mozilla_nimbus_schemas" }]


### PR DESCRIPTION
Because

* Poetry now appears to be strongly validating against a valid email in the authors field in pyproject.toml

This commit

* Adds project-nimbus@mozilla.com as the author for all of the pyproject.toml files


