### PR TITLE
feat(nimbus): only show one require/exclude option if only one branch

### DIFF
--- a/experimenter/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/index.test.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/index.test.tsx
@@ -107,6 +107,49 @@ describe("FormAudience", () => {
       ).toBeUndefined();
     });
 
+    it("only displays one option for experiments with one branch", async () => {
+      const experiment = {
+        ...MOCK_EXPERIMENT,
+        name: MOCK_EXPERIMENTS_BY_APPLICATION[0].name,
+        slug: MOCK_EXPERIMENTS_BY_APPLICATION[0].slug,
+        id: MOCK_EXPERIMENTS_BY_APPLICATION[0].id,
+      };
+
+      const experimentsByApplication = [
+        { ...MOCK_EXPERIMENTS_BY_APPLICATION[1], treatmentBranches: [] },
+      ];
+
+      const { container } = render(
+        <Subject
+          experiment={experiment}
+          experimentsByApplication={{
+            allExperiments: experimentsByApplication,
+          }}
+        />,
+      );
+      const excluded = screen.getByLabelText(/Exclude users enrolled/);
+      await selectEvent.openMenu(excluded);
+      let options = container.querySelectorAll(query("excludedExperiments"));
+      expect(options.length).toEqual(1);
+
+      expect(
+        Array.from(options, (e) => e.textContent).find((text) =>
+          text?.includes(`(${experiment.slug})`),
+        ),
+      ).toBeUndefined();
+
+      const required = screen.getByLabelText(/Require users to be enrolled/);
+      await selectEvent.openMenu(required);
+      options = container.querySelectorAll(query("requiredExperiments"));
+      expect(options.length).toEqual(1);
+
+      expect(
+        Array.from(options, (e) => e.textContent).find((text) =>
+          text?.includes(`(${experiment.slug})`),
+        ),
+      ).toBeUndefined();
+    });
+
     it("saves required and excluded experiments with all branches for experiments", async () => {
       const onSubmit = jest.fn();
       const MOCK_EXPERIMENTS_BY_APPLICATION: getAllExperimentsByApplication_experimentsByApplication[] =

--- a/experimenter/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/index.tsx
@@ -118,12 +118,21 @@ const toSelectExperimentBranchOption: (
 
 const toSelectExperimentBranchOptions: (
   experiment: getAllExperimentsByApplication_experimentsByApplication,
-) => SelectExperimentBranchOption[] = (experiment) =>
-  [
-    null,
-    experiment.referenceBranch!.slug,
-    ...experiment.treatmentBranches!.map((branch) => branch!.slug),
-  ].map((branchSlug) => toSelectExperimentBranchOption(experiment, branchSlug));
+) => SelectExperimentBranchOption[] = (experiment) => {
+  let experimentBranchOptions;
+  if (experiment.treatmentBranches!.length === 0) {
+    experimentBranchOptions = [experiment.referenceBranch!.slug];
+  } else {
+    experimentBranchOptions = [
+      null,
+      experiment.referenceBranch!.slug,
+      ...experiment.treatmentBranches!.map((branch) => branch!.slug),
+    ];
+  }
+  return experimentBranchOptions.map((branchSlug) =>
+    toSelectExperimentBranchOption(experiment, branchSlug),
+  );
+};
 
 const selectOptions = (items: SelectIdItems) =>
   items.map((item) => ({


### PR DESCRIPTION
Because

* We don't need to show the 'All branches' option if there's only a single branch in an experiment/rollout

This commit

* Only shows a single entry in require/exclude for experiments/rollouts with one branch

fixes #10082
