### PR TITLE
For #9884 feat(nimbus): Add QA status column to the homescreen

### DIFF
--- a/experimenter/experimenter/nimbus-ui/src/components/PageHome/DirectoryTable/index.test.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageHome/DirectoryTable/index.test.tsx
@@ -24,7 +24,7 @@ import DirectoryTable, {
   SortableColumnTitle,
 } from "src/components/PageHome/DirectoryTable";
 import { UpdateSearchParams } from "src/hooks/useSearchParamsState";
-import { QA_STATUS_WITH_EMOJI } from "src/lib/constants";
+import { QA_STATUS_PROPERTIES } from "src/lib/constants";
 import { getProposedEnrollmentRange, humanDate } from "src/lib/dateUtils";
 import {
   mockDirectoryExperiments,
@@ -32,6 +32,7 @@ import {
 } from "src/lib/mocks";
 import { RouterSlugProvider } from "src/lib/test-utils";
 import { getAllExperiments_experiments } from "src/types/getAllExperiments";
+import { NimbusExperimentQAStatusEnum } from "src/types/globalTypes";
 
 const experiment = mockSingleDirectoryExperiment();
 
@@ -96,7 +97,7 @@ describe("DirectoryColumnQA", () => {
       </TestTable>,
     );
     expect(screen.getByTestId("directory-table-cell-qa")).toHaveTextContent(
-      QA_STATUS_WITH_EMOJI.GREEN[2],
+      QA_STATUS_PROPERTIES[NimbusExperimentQAStatusEnum.GREEN].emoji,
     );
   });
 

--- a/experimenter/experimenter/nimbus-ui/src/components/PageHome/DirectoryTable/index.test.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageHome/DirectoryTable/index.test.tsx
@@ -17,12 +17,14 @@ import DirectoryTable, {
   DirectoryColumnFirefoxMinVersion,
   DirectoryColumnOwner,
   DirectoryColumnPopulationPercent,
+  DirectoryColumnQA,
   DirectoryColumnStartDate,
   DirectoryColumnTitle,
   DirectoryColumnUnpublishedUpdates,
   SortableColumnTitle,
 } from "src/components/PageHome/DirectoryTable";
 import { UpdateSearchParams } from "src/hooks/useSearchParamsState";
+import { QA_STATUS_WITH_EMOJI } from "src/lib/constants";
 import { getProposedEnrollmentRange, humanDate } from "src/lib/dateUtils";
 import {
   mockDirectoryExperiments,
@@ -82,6 +84,30 @@ describe("DirectoryColumnOwner", () => {
     );
     expect(screen.getByTestId("directory-table-cell")).toHaveTextContent(
       "Not set",
+    );
+  });
+});
+
+describe("DirectoryColumnQA", () => {
+  it("renders the QA status field if present", () => {
+    render(
+      <TestTable>
+        <DirectoryColumnQA {...experiment} />
+      </TestTable>,
+    );
+    expect(screen.getByTestId("directory-table-cell-qa")).toHaveTextContent(
+      QA_STATUS_WITH_EMOJI.GREEN[2],
+    );
+  });
+
+  it("renders nothing if qa status is not set", () => {
+    render(
+      <TestTable>
+        <DirectoryColumnQA {...experiment} qaStatus={null} />
+      </TestTable>,
+    );
+    expect(screen.queryByTestId("directory-table-cell-qa")).toHaveTextContent(
+      "",
     );
   });
 });
@@ -397,6 +423,7 @@ describe("DirectoryTable", () => {
       );
       expectTableCells("directory-table-header", [
         "Name",
+        "QA",
         "Owner",
         "Feature",
         "Application",

--- a/experimenter/experimenter/nimbus-ui/src/components/PageHome/DirectoryTable/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageHome/DirectoryTable/index.tsx
@@ -10,7 +10,7 @@ import LinkExternal from "src/components/LinkExternal";
 import NotSet from "src/components/NotSet";
 import { displayConfigLabelOrNotSet } from "src/components/Summary";
 import { UpdateSearchParams, useConfig, useSearchParamsState } from "src/hooks";
-import { QA_STATUS_WITH_EMOJI } from "src/lib/constants";
+import { QA_STATUS_PROPERTIES } from "src/lib/constants";
 import { getProposedEnrollmentRange, humanDate } from "src/lib/dateUtils";
 import {
   applicationSortSelector,
@@ -30,7 +30,6 @@ import {
   unpublishedUpdatesSortSelector,
 } from "src/lib/experiment";
 import { getAllExperiments_experiments } from "src/types/getAllExperiments";
-import { NimbusExperimentQAStatusEnum } from "src/types/globalTypes";
 
 // These are all render functions for column types in the table.
 export type ColumnComponent = React.FC<getAllExperiments_experiments>;
@@ -52,18 +51,12 @@ export const DirectoryColumnTitle: React.FC<getAllExperiments_experiments> = ({
   );
 };
 
-export function qaStatusLabel(qaStatus: NimbusExperimentQAStatusEnum) {
-  return qaStatus
-    ? QA_STATUS_WITH_EMOJI[qaStatus]
-    : QA_STATUS_WITH_EMOJI[NimbusExperimentQAStatusEnum.RED];
-}
-
-export const DirectoryColumnQA: ColumnComponent = ({ qaStatus: q }) => (
+export const DirectoryColumnQA: ColumnComponent = ({ qaStatus }) => (
   <td
-    title={q ? qaStatusLabel(q)[0] : ""}
+    title={qaStatus ? QA_STATUS_PROPERTIES[qaStatus].description : ""}
     data-testid="directory-table-cell-qa"
   >
-    {q && qaStatusLabel(q)[2]}
+    {qaStatus && QA_STATUS_PROPERTIES[qaStatus].emoji}
   </td>
 );
 

--- a/experimenter/experimenter/nimbus-ui/src/components/PageHome/DirectoryTable/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageHome/DirectoryTable/index.tsx
@@ -10,6 +10,7 @@ import LinkExternal from "src/components/LinkExternal";
 import NotSet from "src/components/NotSet";
 import { displayConfigLabelOrNotSet } from "src/components/Summary";
 import { UpdateSearchParams, useConfig, useSearchParamsState } from "src/hooks";
+import { QA_STATUS_WITH_EMOJI } from "src/lib/constants";
 import { getProposedEnrollmentRange, humanDate } from "src/lib/dateUtils";
 import {
   applicationSortSelector,
@@ -23,11 +24,13 @@ import {
   firefoxMinVersionSortSelector,
   ownerUsernameSortSelector,
   populationPercentSortSelector,
+  qaStatusSortSelector,
   resultsReadySortSelector,
   startDateSortSelector,
   unpublishedUpdatesSortSelector,
 } from "src/lib/experiment";
 import { getAllExperiments_experiments } from "src/types/getAllExperiments";
+import { NimbusExperimentQAStatusEnum } from "src/types/globalTypes";
 
 // These are all render functions for column types in the table.
 export type ColumnComponent = React.FC<getAllExperiments_experiments>;
@@ -48,6 +51,21 @@ export const DirectoryColumnTitle: React.FC<getAllExperiments_experiments> = ({
     </td>
   );
 };
+
+export function qaStatusLabel(qaStatus: NimbusExperimentQAStatusEnum) {
+  return qaStatus
+    ? QA_STATUS_WITH_EMOJI[qaStatus]
+    : QA_STATUS_WITH_EMOJI[NimbusExperimentQAStatusEnum.RED];
+}
+
+export const DirectoryColumnQA: ColumnComponent = ({ qaStatus: q }) => (
+  <td
+    title={q ? qaStatusLabel(q)[0] : ""}
+    data-testid="directory-table-cell-qa"
+  >
+    {q && qaStatusLabel(q)[2]}
+  </td>
+);
 
 export const DirectoryColumnOwner: ColumnComponent = (experiment) => (
   // #4380 made it so owner is never null, but we have experiments pre-this
@@ -280,6 +298,11 @@ interface DirectoryTableProps {
 
 const commonColumns: Column[] = [
   { label: "Name", sortBy: "name", component: DirectoryColumnTitle },
+  {
+    label: "QA",
+    sortBy: qaStatusSortSelector,
+    component: DirectoryColumnQA,
+  },
   {
     label: "Owner",
     sortBy: ownerUsernameSortSelector,

--- a/experimenter/experimenter/nimbus-ui/src/components/PageSummary/index.test.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageSummary/index.test.tsx
@@ -23,7 +23,7 @@ import {
 import { createMutationMock } from "src/components/Summary/mocks";
 import {
   CHANGELOG_MESSAGES,
-  QA_STATUS_WITH_EMOJI,
+  QA_STATUS_PROPERTIES,
   SERVER_ERRORS,
 } from "src/lib/constants";
 import { mockExperimentQuery, mockLiveRolloutQuery } from "src/lib/mocks";
@@ -711,9 +711,18 @@ describe("PageSummary", () => {
   );
 
   it.each([
-    [NimbusExperimentQAStatusEnum.GREEN, QA_STATUS_WITH_EMOJI.GREEN[0]],
-    [NimbusExperimentQAStatusEnum.YELLOW, QA_STATUS_WITH_EMOJI.YELLOW[0]],
-    [NimbusExperimentQAStatusEnum.RED, QA_STATUS_WITH_EMOJI.RED[0]],
+    [
+      NimbusExperimentQAStatusEnum.GREEN,
+      QA_STATUS_PROPERTIES[NimbusExperimentQAStatusEnum.GREEN].description,
+    ],
+    [
+      NimbusExperimentQAStatusEnum.YELLOW,
+      QA_STATUS_PROPERTIES[NimbusExperimentQAStatusEnum.YELLOW].description,
+    ],
+    [
+      NimbusExperimentQAStatusEnum.RED,
+      QA_STATUS_PROPERTIES[NimbusExperimentQAStatusEnum.RED].description,
+    ],
   ])(
     "renders qa status pill for each qa status",
     async (qaStatus: NimbusExperimentQAStatusEnum, qaLabel: string) => {
@@ -749,7 +758,9 @@ describe("PageSummary", () => {
       render(<Subject mocks={[mock]} />);
       const qaStatusPill = await screen.findByTestId("pill-qa-status");
       expect(qaStatusPill).toBeInTheDocument();
-      expect(qaStatusPill).toHaveTextContent(QA_STATUS_WITH_EMOJI.GREEN[0]);
+      expect(qaStatusPill).toHaveTextContent(
+        QA_STATUS_PROPERTIES[NimbusExperimentQAStatusEnum.GREEN].description,
+      );
     },
   );
 
@@ -765,7 +776,9 @@ describe("PageSummary", () => {
     render(<Subject mocks={[mock]} />);
     const qaStatusPill = await screen.findByTestId("pill-qa-status");
     expect(qaStatusPill).toBeInTheDocument();
-    expect(qaStatusPill).toHaveTextContent(QA_STATUS_WITH_EMOJI.GREEN[0]);
+    expect(qaStatusPill).toHaveTextContent(
+      QA_STATUS_PROPERTIES[NimbusExperimentQAStatusEnum.GREEN].description,
+    );
   });
 
   it("will not render qa status pill when status is not set", async () => {

--- a/experimenter/experimenter/nimbus-ui/src/components/PageSummary/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageSummary/index.tsx
@@ -23,14 +23,13 @@ import {
   CHANGELOG_MESSAGES,
   EXTERNAL_URLS,
   LIFECYCLE_REVIEW_FLOWS,
-  QA_STATUS_WITH_EMOJI,
+  QA_STATUS_PROPERTIES,
 } from "src/lib/constants";
 import { ExperimentContext } from "src/lib/contexts";
 import { getStatus, getSummaryAction, StatusCheck } from "src/lib/experiment";
 import { getExperiment_experimentBySlug } from "src/types/getExperiment";
 import {
   NimbusExperimentPublishStatusEnum,
-  NimbusExperimentQAStatusEnum,
   NimbusExperimentStatusEnum,
 } from "src/types/globalTypes";
 
@@ -216,9 +215,13 @@ const PageSummary = (props: RouteComponentProps) => {
         {status.live && <StatusPills {...{ experiment, status }} />}
         {qaStatus != null &&
           (() => {
-            const [label, color] = qaStatusLabel(qaStatus!);
+            const qaStatusProps = QA_STATUS_PROPERTIES[qaStatus!];
             return (
-              <StatusPill testId="pill-qa-status" label={label} color={color} />
+              <StatusPill
+                testId="pill-qa-status"
+                label={qaStatusProps.description}
+                color={qaStatusProps.className}
+              />
             );
           })()}
       </h5>
@@ -315,12 +318,6 @@ const PageSummary = (props: RouteComponentProps) => {
 };
 
 export default PageSummary;
-
-export function qaStatusLabel(qaStatus: NimbusExperimentQAStatusEnum) {
-  return qaStatus
-    ? QA_STATUS_WITH_EMOJI[qaStatus]
-    : QA_STATUS_WITH_EMOJI[NimbusExperimentQAStatusEnum.RED];
-}
 
 const StatusPills = ({
   experiment,

--- a/experimenter/experimenter/nimbus-ui/src/components/PageSummary/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageSummary/index.tsx
@@ -317,13 +317,9 @@ const PageSummary = (props: RouteComponentProps) => {
 export default PageSummary;
 
 export function qaStatusLabel(qaStatus: NimbusExperimentQAStatusEnum) {
-  const statuses = {
-    [NimbusExperimentQAStatusEnum.GREEN]: QA_STATUS_WITH_EMOJI.GREEN,
-    [NimbusExperimentQAStatusEnum.YELLOW]: QA_STATUS_WITH_EMOJI.YELLOW,
-    [NimbusExperimentQAStatusEnum.RED]: QA_STATUS_WITH_EMOJI.RED,
-  };
-
-  return statuses[qaStatus] || QA_STATUS_WITH_EMOJI.RED;
+  return qaStatus
+    ? QA_STATUS_WITH_EMOJI[qaStatus]
+    : QA_STATUS_WITH_EMOJI[NimbusExperimentQAStatusEnum.RED];
 }
 
 const StatusPills = ({

--- a/experimenter/experimenter/nimbus-ui/src/components/Summary/TableQA/QAEditor.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/Summary/TableQA/QAEditor.tsx
@@ -11,7 +11,7 @@ import Row from "react-bootstrap/Row";
 import { FormProvider } from "react-hook-form";
 import { UseQAResult } from "src/components/Summary/TableQA/useQA";
 import { useCommonForm } from "src/hooks";
-import { QA_STATUS_WITH_EMOJI } from "src/lib/constants";
+import { QA_STATUS_PROPERTIES } from "src/lib/constants";
 import { NimbusExperimentQAStatusEnum } from "src/types/globalTypes";
 
 export const qaEditorFieldNames = ["qaStatus", "qaComment"] as const;
@@ -63,17 +63,20 @@ export const QAEditor = ({
     {
       label: NimbusExperimentQAStatusEnum.RED,
       value: NimbusExperimentQAStatusEnum.RED,
-      description: QA_STATUS_WITH_EMOJI.RED[0],
+      description:
+        QA_STATUS_PROPERTIES[NimbusExperimentQAStatusEnum.RED].description,
     },
     {
       label: NimbusExperimentQAStatusEnum.YELLOW,
       value: NimbusExperimentQAStatusEnum.YELLOW,
-      description: QA_STATUS_WITH_EMOJI.YELLOW[0],
+      description:
+        QA_STATUS_PROPERTIES[NimbusExperimentQAStatusEnum.YELLOW].description,
     },
     {
       label: NimbusExperimentQAStatusEnum.GREEN,
       value: NimbusExperimentQAStatusEnum.GREEN,
-      description: QA_STATUS_WITH_EMOJI.GREEN[0],
+      description:
+        QA_STATUS_PROPERTIES[NimbusExperimentQAStatusEnum.GREEN].description,
     },
   ] as const;
 

--- a/experimenter/experimenter/nimbus-ui/src/components/Summary/TableQA/index.test.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/Summary/TableQA/index.test.tsx
@@ -16,7 +16,7 @@ import useQA, { UseQAResult } from "src/components/Summary/TableQA/useQA";
 import { UPDATE_EXPERIMENT_MUTATION } from "src/gql/experiments";
 import {
   CHANGELOG_MESSAGES,
-  QA_STATUS_WITH_EMOJI,
+  QA_STATUS_PROPERTIES,
   SUBMIT_ERROR,
 } from "src/lib/constants";
 import {
@@ -67,7 +67,7 @@ describe("TableQA", () => {
   it("renders 'QA status' row as expected with status set", () => {
     render(<Subject {...{ qaStatus }} />);
     expect(screen.getByTestId("experiment-qa-status")).toHaveTextContent(
-      QA_STATUS_WITH_EMOJI.GREEN[0],
+      QA_STATUS_PROPERTIES[NimbusExperimentQAStatusEnum.GREEN].description,
     );
   });
 
@@ -105,7 +105,9 @@ describe("QAEditor", () => {
 
     const qaStatusField = await screen.findByTestId("qa-status-section");
     expect(qaStatusField).toBeInTheDocument();
-    expect(qaStatusField).toHaveTextContent(QA_STATUS_WITH_EMOJI.GREEN[0]);
+    expect(qaStatusField).toHaveTextContent(
+      QA_STATUS_PROPERTIES[NimbusExperimentQAStatusEnum.GREEN].description,
+    );
 
     const qaCommentField = await screen.findByTestId("qa-comment-section");
     expect(qaCommentField).toBeInTheDocument();

--- a/experimenter/experimenter/nimbus-ui/src/components/Summary/TableQA/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/Summary/TableQA/index.tsx
@@ -7,7 +7,7 @@ import { Button, Card, Col, Row, Table } from "react-bootstrap";
 import NotSet from "src/components/NotSet";
 import QAEditor from "src/components/Summary/TableQA/QAEditor";
 import { UseQAResult } from "src/components/Summary/TableQA/useQA";
-import { QA_STATUS_WITH_EMOJI } from "src/lib/constants";
+import { QA_STATUS_PROPERTIES } from "src/lib/constants";
 import {
   NimbusExperimentPublishStatusEnum,
   NimbusExperimentQAStatusEnum,
@@ -22,12 +22,6 @@ type TableQAProps = {
 export type QAEditorProps = UseQAResult & {
   setShowEditor: (state: boolean) => void;
 };
-
-export function qaStatusLabel(qaStatus: NimbusExperimentQAStatusEnum) {
-  return qaStatus
-    ? QA_STATUS_WITH_EMOJI[qaStatus]
-    : QA_STATUS_WITH_EMOJI[NimbusExperimentQAStatusEnum.RED];
-}
 
 const TableQA = (props: TableQAProps) => {
   const { publishStatus, qaStatus, qaComment, showEditor, setShowEditor } =
@@ -75,7 +69,11 @@ const TableQA = (props: TableQAProps) => {
                   colSpan={4}
                   className="border-top-0 border-bottom-2"
                 >
-                  {qaStatus ? qaStatusLabel(qaStatus)[0] : <NotSet />}
+                  {qaStatus ? (
+                    QA_STATUS_PROPERTIES[qaStatus].description
+                  ) : (
+                    <NotSet />
+                  )}
                 </td>
                 <th className="border-top-0 w-75 border-bottom-2"></th>
                 <td className="border-top-0 border-bottom-2" />

--- a/experimenter/experimenter/nimbus-ui/src/components/Summary/TableQA/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/Summary/TableQA/index.tsx
@@ -24,13 +24,9 @@ export type QAEditorProps = UseQAResult & {
 };
 
 export function qaStatusLabel(qaStatus: NimbusExperimentQAStatusEnum) {
-  const statuses = {
-    [NimbusExperimentQAStatusEnum.GREEN]: QA_STATUS_WITH_EMOJI.GREEN,
-    [NimbusExperimentQAStatusEnum.YELLOW]: QA_STATUS_WITH_EMOJI.YELLOW,
-    [NimbusExperimentQAStatusEnum.RED]: QA_STATUS_WITH_EMOJI.RED,
-  };
-
-  return statuses[qaStatus] || QA_STATUS_WITH_EMOJI.RED;
+  return qaStatus
+    ? QA_STATUS_WITH_EMOJI[qaStatus]
+    : QA_STATUS_WITH_EMOJI[NimbusExperimentQAStatusEnum.RED];
 }
 
 const TableQA = (props: TableQAProps) => {

--- a/experimenter/experimenter/nimbus-ui/src/lib/constants.ts
+++ b/experimenter/experimenter/nimbus-ui/src/lib/constants.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { RegisterOptions } from "react-hook-form";
+import { NimbusExperimentQAStatusEnum } from "src/types/globalTypes";
 
 export const BASE_PATH = "/nimbus";
 
@@ -191,7 +192,7 @@ export const IMAGE_UPLOAD_ACCEPT = ".gif,.jpg,.jpeg,.png";
 export const POLL_INTERVAL = 30000;
 
 export const QA_STATUS_WITH_EMOJI = {
-  GREEN: ["✅ QA: Green", "success"],
-  YELLOW: ["⚠️ QA: Yellow", "text-dark"],
-  RED: ["❌ QA: Red", "danger"],
+  [NimbusExperimentQAStatusEnum.GREEN]: ["✅ QA: Green", "success", "✅"],
+  [NimbusExperimentQAStatusEnum.YELLOW]: ["⚠️ QA: Yellow", "text-dark", "⚠️"],
+  [NimbusExperimentQAStatusEnum.RED]: ["❌ QA: Red", "danger", "❌"],
 };

--- a/experimenter/experimenter/nimbus-ui/src/lib/constants.ts
+++ b/experimenter/experimenter/nimbus-ui/src/lib/constants.ts
@@ -191,8 +191,29 @@ export const IMAGE_UPLOAD_ACCEPT = ".gif,.jpg,.jpeg,.png";
 
 export const POLL_INTERVAL = 30000;
 
-export const QA_STATUS_WITH_EMOJI = {
-  [NimbusExperimentQAStatusEnum.GREEN]: ["✅ QA: Green", "success", "✅"],
-  [NimbusExperimentQAStatusEnum.YELLOW]: ["⚠️ QA: Yellow", "text-dark", "⚠️"],
-  [NimbusExperimentQAStatusEnum.RED]: ["❌ QA: Red", "danger", "❌"],
+interface QAStatusProperties {
+  emoji: string;
+  description: string;
+  className: string;
+}
+
+export const QA_STATUS_PROPERTIES: Record<
+  NimbusExperimentQAStatusEnum,
+  QAStatusProperties
+> = {
+  [NimbusExperimentQAStatusEnum.GREEN]: {
+    emoji: "✅",
+    description: "✅ QA: Green",
+    className: "success",
+  },
+  [NimbusExperimentQAStatusEnum.YELLOW]: {
+    emoji: "⚠️",
+    description: "⚠️ QA: Yellow",
+    className: "text-dark",
+  },
+  [NimbusExperimentQAStatusEnum.RED]: {
+    emoji: "❌",
+    description: "❌ QA: Red",
+    className: "danger",
+  },
 };

--- a/experimenter/experimenter/nimbus-ui/src/lib/experiment.test.ts
+++ b/experimenter/experimenter/nimbus-ui/src/lib/experiment.test.ts
@@ -15,6 +15,7 @@ import {
   getStatus,
   ownerUsernameSortSelector,
   populationPercentSortSelector,
+  qaStatusSortSelector,
   resultsReadySortSelector,
   selectFromExperiment,
   startDateSortSelector,
@@ -27,6 +28,7 @@ import {
 } from "src/lib/mocks";
 import {
   NimbusExperimentPublishStatusEnum,
+  NimbusExperimentQAStatusEnum,
   NimbusExperimentStatusEnum,
 } from "src/types/globalTypes";
 
@@ -122,6 +124,7 @@ describe("selectFromExperiment", () => {
       [featureConfigNameSortSelector, "Picture-in-Picture"],
       [ownerUsernameSortSelector, "example@mozilla.com"],
       [resultsReadySortSelector, "0"],
+      [qaStatusSortSelector, NimbusExperimentQAStatusEnum.GREEN],
       [enrollmentSortSelector, "2021-07-07T00:00:00.000Z"],
       [applicationSortSelector, "DESKTOP"],
       [channelSortSelector, "NIGHTLY"],
@@ -157,6 +160,18 @@ describe("selectFromExperiment", () => {
         resultsReadySortSelector,
       ),
     ).toEqual("1");
+  });
+
+  it("returns nothing for qa status not set", () => {
+    const experiment = mockSingleDirectoryExperiment({
+      qaStatus: null,
+    });
+    expect(
+      selectFromExperiment(
+        { ...experiment, qaStatus: null },
+        qaStatusSortSelector,
+      ),
+    ).toEqual("0");
   });
 });
 

--- a/experimenter/experimenter/nimbus-ui/src/lib/experiment.ts
+++ b/experimenter/experimenter/nimbus-ui/src/lib/experiment.ts
@@ -122,6 +122,14 @@ export const featureConfigNameSortSelector: ExperimentSortSelector = (
 export const ownerUsernameSortSelector: ExperimentSortSelector = (experiment) =>
   experiment.owner?.username;
 
+export const qaStatusSortSelector: ExperimentSortSelector = ({ qaStatus }) => {
+  if (qaStatus) {
+    return qaStatus;
+  } else {
+    return "0";
+  }
+};
+
 export const applicationSortSelector: ExperimentSortSelector = (experiment) =>
   experiment.application!;
 

--- a/experimenter/experimenter/nimbus-ui/src/lib/mocks.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/lib/mocks.tsx
@@ -47,6 +47,7 @@ import {
   NimbusExperimentDocumentationLinkEnum,
   NimbusExperimentFirefoxVersionEnum,
   NimbusExperimentPublishStatusEnum,
+  NimbusExperimentQAStatusEnum,
   NimbusExperimentStatusEnum,
 } from "src/types/globalTypes";
 
@@ -957,7 +958,7 @@ export function mockSingleDirectoryExperiment(
     projects: [MOCK_CONFIG.projects![0]],
     hypothesis: "test hypothesis",
     qaComment: null,
-    qaStatus: null,
+    qaStatus: NimbusExperimentQAStatusEnum.GREEN,
     ...overrides,
   };
 }


### PR DESCRIPTION
Because

- We want a quick, non-intrusive way to see which experiments have had QA, and what the QA status is

This commit

- Adds a new column, "QA", to the homescreen
- Shows the emoji corresponding to the QA status that has been set (empty if no qaStatus)
- Hovering over the emoji shows the full qaStatus text (e.g. ✅ -> "✅ QA: Green")
- The QA column is sortable

Fixes #9884 

----

<img width="1650" alt="Screenshot 2024-01-08 at 2 56 53 PM" src="https://github.com/mozilla/experimenter/assets/43795363/5f023e8e-81a0-4762-9ffa-3e7caa928a96">
<img width="435" alt="Screenshot 2024-01-08 at 2 57 10 PM" src="https://github.com/mozilla/experimenter/assets/43795363/884badc9-38fd-4a51-94ec-e3c1639235b3">

