### PR TITLE
fixes mozilla#9986 feat(nimbus): Land advanced targeting for January …

### DIFF
--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -700,6 +700,29 @@ EXISTING_USER_NO_VPN_HAS_NOT_DISABLED_RECOMMEND_FEATURES = NimbusTargetingConfig
     application_choice_names=(Application.DESKTOP.name,),
 )
 
+NO_VPN_HAS_NOT_DISABLED_RECOMMEND_FEATURES = NimbusTargetingConfig(
+    name=(
+        "All users, no enterprise or past VPN use, hasn't disabled "
+        "'Recommend extensions/features'"
+    ),
+    slug="no_vpn_has_not_disabled_recommend_features",
+    description=(
+        "Exclude users who have used Mozilla VPN, are enterprise users, or have"
+        " disabled 'Recommend extensions/features'"
+    ),
+    targeting=(
+        f"{NO_ENTERPRISE_OR_PAST_VPN.targeting} && "
+        "(!os.isWindows || os.windowsBuildNumber >= 18362) && "
+        "'browser.newtabpage.activity-stream.asrouter.userprefs.cfr.features'|preferenceValue"
+        " && "
+        "'browser.newtabpage.activity-stream.asrouter.userprefs.cfr.addons'|preferenceValue"
+    ),
+    desktop_telemetry="",
+    sticky_required=False,
+    is_first_run_required=False,
+    application_choice_names=(Application.DESKTOP.name,),
+)
+
 NO_ENTERPRISE_OR_RECENT_VPN = NimbusTargetingConfig(
     name="No enterprise and no VPN connection in the last 30 days",
     slug="no_enterprise_or_last_30d_vpn_use",


### PR DESCRIPTION
[Track on Bugzilla](https://bugzilla.mozilla.org/show_bug.cgi?id=1871614)

Adds a NO_VPN_HAS_NOT_DISABLED_RECOMMEND_FEATURES targeting for all profile ages to support the January Moments Page experiment.

Fixes #9986 