### PR TITLE
fix #9687 chore(project): lock application services version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -220,16 +220,22 @@ CIRRUS_GENERATE_DOCS = python cirrus/generate_docs.py
 cirrus_build:
 	$(DOCKER_BUILD) --target deploy -f cirrus/server/Dockerfile -t cirrus:deploy cirrus/server/
 
+cirrus_build_test:
+	$(COMPOSE_TEST) build cirrus
+
+cirrus_bash: cirrus_build
+	$(COMPOSE) run cirrus bash
+
 cirrus_up: cirrus_build
 	$(COMPOSE) up cirrus
 
 cirrus_down: cirrus_build
 	$(COMPOSE) down cirrus
 
-cirrus_test: cirrus_build
+cirrus_test: cirrus_build_test
 	$(COMPOSE_TEST) run cirrus sh -c '$(CIRRUS_PYTEST)'
 
-cirrus_check: cirrus_build
+cirrus_check: cirrus_build_test
 	$(COMPOSE_TEST) run cirrus sh -c "$(CIRRUS_RUFF_CHECK) && $(CIRRUS_BLACK_CHECK) && $(CIRRUS_PYTHON_TYPECHECK) && $(CIRRUS_PYTEST) && $(CIRRUS_GENERATE_DOCS) --check"
 
 cirrus_code_format: cirrus_build

--- a/cirrus/server/Dockerfile
+++ b/cirrus/server/Dockerfile
@@ -1,8 +1,6 @@
 # First stage: Build the Rust components
 FROM rust:buster AS rust-builder
 
-ARG as_version
-
 RUN update-ca-certificates
 
 RUN apt-get update -qqy \
@@ -15,12 +13,9 @@ RUN apt-get update -qqy \
 
 WORKDIR /application-services
 
+# Checkout application services at a locked commit
 RUN git clone https://github.com/mozilla/application-services.git .
-RUN if [[ -z "${as_version}" ]] ; then \
-    echo "No application-services version supplied, using latest commit." ; \
-    else \
-    git fetch ; \
-    fi
+RUN git fetch && git checkout da9301f829de67149d50dce5b709aed42f1bfe1b
 
 RUN git submodule init
 RUN git submodule update --recursive

--- a/experimenter/Dockerfile
+++ b/experimenter/Dockerfile
@@ -80,15 +80,9 @@ FROM system-builder AS rust-builder
 WORKDIR /application-services
 
 # Rust packages
-# This is temporary while megazord packaging is pending.
-ARG as_version
-
+# Checkout application services at a locked commit
 RUN git clone https://github.com/mozilla/application-services.git .
-RUN if [[ -z "${as_version}" ]] ; then \
-    echo "No application-services version supplied, using latest commit." ; \
-    else \
-    git fetch ; \
-    fi
+RUN git fetch && git checkout da9301f829de67149d50dce5b709aed42f1bfe1b
 
 RUN git submodule init
 RUN git submodule update --recursive


### PR DESCRIPTION
Because

* Changes to Application Services can break consuming code in Cirrus/Experimenter
* We currently consume the main branch of Application Services
* This means that changes can land in main in Application Services and break main in Cirrus/Experimenter
* We also neglected to explicitly rebuild the Cirrus test container when running Cirrus tests

This commit

* Explicitly locks Application Services to a specific hash when consumed in Cirrus/Experimenter
* Explicitly builds the test container for Cirrus when running Cirrus tests


