### PR TITLE
feat(nimbus): group errors by version

### DIFF
--- a/experimenter/experimenter/experiments/constants.py
+++ b/experimenter/experimenter/experiments/constants.py
@@ -682,9 +682,11 @@ Optional - We believe this outcome will <describe impact> on <core metric>
         "Feature {feature_config} is not supported by any version in this range."
     )
 
-    ERROR_FEATURE_CONFIG_UNSUPPORTED_IN_VERSION = (
-        "Feature {feature_config} is not supported in version {version}."
+    ERROR_FEATURE_CONFIG_UNSUPPORTED_IN_VERSIONS = (
+        "In versions {versions}: Feature {feature_config} is not supported"
     )
+
+    ERROR_FEATURE_VALUE_IN_VERSIONS = "In versions {versions}: {error}"
 
     WARNING_ROLLOUT_PREF_REENROLL = (
         "WARNING: One or more features of this rollouts sets prefs and this rollout is "

--- a/experimenter/experimenter/nimbus-ui/src/hooks/useCommonForm/useCommonFormMethods.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/hooks/useCommonForm/useCommonFormMethods.tsx
@@ -104,14 +104,18 @@ export function useCommonFormMethods<FieldNames extends string>(
           // @ts-ignore This component doesn't technically support type="warning", but
           // all it's doing is using the string in a class, so we can safely override.
           <Form.Control.Feedback type="warning" data-for={fieldName}>
-            {fieldReviewMessages.join(", ")}
+            {fieldReviewMessages.map((m) => (
+              <p key={`${m}`}>{m}</p>
+            ))}
           </Form.Control.Feedback>
         )}
         {fieldReviewWarnings.length > 0 && (
           // @ts-ignore This component doesn't technically support type="warning", but
           // all it's doing is using the string in a class, so we can safely override.
           <Form.Control.Feedback type="warning" data-for={fieldName}>
-            {fieldReviewWarnings.join(", ")}
+            {fieldReviewWarnings.map((m) => (
+              <p key={`${m}`}>{m}</p>
+            ))}
           </Form.Control.Feedback>
         )}
         {errors[name] && (

--- a/experimenter/experimenter/nimbus-ui/src/lib/test-utils.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/lib/test-utils.tsx
@@ -138,9 +138,9 @@ export const Route = (
 ) => <div {...{ props }}>{props.component()}</div>;
 
 const assertFieldErrors = async (errors: string[], selector: string) => {
-  await screen.findByText(errors.join(", "), {
-    selector: `[data-for="${snakeToCamelCase(selector)}"]`,
-  });
+  for (const error of errors) {
+    await screen.findAllByText(error);
+  }
 };
 
 export const assertSerializerMessages = async (


### PR DESCRIPTION
Because

* We now validate feature errors across multiple feature schema versions
* This can produce duplicate errors across each version
* If we just serialize them naively it's very visually noisy

This commit

* Groups feature validation errors by version

fixes #9917
