### PR TITLE
bug(nimbus): disable review checks after launch

### DIFF
--- a/experimenter/experimenter/experiments/api/v5/serializers.py
+++ b/experimenter/experimenter/experiments/api/v5/serializers.py
@@ -2127,24 +2127,25 @@ class NimbusReviewSerializer(serializers.ModelSerializer):
         return data
 
     def validate(self, data):
-        application = data.get("application")
-        channel = data.get("channel")
-        if application != NimbusExperiment.Application.DESKTOP and not channel:
-            raise serializers.ValidationError(
-                {"channel": "Channel is required for this application."}
-            )
-        data = super().validate(data)
-        data = self._validate_versions(data)
-        data = self._validate_localizations(data)
-        data = self._validate_feature_configs(data)
-        data = self._validate_enrollment_targeting(data)
-        data = self._validate_sticky_enrollment(data)
-        data = self._validate_rollout_version_support(data)
-        data = self._validate_bucket_duplicates(data)
-        data = self._validate_proposed_release_date(data)
-        if application != NimbusExperiment.Application.DESKTOP:
-            data = self._validate_languages_versions(data)
-            data = self._validate_countries_versions(data)
+        if self.instance.status == self.instance.Status.DRAFT:
+            application = data.get("application")
+            channel = data.get("channel")
+            if application != NimbusExperiment.Application.DESKTOP and not channel:
+                raise serializers.ValidationError(
+                    {"channel": "Channel is required for this application."}
+                )
+            data = super().validate(data)
+            data = self._validate_versions(data)
+            data = self._validate_localizations(data)
+            data = self._validate_feature_configs(data)
+            data = self._validate_enrollment_targeting(data)
+            data = self._validate_sticky_enrollment(data)
+            data = self._validate_rollout_version_support(data)
+            data = self._validate_bucket_duplicates(data)
+            data = self._validate_proposed_release_date(data)
+            if application != NimbusExperiment.Application.DESKTOP:
+                data = self._validate_languages_versions(data)
+                data = self._validate_countries_versions(data)
         return data
 
 

--- a/experimenter/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_ready_for_review_serializer.py
+++ b/experimenter/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_ready_for_review_serializer.py
@@ -4265,3 +4265,59 @@ class TestNimbusReviewSerializerMultiFeature(MockFmlErrorMixin, TestCase):
                     ]
                 },
             )
+
+    @parameterized.expand(
+        [
+            (NimbusExperimentFactory.Lifecycles.CREATED, False),
+            (NimbusExperimentFactory.Lifecycles.PREVIEW, True),
+            (NimbusExperimentFactory.Lifecycles.LIVE_APPROVE_APPROVE, True),
+            (NimbusExperimentFactory.Lifecycles.ENDING_APPROVE_APPROVE, True),
+        ]
+    )
+    def test_review_failures_are_skipped_for_non_draft(self, lifecycle, expected_valid):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            lifecycle,
+            application=NimbusExperiment.Application.FENIX,
+            channel=NimbusExperiment.Channel.RELEASE,
+            feature_configs=[
+                NimbusFeatureConfigFactory.create(
+                    application=NimbusExperiment.Application.FENIX,
+                    schemas=[
+                        NimbusVersionedSchemaFactory.build(
+                            version=None,
+                            schema=None,
+                        )
+                    ],
+                ),
+                NimbusFeatureConfigFactory.create(
+                    application=NimbusExperiment.Application.IOS,
+                    schemas=[
+                        NimbusVersionedSchemaFactory.build(
+                            version=None,
+                            schema=None,
+                        )
+                    ],
+                ),
+            ],
+            is_sticky=True,
+            firefox_min_version=NimbusExperiment.MIN_REQUIRED_VERSION,
+        )
+
+        serializer = NimbusReviewSerializer(
+            experiment,
+            data=NimbusReviewSerializer(
+                experiment,
+                context={"user": self.user},
+            ).data,
+            context={"user": self.user},
+        )
+
+        self.assertEqual(serializer.is_valid(), expected_valid)
+        if not expected_valid:
+            self.assertEqual(
+                serializer.errors["feature_configs"],
+                [
+                    "Feature Config application ios does not "
+                    "match experiment application fenix."
+                ],
+            )


### PR DESCRIPTION
Because

* As we add more pre launch review checks, the time complexity of running them grows
* Right now we fetch the ready for review details on every page load
* In particular, the jsonschema validation can be slow for complex schemas
* There's nothing we can do to improve the performance of that external library
* But we also don't need to run through the review checks after an experiment launches

This commit

* Disables the ready for review checks after an experiment launches

fixes #10178

