### PR TITLE
feat(nimbus): import desktop features from esr115, release, beta, and central

### DIFF
--- a/experimenter/experimenter/features/manifests/apps.yaml
+++ b/experimenter/experimenter/features/manifests/apps.yaml
@@ -82,3 +82,14 @@ firefox_desktop:
     name: "mozilla-unified"
     default_branch: "central"
   experimenter_yaml_path: "toolkit/components/nimbus/FeatureManifest.yaml"
+  release_discovery:
+    version_file:
+      type: "plaintext"
+      path: "browser/config/version.txt"
+    strategies:
+      - type: "branched"
+        branches:
+          - "central"
+          - "beta"
+          - "release"
+          - "esr115"

--- a/experimenter/experimenter/features/manifests/apps.yaml
+++ b/experimenter/experimenter/features/manifests/apps.yaml
@@ -8,62 +8,76 @@ fenix:
     type: "github"
     name: "mozilla-mobile/firefox-android"
   fml_path: "fenix/app/nimbus.fml.yaml"
-  branch_re: 'releases_v(?P<major>\d+)'
-  tag_re: 'fenix-v(?P<major>\d+)\.(?P<minor>\d+)(?:\.(?P<patch>\d+))?'
-  version_file:
-    type: "plaintext"
-    path: "version.txt"
+  release_discovery:
+    version_file:
+      type: "plaintext"
+      path: "version.txt"
+    strategies:
+      - type: "tagged"
+        branch_re: 'releases_v(?P<major>\d+)'
+        tag_re: 'fenix-v(?P<major>\d+)\.(?P<minor>\d+)(?:\.(?P<patch>\d+))?'
+
 firefox_ios:
   slug: "ios"
   repo:
     type: "github"
     name: "mozilla-mobile/firefox-ios"
   fml_path: "nimbus.fml.yaml"
-  branch_re: 'release/v(?P<major>\d+)(?:\.(?P<minor>\d+))?'
-  tag_re: 'v(?P<major>\d+)\.(?P<minor>\d+)'
-  version_file:
-    type: "plist"
-    path: "Client/Info.plist"
-    key: "CFBundleShortVersionString"
+  release_discovery:
+    version_file:
+      type: "plist"
+      path: "Client/Info.plist"
+      key: "CFBundleShortVersionString"
+    strategies:
+      - type: "tagged"
+        branch_re: 'release/v(?P<major>\d+)(?:\.(?P<minor>\d+))?'
+        tag_re: 'v(?P<major>\d+)\.(?P<minor>\d+)'
+
 focus_android:
   slug: "focus-android"
   repo:
     type: "github"
     name: "mozilla-mobile/firefox-android"
   fml_path: "focus-android/app/nimbus.fml.yaml"
-  branch_re: 'releases_v(?P<major>\d+)'
-  tag_re: 'focus-v(?P<major>\d+)\.(?P<minor>\d+)(?:\.(?P<patch>\d+))?'
-  version_file:
-    type: "plaintext"
-    path: "version.txt"
+  release_discovery:
+    version_file:
+      type: "plaintext"
+      path: "version.txt"
+    strategies:
+      - type: "tagged"
+        branch_re: 'releases_v(?P<major>\d+)'
+        tag_re: 'focus-v(?P<major>\d+)\.(?P<minor>\d+)(?:\.(?P<patch>\d+))?'
+
 focus_ios:
   slug: "focus-ios"
   repo:
     type: "github"
     name: "mozilla-mobile/focus-ios"
   fml_path: "nimbus.fml.yaml"
-  branch_re: 'releases_v(?P<major>\d+)(?:\.(?P<minor>\d+))?'
-  tag_re: 'v(?P<major>\d+)\.(?P<minor>\d+)(?:\.(?P<patch>\d+))?'
-  ignored_branches:
-    - "releases_v999" # nimbus.fml.yaml missing. Breaks "last 5 releases" logic.
-  ignored_tags:
-    - "v999.0.0" # nimbus.fml.yaml missing.
-  version_file:
-    type: "plist"
-    path: "Blockzilla/Info.plist"
-    key: "CFBundleShortVersionString"
+  release_discovery:
+    version_file:
+      type: "plist"
+      path: "Blockzilla/Info.plist"
+      key: "CFBundleShortVersionString"
+    strategies:
+      - type: "tagged"
+        branch_re: 'releases_v(?P<major>\d+)(?:\.(?P<minor>\d+))?'
+        tag_re: 'v(?P<major>\d+)\.(?P<minor>\d+)(?:\.(?P<patch>\d+))?'
+        ignored_branches:
+          - "releases_v999" # nimbus.fml.yaml missing. Breaks "last 5 releases" logic.
+        ignored_tags:
+          - "v999.0.0" # nimbus.fml.yaml missing.
+
 monitor_cirrus:
   slug: "monitor-web"
   repo:
     type: "github"
     name: "mozilla/blurts-server"
   fml_path: "config/nimbus.yaml"
+
 firefox_desktop:
   slug: "firefox-desktop"
   repo:
     type: "hgmo"
     name: "mozilla-central"
   experimenter_yaml_path: "toolkit/components/nimbus/FeatureManifest.yaml"
-  version_file:
-    type: "plaintext"
-    path: "browser/config/version.txt"

--- a/experimenter/experimenter/features/manifests/apps.yaml
+++ b/experimenter/experimenter/features/manifests/apps.yaml
@@ -79,5 +79,6 @@ firefox_desktop:
   slug: "firefox-desktop"
   repo:
     type: "hgmo"
-    name: "mozilla-central"
+    name: "mozilla-unified"
+    default_branch: "central"
   experimenter_yaml_path: "toolkit/components/nimbus/FeatureManifest.yaml"

--- a/experimenter/experimenter/features/manifests/apps.yaml
+++ b/experimenter/experimenter/features/manifests/apps.yaml
@@ -89,6 +89,15 @@ firefox_desktop:
     strategies:
       - type: "branched"
         branches:
+          # The order here is important!
+          #
+          # When central is merging to beta or beta is merging to release, then
+          # both of those will have the same version number for a period of
+          # time.
+          #
+          # In this order, if two consecutive branches have the same version,
+          # then the latter will take precedence. e.g., if both beta and release
+          # report the same version, we will use the feature manifest from release.
           - "central"
           - "beta"
           - "release"

--- a/experimenter/experimenter/features/manifests/firefox-desktop/v115.5.0/experimenter.yaml
+++ b/experimenter/experimenter/features/manifests/firefox-desktop/v115.5.0/experimenter.yaml
@@ -1,0 +1,1564 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# Features must be added here to be accessible through the NimbusFeature API.
+
+"no-feature-firefox-desktop":
+  description: A dummy feature for experiments that target no feature.
+  owner: barret@mozilla.com
+  applications:
+    - firefox-desktop
+    - firefox-desktop-background-task
+  hasExposure: false
+  variables: {}
+
+testFeature:
+  description: Test only feature
+  owner: barret@mozilla.com
+  applications:
+    - firefox-desktop
+    - firefox-desktop-background-task
+  hasExposure: false
+  isEarlyStartup: true
+  variables:
+    enabled:
+      type: boolean
+      description: Whether or not this feature is enabled
+    testInt:
+      type: int
+      fallbackPref: nimbus.testing.testInt
+      description: Int pref used by platform API tests
+    testSetString:
+      type: string
+      setPref: nimbus.testing.testSetString
+      description: A string pref set by Nimbus tests
+
+nimbus-qa-1:
+  description: A feature for testing pref-setting on the default branch.
+  owner: barret@mozilla.com
+  hasExposure: false
+  variables:
+    value:
+      type: string
+      setPref: nimbus.qa.pref-1
+      description: The value to set for the pref.
+
+nimbus-qa-2:
+  description: A feature for testing pref-setting on the user branch.
+  owner: barret@mozilla.com
+  isEarlyStartup: true
+  hasExposure: false
+  variables:
+    value:
+      type: string
+      setPref: nimbus.qa.pref-2
+      description: The value to set for the pref.
+
+# `search` is for search engine experimentation features which do not require
+# isEarlyStartup to be set.
+search:
+  description: Search engine experimentation support and testing features.
+  owner: search-and-suggest-program@mozilla.com
+  hasExposure: false
+  variables:
+    extraParams:
+      type: json
+      description: >-
+        This allows extra parameters to be set for search engines requests including,
+        where calls to the suggestions API, the search engine configuration defines
+        those parameters.
+
+        The use of this field should be coordinated with the Search team.
+
+        The field value is an array of objects with key/value fields. For example:
+
+        [
+          {"key": "google_channel_row", "value": "foo"}
+        ]
+
+        This is matched to a section in the search configuration:
+
+        "extraParams": [
+          {
+            "name": "channel",
+            "pref": "google_channel_row",
+            "condition": "pref"
+          }
+        ],
+
+        In this case, the resulting URL for the appropriate search engine would have
+        `&channel=foo` added to the URL when doing searches.
+
+        If the key is not referenced in the search configuration, then no parameter
+        will be added. Only the search team can update the configuration.
+    cbhStudyUs:
+      type: string
+      setPref: browser.search.param.google_channel_us
+      description: >-
+        NOTE: Please use `extraParams` rather than this field.
+        A string pref set by Nimbus tests for US search cohort
+    cbhStudyRow:
+      type: string
+      setPref: browser.search.param.google_channel_row
+      description: >-
+        NOTE: Please use `extraParams` rather than this field.
+        A string pref set by Nimbus tests for Rest of World (ROW) search cohort
+    richSuggestionsFeatureGate:
+      type: boolean
+      setPref: browser.urlbar.richSuggestions.featureGate
+      description: >-
+        Feature gate that controls whether Rich Suggestions are enabled.
+    serpEventTelemetryEnabled:
+      type: boolean
+      setPref: browser.search.serpEventTelemetry.enabled
+      description: Whether the Glean SERP event telemetry is enabled.
+
+# `searchConfiguration` is for search experiment features for items that require
+# isEarlyStartup to be true. These items may require a reload of the search
+# engine configuration, and an additional reload may happen during the startup
+# process.
+searchConfiguration:
+  description: Search experimentation support for the engine configuration
+  owner: search-and-suggest-program@mozilla.com
+  isEarlyStartup: true
+  hasExposure: false
+  variables:
+    experiment:
+      type: string
+      fallbackPref: browser.search.experiment
+      description: >-
+        Used to activate only matching configurations that contain the value in
+        `experiment`
+    seperatePrivateDefaultUIEnabled:
+      type: boolean
+      description: Whether the UI for the separate private default feature is enabled.
+    seperatePrivateDefaultUrlbarResultEnabled:
+      type: boolean
+      description: Whether the urlbar result for the separate private default is shown.
+
+urlbar:
+  description: The Address Bar
+  owner: search-and-suggest-program@mozilla.com
+  hasExposure: true
+  exposureDescription: >-
+    The timing of the exposure event depends on the experiment, but generally
+    the event is recorded once per app session when the user first encounters
+    the UI of the experiment in which they're enrolled.
+  variables:
+    addonsFeatureGate:
+      type: boolean
+      fallbackPref: browser.urlbar.addons.featureGate
+      description: >-
+        Feature gate that controls whether all aspects of the addons suggestion
+        feature are exposed to the user.
+    addonsShowLessFrequentlyCap:
+      type: int
+      description: >-
+        If defined and non-zero, this is the maximum number of times the user
+        will be able to click the "Show less frequently" command for addon
+        suggestions. If undefined or zero, the user will be able to click the
+        command without any limit.
+    addonsUITreatment:
+      type: string
+      enum:
+        - a
+        - b
+      description: >-
+        Define the UI type for addon suggestions.
+        In case of "a", display rating stars and review volume on the bottom of
+        the suggestion. In case of "b", display a label explaining that the
+        addon suggestion is a recommendation.
+    autoFillAdaptiveHistoryEnabled:
+      type: boolean
+      fallbackPref: browser.urlbar.autoFill.adaptiveHistory.enabled
+      description: Whether enabling adaptive history autofill.
+    autoFillAdaptiveHistoryMinCharsThreshold:
+      type: int
+      fallbackPref: browser.urlbar.autoFill.adaptiveHistory.minCharsThreshold
+      description: Minimum char length of the user's search string to trigger adaptive history autofill.
+    autoFillAdaptiveHistoryUseCountThreshold:
+      type: string
+      description: This value assumes float expression like "0.47". Threshold for use count of input history that we handle as adaptive history autofill. If the use count is this value or more, it will be a candidate.
+    bestMatchBlockingEnabled:
+      type: boolean
+      fallbackPref: browser.urlbar.bestMatch.blockingEnabled
+      description: Whether best match Suggest suggestions can be blocked.
+    bestMatchEnabled:
+      type: boolean
+      fallbackPref: browser.urlbar.bestMatch.enabled
+      description: Gate for the best match feature. If false, the best match preferences UI and best match suggestions will not be shown. If true, the preferences UI will be shown, and the user can turn best match suggestions on or off.
+    experimentType:
+      type: string
+      description: The type of the experiment (or rollout). If "best-match", then the Nimbus exposure event will be recorded when the user first triggers a best match (or would have triggered a best match, for users in the control group). If "modal", the event will be recorded when the user first triggers to show the onbording dialog. If empty, the event will be recorded when the user first triggers any type of Suggest suggestion.
+      enum:
+        - best-match
+        - modal
+        - ""
+    isBestMatchExperiment:
+      type: boolean
+      description: >-
+        Whether the experiment (or rollout) is related to best match. If true, then the Nimbus exposure event will be recorded when the user first triggers a best match (or would have triggered a best match, for users in the control group). Deprecated, please use `experimentType: "best-match"` instead.
+    merinoClientVariants:
+      type: string
+      fallbackPref: browser.urlbar.merino.clientVariants
+      description: >-
+        Comma separated list of client variants to report to the Merino server.
+        May impact server behavior.
+    merinoEnabled:
+      type: boolean
+      fallbackPref: browser.urlbar.merino.enabled
+      description: Whether Merino is enabled as a quick suggest source
+    merinoEndpointURL:
+      type: string
+      fallbackPref: browser.urlbar.merino.endpointURL
+      description: The Merino endpoint URL, not including parameters.
+    merinoProviders:
+      type: string
+      fallbackPref: browser.urlbar.merino.providers
+      description: >-
+        Comma-separated list of providers to request from the Merino server.
+        Merino will return suggestions only for these providers.
+    merinoTimeoutMs:
+      type: int
+      fallbackPref: browser.urlbar.merino.timeoutMs
+      description: Timeout for Merino fetches (ms)
+    exposureResults:
+      type: string
+      setPref: browser.urlbar.exposureResults
+      description: >-
+        Comma-separated list of result type combinations, that are used to determine if an exposure event should be fired.
+    showExposureResults:
+      type: boolean
+      setPref: browser.urlbar.showExposureResults
+      description: >-
+        Boolean used to determine if the results defined in `exposureResults` should be shown in search results. Should be false for Control branch of an experiment.
+    quickSuggestAllowPositionInSuggestions:
+      type: boolean
+      fallbackPref: browser.urlbar.quicksuggest.allowPositionInSuggestions
+      description: Whether quick suggest results can be shown in position specified in the suggestions.
+    quickSuggestBlockingEnabled:
+      type: boolean
+      fallbackPref: browser.urlbar.quicksuggest.blockingEnabled
+      description: Whether the usual non-best-match Suggest suggestions can be blocked.
+    quickSuggestDataCollectionEnabled:
+      type: boolean
+      description: Whether data collection should be enabled by default. If this variable is specified, it will override the value implied by the scenario. It will never override the user's local preference to disable (or enable) data collection, if the user has already toggled that preference.
+    quickSuggestEnabled:
+      type: boolean
+      fallbackPref: browser.urlbar.quicksuggest.enabled
+      description: Gate for the Firefox Suggest feature as a whole. If false, the Firefox Suggest preferences UI and Suggest suggestions will not be shown. If true, the preferences UI will be shown, and the user can turn suggestions on or off.
+    quickSuggestImpressionCapsSponsoredEnabled:
+      type: boolean
+      fallbackPref: browser.urlbar.quicksuggest.impressionCaps.sponsoredEnabled
+      description: Whether sponsored suggestions are subject to impression frequency caps. If false, sponsored suggestions can be shown an unlimited number of times over any given period. If true, sponsored suggestion impressions will be subject to the caps in the remote settings configuration.
+    quickSuggestImpressionCapsNonSponsoredEnabled:
+      type: boolean
+      fallbackPref: browser.urlbar.quicksuggest.impressionCaps.nonSponsoredEnabled
+      description: Whether non-sponsored suggestions are subject to impression frequency caps. If false, non-sponsored suggestions can be shown an unlimited number of times over any given period. If true, non-sponsored suggestion impressions will be subject to the caps in the remote settings configuration.
+    quickSuggestNonSponsoredEnabled:
+      type: boolean
+      description: Whether non-sponsored suggestions should be enabled by default. If this variable is specified, it will override the value implied by the scenario. It will never override the user's local preference to disable (or enable) non-sponsored suggestions, if the user has already toggled that preference.
+    quickSuggestNonSponsoredIndex:
+      type: int
+      fallbackPref: browser.urlbar.quicksuggest.nonSponsoredIndex
+      description: >-
+        The index of non-sponsored QuickSuggest results within the general
+        group. A negative index is relative to the end of the group
+    quickSuggestOnboardingDialogVariation:
+      type: string
+      description: >-
+        Specify the messages/UI variation for QuickSuggest onboarding dialog. This value is case insensitive.
+    quickSuggestRemoteSettingsDataType:
+      type: string
+      description: The `type` of the suggestions data in remote settings. If not specified, "data" is used.
+    quickSuggestRemoteSettingsEnabled:
+      type: boolean
+      fallbackPref: browser.urlbar.quicksuggest.remoteSettings.enabled
+      description: Whether Remote Settings is enabled as a quick suggest source
+    quickSuggestScenario:
+      # IMPORTANT: This should not have a fallbackPref. See UrlbarPrefs.jsm.
+      type: string
+      description: The Firefox Suggest scenario in which the user is enrolled
+      enum:
+        - history
+        - offline
+        - online
+    quickSuggestShouldShowOnboardingDialog:
+      type: boolean
+      fallbackPref: browser.urlbar.quicksuggest.shouldShowOnboardingDialog
+      description: Whether or not to show the QuickSuggest onboarding dialog
+    quickSuggestShowOnboardingDialogAfterNRestarts:
+      type: int
+      fallbackPref: browser.urlbar.quicksuggest.showOnboardingDialogAfterNRestarts
+      description: Show QuickSuggest onboarding dialog after N browser restarts
+    quickSuggestSponsoredEnabled:
+      type: boolean
+      description: Whether sponsored suggestions should be enabled by default. If this variable is specified, it will override the value implied by the scenario. It will never override the user's local preference to disable (or enable) sponsored suggestions, if the user has already toggled that preference.
+    quickSuggestSponsoredIndex:
+      type: int
+      fallbackPref: browser.urlbar.quicksuggest.sponsoredIndex
+      description: >-
+        The index of sponsored QuickSuggest results within the general group. A
+        negative index is relative to the end of the group
+    recordNavigationalSuggestionTelemetry:
+      type: boolean
+      description: Whether to record navigational suggestion telemetry. Defaults to false.
+    showSearchTermsFeatureGate:
+      type: boolean
+      fallbackPref: browser.urlbar.showSearchTerms.featureGate
+      description: Gate for the show search terms feature. If false, the preference#search will not show the search terms feature checkbox, and search terms will never persist in the urlbar. If true, the preference checkbox will be shown on preferences#search, and the user can choose to persist search terms on or off in the urlbar.
+    weatherFeatureGate:
+      type: boolean
+      fallbackPref: browser.urlbar.weather.featureGate
+      description: >-
+        Feature gate that controls whether all aspects of the weather suggestion
+        feature are exposed to the user. See also `weatherKeywords` and
+        `weatherKeywordsMinimumLength`. In summary: To enable the weather
+        suggestion, set `weatherFeatureGate` to true, `weatherKeywords` to an
+        array of full keyword strings, and `weatherKeywordsMinimumLength` to a
+        non-zero integer. To disable the weather suggestion, leave out all
+        weather-related variables.
+    weatherKeywords:
+      type: json
+      description: >-
+        An array of full keyword strings that will trigger the weather
+        suggestion when the user types them in the address bar. If absent or
+        null, Firefox will fall back to the weather keywords defined in remote
+        settings. If neither Nimbus nor remote settings defines any keywords,
+        the weather suggestion will be disabled. See also
+        `weatherKeywordsMinimumLength`.
+    weatherKeywordsMinimumLength:
+      type: int
+      description: >-
+        If defined and non-zero, the weather suggestion will be triggered by
+        typing any prefix of a full weather keyword when the prefix is at least
+        `weatherKeywordsMinimumLength` characters long. If this variable is
+        absent or zero, Firefox will fall back to the minimum length defined in
+        remote settings. If neither Nimbus nor remote settings defines a minimum
+        length, only full keywords will trigger the suggestion. See also
+        `weatherKeywords`.
+    weatherKeywordsMinimumLengthCap:
+      type: int
+      description: >-
+        If defined and non-zero, the user will not be able to increment the
+        minimum keyword length beyond this value. e.g., if this value is 6, the
+        current minimum length is 5, and the user clicks "Show less frequently",
+        then the minimum length will be incremented to 6, the "Show less
+        frequently" command will be hidden, and the user can continue to trigger
+        the weather suggestion by typing 6 characters, but they will not be able
+        to increment the minimum length any further. If this variable is absent
+        or zero, Firefox will fall back to the cap defined in remote settings.
+        If neither Nimbus nor remote settings defines a cap, no cap will be
+        used, and the user will be able to increment the minimum length without
+        any limit.
+
+frecency:
+  description: "The address bar ranking algorithm"
+  owner: search-and-suggest-program@mozilla.com
+  hasExposure: false
+  isEarlyStartup: true
+  variables:
+    originsAlternativeEnable:
+      description: >-
+        Use an alternative ranking algorithm for autofilling origins, that is
+        mainly domains of Web pages. When the user types the beginning of an
+        origin, we autofill the whole origin. Whether autofill happens depends
+        on the ranking algorithm. Bookmarks are always autofilled anyway.
+      type: boolean
+      setPref: "places.frecency.origins.alternative.featureGate"
+    originsDaysCutOff:
+      description: >-
+        The alternative ranking algorithm only considers pages visited in the
+        last N days, where N is controlled by this variable.
+      type: int
+      setPref: "places.frecency.origins.alternative.daysCutOff"
+
+aboutwelcome:
+  description: "The about:welcome page"
+  owner: omc@mozilla.com
+  hasExposure: true
+  exposureDescription: >-
+    Exposure is sent once per browsing session when the about:welcome URL is
+    first accessed.
+  isEarlyStartup: true
+  variables:
+    enabled:
+      type: boolean
+      fallbackPref: browser.aboutwelcome.enabled
+      description: >-
+        Should users see about:welcome? If this is false, users will see a
+        regular new tab instead.
+    id:
+      type: string
+      description: >-
+        Descriptive ID for the about:welcome content
+    screens:
+      type: json
+      fallbackPref: browser.aboutwelcome.screens
+      description: Content to show in the onboarding flow
+    languageMismatchEnabled:
+      type: boolean
+      fallbackPref: intl.multilingual.aboutWelcome.languageMismatchEnabled
+      description: >-
+        Suggest to change the language on about:welcome when there is a mismatch with
+        the OS.
+    transitions:
+      type: boolean
+      description: Enable transition effect between screens
+    showModal:
+      type: boolean
+      fallbackPref: browser.aboutwelcome.showModal
+      description: >-
+        Should users see window modal onboarding
+    backdrop:
+      type: string
+      fallbackPref: browser.aboutwelcome.backdrop
+      description: >-
+        Specify the color to be used to update the background color
+
+moreFromMozilla:
+  description: "New page on about:preferences to suggest more Mozilla products"
+  owner: omc@mozilla.com
+  hasExposure: true
+  exposureDescription: >-
+    Exposure is sent once per browsing session when the about:preferences URL is
+    first accessed.
+  variables:
+    enabled:
+      type: boolean
+      fallbackPref: browser.preferences.moreFromMozilla
+      description: Should users see the new more from Mozilla section.
+    template:
+      type: string
+      fallbackPref: browser.preferences.moreFromMozilla.template
+      description: UI template used to display Mozilla products. Possible values simple, advanced. Default is simple.
+
+abouthomecache:
+  description: "The startup about:home cache."
+  owner: omc@mozilla.com
+  hasExposure: false
+  isEarlyStartup: true
+  variables:
+    enabled:
+      type: boolean
+      fallbackPref: browser.startup.homepage.abouthome_cache.enabled
+      description: Is the feature enabled?
+
+newtab:
+  description: "The about:newtab page"
+  owner: omc@mozilla.com
+  hasExposure: true
+  exposureDescription: >-
+    Exposure is sent once per browsing session when the first newtab page loads
+    (either about:newtab or about:home).
+  isEarlyStartup: true
+  variables:
+    newTheme:
+      type: boolean
+      description: Enable the new theme
+    customizationMenuEnabled:
+      type: boolean
+      fallbackPref: browser.newtabpage.activity-stream.customizationMenu.enabled
+      description: Enable the customization panel inside of the newtab
+    prefsButtonIcon:
+      type: string
+      description: Icon url to use for the preferences button
+    topSitesContileEnabled:
+      type: boolean
+      fallbackPref: browser.topsites.contile.enabled
+      description: Enable the Contile integration for Sponsored Top Sites
+    topSitesUseAdditionalTilesFromContile:
+      type: boolean
+      description: Allow Contile to use additonal sponsored top sites
+
+pocketNewtab:
+  description: The Pocket section in newtab
+  owner: sdowne@getpocket.com
+  hasExposure: false
+  isEarlyStartup: true
+  variables:
+    spocPositions:
+      type: string
+      fallbackPref: browser.newtabpage.activity-stream.discoverystream.spoc-positions
+      description: CSV string of spoc position indexes on newtab Pocket grid
+    spocTopsitesPositions:
+      type: string
+      fallbackPref: browser.newtabpage.activity-stream.discoverystream.spoc-topsites-positions
+      description: CSV string of spoc position indexes on newtab topsites section
+    spocAdTypes:
+      type: string
+      fallbackPref: browser.newtabpage.activity-stream.discoverystream.spocAdTypes
+      description: CSV string of data to set the spoc content.
+    spocZoneIds:
+      type: string
+      fallbackPref: browser.newtabpage.activity-stream.discoverystream.spocZoneIds
+      description: CSV string of data to set the spoc content.
+    spocTopsitesAdTypes:
+      type: string
+      fallbackPref: browser.newtabpage.activity-stream.discoverystream.spocTopsitesAdTypes
+      description: CSV string of data to set the spoc content.
+    spocTopsitesZoneIds:
+      type: string
+      fallbackPref: browser.newtabpage.activity-stream.discoverystream.spocTopsitesZoneIds
+      description: CSV string of data to set the spoc content.
+    spocSiteId:
+      type: string
+      fallbackPref: browser.newtabpage.activity-stream.discoverystream.spocSiteId
+      description: String ID to set the spoc content.
+    widgetPositions:
+      type: string
+      fallbackPref: browser.newtabpage.activity-stream.discoverystream.widget-positions
+      description: CSV string of widget position indexes on newtab grid
+    hybridLayout:
+      type: boolean
+      fallbackPref: browser.newtabpage.activity-stream.discoverystream.hybridLayout.enabled
+      description: Enable compact cards on newtab grid only for specific breakpoints
+    hideCardBackground:
+      type: boolean
+      fallbackPref: browser.newtabpage.activity-stream.discoverystream.hideCardBackground.enabled
+      description: Removes Pocket card background and borders.
+    fourCardLayout:
+      type: boolean
+      fallbackPref: browser.newtabpage.activity-stream.discoverystream.fourCardLayout.enabled
+      description: Enable four Pocket cards per row.
+    newFooterSection:
+      type: boolean
+      fallbackPref: >-
+        browser.newtabpage.activity-stream.discoverystream.newFooterSection.enabled
+      description: Enable an updated Pocket section topics footer
+    saveToPocketCard:
+      type: boolean
+      fallbackPref: >-
+        browser.newtabpage.activity-stream.discoverystream.saveToPocketCard.enabled
+      description: >-
+        A save to Pocket button inside the card, shown on the card thumbnail, on
+        hover.
+    saveToPocketCardRegions:
+      type: string
+      fallbackPref: >-
+        browser.newtabpage.activity-stream.discoverystream.saveToPocketCardRegions
+      description: >-
+        CSV string of regions that support the save to Pocket button inside the card.
+    hideDescriptions:
+      type: boolean
+      fallbackPref: >-
+        browser.newtabpage.activity-stream.discoverystream.hideDescriptions.enabled
+      description: >-
+        Hide or display descriptions for Pocket stories on newtab.
+    hideDescriptionsRegions:
+      type: string
+      fallbackPref: >-
+        browser.newtabpage.activity-stream.discoverystream.hideDescriptionsRegions
+      description: >-
+        CSV string of regions that hide descriptions for Pocket stories on newtab.
+    compactGrid:
+      type: boolean
+      fallbackPref: >-
+        browser.newtabpage.activity-stream.discoverystream.compactGrid.enabled
+      description: >-
+        Reduce the number of pixels between the Pocket cards on newtab.
+    compactImages:
+      type: boolean
+      fallbackPref: >-
+        browser.newtabpage.activity-stream.discoverystream.compactImages.enabled
+      description: >-
+        Reduce the height on Pocket card images on newtab.
+    imageGradient:
+      type: boolean
+      fallbackPref: >-
+        browser.newtabpage.activity-stream.discoverystream.imageGradient.enabled
+      description: >-
+        Add a gradient to the bottom of Pocket card images on newtab to blend the
+        image in with the card.
+    titleLines:
+      type: int
+      fallbackPref: >-
+        browser.newtabpage.activity-stream.discoverystream.titleLines
+      description: >-
+        Changes the maximum number of lines a title can be for Pocket cards on newtab.
+    descLines:
+      type: int
+      fallbackPref: >-
+        browser.newtabpage.activity-stream.discoverystream.descLines
+      description: >-
+        Changes the maximum number of lines a description can be for Pocket cards on newtab.
+    onboardingExperience:
+      type: boolean
+      fallbackPref: >-
+        browser.newtabpage.activity-stream.discoverystream.onboardingExperience.enabled
+      description: >-
+        Enables an onboarding experience for Pocket section on newtab.
+    essentialReadsHeader:
+      type: boolean
+      fallbackPref: >-
+        browser.newtabpage.activity-stream.discoverystream.essentialReadsHeader.enabled
+      description: >-
+        Updates the Pocket section header and title to say "Today’s Essential Reads",
+        moves the "Recommended by Pocket" header to the right side.
+    editorsPicksHeader:
+      type: boolean
+      fallbackPref: >-
+        browser.newtabpage.activity-stream.discoverystream.editorsPicksHeader.enabled
+      description: >-
+        Updates the Pocket section header and title to say "Editor’s Picks", if used with
+        essentialReadsHeader, creates a second section 2 rows down for editorsPicksHeader.
+    recentSavesEnabled:
+      type: boolean
+      fallbackPref: >-
+        browser.newtabpage.activity-stream.discoverystream.recentSaves.enabled
+      description: >-
+        Updates the Pocket section with a new header and 1 row of recently saved Pocket stories.
+    readTime:
+      type: boolean
+      fallbackPref: >-
+        browser.newtabpage.activity-stream.discoverystream.readTime.enabled
+      description: >-
+        Displays an estimated read time for Pocket cards on newtab.
+    newSponsoredLabel:
+      type: boolean
+      fallbackPref: >-
+        browser.newtabpage.activity-stream.discoverystream.newSponsoredLabel.enabled
+      description: >-
+        Updates the sponsored label position to below the image for Pocket cards on newtab.
+    sendToPocket:
+      type: boolean
+      fallbackPref: >-
+        browser.newtabpage.activity-stream.discoverystream.sendToPocket.enabled
+      description: >-
+        Decides what to do when a logged out user click "Save to Pocket" from a Pocket card.
+    recsPersonalized:
+      type: boolean
+      fallbackPref: >-
+        browser.newtabpage.activity-stream.discoverystream.recs.personalized
+      description: >-
+        Enables Pocket stories personalization.
+    spocsPersonalized:
+      type: boolean
+      fallbackPref: >-
+        browser.newtabpage.activity-stream.discoverystream.spocs.personalized
+      description: >-
+        Enables Pocket sponsored content personalization.
+    spocsCacheTimeout:
+      type: int
+      fallbackPref: >-
+        browser.newtabpage.activity-stream.discoverystream.spocs.cacheTimeout
+      description: >-
+        Set sponsored content cache timeout in minutes.
+    discoveryStreamConfig:
+      description: A JSON blob of discovery stream configuration.
+      type: string
+      setPref: "browser.newtabpage.activity-stream.discoverystream.config"
+    spocsEndpoint:
+      description: The URL for the spocs endpoint.
+      type: string
+      setPref: "browser.newtabpage.activity-stream.discoverystream.spocs-endpoint"
+    regionStoriesConfig:
+      description: A comma-separated list of region to get stories for.
+      type: string
+      fallbackPref: >-
+        browser.newtabpage.activity-stream.discoverystream.region-stories-config
+    regionBffConfig:
+      type: string
+      fallbackPref: >-
+        browser.newtabpage.activity-stream.discoverystream.region-bff-config
+      description: A comma-separated list of regions to get stories from the recommendations BFF. Also requires region-stories-config.
+    regionStoriesBlock:
+      description: A comma-separated list of regions that do not get stories, regardless of locale-list-config.
+      type: string
+      fallbackPref: >-
+        browser.newtabpage.activity-stream.discoverystream.region-stories-block
+    localeListConfig:
+      description: A comma-separated list of locales that get stories, regardless of region-stories-config.
+      type: string
+      fallbackPref: >-
+        browser.newtabpage.activity-stream.discoverystream.locale-list-config
+    regionSpocsConfig:
+      description: A comma-separated list of regions that get spocs by default.
+      type: string
+      fallbackPref: >-
+        browser.newtabpage.activity-stream.discoverystream.region-spocs-config
+    topSitesMaxSponsored:
+      # Defined under `pocketNewtab` as it needs to be used along with other variables
+      type: int
+      description: The maximum number of sponsored Top Sites to be displayed
+    topSitesContileMaxSponsored:
+      # Defined under `pocketNewtab` as it needs to be used along with other variables
+      type: int
+      description: The maximum number of sponsored Top Sites used from Contile
+    topSitesContileSovEnabled:
+      # Defined under `pocketNewtab` as it needs to be used along with other variables
+      description: Enable the Share-of-Voice feature for Sponsored Topsites.
+      type: boolean
+      fallbackPref: >-
+        browser.topsites.contile.sov.enabled
+
+saveToPocket:
+  description: The save to Pocket feature
+  owner: sdowne@getpocket.com
+  hasExposure: false
+  isEarlyStartup: true
+  variables:
+    emailButton:
+      type: boolean
+      fallbackPref: extensions.pocket.refresh.emailButton.enabled
+      description: Just for the new Pocket panels, enables the email signup button.
+    hideRecentSaves:
+      type: boolean
+      fallbackPref: extensions.pocket.refresh.hideRecentSaves.enabled
+      description: Hides the recently saved section in the home panel.
+    bffRecentSaves:
+      type: boolean
+      fallbackPref: "extensions.pocket.bffRecentSaves"
+      description: Use the new BFF Proxy Service instead of the legacy Pocket Service for Recent Saves
+    bffApi:
+      type: string
+      fallbackPref: "extensions.pocket.bffApi"
+      description: BFF Proxy Service domain
+    oAuthConsumerKeyBff:
+      type: string
+      fallbackPref: "extensions.pocket.oAuthConsumerKeyBff"
+      description: BFF Proxy Service OAuth Consumer Key
+
+password-autocomplete:
+  description: A special autocomplete UI for password fields.
+  owner: sgalich@mozilla.com
+  hasExposure: false
+  variables:
+    directMigrateSingleProfile:
+      type: boolean
+      description: Enable direct migration?
+
+shellService:
+  description: "Interface with OS, e.g., pinning and set default"
+  owner: desktop-integrations@mozilla.com
+  hasExposure: false
+  isEarlyStartup: true
+  variables:
+    disablePin:
+      type: boolean
+      description: Disable pin to taskbar feature
+    setDefaultBrowserUserChoice:
+      type: boolean
+      fallbackPref: browser.shell.setDefaultBrowserUserChoice
+      description: Should it set as default browser
+    setDefaultPDFHandler:
+      type: boolean
+      fallbackPref: browser.shell.setDefaultPDFHandler
+      description: Should setting it as the default browser set it as the default PDF handler.
+    setDefaultPDFHandlerOnlyReplaceBrowsers:
+      type: boolean
+      fallbackPref: browser.shell.setDefaultPDFHandler.onlyReplaceBrowsers
+      description: >-
+        Should setting it as the default PDF handler only replace existing PDF
+        handlers that are browsers, and not other PDF handlers such as Acrobat
+        Reader or Nitro PDF.
+
+upgradeDialog:
+  description: The dialog shown for major upgrades
+  owner: omc@mozilla.com
+  hasExposure: false
+  isEarlyStartup: true
+  variables:
+    enabled:
+      type: boolean
+      fallbackPref: browser.startup.upgradeDialog.enabled
+      description: Is the feature enabled?
+
+readerMode:
+  description: Firefox Reader Mode
+  owner: sdowne@getpocket.com
+  hasExposure: false
+  isEarlyStartup: true
+  variables:
+    pocketCTAVersion:
+      type: string
+      fallbackPref: reader.pocket.ctaVersion
+      description: >-
+        What version of Pocket CTA to show in Reader Mode (Empty string is no
+        CTA)
+cfr:
+  description: "A Firefox Messaging System message for the cfr message channel"
+  owner: omc@mozilla.com
+  hasExposure: true
+  exposureDescription: "Exposure is sent if the message is about to be shown after trigger and targeting conditions on the message matched."
+  isEarlyStartup: false
+  schema:
+    uri: "resource://activity-stream/schemas/MessagingExperiment.schema.json"
+    path: "browser/components/newtab/content-src/asrouter/schemas/MessagingExperiment.schema.json"
+  variables: {}
+
+"moments-page":
+  description: "A Firefox Messaging System message for the moments-page message channel"
+  owner: omc@mozilla.com
+  hasExposure: true
+  exposureDescription: >-
+    "Exposure is sent if the message is about to be shown after trigger and targeting conditions on the message matched."
+  isEarlyStartup: false
+  schema:
+    uri: "resource://activity-stream/schemas/MessagingExperiment.schema.json"
+    path: "browser/components/newtab/content-src/asrouter/schemas/MessagingExperiment.schema.json"
+  variables: {}
+
+infobar:
+  description: "A Firefox Messaging system message for the infobar message channel"
+  owner: omc@mozilla.com
+  hasExposure: true
+  exposureDescription: >-
+    "Exposure is sent if the message is about to be shown after trigger and targeting conditions on the message matched."
+  isEarlyStartup: false
+  schema:
+    uri: "resource://activity-stream/schemas/MessagingExperiment.schema.json"
+    path: "browser/components/newtab/content-src/asrouter/schemas/MessagingExperiment.schema.json"
+  variables: {}
+
+spotlight:
+  description: "A Firefox Messaging System message for the spotlight message channel"
+  owner: omc@mozilla.com
+  hasExposure: true
+  exposureDescription: >-
+    "Exposure is sent if the message is about to be shown after trigger and targeting conditions on the message matched."
+  isEarlyStartup: false
+  schema:
+    uri: "resource://activity-stream/schemas/MessagingExperiment.schema.json"
+    path: "browser/components/newtab/content-src/asrouter/schemas/MessagingExperiment.schema.json"
+  variables: {}
+
+# More info about the fx-message-* feature id prototype is available at:
+# https://docs.google.com/document/d/1KdtaNycZL5j240nXofbibm9yKh7qVvu1-uZFLdmYM7Y/
+#
+# Before each Nightly leaves the station for Beta, we're currently
+# experimenting with ensuring that we have enough fx-messages-* messages to
+# accomodate all the rollout possibilities for Release that we're aware of,
+# plus one for a buffer just-in-case.
+#
+# When adding an fxms-message-* feature id, be sure to also add it to the
+# MESSAGING_EXPERIMENTS_DEFAULT_FEATURES list in ASRouter.
+
+# currently in use by 107+ exp/rollout pair of Import Bookmarks Infrequent
+# Existing Users with 5 bookmarks:
+# https://experimenter.services.mozilla.com/nimbus/import-infrequent-rollout-make-yourself-at-home/summary
+fxms-message-1:
+  description: "A Firefox Messaging System message"
+  owner: omc@mozilla.com
+  hasExposure: true
+  exposureDescription: >-
+    "Exposure is sent if the message is about to be shown after trigger and targeting conditions on the message matched."
+  isEarlyStartup: false
+  schema:
+    uri: "resource://activity-stream/schemas/MessagingExperiment.schema.json"
+    path: "browser/components/newtab/content-src/asrouter/schemas/MessagingExperiment.schema.json"
+  variables: {}
+
+# next planned use: 110+ exp/rollout pair of Fox Doodle: Pin experiment winner
+# (Existing Users)
+# More info about the fx-message-* feature id prototype is available at:
+# https://docs.google.com/document/d/1KdtaNycZL5j240nXofbibm9yKh7qVvu1-uZFLdmYM7Y/
+fxms-message-2:
+  description: "Firefox Messaging System message 2"
+  owner: omc@mozilla.com
+  hasExposure: true
+  exposureDescription: >-
+    "Exposure is sent if the message is about to be shown after trigger and targeting conditions on the message matched."
+  isEarlyStartup: false
+  schema:
+    uri: "resource://activity-stream/schemas/MessagingExperiment.schema.json"
+    path: "browser/components/newtab/content-src/asrouter/schemas/MessagingExperiment.schema.json"
+  variables: {}
+
+# next planned use: 110+ exp/rollout pair of Fox Doodle: Set Default (Existing
+# Users)
+# More info about the fx-message-* feature id prototype is available at:
+# https://docs.google.com/document/d/1KdtaNycZL5j240nXofbibm9yKh7qVvu1-uZFLdmYM7Y/
+fxms-message-3:
+  description: "Firefox Messaging System message 3"
+  owner: omc@mozilla.com
+  hasExposure: true
+  exposureDescription: >-
+    "Exposure is sent if the message is about to be shown after trigger and targeting conditions on the message matched."
+  isEarlyStartup: false
+  schema:
+    uri: "resource://activity-stream/schemas/MessagingExperiment.schema.json"
+    path: "browser/components/newtab/content-src/asrouter/schemas/MessagingExperiment.schema.json"
+  variables: {}
+
+# next potential planned use: 111+ exp/rollout pair for PDF annotations callout
+# (https://mozilla-hub.atlassian.net/browse/FXE-83) experiment.
+#
+# More info about the fx-message-* feature id prototype is available at:
+# https://docs.google.com/document/d/1KdtaNycZL5j240nXofbibm9yKh7qVvu1-uZFLdmYM7Y/
+fxms-message-4:
+  description: "Firefox Messaging System message 4"
+  owner: omc@mozilla.com
+  hasExposure: true
+  exposureDescription: >-
+    "Exposure is sent if the message is about to be shown after trigger and targeting conditions on the message matched."
+  isEarlyStartup: false
+  schema:
+    uri: "resource://activity-stream/schemas/MessagingExperiment.schema.json"
+    path: "browser/components/newtab/content-src/asrouter/schemas/MessagingExperiment.schema.json"
+  variables: {}
+
+# next potential planned use: 112+ holdback/rollout pair for default PDF handler
+# (https://mozilla-hub.atlassian.net/browse/FXE-91) experiment.
+#
+# More info about the fx-message-* feature id prototype is available at:
+# https://docs.google.com/document/d/1KdtaNycZL5j240nXofbibm9yKh7qVvu1-uZFLdmYM7Y/
+fxms-message-5:
+  description: "Firefox Messaging System message 5"
+  owner: omc@mozilla.com
+  hasExposure: true
+  exposureDescription: >-
+    "Exposure is sent if the message is about to be shown after trigger and targeting conditions on the message matched."
+  isEarlyStartup: false
+  schema:
+    uri: "resource://activity-stream/schemas/MessagingExperiment.schema.json"
+    path: "browser/components/newtab/content-src/asrouter/schemas/MessagingExperiment.schema.json"
+  variables: {}
+
+# next potential planned use: 114+ possible holdback/rollout pair (Device Migration):
+# https://mozilla-hub.atlassian.net/browse/FXE-271
+#
+# More info about the fx-message-* feature id prototype is available at:
+# https://docs.google.com/document/d/1KdtaNycZL5j240nXofbibm9yKh7qVvu1-uZFLdmYM7Y/
+fxms-message-6:
+  description: "Firefox Messaging System message 6"
+  owner: omc@mozilla.com
+  hasExposure: true
+  exposureDescription: >-
+    "Exposure is sent if the message is about to be shown after trigger and targeting conditions on the message matched."
+  isEarlyStartup: false
+  schema:
+    uri: "resource://activity-stream/schemas/MessagingExperiment.schema.json"
+    path: "browser/components/newtab/content-src/asrouter/schemas/MessagingExperiment.schema.json"
+  variables: {}
+
+# next planned use: buffer, for the unexpected
+#
+# More info about the fx-message-* feature id prototype is available at:
+# https://docs.google.com/document/d/1KdtaNycZL5j240nXofbibm9yKh7qVvu1-uZFLdmYM7Y/
+fxms-message-7:
+  description: "Firefox Messaging System message 7"
+  owner: omc@mozilla.com
+  hasExposure: true
+  exposureDescription: >-
+    "Exposure is sent if the message is about to be shown after trigger and targeting conditions on the message matched."
+  isEarlyStartup: false
+  schema:
+    uri: "resource://activity-stream/schemas/MessagingExperiment.schema.json"
+    path: "browser/components/newtab/content-src/asrouter/schemas/MessagingExperiment.schema.json"
+  variables: {}
+
+
+# next planned use: buffer, for the unexpected
+#
+# More info about the fx-message-* feature id prototype is available at:
+# https://docs.google.com/document/d/1KdtaNycZL5j240nXofbibm9yKh7qVvu1-uZFLdmYM7Y/
+fxms-message-8:
+  description: "Firefox Messaging System message 8"
+  owner: omc@mozilla.com
+  hasExposure: true
+  exposureDescription: >-
+    "Exposure is sent if the message is about to be shown after trigger and targeting conditions on the message matched."
+  isEarlyStartup: false
+  schema:
+    uri: "resource://activity-stream/schemas/MessagingExperiment.schema.json"
+    path: "browser/components/newtab/content-src/asrouter/schemas/MessagingExperiment.schema.json"
+  variables: {}
+
+# next planned use: buffer, for the unexpected
+#
+# More info about the fx-message-* feature id prototype is available at:
+# https://docs.google.com/document/d/1KdtaNycZL5j240nXofbibm9yKh7qVvu1-uZFLdmYM7Y/
+fxms-message-9:
+  description: "Firefox Messaging System message 9"
+  owner: omc@mozilla.com
+  hasExposure: true
+  exposureDescription: >-
+    "Exposure is sent if the message is about to be shown after trigger and targeting conditions on the message matched."
+  isEarlyStartup: false
+  schema:
+    uri: "resource://activity-stream/schemas/MessagingExperiment.schema.json"
+    path: "browser/components/newtab/content-src/asrouter/schemas/MessagingExperiment.schema.json"
+  variables: {}
+
+# next planned use: buffer, for the unexpected
+#
+# More info about the fx-message-* feature id prototype is available at:
+# https://docs.google.com/document/d/1KdtaNycZL5j240nXofbibm9yKh7qVvu1-uZFLdmYM7Y/
+fxms-message-10:
+  description: "Firefox Messaging System message 10"
+  owner: omc@mozilla.com
+  hasExposure: true
+  exposureDescription: >-
+    "Exposure is sent if the message is about to be shown after trigger and targeting conditions on the message matched."
+  isEarlyStartup: false
+  schema:
+    uri: "resource://activity-stream/schemas/MessagingExperiment.schema.json"
+    path: "browser/components/newtab/content-src/asrouter/schemas/MessagingExperiment.schema.json"
+  variables: {}
+
+# next planned use: buffer, for the unexpected
+#
+# More info about the fx-message-* feature id prototype is available at:
+# https://docs.google.com/document/d/1KdtaNycZL5j240nXofbibm9yKh7qVvu1-uZFLdmYM7Y/
+fxms-message-11:
+  description: "Firefox Messaging System message 11"
+  owner: omc@mozilla.com
+  hasExposure: true
+  exposureDescription: >-
+    "Exposure is sent if the message is about to be shown after trigger and targeting conditions on the message matched."
+  isEarlyStartup: false
+  schema:
+    uri: "resource://activity-stream/schemas/MessagingExperiment.schema.json"
+    path: "browser/components/newtab/content-src/asrouter/schemas/MessagingExperiment.schema.json"
+  variables: {}
+
+pbNewtab:
+  description: "A Firefox Messaging System message for the pbNewtab message channel"
+  owner: omc@mozilla.com
+  hasExposure: true
+  exposureDescription: >-
+    Exposure is sent if the message is about to be shown after trigger and targeting conditions on the message matched.
+  isEarlyStartup: false
+  schema:
+    uri: "resource://activity-stream/schemas/MessagingExperiment.schema.json"
+    path: "browser/components/newtab/content-src/asrouter/schemas/MessagingExperiment.schema.json"
+  variables: {}
+
+backgroundTaskMessage:
+  description: "A Firefox Messaging System message for the background task message channel"
+  owner: nalexander@mozilla.com
+  applications:
+    - firefox-desktop-background-task
+  hasExposure: true
+  exposureDescription: >-
+    Exposure is sent if the message is about to be shown after trigger and targeting conditions on the message matched.
+  isEarlyStartup: false
+  schema:
+    uri: "resource://activity-stream/schemas/BackgroundTaskMessagingExperiment.schema.json"
+    path: "browser/components/newtab/content-src/asrouter/schemas/BackgroundTaskMessagingExperiment.schema.json"
+  variables: {}
+
+pictureinpicture:
+  description: Message for first time Picture-in-Picture users
+  owner: nbaumgardner@mozilla.com
+  hasExposure: true
+  exposureDescription: Exposure is sent when a user hovers over a video and Picture-in-Picture has not been used before
+  variables:
+    title:
+      type: string
+      description: The title to be used for the PiP toggle
+    message:
+      type: string
+      description: The message to be used in the PiP toggle
+    showIconOnly:
+      type: boolean
+      description: Whether to show the first time PiP toggle or show the PiP icon only
+    oldToggle:
+      type: boolean
+      description: Whether to show the control style (true) or variant style (false) for the first time PiP toggle
+    displayDuration:
+      type: int
+      description: Duration of PiP first time toggle display in days before switching to PiP icon toggle
+
+glean:
+  description: "The Glean data collection SDK within Firefox Desktop"
+  owner: glean-team@mozilla.com
+  hasExposure: false
+  variables:
+    finalInactive:
+      type: "boolean"
+      description: "Enables FOG early shutdown pings when true"
+    newtabPingEnabled:
+      type: "boolean"
+      fallbackPref: "browser.newtabpage.ping.enabled"
+      description: "Whether to submit the 'newtab' ping"
+    gleanMetricConfiguration:
+      type: json
+      description: >-
+        "A map of metric base-identifiers to booleans representing the state of the 'disabled' flag for that metric"
+
+majorRelease2022:
+  description: Major Release 2022
+  owner: firefoxview@mozilla.com
+  hasExposure: false
+  isEarlyStartup: true
+  variables:
+    feltPrivacyPBMDarkTheme:
+      type: boolean
+      fallbackPref: "browser.theme.dark-private-windows"
+      description: "Use dark theme variant for PBM windows. This is only supported if the theme sets darkTheme data."
+    feltPrivacyPBMNewIndicator:
+      type: boolean
+      fallbackPref: "browser.privatebrowsing.enable-new-indicator"
+      description: "Enables the new private browsing indicator."
+    feltPrivacyPBMNewLogo:
+      type: boolean
+      fallbackPref: "browser.privatebrowsing.enable-new-logo"
+      description: "Enables the new about:privatebrowsing logo."
+    feltPrivacyShowPreferencesSection:
+      type: boolean
+      fallbackPref: "browser.privacySegmentation.preferences.show"
+      description: "Controls visibility of the privacy segmentation preferences section."
+    feltPrivacyWindowSeparation:
+      type: boolean
+      fallbackPref: "browser.privateWindowSeparation.enabled"
+      description: "Whether or not private browsing windows use a separate icon in the Windows taskbar"
+    colorwayCloset:
+      type: boolean
+      fallbackPref: "browser.theme.colorway-closet"
+      description: "Whether or not to show the colorway closet modal"
+    firefoxView:
+      type: boolean
+      fallbackPref: "browser.tabs.firefox-view"
+      description: "Whether or not to show the firefox view tab"
+    onboarding:
+      type: boolean
+      fallbackPref: "browser.majorrelease.onboarding"
+      description: "Whether or not to use the MR2022 onboarding settings."
+
+featureCallout:
+  description: "Prefs that control users' progress through Feature Callout tours"
+  owner: omc@mozilla.com
+  hasExposure: false
+  isEarlyStartup: false
+  variables:
+    pdfJsTourProgress:
+      description: A JSON String representing the intitial state of the pref that holds the progress of the PDF.js feature tour.
+      type: string
+      setPref: "browser.pdfjs.feature-tour"
+browserLowMemoryPrefs:
+  description: Prefs which control the browser's behaviour under low memory.
+  owner: haftandilian@mozilla.com
+  hasExposure: false
+  variables:
+    lowMemoryResponseMask:
+      description: Control the response on macOS when under memory pressure.
+      type: int
+      setPref: "browser.lowMemoryResponseMask"
+    lowMemoryResponseOnWarn:
+      description: Controls which macOS memory-pressure levels trigger the browser low memory response.
+      type: boolean
+      setPref: "browser.lowMemoryResponseOnWarn"
+    tabsUnloadOnLowMemory:
+      description: Whether to unload tabs when available memory is running low.
+      type: boolean
+      setPref: "browser.tabs.unloadOnLowMemory"
+
+scriptLoaderPrefs:
+  description: Prefs that control the script loader.
+  owner: npierron@mozilla.com
+  hasExposure: false
+  variables:
+    delazificationStrategy:
+      description: >-
+        Selects which parsing/delazification strategy should be used while
+        parsing scripts off-main-thread. See DelazificationOption in
+        CompileOptions.h for values.
+      type: int
+      setPref: "dom.script_loader.delazification.strategy"
+
+echPrefs:
+  description: Prefs that control Encrypted Client Hello.
+  owner: djackson@mozilla.com
+  hasExposure: false
+  variables:
+    tlsEnabled:
+      description: Whether to enable ECH for connections using TLS
+      type: boolean
+      setPref: "network.dns.echconfig.enabled"
+    h3Enabled:
+      description: Whether to enable ECH for connections using H3/QUIC
+      type: boolean
+      setPref: "network.dns.http3_echconfig.enabled"
+    forceWaitHttpsRR:
+      description: Whether to force waiting for HTTPS DNS records, which ECH requires.
+      type: boolean
+      setPref: "network.dns.force_waiting_https_rr"
+    insecureFallback:
+      description: Whether to fallback to non-ECH connections if all ECH RRs fail.
+      type: boolean
+      setPref: "network.dns.echconfig.fallback_to_origin_when_all_failed"
+    tlsGreaseProb:
+      description: Probability of GREASEing a TLS connection with ECH (0-100).
+      type: int
+      setPref: "security.tls.ech.grease_probability"
+    h3GreaseEnabled:
+      description: Whether to apply GREASE settings to H3/QUIC connections.
+      type: boolean
+      setPref: "security.tls.ech.grease_http3"
+    disableGreaseOnFallback:
+      description: Whether to disable GREASE when retrying a connection.
+      type: boolean
+      setPref: "security.tls.ech.disable_grease_on_fallback"
+    greasePaddingSize:
+      description: Assumed echConfig padding length for GREASE extensions (1-255).
+      type: int
+      setPref: "security.tls.ech.grease_size"
+
+dohPrefs:
+  description: Prefs that control DNS over HTTPS.
+  owner: vgosu@mozilla.com
+  hasExposure: false
+  variables:
+    trrMode:
+      description: Has a value of 2 for TRR first, 3 for TRR only, 0 for off.
+      type: int
+      setPref: "network.trr.mode"
+    trrUri:
+      description: The URL of the DNS over HTTPS endpoint
+      type: string
+      setPref: "network.trr.uri"
+    dohMode:
+      description: Same as trrMode, but set by the DoHController module.
+      type: int
+      setPref: "doh-rollout.mode"
+    dohUri:
+      description: Same as trrUri, but set by the DoHController module.
+      type: string
+      setPref: "doh-rollout.uri"
+    enableFallbackWarningPage:
+      description: Whether DoH fallback warning page will be displayed when DoH doesn't work in TRR first mode.
+      type: boolean
+      setPref: "network.trr.display_fallback_warning"
+    showFallbackCheckbox:
+      description: Whether the checkbox to enable the fallback warning page is displayed in the settings UI.
+      type: boolean
+      setPref: "network.trr_ui.show_fallback_warning_option"
+
+dooh:
+  description: "DNS over Oblivious HTTP"
+  owner: vgosu@mozilla.com
+  hasExposure: false
+  variables:
+    ohttpEnabled:
+      description: Whether to use Oblivious HTTP for the resolution
+      type: boolean
+      setPref: "network.trr.use_ohttp"
+    ohttpRelayUri:
+      description: The URL of the Oblivious HTTP relay
+      type: string
+      setPref: "network.trr.ohttp.relay_uri"
+    ohttpConfigUri:
+      description: The URL used to fetch the configuration of the Oblivious HTTP gateway
+      type: string
+      setPref: "network.trr.ohttp.config_uri"
+    ohttpUri:
+      description: The URL of the Oblivious DNS over HTTPS target resource
+      type: string
+      setPref: "network.trr.ohttp.uri"
+
+networking:
+  description: "Firefox Networking (Necko)"
+  owner: vgosu@mozilla.com
+  hasExposure: false
+  variables:
+    ehPreloadEnabled:
+      description: Whether Early Hints preload is enabled
+      type: boolean
+      setPref: "network.early-hints.enabled"
+    ehPreconnectEnabled:
+      description: Whether Early Hints preconnect is enabled
+      type: boolean
+      setPref: "network.early-hints.preconnect.enabled"
+
+pingsender:
+  description: "In-product usage of the pingsender telemetry reporter."
+  owner: nalexander@mozilla.com
+  hasExposure: false
+  variables:
+    backgroundTaskEnabled:
+      type: "boolean"
+      fallbackPref: "toolkit.telemetry.shutdownPingSender.backgroundtask.enabled"
+      description: "Whether to use the `pingsender` background task to send shutdown telemetry"
+
+dapTelemetry:
+  description: DAP Telemetry
+  owner: simon@mozilla.com
+  hasExposure: false
+  isEarlyStartup: true # Data is sent on startup with a trigger in BrowserGlue.sys.mjs
+  variables:
+    enabled:
+      type: boolean
+      fallbackPref: toolkit.telemetry.dap_enabled
+      description: Whether to automatically send DAP measurements.
+    task1Enabled:
+      type: boolean
+      fallbackPref: toolkit.telemetry.dap_task1_enabled
+      description: Whether to send fake measurements for verification task 1.
+
+etpLevel2PBMPref:
+  description: The pref that controls the ETP level 2 list in the private browsing mode
+  owner: tihuang@mozilla.com
+  hasExposure: false
+  variables:
+    enabled:
+      description: Whether to enable ETP level 2 list in the private browsing mode.
+      type: boolean
+      setPref: "privacy.annotate_channels.strict_list.pbmode.enabled"
+
+fxaButtonVisibility:
+  description: Prefs to control the visibility of the Firefox Accounts toolbar button when not signed in.
+  owner: mconley@mozilla.com
+  hasExposure: false
+  isEarlyStartup: true
+  variables:
+    boolean:
+      description: True if the Firefox Accounts toolbar button should be visible when not signed in.
+      type: boolean
+      setPref: identity.fxaccounts.toolbar.defaultVisible
+
+legacyHeartbeat:
+  description: Normandy Heartbeat exposed to Nimbus
+  owner: barret@mozilla.com
+  hasExposure: false
+  schema:
+    uri: "resource://normandy/schemas/LegacyHeartbeat.schema.json"
+    path: "toolkit/components/normandy/schemas/LegacyHeartbeat.schema.json"
+  variables:
+    survey:
+      type: json
+      description: The Heartbeat survey parameters.
+
+queryStripping:
+  description: Query parameter stripping anti-tracking feature.
+  owner: pbz@mozilla.com
+  hasExposure: false
+  variables:
+    enabledNormalBrowsing:
+      type: boolean
+      setPref: privacy.query_stripping.enabled
+      description: Enables / disables URL query string stripping in normal browsing mode.
+    enabledPrivateBrowsing:
+      type: boolean
+      setPref: privacy.query_stripping.enabled.pbmode
+      description: Enables / disables URL query string stripping in private browsing mode.
+    allowList:
+      type: string
+      setPref: privacy.query_stripping.allow_list
+      description: >-
+        List of sites exempt from query stripping. This list will be merged with
+        records coming from RemoteSettings.
+    stripList:
+      type: string
+      setPref: privacy.query_stripping.strip_list
+      description: >-
+        List of query params to be stripped from URIs. This list will be merged
+        with records coming from RemoteSettings.
+
+fontvisibility:
+  description: Control Font Visibility in PBM
+  owner: tom@mozilla.com
+  hasExposure: false
+  variables:
+    enabledETP:
+      type: int
+      setPref: layout.css.font-visibility.trackingprotection
+      description: Set the Font Visibility level when Enhanced Tracking Protection is enabled
+    enabledStandard:
+      type: int
+      setPref: layout.css.font-visibility.standard
+      description: Set the Font Visibility level for normal browsing
+    enabledPBM:
+      type: int
+      setPref: layout.css.font-visibility.private
+      description: Set the Font Visibility level for private browsing (will override ETP)
+
+fingerprintingProtection:
+  description: Control Fingerprinting Protection
+  owner: tihuang@mozilla.com
+  hasExposure: false
+  variables:
+    enabledNormal:
+      type: boolean
+      setPref: privacy.fingerprintingProtection
+      description: Enables / disables fingerprinting protection in normal browsing mode.
+    enabledPrivate:
+      type: boolean
+      setPref: privacy.fingerprintingProtection.pbmode
+      description: Enables / disables fingerprinting protection in private browsing mode.
+    overrides:
+      type: string
+      setPref: privacy.fingerprintingProtection.overrides
+      description: >-
+        The protection overrides to add or remove fingerprinting protection
+        targets. Please check RFPTargets.inc for all supported targets.
+
+migrationWizard:
+  description: Prefs to control the Migration Wizard UI.
+  owner: mconley@mozilla.com
+  hasExposure: false
+  isEarlyStartup: true
+  variables:
+    useNewWizard:
+      description: True if the new migration wizard should be used.
+      type: boolean
+      setPref: browser.migrate.content-modal.enabled
+    showImportAll:
+      description: True if the "Variant 2" of the Migration Wizard browser / profile selection UI should be used. This is only meaningful in the new Migration Wizard.
+      type: boolean
+      setPref: browser.migrate.content-modal.import-all.enabled
+    showPreferencesEntrypoint:
+      description: True if an entrypoint to the migration wizard should be visible in about:preferences.
+      type: boolean
+      setPref: browser.migrate.preferences-entrypoint.enabled
+    aboutWelcomeBehavior:
+      description: >-
+        When migration is kicked off from about:welcome, there are
+        a few different behaviors that we want to test, controlled
+        by a preference that is instrumented for Nimbus. The pref
+        has the following possible states:
+
+        "autoclose":
+          The user will be directed to the migration wizard in
+          about:preferences, but once the wizard is dismissed,
+          the tab will close.
+
+        "embedded":
+          The migration wizard is embedded in about:welcome.
+
+        "standalone":
+          The migration wizard will open in a new top-level content
+          window.
+
+        "legacy":
+          The legacy wizard will be opened from about:welcome, even if
+          the new wizard is enabled by default.
+
+        "default" / other
+          The user will be directed to the migration wizard in
+          about:preferences. The tab will not close once the
+          user closes the wizard.
+      type: string
+      setPref: browser.migrate.content-modal.about-welcome-behavior
+
+mixedContentUpgrading:
+  description: Prefs to control whether we upgrade mixed passive content (images, audio, video) from http to https
+  owner: fbraun@mozilla.com
+  hasExposure: false
+  variables:
+    boolean:
+      description: True if the mixed content upgrading pref is enabled
+      type: boolean
+      setPref: security.mixed_content.upgrade_display_content
+
+jsParallelParsing:
+  description: Pref to toggle JS parallel parsing.
+  owner: dpalmeiro@mozilla.com, nbp@mozilla.com
+  isEarlyStartup: true
+  hasExposure: false
+  variables:
+    enabled:
+      description: True to enable parallel parsing.
+      type: boolean
+      setPref: "javascript.options.parallel_parsing"
+
+gcParallelMarking:
+  description: Pref to toggle parallel marking in the GC.
+  owner: dpalmeiro@mozilla.com, jonco@mozilla.com
+  isEarlyStartup: true
+  hasExposure: false
+  variables:
+    enabled:
+      description: True to enable parallel marking.
+      type: boolean
+      setPref: "javascript.options.mem.gc_parallel_marking"
+
+jitThresholds:
+  description: Prefs that control jit tier thresholds.
+  owner: dpalmeiro@mozilla.com, jdemooij@mozilla.com
+  isEarlyStartup: true
+  hasExposure: false
+  variables:
+    blinterp_threshold:
+      description: Set the threshold to enable blinterp compilation.
+      type: int
+      setPref: "javascript.options.blinterp.threshold"
+    baseline_threshold:
+      description: Set the threshold to enable baseline compilation.
+      type: int
+      setPref: "javascript.options.baselinejit.threshold"
+    ion_threshold:
+      description: Set the threshold to enable ion compilation.
+      type: int
+      setPref: "javascript.options.ion.threshold"
+    ion_bailout_threshold:
+      description: Set the ion frequent bailout threshold.
+      type: int
+      setPref: "javascript.options.ion.frequent_bailout_threshold"
+    ion_offthread_compilation:
+      description: True to enable offthread ion compilations.
+      type: boolean
+      setPref: "javascript.options.ion.offthread_compilation"
+    inlining_max_length:
+      description: Set the max bytecode length considered for inlining.
+      type: int
+      setPref: "javascript.options.inlining_bytecode_max_length"
+
+jitHintsCache:
+  description: Pref to toggle the JIT hints cache.
+  owner: dpalmeiro@mozilla.com
+  isEarlyStartup: true
+  hasExposure: false
+  variables:
+    enabled:
+      description: True to enable the hints cache.
+      type: boolean
+      setPref: "javascript.options.jithints"
+
+raceCacheWithNetwork:
+  description: Prefs to toggle the race cache with network.
+  owner: dpalmeiro@mozilla.com, acreskey@mozilla.com
+  hasExposure: false
+  variables:
+    enabled:
+      description: True to enable the rcwn feature.
+      type: boolean
+      setPref: "network.http.rcwn.enabled"
+
+httpSpeculativeParallelLimit:
+  description: Prefs to control the http speculative parallel limit.
+  owner: dpalmeiro@mozilla.com, acreskey@mozilla.com
+  hasExposure: false
+  variables:
+    speculative_parallel_limit:
+      description: Maximum number of parallel speculative connections.
+      type: int
+      setPref: "network.http.speculative-parallel-limit"
+
+deviceMigration:
+  description: Prefs to control aspects of the new device migration experiment
+  owner: hjones@mozilla.com
+  hasExposure: false
+  isEarlyStartup: true
+  variables:
+    helpMenuHidden:
+      description: True if new help menu item should be hidden
+      type: boolean
+      fallbackPref: browser.device-migration.help-menu.hidden
+
+opaqueResponseBlocking:
+  description: Prefs to enable Opaque Response Blocking
+  owner: farre@mozilla.com
+  isEarlyStartup: true
+  hasExposure: true
+  exposureDescription: Exposure is sent when a response is blocked
+  variables:
+    enabled:
+      description: Whether ORB is enabled
+      type: boolean
+      setPref: "browser.opaqueResponseBlocking"
+    javascriptValidator:
+      description: Whether JavaScript validation for ORB is enabled
+      type: boolean
+      setPref: "browser.opaqueResponseBlocking.javascriptValidator"
+    filterFetchResponse:
+      description: Whether filtering of internal responses in the parent ORB is enabled
+      type: int
+      setPref: "browser.opaqueResponseBlocking.filterFetchResponse"
+    mediaExceptionsStrategy:
+      description: >-
+        If we partially or wholly allow audio and video MIME types in conflict with spec.
+      type: int
+      setPref: "browser.opaqueResponseBlocking.mediaExceptionsStrategy"

--- a/experimenter/experimenter/features/manifests/firefox-desktop/v115.5.0/schemas/browser/components/newtab/content-src/asrouter/schemas/BackgroundTaskMessagingExperiment.schema.json
+++ b/experimenter/experimenter/features/manifests/firefox-desktop/v115.5.0/schemas/browser/components/newtab/content-src/asrouter/schemas/BackgroundTaskMessagingExperiment.schema.json
@@ -1,0 +1,312 @@
+{
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "$id": "resource://activity-stream/schemas/BackgroundTaskMessagingExperiment.schema.json",
+  "title": "Messaging Experiment",
+  "description": "A Firefox Messaging System message.",
+  "if": {
+    "type": "object",
+    "properties": {
+      "template": {
+        "const": "multi"
+      }
+    },
+    "required": [
+      "template"
+    ]
+  },
+  "then": {
+    "$ref": "resource://activity-stream/schemas/BackgroundTaskMessagingExperiment.schema.json#/$defs/MultiMessage"
+  },
+  "else": {
+    "$ref": "resource://activity-stream/schemas/BackgroundTaskMessagingExperiment.schema.json#/$defs/TemplatedMessage"
+  },
+  "$defs": {
+    "ToastNotification": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "$id": "file:///ToastNotification.schema.json",
+      "title": "ToastNotification",
+      "description": "A template for toast notifications displayed by the Alert service.",
+      "allOf": [
+        {
+          "$ref": "resource://activity-stream/schemas/BackgroundTaskMessagingExperiment.schema.json#/$defs/Message"
+        }
+      ],
+      "type": "object",
+      "properties": {
+        "content": {
+          "type": "object",
+          "properties": {
+            "title": {
+              "$ref": "resource://activity-stream/schemas/BackgroundTaskMessagingExperiment.schema.json#/$defs/localizableText",
+              "description": "Id of localized string or message override of toast notification title"
+            },
+            "body": {
+              "$ref": "resource://activity-stream/schemas/BackgroundTaskMessagingExperiment.schema.json#/$defs/localizableText",
+              "description": "Id of localized string or message override of toast notification body"
+            },
+            "icon_url": {
+              "description": "The URL of the image used as an icon of the toast notification.",
+              "type": "string",
+              "format": "moz-url-format"
+            },
+            "image_url": {
+              "description": "The URL of an image to be displayed as part of the notification.",
+              "type": "string",
+              "format": "moz-url-format"
+            },
+            "launch_url": {
+              "description": "The URL to launch when the notification or an action button is clicked.",
+              "type": "string",
+              "format": "moz-url-format"
+            },
+            "requireInteraction": {
+              "type": "boolean",
+              "description": "Whether the toast notification should remain active until the user clicks or dismisses it, rather than closing automatically."
+            },
+            "tag": {
+              "type": "string",
+              "description": "An identifying tag for the toast notification."
+            },
+            "data": {
+              "type": "object",
+              "description": "Arbitrary data associated with the toast notification."
+            },
+            "actions": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "title": {
+                    "$ref": "resource://activity-stream/schemas/BackgroundTaskMessagingExperiment.schema.json#/$defs/localizableText",
+                    "description": "The action text to be shown to the user."
+                  },
+                  "action": {
+                    "type": "string",
+                    "description": "Opaque identifer that identifies action."
+                  },
+                  "iconURL": {
+                    "type": "string",
+                    "format": "uri",
+                    "description": "URL of an icon to display with the action."
+                  },
+                  "windowsSystemActivationType": {
+                    "type": "boolean",
+                    "description": "Whether to have Windows process the given `action`."
+                  }
+                },
+                "required": [
+                  "action",
+                  "title"
+                ],
+                "additionalProperties": true
+              }
+            }
+          },
+          "additionalProperties": true,
+          "required": [
+            "title",
+            "body"
+          ]
+        },
+        "template": {
+          "type": "string",
+          "const": "toast_notification"
+        }
+      },
+      "required": [
+        "content",
+        "targeting",
+        "template",
+        "trigger"
+      ],
+      "additionalProperties": true
+    },
+    "Message": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "The message identifier"
+        },
+        "groups": {
+          "description": "Array of preferences used to control `enabled` status of the group. If any is `false` the group is disabled.",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "description": "Preference name"
+          }
+        },
+        "template": {
+          "type": "string",
+          "description": "Which messaging template this message is using.",
+          "enum": [
+            "toast_notification"
+          ]
+        },
+        "frequency": {
+          "type": "object",
+          "description": "An object containing frequency cap information for a message.",
+          "properties": {
+            "lifetime": {
+              "type": "integer",
+              "description": "The maximum lifetime impressions for a message.",
+              "minimum": 1,
+              "maximum": 100
+            },
+            "custom": {
+              "type": "array",
+              "description": "An array of custom frequency cap definitions.",
+              "items": {
+                "description": "A frequency cap definition containing time and max impression information",
+                "type": "object",
+                "properties": {
+                  "period": {
+                    "type": "integer",
+                    "description": "Period of time in milliseconds (e.g. 86400000 for one day)"
+                  },
+                  "cap": {
+                    "type": "integer",
+                    "description": "The maximum impressions for the message within the defined period.",
+                    "minimum": 1,
+                    "maximum": 100
+                  }
+                },
+                "required": [
+                  "period",
+                  "cap"
+                ]
+              }
+            }
+          }
+        },
+        "priority": {
+          "description": "The priority of the message. If there are two competing messages to show, the one with the highest priority will be shown",
+          "type": "integer"
+        },
+        "order": {
+          "description": "The order in which messages should be shown. Messages will be shown in increasing order.",
+          "type": "integer"
+        },
+        "targeting": {
+          "description": "A JEXL expression representing targeting information",
+          "type": "string"
+        },
+        "trigger": {
+          "description": "An action to trigger potentially showing the message",
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "A string identifying the trigger action"
+            },
+            "params": {
+              "type": "array",
+              "description": "An optional array of string parameters for the trigger action",
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "string"
+                  }
+                ]
+              }
+            }
+          },
+          "required": [
+            "id"
+          ]
+        },
+        "provider": {
+          "description": "An identifier for the provider of this message, such as \"cfr\" or \"preview\".",
+          "type": "string"
+        }
+      },
+      "additionalProperties": true,
+      "dependentRequired": {
+        "content": [
+          "id",
+          "template"
+        ],
+        "template": [
+          "id",
+          "content"
+        ]
+      }
+    },
+    "localizedText": {
+      "type": "object",
+      "properties": {
+        "string_id": {
+          "description": "Id of localized string to be rendered.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "string_id"
+      ]
+    },
+    "localizableText": {
+      "description": "Either a raw string or an object containing the string_id of the localized text",
+      "oneOf": [
+        {
+          "type": "string",
+          "description": "The string to be rendered."
+        },
+        {
+          "$ref": "resource://activity-stream/schemas/BackgroundTaskMessagingExperiment.schema.json#/$defs/localizedText"
+        }
+      ]
+    },
+    "TemplatedMessage": {
+      "description": "An FxMS message of one of a variety of types.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "resource://activity-stream/schemas/BackgroundTaskMessagingExperiment.schema.json#/$defs/Message"
+        },
+        {
+          "if": {
+            "type": "object",
+            "properties": {
+              "template": {
+                "type": "string",
+                "enum": [
+                  "toast_notification"
+                ]
+              }
+            },
+            "required": [
+              "template"
+            ]
+          },
+          "then": {
+            "$ref": "resource://activity-stream/schemas/BackgroundTaskMessagingExperiment.schema.json#/$defs/ToastNotification"
+          }
+        }
+      ]
+    },
+    "MultiMessage": {
+      "description": "An object containing an array of messages.",
+      "type": "object",
+      "properties": {
+        "template": {
+          "type": "string",
+          "const": "multi"
+        },
+        "messages": {
+          "type": "array",
+          "description": "An array of messages.",
+          "items": {
+            "$ref": "resource://activity-stream/schemas/BackgroundTaskMessagingExperiment.schema.json#/$defs/TemplatedMessage"
+          }
+        }
+      },
+      "required": [
+        "template",
+        "messages"
+      ]
+    }
+  }
+}

--- a/experimenter/experimenter/features/manifests/firefox-desktop/v115.5.0/schemas/browser/components/newtab/content-src/asrouter/schemas/MessagingExperiment.schema.json
+++ b/experimenter/experimenter/features/manifests/firefox-desktop/v115.5.0/schemas/browser/components/newtab/content-src/asrouter/schemas/MessagingExperiment.schema.json
@@ -1,0 +1,1640 @@
+{
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "$id": "resource://activity-stream/schemas/MessagingExperiment.schema.json",
+  "title": "Messaging Experiment",
+  "description": "A Firefox Messaging System message.",
+  "if": {
+    "type": "object",
+    "properties": {
+      "template": {
+        "const": "multi"
+      }
+    },
+    "required": [
+      "template"
+    ]
+  },
+  "then": {
+    "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/MultiMessage"
+  },
+  "else": {
+    "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/TemplatedMessage"
+  },
+  "$defs": {
+    "CFRUrlbarChiclet": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "$id": "file:///CFRUrlbarChiclet.schema.json",
+      "title": "CFRUrlbarChiclet",
+      "description": "A template with a chiclet button with text.",
+      "allOf": [
+        {
+          "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/Message"
+        }
+      ],
+      "type": "object",
+      "properties": {
+        "content": {
+          "type": "object",
+          "properties": {
+            "category": {
+              "type": "string",
+              "description": "Attribute used for different groups of messages from the same provider"
+            },
+            "layout": {
+              "type": "string",
+              "description": "Describes how content should be displayed.",
+              "enum": [
+                "chiclet_open_url"
+              ]
+            },
+            "bucket_id": {
+              "type": "string",
+              "description": "A bucket identifier for the addon. This is used in order to anonymize telemetry for history-sensitive targeting."
+            },
+            "notification_text": {
+              "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/localizableText",
+              "description": "The text in the small blue chicklet that appears in the URL bar. This can be a reference to a localized string in Firefox or just a plain string."
+            },
+            "active_color": {
+              "type": "string",
+              "description": "Background color of the button"
+            },
+            "action": {
+              "type": "object",
+              "properties": {
+                "url": {
+                  "description": "The page to open when the button is clicked.",
+                  "type": "string",
+                  "format": "moz-url-format"
+                },
+                "where": {
+                  "description": "Should it open in a new tab or the current tab",
+                  "type": "string",
+                  "enum": [
+                    "current",
+                    "tabshifted"
+                  ]
+                }
+              },
+              "additionalProperties": true,
+              "required": [
+                "url",
+                "where"
+              ]
+            }
+          },
+          "additionalProperties": true,
+          "required": [
+            "layout",
+            "category",
+            "bucket_id",
+            "notification_text",
+            "action"
+          ]
+        },
+        "template": {
+          "type": "string",
+          "const": "cfr_urlbar_chiclet"
+        }
+      },
+      "required": [
+        "targeting",
+        "trigger"
+      ]
+    },
+    "ExtensionDoorhanger": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "$id": "file:///ExtensionDoorhanger.schema.json",
+      "title": "ExtensionDoorhanger",
+      "description": "A template with a heading, addon icon, title and description. No markup allowed.",
+      "allOf": [
+        {
+          "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/Message"
+        }
+      ],
+      "type": "object",
+      "properties": {
+        "content": {
+          "type": "object",
+          "properties": {
+            "category": {
+              "type": "string",
+              "description": "Attribute used for different groups of messages from the same provider"
+            },
+            "layout": {
+              "type": "string",
+              "description": "Attribute used for different groups of messages from the same provider",
+              "enum": [
+                "short_message",
+                "icon_and_message",
+                "addon_recommendation"
+              ]
+            },
+            "anchor_id": {
+              "type": "string",
+              "description": "A DOM element ID that the pop-over will be anchored."
+            },
+            "alt_anchor_id": {
+              "type": "string",
+              "description": "An alternate DOM element ID that the pop-over will be anchored."
+            },
+            "bucket_id": {
+              "type": "string",
+              "description": "A bucket identifier for the addon. This is used in order to anonymize telemetry for history-sensitive targeting."
+            },
+            "skip_address_bar_notifier": {
+              "type": "boolean",
+              "description": "Skip the 'Recommend' notifier and show directly."
+            },
+            "persistent_doorhanger": {
+              "type": "boolean",
+              "description": "Prevent the doorhanger from being dismissed if user interacts with the page or switches between applications."
+            },
+            "show_in_private_browsing": {
+              "type": "boolean",
+              "description": "Whether to allow the message to be shown in private browsing mode. Defaults to false."
+            },
+            "notification_text": {
+              "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/localizableText",
+              "description": "The text in the small blue chicklet that appears in the URL bar. This can be a reference to a localized string in Firefox or just a plain string."
+            },
+            "info_icon": {
+              "type": "object",
+              "description": "The small icon displayed in the top right corner of the pop-over. Should be 19x19px, svg or png. Defaults to a small question mark.",
+              "properties": {
+                "label": {
+                  "oneOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "attributes": {
+                          "type": "object",
+                          "properties": {
+                            "tooltiptext": {
+                              "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/localizableText",
+                              "description": "Text for button tooltip used to provide information about the doorhanger."
+                            }
+                          },
+                          "required": [
+                            "tooltiptext"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "attributes"
+                      ]
+                    },
+                    {
+                      "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/localizedText"
+                    }
+                  ]
+                },
+                "sumo_path": {
+                  "type": "string",
+                  "description": "Last part of the path in the URL to the support page with the information about the doorhanger.",
+                  "examples": [
+                    "extensionpromotions",
+                    "extensionrecommendations"
+                  ]
+                }
+              }
+            },
+            "learn_more": {
+              "type": "string",
+              "description": "Last part of the path in the SUMO URL to the support page with the information about the doorhanger.",
+              "examples": [
+                "extensionpromotions",
+                "extensionrecommendations"
+              ]
+            },
+            "heading_text": {
+              "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/localizableText",
+              "description": "The larger heading text displayed in the pop-over. This can be a reference to a localized string in Firefox or just a plain string."
+            },
+            "icon": {
+              "$ref": "file:///ExtensionDoorhanger.schema.json#/$defs/linkUrl",
+              "description": "The icon displayed in the pop-over. Should be 32x32px or 64x64px and png/svg."
+            },
+            "icon_dark_theme": {
+              "type": "string",
+              "description": "Pop-over icon, dark theme variant. Should be 32x32px or 64x64px and png/svg."
+            },
+            "icon_class": {
+              "type": "string",
+              "description": "CSS class of the pop-over icon."
+            },
+            "addon": {
+              "description": "Addon information including AMO URL.",
+              "type": "object",
+              "properties": {
+                "id": {
+                  "$ref": "file:///ExtensionDoorhanger.schema.json#/$defs/plainText",
+                  "description": "Unique addon ID"
+                },
+                "title": {
+                  "$ref": "file:///ExtensionDoorhanger.schema.json#/$defs/plainText",
+                  "description": "Addon name"
+                },
+                "author": {
+                  "$ref": "file:///ExtensionDoorhanger.schema.json#/$defs/plainText",
+                  "description": "Addon author"
+                },
+                "icon": {
+                  "$ref": "file:///ExtensionDoorhanger.schema.json#/$defs/linkUrl",
+                  "description": "The icon displayed in the pop-over. Should be 64x64px and png/svg."
+                },
+                "rating": {
+                  "type": "string",
+                  "description": "Star rating"
+                },
+                "users": {
+                  "type": "string",
+                  "description": "Installed users"
+                },
+                "amo_url": {
+                  "$ref": "file:///ExtensionDoorhanger.schema.json#/$defs/linkUrl",
+                  "description": "Link that offers more information related to the addon."
+                }
+              },
+              "required": [
+                "title",
+                "author",
+                "icon",
+                "amo_url"
+              ]
+            },
+            "text": {
+              "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/localizableText",
+              "description": "The body text displayed in the pop-over. This can be a reference to a localized string in Firefox or just a plain string."
+            },
+            "descriptionDetails": {
+              "description": "Additional information and steps on how to use",
+              "type": "object",
+              "properties": {
+                "steps": {
+                  "description": "Array of string_ids",
+                  "type": "array",
+                  "items": {
+                    "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/localizedText",
+                    "description": "Id of string to localized addon description"
+                  }
+                }
+              },
+              "required": [
+                "steps"
+              ]
+            },
+            "buttons": {
+              "description": "The label and functionality for the buttons in the pop-over.",
+              "type": "object",
+              "properties": {
+                "primary": {
+                  "type": "object",
+                  "properties": {
+                    "label": {
+                      "type": "object",
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "value": {
+                              "$ref": "file:///ExtensionDoorhanger.schema.json#/$defs/plainText",
+                              "description": "Button label override used when a localized version is not available."
+                            },
+                            "attributes": {
+                              "type": "object",
+                              "properties": {
+                                "accesskey": {
+                                  "type": "string",
+                                  "description": "A single character to be used as a shortcut key for the secondary button. This should be one of the characters that appears in the button label."
+                                }
+                              },
+                              "required": [
+                                "accesskey"
+                              ],
+                              "description": "Button attributes."
+                            }
+                          },
+                          "required": [
+                            "value",
+                            "attributes"
+                          ]
+                        },
+                        {
+                          "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/localizedText"
+                        }
+                      ],
+                      "description": "Id of localized string or message override."
+                    },
+                    "action": {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "description": "Action dispatched by the button."
+                        },
+                        "data": {
+                          "properties": {
+                            "url": {
+                              "type": "string",
+                              "$comment": "This is dynamically generated from the addon.id. See CFRPageActions.jsm",
+                              "description": "URL used in combination with the primary action dispatched."
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "secondary": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "label": {
+                        "type": "object",
+                        "oneOf": [
+                          {
+                            "properties": {
+                              "value": {
+                                "allOf": [
+                                  {
+                                    "$ref": "file:///ExtensionDoorhanger.schema.json#/$defs/plainText"
+                                  },
+                                  {
+                                    "description": "Button label override used when a localized version is not available."
+                                  }
+                                ]
+                              },
+                              "attributes": {
+                                "type": "object",
+                                "properties": {
+                                  "accesskey": {
+                                    "type": "string",
+                                    "description": "A single character to be used as a shortcut key for the secondary button. This should be one of the characters that appears in the button label."
+                                  }
+                                },
+                                "required": [
+                                  "accesskey"
+                                ],
+                                "description": "Button attributes."
+                              }
+                            },
+                            "required": [
+                              "value",
+                              "attributes"
+                            ]
+                          },
+                          {
+                            "properties": {
+                              "string_id": {
+                                "allOf": [
+                                  {
+                                    "$ref": "file:///ExtensionDoorhanger.schema.json#/$defs/plainText"
+                                  },
+                                  {
+                                    "description": "Id of localized string for button"
+                                  }
+                                ]
+                              }
+                            },
+                            "required": [
+                              "string_id"
+                            ]
+                          }
+                        ],
+                        "description": "Id of localized string or message override."
+                      },
+                      "action": {
+                        "type": "object",
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "description": "Action dispatched by the button."
+                          },
+                          "data": {
+                            "properties": {
+                              "url": {
+                                "allOf": [
+                                  {
+                                    "$ref": "file:///ExtensionDoorhanger.schema.json#/$defs/linkUrl"
+                                  },
+                                  {
+                                    "description": "URL used in combination with the primary action dispatched."
+                                  }
+                                ]
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "additionalProperties": true,
+          "required": [
+            "layout",
+            "bucket_id",
+            "heading_text",
+            "text",
+            "buttons"
+          ],
+          "if": {
+            "properties": {
+              "skip_address_bar_notifier": {
+                "anyOf": [
+                  {
+                    "const": "false"
+                  },
+                  {
+                    "const": null
+                  }
+                ]
+              }
+            }
+          },
+          "then": {
+            "required": [
+              "category",
+              "notification_text"
+            ]
+          }
+        },
+        "template": {
+          "type": "string",
+          "enum": [
+            "cfr_doorhanger",
+            "milestone_message"
+          ]
+        }
+      },
+      "additionalProperties": true,
+      "required": [
+        "targeting",
+        "trigger"
+      ],
+      "$defs": {
+        "plainText": {
+          "description": "Plain text (no HTML allowed)",
+          "type": "string"
+        },
+        "linkUrl": {
+          "description": "Target for links or buttons",
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "InfoBar": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "$id": "file:///InfoBar.schema.json",
+      "title": "InfoBar",
+      "description": "A template with an image, test and buttons.",
+      "allOf": [
+        {
+          "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/Message"
+        }
+      ],
+      "type": "object",
+      "properties": {
+        "content": {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "description": "Should the message be global (persisted across tabs) or local (disappear when switching to a different tab).",
+              "enum": [
+                "global",
+                "tab"
+              ]
+            },
+            "text": {
+              "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/localizableText",
+              "description": "The text show in the notification box."
+            },
+            "priority": {
+              "description": "Infobar priority level https://searchfox.org/mozilla-central/rev/3aef835f6cb12e607154d56d68726767172571e4/toolkit/content/widgets/notificationbox.js#387",
+              "type": "number",
+              "minumum": 0,
+              "exclusiveMaximum": 10
+            },
+            "buttons": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "label": {
+                    "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/localizableText",
+                    "description": "The text label of the button."
+                  },
+                  "primary": {
+                    "type": "boolean",
+                    "description": "Is this the primary button?"
+                  },
+                  "accessKey": {
+                    "type": "string",
+                    "description": "Keyboard shortcut letter."
+                  },
+                  "action": {
+                    "type": "object",
+                    "properties": {
+                      "type": {
+                        "type": "string",
+                        "description": "Action dispatched by the button."
+                      },
+                      "data": {
+                        "type": "object"
+                      }
+                    },
+                    "required": [
+                      "type"
+                    ],
+                    "additionalProperties": true
+                  },
+                  "supportPage": {
+                    "type": "string",
+                    "description": "A page title on SUMO to link to"
+                  }
+                },
+                "required": [
+                  "label",
+                  "action"
+                ],
+                "additionalProperties": true
+              }
+            }
+          },
+          "additionalProperties": true,
+          "required": [
+            "text",
+            "buttons"
+          ]
+        },
+        "template": {
+          "type": "string",
+          "const": "infobar"
+        }
+      },
+      "additionalProperties": true,
+      "required": [
+        "targeting",
+        "trigger"
+      ],
+      "$defs": {
+        "plainText": {
+          "description": "Plain text (no HTML allowed)",
+          "type": "string"
+        },
+        "linkUrl": {
+          "description": "Target for links or buttons",
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "NewtabPromoMessage": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "$id": "file:///NewtabPromoMessage.schema.json",
+      "title": "PBNewtabPromoMessage",
+      "description": "Message shown on the private browsing newtab page.",
+      "allOf": [
+        {
+          "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/Message"
+        }
+      ],
+      "type": "object",
+      "properties": {
+        "content": {
+          "type": "object",
+          "properties": {
+            "hideDefault": {
+              "type": "boolean",
+              "description": "Should we hide the default promo after the experiment promo is dismissed."
+            },
+            "infoEnabled": {
+              "type": "boolean",
+              "description": "Should we show the info section."
+            },
+            "infoIcon": {
+              "type": "string",
+              "description": "Icon shown in the left side of the info section. Default is the private browsing icon."
+            },
+            "infoTitle": {
+              "type": "string",
+              "description": "Is the title in the info section enabled."
+            },
+            "infoTitleEnabled": {
+              "type": "boolean",
+              "description": "Is the title in the info section enabled."
+            },
+            "infoBody": {
+              "type": "string",
+              "description": "Text content in the info section."
+            },
+            "infoLinkText": {
+              "type": "string",
+              "description": "Text for the link in the info section."
+            },
+            "infoLinkUrl": {
+              "type": "string",
+              "description": "URL for the info section link.",
+              "format": "moz-url-format"
+            },
+            "promoEnabled": {
+              "type": "boolean",
+              "description": "Should we show the promo section."
+            },
+            "promoType": {
+              "type": "string",
+              "description": "Promo type used to determine if promo should show to a given user",
+              "enum": [
+                "FOCUS",
+                "VPN",
+                "PIN",
+                "COOKIE_BANNERS",
+                "OTHER"
+              ]
+            },
+            "promoSectionStyle": {
+              "type": "string",
+              "description": "Sets the position of the promo section. Possible values are: top, below-search, bottom. Default bottom.",
+              "enum": [
+                "top",
+                "below-search",
+                "bottom"
+              ]
+            },
+            "promoTitle": {
+              "type": "string",
+              "description": "The text content of the promo section."
+            },
+            "promoTitleEnabled": {
+              "type": "boolean",
+              "description": "Should we show text content in the promo section."
+            },
+            "promoLinkText": {
+              "type": "string",
+              "description": "The text of the link in the promo box."
+            },
+            "promoHeader": {
+              "type": "string",
+              "description": "The title of the promo section."
+            },
+            "promoButton": {
+              "type": "object",
+              "properties": {
+                "action": {
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "description": "Action dispatched by the button."
+                    },
+                    "data": {
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "type"
+                  ],
+                  "additionalProperties": true
+                }
+              },
+              "required": [
+                "action"
+              ]
+            },
+            "promoLinkType": {
+              "type": "string",
+              "description": "Type of promo link type. Possible values: link, button. Default is link.",
+              "enum": [
+                "link",
+                "button"
+              ]
+            },
+            "promoImageLarge": {
+              "type": "string",
+              "description": "URL for image used on the left side of the promo box, larger, showcases some feature. Default off.",
+              "format": "uri"
+            },
+            "promoImageSmall": {
+              "type": "string",
+              "description": "URL for image used on the right side of the promo box, smaller, usually a logo. Default off.",
+              "format": "uri"
+            }
+          },
+          "additionalProperties": true,
+          "allOf": [
+            {
+              "if": {
+                "properties": {
+                  "promoEnabled": {
+                    "const": true
+                  }
+                },
+                "required": [
+                  "promoEnabled"
+                ]
+              },
+              "then": {
+                "required": [
+                  "promoButton"
+                ]
+              }
+            },
+            {
+              "if": {
+                "properties": {
+                  "infoEnabled": {
+                    "const": true
+                  }
+                },
+                "required": [
+                  "infoEnabled"
+                ]
+              },
+              "then": {
+                "required": [
+                  "infoLinkText"
+                ],
+                "if": {
+                  "properties": {
+                    "infoTitleEnabled": {
+                      "const": true
+                    }
+                  },
+                  "required": [
+                    "infoTitleEnabled"
+                  ]
+                },
+                "then": {
+                  "required": [
+                    "infoTitle"
+                  ]
+                }
+              }
+            }
+          ]
+        },
+        "template": {
+          "type": "string",
+          "const": "pb_newtab"
+        }
+      },
+      "additionalProperties": true,
+      "required": [
+        "targeting"
+      ]
+    },
+    "ProtectionsPanelMessage": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "$id": "file:///ProtectionsPanelMessage.schema.json",
+      "title": "ProtectionsPanelMessage",
+      "description": "A message shown in the protections panel.",
+      "allOf": [
+        {
+          "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/Message"
+        }
+      ],
+      "type": "object",
+      "properties": {
+        "content": {
+          "type": "object",
+          "properties": {
+            "title": {
+              "description": "The message title.",
+              "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/localizableText"
+            },
+            "body": {
+              "description": "The body of the message.",
+              "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/localizableText"
+            },
+            "link_text": {
+              "description": "The text of the call to action link.",
+              "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/localizableText"
+            },
+            "cta_type": {
+              "description": "The type of URL open action.",
+              "type": "string",
+              "enum": [
+                "OPEN_URL",
+                "OPEN_PROTECTION_REPORT",
+                "OPEN_ABOUT_PAGE"
+              ]
+            },
+            "cta_url": {
+              "description": "The URL to open when the call to action is clicked",
+              "type": "string",
+              "format": "moz-url-format"
+            },
+            "cta_where": {
+              "description": "How to open the cta.",
+              "type": "string",
+              "enum": [
+                "current",
+                "tabshifted",
+                "tab",
+                "save",
+                "window"
+              ]
+            }
+          },
+          "dependantSchemas": {
+            "link_text": [
+              "cta_type",
+              "cta_url"
+            ],
+            "cta_type": [
+              "link_text"
+            ],
+            "cta_url": [
+              "link_text"
+            ],
+            "cta_where": [
+              "link_text"
+            ]
+          },
+          "additionalProperties": false,
+          "required": [
+            "title",
+            "body"
+          ]
+        },
+        "template": {
+          "type": "string",
+          "const": "protections_panel"
+        },
+        "trigger": {
+          "description": "An action to trigger potentially showing the message. The action ID `protectionsPanelOpen` is required.",
+          "const": {
+            "id": "protectionsPanelOpen"
+          }
+        }
+      },
+      "required": [
+        "content",
+        "template",
+        "trigger"
+      ],
+      "additionalProperties": true
+    },
+    "Spotlight": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "$id": "file:///Spotlight.schema.json",
+      "title": "Spotlight",
+      "description": "A template with an image, title, content and two buttons.",
+      "allOf": [
+        {
+          "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/Message"
+        }
+      ],
+      "type": "object",
+      "properties": {
+        "content": {
+          "type": "object",
+          "properties": {
+            "template": {
+              "type": "string",
+              "description": "Specify the layout template for the Spotlight",
+              "const": "multistage"
+            },
+            "backdrop": {
+              "type": "string",
+              "description": "Background css behind modal content"
+            },
+            "logo": {
+              "type": "object",
+              "properties": {
+                "imageURL": {
+                  "type": "string",
+                  "description": "URL for image to use with the content"
+                },
+                "imageId": {
+                  "type": "string",
+                  "description": "The ID for a remotely hosted image"
+                },
+                "size": {
+                  "type": "string",
+                  "description": "The logo size."
+                }
+              },
+              "additionalProperties": true
+            },
+            "screens": {
+              "type": "array",
+              "description": "Collection of individual screen content"
+            },
+            "transitions": {
+              "type": "boolean",
+              "description": "Show transitions within and between screens"
+            },
+            "disableHistoryUpdates": {
+              "type": "boolean",
+              "description": "Don't alter the browser session's history stack - used with messaging surfaces like Feature Callouts"
+            },
+            "startScreen": {
+              "type": "integer",
+              "description": "Index of first screen to show from message, defaulting to 0"
+            }
+          },
+          "additionalProperties": true
+        },
+        "template": {
+          "type": "string",
+          "description": "Specify whether the surface is shown as a Spotlight modal or an in-surface Feature Callout dialog",
+          "enum": [
+            "spotlight",
+            "feature_callout"
+          ]
+        }
+      },
+      "additionalProperties": true,
+      "required": [
+        "targeting"
+      ]
+    },
+    "ToastNotification": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "$id": "file:///ToastNotification.schema.json",
+      "title": "ToastNotification",
+      "description": "A template for toast notifications displayed by the Alert service.",
+      "allOf": [
+        {
+          "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/Message"
+        }
+      ],
+      "type": "object",
+      "properties": {
+        "content": {
+          "type": "object",
+          "properties": {
+            "title": {
+              "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/localizableText",
+              "description": "Id of localized string or message override of toast notification title"
+            },
+            "body": {
+              "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/localizableText",
+              "description": "Id of localized string or message override of toast notification body"
+            },
+            "icon_url": {
+              "description": "The URL of the image used as an icon of the toast notification.",
+              "type": "string",
+              "format": "moz-url-format"
+            },
+            "image_url": {
+              "description": "The URL of an image to be displayed as part of the notification.",
+              "type": "string",
+              "format": "moz-url-format"
+            },
+            "launch_url": {
+              "description": "The URL to launch when the notification or an action button is clicked.",
+              "type": "string",
+              "format": "moz-url-format"
+            },
+            "requireInteraction": {
+              "type": "boolean",
+              "description": "Whether the toast notification should remain active until the user clicks or dismisses it, rather than closing automatically."
+            },
+            "tag": {
+              "type": "string",
+              "description": "An identifying tag for the toast notification."
+            },
+            "data": {
+              "type": "object",
+              "description": "Arbitrary data associated with the toast notification."
+            },
+            "actions": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "title": {
+                    "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/localizableText",
+                    "description": "The action text to be shown to the user."
+                  },
+                  "action": {
+                    "type": "string",
+                    "description": "Opaque identifer that identifies action."
+                  },
+                  "iconURL": {
+                    "type": "string",
+                    "format": "uri",
+                    "description": "URL of an icon to display with the action."
+                  },
+                  "windowsSystemActivationType": {
+                    "type": "boolean",
+                    "description": "Whether to have Windows process the given `action`."
+                  }
+                },
+                "required": [
+                  "action",
+                  "title"
+                ],
+                "additionalProperties": true
+              }
+            }
+          },
+          "additionalProperties": true,
+          "required": [
+            "title",
+            "body"
+          ]
+        },
+        "template": {
+          "type": "string",
+          "const": "toast_notification"
+        }
+      },
+      "required": [
+        "content",
+        "targeting",
+        "template",
+        "trigger"
+      ],
+      "additionalProperties": true
+    },
+    "ToolbarBadgeMessage": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "$id": "file:///ToolbarBadgeMessage.schema.json",
+      "title": "ToolbarBadgeMessage",
+      "description": "A template that specifies to which element in the browser toolbar to add a notification.",
+      "allOf": [
+        {
+          "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/Message"
+        }
+      ],
+      "type": "object",
+      "properties": {
+        "content": {
+          "type": "object",
+          "properties": {
+            "target": {
+              "type": "string"
+            },
+            "action": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": true,
+              "required": [
+                "id"
+              ],
+              "description": "Optional action to take in addition to showing the notification"
+            },
+            "delay": {
+              "type": "number",
+              "description": "Optional delay in ms after which to show the notification"
+            },
+            "badgeDescription": {
+              "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/localizedText",
+              "description": "This is used in combination with the badged button to offer a text based alternative to the visual badging. Example 'New Feature: What's New'"
+            }
+          },
+          "additionalProperties": true,
+          "required": [
+            "target"
+          ]
+        },
+        "template": {
+          "type": "string",
+          "const": "toolbar_badge"
+        }
+      },
+      "additionalProperties": true,
+      "required": [
+        "targeting"
+      ]
+    },
+    "UpdateAction": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "$id": "file:///UpdateAction.schema.json",
+      "title": "UpdateActionMessage",
+      "description": "A template for messages that execute predetermined actions.",
+      "allOf": [
+        {
+          "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/Message"
+        }
+      ],
+      "type": "object",
+      "properties": {
+        "content": {
+          "type": "object",
+          "properties": {
+            "action": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "data": {
+                  "type": "object",
+                  "description": "Additional data provided as argument when executing the action",
+                  "properties": {
+                    "url": {
+                      "type": "string",
+                      "description": "URL data to be used as argument to the action"
+                    },
+                    "expireDelta": {
+                      "type": "number",
+                      "description": "Expiration timestamp to be used as argument to the action"
+                    }
+                  }
+                }
+              },
+              "additionalProperties": true,
+              "description": "Optional action to take in addition to showing the notification",
+              "required": [
+                "id",
+                "data"
+              ]
+            }
+          },
+          "additionalProperties": true,
+          "required": [
+            "action"
+          ]
+        },
+        "template": {
+          "type": "string",
+          "const": "update_action"
+        }
+      },
+      "required": [
+        "targeting"
+      ]
+    },
+    "WhatsNewMessage": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "$id": "file:///WhatsNewMessage.schema.json",
+      "title": "WhatsNewMessage",
+      "description": "A template for the messages that appear in the What's New panel.",
+      "allOf": [
+        {
+          "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/Message"
+        }
+      ],
+      "type": "object",
+      "properties": {
+        "content": {
+          "type": "object",
+          "properties": {
+            "layout": {
+              "description": "Different message layouts",
+              "enum": [
+                "tracking-protections"
+              ]
+            },
+            "bucket_id": {
+              "type": "string",
+              "description": "A bucket identifier for the addon. This is used in order to anonymize telemetry for history-sensitive targeting."
+            },
+            "published_date": {
+              "type": "integer",
+              "description": "The date/time (number of milliseconds elapsed since January 1, 1970 00:00:00 UTC) the message was published."
+            },
+            "title": {
+              "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/localizableText",
+              "description": "Id of localized string or message override of What's New message title"
+            },
+            "subtitle": {
+              "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/localizableText",
+              "description": "Id of localized string or message override of What's New message subtitle"
+            },
+            "body": {
+              "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/localizableText",
+              "description": "Id of localized string or message override of What's New message body"
+            },
+            "link_text": {
+              "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/localizableText",
+              "description": "(optional) Id of localized string or message override of What's New message link text"
+            },
+            "cta_url": {
+              "description": "Target URL for the What's New message.",
+              "type": "string",
+              "format": "moz-url-format"
+            },
+            "cta_type": {
+              "description": "Type of url open action",
+              "enum": [
+                "OPEN_URL",
+                "OPEN_ABOUT_PAGE",
+                "OPEN_PROTECTION_REPORT"
+              ]
+            },
+            "cta_where": {
+              "description": "How to open the cta: new window, tab, focused, unfocused.",
+              "enum": [
+                "current",
+                "tabshifted",
+                "tab",
+                "save",
+                "window"
+              ]
+            },
+            "icon_url": {
+              "description": "(optional) URL for the What's New message icon.",
+              "type": "string",
+              "format": "uri"
+            },
+            "icon_alt": {
+              "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/localizableText",
+              "description": "Alt text for image."
+            }
+          },
+          "additionalProperties": true,
+          "required": [
+            "published_date",
+            "title",
+            "body",
+            "cta_url",
+            "bucket_id"
+          ]
+        },
+        "template": {
+          "type": "string",
+          "const": "whatsnew_panel_message"
+        }
+      },
+      "required": [
+        "order"
+      ],
+      "additionalProperties": true
+    },
+    "Message": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "The message identifier"
+        },
+        "groups": {
+          "description": "Array of preferences used to control `enabled` status of the group. If any is `false` the group is disabled.",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "description": "Preference name"
+          }
+        },
+        "template": {
+          "type": "string",
+          "description": "Which messaging template this message is using.",
+          "enum": [
+            "cfr_urlbar_chiclet",
+            "cfr_doorhanger",
+            "milestone_message",
+            "infobar",
+            "pb_newtab",
+            "protections_panel",
+            "spotlight",
+            "feature_callout",
+            "toast_notification",
+            "toolbar_badge",
+            "update_action",
+            "whatsnew_panel_message"
+          ]
+        },
+        "frequency": {
+          "type": "object",
+          "description": "An object containing frequency cap information for a message.",
+          "properties": {
+            "lifetime": {
+              "type": "integer",
+              "description": "The maximum lifetime impressions for a message.",
+              "minimum": 1,
+              "maximum": 100
+            },
+            "custom": {
+              "type": "array",
+              "description": "An array of custom frequency cap definitions.",
+              "items": {
+                "description": "A frequency cap definition containing time and max impression information",
+                "type": "object",
+                "properties": {
+                  "period": {
+                    "type": "integer",
+                    "description": "Period of time in milliseconds (e.g. 86400000 for one day)"
+                  },
+                  "cap": {
+                    "type": "integer",
+                    "description": "The maximum impressions for the message within the defined period.",
+                    "minimum": 1,
+                    "maximum": 100
+                  }
+                },
+                "required": [
+                  "period",
+                  "cap"
+                ]
+              }
+            }
+          }
+        },
+        "priority": {
+          "description": "The priority of the message. If there are two competing messages to show, the one with the highest priority will be shown",
+          "type": "integer"
+        },
+        "order": {
+          "description": "The order in which messages should be shown. Messages will be shown in increasing order.",
+          "type": "integer"
+        },
+        "targeting": {
+          "description": "A JEXL expression representing targeting information",
+          "type": "string"
+        },
+        "trigger": {
+          "description": "An action to trigger potentially showing the message",
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "A string identifying the trigger action"
+            },
+            "params": {
+              "type": "array",
+              "description": "An optional array of string parameters for the trigger action",
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "string"
+                  }
+                ]
+              }
+            }
+          },
+          "required": [
+            "id"
+          ]
+        },
+        "provider": {
+          "description": "An identifier for the provider of this message, such as \"cfr\" or \"preview\".",
+          "type": "string"
+        }
+      },
+      "additionalProperties": true,
+      "dependentRequired": {
+        "content": [
+          "id",
+          "template"
+        ],
+        "template": [
+          "id",
+          "content"
+        ]
+      }
+    },
+    "localizedText": {
+      "type": "object",
+      "properties": {
+        "string_id": {
+          "description": "Id of localized string to be rendered.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "string_id"
+      ]
+    },
+    "localizableText": {
+      "description": "Either a raw string or an object containing the string_id of the localized text",
+      "oneOf": [
+        {
+          "type": "string",
+          "description": "The string to be rendered."
+        },
+        {
+          "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/localizedText"
+        }
+      ]
+    },
+    "TemplatedMessage": {
+      "description": "An FxMS message of one of a variety of types.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/Message"
+        },
+        {
+          "if": {
+            "type": "object",
+            "properties": {
+              "template": {
+                "type": "string",
+                "enum": [
+                  "cfr_urlbar_chiclet"
+                ]
+              }
+            },
+            "required": [
+              "template"
+            ]
+          },
+          "then": {
+            "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/CFRUrlbarChiclet"
+          }
+        },
+        {
+          "if": {
+            "type": "object",
+            "properties": {
+              "template": {
+                "type": "string",
+                "enum": [
+                  "cfr_doorhanger",
+                  "milestone_message"
+                ]
+              }
+            },
+            "required": [
+              "template"
+            ]
+          },
+          "then": {
+            "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/ExtensionDoorhanger"
+          }
+        },
+        {
+          "if": {
+            "type": "object",
+            "properties": {
+              "template": {
+                "type": "string",
+                "enum": [
+                  "infobar"
+                ]
+              }
+            },
+            "required": [
+              "template"
+            ]
+          },
+          "then": {
+            "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/InfoBar"
+          }
+        },
+        {
+          "if": {
+            "type": "object",
+            "properties": {
+              "template": {
+                "type": "string",
+                "enum": [
+                  "pb_newtab"
+                ]
+              }
+            },
+            "required": [
+              "template"
+            ]
+          },
+          "then": {
+            "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/NewtabPromoMessage"
+          }
+        },
+        {
+          "if": {
+            "type": "object",
+            "properties": {
+              "template": {
+                "type": "string",
+                "enum": [
+                  "protections_panel"
+                ]
+              }
+            },
+            "required": [
+              "template"
+            ]
+          },
+          "then": {
+            "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/ProtectionsPanelMessage"
+          }
+        },
+        {
+          "if": {
+            "type": "object",
+            "properties": {
+              "template": {
+                "type": "string",
+                "enum": [
+                  "spotlight",
+                  "feature_callout"
+                ]
+              }
+            },
+            "required": [
+              "template"
+            ]
+          },
+          "then": {
+            "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/Spotlight"
+          }
+        },
+        {
+          "if": {
+            "type": "object",
+            "properties": {
+              "template": {
+                "type": "string",
+                "enum": [
+                  "toast_notification"
+                ]
+              }
+            },
+            "required": [
+              "template"
+            ]
+          },
+          "then": {
+            "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/ToastNotification"
+          }
+        },
+        {
+          "if": {
+            "type": "object",
+            "properties": {
+              "template": {
+                "type": "string",
+                "enum": [
+                  "toolbar_badge"
+                ]
+              }
+            },
+            "required": [
+              "template"
+            ]
+          },
+          "then": {
+            "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/ToolbarBadgeMessage"
+          }
+        },
+        {
+          "if": {
+            "type": "object",
+            "properties": {
+              "template": {
+                "type": "string",
+                "enum": [
+                  "update_action"
+                ]
+              }
+            },
+            "required": [
+              "template"
+            ]
+          },
+          "then": {
+            "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/UpdateAction"
+          }
+        },
+        {
+          "if": {
+            "type": "object",
+            "properties": {
+              "template": {
+                "type": "string",
+                "enum": [
+                  "whatsnew_panel_message"
+                ]
+              }
+            },
+            "required": [
+              "template"
+            ]
+          },
+          "then": {
+            "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/WhatsNewMessage"
+          }
+        }
+      ]
+    },
+    "MultiMessage": {
+      "description": "An object containing an array of messages.",
+      "type": "object",
+      "properties": {
+        "template": {
+          "type": "string",
+          "const": "multi"
+        },
+        "messages": {
+          "type": "array",
+          "description": "An array of messages.",
+          "items": {
+            "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/TemplatedMessage"
+          }
+        }
+      },
+      "required": [
+        "template",
+        "messages"
+      ]
+    }
+  }
+}

--- a/experimenter/experimenter/features/manifests/firefox-desktop/v115.5.0/schemas/toolkit/components/normandy/schemas/LegacyHeartbeat.schema.json
+++ b/experimenter/experimenter/features/manifests/firefox-desktop/v115.5.0/schemas/toolkit/components/normandy/schemas/LegacyHeartbeat.schema.json
@@ -1,0 +1,73 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Legacy (Normandy) Heartbeat, via Nimbus",
+  "description": "The schema for the Legacy Heartbeat Nimbus feature.",
+  "type": "object",
+  "properties": {
+    "survey": {
+      "$comment": "Hearbeat arguments are nested under survey to prevent simultaneous rollouts and experiments from overriding eachothers optional variables",
+      "type": "object",
+      "properties": {
+        "repeatOption": {
+          "type": "string",
+          "enum": ["once", "xdays", "nag"],
+          "description": "Determines how often a prompt is shown executes.",
+          "default": "once"
+        },
+        "repeatEvery": {
+          "description": "For repeatOption=xdays, how often (in days) the prompt is displayed.",
+          "default": null,
+          "type": ["number", "null"]
+        },
+        "includeTelemetryUUID": {
+          "type": "boolean",
+          "description": "Include unique user ID in post-answer-url and Telemetry",
+          "default": false
+        },
+        "surveyId": {
+          "description": "Slug uniquely identifying this survey in telemetry",
+          "type": "string"
+        },
+        "message": {
+          "description": "Message to show to the user",
+          "type": "string"
+        },
+        "engagementButtonLabel": {
+          "description": "Text for the engagement button. If specified, this button will be shown instead of rating stars.",
+          "default": null,
+          "type": ["string", "null"]
+        },
+        "thanksMessage": {
+          "description": "Thanks message to show to the user after they've rated Firefox",
+          "type": "string"
+        },
+        "postAnswerUrl": {
+          "description": "URL to redirect the user to after rating Firefox or clicking the engagement button",
+          "default": null,
+          "type": ["string", "null"]
+        },
+        "learnMoreMessage": {
+          "description": "Message to show to the user to learn more",
+          "default": null,
+          "type": ["string", "null"]
+        },
+        "learnMoreUrl": {
+          "description": "URL to show to the user when they click Learn More",
+          "default": null,
+          "type": ["string", "null"]
+        }
+      },
+      "required": [
+        "surveyId",
+        "message",
+        "thanksMessage",
+        "postAnswerUrl",
+        "learnMoreMessage",
+        "learnMoreUrl"
+      ],
+      "additionalProperties": false
+    }
+  },
+  "required": ["survey"],
+  "additionalProperties": false
+}

--- a/experimenter/experimenter/features/manifests/firefox-desktop/v120.0.0/experimenter.yaml
+++ b/experimenter/experimenter/features/manifests/firefox-desktop/v120.0.0/experimenter.yaml
@@ -1,0 +1,1945 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# Features must be added here to be accessible through the NimbusFeature API.
+
+"no-feature-firefox-desktop":
+  description: A dummy feature for experiments that target no feature.
+  owner: barret@mozilla.com
+  applications:
+    - firefox-desktop
+    - firefox-desktop-background-task
+  hasExposure: false
+  variables: {}
+
+testFeature:
+  description: Test only feature
+  owner: barret@mozilla.com
+  applications:
+    - firefox-desktop
+    - firefox-desktop-background-task
+  hasExposure: false
+  isEarlyStartup: true
+  variables:
+    enabled:
+      type: boolean
+      description: Whether or not this feature is enabled
+    testInt:
+      type: int
+      fallbackPref: nimbus.testing.testInt
+      description: Int pref used by platform API tests
+    testSetString:
+      type: string
+      setPref: nimbus.testing.testSetString
+      description: A string pref set by Nimbus tests
+
+nimbus-qa-1:
+  description: A feature for testing pref-setting on the default branch.
+  owner: barret@mozilla.com
+  hasExposure: false
+  variables:
+    value:
+      type: string
+      setPref: nimbus.qa.pref-1
+      description: The value to set for the pref.
+
+nimbus-qa-2:
+  description: A feature for testing pref-setting on the user branch.
+  owner: barret@mozilla.com
+  isEarlyStartup: true
+  hasExposure: false
+  variables:
+    value:
+      type: string
+      setPref: nimbus.qa.pref-2
+      description: The value to set for the pref.
+
+# `search` is for search engine experimentation features which do not require
+# isEarlyStartup to be set.
+search:
+  description: Search engine experimentation support and testing features.
+  owner: search-and-suggest-program@mozilla.com
+  hasExposure: false
+  variables:
+    extraParams:
+      type: json
+      description: >-
+        This allows extra parameters to be set for search engines requests including,
+        where calls to the suggestions API, the search engine configuration defines
+        those parameters.
+
+        The use of this field should be coordinated with the Search team.
+
+        The field value is an array of objects with key/value fields. For example:
+
+        [
+          {"key": "google_channel_row", "value": "foo"}
+        ]
+
+        This is matched to a section in the search configuration:
+
+        "extraParams": [
+          {
+            "name": "channel",
+            "pref": "google_channel_row",
+            "condition": "pref"
+          }
+        ],
+
+        In this case, the resulting URL for the appropriate search engine would have
+        `&channel=foo` added to the URL when doing searches.
+
+        If the key is not referenced in the search configuration, then no parameter
+        will be added. Only the search team can update the configuration.
+    cbhStudyUs:
+      type: string
+      setPref: browser.search.param.google_channel_us
+      description: >-
+        NOTE: Please use `extraParams` rather than this field.
+        A string pref set by Nimbus tests for US search cohort
+    cbhStudyRow:
+      type: string
+      setPref: browser.search.param.google_channel_row
+      description: >-
+        NOTE: Please use `extraParams` rather than this field.
+        A string pref set by Nimbus tests for Rest of World (ROW) search cohort
+    richSuggestionsFeatureGate:
+      type: boolean
+      setPref: browser.urlbar.richSuggestions.featureGate
+      description: >-
+        Feature gate that controls whether Rich Suggestions are enabled.
+    serpEventTelemetryEnabled:
+      type: boolean
+      setPref: browser.search.serpEventTelemetry.enabled
+      description: Whether the Glean SERP event telemetry is enabled.
+    serpEventTelemetryCategorizationEnabled:
+      type: boolean
+      setPref: browser.search.serpEventTelemetryCategorization.enabled
+      description: Whether the Glean SERP event telemetry for SERP categorization is enabled.
+    trendingEnabled:
+      type: boolean
+      setPref: browser.urlbar.trending.featureGate
+      description: Feature gate that controls whether trending suggestions are enabled.
+    trendingRequireSearchMode:
+      type: boolean
+      setPref: browser.urlbar.trending.requireSearchMode
+      description: Controls whether trending suggestions are only shown in search mode or not.
+    trendingMaxResultsNoSearchMode:
+      type: int
+      setPref: browser.urlbar.trending.maxResultsNoSearchMode
+      description: The maximum number of trending results mode outside search mode.
+
+# `searchConfiguration` is for search experiment features for items that require
+# isEarlyStartup to be true. These items may require a reload of the search
+# engine configuration, and an additional reload may happen during the startup
+# process.
+searchConfiguration:
+  description: Search experimentation support for the engine configuration
+  owner: search-and-suggest-program@mozilla.com
+  isEarlyStartup: true
+  hasExposure: false
+  variables:
+    experiment:
+      type: string
+      fallbackPref: browser.search.experiment
+      description: >-
+        Used to activate only matching configurations that contain the value in
+        `experiment`
+    seperatePrivateDefaultUIEnabled:
+      type: boolean
+      description: Whether the UI for the separate private default feature is enabled.
+    seperatePrivateDefaultUrlbarResultEnabled:
+      type: boolean
+      description: Whether the urlbar result for the separate private default is shown.
+
+urlbar:
+  description: The Address Bar
+  owner: search-and-suggest-program@mozilla.com
+  hasExposure: true
+  exposureDescription: >-
+    The timing of the exposure event depends on the experiment, but generally
+    the event is recorded once per app session when the user first encounters
+    the UI of the experiment in which they're enrolled.
+  variables:
+    addonsFeatureGate:
+      type: boolean
+      fallbackPref: browser.urlbar.addons.featureGate
+      description: >-
+        Feature gate that controls whether all aspects of the addons suggestion
+        feature are exposed to the user.
+    addonsShowLessFrequentlyCap:
+      type: int
+      description: >-
+        If defined and non-zero, this is the maximum number of times the user
+        will be able to click the "Show less frequently" command for addon
+        suggestions. If undefined or zero, the user will be able to click the
+        command without any limit.
+    autoFillAdaptiveHistoryEnabled:
+      type: boolean
+      fallbackPref: browser.urlbar.autoFill.adaptiveHistory.enabled
+      description: Whether enabling adaptive history autofill.
+    autoFillAdaptiveHistoryMinCharsThreshold:
+      type: int
+      fallbackPref: browser.urlbar.autoFill.adaptiveHistory.minCharsThreshold
+      description: Minimum char length of the user's search string to trigger adaptive history autofill.
+    autoFillAdaptiveHistoryUseCountThreshold:
+      type: string
+      description: This value assumes float expression like "0.47". Threshold for use count of input history that we handle as adaptive history autofill. If the use count is this value or more, it will be a candidate.
+    experimentType:
+      type: string
+      description: The type of the experiment (or rollout). If "best-match", then the Nimbus exposure event will be recorded when the user first triggers a best match (or would have triggered a best match, for users in the control group). If "modal", the event will be recorded when the user first triggers to show the onbording dialog. If empty, the event will be recorded when the user first triggers any type of Suggest suggestion.
+      enum:
+        - best-match
+        - modal
+        - ""
+    mdnFeatureGate:
+      type: boolean
+      setPref: browser.urlbar.mdn.featureGate
+      description: >-
+        Feature gate that controls whether all aspects of the mdn suggestion
+        feature are exposed to the user.
+    merinoClientVariants:
+      type: string
+      fallbackPref: browser.urlbar.merino.clientVariants
+      description: >-
+        Comma separated list of client variants to report to the Merino server.
+        May impact server behavior.
+    merinoEndpointURL:
+      type: string
+      fallbackPref: browser.urlbar.merino.endpointURL
+      description: >-
+        The Merino endpoint URL, not including parameters. An empty string will
+        cause Firefox not to fetch from Merino.
+    merinoProviders:
+      type: string
+      fallbackPref: browser.urlbar.merino.providers
+      description: >-
+        Comma-separated list of providers to request from the Merino server.
+        Merino will return suggestions only for these providers.
+    merinoTimeoutMs:
+      type: int
+      fallbackPref: browser.urlbar.merino.timeoutMs
+      description: Timeout for Merino fetches (ms)
+    exposureResults:
+      type: string
+      setPref: browser.urlbar.exposureResults
+      description: >-
+        Comma-separated list of result type combinations, that are used to determine if an exposure event should be fired.
+    showExposureResults:
+      type: boolean
+      setPref: browser.urlbar.showExposureResults
+      description: >-
+        Boolean used to determine if the results defined in `exposureResults` should be shown in search results. Should be false for Control branch of an experiment.
+    pocketFeatureGate:
+      type: boolean
+      fallbackPref: browser.urlbar.pocket.featureGate
+      description: >-
+        Feature gate that controls whether all aspects of the Pocket suggestions
+        feature are exposed to the user.
+    pocketShowLessFrequentlyCap:
+      type: int
+      description: >-
+        If defined and non-zero, this is the maximum number of times the user
+        will be able to click the "Show less frequently" command for Pocket
+        suggestions. If undefined or zero, the user will be able to click the
+        command without any limit.
+    quickSuggestAllowPositionInSuggestions:
+      type: boolean
+      fallbackPref: browser.urlbar.quicksuggest.allowPositionInSuggestions
+      description: Whether quick suggest results can be shown in position specified in the suggestions.
+    quickSuggestDataCollectionEnabled:
+      type: boolean
+      description: Whether data collection should be enabled by default. If this variable is specified, it will override the value implied by the scenario. It will never override the user's local preference to disable (or enable) data collection, if the user has already toggled that preference.
+    quickSuggestEnabled:
+      type: boolean
+      fallbackPref: browser.urlbar.quicksuggest.enabled
+      description: Gate for the Firefox Suggest feature as a whole. If false, the Firefox Suggest preferences UI and Suggest suggestions will not be shown. If true, the preferences UI will be shown, and the user can turn suggestions on or off.
+    quickSuggestImpressionCapsSponsoredEnabled:
+      type: boolean
+      fallbackPref: browser.urlbar.quicksuggest.impressionCaps.sponsoredEnabled
+      description: Whether sponsored suggestions are subject to impression frequency caps. If false, sponsored suggestions can be shown an unlimited number of times over any given period. If true, sponsored suggestion impressions will be subject to the caps in the remote settings configuration.
+    quickSuggestImpressionCapsNonSponsoredEnabled:
+      type: boolean
+      fallbackPref: browser.urlbar.quicksuggest.impressionCaps.nonSponsoredEnabled
+      description: Whether non-sponsored suggestions are subject to impression frequency caps. If false, non-sponsored suggestions can be shown an unlimited number of times over any given period. If true, non-sponsored suggestion impressions will be subject to the caps in the remote settings configuration.
+    quickSuggestNonSponsoredEnabled:
+      type: boolean
+      description: Whether non-sponsored suggestions should be enabled by default. If this variable is specified, it will override the value implied by the scenario. It will never override the user's local preference to disable (or enable) non-sponsored suggestions, if the user has already toggled that preference.
+    quickSuggestNonSponsoredIndex:
+      type: int
+      fallbackPref: browser.urlbar.quicksuggest.nonSponsoredIndex
+      description: >-
+        The index of non-sponsored QuickSuggest results within the general
+        group. A negative index is relative to the end of the group
+    quickSuggestOnboardingDialogVariation:
+      type: string
+      description: >-
+        Specify the messages/UI variation for QuickSuggest onboarding dialog. This value is case insensitive.
+    quickSuggestRemoteSettingsDataType:
+      type: string
+      description: The `type` of the suggestions data in remote settings. If not specified, "data" is used.
+    quickSuggestRustEnabled:
+      type: boolean
+      fallbackPref: browser.urlbar.quicksuggest.rustEnabled
+      description: >-
+        Whether Firefox Suggest will use the new Rust backend instead of the
+        original JS backend.
+    quickSuggestScenario:
+      # IMPORTANT: This should not have a fallbackPref. See UrlbarPrefs.jsm.
+      type: string
+      description: The Firefox Suggest scenario in which the user is enrolled
+      enum:
+        - history
+        - offline
+        - online
+    quickSuggestScoreMap:
+      type: json
+      description: >-
+        A JSON object that maps telemetry result types to suggestion scores. If
+        a telemetry result type is present in this map, the client will use the
+        corresponding score as the score for all suggestions of the type,
+        overriding all other sources of scores for the type. In other words,
+        the scores in this map will override scores that are set in remote
+        settings and Merino as well as scores that are hardcoded in the client.
+        Example entries: `"amo": 0.5`, `"adm_sponsored": 0.9`
+    quickSuggestShouldShowOnboardingDialog:
+      type: boolean
+      fallbackPref: browser.urlbar.quicksuggest.shouldShowOnboardingDialog
+      description: Whether or not to show the QuickSuggest onboarding dialog
+    quickSuggestShowOnboardingDialogAfterNRestarts:
+      type: int
+      fallbackPref: browser.urlbar.quicksuggest.showOnboardingDialogAfterNRestarts
+      description: Show QuickSuggest onboarding dialog after N browser restarts
+    quickSuggestSponsoredEnabled:
+      type: boolean
+      description: Whether sponsored suggestions should be enabled by default. If this variable is specified, it will override the value implied by the scenario. It will never override the user's local preference to disable (or enable) sponsored suggestions, if the user has already toggled that preference.
+    quickSuggestSponsoredIndex:
+      type: int
+      fallbackPref: browser.urlbar.quicksuggest.sponsoredIndex
+      description: >-
+        The index of sponsored QuickSuggest results within the general group. A
+        negative index is relative to the end of the group
+    quickSuggestSponsoredPriority:
+      type: boolean
+      fallbackPref: browser.urlbar.quicksuggest.sponsoredPriority
+      description: >-
+        Whether or not showing sponsored suggestion as priority.
+        If this variable is true, the following things are processed.
+        * "Sponsored" label is shown as the group label.
+        * Change the suggested index to 1.
+        * Handle as top pick.
+    recentSearchesFeatureGate:
+      type: boolean
+      setPref: browser.urlbar.recentsearches.featureGate
+      description: Gate for the recent searches feature.
+    recentSearchesMaxResults:
+      type: int
+      setPref: browser.urlbar.recentsearches.maxResults
+      description: The maximum number of recent searches to show.
+    recordNavigationalSuggestionTelemetry:
+      type: boolean
+      description: Whether to record navigational suggestion telemetry. Defaults to false.
+    showSearchTermsFeatureGate:
+      type: boolean
+      fallbackPref: browser.urlbar.showSearchTerms.featureGate
+      description: Gate for the show search terms feature. If false, the preference#search will not show the search terms feature checkbox, and search terms will never persist in the urlbar. If true, the preference checkbox will be shown on preferences#search, and the user can choose to persist search terms on or off in the urlbar.
+    weatherFeatureGate:
+      type: boolean
+      fallbackPref: browser.urlbar.weather.featureGate
+      description: >-
+        Feature gate that controls whether all aspects of the weather suggestion
+        feature are exposed to the user. See also `weatherKeywords` and
+        `weatherKeywordsMinimumLength`. In summary: To enable the weather
+        suggestion, set `weatherFeatureGate` to true, `weatherKeywords` to an
+        array of full keyword strings, and `weatherKeywordsMinimumLength` to a
+        non-zero integer. To disable the weather suggestion, leave out all
+        weather-related variables.
+    weatherKeywords:
+      type: json
+      description: >-
+        An array of full keyword strings that will trigger the weather
+        suggestion when the user types them in the address bar. If absent or
+        null, Firefox will fall back to the weather keywords defined in remote
+        settings. If neither Nimbus nor remote settings defines any keywords,
+        the weather suggestion will be disabled. See also
+        `weatherKeywordsMinimumLength`.
+    weatherKeywordsMinimumLength:
+      type: int
+      description: >-
+        If defined and non-zero, the weather suggestion will be triggered by
+        typing any prefix of a full weather keyword when the prefix is at least
+        `weatherKeywordsMinimumLength` characters long. If this variable is
+        absent or zero, Firefox will fall back to the minimum length defined in
+        remote settings. If neither Nimbus nor remote settings defines a minimum
+        length, only full keywords will trigger the suggestion. See also
+        `weatherKeywords`.
+    weatherKeywordsMinimumLengthCap:
+      type: int
+      description: >-
+        If defined and non-zero, the user will not be able to increment the
+        minimum keyword length beyond this value. e.g., if this value is 6, the
+        current minimum length is 5, and the user clicks "Show less frequently",
+        then the minimum length will be incremented to 6, the "Show less
+        frequently" command will be hidden, and the user can continue to trigger
+        the weather suggestion by typing 6 characters, but they will not be able
+        to increment the minimum length any further. If this variable is absent
+        or zero, Firefox will fall back to the cap defined in remote settings.
+        If neither Nimbus nor remote settings defines a cap, no cap will be
+        used, and the user will be able to increment the minimum length without
+        any limit.
+
+frecency:
+  description: "The address bar ranking algorithm"
+  owner: search-and-suggest-program@mozilla.com
+  hasExposure: false
+  isEarlyStartup: true
+  variables:
+    originsAlternativeEnable:
+      description: >-
+        Use an alternative ranking algorithm for autofilling origins, that is
+        mainly domains of Web pages. When the user types the beginning of an
+        origin, we autofill the whole origin. Whether autofill happens depends
+        on the ranking algorithm. Bookmarks are always autofilled anyway.
+      type: boolean
+      setPref: "places.frecency.origins.alternative.featureGate"
+    originsDaysCutOff:
+      description: >-
+        The alternative ranking algorithm only considers pages visited in the
+        last N days, where N is controlled by this variable.
+      type: int
+      setPref: "places.frecency.origins.alternative.daysCutOff"
+    pagesAlternativeEnable:
+      description: >-
+        Use an alternative ranking algorithm for sorting history and bookmarks
+        among the urlbar results.
+      type: boolean
+      setPref: "places.frecency.pages.alternative.featureGate"
+    pagesNumSampledVisits:
+      description: >-
+        The number of recent visits to sample when calculating the ranking of
+        a page. Examining all the visits would be expensive, so we only sample
+        recent visits.
+      type: int
+      setPref: "places.frecency.pages.alternative.numSampledVisits"
+    pagesHalfLifeDays:
+      description: >-
+        The number of days after which the ranking halves. This implements the
+        "recency" part of the algorithm.
+      type: int
+      setPref: "places.frecency.pages.alternative.halfLifeDays"
+    pagesHighWeight:
+      description: >-
+        The weight to use for the high importance bucket.
+      type: int
+      setPref: "places.frecency.pages.alternative.highWeight"
+    pagesMediumWeight:
+      description: >-
+        The weight to use for the medium importance bucket.
+      type: int
+      setPref: "places.frecency.pages.alternative.mediumWeight"
+    pagesLowWeight:
+      description: >-
+        The weight to use for the low importance bucket.
+      type: int
+      setPref: "places.frecency.pages.alternative.lowWeight"
+
+aboutwelcome:
+  description: "The about:welcome page"
+  owner: omc@mozilla.com
+  hasExposure: true
+  exposureDescription: >-
+    Exposure is sent once per browsing session when the about:welcome URL is
+    first accessed.
+  isEarlyStartup: true
+  variables:
+    enabled:
+      type: boolean
+      fallbackPref: browser.aboutwelcome.enabled
+      description: >-
+        Should users see about:welcome? If this is false, users will see a
+        regular new tab instead.
+    id:
+      type: string
+      description: >-
+        Descriptive ID for the about:welcome content
+    screens:
+      type: json
+      fallbackPref: browser.aboutwelcome.screens
+      description: Content to show in the onboarding flow
+    languageMismatchEnabled:
+      type: boolean
+      fallbackPref: intl.multilingual.aboutWelcome.languageMismatchEnabled
+      description: >-
+        Suggest to change the language on about:welcome when there is a mismatch with
+        the OS.
+    transitions:
+      type: boolean
+      description: Enable transition effect between screens
+    showModal:
+      type: boolean
+      fallbackPref: browser.aboutwelcome.showModal
+      description: >-
+        Should users see window modal onboarding
+    backdrop:
+      type: string
+      fallbackPref: browser.aboutwelcome.backdrop
+      description: >-
+        Specify the color to be used to update the background color
+
+moreFromMozilla:
+  description: "New page on about:preferences to suggest more Mozilla products"
+  owner: omc@mozilla.com
+  hasExposure: true
+  exposureDescription: >-
+    Exposure is sent once per browsing session when the about:preferences URL is
+    first accessed.
+  variables:
+    enabled:
+      type: boolean
+      fallbackPref: browser.preferences.moreFromMozilla
+      description: Should users see the new more from Mozilla section.
+    template:
+      type: string
+      fallbackPref: browser.preferences.moreFromMozilla.template
+      description: UI template used to display Mozilla products. Possible values simple, advanced. Default is simple.
+
+windowsLaunchOnLogin:
+  description: "New checkbox in about:preferences startup section to start Firefox on Windows login"
+  owner: omc@mozilla.com
+  hasExposure: true
+  exposureDescription: >-
+    Exposure is sent once per browsing session when the about:preferences URL is
+    first accessed.
+  variables:
+    enabled:
+      type: boolean
+      setPref: browser.startup.windowsLaunchOnLogin.enabled
+      description: Should users see the Windows launch on login checkbox.
+
+abouthomecache:
+  description: "The startup about:home cache."
+  owner: omc@mozilla.com
+  hasExposure: false
+  isEarlyStartup: true
+  variables:
+    enabled:
+      type: boolean
+      fallbackPref: browser.startup.homepage.abouthome_cache.enabled
+      description: Is the feature enabled?
+
+newtab:
+  description: "The about:newtab page"
+  owner: omc@mozilla.com
+  hasExposure: true
+  exposureDescription: >-
+    Exposure is sent once per browsing session when the first newtab page loads
+    (either about:newtab or about:home).
+  isEarlyStartup: true
+  variables:
+    newTheme:
+      type: boolean
+      description: Enable the new theme
+    customizationMenuEnabled:
+      type: boolean
+      fallbackPref: browser.newtabpage.activity-stream.customizationMenu.enabled
+      description: Enable the customization panel inside of the newtab
+    prefsButtonIcon:
+      type: string
+      description: Icon url to use for the preferences button
+    topSitesContileEnabled:
+      type: boolean
+      fallbackPref: browser.topsites.contile.enabled
+      description: Enable the Contile integration for Sponsored Top Sites
+    topSitesUseAdditionalTilesFromContile:
+      type: boolean
+      description: Allow Contile to use additonal sponsored top sites
+
+pocketNewtab:
+  description: The Pocket section in newtab
+  owner: sdowne@getpocket.com
+  hasExposure: false
+  isEarlyStartup: true
+  variables:
+    spocPositions:
+      type: string
+      fallbackPref: browser.newtabpage.activity-stream.discoverystream.spoc-positions
+      description: CSV string of spoc position indexes on newtab Pocket grid
+    spocTopsitesPositions:
+      type: string
+      fallbackPref: browser.newtabpage.activity-stream.discoverystream.spoc-topsites-positions
+      description: CSV string of spoc position indexes on newtab topsites section
+    spocAdTypes:
+      type: string
+      fallbackPref: browser.newtabpage.activity-stream.discoverystream.spocAdTypes
+      description: CSV string of data to set the spoc content.
+    spocZoneIds:
+      type: string
+      fallbackPref: browser.newtabpage.activity-stream.discoverystream.spocZoneIds
+      description: CSV string of data to set the spoc content.
+    spocTopsitesAdTypes:
+      type: string
+      fallbackPref: browser.newtabpage.activity-stream.discoverystream.spocTopsitesAdTypes
+      description: CSV string of data to set the spoc content.
+    spocTopsitesZoneIds:
+      type: string
+      fallbackPref: browser.newtabpage.activity-stream.discoverystream.spocTopsitesZoneIds
+      description: CSV string of data to set the spoc content.
+    spocTopsitesPlacementEnabled:
+      type: boolean
+      fallbackPref: browser.newtabpage.activity-stream.discoverystream.spocTopsitesPlacement.enabled
+      description: Tuns on and off the sponsored topsites placement.
+    spocSiteId:
+      type: string
+      fallbackPref: browser.newtabpage.activity-stream.discoverystream.spocSiteId
+      description: String ID to set the spoc content.
+    widgetPositions:
+      type: string
+      fallbackPref: browser.newtabpage.activity-stream.discoverystream.widget-positions
+      description: CSV string of widget position indexes on newtab grid
+    hybridLayout:
+      type: boolean
+      fallbackPref: browser.newtabpage.activity-stream.discoverystream.hybridLayout.enabled
+      description: Enable compact cards on newtab grid only for specific breakpoints
+    hideCardBackground:
+      type: boolean
+      fallbackPref: browser.newtabpage.activity-stream.discoverystream.hideCardBackground.enabled
+      description: Removes Pocket card background and borders.
+    fourCardLayout:
+      type: boolean
+      fallbackPref: browser.newtabpage.activity-stream.discoverystream.fourCardLayout.enabled
+      description: Enable four Pocket cards per row.
+    newFooterSection:
+      type: boolean
+      fallbackPref: >-
+        browser.newtabpage.activity-stream.discoverystream.newFooterSection.enabled
+      description: Enable an updated Pocket section topics footer
+    saveToPocketCard:
+      type: boolean
+      fallbackPref: >-
+        browser.newtabpage.activity-stream.discoverystream.saveToPocketCard.enabled
+      description: >-
+        A save to Pocket button inside the card, shown on the card thumbnail, on
+        hover.
+    saveToPocketCardRegions:
+      type: string
+      fallbackPref: >-
+        browser.newtabpage.activity-stream.discoverystream.saveToPocketCardRegions
+      description: >-
+        CSV string of regions that support the save to Pocket button inside the card.
+    hideDescriptions:
+      type: boolean
+      fallbackPref: >-
+        browser.newtabpage.activity-stream.discoverystream.hideDescriptions.enabled
+      description: >-
+        Hide or display descriptions for Pocket stories on newtab.
+    hideDescriptionsRegions:
+      type: string
+      fallbackPref: >-
+        browser.newtabpage.activity-stream.discoverystream.hideDescriptionsRegions
+      description: >-
+        CSV string of regions that hide descriptions for Pocket stories on newtab.
+    compactGrid:
+      type: boolean
+      fallbackPref: >-
+        browser.newtabpage.activity-stream.discoverystream.compactGrid.enabled
+      description: >-
+        Reduce the number of pixels between the Pocket cards on newtab.
+    compactImages:
+      type: boolean
+      fallbackPref: >-
+        browser.newtabpage.activity-stream.discoverystream.compactImages.enabled
+      description: >-
+        Reduce the height on Pocket card images on newtab.
+    imageGradient:
+      type: boolean
+      fallbackPref: >-
+        browser.newtabpage.activity-stream.discoverystream.imageGradient.enabled
+      description: >-
+        Add a gradient to the bottom of Pocket card images on newtab to blend the
+        image in with the card.
+    titleLines:
+      type: int
+      fallbackPref: >-
+        browser.newtabpage.activity-stream.discoverystream.titleLines
+      description: >-
+        Changes the maximum number of lines a title can be for Pocket cards on newtab.
+    descLines:
+      type: int
+      fallbackPref: >-
+        browser.newtabpage.activity-stream.discoverystream.descLines
+      description: >-
+        Changes the maximum number of lines a description can be for Pocket cards on newtab.
+    onboardingExperience:
+      type: boolean
+      fallbackPref: >-
+        browser.newtabpage.activity-stream.discoverystream.onboardingExperience.enabled
+      description: >-
+        Enables an onboarding experience for Pocket section on newtab.
+    essentialReadsHeader:
+      type: boolean
+      fallbackPref: >-
+        browser.newtabpage.activity-stream.discoverystream.essentialReadsHeader.enabled
+      description: >-
+        Updates the Pocket section header and title to say "Today’s Essential Reads",
+        moves the "Recommended by Pocket" header to the right side.
+    editorsPicksHeader:
+      type: boolean
+      fallbackPref: >-
+        browser.newtabpage.activity-stream.discoverystream.editorsPicksHeader.enabled
+      description: >-
+        Updates the Pocket section header and title to say "Editor’s Picks", if used with
+        essentialReadsHeader, creates a second section 2 rows down for editorsPicksHeader.
+    recentSavesEnabled:
+      type: boolean
+      fallbackPref: >-
+        browser.newtabpage.activity-stream.discoverystream.recentSaves.enabled
+      description: >-
+        Updates the Pocket section with a new header and 1 row of recently saved Pocket stories.
+    readTime:
+      type: boolean
+      fallbackPref: >-
+        browser.newtabpage.activity-stream.discoverystream.readTime.enabled
+      description: >-
+        Displays an estimated read time for Pocket cards on newtab.
+    newSponsoredLabel:
+      type: boolean
+      fallbackPref: >-
+        browser.newtabpage.activity-stream.discoverystream.newSponsoredLabel.enabled
+      description: >-
+        Updates the sponsored label position to below the image for Pocket cards on newtab.
+    sendToPocket:
+      type: boolean
+      fallbackPref: >-
+        browser.newtabpage.activity-stream.discoverystream.sendToPocket.enabled
+      description: >-
+        Decides what to do when a logged out user click "Save to Pocket" from a Pocket card.
+    recsPersonalized:
+      type: boolean
+      fallbackPref: >-
+        browser.newtabpage.activity-stream.discoverystream.recs.personalized
+      description: >-
+        Enables Pocket stories personalization.
+    spocsPersonalized:
+      type: boolean
+      fallbackPref: >-
+        browser.newtabpage.activity-stream.discoverystream.spocs.personalized
+      description: >-
+        Enables Pocket sponsored content personalization.
+    spocsCacheTimeout:
+      type: int
+      fallbackPref: >-
+        browser.newtabpage.activity-stream.discoverystream.spocs.cacheTimeout
+      description: >-
+        Set sponsored content cache timeout in minutes.
+    discoveryStreamConfig:
+      description: A JSON blob of discovery stream configuration.
+      type: string
+      setPref: "browser.newtabpage.activity-stream.discoverystream.config"
+    spocsEndpoint:
+      description: The URL for the spocs endpoint.
+      type: string
+      setPref: "browser.newtabpage.activity-stream.discoverystream.spocs-endpoint"
+    regionStoriesConfig:
+      description: A comma-separated list of region to get stories for.
+      type: string
+      fallbackPref: >-
+        browser.newtabpage.activity-stream.discoverystream.region-stories-config
+    regionBffConfig:
+      type: string
+      fallbackPref: >-
+        browser.newtabpage.activity-stream.discoverystream.region-bff-config
+      description: A comma-separated list of regions to get stories from the recommendations BFF. Also requires region-stories-config.
+    regionStoriesBlock:
+      description: A comma-separated list of regions that do not get stories, regardless of locale-list-config.
+      type: string
+      fallbackPref: >-
+        browser.newtabpage.activity-stream.discoverystream.region-stories-block
+    localeListConfig:
+      description: A comma-separated list of locales that get stories, regardless of region-stories-config.
+      type: string
+      fallbackPref: >-
+        browser.newtabpage.activity-stream.discoverystream.locale-list-config
+    regionSpocsConfig:
+      description: A comma-separated list of regions that get spocs by default.
+      type: string
+      fallbackPref: >-
+        browser.newtabpage.activity-stream.discoverystream.region-spocs-config
+    topSitesMaxSponsored:
+      # Defined under `pocketNewtab` as it needs to be used along with other variables
+      type: int
+      description: The maximum number of sponsored Top Sites to be displayed
+    topSitesContileMaxSponsored:
+      # Defined under `pocketNewtab` as it needs to be used along with other variables
+      type: int
+      description: The maximum number of sponsored Top Sites used from Contile
+    topSitesContileSovEnabled:
+      # Defined under `pocketNewtab` as it needs to be used along with other variables
+      description: Enable the Share-of-Voice feature for Sponsored Topsites.
+      type: boolean
+      fallbackPref: >-
+        browser.topsites.contile.sov.enabled
+
+saveToPocket:
+  description: The save to Pocket feature
+  owner: sdowne@getpocket.com
+  hasExposure: false
+  isEarlyStartup: true
+  variables:
+    emailButton:
+      type: boolean
+      fallbackPref: extensions.pocket.refresh.emailButton.enabled
+      description: Just for the new Pocket panels, enables the email signup button.
+    hideRecentSaves:
+      type: boolean
+      fallbackPref: extensions.pocket.refresh.hideRecentSaves.enabled
+      description: Hides the recently saved section in the home panel.
+    bffRecentSaves:
+      type: boolean
+      fallbackPref: "extensions.pocket.bffRecentSaves"
+      description: Use the new BFF Proxy Service instead of the legacy Pocket Service for Recent Saves
+    bffApi:
+      type: string
+      fallbackPref: "extensions.pocket.bffApi"
+      description: BFF Proxy Service domain
+    oAuthConsumerKeyBff:
+      type: string
+      fallbackPref: "extensions.pocket.oAuthConsumerKeyBff"
+      description: BFF Proxy Service OAuth Consumer Key
+
+password-autocomplete:
+  description: A special autocomplete UI for password fields.
+  owner: sgalich@mozilla.com
+  hasExposure: false
+  variables:
+    directMigrateSingleProfile:
+      type: boolean
+      description: Enable direct migration?
+
+cm-csv-import:
+  description: Importing logins from CSV files
+  owner: issozi@mozilla.com
+  hasExposure: false
+  variables:
+    csvImport:
+      type: boolean
+      description: Can show CSV Import in about:logins or Migration Wizard
+      setPref: "signon.management.page.fileImport.enabled"
+
+shellService:
+  description: "Interface with OS, e.g., pinning and set default"
+  owner: desktop-integrations@mozilla.com
+  hasExposure: false
+  isEarlyStartup: true
+  variables:
+    disablePin:
+      type: boolean
+      description: Disable pin to taskbar feature
+    setDefaultBrowserUserChoice:
+      type: boolean
+      fallbackPref: browser.shell.setDefaultBrowserUserChoice
+      description: Should it set as default browser
+    setDefaultPDFHandler:
+      type: boolean
+      fallbackPref: browser.shell.setDefaultPDFHandler
+      description: Should setting it as the default browser set it as the default PDF handler.
+    setDefaultPDFHandlerOnlyReplaceBrowsers:
+      type: boolean
+      fallbackPref: browser.shell.setDefaultPDFHandler.onlyReplaceBrowsers
+      description: >-
+        Should setting it as the default PDF handler only replace existing PDF
+        handlers that are browsers, and not other PDF handlers such as Acrobat
+        Reader or Nitro PDF.
+
+upgradeDialog:
+  description: The dialog shown for major upgrades
+  owner: omc@mozilla.com
+  hasExposure: false
+  isEarlyStartup: true
+  variables:
+    enabled:
+      type: boolean
+      fallbackPref: browser.startup.upgradeDialog.enabled
+      description: Is the feature enabled?
+
+cfr:
+  description: "A Firefox Messaging System message for the cfr message channel"
+  owner: omc@mozilla.com
+  hasExposure: true
+  exposureDescription: "Exposure is sent if the message is about to be shown after trigger and targeting conditions on the message matched."
+  isEarlyStartup: false
+  schema:
+    uri: "resource://activity-stream/schemas/MessagingExperiment.schema.json"
+    path: "browser/components/newtab/content-src/asrouter/schemas/MessagingExperiment.schema.json"
+  variables: {}
+
+"moments-page":
+  description: "A Firefox Messaging System message for the moments-page message channel"
+  owner: omc@mozilla.com
+  hasExposure: true
+  exposureDescription: >-
+    "Exposure is sent if the message is about to be shown after trigger and targeting conditions on the message matched."
+  isEarlyStartup: false
+  schema:
+    uri: "resource://activity-stream/schemas/MessagingExperiment.schema.json"
+    path: "browser/components/newtab/content-src/asrouter/schemas/MessagingExperiment.schema.json"
+  variables: {}
+
+infobar:
+  description: "A Firefox Messaging system message for the infobar message channel"
+  owner: omc@mozilla.com
+  hasExposure: true
+  exposureDescription: >-
+    "Exposure is sent if the message is about to be shown after trigger and targeting conditions on the message matched."
+  isEarlyStartup: false
+  schema:
+    uri: "resource://activity-stream/schemas/MessagingExperiment.schema.json"
+    path: "browser/components/newtab/content-src/asrouter/schemas/MessagingExperiment.schema.json"
+  variables: {}
+
+spotlight:
+  description: "A Firefox Messaging System message for the spotlight message channel"
+  owner: omc@mozilla.com
+  hasExposure: true
+  exposureDescription: >-
+    "Exposure is sent if the message is about to be shown after trigger and targeting conditions on the message matched."
+  isEarlyStartup: false
+  schema:
+    uri: "resource://activity-stream/schemas/MessagingExperiment.schema.json"
+    path: "browser/components/newtab/content-src/asrouter/schemas/MessagingExperiment.schema.json"
+  variables: {}
+
+# Before 117, this feature only included one variable, pdfJsTourProgress. So,
+# the minimum version for messaging experiments using this feature ID is 117.
+featureCallout:
+  description: "A Firefox Messaging System message for the Feature Callout message channel"
+  owner: omc@mozilla.com
+  hasExposure: true
+  exposureDescription: >-
+    "Exposure is sent if the message is about to be shown after trigger and targeting conditions on the message matched."
+  isEarlyStartup: false
+  schema:
+    uri: "resource://activity-stream/schemas/MessagingExperiment.schema.json"
+    path: "browser/components/newtab/content-src/asrouter/schemas/MessagingExperiment.schema.json"
+  variables: {}
+
+fullPageTranslation:
+  description: This feature opens a popup panel to offer to translate a page.
+  owner: gtatum@mozilla.com
+  hasExposure: false
+  isEarlyStartup: true
+  variables:
+    boolean:
+      description: Set to true to enable the translations feature
+      type: boolean
+      setPref: browser.translations.enable
+
+fullPageTranslationAutomaticPopup:
+  description: Controls whether the popup automatically shows for translations.
+  owner: gtatum@mozilla.com
+  hasExposure: false
+  isEarlyStartup: true
+  variables:
+    boolean:
+      description: Set to true to automatically popup, and false to only show the button.
+      type: boolean
+      setPref: browser.translations.automaticallyPopup
+
+addAnImageInPDF:
+  description: Add an image in an existing pdf.
+  owner: cdenizet@mozilla.com
+  hasExposure: false
+  variables:
+    boolean:
+      description: Set to true to enable the add-an-image feature
+      type: boolean
+      setPref: pdfjs.enableStampEditor
+
+# fxms-message-* placeholder feature ids
+#
+# https://docs.google.com/spreadsheets/d/119YbeKStLL0Fg2QkK-yN93mrtD1rlneGZGTl_jAwtyw/edit#gid=1903378504
+# has info on using these placeholder feature ids, as well as (very short) instructions on
+# checking to see if we need more (which we do once per Nightly) and how to add them.
+#
+# Instructions for adding a new fxms-message-* placeholder feature id
+# 1) clone an existing one here
+# 2) update the YAML feature id to the next unused number
+# 3) update the YAML description
+# 4) add the new feature id to MESSAGING_EXPERIMENTS_DEFAULT_FEATURES list in MessagingExperimentConstants.sys.mjs
+# 5) add the new feature id and the version it landed to the spreadsheet tab linked to above
+
+fxms-message-1:
+  description: "A Firefox Messaging System message"
+  owner: omc@mozilla.com
+  hasExposure: true
+  exposureDescription: >-
+    "Exposure is sent if the message is about to be shown after trigger and targeting conditions on the message matched."
+  isEarlyStartup: false
+  schema:
+    uri: "resource://activity-stream/schemas/MessagingExperiment.schema.json"
+    path: "browser/components/newtab/content-src/asrouter/schemas/MessagingExperiment.schema.json"
+  variables: {}
+
+fxms-message-2:
+  description: "Firefox Messaging System message 2"
+  owner: omc@mozilla.com
+  hasExposure: true
+  exposureDescription: >-
+    "Exposure is sent if the message is about to be shown after trigger and targeting conditions on the message matched."
+  isEarlyStartup: false
+  schema:
+    uri: "resource://activity-stream/schemas/MessagingExperiment.schema.json"
+    path: "browser/components/newtab/content-src/asrouter/schemas/MessagingExperiment.schema.json"
+  variables: {}
+
+fxms-message-3:
+  description: "Firefox Messaging System message 3"
+  owner: omc@mozilla.com
+  hasExposure: true
+  exposureDescription: >-
+    "Exposure is sent if the message is about to be shown after trigger and targeting conditions on the message matched."
+  isEarlyStartup: false
+  schema:
+    uri: "resource://activity-stream/schemas/MessagingExperiment.schema.json"
+    path: "browser/components/newtab/content-src/asrouter/schemas/MessagingExperiment.schema.json"
+  variables: {}
+
+fxms-message-4:
+  description: "Firefox Messaging System message 4"
+  owner: omc@mozilla.com
+  hasExposure: true
+  exposureDescription: >-
+    "Exposure is sent if the message is about to be shown after trigger and targeting conditions on the message matched."
+  isEarlyStartup: false
+  schema:
+    uri: "resource://activity-stream/schemas/MessagingExperiment.schema.json"
+    path: "browser/components/newtab/content-src/asrouter/schemas/MessagingExperiment.schema.json"
+  variables: {}
+
+fxms-message-5:
+  description: "Firefox Messaging System message 5"
+  owner: omc@mozilla.com
+  hasExposure: true
+  exposureDescription: >-
+    "Exposure is sent if the message is about to be shown after trigger and targeting conditions on the message matched."
+  isEarlyStartup: false
+  schema:
+    uri: "resource://activity-stream/schemas/MessagingExperiment.schema.json"
+    path: "browser/components/newtab/content-src/asrouter/schemas/MessagingExperiment.schema.json"
+  variables: {}
+
+fxms-message-6:
+  description: "Firefox Messaging System message 6"
+  owner: omc@mozilla.com
+  hasExposure: true
+  exposureDescription: >-
+    "Exposure is sent if the message is about to be shown after trigger and targeting conditions on the message matched."
+  isEarlyStartup: false
+  schema:
+    uri: "resource://activity-stream/schemas/MessagingExperiment.schema.json"
+    path: "browser/components/newtab/content-src/asrouter/schemas/MessagingExperiment.schema.json"
+  variables: {}
+
+fxms-message-7:
+  description: "Firefox Messaging System message 7"
+  owner: omc@mozilla.com
+  hasExposure: true
+  exposureDescription: >-
+    "Exposure is sent if the message is about to be shown after trigger and targeting conditions on the message matched."
+  isEarlyStartup: false
+  schema:
+    uri: "resource://activity-stream/schemas/MessagingExperiment.schema.json"
+    path: "browser/components/newtab/content-src/asrouter/schemas/MessagingExperiment.schema.json"
+  variables: {}
+
+fxms-message-8:
+  description: "Firefox Messaging System message 8"
+  owner: omc@mozilla.com
+  hasExposure: true
+  exposureDescription: >-
+    "Exposure is sent if the message is about to be shown after trigger and targeting conditions on the message matched."
+  isEarlyStartup: false
+  schema:
+    uri: "resource://activity-stream/schemas/MessagingExperiment.schema.json"
+    path: "browser/components/newtab/content-src/asrouter/schemas/MessagingExperiment.schema.json"
+  variables: {}
+
+fxms-message-9:
+  description: "Firefox Messaging System message 9"
+  owner: omc@mozilla.com
+  hasExposure: true
+  exposureDescription: >-
+    "Exposure is sent if the message is about to be shown after trigger and targeting conditions on the message matched."
+  isEarlyStartup: false
+  schema:
+    uri: "resource://activity-stream/schemas/MessagingExperiment.schema.json"
+    path: "browser/components/newtab/content-src/asrouter/schemas/MessagingExperiment.schema.json"
+  variables: {}
+
+fxms-message-10:
+  description: "Firefox Messaging System message 10"
+  owner: omc@mozilla.com
+  hasExposure: true
+  exposureDescription: >-
+    "Exposure is sent if the message is about to be shown after trigger and targeting conditions on the message matched."
+  isEarlyStartup: false
+  schema:
+    uri: "resource://activity-stream/schemas/MessagingExperiment.schema.json"
+    path: "browser/components/newtab/content-src/asrouter/schemas/MessagingExperiment.schema.json"
+  variables: {}
+
+fxms-message-11:
+  description: "Firefox Messaging System message 11"
+  owner: omc@mozilla.com
+  hasExposure: true
+  exposureDescription: >-
+    "Exposure is sent if the message is about to be shown after trigger and targeting conditions on the message matched."
+  isEarlyStartup: false
+  schema:
+    uri: "resource://activity-stream/schemas/MessagingExperiment.schema.json"
+    path: "browser/components/newtab/content-src/asrouter/schemas/MessagingExperiment.schema.json"
+  variables: {}
+
+pbNewtab:
+  description: "A Firefox Messaging System message for the pbNewtab message channel"
+  owner: omc@mozilla.com
+  hasExposure: true
+  exposureDescription: >-
+    Exposure is sent if the message is about to be shown after trigger and targeting conditions on the message matched.
+  isEarlyStartup: false
+  schema:
+    uri: "resource://activity-stream/schemas/MessagingExperiment.schema.json"
+    path: "browser/components/newtab/content-src/asrouter/schemas/MessagingExperiment.schema.json"
+  variables: {}
+
+backgroundTaskMessage:
+  description: "A Firefox Messaging System message for the background task message channel"
+  owner: nalexander@mozilla.com
+  applications:
+    - firefox-desktop-background-task
+  hasExposure: true
+  exposureDescription: >-
+    Exposure is sent if the message is about to be shown after trigger and targeting conditions on the message matched.
+  isEarlyStartup: false
+  schema:
+    uri: "resource://activity-stream/schemas/BackgroundTaskMessagingExperiment.schema.json"
+    path: "browser/components/newtab/content-src/asrouter/schemas/BackgroundTaskMessagingExperiment.schema.json"
+  variables: {}
+
+pictureinpicture:
+  description: Message for first time Picture-in-Picture users
+  owner: nbaumgardner@mozilla.com
+  hasExposure: true
+  exposureDescription: Exposure is sent when a user hovers over a video and Picture-in-Picture has not been used before
+  variables:
+    title:
+      type: string
+      description: The title to be used for the PiP toggle
+    message:
+      type: string
+      description: The message to be used in the PiP toggle
+    showIconOnly:
+      type: boolean
+      description: Whether to show the first time PiP toggle or show the PiP icon only
+    oldToggle:
+      type: boolean
+      description: Whether to show the control style (true) or variant style (false) for the first time PiP toggle
+    displayDuration:
+      type: int
+      description: Duration of PiP first time toggle display in days before switching to PiP icon toggle
+
+glean:
+  description: "The Glean data-control-plane feature within Firefox Desktop for controlling metric configuration"
+  owner: glean-team@mozilla.com
+  hasExposure: false
+  variables:
+    newtabPingEnabled:
+      type: "boolean"
+      fallbackPref: "browser.newtabpage.ping.enabled"
+      description: "Whether to submit the 'newtab' ping"
+    gleanMetricConfiguration:
+      type: json
+      description: |
+        A map of metric base-identifiers to booleans representing the state of the 'enabled' flag for that metric.
+        This variable is intended for interacting with the Glean data-control-plane via the Server Knobs functionality
+        to remotely configure metrics to be enabled or disabled.
+
+gleanInternalSdk:
+  description: "The Glean internal SDK feature intended only for internal Glean Team use"
+  hasExposure: false
+  # Some variables are used through the C++ API and thus require pref-storage.
+  # We rely on those values at Glean.init time, which happens at startup.
+  isEarlyStartup: true
+  variables:
+    finalInactive:
+      type: "boolean"
+      description: "Enables FOG early shutdown pings when true"
+    gleanMetricConfiguration:
+      type: json
+      description: |
+        A map of metric base-identifiers to booleans representing the state of the 'enabled' flag for that metric.
+        This is not for public use! For data-control-plane use, please refer to the Glean documentation and use the
+        `gleanMetricConfiguration` found in the `glean` feature for this.
+    gleanMaxPingsPerMinute:
+      type: int
+      description: >-
+        Maximum number of pings that can be sent in a 60 second interval
+    enableEventTimestamps:
+      type: "boolean"
+      description: "Enables precise event timestamps for Glean events"
+
+majorRelease2022:
+  description: Major Release 2022
+  owner: firefoxview@mozilla.com
+  hasExposure: false
+  isEarlyStartup: true
+  variables:
+    feltPrivacyPBMDarkTheme:
+      type: boolean
+      fallbackPref: "browser.theme.dark-private-windows"
+      description: "Use dark theme variant for PBM windows. This is only supported if the theme sets darkTheme data."
+    feltPrivacyShowPreferencesSection:
+      type: boolean
+      fallbackPref: "browser.privacySegmentation.preferences.show"
+      description: "Controls visibility of the privacy segmentation preferences section."
+    feltPrivacyWindowSeparation:
+      type: boolean
+      fallbackPref: "browser.privateWindowSeparation.enabled"
+      description: "Whether or not private browsing windows use a separate icon in the Windows taskbar"
+    colorwayCloset:
+      type: boolean
+      fallbackPref: "browser.theme.colorway-closet"
+      description: "Whether or not to show the colorway closet modal"
+    firefoxView:
+      type: boolean
+      fallbackPref: "browser.tabs.firefox-view"
+      description: "Whether or not to show the firefox view tab"
+    onboarding:
+      type: boolean
+      fallbackPref: "browser.majorrelease.onboarding"
+      description: "Whether or not to use the MR2022 onboarding settings."
+
+browserLowMemoryPrefs:
+  description: Prefs which control the browser's behaviour under low memory.
+  owner: haftandilian@mozilla.com
+  hasExposure: false
+  variables:
+    lowMemoryResponseMask:
+      description: Control the response on macOS when under memory pressure.
+      type: int
+      setPref: "browser.lowMemoryResponseMask"
+    lowMemoryResponseOnWarn:
+      description: Controls which macOS memory-pressure levels trigger the browser low memory response.
+      type: boolean
+      setPref: "browser.lowMemoryResponseOnWarn"
+    tabsUnloadOnLowMemory:
+      description: Whether to unload tabs when available memory is running low.
+      type: boolean
+      setPref: "browser.tabs.unloadOnLowMemory"
+
+scriptLoaderPrefs:
+  description: Prefs that control the script loader.
+  owner: npierron@mozilla.com
+  hasExposure: false
+  variables:
+    delazificationStrategy:
+      description: >-
+        Selects which parsing/delazification strategy should be used while
+        parsing scripts off-main-thread. See DelazificationOption in
+        CompileOptions.h for values.
+      type: int
+      setPref: "dom.script_loader.delazification.strategy"
+
+echPrefs:
+  description: Prefs that control Encrypted Client Hello.
+  owner: djackson@mozilla.com
+  hasExposure: false
+  variables:
+    tlsEnabled:
+      description: Whether to enable ECH for connections using TLS
+      type: boolean
+      setPref: "network.dns.echconfig.enabled"
+    h3Enabled:
+      description: Whether to enable ECH for connections using H3/QUIC
+      type: boolean
+      setPref: "network.dns.http3_echconfig.enabled"
+    forceWaitHttpsRR:
+      description: Whether to force waiting for HTTPS DNS records, which ECH requires.
+      type: boolean
+      setPref: "network.dns.force_waiting_https_rr"
+    insecureFallback:
+      description: Whether to fallback to non-ECH connections if all ECH RRs fail.
+      type: boolean
+      setPref: "network.dns.echconfig.fallback_to_origin_when_all_failed"
+    tlsGreaseProb:
+      description: Probability of GREASEing a TLS connection with ECH (0-100).
+      type: int
+      setPref: "security.tls.ech.grease_probability"
+    h3GreaseEnabled:
+      description: Whether to apply GREASE settings to H3/QUIC connections.
+      type: boolean
+      setPref: "security.tls.ech.grease_http3"
+    disableGreaseOnFallback:
+      description: Whether to disable GREASE when retrying a connection.
+      type: boolean
+      setPref: "security.tls.ech.disable_grease_on_fallback"
+    greasePaddingSize:
+      description: Assumed echConfig padding length for GREASE extensions (1-255).
+      type: int
+      setPref: "security.tls.ech.grease_size"
+
+dohPrefs:
+  description: Prefs that control DNS over HTTPS.
+  owner: vgosu@mozilla.com
+  hasExposure: false
+  variables:
+    trrMode:
+      description: Has a value of 2 for TRR first, 3 for TRR only, 0 for off.
+      type: int
+      setPref: "network.trr.mode"
+    trrUri:
+      description: The URL of the DNS over HTTPS endpoint
+      type: string
+      setPref: "network.trr.uri"
+    dohMode:
+      description: Same as trrMode, but set by the DoHController module.
+      type: int
+      setPref: "doh-rollout.mode"
+    dohUri:
+      description: Same as trrUri, but set by the DoHController module.
+      type: string
+      setPref: "doh-rollout.uri"
+    enableFallbackWarningPage:
+      description: Whether DoH fallback warning page will be displayed when DoH doesn't work in TRR first mode.
+      type: boolean
+      setPref: "network.trr.display_fallback_warning"
+    showFallbackCheckbox:
+      description: Whether the checkbox to enable the fallback warning page is displayed in the settings UI.
+      type: boolean
+      setPref: "network.trr_ui.show_fallback_warning_option"
+
+dooh:
+  description: "DNS over Oblivious HTTP"
+  owner: vgosu@mozilla.com
+  hasExposure: false
+  variables:
+    ohttpEnabled:
+      description: Whether to use Oblivious HTTP for the resolution
+      type: boolean
+      setPref: "network.trr.use_ohttp"
+    ohttpRelayUri:
+      description: The URL of the Oblivious HTTP relay
+      type: string
+      setPref: "network.trr.ohttp.relay_uri"
+    ohttpConfigUri:
+      description: The URL used to fetch the configuration of the Oblivious HTTP gateway
+      type: string
+      setPref: "network.trr.ohttp.config_uri"
+    ohttpUri:
+      description: The URL of the Oblivious DNS over HTTPS target resource
+      type: string
+      setPref: "network.trr.ohttp.uri"
+
+networking:
+  description: "Firefox Networking (Necko)"
+  owner: vgosu@mozilla.com
+  hasExposure: false
+  variables:
+    ehPreloadEnabled:
+      description: Whether Early Hints preload is enabled
+      type: boolean
+      setPref: "network.early-hints.enabled"
+    ehPreconnectEnabled:
+      description: Whether Early Hints preconnect is enabled
+      type: boolean
+      setPref: "network.early-hints.preconnect.enabled"
+    dnsMaxPriorityThreads:
+      description: The maximum number of high priority DNS threads that can be created.
+      type: int
+      setPref: "network.dns.max_high_priority_threads"
+    dnsMaxAnyPriorityThreads:
+      description: The maximum number of DNS threads that can be created to handle any priority DNS requests.
+      type: int
+      setPref: "network.dns.max_any_priority_threads"
+    preconnect:
+      description: Whether the rel=preconnect feature is enabled
+      type: boolean
+      setPref: "network.preconnect"
+    networkPredictor:
+      description: Whether the Necko predictor is enabled
+      type: boolean
+      setPref: "network.predictor.enabled"
+    http3CCalgorithm:
+      description: The congestion control algorithm with which to configure neqo. 0 for NewReno, 1 for Cubic
+      type: int
+      setPref: "network.http.http3.cc_algorithm"
+    sendOnDataFinished:
+      description: Whether we can send OnDataFinished in the content process
+      type: boolean
+      setPref: "network.send_OnDataFinished"
+    sendOnDataFinishedToHtml5parser:
+      description: Whether we can send OnDataFinished to the html5parser in content process
+      type: boolean
+      setPref: "network.send_OnDataFinished.html5parser"
+    sendOnDataFinishedToCssLoader:
+      description: Whether we can send OnDataFinished to the cssLoader in content process
+      type: boolean
+      setPref: "network.send_OnDataFinished.cssLoader"
+
+
+pingsender:
+  description: "In-product usage of the pingsender telemetry reporter."
+  owner: nalexander@mozilla.com
+  hasExposure: false
+  variables:
+    backgroundTaskEnabled:
+      type: "boolean"
+      fallbackPref: "toolkit.telemetry.shutdownPingSender.backgroundtask.enabled"
+      description: "Whether to use the `pingsender` background task to send shutdown telemetry"
+
+dapTelemetry:
+  description: DAP Telemetry
+  owner: simon@mozilla.com
+  hasExposure: false
+  isEarlyStartup: true # Data is sent on startup with a trigger in BrowserGlue.sys.mjs
+  variables:
+    enabled:
+      type: boolean
+      fallbackPref: toolkit.telemetry.dap_enabled
+      description: Whether to automatically send DAP measurements.
+    task1Enabled:
+      type: boolean
+      fallbackPref: toolkit.telemetry.dap_task1_enabled
+      description: Whether to send fake measurements for verification task 1.
+
+etpLevel2PBMPref:
+  description: The pref that controls the ETP level 2 list in the private browsing mode
+  owner: tihuang@mozilla.com
+  hasExposure: false
+  variables:
+    enabled:
+      description: Whether to enable ETP level 2 list in the private browsing mode.
+      type: boolean
+      setPref: "privacy.annotate_channels.strict_list.pbmode.enabled"
+
+fxaButtonVisibility:
+  description: Prefs to control the visibility of the Firefox Accounts toolbar button when not signed in.
+  owner: mconley@mozilla.com
+  hasExposure: false
+  isEarlyStartup: true
+  variables:
+    boolean:
+      description: True if the Firefox Accounts toolbar button should be visible when not signed in.
+      type: boolean
+      setPref: identity.fxaccounts.toolbar.defaultVisible
+
+legacyHeartbeat:
+  description: Normandy Heartbeat exposed to Nimbus
+  owner: barret@mozilla.com
+  hasExposure: false
+  schema:
+    uri: "resource://normandy/schemas/LegacyHeartbeat.schema.json"
+    path: "toolkit/components/normandy/schemas/LegacyHeartbeat.schema.json"
+  variables:
+    survey:
+      type: json
+      description: The Heartbeat survey parameters.
+
+queryStripping:
+  description: Query parameter stripping anti-tracking feature.
+  owner: pbz@mozilla.com
+  hasExposure: false
+  variables:
+    enabledNormalBrowsing:
+      type: boolean
+      setPref: privacy.query_stripping.enabled
+      description: Enables / disables URL query string stripping in normal browsing mode.
+    enabledPrivateBrowsing:
+      type: boolean
+      setPref: privacy.query_stripping.enabled.pbmode
+      description: Enables / disables URL query string stripping in private browsing mode.
+    allowList:
+      type: string
+      setPref: privacy.query_stripping.allow_list
+      description: >-
+        List of sites exempt from query stripping. This list will be merged with
+        records coming from RemoteSettings.
+    stripList:
+      type: string
+      setPref: privacy.query_stripping.strip_list
+      description: >-
+        List of query params to be stripped from URIs. This list will be merged
+        with records coming from RemoteSettings.
+
+fontvisibility:
+  description: Control Font Visibility in PBM
+  owner: tom@mozilla.com
+  hasExposure: false
+  variables:
+    enabledETP:
+      type: int
+      setPref: layout.css.font-visibility.trackingprotection
+      description: Set the Font Visibility level when Enhanced Tracking Protection is enabled
+    enabledStandard:
+      type: int
+      setPref: layout.css.font-visibility.standard
+      description: Set the Font Visibility level for normal browsing
+    enabledPBM:
+      type: int
+      setPref: layout.css.font-visibility.private
+      description: Set the Font Visibility level for private browsing (will override ETP)
+
+fingerprintingProtection:
+  description: Control Fingerprinting Protection
+  owner: tihuang@mozilla.com
+  hasExposure: false
+  variables:
+    enabledNormal:
+      type: boolean
+      setPref: privacy.fingerprintingProtection
+      description: Enables / disables fingerprinting protection in normal browsing mode.
+    enabledPrivate:
+      type: boolean
+      setPref: privacy.fingerprintingProtection.pbmode
+      description: Enables / disables fingerprinting protection in private browsing mode.
+    overrides:
+      type: string
+      setPref: privacy.fingerprintingProtection.overrides
+      description: >-
+        The protection overrides to add or remove fingerprinting protection
+        targets. Please check RFPTargets.inc for all supported targets.
+
+migrationWizard:
+  description: Prefs to control the Migration Wizard UI.
+  owner: mconley@mozilla.com
+  hasExposure: false
+  isEarlyStartup: true
+  variables:
+    showImportAll:
+      description: True if the "Variant 2" of the Migration Wizard browser / profile selection UI should be used. This is only meaningful in the new Migration Wizard.
+      type: boolean
+      setPref: browser.migrate.content-modal.import-all.enabled
+    showPreferencesEntrypoint:
+      description: True if an entrypoint to the migration wizard should be visible in about:preferences.
+      type: boolean
+      setPref: browser.migrate.preferences-entrypoint.enabled
+    aboutWelcomeBehavior:
+      description: >-
+        When migration is kicked off from about:welcome, there are
+        a few different behaviors that we want to test, controlled
+        by a preference that is instrumented for Nimbus. The pref
+        has the following possible states:
+
+        "autoclose":
+          The user will be directed to the migration wizard in
+          about:preferences, but once the wizard is dismissed,
+          the tab will close.
+
+        "embedded":
+          The migration wizard is embedded in about:welcome.
+
+        "standalone":
+          The migration wizard will open in a new top-level content
+          window.
+
+        "default" / other
+          The user will be directed to the migration wizard in
+          about:preferences. The tab will not close once the
+          user closes the wizard.
+      type: string
+      setPref: browser.migrate.content-modal.about-welcome-behavior
+    migrateExtensions:
+      description: True if importing extensions is enabled.
+      type: boolean
+      setPref: browser.migrate.chrome.extensions.enabled
+    chromeCanRequestPermissions:
+      description: >-
+        True if Chrome-based browsers can request read permissions on
+        platforms where the browser is restricted from reading the contents
+        of a Chrome-based browser's user data directory. In practice, this
+        is only relevant to the Linux platform when the browser is installed
+        as a Snap package.
+      type: boolean
+      setPref: browser.migrate.chrome.get_permissions.enabled
+
+mixedContentUpgrading:
+  description: Prefs to control whether we upgrade mixed passive content (images, audio, video) from http to https
+  owner: fbraun@mozilla.com
+  hasExposure: false
+  variables:
+    enabled:
+      description: True if the mixed content upgrading pref is enabled
+      type: boolean
+      setPref: security.mixed_content.upgrade_display_content
+    image:
+      description: True if the mixed content upgrading is enabled for images
+      type: boolean
+      setPref: security.mixed_content.upgrade_display_content.image
+    audio:
+      description: True if the mixed content upgrading is enabled for audio
+      type: boolean
+      setPref: security.mixed_content.upgrade_display_content.audio
+    video:
+      description: True if the mixed content upgrading is enabled for videos
+      type: boolean
+      setPref: security.mixed_content.upgrade_display_content.video
+
+jsParallelParsing:
+  description: Pref to toggle JS parallel parsing.
+  owner: dpalmeiro@mozilla.com, nbp@mozilla.com
+  isEarlyStartup: true
+  hasExposure: false
+  variables:
+    enabled:
+      description: True to enable parallel parsing.
+      type: boolean
+      setPref: "javascript.options.parallel_parsing"
+
+gcParallelMarking:
+  description: Pref to toggle parallel marking in the GC.
+  owner: dpalmeiro@mozilla.com, jonco@mozilla.com
+  isEarlyStartup: true
+  hasExposure: false
+  variables:
+    enabled:
+      description: True to enable parallel marking.
+      type: boolean
+      setPref: "javascript.options.mem.gc_parallel_marking"
+
+jitThresholds:
+  description: Prefs that control jit tier thresholds.
+  owner: dpalmeiro@mozilla.com, jdemooij@mozilla.com
+  isEarlyStartup: true
+  hasExposure: false
+  variables:
+    blinterp_threshold:
+      description: Set the threshold to enable blinterp compilation.
+      type: int
+      setPref: "javascript.options.blinterp.threshold"
+    baseline_threshold:
+      description: Set the threshold to enable baseline compilation.
+      type: int
+      setPref: "javascript.options.baselinejit.threshold"
+    ion_threshold:
+      description: Set the threshold to enable ion compilation.
+      type: int
+      setPref: "javascript.options.ion.threshold"
+    ion_bailout_threshold:
+      description: Set the ion frequent bailout threshold.
+      type: int
+      setPref: "javascript.options.ion.frequent_bailout_threshold"
+    ion_offthread_compilation:
+      description: True to enable offthread ion compilations.
+      type: boolean
+      setPref: "javascript.options.ion.offthread_compilation"
+    inlining_max_length:
+      description: Set the max bytecode length considered for inlining.
+      type: int
+      setPref: "javascript.options.inlining_bytecode_max_length"
+
+jitHintsCache:
+  description: Pref to toggle the JIT hints cache.
+  owner: dpalmeiro@mozilla.com
+  isEarlyStartup: true
+  hasExposure: false
+  variables:
+    enabled:
+      description: True to enable the hints cache.
+      type: boolean
+      setPref: "javascript.options.jithints"
+
+raceCacheWithNetwork:
+  description: Prefs to toggle the race cache with network.
+  owner: dpalmeiro@mozilla.com, acreskey@mozilla.com
+  hasExposure: false
+  variables:
+    enabled:
+      description: True to enable the rcwn feature.
+      type: boolean
+      setPref: "network.http.rcwn.enabled"
+
+httpSpeculativeParallelLimit:
+  description: Prefs to control the http speculative parallel limit.
+  owner: dpalmeiro@mozilla.com, acreskey@mozilla.com
+  hasExposure: false
+  variables:
+    speculative_parallel_limit:
+      description: Maximum number of parallel speculative connections.
+      type: int
+      setPref: "network.http.speculative-parallel-limit"
+
+deviceMigration:
+  description: Prefs to control aspects of the new device migration experiment
+  owner: hjones@mozilla.com
+  hasExposure: false
+  isEarlyStartup: true
+  variables:
+    helpMenuHidden:
+      description: True if new help menu item should be hidden
+      type: boolean
+      fallbackPref: browser.device-migration.help-menu.hidden
+
+shopping2023:
+  description: Prefs to control the 2023 shopping experiment.
+  owner: jhirsch@mozilla.com
+  hasExposure: true
+  exposureDescription: >-
+    The timing of the exposure event depends on the experiment, but generally
+    the event is recorded when the user first encounters onboarding UI for
+    the shopping feature.
+  variables:
+    enabled:
+      description: True if the experience is enabled (experimental treatment group)
+      type: boolean
+      fallbackPref: browser.shopping.experience2023.enabled
+    control:
+      description: True if the experiment is enabled but experience is disabled (experimental control group)
+      type: boolean
+      fallbackPref: browser.shopping.experience2023.control
+    adsEnabled:
+      description: True if showing recommended products is enabled
+      type: boolean
+      setPref: browser.shopping.experience2023.ads.enabled
+    adsExposure:
+      description: True if we want to record ad inventory for opted-in users, even if ads are disabled
+      type: boolean
+      setPref: browser.shopping.experience2023.ads.exposure
+    surveyEnabled:
+      description: True if showing survey is enabled
+      type: boolean
+      fallbackPref: browser.shopping.experience2023.survey.enabled
+shoppingOHTTP:
+  description: Prefs to control the OHTTP URLs used for shopping.
+  owner: gijs@mozilla.com
+  hasExposure: false
+  variables:
+    ohttpRelayURL:
+      description: What OHTTP relay URL to use
+      type: string
+      setPref: toolkit.shopping.ohttpRelayURL
+    ohttpConfigURL:
+      description: URL for the OHTTP config to use
+      type: string
+      setPref: toolkit.shopping.ohttpConfigURL
+
+opaqueResponseBlocking:
+  description: Prefs to enable Opaque Response Blocking
+  owner: farre@mozilla.com
+  isEarlyStartup: true
+  hasExposure: true
+  exposureDescription: Exposure is sent when a response is blocked
+  variables:
+    enabled:
+      description: Whether ORB is enabled
+      type: boolean
+      setPref: "browser.opaqueResponseBlocking"
+    javascriptValidator:
+      description: Whether JavaScript validation for ORB is enabled
+      type: boolean
+      setPref: "browser.opaqueResponseBlocking.javascriptValidator"
+    filterFetchResponse:
+      description: Whether filtering of internal responses in the parent ORB is enabled
+      type: int
+      setPref: "browser.opaqueResponseBlocking.filterFetchResponse"
+    mediaExceptionsStrategy:
+      description: >-
+        If we partially or wholly allow audio and video MIME types in conflict with spec.
+      type: int
+      setPref: "browser.opaqueResponseBlocking.mediaExceptionsStrategy"
+
+updatePrompt:
+  description: Prefs to control content and behavior of update notifications
+  owner: omc@mozilla.com
+  hasExposure: true
+  exposureDescription: >-
+    Exposure is sent at most once per browsing session when an update
+    notification prompt is displayed.
+  isEarlyStartup: true
+  variables:
+    showReleaseNotesLink:
+      type: boolean
+      description: >-
+        If true, the "Learn More" link will be shown in the update prompt. If
+        false or omitted, the link will only be shown for supported locales.
+    releaseNotesURL:
+      type: string
+      fallbackPref: app.releaseNotesURL.prompt
+      description: >-
+        Template for the URL opened when the user clicks the "Learn More" link
+        in the update prompt. If an empty string, the link will not be shown.
+
+powerSaver:
+  description: Prefs to control power saving behaviors
+  owner: florian@mozilla.com
+  hasExposure: false
+  isEarlyStartup: true
+  variables:
+    reduceFrameRates:
+      type: int
+      setPref: "gfx.display.max-frame-rate"
+      description: >-
+        Limit the number of frames displayed per second.
+        If omitted, the refresh rate of the screen will be used.
+    mediaAutoPlay:
+      type: int
+      setPref: "media.autoplay.default"
+      description: >-
+        Control if media is allowed to auto-play, with and without sound.
+    backgroundTimerMinTime:
+      type: int
+      setPref: "dom.min_background_timeout_value"
+      description: >-
+        Limit how frequently timers are allowed to run in background tabs.
+    backgroundTimerRegenerationRate:
+      type: int
+      setPref: "dom.timeout.background_budget_regeneration_rate"
+      description: >-
+        Limit how quickly the background tab timer budget regenerates.
+
+firefoxViewNext:
+  description: Next Iteration of Firefox View
+  owner: firefoxview@mozilla.com
+  hasExposure: false
+  isEarlyStartup: true
+  variables:
+    enabled:
+      type: boolean
+      fallbackPref: "browser.tabs.firefox-view-next"
+      description: "Whether or not to enable the new Firefox View"
+    newIcon:
+      type: boolean
+      fallbackPref: "browser.tabs.firefox-view-newIcon"
+      description: "Whether or not use the new icon"
+
+backgroundUpdate:
+  description: Prefs to control aspects of the background update process.
+  owner: install-update@mozilla.com
+  hasExposure: true
+  exposureDescription: >-
+    The exposure event is sent when scheduling the background task and both the
+    feature is enabled and the service registry key (Mozilla Maintenance
+    Service) is *not* available for this installation. That is the first time
+    the feature can impact Firefox behaviour and the user experience.
+  isEarlyStartup: true
+  variables:
+    enableUpdatesForUnelevatedInstallations:
+      description: >-
+        Allow the background update process to download and apply updates when
+        the Mozilla Maintenance Service is unavailable but the installation
+        directory can be written.
+      type: boolean
+      setPref: app.update.background.allowUpdatesForUnelevatedInstallations
+
+bookmarks:
+  description: Prefs to control aspects of the bookmarks system.
+  owner: omc@mozilla.com
+  hasExposure: false
+  isEarlyStartup: true
+  variables:
+    enableBookmarksToolbar:
+      type: string
+      setPref: browser.toolbars.bookmarks.visibility
+      description: If the bookmarks toolbar should never, always, or only show on newtab.
+
+cookieBannerHandling:
+  description: Automatically handle cookie banners on the user's behalf.
+  owner: pbz@mozilla.com
+  hasExposure: false
+  variables:
+    modeNormalBrowsing:
+      type: int
+      setPref: cookiebanners.service.mode
+      description: >-
+        Controls the cookie banner handling mode in normal browsing.
+        Values: 0 - disabled, 1 - reject all, 2 - reject all with accept all fallback.
+    modePrivateBrowsing:
+      type: int
+      setPref: cookiebanners.service.mode.privateBrowsing
+      description: >-
+        Controls the cookie banner handling mode in private browsing.
+        Values: 0 - disabled, 1 - reject all, 2 - reject all with accept all fallback.
+    enableGlobalRules:
+      type: boolean
+      setPref: cookiebanners.service.enableGlobalRules
+      description: >-
+        Enables use of global CookieBannerRules, which apply to all sites.
+        This enables handling of CMPs across sites without the use of site-specific rules.
+    enableGlobalRulesSubFrames:
+      type: boolean
+      setPref: cookiebanners.service.enableGlobalRules.subFrames
+      description: >-
+        Whether global rules are allowed to run in sub-frames. Running query
+        selectors in every sub-frame may negatively impact performance, but is
+        required for some CMPs.
+    enableDetectOnly:
+      type: boolean
+      setPref: cookiebanners.service.detectOnly
+      description: >-
+        When set to true, cookie banners are detected and detection events are
+        dispatched, but they will not be handled.
+        This pref applies to both normal and private browsing windows.
+    enableFirefoxDesktopUI:
+      type: boolean
+      setPref: cookiebanners.ui.desktop.enabled
+      description: Enables the cookie banner desktop UI.
+    enablePromo:
+      type: boolean
+      setPref: browser.promo.cookiebanners.enabled
+      description: Enables the cookie banner promo in about:privatebrowsing.
+
+backgroundThreads:
+  description: Prefs to control MacOS thread priorities for power savings.
+  owner: kwright@mozilla.com
+  hasExposure: false
+  isEarlyStartup: true
+  variables:
+    use_low_power:
+      description: >-
+        Use the MacOS QoS libraries to deprioritize select threads.
+      type: boolean
+      setPref: threads.use_low_power.enabled
+    lower_mainthread_priority_in_background:
+      description: >-
+        When a browsing context is put in the background and isn't actively playing
+        media, deprioritize its main thread.
+      type: boolean
+      setPref: threads.lower_mainthread_priority_in_background.enabled
+
+feltPrivacy:
+  description: Prefs for Felt Privacy v1 experiments
+  owner: cmeador@mozilla.com
+  hasExposure: true
+  exposureDescription: Exposure when user opens a private browsing window.
+  variables:
+    feltPrivacy:
+      type: boolean
+      setPref: browser.privatebrowsing.felt-privacy-v1
+      description: >-
+        When true, new styles and copy enabled on about:privatebrowsing. When true,
+        a toggle for showing or hiding quick suggestions appears in about:preferences.
+    resetPBMAction:
+      type: boolean
+      setPref: browser.privatebrowsing.resetPBM.enabled
+      description: >-
+        Enables the reset PBM feature button and confirmation panel.
+
+attribution:
+  description: Prefs related to install attribution
+  hasExposure: false
+  isEarlyStartup: true
+  variables:
+    macosEnabled:
+      type: boolean
+      description: Whether or not macOS attribution data will be processed and sent in Telemetry
+      fallbackPref: browser.attribution.macos.enabled
+
+phc:
+  description: Prefs to control the Probabalistic Heap Checker (PHC)
+  owner: pbone@mozilla.com
+  hasExposure: false
+  isEarlyStartup: true
+  variables:
+    phcEnabled:
+      description: Whether to enable PHC
+      type: boolean
+      setPref: memory.phc.enabled

--- a/experimenter/experimenter/features/manifests/firefox-desktop/v120.0.0/schemas/browser/components/newtab/content-src/asrouter/schemas/BackgroundTaskMessagingExperiment.schema.json
+++ b/experimenter/experimenter/features/manifests/firefox-desktop/v120.0.0/schemas/browser/components/newtab/content-src/asrouter/schemas/BackgroundTaskMessagingExperiment.schema.json
@@ -1,0 +1,344 @@
+{
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "$id": "resource://activity-stream/schemas/BackgroundTaskMessagingExperiment.schema.json",
+  "title": "Messaging Experiment",
+  "description": "A Firefox Messaging System message.",
+  "if": {
+    "type": "object",
+    "properties": {
+      "template": {
+        "const": "multi"
+      }
+    },
+    "required": [
+      "template"
+    ]
+  },
+  "then": {
+    "$ref": "resource://activity-stream/schemas/BackgroundTaskMessagingExperiment.schema.json#/$defs/MultiMessage"
+  },
+  "else": {
+    "$ref": "resource://activity-stream/schemas/BackgroundTaskMessagingExperiment.schema.json#/$defs/TemplatedMessage"
+  },
+  "$defs": {
+    "ToastNotification": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "$id": "file:///ToastNotification.schema.json",
+      "title": "ToastNotification",
+      "description": "A template for toast notifications displayed by the Alert service.",
+      "allOf": [
+        {
+          "$ref": "resource://activity-stream/schemas/BackgroundTaskMessagingExperiment.schema.json#/$defs/Message"
+        }
+      ],
+      "type": "object",
+      "properties": {
+        "content": {
+          "type": "object",
+          "properties": {
+            "title": {
+              "$ref": "resource://activity-stream/schemas/BackgroundTaskMessagingExperiment.schema.json#/$defs/localizableText",
+              "description": "Id of localized string or message override of toast notification title"
+            },
+            "body": {
+              "$ref": "resource://activity-stream/schemas/BackgroundTaskMessagingExperiment.schema.json#/$defs/localizableText",
+              "description": "Id of localized string or message override of toast notification body"
+            },
+            "icon_url": {
+              "description": "The URL of the image used as an icon of the toast notification.",
+              "type": "string",
+              "format": "moz-url-format"
+            },
+            "image_url": {
+              "description": "The URL of an image to be displayed as part of the notification.",
+              "type": "string",
+              "format": "moz-url-format"
+            },
+            "launch_url": {
+              "description": "The URL to launch when the notification or an action button is clicked.",
+              "type": "string",
+              "format": "moz-url-format"
+            },
+            "launch_action": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "description": "The launch action to be performed when Firefox is launched."
+                },
+                "data": {
+                  "type": "object"
+                }
+              },
+              "required": [
+                "type"
+              ],
+              "additionalProperties": true
+            },
+            "requireInteraction": {
+              "type": "boolean",
+              "description": "Whether the toast notification should remain active until the user clicks or dismisses it, rather than closing automatically."
+            },
+            "tag": {
+              "type": "string",
+              "description": "An identifying tag for the toast notification."
+            },
+            "data": {
+              "type": "object",
+              "description": "Arbitrary data associated with the toast notification."
+            },
+            "actions": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "title": {
+                    "$ref": "resource://activity-stream/schemas/BackgroundTaskMessagingExperiment.schema.json#/$defs/localizableText",
+                    "description": "The action text to be shown to the user."
+                  },
+                  "action": {
+                    "type": "string",
+                    "description": "Opaque identifer that identifies action."
+                  },
+                  "iconURL": {
+                    "type": "string",
+                    "format": "uri",
+                    "description": "URL of an icon to display with the action."
+                  },
+                  "windowsSystemActivationType": {
+                    "type": "boolean",
+                    "description": "Whether to have Windows process the given `action`."
+                  },
+                  "launch_action": {
+                    "type": "object",
+                    "properties": {
+                      "type": {
+                        "type": "string",
+                        "description": "The launch action to be performed when Firefox is launched."
+                      },
+                      "data": {
+                        "type": "object"
+                      }
+                    },
+                    "required": [
+                      "type"
+                    ],
+                    "additionalProperties": true
+                  }
+                },
+                "required": [
+                  "action",
+                  "title"
+                ],
+                "additionalProperties": true
+              }
+            }
+          },
+          "additionalProperties": true,
+          "required": [
+            "title",
+            "body"
+          ]
+        },
+        "template": {
+          "type": "string",
+          "const": "toast_notification"
+        }
+      },
+      "required": [
+        "content",
+        "targeting",
+        "template",
+        "trigger"
+      ],
+      "additionalProperties": true
+    },
+    "Message": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "The message identifier"
+        },
+        "groups": {
+          "description": "Array of preferences used to control `enabled` status of the group. If any is `false` the group is disabled.",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "description": "Preference name"
+          }
+        },
+        "template": {
+          "type": "string",
+          "description": "Which messaging template this message is using.",
+          "enum": [
+            "toast_notification"
+          ]
+        },
+        "frequency": {
+          "type": "object",
+          "description": "An object containing frequency cap information for a message.",
+          "properties": {
+            "lifetime": {
+              "type": "integer",
+              "description": "The maximum lifetime impressions for a message.",
+              "minimum": 1,
+              "maximum": 100
+            },
+            "custom": {
+              "type": "array",
+              "description": "An array of custom frequency cap definitions.",
+              "items": {
+                "description": "A frequency cap definition containing time and max impression information",
+                "type": "object",
+                "properties": {
+                  "period": {
+                    "type": "integer",
+                    "description": "Period of time in milliseconds (e.g. 86400000 for one day)"
+                  },
+                  "cap": {
+                    "type": "integer",
+                    "description": "The maximum impressions for the message within the defined period.",
+                    "minimum": 1,
+                    "maximum": 100
+                  }
+                },
+                "required": [
+                  "period",
+                  "cap"
+                ]
+              }
+            }
+          }
+        },
+        "priority": {
+          "description": "The priority of the message. If there are two competing messages to show, the one with the highest priority will be shown",
+          "type": "integer"
+        },
+        "order": {
+          "description": "The order in which messages should be shown. Messages will be shown in increasing order.",
+          "type": "integer"
+        },
+        "targeting": {
+          "description": "A JEXL expression representing targeting information",
+          "type": "string"
+        },
+        "trigger": {
+          "description": "An action to trigger potentially showing the message",
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "A string identifying the trigger action"
+            },
+            "params": {
+              "type": "array",
+              "description": "An optional array of string parameters for the trigger action",
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "string"
+                  }
+                ]
+              }
+            }
+          },
+          "required": [
+            "id"
+          ]
+        },
+        "provider": {
+          "description": "An identifier for the provider of this message, such as \"cfr\" or \"preview\".",
+          "type": "string"
+        }
+      },
+      "additionalProperties": true,
+      "dependentRequired": {
+        "content": [
+          "id",
+          "template"
+        ],
+        "template": [
+          "id",
+          "content"
+        ]
+      }
+    },
+    "localizedText": {
+      "type": "object",
+      "properties": {
+        "string_id": {
+          "description": "Id of localized string to be rendered.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "string_id"
+      ]
+    },
+    "localizableText": {
+      "description": "Either a raw string or an object containing the string_id of the localized text",
+      "oneOf": [
+        {
+          "type": "string",
+          "description": "The string to be rendered."
+        },
+        {
+          "$ref": "resource://activity-stream/schemas/BackgroundTaskMessagingExperiment.schema.json#/$defs/localizedText"
+        }
+      ]
+    },
+    "TemplatedMessage": {
+      "description": "An FxMS message of one of a variety of types.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "resource://activity-stream/schemas/BackgroundTaskMessagingExperiment.schema.json#/$defs/Message"
+        },
+        {
+          "if": {
+            "type": "object",
+            "properties": {
+              "template": {
+                "type": "string",
+                "enum": [
+                  "toast_notification"
+                ]
+              }
+            },
+            "required": [
+              "template"
+            ]
+          },
+          "then": {
+            "$ref": "resource://activity-stream/schemas/BackgroundTaskMessagingExperiment.schema.json#/$defs/ToastNotification"
+          }
+        }
+      ]
+    },
+    "MultiMessage": {
+      "description": "An object containing an array of messages.",
+      "type": "object",
+      "properties": {
+        "template": {
+          "type": "string",
+          "const": "multi"
+        },
+        "messages": {
+          "type": "array",
+          "description": "An array of messages.",
+          "items": {
+            "$ref": "resource://activity-stream/schemas/BackgroundTaskMessagingExperiment.schema.json#/$defs/TemplatedMessage"
+          }
+        }
+      },
+      "required": [
+        "template",
+        "messages"
+      ]
+    }
+  }
+}

--- a/experimenter/experimenter/features/manifests/firefox-desktop/v120.0.0/schemas/browser/components/newtab/content-src/asrouter/schemas/MessagingExperiment.schema.json
+++ b/experimenter/experimenter/features/manifests/firefox-desktop/v120.0.0/schemas/browser/components/newtab/content-src/asrouter/schemas/MessagingExperiment.schema.json
@@ -1,0 +1,1672 @@
+{
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "$id": "resource://activity-stream/schemas/MessagingExperiment.schema.json",
+  "title": "Messaging Experiment",
+  "description": "A Firefox Messaging System message.",
+  "if": {
+    "type": "object",
+    "properties": {
+      "template": {
+        "const": "multi"
+      }
+    },
+    "required": [
+      "template"
+    ]
+  },
+  "then": {
+    "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/MultiMessage"
+  },
+  "else": {
+    "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/TemplatedMessage"
+  },
+  "$defs": {
+    "CFRUrlbarChiclet": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "$id": "file:///CFRUrlbarChiclet.schema.json",
+      "title": "CFRUrlbarChiclet",
+      "description": "A template with a chiclet button with text.",
+      "allOf": [
+        {
+          "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/Message"
+        }
+      ],
+      "type": "object",
+      "properties": {
+        "content": {
+          "type": "object",
+          "properties": {
+            "category": {
+              "type": "string",
+              "description": "Attribute used for different groups of messages from the same provider"
+            },
+            "layout": {
+              "type": "string",
+              "description": "Describes how content should be displayed.",
+              "enum": [
+                "chiclet_open_url"
+              ]
+            },
+            "bucket_id": {
+              "type": "string",
+              "description": "A bucket identifier for the addon. This is used in order to anonymize telemetry for history-sensitive targeting."
+            },
+            "notification_text": {
+              "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/localizableText",
+              "description": "The text in the small blue chicklet that appears in the URL bar. This can be a reference to a localized string in Firefox or just a plain string."
+            },
+            "active_color": {
+              "type": "string",
+              "description": "Background color of the button"
+            },
+            "action": {
+              "type": "object",
+              "properties": {
+                "url": {
+                  "description": "The page to open when the button is clicked.",
+                  "type": "string",
+                  "format": "moz-url-format"
+                },
+                "where": {
+                  "description": "Should it open in a new tab or the current tab",
+                  "type": "string",
+                  "enum": [
+                    "current",
+                    "tabshifted"
+                  ]
+                }
+              },
+              "additionalProperties": true,
+              "required": [
+                "url",
+                "where"
+              ]
+            }
+          },
+          "additionalProperties": true,
+          "required": [
+            "layout",
+            "category",
+            "bucket_id",
+            "notification_text",
+            "action"
+          ]
+        },
+        "template": {
+          "type": "string",
+          "const": "cfr_urlbar_chiclet"
+        }
+      },
+      "required": [
+        "targeting",
+        "trigger"
+      ]
+    },
+    "ExtensionDoorhanger": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "$id": "file:///ExtensionDoorhanger.schema.json",
+      "title": "ExtensionDoorhanger",
+      "description": "A template with a heading, addon icon, title and description. No markup allowed.",
+      "allOf": [
+        {
+          "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/Message"
+        }
+      ],
+      "type": "object",
+      "properties": {
+        "content": {
+          "type": "object",
+          "properties": {
+            "category": {
+              "type": "string",
+              "description": "Attribute used for different groups of messages from the same provider"
+            },
+            "layout": {
+              "type": "string",
+              "description": "Attribute used for different groups of messages from the same provider",
+              "enum": [
+                "short_message",
+                "icon_and_message",
+                "addon_recommendation"
+              ]
+            },
+            "anchor_id": {
+              "type": "string",
+              "description": "A DOM element ID that the pop-over will be anchored."
+            },
+            "alt_anchor_id": {
+              "type": "string",
+              "description": "An alternate DOM element ID that the pop-over will be anchored."
+            },
+            "bucket_id": {
+              "type": "string",
+              "description": "A bucket identifier for the addon. This is used in order to anonymize telemetry for history-sensitive targeting."
+            },
+            "skip_address_bar_notifier": {
+              "type": "boolean",
+              "description": "Skip the 'Recommend' notifier and show directly."
+            },
+            "persistent_doorhanger": {
+              "type": "boolean",
+              "description": "Prevent the doorhanger from being dismissed if user interacts with the page or switches between applications."
+            },
+            "show_in_private_browsing": {
+              "type": "boolean",
+              "description": "Whether to allow the message to be shown in private browsing mode. Defaults to false."
+            },
+            "notification_text": {
+              "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/localizableText",
+              "description": "The text in the small blue chicklet that appears in the URL bar. This can be a reference to a localized string in Firefox or just a plain string."
+            },
+            "info_icon": {
+              "type": "object",
+              "description": "The small icon displayed in the top right corner of the pop-over. Should be 19x19px, svg or png. Defaults to a small question mark.",
+              "properties": {
+                "label": {
+                  "oneOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "attributes": {
+                          "type": "object",
+                          "properties": {
+                            "tooltiptext": {
+                              "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/localizableText",
+                              "description": "Text for button tooltip used to provide information about the doorhanger."
+                            }
+                          },
+                          "required": [
+                            "tooltiptext"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "attributes"
+                      ]
+                    },
+                    {
+                      "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/localizedText"
+                    }
+                  ]
+                },
+                "sumo_path": {
+                  "type": "string",
+                  "description": "Last part of the path in the URL to the support page with the information about the doorhanger.",
+                  "examples": [
+                    "extensionpromotions",
+                    "extensionrecommendations"
+                  ]
+                }
+              }
+            },
+            "learn_more": {
+              "type": "string",
+              "description": "Last part of the path in the SUMO URL to the support page with the information about the doorhanger.",
+              "examples": [
+                "extensionpromotions",
+                "extensionrecommendations"
+              ]
+            },
+            "heading_text": {
+              "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/localizableText",
+              "description": "The larger heading text displayed in the pop-over. This can be a reference to a localized string in Firefox or just a plain string."
+            },
+            "icon": {
+              "$ref": "file:///ExtensionDoorhanger.schema.json#/$defs/linkUrl",
+              "description": "The icon displayed in the pop-over. Should be 32x32px or 64x64px and png/svg."
+            },
+            "icon_dark_theme": {
+              "type": "string",
+              "description": "Pop-over icon, dark theme variant. Should be 32x32px or 64x64px and png/svg."
+            },
+            "icon_class": {
+              "type": "string",
+              "description": "CSS class of the pop-over icon."
+            },
+            "addon": {
+              "description": "Addon information including AMO URL.",
+              "type": "object",
+              "properties": {
+                "id": {
+                  "$ref": "file:///ExtensionDoorhanger.schema.json#/$defs/plainText",
+                  "description": "Unique addon ID"
+                },
+                "title": {
+                  "$ref": "file:///ExtensionDoorhanger.schema.json#/$defs/plainText",
+                  "description": "Addon name"
+                },
+                "author": {
+                  "$ref": "file:///ExtensionDoorhanger.schema.json#/$defs/plainText",
+                  "description": "Addon author"
+                },
+                "icon": {
+                  "$ref": "file:///ExtensionDoorhanger.schema.json#/$defs/linkUrl",
+                  "description": "The icon displayed in the pop-over. Should be 64x64px and png/svg."
+                },
+                "rating": {
+                  "type": "string",
+                  "description": "Star rating"
+                },
+                "users": {
+                  "type": "string",
+                  "description": "Installed users"
+                },
+                "amo_url": {
+                  "$ref": "file:///ExtensionDoorhanger.schema.json#/$defs/linkUrl",
+                  "description": "Link that offers more information related to the addon."
+                }
+              },
+              "required": [
+                "title",
+                "author",
+                "icon",
+                "amo_url"
+              ]
+            },
+            "text": {
+              "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/localizableText",
+              "description": "The body text displayed in the pop-over. This can be a reference to a localized string in Firefox or just a plain string."
+            },
+            "descriptionDetails": {
+              "description": "Additional information and steps on how to use",
+              "type": "object",
+              "properties": {
+                "steps": {
+                  "description": "Array of string_ids",
+                  "type": "array",
+                  "items": {
+                    "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/localizedText",
+                    "description": "Id of string to localized addon description"
+                  }
+                }
+              },
+              "required": [
+                "steps"
+              ]
+            },
+            "buttons": {
+              "description": "The label and functionality for the buttons in the pop-over.",
+              "type": "object",
+              "properties": {
+                "primary": {
+                  "type": "object",
+                  "properties": {
+                    "label": {
+                      "type": "object",
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "value": {
+                              "$ref": "file:///ExtensionDoorhanger.schema.json#/$defs/plainText",
+                              "description": "Button label override used when a localized version is not available."
+                            },
+                            "attributes": {
+                              "type": "object",
+                              "properties": {
+                                "accesskey": {
+                                  "type": "string",
+                                  "description": "A single character to be used as a shortcut key for the secondary button. This should be one of the characters that appears in the button label."
+                                }
+                              },
+                              "required": [
+                                "accesskey"
+                              ],
+                              "description": "Button attributes."
+                            }
+                          },
+                          "required": [
+                            "value",
+                            "attributes"
+                          ]
+                        },
+                        {
+                          "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/localizedText"
+                        }
+                      ],
+                      "description": "Id of localized string or message override."
+                    },
+                    "action": {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "description": "Action dispatched by the button."
+                        },
+                        "data": {
+                          "properties": {
+                            "url": {
+                              "type": "string",
+                              "$comment": "This is dynamically generated from the addon.id. See CFRPageActions.jsm",
+                              "description": "URL used in combination with the primary action dispatched."
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "secondary": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "label": {
+                        "type": "object",
+                        "oneOf": [
+                          {
+                            "properties": {
+                              "value": {
+                                "allOf": [
+                                  {
+                                    "$ref": "file:///ExtensionDoorhanger.schema.json#/$defs/plainText"
+                                  },
+                                  {
+                                    "description": "Button label override used when a localized version is not available."
+                                  }
+                                ]
+                              },
+                              "attributes": {
+                                "type": "object",
+                                "properties": {
+                                  "accesskey": {
+                                    "type": "string",
+                                    "description": "A single character to be used as a shortcut key for the secondary button. This should be one of the characters that appears in the button label."
+                                  }
+                                },
+                                "required": [
+                                  "accesskey"
+                                ],
+                                "description": "Button attributes."
+                              }
+                            },
+                            "required": [
+                              "value",
+                              "attributes"
+                            ]
+                          },
+                          {
+                            "properties": {
+                              "string_id": {
+                                "allOf": [
+                                  {
+                                    "$ref": "file:///ExtensionDoorhanger.schema.json#/$defs/plainText"
+                                  },
+                                  {
+                                    "description": "Id of localized string for button"
+                                  }
+                                ]
+                              }
+                            },
+                            "required": [
+                              "string_id"
+                            ]
+                          }
+                        ],
+                        "description": "Id of localized string or message override."
+                      },
+                      "action": {
+                        "type": "object",
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "description": "Action dispatched by the button."
+                          },
+                          "data": {
+                            "properties": {
+                              "url": {
+                                "allOf": [
+                                  {
+                                    "$ref": "file:///ExtensionDoorhanger.schema.json#/$defs/linkUrl"
+                                  },
+                                  {
+                                    "description": "URL used in combination with the primary action dispatched."
+                                  }
+                                ]
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "additionalProperties": true,
+          "required": [
+            "layout",
+            "bucket_id",
+            "heading_text",
+            "text",
+            "buttons"
+          ],
+          "if": {
+            "properties": {
+              "skip_address_bar_notifier": {
+                "anyOf": [
+                  {
+                    "const": "false"
+                  },
+                  {
+                    "const": null
+                  }
+                ]
+              }
+            }
+          },
+          "then": {
+            "required": [
+              "category",
+              "notification_text"
+            ]
+          }
+        },
+        "template": {
+          "type": "string",
+          "enum": [
+            "cfr_doorhanger",
+            "milestone_message"
+          ]
+        }
+      },
+      "additionalProperties": true,
+      "required": [
+        "targeting",
+        "trigger"
+      ],
+      "$defs": {
+        "plainText": {
+          "description": "Plain text (no HTML allowed)",
+          "type": "string"
+        },
+        "linkUrl": {
+          "description": "Target for links or buttons",
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "InfoBar": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "$id": "file:///InfoBar.schema.json",
+      "title": "InfoBar",
+      "description": "A template with an image, test and buttons.",
+      "allOf": [
+        {
+          "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/Message"
+        }
+      ],
+      "type": "object",
+      "properties": {
+        "content": {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "description": "Should the message be global (persisted across tabs) or local (disappear when switching to a different tab).",
+              "enum": [
+                "global",
+                "tab"
+              ]
+            },
+            "text": {
+              "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/localizableText",
+              "description": "The text show in the notification box."
+            },
+            "priority": {
+              "description": "Infobar priority level https://searchfox.org/mozilla-central/rev/3aef835f6cb12e607154d56d68726767172571e4/toolkit/content/widgets/notificationbox.js#387",
+              "type": "number",
+              "minumum": 0,
+              "exclusiveMaximum": 10
+            },
+            "buttons": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "label": {
+                    "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/localizableText",
+                    "description": "The text label of the button."
+                  },
+                  "primary": {
+                    "type": "boolean",
+                    "description": "Is this the primary button?"
+                  },
+                  "accessKey": {
+                    "type": "string",
+                    "description": "Keyboard shortcut letter."
+                  },
+                  "action": {
+                    "type": "object",
+                    "properties": {
+                      "type": {
+                        "type": "string",
+                        "description": "Action dispatched by the button."
+                      },
+                      "data": {
+                        "type": "object"
+                      }
+                    },
+                    "required": [
+                      "type"
+                    ],
+                    "additionalProperties": true
+                  },
+                  "supportPage": {
+                    "type": "string",
+                    "description": "A page title on SUMO to link to"
+                  }
+                },
+                "required": [
+                  "label",
+                  "action"
+                ],
+                "additionalProperties": true
+              }
+            }
+          },
+          "additionalProperties": true,
+          "required": [
+            "text",
+            "buttons"
+          ]
+        },
+        "template": {
+          "type": "string",
+          "const": "infobar"
+        }
+      },
+      "additionalProperties": true,
+      "required": [
+        "targeting",
+        "trigger"
+      ],
+      "$defs": {
+        "plainText": {
+          "description": "Plain text (no HTML allowed)",
+          "type": "string"
+        },
+        "linkUrl": {
+          "description": "Target for links or buttons",
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "NewtabPromoMessage": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "$id": "file:///NewtabPromoMessage.schema.json",
+      "title": "PBNewtabPromoMessage",
+      "description": "Message shown on the private browsing newtab page.",
+      "allOf": [
+        {
+          "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/Message"
+        }
+      ],
+      "type": "object",
+      "properties": {
+        "content": {
+          "type": "object",
+          "properties": {
+            "hideDefault": {
+              "type": "boolean",
+              "description": "Should we hide the default promo after the experiment promo is dismissed."
+            },
+            "infoEnabled": {
+              "type": "boolean",
+              "description": "Should we show the info section."
+            },
+            "infoIcon": {
+              "type": "string",
+              "description": "Icon shown in the left side of the info section. Default is the private browsing icon."
+            },
+            "infoTitle": {
+              "type": "string",
+              "description": "Is the title in the info section enabled."
+            },
+            "infoTitleEnabled": {
+              "type": "boolean",
+              "description": "Is the title in the info section enabled."
+            },
+            "infoBody": {
+              "type": "string",
+              "description": "Text content in the info section."
+            },
+            "infoLinkText": {
+              "type": "string",
+              "description": "Text for the link in the info section."
+            },
+            "infoLinkUrl": {
+              "type": "string",
+              "description": "URL for the info section link.",
+              "format": "moz-url-format"
+            },
+            "promoEnabled": {
+              "type": "boolean",
+              "description": "Should we show the promo section."
+            },
+            "promoType": {
+              "type": "string",
+              "description": "Promo type used to determine if promo should show to a given user",
+              "enum": [
+                "FOCUS",
+                "VPN",
+                "PIN",
+                "COOKIE_BANNERS",
+                "OTHER"
+              ]
+            },
+            "promoSectionStyle": {
+              "type": "string",
+              "description": "Sets the position of the promo section. Possible values are: top, below-search, bottom. Default bottom.",
+              "enum": [
+                "top",
+                "below-search",
+                "bottom"
+              ]
+            },
+            "promoTitle": {
+              "type": "string",
+              "description": "The text content of the promo section."
+            },
+            "promoTitleEnabled": {
+              "type": "boolean",
+              "description": "Should we show text content in the promo section."
+            },
+            "promoLinkText": {
+              "type": "string",
+              "description": "The text of the link in the promo box."
+            },
+            "promoHeader": {
+              "type": "string",
+              "description": "The title of the promo section."
+            },
+            "promoButton": {
+              "type": "object",
+              "properties": {
+                "action": {
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "description": "Action dispatched by the button."
+                    },
+                    "data": {
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "type"
+                  ],
+                  "additionalProperties": true
+                }
+              },
+              "required": [
+                "action"
+              ]
+            },
+            "promoLinkType": {
+              "type": "string",
+              "description": "Type of promo link type. Possible values: link, button. Default is link.",
+              "enum": [
+                "link",
+                "button"
+              ]
+            },
+            "promoImageLarge": {
+              "type": "string",
+              "description": "URL for image used on the left side of the promo box, larger, showcases some feature. Default off.",
+              "format": "uri"
+            },
+            "promoImageSmall": {
+              "type": "string",
+              "description": "URL for image used on the right side of the promo box, smaller, usually a logo. Default off.",
+              "format": "uri"
+            }
+          },
+          "additionalProperties": true,
+          "allOf": [
+            {
+              "if": {
+                "properties": {
+                  "promoEnabled": {
+                    "const": true
+                  }
+                },
+                "required": [
+                  "promoEnabled"
+                ]
+              },
+              "then": {
+                "required": [
+                  "promoButton"
+                ]
+              }
+            },
+            {
+              "if": {
+                "properties": {
+                  "infoEnabled": {
+                    "const": true
+                  }
+                },
+                "required": [
+                  "infoEnabled"
+                ]
+              },
+              "then": {
+                "required": [
+                  "infoLinkText"
+                ],
+                "if": {
+                  "properties": {
+                    "infoTitleEnabled": {
+                      "const": true
+                    }
+                  },
+                  "required": [
+                    "infoTitleEnabled"
+                  ]
+                },
+                "then": {
+                  "required": [
+                    "infoTitle"
+                  ]
+                }
+              }
+            }
+          ]
+        },
+        "template": {
+          "type": "string",
+          "const": "pb_newtab"
+        }
+      },
+      "additionalProperties": true,
+      "required": [
+        "targeting"
+      ]
+    },
+    "ProtectionsPanelMessage": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "$id": "file:///ProtectionsPanelMessage.schema.json",
+      "title": "ProtectionsPanelMessage",
+      "description": "A message shown in the protections panel.",
+      "allOf": [
+        {
+          "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/Message"
+        }
+      ],
+      "type": "object",
+      "properties": {
+        "content": {
+          "type": "object",
+          "properties": {
+            "title": {
+              "description": "The message title.",
+              "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/localizableText"
+            },
+            "body": {
+              "description": "The body of the message.",
+              "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/localizableText"
+            },
+            "link_text": {
+              "description": "The text of the call to action link.",
+              "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/localizableText"
+            },
+            "cta_type": {
+              "description": "The type of URL open action.",
+              "type": "string",
+              "enum": [
+                "OPEN_URL",
+                "OPEN_PROTECTION_REPORT",
+                "OPEN_ABOUT_PAGE"
+              ]
+            },
+            "cta_url": {
+              "description": "The URL to open when the call to action is clicked",
+              "type": "string",
+              "format": "moz-url-format"
+            },
+            "cta_where": {
+              "description": "How to open the cta.",
+              "type": "string",
+              "enum": [
+                "current",
+                "tabshifted",
+                "tab",
+                "save",
+                "window"
+              ]
+            }
+          },
+          "dependantSchemas": {
+            "link_text": [
+              "cta_type",
+              "cta_url"
+            ],
+            "cta_type": [
+              "link_text"
+            ],
+            "cta_url": [
+              "link_text"
+            ],
+            "cta_where": [
+              "link_text"
+            ]
+          },
+          "additionalProperties": false,
+          "required": [
+            "title",
+            "body"
+          ]
+        },
+        "template": {
+          "type": "string",
+          "const": "protections_panel"
+        },
+        "trigger": {
+          "description": "An action to trigger potentially showing the message. The action ID `protectionsPanelOpen` is required.",
+          "const": {
+            "id": "protectionsPanelOpen"
+          }
+        }
+      },
+      "required": [
+        "content",
+        "template",
+        "trigger"
+      ],
+      "additionalProperties": true
+    },
+    "Spotlight": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "$id": "file:///Spotlight.schema.json",
+      "title": "Spotlight",
+      "description": "A template with an image, title, content and two buttons.",
+      "allOf": [
+        {
+          "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/Message"
+        }
+      ],
+      "type": "object",
+      "properties": {
+        "content": {
+          "type": "object",
+          "properties": {
+            "template": {
+              "type": "string",
+              "description": "Specify the layout template for the Spotlight",
+              "const": "multistage"
+            },
+            "backdrop": {
+              "type": "string",
+              "description": "Background css behind modal content"
+            },
+            "logo": {
+              "type": "object",
+              "properties": {
+                "imageURL": {
+                  "type": "string",
+                  "description": "URL for image to use with the content"
+                },
+                "imageId": {
+                  "type": "string",
+                  "description": "The ID for a remotely hosted image"
+                },
+                "size": {
+                  "type": "string",
+                  "description": "The logo size."
+                }
+              },
+              "additionalProperties": true
+            },
+            "screens": {
+              "type": "array",
+              "description": "Collection of individual screen content"
+            },
+            "transitions": {
+              "type": "boolean",
+              "description": "Show transitions within and between screens"
+            },
+            "disableHistoryUpdates": {
+              "type": "boolean",
+              "description": "Don't alter the browser session's history stack - used with messaging surfaces like Feature Callouts"
+            },
+            "startScreen": {
+              "type": "integer",
+              "description": "Index of first screen to show from message, defaulting to 0"
+            }
+          },
+          "additionalProperties": true
+        },
+        "template": {
+          "type": "string",
+          "description": "Specify whether the surface is shown as a Spotlight modal or an in-surface Feature Callout dialog",
+          "enum": [
+            "spotlight",
+            "feature_callout"
+          ]
+        }
+      },
+      "additionalProperties": true,
+      "required": [
+        "targeting"
+      ]
+    },
+    "ToastNotification": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "$id": "file:///ToastNotification.schema.json",
+      "title": "ToastNotification",
+      "description": "A template for toast notifications displayed by the Alert service.",
+      "allOf": [
+        {
+          "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/Message"
+        }
+      ],
+      "type": "object",
+      "properties": {
+        "content": {
+          "type": "object",
+          "properties": {
+            "title": {
+              "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/localizableText",
+              "description": "Id of localized string or message override of toast notification title"
+            },
+            "body": {
+              "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/localizableText",
+              "description": "Id of localized string or message override of toast notification body"
+            },
+            "icon_url": {
+              "description": "The URL of the image used as an icon of the toast notification.",
+              "type": "string",
+              "format": "moz-url-format"
+            },
+            "image_url": {
+              "description": "The URL of an image to be displayed as part of the notification.",
+              "type": "string",
+              "format": "moz-url-format"
+            },
+            "launch_url": {
+              "description": "The URL to launch when the notification or an action button is clicked.",
+              "type": "string",
+              "format": "moz-url-format"
+            },
+            "launch_action": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "description": "The launch action to be performed when Firefox is launched."
+                },
+                "data": {
+                  "type": "object"
+                }
+              },
+              "required": [
+                "type"
+              ],
+              "additionalProperties": true
+            },
+            "requireInteraction": {
+              "type": "boolean",
+              "description": "Whether the toast notification should remain active until the user clicks or dismisses it, rather than closing automatically."
+            },
+            "tag": {
+              "type": "string",
+              "description": "An identifying tag for the toast notification."
+            },
+            "data": {
+              "type": "object",
+              "description": "Arbitrary data associated with the toast notification."
+            },
+            "actions": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "title": {
+                    "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/localizableText",
+                    "description": "The action text to be shown to the user."
+                  },
+                  "action": {
+                    "type": "string",
+                    "description": "Opaque identifer that identifies action."
+                  },
+                  "iconURL": {
+                    "type": "string",
+                    "format": "uri",
+                    "description": "URL of an icon to display with the action."
+                  },
+                  "windowsSystemActivationType": {
+                    "type": "boolean",
+                    "description": "Whether to have Windows process the given `action`."
+                  },
+                  "launch_action": {
+                    "type": "object",
+                    "properties": {
+                      "type": {
+                        "type": "string",
+                        "description": "The launch action to be performed when Firefox is launched."
+                      },
+                      "data": {
+                        "type": "object"
+                      }
+                    },
+                    "required": [
+                      "type"
+                    ],
+                    "additionalProperties": true
+                  }
+                },
+                "required": [
+                  "action",
+                  "title"
+                ],
+                "additionalProperties": true
+              }
+            }
+          },
+          "additionalProperties": true,
+          "required": [
+            "title",
+            "body"
+          ]
+        },
+        "template": {
+          "type": "string",
+          "const": "toast_notification"
+        }
+      },
+      "required": [
+        "content",
+        "targeting",
+        "template",
+        "trigger"
+      ],
+      "additionalProperties": true
+    },
+    "ToolbarBadgeMessage": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "$id": "file:///ToolbarBadgeMessage.schema.json",
+      "title": "ToolbarBadgeMessage",
+      "description": "A template that specifies to which element in the browser toolbar to add a notification.",
+      "allOf": [
+        {
+          "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/Message"
+        }
+      ],
+      "type": "object",
+      "properties": {
+        "content": {
+          "type": "object",
+          "properties": {
+            "target": {
+              "type": "string"
+            },
+            "action": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": true,
+              "required": [
+                "id"
+              ],
+              "description": "Optional action to take in addition to showing the notification"
+            },
+            "delay": {
+              "type": "number",
+              "description": "Optional delay in ms after which to show the notification"
+            },
+            "badgeDescription": {
+              "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/localizedText",
+              "description": "This is used in combination with the badged button to offer a text based alternative to the visual badging. Example 'New Feature: What's New'"
+            }
+          },
+          "additionalProperties": true,
+          "required": [
+            "target"
+          ]
+        },
+        "template": {
+          "type": "string",
+          "const": "toolbar_badge"
+        }
+      },
+      "additionalProperties": true,
+      "required": [
+        "targeting"
+      ]
+    },
+    "UpdateAction": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "$id": "file:///UpdateAction.schema.json",
+      "title": "UpdateActionMessage",
+      "description": "A template for messages that execute predetermined actions.",
+      "allOf": [
+        {
+          "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/Message"
+        }
+      ],
+      "type": "object",
+      "properties": {
+        "content": {
+          "type": "object",
+          "properties": {
+            "action": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "data": {
+                  "type": "object",
+                  "description": "Additional data provided as argument when executing the action",
+                  "properties": {
+                    "url": {
+                      "type": "string",
+                      "description": "URL data to be used as argument to the action"
+                    },
+                    "expireDelta": {
+                      "type": "number",
+                      "description": "Expiration timestamp to be used as argument to the action"
+                    }
+                  }
+                }
+              },
+              "additionalProperties": true,
+              "description": "Optional action to take in addition to showing the notification",
+              "required": [
+                "id",
+                "data"
+              ]
+            }
+          },
+          "additionalProperties": true,
+          "required": [
+            "action"
+          ]
+        },
+        "template": {
+          "type": "string",
+          "const": "update_action"
+        }
+      },
+      "required": [
+        "targeting"
+      ]
+    },
+    "WhatsNewMessage": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "$id": "file:///WhatsNewMessage.schema.json",
+      "title": "WhatsNewMessage",
+      "description": "A template for the messages that appear in the What's New panel.",
+      "allOf": [
+        {
+          "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/Message"
+        }
+      ],
+      "type": "object",
+      "properties": {
+        "content": {
+          "type": "object",
+          "properties": {
+            "layout": {
+              "description": "Different message layouts",
+              "enum": [
+                "tracking-protections"
+              ]
+            },
+            "bucket_id": {
+              "type": "string",
+              "description": "A bucket identifier for the addon. This is used in order to anonymize telemetry for history-sensitive targeting."
+            },
+            "published_date": {
+              "type": "integer",
+              "description": "The date/time (number of milliseconds elapsed since January 1, 1970 00:00:00 UTC) the message was published."
+            },
+            "title": {
+              "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/localizableText",
+              "description": "Id of localized string or message override of What's New message title"
+            },
+            "subtitle": {
+              "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/localizableText",
+              "description": "Id of localized string or message override of What's New message subtitle"
+            },
+            "body": {
+              "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/localizableText",
+              "description": "Id of localized string or message override of What's New message body"
+            },
+            "link_text": {
+              "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/localizableText",
+              "description": "(optional) Id of localized string or message override of What's New message link text"
+            },
+            "cta_url": {
+              "description": "Target URL for the What's New message.",
+              "type": "string",
+              "format": "moz-url-format"
+            },
+            "cta_type": {
+              "description": "Type of url open action",
+              "enum": [
+                "OPEN_URL",
+                "OPEN_ABOUT_PAGE",
+                "OPEN_PROTECTION_REPORT"
+              ]
+            },
+            "cta_where": {
+              "description": "How to open the cta: new window, tab, focused, unfocused.",
+              "enum": [
+                "current",
+                "tabshifted",
+                "tab",
+                "save",
+                "window"
+              ]
+            },
+            "icon_url": {
+              "description": "(optional) URL for the What's New message icon.",
+              "type": "string",
+              "format": "uri"
+            },
+            "icon_alt": {
+              "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/localizableText",
+              "description": "Alt text for image."
+            }
+          },
+          "additionalProperties": true,
+          "required": [
+            "published_date",
+            "title",
+            "body",
+            "cta_url",
+            "bucket_id"
+          ]
+        },
+        "template": {
+          "type": "string",
+          "const": "whatsnew_panel_message"
+        }
+      },
+      "required": [
+        "order"
+      ],
+      "additionalProperties": true
+    },
+    "Message": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "The message identifier"
+        },
+        "groups": {
+          "description": "Array of preferences used to control `enabled` status of the group. If any is `false` the group is disabled.",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "description": "Preference name"
+          }
+        },
+        "template": {
+          "type": "string",
+          "description": "Which messaging template this message is using.",
+          "enum": [
+            "cfr_urlbar_chiclet",
+            "cfr_doorhanger",
+            "milestone_message",
+            "infobar",
+            "pb_newtab",
+            "protections_panel",
+            "spotlight",
+            "feature_callout",
+            "toast_notification",
+            "toolbar_badge",
+            "update_action",
+            "whatsnew_panel_message"
+          ]
+        },
+        "frequency": {
+          "type": "object",
+          "description": "An object containing frequency cap information for a message.",
+          "properties": {
+            "lifetime": {
+              "type": "integer",
+              "description": "The maximum lifetime impressions for a message.",
+              "minimum": 1,
+              "maximum": 100
+            },
+            "custom": {
+              "type": "array",
+              "description": "An array of custom frequency cap definitions.",
+              "items": {
+                "description": "A frequency cap definition containing time and max impression information",
+                "type": "object",
+                "properties": {
+                  "period": {
+                    "type": "integer",
+                    "description": "Period of time in milliseconds (e.g. 86400000 for one day)"
+                  },
+                  "cap": {
+                    "type": "integer",
+                    "description": "The maximum impressions for the message within the defined period.",
+                    "minimum": 1,
+                    "maximum": 100
+                  }
+                },
+                "required": [
+                  "period",
+                  "cap"
+                ]
+              }
+            }
+          }
+        },
+        "priority": {
+          "description": "The priority of the message. If there are two competing messages to show, the one with the highest priority will be shown",
+          "type": "integer"
+        },
+        "order": {
+          "description": "The order in which messages should be shown. Messages will be shown in increasing order.",
+          "type": "integer"
+        },
+        "targeting": {
+          "description": "A JEXL expression representing targeting information",
+          "type": "string"
+        },
+        "trigger": {
+          "description": "An action to trigger potentially showing the message",
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "A string identifying the trigger action"
+            },
+            "params": {
+              "type": "array",
+              "description": "An optional array of string parameters for the trigger action",
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "string"
+                  }
+                ]
+              }
+            }
+          },
+          "required": [
+            "id"
+          ]
+        },
+        "provider": {
+          "description": "An identifier for the provider of this message, such as \"cfr\" or \"preview\".",
+          "type": "string"
+        }
+      },
+      "additionalProperties": true,
+      "dependentRequired": {
+        "content": [
+          "id",
+          "template"
+        ],
+        "template": [
+          "id",
+          "content"
+        ]
+      }
+    },
+    "localizedText": {
+      "type": "object",
+      "properties": {
+        "string_id": {
+          "description": "Id of localized string to be rendered.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "string_id"
+      ]
+    },
+    "localizableText": {
+      "description": "Either a raw string or an object containing the string_id of the localized text",
+      "oneOf": [
+        {
+          "type": "string",
+          "description": "The string to be rendered."
+        },
+        {
+          "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/localizedText"
+        }
+      ]
+    },
+    "TemplatedMessage": {
+      "description": "An FxMS message of one of a variety of types.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/Message"
+        },
+        {
+          "if": {
+            "type": "object",
+            "properties": {
+              "template": {
+                "type": "string",
+                "enum": [
+                  "cfr_urlbar_chiclet"
+                ]
+              }
+            },
+            "required": [
+              "template"
+            ]
+          },
+          "then": {
+            "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/CFRUrlbarChiclet"
+          }
+        },
+        {
+          "if": {
+            "type": "object",
+            "properties": {
+              "template": {
+                "type": "string",
+                "enum": [
+                  "cfr_doorhanger",
+                  "milestone_message"
+                ]
+              }
+            },
+            "required": [
+              "template"
+            ]
+          },
+          "then": {
+            "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/ExtensionDoorhanger"
+          }
+        },
+        {
+          "if": {
+            "type": "object",
+            "properties": {
+              "template": {
+                "type": "string",
+                "enum": [
+                  "infobar"
+                ]
+              }
+            },
+            "required": [
+              "template"
+            ]
+          },
+          "then": {
+            "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/InfoBar"
+          }
+        },
+        {
+          "if": {
+            "type": "object",
+            "properties": {
+              "template": {
+                "type": "string",
+                "enum": [
+                  "pb_newtab"
+                ]
+              }
+            },
+            "required": [
+              "template"
+            ]
+          },
+          "then": {
+            "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/NewtabPromoMessage"
+          }
+        },
+        {
+          "if": {
+            "type": "object",
+            "properties": {
+              "template": {
+                "type": "string",
+                "enum": [
+                  "protections_panel"
+                ]
+              }
+            },
+            "required": [
+              "template"
+            ]
+          },
+          "then": {
+            "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/ProtectionsPanelMessage"
+          }
+        },
+        {
+          "if": {
+            "type": "object",
+            "properties": {
+              "template": {
+                "type": "string",
+                "enum": [
+                  "spotlight",
+                  "feature_callout"
+                ]
+              }
+            },
+            "required": [
+              "template"
+            ]
+          },
+          "then": {
+            "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/Spotlight"
+          }
+        },
+        {
+          "if": {
+            "type": "object",
+            "properties": {
+              "template": {
+                "type": "string",
+                "enum": [
+                  "toast_notification"
+                ]
+              }
+            },
+            "required": [
+              "template"
+            ]
+          },
+          "then": {
+            "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/ToastNotification"
+          }
+        },
+        {
+          "if": {
+            "type": "object",
+            "properties": {
+              "template": {
+                "type": "string",
+                "enum": [
+                  "toolbar_badge"
+                ]
+              }
+            },
+            "required": [
+              "template"
+            ]
+          },
+          "then": {
+            "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/ToolbarBadgeMessage"
+          }
+        },
+        {
+          "if": {
+            "type": "object",
+            "properties": {
+              "template": {
+                "type": "string",
+                "enum": [
+                  "update_action"
+                ]
+              }
+            },
+            "required": [
+              "template"
+            ]
+          },
+          "then": {
+            "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/UpdateAction"
+          }
+        },
+        {
+          "if": {
+            "type": "object",
+            "properties": {
+              "template": {
+                "type": "string",
+                "enum": [
+                  "whatsnew_panel_message"
+                ]
+              }
+            },
+            "required": [
+              "template"
+            ]
+          },
+          "then": {
+            "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/WhatsNewMessage"
+          }
+        }
+      ]
+    },
+    "MultiMessage": {
+      "description": "An object containing an array of messages.",
+      "type": "object",
+      "properties": {
+        "template": {
+          "type": "string",
+          "const": "multi"
+        },
+        "messages": {
+          "type": "array",
+          "description": "An array of messages.",
+          "items": {
+            "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/TemplatedMessage"
+          }
+        }
+      },
+      "required": [
+        "template",
+        "messages"
+      ]
+    }
+  }
+}

--- a/experimenter/experimenter/features/manifests/firefox-desktop/v120.0.0/schemas/toolkit/components/normandy/schemas/LegacyHeartbeat.schema.json
+++ b/experimenter/experimenter/features/manifests/firefox-desktop/v120.0.0/schemas/toolkit/components/normandy/schemas/LegacyHeartbeat.schema.json
@@ -1,0 +1,73 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Legacy (Normandy) Heartbeat, via Nimbus",
+  "description": "The schema for the Legacy Heartbeat Nimbus feature.",
+  "type": "object",
+  "properties": {
+    "survey": {
+      "$comment": "Hearbeat arguments are nested under survey to prevent simultaneous rollouts and experiments from overriding eachothers optional variables",
+      "type": "object",
+      "properties": {
+        "repeatOption": {
+          "type": "string",
+          "enum": ["once", "xdays", "nag"],
+          "description": "Determines how often a prompt is shown executes.",
+          "default": "once"
+        },
+        "repeatEvery": {
+          "description": "For repeatOption=xdays, how often (in days) the prompt is displayed.",
+          "default": null,
+          "type": ["number", "null"]
+        },
+        "includeTelemetryUUID": {
+          "type": "boolean",
+          "description": "Include unique user ID in post-answer-url and Telemetry",
+          "default": false
+        },
+        "surveyId": {
+          "description": "Slug uniquely identifying this survey in telemetry",
+          "type": "string"
+        },
+        "message": {
+          "description": "Message to show to the user",
+          "type": "string"
+        },
+        "engagementButtonLabel": {
+          "description": "Text for the engagement button. If specified, this button will be shown instead of rating stars.",
+          "default": null,
+          "type": ["string", "null"]
+        },
+        "thanksMessage": {
+          "description": "Thanks message to show to the user after they've rated Firefox",
+          "type": "string"
+        },
+        "postAnswerUrl": {
+          "description": "URL to redirect the user to after rating Firefox or clicking the engagement button",
+          "default": null,
+          "type": ["string", "null"]
+        },
+        "learnMoreMessage": {
+          "description": "Message to show to the user to learn more",
+          "default": null,
+          "type": ["string", "null"]
+        },
+        "learnMoreUrl": {
+          "description": "URL to show to the user when they click Learn More",
+          "default": null,
+          "type": ["string", "null"]
+        }
+      },
+      "required": [
+        "surveyId",
+        "message",
+        "thanksMessage",
+        "postAnswerUrl",
+        "learnMoreMessage",
+        "learnMoreUrl"
+      ],
+      "additionalProperties": false
+    }
+  },
+  "required": ["survey"],
+  "additionalProperties": false
+}

--- a/experimenter/experimenter/features/manifests/firefox-desktop/v121.0.0/experimenter.yaml
+++ b/experimenter/experimenter/features/manifests/firefox-desktop/v121.0.0/experimenter.yaml
@@ -1,0 +1,1992 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# Features must be added here to be accessible through the NimbusFeature API.
+
+"no-feature-firefox-desktop":
+  description: A dummy feature for experiments that target no feature.
+  owner: barret@mozilla.com
+  applications:
+    - firefox-desktop
+    - firefox-desktop-background-task
+  hasExposure: false
+  variables: {}
+
+testFeature:
+  description: Test only feature
+  owner: barret@mozilla.com
+  applications:
+    - firefox-desktop
+    - firefox-desktop-background-task
+  hasExposure: false
+  isEarlyStartup: true
+  variables:
+    enabled:
+      type: boolean
+      description: Whether or not this feature is enabled
+    testInt:
+      type: int
+      fallbackPref: nimbus.testing.testInt
+      description: Int pref used by platform API tests
+    testSetString:
+      type: string
+      setPref: nimbus.testing.testSetString
+      description: A string pref set by Nimbus tests
+
+nimbus-qa-1:
+  description: A feature for testing pref-setting on the default branch.
+  owner: barret@mozilla.com
+  hasExposure: false
+  variables:
+    value:
+      type: string
+      setPref: nimbus.qa.pref-1
+      description: The value to set for the pref.
+
+nimbus-qa-2:
+  description: A feature for testing pref-setting on the user branch.
+  owner: barret@mozilla.com
+  isEarlyStartup: true
+  hasExposure: false
+  variables:
+    value:
+      type: string
+      setPref: nimbus.qa.pref-2
+      description: The value to set for the pref.
+
+# `search` is for search engine experimentation features which do not require
+# isEarlyStartup to be set.
+search:
+  description: Search engine experimentation support and testing features.
+  owner: search-and-suggest-program@mozilla.com
+  hasExposure: false
+  variables:
+    extraParams:
+      type: json
+      description: >-
+        This allows extra parameters to be set for search engines requests including,
+        where calls to the suggestions API, the search engine configuration defines
+        those parameters.
+
+        The use of this field should be coordinated with the Search team.
+
+        The field value is an array of objects with key/value fields. For example:
+
+        [
+          {"key": "google_channel_row", "value": "foo"}
+        ]
+
+        This is matched to a section in the search configuration:
+
+        "extraParams": [
+          {
+            "name": "channel",
+            "pref": "google_channel_row",
+            "condition": "pref"
+          }
+        ],
+
+        In this case, the resulting URL for the appropriate search engine would have
+        `&channel=foo` added to the URL when doing searches.
+
+        If the key is not referenced in the search configuration, then no parameter
+        will be added. Only the search team can update the configuration.
+    cbhStudyUs:
+      type: string
+      setPref: browser.search.param.google_channel_us
+      description: >-
+        NOTE: Please use `extraParams` rather than this field.
+        A string pref set by Nimbus tests for US search cohort
+    cbhStudyRow:
+      type: string
+      setPref: browser.search.param.google_channel_row
+      description: >-
+        NOTE: Please use `extraParams` rather than this field.
+        A string pref set by Nimbus tests for Rest of World (ROW) search cohort
+    richSuggestionsFeatureGate:
+      type: boolean
+      setPref: browser.urlbar.richSuggestions.featureGate
+      description: >-
+        Feature gate that controls whether Rich Suggestions are enabled.
+    serpEventTelemetryEnabled:
+      type: boolean
+      setPref: browser.search.serpEventTelemetry.enabled
+      description: Whether the Glean SERP event telemetry is enabled.
+    serpEventTelemetryCategorizationEnabled:
+      type: boolean
+      setPref: browser.search.serpEventTelemetryCategorization.enabled
+      description: Whether the Glean SERP event telemetry for SERP categorization is enabled.
+    trendingEnabled:
+      type: boolean
+      setPref: browser.urlbar.trending.featureGate
+      description: Feature gate that controls whether trending suggestions are enabled.
+    trendingRequireSearchMode:
+      type: boolean
+      setPref: browser.urlbar.trending.requireSearchMode
+      description: Controls whether trending suggestions are only shown in search mode or not.
+    trendingMaxResultsNoSearchMode:
+      type: int
+      setPref: browser.urlbar.trending.maxResultsNoSearchMode
+      description: The maximum number of trending results mode outside search mode.
+
+# `searchConfiguration` is for search experiment features for items that require
+# isEarlyStartup to be true. These items may require a reload of the search
+# engine configuration, and an additional reload may happen during the startup
+# process.
+searchConfiguration:
+  description: Search experimentation support for the engine configuration
+  owner: search-and-suggest-program@mozilla.com
+  isEarlyStartup: true
+  hasExposure: false
+  variables:
+    experiment:
+      type: string
+      fallbackPref: browser.search.experiment
+      description: >-
+        Used to activate only matching configurations that contain the value in
+        `experiment`
+    seperatePrivateDefaultUIEnabled:
+      type: boolean
+      description: Whether the UI for the separate private default feature is enabled.
+    seperatePrivateDefaultUrlbarResultEnabled:
+      type: boolean
+      description: Whether the urlbar result for the separate private default is shown.
+
+urlbar:
+  description: The Address Bar
+  owner: search-and-suggest-program@mozilla.com
+  hasExposure: true
+  exposureDescription: >-
+    The timing of the exposure event depends on the experiment, but generally
+    the event is recorded once per app session when the user first encounters
+    the UI of the experiment in which they're enrolled.
+  variables:
+    addonsFeatureGate:
+      type: boolean
+      fallbackPref: browser.urlbar.addons.featureGate
+      description: >-
+        Feature gate that controls whether all aspects of the addons suggestion
+        feature are exposed to the user.
+    addonsShowLessFrequentlyCap:
+      type: int
+      description: >-
+        If defined and non-zero, this is the maximum number of times the user
+        will be able to click the "Show less frequently" command for addon
+        suggestions. If undefined or zero, the user will be able to click the
+        command without any limit.
+    autoFillAdaptiveHistoryEnabled:
+      type: boolean
+      fallbackPref: browser.urlbar.autoFill.adaptiveHistory.enabled
+      description: Whether enabling adaptive history autofill.
+    autoFillAdaptiveHistoryMinCharsThreshold:
+      type: int
+      fallbackPref: browser.urlbar.autoFill.adaptiveHistory.minCharsThreshold
+      description: Minimum char length of the user's search string to trigger adaptive history autofill.
+    autoFillAdaptiveHistoryUseCountThreshold:
+      type: string
+      description: This value assumes float expression like "0.47". Threshold for use count of input history that we handle as adaptive history autofill. If the use count is this value or more, it will be a candidate.
+    experimentType:
+      type: string
+      description: The type of the experiment (or rollout). If "best-match", then the Nimbus exposure event will be recorded when the user first triggers a best match (or would have triggered a best match, for users in the control group). If "modal", the event will be recorded when the user first triggers to show the onbording dialog. If empty, the event will be recorded when the user first triggers any type of Suggest suggestion.
+      enum:
+        - best-match
+        - modal
+        - ""
+    mdnFeatureGate:
+      type: boolean
+      setPref: browser.urlbar.mdn.featureGate
+      description: >-
+        Feature gate that controls whether all aspects of the mdn suggestion
+        feature are exposed to the user.
+    merinoClientVariants:
+      type: string
+      fallbackPref: browser.urlbar.merino.clientVariants
+      description: >-
+        Comma separated list of client variants to report to the Merino server.
+        May impact server behavior.
+    merinoEndpointURL:
+      type: string
+      fallbackPref: browser.urlbar.merino.endpointURL
+      description: >-
+        The Merino endpoint URL, not including parameters. An empty string will
+        cause Firefox not to fetch from Merino.
+    merinoProviders:
+      type: string
+      fallbackPref: browser.urlbar.merino.providers
+      description: >-
+        Comma-separated list of providers to request from the Merino server.
+        Merino will return suggestions only for these providers.
+    merinoTimeoutMs:
+      type: int
+      fallbackPref: browser.urlbar.merino.timeoutMs
+      description: Timeout for Merino fetches (ms)
+    exposureResults:
+      type: string
+      setPref: browser.urlbar.exposureResults
+      description: >-
+        Comma-separated list of result type combinations, that are used to determine if an exposure event should be fired.
+    showExposureResults:
+      type: boolean
+      setPref: browser.urlbar.showExposureResults
+      description: >-
+        Boolean used to determine if the results defined in `exposureResults` should be shown in search results. Should be false for Control branch of an experiment.
+    pocketFeatureGate:
+      type: boolean
+      fallbackPref: browser.urlbar.pocket.featureGate
+      description: >-
+        Feature gate that controls whether all aspects of the Pocket suggestions
+        feature are exposed to the user.
+    pocketShowLessFrequentlyCap:
+      type: int
+      description: >-
+        If defined and non-zero, this is the maximum number of times the user
+        will be able to click the "Show less frequently" command for Pocket
+        suggestions. If undefined or zero, the user will be able to click the
+        command without any limit.
+    quickSuggestAllowPositionInSuggestions:
+      type: boolean
+      fallbackPref: browser.urlbar.quicksuggest.allowPositionInSuggestions
+      description: Whether quick suggest results can be shown in position specified in the suggestions.
+    quickSuggestContextualOptInEnabled:
+      type: boolean
+      setPref: browser.urlbar.quicksuggest.contextualOptIn
+      description: Whether the Firefox Suggest contextual opt-in result is enabled. If true, this implicitly disables shouldShowOnboardingDialog.
+    quickSuggestContextualOptInSayHello:
+      type: boolean
+      setPref: browser.urlbar.quicksuggest.contextualOptIn.sayHello
+      description: Controls which variant of the copy is used for the Firefox Suggest contextual opt-in result.
+    quickSuggestContextualOptInTopPosition:
+      type: boolean
+      setPref: browser.urlbar.quicksuggest.contextualOptIn.topPosition
+      description: Controls whether the Firefox Suggest contextual opt-in result appears at the top of results or at the bottom, after one-off buttons.
+    quickSuggestDataCollectionEnabled:
+      type: boolean
+      description: Whether data collection should be enabled by default. If this variable is specified, it will override the value implied by the scenario. It will never override the user's local preference to disable (or enable) data collection, if the user has already toggled that preference.
+    quickSuggestEnabled:
+      type: boolean
+      fallbackPref: browser.urlbar.quicksuggest.enabled
+      description: Gate for the Firefox Suggest feature as a whole. If false, the Firefox Suggest preferences UI and Suggest suggestions will not be shown. If true, the preferences UI will be shown, and the user can turn suggestions on or off.
+    quickSuggestImpressionCapsSponsoredEnabled:
+      type: boolean
+      fallbackPref: browser.urlbar.quicksuggest.impressionCaps.sponsoredEnabled
+      description: Whether sponsored suggestions are subject to impression frequency caps. If false, sponsored suggestions can be shown an unlimited number of times over any given period. If true, sponsored suggestion impressions will be subject to the caps in the remote settings configuration.
+    quickSuggestImpressionCapsNonSponsoredEnabled:
+      type: boolean
+      fallbackPref: browser.urlbar.quicksuggest.impressionCaps.nonSponsoredEnabled
+      description: Whether non-sponsored suggestions are subject to impression frequency caps. If false, non-sponsored suggestions can be shown an unlimited number of times over any given period. If true, non-sponsored suggestion impressions will be subject to the caps in the remote settings configuration.
+    quickSuggestNonSponsoredEnabled:
+      type: boolean
+      description: Whether non-sponsored suggestions should be enabled by default. If this variable is specified, it will override the value implied by the scenario. It will never override the user's local preference to disable (or enable) non-sponsored suggestions, if the user has already toggled that preference.
+    quickSuggestNonSponsoredIndex:
+      type: int
+      fallbackPref: browser.urlbar.quicksuggest.nonSponsoredIndex
+      description: >-
+        The index of non-sponsored QuickSuggest results within the general
+        group. A negative index is relative to the end of the group
+    quickSuggestOnboardingDialogVariation:
+      type: string
+      description: >-
+        Specify the messages/UI variation for QuickSuggest onboarding dialog. This value is case insensitive.
+    quickSuggestRemoteSettingsDataType:
+      type: string
+      description: The `type` of the suggestions data in remote settings. If not specified, "data" is used.
+    quickSuggestRustEnabled:
+      type: boolean
+      fallbackPref: browser.urlbar.quicksuggest.rustEnabled
+      description: >-
+        Whether Firefox Suggest will use the new Rust backend instead of the
+        original JS backend.
+    quickSuggestScenario:
+      # IMPORTANT: This should not have a fallbackPref. See UrlbarPrefs.jsm.
+      type: string
+      description: The Firefox Suggest scenario in which the user is enrolled
+      enum:
+        - history
+        - offline
+        - online
+    quickSuggestScoreMap:
+      type: json
+      description: >-
+        A JSON object that maps telemetry result types to suggestion scores. If
+        a telemetry result type is present in this map, the client will use the
+        corresponding score as the score for all suggestions of the type,
+        overriding all other sources of scores for the type. In other words,
+        the scores in this map will override scores that are set in remote
+        settings and Merino as well as scores that are hardcoded in the client.
+        Example entries: `"amo": 0.5`, `"adm_sponsored": 0.9`
+    quickSuggestShouldShowOnboardingDialog:
+      type: boolean
+      fallbackPref: browser.urlbar.quicksuggest.shouldShowOnboardingDialog
+      description: Whether or not to show the QuickSuggest onboarding dialog
+    quickSuggestShowOnboardingDialogAfterNRestarts:
+      type: int
+      fallbackPref: browser.urlbar.quicksuggest.showOnboardingDialogAfterNRestarts
+      description: Show QuickSuggest onboarding dialog after N browser restarts
+    quickSuggestSponsoredEnabled:
+      type: boolean
+      description: Whether sponsored suggestions should be enabled by default. If this variable is specified, it will override the value implied by the scenario. It will never override the user's local preference to disable (or enable) sponsored suggestions, if the user has already toggled that preference.
+    quickSuggestSponsoredIndex:
+      type: int
+      fallbackPref: browser.urlbar.quicksuggest.sponsoredIndex
+      description: >-
+        The index of sponsored QuickSuggest results within the general group. A
+        negative index is relative to the end of the group
+    quickSuggestSponsoredPriority:
+      type: boolean
+      fallbackPref: browser.urlbar.quicksuggest.sponsoredPriority
+      description: >-
+        Whether or not showing sponsored suggestion as priority.
+        If this variable is true, the following things are processed.
+        * "Sponsored" label is shown as the group label.
+        * Change the suggested index to 1.
+        * Handle as top pick.
+    recentSearchesFeatureGate:
+      type: boolean
+      setPref: browser.urlbar.recentsearches.featureGate
+      description: Gate for the recent searches feature.
+    recentSearchesMaxResults:
+      type: int
+      setPref: browser.urlbar.recentsearches.maxResults
+      description: The maximum number of recent searches to show.
+    recordNavigationalSuggestionTelemetry:
+      type: boolean
+      description: Whether to record navigational suggestion telemetry. Defaults to false.
+    showSearchTermsFeatureGate:
+      type: boolean
+      fallbackPref: browser.urlbar.showSearchTerms.featureGate
+      description: Gate for the show search terms feature. If false, the preference#search will not show the search terms feature checkbox, and search terms will never persist in the urlbar. If true, the preference checkbox will be shown on preferences#search, and the user can choose to persist search terms on or off in the urlbar.
+    weatherFeatureGate:
+      type: boolean
+      fallbackPref: browser.urlbar.weather.featureGate
+      description: >-
+        Feature gate that controls whether all aspects of the weather suggestion
+        feature are exposed to the user. See also `weatherKeywords` and
+        `weatherKeywordsMinimumLength`. In summary: To enable the weather
+        suggestion, set `weatherFeatureGate` to true, `weatherKeywords` to an
+        array of full keyword strings, and `weatherKeywordsMinimumLength` to a
+        non-zero integer. To disable the weather suggestion, leave out all
+        weather-related variables.
+    weatherKeywords:
+      type: json
+      description: >-
+        An array of full keyword strings that will trigger the weather
+        suggestion when the user types them in the address bar. If absent or
+        null, Firefox will fall back to the weather keywords defined in remote
+        settings. If neither Nimbus nor remote settings defines any keywords,
+        the weather suggestion will be disabled. See also
+        `weatherKeywordsMinimumLength`.
+    weatherKeywordsMinimumLength:
+      type: int
+      description: >-
+        If defined and non-zero, the weather suggestion will be triggered by
+        typing any prefix of a full weather keyword when the prefix is at least
+        `weatherKeywordsMinimumLength` characters long. If this variable is
+        absent or zero, Firefox will fall back to the minimum length defined in
+        remote settings. If neither Nimbus nor remote settings defines a minimum
+        length, only full keywords will trigger the suggestion. See also
+        `weatherKeywords`.
+    weatherKeywordsMinimumLengthCap:
+      type: int
+      description: >-
+        If defined and non-zero, the user will not be able to increment the
+        minimum keyword length beyond this value. e.g., if this value is 6, the
+        current minimum length is 5, and the user clicks "Show less frequently",
+        then the minimum length will be incremented to 6, the "Show less
+        frequently" command will be hidden, and the user can continue to trigger
+        the weather suggestion by typing 6 characters, but they will not be able
+        to increment the minimum length any further. If this variable is absent
+        or zero, Firefox will fall back to the cap defined in remote settings.
+        If neither Nimbus nor remote settings defines a cap, no cap will be
+        used, and the user will be able to increment the minimum length without
+        any limit.
+
+frecency:
+  description: "The address bar ranking algorithm"
+  owner: search-and-suggest-program@mozilla.com
+  hasExposure: false
+  isEarlyStartup: true
+  variables:
+    originsAlternativeEnable:
+      description: >-
+        Use an alternative ranking algorithm for autofilling origins, that is
+        mainly domains of Web pages. When the user types the beginning of an
+        origin, we autofill the whole origin. Whether autofill happens depends
+        on the ranking algorithm. Bookmarks are always autofilled anyway.
+      type: boolean
+      setPref: "places.frecency.origins.alternative.featureGate"
+    originsDaysCutOff:
+      description: >-
+        The alternative ranking algorithm only considers pages visited in the
+        last N days, where N is controlled by this variable.
+      type: int
+      setPref: "places.frecency.origins.alternative.daysCutOff"
+    pagesAlternativeEnable:
+      description: >-
+        Use an alternative ranking algorithm for sorting history and bookmarks
+        among the urlbar results.
+      type: boolean
+      setPref: "places.frecency.pages.alternative.featureGate"
+    pagesNumSampledVisits:
+      description: >-
+        The number of recent visits to sample when calculating the ranking of
+        a page. Examining all the visits would be expensive, so we only sample
+        recent visits.
+      type: int
+      setPref: "places.frecency.pages.alternative.numSampledVisits"
+    pagesHalfLifeDays:
+      description: >-
+        The number of days after which the ranking halves. This implements the
+        "recency" part of the algorithm.
+      type: int
+      setPref: "places.frecency.pages.alternative.halfLifeDays"
+    pagesHighWeight:
+      description: >-
+        The weight to use for the high importance bucket.
+      type: int
+      setPref: "places.frecency.pages.alternative.highWeight"
+    pagesMediumWeight:
+      description: >-
+        The weight to use for the medium importance bucket.
+      type: int
+      setPref: "places.frecency.pages.alternative.mediumWeight"
+    pagesLowWeight:
+      description: >-
+        The weight to use for the low importance bucket.
+      type: int
+      setPref: "places.frecency.pages.alternative.lowWeight"
+
+aboutwelcome:
+  description: "The about:welcome page"
+  owner: omc@mozilla.com
+  hasExposure: true
+  exposureDescription: >-
+    Exposure is sent once per browsing session when the about:welcome URL is
+    first accessed.
+  isEarlyStartup: true
+  variables:
+    enabled:
+      type: boolean
+      fallbackPref: browser.aboutwelcome.enabled
+      description: >-
+        Should users see about:welcome? If this is false, users will see a
+        regular new tab instead.
+    id:
+      type: string
+      description: >-
+        Descriptive ID for the about:welcome content
+    screens:
+      type: json
+      fallbackPref: browser.aboutwelcome.screens
+      description: Content to show in the onboarding flow
+    languageMismatchEnabled:
+      type: boolean
+      fallbackPref: intl.multilingual.aboutWelcome.languageMismatchEnabled
+      description: >-
+        Suggest to change the language on about:welcome when there is a mismatch with
+        the OS.
+    transitions:
+      type: boolean
+      description: Enable transition effect between screens
+    showModal:
+      type: boolean
+      fallbackPref: browser.aboutwelcome.showModal
+      description: >-
+        Should users see window modal onboarding
+    backdrop:
+      type: string
+      fallbackPref: browser.aboutwelcome.backdrop
+      description: >-
+        Specify the color to be used to update the background color
+
+moreFromMozilla:
+  description: "New page on about:preferences to suggest more Mozilla products"
+  owner: omc@mozilla.com
+  hasExposure: true
+  exposureDescription: >-
+    Exposure is sent once per browsing session when the about:preferences URL is
+    first accessed.
+  variables:
+    enabled:
+      type: boolean
+      fallbackPref: browser.preferences.moreFromMozilla
+      description: Should users see the new more from Mozilla section.
+    template:
+      type: string
+      fallbackPref: browser.preferences.moreFromMozilla.template
+      description: UI template used to display Mozilla products. Possible values simple, advanced. Default is simple.
+
+windowsLaunchOnLogin:
+  description: "New checkbox in about:preferences startup section to start Firefox on Windows login"
+  owner: omc@mozilla.com
+  hasExposure: true
+  exposureDescription: >-
+    Exposure is sent once per browsing session when the about:preferences URL is
+    first accessed.
+  variables:
+    enabled:
+      type: boolean
+      setPref: browser.startup.windowsLaunchOnLogin.enabled
+      description: Should users see the Windows launch on login checkbox.
+
+abouthomecache:
+  description: "The startup about:home cache."
+  owner: omc@mozilla.com
+  hasExposure: false
+  isEarlyStartup: true
+  variables:
+    enabled:
+      type: boolean
+      fallbackPref: browser.startup.homepage.abouthome_cache.enabled
+      description: Is the feature enabled?
+
+newtab:
+  description: "The about:newtab page"
+  owner: omc@mozilla.com
+  hasExposure: true
+  exposureDescription: >-
+    Exposure is sent once per browsing session when the first newtab page loads
+    (either about:newtab or about:home).
+  isEarlyStartup: true
+  variables:
+    newTheme:
+      type: boolean
+      description: Enable the new theme
+    customizationMenuEnabled:
+      type: boolean
+      fallbackPref: browser.newtabpage.activity-stream.customizationMenu.enabled
+      description: Enable the customization panel inside of the newtab
+    prefsButtonIcon:
+      type: string
+      description: Icon url to use for the preferences button
+    topSitesContileEnabled:
+      type: boolean
+      fallbackPref: browser.topsites.contile.enabled
+      description: Enable the Contile integration for Sponsored Top Sites
+    topSitesUseAdditionalTilesFromContile:
+      type: boolean
+      description: Allow Contile to use additonal sponsored top sites
+
+pocketNewtab:
+  description: The Pocket section in newtab
+  owner: sdowne@getpocket.com
+  hasExposure: false
+  isEarlyStartup: true
+  variables:
+    spocPositions:
+      type: string
+      fallbackPref: browser.newtabpage.activity-stream.discoverystream.spoc-positions
+      description: CSV string of spoc position indexes on newtab Pocket grid
+    spocTopsitesPositions:
+      type: string
+      fallbackPref: browser.newtabpage.activity-stream.discoverystream.spoc-topsites-positions
+      description: CSV string of spoc position indexes on newtab topsites section
+    spocAdTypes:
+      type: string
+      fallbackPref: browser.newtabpage.activity-stream.discoverystream.spocAdTypes
+      description: CSV string of data to set the spoc content.
+    spocZoneIds:
+      type: string
+      fallbackPref: browser.newtabpage.activity-stream.discoverystream.spocZoneIds
+      description: CSV string of data to set the spoc content.
+    spocTopsitesAdTypes:
+      type: string
+      fallbackPref: browser.newtabpage.activity-stream.discoverystream.spocTopsitesAdTypes
+      description: CSV string of data to set the spoc content.
+    spocTopsitesZoneIds:
+      type: string
+      fallbackPref: browser.newtabpage.activity-stream.discoverystream.spocTopsitesZoneIds
+      description: CSV string of data to set the spoc content.
+    spocTopsitesPlacementEnabled:
+      type: boolean
+      fallbackPref: browser.newtabpage.activity-stream.discoverystream.spocTopsitesPlacement.enabled
+      description: Tuns on and off the sponsored topsites placement.
+    spocSiteId:
+      type: string
+      fallbackPref: browser.newtabpage.activity-stream.discoverystream.spocSiteId
+      description: String ID to set the spoc content.
+    widgetPositions:
+      type: string
+      fallbackPref: browser.newtabpage.activity-stream.discoverystream.widget-positions
+      description: CSV string of widget position indexes on newtab grid
+    hybridLayout:
+      type: boolean
+      fallbackPref: browser.newtabpage.activity-stream.discoverystream.hybridLayout.enabled
+      description: Enable compact cards on newtab grid only for specific breakpoints
+    hideCardBackground:
+      type: boolean
+      fallbackPref: browser.newtabpage.activity-stream.discoverystream.hideCardBackground.enabled
+      description: Removes Pocket card background and borders.
+    fourCardLayout:
+      type: boolean
+      fallbackPref: browser.newtabpage.activity-stream.discoverystream.fourCardLayout.enabled
+      description: Enable four Pocket cards per row.
+    newFooterSection:
+      type: boolean
+      fallbackPref: >-
+        browser.newtabpage.activity-stream.discoverystream.newFooterSection.enabled
+      description: Enable an updated Pocket section topics footer
+    saveToPocketCard:
+      type: boolean
+      fallbackPref: >-
+        browser.newtabpage.activity-stream.discoverystream.saveToPocketCard.enabled
+      description: >-
+        A save to Pocket button inside the card, shown on the card thumbnail, on
+        hover.
+    saveToPocketCardRegions:
+      type: string
+      fallbackPref: >-
+        browser.newtabpage.activity-stream.discoverystream.saveToPocketCardRegions
+      description: >-
+        CSV string of regions that support the save to Pocket button inside the card.
+    hideDescriptions:
+      type: boolean
+      fallbackPref: >-
+        browser.newtabpage.activity-stream.discoverystream.hideDescriptions.enabled
+      description: >-
+        Hide or display descriptions for Pocket stories on newtab.
+    hideDescriptionsRegions:
+      type: string
+      fallbackPref: >-
+        browser.newtabpage.activity-stream.discoverystream.hideDescriptionsRegions
+      description: >-
+        CSV string of regions that hide descriptions for Pocket stories on newtab.
+    compactGrid:
+      type: boolean
+      fallbackPref: >-
+        browser.newtabpage.activity-stream.discoverystream.compactGrid.enabled
+      description: >-
+        Reduce the number of pixels between the Pocket cards on newtab.
+    compactImages:
+      type: boolean
+      fallbackPref: >-
+        browser.newtabpage.activity-stream.discoverystream.compactImages.enabled
+      description: >-
+        Reduce the height on Pocket card images on newtab.
+    imageGradient:
+      type: boolean
+      fallbackPref: >-
+        browser.newtabpage.activity-stream.discoverystream.imageGradient.enabled
+      description: >-
+        Add a gradient to the bottom of Pocket card images on newtab to blend the
+        image in with the card.
+    titleLines:
+      type: int
+      fallbackPref: >-
+        browser.newtabpage.activity-stream.discoverystream.titleLines
+      description: >-
+        Changes the maximum number of lines a title can be for Pocket cards on newtab.
+    descLines:
+      type: int
+      fallbackPref: >-
+        browser.newtabpage.activity-stream.discoverystream.descLines
+      description: >-
+        Changes the maximum number of lines a description can be for Pocket cards on newtab.
+    onboardingExperience:
+      type: boolean
+      fallbackPref: >-
+        browser.newtabpage.activity-stream.discoverystream.onboardingExperience.enabled
+      description: >-
+        Enables an onboarding experience for Pocket section on newtab.
+    essentialReadsHeader:
+      type: boolean
+      fallbackPref: >-
+        browser.newtabpage.activity-stream.discoverystream.essentialReadsHeader.enabled
+      description: >-
+        Updates the Pocket section header and title to say "Today’s Essential Reads",
+        moves the "Recommended by Pocket" header to the right side.
+    editorsPicksHeader:
+      type: boolean
+      fallbackPref: >-
+        browser.newtabpage.activity-stream.discoverystream.editorsPicksHeader.enabled
+      description: >-
+        Updates the Pocket section header and title to say "Editor’s Picks", if used with
+        essentialReadsHeader, creates a second section 2 rows down for editorsPicksHeader.
+    recentSavesEnabled:
+      type: boolean
+      fallbackPref: >-
+        browser.newtabpage.activity-stream.discoverystream.recentSaves.enabled
+      description: >-
+        Updates the Pocket section with a new header and 1 row of recently saved Pocket stories.
+    readTime:
+      type: boolean
+      fallbackPref: >-
+        browser.newtabpage.activity-stream.discoverystream.readTime.enabled
+      description: >-
+        Displays an estimated read time for Pocket cards on newtab.
+    newSponsoredLabel:
+      type: boolean
+      fallbackPref: >-
+        browser.newtabpage.activity-stream.discoverystream.newSponsoredLabel.enabled
+      description: >-
+        Updates the sponsored label position to below the image for Pocket cards on newtab.
+    sendToPocket:
+      type: boolean
+      fallbackPref: >-
+        browser.newtabpage.activity-stream.discoverystream.sendToPocket.enabled
+      description: >-
+        Decides what to do when a logged out user click "Save to Pocket" from a Pocket card.
+    recsPersonalized:
+      type: boolean
+      fallbackPref: >-
+        browser.newtabpage.activity-stream.discoverystream.recs.personalized
+      description: >-
+        Enables Pocket stories personalization.
+    spocsPersonalized:
+      type: boolean
+      fallbackPref: >-
+        browser.newtabpage.activity-stream.discoverystream.spocs.personalized
+      description: >-
+        Enables Pocket sponsored content personalization.
+    spocsCacheTimeout:
+      type: int
+      fallbackPref: >-
+        browser.newtabpage.activity-stream.discoverystream.spocs.cacheTimeout
+      description: >-
+        Set sponsored content cache timeout in minutes.
+    discoveryStreamConfig:
+      description: A JSON blob of discovery stream configuration.
+      type: string
+      setPref: "browser.newtabpage.activity-stream.discoverystream.config"
+    spocsEndpoint:
+      description: The URL for the spocs endpoint.
+      type: string
+      setPref: "browser.newtabpage.activity-stream.discoverystream.spocs-endpoint"
+    regionStoriesConfig:
+      description: A comma-separated list of region to get stories for.
+      type: string
+      fallbackPref: >-
+        browser.newtabpage.activity-stream.discoverystream.region-stories-config
+    regionBffConfig:
+      type: string
+      fallbackPref: >-
+        browser.newtabpage.activity-stream.discoverystream.region-bff-config
+      description: A comma-separated list of regions to get stories from the recommendations BFF. Also requires region-stories-config.
+    regionStoriesBlock:
+      description: A comma-separated list of regions that do not get stories, regardless of locale-list-config.
+      type: string
+      fallbackPref: >-
+        browser.newtabpage.activity-stream.discoverystream.region-stories-block
+    localeListConfig:
+      description: A comma-separated list of locales that get stories, regardless of region-stories-config.
+      type: string
+      fallbackPref: >-
+        browser.newtabpage.activity-stream.discoverystream.locale-list-config
+    regionSpocsConfig:
+      description: A comma-separated list of regions that get spocs by default.
+      type: string
+      fallbackPref: >-
+        browser.newtabpage.activity-stream.discoverystream.region-spocs-config
+    topSitesMaxSponsored:
+      # Defined under `pocketNewtab` as it needs to be used along with other variables
+      type: int
+      description: The maximum number of sponsored Top Sites to be displayed
+    topSitesContileMaxSponsored:
+      # Defined under `pocketNewtab` as it needs to be used along with other variables
+      type: int
+      description: The maximum number of sponsored Top Sites used from Contile
+    topSitesContileSovEnabled:
+      # Defined under `pocketNewtab` as it needs to be used along with other variables
+      description: Enable the Share-of-Voice feature for Sponsored Topsites.
+      type: boolean
+      fallbackPref: >-
+        browser.topsites.contile.sov.enabled
+
+saveToPocket:
+  description: The save to Pocket feature
+  owner: sdowne@getpocket.com
+  hasExposure: false
+  isEarlyStartup: true
+  variables:
+    emailButton:
+      type: boolean
+      fallbackPref: extensions.pocket.refresh.emailButton.enabled
+      description: Just for the new Pocket panels, enables the email signup button.
+    hideRecentSaves:
+      type: boolean
+      fallbackPref: extensions.pocket.refresh.hideRecentSaves.enabled
+      description: Hides the recently saved section in the home panel.
+    bffRecentSaves:
+      type: boolean
+      fallbackPref: "extensions.pocket.bffRecentSaves"
+      description: Use the new BFF Proxy Service instead of the legacy Pocket Service for Recent Saves
+    bffApi:
+      type: string
+      fallbackPref: "extensions.pocket.bffApi"
+      description: BFF Proxy Service domain
+    oAuthConsumerKeyBff:
+      type: string
+      fallbackPref: "extensions.pocket.oAuthConsumerKeyBff"
+      description: BFF Proxy Service OAuth Consumer Key
+
+password-autocomplete:
+  description: A special autocomplete UI for password fields.
+  owner: sgalich@mozilla.com
+  hasExposure: false
+  variables:
+    directMigrateSingleProfile:
+      type: boolean
+      description: Enable direct migration?
+
+cm-csv-import:
+  description: Importing logins from CSV files
+  owner: issozi@mozilla.com
+  hasExposure: false
+  variables:
+    csvImport:
+      type: boolean
+      description: Can show CSV Import in about:logins or Migration Wizard
+      setPref: "signon.management.page.fileImport.enabled"
+
+shellService:
+  description: "Interface with OS, e.g., pinning and set default"
+  owner: desktop-integrations@mozilla.com
+  hasExposure: false
+  isEarlyStartup: true
+  variables:
+    disablePin:
+      type: boolean
+      description: Disable pin to taskbar feature
+    setDefaultBrowserUserChoice:
+      type: boolean
+      fallbackPref: browser.shell.setDefaultBrowserUserChoice
+      description: Should it set as default browser
+    setDefaultPDFHandler:
+      type: boolean
+      fallbackPref: browser.shell.setDefaultPDFHandler
+      description: Should setting it as the default browser set it as the default PDF handler.
+    setDefaultPDFHandlerOnlyReplaceBrowsers:
+      type: boolean
+      fallbackPref: browser.shell.setDefaultPDFHandler.onlyReplaceBrowsers
+      description: >-
+        Should setting it as the default PDF handler only replace existing PDF
+        handlers that are browsers, and not other PDF handlers such as Acrobat
+        Reader or Nitro PDF.
+
+upgradeDialog:
+  description: The dialog shown for major upgrades
+  owner: omc@mozilla.com
+  hasExposure: false
+  isEarlyStartup: true
+  variables:
+    enabled:
+      type: boolean
+      fallbackPref: browser.startup.upgradeDialog.enabled
+      description: Is the feature enabled?
+
+cfr:
+  description: "A Firefox Messaging System message for the cfr message channel"
+  owner: omc@mozilla.com
+  hasExposure: true
+  exposureDescription: "Exposure is sent if the message is about to be shown after trigger and targeting conditions on the message matched."
+  isEarlyStartup: false
+  schema:
+    uri: "resource://activity-stream/schemas/MessagingExperiment.schema.json"
+    path: "browser/components/newtab/content-src/asrouter/schemas/MessagingExperiment.schema.json"
+  variables: {}
+
+"moments-page":
+  description: "A Firefox Messaging System message for the moments-page message channel"
+  owner: omc@mozilla.com
+  hasExposure: true
+  exposureDescription: >-
+    "Exposure is sent if the message is about to be shown after trigger and targeting conditions on the message matched."
+  isEarlyStartup: false
+  schema:
+    uri: "resource://activity-stream/schemas/MessagingExperiment.schema.json"
+    path: "browser/components/newtab/content-src/asrouter/schemas/MessagingExperiment.schema.json"
+  variables: {}
+
+infobar:
+  description: "A Firefox Messaging system message for the infobar message channel"
+  owner: omc@mozilla.com
+  hasExposure: true
+  exposureDescription: >-
+    "Exposure is sent if the message is about to be shown after trigger and targeting conditions on the message matched."
+  isEarlyStartup: false
+  schema:
+    uri: "resource://activity-stream/schemas/MessagingExperiment.schema.json"
+    path: "browser/components/newtab/content-src/asrouter/schemas/MessagingExperiment.schema.json"
+  variables: {}
+
+spotlight:
+  description: "A Firefox Messaging System message for the spotlight message channel"
+  owner: omc@mozilla.com
+  hasExposure: true
+  exposureDescription: >-
+    "Exposure is sent if the message is about to be shown after trigger and targeting conditions on the message matched."
+  isEarlyStartup: false
+  schema:
+    uri: "resource://activity-stream/schemas/MessagingExperiment.schema.json"
+    path: "browser/components/newtab/content-src/asrouter/schemas/MessagingExperiment.schema.json"
+  variables: {}
+
+# Before 117, this feature only included one variable, pdfJsTourProgress. So,
+# the minimum version for messaging experiments using this feature ID is 117.
+featureCallout:
+  description: "A Firefox Messaging System message for the Feature Callout message channel"
+  owner: omc@mozilla.com
+  hasExposure: true
+  exposureDescription: >-
+    "Exposure is sent if the message is about to be shown after trigger and targeting conditions on the message matched."
+  isEarlyStartup: false
+  schema:
+    uri: "resource://activity-stream/schemas/MessagingExperiment.schema.json"
+    path: "browser/components/newtab/content-src/asrouter/schemas/MessagingExperiment.schema.json"
+  variables: {}
+
+fullPageTranslation:
+  description: This feature opens a popup panel to offer to translate a page.
+  owner: gtatum@mozilla.com
+  hasExposure: false
+  isEarlyStartup: true
+  variables:
+    boolean:
+      description: Set to true to enable the translations feature
+      type: boolean
+      setPref: browser.translations.enable
+
+fullPageTranslationAutomaticPopup:
+  description: Controls whether the popup automatically shows for translations.
+  owner: gtatum@mozilla.com
+  hasExposure: false
+  isEarlyStartup: true
+  variables:
+    boolean:
+      description: Set to true to automatically popup, and false to only show the button.
+      type: boolean
+      setPref: browser.translations.automaticallyPopup
+
+addAnImageInPDF:
+  description: Add an image in an existing pdf.
+  owner: cdenizet@mozilla.com
+  hasExposure: false
+  variables:
+    boolean:
+      description: Set to true to enable the add-an-image feature
+      type: boolean
+      setPref: pdfjs.enableStampEditor
+
+# fxms-message-* placeholder feature ids
+#
+# https://docs.google.com/spreadsheets/d/119YbeKStLL0Fg2QkK-yN93mrtD1rlneGZGTl_jAwtyw/edit#gid=1903378504
+# has info on using these placeholder feature ids, as well as (very short) instructions on
+# checking to see if we need more (which we do once per Nightly) and how to add them.
+#
+# Instructions for adding a new fxms-message-* placeholder feature id
+# 1) clone an existing one here
+# 2) update the YAML feature id to the next unused number
+# 3) update the YAML description
+# 4) add the new feature id to MESSAGING_EXPERIMENTS_DEFAULT_FEATURES list in MessagingExperimentConstants.sys.mjs
+# 5) add the new feature id and the version it landed to the spreadsheet tab linked to above
+
+fxms-message-1:
+  description: "A Firefox Messaging System message"
+  owner: omc@mozilla.com
+  hasExposure: true
+  exposureDescription: >-
+    "Exposure is sent if the message is about to be shown after trigger and targeting conditions on the message matched."
+  isEarlyStartup: false
+  schema:
+    uri: "resource://activity-stream/schemas/MessagingExperiment.schema.json"
+    path: "browser/components/newtab/content-src/asrouter/schemas/MessagingExperiment.schema.json"
+  variables: {}
+
+fxms-message-2:
+  description: "Firefox Messaging System message 2"
+  owner: omc@mozilla.com
+  hasExposure: true
+  exposureDescription: >-
+    "Exposure is sent if the message is about to be shown after trigger and targeting conditions on the message matched."
+  isEarlyStartup: false
+  schema:
+    uri: "resource://activity-stream/schemas/MessagingExperiment.schema.json"
+    path: "browser/components/newtab/content-src/asrouter/schemas/MessagingExperiment.schema.json"
+  variables: {}
+
+fxms-message-3:
+  description: "Firefox Messaging System message 3"
+  owner: omc@mozilla.com
+  hasExposure: true
+  exposureDescription: >-
+    "Exposure is sent if the message is about to be shown after trigger and targeting conditions on the message matched."
+  isEarlyStartup: false
+  schema:
+    uri: "resource://activity-stream/schemas/MessagingExperiment.schema.json"
+    path: "browser/components/newtab/content-src/asrouter/schemas/MessagingExperiment.schema.json"
+  variables: {}
+
+fxms-message-4:
+  description: "Firefox Messaging System message 4"
+  owner: omc@mozilla.com
+  hasExposure: true
+  exposureDescription: >-
+    "Exposure is sent if the message is about to be shown after trigger and targeting conditions on the message matched."
+  isEarlyStartup: false
+  schema:
+    uri: "resource://activity-stream/schemas/MessagingExperiment.schema.json"
+    path: "browser/components/newtab/content-src/asrouter/schemas/MessagingExperiment.schema.json"
+  variables: {}
+
+fxms-message-5:
+  description: "Firefox Messaging System message 5"
+  owner: omc@mozilla.com
+  hasExposure: true
+  exposureDescription: >-
+    "Exposure is sent if the message is about to be shown after trigger and targeting conditions on the message matched."
+  isEarlyStartup: false
+  schema:
+    uri: "resource://activity-stream/schemas/MessagingExperiment.schema.json"
+    path: "browser/components/newtab/content-src/asrouter/schemas/MessagingExperiment.schema.json"
+  variables: {}
+
+fxms-message-6:
+  description: "Firefox Messaging System message 6"
+  owner: omc@mozilla.com
+  hasExposure: true
+  exposureDescription: >-
+    "Exposure is sent if the message is about to be shown after trigger and targeting conditions on the message matched."
+  isEarlyStartup: false
+  schema:
+    uri: "resource://activity-stream/schemas/MessagingExperiment.schema.json"
+    path: "browser/components/newtab/content-src/asrouter/schemas/MessagingExperiment.schema.json"
+  variables: {}
+
+fxms-message-7:
+  description: "Firefox Messaging System message 7"
+  owner: omc@mozilla.com
+  hasExposure: true
+  exposureDescription: >-
+    "Exposure is sent if the message is about to be shown after trigger and targeting conditions on the message matched."
+  isEarlyStartup: false
+  schema:
+    uri: "resource://activity-stream/schemas/MessagingExperiment.schema.json"
+    path: "browser/components/newtab/content-src/asrouter/schemas/MessagingExperiment.schema.json"
+  variables: {}
+
+fxms-message-8:
+  description: "Firefox Messaging System message 8"
+  owner: omc@mozilla.com
+  hasExposure: true
+  exposureDescription: >-
+    "Exposure is sent if the message is about to be shown after trigger and targeting conditions on the message matched."
+  isEarlyStartup: false
+  schema:
+    uri: "resource://activity-stream/schemas/MessagingExperiment.schema.json"
+    path: "browser/components/newtab/content-src/asrouter/schemas/MessagingExperiment.schema.json"
+  variables: {}
+
+fxms-message-9:
+  description: "Firefox Messaging System message 9"
+  owner: omc@mozilla.com
+  hasExposure: true
+  exposureDescription: >-
+    "Exposure is sent if the message is about to be shown after trigger and targeting conditions on the message matched."
+  isEarlyStartup: false
+  schema:
+    uri: "resource://activity-stream/schemas/MessagingExperiment.schema.json"
+    path: "browser/components/newtab/content-src/asrouter/schemas/MessagingExperiment.schema.json"
+  variables: {}
+
+fxms-message-10:
+  description: "Firefox Messaging System message 10"
+  owner: omc@mozilla.com
+  hasExposure: true
+  exposureDescription: >-
+    "Exposure is sent if the message is about to be shown after trigger and targeting conditions on the message matched."
+  isEarlyStartup: false
+  schema:
+    uri: "resource://activity-stream/schemas/MessagingExperiment.schema.json"
+    path: "browser/components/newtab/content-src/asrouter/schemas/MessagingExperiment.schema.json"
+  variables: {}
+
+fxms-message-11:
+  description: "Firefox Messaging System message 11"
+  owner: omc@mozilla.com
+  hasExposure: true
+  exposureDescription: >-
+    "Exposure is sent if the message is about to be shown after trigger and targeting conditions on the message matched."
+  isEarlyStartup: false
+  schema:
+    uri: "resource://activity-stream/schemas/MessagingExperiment.schema.json"
+    path: "browser/components/newtab/content-src/asrouter/schemas/MessagingExperiment.schema.json"
+  variables: {}
+
+pbNewtab:
+  description: "A Firefox Messaging System message for the pbNewtab message channel"
+  owner: omc@mozilla.com
+  hasExposure: true
+  exposureDescription: >-
+    Exposure is sent if the message is about to be shown after trigger and targeting conditions on the message matched.
+  isEarlyStartup: false
+  schema:
+    uri: "resource://activity-stream/schemas/MessagingExperiment.schema.json"
+    path: "browser/components/newtab/content-src/asrouter/schemas/MessagingExperiment.schema.json"
+  variables: {}
+
+backgroundTaskMessage:
+  description: "A Firefox Messaging System message for the background task message channel"
+  owner: nalexander@mozilla.com
+  applications:
+    - firefox-desktop-background-task
+  hasExposure: true
+  exposureDescription: >-
+    Exposure is sent if the message is about to be shown after trigger and targeting conditions on the message matched.
+  isEarlyStartup: false
+  schema:
+    uri: "resource://activity-stream/schemas/BackgroundTaskMessagingExperiment.schema.json"
+    path: "browser/components/newtab/content-src/asrouter/schemas/BackgroundTaskMessagingExperiment.schema.json"
+  variables: {}
+
+pictureinpicture:
+  description: Message for first time Picture-in-Picture users
+  owner: nbaumgardner@mozilla.com
+  hasExposure: true
+  exposureDescription: Exposure is sent when a user hovers over a video and Picture-in-Picture has not been used before
+  variables:
+    title:
+      type: string
+      description: The title to be used for the PiP toggle
+    message:
+      type: string
+      description: The message to be used in the PiP toggle
+    showIconOnly:
+      type: boolean
+      description: Whether to show the first time PiP toggle or show the PiP icon only
+    oldToggle:
+      type: boolean
+      description: Whether to show the control style (true) or variant style (false) for the first time PiP toggle
+    displayDuration:
+      type: int
+      description: Duration of PiP first time toggle display in days before switching to PiP icon toggle
+
+glean:
+  description: "The Glean data-control-plane feature within Firefox Desktop for controlling metric configuration"
+  owner: glean-team@mozilla.com
+  hasExposure: false
+  variables:
+    newtabPingEnabled:
+      type: "boolean"
+      fallbackPref: "browser.newtabpage.ping.enabled"
+      description: "Whether to submit the 'newtab' ping"
+    gleanMetricConfiguration:
+      type: json
+      description: |
+        A map of metric base-identifiers to booleans representing the state of the 'enabled' flag for that metric.
+        This variable is intended for interacting with the Glean data-control-plane via the Server Knobs functionality
+        to remotely configure metrics to be enabled or disabled.
+
+gleanInternalSdk:
+  description: "The Glean internal SDK feature intended only for internal Glean Team use"
+  hasExposure: false
+  # Some variables are used through the C++ API and thus require pref-storage.
+  # We rely on those values at Glean.init time, which happens at startup.
+  isEarlyStartup: true
+  variables:
+    finalInactive:
+      type: "boolean"
+      description: "Enables FOG early shutdown pings when true"
+    gleanMetricConfiguration:
+      type: json
+      description: |
+        A map of metric base-identifiers to booleans representing the state of the 'enabled' flag for that metric.
+        This is not for public use! For data-control-plane use, please refer to the Glean documentation and use the
+        `gleanMetricConfiguration` found in the `glean` feature for this.
+    gleanMaxPingsPerMinute:
+      type: int
+      description: >-
+        Maximum number of pings that can be sent in a 60 second interval
+    enableEventTimestamps:
+      type: "boolean"
+      description: "Enables precise event timestamps for Glean events"
+
+majorRelease2022:
+  description: Major Release 2022
+  owner: firefoxview@mozilla.com
+  hasExposure: false
+  isEarlyStartup: true
+  variables:
+    feltPrivacyPBMDarkTheme:
+      type: boolean
+      fallbackPref: "browser.theme.dark-private-windows"
+      description: "Use dark theme variant for PBM windows. This is only supported if the theme sets darkTheme data."
+    feltPrivacyShowPreferencesSection:
+      type: boolean
+      fallbackPref: "browser.privacySegmentation.preferences.show"
+      description: "Controls visibility of the privacy segmentation preferences section."
+    feltPrivacyWindowSeparation:
+      type: boolean
+      fallbackPref: "browser.privateWindowSeparation.enabled"
+      description: "Whether or not private browsing windows use a separate icon in the Windows taskbar"
+    colorwayCloset:
+      type: boolean
+      fallbackPref: "browser.theme.colorway-closet"
+      description: "Whether or not to show the colorway closet modal"
+    firefoxView:
+      type: boolean
+      fallbackPref: "browser.tabs.firefox-view"
+      description: "Whether or not to show the firefox view tab"
+    onboarding:
+      type: boolean
+      fallbackPref: "browser.majorrelease.onboarding"
+      description: "Whether or not to use the MR2022 onboarding settings."
+
+browserLowMemoryPrefs:
+  description: Prefs which control the browser's behaviour under low memory.
+  owner: haftandilian@mozilla.com
+  hasExposure: false
+  variables:
+    lowMemoryResponseMask:
+      description: Control the response on macOS when under memory pressure.
+      type: int
+      setPref: "browser.lowMemoryResponseMask"
+    lowMemoryResponseOnWarn:
+      description: Controls which macOS memory-pressure levels trigger the browser low memory response.
+      type: boolean
+      setPref: "browser.lowMemoryResponseOnWarn"
+    tabsUnloadOnLowMemory:
+      description: Whether to unload tabs when available memory is running low.
+      type: boolean
+      setPref: "browser.tabs.unloadOnLowMemory"
+
+scriptLoaderPrefs:
+  description: Prefs that control the script loader.
+  owner: npierron@mozilla.com
+  hasExposure: false
+  variables:
+    delazificationStrategy:
+      description: >-
+        Selects which parsing/delazification strategy should be used while
+        parsing scripts off-main-thread. See DelazificationOption in
+        CompileOptions.h for values.
+      type: int
+      setPref: "dom.script_loader.delazification.strategy"
+
+echPrefs:
+  description: Prefs that control Encrypted Client Hello.
+  owner: djackson@mozilla.com
+  hasExposure: false
+  variables:
+    tlsEnabled:
+      description: Whether to enable ECH for connections using TLS
+      type: boolean
+      setPref: "network.dns.echconfig.enabled"
+    h3Enabled:
+      description: Whether to enable ECH for connections using H3/QUIC
+      type: boolean
+      setPref: "network.dns.http3_echconfig.enabled"
+    forceWaitHttpsRR:
+      description: Whether to force waiting for HTTPS DNS records, which ECH requires.
+      type: boolean
+      setPref: "network.dns.force_waiting_https_rr"
+    insecureFallback:
+      description: Whether to fallback to non-ECH connections if all ECH RRs fail.
+      type: boolean
+      setPref: "network.dns.echconfig.fallback_to_origin_when_all_failed"
+    tlsGreaseProb:
+      description: Probability of GREASEing a TLS connection with ECH (0-100).
+      type: int
+      setPref: "security.tls.ech.grease_probability"
+    h3GreaseEnabled:
+      description: Whether to apply GREASE settings to H3/QUIC connections.
+      type: boolean
+      setPref: "security.tls.ech.grease_http3"
+    disableGreaseOnFallback:
+      description: Whether to disable GREASE when retrying a connection.
+      type: boolean
+      setPref: "security.tls.ech.disable_grease_on_fallback"
+    greasePaddingSize:
+      description: Assumed echConfig padding length for GREASE extensions (1-255).
+      type: int
+      setPref: "security.tls.ech.grease_size"
+
+dohPrefs:
+  description: Prefs that control DNS over HTTPS.
+  owner: vgosu@mozilla.com
+  hasExposure: false
+  variables:
+    trrMode:
+      description: Has a value of 2 for TRR first, 3 for TRR only, 0 for off.
+      type: int
+      setPref: "network.trr.mode"
+    trrUri:
+      description: The URL of the DNS over HTTPS endpoint
+      type: string
+      setPref: "network.trr.uri"
+    dohMode:
+      description: Same as trrMode, but set by the DoHController module.
+      type: int
+      setPref: "doh-rollout.mode"
+    dohUri:
+      description: Same as trrUri, but set by the DoHController module.
+      type: string
+      setPref: "doh-rollout.uri"
+    enableFallbackWarningPage:
+      description: Whether DoH fallback warning page will be displayed when DoH doesn't work in TRR first mode.
+      type: boolean
+      setPref: "network.trr.display_fallback_warning"
+    showFallbackCheckbox:
+      description: Whether the checkbox to enable the fallback warning page is displayed in the settings UI.
+      type: boolean
+      setPref: "network.trr_ui.show_fallback_warning_option"
+
+dooh:
+  description: "DNS over Oblivious HTTP"
+  owner: vgosu@mozilla.com
+  hasExposure: false
+  variables:
+    ohttpEnabled:
+      description: Whether to use Oblivious HTTP for the resolution
+      type: boolean
+      setPref: "network.trr.use_ohttp"
+    ohttpRelayUri:
+      description: The URL of the Oblivious HTTP relay
+      type: string
+      setPref: "network.trr.ohttp.relay_uri"
+    ohttpConfigUri:
+      description: The URL used to fetch the configuration of the Oblivious HTTP gateway
+      type: string
+      setPref: "network.trr.ohttp.config_uri"
+    ohttpUri:
+      description: The URL of the Oblivious DNS over HTTPS target resource
+      type: string
+      setPref: "network.trr.ohttp.uri"
+
+networking:
+  description: "Firefox Networking (Necko)"
+  owner: vgosu@mozilla.com
+  hasExposure: false
+  variables:
+    ehPreloadEnabled:
+      description: Whether Early Hints preload is enabled
+      type: boolean
+      setPref: "network.early-hints.enabled"
+    ehPreconnectEnabled:
+      description: Whether Early Hints preconnect is enabled
+      type: boolean
+      setPref: "network.early-hints.preconnect.enabled"
+    dnsMaxPriorityThreads:
+      description: The maximum number of high priority DNS threads that can be created.
+      type: int
+      setPref: "network.dns.max_high_priority_threads"
+    dnsMaxAnyPriorityThreads:
+      description: The maximum number of DNS threads that can be created to handle any priority DNS requests.
+      type: int
+      setPref: "network.dns.max_any_priority_threads"
+    preconnect:
+      description: Whether the rel=preconnect feature is enabled
+      type: boolean
+      setPref: "network.preconnect"
+    networkPredictor:
+      description: Whether the Necko predictor is enabled
+      type: boolean
+      setPref: "network.predictor.enabled"
+    http3CCalgorithm:
+      description: The congestion control algorithm with which to configure neqo. 0 for NewReno, 1 for Cubic
+      type: int
+      setPref: "network.http.http3.cc_algorithm"
+    sendOnDataFinished:
+      description: Whether we can send OnDataFinished in the content process
+      type: boolean
+      setPref: "network.send_OnDataFinished"
+    sendOnDataFinishedToHtml5parser:
+      description: Whether we can send OnDataFinished to the html5parser in content process
+      type: boolean
+      setPref: "network.send_OnDataFinished.html5parser"
+    sendOnDataFinishedToCssLoader:
+      description: Whether we can send OnDataFinished to the cssLoader in content process
+      type: boolean
+      setPref: "network.send_OnDataFinished.cssLoader"
+
+
+pingsender:
+  description: "In-product usage of the pingsender telemetry reporter."
+  owner: nalexander@mozilla.com
+  hasExposure: false
+  variables:
+    backgroundTaskEnabled:
+      type: "boolean"
+      fallbackPref: "toolkit.telemetry.shutdownPingSender.backgroundtask.enabled"
+      description: "Whether to use the `pingsender` background task to send shutdown telemetry"
+
+dapTelemetry:
+  description: DAP Telemetry
+  owner: simon@mozilla.com
+  hasExposure: false
+  isEarlyStartup: true # Data is sent on startup with a trigger in BrowserGlue.sys.mjs
+  variables:
+    enabled:
+      type: boolean
+      fallbackPref: toolkit.telemetry.dap_enabled
+      description: Whether to automatically send DAP measurements.
+    task1Enabled:
+      type: boolean
+      fallbackPref: toolkit.telemetry.dap_task1_enabled
+      description: Whether to send fake measurements for task 1.
+    task1TaskId:
+      type: string
+      fallbackPref: toolkit.telemetry.dap_task1_taskid
+      description: The task ID to use for task 1 measurements.
+    visitCountingEnabled:
+      type: boolean
+      fallbackPref: toolkit.telemetry.dap_visit_counting_enabled
+      description: Whether to count visits to the provided list of URLs.
+    visitCountingExperimentList:
+      fallbackPref: toolkit.telemetry.dap_visit_counting_experiment_list
+      type: json
+      description: A list of experiments with URLs for which we want to count visits.
+
+etpLevel2PBMPref:
+  description: The pref that controls the ETP level 2 list in the private browsing mode
+  owner: tihuang@mozilla.com
+  hasExposure: false
+  variables:
+    enabled:
+      description: Whether to enable ETP level 2 list in the private browsing mode.
+      type: boolean
+      setPref: "privacy.annotate_channels.strict_list.pbmode.enabled"
+
+fxaButtonVisibility:
+  description: Prefs to control the visibility of the Firefox Accounts toolbar button when not signed in.
+  owner: mconley@mozilla.com
+  hasExposure: false
+  isEarlyStartup: true
+  variables:
+    boolean:
+      description: True if the Firefox Accounts toolbar button should be visible when not signed in.
+      type: boolean
+      setPref: identity.fxaccounts.toolbar.defaultVisible
+
+legacyHeartbeat:
+  description: Normandy Heartbeat exposed to Nimbus
+  owner: barret@mozilla.com
+  hasExposure: false
+  schema:
+    uri: "resource://normandy/schemas/LegacyHeartbeat.schema.json"
+    path: "toolkit/components/normandy/schemas/LegacyHeartbeat.schema.json"
+  variables:
+    survey:
+      type: json
+      description: The Heartbeat survey parameters.
+
+queryStripping:
+  description: Query parameter stripping anti-tracking feature.
+  owner: pbz@mozilla.com
+  hasExposure: false
+  variables:
+    enabledNormalBrowsing:
+      type: boolean
+      setPref: privacy.query_stripping.enabled
+      description: Enables / disables URL query string stripping in normal browsing mode.
+    enabledPrivateBrowsing:
+      type: boolean
+      setPref: privacy.query_stripping.enabled.pbmode
+      description: Enables / disables URL query string stripping in private browsing mode.
+    allowList:
+      type: string
+      setPref: privacy.query_stripping.allow_list
+      description: >-
+        List of sites exempt from query stripping. This list will be merged with
+        records coming from RemoteSettings.
+    stripList:
+      type: string
+      setPref: privacy.query_stripping.strip_list
+      description: >-
+        List of query params to be stripped from URIs. This list will be merged
+        with records coming from RemoteSettings.
+
+fontvisibility:
+  description: Control Font Visibility in PBM
+  owner: tom@mozilla.com
+  hasExposure: false
+  variables:
+    enabledETP:
+      type: int
+      setPref: layout.css.font-visibility.trackingprotection
+      description: Set the Font Visibility level when Enhanced Tracking Protection is enabled
+    enabledStandard:
+      type: int
+      setPref: layout.css.font-visibility.standard
+      description: Set the Font Visibility level for normal browsing
+    enabledPBM:
+      type: int
+      setPref: layout.css.font-visibility.private
+      description: Set the Font Visibility level for private browsing (will override ETP)
+
+fingerprintingProtection:
+  description: Control Fingerprinting Protection
+  owner: tihuang@mozilla.com
+  hasExposure: false
+  variables:
+    enabledNormal:
+      type: boolean
+      setPref: privacy.fingerprintingProtection
+      description: Enables / disables fingerprinting protection in normal browsing mode.
+    enabledPrivate:
+      type: boolean
+      setPref: privacy.fingerprintingProtection.pbmode
+      description: Enables / disables fingerprinting protection in private browsing mode.
+    overrides:
+      type: string
+      setPref: privacy.fingerprintingProtection.overrides
+      description: >-
+        The protection overrides to add or remove fingerprinting protection
+        targets. Please check RFPTargets.inc for all supported targets.
+
+migrationWizard:
+  description: Prefs to control the Migration Wizard UI.
+  owner: mconley@mozilla.com
+  hasExposure: false
+  isEarlyStartup: true
+  variables:
+    showImportAll:
+      description: True if the "Variant 2" of the Migration Wizard browser / profile selection UI should be used. This is only meaningful in the new Migration Wizard.
+      type: boolean
+      setPref: browser.migrate.content-modal.import-all.enabled
+    showPreferencesEntrypoint:
+      description: True if an entrypoint to the migration wizard should be visible in about:preferences.
+      type: boolean
+      setPref: browser.migrate.preferences-entrypoint.enabled
+    aboutWelcomeBehavior:
+      description: >-
+        When migration is kicked off from about:welcome, there are
+        a few different behaviors that we want to test, controlled
+        by a preference that is instrumented for Nimbus. The pref
+        has the following possible states:
+
+        "autoclose":
+          The user will be directed to the migration wizard in
+          about:preferences, but once the wizard is dismissed,
+          the tab will close.
+
+        "embedded":
+          The migration wizard is embedded in about:welcome.
+
+        "standalone":
+          The migration wizard will open in a new top-level content
+          window.
+
+        "default" / other
+          The user will be directed to the migration wizard in
+          about:preferences. The tab will not close once the
+          user closes the wizard.
+      type: string
+      setPref: browser.migrate.content-modal.about-welcome-behavior
+    migrateExtensions:
+      description: True if importing extensions is enabled.
+      type: boolean
+      setPref: browser.migrate.chrome.extensions.enabled
+    chromeCanRequestPermissions:
+      description: >-
+        True if Chrome-based browsers can request read permissions on
+        platforms where the browser is restricted from reading the contents
+        of a Chrome-based browser's user data directory. In practice, this
+        is only relevant to the Linux platform when the browser is installed
+        as a Snap package.
+      type: boolean
+      setPref: browser.migrate.chrome.get_permissions.enabled
+
+mixedContentUpgrading:
+  description: Prefs to control whether we upgrade mixed passive content (images, audio, video) from http to https
+  owner: fbraun@mozilla.com
+  hasExposure: false
+  variables:
+    enabled:
+      description: True if the mixed content upgrading pref is enabled
+      type: boolean
+      setPref: security.mixed_content.upgrade_display_content
+    image:
+      description: True if the mixed content upgrading is enabled for images
+      type: boolean
+      setPref: security.mixed_content.upgrade_display_content.image
+    audio:
+      description: True if the mixed content upgrading is enabled for audio
+      type: boolean
+      setPref: security.mixed_content.upgrade_display_content.audio
+    video:
+      description: True if the mixed content upgrading is enabled for videos
+      type: boolean
+      setPref: security.mixed_content.upgrade_display_content.video
+
+jsParallelParsing:
+  description: Pref to toggle JS parallel parsing.
+  owner: dpalmeiro@mozilla.com, nbp@mozilla.com
+  isEarlyStartup: true
+  hasExposure: false
+  variables:
+    enabled:
+      description: True to enable parallel parsing.
+      type: boolean
+      setPref: "javascript.options.parallel_parsing"
+
+gcParallelMarking:
+  description: Pref to toggle parallel marking in the GC.
+  owner: dpalmeiro@mozilla.com, jonco@mozilla.com
+  isEarlyStartup: true
+  hasExposure: false
+  variables:
+    enabled:
+      description: True to enable parallel marking.
+      type: boolean
+      setPref: "javascript.options.mem.gc_parallel_marking"
+
+jitThresholds:
+  description: Prefs that control jit tier thresholds.
+  owner: dpalmeiro@mozilla.com, jdemooij@mozilla.com
+  isEarlyStartup: true
+  hasExposure: false
+  variables:
+    blinterp_threshold:
+      description: Set the threshold to enable blinterp compilation.
+      type: int
+      setPref: "javascript.options.blinterp.threshold"
+    baseline_threshold:
+      description: Set the threshold to enable baseline compilation.
+      type: int
+      setPref: "javascript.options.baselinejit.threshold"
+    ion_threshold:
+      description: Set the threshold to enable ion compilation.
+      type: int
+      setPref: "javascript.options.ion.threshold"
+    ion_bailout_threshold:
+      description: Set the ion frequent bailout threshold.
+      type: int
+      setPref: "javascript.options.ion.frequent_bailout_threshold"
+    ion_offthread_compilation:
+      description: True to enable offthread ion compilations.
+      type: boolean
+      setPref: "javascript.options.ion.offthread_compilation"
+    inlining_max_length:
+      description: Set the max bytecode length considered for inlining.
+      type: int
+      setPref: "javascript.options.inlining_bytecode_max_length"
+
+jitHintsCache:
+  description: Pref to toggle the JIT hints cache.
+  owner: dpalmeiro@mozilla.com
+  isEarlyStartup: true
+  hasExposure: false
+  variables:
+    enabled:
+      description: True to enable the hints cache.
+      type: boolean
+      setPref: "javascript.options.jithints"
+
+raceCacheWithNetwork:
+  description: Prefs to toggle the race cache with network.
+  owner: dpalmeiro@mozilla.com, acreskey@mozilla.com
+  hasExposure: false
+  variables:
+    enabled:
+      description: True to enable the rcwn feature.
+      type: boolean
+      setPref: "network.http.rcwn.enabled"
+
+httpSpeculativeParallelLimit:
+  description: Prefs to control the http speculative parallel limit.
+  owner: dpalmeiro@mozilla.com, acreskey@mozilla.com
+  hasExposure: false
+  variables:
+    speculative_parallel_limit:
+      description: Maximum number of parallel speculative connections.
+      type: int
+      setPref: "network.http.speculative-parallel-limit"
+
+deviceMigration:
+  description: Prefs to control aspects of the new device migration experiment
+  owner: hjones@mozilla.com
+  hasExposure: false
+  isEarlyStartup: true
+  variables:
+    helpMenuHidden:
+      description: True if new help menu item should be hidden
+      type: boolean
+      fallbackPref: browser.device-migration.help-menu.hidden
+
+shopping2023:
+  description: Prefs to control the 2023 shopping experiment.
+  owner: jhirsch@mozilla.com
+  hasExposure: true
+  exposureDescription: >-
+    The timing of the exposure event depends on the experiment, but generally
+    the event is recorded when the user first encounters onboarding UI for
+    the shopping feature.
+  variables:
+    enabled:
+      description: True if the experience is enabled (experimental treatment group)
+      type: boolean
+      fallbackPref: browser.shopping.experience2023.enabled
+    control:
+      description: True if the experiment is enabled but experience is disabled (experimental control group)
+      type: boolean
+      fallbackPref: browser.shopping.experience2023.control
+    adsEnabled:
+      description: True if showing recommended products is enabled
+      type: boolean
+      setPref: browser.shopping.experience2023.ads.enabled
+    adsExposure:
+      description: True if we want to record ad inventory for opted-in users, even if ads are disabled
+      type: boolean
+      setPref: browser.shopping.experience2023.ads.exposure
+    surveyEnabled:
+      description: True if showing survey is enabled
+      type: boolean
+      fallbackPref: browser.shopping.experience2023.survey.enabled
+shoppingOHTTP:
+  description: Prefs to control the OHTTP URLs used for shopping.
+  owner: gijs@mozilla.com
+  hasExposure: false
+  variables:
+    ohttpRelayURL:
+      description: What OHTTP relay URL to use
+      type: string
+      setPref: toolkit.shopping.ohttpRelayURL
+    ohttpConfigURL:
+      description: URL for the OHTTP config to use
+      type: string
+      setPref: toolkit.shopping.ohttpConfigURL
+
+opaqueResponseBlocking:
+  description: Prefs to enable Opaque Response Blocking
+  owner: farre@mozilla.com
+  isEarlyStartup: true
+  hasExposure: true
+  exposureDescription: Exposure is sent when a response is blocked
+  variables:
+    enabled:
+      description: Whether ORB is enabled
+      type: boolean
+      setPref: "browser.opaqueResponseBlocking"
+    javascriptValidator:
+      description: Whether JavaScript validation for ORB is enabled
+      type: boolean
+      setPref: "browser.opaqueResponseBlocking.javascriptValidator"
+    filterFetchResponse:
+      description: Whether filtering of internal responses in the parent ORB is enabled
+      type: int
+      setPref: "browser.opaqueResponseBlocking.filterFetchResponse"
+    mediaExceptionsStrategy:
+      description: >-
+        If we partially or wholly allow audio and video MIME types in conflict with spec.
+      type: int
+      setPref: "browser.opaqueResponseBlocking.mediaExceptionsStrategy"
+
+updatePrompt:
+  description: Prefs to control content and behavior of update notifications
+  owner: omc@mozilla.com
+  hasExposure: true
+  exposureDescription: >-
+    Exposure is sent at most once per browsing session when an update
+    notification prompt is displayed.
+  isEarlyStartup: true
+  variables:
+    showReleaseNotesLink:
+      type: boolean
+      description: >-
+        If true, the "Learn More" link will be shown in the update prompt. If
+        false or omitted, the link will only be shown for supported locales.
+    releaseNotesURL:
+      type: string
+      fallbackPref: app.releaseNotesURL.prompt
+      description: >-
+        Template for the URL opened when the user clicks the "Learn More" link
+        in the update prompt. If an empty string, the link will not be shown.
+
+powerSaver:
+  description: Prefs to control power saving behaviors
+  owner: florian@mozilla.com
+  hasExposure: false
+  isEarlyStartup: true
+  variables:
+    reduceFrameRates:
+      type: int
+      setPref: "gfx.display.max-frame-rate"
+      description: >-
+        Limit the number of frames displayed per second.
+        If omitted, the refresh rate of the screen will be used.
+    mediaAutoPlay:
+      type: int
+      setPref: "media.autoplay.default"
+      description: >-
+        Control if media is allowed to auto-play, with and without sound.
+    backgroundTimerMinTime:
+      type: int
+      setPref: "dom.min_background_timeout_value"
+      description: >-
+        Limit how frequently timers are allowed to run in background tabs.
+    backgroundTimerRegenerationRate:
+      type: int
+      setPref: "dom.timeout.background_budget_regeneration_rate"
+      description: >-
+        Limit how quickly the background tab timer budget regenerates.
+
+firefoxViewNext:
+  description: Next Iteration of Firefox View
+  owner: firefoxview@mozilla.com
+  hasExposure: false
+  isEarlyStartup: true
+  variables:
+    enabled:
+      type: boolean
+      fallbackPref: "browser.tabs.firefox-view-next"
+      description: "Whether or not to enable the new Firefox View"
+    newIcon:
+      type: boolean
+      fallbackPref: "browser.tabs.firefox-view-newIcon"
+      description: "Whether or not use the new icon"
+
+backgroundUpdate:
+  description: Prefs to control aspects of the background update process.
+  owner: install-update@mozilla.com
+  hasExposure: true
+  exposureDescription: >-
+    The exposure event is sent when scheduling the background task and both the
+    feature is enabled and the service registry key (Mozilla Maintenance
+    Service) is *not* available for this installation. That is the first time
+    the feature can impact Firefox behaviour and the user experience.
+  isEarlyStartup: true
+  variables:
+    enableUpdatesForUnelevatedInstallations:
+      description: >-
+        Allow the background update process to download and apply updates when
+        the Mozilla Maintenance Service is unavailable but the installation
+        directory can be written.
+      type: boolean
+      setPref: app.update.background.allowUpdatesForUnelevatedInstallations
+
+bookmarks:
+  description: Prefs to control aspects of the bookmarks system.
+  owner: omc@mozilla.com
+  hasExposure: false
+  isEarlyStartup: true
+  variables:
+    enableBookmarksToolbar:
+      type: string
+      setPref: browser.toolbars.bookmarks.visibility
+      description: If the bookmarks toolbar should never, always, or only show on newtab.
+
+cookieBannerHandling:
+  description: Automatically handle cookie banners on the user's behalf.
+  owner: pbz@mozilla.com
+  hasExposure: false
+  variables:
+    modeNormalBrowsing:
+      type: int
+      setPref: cookiebanners.service.mode
+      description: >-
+        Controls the cookie banner handling mode in normal browsing.
+        Values: 0 - disabled, 1 - reject all, 2 - reject all with accept all fallback.
+    modePrivateBrowsing:
+      type: int
+      setPref: cookiebanners.service.mode.privateBrowsing
+      description: >-
+        Controls the cookie banner handling mode in private browsing.
+        Values: 0 - disabled, 1 - reject all, 2 - reject all with accept all fallback.
+    enableGlobalRules:
+      type: boolean
+      setPref: cookiebanners.service.enableGlobalRules
+      description: >-
+        Enables use of global CookieBannerRules, which apply to all sites.
+        This enables handling of CMPs across sites without the use of site-specific rules.
+    enableGlobalRulesSubFrames:
+      type: boolean
+      setPref: cookiebanners.service.enableGlobalRules.subFrames
+      description: >-
+        Whether global rules are allowed to run in sub-frames. Running query
+        selectors in every sub-frame may negatively impact performance, but is
+        required for some CMPs.
+    enableDetectOnly:
+      type: boolean
+      setPref: cookiebanners.service.detectOnly
+      description: >-
+        When set to true, cookie banners are detected and detection events are
+        dispatched, but they will not be handled.
+        This pref applies to both normal and private browsing windows.
+    enableFirefoxDesktopUI:
+      type: boolean
+      setPref: cookiebanners.ui.desktop.enabled
+      description: Enables the cookie banner desktop UI.
+    enablePromo:
+      type: boolean
+      setPref: browser.promo.cookiebanners.enabled
+      description: Enables the cookie banner promo in about:privatebrowsing.
+
+backgroundThreads:
+  description: Prefs to control MacOS thread priorities for power savings.
+  owner: kwright@mozilla.com
+  hasExposure: false
+  isEarlyStartup: true
+  variables:
+    use_low_power:
+      description: >-
+        Use the MacOS QoS libraries to deprioritize select threads.
+      type: boolean
+      setPref: threads.use_low_power.enabled
+    lower_mainthread_priority_in_background:
+      description: >-
+        When a browsing context is put in the background and isn't actively playing
+        media, deprioritize its main thread.
+      type: boolean
+      setPref: threads.lower_mainthread_priority_in_background.enabled
+
+feltPrivacy:
+  description: Prefs for Felt Privacy v1 experiments
+  owner: cmeador@mozilla.com
+  hasExposure: true
+  exposureDescription: Exposure when user opens a private browsing window.
+  variables:
+    feltPrivacy:
+      type: boolean
+      setPref: browser.privatebrowsing.felt-privacy-v1
+      description: >-
+        When true, new styles and copy enabled on about:privatebrowsing. When true,
+        a toggle for showing or hiding quick suggestions appears in about:preferences.
+    resetPBMAction:
+      type: boolean
+      setPref: browser.privatebrowsing.resetPBM.enabled
+      description: >-
+        Enables the reset PBM feature button and confirmation panel.
+
+attribution:
+  description: Prefs related to install attribution
+  hasExposure: false
+  isEarlyStartup: true
+  variables:
+    macosEnabled:
+      type: boolean
+      description: Whether or not macOS attribution data will be processed and sent in Telemetry
+      fallbackPref: browser.attribution.macos.enabled
+
+phc:
+  description: Prefs to control the Probabalistic Heap Checker (PHC)
+  owner: pbone@mozilla.com
+  hasExposure: false
+  isEarlyStartup: true
+  variables:
+    phcEnabled:
+      description: Whether to enable PHC
+      type: boolean
+      setPref: memory.phc.enabled
+
+mailto:
+  description: Prefs to control aspects of the mailto handler
+  owner: install-update@mozilla.com
+  hasExposure: true
+  exposureDescription: >-
+    The exposure event is sent when a webmail site calls the
+    registerProtocolHandler function and when users use mailto links in Firefox.
+  isEarlyStartup: false
+  variables:
+    dualPrompt:
+      type: boolean
+      description: >-
+        Can be used to toggle the entire feature on and off.
+      fallbackPref: browser.mailto.dualPrompt
+    dualPrompt.os:
+      type: boolean
+      description: >-
+        Make webmail sites display prompts to set Firefox as default OS mailto
+        application and another prompt to set the current site as default
+        webmail site in Firefox.
+      fallbackPref: browser.mailto.dualPrompt.os
+

--- a/experimenter/experimenter/features/manifests/firefox-desktop/v121.0.0/schemas/browser/components/newtab/content-src/asrouter/schemas/BackgroundTaskMessagingExperiment.schema.json
+++ b/experimenter/experimenter/features/manifests/firefox-desktop/v121.0.0/schemas/browser/components/newtab/content-src/asrouter/schemas/BackgroundTaskMessagingExperiment.schema.json
@@ -1,0 +1,344 @@
+{
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "$id": "resource://activity-stream/schemas/BackgroundTaskMessagingExperiment.schema.json",
+  "title": "Messaging Experiment",
+  "description": "A Firefox Messaging System message.",
+  "if": {
+    "type": "object",
+    "properties": {
+      "template": {
+        "const": "multi"
+      }
+    },
+    "required": [
+      "template"
+    ]
+  },
+  "then": {
+    "$ref": "resource://activity-stream/schemas/BackgroundTaskMessagingExperiment.schema.json#/$defs/MultiMessage"
+  },
+  "else": {
+    "$ref": "resource://activity-stream/schemas/BackgroundTaskMessagingExperiment.schema.json#/$defs/TemplatedMessage"
+  },
+  "$defs": {
+    "ToastNotification": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "$id": "file:///ToastNotification.schema.json",
+      "title": "ToastNotification",
+      "description": "A template for toast notifications displayed by the Alert service.",
+      "allOf": [
+        {
+          "$ref": "resource://activity-stream/schemas/BackgroundTaskMessagingExperiment.schema.json#/$defs/Message"
+        }
+      ],
+      "type": "object",
+      "properties": {
+        "content": {
+          "type": "object",
+          "properties": {
+            "title": {
+              "$ref": "resource://activity-stream/schemas/BackgroundTaskMessagingExperiment.schema.json#/$defs/localizableText",
+              "description": "Id of localized string or message override of toast notification title"
+            },
+            "body": {
+              "$ref": "resource://activity-stream/schemas/BackgroundTaskMessagingExperiment.schema.json#/$defs/localizableText",
+              "description": "Id of localized string or message override of toast notification body"
+            },
+            "icon_url": {
+              "description": "The URL of the image used as an icon of the toast notification.",
+              "type": "string",
+              "format": "moz-url-format"
+            },
+            "image_url": {
+              "description": "The URL of an image to be displayed as part of the notification.",
+              "type": "string",
+              "format": "moz-url-format"
+            },
+            "launch_url": {
+              "description": "The URL to launch when the notification or an action button is clicked.",
+              "type": "string",
+              "format": "moz-url-format"
+            },
+            "launch_action": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "description": "The launch action to be performed when Firefox is launched."
+                },
+                "data": {
+                  "type": "object"
+                }
+              },
+              "required": [
+                "type"
+              ],
+              "additionalProperties": true
+            },
+            "requireInteraction": {
+              "type": "boolean",
+              "description": "Whether the toast notification should remain active until the user clicks or dismisses it, rather than closing automatically."
+            },
+            "tag": {
+              "type": "string",
+              "description": "An identifying tag for the toast notification."
+            },
+            "data": {
+              "type": "object",
+              "description": "Arbitrary data associated with the toast notification."
+            },
+            "actions": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "title": {
+                    "$ref": "resource://activity-stream/schemas/BackgroundTaskMessagingExperiment.schema.json#/$defs/localizableText",
+                    "description": "The action text to be shown to the user."
+                  },
+                  "action": {
+                    "type": "string",
+                    "description": "Opaque identifer that identifies action."
+                  },
+                  "iconURL": {
+                    "type": "string",
+                    "format": "uri",
+                    "description": "URL of an icon to display with the action."
+                  },
+                  "windowsSystemActivationType": {
+                    "type": "boolean",
+                    "description": "Whether to have Windows process the given `action`."
+                  },
+                  "launch_action": {
+                    "type": "object",
+                    "properties": {
+                      "type": {
+                        "type": "string",
+                        "description": "The launch action to be performed when Firefox is launched."
+                      },
+                      "data": {
+                        "type": "object"
+                      }
+                    },
+                    "required": [
+                      "type"
+                    ],
+                    "additionalProperties": true
+                  }
+                },
+                "required": [
+                  "action",
+                  "title"
+                ],
+                "additionalProperties": true
+              }
+            }
+          },
+          "additionalProperties": true,
+          "required": [
+            "title",
+            "body"
+          ]
+        },
+        "template": {
+          "type": "string",
+          "const": "toast_notification"
+        }
+      },
+      "required": [
+        "content",
+        "targeting",
+        "template",
+        "trigger"
+      ],
+      "additionalProperties": true
+    },
+    "Message": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "The message identifier"
+        },
+        "groups": {
+          "description": "Array of preferences used to control `enabled` status of the group. If any is `false` the group is disabled.",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "description": "Preference name"
+          }
+        },
+        "template": {
+          "type": "string",
+          "description": "Which messaging template this message is using.",
+          "enum": [
+            "toast_notification"
+          ]
+        },
+        "frequency": {
+          "type": "object",
+          "description": "An object containing frequency cap information for a message.",
+          "properties": {
+            "lifetime": {
+              "type": "integer",
+              "description": "The maximum lifetime impressions for a message.",
+              "minimum": 1,
+              "maximum": 100
+            },
+            "custom": {
+              "type": "array",
+              "description": "An array of custom frequency cap definitions.",
+              "items": {
+                "description": "A frequency cap definition containing time and max impression information",
+                "type": "object",
+                "properties": {
+                  "period": {
+                    "type": "integer",
+                    "description": "Period of time in milliseconds (e.g. 86400000 for one day)"
+                  },
+                  "cap": {
+                    "type": "integer",
+                    "description": "The maximum impressions for the message within the defined period.",
+                    "minimum": 1,
+                    "maximum": 100
+                  }
+                },
+                "required": [
+                  "period",
+                  "cap"
+                ]
+              }
+            }
+          }
+        },
+        "priority": {
+          "description": "The priority of the message. If there are two competing messages to show, the one with the highest priority will be shown",
+          "type": "integer"
+        },
+        "order": {
+          "description": "The order in which messages should be shown. Messages will be shown in increasing order.",
+          "type": "integer"
+        },
+        "targeting": {
+          "description": "A JEXL expression representing targeting information",
+          "type": "string"
+        },
+        "trigger": {
+          "description": "An action to trigger potentially showing the message",
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "A string identifying the trigger action"
+            },
+            "params": {
+              "type": "array",
+              "description": "An optional array of string parameters for the trigger action",
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "string"
+                  }
+                ]
+              }
+            }
+          },
+          "required": [
+            "id"
+          ]
+        },
+        "provider": {
+          "description": "An identifier for the provider of this message, such as \"cfr\" or \"preview\".",
+          "type": "string"
+        }
+      },
+      "additionalProperties": true,
+      "dependentRequired": {
+        "content": [
+          "id",
+          "template"
+        ],
+        "template": [
+          "id",
+          "content"
+        ]
+      }
+    },
+    "localizedText": {
+      "type": "object",
+      "properties": {
+        "string_id": {
+          "description": "Id of localized string to be rendered.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "string_id"
+      ]
+    },
+    "localizableText": {
+      "description": "Either a raw string or an object containing the string_id of the localized text",
+      "oneOf": [
+        {
+          "type": "string",
+          "description": "The string to be rendered."
+        },
+        {
+          "$ref": "resource://activity-stream/schemas/BackgroundTaskMessagingExperiment.schema.json#/$defs/localizedText"
+        }
+      ]
+    },
+    "TemplatedMessage": {
+      "description": "An FxMS message of one of a variety of types.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "resource://activity-stream/schemas/BackgroundTaskMessagingExperiment.schema.json#/$defs/Message"
+        },
+        {
+          "if": {
+            "type": "object",
+            "properties": {
+              "template": {
+                "type": "string",
+                "enum": [
+                  "toast_notification"
+                ]
+              }
+            },
+            "required": [
+              "template"
+            ]
+          },
+          "then": {
+            "$ref": "resource://activity-stream/schemas/BackgroundTaskMessagingExperiment.schema.json#/$defs/ToastNotification"
+          }
+        }
+      ]
+    },
+    "MultiMessage": {
+      "description": "An object containing an array of messages.",
+      "type": "object",
+      "properties": {
+        "template": {
+          "type": "string",
+          "const": "multi"
+        },
+        "messages": {
+          "type": "array",
+          "description": "An array of messages.",
+          "items": {
+            "$ref": "resource://activity-stream/schemas/BackgroundTaskMessagingExperiment.schema.json#/$defs/TemplatedMessage"
+          }
+        }
+      },
+      "required": [
+        "template",
+        "messages"
+      ]
+    }
+  }
+}

--- a/experimenter/experimenter/features/manifests/firefox-desktop/v121.0.0/schemas/browser/components/newtab/content-src/asrouter/schemas/MessagingExperiment.schema.json
+++ b/experimenter/experimenter/features/manifests/firefox-desktop/v121.0.0/schemas/browser/components/newtab/content-src/asrouter/schemas/MessagingExperiment.schema.json
@@ -1,0 +1,1672 @@
+{
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "$id": "resource://activity-stream/schemas/MessagingExperiment.schema.json",
+  "title": "Messaging Experiment",
+  "description": "A Firefox Messaging System message.",
+  "if": {
+    "type": "object",
+    "properties": {
+      "template": {
+        "const": "multi"
+      }
+    },
+    "required": [
+      "template"
+    ]
+  },
+  "then": {
+    "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/MultiMessage"
+  },
+  "else": {
+    "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/TemplatedMessage"
+  },
+  "$defs": {
+    "CFRUrlbarChiclet": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "$id": "file:///CFRUrlbarChiclet.schema.json",
+      "title": "CFRUrlbarChiclet",
+      "description": "A template with a chiclet button with text.",
+      "allOf": [
+        {
+          "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/Message"
+        }
+      ],
+      "type": "object",
+      "properties": {
+        "content": {
+          "type": "object",
+          "properties": {
+            "category": {
+              "type": "string",
+              "description": "Attribute used for different groups of messages from the same provider"
+            },
+            "layout": {
+              "type": "string",
+              "description": "Describes how content should be displayed.",
+              "enum": [
+                "chiclet_open_url"
+              ]
+            },
+            "bucket_id": {
+              "type": "string",
+              "description": "A bucket identifier for the addon. This is used in order to anonymize telemetry for history-sensitive targeting."
+            },
+            "notification_text": {
+              "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/localizableText",
+              "description": "The text in the small blue chicklet that appears in the URL bar. This can be a reference to a localized string in Firefox or just a plain string."
+            },
+            "active_color": {
+              "type": "string",
+              "description": "Background color of the button"
+            },
+            "action": {
+              "type": "object",
+              "properties": {
+                "url": {
+                  "description": "The page to open when the button is clicked.",
+                  "type": "string",
+                  "format": "moz-url-format"
+                },
+                "where": {
+                  "description": "Should it open in a new tab or the current tab",
+                  "type": "string",
+                  "enum": [
+                    "current",
+                    "tabshifted"
+                  ]
+                }
+              },
+              "additionalProperties": true,
+              "required": [
+                "url",
+                "where"
+              ]
+            }
+          },
+          "additionalProperties": true,
+          "required": [
+            "layout",
+            "category",
+            "bucket_id",
+            "notification_text",
+            "action"
+          ]
+        },
+        "template": {
+          "type": "string",
+          "const": "cfr_urlbar_chiclet"
+        }
+      },
+      "required": [
+        "targeting",
+        "trigger"
+      ]
+    },
+    "ExtensionDoorhanger": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "$id": "file:///ExtensionDoorhanger.schema.json",
+      "title": "ExtensionDoorhanger",
+      "description": "A template with a heading, addon icon, title and description. No markup allowed.",
+      "allOf": [
+        {
+          "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/Message"
+        }
+      ],
+      "type": "object",
+      "properties": {
+        "content": {
+          "type": "object",
+          "properties": {
+            "category": {
+              "type": "string",
+              "description": "Attribute used for different groups of messages from the same provider"
+            },
+            "layout": {
+              "type": "string",
+              "description": "Attribute used for different groups of messages from the same provider",
+              "enum": [
+                "short_message",
+                "icon_and_message",
+                "addon_recommendation"
+              ]
+            },
+            "anchor_id": {
+              "type": "string",
+              "description": "A DOM element ID that the pop-over will be anchored."
+            },
+            "alt_anchor_id": {
+              "type": "string",
+              "description": "An alternate DOM element ID that the pop-over will be anchored."
+            },
+            "bucket_id": {
+              "type": "string",
+              "description": "A bucket identifier for the addon. This is used in order to anonymize telemetry for history-sensitive targeting."
+            },
+            "skip_address_bar_notifier": {
+              "type": "boolean",
+              "description": "Skip the 'Recommend' notifier and show directly."
+            },
+            "persistent_doorhanger": {
+              "type": "boolean",
+              "description": "Prevent the doorhanger from being dismissed if user interacts with the page or switches between applications."
+            },
+            "show_in_private_browsing": {
+              "type": "boolean",
+              "description": "Whether to allow the message to be shown in private browsing mode. Defaults to false."
+            },
+            "notification_text": {
+              "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/localizableText",
+              "description": "The text in the small blue chicklet that appears in the URL bar. This can be a reference to a localized string in Firefox or just a plain string."
+            },
+            "info_icon": {
+              "type": "object",
+              "description": "The small icon displayed in the top right corner of the pop-over. Should be 19x19px, svg or png. Defaults to a small question mark.",
+              "properties": {
+                "label": {
+                  "oneOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "attributes": {
+                          "type": "object",
+                          "properties": {
+                            "tooltiptext": {
+                              "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/localizableText",
+                              "description": "Text for button tooltip used to provide information about the doorhanger."
+                            }
+                          },
+                          "required": [
+                            "tooltiptext"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "attributes"
+                      ]
+                    },
+                    {
+                      "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/localizedText"
+                    }
+                  ]
+                },
+                "sumo_path": {
+                  "type": "string",
+                  "description": "Last part of the path in the URL to the support page with the information about the doorhanger.",
+                  "examples": [
+                    "extensionpromotions",
+                    "extensionrecommendations"
+                  ]
+                }
+              }
+            },
+            "learn_more": {
+              "type": "string",
+              "description": "Last part of the path in the SUMO URL to the support page with the information about the doorhanger.",
+              "examples": [
+                "extensionpromotions",
+                "extensionrecommendations"
+              ]
+            },
+            "heading_text": {
+              "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/localizableText",
+              "description": "The larger heading text displayed in the pop-over. This can be a reference to a localized string in Firefox or just a plain string."
+            },
+            "icon": {
+              "$ref": "file:///ExtensionDoorhanger.schema.json#/$defs/linkUrl",
+              "description": "The icon displayed in the pop-over. Should be 32x32px or 64x64px and png/svg."
+            },
+            "icon_dark_theme": {
+              "type": "string",
+              "description": "Pop-over icon, dark theme variant. Should be 32x32px or 64x64px and png/svg."
+            },
+            "icon_class": {
+              "type": "string",
+              "description": "CSS class of the pop-over icon."
+            },
+            "addon": {
+              "description": "Addon information including AMO URL.",
+              "type": "object",
+              "properties": {
+                "id": {
+                  "$ref": "file:///ExtensionDoorhanger.schema.json#/$defs/plainText",
+                  "description": "Unique addon ID"
+                },
+                "title": {
+                  "$ref": "file:///ExtensionDoorhanger.schema.json#/$defs/plainText",
+                  "description": "Addon name"
+                },
+                "author": {
+                  "$ref": "file:///ExtensionDoorhanger.schema.json#/$defs/plainText",
+                  "description": "Addon author"
+                },
+                "icon": {
+                  "$ref": "file:///ExtensionDoorhanger.schema.json#/$defs/linkUrl",
+                  "description": "The icon displayed in the pop-over. Should be 64x64px and png/svg."
+                },
+                "rating": {
+                  "type": "string",
+                  "description": "Star rating"
+                },
+                "users": {
+                  "type": "string",
+                  "description": "Installed users"
+                },
+                "amo_url": {
+                  "$ref": "file:///ExtensionDoorhanger.schema.json#/$defs/linkUrl",
+                  "description": "Link that offers more information related to the addon."
+                }
+              },
+              "required": [
+                "title",
+                "author",
+                "icon",
+                "amo_url"
+              ]
+            },
+            "text": {
+              "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/localizableText",
+              "description": "The body text displayed in the pop-over. This can be a reference to a localized string in Firefox or just a plain string."
+            },
+            "descriptionDetails": {
+              "description": "Additional information and steps on how to use",
+              "type": "object",
+              "properties": {
+                "steps": {
+                  "description": "Array of string_ids",
+                  "type": "array",
+                  "items": {
+                    "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/localizedText",
+                    "description": "Id of string to localized addon description"
+                  }
+                }
+              },
+              "required": [
+                "steps"
+              ]
+            },
+            "buttons": {
+              "description": "The label and functionality for the buttons in the pop-over.",
+              "type": "object",
+              "properties": {
+                "primary": {
+                  "type": "object",
+                  "properties": {
+                    "label": {
+                      "type": "object",
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "value": {
+                              "$ref": "file:///ExtensionDoorhanger.schema.json#/$defs/plainText",
+                              "description": "Button label override used when a localized version is not available."
+                            },
+                            "attributes": {
+                              "type": "object",
+                              "properties": {
+                                "accesskey": {
+                                  "type": "string",
+                                  "description": "A single character to be used as a shortcut key for the secondary button. This should be one of the characters that appears in the button label."
+                                }
+                              },
+                              "required": [
+                                "accesskey"
+                              ],
+                              "description": "Button attributes."
+                            }
+                          },
+                          "required": [
+                            "value",
+                            "attributes"
+                          ]
+                        },
+                        {
+                          "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/localizedText"
+                        }
+                      ],
+                      "description": "Id of localized string or message override."
+                    },
+                    "action": {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "description": "Action dispatched by the button."
+                        },
+                        "data": {
+                          "properties": {
+                            "url": {
+                              "type": "string",
+                              "$comment": "This is dynamically generated from the addon.id. See CFRPageActions.jsm",
+                              "description": "URL used in combination with the primary action dispatched."
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "secondary": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "label": {
+                        "type": "object",
+                        "oneOf": [
+                          {
+                            "properties": {
+                              "value": {
+                                "allOf": [
+                                  {
+                                    "$ref": "file:///ExtensionDoorhanger.schema.json#/$defs/plainText"
+                                  },
+                                  {
+                                    "description": "Button label override used when a localized version is not available."
+                                  }
+                                ]
+                              },
+                              "attributes": {
+                                "type": "object",
+                                "properties": {
+                                  "accesskey": {
+                                    "type": "string",
+                                    "description": "A single character to be used as a shortcut key for the secondary button. This should be one of the characters that appears in the button label."
+                                  }
+                                },
+                                "required": [
+                                  "accesskey"
+                                ],
+                                "description": "Button attributes."
+                              }
+                            },
+                            "required": [
+                              "value",
+                              "attributes"
+                            ]
+                          },
+                          {
+                            "properties": {
+                              "string_id": {
+                                "allOf": [
+                                  {
+                                    "$ref": "file:///ExtensionDoorhanger.schema.json#/$defs/plainText"
+                                  },
+                                  {
+                                    "description": "Id of localized string for button"
+                                  }
+                                ]
+                              }
+                            },
+                            "required": [
+                              "string_id"
+                            ]
+                          }
+                        ],
+                        "description": "Id of localized string or message override."
+                      },
+                      "action": {
+                        "type": "object",
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "description": "Action dispatched by the button."
+                          },
+                          "data": {
+                            "properties": {
+                              "url": {
+                                "allOf": [
+                                  {
+                                    "$ref": "file:///ExtensionDoorhanger.schema.json#/$defs/linkUrl"
+                                  },
+                                  {
+                                    "description": "URL used in combination with the primary action dispatched."
+                                  }
+                                ]
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "additionalProperties": true,
+          "required": [
+            "layout",
+            "bucket_id",
+            "heading_text",
+            "text",
+            "buttons"
+          ],
+          "if": {
+            "properties": {
+              "skip_address_bar_notifier": {
+                "anyOf": [
+                  {
+                    "const": "false"
+                  },
+                  {
+                    "const": null
+                  }
+                ]
+              }
+            }
+          },
+          "then": {
+            "required": [
+              "category",
+              "notification_text"
+            ]
+          }
+        },
+        "template": {
+          "type": "string",
+          "enum": [
+            "cfr_doorhanger",
+            "milestone_message"
+          ]
+        }
+      },
+      "additionalProperties": true,
+      "required": [
+        "targeting",
+        "trigger"
+      ],
+      "$defs": {
+        "plainText": {
+          "description": "Plain text (no HTML allowed)",
+          "type": "string"
+        },
+        "linkUrl": {
+          "description": "Target for links or buttons",
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "InfoBar": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "$id": "file:///InfoBar.schema.json",
+      "title": "InfoBar",
+      "description": "A template with an image, test and buttons.",
+      "allOf": [
+        {
+          "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/Message"
+        }
+      ],
+      "type": "object",
+      "properties": {
+        "content": {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "description": "Should the message be global (persisted across tabs) or local (disappear when switching to a different tab).",
+              "enum": [
+                "global",
+                "tab"
+              ]
+            },
+            "text": {
+              "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/localizableText",
+              "description": "The text show in the notification box."
+            },
+            "priority": {
+              "description": "Infobar priority level https://searchfox.org/mozilla-central/rev/3aef835f6cb12e607154d56d68726767172571e4/toolkit/content/widgets/notificationbox.js#387",
+              "type": "number",
+              "minumum": 0,
+              "exclusiveMaximum": 10
+            },
+            "buttons": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "label": {
+                    "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/localizableText",
+                    "description": "The text label of the button."
+                  },
+                  "primary": {
+                    "type": "boolean",
+                    "description": "Is this the primary button?"
+                  },
+                  "accessKey": {
+                    "type": "string",
+                    "description": "Keyboard shortcut letter."
+                  },
+                  "action": {
+                    "type": "object",
+                    "properties": {
+                      "type": {
+                        "type": "string",
+                        "description": "Action dispatched by the button."
+                      },
+                      "data": {
+                        "type": "object"
+                      }
+                    },
+                    "required": [
+                      "type"
+                    ],
+                    "additionalProperties": true
+                  },
+                  "supportPage": {
+                    "type": "string",
+                    "description": "A page title on SUMO to link to"
+                  }
+                },
+                "required": [
+                  "label",
+                  "action"
+                ],
+                "additionalProperties": true
+              }
+            }
+          },
+          "additionalProperties": true,
+          "required": [
+            "text",
+            "buttons"
+          ]
+        },
+        "template": {
+          "type": "string",
+          "const": "infobar"
+        }
+      },
+      "additionalProperties": true,
+      "required": [
+        "targeting",
+        "trigger"
+      ],
+      "$defs": {
+        "plainText": {
+          "description": "Plain text (no HTML allowed)",
+          "type": "string"
+        },
+        "linkUrl": {
+          "description": "Target for links or buttons",
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "NewtabPromoMessage": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "$id": "file:///NewtabPromoMessage.schema.json",
+      "title": "PBNewtabPromoMessage",
+      "description": "Message shown on the private browsing newtab page.",
+      "allOf": [
+        {
+          "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/Message"
+        }
+      ],
+      "type": "object",
+      "properties": {
+        "content": {
+          "type": "object",
+          "properties": {
+            "hideDefault": {
+              "type": "boolean",
+              "description": "Should we hide the default promo after the experiment promo is dismissed."
+            },
+            "infoEnabled": {
+              "type": "boolean",
+              "description": "Should we show the info section."
+            },
+            "infoIcon": {
+              "type": "string",
+              "description": "Icon shown in the left side of the info section. Default is the private browsing icon."
+            },
+            "infoTitle": {
+              "type": "string",
+              "description": "Is the title in the info section enabled."
+            },
+            "infoTitleEnabled": {
+              "type": "boolean",
+              "description": "Is the title in the info section enabled."
+            },
+            "infoBody": {
+              "type": "string",
+              "description": "Text content in the info section."
+            },
+            "infoLinkText": {
+              "type": "string",
+              "description": "Text for the link in the info section."
+            },
+            "infoLinkUrl": {
+              "type": "string",
+              "description": "URL for the info section link.",
+              "format": "moz-url-format"
+            },
+            "promoEnabled": {
+              "type": "boolean",
+              "description": "Should we show the promo section."
+            },
+            "promoType": {
+              "type": "string",
+              "description": "Promo type used to determine if promo should show to a given user",
+              "enum": [
+                "FOCUS",
+                "VPN",
+                "PIN",
+                "COOKIE_BANNERS",
+                "OTHER"
+              ]
+            },
+            "promoSectionStyle": {
+              "type": "string",
+              "description": "Sets the position of the promo section. Possible values are: top, below-search, bottom. Default bottom.",
+              "enum": [
+                "top",
+                "below-search",
+                "bottom"
+              ]
+            },
+            "promoTitle": {
+              "type": "string",
+              "description": "The text content of the promo section."
+            },
+            "promoTitleEnabled": {
+              "type": "boolean",
+              "description": "Should we show text content in the promo section."
+            },
+            "promoLinkText": {
+              "type": "string",
+              "description": "The text of the link in the promo box."
+            },
+            "promoHeader": {
+              "type": "string",
+              "description": "The title of the promo section."
+            },
+            "promoButton": {
+              "type": "object",
+              "properties": {
+                "action": {
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "description": "Action dispatched by the button."
+                    },
+                    "data": {
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "type"
+                  ],
+                  "additionalProperties": true
+                }
+              },
+              "required": [
+                "action"
+              ]
+            },
+            "promoLinkType": {
+              "type": "string",
+              "description": "Type of promo link type. Possible values: link, button. Default is link.",
+              "enum": [
+                "link",
+                "button"
+              ]
+            },
+            "promoImageLarge": {
+              "type": "string",
+              "description": "URL for image used on the left side of the promo box, larger, showcases some feature. Default off.",
+              "format": "uri"
+            },
+            "promoImageSmall": {
+              "type": "string",
+              "description": "URL for image used on the right side of the promo box, smaller, usually a logo. Default off.",
+              "format": "uri"
+            }
+          },
+          "additionalProperties": true,
+          "allOf": [
+            {
+              "if": {
+                "properties": {
+                  "promoEnabled": {
+                    "const": true
+                  }
+                },
+                "required": [
+                  "promoEnabled"
+                ]
+              },
+              "then": {
+                "required": [
+                  "promoButton"
+                ]
+              }
+            },
+            {
+              "if": {
+                "properties": {
+                  "infoEnabled": {
+                    "const": true
+                  }
+                },
+                "required": [
+                  "infoEnabled"
+                ]
+              },
+              "then": {
+                "required": [
+                  "infoLinkText"
+                ],
+                "if": {
+                  "properties": {
+                    "infoTitleEnabled": {
+                      "const": true
+                    }
+                  },
+                  "required": [
+                    "infoTitleEnabled"
+                  ]
+                },
+                "then": {
+                  "required": [
+                    "infoTitle"
+                  ]
+                }
+              }
+            }
+          ]
+        },
+        "template": {
+          "type": "string",
+          "const": "pb_newtab"
+        }
+      },
+      "additionalProperties": true,
+      "required": [
+        "targeting"
+      ]
+    },
+    "ProtectionsPanelMessage": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "$id": "file:///ProtectionsPanelMessage.schema.json",
+      "title": "ProtectionsPanelMessage",
+      "description": "A message shown in the protections panel.",
+      "allOf": [
+        {
+          "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/Message"
+        }
+      ],
+      "type": "object",
+      "properties": {
+        "content": {
+          "type": "object",
+          "properties": {
+            "title": {
+              "description": "The message title.",
+              "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/localizableText"
+            },
+            "body": {
+              "description": "The body of the message.",
+              "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/localizableText"
+            },
+            "link_text": {
+              "description": "The text of the call to action link.",
+              "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/localizableText"
+            },
+            "cta_type": {
+              "description": "The type of URL open action.",
+              "type": "string",
+              "enum": [
+                "OPEN_URL",
+                "OPEN_PROTECTION_REPORT",
+                "OPEN_ABOUT_PAGE"
+              ]
+            },
+            "cta_url": {
+              "description": "The URL to open when the call to action is clicked",
+              "type": "string",
+              "format": "moz-url-format"
+            },
+            "cta_where": {
+              "description": "How to open the cta.",
+              "type": "string",
+              "enum": [
+                "current",
+                "tabshifted",
+                "tab",
+                "save",
+                "window"
+              ]
+            }
+          },
+          "dependantSchemas": {
+            "link_text": [
+              "cta_type",
+              "cta_url"
+            ],
+            "cta_type": [
+              "link_text"
+            ],
+            "cta_url": [
+              "link_text"
+            ],
+            "cta_where": [
+              "link_text"
+            ]
+          },
+          "additionalProperties": false,
+          "required": [
+            "title",
+            "body"
+          ]
+        },
+        "template": {
+          "type": "string",
+          "const": "protections_panel"
+        },
+        "trigger": {
+          "description": "An action to trigger potentially showing the message. The action ID `protectionsPanelOpen` is required.",
+          "const": {
+            "id": "protectionsPanelOpen"
+          }
+        }
+      },
+      "required": [
+        "content",
+        "template",
+        "trigger"
+      ],
+      "additionalProperties": true
+    },
+    "Spotlight": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "$id": "file:///Spotlight.schema.json",
+      "title": "Spotlight",
+      "description": "A template with an image, title, content and two buttons.",
+      "allOf": [
+        {
+          "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/Message"
+        }
+      ],
+      "type": "object",
+      "properties": {
+        "content": {
+          "type": "object",
+          "properties": {
+            "template": {
+              "type": "string",
+              "description": "Specify the layout template for the Spotlight",
+              "const": "multistage"
+            },
+            "backdrop": {
+              "type": "string",
+              "description": "Background css behind modal content"
+            },
+            "logo": {
+              "type": "object",
+              "properties": {
+                "imageURL": {
+                  "type": "string",
+                  "description": "URL for image to use with the content"
+                },
+                "imageId": {
+                  "type": "string",
+                  "description": "The ID for a remotely hosted image"
+                },
+                "size": {
+                  "type": "string",
+                  "description": "The logo size."
+                }
+              },
+              "additionalProperties": true
+            },
+            "screens": {
+              "type": "array",
+              "description": "Collection of individual screen content"
+            },
+            "transitions": {
+              "type": "boolean",
+              "description": "Show transitions within and between screens"
+            },
+            "disableHistoryUpdates": {
+              "type": "boolean",
+              "description": "Don't alter the browser session's history stack - used with messaging surfaces like Feature Callouts"
+            },
+            "startScreen": {
+              "type": "integer",
+              "description": "Index of first screen to show from message, defaulting to 0"
+            }
+          },
+          "additionalProperties": true
+        },
+        "template": {
+          "type": "string",
+          "description": "Specify whether the surface is shown as a Spotlight modal or an in-surface Feature Callout dialog",
+          "enum": [
+            "spotlight",
+            "feature_callout"
+          ]
+        }
+      },
+      "additionalProperties": true,
+      "required": [
+        "targeting"
+      ]
+    },
+    "ToastNotification": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "$id": "file:///ToastNotification.schema.json",
+      "title": "ToastNotification",
+      "description": "A template for toast notifications displayed by the Alert service.",
+      "allOf": [
+        {
+          "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/Message"
+        }
+      ],
+      "type": "object",
+      "properties": {
+        "content": {
+          "type": "object",
+          "properties": {
+            "title": {
+              "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/localizableText",
+              "description": "Id of localized string or message override of toast notification title"
+            },
+            "body": {
+              "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/localizableText",
+              "description": "Id of localized string or message override of toast notification body"
+            },
+            "icon_url": {
+              "description": "The URL of the image used as an icon of the toast notification.",
+              "type": "string",
+              "format": "moz-url-format"
+            },
+            "image_url": {
+              "description": "The URL of an image to be displayed as part of the notification.",
+              "type": "string",
+              "format": "moz-url-format"
+            },
+            "launch_url": {
+              "description": "The URL to launch when the notification or an action button is clicked.",
+              "type": "string",
+              "format": "moz-url-format"
+            },
+            "launch_action": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "description": "The launch action to be performed when Firefox is launched."
+                },
+                "data": {
+                  "type": "object"
+                }
+              },
+              "required": [
+                "type"
+              ],
+              "additionalProperties": true
+            },
+            "requireInteraction": {
+              "type": "boolean",
+              "description": "Whether the toast notification should remain active until the user clicks or dismisses it, rather than closing automatically."
+            },
+            "tag": {
+              "type": "string",
+              "description": "An identifying tag for the toast notification."
+            },
+            "data": {
+              "type": "object",
+              "description": "Arbitrary data associated with the toast notification."
+            },
+            "actions": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "title": {
+                    "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/localizableText",
+                    "description": "The action text to be shown to the user."
+                  },
+                  "action": {
+                    "type": "string",
+                    "description": "Opaque identifer that identifies action."
+                  },
+                  "iconURL": {
+                    "type": "string",
+                    "format": "uri",
+                    "description": "URL of an icon to display with the action."
+                  },
+                  "windowsSystemActivationType": {
+                    "type": "boolean",
+                    "description": "Whether to have Windows process the given `action`."
+                  },
+                  "launch_action": {
+                    "type": "object",
+                    "properties": {
+                      "type": {
+                        "type": "string",
+                        "description": "The launch action to be performed when Firefox is launched."
+                      },
+                      "data": {
+                        "type": "object"
+                      }
+                    },
+                    "required": [
+                      "type"
+                    ],
+                    "additionalProperties": true
+                  }
+                },
+                "required": [
+                  "action",
+                  "title"
+                ],
+                "additionalProperties": true
+              }
+            }
+          },
+          "additionalProperties": true,
+          "required": [
+            "title",
+            "body"
+          ]
+        },
+        "template": {
+          "type": "string",
+          "const": "toast_notification"
+        }
+      },
+      "required": [
+        "content",
+        "targeting",
+        "template",
+        "trigger"
+      ],
+      "additionalProperties": true
+    },
+    "ToolbarBadgeMessage": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "$id": "file:///ToolbarBadgeMessage.schema.json",
+      "title": "ToolbarBadgeMessage",
+      "description": "A template that specifies to which element in the browser toolbar to add a notification.",
+      "allOf": [
+        {
+          "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/Message"
+        }
+      ],
+      "type": "object",
+      "properties": {
+        "content": {
+          "type": "object",
+          "properties": {
+            "target": {
+              "type": "string"
+            },
+            "action": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": true,
+              "required": [
+                "id"
+              ],
+              "description": "Optional action to take in addition to showing the notification"
+            },
+            "delay": {
+              "type": "number",
+              "description": "Optional delay in ms after which to show the notification"
+            },
+            "badgeDescription": {
+              "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/localizedText",
+              "description": "This is used in combination with the badged button to offer a text based alternative to the visual badging. Example 'New Feature: What's New'"
+            }
+          },
+          "additionalProperties": true,
+          "required": [
+            "target"
+          ]
+        },
+        "template": {
+          "type": "string",
+          "const": "toolbar_badge"
+        }
+      },
+      "additionalProperties": true,
+      "required": [
+        "targeting"
+      ]
+    },
+    "UpdateAction": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "$id": "file:///UpdateAction.schema.json",
+      "title": "UpdateActionMessage",
+      "description": "A template for messages that execute predetermined actions.",
+      "allOf": [
+        {
+          "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/Message"
+        }
+      ],
+      "type": "object",
+      "properties": {
+        "content": {
+          "type": "object",
+          "properties": {
+            "action": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "data": {
+                  "type": "object",
+                  "description": "Additional data provided as argument when executing the action",
+                  "properties": {
+                    "url": {
+                      "type": "string",
+                      "description": "URL data to be used as argument to the action"
+                    },
+                    "expireDelta": {
+                      "type": "number",
+                      "description": "Expiration timestamp to be used as argument to the action"
+                    }
+                  }
+                }
+              },
+              "additionalProperties": true,
+              "description": "Optional action to take in addition to showing the notification",
+              "required": [
+                "id",
+                "data"
+              ]
+            }
+          },
+          "additionalProperties": true,
+          "required": [
+            "action"
+          ]
+        },
+        "template": {
+          "type": "string",
+          "const": "update_action"
+        }
+      },
+      "required": [
+        "targeting"
+      ]
+    },
+    "WhatsNewMessage": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "$id": "file:///WhatsNewMessage.schema.json",
+      "title": "WhatsNewMessage",
+      "description": "A template for the messages that appear in the What's New panel.",
+      "allOf": [
+        {
+          "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/Message"
+        }
+      ],
+      "type": "object",
+      "properties": {
+        "content": {
+          "type": "object",
+          "properties": {
+            "layout": {
+              "description": "Different message layouts",
+              "enum": [
+                "tracking-protections"
+              ]
+            },
+            "bucket_id": {
+              "type": "string",
+              "description": "A bucket identifier for the addon. This is used in order to anonymize telemetry for history-sensitive targeting."
+            },
+            "published_date": {
+              "type": "integer",
+              "description": "The date/time (number of milliseconds elapsed since January 1, 1970 00:00:00 UTC) the message was published."
+            },
+            "title": {
+              "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/localizableText",
+              "description": "Id of localized string or message override of What's New message title"
+            },
+            "subtitle": {
+              "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/localizableText",
+              "description": "Id of localized string or message override of What's New message subtitle"
+            },
+            "body": {
+              "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/localizableText",
+              "description": "Id of localized string or message override of What's New message body"
+            },
+            "link_text": {
+              "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/localizableText",
+              "description": "(optional) Id of localized string or message override of What's New message link text"
+            },
+            "cta_url": {
+              "description": "Target URL for the What's New message.",
+              "type": "string",
+              "format": "moz-url-format"
+            },
+            "cta_type": {
+              "description": "Type of url open action",
+              "enum": [
+                "OPEN_URL",
+                "OPEN_ABOUT_PAGE",
+                "OPEN_PROTECTION_REPORT"
+              ]
+            },
+            "cta_where": {
+              "description": "How to open the cta: new window, tab, focused, unfocused.",
+              "enum": [
+                "current",
+                "tabshifted",
+                "tab",
+                "save",
+                "window"
+              ]
+            },
+            "icon_url": {
+              "description": "(optional) URL for the What's New message icon.",
+              "type": "string",
+              "format": "uri"
+            },
+            "icon_alt": {
+              "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/localizableText",
+              "description": "Alt text for image."
+            }
+          },
+          "additionalProperties": true,
+          "required": [
+            "published_date",
+            "title",
+            "body",
+            "cta_url",
+            "bucket_id"
+          ]
+        },
+        "template": {
+          "type": "string",
+          "const": "whatsnew_panel_message"
+        }
+      },
+      "required": [
+        "order"
+      ],
+      "additionalProperties": true
+    },
+    "Message": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "The message identifier"
+        },
+        "groups": {
+          "description": "Array of preferences used to control `enabled` status of the group. If any is `false` the group is disabled.",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "description": "Preference name"
+          }
+        },
+        "template": {
+          "type": "string",
+          "description": "Which messaging template this message is using.",
+          "enum": [
+            "cfr_urlbar_chiclet",
+            "cfr_doorhanger",
+            "milestone_message",
+            "infobar",
+            "pb_newtab",
+            "protections_panel",
+            "spotlight",
+            "feature_callout",
+            "toast_notification",
+            "toolbar_badge",
+            "update_action",
+            "whatsnew_panel_message"
+          ]
+        },
+        "frequency": {
+          "type": "object",
+          "description": "An object containing frequency cap information for a message.",
+          "properties": {
+            "lifetime": {
+              "type": "integer",
+              "description": "The maximum lifetime impressions for a message.",
+              "minimum": 1,
+              "maximum": 100
+            },
+            "custom": {
+              "type": "array",
+              "description": "An array of custom frequency cap definitions.",
+              "items": {
+                "description": "A frequency cap definition containing time and max impression information",
+                "type": "object",
+                "properties": {
+                  "period": {
+                    "type": "integer",
+                    "description": "Period of time in milliseconds (e.g. 86400000 for one day)"
+                  },
+                  "cap": {
+                    "type": "integer",
+                    "description": "The maximum impressions for the message within the defined period.",
+                    "minimum": 1,
+                    "maximum": 100
+                  }
+                },
+                "required": [
+                  "period",
+                  "cap"
+                ]
+              }
+            }
+          }
+        },
+        "priority": {
+          "description": "The priority of the message. If there are two competing messages to show, the one with the highest priority will be shown",
+          "type": "integer"
+        },
+        "order": {
+          "description": "The order in which messages should be shown. Messages will be shown in increasing order.",
+          "type": "integer"
+        },
+        "targeting": {
+          "description": "A JEXL expression representing targeting information",
+          "type": "string"
+        },
+        "trigger": {
+          "description": "An action to trigger potentially showing the message",
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "A string identifying the trigger action"
+            },
+            "params": {
+              "type": "array",
+              "description": "An optional array of string parameters for the trigger action",
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "string"
+                  }
+                ]
+              }
+            }
+          },
+          "required": [
+            "id"
+          ]
+        },
+        "provider": {
+          "description": "An identifier for the provider of this message, such as \"cfr\" or \"preview\".",
+          "type": "string"
+        }
+      },
+      "additionalProperties": true,
+      "dependentRequired": {
+        "content": [
+          "id",
+          "template"
+        ],
+        "template": [
+          "id",
+          "content"
+        ]
+      }
+    },
+    "localizedText": {
+      "type": "object",
+      "properties": {
+        "string_id": {
+          "description": "Id of localized string to be rendered.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "string_id"
+      ]
+    },
+    "localizableText": {
+      "description": "Either a raw string or an object containing the string_id of the localized text",
+      "oneOf": [
+        {
+          "type": "string",
+          "description": "The string to be rendered."
+        },
+        {
+          "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/localizedText"
+        }
+      ]
+    },
+    "TemplatedMessage": {
+      "description": "An FxMS message of one of a variety of types.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/Message"
+        },
+        {
+          "if": {
+            "type": "object",
+            "properties": {
+              "template": {
+                "type": "string",
+                "enum": [
+                  "cfr_urlbar_chiclet"
+                ]
+              }
+            },
+            "required": [
+              "template"
+            ]
+          },
+          "then": {
+            "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/CFRUrlbarChiclet"
+          }
+        },
+        {
+          "if": {
+            "type": "object",
+            "properties": {
+              "template": {
+                "type": "string",
+                "enum": [
+                  "cfr_doorhanger",
+                  "milestone_message"
+                ]
+              }
+            },
+            "required": [
+              "template"
+            ]
+          },
+          "then": {
+            "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/ExtensionDoorhanger"
+          }
+        },
+        {
+          "if": {
+            "type": "object",
+            "properties": {
+              "template": {
+                "type": "string",
+                "enum": [
+                  "infobar"
+                ]
+              }
+            },
+            "required": [
+              "template"
+            ]
+          },
+          "then": {
+            "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/InfoBar"
+          }
+        },
+        {
+          "if": {
+            "type": "object",
+            "properties": {
+              "template": {
+                "type": "string",
+                "enum": [
+                  "pb_newtab"
+                ]
+              }
+            },
+            "required": [
+              "template"
+            ]
+          },
+          "then": {
+            "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/NewtabPromoMessage"
+          }
+        },
+        {
+          "if": {
+            "type": "object",
+            "properties": {
+              "template": {
+                "type": "string",
+                "enum": [
+                  "protections_panel"
+                ]
+              }
+            },
+            "required": [
+              "template"
+            ]
+          },
+          "then": {
+            "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/ProtectionsPanelMessage"
+          }
+        },
+        {
+          "if": {
+            "type": "object",
+            "properties": {
+              "template": {
+                "type": "string",
+                "enum": [
+                  "spotlight",
+                  "feature_callout"
+                ]
+              }
+            },
+            "required": [
+              "template"
+            ]
+          },
+          "then": {
+            "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/Spotlight"
+          }
+        },
+        {
+          "if": {
+            "type": "object",
+            "properties": {
+              "template": {
+                "type": "string",
+                "enum": [
+                  "toast_notification"
+                ]
+              }
+            },
+            "required": [
+              "template"
+            ]
+          },
+          "then": {
+            "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/ToastNotification"
+          }
+        },
+        {
+          "if": {
+            "type": "object",
+            "properties": {
+              "template": {
+                "type": "string",
+                "enum": [
+                  "toolbar_badge"
+                ]
+              }
+            },
+            "required": [
+              "template"
+            ]
+          },
+          "then": {
+            "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/ToolbarBadgeMessage"
+          }
+        },
+        {
+          "if": {
+            "type": "object",
+            "properties": {
+              "template": {
+                "type": "string",
+                "enum": [
+                  "update_action"
+                ]
+              }
+            },
+            "required": [
+              "template"
+            ]
+          },
+          "then": {
+            "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/UpdateAction"
+          }
+        },
+        {
+          "if": {
+            "type": "object",
+            "properties": {
+              "template": {
+                "type": "string",
+                "enum": [
+                  "whatsnew_panel_message"
+                ]
+              }
+            },
+            "required": [
+              "template"
+            ]
+          },
+          "then": {
+            "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/WhatsNewMessage"
+          }
+        }
+      ]
+    },
+    "MultiMessage": {
+      "description": "An object containing an array of messages.",
+      "type": "object",
+      "properties": {
+        "template": {
+          "type": "string",
+          "const": "multi"
+        },
+        "messages": {
+          "type": "array",
+          "description": "An array of messages.",
+          "items": {
+            "$ref": "resource://activity-stream/schemas/MessagingExperiment.schema.json#/$defs/TemplatedMessage"
+          }
+        }
+      },
+      "required": [
+        "template",
+        "messages"
+      ]
+    }
+  }
+}

--- a/experimenter/experimenter/features/manifests/firefox-desktop/v121.0.0/schemas/toolkit/components/normandy/schemas/LegacyHeartbeat.schema.json
+++ b/experimenter/experimenter/features/manifests/firefox-desktop/v121.0.0/schemas/toolkit/components/normandy/schemas/LegacyHeartbeat.schema.json
@@ -1,0 +1,73 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Legacy (Normandy) Heartbeat, via Nimbus",
+  "description": "The schema for the Legacy Heartbeat Nimbus feature.",
+  "type": "object",
+  "properties": {
+    "survey": {
+      "$comment": "Hearbeat arguments are nested under survey to prevent simultaneous rollouts and experiments from overriding eachothers optional variables",
+      "type": "object",
+      "properties": {
+        "repeatOption": {
+          "type": "string",
+          "enum": ["once", "xdays", "nag"],
+          "description": "Determines how often a prompt is shown executes.",
+          "default": "once"
+        },
+        "repeatEvery": {
+          "description": "For repeatOption=xdays, how often (in days) the prompt is displayed.",
+          "default": null,
+          "type": ["number", "null"]
+        },
+        "includeTelemetryUUID": {
+          "type": "boolean",
+          "description": "Include unique user ID in post-answer-url and Telemetry",
+          "default": false
+        },
+        "surveyId": {
+          "description": "Slug uniquely identifying this survey in telemetry",
+          "type": "string"
+        },
+        "message": {
+          "description": "Message to show to the user",
+          "type": "string"
+        },
+        "engagementButtonLabel": {
+          "description": "Text for the engagement button. If specified, this button will be shown instead of rating stars.",
+          "default": null,
+          "type": ["string", "null"]
+        },
+        "thanksMessage": {
+          "description": "Thanks message to show to the user after they've rated Firefox",
+          "type": "string"
+        },
+        "postAnswerUrl": {
+          "description": "URL to redirect the user to after rating Firefox or clicking the engagement button",
+          "default": null,
+          "type": ["string", "null"]
+        },
+        "learnMoreMessage": {
+          "description": "Message to show to the user to learn more",
+          "default": null,
+          "type": ["string", "null"]
+        },
+        "learnMoreUrl": {
+          "description": "URL to show to the user when they click Learn More",
+          "default": null,
+          "type": ["string", "null"]
+        }
+      },
+      "required": [
+        "surveyId",
+        "message",
+        "thanksMessage",
+        "postAnswerUrl",
+        "learnMoreMessage",
+        "learnMoreUrl"
+      ],
+      "additionalProperties": false
+    }
+  },
+  "required": ["survey"],
+  "additionalProperties": false
+}

--- a/experimenter/manifesttool/appconfig.py
+++ b/experimenter/manifesttool/appconfig.py
@@ -55,6 +55,46 @@ class VersionFile(BaseModel):
         )
 
 
+class DiscoveryStrategyType(str, Enum):
+    TAGGED = "tagged"
+
+
+class TaggedDiscoveryStrategy(BaseModel):
+    type: Literal[DiscoveryStrategyType.TAGGED]
+    branch_re: str
+    tag_re: Optional[str]
+    ignored_branches: Optional[list[str]]
+    ignored_tags: Optional[list[str]]
+
+
+class DiscoveryStrategy(BaseModel):
+    __root__: TaggedDiscoveryStrategy
+
+    @classmethod
+    def create_tagged(
+        cls,
+        *,
+        branch_re: Optional[str],
+        tag_re: Optional[str] = None,
+        ignored_branches: Optional[list[str]] = None,
+        ignored_tags: Optional[list[str]] = None,
+    ):  # pragma: no cover
+        return cls(
+            __root__=TaggedDiscoveryStrategy(
+                type=DiscoveryStrategyType.TAGGED,
+                branch_re=branch_re,
+                tag_re=tag_re,
+                ignored_branches=ignored_branches,
+                ignored_tags=ignored_tags,
+            )
+        )
+
+
+class ReleaseDiscovery(BaseModel):
+    version_file: VersionFile
+    strategies: list[DiscoveryStrategy] = Field(min_items=1)
+
+
 class AppConfig(BaseModel):
     """The configuration of a single app in apps.yaml."""
 
@@ -62,11 +102,7 @@ class AppConfig(BaseModel):
     repo: Repository
     fml_path: Optional[str]
     experimenter_yaml_path: Optional[str]
-    branch_re: Optional[str]
-    tag_re: Optional[str]
-    ignored_branches: Optional[list[str]]
-    ignored_tags: Optional[list[str]]
-    version_file: Optional[VersionFile]
+    release_discovery: Optional[ReleaseDiscovery]
 
     @root_validator(pre=True)
     def validate_one_manifest_path(cls, values):

--- a/experimenter/manifesttool/appconfig.py
+++ b/experimenter/manifesttool/appconfig.py
@@ -68,6 +68,7 @@ class VersionFile(BaseModel):
 
 class DiscoveryStrategyType(str, Enum):
     TAGGED = "tagged"
+    BRANCHED = "branched"
 
 
 class TaggedDiscoveryStrategy(BaseModel):
@@ -78,8 +79,13 @@ class TaggedDiscoveryStrategy(BaseModel):
     ignored_tags: Optional[list[str]]
 
 
+class BranchedDiscoveryStrategy(BaseModel):
+    type: Literal[DiscoveryStrategyType.BRANCHED]
+    branches: Optional[list[str]]
+
+
 class DiscoveryStrategy(BaseModel):
-    __root__: TaggedDiscoveryStrategy
+    __root__: Union[TaggedDiscoveryStrategy, BranchedDiscoveryStrategy] = Field(discriminator="type")
 
     @classmethod
     def create_tagged(
@@ -100,6 +106,14 @@ class DiscoveryStrategy(BaseModel):
             )
         )
 
+    @classmethod
+    def create_branched(cls, branches: Optional[list[str]] = None):  # pragma: no cover
+        return cls(
+            __root__=BranchedDiscoveryStrategy(
+                type=DiscoveryStrategyType.BRANCHED,
+                branches=branches,
+            ),
+        )
 
 class ReleaseDiscovery(BaseModel):
     version_file: VersionFile

--- a/experimenter/manifesttool/appconfig.py
+++ b/experimenter/manifesttool/appconfig.py
@@ -6,7 +6,7 @@ import yaml
 from pydantic import BaseModel, Field, root_validator
 
 
-class RepositoryType(Enum):
+class RepositoryType(str, Enum):
     HGMO = "hgmo"  # hg.mozilla.org
     GITHUB = "github"
 
@@ -14,6 +14,17 @@ class RepositoryType(Enum):
 class Repository(BaseModel):
     type: RepositoryType
     name: str
+    default_branch: str = Field(default="main")
+
+    @root_validator(pre=True)
+    def validate_default_branch(cls, values):
+        ty = values.get("type")
+        default_branch = values.get("default_branch")
+
+        if ty == RepositoryType.HGMO and default_branch is None:
+            raise ValueError("hg.mozilla.org-hosted repositories require default_branch")
+
+        return values
 
 
 class VersionFileType(str, Enum):

--- a/experimenter/manifesttool/appconfig.py
+++ b/experimenter/manifesttool/appconfig.py
@@ -85,7 +85,9 @@ class BranchedDiscoveryStrategy(BaseModel):
 
 
 class DiscoveryStrategy(BaseModel):
-    __root__: Union[TaggedDiscoveryStrategy, BranchedDiscoveryStrategy] = Field(discriminator="type")
+    __root__: Union[TaggedDiscoveryStrategy, BranchedDiscoveryStrategy] = Field(
+        discriminator="type"
+    )
 
     @classmethod
     def create_tagged(
@@ -114,6 +116,7 @@ class DiscoveryStrategy(BaseModel):
                 branches=branches,
             ),
         )
+
 
 class ReleaseDiscovery(BaseModel):
     version_file: VersionFile

--- a/experimenter/manifesttool/cli.py
+++ b/experimenter/manifesttool/cli.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 import click
 
-from manifesttool.appconfig import AppConfigs, RepositoryType
+from manifesttool.appconfig import AppConfigs
 from manifesttool.fetch import (
     fetch_fml_app,
     fetch_legacy_app,
@@ -55,11 +55,7 @@ def fetch(ctx: click.Context):
         else:  # pragma: no cover
             assert False, "unreachable"
 
-        if (
-            app_config.repo.type == RepositoryType.GITHUB
-            and app_config.fml_path is not None
-            and app_config.version_file is not None
-        ):
+        if app_config.release_discovery:
             results.extend(fetch_releases(context.manifest_dir, app_name, app_config))
 
     summarize_results(results)

--- a/experimenter/manifesttool/fetch.py
+++ b/experimenter/manifesttool/fetch.py
@@ -121,7 +121,9 @@ def fetch_legacy_app(
         # feature schemas could differ or not be present if they were removed in a
         # subsequent commit.
         if ref is None:
-            ref = result.ref = hgmo_api.get_tip_rev(app_config.repo.name)
+            ref = result.ref = hgmo_api.get_bookmark_ref(
+                app_config.repo.name, app_config.repo.default_branch
+            )
 
         if version:
             print(f"fetch: {app_name} at {ref} version {version}")

--- a/experimenter/manifesttool/hgmo_api.py
+++ b/experimenter/manifesttool/hgmo_api.py
@@ -14,15 +14,21 @@ def api_request(path: str, **kwargs) -> dict[str, Any]:
     return requests.get(f"{HGMO_URL}/{path}", **kwargs).json()
 
 
-def get_tip_rev(repo: str) -> Ref:
-    """Get the revision of the current repository tip.
+def get_bookmark_ref(repo: str, bookmark: str) -> Ref:
+    """Resolve a bookmark to a Ref.
 
     Args:
         repo:
             The repository name.
+
+        bookmark.
+            The bookmark to fetch
+
+    Returns:
+        A Ref for the given bookmark.
     """
-    rsp = api_request(f"{repo}/json-log?rev=tip:tip")
-    return Ref("tip", rsp["node"])
+    rsp = api_request(f"{repo}/json-log?rev={bookmark}:{bookmark}")
+    return Ref(bookmark, rsp["node"])
 
 
 @overload

--- a/experimenter/manifesttool/hgmo_api.py
+++ b/experimenter/manifesttool/hgmo_api.py
@@ -28,7 +28,7 @@ def get_bookmark_ref(repo: str, bookmark: str) -> Ref:
         A Ref for the given bookmark.
     """
     rsp = api_request(f"{repo}/json-log?rev={bookmark}:{bookmark}")
-    return Ref(bookmark, rsp["node"])
+    return Ref(bookmark, rsp["entries"][0]["node"])
 
 
 @overload

--- a/experimenter/manifesttool/releases.py
+++ b/experimenter/manifesttool/releases.py
@@ -60,7 +60,9 @@ def discover_tagged_releases(
 
 
 def discover_branched_releases(
-    app_name: str, app_config: AppConfig, strategy: BranchedDiscoveryStrategy,
+    app_name: str,
+    app_config: AppConfig,
+    strategy: BranchedDiscoveryStrategy,
 ) -> dict[Version, Ref]:
     assert app_config.repo.type == RepositoryType.HGMO
 
@@ -70,9 +72,7 @@ def discover_branched_releases(
         branches = [app_config.repo.default_branch]
 
     refs = [
-        hgmo_api.get_bookmark_ref(app_config.repo.name, branch)
-        for branch in branches
+        hgmo_api.get_bookmark_ref(app_config.repo.name, branch) for branch in branches
     ]
 
     return resolve_ref_versions(app_config, refs)
-

--- a/experimenter/manifesttool/releases.py
+++ b/experimenter/manifesttool/releases.py
@@ -1,0 +1,58 @@
+from manifesttool import github_api
+from manifesttool.appconfig import (
+    AppConfig,
+    RepositoryType,
+    TaggedDiscoveryStrategy,
+)
+from manifesttool.repository import Ref
+from manifesttool.version import (
+    Version,
+    filter_versioned_refs,
+    find_versioned_refs,
+    resolve_ref_versions,
+)
+
+
+def discover_tagged_releases(
+    app_name: str, app_config: AppConfig, strategy: TaggedDiscoveryStrategy
+) -> dict[Version, Ref]:
+    """Discover releases based on release branches and tags.
+
+    Only the most recent 5 major versions of releases will be returned.
+    """
+    assert app_config.repo.type == RepositoryType.GITHUB
+
+    # Find all release branches.
+    branches = github_api.get_branches(app_config.repo.name)
+    versions = find_versioned_refs(
+        branches,
+        strategy.branch_re,
+        strategy.ignored_branches,
+    )
+
+    # Limit to the last 5 major versions.
+    #
+    # We must pass a list here because if max() is passed a single arg it will
+    # try to iterate over it.
+    max_major_version = max([0, *(v.major for v in versions)])
+
+    if max_major_version == 0:
+        raise Exception(f"Could not find a major release for {app_name}.")
+
+    min_version = Version(max_major_version - 4, 0, 0)
+
+    versions = filter_versioned_refs(versions, min_version)
+
+    # Extract the actual version number for each branch's version file.
+    # Otherwise, e.g., a branch like release/v1 would end up overwriting 1.0.0
+    # version constantly, even though it is likely futher ahead than 1.0.0.
+    versions = resolve_ref_versions(app_config, versions.values())
+
+    if strategy.tag_re:
+        tags = github_api.get_tags(app_config.repo.name)
+        tag_versions = find_versioned_refs(tags, strategy.tag_re, strategy.ignored_tags)
+        tag_versions = filter_versioned_refs(tag_versions, min_version)
+
+        versions.update(tag_versions)
+
+    return versions

--- a/experimenter/manifesttool/tests/test_appconfig.py
+++ b/experimenter/manifesttool/tests/test_appconfig.py
@@ -13,7 +13,9 @@ class AppConfigTests(TestCase):
         """Testing that parsing apps.yaml fails if an app contains both the
         fml_path and experimenter_yaml_path keys.
         """
-        with self.assertRaises(ValueError):
+        with self.assertRaisesRegex(
+            ValueError, "fml_path and experimenter_yaml_path are mutually exclusive"
+        ):
             AppConfigs.parse_obj(
                 {
                     "app": {
@@ -29,12 +31,31 @@ class AppConfigTests(TestCase):
         """Testing that parsing apps.yaml fails if an app is missing both the
         fml_path and experimenter_yaml_path keys.
         """
-        with self.assertRaises(ValueError):
+        with self.assertRaisesRegex(
+            ValueError, "one of fml_path and experimenter_yaml_path is required"
+        ):
             AppConfigs.parse_obj(
                 {
                     "app": {
                         "slug": "app",
                         "repo": {"type": "github", "name": "owner/repo"},
+                    },
+                }
+            )
+
+    def test_parse_hgmo_no_default(self):
+        """Testing that parsing apps.yaml fails if an app has an
+        hg.mozilla.org-hosted repository but does not specify a default branch.
+        """
+        with self.assertRaisesRegex(
+            ValueError, "hg.mozilla.org-hosted repositories require default_branch"
+        ):
+            AppConfigs.parse_obj(
+                {
+                    "app": {
+                        "slug": "app",
+                        "repo": {"type": "hgmo", "name": "repo"},
+                        "experimenter_yaml_path": "experimenter.yaml",
                     },
                 }
             )

--- a/experimenter/manifesttool/tests/test_fetch.py
+++ b/experimenter/manifesttool/tests/test_fetch.py
@@ -1,9 +1,7 @@
 import json
-from contextlib import redirect_stderr, contextmanager
-from io import StringIO
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import Any, Iterable, Optional
+from typing import Any, Optional
 from unittest import TestCase
 from unittest.mock import call, patch
 
@@ -12,13 +10,13 @@ import yaml
 from parameterized import parameterized
 
 import manifesttool
-from manifesttool import fetch
 from manifesttool.appconfig import (
     AppConfig,
+    DiscoveryStrategy,
+    ReleaseDiscovery,
     Repository,
     RepositoryType,
     VersionFile,
-    VersionFileType,
 )
 from manifesttool.fetch import (
     FetchResult,
@@ -142,82 +140,6 @@ def mock_fetch(
     return FetchResult(app_name, ref, version)
 
 
-@contextmanager
-def mocks_for_fetch_releases(
-    app_config: AppConfig,
-    branches: list[Ref],
-    tags: Optional[list[Ref]],
-    ref_versions: dict[str, Version],
-):
-    """Create a set of mocks to call fetch_releases.
-
-    Args:
-        app_config:
-            The app configuration.
-
-            The ``version_file`` and ``branch_re`` fields are required.
-
-        branches:
-            The list of refs to return from ``get_branches()``.
-
-        Tags:
-            The list of refs to return from ``get_tags()``.
-
-            If ``None``, ``app_config.tag_re`` must also be ``None``.
-
-        ref_versions:
-            A mapping of resolved refs to Versions.
-
-            This argument is used to generate a mock for ``fetch_file()``.
-
-    Yields:
-        A 3-tuple of the mocks for ``get_branches``, ``get_tags``, and ``fetch_file``.
-    """
-    assert app_config.repo.type == RepositoryType.GITHUB
-    assert app_config.branch_re is not None
-
-    # Mocking plist files is more annoying.
-    assert app_config.version_file is not None
-    assert app_config.version_file.__root__.type == VersionFileType.PLAIN_TEXT
-
-    # Ensure tags are defined if app specifies a tag regex.
-    assert app_config.tag_re is None or tags is not None
-
-    def mock_get_branches(*args):
-        return branches
-
-    def mock_get_tags(*args):
-        assert tags is not None
-        return tags
-
-    def mock_fetch_file(
-        repo: str, path: str, ref: str, download_path: Optional[Path] = None
-    ):
-        assert repo == app_config.repo.name
-        assert download_path is None
-        assert path == app_config.version_file.__root__.path
-        assert ref in ref_versions
-
-        return str(ref_versions[ref])
-
-    with (
-        patch.object(
-            manifesttool.github_api, "get_branches", side_effect=mock_get_branches
-        ) as get_branches,
-        patch.object(
-            manifesttool.github_api, "get_tags", side_effect=mock_get_tags
-        ) as get_tags,
-        patch.object(
-            manifesttool.github_api, "fetch_file", side_effect=mock_fetch_file
-        ) as fetch_file,
-    ):
-        yield (
-            get_branches,
-            get_tags,
-            fetch_file,
-        )
-
-
 class FetchTests(TestCase):
     maxDiff = None
 
@@ -233,13 +155,19 @@ class FetchTests(TestCase):
         responses.stop()
 
     @patch.object(
-        fetch.github_api, "get_main_ref", side_effect=lambda *args: Ref("main", "ref")
+        manifesttool.fetch.github_api,
+        "get_main_ref",
+        side_effect=lambda *args: Ref("main", "ref"),
     )
     @patch.object(
-        fetch.nimbus_cli, "download_single_file", side_effect=mock_download_single_file
+        manifesttool.fetch.nimbus_cli,
+        "download_single_file",
+        side_effect=mock_download_single_file,
     )
     @patch.object(
-        fetch.nimbus_cli, "get_channels", side_effect=lambda *args: ["release", "beta"]
+        manifesttool.fetch.nimbus_cli,
+        "get_channels",
+        side_effect=lambda *args: ["release", "beta"],
     )
     def test_fetch_fml(self, get_channels, download_single_file, get_main_ref):
         """Testing fetch_fml_app."""
@@ -288,10 +216,14 @@ class FetchTests(TestCase):
                 },
             )
 
-    @patch.object(fetch.github_api, "get_main_ref")
-    @patch.object(fetch.nimbus_cli, "get_channels", side_effect=lambda *args: ["release"])
-    @patch.object(fetch.nimbus_cli, "download_single_file")
-    @patch.object(fetch.nimbus_cli, "generate_experimenter_yaml")
+    @patch.object(manifesttool.fetch.github_api, "get_main_ref")
+    @patch.object(
+        manifesttool.fetch.nimbus_cli,
+        "get_channels",
+        side_effect=lambda *args: ["release"],
+    )
+    @patch.object(manifesttool.fetch.nimbus_cli, "download_single_file")
+    @patch.object(manifesttool.fetch.nimbus_cli, "generate_experimenter_yaml")
     def test_fetch_fml_ref(
         self, generate_experimenter_yaml, download_single_file, get_channels, get_main_ref
     ):
@@ -331,17 +263,21 @@ class FetchTests(TestCase):
             ):
                 fetch_fml_app(manifest_dir, "app", FML_APP_CONFIG, version=Version(1))
 
-    @patch.object(fetch.github_api, "get_main_ref")
+    @patch.object(manifesttool.fetch.github_api, "get_main_ref")
     @patch.object(
-        fetch.nimbus_cli, "get_channels", side_effect=lambda *args: ["release", "beta"]
+        manifesttool.fetch.nimbus_cli,
+        "get_channels",
+        side_effect=lambda *args: ["release", "beta"],
     )
     @patch.object(
-        fetch.nimbus_cli, "download_single_file", side_effect=mock_download_single_file
+        manifesttool.fetch.nimbus_cli,
+        "download_single_file",
+        side_effect=mock_download_single_file,
     )
     @patch.object(
-        fetch.nimbus_cli,
+        manifesttool.fetch.nimbus_cli,
         "generate_experimenter_yaml",
-        wraps=fetch.nimbus_cli.generate_experimenter_yaml,
+        wraps=manifesttool.fetch.nimbus_cli.generate_experimenter_yaml,
     )
     def test_fetch_fml_ref_version(
         self, generate_experimenter_yaml, download_single_file, get_channels, get_main_ref
@@ -377,7 +313,9 @@ class FetchTests(TestCase):
             self.assertTrue(experimenter_manifest_path.exists())
 
     @patch.object(
-        fetch.github_api, "get_main_ref", side_effect=Exception("Connection error")
+        manifesttool.fetch.github_api,
+        "get_main_ref",
+        side_effect=Exception("Connection error"),
     )
     def test_fetch_fml_exception(self, get_main_ref):
         """Testing fetch_fml_app when an exception is caught."""
@@ -413,9 +351,9 @@ class FetchTests(TestCase):
         ):
             fetch_fml_app(Path("."), "repo", FML_APP_CONFIG, Ref("foo"))
 
-    @patch.object(fetch.nimbus_cli, "download_single_file")
-    @patch.object(fetch.nimbus_cli, "generate_experimenter_yaml")
-    @patch.object(fetch.nimbus_cli, "get_channels", lambda *args: [])
+    @patch.object(manifesttool.fetch.nimbus_cli, "download_single_file")
+    @patch.object(manifesttool.fetch.nimbus_cli, "generate_experimenter_yaml")
+    @patch.object(manifesttool.fetch.nimbus_cli, "get_channels", lambda *args: [])
     def test_fetch_fml_no_channels(
         self, generate_experimenter_yaml, download_single_file
     ):
@@ -437,8 +375,12 @@ class FetchTests(TestCase):
         download_single_file.assert_not_called()
         generate_experimenter_yaml.assert_not_called()
 
-    @patch.object(fetch.hgmo_api, "get_tip_rev", lambda *args: Ref("tip", "ref"))
-    @patch.object(fetch.hgmo_api, "fetch_file", side_effect=make_mock_fetch_file())
+    @patch.object(
+        manifesttool.fetch.hgmo_api, "get_tip_rev", lambda *args: Ref("tip", "ref")
+    )
+    @patch.object(
+        manifesttool.fetch.hgmo_api, "fetch_file", side_effect=make_mock_fetch_file()
+    )
     def test_fetch_legacy(self, fetch_file):
         """Testing fetch_legacy_app."""
         with TemporaryDirectory() as tmp:
@@ -469,8 +411,10 @@ class FetchTests(TestCase):
             )
             self.assertEqual(fetch_file.call_count, 2)
 
-    @patch.object(fetch.hgmo_api, "get_tip_rev")
-    @patch.object(fetch.hgmo_api, "fetch_file", side_effect=make_mock_fetch_file())
+    @patch.object(manifesttool.fetch.hgmo_api, "get_tip_rev")
+    @patch.object(
+        manifesttool.fetch.hgmo_api, "fetch_file", side_effect=make_mock_fetch_file()
+    )
     def test_fetch_legacy_ref(self, fetch_file, get_tip_rev):
         """Testing fetch_legacy_app with a specific ref."""
         ref = Ref("custom", "resolved")
@@ -515,8 +459,10 @@ class FetchTests(TestCase):
                     manifest_dir, "app", LEGACY_APP_CONFIG, version=Version(1)
                 )
 
-    @patch.object(fetch.hgmo_api, "get_tip_rev")
-    @patch.object(fetch.hgmo_api, "fetch_file", side_effect=make_mock_fetch_file())
+    @patch.object(manifesttool.fetch.hgmo_api, "get_tip_rev")
+    @patch.object(
+        manifesttool.fetch.hgmo_api, "fetch_file", side_effect=make_mock_fetch_file()
+    )
     def test_fetch_legacy_ref_version(self, fetch_file, get_tip_rev):
         """Testing fetch_legacy_app with a ref and a version."""
         ref = Ref("v1.2.3", "foo")
@@ -556,9 +502,11 @@ class FetchTests(TestCase):
                 ]
             )
 
-    @patch.object(fetch.hgmo_api, "get_tip_rev", lambda *args: Ref("tip", "ref"))
     @patch.object(
-        fetch.hgmo_api,
+        manifesttool.fetch.hgmo_api, "get_tip_rev", lambda *args: Ref("tip", "ref")
+    )
+    @patch.object(
+        manifesttool.fetch.hgmo_api,
         "fetch_file",
         side_effect=make_mock_fetch_file(
             {
@@ -601,7 +549,9 @@ class FetchTests(TestCase):
             self.assertEqual(fetch_file.call_count, 2)
 
     @patch.object(
-        fetch.hgmo_api, "get_tip_rev", side_effect=Exception("Connection error")
+        manifesttool.fetch.hgmo_api,
+        "get_tip_rev",
+        side_effect=Exception("Connection error"),
     )
     def test_fetch_legacy_exception(self, get_tip_rev):
         """Testing fetch_fml_app when an exception is caught."""
@@ -663,6 +613,10 @@ class FetchTests(TestCase):
                         name="legacy-repo",
                     ),
                     experimenter_yaml_path="experimenter.yaml",
+                    release_discovery=ReleaseDiscovery(
+                        version_file=VersionFile.create_plain_text("version.txt"),
+                        strategies=[DiscoveryStrategy.create_tagged(branch_re="")],
+                    ),
                 ),
                 "Cannot fetch releases for legacy apps",
             ),
@@ -675,7 +629,7 @@ class FetchTests(TestCase):
                     ),
                     fml_path="nimbus.fml.yaml",
                 ),
-                "App app does not have a version file.",
+                "App app does not support releases.",
             ),
         ]
     )
@@ -690,33 +644,20 @@ class FetchTests(TestCase):
             with self.assertRaisesRegex(Exception, exc_message):
                 fetch_releases(manifest_dir, "app", app_config)
 
-    @patch.object(fetch.github_api, "get_branches")
-    def test_fetch_releases_no_branch_re(self, app_config):
-        app_config = AppConfig(
-            slug="fml-app",
-            repo=Repository(
-                type=RepositoryType.GITHUB,
-                name="fml-repo",
-            ),
-            fml_path="nimbus.fml.yaml",
-            version_file=VersionFile.create_plain_text("version.txt"),
-        )
-        with TemporaryDirectory() as tmp:
-            manifest_dir = Path(tmp)
-            manifest_dir.joinpath(app_config.slug).mkdir()
-
-            f = StringIO()
-            with redirect_stderr(f):
-                fetch_releases(manifest_dir, "app", app_config)
-
-            self.assertIn("fetch: releases: app does not support releases", f.getvalue())
-
     @patch.object(
-        fetch,
-        "fetch_fml_app",
-        mock_fetch,
+        manifesttool.fetch,
+        "discover_tagged_releases",
+        lambda *args: {
+            Version(1): Ref("branch", "foo"),
+            Version(1, 2, 3): Ref("tag", "bar"),
+        },
     )
-    def test_fetch_releases(self):
+    @patch.object(
+        manifesttool.fetch,
+        "fetch_fml_app",
+        side_effect=mock_fetch,
+    )
+    def test_fetch_releases(self, fetch_fml_app):
         """Testing fetch_releases."""
         app_config = AppConfig(
             slug="fml-app",
@@ -725,109 +666,31 @@ class FetchTests(TestCase):
                 name="fml-repo",
             ),
             fml_path="nimbus.fml.yaml",
-            version_file=VersionFile.create_plain_text("version.txt"),
-            branch_re=r"release_v(?P<major>\d)+",
-            tag_re=r"v(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)",
-        )
-
-        branches = [Ref(f"release_v{major}", f"branch-v{major}") for major in range(1, 7)]
-        tags = [Ref(f"v{major}.0.0", f"tag-v{major}") for major in range(1, 7)]
-        ref_versions = {
-            **{f"branch-v{major}": Version(major, 0, 1) for major in range(1, 7)},
-            **{f"tag-v{major}": Version(major) for major in range(1, 7)},
-        }
-
-        with TemporaryDirectory() as tmp:
-            manifest_dir = Path(tmp)
-            manifest_dir.joinpath(app_config.slug).mkdir()
-
-            with mocks_for_fetch_releases(app_config, branches, tags, ref_versions):
-                results = fetch_releases(manifest_dir, "app", app_config)
-
-        self.assertEqual(len(results), 10)  # 5 branches and 5 tags
-        for major in range(2, 7):
-            self.assertIn(
-                FetchResult(
-                    app_name="app",
-                    ref=Ref(f"v{major}.0.0", f"tag-v{major}"),
-                    version=Version(major),
-                ),
-                results,
-            )
-            self.assertIn(
-                FetchResult(
-                    app_name="app",
-                    ref=Ref(f"release_v{major}", f"branch-v{major}"),
-                    version=Version(major, 0, 1),
-                ),
-                results,
-            )
-
-    @patch.object(
-        fetch,
-        "fetch_fml_app",
-        mock_fetch,
-    )
-    def test_fetch_releases_no_tag_re(self):
-        """Testing fetch_releases with no tag_re specified."""
-        app_config = AppConfig(
-            slug="fml-app",
-            repo=Repository(
-                type=RepositoryType.GITHUB,
-                name="fml-repo",
+            release_discovery=ReleaseDiscovery(
+                version_file=VersionFile.create_plain_text("version.txt"),
+                strategies=[DiscoveryStrategy.create_tagged(branch_re="", tag_re="")],
             ),
-            fml_path="nimbus.fml.yaml",
-            version_file=VersionFile.create_plain_text("version.txt"),
-            branch_re=r"release_v(?P<major>\d)+",
         )
-
-        branches = [Ref(f"release_v{major}", f"branch-v{major}") for major in range(1, 7)]
-        ref_versions = {f"branch-v{major}": Version(major, 0, 1) for major in range(1, 7)}
 
         with TemporaryDirectory() as tmp:
             manifest_dir = Path(tmp)
-            manifest_dir.joinpath(app_config.slug).mkdir()
 
-            with mocks_for_fetch_releases(app_config, branches, None, ref_versions) as (
-                get_branches,
-                get_tags,
-                resolve_ref_versions,
-            ):
-                results = fetch_releases(manifest_dir, "app", app_config)
+            results = fetch_releases(manifest_dir, "fml_app", app_config)
 
-                get_tags.assert_not_called()
-
-        self.assertEqual(len(results), 5)  # 5 branches
-        for major in range(2, 7):
-            self.assertIn(
-                FetchResult(
-                    app_name="app",
-                    ref=Ref(f"release_v{major}", f"branch-v{major}"),
-                    version=Version(major, 0, 1),
-                ),
-                results,
-            )
-
-    @patch.object(fetch.github_api, "get_branches", lambda *args: [])
-    def test_fetch_releases_no_major_release(self):
-        """Testing fetch_releases when there are no release branches."""
-        app_config = AppConfig(
-            slug="fml-app",
-            repo=Repository(
-                type=RepositoryType.GITHUB,
-                name="fml-repo",
+        self.assertEqual(len(results), 2)
+        self.assertIn(
+            FetchResult(
+                app_name="fml_app",
+                ref=Ref("branch", "foo"),
+                version=Version(1),
             ),
-            fml_path="nimbus.fml.yaml",
-            version_file=VersionFile.create_plain_text("version.txt"),
-            branch_re=r"release_v(?P<major>\d)+",
-            tag_re=r"v(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)",
+            results,
         )
-
-        with TemporaryDirectory() as tmp:
-            manifest_dir = Path(tmp)
-            manifest_dir.joinpath(app_config.slug).mkdir()
-
-            with self.assertRaisesRegex(
-                Exception, "Could not find a major release for app."
-            ):
-                fetch_releases(manifest_dir, "app", app_config)
+        self.assertIn(
+            FetchResult(
+                app_name="fml_app",
+                ref=Ref("tag", "bar"),
+                version=Version(1, 2, 3),
+            ),
+            results,
+        )

--- a/experimenter/manifesttool/tests/test_fetch.py
+++ b/experimenter/manifesttool/tests/test_fetch.py
@@ -42,6 +42,7 @@ LEGACY_APP_CONFIG = AppConfig(
     repo=Repository(
         type=RepositoryType.HGMO,
         name="legacy-repo",
+        default_branch="tip",
     ),
     experimenter_yaml_path="experimenter.yaml",
 )
@@ -333,6 +334,7 @@ class FetchTests(TestCase):
             repo=Repository(
                 type=RepositoryType.HGMO,
                 name="invalid",
+                default_branch="tip",
             ),
             fml_path="nimbus.fml.yaml",
         )
@@ -376,7 +378,7 @@ class FetchTests(TestCase):
         generate_experimenter_yaml.assert_not_called()
 
     @patch.object(
-        manifesttool.fetch.hgmo_api, "get_tip_rev", lambda *args: Ref("tip", "ref")
+        manifesttool.fetch.hgmo_api, "get_bookmark_ref", lambda *args: Ref("tip", "ref")
     )
     @patch.object(
         manifesttool.fetch.hgmo_api, "fetch_file", side_effect=make_mock_fetch_file()
@@ -411,11 +413,11 @@ class FetchTests(TestCase):
             )
             self.assertEqual(fetch_file.call_count, 2)
 
-    @patch.object(manifesttool.fetch.hgmo_api, "get_tip_rev")
+    @patch.object(manifesttool.fetch.hgmo_api, "get_bookmark_ref")
     @patch.object(
         manifesttool.fetch.hgmo_api, "fetch_file", side_effect=make_mock_fetch_file()
     )
-    def test_fetch_legacy_ref(self, fetch_file, get_tip_rev):
+    def test_fetch_legacy_ref(self, fetch_file, get_bookmark_ref):
         """Testing fetch_legacy_app with a specific ref."""
         ref = Ref("custom", "resolved")
         with TemporaryDirectory() as tmp:
@@ -425,7 +427,7 @@ class FetchTests(TestCase):
             result = fetch_legacy_app(manifest_dir, "app", LEGACY_APP_CONFIG, ref)
             self.assertIsNone(result.exc)
 
-            get_tip_rev.assert_not_called()
+            get_bookmark_ref.assert_not_called()
             fetch_file.assert_has_calls(
                 [
                     call(
@@ -459,11 +461,11 @@ class FetchTests(TestCase):
                     manifest_dir, "app", LEGACY_APP_CONFIG, version=Version(1)
                 )
 
-    @patch.object(manifesttool.fetch.hgmo_api, "get_tip_rev")
+    @patch.object(manifesttool.fetch.hgmo_api, "get_bookmark_ref")
     @patch.object(
         manifesttool.fetch.hgmo_api, "fetch_file", side_effect=make_mock_fetch_file()
     )
-    def test_fetch_legacy_ref_version(self, fetch_file, get_tip_rev):
+    def test_fetch_legacy_ref_version(self, fetch_file, get_bookmark_ref):
         """Testing fetch_legacy_app with a ref and a version."""
         ref = Ref("v1.2.3", "foo")
         version = Version(1, 2, 3)
@@ -477,7 +479,7 @@ class FetchTests(TestCase):
             )
             self.assertEqual(result, FetchResult("app", ref, version))
 
-            get_tip_rev.assert_not_called()
+            get_bookmark_ref.assert_not_called()
             fetch_file.assert_has_calls(
                 [
                     call(
@@ -503,7 +505,7 @@ class FetchTests(TestCase):
             )
 
     @patch.object(
-        manifesttool.fetch.hgmo_api, "get_tip_rev", lambda *args: Ref("tip", "ref")
+        manifesttool.fetch.hgmo_api, "get_bookmark_ref", lambda *args: Ref("tip", "ref")
     )
     @patch.object(
         manifesttool.fetch.hgmo_api,
@@ -550,10 +552,10 @@ class FetchTests(TestCase):
 
     @patch.object(
         manifesttool.fetch.hgmo_api,
-        "get_tip_rev",
+        "get_bookmark_ref",
         side_effect=Exception("Connection error"),
     )
-    def test_fetch_legacy_exception(self, get_tip_rev):
+    def test_fetch_legacy_exception(self, get_bookmark_ref):
         """Testing fetch_fml_app when an exception is caught."""
         with TemporaryDirectory() as tmp:
             manifest_dir = Path(tmp)
@@ -600,6 +602,7 @@ class FetchTests(TestCase):
                     repo=Repository(
                         type=RepositoryType.HGMO,
                         name="legacy-repo",
+                        default_branch="tip",
                     ),
                     experimenter_yaml_path="experimenter.yaml",
                 ),

--- a/experimenter/manifesttool/tests/test_fetch.py
+++ b/experimenter/manifesttool/tests/test_fetch.py
@@ -7,7 +7,6 @@ from unittest.mock import call, patch
 
 import responses
 import yaml
-from parameterized import parameterized
 
 import manifesttool
 from manifesttool.appconfig import (
@@ -101,10 +100,12 @@ def mock_download_single_file(
     with filename.open("w") as f:
         yaml.dump(generate_fml(app_config, channel), f)
 
+
 DEFAULT_MOCK_FETCHES = {
     LEGACY_MANIFEST_PATH: LEGACY_MANIFEST,
     FEATURE_JSON_SCHEMA_PATH: FEATURE_JSON_SCHEMA,
 }
+
 
 def make_mock_fetch_file(
     *,
@@ -137,9 +138,7 @@ def make_mock_fetch_file(
                 ref: DEFAULT_MOCK_FETCHES,
             }
     else:
-        raise ValueError(
-            "mack_mock_fetch_file requires one of paths_by_ref or ref"
-        )
+        raise ValueError("mack_mock_fetch_file requires one of paths_by_ref or ref")
 
     def mock_fetch_file(
         repo: str,
@@ -150,10 +149,8 @@ def make_mock_fetch_file(
         """A mock version of hgmo_api.fetch_file."""
         try:
             paths = paths_by_ref[rev]
-        except KeyError as e:
-            raise Exception(
-                f"Unexpected ref {rev} passed to hgmo_api.fetch_file"
-            )
+        except KeyError:
+            raise Exception(f"Unexpected ref {rev} passed to hgmo_api.fetch_file")
 
         try:
             content = paths[file_path]
@@ -165,7 +162,7 @@ def make_mock_fetch_file(
         if download_path:
             with download_path.open("w", newline="\n") as f:
                 json.dump(content, f)
-            return
+            return None
 
         return content
 
@@ -423,7 +420,9 @@ class FetchTests(TestCase):
         manifesttool.fetch.hgmo_api, "get_bookmark_ref", lambda *args: Ref("tip", "ref")
     )
     @patch.object(
-        manifesttool.fetch.hgmo_api, "fetch_file", side_effect=make_mock_fetch_file(ref="ref")
+        manifesttool.fetch.hgmo_api,
+        "fetch_file",
+        side_effect=make_mock_fetch_file(ref="ref"),
     )
     def test_fetch_legacy(self, fetch_file):
         """Testing fetch_legacy_app."""
@@ -457,7 +456,9 @@ class FetchTests(TestCase):
 
     @patch.object(manifesttool.fetch.hgmo_api, "get_bookmark_ref")
     @patch.object(
-        manifesttool.fetch.hgmo_api, "fetch_file", side_effect=make_mock_fetch_file(ref="resolved")
+        manifesttool.fetch.hgmo_api,
+        "fetch_file",
+        side_effect=make_mock_fetch_file(ref="resolved"),
     )
     def test_fetch_legacy_ref(self, fetch_file, get_bookmark_ref):
         """Testing fetch_legacy_app with a specific ref."""
@@ -505,7 +506,9 @@ class FetchTests(TestCase):
 
     @patch.object(manifesttool.fetch.hgmo_api, "get_bookmark_ref")
     @patch.object(
-        manifesttool.fetch.hgmo_api, "fetch_file", side_effect=make_mock_fetch_file(ref="foo")
+        manifesttool.fetch.hgmo_api,
+        "fetch_file",
+        side_effect=make_mock_fetch_file(ref="foo"),
     )
     def test_fetch_legacy_ref_version(self, fetch_file, get_bookmark_ref):
         """Testing fetch_legacy_app with a ref and a version."""
@@ -554,8 +557,7 @@ class FetchTests(TestCase):
         "fetch_file",
         side_effect=make_mock_fetch_file(
             paths_by_ref={
-                "ref":
-                {
+                "ref": {
                     LEGACY_MANIFEST_PATH: {
                         "feature": LEGACY_MANIFEST["feature"],
                         "feature-2": LEGACY_MANIFEST["feature"],
@@ -732,7 +734,7 @@ class FetchTests(TestCase):
             experimenter_yaml_path="experimenter.yaml",
             release_discovery=ReleaseDiscovery(
                 version_file=VersionFile.create_plain_text("version.txt"),
-                strategies=[DiscoveryStrategy.create_branched()]
+                strategies=[DiscoveryStrategy.create_branched()],
             ),
         )
 

--- a/experimenter/manifesttool/tests/test_hgmo_api.py
+++ b/experimenter/manifesttool/tests/test_hgmo_api.py
@@ -25,7 +25,12 @@ class HgMoApiTests(TestCase):
         responses.get(
             f"{HGMO_URL}/repo/json-log?rev={ref_name}:{ref_name}",
             json={
-                "node": resolved,
+                "node": "bogus",
+                "entries": [
+                    {
+                        "node": resolved,
+                    },
+                ],
             },
         )
 

--- a/experimenter/manifesttool/tests/test_hgmo_api.py
+++ b/experimenter/manifesttool/tests/test_hgmo_api.py
@@ -3,6 +3,7 @@ from tempfile import TemporaryDirectory
 from unittest import TestCase
 
 import responses
+from parameterized import parameterized
 
 from manifesttool import hgmo_api
 from manifesttool.hgmo_api import HGMO_URL
@@ -12,19 +13,25 @@ from manifesttool.repository import Ref
 class HgMoApiTests(TestCase):
     """Tests for hg.mozilla.org API wrappers."""
 
+    @parameterized.expand(
+        [
+            ("tip", "0" * 40),
+            ("foo", "1" * 40),
+        ]
+    )
     @responses.activate
-    def test_get_tip_rev(self):
-        """Testing get_tip_rev."""
+    def test_get_bookmark_ref(self, ref_name: str, resolved: str):
+        """Testing get_bookmark_rev."""
         responses.get(
-            f"{HGMO_URL}/repo/json-log?rev=tip:tip",
+            f"{HGMO_URL}/repo/json-log?rev={ref_name}:{ref_name}",
             json={
-                "node": "0" * 40,
+                "node": resolved,
             },
         )
 
-        result = hgmo_api.get_tip_rev("repo")
+        result = hgmo_api.get_bookmark_ref("repo", ref_name)
 
-        self.assertEqual(result, Ref("tip", "0" * 40))
+        self.assertEqual(result, Ref(ref_name, resolved))
 
     @responses.activate
     def test_fetch_file(self):

--- a/experimenter/manifesttool/tests/test_releases.py
+++ b/experimenter/manifesttool/tests/test_releases.py
@@ -1,0 +1,239 @@
+from contextlib import contextmanager
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import Optional
+from unittest import TestCase
+from unittest.mock import patch
+
+import responses
+
+import manifesttool
+from manifesttool.appconfig import (
+    AppConfig,
+    DiscoveryStrategy,
+    ReleaseDiscovery,
+    Repository,
+    RepositoryType,
+    TaggedDiscoveryStrategy,
+    VersionFile,
+    VersionFileType,
+)
+from manifesttool.releases import discover_tagged_releases
+from manifesttool.repository import Ref
+from manifesttool.version import Version
+
+
+@contextmanager
+def mocks_for_discover_tagged_releases(
+    app_config: AppConfig,
+    strategy: TaggedDiscoveryStrategy,
+    branches: list[Ref],
+    tags: Optional[list[Ref]],
+    ref_versions: dict[str, Version],
+):
+    """Create a set of mocks to call ``fetch_releases``.
+
+    Args:
+        app_config:
+            The app configuration.
+
+        strategy:
+            The strategy that will be used to create the mocks.
+
+            If ``tag_re`` is not specified, then ``tags`` must be ``None``.
+
+        branches:
+            The list of refs to return from ``get_branches()``.
+
+        Tags:
+            The list of refs to return from ``get_tags()``.
+
+            If ``None``, ``strategy.tag_re`` must also be ``None``.
+
+        ref_versions:
+            A mapping of resolved refs to Versions.
+
+            This argument is used to generate a mock for ``fetch_file()``.
+
+    Yields:
+        A 3-tuple of the mocks for ``get_branches``, ``get_tags``, and ``fetch_file``.
+    """
+    assert app_config.repo.type == RepositoryType.GITHUB
+    assert strategy.branch_re is not None
+
+    # Mocking plist files is more annoying.
+    assert app_config.release_discovery is not None
+    assert (
+        app_config.release_discovery.version_file.__root__.type
+        == VersionFileType.PLAIN_TEXT
+    )
+
+    # Ensure tags are defined if app specifies a tag regex.
+    assert strategy.tag_re is None or tags is not None
+
+    def mock_get_branches(*args):
+        return branches
+
+    def mock_get_tags(*args):
+        assert tags is not None
+        return tags
+
+    def mock_fetch_file(
+        repo: str, path: str, ref: str, download_path: Optional[Path] = None
+    ):
+        assert repo == app_config.repo.name
+        assert download_path is None
+        assert path == app_config.release_discovery.version_file.__root__.path
+        assert ref in ref_versions
+
+        return str(ref_versions[ref])
+
+    with (
+        patch.object(
+            manifesttool.github_api, "get_branches", side_effect=mock_get_branches
+        ) as get_branches,
+        patch.object(
+            manifesttool.github_api, "get_tags", side_effect=mock_get_tags
+        ) as get_tags,
+        patch.object(
+            manifesttool.github_api, "fetch_file", side_effect=mock_fetch_file
+        ) as fetch_file,
+    ):
+        yield (
+            get_branches,
+            get_tags,
+            fetch_file,
+        )
+
+
+class ReleaseTests(TestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        # Use responses to ensure we don't make any HTTP calls.
+        responses.start()
+
+    @classmethod
+    def tearDownClass(cls):
+        super().tearDownClass()
+        responses.stop()
+
+    def test_discover_tagged_releases(self):
+        """Testing discover_tagged_releases."""
+        strategy = DiscoveryStrategy.create_tagged(
+            branch_re=r"release_v(?P<major>\d)+",
+            tag_re=r"v(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)",
+        )
+        app_config = AppConfig(
+            slug="fml-app",
+            repo=Repository(
+                type=RepositoryType.GITHUB,
+                name="fml-repo",
+            ),
+            fml_path="nimbus.fml.yaml",
+            release_discovery=ReleaseDiscovery(
+                version_file=VersionFile.create_plain_text("version.txt"),
+                strategies=[strategy],
+            ),
+        )
+
+        branches = [Ref(f"release_v{major}", f"branch-v{major}") for major in range(1, 7)]
+        tags = [Ref(f"v{major}.0.0", f"tag-v{major}") for major in range(1, 7)]
+        ref_versions = {
+            **{f"branch-v{major}": Version(major, 0, 1) for major in range(1, 7)},
+            **{f"tag-v{major}": Version(major) for major in range(1, 7)},
+        }
+
+        with TemporaryDirectory() as tmp:
+            manifest_dir = Path(tmp)
+            manifest_dir.joinpath(app_config.slug).mkdir()
+
+            with mocks_for_discover_tagged_releases(
+                app_config, strategy.__root__, branches, tags, ref_versions
+            ):
+                releases = discover_tagged_releases("app", app_config, strategy.__root__)
+
+        self.assertEqual(
+            releases,
+            {
+                **{
+                    Version(major, 0, 1): Ref(f"release_v{major}", f"branch-v{major}")
+                    for major in range(2, 7)
+                },
+                **{
+                    Version(major): Ref(f"v{major}.0.0", f"tag-v{major}")
+                    for major in range(2, 7)
+                },
+            },
+        )
+
+    def test_fetch_releases_no_tag_re(self):
+        """Testing discover_tagged_releases with no tag_re specified."""
+        strategy = DiscoveryStrategy.create_tagged(branch_re=r"release_v(?P<major>\d)+")
+        app_config = AppConfig(
+            slug="fml-app",
+            repo=Repository(
+                type=RepositoryType.GITHUB,
+                name="fml-repo",
+            ),
+            fml_path="nimbus.fml.yaml",
+            release_discovery=ReleaseDiscovery(
+                version_file=VersionFile.create_plain_text("version.txt"),
+                strategies=[strategy],
+            ),
+        )
+
+        branches = [Ref(f"release_v{major}", f"branch-v{major}") for major in range(1, 7)]
+        ref_versions = {f"branch-v{major}": Version(major, 0, 1) for major in range(1, 7)}
+
+        with TemporaryDirectory() as tmp:
+            manifest_dir = Path(tmp)
+            manifest_dir.joinpath(app_config.slug).mkdir()
+
+            with mocks_for_discover_tagged_releases(
+                app_config, strategy.__root__, branches, None, ref_versions
+            ) as (
+                get_branches,
+                get_tags,
+                resolve_ref_versions,
+            ):
+                releases = discover_tagged_releases("app", app_config, strategy.__root__)
+
+                get_tags.assert_not_called()
+
+        self.assertEqual(
+            releases,
+            {
+                Version(major, 0, 1): Ref(f"release_v{major}", f"branch-v{major}")
+                for major in range(2, 7)
+            },
+        )
+
+    @patch.object(manifesttool.releases.github_api, "get_branches", lambda *args: [])
+    def test_fetch_releases_no_major_release(self):
+        """Testing fetch_releases when there are no release branches."""
+        strategy = DiscoveryStrategy.create_tagged(
+            branch_re=r"release_v(?P<major>\d)+",
+            tag_re=r"v(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)",
+        )
+        app_config = AppConfig(
+            slug="fml-app",
+            repo=Repository(
+                type=RepositoryType.GITHUB,
+                name="fml-repo",
+            ),
+            fml_path="nimbus.fml.yaml",
+            release_discovery=ReleaseDiscovery(
+                version_file=VersionFile.create_plain_text("version.txt"),
+                strategies=[strategy],
+            ),
+        )
+
+        with TemporaryDirectory() as tmp:
+            manifest_dir = Path(tmp)
+            manifest_dir.joinpath(app_config.slug).mkdir()
+
+            with self.assertRaisesRegex(
+                Exception, "Could not find a major release for app."
+            ):
+                discover_tagged_releases("app", app_config, strategy.__root__)

--- a/experimenter/manifesttool/tests/test_releases.py
+++ b/experimenter/manifesttool/tests/test_releases.py
@@ -249,22 +249,24 @@ class ReleaseTests(TestCase):
     @patch.object(
         manifesttool.releases.hgmo_api,
         "get_bookmark_ref",
-        make_mock_get_bookmark_ref({
-            "foo": "1",
-            "bar": "2",
-            "baz": "3",
-        })
+        make_mock_get_bookmark_ref(
+            {
+                "foo": "1",
+                "bar": "2",
+                "baz": "3",
+            }
+        ),
     )
     @patch.object(
         manifesttool.releases.hgmo_api,
         "fetch_file",
         make_mock_fetch_file(
             paths_by_ref={
-                "1": { "version.txt": "1.0.0" },
-                "2": { "version.txt": "2.0.0" },
-                "3": { "version.txt": "3.0.0" },
+                "1": {"version.txt": "1.0.0"},
+                "2": {"version.txt": "2.0.0"},
+                "3": {"version.txt": "3.0.0"},
             }
-        )
+        ),
     )
     def test_discover_branched_releases(self):
         strategy = DiscoveryStrategy.create_branched(["foo", "bar", "baz"])
@@ -286,7 +288,9 @@ class ReleaseTests(TestCase):
             manifest_dir = Path(tmp)
             manifest_dir.joinpath(app_config.slug).mkdir()
 
-            releases = discover_branched_releases("legacy_app", app_config, strategy.__root__)
+            releases = discover_branched_releases(
+                "legacy_app", app_config, strategy.__root__
+            )
 
             self.assertEqual(
                 releases,
@@ -294,24 +298,26 @@ class ReleaseTests(TestCase):
                     Version(1): Ref("foo", "1"),
                     Version(2): Ref("bar", "2"),
                     Version(3): Ref("baz", "3"),
-                }
+                },
             )
 
     @patch.object(
         manifesttool.releases.hgmo_api,
         "get_bookmark_ref",
-        side_effect=make_mock_get_bookmark_ref({
-            "default": "1",
-        })
+        side_effect=make_mock_get_bookmark_ref(
+            {
+                "default": "1",
+            }
+        ),
     )
     @patch.object(
         manifesttool.releases.hgmo_api,
         "fetch_file",
         make_mock_fetch_file(
             paths_by_ref={
-                "1": { "version.txt": "1.0.0" },
+                "1": {"version.txt": "1.0.0"},
             }
-        )
+        ),
     )
     def test_discover_branched_releases_default(self, get_bookmark_ref):
         strategy = DiscoveryStrategy.create_branched()
@@ -333,13 +339,15 @@ class ReleaseTests(TestCase):
             manifest_dir = Path(tmp)
             manifest_dir.joinpath(app_config.slug).mkdir()
 
-            releases = discover_branched_releases("legacy_app", app_config, strategy.__root__)
+            releases = discover_branched_releases(
+                "legacy_app", app_config, strategy.__root__
+            )
 
             self.assertEqual(
                 releases,
                 {
                     Version(1): Ref("default", "1"),
-                }
+                },
             )
 
         get_bookmark_ref.assert_called_once_with(app_config.repo.name, "default")

--- a/experimenter/manifesttool/tests/test_version.py
+++ b/experimenter/manifesttool/tests/test_version.py
@@ -437,6 +437,7 @@ class VersionTests(TestCase):
                     repo=Repository(
                         type=RepositoryType.HGMO,
                         name="legacy-app",
+                        default_branch="tip",
                     ),
                     experimenter_yaml_path="nimbus.yaml",
                     release_discovery=ReleaseDiscovery(

--- a/experimenter/manifesttool/version.py
+++ b/experimenter/manifesttool/version.py
@@ -184,10 +184,14 @@ def resolve_ref_versions(
 
     for ref in refs:
         version_file_contents = fetch_file(
-            app_config.repo.name, app_config.version_file.__root__.path, ref.resolved
+            app_config.repo.name,
+            app_config.release_discovery.version_file.__root__.path,
+            ref.resolved,
         )
 
-        v = parse_version_file(app_config.version_file, version_file_contents)
+        v = parse_version_file(
+            app_config.release_discovery.version_file, version_file_contents
+        )
 
         versions[v] = ref
 


### PR DESCRIPTION
Because

- we want versioned feature manfiests for Firefox deskop

this commit

- refactors the majority of fetch_releases into a new releases module;
- refactors the current regex-based release discovery into a "tagged release
  strategy";
- updates firefox_desktop in apps.yaml to use mozilla-unified;
- adds a release discovery strategy for named branches (i.e., esr115, release,
  beta, central bookmarks of mozilla-unified); and
- does an import for Firefox.

Note: This only actually imports 115.5 (esr15), 120 (release), and 121 (central
/ nightly). This is because beta is currently merging into release and they
both have the same version of 120.0.0a1.

Fixes #9770
