### PR TITLE
feat(nimbus): Include stdout and stderr in manifesttool summaries

### DIFF
--- a/experimenter/manifesttool/exception_utils.py
+++ b/experimenter/manifesttool/exception_utils.py
@@ -1,0 +1,41 @@
+import subprocess
+import traceback
+
+
+def _format_output(output: bytes) -> str:
+    try:
+        output = output.decode("utf-8")
+    except Exception:
+        return f"{output}\n"
+
+    # If there is any output, ensure it ends with a newline for formatting
+    # purposes.
+    if not output.endswith("\n"):
+        output += "\n"
+
+    return output
+
+
+def format_exception(exc: Exception) -> str:
+    """Format an exception into a string.
+
+    If the exception is a :ref:`subprocess.CalledProcessError`, stdout and
+    stderr will be included if present.
+
+    NB: This is similar to :ref:`traceback.format_exception`, except it returns
+    a string instead of a list of strings.
+    """
+    parts = traceback.format_exception(exc)
+
+    if isinstance(exc, subprocess.CalledProcessError):
+        if exc.stdout is not None:
+            stdout = _format_output(exc.stdout)
+            if stdout:
+                parts.append(f"\nstdout:\n-----\n{stdout}-----\n")
+
+        if exc.stderr is not None:
+            stderr = _format_output(exc.stderr)
+            if stderr:
+                parts.append(f"\nstderr:\n-----\n{stderr}-----\n")
+
+    return "".join(parts)

--- a/experimenter/manifesttool/fetch.py
+++ b/experimenter/manifesttool/fetch.py
@@ -1,7 +1,6 @@
 import sys
 from dataclasses import dataclass
 from pathlib import Path
-from traceback import print_exception
 from typing import Optional, TextIO
 
 import yaml
@@ -9,6 +8,7 @@ from mozilla_nimbus_schemas import FeatureManifest
 
 from manifesttool import github_api, hgmo_api, nimbus_cli
 from manifesttool.appconfig import AppConfig, DiscoveryStrategyType, RepositoryType
+from manifesttool.exception_utils import format_exception
 from manifesttool.releases import discover_branched_releases, discover_tagged_releases
 from manifesttool.repository import Ref, RefCache
 from manifesttool.version import Version
@@ -26,10 +26,9 @@ class FetchResult:
         as_str = f"{self.app_name} at {self.ref} version {self.version}"
 
         if self.exc:
-            exc_message = str(self.exc).partition("\n")[0]
-            as_str = f"{as_str}\n{exc_message}\n"
+            as_str += f"\n{format_exception(self.exc)}"
         elif self.cached:
-            as_str = f"{as_str} (cached)"
+            as_str += " (cached)"
 
         return as_str
 
@@ -109,7 +108,7 @@ def fetch_fml_app(
             version,
         )
     except Exception as e:
-        print_exception(e, file=sys.stderr)
+        print(format_exception(e), file=sys.stderr)
         result.exc = e
 
     return result
@@ -203,7 +202,7 @@ def fetch_legacy_app(
 
                 fetched_schemas.add(feature.json_schema.path)
     except Exception as e:
-        print_exception(e, file=sys.stderr)
+        print(format_exception(e), file=sys.stderr)
         result.exc = e
 
     return result

--- a/experimenter/manifesttool/nimbus_cli.py
+++ b/experimenter/manifesttool/nimbus_cli.py
@@ -4,23 +4,22 @@ import sys
 from pathlib import Path
 from typing import Optional
 
-from manifesttool import github_api
 from manifesttool.appconfig import AppConfig, RepositoryType
 from manifesttool.version import Version
 
 NIMBUS_CLI_PATH = "/application-services/bin/nimbus-cli"
 
 
-def nimbus_cli(args: list[str], *, output: bool = False):
+def nimbus_cli(args: list[str]) -> bytes:
     """Run nimbus-cli with the given arguments."""
     print("nimbus-cli", " ".join(args))
-    method = subprocess.check_output if output else subprocess.check_call
 
-    return method(
+    return subprocess.check_output(
         [
             NIMBUS_CLI_PATH,
             *args,
-        ]
+        ],
+        stderr=subprocess.PIPE,
     )
 
 
@@ -36,8 +35,7 @@ def get_channels(app_config: AppConfig, fml_path: str, ref: str) -> list[str]:
             "--ref",
             ref,
             f"@{app_config.repo.name}/{fml_path}",
-        ],
-        output=True,
+        ]
     )
 
     try:

--- a/experimenter/manifesttool/tests/test_cli.py
+++ b/experimenter/manifesttool/tests/test_cli.py
@@ -98,7 +98,7 @@ class CliTests(TestCase):
         self.assertEqual(result.exit_code, 1, result.exception or result.stdout)
 
         self.assertIn(
-            "SUMMARY:\n\nFAILURES:\n\nfml_app at main version None\nConnection error\n",
+            "SUMMARY:\n\nFAILURES:\n\nfml_app at main version None\nException: Connection error\n",
             result.stdout,
         )
 
@@ -148,7 +148,7 @@ class CliTests(TestCase):
         self.assertEqual(result.exit_code, 1, result.exception or result.stdout)
 
         self.assertIn(
-            "SUMMARY:\n\nFAILURES:\n\nlegacy_app at tip version None\nConnection error\n",
+            "SUMMARY:\n\nFAILURES:\n\nlegacy_app at tip version None\nException: Connection error\n",
             result.stdout,
         )
 
@@ -260,7 +260,7 @@ class CliTests(TestCase):
             "SUMMARY:\n\n"
             "FAILURES:\n\n"
             "fml_app at main (quux) version None\n"
-            "oh no\n\n"
+            "Exception: oh no\n\n"
             "SUCCESS:\n\n"
             "fml_app at baz (qux) version 2.0.0\n\n"
             "CACHED:\n\n"

--- a/experimenter/manifesttool/tests/test_exception_utils.py
+++ b/experimenter/manifesttool/tests/test_exception_utils.py
@@ -1,0 +1,139 @@
+import re
+from subprocess import CalledProcessError
+from unittest import TestCase
+
+from parameterized import parameterized
+
+from manifesttool.exception_utils import format_exception
+
+
+class BogusError(Exception):
+    pass
+
+
+class ExceptionUtilsTests(TestCase):
+    maxDiff = None
+
+    def test_format_exception(self):
+        self.assertEqual(
+            format_exception(Exception("exceptional")), "Exception: exceptional\n"
+        )
+
+    @parameterized.expand(
+        [
+            (
+                CalledProcessError(1, ["/bin/bogus"]),
+                "subprocess.CalledProcessError: Command '['/bin/bogus']' returned non-zero exit status 1.\n",
+            ),
+            (
+                CalledProcessError(1, ["/bin/bogus"], output=b"stdout"),
+                "subprocess.CalledProcessError: Command '['/bin/bogus']' returned non-zero exit status 1.\n"
+                "\n"
+                "stdout:\n"
+                "-----\n"
+                "stdout\n"
+                "-----\n",
+            ),
+            (
+                CalledProcessError(1, ["/bin/bogus"], stderr=b"stderr"),
+                "subprocess.CalledProcessError: Command '['/bin/bogus']' returned non-zero exit status 1.\n"
+                "\n"
+                "stderr:\n"
+                "-----\n"
+                "stderr\n"
+                "-----\n",
+            ),
+            (
+                CalledProcessError(
+                    1,
+                    ["/bin/bogus"],
+                    output=b"multi-line\nstdout\n",
+                    stderr=b"multi-line\nstderr\n",
+                ),
+                "subprocess.CalledProcessError: Command '['/bin/bogus']' returned non-zero exit status 1.\n"
+                "\n"
+                "stdout:\n"
+                "-----\n"
+                "multi-line\n"
+                "stdout\n"
+                "-----\n"
+                "\n"
+                "stderr:\n"
+                "-----\n"
+                "multi-line\n"
+                "stderr\n"
+                "-----\n",
+            ),
+            (
+                CalledProcessError(1, ["/bin/bogus"], output=b"\xff", stderr=b"stderr"),
+                "subprocess.CalledProcessError: Command '['/bin/bogus']' returned non-zero exit status 1.\n"
+                "\n"
+                "stdout:\n"
+                "-----\n"
+                "b'\\xff'\n"
+                "-----\n"
+                "\n"
+                "stderr:\n"
+                "-----\n"
+                "stderr\n"
+                "-----\n",
+            ),
+            (
+                CalledProcessError(2, ["/bin/bogus"], output=b"stdout", stderr=b"\xff"),
+                "subprocess.CalledProcessError: Command '['/bin/bogus']' returned non-zero exit status 2.\n"
+                "\n"
+                "stdout:\n"
+                "-----\n"
+                "stdout\n"
+                "-----\n"
+                "\n"
+                "stderr:\n"
+                "-----\n"
+                "b'\\xff'\n"
+                "-----\n",
+            ),
+        ],
+    )
+    def test_format_exception_cpe(self, exc, expected):
+        """Testing format_exception with a subprocess.CalledProcessError."""
+        self.assertEqual(format_exception(exc), expected)
+
+    def test_format_exception_tb(self):
+        """Testing format_exception with a raised exception includes a traceback."""
+
+        # Raise an exception so we can get a real traceback to compare against.
+        try:
+            raise CalledProcessError(
+                1, ["/bin/bogus"], output=b"this is stdout", stderr=b"this\nis\nstderr\n"
+            )
+        except Exception as e:
+            exc = e
+
+        # Replace the line number in the test so that we don't have to update
+        # this test if line numbers change.
+        formatted = re.sub(
+            r"""File "/experimenter/manifesttool/tests/test_exception_utils.py", line \d+, in test_format_exception_tb""",
+            """File "/experimenter/manifesttool/tests/test_exception_utils.py", line 0000, in test_format_exception_tb""",
+            format_exception(exc),
+        )
+
+        expected = """\
+Traceback (most recent call last):
+  File "/experimenter/manifesttool/tests/test_exception_utils.py", line 0000, in test_format_exception_tb
+    raise CalledProcessError(
+subprocess.CalledProcessError: Command '['/bin/bogus']' returned non-zero exit status 1.
+
+stdout:
+-----
+this is stdout
+-----
+
+stderr:
+-----
+this
+is
+stderr
+-----
+"""
+
+        self.assertEqual(formatted, expected)

--- a/experimenter/manifesttool/tests/test_fetch.py
+++ b/experimenter/manifesttool/tests/test_fetch.py
@@ -1023,18 +1023,26 @@ class FetchTests(TestCase):
             buffer,
         )
 
-        self.assertEqual(
-            buffer.getvalue(),
-            "SUMMARY:\n\n"
-            "FAILURES:\n\n"
-            "app-3 at c (baz) version None\n"
-            "oh no\n\n"
-            "app-5 at e (quux) version 7.8.9\n"
-            "rats!\n\n"
-            "SUCCESS:\n\n"
-            "app-1 at a (foo) version None\n"
-            "app-2 at b (bar) version 1.2.3\n"
-            "\n"
-            "CACHED:\n\n"
-            "app-4 at d (qux) version 4.5.6 (cached)\n",
-        )
+        summary = buffer.getvalue()
+        expected = """\
+SUMMARY:
+
+FAILURES:
+
+app-3 at c (baz) version None
+Exception: oh no
+
+app-5 at e (quux) version 7.8.9
+Exception: rats!
+
+SUCCESS:
+
+app-1 at a (foo) version None
+app-2 at b (bar) version 1.2.3
+
+CACHED:
+
+app-4 at d (qux) version 4.5.6 (cached)
+"""
+
+        self.assertEqual(summary, expected)

--- a/experimenter/manifesttool/tests/test_nimbus_cli.py
+++ b/experimenter/manifesttool/tests/test_nimbus_cli.py
@@ -1,8 +1,9 @@
+import subprocess
 import json
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest import TestCase
-from unittest.mock import call, patch
+from unittest.mock import patch
 
 from parameterized import parameterized
 
@@ -45,12 +46,13 @@ class NimbusCliTests(TestCase):
                 "0" * 40,
                 "@owner/repo/path",
             ],
+            stderr=subprocess.PIPE,
         )
 
     @patch.object(
         nimbus_cli.subprocess,
         "check_output",
-        lambda *args: "invalid json",
+        lambda *args, **kwargs: "invalid json",
     )
     def test_get_channels_invalid(self):
         "Testing get_channels handling of invalid JSON."
@@ -69,10 +71,11 @@ class NimbusCliTests(TestCase):
         """Tesing download_single_file calls nimbus-cli with correct arguments."""
         with (
             TemporaryDirectory() as tmp,
-            patch.object(nimbus_cli.subprocess, "check_call") as check_call,
+            patch.object(nimbus_cli.subprocess, "check_output") as check_output,
         ):
             manifest_dir = Path(tmp)
             manifest_dir.joinpath("slug").mkdir()
+
             nimbus_cli.download_single_file(
                 manifest_dir,
                 APP_CONFIG,
@@ -82,7 +85,7 @@ class NimbusCliTests(TestCase):
                 version,
             )
 
-            check_call.assert_called_with(
+            check_output.assert_called_with(
                 [
                     "/application-services/bin/nimbus-cli",
                     "fml",
@@ -94,7 +97,8 @@ class NimbusCliTests(TestCase):
                     "0" * 40,
                     "@owner/repo/path",
                     str(manifest_dir / fml_path),
-                ]
+                ],
+                stderr=subprocess.PIPE,
             )
 
     @parameterized.expand(
@@ -119,7 +123,7 @@ class NimbusCliTests(TestCase):
         """Testing generate_experimenter_yaml calls nimbus-cli with correct arguments."""
         with (
             TemporaryDirectory() as tmp,
-            patch.object(nimbus_cli.subprocess, "check_call") as check_call,
+            patch.object(nimbus_cli.subprocess, "check_output") as check_output,
         ):
             manifest_dir = Path(tmp)
             manifest_dir.joinpath("slug").mkdir()
@@ -127,7 +131,7 @@ class NimbusCliTests(TestCase):
                 manifest_dir, APP_CONFIG, "channel", version
             )
 
-            check_call.assert_called_with(
+            check_output.assert_called_with(
                 [
                     "/application-services/bin/nimbus-cli",
                     "fml",
@@ -135,5 +139,6 @@ class NimbusCliTests(TestCase):
                     "generate-experimenter",
                     str(manifest_dir / fml_path),
                     str(manifest_dir / experimenter_yaml_path),
-                ]
+                ],
+                stderr=subprocess.PIPE,
             )


### PR DESCRIPTION
Because:

- manifesttool does not include stdout and stderr of subcommands in its summaries;
- the most common failure so far has been intermittent network issues in nimbus-cli; and
- we currently have to check the CI logs to find out why commands fail

This commit:

- includes stdout and stderr of subcommands in the summaries.

Fixes #10678