### PR TITLE
bug(nimbus): fix z index ordering of results config

### DIFF
--- a/experimenter/experimenter/nimbus-ui/src/components/PageResults/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageResults/index.tsx
@@ -238,7 +238,6 @@ const PageResults: React.FunctionComponent<RouteComponentProps> = () => {
                 marginRight: "1rem",
                 marginTop: "1.5rem",
                 top: "1.5rem",
-                zIndex: 1,
               }}
             >
               <Card.Header as="h5" style={{ paddingLeft: "0.5rem" }}>

--- a/experimenter/experimenter/nimbus-ui/src/components/PageResults/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageResults/index.tsx
@@ -238,6 +238,7 @@ const PageResults: React.FunctionComponent<RouteComponentProps> = () => {
                 marginRight: "1rem",
                 marginTop: "1.5rem",
                 top: "1.5rem",
+                zIndex: 1,
               }}
             >
               <Card.Header as="h5" style={{ paddingLeft: "0.5rem" }}>

--- a/experimenter/experimenter/nimbus-ui/src/styles/index.scss
+++ b/experimenter/experimenter/nimbus-ui/src/styles/index.scss
@@ -158,6 +158,8 @@ select.form-control.is-warning {
   > p:last-child {
     margin-bottom: 0;
   }
+  // override the react-tooltip default 999 to match bootstrap's tooltip z-index
+  z-index: 1080 !important; 
 }
 
 .cursor-copy {


### PR DESCRIPTION
Because

- Bootstrap's z-index for card is 1020 (and all z-indexes are 1000-1100) and react-tooltip uses 999

This commit

- Manually sets the Results page config card to a z-index of 1 so it appears behind react-tooltip

Fixes #10002