### PR TITLE
Fixes #9889 feat(nimbus): Add filter for qa status on homepage

### DIFF
--- a/docs/experimenter/openapi-schema.json
+++ b/docs/experimenter/openapi-schema.json
@@ -3577,6 +3577,24 @@
               ]
             }
           },
+          "qaStatus": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "label": {
+                  "type": "string"
+                },
+                "value": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "label",
+                "value"
+              ]
+            }
+          },
           "populationSizingData": {
             "type": "string"
           },
@@ -3604,6 +3622,7 @@
           "conclusionRecommendations",
           "takeaways",
           "types",
+          "qaStatus",
           "populationSizingData"
         ]
       },

--- a/docs/experimenter/swagger-ui.html
+++ b/docs/experimenter/swagger-ui.html
@@ -3589,6 +3589,24 @@
               ]
             }
           },
+          "qaStatus": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "label": {
+                  "type": "string"
+                },
+                "value": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "label",
+                "value"
+              ]
+            }
+          },
           "populationSizingData": {
             "type": "string"
           },
@@ -3616,6 +3634,7 @@
           "conclusionRecommendations",
           "takeaways",
           "types",
+          "qaStatus",
           "populationSizingData"
         ]
       },

--- a/experimenter/experimenter/experiments/api/v5/serializers.py
+++ b/experimenter/experimenter/experiments/api/v5/serializers.py
@@ -222,6 +222,7 @@ class NimbusConfigurationDataClass:
     conclusionRecommendations: typing.List[LabelValueDataClass]
     takeaways: typing.List[LabelValueDataClass]
     types: typing.List[LabelValueDataClass]
+    qaStatus: typing.List[LabelValueDataClass]
     populationSizingData: str
     hypothesisDefault: str = NimbusExperiment.HYPOTHESIS_DEFAULT
     maxPrimaryOutcomes: int = NimbusExperiment.MAX_PRIMARY_OUTCOMES
@@ -254,6 +255,7 @@ class NimbusConfigurationDataClass:
         self.types = self._enum_to_label_value(NimbusExperiment.Type)
         self.populationSizingData = self._get_population_sizing_data()
         self.takeaways = self._enum_to_label_value(NimbusExperiment.Takeaways)
+        self.qaStatus = self._enum_to_label_value(NimbusExperiment.QAStatus)
 
     def _geo_model_to_dataclass(self, queryset):
         return [GeoDataClass(id=i.id, name=i.name, code=i.code) for i in queryset]

--- a/experimenter/experimenter/experiments/api/v5/types.py
+++ b/experimenter/experimenter/experiments/api/v5/types.py
@@ -309,6 +309,7 @@ class NimbusConfigurationType(graphene.ObjectType):
     types = graphene.List(NimbusLabelValueType)
     status_update_exempt_fields = graphene.List(NimbusStatusUpdateExemptFieldsType)
     population_sizing_data = graphene.String()
+    qa_status = graphene.List(NimbusLabelValueType)
 
     def _text_choices_to_label_value_list(self, text_choices):
         return [
@@ -428,6 +429,9 @@ class NimbusConfigurationType(graphene.ObjectType):
 
     def resolve_takeaways(self, info):
         return self._text_choices_to_label_value_list(NimbusExperiment.Takeaways)
+
+    def resolve_qa_status(self, info):
+        return self._text_choices_to_label_value_list(NimbusExperiment.QAStatus)
 
     def resolve_status_update_exempt_fields(self, info):
         return [

--- a/experimenter/experimenter/experiments/tests/api/v5/test_queries.py
+++ b/experimenter/experimenter/experiments/tests/api/v5/test_queries.py
@@ -2411,6 +2411,10 @@ class TestNimbusConfigQuery(MockSizingDataMixin, GraphQLTestCase):
                         id
                         name
                     }
+                    qaStatus {
+                        label
+                        value
+                    }
                     takeaways {
                         label
                         value
@@ -2442,6 +2446,7 @@ class TestNimbusConfigQuery(MockSizingDataMixin, GraphQLTestCase):
 
         assertChoices(config["applications"], NimbusExperiment.Application)
         assertChoices(config["takeaways"], NimbusExperiment.Takeaways)
+        assertChoices(config["qaStatus"], NimbusExperiment.QAStatus)
         assertChoices(config["types"], NimbusExperiment.Type)
         assertChoices(config["channels"], NimbusExperiment.Channel)
         assertChoices(

--- a/experimenter/experimenter/nimbus-ui/schema.graphql
+++ b/experimenter/experimenter/nimbus-ui/schema.graphql
@@ -456,6 +456,7 @@ type NimbusConfigurationType {
   types: [NimbusLabelValueType]
   statusUpdateExemptFields: [NimbusStatusUpdateExemptFieldsType]
   populationSizingData: String
+  qaStatus: [NimbusLabelValueType]
 }
 
 type NimbusExperimentApplicationConfigType {

--- a/experimenter/experimenter/nimbus-ui/src/components/PageHome/FilterBar/index.test.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageHome/FilterBar/index.test.tsx
@@ -2,10 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { render } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import React from "react";
 import {
   EVERYTHING_SELECTED_VALUE,
+  FilterSelectSubject,
   Subject,
 } from "src/components/PageHome/mocks";
 import { MockedCache } from "src/lib/mocks";
@@ -17,5 +18,22 @@ describe("FilterBar", () => {
         <Subject value={EVERYTHING_SELECTED_VALUE} />
       </MockedCache>,
     );
+  });
+});
+
+describe("FilterSelect", () => {
+  it("pluralizes the filter names correctly", () => {
+    render(
+      <MockedCache>
+        <FilterSelectSubject
+          filterValueName="qaStatus"
+          fieldLabel="QA Status"
+          fieldOptions={EVERYTHING_SELECTED_VALUE.qaStatus!}
+        />
+      </MockedCache>,
+    );
+
+    expect(screen.queryByText("All QA Statuss")).not.toBeInTheDocument();
+    expect(screen.queryByText("All QA Statuses")).toBeInTheDocument();
   });
 });

--- a/experimenter/experimenter/nimbus-ui/src/components/PageHome/FilterBar/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageHome/FilterBar/index.tsx
@@ -102,12 +102,19 @@ export const FilterBar: React.FC<FilterBarProps> = ({
           optionLabelName="label"
           {...{ filterValue, onChange }}
         />
+        <FilterSelect
+          fieldLabel="QA Status"
+          fieldOptions={options.qaStatus!}
+          filterValueName="qaStatus"
+          optionLabelName="label"
+          {...{ filterValue, onChange }}
+        />
       </Nav>
     </Navbar>
   );
 };
 
-type FilterSelectProps<
+export type FilterSelectProps<
   K extends FilterValueKeys,
   T extends NonNullFilterOptions<K>,
 > = {
@@ -116,10 +123,10 @@ type FilterSelectProps<
   filterValueName: K;
   fieldLabel: string;
   fieldOptions: T;
-  optionLabelName: keyof NonNullFilterOption<K>;
+  optionLabelName?: keyof NonNullFilterOption<K>;
 };
 
-const FilterSelect = <
+export const FilterSelect = <
   K extends FilterValueKeys,
   T extends NonNullFilterOptions<K>,
 >({
@@ -153,7 +160,7 @@ const FilterSelect = <
           isMulti: true,
           value: fieldValue,
           isDisabled: loading,
-          placeholder: "All " + fieldLabel + "s",
+          placeholder: pluralizeTitle(fieldLabel),
           getOptionLabel: (item: OptionType) =>
             fieldLabel === "Feature"
               ? item[optionLabelName as string] +
@@ -178,6 +185,11 @@ const FilterSelect = <
       />
     </Nav.Item>
   );
+};
+
+export const pluralizeTitle = (fieldLabel: string) => {
+  const label = fieldLabel.endsWith("s") ? fieldLabel + "es" : fieldLabel + "s";
+  return "All " + label;
 };
 
 export default FilterBar;

--- a/experimenter/experimenter/nimbus-ui/src/components/PageHome/filterExperiments.test.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageHome/filterExperiments.test.tsx
@@ -138,6 +138,9 @@ describe("filterExperiments", () => {
               MOCK_CONFIG!.targetingConfigs![0]!,
             ]);
             break;
+          case "qaStatus":
+            expect(experiment.qaStatus).toEqual([MOCK_CONFIG!.qaStatus![0]]);
+            break;
         }
       }
     }

--- a/experimenter/experimenter/nimbus-ui/src/components/PageHome/filterExperiments.ts
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageHome/filterExperiments.ts
@@ -30,6 +30,7 @@ export const optionIndexKeys: {
   projects: (option) => option.name,
   targetingConfigs: (option) => option.value,
   takeaways: (option) => option.value,
+  qaStatus: (option) => option.value,
 };
 
 type ExperimentFilter<K extends FilterValueKeys> = (
@@ -89,6 +90,7 @@ const experimentFilters: { [key in FilterValueKeys]: ExperimentFilter<key> } = {
       (experiment.takeawaysMetricGain && option.value === "DAU_GAIN")
     );
   },
+  qaStatus: (option, experiment) => experiment.qaStatus === option.value,
 };
 
 export function getFilterValueFromParams(
@@ -159,6 +161,13 @@ export function getFilterValueFromParams(
         break;
       case "takeaways":
         filterValue[key] = selectFilterOptions<"takeaways">(
+          options[key],
+          optionIndexKeys[key],
+          values as string[],
+        );
+        break;
+      case "qaStatus":
+        filterValue[key] = selectFilterOptions<"qaStatus">(
           options[key],
           optionIndexKeys[key],
           values as string[],
@@ -247,6 +256,12 @@ export function updateParamsFromFilterValue(
             optionIndexKeys[key],
           );
           break;
+        case "qaStatus":
+          values = indexFilterOptions<"qaStatus">(
+            filterValue[key],
+            optionIndexKeys[key],
+          );
+          break;
       }
       if (values && values.length) {
         params.set(key, values.join(","));
@@ -331,6 +346,13 @@ export function filterExperiments(
         break;
       case "takeaways":
         filteredExperiments = filterExperimentsByOptions<"takeaways">(
+          filterState[key],
+          experimentFilters[key],
+          filteredExperiments,
+        );
+        break;
+      case "qaStatus":
+        filteredExperiments = filterExperimentsByOptions<"qaStatus">(
           filterState[key],
           experimentFilters[key],
           filteredExperiments,

--- a/experimenter/experimenter/nimbus-ui/src/components/PageHome/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageHome/index.tsx
@@ -108,6 +108,7 @@ const PageHome: React.FunctionComponent<PageHomeProps> = () => {
     projects: config!.projects!,
     targetingConfigs: config!.targetingConfigs,
     takeaways: config!.takeaways,
+    qaStatus: config!.qaStatus,
   };
 
   const { data, loading, error, refetch } = useQuery<{

--- a/experimenter/experimenter/nimbus-ui/src/components/PageHome/mocks.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageHome/mocks.tsx
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React, { useState } from "react";
-import { FilterBar } from "src/components/PageHome/FilterBar";
+import { FilterBar, FilterSelect } from "src/components/PageHome/FilterBar";
 import { FilterOptions, FilterValue } from "src/components/PageHome/types";
 import { mockDirectoryExperiments, MOCK_CONFIG } from "src/lib/mocks";
 
@@ -19,6 +19,7 @@ export const DEFAULT_OPTIONS: FilterOptions = {
   types: MOCK_CONFIG!.types,
   projects: MOCK_CONFIG!.projects!,
   targetingConfigs: MOCK_CONFIG!.targetingConfigs,
+  qaStatus: MOCK_CONFIG!.qaStatus,
 };
 
 export const DEFAULT_VALUE: FilterValue = {
@@ -31,6 +32,7 @@ export const DEFAULT_VALUE: FilterValue = {
   types: [],
   projects: [],
   targetingConfigs: [],
+  qaStatus: [],
 };
 
 export const EVERYTHING_SELECTED_VALUE: FilterValue = DEFAULT_OPTIONS;
@@ -49,5 +51,22 @@ export const Subject = ({
         <pre>{JSON.stringify(filterState, null, "  ")}</pre>
       </div>
     </div>
+  );
+};
+
+export const FilterSelectSubject = ({
+  filterValue = DEFAULT_VALUE,
+  onChange = () => {},
+  filterValueName,
+  fieldLabel,
+  fieldOptions,
+}: Partial<React.ComponentProps<typeof FilterSelect>>) => {
+  return (
+    <FilterSelect
+      filterValueName={filterValueName!}
+      fieldLabel={fieldLabel!}
+      fieldOptions={fieldOptions!}
+      {...{ filterValue, onChange }}
+    />
   );
 };

--- a/experimenter/experimenter/nimbus-ui/src/components/PageHome/types.ts
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageHome/types.ts
@@ -14,6 +14,7 @@ export const filterValueKeys = [
   "projects",
   "targetingConfigs",
   "takeaways",
+  "qaStatus",
 ] as const;
 
 export type FilterValueKeys = typeof filterValueKeys[number];

--- a/experimenter/experimenter/nimbus-ui/src/gql/config.ts
+++ b/experimenter/experimenter/nimbus-ui/src/gql/config.ts
@@ -103,6 +103,10 @@ export const GET_CONFIG_QUERY = gql`
         label
         value
       }
+      qaStatus {
+        label
+        value
+      }
     }
   }
 `;

--- a/experimenter/experimenter/nimbus-ui/src/lib/mocks.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/lib/mocks.tsx
@@ -436,6 +436,20 @@ export const MOCK_CONFIG: getConfig_nimbusConfig = {
     },
   ],
   populationSizingData: JSON.stringify(MOCK_SIZING),
+  qaStatus: [
+    {
+      label: "RED",
+      value: NimbusExperimentQAStatusEnum.RED,
+    },
+    {
+      label: "YELLOW",
+      value: NimbusExperimentQAStatusEnum.YELLOW,
+    },
+    {
+      label: "GREEN",
+      value: NimbusExperimentQAStatusEnum.GREEN,
+    },
+  ],
 };
 
 // Disabling this rule for now because we'll eventually

--- a/experimenter/experimenter/nimbus-ui/src/types/getConfig.ts
+++ b/experimenter/experimenter/nimbus-ui/src/types/getConfig.ts
@@ -126,6 +126,11 @@ export interface getConfig_nimbusConfig_takeaways {
   value: string | null;
 }
 
+export interface getConfig_nimbusConfig_qaStatus {
+  label: string | null;
+  value: string | null;
+}
+
 export interface getConfig_nimbusConfig {
   applications: (getConfig_nimbusConfig_applications | null)[] | null;
   channels: (getConfig_nimbusConfig_channels | null)[] | null;
@@ -147,6 +152,7 @@ export interface getConfig_nimbusConfig {
   statusUpdateExemptFields: (getConfig_nimbusConfig_statusUpdateExemptFields | null)[] | null;
   populationSizingData: string | null;
   takeaways: (getConfig_nimbusConfig_takeaways | null)[] | null;
+  qaStatus: (getConfig_nimbusConfig_qaStatus | null)[] | null;
 }
 
 export interface getConfig {


### PR DESCRIPTION
Because

- We want to be able to quickly filter by the QA status on the homescreen

This commit

- Adds qa_status to config so that it can be filterable
- Adds the UI for the qa status filter
- Updates the pluralization for filters so that it correctly pluralizes "QA Status" -> "QA Statuses" (instead of just adding an "s" to the end)

Fixes #9889 

----

<img width="288" alt="Screenshot 2024-01-11 at 6 11 05 PM" src="https://github.com/mozilla/experimenter/assets/43795363/c1f8aeae-241f-4065-9fdd-b15eafd0ee71">

<img width="1663" alt="Screenshot 2024-01-11 at 6 10 43 PM" src="https://github.com/mozilla/experimenter/assets/43795363/9b3d8020-650c-42c0-a98e-1478e254211b">

<img width="1669" alt="Screenshot 2024-01-11 at 6 10 57 PM" src="https://github.com/mozilla/experimenter/assets/43795363/2298c8c6-8503-411a-82ad-1d1cd761186e">
