### PR TITLE
bug(nimbus): fix export of qa_status enum

### DIFF
--- a/experimenter/experimenter/experiments/admin.py
+++ b/experimenter/experimenter/experiments/admin.py
@@ -73,6 +73,7 @@ class NimbusExperimentResource(resources.ModelResource):
     #   which breaks the Nimbus UI type validation
     status_next = fields.Field()
     conclusion_recommendation = fields.Field()
+    qa_status = fields.Field()
 
     def get_diff_headers(self):
         skip_list = ["reference_branch_slug"]
@@ -106,6 +107,12 @@ class NimbusExperimentResource(resources.ModelResource):
         if experiment.status_next not in dict(NimbusConstants.Status.choices):
             return None
         return experiment.status_next
+
+    def dehydrate_qa_status(self, experiment):
+        """Return None instead of empty string for nullable enums"""
+        if experiment.qa_status not in dict(NimbusConstants.Status.choices):
+            return None
+        return experiment.qa_status
 
     def dehydrate_conclusion_recommendation(self, experiment):
         """Return None instead of empty string for nullable enums"""

--- a/experimenter/experimenter/experiments/admin.py
+++ b/experimenter/experimenter/experiments/admin.py
@@ -110,7 +110,7 @@ class NimbusExperimentResource(resources.ModelResource):
 
     def dehydrate_qa_status(self, experiment):
         """Return None instead of empty string for nullable enums"""
-        if experiment.qa_status not in dict(NimbusConstants.Status.choices):
+        if experiment.qa_status not in dict(NimbusConstants.QAStatus.choices):
             return None
         return experiment.qa_status
 

--- a/experimenter/experimenter/experiments/tests/test_admin.py
+++ b/experimenter/experimenter/experiments/tests/test_admin.py
@@ -180,10 +180,12 @@ class TestNimbusExperimentExport(TestCase):
         # test normal dehydrate conditions
         experiment.status_next = "Complete"
         experiment.conclusion_recommendation = "STOP"
+        experiment.qa_status = "GREEN"
         status_next = resource.dehydrate_status_next(experiment)
         conclusion_recommendation = resource.dehydrate_conclusion_recommendation(
             experiment
         )
+        qa_status = resource.dehydrate_qa_status(experiment)
 
         num_changes = len(resource.dehydrate_changes(experiment))
         num_branches = len(resource.dehydrate_branches(experiment))
@@ -193,6 +195,7 @@ class TestNimbusExperimentExport(TestCase):
         self.assertEqual(num_branches, 2)
         self.assertEqual(reference_branch_slug, "control")
         self.assertEqual(status_next, "Complete")
+        self.assertEqual(qa_status, "GREEN")
         self.assertEqual(conclusion_recommendation, "STOP")
 
     def test_resource_dehydrate_none(self):

--- a/experimenter/experimenter/experiments/tests/test_admin.py
+++ b/experimenter/experimenter/experiments/tests/test_admin.py
@@ -211,10 +211,12 @@ class TestNimbusExperimentExport(TestCase):
         conclusion_recommendation = resource.dehydrate_conclusion_recommendation(
             experiment
         )
+        qa_status = resource.dehydrate_qa_status(experiment)
 
         self.assertIsNone(none_slug)
         self.assertIsNone(status_next)
         self.assertIsNone(conclusion_recommendation)
+        self.assertIsNone(qa_status)
 
     def test_before_import_row(self):
         resource = NimbusExperimentResource()


### PR DESCRIPTION
Because

- we added `qa_status` enum field to the experiment model
- the export/import converts a null value for an enum to empty string instead of `None`
- type checking doesn't allow empty string as enum value but `None` is allowed

This commit

- converts a null enum value to `None` explicitly during export/import

Fixes #9862 