### PR TITLE
feat(nimbus): CC emails to all subscribers

### DIFF
--- a/experimenter/experimenter/experiments/email.py
+++ b/experimenter/experimenter/experiments/email.py
@@ -30,7 +30,7 @@ def nimbus_send_enrollment_ending_email(experiment):
 
 
 def nimbus_format_and_send_html_email(
-    experiment, file_string, template_vars, subject, email_type, cc_recipients=None
+    experiment, file_string, template_vars, subject, email_type
 ):
     content = render_to_string(file_string, template_vars)
 
@@ -39,7 +39,7 @@ def nimbus_format_and_send_html_email(
         content,
         settings.EMAIL_SENDER,
         [experiment.owner.email],
-        cc=cc_recipients,
+        cc=experiment.subscribers.all().values_list("email", flat=True),
     )
     email.content_subtype = "html"
     email.send(fail_silently=False)

--- a/experimenter/experimenter/experiments/tests/test_email.py
+++ b/experimenter/experimenter/experiments/tests/test_email.py
@@ -9,6 +9,7 @@ from experimenter.experiments.email import (
 )
 from experimenter.experiments.models import NimbusExperiment
 from experimenter.experiments.tests.factories import NimbusExperimentFactory
+from experimenter.openidc.tests.factories import UserFactory
 
 
 class TestNimbusEmail(TestCase):
@@ -17,6 +18,7 @@ class TestNimbusEmail(TestCase):
             NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE_APPROVE,
             start_date=datetime.date.today() - datetime.timedelta(days=10),
             proposed_duration=10,
+            subscribers=[],
         )
 
         nimbus_send_experiment_ending_email(experiment)
@@ -37,12 +39,35 @@ class TestNimbusEmail(TestCase):
             sent_email.recipients(),
             [experiment.owner.email],
         )
+        self.assertEqual(sent_email.cc, [])
         self.assertIn(experiment.experiment_url, sent_email.body)
+
+    def test_send_experiment_ending_email_to_subscribers(self):
+        subscriber1 = UserFactory.create()
+        subscriber2 = UserFactory.create()
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE_APPROVE,
+            start_date=datetime.date.today() - datetime.timedelta(days=10),
+            proposed_duration=10,
+            subscribers=[subscriber1, subscriber2],
+        )
+
+        nimbus_send_experiment_ending_email(experiment)
+
+        sent_email = mail.outbox[-1]
+        self.assertIn(
+            experiment.owner.email,
+            sent_email.recipients(),
+        )
+        self.assertIn(subscriber1.email, sent_email.cc)
+        self.assertIn(subscriber2.email, sent_email.cc)
+        self.assertEqual(len(sent_email.recipients()), 3)
 
     def test_send_enrollment_ending_email(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE_APPROVE,
             proposed_enrollment=10,
+            subscribers=[],
         )
 
         nimbus_send_enrollment_ending_email(experiment)
@@ -63,4 +88,26 @@ class TestNimbusEmail(TestCase):
             sent_email.recipients(),
             [experiment.owner.email],
         )
+        self.assertEqual(sent_email.cc, [])
         self.assertIn(experiment.experiment_url, sent_email.body)
+
+    def test_send_enrollment_ending_email_to_subscribers(self):
+        subscriber1 = UserFactory.create()
+        subscriber2 = UserFactory.create()
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE_APPROVE,
+            proposed_enrollment=10,
+            subscribers=[subscriber1, subscriber2],
+        )
+
+        nimbus_send_enrollment_ending_email(experiment)
+
+        sent_email = mail.outbox[-1]
+
+        self.assertIn(
+            experiment.owner.email,
+            sent_email.recipients(),
+        )
+        self.assertIn(subscriber1.email, sent_email.cc)
+        self.assertIn(subscriber2.email, sent_email.cc)
+        self.assertEqual(len(sent_email.recipients()), 3)


### PR DESCRIPTION
Because

- We want to send emails to subscribers as well as owners

This commit

- Send emails with all subscribers CC'd 

Fixes #10089