### PR TITLE
Fixes #9738 feat(nimbus): Add QA section on Summary page with editable QA Status

### DIFF
--- a/experimenter/experimenter/experiments/constants.py
+++ b/experimenter/experimenter/experiments/constants.py
@@ -276,6 +276,7 @@ class NimbusConstants:
     ARCHIVE_UPDATE_EXEMPT_FIELDS = (
         "is_archived",
         "changelog_message",
+        "qa_status",
     )
 
     class QAStatus(models.TextChoices):

--- a/experimenter/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_experiment_serializer.py
+++ b/experimenter/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_experiment_serializer.py
@@ -1430,6 +1430,22 @@ class TestNimbusExperimentSerializer(TestCase):
         self.assertFalse(serializer.is_valid())
         self.assertIn("name", serializer.errors)
 
+    def test_can_update_qa_status_while_archived(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            is_archived=True,
+        )
+        serializer = NimbusExperimentSerializer(
+            experiment,
+            {
+                "qa_status": NimbusExperiment.QAStatus.GREEN,
+                "changelog_message": "updating name",
+            },
+            context={"user": self.user},
+        )
+        self.assertTrue(serializer.is_valid())
+        self.assertTrue(experiment.is_archived, serializer.errors)
+
     def test_can_unarchive_experiment(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.CREATED,

--- a/experimenter/experimenter/nimbus-ui/src/components/Summary/TableQA/QAEditor.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/Summary/TableQA/QAEditor.tsx
@@ -72,7 +72,7 @@ export const QAEditor = ({
       value: NimbusExperimentQAStatusEnum.GREEN,
       description: "🟢 GREEN ",
     },
-  ];
+  ] as const;
 
   const onClickCancel = useCallback(
     () => setShowEditor(false),
@@ -130,64 +130,45 @@ export const QAEditor = ({
             </Alert>
           )}
 
-          <Form.Group as={Row} controlId="qaStatus" className="mb-0 pl-1">
-            <Form.Group data-testid="qa-status">
-              <Row className="ml-0 flex-fill pl-0">
-                <Col className="ml-2 mr-0 pr-0 w-25">
-                  <Form.Label>
-                    <p className="font-weight-bold">QA Status: </p>
-                  </Form.Label>
-                </Col>
-                <Col className="ml-4 flex-fill pl-0 pr-8 mr-4">
-                  <Form.Control
-                    as="select"
-                    className="ml-0 mr-0"
-                    value={qaStatusField as NimbusExperimentQAStatusEnum}
-                    onSubmit={handleSave}
-                    onChange={(e) =>
-                      setQaStatus(
-                        e.target
-                          ? (e.target.value as NimbusExperimentQAStatusEnum)
-                          : null,
-                      )
-                    }
-                    id="qaStatus"
-                    {...{ "data-testid": "qaStatus" }}
-                  >
-                    <QaStatusOptions options={qaStatusOptions} />
-                  </Form.Control>
-                </Col>
-              </Row>
-            </Form.Group>
-            {/* Hello world */}
+          <Form.Group as={Row} className="mb-0 pl-1">
+            <Row className="ml-0 flex-fill pl-0">
+              <Col className="ml-2 mr-0 pr-0 w-25">
+                <Form.Label>
+                  <p className="font-weight-bold">QA Status: </p>
+                </Form.Label>
+              </Col>
+              <Col className="ml-4 flex-fill pl-0 pr-8 mr-4">
+                <Form.Control
+                  as="select"
+                  className="ml-0 mr-0"
+                  value={qaStatusField as NimbusExperimentQAStatusEnum}
+                  onSubmit={handleSave}
+                  onChange={(e) =>
+                    setQaStatus(
+                      e.target
+                        ? (e.target.value as NimbusExperimentQAStatusEnum)
+                        : null,
+                    )
+                  }
+                  id="qa-status-select"
+                  data-testid="qa-status"
+                >
+                  {qaStatusOptions.map(
+                    (item, idx) =>
+                      item && (
+                        <option key={idx} value={item.value}>
+                          {item.description}
+                        </option>
+                      ),
+                  )}
+                </Form.Control>
+              </Col>
+            </Row>
           </Form.Group>
         </Form>
       </FormProvider>
     </section>
   );
 };
-
-const QaStatusOptions = ({
-  options,
-}: {
-  options:
-    | null
-    | (null | {
-        label: null | string;
-        value: null | string;
-        description: null | string;
-      })[];
-}) => (
-  <>
-    {options?.map(
-      (item, idx) =>
-        item && (
-          <option key={idx} value={item.value || ""}>
-            {item.description}
-          </option>
-        ),
-    )}
-  </>
-);
 
 export default QAEditor;

--- a/experimenter/experimenter/nimbus-ui/src/components/Summary/TableQA/QAEditor.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/Summary/TableQA/QAEditor.tsx
@@ -20,11 +20,6 @@ type QAEditorFieldName = typeof qaEditorFieldNames[number];
 export type QAEditorProps = UseQAResult & {
   setShowEditor: (state: boolean) => void;
 };
-// ELISE - todo - might need this Pick?
-// export type TakeawaysEditorProps = UseTakeawaysResult &
-//   Pick<getConfig_nimbusConfig, "conclusionRecommendations"> & {
-//     setShowEditor: (state: boolean) => void;
-//   };
 
 export const QAEditor = ({
   isLoading,
@@ -56,28 +51,28 @@ export const QAEditor = ({
     {},
   );
 
-  // const qaStatusSlugOptions = [
-  //   {
-  //     label: "Choose a score",
-  //     value: "",
-  //     description: "Choose a score",
-  //   },
-  // {
-  //   label: NimbusExperimentQAStatusEnum.RED,
-  //   value: NimbusExperimentQAStatusEnum.RED,
-  //   description: "🔴 RED ",
-  // },
-  // {
-  //   label: NimbusExperimentQAStatusEnum.YELLOW,
-  //   value: NimbusExperimentQAStatusEnum.YELLOW,
-  //   description: "🟡 YELLOW ",
-  // },
-  // {
-  //   label: NimbusExperimentQAStatusEnum.GREEN,
-  //   value: NimbusExperimentQAStatusEnum.GREEN,
-  //   description: "🟢 GREEN ",
-  // },
-  // ];
+  const qaStatusOptions = [
+    {
+      label: "Choose a score",
+      value: "",
+      description: "Choose a score",
+    },
+    {
+      label: NimbusExperimentQAStatusEnum.RED,
+      value: NimbusExperimentQAStatusEnum.RED,
+      description: "🔴 RED ",
+    },
+    {
+      label: NimbusExperimentQAStatusEnum.YELLOW,
+      value: NimbusExperimentQAStatusEnum.YELLOW,
+      description: "🟡 YELLOW ",
+    },
+    {
+      label: NimbusExperimentQAStatusEnum.GREEN,
+      value: NimbusExperimentQAStatusEnum.GREEN,
+      description: "🟢 GREEN ",
+    },
+  ];
 
   const onClickCancel = useCallback(
     () => setShowEditor(false),
@@ -94,7 +89,7 @@ export const QAEditor = ({
   });
 
   return (
-    <section id="qa-editor" data-testid="QAEditor">
+    <section id="qa-editor" className="mx-4" data-testid="QAEditor">
       <h3 className="h4 mb-3 mt-4">
         <Row>
           <Col>QA</Col>
@@ -136,18 +131,35 @@ export const QAEditor = ({
           )}
 
           <Form.Group as={Row} controlId="qaStatus" className="mb-0 pl-1">
-            {/* <Form.Group data-testid="qa-status" className="ml-3">
-              <Form.Control
-                as="select"
-                onSubmit={handleSave}
-                onChange={(e) => setQaStatus(qaStatusField)}
-                id="qaStatus"
-                {...{ "data-testid": "qaStatus" }}
-              >
-                <QaStatusSelectOptions options={qaStatusSlugOptions} />
-              </Form.Control>
-            </Form.Group> */}
-            Hello world
+            <Form.Group data-testid="qa-status">
+              <Row className="ml-0 flex-fill pl-0">
+                <Col className="ml-2 mr-0 pr-0 w-25">
+                  <Form.Label>
+                    <p className="font-weight-bold">QA Status: </p>
+                  </Form.Label>
+                </Col>
+                <Col className="ml-4 flex-fill pl-0 pr-8 mr-4">
+                  <Form.Control
+                    as="select"
+                    className="ml-0 mr-0"
+                    value={qaStatusField as NimbusExperimentQAStatusEnum}
+                    onSubmit={handleSave}
+                    onChange={(e) =>
+                      setQaStatus(
+                        e.target
+                          ? (e.target.value as NimbusExperimentQAStatusEnum)
+                          : null,
+                      )
+                    }
+                    id="qaStatus"
+                    {...{ "data-testid": "qaStatus" }}
+                  >
+                    <QaStatusOptions options={qaStatusOptions} />
+                  </Form.Control>
+                </Col>
+              </Row>
+            </Form.Group>
+            {/* Hello world */}
           </Form.Group>
         </Form>
       </FormProvider>
@@ -155,27 +167,27 @@ export const QAEditor = ({
   );
 };
 
-// const QaStatusSelectOptions = ({
-//   options,
-// }: {
-//   options:
-//     | null
-//     | (null | {
-//         label: null | string;
-//         value: null | string;
-//         description: null | string;
-//       })[];
-// }) => (
-//   <>
-//     {options?.map(
-//       (item, idx) =>
-//         item && (
-//           <option key={idx} value={item.value || ""}>
-//             `${item.description}`
-//           </option>
-//         ),
-//     )}
-//   </>
-// );
+const QaStatusOptions = ({
+  options,
+}: {
+  options:
+    | null
+    | (null | {
+        label: null | string;
+        value: null | string;
+        description: null | string;
+      })[];
+}) => (
+  <>
+    {options?.map(
+      (item, idx) =>
+        item && (
+          <option key={idx} value={item.value || ""}>
+            {item.description}
+          </option>
+        ),
+    )}
+  </>
+);
 
 export default QAEditor;

--- a/experimenter/experimenter/nimbus-ui/src/components/Summary/TableQA/QAEditor.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/Summary/TableQA/QAEditor.tsx
@@ -1,0 +1,181 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React, { useCallback, useState } from "react";
+import Alert from "react-bootstrap/Alert";
+import Button from "react-bootstrap/Button";
+import Col from "react-bootstrap/Col";
+import Form from "react-bootstrap/Form";
+import Row from "react-bootstrap/Row";
+import { FormProvider } from "react-hook-form";
+import { UseQAResult } from "src/components/Summary/TableQA/useQA";
+import { useCommonForm } from "src/hooks";
+import { NimbusExperimentQAStatusEnum } from "src/types/globalTypes";
+
+export const qaEditorFieldNames = ["qaStatus"] as const;
+
+type QAEditorFieldName = typeof qaEditorFieldNames[number];
+
+export type QAEditorProps = UseQAResult & {
+  setShowEditor: (state: boolean) => void;
+};
+// ELISE - todo - might need this Pick?
+// export type TakeawaysEditorProps = UseTakeawaysResult &
+//   Pick<getConfig_nimbusConfig, "conclusionRecommendations"> & {
+//     setShowEditor: (state: boolean) => void;
+//   };
+
+export const QAEditor = ({
+  isLoading,
+  qaStatus,
+  setShowEditor,
+  onSubmit,
+  submitErrors,
+  setSubmitErrors,
+  isServerValid,
+}: QAEditorProps) => {
+  const defaultValues = {
+    qaStatus,
+  };
+
+  type DefaultValues = typeof defaultValues;
+
+  const {
+    isValid,
+    isSubmitted,
+    FormErrors,
+    formControlAttrs,
+    handleSubmit,
+    formMethods,
+  } = useCommonForm<QAEditorFieldName>(
+    defaultValues,
+    isServerValid,
+    submitErrors,
+    setSubmitErrors,
+    {},
+  );
+
+  // const qaStatusSlugOptions = [
+  //   {
+  //     label: "Choose a score",
+  //     value: "",
+  //     description: "Choose a score",
+  //   },
+  // {
+  //   label: NimbusExperimentQAStatusEnum.RED,
+  //   value: NimbusExperimentQAStatusEnum.RED,
+  //   description: "🔴 RED ",
+  // },
+  // {
+  //   label: NimbusExperimentQAStatusEnum.YELLOW,
+  //   value: NimbusExperimentQAStatusEnum.YELLOW,
+  //   description: "🟡 YELLOW ",
+  // },
+  // {
+  //   label: NimbusExperimentQAStatusEnum.GREEN,
+  //   value: NimbusExperimentQAStatusEnum.GREEN,
+  //   description: "🟢 GREEN ",
+  // },
+  // ];
+
+  const onClickCancel = useCallback(
+    () => setShowEditor(false),
+    [setShowEditor],
+  );
+
+  const [qaStatusField, setQaStatus] =
+    useState<NimbusExperimentQAStatusEnum | null>(qaStatus);
+
+  const handleSave = handleSubmit(async (data: DefaultValues) => {
+    if (isLoading) return;
+    data.qaStatus = qaStatusField;
+    await onSubmit(data);
+  });
+
+  return (
+    <section id="qa-editor" data-testid="QAEditor">
+      <h3 className="h4 mb-3 mt-4">
+        <Row>
+          <Col>QA</Col>
+          <Col className="text-right">
+            <Button
+              data-testid="qa-edit-save"
+              onClick={handleSave}
+              disabled={isLoading}
+              variant="primary"
+              size="sm"
+              className="mx-1"
+            >
+              Save
+            </Button>
+            <Button
+              data-testid="qa-edit-cancel"
+              onClick={onClickCancel}
+              disabled={isLoading}
+              variant="secondary"
+              size="sm"
+              className="mx-1"
+            >
+              Cancel
+            </Button>
+          </Col>
+        </Row>
+      </h3>
+      <FormProvider {...formMethods}>
+        <Form
+          noValidate
+          onSubmit={handleSave}
+          validated={isSubmitted && isValid}
+          data-testid="FormQA"
+        >
+          {submitErrors["*"] && (
+            <Alert data-testid="submit-error" variant="warning">
+              {submitErrors["*"]}
+            </Alert>
+          )}
+
+          <Form.Group as={Row} controlId="qaStatus" className="mb-0 pl-1">
+            {/* <Form.Group data-testid="qa-status" className="ml-3">
+              <Form.Control
+                as="select"
+                onSubmit={handleSave}
+                onChange={(e) => setQaStatus(qaStatusField)}
+                id="qaStatus"
+                {...{ "data-testid": "qaStatus" }}
+              >
+                <QaStatusSelectOptions options={qaStatusSlugOptions} />
+              </Form.Control>
+            </Form.Group> */}
+            Hello world
+          </Form.Group>
+        </Form>
+      </FormProvider>
+    </section>
+  );
+};
+
+// const QaStatusSelectOptions = ({
+//   options,
+// }: {
+//   options:
+//     | null
+//     | (null | {
+//         label: null | string;
+//         value: null | string;
+//         description: null | string;
+//       })[];
+// }) => (
+//   <>
+//     {options?.map(
+//       (item, idx) =>
+//         item && (
+//           <option key={idx} value={item.value || ""}>
+//             `${item.description}`
+//           </option>
+//         ),
+//     )}
+//   </>
+// );
+
+export default QAEditor;

--- a/experimenter/experimenter/nimbus-ui/src/components/Summary/TableQA/index.test.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/Summary/TableQA/index.test.tsx
@@ -1,0 +1,219 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { render, screen, within } from "@testing-library/react";
+import React from "react";
+import TableOverview from "src/components/Summary/TableOverview";
+import { MockedCache, mockExperimentQuery, MOCK_CONFIG } from "src/lib/mocks";
+import { getExperiment_experimentBySlug } from "src/types/getExperiment";
+
+describe("TableOverview", () => {
+  it("renders rows displaying required fields at experiment creation as expected", () => {
+    const { experiment } = mockExperimentQuery("demo-slug");
+    render(<Subject {...{ experiment }} />);
+
+    expect(screen.getByTestId("experiment-slug")).toHaveTextContent(
+      "demo-slug",
+    );
+    expect(screen.getByTestId("experiment-owner")).toHaveTextContent(
+      "example@mozilla.com",
+    );
+    expect(screen.getByTestId("experiment-application")).toHaveTextContent(
+      "Desktop",
+    );
+    expect(screen.getByTestId("experiment-hypothesis")).toHaveTextContent(
+      "Realize material say pretty.",
+    );
+    expect(screen.getByTestId("experiment-team-projects")).toHaveTextContent(
+      "Pocket",
+    );
+  });
+
+  describe("renders 'Primary outcomes' row as expected", () => {
+    it("with one outcome", () => {
+      const { experiment } = mockExperimentQuery("demo-slug");
+      render(<Subject {...{ experiment }} />);
+      expect(
+        screen.getByTestId("experiment-outcome-primary"),
+      ).toHaveTextContent("Picture-in-Picture");
+    });
+    it("with correct documentation URl", () => {
+      const { experiment } = mockExperimentQuery("demo-slug", {
+        primaryOutcomes: ["picture_in_picture"],
+      });
+      render(<Subject {...{ experiment }} />);
+      expect(
+        screen.getByTestId("primary-outcome-picture_in_picture"),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByTestId("primary-outcome-picture_in_picture"),
+      ).toHaveAttribute(
+        "href",
+        "https://mozilla.github.io/metric-hub/outcomes/firefox_desktop/picture_in_picture",
+      );
+    });
+    it("with multiple outcomes", () => {
+      const { experiment } = mockExperimentQuery("demo-slug", {
+        primaryOutcomes: ["picture_in_picture", "feature_c"],
+      });
+      render(<Subject {...{ experiment }} />);
+      expect(
+        screen.getByTestId("experiment-outcome-primary"),
+      ).toHaveTextContent("Picture-in-Picture, Feature C");
+    });
+    it("when not set", () => {
+      const { experiment } = mockExperimentQuery("demo-slug", {
+        primaryOutcomes: [],
+      });
+      render(<Subject {...{ experiment }} />);
+      expect(
+        screen.queryByTestId("experiment-outcome-primary"),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe("renders 'Secondary outcomes' row as expected", () => {
+    it("with one outcome", () => {
+      const { experiment } = mockExperimentQuery("demo-slug");
+      render(<Subject {...{ experiment }} />);
+      expect(
+        screen.getByTestId("experiment-outcome-secondary"),
+      ).toHaveTextContent("Feature B");
+    });
+    it("with correct documentation URl", () => {
+      const { experiment } = mockExperimentQuery("demo-slug", {
+        secondaryOutcomes: ["picture_in_picture"],
+      });
+      render(<Subject {...{ experiment }} />);
+      expect(
+        screen.getByTestId("secondary-outcome-picture_in_picture"),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByTestId("secondary-outcome-picture_in_picture"),
+      ).toHaveAttribute(
+        "href",
+        "https://mozilla.github.io/metric-hub/outcomes/firefox_desktop/picture_in_picture",
+      );
+    });
+    it("with multiple outcomes", () => {
+      const { experiment } = mockExperimentQuery("demo-slug", {
+        secondaryOutcomes: ["picture_in_picture", "feature_b"],
+      });
+      render(<Subject {...{ experiment }} />);
+      expect(
+        screen.getByTestId("experiment-outcome-secondary"),
+      ).toHaveTextContent("Picture-in-Picture, Feature B");
+    });
+    it("when not set", () => {
+      const { experiment } = mockExperimentQuery("demo-slug", {
+        secondaryOutcomes: [],
+      });
+      render(<Subject {...{ experiment }} />);
+      expect(
+        screen.queryByTestId("experiment-outcome-secondary"),
+      ).not.toBeInTheDocument();
+    });
+
+    describe("renders 'Public description' row as expected", () => {
+      it("when set", () => {
+        const { experiment } = mockExperimentQuery("demo-slug");
+        render(<Subject {...{ experiment }} />);
+        expect(screen.getByTestId("experiment-description")).toHaveTextContent(
+          "Official approach present industry strategy dream piece.",
+        );
+      });
+      it("when not set", () => {
+        const { experiment } = mockExperimentQuery("demo-slug", {
+          publicDescription: "",
+        });
+        render(<Subject {...{ experiment }} />);
+        expect(screen.getByTestId("experiment-description")).toHaveTextContent(
+          "Not set",
+        );
+      });
+    });
+  });
+
+  describe("renders 'Feature config' row as expected", () => {
+    it("when set", () => {
+      const { experiment } = mockExperimentQuery("demo-slug");
+      render(<Subject {...{ experiment }} />);
+      expect(screen.getByTestId("experiment-feature-config")).toHaveTextContent(
+        "Picture-in-Picture",
+      );
+    });
+    it("when not set", () => {
+      const { experiment } = mockExperimentQuery("demo-slug", {
+        featureConfigs: [],
+      });
+      render(<Subject {...{ experiment }} />);
+      expect(screen.getByTestId("experiment-feature-config")).toHaveTextContent(
+        "Not set",
+      );
+    });
+  });
+  describe("renders 'Targeting config' row as expected", () => {
+    it("when set", () => {
+      const { experiment } = mockExperimentQuery("demo-slug", {
+        targetingConfig: [MOCK_CONFIG.targetingConfigs![0]],
+      });
+      render(<Subject {...{ experiment }} />);
+      expect(
+        screen.getByTestId("experiment-targeting-config"),
+      ).toHaveTextContent("Mac Only - Mac only configuration");
+    });
+    it("when not set", () => {
+      const { experiment } = mockExperimentQuery("demo-slug", {
+        targetingConfig: [],
+      });
+      render(<Subject {...{ experiment }} />);
+      expect(
+        screen.getByTestId("experiment-targeting-config"),
+      ).toHaveTextContent("Not set");
+    });
+  });
+
+  describe("renders 'Team Projects' row as expected", () => {
+    it("with one team project", () => {
+      const { experiment } = mockExperimentQuery("demo-slug");
+      render(<Subject {...{ experiment }} />);
+      expect(screen.getByTestId("experiment-team-projects")).toHaveTextContent(
+        "Pocket",
+      );
+    });
+    it("with multiple projects", () => {
+      const { experiment } = mockExperimentQuery("demo-slug", {
+        projects: [
+          { id: "1", name: "Pocket" },
+          { id: "2", name: "VPN" },
+        ],
+      });
+      render(<Subject {...{ experiment }} />);
+      experiment.projects!.forEach((team) =>
+        within(screen.getByTestId("experiment-team-projects")).findByText(
+          team!.name!,
+        ),
+      );
+    });
+    it("when not set", () => {
+      const { experiment } = mockExperimentQuery("demo-slug", {
+        projects: [],
+      });
+      render(<Subject {...{ experiment }} />);
+      expect(
+        screen.queryByTestId("experiment-team-projects"),
+      ).toHaveTextContent("Not set");
+    });
+  });
+});
+
+const Subject = ({
+  experiment,
+}: {
+  experiment: getExperiment_experimentBySlug;
+}) => (
+  <MockedCache>
+    <TableOverview {...{ experiment }} />
+  </MockedCache>
+);

--- a/experimenter/experimenter/nimbus-ui/src/components/Summary/TableQA/index.test.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/Summary/TableQA/index.test.tsx
@@ -2,218 +2,39 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { render, screen, within } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import React from "react";
-import TableOverview from "src/components/Summary/TableOverview";
-import { MockedCache, mockExperimentQuery, MOCK_CONFIG } from "src/lib/mocks";
-import { getExperiment_experimentBySlug } from "src/types/getExperiment";
-
-describe("TableOverview", () => {
-  it("renders rows displaying required fields at experiment creation as expected", () => {
-    const { experiment } = mockExperimentQuery("demo-slug");
-    render(<Subject {...{ experiment }} />);
-
-    expect(screen.getByTestId("experiment-slug")).toHaveTextContent(
-      "demo-slug",
-    );
-    expect(screen.getByTestId("experiment-owner")).toHaveTextContent(
-      "example@mozilla.com",
-    );
-    expect(screen.getByTestId("experiment-application")).toHaveTextContent(
-      "Desktop",
-    );
-    expect(screen.getByTestId("experiment-hypothesis")).toHaveTextContent(
-      "Realize material say pretty.",
-    );
-    expect(screen.getByTestId("experiment-team-projects")).toHaveTextContent(
-      "Pocket",
-    );
-  });
-
-  describe("renders 'Primary outcomes' row as expected", () => {
-    it("with one outcome", () => {
-      const { experiment } = mockExperimentQuery("demo-slug");
-      render(<Subject {...{ experiment }} />);
-      expect(
-        screen.getByTestId("experiment-outcome-primary"),
-      ).toHaveTextContent("Picture-in-Picture");
-    });
-    it("with correct documentation URl", () => {
-      const { experiment } = mockExperimentQuery("demo-slug", {
-        primaryOutcomes: ["picture_in_picture"],
-      });
-      render(<Subject {...{ experiment }} />);
-      expect(
-        screen.getByTestId("primary-outcome-picture_in_picture"),
-      ).toBeInTheDocument();
-      expect(
-        screen.getByTestId("primary-outcome-picture_in_picture"),
-      ).toHaveAttribute(
-        "href",
-        "https://mozilla.github.io/metric-hub/outcomes/firefox_desktop/picture_in_picture",
-      );
-    });
-    it("with multiple outcomes", () => {
-      const { experiment } = mockExperimentQuery("demo-slug", {
-        primaryOutcomes: ["picture_in_picture", "feature_c"],
-      });
-      render(<Subject {...{ experiment }} />);
-      expect(
-        screen.getByTestId("experiment-outcome-primary"),
-      ).toHaveTextContent("Picture-in-Picture, Feature C");
-    });
-    it("when not set", () => {
-      const { experiment } = mockExperimentQuery("demo-slug", {
-        primaryOutcomes: [],
-      });
-      render(<Subject {...{ experiment }} />);
-      expect(
-        screen.queryByTestId("experiment-outcome-primary"),
-      ).not.toBeInTheDocument();
-    });
-  });
-
-  describe("renders 'Secondary outcomes' row as expected", () => {
-    it("with one outcome", () => {
-      const { experiment } = mockExperimentQuery("demo-slug");
-      render(<Subject {...{ experiment }} />);
-      expect(
-        screen.getByTestId("experiment-outcome-secondary"),
-      ).toHaveTextContent("Feature B");
-    });
-    it("with correct documentation URl", () => {
-      const { experiment } = mockExperimentQuery("demo-slug", {
-        secondaryOutcomes: ["picture_in_picture"],
-      });
-      render(<Subject {...{ experiment }} />);
-      expect(
-        screen.getByTestId("secondary-outcome-picture_in_picture"),
-      ).toBeInTheDocument();
-      expect(
-        screen.getByTestId("secondary-outcome-picture_in_picture"),
-      ).toHaveAttribute(
-        "href",
-        "https://mozilla.github.io/metric-hub/outcomes/firefox_desktop/picture_in_picture",
-      );
-    });
-    it("with multiple outcomes", () => {
-      const { experiment } = mockExperimentQuery("demo-slug", {
-        secondaryOutcomes: ["picture_in_picture", "feature_b"],
-      });
-      render(<Subject {...{ experiment }} />);
-      expect(
-        screen.getByTestId("experiment-outcome-secondary"),
-      ).toHaveTextContent("Picture-in-Picture, Feature B");
-    });
-    it("when not set", () => {
-      const { experiment } = mockExperimentQuery("demo-slug", {
-        secondaryOutcomes: [],
-      });
-      render(<Subject {...{ experiment }} />);
-      expect(
-        screen.queryByTestId("experiment-outcome-secondary"),
-      ).not.toBeInTheDocument();
-    });
-
-    describe("renders 'Public description' row as expected", () => {
-      it("when set", () => {
-        const { experiment } = mockExperimentQuery("demo-slug");
-        render(<Subject {...{ experiment }} />);
-        expect(screen.getByTestId("experiment-description")).toHaveTextContent(
-          "Official approach present industry strategy dream piece.",
-        );
-      });
-      it("when not set", () => {
-        const { experiment } = mockExperimentQuery("demo-slug", {
-          publicDescription: "",
-        });
-        render(<Subject {...{ experiment }} />);
-        expect(screen.getByTestId("experiment-description")).toHaveTextContent(
-          "Not set",
-        );
-      });
-    });
-  });
-
-  describe("renders 'Feature config' row as expected", () => {
-    it("when set", () => {
-      const { experiment } = mockExperimentQuery("demo-slug");
-      render(<Subject {...{ experiment }} />);
-      expect(screen.getByTestId("experiment-feature-config")).toHaveTextContent(
-        "Picture-in-Picture",
-      );
-    });
-    it("when not set", () => {
-      const { experiment } = mockExperimentQuery("demo-slug", {
-        featureConfigs: [],
-      });
-      render(<Subject {...{ experiment }} />);
-      expect(screen.getByTestId("experiment-feature-config")).toHaveTextContent(
-        "Not set",
-      );
-    });
-  });
-  describe("renders 'Targeting config' row as expected", () => {
-    it("when set", () => {
-      const { experiment } = mockExperimentQuery("demo-slug", {
-        targetingConfig: [MOCK_CONFIG.targetingConfigs![0]],
-      });
-      render(<Subject {...{ experiment }} />);
-      expect(
-        screen.getByTestId("experiment-targeting-config"),
-      ).toHaveTextContent("Mac Only - Mac only configuration");
-    });
-    it("when not set", () => {
-      const { experiment } = mockExperimentQuery("demo-slug", {
-        targetingConfig: [],
-      });
-      render(<Subject {...{ experiment }} />);
-      expect(
-        screen.getByTestId("experiment-targeting-config"),
-      ).toHaveTextContent("Not set");
-    });
-  });
-
-  describe("renders 'Team Projects' row as expected", () => {
-    it("with one team project", () => {
-      const { experiment } = mockExperimentQuery("demo-slug");
-      render(<Subject {...{ experiment }} />);
-      expect(screen.getByTestId("experiment-team-projects")).toHaveTextContent(
-        "Pocket",
-      );
-    });
-    it("with multiple projects", () => {
-      const { experiment } = mockExperimentQuery("demo-slug", {
-        projects: [
-          { id: "1", name: "Pocket" },
-          { id: "2", name: "VPN" },
-        ],
-      });
-      render(<Subject {...{ experiment }} />);
-      experiment.projects!.forEach((team) =>
-        within(screen.getByTestId("experiment-team-projects")).findByText(
-          team!.name!,
-        ),
-      );
-    });
-    it("when not set", () => {
-      const { experiment } = mockExperimentQuery("demo-slug", {
-        projects: [],
-      });
-      render(<Subject {...{ experiment }} />);
-      expect(
-        screen.queryByTestId("experiment-team-projects"),
-      ).toHaveTextContent("Not set");
-    });
-  });
-});
+import { Subject as BaseSubject } from "src/components/Summary/TableQA/mocks";
+import { mockExperimentQuery } from "src/lib/mocks";
+import { NimbusExperimentQAStatusEnum } from "src/types/globalTypes";
 
 const Subject = ({
-  experiment,
-}: {
-  experiment: getExperiment_experimentBySlug;
-}) => (
-  <MockedCache>
-    <TableOverview {...{ experiment }} />
-  </MockedCache>
+  onSubmit = jest.fn(),
+  ...props
+}: React.ComponentProps<typeof BaseSubject>) => (
+  <BaseSubject {...{ onSubmit, ...props }} />
 );
+
+const qaStatus = NimbusExperimentQAStatusEnum.GREEN;
+const { experiment } = mockExperimentQuery("demo-slug", {
+  qaStatus: null,
+});
+
+describe("TableQA", () => {
+  it("renders rows displaying required fields at experiment creation as expected", () => {
+    const { experiment } = mockExperimentQuery("demo-slug");
+    const qaStatus = experiment.qaStatus;
+    render(<Subject />);
+
+    expect(screen.getByTestId("experiment-qa-status")).toHaveTextContent(
+      "Not set",
+    );
+  });
+
+  it("renders 'QA status' row as expected with status set", () => {
+    render(<Subject {...{ qaStatus }} />);
+    expect(screen.getByTestId("experiment-qa-status")).toHaveTextContent(
+      "GREEN",
+    );
+  });
+});

--- a/experimenter/experimenter/nimbus-ui/src/components/Summary/TableQA/index.test.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/Summary/TableQA/index.test.tsx
@@ -2,10 +2,25 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { render, screen } from "@testing-library/react";
+import { MockedResponse } from "@apollo/client/testing";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import {
+  act as hookAct,
+  renderHook,
+  RenderResult as HookRenderResult,
+} from "@testing-library/react-hooks";
 import React from "react";
+import { act } from "react-dom/test-utils";
 import { Subject as BaseSubject } from "src/components/Summary/TableQA/mocks";
-import { mockExperimentQuery } from "src/lib/mocks";
+import useQA, { UseQAResult } from "src/components/Summary/TableQA/useQA";
+import { UPDATE_EXPERIMENT_MUTATION } from "src/gql/experiments";
+import { CHANGELOG_MESSAGES, SUBMIT_ERROR } from "src/lib/constants";
+import {
+  MockedCache,
+  mockExperimentMutation,
+  mockExperimentQuery,
+} from "src/lib/mocks";
+import { getExperiment_experimentBySlug } from "src/types/getExperiment";
 import { NimbusExperimentQAStatusEnum } from "src/types/globalTypes";
 
 const Subject = ({
@@ -23,9 +38,10 @@ const { experiment } = mockExperimentQuery("demo-slug", {
 describe("TableQA", () => {
   it("renders rows displaying required fields at experiment creation as expected", () => {
     const { experiment } = mockExperimentQuery("demo-slug");
-    const qaStatus = experiment.qaStatus;
     render(<Subject />);
 
+    expect(screen.queryByTestId("section-qa")).toBeInTheDocument();
+    expect(screen.queryByTestId("QAEditor")).not.toBeInTheDocument();
     expect(screen.getByTestId("experiment-qa-status")).toHaveTextContent(
       "Not set",
     );
@@ -38,3 +54,343 @@ describe("TableQA", () => {
     );
   });
 });
+
+describe("QAEditor", () => {
+  it("appears when showEditor is true", () => {
+    render(<Subject showEditor />);
+    expect(screen.queryByTestId("section-qa")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("QAEditor")).toBeInTheDocument();
+  });
+
+  it("renders as expected with content", () => {
+    render(
+      <Subject
+        {...{
+          showEditor: true,
+          qaStatus,
+        }}
+      />,
+    );
+    expect(screen.queryByTestId("QAEditor")).toBeInTheDocument();
+    expect(screen.getByText("Save")).not.toBeDisabled();
+    expect(screen.getByText("Cancel")).not.toBeDisabled();
+    expect(screen.queryByTestId("qa-status")).toBeInTheDocument();
+  });
+
+  it("disables buttons when loading", async () => {
+    const onSubmit = jest.fn();
+    render(
+      <Subject
+        {...{
+          onSubmit,
+          showEditor: true,
+          isLoading: true,
+          qaStatus,
+        }}
+      />,
+    );
+    expect(screen.getByText("Save")).toBeDisabled();
+    expect(screen.getByText("Cancel")).toBeDisabled();
+    await act(async () => {
+      fireEvent.submit(screen.getByTestId("FormQA"));
+    });
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it("submits form data when save is clicked", async () => {
+    const expected = {
+      qaStatus: qaStatus,
+    };
+
+    const onSubmit = jest.fn();
+    const { container } = render(
+      <Subject
+        {...{
+          onSubmit,
+          showEditor: true,
+          qaStatus,
+        }}
+      />,
+    );
+    await act(async () => {
+      fireEvent.click(screen.getByText("Save"));
+    });
+    const result = onSubmit.mock.calls[0][0];
+    await waitFor(() => expect(onSubmit).toHaveBeenCalled());
+
+    expect(result).toEqual(expected);
+    expect(result.qaStatus).toEqual(qaStatus);
+  });
+
+  it("updates qa status and saves as expected", async () => {
+    const onSubmit = jest.fn();
+    const expectedStatus = NimbusExperimentQAStatusEnum.GREEN.toString();
+    const expectedVal = { qaStatus: NimbusExperimentQAStatusEnum.GREEN };
+    render(
+      <Subject
+        {...{
+          onSubmit,
+          showEditor: true,
+        }}
+      />,
+    );
+
+    const select = await screen.findByTestId("qa-status");
+    expect(select).toHaveTextContent("Choose a score");
+    fireEvent.change(select, {
+      target: { value: expectedStatus },
+    });
+
+    const select1 = await screen.findByTestId("qa-status");
+    expect(select1).toBeInTheDocument();
+    expect((select1 as HTMLInputElement).value).toEqual(expectedStatus);
+
+    expect(screen.getByTestId("qa-status")).toHaveTextContent(expectedStatus);
+
+    await act(async () => {
+      fireEvent.click(screen.getByText("Save"));
+    });
+    const result1 = onSubmit.mock.calls[0][0];
+
+    expect(onSubmit).toHaveBeenCalledWith(expectedVal);
+    expect(result1.qaStatus).toBeTruthy();
+    expect(result1.qaStatus).toEqual(expectedStatus);
+  });
+
+  it("hides the editor when cancel is clicked", async () => {
+    const setShowEditor = jest.fn();
+    render(
+      <Subject
+        {...{
+          setShowEditor,
+          showEditor: true,
+          qaStatus,
+        }}
+      />,
+    );
+    await act(async () => {
+      fireEvent.click(screen.getByText("Cancel"));
+    });
+    expect(setShowEditor).toHaveBeenCalledWith(false);
+  });
+});
+
+describe("useQA hook", () => {
+  const submitData = {
+    qaStatus: NimbusExperimentQAStatusEnum.GREEN,
+  };
+  const mutationVariables = {
+    id: experiment.id,
+    qaStatus: submitData.qaStatus,
+    changelogMessage: CHANGELOG_MESSAGES.UPDATED_QA_STATUS,
+  };
+  let refetch = jest.fn();
+
+  beforeEach(() => {
+    refetch = jest.fn();
+  });
+
+  it("returns expected initial props", () => {
+    const { result } = setupTestHook({ refetch });
+    const props = result.current;
+    expect(props).toMatchObject({
+      id: experiment.id,
+      qaStatus: experiment.qaStatus,
+      showEditor: false,
+      isLoading: false,
+      submitErrors: {},
+      isServerValid: true,
+    });
+    const functionNames: (keyof UseQAResult)[] = [
+      "onSubmit",
+      "setShowEditor",
+      "setSubmitErrors",
+    ];
+    for (const name of functionNames) {
+      expect(typeof props[name]).toEqual("function");
+    }
+  });
+
+  it("performs an update mutation as expected on submit", async () => {
+    const { result } = setupTestHook({
+      refetch,
+      mocks: [
+        mockExperimentMutation(
+          UPDATE_EXPERIMENT_MUTATION,
+          mutationVariables,
+          "updateExperiment",
+          { experiment: mutationVariables },
+        ),
+      ],
+    });
+    await hookAct(async () => {
+      await result.current.setShowEditor(true);
+    });
+    await hookAct(async () => {
+      await result.current.onSubmit(submitData);
+    });
+    expect(refetch).toHaveBeenCalled();
+    assertHookSteps(
+      result,
+      ["isLoading", "isServerValid", "submitErrors", "showEditor"],
+      [
+        [false, true, {}, false],
+        [false, true, {}, true],
+        [true, true, {}, true],
+        [true, true, {}, true],
+        [true, true, {}, true],
+        [true, true, {}, true],
+        [true, true, {}, false],
+        [false, true, {}, false],
+      ],
+    );
+  });
+
+  it("handles submit errors on submit", async () => {
+    const mocks = [
+      mockExperimentMutation(
+        UPDATE_EXPERIMENT_MUTATION,
+        mutationVariables,
+        "updateExperiment",
+        { experiment: mutationVariables },
+      ),
+    ];
+    const submitErrors = {
+      "*": ["Oh no! Bad server!"],
+      qa_status: ["Too many bad vibes!"],
+    };
+    mocks[0].result.data.updateExperiment.message = submitErrors;
+    const refetch = jest.fn();
+    const { result } = setupTestHook({ refetch, mocks });
+    await hookAct(async () => {
+      await result.current.setShowEditor(true);
+    });
+    await hookAct(async () => {
+      await result.current.onSubmit(submitData);
+    });
+    expect(refetch).not.toHaveBeenCalled();
+    assertHookSteps(
+      result,
+      ["isLoading", "isServerValid", "submitErrors", "showEditor"],
+      [
+        [false, true, {}, false],
+        [false, true, {}, true],
+        [true, true, {}, true],
+        [true, true, {}, true],
+        [true, false, {}, true],
+        [false, false, {}, true],
+        [false, false, submitErrors, true],
+      ],
+    );
+  });
+
+  it("handles exceptions on submit", async () => {
+    const mocks = [
+      mockExperimentMutation(
+        UPDATE_EXPERIMENT_MUTATION,
+        mutationVariables,
+        "updateExperiment",
+        { experiment: mutationVariables },
+      ),
+    ];
+    mocks[0].result.errors = [new Error("OOPSIE")];
+    const { result } = setupTestHook({ refetch, mocks });
+    await hookAct(async () => {
+      await result.current.setShowEditor(true);
+    });
+    await hookAct(async () => {
+      await result.current.onSubmit(submitData);
+    });
+    expect(refetch).not.toHaveBeenCalled();
+    assertHookSteps(
+      result,
+      ["isLoading", "isServerValid", "submitErrors", "showEditor"],
+      [
+        [false, true, {}, false],
+        [false, true, {}, true],
+        [true, true, {}, true],
+        [true, true, {}, true],
+        [true, false, {}, true],
+        [false, false, {}, true],
+        [false, false, { "*": SUBMIT_ERROR }, true],
+      ],
+    );
+  });
+
+  it("handles invalid server data on submit", async () => {
+    const mocks = [
+      mockExperimentMutation(
+        UPDATE_EXPERIMENT_MUTATION,
+        mutationVariables,
+        "updateExperiment",
+        { experiment: mutationVariables },
+      ),
+    ];
+    // @ts-ignore intentionally broken type
+    delete mocks[0].result.data;
+    const { result } = setupTestHook({ refetch, mocks });
+    await hookAct(async () => {
+      await result.current.setShowEditor(true);
+    });
+    await hookAct(async () => {
+      await result.current.onSubmit(submitData);
+    });
+    expect(refetch).not.toHaveBeenCalled();
+    assertHookSteps(
+      result,
+      ["isLoading", "isServerValid", "submitErrors", "showEditor"],
+      [
+        [false, true, {}, false],
+        [false, true, {}, true],
+        [true, true, {}, true],
+        [true, true, {}, true],
+        [true, false, {}, true],
+        [false, false, {}, true],
+        [false, false, { "*": SUBMIT_ERROR }, true],
+      ],
+    );
+  });
+
+  function assertHookSteps(
+    result: HookRenderResult<UseQAResult>,
+    expectedStepKeys: (keyof UseQAResult)[],
+    expectedSteps: any[],
+  ) {
+    for (let stepIdx = 0; stepIdx < expectedSteps.length; stepIdx++) {
+      expect(result.all[stepIdx]).not.toBeInstanceOf(Error);
+      const props = result.all[stepIdx] as UseQAResult;
+      // Zip together the expected step keys with values into expected object
+      const expected = expectedStepKeys.reduce(
+        (acc, key, idx) => ({ ...acc, [key]: expectedSteps[stepIdx][idx] }),
+        {},
+      );
+      expect(props).toMatchObject(expected);
+    }
+  }
+});
+
+const defaultMockExperiment = experiment;
+const setupTestHook = ({
+  experiment = defaultMockExperiment,
+  refetch = jest.fn(),
+  mocks = [],
+}: {
+  experiment?: getExperiment_experimentBySlug;
+  refetch?: () => Promise<void>;
+  mocks?: MockedResponse[];
+}) => {
+  return renderHook(() => useQA(experiment, refetch), {
+    wrapper,
+    initialProps: { mocks },
+  });
+};
+
+const wrapper = ({
+  mocks = [],
+  children,
+}: {
+  mocks?: MockedResponse[];
+  children?: React.ReactNode;
+}) => (
+  <MockedCache {...{ mocks }}>{children as React.ReactElement}</MockedCache>
+);

--- a/experimenter/experimenter/nimbus-ui/src/components/Summary/TableQA/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/Summary/TableQA/index.tsx
@@ -18,7 +18,6 @@ export type QAEditorProps = UseQAResult & {
 };
 
 const TableQA = (props: TableQAProps) => {
-  // const { experiment, showEditor, setShowEditor } = props;
   const { qaStatus, showEditor, setShowEditor } = props;
 
   const onClickEdit = useCallback(() => setShowEditor(true), [setShowEditor]);
@@ -53,16 +52,13 @@ const TableQA = (props: TableQAProps) => {
             <tr className="w-25">
               <th className="border-top-0 border-bottom-2">QA Status</th>
               <td
-                data-testid="experiment-slug"
+                data-testid="experiment-qa-status"
                 className="text-monospace border-top-0 border-bottom-2"
               >
                 {qaStatus || <NotSet />}
               </td>
               <th className="border-top-0 w-75 border-bottom-2"></th>
-              <td
-                data-testid="experiment-owner"
-                className="border-top-0 border-bottom-2"
-              />
+              <td className="border-top-0 border-bottom-2" />
             </tr>
           </tbody>
         </Table>

--- a/experimenter/experimenter/nimbus-ui/src/components/Summary/TableQA/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/Summary/TableQA/index.tsx
@@ -1,0 +1,74 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React, { useCallback } from "react";
+import { Button, Card, Col, Row, Table } from "react-bootstrap";
+import NotSet from "src/components/NotSet";
+import QAEditor from "src/components/Summary/TableQA/QAEditor";
+import { UseQAResult } from "src/components/Summary/TableQA/useQA";
+import { NimbusExperimentQAStatusEnum } from "src/types/globalTypes";
+
+type TableQAProps = {
+  qaStatus?: NimbusExperimentQAStatusEnum | null;
+} & UseQAResult;
+
+export type QAEditorProps = UseQAResult & {
+  setShowEditor: (state: boolean) => void;
+};
+
+const TableQA = (props: TableQAProps) => {
+  // const { experiment, showEditor, setShowEditor } = props;
+  const { qaStatus, showEditor, setShowEditor } = props;
+
+  const onClickEdit = useCallback(() => setShowEditor(true), [setShowEditor]);
+
+  if (showEditor) {
+    return <QAEditor {...{ ...props, setShowEditor }} />;
+  }
+
+  return (
+    <Card className="my-4 border-left-0 border-right-0">
+      <Card.Header as="h5">
+        <Row>
+          <Col className="my-1">QA</Col>
+          <Col className="text-right">
+            {
+              <Button
+                onClick={onClickEdit}
+                variant="outline-primary"
+                size="sm"
+                className="mx-1"
+                data-testid="edit-qa-status"
+              >
+                Edit
+              </Button>
+            }
+          </Col>
+        </Row>
+      </Card.Header>
+      <Card.Body className=" pe-2 ps-2">
+        <Table data-testid="table-qa-status">
+          <tbody>
+            <tr className="w-25">
+              <th className="border-top-0 border-bottom-2">QA Status</th>
+              <td
+                data-testid="experiment-slug"
+                className="text-monospace border-top-0 border-bottom-2"
+              >
+                {qaStatus || <NotSet />}
+              </td>
+              <th className="border-top-0 w-75 border-bottom-2"></th>
+              <td
+                data-testid="experiment-owner"
+                className="border-top-0 border-bottom-2"
+              />
+            </tr>
+          </tbody>
+        </Table>
+      </Card.Body>
+    </Card>
+  );
+};
+
+export default TableQA;

--- a/experimenter/experimenter/nimbus-ui/src/components/Summary/TableQA/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/Summary/TableQA/index.tsx
@@ -28,41 +28,43 @@ const TableQA = (props: TableQAProps) => {
 
   return (
     <Card className="my-4 border-left-0 border-right-0">
-      <Card.Header as="h5">
-        <Row>
-          <Col className="my-1">QA</Col>
-          <Col className="text-right">
-            {
-              <Button
-                onClick={onClickEdit}
-                variant="outline-primary"
-                size="sm"
-                className="mx-1"
-                data-testid="edit-qa-status"
-              >
-                Edit
-              </Button>
-            }
-          </Col>
-        </Row>
-      </Card.Header>
-      <Card.Body className=" pe-2 ps-2">
-        <Table data-testid="table-qa-status">
-          <tbody>
-            <tr className="w-25">
-              <th className="border-top-0 border-bottom-2">QA Status</th>
-              <td
-                data-testid="experiment-qa-status"
-                className="text-monospace border-top-0 border-bottom-2"
-              >
-                {qaStatus || <NotSet />}
-              </td>
-              <th className="border-top-0 w-75 border-bottom-2"></th>
-              <td className="border-top-0 border-bottom-2" />
-            </tr>
-          </tbody>
-        </Table>
-      </Card.Body>
+      <section id="section-qa" data-testid="section-qa">
+        <Card.Header as="h5">
+          <Row>
+            <Col className="my-1">QA</Col>
+            <Col className="text-right">
+              {
+                <Button
+                  onClick={onClickEdit}
+                  variant="outline-primary"
+                  size="sm"
+                  className="mx-1"
+                  data-testid="edit-qa-status"
+                >
+                  Edit
+                </Button>
+              }
+            </Col>
+          </Row>
+        </Card.Header>
+        <Card.Body className=" pe-2 ps-2">
+          <Table data-testid="table-qa-status">
+            <tbody>
+              <tr className="w-25">
+                <th className="border-top-0 border-bottom-2">QA Status</th>
+                <td
+                  data-testid="experiment-qa-status"
+                  className="text-monospace border-top-0 border-bottom-2"
+                >
+                  {qaStatus || <NotSet />}
+                </td>
+                <th className="border-top-0 w-75 border-bottom-2"></th>
+                <td className="border-top-0 border-bottom-2" />
+              </tr>
+            </tbody>
+          </Table>
+        </Card.Body>
+      </section>
     </Card>
   );
 };

--- a/experimenter/experimenter/nimbus-ui/src/components/Summary/TableQA/mocks.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/Summary/TableQA/mocks.tsx
@@ -1,0 +1,44 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+import React, { useState } from "react";
+import TableQA from "src/components/Summary/TableQA";
+import { RouterSlugProvider } from "src/lib/test-utils";
+
+export const Subject = ({
+  id = 123,
+  qaStatus = null,
+  isLoading = false,
+  onSubmit = async (data) => {},
+  ...props
+}: Partial<React.ComponentProps<typeof TableQA>>) => {
+  const [showEditor, setShowEditor] = useState(
+    typeof props.showEditor !== "undefined" ? props.showEditor : false,
+  );
+  const [submitErrors, setSubmitErrors] = useState<Record<string, any>>(
+    props.submitErrors || {},
+  );
+  const isServerValid =
+    typeof props.isServerValid !== "undefined" ? props.isServerValid : false;
+
+  return (
+    <RouterSlugProvider>
+      <div className="p-4">
+        <TableQA
+          {...{
+            id,
+            qaStatus,
+            isLoading,
+            onSubmit,
+            showEditor,
+            setShowEditor,
+            submitErrors,
+            setSubmitErrors,
+            isServerValid,
+            ...props,
+          }}
+        />
+      </div>
+    </RouterSlugProvider>
+  );
+};

--- a/experimenter/experimenter/nimbus-ui/src/components/Summary/TableQA/useQA.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/Summary/TableQA/useQA.tsx
@@ -1,0 +1,102 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { useMutation } from "@apollo/client";
+import { useCallback, useState } from "react";
+import { UPDATE_EXPERIMENT_MUTATION } from "src/gql/experiments";
+import {
+  CHANGELOG_MESSAGES,
+  SAVE_FAILED_QA_STATUS,
+  SUBMIT_ERROR,
+} from "src/lib/constants";
+import { getExperiment_experimentBySlug } from "src/types/getExperiment";
+import {
+  updateExperiment,
+  updateExperimentVariables,
+} from "src/types/updateExperiment";
+
+// Params are a select subset of experiment properties
+export type UseQAExperimentSubset = Pick<
+  getExperiment_experimentBySlug,
+  "id" | "qaStatus"
+>;
+
+export type UseQAResult = UseQAExperimentSubset & {
+  showEditor: boolean;
+  setShowEditor: React.Dispatch<React.SetStateAction<boolean>>;
+  isLoading: boolean;
+  onSubmit: (data: Record<string, any>) => Promise<void>;
+  isServerValid: boolean;
+  submitErrors: SerializerMessages;
+  setSubmitErrors: React.Dispatch<React.SetStateAction<Record<string, any>>>;
+};
+
+export const useQA = (
+  params: UseQAExperimentSubset,
+  refetch?: () => Promise<unknown>,
+): UseQAResult => {
+  const [isLoading, setIsLoading] = useState(false);
+  const [showEditor, setShowEditor] = useState(false);
+  const [submitErrors, setSubmitErrors] = useState<Record<string, any>>({});
+  const [isServerValid, setIsServerValid] = useState(true);
+  const [updateExperiment] = useMutation<
+    updateExperiment,
+    updateExperimentVariables
+  >(UPDATE_EXPERIMENT_MUTATION);
+
+  const onSubmit = useCallback(
+    ({ id }: UseQAExperimentSubset, refetch?: () => Promise<unknown>) =>
+      async (data: Record<string, any>) => {
+        const { qaStatus } = data;
+
+        try {
+          setIsLoading(true);
+          const variables = {
+            input: {
+              id,
+              qaStatus: qaStatus || null,
+              changelogMessage: CHANGELOG_MESSAGES.UPDATED_QA_STATUS,
+            },
+          };
+
+          const result = await updateExperiment({ variables });
+          if (!result.data?.updateExperiment) {
+            throw new Error(SAVE_FAILED_QA_STATUS);
+          }
+
+          const { message } = result.data.updateExperiment;
+
+          if (message && message !== "success" && typeof message === "object") {
+            setIsServerValid(false);
+            setIsLoading(false);
+            setSubmitErrors(message);
+          } else {
+            if (refetch) await refetch();
+            setIsServerValid(true);
+            setSubmitErrors({});
+            setShowEditor(false);
+            setIsLoading(false);
+          }
+        } catch (error) {
+          setIsServerValid(false);
+          setIsLoading(false);
+          setSubmitErrors({ "*": SUBMIT_ERROR });
+        }
+      },
+    [updateExperiment],
+  );
+
+  return {
+    ...params,
+    onSubmit: onSubmit(params, refetch),
+    showEditor,
+    setShowEditor,
+    isLoading,
+    submitErrors,
+    setSubmitErrors,
+    isServerValid,
+  };
+};
+
+export default useQA;

--- a/experimenter/experimenter/nimbus-ui/src/components/Summary/TableQA/useQA.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/Summary/TableQA/useQA.tsx
@@ -71,7 +71,9 @@ export const useQA = (
             setIsLoading(false);
             setSubmitErrors(message);
           } else {
-            if (refetch) await refetch();
+            if (refetch) {
+              await refetch();
+            }
             setIsServerValid(true);
             setSubmitErrors({});
             setShowEditor(false);

--- a/experimenter/experimenter/nimbus-ui/src/components/Summary/TableQA/useQA.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/Summary/TableQA/useQA.tsx
@@ -16,7 +16,6 @@ import {
   updateExperimentVariables,
 } from "src/types/updateExperiment";
 
-// Params are a select subset of experiment properties
 export type UseQAExperimentSubset = Pick<
   getExperiment_experimentBySlug,
   "id" | "qaStatus"

--- a/experimenter/experimenter/nimbus-ui/src/components/Summary/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/Summary/index.tsx
@@ -16,6 +16,8 @@ import RequestLiveUpdate from "src/components/Summary/RequestLiveUpdate";
 import TableAudience from "src/components/Summary/TableAudience";
 import TableBranches from "src/components/Summary/TableBranches";
 import TableOverview from "src/components/Summary/TableOverview";
+import TableQA from "src/components/Summary/TableQA";
+import useQA from "src/components/Summary/TableQA/useQA";
 import TableRiskMitigation from "src/components/Summary/TableRiskMitigation";
 import { useChangeOperationMutation } from "src/hooks";
 import { CHANGELOG_MESSAGES } from "src/lib/constants";
@@ -34,6 +36,7 @@ type SummaryProps = {
 
 const Summary = ({ experiment, refetch }: SummaryProps) => {
   const takeawaysProps = useTakeaways(experiment, refetch);
+  const qaProps = useQA(experiment, refetch);
   const status = getStatus(experiment);
   const shouldDisableUpdateButton =
     !status.dirty || status.review || status.approved || status.waiting;
@@ -173,6 +176,7 @@ const Summary = ({ experiment, refetch }: SummaryProps) => {
 
       {/* Branches title is inside its table */}
       <TableBranches {...{ experiment }} />
+      <TableQA {...qaProps} />
     </div>
   );
 };

--- a/experimenter/experimenter/nimbus-ui/src/lib/constants.ts
+++ b/experimenter/experimenter/nimbus-ui/src/lib/constants.ts
@@ -15,6 +15,8 @@ export const CONTROL_BRANCH_REQUIRED_ERROR = "Control branch is required";
 
 export const SAVE_FAILED_NO_ERROR = "Save failed, no error available";
 
+export const SAVE_FAILED_QA_STATUS = "Failed to save qa status.";
+
 export const CONFIG_EMPTY_ERROR = "Configuration is empty";
 
 export const INVALID_CONFIG_ERROR = "Invalid configuration";
@@ -142,6 +144,7 @@ export const CHANGELOG_MESSAGES = {
   ARCHIVING_EXPERIMENT: "Archiving experiment",
   UNARCHIVING_EXPERIMENT: "Unarchiving experiment",
   UPDATED_TAKEAWAYS: "Updated Takeaways",
+  UPDATED_QA_STATUS: "Updated QA Status",
   CANCEL_REVIEW: "Cancelled Review Request",
 } as const;
 


### PR DESCRIPTION
Because

- We want QA to be able to start tracking the status of experiments on Experimenter

This commit

- Adds a new section on the Summary page
- Adds the QA Status field to that section, with options for `null`, RED, YELLOW, and GREEN 🔴🟡🟢
- Makes the qa status editable - matches the Takeaways section formatting/edit flow

Fixes #9738

----
<img width="1348" alt="Screenshot 2023-11-29 at 3 31 46 PM" src="https://github.com/mozilla/experimenter/assets/43795363/9d7831b2-48af-4ad9-accb-f0b8976036fb">

<img width="1342" alt="Screenshot 2023-11-29 at 3 31 54 PM" src="https://github.com/mozilla/experimenter/assets/43795363/bd9c57d8-daea-4a07-ab75-dffec73b9970">

Takeaways for reference:
<img width="1352" alt="Screenshot 2023-11-29 at 11 46 15 AM" src="https://github.com/mozilla/experimenter/assets/43795363/d7b7a6fc-71ae-4461-8173-e5fca68d0eb4">

https://github.com/mozilla/experimenter/assets/43795363/8f8a72d7-6968-433a-a069-71ff73a9cf5c


