### PR TITLE
For #9857 feat(nimbus): Refactoring NimbusFmlLoader

### DIFF
--- a/experimenter/experimenter/features/manifests/nimbus_fml_loader.py
+++ b/experimenter/experimenter/features/manifests/nimbus_fml_loader.py
@@ -1,10 +1,12 @@
 import logging
 from functools import lru_cache
 from pathlib import Path
+from typing import Optional
 
 from rust_fml import FmlClient, FmlFeatureInspector
 
 from experimenter.experiments.constants import NimbusConstants
+from experimenter.experiments.models import NimbusFeatureVersion
 from experimenter.settings import BASE_DIR
 
 logger = logging.getLogger()
@@ -22,14 +24,25 @@ class NimbusFmlLoader:
     @classmethod
     @lru_cache
     def create_loader(cls, application: str, channel: str):
+        """Application and channel should stay the same for each iteration of the 
+        FML loader.
+        """
         return cls(application, channel)
 
-    def file_path(self):
+    def file_path(self, version: NimbusFeatureVersion = None):
         """Get path to release feature manifest from experimenter (local)."""
+
         if self.application is not None:
-            path = Path(self.MANIFEST_PATH, self.application, f"{self.channel}.fml.yaml")
+            path = Path(self.MANIFEST_PATH, self.application)
+            if version:
+                path /= f"v{version}"
+            path /= f"{self.channel}.fml.yaml"
+
             if Path.exists(path):
                 return path
+            else:
+                logger.error(f"Nimbus FML Loader: Invalid manifest path: {path}")
+                return None
         else:
             logger.error(
                 "Nimbus FML Loader: Invalid application. Failed to get local "
@@ -37,60 +50,49 @@ class NimbusFmlLoader:
             )
         return None
 
-    # Todo: Add versioning https://mozilla-hub.atlassian.net/browse/EXP-3875
-    def _get_fml_clients(self) -> list[FmlClient]:
-        clients = []
-        if file_path := self.file_path():
-            client = self.fml_client(str(file_path), self.channel)
-            if client is not None:
-                clients.append(client)
-            else:
-                logger.error(
-                    "Nimbus FML Loader: "
-                    f"Failed to create FML clients for file path {file_path} and "
-                    f"channel {self.channel}."
-                )
-        return clients
+    @lru_cache  # noqa: B019
+    def fml_client(self, version: Optional[NimbusFeatureVersion] = None) -> FmlClient:
+        """There is a single FmlClient for each combination of application, app version,
+        and channel.
+        """
+        return FmlClient(
+            str(self.file_path(version)),
+            self.channel,
+        )
 
     @lru_cache  # noqa: B019
-    def fml_client(self, path: str, channel: str) -> FmlClient:
-        return FmlClient(path, channel)
-
-    def _get_inspectors(
-        self, clients: list[FmlClient], feature_id: str
-    ) -> list[FmlFeatureInspector]:
-        return [
-            inspector
-            for inspector in (
-                client.get_feature_inspector(feature_id) for client in clients
-            )
-            if inspector is not None
-        ]
+    def feature_inspector(
+        self, client: FmlClient, feature_id: str
+    ) -> FmlFeatureInspector:
+        """There is a single FmlFeatureInspector for each feature."""
+        return client.get_feature_inspector(feature_id)
 
     @staticmethod
     def _get_errors(inspector: FmlFeatureInspector, blob: str):
+        """There can be None or more errors returned from a single feature inspector."""
         return inspector.get_errors(blob)
 
-    # Todo: Add versioning https://mozilla-hub.atlassian.net/browse/EXP-3875
-    def get_fml_errors(self, blob: str, feature_id: str):
+    def get_fml_errors(
+        self,
+        blob: str,
+        feature_id: str,
+        version: Optional[NimbusFeatureVersion] = None,
+    ):
         """Fetch errors from the FML. This method creates FML clients, which are
-        used by `FmlFeatureInspector`s to fetch errors based on the blob of text and
-        the given feature.
+        used by `FmlFeatureInspector`s to fetch FML errors based on a blob of text and
+        the given feature id.
 
         Returns:
             A list of feature manifest errors.
         """
         if self.application is not None:
             errors = []
-            if clients := self._get_fml_clients():
-                if inspectors := self._get_inspectors(clients, feature_id):
-                    if inspectors != []:
-                        for inspector in inspectors:
-                            if error := self._get_errors(inspector, blob):
-                                errors.extend(error)
-            return errors
-        else:
-            logger.error(
-                "Nimbus FML Loader: Invalid application. Failed to fetch FML errors."
-            )
-            return []
+            if client := self.fml_client(version):
+                if inspector := self.feature_inspector(client, feature_id):
+                    if errs := self._get_errors(inspector, blob):
+                        errors.extend(errs)
+                return errors
+        logger.error(
+            "Nimbus FML Loader: Invalid application. Failed to fetch FML errors."
+        )
+        return []

--- a/experimenter/experimenter/features/tests/test_nimbus_fml_loader.py
+++ b/experimenter/experimenter/features/tests/test_nimbus_fml_loader.py
@@ -10,13 +10,17 @@ from experimenter.settings import BASE_DIR
 
 
 class TestNimbusFmlLoader(TestCase):
-    TEST_MANIFEST_PATH = Path(
-        BASE_DIR, "features", "tests", "fixtures", "fml", "fenix", "release.fml.yaml"
+    MANIFEST_PATH_NO_VERSION = Path(
+        BASE_DIR, "features", "manifests", "fenix", "release.fml.yaml"
+    )
+    MANIFEST_PATH_WITH_VERSION = Path(
+        BASE_DIR, "features", "manifests", "fenix", "v119.0.0", "nightly.fml.yaml"
     )
 
     def setUp(self):
         NimbusFmlLoader.create_loader.cache_clear()
         NimbusFmlLoader.fml_client.cache_clear()
+        NimbusFmlLoader.feature_inspector.cache_clear()
 
     def create_loader(
         self,
@@ -37,61 +41,14 @@ class TestNimbusFmlLoader(TestCase):
         self.assertEqual(loader.application, application)
         self.assertEqual(loader.channel, channel)
 
-    def test_intiate_new_fml_loader_local_fml_files_do_not_exist_for_app(self):
+    def test_intiate_new_fml_loader_app_and_channel_do_not_exist(self):
         application = "badapp"
-        channel = "release"
+        channel = "releaseit"
 
         loader = NimbusFmlLoader(application, channel)
 
-        self.assertEqual(loader.application, None)
-        self.assertEqual(loader.channel, channel)
-
-    def test_get_fml_clients(self):
-        loader = self.create_loader()
-
-        with patch(
-            "experimenter.features.manifests.nimbus_fml_loader.NimbusFmlLoader.fml_client",
-        ) as create:
-            result = loader._get_fml_clients()
-            self.assertEqual(len(result), 1)
-            create.assert_called()
-
-    @patch(
-        "experimenter.features.manifests.nimbus_fml_loader.NimbusFmlLoader.fml_client",
-    )
-    @patch(
-        "experimenter.features.manifests.nimbus_fml_loader.NimbusFmlLoader.file_path",
-    )
-    def test_get_fml_client_no_versions(self, mock_file_path, mock_create_client):
-        path = str(self.TEST_MANIFEST_PATH)
-        mock_file_path.return_value = path
-        mock_create_client.return_value = MagicMock(spec=FmlClient)
-        expected_channel = "release"
-        loader = self.create_loader()
-
-        result = loader._get_fml_clients()
-        self.assertEqual(len(result), 1)
-        mock_create_client.assert_called()
-        mock_file_path.assert_called()
-        mock_create_client.assert_called_with(path, expected_channel)
-
-    @patch(
-        "experimenter.features.manifests.nimbus_fml_loader.NimbusFmlLoader.fml_client",
-    )
-    def test_fetch_clients_returns_none(
-        self,
-        mock_create_client,
-    ):
-        mock_create_client.return_value = None
-        loader = self.create_loader()
-        with self.assertLogs(level="ERROR") as log:
-            result = loader._get_fml_clients()
-            self.assertEqual(result, [])
-            mock_create_client.assert_called()
-            self.assertIn(
-                "Nimbus FML Loader: Failed to create FML clients for file path",
-                log.output[0],
-            )
+        self.assertIsNone(loader.application)
+        self.assertIsNone(loader.channel)
 
     @patch(
         "rust_fml.FmlClient.__init__",
@@ -99,40 +56,28 @@ class TestNimbusFmlLoader(TestCase):
     def test_create_fml_client(self, new_client):
         new_client.return_value = None
         application = "fenix"
-        path = str(self.TEST_MANIFEST_PATH)
         channel = "release"
         loader = self.create_loader(application, channel)
+        expected_path = self.MANIFEST_PATH_NO_VERSION
 
-        loader.fml_client(path, channel)
+        client = loader.fml_client()
+        self.assertIsNotNone(client)
         new_client.assert_called()
-        new_client.assert_called_with(path, channel)
+        new_client.assert_called_with(str(expected_path), channel)
 
-    def test_get_local_file_path(self):
-        expected_path = Path(
-            "/experimenter",
-            "experimenter",
-            "features",
-            "manifests",
-            "fenix",
-            "release.fml.yaml",
-        )
-
+    def test_get_local_file_path_no_version(self):
         loader = self.create_loader()
         file_path = loader.file_path()
-        self.assertEqual(file_path, expected_path)
+        self.assertEqual(file_path, self.MANIFEST_PATH_NO_VERSION)
 
-    def test_get_local_file_path_for_nightly(self):
-        expected_path = Path(
-            "/experimenter/experimenter/features/manifests/fenix/nightly.fml.yaml"
-        )
-
+    def test_get_local_file_path_for_nightly_with_version(self):
         loader = self.create_loader(channel="nightly")
-        file_path = loader.file_path()
-        self.assertEqual(file_path, expected_path)
+        file_path = loader.file_path(version="119.0.0")
+        self.assertEqual(file_path, self.MANIFEST_PATH_WITH_VERSION)
 
     def test_get_local_file_path_for_invalid_channel(self):
         loader = self.create_loader(channel="rats")
-        file_path = loader.file_path()
+        file_path = loader.file_path(version="119.0.0")
         self.assertIsNone(file_path)
 
     @patch(
@@ -153,57 +98,54 @@ class TestNimbusFmlLoader(TestCase):
             self.assertIsNone(file_path)
             self.assertIn("Nimbus FML Loader: Invalid application", log.output[0])
 
+    def test_local_fml_files_do_not_exist_for_version(self):
+        application = "fenix"
+        channel = "release"
+        version = "119.9.9"
+        with self.assertLogs(level="ERROR") as log:
+            loader = NimbusFmlLoader(application, channel)
+            file_path = loader.file_path(version=version)
+            self.assertIsNone(file_path)
+            self.assertIn("Nimbus FML Loader: Invalid manifest path", log.output[0])
+
     def test_create_client(self):
         loader = self.create_loader()
-        path = loader.file_path()
-        result = loader.fml_client(str(path), "release")
+        result = loader.fml_client()
         self.assertIsInstance(result, FmlClient)
 
     @patch(
         "rust_fml.FmlClient.get_feature_inspector",
     )
-    def test_get_inspectors_from_client(self, mock_get_inspector):
+    def test_get_feature_inspector_from_client(self, mock_get_inspector):
         loader = self.create_loader()
-        path = loader.file_path()
-        client = loader.fml_client(str(path), "release")
-        result = loader._get_inspectors([client], "some_id")
+        client = loader.fml_client()
+
+        result = loader.feature_inspector(client, "some_id")
+
         mock_get_inspector.assert_called_once_with("some_id")
         self.assertIsNotNone(result)
-
-    @patch(
-        "rust_fml.FmlClient.get_feature_inspector",
-    )
-    def test_get_inspectors_with_no_clients(self, mock_get_inspector):
-        loader = self.create_loader()
-        result = loader._get_inspectors([], "some_id")
-        mock_get_inspector.assert_not_called()
-        self.assertEqual(result, [])
 
     @patch(
         "rust_fml.FmlFeatureInspector.get_errors",
     )
     def test_get_errors_from_fml_inspector(self, mock_get_errors):
         loader = self.create_loader()
+        client = loader.fml_client()
         test_blob = str(json.dumps({"new-feature": "false"}))
-        path = loader.file_path()
-        client = loader.fml_client(str(path), "release")
-        inspectors = loader._get_inspectors([client], "nimbus-validation")
 
-        result = loader._get_errors(inspectors[0], test_blob)
+        inspector = loader.feature_inspector(client, "nimbus-validation")
+        result = loader._get_errors(inspector, test_blob)
         mock_get_errors.assert_called_once_with(test_blob)
         self.assertIsNotNone(result)
 
     @patch(
-        "experimenter.features.manifests.nimbus_fml_loader.NimbusFmlLoader._get_fml_clients",
-    )
-    @patch(
-        "experimenter.features.manifests.nimbus_fml_loader.NimbusFmlLoader._get_inspectors",
+        "experimenter.features.manifests.nimbus_fml_loader.NimbusFmlLoader.feature_inspector",
     )
     @patch(
         "experimenter.features.manifests.nimbus_fml_loader.NimbusFmlLoader._get_errors",
     )
     def test_get_fml_errors_fetches_client_inspector_and_error(
-        self, mock_get_errors, mock_get_inspectors, mock_get_clients
+        self, mock_get_errors, mock_feature_inspector
     ):
         fml_errors = [
             {
@@ -220,34 +162,59 @@ class TestNimbusFmlLoader(TestCase):
             },
         ]
         mock_get_errors.return_value = fml_errors
-        mock_get_clients.return_value = fml_errors
-        mock_get_inspectors.return_value = [MagicMock()]
+        mock_feature_inspector.return_value = MagicMock()
         loader = self.create_loader()
         test_blob = json.dumps({"features": {"new-feature": {"enabled": "false"}}})
 
         result = loader.get_fml_errors(test_blob, "my_feature_id")
 
-        mock_get_clients.assert_called()
-        mock_get_inspectors.assert_called()
+        mock_feature_inspector.assert_called()
         mock_get_errors.assert_called()
-
         self.assertIn(fml_errors[0]["message"], result[0]["message"])
         self.assertIn(fml_errors[1]["message"], result[1]["message"])
 
     @patch(
-        "experimenter.features.manifests.nimbus_fml_loader.NimbusFmlLoader._get_fml_clients",
+        "experimenter.features.manifests.nimbus_fml_loader.NimbusFmlLoader.feature_inspector",
     )
     @patch(
-        "experimenter.features.manifests.nimbus_fml_loader.NimbusFmlLoader._get_inspectors",
+        "experimenter.features.manifests.nimbus_fml_loader.NimbusFmlLoader._get_errors",
+    )
+    def test_get_fml_errors_with_no_inspector(
+        self, mock_get_errors, mock_feature_inspector
+    ):
+        fml_errors = [
+            {
+                "line": 2,
+                "col": 0,
+                "message": "Incorrect value",
+                "highlight": "enabled",
+            },
+            {
+                "line": 3,
+                "col": 1,
+                "message": "Incorrect value again",
+                "highlight": "disabled",
+            },
+        ]
+        mock_get_errors.return_value = fml_errors
+        mock_feature_inspector.return_value = None
+        loader = self.create_loader()
+        test_blob = json.dumps({"features": {"new-feature": {"enabled": "false"}}})
+
+        result = loader.get_fml_errors(test_blob, "my_feature_id")
+
+        mock_feature_inspector.assert_called()
+        mock_get_errors.assert_not_called()
+        self.assertEqual(result, [])
+
+    @patch(
+        "experimenter.features.manifests.nimbus_fml_loader.NimbusFmlLoader.feature_inspector",
     )
     def test_return_empty_list_for_no_fml_errors(
         self,
-        mock_get_inspectors,
-        mock_get_clients,
+        mock_feature_inspector,
     ):
-        mock = MagicMock()
-        mock_get_inspectors.return_value = [mock]
-        mock_get_clients.return_value = [mock]
+        mock_feature_inspector.return_value = MagicMock()
         loader = self.create_loader()
         test_blob = json.dumps({"features": {"new-feature": {"enabled": "false"}}})
         with patch(
@@ -256,23 +223,9 @@ class TestNimbusFmlLoader(TestCase):
             mock_get_errors.return_value = None
             result = loader.get_fml_errors(test_blob, "my_feature_id")
 
-            mock_get_clients.assert_called()
-            mock_get_inspectors.assert_called()
+            mock_feature_inspector.assert_called()
             mock_get_errors.assert_called()
             self.assertEqual(result, [])
-
-    @patch(
-        "experimenter.features.manifests.nimbus_fml_loader.NimbusFmlLoader._get_fml_clients",
-    )
-    def test_return_empty_list_for_no_fml_clients(
-        self,
-        mock_get_clients,
-    ):
-        mock_get_clients.return_value = None
-        loader = self.create_loader()
-        test_blob = json.dumps({"features": {"new-feature": {"enabled": "false"}}})
-        result = loader.get_fml_errors(test_blob, "my_feature_id")
-        self.assertEqual(result, [])
 
     def test_return_no_errors_for_invalid_application(
         self,


### PR DESCRIPTION
**Waiting on #9896 to land first**

According to [The Big O of Code Reviews](https://www.egorand.dev/the-big-o-of-code-reviews/), this is a O(_1_) change.

Because

- #9896 adds versioning to the `NimbusFmlLoader`

This commit

- Refactors the `NimbusFmlLoader` and adds some docstrings

**This commit does not**

- Do anything with serialization (see PR #TBD)
- Make any logic changes to the `NimbusFmlLoader` (see PR #9896)

For #9857

