### PR TITLE
feat(nimbus): get analysis bases from weekly results as fallback

### DIFF
--- a/experimenter/experimenter/nimbus-ui/src/components/PageResults/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageResults/index.tsx
@@ -125,7 +125,7 @@ const PageResults: React.FunctionComponent<RouteComponentProps> = () => {
   const { external_config: externalConfig } = analysis.metadata || {};
 
   const allAnalysisBases: AnalysisBases[] = Object.keys(
-    analysis?.overall || {},
+    analysis?.overall || analysis?.weekly || {},
   ).sort() as AnalysisBases[];
   const analysisBasisHelpMarkdown =
     "Select the **analysis basis** whose results you want to see. See [defining exposure signals](https://experimenter.info/jetstream/configuration/#defining-exposure-signals) in the docs for more info.";


### PR DESCRIPTION
Because

- weekly results are available before overall
- experiments with multiple analysis bases may want to seem them in preliminary weekly results

This commit

- gets the analysis basis list from weekly as a fallback if overall results are not available

fixes #9775 