### PR TITLE
chore(nimbus): Pull fenix manifests from mozilla-central for 126 release

### DIFF
--- a/experimenter/experimenter/features/manifests/apps.yaml
+++ b/experimenter/experimenter/features/manifests/apps.yaml
@@ -2,32 +2,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 ---
-# Fenix is still doing dot releases from its GitHub repository for 124.* and
-# 125.*.
-#
-# NB: This order is important. This entry must come before the regular Fenix
-# entry because this will generate an experimenter.yaml for the main branch
-# (version 125) which we need to overwrite with the version in mozilla-central
-# (version 126). We could add logic to conditionally fetch unversioned
-# manifests, but this is a temporary workaround until 126 hits release.
-#
-# This should be removed once 126 ships to release (#10515).
-fenix_legacy:
-  slug: "fenix"
-  repo:
-    type: "github"
-    name: "mozilla-mobile/firefox-android"
-  fml_path: "fenix/app/nimbus.fml.yaml"
-  release_discovery:
-    version_file:
-      type: "plaintext"
-      path: "version.txt"
-    strategies:
-      - type: "tagged"
-        branch_re: 'releases_v(?P<major>\d+)'
-        tag_re: 'fenix-v(?P<major>\d+)\.(?P<minor>\d+)(?:\.(?P<patch>\d+))?'
-      - type: "branched"
-
 fenix:
   slug: "fenix"
   repo:
@@ -42,12 +16,9 @@ fenix:
     strategies:
       - type: "branched"
         branches:
-          # Fenix has only just merged into beta. Once 126 merges to release,
-          # that branch should be added here.
-          #
-          # See issue #10515.
           - "master"
           - "beta"
+          - "release"
 
 firefox_ios:
   slug: "ios"

--- a/experimenter/manifesttool/tests/test_version.py
+++ b/experimenter/manifesttool/tests/test_version.py
@@ -111,18 +111,6 @@ class VersionTests(TestCase):
     @parameterized.expand(
         [
             (
-                "fenix_legacy",
-                [
-                    "main",
-                    "releases_v109",
-                    "releases_v110",
-                ],
-                {
-                    Version(109): Ref("releases_v109"),
-                    Version(110): Ref("releases_v110"),
-                },
-            ),
-            (
                 "firefox_ios",
                 [
                     "main",
@@ -191,32 +179,6 @@ class VersionTests(TestCase):
 
     @parameterized.expand(
         [
-            (
-                "fenix_legacy",
-                [
-                    "components-v118.0",
-                    "components-v118.2",
-                    "components-v119.1.1",
-                    "components-v120.0b9",
-                    "fenix-v118.0",
-                    "fenix-v118.2",
-                    "fenix-v119.1.1",
-                    "fenix-v120.0b9",
-                    "focus-v118.0",
-                    "focus-v118.2",
-                    "focus-v119.1.1",
-                    "focus-v120.0b9",
-                    "klar-v119.1.1",
-                    "klar-v118.2",
-                    "v109.0b2",
-                    "v108.1.1",
-                ],
-                {
-                    Version(118): Ref("fenix-v118.0"),
-                    Version(118, 2): Ref("fenix-v118.2"),
-                    Version(119, 1, 1): Ref("fenix-v119.1.1"),
-                },
-            ),
             (
                 "firefox_ios",
                 [


### PR DESCRIPTION
Because:

- there will be no futher 125.x release for Fenix; and
- Fenix has merged into 126 release

This commit:

- stops fetching manifests from Fenix via the @mozilla-mobile/firefox-android repository;
- fetches manifests from the @mozilla/gecko-dev repository on the release branch; and
- removes the `fenix_legacy` entry from apps.yaml and all references to it from manifesttool's unit tests.

Fixes #10515