### PR TITLE
chore(nimbus): remove old required/excluded api fields

### DIFF
--- a/experimenter/experimenter/experiments/api/v5/inputs.py
+++ b/experimenter/experimenter/experiments/api/v5/inputs.py
@@ -55,7 +55,6 @@ class ExperimentInput(graphene.InputObjectType):
     conclusion_recommendation = NimbusExperimentConclusionRecommendationEnum()
     countries = graphene.List(graphene.String)
     documentation_links = graphene.List(DocumentationLinkInput)
-    excluded_experiments = graphene.List(graphene.NonNull(graphene.Int))
     excluded_experiments_branches = graphene.List(
         graphene.NonNull(NimbusExperimentBranchThroughExcludedInput)
     )
@@ -86,7 +85,6 @@ class ExperimentInput(graphene.InputObjectType):
     qa_comment = graphene.String()
     qa_status = NimbusExperimentQAStatusEnum()
     reference_branch = graphene.Field(BranchInput)
-    required_experiments = graphene.List(graphene.NonNull(graphene.Int))
     required_experiments_branches = graphene.List(
         graphene.NonNull(NimbusExperimentBranchThroughRequiredInput)
     )

--- a/experimenter/experimenter/experiments/api/v5/serializers.py
+++ b/experimenter/experimenter/experiments/api/v5/serializers.py
@@ -931,18 +931,6 @@ class NimbusExperimentSerializer(
         allow_null=True,
         required=False,
     )
-    excluded_experiments = serializers.PrimaryKeyRelatedField(
-        queryset=NimbusExperiment.objects.all(),
-        many=True,
-        allow_empty=True,
-        required=False,
-    )
-    required_experiments = serializers.PrimaryKeyRelatedField(
-        queryset=NimbusExperiment.objects.all(),
-        many=True,
-        allow_empty=True,
-        required=False,
-    )
     excluded_experiments_branches = NimbusExperimentBranchThroughExcludedSerializer(
         many=True,
         required=False,
@@ -978,7 +966,6 @@ class NimbusExperimentSerializer(
             "countries",
             "documentation_links",
             "excluded_experiments_branches",
-            "excluded_experiments",
             "feature_config",
             "feature_configs",
             "firefox_max_version",
@@ -1008,7 +995,6 @@ class NimbusExperimentSerializer(
             "qa_status",
             "reference_branch",
             "required_experiments_branches",
-            "required_experiments",
             "risk_brand",
             "risk_mitigation_link",
             "risk_partner_related",

--- a/experimenter/experimenter/experiments/api/v5/types.py
+++ b/experimenter/experimenter/experiments/api/v5/types.py
@@ -486,9 +486,6 @@ class NimbusExperimentType(DjangoObjectType):
     countries = graphene.List(graphene.NonNull(NimbusCountryType), required=True)
     documentation_links = DjangoListField(NimbusDocumentationLinkType)
     enrollment_end_date = graphene.DateTime()
-    excluded_experiments = graphene.NonNull(
-        lambda: graphene.List(graphene.NonNull(NimbusExperimentType))
-    )
     excluded_experiments_branches = graphene.NonNull(
         lambda: graphene.List(graphene.NonNull(NimbusExperimentBranchThroughExcludedType))
     )
@@ -526,9 +523,6 @@ class NimbusExperimentType(DjangoObjectType):
     recipe_json = graphene.String()
     reference_branch = graphene.Field(NimbusBranchType)
     rejection = graphene.Field(NimbusChangeLogType)
-    required_experiments = graphene.NonNull(
-        lambda: graphene.List(graphene.NonNull(NimbusExperimentType))
-    )
     required_experiments_branches = graphene.NonNull(
         lambda: graphene.List(graphene.NonNull(NimbusExperimentBranchThroughRequiredType))
     )
@@ -743,12 +737,6 @@ class NimbusExperimentType(DjangoObjectType):
 
     def resolve_changes(self, info):
         return self.changes.all().order_by("changed_on")
-
-    def resolve_excluded_experiments(self, info):
-        return self.excluded_experiments.only("id", "slug", "name", "public_description")
-
-    def resolve_required_experiments(self, info):
-        return self.required_experiments.only("id", "slug", "name", "public_description")
 
     def resolve_excluded_experiments_branches(self, info):
         return NimbusExperimentBranchThroughExcluded.objects.filter(

--- a/experimenter/experimenter/experiments/tests/api/v5/test_queries.py
+++ b/experimenter/experimenter/experiments/tests/api/v5/test_queries.py
@@ -113,14 +113,6 @@ class TestNimbusExperimentsQuery(GraphQLTestCase):
                         name
                     }
                     hypothesis
-                    excludedExperiments {
-                        id
-                        slug
-                    }
-                    requiredExperiments {
-                        id
-                        slug
-                    }
                     subscribers {
                         email
                     }
@@ -223,8 +215,6 @@ class TestNimbusExperimentsQuery(GraphQLTestCase):
                 ],
                 "projects": [{"id": str(project.id), "name": project.name}],
                 "hypothesis": experiment.hypothesis,
-                "requiredExperiments": [],
-                "excludedExperiments": [],
             },
         )
         self.assertEqual(experiment_data["hypothesis"], experiment.hypothesis)
@@ -555,83 +545,6 @@ class TestNimbusExperimentsQuery(GraphQLTestCase):
         self.assertIn(
             {"email": subscriber.email},
             experiment_data["subscribers"],
-        )
-
-    def test_query_excluded_required_experiments(self):
-        excluded = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperimentFactory.Lifecycles.CREATED,
-            application=NimbusExperiment.Application.DESKTOP,
-        )
-        required = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperimentFactory.Lifecycles.CREATED,
-            application=NimbusExperiment.Application.DESKTOP,
-        )
-        experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperimentFactory.Lifecycles.CREATED,
-            application=NimbusExperiment.Application.DESKTOP,
-            excluded_experiments=[excluded],
-            required_experiments=[required],
-        )
-
-        response = self.query(
-            """
-            query getAllExperiments {
-                experiments {
-                    id
-                    excludedExperiments {
-                        id
-                        slug
-                    }
-                    requiredExperiments {
-                        id
-                        slug
-                    }
-                }
-            }
-            """,
-            headers={settings.OPENIDC_EMAIL_HEADER: "user@example.com"},
-        )
-
-        self.assertEqual(response.status_code, 200, response.content)
-        content = json.loads(response.content)
-
-        experiments = content["data"]["experiments"]
-
-        self.assertEqual(len(experiments), 3)
-
-        self.assertIn(
-            {
-                "id": excluded.id,
-                "excludedExperiments": [],
-                "requiredExperiments": [],
-            },
-            experiments,
-        )
-        self.assertIn(
-            {
-                "id": required.id,
-                "excludedExperiments": [],
-                "requiredExperiments": [],
-            },
-            experiments,
-        )
-        self.assertIn(
-            {
-                "id": experiment.id,
-                "excludedExperiments": [
-                    {
-                        "id": excluded.id,
-                        "slug": excluded.slug,
-                    }
-                ],
-                "requiredExperiments": [
-                    {
-                        "id": required.id,
-                        "slug": required.slug,
-                    },
-                ],
-            },
-            experiments,
         )
 
 

--- a/experimenter/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_experiment_serializer.py
+++ b/experimenter/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_experiment_serializer.py
@@ -1518,36 +1518,6 @@ class TestNimbusExperimentSerializer(TestCase):
         self.assertIsNone(experiment.published_dto)
         self.assertEqual(experiment.proposed_release_date, None)
 
-    def test_can_set_excluded_required_experiments(self):
-        excluded = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperimentFactory.Lifecycles.CREATED,
-            application=NimbusExperiment.Application.DESKTOP,
-        )
-        required = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperimentFactory.Lifecycles.CREATED,
-            application=NimbusExperiment.Application.DESKTOP,
-        )
-        experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperimentFactory.Lifecycles.CREATED,
-            application=NimbusExperiment.Application.DESKTOP,
-        )
-
-        serializer = NimbusExperimentSerializer(
-            experiment,
-            {
-                "excluded_experiments": [excluded.id],
-                "required_experiments": [required.id],
-                "changelog_message": "Test changelog",
-            },
-            context={"user": self.user},
-        )
-
-        self.assertTrue(serializer.is_valid(), serializer.errors)
-        experiment = serializer.save()
-
-        self.assertEqual(experiment.excluded_experiments.get(), excluded)
-        self.assertEqual(experiment.required_experiments.get(), required)
-
     def test_can_set_excluded_required_experiments_all_branches(self):
         excluded = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.CREATED,

--- a/experimenter/experimenter/nimbus-ui/schema.graphql
+++ b/experimenter/experimenter/nimbus-ui/schema.graphql
@@ -72,7 +72,6 @@ type NimbusExperimentType {
   computedEnrollmentDays: Int
   computedEnrollmentEndDate: DateTime
   enrollmentEndDate: DateTime
-  excludedExperiments: [NimbusExperimentType!]!
   excludedExperimentsBranches: [NimbusExperimentBranchThroughExcludedType!]!
   isEnrollmentPausePending: Boolean
   isEnrollmentPaused: Boolean
@@ -82,7 +81,6 @@ type NimbusExperimentType {
   readyForReview: NimbusReviewType
   recipeJson: String
   rejection: NimbusChangeLogType
-  requiredExperiments: [NimbusExperimentType!]!
   requiredExperimentsBranches: [NimbusExperimentBranchThroughRequiredType!]!
   resultsExpectedDate: DateTime
   resultsReady: Boolean
@@ -527,7 +525,6 @@ input ExperimentInput {
   conclusionRecommendation: NimbusExperimentConclusionRecommendationEnum
   countries: [String]
   documentationLinks: [DocumentationLinkInput]
-  excludedExperiments: [Int!]
   excludedExperimentsBranches: [NimbusExperimentBranchThroughExcludedInput!]
   featureConfigIds: [Int]
   firefoxMaxVersion: NimbusExperimentFirefoxVersionEnum
@@ -556,7 +553,6 @@ input ExperimentInput {
   qaComment: String
   qaStatus: NimbusExperimentQAStatusEnum
   referenceBranch: BranchInput = null
-  requiredExperiments: [Int!]
   requiredExperimentsBranches: [NimbusExperimentBranchThroughRequiredInput!]
   riskBrand: Boolean
   riskMitigationLink: String

--- a/experimenter/experimenter/nimbus-ui/src/types/globalTypes.ts
+++ b/experimenter/experimenter/nimbus-ui/src/types/globalTypes.ts
@@ -263,7 +263,6 @@ export interface ExperimentInput {
   conclusionRecommendation?: NimbusExperimentConclusionRecommendationEnum | null;
   countries?: (string | null)[] | null;
   documentationLinks?: (DocumentationLinkInput | null)[] | null;
-  excludedExperiments?: number[] | null;
   excludedExperimentsBranches?: NimbusExperimentBranchThroughExcludedInput[] | null;
   featureConfigIds?: (number | null)[] | null;
   firefoxMaxVersion?: NimbusExperimentFirefoxVersionEnum | null;
@@ -292,7 +291,6 @@ export interface ExperimentInput {
   qaComment?: string | null;
   qaStatus?: NimbusExperimentQAStatusEnum | null;
   referenceBranch?: BranchInput | null;
-  requiredExperiments?: number[] | null;
   requiredExperimentsBranches?: NimbusExperimentBranchThroughRequiredInput[] | null;
   riskBrand?: boolean | null;
   riskMitigationLink?: string | null;


### PR DESCRIPTION
Because

* We've now migrated the UI over to use the new required/excluded fields
* It is now safe to remove the old required/excluded fields

This commit

* Removes the old required/excluded fields from the V5 API

fixes #10047
