### PR TITLE
feat(nimbus): add note about preview delay

### DIFF
--- a/experimenter/experimenter/nimbus-ui/src/components/PageSummary/FormLaunchPreviewToReview.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageSummary/FormLaunchPreviewToReview.tsx
@@ -38,7 +38,11 @@ const FormLaunchPreviewToReview = ({
             This experiment is currently <strong>live for testing</strong>, but
             you will need to let QA know in your PI request. When you have
             received a sign-off, click “Request launch” to launch the
-            experiment.
+            experiment.{" "}
+            <strong>
+              Note: It can take up to an hour before clients receive a preview
+              experiment.
+            </strong>
           </p>
 
           <FormLaunchConfirmationCheckboxes onChange={setAllBoxesChecked} />


### PR DESCRIPTION
Because

* After an experiment is marked for preview, it can take up to an hour for it to be replicated into the Remote Settings CDN
* This often confuses users since they expect it to happen immediately

This commit

* Adds a note to the preview guidance about the delay

fixes #9848

