### PR TITLE
feat(nimbus): Collapsible locales, languages and countries

### DIFF
--- a/experimenter/experimenter/nimbus-ui/src/components/Summary/TableAudience/index.test.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/Summary/TableAudience/index.test.tsx
@@ -277,6 +277,48 @@ describe("TableAudience", () => {
         ),
       );
     });
+    it("when more than 10 locales exist, displays show more option and hides after click", () => {
+      const data = {
+        locales: [
+          { name: "Quebecois", id: "1", code: "Qu" },
+          { name: "Acholi", id: "2", code: "Ac" },
+          { name: "Locale 3", id: "3", code: "L3" },
+          { name: "Locale 4", id: "4", code: "L4" },
+          { name: "Locale 5", id: "5", code: "L5" },
+          { name: "Locale 6", id: "6", code: "L6" },
+          { name: "Locale 7", id: "7", code: "L7" },
+          { name: "Locale 8", id: "8", code: "L8" },
+          { name: "Locale 9", id: "9", code: "L9" },
+          { name: "Locale 10", id: "10", code: "L10" },
+          { name: "Locale 11", id: "11", code: "L11" },
+        ],
+      };
+      const { experiment } = mockExperimentQuery("demo-slug", data);
+      render(<Subject {...{ experiment }} />);
+
+      const showMoreButton = screen.getByTestId("locales-show-more");
+      expect(showMoreButton).toBeInTheDocument();
+      fireEvent.click(showMoreButton);
+      const hideButton = screen.getByTestId("locales-hide");
+      expect(hideButton).toBeInTheDocument();
+
+      data.locales.forEach((locale) => {
+        expect(
+          within(screen.getByTestId("experiment-locales")).getByText(
+            locale.name,
+          ),
+        ).toBeInTheDocument();
+      });
+      fireEvent.click(hideButton);
+
+      expect(showMoreButton).toBeInTheDocument();
+      data.locales.slice(0, 10).forEach((locale) => {
+        expect(screen.getByTestId("experiment-locales")).toHaveTextContent(
+          locale.name,
+        );
+      });
+    });
+
     it("when locales don't exist, displays all", async () => {
       const { experiment } = mockExperimentQuery("demo-slug", {
         locales: [],
@@ -339,6 +381,47 @@ describe("TableAudience", () => {
         ),
       );
     });
+    it("when more than 10 languages exist, displays show more option and hides after click", () => {
+      const data = {
+        languages: [
+          { name: "English", id: "1", code: "en" },
+          { name: "Spanish", id: "2", code: "es" },
+          { name: "French", id: "3", code: "fr" },
+          { name: "German", id: "4", code: "de" },
+          { name: "Chinese", id: "5", code: "zh" },
+          { name: "Japanese", id: "6", code: "ja" },
+          { name: "Arabic", id: "7", code: "ar" },
+          { name: "Russian", id: "8", code: "ru" },
+          { name: "Portuguese", id: "9", code: "pt" },
+          { name: "Italian", id: "10", code: "it" },
+          { name: "Korean", id: "11", code: "ko" },
+        ],
+        application: NimbusExperimentApplicationEnum.FENIX,
+      };
+      const { experiment } = mockExperimentQuery("demo-slug", data);
+      render(<Subject {...{ experiment }} />);
+
+      const showMoreButton = screen.getByTestId("languages-show-more");
+      expect(showMoreButton).toBeInTheDocument();
+      fireEvent.click(showMoreButton);
+      const hideButton = screen.getByTestId("languages-hide");
+      expect(hideButton).toBeInTheDocument();
+
+      data.languages.forEach((language) => {
+        expect(screen.getByTestId("experiment-languages")).toHaveTextContent(
+          language.name,
+        );
+      });
+
+      fireEvent.click(hideButton);
+      expect(showMoreButton).toBeInTheDocument();
+      data.languages.slice(0, 10).forEach((language) => {
+        expect(screen.getByTestId("experiment-languages")).toHaveTextContent(
+          language.name,
+        );
+      });
+    });
+
     it("when languages don't exist, displays all", async () => {
       const { experiment } = mockExperimentQuery("demo-slug", {
         languages: [],
@@ -373,6 +456,45 @@ describe("TableAudience", () => {
         ),
       );
     });
+    it("when more than 10 countries exist, displays show more option and hides after click", () => {
+      const data = {
+        countries: [
+          { name: "United States", id: "1", code: "US" },
+          { name: "Canada", id: "2", code: "CA" },
+          { name: "United Kingdom", id: "3", code: "UK" },
+          { name: "Germany", id: "4", code: "DE" },
+          { name: "France", id: "5", code: "FR" },
+          { name: "Italy", id: "6", code: "IT" },
+          { name: "Spain", id: "7", code: "ES" },
+          { name: "Australia", id: "8", code: "AU" },
+          { name: "Japan", id: "9", code: "JP" },
+          { name: "China", id: "10", code: "CN" },
+          { name: "Brazil", id: "11", code: "BR" },
+        ],
+      };
+      const { experiment } = mockExperimentQuery("demo-slug", data);
+      render(<Subject {...{ experiment }} />);
+      const showMoreButton = screen.getByTestId("countries-show-more");
+      expect(showMoreButton).toBeInTheDocument();
+
+      fireEvent.click(showMoreButton);
+      const hideButton = screen.getByTestId("countries-hide");
+      expect(hideButton).toBeInTheDocument();
+
+      data.countries.forEach((country) => {
+        expect(screen.getByTestId("experiment-countries")).toHaveTextContent(
+          country.name,
+        );
+      });
+      fireEvent.click(hideButton);
+      expect(showMoreButton).toBeInTheDocument();
+      data.countries.slice(0, 10).forEach((country) => {
+        expect(screen.getByTestId("experiment-countries")).toHaveTextContent(
+          country.name,
+        );
+      });
+    });
+
     it("when countries don't exist, displays all", async () => {
       const { experiment } = mockExperimentQuery("demo-slug", {
         countries: [],

--- a/experimenter/experimenter/nimbus-ui/src/components/Summary/TableAudience/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/Summary/TableAudience/index.tsx
@@ -33,6 +33,9 @@ const TableAudience = ({ experiment }: TableAudienceProps) => {
     MOBILE_APPLICATIONS.includes(experiment.application);
 
   const [expand, setExpand] = useState(false);
+  const [expandLocale, setExpandLocale] = useState(false);
+  const [expandCountry, setExpandCountry] = useState(false);
+  const [expandLanguage, setExpandLanguage] = useState(false);
 
   return (
     <Card className="border-left-0 border-right-0 border-bottom-0">
@@ -80,11 +83,67 @@ const TableAudience = ({ experiment }: TableAudienceProps) => {
                   <th>Locales</th>
                   <td data-testid="experiment-locales">
                     {experiment.locales.length > 0 ? (
-                      <ul className="list-unstyled mb-0">
-                        {experiment.locales.map((l) => (
-                          <li key={l.id}>{l.name}</li>
-                        ))}
-                      </ul>
+                      experiment.locales.length > 10 ? (
+                        <>
+                          <Accordion>
+                            <Accordion.Toggle
+                              as={Accordion}
+                              eventKey="0"
+                              onClick={() => setExpandLocale(!expandLocale)}
+                            >
+                              {expandLocale ? (
+                                <>
+                                  <div className="float-right">
+                                    <Button
+                                      size="sm"
+                                      variant="outline-primary"
+                                      data-testid="locales-hide"
+                                    >
+                                      <CollapseMinus />
+                                      Hide
+                                    </Button>
+                                  </div>
+                                </>
+                              ) : (
+                                <>
+                                  <div className="float-right">
+                                    <Button
+                                      size="sm"
+                                      variant="outline-primary"
+                                      data-testid="locales-show-more"
+                                    >
+                                      <ExpandPlus />
+                                      Show More
+                                    </Button>
+                                  </div>
+                                  <ul className="list-unstyled mb-0">
+                                    {experiment.locales
+                                      .slice(0, 10)
+                                      .map((l) => (
+                                        <li key={l.id}>{l.name}</li>
+                                      ))}{" "}
+                                    ...
+                                  </ul>
+                                </>
+                              )}
+                            </Accordion.Toggle>
+
+                            <Accordion.Collapse eventKey="0">
+                              <ul className="list-unstyled mb-0">
+                                {experiment.locales.map((l) => (
+                                  <li key={l.id}>{l.name}</li>
+                                ))}
+                              </ul>
+                            </Accordion.Collapse>
+                          </Accordion>
+                        </>
+                      ) : (
+                        <ul className="list-unstyled mb-0">
+                          {experiment.locales.map((l) => (
+                            <li key={l.id}>{l.name}</li>
+                          ))}
+                        </ul>
+                      )
                     ) : (
                       "All locales"
                     )}
@@ -96,11 +155,67 @@ const TableAudience = ({ experiment }: TableAudienceProps) => {
                   <th>Languages</th>
                   <td data-testid="experiment-languages">
                     {experiment.languages.length > 0 ? (
-                      <ul className="list-unstyled mb-0">
-                        {experiment.languages.map((l) => (
-                          <li key={l.id}>{l.name}</li>
-                        ))}
-                      </ul>
+                      experiment.languages.length > 10 ? (
+                        <>
+                          <Accordion>
+                            <Accordion.Toggle
+                              as={Accordion}
+                              eventKey="0"
+                              onClick={() => setExpandLanguage(!expandLanguage)}
+                            >
+                              {expandLanguage ? (
+                                <>
+                                  <div className="float-right">
+                                    <Button
+                                      size="sm"
+                                      variant="outline-primary"
+                                      data-testid="languages-hide"
+                                    >
+                                      <CollapseMinus />
+                                      Hide
+                                    </Button>
+                                  </div>
+                                </>
+                              ) : (
+                                <>
+                                  <div className="float-right">
+                                    <Button
+                                      size="sm"
+                                      variant="outline-primary"
+                                      data-testid="languages-show-more"
+                                    >
+                                      <ExpandPlus />
+                                      Show More
+                                    </Button>
+                                  </div>
+                                  <ul className="list-unstyled mb-0">
+                                    {experiment.languages
+                                      .slice(0, 10)
+                                      .map((l) => (
+                                        <li key={l.id}>{l.name}</li>
+                                      ))}{" "}
+                                    ...
+                                  </ul>
+                                </>
+                              )}
+                            </Accordion.Toggle>
+
+                            <Accordion.Collapse eventKey="0">
+                              <ul className="list-unstyled mb-0">
+                                {experiment.languages.map((l) => (
+                                  <li key={l.id}>{l.name}</li>
+                                ))}
+                              </ul>
+                            </Accordion.Collapse>
+                          </Accordion>
+                        </>
+                      ) : (
+                        <ul className="list-unstyled mb-0">
+                          {experiment.languages.map((l) => (
+                            <li key={l.id}>{l.name}</li>
+                          ))}
+                        </ul>
+                      )
                     ) : (
                       "All Languages"
                     )}
@@ -111,11 +226,65 @@ const TableAudience = ({ experiment }: TableAudienceProps) => {
               <th>Countries</th>
               <td data-testid="experiment-countries">
                 {experiment.countries.length > 0 ? (
-                  <ul className="list-unstyled mb-0">
-                    {experiment.countries.map((c) => (
-                      <li key={c.id}>{c.name}</li>
-                    ))}
-                  </ul>
+                  experiment.countries.length > 10 ? (
+                    <>
+                      <Accordion>
+                        <Accordion.Toggle
+                          as={Accordion}
+                          eventKey="0"
+                          onClick={() => setExpandCountry(!expandCountry)}
+                        >
+                          {expandCountry ? (
+                            <>
+                              <div className="float-right">
+                                <Button
+                                  size="sm"
+                                  variant="outline-primary"
+                                  data-testid="countries-hide"
+                                >
+                                  <CollapseMinus />
+                                  Hide
+                                </Button>
+                              </div>
+                            </>
+                          ) : (
+                            <>
+                              <div className="float-right">
+                                <Button
+                                  size="sm"
+                                  variant="outline-primary"
+                                  data-testid="countries-show-more"
+                                >
+                                  <ExpandPlus />
+                                  Show More
+                                </Button>
+                              </div>
+                              <ul className="list-unstyled mb-0">
+                                {experiment.countries.slice(0, 10).map((l) => (
+                                  <li key={l.id}>{l.name}</li>
+                                ))}{" "}
+                                ...
+                              </ul>
+                            </>
+                          )}
+                        </Accordion.Toggle>
+
+                        <Accordion.Collapse eventKey="0">
+                          <ul className="list-unstyled mb-0">
+                            {experiment.countries.map((l) => (
+                              <li key={l.id}>{l.name}</li>
+                            ))}
+                          </ul>
+                        </Accordion.Collapse>
+                      </Accordion>
+                    </>
+                  ) : (
+                    <ul className="list-unstyled mb-0">
+                      {experiment.countries.map((l) => (
+                        <li key={l.id}>{l.name}</li>
+                      ))}
+                    </ul>
+                  )
                 ) : (
                   "All countries"
                 )}

--- a/experimenter/experimenter/nimbus-ui/src/components/Summary/TableAudience/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/Summary/TableAudience/index.tsx
@@ -22,6 +22,82 @@ type TableAudienceProps = {
   experiment: getExperiment_experimentBySlug;
 };
 
+const ListWithShowMore = ({
+  items,
+  maxItems,
+  testId,
+}: {
+  items: any[];
+  maxItems: number;
+  testId: string;
+}) => {
+  const [expanded, setExpanded] = useState(false);
+
+  return (
+    <>
+      {items.length > maxItems && (
+        <Accordion>
+          <Accordion.Toggle
+            as={Accordion}
+            eventKey="0"
+            onClick={() => setExpanded(!expanded)}
+            data-testid={`${testId}-toggle`}
+          >
+            {expanded ? (
+              <>
+                <div className="float-right">
+                  <Button
+                    size="sm"
+                    variant="outline-primary"
+                    data-testid={`${testId}-hide`}
+                  >
+                    <CollapseMinus />
+                    Hide
+                  </Button>
+                </div>
+              </>
+            ) : (
+              <>
+                <div className="float-right">
+                  <Button
+                    size="sm"
+                    variant="outline-primary"
+                    data-testid={`${testId}-show-more`}
+                  >
+                    <ExpandPlus />
+                    Show More
+                  </Button>
+                </div>
+                <ul className="list-unstyled mb-0">
+                  {items.slice(0, maxItems).map((item) => (
+                    <li key={item.id}>{item.name}</li>
+                  ))}{" "}
+                  ...
+                </ul>
+              </>
+            )}
+          </Accordion.Toggle>
+
+          <Accordion.Collapse eventKey="0">
+            <ul className="list-unstyled mb-0">
+              {items.map((item) => (
+                <li key={item.id}>{item.name}</li>
+              ))}
+            </ul>
+          </Accordion.Collapse>
+        </Accordion>
+      )}
+
+      {items.length <= maxItems && (
+        <ul className="list-unstyled mb-0">
+          {items.map((item) => (
+            <li key={item.id}>{item.name}</li>
+          ))}
+        </ul>
+      )}
+    </>
+  );
+};
 // `<tr>`s showing optional fields that are not set are not displayed.
 
 const TableAudience = ({ experiment }: TableAudienceProps) => {
@@ -33,9 +109,6 @@ const TableAudience = ({ experiment }: TableAudienceProps) => {
     MOBILE_APPLICATIONS.includes(experiment.application);
 
   const [expand, setExpand] = useState(false);
-  const [expandLocale, setExpandLocale] = useState(false);
-  const [expandCountry, setExpandCountry] = useState(false);
-  const [expandLanguage, setExpandLanguage] = useState(false);
 
   return (
     <Card className="border-left-0 border-right-0 border-bottom-0">
@@ -83,67 +156,11 @@ const TableAudience = ({ experiment }: TableAudienceProps) => {
                   <th>Locales</th>
                   <td data-testid="experiment-locales">
                     {experiment.locales.length > 0 ? (
-                      experiment.locales.length > 10 ? (
-                        <>
-                          <Accordion>
-                            <Accordion.Toggle
-                              as={Accordion}
-                              eventKey="0"
-                              onClick={() => setExpandLocale(!expandLocale)}
-                            >
-                              {expandLocale ? (
-                                <>
-                                  <div className="float-right">
-                                    <Button
-                                      size="sm"
-                                      variant="outline-primary"
-                                      data-testid="locales-hide"
-                                    >
-                                      <CollapseMinus />
-                                      Hide
-                                    </Button>
-                                  </div>
-                                </>
-                              ) : (
-                                <>
-                                  <div className="float-right">
-                                    <Button
-                                      size="sm"
-                                      variant="outline-primary"
-                                      data-testid="locales-show-more"
-                                    >
-                                      <ExpandPlus />
-                                      Show More
-                                    </Button>
-                                  </div>
-                                  <ul className="list-unstyled mb-0">
-                                    {experiment.locales
-                                      .slice(0, 10)
-                                      .map((l) => (
-                                        <li key={l.id}>{l.name}</li>
-                                      ))}{" "}
-                                    ...
-                                  </ul>
-                                </>
-                              )}
-                            </Accordion.Toggle>
-
-                            <Accordion.Collapse eventKey="0">
-                              <ul className="list-unstyled mb-0">
-                                {experiment.locales.map((l) => (
-                                  <li key={l.id}>{l.name}</li>
-                                ))}
-                              </ul>
-                            </Accordion.Collapse>
-                          </Accordion>
-                        </>
-                      ) : (
-                        <ul className="list-unstyled mb-0">
-                          {experiment.locales.map((l) => (
-                            <li key={l.id}>{l.name}</li>
-                          ))}
-                        </ul>
-                      )
+                      <ListWithShowMore
+                        items={experiment.locales}
+                        maxItems={10}
+                        testId="locales"
+                      />
                     ) : (
                       "All locales"
                     )}
@@ -155,136 +172,25 @@ const TableAudience = ({ experiment }: TableAudienceProps) => {
                   <th>Languages</th>
                   <td data-testid="experiment-languages">
                     {experiment.languages.length > 0 ? (
-                      experiment.languages.length > 10 ? (
-                        <>
-                          <Accordion>
-                            <Accordion.Toggle
-                              as={Accordion}
-                              eventKey="0"
-                              onClick={() => setExpandLanguage(!expandLanguage)}
-                            >
-                              {expandLanguage ? (
-                                <>
-                                  <div className="float-right">
-                                    <Button
-                                      size="sm"
-                                      variant="outline-primary"
-                                      data-testid="languages-hide"
-                                    >
-                                      <CollapseMinus />
-                                      Hide
-                                    </Button>
-                                  </div>
-                                </>
-                              ) : (
-                                <>
-                                  <div className="float-right">
-                                    <Button
-                                      size="sm"
-                                      variant="outline-primary"
-                                      data-testid="languages-show-more"
-                                    >
-                                      <ExpandPlus />
-                                      Show More
-                                    </Button>
-                                  </div>
-                                  <ul className="list-unstyled mb-0">
-                                    {experiment.languages
-                                      .slice(0, 10)
-                                      .map((l) => (
-                                        <li key={l.id}>{l.name}</li>
-                                      ))}{" "}
-                                    ...
-                                  </ul>
-                                </>
-                              )}
-                            </Accordion.Toggle>
-
-                            <Accordion.Collapse eventKey="0">
-                              <ul className="list-unstyled mb-0">
-                                {experiment.languages.map((l) => (
-                                  <li key={l.id}>{l.name}</li>
-                                ))}
-                              </ul>
-                            </Accordion.Collapse>
-                          </Accordion>
-                        </>
-                      ) : (
-                        <ul className="list-unstyled mb-0">
-                          {experiment.languages.map((l) => (
-                            <li key={l.id}>{l.name}</li>
-                          ))}
-                        </ul>
-                      )
+                      <ListWithShowMore
+                        items={experiment.languages}
+                        maxItems={10}
+                        testId="languages"
+                      />
                     ) : (
                       "All Languages"
                     )}
                   </td>
                 </>
               )}
-
               <th>Countries</th>
               <td data-testid="experiment-countries">
                 {experiment.countries.length > 0 ? (
-                  experiment.countries.length > 10 ? (
-                    <>
-                      <Accordion>
-                        <Accordion.Toggle
-                          as={Accordion}
-                          eventKey="0"
-                          onClick={() => setExpandCountry(!expandCountry)}
-                        >
-                          {expandCountry ? (
-                            <>
-                              <div className="float-right">
-                                <Button
-                                  size="sm"
-                                  variant="outline-primary"
-                                  data-testid="countries-hide"
-                                >
-                                  <CollapseMinus />
-                                  Hide
-                                </Button>
-                              </div>
-                            </>
-                          ) : (
-                            <>
-                              <div className="float-right">
-                                <Button
-                                  size="sm"
-                                  variant="outline-primary"
-                                  data-testid="countries-show-more"
-                                >
-                                  <ExpandPlus />
-                                  Show More
-                                </Button>
-                              </div>
-                              <ul className="list-unstyled mb-0">
-                                {experiment.countries.slice(0, 10).map((l) => (
-                                  <li key={l.id}>{l.name}</li>
-                                ))}{" "}
-                                ...
-                              </ul>
-                            </>
-                          )}
-                        </Accordion.Toggle>
-
-                        <Accordion.Collapse eventKey="0">
-                          <ul className="list-unstyled mb-0">
-                            {experiment.countries.map((l) => (
-                              <li key={l.id}>{l.name}</li>
-                            ))}
-                          </ul>
-                        </Accordion.Collapse>
-                      </Accordion>
-                    </>
-                  ) : (
-                    <ul className="list-unstyled mb-0">
-                      {experiment.countries.map((l) => (
-                        <li key={l.id}>{l.name}</li>
-                      ))}
-                    </ul>
-                  )
+                  <ListWithShowMore
+                    items={experiment.countries}
+                    maxItems={10}
+                    testId="countries"
+                  />
                 ) : (
                   "All countries"
                 )}
@@ -439,6 +345,7 @@ interface ExperimentListProps {
     branchSlug: string | null;
   }[];
 }
+
 function ExperimentList({ experimentsBranches }: ExperimentListProps) {
   if (experimentsBranches.length === 0) {
     return <span>None</span>;


### PR DESCRIPTION
Because

- Sometimes locales, languages, and countries lists are so extensive that we have to scroll a page. For example https://experimenter.services.mozilla.com/nimbus/private-window-visual-refresh/summary

This commit

- Collapsible locales, languages and countries option if user have selected more than 10

Fixes #10312 

Example 
- Less than 10
<img width="1433" alt="Screenshot 2024-03-15 at 9 29 34 AM" src="https://github.com/mozilla/experimenter/assets/25848231/08f66131-04bb-4e59-a2ec-f08e5a44c32d">

- More than 10
<img width="1433" alt="Screenshot 2024-03-15 at 9 32 24 AM" src="https://github.com/mozilla/experimenter/assets/25848231/c362482f-5bc9-475e-9f7c-e1d03f624740">
<img width="1433" alt="Screenshot 2024-03-15 at 9 32 34 AM" src="https://github.com/mozilla/experimenter/assets/25848231/f8179042-d59d-4a8f-a9a9-5be9d6422904">
