### PR TITLE
chore(project): remove duplicate test deploy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -412,9 +412,7 @@ jobs:
             ./scripts/store_git_info.sh
             make build_prod
             docker tag experimenter:deploy ${DOCKERHUB_REPO}:latest
-            docker tag experimenter:deploy ${DOCKERHUB_REPO}:latest-test
             docker push ${DOCKERHUB_REPO}:latest
-            docker push ${DOCKERHUB_REPO}:latest-test
       - gcp-cli/setup
       - run:
           name: Deploy to Google Container Registry


### PR DESCRIPTION
Becuase

* We added a second deploy to a test tag as part of debugging dockerhub deploy issues
* The deploy issues are resolved now and it is safe to remove this duplicate deploy

This commit

* Removes duplicate deploy

fixes #10297

