### PR TITLE
feat(nimbus): Support new setPref schema for Desktop

### DIFF
--- a/experimenter/experimenter/experiments/tests/test_models.py
+++ b/experimenter/experimenter/experiments/tests/test_models.py
@@ -762,7 +762,7 @@ class TestNimbusExperiment(TestCase):
             feature_configs=[
                 NimbusFeatureConfig.objects.get(
                     application=NimbusExperiment.Application.DESKTOP,
-                    slug="prefSettingFeature",
+                    slug="oldSetPrefFeature",
                 )
             ],
         )
@@ -798,7 +798,7 @@ class TestNimbusExperiment(TestCase):
             feature_configs=[
                 NimbusFeatureConfig.objects.get(
                     application=NimbusExperiment.Application.DESKTOP,
-                    slug="prefSettingFeature",
+                    slug="oldSetPrefFeature",
                 )
             ],
         )

--- a/experimenter/experimenter/features/management/commands/load_feature_configs.py
+++ b/experimenter/experimenter/features/management/commands/load_feature_configs.py
@@ -1,9 +1,10 @@
 import itertools
 import logging
-from typing import Optional
+from typing import Optional, Union
 
 from django.core.management.base import BaseCommand
 from django.db import transaction
+from mozilla_nimbus_schemas.experiments.feature_manifests import SetPref
 
 from experimenter.experiments.constants import NO_FEATURE_SLUG
 from experimenter.experiments.models import (
@@ -170,8 +171,14 @@ class Command(BaseCommand):
                     schema.schema = jsonschema
                     dirty_fields.append("schema")
 
+            def set_pref_name(v: Union[SetPref, str]) -> str:
+                if isinstance(v, SetPref):
+                    return v.pref
+                else:
+                    return v
+
             sets_prefs = [
-                v.set_pref
+                set_pref_name(v.set_pref)
                 for v in feature.model.variables.values()
                 if v.set_pref is not None
             ]

--- a/experimenter/experimenter/features/tests/fixtures/valid_features/firefox-desktop/experimenter.yaml
+++ b/experimenter/experimenter/features/tests/fixtures/valid_features/firefox-desktop/experimenter.yaml
@@ -30,8 +30,8 @@ missingVariables:
   exposureDescription: An exposure event
   isEarlyStartup: true
   variables: {}
-prefSettingFeature:
-  description: A feature that sets prefs
+oldSetPrefFeature:
+  description: A feature that sets prefs via the old setPref schema
   hasExposure: true
   exposureDescription: An exposure event
   variables:
@@ -47,3 +47,17 @@ prefSettingFeature:
       type: boolean
       setPref: nimbus.test.boolean
       description: Boolean property
+setPrefFeature:
+  description: A feature that sets prefs
+  hasExposure: false
+  variables:
+    user:
+      type: string
+      setPref:
+        branch: user
+        pref: nimbus.user
+    default:
+      type: string
+      setPref:
+        branch: default
+        pref: nimbus.default

--- a/experimenter/experimenter/features/tests/test_features.py
+++ b/experimenter/experimenter/features/tests/test_features.py
@@ -34,7 +34,7 @@ class TestFeatures(TestCase):
 
     def test_load_all_features(self):
         features = Features.all()
-        self.assertEqual(len(features), 4)
+        self.assertEqual(len(features), 5)
         self.assertIn(
             Feature(
                 slug="someFeature",
@@ -96,7 +96,7 @@ class TestFeatures(TestCase):
 
     def test_load_features_by_application(self):
         desktop_features = Features.by_application(NimbusExperiment.Application.DESKTOP)
-        self.assertEqual(len(desktop_features), 3)
+        self.assertEqual(len(desktop_features), 4)
         self.assertIn(
             Feature(
                 slug="someFeature",

--- a/experimenter/experimenter/features/tests/test_load_feature_configs.py
+++ b/experimenter/experimenter/features/tests/test_load_feature_configs.py
@@ -67,12 +67,18 @@ class TestLoadFeatureConfigs(TestCase):
         )
 
         self.assertTrue(schema.is_early_startup)
-        feature_config = NimbusFeatureConfig.objects.get(slug="prefSettingFeature")
+        feature_config = NimbusFeatureConfig.objects.get(slug="oldSetPrefFeature")
         schema = feature_config.schemas.get(version=None)
 
         self.assertEqual(
             sorted(schema.sets_prefs),
             sorted(["nimbus.test.string", "nimbus.test.int", "nimbus.test.boolean"]),
+        )
+
+        feature_config = NimbusFeatureConfig.objects.get(slug="setPrefFeature")
+        schema = feature_config.schemas.get(version=None)
+        self.assertEqual(
+            sorted(schema.sets_prefs), sorted(["nimbus.user", "nimbus.default"])
         )
 
     def test_updates_existing_feature_configs(self):
@@ -88,8 +94,8 @@ class TestLoadFeatureConfigs(TestCase):
             ],
         )
         NimbusFeatureConfigFactory.create(
-            name="prefSettingFeature",
-            slug="prefSettingFeature",
+            name="oldSetPrefFeature",
+            slug="oldSetPrefeature",
             application=NimbusExperiment.Application.DESKTOP,
             schemas=[
                 NimbusVersionedSchemaFactory.build(
@@ -133,7 +139,7 @@ class TestLoadFeatureConfigs(TestCase):
         )
         self.assertTrue(schema.is_early_startup)
 
-        feature_config = NimbusFeatureConfig.objects.get(slug="prefSettingFeature")
+        feature_config = NimbusFeatureConfig.objects.get(slug="oldSetPrefFeature")
 
         self.assertEqual(
             sorted(feature_config.schemas.get(version=None).sets_prefs),


### PR DESCRIPTION
Because

- Desktop changed the format of setPref annotations in https://bugzilla.mozilla.org/show_bug.cgi?id=1875404; and
- mozilla-nimbus-schemas added support in #10116 

This commit

- updates our version of mozilla-nimbus-schemas to the latest; and
- updates feature config loading to support both the old and new annotation format.

Fixes #10078 