### PR TITLE
bug(nimbus): fix intermittent failure in integration tests

### DIFF
--- a/experimenter/tests/integration/nimbus/test_experimenter_ui.py
+++ b/experimenter/tests/integration/nimbus/test_experimenter_ui.py
@@ -128,9 +128,7 @@ def test_first_run_release_date_visible_for_mobile(
     assert audience.is_first_run
     assert audience.proposed_release_date == "2023-12-12"
 
-    audience.save_and_continue()
-
-    summary = SummaryPage(selenium, experiment_url).open()
+    summary = audience.save_and_continue()
 
     assert summary.proposed_release_date == "2023-12-12"
 

--- a/experimenter/tests/integration/nimbus/test_remote_settings.py
+++ b/experimenter/tests/integration/nimbus/test_remote_settings.py
@@ -234,12 +234,10 @@ def test_rollout_live_update_approve(
     audience = summary.navigate_to_audience()
 
     audience.percentage = "60"
-    audience.save_and_continue()
+    summary = audience.save_and_continue()
 
-    summary_page = SummaryPage(selenium, experiment_url).open()
-    summary_page.wait_for_update_request_visible()
-
-    summary_page.request_update_and_approve()
+    summary.wait_for_update_request_visible()
+    summary.request_update_and_approve()
     kinto_client.approve()
 
 
@@ -266,15 +264,14 @@ def test_rollout_live_update_approve_and_reject(
     audience = summary.navigate_to_audience()
 
     audience.percentage = "60"
-    audience.save_and_continue()
+    summary = audience.save_and_continue()
 
-    summary_page = SummaryPage(selenium, experiment_url).open()
-    summary_page.wait_for_update_request_visible()
+    summary.wait_for_update_request_visible()
 
-    summary_page.request_update_and_approve()
+    summary.request_update_and_approve()
     kinto_client.reject()
 
-    summary_page.wait_for_rejection_notice_visible()
+    summary.wait_for_rejection_notice_visible()
 
 
 @pytest.mark.remote_settings
@@ -300,17 +297,16 @@ def test_rollout_live_update_reject_on_experimenter(
     audience = summary.navigate_to_audience()
 
     audience.percentage = "60"
-    audience.save_and_continue()
+    summary = audience.save_and_continue()
 
-    summary_page = SummaryPage(selenium, experiment_url).open()
-    summary_page.wait_for_update_request_visible()
+    summary.wait_for_update_request_visible()
 
-    summary_page.request_update_and_reject()
-    summary_page.wait_for_rejection_reason_text_input_visible()
+    summary.request_update_and_reject()
+    summary.wait_for_rejection_reason_text_input_visible()
 
-    summary_page.set_rejection_reason()
-    summary_page.submit_rejection()
-    summary_page.wait_for_rejection_notice_visible()
+    summary.set_rejection_reason()
+    summary.submit_rejection()
+    summary.wait_for_rejection_notice_visible()
 
 
 @pytest.mark.remote_settings


### PR DESCRIPTION
Because

* We have been seeing intermittent failures in the integration tests
* They are complaining they are unable to find the launch locator
* We see in the screenshots that the audience page is invalid
* The audience fixtures are static so how could that lead to intermittency
* Observing the tests locally we see that the audience page is valid but the summary page is loading too fast, before the audience save is complete
* The pattern of triggering a save and opening the summary page directly can cause the summary page to load before the save is complete, reporting the audience page as incomplete
* We should instead receive the summary page from calling audience.save_and_continue() which will give sufficient time for the save to complete and then summary page to load

This commit

* Changes any place where we save on the audience page but load the summary page directly to instead receive the summary page from calling save_and_continue on the audience page

fixes #9909

