### PR TITLE
Fixes #9792 feat(nimbus): Update Cirrus AS version to latest main

### DIFF
--- a/cirrus/server/Dockerfile
+++ b/cirrus/server/Dockerfile
@@ -15,7 +15,7 @@ WORKDIR /application-services
 
 # Checkout application services at a locked commit
 RUN git clone https://github.com/mozilla/application-services.git .
-RUN git fetch && git checkout 0a53eff4c6e89649b18086d259c0ff5a5fc89061
+RUN git fetch && git checkout e8d45a3554d2fbf05631ae7f801ad9d840c69819
 
 RUN git submodule init
 RUN git submodule update --recursive


### PR DESCRIPTION
Because

- We updated to the latest `main` version of App Services in experimenter/Dockerfile

This commit

- Also updates the experimenter/cirrus/server/Dockerfile to the same version of App Services

Fixes #9792 
