### PR TITLE
feat(nimbus): Add first run iOS iPhone only target

### DIFF
--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -442,6 +442,7 @@ MOBILE_NEW_USER = NimbusTargetingConfig(
         Application.KLAR_IOS.name,
     ),
 )
+
 MOBILE_FIRST_RUN_USER = NimbusTargetingConfig(
     name="First run Users on Mobile",
     slug="mobile_first_run",
@@ -1772,6 +1773,17 @@ IOS_IPHONE_USERS_ONLY = NimbusTargetingConfig(
     desktop_telemetry="",
     sticky_required=False,
     is_first_run_required=False,
+    application_choice_names=(Application.IOS.name,),
+)
+
+IOS_IPHONE_FIRST_RUN_USER = NimbusTargetingConfig(
+    name="First run Users on iPhone",
+    slug="ios_iphone_first_run_user",
+    description="First-run users on Firefox for iOS on iPhones",
+    targeting="isFirstRun == 'true' && is_phone",
+    desktop_telemetry="",
+    sticky_required=False,
+    is_first_run_required=True,
     application_choice_names=(Application.IOS.name,),
 )
 


### PR DESCRIPTION
Because

- We need to be able to target first run iPhone users only...

This commit

- Adds a target to give the ability to do so... I think.

Fixes [FXIOS-8918](https://github.com/mozilla-mobile/firefox-ios/issues/19706)