### PR TITLE
refactor(nimbus): Format audience overlap as a list

### DIFF
--- a/experimenter/experimenter/nimbus-ui/src/components/PageSummary/index.test.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageSummary/index.test.tsx
@@ -1015,8 +1015,7 @@ describe("PageSummary Warnings", () => {
   });
 
   it("displays warnings for excluded live experiments audience overlap", async () => {
-    const warning =
-      AUDIENCE_OVERLAP_WARNINGS.EXCLUDING_EXPERIMENTS_WARNING("my-slimy-slug");
+    const warning = AUDIENCE_OVERLAP_WARNINGS.EXCLUDING_EXPERIMENTS_WARNING();
     const { mock } = mockExperimentQuery("demo-slug", {
       application: NimbusExperimentApplicationEnum.DESKTOP,
       channel: NimbusExperimentChannelEnum.NIGHTLY,
@@ -1026,7 +1025,12 @@ describe("PageSummary Warnings", () => {
     render(<Subject mocks={[mock]} />);
     await waitFor(() => {
       expect(screen.queryByTestId("excluding-live-experiments-warning"));
-      expect(screen.getByText(warning));
+      expect(screen.getByText("my-slimy-slug")).toBeInTheDocument();
+      const excludingTest = screen.findByText(
+        (content: string, node: Element | null) =>
+          node ? (node.textContent ?? "").includes(warning) : false,
+      );
+      expect(excludingTest).resolves.toBeInTheDocument();
     });
   });
 
@@ -1046,10 +1050,7 @@ describe("PageSummary Warnings", () => {
   });
 
   it("displays warnings for live experiments in bucket audience overlap", async () => {
-    const warning =
-      AUDIENCE_OVERLAP_WARNINGS.LIVE_EXPERIMENTS_BUCKET_WARNING(
-        "my-slimy-slug",
-      );
+    const warning = AUDIENCE_OVERLAP_WARNINGS.LIVE_EXPERIMENTS_BUCKET_WARNING();
     const { mock } = mockExperimentQuery("demo-slug", {
       application: NimbusExperimentApplicationEnum.DESKTOP,
       channel: NimbusExperimentChannelEnum.NIGHTLY,
@@ -1059,7 +1060,12 @@ describe("PageSummary Warnings", () => {
     render(<Subject mocks={[mock]} />);
     await waitFor(() => {
       expect(screen.queryByTestId("live-experiments-in-bucket-warning"));
-      expect(screen.getByText(warning));
+      expect(screen.getByText("my-slimy-slug")).toBeInTheDocument();
+      const bucketTest = screen.findByText(
+        (content: string, node: Element | null) =>
+          node ? (node.textContent ?? "").includes(warning) : false,
+      );
+      expect(bucketTest).resolves.toBeInTheDocument();
     });
   });
 
@@ -1080,7 +1086,7 @@ describe("PageSummary Warnings", () => {
 
   it("displays just the multifeature warning when there are multiple audience overlaps", async () => {
     const multifeatureWarning =
-      AUDIENCE_OVERLAP_WARNINGS.LIVE_MULTIFEATURE_WARNING("my-slimy-slug");
+      AUDIENCE_OVERLAP_WARNINGS.LIVE_MULTIFEATURE_WARNING();
     const { mock } = mockExperimentQuery("demo-slug", {
       application: NimbusExperimentApplicationEnum.DESKTOP,
       channel: NimbusExperimentChannelEnum.NIGHTLY,
@@ -1094,14 +1100,17 @@ describe("PageSummary Warnings", () => {
         screen.queryByTestId("live-experiments-in-bucket-warning"),
       ).toBeNull();
       expect(screen.queryByTestId("live-multifeature-warning"));
-      expect(screen.getByText(multifeatureWarning));
+      expect(screen.getByText("my-slimy-slug")).toBeInTheDocument();
+      const multifeatureTest = screen.findByText(
+        (content: string, node: Element | null) =>
+          node ? (node.textContent ?? "").includes(multifeatureWarning) : false,
+      );
+      expect(multifeatureTest).resolves.toBeInTheDocument();
     });
   });
 
   it("displays warnings for live multifeature audience overlap", async () => {
-    const warning = AUDIENCE_OVERLAP_WARNINGS.LIVE_MULTIFEATURE_WARNING(
-      "my-slimy-slug, smooth-slug",
-    );
+    const warning = AUDIENCE_OVERLAP_WARNINGS.LIVE_MULTIFEATURE_WARNING();
     const { mock } = mockExperimentQuery("demo-slug", {
       application: NimbusExperimentApplicationEnum.DESKTOP,
       channel: NimbusExperimentChannelEnum.NIGHTLY,
@@ -1111,7 +1120,13 @@ describe("PageSummary Warnings", () => {
     render(<Subject mocks={[mock]} />);
     await waitFor(() => {
       expect(screen.queryByTestId("live-multifeature-warning"));
-      expect(screen.getByText(warning));
+      expect(screen.getByText("my-slimy-slug")).toBeInTheDocument();
+      expect(screen.getByText("smooth-slug")).toBeInTheDocument();
+      const multifeatureTest = screen.findByText(
+        (content: string, node: Element | null) =>
+          node ? (node.textContent ?? "").includes(warning) : false,
+      );
+      expect(multifeatureTest).resolves.toBeInTheDocument();
     });
   });
 

--- a/experimenter/experimenter/nimbus-ui/src/components/PageSummary/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageSummary/index.tsx
@@ -353,18 +353,27 @@ const StatusPill = ({
 const Warning = ({
   text,
   testId,
+  slugs,
   learnMoreLink,
   learnMoreText = "Learn more",
   variant = "danger",
 }: {
   text: string | SerializerMessage;
   testId: string;
+  slugs?: string[];
   learnMoreLink?: string;
   learnMoreText?: string;
   variant?: string;
 }) => (
   <Alert data-testid={`${testId}-warning`} variant={variant}>
     {text}{" "}
+    {slugs && slugs.length > 0 && (
+      <ul>
+        {slugs.map((slug) => (
+          <li key={slug}>{slug}</li>
+        ))}
+      </ul>
+    )}
     {learnMoreLink && (
       <LinkExternal href={learnMoreLink}>
         <span className="mr-1">{learnMoreText}</span>
@@ -456,9 +465,8 @@ const WarningList = ({
       warnings.push(
         <Warning
           {...{
-            text: AUDIENCE_OVERLAP_WARNINGS.EXCLUDING_EXPERIMENTS_WARNING(
-              excludedLiveDeliveries,
-            ),
+            text: AUDIENCE_OVERLAP_WARNINGS.EXCLUDING_EXPERIMENTS_WARNING(),
+            slugs: experiment.excludedLiveDeliveries,
             testId: "excluding-live-experiments",
             variant: "warning",
             learnMoreLink: EXTERNAL_URLS.AUDIENCE_OVERLAP_WARNING,
@@ -471,9 +479,8 @@ const WarningList = ({
       warnings.push(
         <Warning
           {...{
-            text: AUDIENCE_OVERLAP_WARNINGS.LIVE_EXPERIMENTS_BUCKET_WARNING(
-              liveExperimentsInNamespace,
-            ),
+            text: AUDIENCE_OVERLAP_WARNINGS.LIVE_EXPERIMENTS_BUCKET_WARNING(),
+            slugs: experiment.liveExperimentsInNamespace,
             testId: "live-experiments-in-bucket",
             variant: "warning",
             learnMoreLink: EXTERNAL_URLS.AUDIENCE_OVERLAP_WARNING,
@@ -486,9 +493,8 @@ const WarningList = ({
       warnings.push(
         <Warning
           {...{
-            text: AUDIENCE_OVERLAP_WARNINGS.LIVE_MULTIFEATURE_WARNING(
-              featureHasLiveMultifeatureExperiments,
-            ),
+            text: AUDIENCE_OVERLAP_WARNINGS.LIVE_MULTIFEATURE_WARNING(),
+            slugs: experiment.featureHasLiveMultifeatureExperiments,
             testId: "live-multifeature",
             variant: "warning",
             learnMoreLink: EXTERNAL_URLS.AUDIENCE_OVERLAP_WARNING,

--- a/experimenter/experimenter/nimbus-ui/src/lib/constants.ts
+++ b/experimenter/experimenter/nimbus-ui/src/lib/constants.ts
@@ -97,14 +97,14 @@ export const TOOLTIP_RELEASE_DATE =
   "This is the approximate release date of the version that is being targeted. Click here to find your date!";
 
 export const AUDIENCE_OVERLAP_WARNINGS = {
-  EXCLUDING_EXPERIMENTS_WARNING: (slugs: string) => {
-    return `The following experiments are being excluded by your experiment and may cause audience overlap: ${slugs}`;
+  EXCLUDING_EXPERIMENTS_WARNING: () => {
+    return `The following experiments are being excluded by your experiment and may cause audience overlap: `;
   },
-  LIVE_EXPERIMENTS_BUCKET_WARNING: (slugs: string) => {
-    return `The following experiments are LIVE and may cause audience overlap with your experiment: ${slugs}`;
+  LIVE_EXPERIMENTS_BUCKET_WARNING: () => {
+    return `The following experiments are LIVE and may cause audience overlap with your experiment: `;
   },
-  LIVE_MULTIFEATURE_WARNING: (slugs: string) => {
-    return `The following multi-feature experiments are LIVE and may cause audience overlap with your experiment: ${slugs}`;
+  LIVE_MULTIFEATURE_WARNING: () => {
+    return `The following multi-feature experiments are LIVE and may cause audience overlap with your experiment: `;
   },
 };
 


### PR DESCRIPTION
Because

- Displaying the slugs in a comma-seperated list is hard to visually parse

This commit

- Changes the format of displaying the slugs from a comma-seperated list into a bulleted list

Fixes #10302