### PR TITLE
chore(nimbus): use gql api in remote settings tests

### DIFF
--- a/experimenter/tests/integration/nimbus/conftest.py
+++ b/experimenter/tests/integration/nimbus/conftest.py
@@ -336,48 +336,6 @@ def trigger_experiment_loader(selenium):
     return _trigger_experiment_loader
 
 
-@pytest.fixture(name="experiment_default_data")
-def fixture_experiment_default_data():
-    return {
-        "hypothesis": "Test Hypothesis",
-        "application": BaseExperimentApplications.FIREFOX_DESKTOP.value,
-        "changelogMessage": "test updates",
-        "targetingConfigSlug": "no_targeting",
-        "publicDescription": "Some sort of Fancy Words",
-        "riskRevenue": False,
-        "riskPartnerRelated": False,
-        "riskBrand": False,
-        "featureConfigIds": [1],
-        "referenceBranch": {
-            "description": "reference branch",
-            "name": "Branch 1",
-            "ratio": 50,
-            "featureValues": [
-                {
-                    "featureConfig": "1",
-                    "value": "{}",
-                },
-            ],
-        },
-        "treatmentBranches": [
-            {
-                "description": "treatment branch",
-                "name": "Branch 2",
-                "ratio": 50,
-                "featureValues": [
-                    {
-                        "featureConfig": "1",
-                        "value": "",
-                    },
-                ],
-            }
-        ],
-        "populationPercent": "100",
-        "totalEnrolledClients": 55,
-        "firefoxMinVersion": "FIREFOX_96",
-    }
-
-
 @pytest.fixture()
 def default_data_api(application):
     feature_config_id = APPLICATION_FEATURE_IDS[application]

--- a/experimenter/tests/integration/nimbus/test_desktop_client_integrations.py
+++ b/experimenter/tests/integration/nimbus/test_desktop_client_integrations.py
@@ -70,35 +70,12 @@ def test_check_telemetry_enrollment_unenrollment(
     check_ping_for_experiment,
     experiment_slug,
     experiment_url,
+    default_data_api,
 ):
-    data = {
-        "hypothesis": "Test Hypothesis",
-        "changelogMessage": "test updates",
-        "publicDescription": "Some sort of Fancy Words",
-        "riskRevenue": False,
-        "riskPartnerRelated": False,
-        "riskBrand": False,
-        "featureConfigIds": [1],
-        "referenceBranch": {
-            "description": "reference branch",
-            "name": "Branch 1",
-            "ratio": 50,
-            "featureValues": [
-                {
-                    "featureConfig": "1",
-                    "value": "{}",
-                },
-            ],
-        },
-        "treatmentBranches": [],
-        "populationPercent": "100",
-        "totalEnrolledClients": 55,
-        "firefoxMinVersion": "FIREFOX_96",
-    }
     helpers.create_experiment(
         experiment_slug,
         BaseExperimentApplications.FIREFOX_DESKTOP.value,
-        data,
+        default_data_api,
     )
     summary = SummaryPage(selenium, experiment_url).open()
     summary.launch_and_approve()
@@ -153,7 +130,7 @@ def test_check_telemetry_enrollment_unenrollment(
 def test_check_telemetry_pref_flip(
     selenium,
     kinto_client,
-    experiment_default_data,
+    default_data_api,
     check_ping_for_experiment,
     telemetry_event_check,
     trigger_experiment_loader,
@@ -162,8 +139,8 @@ def test_check_telemetry_pref_flip(
 ):
     about_config = AboutConfig(selenium)
 
-    experiment_default_data["featureConfigIds"] = [9]
-    experiment_default_data["referenceBranch"] = {
+    default_data_api["featureConfigIds"] = [9]
+    default_data_api["referenceBranch"] = {
         "description": "reference branch",
         "name": "Branch 1",
         "ratio": 100,
@@ -174,11 +151,11 @@ def test_check_telemetry_pref_flip(
             },
         ],
     }
-    experiment_default_data["treatmentBranches"] = []
+    default_data_api["treatmentBranches"] = []
     helpers.create_experiment(
         experiment_slug,
         BaseExperimentApplications.FIREFOX_DESKTOP.value,
-        experiment_default_data,
+        default_data_api,
     )
 
     about_config = about_config.open().wait_for_page_to_load()
@@ -241,7 +218,7 @@ def test_check_telemetry_pref_flip(
 def test_check_telemetry_sticky_targeting(
     selenium,
     kinto_client,
-    experiment_default_data,
+    default_data_api,
     check_ping_for_experiment,
     telemetry_event_check,
     trigger_experiment_loader,
@@ -253,8 +230,8 @@ def test_check_telemetry_sticky_targeting(
 
     requests.delete("http://ping-server:5000/pings")
     targeting_config_slug = "no_targeting"
-    experiment_default_data["targetingConfigSlug"] = targeting_config_slug
-    experiment_default_data["referenceBranch"] = {
+    default_data_api["targetingConfigSlug"] = targeting_config_slug
+    default_data_api["referenceBranch"] = {
         "description": "reference branch",
         "name": "Branch 1",
         "ratio": 100,
@@ -265,12 +242,12 @@ def test_check_telemetry_sticky_targeting(
             },
         ],
     }
-    experiment_default_data["treatmentBranches"] = []
-    experiment_default_data["isSticky"] = True
+    default_data_api["treatmentBranches"] = []
+    default_data_api["isSticky"] = True
     helpers.create_experiment(
         experiment_slug,
         BaseExperimentApplications.FIREFOX_DESKTOP.value,
-        experiment_default_data,
+        default_data_api,
         targeting=targeting_config_slug,
     )
 

--- a/experimenter/tests/integration/nimbus/test_desktop_client_integrations.py
+++ b/experimenter/tests/integration/nimbus/test_desktop_client_integrations.py
@@ -1,5 +1,4 @@
 import time
-from urllib.parse import urljoin
 
 import pytest
 import requests
@@ -65,20 +64,16 @@ def firefox_options(firefox_options):
 @pytest.mark.desktop_enrollment
 @pytest.mark.xdist_group(name="group1")
 def test_check_telemetry_enrollment_unenrollment(
-    base_url,
     selenium,
     kinto_client,
-    slugify,
-    experiment_name,
     telemetry_event_check,
     check_ping_for_experiment,
+    experiment_slug,
+    experiment_url,
 ):
-    targeting = helpers.load_targeting_configs()[0]
-    experiment_slug = str(slugify(experiment_name))
     data = {
         "hypothesis": "Test Hypothesis",
         "changelogMessage": "test updates",
-        "targetingConfigSlug": targeting,
         "publicDescription": "Some sort of Fancy Words",
         "riskRevenue": False,
         "riskPartnerRelated": False,
@@ -103,15 +98,14 @@ def test_check_telemetry_enrollment_unenrollment(
     helpers.create_experiment(
         experiment_slug,
         BaseExperimentApplications.FIREFOX_DESKTOP.value,
-        targeting,
         data,
     )
-    summary = SummaryPage(selenium, urljoin(base_url, experiment_slug)).open()
+    summary = SummaryPage(selenium, experiment_url).open()
     summary.launch_and_approve()
 
     kinto_client.approve()
 
-    summary = SummaryPage(selenium, urljoin(base_url, experiment_slug)).open()
+    summary = SummaryPage(selenium, experiment_url).open()
     summary.wait_for_live_status()
 
     # Ping the server twice as it sleeps sometimes
@@ -137,10 +131,10 @@ def test_check_telemetry_enrollment_unenrollment(
                     break
 
     # unenroll
-    summary = SummaryPage(selenium, urljoin(base_url, experiment_slug)).open()
+    summary = SummaryPage(selenium, experiment_url).open()
     summary.end_and_approve()
     kinto_client.approve()
-    summary = SummaryPage(selenium, urljoin(base_url, experiment_slug)).open()
+    summary = SummaryPage(selenium, experiment_url).open()
     summary.wait_for_complete_status()
 
     requests.get("http://ping-server:5000/pings")
@@ -157,21 +151,17 @@ def test_check_telemetry_enrollment_unenrollment(
 @pytest.mark.desktop_enrollment
 @pytest.mark.xdist_group(name="group2")
 def test_check_telemetry_pref_flip(
-    base_url,
     selenium,
     kinto_client,
-    slugify,
-    experiment_name,
     experiment_default_data,
     check_ping_for_experiment,
     telemetry_event_check,
     trigger_experiment_loader,
+    experiment_slug,
+    experiment_url,
 ):
     about_config = AboutConfig(selenium)
 
-    targeting = helpers.load_targeting_configs()[0]
-    experiment_slug = str(slugify(experiment_name))
-    experiment_default_data["targetingConfigSlug"] = targeting
     experiment_default_data["featureConfigIds"] = [9]
     experiment_default_data["referenceBranch"] = {
         "description": "reference branch",
@@ -188,7 +178,6 @@ def test_check_telemetry_pref_flip(
     helpers.create_experiment(
         experiment_slug,
         BaseExperimentApplications.FIREFOX_DESKTOP.value,
-        targeting,
         experiment_default_data,
     )
 
@@ -197,12 +186,12 @@ def test_check_telemetry_pref_flip(
         "nimbus.qa.pref-1", "default", action=trigger_experiment_loader
     )
 
-    summary = SummaryPage(selenium, urljoin(base_url, experiment_slug)).open()
+    summary = SummaryPage(selenium, experiment_url).open()
     summary.launch_and_approve()
 
     kinto_client.approve()
 
-    summary = SummaryPage(selenium, urljoin(base_url, experiment_slug)).open()
+    summary = SummaryPage(selenium, experiment_url).open()
     summary.wait_for_live_status()
 
     # Ping the server twice as it sleeps sometimes
@@ -225,10 +214,10 @@ def test_check_telemetry_pref_flip(
     )
 
     # unenroll
-    summary = SummaryPage(selenium, urljoin(base_url, experiment_slug)).open()
+    summary = SummaryPage(selenium, experiment_url).open()
     summary.end_and_approve()
     kinto_client.approve()
-    summary = SummaryPage(selenium, urljoin(base_url, experiment_slug)).open()
+    summary = SummaryPage(selenium, experiment_url).open()
     summary.wait_for_complete_status()
 
     requests.get("http://ping-server:5000/pings")
@@ -250,21 +239,19 @@ def test_check_telemetry_pref_flip(
 @pytest.mark.desktop_enrollment
 @pytest.mark.xdist_group(name="group1")
 def test_check_telemetry_sticky_targeting(
-    base_url,
     selenium,
     kinto_client,
-    slugify,
-    experiment_name,
     experiment_default_data,
     check_ping_for_experiment,
     telemetry_event_check,
     trigger_experiment_loader,
+    experiment_slug,
+    experiment_url,
 ):
     about_config = AboutConfig(selenium)
     pref_name = "sticky.targeting.test.pref"
 
     requests.delete("http://ping-server:5000/pings")
-    experiment_slug = str(slugify(experiment_name))
     targeting_config_slug = "no_targeting"
     experiment_default_data["targetingConfigSlug"] = targeting_config_slug
     experiment_default_data["referenceBranch"] = {
@@ -283,16 +270,16 @@ def test_check_telemetry_sticky_targeting(
     helpers.create_experiment(
         experiment_slug,
         BaseExperimentApplications.FIREFOX_DESKTOP.value,
-        targeting_config_slug,
         experiment_default_data,
+        targeting=targeting_config_slug,
     )
 
-    summary = SummaryPage(selenium, urljoin(base_url, experiment_slug)).open()
+    summary = SummaryPage(selenium, experiment_url).open()
     summary.launch_and_approve()
 
     kinto_client.approve()
 
-    summary = SummaryPage(selenium, urljoin(base_url, experiment_slug)).open()
+    summary = SummaryPage(selenium, experiment_url).open()
     summary.wait_for_live_status()
 
     # Ping the server twice as it sleeps sometimes
@@ -328,10 +315,10 @@ def test_check_telemetry_sticky_targeting(
     assert check_ping_for_experiment(experiment_slug), "Experiment not found in telemetry"
 
     # unenroll
-    summary = SummaryPage(selenium, urljoin(base_url, experiment_slug)).open()
+    summary = SummaryPage(selenium, experiment_url).open()
     summary.end_and_approve()
     kinto_client.approve()
-    summary = SummaryPage(selenium, urljoin(base_url, experiment_slug)).open()
+    summary = SummaryPage(selenium, experiment_url).open()
     summary.wait_for_complete_status()
 
     requests.get("http://ping-server:5000/pings")

--- a/experimenter/tests/integration/nimbus/test_desktop_targeting.py
+++ b/experimenter/tests/integration/nimbus/test_desktop_targeting.py
@@ -15,12 +15,10 @@ def targeting_config_slug(request):
 @pytest.mark.run_targeting
 def test_check_advanced_targeting(
     selenium,
-    slugify,
-    experiment_name,
     targeting_config_slug,
+    experiment_slug,
 ):
     targeting = helpers.load_targeting_configs()[1]
-    experiment_slug = str(slugify(experiment_name))
     data = {
         "hypothesis": "Test Hypothesis",
         "application": BaseExperimentApplications.FIREFOX_DESKTOP.value,
@@ -61,8 +59,8 @@ def test_check_advanced_targeting(
     helpers.create_experiment(
         experiment_slug,
         BaseExperimentApplications.FIREFOX_DESKTOP.value,
-        targeting_config_slug,
         data,
+        targeting=targeting_config_slug,
     )
     experiment_data = helpers.load_experiment_data(experiment_slug)
     targeting = experiment_data["data"]["experimentBySlug"]["jexlTargetingExpression"]
@@ -105,18 +103,16 @@ def test_check_advanced_targeting(
 @pytest.mark.run_targeting
 def test_check_audience_targeting(
     selenium,
-    slugify,
-    experiment_name,
     audience_field,
     experiment_default_data,
+    experiment_slug,
 ):
-    experiment_slug = str(slugify(experiment_name))
     experiment_default_data.update(audience_field)
     helpers.create_experiment(
         experiment_slug,
         BaseExperimentApplications.FIREFOX_DESKTOP.value,
-        "no_targeting",
         experiment_default_data,
+        targeting="no_targeting",
     )
     experiment_data = helpers.load_experiment_data(experiment_slug)
     targeting = experiment_data["data"]["experimentBySlug"]["jexlTargetingExpression"]

--- a/experimenter/tests/integration/nimbus/test_desktop_targeting.py
+++ b/experimenter/tests/integration/nimbus/test_desktop_targeting.py
@@ -17,49 +17,12 @@ def test_check_advanced_targeting(
     selenium,
     targeting_config_slug,
     experiment_slug,
+    default_data_api,
 ):
-    targeting = helpers.load_targeting_configs()[1]
-    data = {
-        "hypothesis": "Test Hypothesis",
-        "application": BaseExperimentApplications.FIREFOX_DESKTOP.value,
-        "changelogMessage": "test updates",
-        "targetingConfigSlug": targeting,
-        "publicDescription": "Some sort of Fancy Words",
-        "riskRevenue": False,
-        "riskPartnerRelated": False,
-        "riskBrand": False,
-        "featureConfigIds": [1],
-        "referenceBranch": {
-            "description": "reference branch",
-            "name": "Branch 1",
-            "ratio": 50,
-            "featureValues": [
-                {
-                    "featureConfig": "1",
-                    "value": "{}",
-                },
-            ],
-        },
-        "treatmentBranches": [
-            {
-                "description": "treatment branch",
-                "name": "Branch 2",
-                "ratio": 50,
-                "featureValues": [
-                    {
-                        "featureConfig": "1",
-                        "value": "{}",
-                    },
-                ],
-            }
-        ],
-        "populationPercent": "100",
-        "totalEnrolledClients": 55,
-    }
     helpers.create_experiment(
         experiment_slug,
         BaseExperimentApplications.FIREFOX_DESKTOP.value,
-        data,
+        default_data_api,
         targeting=targeting_config_slug,
     )
     experiment_data = helpers.load_experiment_data(experiment_slug)
@@ -104,14 +67,14 @@ def test_check_advanced_targeting(
 def test_check_audience_targeting(
     selenium,
     audience_field,
-    experiment_default_data,
     experiment_slug,
+    default_data_api,
 ):
-    experiment_default_data.update(audience_field)
+    default_data_api.update(audience_field)
     helpers.create_experiment(
         experiment_slug,
         BaseExperimentApplications.FIREFOX_DESKTOP.value,
-        experiment_default_data,
+        default_data_api,
         targeting="no_targeting",
     )
     experiment_data = helpers.load_experiment_data(experiment_slug)

--- a/experimenter/tests/integration/nimbus/test_experimenter_ui.py
+++ b/experimenter/tests/integration/nimbus/test_experimenter_ui.py
@@ -1,5 +1,4 @@
 import os
-from urllib.parse import urljoin
 
 import pytest
 
@@ -111,17 +110,16 @@ def test_every_form_page_can_be_resaved(
 
 @pytest.mark.nimbus_ui
 def test_first_run_release_date_visible_for_mobile(
-    base_url,
     selenium,
     kinto_client,
     application,
     create_experiment,
+    experiment_url,
 ):
     if application not in MOBILE_APPS:
         pytest.skip(f"Skipping for {application}")
 
     summary = create_experiment(selenium)
-    experiment_slug = summary.experiment_slug
 
     audience = summary.navigate_to_audience()
     audience.make_first_run()
@@ -132,7 +130,7 @@ def test_first_run_release_date_visible_for_mobile(
 
     audience.save_and_continue()
 
-    summary = SummaryPage(selenium, urljoin(base_url, experiment_slug)).open()
+    summary = SummaryPage(selenium, experiment_url).open()
 
     assert summary.proposed_release_date == "2023-12-12"
 
@@ -140,7 +138,7 @@ def test_first_run_release_date_visible_for_mobile(
 
     kinto_client.approve()
 
-    summary = SummaryPage(selenium, urljoin(base_url, experiment_slug)).open()
+    summary = SummaryPage(selenium, experiment_url).open()
     summary.wait_for_live_status()
 
     assert summary.first_run
@@ -149,17 +147,16 @@ def test_first_run_release_date_visible_for_mobile(
 
 @pytest.mark.nimbus_ui
 def test_first_run_release_date_not_visible_for_non_mobile(
-    base_url,
     selenium,
     kinto_client,
     application,
     create_experiment,
+    experiment_url,
 ):
     if application in MOBILE_APPS:
         pytest.skip(f"Skipping for {application}")
 
     summary = create_experiment(selenium)
-    experiment_slug = summary.experiment_slug
 
     audience = summary.navigate_to_audience()
 
@@ -171,7 +168,7 @@ def test_first_run_release_date_not_visible_for_non_mobile(
 
     kinto_client.approve()
 
-    summary = SummaryPage(selenium, urljoin(base_url, experiment_slug)).open()
+    summary = SummaryPage(selenium, experiment_url).open()
     summary.wait_for_live_status()
 
     summary.wait_for_timeline_visible()

--- a/experimenter/tests/integration/nimbus/test_mobile_targeting.py
+++ b/experimenter/tests/integration/nimbus/test_mobile_targeting.py
@@ -63,9 +63,8 @@ def test_check_mobile_targeting(
     sdk_client,
     load_app_context,
     context,
-    slugify,
-    experiment_name,
     targeting,
+    experiment_slug,
 ):
     # The context fixtures can only contain strings or null
     context["language"] = context["language"][:2]  # strip region
@@ -86,7 +85,6 @@ def test_check_mobile_targeting(
         additional_context=custom_targeting_attributes
     )
 
-    experiment_slug = str(slugify(experiment_name))
     helpers.create_basic_experiment(
         experiment_slug,
         BaseExperimentApplications.FIREFOX_FENIX.value,

--- a/experimenter/tests/integration/nimbus/test_remote_settings.py
+++ b/experimenter/tests/integration/nimbus/test_remote_settings.py
@@ -1,57 +1,71 @@
-from urllib.parse import urljoin
-
 import pytest
 
 from nimbus.pages.experimenter.home import HomePage
 from nimbus.pages.experimenter.summary import SummaryPage
+from nimbus.utils import helpers
 
 
 @pytest.mark.remote_settings
 def test_create_new_experiment_approve_remote_settings(
     selenium,
     experiment_url,
-    create_experiment,
     kinto_client,
     base_url,
-    experiment_name,
+    application,
+    default_data_api,
+    experiment_slug,
 ):
-    create_experiment(selenium, is_rollout=False).launch_and_approve()
+    helpers.create_experiment(experiment_slug, application, default_data_api)
+
+    summary = SummaryPage(selenium, experiment_url).open()
+    summary.launch_and_approve()
 
     kinto_client.approve()
 
     SummaryPage(selenium, experiment_url).open().wait_for_live_status()
 
     home = HomePage(selenium, base_url).open()
-    assert True in [experiment_name in item.text for item in home.tables[0].experiments]
+    assert experiment_slug in [item.text for item in home.tables[0].experiments]
 
 
 @pytest.mark.remote_settings
 def test_create_new_rollout_approve_remote_settings(
     selenium,
     experiment_url,
-    create_experiment,
     kinto_client,
     base_url,
-    experiment_name,
+    application,
+    default_data_api,
+    experiment_slug,
 ):
-    create_experiment(selenium, is_rollout=True).launch_and_approve()
+    helpers.create_experiment(
+        experiment_slug, application, default_data_api, is_rollout=True
+    )
+
+    summary = SummaryPage(selenium, experiment_url).open()
+    summary.launch_and_approve()
 
     kinto_client.approve()
 
     SummaryPage(selenium, experiment_url).open().wait_for_live_status()
 
     home = HomePage(selenium, base_url).open()
-    assert True in [experiment_name in item.text for item in home.tables[0].experiments]
+    assert experiment_slug in [item.text for item in home.tables[0].experiments]
 
 
 @pytest.mark.remote_settings
 def test_create_new_experiment_reject_remote_settings(
     selenium,
     experiment_url,
-    create_experiment,
     kinto_client,
+    application,
+    default_data_api,
+    experiment_slug,
 ):
-    create_experiment(selenium).launch_and_approve()
+    helpers.create_experiment(experiment_slug, application, default_data_api)
+
+    summary = SummaryPage(selenium, experiment_url).open()
+    summary.launch_and_approve()
 
     kinto_client.reject()
 
@@ -62,10 +76,17 @@ def test_create_new_experiment_reject_remote_settings(
 def test_create_new_rollout_reject_remote_settings(
     selenium,
     experiment_url,
-    create_experiment,
     kinto_client,
+    application,
+    default_data_api,
+    experiment_slug,
 ):
-    create_experiment(selenium, is_rollout=True).launch_and_approve()
+    helpers.create_experiment(
+        experiment_slug, application, default_data_api, is_rollout=True
+    )
+
+    summary = SummaryPage(selenium, experiment_url).open()
+    summary.launch_and_approve()
 
     kinto_client.reject()
 
@@ -76,10 +97,15 @@ def test_create_new_rollout_reject_remote_settings(
 def test_end_experiment_and_approve_end_set_takeaways(
     selenium,
     experiment_url,
-    create_experiment,
     kinto_client,
+    application,
+    default_data_api,
+    experiment_slug,
 ):
-    create_experiment(selenium).launch_and_approve()
+    helpers.create_experiment(experiment_slug, application, default_data_api)
+
+    summary = SummaryPage(selenium, experiment_url).open()
+    summary.launch_and_approve()
 
     kinto_client.approve()
 
@@ -103,10 +129,17 @@ def test_end_experiment_and_approve_end_set_takeaways(
 def test_end_rollout_and_approve_end_set_takeaways(
     selenium,
     experiment_url,
-    create_experiment,
     kinto_client,
+    application,
+    default_data_api,
+    experiment_slug,
 ):
-    create_experiment(selenium, is_rollout=True).launch_and_approve()
+    helpers.create_experiment(
+        experiment_slug, application, default_data_api, is_rollout=True
+    )
+
+    summary = SummaryPage(selenium, experiment_url).open()
+    summary.launch_and_approve()
 
     kinto_client.approve()
 
@@ -130,10 +163,15 @@ def test_end_rollout_and_approve_end_set_takeaways(
 def test_end_experiment_and_reject_end(
     selenium,
     experiment_url,
-    create_experiment,
     kinto_client,
+    application,
+    default_data_api,
+    experiment_slug,
 ):
-    create_experiment(selenium).launch_and_approve()
+    helpers.create_experiment(experiment_slug, application, default_data_api)
+
+    summary = SummaryPage(selenium, experiment_url).open()
+    summary.launch_and_approve()
 
     kinto_client.approve()
 
@@ -150,10 +188,17 @@ def test_end_experiment_and_reject_end(
 def test_end_rollout_and_reject_end(
     selenium,
     experiment_url,
-    create_experiment,
     kinto_client,
+    application,
+    default_data_api,
+    experiment_slug,
 ):
-    create_experiment(selenium, is_rollout=True).launch_and_approve()
+    helpers.create_experiment(
+        experiment_slug, application, default_data_api, is_rollout=True
+    )
+
+    summary = SummaryPage(selenium, experiment_url).open()
+    summary.launch_and_approve()
 
     kinto_client.approve()
 
@@ -169,17 +214,21 @@ def test_end_rollout_and_reject_end(
 @pytest.mark.remote_settings
 def test_rollout_live_update_approve(
     selenium,
-    base_url,
-    create_experiment,
     kinto_client,
-    experiment_name,
-    slugify,
+    application,
+    default_data_api,
+    experiment_slug,
+    experiment_url,
 ):
-    experiment_slug = str(slugify(experiment_name))
-    create_experiment(selenium, is_rollout=True).launch_and_approve()
+    helpers.create_experiment(
+        experiment_slug, application, default_data_api, is_rollout=True
+    )
+
+    summary = SummaryPage(selenium, experiment_url).open()
+    summary.launch_and_approve()
 
     kinto_client.approve()
-    summary = SummaryPage(selenium, urljoin(base_url, experiment_slug)).open()
+    summary = SummaryPage(selenium, experiment_url).open()
 
     summary.wait_for_live_status()
     audience = summary.navigate_to_audience()
@@ -187,7 +236,7 @@ def test_rollout_live_update_approve(
     audience.percentage = "60"
     audience.save_and_continue()
 
-    summary_page = SummaryPage(selenium, urljoin(base_url, experiment_slug)).open()
+    summary_page = SummaryPage(selenium, experiment_url).open()
     summary_page.wait_for_update_request_visible()
 
     summary_page.request_update_and_approve()
@@ -197,17 +246,21 @@ def test_rollout_live_update_approve(
 @pytest.mark.remote_settings
 def test_rollout_live_update_approve_and_reject(
     selenium,
-    base_url,
-    create_experiment,
     kinto_client,
-    experiment_name,
-    slugify,
+    application,
+    default_data_api,
+    experiment_slug,
+    experiment_url,
 ):
-    experiment_slug = str(slugify(experiment_name))
-    create_experiment(selenium, is_rollout=True).launch_and_approve()
+    helpers.create_experiment(
+        experiment_slug, application, default_data_api, is_rollout=True
+    )
+
+    summary = SummaryPage(selenium, experiment_url).open()
+    summary.launch_and_approve()
 
     kinto_client.approve()
-    summary = SummaryPage(selenium, urljoin(base_url, experiment_slug)).open()
+    summary = SummaryPage(selenium, experiment_url).open()
 
     summary.wait_for_live_status()
     audience = summary.navigate_to_audience()
@@ -215,7 +268,7 @@ def test_rollout_live_update_approve_and_reject(
     audience.percentage = "60"
     audience.save_and_continue()
 
-    summary_page = SummaryPage(selenium, urljoin(base_url, experiment_slug)).open()
+    summary_page = SummaryPage(selenium, experiment_url).open()
     summary_page.wait_for_update_request_visible()
 
     summary_page.request_update_and_approve()
@@ -227,17 +280,21 @@ def test_rollout_live_update_approve_and_reject(
 @pytest.mark.remote_settings
 def test_rollout_live_update_reject_on_experimenter(
     selenium,
-    base_url,
-    create_experiment,
     kinto_client,
-    experiment_name,
-    slugify,
+    application,
+    default_data_api,
+    experiment_slug,
+    experiment_url,
 ):
-    experiment_slug = str(slugify(experiment_name))
-    create_experiment(selenium, is_rollout=True).launch_and_approve()
+    helpers.create_experiment(
+        experiment_slug, application, default_data_api, is_rollout=True
+    )
+
+    summary = SummaryPage(selenium, experiment_url).open()
+    summary.launch_and_approve()
 
     kinto_client.approve()
-    summary = SummaryPage(selenium, urljoin(base_url, experiment_slug)).open()
+    summary = SummaryPage(selenium, experiment_url).open()
 
     summary.wait_for_live_status()
     audience = summary.navigate_to_audience()
@@ -245,7 +302,7 @@ def test_rollout_live_update_reject_on_experimenter(
     audience.percentage = "60"
     audience.save_and_continue()
 
-    summary_page = SummaryPage(selenium, urljoin(base_url, experiment_slug)).open()
+    summary_page = SummaryPage(selenium, experiment_url).open()
     summary_page.wait_for_update_request_visible()
 
     summary_page.request_update_and_reject()
@@ -259,8 +316,13 @@ def test_rollout_live_update_reject_on_experimenter(
 @pytest.mark.remote_settings
 def test_create_new_experiment_timeout_remote_settings(
     selenium,
-    create_experiment,
+    application,
+    default_data_api,
+    experiment_slug,
+    experiment_url,
 ):
-    summary = create_experiment(selenium)
+    helpers.create_experiment(experiment_slug, application, default_data_api)
+
+    summary = SummaryPage(selenium, experiment_url).open()
     summary.launch_and_approve()
     summary.wait_for_timeout_alert()


### PR DESCRIPTION
Because

* We should test the Nimbus UI somewhere in the integration tests
* Using the forms to create experiments is time consuming
* We use the Nimbus UI forms in the Experimenter UI integration tests
* We don't also need to test them in the Remote Settings tests
* The Remote Settings tests are already slow and so we can speed them up by using the V5 GQL API to create experiments in those tests

This commit

* Changes the Remote Settings tests to use the GQL API to create experiments
* Refactors the GQL API client in the integration tests to use the same set of default data as the UI creation data to be more reusable in the future

fixes #9841 