### PR TITLE
feat(nimbus): Include localizations field in v7 api

### DIFF
--- a/docs/experimenter/openapi-schema.json
+++ b/docs/experimenter/openapi-schema.json
@@ -3912,6 +3912,10 @@
             "type": "string",
             "readOnly": true
           },
+          "localizations": {
+            "type": "string",
+            "readOnly": true
+          },
           "publishedDate": {
             "type": "string",
             "format": "date-time"

--- a/docs/experimenter/swagger-ui.html
+++ b/docs/experimenter/swagger-ui.html
@@ -3924,6 +3924,10 @@
             "type": "string",
             "readOnly": true
           },
+          "localizations": {
+            "type": "string",
+            "readOnly": true
+          },
           "publishedDate": {
             "type": "string",
             "format": "date-time"

--- a/experimenter/experimenter/experiments/api/v7/serializers.py
+++ b/experimenter/experimenter/experiments/api/v7/serializers.py
@@ -64,6 +64,7 @@ class NimbusExperimentSerializer(serializers.ModelSerializer):
         source="is_client_schema_disabled"
     )
     locales = serializers.SerializerMethodField()
+    localizations = serializers.SerializerMethodField()
     publishedDate = serializers.DateTimeField(source="published_date")
 
     class Meta:
@@ -95,6 +96,7 @@ class NimbusExperimentSerializer(serializers.ModelSerializer):
             "referenceBranch",
             "featureValidationOptOut",
             "locales",
+            "localizations",
             "publishedDate",
         )
 
@@ -126,6 +128,10 @@ class NimbusExperimentSerializer(serializers.ModelSerializer):
     def get_referenceBranch(self, obj):
         if obj.reference_branch:
             return obj.reference_branch.slug
+
+    def get_localizations(self, obj):
+        if obj.is_localized:
+            return json.loads(obj.localizations)
 
     def get_locales(self, obj):
         locale_codes = [locale.code for locale in obj.locales.all()]


### PR DESCRIPTION
Because:

- Skylight needs access to the localizations field in the v7 API

This commit:

- Adds the localizations field to the v7 API

Fixes #10719