### PR TITLE
feat(nimbus): List GitHub branches and tags in manifesttool

### DIFF
--- a/experimenter/manifesttool/github_api.py
+++ b/experimenter/manifesttool/github_api.py
@@ -1,5 +1,5 @@
 import os
-from typing import Any
+from typing import Any, Generator
 
 import requests
 
@@ -15,11 +15,34 @@ if bearer_token := os.getenv("GITHUB_BEARER_TOKEN"):  # pragma: no cover
     GITHUB_API_HEADERS["Authorization"] = f"Bearer {bearer_token}"
 
 
-def api_request(path: str, **kwargs: dict[str, Any]) -> dict[str, Any]:
+def api_request(path: str, **kwargs: dict[str, Any]) -> Any:
     """Make a request to the GitHub API."""
-    return requests.get(
-        f"{GITHUB_API_URL}/{path}", headers=GITHUB_API_HEADERS, **kwargs
-    ).json()
+    url = f"{GITHUB_API_URL}/{path}"
+    rsp = requests.get(url, headers=GITHUB_API_HEADERS, **kwargs)
+
+    if rsp.status_code == 403:
+        if rsp.headers.get("X-RateLimit-Remaining") == "0":
+            raise Exception(f"Could not fetch {url}: GitHub API rate limit exceeded")
+
+    rsp.raise_for_status()
+
+    return rsp.json()
+
+
+def paginated_api_request(path: str, per_page: int = 100) -> Generator[Any, None, None]:
+    """Make several reqeusts to a paginated API resource and yield each page of results."""
+    page = 1
+
+    while True:
+        results = api_request(path, params={"page": page, "per_page": per_page})
+
+        # When there are no more results, the API returns an empty list.
+        if results:
+            yield results
+        else:
+            break
+
+        page += 1
 
 
 def get_main_ref(repo: str) -> Ref:
@@ -31,3 +54,30 @@ def get_main_ref(repo: str) -> Ref:
     """
     rsp = api_request(f"repos/{repo}/branches/main")
     return Ref("main", rsp["commit"]["sha"])
+
+
+def get_branches(repo: str) -> list[Ref]:
+    """Return all the branches in a repository."""
+    return _get_refs(repo, "branches")
+
+
+def get_tags(repo: str) -> list[Ref]:
+    """Return all the tags in a repository."""
+    return _get_refs(repo, "tags")
+
+
+def _get_refs(repo: str, kind: str) -> list[Ref]:
+    """Return all the refs of a given kind.
+
+    Args:
+        repo: The name of the repository, including the owner.
+        kind: Either ``"branches"`` or ``"tags"``.
+
+    Returns:
+        The list of refs.
+    """
+    return [
+        Ref(ref["name"], ref["commit"]["sha"])
+        for page in paginated_api_request(f"repos/{repo}/{kind}")
+        for ref in page
+    ]

--- a/experimenter/manifesttool/tests/test_github_api.py
+++ b/experimenter/manifesttool/tests/test_github_api.py
@@ -1,9 +1,27 @@
 from unittest import TestCase
+from typing import Any
 
 import responses
+from responses import matchers
 
 from manifesttool import github_api
 from manifesttool.repository import Ref
+
+
+def _add_paginated_responses(
+    url: str,
+    pages: dict[str, dict[str, Any]],
+) -> dict[str, responses.Response]:
+    return {
+        page_number: responses.get(
+            url,
+            **page_kwargs,
+            match=[
+                matchers.query_param_matcher({"page": page_number}, strict_match=False),
+            ]
+        )
+        for page_number, page_kwargs in pages.items()
+    }
 
 
 class GitHubApiTests(TestCase):
@@ -12,18 +30,131 @@ class GitHubApiTests(TestCase):
     @responses.activate
     def test_get_main_ref(self):
         """Testing get_main_ref."""
-        responses.add(
-            responses.Response(
-                method="GET",
-                url="https://api.github.com/repos/owner/repo/branches/main",
-                json={
-                    "commit": {
-                        "sha": "0" * 40,
-                    }
-                },
-            )
+        responses.get(
+            "https://api.github.com/repos/owner/repo/branches/main",
+            json={
+                "commit": {
+                    "sha": "0" * 40,
+                }
+            },
         )
 
         result = github_api.get_main_ref("owner/repo")
 
         self.assertEqual(result, Ref("main", "0" * 40))
+
+    @responses.activate
+    def test_api_limit(self):
+        """Testing detection of API rate limit errors."""
+        responses.get(
+            "https://api.github.com/repos/owner/repo/branches/main",
+            headers={
+                "X-RateLimit-Remaining": "0",
+            },
+            status=403,
+            body="do not try to json parse this",
+        )
+        with self.assertRaises(Exception) as e:
+            github_api.get_main_ref("owner/repo")
+            self.assertIn("GitHub API rate limit exceeded", str(e))
+
+    @responses.activate
+    def test_get_branches(self):
+        """Testing get_branches and the underlying paginated_api_request."""
+        rsps = _add_paginated_responses(
+            "https://api.github.com/repos/owner/repo/branches",
+            {
+                "1": {
+                    "json": [
+                        {
+                            "name": "main",
+                            "commit": {"sha": "0" * 40},
+                        }
+                    ],
+                },
+                "2": {
+                    "json": [
+                        {
+                            "name": "foo",
+                            "commit": {"sha": "1" * 40},
+                        }
+                    ]
+                },
+                "3": {
+                    "json": [],
+                },
+                "4": {
+                    "body": Exception("should not be requested"),
+                    "status": 400,
+                },
+            },
+        )
+
+        result = github_api.get_branches("owner/repo")
+        self.assertEqual(
+            result,
+            [
+                Ref("main", "0" * 40),
+                Ref("foo", "1" * 40),
+            ],
+        )
+
+        self.assertEqual(rsps["1"].call_count, 1)
+        self.assertEqual(rsps["2"].call_count, 1)
+        self.assertEqual(rsps["3"].call_count, 1)
+        self.assertEqual(rsps["4"].call_count, 0)
+
+    @responses.activate
+    def test_get_tags(self):
+        """Testing get_tags."""
+        rsps = _add_paginated_responses(
+            "https://api.github.com/repos/owner/repo/tags",
+            {
+                "1": {
+                    "json": [
+                        {
+                            "name": "tag-1",
+                            "commit": {"sha": "0" * 40},
+                        }
+                    ]
+                },
+                "2": {
+                    "json": [
+                        {
+                            "name": "tag-2",
+                            "commit": {
+                                "sha": "1" * 40,
+                            },
+                        },
+                        {
+                            "name": "tag-3",
+                            "commit": {
+                                "sha": "2" * 40,
+                            },
+                        },
+                    ]
+                },
+                "3": {
+                    "json": [],
+                },
+                "4": {
+                    "body": Exception("should not be requested"),
+                    "status": 400,
+                },
+            },
+        )
+
+        result = github_api.get_tags("owner/repo")
+        self.assertEqual(
+            result,
+            [
+                Ref("tag-1", "0" * 40),
+                Ref("tag-2", "1" * 40),
+                Ref("tag-3", "2" * 40),
+            ],
+        )
+
+        self.assertEqual(rsps["1"].call_count, 1)
+        self.assertEqual(rsps["2"].call_count, 1)
+        self.assertEqual(rsps["3"].call_count, 1)
+        self.assertEqual(rsps["4"].call_count, 0)


### PR DESCRIPTION
Because

- we need to discover versions based on GitHub branches and tags

This commit

- adds methods to manifesttool's github_api to find all branches and
  tags.
