### PR TITLE
feat(nimbus): make results config options scroll with results page

### DIFF
--- a/experimenter/experimenter/nimbus-ui/src/components/PageResults/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageResults/index.tsx
@@ -4,8 +4,10 @@
 
 import { RouteComponentProps } from "@reach/router";
 import React, { useContext, useState } from "react";
-import { Form } from "react-bootstrap";
+import { Card, Form } from "react-bootstrap";
 import Collapse from "react-bootstrap/Collapse";
+import Col from "react-bootstrap/Col";
+import Row from "react-bootstrap/Row";
 import Select from "react-select";
 import AppLayoutWithExperiment from "src/components/AppLayoutWithExperiment";
 import AnalysisErrorAlert from "src/components/PageResults/AnalysisErrorAlert";
@@ -222,17 +224,6 @@ const PageResults: React.FunctionComponent<RouteComponentProps> = () => {
   return (
     <AppLayoutWithExperiment title="Analysis" testId="PageResults">
       <ResultsContext.Provider value={resultsContextValue}>
-        {analysis?.metadata?.analysis_start_time && (
-          <p>
-            Results last calculated:{" "}
-            <b>
-              {new Date(analysis?.metadata?.analysis_start_time).toLocaleString(
-                undefined,
-                { timeZone: "UTC", timeZoneName: "short" },
-              )}
-            </b>
-          </p>
-        )}
         {analysis?.errors?.experiment &&
           analysis?.errors?.experiment.length > 0 && (
             <AnalysisErrorAlert errors={analysis.errors.experiment} />
@@ -240,298 +231,323 @@ const PageResults: React.FunctionComponent<RouteComponentProps> = () => {
 
         {externalConfig && <ExternalConfigAlert {...{ externalConfig }} />}
 
-        {allAnalysisBases.length > 1 && (
-          <>
-            <span>
-              <b>Analysis Basis</b>:
-              <span className="align-middle">
-                <Info
-                  className="align-baseline"
-                  data-tip
-                  data-for="analysis-basis-help"
-                />
-              </span>
-              <TooltipWithMarkdown
-                tooltipId="analysis-basis-help"
-                markdown={analysisBasisHelpMarkdown}
-              />
+        <Row noGutters>
+          <Col lg="4" xl="2">
+            <Card className="sticky-top" style={{ marginRight: "1rem", marginTop: "1.5rem", top: "1.5rem" }}>
+              <Card.Header as="h5" style={{ paddingLeft: "0.5rem" }}>Results Config</Card.Header>
+              <Card.Body className="border-left-0 border-right-0 border-bottom-0" style={{ padding: "0.5rem" }}>
+                {allAnalysisBases.length > 1 && (
+                  <>
+                    <div>
+                      <b>Analysis Basis</b>:
+                      <span className="align-middle">
+                        <Info
+                          className="align-baseline"
+                          data-tip
+                          data-for="analysis-basis-help"
+                        />
+                      </span>
+                      <TooltipWithMarkdown
+                        tooltipId="analysis-basis-help"
+                        markdown={analysisBasisHelpMarkdown}
+                      />
+                    </div>
+                    {allAnalysisBases.map((basis) => (
+                      <div
+                        style={{ marginTop: "0.25rem", marginLeft: "0.5rem" }}
+                        data-testid="analysis-basis-results-selector"
+                      >
+                        <Form.Check
+                          inline
+                          radioGroup="analysis-basis-group"
+                          type="radio"
+                          key={`${basis}_radio_option`}
+                          onChange={() => setSelectedAnalysisBasis(basis)}
+                          label={basis}
+                          checked={basis === selectedAnalysisBasis}
+                          data-testid={`${basis}-radio`}
+                        />
+                      </div>
+                    ))}
             </span>
-            <span
-              style={{ margin: 8 }}
-              data-testid="analysis-basis-results-selector"
-            >
-              {allAnalysisBases.map((basis) => (
-                <Form.Check
-                  inline
-                  radioGroup="analysis-basis-group"
-                  type="radio"
-                  key={`${basis}_radio_option`}
-                  onChange={() => setSelectedAnalysisBasis(basis)}
-                  label={basis}
-                  checked={basis === selectedAnalysisBasis}
-                  data-testid={`${basis}-radio`}
-                />
-              ))}
-            </span>
-          </>
-        )}
-
-        {allSegments.length > 1 && (
-          <>
-            <h6>
-              Segment:
-              <span className="align-middle">
-                <Info
-                  className="align-baseline"
-                  data-tip
-                  data-for="segments-help"
-                />
-              </span>
-              <TooltipWithMarkdown
-                tooltipId="segments-help"
-                markdown={segmentHelpMarkdown}
-              />
-            </h6>
-            <span data-testid="segment-results-selector">
-              <Select
-                classNamePrefix="segmentation"
-                onChange={(option) => setSelectedSegment(option!.value)}
-                options={segmentOptions}
-                value={segmentOptions.find(
-                  (option) => option.value === selectedSegment,
+                  </>
                 )}
-              />
-            </span>
-          </>
-        )}
+                {allSegments.length > 1 && (
+                  <>
+                    <div style={{ marginTop: "1rem" }}>
+                      <b>Segment</b>:
+                      <span className="align-middle">
+                        <Info
+                          className="align-baseline"
+                          data-tip
+                          data-for="segments-help"
+                        />
+                      </span>
+                      <TooltipWithMarkdown
+                        tooltipId="segments-help"
+                        markdown={segmentHelpMarkdown}
+                      />
+                    </div>
+                    {allSegments.map((segment) => (
+                      <div style={{ marginTop: "0.25rem", marginLeft: "0.5rem" }} data-testid="segment-results-selector">
+                        <Form.Check
+                          inline
+                          radioGroup="segment-radio-group"
+                          type="radio"
+                          key={`${segment}_radio_option`}
+                          onChange={() => setSelectedSegment(segment)}
+                          label={segment}
+                          checked={segment === selectedSegment}
+                          data-testid={`${segment}-radio`}
+                        />
+                      </div>
+                    ))}
+                  </>
+                )}
+                {analysis?.metadata?.analysis_start_time && (
+                  <div style={{ marginTop: "1.5rem" }}>
+                    Results last calculated:{" "}
+                    <b>
+                      {new Date(analysis?.metadata?.analysis_start_time).toLocaleString(
+                        undefined,
+                        { timeZone: "UTC", timeZoneName: "short" },
+                      )}
+                    </b>
+                  </div>
+                )}
+              </Card.Body>
+            </Card>
+          </Col>
+          <Col>
+            <h3 className="h4 mb-3 mt-4" id="overview">
+              Overview
+            </h3>
+            <p className="mb-4">
+              <b>Hypothesis</b>: {experiment.hypothesis}
+            </p>
 
-        <h3 className="h4 mb-3 mt-4" id="overview">
-          Overview
-        </h3>
-        <p className="mb-4">
-          <b>Hypothesis</b>: {experiment.hypothesis}
-        </p>
+            {analysis.overall?.[selectedAnalysisBasis]?.[selectedSegment] &&
+              Object.keys(
+                analysis.overall?.[selectedAnalysisBasis]?.[selectedSegment] || {},
+              ).length > 0 && (
+                <TableWithTabComparison
+                  {...{ experiment }}
+                  Table={TableHighlights}
+                  className="mb-2 border-top-0"
+                  analysisBasis={selectedAnalysisBasis}
+                  segment={selectedSegment}
+                />
+              )}
+            <TableHighlightsOverview {...{ experiment }} />
 
-        {analysis.overall?.[selectedAnalysisBasis]?.[selectedSegment] &&
-          Object.keys(
-            analysis.overall?.[selectedAnalysisBasis]?.[selectedSegment] || {},
-          ).length > 0 && (
-            <TableWithTabComparison
-              {...{ experiment }}
-              Table={TableHighlights}
-              className="mb-2 border-top-0"
-              analysisBasis={selectedAnalysisBasis}
-              segment={selectedSegment}
-            />
-          )}
-        <TableHighlightsOverview {...{ experiment }} />
-
-        <div id="results_summary">
-          <h2 className="h4 mb-3">Results Summary</h2>
-          {analysis.overall?.[selectedAnalysisBasis]?.[selectedSegment] &&
-            Object.keys(
-              analysis.overall?.[selectedAnalysisBasis]?.[selectedSegment] ||
-                {},
-            ).length > 0 && (
-              <TableWithTabComparison
-                {...{ experiment }}
-                Table={TableResults}
-                className="rounded-bottom mb-3 border-top-0"
-                analysisBasis={selectedAnalysisBasis}
-                segment={selectedSegment}
-                isDesktop={
-                  experiment.application ===
-                  NimbusExperimentApplicationEnum.DESKTOP
-                }
-              />
-            )}
-
-          {analysis.weekly?.[selectedAnalysisBasis]?.[selectedSegment] &&
-            Object.keys(
-              analysis.weekly?.[selectedAnalysisBasis]?.[selectedSegment] || {},
-            ).length > 0 && (
-              <TableWithTabComparison
-                Table={TableResultsWeekly}
-                analysisBasis={selectedAnalysisBasis}
-                segment={selectedSegment}
-                isDesktop={
-                  experiment.application ===
-                  NimbusExperimentApplicationEnum.DESKTOP
-                }
-              />
-            )}
-        </div>
-
-        <div>
-          <h2 className="h4 mb-3">Outcome Metrics</h2>
-          {controlBranchError}
-          {analysis.overall?.[selectedAnalysisBasis]?.[selectedSegment] &&
-          Object.keys(
-            analysis.overall?.[selectedAnalysisBasis]?.[selectedSegment] || {},
-          ).length > 0
-            ? experiment.primaryOutcomes?.map((slug) => {
-                const outcome = configOutcomes!.find((set) => {
-                  return set?.slug === slug;
-                });
-                return outcome?.metrics?.map((metric) => {
-                  if (
-                    !analysis!.overall![selectedAnalysisBasis]?.[
-                      selectedSegment
-                    ]?.[resultsContextValue.controlBranchName].branch_data[
-                      GROUP.OTHER
-                    ][metric?.slug!]
-                  ) {
-                    // Primary metric does not have data to display. Show error if there is one.
-                    if (
-                      metric?.slug &&
-                      analysis?.errors &&
-                      metric.slug in analysis.errors &&
-                      analysis.errors[metric.slug].length > 0
-                    ) {
-                      return (
-                        <>
-                          <MetricHeader
-                            key={metric.slug}
-                            outcomeSlug={metric.slug!}
-                            outcomeDefaultName={metric?.friendlyName!}
-                            metricType={METRIC_TYPE.PRIMARY}
-                          />
-                          <AnalysisErrorAlert
-                            errors={analysis.errors[metric.slug]}
-                          />
-                        </>
-                      );
-                    }
-                  }
-                  return (
-                    <TableMetricCount
-                      key={metric?.slug}
-                      outcomeSlug={metric?.slug!}
-                      outcomeDefaultName={metric?.friendlyName!}
-                      group={GROUP.OTHER}
-                      metricType={METRIC_TYPE.PRIMARY}
-                      analysisBasis={selectedAnalysisBasis}
-                      segment={selectedSegment}
-                    />
-                  );
-                });
-              })
-            : // no Overall results, check for errors in primary outcome metrics
-              analysis?.errors &&
-              Object.keys(analysis.errors).length > 1 &&
-              getErrorsForOutcomes(experiment.primaryOutcomes, true)}
-          {analysis.overall?.[selectedAnalysisBasis]?.[selectedSegment] &&
-          Object.keys(
-            analysis.overall?.[selectedAnalysisBasis]?.[selectedSegment] || {},
-          ).length > 0
-            ? experiment.secondaryOutcomes?.map((slug) => {
-                const outcome = configOutcomes!.find((set) => {
-                  return set?.slug === slug;
-                });
-
-                return (
-                  <TableMetricCount
-                    key={outcome!.slug}
-                    outcomeSlug={outcome!.slug!}
-                    outcomeDefaultName={outcome!.friendlyName!}
-                    group={GROUP.OTHER}
-                    metricType={METRIC_TYPE.DEFAULT_SECONDARY}
+            <div id="results_summary">
+              <h2 className="h4 mb-3">Results Summary</h2>
+              {analysis.overall?.[selectedAnalysisBasis]?.[selectedSegment] &&
+                Object.keys(
+                  analysis.overall?.[selectedAnalysisBasis]?.[selectedSegment] ||
+                    {},
+                ).length > 0 && (
+                  <TableWithTabComparison
+                    {...{ experiment }}
+                    Table={TableResults}
+                    className="rounded-bottom mb-3 border-top-0"
                     analysisBasis={selectedAnalysisBasis}
                     segment={selectedSegment}
-                  />
-                );
-              })
-            : // no Overall results, check for errors in secondary outcome metrics
-              analysis?.errors &&
-              Object.keys(analysis.errors).length > 1 &&
-              getErrorsForOutcomes(experiment.secondaryOutcomes, false)}
-          {analysis.other_metrics &&
-            Object.keys(analysis.other_metrics).map((group: string) => {
-              const [open, setOpen] = groupStates[group];
-              const groupName = group.replace("_", " ");
-
-              return (
-                <div key={`${group}-toggle`}>
-                  <span
-                    onClick={
-                      // istanbul ignore next - test covering this line intermittently fails
-                      () => setOpen(!open)
+                    isDesktop={
+                      experiment.application ===
+                      NimbusExperimentApplicationEnum.DESKTOP
                     }
-                    aria-controls="group"
-                    aria-expanded={open}
-                    className="text-primary btn mb-5"
-                  >
-                    {open ? (
-                      <>
-                        <CollapseMinus />
-                        <span style={{ textTransform: "capitalize" }}>
-                          Hide {groupName}
-                        </span>
-                      </>
-                    ) : (
-                      <>
-                        <ExpandPlus />
-                        <span style={{ textTransform: "capitalize" }}>
-                          Show {groupName}
-                        </span>
-                      </>
-                    )}
-                  </span>
-                  <Collapse in={open}>
-                    <div>
-                      {analysis.overall?.[selectedAnalysisBasis]?.[
-                        selectedSegment
-                      ] &&
-                        Object.keys(
-                          analysis.overall?.[selectedAnalysisBasis]?.[
-                            selectedSegment
-                          ] || {},
-                        ).length > 0 &&
-                        analysis.other_metrics?.[group] &&
-                        Object.keys(analysis.other_metrics[group]).map(
-                          (metric: string) => (
-                            <TableMetricCount
-                              key={metric}
-                              outcomeSlug={metric}
-                              outcomeDefaultName={
-                                analysis.other_metrics![group][metric]
-                              }
-                              {...{ group }}
-                              analysisBasis={selectedAnalysisBasis}
-                              segment={selectedSegment}
-                            />
-                          ),
+                  />
+                )}
+
+              {analysis.weekly?.[selectedAnalysisBasis]?.[selectedSegment] &&
+                Object.keys(
+                  analysis.weekly?.[selectedAnalysisBasis]?.[selectedSegment] || {},
+                ).length > 0 && (
+                  <TableWithTabComparison
+                    Table={TableResultsWeekly}
+                    analysisBasis={selectedAnalysisBasis}
+                    segment={selectedSegment}
+                    isDesktop={
+                      experiment.application ===
+                      NimbusExperimentApplicationEnum.DESKTOP
+                    }
+                  />
+                )}
+            </div>
+
+            <div>
+              <h2 className="h4 mb-3">Outcome Metrics</h2>
+              {controlBranchError}
+              {analysis.overall?.[selectedAnalysisBasis]?.[selectedSegment] &&
+              Object.keys(
+                analysis.overall?.[selectedAnalysisBasis]?.[selectedSegment] || {},
+              ).length > 0
+                ? experiment.primaryOutcomes?.map((slug) => {
+                    const outcome = configOutcomes!.find((set) => {
+                      return set?.slug === slug;
+                    });
+                    return outcome?.metrics?.map((metric) => {
+                      if (
+                        !analysis!.overall![selectedAnalysisBasis]?.[
+                          selectedSegment
+                        ]?.[resultsContextValue.controlBranchName].branch_data[
+                          GROUP.OTHER
+                        ][metric?.slug!]
+                      ) {
+                        // Primary metric does not have data to display. Show error if there is one.
+                        if (
+                          metric?.slug &&
+                          analysis?.errors &&
+                          metric.slug in analysis.errors &&
+                          analysis.errors[metric.slug].length > 0
+                        ) {
+                          return (
+                            <>
+                              <MetricHeader
+                                key={metric.slug}
+                                outcomeSlug={metric.slug!}
+                                outcomeDefaultName={metric?.friendlyName!}
+                                metricType={METRIC_TYPE.PRIMARY}
+                              />
+                              <AnalysisErrorAlert
+                                errors={analysis.errors[metric.slug]}
+                              />
+                            </>
+                          );
+                        }
+                      }
+                      return (
+                        <TableMetricCount
+                          key={metric?.slug}
+                          outcomeSlug={metric?.slug!}
+                          outcomeDefaultName={metric?.friendlyName!}
+                          group={GROUP.OTHER}
+                          metricType={METRIC_TYPE.PRIMARY}
+                          analysisBasis={selectedAnalysisBasis}
+                          segment={selectedSegment}
+                        />
+                      );
+                    });
+                  })
+                : // no Overall results, check for errors in primary outcome metrics
+                  analysis?.errors &&
+                  Object.keys(analysis.errors).length > 1 &&
+                  getErrorsForOutcomes(experiment.primaryOutcomes, true)}
+              {analysis.overall?.[selectedAnalysisBasis]?.[selectedSegment] &&
+              Object.keys(
+                analysis.overall?.[selectedAnalysisBasis]?.[selectedSegment] || {},
+              ).length > 0
+                ? experiment.secondaryOutcomes?.map((slug) => {
+                    const outcome = configOutcomes!.find((set) => {
+                      return set?.slug === slug;
+                    });
+
+                    return (
+                      <TableMetricCount
+                        key={outcome!.slug}
+                        outcomeSlug={outcome!.slug!}
+                        outcomeDefaultName={outcome!.friendlyName!}
+                        group={GROUP.OTHER}
+                        metricType={METRIC_TYPE.DEFAULT_SECONDARY}
+                        analysisBasis={selectedAnalysisBasis}
+                        segment={selectedSegment}
+                      />
+                    );
+                  })
+                : // no Overall results, check for errors in secondary outcome metrics
+                  analysis?.errors &&
+                  Object.keys(analysis.errors).length > 1 &&
+                  getErrorsForOutcomes(experiment.secondaryOutcomes, false)}
+              {analysis.other_metrics &&
+                Object.keys(analysis.other_metrics).map((group: string) => {
+                  const [open, setOpen] = groupStates[group];
+                  const groupName = group.replace("_", " ");
+
+                  return (
+                    <div key={`${group}-toggle`}>
+                      <span
+                        onClick={
+                          // istanbul ignore next - test covering this line intermittently fails
+                          () => setOpen(!open)
+                        }
+                        aria-controls="group"
+                        aria-expanded={open}
+                        className="text-primary btn mb-5"
+                      >
+                        {open ? (
+                          <>
+                            <CollapseMinus />
+                            <span style={{ textTransform: "capitalize" }}>
+                              Hide {groupName}
+                            </span>
+                          </>
+                        ) : (
+                          <>
+                            <ExpandPlus />
+                            <span style={{ textTransform: "capitalize" }}>
+                              Show {groupName}
+                            </span>
+                          </>
                         )}
+                      </span>
+                      <Collapse in={open}>
+                        <div>
+                          {analysis.overall?.[selectedAnalysisBasis]?.[
+                            selectedSegment
+                          ] &&
+                            Object.keys(
+                              analysis.overall?.[selectedAnalysisBasis]?.[
+                                selectedSegment
+                              ] || {},
+                            ).length > 0 &&
+                            analysis.other_metrics?.[group] &&
+                            Object.keys(analysis.other_metrics[group]).map(
+                              (metric: string) => (
+                                <TableMetricCount
+                                  key={metric}
+                                  outcomeSlug={metric}
+                                  outcomeDefaultName={
+                                    analysis.other_metrics![group][metric]
+                                  }
+                                  {...{ group }}
+                                  analysisBasis={selectedAnalysisBasis}
+                                  segment={selectedSegment}
+                                />
+                              ),
+                            )}
+                        </div>
+                      </Collapse>
                     </div>
-                  </Collapse>
-                </div>
-              );
-            })}
-          {otherMetricErrors.length > 0 && (
-            <>
-              <h3 className="h5 mb-3">
-                <i>Other Metric Errors</i>
-              </h3>
-              {otherMetricErrors.map((errorMetric) => (
+                  );
+                })}
+              {otherMetricErrors.length > 0 && (
                 <>
-                  <MetricHeader
-                    key={errorMetric}
-                    outcomeSlug={errorMetric}
-                    outcomeDefaultName={errorMetric}
-                    metricType={METRIC_TYPE.USER_SELECTED_SECONDARY}
-                  />
-                  <AnalysisErrorAlert
-                    errors={filterErrors(
-                      analysis.errors?.[errorMetric] || [],
-                      selectedAnalysisBasis,
-                      selectedSegment,
-                    )}
-                  />
+                  <h3 className="h5 mb-3">
+                    <i>Other Metric Errors</i>
+                  </h3>
+                  {otherMetricErrors.map((errorMetric) => (
+                    <>
+                      <MetricHeader
+                        key={errorMetric}
+                        outcomeSlug={errorMetric}
+                        outcomeDefaultName={errorMetric}
+                        metricType={METRIC_TYPE.USER_SELECTED_SECONDARY}
+                      />
+                      <AnalysisErrorAlert
+                        errors={filterErrors(
+                          analysis.errors?.[errorMetric] || [],
+                          selectedAnalysisBasis,
+                          selectedSegment,
+                        )}
+                      />
+                    </>
+                  ))}
                 </>
-              ))}
-            </>
-          )}
-        </div>
+              )}
+            </div>
+          </Col>
+        </Row>
       </ResultsContext.Provider>
     </AppLayoutWithExperiment>
   );


### PR DESCRIPTION
Because

- Results page config options should be visible throughout the page

This commit

- puts the config options in a card that is sticky to the top of page while scrolling

Fixes #9993 