### PR TITLE
bug(nimbus): fix results page redirect condition

### DIFF
--- a/experimenter/experimenter/nimbus-ui/src/components/App/ExperimentRoot/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/App/ExperimentRoot/index.tsx
@@ -81,7 +81,7 @@ export const ExperimentRoot = ({
       if (
         !loading &&
         status &&
-        (redirectResult = redirect!({ status, analysis })) != null
+        (redirectResult = redirect!({ status, experiment, analysis })) != null
       ) {
         redirectResult = redirectResult.length
           ? `/${redirectResult}`

--- a/experimenter/experimenter/nimbus-ui/src/components/PageResults/index.test.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageResults/index.test.tsx
@@ -384,6 +384,7 @@ describe("PageResults", () => {
       redirectTestCommon({
         mockExperiment: mockExperimentQuery("demo-slug", {
           status: NimbusExperimentStatusEnum.COMPLETE,
+          showResultsUrl: false,
         }).experiment,
       }),
     ).toEqual("");

--- a/experimenter/experimenter/nimbus-ui/src/components/PageResults/index.test.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageResults/index.test.tsx
@@ -421,6 +421,7 @@ describe("PageResults", () => {
     return condition({
       analysis: mockAnalysisData,
       status: mockGetStatus(mockExperiment),
+      experiment: mockExperiment,
     });
   };
 

--- a/experimenter/experimenter/nimbus-ui/src/components/PageResults/index.test.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageResults/index.test.tsx
@@ -389,6 +389,18 @@ describe("PageResults", () => {
     ).toEqual("");
   });
 
+  it("does not redirect to the summary page if the visualization flags are undefined", async () => {
+    expect(
+      redirectTestCommon({
+        mockAnalysisData: mockAnalysis({ show_analysis: undefined }),
+        mockExperiment: mockExperimentQuery("demo-slug", {
+          status: NimbusExperimentStatusEnum.COMPLETE,
+          showResultsUrl: undefined,
+        }).experiment,
+      }),
+    ).not.toEqual("");
+  });
+
   const redirectTestCommon = (props: React.ComponentProps<typeof Subject>) => {
     const { mockAnalysisData, mockExperiment } = props;
     const useRedirectCondition = jest.fn();

--- a/experimenter/experimenter/nimbus-ui/src/components/PageResults/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageResults/index.tsx
@@ -41,7 +41,7 @@ const PageResults: React.FunctionComponent<RouteComponentProps> = () => {
   useRedirectCondition(({ status, experiment, analysis }) => {
     if (!status?.launched) return "edit/overview";
     // explicitly check for false to avoid undefined being falsy
-    if (experiment?.showResultsUrl === false || !analysis?.show_analysis)
+    if (experiment?.showResultsUrl === false || analysis?.show_analysis === false)
       return "";
   });
 
@@ -68,7 +68,7 @@ const PageResults: React.FunctionComponent<RouteComponentProps> = () => {
   if (
     !analysis ||
     experiment?.showResultsUrl === false ||
-    !analysis?.show_analysis
+    analysis?.show_analysis === false
   )
     return null;
 

--- a/experimenter/experimenter/nimbus-ui/src/components/PageResults/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageResults/index.tsx
@@ -41,7 +41,10 @@ const PageResults: React.FunctionComponent<RouteComponentProps> = () => {
   useRedirectCondition(({ status, experiment, analysis }) => {
     if (!status?.launched) return "edit/overview";
     // explicitly check for false to avoid undefined being falsy
-    if (experiment?.showResultsUrl === false || analysis?.show_analysis === false)
+    if (
+      experiment?.showResultsUrl === false ||
+      analysis?.show_analysis === false
+    )
       return "";
   });
 


### PR DESCRIPTION
Because

- direct links to an experiment Results page erroneously redirect to /summary

This commit

- fixes the redirect conditions for the Results page so that not-yet-loaded flags don't trigger a redirect
- the redirect hook updates on experiment load so a not-ready Results link (e.g., if you manually go to /results for an experiment without results) will redirect to /summary properly

Fixes #8683