### PR TITLE
feat(nimbus): Add a warning for rollouts that will re-enroll and clobber prefs

### DIFF
--- a/experimenter/experimenter/experiments/constants.py
+++ b/experimenter/experimenter/experiments/constants.py
@@ -663,3 +663,10 @@ Optional - We believe this outcome will <describe impact> on <core metric>
     ERROR_FEATURE_CONFIG_UNSUPPORTED_IN_VERSION = (
         "Feature {feature_config} is not supported in version {version}."
     )
+
+    WARNING_ROLLOUT_PREF_REENROLL = (
+        "WARNING: One or more features of this rollouts sets prefs and this rollout is "
+        "not configured to prevent pref conflicts. Users that change prefs set by this "
+        "rollout will re-enroll in this rollout, which will result in overriding their "
+        "changes."
+    )

--- a/experimenter/experimenter/nimbus-ui/src/components/PageSummary/index.test.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageSummary/index.test.tsx
@@ -990,4 +990,24 @@ describe("PageSummary", () => {
     render(<Subject mocks={[mock]} />);
     expect(screen.queryByTestId("desktop-min-version-warning")).toBeNull();
   });
+
+  it("displays rollout setpref warning", async () => {
+    const { mock } = mockExperimentQuery("demo-slug", {
+      readyForReview: {
+        ready: true,
+        message: {},
+        warnings: {
+          pref_rollout_reenroll: ["uh oh"],
+        },
+      },
+      isRollout: true,
+      application: NimbusExperimentApplicationEnum.DESKTOP,
+      channel: NimbusExperimentChannelEnum.NIGHTLY,
+      status: NimbusExperimentStatusEnum.DRAFT,
+    });
+
+    render(<Subject mocks={[mock]} />);
+
+    screen.queryByTestId("rollout-setpref-reenroll-warnings");
+  });
 });

--- a/experimenter/experimenter/nimbus-ui/src/components/PageSummary/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageSummary/index.tsx
@@ -231,40 +231,7 @@ const PageSummary = (props: RouteComponentProps) => {
 
       <SummaryTimeline {...{ experiment }} />
 
-      {submitError && (
-        <Warning
-          {...{
-            text: submitError,
-            testId: "submit-error",
-            variant: "warning",
-          }}
-        />
-      )}
-
-      {experiment.isRollout &&
-        (status.draft || status.preview) &&
-        fieldWarnings.bucketing?.length > 0 && (
-          <Warning
-            {...{
-              text: fieldWarnings.bucketing as SerializerMessage,
-              testId: "bucketing",
-              learnMoreLink: EXTERNAL_URLS.BUCKET_WARNING_EXPLANATION,
-            }}
-          />
-        )}
-
-      {experiment.isRollout &&
-        (experiment.status === NimbusExperimentStatusEnum.DRAFT ||
-          experiment.status === NimbusExperimentStatusEnum.PREVIEW) &&
-        fieldWarnings.firefox_min_version?.length > 0 && (
-          <Warning
-            {...{
-              text: fieldWarnings.firefox_min_version as SerializerMessage,
-              testId: "desktop-min-version",
-              variant: "warning",
-            }}
-          />
-        )}
+      <WarningList {...{ experiment, submitError, fieldWarnings, status }} />
 
       {summaryAction && (
         <h5 className="mt-3 mb-4 ml-3">
@@ -405,3 +372,71 @@ const Warning = ({
     )}
   </Alert>
 );
+
+type WarningsProps = {
+  experiment: getExperiment_experimentBySlug;
+  submitError: string | null;
+  fieldWarnings: ReturnType<typeof useReviewCheck>["fieldWarnings"];
+  status: ReturnType<typeof getStatus>;
+};
+
+const WarningList = ({
+  experiment,
+  submitError,
+  fieldWarnings,
+  status,
+}: WarningsProps) => {
+  const warnings: JSX.Element[] = [];
+
+  if (submitError) {
+    warnings.push(
+      <Warning
+        {...{
+          text: submitError,
+          testId: "submit-error",
+          variant: "warning",
+        }}
+      />,
+    );
+  }
+
+  if (experiment.isRollout && (status.draft || status.preview)) {
+    if (fieldWarnings.bucketing?.length) {
+      warnings.push(
+        <Warning
+          {...{
+            text: fieldWarnings.bucketing as SerializerMessage,
+            testId: "bucketing",
+            learnMoreLink: EXTERNAL_URLS.BUCKET_WARNING_EXPLANATION,
+          }}
+        />,
+      );
+    }
+
+    if (fieldWarnings.firefox_min_version?.length) {
+      warnings.push(
+        <Warning
+          {...{
+            text: fieldWarnings.firefox_min_version as SerializerMessage,
+            testId: "desktop-min-version",
+            variant: "warning",
+          }}
+        />,
+      );
+    }
+
+    if (fieldWarnings.pref_rollout_reenroll?.length) {
+      warnings.push(
+        <Warning
+          {...{
+            text: fieldWarnings.pref_rollout_reenroll as SerializerMessage,
+            testId: "rollout-setpref-reenroll",
+            learnMoreLink: EXTERNAL_URLS.ROLLOUT_SETPREF_REENROLL_EXPLANATION,
+          }}
+        />,
+      );
+    }
+  }
+
+  return <>{warnings}</>;
+};

--- a/experimenter/experimenter/nimbus-ui/src/lib/constants.ts
+++ b/experimenter/experimenter/nimbus-ui/src/lib/constants.ts
@@ -50,6 +50,8 @@ export const EXTERNAL_URLS = {
     "https://mana.mozilla.org/wiki/display/FIREFOX/Pref-Flip+and+Add-On+Experiments#PrefFlipandAddOnExperiments-Isthisstudypartnerrelated?riskPARTNER",
   RISK_REVENUE:
     "https://mana.mozilla.org/wiki/display/FIREFOX/Pref-Flip+and+Add-On+Experiments#PrefFlipandAddOnExperiments-riskREV",
+  ROLLOUT_SETPREF_REENROLL_EXPLANATION:
+    "https://experimenter.info/faq/rollouts/rollout-setpref-reenroll",
   SIGNOFF_QA:
     "https://docs.google.com/document/d/1oz1YyaaBI-oHUDsktWA-dLtX7WzhYqs7C121yOPKo2w/edit",
   SIGNOFF_VP:


### PR DESCRIPTION
Because:

- rollouts always re-enroll when possible, unless the user opts out;
- unenrollments from changing prefs are not marked as opt-outs; and
- this can result in constant re-enrollment of rollouts that overwrite user pref choices

This commit:

- adds a warning when this situtation could occur; and
- also improves the performance of feature value validation by refactoring the
  validation logic to cache the `VersionedSchemaRange`s per feature ID, saving
  O(F*B) queries (where F is is the number of features and B is the number of
  treatment branches)

Fixes #10137 
