### PR TITLE
feat(nimbus): add targeting for shopping experiment participants

### DIFF
--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -1808,6 +1808,21 @@ SHOPPING_OPTED_IN = NimbusTargetingConfig(
     application_choice_names=(Application.DESKTOP.name,),
 )
 
+SHOPPING_ONBOARDING_SHOWN = NimbusTargetingConfig(
+    name="Shopping onboarding shown",
+    slug="shopping_onboarding_shown",
+    description=(
+        "Users that have seen the shopping experiment onboarding at least once. "
+        "Used as a proxy to target shopping users for a feature continuity rollout, "
+        "ensuring the shopping feature stays active across different experiments."
+    ),
+    targeting="'browser.shopping.experience2023.autoActivateCount'|preferenceValue >= 1",
+    desktop_telemetry="",
+    sticky_required=False,
+    is_first_run_required=False,
+    application_choice_names=(Application.DESKTOP.name,),
+)
+
 
 class TargetingConstants:
     TARGETING_VERSION = "version|versionCompare('{version}') >= 0"


### PR DESCRIPTION
Because

- The review checker shopping feature has not been preffed on globally

- We want to run a series of different experiments on the population who have onboarded to the review checker

- We don't want these users to lose access to the feature when they move between experiments

- We need a way to target users who have seen the initial shopping experiment, excluding the `browser.shopping.experience2023.enabled` pref which is managed by Nimbus, hence, is unset when a user is unenrolled from an experiment

This commit

- Adds a new SHOPPING_ONBOARDING_SHOWN targeting constant based on the value of the `browser.shopping.experience2023.autoActivateCount` pref, which is an integer that's incremented each time a user is shown the review checker onboarding.

Fixes #9839