### PR TITLE
feat(nimbus): add required excluded branch to v5 api

### DIFF
--- a/experimenter/experimenter/experiments/api/v5/inputs.py
+++ b/experimenter/experimenter/experiments/api/v5/inputs.py
@@ -38,6 +38,16 @@ class DocumentationLinkInput(graphene.InputObjectType):
     link = graphene.String(required=True)
 
 
+class NimbusExperimentBranchThroughRequiredInput(graphene.InputObjectType):
+    required_experiment = graphene.NonNull(graphene.Int)
+    branch_slug = graphene.String()
+
+
+class NimbusExperimentBranchThroughExcludedInput(graphene.InputObjectType):
+    excluded_experiment = graphene.NonNull(graphene.Int)
+    branch_slug = graphene.String()
+
+
 class ExperimentInput(graphene.InputObjectType):
     application = NimbusExperimentApplicationEnum()
     changelog_message = graphene.String()
@@ -46,6 +56,9 @@ class ExperimentInput(graphene.InputObjectType):
     countries = graphene.List(graphene.String)
     documentation_links = graphene.List(DocumentationLinkInput)
     excluded_experiments = graphene.List(graphene.NonNull(graphene.Int))
+    excluded_experiments_branches = graphene.List(
+        NimbusExperimentBranchThroughExcludedInput
+    )
     feature_config_ids = graphene.List(graphene.Int)
     firefox_max_version = NimbusExperimentFirefoxVersionEnum()
     firefox_min_version = NimbusExperimentFirefoxVersionEnum()
@@ -74,6 +87,9 @@ class ExperimentInput(graphene.InputObjectType):
     qa_status = NimbusExperimentQAStatusEnum()
     reference_branch = graphene.Field(BranchInput)
     required_experiments = graphene.List(graphene.NonNull(graphene.Int))
+    required_experiments_branches = graphene.List(
+        NimbusExperimentBranchThroughRequiredInput
+    )
     risk_brand = graphene.Boolean()
     risk_mitigation_link = graphene.String()
     risk_partner_related = graphene.Boolean()

--- a/experimenter/experimenter/experiments/tests/api/v5/test_queries.py
+++ b/experimenter/experimenter/experiments/tests/api/v5/test_queries.py
@@ -620,6 +620,8 @@ class TestNimbusExperimentBySlugQuery(GraphQLTestCase):
         locale = LocaleFactory.create()
         language = LanguageFactory.create()
         project = ProjectFactory.create()
+        required = NimbusExperimentFactory.create(application=application)
+        excluded = NimbusExperimentFactory.create(application=application)
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             lifecycle,
             parent=NimbusExperimentFactory.create(),
@@ -629,6 +631,8 @@ class TestNimbusExperimentBySlugQuery(GraphQLTestCase):
             locales=[locale],
             languages=[language],
             projects=[project],
+            required_experiments_branches=[required],
+            excluded_experiments_branches=[excluded],
         )
 
         review_request_change = experiment.changes.latest_review_request()
@@ -839,6 +843,21 @@ class TestNimbusExperimentBySlugQuery(GraphQLTestCase):
                     localizations
                     isWeb
                     qaStatus
+
+                    requiredExperimentsBranches {
+                        requiredExperiment {
+                            id
+                            slug
+                        }
+                        branchSlug
+                    }
+                    excludedExperimentsBranches {
+                        excludedExperiment {
+                            id
+                            slug
+                        }
+                        branchSlug
+                    }
                 }
             }
             """,
@@ -884,6 +903,15 @@ class TestNimbusExperimentBySlugQuery(GraphQLTestCase):
                     if experiment.proposed_enrollment_end_date
                     else None
                 ),
+                "excludedExperimentsBranches": [
+                    {
+                        "excludedExperiment": {
+                            "id": excluded.id,
+                            "slug": excluded.slug,
+                        },
+                        "branchSlug": excluded.reference_branch.slug,
+                    }
+                ],
                 "featureConfigs": [
                     {
                         "application": NimbusExperiment.Application(
@@ -991,6 +1019,15 @@ class TestNimbusExperimentBySlugQuery(GraphQLTestCase):
                     if rejection_change
                     else None
                 ),
+                "requiredExperimentsBranches": [
+                    {
+                        "requiredExperiment": {
+                            "id": required.id,
+                            "slug": required.slug,
+                        },
+                        "branchSlug": required.reference_branch.slug,
+                    }
+                ],
                 "resultsReady": experiment.results_ready,
                 "reviewRequest": (
                     {

--- a/experimenter/experimenter/experiments/tests/factories.py
+++ b/experimenter/experimenter/experiments/tests/factories.py
@@ -26,6 +26,8 @@ from experimenter.experiments.models import (
     NimbusChangeLog,
     NimbusDocumentationLink,
     NimbusExperiment,
+    NimbusExperimentBranchThroughExcluded,
+    NimbusExperimentBranchThroughRequired,
     NimbusFeatureConfig,
     NimbusIsolationGroup,
     NimbusVersionedSchema,
@@ -495,6 +497,34 @@ class NimbusExperimentFactory(factory.django.DjangoModelFactory):
 
         if extracted:
             self.languages.add(*extracted)
+
+    @factory.post_generation
+    def required_experiments_branches(self, create, extracted, **kwargs):
+        if not create:
+            # Simple build, do nothing.
+            return
+
+        if extracted:
+            for required in extracted:
+                NimbusExperimentBranchThroughRequired.objects.create(
+                    parent_experiment=self,
+                    child_experiment=required,
+                    branch_slug=required.reference_branch.slug,
+                )
+
+    @factory.post_generation
+    def excluded_experiments_branches(self, create, extracted, **kwargs):
+        if not create:
+            # Simple build, do nothing.
+            return
+
+        if extracted:
+            for excluded in extracted:
+                NimbusExperimentBranchThroughExcluded.objects.create(
+                    parent_experiment=self,
+                    child_experiment=excluded,
+                    branch_slug=excluded.reference_branch.slug,
+                )
 
     @classmethod
     def create(

--- a/experimenter/experimenter/nimbus-ui/schema.graphql
+++ b/experimenter/experimenter/nimbus-ui/schema.graphql
@@ -72,6 +72,7 @@ type NimbusExperimentType {
   computedEnrollmentEndDate: DateTime
   enrollmentEndDate: DateTime
   excludedExperiments: [NimbusExperimentType!]!
+  excludedExperimentsBranches: [NimbusExperimentBranchThroughExcludedType!]!
   isEnrollmentPausePending: Boolean
   isEnrollmentPaused: Boolean
   isWeb: Boolean!
@@ -81,6 +82,7 @@ type NimbusExperimentType {
   recipeJson: String
   rejection: NimbusChangeLogType
   requiredExperiments: [NimbusExperimentType!]!
+  requiredExperimentsBranches: [NimbusExperimentBranchThroughRequiredType!]!
   resultsExpectedDate: DateTime
   resultsReady: Boolean
   reviewRequest: NimbusChangeLogType
@@ -411,6 +413,11 @@ schema (one of the key benefits of GraphQL).
 """
 scalar JSONString
 
+type NimbusExperimentBranchThroughExcludedType {
+  branchSlug: String
+  excludedExperiment: NimbusExperimentType!
+}
+
 type NimbusReviewType {
   message: ObjectField
   warnings: ObjectField
@@ -419,6 +426,11 @@ type NimbusReviewType {
 
 """Utilized to serialize out Serializer errors"""
 scalar ObjectField
+
+type NimbusExperimentBranchThroughRequiredType {
+  branchSlug: String
+  requiredExperiment: NimbusExperimentType!
+}
 
 type NimbusSignoffRecommendationsType {
   qaSignoff: Boolean
@@ -514,6 +526,7 @@ input ExperimentInput {
   countries: [String]
   documentationLinks: [DocumentationLinkInput]
   excludedExperiments: [Int!]
+  excludedExperimentsBranches: [NimbusExperimentBranchThroughExcludedInput]
   featureConfigIds: [Int]
   firefoxMaxVersion: NimbusExperimentFirefoxVersionEnum
   firefoxMinVersion: NimbusExperimentFirefoxVersionEnum
@@ -542,6 +555,7 @@ input ExperimentInput {
   qaStatus: NimbusExperimentQAStatusEnum
   referenceBranch: BranchInput = null
   requiredExperiments: [Int!]
+  requiredExperimentsBranches: [NimbusExperimentBranchThroughRequiredInput]
   riskBrand: Boolean
   riskMitigationLink: String
   riskPartnerRelated: Boolean
@@ -562,6 +576,11 @@ input ExperimentInput {
 input DocumentationLinkInput {
   title: NimbusExperimentDocumentationLinkEnum!
   link: String!
+}
+
+input NimbusExperimentBranchThroughExcludedInput {
+  excludedExperiment: Int!
+  branchSlug: String
 }
 
 input BranchInput {
@@ -589,6 +608,11 @@ Create scalar that ignores normal serialization/deserialization, since
 that will be handled by the multipart request spec
 """
 scalar Upload
+
+input NimbusExperimentBranchThroughRequiredInput {
+  requiredExperiment: Int!
+  branchSlug: String
+}
 
 type UpdateExperiment {
   nimbusExperiment: NimbusExperimentType

--- a/experimenter/experimenter/nimbus-ui/src/types/globalTypes.ts
+++ b/experimenter/experimenter/nimbus-ui/src/types/globalTypes.ts
@@ -263,6 +263,7 @@ export interface ExperimentInput {
   countries?: (string | null)[] | null;
   documentationLinks?: (DocumentationLinkInput | null)[] | null;
   excludedExperiments?: number[] | null;
+  excludedExperimentsBranches?: (NimbusExperimentBranchThroughExcludedInput | null)[] | null;
   featureConfigIds?: (number | null)[] | null;
   firefoxMaxVersion?: NimbusExperimentFirefoxVersionEnum | null;
   firefoxMinVersion?: NimbusExperimentFirefoxVersionEnum | null;
@@ -291,6 +292,7 @@ export interface ExperimentInput {
   qaStatus?: NimbusExperimentQAStatusEnum | null;
   referenceBranch?: BranchInput | null;
   requiredExperiments?: number[] | null;
+  requiredExperimentsBranches?: (NimbusExperimentBranchThroughRequiredInput | null)[] | null;
   riskBrand?: boolean | null;
   riskMitigationLink?: string | null;
   riskPartnerRelated?: boolean | null;
@@ -306,6 +308,16 @@ export interface ExperimentInput {
   totalEnrolledClients?: number | null;
   treatmentBranches?: (BranchInput | null)[] | null;
   warnFeatureSchema?: boolean | null;
+}
+
+export interface NimbusExperimentBranchThroughExcludedInput {
+  excludedExperiment: number;
+  branchSlug?: string | null;
+}
+
+export interface NimbusExperimentBranchThroughRequiredInput {
+  requiredExperiment: number;
+  branchSlug?: string | null;
 }
 
 //==============================================================


### PR DESCRIPTION
Because

* We need to be able to set branch slugs with required/excluded experiments

This commit

* Adds new fields to the V5 API to set required/excluded experiments with branch slugs

fixes #10028

