### PR TITLE
feat(nimbus): Use set_pref_vars in place of sets_prefs

### DIFF
--- a/experimenter/experimenter/experiments/api/v5/serializers.py
+++ b/experimenter/experimenter/experiments/api/v5/serializers.py
@@ -1857,7 +1857,7 @@ class NimbusReviewSerializer(serializers.ModelSerializer):
     def _validate_desktop_pref_rollouts(self, data):
         if self.instance.is_rollout:
             any_feature_sets_prefs = any(
-                schema.sets_prefs
+                bool(schema.set_pref_vars)
                 for schemas_in_range in self.schemas_by_feature_id.values()
                 for schema in schemas_in_range.schemas
             )

--- a/experimenter/experimenter/experiments/api/v5/types.py
+++ b/experimenter/experimenter/experiments/api/v5/types.py
@@ -167,7 +167,7 @@ class NimbusFeatureConfigType(DjangoObjectType):
     def resolve_sets_prefs(self, info):
         for schema in self.schemas.all():
             if schema.version is None:
-                return bool(schema.sets_prefs)
+                return bool(schema.set_pref_vars)
 
     def resolve_schema(self, info):
         for schema in self.schemas.all():

--- a/experimenter/experimenter/experiments/models.py
+++ b/experimenter/experimenter/experiments/models.py
@@ -452,7 +452,7 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
 
         if self.prevent_pref_conflicts:
             for config in self.feature_configs.all():
-                prefs.extend(config.schemas.get(version=None).sets_prefs)
+                prefs.extend(config.schemas.get(version=None).set_pref_vars.values())
 
         return prefs
 
@@ -539,7 +539,7 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
                 make_sticky_targeting_expression(
                     is_desktop,
                     self.is_rollout,
-                    (f"!('{pref}'|preferenceIsUserSet)" for pref in prefs),
+                    (f"!('{pref}'|preferenceIsUserSet)" for pref in sorted(prefs)),
                 )
             )
 

--- a/experimenter/experimenter/experiments/tests/api/v5/test_mutations.py
+++ b/experimenter/experimenter/experiments/tests/api/v5/test_mutations.py
@@ -1183,7 +1183,7 @@ class TestUpdateExperimentMutationSingleFeature(
             schemas=[
                 NimbusVersionedSchemaFactory.build(
                     version=None,
-                    sets_prefs=["foo.bar.baz"],
+                    set_pref_vars={"baz": "foo.bar.baz"},
                 ),
             ],
         )

--- a/experimenter/experimenter/experiments/tests/api/v5/test_queries.py
+++ b/experimenter/experimenter/experiments/tests/api/v5/test_queries.py
@@ -882,7 +882,7 @@ class TestNimbusExperimentBySlugQuery(GraphQLTestCase):
                         "ownerEmail": feature_config.owner_email,
                         "schema": feature_config.schemas.get(version=None).schema,
                         "setsPrefs": bool(
-                            feature_config.schemas.get(version=None).sets_prefs
+                            feature_config.schemas.get(version=None).set_pref_vars
                         ),
                         "slug": feature_config.slug,
                     }
@@ -1980,7 +1980,9 @@ class TestNimbusExperimentBySlugQuery(GraphQLTestCase):
             schemas=[
                 NimbusVersionedSchemaFactory.build(
                     version=None,
-                    sets_prefs=["foo.bar.baz"],
+                    set_pref_vars={
+                        "baz": "foo.bar.baz",
+                    },
                 ),
             ],
         )
@@ -2543,7 +2545,7 @@ class TestNimbusConfigQuery(MockSizingDataMixin, GraphQLTestCase):
                     "ownerEmail": feature_config.owner_email,
                     "schema": feature_config.schemas.get(version=None).schema,
                     "setsPrefs": bool(
-                        feature_config.schemas.get(version=None).sets_prefs
+                        feature_config.schemas.get(version=None).set_pref_vars
                     ),
                 },
                 config["allFeatureConfigs"],

--- a/experimenter/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_experiment_serializer.py
+++ b/experimenter/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_experiment_serializer.py
@@ -283,7 +283,8 @@ class TestNimbusExperimentSerializer(TestCase):
             application=NimbusExperiment.Application.DESKTOP,
             schemas=[
                 NimbusVersionedSchemaFactory.build(
-                    version=None, sets_prefs=["foo.bar.baz"]
+                    version=None,
+                    set_pref_vars={"baz": "foo.bar.baz"},
                 ),
             ],
         )

--- a/experimenter/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_ready_for_review_serializer.py
+++ b/experimenter/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_ready_for_review_serializer.py
@@ -2717,7 +2717,9 @@ class TestNimbusReviewSerializerSingleFeature(MockFmlErrorMixin, TestCase):
                         NimbusVersionedSchemaFactory.build(
                             version=None,
                             schema=None,
-                            sets_prefs=["foo.bar.baz"],
+                            set_pref_vars={
+                                "baz": "foo.bar.baz",
+                            },
                         ),
                     ],
                 ),

--- a/experimenter/experimenter/experiments/tests/factories.py
+++ b/experimenter/experimenter/experiments/tests/factories.py
@@ -116,6 +116,7 @@ class NimbusVersionedSchemaFactory(factory.django.DjangoModelFactory):
     )
     schema = factory.LazyAttribute(lambda o: FAKER_JSON_SCHEMA)
     sets_prefs = factory.LazyAttribute(lambda o: [])
+    set_pref_vars = factory.LazyAttribute(lambda o: {})
     is_early_startup = False
 
     class Meta:

--- a/experimenter/experimenter/experiments/tests/test_models.py
+++ b/experimenter/experimenter/experiments/tests/test_models.py
@@ -772,9 +772,9 @@ class TestNimbusExperiment(TestCase):
             (
                 '(browserSettings.update.channel == "release") && '
                 "((experiment.slug in activeExperiments) || ("
-                "(!('nimbus.test.string'|preferenceIsUserSet)) && "
+                "(!('nimbus.test.boolean'|preferenceIsUserSet)) && "
                 "(!('nimbus.test.int'|preferenceIsUserSet)) && "
-                "(!('nimbus.test.boolean'|preferenceIsUserSet))))"
+                "(!('nimbus.test.string'|preferenceIsUserSet))))"
             ),
         )
         JEXLParser().parse(experiment.targeting)
@@ -3241,10 +3241,9 @@ class NimbusFeatureConfigTests(TestCase):
         schemas = {
             schema.version: schema
             for schema in NimbusVersionedSchema.objects.bulk_create(
-                NimbusVersionedSchema(
+                NimbusVersionedSchemaFactory.build(
                     feature_config=feature,
                     version=versions[(major, minor, patch)],
-                    sets_prefs=[],
                 )
                 for major in range(1, 3)
                 for minor in range(3)

--- a/experimenter/experimenter/features/management/commands/load_feature_configs.py
+++ b/experimenter/experimenter/features/management/commands/load_feature_configs.py
@@ -174,16 +174,6 @@ class Command(BaseCommand):
                     dirty_fields.append("schema")
 
             if feature_config.application == Application.DESKTOP:
-                sets_prefs = [
-                    _set_pref_name(v.set_pref)
-                    for v in feature.model.variables.values()
-                    if v.set_pref is not None
-                ]
-
-                if schema.sets_prefs != sets_prefs:
-                    schema.sets_prefs = sets_prefs
-                    dirty_fields.append("sets_prefs")
-
                 set_pref_vars = {
                     var_name: _set_pref_name(var.set_pref)
                     for var_name, var in feature.model.variables.items()

--- a/experimenter/experimenter/features/tests/test_load_feature_configs.py
+++ b/experimenter/experimenter/features/tests/test_load_feature_configs.py
@@ -71,11 +71,6 @@ class TestLoadFeatureConfigs(TestCase):
         schema = feature_config.schemas.get(version=None)
 
         self.assertEqual(
-            sorted(schema.sets_prefs),
-            sorted(["nimbus.test.string", "nimbus.test.int", "nimbus.test.boolean"]),
-        )
-
-        self.assertEqual(
             schema.set_pref_vars,
             {
                 "string": "nimbus.test.string",
@@ -86,10 +81,6 @@ class TestLoadFeatureConfigs(TestCase):
 
         feature_config = NimbusFeatureConfig.objects.get(slug="setPrefFeature")
         schema = feature_config.schemas.get(version=None)
-        self.assertEqual(
-            sorted(schema.sets_prefs), sorted(["nimbus.user", "nimbus.default"])
-        )
-
         self.assertEqual(
             schema.set_pref_vars,
             {
@@ -158,12 +149,6 @@ class TestLoadFeatureConfigs(TestCase):
 
         feature_config = NimbusFeatureConfig.objects.get(slug="oldSetPrefFeature")
         schema = feature_config.schemas.get(version=None)
-
-        self.assertEqual(
-            sorted(schema.sets_prefs),
-            sorted(["nimbus.test.string", "nimbus.test.int", "nimbus.test.boolean"]),
-        )
-
         self.assertEqual(
             schema.set_pref_vars,
             {


### PR DESCRIPTION
Because:

- we now have the `set_pref_vars` field, which includes both the prefs and the variables that set them

This commit:

- migrates all logic to use the new field.

Fixes #10076