### PR TITLE
feat(nimbus): fml errors in feature value editor

### DIFF
--- a/docs/experimenter/openapi-schema.json
+++ b/docs/experimenter/openapi-schema.json
@@ -1790,6 +1790,106 @@
           "Core: Private"
         ]
       }
+    },
+    "/api/v5/fml-errors/{slug}/": {
+      "put": {
+        "operationId": "updateNimbusExperiment",
+        "description": "",
+        "parameters": [
+          {
+            "name": "slug",
+            "in": "path",
+            "required": true,
+            "description": "",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FmlFeatureValue"
+              }
+            },
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/FmlFeatureValue"
+              }
+            },
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/FmlFeatureValue"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FmlFeatureValue"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "tags": [
+          "api"
+        ]
+      },
+      "patch": {
+        "operationId": "partialUpdateNimbusExperiment",
+        "description": "",
+        "parameters": [
+          {
+            "name": "slug",
+            "in": "path",
+            "required": true,
+            "description": "",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FmlFeatureValue"
+              }
+            },
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/FmlFeatureValue"
+              }
+            },
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/FmlFeatureValue"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FmlFeatureValue"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "tags": [
+          "api"
+        ]
+      }
     }
   },
   "components": {
@@ -3415,6 +3515,21 @@
         },
         "required": [
           "name"
+        ]
+      },
+      "FmlFeatureValue": {
+        "type": "object",
+        "properties": {
+          "featureSlug": {
+            "type": "string"
+          },
+          "featureValue": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "featureSlug",
+          "featureValue"
         ]
       }
     }

--- a/docs/experimenter/swagger-ui.html
+++ b/docs/experimenter/swagger-ui.html
@@ -1802,6 +1802,106 @@
           "Core: Private"
         ]
       }
+    },
+    "/api/v5/fml-errors/{slug}/": {
+      "put": {
+        "operationId": "updateNimbusExperiment",
+        "description": "",
+        "parameters": [
+          {
+            "name": "slug",
+            "in": "path",
+            "required": true,
+            "description": "",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FmlFeatureValue"
+              }
+            },
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/FmlFeatureValue"
+              }
+            },
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/FmlFeatureValue"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FmlFeatureValue"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "tags": [
+          "api"
+        ]
+      },
+      "patch": {
+        "operationId": "partialUpdateNimbusExperiment",
+        "description": "",
+        "parameters": [
+          {
+            "name": "slug",
+            "in": "path",
+            "required": true,
+            "description": "",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FmlFeatureValue"
+              }
+            },
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/FmlFeatureValue"
+              }
+            },
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/FmlFeatureValue"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FmlFeatureValue"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "tags": [
+          "api"
+        ]
+      }
     }
   },
   "components": {
@@ -3427,6 +3527,21 @@
         },
         "required": [
           "name"
+        ]
+      },
+      "FmlFeatureValue": {
+        "type": "object",
+        "properties": {
+          "featureSlug": {
+            "type": "string"
+          },
+          "featureValue": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "featureSlug",
+          "featureValue"
         ]
       }
     }

--- a/experimenter/experimenter/experiments/api/v5/serializers.py
+++ b/experimenter/experimenter/experiments/api/v5/serializers.py
@@ -2122,3 +2122,25 @@ class NimbusExperimentCloneSerializer(
 
 class LocalizationError(Exception):
     """An error that occurs during localization substitution."""
+
+
+class FmlErrorSerializer(serializers.Serializer):
+    line = serializers.IntegerField()
+    col = serializers.IntegerField()
+    highlight = serializers.CharField()
+    message = serializers.CharField()
+
+
+class FmlFeatureValueSerializer(serializers.Serializer):
+    featureSlug = serializers.CharField()
+    featureValue = serializers.CharField()
+
+    def update(self, instance, validated_data):
+        fml_loader = NimbusFmlLoader.create_loader(instance.application, instance.channel)
+        feature_slug = validated_data["featureSlug"]
+        feature_value = validated_data["featureValue"]
+        return fml_loader.get_fml_errors(feature_value, feature_slug)
+
+    @property
+    def data(self):
+        return FmlErrorSerializer(self.instance, many=True).data

--- a/experimenter/experimenter/experiments/api/v5/urls.py
+++ b/experimenter/experimenter/experiments/api/v5/urls.py
@@ -1,8 +1,11 @@
-from django.urls import re_path
+from django.urls import path, re_path
 from django.views.decorators.csrf import csrf_exempt
 from graphene_file_upload.django import FileUploadGraphQLView
 
-from experimenter.experiments.api.v5.views import NimbusExperimentCsvListView
+from experimenter.experiments.api.v5.views import (
+    FmlErrorsView,
+    NimbusExperimentCsvListView,
+)
 
 urlpatterns = [
     re_path(
@@ -15,4 +18,5 @@ urlpatterns = [
         NimbusExperimentCsvListView.as_view(),
         name="nimbus-experiments-csv",
     ),
+    path(r"fml-errors/<slug:slug>/", FmlErrorsView.as_view(), name="nimbus-fml-errors"),
 ]

--- a/experimenter/experimenter/experiments/api/v5/views.py
+++ b/experimenter/experimenter/experiments/api/v5/views.py
@@ -1,7 +1,8 @@
-from rest_framework.generics import ListAPIView
+from rest_framework.generics import ListAPIView, UpdateAPIView
 from rest_framework_csv.renderers import CSVRenderer
 
 from experimenter.experiments.api.v5.serializers import (
+    FmlFeatureValueSerializer,
     NimbusExperimentCsvSerializer,
 )
 from experimenter.experiments.models import NimbusExperiment
@@ -13,12 +14,13 @@ class NimbusExperimentCsvRenderer(CSVRenderer):
 
 
 class NimbusExperimentCsvListView(ListAPIView):
-
     queryset = (
         NimbusExperiment.objects.select_related("owner")
         .prefetch_related("feature_configs")
         .filter(is_archived=False)
     )
+    serializer_class = NimbusExperimentCsvSerializer
+    renderer_classes = (NimbusExperimentCsvRenderer,)
 
     def get_queryset(self):
         return sorted(
@@ -30,6 +32,8 @@ class NimbusExperimentCsvListView(ListAPIView):
             reverse=True,
         )
 
-    serializer_class = NimbusExperimentCsvSerializer
 
-    renderer_classes = (NimbusExperimentCsvRenderer,)
+class FmlErrorsView(UpdateAPIView):
+    queryset = NimbusExperiment.objects.all()
+    lookup_field = "slug"
+    serializer_class = FmlFeatureValueSerializer

--- a/experimenter/experimenter/experiments/tests/api/v5/test_serializers/test_fml_lint_serializers.py
+++ b/experimenter/experimenter/experiments/tests/api/v5/test_serializers/test_fml_lint_serializers.py
@@ -1,0 +1,52 @@
+import json
+
+from django.test import TestCase
+
+from experimenter.experiments.api.v5.serializers import (
+    FmlFeatureValueSerializer,
+)
+from experimenter.experiments.models import NimbusExperiment
+from experimenter.experiments.tests.api.v5.test_serializers.mixins import (
+    MockFmlErrorMixin,
+)
+from experimenter.experiments.tests.factories import (
+    NimbusExperimentFactory,
+    NimbusFmlErrorDataClass,
+)
+
+
+class TestFmlFeatureValueSerializer(MockFmlErrorMixin, TestCase):
+    maxDiff = None
+
+    def test_serializer_returns_fml_errors(self):
+        self.setup_get_fml_errors(
+            [
+                NimbusFmlErrorDataClass(
+                    line=1,
+                    col=0,
+                    message="Incorrect value!",
+                    highlight="enabled",
+                ),
+            ]
+        )
+
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            application=NimbusExperiment.Application.FENIX,
+        )
+        data = {"featureSlug": "blerp", "featureValue": json.dumps({"some": "value"})}
+
+        serializer = FmlFeatureValueSerializer(experiment, data=data)
+        self.assertTrue(serializer.is_valid())
+        serializer.save()
+        self.assertEqual(
+            serializer.data,
+            [
+                {
+                    "line": 1,
+                    "col": 0,
+                    "highlight": "enabled",
+                    "message": "Incorrect value!",
+                }
+            ],
+        )

--- a/experimenter/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_ready_for_review_serializer.py
+++ b/experimenter/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_ready_for_review_serializer.py
@@ -1,9 +1,7 @@
 import datetime
 import json
-from dataclasses import dataclass
 from itertools import chain, product
 from typing import Literal, Optional, Union
-from unittest.mock import patch
 
 from django.test import TestCase
 from parameterized import parameterized
@@ -24,6 +22,7 @@ from experimenter.experiments.tests.factories import (
     NimbusBranchFactory,
     NimbusExperimentFactory,
     NimbusFeatureConfigFactory,
+    NimbusFmlErrorDataClass,
     NimbusVersionedSchemaFactory,
 )
 from experimenter.openidc.tests.factories import UserFactory
@@ -73,14 +72,6 @@ REF_JSON_SCHEMA = """\
   }
 }
 """
-
-
-@dataclass
-class NimbusFmlErrorDataClass:
-    line: int
-    col: int
-    message: str
-    highlight: str
 
 
 class TestNimbusReviewSerializerSingleFeature(MockFmlErrorMixin, TestCase):
@@ -3507,21 +3498,17 @@ class VersionedFeatureValidationTests(MockFmlErrorMixin, TestCase):
             serializer.errors,
         )
 
-    @patch(
-        "experimenter.features.manifests.nimbus_fml_loader.NimbusFmlLoader.get_fml_errors",
-    )
-    def test_fml_validate_feature_versioned_truncated_range(
-        self,
-        mock_fml_errors,
-    ):
-        mock_fml_errors.return_value = [
-            NimbusFmlErrorDataClass(
-                line=1,
-                col=0,
-                message="Incorrect value!",
-                highlight="enabled",
-            ),
-        ]
+    def test_fml_validate_feature_versioned_truncated_range(self):
+        self.setup_get_fml_errors(
+            [
+                NimbusFmlErrorDataClass(
+                    line=1,
+                    col=0,
+                    message="Incorrect value!",
+                    highlight="enabled",
+                ),
+            ]
+        )
         application = NimbusExperiment.Application.IOS
         min_version = NimbusExperiment.Version.FIREFOX_110
         max_version = NimbusExperiment.Version.NO_VERSION

--- a/experimenter/experimenter/experiments/tests/api/v5/test_views.py
+++ b/experimenter/experimenter/experiments/tests/api/v5/test_views.py
@@ -1,4 +1,5 @@
 import datetime
+import json
 
 from django.conf import settings
 from django.test import TestCase
@@ -7,9 +8,13 @@ from django.urls import reverse
 from experimenter.experiments.api.v5.serializers import NimbusExperimentCsvSerializer
 from experimenter.experiments.api.v5.views import NimbusExperimentCsvRenderer
 from experimenter.experiments.models import NimbusExperiment
+from experimenter.experiments.tests.api.v5.test_serializers.mixins import (
+    MockFmlErrorMixin,
+)
 from experimenter.experiments.tests.factories import (
     NimbusExperimentFactory,
     NimbusFeatureConfigFactory,
+    NimbusFmlErrorDataClass,
 )
 
 
@@ -95,3 +100,43 @@ class TestNimbusExperimentCsvListView(TestCase):
             renderer_context={"header": NimbusExperimentCsvSerializer.Meta.fields},
         )
         self.assertEqual(csv_data, expected_csv_data)
+
+
+class TestFmlErrorsView(MockFmlErrorMixin, TestCase):
+    def test_returns_fml_errors(self):
+        user_email = "user@example.com"
+        self.setup_get_fml_errors(
+            [
+                NimbusFmlErrorDataClass(
+                    line=1,
+                    col=0,
+                    message="Incorrect value!",
+                    highlight="enabled",
+                ),
+            ]
+        )
+
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            application=NimbusExperiment.Application.FENIX,
+        )
+
+        response = self.client.put(
+            reverse("nimbus-fml-errors", kwargs={"slug": experiment.slug}),
+            {"featureSlug": "blerp", "featureValue": json.dumps({"some": "value"})},
+            content_type="application/json",
+            **{settings.OPENIDC_EMAIL_HEADER: user_email},
+        )
+
+        self.assertEqual(response.status_code, 200, response.content)
+        self.assertEqual(
+            response.json(),
+            [
+                {
+                    "line": 1,
+                    "col": 0,
+                    "highlight": "enabled",
+                    "message": "Incorrect value!",
+                }
+            ],
+        )

--- a/experimenter/experimenter/experiments/tests/factories.py
+++ b/experimenter/experimenter/experiments/tests/factories.py
@@ -4,6 +4,7 @@ import decimal
 import json
 import random
 from collections.abc import Iterable
+from dataclasses import dataclass
 from enum import Enum
 
 import factory
@@ -749,3 +750,11 @@ class NimbusChangeLogFactory(factory.django.DjangoModelFactory):
 
     class Meta:
         model = NimbusChangeLog
+
+
+@dataclass
+class NimbusFmlErrorDataClass:
+    line: int
+    col: int
+    message: str
+    highlight: str

--- a/experimenter/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/FormBranch.test.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/FormBranch.test.tsx
@@ -15,34 +15,37 @@ import {
   SubjectBranch,
 } from "src/components/PageEditBranches/FormBranches/mocks";
 import { FIELD_MESSAGES } from "src/lib/constants";
+import { mockExperimentQuery } from "src/lib/mocks";
 
 describe("FormBranch", () => {
+  const { experiment } = mockExperimentQuery("boo", {});
   it("renders as expected", () => {
-    render(<SubjectBranch />);
+    render(<SubjectBranch experiment={experiment} />);
     expect(screen.getByTestId("FormBranch")).toBeInTheDocument();
     expect(screen.queryByTestId("control-pill")).not.toBeInTheDocument();
     expect(screen.queryByTestId("equal-ratio")).not.toBeInTheDocument();
   });
 
   it("does nothing on form submission", () => {
-    render(<SubjectBranch />);
+    render(<SubjectBranch experiment={experiment} />);
     const form = screen.getByTestId("FormBranch");
     fireEvent.submit(form);
   });
 
   it("includes a control label when reference branch", () => {
-    render(<SubjectBranch isReference />);
+    render(<SubjectBranch experiment={experiment} isReference />);
     expect(screen.getByTestId("control-pill")).toBeInTheDocument();
   });
 
   it("indicates equal ratio when enabled", () => {
-    render(<SubjectBranch equalRatio />);
+    render(<SubjectBranch experiment={experiment} equalRatio />);
     expect(screen.getByTestId("equal-ratio")).toBeInTheDocument();
   });
 
   it("displays feature value edit when value is non-null", () => {
     render(
       <SubjectBranch
+        experiment={experiment}
         branch={{
           ...MOCK_ANNOTATED_BRANCH,
           featureValues: [{ value: "this is a default value" }],
@@ -56,7 +59,7 @@ describe("FormBranch", () => {
 
   it("calls onRemove when the branch remove button is clicked", async () => {
     const onRemove = jest.fn();
-    render(<SubjectBranch {...{ onRemove }} />);
+    render(<SubjectBranch experiment={experiment} {...{ onRemove }} />);
     fireEvent.click(screen.getByTestId("remove-branch"));
     expect(onRemove).toHaveBeenCalled();
   });
@@ -65,7 +68,9 @@ describe("FormBranch", () => {
     const branch = {
       ...MOCK_ANNOTATED_BRANCH,
     };
-    const { container } = render(<SubjectBranch {...{ branch }} />);
+    const { container } = render(
+      <SubjectBranch experiment={experiment} {...{ branch }} />,
+    );
     const field = screen.getByTestId("referenceBranch.ratio");
     act(() => {
       fireEvent.change(field, { target: { value: "abc" } });
@@ -83,7 +88,9 @@ describe("FormBranch", () => {
     const branch = {
       ...MOCK_ANNOTATED_BRANCH,
     };
-    const { container } = render(<SubjectBranch {...{ branch }} />);
+    const { container } = render(
+      <SubjectBranch experiment={experiment} {...{ branch }} />,
+    );
     const field = screen.getByTestId("referenceBranch.name");
     act(() => {
       fireEvent.change(field, { target: { value: "" } });
@@ -104,7 +111,9 @@ describe("FormBranch", () => {
         description: ["This description is boring"],
       },
     };
-    const { container } = render(<SubjectBranch branch={branch} />);
+    const { container } = render(
+      <SubjectBranch experiment={experiment} branch={branch} />,
+    );
     await assertInvalidField(container, "referenceBranch.description");
   });
 
@@ -114,7 +123,7 @@ describe("FormBranch", () => {
       featureValues: [],
     };
 
-    render(<SubjectBranch branch={branch} />);
+    render(<SubjectBranch experiment={experiment} branch={branch} />);
 
     expect(
       screen.queryByTestId("referenceBranch.featureValues[0].value"),
@@ -140,7 +149,7 @@ describe("FormBranch", () => {
       ],
     };
 
-    render(<SubjectBranch branch={branch} />);
+    render(<SubjectBranch experiment={experiment} branch={branch} />);
 
     const inputs = [
       screen.getByTestId(

--- a/experimenter/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/FormBranch.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/FormBranch.tsx
@@ -18,12 +18,14 @@ import { AnnotatedBranch } from "src/components/PageEditBranches/FormBranches/re
 import { useCommonNestedForm } from "src/hooks";
 import { ReactComponent as DeleteIcon } from "src/images/x.svg";
 import { NUMBER_FIELD, REQUIRED_FIELD } from "src/lib/constants";
+import { getExperiment_experimentBySlug } from "src/types/getExperiment";
 
 export const branchFieldNames = ["name", "description", "ratio"] as const;
 
 type BranchFieldName = typeof branchFieldNames[number];
 
 export const FormBranch = ({
+  experiment,
   fieldNamePrefix,
   touched,
   errors,
@@ -39,6 +41,7 @@ export const FormBranch = ({
   defaultValues,
   setSubmitErrors,
 }: {
+  experiment: getExperiment_experimentBySlug;
   fieldNamePrefix: string;
   touched: Record<string, boolean>;
   errors: Record<string, FieldError>;
@@ -171,6 +174,7 @@ export const FormBranch = ({
               <div key={idx}>
                 <FormFeatureValue
                   {...{
+                    experiment,
                     featureId: parseInt(featureValue!.featureConfig!, 10),
                     fieldNamePrefix: `${fieldNamePrefix}.featureValues[${idx}]`,
                     defaultValues: defaultValues.featureValues?.[idx] || {},

--- a/experimenter/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/FormFeatureValue/RichFeatureValueEditor.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/FormFeatureValue/RichFeatureValueEditor.tsx
@@ -15,10 +15,10 @@ import {
   schemaAutocomplete,
   schemaLinter,
 } from "src/components/PageEditBranches/FormBranches/FormFeatureValue/validators";
-
-const allowFmlLinting = false;
+import { NimbusExperimentApplicationEnum } from "src/types/globalTypes";
 
 export default function RichFeatureValueEditor({
+  experiment,
   featureConfig,
   defaultValues,
   fieldNamePrefix,
@@ -84,11 +84,12 @@ export default function RichFeatureValueEditor({
     ];
 
     if (schema) {
-      if (allowFmlLinting) {
-        extensions.push(linter(fmlLinter()));
-      } else {
+      if (experiment.application === NimbusExperimentApplicationEnum.DESKTOP) {
         extensions.push(linter(schemaLinter(schema)));
+      } else {
+        extensions.push(linter(fmlLinter(experiment.slug, featureConfig)));
       }
+
       const completionSource = schemaAutocomplete(schema);
       if (completionSource) {
         extensions.push(
@@ -100,7 +101,14 @@ export default function RichFeatureValueEditor({
     }
 
     return extensions;
-  }, [field, hideSubmitErrors, schema]);
+  }, [
+    field,
+    hideSubmitErrors,
+    schema,
+    featureConfig,
+    experiment.slug,
+    experiment.application,
+  ]);
 
   // We can't use formControlAttrs() because this isn't actually a form component
   // -- it is actually a bunch of divs, so there is no <input> to pass the return

--- a/experimenter/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/FormFeatureValue/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/FormFeatureValue/index.tsx
@@ -16,6 +16,7 @@ export const featureValueFieldNames = ["featureConfig", "value"] as const;
 type FeatureValueFieldName = typeof featureValueFieldNames[number];
 
 export const FormFeatureValue = ({
+  experiment,
   featureId,
   ...commonProps
 }: FormFeatureValueProps) => {
@@ -59,7 +60,11 @@ export const FormFeatureValue = ({
             </Col>
           </Row>
         </Form.Label>
-        <FeatureValueEditor featureConfig={featureConfig!} {...commonProps} />
+        <FeatureValueEditor
+          experiment={experiment}
+          featureConfig={featureConfig!}
+          {...commonProps}
+        />
         <FormErrors name="value" />
       </Form.Group>
     </Form.Group>

--- a/experimenter/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/FormFeatureValue/props.ts
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/FormFeatureValue/props.ts
@@ -1,5 +1,6 @@
 import { FieldError } from "react-hook-form";
 import { getConfig_nimbusConfig_allFeatureConfigs } from "src/types/getConfig";
+import { getExperiment_experimentBySlug } from "src/types/getExperiment";
 
 type UseCommonNestedFormProps = {
   defaultValues: Record<string, any>;
@@ -14,8 +15,10 @@ type UseCommonNestedFormProps = {
 
 export type FormFeatureValueProps = UseCommonNestedFormProps & {
   featureId: number;
+  experiment: getExperiment_experimentBySlug;
 };
 
 export type FeatureValueEditorProps = UseCommonNestedFormProps & {
   featureConfig: getConfig_nimbusConfig_allFeatureConfigs;
+  experiment: getExperiment_experimentBySlug;
 };

--- a/experimenter/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/FormFeatureValue/validators.test.ts
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/FormFeatureValue/validators.test.ts
@@ -1,6 +1,7 @@
 import { json } from "@codemirror/lang-json";
 import { EditorState, EditorStateConfig } from "@codemirror/state";
 import { basicSetup } from "codemirror";
+import fetchMock from "jest-fetch-mock";
 import {
   detectDraft,
   fmlLinter,
@@ -8,6 +9,7 @@ import {
   schemaLinter,
   simpleObjectSchema,
 } from "src/components/PageEditBranches/FormBranches/FormFeatureValue/validators";
+import { MOCK_CONFIG } from "src/lib/mocks";
 import { z } from "zod";
 
 const SIMPLE_SCHEMA: z.infer<typeof simpleObjectSchema> = {
@@ -332,35 +334,53 @@ describe("detectDraft", () => {
 });
 
 describe("fmlLinter", () => {
-  it.each(["", "   ", "\t", "\n", " \n \t "])(
-    "does not return fml errors for an empty document",
-    (doc) => {
-      const linter = fmlLinter();
-      const state = createEditorState({ doc: JSON.stringify(doc) });
-      const diagnostics = linter({ state });
-      expect(diagnostics).toEqual([]);
-    },
-  );
+  beforeAll(() => {
+    fetchMock.enableMocks();
+  });
 
-  it.each([`{"foo": {"error"}`, `{"error": {"bingo"}`])(
-    "returns FML errors",
-    (doc) => {
-      const linter = fmlLinter();
-      const message = { message: "oh no!" };
-      const state = createEditorState({ doc: JSON.stringify(doc) });
-      const diagnostics = linter({ state });
-      expect(diagnostics).toContainEqual(expect.objectContaining(message));
-    },
-  );
+  afterAll(() => {
+    fetchMock.disableMocks();
+  });
 
-  it.each([`{"foo": {"bar"}`, `{"foo": {"mimsy"}`])(
-    "does not returns FML errors",
-    (doc) => {
-      const linter = fmlLinter();
-      const message = { message: "oh no!" };
-      const state = createEditorState({ doc: JSON.stringify(doc) });
-      const diagnostics = linter({ state });
-      expect(diagnostics).not.toContainEqual(expect.objectContaining(message));
-    },
-  );
+  afterEach(() => {
+    fetchMock.resetMocks();
+  });
+  const featureConfig = MOCK_CONFIG.allFeatureConfigs![0];
+
+  it("returns empty array when no errors returned", async () => {
+    fetchMock.mockResponseOnce(JSON.stringify([]));
+    const linter = fmlLinter("test-slug", featureConfig);
+    const state = createEditorState({ doc: "" });
+    const errors = await linter({ state });
+    expect(errors).toEqual([]);
+    expect(fetch).toHaveBeenCalledWith("/api/v5/fml-errors/test-slug/", {
+      body: '{"featureSlug":"picture-in-picture","featureValue":""}',
+      headers: { "Content-Type": "application/json" },
+      method: "PUT",
+    });
+  });
+
+  it("returns diagnostics when errors returned", async () => {
+    fetchMock.mockResponseOnce(
+      JSON.stringify([
+        { line: 0, col: 0, highlight: "enabled", message: "Invalid value" },
+      ]),
+    );
+    const linter = fmlLinter("test-slug", featureConfig);
+    const state = createEditorState({ doc: JSON.stringify({ some: "data" }) });
+    const errors = await linter({ state });
+    expect(errors).toEqual([
+      {
+        message: "Invalid value",
+        severity: "error",
+        from: 0,
+        to: 7,
+      },
+    ]);
+    expect(fetch).toHaveBeenCalledWith("/api/v5/fml-errors/test-slug/", {
+      body: '{"featureSlug":"picture-in-picture","featureValue":"{\\"some\\":\\"data\\"}"}',
+      headers: { "Content-Type": "application/json" },
+      method: "PUT",
+    });
+  });
 });

--- a/experimenter/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/index.tsx
@@ -454,6 +454,7 @@ export const FormBranches = ({
           {referenceBranch && (
             <FormBranch
               {...{
+                experiment,
                 ...commonBranchProps,
                 fieldNamePrefix: "referenceBranch",
                 // react-hook-form types seem broken for nested fields
@@ -488,6 +489,7 @@ export const FormBranches = ({
                 <FormBranch
                   key={branch.key}
                   {...{
+                    experiment,
                     ...commonBranchProps,
                     fieldNamePrefix: `treatmentBranches[${idx}]`,
                     //@ts-ignore react-hook-form types seem broken for nested fields

--- a/experimenter/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/mocks.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/mocks.tsx
@@ -11,6 +11,7 @@ import { formBranchesActionReducer } from "src/components/PageEditBranches/FormB
 import { FormBranchesState } from "src/components/PageEditBranches/FormBranches/reducer/state";
 import { useForm } from "src/hooks";
 import { MockedCache, mockExperimentQuery, MOCK_CONFIG } from "src/lib/mocks";
+import { getExperiment_experimentBySlug } from "src/types/getExperiment";
 import { NimbusExperimentApplicationEnum } from "src/types/globalTypes";
 
 export const MOCK_EXPERIMENT = mockExperimentQuery("demo-slug", {
@@ -103,6 +104,7 @@ const MOCK_STATE: FormBranchesState = {
 type FormBranchProps = React.ComponentProps<typeof FormBranch>;
 
 export const SubjectBranch = ({
+  experiment,
   fieldNamePrefix = "referenceBranch",
   branch = MOCK_ANNOTATED_BRANCH,
   equalRatio = false,
@@ -113,6 +115,7 @@ export const SubjectBranch = ({
   isDesktop = true,
   config = MOCK_CONFIG,
 }: Partial<React.ComponentProps<typeof FormBranch>> & {
+  experiment: getExperiment_experimentBySlug;
   config?: typeof MOCK_CONFIG;
 }) => {
   const defaultValues = {
@@ -138,6 +141,7 @@ export const SubjectBranch = ({
         <form className="p-5">
           <FormBranch
             {...{
+              experiment,
               fieldNamePrefix,
               // react-hook-form types seem broken for nested fields
               errors: (errors.referenceBranch ||

--- a/experimenter/experimenter/nimbus-ui/src/hooks/useCommonForm/index.test.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/hooks/useCommonForm/index.test.tsx
@@ -169,7 +169,8 @@ describe("hooks/useCommonForm", () => {
     });
 
     it("FormBranch", () => {
-      render(<BranchSubject />);
+      const { experiment } = mockExperimentQuery("boo", {});
+      render(<BranchSubject experiment={experiment} />);
 
       branchFieldNames.forEach((name) => {
         const fieldName = `referenceBranch.${name}`;


### PR DESCRIPTION
Because

* We now have the ability to validate feature values using FML in Python
* We are using the CodeMirror JSON editor for feature values
* We can use the dynamic linter module in CodeMirror to do inline FML validation for feature values

This commit

* Creates an API endpoint for PUTing a feature value and receiving an array of FML errors
* Attaches that API to the feature value editor in CodeMirror

fixes #9478
<img width="1179" alt="Screenshot 2024-03-12 at 17 54 57" src="https://github.com/mozilla/experimenter/assets/119884/b5214e7b-c1b7-4b61-b205-2693f6452330">

