### PR TITLE
bug(cirrus): Revert "Run cirrus pytest command in verbose mode (#10084)"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,7 +89,7 @@ jobs:
       - run:
           name: Run Cirrus tests and linting
           command: |
-            make cirrus_check -v
+            make cirrus_check
 
   check_cirrus_aarch64:
     machine:
@@ -104,7 +104,7 @@ jobs:
       - run:
           name: Run Cirrus tests and linting
           command: |
-            make cirrus_check -v
+            make cirrus_check
 
   check_schemas:
     machine:

--- a/cirrus/README.md
+++ b/cirrus/README.md
@@ -67,7 +67,7 @@ The following are the available commands for working with Cirrus:
 
   - Usage: `make cirrus_test`
 
-- **cirrus_check**: Performs various checks on the Cirrus application including Ruff linting, Black code formatting check, Pyright static type checking, pytest tests, and documentation generation.
+- **cirrus_check**: Performs various checks on the Cirrus application including Ruff linting, Black code formatting check, Pyright static type checking, pytest tests, and documentation generation..
 
   - Usage: `make cirrus_check`
 


### PR DESCRIPTION
Because:

- #10084 stopped Cirrus tests from running in CI

This commit:

-  reverts commit aad815110c48e356e326a9ad94f4ab99a30cd830 (#10084).

Fixes #10174.