### PR TITLE
feat(nimbus): default to exposures results and display info box

### DIFF
--- a/experimenter/experimenter/nimbus-ui/src/components/PageResults/index.test.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageResults/index.test.tsx
@@ -152,7 +152,14 @@ describe("PageResults", () => {
   });
 
   it("hides the analysis basis selector when there are no exposures", async () => {
-    render(<Subject />);
+    render(
+      <Subject
+        mockAnalysisData={mockAnalysis({
+          weekly: { enrollments: { all: [] } },
+          overall: { enrollments: { all: [] } },
+        })}
+      />,
+    );
 
     expect(screen.queryByText("Analysis Basis")).not.toBeInTheDocument();
     expect(
@@ -219,6 +226,15 @@ describe("PageResults", () => {
       />,
     );
 
+    const analysisBasisSelectParent = screen.getByTestId(
+      "analysis-basis-results-selector",
+    );
+    fireEvent.click(
+      within(analysisBasisSelectParent).getByTestId(
+        `${ENROLLMENTS_BASIS}-basis-radio`,
+      ),
+    );
+
     expect(screen.getByText("NoEnrollmentPeriodException"));
     expect(
       screen.getByText(
@@ -246,6 +262,15 @@ describe("PageResults", () => {
           }).experiment
         }
       />,
+    );
+
+    const analysisBasisSelectParent = screen.getByTestId(
+      "analysis-basis-results-selector",
+    );
+    fireEvent.click(
+      within(analysisBasisSelectParent).getByTestId(
+        `${ENROLLMENTS_BASIS}-basis-radio`,
+      ),
     );
 
     expect(
@@ -305,7 +330,7 @@ describe("PageResults", () => {
                 metric: "bad_metric",
                 statistic: "test_statistic",
                 timestamp: "2022-11-04 00:00:00+00:00",
-                analysis_basis: "enrollments",
+                analysis_basis: "exposures",
                 segment: "all",
               },
             ],

--- a/experimenter/experimenter/nimbus-ui/src/components/PageResults/index.test.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageResults/index.test.tsx
@@ -172,23 +172,23 @@ describe("PageResults", () => {
     expect(within(analysisBasisSelectParent).getByText(ENROLLMENTS_BASIS));
     expect(within(analysisBasisSelectParent).getByText(EXPOSURES_BASIS));
 
-    // enrollments checked by default
+    // exposures checked by default
     expect(
       within(analysisBasisSelectParent).getByTestId(
-        `${ENROLLMENTS_BASIS}-basis-radio`,
+        `${EXPOSURES_BASIS}-basis-radio`,
       ),
     ).toBeChecked();
 
     fireEvent.click(
       within(analysisBasisSelectParent).getByTestId(
-        `${EXPOSURES_BASIS}-basis-radio`,
+        `${ENROLLMENTS_BASIS}-basis-radio`,
       ),
     );
 
-    // exposures checked after click
+    // enrollments checked after click
     expect(
       within(analysisBasisSelectParent).getByTestId(
-        `${EXPOSURES_BASIS}-basis-radio`,
+        `${ENROLLMENTS_BASIS}-basis-radio`,
       ),
     ).toBeChecked();
   });

--- a/experimenter/experimenter/nimbus-ui/src/components/PageResults/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageResults/index.tsx
@@ -9,9 +9,9 @@ import Col from "react-bootstrap/Col";
 import Collapse from "react-bootstrap/Collapse";
 import Row from "react-bootstrap/Row";
 import AppLayoutWithExperiment from "src/components/AppLayoutWithExperiment";
+import LinkExternal from "src/components/LinkExternal";
 import AnalysisErrorAlert from "src/components/PageResults/AnalysisErrorAlert";
 import ExternalConfigAlert from "src/components/PageResults/ExternalConfigAlert";
-import LinkExternal from "src/components/LinkExternal";
 import TableHighlights from "src/components/PageResults/TableHighlights";
 import TableHighlightsOverview from "src/components/PageResults/TableHighlightsOverview";
 import TableMetricCount from "src/components/PageResults/TableMetricCount";
@@ -227,20 +227,25 @@ const PageResults: React.FunctionComponent<RouteComponentProps> = () => {
     <AppLayoutWithExperiment title="Analysis" testId="PageResults">
       <ResultsContext.Provider value={resultsContextValue}>
         <Alert variant="warning" data-testid="exposures-as-default-alert">
-          <Alert.Heading>Analysis Results now default to Exposures basis</Alert.Heading>
+          <Alert.Heading>
+            Analysis Results now default to Exposures basis
+          </Alert.Heading>
           <p>
-            The results shown on this page now default to the Exposures analysis basis.
-            This does not change the available results (i.e., results for Enrollments
-            are still available), and you can still select any available Analysis Basis
-            via the radio buttons on the left.
+            The results shown on this page now default to the Exposures analysis
+            basis. This does not change the available results (i.e., results for
+            Enrollments are still available), and you can still select any
+            available Analysis Basis via the radio buttons on the left.
           </p>
           <ul className="pl-0">
             <strong>Results not available or not what you expected?</strong>{" "}
-            <LinkExternal href={exposureEventsInfoUrl} data-testid="external-config-url">
+            <LinkExternal
+              href={exposureEventsInfoUrl}
+              data-testid="external-config-url"
+            >
               Click here
             </LinkExternal>{" "}
-            for more information about Exposure events, including how to set up experiments
-            that have exposure events analysis results.
+            for more information about Exposure events, including how to set up
+            experiments that have exposure events analysis results.
           </ul>
           <p>
             If you have questions about this, please ask data science in{" "}

--- a/experimenter/experimenter/nimbus-ui/src/components/PageResults/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageResults/index.tsx
@@ -4,13 +4,14 @@
 
 import { RouteComponentProps } from "@reach/router";
 import React, { useContext, useState } from "react";
-import { Card, Form } from "react-bootstrap";
+import { Alert, Card, Form } from "react-bootstrap";
 import Col from "react-bootstrap/Col";
 import Collapse from "react-bootstrap/Collapse";
 import Row from "react-bootstrap/Row";
 import AppLayoutWithExperiment from "src/components/AppLayoutWithExperiment";
 import AnalysisErrorAlert from "src/components/PageResults/AnalysisErrorAlert";
 import ExternalConfigAlert from "src/components/PageResults/ExternalConfigAlert";
+import LinkExternal from "src/components/LinkExternal";
 import TableHighlights from "src/components/PageResults/TableHighlights";
 import TableHighlightsOverview from "src/components/PageResults/TableHighlightsOverview";
 import TableMetricCount from "src/components/PageResults/TableMetricCount";
@@ -56,7 +57,7 @@ const PageResults: React.FunctionComponent<RouteComponentProps> = () => {
   const [selectedSegment, setSelectedSegment] = useState<string>("all");
 
   const [selectedAnalysisBasis, setSelectedAnalysisBasis] =
-    useState<AnalysisBases>("enrollments");
+    useState<AnalysisBases>("exposures");
 
   // For testing - users will be redirected if the analysis is unavailable
   // before reaching this return, but tests reach this return and
@@ -220,9 +221,36 @@ const PageResults: React.FunctionComponent<RouteComponentProps> = () => {
     );
   };
 
+  const exposureEventsInfoUrl = "https://experimenter.info/missing-exposure";
+
   return (
     <AppLayoutWithExperiment title="Analysis" testId="PageResults">
       <ResultsContext.Provider value={resultsContextValue}>
+        <Alert variant="warning" data-testid="exposures-as-default-alert">
+          <Alert.Heading>Analysis Results now default to Exposures basis</Alert.Heading>
+          <p>
+            The results shown on this page now default to the Exposures analysis basis.
+            This does not change the available results (i.e., results for Enrollments
+            are still available), and you can still select any available Analysis Basis
+            via the radio buttons on the left.
+          </p>
+          <ul className="pl-0">
+            <strong>Results not available or not what you expected?</strong>{" "}
+            <LinkExternal href={exposureEventsInfoUrl} data-testid="external-config-url">
+              Click here
+            </LinkExternal>{" "}
+            for more information about Exposure events, including how to set up experiments
+            that have exposure events analysis results.
+          </ul>
+          <p>
+            If you have questions about this, please ask data science in{" "}
+            <LinkExternal href="https://mozilla.slack.com/archives/CF94YGE03">
+              #ask-experimenter
+            </LinkExternal>
+            .
+          </p>
+        </Alert>
+
         {analysis?.errors?.experiment &&
           analysis?.errors?.experiment.length > 0 && (
             <AnalysisErrorAlert errors={analysis.errors.experiment} />

--- a/experimenter/experimenter/nimbus-ui/src/lib/visualization/mocks.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/lib/visualization/mocks.tsx
@@ -697,9 +697,643 @@ export const mockAnalysis = (modifications = {}) =>
         ],
       },
       daily: { enrollments: { all: [] } },
-      weekly: { enrollments: { all: weeklyMockAnalysis() } },
+      weekly: {
+        enrollments: { all: weeklyMockAnalysis() },
+        exposures: { all: weeklyMockAnalysis() },
+      },
       overall: {
         enrollments: {
+          all: {
+            control: {
+              is_control: true,
+              branch_data: {
+                other_metrics: {
+                  identity: {
+                    absolute: {
+                      all: [
+                        {
+                          point: 198,
+                        },
+                      ],
+                      first: {
+                        point: 198,
+                      },
+                    },
+                    difference: {
+                      first: {},
+                      all: [],
+                    },
+                    relative_uplift: {
+                      first: {},
+                      all: [],
+                    },
+                    percent: 45,
+                  },
+                  retained: {
+                    absolute: {
+                      all: [
+                        {
+                          point: 0.9261083743842364,
+                          lower: 0.8864481497569532,
+                          upper: 0.9578449264993547,
+                        },
+                      ],
+                      first: {
+                        point: 14.967359019193298,
+                        lower: 10.534758870048162,
+                        upper: 20.754349791764547,
+                      },
+                    },
+                    difference: {
+                      first: {},
+                      all: [],
+                    },
+                    relative_uplift: {
+                      first: {},
+                      all: [],
+                    },
+                  },
+                  picture_in_picture_ever_used: {
+                    absolute: {
+                      first: {
+                        point: 0.05,
+                        count: 10,
+                        lower: 0.024357271316207685,
+                        upper: 0.08411463700173483,
+                      },
+                      all: [
+                        {
+                          point: 0.05,
+                          count: 10,
+                          lower: 0.024357271316207685,
+                          upper: 0.08411463700173483,
+                        },
+                      ],
+                    },
+                    difference: {
+                      first: {},
+                      all: [],
+                    },
+                    relative_uplift: {
+                      first: {},
+                      all: [],
+                    },
+                  },
+                  picture_in_picture: {
+                    absolute: {
+                      first: {
+                        point: 0.05,
+                        count: 10,
+                        lower: 0.024357271316207685,
+                        upper: 0.08411463700173483,
+                      },
+                      all: [
+                        {
+                          point: 0.05,
+                          count: 10,
+                          lower: 0.024357271316207685,
+                          upper: 0.08411463700173483,
+                        },
+                      ],
+                    },
+                    difference: {
+                      first: {},
+                      all: [],
+                    },
+                    relative_uplift: {
+                      first: {},
+                      all: [],
+                    },
+                  },
+                  feature_b_ever_used: {
+                    absolute: {
+                      first: {
+                        point: 0.05,
+                        count: 10,
+                        lower: 0.024357271316207685,
+                        upper: 0.08411463700173483,
+                      },
+                      all: [
+                        {
+                          point: 0.05,
+                          count: 10,
+                          lower: 0.024357271316207685,
+                          upper: 0.08411463700173483,
+                        },
+                      ],
+                    },
+                    difference: {
+                      first: {},
+                      all: [],
+                    },
+                    relative_uplift: {
+                      first: {},
+                      all: [],
+                    },
+                  },
+                  feature_b: {
+                    absolute: {
+                      first: {
+                        point: 0.05,
+                        count: 10,
+                        lower: 0.024357271316207685,
+                        upper: 0.08411463700173483,
+                      },
+                      all: [
+                        {
+                          point: 0.05,
+                          count: 10,
+                          lower: 0.024357271316207685,
+                          upper: 0.08411463700173483,
+                        },
+                      ],
+                    },
+                    difference: {
+                      first: {},
+                      all: [],
+                    },
+                    relative_uplift: {
+                      first: {},
+                      all: [],
+                    },
+                  },
+                  feature_c_ever_used: {
+                    absolute: {
+                      first: {
+                        point: 0.05,
+                        count: 10,
+                        lower: 0.024357271316207685,
+                        upper: 0.08411463700173483,
+                      },
+                      all: [
+                        {
+                          point: 0.05,
+                          count: 10,
+                          lower: 0.024357271316207685,
+                          upper: 0.08411463700173483,
+                        },
+                      ],
+                    },
+                    difference: {
+                      first: {},
+                      all: [],
+                    },
+                    relative_uplift: {
+                      first: {},
+                      all: [],
+                    },
+                  },
+                  feature_c: CONTROL_NEUTRAL,
+                  feature_d: {
+                    absolute: {
+                      first: {
+                        point: 0.05,
+                        count: 10,
+                        lower: 0.024357271316207685,
+                        upper: 0.08411463700173483,
+                      },
+                      all: [
+                        {
+                          point: 0.05,
+                          count: 10,
+                          lower: 0.024357271316207685,
+                          upper: 0.08411463700173483,
+                        },
+                      ],
+                    },
+                    difference: {
+                      first: {},
+                      all: [],
+                    },
+                    relative_uplift: {
+                      first: {},
+                      all: [],
+                    },
+                  },
+                  outcome_d: {
+                    absolute: {
+                      first: {
+                        point: 0.05,
+                        count: 10,
+                        lower: 0.024357271316207685,
+                        upper: 0.08411463700173483,
+                      },
+                      all: [
+                        {
+                          point: 0.05,
+                          count: 10,
+                          lower: 0.024357271316207685,
+                          upper: 0.08411463700173483,
+                        },
+                      ],
+                    },
+                    difference: {
+                      first: {},
+                      all: [],
+                    },
+                    relative_uplift: {
+                      first: {},
+                      all: [],
+                    },
+                  },
+                  days_of_use: CONTROL_NEUTRAL,
+                  qualified_cumulative_days_of_use: CONTROL_NEUTRAL,
+                },
+                search_metrics: {
+                  search_count: {
+                    absolute: {
+                      all: [
+                        {
+                          point: 14.967359019193298,
+                          lower: 10.534758870048162,
+                          upper: 20.754349791764547,
+                        },
+                      ],
+                      first: {
+                        point: 14.967359019193298,
+                        lower: 10.534758870048162,
+                        upper: 20.754349791764547,
+                      },
+                    },
+                    difference: {
+                      first: {},
+                      all: [],
+                    },
+                    relative_uplift: {
+                      first: {},
+                      all: [],
+                    },
+                  },
+                },
+              },
+            },
+            treatment: {
+              is_control: false,
+              branch_data: {
+                other_metrics: {
+                  identity: {
+                    absolute: {
+                      first: {
+                        point: 200,
+                      },
+                      all: [
+                        {
+                          point: 200,
+                        },
+                      ],
+                    },
+                    difference: {
+                      first: {},
+                      all: [],
+                    },
+                    relative_uplift: {
+                      first: {},
+                      all: [],
+                    },
+                    percent: 55,
+                  },
+                  retained: TREATMENT_NEUTRAL,
+                  picture_in_picture_ever_used: {
+                    absolute: {
+                      first: {
+                        point: 0.049019607843137254,
+                        count: 10,
+                        lower: 0.023872203557007872,
+                        upper: 0.08249069209461024,
+                      },
+                      all: [
+                        {
+                          point: 0.049019607843137254,
+                          count: 10,
+                          lower: 0.023872203557007872,
+                          upper: 0.08249069209461024,
+                        },
+                      ],
+                    },
+                    difference: {
+                      first: {
+                        point: -0.0006569487628876534,
+                        upper: 0.04316381736512019,
+                        lower: 0.04175095963994029,
+                      },
+                      all: [
+                        {
+                          point: -0.0006569487628876534,
+                          upper: 0.04316381736512019,
+                          lower: 0.04175095963994029,
+                        },
+                      ],
+                    },
+                    relative_uplift: {
+                      first: {
+                        lower: -0.455210299676828,
+                        upper: 0.5104985718410426,
+                        point: -0.06233954570562385,
+                      },
+                      all: [
+                        {
+                          lower: -0.455210299676828,
+                          upper: 0.5104985718410426,
+                          point: -0.06233954570562385,
+                        },
+                      ],
+                    },
+                    significance: { overall: { "1": "positive" }, weekly: {} },
+                  },
+                  picture_in_picture: {
+                    absolute: {
+                      first: {
+                        point: 0.049019607843137254,
+                        count: 10,
+                        lower: 0.023872203557007872,
+                        upper: 0.08249069209461024,
+                      },
+                      all: [
+                        {
+                          point: 0.049019607843137254,
+                          count: 10,
+                          lower: 0.023872203557007872,
+                          upper: 0.08249069209461024,
+                        },
+                      ],
+                    },
+                    difference: {
+                      first: {
+                        point: -0.0006569487628876534,
+                        upper: 0.04316381736512019,
+                        lower: 0.04175095963994029,
+                      },
+                      all: [
+                        {
+                          point: -0.0006569487628876534,
+                          upper: 0.04316381736512019,
+                          lower: 0.04175095963994029,
+                        },
+                      ],
+                    },
+                    relative_uplift: {
+                      first: {
+                        lower: -0.455210299676828,
+                        upper: 0.5104985718410426,
+                        point: -0.06233954570562385,
+                      },
+                      all: [
+                        {
+                          lower: -0.455210299676828,
+                          upper: 0.5104985718410426,
+                          point: -0.06233954570562385,
+                        },
+                      ],
+                    },
+                    significance: { overall: { "1": "positive" }, weekly: {} },
+                  },
+                  feature_b_ever_used: {
+                    absolute: {
+                      first: {
+                        point: 0.049019607843137254,
+                        count: 10,
+                        lower: 0.023872203557007872,
+                        upper: 0.08249069209461024,
+                      },
+                      all: [
+                        {
+                          point: 0.049019607843137254,
+                          count: 10,
+                          lower: 0.023872203557007872,
+                          upper: 0.08249069209461024,
+                        },
+                      ],
+                    },
+                    difference: {
+                      first: {
+                        point: -0.0006569487628876534,
+                        upper: 0.04316381736512019,
+                        lower: 0.04175095963994029,
+                      },
+                      all: [
+                        {
+                          point: -0.0006569487628876534,
+                          upper: 0.04316381736512019,
+                          lower: 0.04175095963994029,
+                        },
+                      ],
+                    },
+                    relative_uplift: {
+                      first: {
+                        lower: -0.455210299676828,
+                        upper: 0.5104985718410426,
+                        point: -0.06233954570562385,
+                      },
+                      all: [
+                        {
+                          lower: -0.455210299676828,
+                          upper: 0.5104985718410426,
+                          point: -0.06233954570562385,
+                        },
+                      ],
+                    },
+                    significance: { overall: { "1": "negative" }, weekly: {} },
+                  },
+                  feature_b: {
+                    absolute: {
+                      first: {
+                        point: 0.049019607843137254,
+                        count: 10,
+                        lower: 0.023872203557007872,
+                        upper: 0.08249069209461024,
+                      },
+                      all: [
+                        {
+                          point: 0.049019607843137254,
+                          count: 10,
+                          lower: 0.023872203557007872,
+                          upper: 0.08249069209461024,
+                        },
+                      ],
+                    },
+                    difference: {
+                      first: {
+                        point: -0.0006569487628876534,
+                        upper: 0.04316381736512019,
+                        lower: 0.04175095963994029,
+                      },
+                      all: [
+                        {
+                          point: -0.0006569487628876534,
+                          upper: 0.04316381736512019,
+                          lower: 0.04175095963994029,
+                        },
+                      ],
+                    },
+                    relative_uplift: {
+                      first: {
+                        lower: -0.455210299676828,
+                        upper: 0.5104985718410426,
+                        point: -0.06233954570562385,
+                      },
+                      all: [
+                        {
+                          lower: -0.455210299676828,
+                          upper: 0.5104985718410426,
+                          point: -0.06233954570562385,
+                        },
+                      ],
+                    },
+                    significance: { overall: { "1": "negative" }, weekly: {} },
+                  },
+                  feature_c_ever_used: {
+                    absolute: {
+                      first: {
+                        point: 0.049019607843137254,
+                        count: 10,
+                        lower: 0.023872203557007872,
+                        upper: 0.08249069209461024,
+                      },
+                      all: [
+                        {
+                          point: 0.049019607843137254,
+                          count: 10,
+                          lower: 0.023872203557007872,
+                          upper: 0.08249069209461024,
+                        },
+                      ],
+                    },
+                    difference: {
+                      first: {
+                        point: -0.0006569487628876534,
+                        upper: 0.04316381736512019,
+                        lower: 0.04175095963994029,
+                      },
+                      all: [
+                        {
+                          point: -0.0006569487628876534,
+                          upper: 0.04316381736512019,
+                          lower: 0.04175095963994029,
+                        },
+                      ],
+                    },
+                    relative_uplift: {
+                      first: {
+                        lower: -0.455210299676828,
+                        upper: 0.5104985718410426,
+                        point: -0.06233954570562385,
+                      },
+                      all: [
+                        {
+                          lower: -0.455210299676828,
+                          upper: 0.5104985718410426,
+                          point: -0.06233954570562385,
+                        },
+                      ],
+                    },
+                    significance: { overall: { "1": "neutral" }, weekly: {} },
+                  },
+                  feature_c: TREATMENT_NEUTRAL,
+                  days_of_use: TREATMENT_NEUTRAL,
+                  qualified_cumulative_days_of_use: TREATMENT_NEUTRAL,
+                  feature_d: {
+                    absolute: {
+                      first: {
+                        point: 0.049019607843137254,
+                        count: 10,
+                        lower: 0.023872203557007872,
+                        upper: 0.08249069209461024,
+                      },
+                      all: [
+                        {
+                          point: 0.049019607843137254,
+                          count: 10,
+                          lower: 0.023872203557007872,
+                          upper: 0.08249069209461024,
+                        },
+                      ],
+                    },
+                    difference: {
+                      first: {
+                        point: -0.0006569487628876534,
+                        upper: 0.04316381736512019,
+                        lower: 0.04175095963994029,
+                      },
+                      all: [
+                        {
+                          point: -0.0006569487628876534,
+                          upper: 0.04316381736512019,
+                          lower: 0.04175095963994029,
+                        },
+                      ],
+                    },
+                    relative_uplift: {
+                      first: {
+                        lower: -0.455210299676828,
+                        upper: 0.5104985718410426,
+                        point: -0.06233954570562385,
+                      },
+                      all: [
+                        {
+                          lower: -0.455210299676828,
+                          upper: 0.5104985718410426,
+                          point: -0.06233954570562385,
+                        },
+                      ],
+                    },
+                    significance: { overall: { "1": "positive" }, weekly: {} },
+                  },
+                  outcome_d: {
+                    absolute: {
+                      first: {
+                        point: 0.049019607843137254,
+                        count: 10,
+                        lower: 0.023872203557007872,
+                        upper: 0.08249069209461024,
+                      },
+                      all: [
+                        {
+                          point: 0.049019607843137254,
+                          count: 10,
+                          lower: 0.023872203557007872,
+                          upper: 0.08249069209461024,
+                        },
+                      ],
+                    },
+                    difference: {
+                      first: {
+                        point: -0.0006569487628876534,
+                        upper: 0.04316381736512019,
+                        lower: 0.04175095963994029,
+                      },
+                      all: [
+                        {
+                          point: -0.0006569487628876534,
+                          upper: 0.04316381736512019,
+                          lower: 0.04175095963994029,
+                        },
+                      ],
+                    },
+                    relative_uplift: {
+                      first: {
+                        lower: -0.455210299676828,
+                        upper: 0.5104985718410426,
+                        point: -0.06233954570562385,
+                      },
+                      all: [
+                        {
+                          lower: -0.455210299676828,
+                          upper: 0.5104985718410426,
+                          point: -0.06233954570562385,
+                        },
+                      ],
+                    },
+                    significance: { overall: { "1": "positive" }, weekly: {} },
+                  },
+                },
+                search_metrics: {
+                  search_count: TREATMENT_NEGATIVE,
+                },
+              },
+            },
+          },
+        },
+        exposures: {
           all: {
             control: {
               is_control: true,
@@ -4693,7 +5327,10 @@ export const mockAnalysisWithErrors = (modifications = {}) =>
         ],
       },
       daily: { enrollments: { all: [] } },
-      weekly: { enrollments: { all: weeklyMockAnalysis() } },
+      weekly: {
+        enrollments: { all: weeklyMockAnalysis() },
+        exposures: { all: weeklyMockAnalysis() },
+      },
       overall: null,
     },
     modifications,
@@ -4761,9 +5398,617 @@ export const mockAnalysisWithErrorsAndResults = (modifications = {}) =>
         ],
       },
       daily: { enrollments: { all: [] } },
-      weekly: { enrollments: { all: weeklyMockAnalysis() } },
+      weekly: {
+        enrollments: { all: weeklyMockAnalysis() },
+        exposures: { all: weeklyMockAnalysis() },
+      },
       overall: {
         enrollments: {
+          all: {
+            control: {
+              is_control: true,
+              branch_data: {
+                other_metrics: {
+                  identity: {
+                    absolute: {
+                      all: [
+                        {
+                          point: 198,
+                        },
+                      ],
+                      first: {
+                        point: 198,
+                      },
+                    },
+                    difference: {
+                      first: {},
+                      all: [],
+                    },
+                    relative_uplift: {
+                      first: {},
+                      all: [],
+                    },
+                    percent: 45,
+                  },
+                  retained: {
+                    absolute: {
+                      all: [
+                        {
+                          point: 0.9261083743842364,
+                          lower: 0.8864481497569532,
+                          upper: 0.9578449264993547,
+                        },
+                      ],
+                      first: {
+                        point: 14.967359019193298,
+                        lower: 10.534758870048162,
+                        upper: 20.754349791764547,
+                      },
+                    },
+                    difference: {
+                      first: {},
+                      all: [],
+                    },
+                    relative_uplift: {
+                      first: {},
+                      all: [],
+                    },
+                  },
+                  picture_in_picture_ever_used: {
+                    absolute: {
+                      first: {
+                        point: 0.05,
+                        count: 10,
+                        lower: 0.024357271316207685,
+                        upper: 0.08411463700173483,
+                      },
+                      all: [
+                        {
+                          point: 0.05,
+                          count: 10,
+                          lower: 0.024357271316207685,
+                          upper: 0.08411463700173483,
+                        },
+                      ],
+                    },
+                    difference: {
+                      first: {},
+                      all: [],
+                    },
+                    relative_uplift: {
+                      first: {},
+                      all: [],
+                    },
+                  },
+                  feature_b_ever_used: {
+                    absolute: {
+                      first: {
+                        point: 0.05,
+                        count: 10,
+                        lower: 0.024357271316207685,
+                        upper: 0.08411463700173483,
+                      },
+                      all: [
+                        {
+                          point: 0.05,
+                          count: 10,
+                          lower: 0.024357271316207685,
+                          upper: 0.08411463700173483,
+                        },
+                      ],
+                    },
+                    difference: {
+                      first: {},
+                      all: [],
+                    },
+                    relative_uplift: {
+                      first: {},
+                      all: [],
+                    },
+                  },
+                  feature_b: {
+                    absolute: {
+                      first: {
+                        point: 0.05,
+                        count: 10,
+                        lower: 0.024357271316207685,
+                        upper: 0.08411463700173483,
+                      },
+                      all: [
+                        {
+                          point: 0.05,
+                          count: 10,
+                          lower: 0.024357271316207685,
+                          upper: 0.08411463700173483,
+                        },
+                      ],
+                    },
+                    difference: {
+                      first: {},
+                      all: [],
+                    },
+                    relative_uplift: {
+                      first: {},
+                      all: [],
+                    },
+                  },
+                  feature_c_ever_used: {
+                    absolute: {
+                      first: {
+                        point: 0.05,
+                        count: 10,
+                        lower: 0.024357271316207685,
+                        upper: 0.08411463700173483,
+                      },
+                      all: [
+                        {
+                          point: 0.05,
+                          count: 10,
+                          lower: 0.024357271316207685,
+                          upper: 0.08411463700173483,
+                        },
+                      ],
+                    },
+                    difference: {
+                      first: {},
+                      all: [],
+                    },
+                    relative_uplift: {
+                      first: {},
+                      all: [],
+                    },
+                  },
+                  feature_c: CONTROL_NEUTRAL,
+                  feature_d: {
+                    absolute: {
+                      first: {
+                        point: 0.05,
+                        count: 10,
+                        lower: 0.024357271316207685,
+                        upper: 0.08411463700173483,
+                      },
+                      all: [
+                        {
+                          point: 0.05,
+                          count: 10,
+                          lower: 0.024357271316207685,
+                          upper: 0.08411463700173483,
+                        },
+                      ],
+                    },
+                    difference: {
+                      first: {},
+                      all: [],
+                    },
+                    relative_uplift: {
+                      first: {},
+                      all: [],
+                    },
+                  },
+                  outcome_d: {
+                    absolute: {
+                      first: {
+                        point: 0.05,
+                        count: 10,
+                        lower: 0.024357271316207685,
+                        upper: 0.08411463700173483,
+                      },
+                      all: [
+                        {
+                          point: 0.05,
+                          count: 10,
+                          lower: 0.024357271316207685,
+                          upper: 0.08411463700173483,
+                        },
+                      ],
+                    },
+                    difference: {
+                      first: {},
+                      all: [],
+                    },
+                    relative_uplift: {
+                      first: {},
+                      all: [],
+                    },
+                  },
+                  days_of_use: CONTROL_NEUTRAL,
+                  qualified_cumulative_days_of_use: CONTROL_NEUTRAL,
+                },
+                search_metrics: {
+                  search_count: {
+                    absolute: {
+                      all: [
+                        {
+                          point: 14.967359019193298,
+                          lower: 10.534758870048162,
+                          upper: 20.754349791764547,
+                        },
+                      ],
+                      first: {
+                        point: 14.967359019193298,
+                        lower: 10.534758870048162,
+                        upper: 20.754349791764547,
+                      },
+                    },
+                    difference: {
+                      first: {},
+                      all: [],
+                    },
+                    relative_uplift: {
+                      first: {},
+                      all: [],
+                    },
+                  },
+                },
+              },
+            },
+            treatment: {
+              is_control: false,
+              branch_data: {
+                other_metrics: {
+                  identity: {
+                    absolute: {
+                      first: {
+                        point: 200,
+                      },
+                      all: [
+                        {
+                          point: 200,
+                        },
+                      ],
+                    },
+                    difference: {
+                      first: {},
+                      all: [],
+                    },
+                    relative_uplift: {
+                      first: {},
+                      all: [],
+                    },
+                    percent: 55,
+                  },
+                  retained: TREATMENT_NEUTRAL,
+                  picture_in_picture_ever_used: {
+                    absolute: {
+                      first: {
+                        point: 0.049019607843137254,
+                        count: 10,
+                        lower: 0.023872203557007872,
+                        upper: 0.08249069209461024,
+                      },
+                      all: [
+                        {
+                          point: 0.049019607843137254,
+                          count: 10,
+                          lower: 0.023872203557007872,
+                          upper: 0.08249069209461024,
+                        },
+                      ],
+                    },
+                    difference: {
+                      first: {
+                        point: -0.0006569487628876534,
+                        upper: 0.04316381736512019,
+                        lower: 0.04175095963994029,
+                      },
+                      all: [
+                        {
+                          point: -0.0006569487628876534,
+                          upper: 0.04316381736512019,
+                          lower: 0.04175095963994029,
+                        },
+                      ],
+                    },
+                    relative_uplift: {
+                      first: {
+                        lower: -0.455210299676828,
+                        upper: 0.5104985718410426,
+                        point: -0.06233954570562385,
+                      },
+                      all: [
+                        {
+                          lower: -0.455210299676828,
+                          upper: 0.5104985718410426,
+                          point: -0.06233954570562385,
+                        },
+                      ],
+                    },
+                    significance: { overall: { "1": "positive" }, weekly: {} },
+                  },
+                  picture_in_picture: {
+                    absolute: {
+                      first: {
+                        point: 0.049019607843137254,
+                        count: 10,
+                        lower: 0.023872203557007872,
+                        upper: 0.08249069209461024,
+                      },
+                      all: [
+                        {
+                          point: 0.049019607843137254,
+                          count: 10,
+                          lower: 0.023872203557007872,
+                          upper: 0.08249069209461024,
+                        },
+                      ],
+                    },
+                    difference: {
+                      first: {
+                        point: -0.0006569487628876534,
+                        upper: 0.04316381736512019,
+                        lower: 0.04175095963994029,
+                      },
+                      all: [
+                        {
+                          point: -0.0006569487628876534,
+                          upper: 0.04316381736512019,
+                          lower: 0.04175095963994029,
+                        },
+                      ],
+                    },
+                    relative_uplift: {
+                      first: {
+                        lower: -0.455210299676828,
+                        upper: 0.5104985718410426,
+                        point: -0.06233954570562385,
+                      },
+                      all: [
+                        {
+                          lower: -0.455210299676828,
+                          upper: 0.5104985718410426,
+                          point: -0.06233954570562385,
+                        },
+                      ],
+                    },
+                    significance: { overall: { "1": "positive" }, weekly: {} },
+                  },
+                  feature_b_ever_used: {
+                    absolute: {
+                      first: {
+                        point: 0.049019607843137254,
+                        count: 10,
+                        lower: 0.023872203557007872,
+                        upper: 0.08249069209461024,
+                      },
+                      all: [
+                        {
+                          point: 0.049019607843137254,
+                          count: 10,
+                          lower: 0.023872203557007872,
+                          upper: 0.08249069209461024,
+                        },
+                      ],
+                    },
+                    difference: {
+                      first: {
+                        point: -0.0006569487628876534,
+                        upper: 0.04316381736512019,
+                        lower: 0.04175095963994029,
+                      },
+                      all: [
+                        {
+                          point: -0.0006569487628876534,
+                          upper: 0.04316381736512019,
+                          lower: 0.04175095963994029,
+                        },
+                      ],
+                    },
+                    relative_uplift: {
+                      first: {
+                        lower: -0.455210299676828,
+                        upper: 0.5104985718410426,
+                        point: -0.06233954570562385,
+                      },
+                      all: [
+                        {
+                          lower: -0.455210299676828,
+                          upper: 0.5104985718410426,
+                          point: -0.06233954570562385,
+                        },
+                      ],
+                    },
+                    significance: { overall: { "1": "negative" }, weekly: {} },
+                  },
+                  feature_b: {
+                    absolute: {
+                      first: {
+                        point: 0.049019607843137254,
+                        count: 10,
+                        lower: 0.023872203557007872,
+                        upper: 0.08249069209461024,
+                      },
+                      all: [
+                        {
+                          point: 0.049019607843137254,
+                          count: 10,
+                          lower: 0.023872203557007872,
+                          upper: 0.08249069209461024,
+                        },
+                      ],
+                    },
+                    difference: {
+                      first: {
+                        point: -0.0006569487628876534,
+                        upper: 0.04316381736512019,
+                        lower: 0.04175095963994029,
+                      },
+                      all: [
+                        {
+                          point: -0.0006569487628876534,
+                          upper: 0.04316381736512019,
+                          lower: 0.04175095963994029,
+                        },
+                      ],
+                    },
+                    relative_uplift: {
+                      first: {
+                        lower: -0.455210299676828,
+                        upper: 0.5104985718410426,
+                        point: -0.06233954570562385,
+                      },
+                      all: [
+                        {
+                          lower: -0.455210299676828,
+                          upper: 0.5104985718410426,
+                          point: -0.06233954570562385,
+                        },
+                      ],
+                    },
+                    significance: { overall: { "1": "negative" }, weekly: {} },
+                  },
+                  feature_c_ever_used: {
+                    absolute: {
+                      first: {
+                        point: 0.049019607843137254,
+                        count: 10,
+                        lower: 0.023872203557007872,
+                        upper: 0.08249069209461024,
+                      },
+                      all: [
+                        {
+                          point: 0.049019607843137254,
+                          count: 10,
+                          lower: 0.023872203557007872,
+                          upper: 0.08249069209461024,
+                        },
+                      ],
+                    },
+                    difference: {
+                      first: {
+                        point: -0.0006569487628876534,
+                        upper: 0.04316381736512019,
+                        lower: 0.04175095963994029,
+                      },
+                      all: [
+                        {
+                          point: -0.0006569487628876534,
+                          upper: 0.04316381736512019,
+                          lower: 0.04175095963994029,
+                        },
+                      ],
+                    },
+                    relative_uplift: {
+                      first: {
+                        lower: -0.455210299676828,
+                        upper: 0.5104985718410426,
+                        point: -0.06233954570562385,
+                      },
+                      all: [
+                        {
+                          lower: -0.455210299676828,
+                          upper: 0.5104985718410426,
+                          point: -0.06233954570562385,
+                        },
+                      ],
+                    },
+                    significance: { overall: { "1": "neutral" }, weekly: {} },
+                  },
+                  feature_c: TREATMENT_NEUTRAL,
+                  days_of_use: TREATMENT_NEUTRAL,
+                  qualified_cumulative_days_of_use: TREATMENT_NEUTRAL,
+                  feature_d: {
+                    absolute: {
+                      first: {
+                        point: 0.049019607843137254,
+                        count: 10,
+                        lower: 0.023872203557007872,
+                        upper: 0.08249069209461024,
+                      },
+                      all: [
+                        {
+                          point: 0.049019607843137254,
+                          count: 10,
+                          lower: 0.023872203557007872,
+                          upper: 0.08249069209461024,
+                        },
+                      ],
+                    },
+                    difference: {
+                      first: {
+                        point: -0.0006569487628876534,
+                        upper: 0.04316381736512019,
+                        lower: 0.04175095963994029,
+                      },
+                      all: [
+                        {
+                          point: -0.0006569487628876534,
+                          upper: 0.04316381736512019,
+                          lower: 0.04175095963994029,
+                        },
+                      ],
+                    },
+                    relative_uplift: {
+                      first: {
+                        lower: -0.455210299676828,
+                        upper: 0.5104985718410426,
+                        point: -0.06233954570562385,
+                      },
+                      all: [
+                        {
+                          lower: -0.455210299676828,
+                          upper: 0.5104985718410426,
+                          point: -0.06233954570562385,
+                        },
+                      ],
+                    },
+                    significance: { overall: { "1": "positive" }, weekly: {} },
+                  },
+                  outcome_d: {
+                    absolute: {
+                      first: {
+                        point: 0.049019607843137254,
+                        count: 10,
+                        lower: 0.023872203557007872,
+                        upper: 0.08249069209461024,
+                      },
+                      all: [
+                        {
+                          point: 0.049019607843137254,
+                          count: 10,
+                          lower: 0.023872203557007872,
+                          upper: 0.08249069209461024,
+                        },
+                      ],
+                    },
+                    difference: {
+                      first: {
+                        point: -0.0006569487628876534,
+                        upper: 0.04316381736512019,
+                        lower: 0.04175095963994029,
+                      },
+                      all: [
+                        {
+                          point: -0.0006569487628876534,
+                          upper: 0.04316381736512019,
+                          lower: 0.04175095963994029,
+                        },
+                      ],
+                    },
+                    relative_uplift: {
+                      first: {
+                        lower: -0.455210299676828,
+                        upper: 0.5104985718410426,
+                        point: -0.06233954570562385,
+                      },
+                      all: [
+                        {
+                          lower: -0.455210299676828,
+                          upper: 0.5104985718410426,
+                          point: -0.06233954570562385,
+                        },
+                      ],
+                    },
+                    significance: { overall: { "1": "positive" }, weekly: {} },
+                  },
+                },
+                search_metrics: {
+                  search_count: TREATMENT_NEGATIVE,
+                },
+              },
+            },
+          },
+        },
+        exposures: {
           all: {
             control: {
               is_control: true,


### PR DESCRIPTION
Because

- we want to put more focus on exposures-based analysis

This commit

- changes the UI default to Exposures instead of Enrollments
- displays an info box about the change with links for more info

Fixes #9427 

Screenshot
![image](https://github.com/mozilla/experimenter/assets/102263964/0d7018e5-fda1-4b9b-ab58-e07513ef552a)
