### PR TITLE
feat(cirrus): Configure sentry for different projects

### DIFF
--- a/.env.integration-tests
+++ b/.env.integration-tests
@@ -52,3 +52,4 @@ CIRRUS_APP_NAME=demo_app
 CIRRUS_CHANNEL=release
 CIRRUS_FML_PATH=./feature_manifest/sample.yml
 CIRRUS_SENTRY_DSN=
+CIRRUS_ENV_NAME=test_instance_stage

--- a/.env.sample
+++ b/.env.sample
@@ -57,3 +57,4 @@ CIRRUS_CHANNEL=beta
 CIRRUS_FML_PATH=./feature_manifest/sample.yml
 CIRRUS_SENTRY_DSN=
 CIRRUS_INSTANCE_NAME=
+CIRRUS_ENV_NAME=test_instance_stage

--- a/.env.test
+++ b/.env.test
@@ -6,3 +6,4 @@ CIRRUS_CHANNEL=developer
 CIRRUS_FML_PATH=./tests/feature_manifest/sample.fml.yaml
 CIRRUS_SENTRY_DSN=
 CIRRUS_INSTANCE_NAME=test_instance
+CIRRUS_ENV_NAME=test_instance_stage

--- a/cirrus/README.md
+++ b/cirrus/README.md
@@ -25,6 +25,8 @@ To set up the Cirrus environment, follow these steps:
    CIRRUS_FML_PATH=./feature_manifest/sample.fml.yaml
    CIRRUS_SENTRY_DSN=dsn_url
    CIRRUS_INSTANCE_NAME=cirrus_pod_app_v1
+   CIRRUS_ENV_NAME=test_app_stage
+
    ```
 
    Here's what each variable represents:
@@ -37,6 +39,7 @@ To set up the Cirrus environment, follow these steps:
    - `CIRRUS_FML_PATH`: The file path to the feature manifest file. Set it to `./feature_manifest/sample.fml.yaml` or specify the correct path to your feature manifest file.
    - `CIRRUS_SENTRY_DSN`: Replace `dsn_url` with the appropriate DSN value.
    - `CIRRUS_INSTANCE_NAME`: Replace with the instance name.
+   - `CIRRUS_ENV_NAME:` Replace with the concatenation of project and environment name
 
    Adjust the values of these variables according to your specific configuration requirements.
 

--- a/cirrus/server/cirrus/main.py
+++ b/cirrus/server/cirrus/main.py
@@ -20,6 +20,7 @@ from .settings import (
     channel,
     cirrus_sentry_dsn,
     context,
+    env_name,
     fml_path,
     instance_name,
     metrics_config,
@@ -73,6 +74,7 @@ def initialize_sentry():
             # of sampled transactions.
             # We recommend adjusting this value in production.
             profiles_sample_rate=0.1,
+            environment=env_name,
         )
 
 

--- a/cirrus/server/cirrus/settings.py
+++ b/cirrus/server/cirrus/settings.py
@@ -29,6 +29,7 @@ cirrus_sentry_dsn: str = cast(str, config("CIRRUS_SENTRY_DSN", default=""))
 instance_name: str = cast(
     str, config("CIRRUS_INSTANCE_NAME", default="instance name not defined")
 )
+env_name = cast(str, config("CIRRUS_ENV_NAME", default="production"))
 
 
 @dataclass


### PR DESCRIPTION
Because

- We are using Sentry for all the Cirrus implementing applications such as Monitor, VPN, and so on...... Currently, it is hard to track where the error is coming from until we see the issue in detail. 

This commit

- Sentry supports the concept of environment, so in the same project you can configure different environment
- By default, Sentry uses a `production` environment, so the default value used in initialization is `production`
- Add support for using environment so that the `cirrus-stage` project can have `monitor-stage` and `vpn-stage` and similarly `cirrus-prod` can have `monitor-prod` and `vpn-prod` environments.

Note: Sentry [environment](https://docs.sentry.io/product/sentry-basics/concepts/environments/) selection also makes it easy to filter the issues, for example
![image](https://github.com/mozilla/experimenter/assets/25848231/34f7dd90-c19a-4c5d-9541-9fb8168167ea)


Fixes #9999 