### PR TITLE
For #10192 feat(nimbus): Cleanup new audience overlap model queries

### DIFF
--- a/experimenter/experimenter/experiments/models.py
+++ b/experimenter/experimenter/experiments/models.py
@@ -800,11 +800,6 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
 
     @property
     def feature_has_live_multifeature_experiments(self):
-        """Live multifeature experiments that share a feature with this experiment.
-
-        Returns:
-            A list of experiment slugs.
-        """
         matching = []
         live_experiments = NimbusExperiment.objects.filter(
             status=self.Status.LIVE,
@@ -816,6 +811,7 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
                 live_experiments.annotate(n_feature_configs=Count("feature_configs"))
                 .filter(n_feature_configs__gt=1)
                 .filter(feature_configs__slug__in=feature_slugs)
+                .exclude(id=self.id)
                 .values_list("slug", flat=True)
                 .distinct()
                 .order_by("slug")
@@ -831,6 +827,7 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
                     status=NimbusExperiment.Status.LIVE,
                     application=self.application,
                 )
+                .exclude(id=self.id)
                 .values_list("slug", flat=True)
                 .distinct()
                 .order_by("slug")

--- a/experimenter/experimenter/nimbus-ui/src/gql/experiments.ts
+++ b/experimenter/experimenter/nimbus-ui/src/gql/experiments.ts
@@ -255,6 +255,7 @@ export const GET_EXPERIMENT_QUERY = gql`
       isRolloutDirty
       qaComment
       qaStatus
+      excludedLiveDeliveries
       featureHasLiveMultifeatureExperiments
       liveExperimentsInNamespace
     }

--- a/experimenter/experimenter/nimbus-ui/src/types/getExperiment.ts
+++ b/experimenter/experimenter/nimbus-ui/src/types/getExperiment.ts
@@ -286,6 +286,7 @@ export interface getExperiment_experimentBySlug {
   isRolloutDirty: boolean;
   qaComment: string | null;
   qaStatus: NimbusExperimentQAStatusEnum | null;
+  excludedLiveDeliveries: string[];
   featureHasLiveMultifeatureExperiments: string[];
   liveExperimentsInNamespace: string[];
 }


### PR DESCRIPTION
Because

- We want to use the three new queries to determine audience overlap
- And this needs a little cleanup

This commit

- Exclude self from audience overlap queries on the model. 
- Add `excludedLiveDeliveries` to the `getExperimentQuery`
- Remove doc from `feature_has_live_multifeature_experiments` (per Yashika's comment [here](https://github.com/mozilla/experimenter/pull/10215#discussion_r1478966516))

For #10192 