### PR TITLE
feat(nimbus): Add status pill for qa status on Timeline

### DIFF
--- a/experimenter/experimenter/nimbus-ui/src/components/PageSummary/index.test.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageSummary/index.test.tsx
@@ -21,13 +21,18 @@ import {
   updateReviewRequestedBaseProps,
 } from "src/components/PageSummary/mocks";
 import { createMutationMock } from "src/components/Summary/mocks";
-import { CHANGELOG_MESSAGES, SERVER_ERRORS } from "src/lib/constants";
+import {
+  CHANGELOG_MESSAGES,
+  QA_STATUS_WITH_EMOJI,
+  SERVER_ERRORS,
+} from "src/lib/constants";
 import { mockExperimentQuery, mockLiveRolloutQuery } from "src/lib/mocks";
 import {
   NimbusExperimentApplicationEnum,
   NimbusExperimentChannelEnum,
   NimbusExperimentFirefoxVersionEnum,
   NimbusExperimentPublishStatusEnum,
+  NimbusExperimentQAStatusEnum,
   NimbusExperimentStatusEnum,
 } from "src/types/globalTypes";
 
@@ -704,6 +709,37 @@ describe("PageSummary", () => {
       ).toBeInTheDocument();
     },
   );
+
+  it.each([
+    [NimbusExperimentQAStatusEnum.GREEN, QA_STATUS_WITH_EMOJI.GREEN[0]],
+    [NimbusExperimentQAStatusEnum.YELLOW, QA_STATUS_WITH_EMOJI.YELLOW[0]],
+    [NimbusExperimentQAStatusEnum.RED, QA_STATUS_WITH_EMOJI.RED[0]],
+  ])(
+    "renders qa status pill for each status",
+    async (qaStatus: NimbusExperimentQAStatusEnum, qaLabel: string) => {
+      const { mock } = mockExperimentQuery("demo-slug", {
+        status: NimbusExperimentStatusEnum.LIVE,
+        publishStatus: NimbusExperimentPublishStatusEnum.IDLE,
+        qaStatus: qaStatus,
+        statusNext: null,
+      });
+
+      render(<Subject mocks={[mock]} />);
+      const qaStatusPill = await screen.findByTestId("pill-qa-status");
+      expect(qaStatusPill).toBeInTheDocument();
+      expect(screen.getByText(qaLabel)).toBeInTheDocument();
+    },
+  );
+
+  it("will not render qa status pill when status is not set", async () => {
+    const { mock, experiment } = mockExperimentQuery("demo-slug", {
+      status: NimbusExperimentStatusEnum.LIVE,
+      publishStatus: NimbusExperimentPublishStatusEnum.IDLE,
+      statusNext: null,
+    });
+    render(<Subject mocks={[mock]} />);
+    expect(screen.queryByTestId("pill-qa-status")).not.toBeInTheDocument();
+  });
 
   it.each([
     [

--- a/experimenter/experimenter/nimbus-ui/src/components/PageSummary/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageSummary/index.tsx
@@ -23,12 +23,14 @@ import {
   CHANGELOG_MESSAGES,
   EXTERNAL_URLS,
   LIFECYCLE_REVIEW_FLOWS,
+  QA_STATUS_WITH_EMOJI,
 } from "src/lib/constants";
 import { ExperimentContext } from "src/lib/contexts";
 import { getStatus, getSummaryAction, StatusCheck } from "src/lib/experiment";
 import { getExperiment_experimentBySlug } from "src/types/getExperiment";
 import {
   NimbusExperimentPublishStatusEnum,
+  NimbusExperimentQAStatusEnum,
   NimbusExperimentStatusEnum,
 } from "src/types/globalTypes";
 
@@ -306,6 +308,26 @@ const PageSummary = (props: RouteComponentProps) => {
 
 export default PageSummary;
 
+export function qaStatusLabel(status: NimbusExperimentQAStatusEnum) {
+  if (status === NimbusExperimentQAStatusEnum.GREEN) {
+    return QA_STATUS_WITH_EMOJI.GREEN[0];
+  } else if (status === NimbusExperimentQAStatusEnum.YELLOW) {
+    return QA_STATUS_WITH_EMOJI.YELLOW[0];
+  } else {
+    return QA_STATUS_WITH_EMOJI.RED[0];
+  }
+}
+
+export function qaStatusColor(status: NimbusExperimentQAStatusEnum) {
+  if (status === NimbusExperimentQAStatusEnum.GREEN) {
+    return QA_STATUS_WITH_EMOJI.GREEN[1];
+  } else if (status === NimbusExperimentQAStatusEnum.YELLOW) {
+    return QA_STATUS_WITH_EMOJI.YELLOW[1];
+  } else {
+    return QA_STATUS_WITH_EMOJI.RED[1];
+  }
+}
+
 const StatusPills = ({
   experiment,
   status,
@@ -334,6 +356,13 @@ const StatusPills = ({
         testId="pill-dirty-unpublished"
         label="Unpublished changes"
         color={"danger"}
+      />
+    )}
+    {experiment.qaStatus != null && (
+      <StatusPill
+        testId="pill-qa-status"
+        label={qaStatusLabel(experiment.qaStatus)}
+        color={qaStatusColor(experiment.qaStatus)}
       />
     )}
   </>

--- a/experimenter/experimenter/nimbus-ui/src/lib/constants.ts
+++ b/experimenter/experimenter/nimbus-ui/src/lib/constants.ts
@@ -189,3 +189,9 @@ export const URL_FIELD = {
 export const IMAGE_UPLOAD_ACCEPT = ".gif,.jpg,.jpeg,.png";
 
 export const POLL_INTERVAL = 30000;
+
+export const QA_STATUS_WITH_EMOJI = {
+  GREEN: ["✅ QA: Green", "success"],
+  YELLOW: ["⚠️ QA: Yellow", "text-dark"],
+  RED: ["❌ QA: Red", "danger"],
+};


### PR DESCRIPTION
Because

- We want to be able to quickly identify the QA status of an experiment if it has been set

This commit

- Adds a pill next to the existing ones on the Timeline
- Changes the color and text of the QA status pill to match the status that has been chosen, with a normal dark text color for `YELLOW` since it was too hard to read

Fixes #9883 



https://github.com/mozilla/experimenter/assets/43795363/499b3da2-f6a7-44f8-be66-f17d8d740e6f

<img width="1612" alt="Screenshot 2023-12-13 at 4 41 01 PM" src="https://github.com/mozilla/experimenter/assets/43795363/68228c08-b91e-4f10-b3b5-dc18cbcdbf79">
