### PR TITLE
bug(nimbus): wait for next page to load after saving in integration tests

### DIFF
--- a/experimenter/tests/integration/nimbus/pages/experimenter/base.py
+++ b/experimenter/tests/integration/nimbus/pages/experimenter/base.py
@@ -21,6 +21,10 @@ class ExperimenterBase(Base):
             *self._save_continue_btn_locator, "save and continue button"
         )
         element.click()
+
+        # Wait for next page to load after save and continue before proceeding
+        self.wait_for_locator(self.NEXT_PAGE._page_wait_locator)
+
         return self.NEXT_PAGE(self.driver, self.base_url).wait_for_page_to_load()
 
     def save(self):


### PR DESCRIPTION
Because

* We have seen many intermittent failures in the integration tests
* We have discovered that sometimes when saving the next page will load before the save has completed

This commit

* Adds a wait for the next page to load after saving before continuing with the test

fixes #9923

