### PR TITLE
Adds targeting for default PDF is known browser

### DIFF
--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -1717,6 +1717,21 @@ ANDROID_LATER_DAY_USERS_ONLY = NimbusTargetingConfig(
 )
 
 
+DEFAULT_PDF_IS_DIFFERENT_BROWSER = NimbusTargetingConfig(
+    name="Default PDF handler is a different browser",
+    slug="default_pdf_is_different_browser",
+    description=(
+        "Targeting users that have their default PDF handler set to a browser other than the "
+        "current Firefox installation"
+    ),
+    targeting="!defaultHandler?.pdf && defaultPDFHandler?.knownBrowser",
+    desktop_telemetry="",
+    sticky_required=False,
+    is_first_run_required=False,
+    application_choice_names=(Application.DESKTOP.name,),
+)
+
+
 class TargetingConstants:
     TARGETING_VERSION = "version|versionCompare('{version}') >= 0"
     TARGETING_CHANNEL = 'browserSettings.update.channel == "{channel}"'


### PR DESCRIPTION
Adds an Advanced Targeting option for targeting users whose default PDF handler is a known browser other than the current installation.

Because

- We would like to be able to target and experiment towards users that have another browser set as the default PDF handler

This commit

- Allows us to target experiments this way
