### PR TITLE
feat(nimbus): Support multiple locations for version files

### DIFF
--- a/experimenter/experimenter/features/manifests/apps.yaml
+++ b/experimenter/experimenter/features/manifests/apps.yaml
@@ -29,7 +29,9 @@ firefox_ios:
   release_discovery:
     version_file:
       type: "plist"
-      path: "Client/Info.plist"
+      path:
+        - "firefox-ios/Client/Info.plist"
+        - "Client/Info.plist"
       key: "CFBundleShortVersionString"
     strategies:
       - type: "tagged"
@@ -64,7 +66,9 @@ focus_ios:
   release_discovery:
     version_file:
       type: "plist"
-      path: "Blockzilla/Info.plist"
+      path:
+        - "focus-ios/Blockzilla/Info.plist"
+        - "Blockzilla/Info.plist"
       key: "CFBundleShortVersionString"
     strategies:
       # We don't use a branched strategy for focus_ios because it is on v9000.
@@ -76,37 +80,37 @@ focus_ios:
         ignored_tags:
           - "v999.0.0" # nimbus.fml.yaml missing.
 
-monitor_cirrus:
-  slug: "monitor-web"
-  repo:
-    type: "github"
-    name: "mozilla/blurts-server"
-  fml_path: "config/nimbus.yaml"
+# monitor_cirrus:
+#   slug: "monitor-web"
+#   repo:
+#     type: "github"
+#     name: "mozilla/blurts-server"
+#   fml_path: "config/nimbus.yaml"
 
-firefox_desktop:
-  slug: "firefox-desktop"
-  repo:
-    type: "hgmo"
-    name: "mozilla-unified"
-    default_branch: "central"
-  experimenter_yaml_path: "toolkit/components/nimbus/FeatureManifest.yaml"
-  release_discovery:
-    version_file:
-      type: "plaintext"
-      path: "browser/config/version.txt"
-    strategies:
-      - type: "branched"
-        branches:
-          # The order here is important!
-          #
-          # When central is merging to beta or beta is merging to release, then
-          # both of those will have the same version number for a period of
-          # time.
-          #
-          # In this order, if two consecutive branches have the same version,
-          # then the latter will take precedence. e.g., if both beta and release
-          # report the same version, we will use the feature manifest from release.
-          - "central"
-          - "beta"
-          - "release"
-          - "esr115"
+# firefox_desktop:
+#   slug: "firefox-desktop"
+#   repo:
+#     type: "hgmo"
+#     name: "mozilla-unified"
+#     default_branch: "central"
+#   experimenter_yaml_path: "toolkit/components/nimbus/FeatureManifest.yaml"
+#   release_discovery:
+#     version_file:
+#       type: "plaintext"
+#       path: "browser/config/version.txt"
+#     strategies:
+#       - type: "branched"
+#         branches:
+#           # The order here is important!
+#           #
+#           # When central is merging to beta or beta is merging to release, then
+#           # both of those will have the same version number for a period of
+#           # time.
+#           #
+#           # In this order, if two consecutive branches have the same version,
+#           # then the latter will take precedence. e.g., if both beta and release
+#           # report the same version, we will use the feature manifest from release.
+#           - "central"
+#           - "beta"
+#           - "release"
+#           - "esr115"

--- a/experimenter/manifesttool/appconfig.py
+++ b/experimenter/manifesttool/appconfig.py
@@ -34,12 +34,12 @@ class VersionFileType(str, Enum):
 
 class PlainTextVersionFile(BaseModel):
     type: Literal[VersionFileType.PLAIN_TEXT]
-    path: str
+    path: Optional[Union[str, list[str]]]
 
 
 class PListVersionFile(BaseModel):
     type: Literal[VersionFileType.PLIST]
-    path: str
+    path: Optional[Union[str, list[str]]]
     key: str
 
 
@@ -47,7 +47,7 @@ class VersionFile(BaseModel):
     __root__: Union[PlainTextVersionFile, PListVersionFile] = Field(discriminator="type")
 
     @classmethod
-    def create_plain_text(cls, path: str):  # pragma: no cover
+    def create_plain_text(cls, path: str | list[str]):  # pragma: no cover
         return cls(
             __root__=PlainTextVersionFile(
                 type=VersionFileType.PLAIN_TEXT,
@@ -56,7 +56,7 @@ class VersionFile(BaseModel):
         )
 
     @classmethod
-    def create_plist(cls, path: str, key: str):  # pragma: no cover
+    def create_plist(cls, path: str | list[str], key: str):  # pragma: no cover
         return cls(
             __root__=PListVersionFile(
                 type=VersionFileType.PLIST,

--- a/experimenter/manifesttool/tests/test_version.py
+++ b/experimenter/manifesttool/tests/test_version.py
@@ -19,7 +19,7 @@ from manifesttool.cli import MANIFEST_DIR
 from manifesttool.github_api import GITHUB_API_URL
 from manifesttool.hgmo_api import HGMO_URL
 from manifesttool.repository import Ref
-from manifesttool.tests.test_github_api import GITHUB_RAW_URL
+from manifesttool.tests.test_github_api import make_responses_for_fetch
 from manifesttool.version import (
     Version,
     filter_versioned_refs,
@@ -411,9 +411,9 @@ class VersionTests(TestCase):
             (
                 app_config,
                 [
-                    (Ref("v120", "r0"), "120.0a1\n"),
-                    (Ref("v120.1", "r1"), "120.1a1\n"),
-                    (Ref("v121", "r2"), "121.0a1\n"),
+                    (Ref("v120", "r0"), b"120.0a1\n"),
+                    (Ref("v120.1", "r1"), b"120.1a1\n"),
+                    (Ref("v121", "r2"), b"121.0a1\n"),
                 ],
                 {
                     Version(120): Ref("v120", "r0"),
@@ -458,35 +458,26 @@ class VersionTests(TestCase):
         expected: dict[Version, Ref],
     ):
         """Testing resolve_ref_versions."""
-        if app_config.repo.type == RepositoryType.GITHUB:
-            url_template = (
-                f"{GITHUB_RAW_URL}/{app_config.repo.name}/"
-                f"{{ref.target}}/{app_config.release_discovery.version_file.__root__.path}"
-            )
-        else:
-            url_template = (
-                f"{HGMO_URL}/{app_config.repo.name}/raw-file/"
-                f"{{ref.target}}/{app_config.release_discovery.version_file.__root__.path}"
-            )
-
         refs = []
         rsps = []
         for ref, body in bodies:
-            download_url = url_template.format(ref=ref)
-            rsps.append(responses.get(download_url, body=body))
             refs.append(ref)
 
             if app_config.repo.type == RepositoryType.GITHUB:
+                rsps.extend(
+                    make_responses_for_fetch(
+                        app_config.repo.name,
+                        ref.target,
+                        app_config.release_discovery.version_file.__root__.path,
+                        body,
+                    )
+                )
+            else:
                 rsps.append(
                     responses.get(
-                        (
-                            f"{GITHUB_API_URL}/repos/{app_config.repo.name}/"
-                            f"contents/{app_config.release_discovery.version_file.__root__.path}"
-                        ),
-                        match=[matchers.query_param_matcher({"ref": ref.target})],
-                        json={
-                            "download_url": download_url,
-                        },
+                        f"{HGMO_URL}/{app_config.repo.name}/raw-file/"
+                        f"{ref.target}/{app_config.release_discovery.version_file.__root__.path}",
+                        body=body,
                     )
                 )
 
@@ -496,3 +487,127 @@ class VersionTests(TestCase):
             self.assertEqual(rsp.call_count, 1)
 
         self.assertEqual(result, expected)
+
+    @parameterized.expand(
+        [
+            (
+                app_config,
+                [
+                    (Ref("v120", "r0"), "a/version.txt", b"120.0a1\n"),
+                    (Ref("v120.1", "r1"), "a/version.txt", b"120.1a1\n"),
+                    (Ref("v121", "r2"), "b/version.txt", b"121.0a1\n"),
+                ],
+                {
+                    Version(120): Ref("v120", "r0"),
+                    Version(120, 1): Ref("v120.1", "r1"),
+                    Version(121): Ref("v121", "r2"),
+                },
+            )
+            for app_config in (
+                AppConfig(
+                    slug="fml-app",
+                    repo=Repository(
+                        type=RepositoryType.GITHUB,
+                        name="fml-app",
+                    ),
+                    fml_path="nimbus.fml.yaml",
+                    release_discovery=ReleaseDiscovery(
+                        version_file=VersionFile.create_plain_text(
+                            ["a/version.txt", "b/version.txt"]
+                        ),
+                        strategies=[DiscoveryStrategy.create_tagged(branch_re="")],
+                    ),
+                ),
+                AppConfig(
+                    slug="legacy-app",
+                    repo=Repository(
+                        type=RepositoryType.HGMO,
+                        name="legacy-app",
+                        default_branch="default",
+                    ),
+                    fml_path="experimenter.yaml",
+                    release_discovery=ReleaseDiscovery(
+                        version_file=VersionFile.create_plain_text(
+                            ["a/version.txt", "b/version.txt"]
+                        ),
+                        strategies=[DiscoveryStrategy.create_tagged(branch_re="")],
+                    ),
+                ),
+            )
+        ]
+    )
+    @responses.activate
+    def test_resolve_ref_versions_multiple_files(self, app_config, bodies, expected):
+        version_paths = app_config.release_discovery.version_file.__root__.path
+
+        refs = []
+        rsps = []
+        for ref, good_path, body in bodies:
+            refs.append(ref)
+
+            bad_path = next(p for p in version_paths if p != good_path)
+
+            if app_config.repo.type == RepositoryType.GITHUB:
+                rsps.extend(
+                    make_responses_for_fetch(
+                        app_config.repo.name,
+                        ref.target,
+                        good_path,
+                        body,
+                    )
+                )
+                responses.get(
+                    f"{GITHUB_API_URL}/repos/{app_config.repo.name}/contents/{bad_path}",
+                    match=[matchers.query_param_matcher({"ref": ref.target})],
+                    status=404,
+                    body=b"",
+                )
+            else:
+                url_template = (
+                    f"{HGMO_URL}/{app_config.repo.name}/raw-file/"
+                    f"{ref.target}/{{path}}"
+                )
+                rsps.append(responses.get(url_template.format(path=good_path), body=body))
+                responses.get(url_template.format(path=bad_path), status=404, body=b"")
+
+        result = resolve_ref_versions(app_config, refs)
+
+        for rsp in rsps:
+            self.assertEqual(rsp.call_count, 1)
+
+        self.assertEqual(result, expected)
+
+    @responses.activate
+    def test_resolve_ref_cannot_find_version(self):
+        app_config = AppConfig(
+            slug="fml-app",
+            repo=Repository(
+                type=RepositoryType.GITHUB,
+                name="fml-app",
+            ),
+            fml_path="nimbus.fml.yaml",
+            release_discovery=ReleaseDiscovery(
+                version_file=VersionFile.create_plain_text(
+                    ["a/version.txt", "b/version.txt"]
+                ),
+                strategies=[DiscoveryStrategy.create_tagged(branch_re="")],
+            ),
+        )
+
+        rsps = [
+            responses.get(
+                f"{GITHUB_API_URL}/repos/{app_config.repo.name}/contents/{path}",
+                match=[matchers.query_param_matcher({"ref": "foo"})],
+                status=404,
+                body=b"",
+            )
+            for path in app_config.release_discovery.version_file.__root__.path
+        ]
+
+        with self.assertRaisesRegex(
+            Exception, "Could not find version file for app fml-app"
+        ):
+            resolve_ref_versions(app_config, [Ref("main", "foo")])
+
+        for rsp in rsps:
+            self.assertEqual(rsp.call_count, 1)


### PR DESCRIPTION
Because

- firefox-ios and focus-ios are merging into a single mono-repo;
- focus-ios relocated the file we use to determine versions; and
- firefox-ios will soon be doing the same

This commit

- updates AppConfig to support multiple version files;
- updates the resolving logic to try each file in turn; and
- updates the version file entries for firefox-ios and focus-ios.

Fixes #9966