### PR TITLE
feat(nimbus): Audience overlap warning for live multifeature experiments

### DIFF
--- a/experimenter/experimenter/nimbus-ui/src/components/PageSummary/index.test.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageSummary/index.test.tsx
@@ -1045,6 +1045,36 @@ describe("PageSummary Warnings", () => {
     );
   });
 
+  it("displays warnings for live multifeature audience overlap", async () => {
+    const warning = AUDIENCE_OVERLAP_WARNINGS.LIVE_MULTIFEATURE_WARNING(
+      "my-slimy-slug, smooth-slug",
+    );
+    const { mock } = mockExperimentQuery("demo-slug", {
+      application: NimbusExperimentApplicationEnum.DESKTOP,
+      channel: NimbusExperimentChannelEnum.NIGHTLY,
+      status: NimbusExperimentStatusEnum.DRAFT,
+      featureHasLiveMultifeatureExperiments: ["my-slimy-slug", "smooth-slug"],
+    });
+    render(<Subject mocks={[mock]} />);
+    await waitFor(() => {
+      expect(screen.queryByTestId("live-multifeature-warning"));
+      expect(screen.getByText(warning));
+    });
+  });
+
+  it("displays no warning when no live multifeature audience overlap", async () => {
+    const { mock } = mockExperimentQuery("demo-slug", {
+      application: NimbusExperimentApplicationEnum.DESKTOP,
+      channel: NimbusExperimentChannelEnum.NIGHTLY,
+      status: NimbusExperimentStatusEnum.DRAFT,
+      featureHasLiveMultifeatureExperiments: [],
+    });
+    render(<Subject mocks={[mock]} />);
+    await waitFor(() =>
+      expect(screen.queryByTestId("live-multifeature-warning")).toBeNull(),
+    );
+  });
+
   it.each([
     [
       NimbusExperimentStatusEnum.DRAFT,
@@ -1084,17 +1114,20 @@ describe("PageSummary Warnings", () => {
         status: status,
         publishStatus: publishStatus,
         excludedLiveDeliveries: ["my-silly-slug"],
+        featureHasLiveMultifeatureExperiments: ["my-slimy-slug"],
       });
       render(<Subject mocks={[mock]} />);
       if (displayWarning) {
         await waitFor(() => {
           expect(screen.queryByTestId("excluding-live-experiments-warning"));
+          expect(screen.queryByTestId("live-multifeature-warning"));
         });
       } else {
         await waitFor(() => {
           expect(
             screen.queryByTestId("excluding-live-experiments-warning"),
           ).toBeNull();
+          expect(screen.queryByTestId("live-multifeature-warning")).toBeNull();
         });
       }
     },

--- a/experimenter/experimenter/nimbus-ui/src/components/PageSummary/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageSummary/index.tsx
@@ -388,9 +388,15 @@ const WarningList = ({
   status,
 }: WarningsProps) => {
   const warnings: JSX.Element[] = [];
+
   const excludedLiveDeliveries = experiment.excludedLiveDeliveries
     ?.toString()
-    .replace(",", ", ");
+    .replaceAll(",", ", ");
+
+  const featureHasLiveMultifeatureExperiments =
+    experiment.featureHasLiveMultifeatureExperiments
+      ?.toString()
+      .replaceAll(",", ", ");
 
   if (submitError) {
     warnings.push(
@@ -453,6 +459,23 @@ const WarningList = ({
             excludedLiveDeliveries,
           ),
           testId: "excluding-live-experiments",
+          variant: "warning",
+        }}
+      />,
+    );
+  }
+
+  if (
+    (status.draft || status.preview || status.review) &&
+    featureHasLiveMultifeatureExperiments
+  ) {
+    warnings.push(
+      <Warning
+        {...{
+          text: AUDIENCE_OVERLAP_WARNINGS.LIVE_MULTIFEATURE_WARNING(
+            featureHasLiveMultifeatureExperiments,
+          ),
+          testId: "live-multifeature",
           variant: "warning",
         }}
       />,

--- a/experimenter/experimenter/nimbus-ui/src/lib/constants.ts
+++ b/experimenter/experimenter/nimbus-ui/src/lib/constants.ts
@@ -98,6 +98,9 @@ export const AUDIENCE_OVERLAP_WARNINGS = {
   EXCLUDING_EXPERIMENTS_WARNING: (slugs: string) => {
     return `The following experiments are being excluded by your experiment and may cause audience overlap: ${slugs}`;
   },
+  LIVE_MULTIFEATURE_WARNING: (slugs: string) => {
+    return `The following multi-feature experiments are LIVE and may cause audience overlap with your experiment: ${slugs}`;
+  },
 };
 
 export const LIFECYCLE_REVIEW_FLOWS = {


### PR DESCRIPTION
Because

- Potential audience overlap can be determined if there are Live multifeature experiments for the targeted features

This commit

- Adds a warning to the Summary page if live multifeature experiments exist for these features
- The warning shows the experiment Slugs of the conflicting experiments
- Only shows the warning in Draft, Preview, or Review states
- Moves all of the warning tests for PageSummary into their own section in `PageSummary/index.test.tsx`

For #10192
Related to #10238

<img width="1358" alt="Screenshot 2024-02-06 at 1 08 55 PM" src="https://github.com/mozilla/experimenter/assets/43795363/3cf99939-b72f-417c-8f1f-201291ee2aff">

