### PR TITLE
For #10094 feat(nimbus): Check if there are other live multifeature experiments for targeted features

### DIFF
--- a/experimenter/experimenter/experiments/api/v5/types.py
+++ b/experimenter/experimenter/experiments/api/v5/types.py
@@ -494,6 +494,9 @@ class NimbusExperimentType(DjangoObjectType):
         lambda: graphene.List(graphene.NonNull(NimbusExperimentBranchThroughExcludedType))
     )
     feature_configs = DjangoListField(NimbusFeatureConfigType)
+    feature_has_live_multifeature_experiments = graphene.NonNull(
+        lambda: graphene.List(graphene.NonNull(graphene.String))
+    )
     firefox_max_version = NimbusExperimentFirefoxVersionEnum()
     firefox_min_version = NimbusExperimentFirefoxVersionEnum()
     hypothesis = graphene.String()
@@ -571,6 +574,7 @@ class NimbusExperimentType(DjangoObjectType):
             "documentation_links",
             "enrollment_end_date",
             "feature_configs",
+            "feature_has_live_multifeature_experiments",
             "firefox_max_version",
             "firefox_min_version",
             "hypothesis",
@@ -754,3 +758,6 @@ class NimbusExperimentType(DjangoObjectType):
 
     def resolve_subscribers(self, info):
         return self.subscribers.all().order_by("username")
+
+    def resolve_feature_has_live_multifeature_experiments(self, info):
+        return self.feature_has_live_multifeature_experiments

--- a/experimenter/experimenter/experiments/api/v5/types.py
+++ b/experimenter/experimenter/experiments/api/v5/types.py
@@ -758,6 +758,3 @@ class NimbusExperimentType(DjangoObjectType):
 
     def resolve_subscribers(self, info):
         return self.subscribers.all().order_by("username")
-
-    def resolve_feature_has_live_multifeature_experiments(self, info):
-        return self.feature_has_live_multifeature_experiments

--- a/experimenter/experimenter/experiments/models.py
+++ b/experimenter/experimenter/experiments/models.py
@@ -17,7 +17,7 @@ from django.core.files.base import ContentFile
 from django.core.serializers.json import DjangoJSONEncoder
 from django.core.validators import MaxValueValidator
 from django.db import models
-from django.db.models import F, Q, QuerySet
+from django.db.models import Count, F, Q, QuerySet
 from django.db.models.constraints import UniqueConstraint
 from django.urls import reverse
 from django.utils import timezone
@@ -797,6 +797,29 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
                 self.population_percent / Decimal("100.0") * NimbusExperiment.BUCKET_TOTAL
             ),
         )
+
+    @property
+    def feature_has_live_multifeature_experiments(self):
+        """Live multifeature experiments that share a feature with this experiment.
+
+        Returns:
+            A list of experiment slugs.
+        """
+        matching = set()
+        live_experiments = NimbusExperiment.objects.filter(
+            status=self.Status.LIVE,
+            application=self.application,
+        )
+        if len(live_experiments.all()) >= 0:
+            for feature in self.feature_configs.all().values_list("slug", flat=True):
+                experiments = (
+                    live_experiments.annotate(n_feature_configs=Count("feature_configs"))
+                    .filter(n_feature_configs__gt=1)
+                    .filter(feature_configs__slug=feature)
+                    .all()
+                )
+                matching.update([e.slug for e in experiments])
+        return list(matching)
 
     @property
     def can_edit(self):

--- a/experimenter/experimenter/experiments/tests/api/v5/test_queries.py
+++ b/experimenter/experimenter/experiments/tests/api/v5/test_queries.py
@@ -800,6 +800,7 @@ class TestNimbusExperimentBySlugQuery(GraphQLTestCase):
                     subscribers {
                         email
                     }
+                    featureHasLiveMultifeatureExperiments
                 }
             }
             """,
@@ -870,6 +871,7 @@ class TestNimbusExperimentBySlugQuery(GraphQLTestCase):
                         "slug": feature_config.slug,
                     }
                 ],
+                "featureHasLiveMultifeatureExperiments": [],
                 "firefoxMaxVersion": NimbusExperiment.Version(
                     experiment.firefox_max_version
                 ).name,

--- a/experimenter/experimenter/experiments/tests/test_models.py
+++ b/experimenter/experimenter/experiments/tests/test_models.py
@@ -2539,6 +2539,99 @@ class TestNimbusExperiment(TestCase):
             ],
         )
 
+    @parameterized.expand(
+        [
+            (NimbusExperiment.Application.FENIX, NimbusExperiment.Application.FENIX, 3),
+            (NimbusExperiment.Application.FENIX, NimbusExperiment.Application.DESKTOP, 0),
+        ]
+    )
+    def test_get_live_multifeature_experiments_for_feature(
+        self,
+        application1,
+        application2,
+        expected_matches,
+    ):
+        feature1 = NimbusFeatureConfigFactory.create()
+        feature2 = NimbusFeatureConfigFactory.create()
+
+        NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.LIVE_APPROVE_APPROVE,
+            application=application1,
+            feature_configs=[feature1, feature2],
+        )
+        NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.LIVE_APPROVE_APPROVE,
+            application=application1,
+            feature_configs=[feature1, feature2],
+        )
+        NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.LIVE_APPROVE_APPROVE,
+            application=application1,
+            feature_configs=[feature1, feature2],
+        )
+        NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            application=application1,
+            feature_configs=[feature1, feature2],
+        )
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            application=application2,
+            feature_configs=[feature1],
+        )
+
+        experiments = experiment.feature_has_live_multifeature_experiments
+        self.assertEqual(len(experiments), expected_matches)
+
+    def test_get_live_multifeature_experiments_for_feature_no_live(self):
+        feature1 = NimbusFeatureConfigFactory.create()
+        feature2 = NimbusFeatureConfigFactory.create()
+
+        NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.ENDING_APPROVE_APPROVE,
+            feature_configs=[feature1, feature2],
+        )
+        NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            feature_configs=[feature1, feature2],
+        )
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            feature_configs=[feature1, feature2],
+        )
+
+        experiments = experiment.feature_has_live_multifeature_experiments
+        self.assertEqual(len(experiments), 0)
+
+    def test_get_live_multifeature_experiments_for_feature_no_live_multifeature(self):
+        feature1 = NimbusFeatureConfigFactory.create()
+        feature2 = NimbusFeatureConfigFactory.create()
+
+        NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.LIVE_APPROVE_APPROVE,
+            feature_configs=[feature1],
+        )
+        NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            feature_configs=[feature1, feature2],
+        )
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            feature_configs=[feature1],
+        )
+
+        experiments = experiment.feature_has_live_multifeature_experiments
+        self.assertEqual(len(experiments), 0)
+
+    def test_get_live_multifeature_experiments_none(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            feature_configs=[NimbusFeatureConfigFactory.create()],
+        )
+
+        experiments = experiment.feature_has_live_multifeature_experiments
+        self.assertEqual(len(experiments), 0)
+
 
 class TestNimbusBranch(TestCase):
     def test_str(self):

--- a/experimenter/experimenter/nimbus-ui/schema.graphql
+++ b/experimenter/experimenter/nimbus-ui/schema.graphql
@@ -73,6 +73,7 @@ type NimbusExperimentType {
   computedEnrollmentEndDate: DateTime
   enrollmentEndDate: DateTime
   excludedExperimentsBranches: [NimbusExperimentBranchThroughExcludedType!]!
+  featureHasLiveMultifeatureExperiments: [String!]!
   isEnrollmentPausePending: Boolean
   isEnrollmentPaused: Boolean
   isWeb: Boolean!

--- a/experimenter/experimenter/nimbus-ui/src/gql/experiments.ts
+++ b/experimenter/experimenter/nimbus-ui/src/gql/experiments.ts
@@ -255,6 +255,7 @@ export const GET_EXPERIMENT_QUERY = gql`
       isRolloutDirty
       qaComment
       qaStatus
+      featureHasLiveMultifeatureExperiments
     }
   }
 `;

--- a/experimenter/experimenter/nimbus-ui/src/types/getExperiment.ts
+++ b/experimenter/experimenter/nimbus-ui/src/types/getExperiment.ts
@@ -286,6 +286,7 @@ export interface getExperiment_experimentBySlug {
   isRolloutDirty: boolean;
   qaComment: string | null;
   qaStatus: NimbusExperimentQAStatusEnum | null;
+  featureHasLiveMultifeatureExperiments: string[];
 }
 
 export interface getExperiment {


### PR DESCRIPTION
Because

- Audience overlap can happen if there are other live multifeature experiments for features being targeted by your experiment

This commit

- Adds a query to the model to check for other live multifeature experiments for your features
- This query returns a list of the slugs of any matching experiments, so that we will be able to say "these are the experiments that might cause overlap with yours" once we connect this to the frontend

Fixes #10094