### PR TITLE
chore(nimbus): enable cached template loader

### DIFF
--- a/experimenter/experimenter/settings.py
+++ b/experimenter/experimenter/settings.py
@@ -131,7 +131,6 @@ TEMPLATES = [
             BASE_DIR / "nimbus_ui_new" / "templates",
             BASE_DIR / "docs",
         ],
-        "APP_DIRS": True,
         "OPTIONS": {
             "context_processors": [
                 "django.template.context_processors.debug",
@@ -142,6 +141,15 @@ TEMPLATES = [
                 "experimenter.base.context_processors.debug",
             ],
             "debug": DEBUG,
+            "loaders": [
+                (
+                    "django.template.loaders.cached.Loader",
+                    [
+                        "django.template.loaders.filesystem.Loader",
+                        "django.template.loaders.app_directories.Loader",
+                    ],
+                ),
+            ],
         },
     }
 ]


### PR DESCRIPTION
Because

* We are now reimplementing Nimbus UI in django templates
* We are using a pattern of many embedded includes
* This can significantly increase page load times when templates are loaded on every render
* There is a caching template loader to prevent exactly this

This commit

* Enables the cached template loader

fixes #10720
