### PR TITLE
feat(nimbus): Resolve branches to versions based on files

### DIFF
--- a/experimenter/experimenter/features/manifests/apps.yaml
+++ b/experimenter/experimenter/features/manifests/apps.yaml
@@ -10,6 +10,9 @@ fenix:
   fml_path: "fenix/app/nimbus.fml.yaml"
   branch_re: 'releases_v(?P<major>\d+)'
   tag_re: 'fenix-v(?P<major>\d+)\.(?P<minor>\d+)(?:\.(?P<patch>\d+))?'
+  version_file:
+    type: "plaintext"
+    path: "version.txt"
 firefox_ios:
   slug: "ios"
   repo:
@@ -18,6 +21,10 @@ firefox_ios:
   fml_path: "nimbus.fml.yaml"
   branch_re: 'release/v(?P<major>\d+)(?:\.(?P<minor>\d+))?'
   tag_re: 'v(?P<major>\d+)\.(?P<minor>\d+)'
+  version_file:
+    type: "plist"
+    path: "Client/Info.plist"
+    key: "CFBundleShortVersionString"
 focus_android:
   slug: "focus-android"
   repo:
@@ -26,6 +33,9 @@ focus_android:
   fml_path: "focus-android/app/nimbus.fml.yaml"
   branch_re: 'releases_v(?P<major>\d+)'
   tag_re: 'focus-v(?P<major>\d+)\.(?P<minor>\d+)(?:\.(?P<patch>\d+))?'
+  version_file:
+    type: "plaintext"
+    path: "version.txt"
 focus_ios:
   slug: "focus-ios"
   repo:
@@ -38,6 +48,10 @@ focus_ios:
     - "releases_v999" # nimbus.fml.yaml missing. Breaks "last 5 releases" logic.
   ignored_tags:
     - "v999.0.0" # nimbus.fml.yaml missing.
+  version_file:
+    type: "plist"
+    path: "Blockzilla/Info.plist"
+    key: "CFBundleShortVersionString"
 monitor_cirrus:
   slug: "monitor-web"
   repo:
@@ -50,3 +64,6 @@ firefox_desktop:
     type: "hgmo"
     name: "mozilla-central"
   experimenter_yaml_path: "toolkit/components/nimbus/FeatureManifest.yaml"
+  version_file:
+    type: "plaintext"
+    path: "browser/config/version.txt"

--- a/experimenter/manifesttool/appconfig.py
+++ b/experimenter/manifesttool/appconfig.py
@@ -1,9 +1,9 @@
 from enum import Enum
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, Optional, Literal, Union
 
 import yaml
-from pydantic import BaseModel, root_validator
+from pydantic import BaseModel, Field, root_validator
 
 
 class RepositoryType(Enum):
@@ -14,6 +14,41 @@ class RepositoryType(Enum):
 class Repository(BaseModel):
     type: RepositoryType
     name: str
+
+
+class VersionFileType(str, Enum):
+    PLAIN_TEXT = "plaintext"
+    PLIST = "plist"
+
+
+class PlainTextVersionFile(BaseModel):
+    type: Literal[VersionFileType.PLAIN_TEXT]
+    path: str
+
+
+class PListVersionFile(BaseModel):
+    type: Literal[VersionFileType.PLIST]
+    path: str
+    key: str
+
+
+class VersionFile(BaseModel):
+    __root__: Union[PlainTextVersionFile, PListVersionFile] = Field(discriminator="type")
+
+
+class RepositoryType(str, Enum):
+    GITHUB = "github"
+    HGMO = "hgmo"
+
+
+
+class Repository(BaseModel):
+    """A repository."""
+
+
+    type: RepositoryType
+    name: str
+
 
 
 class AppConfig(BaseModel):
@@ -27,6 +62,8 @@ class AppConfig(BaseModel):
     tag_re: Optional[str]
     ignored_branches: Optional[list[str]]
     ignored_tags: Optional[list[str]]
+    version_file: VersionFile
+
 
     @root_validator(pre=True)
     def validate_one_manifest_path(cls, values):

--- a/experimenter/manifesttool/appconfig.py
+++ b/experimenter/manifesttool/appconfig.py
@@ -1,6 +1,6 @@
 from enum import Enum
 from pathlib import Path
-from typing import Any, Optional, Literal, Union
+from typing import Any, Literal, Optional, Union
 
 import yaml
 from pydantic import BaseModel, Field, root_validator
@@ -36,21 +36,6 @@ class VersionFile(BaseModel):
     __root__: Union[PlainTextVersionFile, PListVersionFile] = Field(discriminator="type")
 
 
-class RepositoryType(str, Enum):
-    GITHUB = "github"
-    HGMO = "hgmo"
-
-
-
-class Repository(BaseModel):
-    """A repository."""
-
-
-    type: RepositoryType
-    name: str
-
-
-
 class AppConfig(BaseModel):
     """The configuration of a single app in apps.yaml."""
 
@@ -62,8 +47,7 @@ class AppConfig(BaseModel):
     tag_re: Optional[str]
     ignored_branches: Optional[list[str]]
     ignored_tags: Optional[list[str]]
-    version_file: VersionFile
-
+    version_file: Optional[VersionFile]
 
     @root_validator(pre=True)
     def validate_one_manifest_path(cls, values):

--- a/experimenter/manifesttool/download.py
+++ b/experimenter/manifesttool/download.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+
+import requests
+
+
+def to_path(url: str, download_path: Path):
+    """Download the given url to the given path."""
+    with requests.get(url, stream=True) as rsp:
+        rsp.raise_for_status()
+
+        with download_path.open("wb") as f:
+            for chunk in rsp.iter_content(chunk_size=8192):
+                f.write(chunk)
+
+
+def as_text(url: str) -> str:
+    """Return the contents of the given URL."""
+    rsp = requests.get(url)
+    rsp.raise_for_status()
+
+    return rsp.text

--- a/experimenter/manifesttool/tests/test_hgmo_api.py
+++ b/experimenter/manifesttool/tests/test_hgmo_api.py
@@ -1,10 +1,11 @@
 from pathlib import Path
-from tempfile import NamedTemporaryFile
+from tempfile import TemporaryDirectory
 from unittest import TestCase
 
 import responses
 
 from manifesttool import hgmo_api
+from manifesttool.hgmo_api import HGMO_URL
 from manifesttool.repository import Ref
 
 
@@ -14,14 +15,11 @@ class HgMoApiTests(TestCase):
     @responses.activate
     def test_get_tip_rev(self):
         """Testing get_tip_rev."""
-        responses.add(
-            responses.Response(
-                method="GET",
-                url="https://hg.mozilla.org/repo/json-log?rev=tip:tip",
-                json={
-                    "node": "0" * 40,
-                },
-            )
+        responses.get(
+            f"{HGMO_URL}/repo/json-log?rev=tip:tip",
+            json={
+                "node": "0" * 40,
+            },
         )
 
         result = hgmo_api.get_tip_rev("repo")
@@ -31,26 +29,21 @@ class HgMoApiTests(TestCase):
     @responses.activate
     def test_fetch_file(self):
         """Testing fetch_file."""
-        responses.add(
-            responses.Response(
-                method="GET",
-                url="https://hg.mozilla.org/repo/raw-file/rev/file/path.txt",
-                body=b"hello world\n",
-            )
+        responses.get(
+            f"{HGMO_URL}/repo/raw-file/rev/file/path.txt",
+            body=b"hello, world\n",
         )
 
-        with NamedTemporaryFile() as temp:
-            temp_path = Path(temp.name)
-            hgmo_api.fetch_file(
-                "repo",
-                "file/path.txt",
-                "rev",
-                temp_path,
-            )
+        with TemporaryDirectory() as tmp_dir:
+            tmp_filename = Path(tmp_dir, "file.txt")
+            hgmo_api.fetch_file("repo", "file/path.txt", "rev", tmp_filename)
 
-            self.assertTrue(temp_path.exists())
+            self.assertTrue(tmp_filename.exists())
 
-            with temp_path.open("rb") as f:
+            with tmp_filename.open("rb") as f:
                 content = f.read()
 
-            self.assertEqual(content, b"hello world\n")
+            self.assertEqual(content, b"hello, world\n")
+
+        contents = hgmo_api.fetch_file("repo", "file/path.txt", "rev")
+        self.assertEqual(contents, "hello, world\n")

--- a/experimenter/manifesttool/tests/test_version.py
+++ b/experimenter/manifesttool/tests/test_version.py
@@ -1,11 +1,27 @@
+from typing import Optional
 from unittest import TestCase
 
+import responses
 from parameterized import parameterized
 
-from manifesttool.appconfig import AppConfigs, VersionFile, VersionFileType
+from manifesttool.appconfig import (
+    AppConfig,
+    AppConfigs,
+    RepositoryType,
+    VersionFile,
+    VersionFileType,
+)
 from manifesttool.cli import MANIFESTS_DIR
+from manifesttool.github_api import GITHUB_RAW_URL
+from manifesttool.hgmo_api import HGMO_URL
 from manifesttool.repository import Ref
-from manifesttool.version import Version, find_versioned_refs, filter_versioned_refs, parse_version_file
+from manifesttool.version import (
+    Version,
+    filter_versioned_refs,
+    find_versioned_refs,
+    parse_version_file,
+    resolve_ref_versions,
+)
 
 
 class VersionTests(TestCase):
@@ -352,43 +368,146 @@ class VersionTests(TestCase):
 
     @parameterized.expand(
         [
+            ("bogus", None),
+            ("1", Version(1)),
+            ("1\n", Version(1)),
+            ("1a1", Version(1)),
+            ("1.2", Version(1, 2)),
+            ("1.2\n", Version(1, 2)),
+            ("1.2a1", Version(1, 2)),
+            ("1.2.1", Version(1, 2, 1)),
+            ("1.2.1\n", Version(1, 2, 1)),
+            ("1.2.1a1", Version(1, 2, 1)),
+        ]
+    )
+    def test_version_parse(self, s: str, expected: Optional[Version]):
+        """Testing Version.parse."""
+        self.assertEqual(Version.parse(s), expected)
+
+    @parameterized.expand(
+        [
             ("121.0a1\n", Version(121)),
             ("119.0.1\n", Version(119, 0, 1)),
+            ("bogus", None),
         ],
     )
     def test_parse_version_file_plain_text(self, contents, expected):
         """Testing parse_version_file with a plain-text version file."""
-        version_file = VersionFile.parse_obj({
-            "type": VersionFileType.PLAIN_TEXT,
-            "path": "version.txt",
-        })
+        version_file = VersionFile.parse_obj(
+            {
+                "type": VersionFileType.PLAIN_TEXT,
+                "path": "version.txt",
+            }
+        )
 
-        self.assert_equal(parse_version_file(version_file, contents), expected)
+        self.assertEqual(parse_version_file(version_file, contents), expected)
 
     @parameterized.expand(
         [
             ("121.0", Version(121)),
-            ("121.1", Version(121)),
+            ("121.1", Version(121, 1)),
+            ("bogus", None),
         ]
     )
     def test_parse_version_file_plist(self, version_str, expected):
         """Testing parse_version_file with a plist version file."""
-        version_file = VersionFile.parse_obj({
-            "type": VersionFileType.PLIST,
-            "path": "info.plist",
-            "key": "Version",
-        })
+        version_file = VersionFile.parse_obj(
+            {
+                "type": VersionFileType.PLIST,
+                "path": "info.plist",
+                "key": "Version",
+            }
+        )
 
         contents = (
             '<?xml version="1.0" encoding="UTF-8"?>\n'
             '<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"'
             ' "http://www.apple.com/DTDs/PropertyList-1.0.dtd">\n'
             '<plist version="1.0">\n'
-            '<dict>\n'
-            '  <key>Version</key>\n'
-            f'  <string>{version_str}</string>\n'
-            '</dict>\n'
-            '</plist>\n'
+            "<dict>\n"
+            "  <key>Version</key>\n"
+            f"  <string>{version_str}</string>\n"
+            "</dict>\n"
+            "</plist>\n"
         )
 
-        self.assert_equal(parse_version_file(version_file, contents), expected)
+        self.assertEqual(parse_version_file(version_file, contents), expected)
+
+    @parameterized.expand(
+        [
+            (
+                app_config,
+                [
+                    (Ref("v120", "r0"), "120.0a1\n"),
+                    (Ref("v120.1", "r1"), "120.1a1\n"),
+                    (Ref("v121", "r2"), "121.0a1\n"),
+                ],
+                {
+                    Version(120): Ref("v120", "r0"),
+                    Version(120, 1): Ref("v120.1", "r1"),
+                    Version(121): Ref("v121", "r2"),
+                },
+            )
+            for app_config in (
+                AppConfig.parse_obj(
+                    {
+                        "slug": "fml-app",
+                        "repo": {
+                            "type": "github",
+                            "name": "fml-app",
+                        },
+                        "fml_path": "nimbus.fml.yaml",
+                        "version_file": {
+                            "type": "plaintext",
+                            "path": "version.txt",
+                        },
+                    },
+                ),
+                AppConfig.parse_obj(
+                    {
+                        "slug": "legacy-app",
+                        "repo": {
+                            "type": "hgmo",
+                            "name": "legacy-app",
+                        },
+                        "experimenter_yaml_path": "nimbus.yaml",
+                        "version_file": {
+                            "type": "plaintext",
+                            "path": "version.txt",
+                        },
+                    },
+                ),
+            )
+        ]
+    )
+    @responses.activate
+    def test_resolve_ref_versions(
+        self,
+        app_config: AppConfig,
+        bodies: list[tuple[Ref, str]],
+        expected: dict[Version, Ref],
+    ):
+        """Testing resolve_ref_versions."""
+        if app_config.repo.type == RepositoryType.GITHUB:
+            url_template = (
+                f"{GITHUB_RAW_URL}/{app_config.repo.name}/"
+                f"{{ref.resolved}}/{app_config.version_file.__root__.path}"
+            )
+        else:
+            url_template = (
+                f"{HGMO_URL}/{app_config.repo.name}/raw-file/"
+                f"{{ref.resolved}}/{app_config.version_file.__root__.path}"
+            )
+
+        refs = []
+        rsps = []
+        for ref, body in bodies:
+            rsps.append(responses.get(url_template.format(ref=ref), body=body))
+            refs.append(ref)
+
+        result = resolve_ref_versions(app_config, refs)
+
+        for rsp in rsps:
+            self.assertEqual(rsp.call_count, 1)
+
+        self.assertEqual(result, expected)


### PR DESCRIPTION
Because

- versioned branches (e.g., release/v121) do not reveal their full
  version information in the branch name; and
- products store version information in plain text and plist files

this commit

- defines where version information is in each app's repository;
- adds `version.parse_version_file` to parse version from these files;
  and
- adds `version.resolve_ref_versions` to resolve repository refs to
  versions based on these files.

Fixes #9736 