### PR TITLE
fix #9660 feat(nimbus): Update end enrollment and end experiment for web applications

### DIFF
--- a/experimenter/experimenter/nimbus-ui/src/components/Summary/index.test.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/Summary/index.test.tsx
@@ -166,6 +166,7 @@ describe("Summary", () => {
           changelogMessage: CHANGELOG_MESSAGES.REQUESTED_REVIEW_END,
           status: NimbusExperimentStatusEnum.LIVE,
           statusNext: NimbusExperimentStatusEnum.COMPLETE,
+          isEnrollmentPaused: true,
         },
       );
       render(
@@ -338,6 +339,7 @@ describe("Summary", () => {
           changelogMessage: CHANGELOG_MESSAGES.REQUESTED_REVIEW_END,
           statusNext: NimbusExperimentStatusEnum.COMPLETE,
           status: NimbusExperimentStatusEnum.LIVE,
+          isEnrollmentPaused: true,
         },
       );
       const errorMessage = "Something went very wrong.";
@@ -379,6 +381,34 @@ describe("Summary", () => {
           status: NimbusExperimentStatusEnum.LIVE,
           statusNext: NimbusExperimentStatusEnum.LIVE,
           isEnrollmentPaused: true,
+        },
+      );
+      render(
+        <Subject props={experiment} mocks={[mutationMock]} {...{ refetch }} />,
+      );
+      fireEvent.click(screen.getByTestId("end-enrollment-start"));
+      await waitFor(() => {
+        expect(refetch).toHaveBeenCalled();
+        expect(screen.queryByTestId("submit-error")).not.toBeInTheDocument();
+      });
+    });
+
+    it("can mark the experiment as requesting review on enrollment end confirmation when experiment is web", async () => {
+      const refetch = jest.fn();
+      const { experiment } = mockExperimentQuery("demo-slug", {
+        status: NimbusExperimentStatusEnum.LIVE,
+        statusNext: null,
+        isEnrollmentPaused: false,
+        isWeb: true,
+      });
+      const mutationMock = createMutationMock(
+        experiment.id!,
+        NimbusExperimentPublishStatusEnum.REVIEW,
+        {
+          changelogMessage: CHANGELOG_MESSAGES.REQUESTED_REVIEW_END_ENROLLMENT,
+          status: NimbusExperimentStatusEnum.LIVE,
+          statusNext: NimbusExperimentStatusEnum.LIVE,
+          isEnrollmentPaused: false,
         },
       );
       render(

--- a/experimenter/experimenter/nimbus-ui/src/components/Summary/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/Summary/index.tsx
@@ -54,13 +54,14 @@ const Summary = ({ experiment, refetch }: SummaryProps) => {
       publishStatus: NimbusExperimentPublishStatusEnum.REVIEW,
       status: NimbusExperimentStatusEnum.LIVE,
       statusNext: NimbusExperimentStatusEnum.COMPLETE,
+      isEnrollmentPaused: true,
       changelogMessage: CHANGELOG_MESSAGES.REQUESTED_REVIEW_END,
     },
     {
       publishStatus: NimbusExperimentPublishStatusEnum.REVIEW,
       status: NimbusExperimentStatusEnum.LIVE,
       statusNext: NimbusExperimentStatusEnum.LIVE,
-      isEnrollmentPaused: true,
+      isEnrollmentPaused: experiment.isWeb ? false : true,
       changelogMessage: CHANGELOG_MESSAGES.REQUESTED_REVIEW_END_ENROLLMENT,
     },
     {


### PR DESCRIPTION
Because

- For the web applications that are using `Cirrus`, end enrollment is a little bit different as enrollment is continuous and it only ends once we end the experiment

This commit

- Changes end experiment to send explicitly `true` value
- Changes end enrollment to only send `true` value if it is not a web experiment, otherwise it will remain false

fixes #9660 
