### PR TITLE
Update to latest version of application services

### DIFF
--- a/cirrus/server/Dockerfile
+++ b/cirrus/server/Dockerfile
@@ -15,7 +15,7 @@ WORKDIR /application-services
 
 # Checkout application services at a locked commit
 RUN git clone https://github.com/mozilla/application-services.git .
-RUN git fetch && git checkout 8ded4cb602aed89fd22c0dd7fdbfc6fa063c5ef1
+RUN git fetch && git checkout 1f11e95bf478666ca49c279a8927931c5535a786
 
 RUN git submodule init
 RUN git submodule update --recursive

--- a/experimenter/Dockerfile
+++ b/experimenter/Dockerfile
@@ -82,7 +82,7 @@ WORKDIR /application-services
 # Rust packages
 # Checkout application services at a locked commit
 RUN git clone https://github.com/mozilla/application-services.git .
-RUN git fetch && git checkout 8ded4cb602aed89fd22c0dd7fdbfc6fa063c5ef1
+RUN git fetch && git checkout 1f11e95bf478666ca49c279a8927931c5535a786
 
 RUN git submodule init
 RUN git submodule update --recursive


### PR DESCRIPTION
Because

- We want to get the latest version of AS which contains new validation and targeting

This commit

- Updates our AS version for `experimenter` and `cirrus`

Changelog: https://github.com/mozilla/application-services/blob/6ec8fa41bcf8792ac522503d17597fc46a5687c5/CHANGELOG.md