### PR TITLE
chore(nimbus): remove duplicate feature manifest path

### DIFF
--- a/experimenter/experimenter/features/manifests/nimbus_fml_loader.py
+++ b/experimenter/experimenter/features/manifests/nimbus_fml_loader.py
@@ -8,14 +8,11 @@ from rust_fml import FmlClient
 
 from experimenter.experiments.constants import NimbusConstants
 from experimenter.experiments.models import NimbusFeatureVersion
-from experimenter.settings import BASE_DIR
 
 logger = logging.getLogger()
 
 
 class NimbusFmlLoader:
-    MANIFEST_PATH = BASE_DIR / "features" / "manifests"
-
     def __init__(self, application: str, channel: str):
         self.application: str = (
             application if application in NimbusConstants.Application else None


### PR DESCRIPTION
Because

* The feature manifest path is stored in settings.py
* We don't also need a duplicate definition in the feature loader

This commit

* Removes the duplicate feature manifest path

fixes #9768
