### PR TITLE
chore(nimbus): Pull fenix manifests from mozilla-central for 126 nightly

### DIFF
--- a/experimenter/experimenter/features/manifests/apps.yaml
+++ b/experimenter/experimenter/features/manifests/apps.yaml
@@ -6,6 +6,30 @@ fenix:
   slug: "fenix"
   repo:
     type: "github"
+    name: "mozilla/gecko-dev"
+    default_branch: "master"
+  fml_path: "mobile/android/fenix/app/nimbus.fml.yaml"
+  release_discovery:
+    version_file:
+      type: "plaintext"
+      path: "browser/config/version.txt"
+    strategies:
+      - type: "branched"
+        branches:
+          # Fenix has only just merged into mozilla-central. Once 126 merges to
+          # beta (and then release), those branches should be added here.
+          #
+          # See #10514 (beta) and #10515 (release) issues.
+          - "master"
+
+# Fenix is still doing dot releases from its GitHub repository for 124.* and
+# 125.*.
+#
+# This should be removed once 126 ships to release (#10515).
+fenix_legacy:
+  slug: "fenix"
+  repo:
+    type: "github"
     name: "mozilla-mobile/firefox-android"
   fml_path: "fenix/app/nimbus.fml.yaml"
   release_discovery:

--- a/experimenter/manifesttool/tests/test_version.py
+++ b/experimenter/manifesttool/tests/test_version.py
@@ -111,7 +111,7 @@ class VersionTests(TestCase):
     @parameterized.expand(
         [
             (
-                "fenix",
+                "fenix_legacy",
                 [
                     "main",
                     "releases_v109",
@@ -193,7 +193,7 @@ class VersionTests(TestCase):
     @parameterized.expand(
         [
             (
-                "fenix",
+                "fenix_legacy",
                 [
                     "components-v118.0",
                     "components-v118.2",


### PR DESCRIPTION
Because:

- Fenix is now in mozilla-central for Firefox 126+

This commit:

- Adds an apps.yaml entry to sync Fenix from the git mirror of mozilla-central.

Fixes #10513.