### PR TITLE
feat(nimbus): filter by status on new nimbus list page

### DIFF
--- a/experimenter/experimenter/nimbus_ui_new/templates/common/footer.html
+++ b/experimenter/experimenter/nimbus_ui_new/templates/common/footer.html
@@ -1,4 +1,3 @@
 <footer class="text-center my-4">
-  <hr>
   <div>© Mozilla Corporation 2024</div>
 </footer>

--- a/experimenter/experimenter/nimbus_ui_new/templates/common/header.html
+++ b/experimenter/experimenter/nimbus_ui_new/templates/common/header.html
@@ -44,13 +44,16 @@
           Legacy
         </a>
       </li>
-      <li>
-        <select id="theme-selector"
-                class="form-select"
-                onchange="document.documentElement.setAttribute('data-bs-theme', document.getElementById('theme-selector').value)">
-          <option value="light" selected>Light</option>
-          <option value="dark">Dark</option>
-        </select>
+      <li class="d-flex align-items-center">
+        <i class="fa-regular fa-lightbulb"></i>
+        <div class="form-check form-switch ms-2 mt-1">
+          <input id="theme-selector"
+                 class="form-check-input"
+                 type="checkbox"
+                 role="switch"
+                 onchange="document.documentElement.setAttribute('data-bs-theme', document.getElementById('theme-selector').checked ? 'light': 'dark')"
+                 checked>
+        </div>
       </li>
     </ul>
   </div>

--- a/experimenter/experimenter/nimbus_ui_new/templates/common/list_tab.html
+++ b/experimenter/experimenter/nimbus_ui_new/templates/common/list_tab.html
@@ -1,0 +1,11 @@
+<li class="nav-item">
+  <button class="nav-link {% if active_status == status %}active{% endif %}"
+          hx-get="?status={{ status }}"
+          hx-select="#experiment-list"
+          hx-target="#experiment-list"
+          hx-push-url="true"
+          hx-indicator="#htmx-indicator">
+    <i class="{{ icon }}"></i>
+    {{ status }} ({{ count }})
+  </button>
+</li>

--- a/experimenter/experimenter/nimbus_ui_new/templates/experimenter_base.html
+++ b/experimenter/experimenter/nimbus_ui_new/templates/experimenter_base.html
@@ -7,13 +7,14 @@
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="icon" href="{% static 'imgs/favicon.ico' %}" />
     <title>
       {% block title %}
       {% endblock title %}
 
     </title>
     <script src="{% static 'fontawesomefree/js/all.min.js' %}"></script>
-    <link rel="icon" href="{% static 'imgs/favicon.ico' %}" />
+    <script src="https://unpkg.com/htmx.org@1.9.12"></script>
     {% bootstrap_css %}
     {% bootstrap_javascript %}
   </head>

--- a/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/list.html
+++ b/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/list.html
@@ -5,6 +5,10 @@
 {% endblock title %}
 
 {% block sidebar %}
+  <button class="btn btn-primary w-100 mb-2">
+    <i class="fa-regular fa-pen-to-square"></i>
+    Create Experiment
+  </button>
   <input class="form-control mb-2 bg-body-tertiary"
          type="text"
          placeholder="🔎 Search"
@@ -24,110 +28,93 @@
 {% endblock sidebar %}
 
 {% block main_content %}
-  <ul class="nav nav-tabs">
-    <li class="nav-item">
-      <a class="nav-link active" aria-current="page" href="#">
-        <i class="fa-regular fa-circle-play"></i>
-        Live ({{ status_counts.Live }})
-      </a>
-    </li>
-    <li class="nav-item">
-      <a class="nav-link" href="#">
-        <i class="fa-solid fa-eye"></i>
-        Review ({{ status_counts.Review }})
-      </a>
-    </li>
-    <li class="nav-item">
-      <a class="nav-link" href="#">
-        <i class="fa-solid fa-person-circle-check"></i>
-        Preview ({{ status_counts.Preview }})
-      </a>
-    </li>
-    <li class="nav-item">
-      <a class="nav-link" href="#">
-        <i class="fa-solid fa-vial-circle-check"></i>
-        Completed ({{ status_counts.Complete }})
-      </a>
-    </li>
-    <li class="nav-item">
-      <a class="nav-link" href="#">
-        <i class="fa-solid fa-pen-to-square"></i>
-        Draft ({{ status_counts.Draft }})
-      </a>
-    </li>
-    <li class="nav-item">
-      <a class="nav-link" href="#">
-        <i class="fa-solid fa-box-archive"></i>
-        Archived ({{ status_counts.Archived }})
-      </a>
-    </li>
-    <li class="nav-item">
-      <a class="nav-link" href="#">
-        <i class="fa-solid fa-heart"></i>
-        My Experiments ({{ status_counts.MyExperiments }})
-      </a>
-    </li>
-  </ul>
-  <div class="border border-1 border-top-0 border-bottom-0">
-    <table class="table table-striped mb-0">
-      <thead>
-        <tr>
-          <th scope="col">Name</th>
-          <th scope="col">QA</th>
-          <th scope="col">Application</th>
-          <th scope="col">Channel</th>
-          <th scope="col">Size</th>
-          <th scope="col">Features</th>
-          <th scope="col">Versions</th>
-          <th scope="col">Dates</th>
-        </tr>
-      </thead>
-      <tbody>
-        {% for experiment in experiments %}
+  <div id="experiment-list">
+    <ul class="nav nav-tabs">
+      {% include "common/list_tab.html" with status="Live" count=status_counts.Live icon="fa-regular fa-circle-play" %}
+      {% include "common/list_tab.html" with status="Review" count=status_counts.Review icon="fa-solid fa-eye" %}
+      {% include "common/list_tab.html" with status="Preview" count=status_counts.Preview icon="fa-solid fa-person-circle-check" %}
+      {% include "common/list_tab.html" with status="Complete" count=status_counts.Complete icon="fa-solid fa-vial-circle-check" %}
+      {% include "common/list_tab.html" with status="Draft" count=status_counts.Draft icon="fa-solid fa-pen-to-square" %}
+      {% include "common/list_tab.html" with status="Archived" count=status_counts.Archived icon="fa-solid fa-box-archive" %}
+      {% include "common/list_tab.html" with status="MyExperiments" count=status_counts.MyExperiments icon="fa-solid fa-heart" %}
+
+      <li class="nav-item ms-auto d-flex align-items-center">
+        <button class="btn btn-link">
+          <i class="fa-solid fa-angle-left"></i>
+        </button>
+        <select class="form-select border-0 bg-body-tertiary">
+          <option>1</option>
+        </select>
+        /&nbsp;10
+        <button class="btn btn-link">
+          <i class="fa-solid fa-angle-right"></i>
+        </button>
+      </li>
+    </ul>
+    <div class="border border-1 border-top-0 border-bottom-0 mb-3">
+      <table class="table table-striped mb-0">
+        <thead>
           <tr>
-            <th scope="row">
-              <a href="{% url "nimbus-detail" slug=experiment.slug %}">{{ experiment.name }}</a>
-            </th>
-            <td>
-              {% if experiment.qa_status == 'NOT SET' %}<i class="fa-regular fa-circle-question"></i>{% endif %}
-              {% if experiment.qa_status == 'GREEN' %}
-                <span class="text-success"><i class="fa-regular fa-circle-check"></i></span>
-              {% endif %}
-              {% if experiment.qa_status == 'YELLOW' %}
-                <span class="text-warning"><i class="fa-regular fa-circle-pause"></i></span>
-              {% endif %}
-              {% if experiment.qa_status == 'RED' %}
-                <span class="text-danger"><i class="fa-regular fa-circle-xmark"></i></span>
-              {% endif %}
-            </td>
-            <td>{{ experiment.get_application_display }}</td>
-            <td>{{ experiment.get_channel_display }}</td>
-            <td>{{ experiment.population_percent|floatformat }}%</td>
-            <td>
-              {% for feature in experiment.feature_configs.all %}{{ feature.name }}{% endfor %}
-            </td>
-            <td>
-              {{ experiment.get_firefox_min_version_display }}
-              {% if experiment.firefox_max_version %}
-                - {{ experiment.get_firefox_max_version_display }}
-              {% else %}
-                +
-              {% endif %}
-            </td>
-            <td>
-              {% if experiment.start_date %}
-                {{ experiment.start_date|date:"M j/y" }} -
-                <br>
-                {{ experiment.computed_end_date|date:"M j/y" }}
-                <br>
-                ({{ experiment.proposed_duration }} days)
-              {% else %}
-                N/A
-              {% endif %}
-            </td>
+            <th scope="col">Name</th>
+            <th scope="col">QA</th>
+            <th scope="col">Application</th>
+            <th scope="col">Channel</th>
+            <th scope="col">Size</th>
+            <th scope="col">Features</th>
+            <th scope="col">Versions</th>
+            <th scope="col">Dates</th>
           </tr>
-        {% endfor %}
-      </tbody>
-    </table>
+        </thead>
+        <tbody>
+          {% for experiment in experiments %}
+            <tr>
+              <th scope="row">
+                <a href="{% url "nimbus-detail" slug=experiment.slug %}">{{ experiment.name }}</a>
+              </th>
+              <td>
+                {% if experiment.qa_status == 'NOT SET' %}<i class="fa-regular fa-circle-question"></i>{% endif %}
+                {% if experiment.qa_status == 'GREEN' %}
+                  <span class="text-success"><i class="fa-regular fa-circle-check"></i></span>
+                {% endif %}
+                {% if experiment.qa_status == 'YELLOW' %}
+                  <span class="text-warning"><i class="fa-regular fa-circle-pause"></i></span>
+                {% endif %}
+                {% if experiment.qa_status == 'RED' %}
+                  <span class="text-danger"><i class="fa-regular fa-circle-xmark"></i></span>
+                {% endif %}
+              </td>
+              <td>{{ experiment.get_application_display }}</td>
+              <td>{{ experiment.get_channel_display }}</td>
+              <td>{{ experiment.population_percent|floatformat }}%</td>
+              <td>
+                {% for feature in experiment.feature_configs.all %}
+                  {{ feature.name }}
+                  <br>
+                {% endfor %}
+              </td>
+              <td>
+                {{ experiment.get_firefox_min_version_display }}
+                {% if experiment.firefox_max_version %}
+                  - {{ experiment.get_firefox_max_version_display }}
+                {% else %}
+                  +
+                {% endif %}
+              </td>
+              <td>
+                {% if experiment.start_date %}
+                  {{ experiment.start_date|date:"M j/y" }} -
+                  <br>
+                  {{ experiment.computed_end_date|date:"M j/y" }}
+                  <br>
+                  ({{ experiment.proposed_duration }} days)
+                {% else %}
+                  N/A
+                {% endif %}
+              </td>
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
   </div>
 {% endblock main_content %}

--- a/experimenter/experimenter/nimbus_ui_new/views.py
+++ b/experimenter/experimenter/nimbus_ui_new/views.py
@@ -1,8 +1,48 @@
 from collections import defaultdict
 
-from django.views.generic import DetailView, ListView
+import django_filters
+from django.db import models
+from django.views.generic import DetailView
+from django_filters.views import FilterView
 
 from experimenter.experiments.models import NimbusExperiment
+
+
+class StatusChoices(models.TextChoices):
+    DRAFT = NimbusExperiment.Status.DRAFT.value
+    PREVIEW = NimbusExperiment.Status.PREVIEW.value
+    LIVE = NimbusExperiment.Status.LIVE.value
+    COMPLETE = NimbusExperiment.Status.COMPLETE.value
+    REVIEW = "Review"
+    ARCHIVED = "Archived"
+    MY_EXPERIMENTS = "MyExperiments"
+
+
+class NimbusExperimentFilter(django_filters.FilterSet):
+    status = django_filters.ChoiceFilter(
+        choices=StatusChoices.choices, method="filter_status"
+    )
+
+    class Meta:
+        model = NimbusExperiment
+        fields = ["status"]
+
+    def filter_status(self, queryset, name, value):
+        match value:
+            case StatusChoices.REVIEW:
+                return queryset.filter(
+                    status=NimbusExperiment.Status.DRAFT,
+                    publish_status=NimbusExperiment.PublishStatus.REVIEW,
+                )
+            case StatusChoices.ARCHIVED:
+                return queryset.filter(is_archived=True)
+            case StatusChoices.MY_EXPERIMENTS:
+                return queryset.filter(owner=self.request.user)
+            case _:
+                return queryset.filter(
+                    status=value,
+                    is_archived=False,
+                ).exclude(publish_status=NimbusExperiment.PublishStatus.REVIEW)
 
 
 class NimbusChangeLogsView(DetailView):
@@ -11,22 +51,38 @@ class NimbusChangeLogsView(DetailView):
     template_name = "changelog/overview.html"
 
 
-class NimbusExperimentsListView(ListView):
+class NimbusExperimentsListView(FilterView):
     model = NimbusExperiment
     queryset = NimbusExperiment.objects.with_owner_features()
+    filterset_class = NimbusExperimentFilter
     context_object_name = "experiments"
     template_name = "nimbus_experiments/list.html"
+
+    def get_filterset_kwargs(self, filterset_class):
+        kwargs = super().get_filterset_kwargs(filterset_class)
+        if kwargs["data"] is None:
+            kwargs["data"] = {"status": StatusChoices.LIVE.value}
+        return kwargs
 
     def get_context_data(self, **kwargs):
         queryset = self.get_queryset()
         status_counts = defaultdict(int)
         for experiment in queryset:
-            status_counts[experiment.status] += 1
-            if experiment.is_archived:
-                status_counts["Archived"] += 1
             if experiment.owner == self.request.user:
-                status_counts["MyExperiments"] += 1
-            if experiment.publish_status != NimbusExperiment.PublishStatus.IDLE:
-                status_counts["Review"] += 1
+                status_counts[StatusChoices.MY_EXPERIMENTS.value] += 1
+            if experiment.is_archived:
+                status_counts[StatusChoices.ARCHIVED.value] += 1
+                continue
+            if (
+                experiment.status == NimbusExperiment.Status.DRAFT
+                and experiment.publish_status == NimbusExperiment.PublishStatus.REVIEW
+            ):
+                status_counts[StatusChoices.REVIEW.value] += 1
+            else:
+                status_counts[experiment.status] += 1
 
-        return super().get_context_data(status_counts=status_counts, **kwargs)
+        return super().get_context_data(
+            active_status=kwargs["filter"].data["status"],
+            status_counts=status_counts,
+            **kwargs,
+        )


### PR DESCRIPTION
Because

* We are implementing a new Nimbus list page in django templates and htmx
* We need to be able to filter by status using tabs like the old page does
* We can use django-filters for the filtering
* We can use htmx for the first time to handle the page updates

This commit

* Adds a status filter to the list page
* Uses htmx to update the page in place

fixes #10681

https://github.com/mozilla/experimenter/assets/119884/dc27cc11-6d50-4a29-a3d6-8dd7d5ed842f



