### PR TITLE
Fixes #9943 feat(nimbus): Use different emojis for QA statuses

### DIFF
--- a/experimenter/experimenter/nimbus-ui/src/components/PageSummary/index.test.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageSummary/index.test.tsx
@@ -715,7 +715,7 @@ describe("PageSummary", () => {
     [NimbusExperimentQAStatusEnum.YELLOW, QA_STATUS_WITH_EMOJI.YELLOW[0]],
     [NimbusExperimentQAStatusEnum.RED, QA_STATUS_WITH_EMOJI.RED[0]],
   ])(
-    "renders qa status pill for each status",
+    "renders qa status pill for each qa status",
     async (qaStatus: NimbusExperimentQAStatusEnum, qaLabel: string) => {
       const { mock } = mockExperimentQuery("demo-slug", {
         status: NimbusExperimentStatusEnum.LIVE,
@@ -727,9 +727,46 @@ describe("PageSummary", () => {
       render(<Subject mocks={[mock]} />);
       const qaStatusPill = await screen.findByTestId("pill-qa-status");
       expect(qaStatusPill).toBeInTheDocument();
-      expect(screen.getByText(qaLabel)).toBeInTheDocument();
+      expect(qaStatusPill).toHaveTextContent(qaLabel);
     },
   );
+
+  it.each([
+    [NimbusExperimentStatusEnum.DRAFT],
+    [NimbusExperimentStatusEnum.LIVE],
+    [NimbusExperimentStatusEnum.PREVIEW],
+    [NimbusExperimentStatusEnum.COMPLETE],
+  ])(
+    "renders qa status pill for each status",
+    async (experimentStatus: NimbusExperimentStatusEnum) => {
+      const { mock } = mockExperimentQuery("demo-slug", {
+        status: experimentStatus,
+        publishStatus: NimbusExperimentPublishStatusEnum.IDLE,
+        qaStatus: NimbusExperimentQAStatusEnum.GREEN,
+        statusNext: null,
+      });
+
+      render(<Subject mocks={[mock]} />);
+      const qaStatusPill = await screen.findByTestId("pill-qa-status");
+      expect(qaStatusPill).toBeInTheDocument();
+      expect(qaStatusPill).toHaveTextContent(QA_STATUS_WITH_EMOJI.GREEN[0]);
+    },
+  );
+
+  it("renders qa status pill when archived", async () => {
+    const { mock } = mockExperimentQuery("demo-slug", {
+      status: NimbusExperimentStatusEnum.COMPLETE,
+      publishStatus: NimbusExperimentPublishStatusEnum.IDLE,
+      qaStatus: NimbusExperimentQAStatusEnum.GREEN,
+      statusNext: null,
+      isArchived: true,
+    });
+
+    render(<Subject mocks={[mock]} />);
+    const qaStatusPill = await screen.findByTestId("pill-qa-status");
+    expect(qaStatusPill).toBeInTheDocument();
+    expect(qaStatusPill).toHaveTextContent(QA_STATUS_WITH_EMOJI.GREEN[0]);
+  });
 
   it("will not render qa status pill when status is not set", async () => {
     const { mock, experiment } = mockExperimentQuery("demo-slug", {

--- a/experimenter/experimenter/nimbus-ui/src/components/PageSummary/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageSummary/index.tsx
@@ -129,6 +129,7 @@ const PageSummary = (props: RouteComponentProps) => {
 
   const {
     publishStatus,
+    qaStatus,
     canReview,
     reviewRequest: reviewRequestEvent,
     rejection: rejectionEvent,
@@ -213,6 +214,13 @@ const PageSummary = (props: RouteComponentProps) => {
       <h5 className="mb-3">
         Timeline
         {status.live && <StatusPills {...{ experiment, status }} />}
+        {qaStatus != null &&
+          (() => {
+            const [label, color] = qaStatusLabel(qaStatus!);
+            return (
+              <StatusPill testId="pill-qa-status" label={label} color={color} />
+            );
+          })()}
       </h5>
 
       <SummaryTimeline {...{ experiment }} />
@@ -308,24 +316,14 @@ const PageSummary = (props: RouteComponentProps) => {
 
 export default PageSummary;
 
-export function qaStatusLabel(status: NimbusExperimentQAStatusEnum) {
-  if (status === NimbusExperimentQAStatusEnum.GREEN) {
-    return QA_STATUS_WITH_EMOJI.GREEN[0];
-  } else if (status === NimbusExperimentQAStatusEnum.YELLOW) {
-    return QA_STATUS_WITH_EMOJI.YELLOW[0];
-  } else {
-    return QA_STATUS_WITH_EMOJI.RED[0];
-  }
-}
+export function qaStatusLabel(qaStatus: NimbusExperimentQAStatusEnum) {
+  const statuses = {
+    [NimbusExperimentQAStatusEnum.GREEN]: QA_STATUS_WITH_EMOJI.GREEN,
+    [NimbusExperimentQAStatusEnum.YELLOW]: QA_STATUS_WITH_EMOJI.YELLOW,
+    [NimbusExperimentQAStatusEnum.RED]: QA_STATUS_WITH_EMOJI.RED,
+  };
 
-export function qaStatusColor(status: NimbusExperimentQAStatusEnum) {
-  if (status === NimbusExperimentQAStatusEnum.GREEN) {
-    return QA_STATUS_WITH_EMOJI.GREEN[1];
-  } else if (status === NimbusExperimentQAStatusEnum.YELLOW) {
-    return QA_STATUS_WITH_EMOJI.YELLOW[1];
-  } else {
-    return QA_STATUS_WITH_EMOJI.RED[1];
-  }
+  return statuses[qaStatus] || QA_STATUS_WITH_EMOJI.RED;
 }
 
 const StatusPills = ({
@@ -356,13 +354,6 @@ const StatusPills = ({
         testId="pill-dirty-unpublished"
         label="Unpublished changes"
         color={"danger"}
-      />
-    )}
-    {experiment.qaStatus != null && (
-      <StatusPill
-        testId="pill-qa-status"
-        label={qaStatusLabel(experiment.qaStatus)}
-        color={qaStatusColor(experiment.qaStatus)}
       />
     )}
   </>

--- a/experimenter/experimenter/nimbus-ui/src/components/Summary/TableQA/QAEditor.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/Summary/TableQA/QAEditor.tsx
@@ -11,6 +11,7 @@ import Row from "react-bootstrap/Row";
 import { FormProvider } from "react-hook-form";
 import { UseQAResult } from "src/components/Summary/TableQA/useQA";
 import { useCommonForm } from "src/hooks";
+import { QA_STATUS_WITH_EMOJI } from "src/lib/constants";
 import { NimbusExperimentQAStatusEnum } from "src/types/globalTypes";
 
 export const qaEditorFieldNames = ["qaStatus"] as const;
@@ -60,17 +61,17 @@ export const QAEditor = ({
     {
       label: NimbusExperimentQAStatusEnum.RED,
       value: NimbusExperimentQAStatusEnum.RED,
-      description: NimbusExperimentQAStatusEnum.RED,
+      description: QA_STATUS_WITH_EMOJI.RED[0],
     },
     {
       label: NimbusExperimentQAStatusEnum.YELLOW,
       value: NimbusExperimentQAStatusEnum.YELLOW,
-      description: NimbusExperimentQAStatusEnum.YELLOW,
+      description: QA_STATUS_WITH_EMOJI.YELLOW[0],
     },
     {
       label: NimbusExperimentQAStatusEnum.GREEN,
       value: NimbusExperimentQAStatusEnum.GREEN,
-      description: NimbusExperimentQAStatusEnum.GREEN,
+      description: QA_STATUS_WITH_EMOJI.GREEN[0],
     },
   ] as const;
 
@@ -132,11 +133,6 @@ export const QAEditor = ({
 
           <Form.Group as={Row} className="mb-0 pl-1">
             <Row className="ml-0 flex-fill pl-0">
-              <Col className="ml-2 mr-0 pr-0 w-25">
-                <Form.Label>
-                  <p className="font-weight-bold">QA Status: </p>
-                </Form.Label>
-              </Col>
               <Col className="ml-4 flex-fill pl-0 pr-8 mr-4">
                 <Form.Control
                   as="select"
@@ -145,7 +141,7 @@ export const QAEditor = ({
                   onSubmit={handleSave}
                   onChange={(e) =>
                     setQaStatus(
-                      e.target
+                      e.target.value
                         ? (e.target.value as NimbusExperimentQAStatusEnum)
                         : null,
                     )

--- a/experimenter/experimenter/nimbus-ui/src/components/Summary/TableQA/QAEditor.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/Summary/TableQA/QAEditor.tsx
@@ -60,17 +60,17 @@ export const QAEditor = ({
     {
       label: NimbusExperimentQAStatusEnum.RED,
       value: NimbusExperimentQAStatusEnum.RED,
-      description: "🔴 RED ",
+      description: NimbusExperimentQAStatusEnum.RED,
     },
     {
       label: NimbusExperimentQAStatusEnum.YELLOW,
       value: NimbusExperimentQAStatusEnum.YELLOW,
-      description: "🟡 YELLOW ",
+      description: NimbusExperimentQAStatusEnum.YELLOW,
     },
     {
       label: NimbusExperimentQAStatusEnum.GREEN,
       value: NimbusExperimentQAStatusEnum.GREEN,
-      description: "🟢 GREEN ",
+      description: NimbusExperimentQAStatusEnum.GREEN,
     },
   ] as const;
 

--- a/experimenter/experimenter/nimbus-ui/src/components/Summary/TableQA/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/Summary/TableQA/index.tsx
@@ -7,9 +7,14 @@ import { Button, Card, Col, Row, Table } from "react-bootstrap";
 import NotSet from "src/components/NotSet";
 import QAEditor from "src/components/Summary/TableQA/QAEditor";
 import { UseQAResult } from "src/components/Summary/TableQA/useQA";
-import { NimbusExperimentQAStatusEnum } from "src/types/globalTypes";
+import { QA_STATUS_WITH_EMOJI } from "src/lib/constants";
+import {
+  NimbusExperimentPublishStatusEnum,
+  NimbusExperimentQAStatusEnum,
+} from "src/types/globalTypes";
 
 type TableQAProps = {
+  publishStatus: NimbusExperimentPublishStatusEnum | null;
   qaStatus?: NimbusExperimentQAStatusEnum | null;
 } & UseQAResult;
 
@@ -17,8 +22,18 @@ export type QAEditorProps = UseQAResult & {
   setShowEditor: (state: boolean) => void;
 };
 
+export function qaStatusLabel(status: NimbusExperimentQAStatusEnum) {
+  if (status === NimbusExperimentQAStatusEnum.GREEN) {
+    return QA_STATUS_WITH_EMOJI.GREEN;
+  } else if (status === NimbusExperimentQAStatusEnum.YELLOW) {
+    return QA_STATUS_WITH_EMOJI.YELLOW;
+  } else {
+    return QA_STATUS_WITH_EMOJI.RED;
+  }
+}
+
 const TableQA = (props: TableQAProps) => {
-  const { qaStatus, showEditor, setShowEditor } = props;
+  const { publishStatus, qaStatus, showEditor, setShowEditor } = props;
 
   const onClickEdit = useCallback(() => setShowEditor(true), [setShowEditor]);
 
@@ -33,7 +48,7 @@ const TableQA = (props: TableQAProps) => {
           <Row>
             <Col className="my-1">QA</Col>
             <Col className="text-right">
-              {
+              {publishStatus !== NimbusExperimentPublishStatusEnum.REVIEW && (
                 <Button
                   onClick={onClickEdit}
                   variant="outline-primary"
@@ -43,7 +58,7 @@ const TableQA = (props: TableQAProps) => {
                 >
                   Edit
                 </Button>
-              }
+              )}
             </Col>
           </Row>
         </Card.Header>
@@ -56,7 +71,7 @@ const TableQA = (props: TableQAProps) => {
                   data-testid="experiment-qa-status"
                   className="text-monospace border-top-0 border-bottom-2"
                 >
-                  {qaStatus || <NotSet />}
+                  {qaStatus ? qaStatusLabel(qaStatus)[0] : <NotSet />}
                 </td>
                 <th className="border-top-0 w-75 border-bottom-2"></th>
                 <td className="border-top-0 border-bottom-2" />

--- a/experimenter/experimenter/nimbus-ui/src/components/Summary/TableQA/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/Summary/TableQA/index.tsx
@@ -22,14 +22,14 @@ export type QAEditorProps = UseQAResult & {
   setShowEditor: (state: boolean) => void;
 };
 
-export function qaStatusLabel(status: NimbusExperimentQAStatusEnum) {
-  if (status === NimbusExperimentQAStatusEnum.GREEN) {
-    return QA_STATUS_WITH_EMOJI.GREEN;
-  } else if (status === NimbusExperimentQAStatusEnum.YELLOW) {
-    return QA_STATUS_WITH_EMOJI.YELLOW;
-  } else {
-    return QA_STATUS_WITH_EMOJI.RED;
-  }
+export function qaStatusLabel(qaStatus: NimbusExperimentQAStatusEnum) {
+  const statuses = {
+    [NimbusExperimentQAStatusEnum.GREEN]: QA_STATUS_WITH_EMOJI.GREEN,
+    [NimbusExperimentQAStatusEnum.YELLOW]: QA_STATUS_WITH_EMOJI.YELLOW,
+    [NimbusExperimentQAStatusEnum.RED]: QA_STATUS_WITH_EMOJI.RED,
+  };
+
+  return statuses[qaStatus] || QA_STATUS_WITH_EMOJI.RED;
 }
 
 const TableQA = (props: TableQAProps) => {

--- a/experimenter/experimenter/nimbus-ui/src/components/Summary/TableQA/mocks.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/Summary/TableQA/mocks.tsx
@@ -7,6 +7,7 @@ import { RouterSlugProvider } from "src/lib/test-utils";
 
 export const Subject = ({
   id = 123,
+  publishStatus = null,
   qaStatus = null,
   isLoading = false,
   onSubmit = async (data) => {},
@@ -27,6 +28,7 @@ export const Subject = ({
         <TableQA
           {...{
             id,
+            publishStatus,
             qaStatus,
             isLoading,
             onSubmit,

--- a/experimenter/experimenter/nimbus-ui/src/components/Summary/TableQA/useQA.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/Summary/TableQA/useQA.tsx
@@ -18,7 +18,7 @@ import {
 
 export type UseQAExperimentSubset = Pick<
   getExperiment_experimentBySlug,
-  "id" | "qaStatus"
+  "id" | "publishStatus" | "qaStatus"
 >;
 
 export type UseQAResult = UseQAExperimentSubset & {
@@ -47,7 +47,7 @@ export const useQA = (
   const onSubmit = useCallback(
     ({ id }: UseQAExperimentSubset, refetch?: () => Promise<unknown>) =>
       async (data: Record<string, any>) => {
-        const { qaStatus } = data;
+        const { publishStatus, qaStatus } = data;
 
         try {
           setIsLoading(true);

--- a/experimenter/experimenter/nimbus-ui/src/types/globalTypes.ts
+++ b/experimenter/experimenter/nimbus-ui/src/types/globalTypes.ts
@@ -211,9 +211,9 @@ export enum NimbusExperimentPublishStatusEnum {
 }
 
 export enum NimbusExperimentQAStatusEnum {
-  GREEN = "✅ GREEN",
-  RED = "❌ RED",
-  YELLOW = "⚠️ YELLOW",
+  GREEN = "GREEN",
+  RED = "RED",
+  YELLOW = "YELLOW",
 }
 
 export enum NimbusExperimentStatusEnum {

--- a/experimenter/experimenter/nimbus-ui/src/types/globalTypes.ts
+++ b/experimenter/experimenter/nimbus-ui/src/types/globalTypes.ts
@@ -211,9 +211,9 @@ export enum NimbusExperimentPublishStatusEnum {
 }
 
 export enum NimbusExperimentQAStatusEnum {
-  GREEN = "GREEN",
-  RED = "RED",
-  YELLOW = "YELLOW",
+  GREEN = "✅ GREEN",
+  RED = "❌ RED",
+  YELLOW = "⚠️ YELLOW",
 }
 
 export enum NimbusExperimentStatusEnum {


### PR DESCRIPTION
Because...

* We want to use easily distinguishable emojis to differentiate between QA statuses

This commit...

* Updates the Summary page to use the emoji + QA status, not just the raw Enum value
* Removes the "QA" title in QAEditor, since it's redundant if we're using the "✅ QA: Green" format
* Uses a single helper method to get the const values for QA status in PageSummary
* Doesn't render the "Edit" button for the QAEditor if you're in review

Fixes #9943