### PR TITLE
feat(nimbus): Audience overlap warning for excluded live deliveries

### DIFF
--- a/experimenter/experimenter/nimbus-ui/src/components/PageSummary/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageSummary/index.tsx
@@ -20,6 +20,7 @@ import { useChangeOperationMutation, useReviewCheck } from "src/hooks";
 import { ReactComponent as ExternalIcon } from "src/images/external.svg";
 import { ReactComponent as InfoCircle } from "src/images/info-circle.svg";
 import {
+  AUDIENCE_OVERLAP_WARNINGS,
   CHANGELOG_MESSAGES,
   EXTERNAL_URLS,
   LIFECYCLE_REVIEW_FLOWS,
@@ -387,6 +388,9 @@ const WarningList = ({
   status,
 }: WarningsProps) => {
   const warnings: JSX.Element[] = [];
+  const excludedLiveDeliveries = experiment.excludedLiveDeliveries
+    ?.toString()
+    .replace(",", ", ");
 
   if (submitError) {
     warnings.push(
@@ -436,6 +440,23 @@ const WarningList = ({
         />,
       );
     }
+  }
+
+  if (
+    (status.draft || status.preview || status.review) &&
+    excludedLiveDeliveries
+  ) {
+    warnings.push(
+      <Warning
+        {...{
+          text: AUDIENCE_OVERLAP_WARNINGS.EXCLUDING_EXPERIMENTS_WARNING(
+            excludedLiveDeliveries,
+          ),
+          testId: "excluding-live-experiments",
+          variant: "warning",
+        }}
+      />,
+    );
   }
 
   return <>{warnings}</>;

--- a/experimenter/experimenter/nimbus-ui/src/lib/constants.ts
+++ b/experimenter/experimenter/nimbus-ui/src/lib/constants.ts
@@ -94,6 +94,12 @@ export const TOOLTIP_DISABLED_FOR_WEBAPP =
 export const TOOLTIP_RELEASE_DATE =
   "This is the approximate release date of the version that is being targeted. Click here to find your date!";
 
+export const AUDIENCE_OVERLAP_WARNINGS = {
+  EXCLUDING_EXPERIMENTS_WARNING: (slugs: string) => {
+    return `The following experiments are being excluded by your experiment and may cause audience overlap: ${slugs}`;
+  },
+};
+
 export const LIFECYCLE_REVIEW_FLOWS = {
   LAUNCH: {
     buttonTitle: "Launch Experiment",


### PR DESCRIPTION
Because

- Potential audience overlap can be determined if an experiment excludes other live deliveries

This commit

- Adds a warning to the Summary page if excluded live deliveries exist
- The warning shows the experiment Slugs of the conflicting experiments
- Only shows the warning in Draft, Preview, or Review states
- Moves all of the warning tests for PageSummary into their own section in `PageSummary/index.test.tsx`

For #10192

<img width="1347" alt="Screenshot 2024-02-06 at 1 24 36 PM" src="https://github.com/mozilla/experimenter/assets/43795363/42edae90-4aa4-442a-aff8-90db5561caf8">
