### PR TITLE
feat(nimbus): don't open PRs for just ref-cache changes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -507,7 +507,7 @@ jobs:
             git pull origin main
             cp .env.sample .env
             env GITHUB_BEARER_TOKEN="${GH_TOKEN}" make fetch_external_resources
-            if (($(git status --porcelain | wc -c) > 0))
+            if ./experimenter/bin/should-pr.py
               then
                 git checkout -B external-config
                 git add .

--- a/experimenter/bin/should-pr.py
+++ b/experimenter/bin/should-pr.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python
+
+import subprocess
+import sys
+from pathlib import Path
+
+MANIFEST_DIR = (
+    Path(__file__)
+    .parent.parent.joinpath("experimenter", "features", "manifests")
+    .resolve()
+)
+
+
+def changed_files() -> list[Path]:
+    output = subprocess.check_output(["git", "status", "--porcelain"], encoding="utf-8")
+    files = [Path(line[3:]) for line in output.splitlines()]
+    return files
+
+
+def is_ref_cache(path: Path):
+    return path.name == ".ref-cache.yaml" and path.resolve().is_relative_to(MANIFEST_DIR)
+
+
+def main() -> int:
+    files = [f for f in changed_files() if not is_ref_cache(f)]
+
+    return int(not len(files))
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Because

- we only want to merge PRs that have feature configuration changes

this commit

- adds a script to check if there are only `.ref-cache` changes;
- updates the `update_external_configs` CI job to call that script and;
- only push to the `external-config` branch and open PRs if that script reports changes.

Fixes #9806