### PR TITLE
Adds advanced targeting for new profiles mac only

### DIFF
--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -1938,10 +1938,7 @@ NEW_PROFILE_MAC_ONLY = NimbusTargetingConfig(
     slug="mac_only_new_profiles",
     description="New profiles with Mac OS",
     targeting=f"os.isMac && {NEW_PROFILE}",
-    desktop_telemetry=(
-        f"{NEW_PROFILE} "
-        "AND environment.system.os.name = 'Darwin'"
-    ),
+    desktop_telemetry=f"{NEW_PROFILE} AND environment.system.os.name = 'Darwin'",
     sticky_required=True,
     is_first_run_required=False,
     application_choice_names=(Application.DESKTOP.name,),

--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -1933,6 +1933,20 @@ VIEWPOINT_SURVEY_MOBILE = NimbusTargetingConfig(
     application_choice_names=(Application.IOS.name, Application.FENIX.name),
 )
 
+NEW_PROFILE_MAC_ONLY = NimbusTargetingConfig(
+    name="New profile Mac OS only",
+    slug="mac_only_new_profiles",
+    description="New profiles with Mac OS",
+    targeting=f"os.isMac && {NEW_PROFILE}",
+    desktop_telemetry=(
+        f"{NEW_PROFILE} "
+        "AND environment.system.os.name = 'Darwin'"
+    ),
+    sticky_required=True,
+    is_first_run_required=False,
+    application_choice_names=(Application.DESKTOP.name,),
+)
+
 
 class TargetingConstants:
     TARGETING_VERSION = "version|versionCompare('{version}') >= 0"


### PR DESCRIPTION
Because

- We'd like to run a [survey experiment](https://mozilla-hub.atlassian.net/browse/FXE-594) post onboarding for new profies on macOS only

This commit

- Adds advanced targeting for only mac new profile users

Fixes #10621