### PR TITLE
feat(nimbus): use reference branch name in comparison results viz

### DIFF
--- a/experimenter/experimenter/nimbus-ui/src/components/PageResults/ConfidenceInterval/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageResults/ConfidenceInterval/index.tsx
@@ -65,7 +65,8 @@ const ConfidenceInterval: React.FC<{
   lower: number;
   range: number;
   significance: string;
-}> = ({ upper, lower, range, significance }) => {
+  referenceBranch: string;
+}> = ({ upper, lower, range, significance, referenceBranch }) => {
   const fullWidth = range * 2;
   const barWidth = ((upper - lower) / fullWidth) * 100;
   const leftPercent = (Math.abs(lower - range * -1) / fullWidth) * 100;
@@ -92,7 +93,7 @@ const ConfidenceInterval: React.FC<{
 
       <div className="row w-100 float-right position-relative mt-2">{line}</div>
       <div className="row w-100 float-right h6">
-        <div className="col d-flex justify-content-center mt-3">control</div>
+        <div className="col d-flex justify-content-center mt-3">{referenceBranch}</div>
       </div>
     </div>
   );

--- a/experimenter/experimenter/nimbus-ui/src/components/PageResults/ConfidenceInterval/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageResults/ConfidenceInterval/index.tsx
@@ -93,7 +93,9 @@ const ConfidenceInterval: React.FC<{
 
       <div className="row w-100 float-right position-relative mt-2">{line}</div>
       <div className="row w-100 float-right h6">
-        <div className="col d-flex justify-content-center mt-3">{referenceBranch}</div>
+        <div className="col d-flex justify-content-center mt-3">
+          {referenceBranch}
+        </div>
       </div>
     </div>
   );

--- a/experimenter/experimenter/nimbus-ui/src/components/PageResults/TableVisualizationRow/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageResults/TableVisualizationRow/index.tsx
@@ -109,12 +109,13 @@ const conversionChangeField = (
   upper: number,
   range: number,
   significance: string | undefined,
+  referenceBranch: string,
 ) => {
   lower = Math.round(lower * 1000) / 10;
   upper = Math.round(upper * 1000) / 10;
   range = Math.round(range * 1000) / 10;
   significance = significance || SIGNIFICANCE.NEUTRAL;
-  return <ConfidenceInterval {...{ upper, lower, range, significance }} />;
+  return <ConfidenceInterval {...{ upper, lower, range, significance, referenceBranch }} />;
 };
 
 const populationField = (point: number, percent: number | undefined) => {
@@ -285,7 +286,7 @@ const TableVisualizationRow: React.FC<{
             field = conversionCountField(count!, userCountMetric!);
             break;
           case DISPLAY_TYPE.CONVERSION_CHANGE:
-            field = conversionChangeField(lower!, upper!, bounds, significance);
+            field = conversionChangeField(lower!, upper!, bounds, significance, referenceBranch);
             break;
         }
         fieldList.push({ field, tooltipText, className });

--- a/experimenter/experimenter/nimbus-ui/src/components/PageResults/TableVisualizationRow/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageResults/TableVisualizationRow/index.tsx
@@ -115,7 +115,11 @@ const conversionChangeField = (
   upper = Math.round(upper * 1000) / 10;
   range = Math.round(range * 1000) / 10;
   significance = significance || SIGNIFICANCE.NEUTRAL;
-  return <ConfidenceInterval {...{ upper, lower, range, significance, referenceBranch }} />;
+  return (
+    <ConfidenceInterval
+      {...{ upper, lower, range, significance, referenceBranch }}
+    />
+  );
 };
 
 const populationField = (point: number, percent: number | undefined) => {
@@ -286,7 +290,13 @@ const TableVisualizationRow: React.FC<{
             field = conversionCountField(count!, userCountMetric!);
             break;
           case DISPLAY_TYPE.CONVERSION_CHANGE:
-            field = conversionChangeField(lower!, upper!, bounds, significance, referenceBranch);
+            field = conversionChangeField(
+              lower!,
+              upper!,
+              bounds,
+              significance,
+              referenceBranch,
+            );
             break;
         }
         fieldList.push({ field, tooltipText, className });


### PR DESCRIPTION
Because

- we now allow the selection of any branch as the reference
- it could be confusing to use the word "control" instead of the reference branch name as a point of comparison in visualizations

This commit

- updates the ConfidenceInterval component to use the actual reference branch name instead of static text "control"

Fixes #10583