### PR TITLE
bug(nimbus): unset published_date for clones

### DIFF
--- a/experimenter/experimenter/experiments/models.py
+++ b/experimenter/experimenter/experiments/models.py
@@ -976,6 +976,7 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
         cloned.reference_branch = None
         cloned.proposed_release_date = None
         cloned.published_dto = None
+        cloned.published_date = None
         cloned.results_data = None
         cloned.takeaways_summary = None
         cloned.conclusion_recommendation = None

--- a/experimenter/experimenter/experiments/tests/test_models.py
+++ b/experimenter/experimenter/experiments/tests/test_models.py
@@ -2244,6 +2244,7 @@ class TestNimbusExperiment(TestCase):
         self.assertEqual(child.release_date, None)
         self.assertEqual(child.enrollment_start_date, None)
         self.assertEqual(child.published_dto, None)
+        self.assertEqual(child.published_date, None)
         self.assertEqual(child.results_data, None)
         self.assertEqual(child.takeaways_gain_amount, None)
         self.assertEqual(child.takeaways_metric_gain, False)


### PR DESCRIPTION
Because

* When cloning an experiment, we need to unset published_date otherwise unlaunched experiments will have the wrong published_date
* published_date is always overwritten when launching to live so this only affects experiments in drafts/preview which can still make testing difficult

This commit

* Sets published_date to None for cloned experiments

fixes #10397

