### PR TITLE
bug(nimbus): hardcode dockerhub repo when pulling integration test image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -348,7 +348,7 @@ jobs:
           name: Run rust integration tests
           command: |
             cp .env.integration-tests .env
-            docker pull ${DOCKERHUB_REPO}:nimbus-rust-image
+            docker pull mozilla/experimenter:nimbus-rust-image
             make refresh SKIP_DUMMY=1 PYTEST_SENTRY_DSN=$PYTEST_SENTRY_DSN CIRCLECI=$CIRCLECI up_prod_detached integration_test_nimbus_rust PYTEST_ARGS="$PYTEST_ARGS"
       - store_artifacts:
           path: ~/experimenter/experimenter/tests/integration/test-reports/report.htm


### PR DESCRIPTION
Because:
- #9712 broke integration tests on fork PRs by referencing $DOCKERHUB_REPO, which is not available in fork PRs

this commit:
- hardcodes the dockerhub repo (mozilla/experimenter) for pulling the image, which will allow fork PRs to run integration tests.

Fixes #9716