### PR TITLE
feat(nimbus): Add NimbusFeatureVersion to admin

### DIFF
--- a/experimenter/experimenter/experiments/admin.py
+++ b/experimenter/experimenter/experiments/admin.py
@@ -337,10 +337,10 @@ class NimbusVersionedSchemaApplicationFilter(admin.SimpleListFilter):
     title = "application"
     parameter_name = "application"
 
-    def lookups(self, request, model_admin):  # pragma: no cover
+    def lookups(self, request, model_admin):
         return NimbusExperiment.Application.choices
 
-    def queryset(self, request, queryset):  # pragma: no cover
+    def queryset(self, request, queryset):
         if self.value():
             queryset = queryset.filter(feature_config__application=self.value())
 
@@ -351,10 +351,10 @@ class NimbusVersionedSchemaAdmin(
     ReadOnlyAdminMixin, admin.ModelAdmin[NimbusVersionedSchema]
 ):
     @staticmethod
-    def get_application(obj: NimbusVersionedSchema):  # pragma: no cover
+    def get_application(obj: NimbusVersionedSchema):
         return obj.feature_config.application
 
-    def get_queryset(self, request):  # pragma: no cover
+    def get_queryset(self, request):
         return super().get_queryset(request).select_related("feature_config")
 
     get_application.short_description = "Application"

--- a/experimenter/experimenter/experiments/admin.py
+++ b/experimenter/experimenter/experiments/admin.py
@@ -23,6 +23,7 @@ from experimenter.experiments.models import (
     NimbusDocumentationLink,
     NimbusExperiment,
     NimbusFeatureConfig,
+    NimbusFeatureVersion,
     NimbusIsolationGroup,
     NimbusVersionedSchema,
 )
@@ -326,10 +327,43 @@ class NimbusExperimentAdmin(
     filter_horizontal = ("excluded_experiments", "required_experiments")
 
 
+class NimbusFeatureVersionAdmin(
+    ReadOnlyAdminMixin, admin.ModelAdmin[NimbusFeatureVersion]
+):
+    pass
+
+
+class NimbusVersionedSchemaApplicationFilter(admin.SimpleListFilter):
+    title = "application"
+    parameter_name = "application"
+
+    def lookups(self, request, model_admin):  # pragma: no cover
+        return NimbusExperiment.Application.choices
+
+    def queryset(self, request, queryset):  # pragma: no cover
+        if self.value():
+            queryset = queryset.filter(feature_config__application=self.value())
+
+        return queryset
+
+
 class NimbusVersionedSchemaAdmin(
     ReadOnlyAdminMixin, admin.ModelAdmin[NimbusVersionedSchema]
 ):
-    pass
+    @staticmethod
+    def get_application(obj: NimbusVersionedSchema):  # pragma: no cover
+        return obj.feature_config.application
+
+    def get_queryset(self, request):  # pragma: no cover
+        return super().get_queryset(request).select_related("feature_config")
+
+    get_application.short_description = "Application"
+
+    list_filter = (NimbusVersionedSchemaApplicationFilter,)
+    list_display = (
+        "__str__",
+        get_application,
+    )
 
 
 class NimbusVersionedSchemaInlineAdmin(
@@ -379,4 +413,5 @@ admin.site.register(NimbusExperiment, NimbusExperimentAdmin)
 admin.site.register(NimbusFeatureConfig, NimbusFeatureConfigAdmin)
 admin.site.register(NimbusVersionedSchema, NimbusVersionedSchemaAdmin)
 admin.site.register(NimbusBranch, NimbusBranchAdmin)
+admin.site.register(NimbusFeatureVersion, NimbusFeatureVersionAdmin)
 admin.site.register(NimbusDocumentationLink)

--- a/experimenter/experimenter/experiments/models.py
+++ b/experimenter/experimenter/experiments/models.py
@@ -1284,10 +1284,12 @@ class NimbusVersionedSchema(models.Model):
         )
 
     def __str__(self):  # pragma: no cover
-        as_str = f"NimbusVersionedSchema for {self.feature_config_id}"
+        as_str = f"{self.feature_config}"
 
         if self.version is not None:
-            as_str = f"{as_str} at {self.version}"
+            as_str += f" (version {self.version})"
+        else:
+            as_str += " (unversioned)"
 
         return as_str
 


### PR DESCRIPTION
Because:

- we want to inspect versioned feature configurations in the Django admin

This commit:

- adds a model admin for `NimbusFeatureVersion`;
- updates the str representation for `NimbusFeatureVersion` and `NimbusVersionedSchema` to be more concise; and
- adds filtering by application to the `NimbusVersionedSchema` model admin.

Fixes #9818