### PR TITLE
bug(nimbus): re-enable manifest updates for desktop, monitor

### DIFF
--- a/experimenter/experimenter/features/manifests/apps.yaml
+++ b/experimenter/experimenter/features/manifests/apps.yaml
@@ -80,37 +80,37 @@ focus_ios:
         ignored_tags:
           - "v999.0.0" # nimbus.fml.yaml missing.
 
-# monitor_cirrus:
-#   slug: "monitor-web"
-#   repo:
-#     type: "github"
-#     name: "mozilla/blurts-server"
-#   fml_path: "config/nimbus.yaml"
+monitor_cirrus:
+  slug: "monitor-web"
+  repo:
+    type: "github"
+    name: "mozilla/blurts-server"
+  fml_path: "config/nimbus.yaml"
 
-# firefox_desktop:
-#   slug: "firefox-desktop"
-#   repo:
-#     type: "hgmo"
-#     name: "mozilla-unified"
-#     default_branch: "central"
-#   experimenter_yaml_path: "toolkit/components/nimbus/FeatureManifest.yaml"
-#   release_discovery:
-#     version_file:
-#       type: "plaintext"
-#       path: "browser/config/version.txt"
-#     strategies:
-#       - type: "branched"
-#         branches:
-#           # The order here is important!
-#           #
-#           # When central is merging to beta or beta is merging to release, then
-#           # both of those will have the same version number for a period of
-#           # time.
-#           #
-#           # In this order, if two consecutive branches have the same version,
-#           # then the latter will take precedence. e.g., if both beta and release
-#           # report the same version, we will use the feature manifest from release.
-#           - "central"
-#           - "beta"
-#           - "release"
-#           - "esr115"
+firefox_desktop:
+  slug: "firefox-desktop"
+  repo:
+    type: "hgmo"
+    name: "mozilla-unified"
+    default_branch: "central"
+  experimenter_yaml_path: "toolkit/components/nimbus/FeatureManifest.yaml"
+  release_discovery:
+    version_file:
+      type: "plaintext"
+      path: "browser/config/version.txt"
+    strategies:
+      - type: "branched"
+        branches:
+          # The order here is important!
+          #
+          # When central is merging to beta or beta is merging to release, then
+          # both of those will have the same version number for a period of
+          # time.
+          #
+          # In this order, if two consecutive branches have the same version,
+          # then the latter will take precedence. e.g., if both beta and release
+          # report the same version, we will use the feature manifest from release.
+          - "central"
+          - "beta"
+          - "release"
+          - "esr115"


### PR DESCRIPTION
Because:

- desktop and monitor configurations were commented out

This commit:

- uncomments them.

Fixes #10059