### PR TITLE
fix #9675 chore(project): lock Poetry to 1.6.0

### DIFF
--- a/cirrus/server/Dockerfile
+++ b/cirrus/server/Dockerfile
@@ -43,7 +43,7 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | /bin/sh -s -- -y
 ENV PATH=$PATH:/root/.cargo/bin
 
 # Install poetry package management tool
-RUN curl -sSL https://install.python-poetry.org | python3 -
+RUN curl -sSL https://install.python-poetry.org | python3 - --version 1.6.0
 
 # Add poetry to PATH environment variable
 ENV PATH "/root/.local/bin:$PATH"

--- a/experimenter/Dockerfile
+++ b/experimenter/Dockerfile
@@ -33,7 +33,7 @@ RUN . "$NVM_DIR/nvm.sh" && nvm alias default v${NODE_VERSION}
 ENV PYTHONDONTWRITEBYTECODE 1
 
 # Python packages
-RUN curl -sSL https://install.python-poetry.org | python3 -
+RUN curl -sSL https://install.python-poetry.org | python3 - --version 1.6.0
 ENV PATH "/root/.local/bin:$PATH"
 RUN poetry config virtualenvs.create false
 

--- a/schemas/Dockerfile
+++ b/schemas/Dockerfile
@@ -33,7 +33,7 @@ RUN . "$NVM_DIR/nvm.sh" && nvm alias default v${NODE_VERSION}
 ENV PYTHONDONTWRITEBYTECODE 1
 
 # Python packages
-RUN curl -sSL https://install.python-poetry.org | python3 -
+RUN curl -sSL https://install.python-poetry.org | python3 - --version 1.6.0
 ENV PATH "/root/.local/bin:$PATH"
 RUN poetry config virtualenvs.create false
 


### PR DESCRIPTION
Because

* Poetry 1.7.0 appears to validate against the author field in pyproject.toml
* It seems that if a dependency package does not fill this in then Poetry will fail to install dependencies

This commit

* Locks Poetry to 1.6.0


