### PR TITLE
bug(nimbus): Pass GITHUB_BEARER_TOKEN through docker to manifesttool

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ jetstream_config:
 	rm -Rf experimenter/experimenter/outcomes/metric-hub-main/.script/
 
 feature_manifests: build_dev
-	$(COMPOSE) run experimenter /experimenter/bin/manifest-tool.py fetch $(FETCH_ARGS)
+	$(COMPOSE) run -e GITHUB_BEARER_TOKEN=$(GITHUB_BEARER_TOKEN) experimenter /experimenter/bin/manifest-tool.py fetch $(FETCH_ARGS)
 
 install_nimbus_cli:  ## Install Nimbus client
 	mkdir -p $(CLI_DIR)


### PR DESCRIPTION
Because

- we are running into the GitHub API request limit;
- we have an API token in CI; and
- we are not using the API while authenticated because Docker does not
  transparently pass environment variables through to containers

This commit

- updates the `feature_manfests` Make target to pass the
  `GITHUB_BEARER_TOKEN` through to the docker container.

Fixes #9972
