### PR TITLE
feat(nimbus): Support multiple FML paths per app; fix focus-ios fetching

### DIFF
--- a/experimenter/experimenter/features/manifests/apps.yaml
+++ b/experimenter/experimenter/features/manifests/apps.yaml
@@ -56,7 +56,9 @@ focus_ios:
   repo:
     type: "github"
     name: "mozilla-mobile/focus-ios"
-  fml_path: "nimbus.fml.yaml"
+  fml_path:
+    - "focus-ios/nimbus.fml.yaml"
+    - "nimbus.fml.yaml"
   release_discovery:
     version_file:
       type: "plist"

--- a/experimenter/manifesttool/appconfig.py
+++ b/experimenter/manifesttool/appconfig.py
@@ -128,7 +128,7 @@ class AppConfig(BaseModel):
 
     slug: str
     repo: Repository
-    fml_path: Optional[str]
+    fml_path: Optional[Union[str, list[str]]]
     experimenter_yaml_path: Optional[str]
     release_discovery: Optional[ReleaseDiscovery]
 

--- a/experimenter/manifesttool/fetch.py
+++ b/experimenter/manifesttool/fetch.py
@@ -67,7 +67,18 @@ def fetch_fml_app(
         else:
             print(f"fetch: {app_name} at {ref}")
 
-        channels = nimbus_cli.get_channels(app_config, ref.target)
+        if isinstance(app_config.fml_path, str):
+            fml_path = app_config.fml_path
+        elif isinstance(app_config.fml_path, list):
+            for fml_path in app_config.fml_path:
+                if github_api.file_exists(app_config.repo.name, fml_path, ref.target):
+                    break
+            else:
+                raise Exception(
+                    f"Could not find a feature manifest for {app_name} at {ref}"
+                )
+
+        channels = nimbus_cli.get_channels(app_config, fml_path, ref.target)
         print(f"fetch: {app_name}: channels are {', '.join(channels)}")
 
         if not channels:
@@ -82,6 +93,7 @@ def fetch_fml_app(
             nimbus_cli.download_single_file(
                 manifest_dir,
                 app_config,
+                fml_path,
                 channel,
                 ref.target,
                 version,

--- a/experimenter/manifesttool/nimbus_cli.py
+++ b/experimenter/manifesttool/nimbus_cli.py
@@ -4,6 +4,7 @@ import sys
 from pathlib import Path
 from typing import Optional
 
+from manifesttool import github_api
 from manifesttool.appconfig import AppConfig, RepositoryType
 from manifesttool.version import Version
 
@@ -23,7 +24,7 @@ def nimbus_cli(args: list[str], *, output: bool = False):
     )
 
 
-def get_channels(app_config: AppConfig, ref: str) -> list[str]:
+def get_channels(app_config: AppConfig, fml_path: str, ref: str) -> list[str]:
     """Get the list of channels supported by the application."""
     assert app_config.repo.type == RepositoryType.GITHUB
     output = nimbus_cli(
@@ -34,7 +35,7 @@ def get_channels(app_config: AppConfig, ref: str) -> list[str]:
             "--json",
             "--ref",
             ref,
-            f"@{app_config.repo.name}/{app_config.fml_path}",
+            f"@{app_config.repo.name}/{fml_path}",
         ],
         output=True,
     )
@@ -53,12 +54,18 @@ def get_channels(app_config: AppConfig, ref: str) -> list[str]:
 def download_single_file(
     manifest_dir: Path,
     app_config: AppConfig,
+    fml_path: str,
     channel: str,
     ref: str,
     version: Optional[Version],
 ):
-    """Download the single-file FML manifest for the app on the specified channel."""
+    """Download the single-file FML manifest for the app on the specified
+    channel.
+
+    If the AppConfig provides multiple FML paths, they will be tried in order.
+    """
     assert app_config.repo.type == RepositoryType.GITHUB
+
     nimbus_cli(
         [
             "fml",
@@ -68,7 +75,7 @@ def download_single_file(
             channel,
             "--ref",
             ref,
-            f"@{app_config.repo.name}/{app_config.fml_path}",
+            f"@{app_config.repo.name}/{fml_path}",
             str(_get_fml_path(manifest_dir, app_config, channel, version)),
         ],
     )

--- a/experimenter/manifesttool/tests/test_nimbus_cli.py
+++ b/experimenter/manifesttool/tests/test_nimbus_cli.py
@@ -2,7 +2,7 @@ import json
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest import TestCase
-from unittest.mock import patch
+from unittest.mock import call, patch
 
 from parameterized import parameterized
 
@@ -31,7 +31,8 @@ class NimbusCliTests(TestCase):
     def test_get_channels(self, mock_cli):
         """Testing get_channels calls nimbus-cli with correct arguments."""
         self.assertEqual(
-            nimbus_cli.get_channels(APP_CONFIG, "0" * 40), ["staging", "prod"]
+            nimbus_cli.get_channels(APP_CONFIG, APP_CONFIG.fml_path, "0" * 40),
+            ["staging", "prod"],
         )
         mock_cli.assert_called_with(
             [
@@ -54,7 +55,7 @@ class NimbusCliTests(TestCase):
     def test_get_channels_invalid(self):
         "Testing get_channels handling of invalid JSON."
         with self.assertRaises(json.decoder.JSONDecodeError):
-            nimbus_cli.get_channels(APP_CONFIG, "channel")
+            nimbus_cli.get_channels(APP_CONFIG, APP_CONFIG.fml_path, "channel")
 
     @parameterized.expand(
         [
@@ -73,7 +74,12 @@ class NimbusCliTests(TestCase):
             manifest_dir = Path(tmp)
             manifest_dir.joinpath("slug").mkdir()
             nimbus_cli.download_single_file(
-                manifest_dir, APP_CONFIG, "channel", "0" * 40, version
+                manifest_dir,
+                APP_CONFIG,
+                APP_CONFIG.fml_path,
+                "channel",
+                "0" * 40,
+                version,
             )
 
             check_call.assert_called_with(


### PR DESCRIPTION
Because

- focus-ios had its nimbus.fml.yaml file move recently (see https://github.com/mozilla-mobile/focus-ios/pull/3917)

This commit

- updates our fetch logic to support multiple potential FML file locations; and
- updates focus_ios.fml_path to support the old and new paths.

Fixes #9804 
