### PR TITLE
feat(cirrus): Support non-root user

### DIFF
--- a/cirrus/README.md
+++ b/cirrus/README.md
@@ -49,19 +49,15 @@ By following these steps, you will create the `.env` file and configure the nece
 
 ## Running as Non-Root User
 
-By default, the Cirrus Docker image runs the application as the root user. However, if you prefer to run the application as a non-root user for security reasons, you can build the Docker image with additional parameters.
+By default, the Cirrus Docker image runs the application as cirrus/1000/1000. However, if you prefer to run the application as a different user for security reasons, you can build the Docker image with additional parameters.
 
-To run the Cirrus application as a non-root user, follow these steps:
-
-- Build the Docker image while specifying the desired username, user ID, and group ID for the non-root user. For example:
+- Build the Docker image while specifying the desired username, user ID, and group ID. For example:
 
 ```bash
 docker build --build-arg USERNAME=myuser --build-arg USER_UID=1000 --build-arg USER_GID=1000 -t your_image_name:tag .
 ```
 
 Replace myuser with the desired username and 1000 with the desired user ID and group ID.
-
-- After building the image, you can run the Cirrus container as usual, and it will execute as the non-root user specified during the build process.
 
 ## Commands
 

--- a/cirrus/README.md
+++ b/cirrus/README.md
@@ -47,6 +47,22 @@ To set up the Cirrus environment, follow these steps:
 
 By following these steps, you will create the `.env` file and configure the necessary environment variables for the Cirrus application.
 
+## Running as Non-Root User
+
+By default, the Cirrus Docker image runs the application as the root user. However, if you prefer to run the application as a non-root user for security reasons, you can build the Docker image with additional parameters.
+
+To run the Cirrus application as a non-root user, follow these steps:
+
+- Build the Docker image while specifying the desired username, user ID, and group ID for the non-root user. For example:
+
+```bash
+docker build --build-arg USERNAME=myuser --build-arg USER_UID=1000 --build-arg USER_GID=1000 -t your_image_name:tag .
+```
+
+Replace myuser with the desired username and 1000 with the desired user ID and group ID.
+
+- After building the image, you can run the Cirrus container as usual, and it will execute as the non-root user specified during the build process.
+
 ## Commands
 
 The following are the available commands for working with Cirrus:

--- a/cirrus/server/Dockerfile
+++ b/cirrus/server/Dockerfile
@@ -30,6 +30,14 @@ RUN poetry config virtualenvs.create false && \
 # Second stage: Deploy stage
 FROM python:3.11-slim-bullseye as deploy
 
+# Create a non-root user
+ARG USERNAME=myuser
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
+
+RUN groupadd --gid $USER_GID $USERNAME \
+    && useradd --uid $USER_UID --gid $USER_GID -m $USERNAME
+
 WORKDIR /cirrus
 
 # Copy specific Rust components
@@ -45,6 +53,12 @@ ENV PYTHONPATH=$PYTHONPATH:/application-services
 
 # Copy all other files into the container's working directory
 COPY . .
+
+# Change ownership of the working directory to the non-root user
+RUN chown -R $USERNAME:$USERNAME /cirrus
+
+# Switch to non-root user
+USER $USERNAME
 
 # Start application with Uvicorn server
 CMD ["uvicorn", "cirrus.main:app", "--host", "0.0.0.0", "--port", "8001"]

--- a/cirrus/server/Dockerfile
+++ b/cirrus/server/Dockerfile
@@ -31,7 +31,7 @@ RUN poetry config virtualenvs.create false && \
 FROM python:3.11-slim-bullseye as deploy
 
 # Create a non-root user
-ARG USERNAME=myuser
+ARG USERNAME=cirrus
 ARG USER_UID=1000
 ARG USER_GID=$USER_UID
 


### PR DESCRIPTION
Because

- Fxa can run the cirrus image in a container in the GCP v2 environment as a non-root user only due to security policies.

This commit

- Support cirrus images to run as non-root users too.

Fixes #10459