### PR TITLE
bug(nimbus): don't use multiplatform builds in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -435,8 +435,7 @@ jobs:
       - run:
           name: Deploy to latest
           command: |
-            # Build all images for aarch64 and x86_64 to hydrate build cache
-            make BUILD_MULTIPLATFORM=1 cirrus_build
+            make cirrus_build
             # Pull x86_64 and tag to dockerhub for deploy
             make cirrus_build
             docker tag cirrus:deploy ${DOCKERHUB_CIRRUS_REPO}:latest

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ COMPOSE_LEGACY = ${COMPOSE} -f docker-compose-legacy.yml
 COMPOSE_TEST = docker compose -f docker-compose-test.yml
 COMPOSE_PROD = docker compose -f docker-compose-prod.yml
 COMPOSE_INTEGRATION = ${COMPOSE_PROD} -f docker-compose-integration-test.yml
-DOCKER_BUILD = docker buildx build $$( [ $$BUILD_MULTIPLATFORM  ] && echo "--platform linux/amd64,linux/arm64 --output type=cacheonly" )
+DOCKER_BUILD = docker buildx build
 
 JOBS = 4
 PARALLEL = parallel --halt now,fail=1 --jobs ${JOBS} {} :::


### PR DESCRIPTION
Because

- the default docker builder does not support multi-platform builds

This commit

- removes multi-platform build support from our Makefile.
