### PR TITLE
Allow enrollment when other browser is PDF handler

### DIFF
--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -1717,6 +1717,21 @@ ANDROID_LATER_DAY_USERS_ONLY = NimbusTargetingConfig(
 )
 
 
+DEFAULT_PDF_IS_DIFFERENT_BROWSER = NimbusTargetingConfig(
+    name="Default PDF handler is a different browser",
+    slug="default_pdf_is_different_browser",
+    description=(
+        "Targeting users that have their default PDF handler set to a browser other "
+        "than the current Firefox installation"
+    ),
+    targeting="!defaultHandler?.pdf && defaultPDFHandler?.knownBrowser",
+    desktop_telemetry="",
+    sticky_required=False,
+    is_first_run_required=False,
+    application_choice_names=(Application.DESKTOP.name,),
+)
+
+
 class TargetingConstants:
     TARGETING_VERSION = "version|versionCompare('{version}') >= 0"
     TARGETING_CHANNEL = 'browserSettings.update.channel == "{channel}"'

--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -1724,7 +1724,10 @@ DEFAULT_PDF_IS_DIFFERENT_BROWSER = NimbusTargetingConfig(
         "Targeting users that have their default PDF handler set to a browser other "
         "than the current Firefox installation"
     ),
-    targeting="!defaultHandler?.pdf && defaultPDFHandler?.knownBrowser",
+    targeting=(
+        "'pdf' in isDefaultHandler && !isDefaultHandler['pdf'] && "
+        "'knownBrowser' in defaultPDFHandler && defaultPDFHandler['knownBrowser']"
+    ),
     desktop_telemetry="",
     sticky_required=False,
     is_first_run_required=False,


### PR DESCRIPTION
We would like to be able to enroll browsers in Nimbus experiments based on whether or not the default PDF handler is currently a browser other than the current Firefox installation. This will add that as an Advanced Targeting option.

Because

- We would like to be able to target [this experiment](https://experimenter.services.mozilla.com/nimbus/set-default-pdf-handler-rollout/summary) at users that currently have a browser other than the current Firefox installation as their default PDF handler.

This commit

- Adds that as an Advanced Targeting option
