### PR TITLE
chore(nimbus): Publish prefFlips experiments to secure collection

### DIFF
--- a/experimenter/bin/setup_kinto.py
+++ b/experimenter/bin/setup_kinto.py
@@ -15,6 +15,7 @@ KINTO_BUCKET_MAIN = "main"
 KINTO_COLLECTION_NIMBUS_DESKTOP = "nimbus-desktop-experiments"
 KINTO_COLLECTION_NIMBUS_MOBILE = "nimbus-mobile-experiments"
 KINTO_COLLECTION_NIMBUS_PREVIEW = "nimbus-preview"
+KINTO_COLLECTION_NIMBUS_SECURE = "nimbus-secure-experiments"
 KINTO_COLLECTION_NIMBUS_WEB = "nimbus-web-experiments"
 
 
@@ -48,6 +49,7 @@ def setup():
         KINTO_COLLECTION_NIMBUS_DESKTOP,
         KINTO_COLLECTION_NIMBUS_MOBILE,
         KINTO_COLLECTION_NIMBUS_PREVIEW,
+        KINTO_COLLECTION_NIMBUS_SECURE,
         KINTO_COLLECTION_NIMBUS_WEB,
     ]:
         print(">>>> Creating kinto group: editors")

--- a/experimenter/experimenter/experiments/constants.py
+++ b/experimenter/experimenter/experiments/constants.py
@@ -109,6 +109,9 @@ APPLICATION_CONFIG_DESKTOP = ApplicationConfig(
     default_kinto_collection=settings.KINTO_COLLECTION_NIMBUS_DESKTOP,
     randomization_unit=BucketRandomizationUnit.NORMANDY,
     is_web=False,
+    kinto_collections_by_feature_id={
+        "prefFlips": settings.KINTO_COLLECTION_NIMBUS_SECURE,
+    },
 )
 
 APPLICATION_CONFIG_FENIX = ApplicationConfig(

--- a/experimenter/experimenter/settings.py
+++ b/experimenter/experimenter/settings.py
@@ -477,6 +477,7 @@ KINTO_PASS = config("KINTO_PASS")
 KINTO_BUCKET_WORKSPACE = "main-workspace"
 KINTO_BUCKET_MAIN = "main"
 KINTO_COLLECTION_NIMBUS_DESKTOP = "nimbus-desktop-experiments"
+KINTO_COLLECTION_NIMBUS_SECURE = "nimbus-secure-experiments"
 KINTO_COLLECTION_NIMBUS_MOBILE = "nimbus-mobile-experiments"
 KINTO_COLLECTION_NIMBUS_WEB = "nimbus-web-experiments"
 KINTO_COLLECTION_NIMBUS_PREVIEW = "nimbus-preview"


### PR DESCRIPTION
Because:

- the prefFlips feature of Firefox Desktop requires a separate RS collection

this commit:

- updates the Firefox Desktop configuration to publish experiments using the prefFlips feature to the secure collection; and
- updates the setup_kinto script to with this new collection.

Fixes #10700