### PR TITLE
chore(nimbus): remove feature config schema from getAllExperiments gql call

### DIFF
--- a/experimenter/experimenter/nimbus-ui/src/gql/experiments.ts
+++ b/experimenter/experimenter/nimbus-ui/src/gql/experiments.ts
@@ -251,7 +251,6 @@ export const GET_EXPERIMENTS_QUERY = gql`
         description
         application
         ownerEmail
-        schema
       }
       targetingConfig {
         label

--- a/experimenter/experimenter/nimbus-ui/src/types/getAllExperiments.ts
+++ b/experimenter/experimenter/nimbus-ui/src/types/getAllExperiments.ts
@@ -23,7 +23,6 @@ export interface getAllExperiments_experiments_featureConfigs {
   description: string | null;
   application: NimbusExperimentApplicationEnum | null;
   ownerEmail: string | null;
-  schema: string | null;
 }
 
 export interface getAllExperiments_experiments_targetingConfig {


### PR DESCRIPTION


Because

* We included the feature config schema in the getAllExperiments call that's used to populate the landing page
* Those schemas can get quite large
* That field is not used by any callers of that query
* It can be safely removed
* This should reduce the size of the payload and time to load that page

This commit

* Removes feature config schema from the getAllExperiments gql query

fixes #9940

