### PR TITLE
chore(project): update codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 cirrus/ @jaredlockhart @yashikakhurana @jeddai
-experimenter/experimenter/ @jaredlockhart @yashikakhurana @eliserichards @brennie
+experimenter/experimenter/ @jaredlockhart @yashikakhurana @brennie
 experimenter/manifesttool/ @jaredlockhart @brennie
 schemas/ @jaredlockhart @mikewilli
 experimenter/tests @jrbenny35


### PR DESCRIPTION
Because

* Elise will no longer be maintaining Experimenter

This commit

* Removes Elise from CODEOWNERS

