### PR TITLE
feat(cirrus): Support fxa targeting

### DIFF
--- a/experimenter/experimenter/experiments/constants.py
+++ b/experimenter/experimenter/experiments/constants.py
@@ -517,6 +517,7 @@ class NimbusConstants:
         Application.DEMO_APP: Version.NO_VERSION,
         Application.MONITOR: Version.NO_VERSION,
         Application.VPN: Version.NO_VERSION,
+        Application.FXA: Version.NO_VERSION,
     }
 
     COUNTRIES_APPLICATION_SUPPORTED_VERSION = {
@@ -527,6 +528,7 @@ class NimbusConstants:
         Application.DEMO_APP: Version.NO_VERSION,
         Application.MONITOR: Version.NO_VERSION,
         Application.VPN: Version.NO_VERSION,
+        Application.FXA: Version.NO_VERSION,
     }
 
     FEATURE_ENABLED_MIN_UNSUPPORTED_VERSION = Version.FIREFOX_104


### PR DESCRIPTION
Because

- We want to allow FxA to able to target by languages and countries

This commit

- Support targeting with no version required

Fixes #10489 