### PR TITLE
feat(nimbus): use the GitHub contents API to find download URLs

### DIFF
--- a/experimenter/manifesttool/github_api.py
+++ b/experimenter/manifesttool/github_api.py
@@ -8,7 +8,6 @@ from manifesttool import download
 from manifesttool.repository import Ref
 
 GITHUB_API_URL = "https://api.github.com"
-GITHUB_RAW_URL = "https://raw.githubusercontent.com"
 GITHUB_API_HEADERS = {
     "Accept": "application/vnd.github+json",
     "X-GitHub-Api-Version": "2022-11-28",
@@ -127,7 +126,15 @@ def fetch_file(
         If ``download_path`` is ``None``, the file contents are returned as a
         ``str``. Otherwise, ``None`` is returned.
     """
-    url = f"{GITHUB_RAW_URL}/{repo}/{rev}/{file_path}"
+    rsp = api_request(
+        f"repos/{repo}/contents/{file_path}",
+        raise_for_status=False,
+        params={"ref": rev},
+    )
+
+    rsp.raise_for_status()
+
+    url = rsp.json()["download_url"]
 
     if download_path is None:
         return download.as_text(url)


### PR DESCRIPTION
Because: 

- we can't directly access raw.githubusercontent.com paths for private
  repositories, even with a GitHub API key

This commit:

- updates fetch logic to use the file contents API, which will return a
  download URL that includes a token; and
- downloads the file from the returned URL.

Fixes #9946
