### PR TITLE
feat(nimbus): select required/excluded branches in audience page

### DIFF
--- a/experimenter/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/index.test.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/index.test.tsx
@@ -27,9 +27,17 @@ import {
   FIELD_MESSAGES,
   TOOLTIP_DURATION,
 } from "src/lib/constants";
-import { MOCK_CONFIG, MOCK_EXPERIMENTS_BY_APPLICATION } from "src/lib/mocks";
-import { assertSerializerMessages } from "src/lib/test-utils";
 import {
+  mockDirectoryExperiments,
+  mockExperimentQuery,
+  MOCK_CONFIG,
+  MOCK_EXPERIMENTS_BY_APPLICATION,
+} from "src/lib/mocks";
+import { assertSerializerMessages } from "src/lib/test-utils";
+import { getAllExperimentsByApplication_experimentsByApplication } from "src/types/getAllExperimentsByApplication";
+import { getExperiment_experimentBySlug } from "src/types/getExperiment";
+import {
+  ExperimentInput,
   NimbusExperimentApplicationEnum,
   NimbusExperimentChannelEnum,
   NimbusExperimentFirefoxVersionEnum,
@@ -47,6 +55,433 @@ describe("FormAudience", () => {
 
   afterEach(() => {
     global.window.open = origWindowOpen;
+  });
+
+  describe("excluded and required experiments fields", () => {
+    const sum = (items: number[]) =>
+      items.reduce((acc: number, curr: number) => acc + curr);
+    const countBranches = (
+      experiments: getAllExperimentsByApplication_experimentsByApplication[],
+    ) => sum(experiments.map((e) => e.treatmentBranches!.length + 2));
+    const query = (field: string) =>
+      `#react-select-${field}-listbox .react-select__option`;
+
+    it("fields renders options", async () => {
+      const experiment = {
+        ...MOCK_EXPERIMENT,
+        name: MOCK_EXPERIMENTS_BY_APPLICATION[0].name,
+        slug: MOCK_EXPERIMENTS_BY_APPLICATION[0].slug,
+        id: MOCK_EXPERIMENTS_BY_APPLICATION[0].id,
+      };
+
+      const { container } = render(<Subject experiment={experiment} />);
+      const excluded = screen.getByLabelText(/Exclude users enrolled/);
+
+      let options = container.querySelectorAll(query("excludedExperiments"));
+      expect(options.length).toEqual(0);
+      await selectEvent.openMenu(excluded);
+      options = container.querySelectorAll(query("excludedExperiments"));
+      expect(options.length).toEqual(
+        countBranches(MOCK_EXPERIMENTS_BY_APPLICATION) - 3,
+      );
+
+      expect(
+        Array.from(options, (e) => e.textContent).find((text) =>
+          text?.includes(`(${experiment.slug})`),
+        ),
+      ).toBeUndefined();
+
+      const required = screen.getByLabelText(/Require users to be enrolled/);
+      options = container.querySelectorAll(query("requiredExperiments"));
+      expect(options.length).toEqual(0);
+      await selectEvent.openMenu(required);
+      options = container.querySelectorAll(query("requiredExperiments"));
+      expect(options.length).toEqual(
+        countBranches(MOCK_EXPERIMENTS_BY_APPLICATION) - 3,
+      );
+
+      expect(
+        Array.from(options, (e) => e.textContent).find((text) =>
+          text?.includes(`(${experiment.slug})`),
+        ),
+      ).toBeUndefined();
+    });
+
+    it("saves required and excluded experiments with all branches for experiments", async () => {
+      const onSubmit = jest.fn();
+      const MOCK_EXPERIMENTS_BY_APPLICATION: getAllExperimentsByApplication_experimentsByApplication[] =
+        Array.from(mockDirectoryExperiments().entries()).map(
+          ([idx, experiment]) => ({
+            id: idx + 1,
+            name: experiment.name,
+            slug:
+              experiment.slug ??
+              experiment.name.toLowerCase().replace(" ", "-"),
+            publicDescription: "mock description",
+            referenceBranch: { slug: "control" },
+            treatmentBranches: [{ slug: "treatment" }],
+          }),
+        );
+      const experiment: getExperiment_experimentBySlug = mockExperimentQuery(
+        "demo-slug",
+        {
+          excludedExperimentsBranches: [],
+          requiredExperimentsBranches: [],
+        },
+      ).experiment;
+      const requiredExperiment = MOCK_EXPERIMENTS_BY_APPLICATION[1];
+      const excludedExperiment = MOCK_EXPERIMENTS_BY_APPLICATION[2];
+
+      const expected: ExperimentInput = {
+        channel: experiment.channel,
+        firefoxMinVersion: experiment.firefoxMinVersion,
+        firefoxMaxVersion: experiment.firefoxMaxVersion,
+        targetingConfigSlug: experiment.targetingConfigSlug,
+        populationPercent: experiment.populationPercent,
+        totalEnrolledClients: experiment.totalEnrolledClients,
+        proposedEnrollment: "" + experiment.proposedEnrollment,
+        proposedDuration: "" + experiment.proposedDuration,
+        countries: experiment.countries.map((v) => "" + v.id),
+        locales: experiment.locales.map((v) => "" + v.id),
+        languages: experiment.languages.map((v) => "" + v.id),
+        isSticky: experiment.isSticky,
+        isFirstRun: experiment.isFirstRun,
+        requiredExperimentsBranches: [
+          {
+            requiredExperiment: requiredExperiment.id,
+            branchSlug: null,
+          },
+        ],
+        excludedExperimentsBranches: [
+          {
+            excludedExperiment: excludedExperiment.id,
+            branchSlug: null,
+          },
+        ],
+      };
+
+      render(<Subject {...{ experiment, onSubmit }} />);
+      await screen.findByTestId("FormAudience");
+
+      const required = screen.getByLabelText(/Require users to be enrolled/);
+      await selectEvent.openMenu(required);
+      await selectEvent.select(required, [
+        `${requiredExperiment.name} (All branches)`,
+      ]);
+
+      const excluded = screen.getByLabelText(/Exclude users enrolled/);
+      await selectEvent.openMenu(excluded);
+      await selectEvent.select(excluded, [
+        `${excludedExperiment.name} (All branches)`,
+      ]);
+
+      const submitButton = screen.getByTestId("submit-button");
+
+      fireEvent.click(submitButton);
+
+      await waitFor(() => {
+        expect(onSubmit).toHaveBeenCalledTimes(1);
+        expect(onSubmit.mock.calls).toEqual([[expected, false]]);
+      });
+    });
+
+    it("saves required and excluded experiments with all branches for rollouts", async () => {
+      const onSubmit = jest.fn();
+      const MOCK_EXPERIMENTS_BY_APPLICATION: getAllExperimentsByApplication_experimentsByApplication[] =
+        Array.from(mockDirectoryExperiments().entries()).map(
+          ([idx, experiment]) => ({
+            id: idx + 1,
+            name: experiment.name,
+            slug:
+              experiment.slug ??
+              experiment.name.toLowerCase().replace(" ", "-"),
+            publicDescription: "mock description",
+            referenceBranch: { slug: "control" },
+            treatmentBranches: [{ slug: "treatment" }],
+          }),
+        );
+      const experiment: getExperiment_experimentBySlug = mockExperimentQuery(
+        "demo-slug",
+        {
+          isRollout: true,
+          excludedExperimentsBranches: [],
+          requiredExperimentsBranches: [],
+        },
+      ).experiment;
+      const requiredExperiment = MOCK_EXPERIMENTS_BY_APPLICATION[1];
+      const excludedExperiment = MOCK_EXPERIMENTS_BY_APPLICATION[2];
+
+      const expected: ExperimentInput = {
+        channel: experiment.channel,
+        firefoxMinVersion: experiment.firefoxMinVersion,
+        firefoxMaxVersion: experiment.firefoxMaxVersion,
+        targetingConfigSlug: experiment.targetingConfigSlug,
+        populationPercent: experiment.populationPercent,
+        totalEnrolledClients: experiment.totalEnrolledClients,
+        proposedEnrollment: "" + experiment.proposedEnrollment,
+        proposedDuration: "" + experiment.proposedDuration,
+        countries: experiment.countries.map((v) => "" + v.id),
+        locales: experiment.locales.map((v) => "" + v.id),
+        languages: experiment.languages.map((v) => "" + v.id),
+        isSticky: experiment.isSticky,
+        isFirstRun: experiment.isFirstRun,
+        requiredExperimentsBranches: [
+          {
+            requiredExperiment: requiredExperiment.id,
+            branchSlug: null,
+          },
+        ],
+        excludedExperimentsBranches: [
+          {
+            excludedExperiment: excludedExperiment.id,
+            branchSlug: null,
+          },
+        ],
+      };
+
+      render(<Subject {...{ experiment, onSubmit }} />);
+      await screen.findByTestId("FormAudience");
+
+      const required = screen.getByLabelText(/Require users to be enrolled/);
+      await selectEvent.openMenu(required);
+      await selectEvent.select(required, [
+        `${requiredExperiment.name} (All branches)`,
+      ]);
+
+      const excluded = screen.getByLabelText(/Exclude users enrolled/);
+      await selectEvent.openMenu(excluded);
+      await selectEvent.select(excluded, [
+        `${excludedExperiment.name} (All branches)`,
+      ]);
+
+      const submitButton = screen.getByTestId("submit-button");
+
+      fireEvent.click(submitButton);
+
+      await waitFor(() => {
+        expect(onSubmit).toHaveBeenCalledTimes(1);
+        expect(onSubmit.mock.calls).toEqual([[expected, false]]);
+      });
+    });
+
+    it("saves required and excluded experiments with specific branches for experiments", async () => {
+      const onSubmit = jest.fn();
+      const MOCK_EXPERIMENTS_BY_APPLICATION: getAllExperimentsByApplication_experimentsByApplication[] =
+        Array.from(mockDirectoryExperiments().entries()).map(
+          ([idx, experiment]) => ({
+            id: idx + 1,
+            name: experiment.name,
+            slug:
+              experiment.slug ??
+              experiment.name.toLowerCase().replace(" ", "-"),
+            publicDescription: "mock description",
+            referenceBranch: { slug: "control" },
+            treatmentBranches: [{ slug: "treatment" }],
+          }),
+        );
+      const experiment: getExperiment_experimentBySlug = mockExperimentQuery(
+        "demo-slug",
+        {
+          excludedExperimentsBranches: [],
+          requiredExperimentsBranches: [],
+        },
+      ).experiment;
+      const requiredExperiment = MOCK_EXPERIMENTS_BY_APPLICATION[1];
+      const excludedExperiment = MOCK_EXPERIMENTS_BY_APPLICATION[2];
+
+      const expected: ExperimentInput = {
+        channel: experiment.channel,
+        firefoxMinVersion: experiment.firefoxMinVersion,
+        firefoxMaxVersion: experiment.firefoxMaxVersion,
+        targetingConfigSlug: experiment.targetingConfigSlug,
+        populationPercent: experiment.populationPercent,
+        totalEnrolledClients: experiment.totalEnrolledClients,
+        proposedEnrollment: "" + experiment.proposedEnrollment,
+        proposedDuration: "" + experiment.proposedDuration,
+        countries: experiment.countries.map((v) => "" + v.id),
+        locales: experiment.locales.map((v) => "" + v.id),
+        languages: experiment.languages.map((v) => "" + v.id),
+        isSticky: experiment.isSticky,
+        isFirstRun: experiment.isFirstRun,
+        requiredExperimentsBranches: [
+          {
+            requiredExperiment: requiredExperiment.id,
+            branchSlug: "control",
+          },
+        ],
+        excludedExperimentsBranches: [
+          {
+            excludedExperiment: excludedExperiment.id,
+            branchSlug: "treatment",
+          },
+        ],
+      };
+
+      render(<Subject {...{ experiment, onSubmit }} />);
+      await screen.findByTestId("FormAudience");
+
+      const required = screen.getByLabelText(/Require users to be enrolled/);
+      await selectEvent.openMenu(required);
+      await selectEvent.select(required, [
+        `${requiredExperiment.name} (control branch)`,
+      ]);
+
+      const excluded = screen.getByLabelText(/Exclude users enrolled/);
+      await selectEvent.openMenu(excluded);
+      await selectEvent.select(excluded, [
+        `${excludedExperiment.name} (treatment branch)`,
+      ]);
+
+      const submitButton = screen.getByTestId("submit-button");
+
+      fireEvent.click(submitButton);
+
+      await waitFor(() => {
+        expect(onSubmit).toHaveBeenCalledTimes(1);
+        expect(onSubmit.mock.calls).toEqual([[expected, false]]);
+      });
+    });
+
+    it("saves required and excluded experiments with specific branches for rollouts", async () => {
+      const onSubmit = jest.fn();
+      const MOCK_EXPERIMENTS_BY_APPLICATION: getAllExperimentsByApplication_experimentsByApplication[] =
+        Array.from(mockDirectoryExperiments().entries()).map(
+          ([idx, experiment]) => ({
+            id: idx + 1,
+            name: experiment.name,
+            slug:
+              experiment.slug ??
+              experiment.name.toLowerCase().replace(" ", "-"),
+            publicDescription: "mock description",
+            referenceBranch: { slug: "control" },
+            treatmentBranches: [{ slug: "treatment" }],
+          }),
+        );
+      const experiment: getExperiment_experimentBySlug = mockExperimentQuery(
+        "demo-slug",
+        {
+          isRollout: true,
+          excludedExperimentsBranches: [],
+          requiredExperimentsBranches: [],
+        },
+      ).experiment;
+      const requiredExperiment = MOCK_EXPERIMENTS_BY_APPLICATION[1];
+      const excludedExperiment = MOCK_EXPERIMENTS_BY_APPLICATION[2];
+
+      const expected: ExperimentInput = {
+        channel: experiment.channel,
+        firefoxMinVersion: experiment.firefoxMinVersion,
+        firefoxMaxVersion: experiment.firefoxMaxVersion,
+        targetingConfigSlug: experiment.targetingConfigSlug,
+        populationPercent: experiment.populationPercent,
+        totalEnrolledClients: experiment.totalEnrolledClients,
+        proposedEnrollment: "" + experiment.proposedEnrollment,
+        proposedDuration: "" + experiment.proposedDuration,
+        countries: experiment.countries.map((v) => "" + v.id),
+        locales: experiment.locales.map((v) => "" + v.id),
+        languages: experiment.languages.map((v) => "" + v.id),
+        isSticky: experiment.isSticky,
+        isFirstRun: experiment.isFirstRun,
+        requiredExperimentsBranches: [
+          {
+            requiredExperiment: requiredExperiment.id,
+            branchSlug: "control",
+          },
+        ],
+        excludedExperimentsBranches: [
+          {
+            excludedExperiment: excludedExperiment.id,
+            branchSlug: "treatment",
+          },
+        ],
+      };
+
+      render(<Subject {...{ experiment, onSubmit }} />);
+      await screen.findByTestId("FormAudience");
+
+      const required = screen.getByLabelText(/Require users to be enrolled/);
+      await selectEvent.openMenu(required);
+      await selectEvent.select(required, [
+        `${requiredExperiment.name} (control branch)`,
+      ]);
+
+      const excluded = screen.getByLabelText(/Exclude users enrolled/);
+      await selectEvent.openMenu(excluded);
+      await selectEvent.select(excluded, [
+        `${excludedExperiment.name} (treatment branch)`,
+      ]);
+
+      const submitButton = screen.getByTestId("submit-button");
+
+      fireEvent.click(submitButton);
+
+      await waitFor(() => {
+        expect(onSubmit).toHaveBeenCalledTimes(1);
+        expect(onSubmit.mock.calls).toEqual([[expected, false]]);
+      });
+    });
+
+    it("excludes selected required experiments from the exclude field options", async () => {
+      const experiment = {
+        ...MOCK_EXPERIMENT,
+        name: MOCK_EXPERIMENTS_BY_APPLICATION[0].name,
+        slug: MOCK_EXPERIMENTS_BY_APPLICATION[0].slug,
+        id: MOCK_EXPERIMENTS_BY_APPLICATION[0].id,
+        excludedExperimentsBranches: [
+          {
+            excludedExperiment: MOCK_EXPERIMENTS_BY_APPLICATION[1],
+            branchSlug: null,
+          },
+        ],
+      };
+
+      const { container } = render(<Subject experiment={experiment} />);
+      const required = screen.getByLabelText(/Require users to be enrolled/);
+
+      await selectEvent.openMenu(required);
+
+      const options = container.querySelectorAll(query("requiredExperiments"));
+      expect(options.length).toEqual(
+        countBranches(MOCK_EXPERIMENTS_BY_APPLICATION) - 4,
+      );
+
+      expect(
+        Array.from(options, (e) => e.textContent).find((text) =>
+          text?.includes(`(${MOCK_EXPERIMENTS_BY_APPLICATION[1].slug})`),
+        ),
+      ).toBeUndefined();
+    });
+
+    it("excludes selected excluded experiment branch from the required field options", async () => {
+      const experiment = {
+        ...MOCK_EXPERIMENT,
+        name: MOCK_EXPERIMENTS_BY_APPLICATION[0].name,
+        slug: MOCK_EXPERIMENTS_BY_APPLICATION[0].slug,
+        id: MOCK_EXPERIMENTS_BY_APPLICATION[0].id,
+        requiredExperimentsBranches: [
+          {
+            requiredExperiment: MOCK_EXPERIMENTS_BY_APPLICATION[1],
+            branchSlug: null,
+          },
+        ],
+      };
+
+      const { container } = render(<Subject experiment={experiment} />);
+      const excluded = screen.getByLabelText(/Exclude users enrolled/);
+
+      await selectEvent.openMenu(excluded);
+
+      const options = container.querySelectorAll(query("excludedExperiments"));
+      expect(options.length).toEqual(
+        countBranches(MOCK_EXPERIMENTS_BY_APPLICATION) - 4,
+      );
+
+      expect(
+        Array.from(options, (e) => e.textContent).find((text) =>
+          text?.includes(`(${MOCK_EXPERIMENTS_BY_APPLICATION[1].slug})`),
+        ),
+      ).toBeUndefined();
+    });
   });
 
   it("renders without error", async () => {
@@ -908,7 +1343,7 @@ describe("FormAudience", () => {
 
   it("calls onSubmit when save and next buttons are clicked", async () => {
     const onSubmit = jest.fn();
-    const expected = {
+    const expected: ExperimentInput = {
       channel: MOCK_EXPERIMENT.channel,
       firefoxMinVersion: MOCK_EXPERIMENT.firefoxMinVersion,
       firefoxMaxVersion: MOCK_EXPERIMENT.firefoxMaxVersion,
@@ -922,13 +1357,33 @@ describe("FormAudience", () => {
       languages: MOCK_EXPERIMENT.languages.map((v) => "" + v.id),
       isSticky: MOCK_EXPERIMENT.isSticky,
       isFirstRun: MOCK_EXPERIMENT.isFirstRun,
-      excludedExperiments: [MOCK_EXPERIMENTS_BY_APPLICATION[0].id],
-      requiredExperiments: [MOCK_EXPERIMENTS_BY_APPLICATION[1].id],
+      excludedExperimentsBranches: [
+        {
+          excludedExperiment: MOCK_EXPERIMENTS_BY_APPLICATION[0].id,
+          branchSlug: null,
+        },
+      ],
+      requiredExperimentsBranches: [
+        {
+          requiredExperiment: MOCK_EXPERIMENTS_BY_APPLICATION[1].id,
+          branchSlug: null,
+        },
+      ],
     };
-    const experiment = {
+    const experiment: getExperiment_experimentBySlug = {
       ...MOCK_EXPERIMENT,
-      excludedExperiments: [MOCK_EXPERIMENTS_BY_APPLICATION[0]],
-      requiredExperiments: [MOCK_EXPERIMENTS_BY_APPLICATION[1]],
+      excludedExperimentsBranches: [
+        {
+          excludedExperiment: MOCK_EXPERIMENTS_BY_APPLICATION[0],
+          branchSlug: null,
+        },
+      ],
+      requiredExperimentsBranches: [
+        {
+          requiredExperiment: MOCK_EXPERIMENTS_BY_APPLICATION[1],
+          branchSlug: null,
+        },
+      ],
     };
     render(<Subject {...{ experiment, onSubmit }} />);
     await screen.findByTestId("FormAudience");
@@ -1817,104 +2272,6 @@ describe("FormAudience", () => {
       channel: ["Underneath the electric stars."],
       countries: ["Just come with me"],
       locales: ["We can shake it loose right away"],
-    });
-  });
-
-  describe("excluded and required experiments fields", () => {
-    const query = (field: string) =>
-      `#react-select-${field}-listbox .react-select__option`;
-
-    it("fields renders options", async () => {
-      const experiment = {
-        ...MOCK_EXPERIMENT,
-        name: MOCK_EXPERIMENTS_BY_APPLICATION[0].name,
-        slug: MOCK_EXPERIMENTS_BY_APPLICATION[0].slug,
-        id: MOCK_EXPERIMENTS_BY_APPLICATION[0].id,
-      };
-
-      const { container } = render(<Subject experiment={experiment} />);
-      const excluded = screen.getByLabelText(/Exclude users enrolled/);
-
-      let options = container.querySelectorAll(query("excludedExperiments"));
-      expect(options.length).toEqual(0);
-      await selectEvent.openMenu(excluded);
-      options = container.querySelectorAll(query("excludedExperiments"));
-      expect(options.length).toEqual(
-        MOCK_EXPERIMENTS_BY_APPLICATION.length - 1,
-      );
-
-      expect(
-        Array.from(options, (e) => e.textContent).find((text) =>
-          text?.includes(`(${experiment.slug})`),
-        ),
-      ).toBeUndefined();
-
-      const required = screen.getByLabelText(/Require users to be enrolled/);
-      options = container.querySelectorAll(query("requiredExperiments"));
-      expect(options.length).toEqual(0);
-      await selectEvent.openMenu(required);
-      options = container.querySelectorAll(query("requiredExperiments"));
-      expect(options.length).toEqual(
-        MOCK_EXPERIMENTS_BY_APPLICATION.length - 1,
-      );
-
-      expect(
-        Array.from(options, (e) => e.textContent).find((text) =>
-          text?.includes(`(${experiment.slug})`),
-        ),
-      ).toBeUndefined();
-    });
-
-    it("excludes selected required experiments from the exclude field options", async () => {
-      const experiment = {
-        ...MOCK_EXPERIMENT,
-        name: MOCK_EXPERIMENTS_BY_APPLICATION[0].name,
-        slug: MOCK_EXPERIMENTS_BY_APPLICATION[0].slug,
-        id: MOCK_EXPERIMENTS_BY_APPLICATION[0].id,
-        excludedExperiments: [MOCK_EXPERIMENTS_BY_APPLICATION[1]],
-      };
-
-      const { container } = render(<Subject experiment={experiment} />);
-      const required = screen.getByLabelText(/Require users to be enrolled/);
-
-      await selectEvent.openMenu(required);
-
-      const options = container.querySelectorAll(query("requiredExperiments"));
-      expect(options.length).toEqual(
-        MOCK_EXPERIMENTS_BY_APPLICATION.length - 2,
-      );
-
-      expect(
-        Array.from(options, (e) => e.textContent).find((text) =>
-          text?.includes(`(${MOCK_EXPERIMENTS_BY_APPLICATION[1].slug})`),
-        ),
-      ).toBeUndefined();
-    });
-
-    it("excludes selected excluded experiment from the required field options", async () => {
-      const experiment = {
-        ...MOCK_EXPERIMENT,
-        name: MOCK_EXPERIMENTS_BY_APPLICATION[0].name,
-        slug: MOCK_EXPERIMENTS_BY_APPLICATION[0].slug,
-        id: MOCK_EXPERIMENTS_BY_APPLICATION[0].id,
-        requiredExperiments: [MOCK_EXPERIMENTS_BY_APPLICATION[1]],
-      };
-
-      const { container } = render(<Subject experiment={experiment} />);
-      const excluded = screen.getByLabelText(/Exclude users enrolled/);
-
-      await selectEvent.openMenu(excluded);
-
-      const options = container.querySelectorAll(query("excludedExperiments"));
-      expect(options.length).toEqual(
-        MOCK_EXPERIMENTS_BY_APPLICATION.length - 2,
-      );
-
-      expect(
-        Array.from(options, (e) => e.textContent).find((text) =>
-          text?.includes(`(${MOCK_EXPERIMENTS_BY_APPLICATION[1].slug})`),
-        ),
-      ).toBeUndefined();
     });
   });
 });

--- a/experimenter/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/index.tsx
@@ -8,7 +8,7 @@ import {
   SizingByUserType,
   SizingTarget,
 } from "@mozilla/nimbus-schemas";
-import React, { useMemo, useState } from "react";
+import React, { useCallback, useMemo, useState } from "react";
 import Alert from "react-bootstrap/Alert";
 import Col from "react-bootstrap/Col";
 import Form from "react-bootstrap/Form";
@@ -40,7 +40,10 @@ import {
   getConfig_nimbusConfig_targetingConfigs,
 } from "src/types/getConfig";
 import { getExperiment_experimentBySlug } from "src/types/getExperiment";
-import { NimbusExperimentApplicationEnum } from "src/types/globalTypes";
+import {
+  ExperimentInput,
+  NimbusExperimentApplicationEnum,
+} from "src/types/globalTypes";
 
 type FormAudienceProps = {
   experiment: getExperiment_experimentBySlug;
@@ -48,7 +51,7 @@ type FormAudienceProps = {
   setSubmitErrors: React.Dispatch<React.SetStateAction<Record<string, any>>>;
   isServerValid: boolean;
   isLoading: boolean;
-  onSubmit: (data: Record<string, any>, next: boolean) => void;
+  onSubmit: (data: ExperimentInput, next: boolean) => void;
 };
 
 type AudienceFieldName = typeof audienceFieldNames[number];
@@ -83,12 +86,44 @@ export const MOBILE_APPLICATIONS = [
   NimbusExperimentApplicationEnum.FOCUS_IOS,
 ];
 
-interface SelectExperimentOption {
+interface SelectExperimentBranchOption {
+  id: number;
   name: string;
   slug: string;
   description: string;
   value: string;
+  branchSlug: string | null;
 }
+
+const toExperimentBranchValue = (
+  experiment: getAllExperimentsByApplication_experimentsByApplication,
+  branchSlug: string | null,
+) => `${experiment.slug}:${branchSlug}`;
+
+const toSelectExperimentBranchOption: (
+  experiment: getAllExperimentsByApplication_experimentsByApplication,
+  branchSlug: string | null,
+) => SelectExperimentBranchOption = (experiment, branchSlug) => {
+  const branchLabel = branchSlug ? `${branchSlug} branch` : "All branches";
+
+  return {
+    id: experiment.id,
+    name: `${experiment.name} (${branchLabel})`,
+    slug: experiment.slug,
+    description: experiment.publicDescription ?? "",
+    value: toExperimentBranchValue(experiment, branchSlug),
+    branchSlug,
+  };
+};
+
+const toSelectExperimentBranchOptions: (
+  experiment: getAllExperimentsByApplication_experimentsByApplication,
+) => SelectExperimentBranchOption[] = (experiment) =>
+  [
+    null,
+    experiment.referenceBranch!.slug,
+    ...experiment.treatmentBranches!.map((branch) => branch!.slug),
+  ].map((branchSlug) => toSelectExperimentBranchOption(experiment, branchSlug));
 
 const selectOptions = (items: SelectIdItems) =>
   items.map((item) => ({
@@ -104,60 +139,61 @@ type FilterOptionOption<T> = {
   label: string;
   value: string;
 };
+
 const experimentOptionFilterConfig = {
-  stringify: (option: FilterOptionOption<SelectExperimentOption>): string => {
+  stringify: (
+    option: FilterOptionOption<SelectExperimentBranchOption>,
+  ): string => {
     return `${option.data.slug} ${option.data.name} ${option.data.description}`;
   },
 };
 
 function selectExperimentOptions(
   allExperiments: getAllExperimentsByApplication_experimentsByApplication[],
-  ids?: (number | string)[],
-): SelectExperimentOption[] {
-  let options: getAllExperimentsByApplication_experimentsByApplication[];
-  if (ids) {
-    options = ids.reduce((found, id) => {
-      const meta = allExperiments.find((experiment) => experiment?.id === +id);
-      if (meta) {
-        found.push(meta);
-      }
-      return found;
-    }, [] as getAllExperimentsByApplication_experimentsByApplication[]);
-  } else {
-    options = allExperiments;
+  selectedExperimentBranchValues?: string[],
+): SelectExperimentBranchOption[] {
+  let selectableExperimentBranchOptions = allExperiments.flatMap(
+    toSelectExperimentBranchOptions,
+  );
+
+  if (selectedExperimentBranchValues) {
+    const selectedExperimentBranchValuesSet = new Set(
+      selectedExperimentBranchValues,
+    );
+    selectableExperimentBranchOptions =
+      selectableExperimentBranchOptions.filter((option) =>
+        selectedExperimentBranchValuesSet.has(option.value),
+      );
   }
 
-  return options.map((experiment) => ({
-    name: experiment.name,
-    slug: experiment.slug,
-    description: experiment.publicDescription ?? "",
-    value: experiment.id.toString(),
-  }));
+  return selectableExperimentBranchOptions;
 }
 
 function filterExperimentOptions(
-  options: SelectExperimentOption[],
-  excludeIds: string[],
-): SelectExperimentOption[] {
-  return options.filter((option) => !excludeIds.includes(option.value));
+  options: SelectExperimentBranchOption[],
+  exclude: SelectExperimentBranchOption[],
+): SelectExperimentBranchOption[] {
+  const excludeSlugs = new Set(exclude.map((e) => e.value));
+  return options.filter((option) => !excludeSlugs.has(option.value));
 }
 
 function formatExperimentOptionLabel(
-  data: SelectExperimentOption,
-  meta: FormatOptionLabelMeta<SelectExperimentOption>,
+  data: SelectExperimentBranchOption,
+  meta: FormatOptionLabelMeta<SelectExperimentBranchOption>,
 ): React.ReactNode {
   if (meta.context === "menu") {
     return (
       <>
-        <b>{data.name}</b> (
-        <span className="required-excluded-experiment-slug">{data.slug}</span>)
+        <b>{data.name}</b>
+        <br />
+        <span className="required-excluded-experiment-slug">{data.slug}</span>
         <br />
         <i>{data.description}</i>
       </>
     );
   }
 
-  return <span className="required-excluded-experiment-slug">{data.slug}</span>;
+  return <span>{data.name}</span>;
 }
 
 export const FormAudience = ({
@@ -198,11 +234,20 @@ export const FormAudience = ({
     experiment.isSticky ?? false,
   );
 
-  const [excludedExperiments, setExcludedExperiments] = useState<string[]>(
-    experiment!.excludedExperiments.map((e) => e.id.toString()),
+  const [excludedExperiments, setExcludedExperiments] = useState<
+    SelectExperimentBranchOption[]
+  >(
+    experiment!.excludedExperimentsBranches.map((eb) =>
+      toSelectExperimentBranchOption(eb.excludedExperiment, eb.branchSlug),
+    ),
   );
-  const [requiredExperiments, setRequiredExperiments] = useState<string[]>(
-    experiment!.requiredExperiments.map((e) => e.id.toString()),
+
+  const [requiredExperiments, setRequiredExperiments] = useState<
+    SelectExperimentBranchOption[]
+  >(
+    experiment!.requiredExperimentsBranches.map((eb) =>
+      toSelectExperimentBranchOption(eb.requiredExperiment, eb.branchSlug),
+    ),
   );
 
   const experimentOptions = useMemo(
@@ -213,19 +258,51 @@ export const FormAudience = ({
   const requiredExperimentOptions = useMemo(
     () =>
       filterExperimentOptions(experimentOptions, [
-        experiment.id.toString(),
+        ...toSelectExperimentBranchOptions(experiment),
         ...excludedExperiments,
       ]),
-    [experiment.id, experimentOptions, excludedExperiments],
+    [experiment, experimentOptions, excludedExperiments],
+  );
+
+  const requiredExperimentIds = useMemo(
+    () => requiredExperiments.map((e) => e.value),
+    [requiredExperiments],
   );
 
   const excludedExperimentOptions = useMemo(
     () =>
       filterExperimentOptions(experimentOptions, [
-        experiment.id.toString(),
+        ...toSelectExperimentBranchOptions(experiment),
         ...requiredExperiments,
       ]),
-    [experiment.id, experimentOptions, requiredExperiments],
+    [experiment, experimentOptions, requiredExperiments],
+  );
+
+  const excludedExperimentIds = useMemo(
+    () => excludedExperiments.map((e) => e.value),
+    [excludedExperiments],
+  );
+
+  const setRequiredExperimentsCallback = useCallback(
+    (values) => {
+      setRequiredExperiments(
+        experimentOptions.filter((eo) =>
+          (values as string[]).includes(eo.value),
+        ),
+      );
+    },
+    [experimentOptions],
+  );
+
+  const setExcludedExperimentsCallback = useCallback(
+    (values) => {
+      setExcludedExperiments(
+        experimentOptions.filter((eo) =>
+          (values as string[]).includes(eo.value),
+        ),
+      );
+    },
+    [experimentOptions],
   );
 
   const [isFirstRun, setIsFirstRun] = useState<boolean>(
@@ -266,11 +343,15 @@ export const FormAudience = ({
       languages: selectOptions(experiment.languages as SelectIdItems),
       isSticky: experiment.isSticky,
       isFirstRun: experiment.isFirstRun,
-      excludedExperiments: selectExperimentOptions(
-        experiment.excludedExperiments as getAllExperimentsByApplication_experimentsByApplication[],
+      excludedExperimentsBranches: selectExperimentOptions(
+        experiment.excludedExperimentsBranches.map(
+          (eb) => eb.excludedExperiment,
+        ),
       ),
-      requiredExperiments: selectExperimentOptions(
-        experiment.requiredExperiments as getAllExperimentsByApplication_experimentsByApplication[],
+      requiredExperimentsBranches: selectExperimentOptions(
+        experiment.requiredExperimentsBranches.map(
+          (eb) => eb.requiredExperiment,
+        ),
       ),
     }),
     [experiment],
@@ -303,18 +384,28 @@ export const FormAudience = ({
             onSubmit(
               {
                 ...dataIn,
+                // dataIn.proposedDuration will be undefined for live rollouts
+                proposedDuration: dataIn.proposedDuration
+                  ? dataIn.proposedDuration.toString()
+                  : defaultValues.proposedDuration.toString(),
+                // dataIn.proposedEnrollment will be undefined for rollouts
+                proposedEnrollment: (
+                  dataIn.proposedEnrollment ?? defaultValues.proposedEnrollment
+                ).toString(),
                 isSticky,
                 populationPercent,
                 isFirstRun,
                 locales,
                 countries,
                 languages,
-                requiredExperiments: requiredExperiments.map((id) =>
-                  parseInt(id, 10),
-                ),
-                excludedExperiments: excludedExperiments.map((id) =>
-                  parseInt(id, 10),
-                ),
+                requiredExperimentsBranches: requiredExperiments.map((e) => ({
+                  requiredExperiment: e.id,
+                  branchSlug: e.branchSlug,
+                })),
+                excludedExperimentsBranches: excludedExperiments.map((e) => ({
+                  excludedExperiment: e.id,
+                  branchSlug: e.branchSlug,
+                })),
               },
               next,
             )
@@ -333,6 +424,8 @@ export const FormAudience = ({
       languages,
       excludedExperiments,
       requiredExperiments,
+      defaultValues.proposedDuration,
+      defaultValues.proposedEnrollment,
     ],
   );
 
@@ -627,9 +720,9 @@ export const FormAudience = ({
             <SelectExperimentField
               name="excludedExperiments"
               formSelectAttrs={formSelectAttrs}
-              setExperiments={setExcludedExperiments}
+              setExperiments={setExcludedExperimentsCallback}
               allExperiments={allExperimentMeta}
-              experimentIds={excludedExperiments}
+              experimentIds={excludedExperimentIds}
               options={excludedExperimentOptions}
               isDisabled={isLocked!}
             />
@@ -645,9 +738,9 @@ export const FormAudience = ({
             <SelectExperimentField
               name="requiredExperiments"
               formSelectAttrs={formSelectAttrs}
-              setExperiments={setRequiredExperiments}
+              setExperiments={setRequiredExperimentsCallback}
               allExperiments={allExperimentMeta}
-              experimentIds={requiredExperiments}
+              experimentIds={requiredExperimentIds}
               options={requiredExperimentOptions}
               isDisabled={isLocked!}
             />
@@ -1021,7 +1114,7 @@ interface SelectExperimentFieldProps {
   setExperiments: React.Dispatch<React.SetStateAction<string[]>>;
   allExperiments: getAllExperimentsByApplication_experimentsByApplication[];
   experimentIds: string[];
-  options: SelectExperimentOption[];
+  options: SelectExperimentBranchOption[];
   isDisabled?: boolean;
 }
 
@@ -1035,7 +1128,7 @@ function SelectExperimentField({
   isDisabled,
 }: SelectExperimentFieldProps) {
   return (
-    <Select<SelectExperimentOption, true>
+    <Select<SelectExperimentBranchOption, true>
       isMulti
       placeholder="Experiments..."
       {...formSelectAttrs(name, setExperiments)}
@@ -1047,7 +1140,7 @@ function SelectExperimentField({
       name={name}
       inputId={name}
       classNamePrefix="react-select"
-      filterOption={createFilter<SelectExperimentOption>(
+      filterOption={createFilter<SelectExperimentBranchOption>(
         experimentOptionFilterConfig,
       )}
     />

--- a/experimenter/experimenter/nimbus-ui/src/components/PageEditAudience/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageEditAudience/index.tsx
@@ -46,8 +46,8 @@ const PageEditAudience: React.FunctionComponent<RouteComponentProps> = () => {
         languages,
         isSticky,
         isFirstRun,
-        requiredExperiments,
-        excludedExperiments,
+        requiredExperimentsBranches,
+        excludedExperimentsBranches,
       }: Record<string, any>,
       next: boolean,
     ) => {
@@ -76,8 +76,8 @@ const PageEditAudience: React.FunctionComponent<RouteComponentProps> = () => {
               languages,
               isSticky,
               isFirstRun,
-              requiredExperiments,
-              excludedExperiments,
+              requiredExperimentsBranches,
+              excludedExperimentsBranches,
             },
           },
         });

--- a/experimenter/experimenter/nimbus-ui/src/components/Summary/TableAudience/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/Summary/TableAudience/index.tsx
@@ -13,7 +13,8 @@ import { ReactComponent as CollapseMinus } from "src/images/minus.svg";
 import { ReactComponent as ExpandPlus } from "src/images/plus.svg";
 import {
   getExperiment_experimentBySlug,
-  getExperiment_experimentBySlug_excludedExperiments,
+  getExperiment_experimentBySlug_excludedExperimentsBranches_excludedExperiment,
+  getExperiment_experimentBySlug_requiredExperimentsBranches_requiredExperiment,
 } from "src/types/getExperiment";
 import { NimbusExperimentApplicationEnum } from "src/types/globalTypes";
 
@@ -170,11 +171,25 @@ const TableAudience = ({ experiment }: TableAudienceProps) => {
             <tr>
               <th>Required Experiments</th>
               <td>
-                <ExperimentList experiments={experiment.requiredExperiments} />
+                <ExperimentList
+                  experimentsBranches={experiment.requiredExperimentsBranches.map(
+                    (eb) => ({
+                      experiment: eb.requiredExperiment,
+                      branchSlug: eb.branchSlug,
+                    }),
+                  )}
+                />
               </td>
               <th>Excluded Experiments</th>
               <td>
-                <ExperimentList experiments={experiment.excludedExperiments} />
+                <ExperimentList
+                  experimentsBranches={experiment.excludedExperimentsBranches.map(
+                    (eb) => ({
+                      experiment: eb.excludedExperiment,
+                      branchSlug: eb.branchSlug,
+                    }),
+                  )}
+                />
               </td>
             </tr>
 
@@ -248,20 +263,32 @@ const TableAudience = ({ experiment }: TableAudienceProps) => {
 };
 
 interface ExperimentListProps {
-  experiments: getExperiment_experimentBySlug_excludedExperiments[];
+  experimentsBranches: {
+    experiment:
+      | getExperiment_experimentBySlug_excludedExperimentsBranches_excludedExperiment
+      | getExperiment_experimentBySlug_requiredExperimentsBranches_requiredExperiment;
+    branchSlug: string | null;
+  }[];
 }
-function ExperimentList({ experiments }: ExperimentListProps) {
-  if (experiments.length === 0) {
+function ExperimentList({ experimentsBranches }: ExperimentListProps) {
+  if (experimentsBranches.length === 0) {
     return <span>None</span>;
   }
 
   return (
     <>
-      {experiments.map((experiment) => (
-        <p key={experiment.slug}>
-          <a href={`/nimbus/${experiment.slug}/summary`}>{experiment.name}</a>
-        </p>
-      ))}
+      {experimentsBranches.map((experimentBranch) => {
+        const branchLabel = experimentBranch.branchSlug
+          ? `${experimentBranch.branchSlug} branch`
+          : "All branches";
+        return (
+          <p key={experimentBranch.experiment.slug}>
+            <a href={`/nimbus/${experimentBranch.experiment.slug}/summary`}>
+              {experimentBranch.experiment.name} ({branchLabel})
+            </a>
+          </p>
+        );
+      })}
     </>
   );
 }

--- a/experimenter/experimenter/nimbus-ui/src/components/Summary/index.test.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/Summary/index.test.tsx
@@ -728,15 +728,55 @@ describe("Summary", () => {
     });
   });
 
-  it("render the required and excluded experiments", () => {
+  it("render the required and excluded experiments all branches", () => {
     const experiment = {
       ...MOCK_EXPERIMENT,
-      requiredExperiments: [MOCK_EXPERIMENTS_BY_APPLICATION[1]],
-      excludedExperiments: [MOCK_EXPERIMENTS_BY_APPLICATION[2]],
+      requiredExperimentsBranches: [
+        {
+          requiredExperiment: MOCK_EXPERIMENTS_BY_APPLICATION[1],
+          branchSlug: null,
+        },
+      ],
+      excludedExperimentsBranches: [
+        {
+          excludedExperiment: MOCK_EXPERIMENTS_BY_APPLICATION[2],
+          branchSlug: null,
+        },
+      ],
     };
     render(<Subject props={experiment} />);
 
-    screen.getByRole("link", { name: MOCK_EXPERIMENTS_BY_APPLICATION[1].name });
-    screen.getByRole("link", { name: MOCK_EXPERIMENTS_BY_APPLICATION[2].name });
+    screen.getByRole("link", {
+      name: `${MOCK_EXPERIMENTS_BY_APPLICATION[1].name} (All branches)`,
+    });
+    screen.getByRole("link", {
+      name: `${MOCK_EXPERIMENTS_BY_APPLICATION[2].name} (All branches)`,
+    });
+  });
+
+  it("render the required and excluded experiments specific branches", () => {
+    const experiment = {
+      ...MOCK_EXPERIMENT,
+      requiredExperimentsBranches: [
+        {
+          requiredExperiment: MOCK_EXPERIMENTS_BY_APPLICATION[1],
+          branchSlug: "control",
+        },
+      ],
+      excludedExperimentsBranches: [
+        {
+          excludedExperiment: MOCK_EXPERIMENTS_BY_APPLICATION[2],
+          branchSlug: "treatment",
+        },
+      ],
+    };
+    render(<Subject props={experiment} />);
+
+    screen.getByRole("link", {
+      name: `${MOCK_EXPERIMENTS_BY_APPLICATION[1].name} (control branch)`,
+    });
+    screen.getByRole("link", {
+      name: `${MOCK_EXPERIMENTS_BY_APPLICATION[2].name} (treatment branch)`,
+    });
   });
 });

--- a/experimenter/experimenter/nimbus-ui/src/gql/experiments.ts
+++ b/experimenter/experimenter/nimbus-ui/src/gql/experiments.ts
@@ -132,15 +132,35 @@ export const GET_EXPERIMENT_QUERY = gql`
       isSticky
       isFirstRun
       isWeb
-      excludedExperiments {
-        id
-        slug
-        name
+      excludedExperimentsBranches {
+        excludedExperiment {
+          id
+          slug
+          name
+          publicDescription
+          referenceBranch {
+            slug
+          }
+          treatmentBranches {
+            slug
+          }
+        }
+        branchSlug
       }
-      requiredExperiments {
-        id
-        slug
-        name
+      requiredExperimentsBranches {
+        requiredExperiment {
+          id
+          slug
+          name
+          publicDescription
+          referenceBranch {
+            slug
+          }
+          treatmentBranches {
+            slug
+          }
+        }
+        branchSlug
       }
       jexlTargetingExpression
 
@@ -305,6 +325,12 @@ export const GET_ALL_EXPERIMENTS_BY_APPLICATION_QUERY = gql`
       name
       slug
       publicDescription
+      referenceBranch {
+        slug
+      }
+      treatmentBranches {
+        slug
+      }
     }
   }
 `;

--- a/experimenter/experimenter/nimbus-ui/src/lib/mocks.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/lib/mocks.tsx
@@ -669,8 +669,8 @@ export const MOCK_EXPERIMENT: Partial<getExperiment["experimentBySlug"]> = {
   projects: [{ name: "Pocket", id: "1" }],
   isLocalized: false,
   localizations: null,
-  requiredExperiments: [],
-  excludedExperiments: [],
+  requiredExperimentsBranches: [],
+  excludedExperimentsBranches: [],
   takeawaysQbrLearning: false,
   takeawaysMetricGain: false,
   takeawaysGainAmount: null,
@@ -781,8 +781,8 @@ export const MOCK_LIVE_ROLLOUT: Partial<getExperiment["experimentBySlug"]> = {
   countries: [{ name: "Canada", id: "1", code: "Ca" }],
   languages: [{ name: "English", id: "1", code: "En" }],
   projects: [{ name: "Pocket", id: "1" }],
-  requiredExperiments: [],
-  excludedExperiments: [],
+  requiredExperimentsBranches: [],
+  excludedExperimentsBranches: [],
   qaComment: null,
   qaStatus: NimbusExperimentQAStatusEnum.NOT_SET,
 };
@@ -1109,6 +1109,8 @@ export const MOCK_EXPERIMENTS_BY_APPLICATION: getAllExperimentsByApplication_exp
     name: experiment.name,
     slug: experiment.slug ?? experiment.name.toLowerCase().replace(" ", "-"),
     publicDescription: "mock description",
+    referenceBranch: { slug: "control" },
+    treatmentBranches: [{ slug: "treatment" }],
   }));
 
 // Basically the same as useOutcomes, but uses the mocked config values

--- a/experimenter/experimenter/nimbus-ui/src/types/getAllExperimentsByApplication.ts
+++ b/experimenter/experimenter/nimbus-ui/src/types/getAllExperimentsByApplication.ts
@@ -9,11 +9,21 @@ import { NimbusExperimentApplicationEnum } from "./globalTypes";
 // GraphQL query operation: getAllExperimentsByApplication
 // ====================================================
 
+export interface getAllExperimentsByApplication_experimentsByApplication_referenceBranch {
+  slug: string;
+}
+
+export interface getAllExperimentsByApplication_experimentsByApplication_treatmentBranches {
+  slug: string;
+}
+
 export interface getAllExperimentsByApplication_experimentsByApplication {
   id: number;
   name: string;
   slug: string;
   publicDescription: string | null;
+  referenceBranch: getAllExperimentsByApplication_experimentsByApplication_referenceBranch | null;
+  treatmentBranches: (getAllExperimentsByApplication_experimentsByApplication_treatmentBranches | null)[] | null;
 }
 
 export interface getAllExperimentsByApplication {

--- a/experimenter/experimenter/nimbus-ui/src/types/getExperiment.ts
+++ b/experimenter/experimenter/nimbus-ui/src/types/getExperiment.ts
@@ -88,16 +88,48 @@ export interface getExperiment_experimentBySlug_targetingConfig {
   isFirstRunRequired: boolean | null;
 }
 
-export interface getExperiment_experimentBySlug_excludedExperiments {
-  id: number;
+export interface getExperiment_experimentBySlug_excludedExperimentsBranches_excludedExperiment_referenceBranch {
   slug: string;
-  name: string;
 }
 
-export interface getExperiment_experimentBySlug_requiredExperiments {
+export interface getExperiment_experimentBySlug_excludedExperimentsBranches_excludedExperiment_treatmentBranches {
+  slug: string;
+}
+
+export interface getExperiment_experimentBySlug_excludedExperimentsBranches_excludedExperiment {
   id: number;
   slug: string;
   name: string;
+  publicDescription: string | null;
+  referenceBranch: getExperiment_experimentBySlug_excludedExperimentsBranches_excludedExperiment_referenceBranch | null;
+  treatmentBranches: (getExperiment_experimentBySlug_excludedExperimentsBranches_excludedExperiment_treatmentBranches | null)[] | null;
+}
+
+export interface getExperiment_experimentBySlug_excludedExperimentsBranches {
+  excludedExperiment: getExperiment_experimentBySlug_excludedExperimentsBranches_excludedExperiment;
+  branchSlug: string | null;
+}
+
+export interface getExperiment_experimentBySlug_requiredExperimentsBranches_requiredExperiment_referenceBranch {
+  slug: string;
+}
+
+export interface getExperiment_experimentBySlug_requiredExperimentsBranches_requiredExperiment_treatmentBranches {
+  slug: string;
+}
+
+export interface getExperiment_experimentBySlug_requiredExperimentsBranches_requiredExperiment {
+  id: number;
+  slug: string;
+  name: string;
+  publicDescription: string | null;
+  referenceBranch: getExperiment_experimentBySlug_requiredExperimentsBranches_requiredExperiment_referenceBranch | null;
+  treatmentBranches: (getExperiment_experimentBySlug_requiredExperimentsBranches_requiredExperiment_treatmentBranches | null)[] | null;
+}
+
+export interface getExperiment_experimentBySlug_requiredExperimentsBranches {
+  requiredExperiment: getExperiment_experimentBySlug_requiredExperimentsBranches_requiredExperiment;
+  branchSlug: string | null;
 }
 
 export interface getExperiment_experimentBySlug_readyForReview {
@@ -211,8 +243,8 @@ export interface getExperiment_experimentBySlug {
   isSticky: boolean | null;
   isFirstRun: boolean;
   isWeb: boolean;
-  excludedExperiments: getExperiment_experimentBySlug_excludedExperiments[];
-  requiredExperiments: getExperiment_experimentBySlug_requiredExperiments[];
+  excludedExperimentsBranches: getExperiment_experimentBySlug_excludedExperimentsBranches[];
+  requiredExperimentsBranches: getExperiment_experimentBySlug_requiredExperimentsBranches[];
   jexlTargetingExpression: string | null;
   populationPercent: string | null;
   totalEnrolledClients: number;


### PR DESCRIPTION
Because

* We can now require/exclude specific branches of experiments/rollouts

This commit

* Adds entries in the require/exclude drop downs for specific branches of each experiment/rollout

fixes #10029

<img width="1292" alt="image" src="https://github.com/mozilla/experimenter/assets/119884/1353be93-f838-45f9-9847-d31925dc9c6d">

