### PR TITLE
refactor(nimbus): Reusable warning on PageSummary

### DIFF
--- a/experimenter/experimenter/nimbus-ui/src/components/PageSummary/index.test.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageSummary/index.test.tsx
@@ -471,9 +471,7 @@ describe("PageSummary", () => {
     mutationMock.result.errors = [new Error("Boo")];
     render(<Subject mocks={[mock, mutationMock]} />);
     await launchFromDraftToReview();
-    await waitFor(() =>
-      expect(screen.getByTestId("submit-error")).toBeInTheDocument(),
-    );
+    await waitFor(() => screen.getByTestId("submit-error-warning"));
   });
 
   // TODO: #6802
@@ -912,7 +910,7 @@ describe("PageSummary", () => {
       targetingConfigSlug: "OH_NO",
     });
     render(<Subject mocks={[mock]} />);
-    expect(screen.queryByTestId("bucketing-warning")).toBeInTheDocument();
+    screen.getByTestId("bucketing-warning");
   });
 
   it("displays no duplicate rollout warning for experiments", async () => {
@@ -934,7 +932,7 @@ describe("PageSummary", () => {
       targetingConfigSlug: "OH_NO",
     });
     render(<Subject mocks={[mock]} />);
-    expect(screen.queryByTestId("bucketing-warning")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("bucketing-warning")).toBeNull();
   });
 
   it("displays a warning for desktop rollouts under v114", async () => {
@@ -954,11 +952,7 @@ describe("PageSummary", () => {
       targetingConfigSlug: "OH_NO",
     });
     render(<Subject mocks={[mockRollout]} />);
-    await waitFor(() =>
-      expect(
-        screen.queryByTestId("desktop-min-version-warning"),
-      ).toBeInTheDocument(),
-    );
+    await waitFor(() => screen.queryByTestId("desktop-min-version-warning"));
   });
 
   it("displays no warning for desktop rollouts above v113", async () => {
@@ -976,9 +970,7 @@ describe("PageSummary", () => {
       targetingConfigSlug: "OH_NO",
     });
     render(<Subject mocks={[mockRollout]} />);
-    expect(
-      screen.queryByTestId("desktop-min-version-warning"),
-    ).not.toBeInTheDocument();
+    expect(screen.queryByTestId("desktop-min-version-warning")).toBeNull();
   });
 
   it("displays no min version warning for non-desktop rollouts", async () => {
@@ -996,8 +988,6 @@ describe("PageSummary", () => {
       targetingConfigSlug: "OH_NO",
     });
     render(<Subject mocks={[mock]} />);
-    expect(
-      screen.queryByTestId("desktop-min-version-warning"),
-    ).not.toBeInTheDocument();
+    expect(screen.queryByTestId("desktop-min-version-warning")).toBeNull();
   });
 });

--- a/experimenter/experimenter/nimbus-ui/src/components/PageSummary/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageSummary/index.tsx
@@ -373,3 +373,27 @@ const StatusPill = ({
     {label}
   </Badge>
 );
+
+const AlertWarning = ({
+  text,
+  testId,
+  learnMoreLink,
+  learnMoreText = "Learn more",
+  color = "danger",
+}: {
+  text: string;
+  testId: string;
+  learnMoreLink?: string;
+  learnMoreText?: string;
+  color?: string;
+}) => (
+  <Alert data-testid={`warning-${testId}`} variant={color}>
+    {text as SerializerMessage}
+    {learnMoreLink && (
+      <LinkExternal href={learnMoreLink}>
+        <span className="mr-1">{learnMoreText}</span>
+        <ExternalIcon />
+      </LinkExternal>
+    )}
+  </Alert>
+);

--- a/experimenter/experimenter/nimbus-ui/src/components/PageSummary/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageSummary/index.tsx
@@ -232,30 +232,38 @@ const PageSummary = (props: RouteComponentProps) => {
       <SummaryTimeline {...{ experiment }} />
 
       {submitError && (
-        <Alert data-testid="submit-error" variant="warning">
-          {submitError}
-        </Alert>
+        <Warning
+          {...{
+            text: submitError,
+            testId: "submit-error",
+            variant: "warning",
+          }}
+        />
       )}
 
       {experiment.isRollout &&
         (status.draft || status.preview) &&
         fieldWarnings.bucketing?.length > 0 && (
-          <Alert data-testid="bucketing-warning" variant="danger">
-            {fieldWarnings.bucketing as SerializerMessage}
-            <LinkExternal href={EXTERNAL_URLS.BUCKET_WARNING_EXPLANATION}>
-              <span className="mr-1">Learn more</span>
-              <ExternalIcon />
-            </LinkExternal>
-          </Alert>
+          <Warning
+            {...{
+              text: fieldWarnings.bucketing as SerializerMessage,
+              testId: "bucketing",
+              learnMoreLink: EXTERNAL_URLS.BUCKET_WARNING_EXPLANATION,
+            }}
+          />
         )}
 
       {experiment.isRollout &&
         (experiment.status === NimbusExperimentStatusEnum.DRAFT ||
           experiment.status === NimbusExperimentStatusEnum.PREVIEW) &&
         fieldWarnings.firefox_min_version?.length > 0 && (
-          <Alert data-testid="desktop-min-version-warning" variant="warning">
-            {fieldWarnings.firefox_min_version as SerializerMessage}
-          </Alert>
+          <Warning
+            {...{
+              text: fieldWarnings.firefox_min_version as SerializerMessage,
+              testId: "desktop-min-version",
+              variant: "warning",
+            }}
+          />
         )}
 
       {summaryAction && (
@@ -374,21 +382,21 @@ const StatusPill = ({
   </Badge>
 );
 
-const AlertWarning = ({
+const Warning = ({
   text,
   testId,
   learnMoreLink,
   learnMoreText = "Learn more",
-  color = "danger",
+  variant = "danger",
 }: {
-  text: string;
+  text: string | SerializerMessage;
   testId: string;
   learnMoreLink?: string;
   learnMoreText?: string;
-  color?: string;
+  variant?: string;
 }) => (
-  <Alert data-testid={`warning-${testId}`} variant={color}>
-    {text as SerializerMessage}
+  <Alert data-testid={`${testId}-warning`} variant={variant}>
+    {text}{" "}
     {learnMoreLink && (
       <LinkExternal href={learnMoreLink}>
         <span className="mr-1">{learnMoreText}</span>


### PR DESCRIPTION
Because

- We're going to need some easily reusable warnings on the summary page

This commit

- Creates a new warning `AlertWarning` (bad name) and replaces the three existing warnings with it
- Gives it variants, nice testids, etc

Fixes #10096