### PR TITLE
fix #9755 feat(cirrus): Make record metrics function async

### DIFF
--- a/cirrus/server/cirrus/main.py
+++ b/cirrus/server/cirrus/main.py
@@ -152,7 +152,7 @@ def collate_enrollment_metric_data(
     return data
 
 
-def record_metrics(enrolled_partial_configuration: dict[str, Any], client_id: str):
+async def record_metrics(enrolled_partial_configuration: dict[str, Any], client_id: str):
     metrics = collate_enrollment_metric_data(
         enrolled_partial_configuration=enrolled_partial_configuration
     )
@@ -202,7 +202,7 @@ async def compute_features(request_data: FeatureRequest):
         str, Any
     ] = app.state.fml.compute_feature_configurations(enrolled_partial_configuration)
 
-    record_metrics(
+    await record_metrics(
         enrolled_partial_configuration=enrolled_partial_configuration,
         client_id=request_data.client_id,
     )

--- a/cirrus/server/tests/test_telemetry.py
+++ b/cirrus/server/tests/test_telemetry.py
@@ -39,7 +39,8 @@ def before_enrollment_ping(data):
     assert extra_2["experiment_type"] == RecipeType.EXPERIMENT.value
 
 
-def test_enrollment_metrics_recorded_with_record_metrics(mocker, recipes):
+@pytest.mark.asyncio
+async def test_enrollment_metrics_recorded_with_record_metrics(mocker, recipes):
     app.state.remote_setting.update_recipes(recipes)
     _, metrics = initialize_glean()
     ping_spy = mocker.spy(app.state.pings.enrollment, "submit")
@@ -71,7 +72,7 @@ def test_enrollment_metrics_recorded_with_record_metrics(mocker, recipes):
 
     app.state.pings.enrollment.test_before_next_submit(before_enrollment_ping)
 
-    record_metrics(enrolled_partial_configuration, "test_client_id")
+    await record_metrics(enrolled_partial_configuration, "test_client_id")
 
     assert ping_spy.call_count == 1
     assert app.state.metrics.cirrus_events.enrollment.test_get_value() is None


### PR DESCRIPTION
Because

- We want to continue serving requests to the users when we are recording metrics and flushing the events, there is no way to manually flush the events, if filling it triggers the buffer full then it submits the pings. 

This commit

- Make the record metrics function async so that it can do tasks in the background as a nonblocking task
