### PR TITLE
chore(schemas): bump version to 2024.1.2

### DIFF
--- a/schemas/package.json
+++ b/schemas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mozilla/nimbus-schemas",
-  "version": "2024.1.1",
+  "version": "2024.1.2",
   "description": "Schemas used by Mozilla Nimbus and related projects.",
   "main": "index.d.ts",
   "repository": {

--- a/schemas/pyproject.toml
+++ b/schemas/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "mozilla-nimbus-schemas"
-version = "2024.1.1"
+version = "2024.1.2"
 description = "Schemas used by Mozilla Nimbus and related projects."
 authors = ["mikewilli"]
 license = "MPL 2.0"


### PR DESCRIPTION
Because

- #10007 updated the schemas package but not the versions

This commit

- updates the version in the config files so that it will be deployed by CI
