### PR TITLE
feat(nimbus): Fetch features from FML apps going back 5 versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -506,7 +506,7 @@ jobs:
             git checkout main
             git pull origin main
             cp .env.sample .env
-            make fetch_external_resources
+            env GITHUB_BEARER_TOKEN="${GH_TOKEN}" make fetch_external_resources
             if (($(git status --porcelain | wc -c) > 0))
               then
                 git checkout -B external-config

--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,7 @@ jetstream_config:
 	rm -Rf experimenter/experimenter/outcomes/metric-hub-main/.script/
 
 feature_manifests: build_dev
-	$(COMPOSE) run experimenter /experimenter/bin/manifest-tool.py fetch-latest
+	$(COMPOSE) run experimenter /experimenter/bin/manifest-tool.py fetch
 
 install_nimbus_cli:  ## Install Nimbus client
 	mkdir -p $(CLI_DIR)

--- a/experimenter/manifesttool/appconfig.py
+++ b/experimenter/manifesttool/appconfig.py
@@ -35,6 +35,25 @@ class PListVersionFile(BaseModel):
 class VersionFile(BaseModel):
     __root__: Union[PlainTextVersionFile, PListVersionFile] = Field(discriminator="type")
 
+    @classmethod
+    def create_plain_text(cls, path: str):  # pragma: no cover
+        return cls(
+            __root__=PlainTextVersionFile(
+                type=VersionFileType.PLAIN_TEXT,
+                path=path,
+            ),
+        )
+
+    @classmethod
+    def create_plist(cls, path: str, key: str):  # pragma: no cover
+        return cls(
+            __root__=PListVersionFile(
+                type=VersionFileType.PLIST,
+                path=path,
+                key=key,
+            ),
+        )
+
 
 class AppConfig(BaseModel):
     """The configuration of a single app in apps.yaml."""

--- a/experimenter/manifesttool/cli.py
+++ b/experimenter/manifesttool/cli.py
@@ -6,7 +6,7 @@ import click
 from manifesttool.appconfig import AppConfigs
 from manifesttool.fetch import fetch_fml_app, fetch_legacy_app, summarize_results
 
-MANIFESTS_DIR = Path(__file__).parent.parent / "experimenter" / "features" / "manifests"
+MANIFEST_DIR = Path(__file__).parent.parent / "experimenter" / "features" / "manifests"
 
 
 @dataclass
@@ -19,7 +19,7 @@ class Context:
 @click.option(
     "--manifest-dir",
     type=Path,
-    default=MANIFESTS_DIR,
+    default=MANIFEST_DIR,
     help="The directory that contains manifests",
 )
 @click.pass_context

--- a/experimenter/manifesttool/cli.py
+++ b/experimenter/manifesttool/cli.py
@@ -3,8 +3,13 @@ from pathlib import Path
 
 import click
 
-from manifesttool.appconfig import AppConfigs
-from manifesttool.fetch import fetch_fml_app, fetch_legacy_app, summarize_results
+from manifesttool.appconfig import AppConfigs, RepositoryType
+from manifesttool.fetch import (
+    fetch_fml_app,
+    fetch_legacy_app,
+    fetch_releases,
+    summarize_results,
+)
 
 MANIFEST_DIR = Path(__file__).parent.parent / "experimenter" / "features" / "manifests"
 
@@ -49,5 +54,12 @@ def fetch(ctx: click.Context):
             results.append(fetch_legacy_app(context.manifest_dir, app_name, app_config))
         else:  # pragma: no cover
             assert False, "unreachable"
+
+        if (
+            app_config.repo.type == RepositoryType.GITHUB
+            and app_config.fml_path is not None
+            and app_config.version_file is not None
+        ):
+            results.extend(fetch_releases(context.manifest_dir, app_name, app_config))
 
     summarize_results(results)

--- a/experimenter/manifesttool/cli.py
+++ b/experimenter/manifesttool/cli.py
@@ -32,10 +32,10 @@ def main(ctx: click.Context, *, manifest_dir: Path):
     )
 
 
-@main.command("fetch-latest")
+@main.command("fetch")
 @click.pass_context
-def fetch_latest(ctx: click.Context):
-    """Fetch the latest FML manifests and generate experimenter.yaml files."""
+def fetch(ctx: click.Context):
+    """Fetch the FML manifests and generate experimenter.yaml files."""
     context = ctx.find_object(Context)
 
     results = []

--- a/experimenter/manifesttool/fetch.py
+++ b/experimenter/manifesttool/fetch.py
@@ -127,20 +127,27 @@ def fetch_legacy_app(
         else:
             print(f"fetch: {app_name} at {ref}")
 
-        manifest_path = manifest_dir / app_config.slug / "experimenter.yaml"
         print(f"fetch: {app_name}: downloading experimenter.yaml")
+
+        app_dir = manifest_dir / app_config.slug
+        if version:
+            app_dir /= f"v{version}"
+
+        app_dir.mkdir(exist_ok=True)
+        manifest_path = app_dir / "experimenter.yaml"
+
         hgmo_api.fetch_file(
             app_config.repo.name,
             app_config.experimenter_yaml_path,
             ref.resolved,
-            manifest_dir / app_config.slug / "experimenter.yaml",
+            manifest_path,
         )
 
         with manifest_path.open() as f:
             raw_manifest = yaml.safe_load(f)
             manifest = FeatureManifest.parse_obj(raw_manifest)
 
-        schema_dir = manifest_dir / app_config.slug / "schemas"
+        schema_dir = app_dir / "schemas"
         schema_dir.mkdir(exist_ok=True)
 
         # Some features may re-use the same schemas, so we only have to fetch them

--- a/experimenter/manifesttool/fetch.py
+++ b/experimenter/manifesttool/fetch.py
@@ -10,7 +10,12 @@ from mozilla_nimbus_schemas import FeatureManifest
 from manifesttool import github_api, hgmo_api, nimbus_cli
 from manifesttool.appconfig import AppConfig, RepositoryType
 from manifesttool.repository import Ref
-from manifesttool.version import Version
+from manifesttool.version import (
+    Version,
+    filter_versioned_refs,
+    find_versioned_refs,
+    resolve_ref_versions,
+)
 
 
 @dataclass
@@ -186,6 +191,66 @@ def fetch_legacy_app(
         result.exc = e
 
     return result
+
+
+def fetch_releases(
+    manifest_dir: Path,
+    app_name: str,
+    app_config: AppConfig,
+) -> list[FetchResult]:
+    """Fetch all releases in the past 5 major versions of the app."""
+    results = []
+
+    if app_config.repo.type == RepositoryType.HGMO:
+        raise Exception("Cannot fetch releases for apps hosted on hg.mozilla.org.")
+
+    if app_config.fml_path is None:
+        raise Exception("Cannot fetch releases for legacy apps.")
+
+    if app_config.version_file is None:
+        raise Exception(f"App {app_name} does not have a version file.")
+
+    if not app_config.branch_re:
+        print(f"fetch: releases: {app_name} does not support releases", file=sys.stderr)
+        return results
+
+    # Find all release branches.
+    branches = github_api.get_branches(app_config.repo.name)
+    versions = find_versioned_refs(
+        branches, app_config.branch_re, app_config.ignored_branches
+    )
+
+    # Limit to the last 5 major versions.
+    #
+    # We must pass a list here because if max() is passed a single arg it will
+    # try to iterate over it.
+    max_major_version = max([0, *(v.major for v in versions.keys())])
+
+    if max_major_version == 0:
+        raise Exception(f"Could not find a major release for {app_name}.")
+
+    min_version = Version(max_major_version - 4, 0, 0)
+
+    versions = filter_versioned_refs(versions, min_version)
+
+    # Extract the actual version number for each branch's version file.
+    # Otherwise, e.g., a branch like release/v1 would end up overwriting 1.0.0
+    # version constantly, even though it is likely futher ahead than 1.0.0.
+    versions = resolve_ref_versions(app_config, versions.values())
+
+    if app_config.tag_re:
+        tags = github_api.get_tags(app_config.repo.name)
+        tag_versions = find_versioned_refs(
+            tags, app_config.tag_re, app_config.ignored_tags
+        )
+        tag_versions = filter_versioned_refs(tag_versions, min_version)
+
+        versions.update(tag_versions)
+
+    for version, ref in versions.items():
+        results.append(fetch_fml_app(manifest_dir, app_name, app_config, ref, version))
+
+    return results
 
 
 def summarize_results(results: list[FetchResult]):

--- a/experimenter/manifesttool/fetch.py
+++ b/experimenter/manifesttool/fetch.py
@@ -73,19 +73,21 @@ def fetch_fml_app(
         for channel in channels:
             print(f"fetch: {app_name}: download {channel} manifest")
             nimbus_cli.download_single_file(
+                manifest_dir,
                 app_config,
                 channel,
-                manifest_dir,
                 ref.resolved,
+                version,
             )
 
         print(f"fetch: {app_name}: generate experimenter.yaml")
         # The single-file fml file for each channel will generate the same
         # experimenter.yaml, so we can pick any here.
         nimbus_cli.generate_experimenter_yaml(
+            manifest_dir,
             app_config,
             channels[0],
-            manifest_dir,
+            version,
         )
     except Exception as e:
         print_exception(e, file=sys.stderr)

--- a/experimenter/manifesttool/fetch.py
+++ b/experimenter/manifesttool/fetch.py
@@ -26,12 +26,12 @@ class FetchResult:
     exc: Optional[Exception] = None
 
     def __str__(self):
-        s = f"{self.app_name} at {self.ref} version {self.version}"
+        as_str = f"{self.app_name} at {self.ref} version {self.version}"
         if self.exc:
             exc_message = str(self.exc).partition("\n")[0]
-            s = f"{s}\n{exc_message}\n"
+            as_str = f"{as_str}\n{exc_message}\n"
 
-        return s
+        return as_str
 
 
 def fetch_fml_app(

--- a/experimenter/manifesttool/fetch.py
+++ b/experimenter/manifesttool/fetch.py
@@ -21,7 +21,12 @@ class FetchResult:
     exc: Optional[Exception] = None
 
     def __str__(self):
-        return f"{self.app_name} at {self.ref} version {self.version}"
+        s = f"{self.app_name} at {self.ref} version {self.version}"
+        if self.exc:
+            exc_message = str(self.exc).partition("\n")[0]
+            s = f"{s}\n{exc_message}\n"
+
+        return s
 
 
 def fetch_fml_app(
@@ -29,7 +34,7 @@ def fetch_fml_app(
     app_name: str,
     app_config: AppConfig,
     ref: Optional[Ref] = None,
-    version: Optional[Version] = None
+    version: Optional[Version] = None,
 ) -> FetchResult:
     if app_config.repo.type == RepositoryType.HGMO:
         raise Exception("FML-based apps on hg.mozilla.org are not supported.")

--- a/experimenter/manifesttool/fetch.py
+++ b/experimenter/manifesttool/fetch.py
@@ -38,10 +38,10 @@ def fetch_fml_app(
         if ref is None:
             ref = result.ref = github_api.get_main_ref(app_config.repo.name)
 
-        print(f"fetch-latest: {app_name} at {ref}")
+        print(f"fetch: {app_name} at {ref}")
 
         channels = nimbus_cli.get_channels(app_config, ref.resolved)
-        print(f"fetch-latest: {app_name}: channels are {', '.join(channels)}")
+        print(f"fetch: {app_name}: channels are {', '.join(channels)}")
 
         if not channels:
             print(
@@ -51,7 +51,7 @@ def fetch_fml_app(
             raise Exception("No channels found")
 
         for channel in channels:
-            print(f"fetch-latest: {app_name}: download {channel} manifest")
+            print(f"fetch: {app_name}: download {channel} manifest")
             nimbus_cli.download_single_file(
                 app_config,
                 channel,
@@ -59,7 +59,7 @@ def fetch_fml_app(
                 ref.resolved,
             )
 
-        print(f"fetch-latest: {app_name}: generate experimenter.yaml")
+        print(f"fetch: {app_name}: generate experimenter.yaml")
         # The single-file fml file for each channel will generate the same
         # experimenter.yaml, so we can pick any here.
         nimbus_cli.generate_experimenter_yaml(
@@ -93,10 +93,10 @@ def fetch_legacy_app(
         if ref is None:
             ref = result.ref = hgmo_api.get_tip_rev(app_config.repo.name)
 
-        print(f"fetch-latest: {app_name} at {ref}")
+        print(f"fetch: {app_name} at {ref}")
 
         manifest_path = manifest_dir / app_config.slug / "experimenter.yaml"
-        print(f"fetch-latest: {app_name}: downloading experimenter.yaml")
+        print(f"fetch: {app_name}: downloading experimenter.yaml")
         hgmo_api.fetch_file(
             app_config.repo.name,
             app_config.experimenter_yaml_path,
@@ -121,13 +121,13 @@ def fetch_legacy_app(
             if feature.json_schema is not None:
                 if feature.json_schema.path in fetched_schemas:
                     print(
-                        f"fetch-latest: {app_name}: already fetched schema for "
+                        f"fetch: {app_name}: already fetched schema for "
                         f"feature {feature_slug} ({feature.json_schema.path})"
                     )
                     continue
 
                 print(
-                    f"fetch-latest: {app_name}: fetching schema for feature {feature_slug} "
+                    f"fetch: {app_name}: fetching schema for feature {feature_slug} "
                     f"({feature.json_schema.path})"
                 )
 

--- a/experimenter/manifesttool/tests/test_appconfig.py
+++ b/experimenter/manifesttool/tests/test_appconfig.py
@@ -1,13 +1,13 @@
 from unittest import TestCase
 
 from manifesttool.appconfig import AppConfigs
-from manifesttool.cli import MANIFESTS_DIR
+from manifesttool.cli import MANIFEST_DIR
 
 
 class AppConfigTests(TestCase):
     def test_parse_apps_yaml(self):
         """Testing that we can parse apps.yaml."""
-        AppConfigs.load_from_directory(MANIFESTS_DIR)
+        AppConfigs.load_from_directory(MANIFEST_DIR)
 
     def test_parse_experimenter_and_fml_paths(self):
         """Testing that parsing apps.yaml fails if an app contains both the

--- a/experimenter/manifesttool/tests/test_cli.py
+++ b/experimenter/manifesttool/tests/test_cli.py
@@ -64,7 +64,8 @@ class CliTests(TestCase):
             )
 
             self.assertIn(
-                "SUMMARY:\n\nSUCCESS:\n\nfml_app at main (resolved) version None\n", result.stdout
+                "SUMMARY:\n\nSUCCESS:\n\nfml_app at main (resolved) version None\n",
+                result.stdout,
             )
 
     @patch.object(
@@ -79,12 +80,17 @@ class CliTests(TestCase):
             result = runner.invoke(cli.main, ["--manifest-dir", ".", "fetch"])
             self.assertEqual(result.exit_code, 0, result.exception or result.stdout)
 
-            self.assertIn("SUMMARY:\n\nFAILURES:\n\nfml_app at main version None\n", result.stdout)
+            self.assertIn(
+                "SUMMARY:\n\nFAILURES:\n\nfml_app at main version None\nConnection error\n",
+                result.stdout,
+            )
 
     @patch.object(
         cli,
         "fetch_legacy_app",
-        side_effect=lambda *args: FetchResult("legacy_app", Ref("tip", "resolved"), version=None),
+        side_effect=lambda *args: FetchResult(
+            "legacy_app", Ref("tip", "resolved"), version=None
+        ),
     )
     def test_fetch_legacy(self, fetch_legacy_app):
         with cli_runner(app_config=LEGACY_APP_CONFIG) as runner:
@@ -98,7 +104,8 @@ class CliTests(TestCase):
             )
 
             self.assertIn(
-                "SUMMARY:\n\nSUCCESS:\n\nlegacy_app at tip (resolved) version None\n", result.stdout
+                "SUMMARY:\n\nSUCCESS:\n\nlegacy_app at tip (resolved) version None\n",
+                result.stdout,
             )
 
     @patch.object(
@@ -114,6 +121,6 @@ class CliTests(TestCase):
             self.assertEqual(result.exit_code, 0, result.exception or result.stdout)
 
             self.assertIn(
-                "SUMMARY:\n\nFAILURES:\n\nlegacy_app at tip version None\n",
+                "SUMMARY:\n\nFAILURES:\n\nlegacy_app at tip version None\nConnection error\n",
                 result.stdout,
             )

--- a/experimenter/manifesttool/tests/test_cli.py
+++ b/experimenter/manifesttool/tests/test_cli.py
@@ -52,9 +52,9 @@ class CliTests(TestCase):
         "fetch_fml_app",
         side_effect=lambda *args: FetchResult("fml_app", Ref("main", "resolved")),
     )
-    def test_fetch_latest_fml(self, fetch_fml_app):
+    def test_fetch_fml(self, fetch_fml_app):
         with cli_runner(app_config=FML_APP_CONFIG) as runner:
-            result = runner.invoke(cli.main, ["--manifest-dir", ".", "fetch-latest"])
+            result = runner.invoke(cli.main, ["--manifest-dir", ".", "fetch"])
             self.assertEqual(result.exit_code, 0, result.exception or result.stdout)
 
             fetch_fml_app.assert_called_with(
@@ -74,9 +74,9 @@ class CliTests(TestCase):
             "fml_app", Ref("main"), exc=Exception("Connection error")
         ),
     )
-    def test_fetch_latest_fml_failure(self):
+    def test_fetch_fml_failure(self):
         with cli_runner(app_config=FML_APP_CONFIG) as runner:
-            result = runner.invoke(cli.main, ["--manifest-dir", ".", "fetch-latest"])
+            result = runner.invoke(cli.main, ["--manifest-dir", ".", "fetch"])
             self.assertEqual(result.exit_code, 0, result.exception or result.stdout)
 
             self.assertIn("SUMMARY:\n\nFAILURES:\n\nfml_app at main\n", result.stdout)
@@ -86,9 +86,9 @@ class CliTests(TestCase):
         "fetch_legacy_app",
         side_effect=lambda *args: FetchResult("legacy_app", Ref("tip", "resolved")),
     )
-    def fetch_latest_legacy_success(self, fetch_legacy_app):
+    def test_fetch_legacy(self, fetch_legacy_app):
         with cli_runner(app_config=LEGACY_APP_CONFIG) as runner:
-            result = runner.invoke(cli.main, ["--manifest-dir", ".", "fetch-latest"])
+            result = runner.invoke(cli.main, ["--manifest-dir", ".", "fetch"])
             self.assertEqual(result.exit_code, 0, result.exception or result.stdout)
 
             fetch_legacy_app.assert_called_with(
@@ -110,7 +110,7 @@ class CliTests(TestCase):
     )
     def test_fetch_legacy_failure(self):
         with cli_runner(app_config=LEGACY_APP_CONFIG) as runner:
-            result = runner.invoke(cli.main, ["--manifest-dir", ".", "fetch-latest"])
+            result = runner.invoke(cli.main, ["--manifest-dir", ".", "fetch"])
             self.assertEqual(result.exit_code, 0, result.exception or result.stdout)
 
             self.assertIn(

--- a/experimenter/manifesttool/tests/test_cli.py
+++ b/experimenter/manifesttool/tests/test_cli.py
@@ -11,7 +11,7 @@ from manifesttool import cli
 from manifesttool.appconfig import AppConfig, AppConfigs
 from manifesttool.fetch import FetchResult
 from manifesttool.repository import Ref
-from manifesttool.tests.test_fetch import FML_APP_CONFIG, LEGACY_APP_CONFIG
+from manifesttool.tests.test_fetch import FML_APP_CONFIG, LEGACY_APP_CONFIG, mock_fetch
 
 
 def make_app_configs(app_config: AppConfig) -> AppConfigs:
@@ -50,7 +50,7 @@ class CliTests(TestCase):
     @patch.object(
         cli,
         "fetch_fml_app",
-        side_effect=lambda *args: FetchResult("fml_app", Ref("main", "resolved")),
+        side_effect=lambda *args: mock_fetch(*args, ref=Ref("main", "resolved"))
     )
     def test_fetch_fml(self, fetch_fml_app):
         with cli_runner(app_config=FML_APP_CONFIG) as runner:
@@ -64,14 +64,14 @@ class CliTests(TestCase):
             )
 
             self.assertIn(
-                "SUMMARY:\n\nSUCCESS:\n\nfml_app at main (resolved)\n", result.stdout
+                "SUMMARY:\n\nSUCCESS:\n\nfml_app at main (resolved) version None\n", result.stdout
             )
 
     @patch.object(
         cli,
         "fetch_fml_app",
         lambda *args: FetchResult(
-            "fml_app", Ref("main"), exc=Exception("Connection error")
+            "fml_app", Ref("main"), version=None, exc=Exception("Connection error")
         ),
     )
     def test_fetch_fml_failure(self):
@@ -79,12 +79,12 @@ class CliTests(TestCase):
             result = runner.invoke(cli.main, ["--manifest-dir", ".", "fetch"])
             self.assertEqual(result.exit_code, 0, result.exception or result.stdout)
 
-            self.assertIn("SUMMARY:\n\nFAILURES:\n\nfml_app at main\n", result.stdout)
+            self.assertIn("SUMMARY:\n\nFAILURES:\n\nfml_app at main version None\n", result.stdout)
 
     @patch.object(
         cli,
         "fetch_legacy_app",
-        side_effect=lambda *args: FetchResult("legacy_app", Ref("tip", "resolved")),
+        side_effect=lambda *args: FetchResult("legacy_app", Ref("tip", "resolved"), version=None),
     )
     def test_fetch_legacy(self, fetch_legacy_app):
         with cli_runner(app_config=LEGACY_APP_CONFIG) as runner:
@@ -98,14 +98,14 @@ class CliTests(TestCase):
             )
 
             self.assertIn(
-                "SUMMARY:\n\nSUCCESS:\n\nlegacy_app at tip (resolved)\n", result.stdout
+                "SUMMARY:\n\nSUCCESS:\n\nlegacy_app at tip (resolved) version None\n", result.stdout
             )
 
     @patch.object(
         cli,
         "fetch_legacy_app",
         lambda *args: FetchResult(
-            "legacy_app", Ref("tip"), exc=Exception("Connection error")
+            "legacy_app", Ref("tip"), version=None, exc=Exception("Connection error")
         ),
     )
     def test_fetch_legacy_failure(self):
@@ -114,6 +114,6 @@ class CliTests(TestCase):
             self.assertEqual(result.exit_code, 0, result.exception or result.stdout)
 
             self.assertIn(
-                "SUMMARY:\n\nFAILURES:\n\nlegacy_app at tip\n",
+                "SUMMARY:\n\nFAILURES:\n\nlegacy_app at tip version None\n",
                 result.stdout,
             )

--- a/experimenter/manifesttool/tests/test_fetch.py
+++ b/experimenter/manifesttool/tests/test_fetch.py
@@ -1,16 +1,31 @@
 import json
+from contextlib import redirect_stderr, contextmanager
+from io import StringIO
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import Any, Optional
+from typing import Any, Iterable, Optional
 from unittest import TestCase
 from unittest.mock import call, patch
 
 import responses
 import yaml
+from parameterized import parameterized
 
+import manifesttool
 from manifesttool import fetch
-from manifesttool.appconfig import AppConfig, Repository, RepositoryType
-from manifesttool.fetch import FetchResult, fetch_fml_app, fetch_legacy_app
+from manifesttool.appconfig import (
+    AppConfig,
+    Repository,
+    RepositoryType,
+    VersionFile,
+    VersionFileType,
+)
+from manifesttool.fetch import (
+    FetchResult,
+    fetch_fml_app,
+    fetch_legacy_app,
+    fetch_releases,
+)
 from manifesttool.nimbus_cli import _get_experimenter_yaml_path, _get_fml_path
 from manifesttool.repository import Ref
 from manifesttool.version import Version
@@ -126,6 +141,83 @@ def mock_fetch(
     """A mock version of fetch_fml_app and fetch_legacy_app that returns success."""
     return FetchResult(app_name, ref, version)
 
+
+@contextmanager
+def mocks_for_fetch_releases(
+    app_config: AppConfig,
+    branches: list[Ref],
+    tags: Optional[list[Ref]],
+    ref_versions: dict[str, Version],
+):
+    """Create a set of mocks to call fetch_releases.
+
+    Args:
+        app_config:
+            The app configuration.
+
+            The ``version_file`` and ``branch_re`` fields are required.
+
+        branches:
+            The list of refs to return from ``get_branches()``.
+
+        Tags:
+            The list of refs to return from ``get_tags()``.
+
+            If ``None``, ``app_config.tag_re`` must also be ``None``.
+
+        ref_versions:
+            A mapping of resolved refs to Versions.
+
+            This argument is used to generate a mock for ``fetch_file()``.
+
+    Yields:
+        A 3-tuple of the mocks for ``get_branches``, ``get_tags``, and ``fetch_file``.
+    """
+    assert app_config.repo.type == RepositoryType.GITHUB
+    assert app_config.branch_re is not None
+
+    # Mocking plist files is more annoying.
+    assert app_config.version_file is not None
+    assert app_config.version_file.__root__.type == VersionFileType.PLAIN_TEXT
+
+    # Ensure tags are defined if app specifies a tag regex.
+    assert app_config.tag_re is None or tags is not None
+
+    def mock_get_branches(*args):
+        return branches
+
+    def mock_get_tags(*args):
+        assert tags is not None
+        return tags
+
+    def mock_fetch_file(
+        repo: str, path: str, ref: str, download_path: Optional[Path] = None
+    ):
+        assert repo == app_config.repo.name
+        assert download_path is None
+        assert path == app_config.version_file.__root__.path
+        assert ref in ref_versions
+
+        return str(ref_versions[ref])
+
+    with (
+        patch.object(
+            manifesttool.github_api, "get_branches", side_effect=mock_get_branches
+        ) as get_branches,
+        patch.object(
+            manifesttool.github_api, "get_tags", side_effect=mock_get_tags
+        ) as get_tags,
+        patch.object(
+            manifesttool.github_api, "fetch_file", side_effect=mock_fetch_file
+        ) as fetch_file,
+    ):
+        yield (
+            get_branches,
+            get_tags,
+            fetch_file,
+        )
+
+
 class FetchTests(TestCase):
     maxDiff = None
 
@@ -167,8 +259,10 @@ class FetchTests(TestCase):
                 ]
             )
 
-            experimenter_manifest_path = (
-                manifest_dir / FML_APP_CONFIG.slug / "experimenter.yaml"
+            experimenter_manifest_path = _get_experimenter_yaml_path(
+                manifest_dir,
+                FML_APP_CONFIG,
+                None,
             )
             self.assertTrue(
                 experimenter_manifest_path.exists(), "experimenter.yaml should exist"
@@ -547,3 +641,193 @@ class FetchTests(TestCase):
                 "fetch_legacy_app: ref foo is not resolved",
             ):
                 fetch_legacy_app(manifest_dir, "repo", LEGACY_APP_CONFIG, Ref("foo"))
+
+    @parameterized.expand(
+        [
+            (
+                AppConfig(
+                    slug="legacy-app",
+                    repo=Repository(
+                        type=RepositoryType.HGMO,
+                        name="legacy-repo",
+                    ),
+                    experimenter_yaml_path="experimenter.yaml",
+                ),
+                "Cannot fetch releases for apps hosted on hg.mozilla.org",
+            ),
+            (
+                AppConfig(
+                    slug="legacy-app",
+                    repo=Repository(
+                        type=RepositoryType.GITHUB,
+                        name="legacy-repo",
+                    ),
+                    experimenter_yaml_path="experimenter.yaml",
+                ),
+                "Cannot fetch releases for legacy apps",
+            ),
+            (
+                AppConfig(
+                    slug="fml-app",
+                    repo=Repository(
+                        type=RepositoryType.GITHUB,
+                        name="fml-repo",
+                    ),
+                    fml_path="nimbus.fml.yaml",
+                ),
+                "App app does not have a version file.",
+            ),
+        ]
+    )
+    def test_fetch_releases_unsupported_apps(
+        self, app_config: AppConfig, exc_message: str
+    ):
+        """Testing fetch_releases with unsupported apps."""
+        with TemporaryDirectory() as tmp:
+            manifest_dir = Path(tmp)
+            manifest_dir.joinpath(app_config.slug).mkdir()
+
+            with self.assertRaisesRegex(Exception, exc_message):
+                fetch_releases(manifest_dir, "app", app_config)
+
+    @patch.object(fetch.github_api, "get_branches")
+    def test_fetch_releases_no_branch_re(self, app_config):
+        app_config = AppConfig(
+            slug="fml-app",
+            repo=Repository(
+                type=RepositoryType.GITHUB,
+                name="fml-repo",
+            ),
+            fml_path="nimbus.fml.yaml",
+            version_file=VersionFile.create_plain_text("version.txt"),
+        )
+        with TemporaryDirectory() as tmp:
+            manifest_dir = Path(tmp)
+            manifest_dir.joinpath(app_config.slug).mkdir()
+
+            f = StringIO()
+            with redirect_stderr(f):
+                fetch_releases(manifest_dir, "app", app_config)
+
+            self.assertIn("fetch: releases: app does not support releases", f.getvalue())
+
+    @patch.object(
+        fetch,
+        "fetch_fml_app",
+        mock_fetch,
+    )
+    def test_fetch_releases(self):
+        """Testing fetch_releases."""
+        app_config = AppConfig(
+            slug="fml-app",
+            repo=Repository(
+                type=RepositoryType.GITHUB,
+                name="fml-repo",
+            ),
+            fml_path="nimbus.fml.yaml",
+            version_file=VersionFile.create_plain_text("version.txt"),
+            branch_re=r"release_v(?P<major>\d)+",
+            tag_re=r"v(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)",
+        )
+
+        branches = [Ref(f"release_v{major}", f"branch-v{major}") for major in range(1, 7)]
+        tags = [Ref(f"v{major}.0.0", f"tag-v{major}") for major in range(1, 7)]
+        ref_versions = {
+            **{f"branch-v{major}": Version(major, 0, 1) for major in range(1, 7)},
+            **{f"tag-v{major}": Version(major) for major in range(1, 7)},
+        }
+
+        with TemporaryDirectory() as tmp:
+            manifest_dir = Path(tmp)
+            manifest_dir.joinpath(app_config.slug).mkdir()
+
+            with mocks_for_fetch_releases(app_config, branches, tags, ref_versions):
+                results = fetch_releases(manifest_dir, "app", app_config)
+
+        self.assertEqual(len(results), 10)  # 5 branches and 5 tags
+        for major in range(2, 7):
+            self.assertIn(
+                FetchResult(
+                    app_name="app",
+                    ref=Ref(f"v{major}.0.0", f"tag-v{major}"),
+                    version=Version(major),
+                ),
+                results,
+            )
+            self.assertIn(
+                FetchResult(
+                    app_name="app",
+                    ref=Ref(f"release_v{major}", f"branch-v{major}"),
+                    version=Version(major, 0, 1),
+                ),
+                results,
+            )
+
+    @patch.object(
+        fetch,
+        "fetch_fml_app",
+        mock_fetch,
+    )
+    def test_fetch_releases_no_tag_re(self):
+        """Testing fetch_releases with no tag_re specified."""
+        app_config = AppConfig(
+            slug="fml-app",
+            repo=Repository(
+                type=RepositoryType.GITHUB,
+                name="fml-repo",
+            ),
+            fml_path="nimbus.fml.yaml",
+            version_file=VersionFile.create_plain_text("version.txt"),
+            branch_re=r"release_v(?P<major>\d)+",
+        )
+
+        branches = [Ref(f"release_v{major}", f"branch-v{major}") for major in range(1, 7)]
+        ref_versions = {f"branch-v{major}": Version(major, 0, 1) for major in range(1, 7)}
+
+        with TemporaryDirectory() as tmp:
+            manifest_dir = Path(tmp)
+            manifest_dir.joinpath(app_config.slug).mkdir()
+
+            with mocks_for_fetch_releases(app_config, branches, None, ref_versions) as (
+                get_branches,
+                get_tags,
+                resolve_ref_versions,
+            ):
+                results = fetch_releases(manifest_dir, "app", app_config)
+
+                get_tags.assert_not_called()
+
+        self.assertEqual(len(results), 5)  # 5 branches
+        for major in range(2, 7):
+            self.assertIn(
+                FetchResult(
+                    app_name="app",
+                    ref=Ref(f"release_v{major}", f"branch-v{major}"),
+                    version=Version(major, 0, 1),
+                ),
+                results,
+            )
+
+    @patch.object(fetch.github_api, "get_branches", lambda *args: [])
+    def test_fetch_releases_no_major_release(self):
+        """Testing fetch_releases when there are no release branches."""
+        app_config = AppConfig(
+            slug="fml-app",
+            repo=Repository(
+                type=RepositoryType.GITHUB,
+                name="fml-repo",
+            ),
+            fml_path="nimbus.fml.yaml",
+            version_file=VersionFile.create_plain_text("version.txt"),
+            branch_re=r"release_v(?P<major>\d)+",
+            tag_re=r"v(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)",
+        )
+
+        with TemporaryDirectory() as tmp:
+            manifest_dir = Path(tmp)
+            manifest_dir.joinpath(app_config.slug).mkdir()
+
+            with self.assertRaisesRegex(
+                Exception, "Could not find a major release for app."
+            ):
+                fetch_releases(manifest_dir, "app", app_config)

--- a/experimenter/manifesttool/tests/test_nimbus_cli.py
+++ b/experimenter/manifesttool/tests/test_nimbus_cli.py
@@ -1,10 +1,14 @@
 import json
 from pathlib import Path
+from tempfile import TemporaryDirectory
 from unittest import TestCase
 from unittest.mock import patch
 
+from parameterized import parameterized
+
 from manifesttool import nimbus_cli
 from manifesttool.appconfig import AppConfig, Repository, RepositoryType
+from manifesttool.version import Version
 
 APP_CONFIG = AppConfig(
     slug="slug",
@@ -52,38 +56,78 @@ class NimbusCliTests(TestCase):
         with self.assertRaises(json.decoder.JSONDecodeError):
             nimbus_cli.get_channels(APP_CONFIG, "channel")
 
-    @patch.object(nimbus_cli.subprocess, "check_call")
-    def test_download_single_file(self, mock_cli):
+    @parameterized.expand(
+        [
+            (None, "slug/channel.fml.yaml"),
+            (Version(1), "slug/v1.0.0/channel.fml.yaml"),
+            (Version(1, 1), "slug/v1.1.0/channel.fml.yaml"),
+            (Version(1, 1, 1), "slug/v1.1.1/channel.fml.yaml"),
+        ]
+    )
+    def test_download_single_file(self, version, fml_path):
         """Tesing download_single_file calls nimbus-cli with correct arguments."""
-        nimbus_cli.download_single_file(APP_CONFIG, "channel", Path("."), "0" * 40)
+        with (
+            TemporaryDirectory() as tmp,
+            patch.object(nimbus_cli.subprocess, "check_call") as check_call,
+        ):
+            manifest_dir = Path(tmp)
+            manifest_dir.joinpath("slug").mkdir()
+            nimbus_cli.download_single_file(
+                manifest_dir, APP_CONFIG, "channel", "0" * 40, version
+            )
 
-        mock_cli.assert_called_with(
-            [
-                "/application-services/bin/nimbus-cli",
-                "fml",
-                "--",
-                "single-file",
-                "--channel",
-                "channel",
-                "--ref",
-                "0" * 40,
-                "@owner/repo/path",
-                "slug/channel.fml.yaml",
-            ]
-        )
+            check_call.assert_called_with(
+                [
+                    "/application-services/bin/nimbus-cli",
+                    "fml",
+                    "--",
+                    "single-file",
+                    "--channel",
+                    "channel",
+                    "--ref",
+                    "0" * 40,
+                    "@owner/repo/path",
+                    str(manifest_dir / fml_path),
+                ]
+            )
 
-    @patch.object(nimbus_cli.subprocess, "check_call")
-    def test_generate_experimenter_yaml(self, mock_cli):
+    @parameterized.expand(
+        [
+            (None, "slug/channel.fml.yaml", "slug/experimenter.yaml"),
+            (Version(1), "slug/v1.0.0/channel.fml.yaml", "slug/v1.0.0/experimenter.yaml"),
+            (
+                Version(1, 1),
+                "slug/v1.1.0/channel.fml.yaml",
+                "slug/v1.1.0/experimenter.yaml",
+            ),
+            (
+                Version(1, 1, 1),
+                "slug/v1.1.1/channel.fml.yaml",
+                "slug/v1.1.1/experimenter.yaml",
+            ),
+        ]
+    )
+    def test_generate_experimenter_yaml(
+        self, version: Version, fml_path: str, experimenter_yaml_path: str
+    ):
         """Testing generate_experimenter_yaml calls nimbus-cli with correct arguments."""
-        nimbus_cli.generate_experimenter_yaml(APP_CONFIG, "channel", Path("."))
+        with (
+            TemporaryDirectory() as tmp,
+            patch.object(nimbus_cli.subprocess, "check_call") as check_call,
+        ):
+            manifest_dir = Path(tmp)
+            manifest_dir.joinpath("slug").mkdir()
+            nimbus_cli.generate_experimenter_yaml(
+                manifest_dir, APP_CONFIG, "channel", version
+            )
 
-        mock_cli.assert_called_with(
-            [
-                "/application-services/bin/nimbus-cli",
-                "fml",
-                "--",
-                "generate-experimenter",
-                "slug/channel.fml.yaml",
-                "slug/experimenter.yaml",
-            ]
-        )
+            check_call.assert_called_with(
+                [
+                    "/application-services/bin/nimbus-cli",
+                    "fml",
+                    "--",
+                    "generate-experimenter",
+                    str(manifest_dir / fml_path),
+                    str(manifest_dir / experimenter_yaml_path),
+                ]
+            )

--- a/experimenter/manifesttool/tests/test_version.py
+++ b/experimenter/manifesttool/tests/test_version.py
@@ -11,7 +11,7 @@ from manifesttool.appconfig import (
     VersionFile,
     VersionFileType,
 )
-from manifesttool.cli import MANIFESTS_DIR
+from manifesttool.cli import MANIFEST_DIR
 from manifesttool.github_api import GITHUB_RAW_URL
 from manifesttool.hgmo_api import HGMO_URL
 from manifesttool.repository import Ref
@@ -29,7 +29,7 @@ class VersionTests(TestCase):
     def setUpClass(cls):
         super().setUpClass()
 
-        cls.app_configs = AppConfigs.load_from_directory(MANIFESTS_DIR)
+        cls.app_configs = AppConfigs.load_from_directory(MANIFEST_DIR)
 
     def test_from_match(self):
         """Tesing Version.from_match."""

--- a/experimenter/manifesttool/tests/test_version.py
+++ b/experimenter/manifesttool/tests/test_version.py
@@ -151,12 +151,10 @@ class VersionTests(TestCase):
                     "releases/v8.1.6",
                     "releases_v107.1",
                     "releases_v120",
-                    "releases_v999",
                 ],
                 {
                     Version(107, 1): Ref("releases_v107.1"),
                     Version(120): Ref("releases_v120"),
-                    Version(999): Ref("releases_v999"),
                 },
             ),
         ]
@@ -171,6 +169,7 @@ class VersionTests(TestCase):
         self._test_find_versioned_refs(
             self.app_configs.__root__[app_name].branch_re,
             [Ref(name) for name in names],
+            self.app_configs.__root__[app_name].ignored_branches,
             expected,
         )
 
@@ -259,7 +258,6 @@ class VersionTests(TestCase):
                     "8.1.6",
                 ],
                 {
-                    Version(999): Ref("v999.0.0"),
                     Version(120): Ref("v120.0"),
                     Version(98, 1): Ref("v98.1.0"),
                 },
@@ -276,6 +274,7 @@ class VersionTests(TestCase):
         self._test_find_versioned_refs(
             self.app_configs.__root__[app_name].tag_re,
             [Ref(name) for name in names],
+            self.app_configs.__root__[app_name].ignored_tags,
             expected,
         )
 
@@ -283,9 +282,10 @@ class VersionTests(TestCase):
         self,
         pattern: str,
         refs: list[Ref],
+        ignored_refs: Optional[list[str]],
         expected: dict[Version, Ref],
     ):
-        versions = find_versioned_refs(refs, pattern)
+        versions = find_versioned_refs(refs, pattern, ignored_refs)
 
         self.assertEqual(
             versions,
@@ -301,9 +301,7 @@ class VersionTests(TestCase):
             for patch in (0, 1)
         }
 
-        versioned_refs[Version(9999)] = Ref("over_9000")
-
-        result = filter_versioned_refs(versioned_refs, Version(100), ["over_9000"])
+        result = filter_versioned_refs(versioned_refs, Version(100))
 
         self.assertEqual(
             set(result.keys()),
@@ -333,37 +331,6 @@ class VersionTests(TestCase):
                 Version(100, 1, 1),
                 Version(100, 0, 1),
             },
-        )
-
-    def test_filter_versioned_refs_focus_ios(self):
-        """Testing filter_versioned_refs for focus-ios with real data."""
-        app_config = self.app_configs.__root__["focus_ios"]
-        versioned_tags = {
-            Version(999): Ref("v999.0.0"),
-            Version(120): Ref("v120.0"),
-            Version(98, 1): Ref("v98.1.0"),
-        }
-        filtered_tags = filter_versioned_refs(
-            versioned_tags, Version(100), app_config.ignored_tags
-        )
-        self.assertEqual(
-            set(filtered_tags.keys()),
-            {Version(120)},
-        )
-
-        versioned_branches = {
-            Version(107, 1): Ref("releases_v107.1"),
-            Version(120): Ref("releases_v120"),
-            Version(999): Ref("releases_v999"),
-        }
-        filtered_branches = filter_versioned_refs(
-            versioned_branches,
-            Version(100),
-            app_config.ignored_branches,
-        )
-        self.assertEqual(
-            set(filtered_branches.keys()),
-            {Version(107, 1), Version(120)},
         )
 
     @parameterized.expand(


### PR DESCRIPTION
Because

- we want to keep track of features on individual product versions

This commit

- fetches features from releases going back 5 versions in FML apps; and
- does not do an initial import for the FML apps because it is a very
  large change (see #9751).

Fixes #9685 