### PR TITLE
bug(nimbus): fml highlight may be null

### DIFF
--- a/experimenter/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/FormFeatureValue/validators.test.ts
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/FormFeatureValue/validators.test.ts
@@ -383,4 +383,27 @@ describe("fmlLinter", () => {
       method: "PUT",
     });
   });
+  it("returns diagnostics when errors returned with null highlight", async () => {
+    fetchMock.mockResponseOnce(
+      JSON.stringify([
+        { line: 0, col: 0, highlight: null, message: "Invalid value" },
+      ]),
+    );
+    const linter = fmlLinter("test-slug", featureConfig);
+    const state = createEditorState({ doc: JSON.stringify({ some: "data" }) });
+    const errors = await linter({ state });
+    expect(errors).toEqual([
+      {
+        message: "Invalid value",
+        severity: "error",
+        from: 0,
+        to: 0,
+      },
+    ]);
+    expect(fetch).toHaveBeenCalledWith("/api/v5/fml-errors/test-slug/", {
+      body: '{"featureSlug":"picture-in-picture","featureValue":"{\\"some\\":\\"data\\"}"}',
+      headers: { "Content-Type": "application/json" },
+      method: "PUT",
+    });
+  });
 });

--- a/experimenter/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/FormFeatureValue/validators.ts
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageEditBranches/FormBranches/FormFeatureValue/validators.ts
@@ -372,12 +372,9 @@ export function fmlLinter(
         e["line"] + 1,
         e["col"],
       );
+      const length = e["highlight"] ? e["highlight"].length : 0;
 
-      return createDiagnostic(
-        position,
-        position + e["highlight"].length,
-        e["message"],
-      );
+      return createDiagnostic(position, position + length, e["message"]);
     });
   };
 }


### PR DESCRIPTION
Because

* We recently hook up FML errors to the CodeMirror JSON editor on the branch page
* We use the `highlight` field to determine which tokens to highlight in the editor
* Highlight may be null but we didn't handle the null case

This commit

* Checks if highlight is null and handles that case appropriately

fixes #10454
