### PR TITLE
Add Win 11 targeting for use with pinning adaptation experiment

### DIFF
--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -177,6 +177,29 @@ FIRST_RUN_NEW_PROFILE_WINDOWS_1903_NEWER = NimbusTargetingConfig(
     application_choice_names=(Application.DESKTOP.name,),
 )
 
+FIRST_RUN_NEW_PROFILE_WINDOWS_11_NEED_PIN = NimbusTargetingConfig(
+    name=(
+        "First start-up users with a new profile, "
+        "on Windows 11 (build 22621) or newer, needing pin"
+    ),
+    slug="first_run_new_profile_win11",
+    description=(
+        "First start-up users (e.g. for about:welcome), with a "
+        "new profile, on Windows 22621+, needing pin"
+    ),
+    targeting=(
+        f"{FIRST_RUN.targeting} && doesAppNeedPin && os.windowsBuildNumber >= 22621 && "
+        f"{NEW_PROFILE}"
+    ),
+    desktop_telemetry=(
+        "{first_run} AND environment.system.os.windows_build_number >= 22621 "
+        "AND {new_profile} AND doesAppNeedPin"
+    ).format(first_run=FIRST_RUN.desktop_telemetry, new_profile=NEW_PROFILE),
+    sticky_required=True,
+    is_first_run_required=False,
+    application_choice_names=(Application.DESKTOP.name,),
+)
+
 FIRST_RUN_NEW_PROFILE_NEED_DEFAULT_WINDOWS_1903 = NimbusTargetingConfig(
     name=(
         "First start-up users on Windows 10 1903 (build 18362) or newer, with a "


### PR DESCRIPTION

This commit adds targeting for Win 11 build number 22621, for first startup users with a new profile, needing pin.

This is for use with the [Pinning adaptation experiment](https://docs.google.com/document/d/1oivKNuH7CT_HcQkMiEm1vCOke65VpgRT6BFlVYllBok/edit#heading=h.uoblsnu302hk), in response to API changes to pinning in Win 11. 

