### PR TITLE
bug(nimbus): count statuses in db instead of in memory

### DIFF
--- a/experimenter/experimenter/nimbus_ui_new/tests/test_views.py
+++ b/experimenter/experimenter/nimbus_ui_new/tests/test_views.py
@@ -87,8 +87,8 @@ class NimbusExperimentsListViewTest(TestCase):
         )
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
-            [e.slug for e in response.context["experiments"]],
-            expected_slugs,
+            {e.slug for e in response.context["experiments"]},
+            set(expected_slugs),
         )
 
     @patch(


### PR DESCRIPTION
Because

* We had added logic to count the number of experiments in each status for the new list page
* We did this by looping over them and counting them in memory
* This unnecessarily loads a large number of experiments into memory which blows up the db query and memory cost per request

This commit

* Counts the experiments in the db instead of in memory

fixes #10748

