### PR TITLE
feat(nimbus): persist theme switcher in new nimbus ui

### DIFF
--- a/experimenter/experimenter/nimbus_ui_new/static/js/scripts/theme.js
+++ b/experimenter/experimenter/nimbus_ui_new/static/js/scripts/theme.js
@@ -1,0 +1,33 @@
+(() => {
+  const LIGHT = "light";
+  const DARK = "dark";
+  const getStoredTheme = () => localStorage.getItem("theme");
+  const setStoredTheme = (theme) => localStorage.setItem("theme", theme);
+
+  const getPreferredTheme = () => {
+    const storedTheme = getStoredTheme();
+
+    if (storedTheme) {
+      return storedTheme;
+    }
+
+    return window.matchMedia("(prefers-color-scheme: dark)").matches
+      ? DARK
+      : LIGHT;
+  };
+
+  const setTheme = (theme) => {
+    const themeSwitcher = document.querySelector("#theme-selector");
+    themeSwitcher.checked = theme === LIGHT;
+    document.documentElement.setAttribute("data-bs-theme", theme);
+    setStoredTheme(theme);
+  };
+
+  setTheme(getPreferredTheme());
+
+  const themeSwitcher = document.querySelector("#theme-selector");
+  themeSwitcher.addEventListener("change", function () {
+    const theme = themeSwitcher.checked ? LIGHT : DARK;
+    setTheme(theme);
+  });
+})();

--- a/experimenter/experimenter/nimbus_ui_new/static/webpack.config.js
+++ b/experimenter/experimenter/nimbus_ui_new/static/webpack.config.js
@@ -5,6 +5,7 @@ module.exports = {
     entry: {
         app: './js/index.js',
         experiment_list: './js/scripts/experiment_list.js',
+        theme: './js/scripts/theme.js',
     },
     output: {
         filename: '[name].bundle.js',

--- a/experimenter/experimenter/nimbus_ui_new/templates/common/header.html
+++ b/experimenter/experimenter/nimbus_ui_new/templates/common/header.html
@@ -59,9 +59,7 @@
           <input id="theme-selector"
                  class="form-check-input"
                  type="checkbox"
-                 role="switch"
-                 onchange="document.documentElement.setAttribute('data-bs-theme', document.getElementById('theme-selector').checked ? 'light': 'dark')"
-                 checked>
+                 role="switch">
         </div>
       </li>
     </ul>

--- a/experimenter/experimenter/nimbus_ui_new/templates/experimenter_base.html
+++ b/experimenter/experimenter/nimbus_ui_new/templates/experimenter_base.html
@@ -27,6 +27,7 @@
       {% include "common/footer.html" %}
 
     </div>
+    <script src="{% static 'nimbus_ui_new/theme.bundle.js' %}"></script>
     {% block extrascripts %}
     {% endblock extrascripts %}
 


### PR DESCRIPTION
Because

* We are implementing the new Nimbus UI in bootstrap 5 which supports light/dark themes
* We can add a toggle to switch themes
* We should persist the chosen theme

This commit

* Persists the chosen theme in localstorage
* Defaults to system light/dark theme

fixes #10685


https://github.com/mozilla/experimenter/assets/119884/cd8539dc-48fd-42e2-adf6-1b886c94d355

