### PR TITLE
feat(nimbus): Add model query for getting a list of experiments that are live and excluded

### DIFF
--- a/experimenter/experimenter/experiments/api/v5/types.py
+++ b/experimenter/experimenter/experiments/api/v5/types.py
@@ -493,6 +493,9 @@ class NimbusExperimentType(DjangoObjectType):
     excluded_experiments_branches = graphene.NonNull(
         lambda: graphene.List(graphene.NonNull(NimbusExperimentBranchThroughExcludedType))
     )
+    excluded_live_deliveries = graphene.NonNull(
+        lambda: graphene.List(graphene.NonNull(graphene.String))
+    )
     feature_configs = DjangoListField(NimbusFeatureConfigType)
     feature_has_live_multifeature_experiments = graphene.NonNull(
         lambda: graphene.List(graphene.NonNull(graphene.String))
@@ -573,6 +576,7 @@ class NimbusExperimentType(DjangoObjectType):
             "countries",
             "documentation_links",
             "enrollment_end_date",
+            "excluded_live_deliveries",
             "feature_configs",
             "feature_has_live_multifeature_experiments",
             "firefox_max_version",

--- a/experimenter/experimenter/experiments/models.py
+++ b/experimenter/experimenter/experiments/models.py
@@ -824,11 +824,6 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
 
     @property
     def excluded_live_deliveries(self):
-        """Live experiments that are excluded by the current experiment.
-
-        Returns:
-            A list of experiment slugs.
-        """
         matching = []
         if self.excluded_experiments.exists():
             matching = (

--- a/experimenter/experimenter/experiments/models.py
+++ b/experimenter/experimenter/experiments/models.py
@@ -823,6 +823,26 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
         return matching
 
     @property
+    def excluded_live_deliveries(self):
+        """Live experiments that are excluded by the current experiment.
+
+        Returns:
+            A list of experiment slugs.
+        """
+        matching = []
+        if self.excluded_experiments.exists():
+            matching = (
+                self.excluded_experiments.filter(
+                    status=NimbusExperiment.Status.LIVE,
+                    application=self.application,
+                )
+                .values_list("slug", flat=True)
+                .distinct()
+                .order_by("slug")
+            )
+        return matching
+
+    @property
     def can_edit(self):
         return (
             (

--- a/experimenter/experimenter/experiments/tests/api/v5/test_queries.py
+++ b/experimenter/experimenter/experiments/tests/api/v5/test_queries.py
@@ -559,7 +559,10 @@ class TestNimbusExperimentBySlugQuery(GraphQLTestCase):
         language = LanguageFactory.create()
         project = ProjectFactory.create()
         required = NimbusExperimentFactory.create(application=application)
-        excluded = NimbusExperimentFactory.create(application=application)
+        excluded = NimbusExperimentFactory.create(
+            application=application,
+            status=NimbusExperiment.Status.COMPLETE,
+        )
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             lifecycle,
             parent=NimbusExperimentFactory.create(),
@@ -800,6 +803,7 @@ class TestNimbusExperimentBySlugQuery(GraphQLTestCase):
                     subscribers {
                         email
                     }
+                    excludedLiveDeliveries
                     featureHasLiveMultifeatureExperiments
                 }
             }
@@ -855,6 +859,7 @@ class TestNimbusExperimentBySlugQuery(GraphQLTestCase):
                         "branchSlug": excluded.reference_branch.slug,
                     }
                 ],
+                "excludedLiveDeliveries": [],
                 "featureConfigs": [
                     {
                         "application": NimbusExperiment.Application(

--- a/experimenter/experimenter/nimbus-ui/schema.graphql
+++ b/experimenter/experimenter/nimbus-ui/schema.graphql
@@ -73,6 +73,7 @@ type NimbusExperimentType {
   computedEnrollmentEndDate: DateTime
   enrollmentEndDate: DateTime
   excludedExperimentsBranches: [NimbusExperimentBranchThroughExcludedType!]!
+  excludedLiveDeliveries: [String!]!
   featureHasLiveMultifeatureExperiments: [String!]!
   isEnrollmentPausePending: Boolean
   isEnrollmentPaused: Boolean

--- a/experimenter/experimenter/nimbus-ui/src/gql/experiments.ts
+++ b/experimenter/experimenter/nimbus-ui/src/gql/experiments.ts
@@ -255,6 +255,7 @@ export const GET_EXPERIMENT_QUERY = gql`
       isRolloutDirty
       qaComment
       qaStatus
+      excludedLiveDeliveries
       featureHasLiveMultifeatureExperiments
     }
   }

--- a/experimenter/experimenter/nimbus-ui/src/types/getExperiment.ts
+++ b/experimenter/experimenter/nimbus-ui/src/types/getExperiment.ts
@@ -286,6 +286,7 @@ export interface getExperiment_experimentBySlug {
   isRolloutDirty: boolean;
   qaComment: string | null;
   qaStatus: NimbusExperimentQAStatusEnum | null;
+  excludedLiveDeliveries: string[];
   featureHasLiveMultifeatureExperiments: string[];
 }
 


### PR DESCRIPTION
Because

- Audience overlap can happen when there are Live experiments that you are explicitly excluding from your experiment

This commit

- Adds a query to the model to find any of these matching experiments
- This query returns a list of the slugs of any matching experiments, so that we will be able to say "these are the experiments that might cause overlap with yours" once we connect this to the frontend

Fixes #10095 