### PR TITLE
tests(nimbus): Use a random qa status in factories

### DIFF
--- a/experimenter/experimenter/experiments/tests/api/v5/test_mutations.py
+++ b/experimenter/experimenter/experiments/tests/api/v5/test_mutations.py
@@ -1507,8 +1507,8 @@ class TestUpdateExperimentMutationMultiFeature(GraphQLTestCase):
         user_email = "user@example.com"
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE_APPROVE,
+            qa_status=NimbusExperiment.QAStatus.NOT_SET,
         )
-        self.assertEqual(experiment.qa_status, NimbusExperiment.QAStatus.NOT_SET)
 
         new_status = NimbusExperiment.QAStatus.YELLOW
         response = self.query(

--- a/experimenter/experimenter/experiments/tests/factories.py
+++ b/experimenter/experimenter/experiments/tests/factories.py
@@ -410,7 +410,9 @@ class NimbusExperimentFactory(factory.django.DjangoModelFactory):
     risk_brand = factory.LazyAttribute(lambda o: random.choice([True, False]))
     is_localized = factory.LazyAttribute(lambda o: False)
     localizations = factory.LazyAttribute(lambda o: None)
-    qa_status = factory.LazyAttribute(lambda o: NimbusExperiment.QAStatus.NOT_SET)
+    qa_status = factory.LazyAttribute(
+        lambda o: random.choice(list(NimbusExperiment.QAStatus)).value
+    )
 
     class Meta:
         model = NimbusExperiment


### PR DESCRIPTION
Because

- We want to include qa_status in our factories 

This commit

- Uses a random choice of qa status

Fixes #10038