### PR TITLE
For #9745 feat(nimbus): Update AS version to latest main

### DIFF
--- a/experimenter/Dockerfile
+++ b/experimenter/Dockerfile
@@ -82,7 +82,7 @@ WORKDIR /application-services
 # Rust packages
 # Checkout application services at a locked commit
 RUN git clone https://github.com/mozilla/application-services.git .
-RUN git fetch && git checkout da9301f829de67149d50dce5b709aed42f1bfe1b
+RUN git fetch && git checkout e8d45a3554d2fbf05631ae7f801ad9d840c69819
 
 RUN git submodule init
 RUN git submodule update --recursive


### PR DESCRIPTION
Because

- We want to pull in the latest changes from Application Services, which includes the fix for https://github.com/mozilla/experimenter/issues/9745

This commit

- Updates the AS hash in our Dockerfile to the latest from [AS `main`](https://github.com/mozilla/application-services/commits/main)

For #9745 
