### PR TITLE
feat(nimbus): add capability to run integration tests outside of docker container

### DIFF
--- a/README.md
+++ b/README.md
@@ -478,7 +478,7 @@ To use NoVNC, navgate to this url `http://localhost:7902` with the password `sec
 ```sh
 alias firefox="path-to/firefox"
 ```
-Example for macos: 
+Example for macos add this to your `~/.zshrc` file: 
 ```sh
 alias firefox="/Applications/Firefox.app/Contents/MacOS/firefox"
 ```

--- a/README.md
+++ b/README.md
@@ -473,15 +473,25 @@ To use NoVNC, navgate to this url `http://localhost:7902` with the password `sec
 
 ### Running Integration tests locally
 
-1. Install [geckodriver](https://github.com/mozilla/geckodriver/releases) and have it available in your path. You should be able to run `geckodriver --version` from your command line.
-2. Add your Firefox install to your path. You should be able to run `firefox --version` from your command line.
+1. Install [geckodriver](https://github.com/mozilla/geckodriver/releases) and have it available in your path. You should be able to run `geckodriver --version` from your command line. On MacOS you can do `brew install geckodriver` if you have homebrew installed.
+2. Add your Firefox install to your path. You should be able to run `firefox --version` from your command line. 
+```sh
+alias firefox="path-to/firefox"
+```
+Example for macos: 
+```sh
+alias firefox="/Applications/Firefox.app/Contents/MacOS/firefox"
+```
 3. Setup experimenter:
 ```sh
-make refresh build_integration_test SKIP_DUMMY=1 up_prod_detatched
+make refresh build_integration_test SKIP_DUMMY=1 up_prod_detached
 ```
 Navigate with your browser to `https://localhost/nimbus` to confirm everything is working.
-
-4. Run the Integration Tests using tox:
+4. Install tox:
+```sh
+pip install tox
+```
+5. Run the Integration Tests using tox:
 ```sh
 tox -c experimenter/tests/integration -e integration-test-nimbus-local
 ```

--- a/README.md
+++ b/README.md
@@ -471,6 +471,31 @@ This should run the integration tests and watch them run in a Firefox instance y
 
 To use NoVNC, navgate to this url `http://localhost:7902` with the password `secret`. Then you can follow the same steps as above.
 
+### Running Integration tests locally
+
+1. Install [geckodriver](https://github.com/mozilla/geckodriver/releases) and have it available in your path. You should be able to run `geckodriver --version` from your command line.
+2. Add your Firefox install to your path. You should be able to run `firefox --version` from your command line.
+3. Setup experimenter:
+```sh
+make refresh build_integration_test SKIP_DUMMY=1 up_prod_detatched
+```
+Navigate with your browser to `https://localhost/nimbus` to confirm everything is working.
+
+4. Run the Integration Tests using tox:
+```sh
+tox -c experimenter/tests/integration -e integration-test-nimbus-local
+```
+
+* To run a specific test:
+```sh
+tox -c experimenter/tests/integration -e integration-test-nimbus-local -- -k "test_name_here[WITH_CLIENT]
+```
+Firefox should pop up and start running through your test! You can change the firefox version the tests run on by copying the path of the `firefox-bin` and adding it to the `firefox_options` fixture in the `tests/integration/nimbus/conftest.py` file:
+
+```sh
+firefox_options.binary = "path/to/firefox-bin"
+```
+
 #### Integration Test options
 
 - `TOX_ARGS`: [Tox](https://tox.readthedocs.io/en/latest/config.html#tox) commandline variables.

--- a/docker-compose-integration-test.yml
+++ b/docker-compose-integration-test.yml
@@ -26,6 +26,8 @@ services:
   rust-sdk:
     image: experimenter:integration-tests
     env_file: .env
+    environment:
+      - DEBIAN_FRONTEND=0
     volumes:
       - .:/code
       - /code/experimenter/tests/integration/.tox

--- a/docker-compose-integration-test.yml
+++ b/docker-compose-integration-test.yml
@@ -8,6 +8,8 @@ services:
       - MOZ_HEADLESS
       - FIREFOX_VERSION
       - PYTEST_ARGS
+      - INTEGRATION_TEST_KINTO_URL
+      - INTEGRATION_TEST_NGINX_URL
     volumes:
       - .:/code
       - /code/experimenter/tests/integration/.tox
@@ -26,8 +28,6 @@ services:
   rust-sdk:
     image: experimenter:integration-tests
     env_file: .env
-    environment:
-      - DEBIAN_FRONTEND=0
     volumes:
       - .:/code
       - /code/experimenter/tests/integration/.tox

--- a/experimenter/tests/integration/nimbus/conftest.py
+++ b/experimenter/tests/integration/nimbus/conftest.py
@@ -137,9 +137,7 @@ def _verify_url(request, base_url):
 
 @pytest.fixture
 def kinto_client(default_data):
-    kinto_url = "http://kinto:8888/v1"
-    if not os.environ.get("DEBIAN_FRONTEND"):
-        kinto_url = "http://localhost:8888/v1"
+    kinto_url = os.getenv("INTEGRATION_TEST_KINTO_URL", "http://kinto:8888/v1")
     return KintoClient(
         APPLICATION_KINTO_COLLECTION[default_data.application], server_url=kinto_url
     )
@@ -147,7 +145,7 @@ def kinto_client(default_data):
 
 @pytest.fixture(name="ping_server")
 def fixture_ping_server():
-    if not os.environ.get("DEBIAN_FRONTEND"):
+    if os.environ.get("NIMBUS_LOCAL_DEV"):
         return "http://localhost:5000"
     return "http://ping-server:5000"
 

--- a/experimenter/tests/integration/nimbus/conftest.py
+++ b/experimenter/tests/integration/nimbus/conftest.py
@@ -1,6 +1,7 @@
 import os
 import time
 import uuid
+from pathlib import Path
 from urllib.parse import urljoin
 
 import pytest
@@ -136,7 +137,19 @@ def _verify_url(request, base_url):
 
 @pytest.fixture
 def kinto_client(default_data):
-    return KintoClient(APPLICATION_KINTO_COLLECTION[default_data.application])
+    kinto_url = "http://kinto:8888/v1"
+    if not os.environ.get("DEBIAN_FRONTEND"):
+        kinto_url = "http://localhost:8888/v1"
+    return KintoClient(
+        APPLICATION_KINTO_COLLECTION[default_data.application], server_url=kinto_url
+    )
+
+
+@pytest.fixture(name="ping_server")
+def fixture_ping_server():
+    if not os.environ.get("DEBIAN_FRONTEND"):
+        return "http://localhost:5000"
+    return "http://ping-server:5000"
 
 
 @pytest.fixture
@@ -168,8 +181,9 @@ def experiment_url(base_url, experiment_slug):
 def fixture_load_experiment_outcomes():
     """Fixture to create a list of outcomes based on the current configs."""
     outcomes = {"firefox_desktop": "", "fenix": "", "firefox_ios": ""}
-    base_path = (
-        "/code/experimenter/experimenter/outcomes/metric-hub-main/jetstream/outcomes"
+    current_path = Path.cwd()
+    base_path = Path(
+        f"{current_path.parent.parent}/experimenter/outcomes/metric-hub-main/jetstream/outcomes"
     )
 
     for k in list(outcomes):
@@ -378,12 +392,12 @@ def default_data_api(application):
 
 
 @pytest.fixture(name="check_ping_for_experiment")
-def fixture_check_ping_for_experiment(trigger_experiment_loader):
+def fixture_check_ping_for_experiment(trigger_experiment_loader, ping_server):
     def _check_ping_for_experiment(experiment=None):
         control = True
         timeout = time.time() + 60 * 5
         while control and time.time() < timeout:
-            data = requests.get("http://ping-server:5000/pings").json()
+            data = requests.get(f"{ping_server}/pings").json()
             experiments_data = [
                 item["environment"]["experiments"]
                 for item in data
@@ -400,9 +414,9 @@ def fixture_check_ping_for_experiment(trigger_experiment_loader):
 
 
 @pytest.fixture(name="telemetry_event_check")
-def fixture_telemetry_event_check(trigger_experiment_loader):
+def fixture_telemetry_event_check(trigger_experiment_loader, ping_server):
     def _telemetry_event_check(experiment=None, event=None):
-        telemetry = requests.get("http://ping-server:5000/pings").json()
+        telemetry = requests.get(f"{ping_server}/pings").json()
         events = [
             event["payload"]["events"]["parent"]
             for event in telemetry

--- a/experimenter/tests/integration/nimbus/kinto/client.py
+++ b/experimenter/tests/integration/nimbus/kinto/client.py
@@ -17,10 +17,10 @@ KINTO_SIGN_STATUS = "to-sign"
 class KintoClient:
     RETRIES = 60
 
-    def __init__(self, collection):
+    def __init__(self, collection, server_url):
         self.collection = collection
         self.kinto_http_client = kinto_http.Client(
-            server_url=KINTO_HOST,
+            server_url=server_url,
             auth=(KINTO_USER, KINTO_PASS),
         )
 

--- a/experimenter/tests/integration/nimbus/test-reports/report.htm
+++ b/experimenter/tests/integration/nimbus/test-reports/report.htm
@@ -1,0 +1,478 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8"/>
+    <title>report.htm</title>
+    <style>body {
+  font-family: Helvetica, Arial, sans-serif;
+  font-size: 12px;
+  /* do not increase min-width as some may use split screens */
+  min-width: 800px;
+  color: #999;
+}
+
+h1 {
+  font-size: 24px;
+  color: black;
+}
+
+h2 {
+  font-size: 16px;
+  color: black;
+}
+
+p {
+  color: black;
+}
+
+a {
+  color: #999;
+}
+
+table {
+  border-collapse: collapse;
+}
+
+/******************************
+ * SUMMARY INFORMATION
+ ******************************/
+#environment td {
+  padding: 5px;
+  border: 1px solid #E6E6E6;
+}
+#environment tr:nth-child(odd) {
+  background-color: #f6f6f6;
+}
+
+/******************************
+ * TEST RESULT COLORS
+ ******************************/
+span.passed,
+.passed .col-result {
+  color: green;
+}
+
+span.skipped,
+span.xfailed,
+span.rerun,
+.skipped .col-result,
+.xfailed .col-result,
+.rerun .col-result {
+  color: orange;
+}
+
+span.error,
+span.failed,
+span.xpassed,
+.error .col-result,
+.failed .col-result,
+.xpassed .col-result {
+  color: red;
+}
+
+/******************************
+ * RESULTS TABLE
+ *
+ * 1. Table Layout
+ * 2. Extra
+ * 3. Sorting items
+ *
+ ******************************/
+/*------------------
+ * 1. Table Layout
+ *------------------*/
+#results-table {
+  border: 1px solid #e6e6e6;
+  color: #999;
+  font-size: 12px;
+  width: 100%;
+}
+#results-table th,
+#results-table td {
+  padding: 5px;
+  border: 1px solid #E6E6E6;
+  text-align: left;
+}
+#results-table th {
+  font-weight: bold;
+}
+
+/*------------------
+ * 2. Extra
+ *------------------*/
+.log {
+  background-color: #e6e6e6;
+  border: 1px solid #e6e6e6;
+  color: black;
+  display: block;
+  font-family: "Courier New", Courier, monospace;
+  height: 230px;
+  overflow-y: scroll;
+  padding: 5px;
+  white-space: pre-wrap;
+}
+.log:only-child {
+  height: inherit;
+}
+
+div.image {
+  border: 1px solid #e6e6e6;
+  float: right;
+  height: 240px;
+  margin-left: 5px;
+  overflow: hidden;
+  width: 320px;
+}
+div.image img {
+  width: 320px;
+}
+
+div.video {
+  border: 1px solid #e6e6e6;
+  float: right;
+  height: 240px;
+  margin-left: 5px;
+  overflow: hidden;
+  width: 320px;
+}
+div.video video {
+  overflow: hidden;
+  width: 320px;
+  height: 240px;
+}
+
+.collapsed {
+  display: none;
+}
+
+.expander::after {
+  content: " (show details)";
+  color: #BBB;
+  font-style: italic;
+  cursor: pointer;
+}
+
+.collapser::after {
+  content: " (hide details)";
+  color: #BBB;
+  font-style: italic;
+  cursor: pointer;
+}
+
+/*------------------
+ * 3. Sorting items
+ *------------------*/
+.sortable {
+  cursor: pointer;
+}
+
+.sort-icon {
+  font-size: 0px;
+  float: left;
+  margin-right: 5px;
+  margin-top: 5px;
+  /*triangle*/
+  width: 0;
+  height: 0;
+  border-left: 8px solid transparent;
+  border-right: 8px solid transparent;
+}
+.inactive .sort-icon {
+  /*finish triangle*/
+  border-top: 8px solid #E6E6E6;
+}
+.asc.active .sort-icon {
+  /*finish triangle*/
+  border-bottom: 8px solid #999;
+}
+.desc.active .sort-icon {
+  /*finish triangle*/
+  border-top: 8px solid #999;
+}
+</style></head>
+  <body onLoad="init()">
+    <script>/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+
+function toArray(iter) {
+    if (iter === null) {
+        return null;
+    }
+    return Array.prototype.slice.call(iter);
+}
+
+function find(selector, elem) { // eslint-disable-line no-redeclare
+    if (!elem) {
+        elem = document;
+    }
+    return elem.querySelector(selector);
+}
+
+function findAll(selector, elem) {
+    if (!elem) {
+        elem = document;
+    }
+    return toArray(elem.querySelectorAll(selector));
+}
+
+function sortColumn(elem) {
+    toggleSortStates(elem);
+    const colIndex = toArray(elem.parentNode.childNodes).indexOf(elem);
+    let key;
+    if (elem.classList.contains('result')) {
+        key = keyResult;
+    } else if (elem.classList.contains('links')) {
+        key = keyLink;
+    } else {
+        key = keyAlpha;
+    }
+    sortTable(elem, key(colIndex));
+}
+
+function showAllExtras() { // eslint-disable-line no-unused-vars
+    findAll('.col-result').forEach(showExtras);
+}
+
+function hideAllExtras() { // eslint-disable-line no-unused-vars
+    findAll('.col-result').forEach(hideExtras);
+}
+
+function showExtras(colresultElem) {
+    const extras = colresultElem.parentNode.nextElementSibling;
+    const expandcollapse = colresultElem.firstElementChild;
+    extras.classList.remove('collapsed');
+    expandcollapse.classList.remove('expander');
+    expandcollapse.classList.add('collapser');
+}
+
+function hideExtras(colresultElem) {
+    const extras = colresultElem.parentNode.nextElementSibling;
+    const expandcollapse = colresultElem.firstElementChild;
+    extras.classList.add('collapsed');
+    expandcollapse.classList.remove('collapser');
+    expandcollapse.classList.add('expander');
+}
+
+function showFilters() {
+    let visibleString = getQueryParameter('visible') || 'all';
+    visibleString = visibleString.toLowerCase();
+    const checkedItems = visibleString.split(',');
+
+    const filterItems = document.getElementsByClassName('filter');
+    for (let i = 0; i < filterItems.length; i++) {
+        filterItems[i].hidden = false;
+
+        if (visibleString != 'all') {
+            filterItems[i].checked = checkedItems.includes(filterItems[i].getAttribute('data-test-result'));
+            filterTable(filterItems[i]);
+        }
+    }
+}
+
+function addCollapse() {
+    // Add links for show/hide all
+    const resulttable = find('table#results-table');
+    const showhideall = document.createElement('p');
+    showhideall.innerHTML = '<a href="javascript:showAllExtras()">Show all details</a> / ' +
+                            '<a href="javascript:hideAllExtras()">Hide all details</a>';
+    resulttable.parentElement.insertBefore(showhideall, resulttable);
+
+    // Add show/hide link to each result
+    findAll('.col-result').forEach(function(elem) {
+        const collapsed = getQueryParameter('collapsed') || 'Passed';
+        const extras = elem.parentNode.nextElementSibling;
+        const expandcollapse = document.createElement('span');
+        if (extras.classList.contains('collapsed')) {
+            expandcollapse.classList.add('expander');
+        } else if (collapsed.includes(elem.innerHTML)) {
+            extras.classList.add('collapsed');
+            expandcollapse.classList.add('expander');
+        } else {
+            expandcollapse.classList.add('collapser');
+        }
+        elem.appendChild(expandcollapse);
+
+        elem.addEventListener('click', function(event) {
+            if (event.currentTarget.parentNode.nextElementSibling.classList.contains('collapsed')) {
+                showExtras(event.currentTarget);
+            } else {
+                hideExtras(event.currentTarget);
+            }
+        });
+    });
+}
+
+function getQueryParameter(name) {
+    const match = RegExp('[?&]' + name + '=([^&]*)').exec(window.location.search);
+    return match && decodeURIComponent(match[1].replace(/\+/g, ' '));
+}
+
+function init () { // eslint-disable-line no-unused-vars
+    resetSortHeaders();
+
+    addCollapse();
+
+    showFilters();
+
+    sortColumn(find('.initial-sort'));
+
+    findAll('.sortable').forEach(function(elem) {
+        elem.addEventListener('click',
+            function() {
+                sortColumn(elem);
+            }, false);
+    });
+}
+
+function sortTable(clicked, keyFunc) {
+    const rows = findAll('.results-table-row');
+    const reversed = !clicked.classList.contains('asc');
+    const sortedRows = sort(rows, keyFunc, reversed);
+    /* Whole table is removed here because browsers acts much slower
+     * when appending existing elements.
+     */
+    const thead = document.getElementById('results-table-head');
+    document.getElementById('results-table').remove();
+    const parent = document.createElement('table');
+    parent.id = 'results-table';
+    parent.appendChild(thead);
+    sortedRows.forEach(function(elem) {
+        parent.appendChild(elem);
+    });
+    document.getElementsByTagName('BODY')[0].appendChild(parent);
+}
+
+function sort(items, keyFunc, reversed) {
+    const sortArray = items.map(function(item, i) {
+        return [keyFunc(item), i];
+    });
+
+    sortArray.sort(function(a, b) {
+        const keyA = a[0];
+        const keyB = b[0];
+
+        if (keyA == keyB) return 0;
+
+        if (reversed) {
+            return keyA < keyB ? 1 : -1;
+        } else {
+            return keyA > keyB ? 1 : -1;
+        }
+    });
+
+    return sortArray.map(function(item) {
+        const index = item[1];
+        return items[index];
+    });
+}
+
+function keyAlpha(colIndex) {
+    return function(elem) {
+        return elem.childNodes[1].childNodes[colIndex].firstChild.data.toLowerCase();
+    };
+}
+
+function keyLink(colIndex) {
+    return function(elem) {
+        const dataCell = elem.childNodes[1].childNodes[colIndex].firstChild;
+        return dataCell == null ? '' : dataCell.innerText.toLowerCase();
+    };
+}
+
+function keyResult(colIndex) {
+    return function(elem) {
+        const strings = ['Error', 'Failed', 'Rerun', 'XFailed', 'XPassed',
+            'Skipped', 'Passed'];
+        return strings.indexOf(elem.childNodes[1].childNodes[colIndex].firstChild.data);
+    };
+}
+
+function resetSortHeaders() {
+    findAll('.sort-icon').forEach(function(elem) {
+        elem.parentNode.removeChild(elem);
+    });
+    findAll('.sortable').forEach(function(elem) {
+        const icon = document.createElement('div');
+        icon.className = 'sort-icon';
+        icon.textContent = 'vvv';
+        elem.insertBefore(icon, elem.firstChild);
+        elem.classList.remove('desc', 'active');
+        elem.classList.add('asc', 'inactive');
+    });
+}
+
+function toggleSortStates(elem) {
+    //if active, toggle between asc and desc
+    if (elem.classList.contains('active')) {
+        elem.classList.toggle('asc');
+        elem.classList.toggle('desc');
+    }
+
+    //if inactive, reset all other functions and add ascending active
+    if (elem.classList.contains('inactive')) {
+        resetSortHeaders();
+        elem.classList.remove('inactive');
+        elem.classList.add('active');
+    }
+}
+
+function isAllRowsHidden(value) {
+    return value.hidden == false;
+}
+
+function filterTable(elem) { // eslint-disable-line no-unused-vars
+    const outcomeAtt = 'data-test-result';
+    const outcome = elem.getAttribute(outcomeAtt);
+    const classOutcome = outcome + ' results-table-row';
+    const outcomeRows = document.getElementsByClassName(classOutcome);
+
+    for(let i = 0; i < outcomeRows.length; i++){
+        outcomeRows[i].hidden = !elem.checked;
+    }
+
+    const rows = findAll('.results-table-row').filter(isAllRowsHidden);
+    const allRowsHidden = rows.length == 0 ? true : false;
+    const notFoundMessage = document.getElementById('not-found-message');
+    notFoundMessage.hidden = !allRowsHidden;
+}
+</script>
+    <h1>report.htm</h1>
+    <p>Report generated on 17-Apr-2024 at 14:16:13 by <a href="https://pypi.python.org/pypi/pytest-html">pytest-html</a> v3.2.0</p>
+    <h2>Environment</h2>
+    <table id="environment">
+      <tr>
+        <td>Base URL</td>
+        <td><a href="https://localhost/nimbus/" target="_blank">https://localhost/nimbus/</a></td></tr>
+      <tr>
+        <td>Capabilities</td>
+        <td>{}</td></tr>
+      <tr>
+        <td>Driver</td>
+        <td>Firefox</td></tr>
+      <tr>
+        <td>Packages</td>
+        <td>{"pluggy": "0.13.1", "py": "1.11.0", "pytest": "6.2.4"}</td></tr>
+      <tr>
+        <td>Platform</td>
+        <td>Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.35</td></tr>
+      <tr>
+        <td>Plugins</td>
+        <td>{"base-url": "1.4.2", "forked": "1.6.0", "html": "3.2.0", "lazy-fixture": "0.6.0", "metadata": "1.11.0", "pytest_sentry": "0.2.1", "repeat": "0.9.1", "rerunfailures": "10.3", "selenium": "2.0.1", "variables": "1.9.0", "xdist": "2.5.0"}</td></tr>
+      <tr>
+        <td>Python</td>
+        <td>3.11.3</td></tr></table>
+    <h2>Summary</h2>
+    <p>0 tests ran in 0.01 seconds. </p>
+    <p class="filter" hidden="true">(Un)check the boxes to filter the results.</p><input checked="true" class="filter" data-test-result="passed" disabled="true" hidden="true" name="filter_checkbox" onChange="filterTable(this)" type="checkbox"/><span class="passed">0 passed</span>, <input checked="true" class="filter" data-test-result="skipped" disabled="true" hidden="true" name="filter_checkbox" onChange="filterTable(this)" type="checkbox"/><span class="skipped">0 skipped</span>, <input checked="true" class="filter" data-test-result="failed" disabled="true" hidden="true" name="filter_checkbox" onChange="filterTable(this)" type="checkbox"/><span class="failed">0 failed</span>, <input checked="true" class="filter" data-test-result="error" disabled="true" hidden="true" name="filter_checkbox" onChange="filterTable(this)" type="checkbox"/><span class="error">0 errors</span>, <input checked="true" class="filter" data-test-result="xfailed" disabled="true" hidden="true" name="filter_checkbox" onChange="filterTable(this)" type="checkbox"/><span class="xfailed">0 expected failures</span>, <input checked="true" class="filter" data-test-result="xpassed" disabled="true" hidden="true" name="filter_checkbox" onChange="filterTable(this)" type="checkbox"/><span class="xpassed">0 unexpected passes</span>, <input checked="true" class="filter" data-test-result="rerun" disabled="true" hidden="true" name="filter_checkbox" onChange="filterTable(this)" type="checkbox"/><span class="rerun">0 rerun</span>
+    <h2>Results</h2>
+    <table id="results-table">
+      <thead id="results-table-head">
+        <tr>
+          <th class="sortable result initial-sort" col="result">Result</th>
+          <th class="sortable" col="name">Test</th>
+          <th class="sortable" col="duration">Duration</th>
+          <th class="sortable links" col="links">Links</th></tr>
+        <tr hidden="true" id="not-found-message">
+          <th colspan="4">No results found. Try to check the filters</th></tr></thead></table></body></html>

--- a/experimenter/tests/integration/nimbus/test_desktop_client_integrations.py
+++ b/experimenter/tests/integration/nimbus/test_desktop_client_integrations.py
@@ -10,11 +10,11 @@ from nimbus.utils import helpers
 
 
 @pytest.fixture
-def firefox_options(firefox_options):
+def firefox_options(firefox_options, ping_server):
     """Set Firefox Options."""
     firefox_options.log.level = "trace"
     firefox_options.set_preference("browser.cache.disk.smart_size.enabled", False)
-    firefox_options.set_preference("toolkit.telemetry.server", "http://ping-server:5000")
+    firefox_options.set_preference("toolkit.telemetry.server", f"{ping_server}")
     firefox_options.set_preference("telemetry.fog.test.localhost_port", -1)
     firefox_options.set_preference("toolkit.telemetry.initDelay", 1)
     firefox_options.set_preference("toolkit.telemetry.minSubsessionLength", 0)

--- a/experimenter/tests/integration/nimbus/utils/helpers.py
+++ b/experimenter/tests/integration/nimbus/utils/helpers.py
@@ -14,9 +14,7 @@ LOAD_DATA_RETRY_DELAY = 1.0
 
 
 def load_graphql_data(query):
-    nginx_url = "https://nginx"
-    if not os.environ.get("DEBIAN_FRONTEND"):
-        nginx_url = "https://localhost"
+    nginx_url = os.getenv("INTEGRATION_TEST_NGINX_URL", "https://nginx")
     for retry in range(LOAD_DATA_RETRIES):
         try:
             return requests.post(

--- a/experimenter/tests/integration/nimbus/utils/helpers.py
+++ b/experimenter/tests/integration/nimbus/utils/helpers.py
@@ -1,4 +1,5 @@
 import json
+import os
 import time
 from functools import lru_cache
 
@@ -13,10 +14,13 @@ LOAD_DATA_RETRY_DELAY = 1.0
 
 
 def load_graphql_data(query):
+    nginx_url = "https://nginx"
+    if not os.environ.get("DEBIAN_FRONTEND"):
+        nginx_url = "https://localhost"
     for retry in range(LOAD_DATA_RETRIES):
         try:
             return requests.post(
-                "https://nginx/api/v5/graphql",
+                f"{nginx_url}/api/v5/graphql",
                 json=query,
                 verify=False,
             ).json()

--- a/experimenter/tests/integration/tox.ini
+++ b/experimenter/tests/integration/tox.ini
@@ -15,6 +15,14 @@ commands =
     pip install -r ../requirements.txt
     pytest --verify-base-url --base-url https://nginx/nimbus/ --html=test-reports/report.htm --self-contained-html --reruns-delay 30 --driver Firefox nimbus/ {posargs} -vvv
 
+[testenv:integration-test-nimbus-local]
+passenv = *
+recreate = true
+commands =
+    pip install -r ../requirements.txt
+    pytest --verify-base-url --base-url https://localhost/nimbus/ --html=test-reports/report.htm --self-contained-html --reruns-delay 30 --driver Firefox nimbus/ {posargs} -vvv
+
+
 [testenv:integration-test-nimbus-rust]
 passenv = *
 recreate = true
@@ -24,6 +32,8 @@ commands =
 
 [pytest]
 addopts = -p no:warnings
+log_cli = true
+log_cli_level = info
 markers =
     use_variables: marks tests that need to use pytest-variables
     run_targeting: run jexl targeting tests in firefox


### PR DESCRIPTION
Because

- To run our firefox integration tests locally you must connect via VNC to the docker container that runs the tests. This can cause slowdown and recently on mac it has been a major bottleneck.

This commit

- Allows for a user to run the integration tests externally to the docker container. This will allow for less overhead when writing new tests or just running integration tests in general.

Fixes #10593 