### PR TITLE
feat(nimbus): Land new advanced targeting with cor…

### DIFF
--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -1526,11 +1526,33 @@ EARLY_DAY_USER = NimbusTargetingConfig(
     application_choice_names=(Application.DESKTOP.name,),
 )
 
+EARLY_DAY_USER_V2 = NimbusTargetingConfig(
+    name="Early day user (less than 28 days)",
+    slug="early_day_user_v2",
+    description="Users with profiles that are less than 28 days old",
+    targeting=f"{PROFILELESSTHAN28DAYS}",
+    desktop_telemetry="",
+    sticky_required=True,
+    is_first_run_required=False,
+    application_choice_names=(Application.DESKTOP.name,),
+)
+
 EARLY_DAY_USER_NEED_DEFAULT = NimbusTargetingConfig(
     name="Early day user (28 days or less) needs default",
     slug="early_day_user_need_default",
     description="Less than 28 day old profile age and has not set default",
     targeting=f"{EARLY_DAY_USER.targeting} && {NEED_DEFAULT}",
+    desktop_telemetry="",
+    sticky_required=True,
+    is_first_run_required=False,
+    application_choice_names=(Application.DESKTOP.name,),
+)
+
+EARLY_DAY_USER_NEED_DEFAULT_V2 = NimbusTargetingConfig(
+    name="Early day user (less than 28 days) needs default",
+    slug="early_day_user_need_default_v2",
+    description="Users with profiles that are less than 28 days old and has not set default",
+    targeting=f"{EARLY_DAY_USER_V2.targeting} && {NEED_DEFAULT}",
     desktop_telemetry="",
     sticky_required=True,
     is_first_run_required=False,
@@ -1548,11 +1570,33 @@ EARLY_DAY_USER_NEED_PIN = NimbusTargetingConfig(
     application_choice_names=(Application.DESKTOP.name,),
 )
 
+EARLY_DAY_USER_NEED_PIN_V2 = NimbusTargetingConfig(
+    name="Early day user (less than 28 days) needs pin",
+    slug="early_day_user_need_pin_v2",
+    description="Users with profiles that are less than 28 days old and has not pinned",
+    targeting=f"{EARLY_DAY_USER_V2.targeting} && doesAppNeedPin",
+    desktop_telemetry="",
+    sticky_required=True,
+    is_first_run_required=False,
+    application_choice_names=(Application.DESKTOP.name,),
+)
+
 EARLY_DAY_USER_HAS_DEFAULT_NEED_PIN = NimbusTargetingConfig(
     name="Early day user (28 days or less) has default needs pin",
     slug="early_day_user_has_default_need_pin",
     description="Less than 28 day old profile age has set default and has not pinned",
     targeting=f"{EARLY_DAY_USER_NEED_PIN.targeting} && isDefaultBrowser",
+    desktop_telemetry="",
+    sticky_required=True,
+    is_first_run_required=False,
+    application_choice_names=(Application.DESKTOP.name,),
+)
+
+EARLY_DAY_USER_HAS_DEFAULT_NEED_PIN_V2 = NimbusTargetingConfig(
+    name="Early day user (less than 28 days) has default needs pin",
+    slug="early_day_user_has_default_need_pin_v2",
+    description="Less than 28 day old profile age has set default and has not pinned",
+    targeting=f"{EARLY_DAY_USER_NEED_PIN_V2.targeting} && isDefaultBrowser",
     desktop_telemetry="",
     sticky_required=True,
     is_first_run_required=False,

--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -1551,7 +1551,8 @@ EARLY_DAY_USER_NEED_DEFAULT = NimbusTargetingConfig(
 EARLY_DAY_USER_NEED_DEFAULT_V2 = NimbusTargetingConfig(
     name="Early day user (less than 28 days) needs default",
     slug="early_day_user_need_default_v2",
-    description="Users with profiles that are less than 28 days old and has not set default",
+    description="Users with profiles that are less than 28 days old and "
+    "has not set default",
     targeting=f"{EARLY_DAY_USER_V2.targeting} && {NEED_DEFAULT}",
     desktop_telemetry="",
     sticky_required=True,


### PR DESCRIPTION
We have a few "Early Day User ..." definitions targeting users with profiles <= 28 days. This is not consistent with DS definitions and overlaps with "Existing User" targeting (profiles >= 28 days). Since we don't want to modify existing targeting(to avoid affecting current/past experiments) This pull request is to add new targeting that corrects all targeting that references "Early user" to only target profile age < 28 days (NON INCLUSIVE) so that it's mutually exclusive with Existing user definitions.

Current Early day user definitions with <=28 days:-

    Early day user
    Early day user has default needs pin
    Early day user need default
    Early day user need pin

Fixes #9783
