### PR TITLE
feat(nimbus): Add model query for getting a list of live experiments that exist in previous iterations of the namespace

### DIFF
--- a/experimenter/experimenter/experiments/api/v5/types.py
+++ b/experimenter/experimenter/experiments/api/v5/types.py
@@ -514,6 +514,9 @@ class NimbusExperimentType(DjangoObjectType):
     is_web = graphene.NonNull(graphene.Boolean)
     jexl_targeting_expression = graphene.String()
     languages = graphene.List(graphene.NonNull(NimbusLanguageType), required=True)
+    live_experiments_in_namespace = graphene.NonNull(
+        lambda: graphene.List(graphene.NonNull(graphene.String))
+    )
     locales = graphene.List(graphene.NonNull(NimbusLocaleType), required=True)
     localizations = graphene.String()
     monitoring_dashboard_url = graphene.String()
@@ -594,6 +597,7 @@ class NimbusExperimentType(DjangoObjectType):
             "is_web",
             "jexl_targeting_expression",
             "languages",
+            "live_experiments_in_namespace",
             "locales",
             "localizations",
             "monitoring_dashboard_url",

--- a/experimenter/experimenter/experiments/models.py
+++ b/experimenter/experimenter/experiments/models.py
@@ -839,25 +839,20 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
 
     @property
     def live_experiments_in_namespace(self):
-        matching = []
-        isolation_groups = NimbusIsolationGroup.objects.filter(
-            name=self.bucket_namespace, application=self.application
-        )
-        if isolation_groups.exists():
-            experiment_ids = NimbusBucketRange.objects.filter(
-                isolation_group__in=isolation_groups
-            ).values_list("experiment_id")
-            matching = (
-                NimbusExperiment.objects.filter(
-                    id__in=experiment_ids,
-                    status=NimbusExperiment.Status.LIVE,
-                )
-                .exclude(id=self.id)
-                .values_list("slug", flat=True)
-                .distinct()
-                .order_by("slug")
+        experiment_ids = NimbusBucketRange.objects.filter(
+            isolation_group__name=self.bucket_namespace,
+            isolation_group__application=self.application,
+        ).values_list("experiment_id", flat=True)
+        return (
+            NimbusExperiment.objects.filter(
+                id__in=experiment_ids,
+                status=NimbusExperiment.Status.LIVE,
             )
-        return matching
+            .exclude(id=self.id)
+            .values_list("slug", flat=True)
+            .distinct()
+            .order_by("slug")
+        )
 
     @property
     def can_edit(self):

--- a/experimenter/experimenter/experiments/tests/api/v5/test_queries.py
+++ b/experimenter/experimenter/experiments/tests/api/v5/test_queries.py
@@ -805,6 +805,7 @@ class TestNimbusExperimentBySlugQuery(GraphQLTestCase):
                     }
                     excludedLiveDeliveries
                     featureHasLiveMultifeatureExperiments
+                    liveExperimentsInNamespace
                 }
             }
             """,
@@ -898,6 +899,7 @@ class TestNimbusExperimentBySlugQuery(GraphQLTestCase):
                 ].is_web,
                 "jexlTargetingExpression": experiment.targeting,
                 "languages": [{"id": str(language.id), "name": language.name}],
+                "liveExperimentsInNamespace": [],
                 "locales": [{"id": str(locale.id), "name": locale.name}],
                 "localizations": experiment.localizations,
                 "monitoringDashboardUrl": experiment.monitoring_dashboard_url,

--- a/experimenter/experimenter/nimbus-ui/schema.graphql
+++ b/experimenter/experimenter/nimbus-ui/schema.graphql
@@ -79,6 +79,7 @@ type NimbusExperimentType {
   isEnrollmentPaused: Boolean
   isWeb: Boolean!
   jexlTargetingExpression: String
+  liveExperimentsInNamespace: [String!]!
   monitoringDashboardUrl: String
   readyForReview: NimbusReviewType
   recipeJson: String

--- a/experimenter/experimenter/nimbus-ui/src/gql/experiments.ts
+++ b/experimenter/experimenter/nimbus-ui/src/gql/experiments.ts
@@ -255,8 +255,8 @@ export const GET_EXPERIMENT_QUERY = gql`
       isRolloutDirty
       qaComment
       qaStatus
-      excludedLiveDeliveries
       featureHasLiveMultifeatureExperiments
+      liveExperimentsInNamespace
     }
   }
 `;

--- a/experimenter/experimenter/nimbus-ui/src/types/getExperiment.ts
+++ b/experimenter/experimenter/nimbus-ui/src/types/getExperiment.ts
@@ -286,8 +286,8 @@ export interface getExperiment_experimentBySlug {
   isRolloutDirty: boolean;
   qaComment: string | null;
   qaStatus: NimbusExperimentQAStatusEnum | null;
-  excludedLiveDeliveries: string[];
   featureHasLiveMultifeatureExperiments: string[];
+  liveExperimentsInNamespace: string[];
 }
 
 export interface getExperiment {


### PR DESCRIPTION
Because

- Audience overlap can happen when there are Live experiments that exist in previous iterations of a namespace

This commit

- Adds a query to the model to find any of these matching experiments
- This query returns a list of the slugs of any matching experiments, so that we will be able to say "these are the experiments that might cause overlap with yours" once we connect this to the frontend


Fixes #10093