### PR TITLE
bug(cirrus): Fix cirrus builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -240,7 +240,7 @@ CIRRUS_GENERATE_DOCS = python cirrus/generate_docs.py
 cirrus_build: build_megazords
 	$(CIRRUS_ENABLE) $(DOCKER_BUILD) --target deploy -f cirrus/server/Dockerfile -t cirrus:deploy cirrus/server/
 
-cirrus_build_test:
+cirrus_build_test: build_megazords
 	$(CIRRUS_ENABLE) $(COMPOSE_TEST) build cirrus
 
 cirrus_bash: cirrus_build

--- a/cirrus/server/Dockerfile
+++ b/cirrus/server/Dockerfile
@@ -9,6 +9,10 @@ RUN apt-get update && \
     apt-get -y install curl bash build-essential && \
     rm -rf /var/lib/apt/lists/*
 
+# Rust is required to build some Python packages on arm64 Linux.
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | /bin/sh -s -- -y --no-modify-path
+ENV PATH=$PATH:/root/.cargo/bin
+
 # Install poetry package management tool
 RUN curl -sSL https://install.python-poetry.org | python3 - --version 1.6.0
 


### PR DESCRIPTION
Because:

- the cirrus test jobs require the megazords; and
- the cirrus build requires rustc on arm64

This commit:

- adds `build_megazords` as a dependency of `cirrus_build_test`; and
- installs `rustc` inside the `python-builder` phase of the Cirrus build.

Fixes #10172