### PR TITLE
chore(nimbus): Set default for integration-test firefox docker image.

### DIFF
--- a/docker-compose-integration-test.yml
+++ b/docker-compose-integration-test.yml
@@ -2,7 +2,7 @@ version: "3"
 
 services:
   firefox:
-    image: mozilla/experimenter:${FIREFOX_VERSION}
+    image: mozilla/experimenter:${FIREFOX_VERSION:-nimbus-firefox-release}
     env_file: .env
     environment:
       - MOZ_HEADLESS


### PR DESCRIPTION
Because

Running the integration-tests locally required you to set a ```FIREFOX_VERSION``` environment variable.

This commit

Sets a default for that image if it isn't provided.

Fixes #10167 