### PR TITLE
feat(nimbus): make side navbars sticky

### DIFF
--- a/experimenter/experimenter/nimbus-ui/src/components/AppLayoutSidebarLaunched/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/AppLayoutSidebarLaunched/index.tsx
@@ -175,7 +175,10 @@ export const AppLayoutSidebarLaunched = ({
           xl="2"
           className="bg-light pt-2 border-right shadow-sm"
         >
-          <nav data-testid="nav-sidebar" className="navbar">
+          <nav
+            data-testid="nav-sidebar"
+            className="navbar sticky-top overflow-auto vh-100 align-items-start"
+          >
             <Nav
               className="flex-column font-weight-semibold mx-2 w-100"
               as="ul"

--- a/experimenter/experimenter/nimbus-ui/src/components/AppLayoutWithSidebar/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/AppLayoutWithSidebar/index.tsx
@@ -80,7 +80,10 @@ export const AppLayoutWithSidebar = ({
           xl="2"
           className="bg-light pt-2 border-right shadow-sm"
         >
-          <nav data-testid="nav-sidebar" className="navbar">
+          <nav
+            data-testid="nav-sidebar"
+            className="navbar sticky-top overflow-auto vh-100 align-items-start"
+          >
             <Nav className="flex-column font-weight-semibold w-100" as="ul">
               <LinkNav
                 className="mb-3 small font-weight-bold"

--- a/experimenter/experimenter/nimbus-ui/src/components/PageHome/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageHome/index.tsx
@@ -181,61 +181,63 @@ const PageHome: React.FunctionComponent<PageHomeProps> = () => {
             xl="2"
             className="bg-light pt-2 border-right shadow-sm"
           >
-            <Row>
-              <Col>
-                <Link
-                  to="new"
-                  data-sb-kind="pages/New"
-                  className="btn btn-primary btn-small mt-2 w-100"
-                  id="create-new-button"
-                >
-                  <CreateNewIcon
-                    width="20"
-                    height="20"
-                    fill="white"
-                    dominantBaseline="start"
-                    role="img"
-                    aria-label="download icon"
+            <div className="sticky-top overflow-auto vh-100 align-items-start">
+              <Row>
+                <Col>
+                  <Link
+                    to="new"
+                    data-sb-kind="pages/New"
+                    className="btn btn-primary btn-small mt-2 w-100"
+                    id="create-new-button"
+                  >
+                    <CreateNewIcon
+                      width="20"
+                      height="20"
+                      fill="white"
+                      dominantBaseline="start"
+                      role="img"
+                      aria-label="download icon"
+                    />
+                    <span className="ml-1 pl-1">Create New </span>
+                  </Link>
+                </Col>
+              </Row>
+              <Row>
+                <Col>
+                  <a
+                    href={`/api/v5/csv`}
+                    className="btn btn-secondary btn-small mt-3 w-100"
+                    data-testid="reports-anchor"
+                  >
+                    <DownloadIcon
+                      width="20"
+                      height="20"
+                      fill="white"
+                      dominantBaseline="start"
+                      role="img"
+                      aria-label="download icon"
+                    />
+                    <span> Reports</span>
+                  </a>
+                </Col>
+              </Row>
+              <Row>
+                <Col>
+                  <h5 className="mt-3">{"Filters"}</h5>
+                  <SearchBar
+                    experiments={data?.experiments ?? []}
+                    onChange={setSearchedData}
                   />
-                  <span className="ml-1 pl-1">Create New </span>
-                </Link>
-              </Col>
-            </Row>
-            <Row>
-              <Col>
-                <a
-                  href={`/api/v5/csv`}
-                  className="btn btn-secondary btn-small mt-3 w-100"
-                  data-testid="reports-anchor"
-                >
-                  <DownloadIcon
-                    width="20"
-                    height="20"
-                    fill="white"
-                    dominantBaseline="start"
-                    role="img"
-                    aria-label="download icon"
+                  <FilterBar
+                    {...{
+                      options: filterOptions,
+                      value: filterValue,
+                      onChange: onFilterChange,
+                    }}
                   />
-                  <span> Reports</span>
-                </a>
-              </Col>
-            </Row>
-            <Row>
-              <Col>
-                <h5 className="mt-3">{"Filters"}</h5>
-                <SearchBar
-                  experiments={data?.experiments ?? []}
-                  onChange={setSearchedData}
-                />
-                <FilterBar
-                  {...{
-                    options: filterOptions,
-                    value: filterValue,
-                    onChange: onFilterChange,
-                  }}
-                />
-              </Col>
-            </Row>
+                </Col>
+              </Row>
+            </div>
           </Col>
           <Col md="9" lg="9" xl="10">
             <Body


### PR DESCRIPTION
Because

- some pages are long enough that scrolling down page moves the nav bar out of view
- having navigation controls in view is nice

This commit

- makes the nav bar sticky to the top of the page so it comes with you when you scroll
- makes the nav bar contents scrollable in case the window isn't large enough to show all the content on one screen

Fixes #8016