### PR TITLE
feat(nimbus): results_ready should be based off of the computed enrollment

### DIFF
--- a/experimenter/experimenter/experiments/models.py
+++ b/experimenter/experimenter/experiments/models.py
@@ -905,17 +905,21 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
         return False
 
     # Results are available if enrollment is complete and
-    # more than a week has passed after that.
+    # more than a week (DAYS_UNTIL_ANALYSIS) has passed after that.
     @property
     def results_ready_date(self):
-        if self.proposed_enrollment_end_date:
-            return self.proposed_enrollment_end_date + datetime.timedelta(
+        if self.actual_enrollment_end_date:
+            return self.actual_enrollment_end_date + datetime.timedelta(
+                days=NimbusConstants.DAYS_UNTIL_ANALYSIS
+            )
+        if self.computed_enrollment_end_date:
+            return self.computed_enrollment_end_date + datetime.timedelta(
                 days=NimbusConstants.DAYS_UNTIL_ANALYSIS
             )
 
     @property
     def results_ready(self):
-        if self.proposed_enrollment_end_date:
+        if self.results_ready_date:
             results_ready_date = self.results_ready_date
             return datetime.date.today() >= results_ready_date
 


### PR DESCRIPTION
Because

- enrollment can end before proposed enrollment duration is over
- results link is not available until `results_ready_date` + 8 days
- `results_ready_date` is (was) based off of the proposed enrollment
- proposed enrollment does not change to reflect actual enrollment

This commit

- updates the `results_ready_date` to use the actual (if available) or computed enrollment

Fixes #10559