### PR TITLE
Fixes #10265 fix(nimbus): Only show audience overlap warning in draft and preview

### DIFF
--- a/experimenter/experimenter/nimbus-ui/src/components/PageSummary/index.test.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageSummary/index.test.tsx
@@ -1135,6 +1135,11 @@ describe("PageSummary Warnings", () => {
       true,
     ],
     [
+      NimbusExperimentStatusEnum.DRAFT,
+      NimbusExperimentPublishStatusEnum.REVIEW,
+      true,
+    ],
+    [
       NimbusExperimentStatusEnum.PREVIEW,
       NimbusExperimentPublishStatusEnum.IDLE,
       true,
@@ -1145,14 +1150,14 @@ describe("PageSummary Warnings", () => {
       false,
     ],
     [
-      NimbusExperimentStatusEnum.COMPLETE,
-      NimbusExperimentPublishStatusEnum.IDLE,
+      NimbusExperimentStatusEnum.LIVE,
+      NimbusExperimentPublishStatusEnum.REVIEW,
       false,
     ],
     [
-      NimbusExperimentStatusEnum.DRAFT,
-      NimbusExperimentPublishStatusEnum.REVIEW,
-      true,
+      NimbusExperimentStatusEnum.COMPLETE,
+      NimbusExperimentPublishStatusEnum.IDLE,
+      false,
     ],
   ])(
     "displays audience overlap warnings in status",

--- a/experimenter/experimenter/nimbus-ui/src/components/PageSummary/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageSummary/index.tsx
@@ -451,7 +451,7 @@ const WarningList = ({
       );
     }
   }
-  if (status.draft || status.preview || status.review) {
+  if (status.draft || status.preview) {
     if (excludedLiveDeliveries) {
       warnings.push(
         <Warning


### PR DESCRIPTION
Because

- We only care about showing the warnings for audience overlap in draft and preview

This commit

- Removed the check for `status.review` (disregard `publish_status` and only check `status`)

Fixes #10265