### PR TITLE
feat(nimbus): add branched release strategies for mobile apps

### DIFF
--- a/experimenter/experimenter/features/manifests/apps.yaml
+++ b/experimenter/experimenter/features/manifests/apps.yaml
@@ -16,6 +16,7 @@ fenix:
       - type: "tagged"
         branch_re: 'releases_v(?P<major>\d+)'
         tag_re: 'fenix-v(?P<major>\d+)\.(?P<minor>\d+)(?:\.(?P<patch>\d+))?'
+      - type: "branched"
 
 firefox_ios:
   slug: "ios"
@@ -32,6 +33,7 @@ firefox_ios:
       - type: "tagged"
         branch_re: 'release/v(?P<major>\d+)(?:\.(?P<minor>\d+))?'
         tag_re: 'v(?P<major>\d+)\.(?P<minor>\d+)'
+      - type: "branched"
 
 focus_android:
   slug: "focus-android"
@@ -47,6 +49,7 @@ focus_android:
       - type: "tagged"
         branch_re: 'releases_v(?P<major>\d+)'
         tag_re: 'focus-v(?P<major>\d+)\.(?P<minor>\d+)(?:\.(?P<patch>\d+))?'
+      - type: "branched"
 
 focus_ios:
   slug: "focus-ios"
@@ -60,6 +63,7 @@ focus_ios:
       path: "Blockzilla/Info.plist"
       key: "CFBundleShortVersionString"
     strategies:
+      # We don't use a branched strategy for focus_ios because it is on v9000.
       - type: "tagged"
         branch_re: 'releases_v(?P<major>\d+)(?:\.(?P<minor>\d+))?'
         tag_re: 'v(?P<major>\d+)\.(?P<minor>\d+)(?:\.(?P<patch>\d+))?'

--- a/experimenter/experimenter/features/manifests/fenix/v121.0.0/beta.fml.yaml
+++ b/experimenter/experimenter/features/manifests/fenix/v121.0.0/beta.fml.yaml
@@ -1,0 +1,594 @@
+---
+version: 1.0.0
+about:
+  description: Nimbus Feature Manifest for Fenix (Firefox Android)
+channels:
+  - beta
+features:
+  cookie-banners:
+    description: Features for cookie banner handling.
+    variables:
+      sections-enabled:
+        description: This property provides a lookup table of whether or not the given section should be enabled.
+        type: "Map<CookieBannersSection, Int>"
+        default:
+          feature-setting-detect-only: 0
+          feature-setting-global-rules: 0
+          feature-setting-global-rules-sub-frames: 0
+          feature-setting-value: 0
+          feature-setting-value-pbm: 1
+          feature-ui: 1
+  extensions-process:
+    description: A feature to rollout the extensions process.
+    variables:
+      enabled:
+        description: "If true, the extensions process is enabled."
+        type: Boolean
+        default: true
+  fx-suggest:
+    description: A feature that provides Firefox Suggest search suggestions.
+    variables:
+      enabled:
+        description: "Whether the feature is enabled. When Firefox Suggest is enabled, Firefox will download and store new search suggestions in the background, and show additional Search settings to control which suggestions appear in the awesomebar. When Firefox Suggest is disabled, Firefox will not download new suggestions, and hide the additional Search settings.\n"
+        type: Boolean
+        default: false
+  glean:
+    description: A feature that provides server-side configurations for Glean metrics (aka Server Knobs).
+    variables:
+      enable-event-timestamps:
+        description: Enables precise event timestamps for Glean events
+        type: Boolean
+        default: false
+      metrics-enabled:
+        description: "A map of metric base-identifiers to booleans representing the state of the 'enabled' flag for that metric."
+        type: "Map<String, Boolean>"
+        default: {}
+  growth-data:
+    description: A feature measuring campaign growth data
+    variables:
+      enabled:
+        description: "If true, the feature is active"
+        type: Boolean
+        default: false
+  homescreen:
+    description: The homescreen that the user goes to when they press home or new tab.
+    variables:
+      sections-enabled:
+        description: "This property provides a lookup table of whether or not the given section should be enabled. If the section is enabled, it should be toggleable in the settings screen, and on by default."
+        type: "Map<HomeScreenSection, Boolean>"
+        default:
+          jump-back-in: true
+          pocket: true
+          pocket-sponsored-stories: true
+          recent-explorations: true
+          recently-saved: true
+          top-sites: true
+  juno-onboarding:
+    description: A feature that shows juno onboarding flow.
+    variables:
+      cards:
+        description: Collection of user facing onboarding cards.
+        type: "Map<String, OnboardingCardData>"
+        default:
+          add-search-widget:
+            body: juno_onboarding_add_search_widget_description
+            card-type: add-search-widget
+            enabled: false
+            image-res: ic_onboarding_search_widget
+            ordering: 15
+            primary-button-label: juno_onboarding_add_search_widget_positive_button
+            secondary-button-label: juno_onboarding_add_search_widget_negative_button
+            title: juno_onboarding_add_search_widget_title
+          default-browser:
+            body: juno_onboarding_default_browser_description_nimbus_2
+            card-type: default-browser
+            image-res: ic_onboarding_welcome
+            link-text: juno_onboarding_default_browser_description_link_text
+            ordering: 10
+            primary-button-label: juno_onboarding_default_browser_positive_button
+            secondary-button-label: juno_onboarding_default_browser_negative_button
+            title: juno_onboarding_default_browser_title_nimbus_2
+          notification-permission:
+            body: juno_onboarding_enable_notifications_description_nimbus_2
+            card-type: notification-permission
+            image-res: ic_notification_permission
+            ordering: 30
+            primary-button-label: juno_onboarding_enable_notifications_positive_button
+            secondary-button-label: juno_onboarding_enable_notifications_negative_button
+            title: juno_onboarding_enable_notifications_title_nimbus_2
+          sync-sign-in:
+            body: juno_onboarding_sign_in_description_2
+            card-type: sync-sign-in
+            image-res: ic_onboarding_sync
+            ordering: 20
+            primary-button-label: juno_onboarding_sign_in_positive_button
+            secondary-button-label: juno_onboarding_sign_in_negative_button
+            title: juno_onboarding_sign_in_title_2
+      conditions:
+        description: "A collection of out the box conditional expressions to be used in determining whether a card should show or not. Each entry maps to a valid JEXL expression.\n"
+        type: "Map<String, String>"
+        default:
+          ALWAYS: "true"
+          NEVER: "false"
+  messaging:
+    description: "The in-app messaging system.\n"
+    variables:
+      actions:
+        description: A growable map of action URLs.
+        type: "Map<String, String>"
+        default:
+          ENABLE_PRIVATE_BROWSING: "://enable_private_browsing"
+          INSTALL_SEARCH_WIDGET: "://install_search_widget"
+          MAKE_DEFAULT_BROWSER: "://make_default_browser"
+          OPEN_SETTINGS: "://settings"
+          OPEN_SETTINGS_ACCESSIBILITY: "://settings_accessibility"
+          OPEN_SETTINGS_ADDON_MANAGER: "://settings_addon_manager"
+          OPEN_SETTINGS_DELETE_BROWSING_DATA: "://settings_delete_browsing_data"
+          OPEN_SETTINGS_LOGINS: "://settings_logins"
+          OPEN_SETTINGS_NOTIFICATIONS: "://settings_notifications"
+          OPEN_SETTINGS_PRIVACY: "://settings_privacy"
+          OPEN_SETTINGS_SEARCH_ENGINE: "://settings_search_engine"
+          OPEN_SETTINGS_TRACKING_PROTECTION: "://settings_tracking_protection"
+          OPEN_SETTINGS_WALLPAPERS: "://settings_wallpapers"
+          TURN_ON_SYNC: "://turn_on_sync"
+          VIEW_BOOKMARKS: "://urls_bookmarks"
+          VIEW_COLLECTIONS: "://home_collections"
+          VIEW_HISTORY: "://urls_history"
+          VIEW_HOMESCREEN: "://home"
+      message-under-experiment:
+        description: "Deprecated in favor of `MessageData#experiment`. This will be removed in future releases."
+        type: Option<String>
+        default: ~
+      messages:
+        description: A growable collection of messages
+        type: "Map<String, MessageData>"
+        default:
+          default-browser:
+            action: MAKE_DEFAULT_BROWSER
+            button-label: preferences_set_as_default_browser
+            style: PERSISTENT
+            surface: homescreen
+            text: default_browser_experiment_card_text
+            trigger:
+              - I_AM_NOT_DEFAULT_BROWSER
+              - USER_ESTABLISHED_INSTALL
+          default-browser-notification:
+            action: MAKE_DEFAULT_BROWSER
+            style: NOTIFICATION
+            surface: notification
+            text: nimbus_notification_default_browser_text
+            title: nimbus_notification_default_browser_title
+            trigger:
+              - I_AM_NOT_DEFAULT_BROWSER
+              - DAY_3_AFTER_INSTALL
+      notification-config:
+        description: Configuration of the notification worker for all notification messages.
+        type: NotificationConfig
+        default: {}
+      on-control:
+        description: What should be displayed when a control message is selected.
+        type: ControlMessageBehavior
+        default: show-next-message
+      styles:
+        description: "A map of styles to configure message appearance.\n"
+        type: "Map<String, StyleData>"
+        default:
+          DEFAULT:
+            max-display-count: 5
+            priority: 50
+          NOTIFICATION:
+            max-display-count: 1
+            priority: 50
+          PERSISTENT:
+            max-display-count: 20
+            priority: 50
+          SURVEY:
+            max-display-count: 1
+            priority: 55
+          URGENT:
+            max-display-count: 10
+            priority: 100
+          WARNING:
+            max-display-count: 10
+            priority: 60
+      triggers:
+        description: "A collection of out the box trigger expressions. Each entry maps to a valid JEXL expression.\n"
+        type: "Map<String, String>"
+        default:
+          ALWAYS: "true"
+          DAY_1_AFTER_INSTALL: days_since_install == 1
+          DAY_2_AFTER_INSTALL: days_since_install == 2
+          DAY_3_AFTER_INSTALL: days_since_install == 3
+          DAY_4_AFTER_INSTALL: days_since_install == 4
+          DAY_5_AFTER_INSTALL: days_since_install == 5
+          DEVICE_ANDROID: "os == 'Android'"
+          DEVICE_IOS: "os == 'iOS'"
+          FUNNEL_ORGANIC: "adjust_campaign == ''"
+          FUNNEL_PAID: "adjust_campaign != ''"
+          FXA_NOT_SIGNED_IN: "'sync_auth.sign_in'|eventLastSeen('Years', 0) > 4"
+          FXA_SIGNED_IN: "'sync_auth.sign_in'|eventLastSeen('Years', 0) <= 4"
+          INACTIVE_1_DAY: "'app_launched'|eventLastSeen('Hours') >= 24"
+          INACTIVE_2_DAYS: "'app_launched'|eventLastSeen('Days', 0) >= 2"
+          INACTIVE_3_DAYS: "'app_launched'|eventLastSeen('Days', 0) >= 3"
+          INACTIVE_4_DAYS: "'app_launched'|eventLastSeen('Days', 0) >= 4"
+          INACTIVE_5_DAYS: "'app_launched'|eventLastSeen('Days', 0) >= 5"
+          I_AM_DEFAULT_BROWSER: is_default_browser
+          I_AM_NOT_DEFAULT_BROWSER: is_default_browser == false
+          LAUNCHED_ONCE_THIS_WEEK: "'app_launched'|eventSum('Days', 7) == 1"
+          MORE_THAN_24H_SINCE_INSTALLED_OR_UPDATED: days_since_update >= 1
+          NEVER: "false"
+          USER_CASUAL: "'app_launched'|eventCountNonZero('Days', 28) >= 7 && 'app_launched'|eventCountNonZero('Days', 28) < 14"
+          USER_CORE_ACTIVE: "'app_launched'|eventCountNonZero('Days', 28) >= 21"
+          USER_DE_SPEAKER: "'de' in locale"
+          USER_EN_SPEAKER: "'en' in locale"
+          USER_ESTABLISHED_INSTALL: number_of_app_launches >=4
+          USER_ES_SPEAKER: "'es' in locale"
+          USER_FR_SPEAKER: "'fr' in locale"
+          USER_INFREQUENT: "'app_launched'|eventCountNonZero('Days', 28) >= 1 && 'app_launched'|eventCountNonZero('Days', 28) < 7"
+          USER_RECENTLY_INSTALLED: days_since_install < 7
+          USER_RECENTLY_UPDATED: days_since_update < 7 && days_since_install != days_since_update
+          USER_REGULAR: "'app_launched'|eventCountNonZero('Days', 28) >= 14 && 'app_launched'|eventCountNonZero('Days', 28) < 21"
+          USER_TIER_ONE_COUNTRY: "('US' in locale || 'GB' in locale || 'CA' in locale || 'DE' in locale || 'FR' in locale)"
+    allow-coenrollment: true
+  mr2022:
+    description: Features for MR 2022.
+    variables:
+      sections-enabled:
+        description: This property provides a lookup table of whether or not the given section should be enabled.
+        type: "Map<MR2022Section, Boolean>"
+        default:
+          home-onboarding-dialog-existing-users: true
+          jump-back-in-cfr: true
+          sync-cfr: true
+          tcp-cfr: true
+          tcp-feature: true
+          wallpapers-selection-tool: true
+  nimbus-system:
+    description: "Configuration of the Nimbus System in Android.\n"
+    variables:
+      refresh-interval-foreground:
+        description: "The minimum interval in minutes between fetching experiment \nrecipes in the foreground.\n"
+        type: Int
+        default: 60
+  nimbus-validation:
+    description: A feature that does not correspond to an application feature suitable for showing that Nimbus is working. This should never be used in production.
+    variables:
+      settings-icon:
+        description: The drawable displayed in the app menu for Settings
+        type: String
+        default: mozac_ic_settings
+      settings-punctuation:
+        description: The emoji displayed in the Settings screen title.
+        type: String
+        default: ""
+      settings-title:
+        description: The title of displayed in the Settings screen and app menu.
+        type: Text
+        default: browser_menu_settings
+  onboarding:
+    description: "A feature that configures the new user onboarding page. Note that onboarding is a **first run** feature, and should only be modified by first run experiments."
+    variables:
+      order:
+        description: Determines the order of the onboarding page panels
+        type: List<OnboardingPanel>
+        default:
+          - themes
+          - toolbar-placement
+          - sync
+          - tcp
+          - privacy-notice
+  pdfjs:
+    description: PDF.js features
+    variables:
+      download-button:
+        description: Download button
+        type: Boolean
+        default: true
+      open-in-app-button:
+        description: Open in app button
+        type: Boolean
+        default: true
+  pre-permission-notification-prompt:
+    description: A feature that shows the pre-permission notification prompt.
+    variables:
+      enabled:
+        description: "if true, the pre-permission notification prompt is shown to the user."
+        type: Boolean
+        default: false
+  print:
+    description: A feature for printing from the share or browser menu.
+    variables:
+      browser-print-enabled:
+        description: "If true, a print button from the browser menu is available."
+        type: Boolean
+        default: true
+      share-print-enabled:
+        description: "If true, a print button from the share menu is available."
+        type: Boolean
+        default: true
+  private-browsing:
+    description: Private Browsing Mode
+    variables:
+      felt-privacy-enabled:
+        description: "if true, enable felt privacy related UI"
+        type: Boolean
+        default: false
+  query-parameter-stripping:
+    description: Features for query parameter stripping.
+    variables:
+      sections-enabled:
+        description: This property provides a lookup table of whether or not the given section should be enabled.
+        type: "Map<QueryParameterStrippingSection, String>"
+        default:
+          query-parameter-stripping: "0"
+          query-parameter-stripping-allow-list: ""
+          query-parameter-stripping-pmb: "0"
+          query-parameter-stripping-strip-list: ""
+  re-engagement-notification:
+    description: A feature that shows the re-engagement notification if the user is inactive.
+    variables:
+      enabled:
+        description: "If true, the re-engagement notification is shown to the inactive user."
+        type: Boolean
+        default: false
+      type:
+        description: The type of re-engagement notification that is shown to the inactive user.
+        type: Int
+        default: 0
+  search-extra-params:
+    description: A feature that provides additional args for search.
+    variables:
+      channel-id:
+        description: The channel Id param name with arg.
+        type: "Map<String, String>"
+        default: {}
+      enabled:
+        description: "If true, the feature is active."
+        type: Boolean
+        default: false
+      feature-enabler:
+        description: "The feature enabler param name with arg, NOTE this map could be empty."
+        type: "Map<String, String>"
+        default: {}
+      search-engine:
+        description: The search engine name.
+        type: String
+        default: ""
+  search-term-groups:
+    description: A feature allowing the grouping of URLs around the search term that it came from.
+    variables:
+      enabled:
+        description: "If true, the feature shows up on the homescreen and on the new tab screen."
+        type: Boolean
+        default: false
+  shopping-experience:
+    description: A feature that shows product review quality information.
+    variables:
+      enabled:
+        description: "if true, the shopping experience feature is shown to the user."
+        type: Boolean
+        default: false
+      product-recommendations:
+        description: "if true, recommended products feature is enabled to be shown to the user based on their preference."
+        type: Boolean
+        default: false
+  splash-screen:
+    description: "A feature that extends splash screen duration, allowing additional data fetching time for the app's initial run."
+    variables:
+      enabled:
+        description: "If true, the feature is active."
+        type: Boolean
+        default: false
+      maximum_duration_ms:
+        description: The maximum amount of time in milliseconds the splashscreen will be visible while waiting for initialization calls to complete.
+        type: Int
+        default: 0
+  toolbar:
+    description: The searchbar/awesomebar that user uses to search.
+    variables:
+      toolbar-position-top:
+        description: "If true, toolbar appears at top of the screen."
+        type: Boolean
+        default: false
+  unified-search:
+    description: A feature allowing user to easily search for specified results directly in the search bar.
+    variables:
+      enabled:
+        description: "If true, the feature shows up in the search bar."
+        type: Boolean
+        default: true
+enums:
+  ControlMessageBehavior:
+    description: An enum to influence what should be displayed when a control message is selected.
+    variants:
+      show-next-message:
+        description: The next eligible message should be shown.
+      show-none:
+        description: The surface should show no message.
+  CookieBannersSection:
+    description: The identifiers for the sections of the MR 2022.
+    variants:
+      feature-setting-detect-only:
+        description: "An integer either 0 or 1 indicating if cookie banner detect only mode should be enabled or disabled. 0 for setting to be disabled, and 1 for enabling the setting."
+      feature-setting-global-rules:
+        description: "An integer either 0 or 1 indicating if cookie banner global rules should be enabled or disabled. 0 for setting to be disabled, and 1 for enabling the setting."
+      feature-setting-global-rules-sub-frames:
+        description: "An integer either 0 or 1 indicating if cookie banner global rules sub-frames should be enabled or disabled. 0 for setting to be disabled, and 1 for enabling the setting."
+      feature-setting-value:
+        description: "An integer either 0 or 1 indicating if cookie banner setting should be enabled or disabled, 0 for setting the value to disabled, 1  for enabling the setting with the value reject_all."
+      feature-setting-value-pbm:
+        description: "An integer either 0 or 1 indicating if cookie banner setting should be enabled or disabled, 0 for setting the value to disabled, 1  for enabling the setting with the value reject_all."
+      feature-ui:
+        description: "An integer either 0 or 1 indicating if the UI for cookie banner handling should be visible, 0 to hide the UI and 1 to show the UI. The actual UI is composed by cookie banner section in the settings page, the toolbar section and the re-engagement dialog."
+  HomeScreenSection:
+    description: The identifiers for the sections of the homescreen.
+    variants:
+      jump-back-in:
+        description: The tabs the user was looking immediately before being interrupted.
+      pocket:
+        description: The pocket section. This should only be available in the US.
+      pocket-sponsored-stories:
+        description: Subsection of the Pocket homescreen section which shows sponsored stories.
+      recent-explorations:
+        description: The tab groups
+      recently-saved:
+        description: The sites the user has bookmarked recently.
+      top-sites:
+        description: The frecency and pinned sites.
+  MR2022Section:
+    description: The identifiers for the sections of the MR 2022.
+    variants:
+      home-onboarding-dialog-existing-users:
+        description: Home onboarding dialog for upgraded users.
+      jump-back-in-cfr:
+        description: Jump back-in onboarding message.
+      sync-cfr:
+        description: CFR for the first time you see a synced tab on the home screen.
+      tcp-cfr:
+        description: CFR for the first time you use the browse with Total Cookie Protection on the browser screen.
+      tcp-feature:
+        description: Controls the Total Cookie Protection feature.
+      wallpapers-selection-tool:
+        description: Wallpapers selection dialog tool for the home screen.
+  OnboardingCardType:
+    description: An enum to describe a type of card.
+    variants:
+      add-search-widget:
+        description: Allows user to add search widget to homescreen.
+      default-browser:
+        description: Allows user to set Firefox as the default browser.
+      notification-permission:
+        description: Allows user to enable notification permission.
+      sync-sign-in:
+        description: Allows user to sync with a Firefox account.
+  OnboardingPanel:
+    description: The types of onboarding panels in the onboarding page
+    variants:
+      privacy-notice:
+        description: The onboarding panel where users can tap to view our privacy notice.
+      sync:
+        description: The onboarding panel where users can sign in to sync
+      tcp:
+        description: The onboarding panel where users can choose their total cookie protection settings
+      themes:
+        description: The themes onboarding panel where users pick themes
+      toolbar-placement:
+        description: The onboarding panel where users choose their toolbar placement (bottom or top)
+  QueryParameterStrippingSection:
+    description: The identifiers for the options for the Query Parameter Stripping feature.
+    variants:
+      query-parameter-stripping:
+        description: "An integer either 0 or 1 indicating if query parameter stripping should be enabled or disabled in normal mode. 0 for setting to be disabled, and 1 for enabling the setting."
+      query-parameter-stripping-allow-list:
+        description: An string separated by commas indicating the sites where should from query stripping should be exempted.
+      query-parameter-stripping-pmb:
+        description: "An integer either 0 or 1 indicating if query parameter stripping should be enabled or disabled in private mode. 0 for setting to be disabled, and 1 for enabling the setting."
+      query-parameter-stripping-strip-list:
+        description: An string separated by commas indicating the list of query params to be stripped from URIs. This list will be merged with records coming from RemoteSettings.
+objects:
+  MessageData:
+    description: "An object to describe a message. It uses human readable strings to describe the triggers, action and style of the message as well as the text of the message and call to action.\n"
+    fields:
+      action:
+        description: "A URL of a page or a deeplink. This may have substitution variables in.\n"
+        type: Text
+        default: ""
+      button-label:
+        description: "The text on the button. If no text is present, the whole message is clickable.\n"
+        type: Option<Text>
+        default: ~
+      experiment:
+        description: The slug of the experiment that this message came from.
+        type: Option<String>
+        default: ~
+      is-control:
+        description: "Indicates if this message is the control message, if true shouldn't be displayed"
+        type: Boolean
+        default: false
+      style:
+        description: "The style as described in a `StyleData` from the styles table.\n"
+        type: String
+        default: DEFAULT
+      surface:
+        description: The surface identifier for this message.
+        type: String
+        default: homescreen
+      text:
+        description: The message text displayed to the user
+        type: Text
+        default: ""
+      title:
+        description: The title text displayed to the user
+        type: Option<Text>
+        default: ~
+      trigger:
+        description: "A list of strings corresponding to targeting expressions. The message will be shown if all expressions `true`.\n"
+        type: List<String>
+        default: []
+  NotificationConfig:
+    description: Attributes controlling the global configuration of notification messages.
+    fields:
+      refresh-interval:
+        description: "How often, in minutes, the notification message worker will wake up and check for new messages.\n"
+        type: Int
+        default: 240
+  OnboardingCardData:
+    description: An object to describe a user facing onboarding card.
+    fields:
+      body:
+        description: The message text displayed to the user. May contain linkable text.
+        type: Text
+        default: ""
+      card-type:
+        description: The type of the card.
+        type: OnboardingCardType
+        default: default-browser
+      disqualifiers:
+        description: "A list of strings corresponding to targeting expressions. The card will not be shown if any expression is `true`.\n"
+        type: List<String>
+        default:
+          - NEVER
+      enabled:
+        description: "If true, this card is shown to the user."
+        type: Boolean
+        default: true
+      image-res:
+        description: The resource id of the image to be displayed.
+        type: Image
+        default: ic_onboarding_welcome
+      link-text:
+        description: "The text to link from the body text. This should match the linkable text from the body text exactly. e.g. body: This is a policy link\n     link-text: policy link\n"
+        type: Option<Text>
+        default: ~
+      ordering:
+        description: Used to sequence the cards.
+        type: Int
+        default: 0
+      prerequisites:
+        description: "A list of strings corresponding to targeting expressions. The card will be shown if all expressions are `true` and if no expressions in the `disqualifiers` table are true, or if the `disqualifiers` table is empty.\n"
+        type: List<String>
+        default:
+          - ALWAYS
+      primary-button-label:
+        description: The text to display on the primary button.
+        type: Text
+        default: ""
+      secondary-button-label:
+        description: The text to display on the secondary button.
+        type: Text
+        default: ""
+      title:
+        description: The title text displayed to the user.
+        type: Text
+        default: ""
+  StyleData:
+    description: "A group of properties (predominantly visual) to describe the style of the message.\n"
+    fields:
+      max-display-count:
+        description: "How many sessions will this message be shown to the user before it is expired.\n"
+        type: Int
+        default: 5
+      priority:
+        description: "The importance of this message. 0 is not very important, 100 is very important.\n"
+        type: Int
+        default: 50

--- a/experimenter/experimenter/features/manifests/fenix/v121.0.0/developer.fml.yaml
+++ b/experimenter/experimenter/features/manifests/fenix/v121.0.0/developer.fml.yaml
@@ -1,0 +1,598 @@
+---
+version: 1.0.0
+about:
+  description: Nimbus Feature Manifest for Fenix (Firefox Android)
+channels:
+  - developer
+features:
+  cookie-banners:
+    description: Features for cookie banner handling.
+    variables:
+      sections-enabled:
+        description: This property provides a lookup table of whether or not the given section should be enabled.
+        type: "Map<CookieBannersSection, Int>"
+        default:
+          feature-setting-detect-only: 0
+          feature-setting-global-rules: 0
+          feature-setting-global-rules-sub-frames: 0
+          feature-setting-value: 0
+          feature-setting-value-pbm: 1
+          feature-ui: 1
+  extensions-process:
+    description: A feature to rollout the extensions process.
+    variables:
+      enabled:
+        description: "If true, the extensions process is enabled."
+        type: Boolean
+        default: true
+  fx-suggest:
+    description: A feature that provides Firefox Suggest search suggestions.
+    variables:
+      enabled:
+        description: "Whether the feature is enabled. When Firefox Suggest is enabled, Firefox will download and store new search suggestions in the background, and show additional Search settings to control which suggestions appear in the awesomebar. When Firefox Suggest is disabled, Firefox will not download new suggestions, and hide the additional Search settings.\n"
+        type: Boolean
+        default: true
+  glean:
+    description: A feature that provides server-side configurations for Glean metrics (aka Server Knobs).
+    variables:
+      enable-event-timestamps:
+        description: Enables precise event timestamps for Glean events
+        type: Boolean
+        default: false
+      metrics-enabled:
+        description: "A map of metric base-identifiers to booleans representing the state of the 'enabled' flag for that metric."
+        type: "Map<String, Boolean>"
+        default: {}
+  growth-data:
+    description: A feature measuring campaign growth data
+    variables:
+      enabled:
+        description: "If true, the feature is active"
+        type: Boolean
+        default: false
+  homescreen:
+    description: The homescreen that the user goes to when they press home or new tab.
+    variables:
+      sections-enabled:
+        description: "This property provides a lookup table of whether or not the given section should be enabled. If the section is enabled, it should be toggleable in the settings screen, and on by default."
+        type: "Map<HomeScreenSection, Boolean>"
+        default:
+          jump-back-in: true
+          pocket: true
+          pocket-sponsored-stories: true
+          recent-explorations: true
+          recently-saved: true
+          top-sites: true
+  juno-onboarding:
+    description: A feature that shows juno onboarding flow.
+    variables:
+      cards:
+        description: Collection of user facing onboarding cards.
+        type: "Map<String, OnboardingCardData>"
+        default:
+          add-search-widget:
+            body: juno_onboarding_add_search_widget_description
+            card-type: add-search-widget
+            enabled: false
+            image-res: ic_onboarding_search_widget
+            ordering: 15
+            primary-button-label: juno_onboarding_add_search_widget_positive_button
+            secondary-button-label: juno_onboarding_add_search_widget_negative_button
+            title: juno_onboarding_add_search_widget_title
+          default-browser:
+            body: juno_onboarding_default_browser_description_nimbus_2
+            card-type: default-browser
+            image-res: ic_onboarding_welcome
+            link-text: juno_onboarding_default_browser_description_link_text
+            ordering: 10
+            primary-button-label: juno_onboarding_default_browser_positive_button
+            secondary-button-label: juno_onboarding_default_browser_negative_button
+            title: juno_onboarding_default_browser_title_nimbus_2
+          notification-permission:
+            body: juno_onboarding_enable_notifications_description_nimbus_2
+            card-type: notification-permission
+            image-res: ic_notification_permission
+            ordering: 30
+            primary-button-label: juno_onboarding_enable_notifications_positive_button
+            secondary-button-label: juno_onboarding_enable_notifications_negative_button
+            title: juno_onboarding_enable_notifications_title_nimbus_2
+          sync-sign-in:
+            body: juno_onboarding_sign_in_description_2
+            card-type: sync-sign-in
+            image-res: ic_onboarding_sync
+            ordering: 20
+            primary-button-label: juno_onboarding_sign_in_positive_button
+            secondary-button-label: juno_onboarding_sign_in_negative_button
+            title: juno_onboarding_sign_in_title_2
+      conditions:
+        description: "A collection of out the box conditional expressions to be used in determining whether a card should show or not. Each entry maps to a valid JEXL expression.\n"
+        type: "Map<String, String>"
+        default:
+          ALWAYS: "true"
+          NEVER: "false"
+  messaging:
+    description: "The in-app messaging system.\n"
+    variables:
+      actions:
+        description: A growable map of action URLs.
+        type: "Map<String, String>"
+        default:
+          ENABLE_PRIVATE_BROWSING: "://enable_private_browsing"
+          INSTALL_SEARCH_WIDGET: "://install_search_widget"
+          MAKE_DEFAULT_BROWSER: "://make_default_browser"
+          OPEN_SETTINGS: "://settings"
+          OPEN_SETTINGS_ACCESSIBILITY: "://settings_accessibility"
+          OPEN_SETTINGS_ADDON_MANAGER: "://settings_addon_manager"
+          OPEN_SETTINGS_DELETE_BROWSING_DATA: "://settings_delete_browsing_data"
+          OPEN_SETTINGS_LOGINS: "://settings_logins"
+          OPEN_SETTINGS_NOTIFICATIONS: "://settings_notifications"
+          OPEN_SETTINGS_PRIVACY: "://settings_privacy"
+          OPEN_SETTINGS_SEARCH_ENGINE: "://settings_search_engine"
+          OPEN_SETTINGS_TRACKING_PROTECTION: "://settings_tracking_protection"
+          OPEN_SETTINGS_WALLPAPERS: "://settings_wallpapers"
+          TURN_ON_SYNC: "://turn_on_sync"
+          VIEW_BOOKMARKS: "://urls_bookmarks"
+          VIEW_COLLECTIONS: "://home_collections"
+          VIEW_HISTORY: "://urls_history"
+          VIEW_HOMESCREEN: "://home"
+      message-under-experiment:
+        description: "Deprecated in favor of `MessageData#experiment`. This will be removed in future releases."
+        type: Option<String>
+        default: ~
+      messages:
+        description: A growable collection of messages
+        type: "Map<String, MessageData>"
+        default:
+          default-browser:
+            action: MAKE_DEFAULT_BROWSER
+            button-label: preferences_set_as_default_browser
+            style: PERSISTENT
+            surface: homescreen
+            text: default_browser_experiment_card_text
+            trigger:
+              - I_AM_NOT_DEFAULT_BROWSER
+              - USER_ESTABLISHED_INSTALL
+          default-browser-notification:
+            action: MAKE_DEFAULT_BROWSER
+            style: NOTIFICATION
+            surface: notification
+            text: nimbus_notification_default_browser_text
+            title: nimbus_notification_default_browser_title
+            trigger:
+              - I_AM_NOT_DEFAULT_BROWSER
+              - DAY_3_AFTER_INSTALL
+      notification-config:
+        description: Configuration of the notification worker for all notification messages.
+        type: NotificationConfig
+        default:
+          refresh-interval: 120
+      on-control:
+        description: What should be displayed when a control message is selected.
+        type: ControlMessageBehavior
+        default: show-next-message
+      styles:
+        description: "A map of styles to configure message appearance.\n"
+        type: "Map<String, StyleData>"
+        default:
+          DEFAULT:
+            max-display-count: 100
+            priority: 50
+          EXPIRES_QUICKLY:
+            max-display-count: 1
+            priority: 100
+          NOTIFICATION:
+            max-display-count: 1
+            priority: 50
+          PERSISTENT:
+            max-display-count: 20
+            priority: 50
+          SURVEY:
+            max-display-count: 1
+            priority: 55
+          URGENT:
+            max-display-count: 10
+            priority: 100
+          WARNING:
+            max-display-count: 10
+            priority: 60
+      triggers:
+        description: "A collection of out the box trigger expressions. Each entry maps to a valid JEXL expression.\n"
+        type: "Map<String, String>"
+        default:
+          ALWAYS: "true"
+          DAY_1_AFTER_INSTALL: days_since_install == 1
+          DAY_2_AFTER_INSTALL: days_since_install == 2
+          DAY_3_AFTER_INSTALL: days_since_install == 3
+          DAY_4_AFTER_INSTALL: days_since_install == 4
+          DAY_5_AFTER_INSTALL: days_since_install == 5
+          DEVICE_ANDROID: "os == 'Android'"
+          DEVICE_IOS: "os == 'iOS'"
+          FUNNEL_ORGANIC: "adjust_campaign == ''"
+          FUNNEL_PAID: "adjust_campaign != ''"
+          FXA_NOT_SIGNED_IN: "'sync_auth.sign_in'|eventLastSeen('Years', 0) > 4"
+          FXA_SIGNED_IN: "'sync_auth.sign_in'|eventLastSeen('Years', 0) <= 4"
+          INACTIVE_1_DAY: "'app_launched'|eventLastSeen('Hours') >= 24"
+          INACTIVE_2_DAYS: "'app_launched'|eventLastSeen('Days', 0) >= 2"
+          INACTIVE_3_DAYS: "'app_launched'|eventLastSeen('Days', 0) >= 3"
+          INACTIVE_4_DAYS: "'app_launched'|eventLastSeen('Days', 0) >= 4"
+          INACTIVE_5_DAYS: "'app_launched'|eventLastSeen('Days', 0) >= 5"
+          I_AM_DEFAULT_BROWSER: is_default_browser
+          I_AM_NOT_DEFAULT_BROWSER: is_default_browser == false
+          LAUNCHED_ONCE_THIS_WEEK: "'app_launched'|eventSum('Days', 7) == 1"
+          MORE_THAN_24H_SINCE_INSTALLED_OR_UPDATED: days_since_update >= 1
+          NEVER: "false"
+          USER_CASUAL: "'app_launched'|eventCountNonZero('Days', 28) >= 7 && 'app_launched'|eventCountNonZero('Days', 28) < 14"
+          USER_CORE_ACTIVE: "'app_launched'|eventCountNonZero('Days', 28) >= 21"
+          USER_DE_SPEAKER: "'de' in locale"
+          USER_EN_SPEAKER: "'en' in locale"
+          USER_ESTABLISHED_INSTALL: number_of_app_launches >=4
+          USER_ES_SPEAKER: "'es' in locale"
+          USER_FR_SPEAKER: "'fr' in locale"
+          USER_INFREQUENT: "'app_launched'|eventCountNonZero('Days', 28) >= 1 && 'app_launched'|eventCountNonZero('Days', 28) < 7"
+          USER_RECENTLY_INSTALLED: days_since_install < 7
+          USER_RECENTLY_UPDATED: days_since_update < 7 && days_since_install != days_since_update
+          USER_REGULAR: "'app_launched'|eventCountNonZero('Days', 28) >= 14 && 'app_launched'|eventCountNonZero('Days', 28) < 21"
+          USER_TIER_ONE_COUNTRY: "('US' in locale || 'GB' in locale || 'CA' in locale || 'DE' in locale || 'FR' in locale)"
+    allow-coenrollment: true
+  mr2022:
+    description: Features for MR 2022.
+    variables:
+      sections-enabled:
+        description: This property provides a lookup table of whether or not the given section should be enabled.
+        type: "Map<MR2022Section, Boolean>"
+        default:
+          home-onboarding-dialog-existing-users: true
+          jump-back-in-cfr: true
+          sync-cfr: true
+          tcp-cfr: true
+          tcp-feature: true
+          wallpapers-selection-tool: true
+  nimbus-system:
+    description: "Configuration of the Nimbus System in Android.\n"
+    variables:
+      refresh-interval-foreground:
+        description: "The minimum interval in minutes between fetching experiment \nrecipes in the foreground.\n"
+        type: Int
+        default: 60
+  nimbus-validation:
+    description: A feature that does not correspond to an application feature suitable for showing that Nimbus is working. This should never be used in production.
+    variables:
+      settings-icon:
+        description: The drawable displayed in the app menu for Settings
+        type: String
+        default: mozac_ic_settings
+      settings-punctuation:
+        description: The emoji displayed in the Settings screen title.
+        type: String
+        default: ""
+      settings-title:
+        description: The title of displayed in the Settings screen and app menu.
+        type: Text
+        default: browser_menu_settings
+  onboarding:
+    description: "A feature that configures the new user onboarding page. Note that onboarding is a **first run** feature, and should only be modified by first run experiments."
+    variables:
+      order:
+        description: Determines the order of the onboarding page panels
+        type: List<OnboardingPanel>
+        default:
+          - themes
+          - toolbar-placement
+          - sync
+          - tcp
+          - privacy-notice
+  pdfjs:
+    description: PDF.js features
+    variables:
+      download-button:
+        description: Download button
+        type: Boolean
+        default: true
+      open-in-app-button:
+        description: Open in app button
+        type: Boolean
+        default: true
+  pre-permission-notification-prompt:
+    description: A feature that shows the pre-permission notification prompt.
+    variables:
+      enabled:
+        description: "if true, the pre-permission notification prompt is shown to the user."
+        type: Boolean
+        default: false
+  print:
+    description: A feature for printing from the share or browser menu.
+    variables:
+      browser-print-enabled:
+        description: "If true, a print button from the browser menu is available."
+        type: Boolean
+        default: true
+      share-print-enabled:
+        description: "If true, a print button from the share menu is available."
+        type: Boolean
+        default: true
+  private-browsing:
+    description: Private Browsing Mode
+    variables:
+      felt-privacy-enabled:
+        description: "if true, enable felt privacy related UI"
+        type: Boolean
+        default: false
+  query-parameter-stripping:
+    description: Features for query parameter stripping.
+    variables:
+      sections-enabled:
+        description: This property provides a lookup table of whether or not the given section should be enabled.
+        type: "Map<QueryParameterStrippingSection, String>"
+        default:
+          query-parameter-stripping: "0"
+          query-parameter-stripping-allow-list: ""
+          query-parameter-stripping-pmb: "0"
+          query-parameter-stripping-strip-list: ""
+  re-engagement-notification:
+    description: A feature that shows the re-engagement notification if the user is inactive.
+    variables:
+      enabled:
+        description: "If true, the re-engagement notification is shown to the inactive user."
+        type: Boolean
+        default: false
+      type:
+        description: The type of re-engagement notification that is shown to the inactive user.
+        type: Int
+        default: 0
+  search-extra-params:
+    description: A feature that provides additional args for search.
+    variables:
+      channel-id:
+        description: The channel Id param name with arg.
+        type: "Map<String, String>"
+        default: {}
+      enabled:
+        description: "If true, the feature is active."
+        type: Boolean
+        default: false
+      feature-enabler:
+        description: "The feature enabler param name with arg, NOTE this map could be empty."
+        type: "Map<String, String>"
+        default: {}
+      search-engine:
+        description: The search engine name.
+        type: String
+        default: ""
+  search-term-groups:
+    description: A feature allowing the grouping of URLs around the search term that it came from.
+    variables:
+      enabled:
+        description: "If true, the feature shows up on the homescreen and on the new tab screen."
+        type: Boolean
+        default: true
+  shopping-experience:
+    description: A feature that shows product review quality information.
+    variables:
+      enabled:
+        description: "if true, the shopping experience feature is shown to the user."
+        type: Boolean
+        default: true
+      product-recommendations:
+        description: "if true, recommended products feature is enabled to be shown to the user based on their preference."
+        type: Boolean
+        default: true
+  splash-screen:
+    description: "A feature that extends splash screen duration, allowing additional data fetching time for the app's initial run."
+    variables:
+      enabled:
+        description: "If true, the feature is active."
+        type: Boolean
+        default: false
+      maximum_duration_ms:
+        description: The maximum amount of time in milliseconds the splashscreen will be visible while waiting for initialization calls to complete.
+        type: Int
+        default: 0
+  toolbar:
+    description: The searchbar/awesomebar that user uses to search.
+    variables:
+      toolbar-position-top:
+        description: "If true, toolbar appears at top of the screen."
+        type: Boolean
+        default: false
+  unified-search:
+    description: A feature allowing user to easily search for specified results directly in the search bar.
+    variables:
+      enabled:
+        description: "If true, the feature shows up in the search bar."
+        type: Boolean
+        default: true
+enums:
+  ControlMessageBehavior:
+    description: An enum to influence what should be displayed when a control message is selected.
+    variants:
+      show-next-message:
+        description: The next eligible message should be shown.
+      show-none:
+        description: The surface should show no message.
+  CookieBannersSection:
+    description: The identifiers for the sections of the MR 2022.
+    variants:
+      feature-setting-detect-only:
+        description: "An integer either 0 or 1 indicating if cookie banner detect only mode should be enabled or disabled. 0 for setting to be disabled, and 1 for enabling the setting."
+      feature-setting-global-rules:
+        description: "An integer either 0 or 1 indicating if cookie banner global rules should be enabled or disabled. 0 for setting to be disabled, and 1 for enabling the setting."
+      feature-setting-global-rules-sub-frames:
+        description: "An integer either 0 or 1 indicating if cookie banner global rules sub-frames should be enabled or disabled. 0 for setting to be disabled, and 1 for enabling the setting."
+      feature-setting-value:
+        description: "An integer either 0 or 1 indicating if cookie banner setting should be enabled or disabled, 0 for setting the value to disabled, 1  for enabling the setting with the value reject_all."
+      feature-setting-value-pbm:
+        description: "An integer either 0 or 1 indicating if cookie banner setting should be enabled or disabled, 0 for setting the value to disabled, 1  for enabling the setting with the value reject_all."
+      feature-ui:
+        description: "An integer either 0 or 1 indicating if the UI for cookie banner handling should be visible, 0 to hide the UI and 1 to show the UI. The actual UI is composed by cookie banner section in the settings page, the toolbar section and the re-engagement dialog."
+  HomeScreenSection:
+    description: The identifiers for the sections of the homescreen.
+    variants:
+      jump-back-in:
+        description: The tabs the user was looking immediately before being interrupted.
+      pocket:
+        description: The pocket section. This should only be available in the US.
+      pocket-sponsored-stories:
+        description: Subsection of the Pocket homescreen section which shows sponsored stories.
+      recent-explorations:
+        description: The tab groups
+      recently-saved:
+        description: The sites the user has bookmarked recently.
+      top-sites:
+        description: The frecency and pinned sites.
+  MR2022Section:
+    description: The identifiers for the sections of the MR 2022.
+    variants:
+      home-onboarding-dialog-existing-users:
+        description: Home onboarding dialog for upgraded users.
+      jump-back-in-cfr:
+        description: Jump back-in onboarding message.
+      sync-cfr:
+        description: CFR for the first time you see a synced tab on the home screen.
+      tcp-cfr:
+        description: CFR for the first time you use the browse with Total Cookie Protection on the browser screen.
+      tcp-feature:
+        description: Controls the Total Cookie Protection feature.
+      wallpapers-selection-tool:
+        description: Wallpapers selection dialog tool for the home screen.
+  OnboardingCardType:
+    description: An enum to describe a type of card.
+    variants:
+      add-search-widget:
+        description: Allows user to add search widget to homescreen.
+      default-browser:
+        description: Allows user to set Firefox as the default browser.
+      notification-permission:
+        description: Allows user to enable notification permission.
+      sync-sign-in:
+        description: Allows user to sync with a Firefox account.
+  OnboardingPanel:
+    description: The types of onboarding panels in the onboarding page
+    variants:
+      privacy-notice:
+        description: The onboarding panel where users can tap to view our privacy notice.
+      sync:
+        description: The onboarding panel where users can sign in to sync
+      tcp:
+        description: The onboarding panel where users can choose their total cookie protection settings
+      themes:
+        description: The themes onboarding panel where users pick themes
+      toolbar-placement:
+        description: The onboarding panel where users choose their toolbar placement (bottom or top)
+  QueryParameterStrippingSection:
+    description: The identifiers for the options for the Query Parameter Stripping feature.
+    variants:
+      query-parameter-stripping:
+        description: "An integer either 0 or 1 indicating if query parameter stripping should be enabled or disabled in normal mode. 0 for setting to be disabled, and 1 for enabling the setting."
+      query-parameter-stripping-allow-list:
+        description: An string separated by commas indicating the sites where should from query stripping should be exempted.
+      query-parameter-stripping-pmb:
+        description: "An integer either 0 or 1 indicating if query parameter stripping should be enabled or disabled in private mode. 0 for setting to be disabled, and 1 for enabling the setting."
+      query-parameter-stripping-strip-list:
+        description: An string separated by commas indicating the list of query params to be stripped from URIs. This list will be merged with records coming from RemoteSettings.
+objects:
+  MessageData:
+    description: "An object to describe a message. It uses human readable strings to describe the triggers, action and style of the message as well as the text of the message and call to action.\n"
+    fields:
+      action:
+        description: "A URL of a page or a deeplink. This may have substitution variables in.\n"
+        type: Text
+        default: ""
+      button-label:
+        description: "The text on the button. If no text is present, the whole message is clickable.\n"
+        type: Option<Text>
+        default: ~
+      experiment:
+        description: The slug of the experiment that this message came from.
+        type: Option<String>
+        default: ~
+      is-control:
+        description: "Indicates if this message is the control message, if true shouldn't be displayed"
+        type: Boolean
+        default: false
+      style:
+        description: "The style as described in a `StyleData` from the styles table.\n"
+        type: String
+        default: DEFAULT
+      surface:
+        description: The surface identifier for this message.
+        type: String
+        default: homescreen
+      text:
+        description: The message text displayed to the user
+        type: Text
+        default: ""
+      title:
+        description: The title text displayed to the user
+        type: Option<Text>
+        default: ~
+      trigger:
+        description: "A list of strings corresponding to targeting expressions. The message will be shown if all expressions `true`.\n"
+        type: List<String>
+        default: []
+  NotificationConfig:
+    description: Attributes controlling the global configuration of notification messages.
+    fields:
+      refresh-interval:
+        description: "How often, in minutes, the notification message worker will wake up and check for new messages.\n"
+        type: Int
+        default: 240
+  OnboardingCardData:
+    description: An object to describe a user facing onboarding card.
+    fields:
+      body:
+        description: The message text displayed to the user. May contain linkable text.
+        type: Text
+        default: ""
+      card-type:
+        description: The type of the card.
+        type: OnboardingCardType
+        default: default-browser
+      disqualifiers:
+        description: "A list of strings corresponding to targeting expressions. The card will not be shown if any expression is `true`.\n"
+        type: List<String>
+        default:
+          - NEVER
+      enabled:
+        description: "If true, this card is shown to the user."
+        type: Boolean
+        default: true
+      image-res:
+        description: The resource id of the image to be displayed.
+        type: Image
+        default: ic_onboarding_welcome
+      link-text:
+        description: "The text to link from the body text. This should match the linkable text from the body text exactly. e.g. body: This is a policy link\n     link-text: policy link\n"
+        type: Option<Text>
+        default: ~
+      ordering:
+        description: Used to sequence the cards.
+        type: Int
+        default: 0
+      prerequisites:
+        description: "A list of strings corresponding to targeting expressions. The card will be shown if all expressions are `true` and if no expressions in the `disqualifiers` table are true, or if the `disqualifiers` table is empty.\n"
+        type: List<String>
+        default:
+          - ALWAYS
+      primary-button-label:
+        description: The text to display on the primary button.
+        type: Text
+        default: ""
+      secondary-button-label:
+        description: The text to display on the secondary button.
+        type: Text
+        default: ""
+      title:
+        description: The title text displayed to the user.
+        type: Text
+        default: ""
+  StyleData:
+    description: "A group of properties (predominantly visual) to describe the style of the message.\n"
+    fields:
+      max-display-count:
+        description: "How many sessions will this message be shown to the user before it is expired.\n"
+        type: Int
+        default: 5
+      priority:
+        description: "The importance of this message. 0 is not very important, 100 is very important.\n"
+        type: Int
+        default: 50

--- a/experimenter/experimenter/features/manifests/fenix/v121.0.0/experimenter.yaml
+++ b/experimenter/experimenter/features/manifests/fenix/v121.0.0/experimenter.yaml
@@ -1,0 +1,250 @@
+---
+cookie-banners:
+  description: Features for cookie banner handling.
+  hasExposure: true
+  exposureDescription: ""
+  variables:
+    sections-enabled:
+      type: json
+      description: This property provides a lookup table of whether or not the given section should be enabled.
+extensions-process:
+  description: A feature to rollout the extensions process.
+  hasExposure: true
+  exposureDescription: ""
+  variables:
+    enabled:
+      type: boolean
+      description: "If true, the extensions process is enabled."
+fx-suggest:
+  description: A feature that provides Firefox Suggest search suggestions.
+  hasExposure: true
+  exposureDescription: ""
+  variables:
+    enabled:
+      type: boolean
+      description: "Whether the feature is enabled. When Firefox Suggest is enabled, Firefox will download and store new search suggestions in the background, and show additional Search settings to control which suggestions appear in the awesomebar. When Firefox Suggest is disabled, Firefox will not download new suggestions, and hide the additional Search settings.\n"
+glean:
+  description: A feature that provides server-side configurations for Glean metrics (aka Server Knobs).
+  hasExposure: true
+  exposureDescription: ""
+  variables:
+    enable-event-timestamps:
+      type: boolean
+      description: Enables precise event timestamps for Glean events
+    metrics-enabled:
+      type: json
+      description: "A map of metric base-identifiers to booleans representing the state of the 'enabled' flag for that metric."
+growth-data:
+  description: A feature measuring campaign growth data
+  hasExposure: true
+  exposureDescription: ""
+  variables:
+    enabled:
+      type: boolean
+      description: "If true, the feature is active"
+homescreen:
+  description: The homescreen that the user goes to when they press home or new tab.
+  hasExposure: true
+  exposureDescription: ""
+  variables:
+    sections-enabled:
+      type: json
+      description: "This property provides a lookup table of whether or not the given section should be enabled. If the section is enabled, it should be toggleable in the settings screen, and on by default."
+juno-onboarding:
+  description: A feature that shows juno onboarding flow.
+  hasExposure: true
+  exposureDescription: ""
+  variables:
+    cards:
+      type: json
+      description: Collection of user facing onboarding cards.
+    conditions:
+      type: json
+      description: "A collection of out the box conditional expressions to be used in determining whether a card should show or not. Each entry maps to a valid JEXL expression.\n"
+messaging:
+  description: "The in-app messaging system.\n"
+  hasExposure: true
+  exposureDescription: ""
+  variables:
+    actions:
+      type: json
+      description: A growable map of action URLs.
+    message-under-experiment:
+      type: string
+      description: "Deprecated in favor of `MessageData#experiment`. This will be removed in future releases."
+    messages:
+      type: json
+      description: A growable collection of messages
+    notification-config:
+      type: json
+      description: Configuration of the notification worker for all notification messages.
+    on-control:
+      type: string
+      description: What should be displayed when a control message is selected.
+      enum:
+        - show-next-message
+        - show-none
+    styles:
+      type: json
+      description: "A map of styles to configure message appearance.\n"
+    triggers:
+      type: json
+      description: "A collection of out the box trigger expressions. Each entry maps to a valid JEXL expression.\n"
+mr2022:
+  description: Features for MR 2022.
+  hasExposure: true
+  exposureDescription: ""
+  variables:
+    sections-enabled:
+      type: json
+      description: This property provides a lookup table of whether or not the given section should be enabled.
+nimbus-system:
+  description: "Configuration of the Nimbus System in Android.\n"
+  hasExposure: true
+  exposureDescription: ""
+  variables:
+    refresh-interval-foreground:
+      type: int
+      description: "The minimum interval in minutes between fetching experiment \nrecipes in the foreground.\n"
+nimbus-validation:
+  description: A feature that does not correspond to an application feature suitable for showing that Nimbus is working. This should never be used in production.
+  hasExposure: true
+  exposureDescription: ""
+  variables:
+    settings-icon:
+      type: string
+      description: The drawable displayed in the app menu for Settings
+    settings-punctuation:
+      type: string
+      description: The emoji displayed in the Settings screen title.
+    settings-title:
+      type: string
+      description: The title of displayed in the Settings screen and app menu.
+onboarding:
+  description: "A feature that configures the new user onboarding page. Note that onboarding is a **first run** feature, and should only be modified by first run experiments."
+  hasExposure: true
+  exposureDescription: ""
+  variables:
+    order:
+      type: json
+      description: Determines the order of the onboarding page panels
+pdfjs:
+  description: PDF.js features
+  hasExposure: true
+  exposureDescription: ""
+  variables:
+    download-button:
+      type: boolean
+      description: Download button
+    open-in-app-button:
+      type: boolean
+      description: Open in app button
+pre-permission-notification-prompt:
+  description: A feature that shows the pre-permission notification prompt.
+  hasExposure: true
+  exposureDescription: ""
+  variables:
+    enabled:
+      type: boolean
+      description: "if true, the pre-permission notification prompt is shown to the user."
+print:
+  description: A feature for printing from the share or browser menu.
+  hasExposure: true
+  exposureDescription: ""
+  variables:
+    browser-print-enabled:
+      type: boolean
+      description: "If true, a print button from the browser menu is available."
+    share-print-enabled:
+      type: boolean
+      description: "If true, a print button from the share menu is available."
+private-browsing:
+  description: Private Browsing Mode
+  hasExposure: true
+  exposureDescription: ""
+  variables:
+    felt-privacy-enabled:
+      type: boolean
+      description: "if true, enable felt privacy related UI"
+query-parameter-stripping:
+  description: Features for query parameter stripping.
+  hasExposure: true
+  exposureDescription: ""
+  variables:
+    sections-enabled:
+      type: json
+      description: This property provides a lookup table of whether or not the given section should be enabled.
+re-engagement-notification:
+  description: A feature that shows the re-engagement notification if the user is inactive.
+  hasExposure: true
+  exposureDescription: ""
+  variables:
+    enabled:
+      type: boolean
+      description: "If true, the re-engagement notification is shown to the inactive user."
+    type:
+      type: int
+      description: The type of re-engagement notification that is shown to the inactive user.
+search-extra-params:
+  description: A feature that provides additional args for search.
+  hasExposure: true
+  exposureDescription: ""
+  variables:
+    channel-id:
+      type: json
+      description: The channel Id param name with arg.
+    enabled:
+      type: boolean
+      description: "If true, the feature is active."
+    feature-enabler:
+      type: json
+      description: "The feature enabler param name with arg, NOTE this map could be empty."
+    search-engine:
+      type: string
+      description: The search engine name.
+search-term-groups:
+  description: A feature allowing the grouping of URLs around the search term that it came from.
+  hasExposure: true
+  exposureDescription: ""
+  variables:
+    enabled:
+      type: boolean
+      description: "If true, the feature shows up on the homescreen and on the new tab screen."
+shopping-experience:
+  description: A feature that shows product review quality information.
+  hasExposure: true
+  exposureDescription: ""
+  variables:
+    enabled:
+      type: boolean
+      description: "if true, the shopping experience feature is shown to the user."
+    product-recommendations:
+      type: boolean
+      description: "if true, recommended products feature is enabled to be shown to the user based on their preference."
+splash-screen:
+  description: "A feature that extends splash screen duration, allowing additional data fetching time for the app's initial run."
+  hasExposure: true
+  exposureDescription: ""
+  variables:
+    enabled:
+      type: boolean
+      description: "If true, the feature is active."
+    maximum_duration_ms:
+      type: int
+      description: The maximum amount of time in milliseconds the splashscreen will be visible while waiting for initialization calls to complete.
+toolbar:
+  description: The searchbar/awesomebar that user uses to search.
+  hasExposure: true
+  exposureDescription: ""
+  variables:
+    toolbar-position-top:
+      type: boolean
+      description: "If true, toolbar appears at top of the screen."
+unified-search:
+  description: A feature allowing user to easily search for specified results directly in the search bar.
+  hasExposure: true
+  exposureDescription: ""
+  variables:
+    enabled:
+      type: boolean
+      description: "If true, the feature shows up in the search bar."

--- a/experimenter/experimenter/features/manifests/fenix/v121.0.0/nightly.fml.yaml
+++ b/experimenter/experimenter/features/manifests/fenix/v121.0.0/nightly.fml.yaml
@@ -1,0 +1,594 @@
+---
+version: 1.0.0
+about:
+  description: Nimbus Feature Manifest for Fenix (Firefox Android)
+channels:
+  - nightly
+features:
+  cookie-banners:
+    description: Features for cookie banner handling.
+    variables:
+      sections-enabled:
+        description: This property provides a lookup table of whether or not the given section should be enabled.
+        type: "Map<CookieBannersSection, Int>"
+        default:
+          feature-setting-detect-only: 0
+          feature-setting-global-rules: 0
+          feature-setting-global-rules-sub-frames: 0
+          feature-setting-value: 0
+          feature-setting-value-pbm: 1
+          feature-ui: 1
+  extensions-process:
+    description: A feature to rollout the extensions process.
+    variables:
+      enabled:
+        description: "If true, the extensions process is enabled."
+        type: Boolean
+        default: true
+  fx-suggest:
+    description: A feature that provides Firefox Suggest search suggestions.
+    variables:
+      enabled:
+        description: "Whether the feature is enabled. When Firefox Suggest is enabled, Firefox will download and store new search suggestions in the background, and show additional Search settings to control which suggestions appear in the awesomebar. When Firefox Suggest is disabled, Firefox will not download new suggestions, and hide the additional Search settings.\n"
+        type: Boolean
+        default: true
+  glean:
+    description: A feature that provides server-side configurations for Glean metrics (aka Server Knobs).
+    variables:
+      enable-event-timestamps:
+        description: Enables precise event timestamps for Glean events
+        type: Boolean
+        default: false
+      metrics-enabled:
+        description: "A map of metric base-identifiers to booleans representing the state of the 'enabled' flag for that metric."
+        type: "Map<String, Boolean>"
+        default: {}
+  growth-data:
+    description: A feature measuring campaign growth data
+    variables:
+      enabled:
+        description: "If true, the feature is active"
+        type: Boolean
+        default: false
+  homescreen:
+    description: The homescreen that the user goes to when they press home or new tab.
+    variables:
+      sections-enabled:
+        description: "This property provides a lookup table of whether or not the given section should be enabled. If the section is enabled, it should be toggleable in the settings screen, and on by default."
+        type: "Map<HomeScreenSection, Boolean>"
+        default:
+          jump-back-in: true
+          pocket: true
+          pocket-sponsored-stories: true
+          recent-explorations: true
+          recently-saved: true
+          top-sites: true
+  juno-onboarding:
+    description: A feature that shows juno onboarding flow.
+    variables:
+      cards:
+        description: Collection of user facing onboarding cards.
+        type: "Map<String, OnboardingCardData>"
+        default:
+          add-search-widget:
+            body: juno_onboarding_add_search_widget_description
+            card-type: add-search-widget
+            enabled: false
+            image-res: ic_onboarding_search_widget
+            ordering: 15
+            primary-button-label: juno_onboarding_add_search_widget_positive_button
+            secondary-button-label: juno_onboarding_add_search_widget_negative_button
+            title: juno_onboarding_add_search_widget_title
+          default-browser:
+            body: juno_onboarding_default_browser_description_nimbus_2
+            card-type: default-browser
+            image-res: ic_onboarding_welcome
+            link-text: juno_onboarding_default_browser_description_link_text
+            ordering: 10
+            primary-button-label: juno_onboarding_default_browser_positive_button
+            secondary-button-label: juno_onboarding_default_browser_negative_button
+            title: juno_onboarding_default_browser_title_nimbus_2
+          notification-permission:
+            body: juno_onboarding_enable_notifications_description_nimbus_2
+            card-type: notification-permission
+            image-res: ic_notification_permission
+            ordering: 30
+            primary-button-label: juno_onboarding_enable_notifications_positive_button
+            secondary-button-label: juno_onboarding_enable_notifications_negative_button
+            title: juno_onboarding_enable_notifications_title_nimbus_2
+          sync-sign-in:
+            body: juno_onboarding_sign_in_description_2
+            card-type: sync-sign-in
+            image-res: ic_onboarding_sync
+            ordering: 20
+            primary-button-label: juno_onboarding_sign_in_positive_button
+            secondary-button-label: juno_onboarding_sign_in_negative_button
+            title: juno_onboarding_sign_in_title_2
+      conditions:
+        description: "A collection of out the box conditional expressions to be used in determining whether a card should show or not. Each entry maps to a valid JEXL expression.\n"
+        type: "Map<String, String>"
+        default:
+          ALWAYS: "true"
+          NEVER: "false"
+  messaging:
+    description: "The in-app messaging system.\n"
+    variables:
+      actions:
+        description: A growable map of action URLs.
+        type: "Map<String, String>"
+        default:
+          ENABLE_PRIVATE_BROWSING: "://enable_private_browsing"
+          INSTALL_SEARCH_WIDGET: "://install_search_widget"
+          MAKE_DEFAULT_BROWSER: "://make_default_browser"
+          OPEN_SETTINGS: "://settings"
+          OPEN_SETTINGS_ACCESSIBILITY: "://settings_accessibility"
+          OPEN_SETTINGS_ADDON_MANAGER: "://settings_addon_manager"
+          OPEN_SETTINGS_DELETE_BROWSING_DATA: "://settings_delete_browsing_data"
+          OPEN_SETTINGS_LOGINS: "://settings_logins"
+          OPEN_SETTINGS_NOTIFICATIONS: "://settings_notifications"
+          OPEN_SETTINGS_PRIVACY: "://settings_privacy"
+          OPEN_SETTINGS_SEARCH_ENGINE: "://settings_search_engine"
+          OPEN_SETTINGS_TRACKING_PROTECTION: "://settings_tracking_protection"
+          OPEN_SETTINGS_WALLPAPERS: "://settings_wallpapers"
+          TURN_ON_SYNC: "://turn_on_sync"
+          VIEW_BOOKMARKS: "://urls_bookmarks"
+          VIEW_COLLECTIONS: "://home_collections"
+          VIEW_HISTORY: "://urls_history"
+          VIEW_HOMESCREEN: "://home"
+      message-under-experiment:
+        description: "Deprecated in favor of `MessageData#experiment`. This will be removed in future releases."
+        type: Option<String>
+        default: ~
+      messages:
+        description: A growable collection of messages
+        type: "Map<String, MessageData>"
+        default:
+          default-browser:
+            action: MAKE_DEFAULT_BROWSER
+            button-label: preferences_set_as_default_browser
+            style: PERSISTENT
+            surface: homescreen
+            text: default_browser_experiment_card_text
+            trigger:
+              - I_AM_NOT_DEFAULT_BROWSER
+              - USER_ESTABLISHED_INSTALL
+          default-browser-notification:
+            action: MAKE_DEFAULT_BROWSER
+            style: NOTIFICATION
+            surface: notification
+            text: nimbus_notification_default_browser_text
+            title: nimbus_notification_default_browser_title
+            trigger:
+              - I_AM_NOT_DEFAULT_BROWSER
+              - DAY_3_AFTER_INSTALL
+      notification-config:
+        description: Configuration of the notification worker for all notification messages.
+        type: NotificationConfig
+        default: {}
+      on-control:
+        description: What should be displayed when a control message is selected.
+        type: ControlMessageBehavior
+        default: show-next-message
+      styles:
+        description: "A map of styles to configure message appearance.\n"
+        type: "Map<String, StyleData>"
+        default:
+          DEFAULT:
+            max-display-count: 5
+            priority: 50
+          NOTIFICATION:
+            max-display-count: 1
+            priority: 50
+          PERSISTENT:
+            max-display-count: 20
+            priority: 50
+          SURVEY:
+            max-display-count: 1
+            priority: 55
+          URGENT:
+            max-display-count: 10
+            priority: 100
+          WARNING:
+            max-display-count: 10
+            priority: 60
+      triggers:
+        description: "A collection of out the box trigger expressions. Each entry maps to a valid JEXL expression.\n"
+        type: "Map<String, String>"
+        default:
+          ALWAYS: "true"
+          DAY_1_AFTER_INSTALL: days_since_install == 1
+          DAY_2_AFTER_INSTALL: days_since_install == 2
+          DAY_3_AFTER_INSTALL: days_since_install == 3
+          DAY_4_AFTER_INSTALL: days_since_install == 4
+          DAY_5_AFTER_INSTALL: days_since_install == 5
+          DEVICE_ANDROID: "os == 'Android'"
+          DEVICE_IOS: "os == 'iOS'"
+          FUNNEL_ORGANIC: "adjust_campaign == ''"
+          FUNNEL_PAID: "adjust_campaign != ''"
+          FXA_NOT_SIGNED_IN: "'sync_auth.sign_in'|eventLastSeen('Years', 0) > 4"
+          FXA_SIGNED_IN: "'sync_auth.sign_in'|eventLastSeen('Years', 0) <= 4"
+          INACTIVE_1_DAY: "'app_launched'|eventLastSeen('Hours') >= 24"
+          INACTIVE_2_DAYS: "'app_launched'|eventLastSeen('Days', 0) >= 2"
+          INACTIVE_3_DAYS: "'app_launched'|eventLastSeen('Days', 0) >= 3"
+          INACTIVE_4_DAYS: "'app_launched'|eventLastSeen('Days', 0) >= 4"
+          INACTIVE_5_DAYS: "'app_launched'|eventLastSeen('Days', 0) >= 5"
+          I_AM_DEFAULT_BROWSER: is_default_browser
+          I_AM_NOT_DEFAULT_BROWSER: is_default_browser == false
+          LAUNCHED_ONCE_THIS_WEEK: "'app_launched'|eventSum('Days', 7) == 1"
+          MORE_THAN_24H_SINCE_INSTALLED_OR_UPDATED: days_since_update >= 1
+          NEVER: "false"
+          USER_CASUAL: "'app_launched'|eventCountNonZero('Days', 28) >= 7 && 'app_launched'|eventCountNonZero('Days', 28) < 14"
+          USER_CORE_ACTIVE: "'app_launched'|eventCountNonZero('Days', 28) >= 21"
+          USER_DE_SPEAKER: "'de' in locale"
+          USER_EN_SPEAKER: "'en' in locale"
+          USER_ESTABLISHED_INSTALL: number_of_app_launches >=4
+          USER_ES_SPEAKER: "'es' in locale"
+          USER_FR_SPEAKER: "'fr' in locale"
+          USER_INFREQUENT: "'app_launched'|eventCountNonZero('Days', 28) >= 1 && 'app_launched'|eventCountNonZero('Days', 28) < 7"
+          USER_RECENTLY_INSTALLED: days_since_install < 7
+          USER_RECENTLY_UPDATED: days_since_update < 7 && days_since_install != days_since_update
+          USER_REGULAR: "'app_launched'|eventCountNonZero('Days', 28) >= 14 && 'app_launched'|eventCountNonZero('Days', 28) < 21"
+          USER_TIER_ONE_COUNTRY: "('US' in locale || 'GB' in locale || 'CA' in locale || 'DE' in locale || 'FR' in locale)"
+    allow-coenrollment: true
+  mr2022:
+    description: Features for MR 2022.
+    variables:
+      sections-enabled:
+        description: This property provides a lookup table of whether or not the given section should be enabled.
+        type: "Map<MR2022Section, Boolean>"
+        default:
+          home-onboarding-dialog-existing-users: true
+          jump-back-in-cfr: true
+          sync-cfr: true
+          tcp-cfr: true
+          tcp-feature: true
+          wallpapers-selection-tool: true
+  nimbus-system:
+    description: "Configuration of the Nimbus System in Android.\n"
+    variables:
+      refresh-interval-foreground:
+        description: "The minimum interval in minutes between fetching experiment \nrecipes in the foreground.\n"
+        type: Int
+        default: 60
+  nimbus-validation:
+    description: A feature that does not correspond to an application feature suitable for showing that Nimbus is working. This should never be used in production.
+    variables:
+      settings-icon:
+        description: The drawable displayed in the app menu for Settings
+        type: String
+        default: mozac_ic_settings
+      settings-punctuation:
+        description: The emoji displayed in the Settings screen title.
+        type: String
+        default: ""
+      settings-title:
+        description: The title of displayed in the Settings screen and app menu.
+        type: Text
+        default: browser_menu_settings
+  onboarding:
+    description: "A feature that configures the new user onboarding page. Note that onboarding is a **first run** feature, and should only be modified by first run experiments."
+    variables:
+      order:
+        description: Determines the order of the onboarding page panels
+        type: List<OnboardingPanel>
+        default:
+          - themes
+          - toolbar-placement
+          - sync
+          - tcp
+          - privacy-notice
+  pdfjs:
+    description: PDF.js features
+    variables:
+      download-button:
+        description: Download button
+        type: Boolean
+        default: true
+      open-in-app-button:
+        description: Open in app button
+        type: Boolean
+        default: true
+  pre-permission-notification-prompt:
+    description: A feature that shows the pre-permission notification prompt.
+    variables:
+      enabled:
+        description: "if true, the pre-permission notification prompt is shown to the user."
+        type: Boolean
+        default: false
+  print:
+    description: A feature for printing from the share or browser menu.
+    variables:
+      browser-print-enabled:
+        description: "If true, a print button from the browser menu is available."
+        type: Boolean
+        default: true
+      share-print-enabled:
+        description: "If true, a print button from the share menu is available."
+        type: Boolean
+        default: true
+  private-browsing:
+    description: Private Browsing Mode
+    variables:
+      felt-privacy-enabled:
+        description: "if true, enable felt privacy related UI"
+        type: Boolean
+        default: false
+  query-parameter-stripping:
+    description: Features for query parameter stripping.
+    variables:
+      sections-enabled:
+        description: This property provides a lookup table of whether or not the given section should be enabled.
+        type: "Map<QueryParameterStrippingSection, String>"
+        default:
+          query-parameter-stripping: "0"
+          query-parameter-stripping-allow-list: ""
+          query-parameter-stripping-pmb: "0"
+          query-parameter-stripping-strip-list: ""
+  re-engagement-notification:
+    description: A feature that shows the re-engagement notification if the user is inactive.
+    variables:
+      enabled:
+        description: "If true, the re-engagement notification is shown to the inactive user."
+        type: Boolean
+        default: false
+      type:
+        description: The type of re-engagement notification that is shown to the inactive user.
+        type: Int
+        default: 0
+  search-extra-params:
+    description: A feature that provides additional args for search.
+    variables:
+      channel-id:
+        description: The channel Id param name with arg.
+        type: "Map<String, String>"
+        default: {}
+      enabled:
+        description: "If true, the feature is active."
+        type: Boolean
+        default: false
+      feature-enabler:
+        description: "The feature enabler param name with arg, NOTE this map could be empty."
+        type: "Map<String, String>"
+        default: {}
+      search-engine:
+        description: The search engine name.
+        type: String
+        default: ""
+  search-term-groups:
+    description: A feature allowing the grouping of URLs around the search term that it came from.
+    variables:
+      enabled:
+        description: "If true, the feature shows up on the homescreen and on the new tab screen."
+        type: Boolean
+        default: true
+  shopping-experience:
+    description: A feature that shows product review quality information.
+    variables:
+      enabled:
+        description: "if true, the shopping experience feature is shown to the user."
+        type: Boolean
+        default: false
+      product-recommendations:
+        description: "if true, recommended products feature is enabled to be shown to the user based on their preference."
+        type: Boolean
+        default: false
+  splash-screen:
+    description: "A feature that extends splash screen duration, allowing additional data fetching time for the app's initial run."
+    variables:
+      enabled:
+        description: "If true, the feature is active."
+        type: Boolean
+        default: false
+      maximum_duration_ms:
+        description: The maximum amount of time in milliseconds the splashscreen will be visible while waiting for initialization calls to complete.
+        type: Int
+        default: 0
+  toolbar:
+    description: The searchbar/awesomebar that user uses to search.
+    variables:
+      toolbar-position-top:
+        description: "If true, toolbar appears at top of the screen."
+        type: Boolean
+        default: false
+  unified-search:
+    description: A feature allowing user to easily search for specified results directly in the search bar.
+    variables:
+      enabled:
+        description: "If true, the feature shows up in the search bar."
+        type: Boolean
+        default: true
+enums:
+  ControlMessageBehavior:
+    description: An enum to influence what should be displayed when a control message is selected.
+    variants:
+      show-next-message:
+        description: The next eligible message should be shown.
+      show-none:
+        description: The surface should show no message.
+  CookieBannersSection:
+    description: The identifiers for the sections of the MR 2022.
+    variants:
+      feature-setting-detect-only:
+        description: "An integer either 0 or 1 indicating if cookie banner detect only mode should be enabled or disabled. 0 for setting to be disabled, and 1 for enabling the setting."
+      feature-setting-global-rules:
+        description: "An integer either 0 or 1 indicating if cookie banner global rules should be enabled or disabled. 0 for setting to be disabled, and 1 for enabling the setting."
+      feature-setting-global-rules-sub-frames:
+        description: "An integer either 0 or 1 indicating if cookie banner global rules sub-frames should be enabled or disabled. 0 for setting to be disabled, and 1 for enabling the setting."
+      feature-setting-value:
+        description: "An integer either 0 or 1 indicating if cookie banner setting should be enabled or disabled, 0 for setting the value to disabled, 1  for enabling the setting with the value reject_all."
+      feature-setting-value-pbm:
+        description: "An integer either 0 or 1 indicating if cookie banner setting should be enabled or disabled, 0 for setting the value to disabled, 1  for enabling the setting with the value reject_all."
+      feature-ui:
+        description: "An integer either 0 or 1 indicating if the UI for cookie banner handling should be visible, 0 to hide the UI and 1 to show the UI. The actual UI is composed by cookie banner section in the settings page, the toolbar section and the re-engagement dialog."
+  HomeScreenSection:
+    description: The identifiers for the sections of the homescreen.
+    variants:
+      jump-back-in:
+        description: The tabs the user was looking immediately before being interrupted.
+      pocket:
+        description: The pocket section. This should only be available in the US.
+      pocket-sponsored-stories:
+        description: Subsection of the Pocket homescreen section which shows sponsored stories.
+      recent-explorations:
+        description: The tab groups
+      recently-saved:
+        description: The sites the user has bookmarked recently.
+      top-sites:
+        description: The frecency and pinned sites.
+  MR2022Section:
+    description: The identifiers for the sections of the MR 2022.
+    variants:
+      home-onboarding-dialog-existing-users:
+        description: Home onboarding dialog for upgraded users.
+      jump-back-in-cfr:
+        description: Jump back-in onboarding message.
+      sync-cfr:
+        description: CFR for the first time you see a synced tab on the home screen.
+      tcp-cfr:
+        description: CFR for the first time you use the browse with Total Cookie Protection on the browser screen.
+      tcp-feature:
+        description: Controls the Total Cookie Protection feature.
+      wallpapers-selection-tool:
+        description: Wallpapers selection dialog tool for the home screen.
+  OnboardingCardType:
+    description: An enum to describe a type of card.
+    variants:
+      add-search-widget:
+        description: Allows user to add search widget to homescreen.
+      default-browser:
+        description: Allows user to set Firefox as the default browser.
+      notification-permission:
+        description: Allows user to enable notification permission.
+      sync-sign-in:
+        description: Allows user to sync with a Firefox account.
+  OnboardingPanel:
+    description: The types of onboarding panels in the onboarding page
+    variants:
+      privacy-notice:
+        description: The onboarding panel where users can tap to view our privacy notice.
+      sync:
+        description: The onboarding panel where users can sign in to sync
+      tcp:
+        description: The onboarding panel where users can choose their total cookie protection settings
+      themes:
+        description: The themes onboarding panel where users pick themes
+      toolbar-placement:
+        description: The onboarding panel where users choose their toolbar placement (bottom or top)
+  QueryParameterStrippingSection:
+    description: The identifiers for the options for the Query Parameter Stripping feature.
+    variants:
+      query-parameter-stripping:
+        description: "An integer either 0 or 1 indicating if query parameter stripping should be enabled or disabled in normal mode. 0 for setting to be disabled, and 1 for enabling the setting."
+      query-parameter-stripping-allow-list:
+        description: An string separated by commas indicating the sites where should from query stripping should be exempted.
+      query-parameter-stripping-pmb:
+        description: "An integer either 0 or 1 indicating if query parameter stripping should be enabled or disabled in private mode. 0 for setting to be disabled, and 1 for enabling the setting."
+      query-parameter-stripping-strip-list:
+        description: An string separated by commas indicating the list of query params to be stripped from URIs. This list will be merged with records coming from RemoteSettings.
+objects:
+  MessageData:
+    description: "An object to describe a message. It uses human readable strings to describe the triggers, action and style of the message as well as the text of the message and call to action.\n"
+    fields:
+      action:
+        description: "A URL of a page or a deeplink. This may have substitution variables in.\n"
+        type: Text
+        default: ""
+      button-label:
+        description: "The text on the button. If no text is present, the whole message is clickable.\n"
+        type: Option<Text>
+        default: ~
+      experiment:
+        description: The slug of the experiment that this message came from.
+        type: Option<String>
+        default: ~
+      is-control:
+        description: "Indicates if this message is the control message, if true shouldn't be displayed"
+        type: Boolean
+        default: false
+      style:
+        description: "The style as described in a `StyleData` from the styles table.\n"
+        type: String
+        default: DEFAULT
+      surface:
+        description: The surface identifier for this message.
+        type: String
+        default: homescreen
+      text:
+        description: The message text displayed to the user
+        type: Text
+        default: ""
+      title:
+        description: The title text displayed to the user
+        type: Option<Text>
+        default: ~
+      trigger:
+        description: "A list of strings corresponding to targeting expressions. The message will be shown if all expressions `true`.\n"
+        type: List<String>
+        default: []
+  NotificationConfig:
+    description: Attributes controlling the global configuration of notification messages.
+    fields:
+      refresh-interval:
+        description: "How often, in minutes, the notification message worker will wake up and check for new messages.\n"
+        type: Int
+        default: 240
+  OnboardingCardData:
+    description: An object to describe a user facing onboarding card.
+    fields:
+      body:
+        description: The message text displayed to the user. May contain linkable text.
+        type: Text
+        default: ""
+      card-type:
+        description: The type of the card.
+        type: OnboardingCardType
+        default: default-browser
+      disqualifiers:
+        description: "A list of strings corresponding to targeting expressions. The card will not be shown if any expression is `true`.\n"
+        type: List<String>
+        default:
+          - NEVER
+      enabled:
+        description: "If true, this card is shown to the user."
+        type: Boolean
+        default: true
+      image-res:
+        description: The resource id of the image to be displayed.
+        type: Image
+        default: ic_onboarding_welcome
+      link-text:
+        description: "The text to link from the body text. This should match the linkable text from the body text exactly. e.g. body: This is a policy link\n     link-text: policy link\n"
+        type: Option<Text>
+        default: ~
+      ordering:
+        description: Used to sequence the cards.
+        type: Int
+        default: 0
+      prerequisites:
+        description: "A list of strings corresponding to targeting expressions. The card will be shown if all expressions are `true` and if no expressions in the `disqualifiers` table are true, or if the `disqualifiers` table is empty.\n"
+        type: List<String>
+        default:
+          - ALWAYS
+      primary-button-label:
+        description: The text to display on the primary button.
+        type: Text
+        default: ""
+      secondary-button-label:
+        description: The text to display on the secondary button.
+        type: Text
+        default: ""
+      title:
+        description: The title text displayed to the user.
+        type: Text
+        default: ""
+  StyleData:
+    description: "A group of properties (predominantly visual) to describe the style of the message.\n"
+    fields:
+      max-display-count:
+        description: "How many sessions will this message be shown to the user before it is expired.\n"
+        type: Int
+        default: 5
+      priority:
+        description: "The importance of this message. 0 is not very important, 100 is very important.\n"
+        type: Int
+        default: 50

--- a/experimenter/experimenter/features/manifests/fenix/v121.0.0/release.fml.yaml
+++ b/experimenter/experimenter/features/manifests/fenix/v121.0.0/release.fml.yaml
@@ -1,0 +1,594 @@
+---
+version: 1.0.0
+about:
+  description: Nimbus Feature Manifest for Fenix (Firefox Android)
+channels:
+  - release
+features:
+  cookie-banners:
+    description: Features for cookie banner handling.
+    variables:
+      sections-enabled:
+        description: This property provides a lookup table of whether or not the given section should be enabled.
+        type: "Map<CookieBannersSection, Int>"
+        default:
+          feature-setting-detect-only: 0
+          feature-setting-global-rules: 0
+          feature-setting-global-rules-sub-frames: 0
+          feature-setting-value: 0
+          feature-setting-value-pbm: 0
+          feature-ui: 0
+  extensions-process:
+    description: A feature to rollout the extensions process.
+    variables:
+      enabled:
+        description: "If true, the extensions process is enabled."
+        type: Boolean
+        default: true
+  fx-suggest:
+    description: A feature that provides Firefox Suggest search suggestions.
+    variables:
+      enabled:
+        description: "Whether the feature is enabled. When Firefox Suggest is enabled, Firefox will download and store new search suggestions in the background, and show additional Search settings to control which suggestions appear in the awesomebar. When Firefox Suggest is disabled, Firefox will not download new suggestions, and hide the additional Search settings.\n"
+        type: Boolean
+        default: false
+  glean:
+    description: A feature that provides server-side configurations for Glean metrics (aka Server Knobs).
+    variables:
+      enable-event-timestamps:
+        description: Enables precise event timestamps for Glean events
+        type: Boolean
+        default: false
+      metrics-enabled:
+        description: "A map of metric base-identifiers to booleans representing the state of the 'enabled' flag for that metric."
+        type: "Map<String, Boolean>"
+        default: {}
+  growth-data:
+    description: A feature measuring campaign growth data
+    variables:
+      enabled:
+        description: "If true, the feature is active"
+        type: Boolean
+        default: true
+  homescreen:
+    description: The homescreen that the user goes to when they press home or new tab.
+    variables:
+      sections-enabled:
+        description: "This property provides a lookup table of whether or not the given section should be enabled. If the section is enabled, it should be toggleable in the settings screen, and on by default."
+        type: "Map<HomeScreenSection, Boolean>"
+        default:
+          jump-back-in: true
+          pocket: true
+          pocket-sponsored-stories: true
+          recent-explorations: true
+          recently-saved: true
+          top-sites: true
+  juno-onboarding:
+    description: A feature that shows juno onboarding flow.
+    variables:
+      cards:
+        description: Collection of user facing onboarding cards.
+        type: "Map<String, OnboardingCardData>"
+        default:
+          add-search-widget:
+            body: juno_onboarding_add_search_widget_description
+            card-type: add-search-widget
+            enabled: false
+            image-res: ic_onboarding_search_widget
+            ordering: 15
+            primary-button-label: juno_onboarding_add_search_widget_positive_button
+            secondary-button-label: juno_onboarding_add_search_widget_negative_button
+            title: juno_onboarding_add_search_widget_title
+          default-browser:
+            body: juno_onboarding_default_browser_description_nimbus_2
+            card-type: default-browser
+            image-res: ic_onboarding_welcome
+            link-text: juno_onboarding_default_browser_description_link_text
+            ordering: 10
+            primary-button-label: juno_onboarding_default_browser_positive_button
+            secondary-button-label: juno_onboarding_default_browser_negative_button
+            title: juno_onboarding_default_browser_title_nimbus_2
+          notification-permission:
+            body: juno_onboarding_enable_notifications_description_nimbus_2
+            card-type: notification-permission
+            image-res: ic_notification_permission
+            ordering: 30
+            primary-button-label: juno_onboarding_enable_notifications_positive_button
+            secondary-button-label: juno_onboarding_enable_notifications_negative_button
+            title: juno_onboarding_enable_notifications_title_nimbus_2
+          sync-sign-in:
+            body: juno_onboarding_sign_in_description_2
+            card-type: sync-sign-in
+            image-res: ic_onboarding_sync
+            ordering: 20
+            primary-button-label: juno_onboarding_sign_in_positive_button
+            secondary-button-label: juno_onboarding_sign_in_negative_button
+            title: juno_onboarding_sign_in_title_2
+      conditions:
+        description: "A collection of out the box conditional expressions to be used in determining whether a card should show or not. Each entry maps to a valid JEXL expression.\n"
+        type: "Map<String, String>"
+        default:
+          ALWAYS: "true"
+          NEVER: "false"
+  messaging:
+    description: "The in-app messaging system.\n"
+    variables:
+      actions:
+        description: A growable map of action URLs.
+        type: "Map<String, String>"
+        default:
+          ENABLE_PRIVATE_BROWSING: "://enable_private_browsing"
+          INSTALL_SEARCH_WIDGET: "://install_search_widget"
+          MAKE_DEFAULT_BROWSER: "://make_default_browser"
+          OPEN_SETTINGS: "://settings"
+          OPEN_SETTINGS_ACCESSIBILITY: "://settings_accessibility"
+          OPEN_SETTINGS_ADDON_MANAGER: "://settings_addon_manager"
+          OPEN_SETTINGS_DELETE_BROWSING_DATA: "://settings_delete_browsing_data"
+          OPEN_SETTINGS_LOGINS: "://settings_logins"
+          OPEN_SETTINGS_NOTIFICATIONS: "://settings_notifications"
+          OPEN_SETTINGS_PRIVACY: "://settings_privacy"
+          OPEN_SETTINGS_SEARCH_ENGINE: "://settings_search_engine"
+          OPEN_SETTINGS_TRACKING_PROTECTION: "://settings_tracking_protection"
+          OPEN_SETTINGS_WALLPAPERS: "://settings_wallpapers"
+          TURN_ON_SYNC: "://turn_on_sync"
+          VIEW_BOOKMARKS: "://urls_bookmarks"
+          VIEW_COLLECTIONS: "://home_collections"
+          VIEW_HISTORY: "://urls_history"
+          VIEW_HOMESCREEN: "://home"
+      message-under-experiment:
+        description: "Deprecated in favor of `MessageData#experiment`. This will be removed in future releases."
+        type: Option<String>
+        default: ~
+      messages:
+        description: A growable collection of messages
+        type: "Map<String, MessageData>"
+        default:
+          default-browser:
+            action: MAKE_DEFAULT_BROWSER
+            button-label: preferences_set_as_default_browser
+            style: PERSISTENT
+            surface: homescreen
+            text: default_browser_experiment_card_text
+            trigger:
+              - I_AM_NOT_DEFAULT_BROWSER
+              - USER_ESTABLISHED_INSTALL
+          default-browser-notification:
+            action: MAKE_DEFAULT_BROWSER
+            style: NOTIFICATION
+            surface: notification
+            text: nimbus_notification_default_browser_text
+            title: nimbus_notification_default_browser_title
+            trigger:
+              - I_AM_NOT_DEFAULT_BROWSER
+              - DAY_3_AFTER_INSTALL
+      notification-config:
+        description: Configuration of the notification worker for all notification messages.
+        type: NotificationConfig
+        default: {}
+      on-control:
+        description: What should be displayed when a control message is selected.
+        type: ControlMessageBehavior
+        default: show-next-message
+      styles:
+        description: "A map of styles to configure message appearance.\n"
+        type: "Map<String, StyleData>"
+        default:
+          DEFAULT:
+            max-display-count: 5
+            priority: 50
+          NOTIFICATION:
+            max-display-count: 1
+            priority: 50
+          PERSISTENT:
+            max-display-count: 20
+            priority: 50
+          SURVEY:
+            max-display-count: 1
+            priority: 55
+          URGENT:
+            max-display-count: 10
+            priority: 100
+          WARNING:
+            max-display-count: 10
+            priority: 60
+      triggers:
+        description: "A collection of out the box trigger expressions. Each entry maps to a valid JEXL expression.\n"
+        type: "Map<String, String>"
+        default:
+          ALWAYS: "true"
+          DAY_1_AFTER_INSTALL: days_since_install == 1
+          DAY_2_AFTER_INSTALL: days_since_install == 2
+          DAY_3_AFTER_INSTALL: days_since_install == 3
+          DAY_4_AFTER_INSTALL: days_since_install == 4
+          DAY_5_AFTER_INSTALL: days_since_install == 5
+          DEVICE_ANDROID: "os == 'Android'"
+          DEVICE_IOS: "os == 'iOS'"
+          FUNNEL_ORGANIC: "adjust_campaign == ''"
+          FUNNEL_PAID: "adjust_campaign != ''"
+          FXA_NOT_SIGNED_IN: "'sync_auth.sign_in'|eventLastSeen('Years', 0) > 4"
+          FXA_SIGNED_IN: "'sync_auth.sign_in'|eventLastSeen('Years', 0) <= 4"
+          INACTIVE_1_DAY: "'app_launched'|eventLastSeen('Hours') >= 24"
+          INACTIVE_2_DAYS: "'app_launched'|eventLastSeen('Days', 0) >= 2"
+          INACTIVE_3_DAYS: "'app_launched'|eventLastSeen('Days', 0) >= 3"
+          INACTIVE_4_DAYS: "'app_launched'|eventLastSeen('Days', 0) >= 4"
+          INACTIVE_5_DAYS: "'app_launched'|eventLastSeen('Days', 0) >= 5"
+          I_AM_DEFAULT_BROWSER: is_default_browser
+          I_AM_NOT_DEFAULT_BROWSER: is_default_browser == false
+          LAUNCHED_ONCE_THIS_WEEK: "'app_launched'|eventSum('Days', 7) == 1"
+          MORE_THAN_24H_SINCE_INSTALLED_OR_UPDATED: days_since_update >= 1
+          NEVER: "false"
+          USER_CASUAL: "'app_launched'|eventCountNonZero('Days', 28) >= 7 && 'app_launched'|eventCountNonZero('Days', 28) < 14"
+          USER_CORE_ACTIVE: "'app_launched'|eventCountNonZero('Days', 28) >= 21"
+          USER_DE_SPEAKER: "'de' in locale"
+          USER_EN_SPEAKER: "'en' in locale"
+          USER_ESTABLISHED_INSTALL: number_of_app_launches >=4
+          USER_ES_SPEAKER: "'es' in locale"
+          USER_FR_SPEAKER: "'fr' in locale"
+          USER_INFREQUENT: "'app_launched'|eventCountNonZero('Days', 28) >= 1 && 'app_launched'|eventCountNonZero('Days', 28) < 7"
+          USER_RECENTLY_INSTALLED: days_since_install < 7
+          USER_RECENTLY_UPDATED: days_since_update < 7 && days_since_install != days_since_update
+          USER_REGULAR: "'app_launched'|eventCountNonZero('Days', 28) >= 14 && 'app_launched'|eventCountNonZero('Days', 28) < 21"
+          USER_TIER_ONE_COUNTRY: "('US' in locale || 'GB' in locale || 'CA' in locale || 'DE' in locale || 'FR' in locale)"
+    allow-coenrollment: true
+  mr2022:
+    description: Features for MR 2022.
+    variables:
+      sections-enabled:
+        description: This property provides a lookup table of whether or not the given section should be enabled.
+        type: "Map<MR2022Section, Boolean>"
+        default:
+          home-onboarding-dialog-existing-users: true
+          jump-back-in-cfr: true
+          sync-cfr: true
+          tcp-cfr: true
+          tcp-feature: true
+          wallpapers-selection-tool: true
+  nimbus-system:
+    description: "Configuration of the Nimbus System in Android.\n"
+    variables:
+      refresh-interval-foreground:
+        description: "The minimum interval in minutes between fetching experiment \nrecipes in the foreground.\n"
+        type: Int
+        default: 60
+  nimbus-validation:
+    description: A feature that does not correspond to an application feature suitable for showing that Nimbus is working. This should never be used in production.
+    variables:
+      settings-icon:
+        description: The drawable displayed in the app menu for Settings
+        type: String
+        default: mozac_ic_settings
+      settings-punctuation:
+        description: The emoji displayed in the Settings screen title.
+        type: String
+        default: ""
+      settings-title:
+        description: The title of displayed in the Settings screen and app menu.
+        type: Text
+        default: browser_menu_settings
+  onboarding:
+    description: "A feature that configures the new user onboarding page. Note that onboarding is a **first run** feature, and should only be modified by first run experiments."
+    variables:
+      order:
+        description: Determines the order of the onboarding page panels
+        type: List<OnboardingPanel>
+        default:
+          - themes
+          - toolbar-placement
+          - sync
+          - tcp
+          - privacy-notice
+  pdfjs:
+    description: PDF.js features
+    variables:
+      download-button:
+        description: Download button
+        type: Boolean
+        default: true
+      open-in-app-button:
+        description: Open in app button
+        type: Boolean
+        default: true
+  pre-permission-notification-prompt:
+    description: A feature that shows the pre-permission notification prompt.
+    variables:
+      enabled:
+        description: "if true, the pre-permission notification prompt is shown to the user."
+        type: Boolean
+        default: false
+  print:
+    description: A feature for printing from the share or browser menu.
+    variables:
+      browser-print-enabled:
+        description: "If true, a print button from the browser menu is available."
+        type: Boolean
+        default: true
+      share-print-enabled:
+        description: "If true, a print button from the share menu is available."
+        type: Boolean
+        default: true
+  private-browsing:
+    description: Private Browsing Mode
+    variables:
+      felt-privacy-enabled:
+        description: "if true, enable felt privacy related UI"
+        type: Boolean
+        default: false
+  query-parameter-stripping:
+    description: Features for query parameter stripping.
+    variables:
+      sections-enabled:
+        description: This property provides a lookup table of whether or not the given section should be enabled.
+        type: "Map<QueryParameterStrippingSection, String>"
+        default:
+          query-parameter-stripping: "0"
+          query-parameter-stripping-allow-list: ""
+          query-parameter-stripping-pmb: "0"
+          query-parameter-stripping-strip-list: ""
+  re-engagement-notification:
+    description: A feature that shows the re-engagement notification if the user is inactive.
+    variables:
+      enabled:
+        description: "If true, the re-engagement notification is shown to the inactive user."
+        type: Boolean
+        default: false
+      type:
+        description: The type of re-engagement notification that is shown to the inactive user.
+        type: Int
+        default: 0
+  search-extra-params:
+    description: A feature that provides additional args for search.
+    variables:
+      channel-id:
+        description: The channel Id param name with arg.
+        type: "Map<String, String>"
+        default: {}
+      enabled:
+        description: "If true, the feature is active."
+        type: Boolean
+        default: false
+      feature-enabler:
+        description: "The feature enabler param name with arg, NOTE this map could be empty."
+        type: "Map<String, String>"
+        default: {}
+      search-engine:
+        description: The search engine name.
+        type: String
+        default: ""
+  search-term-groups:
+    description: A feature allowing the grouping of URLs around the search term that it came from.
+    variables:
+      enabled:
+        description: "If true, the feature shows up on the homescreen and on the new tab screen."
+        type: Boolean
+        default: false
+  shopping-experience:
+    description: A feature that shows product review quality information.
+    variables:
+      enabled:
+        description: "if true, the shopping experience feature is shown to the user."
+        type: Boolean
+        default: false
+      product-recommendations:
+        description: "if true, recommended products feature is enabled to be shown to the user based on their preference."
+        type: Boolean
+        default: false
+  splash-screen:
+    description: "A feature that extends splash screen duration, allowing additional data fetching time for the app's initial run."
+    variables:
+      enabled:
+        description: "If true, the feature is active."
+        type: Boolean
+        default: false
+      maximum_duration_ms:
+        description: The maximum amount of time in milliseconds the splashscreen will be visible while waiting for initialization calls to complete.
+        type: Int
+        default: 0
+  toolbar:
+    description: The searchbar/awesomebar that user uses to search.
+    variables:
+      toolbar-position-top:
+        description: "If true, toolbar appears at top of the screen."
+        type: Boolean
+        default: false
+  unified-search:
+    description: A feature allowing user to easily search for specified results directly in the search bar.
+    variables:
+      enabled:
+        description: "If true, the feature shows up in the search bar."
+        type: Boolean
+        default: true
+enums:
+  ControlMessageBehavior:
+    description: An enum to influence what should be displayed when a control message is selected.
+    variants:
+      show-next-message:
+        description: The next eligible message should be shown.
+      show-none:
+        description: The surface should show no message.
+  CookieBannersSection:
+    description: The identifiers for the sections of the MR 2022.
+    variants:
+      feature-setting-detect-only:
+        description: "An integer either 0 or 1 indicating if cookie banner detect only mode should be enabled or disabled. 0 for setting to be disabled, and 1 for enabling the setting."
+      feature-setting-global-rules:
+        description: "An integer either 0 or 1 indicating if cookie banner global rules should be enabled or disabled. 0 for setting to be disabled, and 1 for enabling the setting."
+      feature-setting-global-rules-sub-frames:
+        description: "An integer either 0 or 1 indicating if cookie banner global rules sub-frames should be enabled or disabled. 0 for setting to be disabled, and 1 for enabling the setting."
+      feature-setting-value:
+        description: "An integer either 0 or 1 indicating if cookie banner setting should be enabled or disabled, 0 for setting the value to disabled, 1  for enabling the setting with the value reject_all."
+      feature-setting-value-pbm:
+        description: "An integer either 0 or 1 indicating if cookie banner setting should be enabled or disabled, 0 for setting the value to disabled, 1  for enabling the setting with the value reject_all."
+      feature-ui:
+        description: "An integer either 0 or 1 indicating if the UI for cookie banner handling should be visible, 0 to hide the UI and 1 to show the UI. The actual UI is composed by cookie banner section in the settings page, the toolbar section and the re-engagement dialog."
+  HomeScreenSection:
+    description: The identifiers for the sections of the homescreen.
+    variants:
+      jump-back-in:
+        description: The tabs the user was looking immediately before being interrupted.
+      pocket:
+        description: The pocket section. This should only be available in the US.
+      pocket-sponsored-stories:
+        description: Subsection of the Pocket homescreen section which shows sponsored stories.
+      recent-explorations:
+        description: The tab groups
+      recently-saved:
+        description: The sites the user has bookmarked recently.
+      top-sites:
+        description: The frecency and pinned sites.
+  MR2022Section:
+    description: The identifiers for the sections of the MR 2022.
+    variants:
+      home-onboarding-dialog-existing-users:
+        description: Home onboarding dialog for upgraded users.
+      jump-back-in-cfr:
+        description: Jump back-in onboarding message.
+      sync-cfr:
+        description: CFR for the first time you see a synced tab on the home screen.
+      tcp-cfr:
+        description: CFR for the first time you use the browse with Total Cookie Protection on the browser screen.
+      tcp-feature:
+        description: Controls the Total Cookie Protection feature.
+      wallpapers-selection-tool:
+        description: Wallpapers selection dialog tool for the home screen.
+  OnboardingCardType:
+    description: An enum to describe a type of card.
+    variants:
+      add-search-widget:
+        description: Allows user to add search widget to homescreen.
+      default-browser:
+        description: Allows user to set Firefox as the default browser.
+      notification-permission:
+        description: Allows user to enable notification permission.
+      sync-sign-in:
+        description: Allows user to sync with a Firefox account.
+  OnboardingPanel:
+    description: The types of onboarding panels in the onboarding page
+    variants:
+      privacy-notice:
+        description: The onboarding panel where users can tap to view our privacy notice.
+      sync:
+        description: The onboarding panel where users can sign in to sync
+      tcp:
+        description: The onboarding panel where users can choose their total cookie protection settings
+      themes:
+        description: The themes onboarding panel where users pick themes
+      toolbar-placement:
+        description: The onboarding panel where users choose their toolbar placement (bottom or top)
+  QueryParameterStrippingSection:
+    description: The identifiers for the options for the Query Parameter Stripping feature.
+    variants:
+      query-parameter-stripping:
+        description: "An integer either 0 or 1 indicating if query parameter stripping should be enabled or disabled in normal mode. 0 for setting to be disabled, and 1 for enabling the setting."
+      query-parameter-stripping-allow-list:
+        description: An string separated by commas indicating the sites where should from query stripping should be exempted.
+      query-parameter-stripping-pmb:
+        description: "An integer either 0 or 1 indicating if query parameter stripping should be enabled or disabled in private mode. 0 for setting to be disabled, and 1 for enabling the setting."
+      query-parameter-stripping-strip-list:
+        description: An string separated by commas indicating the list of query params to be stripped from URIs. This list will be merged with records coming from RemoteSettings.
+objects:
+  MessageData:
+    description: "An object to describe a message. It uses human readable strings to describe the triggers, action and style of the message as well as the text of the message and call to action.\n"
+    fields:
+      action:
+        description: "A URL of a page or a deeplink. This may have substitution variables in.\n"
+        type: Text
+        default: ""
+      button-label:
+        description: "The text on the button. If no text is present, the whole message is clickable.\n"
+        type: Option<Text>
+        default: ~
+      experiment:
+        description: The slug of the experiment that this message came from.
+        type: Option<String>
+        default: ~
+      is-control:
+        description: "Indicates if this message is the control message, if true shouldn't be displayed"
+        type: Boolean
+        default: false
+      style:
+        description: "The style as described in a `StyleData` from the styles table.\n"
+        type: String
+        default: DEFAULT
+      surface:
+        description: The surface identifier for this message.
+        type: String
+        default: homescreen
+      text:
+        description: The message text displayed to the user
+        type: Text
+        default: ""
+      title:
+        description: The title text displayed to the user
+        type: Option<Text>
+        default: ~
+      trigger:
+        description: "A list of strings corresponding to targeting expressions. The message will be shown if all expressions `true`.\n"
+        type: List<String>
+        default: []
+  NotificationConfig:
+    description: Attributes controlling the global configuration of notification messages.
+    fields:
+      refresh-interval:
+        description: "How often, in minutes, the notification message worker will wake up and check for new messages.\n"
+        type: Int
+        default: 240
+  OnboardingCardData:
+    description: An object to describe a user facing onboarding card.
+    fields:
+      body:
+        description: The message text displayed to the user. May contain linkable text.
+        type: Text
+        default: ""
+      card-type:
+        description: The type of the card.
+        type: OnboardingCardType
+        default: default-browser
+      disqualifiers:
+        description: "A list of strings corresponding to targeting expressions. The card will not be shown if any expression is `true`.\n"
+        type: List<String>
+        default:
+          - NEVER
+      enabled:
+        description: "If true, this card is shown to the user."
+        type: Boolean
+        default: true
+      image-res:
+        description: The resource id of the image to be displayed.
+        type: Image
+        default: ic_onboarding_welcome
+      link-text:
+        description: "The text to link from the body text. This should match the linkable text from the body text exactly. e.g. body: This is a policy link\n     link-text: policy link\n"
+        type: Option<Text>
+        default: ~
+      ordering:
+        description: Used to sequence the cards.
+        type: Int
+        default: 0
+      prerequisites:
+        description: "A list of strings corresponding to targeting expressions. The card will be shown if all expressions are `true` and if no expressions in the `disqualifiers` table are true, or if the `disqualifiers` table is empty.\n"
+        type: List<String>
+        default:
+          - ALWAYS
+      primary-button-label:
+        description: The text to display on the primary button.
+        type: Text
+        default: ""
+      secondary-button-label:
+        description: The text to display on the secondary button.
+        type: Text
+        default: ""
+      title:
+        description: The title text displayed to the user.
+        type: Text
+        default: ""
+  StyleData:
+    description: "A group of properties (predominantly visual) to describe the style of the message.\n"
+    fields:
+      max-display-count:
+        description: "How many sessions will this message be shown to the user before it is expired.\n"
+        type: Int
+        default: 5
+      priority:
+        description: "The importance of this message. 0 is not very important, 100 is very important.\n"
+        type: Int
+        default: 50

--- a/experimenter/experimenter/features/manifests/focus-android/v121.0.0/beta.fml.yaml
+++ b/experimenter/experimenter/features/manifests/focus-android/v121.0.0/beta.fml.yaml
@@ -1,0 +1,29 @@
+---
+version: 1.0.0
+about:
+  description: Nimbus Feature Manifest for Focus Android
+channels:
+  - beta
+features:
+  cookie-banner:
+    description: Nimbus feature name intended to control the cookie banner handling  in the app.
+    variables:
+      is-cookie-handling-enabled:
+        description: "If 'true' , the app will show the settings part for cookie banner handling"
+        type: Boolean
+        default: false
+  onboarding:
+    description: Nimbus feature name intended to control the onboarding plus all CFRs in the app.
+    variables:
+      is-cfr-enabled:
+        description: "If `true`, the app will show the cfrs"
+        type: Boolean
+        default: false
+      is-enabled:
+        description: "If `true`, the app will show the new onboarding screen"
+        type: Boolean
+        default: true
+      is-promote-search-widget-dialog-enabled:
+        description: "If `true`, the app will show the new dialog for promote search widget"
+        type: Boolean
+        default: false

--- a/experimenter/experimenter/features/manifests/focus-android/v121.0.0/debug.fml.yaml
+++ b/experimenter/experimenter/features/manifests/focus-android/v121.0.0/debug.fml.yaml
@@ -1,0 +1,29 @@
+---
+version: 1.0.0
+about:
+  description: Nimbus Feature Manifest for Focus Android
+channels:
+  - debug
+features:
+  cookie-banner:
+    description: Nimbus feature name intended to control the cookie banner handling  in the app.
+    variables:
+      is-cookie-handling-enabled:
+        description: "If 'true' , the app will show the settings part for cookie banner handling"
+        type: Boolean
+        default: true
+  onboarding:
+    description: Nimbus feature name intended to control the onboarding plus all CFRs in the app.
+    variables:
+      is-cfr-enabled:
+        description: "If `true`, the app will show the cfrs"
+        type: Boolean
+        default: true
+      is-enabled:
+        description: "If `true`, the app will show the new onboarding screen"
+        type: Boolean
+        default: true
+      is-promote-search-widget-dialog-enabled:
+        description: "If `true`, the app will show the new dialog for promote search widget"
+        type: Boolean
+        default: true

--- a/experimenter/experimenter/features/manifests/focus-android/v121.0.0/experimenter.yaml
+++ b/experimenter/experimenter/features/manifests/focus-android/v121.0.0/experimenter.yaml
@@ -1,0 +1,23 @@
+---
+cookie-banner:
+  description: Nimbus feature name intended to control the cookie banner handling  in the app.
+  hasExposure: true
+  exposureDescription: ""
+  variables:
+    is-cookie-handling-enabled:
+      type: boolean
+      description: "If 'true' , the app will show the settings part for cookie banner handling"
+onboarding:
+  description: Nimbus feature name intended to control the onboarding plus all CFRs in the app.
+  hasExposure: true
+  exposureDescription: ""
+  variables:
+    is-cfr-enabled:
+      type: boolean
+      description: "If `true`, the app will show the cfrs"
+    is-enabled:
+      type: boolean
+      description: "If `true`, the app will show the new onboarding screen"
+    is-promote-search-widget-dialog-enabled:
+      type: boolean
+      description: "If `true`, the app will show the new dialog for promote search widget"

--- a/experimenter/experimenter/features/manifests/focus-android/v121.0.0/nightly.fml.yaml
+++ b/experimenter/experimenter/features/manifests/focus-android/v121.0.0/nightly.fml.yaml
@@ -1,0 +1,29 @@
+---
+version: 1.0.0
+about:
+  description: Nimbus Feature Manifest for Focus Android
+channels:
+  - nightly
+features:
+  cookie-banner:
+    description: Nimbus feature name intended to control the cookie banner handling  in the app.
+    variables:
+      is-cookie-handling-enabled:
+        description: "If 'true' , the app will show the settings part for cookie banner handling"
+        type: Boolean
+        default: false
+  onboarding:
+    description: Nimbus feature name intended to control the onboarding plus all CFRs in the app.
+    variables:
+      is-cfr-enabled:
+        description: "If `true`, the app will show the cfrs"
+        type: Boolean
+        default: false
+      is-enabled:
+        description: "If `true`, the app will show the new onboarding screen"
+        type: Boolean
+        default: true
+      is-promote-search-widget-dialog-enabled:
+        description: "If `true`, the app will show the new dialog for promote search widget"
+        type: Boolean
+        default: false

--- a/experimenter/experimenter/features/manifests/focus-android/v121.0.0/release.fml.yaml
+++ b/experimenter/experimenter/features/manifests/focus-android/v121.0.0/release.fml.yaml
@@ -1,0 +1,29 @@
+---
+version: 1.0.0
+about:
+  description: Nimbus Feature Manifest for Focus Android
+channels:
+  - release
+features:
+  cookie-banner:
+    description: Nimbus feature name intended to control the cookie banner handling  in the app.
+    variables:
+      is-cookie-handling-enabled:
+        description: "If 'true' , the app will show the settings part for cookie banner handling"
+        type: Boolean
+        default: false
+  onboarding:
+    description: Nimbus feature name intended to control the onboarding plus all CFRs in the app.
+    variables:
+      is-cfr-enabled:
+        description: "If `true`, the app will show the cfrs"
+        type: Boolean
+        default: false
+      is-enabled:
+        description: "If `true`, the app will show the new onboarding screen"
+        type: Boolean
+        default: true
+      is-promote-search-widget-dialog-enabled:
+        description: "If `true`, the app will show the new dialog for promote search widget"
+        type: Boolean
+        default: false

--- a/experimenter/experimenter/features/manifests/ios/v121.0.0/beta.fml.yaml
+++ b/experimenter/experimenter/features/manifests/ios/v121.0.0/beta.fml.yaml
@@ -1,0 +1,755 @@
+---
+version: 1.0.0
+about:
+  description: The root level Feature Manifest for Firefox for iOS
+channels:
+  - beta
+features:
+  address-autofill-feature:
+    description: This property defines the address card autofill feature
+    variables:
+      status:
+        description: "If true, we will allow user to use the address autofill feature"
+        type: Boolean
+        default: false
+  contextual-hint-feature:
+    description: This set holds all features pertaining to contextual hints.
+    variables:
+      features-enabled:
+        description: "This property provides a lookup table of whether specific contextual hints are enabled.\n"
+        type: "Map<ContextualHint, Boolean>"
+        default:
+          toolbar-hint: true
+  credit-card-autofill:
+    description: This property defines the credit card autofill feature
+    variables:
+      credit-card-autofill-status:
+        description: "If true, we will allow user to use the credit autofill feature"
+        type: Boolean
+        default: true
+  firefox-suggest-feature:
+    description: Configuration for the Firefox Suggest feature.
+    variables:
+      status:
+        description: "Whether the feature is enabled. When Firefox Suggest is enabled, Firefox will download and store new search suggestions in the background, and show additional Search settings to control which suggestions appear in the awesomebar. When Firefox Suggest is disabled, Firefox will not download new suggestions, and hide the additional Search settings.\n"
+        type: Boolean
+        default: false
+  general-app-features:
+    description: The feature that contains feature flags for the entire application
+    variables:
+      report-site-issue:
+        description: This property defines whether or not the feature is enabled
+        type: GeneralFeature
+        default:
+          status: true
+  homescreenFeature:
+    description: The homescreen that the user goes to when they press home or new tab.
+    variables:
+      pocket-sponsored-stories:
+        description: "This property defines whether pocket sponsored stories appear on the homepage.\n"
+        type: Boolean
+        default: false
+      sections-enabled:
+        description: "This property provides a lookup table of whether or not the given section should be enabled. If the section is enabled, it should be toggleable in the settings screen, and on by default.\n"
+        type: "Map<HomeScreenSection, Boolean>"
+        default:
+          jump-back-in: true
+          recent-explorations: true
+  messaging:
+    description: "The in-app messaging system\n"
+    documentation:
+      - name: User documentation
+        url: "https://experimenter.info/messaging/mobile-messaging"
+    contacts:
+      - jhugman@mozilla.com
+      - brennie@mozilla.com
+      - gbuciu@mozilla.com
+      - wteichmann@mozilla.com
+    events:
+      - "https://dictionary.telemetry.mozilla.org/apps/firefox_ios/metrics/messaging_shown"
+      - "https://dictionary.telemetry.mozilla.org/apps/firefox_ios/metrics/messaging_clicked"
+      - "https://dictionary.telemetry.mozilla.org/apps/firefox_ios/metrics/messaging_expired"
+      - "https://dictionary.telemetry.mozilla.org/apps/firefox_ios/metrics/messaging_dismissed"
+      - "https://dictionary.telemetry.mozilla.org/apps/firefox_ios/metrics/messaging_malformed"
+    variables:
+      actions:
+        description: A growable map of action URLs.
+        type: "Map<String, String>"
+        default:
+          ENABLE_PRIVATE_BROWSING: "://deep-link?url=homepanel/new-private-tab"
+          MAKE_DEFAULT_BROWSER: "://deep-link?url=default-browser/system-settings"
+          MAKE_DEFAULT_BROWSER_WITH_TUTORIAL: "://deep-link?url=default-browser/tutorial"
+          OPEN_NEW_TAB: "://deep-link?url=homepanel/new-tab"
+          OPEN_SETTINGS: "://deep-link?url=settings/general"
+          OPEN_SETTINGS_EMAIL: "://deep-link?url=settings/mailto"
+          OPEN_SETTINGS_FXA: "://deep-link?url=settings/fxa"
+          OPEN_SETTINGS_HOMESCREEN: "://deep-link?url=settings/homepage"
+          OPEN_SETTINGS_NEW_TAB: "://deep-link?url=settings/newtab"
+          OPEN_SETTINGS_PRIVACY: "://deep-link?url=settings/clear-private-data"
+          OPEN_SETTINGS_SEARCH_ENGINE: "://deep-link?url=settings/search"
+          OPEN_SETTINGS_THEME: "://deep-link?url=settings/theme"
+          OPEN_SETTINGS_WALLPAPERS: "://deep-link?url=settings/wallpaper"
+          VIEW_BOOKMARKS: "://deep-link?url=homepanel/bookmarks"
+          VIEW_DOWNLOADS: "://deep-link?url=homepanel/downloads"
+          VIEW_HISTORY: "://deep-link?url=homepanel/history"
+          VIEW_READING_LIST: "://deep-link?url=homepanel/reading-list"
+          VIEW_TOP_SITES: "://deep-link?url=homepanel/top-sites"
+      message-under-experiment:
+        description: "Deprecated. Please use \"experiment\": \"{experiment}\" instead."
+        type: Option<String>
+        default: ~
+      messages:
+        description: "A growable collection of messages, where the Key is the message identifier and the value is its associated MessageData.\n"
+        type: "Map<String, MessageData>"
+        default:
+          default-browser:
+            action: MAKE_DEFAULT_BROWSER_WITH_TUTORIAL
+            button-label: Default Browser/DefaultBrowserCard.Button.v2
+            style: FALLBACK
+            surface: new-tab-card
+            text: Default Browser/DefaultBrowserCard.Description
+            title: Default Browser/DefaultBrowserCard.Title
+            trigger:
+              - I_AM_NOT_DEFAULT_BROWSER
+              - SUPPORTS_DEFAULT_BROWSER
+              - ON_FOURTH_LAUNCH_THIS_YEAR
+      on-control:
+        description: What should be displayed when a control message is selected.
+        type: ControlMessageBehavior
+        default: show-next-message
+      styles:
+        description: "A map of styles to configure message appearance.\n"
+        type: "Map<String, StyleData>"
+        default:
+          DEFAULT:
+            max-display-count: 5
+            priority: 50
+          FALLBACK:
+            max-display-count: 20
+            priority: 40
+          NOTIFICATION:
+            max-display-count: 1
+            priority: 50
+          PERSISTENT:
+            max-display-count: 20
+            priority: 50
+          SURVEY:
+            max-display-count: 10
+            priority: 55
+          URGENT:
+            max-display-count: 10
+            priority: 100
+          WARNING:
+            max-display-count: 10
+            priority: 60
+      triggers:
+        description: "A collection of out the box trigger expressions. Each entry maps to a valid JEXL expression.\n"
+        type: "Map<String, String>"
+        default:
+          AFTER_THREE_LAUNCHES_THIS_WEEK: "'app_cycle.foreground'|eventSum('Weeks', 1, 0) >= 3"
+          ALLOWED_TIPS_NOTIFICATIONS: allowed_tips_notifications
+          ALWAYS: "true"
+          DEVICE_ANDROID: "os == 'Android'"
+          DEVICE_IOS: "os == 'iOS'"
+          INACTIVE_NEW_USER: is_inactive_new_user
+          I_AM_DEFAULT_BROWSER: is_default_browser
+          I_AM_NOT_DEFAULT_BROWSER: is_default_browser == false
+          MORE_THAN_24H_SINCE_INSTALLED_OR_UPDATED: days_since_update >= 1
+          NEVER: "false"
+          NOT_INSTALLED_TODAY: days_since_install > 0
+          NOT_LAUNCHED_YESTERDAY: "'app_cycle.foreground'|eventLastSeen('Days', 1) > 1"
+          ON_FOURTH_LAUNCH_THIS_YEAR: "'app_cycle.foreground'|eventSum('Years', 1, 0) > 3"
+          SUPPORTS_DEFAULT_BROWSER: "os_version|versionCompare('14.!') >= 0"
+          USER_DE_SPEAKER: "'de' in locale"
+          USER_EN_SPEAKER: "'en' in locale"
+          USER_FR_SPEAKER: "'fr' in locale"
+          USER_RECENTLY_INSTALLED: days_since_install < 7
+          USER_RECENTLY_UPDATED: days_since_update < 7 && days_since_install != days_since_update
+          USER_TIER_ONE_COUNTRY: "('US' in locale || 'GB' in locale || 'CA' in locale || 'DE' in locale || 'FR' in locale)"
+    allow-coenrollment: true
+  onboarding-framework-feature:
+    description: "The new onboarding framework feature that will allow onboarding to be experimentable through initial experiments.\n"
+    variables:
+      cards:
+        description: "The list of available cards for onboarding.\n"
+        type: "Map<String, NimbusOnboardingCardData>"
+        default:
+          notification-permissions:
+            body: Onboarding/Onboarding.Notification.Description.v120
+            buttons:
+              primary:
+                action: request-notifications
+                title: Onboarding/Onboarding.Notification.TurnOnNotifications.Action.v114
+              secondary:
+                action: next-card
+                title: Onboarding/Onboarding.Notification.Skip.Action.v115
+            image: notifications
+            order: 30
+            prerequisites:
+              - ALWAYS
+            title: Onboarding/Onboarding.Notification.Title.v120
+            type: fresh-install
+          sign-to-sync:
+            body: Onboarding/Onboarding.Sync.Description.v120
+            buttons:
+              primary:
+                action: sync-sign-in
+                title: Onboarding/Onboarding.Sync.SignIn.Action.v114
+              secondary:
+                action: next-card
+                title: Onboarding/Onboarding.Sync.Skip.Action.v114
+            image: sync-devices
+            order: 20
+            prerequisites:
+              - ALWAYS
+            title: Onboarding/Onboarding.Sync.Title.v120
+            type: fresh-install
+          update-sign-to-sync:
+            body: Upgrade/Upgrade.SyncSign.Description.v114
+            buttons:
+              primary:
+                action: sync-sign-in
+                title: Upgrade/Upgrade.SyncSign.Action.v114
+              secondary:
+                action: next-card
+                title: Onboarding/Onboarding.LaterAction.v114
+            image: sync-devices
+            order: 20
+            prerequisites:
+              - NEVER
+            title: Upgrade/Upgrade.SyncSign.Title.v114
+            type: upgrade
+          update-welcome:
+            body: Upgrade/Upgrade.Welcome.Description.v114
+            buttons:
+              primary:
+                action: next-card
+                title: Upgrade/Upgrade.Welcome.Action.v114
+            image: welcome-globe
+            order: 10
+            prerequisites:
+              - NEVER
+            title: Upgrade/Upgrade.Welcome.Title.v114
+            type: upgrade
+          welcome:
+            body: Onboarding/Onboarding.Welcome.Description.TreatementA.v120
+            buttons:
+              primary:
+                action: open-instructions-popup
+                title: Onboarding/Onboarding.Welcome.ActionTreatementA.v114
+              secondary:
+                action: next-card
+                title: Onboarding/Onboarding.Welcome.Skip.v114
+            image: welcome-globe
+            instructions-popup:
+              button-action: open-ios-fx-settings
+              button-title: Onboarding/DefaultBrowserPopup.ButtonTitle.v114
+              instructions:
+                - Onboarding/DefaultBrowserPopup.FirstLabel.v114
+                - Onboarding/DefaultBrowserPopup.SecondLabel.v114
+                - Onboarding/DefaultBrowserPopup.ThirdLabel.v114
+              title: Onboarding/DefaultBrowserPopup.Title.v114
+            link:
+              title: Onboarding/Onboarding.Welcome.Link.Action.v114
+              url: "https://www.mozilla.org/privacy/firefox/"
+            order: 10
+            prerequisites:
+              - ALWAYS
+            title: Onboarding/Onboarding.Welcome.Title.TreatementA.v120
+            type: fresh-install
+      conditions:
+        description: "A collection of out the box conditional expressions to be used in determining whether a card should show or not. Each entry maps to a valid JEXL expression.\n"
+        type: "Map<String, String>"
+        default:
+          ALWAYS: "true"
+          NEVER: "false"
+      dismissable:
+        description: "Whether or not the entire onboarding is dismissable by pressing an X at the top right corner of the screen.\n"
+        type: Boolean
+        default: true
+  private-browsing:
+    description: Private Browsing Mode
+    variables:
+      felt-privacy-enabled:
+        description: "If true, enable felt privacy related UI"
+        type: Boolean
+        default: false
+  qr-code-coordinator-refactor:
+    description: "The feature for managing the roll out of the qrCode coordinator.\n"
+    variables:
+      enabled:
+        description: "Enables the feature\n"
+        type: Boolean
+        default: false
+  redux-integration-feature:
+    description: "This feature is for managing the roll out of the Redux integration feature\n"
+    variables:
+      enabled:
+        description: "Enables the feature\n"
+        type: Boolean
+        default: true
+  search:
+    description: "Configuring the functionality to do with search. This will be separated into smaller sub-features in later releases.\n"
+    variables:
+      awesome-bar:
+        description: Configuring the awesome bar.
+        type: AwesomeBar
+        default:
+          position:
+            is-bottom: false
+            is-position-feature-enabled: true
+            is-toolbar-cfr-on: false
+          search-highlights: false
+          use-page-content: false
+  search-term-groups-feature:
+    description: The feature that controls whether or not search term groups are enabled.
+    variables:
+      grouping-enabled:
+        description: This property provides a lookup table of whether or not the given grouping should be enabled.
+        type: "Map<SearchTermGroups, Boolean>"
+        default:
+          history-groups: true
+          tab-tray-groups: true
+  share-extension-coordinator-refactor:
+    description: "This feature is for managing the roll out of the share extension coordinator as part of the changes to the navigation in the app\n"
+    variables:
+      enabled:
+        description: "Enables the feature\n"
+        type: Boolean
+        default: true
+  share-sheet:
+    description: This feature define the redesign of the share sheet
+    variables:
+      move-actions:
+        description: If true copy and send to device are moved to share sheet
+        type: Boolean
+        default: true
+      toolbar-changes:
+        description: If true share option is shown on the toolbar
+        type: Boolean
+        default: true
+  shopping2023:
+    description: "The configuration setting for the status of the Fakespot feature\n"
+    variables:
+      back_in_stock_reporting:
+        description: "If true, enables for users the reporting feature for products back in stock.\n"
+        type: Boolean
+        default: false
+      config:
+        description: "A Map of website configurations\n"
+        type: "Map<String, WebsiteConfig>"
+        default:
+          amazon:
+            productIdFromURLRegex: "(?:[\\\\/]|$|%2F)(?<productId>[A-Z0-9]{10})(?:[\\\\/]|$|\\\\#|\\\\?|%2F)"
+            validTLDs:
+              - com
+          bestbuy:
+            productIdFromURLRegex: "\\\\/(?<productId>\\\\d+\\\\.p)"
+            validTLDs:
+              - com
+          walmart:
+            productIdFromURLRegex: "\\\\/ip\\\\/(?:[A-Za-z0-9-]{1,320}\\\\/)?(?<productId>[0-9]{3,13})"
+            validTLDs:
+              - com
+      product-recommendations:
+        description: "If true, recommended products feature is enabled\n to be shown to the user based on their preference.\n"
+        type: Boolean
+        default: false
+      relay:
+        description: "Configurable relay URL for production environment\n"
+        type: String
+        default: "https://mozilla-ohttp-fakespot.fastly-edge.com/"
+      status:
+        description: "Whether the Fakespot feature is enabled or disabled\n"
+        type: Boolean
+        default: true
+  spotlight-search:
+    description: Add pages as items findable with Spotlight.
+    variables:
+      enabled:
+        description: "If this is true, then on each page load adds a new item to Spotlight."
+        type: Boolean
+        default: false
+      icon-type:
+        description: "The icon that is displayed next to the item in the search results. If this is `null`, then no icon is displayed.\n"
+        type: Option<IconType>
+        default: letter
+      keep-for-days:
+        description: "Number of days to keep the item before automatic deletion. If this is left `null`, then it is left to iOS's default.\n"
+        type: Option<Int>
+        default: ~
+      searchable-content:
+        description: "The text content that is made searchable. If this is `null` then no additional content is used, and only the title and URL will be used.\n"
+        type: Option<PageContent>
+        default: text-excerpt
+  tab-tray-refactor-feature:
+    description: "This feature is for managing the roll out of the Tab Tray refactor feature\n"
+    variables:
+      enabled:
+        description: "Enables the feature\n"
+        type: Boolean
+        default: false
+  tabTrayFeature:
+    description: The tab tray screen that the user goes to when they open the tab tray.
+    variables:
+      sections-enabled:
+        description: "This property provides a lookup table of whether or not the given section should be enabled. If the section is enabled, it should be toggleable in the settings screen, and on by default."
+        type: "Map<TabTraySection, Boolean>"
+        default:
+          inactive-tabs: true
+  wallpaper-feature:
+    description: This property defines the configuration for the wallpaper feature
+    variables:
+      configuration:
+        description: This property defines the configuration for the wallpaper feature
+        type: WallpaperConfiguration
+        default:
+          status: true
+          version: v1
+      onboarding-sheet:
+        description: This property defines whether the wallpaper onboarding is shown or not
+        type: Boolean
+        default: true
+  zoom-feature:
+    description: "The configuration for the status of the zoom feature\n"
+    variables:
+      status:
+        description: "Whether the page zoom feature is enabled or not\n"
+        type: Boolean
+        default: true
+enums:
+  ContextualHint:
+    description: The identifiers for a individual contextual hints.
+    variants:
+      toolbar-hint:
+        description: The contextual hint bubble that appears to provide a hint about the toolbar.
+  ControlMessageBehavior:
+    description: An enum to influence what should be displayed when a control message is selected.
+    variants:
+      show-next-message:
+        description: The next eligible message should be shown.
+      show-none:
+        description: The surface should show no message.
+  HomeScreenSection:
+    description: The identifiers for the sections of the homescreen.
+    variants:
+      jump-back-in:
+        description: The tabs the user was looking immediately before being interrupted.
+      recent-explorations:
+        description: The tab groups
+  IconType:
+    description: "The icon that will be added to the item in the device's search engine."
+    variants:
+      favicon:
+        description: The favicon of the page
+      letter:
+        description: An icon generated from the first letter of the base domain.
+      screenshot:
+        description: A screenshot of the page at load time.
+  MessageSurfaceId:
+    description: "For messaging, we would like to have a message tell us which surface its associated with. This is a label that matches across both Android and iOS.\n"
+    variants:
+      Unknown:
+        description: A message has NOT declared its target surface.
+      new-tab-card:
+        description: This is the card that appears at the top on the Firefox Home Page.
+      notification:
+        description: This is a local notification send to the user periodically with tips and updates.
+      survey:
+        description: This is a full-page that appears providing a survey to the user.
+  NimbusOnboardingImages:
+    description: "The identifiers for the different images available for cards in onboarding\n"
+    variants:
+      notifications:
+        description: "Corresponding to the notifications image\n"
+      notifications-ctd:
+        description: "Corresponding to the notifications image for CTD\n"
+      search-widget:
+        description: "Corresponding to the fox search widget image\n"
+      set-to-dock:
+        description: "Corresponding to the set to dock image\n"
+      sync-devices:
+        description: "Corresponding to the sync-devices image\n"
+      sync-devices-ctd:
+        description: "Corresponding to the sync image for CTD\n"
+      welcome-ctd:
+        description: "Corresponding to the welcome image for CTD\n"
+      welcome-globe:
+        description: "Corresponding to the fox world image\n"
+  OnboardingActions:
+    description: "The identifiers for the different actions available for cards in onboarding\n"
+    variants:
+      next-card:
+        description: "Will take the user to the next card\n"
+      open-instructions-popup:
+        description: "Will open up a popup with instructions for something\n"
+      read-privacy-policy:
+        description: "Will open a webview where the user can read the privacy policy\n"
+      request-notifications:
+        description: "Will request to allow notifications from the user\n"
+      set-default-browser:
+        description: "Will send the user to settings to set Firefox as their default browser\n"
+      sync-sign-in:
+        description: "Will take the user to the sync sign in flow\n"
+  OnboardingInstructionsPopupActions:
+    description: "The identifiers for the different actions available for the insturction card in onboarding\n"
+    variants:
+      dismiss:
+        description: "Will dismiss the popup\n"
+      dismiss-and-next-card:
+        description: "Will dismiss the popup and move to the next card\n"
+      open-ios-fx-settings:
+        description: "Will take the user to the default browser settings in the iOS system settings\n"
+  OnboardingType:
+    description: "The identifiers for the different types of onboarding cards.\n"
+    variants:
+      fresh-install:
+        description: "Corresponding to onboarding cards that are for new users\n"
+      upgrade:
+        description: "Corresponding to onboarding cards that are for users who have updated\n"
+  PageContent:
+    description: "The page content that will be added as an item in the device's search engine."
+    variants:
+      html-content:
+        description: Use all the page as HTML
+      text-content:
+        description: Use all the page as text
+      text-excerpt:
+        description: Only use the first paragraph
+  SearchTermGroups:
+    description: The identifiers for the different types of search term groups.
+    variants:
+      history-groups:
+        description: Grouping for items in History and RecentlyVisited
+      tab-tray-groups:
+        description: Grouping for items in the Tab Tray and in JumpBackIn
+  TabTraySection:
+    description: The identifiers for the sections of the tab tray.
+    variants:
+      inactive-tabs:
+        description: Tabs that have been automatically closed for the user.
+  WallpaperVariantVersion:
+    description: An enum to identify which version of the wallpaper system to use
+    variants:
+      legacy:
+        description: The legacy wallpaper version
+      v1:
+        description: The 2022 MR version
+objects:
+  AwesomeBar:
+    description: "A configuration option for the awesome bar. Part of the `search` feature."
+    fields:
+      min-search-term:
+        description: The minimum number of characters that the user types before searching in the page.
+        type: Int
+        default: 3
+      position:
+        description: "This property defines whether or not the feature is enabled, and the position of the search bar\n"
+        type: SearchBarPositionFeature
+        default:
+          is-bottom: true
+          is-position-feature-enabled: true
+          is-toolbar-cfr-on: true
+      search-highlights:
+        description: Whether or not search highlights are enabled
+        type: Boolean
+        default: false
+      use-page-content:
+        description: "Search in the open tab's text content when typing."
+        type: Boolean
+        default: false
+  GeneralFeature:
+    description: The configuration for the a feature that can be enabled or disabled
+    fields:
+      status:
+        description: Whether or not the feature is enabled
+        type: Boolean
+        default: false
+  MessageData:
+    description: "An object to describe a message. It uses human readable strings to describe the triggers, action and style of the message as well as the text of the message and call to action.\n"
+    fields:
+      action:
+        description: "A URL of a page or a deeplink. This may have substitution variables in.\n"
+        type: String
+        default: ""
+      button-label:
+        description: "The text on the button. If no text is present, the whole message is clickable.\n"
+        type: Option<Text>
+        default: ~
+      experiment:
+        description: The experiment slug that this message is involved in.
+        type: Option<String>
+        default: ~
+      is-control:
+        description: "Indicates if this message is the control message, if true shouldn't be displayed"
+        type: Boolean
+        default: false
+      style:
+        description: "The style as described in a `StyleData` from the styles table.\n"
+        type: String
+        default: DEFAULT
+      surface:
+        description: Each message will tell us the surface it is targeting with this.
+        type: MessageSurfaceId
+        default: Unknown
+      text:
+        description: The message text displayed to the user
+        type: Text
+        default: ""
+      title:
+        description: The title text displayed to the user
+        type: Option<Text>
+        default: ~
+      trigger:
+        description: "A list of strings corresponding to targeting expressions. The message will be shown if all expressions `true`.\n"
+        type: List<String>
+        default: []
+  NimbusInstructionPopup:
+    description: "The object outlining the content of the instruction card.\n"
+    fields:
+      button-action:
+        description: "The action the button should have. Default is `dismiss-and-next-card`\n"
+        type: OnboardingInstructionsPopupActions
+        default: dismiss-and-next-card
+      button-title:
+        description: "The title the button should have. This should never be defaulted.\n"
+        type: Text
+        default: ""
+      instructions:
+        description: "A list of instructions, either as free text, or as Text identifiers.\n"
+        type: List<Text>
+        default: []
+      title:
+        description: "The text of the popup. This should never be defaulted.\n"
+        type: Text
+        default: ""
+  NimbusOnboardingButton:
+    description: "A group of properties describing the attributes of a card.\n"
+    fields:
+      action:
+        description: "The action the button should take. The default for this will be \"next-card\"\n"
+        type: OnboardingActions
+        default: next-card
+      title:
+        description: "The text of the button title. This should never be defaulted.\n"
+        type: Text
+        default: ""
+  NimbusOnboardingButtons:
+    description: "A set of buttons for the card. There can be up to two, but there must be at least one.\n"
+    fields:
+      primary:
+        description: "The primary button for the card. This must exist.\n"
+        type: NimbusOnboardingButton
+        default:
+          action: next-card
+          title: Primary Button
+      secondary:
+        description: "A secondary, optional, button for the card.\n"
+        type: Option<NimbusOnboardingButton>
+        default: ~
+  NimbusOnboardingCardData:
+    description: "A group of properties describing the attributes of a card.\n"
+    fields:
+      body:
+        description: "The body text dispalyed on the card, in less prominent text. This should never be defaulted.\n"
+        type: Text
+        default: ""
+      buttons:
+        description: "The set of buttons associated with the card.\n"
+        type: NimbusOnboardingButtons
+        default:
+          primary:
+            action: next-card
+            title: Onboarding/Onboarding.Sync.Skip.Action.v114
+          secondary: ~
+      disqualifiers:
+        description: "A list of strings corresponding to targeting expressions. The card will not be shown if any expression is `true`.\n"
+        type: List<String>
+        default: []
+      image:
+        description: "The image that should be dispalyed on the card.\n"
+        type: NimbusOnboardingImages
+        default: welcome-globe
+      instructions-popup:
+        description: "The object describing the specific instruction popup button for a card. If left empty, the card will have no instruction popup information\n"
+        type: Option<NimbusInstructionPopup>
+        default: ~
+      link:
+        description: "The object describing the link button for a card. If left empty, the card will have no link.\n"
+        type: Option<NimbusOnboardingLink>
+        default: ~
+      order:
+        description: "The place in the order where the card will be found. The feature layer will then sort the cards based on this field.\n"
+        type: Int
+        default: 10
+      prerequisites:
+        description: "A list of strings corresponding to targeting expressions. The card will be shown if all expressions `true` and if no expressions in the `disqualifiers` table are true, or if the `disqualifiers` table is empty.\n"
+        type: List<String>
+        default: []
+      title:
+        description: "The title displayed on the card, in prominent, bolded text. This should never be defaulted.\n"
+        type: Text
+        default: ""
+      type:
+        description: "The type of onboarding this card should be shown in, whether it a fresh install or an update. The default is fresh-install.\n"
+        type: OnboardingType
+        default: fresh-install
+  NimbusOnboardingLink:
+    description: "A group of properties describing the attributes for the active link on a card\n"
+    fields:
+      title:
+        description: "The text of the link title.\n"
+        type: Text
+        default: Onboarding/Onboarding.Welcome.Link.Action.v114
+      url:
+        description: "The url that the link will lead to.\n"
+        type: String
+        default: "https://www.mozilla.org/privacy/firefox/"
+  SearchBarPositionFeature:
+    description: The configuration for the bottom search bar on the homescreen
+    fields:
+      is-bottom:
+        description: Whether or not the default position is at the bottom
+        type: Boolean
+        default: true
+      is-position-feature-enabled:
+        description: Whether or not the feature is enabled
+        type: Boolean
+        default: true
+      is-toolbar-cfr-on:
+        description: Whether or not the toolbar CFR shows. This is a temporary hack for Nimbus
+        type: Boolean
+        default: true
+  StyleData:
+    description: "A group of properities (predominantly visual) to the describe style of the message.\n"
+    fields:
+      max-display-count:
+        description: "How many sessions will this message be shown to the user before it is expired.\n"
+        type: Int
+        default: 5
+      priority:
+        description: "The importance of this message. 0 is not very important, 100 is very important.\n"
+        type: Int
+        default: 50
+  WallpaperConfiguration:
+    description: The configuration for the a feature that can be enabled or disabled
+    fields:
+      status:
+        description: Whether or not the feature is enabled
+        type: Boolean
+        default: false
+      version:
+        description: Which version of the wallpaper sytem to use
+        type: WallpaperVariantVersion
+        default: legacy
+  WebsiteConfig:
+    description: "It represents a configuration for different e-commerce websites and includes regular expressions for extracting product IDs from their respective URLs\n"
+    fields:
+      productIdFromURLRegex:
+        description: "It represents the product ID extracted from a regex query\n"
+        type: String
+        default: ""
+      validTLDs:
+        description: "Valid Top Level Domains\n"
+        type: List<String>
+        default: []

--- a/experimenter/experimenter/features/manifests/ios/v121.0.0/developer.fml.yaml
+++ b/experimenter/experimenter/features/manifests/ios/v121.0.0/developer.fml.yaml
@@ -1,0 +1,763 @@
+---
+version: 1.0.0
+about:
+  description: The root level Feature Manifest for Firefox for iOS
+channels:
+  - developer
+features:
+  address-autofill-feature:
+    description: This property defines the address card autofill feature
+    variables:
+      status:
+        description: "If true, we will allow user to use the address autofill feature"
+        type: Boolean
+        default: false
+  contextual-hint-feature:
+    description: This set holds all features pertaining to contextual hints.
+    variables:
+      features-enabled:
+        description: "This property provides a lookup table of whether specific contextual hints are enabled.\n"
+        type: "Map<ContextualHint, Boolean>"
+        default:
+          toolbar-hint: true
+  credit-card-autofill:
+    description: This property defines the credit card autofill feature
+    variables:
+      credit-card-autofill-status:
+        description: "If true, we will allow user to use the credit autofill feature"
+        type: Boolean
+        default: true
+  firefox-suggest-feature:
+    description: Configuration for the Firefox Suggest feature.
+    variables:
+      status:
+        description: "Whether the feature is enabled. When Firefox Suggest is enabled, Firefox will download and store new search suggestions in the background, and show additional Search settings to control which suggestions appear in the awesomebar. When Firefox Suggest is disabled, Firefox will not download new suggestions, and hide the additional Search settings.\n"
+        type: Boolean
+        default: true
+  general-app-features:
+    description: The feature that contains feature flags for the entire application
+    variables:
+      report-site-issue:
+        description: This property defines whether or not the feature is enabled
+        type: GeneralFeature
+        default:
+          status: true
+  homescreenFeature:
+    description: The homescreen that the user goes to when they press home or new tab.
+    variables:
+      pocket-sponsored-stories:
+        description: "This property defines whether pocket sponsored stories appear on the homepage.\n"
+        type: Boolean
+        default: true
+      sections-enabled:
+        description: "This property provides a lookup table of whether or not the given section should be enabled. If the section is enabled, it should be toggleable in the settings screen, and on by default.\n"
+        type: "Map<HomeScreenSection, Boolean>"
+        default:
+          jump-back-in: true
+          recent-explorations: true
+  messaging:
+    description: "The in-app messaging system\n"
+    documentation:
+      - name: User documentation
+        url: "https://experimenter.info/messaging/mobile-messaging"
+    contacts:
+      - jhugman@mozilla.com
+      - brennie@mozilla.com
+      - gbuciu@mozilla.com
+      - wteichmann@mozilla.com
+    events:
+      - "https://dictionary.telemetry.mozilla.org/apps/firefox_ios/metrics/messaging_shown"
+      - "https://dictionary.telemetry.mozilla.org/apps/firefox_ios/metrics/messaging_clicked"
+      - "https://dictionary.telemetry.mozilla.org/apps/firefox_ios/metrics/messaging_expired"
+      - "https://dictionary.telemetry.mozilla.org/apps/firefox_ios/metrics/messaging_dismissed"
+      - "https://dictionary.telemetry.mozilla.org/apps/firefox_ios/metrics/messaging_malformed"
+    variables:
+      actions:
+        description: A growable map of action URLs.
+        type: "Map<String, String>"
+        default:
+          ENABLE_PRIVATE_BROWSING: "://deep-link?url=homepanel/new-private-tab"
+          MAKE_DEFAULT_BROWSER: "://deep-link?url=default-browser/system-settings"
+          MAKE_DEFAULT_BROWSER_WITH_TUTORIAL: "://deep-link?url=default-browser/tutorial"
+          OPEN_NEW_TAB: "://deep-link?url=homepanel/new-tab"
+          OPEN_SETTINGS: "://deep-link?url=settings/general"
+          OPEN_SETTINGS_EMAIL: "://deep-link?url=settings/mailto"
+          OPEN_SETTINGS_FXA: "://deep-link?url=settings/fxa"
+          OPEN_SETTINGS_HOMESCREEN: "://deep-link?url=settings/homepage"
+          OPEN_SETTINGS_NEW_TAB: "://deep-link?url=settings/newtab"
+          OPEN_SETTINGS_PRIVACY: "://deep-link?url=settings/clear-private-data"
+          OPEN_SETTINGS_SEARCH_ENGINE: "://deep-link?url=settings/search"
+          OPEN_SETTINGS_THEME: "://deep-link?url=settings/theme"
+          OPEN_SETTINGS_WALLPAPERS: "://deep-link?url=settings/wallpaper"
+          VIEW_BOOKMARKS: "://deep-link?url=homepanel/bookmarks"
+          VIEW_DOWNLOADS: "://deep-link?url=homepanel/downloads"
+          VIEW_HISTORY: "://deep-link?url=homepanel/history"
+          VIEW_READING_LIST: "://deep-link?url=homepanel/reading-list"
+          VIEW_TOP_SITES: "://deep-link?url=homepanel/top-sites"
+      message-under-experiment:
+        description: "Deprecated. Please use \"experiment\": \"{experiment}\" instead."
+        type: Option<String>
+        default: ~
+      messages:
+        description: "A growable collection of messages, where the Key is the message identifier and the value is its associated MessageData.\n"
+        type: "Map<String, MessageData>"
+        default:
+          default-browser:
+            action: MAKE_DEFAULT_BROWSER_WITH_TUTORIAL
+            button-label: Default Browser/DefaultBrowserCard.Button.v2
+            style: FALLBACK
+            surface: new-tab-card
+            text: Default Browser/DefaultBrowserCard.Description
+            title: Default Browser/DefaultBrowserCard.Title
+            trigger:
+              - I_AM_NOT_DEFAULT_BROWSER
+              - SUPPORTS_DEFAULT_BROWSER
+              - ON_FOURTH_LAUNCH_THIS_YEAR
+          survey-surface-message:
+            action: "https://www.macrumors.com"
+            button-label: ResearchSurface/PrimaryButton.Label.v112
+            style: SURVEY
+            surface: survey
+            text: ResearchSurface/Body.Text.v112
+            trigger:
+              - NEVER
+      on-control:
+        description: What should be displayed when a control message is selected.
+        type: ControlMessageBehavior
+        default: show-next-message
+      styles:
+        description: "A map of styles to configure message appearance.\n"
+        type: "Map<String, StyleData>"
+        default:
+          DEFAULT:
+            max-display-count: 5
+            priority: 50
+          FALLBACK:
+            max-display-count: 20
+            priority: 40
+          NOTIFICATION:
+            max-display-count: 1
+            priority: 50
+          PERSISTENT:
+            max-display-count: 20
+            priority: 50
+          SURVEY:
+            max-display-count: 10
+            priority: 55
+          URGENT:
+            max-display-count: 10
+            priority: 100
+          WARNING:
+            max-display-count: 10
+            priority: 60
+      triggers:
+        description: "A collection of out the box trigger expressions. Each entry maps to a valid JEXL expression.\n"
+        type: "Map<String, String>"
+        default:
+          AFTER_THREE_LAUNCHES_THIS_WEEK: "'app_cycle.foreground'|eventSum('Weeks', 1, 0) >= 3"
+          ALLOWED_TIPS_NOTIFICATIONS: allowed_tips_notifications
+          ALWAYS: "true"
+          DEVICE_ANDROID: "os == 'Android'"
+          DEVICE_IOS: "os == 'iOS'"
+          INACTIVE_NEW_USER: is_inactive_new_user
+          I_AM_DEFAULT_BROWSER: is_default_browser
+          I_AM_NOT_DEFAULT_BROWSER: is_default_browser == false
+          MORE_THAN_24H_SINCE_INSTALLED_OR_UPDATED: days_since_update >= 1
+          NEVER: "false"
+          NOT_INSTALLED_TODAY: days_since_install > 0
+          NOT_LAUNCHED_YESTERDAY: "'app_cycle.foreground'|eventLastSeen('Days', 1) > 1"
+          ON_FOURTH_LAUNCH_THIS_YEAR: "'app_cycle.foreground'|eventSum('Years', 1, 0) > 3"
+          SUPPORTS_DEFAULT_BROWSER: "os_version|versionCompare('14.!') >= 0"
+          USER_DE_SPEAKER: "'de' in locale"
+          USER_EN_SPEAKER: "'en' in locale"
+          USER_FR_SPEAKER: "'fr' in locale"
+          USER_RECENTLY_INSTALLED: days_since_install < 7
+          USER_RECENTLY_UPDATED: days_since_update < 7 && days_since_install != days_since_update
+          USER_TIER_ONE_COUNTRY: "('US' in locale || 'GB' in locale || 'CA' in locale || 'DE' in locale || 'FR' in locale)"
+    allow-coenrollment: true
+  onboarding-framework-feature:
+    description: "The new onboarding framework feature that will allow onboarding to be experimentable through initial experiments.\n"
+    variables:
+      cards:
+        description: "The list of available cards for onboarding.\n"
+        type: "Map<String, NimbusOnboardingCardData>"
+        default:
+          notification-permissions:
+            body: Onboarding/Onboarding.Notification.Description.v120
+            buttons:
+              primary:
+                action: request-notifications
+                title: Onboarding/Onboarding.Notification.TurnOnNotifications.Action.v114
+              secondary:
+                action: next-card
+                title: Onboarding/Onboarding.Notification.Skip.Action.v115
+            image: notifications
+            order: 30
+            prerequisites:
+              - ALWAYS
+            title: Onboarding/Onboarding.Notification.Title.v120
+            type: fresh-install
+          sign-to-sync:
+            body: Onboarding/Onboarding.Sync.Description.v120
+            buttons:
+              primary:
+                action: sync-sign-in
+                title: Onboarding/Onboarding.Sync.SignIn.Action.v114
+              secondary:
+                action: next-card
+                title: Onboarding/Onboarding.Sync.Skip.Action.v114
+            image: sync-devices
+            order: 20
+            prerequisites:
+              - ALWAYS
+            title: Onboarding/Onboarding.Sync.Title.v120
+            type: fresh-install
+          update-sign-to-sync:
+            body: Upgrade/Upgrade.SyncSign.Description.v114
+            buttons:
+              primary:
+                action: sync-sign-in
+                title: Upgrade/Upgrade.SyncSign.Action.v114
+              secondary:
+                action: next-card
+                title: Onboarding/Onboarding.LaterAction.v114
+            image: sync-devices
+            order: 20
+            prerequisites:
+              - NEVER
+            title: Upgrade/Upgrade.SyncSign.Title.v114
+            type: upgrade
+          update-welcome:
+            body: Upgrade/Upgrade.Welcome.Description.v114
+            buttons:
+              primary:
+                action: next-card
+                title: Upgrade/Upgrade.Welcome.Action.v114
+            image: welcome-globe
+            order: 10
+            prerequisites:
+              - NEVER
+            title: Upgrade/Upgrade.Welcome.Title.v114
+            type: upgrade
+          welcome:
+            body: Onboarding/Onboarding.Welcome.Description.TreatementA.v120
+            buttons:
+              primary:
+                action: open-instructions-popup
+                title: Onboarding/Onboarding.Welcome.ActionTreatementA.v114
+              secondary:
+                action: next-card
+                title: Onboarding/Onboarding.Welcome.Skip.v114
+            image: welcome-globe
+            instructions-popup:
+              button-action: open-ios-fx-settings
+              button-title: Onboarding/DefaultBrowserPopup.ButtonTitle.v114
+              instructions:
+                - Onboarding/DefaultBrowserPopup.FirstLabel.v114
+                - Onboarding/DefaultBrowserPopup.SecondLabel.v114
+                - Onboarding/DefaultBrowserPopup.ThirdLabel.v114
+              title: Onboarding/DefaultBrowserPopup.Title.v114
+            link:
+              title: Onboarding/Onboarding.Welcome.Link.Action.v114
+              url: "https://www.mozilla.org/privacy/firefox/"
+            order: 10
+            prerequisites:
+              - ALWAYS
+            title: Onboarding/Onboarding.Welcome.Title.TreatementA.v120
+            type: fresh-install
+      conditions:
+        description: "A collection of out the box conditional expressions to be used in determining whether a card should show or not. Each entry maps to a valid JEXL expression.\n"
+        type: "Map<String, String>"
+        default:
+          ALWAYS: "true"
+          NEVER: "false"
+      dismissable:
+        description: "Whether or not the entire onboarding is dismissable by pressing an X at the top right corner of the screen.\n"
+        type: Boolean
+        default: true
+  private-browsing:
+    description: Private Browsing Mode
+    variables:
+      felt-privacy-enabled:
+        description: "If true, enable felt privacy related UI"
+        type: Boolean
+        default: false
+  qr-code-coordinator-refactor:
+    description: "The feature for managing the roll out of the qrCode coordinator.\n"
+    variables:
+      enabled:
+        description: "Enables the feature\n"
+        type: Boolean
+        default: false
+  redux-integration-feature:
+    description: "This feature is for managing the roll out of the Redux integration feature\n"
+    variables:
+      enabled:
+        description: "Enables the feature\n"
+        type: Boolean
+        default: true
+  search:
+    description: "Configuring the functionality to do with search. This will be separated into smaller sub-features in later releases.\n"
+    variables:
+      awesome-bar:
+        description: Configuring the awesome bar.
+        type: AwesomeBar
+        default:
+          position:
+            is-bottom: false
+            is-position-feature-enabled: true
+            is-toolbar-cfr-on: false
+          search-highlights: false
+          use-page-content: false
+  search-term-groups-feature:
+    description: The feature that controls whether or not search term groups are enabled.
+    variables:
+      grouping-enabled:
+        description: This property provides a lookup table of whether or not the given grouping should be enabled.
+        type: "Map<SearchTermGroups, Boolean>"
+        default:
+          history-groups: true
+          tab-tray-groups: true
+  share-extension-coordinator-refactor:
+    description: "This feature is for managing the roll out of the share extension coordinator as part of the changes to the navigation in the app\n"
+    variables:
+      enabled:
+        description: "Enables the feature\n"
+        type: Boolean
+        default: true
+  share-sheet:
+    description: This feature define the redesign of the share sheet
+    variables:
+      move-actions:
+        description: If true copy and send to device are moved to share sheet
+        type: Boolean
+        default: true
+      toolbar-changes:
+        description: If true share option is shown on the toolbar
+        type: Boolean
+        default: true
+  shopping2023:
+    description: "The configuration setting for the status of the Fakespot feature\n"
+    variables:
+      back_in_stock_reporting:
+        description: "If true, enables for users the reporting feature for products back in stock.\n"
+        type: Boolean
+        default: true
+      config:
+        description: "A Map of website configurations\n"
+        type: "Map<String, WebsiteConfig>"
+        default:
+          amazon:
+            productIdFromURLRegex: "(?:[\\\\/]|$|%2F)(?<productId>[A-Z0-9]{10})(?:[\\\\/]|$|\\\\#|\\\\?|%2F)"
+            validTLDs:
+              - com
+          bestbuy:
+            productIdFromURLRegex: "\\\\/(?<productId>\\\\d+\\\\.p)"
+            validTLDs:
+              - com
+          walmart:
+            productIdFromURLRegex: "\\\\/ip\\\\/(?:[A-Za-z0-9-]{1,320}\\\\/)?(?<productId>[0-9]{3,13})"
+            validTLDs:
+              - com
+      product-recommendations:
+        description: "If true, recommended products feature is enabled\n to be shown to the user based on their preference.\n"
+        type: Boolean
+        default: true
+      relay:
+        description: "Configurable relay URL for production environment\n"
+        type: String
+        default: "https://mozilla-ohttp-fakespot.fastly-edge.com/"
+      status:
+        description: "Whether the Fakespot feature is enabled or disabled\n"
+        type: Boolean
+        default: true
+  spotlight-search:
+    description: Add pages as items findable with Spotlight.
+    variables:
+      enabled:
+        description: "If this is true, then on each page load adds a new item to Spotlight."
+        type: Boolean
+        default: true
+      icon-type:
+        description: "The icon that is displayed next to the item in the search results. If this is `null`, then no icon is displayed.\n"
+        type: Option<IconType>
+        default: screenshot
+      keep-for-days:
+        description: "Number of days to keep the item before automatic deletion. If this is left `null`, then it is left to iOS's default.\n"
+        type: Option<Int>
+        default: ~
+      searchable-content:
+        description: "The text content that is made searchable. If this is `null` then no additional content is used, and only the title and URL will be used.\n"
+        type: Option<PageContent>
+        default: text-excerpt
+  tab-tray-refactor-feature:
+    description: "This feature is for managing the roll out of the Tab Tray refactor feature\n"
+    variables:
+      enabled:
+        description: "Enables the feature\n"
+        type: Boolean
+        default: false
+  tabTrayFeature:
+    description: The tab tray screen that the user goes to when they open the tab tray.
+    variables:
+      sections-enabled:
+        description: "This property provides a lookup table of whether or not the given section should be enabled. If the section is enabled, it should be toggleable in the settings screen, and on by default."
+        type: "Map<TabTraySection, Boolean>"
+        default:
+          inactive-tabs: true
+  wallpaper-feature:
+    description: This property defines the configuration for the wallpaper feature
+    variables:
+      configuration:
+        description: This property defines the configuration for the wallpaper feature
+        type: WallpaperConfiguration
+        default:
+          status: true
+          version: v1
+      onboarding-sheet:
+        description: This property defines whether the wallpaper onboarding is shown or not
+        type: Boolean
+        default: true
+  zoom-feature:
+    description: "The configuration for the status of the zoom feature\n"
+    variables:
+      status:
+        description: "Whether the page zoom feature is enabled or not\n"
+        type: Boolean
+        default: true
+enums:
+  ContextualHint:
+    description: The identifiers for a individual contextual hints.
+    variants:
+      toolbar-hint:
+        description: The contextual hint bubble that appears to provide a hint about the toolbar.
+  ControlMessageBehavior:
+    description: An enum to influence what should be displayed when a control message is selected.
+    variants:
+      show-next-message:
+        description: The next eligible message should be shown.
+      show-none:
+        description: The surface should show no message.
+  HomeScreenSection:
+    description: The identifiers for the sections of the homescreen.
+    variants:
+      jump-back-in:
+        description: The tabs the user was looking immediately before being interrupted.
+      recent-explorations:
+        description: The tab groups
+  IconType:
+    description: "The icon that will be added to the item in the device's search engine."
+    variants:
+      favicon:
+        description: The favicon of the page
+      letter:
+        description: An icon generated from the first letter of the base domain.
+      screenshot:
+        description: A screenshot of the page at load time.
+  MessageSurfaceId:
+    description: "For messaging, we would like to have a message tell us which surface its associated with. This is a label that matches across both Android and iOS.\n"
+    variants:
+      Unknown:
+        description: A message has NOT declared its target surface.
+      new-tab-card:
+        description: This is the card that appears at the top on the Firefox Home Page.
+      notification:
+        description: This is a local notification send to the user periodically with tips and updates.
+      survey:
+        description: This is a full-page that appears providing a survey to the user.
+  NimbusOnboardingImages:
+    description: "The identifiers for the different images available for cards in onboarding\n"
+    variants:
+      notifications:
+        description: "Corresponding to the notifications image\n"
+      notifications-ctd:
+        description: "Corresponding to the notifications image for CTD\n"
+      search-widget:
+        description: "Corresponding to the fox search widget image\n"
+      set-to-dock:
+        description: "Corresponding to the set to dock image\n"
+      sync-devices:
+        description: "Corresponding to the sync-devices image\n"
+      sync-devices-ctd:
+        description: "Corresponding to the sync image for CTD\n"
+      welcome-ctd:
+        description: "Corresponding to the welcome image for CTD\n"
+      welcome-globe:
+        description: "Corresponding to the fox world image\n"
+  OnboardingActions:
+    description: "The identifiers for the different actions available for cards in onboarding\n"
+    variants:
+      next-card:
+        description: "Will take the user to the next card\n"
+      open-instructions-popup:
+        description: "Will open up a popup with instructions for something\n"
+      read-privacy-policy:
+        description: "Will open a webview where the user can read the privacy policy\n"
+      request-notifications:
+        description: "Will request to allow notifications from the user\n"
+      set-default-browser:
+        description: "Will send the user to settings to set Firefox as their default browser\n"
+      sync-sign-in:
+        description: "Will take the user to the sync sign in flow\n"
+  OnboardingInstructionsPopupActions:
+    description: "The identifiers for the different actions available for the insturction card in onboarding\n"
+    variants:
+      dismiss:
+        description: "Will dismiss the popup\n"
+      dismiss-and-next-card:
+        description: "Will dismiss the popup and move to the next card\n"
+      open-ios-fx-settings:
+        description: "Will take the user to the default browser settings in the iOS system settings\n"
+  OnboardingType:
+    description: "The identifiers for the different types of onboarding cards.\n"
+    variants:
+      fresh-install:
+        description: "Corresponding to onboarding cards that are for new users\n"
+      upgrade:
+        description: "Corresponding to onboarding cards that are for users who have updated\n"
+  PageContent:
+    description: "The page content that will be added as an item in the device's search engine."
+    variants:
+      html-content:
+        description: Use all the page as HTML
+      text-content:
+        description: Use all the page as text
+      text-excerpt:
+        description: Only use the first paragraph
+  SearchTermGroups:
+    description: The identifiers for the different types of search term groups.
+    variants:
+      history-groups:
+        description: Grouping for items in History and RecentlyVisited
+      tab-tray-groups:
+        description: Grouping for items in the Tab Tray and in JumpBackIn
+  TabTraySection:
+    description: The identifiers for the sections of the tab tray.
+    variants:
+      inactive-tabs:
+        description: Tabs that have been automatically closed for the user.
+  WallpaperVariantVersion:
+    description: An enum to identify which version of the wallpaper system to use
+    variants:
+      legacy:
+        description: The legacy wallpaper version
+      v1:
+        description: The 2022 MR version
+objects:
+  AwesomeBar:
+    description: "A configuration option for the awesome bar. Part of the `search` feature."
+    fields:
+      min-search-term:
+        description: The minimum number of characters that the user types before searching in the page.
+        type: Int
+        default: 3
+      position:
+        description: "This property defines whether or not the feature is enabled, and the position of the search bar\n"
+        type: SearchBarPositionFeature
+        default:
+          is-bottom: true
+          is-position-feature-enabled: true
+          is-toolbar-cfr-on: true
+      search-highlights:
+        description: Whether or not search highlights are enabled
+        type: Boolean
+        default: false
+      use-page-content:
+        description: "Search in the open tab's text content when typing."
+        type: Boolean
+        default: false
+  GeneralFeature:
+    description: The configuration for the a feature that can be enabled or disabled
+    fields:
+      status:
+        description: Whether or not the feature is enabled
+        type: Boolean
+        default: false
+  MessageData:
+    description: "An object to describe a message. It uses human readable strings to describe the triggers, action and style of the message as well as the text of the message and call to action.\n"
+    fields:
+      action:
+        description: "A URL of a page or a deeplink. This may have substitution variables in.\n"
+        type: String
+        default: ""
+      button-label:
+        description: "The text on the button. If no text is present, the whole message is clickable.\n"
+        type: Option<Text>
+        default: ~
+      experiment:
+        description: The experiment slug that this message is involved in.
+        type: Option<String>
+        default: ~
+      is-control:
+        description: "Indicates if this message is the control message, if true shouldn't be displayed"
+        type: Boolean
+        default: false
+      style:
+        description: "The style as described in a `StyleData` from the styles table.\n"
+        type: String
+        default: DEFAULT
+      surface:
+        description: Each message will tell us the surface it is targeting with this.
+        type: MessageSurfaceId
+        default: Unknown
+      text:
+        description: The message text displayed to the user
+        type: Text
+        default: ""
+      title:
+        description: The title text displayed to the user
+        type: Option<Text>
+        default: ~
+      trigger:
+        description: "A list of strings corresponding to targeting expressions. The message will be shown if all expressions `true`.\n"
+        type: List<String>
+        default: []
+  NimbusInstructionPopup:
+    description: "The object outlining the content of the instruction card.\n"
+    fields:
+      button-action:
+        description: "The action the button should have. Default is `dismiss-and-next-card`\n"
+        type: OnboardingInstructionsPopupActions
+        default: dismiss-and-next-card
+      button-title:
+        description: "The title the button should have. This should never be defaulted.\n"
+        type: Text
+        default: ""
+      instructions:
+        description: "A list of instructions, either as free text, or as Text identifiers.\n"
+        type: List<Text>
+        default: []
+      title:
+        description: "The text of the popup. This should never be defaulted.\n"
+        type: Text
+        default: ""
+  NimbusOnboardingButton:
+    description: "A group of properties describing the attributes of a card.\n"
+    fields:
+      action:
+        description: "The action the button should take. The default for this will be \"next-card\"\n"
+        type: OnboardingActions
+        default: next-card
+      title:
+        description: "The text of the button title. This should never be defaulted.\n"
+        type: Text
+        default: ""
+  NimbusOnboardingButtons:
+    description: "A set of buttons for the card. There can be up to two, but there must be at least one.\n"
+    fields:
+      primary:
+        description: "The primary button for the card. This must exist.\n"
+        type: NimbusOnboardingButton
+        default:
+          action: next-card
+          title: Primary Button
+      secondary:
+        description: "A secondary, optional, button for the card.\n"
+        type: Option<NimbusOnboardingButton>
+        default: ~
+  NimbusOnboardingCardData:
+    description: "A group of properties describing the attributes of a card.\n"
+    fields:
+      body:
+        description: "The body text dispalyed on the card, in less prominent text. This should never be defaulted.\n"
+        type: Text
+        default: ""
+      buttons:
+        description: "The set of buttons associated with the card.\n"
+        type: NimbusOnboardingButtons
+        default:
+          primary:
+            action: next-card
+            title: Onboarding/Onboarding.Sync.Skip.Action.v114
+          secondary: ~
+      disqualifiers:
+        description: "A list of strings corresponding to targeting expressions. The card will not be shown if any expression is `true`.\n"
+        type: List<String>
+        default: []
+      image:
+        description: "The image that should be dispalyed on the card.\n"
+        type: NimbusOnboardingImages
+        default: welcome-globe
+      instructions-popup:
+        description: "The object describing the specific instruction popup button for a card. If left empty, the card will have no instruction popup information\n"
+        type: Option<NimbusInstructionPopup>
+        default: ~
+      link:
+        description: "The object describing the link button for a card. If left empty, the card will have no link.\n"
+        type: Option<NimbusOnboardingLink>
+        default: ~
+      order:
+        description: "The place in the order where the card will be found. The feature layer will then sort the cards based on this field.\n"
+        type: Int
+        default: 10
+      prerequisites:
+        description: "A list of strings corresponding to targeting expressions. The card will be shown if all expressions `true` and if no expressions in the `disqualifiers` table are true, or if the `disqualifiers` table is empty.\n"
+        type: List<String>
+        default: []
+      title:
+        description: "The title displayed on the card, in prominent, bolded text. This should never be defaulted.\n"
+        type: Text
+        default: ""
+      type:
+        description: "The type of onboarding this card should be shown in, whether it a fresh install or an update. The default is fresh-install.\n"
+        type: OnboardingType
+        default: fresh-install
+  NimbusOnboardingLink:
+    description: "A group of properties describing the attributes for the active link on a card\n"
+    fields:
+      title:
+        description: "The text of the link title.\n"
+        type: Text
+        default: Onboarding/Onboarding.Welcome.Link.Action.v114
+      url:
+        description: "The url that the link will lead to.\n"
+        type: String
+        default: "https://www.mozilla.org/privacy/firefox/"
+  SearchBarPositionFeature:
+    description: The configuration for the bottom search bar on the homescreen
+    fields:
+      is-bottom:
+        description: Whether or not the default position is at the bottom
+        type: Boolean
+        default: true
+      is-position-feature-enabled:
+        description: Whether or not the feature is enabled
+        type: Boolean
+        default: true
+      is-toolbar-cfr-on:
+        description: Whether or not the toolbar CFR shows. This is a temporary hack for Nimbus
+        type: Boolean
+        default: true
+  StyleData:
+    description: "A group of properities (predominantly visual) to the describe style of the message.\n"
+    fields:
+      max-display-count:
+        description: "How many sessions will this message be shown to the user before it is expired.\n"
+        type: Int
+        default: 5
+      priority:
+        description: "The importance of this message. 0 is not very important, 100 is very important.\n"
+        type: Int
+        default: 50
+  WallpaperConfiguration:
+    description: The configuration for the a feature that can be enabled or disabled
+    fields:
+      status:
+        description: Whether or not the feature is enabled
+        type: Boolean
+        default: false
+      version:
+        description: Which version of the wallpaper sytem to use
+        type: WallpaperVariantVersion
+        default: legacy
+  WebsiteConfig:
+    description: "It represents a configuration for different e-commerce websites and includes regular expressions for extracting product IDs from their respective URLs\n"
+    fields:
+      productIdFromURLRegex:
+        description: "It represents the product ID extracted from a regex query\n"
+        type: String
+        default: ""
+      validTLDs:
+        description: "Valid Top Level Domains\n"
+        type: List<String>
+        default: []

--- a/experimenter/experimenter/features/manifests/ios/v121.0.0/experimenter.yaml
+++ b/experimenter/experimenter/features/manifests/ios/v121.0.0/experimenter.yaml
@@ -1,0 +1,223 @@
+---
+address-autofill-feature:
+  description: This property defines the address card autofill feature
+  hasExposure: true
+  exposureDescription: ""
+  variables:
+    status:
+      type: boolean
+      description: "If true, we will allow user to use the address autofill feature"
+contextual-hint-feature:
+  description: This set holds all features pertaining to contextual hints.
+  hasExposure: true
+  exposureDescription: ""
+  variables:
+    features-enabled:
+      type: json
+      description: "This property provides a lookup table of whether specific contextual hints are enabled.\n"
+credit-card-autofill:
+  description: This property defines the credit card autofill feature
+  hasExposure: true
+  exposureDescription: ""
+  variables:
+    credit-card-autofill-status:
+      type: boolean
+      description: "If true, we will allow user to use the credit autofill feature"
+firefox-suggest-feature:
+  description: Configuration for the Firefox Suggest feature.
+  hasExposure: true
+  exposureDescription: ""
+  variables:
+    status:
+      type: boolean
+      description: "Whether the feature is enabled. When Firefox Suggest is enabled, Firefox will download and store new search suggestions in the background, and show additional Search settings to control which suggestions appear in the awesomebar. When Firefox Suggest is disabled, Firefox will not download new suggestions, and hide the additional Search settings.\n"
+general-app-features:
+  description: The feature that contains feature flags for the entire application
+  hasExposure: true
+  exposureDescription: ""
+  variables:
+    report-site-issue:
+      type: json
+      description: This property defines whether or not the feature is enabled
+homescreenFeature:
+  description: The homescreen that the user goes to when they press home or new tab.
+  hasExposure: true
+  exposureDescription: ""
+  variables:
+    pocket-sponsored-stories:
+      type: boolean
+      description: "This property defines whether pocket sponsored stories appear on the homepage.\n"
+    sections-enabled:
+      type: json
+      description: "This property provides a lookup table of whether or not the given section should be enabled. If the section is enabled, it should be toggleable in the settings screen, and on by default.\n"
+messaging:
+  description: "The in-app messaging system\n"
+  hasExposure: true
+  exposureDescription: ""
+  variables:
+    actions:
+      type: json
+      description: A growable map of action URLs.
+    message-under-experiment:
+      type: string
+      description: "Deprecated. Please use \"experiment\": \"{experiment}\" instead."
+    messages:
+      type: json
+      description: "A growable collection of messages, where the Key is the message identifier and the value is its associated MessageData.\n"
+    on-control:
+      type: string
+      description: What should be displayed when a control message is selected.
+      enum:
+        - show-next-message
+        - show-none
+    styles:
+      type: json
+      description: "A map of styles to configure message appearance.\n"
+    triggers:
+      type: json
+      description: "A collection of out the box trigger expressions. Each entry maps to a valid JEXL expression.\n"
+onboarding-framework-feature:
+  description: "The new onboarding framework feature that will allow onboarding to be experimentable through initial experiments.\n"
+  hasExposure: true
+  exposureDescription: ""
+  variables:
+    cards:
+      type: json
+      description: "The list of available cards for onboarding.\n"
+    conditions:
+      type: json
+      description: "A collection of out the box conditional expressions to be used in determining whether a card should show or not. Each entry maps to a valid JEXL expression.\n"
+    dismissable:
+      type: boolean
+      description: "Whether or not the entire onboarding is dismissable by pressing an X at the top right corner of the screen.\n"
+private-browsing:
+  description: Private Browsing Mode
+  hasExposure: true
+  exposureDescription: ""
+  variables:
+    felt-privacy-enabled:
+      type: boolean
+      description: "If true, enable felt privacy related UI"
+qr-code-coordinator-refactor:
+  description: "The feature for managing the roll out of the qrCode coordinator.\n"
+  hasExposure: true
+  exposureDescription: ""
+  variables:
+    enabled:
+      type: boolean
+      description: "Enables the feature\n"
+redux-integration-feature:
+  description: "This feature is for managing the roll out of the Redux integration feature\n"
+  hasExposure: true
+  exposureDescription: ""
+  variables:
+    enabled:
+      type: boolean
+      description: "Enables the feature\n"
+search:
+  description: "Configuring the functionality to do with search. This will be separated into smaller sub-features in later releases.\n"
+  hasExposure: true
+  exposureDescription: ""
+  variables:
+    awesome-bar:
+      type: json
+      description: Configuring the awesome bar.
+search-term-groups-feature:
+  description: The feature that controls whether or not search term groups are enabled.
+  hasExposure: true
+  exposureDescription: ""
+  variables:
+    grouping-enabled:
+      type: json
+      description: This property provides a lookup table of whether or not the given grouping should be enabled.
+share-extension-coordinator-refactor:
+  description: "This feature is for managing the roll out of the share extension coordinator as part of the changes to the navigation in the app\n"
+  hasExposure: true
+  exposureDescription: ""
+  variables:
+    enabled:
+      type: boolean
+      description: "Enables the feature\n"
+share-sheet:
+  description: This feature define the redesign of the share sheet
+  hasExposure: true
+  exposureDescription: ""
+  variables:
+    move-actions:
+      type: boolean
+      description: If true copy and send to device are moved to share sheet
+    toolbar-changes:
+      type: boolean
+      description: If true share option is shown on the toolbar
+shopping2023:
+  description: "The configuration setting for the status of the Fakespot feature\n"
+  hasExposure: true
+  exposureDescription: ""
+  variables:
+    back_in_stock_reporting:
+      type: boolean
+      description: "If true, enables for users the reporting feature for products back in stock.\n"
+    config:
+      type: json
+      description: "A Map of website configurations\n"
+    product-recommendations:
+      type: boolean
+      description: "If true, recommended products feature is enabled\n to be shown to the user based on their preference.\n"
+    relay:
+      type: string
+      description: "Configurable relay URL for production environment\n"
+    status:
+      type: boolean
+      description: "Whether the Fakespot feature is enabled or disabled\n"
+spotlight-search:
+  description: Add pages as items findable with Spotlight.
+  hasExposure: true
+  exposureDescription: ""
+  variables:
+    enabled:
+      type: boolean
+      description: "If this is true, then on each page load adds a new item to Spotlight."
+    icon-type:
+      type: string
+      description: "The icon that is displayed next to the item in the search results. If this is `null`, then no icon is displayed.\n"
+    keep-for-days:
+      type: int
+      description: "Number of days to keep the item before automatic deletion. If this is left `null`, then it is left to iOS's default.\n"
+    searchable-content:
+      type: string
+      description: "The text content that is made searchable. If this is `null` then no additional content is used, and only the title and URL will be used.\n"
+tab-tray-refactor-feature:
+  description: "This feature is for managing the roll out of the Tab Tray refactor feature\n"
+  hasExposure: true
+  exposureDescription: ""
+  variables:
+    enabled:
+      type: boolean
+      description: "Enables the feature\n"
+tabTrayFeature:
+  description: The tab tray screen that the user goes to when they open the tab tray.
+  hasExposure: true
+  exposureDescription: ""
+  variables:
+    sections-enabled:
+      type: json
+      description: "This property provides a lookup table of whether or not the given section should be enabled. If the section is enabled, it should be toggleable in the settings screen, and on by default."
+wallpaper-feature:
+  description: This property defines the configuration for the wallpaper feature
+  hasExposure: true
+  exposureDescription: ""
+  variables:
+    configuration:
+      type: json
+      description: This property defines the configuration for the wallpaper feature
+    onboarding-sheet:
+      type: boolean
+      description: This property defines whether the wallpaper onboarding is shown or not
+zoom-feature:
+  description: "The configuration for the status of the zoom feature\n"
+  hasExposure: true
+  exposureDescription: ""
+  variables:
+    status:
+      type: boolean
+      description: "Whether the page zoom feature is enabled or not\n"

--- a/experimenter/experimenter/features/manifests/ios/v121.0.0/release.fml.yaml
+++ b/experimenter/experimenter/features/manifests/ios/v121.0.0/release.fml.yaml
@@ -1,0 +1,755 @@
+---
+version: 1.0.0
+about:
+  description: The root level Feature Manifest for Firefox for iOS
+channels:
+  - release
+features:
+  address-autofill-feature:
+    description: This property defines the address card autofill feature
+    variables:
+      status:
+        description: "If true, we will allow user to use the address autofill feature"
+        type: Boolean
+        default: false
+  contextual-hint-feature:
+    description: This set holds all features pertaining to contextual hints.
+    variables:
+      features-enabled:
+        description: "This property provides a lookup table of whether specific contextual hints are enabled.\n"
+        type: "Map<ContextualHint, Boolean>"
+        default:
+          toolbar-hint: true
+  credit-card-autofill:
+    description: This property defines the credit card autofill feature
+    variables:
+      credit-card-autofill-status:
+        description: "If true, we will allow user to use the credit autofill feature"
+        type: Boolean
+        default: false
+  firefox-suggest-feature:
+    description: Configuration for the Firefox Suggest feature.
+    variables:
+      status:
+        description: "Whether the feature is enabled. When Firefox Suggest is enabled, Firefox will download and store new search suggestions in the background, and show additional Search settings to control which suggestions appear in the awesomebar. When Firefox Suggest is disabled, Firefox will not download new suggestions, and hide the additional Search settings.\n"
+        type: Boolean
+        default: false
+  general-app-features:
+    description: The feature that contains feature flags for the entire application
+    variables:
+      report-site-issue:
+        description: This property defines whether or not the feature is enabled
+        type: GeneralFeature
+        default:
+          status: false
+  homescreenFeature:
+    description: The homescreen that the user goes to when they press home or new tab.
+    variables:
+      pocket-sponsored-stories:
+        description: "This property defines whether pocket sponsored stories appear on the homepage.\n"
+        type: Boolean
+        default: false
+      sections-enabled:
+        description: "This property provides a lookup table of whether or not the given section should be enabled. If the section is enabled, it should be toggleable in the settings screen, and on by default.\n"
+        type: "Map<HomeScreenSection, Boolean>"
+        default:
+          jump-back-in: true
+          recent-explorations: true
+  messaging:
+    description: "The in-app messaging system\n"
+    documentation:
+      - name: User documentation
+        url: "https://experimenter.info/messaging/mobile-messaging"
+    contacts:
+      - jhugman@mozilla.com
+      - brennie@mozilla.com
+      - gbuciu@mozilla.com
+      - wteichmann@mozilla.com
+    events:
+      - "https://dictionary.telemetry.mozilla.org/apps/firefox_ios/metrics/messaging_shown"
+      - "https://dictionary.telemetry.mozilla.org/apps/firefox_ios/metrics/messaging_clicked"
+      - "https://dictionary.telemetry.mozilla.org/apps/firefox_ios/metrics/messaging_expired"
+      - "https://dictionary.telemetry.mozilla.org/apps/firefox_ios/metrics/messaging_dismissed"
+      - "https://dictionary.telemetry.mozilla.org/apps/firefox_ios/metrics/messaging_malformed"
+    variables:
+      actions:
+        description: A growable map of action URLs.
+        type: "Map<String, String>"
+        default:
+          ENABLE_PRIVATE_BROWSING: "://deep-link?url=homepanel/new-private-tab"
+          MAKE_DEFAULT_BROWSER: "://deep-link?url=default-browser/system-settings"
+          MAKE_DEFAULT_BROWSER_WITH_TUTORIAL: "://deep-link?url=default-browser/tutorial"
+          OPEN_NEW_TAB: "://deep-link?url=homepanel/new-tab"
+          OPEN_SETTINGS: "://deep-link?url=settings/general"
+          OPEN_SETTINGS_EMAIL: "://deep-link?url=settings/mailto"
+          OPEN_SETTINGS_FXA: "://deep-link?url=settings/fxa"
+          OPEN_SETTINGS_HOMESCREEN: "://deep-link?url=settings/homepage"
+          OPEN_SETTINGS_NEW_TAB: "://deep-link?url=settings/newtab"
+          OPEN_SETTINGS_PRIVACY: "://deep-link?url=settings/clear-private-data"
+          OPEN_SETTINGS_SEARCH_ENGINE: "://deep-link?url=settings/search"
+          OPEN_SETTINGS_THEME: "://deep-link?url=settings/theme"
+          OPEN_SETTINGS_WALLPAPERS: "://deep-link?url=settings/wallpaper"
+          VIEW_BOOKMARKS: "://deep-link?url=homepanel/bookmarks"
+          VIEW_DOWNLOADS: "://deep-link?url=homepanel/downloads"
+          VIEW_HISTORY: "://deep-link?url=homepanel/history"
+          VIEW_READING_LIST: "://deep-link?url=homepanel/reading-list"
+          VIEW_TOP_SITES: "://deep-link?url=homepanel/top-sites"
+      message-under-experiment:
+        description: "Deprecated. Please use \"experiment\": \"{experiment}\" instead."
+        type: Option<String>
+        default: ~
+      messages:
+        description: "A growable collection of messages, where the Key is the message identifier and the value is its associated MessageData.\n"
+        type: "Map<String, MessageData>"
+        default:
+          default-browser:
+            action: MAKE_DEFAULT_BROWSER_WITH_TUTORIAL
+            button-label: Default Browser/DefaultBrowserCard.Button.v2
+            style: FALLBACK
+            surface: new-tab-card
+            text: Default Browser/DefaultBrowserCard.Description
+            title: Default Browser/DefaultBrowserCard.Title
+            trigger:
+              - I_AM_NOT_DEFAULT_BROWSER
+              - SUPPORTS_DEFAULT_BROWSER
+              - ON_FOURTH_LAUNCH_THIS_YEAR
+      on-control:
+        description: What should be displayed when a control message is selected.
+        type: ControlMessageBehavior
+        default: show-next-message
+      styles:
+        description: "A map of styles to configure message appearance.\n"
+        type: "Map<String, StyleData>"
+        default:
+          DEFAULT:
+            max-display-count: 5
+            priority: 50
+          FALLBACK:
+            max-display-count: 20
+            priority: 40
+          NOTIFICATION:
+            max-display-count: 1
+            priority: 50
+          PERSISTENT:
+            max-display-count: 20
+            priority: 50
+          SURVEY:
+            max-display-count: 10
+            priority: 55
+          URGENT:
+            max-display-count: 10
+            priority: 100
+          WARNING:
+            max-display-count: 10
+            priority: 60
+      triggers:
+        description: "A collection of out the box trigger expressions. Each entry maps to a valid JEXL expression.\n"
+        type: "Map<String, String>"
+        default:
+          AFTER_THREE_LAUNCHES_THIS_WEEK: "'app_cycle.foreground'|eventSum('Weeks', 1, 0) >= 3"
+          ALLOWED_TIPS_NOTIFICATIONS: allowed_tips_notifications
+          ALWAYS: "true"
+          DEVICE_ANDROID: "os == 'Android'"
+          DEVICE_IOS: "os == 'iOS'"
+          INACTIVE_NEW_USER: is_inactive_new_user
+          I_AM_DEFAULT_BROWSER: is_default_browser
+          I_AM_NOT_DEFAULT_BROWSER: is_default_browser == false
+          MORE_THAN_24H_SINCE_INSTALLED_OR_UPDATED: days_since_update >= 1
+          NEVER: "false"
+          NOT_INSTALLED_TODAY: days_since_install > 0
+          NOT_LAUNCHED_YESTERDAY: "'app_cycle.foreground'|eventLastSeen('Days', 1) > 1"
+          ON_FOURTH_LAUNCH_THIS_YEAR: "'app_cycle.foreground'|eventSum('Years', 1, 0) > 3"
+          SUPPORTS_DEFAULT_BROWSER: "os_version|versionCompare('14.!') >= 0"
+          USER_DE_SPEAKER: "'de' in locale"
+          USER_EN_SPEAKER: "'en' in locale"
+          USER_FR_SPEAKER: "'fr' in locale"
+          USER_RECENTLY_INSTALLED: days_since_install < 7
+          USER_RECENTLY_UPDATED: days_since_update < 7 && days_since_install != days_since_update
+          USER_TIER_ONE_COUNTRY: "('US' in locale || 'GB' in locale || 'CA' in locale || 'DE' in locale || 'FR' in locale)"
+    allow-coenrollment: true
+  onboarding-framework-feature:
+    description: "The new onboarding framework feature that will allow onboarding to be experimentable through initial experiments.\n"
+    variables:
+      cards:
+        description: "The list of available cards for onboarding.\n"
+        type: "Map<String, NimbusOnboardingCardData>"
+        default:
+          notification-permissions:
+            body: Onboarding/Onboarding.Notification.Description.v120
+            buttons:
+              primary:
+                action: request-notifications
+                title: Onboarding/Onboarding.Notification.TurnOnNotifications.Action.v114
+              secondary:
+                action: next-card
+                title: Onboarding/Onboarding.Notification.Skip.Action.v115
+            image: notifications
+            order: 30
+            prerequisites:
+              - ALWAYS
+            title: Onboarding/Onboarding.Notification.Title.v120
+            type: fresh-install
+          sign-to-sync:
+            body: Onboarding/Onboarding.Sync.Description.v120
+            buttons:
+              primary:
+                action: sync-sign-in
+                title: Onboarding/Onboarding.Sync.SignIn.Action.v114
+              secondary:
+                action: next-card
+                title: Onboarding/Onboarding.Sync.Skip.Action.v114
+            image: sync-devices
+            order: 20
+            prerequisites:
+              - ALWAYS
+            title: Onboarding/Onboarding.Sync.Title.v120
+            type: fresh-install
+          update-sign-to-sync:
+            body: Upgrade/Upgrade.SyncSign.Description.v114
+            buttons:
+              primary:
+                action: sync-sign-in
+                title: Upgrade/Upgrade.SyncSign.Action.v114
+              secondary:
+                action: next-card
+                title: Onboarding/Onboarding.LaterAction.v114
+            image: sync-devices
+            order: 20
+            prerequisites:
+              - NEVER
+            title: Upgrade/Upgrade.SyncSign.Title.v114
+            type: upgrade
+          update-welcome:
+            body: Upgrade/Upgrade.Welcome.Description.v114
+            buttons:
+              primary:
+                action: next-card
+                title: Upgrade/Upgrade.Welcome.Action.v114
+            image: welcome-globe
+            order: 10
+            prerequisites:
+              - NEVER
+            title: Upgrade/Upgrade.Welcome.Title.v114
+            type: upgrade
+          welcome:
+            body: Onboarding/Onboarding.Welcome.Description.TreatementA.v120
+            buttons:
+              primary:
+                action: open-instructions-popup
+                title: Onboarding/Onboarding.Welcome.ActionTreatementA.v114
+              secondary:
+                action: next-card
+                title: Onboarding/Onboarding.Welcome.Skip.v114
+            image: welcome-globe
+            instructions-popup:
+              button-action: open-ios-fx-settings
+              button-title: Onboarding/DefaultBrowserPopup.ButtonTitle.v114
+              instructions:
+                - Onboarding/DefaultBrowserPopup.FirstLabel.v114
+                - Onboarding/DefaultBrowserPopup.SecondLabel.v114
+                - Onboarding/DefaultBrowserPopup.ThirdLabel.v114
+              title: Onboarding/DefaultBrowserPopup.Title.v114
+            link:
+              title: Onboarding/Onboarding.Welcome.Link.Action.v114
+              url: "https://www.mozilla.org/privacy/firefox/"
+            order: 10
+            prerequisites:
+              - ALWAYS
+            title: Onboarding/Onboarding.Welcome.Title.TreatementA.v120
+            type: fresh-install
+      conditions:
+        description: "A collection of out the box conditional expressions to be used in determining whether a card should show or not. Each entry maps to a valid JEXL expression.\n"
+        type: "Map<String, String>"
+        default:
+          ALWAYS: "true"
+          NEVER: "false"
+      dismissable:
+        description: "Whether or not the entire onboarding is dismissable by pressing an X at the top right corner of the screen.\n"
+        type: Boolean
+        default: true
+  private-browsing:
+    description: Private Browsing Mode
+    variables:
+      felt-privacy-enabled:
+        description: "If true, enable felt privacy related UI"
+        type: Boolean
+        default: false
+  qr-code-coordinator-refactor:
+    description: "The feature for managing the roll out of the qrCode coordinator.\n"
+    variables:
+      enabled:
+        description: "Enables the feature\n"
+        type: Boolean
+        default: false
+  redux-integration-feature:
+    description: "This feature is for managing the roll out of the Redux integration feature\n"
+    variables:
+      enabled:
+        description: "Enables the feature\n"
+        type: Boolean
+        default: true
+  search:
+    description: "Configuring the functionality to do with search. This will be separated into smaller sub-features in later releases.\n"
+    variables:
+      awesome-bar:
+        description: Configuring the awesome bar.
+        type: AwesomeBar
+        default:
+          position:
+            is-bottom: true
+            is-position-feature-enabled: true
+            is-toolbar-cfr-on: false
+          search-highlights: false
+          use-page-content: false
+  search-term-groups-feature:
+    description: The feature that controls whether or not search term groups are enabled.
+    variables:
+      grouping-enabled:
+        description: This property provides a lookup table of whether or not the given grouping should be enabled.
+        type: "Map<SearchTermGroups, Boolean>"
+        default:
+          history-groups: true
+          tab-tray-groups: false
+  share-extension-coordinator-refactor:
+    description: "This feature is for managing the roll out of the share extension coordinator as part of the changes to the navigation in the app\n"
+    variables:
+      enabled:
+        description: "Enables the feature\n"
+        type: Boolean
+        default: true
+  share-sheet:
+    description: This feature define the redesign of the share sheet
+    variables:
+      move-actions:
+        description: If true copy and send to device are moved to share sheet
+        type: Boolean
+        default: false
+      toolbar-changes:
+        description: If true share option is shown on the toolbar
+        type: Boolean
+        default: false
+  shopping2023:
+    description: "The configuration setting for the status of the Fakespot feature\n"
+    variables:
+      back_in_stock_reporting:
+        description: "If true, enables for users the reporting feature for products back in stock.\n"
+        type: Boolean
+        default: false
+      config:
+        description: "A Map of website configurations\n"
+        type: "Map<String, WebsiteConfig>"
+        default:
+          amazon:
+            productIdFromURLRegex: "(?:[\\\\/]|$|%2F)(?<productId>[A-Z0-9]{10})(?:[\\\\/]|$|\\\\#|\\\\?|%2F)"
+            validTLDs:
+              - com
+          bestbuy:
+            productIdFromURLRegex: "\\\\/(?<productId>\\\\d+\\\\.p)"
+            validTLDs:
+              - com
+          walmart:
+            productIdFromURLRegex: "\\\\/ip\\\\/(?:[A-Za-z0-9-]{1,320}\\\\/)?(?<productId>[0-9]{3,13})"
+            validTLDs:
+              - com
+      product-recommendations:
+        description: "If true, recommended products feature is enabled\n to be shown to the user based on their preference.\n"
+        type: Boolean
+        default: false
+      relay:
+        description: "Configurable relay URL for production environment\n"
+        type: String
+        default: "https://mozilla-ohttp-fakespot.fastly-edge.com/"
+      status:
+        description: "Whether the Fakespot feature is enabled or disabled\n"
+        type: Boolean
+        default: false
+  spotlight-search:
+    description: Add pages as items findable with Spotlight.
+    variables:
+      enabled:
+        description: "If this is true, then on each page load adds a new item to Spotlight."
+        type: Boolean
+        default: false
+      icon-type:
+        description: "The icon that is displayed next to the item in the search results. If this is `null`, then no icon is displayed.\n"
+        type: Option<IconType>
+        default: letter
+      keep-for-days:
+        description: "Number of days to keep the item before automatic deletion. If this is left `null`, then it is left to iOS's default.\n"
+        type: Option<Int>
+        default: ~
+      searchable-content:
+        description: "The text content that is made searchable. If this is `null` then no additional content is used, and only the title and URL will be used.\n"
+        type: Option<PageContent>
+        default: text-excerpt
+  tab-tray-refactor-feature:
+    description: "This feature is for managing the roll out of the Tab Tray refactor feature\n"
+    variables:
+      enabled:
+        description: "Enables the feature\n"
+        type: Boolean
+        default: false
+  tabTrayFeature:
+    description: The tab tray screen that the user goes to when they open the tab tray.
+    variables:
+      sections-enabled:
+        description: "This property provides a lookup table of whether or not the given section should be enabled. If the section is enabled, it should be toggleable in the settings screen, and on by default."
+        type: "Map<TabTraySection, Boolean>"
+        default:
+          inactive-tabs: true
+  wallpaper-feature:
+    description: This property defines the configuration for the wallpaper feature
+    variables:
+      configuration:
+        description: This property defines the configuration for the wallpaper feature
+        type: WallpaperConfiguration
+        default:
+          status: true
+          version: v1
+      onboarding-sheet:
+        description: This property defines whether the wallpaper onboarding is shown or not
+        type: Boolean
+        default: true
+  zoom-feature:
+    description: "The configuration for the status of the zoom feature\n"
+    variables:
+      status:
+        description: "Whether the page zoom feature is enabled or not\n"
+        type: Boolean
+        default: true
+enums:
+  ContextualHint:
+    description: The identifiers for a individual contextual hints.
+    variants:
+      toolbar-hint:
+        description: The contextual hint bubble that appears to provide a hint about the toolbar.
+  ControlMessageBehavior:
+    description: An enum to influence what should be displayed when a control message is selected.
+    variants:
+      show-next-message:
+        description: The next eligible message should be shown.
+      show-none:
+        description: The surface should show no message.
+  HomeScreenSection:
+    description: The identifiers for the sections of the homescreen.
+    variants:
+      jump-back-in:
+        description: The tabs the user was looking immediately before being interrupted.
+      recent-explorations:
+        description: The tab groups
+  IconType:
+    description: "The icon that will be added to the item in the device's search engine."
+    variants:
+      favicon:
+        description: The favicon of the page
+      letter:
+        description: An icon generated from the first letter of the base domain.
+      screenshot:
+        description: A screenshot of the page at load time.
+  MessageSurfaceId:
+    description: "For messaging, we would like to have a message tell us which surface its associated with. This is a label that matches across both Android and iOS.\n"
+    variants:
+      Unknown:
+        description: A message has NOT declared its target surface.
+      new-tab-card:
+        description: This is the card that appears at the top on the Firefox Home Page.
+      notification:
+        description: This is a local notification send to the user periodically with tips and updates.
+      survey:
+        description: This is a full-page that appears providing a survey to the user.
+  NimbusOnboardingImages:
+    description: "The identifiers for the different images available for cards in onboarding\n"
+    variants:
+      notifications:
+        description: "Corresponding to the notifications image\n"
+      notifications-ctd:
+        description: "Corresponding to the notifications image for CTD\n"
+      search-widget:
+        description: "Corresponding to the fox search widget image\n"
+      set-to-dock:
+        description: "Corresponding to the set to dock image\n"
+      sync-devices:
+        description: "Corresponding to the sync-devices image\n"
+      sync-devices-ctd:
+        description: "Corresponding to the sync image for CTD\n"
+      welcome-ctd:
+        description: "Corresponding to the welcome image for CTD\n"
+      welcome-globe:
+        description: "Corresponding to the fox world image\n"
+  OnboardingActions:
+    description: "The identifiers for the different actions available for cards in onboarding\n"
+    variants:
+      next-card:
+        description: "Will take the user to the next card\n"
+      open-instructions-popup:
+        description: "Will open up a popup with instructions for something\n"
+      read-privacy-policy:
+        description: "Will open a webview where the user can read the privacy policy\n"
+      request-notifications:
+        description: "Will request to allow notifications from the user\n"
+      set-default-browser:
+        description: "Will send the user to settings to set Firefox as their default browser\n"
+      sync-sign-in:
+        description: "Will take the user to the sync sign in flow\n"
+  OnboardingInstructionsPopupActions:
+    description: "The identifiers for the different actions available for the insturction card in onboarding\n"
+    variants:
+      dismiss:
+        description: "Will dismiss the popup\n"
+      dismiss-and-next-card:
+        description: "Will dismiss the popup and move to the next card\n"
+      open-ios-fx-settings:
+        description: "Will take the user to the default browser settings in the iOS system settings\n"
+  OnboardingType:
+    description: "The identifiers for the different types of onboarding cards.\n"
+    variants:
+      fresh-install:
+        description: "Corresponding to onboarding cards that are for new users\n"
+      upgrade:
+        description: "Corresponding to onboarding cards that are for users who have updated\n"
+  PageContent:
+    description: "The page content that will be added as an item in the device's search engine."
+    variants:
+      html-content:
+        description: Use all the page as HTML
+      text-content:
+        description: Use all the page as text
+      text-excerpt:
+        description: Only use the first paragraph
+  SearchTermGroups:
+    description: The identifiers for the different types of search term groups.
+    variants:
+      history-groups:
+        description: Grouping for items in History and RecentlyVisited
+      tab-tray-groups:
+        description: Grouping for items in the Tab Tray and in JumpBackIn
+  TabTraySection:
+    description: The identifiers for the sections of the tab tray.
+    variants:
+      inactive-tabs:
+        description: Tabs that have been automatically closed for the user.
+  WallpaperVariantVersion:
+    description: An enum to identify which version of the wallpaper system to use
+    variants:
+      legacy:
+        description: The legacy wallpaper version
+      v1:
+        description: The 2022 MR version
+objects:
+  AwesomeBar:
+    description: "A configuration option for the awesome bar. Part of the `search` feature."
+    fields:
+      min-search-term:
+        description: The minimum number of characters that the user types before searching in the page.
+        type: Int
+        default: 3
+      position:
+        description: "This property defines whether or not the feature is enabled, and the position of the search bar\n"
+        type: SearchBarPositionFeature
+        default:
+          is-bottom: true
+          is-position-feature-enabled: true
+          is-toolbar-cfr-on: true
+      search-highlights:
+        description: Whether or not search highlights are enabled
+        type: Boolean
+        default: false
+      use-page-content:
+        description: "Search in the open tab's text content when typing."
+        type: Boolean
+        default: false
+  GeneralFeature:
+    description: The configuration for the a feature that can be enabled or disabled
+    fields:
+      status:
+        description: Whether or not the feature is enabled
+        type: Boolean
+        default: false
+  MessageData:
+    description: "An object to describe a message. It uses human readable strings to describe the triggers, action and style of the message as well as the text of the message and call to action.\n"
+    fields:
+      action:
+        description: "A URL of a page or a deeplink. This may have substitution variables in.\n"
+        type: String
+        default: ""
+      button-label:
+        description: "The text on the button. If no text is present, the whole message is clickable.\n"
+        type: Option<Text>
+        default: ~
+      experiment:
+        description: The experiment slug that this message is involved in.
+        type: Option<String>
+        default: ~
+      is-control:
+        description: "Indicates if this message is the control message, if true shouldn't be displayed"
+        type: Boolean
+        default: false
+      style:
+        description: "The style as described in a `StyleData` from the styles table.\n"
+        type: String
+        default: DEFAULT
+      surface:
+        description: Each message will tell us the surface it is targeting with this.
+        type: MessageSurfaceId
+        default: Unknown
+      text:
+        description: The message text displayed to the user
+        type: Text
+        default: ""
+      title:
+        description: The title text displayed to the user
+        type: Option<Text>
+        default: ~
+      trigger:
+        description: "A list of strings corresponding to targeting expressions. The message will be shown if all expressions `true`.\n"
+        type: List<String>
+        default: []
+  NimbusInstructionPopup:
+    description: "The object outlining the content of the instruction card.\n"
+    fields:
+      button-action:
+        description: "The action the button should have. Default is `dismiss-and-next-card`\n"
+        type: OnboardingInstructionsPopupActions
+        default: dismiss-and-next-card
+      button-title:
+        description: "The title the button should have. This should never be defaulted.\n"
+        type: Text
+        default: ""
+      instructions:
+        description: "A list of instructions, either as free text, or as Text identifiers.\n"
+        type: List<Text>
+        default: []
+      title:
+        description: "The text of the popup. This should never be defaulted.\n"
+        type: Text
+        default: ""
+  NimbusOnboardingButton:
+    description: "A group of properties describing the attributes of a card.\n"
+    fields:
+      action:
+        description: "The action the button should take. The default for this will be \"next-card\"\n"
+        type: OnboardingActions
+        default: next-card
+      title:
+        description: "The text of the button title. This should never be defaulted.\n"
+        type: Text
+        default: ""
+  NimbusOnboardingButtons:
+    description: "A set of buttons for the card. There can be up to two, but there must be at least one.\n"
+    fields:
+      primary:
+        description: "The primary button for the card. This must exist.\n"
+        type: NimbusOnboardingButton
+        default:
+          action: next-card
+          title: Primary Button
+      secondary:
+        description: "A secondary, optional, button for the card.\n"
+        type: Option<NimbusOnboardingButton>
+        default: ~
+  NimbusOnboardingCardData:
+    description: "A group of properties describing the attributes of a card.\n"
+    fields:
+      body:
+        description: "The body text dispalyed on the card, in less prominent text. This should never be defaulted.\n"
+        type: Text
+        default: ""
+      buttons:
+        description: "The set of buttons associated with the card.\n"
+        type: NimbusOnboardingButtons
+        default:
+          primary:
+            action: next-card
+            title: Onboarding/Onboarding.Sync.Skip.Action.v114
+          secondary: ~
+      disqualifiers:
+        description: "A list of strings corresponding to targeting expressions. The card will not be shown if any expression is `true`.\n"
+        type: List<String>
+        default: []
+      image:
+        description: "The image that should be dispalyed on the card.\n"
+        type: NimbusOnboardingImages
+        default: welcome-globe
+      instructions-popup:
+        description: "The object describing the specific instruction popup button for a card. If left empty, the card will have no instruction popup information\n"
+        type: Option<NimbusInstructionPopup>
+        default: ~
+      link:
+        description: "The object describing the link button for a card. If left empty, the card will have no link.\n"
+        type: Option<NimbusOnboardingLink>
+        default: ~
+      order:
+        description: "The place in the order where the card will be found. The feature layer will then sort the cards based on this field.\n"
+        type: Int
+        default: 10
+      prerequisites:
+        description: "A list of strings corresponding to targeting expressions. The card will be shown if all expressions `true` and if no expressions in the `disqualifiers` table are true, or if the `disqualifiers` table is empty.\n"
+        type: List<String>
+        default: []
+      title:
+        description: "The title displayed on the card, in prominent, bolded text. This should never be defaulted.\n"
+        type: Text
+        default: ""
+      type:
+        description: "The type of onboarding this card should be shown in, whether it a fresh install or an update. The default is fresh-install.\n"
+        type: OnboardingType
+        default: fresh-install
+  NimbusOnboardingLink:
+    description: "A group of properties describing the attributes for the active link on a card\n"
+    fields:
+      title:
+        description: "The text of the link title.\n"
+        type: Text
+        default: Onboarding/Onboarding.Welcome.Link.Action.v114
+      url:
+        description: "The url that the link will lead to.\n"
+        type: String
+        default: "https://www.mozilla.org/privacy/firefox/"
+  SearchBarPositionFeature:
+    description: The configuration for the bottom search bar on the homescreen
+    fields:
+      is-bottom:
+        description: Whether or not the default position is at the bottom
+        type: Boolean
+        default: true
+      is-position-feature-enabled:
+        description: Whether or not the feature is enabled
+        type: Boolean
+        default: true
+      is-toolbar-cfr-on:
+        description: Whether or not the toolbar CFR shows. This is a temporary hack for Nimbus
+        type: Boolean
+        default: true
+  StyleData:
+    description: "A group of properities (predominantly visual) to the describe style of the message.\n"
+    fields:
+      max-display-count:
+        description: "How many sessions will this message be shown to the user before it is expired.\n"
+        type: Int
+        default: 5
+      priority:
+        description: "The importance of this message. 0 is not very important, 100 is very important.\n"
+        type: Int
+        default: 50
+  WallpaperConfiguration:
+    description: The configuration for the a feature that can be enabled or disabled
+    fields:
+      status:
+        description: Whether or not the feature is enabled
+        type: Boolean
+        default: false
+      version:
+        description: Which version of the wallpaper sytem to use
+        type: WallpaperVariantVersion
+        default: legacy
+  WebsiteConfig:
+    description: "It represents a configuration for different e-commerce websites and includes regular expressions for extracting product IDs from their respective URLs\n"
+    fields:
+      productIdFromURLRegex:
+        description: "It represents the product ID extracted from a regex query\n"
+        type: String
+        default: ""
+      validTLDs:
+        description: "Valid Top Level Domains\n"
+        type: List<String>
+        default: []

--- a/experimenter/manifesttool/fetch.py
+++ b/experimenter/manifesttool/fetch.py
@@ -54,7 +54,9 @@ def fetch_fml_app(
         # single file manifests could differ because they were based on different
         # commits.
         if ref is None:
-            ref = result.ref = github_api.get_main_ref(app_config.repo.name)
+            ref = result.ref = github_api.resolve_branch(
+                app_config.repo.name, app_config.repo.default_branch
+            )
 
         if version:
             print(f"fetch: {app_name} at {ref} version {version}")

--- a/experimenter/manifesttool/fetch.py
+++ b/experimenter/manifesttool/fetch.py
@@ -123,7 +123,7 @@ def fetch_legacy_app(
         # feature schemas could differ or not be present if they were removed in a
         # subsequent commit.
         if ref is None:
-            ref = result.ref = hgmo_api.get_bookmark_ref(
+            ref = result.ref = hgmo_api.resolve_branch(
                 app_config.repo.name, app_config.repo.default_branch
             )
 

--- a/experimenter/manifesttool/github_api.py
+++ b/experimenter/manifesttool/github_api.py
@@ -48,15 +48,18 @@ def paginated_api_request(path: str, per_page: int = 100) -> Generator[Any, None
         page += 1
 
 
-def get_main_ref(repo: str) -> Ref:
+def resolve_branch(repo: str, branch: str) -> Ref:
     """Get the revision of the current main branch of the requested repository.
 
     Args:
         repo:
             The repository, including the owner.
+
+        branch:
+            The name of the branch.
     """
-    rsp = api_request(f"repos/{repo}/branches/main")
-    return Ref("main", rsp["commit"]["sha"])
+    rsp = api_request(f"repos/{repo}/branches/{branch}")
+    return Ref(branch, rsp["commit"]["sha"])
 
 
 def get_branches(repo: str) -> list[Ref]:

--- a/experimenter/manifesttool/hgmo_api.py
+++ b/experimenter/manifesttool/hgmo_api.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 from typing import Any, Optional, overload
+from urllib.parse import urlencode
 
 import requests
 
@@ -14,7 +15,7 @@ def api_request(path: str, **kwargs) -> dict[str, Any]:
     return requests.get(f"{HGMO_URL}/{path}", **kwargs).json()
 
 
-def get_bookmark_ref(repo: str, bookmark: str) -> Ref:
+def resolve_branch(repo: str, bookmark: str) -> Ref:
     """Resolve a bookmark to a Ref.
 
     Args:
@@ -27,7 +28,12 @@ def get_bookmark_ref(repo: str, bookmark: str) -> Ref:
     Returns:
         A Ref for the given bookmark.
     """
-    rsp = api_request(f"{repo}/json-log?rev={bookmark}:{bookmark}")
+    query = urlencode(
+        {
+            "rev": f"bookmark({bookmark})",
+        }
+    )
+    rsp = api_request(f"{repo}/json-log?{query}")
     return Ref(bookmark, rsp["entries"][0]["node"])
 
 

--- a/experimenter/manifesttool/releases.py
+++ b/experimenter/manifesttool/releases.py
@@ -71,8 +71,6 @@ def discover_branched_releases(
     if branches is None:
         branches = [app_config.repo.default_branch]
 
-    refs = [
-        hgmo_api.get_bookmark_ref(app_config.repo.name, branch) for branch in branches
-    ]
+    refs = [hgmo_api.resolve_branch(app_config.repo.name, branch) for branch in branches]
 
     return resolve_ref_versions(app_config, refs)

--- a/experimenter/manifesttool/releases.py
+++ b/experimenter/manifesttool/releases.py
@@ -64,13 +64,18 @@ def discover_branched_releases(
     app_config: AppConfig,
     strategy: BranchedDiscoveryStrategy,
 ) -> dict[Version, Ref]:
-    assert app_config.repo.type == RepositoryType.HGMO
+    if app_config.repo.type == RepositoryType.GITHUB:
+        resolve_branch = github_api.resolve_branch
+    elif app_config.repo.type == RepositoryType.HGMO:
+        resolve_branch = hgmo_api.resolve_branch
+    else:  # pragma: no cover
+        raise AssertionError()
 
     # If there are no branches listed, we will only scan the default branch.
     branches = strategy.branches
     if branches is None:
         branches = [app_config.repo.default_branch]
 
-    refs = [hgmo_api.resolve_branch(app_config.repo.name, branch) for branch in branches]
+    refs = [resolve_branch(app_config.repo.name, branch) for branch in branches]
 
     return resolve_ref_versions(app_config, refs)

--- a/experimenter/manifesttool/tests/test_fetch.py
+++ b/experimenter/manifesttool/tests/test_fetch.py
@@ -425,7 +425,7 @@ class FetchTests(TestCase):
         generate_experimenter_yaml.assert_not_called()
 
     @patch.object(
-        manifesttool.fetch.hgmo_api, "get_bookmark_ref", lambda *args: Ref("tip", "ref")
+        manifesttool.fetch.hgmo_api, "resolve_branch", lambda *args: Ref("tip", "ref")
     )
     @patch.object(
         manifesttool.fetch.hgmo_api,
@@ -462,13 +462,13 @@ class FetchTests(TestCase):
             )
             self.assertEqual(fetch_file.call_count, 2)
 
-    @patch.object(manifesttool.fetch.hgmo_api, "get_bookmark_ref")
+    @patch.object(manifesttool.fetch.hgmo_api, "resolve_branch")
     @patch.object(
         manifesttool.fetch.hgmo_api,
         "fetch_file",
         side_effect=make_mock_fetch_file(ref="resolved"),
     )
-    def test_fetch_legacy_ref(self, fetch_file, get_bookmark_ref):
+    def test_fetch_legacy_ref(self, fetch_file, resolve_branch):
         """Testing fetch_legacy_app with a specific ref."""
         ref = Ref("custom", "resolved")
         with TemporaryDirectory() as tmp:
@@ -478,7 +478,7 @@ class FetchTests(TestCase):
             result = fetch_legacy_app(manifest_dir, "app", LEGACY_APP_CONFIG, ref)
             self.assertIsNone(result.exc)
 
-            get_bookmark_ref.assert_not_called()
+            resolve_branch.assert_not_called()
             fetch_file.assert_has_calls(
                 [
                     call(
@@ -512,13 +512,13 @@ class FetchTests(TestCase):
                     manifest_dir, "app", LEGACY_APP_CONFIG, version=Version(1)
                 )
 
-    @patch.object(manifesttool.fetch.hgmo_api, "get_bookmark_ref")
+    @patch.object(manifesttool.fetch.hgmo_api, "resolve_branch")
     @patch.object(
         manifesttool.fetch.hgmo_api,
         "fetch_file",
         side_effect=make_mock_fetch_file(ref="foo"),
     )
-    def test_fetch_legacy_ref_version(self, fetch_file, get_bookmark_ref):
+    def test_fetch_legacy_ref_version(self, fetch_file, resolve_branch):
         """Testing fetch_legacy_app with a ref and a version."""
         ref = Ref("v1.2.3", "foo")
         version = Version(1, 2, 3)
@@ -532,7 +532,7 @@ class FetchTests(TestCase):
             )
             self.assertEqual(result, FetchResult("app", ref, version))
 
-            get_bookmark_ref.assert_not_called()
+            resolve_branch.assert_not_called()
             fetch_file.assert_has_calls(
                 [
                     call(
@@ -558,7 +558,7 @@ class FetchTests(TestCase):
             )
 
     @patch.object(
-        manifesttool.fetch.hgmo_api, "get_bookmark_ref", lambda *args: Ref("tip", "ref")
+        manifesttool.fetch.hgmo_api, "resolve_branch", lambda *args: Ref("tip", "ref")
     )
     @patch.object(
         manifesttool.fetch.hgmo_api,
@@ -607,10 +607,10 @@ class FetchTests(TestCase):
 
     @patch.object(
         manifesttool.fetch.hgmo_api,
-        "get_bookmark_ref",
+        "resolve_branch",
         side_effect=Exception("Connection error"),
     )
-    def test_fetch_legacy_exception(self, get_bookmark_ref):
+    def test_fetch_legacy_exception(self, resolve_branch):
         """Testing fetch_fml_app when an exception is caught."""
         with TemporaryDirectory() as tmp:
             manifest_dir = Path(tmp)

--- a/experimenter/manifesttool/tests/test_github_api.py
+++ b/experimenter/manifesttool/tests/test_github_api.py
@@ -57,9 +57,8 @@ class GitHubApiTests(TestCase):
             status=403,
             body="do not try to json parse this",
         )
-        with self.assertRaises(Exception) as e:
-            github_api.resolve_branch("owner/repo")
-            self.assertIn("GitHub API rate limit exceeded", str(e))
+        with self.assertRaisesRegex(Exception, "GitHub API rate limit exceeded") as e:
+            github_api.resolve_branch("owner/repo", "main")
 
     @responses.activate
     def test_get_branches(self):

--- a/experimenter/manifesttool/tests/test_github_api.py
+++ b/experimenter/manifesttool/tests/test_github_api.py
@@ -31,8 +31,8 @@ class GitHubApiTests(TestCase):
     """Tests for GitHub API wrappers."""
 
     @responses.activate
-    def test_get_main_ref(self):
-        """Testing get_main_ref."""
+    def test_resolve_branch(self):
+        """Testing resolve_branch."""
         responses.get(
             "https://api.github.com/repos/owner/repo/branches/main",
             json={
@@ -42,7 +42,7 @@ class GitHubApiTests(TestCase):
             },
         )
 
-        result = github_api.get_main_ref("owner/repo")
+        result = github_api.resolve_branch("owner/repo", "main")
 
         self.assertEqual(result, Ref("main", "0" * 40))
 
@@ -58,7 +58,7 @@ class GitHubApiTests(TestCase):
             body="do not try to json parse this",
         )
         with self.assertRaises(Exception) as e:
-            github_api.get_main_ref("owner/repo")
+            github_api.resolve_branch("owner/repo")
             self.assertIn("GitHub API rate limit exceeded", str(e))
 
     @responses.activate

--- a/experimenter/manifesttool/tests/test_hgmo_api.py
+++ b/experimenter/manifesttool/tests/test_hgmo_api.py
@@ -20,10 +20,10 @@ class HgMoApiTests(TestCase):
         ]
     )
     @responses.activate
-    def test_get_bookmark_ref(self, ref_name: str, resolved: str):
+    def test_resolve_branch(self, ref_name: str, resolved: str):
         """Testing get_bookmark_rev."""
         responses.get(
-            f"{HGMO_URL}/repo/json-log?rev={ref_name}:{ref_name}",
+            f"{HGMO_URL}/repo/json-log?rev=bookmark({ref_name})",
             json={
                 "node": "bogus",
                 "entries": [
@@ -34,7 +34,7 @@ class HgMoApiTests(TestCase):
             },
         )
 
-        result = hgmo_api.get_bookmark_ref("repo", ref_name)
+        result = hgmo_api.resolve_branch("repo", ref_name)
 
         self.assertEqual(result, Ref(ref_name, resolved))
 

--- a/experimenter/manifesttool/tests/test_releases.py
+++ b/experimenter/manifesttool/tests/test_releases.py
@@ -6,6 +6,7 @@ from unittest import TestCase
 from unittest.mock import patch
 
 import responses
+from parameterized import parameterized
 
 import manifesttool
 from manifesttool.appconfig import (
@@ -246,51 +247,73 @@ class ReleaseTests(TestCase):
             ):
                 discover_tagged_releases("app", app_config, strategy.__root__)
 
-    @patch.object(
-        manifesttool.releases.hgmo_api,
-        "resolve_branch",
-        make_mock_resolve_branch(
-            {
-                "foo": "1",
-                "bar": "2",
-                "baz": "3",
-            }
-        ),
-    )
-    @patch.object(
-        manifesttool.releases.hgmo_api,
-        "fetch_file",
-        make_mock_fetch_file(
-            paths_by_ref={
-                "1": {"version.txt": "1.0.0"},
-                "2": {"version.txt": "2.0.0"},
-                "3": {"version.txt": "3.0.0"},
-            }
-        ),
-    )
-    def test_discover_branched_releases(self):
-        strategy = DiscoveryStrategy.create_branched(["foo", "bar", "baz"])
-        app_config = AppConfig(
-            slug="legacy-app",
-            repo=Repository(
-                type=RepositoryType.HGMO,
-                name="legacy-repo",
-                default_branch="foo",
+    @parameterized.expand(
+        [
+            (
+                AppConfig(
+                    slug="fml-app",
+                    repo=Repository(
+                        type=RepositoryType.GITHUB,
+                        name="fml-repo",
+                    ),
+                    fml_path="nimbus.fml.yaml",
+                    release_discovery=ReleaseDiscovery(
+                        version_file=VersionFile.create_plain_text("version.txt"),
+                        strategies=[
+                            DiscoveryStrategy.create_branched(["foo", "bar", "baz"])
+                        ],
+                    ),
+                ),
+                manifesttool.releases.github_api,
             ),
-            experimenter_yaml_path="experimenter.yaml",
-            release_discovery=ReleaseDiscovery(
-                version_file=VersionFile.create_plain_text("version.txt"),
-                strategies=[strategy],
+            (
+                AppConfig(
+                    slug="legacy-app",
+                    repo=Repository(
+                        type=RepositoryType.HGMO,
+                        name="legacy-repo",
+                        default_branch="foo",
+                    ),
+                    experimenter_yaml_path="experimenter.yaml",
+                    release_discovery=ReleaseDiscovery(
+                        version_file=VersionFile.create_plain_text("version.txt"),
+                        strategies=[
+                            DiscoveryStrategy.create_branched(["foo", "bar", "baz"])
+                        ],
+                    ),
+                ),
+                manifesttool.releases.hgmo_api,
             ),
-        )
+        ]
+    )
+    def test_discover_branched_releases(self, app_config: AppConfig, api):
+        strategy = app_config.release_discovery.strategies[0].__root__
+        app_name = app_config.slug.replace("-", "_")
+
+        branches = {"foo": "1", "bar": "2", "baz": "3"}
+        paths_by_ref = {
+            "1": {"version.txt": "1.0.0"},
+            "2": {"version.txt": "2.0.0"},
+            "3": {"version.txt": "3.0.0"},
+        }
 
         with TemporaryDirectory() as tmp:
             manifest_dir = Path(tmp)
             manifest_dir.joinpath(app_config.slug).mkdir()
 
-            releases = discover_branched_releases(
-                "legacy_app", app_config, strategy.__root__
-            )
+            with (
+                patch.object(
+                    api,
+                    "resolve_branch",
+                    make_mock_resolve_branch(branches),
+                ),
+                patch.object(
+                    api,
+                    "fetch_file",
+                    make_mock_fetch_file(paths_by_ref=paths_by_ref),
+                ),
+            ):
+                releases = discover_branched_releases(app_name, app_config, strategy)
 
             self.assertEqual(
                 releases,

--- a/experimenter/manifesttool/tests/test_releases.py
+++ b/experimenter/manifesttool/tests/test_releases.py
@@ -107,11 +107,11 @@ def mocks_for_discover_tagged_releases(
         )
 
 
-def make_mock_get_bookmark_ref(refs: dict[str, str]):
-    def get_bookmark_ref(repo: str, bookmark: str):
+def make_mock_resolve_branch(refs: dict[str, str]):
+    def resolve_branch(repo: str, bookmark: str):
         return Ref(bookmark, refs[bookmark])
 
-    return get_bookmark_ref
+    return resolve_branch
 
 
 class ReleaseTests(TestCase):
@@ -248,8 +248,8 @@ class ReleaseTests(TestCase):
 
     @patch.object(
         manifesttool.releases.hgmo_api,
-        "get_bookmark_ref",
-        make_mock_get_bookmark_ref(
+        "resolve_branch",
+        make_mock_resolve_branch(
             {
                 "foo": "1",
                 "bar": "2",
@@ -303,8 +303,8 @@ class ReleaseTests(TestCase):
 
     @patch.object(
         manifesttool.releases.hgmo_api,
-        "get_bookmark_ref",
-        side_effect=make_mock_get_bookmark_ref(
+        "resolve_branch",
+        side_effect=make_mock_resolve_branch(
             {
                 "default": "1",
             }
@@ -319,7 +319,7 @@ class ReleaseTests(TestCase):
             }
         ),
     )
-    def test_discover_branched_releases_default(self, get_bookmark_ref):
+    def test_discover_branched_releases_default(self, resolve_branch):
         strategy = DiscoveryStrategy.create_branched()
         app_config = AppConfig(
             slug="legacy-app",
@@ -350,4 +350,4 @@ class ReleaseTests(TestCase):
                 },
             )
 
-        get_bookmark_ref.assert_called_once_with(app_config.repo.name, "default")
+        resolve_branch.assert_called_once_with(app_config.repo.name, "default")


### PR DESCRIPTION
Because

- we currently only have branched release discovery strategy support for
  hg.mozilla.org-hosted repositories

This commit

- does some refactors to make the hgmo_api and github_api modules more similar;
- updates the branched release discovery strategy to support GitHub-hosted
  repositories; and
- does an import.

Note:
This does not add the branched strategy for focus_ios because nightly is
v9000.0.0.

Fixes #9772 