### PR TITLE
bug(project): crash in application services megazord build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ commands:
             echo "Changed files:"
             echo "$diff_output"
 
-            if echo "$diff_output" | grep -E '<< parameters.paths >>|^[^/]+$|^.circleci/'
+            if echo "$diff_output" | grep -E '<< parameters.paths >>|^[^/]+$|^.circleci/|application-services/'
               then
                 echo "Changes detected in << parameters.paths >> or .circleci or root directory. Running tests and linting."
               else

--- a/application-services/Dockerfile
+++ b/application-services/Dockerfile
@@ -1,12 +1,12 @@
-FROM debian:bullseye
+FROM debian:bullseye-20240130
 WORKDIR /application-services
 
 COPY . .
 
 RUN apt-get update && \
-    apt-get upgrade && \
+    apt-get upgrade -y && \
     apt-get install -y \
-        curl \
-        jq \
-        zip && \
+    curl \
+    jq \
+    zip && \
     ./fetch-application-services.sh


### PR DESCRIPTION
Because

* In the Dockerfile for application services we call apt-get upgrade
* We were implicitly using the debian:bullseye build dated 20240130
* Calling apt-get upgrade would silently pass becuase no packages had been updated
* On Feb 12 some package updated and so the call to apt-get upgrade produced a prompt to continue
* We had not included the -y flag to accept that prompt
* This caused Docker to abort the build with a spectacularly unhelpful stack trace

This commit
* Locks the application services Dockerfile to a specific tag of debian:bullseye
* Adds the -y flag to apt-get upgrade
* Forces all tests to run on changes to `application-services/`

fixes #10270

