### PR TITLE
feat(nimbus): Ignore specific versions in manifesttool

### DIFF
--- a/experimenter/experimenter/features/manifests/apps.yaml
+++ b/experimenter/experimenter/features/manifests/apps.yaml
@@ -79,6 +79,8 @@ focus_ios:
           - "releases_v999" # nimbus.fml.yaml missing. Breaks "last 5 releases" logic.
         ignored_tags:
           - "v999.0.0" # nimbus.fml.yaml missing.
+        ignored_versions:
+          - "9000.0.0"
 
 monitor_cirrus:
   slug: "monitor-web"

--- a/experimenter/manifesttool/appconfig.py
+++ b/experimenter/manifesttool/appconfig.py
@@ -5,6 +5,8 @@ from typing import Any, Literal, Optional, Union
 import yaml
 from pydantic import BaseModel, Field, root_validator
 
+from manifesttool.version import Version
+
 
 class RepositoryType(str, Enum):
     HGMO = "hgmo"  # hg.mozilla.org
@@ -77,6 +79,7 @@ class TaggedDiscoveryStrategy(BaseModel):
     tag_re: Optional[str]
     ignored_branches: Optional[list[str]]
     ignored_tags: Optional[list[str]]
+    ignored_versions: Optional[list[Version]]
 
 
 class BranchedDiscoveryStrategy(BaseModel):
@@ -97,6 +100,7 @@ class DiscoveryStrategy(BaseModel):
         tag_re: Optional[str] = None,
         ignored_branches: Optional[list[str]] = None,
         ignored_tags: Optional[list[str]] = None,
+        ignored_versions: Optional[list[Version]] = None,
     ):  # pragma: no cover
         return cls(
             __root__=TaggedDiscoveryStrategy(
@@ -105,6 +109,7 @@ class DiscoveryStrategy(BaseModel):
                 tag_re=tag_re,
                 ignored_branches=ignored_branches,
                 ignored_tags=ignored_tags,
+                ignored_versions=ignored_versions,
             )
         )
 


### PR DESCRIPTION
Because

- we ran into a case where focus-ios reported v9000 for a release branch; and
- we don't want to add a v9000 for focus-ios because it is used a placeholder version

This commit:

- adds support for a "ignored_versions" field on tagged discovery strategies, which will omit any matching releases from fetches.

Fixes #10100