### PR TITLE
feat(experimenter): Update links

### DIFF
--- a/experimenter/experimenter/nimbus-ui/src/components/PageEditBranches/index.test.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageEditBranches/index.test.tsx
@@ -52,7 +52,7 @@ describe("PageEditBranches", () => {
     expect(screen.getByTestId("feature-config")).toBeInTheDocument();
     expect(screen.getByTestId("learn-more-link")).toHaveAttribute(
       "href",
-      EXTERNAL_URLS.BRANCHES_GOOGLE_DOC,
+      EXTERNAL_URLS.BRANCHES_EXPERIMENTER_DOC,
     );
 
     for (const feature of MOCK_CONFIG!.allFeatureConfigs!) {

--- a/experimenter/experimenter/nimbus-ui/src/components/PageEditBranches/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageEditBranches/index.tsx
@@ -103,7 +103,7 @@ const PageEditBranches: React.FunctionComponent<RouteComponentProps> = () => {
         You must select at least one <strong>feature</strong> configuration for
         your experiment.{" "}
         <LinkExternal
-          href={EXTERNAL_URLS.BRANCHES_GOOGLE_DOC}
+          href={EXTERNAL_URLS.BRANCHES_EXPERIMENTER_DOC}
           data-testid="learn-more-link"
         >
           Learn more

--- a/experimenter/experimenter/nimbus-ui/src/components/PageEditMetrics/index.test.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageEditMetrics/index.test.tsx
@@ -82,7 +82,7 @@ describe("PageEditMetrics", () => {
       expect(screen.getByTestId("header-experiment")).toBeInTheDocument();
       expect(screen.getByTestId("core-metrics-link")).toHaveAttribute(
         "href",
-        EXTERNAL_URLS.METRICS_GOOGLE_DOC,
+        EXTERNAL_URLS.METRICS_EXPERIMENTER_DOC,
       );
     });
   });

--- a/experimenter/experimenter/nimbus-ui/src/components/PageEditMetrics/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageEditMetrics/index.tsx
@@ -85,7 +85,7 @@ const PageEditMetrics: React.FunctionComponent<RouteComponentProps> = () => {
         impacted <strong>Retention, Search Count, and Ad Click</strong> metrics.
         Get more information on{" "}
         <LinkExternal
-          href={EXTERNAL_URLS.METRICS_GOOGLE_DOC}
+          href={EXTERNAL_URLS.METRICS_EXPERIMENTER_DOC}
           data-testid="core-metrics-link"
         >
           Core Firefox Metrics

--- a/experimenter/experimenter/nimbus-ui/src/components/PageSummary/FormLaunchPreviewToReview.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageSummary/FormLaunchPreviewToReview.tsx
@@ -5,8 +5,10 @@
 import React, { useState } from "react";
 import Alert from "react-bootstrap/Alert";
 import Form from "react-bootstrap/Form";
+import LinkExternal from "src/components/LinkExternal";
 import FormLaunchConfirmationCheckboxes from "src/components/PageSummary/FormLaunchConfirmationCheckboxes";
 import { ReactComponent as Check } from "src/images/check.svg";
+import { EXTERNAL_URLS } from "src/lib/constants";
 
 const FormLaunchPreviewToReview = ({
   isLoading,
@@ -36,9 +38,15 @@ const FormLaunchPreviewToReview = ({
         <Form className="text-body">
           <p className="my-1">
             This experiment is currently <strong>live for testing</strong>, but
-            you will need to let QA know in your PI request. When you have
-            received a sign-off, click “Request launch” to launch the
-            experiment.{" "}
+            you will need to let QA know in your{" "}
+            <LinkExternal
+              href={EXTERNAL_URLS.QA_PI_DOC}
+              data-testid="qa-pi-link"
+            >
+              PI request
+            </LinkExternal>
+            . When you have received a sign-off, click “Request
+            launch” to launch the experiment.{" "}
             <strong>
               Note: It can take up to an hour before clients receive a preview
               experiment.

--- a/experimenter/experimenter/nimbus-ui/src/components/PageSummary/FormLaunchPreviewToReview.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageSummary/FormLaunchPreviewToReview.tsx
@@ -45,8 +45,8 @@ const FormLaunchPreviewToReview = ({
             >
               PI request
             </LinkExternal>
-            . When you have received a sign-off, click “Request
-            launch” to launch the experiment.{" "}
+            . When you have received a sign-off, click “Request launch” to
+            launch the experiment.{" "}
             <strong>
               Note: It can take up to an hour before clients receive a preview
               experiment.

--- a/experimenter/experimenter/nimbus-ui/src/lib/constants.ts
+++ b/experimenter/experimenter/nimbus-ui/src/lib/constants.ts
@@ -35,15 +35,13 @@ export const SERVER_ERRORS = {
 };
 
 export const EXTERNAL_URLS = {
-  TRAINING_AND_PLANNING_DOC:
-    "https://mana.mozilla.org/wiki/display/FJT/Nimbus+Onboarding",
+  TRAINING_AND_PLANNING_DOC: "https://experimenter.info/for-product",
   NIMBUS_MANA_DOC: "https://mana.mozilla.org/wiki/display/FJT/Nimbus",
   WORKFLOW_MANA_DOC:
     "https://experimenter.info/data-scientists/#sample-size-recommendations",
-  BRANCHES_GOOGLE_DOC:
-    "https://docs.google.com/document/d/155EUgzn22VTX8mFwesSROT3Z6JORSfb5VyoMoLra7ws/edit#heading=h.i8g4ppfvkq0x",
-  METRICS_GOOGLE_DOC:
-    "https://docs.google.com/document/d/155EUgzn22VTX8mFwesSROT3Z6JORSfb5VyoMoLra7ws/edit#heading=h.uq23fsvh16rc",
+  BRANCHES_EXPERIMENTER_DOC: "https://experimenter.info/feature-definition/",
+  METRICS_EXPERIMENTER_DOC:
+    "https://experimenter.info/deep-dives/jetstream/metrics",
   // EXP-866 TBD URL
   PREVIEW_LAUNCH_DOC: "https://mana.mozilla.org/wiki/display/FJT/Nimbus",
   RISK_BRAND:
@@ -73,6 +71,8 @@ export const EXTERNAL_URLS = {
   CUSTOM_AUDIENCES_EXPLANATION:
     "https://experimenter.info/workflow/implementing/custom-audiences",
   WHAT_TRAIN_IS_IT: "https://whattrainisitnow.com",
+  QA_PI_DOC:
+    "https://mozilla-hub.atlassian.net/jira/software/c/projects/QA/boards/261",
 };
 
 export const RISK_QUESTIONS = {


### PR DESCRIPTION
Because

- Some links experimenter is not linked to correct info.

This commit

- Update link for `training and planning documentation` when creating a new experiment
- Update branches page `Learn more` link
- Update metric link
- Add a new link for QA PI request
<img width="1569" alt="Screenshot 2024-02-05 at 2 02 59 PM" src="https://github.com/mozilla/experimenter/assets/25848231/d4478445-f10c-419d-8d83-5110a68af210">

Fixes #10217 