### PR TITLE
fix #9678 feat(nimbus): Add is_web flag for web apps

### DIFF
--- a/experimenter/experimenter/experiments/api/v5/types.py
+++ b/experimenter/experimenter/experiments/api/v5/types.py
@@ -468,6 +468,7 @@ class NimbusExperimentType(DjangoObjectType):
     is_localized = graphene.Boolean()
     is_rollout = graphene.Boolean()
     is_sticky = graphene.Boolean()
+    is_web = graphene.Boolean()
     jexl_targeting_expression = graphene.String()
     languages = graphene.List(graphene.NonNull(NimbusLanguageType), required=True)
     locales = graphene.List(graphene.NonNull(NimbusLocaleType), required=True)
@@ -540,6 +541,7 @@ class NimbusExperimentType(DjangoObjectType):
             "is_localized",
             "is_rollout",
             "is_sticky",
+            "is_web",
             "jexl_targeting_expression",
             "languages",
             "locales",
@@ -651,6 +653,9 @@ class NimbusExperimentType(DjangoObjectType):
 
     def resolve_is_enrollment_paused(self, info):
         return self.is_paused_published
+
+    def resolve_is_web(self, info):
+        return NimbusExperiment.APPLICATION_CONFIGS[self.application].is_web
 
     def resolve_enrollment_end_date(self, info):
         return self.proposed_enrollment_end_date

--- a/experimenter/experimenter/experiments/api/v5/types.py
+++ b/experimenter/experimenter/experiments/api/v5/types.py
@@ -468,7 +468,7 @@ class NimbusExperimentType(DjangoObjectType):
     is_localized = graphene.Boolean()
     is_rollout = graphene.Boolean()
     is_sticky = graphene.Boolean()
-    is_web = graphene.Boolean()
+    is_web = graphene.NonNull(graphene.Boolean())
     jexl_targeting_expression = graphene.String()
     languages = graphene.List(graphene.NonNull(NimbusLanguageType), required=True)
     locales = graphene.List(graphene.NonNull(NimbusLocaleType), required=True)

--- a/experimenter/experimenter/experiments/api/v5/types.py
+++ b/experimenter/experimenter/experiments/api/v5/types.py
@@ -468,7 +468,7 @@ class NimbusExperimentType(DjangoObjectType):
     is_localized = graphene.Boolean()
     is_rollout = graphene.Boolean()
     is_sticky = graphene.Boolean()
-    is_web = graphene.NonNull(graphene.Boolean())
+    is_web = graphene.NonNull(graphene.Boolean)
     jexl_targeting_expression = graphene.String()
     languages = graphene.List(graphene.NonNull(NimbusLanguageType), required=True)
     locales = graphene.List(graphene.NonNull(NimbusLocaleType), required=True)

--- a/experimenter/experimenter/experiments/constants.py
+++ b/experimenter/experimenter/experiments/constants.py
@@ -56,6 +56,7 @@ class ApplicationConfig:
     channel_app_id: Dict[str, str]
     kinto_collection: str
     randomization_unit: str
+    is_web: bool
 
 
 APPLICATION_CONFIG_DESKTOP = ApplicationConfig(
@@ -73,6 +74,7 @@ APPLICATION_CONFIG_DESKTOP = ApplicationConfig(
     },
     kinto_collection=settings.KINTO_COLLECTION_NIMBUS_DESKTOP,
     randomization_unit=BucketRandomizationUnit.NORMANDY,
+    is_web=False,
 )
 
 APPLICATION_CONFIG_FENIX = ApplicationConfig(
@@ -86,6 +88,7 @@ APPLICATION_CONFIG_FENIX = ApplicationConfig(
     },
     kinto_collection=settings.KINTO_COLLECTION_NIMBUS_MOBILE,
     randomization_unit=BucketRandomizationUnit.NIMBUS,
+    is_web=False,
 )
 
 APPLICATION_CONFIG_IOS = ApplicationConfig(
@@ -100,6 +103,7 @@ APPLICATION_CONFIG_IOS = ApplicationConfig(
     },
     kinto_collection=settings.KINTO_COLLECTION_NIMBUS_MOBILE,
     randomization_unit=BucketRandomizationUnit.NIMBUS,
+    is_web=False,
 )
 
 APPLICATION_CONFIG_FOCUS_ANDROID = ApplicationConfig(
@@ -113,6 +117,7 @@ APPLICATION_CONFIG_FOCUS_ANDROID = ApplicationConfig(
     },
     kinto_collection=settings.KINTO_COLLECTION_NIMBUS_MOBILE,
     randomization_unit=BucketRandomizationUnit.NIMBUS,
+    is_web=False,
 )
 
 APPLICATION_CONFIG_KLAR_ANDROID = ApplicationConfig(
@@ -124,6 +129,7 @@ APPLICATION_CONFIG_KLAR_ANDROID = ApplicationConfig(
     },
     kinto_collection=settings.KINTO_COLLECTION_NIMBUS_MOBILE,
     randomization_unit=BucketRandomizationUnit.NIMBUS,
+    is_web=False,
 )
 
 
@@ -137,6 +143,7 @@ APPLICATION_CONFIG_FOCUS_IOS = ApplicationConfig(
     },
     kinto_collection=settings.KINTO_COLLECTION_NIMBUS_MOBILE,
     randomization_unit=BucketRandomizationUnit.NIMBUS,
+    is_web=False,
 )
 
 APPLICATION_CONFIG_KLAR_IOS = ApplicationConfig(
@@ -149,6 +156,7 @@ APPLICATION_CONFIG_KLAR_IOS = ApplicationConfig(
     },
     kinto_collection=settings.KINTO_COLLECTION_NIMBUS_MOBILE,
     randomization_unit=BucketRandomizationUnit.NIMBUS,
+    is_web=False,
 )
 
 APPLICATION_CONFIG_MONITOR_WEB = ApplicationConfig(
@@ -161,6 +169,7 @@ APPLICATION_CONFIG_MONITOR_WEB = ApplicationConfig(
     },
     kinto_collection=settings.KINTO_COLLECTION_NIMBUS_WEB,
     randomization_unit=BucketRandomizationUnit.USER_ID,
+    is_web=True,
 )
 
 APPLICATION_CONFIG_DEMO_APP = ApplicationConfig(
@@ -173,6 +182,7 @@ APPLICATION_CONFIG_DEMO_APP = ApplicationConfig(
     },
     kinto_collection=settings.KINTO_COLLECTION_NIMBUS_WEB,
     randomization_unit=BucketRandomizationUnit.USER_ID,
+    is_web=True,
 )
 
 

--- a/experimenter/experimenter/experiments/tests/api/v5/test_queries.py
+++ b/experimenter/experimenter/experiments/tests/api/v5/test_queries.py
@@ -835,6 +835,7 @@ class TestNimbusExperimentBySlugQuery(GraphQLTestCase):
 
                     isLocalized
                     localizations
+                    isWeb
                 }
             }
             """,
@@ -912,6 +913,9 @@ class TestNimbusExperimentBySlugQuery(GraphQLTestCase):
                 "isLocalized": experiment.is_localized,
                 "isRollout": experiment.is_rollout,
                 "isSticky": experiment.is_sticky,
+                "isWeb": NimbusExperiment.APPLICATION_CONFIGS[
+                    experiment.application
+                ].is_web,
                 "jexlTargetingExpression": experiment.targeting,
                 "languages": [{"id": str(language.id), "name": language.name}],
                 "locales": [{"id": str(locale.id), "name": locale.name}],

--- a/experimenter/experimenter/nimbus-ui/schema.graphql
+++ b/experimenter/experimenter/nimbus-ui/schema.graphql
@@ -72,6 +72,7 @@ type NimbusExperimentType {
   excludedExperiments: [NimbusExperimentType!]!
   isEnrollmentPausePending: Boolean
   isEnrollmentPaused: Boolean
+  isWeb: Boolean
   jexlTargetingExpression: String
   monitoringDashboardUrl: String
   readyForReview: NimbusReviewType

--- a/experimenter/experimenter/nimbus-ui/schema.graphql
+++ b/experimenter/experimenter/nimbus-ui/schema.graphql
@@ -72,7 +72,7 @@ type NimbusExperimentType {
   excludedExperiments: [NimbusExperimentType!]!
   isEnrollmentPausePending: Boolean
   isEnrollmentPaused: Boolean
-  isWeb: Boolean
+  isWeb: Boolean!
   jexlTargetingExpression: String
   monitoringDashboardUrl: String
   readyForReview: NimbusReviewType

--- a/experimenter/experimenter/nimbus-ui/src/gql/experiments.ts
+++ b/experimenter/experimenter/nimbus-ui/src/gql/experiments.ts
@@ -131,6 +131,7 @@ export const GET_EXPERIMENT_QUERY = gql`
       }
       isSticky
       isFirstRun
+      isWeb
       excludedExperiments {
         id
         slug

--- a/experimenter/experimenter/nimbus-ui/src/types/getExperiment.ts
+++ b/experimenter/experimenter/nimbus-ui/src/types/getExperiment.ts
@@ -210,6 +210,7 @@ export interface getExperiment_experimentBySlug {
   targetingConfig: (getExperiment_experimentBySlug_targetingConfig | null)[] | null;
   isSticky: boolean | null;
   isFirstRun: boolean;
+  isWeb: boolean;
   excludedExperiments: getExperiment_experimentBySlug_excludedExperiments[];
   requiredExperiments: getExperiment_experimentBySlug_requiredExperiments[];
   jexlTargetingExpression: string | null;


### PR DESCRIPTION
Because

- We want to make changes on UI based on if its a web app or not (cirrus)

This commit

- Add a new property `is_web` to the application config
<img width="1086" alt="Screenshot 2023-11-06 at 6 00 03 PM" src="https://github.com/mozilla/experimenter/assets/25848231/c2f957b3-b71e-4172-8c36-47cea6c40b10">
<img width="1086" alt="Screenshot 2023-11-06 at 5 56 57 PM" src="https://github.com/mozilla/experimenter/assets/25848231/61d61316-46e7-45d8-8d03-4ba30d9e5654">
