### PR TITLE
chore(nimbus): add search rollout targeting

### DIFF
--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -1944,6 +1944,28 @@ NEW_PROFILE_MAC_ONLY = NimbusTargetingConfig(
     application_choice_names=(Application.DESKTOP.name,),
 )
 
+SEARCH_ROLLOUT_1 = NimbusTargetingConfig(
+    name="Search Rollout 1",
+    slug="search_rollout_1",
+    description="Search Rollout 1 Namespace",
+    targeting="",
+    desktop_telemetry="",
+    sticky_required=False,
+    is_first_run_required=False,
+    application_choice_names=(Application.DESKTOP.name,),
+)
+
+SEARCH_ROLLOUT_2 = NimbusTargetingConfig(
+    name="Search Rollout 2",
+    slug="search_rollout_2",
+    description="Search Rollout 2 Namespace",
+    targeting="",
+    desktop_telemetry="",
+    sticky_required=False,
+    is_first_run_required=False,
+    application_choice_names=(Application.DESKTOP.name,),
+)
+
 
 class TargetingConstants:
     TARGETING_VERSION = "version|versionCompare('{version}') >= 0"


### PR DESCRIPTION
Because

* We need to be able to put two rollouts for the same feature into two separate namespaces
* The simplest way to do that right now is by using two advanced targetings with different slugs
* This can serve as a prototype of a user definable namespace workflow that we can develop further in the future

This commit

* Adds two advanced targetings for desktop for Search to use as a way to control their rollout namespaces

fixes #10746

