### PR TITLE
bug(nimbus): Fix integration tests on Nightly 124

### DIFF
--- a/experimenter/tests/integration/nimbus/utils/filter_expression.js
+++ b/experimenter/tests/integration/nimbus/utils/filter_expression.js
@@ -6,13 +6,21 @@ async function remoteSettings(arguments) {
         arguments[1] - the experiment recipe
     */
 
-    const TargetingContext = ChromeUtils.import(
-        "resource://messaging-system/targeting/Targeting.jsm"
-    );
-    const ASRouterTargeting = ChromeUtils.import(
-        "resource://activity-stream/lib/ASRouterTargeting.jsm"
-    )
-    const ExperimentManager = ChromeUtils.import("resource://nimbus/lib/ExperimentManager.jsm")
+    // See https://bugzilla.mozilla.org/show_bug.cgi?id=1868838 -
+    // ASRouterTargeting was moved from browser/components/newtab into
+    // browser/components/asrouter and its import path changed.
+    let ASRouterTargeting;
+    try {
+        ASRouterTargeting = ChromeUtils.import("resource:///modules/asrouter/ASRouterTargeting.jsm");
+    } catch (ex) {
+        if (ex.result === Cr.NS_ERROR_FILE_NOT_FOUND) {
+            ASRouterTargeting = ChromeUtils.import("resource://activity-stream/lib/ASRouterTargeting.jsm");
+        } else {
+            throw ex;
+        }
+    }
+    const ExperimentManager = ChromeUtils.importESModule("resource://nimbus/lib/ExperimentManager.sys.mjs");
+    const TargetingContext = ChromeUtils.importESModule("resource://messaging-system/targeting/Targeting.sys.mjs");
 
     const _experiment = JSON.parse(arguments[1]);
 


### PR DESCRIPTION
Because:

- ASRouterTargeting.jsm had its import path change due to https://bugzilla.mozilla.org/show_bug.cgi?id=1868838;
- filter_expression.js imports ASRouterTargeting; and
- filter_expression.js is using ChromeUtils.import for JSMs that have long-since ported to ESMs

This commit:

- updates filter_expression.js to try both the old and new import paths for ASRouterTargeting; and
- updates the imports in filter_expression.js to use importESModule.

Fixes #10165