### PR TITLE
fixes #9688 feat(nimbus): auto-update application-services

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -520,6 +520,43 @@ jobs:
                 echo "No config changes, skipping"
             fi
 
+  update_application_services:
+    machine:
+      image: ubuntu-2004:2023.10.1
+      docker_layer_caching: true
+    steps:
+      - add_ssh_keys:
+          fingerprints:
+            - "32:8e:72:0b:9a:a1:1c:b8:7e:90:e1:53:a3:73:68:47" # for git pushes from circleci, since relies on ssh
+      - checkout
+      - gh/setup:
+          token: GH_TOKEN # for gh commands from circleci, since relies on user token, since por que no los dos?
+      - run:
+          name: Setup Git
+          command: |
+            git config --local user.name "dataops-ci-bot"
+            git config --local user.email "dataops+ci-bot@mozilla.com"
+            gh config set git_protocol https
+      - run:
+          name: Check for Application Services update
+          command: |
+            git checkout main
+            git pull origin main
+            make update_as
+            if (($(git status --porcelain | wc -c) > 0)); then
+              git checkout -B update-application-services
+              git add .
+              git commit -m "chore(nimbus): Update application-services"
+              if (($((git diff update-application-services origin/update-application-services || git diff HEAD~1) | wc -c) > 0)); then
+                git push origin update-application-services -f
+                gh pr create -t "chore(nimbus): Update application-services" -b "" --base main --head update-application-services --repo mozilla/experimenter || echo "PR already exists, skipping"
+              else
+                echo "Changes already committed, skipping"
+              fi
+            else
+              echo "No config changes, skipping"
+            fi
+
   build_firefox_versions:
     working_directory: ~/experimenter
     machine:
@@ -622,6 +659,7 @@ workflows:
                 - main
     jobs:
       - update_external_configs
+      - update_application_services
 
   build:
     jobs:

--- a/Makefile
+++ b/Makefile
@@ -100,6 +100,12 @@ build_as:
 build_rust_image: build_as
 	$(DOCKER_BUILD) -t experimenter:nimbus-rust-image -f experimenter/tests/integration/nimbus/utils/Dockerfile-ruts-image
 
+update_as: build_as
+	docker run \
+		-v ./application-services/application-services.env:/application-services/application-services.env \
+		as-builder \
+		/application-services/update-application-services.sh
+
 build_dev: ssl build_as
 	$(DOCKER_BUILD) --target dev -f experimenter/Dockerfile -t experimenter:dev experimenter/
 

--- a/application-services/Dockerfile
+++ b/application-services/Dockerfile
@@ -5,6 +5,7 @@ RUN apt-get update && \
     apt-get upgrade && \
     apt-get install -y \
       curl \
+      jq \
       zip
 
 COPY . /application-services

--- a/application-services/update-application-services.sh
+++ b/application-services/update-application-services.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -euo pipefail
+set +x
+
+TASKCLUSTER_API="https://firefox-ci-tc.services.mozilla.com/api/index/v1"
+INDEX_BASE="project.application-services.v2.cirrus"
+CURLFLAGS=("--proto" "=https" "--tlsv1.2" "-sS")
+
+LATEST_VERSION=$(curl ${CURLFLAGS[@]} "${TASKCLUSTER_API}/namespaces/${INDEX_BASE}" | jq -r '[ .namespaces[].name | tonumber ] | max')
+
+echo LATEST VERSION "${LATEST_VERSION}"
+
+INDEX=$(curl ${CURLFLAGS[@]} "${TASKCLUSTER_API}/tasks/${INDEX_BASE}.${LATEST_VERSION}" | jq -r '[.tasks[].namespace] | max')
+
+echo INDEX "${INDEX}"
+
+BUILD_ID="${INDEX#"${INDEX_BASE}."}"
+
+echo BUILD ID "${BUILD_ID}"
+
+echo "APPLICATION_SERVICES_BUILD_ID=${BUILD_ID}" > application-services.env


### PR DESCRIPTION
Because

- we want to automatically update the version of application-services in
  cirrus and experimenter

This commit

- updates the application-services build ID from a CI task