### PR TITLE
bug(nimbus): hide first run fields for non mobile applications

### DIFF
--- a/experimenter/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/index.test.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/index.test.tsx
@@ -12,7 +12,10 @@ import {
 } from "@testing-library/react";
 import React from "react";
 import selectEvent from "react-select-event";
-import { filterAndSortTargetingConfigs } from "src/components/PageEditAudience/FormAudience";
+import {
+  filterAndSortTargetingConfigs,
+  MOBILE_APPLICATIONS,
+} from "src/components/PageEditAudience/FormAudience";
 import {
   MOCK_EXPERIMENT,
   MOCK_ROLLOUT,
@@ -855,17 +858,38 @@ describe("FormAudience", () => {
     expect(screen.queryByTestId("locales")).not.toBeInTheDocument();
   });
 
-  it("isFirstRun renders for mobile application", async () => {
+  it.each(
+    Object.values(NimbusExperimentApplicationEnum).filter((application) =>
+      MOBILE_APPLICATIONS.includes(application),
+    ),
+  )("isFirstRun renders for mobile application", (application) => {
     render(
       <Subject
         experiment={{
           ...MOCK_EXPERIMENT,
-          application: NimbusExperimentApplicationEnum.FENIX,
+          application,
         }}
       />,
     );
 
     expect(screen.queryByTestId("isFirstRun")).toBeInTheDocument();
+  });
+
+  it.each(
+    Object.values(NimbusExperimentApplicationEnum).filter(
+      (application) => !MOBILE_APPLICATIONS.includes(application),
+    ),
+  )("isFirstRun does not render for non mobile application", (application) => {
+    render(
+      <Subject
+        experiment={{
+          ...MOCK_EXPERIMENT,
+          application,
+        }}
+      />,
+    );
+
+    expect(screen.queryByTestId("isFirstRun")).not.toBeInTheDocument();
   });
 
   it("disables language field for desktop", async () => {
@@ -880,18 +904,6 @@ describe("FormAudience", () => {
 
     expect(screen.queryByTestId("languages")).not.toBeInTheDocument();
     expect(screen.queryByTestId("locales")).toBeInTheDocument();
-  });
-  it("isFirstRun does not renders for desktop application", async () => {
-    render(
-      <Subject
-        experiment={{
-          ...MOCK_EXPERIMENT,
-          application: NimbusExperimentApplicationEnum.DESKTOP,
-        }}
-      />,
-    );
-
-    expect(screen.queryByTestId("isFirstRun")).not.toBeInTheDocument();
   });
 
   it("calls onSubmit when save and next buttons are clicked", async () => {

--- a/experimenter/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/index.tsx
@@ -75,6 +75,13 @@ export const audienceFieldNames = [
   "isFirstRun",
 ] as const;
 
+export const MOBILE_APPLICATIONS = [
+  NimbusExperimentApplicationEnum.FENIX,
+  NimbusExperimentApplicationEnum.IOS,
+  NimbusExperimentApplicationEnum.FOCUS_ANDROID,
+  NimbusExperimentApplicationEnum.FOCUS_IOS,
+];
+
 interface SelectExperimentOption {
   name: string;
   slug: string;
@@ -435,6 +442,9 @@ export const FormAudience = ({
 
   const isDesktop =
     experiment.application === NimbusExperimentApplicationEnum.DESKTOP;
+  const isMobile =
+    experiment.application != null &&
+    MOBILE_APPLICATIONS.includes(experiment.application);
   const isLiveRollout = experiment.isRollout && getStatus(experiment).live;
   const isLocked = isLiveRollout && !getStatus(experiment).draft;
   const isArchived =
@@ -617,7 +627,7 @@ export const FormAudience = ({
             <FormErrors name="isSticky" />
           </Form.Group>
         </Form.Row>
-        {!isDesktop && (
+        {isMobile && (
           <Form.Group>
             <Form.Row>
               <Form.Group as={Col} controlId="isFirstRun">

--- a/experimenter/experimenter/nimbus-ui/src/components/Summary/TableAudience/index.test.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/Summary/TableAudience/index.test.tsx
@@ -4,6 +4,7 @@
 
 import { fireEvent, render, screen, within } from "@testing-library/react";
 import React from "react";
+import { MOBILE_APPLICATIONS } from "src/components/PageEditAudience/FormAudience";
 import TableAudience from "src/components/Summary/TableAudience";
 import { MockedCache, mockExperimentQuery } from "src/lib/mocks";
 import { getExperiment_experimentBySlug } from "src/types/getExperiment";
@@ -34,11 +35,15 @@ describe("TableAudience", () => {
     });
   });
 
-  describe("renders 'First Run Release Date' row as expected", () => {
-    it("with proposed release date", () => {
+  describe("renders 'First Run Release Date' row for mobile", () => {
+    it.each(
+      Object.values(NimbusExperimentApplicationEnum).filter((application) =>
+        MOBILE_APPLICATIONS.includes(application),
+      ),
+    )("with proposed release date", (application) => {
       const expectedDate = "2023-12-12";
       const { experiment } = mockExperimentQuery("demo-slug", {
-        application: NimbusExperimentApplicationEnum.IOS,
+        application,
         proposedReleaseDate: expectedDate,
         isFirstRun: true,
       });
@@ -47,9 +52,13 @@ describe("TableAudience", () => {
         expectedDate,
       );
     });
-    it("when not set", () => {
+    it.each(
+      Object.values(NimbusExperimentApplicationEnum).filter((application) =>
+        MOBILE_APPLICATIONS.includes(application),
+      ),
+    )("when not set", (application) => {
       const { experiment } = mockExperimentQuery("demo-slug", {
-        application: NimbusExperimentApplicationEnum.IOS,
+        application,
         isFirstRun: true,
       });
       render(<Subject {...{ experiment }} />);
@@ -60,22 +69,61 @@ describe("TableAudience", () => {
   });
 
   describe("render First Run fields based on application", () => {
-    it("when application is desktop", () => {
-      const { experiment } = mockExperimentQuery("demo-slug");
+    it.each(
+      Object.values(NimbusExperimentApplicationEnum).filter(
+        (application) => !MOBILE_APPLICATIONS.includes(application),
+      ),
+    )("when application is not mobile", (application) => {
+      const { experiment } = mockExperimentQuery("demo-slug", { application });
       render(<Subject {...{ experiment }} />);
       expect(screen.queryByTestId("experiment-is-first-run")).toBeNull();
       expect(screen.queryByTestId("experiment-release-date")).toBeNull();
     });
-    it("when application is mobile", () => {
+    it.each(
+      Object.values(NimbusExperimentApplicationEnum).filter((application) =>
+        MOBILE_APPLICATIONS.includes(application),
+      ),
+    )("when application is mobile", (application) => {
       const expectedDate = "2023-12-12";
       const { experiment } = mockExperimentQuery("demo-slug", {
-        application: NimbusExperimentApplicationEnum.IOS,
+        application,
         proposedReleaseDate: expectedDate,
         isFirstRun: true,
       });
       render(<Subject {...{ experiment }} />);
       expect(screen.getByTestId("experiment-is-first-run")).toBeInTheDocument();
       expect(screen.getByTestId("experiment-release-date")).toBeInTheDocument();
+    });
+  });
+
+  describe("renders 'First Run Experiment' row as expected", () => {
+    it.each(
+      Object.values(NimbusExperimentApplicationEnum).filter((application) =>
+        MOBILE_APPLICATIONS.includes(application),
+      ),
+    )("with stick enrollment True", (application) => {
+      const { experiment } = mockExperimentQuery("demo-slug", {
+        application,
+        isFirstRun: true,
+      });
+      render(<Subject {...{ experiment }} />);
+      expect(screen.getByTestId("experiment-is-first-run")).toHaveTextContent(
+        "True",
+      );
+    });
+    it.each(
+      Object.values(NimbusExperimentApplicationEnum).filter((application) =>
+        MOBILE_APPLICATIONS.includes(application),
+      ),
+    )("when not set", (application) => {
+      const { experiment } = mockExperimentQuery("demo-slug", {
+        application,
+        isFirstRun: false,
+      });
+      render(<Subject {...{ experiment }} />);
+      expect(screen.getByTestId("experiment-is-first-run")).toHaveTextContent(
+        "False",
+      );
     });
   });
 
@@ -239,6 +287,7 @@ describe("TableAudience", () => {
       );
     });
   });
+
   describe("renders 'Locales' row as expected for old experiments", () => {
     it("when locales exist, displays them", () => {
       const data = {
@@ -266,6 +315,7 @@ describe("TableAudience", () => {
       );
     });
   });
+
   describe("renders 'Languages' row as expected", () => {
     it("when languages exist, displays them", () => {
       const data = {
@@ -306,6 +356,7 @@ describe("TableAudience", () => {
       );
     });
   });
+
   describe("renders 'Countries' row as expected", () => {
     it("when countries exist, displays them", async () => {
       const data = {
@@ -332,6 +383,7 @@ describe("TableAudience", () => {
       );
     });
   });
+
   describe("renders 'Stick Enrollment' row as expected", () => {
     it("with stick enrollment True", () => {
       const { experiment } = mockExperimentQuery("demo-slug", {
@@ -346,28 +398,6 @@ describe("TableAudience", () => {
       const { experiment } = mockExperimentQuery("demo-slug", {});
       render(<Subject {...{ experiment }} />);
       expect(screen.getByTestId("experiment-is-sticky")).toHaveTextContent(
-        "False",
-      );
-    });
-  });
-  describe("renders 'First Run Experiment' row as expected", () => {
-    it("with stick enrollment True", () => {
-      const { experiment } = mockExperimentQuery("demo-slug", {
-        application: NimbusExperimentApplicationEnum.IOS,
-        isFirstRun: true,
-      });
-      render(<Subject {...{ experiment }} />);
-      expect(screen.getByTestId("experiment-is-first-run")).toHaveTextContent(
-        "True",
-      );
-    });
-    it("when not set", () => {
-      const { experiment } = mockExperimentQuery("demo-slug", {
-        application: NimbusExperimentApplicationEnum.IOS,
-        isFirstRun: false,
-      });
-      render(<Subject {...{ experiment }} />);
-      expect(screen.getByTestId("experiment-is-first-run")).toHaveTextContent(
         "False",
       );
     });

--- a/experimenter/experimenter/nimbus-ui/src/components/Summary/TableAudience/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/Summary/TableAudience/index.tsx
@@ -6,6 +6,7 @@ import React, { useState } from "react";
 import { Accordion, Button, Card, Table } from "react-bootstrap";
 import { Code } from "src/components/Code";
 import NotSet from "src/components/NotSet";
+import { MOBILE_APPLICATIONS } from "src/components/PageEditAudience/FormAudience";
 import { displayConfigLabelOrNotSet } from "src/components/Summary";
 import { useConfig } from "src/hooks";
 import { ReactComponent as CollapseMinus } from "src/images/minus.svg";
@@ -26,6 +27,9 @@ const TableAudience = ({ experiment }: TableAudienceProps) => {
   const { firefoxVersions, channels, targetingConfigs } = useConfig();
   const isDesktop =
     experiment.application === NimbusExperimentApplicationEnum.DESKTOP;
+  const isMobile =
+    experiment.application != null &&
+    MOBILE_APPLICATIONS.includes(experiment.application);
 
   const [expand, setExpand] = useState(false);
 
@@ -140,7 +144,7 @@ const TableAudience = ({ experiment }: TableAudienceProps) => {
                 {experiment.isSticky ? "True" : "False"}
               </td>
 
-              {!isDesktop ? (
+              {isMobile ? (
                 <>
                   <th>First Run Experiment</th>
                   <td data-testid="experiment-is-first-run">
@@ -151,7 +155,7 @@ const TableAudience = ({ experiment }: TableAudienceProps) => {
                 <td colSpan={2}></td>
               )}
             </tr>
-            {!isDesktop && (
+            {isMobile && (
               <tr>
                 <th>First Run Release Date</th>
                 <td colSpan={3} data-testid="experiment-release-date">

--- a/experimenter/experimenter/nimbus-ui/src/lib/mocks.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/lib/mocks.tsx
@@ -141,59 +141,27 @@ export const MOCK_CONFIG: getConfig_nimbusConfig = {
       value: "FOLLOWUP",
     },
   ],
-  applicationConfigs: [
-    {
-      application: NimbusExperimentApplicationEnum.DESKTOP,
-      channels: [
-        {
-          label: "Desktop Beta",
-          value: "BETA",
-        },
-        {
-          label: "Desktop Nightly",
-          value: "NIGHTLY",
-        },
-        {
-          label: "Platypus Doorstop",
-          value: "PLATYPUS_DOORSTOP",
-        },
-      ],
+  applicationConfigs: Object.values(NimbusExperimentApplicationEnum).map(
+    (application) => {
+      return {
+        application,
+        channels: [
+          {
+            label: "Desktop Beta",
+            value: "BETA",
+          },
+          {
+            label: "Desktop Nightly",
+            value: "NIGHTLY",
+          },
+          {
+            label: "Platypus Doorstop",
+            value: "PLATYPUS_DOORSTOP",
+          },
+        ],
+      };
     },
-    {
-      application: NimbusExperimentApplicationEnum.FENIX,
-      channels: [
-        {
-          label: "Desktop Beta",
-          value: "BETA",
-        },
-        {
-          label: "Desktop Nightly",
-          value: "NIGHTLY",
-        },
-        {
-          label: "Platypus Doorstop",
-          value: "PLATYPUS_DOORSTOP",
-        },
-      ],
-    },
-    {
-      application: NimbusExperimentApplicationEnum.IOS,
-      channels: [
-        {
-          label: "Desktop Beta",
-          value: "BETA",
-        },
-        {
-          label: "Desktop Nightly",
-          value: "NIGHTLY",
-        },
-        {
-          label: "Platypus Doorstop",
-          value: "PLATYPUS_DOORSTOP",
-        },
-      ],
-    },
-  ],
+  ),
   allFeatureConfigs: [
     {
       id: 1,

--- a/experimenter/tests/integration/nimbus/pages/experimenter/summary.py
+++ b/experimenter/tests/integration/nimbus/pages/experimenter/summary.py
@@ -374,14 +374,20 @@ class SummaryPage(ExperimenterBase):
             message="Summary Page: could not find release date on timeline",
         )
 
-    def wait_until_release_date_not_found(self):
+    def wait_until_timeline_release_date_not_found(self):
         self.wait.until_not(
-            EC.presence_of_element_located(self._audience_proposed_release_date_locator),
-            message="Audience Page: could not find release date",
+            EC.presence_of_element_located(self._timeline_proposed_release_date_locator),
+            message="Summary Page: found timeline release date",
         )
 
-    def wait_until_first_run_not_found(self):
+    def wait_until_audience_release_date_not_found(self):
+        self.wait.until_not(
+            EC.presence_of_element_located(self._audience_proposed_release_date_locator),
+            message="Summary Page: found audience release date",
+        )
+
+    def wait_until_audience_first_run_not_found(self):
         self.wait.until_not(
             EC.presence_of_element_located(self._audience_is_first_run_locator),
-            message="Audience Page: could not find first run checkbox",
+            message="Summary Page: found audience first run",
         )

--- a/experimenter/tests/integration/nimbus/test_experimenter_ui.py
+++ b/experimenter/tests/integration/nimbus/test_experimenter_ui.py
@@ -155,10 +155,7 @@ def test_first_run_release_date_not_visible_for_non_mobile(
     application,
     create_experiment,
 ):
-    if application in [
-        *MOBILE_APPS,
-        BaseExperimentApplications.DEMO_APP.value,  # TODO: Remove DEMO_APP with #9817
-    ]:
+    if application in MOBILE_APPS:
         pytest.skip(f"Skipping for {application}")
 
     summary = create_experiment(selenium)
@@ -178,5 +175,6 @@ def test_first_run_release_date_not_visible_for_non_mobile(
     summary.wait_for_live_status()
 
     summary.wait_for_timeline_visible()
-    summary.wait_until_release_date_not_found()
-    summary.wait_until_first_run_not_found()
+    summary.wait_until_timeline_release_date_not_found()
+    summary.wait_until_audience_release_date_not_found()
+    summary.wait_until_audience_first_run_not_found()


### PR DESCRIPTION
Because
    
* First run and release date only apply to mobile applications
* As we add new applications we need to make sure our existing filtering logic continues to function
* It's no longer sufficient to just check that something is not desktop and infer that is mobile
    
This commit
    
* Explicitly shows first run/release date fields for only mobile applications
* We can now check this in the integration tests
    
fix #9817