### PR TITLE
chore(cirrus): Assign permission to cirrus user

### DIFF
--- a/cirrus/server/Dockerfile
+++ b/cirrus/server/Dockerfile
@@ -57,6 +57,9 @@ COPY . .
 # Change ownership of the working directory to the non-root user
 RUN chown -R $USERNAME:$USERNAME /cirrus
 
+# Change ownership of the data directory
+RUN mkdir -p /var/glean && chown -R $USERNAME:$USERNAME /var/glean
+
 # Switch to non-root user
 USER $USERNAME
 


### PR DESCRIPTION
Because

- We recently added support for non root user for the cirrus docker image, but non root user is having difficulty to work with glean data directories

This commit

- Give appropriate permission to the user

Fixes #10594 