### PR TITLE
Fixes #9874 feat(nimbus): Update to latest App Services version

### DIFF
--- a/cirrus/server/Dockerfile
+++ b/cirrus/server/Dockerfile
@@ -15,7 +15,7 @@ WORKDIR /application-services
 
 # Checkout application services at a locked commit
 RUN git clone https://github.com/mozilla/application-services.git .
-RUN git fetch && git checkout e8d45a3554d2fbf05631ae7f801ad9d840c69819
+RUN git fetch && git checkout 8ded4cb602aed89fd22c0dd7fdbfc6fa063c5ef1
 
 RUN git submodule init
 RUN git submodule update --recursive

--- a/experimenter/Dockerfile
+++ b/experimenter/Dockerfile
@@ -82,7 +82,7 @@ WORKDIR /application-services
 # Rust packages
 # Checkout application services at a locked commit
 RUN git clone https://github.com/mozilla/application-services.git .
-RUN git fetch && git checkout e8d45a3554d2fbf05631ae7f801ad9d840c69819
+RUN git fetch && git checkout 8ded4cb602aed89fd22c0dd7fdbfc6fa063c5ef1
 
 RUN git submodule init
 RUN git submodule update --recursive


### PR DESCRIPTION
Because

- We want to get the latest version of AS

This commit

- Updates our AS version for `experimenter` and `cirrus`

Fixes #9874