### PR TITLE
feat(nimbus): Audience overlap warning for live experiments in previous namespaces

### DIFF
--- a/experimenter/experimenter/nimbus-ui/src/components/PageSummary/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageSummary/index.tsx
@@ -398,6 +398,14 @@ const WarningList = ({
       ?.toString()
       .replaceAll(",", ", ");
 
+  const liveExperimentsInNamespace = experiment.liveExperimentsInNamespace
+    ?.toString()
+    .replaceAll(",", ", ");
+
+  const overlappingWarnings = featureHasLiveMultifeatureExperiments?.includes(
+    liveExperimentsInNamespace,
+  );
+
   if (submitError) {
     warnings.push(
       <Warning
@@ -447,39 +455,48 @@ const WarningList = ({
       );
     }
   }
+  if (status.draft || status.preview || status.review) {
+    if (excludedLiveDeliveries) {
+      warnings.push(
+        <Warning
+          {...{
+            text: AUDIENCE_OVERLAP_WARNINGS.EXCLUDING_EXPERIMENTS_WARNING(
+              excludedLiveDeliveries,
+            ),
+            testId: "excluding-live-experiments",
+            variant: "warning",
+          }}
+        />,
+      );
+    }
 
-  if (
-    (status.draft || status.preview || status.review) &&
-    excludedLiveDeliveries
-  ) {
-    warnings.push(
-      <Warning
-        {...{
-          text: AUDIENCE_OVERLAP_WARNINGS.EXCLUDING_EXPERIMENTS_WARNING(
-            excludedLiveDeliveries,
-          ),
-          testId: "excluding-live-experiments",
-          variant: "warning",
-        }}
-      />,
-    );
-  }
+    if (liveExperimentsInNamespace && !overlappingWarnings) {
+      warnings.push(
+        <Warning
+          {...{
+            text: AUDIENCE_OVERLAP_WARNINGS.LIVE_EXPERIMENTS_BUCKET_WARNING(
+              liveExperimentsInNamespace,
+            ),
+            testId: "live-experiments-in-bucket",
+            variant: "warning",
+          }}
+        />,
+      );
+    }
 
-  if (
-    (status.draft || status.preview || status.review) &&
-    featureHasLiveMultifeatureExperiments
-  ) {
-    warnings.push(
-      <Warning
-        {...{
-          text: AUDIENCE_OVERLAP_WARNINGS.LIVE_MULTIFEATURE_WARNING(
-            featureHasLiveMultifeatureExperiments,
-          ),
-          testId: "live-multifeature",
-          variant: "warning",
-        }}
-      />,
-    );
+    if (featureHasLiveMultifeatureExperiments) {
+      warnings.push(
+        <Warning
+          {...{
+            text: AUDIENCE_OVERLAP_WARNINGS.LIVE_MULTIFEATURE_WARNING(
+              featureHasLiveMultifeatureExperiments,
+            ),
+            testId: "live-multifeature",
+            variant: "warning",
+          }}
+        />,
+      );
+    }
   }
 
   return <>{warnings}</>;

--- a/experimenter/experimenter/nimbus-ui/src/components/PageSummary/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageSummary/index.tsx
@@ -389,18 +389,14 @@ const WarningList = ({
 }: WarningsProps) => {
   const warnings: JSX.Element[] = [];
 
-  const excludedLiveDeliveries = experiment.excludedLiveDeliveries
-    ?.toString()
-    .replaceAll(",", ", ");
+  const excludedLiveDeliveries: string =
+    experiment.excludedLiveDeliveries?.join(", ");
 
   const featureHasLiveMultifeatureExperiments =
-    experiment.featureHasLiveMultifeatureExperiments
-      ?.toString()
-      .replaceAll(",", ", ");
+    experiment.featureHasLiveMultifeatureExperiments?.join(", ");
 
-  const liveExperimentsInNamespace = experiment.liveExperimentsInNamespace
-    ?.toString()
-    .replaceAll(",", ", ");
+  const liveExperimentsInNamespace =
+    experiment.liveExperimentsInNamespace?.join(", ");
 
   const overlappingWarnings = featureHasLiveMultifeatureExperiments?.includes(
     liveExperimentsInNamespace,
@@ -465,6 +461,7 @@ const WarningList = ({
             ),
             testId: "excluding-live-experiments",
             variant: "warning",
+            learnMoreLink: EXTERNAL_URLS.AUDIENCE_OVERLAP_WARNING,
           }}
         />,
       );
@@ -479,6 +476,7 @@ const WarningList = ({
             ),
             testId: "live-experiments-in-bucket",
             variant: "warning",
+            learnMoreLink: EXTERNAL_URLS.AUDIENCE_OVERLAP_WARNING,
           }}
         />,
       );
@@ -493,6 +491,7 @@ const WarningList = ({
             ),
             testId: "live-multifeature",
             variant: "warning",
+            learnMoreLink: EXTERNAL_URLS.AUDIENCE_OVERLAP_WARNING,
           }}
         />,
       );

--- a/experimenter/experimenter/nimbus-ui/src/lib/constants.ts
+++ b/experimenter/experimenter/nimbus-ui/src/lib/constants.ts
@@ -70,6 +70,8 @@ export const EXTERNAL_URLS = {
     "https://experimenter.info/access#onboarding-for-new-reviewers-l3",
   BUCKET_WARNING_EXPLANATION:
     "https://experimenter.info/faq/warnings#rollout-bucketing-warning",
+  AUDIENCE_OVERLAP_WARNING:
+    "https://experimenter.info/faq/warnings/#audience-overlap",
   CUSTOM_AUDIENCES_EXPLANATION:
     "https://experimenter.info/workflow/implementing/custom-audiences",
   WHAT_TRAIN_IS_IT: "https://whattrainisitnow.com",

--- a/experimenter/experimenter/nimbus-ui/src/lib/constants.ts
+++ b/experimenter/experimenter/nimbus-ui/src/lib/constants.ts
@@ -98,6 +98,9 @@ export const AUDIENCE_OVERLAP_WARNINGS = {
   EXCLUDING_EXPERIMENTS_WARNING: (slugs: string) => {
     return `The following experiments are being excluded by your experiment and may cause audience overlap: ${slugs}`;
   },
+  LIVE_EXPERIMENTS_BUCKET_WARNING: (slugs: string) => {
+    return `The following experiments are LIVE and may cause audience overlap with your experiment: ${slugs}`;
+  },
   LIVE_MULTIFEATURE_WARNING: (slugs: string) => {
     return `The following multi-feature experiments are LIVE and may cause audience overlap with your experiment: ${slugs}`;
   },


### PR DESCRIPTION
Because

- Potential audience overlap can be determined if there are Live experiments in previous iterations of the namespace

This commit

- Adds a warning to the Summary page if live experiments exist in previous namespaces
- The warning shows the experiment Slugs of the conflicting experiments
- Only shows the warning in Draft, Preview, or Review states
- Adds Learn more links to the three Audience Overlap warnings that point to the sizing instructions (for now, we'll add docs specifically for these warnings)

For #10192
Related to #10238, #10239

<img width="1352" alt="Screenshot 2024-02-06 at 1 24 57 PM" src="https://github.com/mozilla/experimenter/assets/43795363/be7eb1fe-1cfa-4d68-b5ed-ea9d69c2a69e">
<img width="1355" alt="Screenshot 2024-02-06 at 6 23 01 PM" src="https://github.com/mozilla/experimenter/assets/43795363/97973d79-ee63-47cf-aac3-8526ad83ebdd">

