### PR TITLE
feat(nimbus): Add subscribers list to overview table on summary page

### DIFF
--- a/experimenter/experimenter/nimbus-ui/src/components/Summary/TableOverview/index.test.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/Summary/TableOverview/index.test.tsx
@@ -206,6 +206,34 @@ describe("TableOverview", () => {
       ).toHaveTextContent("Not set");
     });
   });
+
+  describe("renders 'Subscribers' as expected", () => {
+    it("with no subscribers", () => {
+      const { experiment } = mockExperimentQuery("demo-slug");
+      render(<Subject {...{ experiment }} />);
+      expect(screen.getByTestId("experiment-subscribers")).toHaveTextContent(
+        "Not set",
+      );
+    });
+    it("with multiple subscribers", () => {
+      const { experiment } = mockExperimentQuery("demo-slug", {
+        subscribers: [
+          {
+            email: "example1@mozilla.com",
+          },
+          {
+            email: "example2@mozilla.com",
+          },
+        ],
+      });
+      render(<Subject {...{ experiment }} />);
+      experiment.subscribers!.forEach((subscriber) =>
+        within(screen.getByTestId("experiment-subscribers")).findByText(
+          subscriber!.email!,
+        ),
+      );
+    });
+  });
 });
 
 const Subject = ({

--- a/experimenter/experimenter/nimbus-ui/src/components/Summary/TableOverview/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/Summary/TableOverview/index.tsx
@@ -165,11 +165,23 @@ const TableOverview = ({ experiment }: TableOverviewProps) => {
 
             <tr>
               <th>Team Projects</th>
-              <td colSpan={3} data-testid="experiment-team-projects">
+              <td data-testid="experiment-team-projects">
                 {experiment.projects!.length > 0 ? (
                   <ul className="list-unstyled mb-0">
                     {experiment.projects!.map((l) => (
                       <li key={l!.id}>{l!.name}</li>
+                    ))}
+                  </ul>
+                ) : (
+                  <NotSet />
+                )}
+              </td>
+              <th>Subscribers</th>
+              <td data-testid="experiment-subscribers">
+                {experiment.subscribers!.length > 0 ? (
+                  <ul className="list-unstyled mb-0">
+                    {experiment.subscribers!.map((subscriber) => (
+                      <li key={subscriber!.email}>{subscriber!.email}</li>
                     ))}
                   </ul>
                 ) : (

--- a/experimenter/experimenter/nimbus-ui/src/lib/mocks.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/lib/mocks.tsx
@@ -677,6 +677,7 @@ export const MOCK_EXPERIMENT: Partial<getExperiment["experimentBySlug"]> = {
   qaComment: null,
   qaStatus: NimbusExperimentQAStatusEnum.NOT_SET,
   isWeb: false,
+  subscribers: [],
 };
 
 export const MOCK_LIVE_ROLLOUT: Partial<getExperiment["experimentBySlug"]> = {
@@ -785,6 +786,7 @@ export const MOCK_LIVE_ROLLOUT: Partial<getExperiment["experimentBySlug"]> = {
   excludedExperimentsBranches: [],
   qaComment: null,
   qaStatus: NimbusExperimentQAStatusEnum.NOT_SET,
+  subscribers: [],
 };
 
 export function mockExperiment<


### PR DESCRIPTION
Because

- We want to be able to see who has subscribed to a given experiment

This commit

- Adds a “Subscribers” field in the Overview section of the Summary page
- The field shows "Not Set" if there are no subscribers

Fixes #10108

----
<img width="1149" alt="Screenshot 2024-01-29 at 3 15 40 PM" src="https://github.com/mozilla/experimenter/assets/43795363/98544da7-18e9-46b2-84ae-a878f39ea0ca">
<img width="1129" alt="Screenshot 2024-01-29 at 3 16 26 PM" src="https://github.com/mozilla/experimenter/assets/43795363/7151cc85-ed91-4d5b-8604-41b8a34a2784">
