### PR TITLE
feat(nimbus): fall back to weekly results for analysis bases

### DIFF
--- a/experimenter/experimenter/nimbus-ui/src/components/PageResults/index.test.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageResults/index.test.tsx
@@ -26,6 +26,7 @@ import {
   mockAnalysisWithErrorsAndResults,
   mockAnalysisWithExposures,
   mockAnalysisWithSegments,
+  mockAnalysisWithWeeklyExposures,
   MOCK_METADATA_WITH_CONFIG,
 } from "src/lib/visualization/mocks";
 import { AnalysisData } from "src/lib/visualization/types";
@@ -156,7 +157,7 @@ describe("PageResults", () => {
   });
 
   it("displays the analysis basis options properly", async () => {
-    const { container } = render(
+    render(
       <Subject mockAnalysisData={mockAnalysisWithExposures} />,
     );
 
@@ -185,6 +186,24 @@ describe("PageResults", () => {
     expect(
       within(analysisBasisSelectParent).getByTestId(`${otherBasis}-radio`),
     ).toBeChecked();
+  });
+
+  it("displays the analysis basis options for weekly results", async () => {
+    render(
+      <Subject mockAnalysisData={mockAnalysisWithWeeklyExposures} />,
+    );
+
+    const defaultBasis = "enrollments";
+    const otherBasis = "exposures";
+
+    expect(screen.getByText("Analysis Basis"));
+    const analysisBasisSelectParent = screen.getByTestId(
+      "analysis-basis-results-selector",
+    );
+
+    // both exist
+    expect(within(analysisBasisSelectParent).getByText(defaultBasis));
+    expect(within(analysisBasisSelectParent).getByText(otherBasis));
   });
 
   it("displays analysis errors", async () => {

--- a/experimenter/experimenter/nimbus-ui/src/components/PageResults/index.test.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageResults/index.test.tsx
@@ -157,9 +157,7 @@ describe("PageResults", () => {
   });
 
   it("displays the analysis basis options properly", async () => {
-    render(
-      <Subject mockAnalysisData={mockAnalysisWithExposures} />,
-    );
+    render(<Subject mockAnalysisData={mockAnalysisWithExposures} />);
 
     const defaultBasis = "enrollments";
     const otherBasis = "exposures";
@@ -189,9 +187,7 @@ describe("PageResults", () => {
   });
 
   it("displays the analysis basis options for weekly results", async () => {
-    render(
-      <Subject mockAnalysisData={mockAnalysisWithWeeklyExposures} />,
-    );
+    render(<Subject mockAnalysisData={mockAnalysisWithWeeklyExposures} />);
 
     const defaultBasis = "enrollments";
     const otherBasis = "exposures";

--- a/experimenter/experimenter/nimbus-ui/src/components/PageResults/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageResults/index.tsx
@@ -124,9 +124,9 @@ const PageResults: React.FunctionComponent<RouteComponentProps> = () => {
 
   const { external_config: externalConfig } = analysis.metadata || {};
 
-  const allAnalysisBases: AnalysisBases[] = Object.keys(
-    analysis?.overall || analysis?.weekly || {},
-  ).sort() as AnalysisBases[];
+  const allAnalysisBases: AnalysisBases[] = Object.keys(analysis?.overall || {}).length > 0
+    ? Object.keys(analysis?.overall || {}).sort() as AnalysisBases[]
+    : Object.keys(analysis?.weekly || {}).sort() as AnalysisBases[];
   const analysisBasisHelpMarkdown =
     "Select the **analysis basis** whose results you want to see. See [defining exposure signals](https://experimenter.info/jetstream/configuration/#defining-exposure-signals) in the docs for more info.";
 

--- a/experimenter/experimenter/nimbus-ui/src/components/PageResults/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageResults/index.tsx
@@ -124,9 +124,10 @@ const PageResults: React.FunctionComponent<RouteComponentProps> = () => {
 
   const { external_config: externalConfig } = analysis.metadata || {};
 
-  const allAnalysisBases: AnalysisBases[] = Object.keys(analysis?.overall || {}).length > 0
-    ? Object.keys(analysis?.overall || {}).sort() as AnalysisBases[]
-    : Object.keys(analysis?.weekly || {}).sort() as AnalysisBases[];
+  const allAnalysisBases: AnalysisBases[] =
+    Object.keys(analysis?.overall || {}).length > 0
+      ? (Object.keys(analysis?.overall || {}).sort() as AnalysisBases[])
+      : (Object.keys(analysis?.weekly || {}).sort() as AnalysisBases[]);
   const analysisBasisHelpMarkdown =
     "Select the **analysis basis** whose results you want to see. See [defining exposure signals](https://experimenter.info/jetstream/configuration/#defining-exposure-signals) in the docs for more info.";
 

--- a/experimenter/experimenter/nimbus-ui/src/lib/visualization/mocks.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/lib/visualization/mocks.tsx
@@ -3755,6 +3755,13 @@ export const mockAnalysisWithExposures = mockAnalysis({
     },
   },
 });
+
+export const mockAnalysisWithWeeklyExposures = mockAnalysis({
+  weekly: {
+    enrollments: { all: weeklyMockAnalysis() },
+    exposures: { all: weeklyMockAnalysis() },
+  },
+});
 /*
  * An incomplete analysis is missing one or both of `retained` and/or `search_count`
  */

--- a/experimenter/experimenter/nimbus-ui/src/lib/visualization/mocks.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/lib/visualization/mocks.tsx
@@ -3761,6 +3761,7 @@ export const mockAnalysisWithWeeklyExposures = mockAnalysis({
     enrollments: { all: weeklyMockAnalysis() },
     exposures: { all: weeklyMockAnalysis() },
   },
+  overall: {},
 });
 /*
  * An incomplete analysis is missing one or both of `retained` and/or `search_count`


### PR DESCRIPTION
Because

* weekly results are available before overall
* experiments with multiple analysis bases may want to seem them in preliminary weekly results

This commit

* gets the analysis basis list from weekly as a fallback if overall results are not available
* adds a test because the last fix didn't actually fix it

fixes #9775 