### PR TITLE
feat(nimbus): Update conclusion recommendation in changelogs

### DIFF
--- a/experimenter/experimenter/experiments/migrations/0272_update_conclusion_recommendation_in_changelogs.py
+++ b/experimenter/experimenter/experiments/migrations/0272_update_conclusion_recommendation_in_changelogs.py
@@ -1,0 +1,27 @@
+from django.db import migrations
+
+
+def update_conclusion_recommendation_in_changelogs(apps, schema_editor):
+    NimbusExperiment = apps.get_model("experiments", "NimbusExperiment")
+
+    for experiment in NimbusExperiment.objects.all():
+
+        for changelog in experiment.changes.all():
+            experiment_data = changelog.experiment_data
+            if "conclusion_recommendation" in experiment_data:
+                old_value = experiment_data.pop("conclusion_recommendation")
+                new_value = [old_value] if old_value else []
+                experiment_data["conclusion_recommendations"] = new_value
+                changelog.experiment_data = experiment_data
+                changelog.save()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("experiments", "0271_remove_nimbusexperiment_conclusion_recommendation"),
+    ]
+
+    operations = [
+        migrations.RunPython(update_conclusion_recommendation_in_changelogs),
+    ]

--- a/experimenter/experimenter/experiments/tests/test_migrations.py
+++ b/experimenter/experimenter/experiments/tests/test_migrations.py
@@ -4,11 +4,11 @@ from django_test_migrations.contrib.unittest_case import MigratorTestCase
 class TestMigrations(MigratorTestCase):
     migrate_from = (
         "experiments",
-        "0269_nimbusexperiment_conclusion_recommendations",
+        "0271_remove_nimbusexperiment_conclusion_recommendation",
     )
     migrate_to = (
         "experiments",
-        "0270_alter_conclusion_recommendations",
+        "0272_update_conclusion_recommendation_in_changelogs",
     )
 
     def prepare(self):
@@ -17,14 +17,22 @@ class TestMigrations(MigratorTestCase):
         NimbusExperiment = self.old_state.apps.get_model(
             "experiments", "NimbusExperiment"
         )
-        owner = User.objects.create()
+        NimbusChangeLog = self.old_state.apps.get_model("experiments", "NimbusChangeLog")
+        owner = User.objects.create(username="testuser")
 
-        # Create NimbusExperiment objects with old values for conclusion_recommendation
-        NimbusExperiment.objects.create(
+        experiment = NimbusExperiment.objects.create(
             owner=owner,
             slug="should_change",
             name="should_change",
-            conclusion_recommendation="RERUN",
+            conclusion_recommendations=[],
+        )
+
+        NimbusChangeLog.objects.create(
+            experiment=experiment,
+            changed_by=owner,
+            experiment_data={"conclusion_recommendation": "RERUN"},
+            message="Initial creation",
+            changed_on="2023-05-12T17:00:48.454269Z",
         )
 
     def test_migration(self):
@@ -32,8 +40,10 @@ class TestMigrations(MigratorTestCase):
         NimbusExperiment = self.new_state.apps.get_model(
             "experiments", "NimbusExperiment"
         )
-
+        NimbusChangeLog = self.new_state.apps.get_model("experiments", "NimbusChangeLog")
+        experiment = NimbusExperiment.objects.get(slug="should_change")
+        changelog = NimbusChangeLog.objects.get(experiment=experiment)
         self.assertEqual(
-            NimbusExperiment.objects.get(slug="should_change").conclusion_recommendations,
-            ["RERUN"],
+            changelog.experiment_data.get("conclusion_recommendations"), ["RERUN"]
         )
+        self.assertNotIn("conclusion_recommendation", changelog.experiment_data)


### PR DESCRIPTION
Because

- Since we have removed old field `conclusion_recommendation`, but in the changelogs we still have that field in experiment_data

This commit

- Changes the reference to new field `conclusion_recommendations` in the changelogs

Fixes #10780 