### PR TITLE
Fix #9741 bug(nimbus): Fix non-deterministic FML errors

### DIFF
--- a/experimenter/experimenter/experiments/api/v5/serializers.py
+++ b/experimenter/experimenter/experiments/api/v5/serializers.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import re
 import typing
 from collections import defaultdict
@@ -40,6 +41,8 @@ from experimenter.kinto.tasks import (
 from experimenter.outcomes import Outcomes
 from experimenter.projects.models import Project
 from experimenter.settings import SIZING_DATA_KEY
+
+logger = logging.getLogger()
 
 
 class TransitionConstants:
@@ -1441,11 +1444,9 @@ class NimbusReviewSerializer(serializers.ModelSerializer):
     def _validate_with_fml(self, feature_config, channel, obj):
         loader = NimbusFmlLoader(feature_config.application, channel)
         if fml_errors := loader.get_fml_errors(obj, feature_config.slug):
-            return [
-                f"{NimbusExperiment.ERROR_FML_VALIDATION}: "
-                f"{e.message} at line {e.line+1} column {e.col}"
-                for e in fml_errors
-            ]
+            for e in fml_errors:
+                logger.error(f"{e.message} at line {e.line+1} column {e.col}")
+            return [f"{NimbusExperiment.ERROR_FML_VALIDATION}"]
         return None
 
     def _validate_schema(self, obj, schema):

--- a/experimenter/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_ready_for_review_serializer.py
+++ b/experimenter/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_ready_for_review_serializer.py
@@ -1503,14 +1503,6 @@ class TestNimbusReviewSerializerSingleFeature(MockFmlErrorMixin, TestCase):
         self.assertFalse(serializer.is_valid())
         self.mock_fml_errors.assert_called()
         self.assertEqual(len(serializer.errors), 2)
-        self.assertIn(
-            fml_errors[0].message,
-            serializer.errors["reference_branch"]["feature_values"][0]["value"][0],
-        )
-        self.assertIn(
-            fml_errors[1].message,
-            serializer.errors["reference_branch"]["feature_values"][0]["value"][1],
-        )
 
     def test_serializer_fml_invalid_treatment_branch_value(self):
         fml_errors = [
@@ -1565,14 +1557,6 @@ class TestNimbusReviewSerializerSingleFeature(MockFmlErrorMixin, TestCase):
         self.assertFalse(serializer.is_valid())
         self.mock_fml_errors.assert_called()
         self.assertEqual(len(serializer.errors), 2)
-        self.assertIn(
-            fml_errors[0].message,
-            serializer.errors["treatment_branches"][0]["feature_values"][0]["value"][0],
-        )
-        self.assertIn(
-            fml_errors[1].message,
-            serializer.errors["treatment_branches"][0]["feature_values"][0]["value"][1],
-        )
 
     def test_fml_validation_with_no_errors(self):
         fml_errors = None


### PR DESCRIPTION
Because

- Some of the FML errors are coming in different orders

This commit

- Removes the error message from the serialization for now, but still logs them

Fixes #9741 