### PR TITLE
feat(nimbus): add sorting to new list page

### DIFF
--- a/experimenter/experimenter/nimbus_ui_new/filtersets.py
+++ b/experimenter/experimenter/nimbus_ui_new/filtersets.py
@@ -26,6 +26,25 @@ class TypeChoices(models.TextChoices):
     EXPERIMENT = "Experiment"
 
 
+class SortChoices(models.TextChoices):
+    NAME_UP = "name"
+    NAME_DOWN = "-name"
+    QA_UP = "qa_status"
+    QA_DOWN = "-qa_status"
+    APPLICATION_UP = "application"
+    APPLICATION_DOWN = "-application"
+    CHANNEL_UP = "channel"
+    CHANNEL_DOWN = "-channel"
+    SIZE_UP = "population_percent"
+    SIZE_DOWN = "-population_percent"
+    FEATURES_UP = "feature_configs__slug"
+    FEATURES_DOWN = "-feature_configs__slug"
+    VERSIONS_UP = "firefox_min_version"
+    VERSIONS_DOWN = "-firefox_min_version"
+    DATES_UP = "_start_date"
+    DATES_DOWN = "-_start_date"
+
+
 class MultiSelectWidget(forms.SelectMultiple):
     template_name = "common/sidebar_select.html"
 
@@ -40,6 +59,11 @@ class MultiSelectWidget(forms.SelectMultiple):
 
 
 class NimbusExperimentFilter(django_filters.FilterSet):
+    sort = django_filters.ChoiceFilter(
+        method="filter_sort",
+        choices=SortChoices.choices,
+        widget=forms.widgets.HiddenInput,
+    )
     status = django_filters.ChoiceFilter(
         method="filter_status",
         choices=StatusChoices.choices,
@@ -214,6 +238,7 @@ class NimbusExperimentFilter(django_filters.FilterSet):
     class Meta:
         model = NimbusExperiment
         fields = [
+            "sort",
             "status",
             "search",
             "type",
@@ -231,6 +256,9 @@ class NimbusExperimentFilter(django_filters.FilterSet):
             "owner",
             "subscribers",
         ]
+
+    def filter_sort(self, queryset, name, value):
+        return queryset.order_by(value)
 
     def filter_status(self, queryset, name, value):
         match value:

--- a/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/list.html
+++ b/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/list.html
@@ -39,14 +39,15 @@
       <table class="table table-striped mb-0">
         <thead>
           <tr>
-            <th scope="col">Name</th>
-            <th scope="col">QA</th>
-            <th scope="col">Application</th>
-            <th scope="col">Channel</th>
-            <th scope="col">Size</th>
-            <th scope="col">Features</th>
-            <th scope="col">Versions</th>
-            <th scope="col">Dates</th>
+            {% include "nimbus_experiments/table_header.html" with field="Name" up=sort_choices.NAME_UP down=sort_choices.NAME_DOWN %}
+            {% include "nimbus_experiments/table_header.html" with field="QA" up=sort_choices.QA_UP down=sort_choices.QA_DOWN %}
+            {% include "nimbus_experiments/table_header.html" with field="Application" up=sort_choices.APPLICATION_UP down=sort_choices.APPLICATION_DOWN %}
+            {% include "nimbus_experiments/table_header.html" with field="Channel" up=sort_choices.CHANNEL_UP down=sort_choices.CHANNEL_DOWN %}
+            {% include "nimbus_experiments/table_header.html" with field="Size" up=sort_choices.SIZE_UP down=sort_choices.SIZE_DOWN %}
+            {% include "nimbus_experiments/table_header.html" with field="Features" up=sort_choices.FEATURES_UP down=sort_choices.FEATURES_DOWN %}
+            {% include "nimbus_experiments/table_header.html" with field="Versions" up=sort_choices.VERSIONS_UP down=sort_choices.VERSIONS_DOWN %}
+            {% include "nimbus_experiments/table_header.html" with field="Dates" up=sort_choices.DATES_UP down=sort_choices.DATES_DOWN %}
+
           </tr>
         </thead>
         <tbody>

--- a/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/table_header.html
+++ b/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/table_header.html
@@ -1,0 +1,24 @@
+<th scope="col">
+  <form hx-get="{% url "nimbus-new-list" %}"
+        hx-trigger="submit"
+        hx-select="#content"
+        hx-target="#content"
+        hx-swap="outerHTML"
+        hx-push-url="true">
+    <input type="hidden"
+           name="sort"
+           value="{% if filter.form.sort.value == up %}{{ down }}{% else %}{{ up }}{% endif %}">
+    {% for field in filter.form %}
+      {% if field.name != "sort" %}
+        {% if field.value %}{{ field.as_hidden }}{% endif %}
+      {% endif %}
+    {% endfor %}
+    <button type="submit" class="nav-link">
+      <div class="d-flex align-items-center">
+        {{ field }}
+        {% if filter.form.sort.value == up %}<i class="ps-2 fa-solid fa-chevron-up"></i>{% endif %}
+        {% if filter.form.sort.value == down %}<i class="ps-2 fa-solid fa-chevron-down"></i>{% endif %}
+      </div>
+    </button>
+  </form>
+</th>

--- a/experimenter/experimenter/nimbus_ui_new/views.py
+++ b/experimenter/experimenter/nimbus_ui_new/views.py
@@ -3,7 +3,11 @@ from django.views.generic import DetailView
 from django_filters.views import FilterView
 
 from experimenter.experiments.models import NimbusExperiment
-from experimenter.nimbus_ui_new.filtersets import NimbusExperimentFilter, StatusChoices
+from experimenter.nimbus_ui_new.filtersets import (
+    NimbusExperimentFilter,
+    SortChoices,
+    StatusChoices,
+)
 
 
 class NimbusChangeLogsView(DetailView):
@@ -14,7 +18,7 @@ class NimbusChangeLogsView(DetailView):
 
 class NimbusExperimentsListView(FilterView):
     model = NimbusExperiment
-    queryset = NimbusExperiment.objects.all()
+    queryset = NimbusExperiment.objects.all().order_by("-_updated_date_time")
     filterset_class = NimbusExperimentFilter
     context_object_name = "experiments"
     template_name = "nimbus_experiments/list.html"
@@ -60,5 +64,6 @@ class NimbusExperimentsListView(FilterView):
         return super().get_context_data(
             active_status=kwargs["filter"].data["status"],
             status_counts=status_counts,
+            sort_choices=SortChoices,
             **kwargs,
         )


### PR DESCRIPTION
Because

* We are building a new list page in django templates and htmx
* We want to be able to sort the table by the column headers

This commit

* Adds sorting by each of the column headers
* Defaults to sorting by most recently updated (similar to previous list pages)

fixes #10682

https://github.com/mozilla/experimenter/assets/119884/7253c112-ed66-44a5-9bcc-6f501c57734b


