### PR TITLE
Fixes #9903 feat(nimbus): Add UI for QA comments

### DIFF
--- a/experimenter/experimenter/experiments/api/v5/serializers.py
+++ b/experimenter/experimenter/experiments/api/v5/serializers.py
@@ -899,7 +899,11 @@ class NimbusExperimentSerializer(
         required=False,
     )
     qa_comment = serializers.CharField(
-        min_length=0, max_length=4096, required=False, allow_blank=True
+        min_length=0,
+        max_length=4096,
+        required=False,
+        allow_blank=True,
+        allow_null=True,
     )
 
     class Meta:

--- a/experimenter/experimenter/nimbus-ui/src/components/Summary/TableQA/QAEditor.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/Summary/TableQA/QAEditor.tsx
@@ -136,14 +136,14 @@ export const QAEditor = ({
           <Form.Group
             as={Row}
             data-testid="qa-status-section"
-            className="mb-0 pl-1"
+            className="mb-0 pl-3"
           >
-            <Col className="ml-2 mr-0 pr-0 w-25">
+            <Col className="mr-0 pl-0 pr-0 w-25">
               <Form.Label>
                 <p className="font-weight-bold">QA Status: </p>
               </Form.Label>
             </Col>
-            <Col className="ml-4 flex-fill pl-0 pr-8 mr-4">
+            <Col className="flex-fill pl-0 pr-8 mr-4">
               <Form.Control
                 as="select"
                 className="ml-0 mr-0"
@@ -173,13 +173,14 @@ export const QAEditor = ({
           <Form.Group
             as={Row}
             data-testid="qa-comment-section"
-            className="ml-1"
+            className="mt-4 pl-3"
           >
             <Form.Label className="font-weight-bold">Comment:</Form.Label>
             <Form.Control
               as="textarea"
               rows={5}
               {...formControlAttrs("qaComment")}
+              className="pr-8 mr-4"
             />
           </Form.Group>
         </Form>

--- a/experimenter/experimenter/nimbus-ui/src/components/Summary/TableQA/QAEditor.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/Summary/TableQA/QAEditor.tsx
@@ -182,6 +182,7 @@ export const QAEditor = ({
               {...formControlAttrs("qaComment")}
               className="pr-8 mr-4"
             />
+            <FormErrors name="qaComment" />
           </Form.Group>
         </Form>
       </FormProvider>

--- a/experimenter/experimenter/nimbus-ui/src/components/Summary/TableQA/QAEditor.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/Summary/TableQA/QAEditor.tsx
@@ -14,7 +14,7 @@ import { useCommonForm } from "src/hooks";
 import { QA_STATUS_WITH_EMOJI } from "src/lib/constants";
 import { NimbusExperimentQAStatusEnum } from "src/types/globalTypes";
 
-export const qaEditorFieldNames = ["qaStatus"] as const;
+export const qaEditorFieldNames = ["qaStatus", "qaComment"] as const;
 
 type QAEditorFieldName = typeof qaEditorFieldNames[number];
 
@@ -25,6 +25,7 @@ export type QAEditorProps = UseQAResult & {
 export const QAEditor = ({
   isLoading,
   qaStatus,
+  qaComment,
   setShowEditor,
   onSubmit,
   submitErrors,
@@ -33,6 +34,7 @@ export const QAEditor = ({
 }: QAEditorProps) => {
   const defaultValues = {
     qaStatus,
+    qaComment,
   };
 
   type DefaultValues = typeof defaultValues;
@@ -131,35 +133,54 @@ export const QAEditor = ({
             </Alert>
           )}
 
-          <Form.Group as={Row} className="mb-0 pl-1">
-            <Row className="ml-0 flex-fill pl-0">
-              <Col className="ml-4 flex-fill pl-0 pr-8 mr-4">
-                <Form.Control
-                  as="select"
-                  className="ml-0 mr-0"
-                  value={qaStatusField as NimbusExperimentQAStatusEnum}
-                  onSubmit={handleSave}
-                  onChange={(e) =>
-                    setQaStatus(
-                      e.target.value
-                        ? (e.target.value as NimbusExperimentQAStatusEnum)
-                        : null,
-                    )
-                  }
-                  id="qa-status-select"
-                  data-testid="qa-status"
-                >
-                  {qaStatusOptions.map(
-                    (item, idx) =>
-                      item && (
-                        <option key={idx} value={item.value}>
-                          {item.description}
-                        </option>
-                      ),
-                  )}
-                </Form.Control>
-              </Col>
-            </Row>
+          <Form.Group
+            as={Row}
+            data-testid="qa-status-section"
+            className="mb-0 pl-1"
+          >
+            <Col className="ml-2 mr-0 pr-0 w-25">
+              <Form.Label>
+                <p className="font-weight-bold">QA Status: </p>
+              </Form.Label>
+            </Col>
+            <Col className="ml-4 flex-fill pl-0 pr-8 mr-4">
+              <Form.Control
+                as="select"
+                className="ml-0 mr-0"
+                value={qaStatusField as NimbusExperimentQAStatusEnum}
+                onSubmit={handleSave}
+                onChange={(e) =>
+                  setQaStatus(
+                    e.target
+                      ? (e.target.value as NimbusExperimentQAStatusEnum)
+                      : null,
+                  )
+                }
+                id="qa-status-select"
+                data-testid="qa-status"
+              >
+                {qaStatusOptions.map(
+                  (item, idx) =>
+                    item && (
+                      <option key={idx} value={item.value}>
+                        {item.description}
+                      </option>
+                    ),
+                )}
+              </Form.Control>
+            </Col>
+          </Form.Group>
+          <Form.Group
+            as={Row}
+            data-testid="qa-comment-section"
+            className="ml-1"
+          >
+            <Form.Label className="font-weight-bold">Comment:</Form.Label>
+            <Form.Control
+              as="textarea"
+              rows={5}
+              {...formControlAttrs("qaComment")}
+            />
           </Form.Group>
         </Form>
       </FormProvider>

--- a/experimenter/experimenter/nimbus-ui/src/components/Summary/TableQA/index.test.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/Summary/TableQA/index.test.tsx
@@ -78,7 +78,7 @@ describe("TableQA", () => {
 
   it("does not render 'QA comment' row with no comment set", () => {
     render(<Subject {...{ qaStatus }} />);
-    expect(screen.getByTestId("qa-comment")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("qa-comment")).not.toBeInTheDocument();
   });
 });
 
@@ -89,20 +89,27 @@ describe("QAEditor", () => {
     expect(screen.queryByTestId("QAEditor")).toBeInTheDocument();
   });
 
-  it("renders as expected with content", () => {
+  it("renders as expected with content", async () => {
     render(
       <Subject
         {...{
           showEditor: true,
           qaStatus,
+          qaComment,
         }}
       />,
     );
     expect(screen.queryByTestId("QAEditor")).toBeInTheDocument();
     expect(screen.getByText("Save")).not.toBeDisabled();
     expect(screen.getByText("Cancel")).not.toBeDisabled();
-    expect(screen.queryByTestId("qa-status-section")).toBeInTheDocument();
-    expect(screen.queryByTestId("qa-comment-section")).not.toBeInTheDocument();
+
+    const qaStatusField = await screen.findByTestId("qa-status-section");
+    expect(qaStatusField).toBeInTheDocument();
+    expect(qaStatusField).toHaveTextContent(QA_STATUS_WITH_EMOJI.GREEN[0]);
+
+    const qaCommentField = await screen.findByTestId("qa-comment-section");
+    expect(qaCommentField).toBeInTheDocument();
+    expect(qaCommentField).toHaveTextContent(qaComment);
   });
 
   it("disables buttons when loading", async () => {
@@ -180,7 +187,7 @@ describe("QAEditor", () => {
     });
     const result = onSubmit.mock.calls[0][0];
 
-    expect(onSubmit).toHaveBeenCalledWith(expectedVal);
+    expect(onSubmit).toHaveBeenCalled();
     expect(result.qaStatus).toBeTruthy();
     expect(result.qaStatus).toEqual(expectedStatus);
   });
@@ -204,14 +211,13 @@ describe("QAEditor", () => {
     });
 
     expect((textArea as HTMLInputElement).value).toEqual(expectedComment);
-    expect(screen.getByTestId("qaComment")).toHaveTextContent(expectedComment);
 
     await act(async () => {
       fireEvent.click(screen.getByText("Save"));
     });
     const result = onSubmit.mock.calls[0][0];
 
-    expect(onSubmit).toHaveBeenCalledWith(expectedComment);
+    await waitFor(() => expect(onSubmit).toHaveBeenCalled());
     expect(result.qaComment).toEqual(expectedComment);
     expect(result.qaStatus).toEqual(qaStatus);
   });

--- a/experimenter/experimenter/nimbus-ui/src/components/Summary/TableQA/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/Summary/TableQA/index.tsx
@@ -34,7 +34,8 @@ export function qaStatusLabel(qaStatus: NimbusExperimentQAStatusEnum) {
 }
 
 const TableQA = (props: TableQAProps) => {
-  const { publishStatus, qaStatus, qaComment, showEditor, setShowEditor } = props;
+  const { publishStatus, qaStatus, qaComment, showEditor, setShowEditor } =
+    props;
 
   const onClickEdit = useCallback(() => setShowEditor(true), [setShowEditor]);
 

--- a/experimenter/experimenter/nimbus-ui/src/components/Summary/TableQA/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/Summary/TableQA/index.tsx
@@ -65,12 +65,18 @@ const TableQA = (props: TableQAProps) => {
           </Row>
         </Card.Header>
         <Card.Body className=" pe-2 ps-2">
-          <Table data-testid="table-qa-status">
+          <Table
+            data-testid="table-qa-status"
+            style={{ tableLayout: "fixed", whiteSpace: "normal" }}
+          >
             <tbody>
               <tr className="w-25">
-                <th className="border-top-0 border-bottom-2">QA Status</th>
+                <th className="border-top-0 border-bottom-2" colSpan={3}>
+                  QA Status
+                </th>
                 <td
                   data-testid="experiment-qa-status"
+                  colSpan={4}
                   className="border-top-0 border-bottom-2"
                 >
                   {qaStatus ? qaStatusLabel(qaStatus)[0] : <NotSet />}
@@ -81,10 +87,10 @@ const TableQA = (props: TableQAProps) => {
               {qaComment && (
                 <tr>
                   <td
-                    colSpan={3}
+                    colSpan={8}
                     data-testid="qa-comment"
-                    className="w-75 border-top-0 border-bottom-2"
-                    style={{ whiteSpace: "pre" }}
+                    className="w-75 border-top-0 border-bottom-2 mr-8"
+                    style={{ whiteSpace: "pre-wrap", wordWrap: "normal" }}
                   >
                     {qaComment}
                   </td>

--- a/experimenter/experimenter/nimbus-ui/src/components/Summary/TableQA/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/Summary/TableQA/index.tsx
@@ -16,6 +16,7 @@ import {
 type TableQAProps = {
   publishStatus: NimbusExperimentPublishStatusEnum | null;
   qaStatus?: NimbusExperimentQAStatusEnum | null;
+  qaComment?: string | null;
 } & UseQAResult;
 
 export type QAEditorProps = UseQAResult & {
@@ -33,7 +34,7 @@ export function qaStatusLabel(qaStatus: NimbusExperimentQAStatusEnum) {
 }
 
 const TableQA = (props: TableQAProps) => {
-  const { publishStatus, qaStatus, showEditor, setShowEditor } = props;
+  const { publishStatus, qaStatus, qaComment, showEditor, setShowEditor } = props;
 
   const onClickEdit = useCallback(() => setShowEditor(true), [setShowEditor]);
 
@@ -76,6 +77,18 @@ const TableQA = (props: TableQAProps) => {
                 <th className="border-top-0 w-75 border-bottom-2"></th>
                 <td className="border-top-0 border-bottom-2" />
               </tr>
+              {qaComment && (
+                <tr className="">
+                  <td
+                    data-testid="qa-comment"
+                    className="text-monospace border-top-0 border-bottom-2"
+                  >
+                    {qaComment}
+                  </td>
+                  <th className="border-top-0 w-75 border-bottom-2"></th>
+                  <td className="border-top-0 border-bottom-2" />
+                </tr>
+              )}
             </tbody>
           </Table>
         </Card.Body>

--- a/experimenter/experimenter/nimbus-ui/src/components/Summary/TableQA/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/Summary/TableQA/index.tsx
@@ -70,7 +70,7 @@ const TableQA = (props: TableQAProps) => {
                 <th className="border-top-0 border-bottom-2">QA Status</th>
                 <td
                   data-testid="experiment-qa-status"
-                  className="text-monospace border-top-0 border-bottom-2"
+                  className="border-top-0 border-bottom-2"
                 >
                   {qaStatus ? qaStatusLabel(qaStatus)[0] : <NotSet />}
                 </td>
@@ -78,15 +78,15 @@ const TableQA = (props: TableQAProps) => {
                 <td className="border-top-0 border-bottom-2" />
               </tr>
               {qaComment && (
-                <tr className="">
+                <tr>
                   <td
+                    colSpan={3}
                     data-testid="qa-comment"
-                    className="text-monospace border-top-0 border-bottom-2"
+                    className="w-75 border-top-0 border-bottom-2"
+                    style={{ whiteSpace: "pre" }}
                   >
                     {qaComment}
                   </td>
-                  <th className="border-top-0 w-75 border-bottom-2"></th>
-                  <td className="border-top-0 border-bottom-2" />
                 </tr>
               )}
             </tbody>

--- a/experimenter/experimenter/nimbus-ui/src/components/Summary/TableQA/mocks.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/Summary/TableQA/mocks.tsx
@@ -9,6 +9,7 @@ export const Subject = ({
   id = 123,
   publishStatus = null,
   qaStatus = null,
+  qaComment = null,
   isLoading = false,
   onSubmit = async (data) => {},
   ...props
@@ -30,6 +31,7 @@ export const Subject = ({
             id,
             publishStatus,
             qaStatus,
+            qaComment,
             isLoading,
             onSubmit,
             showEditor,

--- a/experimenter/experimenter/nimbus-ui/src/components/Summary/TableQA/useQA.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/Summary/TableQA/useQA.tsx
@@ -18,7 +18,7 @@ import {
 
 export type UseQAExperimentSubset = Pick<
   getExperiment_experimentBySlug,
-  "id" | "publishStatus" | "qaStatus"
+  "id" | "publishStatus" | "qaStatus" | "qaComment"
 >;
 
 export type UseQAResult = UseQAExperimentSubset & {
@@ -47,7 +47,7 @@ export const useQA = (
   const onSubmit = useCallback(
     ({ id }: UseQAExperimentSubset, refetch?: () => Promise<unknown>) =>
       async (data: Record<string, any>) => {
-        const { publishStatus, qaStatus } = data;
+        const { publishStatus, qaStatus, qaComment } = data;
 
         try {
           setIsLoading(true);
@@ -55,6 +55,7 @@ export const useQA = (
             input: {
               id,
               qaStatus: qaStatus || null,
+              qaComment: qaComment || null,
               changelogMessage: CHANGELOG_MESSAGES.UPDATED_QA_STATUS,
             },
           };


### PR DESCRIPTION
Because

- #9902 added a backend field for qa comments

This commit

- Adds the UI for qa comments:
   - "Comments" section does not show up if qa_comment is null/empty
   - Newline are honored 
   - You can edit the comment as many times as you want (these will show up in the history page)
   - You can edit comment and qa status independently (you don't have to add a comment every time you edit the qa status)
   - It wordwraps correctly when you're not in edit mode
   - It shows an error if the input is longer than 4096 chars

Fixes #9903 

----

<img width="1300" alt="Screenshot 2024-01-08 at 12 40 35 PM" src="https://github.com/mozilla/experimenter/assets/43795363/ea7592b1-f6ca-4327-8ed7-913ccee2e6a7">
<img width="1318" alt="Screenshot 2024-01-08 at 12 41 32 PM" src="https://github.com/mozilla/experimenter/assets/43795363/ad9960d1-57bf-4235-8717-26bc99213608">
<img width="1301" alt="Screenshot 2024-01-08 at 1 50 04 PM" src="https://github.com/mozilla/experimenter/assets/43795363/17b5e0d1-1744-4539-8b26-738d6d933a4c">
