### PR TITLE
Fix #9757 fix(nimbus): Remove prefetched changelogs for csv reports

### DIFF
--- a/experimenter/experimenter/experiments/api/v5/views.py
+++ b/experimenter/experimenter/experiments/api/v5/views.py
@@ -18,7 +18,7 @@ class NimbusExperimentCsvListView(ListAPIView):
 
     queryset = (
         NimbusExperiment.objects.select_related("owner")
-        .prefetch_related("feature_configs", "changes")
+        .prefetch_related("feature_configs")
         .filter(is_archived=False)
     )
 


### PR DESCRIPTION
Because

- Our reports are taking too long to generate, and nginx is timing them out
- We're seeing that we're prefetching changelogs, but we only have to use the changelogs to compute the start date (find the changelog where the experiment goes from DRAFT->LIVE)

This commit

- Removes the prefetching of the changelogs, which should cut down the time needed to generate the reports
