### PR TITLE
chore(project): push to a new dockerhub tag

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -410,7 +410,9 @@ jobs:
             ./scripts/store_git_info.sh
             make build_prod
             docker tag experimenter:deploy ${DOCKERHUB_REPO}:latest
+            docker tag experimenter:deploy ${DOCKERHUB_REPO}:latest-test
             docker push ${DOCKERHUB_REPO}:latest
+            docker push ${DOCKERHUB_REPO}:latest-test
       - gcp-cli/setup
       - run:
           name: Deploy to Google Container Registry


### PR DESCRIPTION
Because

* We have seen failures while pulling from dockerhub tags
* This may be caused by the tag being corrupted after being in use for so long
* Let's try pushing to a new tag to see if we see the same failures

This commit

* Pushes to a new experimenter tag in dockerhub

fixes #9752


