### PR TITLE
For #10230 feat(nimbus): Subscribe button is not shown when archived

### DIFF
--- a/experimenter/experimenter/nimbus-ui/src/components/Summary/TableOverview/index.test.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/Summary/TableOverview/index.test.tsx
@@ -330,6 +330,16 @@ describe("TableOverview", () => {
       });
     });
 
+    it("when experiment is archived", async () => {
+      const { experiment } = mockExperimentQuery("demo-slug", {
+        isArchived: true,
+      });
+      expect(experiment.subscribers).toEqual([]);
+
+      render(<Subject {...{ experiment }} />);
+      expect(screen.queryByTestId("add-subscriber-button")).toBeNull();
+    });
+
     it("subscribes as expected", async () => {
       const { mock, experiment } = mockExperimentQuery("demo-slug");
       const currentUser = "dev@example.com";

--- a/experimenter/experimenter/nimbus-ui/src/components/Summary/TableOverview/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/Summary/TableOverview/index.tsx
@@ -265,26 +265,28 @@ const TableOverview = ({ experiment }: TableOverviewProps) => {
                 ) : (
                   <NotSet />
                 )}
-                <td className="ml-0 pl-0 border-top-0">
-                  <Button
-                    size="sm"
-                    variant="outline-primary"
-                    data-testid="add-subscriber-button"
-                    onClick={handleSave}
-                  >
-                    {subscribed ? (
-                      <div>
-                        <CollapseMinus />
-                        Unsubscribe
-                      </div>
-                    ) : (
-                      <div>
-                        <ExpandPlus />
-                        Subscribe
-                      </div>
-                    )}
-                  </Button>
-                </td>
+                {!experiment.isArchived && (
+                  <td className="ml-0 pl-0 border-top-0">
+                    <Button
+                      size="sm"
+                      variant="outline-primary"
+                      data-testid="add-subscriber-button"
+                      onClick={handleSave}
+                    >
+                      {subscribed ? (
+                        <div>
+                          <CollapseMinus />
+                          Unsubscribe
+                        </div>
+                      ) : (
+                        <div>
+                          <ExpandPlus />
+                          Subscribe
+                        </div>
+                      )}
+                    </Button>
+                  </td>
+                )}
                 {submitErrors["*"] && (
                   <Alert data-testid="submit-error" variant="warning">
                     {submitErrors["*"]}


### PR DESCRIPTION
Because

- We don't want users to subscribe to archived experiments

This commit

- Only shows the subscribe button when an experiment is NOT archived

Fixes #10230 


https://github.com/mozilla/experimenter/assets/43795363/186f3811-ba0f-410e-89ab-3162d01d07f6

