### PR TITLE
chore(nimbus):Update gh token for external config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -493,7 +493,7 @@ jobs:
             - "32:8e:72:0b:9a:a1:1c:b8:7e:90:e1:53:a3:73:68:47" # for git pushes from circleci, since relies on ssh
       - checkout
       - gh/setup:
-          token: GH_TOKEN # for gh commands from circleci, since relies on user token, since por que no los dos?
+          token: GH_EXTERNAL_CONFIG_TOKEN # for gh commands from circleci, since relies on user token, since por que no los dos?
       - run:
           name: Setup Git
           command: |
@@ -506,7 +506,7 @@ jobs:
             git checkout main
             git pull origin main
             cp .env.sample .env
-            env GITHUB_BEARER_TOKEN="${GH_TOKEN}" make fetch_external_resources FETCH_ARGS="--summary fetch-summary.txt"
+            env GITHUB_BEARER_TOKEN="${GH_EXTERNAL_CONFIG_TOKEN}" make fetch_external_resources FETCH_ARGS="--summary fetch-summary.txt"
             mv ./experimenter/fetch-summary.txt /tmp/fetch-summary.txt
             if python3 ./experimenter/bin/should-pr.py
               then


### PR DESCRIPTION
Because

- Currently token `GH_USER` on CI has limited scope associated with it, and we want to fetch resources from private repo. We have added new token `GH_EXTERNAL_CONFIG_TOKEN` with the required scope

This commit

- Update external config job to use new token value

Fixes #10273 