### PR TITLE
feat(nimbus): add warnings and errors for large pref writes

### DIFF
--- a/experimenter/experimenter/experiments/api/v5/serializers.py
+++ b/experimenter/experimenter/experiments/api/v5/serializers.py
@@ -35,6 +35,7 @@ from experimenter.experiments.models import (
     NimbusExperimentBranchThroughRequired,
     NimbusFeatureConfig,
     NimbusFeatureVersion,
+    NimbusVersionedSchema,
 )
 from experimenter.features.manifests.nimbus_fml_loader import NimbusFmlLoader
 from experimenter.kinto.tasks import (
@@ -1406,11 +1407,11 @@ class NimbusReviewSerializer(serializers.ModelSerializer):
         errors: list[str] = dataclasses.field(default_factory=list)
         warnings: list[str] = dataclasses.field(default_factory=list)
 
-        def extend(self, result: Self):
+        def extend_with_result(self, result: Self):
             self.errors.extend(result.errors)
             self.warnings.extend(result.warnings)
 
-        def extend_with(self, msgs: list[str], warning: bool):
+        def extend(self, msgs: list[str], warning: bool):
             if warning:
                 self.warnings.extend(msgs)
             else:
@@ -1455,8 +1456,9 @@ class NimbusReviewSerializer(serializers.ModelSerializer):
             )
 
         if application == NimbusExperiment.Application.DESKTOP:
-            result.extend(
+            result.extend_with_result(
                 cls._validate_feature_value_with_schema(
+                    feature_config,
                     schemas_in_range,
                     feature_value,
                     localizations,
@@ -1464,23 +1466,22 @@ class NimbusReviewSerializer(serializers.ModelSerializer):
                 ),
             )
         else:
-            value_errors = cls._validate_feature_value_with_fml(
-                schemas_in_range,
-                NimbusFmlLoader.create_loader(application, channel),
-                feature_config,
-                feature_value,
+            result.extend(
+                cls._validate_feature_value_with_fml(
+                    schemas_in_range,
+                    NimbusFmlLoader.create_loader(application, channel),
+                    feature_config,
+                    feature_value,
+                ),
+                suppress_errors,
             )
-
-            if suppress_errors:
-                result.warnings.extend(value_errors)
-            else:
-                result.errors.extend(value_errors)
 
         return result
 
     @classmethod
     def _validate_feature_value_with_schema(
         cls,
+        feature_config: NimbusFeatureConfig,
         schemas_in_range: NimbusFeatureConfig.VersionedSchemaRange,
         value: str,
         localizations: Optional[dict[str, Any]],
@@ -1490,38 +1491,112 @@ class NimbusReviewSerializer(serializers.ModelSerializer):
 
         json_value = json.loads(value)
         for schema in schemas_in_range.schemas:
-            if schema.schema is None:  # Only in tests.
+            if schema.schema:  # Only None in tests.
+                json_schema = json.loads(schema.schema)
+                if not localizations:
+                    result.extend(
+                        cls._validate_schema(json_value, json_schema, schema.version),
+                        suppress_errors,
+                    )
+                else:
+                    for locale_code, substitutions in localizations.items():
+                        try:
+                            substituted_value = cls._substitute_localizations(
+                                json_value, substitutions, locale_code
+                            )
+                        except LocalizationError as e:
+                            result.append(str(e), suppress_errors)
+                            continue
+
+                        if schema_errors := cls._validate_schema(
+                            substituted_value, json_schema, schema.version
+                        ):
+                            err_msg = (
+                                f"Schema validation errors occured during locale "
+                                f"substitution for locale {locale_code}"
+                            )
+
+                            if schema.version is not None:
+                                err_msg += f" at version {schema.version}"
+
+                            result.append(err_msg, suppress_errors)
+                            result.extend(schema_errors, suppress_errors)
+
+            if not schema.is_early_startup:
+                # Normally localized experiments cannot set prefs, but
+                # isEarlyStartup features will always set prefs for all the
+                # variables in the experiment
+                if localizations:
+                    continue
+
+                # If the feature schema is not marked isEarlyStartup and it does
+                # not have any setPref variables, then there is nothing to
+                # check.
+                if not schema.set_pref_vars:
+                    continue
+
+            result.extend_with_result(
+                cls._validate_desktop_feature_value_pref_lengths(
+                    feature_config,
+                    schema,
+                    json_value,
+                    suppress_errors,
+                ),
+            )
+
+        return result
+
+    @classmethod
+    def _validate_desktop_feature_value_pref_lengths(
+        cls,
+        feature_config: NimbusFeatureConfig,
+        schema: NimbusVersionedSchema,
+        feature_value: dict[str, Any],
+        suppress_errors: bool,
+    ) -> ValidateFeatureResult:
+        result = cls.ValidateFeatureResult()
+
+        for variable_name, variable_value in feature_value.items():
+            if not schema.is_early_startup and variable_name not in schema.set_pref_vars:
                 continue
 
-            json_schema = json.loads(schema.schema)
-            if not localizations:
-                result.extend_with(
-                    cls._validate_schema(json_value, json_schema, schema.version),
-                    suppress_errors
+            if isinstance(variable_value, (list, dict)):
+                variable_value = json.dumps(variable_value)
+            elif not isinstance(variable_value, str):
+                # int and bool are not serialized to strings
+                continue
+
+            pref_len = len(variable_value)
+
+            if pref_len > NimbusConstants.LARGE_PREF_ERROR_LEN:
+                message_fmt = NimbusConstants.ERROR_LARGE_PREF
+            elif pref_len > NimbusConstants.LARGE_PREF_WARNING_LEN:
+                message_fmt = NimbusConstants.WARNING_LARGE_PREF
+            else:
+                continue
+
+            if schema.is_early_startup:
+                reason = NimbusConstants.IS_EARLY_STARTUP_REASON.format(
+                    feature=feature_config.name
                 )
             else:
-                for locale_code, substitutions in localizations.items():
-                    try:
-                        substituted_value = cls._substitute_localizations(
-                            json_value, substitutions, locale_code
-                        )
-                    except LocalizationError as e:
-                        result.append(str(e), suppress_errors)
-                        continue
+                reason = NimbusConstants.SET_PREF_REASON
 
-                    if schema_errors := cls._validate_schema(
-                        substituted_value, json_schema, schema.version
-                    ):
-                        err_msg = (
-                            f"Schema validation errors occured during locale "
-                            f"substitution for locale {locale_code}"
-                        )
+            message = message_fmt.format(
+                variable=variable_name,
+                reason=reason,
+            )
 
-                        if schema.version is not None:
-                            err_msg += f" at version {schema.version}"
+            if schema.version:
+                message += f" at version {schema.version}"
 
-                        result.append(err_msg, suppress_errors)
-                        result.extend(schema_errors, suppress_errors)
+            # If the pref is over the error threshold, then this error cannot be
+            # supressed as a warning.
+            as_warning = (
+                suppress_errors and pref_len <= NimbusConstants.LARGE_PREF_ERROR_LEN
+            )
+
+            result.append(message, as_warning)
 
         return result
 

--- a/experimenter/experimenter/experiments/constants.py
+++ b/experimenter/experimenter/experiments/constants.py
@@ -671,3 +671,20 @@ Optional - We believe this outcome will <describe impact> on <core metric>
         "rollout will re-enroll in this rollout, which will result in overriding their "
         "changes."
     )
+
+    # There is a maximum size for prefs that Desktop can write. It will warn at
+    # 4KiB and hard error at 1MiB.
+    # https://searchfox.org/mozilla-central/rev/6b8a3f804789fb865f42af54e9d2fef9dd3ec74d/modules/libpref/Preferences.cpp#161-164
+    LARGE_PREF_WARNING_LEN = 4 * 1024
+    LARGE_PREF_ERROR_LEN = 1024 * 1024
+
+    WARNING_LARGE_PREF = (
+        "The variable '{variable}' will cause Firefox to write a pref over "
+        "4KB size because {reason}. This should be avoided if possible."
+    )
+    ERROR_LARGE_PREF = (
+        "The variable '{variable}' will cause Firefox to write a pref over "
+        "1MB in size because {reason}. This will cause errors in the client."
+    )
+    IS_EARLY_STARTUP_REASON = "the feature {feature} is marked isEarlyStartup"
+    SET_PREF_REASON = "the variable is a setPref variable"

--- a/experimenter/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_ready_for_review_serializer.py
+++ b/experimenter/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_ready_for_review_serializer.py
@@ -2,6 +2,7 @@ import datetime
 import json
 from dataclasses import dataclass
 from itertools import chain, product
+from typing import Literal, Optional, Union
 from unittest.mock import patch
 
 from django.test import TestCase
@@ -2745,6 +2746,238 @@ class TestNimbusReviewSerializerSingleFeature(MockFmlErrorMixin, TestCase):
             self.assertEqual(
                 serializer.warnings["pref_rollout_reenroll"],
                 [NimbusExperiment.WARNING_ROLLOUT_PREF_REENROLL],
+            )
+
+    SET_PREF_WARNING_MSG = NimbusConstants.WARNING_LARGE_PREF.format(
+        variable="foo",
+        reason=NimbusConstants.SET_PREF_REASON,
+    )
+    SET_PREF_ERROR_MSG = NimbusConstants.ERROR_LARGE_PREF.format(
+        variable="foo",
+        reason=NimbusConstants.SET_PREF_REASON,
+    )
+
+    IS_EARLY_STARTUP_WARNING_MSG = NimbusConstants.WARNING_LARGE_PREF.format(
+        variable="foo",
+        reason=NimbusConstants.IS_EARLY_STARTUP_REASON.format(feature="feature"),
+    )
+    IS_EARLY_STARTUP_ERROR_MSG = NimbusConstants.ERROR_LARGE_PREF.format(
+        variable="foo",
+        reason=NimbusConstants.IS_EARLY_STARTUP_REASON.format(feature="feature"),
+    )
+
+    @parameterized.expand(
+        [
+            # No prefs set
+            *(
+                (None, schema_version, pref_type, pref_len, False, True, None, None)
+                for schema_version in (None, 120)
+                for pref_type in (str, list, dict)
+                for pref_len in (0, 4097, 1024 * 1024 + 1)
+            ),
+            # Prefs <= 4kB do not cause any warnings or errors.
+            *(
+                (mode, schema_version, pref_type, 4096, False, True, None, None)
+                for mode in ("setPref", "isEarlyStartup", "both")
+                for schema_version in (None, 120)
+                for pref_type in (str, list, dict)
+            ),
+            # Prefs > 4kB <= 1 mB cause errors when errors are not supressed.
+            *(
+                (mode, schema_version, pref_type, pref_len, False, False, None, msg)
+                for mode, msg in (
+                    ("setPref", SET_PREF_WARNING_MSG),
+                    ("isEarlyStartup", IS_EARLY_STARTUP_WARNING_MSG),
+                    ("both", IS_EARLY_STARTUP_WARNING_MSG),
+                )
+                for schema_version in (None, 120)
+                for pref_type in (str, list, dict)
+                for pref_len in (4097, 1024 * 1024)
+            ),
+            # Prefs > 4kB <= 1mB cause warnings when errors are suppressed.
+            *(
+                (mode, schema_version, pref_type, pref_len, True, True, msg, None)
+                for mode, msg in (
+                    ("setPref", SET_PREF_WARNING_MSG),
+                    ("isEarlyStartup", IS_EARLY_STARTUP_WARNING_MSG),
+                    ("both", IS_EARLY_STARTUP_WARNING_MSG),
+                )
+                for schema_version in (None, 120)
+                for pref_type in (str, list, dict)
+                for pref_len in (4097, 1024 * 1024)
+            ),
+            # Prefs > 1mB cause errors when errors are not supressed and cannot
+            # be suppressed.
+            *(
+                (
+                    mode,
+                    schema_version,
+                    pref_type,
+                    1024 * 1024 + 1,
+                    supress_errors,
+                    False,
+                    None,
+                    msg,
+                )
+                for mode, msg in (
+                    ("setPref", SET_PREF_ERROR_MSG),
+                    ("isEarlyStartup", IS_EARLY_STARTUP_ERROR_MSG),
+                    ("both", IS_EARLY_STARTUP_ERROR_MSG),
+                )
+                for schema_version in (None, 120)
+                for pref_type in (str, list, dict)
+                for supress_errors in (True, False)
+            ),
+        ]
+    )
+    def test_desktop_large_prefs(
+        self,
+        mode: Optional[
+            Union[Literal["setPref"], Literal["isEarlyStartup"], Literal["both"]]
+        ],
+        schema_version: Optional[int],
+        pref_type: type,
+        value_len: int,
+        suppress_errors: bool,
+        expected_valid: bool,
+        expected_warning: Optional[str],
+        expected_error: Optional[str],
+    ):
+        self.assertIn(mode, (None, "setPref", "isEarlyStartup", "both"))
+
+        set_pref_vars = {"bar": "pref.bar", "baz": "pref.baz"}
+        if mode in ("setPref", "both"):
+            set_pref_vars["foo"] = "pref.foo"
+
+        is_early_startup = mode in ("isEarlyStartup", "both")
+        schemas = [
+            # An unversioned schema always exists.
+            NimbusVersionedSchemaFactory.build(
+                version=None,
+                schema=None,
+                is_early_startup=is_early_startup,
+                set_pref_vars=set_pref_vars,
+            ),
+        ]
+
+        if schema_version is not None:
+            schemas.append(
+                NimbusVersionedSchemaFactory.build(
+                    version=NimbusFeatureVersion.objects.create(
+                        major=schema_version,
+                        minor=0,
+                        patch=0,
+                    ),
+                    schema=None,
+                    is_early_startup=is_early_startup,
+                    set_pref_vars=set_pref_vars,
+                ),
+            )
+
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            targeting_config_slug=NimbusExperiment.TargetingConfig.NO_TARGETING,
+            firefox_min_version=NimbusExperiment.Version.FIREFOX_120,
+            application=NimbusExperiment.Application.DESKTOP,
+            channel=NimbusExperiment.Channel.RELEASE,
+            warn_feature_schema=suppress_errors,
+            feature_configs=[
+                NimbusFeatureConfigFactory.create(
+                    application=NimbusExperiment.Application.DESKTOP,
+                    slug="feature",
+                    name="feature",
+                    schemas=schemas,
+                ),
+            ],
+        )
+
+        for branch in experiment.treatment_branches:
+            branch.delete()
+
+        # Ensure the serialized value is *exactly* value_len in length because
+        # we are testing different thresholds
+        if pref_type == str:
+            foo_value = "a" * value_len
+        else:
+            self.assertIn(
+                pref_type, (list, dict), "only str, list, dict supported for pref_type"
+            )
+
+            if pref_type == list:
+                # But for values this short, we're always going to be under the
+                # warning threshold, so it is ok if we bump it up slightly.
+                if value_len <= 4:
+                    value_len = 4
+
+                foo_value = ["a" * (value_len - 4)]
+            elif pref_type == dict:
+                if value_len <= 9:
+                    value_len = 9
+
+                foo_value = {"a": "a" * (value_len - 9)}
+
+            self.assertEqual(len(json.dumps(foo_value)), value_len)
+
+        feature_value = experiment.reference_branch.feature_values.get()
+        feature_value.value = json.dumps(
+            {
+                "foo": foo_value,
+                "bar": 1,
+                "baz": True,
+            }
+        )
+        feature_value.save()
+
+        serializer = NimbusReviewSerializer(
+            experiment,
+            data=NimbusReviewSerializer(
+                experiment,
+                context={"user": self.user},
+            ).data,
+            context={"user": self.user},
+        )
+
+        if expected_valid:
+            self.assertTrue(serializer.is_valid(), serializer.errors)
+        else:
+            self.assertFalse(serializer.is_valid())
+
+        if expected_error is None:
+            self.assertEqual(serializer.errors, {})
+        else:
+            if schema_version is not None:
+                expected_error += f" at version {schema_version}.0.0"
+
+            self.assertEqual(
+                serializer.errors,
+                {
+                    "reference_branch": {
+                        "feature_values": [
+                            {
+                                "value": [expected_error],
+                            }
+                        ],
+                    },
+                },
+            )
+
+        if expected_warning is None:
+            self.assertEqual(serializer.warnings, {})
+        else:
+            if schema_version is not None:
+                expected_warning += f" at version {schema_version}.0.0"
+
+            self.assertEqual(
+                serializer.warnings,
+                {
+                    "reference_branch": {
+                        "feature_values": [
+                            {
+                                "value": [expected_warning],
+                            }
+                        ]
+                    },
+                },
             )
 
 


### PR DESCRIPTION
Because

- it is possible to cause large pref writes on desktop;
- prefs over 4kB will cause warnings on desktop; and
- prefs over 1mB will cause errors on desktop and cause client errors

This commit

- adds dismissable warnings at the 4kB-1mB boundary; and
- adds undimissable errors at the 1mB+ boundary.

Fixes #10340