### PR TITLE
bug(nimbus): wait for audience to save before continuing

### DIFF
--- a/experimenter/tests/integration/nimbus/pages/experimenter/audience.py
+++ b/experimenter/tests/integration/nimbus/pages/experimenter/audience.py
@@ -40,8 +40,18 @@ class AudiencePage(ExperimenterBase):
     )
     _first_run_checkbox_locator = (By.CSS_SELECTOR, '[data-testid="isFirstRun"]')
     _release_date_locator = (By.CSS_SELECTOR, '[data-testid="proposedReleaseDate"]')
+    _saved_locator = (By.CSS_SELECTOR, "form.was-validated")
 
     NEXT_PAGE = SummaryPage
+
+    def save_and_continue(self):
+        # Explicitly save and wait for save to complete before continuing
+        # to prevent intermittent failures where summary loads before saving
+        # audience is complete
+        self.save()
+        self.wait_for_locator(self._saved_locator)
+
+        return super().save_and_continue()
 
     @property
     def channel(self):


### PR DESCRIPTION
Because

* We've seen a lot of intermittent integration test failures
* It seems as if saving on the audience page and then proceeding immediately to the summary page can cause the summary page to load before the audience save is complete which can manifest as many different types of test failure

This commit

* Explicitly saves on the audience page and waits for it to finish saving before continuing to the summary page

fixes #9923

