### PR TITLE
feat(nimbus): use v3 results for pairwise data

### DIFF
--- a/experimenter/experimenter/experiments/models.py
+++ b/experimenter/experimenter/experiments/models.py
@@ -914,8 +914,8 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
     @property
     def has_displayable_results(self):
         # True if self.results_data has weekly or overall results
-        if self.results_data and "v2" in self.results_data:
-            results_data = self.results_data["v2"]
+        if self.results_data and "v3" in self.results_data:
+            results_data = self.results_data["v3"]
             for window in ["overall", "weekly"]:
                 if window in results_data:
                     enrollments = results_data[window].get("enrollments", {}).get("all")

--- a/experimenter/experimenter/experiments/tests/test_models.py
+++ b/experimenter/experimenter/experiments/tests/test_models.py
@@ -1767,8 +1767,8 @@ class TestNimbusExperiment(TestCase):
 
     @parameterized.expand(
         [
-            ({"v2": {"overall": {"enrollments": {"all": {}}}}},),
-            ({"v2": {"weekly": {"enrollments": {"all": {}}}}},),
+            ({"v3": {"overall": {"enrollments": {"all": {}}}}},),
+            ({"v3": {"weekly": {"enrollments": {"all": {}}}}},),
         ]
     )
     def test_has_displayable_results_true(self, results_data):
@@ -1781,13 +1781,13 @@ class TestNimbusExperiment(TestCase):
     @parameterized.expand(
         [
             ({},),
-            ({"v2": {}},),
-            ({"v2": {"overall": {}}},),
-            ({"v2": {"weekly": {}}},),
-            ({"v2": {"overall": {"enrollments": {}}}},),
-            ({"v2": {"weekly": {"enrollments": {}}}},),
-            ({"v2": {"overall": {"enrollments": {"all": None}}}},),
-            ({"v2": {"weekly": {"enrollments": {"all": None}}}},),
+            ({"v3": {}},),
+            ({"v3": {"overall": {}}},),
+            ({"v3": {"weekly": {}}},),
+            ({"v3": {"overall": {"enrollments": {}}}},),
+            ({"v3": {"weekly": {"enrollments": {}}}},),
+            ({"v3": {"overall": {"enrollments": {"all": None}}}},),
+            ({"v3": {"weekly": {"enrollments": {"all": None}}}},),
         ]
     )
     def test_has_displayable_results_false(self, results_data):
@@ -1802,7 +1802,7 @@ class TestNimbusExperiment(TestCase):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             lifecycle, start_date=datetime.date(2020, 1, 1), proposed_enrollment=2
         )
-        experiment.results_data = {"v2": {"overall": {"enrollments": {"all": {}}}}}
+        experiment.results_data = {"v3": {"overall": {"enrollments": {"all": {}}}}}
         experiment.is_rollout = False
         experiment.save()
 
@@ -1812,12 +1812,12 @@ class TestNimbusExperiment(TestCase):
         [
             ({}, datetime.date(2020, 1, 1), False),
             (
-                {"v2": {"overall": {"enrollments": {"all": {}}}}},
+                {"v3": {"overall": {"enrollments": {"all": {}}}}},
                 datetime.date.today(),
                 False,
             ),
             (
-                {"v2": {"overall": {"enrollments": {"all": {}}}}},
+                {"v3": {"overall": {"enrollments": {"all": {}}}}},
                 datetime.date(2020, 1, 1),
                 True,
             ),

--- a/experimenter/experimenter/nimbus-ui/src/components/AppLayoutSidebarLaunched/index.test.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/AppLayoutSidebarLaunched/index.test.tsx
@@ -174,7 +174,6 @@ describe("AppLayoutSidebarLaunched", () => {
         <Subject
           analysis={{
             show_analysis: true,
-            daily: null,
             weekly: null,
             overall: null,
             errors: null,

--- a/experimenter/experimenter/nimbus-ui/src/components/PageResults/GraphsWeekly/index.test.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageResults/GraphsWeekly/index.test.tsx
@@ -21,6 +21,7 @@ describe("GraphsWeekly", () => {
           outcomeSlug="feature_d"
           outcomeName="Feature D"
           group={GROUP.OTHER}
+          referenceBranch="control"
         />
       </RouterSlugProvider>,
     );

--- a/experimenter/experimenter/nimbus-ui/src/components/PageResults/GraphsWeekly/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageResults/GraphsWeekly/index.tsx
@@ -32,6 +32,7 @@ const getMergedBranchData = (
   outcomeSlug: string,
   group: string,
   weeklyResults: { [branch: string]: BranchDescription },
+  referenceBranch: string,
 ) => {
   const mergedBranchData: { [graphID: string]: FormattedAnalysisPoint[] } = {};
   let maxWeeks = 0;
@@ -39,10 +40,11 @@ const getMergedBranchData = (
     if (outcomeSlug in weeklyResults[branch].branch_data[group]) {
       Object.values(BRANCH_COMPARISON).forEach((branchComparison) => {
         const graphID = getGraphID(outcomeSlug, branchComparison);
+        const groupData = weeklyResults[branch].branch_data[group][outcomeSlug];
         const branchData =
-          weeklyResults[branch].branch_data[group][outcomeSlug][
-            branchComparison
-          ].all;
+          branchComparison === BRANCH_COMPARISON.ABSOLUTE
+            ? groupData[branchComparison].all
+            : groupData[branchComparison][referenceBranch].all;
         branchData.forEach((dataPoint: FormattedAnalysisPoint) => {
           dataPoint["branch"] = branch;
           const weekIndex: number =
@@ -89,6 +91,7 @@ type GraphsWeeklyProps = {
   outcomeSlug: string;
   outcomeName: string;
   group: string;
+  referenceBranch: string;
 };
 
 const GraphsWeekly = ({
@@ -96,11 +99,13 @@ const GraphsWeekly = ({
   outcomeSlug,
   outcomeName,
   group,
+  referenceBranch,
 }: GraphsWeeklyProps) => {
   const mergedBranchData = getMergedBranchData(
     outcomeSlug,
     group,
     weeklyResults.all!,
+    referenceBranch,
   );
 
   const [open, setOpen] = useState(false);

--- a/experimenter/experimenter/nimbus-ui/src/components/PageResults/TableHighlights/index.test.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageResults/TableHighlights/index.test.tsx
@@ -16,7 +16,10 @@ describe("TableHighlights", () => {
     render(
       <RouterSlugProvider mocks={[mock]}>
         <MockResultsContextProvider>
-          <TableHighlights {...{ experiment }} />
+          <TableHighlights
+            {...{ experiment }}
+            referenceBranch={experiment.referenceBranch!.slug}
+          />
         </MockResultsContextProvider>
       </RouterSlugProvider>,
     );
@@ -33,7 +36,10 @@ describe("TableHighlights", () => {
     render(
       <RouterSlugProvider mocks={[mock]}>
         <MockResultsContextProvider>
-          <TableHighlights {...{ experiment }} />
+          <TableHighlights
+            {...{ experiment }}
+            referenceBranch={experiment.referenceBranch!.slug}
+          />
         </MockResultsContextProvider>
       </RouterSlugProvider>,
     );
@@ -45,7 +51,10 @@ describe("TableHighlights", () => {
     render(
       <RouterSlugProvider mocks={[mock]}>
         <MockResultsContextProvider>
-          <TableHighlights {...{ experiment }} />
+          <TableHighlights
+            {...{ experiment }}
+            referenceBranch={experiment.referenceBranch!.slug}
+          />
         </MockResultsContextProvider>
       </RouterSlugProvider>,
     );
@@ -59,7 +68,10 @@ describe("TableHighlights", () => {
     render(
       <RouterSlugProvider mocks={[mock]}>
         <MockResultsContextProvider>
-          <TableHighlights {...{ experiment }} />
+          <TableHighlights
+            {...{ experiment }}
+            referenceBranch={experiment.referenceBranch!.slug}
+          />
         </MockResultsContextProvider>
       </RouterSlugProvider>,
     );
@@ -72,7 +84,10 @@ describe("TableHighlights", () => {
     render(
       <RouterSlugProvider mocks={[mock]}>
         <MockResultsContextProvider>
-          <TableHighlights {...{ experiment }} />
+          <TableHighlights
+            {...{ experiment }}
+            referenceBranch={experiment.referenceBranch!.slug}
+          />
         </MockResultsContextProvider>
       </RouterSlugProvider>,
     );
@@ -88,6 +103,7 @@ describe("TableHighlights", () => {
           <TableHighlights
             {...{ experiment }}
             branchComparison={BRANCH_COMPARISON.ABSOLUTE}
+            referenceBranch={experiment.referenceBranch!.slug}
           />
         </MockResultsContextProvider>
       </RouterSlugProvider>,

--- a/experimenter/experimenter/nimbus-ui/src/components/PageResults/TableHighlights/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageResults/TableHighlights/index.tsx
@@ -33,6 +33,7 @@ export type TableHighlightsProps = {
   branchComparison?: BranchComparisonValues;
   analysisBasis?: AnalysisBases;
   segment?: string;
+  referenceBranch: string;
 };
 
 type Branch =
@@ -91,6 +92,7 @@ const TableHighlights = ({
   branchComparison = BRANCH_COMPARISON.UPLIFT,
   analysisBasis = "enrollments",
   segment = "all",
+  referenceBranch,
 }: TableHighlightsProps) => {
   const { primaryOutcomes } = useOutcomes(experiment);
   const highlightMetricsList = getHighlightMetrics(
@@ -104,7 +106,6 @@ const TableHighlights = ({
   const {
     analysis: { metadata, overall },
     sortedBranchNames,
-    controlBranchName,
   } = useContext(ResultsContext);
   const overallResults = overall![analysisBasis]?.[segment]!;
 
@@ -118,7 +119,7 @@ const TableHighlights = ({
             ];
           const participantCount =
             userCountMetric[BRANCH_COMPARISON.ABSOLUTE]["first"]["point"];
-          const isControlBranch = branch === controlBranchName;
+          const isReferenceBranch = branch === referenceBranch;
 
           return (
             <tr key={branch} className="border-top">
@@ -132,7 +133,7 @@ const TableHighlights = ({
               <td className="p-3 col-md-4 align-middle">
                 {branchDescriptions[branch]}
               </td>
-              {isControlBranch &&
+              {isReferenceBranch &&
               branchComparison === BRANCH_COMPARISON.UPLIFT ? (
                 <td className="p-3 align-middle">
                   <div className="font-italic align-middle">---baseline---</div>
@@ -159,9 +160,10 @@ const TableHighlights = ({
                           metricKey,
                           displayType,
                           tooltip,
-                          isControlBranch,
                           branchComparison,
                         }}
+                        isControlBranch={isReferenceBranch}
+                        referenceBranch={referenceBranch}
                       />
                     );
                   })}

--- a/experimenter/experimenter/nimbus-ui/src/components/PageResults/TableMetricConversion/index.test.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageResults/TableMetricConversion/index.test.tsx
@@ -25,7 +25,11 @@ describe("TableMetricConversion", () => {
     render(
       <MockResultsContextProvider>
         <RouterSlugProvider mocks={[mock]}>
-          <TableMetricConversion outcome={primaryOutcomes![0]!} segment="all" />
+          <TableMetricConversion
+            outcome={primaryOutcomes![0]!}
+            segment="all"
+            referenceBranch={experiment.referenceBranch!.slug}
+          />
         </RouterSlugProvider>
       </MockResultsContextProvider>,
     );
@@ -42,7 +46,11 @@ describe("TableMetricConversion", () => {
     render(
       <MockResultsContextProvider>
         <RouterSlugProvider mocks={[mock]}>
-          <TableMetricConversion outcome={primaryOutcomes![0]!} segment="all" />
+          <TableMetricConversion
+            outcome={primaryOutcomes![0]!}
+            segment="all"
+            referenceBranch={experiment.referenceBranch!.slug}
+          />
         </RouterSlugProvider>
       </MockResultsContextProvider>,
     );
@@ -62,7 +70,11 @@ describe("TableMetricConversion", () => {
     render(
       <MockResultsContextProvider>
         <RouterSlugProvider mocks={[mock]}>
-          <TableMetricConversion outcome={primaryOutcomes![0]!} segment="all" />
+          <TableMetricConversion
+            outcome={primaryOutcomes![0]!}
+            segment="all"
+            referenceBranch={experiment.referenceBranch!.slug}
+          />
         </RouterSlugProvider>
       </MockResultsContextProvider>,
     );
@@ -78,7 +90,11 @@ describe("TableMetricConversion", () => {
     render(
       <MockResultsContextProvider>
         <RouterSlugProvider mocks={[mock]}>
-          <TableMetricConversion outcome={primaryOutcomes![0]!} segment="all" />
+          <TableMetricConversion
+            outcome={primaryOutcomes![0]!}
+            segment="all"
+            referenceBranch={experiment.referenceBranch!.slug}
+          />
         </RouterSlugProvider>
       </MockResultsContextProvider>,
     );
@@ -100,7 +116,11 @@ describe("TableMetricConversion", () => {
     render(
       <MockResultsContextProvider>
         <RouterSlugProvider mocks={[mock]}>
-          <TableMetricConversion outcome={primaryOutcomes![0]!} segment="all" />
+          <TableMetricConversion
+            outcome={primaryOutcomes![0]!}
+            segment="all"
+            referenceBranch={experiment.referenceBranch!.slug}
+          />
         </RouterSlugProvider>
       </MockResultsContextProvider>,
     );
@@ -122,7 +142,11 @@ describe("TableMetricConversion", () => {
     render(
       <MockResultsContextProvider>
         <RouterSlugProvider mocks={[mock]}>
-          <TableMetricConversion outcome={primaryOutcomes![0]!} segment="all" />
+          <TableMetricConversion
+            outcome={primaryOutcomes![0]!}
+            segment="all"
+            referenceBranch={experiment.referenceBranch!.slug}
+          />
         </RouterSlugProvider>
       </MockResultsContextProvider>,
     );

--- a/experimenter/experimenter/nimbus-ui/src/components/PageResults/TableMetricConversion/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageResults/TableMetricConversion/index.tsx
@@ -29,6 +29,7 @@ type TableMetricConversionProps = {
   outcome: getConfig_nimbusConfig_outcomes;
   analysisBasis?: AnalysisBases;
   segment?: string;
+  referenceBranch: string;
 };
 
 const getStatistics = (slug: string): Array<ConversionMetricStatistic> => {
@@ -49,11 +50,11 @@ const TableMetricConversion = ({
   outcome,
   analysisBasis = "enrollments",
   segment = "all",
+  referenceBranch,
 }: TableMetricConversionProps) => {
   const {
     analysis: { overall },
     sortedBranchNames,
-    controlBranchName,
   } = useContext(ResultsContext);
   const overallResults = overall![analysisBasis]?.[segment]!;
   const conversionMetricStatistics = getStatistics(outcome.slug!);
@@ -64,6 +65,7 @@ const TableMetricConversion = ({
     outcome.slug!,
     GROUP.OTHER,
     segment,
+    referenceBranch,
   );
 
   return (
@@ -88,7 +90,7 @@ const TableMetricConversion = ({
         </thead>
         <tbody>
           {Object.keys(overallResults).map((branch) => {
-            const isControlBranch = branch === controlBranchName;
+            const isReferenceBranch = branch === referenceBranch;
             return (
               <tr key={branch}>
                 <th className="align-middle" scope="row">
@@ -106,8 +108,9 @@ const TableMetricConversion = ({
                         displayType,
                         branchComparison,
                         bounds,
-                        isControlBranch,
                       }}
+                      isControlBranch={isReferenceBranch}
+                      referenceBranch={referenceBranch}
                     />
                   ),
                 )}

--- a/experimenter/experimenter/nimbus-ui/src/components/PageResults/TableMetricCount/index.test.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageResults/TableMetricCount/index.test.tsx
@@ -27,6 +27,7 @@ describe("TableMetricCount", () => {
             outcomeDefaultName={secondaryOutcomes![0]!.friendlyName!}
             metricType={METRIC_TYPE.USER_SELECTED_SECONDARY}
             group={GROUP.OTHER}
+            referenceBranch={experiment.referenceBranch!.slug}
           />
         </MockResultsContextProvider>
       </RouterSlugProvider>,
@@ -49,6 +50,7 @@ describe("TableMetricCount", () => {
             outcomeDefaultName={secondaryOutcomes![0]!.friendlyName!}
             group={GROUP.OTHER}
             metricType={METRIC_TYPE.USER_SELECTED_SECONDARY}
+            referenceBranch={experiment.referenceBranch!.slug}
           />
         </MockResultsContextProvider>
       </RouterSlugProvider>,
@@ -74,6 +76,7 @@ describe("TableMetricCount", () => {
             outcomeDefaultName={secondaryOutcomes![0]!.friendlyName!}
             group={GROUP.OTHER}
             metricType={METRIC_TYPE.USER_SELECTED_SECONDARY}
+            referenceBranch={experiment.referenceBranch!.slug}
           />
         </MockResultsContextProvider>
       </RouterSlugProvider>,
@@ -95,6 +98,7 @@ describe("TableMetricCount", () => {
             outcomeDefaultName={secondaryOutcomes![0]!.friendlyName!}
             group={GROUP.OTHER}
             metricType={METRIC_TYPE.USER_SELECTED_SECONDARY}
+            referenceBranch={experiment.referenceBranch!.slug}
           />
         </MockResultsContextProvider>
       </RouterSlugProvider>,
@@ -120,6 +124,7 @@ describe("TableMetricCount", () => {
             outcomeDefaultName={secondaryOutcomes![0]!.friendlyName!}
             group={GROUP.OTHER}
             metricType={METRIC_TYPE.USER_SELECTED_SECONDARY}
+            referenceBranch={experiment.referenceBranch!.slug}
           />
         </MockResultsContextProvider>
       </RouterSlugProvider>,
@@ -141,6 +146,7 @@ describe("TableMetricCount", () => {
             outcomeDefaultName={secondaryOutcomes![0]!.friendlyName!}
             group={GROUP.OTHER}
             metricType={METRIC_TYPE.USER_SELECTED_SECONDARY}
+            referenceBranch={experiment.referenceBranch!.slug}
           />
         </MockResultsContextProvider>
       </RouterSlugProvider>,

--- a/experimenter/experimenter/nimbus-ui/src/components/PageResults/TableMetricCount/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageResults/TableMetricCount/index.tsx
@@ -39,6 +39,7 @@ type TableMetricCountProps = {
   metricType?: MetricTypes;
   analysisBasis?: AnalysisBases;
   segment?: string;
+  referenceBranch: string;
 };
 
 const getStatistics = (slug: string): Array<CountMetricStatistic> => {
@@ -60,12 +61,12 @@ const TableMetricCount = ({
   metricType = METRIC_TYPE.DEFAULT_SECONDARY,
   analysisBasis = "enrollments",
   segment = "all",
+  referenceBranch,
 }: TableMetricCountProps) => {
   const countMetricStatistics = getStatistics(outcomeSlug);
   const {
     analysis: { metadata, overall, weekly },
     sortedBranchNames,
-    controlBranchName,
   } = useContext(ResultsContext);
   const overallResults = overall![analysisBasis]?.[segment]!;
   const weeklyBasis = weekly![analysisBasis];
@@ -76,6 +77,7 @@ const TableMetricCount = ({
     outcomeSlug,
     group,
     segment,
+    referenceBranch,
   );
   const outcomeName =
     metadata?.metrics[outcomeSlug]?.friendly_name || outcomeDefaultName;
@@ -106,7 +108,7 @@ const TableMetricCount = ({
         <tbody>
           {group &&
             sortedBranchNames.map((branch) => {
-              const isControlBranch = branch === controlBranchName;
+              const isReferenceBranch = branch === referenceBranch;
               return (
                 overallResults[branch].branch_data[group] && (
                   <tr key={`${branch}-${group}`}>
@@ -125,8 +127,9 @@ const TableMetricCount = ({
                             branchComparison,
                             bounds,
                             group,
-                            isControlBranch,
                           }}
+                          isControlBranch={isReferenceBranch}
+                          referenceBranch={referenceBranch}
                         />
                       ),
                     )}
@@ -139,6 +142,7 @@ const TableMetricCount = ({
       {weeklyBasis?.all && (
         <GraphsWeekly
           weeklyResults={weeklyBasis}
+          referenceBranch={referenceBranch}
           {...{ outcomeSlug, outcomeName, group }}
         />
       )}

--- a/experimenter/experimenter/nimbus-ui/src/components/PageResults/TableResults/index.test.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageResults/TableResults/index.test.tsx
@@ -18,7 +18,10 @@ describe("TableResults", () => {
     render(
       <RouterSlugProvider mocks={[mock]}>
         <MockResultsContextProvider>
-          <TableResults {...{ experiment }} />
+          <TableResults
+            {...{ experiment }}
+            referenceBranch={experiment.referenceBranch!.slug}
+          />
         </MockResultsContextProvider>
       </RouterSlugProvider>,
     );
@@ -41,7 +44,10 @@ describe("TableResults", () => {
     render(
       <RouterSlugProvider mocks={[mock]}>
         <MockResultsContextProvider>
-          <TableResults experiment={ios_experiment} />
+          <TableResults
+            experiment={ios_experiment}
+            referenceBranch={experiment.referenceBranch!.slug}
+          />
         </MockResultsContextProvider>
       </RouterSlugProvider>,
     );
@@ -61,7 +67,10 @@ describe("TableResults", () => {
     render(
       <RouterSlugProvider mocks={[mock]}>
         <MockResultsContextProvider>
-          <TableResults {...{ experiment }} />
+          <TableResults
+            {...{ experiment }}
+            referenceBranch={experiment.referenceBranch!.slug}
+          />
         </MockResultsContextProvider>
       </RouterSlugProvider>,
     );
@@ -84,6 +93,7 @@ describe("TableResults", () => {
           <TableResults
             {...{ experiment }}
             branchComparison={BRANCH_COMPARISON.ABSOLUTE}
+            referenceBranch={experiment.referenceBranch!.slug}
           />
         </MockResultsContextProvider>
       </RouterSlugProvider>,
@@ -105,6 +115,7 @@ describe("TableResults", () => {
           <TableResults
             {...{ experiment }}
             branchComparison={BRANCH_COMPARISON.ABSOLUTE}
+            referenceBranch={experiment.referenceBranch!.slug}
           />
         </MockResultsContextProvider>
       </RouterSlugProvider>,
@@ -118,7 +129,10 @@ describe("TableResults", () => {
     render(
       <RouterSlugProvider mocks={[mock]}>
         <MockResultsContextProvider analysis={mockIncompleteAnalysis()}>
-          <TableResults {...{ experiment }} />
+          <TableResults
+            {...{ experiment }}
+            referenceBranch={experiment.referenceBranch!.slug}
+          />
         </MockResultsContextProvider>
       </RouterSlugProvider>,
     );

--- a/experimenter/experimenter/nimbus-ui/src/components/PageResults/TableResults/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageResults/TableResults/index.tsx
@@ -32,6 +32,7 @@ export type TableResultsProps = {
   analysisBasis?: AnalysisBases;
   segment?: string;
   isDesktop?: boolean;
+  referenceBranch: string;
 };
 
 const getResultMetrics = (outcomes: OutcomesList, isDesktop = false) => {
@@ -70,6 +71,7 @@ const TableResults = ({
   analysisBasis = "enrollments",
   segment = "all",
   isDesktop = false,
+  referenceBranch,
 }: TableResultsProps) => {
   const { primaryOutcomes } = useOutcomes(experiment);
   const resultsMetricsList = getResultMetrics(
@@ -80,7 +82,6 @@ const TableResults = ({
   const {
     analysis: { metadata, overall },
     sortedBranchNames,
-    controlBranchName,
   } = useContext(ResultsContext);
   const overallResults = overall![analysisBasis]?.[segment]!;
 
@@ -122,7 +123,7 @@ const TableResults = ({
       </thead>
       <tbody>
         {sortedBranchNames.map((branch) => {
-          const isControlBranch = branch === controlBranchName;
+          const isReferenceBranch = branch === referenceBranch;
           return (
             <tr key={branch}>
               <th className="align-middle" scope="row">
@@ -145,8 +146,9 @@ const TableResults = ({
                       metricKey,
                       displayType,
                       branchComparison,
-                      isControlBranch,
                     }}
+                    isControlBranch={isReferenceBranch}
+                    referenceBranch={referenceBranch}
                   />
                 );
               })}

--- a/experimenter/experimenter/nimbus-ui/src/components/PageResults/TableResultsWeekly/index.test.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageResults/TableResultsWeekly/index.test.tsx
@@ -12,7 +12,7 @@ describe("TableResultsWeekly", () => {
   it("renders as expected with relative uplift branch comparison (default)", () => {
     render(
       <MockResultsContextProvider>
-        <TableResultsWeekly />,
+        <TableResultsWeekly referenceBranch="control" />,
       </MockResultsContextProvider>,
     );
 
@@ -38,7 +38,10 @@ describe("TableResultsWeekly", () => {
   it("renders as expected with absolute branch comparison", () => {
     render(
       <MockResultsContextProvider>
-        <TableResultsWeekly branchComparison={BRANCH_COMPARISON.ABSOLUTE} />
+        <TableResultsWeekly
+          branchComparison={BRANCH_COMPARISON.ABSOLUTE}
+          referenceBranch="control"
+        />
       </MockResultsContextProvider>,
     );
 
@@ -53,7 +56,7 @@ describe("TableResultsWeekly", () => {
 
     render(
       <MockResultsContextProvider>
-        <TableResultsWeekly />,
+        <TableResultsWeekly referenceBranch="control" />,
       </MockResultsContextProvider>,
     );
 

--- a/experimenter/experimenter/nimbus-ui/src/components/PageResults/TableResultsWeekly/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageResults/TableResultsWeekly/index.tsx
@@ -27,6 +27,7 @@ export type TableResultsWeeklyProps = {
   analysisBasis?: AnalysisBases;
   segment?: string;
   isDesktop?: boolean;
+  referenceBranch: string;
 };
 
 const getHighlightMetrics = (isDesktop = false) => {
@@ -54,6 +55,7 @@ const TableResultsWeekly = ({
   analysisBasis = "enrollments",
   segment = "all",
   isDesktop = false,
+  referenceBranch,
 }: TableResultsWeeklyProps) => {
   const {
     analysis: { overall },
@@ -108,6 +110,7 @@ const TableResultsWeekly = ({
                   {...{ branchComparison }}
                   analysisBasis={analysisBasis}
                   segment={segment}
+                  referenceBranch={referenceBranch}
                 />
               </div>
             );

--- a/experimenter/experimenter/nimbus-ui/src/components/PageResults/TableVisualizationRow/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageResults/TableVisualizationRow/index.tsx
@@ -1,10 +1,11 @@
-import React from "react";
+import React, { useContext } from "react";
 import ReactTooltip from "react-tooltip";
 import ConfidenceInterval from "src/components/PageResults/ConfidenceInterval";
 import { ReactComponent as SignificanceNegative } from "src/components/PageResults/TableVisualizationRow/significance-negative.svg";
 import { ReactComponent as SignificanceNeutral } from "src/components/PageResults/TableVisualizationRow/significance-neutral.svg";
 import { ReactComponent as SignificancePositive } from "src/components/PageResults/TableVisualizationRow/significance-positive.svg";
 import TooltipWithMarkdown from "src/components/PageResults/TooltipWithMarkdown";
+import { ResultsContext } from "src/lib/contexts";
 import {
   BRANCH_COMPARISON,
   DISPLAY_TYPE,
@@ -30,6 +31,7 @@ const showSignificanceField = (
   tableLabel: string,
   tooltip: string,
   isControlBranch: boolean,
+  referenceBranch: string,
   branchComparison?: BranchComparisonValues,
 ) => {
   let significanceIcon,
@@ -54,7 +56,7 @@ const showSignificanceField = (
       significanceIcon = (
         <SignificanceNeutral data-tip={SIGNIFICANCE_TIPS.NEUTRAL} />
       );
-      changeText = "is similar to control";
+      changeText = `is similar to ${referenceBranch}`;
       break;
   }
 
@@ -132,6 +134,7 @@ const countField = (
   tableLabel: string,
   tooltip: string,
   isControlBranch: boolean,
+  referenceBranch: string,
   branchComparison: BranchComparisonValues,
 ) => {
   const interval = `${lower.toFixed(2)} to ${upper.toFixed(2)}`;
@@ -142,6 +145,7 @@ const countField = (
     tableLabel,
     tooltip,
     isControlBranch,
+    referenceBranch,
     branchComparison,
   );
 };
@@ -154,6 +158,7 @@ const percentField = (
   tableLabel: string,
   tooltip: string,
   isControlBranch: boolean,
+  referenceBranch: string,
   branchComparison?: BranchComparisonValues,
 ) => {
   const interval = `${Math.round(lower * 1000) / 10}% to ${
@@ -166,6 +171,7 @@ const percentField = (
     tableLabel,
     tooltip,
     isControlBranch,
+    referenceBranch,
     branchComparison,
   );
 };
@@ -192,6 +198,7 @@ const TableVisualizationRow: React.FC<{
   tooltip?: string;
   window?: string;
   bounds?: number;
+  referenceBranch: string;
 }> = ({
   metricKey,
   results,
@@ -204,10 +211,12 @@ const TableVisualizationRow: React.FC<{
   tooltip = "",
   window = "overall",
   bounds = 0.05,
+  referenceBranch = "",
 }) => {
   const { branch_data } = results;
   const metricData = branch_data[group][metricKey];
   const fieldList = [];
+  const { controlBranchName } = useContext(ResultsContext);
 
   let field = <>{metricName} is not available</>;
   let tooltipText =
@@ -223,16 +232,23 @@ const TableVisualizationRow: React.FC<{
       branch_data[GROUP.OTHER][METRIC.USER_COUNT][BRANCH_COMPARISON.ABSOLUTE][
         "all"
       ];
-    const metricDataList = metricData[branchComparison]["all"];
+    const metricDataList =
+      branchComparison === BRANCH_COMPARISON.ABSOLUTE
+        ? metricData[branchComparison]["all"]
+        : metricData[branchComparison][referenceBranch]?.["all"];
 
-    userCountsList.sort(formattedAnalysisPointComparator);
-    metricDataList.sort(formattedAnalysisPointComparator);
+    if (metricDataList && metricDataList.length > 0) {
+      userCountsList.sort(formattedAnalysisPointComparator);
+      metricDataList.sort(formattedAnalysisPointComparator);
 
-    if (metricDataList.length > 0) {
       metricDataList.forEach((dataPoint: FormattedAnalysisPoint, i: number) => {
         const { lower, upper, point, count } = dataPoint;
         const userCountMetric = userCountsList[i]["point"];
-        const significance = metricData["significance"]?.[window][i + 1];
+        const significanceIndex = `${i + 1}`;
+        const significance =
+          metricData["significance"]?.[referenceBranch]?.[window]?.[
+            significanceIndex
+          ];
 
         switch (displayType) {
           case DISPLAY_TYPE.POPULATION:
@@ -247,6 +263,7 @@ const TableVisualizationRow: React.FC<{
               tableLabel,
               tooltipText,
               isControlBranch,
+              referenceBranch,
               branchComparison,
             );
             break;
@@ -260,6 +277,7 @@ const TableVisualizationRow: React.FC<{
               tableLabel,
               tooltipText,
               isControlBranch,
+              referenceBranch,
               branchComparison,
             );
             break;
@@ -281,6 +299,7 @@ const TableVisualizationRow: React.FC<{
     ) {
       const { point } = userCountsList[0];
       field = populationField(point!, percent);
+      fieldList.push({ field, tooltipText, className });
     }
   }
   /**
@@ -292,8 +311,27 @@ const TableVisualizationRow: React.FC<{
    * should fall back to "baseline".
    *
    * In either case, we need to push the current values below to be displayed.
+   *
+   * **Addition to above**
+   * A new case where this can happen is when an experiment does not have pairwise
+   * branch comparison results, but the user has selected a non-control reference
+   * branch. This means that there will be nothing to display for the branches
+   * as they compare to the selected reference branch.
+   *
+   * For this case, the display should be similar to the relative uplift for control,
+   * but with a different message to clarify that it is not baseline.
    **/
   if (fieldList.length === 0) {
+    if (
+      branchComparison !== BRANCH_COMPARISON.ABSOLUTE &&
+      referenceBranch !== controlBranchName &&
+      !isControlBranch
+    ) {
+      field = <div>(results not available)</div>;
+      tooltipText =
+        "This is likely because pairwise branch comparison results are not available for this experiment. Please select the experiment's configured control branch to view available results, or contact #ask-experimenter to request that analysis be rerun to get pairwise branch comparison results.";
+      className = "text-danger";
+    }
     fieldList.push({ field, tooltipText, className });
   }
 

--- a/experimenter/experimenter/nimbus-ui/src/components/PageResults/TableVisualizationRow/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageResults/TableVisualizationRow/index.tsx
@@ -311,27 +311,8 @@ const TableVisualizationRow: React.FC<{
    * should fall back to "baseline".
    *
    * In either case, we need to push the current values below to be displayed.
-   *
-   * **Addition to above**
-   * A new case where this can happen is when an experiment does not have pairwise
-   * branch comparison results, but the user has selected a non-control reference
-   * branch. This means that there will be nothing to display for the branches
-   * as they compare to the selected reference branch.
-   *
-   * For this case, the display should be similar to the relative uplift for control,
-   * but with a different message to clarify that it is not baseline.
    **/
   if (fieldList.length === 0) {
-    if (
-      branchComparison !== BRANCH_COMPARISON.ABSOLUTE &&
-      referenceBranch !== controlBranchName &&
-      !isControlBranch
-    ) {
-      field = <div>(results not available)</div>;
-      tooltipText =
-        "This is likely because pairwise branch comparison results are not available for this experiment. Please select the experiment's configured control branch to view available results, or contact #ask-experimenter to request that analysis be rerun to get pairwise branch comparison results.";
-      className = "text-danger";
-    }
     fieldList.push({ field, tooltipText, className });
   }
 

--- a/experimenter/experimenter/nimbus-ui/src/components/PageResults/TableWeekly/index.test.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageResults/TableWeekly/index.test.tsx
@@ -49,6 +49,7 @@ describe("TableWeekly", () => {
             metricName="Retention"
             group={GROUP.OTHER}
             branchComparison={BRANCH_COMPARISON.UPLIFT}
+            referenceBranch="control"
           />
         </MockResultsContextProvider>
       </RouterSlugProvider>,
@@ -70,6 +71,7 @@ describe("TableWeekly", () => {
             metricKey="fake"
             metricName="Some Made Up Metric"
             group={GROUP.OTHER}
+            referenceBranch="control"
           />
         </MockResultsContextProvider>
       </RouterSlugProvider>,
@@ -103,6 +105,7 @@ describe("TableWeekly", () => {
             metricName="Retention"
             group={GROUP.OTHER}
             branchComparison={BRANCH_COMPARISON.UPLIFT}
+            referenceBranch="control"
           />
         </MockResultsContextProvider>
       </RouterSlugProvider>,

--- a/experimenter/experimenter/nimbus-ui/src/components/PageResults/TableWithTabComparison/index.test.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageResults/TableWithTabComparison/index.test.tsx
@@ -13,7 +13,13 @@ describe("TableWithTabComparison", () => {
   // to test the tab text. Comparison value tests are in table tests.
   it("toggles between absolute and relative branch comparisons", async () => {
     const { experiment } = mockExperimentQuery("demo-slug");
-    render(<Subject Table={TableHighlights} {...{ experiment }} />);
+    render(
+      <Subject
+        Table={TableHighlights}
+        {...{ experiment }}
+        referenceBranch={experiment.referenceBranch!.slug}
+      />,
+    );
 
     const relativeTab = screen.getByText("Relative uplift comparison");
     const absoluteTab = screen.getByText("Absolute comparison");

--- a/experimenter/experimenter/nimbus-ui/src/components/PageResults/TableWithTabComparison/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageResults/TableWithTabComparison/index.tsx
@@ -24,6 +24,7 @@ export type TableWithTabComparisonProps = {
   analysisBasis?: AnalysisBases;
   segment?: string;
   isDesktop?: boolean;
+  referenceBranch: string;
 };
 
 export const TableWithTabComparison = ({
@@ -33,6 +34,7 @@ export const TableWithTabComparison = ({
   analysisBasis = "enrollments",
   segment = "all",
   isDesktop = false,
+  referenceBranch,
 }: TableWithTabComparisonProps) => (
   <Tabs defaultActiveKey={BRANCH_COMPARISON.UPLIFT} className="border-bottom-0">
     <Tab eventKey={BRANCH_COMPARISON.UPLIFT} title="Relative uplift comparison">
@@ -42,6 +44,7 @@ export const TableWithTabComparison = ({
             {...{ experiment }}
             analysisBasis={analysisBasis}
             segment={segment}
+            referenceBranch={referenceBranch}
           />
         ) : (
           /* @ts-ignore - TODO, assert Table is TablesWithoutExperiment if `experiment` not provided */
@@ -49,6 +52,7 @@ export const TableWithTabComparison = ({
             analysisBasis={analysisBasis}
             segment={segment}
             isDesktop={isDesktop}
+            referenceBranch={referenceBranch}
           />
         )}
       </div>
@@ -61,6 +65,7 @@ export const TableWithTabComparison = ({
             branchComparison={BRANCH_COMPARISON.ABSOLUTE}
             analysisBasis={analysisBasis}
             segment={segment}
+            referenceBranch={referenceBranch}
           />
         ) : (
           <>
@@ -70,6 +75,7 @@ export const TableWithTabComparison = ({
               analysisBasis={analysisBasis}
               segment={segment}
               isDesktop={isDesktop}
+              referenceBranch={referenceBranch}
             />
           </>
         )}

--- a/experimenter/experimenter/nimbus-ui/src/components/PageResults/TableWithTabComparison/mocks.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageResults/TableWithTabComparison/mocks.tsx
@@ -18,7 +18,10 @@ export const Subject = ({
   return (
     <RouterSlugProvider mocks={[mock]}>
       <MockResultsContextProvider>
-        <TableWithTabComparison {...{ experiment, Table, className }} />
+        <TableWithTabComparison
+          {...{ experiment, Table, className }}
+          referenceBranch="control"
+        />
       </MockResultsContextProvider>
     </RouterSlugProvider>
   );

--- a/experimenter/experimenter/nimbus-ui/src/components/PageResults/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageResults/index.tsx
@@ -59,6 +59,9 @@ const PageResults: React.FunctionComponent<RouteComponentProps> = () => {
   const [selectedAnalysisBasis, setSelectedAnalysisBasis] =
     useState<AnalysisBases>("exposures");
 
+  const [selectedReferenceBranch, setSelectedReferenceBranch] =
+    useState<string>("");
+
   // For testing - users will be redirected if the analysis is unavailable
   // before reaching this return, but tests reach this return and
   // analysis.overall is expected to be an object (EXP-800)
@@ -70,11 +73,17 @@ const PageResults: React.FunctionComponent<RouteComponentProps> = () => {
     return null;
 
   const sortedBranchNames = getSortedBranchNames(analysis);
+  const controlBranchSlug =
+    sortedBranchNames.length > 0
+      ? sortedBranchNames[0]
+      : experiment.referenceBranch?.slug;
+  if (selectedReferenceBranch === "" && controlBranchSlug) {
+    setSelectedReferenceBranch(controlBranchSlug);
+  }
   const resultsContextValue: ResultsContextType = {
     analysis,
     sortedBranchNames,
-    controlBranchName:
-      sortedBranchNames.length > 0 ? sortedBranchNames[0] : undefined,
+    controlBranchName: controlBranchSlug || "",
   };
 
   // list of metrics (slugs) with errors that would not otherwise be displayed
@@ -387,6 +396,7 @@ const PageResults: React.FunctionComponent<RouteComponentProps> = () => {
                   className="mb-2 border-top-0"
                   analysisBasis={selectedAnalysisBasis}
                   segment={selectedSegment}
+                  referenceBranch={selectedReferenceBranch}
                 />
               )}
             <TableHighlightsOverview {...{ experiment }} />
@@ -409,6 +419,7 @@ const PageResults: React.FunctionComponent<RouteComponentProps> = () => {
                       experiment.application ===
                       NimbusExperimentApplicationEnum.DESKTOP
                     }
+                    referenceBranch={selectedReferenceBranch}
                   />
                 )}
 
@@ -425,6 +436,7 @@ const PageResults: React.FunctionComponent<RouteComponentProps> = () => {
                       experiment.application ===
                       NimbusExperimentApplicationEnum.DESKTOP
                     }
+                    referenceBranch={selectedReferenceBranch}
                   />
                 )}
             </div>
@@ -445,7 +457,7 @@ const PageResults: React.FunctionComponent<RouteComponentProps> = () => {
                       if (
                         !analysis!.overall![selectedAnalysisBasis]?.[
                           selectedSegment
-                        ]?.[resultsContextValue.controlBranchName].branch_data[
+                        ]?.[resultsContextValue.controlBranchName]?.branch_data[
                           GROUP.OTHER
                         ][metric?.slug!]
                       ) {
@@ -480,6 +492,7 @@ const PageResults: React.FunctionComponent<RouteComponentProps> = () => {
                           metricType={METRIC_TYPE.PRIMARY}
                           analysisBasis={selectedAnalysisBasis}
                           segment={selectedSegment}
+                          referenceBranch={selectedReferenceBranch}
                         />
                       );
                     });
@@ -507,6 +520,7 @@ const PageResults: React.FunctionComponent<RouteComponentProps> = () => {
                         metricType={METRIC_TYPE.DEFAULT_SECONDARY}
                         analysisBasis={selectedAnalysisBasis}
                         segment={selectedSegment}
+                        referenceBranch={selectedReferenceBranch}
                       />
                     );
                   })
@@ -568,6 +582,7 @@ const PageResults: React.FunctionComponent<RouteComponentProps> = () => {
                                   {...{ group }}
                                   analysisBasis={selectedAnalysisBasis}
                                   segment={selectedSegment}
+                                  referenceBranch={selectedReferenceBranch}
                                 />
                               ),
                             )}

--- a/experimenter/experimenter/nimbus-ui/src/lib/visualization/mocks.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/lib/visualization/mocks.tsx
@@ -100,12 +100,24 @@ export const CONTROL_NEUTRAL = {
     ],
   },
   difference: {
-    first: {},
-    all: [],
+    control: {
+      first: {},
+      all: [],
+    },
+    treatment: {
+      first: {},
+      all: [],
+    },
   },
   relative_uplift: {
-    first: {},
-    all: [],
+    control: {
+      first: {},
+      all: [],
+    },
+    treatment: {
+      first: {},
+      all: [],
+    },
   },
 };
 
@@ -127,38 +139,68 @@ export const TREATMENT_NEUTRAL = {
     ],
   },
   difference: {
-    first: {
-      point: -0.0006569487628876534,
-      upper: 0.04316381736512019,
-      lower: 0.04175095963994029,
-    },
-    all: [
-      {
+    control: {
+      first: {
         point: -0.0006569487628876534,
         upper: 0.04316381736512019,
         lower: 0.04175095963994029,
       },
-    ],
+      all: [
+        {
+          point: -0.0006569487628876534,
+          upper: 0.04316381736512019,
+          lower: 0.04175095963994029,
+        },
+      ],
+    },
+    treatment: {
+      first: {},
+      all: [],
+    },
   },
   relative_uplift: {
-    first: {
-      lower: -0.455210299676828,
-      upper: 0.5104985718410426,
-      point: -0.06233954570562385,
-    },
-    all: [
-      {
+    control: {
+      first: {
         lower: -0.455210299676828,
         upper: 0.5104985718410426,
         point: -0.06233954570562385,
       },
-    ],
+      all: [
+        {
+          lower: -0.455210299676828,
+          upper: 0.5104985718410426,
+          point: -0.06233954570562385,
+        },
+      ],
+    },
+    treatment: {
+      first: {},
+      all: [],
+    },
   },
-  significance: { overall: { "1": "neutral" }, weekly: {} },
+  significance: {
+    treatment: {
+      overall: {},
+      weekly: {},
+    },
+    control: {
+      overall: { "1": "neutral" },
+      weekly: {},
+    },
+  },
 };
 
 export const TREATMENT_NEGATIVE = Object.assign({}, TREATMENT_NEUTRAL, {
-  significance: { overall: { "1": "negative" }, weekly: {} },
+  significance: {
+    treatment: {
+      overall: {},
+      weekly: {},
+    },
+    control: {
+      overall: { "1": "negative" },
+      weekly: {},
+    },
+  },
 });
 
 export const WEEKLY_CONTROL = {
@@ -185,12 +227,24 @@ export const WEEKLY_CONTROL = {
     ],
   },
   difference: {
-    first: {},
-    all: [],
+    treatment: {
+      first: {},
+      all: [],
+    },
+    control: {
+      first: {},
+      all: [],
+    },
   },
   relative_uplift: {
-    first: {},
-    all: [],
+    treatment: {
+      first: {},
+      all: [],
+    },
+    control: {
+      first: {},
+      all: [],
+    },
   },
 };
 
@@ -221,50 +275,71 @@ export const WONKY_WEEKLY_TREATMENT = {
     ],
   },
   difference: {
-    first: {
-      point: -0.0006569487628876534,
-      upper: 0.04316381736512019,
-      lower: 0.04175095963994029,
-      window_index: 1,
-    },
-    all: [
-      {
+    control: {
+      first: {
         point: -0.0006569487628876534,
         upper: 0.04316381736512019,
-        lower: -0.04175095963994029,
+        lower: 0.04175095963994029,
         window_index: 1,
       },
-      {
-        point: -0.0006569487628876534,
-        upper: 0.04316381736512019,
-        lower: -0.04175095963994029,
-        window_index: 5,
-      },
-    ],
+      all: [
+        {
+          point: -0.0006569487628876534,
+          upper: 0.04316381736512019,
+          lower: -0.04175095963994029,
+          window_index: 1,
+        },
+        {
+          point: -0.0006569487628876534,
+          upper: 0.04316381736512019,
+          lower: -0.04175095963994029,
+          window_index: 5,
+        },
+      ],
+    },
+    treatment: {
+      first: {},
+      all: [],
+    },
   },
   relative_uplift: {
-    first: {
-      lower: -0.455210299676828,
-      upper: 0.5104985718410426,
-      point: -0.06233954570562385,
-      window_index: 1,
-    },
-    all: [
-      {
+    control: {
+      first: {
         lower: -0.455210299676828,
         upper: 0.5104985718410426,
         point: -0.06233954570562385,
         window_index: 1,
       },
-      {
-        lower: -0.455210299676828,
-        upper: 0.5104985718410426,
-        point: -0.06233954570562385,
-        window_index: 5,
-      },
-    ],
+      all: [
+        {
+          lower: -0.455210299676828,
+          upper: 0.5104985718410426,
+          point: -0.06233954570562385,
+          window_index: 1,
+        },
+        {
+          lower: -0.455210299676828,
+          upper: 0.5104985718410426,
+          point: -0.06233954570562385,
+          window_index: 5,
+        },
+      ],
+    },
+    treatment: {
+      first: {},
+      all: [],
+    },
   },
-  significance: { overall: {}, weekly: { "1": "negative" } },
+  significance: {
+    treatment: {
+      overall: {},
+      weekly: {},
+    },
+    control: {
+      overall: { "1": "negative" },
+      weekly: {},
+    },
+  },
 };
 
 export const WEEKLY_TREATMENT = {
@@ -294,50 +369,71 @@ export const WEEKLY_TREATMENT = {
     ],
   },
   difference: {
-    first: {
-      point: -0.0006569487628876534,
-      upper: 0.04316381736512019,
-      lower: 0.04175095963994029,
-      window_index: 1,
-    },
-    all: [
-      {
+    control: {
+      first: {
         point: -0.0006569487628876534,
         upper: 0.04316381736512019,
-        lower: -0.04175095963994029,
+        lower: 0.04175095963994029,
         window_index: 1,
       },
-      {
-        point: -0.0006569487628876534,
-        upper: 0.04316381736512019,
-        lower: -0.04175095963994029,
-        window_index: 2,
-      },
-    ],
+      all: [
+        {
+          point: -0.0006569487628876534,
+          upper: 0.04316381736512019,
+          lower: -0.04175095963994029,
+          window_index: 1,
+        },
+        {
+          point: -0.0006569487628876534,
+          upper: 0.04316381736512019,
+          lower: -0.04175095963994029,
+          window_index: 2,
+        },
+      ],
+    },
+    treatment: {
+      first: {},
+      all: [],
+    },
   },
   relative_uplift: {
-    first: {
-      lower: -0.455210299676828,
-      upper: 0.5104985718410426,
-      point: -0.06233954570562385,
-      window_index: 1,
-    },
-    all: [
-      {
+    control: {
+      first: {
         lower: -0.455210299676828,
         upper: 0.5104985718410426,
         point: -0.06233954570562385,
         window_index: 1,
       },
-      {
-        lower: -0.455210299676828,
-        upper: 0.5104985718410426,
-        point: -0.06233954570562385,
-        window_index: 2,
-      },
-    ],
+      all: [
+        {
+          lower: -0.455210299676828,
+          upper: 0.5104985718410426,
+          point: -0.06233954570562385,
+          window_index: 1,
+        },
+        {
+          lower: -0.455210299676828,
+          upper: 0.5104985718410426,
+          point: -0.06233954570562385,
+          window_index: 2,
+        },
+      ],
+    },
+    treatment: {
+      first: {},
+      all: [],
+    },
   },
-  significance: { overall: {}, weekly: { "1": "negative" } },
+  significance: {
+    treatment: {
+      overall: {},
+      weekly: {},
+    },
+    control: {
+      overall: { "1": "negative" },
+      weekly: {},
+    },
+  },
 };
 
 export const WEEKLY_IDENTITY = {
@@ -355,12 +451,24 @@ export const WEEKLY_IDENTITY = {
     },
   },
   difference: {
-    first: {},
-    all: [],
+    control: {
+      first: {},
+      all: [],
+    },
+    treatment: {
+      first: {},
+      all: [],
+    },
   },
   relative_uplift: {
-    first: {},
-    all: [],
+    control: {
+      first: {},
+      all: [],
+    },
+    treatment: {
+      first: {},
+      all: [],
+    },
   },
   percent: 50,
 };
@@ -406,74 +514,95 @@ export const WEEKLY_EXTRA_LONG = {
     ],
   },
   difference: {
-    first: {
-      point: -0.0006569487628876534,
-      upper: 0.04316381736512019,
-      lower: 0.04175095963994029,
-      window_index: 1,
+    control: {
+      first: {},
+      all: [],
     },
-    all: [
-      {
+    treatment: {
+      first: {
         point: -0.0006569487628876534,
         upper: 0.04316381736512019,
-        lower: -0.04175095963994029,
+        lower: 0.04175095963994029,
         window_index: 1,
       },
-      {
-        point: -0.0006569487628876534,
-        upper: 0.04316381736512019,
-        lower: -0.04175095963994029,
-        window_index: 5,
-      },
-      {
-        point: -0.0006569487628876534,
-        upper: 0.04316381736512019,
-        lower: -0.04175095963994029,
-        window_index: 10,
-      },
-      {
-        point: -0.0006569487628876534,
-        upper: 0.04316381736512019,
-        lower: -0.04175095963994029,
-        window_index: 15,
-      },
-    ],
+      all: [
+        {
+          point: -0.0006569487628876534,
+          upper: 0.04316381736512019,
+          lower: -0.04175095963994029,
+          window_index: 1,
+        },
+        {
+          point: -0.0006569487628876534,
+          upper: 0.04316381736512019,
+          lower: -0.04175095963994029,
+          window_index: 5,
+        },
+        {
+          point: -0.0006569487628876534,
+          upper: 0.04316381736512019,
+          lower: -0.04175095963994029,
+          window_index: 10,
+        },
+        {
+          point: -0.0006569487628876534,
+          upper: 0.04316381736512019,
+          lower: -0.04175095963994029,
+          window_index: 15,
+        },
+      ],
+    },
   },
   relative_uplift: {
-    first: {
-      lower: -0.455210299676828,
-      upper: 0.5104985718410426,
-      point: -0.06233954570562385,
-      window_index: 1,
+    control: {
+      first: {},
+      all: [],
     },
-    all: [
-      {
+    treatment: {
+      first: {
         lower: -0.455210299676828,
         upper: 0.5104985718410426,
         point: -0.06233954570562385,
         window_index: 1,
       },
-      {
-        lower: -0.455210299676828,
-        upper: 0.5104985718410426,
-        point: -0.06233954570562385,
-        window_index: 5,
-      },
-      {
-        lower: -0.455210299676828,
-        upper: 0.5104985718410426,
-        point: -0.06233954570562385,
-        window_index: 10,
-      },
-      {
-        lower: -0.455210299676828,
-        upper: 0.5104985718410426,
-        point: -0.06233954570562385,
-        window_index: 15,
-      },
-    ],
+      all: [
+        {
+          lower: -0.455210299676828,
+          upper: 0.5104985718410426,
+          point: -0.06233954570562385,
+          window_index: 1,
+        },
+        {
+          lower: -0.455210299676828,
+          upper: 0.5104985718410426,
+          point: -0.06233954570562385,
+          window_index: 5,
+        },
+        {
+          lower: -0.455210299676828,
+          upper: 0.5104985718410426,
+          point: -0.06233954570562385,
+          window_index: 10,
+        },
+        {
+          lower: -0.455210299676828,
+          upper: 0.5104985718410426,
+          point: -0.06233954570562385,
+          window_index: 15,
+        },
+      ],
+    },
   },
-  significance: { overall: {}, weekly: { "1": "negative" } },
+  significance: {
+    control: {
+      overall: {},
+      weekly: {},
+    },
+    treatment: {
+      overall: {},
+      weekly: { "1": "negative" },
+    },
+  },
 };
 
 export const MOCK_SIZING_DATA: SizingByUserType = {
@@ -720,12 +849,24 @@ export const mockAnalysis = (modifications = {}) =>
                       },
                     },
                     difference: {
-                      first: {},
-                      all: [],
+                      control: {
+                        first: {},
+                        all: [],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
                     relative_uplift: {
-                      first: {},
-                      all: [],
+                      control: {
+                        first: {},
+                        all: [],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
                     percent: 45,
                   },
@@ -745,12 +886,24 @@ export const mockAnalysis = (modifications = {}) =>
                       },
                     },
                     difference: {
-                      first: {},
-                      all: [],
+                      control: {
+                        first: {},
+                        all: [],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
                     relative_uplift: {
-                      first: {},
-                      all: [],
+                      control: {
+                        first: {},
+                        all: [],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
                   },
                   picture_in_picture_ever_used: {
@@ -771,12 +924,24 @@ export const mockAnalysis = (modifications = {}) =>
                       ],
                     },
                     difference: {
-                      first: {},
-                      all: [],
+                      control: {
+                        first: {},
+                        all: [],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
                     relative_uplift: {
-                      first: {},
-                      all: [],
+                      control: {
+                        first: {},
+                        all: [],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
                   },
                   picture_in_picture: {
@@ -797,12 +962,24 @@ export const mockAnalysis = (modifications = {}) =>
                       ],
                     },
                     difference: {
-                      first: {},
-                      all: [],
+                      control: {
+                        first: {},
+                        all: [],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
                     relative_uplift: {
-                      first: {},
-                      all: [],
+                      control: {
+                        first: {},
+                        all: [],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
                   },
                   feature_b_ever_used: {
@@ -823,12 +1000,24 @@ export const mockAnalysis = (modifications = {}) =>
                       ],
                     },
                     difference: {
-                      first: {},
-                      all: [],
+                      control: {
+                        first: {},
+                        all: [],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
                     relative_uplift: {
-                      first: {},
-                      all: [],
+                      control: {
+                        first: {},
+                        all: [],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
                   },
                   feature_b: {
@@ -849,12 +1038,24 @@ export const mockAnalysis = (modifications = {}) =>
                       ],
                     },
                     difference: {
-                      first: {},
-                      all: [],
+                      control: {
+                        first: {},
+                        all: [],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
                     relative_uplift: {
-                      first: {},
-                      all: [],
+                      control: {
+                        first: {},
+                        all: [],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
                   },
                   feature_c_ever_used: {
@@ -875,12 +1076,24 @@ export const mockAnalysis = (modifications = {}) =>
                       ],
                     },
                     difference: {
-                      first: {},
-                      all: [],
+                      control: {
+                        first: {},
+                        all: [],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
                     relative_uplift: {
-                      first: {},
-                      all: [],
+                      control: {
+                        first: {},
+                        all: [],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
                   },
                   feature_c: CONTROL_NEUTRAL,
@@ -902,12 +1115,24 @@ export const mockAnalysis = (modifications = {}) =>
                       ],
                     },
                     difference: {
-                      first: {},
-                      all: [],
+                      control: {
+                        first: {},
+                        all: [],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
                     relative_uplift: {
-                      first: {},
-                      all: [],
+                      control: {
+                        first: {},
+                        all: [],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
                   },
                   outcome_d: {
@@ -928,12 +1153,24 @@ export const mockAnalysis = (modifications = {}) =>
                       ],
                     },
                     difference: {
-                      first: {},
-                      all: [],
+                      control: {
+                        first: {},
+                        all: [],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
                     relative_uplift: {
-                      first: {},
-                      all: [],
+                      control: {
+                        first: {},
+                        all: [],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
                   },
                   days_of_use: CONTROL_NEUTRAL,
@@ -956,12 +1193,24 @@ export const mockAnalysis = (modifications = {}) =>
                       },
                     },
                     difference: {
-                      first: {},
-                      all: [],
+                      control: {
+                        first: {},
+                        all: [],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
                     relative_uplift: {
-                      first: {},
-                      all: [],
+                      control: {
+                        first: {},
+                        all: [],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
                   },
                 },
@@ -983,12 +1232,24 @@ export const mockAnalysis = (modifications = {}) =>
                       ],
                     },
                     difference: {
-                      first: {},
-                      all: [],
+                      control: {
+                        first: {},
+                        all: [],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
                     relative_uplift: {
-                      first: {},
-                      all: [],
+                      control: {
+                        first: {},
+                        all: [],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
                     percent: 55,
                   },
@@ -1011,34 +1272,49 @@ export const mockAnalysis = (modifications = {}) =>
                       ],
                     },
                     difference: {
-                      first: {
-                        point: -0.0006569487628876534,
-                        upper: 0.04316381736512019,
-                        lower: 0.04175095963994029,
-                      },
-                      all: [
-                        {
+                      control: {
+                        first: {
                           point: -0.0006569487628876534,
                           upper: 0.04316381736512019,
                           lower: 0.04175095963994029,
                         },
-                      ],
+                        all: [
+                          {
+                            point: -0.0006569487628876534,
+                            upper: 0.04316381736512019,
+                            lower: 0.04175095963994029,
+                          },
+                        ],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
                     relative_uplift: {
-                      first: {
-                        lower: -0.455210299676828,
-                        upper: 0.5104985718410426,
-                        point: -0.06233954570562385,
-                      },
-                      all: [
-                        {
+                      control: {
+                        first: {
                           lower: -0.455210299676828,
                           upper: 0.5104985718410426,
                           point: -0.06233954570562385,
                         },
-                      ],
+                        all: [
+                          {
+                            lower: -0.455210299676828,
+                            upper: 0.5104985718410426,
+                            point: -0.06233954570562385,
+                          },
+                        ],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
-                    significance: { overall: { "1": "positive" }, weekly: {} },
+                    significance: {
+                      control: { overall: { "1": "positive" }, weekly: {} },
+                      treatment: { overall: {}, weekly: {} },
+                    },
                   },
                   picture_in_picture: {
                     absolute: {
@@ -1058,34 +1334,55 @@ export const mockAnalysis = (modifications = {}) =>
                       ],
                     },
                     difference: {
-                      first: {
-                        point: -0.0006569487628876534,
-                        upper: 0.04316381736512019,
-                        lower: 0.04175095963994029,
-                      },
-                      all: [
-                        {
+                      control: {
+                        first: {
                           point: -0.0006569487628876534,
                           upper: 0.04316381736512019,
                           lower: 0.04175095963994029,
                         },
-                      ],
+                        all: [
+                          {
+                            point: -0.0006569487628876534,
+                            upper: 0.04316381736512019,
+                            lower: 0.04175095963994029,
+                          },
+                        ],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
                     relative_uplift: {
-                      first: {
-                        lower: -0.455210299676828,
-                        upper: 0.5104985718410426,
-                        point: -0.06233954570562385,
-                      },
-                      all: [
-                        {
+                      control: {
+                        first: {
                           lower: -0.455210299676828,
                           upper: 0.5104985718410426,
                           point: -0.06233954570562385,
                         },
-                      ],
+                        all: [
+                          {
+                            lower: -0.455210299676828,
+                            upper: 0.5104985718410426,
+                            point: -0.06233954570562385,
+                          },
+                        ],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
-                    significance: { overall: { "1": "positive" }, weekly: {} },
+                    significance: {
+                      control: {
+                        overall: { "1": "positive" },
+                        weekly: {},
+                      },
+                      treatment: {
+                        overall: {},
+                        weekly: {},
+                      },
+                    },
                   },
                   feature_b_ever_used: {
                     absolute: {
@@ -1105,34 +1402,55 @@ export const mockAnalysis = (modifications = {}) =>
                       ],
                     },
                     difference: {
-                      first: {
-                        point: -0.0006569487628876534,
-                        upper: 0.04316381736512019,
-                        lower: 0.04175095963994029,
-                      },
-                      all: [
-                        {
+                      control: {
+                        first: {
                           point: -0.0006569487628876534,
                           upper: 0.04316381736512019,
                           lower: 0.04175095963994029,
                         },
-                      ],
+                        all: [
+                          {
+                            point: -0.0006569487628876534,
+                            upper: 0.04316381736512019,
+                            lower: 0.04175095963994029,
+                          },
+                        ],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
                     relative_uplift: {
-                      first: {
-                        lower: -0.455210299676828,
-                        upper: 0.5104985718410426,
-                        point: -0.06233954570562385,
-                      },
-                      all: [
-                        {
+                      control: {
+                        first: {
                           lower: -0.455210299676828,
                           upper: 0.5104985718410426,
                           point: -0.06233954570562385,
                         },
-                      ],
+                        all: [
+                          {
+                            lower: -0.455210299676828,
+                            upper: 0.5104985718410426,
+                            point: -0.06233954570562385,
+                          },
+                        ],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
-                    significance: { overall: { "1": "negative" }, weekly: {} },
+                    significance: {
+                      control: {
+                        overall: { "1": "negative" },
+                        weekly: {},
+                      },
+                      treatment: {
+                        overall: {},
+                        weekly: {},
+                      },
+                    },
                   },
                   feature_b: {
                     absolute: {
@@ -1152,34 +1470,55 @@ export const mockAnalysis = (modifications = {}) =>
                       ],
                     },
                     difference: {
-                      first: {
-                        point: -0.0006569487628876534,
-                        upper: 0.04316381736512019,
-                        lower: 0.04175095963994029,
-                      },
-                      all: [
-                        {
+                      control: {
+                        first: {
                           point: -0.0006569487628876534,
                           upper: 0.04316381736512019,
                           lower: 0.04175095963994029,
                         },
-                      ],
+                        all: [
+                          {
+                            point: -0.0006569487628876534,
+                            upper: 0.04316381736512019,
+                            lower: 0.04175095963994029,
+                          },
+                        ],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
                     relative_uplift: {
-                      first: {
-                        lower: -0.455210299676828,
-                        upper: 0.5104985718410426,
-                        point: -0.06233954570562385,
-                      },
-                      all: [
-                        {
+                      control: {
+                        first: {
                           lower: -0.455210299676828,
                           upper: 0.5104985718410426,
                           point: -0.06233954570562385,
                         },
-                      ],
+                        all: [
+                          {
+                            lower: -0.455210299676828,
+                            upper: 0.5104985718410426,
+                            point: -0.06233954570562385,
+                          },
+                        ],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
-                    significance: { overall: { "1": "negative" }, weekly: {} },
+                    significance: {
+                      control: {
+                        overall: { "1": "negative" },
+                        weekly: {},
+                      },
+                      treatment: {
+                        overall: {},
+                        weekly: {},
+                      },
+                    },
                   },
                   feature_c_ever_used: {
                     absolute: {
@@ -1199,34 +1538,55 @@ export const mockAnalysis = (modifications = {}) =>
                       ],
                     },
                     difference: {
-                      first: {
-                        point: -0.0006569487628876534,
-                        upper: 0.04316381736512019,
-                        lower: 0.04175095963994029,
-                      },
-                      all: [
-                        {
+                      control: {
+                        first: {
                           point: -0.0006569487628876534,
                           upper: 0.04316381736512019,
                           lower: 0.04175095963994029,
                         },
-                      ],
+                        all: [
+                          {
+                            point: -0.0006569487628876534,
+                            upper: 0.04316381736512019,
+                            lower: 0.04175095963994029,
+                          },
+                        ],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
                     relative_uplift: {
-                      first: {
-                        lower: -0.455210299676828,
-                        upper: 0.5104985718410426,
-                        point: -0.06233954570562385,
-                      },
-                      all: [
-                        {
+                      control: {
+                        first: {
                           lower: -0.455210299676828,
                           upper: 0.5104985718410426,
                           point: -0.06233954570562385,
                         },
-                      ],
+                        all: [
+                          {
+                            lower: -0.455210299676828,
+                            upper: 0.5104985718410426,
+                            point: -0.06233954570562385,
+                          },
+                        ],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
-                    significance: { overall: { "1": "neutral" }, weekly: {} },
+                    significance: {
+                      control: {
+                        overall: { "1": "neutral" },
+                        weekly: {},
+                      },
+                      treatment: {
+                        overall: {},
+                        weekly: {},
+                      },
+                    },
                   },
                   feature_c: TREATMENT_NEUTRAL,
                   days_of_use: TREATMENT_NEUTRAL,
@@ -1249,34 +1609,55 @@ export const mockAnalysis = (modifications = {}) =>
                       ],
                     },
                     difference: {
-                      first: {
-                        point: -0.0006569487628876534,
-                        upper: 0.04316381736512019,
-                        lower: 0.04175095963994029,
-                      },
-                      all: [
-                        {
+                      control: {
+                        first: {
                           point: -0.0006569487628876534,
                           upper: 0.04316381736512019,
                           lower: 0.04175095963994029,
                         },
-                      ],
+                        all: [
+                          {
+                            point: -0.0006569487628876534,
+                            upper: 0.04316381736512019,
+                            lower: 0.04175095963994029,
+                          },
+                        ],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
                     relative_uplift: {
-                      first: {
-                        lower: -0.455210299676828,
-                        upper: 0.5104985718410426,
-                        point: -0.06233954570562385,
-                      },
-                      all: [
-                        {
+                      control: {
+                        first: {
                           lower: -0.455210299676828,
                           upper: 0.5104985718410426,
                           point: -0.06233954570562385,
                         },
-                      ],
+                        all: [
+                          {
+                            lower: -0.455210299676828,
+                            upper: 0.5104985718410426,
+                            point: -0.06233954570562385,
+                          },
+                        ],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
-                    significance: { overall: { "1": "positive" }, weekly: {} },
+                    significance: {
+                      control: {
+                        overall: { "1": "positive" },
+                        weekly: {},
+                      },
+                      treatment: {
+                        overall: {},
+                        weekly: {},
+                      },
+                    },
                   },
                   outcome_d: {
                     absolute: {
@@ -1296,34 +1677,55 @@ export const mockAnalysis = (modifications = {}) =>
                       ],
                     },
                     difference: {
-                      first: {
-                        point: -0.0006569487628876534,
-                        upper: 0.04316381736512019,
-                        lower: 0.04175095963994029,
-                      },
-                      all: [
-                        {
+                      control: {
+                        first: {
                           point: -0.0006569487628876534,
                           upper: 0.04316381736512019,
                           lower: 0.04175095963994029,
                         },
-                      ],
+                        all: [
+                          {
+                            point: -0.0006569487628876534,
+                            upper: 0.04316381736512019,
+                            lower: 0.04175095963994029,
+                          },
+                        ],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
                     relative_uplift: {
-                      first: {
-                        lower: -0.455210299676828,
-                        upper: 0.5104985718410426,
-                        point: -0.06233954570562385,
-                      },
-                      all: [
-                        {
+                      control: {
+                        first: {
                           lower: -0.455210299676828,
                           upper: 0.5104985718410426,
                           point: -0.06233954570562385,
                         },
-                      ],
+                        all: [
+                          {
+                            lower: -0.455210299676828,
+                            upper: 0.5104985718410426,
+                            point: -0.06233954570562385,
+                          },
+                        ],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
-                    significance: { overall: { "1": "positive" }, weekly: {} },
+                    significance: {
+                      control: {
+                        overall: { "1": "positive" },
+                        weekly: {},
+                      },
+                      treatment: {
+                        overall: {},
+                        weekly: {},
+                      },
+                    },
                   },
                 },
                 search_metrics: {
@@ -1351,12 +1753,24 @@ export const mockAnalysis = (modifications = {}) =>
                       },
                     },
                     difference: {
-                      first: {},
-                      all: [],
+                      control: {
+                        first: {},
+                        all: [],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
                     relative_uplift: {
-                      first: {},
-                      all: [],
+                      control: {
+                        first: {},
+                        all: [],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
                     percent: 45,
                   },
@@ -1376,12 +1790,24 @@ export const mockAnalysis = (modifications = {}) =>
                       },
                     },
                     difference: {
-                      first: {},
-                      all: [],
+                      control: {
+                        first: {},
+                        all: [],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
                     relative_uplift: {
-                      first: {},
-                      all: [],
+                      control: {
+                        first: {},
+                        all: [],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
                   },
                   picture_in_picture_ever_used: {
@@ -1402,12 +1828,24 @@ export const mockAnalysis = (modifications = {}) =>
                       ],
                     },
                     difference: {
-                      first: {},
-                      all: [],
+                      control: {
+                        first: {},
+                        all: [],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
                     relative_uplift: {
-                      first: {},
-                      all: [],
+                      control: {
+                        first: {},
+                        all: [],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
                   },
                   picture_in_picture: {
@@ -1428,12 +1866,24 @@ export const mockAnalysis = (modifications = {}) =>
                       ],
                     },
                     difference: {
-                      first: {},
-                      all: [],
+                      control: {
+                        first: {},
+                        all: [],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
                     relative_uplift: {
-                      first: {},
-                      all: [],
+                      control: {
+                        first: {},
+                        all: [],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
                   },
                   feature_b_ever_used: {
@@ -1454,12 +1904,24 @@ export const mockAnalysis = (modifications = {}) =>
                       ],
                     },
                     difference: {
-                      first: {},
-                      all: [],
+                      control: {
+                        first: {},
+                        all: [],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
                     relative_uplift: {
-                      first: {},
-                      all: [],
+                      control: {
+                        first: {},
+                        all: [],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
                   },
                   feature_b: {
@@ -1480,12 +1942,24 @@ export const mockAnalysis = (modifications = {}) =>
                       ],
                     },
                     difference: {
-                      first: {},
-                      all: [],
+                      control: {
+                        first: {},
+                        all: [],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
                     relative_uplift: {
-                      first: {},
-                      all: [],
+                      control: {
+                        first: {},
+                        all: [],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
                   },
                   feature_c_ever_used: {
@@ -1506,12 +1980,24 @@ export const mockAnalysis = (modifications = {}) =>
                       ],
                     },
                     difference: {
-                      first: {},
-                      all: [],
+                      control: {
+                        first: {},
+                        all: [],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
                     relative_uplift: {
-                      first: {},
-                      all: [],
+                      control: {
+                        first: {},
+                        all: [],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
                   },
                   feature_c: CONTROL_NEUTRAL,
@@ -1533,12 +2019,24 @@ export const mockAnalysis = (modifications = {}) =>
                       ],
                     },
                     difference: {
-                      first: {},
-                      all: [],
+                      control: {
+                        first: {},
+                        all: [],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
                     relative_uplift: {
-                      first: {},
-                      all: [],
+                      control: {
+                        first: {},
+                        all: [],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
                   },
                   outcome_d: {
@@ -1559,12 +2057,24 @@ export const mockAnalysis = (modifications = {}) =>
                       ],
                     },
                     difference: {
-                      first: {},
-                      all: [],
+                      control: {
+                        first: {},
+                        all: [],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
                     relative_uplift: {
-                      first: {},
-                      all: [],
+                      control: {
+                        first: {},
+                        all: [],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
                   },
                   days_of_use: CONTROL_NEUTRAL,
@@ -1587,12 +2097,24 @@ export const mockAnalysis = (modifications = {}) =>
                       },
                     },
                     difference: {
-                      first: {},
-                      all: [],
+                      control: {
+                        first: {},
+                        all: [],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
                     relative_uplift: {
-                      first: {},
-                      all: [],
+                      control: {
+                        first: {},
+                        all: [],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
                   },
                 },
@@ -1614,12 +2136,24 @@ export const mockAnalysis = (modifications = {}) =>
                       ],
                     },
                     difference: {
-                      first: {},
-                      all: [],
+                      control: {
+                        first: {},
+                        all: [],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
                     relative_uplift: {
-                      first: {},
-                      all: [],
+                      control: {
+                        first: {},
+                        all: [],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
                     percent: 55,
                   },
@@ -1642,34 +2176,55 @@ export const mockAnalysis = (modifications = {}) =>
                       ],
                     },
                     difference: {
-                      first: {
-                        point: -0.0006569487628876534,
-                        upper: 0.04316381736512019,
-                        lower: 0.04175095963994029,
-                      },
-                      all: [
-                        {
+                      control: {
+                        first: {
                           point: -0.0006569487628876534,
                           upper: 0.04316381736512019,
                           lower: 0.04175095963994029,
                         },
-                      ],
+                        all: [
+                          {
+                            point: -0.0006569487628876534,
+                            upper: 0.04316381736512019,
+                            lower: 0.04175095963994029,
+                          },
+                        ],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
                     relative_uplift: {
-                      first: {
-                        lower: -0.455210299676828,
-                        upper: 0.5104985718410426,
-                        point: -0.06233954570562385,
-                      },
-                      all: [
-                        {
+                      control: {
+                        first: {
                           lower: -0.455210299676828,
                           upper: 0.5104985718410426,
                           point: -0.06233954570562385,
                         },
-                      ],
+                        all: [
+                          {
+                            lower: -0.455210299676828,
+                            upper: 0.5104985718410426,
+                            point: -0.06233954570562385,
+                          },
+                        ],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
-                    significance: { overall: { "1": "positive" }, weekly: {} },
+                    significance: {
+                      control: {
+                        overall: { "1": "positive" },
+                        weekly: {},
+                      },
+                      treatment: {
+                        overall: {},
+                        weekly: {},
+                      },
+                    },
                   },
                   picture_in_picture: {
                     absolute: {
@@ -1689,34 +2244,55 @@ export const mockAnalysis = (modifications = {}) =>
                       ],
                     },
                     difference: {
-                      first: {
-                        point: -0.0006569487628876534,
-                        upper: 0.04316381736512019,
-                        lower: 0.04175095963994029,
-                      },
-                      all: [
-                        {
+                      control: {
+                        first: {
                           point: -0.0006569487628876534,
                           upper: 0.04316381736512019,
                           lower: 0.04175095963994029,
                         },
-                      ],
+                        all: [
+                          {
+                            point: -0.0006569487628876534,
+                            upper: 0.04316381736512019,
+                            lower: 0.04175095963994029,
+                          },
+                        ],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
                     relative_uplift: {
-                      first: {
-                        lower: -0.455210299676828,
-                        upper: 0.5104985718410426,
-                        point: -0.06233954570562385,
-                      },
-                      all: [
-                        {
+                      control: {
+                        first: {
                           lower: -0.455210299676828,
                           upper: 0.5104985718410426,
                           point: -0.06233954570562385,
                         },
-                      ],
+                        all: [
+                          {
+                            lower: -0.455210299676828,
+                            upper: 0.5104985718410426,
+                            point: -0.06233954570562385,
+                          },
+                        ],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
-                    significance: { overall: { "1": "positive" }, weekly: {} },
+                    significance: {
+                      control: {
+                        overall: { "1": "positive" },
+                        weekly: {},
+                      },
+                      treatment: {
+                        overall: {},
+                        weekly: {},
+                      },
+                    },
                   },
                   feature_b_ever_used: {
                     absolute: {
@@ -1736,34 +2312,55 @@ export const mockAnalysis = (modifications = {}) =>
                       ],
                     },
                     difference: {
-                      first: {
-                        point: -0.0006569487628876534,
-                        upper: 0.04316381736512019,
-                        lower: 0.04175095963994029,
-                      },
-                      all: [
-                        {
+                      control: {
+                        first: {
                           point: -0.0006569487628876534,
                           upper: 0.04316381736512019,
                           lower: 0.04175095963994029,
                         },
-                      ],
+                        all: [
+                          {
+                            point: -0.0006569487628876534,
+                            upper: 0.04316381736512019,
+                            lower: 0.04175095963994029,
+                          },
+                        ],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
                     relative_uplift: {
-                      first: {
-                        lower: -0.455210299676828,
-                        upper: 0.5104985718410426,
-                        point: -0.06233954570562385,
-                      },
-                      all: [
-                        {
+                      control: {
+                        first: {
                           lower: -0.455210299676828,
                           upper: 0.5104985718410426,
                           point: -0.06233954570562385,
                         },
-                      ],
+                        all: [
+                          {
+                            lower: -0.455210299676828,
+                            upper: 0.5104985718410426,
+                            point: -0.06233954570562385,
+                          },
+                        ],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
-                    significance: { overall: { "1": "negative" }, weekly: {} },
+                    significance: {
+                      control: {
+                        overall: { "1": "negative" },
+                        weekly: {},
+                      },
+                      treatment: {
+                        overall: {},
+                        weekly: {},
+                      },
+                    },
                   },
                   feature_b: {
                     absolute: {
@@ -1783,34 +2380,55 @@ export const mockAnalysis = (modifications = {}) =>
                       ],
                     },
                     difference: {
-                      first: {
-                        point: -0.0006569487628876534,
-                        upper: 0.04316381736512019,
-                        lower: 0.04175095963994029,
-                      },
-                      all: [
-                        {
+                      control: {
+                        first: {
                           point: -0.0006569487628876534,
                           upper: 0.04316381736512019,
                           lower: 0.04175095963994029,
                         },
-                      ],
+                        all: [
+                          {
+                            point: -0.0006569487628876534,
+                            upper: 0.04316381736512019,
+                            lower: 0.04175095963994029,
+                          },
+                        ],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
                     relative_uplift: {
-                      first: {
-                        lower: -0.455210299676828,
-                        upper: 0.5104985718410426,
-                        point: -0.06233954570562385,
-                      },
-                      all: [
-                        {
+                      control: {
+                        first: {
                           lower: -0.455210299676828,
                           upper: 0.5104985718410426,
                           point: -0.06233954570562385,
                         },
-                      ],
+                        all: [
+                          {
+                            lower: -0.455210299676828,
+                            upper: 0.5104985718410426,
+                            point: -0.06233954570562385,
+                          },
+                        ],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
-                    significance: { overall: { "1": "negative" }, weekly: {} },
+                    significance: {
+                      control: {
+                        overall: { "1": "negative" },
+                        weekly: {},
+                      },
+                      treatment: {
+                        overall: {},
+                        weekly: {},
+                      },
+                    },
                   },
                   feature_c_ever_used: {
                     absolute: {
@@ -1830,34 +2448,55 @@ export const mockAnalysis = (modifications = {}) =>
                       ],
                     },
                     difference: {
-                      first: {
-                        point: -0.0006569487628876534,
-                        upper: 0.04316381736512019,
-                        lower: 0.04175095963994029,
-                      },
-                      all: [
-                        {
+                      control: {
+                        first: {
                           point: -0.0006569487628876534,
                           upper: 0.04316381736512019,
                           lower: 0.04175095963994029,
                         },
-                      ],
+                        all: [
+                          {
+                            point: -0.0006569487628876534,
+                            upper: 0.04316381736512019,
+                            lower: 0.04175095963994029,
+                          },
+                        ],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
                     relative_uplift: {
-                      first: {
-                        lower: -0.455210299676828,
-                        upper: 0.5104985718410426,
-                        point: -0.06233954570562385,
-                      },
-                      all: [
-                        {
+                      control: {
+                        first: {
                           lower: -0.455210299676828,
                           upper: 0.5104985718410426,
                           point: -0.06233954570562385,
                         },
-                      ],
+                        all: [
+                          {
+                            lower: -0.455210299676828,
+                            upper: 0.5104985718410426,
+                            point: -0.06233954570562385,
+                          },
+                        ],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
-                    significance: { overall: { "1": "neutral" }, weekly: {} },
+                    significance: {
+                      control: {
+                        overall: { "1": "neutral" },
+                        weekly: {},
+                      },
+                      treatment: {
+                        overall: {},
+                        weekly: {},
+                      },
+                    },
                   },
                   feature_c: TREATMENT_NEUTRAL,
                   days_of_use: TREATMENT_NEUTRAL,
@@ -1880,34 +2519,55 @@ export const mockAnalysis = (modifications = {}) =>
                       ],
                     },
                     difference: {
-                      first: {
-                        point: -0.0006569487628876534,
-                        upper: 0.04316381736512019,
-                        lower: 0.04175095963994029,
-                      },
-                      all: [
-                        {
+                      control: {
+                        first: {
                           point: -0.0006569487628876534,
                           upper: 0.04316381736512019,
                           lower: 0.04175095963994029,
                         },
-                      ],
+                        all: [
+                          {
+                            point: -0.0006569487628876534,
+                            upper: 0.04316381736512019,
+                            lower: 0.04175095963994029,
+                          },
+                        ],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
                     relative_uplift: {
-                      first: {
-                        lower: -0.455210299676828,
-                        upper: 0.5104985718410426,
-                        point: -0.06233954570562385,
-                      },
-                      all: [
-                        {
+                      control: {
+                        first: {
                           lower: -0.455210299676828,
                           upper: 0.5104985718410426,
                           point: -0.06233954570562385,
                         },
-                      ],
+                        all: [
+                          {
+                            lower: -0.455210299676828,
+                            upper: 0.5104985718410426,
+                            point: -0.06233954570562385,
+                          },
+                        ],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
-                    significance: { overall: { "1": "positive" }, weekly: {} },
+                    significance: {
+                      control: {
+                        overall: { "1": "positive" },
+                        weekly: {},
+                      },
+                      treatment: {
+                        overall: {},
+                        weekly: {},
+                      },
+                    },
                   },
                   outcome_d: {
                     absolute: {
@@ -1927,34 +2587,55 @@ export const mockAnalysis = (modifications = {}) =>
                       ],
                     },
                     difference: {
-                      first: {
-                        point: -0.0006569487628876534,
-                        upper: 0.04316381736512019,
-                        lower: 0.04175095963994029,
-                      },
-                      all: [
-                        {
+                      control: {
+                        first: {
                           point: -0.0006569487628876534,
                           upper: 0.04316381736512019,
                           lower: 0.04175095963994029,
                         },
-                      ],
+                        all: [
+                          {
+                            point: -0.0006569487628876534,
+                            upper: 0.04316381736512019,
+                            lower: 0.04175095963994029,
+                          },
+                        ],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
                     relative_uplift: {
-                      first: {
-                        lower: -0.455210299676828,
-                        upper: 0.5104985718410426,
-                        point: -0.06233954570562385,
-                      },
-                      all: [
-                        {
+                      control: {
+                        first: {
                           lower: -0.455210299676828,
                           upper: 0.5104985718410426,
                           point: -0.06233954570562385,
                         },
-                      ],
+                        all: [
+                          {
+                            lower: -0.455210299676828,
+                            upper: 0.5104985718410426,
+                            point: -0.06233954570562385,
+                          },
+                        ],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
-                    significance: { overall: { "1": "positive" }, weekly: {} },
+                    significance: {
+                      control: {
+                        overall: { "1": "positive" },
+                        weekly: {},
+                      },
+                      treatment: {
+                        overall: {},
+                        weekly: {},
+                      },
+                    },
                   },
                 },
                 search_metrics: {
@@ -1989,12 +2670,24 @@ export const mockAnalysisWithSegments = mockAnalysis({
                   },
                 },
                 difference: {
-                  first: {},
-                  all: [],
+                  control: {
+                    first: {},
+                    all: [],
+                  },
+                  treatment: {
+                    first: {},
+                    all: [],
+                  },
                 },
                 relative_uplift: {
-                  first: {},
-                  all: [],
+                  control: {
+                    first: {},
+                    all: [],
+                  },
+                  treatment: {
+                    first: {},
+                    all: [],
+                  },
                 },
                 percent: 45,
               },
@@ -2014,12 +2707,24 @@ export const mockAnalysisWithSegments = mockAnalysis({
                   },
                 },
                 difference: {
-                  first: {},
-                  all: [],
+                  control: {
+                    first: {},
+                    all: [],
+                  },
+                  treatment: {
+                    first: {},
+                    all: [],
+                  },
                 },
                 relative_uplift: {
-                  first: {},
-                  all: [],
+                  control: {
+                    first: {},
+                    all: [],
+                  },
+                  treatment: {
+                    first: {},
+                    all: [],
+                  },
                 },
               },
               picture_in_picture_ever_used: {
@@ -2040,12 +2745,24 @@ export const mockAnalysisWithSegments = mockAnalysis({
                   ],
                 },
                 difference: {
-                  first: {},
-                  all: [],
+                  control: {
+                    first: {},
+                    all: [],
+                  },
+                  treatment: {
+                    first: {},
+                    all: [],
+                  },
                 },
                 relative_uplift: {
-                  first: {},
-                  all: [],
+                  control: {
+                    first: {},
+                    all: [],
+                  },
+                  treatment: {
+                    first: {},
+                    all: [],
+                  },
                 },
               },
               picture_in_picture: {
@@ -2066,12 +2783,24 @@ export const mockAnalysisWithSegments = mockAnalysis({
                   ],
                 },
                 difference: {
-                  first: {},
-                  all: [],
+                  control: {
+                    first: {},
+                    all: [],
+                  },
+                  treatment: {
+                    first: {},
+                    all: [],
+                  },
                 },
                 relative_uplift: {
-                  first: {},
-                  all: [],
+                  control: {
+                    first: {},
+                    all: [],
+                  },
+                  treatment: {
+                    first: {},
+                    all: [],
+                  },
                 },
               },
               feature_b_ever_used: {
@@ -2092,12 +2821,24 @@ export const mockAnalysisWithSegments = mockAnalysis({
                   ],
                 },
                 difference: {
-                  first: {},
-                  all: [],
+                  control: {
+                    first: {},
+                    all: [],
+                  },
+                  treatment: {
+                    first: {},
+                    all: [],
+                  },
                 },
                 relative_uplift: {
-                  first: {},
-                  all: [],
+                  control: {
+                    first: {},
+                    all: [],
+                  },
+                  treatment: {
+                    first: {},
+                    all: [],
+                  },
                 },
               },
               feature_b: {
@@ -2118,12 +2859,24 @@ export const mockAnalysisWithSegments = mockAnalysis({
                   ],
                 },
                 difference: {
-                  first: {},
-                  all: [],
+                  control: {
+                    first: {},
+                    all: [],
+                  },
+                  treatment: {
+                    first: {},
+                    all: [],
+                  },
                 },
                 relative_uplift: {
-                  first: {},
-                  all: [],
+                  control: {
+                    first: {},
+                    all: [],
+                  },
+                  treatment: {
+                    first: {},
+                    all: [],
+                  },
                 },
               },
               feature_c_ever_used: {
@@ -2144,12 +2897,24 @@ export const mockAnalysisWithSegments = mockAnalysis({
                   ],
                 },
                 difference: {
-                  first: {},
-                  all: [],
+                  control: {
+                    first: {},
+                    all: [],
+                  },
+                  treatment: {
+                    first: {},
+                    all: [],
+                  },
                 },
                 relative_uplift: {
-                  first: {},
-                  all: [],
+                  control: {
+                    first: {},
+                    all: [],
+                  },
+                  treatment: {
+                    first: {},
+                    all: [],
+                  },
                 },
               },
               feature_c: CONTROL_NEUTRAL,
@@ -2171,12 +2936,24 @@ export const mockAnalysisWithSegments = mockAnalysis({
                   ],
                 },
                 difference: {
-                  first: {},
-                  all: [],
+                  control: {
+                    first: {},
+                    all: [],
+                  },
+                  treatment: {
+                    first: {},
+                    all: [],
+                  },
                 },
                 relative_uplift: {
-                  first: {},
-                  all: [],
+                  control: {
+                    first: {},
+                    all: [],
+                  },
+                  treatment: {
+                    first: {},
+                    all: [],
+                  },
                 },
               },
               outcome_d: {
@@ -2197,12 +2974,24 @@ export const mockAnalysisWithSegments = mockAnalysis({
                   ],
                 },
                 difference: {
-                  first: {},
-                  all: [],
+                  control: {
+                    first: {},
+                    all: [],
+                  },
+                  treatment: {
+                    first: {},
+                    all: [],
+                  },
                 },
                 relative_uplift: {
-                  first: {},
-                  all: [],
+                  control: {
+                    first: {},
+                    all: [],
+                  },
+                  treatment: {
+                    first: {},
+                    all: [],
+                  },
                 },
               },
               days_of_use: CONTROL_NEUTRAL,
@@ -2225,12 +3014,24 @@ export const mockAnalysisWithSegments = mockAnalysis({
                   },
                 },
                 difference: {
-                  first: {},
-                  all: [],
+                  control: {
+                    first: {},
+                    all: [],
+                  },
+                  treatment: {
+                    first: {},
+                    all: [],
+                  },
                 },
                 relative_uplift: {
-                  first: {},
-                  all: [],
+                  control: {
+                    first: {},
+                    all: [],
+                  },
+                  treatment: {
+                    first: {},
+                    all: [],
+                  },
                 },
               },
             },
@@ -2252,12 +3053,24 @@ export const mockAnalysisWithSegments = mockAnalysis({
                   ],
                 },
                 difference: {
-                  first: {},
-                  all: [],
+                  control: {
+                    first: {},
+                    all: [],
+                  },
+                  treatment: {
+                    first: {},
+                    all: [],
+                  },
                 },
                 relative_uplift: {
-                  first: {},
-                  all: [],
+                  control: {
+                    first: {},
+                    all: [],
+                  },
+                  treatment: {
+                    first: {},
+                    all: [],
+                  },
                 },
                 percent: 55,
               },
@@ -2280,34 +3093,52 @@ export const mockAnalysisWithSegments = mockAnalysis({
                   ],
                 },
                 difference: {
-                  first: {
-                    point: -0.0006569487628876534,
-                    upper: 0.04316381736512019,
-                    lower: 0.04175095963994029,
-                  },
-                  all: [
-                    {
+                  control: {
+                    first: {
                       point: -0.0006569487628876534,
                       upper: 0.04316381736512019,
                       lower: 0.04175095963994029,
                     },
-                  ],
+                    all: [
+                      {
+                        point: -0.0006569487628876534,
+                        upper: 0.04316381736512019,
+                        lower: 0.04175095963994029,
+                      },
+                    ],
+                  },
+                  treatment: {
+                    first: {},
+                    all: [],
+                  },
                 },
                 relative_uplift: {
-                  first: {
-                    lower: -0.455210299676828,
-                    upper: 0.5104985718410426,
-                    point: -0.06233954570562385,
-                  },
-                  all: [
-                    {
+                  control: {
+                    first: {
                       lower: -0.455210299676828,
                       upper: 0.5104985718410426,
                       point: -0.06233954570562385,
                     },
-                  ],
+                    all: [
+                      {
+                        lower: -0.455210299676828,
+                        upper: 0.5104985718410426,
+                        point: -0.06233954570562385,
+                      },
+                    ],
+                  },
+                  treatment: {
+                    first: {},
+                    all: [],
+                  },
                 },
-                significance: { overall: { "1": "positive" }, weekly: {} },
+                significance: {
+                  control: {
+                    overall: { "1": "positive" },
+                    weekly: {},
+                  },
+                  treatment: { overall: {}, weekly: {} },
+                },
               },
               picture_in_picture: {
                 absolute: {
@@ -2327,34 +3158,52 @@ export const mockAnalysisWithSegments = mockAnalysis({
                   ],
                 },
                 difference: {
-                  first: {
-                    point: -0.0006569487628876534,
-                    upper: 0.04316381736512019,
-                    lower: 0.04175095963994029,
-                  },
-                  all: [
-                    {
+                  control: {
+                    first: {
                       point: -0.0006569487628876534,
                       upper: 0.04316381736512019,
                       lower: 0.04175095963994029,
                     },
-                  ],
+                    all: [
+                      {
+                        point: -0.0006569487628876534,
+                        upper: 0.04316381736512019,
+                        lower: 0.04175095963994029,
+                      },
+                    ],
+                  },
+                  treatment: {
+                    first: {},
+                    all: [],
+                  },
                 },
                 relative_uplift: {
-                  first: {
-                    lower: -0.455210299676828,
-                    upper: 0.5104985718410426,
-                    point: -0.06233954570562385,
-                  },
-                  all: [
-                    {
+                  control: {
+                    first: {
                       lower: -0.455210299676828,
                       upper: 0.5104985718410426,
                       point: -0.06233954570562385,
                     },
-                  ],
+                    all: [
+                      {
+                        lower: -0.455210299676828,
+                        upper: 0.5104985718410426,
+                        point: -0.06233954570562385,
+                      },
+                    ],
+                  },
+                  treatment: {
+                    first: {},
+                    all: [],
+                  },
                 },
-                significance: { overall: { "1": "positive" }, weekly: {} },
+                significance: {
+                  control: {
+                    overall: { "1": "positive" },
+                    weekly: {},
+                  },
+                  treatment: { overall: {}, weekly: {} },
+                },
               },
               feature_b_ever_used: {
                 absolute: {
@@ -2374,34 +3223,52 @@ export const mockAnalysisWithSegments = mockAnalysis({
                   ],
                 },
                 difference: {
-                  first: {
-                    point: -0.0006569487628876534,
-                    upper: 0.04316381736512019,
-                    lower: 0.04175095963994029,
-                  },
-                  all: [
-                    {
+                  control: {
+                    first: {
                       point: -0.0006569487628876534,
                       upper: 0.04316381736512019,
                       lower: 0.04175095963994029,
                     },
-                  ],
+                    all: [
+                      {
+                        point: -0.0006569487628876534,
+                        upper: 0.04316381736512019,
+                        lower: 0.04175095963994029,
+                      },
+                    ],
+                  },
+                  treatment: {
+                    first: {},
+                    all: [],
+                  },
                 },
                 relative_uplift: {
-                  first: {
-                    lower: -0.455210299676828,
-                    upper: 0.5104985718410426,
-                    point: -0.06233954570562385,
-                  },
-                  all: [
-                    {
+                  control: {
+                    first: {
                       lower: -0.455210299676828,
                       upper: 0.5104985718410426,
                       point: -0.06233954570562385,
                     },
-                  ],
+                    all: [
+                      {
+                        lower: -0.455210299676828,
+                        upper: 0.5104985718410426,
+                        point: -0.06233954570562385,
+                      },
+                    ],
+                  },
+                  treatment: {
+                    first: {},
+                    all: [],
+                  },
                 },
-                significance: { overall: { "1": "negative" }, weekly: {} },
+                significance: {
+                  control: {
+                    overall: { "1": "negative" },
+                    weekly: {},
+                  },
+                  treatment: { overall: {}, weekly: {} },
+                },
               },
               feature_b: {
                 absolute: {
@@ -2421,34 +3288,52 @@ export const mockAnalysisWithSegments = mockAnalysis({
                   ],
                 },
                 difference: {
-                  first: {
-                    point: -0.0006569487628876534,
-                    upper: 0.04316381736512019,
-                    lower: 0.04175095963994029,
-                  },
-                  all: [
-                    {
+                  control: {
+                    first: {
                       point: -0.0006569487628876534,
                       upper: 0.04316381736512019,
                       lower: 0.04175095963994029,
                     },
-                  ],
+                    all: [
+                      {
+                        point: -0.0006569487628876534,
+                        upper: 0.04316381736512019,
+                        lower: 0.04175095963994029,
+                      },
+                    ],
+                  },
+                  treatment: {
+                    first: {},
+                    all: [],
+                  },
                 },
                 relative_uplift: {
-                  first: {
-                    lower: -0.455210299676828,
-                    upper: 0.5104985718410426,
-                    point: -0.06233954570562385,
-                  },
-                  all: [
-                    {
+                  control: {
+                    first: {
                       lower: -0.455210299676828,
                       upper: 0.5104985718410426,
                       point: -0.06233954570562385,
                     },
-                  ],
+                    all: [
+                      {
+                        lower: -0.455210299676828,
+                        upper: 0.5104985718410426,
+                        point: -0.06233954570562385,
+                      },
+                    ],
+                  },
+                  treatment: {
+                    first: {},
+                    all: [],
+                  },
                 },
-                significance: { overall: { "1": "negative" }, weekly: {} },
+                significance: {
+                  control: {
+                    overall: { "1": "negative" },
+                    weekly: {},
+                  },
+                  treatment: { overall: {}, weekly: {} },
+                },
               },
               feature_c_ever_used: {
                 absolute: {
@@ -2468,34 +3353,52 @@ export const mockAnalysisWithSegments = mockAnalysis({
                   ],
                 },
                 difference: {
-                  first: {
-                    point: -0.0006569487628876534,
-                    upper: 0.04316381736512019,
-                    lower: 0.04175095963994029,
-                  },
-                  all: [
-                    {
+                  control: {
+                    first: {
                       point: -0.0006569487628876534,
                       upper: 0.04316381736512019,
                       lower: 0.04175095963994029,
                     },
-                  ],
+                    all: [
+                      {
+                        point: -0.0006569487628876534,
+                        upper: 0.04316381736512019,
+                        lower: 0.04175095963994029,
+                      },
+                    ],
+                  },
+                  treatment: {
+                    first: {},
+                    all: [],
+                  },
                 },
                 relative_uplift: {
-                  first: {
-                    lower: -0.455210299676828,
-                    upper: 0.5104985718410426,
-                    point: -0.06233954570562385,
-                  },
-                  all: [
-                    {
+                  control: {
+                    first: {
                       lower: -0.455210299676828,
                       upper: 0.5104985718410426,
                       point: -0.06233954570562385,
                     },
-                  ],
+                    all: [
+                      {
+                        lower: -0.455210299676828,
+                        upper: 0.5104985718410426,
+                        point: -0.06233954570562385,
+                      },
+                    ],
+                  },
+                  treatment: {
+                    first: {},
+                    all: [],
+                  },
                 },
-                significance: { overall: { "1": "neutral" }, weekly: {} },
+                significance: {
+                  control: {
+                    overall: { "1": "neutral" },
+                    weekly: {},
+                  },
+                  treatment: { overall: {}, weekly: {} },
+                },
               },
               feature_c: TREATMENT_NEUTRAL,
               days_of_use: TREATMENT_NEUTRAL,
@@ -2518,34 +3421,52 @@ export const mockAnalysisWithSegments = mockAnalysis({
                   ],
                 },
                 difference: {
-                  first: {
-                    point: -0.0006569487628876534,
-                    upper: 0.04316381736512019,
-                    lower: 0.04175095963994029,
-                  },
-                  all: [
-                    {
+                  control: {
+                    first: {
                       point: -0.0006569487628876534,
                       upper: 0.04316381736512019,
                       lower: 0.04175095963994029,
                     },
-                  ],
+                    all: [
+                      {
+                        point: -0.0006569487628876534,
+                        upper: 0.04316381736512019,
+                        lower: 0.04175095963994029,
+                      },
+                    ],
+                  },
+                  treatment: {
+                    first: {},
+                    all: [],
+                  },
                 },
                 relative_uplift: {
-                  first: {
-                    lower: -0.455210299676828,
-                    upper: 0.5104985718410426,
-                    point: -0.06233954570562385,
-                  },
-                  all: [
-                    {
+                  control: {
+                    first: {
                       lower: -0.455210299676828,
                       upper: 0.5104985718410426,
                       point: -0.06233954570562385,
                     },
-                  ],
+                    all: [
+                      {
+                        lower: -0.455210299676828,
+                        upper: 0.5104985718410426,
+                        point: -0.06233954570562385,
+                      },
+                    ],
+                  },
+                  treatment: {
+                    first: {},
+                    all: [],
+                  },
                 },
-                significance: { overall: { "1": "positive" }, weekly: {} },
+                significance: {
+                  control: {
+                    overall: { "1": "positive" },
+                    weekly: {},
+                  },
+                  treatment: { overall: {}, weekly: {} },
+                },
               },
               outcome_d: {
                 absolute: {
@@ -2565,34 +3486,52 @@ export const mockAnalysisWithSegments = mockAnalysis({
                   ],
                 },
                 difference: {
-                  first: {
-                    point: -0.0006569487628876534,
-                    upper: 0.04316381736512019,
-                    lower: 0.04175095963994029,
-                  },
-                  all: [
-                    {
+                  control: {
+                    first: {
                       point: -0.0006569487628876534,
                       upper: 0.04316381736512019,
                       lower: 0.04175095963994029,
                     },
-                  ],
+                    all: [
+                      {
+                        point: -0.0006569487628876534,
+                        upper: 0.04316381736512019,
+                        lower: 0.04175095963994029,
+                      },
+                    ],
+                  },
+                  treatment: {
+                    first: {},
+                    all: [],
+                  },
                 },
                 relative_uplift: {
-                  first: {
-                    lower: -0.455210299676828,
-                    upper: 0.5104985718410426,
-                    point: -0.06233954570562385,
-                  },
-                  all: [
-                    {
+                  control: {
+                    first: {
                       lower: -0.455210299676828,
                       upper: 0.5104985718410426,
                       point: -0.06233954570562385,
                     },
-                  ],
+                    all: [
+                      {
+                        lower: -0.455210299676828,
+                        upper: 0.5104985718410426,
+                        point: -0.06233954570562385,
+                      },
+                    ],
+                  },
+                  treatment: {
+                    first: {},
+                    all: [],
+                  },
                 },
-                significance: { overall: { "1": "positive" }, weekly: {} },
+                significance: {
+                  control: {
+                    overall: { "1": "positive" },
+                    weekly: {},
+                  },
+                  treatment: { overall: {}, weekly: {} },
+                },
               },
             },
             search_metrics: {
@@ -2618,12 +3557,24 @@ export const mockAnalysisWithSegments = mockAnalysis({
                   },
                 },
                 difference: {
-                  first: {},
-                  all: [],
+                  control: {
+                    first: {},
+                    all: [],
+                  },
+                  treatment: {
+                    first: {},
+                    all: [],
+                  },
                 },
                 relative_uplift: {
-                  first: {},
-                  all: [],
+                  control: {
+                    first: {},
+                    all: [],
+                  },
+                  treatment: {
+                    first: {},
+                    all: [],
+                  },
                 },
                 percent: 45,
               },
@@ -2643,12 +3594,24 @@ export const mockAnalysisWithSegments = mockAnalysis({
                   },
                 },
                 difference: {
-                  first: {},
-                  all: [],
+                  control: {
+                    first: {},
+                    all: [],
+                  },
+                  treatment: {
+                    first: {},
+                    all: [],
+                  },
                 },
                 relative_uplift: {
-                  first: {},
-                  all: [],
+                  control: {
+                    first: {},
+                    all: [],
+                  },
+                  treatment: {
+                    first: {},
+                    all: [],
+                  },
                 },
               },
               picture_in_picture_ever_used: {
@@ -2669,12 +3632,24 @@ export const mockAnalysisWithSegments = mockAnalysis({
                   ],
                 },
                 difference: {
-                  first: {},
-                  all: [],
+                  control: {
+                    first: {},
+                    all: [],
+                  },
+                  treatment: {
+                    first: {},
+                    all: [],
+                  },
                 },
                 relative_uplift: {
-                  first: {},
-                  all: [],
+                  control: {
+                    first: {},
+                    all: [],
+                  },
+                  treatment: {
+                    first: {},
+                    all: [],
+                  },
                 },
               },
               picture_in_picture: {
@@ -2695,12 +3670,24 @@ export const mockAnalysisWithSegments = mockAnalysis({
                   ],
                 },
                 difference: {
-                  first: {},
-                  all: [],
+                  control: {
+                    first: {},
+                    all: [],
+                  },
+                  treatment: {
+                    first: {},
+                    all: [],
+                  },
                 },
                 relative_uplift: {
-                  first: {},
-                  all: [],
+                  control: {
+                    first: {},
+                    all: [],
+                  },
+                  treatment: {
+                    first: {},
+                    all: [],
+                  },
                 },
               },
               feature_b_ever_used: {
@@ -2721,12 +3708,24 @@ export const mockAnalysisWithSegments = mockAnalysis({
                   ],
                 },
                 difference: {
-                  first: {},
-                  all: [],
+                  control: {
+                    first: {},
+                    all: [],
+                  },
+                  treatment: {
+                    first: {},
+                    all: [],
+                  },
                 },
                 relative_uplift: {
-                  first: {},
-                  all: [],
+                  control: {
+                    first: {},
+                    all: [],
+                  },
+                  treatment: {
+                    first: {},
+                    all: [],
+                  },
                 },
               },
               feature_b: {
@@ -2747,12 +3746,24 @@ export const mockAnalysisWithSegments = mockAnalysis({
                   ],
                 },
                 difference: {
-                  first: {},
-                  all: [],
+                  control: {
+                    first: {},
+                    all: [],
+                  },
+                  treatment: {
+                    first: {},
+                    all: [],
+                  },
                 },
                 relative_uplift: {
-                  first: {},
-                  all: [],
+                  control: {
+                    first: {},
+                    all: [],
+                  },
+                  treatment: {
+                    first: {},
+                    all: [],
+                  },
                 },
               },
               feature_c_ever_used: {
@@ -2773,12 +3784,24 @@ export const mockAnalysisWithSegments = mockAnalysis({
                   ],
                 },
                 difference: {
-                  first: {},
-                  all: [],
+                  control: {
+                    first: {},
+                    all: [],
+                  },
+                  treatment: {
+                    first: {},
+                    all: [],
+                  },
                 },
                 relative_uplift: {
-                  first: {},
-                  all: [],
+                  control: {
+                    first: {},
+                    all: [],
+                  },
+                  treatment: {
+                    first: {},
+                    all: [],
+                  },
                 },
               },
               feature_c: CONTROL_NEUTRAL,
@@ -2800,12 +3823,24 @@ export const mockAnalysisWithSegments = mockAnalysis({
                   ],
                 },
                 difference: {
-                  first: {},
-                  all: [],
+                  control: {
+                    first: {},
+                    all: [],
+                  },
+                  treatment: {
+                    first: {},
+                    all: [],
+                  },
                 },
                 relative_uplift: {
-                  first: {},
-                  all: [],
+                  control: {
+                    first: {},
+                    all: [],
+                  },
+                  treatment: {
+                    first: {},
+                    all: [],
+                  },
                 },
               },
               outcome_d: {
@@ -2826,12 +3861,24 @@ export const mockAnalysisWithSegments = mockAnalysis({
                   ],
                 },
                 difference: {
-                  first: {},
-                  all: [],
+                  control: {
+                    first: {},
+                    all: [],
+                  },
+                  treatment: {
+                    first: {},
+                    all: [],
+                  },
                 },
                 relative_uplift: {
-                  first: {},
-                  all: [],
+                  control: {
+                    first: {},
+                    all: [],
+                  },
+                  treatment: {
+                    first: {},
+                    all: [],
+                  },
                 },
               },
               days_of_use: CONTROL_NEUTRAL,
@@ -2854,12 +3901,24 @@ export const mockAnalysisWithSegments = mockAnalysis({
                   },
                 },
                 difference: {
-                  first: {},
-                  all: [],
+                  control: {
+                    first: {},
+                    all: [],
+                  },
+                  treatment: {
+                    first: {},
+                    all: [],
+                  },
                 },
                 relative_uplift: {
-                  first: {},
-                  all: [],
+                  control: {
+                    first: {},
+                    all: [],
+                  },
+                  treatment: {
+                    first: {},
+                    all: [],
+                  },
                 },
               },
             },
@@ -2881,12 +3940,24 @@ export const mockAnalysisWithSegments = mockAnalysis({
                   ],
                 },
                 difference: {
-                  first: {},
-                  all: [],
+                  control: {
+                    first: {},
+                    all: [],
+                  },
+                  treatment: {
+                    first: {},
+                    all: [],
+                  },
                 },
                 relative_uplift: {
-                  first: {},
-                  all: [],
+                  control: {
+                    first: {},
+                    all: [],
+                  },
+                  treatment: {
+                    first: {},
+                    all: [],
+                  },
                 },
                 percent: 55,
               },
@@ -2909,34 +3980,55 @@ export const mockAnalysisWithSegments = mockAnalysis({
                   ],
                 },
                 difference: {
-                  first: {
-                    point: -0.0007569487628876534,
-                    upper: 0.04416381736512019,
-                    lower: 0.04075095963994029,
-                  },
-                  all: [
-                    {
+                  control: {
+                    first: {
                       point: -0.0007569487628876534,
                       upper: 0.04416381736512019,
                       lower: 0.04075095963994029,
                     },
-                  ],
+                    all: [
+                      {
+                        point: -0.0007569487628876534,
+                        upper: 0.04416381736512019,
+                        lower: 0.04075095963994029,
+                      },
+                    ],
+                  },
+                  treatment: {
+                    first: {},
+                    all: [],
+                  },
                 },
                 relative_uplift: {
-                  first: {
-                    lower: -0.465210299676828,
-                    upper: 0.5204985718410426,
-                    point: -0.07233954570562385,
-                  },
-                  all: [
-                    {
+                  control: {
+                    first: {
                       lower: -0.465210299676828,
                       upper: 0.5204985718410426,
                       point: -0.07233954570562385,
                     },
-                  ],
+                    all: [
+                      {
+                        lower: -0.465210299676828,
+                        upper: 0.5204985718410426,
+                        point: -0.07233954570562385,
+                      },
+                    ],
+                  },
+                  treatment: {
+                    first: {},
+                    all: [],
+                  },
                 },
-                significance: { overall: { "1": "positive" }, weekly: {} },
+                significance: {
+                  control: {
+                    overall: { "1": "positive" },
+                    weekly: {},
+                  },
+                  treatment: {
+                    overall: {},
+                    weekly: {},
+                  },
+                },
               },
               picture_in_picture: {
                 absolute: {
@@ -2956,34 +4048,55 @@ export const mockAnalysisWithSegments = mockAnalysis({
                   ],
                 },
                 difference: {
-                  first: {
-                    point: -0.0007569487628876534,
-                    upper: 0.04416381736512019,
-                    lower: 0.04075095963994029,
-                  },
-                  all: [
-                    {
+                  control: {
+                    first: {
                       point: -0.0007569487628876534,
                       upper: 0.04416381736512019,
                       lower: 0.04075095963994029,
                     },
-                  ],
+                    all: [
+                      {
+                        point: -0.0007569487628876534,
+                        upper: 0.04416381736512019,
+                        lower: 0.04075095963994029,
+                      },
+                    ],
+                  },
+                  treatment: {
+                    first: {},
+                    all: [],
+                  },
                 },
                 relative_uplift: {
-                  first: {
-                    lower: -0.465210299676828,
-                    upper: 0.5204985718410426,
-                    point: -0.07233954570562385,
-                  },
-                  all: [
-                    {
+                  control: {
+                    first: {
                       lower: -0.465210299676828,
                       upper: 0.5204985718410426,
                       point: -0.07233954570562385,
                     },
-                  ],
+                    all: [
+                      {
+                        lower: -0.465210299676828,
+                        upper: 0.5204985718410426,
+                        point: -0.07233954570562385,
+                      },
+                    ],
+                  },
+                  treatment: {
+                    first: {},
+                    all: [],
+                  },
                 },
-                significance: { overall: { "1": "positive" }, weekly: {} },
+                significance: {
+                  control: {
+                    overall: { "1": "positive" },
+                    weekly: {},
+                  },
+                  treatment: {
+                    overall: {},
+                    weekly: {},
+                  },
+                },
               },
               feature_b_ever_used: {
                 absolute: {
@@ -3003,34 +4116,55 @@ export const mockAnalysisWithSegments = mockAnalysis({
                   ],
                 },
                 difference: {
-                  first: {
-                    point: -0.0007569487628876534,
-                    upper: 0.04416381736512019,
-                    lower: 0.04075095963994029,
-                  },
-                  all: [
-                    {
+                  control: {
+                    first: {
                       point: -0.0007569487628876534,
                       upper: 0.04416381736512019,
                       lower: 0.04075095963994029,
                     },
-                  ],
+                    all: [
+                      {
+                        point: -0.0007569487628876534,
+                        upper: 0.04416381736512019,
+                        lower: 0.04075095963994029,
+                      },
+                    ],
+                  },
+                  treatment: {
+                    first: {},
+                    all: [],
+                  },
                 },
                 relative_uplift: {
-                  first: {
-                    lower: -0.465210299676828,
-                    upper: 0.5204985718410426,
-                    point: -0.07233954570562385,
-                  },
-                  all: [
-                    {
+                  control: {
+                    first: {
                       lower: -0.465210299676828,
                       upper: 0.5204985718410426,
                       point: -0.07233954570562385,
                     },
-                  ],
+                    all: [
+                      {
+                        lower: -0.465210299676828,
+                        upper: 0.5204985718410426,
+                        point: -0.07233954570562385,
+                      },
+                    ],
+                  },
+                  treatment: {
+                    first: {},
+                    all: [],
+                  },
                 },
-                significance: { overall: { "1": "negative" }, weekly: {} },
+                significance: {
+                  control: {
+                    overall: { "1": "negative" },
+                    weekly: {},
+                  },
+                  treatment: {
+                    overall: {},
+                    weekly: {},
+                  },
+                },
               },
               feature_b: {
                 absolute: {
@@ -3050,34 +4184,55 @@ export const mockAnalysisWithSegments = mockAnalysis({
                   ],
                 },
                 difference: {
-                  first: {
-                    point: -0.0007569487628876534,
-                    upper: 0.04416381736512019,
-                    lower: 0.04075095963994029,
-                  },
-                  all: [
-                    {
+                  control: {
+                    first: {
                       point: -0.0007569487628876534,
                       upper: 0.04416381736512019,
                       lower: 0.04075095963994029,
                     },
-                  ],
+                    all: [
+                      {
+                        point: -0.0007569487628876534,
+                        upper: 0.04416381736512019,
+                        lower: 0.04075095963994029,
+                      },
+                    ],
+                  },
+                  treatment: {
+                    first: {},
+                    all: [],
+                  },
                 },
                 relative_uplift: {
-                  first: {
-                    lower: -0.465210299676828,
-                    upper: 0.5204985718410426,
-                    point: -0.07233954570562385,
-                  },
-                  all: [
-                    {
+                  control: {
+                    first: {
                       lower: -0.465210299676828,
                       upper: 0.5204985718410426,
                       point: -0.07233954570562385,
                     },
-                  ],
+                    all: [
+                      {
+                        lower: -0.465210299676828,
+                        upper: 0.5204985718410426,
+                        point: -0.07233954570562385,
+                      },
+                    ],
+                  },
+                  treatment: {
+                    first: {},
+                    all: [],
+                  },
                 },
-                significance: { overall: { "1": "negative" }, weekly: {} },
+                significance: {
+                  control: {
+                    overall: { "1": "negative" },
+                    weekly: {},
+                  },
+                  treatment: {
+                    overall: {},
+                    weekly: {},
+                  },
+                },
               },
               feature_c_ever_used: {
                 absolute: {
@@ -3097,34 +4252,55 @@ export const mockAnalysisWithSegments = mockAnalysis({
                   ],
                 },
                 difference: {
-                  first: {
-                    point: -0.0007569487628876534,
-                    upper: 0.04416381736512019,
-                    lower: 0.04075095963994029,
-                  },
-                  all: [
-                    {
+                  control: {
+                    first: {
                       point: -0.0007569487628876534,
                       upper: 0.04416381736512019,
                       lower: 0.04075095963994029,
                     },
-                  ],
+                    all: [
+                      {
+                        point: -0.0007569487628876534,
+                        upper: 0.04416381736512019,
+                        lower: 0.04075095963994029,
+                      },
+                    ],
+                  },
+                  treatment: {
+                    first: {},
+                    all: [],
+                  },
                 },
                 relative_uplift: {
-                  first: {
-                    lower: -0.465210299676828,
-                    upper: 0.5204985718410426,
-                    point: -0.07233954570562385,
-                  },
-                  all: [
-                    {
+                  control: {
+                    first: {
                       lower: -0.465210299676828,
                       upper: 0.5204985718410426,
                       point: -0.07233954570562385,
                     },
-                  ],
+                    all: [
+                      {
+                        lower: -0.465210299676828,
+                        upper: 0.5204985718410426,
+                        point: -0.07233954570562385,
+                      },
+                    ],
+                  },
+                  treatment: {
+                    first: {},
+                    all: [],
+                  },
                 },
-                significance: { overall: { "1": "neutral" }, weekly: {} },
+                significance: {
+                  control: {
+                    overall: { "1": "neutral" },
+                    weekly: {},
+                  },
+                  treatment: {
+                    overall: {},
+                    weekly: {},
+                  },
+                },
               },
               feature_c: TREATMENT_NEUTRAL,
               days_of_use: TREATMENT_NEUTRAL,
@@ -3147,34 +4323,55 @@ export const mockAnalysisWithSegments = mockAnalysis({
                   ],
                 },
                 difference: {
-                  first: {
-                    point: -0.0007569487628876534,
-                    upper: 0.04416381736512019,
-                    lower: 0.04075095963994029,
-                  },
-                  all: [
-                    {
+                  control: {
+                    first: {
                       point: -0.0007569487628876534,
                       upper: 0.04416381736512019,
                       lower: 0.04075095963994029,
                     },
-                  ],
+                    all: [
+                      {
+                        point: -0.0007569487628876534,
+                        upper: 0.04416381736512019,
+                        lower: 0.04075095963994029,
+                      },
+                    ],
+                  },
+                  treatment: {
+                    first: {},
+                    all: [],
+                  },
                 },
                 relative_uplift: {
-                  first: {
-                    lower: -0.465210299676828,
-                    upper: 0.5204985718410426,
-                    point: -0.07233954570562385,
-                  },
-                  all: [
-                    {
+                  control: {
+                    first: {
                       lower: -0.465210299676828,
                       upper: 0.5204985718410426,
                       point: -0.07233954570562385,
                     },
-                  ],
+                    all: [
+                      {
+                        lower: -0.465210299676828,
+                        upper: 0.5204985718410426,
+                        point: -0.07233954570562385,
+                      },
+                    ],
+                  },
+                  treatment: {
+                    first: {},
+                    all: [],
+                  },
                 },
-                significance: { overall: { "1": "positive" }, weekly: {} },
+                significance: {
+                  control: {
+                    overall: { "1": "positive" },
+                    weekly: {},
+                  },
+                  treatment: {
+                    overall: {},
+                    weekly: {},
+                  },
+                },
               },
               outcome_d: {
                 absolute: {
@@ -3194,34 +4391,55 @@ export const mockAnalysisWithSegments = mockAnalysis({
                   ],
                 },
                 difference: {
-                  first: {
-                    point: -0.0007569487628876534,
-                    upper: 0.04416381736512019,
-                    lower: 0.04075095963994029,
-                  },
-                  all: [
-                    {
+                  control: {
+                    first: {
                       point: -0.0007569487628876534,
                       upper: 0.04416381736512019,
                       lower: 0.04075095963994029,
                     },
-                  ],
+                    all: [
+                      {
+                        point: -0.0007569487628876534,
+                        upper: 0.04416381736512019,
+                        lower: 0.04075095963994029,
+                      },
+                    ],
+                  },
+                  treatment: {
+                    first: {},
+                    all: [],
+                  },
                 },
                 relative_uplift: {
-                  first: {
-                    lower: -0.465210299676828,
-                    upper: 0.5204985718410426,
-                    point: -0.07233954570562385,
-                  },
-                  all: [
-                    {
+                  control: {
+                    first: {
                       lower: -0.465210299676828,
                       upper: 0.5204985718410426,
                       point: -0.07233954570562385,
                     },
-                  ],
+                    all: [
+                      {
+                        lower: -0.465210299676828,
+                        upper: 0.5204985718410426,
+                        point: -0.07233954570562385,
+                      },
+                    ],
+                  },
+                  treatment: {
+                    first: {},
+                    all: [],
+                  },
                 },
-                significance: { overall: { "1": "positive" }, weekly: {} },
+                significance: {
+                  control: {
+                    overall: { "1": "positive" },
+                    weekly: {},
+                  },
+                  treatment: {
+                    overall: {},
+                    weekly: {},
+                  },
+                },
               },
             },
             search_metrics: {
@@ -3254,12 +4472,24 @@ export const mockAnalysisWithExposures = mockAnalysis({
                   },
                 },
                 difference: {
-                  first: {},
-                  all: [],
+                  control: {
+                    first: {},
+                    all: [],
+                  },
+                  treatment: {
+                    first: {},
+                    all: [],
+                  },
                 },
                 relative_uplift: {
-                  first: {},
-                  all: [],
+                  control: {
+                    first: {},
+                    all: [],
+                  },
+                  treatment: {
+                    first: {},
+                    all: [],
+                  },
                 },
                 percent: 45,
               },
@@ -3279,12 +4509,24 @@ export const mockAnalysisWithExposures = mockAnalysis({
                   },
                 },
                 difference: {
-                  first: {},
-                  all: [],
+                  control: {
+                    first: {},
+                    all: [],
+                  },
+                  treatment: {
+                    first: {},
+                    all: [],
+                  },
                 },
                 relative_uplift: {
-                  first: {},
-                  all: [],
+                  control: {
+                    first: {},
+                    all: [],
+                  },
+                  treatment: {
+                    first: {},
+                    all: [],
+                  },
                 },
               },
               picture_in_picture_ever_used: {
@@ -3305,12 +4547,24 @@ export const mockAnalysisWithExposures = mockAnalysis({
                   ],
                 },
                 difference: {
-                  first: {},
-                  all: [],
+                  control: {
+                    first: {},
+                    all: [],
+                  },
+                  treatment: {
+                    first: {},
+                    all: [],
+                  },
                 },
                 relative_uplift: {
-                  first: {},
-                  all: [],
+                  control: {
+                    first: {},
+                    all: [],
+                  },
+                  treatment: {
+                    first: {},
+                    all: [],
+                  },
                 },
               },
               picture_in_picture: {
@@ -3331,12 +4585,24 @@ export const mockAnalysisWithExposures = mockAnalysis({
                   ],
                 },
                 difference: {
-                  first: {},
-                  all: [],
+                  control: {
+                    first: {},
+                    all: [],
+                  },
+                  treatment: {
+                    first: {},
+                    all: [],
+                  },
                 },
                 relative_uplift: {
-                  first: {},
-                  all: [],
+                  control: {
+                    first: {},
+                    all: [],
+                  },
+                  treatment: {
+                    first: {},
+                    all: [],
+                  },
                 },
               },
               feature_b_ever_used: {
@@ -3357,12 +4623,24 @@ export const mockAnalysisWithExposures = mockAnalysis({
                   ],
                 },
                 difference: {
-                  first: {},
-                  all: [],
+                  control: {
+                    first: {},
+                    all: [],
+                  },
+                  treatment: {
+                    first: {},
+                    all: [],
+                  },
                 },
                 relative_uplift: {
-                  first: {},
-                  all: [],
+                  control: {
+                    first: {},
+                    all: [],
+                  },
+                  treatment: {
+                    first: {},
+                    all: [],
+                  },
                 },
               },
               feature_b: {
@@ -3383,12 +4661,24 @@ export const mockAnalysisWithExposures = mockAnalysis({
                   ],
                 },
                 difference: {
-                  first: {},
-                  all: [],
+                  control: {
+                    first: {},
+                    all: [],
+                  },
+                  treatment: {
+                    first: {},
+                    all: [],
+                  },
                 },
                 relative_uplift: {
-                  first: {},
-                  all: [],
+                  control: {
+                    first: {},
+                    all: [],
+                  },
+                  treatment: {
+                    first: {},
+                    all: [],
+                  },
                 },
               },
               feature_c_ever_used: {
@@ -3409,12 +4699,24 @@ export const mockAnalysisWithExposures = mockAnalysis({
                   ],
                 },
                 difference: {
-                  first: {},
-                  all: [],
+                  control: {
+                    first: {},
+                    all: [],
+                  },
+                  treatment: {
+                    first: {},
+                    all: [],
+                  },
                 },
                 relative_uplift: {
-                  first: {},
-                  all: [],
+                  control: {
+                    first: {},
+                    all: [],
+                  },
+                  treatment: {
+                    first: {},
+                    all: [],
+                  },
                 },
               },
               feature_c: CONTROL_NEUTRAL,
@@ -3436,12 +4738,24 @@ export const mockAnalysisWithExposures = mockAnalysis({
                   ],
                 },
                 difference: {
-                  first: {},
-                  all: [],
+                  control: {
+                    first: {},
+                    all: [],
+                  },
+                  treatment: {
+                    first: {},
+                    all: [],
+                  },
                 },
                 relative_uplift: {
-                  first: {},
-                  all: [],
+                  control: {
+                    first: {},
+                    all: [],
+                  },
+                  treatment: {
+                    first: {},
+                    all: [],
+                  },
                 },
               },
               outcome_d: {
@@ -3462,12 +4776,24 @@ export const mockAnalysisWithExposures = mockAnalysis({
                   ],
                 },
                 difference: {
-                  first: {},
-                  all: [],
+                  control: {
+                    first: {},
+                    all: [],
+                  },
+                  treatment: {
+                    first: {},
+                    all: [],
+                  },
                 },
                 relative_uplift: {
-                  first: {},
-                  all: [],
+                  control: {
+                    first: {},
+                    all: [],
+                  },
+                  treatment: {
+                    first: {},
+                    all: [],
+                  },
                 },
               },
               days_of_use: CONTROL_NEUTRAL,
@@ -3490,12 +4816,24 @@ export const mockAnalysisWithExposures = mockAnalysis({
                   },
                 },
                 difference: {
-                  first: {},
-                  all: [],
+                  control: {
+                    first: {},
+                    all: [],
+                  },
+                  treatment: {
+                    first: {},
+                    all: [],
+                  },
                 },
                 relative_uplift: {
-                  first: {},
-                  all: [],
+                  control: {
+                    first: {},
+                    all: [],
+                  },
+                  treatment: {
+                    first: {},
+                    all: [],
+                  },
                 },
               },
             },
@@ -3517,12 +4855,24 @@ export const mockAnalysisWithExposures = mockAnalysis({
                   ],
                 },
                 difference: {
-                  first: {},
-                  all: [],
+                  control: {
+                    first: {},
+                    all: [],
+                  },
+                  treatment: {
+                    first: {},
+                    all: [],
+                  },
                 },
                 relative_uplift: {
-                  first: {},
-                  all: [],
+                  control: {
+                    first: {},
+                    all: [],
+                  },
+                  treatment: {
+                    first: {},
+                    all: [],
+                  },
                 },
                 percent: 55,
               },
@@ -3545,34 +4895,55 @@ export const mockAnalysisWithExposures = mockAnalysis({
                   ],
                 },
                 difference: {
-                  first: {
-                    point: -0.0006569487628876534,
-                    upper: 0.04316381736512019,
-                    lower: 0.04175095963994029,
-                  },
-                  all: [
-                    {
+                  control: {
+                    first: {
                       point: -0.0006569487628876534,
                       upper: 0.04316381736512019,
                       lower: 0.04175095963994029,
                     },
-                  ],
+                    all: [
+                      {
+                        point: -0.0006569487628876534,
+                        upper: 0.04316381736512019,
+                        lower: 0.04175095963994029,
+                      },
+                    ],
+                  },
+                  treatment: {
+                    first: {},
+                    all: [],
+                  },
                 },
                 relative_uplift: {
-                  first: {
-                    lower: -0.455210299676828,
-                    upper: 0.5104985718410426,
-                    point: -0.06233954570562385,
-                  },
-                  all: [
-                    {
+                  control: {
+                    first: {
                       lower: -0.455210299676828,
                       upper: 0.5104985718410426,
                       point: -0.06233954570562385,
                     },
-                  ],
+                    all: [
+                      {
+                        lower: -0.455210299676828,
+                        upper: 0.5104985718410426,
+                        point: -0.06233954570562385,
+                      },
+                    ],
+                  },
+                  treatment: {
+                    first: {},
+                    all: [],
+                  },
                 },
-                significance: { overall: { "1": "positive" }, weekly: {} },
+                significance: {
+                  control: {
+                    overall: { "1": "positive" },
+                    weekly: {},
+                  },
+                  treatment: {
+                    overall: {},
+                    weekly: {},
+                  },
+                },
               },
               picture_in_picture: {
                 absolute: {
@@ -3592,34 +4963,55 @@ export const mockAnalysisWithExposures = mockAnalysis({
                   ],
                 },
                 difference: {
-                  first: {
-                    point: -0.0006569487628876534,
-                    upper: 0.04316381736512019,
-                    lower: 0.04175095963994029,
-                  },
-                  all: [
-                    {
+                  control: {
+                    first: {
                       point: -0.0006569487628876534,
                       upper: 0.04316381736512019,
                       lower: 0.04175095963994029,
                     },
-                  ],
+                    all: [
+                      {
+                        point: -0.0006569487628876534,
+                        upper: 0.04316381736512019,
+                        lower: 0.04175095963994029,
+                      },
+                    ],
+                  },
+                  treatment: {
+                    first: {},
+                    all: [],
+                  },
                 },
                 relative_uplift: {
-                  first: {
-                    lower: -0.455210299676828,
-                    upper: 0.5104985718410426,
-                    point: -0.06233954570562385,
-                  },
-                  all: [
-                    {
+                  control: {
+                    first: {
                       lower: -0.455210299676828,
                       upper: 0.5104985718410426,
                       point: -0.06233954570562385,
                     },
-                  ],
+                    all: [
+                      {
+                        lower: -0.455210299676828,
+                        upper: 0.5104985718410426,
+                        point: -0.06233954570562385,
+                      },
+                    ],
+                  },
+                  treatment: {
+                    first: {},
+                    all: [],
+                  },
                 },
-                significance: { overall: { "1": "positive" }, weekly: {} },
+                significance: {
+                  control: {
+                    overall: { "1": "positive" },
+                    weekly: {},
+                  },
+                  treatment: {
+                    overall: {},
+                    weekly: {},
+                  },
+                },
               },
               feature_b_ever_used: {
                 absolute: {
@@ -3639,34 +5031,55 @@ export const mockAnalysisWithExposures = mockAnalysis({
                   ],
                 },
                 difference: {
-                  first: {
-                    point: -0.0006569487628876534,
-                    upper: 0.04316381736512019,
-                    lower: 0.04175095963994029,
-                  },
-                  all: [
-                    {
+                  control: {
+                    first: {
                       point: -0.0006569487628876534,
                       upper: 0.04316381736512019,
                       lower: 0.04175095963994029,
                     },
-                  ],
+                    all: [
+                      {
+                        point: -0.0006569487628876534,
+                        upper: 0.04316381736512019,
+                        lower: 0.04175095963994029,
+                      },
+                    ],
+                  },
+                  treatment: {
+                    first: {},
+                    all: [],
+                  },
                 },
                 relative_uplift: {
-                  first: {
-                    lower: -0.455210299676828,
-                    upper: 0.5104985718410426,
-                    point: -0.06233954570562385,
-                  },
-                  all: [
-                    {
+                  control: {
+                    first: {
                       lower: -0.455210299676828,
                       upper: 0.5104985718410426,
                       point: -0.06233954570562385,
                     },
-                  ],
+                    all: [
+                      {
+                        lower: -0.455210299676828,
+                        upper: 0.5104985718410426,
+                        point: -0.06233954570562385,
+                      },
+                    ],
+                  },
+                  treatment: {
+                    first: {},
+                    all: [],
+                  },
                 },
-                significance: { overall: { "1": "negative" }, weekly: {} },
+                significance: {
+                  control: {
+                    overall: { "1": "negative" },
+                    weekly: {},
+                  },
+                  treatment: {
+                    overall: {},
+                    weekly: {},
+                  },
+                },
               },
               feature_b: {
                 absolute: {
@@ -3686,34 +5099,55 @@ export const mockAnalysisWithExposures = mockAnalysis({
                   ],
                 },
                 difference: {
-                  first: {
-                    point: -0.0006569487628876534,
-                    upper: 0.04316381736512019,
-                    lower: 0.04175095963994029,
-                  },
-                  all: [
-                    {
+                  control: {
+                    first: {
                       point: -0.0006569487628876534,
                       upper: 0.04316381736512019,
                       lower: 0.04175095963994029,
                     },
-                  ],
+                    all: [
+                      {
+                        point: -0.0006569487628876534,
+                        upper: 0.04316381736512019,
+                        lower: 0.04175095963994029,
+                      },
+                    ],
+                  },
+                  treatment: {
+                    first: {},
+                    all: [],
+                  },
                 },
                 relative_uplift: {
-                  first: {
-                    lower: -0.455210299676828,
-                    upper: 0.5104985718410426,
-                    point: -0.06233954570562385,
-                  },
-                  all: [
-                    {
+                  control: {
+                    first: {
                       lower: -0.455210299676828,
                       upper: 0.5104985718410426,
                       point: -0.06233954570562385,
                     },
-                  ],
+                    all: [
+                      {
+                        lower: -0.455210299676828,
+                        upper: 0.5104985718410426,
+                        point: -0.06233954570562385,
+                      },
+                    ],
+                  },
+                  treatment: {
+                    first: {},
+                    all: [],
+                  },
                 },
-                significance: { overall: { "1": "negative" }, weekly: {} },
+                significance: {
+                  control: {
+                    overall: { "1": "negative" },
+                    weekly: {},
+                  },
+                  treatment: {
+                    overall: {},
+                    weekly: {},
+                  },
+                },
               },
               feature_c_ever_used: {
                 absolute: {
@@ -3733,34 +5167,55 @@ export const mockAnalysisWithExposures = mockAnalysis({
                   ],
                 },
                 difference: {
-                  first: {
-                    point: -0.0006569487628876534,
-                    upper: 0.04316381736512019,
-                    lower: 0.04175095963994029,
-                  },
-                  all: [
-                    {
+                  control: {
+                    first: {
                       point: -0.0006569487628876534,
                       upper: 0.04316381736512019,
                       lower: 0.04175095963994029,
                     },
-                  ],
+                    all: [
+                      {
+                        point: -0.0006569487628876534,
+                        upper: 0.04316381736512019,
+                        lower: 0.04175095963994029,
+                      },
+                    ],
+                  },
+                  treatment: {
+                    first: {},
+                    all: [],
+                  },
                 },
                 relative_uplift: {
-                  first: {
-                    lower: -0.455210299676828,
-                    upper: 0.5104985718410426,
-                    point: -0.06233954570562385,
-                  },
-                  all: [
-                    {
+                  control: {
+                    first: {
                       lower: -0.455210299676828,
                       upper: 0.5104985718410426,
                       point: -0.06233954570562385,
                     },
-                  ],
+                    all: [
+                      {
+                        lower: -0.455210299676828,
+                        upper: 0.5104985718410426,
+                        point: -0.06233954570562385,
+                      },
+                    ],
+                  },
+                  treatment: {
+                    first: {},
+                    all: [],
+                  },
                 },
-                significance: { overall: { "1": "neutral" }, weekly: {} },
+                significance: {
+                  control: {
+                    overall: { "1": "neutral" },
+                    weekly: {},
+                  },
+                  treatment: {
+                    overall: {},
+                    weekly: {},
+                  },
+                },
               },
               feature_c: TREATMENT_NEUTRAL,
               days_of_use: TREATMENT_NEUTRAL,
@@ -3783,34 +5238,55 @@ export const mockAnalysisWithExposures = mockAnalysis({
                   ],
                 },
                 difference: {
-                  first: {
-                    point: -0.0006569487628876534,
-                    upper: 0.04316381736512019,
-                    lower: 0.04175095963994029,
-                  },
-                  all: [
-                    {
+                  control: {
+                    first: {
                       point: -0.0006569487628876534,
                       upper: 0.04316381736512019,
                       lower: 0.04175095963994029,
                     },
-                  ],
+                    all: [
+                      {
+                        point: -0.0006569487628876534,
+                        upper: 0.04316381736512019,
+                        lower: 0.04175095963994029,
+                      },
+                    ],
+                  },
+                  treatment: {
+                    first: {},
+                    all: [],
+                  },
                 },
                 relative_uplift: {
-                  first: {
-                    lower: -0.455210299676828,
-                    upper: 0.5104985718410426,
-                    point: -0.06233954570562385,
-                  },
-                  all: [
-                    {
+                  control: {
+                    first: {
                       lower: -0.455210299676828,
                       upper: 0.5104985718410426,
                       point: -0.06233954570562385,
                     },
-                  ],
+                    all: [
+                      {
+                        lower: -0.455210299676828,
+                        upper: 0.5104985718410426,
+                        point: -0.06233954570562385,
+                      },
+                    ],
+                  },
+                  treatment: {
+                    first: {},
+                    all: [],
+                  },
                 },
-                significance: { overall: { "1": "positive" }, weekly: {} },
+                significance: {
+                  control: {
+                    overall: { "1": "positive" },
+                    weekly: {},
+                  },
+                  treatment: {
+                    overall: {},
+                    weekly: {},
+                  },
+                },
               },
               outcome_d: {
                 absolute: {
@@ -3830,34 +5306,55 @@ export const mockAnalysisWithExposures = mockAnalysis({
                   ],
                 },
                 difference: {
-                  first: {
-                    point: -0.0006569487628876534,
-                    upper: 0.04316381736512019,
-                    lower: 0.04175095963994029,
-                  },
-                  all: [
-                    {
+                  control: {
+                    first: {
                       point: -0.0006569487628876534,
                       upper: 0.04316381736512019,
                       lower: 0.04175095963994029,
                     },
-                  ],
+                    all: [
+                      {
+                        point: -0.0006569487628876534,
+                        upper: 0.04316381736512019,
+                        lower: 0.04175095963994029,
+                      },
+                    ],
+                  },
+                  treatment: {
+                    first: {},
+                    all: [],
+                  },
                 },
                 relative_uplift: {
-                  first: {
-                    lower: -0.455210299676828,
-                    upper: 0.5104985718410426,
-                    point: -0.06233954570562385,
-                  },
-                  all: [
-                    {
+                  control: {
+                    first: {
                       lower: -0.455210299676828,
                       upper: 0.5104985718410426,
                       point: -0.06233954570562385,
                     },
-                  ],
+                    all: [
+                      {
+                        lower: -0.455210299676828,
+                        upper: 0.5104985718410426,
+                        point: -0.06233954570562385,
+                      },
+                    ],
+                  },
+                  treatment: {
+                    first: {},
+                    all: [],
+                  },
                 },
-                significance: { overall: { "1": "positive" }, weekly: {} },
+                significance: {
+                  control: {
+                    overall: { "1": "positive" },
+                    weekly: {},
+                  },
+                  treatment: {
+                    overall: {},
+                    weekly: {},
+                  },
+                },
               },
             },
             search_metrics: {
@@ -3885,12 +5382,24 @@ export const mockAnalysisWithExposures = mockAnalysis({
                   },
                 },
                 difference: {
-                  first: {},
-                  all: [],
+                  control: {
+                    first: {},
+                    all: [],
+                  },
+                  treatment: {
+                    first: {},
+                    all: [],
+                  },
                 },
                 relative_uplift: {
-                  first: {},
-                  all: [],
+                  control: {
+                    first: {},
+                    all: [],
+                  },
+                  treatment: {
+                    first: {},
+                    all: [],
+                  },
                 },
                 percent: 45,
               },
@@ -3910,12 +5419,24 @@ export const mockAnalysisWithExposures = mockAnalysis({
                   },
                 },
                 difference: {
-                  first: {},
-                  all: [],
+                  control: {
+                    first: {},
+                    all: [],
+                  },
+                  treatment: {
+                    first: {},
+                    all: [],
+                  },
                 },
                 relative_uplift: {
-                  first: {},
-                  all: [],
+                  control: {
+                    first: {},
+                    all: [],
+                  },
+                  treatment: {
+                    first: {},
+                    all: [],
+                  },
                 },
               },
               picture_in_picture_ever_used: {
@@ -3936,12 +5457,24 @@ export const mockAnalysisWithExposures = mockAnalysis({
                   ],
                 },
                 difference: {
-                  first: {},
-                  all: [],
+                  control: {
+                    first: {},
+                    all: [],
+                  },
+                  treatment: {
+                    first: {},
+                    all: [],
+                  },
                 },
                 relative_uplift: {
-                  first: {},
-                  all: [],
+                  control: {
+                    first: {},
+                    all: [],
+                  },
+                  treatment: {
+                    first: {},
+                    all: [],
+                  },
                 },
               },
               picture_in_picture: {
@@ -3962,12 +5495,24 @@ export const mockAnalysisWithExposures = mockAnalysis({
                   ],
                 },
                 difference: {
-                  first: {},
-                  all: [],
+                  control: {
+                    first: {},
+                    all: [],
+                  },
+                  treatment: {
+                    first: {},
+                    all: [],
+                  },
                 },
                 relative_uplift: {
-                  first: {},
-                  all: [],
+                  control: {
+                    first: {},
+                    all: [],
+                  },
+                  treatment: {
+                    first: {},
+                    all: [],
+                  },
                 },
               },
               feature_b_ever_used: {
@@ -3988,12 +5533,24 @@ export const mockAnalysisWithExposures = mockAnalysis({
                   ],
                 },
                 difference: {
-                  first: {},
-                  all: [],
+                  control: {
+                    first: {},
+                    all: [],
+                  },
+                  treatment: {
+                    first: {},
+                    all: [],
+                  },
                 },
                 relative_uplift: {
-                  first: {},
-                  all: [],
+                  control: {
+                    first: {},
+                    all: [],
+                  },
+                  treatment: {
+                    first: {},
+                    all: [],
+                  },
                 },
               },
               feature_b: {
@@ -4014,12 +5571,24 @@ export const mockAnalysisWithExposures = mockAnalysis({
                   ],
                 },
                 difference: {
-                  first: {},
-                  all: [],
+                  control: {
+                    first: {},
+                    all: [],
+                  },
+                  treatment: {
+                    first: {},
+                    all: [],
+                  },
                 },
                 relative_uplift: {
-                  first: {},
-                  all: [],
+                  control: {
+                    first: {},
+                    all: [],
+                  },
+                  treatment: {
+                    first: {},
+                    all: [],
+                  },
                 },
               },
               feature_c_ever_used: {
@@ -4040,12 +5609,24 @@ export const mockAnalysisWithExposures = mockAnalysis({
                   ],
                 },
                 difference: {
-                  first: {},
-                  all: [],
+                  control: {
+                    first: {},
+                    all: [],
+                  },
+                  treatment: {
+                    first: {},
+                    all: [],
+                  },
                 },
                 relative_uplift: {
-                  first: {},
-                  all: [],
+                  control: {
+                    first: {},
+                    all: [],
+                  },
+                  treatment: {
+                    first: {},
+                    all: [],
+                  },
                 },
               },
               feature_c: CONTROL_NEUTRAL,
@@ -4067,12 +5648,24 @@ export const mockAnalysisWithExposures = mockAnalysis({
                   ],
                 },
                 difference: {
-                  first: {},
-                  all: [],
+                  control: {
+                    first: {},
+                    all: [],
+                  },
+                  treatment: {
+                    first: {},
+                    all: [],
+                  },
                 },
                 relative_uplift: {
-                  first: {},
-                  all: [],
+                  control: {
+                    first: {},
+                    all: [],
+                  },
+                  treatment: {
+                    first: {},
+                    all: [],
+                  },
                 },
               },
               outcome_d: {
@@ -4093,12 +5686,24 @@ export const mockAnalysisWithExposures = mockAnalysis({
                   ],
                 },
                 difference: {
-                  first: {},
-                  all: [],
+                  control: {
+                    first: {},
+                    all: [],
+                  },
+                  treatment: {
+                    first: {},
+                    all: [],
+                  },
                 },
                 relative_uplift: {
-                  first: {},
-                  all: [],
+                  control: {
+                    first: {},
+                    all: [],
+                  },
+                  treatment: {
+                    first: {},
+                    all: [],
+                  },
                 },
               },
               days_of_use: CONTROL_NEUTRAL,
@@ -4121,12 +5726,24 @@ export const mockAnalysisWithExposures = mockAnalysis({
                   },
                 },
                 difference: {
-                  first: {},
-                  all: [],
+                  control: {
+                    first: {},
+                    all: [],
+                  },
+                  treatment: {
+                    first: {},
+                    all: [],
+                  },
                 },
                 relative_uplift: {
-                  first: {},
-                  all: [],
+                  control: {
+                    first: {},
+                    all: [],
+                  },
+                  treatment: {
+                    first: {},
+                    all: [],
+                  },
                 },
               },
             },
@@ -4148,12 +5765,24 @@ export const mockAnalysisWithExposures = mockAnalysis({
                   ],
                 },
                 difference: {
-                  first: {},
-                  all: [],
+                  control: {
+                    first: {},
+                    all: [],
+                  },
+                  treatment: {
+                    first: {},
+                    all: [],
+                  },
                 },
                 relative_uplift: {
-                  first: {},
-                  all: [],
+                  control: {
+                    first: {},
+                    all: [],
+                  },
+                  treatment: {
+                    first: {},
+                    all: [],
+                  },
                 },
                 percent: 55,
               },
@@ -4176,34 +5805,55 @@ export const mockAnalysisWithExposures = mockAnalysis({
                   ],
                 },
                 difference: {
-                  first: {
-                    point: -0.0007569487628876534,
-                    upper: 0.04416381736512019,
-                    lower: 0.04075095963994029,
-                  },
-                  all: [
-                    {
+                  control: {
+                    first: {
                       point: -0.0007569487628876534,
                       upper: 0.04416381736512019,
                       lower: 0.04075095963994029,
                     },
-                  ],
+                    all: [
+                      {
+                        point: -0.0007569487628876534,
+                        upper: 0.04416381736512019,
+                        lower: 0.04075095963994029,
+                      },
+                    ],
+                  },
+                  treatment: {
+                    first: {},
+                    all: [],
+                  },
                 },
                 relative_uplift: {
-                  first: {
-                    lower: -0.465210299676828,
-                    upper: 0.5204985718410426,
-                    point: -0.07233954570562385,
-                  },
-                  all: [
-                    {
+                  control: {
+                    first: {
                       lower: -0.465210299676828,
                       upper: 0.5204985718410426,
                       point: -0.07233954570562385,
                     },
-                  ],
+                    all: [
+                      {
+                        lower: -0.465210299676828,
+                        upper: 0.5204985718410426,
+                        point: -0.07233954570562385,
+                      },
+                    ],
+                  },
+                  treatment: {
+                    first: {},
+                    all: [],
+                  },
                 },
-                significance: { overall: { "1": "positive" }, weekly: {} },
+                significance: {
+                  control: {
+                    overall: { "1": "positive" },
+                    weekly: {},
+                  },
+                  treatment: {
+                    overall: {},
+                    weekly: {},
+                  },
+                },
               },
               picture_in_picture: {
                 absolute: {
@@ -4223,34 +5873,55 @@ export const mockAnalysisWithExposures = mockAnalysis({
                   ],
                 },
                 difference: {
-                  first: {
-                    point: -0.0007569487628876534,
-                    upper: 0.04416381736512019,
-                    lower: 0.04075095963994029,
-                  },
-                  all: [
-                    {
+                  control: {
+                    first: {
                       point: -0.0007569487628876534,
                       upper: 0.04416381736512019,
                       lower: 0.04075095963994029,
                     },
-                  ],
+                    all: [
+                      {
+                        point: -0.0007569487628876534,
+                        upper: 0.04416381736512019,
+                        lower: 0.04075095963994029,
+                      },
+                    ],
+                  },
+                  treatment: {
+                    first: {},
+                    all: [],
+                  },
                 },
                 relative_uplift: {
-                  first: {
-                    lower: -0.465210299676828,
-                    upper: 0.5204985718410426,
-                    point: -0.07233954570562385,
-                  },
-                  all: [
-                    {
+                  control: {
+                    first: {
                       lower: -0.465210299676828,
                       upper: 0.5204985718410426,
                       point: -0.07233954570562385,
                     },
-                  ],
+                    all: [
+                      {
+                        lower: -0.465210299676828,
+                        upper: 0.5204985718410426,
+                        point: -0.07233954570562385,
+                      },
+                    ],
+                  },
+                  treatment: {
+                    first: {},
+                    all: [],
+                  },
                 },
-                significance: { overall: { "1": "positive" }, weekly: {} },
+                significance: {
+                  control: {
+                    overall: { "1": "positive" },
+                    weekly: {},
+                  },
+                  treatment: {
+                    overall: {},
+                    weekly: {},
+                  },
+                },
               },
               feature_b_ever_used: {
                 absolute: {
@@ -4270,34 +5941,55 @@ export const mockAnalysisWithExposures = mockAnalysis({
                   ],
                 },
                 difference: {
-                  first: {
-                    point: -0.0007569487628876534,
-                    upper: 0.04416381736512019,
-                    lower: 0.04075095963994029,
-                  },
-                  all: [
-                    {
+                  control: {
+                    first: {
                       point: -0.0007569487628876534,
                       upper: 0.04416381736512019,
                       lower: 0.04075095963994029,
                     },
-                  ],
+                    all: [
+                      {
+                        point: -0.0007569487628876534,
+                        upper: 0.04416381736512019,
+                        lower: 0.04075095963994029,
+                      },
+                    ],
+                  },
+                  treatment: {
+                    first: {},
+                    all: [],
+                  },
                 },
                 relative_uplift: {
-                  first: {
-                    lower: -0.465210299676828,
-                    upper: 0.5204985718410426,
-                    point: -0.07233954570562385,
-                  },
-                  all: [
-                    {
+                  control: {
+                    first: {
                       lower: -0.465210299676828,
                       upper: 0.5204985718410426,
                       point: -0.07233954570562385,
                     },
-                  ],
+                    all: [
+                      {
+                        lower: -0.465210299676828,
+                        upper: 0.5204985718410426,
+                        point: -0.07233954570562385,
+                      },
+                    ],
+                  },
+                  treatment: {
+                    first: {},
+                    all: [],
+                  },
                 },
-                significance: { overall: { "1": "negative" }, weekly: {} },
+                significance: {
+                  control: {
+                    overall: { "1": "negative" },
+                    weekly: {},
+                  },
+                  treatment: {
+                    overall: {},
+                    weekly: {},
+                  },
+                },
               },
               feature_b: {
                 absolute: {
@@ -4317,34 +6009,55 @@ export const mockAnalysisWithExposures = mockAnalysis({
                   ],
                 },
                 difference: {
-                  first: {
-                    point: -0.0007569487628876534,
-                    upper: 0.04416381736512019,
-                    lower: 0.04075095963994029,
-                  },
-                  all: [
-                    {
+                  control: {
+                    first: {
                       point: -0.0007569487628876534,
                       upper: 0.04416381736512019,
                       lower: 0.04075095963994029,
                     },
-                  ],
+                    all: [
+                      {
+                        point: -0.0007569487628876534,
+                        upper: 0.04416381736512019,
+                        lower: 0.04075095963994029,
+                      },
+                    ],
+                  },
+                  treatment: {
+                    first: {},
+                    all: [],
+                  },
                 },
                 relative_uplift: {
-                  first: {
-                    lower: -0.465210299676828,
-                    upper: 0.5204985718410426,
-                    point: -0.07233954570562385,
-                  },
-                  all: [
-                    {
+                  control: {
+                    first: {
                       lower: -0.465210299676828,
                       upper: 0.5204985718410426,
                       point: -0.07233954570562385,
                     },
-                  ],
+                    all: [
+                      {
+                        lower: -0.465210299676828,
+                        upper: 0.5204985718410426,
+                        point: -0.07233954570562385,
+                      },
+                    ],
+                  },
+                  treatment: {
+                    first: {},
+                    all: [],
+                  },
                 },
-                significance: { overall: { "1": "negative" }, weekly: {} },
+                significance: {
+                  control: {
+                    overall: { "1": "negative" },
+                    weekly: {},
+                  },
+                  treatment: {
+                    overall: {},
+                    weekly: {},
+                  },
+                },
               },
               feature_c_ever_used: {
                 absolute: {
@@ -4364,34 +6077,55 @@ export const mockAnalysisWithExposures = mockAnalysis({
                   ],
                 },
                 difference: {
-                  first: {
-                    point: -0.0007569487628876534,
-                    upper: 0.04416381736512019,
-                    lower: 0.04075095963994029,
-                  },
-                  all: [
-                    {
+                  control: {
+                    first: {
                       point: -0.0007569487628876534,
                       upper: 0.04416381736512019,
                       lower: 0.04075095963994029,
                     },
-                  ],
+                    all: [
+                      {
+                        point: -0.0007569487628876534,
+                        upper: 0.04416381736512019,
+                        lower: 0.04075095963994029,
+                      },
+                    ],
+                  },
+                  treatment: {
+                    first: {},
+                    all: [],
+                  },
                 },
                 relative_uplift: {
-                  first: {
-                    lower: -0.465210299676828,
-                    upper: 0.5204985718410426,
-                    point: -0.07233954570562385,
-                  },
-                  all: [
-                    {
+                  control: {
+                    first: {
                       lower: -0.465210299676828,
                       upper: 0.5204985718410426,
                       point: -0.07233954570562385,
                     },
-                  ],
+                    all: [
+                      {
+                        lower: -0.465210299676828,
+                        upper: 0.5204985718410426,
+                        point: -0.07233954570562385,
+                      },
+                    ],
+                  },
+                  treatment: {
+                    first: {},
+                    all: [],
+                  },
                 },
-                significance: { overall: { "1": "neutral" }, weekly: {} },
+                significance: {
+                  control: {
+                    overall: { "1": "neutral" },
+                    weekly: {},
+                  },
+                  treatment: {
+                    overall: {},
+                    weekly: {},
+                  },
+                },
               },
               feature_c: TREATMENT_NEUTRAL,
               days_of_use: TREATMENT_NEUTRAL,
@@ -4414,34 +6148,55 @@ export const mockAnalysisWithExposures = mockAnalysis({
                   ],
                 },
                 difference: {
-                  first: {
-                    point: -0.0007569487628876534,
-                    upper: 0.04416381736512019,
-                    lower: 0.04075095963994029,
-                  },
-                  all: [
-                    {
+                  control: {
+                    first: {
                       point: -0.0007569487628876534,
                       upper: 0.04416381736512019,
                       lower: 0.04075095963994029,
                     },
-                  ],
+                    all: [
+                      {
+                        point: -0.0007569487628876534,
+                        upper: 0.04416381736512019,
+                        lower: 0.04075095963994029,
+                      },
+                    ],
+                  },
+                  treatment: {
+                    first: {},
+                    all: [],
+                  },
                 },
                 relative_uplift: {
-                  first: {
-                    lower: -0.465210299676828,
-                    upper: 0.5204985718410426,
-                    point: -0.07233954570562385,
-                  },
-                  all: [
-                    {
+                  control: {
+                    first: {
                       lower: -0.465210299676828,
                       upper: 0.5204985718410426,
                       point: -0.07233954570562385,
                     },
-                  ],
+                    all: [
+                      {
+                        lower: -0.465210299676828,
+                        upper: 0.5204985718410426,
+                        point: -0.07233954570562385,
+                      },
+                    ],
+                  },
+                  treatment: {
+                    first: {},
+                    all: [],
+                  },
                 },
-                significance: { overall: { "1": "positive" }, weekly: {} },
+                significance: {
+                  control: {
+                    overall: { "1": "positive" },
+                    weekly: {},
+                  },
+                  treatment: {
+                    overall: {},
+                    weekly: {},
+                  },
+                },
               },
               outcome_d: {
                 absolute: {
@@ -4461,34 +6216,55 @@ export const mockAnalysisWithExposures = mockAnalysis({
                   ],
                 },
                 difference: {
-                  first: {
-                    point: -0.0007569487628876534,
-                    upper: 0.04416381736512019,
-                    lower: 0.04075095963994029,
-                  },
-                  all: [
-                    {
+                  control: {
+                    first: {
                       point: -0.0007569487628876534,
                       upper: 0.04416381736512019,
                       lower: 0.04075095963994029,
                     },
-                  ],
+                    all: [
+                      {
+                        point: -0.0007569487628876534,
+                        upper: 0.04416381736512019,
+                        lower: 0.04075095963994029,
+                      },
+                    ],
+                  },
+                  treatment: {
+                    first: {},
+                    all: [],
+                  },
                 },
                 relative_uplift: {
-                  first: {
-                    lower: -0.465210299676828,
-                    upper: 0.5204985718410426,
-                    point: -0.07233954570562385,
-                  },
-                  all: [
-                    {
+                  control: {
+                    first: {
                       lower: -0.465210299676828,
                       upper: 0.5204985718410426,
                       point: -0.07233954570562385,
                     },
-                  ],
+                    all: [
+                      {
+                        lower: -0.465210299676828,
+                        upper: 0.5204985718410426,
+                        point: -0.07233954570562385,
+                      },
+                    ],
+                  },
+                  treatment: {
+                    first: {},
+                    all: [],
+                  },
                 },
-                significance: { overall: { "1": "positive" }, weekly: {} },
+                significance: {
+                  control: {
+                    overall: { "1": "positive" },
+                    weekly: {},
+                  },
+                  treatment: {
+                    overall: {},
+                    weekly: {},
+                  },
+                },
               },
             },
             search_metrics: {
@@ -4539,12 +6315,24 @@ export const mockIncompleteAnalysis = (modifications = {}) =>
                       },
                     },
                     difference: {
-                      first: {},
-                      all: [],
+                      control: {
+                        first: {},
+                        all: [],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
                     relative_uplift: {
-                      first: {},
-                      all: [],
+                      control: {
+                        first: {},
+                        all: [],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
                     percent: 45,
                   },
@@ -4566,12 +6354,24 @@ export const mockIncompleteAnalysis = (modifications = {}) =>
                       ],
                     },
                     difference: {
-                      first: {},
-                      all: [],
+                      control: {
+                        first: {},
+                        all: [],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
                     relative_uplift: {
-                      first: {},
-                      all: [],
+                      control: {
+                        first: {},
+                        all: [],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
                   },
                   picture_in_picture: {
@@ -4592,12 +6392,24 @@ export const mockIncompleteAnalysis = (modifications = {}) =>
                       ],
                     },
                     difference: {
-                      first: {},
-                      all: [],
+                      control: {
+                        first: {},
+                        all: [],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
                     relative_uplift: {
-                      first: {},
-                      all: [],
+                      control: {
+                        first: {},
+                        all: [],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
                   },
                   feature_b_ever_used: {
@@ -4618,12 +6430,24 @@ export const mockIncompleteAnalysis = (modifications = {}) =>
                       ],
                     },
                     difference: {
-                      first: {},
-                      all: [],
+                      control: {
+                        first: {},
+                        all: [],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
                     relative_uplift: {
-                      first: {},
-                      all: [],
+                      control: {
+                        first: {},
+                        all: [],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
                   },
                   feature_b: {
@@ -4644,12 +6468,24 @@ export const mockIncompleteAnalysis = (modifications = {}) =>
                       ],
                     },
                     difference: {
-                      first: {},
-                      all: [],
+                      control: {
+                        first: {},
+                        all: [],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
                     relative_uplift: {
-                      first: {},
-                      all: [],
+                      control: {
+                        first: {},
+                        all: [],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
                   },
                   feature_c_ever_used: {
@@ -4670,12 +6506,24 @@ export const mockIncompleteAnalysis = (modifications = {}) =>
                       ],
                     },
                     difference: {
-                      first: {},
-                      all: [],
+                      control: {
+                        first: {},
+                        all: [],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
                     relative_uplift: {
-                      first: {},
-                      all: [],
+                      control: {
+                        first: {},
+                        all: [],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
                   },
                   feature_c: {
@@ -4696,12 +6544,24 @@ export const mockIncompleteAnalysis = (modifications = {}) =>
                       ],
                     },
                     difference: {
-                      first: {},
-                      all: [],
+                      control: {
+                        first: {},
+                        all: [],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
                     relative_uplift: {
-                      first: {},
-                      all: [],
+                      control: {
+                        first: {},
+                        all: [],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
                   },
                   feature_d: {
@@ -4722,12 +6582,24 @@ export const mockIncompleteAnalysis = (modifications = {}) =>
                       ],
                     },
                     difference: {
-                      first: {},
-                      all: [],
+                      control: {
+                        first: {},
+                        all: [],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
                     relative_uplift: {
-                      first: {},
-                      all: [],
+                      control: {
+                        first: {},
+                        all: [],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
                   },
                   outcome_d: {
@@ -4748,12 +6620,24 @@ export const mockIncompleteAnalysis = (modifications = {}) =>
                       ],
                     },
                     difference: {
-                      first: {},
-                      all: [],
+                      control: {
+                        first: {},
+                        all: [],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
                     relative_uplift: {
-                      first: {},
-                      all: [],
+                      control: {
+                        first: {},
+                        all: [],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
                   },
                 },
@@ -4774,12 +6658,24 @@ export const mockIncompleteAnalysis = (modifications = {}) =>
                       },
                     },
                     difference: {
-                      first: {},
-                      all: [],
+                      control: {
+                        first: {},
+                        all: [],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
                     relative_uplift: {
-                      first: {},
-                      all: [],
+                      control: {
+                        first: {},
+                        all: [],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
                   },
                 },
@@ -4801,12 +6697,24 @@ export const mockIncompleteAnalysis = (modifications = {}) =>
                       ],
                     },
                     difference: {
-                      first: {},
-                      all: [],
+                      control: {
+                        first: {},
+                        all: [],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
                     relative_uplift: {
-                      first: {},
-                      all: [],
+                      control: {
+                        first: {},
+                        all: [],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
                     percent: 55,
                   },
@@ -4828,34 +6736,55 @@ export const mockIncompleteAnalysis = (modifications = {}) =>
                       ],
                     },
                     difference: {
-                      first: {
-                        point: -0.0006569487628876534,
-                        upper: 0.04316381736512019,
-                        lower: 0.04175095963994029,
-                      },
-                      all: [
-                        {
+                      control: {
+                        first: {
                           point: -0.0006569487628876534,
                           upper: 0.04316381736512019,
                           lower: 0.04175095963994029,
                         },
-                      ],
+                        all: [
+                          {
+                            point: -0.0006569487628876534,
+                            upper: 0.04316381736512019,
+                            lower: 0.04175095963994029,
+                          },
+                        ],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
                     relative_uplift: {
-                      first: {
-                        lower: -0.455210299676828,
-                        upper: 0.5104985718410426,
-                        point: -0.06233954570562385,
-                      },
-                      all: [
-                        {
+                      control: {
+                        first: {
                           lower: -0.455210299676828,
                           upper: 0.5104985718410426,
                           point: -0.06233954570562385,
                         },
-                      ],
+                        all: [
+                          {
+                            lower: -0.455210299676828,
+                            upper: 0.5104985718410426,
+                            point: -0.06233954570562385,
+                          },
+                        ],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
-                    significance: { overall: { "1": "positive" }, weekly: {} },
+                    significance: {
+                      control: {
+                        overall: { "1": "positive" },
+                        weekly: {},
+                      },
+                      treatment: {
+                        overall: {},
+                        weekly: {},
+                      },
+                    },
                   },
                   picture_in_picture: {
                     absolute: {
@@ -4875,34 +6804,55 @@ export const mockIncompleteAnalysis = (modifications = {}) =>
                       ],
                     },
                     difference: {
-                      first: {
-                        point: -0.0006569487628876534,
-                        upper: 0.04316381736512019,
-                        lower: 0.04175095963994029,
-                      },
-                      all: [
-                        {
+                      control: {
+                        first: {
                           point: -0.0006569487628876534,
                           upper: 0.04316381736512019,
                           lower: 0.04175095963994029,
                         },
-                      ],
+                        all: [
+                          {
+                            point: -0.0006569487628876534,
+                            upper: 0.04316381736512019,
+                            lower: 0.04175095963994029,
+                          },
+                        ],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
                     relative_uplift: {
-                      first: {
-                        lower: -0.455210299676828,
-                        upper: 0.5104985718410426,
-                        point: -0.06233954570562385,
-                      },
-                      all: [
-                        {
+                      control: {
+                        first: {
                           lower: -0.455210299676828,
                           upper: 0.5104985718410426,
                           point: -0.06233954570562385,
                         },
-                      ],
+                        all: [
+                          {
+                            lower: -0.455210299676828,
+                            upper: 0.5104985718410426,
+                            point: -0.06233954570562385,
+                          },
+                        ],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
-                    significance: { overall: { "1": "positive" }, weekly: {} },
+                    significance: {
+                      control: {
+                        overall: { "1": "positive" },
+                        weekly: {},
+                      },
+                      treatment: {
+                        overall: {},
+                        weekly: {},
+                      },
+                    },
                   },
                   feature_b_ever_used: {
                     absolute: {
@@ -4922,34 +6872,55 @@ export const mockIncompleteAnalysis = (modifications = {}) =>
                       ],
                     },
                     difference: {
-                      first: {
-                        point: -0.0006569487628876534,
-                        upper: 0.04316381736512019,
-                        lower: 0.04175095963994029,
-                      },
-                      all: [
-                        {
+                      control: {
+                        first: {
                           point: -0.0006569487628876534,
                           upper: 0.04316381736512019,
                           lower: 0.04175095963994029,
                         },
-                      ],
+                        all: [
+                          {
+                            point: -0.0006569487628876534,
+                            upper: 0.04316381736512019,
+                            lower: 0.04175095963994029,
+                          },
+                        ],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
                     relative_uplift: {
-                      first: {
-                        lower: -0.455210299676828,
-                        upper: 0.5104985718410426,
-                        point: -0.06233954570562385,
-                      },
-                      all: [
-                        {
+                      control: {
+                        first: {
                           lower: -0.455210299676828,
                           upper: 0.5104985718410426,
                           point: -0.06233954570562385,
                         },
-                      ],
+                        all: [
+                          {
+                            lower: -0.455210299676828,
+                            upper: 0.5104985718410426,
+                            point: -0.06233954570562385,
+                          },
+                        ],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
-                    significance: { overall: { "1": "negative" }, weekly: {} },
+                    significance: {
+                      control: {
+                        overall: { "1": "negative" },
+                        weekly: {},
+                      },
+                      treatment: {
+                        overall: {},
+                        weekly: {},
+                      },
+                    },
                   },
                   feature_b: {
                     absolute: {
@@ -4969,34 +6940,55 @@ export const mockIncompleteAnalysis = (modifications = {}) =>
                       ],
                     },
                     difference: {
-                      first: {
-                        point: -0.0006569487628876534,
-                        upper: 0.04316381736512019,
-                        lower: 0.04175095963994029,
-                      },
-                      all: [
-                        {
+                      control: {
+                        first: {
                           point: -0.0006569487628876534,
                           upper: 0.04316381736512019,
                           lower: 0.04175095963994029,
                         },
-                      ],
+                        all: [
+                          {
+                            point: -0.0006569487628876534,
+                            upper: 0.04316381736512019,
+                            lower: 0.04175095963994029,
+                          },
+                        ],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
                     relative_uplift: {
-                      first: {
-                        lower: -0.455210299676828,
-                        upper: 0.5104985718410426,
-                        point: -0.06233954570562385,
-                      },
-                      all: [
-                        {
+                      control: {
+                        first: {
                           lower: -0.455210299676828,
                           upper: 0.5104985718410426,
                           point: -0.06233954570562385,
                         },
-                      ],
+                        all: [
+                          {
+                            lower: -0.455210299676828,
+                            upper: 0.5104985718410426,
+                            point: -0.06233954570562385,
+                          },
+                        ],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
-                    significance: { overall: { "1": "negative" }, weekly: {} },
+                    significance: {
+                      control: {
+                        overall: { "1": "negative" },
+                        weekly: {},
+                      },
+                      treatment: {
+                        overall: {},
+                        weekly: {},
+                      },
+                    },
                   },
                   feature_c_ever_used: {
                     absolute: {
@@ -5016,34 +7008,55 @@ export const mockIncompleteAnalysis = (modifications = {}) =>
                       ],
                     },
                     difference: {
-                      first: {
-                        point: -0.0006569487628876534,
-                        upper: 0.04316381736512019,
-                        lower: 0.04175095963994029,
-                      },
-                      all: [
-                        {
+                      control: {
+                        first: {
                           point: -0.0006569487628876534,
                           upper: 0.04316381736512019,
                           lower: 0.04175095963994029,
                         },
-                      ],
+                        all: [
+                          {
+                            point: -0.0006569487628876534,
+                            upper: 0.04316381736512019,
+                            lower: 0.04175095963994029,
+                          },
+                        ],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
                     relative_uplift: {
-                      first: {
-                        lower: -0.455210299676828,
-                        upper: 0.5104985718410426,
-                        point: -0.06233954570562385,
-                      },
-                      all: [
-                        {
+                      control: {
+                        first: {
                           lower: -0.455210299676828,
                           upper: 0.5104985718410426,
                           point: -0.06233954570562385,
                         },
-                      ],
+                        all: [
+                          {
+                            lower: -0.455210299676828,
+                            upper: 0.5104985718410426,
+                            point: -0.06233954570562385,
+                          },
+                        ],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
-                    significance: { overall: { "1": "neutral" }, weekly: {} },
+                    significance: {
+                      control: {
+                        overall: { "1": "neutral" },
+                        weekly: {},
+                      },
+                      treatment: {
+                        overall: {},
+                        weekly: {},
+                      },
+                    },
                   },
                   feature_c: {
                     absolute: {
@@ -5063,34 +7076,55 @@ export const mockIncompleteAnalysis = (modifications = {}) =>
                       ],
                     },
                     difference: {
-                      first: {
-                        point: -0.0006569487628876534,
-                        upper: 0.04316381736512019,
-                        lower: 0.04175095963994029,
-                      },
-                      all: [
-                        {
+                      control: {
+                        first: {
                           point: -0.0006569487628876534,
                           upper: 0.04316381736512019,
                           lower: 0.04175095963994029,
                         },
-                      ],
+                        all: [
+                          {
+                            point: -0.0006569487628876534,
+                            upper: 0.04316381736512019,
+                            lower: 0.04175095963994029,
+                          },
+                        ],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
                     relative_uplift: {
-                      first: {
-                        lower: -0.455210299676828,
-                        upper: 0.5104985718410426,
-                        point: -0.06233954570562385,
-                      },
-                      all: [
-                        {
+                      control: {
+                        first: {
                           lower: -0.455210299676828,
                           upper: 0.5104985718410426,
                           point: -0.06233954570562385,
                         },
-                      ],
+                        all: [
+                          {
+                            lower: -0.455210299676828,
+                            upper: 0.5104985718410426,
+                            point: -0.06233954570562385,
+                          },
+                        ],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
-                    significance: { overall: { "1": "neutral" }, weekly: {} },
+                    significance: {
+                      control: {
+                        overall: { "1": "neutral" },
+                        weekly: {},
+                      },
+                      treatment: {
+                        overall: {},
+                        weekly: {},
+                      },
+                    },
                   },
                   feature_d: {
                     absolute: {
@@ -5110,34 +7144,55 @@ export const mockIncompleteAnalysis = (modifications = {}) =>
                       ],
                     },
                     difference: {
-                      first: {
-                        point: -0.0006569487628876534,
-                        upper: 0.04316381736512019,
-                        lower: 0.04175095963994029,
-                      },
-                      all: [
-                        {
+                      control: {
+                        first: {
                           point: -0.0006569487628876534,
                           upper: 0.04316381736512019,
                           lower: 0.04175095963994029,
                         },
-                      ],
+                        all: [
+                          {
+                            point: -0.0006569487628876534,
+                            upper: 0.04316381736512019,
+                            lower: 0.04175095963994029,
+                          },
+                        ],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
                     relative_uplift: {
-                      first: {
-                        lower: -0.455210299676828,
-                        upper: 0.5104985718410426,
-                        point: -0.06233954570562385,
-                      },
-                      all: [
-                        {
+                      control: {
+                        first: {
                           lower: -0.455210299676828,
                           upper: 0.5104985718410426,
                           point: -0.06233954570562385,
                         },
-                      ],
+                        all: [
+                          {
+                            lower: -0.455210299676828,
+                            upper: 0.5104985718410426,
+                            point: -0.06233954570562385,
+                          },
+                        ],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
-                    significance: { overall: { "1": "positive" }, weekly: {} },
+                    significance: {
+                      control: {
+                        overall: { "1": "positive" },
+                        weekly: {},
+                      },
+                      treatment: {
+                        overall: {},
+                        weekly: {},
+                      },
+                    },
                   },
                   outcome_d: {
                     absolute: {
@@ -5157,34 +7212,55 @@ export const mockIncompleteAnalysis = (modifications = {}) =>
                       ],
                     },
                     difference: {
-                      first: {
-                        point: -0.0006569487628876534,
-                        upper: 0.04316381736512019,
-                        lower: 0.04175095963994029,
-                      },
-                      all: [
-                        {
+                      control: {
+                        first: {
                           point: -0.0006569487628876534,
                           upper: 0.04316381736512019,
                           lower: 0.04175095963994029,
                         },
-                      ],
+                        all: [
+                          {
+                            point: -0.0006569487628876534,
+                            upper: 0.04316381736512019,
+                            lower: 0.04175095963994029,
+                          },
+                        ],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
                     relative_uplift: {
-                      first: {
-                        lower: -0.455210299676828,
-                        upper: 0.5104985718410426,
-                        point: -0.06233954570562385,
-                      },
-                      all: [
-                        {
+                      control: {
+                        first: {
                           lower: -0.455210299676828,
                           upper: 0.5104985718410426,
                           point: -0.06233954570562385,
                         },
-                      ],
+                        all: [
+                          {
+                            lower: -0.455210299676828,
+                            upper: 0.5104985718410426,
+                            point: -0.06233954570562385,
+                          },
+                        ],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
-                    significance: { overall: { "1": "positive" }, weekly: {} },
+                    significance: {
+                      control: {
+                        overall: { "1": "positive" },
+                        weekly: {},
+                      },
+                      treatment: {
+                        overall: {},
+                        weekly: {},
+                      },
+                    },
                   },
                 },
                 search_metrics: {
@@ -5204,24 +7280,45 @@ export const mockIncompleteAnalysis = (modifications = {}) =>
                       ],
                     },
                     difference: {
-                      first: {
-                        point: 5.075852767646001,
-                        upper: -5.63685604594333,
-                        lower: -15.289651027022447,
-                      },
-                      all: [
-                        {
+                      control: {
+                        first: {
                           point: 5.075852767646001,
                           upper: -5.63685604594333,
                           lower: -15.289651027022447,
                         },
-                      ],
+                        all: [
+                          {
+                            point: 5.075852767646001,
+                            upper: -5.63685604594333,
+                            lower: -15.289651027022447,
+                          },
+                        ],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
                     relative_uplift: {
-                      first: {},
-                      all: [],
+                      control: {
+                        first: {},
+                        all: [],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
-                    significance: { overall: { "1": "negative" }, weekly: {} },
+                    significance: {
+                      control: {
+                        overall: { "1": "negative" },
+                        weekly: {},
+                      },
+                      treatment: {
+                        overall: {},
+                        weekly: {},
+                      },
+                    },
                   },
                 },
               },
@@ -5421,12 +7518,24 @@ export const mockAnalysisWithErrorsAndResults = (modifications = {}) =>
                       },
                     },
                     difference: {
-                      first: {},
-                      all: [],
+                      control: {
+                        first: {},
+                        all: [],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
                     relative_uplift: {
-                      first: {},
-                      all: [],
+                      control: {
+                        first: {},
+                        all: [],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
                     percent: 45,
                   },
@@ -5446,12 +7555,24 @@ export const mockAnalysisWithErrorsAndResults = (modifications = {}) =>
                       },
                     },
                     difference: {
-                      first: {},
-                      all: [],
+                      control: {
+                        first: {},
+                        all: [],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
                     relative_uplift: {
-                      first: {},
-                      all: [],
+                      control: {
+                        first: {},
+                        all: [],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
                   },
                   picture_in_picture_ever_used: {
@@ -5472,12 +7593,24 @@ export const mockAnalysisWithErrorsAndResults = (modifications = {}) =>
                       ],
                     },
                     difference: {
-                      first: {},
-                      all: [],
+                      control: {
+                        first: {},
+                        all: [],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
                     relative_uplift: {
-                      first: {},
-                      all: [],
+                      control: {
+                        first: {},
+                        all: [],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
                   },
                   feature_b_ever_used: {
@@ -5498,12 +7631,24 @@ export const mockAnalysisWithErrorsAndResults = (modifications = {}) =>
                       ],
                     },
                     difference: {
-                      first: {},
-                      all: [],
+                      control: {
+                        first: {},
+                        all: [],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
                     relative_uplift: {
-                      first: {},
-                      all: [],
+                      control: {
+                        first: {},
+                        all: [],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
                   },
                   feature_b: {
@@ -5524,12 +7669,24 @@ export const mockAnalysisWithErrorsAndResults = (modifications = {}) =>
                       ],
                     },
                     difference: {
-                      first: {},
-                      all: [],
+                      control: {
+                        first: {},
+                        all: [],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
                     relative_uplift: {
-                      first: {},
-                      all: [],
+                      control: {
+                        first: {},
+                        all: [],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
                   },
                   feature_c_ever_used: {
@@ -5550,12 +7707,24 @@ export const mockAnalysisWithErrorsAndResults = (modifications = {}) =>
                       ],
                     },
                     difference: {
-                      first: {},
-                      all: [],
+                      control: {
+                        first: {},
+                        all: [],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
                     relative_uplift: {
-                      first: {},
-                      all: [],
+                      control: {
+                        first: {},
+                        all: [],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
                   },
                   feature_c: CONTROL_NEUTRAL,
@@ -5577,12 +7746,24 @@ export const mockAnalysisWithErrorsAndResults = (modifications = {}) =>
                       ],
                     },
                     difference: {
-                      first: {},
-                      all: [],
+                      control: {
+                        first: {},
+                        all: [],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
                     relative_uplift: {
-                      first: {},
-                      all: [],
+                      control: {
+                        first: {},
+                        all: [],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
                   },
                   outcome_d: {
@@ -5603,12 +7784,24 @@ export const mockAnalysisWithErrorsAndResults = (modifications = {}) =>
                       ],
                     },
                     difference: {
-                      first: {},
-                      all: [],
+                      control: {
+                        first: {},
+                        all: [],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
                     relative_uplift: {
-                      first: {},
-                      all: [],
+                      control: {
+                        first: {},
+                        all: [],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
                   },
                   days_of_use: CONTROL_NEUTRAL,
@@ -5631,12 +7824,24 @@ export const mockAnalysisWithErrorsAndResults = (modifications = {}) =>
                       },
                     },
                     difference: {
-                      first: {},
-                      all: [],
+                      control: {
+                        first: {},
+                        all: [],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
                     relative_uplift: {
-                      first: {},
-                      all: [],
+                      control: {
+                        first: {},
+                        all: [],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
                   },
                 },
@@ -5658,12 +7863,24 @@ export const mockAnalysisWithErrorsAndResults = (modifications = {}) =>
                       ],
                     },
                     difference: {
-                      first: {},
-                      all: [],
+                      control: {
+                        first: {},
+                        all: [],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
                     relative_uplift: {
-                      first: {},
-                      all: [],
+                      control: {
+                        first: {},
+                        all: [],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
                     percent: 55,
                   },
@@ -5686,34 +7903,55 @@ export const mockAnalysisWithErrorsAndResults = (modifications = {}) =>
                       ],
                     },
                     difference: {
-                      first: {
-                        point: -0.0006569487628876534,
-                        upper: 0.04316381736512019,
-                        lower: 0.04175095963994029,
-                      },
-                      all: [
-                        {
+                      control: {
+                        first: {
                           point: -0.0006569487628876534,
                           upper: 0.04316381736512019,
                           lower: 0.04175095963994029,
                         },
-                      ],
+                        all: [
+                          {
+                            point: -0.0006569487628876534,
+                            upper: 0.04316381736512019,
+                            lower: 0.04175095963994029,
+                          },
+                        ],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
                     relative_uplift: {
-                      first: {
-                        lower: -0.455210299676828,
-                        upper: 0.5104985718410426,
-                        point: -0.06233954570562385,
-                      },
-                      all: [
-                        {
+                      control: {
+                        first: {
                           lower: -0.455210299676828,
                           upper: 0.5104985718410426,
                           point: -0.06233954570562385,
                         },
-                      ],
+                        all: [
+                          {
+                            lower: -0.455210299676828,
+                            upper: 0.5104985718410426,
+                            point: -0.06233954570562385,
+                          },
+                        ],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
-                    significance: { overall: { "1": "positive" }, weekly: {} },
+                    significance: {
+                      control: {
+                        overall: { "1": "positive" },
+                        weekly: {},
+                      },
+                      treatment: {
+                        overall: {},
+                        weekly: {},
+                      },
+                    },
                   },
                   picture_in_picture: {
                     absolute: {
@@ -5733,34 +7971,55 @@ export const mockAnalysisWithErrorsAndResults = (modifications = {}) =>
                       ],
                     },
                     difference: {
-                      first: {
-                        point: -0.0006569487628876534,
-                        upper: 0.04316381736512019,
-                        lower: 0.04175095963994029,
-                      },
-                      all: [
-                        {
+                      control: {
+                        first: {
                           point: -0.0006569487628876534,
                           upper: 0.04316381736512019,
                           lower: 0.04175095963994029,
                         },
-                      ],
+                        all: [
+                          {
+                            point: -0.0006569487628876534,
+                            upper: 0.04316381736512019,
+                            lower: 0.04175095963994029,
+                          },
+                        ],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
                     relative_uplift: {
-                      first: {
-                        lower: -0.455210299676828,
-                        upper: 0.5104985718410426,
-                        point: -0.06233954570562385,
-                      },
-                      all: [
-                        {
+                      control: {
+                        first: {
                           lower: -0.455210299676828,
                           upper: 0.5104985718410426,
                           point: -0.06233954570562385,
                         },
-                      ],
+                        all: [
+                          {
+                            lower: -0.455210299676828,
+                            upper: 0.5104985718410426,
+                            point: -0.06233954570562385,
+                          },
+                        ],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
-                    significance: { overall: { "1": "positive" }, weekly: {} },
+                    significance: {
+                      control: {
+                        overall: { "1": "positive" },
+                        weekly: {},
+                      },
+                      treatment: {
+                        overall: {},
+                        weekly: {},
+                      },
+                    },
                   },
                   feature_b_ever_used: {
                     absolute: {
@@ -5780,34 +8039,55 @@ export const mockAnalysisWithErrorsAndResults = (modifications = {}) =>
                       ],
                     },
                     difference: {
-                      first: {
-                        point: -0.0006569487628876534,
-                        upper: 0.04316381736512019,
-                        lower: 0.04175095963994029,
-                      },
-                      all: [
-                        {
+                      control: {
+                        first: {
                           point: -0.0006569487628876534,
                           upper: 0.04316381736512019,
                           lower: 0.04175095963994029,
                         },
-                      ],
+                        all: [
+                          {
+                            point: -0.0006569487628876534,
+                            upper: 0.04316381736512019,
+                            lower: 0.04175095963994029,
+                          },
+                        ],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
                     relative_uplift: {
-                      first: {
-                        lower: -0.455210299676828,
-                        upper: 0.5104985718410426,
-                        point: -0.06233954570562385,
-                      },
-                      all: [
-                        {
+                      control: {
+                        first: {
                           lower: -0.455210299676828,
                           upper: 0.5104985718410426,
                           point: -0.06233954570562385,
                         },
-                      ],
+                        all: [
+                          {
+                            lower: -0.455210299676828,
+                            upper: 0.5104985718410426,
+                            point: -0.06233954570562385,
+                          },
+                        ],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
-                    significance: { overall: { "1": "negative" }, weekly: {} },
+                    significance: {
+                      control: {
+                        overall: { "1": "negative" },
+                        weekly: {},
+                      },
+                      treatment: {
+                        overall: {},
+                        weekly: {},
+                      },
+                    },
                   },
                   feature_b: {
                     absolute: {
@@ -5827,34 +8107,55 @@ export const mockAnalysisWithErrorsAndResults = (modifications = {}) =>
                       ],
                     },
                     difference: {
-                      first: {
-                        point: -0.0006569487628876534,
-                        upper: 0.04316381736512019,
-                        lower: 0.04175095963994029,
-                      },
-                      all: [
-                        {
+                      control: {
+                        first: {
                           point: -0.0006569487628876534,
                           upper: 0.04316381736512019,
                           lower: 0.04175095963994029,
                         },
-                      ],
+                        all: [
+                          {
+                            point: -0.0006569487628876534,
+                            upper: 0.04316381736512019,
+                            lower: 0.04175095963994029,
+                          },
+                        ],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
                     relative_uplift: {
-                      first: {
-                        lower: -0.455210299676828,
-                        upper: 0.5104985718410426,
-                        point: -0.06233954570562385,
-                      },
-                      all: [
-                        {
+                      control: {
+                        first: {
                           lower: -0.455210299676828,
                           upper: 0.5104985718410426,
                           point: -0.06233954570562385,
                         },
-                      ],
+                        all: [
+                          {
+                            lower: -0.455210299676828,
+                            upper: 0.5104985718410426,
+                            point: -0.06233954570562385,
+                          },
+                        ],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
-                    significance: { overall: { "1": "negative" }, weekly: {} },
+                    significance: {
+                      control: {
+                        overall: { "1": "negative" },
+                        weekly: {},
+                      },
+                      treatment: {
+                        overall: {},
+                        weekly: {},
+                      },
+                    },
                   },
                   feature_c_ever_used: {
                     absolute: {
@@ -5874,34 +8175,55 @@ export const mockAnalysisWithErrorsAndResults = (modifications = {}) =>
                       ],
                     },
                     difference: {
-                      first: {
-                        point: -0.0006569487628876534,
-                        upper: 0.04316381736512019,
-                        lower: 0.04175095963994029,
-                      },
-                      all: [
-                        {
+                      control: {
+                        first: {
                           point: -0.0006569487628876534,
                           upper: 0.04316381736512019,
                           lower: 0.04175095963994029,
                         },
-                      ],
+                        all: [
+                          {
+                            point: -0.0006569487628876534,
+                            upper: 0.04316381736512019,
+                            lower: 0.04175095963994029,
+                          },
+                        ],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
                     relative_uplift: {
-                      first: {
-                        lower: -0.455210299676828,
-                        upper: 0.5104985718410426,
-                        point: -0.06233954570562385,
-                      },
-                      all: [
-                        {
+                      control: {
+                        first: {
                           lower: -0.455210299676828,
                           upper: 0.5104985718410426,
                           point: -0.06233954570562385,
                         },
-                      ],
+                        all: [
+                          {
+                            lower: -0.455210299676828,
+                            upper: 0.5104985718410426,
+                            point: -0.06233954570562385,
+                          },
+                        ],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
-                    significance: { overall: { "1": "neutral" }, weekly: {} },
+                    significance: {
+                      control: {
+                        overall: { "1": "neutral" },
+                        weekly: {},
+                      },
+                      treatment: {
+                        overall: {},
+                        weekly: {},
+                      },
+                    },
                   },
                   feature_c: TREATMENT_NEUTRAL,
                   days_of_use: TREATMENT_NEUTRAL,
@@ -5924,34 +8246,55 @@ export const mockAnalysisWithErrorsAndResults = (modifications = {}) =>
                       ],
                     },
                     difference: {
-                      first: {
-                        point: -0.0006569487628876534,
-                        upper: 0.04316381736512019,
-                        lower: 0.04175095963994029,
-                      },
-                      all: [
-                        {
+                      control: {
+                        first: {
                           point: -0.0006569487628876534,
                           upper: 0.04316381736512019,
                           lower: 0.04175095963994029,
                         },
-                      ],
+                        all: [
+                          {
+                            point: -0.0006569487628876534,
+                            upper: 0.04316381736512019,
+                            lower: 0.04175095963994029,
+                          },
+                        ],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
                     relative_uplift: {
-                      first: {
-                        lower: -0.455210299676828,
-                        upper: 0.5104985718410426,
-                        point: -0.06233954570562385,
-                      },
-                      all: [
-                        {
+                      control: {
+                        first: {
                           lower: -0.455210299676828,
                           upper: 0.5104985718410426,
                           point: -0.06233954570562385,
                         },
-                      ],
+                        all: [
+                          {
+                            lower: -0.455210299676828,
+                            upper: 0.5104985718410426,
+                            point: -0.06233954570562385,
+                          },
+                        ],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
-                    significance: { overall: { "1": "positive" }, weekly: {} },
+                    significance: {
+                      control: {
+                        overall: { "1": "positive" },
+                        weekly: {},
+                      },
+                      treatment: {
+                        overall: {},
+                        weekly: {},
+                      },
+                    },
                   },
                   outcome_d: {
                     absolute: {
@@ -5971,34 +8314,55 @@ export const mockAnalysisWithErrorsAndResults = (modifications = {}) =>
                       ],
                     },
                     difference: {
-                      first: {
-                        point: -0.0006569487628876534,
-                        upper: 0.04316381736512019,
-                        lower: 0.04175095963994029,
-                      },
-                      all: [
-                        {
+                      control: {
+                        first: {
                           point: -0.0006569487628876534,
                           upper: 0.04316381736512019,
                           lower: 0.04175095963994029,
                         },
-                      ],
+                        all: [
+                          {
+                            point: -0.0006569487628876534,
+                            upper: 0.04316381736512019,
+                            lower: 0.04175095963994029,
+                          },
+                        ],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
                     relative_uplift: {
-                      first: {
-                        lower: -0.455210299676828,
-                        upper: 0.5104985718410426,
-                        point: -0.06233954570562385,
-                      },
-                      all: [
-                        {
+                      control: {
+                        first: {
                           lower: -0.455210299676828,
                           upper: 0.5104985718410426,
                           point: -0.06233954570562385,
                         },
-                      ],
+                        all: [
+                          {
+                            lower: -0.455210299676828,
+                            upper: 0.5104985718410426,
+                            point: -0.06233954570562385,
+                          },
+                        ],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
-                    significance: { overall: { "1": "positive" }, weekly: {} },
+                    significance: {
+                      control: {
+                        overall: { "1": "positive" },
+                        weekly: {},
+                      },
+                      treatment: {
+                        overall: {},
+                        weekly: {},
+                      },
+                    },
                   },
                 },
                 search_metrics: {
@@ -6026,12 +8390,24 @@ export const mockAnalysisWithErrorsAndResults = (modifications = {}) =>
                       },
                     },
                     difference: {
-                      first: {},
-                      all: [],
+                      control: {
+                        first: {},
+                        all: [],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
                     relative_uplift: {
-                      first: {},
-                      all: [],
+                      control: {
+                        first: {},
+                        all: [],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
                     percent: 45,
                   },
@@ -6051,12 +8427,24 @@ export const mockAnalysisWithErrorsAndResults = (modifications = {}) =>
                       },
                     },
                     difference: {
-                      first: {},
-                      all: [],
+                      control: {
+                        first: {},
+                        all: [],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
                     relative_uplift: {
-                      first: {},
-                      all: [],
+                      control: {
+                        first: {},
+                        all: [],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
                   },
                   picture_in_picture_ever_used: {
@@ -6077,12 +8465,24 @@ export const mockAnalysisWithErrorsAndResults = (modifications = {}) =>
                       ],
                     },
                     difference: {
-                      first: {},
-                      all: [],
+                      control: {
+                        first: {},
+                        all: [],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
                     relative_uplift: {
-                      first: {},
-                      all: [],
+                      control: {
+                        first: {},
+                        all: [],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
                   },
                   feature_b_ever_used: {
@@ -6103,12 +8503,24 @@ export const mockAnalysisWithErrorsAndResults = (modifications = {}) =>
                       ],
                     },
                     difference: {
-                      first: {},
-                      all: [],
+                      control: {
+                        first: {},
+                        all: [],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
                     relative_uplift: {
-                      first: {},
-                      all: [],
+                      control: {
+                        first: {},
+                        all: [],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
                   },
                   feature_b: {
@@ -6129,12 +8541,24 @@ export const mockAnalysisWithErrorsAndResults = (modifications = {}) =>
                       ],
                     },
                     difference: {
-                      first: {},
-                      all: [],
+                      control: {
+                        first: {},
+                        all: [],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
                     relative_uplift: {
-                      first: {},
-                      all: [],
+                      control: {
+                        first: {},
+                        all: [],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
                   },
                   feature_c_ever_used: {
@@ -6155,12 +8579,24 @@ export const mockAnalysisWithErrorsAndResults = (modifications = {}) =>
                       ],
                     },
                     difference: {
-                      first: {},
-                      all: [],
+                      control: {
+                        first: {},
+                        all: [],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
                     relative_uplift: {
-                      first: {},
-                      all: [],
+                      control: {
+                        first: {},
+                        all: [],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
                   },
                   feature_c: CONTROL_NEUTRAL,
@@ -6182,12 +8618,24 @@ export const mockAnalysisWithErrorsAndResults = (modifications = {}) =>
                       ],
                     },
                     difference: {
-                      first: {},
-                      all: [],
+                      control: {
+                        first: {},
+                        all: [],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
                     relative_uplift: {
-                      first: {},
-                      all: [],
+                      control: {
+                        first: {},
+                        all: [],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
                   },
                   outcome_d: {
@@ -6208,12 +8656,24 @@ export const mockAnalysisWithErrorsAndResults = (modifications = {}) =>
                       ],
                     },
                     difference: {
-                      first: {},
-                      all: [],
+                      control: {
+                        first: {},
+                        all: [],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
                     relative_uplift: {
-                      first: {},
-                      all: [],
+                      control: {
+                        first: {},
+                        all: [],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
                   },
                   days_of_use: CONTROL_NEUTRAL,
@@ -6236,12 +8696,24 @@ export const mockAnalysisWithErrorsAndResults = (modifications = {}) =>
                       },
                     },
                     difference: {
-                      first: {},
-                      all: [],
+                      control: {
+                        first: {},
+                        all: [],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
                     relative_uplift: {
-                      first: {},
-                      all: [],
+                      control: {
+                        first: {},
+                        all: [],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
                   },
                 },
@@ -6263,12 +8735,24 @@ export const mockAnalysisWithErrorsAndResults = (modifications = {}) =>
                       ],
                     },
                     difference: {
-                      first: {},
-                      all: [],
+                      control: {
+                        first: {},
+                        all: [],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
                     relative_uplift: {
-                      first: {},
-                      all: [],
+                      control: {
+                        first: {},
+                        all: [],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
                     percent: 55,
                   },
@@ -6291,34 +8775,55 @@ export const mockAnalysisWithErrorsAndResults = (modifications = {}) =>
                       ],
                     },
                     difference: {
-                      first: {
-                        point: -0.0006569487628876534,
-                        upper: 0.04316381736512019,
-                        lower: 0.04175095963994029,
-                      },
-                      all: [
-                        {
+                      control: {
+                        first: {
                           point: -0.0006569487628876534,
                           upper: 0.04316381736512019,
                           lower: 0.04175095963994029,
                         },
-                      ],
+                        all: [
+                          {
+                            point: -0.0006569487628876534,
+                            upper: 0.04316381736512019,
+                            lower: 0.04175095963994029,
+                          },
+                        ],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
                     relative_uplift: {
-                      first: {
-                        lower: -0.455210299676828,
-                        upper: 0.5104985718410426,
-                        point: -0.06233954570562385,
-                      },
-                      all: [
-                        {
+                      control: {
+                        first: {
                           lower: -0.455210299676828,
                           upper: 0.5104985718410426,
                           point: -0.06233954570562385,
                         },
-                      ],
+                        all: [
+                          {
+                            lower: -0.455210299676828,
+                            upper: 0.5104985718410426,
+                            point: -0.06233954570562385,
+                          },
+                        ],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
-                    significance: { overall: { "1": "positive" }, weekly: {} },
+                    significance: {
+                      control: {
+                        overall: { "1": "positive" },
+                        weekly: {},
+                      },
+                      treatment: {
+                        overall: {},
+                        weekly: {},
+                      },
+                    },
                   },
                   picture_in_picture: {
                     absolute: {
@@ -6338,34 +8843,55 @@ export const mockAnalysisWithErrorsAndResults = (modifications = {}) =>
                       ],
                     },
                     difference: {
-                      first: {
-                        point: -0.0006569487628876534,
-                        upper: 0.04316381736512019,
-                        lower: 0.04175095963994029,
-                      },
-                      all: [
-                        {
+                      control: {
+                        first: {
                           point: -0.0006569487628876534,
                           upper: 0.04316381736512019,
                           lower: 0.04175095963994029,
                         },
-                      ],
+                        all: [
+                          {
+                            point: -0.0006569487628876534,
+                            upper: 0.04316381736512019,
+                            lower: 0.04175095963994029,
+                          },
+                        ],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
                     relative_uplift: {
-                      first: {
-                        lower: -0.455210299676828,
-                        upper: 0.5104985718410426,
-                        point: -0.06233954570562385,
-                      },
-                      all: [
-                        {
+                      control: {
+                        first: {
                           lower: -0.455210299676828,
                           upper: 0.5104985718410426,
                           point: -0.06233954570562385,
                         },
-                      ],
+                        all: [
+                          {
+                            lower: -0.455210299676828,
+                            upper: 0.5104985718410426,
+                            point: -0.06233954570562385,
+                          },
+                        ],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
-                    significance: { overall: { "1": "positive" }, weekly: {} },
+                    significance: {
+                      control: {
+                        overall: { "1": "positive" },
+                        weekly: {},
+                      },
+                      treatment: {
+                        overall: {},
+                        weekly: {},
+                      },
+                    },
                   },
                   feature_b_ever_used: {
                     absolute: {
@@ -6385,34 +8911,55 @@ export const mockAnalysisWithErrorsAndResults = (modifications = {}) =>
                       ],
                     },
                     difference: {
-                      first: {
-                        point: -0.0006569487628876534,
-                        upper: 0.04316381736512019,
-                        lower: 0.04175095963994029,
-                      },
-                      all: [
-                        {
+                      control: {
+                        first: {
                           point: -0.0006569487628876534,
                           upper: 0.04316381736512019,
                           lower: 0.04175095963994029,
                         },
-                      ],
+                        all: [
+                          {
+                            point: -0.0006569487628876534,
+                            upper: 0.04316381736512019,
+                            lower: 0.04175095963994029,
+                          },
+                        ],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
                     relative_uplift: {
-                      first: {
-                        lower: -0.455210299676828,
-                        upper: 0.5104985718410426,
-                        point: -0.06233954570562385,
-                      },
-                      all: [
-                        {
+                      control: {
+                        first: {
                           lower: -0.455210299676828,
                           upper: 0.5104985718410426,
                           point: -0.06233954570562385,
                         },
-                      ],
+                        all: [
+                          {
+                            lower: -0.455210299676828,
+                            upper: 0.5104985718410426,
+                            point: -0.06233954570562385,
+                          },
+                        ],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
-                    significance: { overall: { "1": "negative" }, weekly: {} },
+                    significance: {
+                      control: {
+                        overall: { "1": "negative" },
+                        weekly: {},
+                      },
+                      treatment: {
+                        overall: {},
+                        weekly: {},
+                      },
+                    },
                   },
                   feature_b: {
                     absolute: {
@@ -6432,34 +8979,55 @@ export const mockAnalysisWithErrorsAndResults = (modifications = {}) =>
                       ],
                     },
                     difference: {
-                      first: {
-                        point: -0.0006569487628876534,
-                        upper: 0.04316381736512019,
-                        lower: 0.04175095963994029,
-                      },
-                      all: [
-                        {
+                      control: {
+                        first: {
                           point: -0.0006569487628876534,
                           upper: 0.04316381736512019,
                           lower: 0.04175095963994029,
                         },
-                      ],
+                        all: [
+                          {
+                            point: -0.0006569487628876534,
+                            upper: 0.04316381736512019,
+                            lower: 0.04175095963994029,
+                          },
+                        ],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
                     relative_uplift: {
-                      first: {
-                        lower: -0.455210299676828,
-                        upper: 0.5104985718410426,
-                        point: -0.06233954570562385,
-                      },
-                      all: [
-                        {
+                      control: {
+                        first: {
                           lower: -0.455210299676828,
                           upper: 0.5104985718410426,
                           point: -0.06233954570562385,
                         },
-                      ],
+                        all: [
+                          {
+                            lower: -0.455210299676828,
+                            upper: 0.5104985718410426,
+                            point: -0.06233954570562385,
+                          },
+                        ],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
-                    significance: { overall: { "1": "negative" }, weekly: {} },
+                    significance: {
+                      control: {
+                        overall: { "1": "negative" },
+                        weekly: {},
+                      },
+                      treatment: {
+                        overall: {},
+                        weekly: {},
+                      },
+                    },
                   },
                   feature_c_ever_used: {
                     absolute: {
@@ -6479,34 +9047,55 @@ export const mockAnalysisWithErrorsAndResults = (modifications = {}) =>
                       ],
                     },
                     difference: {
-                      first: {
-                        point: -0.0006569487628876534,
-                        upper: 0.04316381736512019,
-                        lower: 0.04175095963994029,
-                      },
-                      all: [
-                        {
+                      control: {
+                        first: {
                           point: -0.0006569487628876534,
                           upper: 0.04316381736512019,
                           lower: 0.04175095963994029,
                         },
-                      ],
+                        all: [
+                          {
+                            point: -0.0006569487628876534,
+                            upper: 0.04316381736512019,
+                            lower: 0.04175095963994029,
+                          },
+                        ],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
                     relative_uplift: {
-                      first: {
-                        lower: -0.455210299676828,
-                        upper: 0.5104985718410426,
-                        point: -0.06233954570562385,
-                      },
-                      all: [
-                        {
+                      control: {
+                        first: {
                           lower: -0.455210299676828,
                           upper: 0.5104985718410426,
                           point: -0.06233954570562385,
                         },
-                      ],
+                        all: [
+                          {
+                            lower: -0.455210299676828,
+                            upper: 0.5104985718410426,
+                            point: -0.06233954570562385,
+                          },
+                        ],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
-                    significance: { overall: { "1": "neutral" }, weekly: {} },
+                    significance: {
+                      control: {
+                        overall: { "1": "neutral" },
+                        weekly: {},
+                      },
+                      treatment: {
+                        overall: {},
+                        weekly: {},
+                      },
+                    },
                   },
                   feature_c: TREATMENT_NEUTRAL,
                   days_of_use: TREATMENT_NEUTRAL,
@@ -6529,34 +9118,55 @@ export const mockAnalysisWithErrorsAndResults = (modifications = {}) =>
                       ],
                     },
                     difference: {
-                      first: {
-                        point: -0.0006569487628876534,
-                        upper: 0.04316381736512019,
-                        lower: 0.04175095963994029,
-                      },
-                      all: [
-                        {
+                      control: {
+                        first: {
                           point: -0.0006569487628876534,
                           upper: 0.04316381736512019,
                           lower: 0.04175095963994029,
                         },
-                      ],
+                        all: [
+                          {
+                            point: -0.0006569487628876534,
+                            upper: 0.04316381736512019,
+                            lower: 0.04175095963994029,
+                          },
+                        ],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
                     relative_uplift: {
-                      first: {
-                        lower: -0.455210299676828,
-                        upper: 0.5104985718410426,
-                        point: -0.06233954570562385,
-                      },
-                      all: [
-                        {
+                      control: {
+                        first: {
                           lower: -0.455210299676828,
                           upper: 0.5104985718410426,
                           point: -0.06233954570562385,
                         },
-                      ],
+                        all: [
+                          {
+                            lower: -0.455210299676828,
+                            upper: 0.5104985718410426,
+                            point: -0.06233954570562385,
+                          },
+                        ],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
-                    significance: { overall: { "1": "positive" }, weekly: {} },
+                    significance: {
+                      control: {
+                        overall: { "1": "positive" },
+                        weekly: {},
+                      },
+                      treatment: {
+                        overall: {},
+                        weekly: {},
+                      },
+                    },
                   },
                   outcome_d: {
                     absolute: {
@@ -6576,34 +9186,55 @@ export const mockAnalysisWithErrorsAndResults = (modifications = {}) =>
                       ],
                     },
                     difference: {
-                      first: {
-                        point: -0.0006569487628876534,
-                        upper: 0.04316381736512019,
-                        lower: 0.04175095963994029,
-                      },
-                      all: [
-                        {
+                      control: {
+                        first: {
                           point: -0.0006569487628876534,
                           upper: 0.04316381736512019,
                           lower: 0.04175095963994029,
                         },
-                      ],
+                        all: [
+                          {
+                            point: -0.0006569487628876534,
+                            upper: 0.04316381736512019,
+                            lower: 0.04175095963994029,
+                          },
+                        ],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
                     relative_uplift: {
-                      first: {
-                        lower: -0.455210299676828,
-                        upper: 0.5104985718410426,
-                        point: -0.06233954570562385,
-                      },
-                      all: [
-                        {
+                      control: {
+                        first: {
                           lower: -0.455210299676828,
                           upper: 0.5104985718410426,
                           point: -0.06233954570562385,
                         },
-                      ],
+                        all: [
+                          {
+                            lower: -0.455210299676828,
+                            upper: 0.5104985718410426,
+                            point: -0.06233954570562385,
+                          },
+                        ],
+                      },
+                      treatment: {
+                        first: {},
+                        all: [],
+                      },
                     },
-                    significance: { overall: { "1": "positive" }, weekly: {} },
+                    significance: {
+                      control: {
+                        overall: { "1": "positive" },
+                        weekly: {},
+                      },
+                      treatment: {
+                        overall: {},
+                        weekly: {},
+                      },
+                    },
                   },
                 },
                 search_metrics: {

--- a/experimenter/experimenter/nimbus-ui/src/lib/visualization/types.ts
+++ b/experimenter/experimenter/nimbus-ui/src/lib/visualization/types.ts
@@ -5,7 +5,6 @@
 import { BRANCH_COMPARISON } from "src/lib/visualization/constants";
 
 export interface AnalysisData {
-  daily: AnalysisBasisData | null;
   weekly: AggregatedAnalysisBasisData | null;
   overall: AggregatedAnalysisBasisData | null;
   show_analysis: boolean;
@@ -107,26 +106,34 @@ export interface FormattedAnalysisPoint {
   window_index?: number;
 }
 
+interface AnalysisPointData {
+  first: FormattedAnalysisPoint;
+  all: FormattedAnalysisPoint[];
+}
+interface PairwiseAnalysisPointData {
+  [comparison_branch: string]: AnalysisPointData;
+}
+
+interface SignificanceByWindow {
+  [window_index: string]: string;
+}
+interface SignificanceData {
+  [window: string]: SignificanceByWindow;
+}
+interface PairwiseSignificanceData {
+  [comparison_branch: string]: SignificanceData;
+}
 export interface BranchDescription {
   is_control: boolean;
   branch_data: {
     [group: string]: {
       [metric: string]: {
         [index: string]: any;
-        absolute: {
-          first: FormattedAnalysisPoint;
-          all: FormattedAnalysisPoint[];
-        };
-        difference: {
-          first: FormattedAnalysisPoint;
-          all: FormattedAnalysisPoint[];
-        };
-        relative_uplift: {
-          first: FormattedAnalysisPoint;
-          all: FormattedAnalysisPoint[];
-        };
+        absolute: AnalysisPointData;
+        difference: PairwiseAnalysisPointData;
+        relative_uplift: PairwiseAnalysisPointData;
         percent?: number;
-        significance?: { [window: string]: { [window_index: string]: string } };
+        significance?: PairwiseSignificanceData;
       };
     };
   };

--- a/experimenter/experimenter/nimbus-ui/src/lib/visualization/utils.test.ts
+++ b/experimenter/experimenter/nimbus-ui/src/lib/visualization/utils.test.ts
@@ -68,60 +68,17 @@ describe("getSortedBranchNames", () => {
 });
 
 describe("getControlBranchName", () => {
-  const MOCK_ANALYSIS_DAILY = {
-    daily: {
-      enrollments: {
-        all: [
-          {
-            point: 1,
-            branch: "test",
-            metric: "test_metric",
-            statistic: "count",
-          },
-        ],
-      },
-    },
+  const MOCK_ANALYSIS_NO_BRANCH_INFO = {
     weekly: { enrollments: { all: {} } },
     overall: { enrollments: { all: {} } },
     show_analysis: true,
     errors: { experiment: [] },
   };
 
-  it("returns the branch from daily if there are no other branches", () => {
-    expect(getControlBranchName(MOCK_ANALYSIS_DAILY)).toEqual("test");
-  });
-
-  it("throws an error if it cannot determine the control branch and there are multiple branches in daily", () => {
-    expect(() =>
-      getControlBranchName({
-        ...MOCK_ANALYSIS_DAILY,
-        daily: {
-          enrollments: {
-            all: [
-              {
-                point: 1,
-                branch: "test",
-                metric: "test_metric",
-                statistic: "count",
-              },
-              {
-                point: 11,
-                branch: "not-test",
-                metric: "test_metric",
-                statistic: "binomial",
-              },
-            ],
-          },
-        },
-      }),
-    ).toThrow("no branch name");
-  });
-
   it("throws an error if it cannot find a branch in the results", () => {
     expect(() =>
       getControlBranchName({
-        ...MOCK_ANALYSIS_DAILY,
-        daily: { enrollments: { all: [] } },
+        ...MOCK_ANALYSIS_NO_BRANCH_INFO,
       }),
     ).toThrow("no branch name");
   });

--- a/experimenter/experimenter/nimbus-ui/src/lib/visualization/utils.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/lib/visualization/utils.tsx
@@ -45,14 +45,6 @@ export const getControlBranchName = (analysis: AnalysisData) => {
       }
     }
   }
-  // last option - try to find a unique branch name in the daily results
-  const daily = analysis.daily?.enrollments?.all || [];
-  if (daily.length > 0) {
-    const branches = new Set(daily.map((point) => point.branch));
-    if (branches.size === 1) {
-      return branches.values().next().value; // return the first and only value
-    }
-  }
 
   throw new Error(
     "Invalid argument 'analysis': no branch name could be found in the results.",
@@ -89,13 +81,14 @@ export const getExtremeBounds = (
   outcomeSlug: string,
   group: string,
   segment: string,
+  referenceBranch: string,
 ) => {
   let extreme = 0;
   sortedBranchNames.forEach((branch) => {
     if (results![segment]![branch].branch_data[group][outcomeSlug]) {
       results![segment]![branch].branch_data[group][outcomeSlug][
         BRANCH_COMPARISON.UPLIFT
-      ]["all"].forEach((dataPoint: FormattedAnalysisPoint) => {
+      ][referenceBranch]["all"].forEach((dataPoint: FormattedAnalysisPoint) => {
         const { lower, upper } = dataPoint;
         const max = Math.max(Math.abs(lower!), Math.abs(upper!));
         extreme = max > extreme ? max : extreme;

--- a/experimenter/experimenter/visualization/api/v3/views.py
+++ b/experimenter/experimenter/visualization/api/v3/views.py
@@ -8,7 +8,7 @@ from experimenter.experiments.models import NimbusExperiment
 @api_view()
 def analysis_results_view(request, slug):
     experiment = get_object_or_404(NimbusExperiment.objects.filter(slug=slug))
-    if experiment.results_data is not None and "v2" in experiment.results_data:
-        return Response(experiment.results_data["v2"])
+    if experiment.results_data is not None and "v3" in experiment.results_data:
+        return Response(experiment.results_data["v3"])
 
     return Response(None)

--- a/experimenter/experimenter/visualization/tests/api/test_views.py
+++ b/experimenter/experimenter/visualization/tests/api/test_views.py
@@ -39,7 +39,7 @@ class TestVisualizationView(TestCase):
         self.assertEqual(response.content, b"")
 
         # test with results_data object
-        experiment.results_data = {"v2": {}}
+        experiment.results_data = {"v3": {}}
         experiment.save()
 
         response = self.client.get(


### PR DESCRIPTION
Because

- we added a `v3` to experiments' `results_data` containing pairwise branch comparison data

This commit

- switches the v3 API to use this `v3` data
- updates the UI to work with `v3` format of data

Fixes #10436

**Note** that this PR should not change anything visible to users. There will be a follow-up PR containing the UI changes that will allow users to select different branches as reference.