### PR TITLE
bug(nimbus): fix outcome slug lookup to filter by app

### DIFF
--- a/experimenter/experimenter/experiments/api/v5/types.py
+++ b/experimenter/experimenter/experiments/api/v5/types.py
@@ -133,7 +133,7 @@ class NimbusUserType(DjangoObjectType):
 
 
 class NimbusExperimentApplicationConfigType(graphene.ObjectType):
-    application = NimbusExperimentApplicationEnum()
+    application = graphene.NonNull(NimbusExperimentApplicationEnum)
     channels = graphene.List(NimbusLabelValueType)
 
 
@@ -148,7 +148,7 @@ class NimbusExperimentTargetingConfigType(graphene.ObjectType):
 
 class NimbusFeatureConfigType(DjangoObjectType):
     id = graphene.Int()
-    application = NimbusExperimentApplicationEnum()
+    application = graphene.NonNull(NimbusExperimentApplicationEnum)
     sets_prefs = graphene.Boolean()
     schema = graphene.String()
 
@@ -244,7 +244,7 @@ class NimbusOutcomeMetricType(graphene.ObjectType):
 class NimbusOutcomeType(graphene.ObjectType):
     friendly_name = graphene.String()
     slug = graphene.String()
-    application = NimbusExperimentApplicationEnum()
+    application = graphene.NonNull(NimbusExperimentApplicationEnum)
     description = graphene.String()
     is_default = graphene.Boolean()
     metrics = graphene.List(NimbusOutcomeMetricType)
@@ -489,7 +489,7 @@ class NimbusConfigurationType(graphene.ObjectType):
 
 
 class NimbusExperimentType(DjangoObjectType):
-    application = NimbusExperimentApplicationEnum()
+    application = graphene.NonNull(NimbusExperimentApplicationEnum)
     can_archive = graphene.Boolean()
     can_edit = graphene.Boolean()
     can_review = graphene.Boolean()

--- a/experimenter/experimenter/nimbus-ui/schema.graphql
+++ b/experimenter/experimenter/nimbus-ui/schema.graphql
@@ -32,7 +32,7 @@ type NimbusExperimentType {
   totalEnrolledClients: Int!
   firefoxMinVersion: NimbusExperimentFirefoxVersionEnum
   firefoxMaxVersion: NimbusExperimentFirefoxVersionEnum
-  application: NimbusExperimentApplicationEnum
+  application: NimbusExperimentApplicationEnum!
   channel: NimbusExperimentChannelEnum
   locales: [NimbusLocaleType!]!
   countries: [NimbusCountryType!]!
@@ -342,7 +342,7 @@ type NimbusFeatureConfigType {
   name: String!
   slug: String!
   description: String
-  application: NimbusExperimentApplicationEnum
+  application: NimbusExperimentApplicationEnum!
   ownerEmail: String
   enabled: Boolean!
   setsPrefs: Boolean
@@ -485,7 +485,7 @@ type NimbusConfigurationType {
 }
 
 type NimbusExperimentApplicationConfigType {
-  application: NimbusExperimentApplicationEnum
+  application: NimbusExperimentApplicationEnum!
   channels: [NimbusLabelValueType]
 }
 
@@ -497,7 +497,7 @@ type NimbusLabelValueType {
 type NimbusOutcomeType {
   friendlyName: String
   slug: String
-  application: NimbusExperimentApplicationEnum
+  application: NimbusExperimentApplicationEnum!
   description: String
   isDefault: Boolean
   metrics: [NimbusOutcomeMetricType]

--- a/experimenter/experimenter/nimbus-ui/src/components/PreviewURL/index.test.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PreviewURL/index.test.tsx
@@ -7,7 +7,10 @@ import React from "react";
 import selectEvent from "react-select-event";
 import PreviewURL from "src/components/PreviewURL";
 import { mockExperimentQuery, mockGetStatus } from "src/lib/mocks";
-import { NimbusExperimentStatusEnum } from "src/types/globalTypes";
+import {
+  NimbusExperimentApplicationEnum,
+  NimbusExperimentStatusEnum,
+} from "src/types/globalTypes";
 
 const { experiment } = mockExperimentQuery("preview-url-slug");
 
@@ -44,7 +47,7 @@ describe("PreviewURL", () => {
     render(
       <PreviewURL
         {...experiment}
-        application={null}
+        application={NimbusExperimentApplicationEnum.DEMO_APP}
         status={mockGetStatus({ status: NimbusExperimentStatusEnum.LIVE })}
       />,
     );

--- a/experimenter/experimenter/nimbus-ui/src/hooks/useOutcomes.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/hooks/useOutcomes.tsx
@@ -18,11 +18,6 @@ export function useOutcomes(experiment: getExperiment_experimentBySlug): {
       return [];
     }
 
-    if (experiment.application === null) {
-      return slugs
-        .map((slug) => outcomes!.find((outcome) => outcome!.slug === slug))
-        .filter((outcome) => outcome != null);
-    }
     return slugs
       .map((slug) =>
         outcomes!.find(

--- a/experimenter/experimenter/nimbus-ui/src/hooks/useOutcomes.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/hooks/useOutcomes.tsx
@@ -24,7 +24,13 @@ export function useOutcomes(experiment: getExperiment_experimentBySlug): {
         .filter((outcome) => outcome != null);
     }
     return slugs
-      .map((slug) => outcomes!.find((outcome) => outcome!.slug === slug && outcome!.application === experiment.application))
+      .map((slug) =>
+        outcomes!.find(
+          (outcome) =>
+            outcome!.slug === slug &&
+            outcome!.application === experiment.application,
+        ),
+      )
       .filter((outcome) => outcome != null);
   };
 

--- a/experimenter/experimenter/nimbus-ui/src/hooks/useOutcomes.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/hooks/useOutcomes.tsx
@@ -18,8 +18,13 @@ export function useOutcomes(experiment: getExperiment_experimentBySlug): {
       return [];
     }
 
+    if (experiment.application === null) {
+      return slugs
+        .map((slug) => outcomes!.find((outcome) => outcome!.slug === slug))
+        .filter((outcome) => outcome != null);
+    }
     return slugs
-      .map((slug) => outcomes!.find((outcome) => outcome!.slug === slug))
+      .map((slug) => outcomes!.find((outcome) => outcome!.slug === slug && outcome!.application === experiment.application))
       .filter((outcome) => outcome != null);
   };
 

--- a/experimenter/experimenter/nimbus-ui/src/lib/mocks.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/lib/mocks.tsx
@@ -1141,11 +1141,6 @@ export function mockOutcomeSets(experiment: getExperiment_experimentBySlug): {
       return [];
     }
 
-    if (experiment.application === null) {
-      return slugs
-        .map((slug) => outcomes!.find((outcome) => outcome!.slug === slug))
-        .filter((outcome) => outcome != null);
-    }
     return slugs
       .map((slug) =>
         outcomes!.find(

--- a/experimenter/experimenter/nimbus-ui/src/lib/mocks.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/lib/mocks.tsx
@@ -1147,7 +1147,13 @@ export function mockOutcomeSets(experiment: getExperiment_experimentBySlug): {
         .filter((outcome) => outcome != null);
     }
     return slugs
-      .map((slug) => outcomes!.find((outcome) => outcome!.slug === slug && outcome!.application === experiment.application))
+      .map((slug) =>
+        outcomes!.find(
+          (outcome) =>
+            outcome!.slug === slug &&
+            outcome!.application === experiment.application,
+        ),
+      )
       .filter((outcome) => outcome != null);
   };
 

--- a/experimenter/experimenter/nimbus-ui/src/lib/mocks.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/lib/mocks.tsx
@@ -1141,8 +1141,13 @@ export function mockOutcomeSets(experiment: getExperiment_experimentBySlug): {
       return [];
     }
 
+    if (experiment.application === null) {
+      return slugs
+        .map((slug) => outcomes!.find((outcome) => outcome!.slug === slug))
+        .filter((outcome) => outcome != null);
+    }
     return slugs
-      .map((slug) => outcomes!.find((outcome) => outcome!.slug === slug))
+      .map((slug) => outcomes!.find((outcome) => outcome!.slug === slug && outcome!.application === experiment.application))
       .filter((outcome) => outcome != null);
   };
 

--- a/experimenter/experimenter/nimbus-ui/src/types/getAllExperiments.ts
+++ b/experimenter/experimenter/nimbus-ui/src/types/getAllExperiments.ts
@@ -21,7 +21,7 @@ export interface getAllExperiments_experiments_featureConfigs {
   slug: string;
   name: string;
   description: string | null;
-  application: NimbusExperimentApplicationEnum | null;
+  application: NimbusExperimentApplicationEnum;
   ownerEmail: string | null;
 }
 
@@ -54,7 +54,7 @@ export interface getAllExperiments_experiments {
   featureConfigs: getAllExperiments_experiments_featureConfigs[] | null;
   targetingConfig: (getAllExperiments_experiments_targetingConfig | null)[] | null;
   slug: string;
-  application: NimbusExperimentApplicationEnum | null;
+  application: NimbusExperimentApplicationEnum;
   firefoxMinVersion: NimbusExperimentFirefoxVersionEnum | null;
   firefoxMaxVersion: NimbusExperimentFirefoxVersionEnum | null;
   startDate: DateTime | null;

--- a/experimenter/experimenter/nimbus-ui/src/types/getConfig.ts
+++ b/experimenter/experimenter/nimbus-ui/src/types/getConfig.ts
@@ -30,7 +30,7 @@ export interface getConfig_nimbusConfig_applicationConfigs_channels {
 }
 
 export interface getConfig_nimbusConfig_applicationConfigs {
-  application: NimbusExperimentApplicationEnum | null;
+  application: NimbusExperimentApplicationEnum;
   channels: (getConfig_nimbusConfig_applicationConfigs_channels | null)[] | null;
 }
 
@@ -39,7 +39,7 @@ export interface getConfig_nimbusConfig_allFeatureConfigs {
   name: string;
   slug: string;
   description: string | null;
-  application: NimbusExperimentApplicationEnum | null;
+  application: NimbusExperimentApplicationEnum;
   ownerEmail: string | null;
   schema: string | null;
   setsPrefs: boolean | null;
@@ -60,7 +60,7 @@ export interface getConfig_nimbusConfig_outcomes_metrics {
 export interface getConfig_nimbusConfig_outcomes {
   friendlyName: string | null;
   slug: string | null;
-  application: NimbusExperimentApplicationEnum | null;
+  application: NimbusExperimentApplicationEnum;
   description: string | null;
   isDefault: boolean | null;
   metrics: (getConfig_nimbusConfig_outcomes_metrics | null)[] | null;

--- a/experimenter/experimenter/nimbus-ui/src/types/getExperiment.ts
+++ b/experimenter/experimenter/nimbus-ui/src/types/getExperiment.ts
@@ -77,7 +77,7 @@ export interface getExperiment_experimentBySlug_featureConfigs {
   slug: string;
   name: string;
   description: string | null;
-  application: NimbusExperimentApplicationEnum | null;
+  application: NimbusExperimentApplicationEnum;
   ownerEmail: string | null;
   schema: string | null;
   enabled: boolean;
@@ -223,7 +223,7 @@ export interface getExperiment_experimentBySlug {
   resultsReady: boolean | null;
   showResultsUrl: boolean | null;
   hypothesis: string | null;
-  application: NimbusExperimentApplicationEnum | null;
+  application: NimbusExperimentApplicationEnum;
   publicDescription: string | null;
   conclusionRecommendation: NimbusExperimentConclusionRecommendationEnum | null;
   takeawaysGainAmount: string | null;


### PR DESCRIPTION
Because

- there can be overlaps in outcome slugs across applications
- we saw some experiment summary pages linking to the wrong application's outcome definitions

This commit

- ensures that the outcomes hook filters to the experiment's application

Fixes #9505
