### PR TITLE
feat(nimbus): add filtering to new nimbus list page

### DIFF
--- a/experimenter/experimenter/experiments/api/v5/serializers.py
+++ b/experimenter/experimenter/experiments/api/v5/serializers.py
@@ -1442,7 +1442,7 @@ class NimbusReviewSerializer(serializers.ModelSerializer):
         if schemas_in_range.unsupported_in_range:
             result.append(
                 NimbusConstants.ERROR_FEATURE_CONFIG_UNSUPPORTED_IN_RANGE.format(
-                    feature_config=feature_config,
+                    feature_config=feature_config.name,
                 ),
                 suppress_errors,
             )
@@ -1456,7 +1456,7 @@ class NimbusReviewSerializer(serializers.ModelSerializer):
             max_unsupported_version = max(unsupported_version_strs)
             result.append(
                 NimbusConstants.ERROR_FEATURE_CONFIG_UNSUPPORTED_IN_VERSIONS.format(
-                    feature_config=feature_config,
+                    feature_config=feature_config.name,
                     versions=f"{min_unsupported_version}-{max_unsupported_version}",
                 ),
                 suppress_errors,

--- a/experimenter/experimenter/experiments/models.py
+++ b/experimenter/experimenter/experiments/models.py
@@ -1391,6 +1391,14 @@ class NimbusFeatureConfig(models.Model):
     owner_email = models.EmailField(blank=True, null=True)
     enabled = models.BooleanField(default=True)
 
+    class Meta:
+        verbose_name = "Nimbus Feature Config"
+        verbose_name_plural = "Nimbus Feature Configs"
+        unique_together = ("application", "slug")
+
+    def __str__(self):  # pragma: no cover
+        return f"{self.name} ({self.application})"
+
     def schemas_between_versions(
         self,
         min_version: packaging.version,
@@ -1503,14 +1511,6 @@ class NimbusFeatureConfig(models.Model):
             unsupported_in_range=False,
             unsupported_versions=unsupported_versions,
         )
-
-    class Meta:
-        verbose_name = "Nimbus Feature Config"
-        verbose_name_plural = "Nimbus Feature Configs"
-        unique_together = ("application", "slug")
-
-    def __str__(self):  # pragma: no cover
-        return self.name
 
 
 class NimbusFeatureVersionManager(models.Manager["NimbusFeatureVersion"]):

--- a/experimenter/experimenter/nimbus_ui_new/filtersets.py
+++ b/experimenter/experimenter/nimbus_ui_new/filtersets.py
@@ -1,0 +1,281 @@
+import django_filters
+from django import forms
+from django.contrib.auth.models import User
+from django.db import models
+from django.db.models import Q
+from django.db.models.functions import Concat
+
+from experimenter.base.models import Country, Language, Locale
+from experimenter.experiments.models import NimbusExperiment, NimbusFeatureConfig
+from experimenter.projects.models import Project
+from experimenter.targeting.constants import TargetingConstants
+
+
+class StatusChoices(models.TextChoices):
+    DRAFT = NimbusExperiment.Status.DRAFT
+    PREVIEW = NimbusExperiment.Status.PREVIEW
+    LIVE = NimbusExperiment.Status.LIVE
+    COMPLETE = NimbusExperiment.Status.COMPLETE
+    REVIEW = "Review"
+    ARCHIVED = "Archived"
+    MY_EXPERIMENTS = "MyExperiments"
+
+
+class TypeChoices(models.TextChoices):
+    ROLLOUT = "Rollout"
+    EXPERIMENT = "Experiment"
+
+
+class MultiSelectWidget(forms.SelectMultiple):
+    template_name = "common/sidebar_select.html"
+
+    def __init__(self, *args, **kwargs):
+        self.icon = kwargs.pop("icon", None)
+        super().__init__(*args, **kwargs)
+
+    def get_context(self, name, value, attrs):
+        context = super().get_context(name, value, attrs)
+        context["icon"] = self.icon
+        return context
+
+
+class NimbusExperimentFilter(django_filters.FilterSet):
+    status = django_filters.ChoiceFilter(
+        method="filter_status",
+        choices=StatusChoices.choices,
+        widget=forms.widgets.HiddenInput,
+    )
+    search = django_filters.CharFilter(
+        method="filter_search",
+        widget=forms.widgets.TextInput(
+            attrs={
+                "class": "form-control mb-2 bg-body-tertiary",
+                "placeholder": "🔎 Search",
+            }
+        ),
+    )
+    type = django_filters.MultipleChoiceFilter(
+        method="filter_type",
+        choices=TypeChoices.choices,
+        widget=MultiSelectWidget(
+            icon="fa-solid fa-flask-vial",
+            attrs={
+                "title": "All Types",
+                "class": "selectpicker",
+                "data-live-search": "true",
+            },
+        ),
+    )
+    application = django_filters.MultipleChoiceFilter(
+        choices=NimbusExperiment.Application.choices,
+        widget=MultiSelectWidget(
+            icon="fa-solid fa-desktop",
+            attrs={
+                "title": "All Applications",
+                "class": "selectpicker",
+                "data-live-search": "true",
+            },
+        ),
+    )
+    channel = django_filters.MultipleChoiceFilter(
+        choices=NimbusExperiment.Channel.choices,
+        widget=MultiSelectWidget(
+            icon="fa-solid fa-road",
+            attrs={
+                "title": "All Channels",
+                "class": "selectpicker",
+                "data-live-search": "true",
+            },
+        ),
+    )
+    firefox_min_version = django_filters.MultipleChoiceFilter(
+        choices=NimbusExperiment.Version.choices,
+        widget=MultiSelectWidget(
+            icon="fa-solid fa-code-branch",
+            attrs={
+                "title": "All Versions",
+                "class": "selectpicker",
+                "data-live-search": "true",
+            },
+        ),
+    )
+    feature_configs = django_filters.ModelMultipleChoiceFilter(
+        queryset=NimbusFeatureConfig.objects.all(),
+        widget=MultiSelectWidget(
+            icon="fa-solid fa-boxes-stacked",
+            attrs={
+                "title": "All Features",
+                "class": "selectpicker",
+                "data-live-search": "true",
+            },
+        ),
+    )
+    countries = django_filters.ModelMultipleChoiceFilter(
+        queryset=Country.objects.all(),
+        widget=MultiSelectWidget(
+            icon="fa-solid fa-globe",
+            attrs={
+                "title": "All Countries",
+                "class": "selectpicker",
+                "data-live-search": "true",
+            },
+        ),
+    )
+    languages = django_filters.ModelMultipleChoiceFilter(
+        queryset=Language.objects.all(),
+        widget=MultiSelectWidget(
+            icon="fa-solid fa-language",
+            attrs={
+                "title": "All Languages",
+                "class": "selectpicker",
+                "data-live-search": "true",
+            },
+        ),
+    )
+    locales = django_filters.ModelMultipleChoiceFilter(
+        queryset=Locale.objects.all(),
+        widget=MultiSelectWidget(
+            icon="fa-solid fa-earth-americas",
+            attrs={
+                "title": "All Locales",
+                "class": "selectpicker",
+                "data-live-search": "true",
+            },
+        ),
+    )
+    targeting_config_slug = django_filters.MultipleChoiceFilter(
+        choices=TargetingConstants.TargetingConfig.choices,
+        widget=MultiSelectWidget(
+            icon="fa-solid fa-users-rectangle",
+            attrs={
+                "title": "All Audiences",
+                "class": "selectpicker",
+                "data-live-search": "true",
+            },
+        ),
+    )
+    projects = django_filters.ModelMultipleChoiceFilter(
+        queryset=Project.objects.all(),
+        widget=MultiSelectWidget(
+            icon="fa-solid fa-person-chalkboard",
+            attrs={
+                "title": "All Projects",
+                "class": "selectpicker",
+                "data-live-search": "true",
+            },
+        ),
+    )
+    qa_status = django_filters.MultipleChoiceFilter(
+        choices=NimbusExperiment.QAStatus.choices,
+        widget=MultiSelectWidget(
+            icon="fa-solid fa-user-shield",
+            attrs={
+                "title": "All QA Statuses",
+                "class": "selectpicker",
+                "data-live-search": "true",
+            },
+        ),
+    )
+    takeaways = django_filters.MultipleChoiceFilter(
+        method="filter_takeaways",
+        choices=NimbusExperiment.Takeaways.choices,
+        widget=MultiSelectWidget(
+            icon="fa-solid fa-list-check",
+            attrs={
+                "title": "All Takeaways",
+                "class": "selectpicker",
+                "data-live-search": "true",
+            },
+        ),
+    )
+    owner = django_filters.ModelMultipleChoiceFilter(
+        queryset=User.objects.order_by("email"),
+        widget=MultiSelectWidget(
+            icon="fa-solid fa-users",
+            attrs={
+                "title": "All Owners",
+                "class": "selectpicker",
+                "data-live-search": "true",
+            },
+        ),
+    )
+    subscribers = django_filters.ModelMultipleChoiceFilter(
+        queryset=User.objects.order_by("email"),
+        widget=MultiSelectWidget(
+            icon="fa-solid fa-bell",
+            attrs={
+                "title": "All Subscribers",
+                "class": "selectpicker",
+                "data-live-search": "true",
+            },
+        ),
+    )
+
+    class Meta:
+        model = NimbusExperiment
+        fields = [
+            "status",
+            "search",
+            "type",
+            "application",
+            "channel",
+            "firefox_min_version",
+            "feature_configs",
+            "countries",
+            "languages",
+            "locales",
+            "targeting_config_slug",
+            "projects",
+            "qa_status",
+            "takeaways",
+            "owner",
+            "subscribers",
+        ]
+
+    def filter_status(self, queryset, name, value):
+        match value:
+            case StatusChoices.REVIEW:
+                return queryset.filter(
+                    status=NimbusExperiment.Status.DRAFT,
+                    publish_status=NimbusExperiment.PublishStatus.REVIEW,
+                )
+            case StatusChoices.ARCHIVED:
+                return queryset.filter(is_archived=True)
+            case StatusChoices.MY_EXPERIMENTS:
+                return queryset.filter(owner=self.request.user)
+            case _:
+                return queryset.filter(
+                    status=value,
+                    is_archived=False,
+                ).exclude(publish_status=NimbusExperiment.PublishStatus.REVIEW)
+
+    def filter_search(self, queryset, name, value):
+        search_fields = Concat(
+            "name",
+            "slug",
+            "public_description",
+            "hypothesis",
+            "takeaways_summary",
+            "qa_comment",
+            output_field=models.TextField(),
+        )
+
+        return queryset.annotate(search_fields=search_fields).filter(
+            search_fields__icontains=value
+        )
+
+    def filter_type(self, queryset, name, value):
+        query = Q()
+        if TypeChoices.EXPERIMENT in value:
+            query |= Q(is_rollout=False)
+        if TypeChoices.ROLLOUT in value:
+            query |= Q(is_rollout=True)
+        return queryset.filter(query)
+
+    def filter_takeaways(self, queryset, name, value):
+        query = Q()
+        if NimbusExperiment.Takeaways.DAU_GAIN in value:
+            query |= Q(takeaways_metric_gain=True)
+        if NimbusExperiment.Takeaways.QBR_LEARNING in value:
+            query |= Q(takeaways_qbr_learning=True)
+        return queryset.filter(query)

--- a/experimenter/experimenter/nimbus_ui_new/templates/common/header.html
+++ b/experimenter/experimenter/nimbus_ui_new/templates/common/header.html
@@ -1,9 +1,9 @@
 {% load static %}
 
-<nav class="navbar mb-2">
+<nav class="navbar">
   <div class="container-fluid">
-    <a class="navbar-brand d-flex align-items-center"
-       href="{% url 'nimbus-list' %}">
+    <a class="navbar-brand d-flex align-items-center fs-3"
+       href="{% url 'nimbus-new-list' %}">
       <img src="{% static 'assets/logo.svg' %}"
            alt="Logo"
            width="30"

--- a/experimenter/experimenter/nimbus_ui_new/templates/common/list_tab.html
+++ b/experimenter/experimenter/nimbus_ui_new/templates/common/list_tab.html
@@ -1,12 +1,20 @@
 <li class="nav-item">
-  <button class="nav-link {% if active_status == status %}active{% endif %}"
-          hx-get="?status={{ status }}"
-          hx-select="#experiment-list"
-          hx-target="#experiment-list"
-          hx-swap="outerHTML"
-          hx-push-url="true"
-          hx-indicator="#htmx-spinner">
-    <i class="{{ icon }}"></i>
-    {{ status }} ({{ count }})
-  </button>
+  <form hx-get="{% url "nimbus-new-list" %}"
+        hx-trigger="submit"
+        hx-select="#content"
+        hx-target="#content"
+        hx-swap="outerHTML"
+        hx-push-url="true">
+    <input type="hidden" name="status" value="{{ status }}">
+    {% for field in filter.form %}
+      {% if field.name != "status" %}
+        {% if field.value %}{{ field.as_hidden }}{% endif %}
+      {% endif %}
+    {% endfor %}
+    <button type="submit"
+            class="nav-link pb-3 {% if active_status == status %}active{% endif %}">
+      <i class="{{ icon }}"></i>
+      {{ status }} ({{ count }})
+    </button>
+  </form>
 </li>

--- a/experimenter/experimenter/nimbus_ui_new/templates/common/sidebar_select.html
+++ b/experimenter/experimenter/nimbus_ui_new/templates/common/sidebar_select.html
@@ -1,9 +1,7 @@
 <div class="row">
-  <div class="col  d-flex align-items-center">
-    <i class="{{ icon }} pb-2 ps-1" style="width:30px;"></i>
-    <select class="form-select bg-body-tertiary border-0 mb-2"
-            aria-label="Default select example">
-      <option selected>{{ placeholder }}</option>
-    </select>
+  <div class="col d-flex align-items-center mb-2">
+    <i class="{{ icon }}" style="width:30px;"></i>
+    {% include "django/forms/widgets/select.html" %}
+
   </div>
 </div>

--- a/experimenter/experimenter/nimbus_ui_new/templates/common/with_sidebar.html
+++ b/experimenter/experimenter/nimbus_ui_new/templates/common/with_sidebar.html
@@ -3,7 +3,7 @@
 {% load static %}
 
 {% block content %}
-  <div class="row">
+  <div id="content" class="row px-3">
     <div class="col-2">
       {% block sidebar %}
       {% endblock sidebar %}

--- a/experimenter/experimenter/nimbus_ui_new/templates/experimenter_base.html
+++ b/experimenter/experimenter/nimbus_ui_new/templates/experimenter_base.html
@@ -17,16 +17,33 @@
     <script src="https://unpkg.com/htmx.org@1.9.12"></script>
     {% bootstrap_css %}
     {% bootstrap_javascript %}
+    <script src="https://code.jquery.com/jquery-3.7.1.min.js"
+            integrity="sha256-/JqT3SQfawRcv/BIHPThkBvs0OEvtFFmqPF/lYI/Cxo="
+            crossorigin="anonymous"></script>
+    <!-- Latest compiled and minified CSS -->
+    <link rel="stylesheet"
+          href="https://cdn.jsdelivr.net/npm/bootstrap-select@1.14.0-beta3/dist/css/bootstrap-select.min.css">
+    <!-- Latest compiled and minified JavaScript -->
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap-select@1.14.0-beta3/dist/js/bootstrap-select.min.js"></script>
   </head>
   <body class="bg-body-tertiary">
-    <div class="container-fluid">
+    <div class="container-fluid bg-body border-bottom border-1 mb-4 py-1">
       {% include "common/header.html" %}
 
+    </div>
+    <div class="container-fluid">
       {% block content %}
       {% endblock content %}
 
       {% include "common/footer.html" %}
 
     </div>
+    <script>
+      {% block extrascripts %}
+      {% endblock extrascripts %}
+
+
+
+    </script>
   </body>
 </html>

--- a/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/list.html
+++ b/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/list.html
@@ -7,26 +7,14 @@
 {% endblock title %}
 
 {% block sidebar %}
-  <button class="btn btn-primary w-100 mb-2">
-    <i class="fa-regular fa-pen-to-square"></i>
-    Create Experiment
-  </button>
-  <input class="form-control mb-2 bg-body-tertiary"
-         type="text"
-         placeholder="🔎 Search"
-         aria-label="default input example">
-  {% include "common/sidebar_select.html" with placeholder="All Features" icon="fa-solid fa-boxes-stacked" %}
-  {% include "common/sidebar_select.html" with placeholder="All Applications" icon="fa-solid fa-desktop" %}
-  {% include "common/sidebar_select.html" with placeholder="All Owners" icon="fa-solid fa-users" %}
-  {% include "common/sidebar_select.html" with placeholder="All Versions" icon="fa-solid fa-code-branch" %}
-  {% include "common/sidebar_select.html" with placeholder="All Channels" icon="fa-solid fa-road" %}
-  {% include "common/sidebar_select.html" with placeholder="All Types" icon="fa-solid fa-flask-vial" %}
-  {% include "common/sidebar_select.html" with placeholder="All Team Projects" icon="fa-solid fa-person-chalkboard" %}
-  {% include "common/sidebar_select.html" with placeholder="All Audiences" icon="fa-solid fa-users-rectangle" %}
-  {% include "common/sidebar_select.html" with placeholder="All Takeaways" icon="fa-solid fa-list-check" %}
-  {% include "common/sidebar_select.html" with placeholder="All QA Statuses" icon="fa-solid fa-user-shield" %}
-  {% include "common/sidebar_select.html" with placeholder="All Subscribers" icon="fa-solid fa-bell" %}
-
+  <form hx-get="{% url "nimbus-new-list" %}"
+        hx-trigger="keyup,mouseup delay:100ms"
+        hx-select="#experiment-list"
+        hx-target="#experiment-list"
+        hx-swap="outerHTML"
+        hx-push-url="true">
+    {% for field in filter.form %}{{ field }}{% endfor %}
+  </form>
 {% endblock sidebar %}
 
 {% block main_content %}
@@ -40,40 +28,11 @@
       {% include "common/list_tab.html" with status="Archived" count=status_counts.Archived icon="fa-solid fa-box-archive" %}
       {% include "common/list_tab.html" with status="MyExperiments" count=status_counts.MyExperiments icon="fa-solid fa-heart" %}
 
-      <li class="nav-item ms-auto d-flex align-items-center">
-        <i id="htmx-spinner"
-           class="fa-solid fa-spinner fa-spin ms-2 htmx-indicator"></i>
-        {% if page_obj.has_previous %}
-          <button class="btn btn-link"
-                  hx-get="{% pagination_url page_obj.previous_page_number %}"
-                  hx-select="#experiment-list"
-                  hx-target="#experiment-list"
-                  hx-swap="outerHTML"
-                  hx-push-url="true"
-                  hx-indicator="#htmx-spinner">
-            <i class="fa-solid fa-angle-left"></i>
-          </button>
-        {% else %}
-          <a class="btn btn-link disabled">
-            <i class="fa-solid fa-angle-left"></i>
-          </a>
-        {% endif %}
-        {{ page_obj.number }}/{{ page_obj.paginator.num_pages }}
-        {% if page_obj.has_next %}
-          <a class="btn btn-link"
-             hx-get="{% pagination_url page_obj.next_page_number %}"
-             hx-select="#experiment-list"
-             hx-target="#experiment-list"
-             hx-swap="outerHTML"
-             hx-push-url="true"
-             hx-indicator="#htmx-spinner">
-            <i class="fa-solid fa-angle-right"></i>
-          </a>
-        {% else %}
-          <a class="btn btn-link disabled">
-            <i class="fa-solid fa-angle-right"></i>
-          </a>
-        {% endif %}
+      <li class="nav-item ms-auto">
+        <a class="btn btn-primary" href="{% url "nimbus-create" %}">
+          <i class="fa-regular fa-pen-to-square"></i>
+          Create Experiment
+        </a>
       </li>
     </ul>
     <div class="border border-1 border-top-0 border-bottom-0 mb-3">
@@ -141,5 +100,46 @@
         </tbody>
       </table>
     </div>
+    {% if page_obj.paginator.num_pages > 1 %}
+      <div class="row">
+        <div class="col text-center">
+          <ul class="pagination justify-content-center">
+            {% if page_obj.has_previous %}
+              <li class="page-item">
+                <a class="page-link"
+                   href="{% pagination_url page_obj.previous_page_number %}"
+                   tabindex="-1">Previous</a>
+              </li>
+            {% else %}
+              <li class="page-item disabled">
+                <a class="page-link" href="#">Previous</a>
+              </li>
+            {% endif %}
+            {% for page_num in page_obj.paginator.page_range %}
+              <li class="page-item {% if page_obj.number == page_num %}active{% endif %}">
+                <a class="page-link" href="{% pagination_url page_num %}">{{ page_num }}</a>
+              </li>
+            {% endfor %}
+            {% if page_obj.has_next %}
+              <li class="page-item">
+                <a class="page-link"
+                   href="{% pagination_url page_obj.next_page_number %}">Next</a>
+              </li>
+            {% else %}
+              <li class="page-item disabled">
+                <a class="page-link" href="#">Next</a>
+              </li>
+            {% endif %}
+          </ul>
+        </div>
+      </div>
+    {% endif %}
   </div>
 {% endblock main_content %}
+
+{% block extrascripts %}
+  {{ block.super }}
+  document.body.addEventListener('htmx:afterSwap', function(evt) {
+  $('.selectpicker').selectpicker()
+  });
+{% endblock %}

--- a/experimenter/experimenter/nimbus_ui_new/views.py
+++ b/experimenter/experimenter/nimbus_ui_new/views.py
@@ -1,47 +1,9 @@
-import django_filters
 from django.conf import settings
-from django.db import models
 from django.views.generic import DetailView
 from django_filters.views import FilterView
 
 from experimenter.experiments.models import NimbusExperiment
-
-
-class StatusChoices(models.TextChoices):
-    DRAFT = NimbusExperiment.Status.DRAFT.value
-    PREVIEW = NimbusExperiment.Status.PREVIEW.value
-    LIVE = NimbusExperiment.Status.LIVE.value
-    COMPLETE = NimbusExperiment.Status.COMPLETE.value
-    REVIEW = "Review"
-    ARCHIVED = "Archived"
-    MY_EXPERIMENTS = "MyExperiments"
-
-
-class NimbusExperimentFilter(django_filters.FilterSet):
-    status = django_filters.ChoiceFilter(
-        choices=StatusChoices.choices, method="filter_status"
-    )
-
-    class Meta:
-        model = NimbusExperiment
-        fields = ["status"]
-
-    def filter_status(self, queryset, name, value):
-        match value:
-            case StatusChoices.REVIEW:
-                return queryset.filter(
-                    status=NimbusExperiment.Status.DRAFT,
-                    publish_status=NimbusExperiment.PublishStatus.REVIEW,
-                )
-            case StatusChoices.ARCHIVED:
-                return queryset.filter(is_archived=True)
-            case StatusChoices.MY_EXPERIMENTS:
-                return queryset.filter(owner=self.request.user)
-            case _:
-                return queryset.filter(
-                    status=value,
-                    is_archived=False,
-                ).exclude(publish_status=NimbusExperiment.PublishStatus.REVIEW)
+from experimenter.nimbus_ui_new.filtersets import NimbusExperimentFilter, StatusChoices
 
 
 class NimbusChangeLogsView(DetailView):

--- a/experimenter/experimenter/urls.py
+++ b/experimenter/experimenter/urls.py
@@ -27,6 +27,7 @@ urlpatterns = [
     re_path(r"^experiments/", include("experimenter.legacy.legacy_experiments.urls")),
     re_path(r"^nimbus_new/", include("experimenter.nimbus_ui_new.urls")),
     re_path(r"^nimbus/", NimbusUIView.as_view(), name="nimbus-list"),
+    re_path(r"^nimbus/new/", NimbusUIView.as_view(), name="nimbus-create"),
     re_path(r"^nimbus/(?P<slug>[\w-]+)/", NimbusUIView.as_view(), name="nimbus-detail"),
     re_path(r"^legacy/$", ExperimentListView.as_view(), name="home"),
     re_path(


### PR DESCRIPTION
Because

* We want to be able to filter experiments on the new list page
* It should use HTMX to update the table dynamically
* It should co operate with the status filter tabs
* The search filter should update as you type

This commit

* Adds a filterset to the new list view page
* Uses HTMX to update the table as filters change

fixes #10684

https://github.com/mozilla/experimenter/assets/119884/0138894d-be18-4019-b734-6e68ad34b440


