### PR TITLE
chore(nimbus): show all branches option for single branch experiments

### DIFF
--- a/experimenter/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/index.test.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/index.test.tsx
@@ -130,7 +130,7 @@ describe("FormAudience", () => {
       const excluded = screen.getByLabelText(/Exclude users enrolled/);
       await selectEvent.openMenu(excluded);
       let options = container.querySelectorAll(query("excludedExperiments"));
-      expect(options.length).toEqual(1);
+      expect(options.length).toEqual(2);
 
       expect(
         Array.from(options, (e) => e.textContent).find((text) =>
@@ -141,7 +141,7 @@ describe("FormAudience", () => {
       const required = screen.getByLabelText(/Require users to be enrolled/);
       await selectEvent.openMenu(required);
       options = container.querySelectorAll(query("requiredExperiments"));
-      expect(options.length).toEqual(1);
+      expect(options.length).toEqual(2);
 
       expect(
         Array.from(options, (e) => e.textContent).find((text) =>

--- a/experimenter/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/index.tsx
@@ -119,16 +119,12 @@ const toSelectExperimentBranchOption: (
 const toSelectExperimentBranchOptions: (
   experiment: getAllExperimentsByApplication_experimentsByApplication,
 ) => SelectExperimentBranchOption[] = (experiment) => {
-  let experimentBranchOptions;
-  if (experiment.treatmentBranches!.length === 0) {
-    experimentBranchOptions = [experiment.referenceBranch!.slug];
-  } else {
-    experimentBranchOptions = [
-      null,
-      experiment.referenceBranch!.slug,
-      ...experiment.treatmentBranches!.map((branch) => branch!.slug),
-    ];
-  }
+  const experimentBranchOptions = [
+    null,
+    experiment.referenceBranch!.slug,
+    ...experiment.treatmentBranches!.map((branch) => branch!.slug),
+  ];
+
   return experimentBranchOptions.map((branchSlug) =>
     toSelectExperimentBranchOption(experiment, branchSlug),
   );


### PR DESCRIPTION
Because

* We recently added the ability to require/exclude experiments by branch
* We added multiple entries to the require/exclude drop downs for either the "All Branches" option, or individual branches
* For experiments with a single branch, we filtered out the "All Branches" option since it's essentially a duplicate of the single branch option
* However some experiments may get into a state where they point to the "All Branches" option for a single branch experiment, but then show no selection in the drop down
* We can revisit this behaviour later when we finish HTMXing the UI, let's just find a simple solution for now

This commit

* Removes the filter that was previously added
* Always shows the "All Branches" option

fixes #10609
