### PR TITLE
chore(Cirrus): pin rust version in cirrus dockerfile

### DIFF
--- a/cirrus/server/Dockerfile
+++ b/cirrus/server/Dockerfile
@@ -1,5 +1,5 @@
 # First stage: Build the Rust components
-FROM rust:buster AS rust-builder
+FROM rust:1.74.0-buster AS rust-builder
 
 RUN update-ca-certificates
 


### PR DESCRIPTION
Because

* We inherit from a rust base image in the Cirrus docker image
* We did not specify a pinned version
* This can cause updates to the base image to break our build without any code changes

This commit

* Pins the rust base image to 1.74.0

fixes #9893

