### PR TITLE
feat(cirrus): Initialize sentry on startup

### DIFF
--- a/cirrus/server/cirrus/main.py
+++ b/cirrus/server/cirrus/main.py
@@ -39,8 +39,8 @@ class FeatureRequest(BaseModel):
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    app.state.pings, app.state.metrics = initialize_glean()
     initialize_sentry()
+    app.state.pings, app.state.metrics = initialize_glean()
     app.state.fml = create_fml()
     app.state.sdk = create_sdk(
         app.state.fml.get_coenrolling_feature_ids(),


### PR DESCRIPTION
Because

- Sentry was getting initializing after glean initialization, hence we were not getting glean error reports on sentry

This commit

- changes the sequence of sentry initialization

Fixes #10614 