### PR TITLE
bug(nimbus): Run should-pr.py with Python 3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -509,7 +509,7 @@ jobs:
             git pull origin main
             cp .env.sample .env
             env GITHUB_BEARER_TOKEN="${GH_TOKEN}" make fetch_external_resources
-            if ./experimenter/bin/should-pr.py
+            if python3 ./experimenter/bin/should-pr.py
               then
                 git checkout -B external-config
                 git add .


### PR DESCRIPTION
Because:

- should-pr.py is written in Python 3; and
- the default Python on Ubuntu 20.04 is Python 2.7

This commit:

- explicitly runs should-pr.py with Python 3 in CI.

Fixes #9825
