### PR TITLE
bug(nimbus): use computed duration on new list page

### DIFF
--- a/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/list.html
+++ b/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/list.html
@@ -91,7 +91,7 @@
                   <br>
                   {{ experiment.computed_end_date|date:"M j/y" }}
                   <br>
-                  ({{ experiment.proposed_duration }} days)
+                  ({{ experiment.computed_duration_days }} days)
                 {% else %}
                   N/A
                 {% endif %}


### PR DESCRIPTION
Because

* We were using the proposed duration and not the computed duration on the list page
* This resulted in the wrong number of days being displayed for each completed experiment

This commit

* Uses computed duration instead of proposed duration on the new list page

fixes #10793

