### PR TITLE
fixes #9661 feat(nimbus): simplify targeting for shopping experiment …

### DIFF
--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -1777,14 +1777,8 @@ DEFAULT_PDF_IS_DIFFERENT_BROWSER = NimbusTargetingConfig(
 SHOPPING_OPTED_IN = NimbusTargetingConfig(
     name="Users opted in to shopping",
     slug="shopping_opted_in",
-    description="Users with the shopping experience enabled and who have opted in",
-    targeting="""
-    (
-        ('browser.shopping.experience2023.enabled'|preferenceValue)
-        &&
-        ('browser.shopping.experience2023.optedIn'|preferenceValue == 1)
-    )
-    """,
+    description="Users who have opted in to the shopping experience",
+    targeting="'browser.shopping.experience2023.optedIn'|preferenceValue == 1",
     desktop_telemetry="",
     sticky_required=False,
     is_first_run_required=False,


### PR DESCRIPTION
…users who have opted in but who may not have the experience enabled

Because

- We want to target desktop users who have ever been enrolled in the shopping experiment, and who have opted in, in order to run related experiments on this population, but we don't want the targeting to depend on the `enabled` Nimbus variable

This commit

- Updates the SHOPPING_OPTED_IN targeting to only check whether users had opted in, but not whether the experience is currently enabled.

Because

- Reason

This commit

- Change
