### PR TITLE
feat(nimbus): add my experiments tab

### DIFF
--- a/experimenter/experimenter/nimbus-ui/src/components/PageHome/index.test.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageHome/index.test.tsx
@@ -49,6 +49,7 @@ describe("PageHome", () => {
       ["drafts", screen.getByText("Draft (3)")],
       ["live", screen.getByText("Live (3)")],
       ["archived", screen.getByText("Archived (1)")],
+      ["owned", screen.getByText("My Experiments (1)")],
     ] as const;
 
   const findSearchTabs = () =>
@@ -59,12 +60,13 @@ describe("PageHome", () => {
       ["drafts", screen.getByText("Draft (0)")],
       ["live", screen.getByText("Live (0)")],
       ["archived", screen.getByText("Archived (0)")],
+      ["owned", screen.getByText("My Experiments (0)")],
     ] as const;
 
   it("displays five Directory Tables (one for each status type)", async () => {
     await renderAndWaitForLoaded();
     // renders all experiments
-    expect(screen.queryAllByTestId("DirectoryTable")).toHaveLength(6);
+    expect(screen.queryAllByTestId("DirectoryTable")).toHaveLength(7);
     for (const [tabKey, tab] of findTabs()) {
       expect(tab).toBeInTheDocument();
     }

--- a/experimenter/experimenter/nimbus-ui/src/components/PageHome/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageHome/index.tsx
@@ -61,9 +61,11 @@ export const Body: React.FC<BodyProps> = ({
     return ErrorAlert;
   }
 
-  const { live, complete, preview, review, draft, archived } = sortByStatus(
-    filterExperiments(searchedExperiments ?? [], filterValue),
-  );
+  const { live, complete, preview, review, draft, archived, owned } =
+    sortByStatus(
+      filterExperiments(searchedExperiments ?? [], filterValue),
+      config.user,
+    );
 
   return (
     <>
@@ -85,6 +87,9 @@ export const Body: React.FC<BodyProps> = ({
         </Tab>
         <Tab eventKey="archived" title={`Archived (${archived.length})`}>
           <DirectoryTable experiments={archived} />
+        </Tab>
+        <Tab eventKey="owned" title={`My Experiments (${owned.length})`}>
+          <DirectoryTable experiments={owned} />
         </Tab>
       </Tabs>
     </>

--- a/experimenter/experimenter/nimbus-ui/src/components/PageHome/sortByStatus.ts
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageHome/sortByStatus.ts
@@ -6,14 +6,18 @@ import { getStatus } from "src/lib/experiment";
 import { getAllExperiments_experiments } from "src/types/getAllExperiments";
 
 export type ExperimentCollector = Record<
-  "draft" | "preview" | "review" | "live" | "complete" | "archived",
+  "draft" | "preview" | "review" | "live" | "complete" | "archived" | "owned",
   getAllExperiments_experiments[]
 >;
 
-function sortByStatus(experiments: getAllExperiments_experiments[] = []) {
+function sortByStatus(
+  experiments: getAllExperiments_experiments[] = [],
+  owner: string,
+) {
   return experiments.reduce<ExperimentCollector>(
     (collector, experiment) => {
       const status = getStatus(experiment);
+
       if (status.archived) {
         collector.archived.push(experiment);
       } else if (status.live) {
@@ -27,6 +31,13 @@ function sortByStatus(experiments: getAllExperiments_experiments[] = []) {
       } else {
         collector.draft.push(experiment);
       }
+
+      if (
+        experiment.owner.username === owner ||
+        experiment.subscribers.map((s) => s.username).includes(owner)
+      ) {
+        collector.owned.push(experiment);
+      }
       return collector;
     },
     {
@@ -36,6 +47,7 @@ function sortByStatus(experiments: getAllExperiments_experiments[] = []) {
       live: [],
       complete: [],
       archived: [],
+      owned: [],
     },
   );
 }

--- a/experimenter/experimenter/nimbus-ui/src/lib/mocks.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/lib/mocks.tsx
@@ -997,7 +997,10 @@ export function mockDirectoryExperiments(
       owner: { username: "alpha-example@mozilla.com" },
       startDate: null,
       computedEndDate: null,
-      subscribers: [{ username: "mac-user-123@mozilla.com" }],
+      subscribers: [
+        { username: "mac-user-123@mozilla.com" },
+        { username: "dev@example.com" },
+      ],
     },
     {
       name: "Ipsum dolor sit amet",


### PR DESCRIPTION
Because

* Now that users can subscribe to experiments it can be a useful way to tag experiments you want to quickly get back to
* We can add a section to the summary page for experiments that the current user either owns or is subscribed to

This commit

* Adds a tab to the directory table for experiments that the current user either owns or is subscribed to

fixes #10259
<img width="1543" alt="image" src="https://github.com/mozilla/experimenter/assets/119884/cb54e11b-27f8-4f64-b7fc-9969e79f51fc">
