### PR TITLE
bug(nimbus): update proposed end date with extended enrollment days

### DIFF
--- a/experimenter/experimenter/experiments/models.py
+++ b/experimenter/experimenter/experiments/models.py
@@ -639,9 +639,11 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
     @property
     def proposed_end_date(self):
         if self.proposed_duration is not None and self.enrollment_start_date is not None:
-            return self.enrollment_start_date + datetime.timedelta(
-                days=self.proposed_duration
+            proposed_observation_duration = (
+                self.proposed_duration - self.proposed_enrollment
             )
+            total_duration = self.computed_enrollment_days + proposed_observation_duration
+            return self.enrollment_start_date + datetime.timedelta(days=total_duration)
 
     @property
     def computed_enrollment_days(self):

--- a/experimenter/experimenter/experiments/tests/test_models.py
+++ b/experimenter/experimenter/experiments/tests/test_models.py
@@ -1364,6 +1364,29 @@ class TestNimbusExperiment(TestCase):
             experiment.end_date,
         )
 
+    def test_computed_end_date_returns_proposed_with_actual_enrollment_duration(self):
+        start_date = datetime.date(2022, 1, 1)
+        enrollment_end_date = datetime.date(2022, 1, 5)
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.LIVE_PAUSED,
+            start_date=start_date,
+            proposed_enrollment=2,
+            _enrollment_end_date=enrollment_end_date,
+        )
+
+        self.assertEqual(experiment.actual_enrollment_end_date, enrollment_end_date)
+        additional_enrollment_days = (
+            experiment.actual_enrollment_end_date - experiment.start_date
+        ).days - experiment.proposed_enrollment
+
+        self.assertEqual(
+            experiment.computed_end_date,
+            experiment.start_date
+            + datetime.timedelta(
+                days=(experiment.proposed_duration + additional_enrollment_days)
+            ),
+        )
+
     def test_monitoring_dashboard_url_is_valid_when_experiment_not_begun(self):
         experiment = NimbusExperimentFactory.create(
             slug="experiment",


### PR DESCRIPTION
Because

* If an experiment enrolls for additional days beyond the originally planned enrollment period, we do not extend the proposed end date by that additional amount
* This can result in observation periods being shortened unintentionally and then experiments ending early without gathering sufficient data

This commit

* Uses the actual enrollment period plus the planned observation period to compute the proposed end date
* This will be shown in the UI and determine when email reminders are sent

fixes #10665

