### PR TITLE
feat(nimbus): Changelogs show subscriber emails

### DIFF
--- a/experimenter/experimenter/experiments/changelog_utils.py
+++ b/experimenter/experimenter/experiments/changelog_utils.py
@@ -53,6 +53,9 @@ class NimbusExperimentChangeLogSerializer(serializers.ModelSerializer):
     feature_configs = NimbusFeatureConfigChangeLogSerializer(many=True)
     owner = serializers.SlugRelatedField(read_only=True, slug_field="email")
     projects = serializers.SlugRelatedField(many=True, read_only=True, slug_field="slug")
+    subscribers = serializers.SlugRelatedField(
+        many=True, read_only=True, slug_field="email"
+    )
 
     class Meta:
         model = NimbusExperiment

--- a/experimenter/experimenter/experiments/tests/test_changelog_utils.py
+++ b/experimenter/experimenter/experiments/tests/test_changelog_utils.py
@@ -189,7 +189,7 @@ class TestNimbusExperimentChangeLogSerializer(TestCase):
                 "slug": experiment.slug,
                 "status": experiment.status,
                 "status_next": experiment.status_next,
-                "subscribers": [subscriber.id],
+                "subscribers": [subscriber.email],
                 "takeaways_gain_amount": None,
                 "takeaways_metric_gain": False,
                 "takeaways_qbr_learning": False,


### PR DESCRIPTION
Because

- The changelogs were showing the subscriber's User id

This commit

- Makes the changelog show the subscriber's User email instead

Fixes #10202

<img width="1320" alt="image" src="https://github.com/mozilla/experimenter/assets/43795363/d87540c7-a2f3-4c1d-bfb5-e132da429097">
