### PR TITLE
feat(nimbus): include Circle build URL in manifest update PRs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -506,6 +506,7 @@ jobs:
             cp .env.sample .env
             env GITHUB_BEARER_TOKEN="${GH_EXTERNAL_CONFIG_TOKEN}" make fetch_external_resources FETCH_ARGS="--summary fetch-summary.txt"
             mv ./experimenter/fetch-summary.txt /tmp/fetch-summary.txt
+            echo -e "\nCircle CI Task: ${CIRCLE_BUILD_URL}" >> /tmp/fetch-summary.txt
             if python3 ./experimenter/bin/should-pr.py
               then
                 git checkout -B external-config


### PR DESCRIPTION
Because:

- it is currently a manual process to investigate failed manifest update PRs

this commit:

- updates the manifest update task to include the CircleCI build URL in the PR body.

Fixes #10199