### PR TITLE
fix #9695 fix(nimbus): Update feature id

### DIFF
--- a/experimenter/tests/integration/nimbus/conftest.py
+++ b/experimenter/tests/integration/nimbus/conftest.py
@@ -31,7 +31,7 @@ APPLICATION_FEATURE_IDS = {
     BaseExperimentApplications.IOS: "3",
     BaseExperimentApplications.FOCUS_ANDROID: "4",
     BaseExperimentApplications.FOCUS_IOS: "6",
-    BaseExperimentApplications.DEMO_APP: "138",
+    BaseExperimentApplications.DEMO_APP: "137",
 }
 
 APPLICATION_KINTO_REVIEW_PATH = {


### PR DESCRIPTION
Because

- We noticed feature id used in ci for the demo app feature is 137

This commit

- Update feature id value to 137
