### PR TITLE
bug(nimbus): don't use cloud builder in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,7 +41,6 @@ commands:
     steps:
       - run: |
           echo "<< parameters.password >>" | docker login --username << parameters.username >> --password-stdin
-          docker buildx create --use --driver cloud "mozilla/default"
 
 
 jobs:


### PR DESCRIPTION
Because

- we just disabled HydroBuild in CI (#9680)

This commit

- configures our CI to not use cloud builders.
