### PR TITLE
chore(nimbus): fetch results every 6 hours on 12/6/12/6 (UTC)

### DIFF
--- a/experimenter/experimenter/settings.py
+++ b/experimenter/experimenter/settings.py
@@ -15,6 +15,7 @@ from importlib import resources
 from pathlib import Path
 from urllib.parse import urljoin
 
+from celery.schedules import crontab
 from decouple import config
 from django.contrib.admin import ModelAdmin, StackedInline, TabularInline
 from django.db.models import DecimalField, ForeignKey, JSONField, ManyToManyField
@@ -383,7 +384,7 @@ CELERY_BEAT_SCHEDULE = {
     },
     "fetch_jetstream_data": {
         "task": "experimenter.jetstream.tasks.fetch_jetstream_data",
-        "schedule": 28800,
+        "schedule": crontab(minute=0, hour="*/6"),
     },
     "fetch_population_sizing_data": {
         "task": "experimenter.jetstream.tasks.fetch_population_sizing_data",


### PR DESCRIPTION
Because

- Experimenter fetches results every 8 hours, starting 8 hours after a deploy
- This makes it hard to know when results were last fetched, and might delay fetching during times with frequent deploys

This commit

- changes to a crontab style scheduling pattern, fetching at the same times every day
- increases the frequency of fetches to every 6 hours (at 12/6/12/6 UTC)

Fixes #9935 