### PR TITLE
docs(cirrus): Link api docs

### DIFF
--- a/cirrus/README.md
+++ b/cirrus/README.md
@@ -81,6 +81,10 @@ The following are the available commands for working with Cirrus:
 
 # Cirrus Server to get Feature configuration API structure
 
+## Api Doc
+
+[Cirrus Api Doc](/cirrus/server/cirrus/docs/apidoc.html) for the Cirrus API
+
 ## Endpoint
 
 `POST /v1/features/`


### PR DESCRIPTION
Because

- We have static cirrus api docs

This commit

- Links api docs to Cirrus readme

Fixes #9876 