### PR TITLE
feat(nimbus): report manifesttool fetch failures first

### DIFF
--- a/experimenter/manifesttool/fetch.py
+++ b/experimenter/manifesttool/fetch.py
@@ -276,6 +276,11 @@ def summarize_results(results: list[FetchResult], file: TextIO) -> (int, int, in
 
     print("SUMMARY:\n", file=file)
 
+    if failures:
+        print("FAILURES:\n", file=file)
+        for result in failures:
+            print(result, file=file)
+
     if successes:
         print("SUCCESS:\n", file=file)
         for result in successes:
@@ -286,13 +291,6 @@ def summarize_results(results: list[FetchResult], file: TextIO) -> (int, int, in
     if cached:
         print("CACHED:\n", file=file)
         for result in cached:
-            print(result, file=file)
-
-        print(file=file)
-
-    if failures:
-        print("FAILURES:\n", file=file)
-        for result in failures:
             print(result, file=file)
 
     return (len(successes), len(cached), len(failures))

--- a/experimenter/manifesttool/tests/test_cli.py
+++ b/experimenter/manifesttool/tests/test_cli.py
@@ -258,13 +258,13 @@ class CliTests(TestCase):
         self.assertEqual(
             summary,
             "SUMMARY:\n\n"
+            "FAILURES:\n\n"
+            "fml_app at main (quux) version None\n"
+            "oh no\n\n"
             "SUCCESS:\n\n"
             "fml_app at baz (qux) version 2.0.0\n\n"
             "CACHED:\n\n"
-            "fml_app at foo (bar) version 1.0.0 (cached)\n\n"
-            "FAILURES:\n\n"
-            "fml_app at main (quux) version None\n"
-            "oh no\n\n",
+            "fml_app at foo (bar) version 1.0.0 (cached)\n",
         )
 
     @patch.object(

--- a/experimenter/manifesttool/tests/test_fetch.py
+++ b/experimenter/manifesttool/tests/test_fetch.py
@@ -1026,16 +1026,15 @@ class FetchTests(TestCase):
         self.assertEqual(
             buffer.getvalue(),
             "SUMMARY:\n\n"
+            "FAILURES:\n\n"
+            "app-3 at c (baz) version None\n"
+            "oh no\n\n"
+            "app-5 at e (quux) version 7.8.9\n"
+            "rats!\n\n"
             "SUCCESS:\n\n"
             "app-1 at a (foo) version None\n"
             "app-2 at b (bar) version 1.2.3\n"
             "\n"
             "CACHED:\n\n"
-            "app-4 at d (qux) version 4.5.6 (cached)\n"
-            "\n"
-            "FAILURES:\n\n"
-            "app-3 at c (baz) version None\n"
-            "oh no\n\n"
-            "app-5 at e (quux) version 7.8.9\n"
-            "rats!\n\n",
+            "app-4 at d (qux) version 4.5.6 (cached)\n",
         )


### PR DESCRIPTION
Because:

- failures are the most important result; and
- they are currently reported at the end of the summary, making them easy to miss

This commit:

- moves the failures to the beginning of the summary.

Fixes #10264