### PR TITLE
chore(nimbus): Prepare for Firefox iOS becoming a monorepo

### DIFF
--- a/experimenter/experimenter/features/manifests/apps.yaml
+++ b/experimenter/experimenter/features/manifests/apps.yaml
@@ -23,7 +23,9 @@ firefox_ios:
   repo:
     type: "github"
     name: "mozilla-mobile/firefox-ios"
-  fml_path: "nimbus.fml.yaml"
+  fml_path:
+    - "firefox-ios/nimbus.fml.yaml"
+    - "nimbus.fml.yaml"
   release_discovery:
     version_file:
       type: "plist"


### PR DESCRIPTION
Because

- Firefox iOS is being refactored into a sub-directory in https://github.com/mozilla-mobile/firefox-ios/pull/17460

this commit

- updates our definition in apps.yaml to support both the new old old location of its feature manifest

Fixes #9954