### PR TITLE
Run cirrus pytest command in verbose mode

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,7 +89,7 @@ jobs:
       - run:
           name: Run Cirrus tests and linting
           command: |
-            make cirrus_check
+            make cirrus_check -v
 
   check_cirrus_aarch64:
     machine:
@@ -104,7 +104,7 @@ jobs:
       - run:
           name: Run Cirrus tests and linting
           command: |
-            make cirrus_check
+            make cirrus_check -v
 
   check_schemas:
     machine:

--- a/cirrus/README.md
+++ b/cirrus/README.md
@@ -65,7 +65,7 @@ The following are the available commands for working with Cirrus:
 
   - Usage: `make cirrus_test`
 
-- **cirrus_check**: Performs various checks on the Cirrus application including Ruff linting, Black code formatting check, Pyright static type checking, pytest tests, and documentation generation..
+- **cirrus_check**: Performs various checks on the Cirrus application including Ruff linting, Black code formatting check, Pyright static type checking, pytest tests, and documentation generation.
 
   - Usage: `make cirrus_check`
 


### PR DESCRIPTION
This commit
- runs `make cirrus_check` in verbose mode.

Fixes #9148 