### PR TITLE
chore(project): add a flag to disable/enable cirrus

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -372,6 +372,7 @@ jobs:
           name: Run integration tests
           command: |
             cp .env.integration-tests .env
+            export CIRRUS=1
             make refresh SKIP_DUMMY=1 PYTEST_SENTRY_DSN=$PYTEST_SENTRY_DSN CIRCLECI=$CIRCLECI up_prod_detached integration_test_nimbus PYTEST_ARGS="$PYTEST_ARGS"
       - store_artifacts:
           path: ~/experimenter/experimenter/tests/integration/test-reports/report.htm
@@ -440,8 +441,6 @@ jobs:
       - run:
           name: Deploy to latest
           command: |
-            make cirrus_build
-            # Pull x86_64 and tag to dockerhub for deploy
             make cirrus_build
             docker tag cirrus:deploy ${DOCKERHUB_CIRRUS_REPO}:latest
             docker push ${DOCKERHUB_CIRRUS_REPO}:latest

--- a/README.md
+++ b/README.md
@@ -302,6 +302,16 @@ Run kill, migrate, load_locales_countries load_dummy_experiments. Useful for res
 
 ### Running a dev instance
 
+#### Enabling Cirrus
+
+Cirrus is required to run and test web application experiments locally.  It is disabled by default.  To enable Cirrus run:
+
+```sh
+export CIRRUS=1
+```
+
+This will be done automatically for any Cirrus related make commands.
+
 #### make up
 
 Start a dev server listening on port 80 using the [Django runserver](https://docs.djangoproject.com/en/1.10/ref/django-admin/#runserver). It is useful to run `make refresh` first to ensure your database is up to date with the latest migrations and test data.

--- a/docker-compose-cirrus.yml
+++ b/docker-compose-cirrus.yml
@@ -1,0 +1,40 @@
+version: "3"
+
+services:
+  cirrus:
+    build:
+      context: cirrus/server/
+      dockerfile: Dockerfile
+    env_file: .env
+    links:
+      - kinto
+    volumes:
+      - ./cirrus/server/:/cirrus
+    working_dir: /cirrus
+    ports:
+      - "8001:8001"
+
+  demo-app-server:
+    build:
+      context: ./demo-app/server
+      dockerfile: Dockerfile
+    ports:
+      - '3002:3002'
+    restart: always
+    links:
+      - cirrus
+    environment:
+      - CIRRUS=http://cirrus:8001
+
+  demo-app-frontend:
+    build:
+      context: ./demo-app/frontend
+      dockerfile: Dockerfile
+    ports:
+      - '8080:3000'
+    restart: always
+    links:
+      - demo-app-server
+    environment:
+      - DEMO_APP_SERVER=http://demo-app-server:3002
+    command: npm start

--- a/docker-compose-integration-test.yml
+++ b/docker-compose-integration-test.yml
@@ -39,40 +39,8 @@ services:
     build: experimenter/tests/integration/nimbus/utils/ping_server
     ports:
       - "5050:5050"
-
-  cirrus:
-    build:
-      context: cirrus/server/
-      dockerfile: Dockerfile
-    env_file: .env.integration-tests
-    links:
-      - kinto
-    volumes:
-      - ./cirrus/server/:/cirrus
-    working_dir: /cirrus
-    ports:
-      - "8001:8001"
-  demo-app-server:
-    build:
-      context: ./demo-app/server
-      dockerfile: Dockerfile
-    ports:
-      - '3002:3002'
-    restart: always
-    links:
-      - cirrus
-    environment:
-      - CIRRUS=http://cirrus:8001
-
-
   demo-app-frontend:
     build:
       context: ./demo-app/frontend
       dockerfile: Dockerfile
-    ports:
-      - '8080:3000'
-    restart: always
-    links:
-      - demo-app-server
-    environment:
-      - DEMO_APP_SERVER=http://demo-app-server:3002
+    command: /bin/true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -112,44 +112,6 @@ services:
     ports:
       - "8000:8000"
 
-  cirrus:
-    build:
-      context: cirrus/server/
-      dockerfile: Dockerfile
-    env_file: .env
-    links:
-      - kinto
-    volumes:
-      - ./cirrus/server/:/cirrus
-    working_dir: /cirrus
-    ports:
-      - "8001:8001"
-  demo-app-server:
-    build:
-      context: ./demo-app/server
-      dockerfile: Dockerfile
-    ports:
-      - '3002:3002'
-    restart: always
-    links:
-      - cirrus
-    environment:
-      - CIRRUS=http://cirrus:8001
-
-
-  demo-app-frontend:
-    build:
-      context: ./demo-app/frontend
-      dockerfile: Dockerfile
-    ports:
-      - '8080:3000'
-    restart: always
-    links:
-      - demo-app-server
-    environment:
-      - DEMO_APP_SERVER=http://demo-app-server:3002
-
-
 volumes:
   db_volume:
   media_volume:


### PR DESCRIPTION
Because

* Building Cirrus can be time consuming
* Cirrus is not necessary for many integration tests or local workflows
* We can add a flag to enable/disable cirrus to speed up the integration tests or local workflows that don't involve Cirrus

This commit

* Adds a flag to enable/disable Cirrus in the Makefile
* Sets the flag automatically for all Cirrus make commands
* Sets the flag for Cirrus integration tests

fixes #9910

