### PR TITLE
feat(nimbus): set published_date on preview

### DIFF
--- a/experimenter/experimenter/kinto/tasks.py
+++ b/experimenter/experimenter/kinto/tasks.py
@@ -393,6 +393,7 @@ def nimbus_synchronize_preview_experiments_in_kinto():
             data = NimbusExperimentSerializer(experiment).data
             kinto_client.create_record(data)
             experiment.published_dto = data
+            experiment.published_date = timezone.now()
             experiment.save()
             logger.info(f"{experiment.slug} is being pushed to preview")
 
@@ -402,6 +403,8 @@ def nimbus_synchronize_preview_experiments_in_kinto():
 
         for experiment in should_unpublish_experiments:
             kinto_client.delete_record(experiment.slug)
+            experiment.published_date = None
+            experiment.save()
             logger.info(f"{experiment.slug} is being removed from preview")
 
         metrics.incr("nimbus_synchronize_preview_experiments_in_kinto.completed")

--- a/experimenter/experimenter/kinto/tests/test_tasks.py
+++ b/experimenter/experimenter/kinto/tests/test_tasks.py
@@ -983,9 +983,11 @@ class TestNimbusSynchronizePreviewExperimentsInKinto(MockKintoClientMixin, TestC
     ):
         should_publish_experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.PREVIEW,
+            published_date=None,
         )
         should_unpublish_experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.CREATED,
+            published_date=timezone.now(),
         )
 
         self.setup_kinto_get_main_records([should_unpublish_experiment.slug])
@@ -998,10 +1000,13 @@ class TestNimbusSynchronizePreviewExperimentsInKinto(MockKintoClientMixin, TestC
             id=should_publish_experiment.id
         )
         self.assertEqual(should_publish_experiment.published_dto, data)
+        self.assertIsNotNone(should_publish_experiment.published_date)
 
         should_unpublish_experiment = NimbusExperiment.objects.get(
             id=should_unpublish_experiment.id
         )
+
+        self.assertIsNone(should_unpublish_experiment.published_date)
 
         self.mock_kinto_client.create_record.assert_called_with(
             data=data,


### PR DESCRIPTION
Because

* To aid in testing holdback experiments, we should set published_date for preview experiments

This commit

* Sets published_date when publishing to preview
* Unsets published_date when unpublishing from preview

fixes #10398