### PR TITLE
Fixes #10032 fix(nimbus): Remove qa_comment from the query that fetches all experiments

### DIFF
--- a/experimenter/experimenter/nimbus-ui/src/gql/experiments.ts
+++ b/experimenter/experimenter/nimbus-ui/src/gql/experiments.ts
@@ -277,7 +277,6 @@ export const GET_EXPERIMENTS_QUERY = gql`
       status
       statusNext
       publishStatus
-      qaComment
       qaStatus
       monitoringDashboardUrl
       rolloutMonitoringDashboardUrl

--- a/experimenter/experimenter/nimbus-ui/src/lib/mocks.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/lib/mocks.tsx
@@ -957,7 +957,6 @@ export function mockSingleDirectoryExperiment(
     takeawaysQbrLearning: false,
     projects: [MOCK_CONFIG.projects![0]],
     hypothesis: "test hypothesis",
-    qaComment: null,
     qaStatus: NimbusExperimentQAStatusEnum.GREEN,
     ...overrides,
   };

--- a/experimenter/experimenter/nimbus-ui/src/types/getAllExperiments.ts
+++ b/experimenter/experimenter/nimbus-ui/src/types/getAllExperiments.ts
@@ -62,7 +62,6 @@ export interface getAllExperiments_experiments {
   status: NimbusExperimentStatusEnum | null;
   statusNext: NimbusExperimentStatusEnum | null;
   publishStatus: NimbusExperimentPublishStatusEnum | null;
-  qaComment: string | null;
   qaStatus: NimbusExperimentQAStatusEnum | null;
   monitoringDashboardUrl: string | null;
   rolloutMonitoringDashboardUrl: string | null;


### PR DESCRIPTION
Because

- Fetching qa comments is slowing the query down which populates the homescreen (`getAllExperiments`)
- And qa comments aren't needed in that query anywhere else

This commit

- Removes qa comments from the query

Fixes #10032