### PR TITLE
feat(nimbus): cache v6 api

### DIFF
--- a/experimenter/experimenter/experiments/api/v6/views.py
+++ b/experimenter/experimenter/experiments/api/v6/views.py
@@ -1,3 +1,6 @@
+from django.conf import settings
+from django.utils.decorators import method_decorator
+from django.views.decorators.cache import cache_page
 from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework import mixins, viewsets
 
@@ -19,6 +22,10 @@ class NimbusExperimentViewSet(
     serializer_class = NimbusExperimentSerializer
     filter_backends = [DjangoFilterBackend]
     filterset_fields = ["is_first_run"]
+
+    @method_decorator(cache_page(settings.V6_API_CACHE_DURATION))
+    def dispatch(self, request, *args, **kwargs):
+        return super().dispatch(request, *args, **kwargs)
 
 
 class NimbusExperimentDraftViewSet(NimbusExperimentViewSet):

--- a/experimenter/experimenter/experiments/tests/api/v6/test_views.py
+++ b/experimenter/experimenter/experiments/tests/api/v6/test_views.py
@@ -1,6 +1,7 @@
 import json
 
-from django.test import TestCase
+from django.core.cache import cache
+from django.test import TestCase, override_settings
 from django.urls import reverse
 
 from experimenter.experiments.api.v6.serializers import NimbusExperimentSerializer
@@ -8,7 +9,20 @@ from experimenter.experiments.models import NimbusExperiment
 from experimenter.experiments.tests.factories import NimbusExperimentFactory
 
 
-class TestNimbusExperimentViewSet(TestCase):
+@override_settings(
+    CACHES={
+        "default": {
+            "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        }
+    }
+)
+class CachedViewSetTest(TestCase):
+    def setUp(self):
+        super().setUp()
+        cache.clear()
+
+
+class TestNimbusExperimentViewSet(CachedViewSetTest):
     maxDiff = None
 
     def test_list_view_serializes_experiments(self):
@@ -74,7 +88,7 @@ class TestNimbusExperimentViewSet(TestCase):
         self.assertEqual(json_data[0]["slug"], first_run_experiment.slug)
 
 
-class TestNimbusExperimentDraftViewSet(TestCase):
+class TestNimbusExperimentDraftViewSet(CachedViewSetTest):
     maxDiff = None
 
     def test_detail_view_serializes_draft_experiments(self):
@@ -150,7 +164,7 @@ class TestNimbusExperimentDraftViewSet(TestCase):
         self.assertEqual(slugs, ["localized_experiment"])
 
 
-class TestNimbusExperimentFirstRunViewSet(TestCase):
+class TestNimbusExperimentFirstRunViewSet(CachedViewSetTest):
     maxDiff = None
 
     def test_list_view_serializes_live_first_run_experiments(self):

--- a/experimenter/experimenter/settings.py
+++ b/experimenter/experimenter/settings.py
@@ -357,6 +357,7 @@ CACHES = {
         "TIMEOUT": None,
     },
 }
+V6_API_CACHE_DURATION = 60 * 60
 SIZING_DATA_KEY = "population_sizing"
 
 # Celery


### PR DESCRIPTION
Because

* There are now many callers for the V6 API
* It can be very slow when fetching and serializing all experiments

This commit

* Caches the V6 API for 60 minutes

fixes #10423

