### PR TITLE
feat(nimbus): add reporting link to new list page

### DIFF
--- a/experimenter/experimenter/nimbus_ui_new/templates/common/header.html
+++ b/experimenter/experimenter/nimbus_ui_new/templates/common/header.html
@@ -21,6 +21,15 @@
         </a>
       </li>
       <li class="nav-item">
+        <a href="{% url "nimbus-experiments-csv" %}"
+           class="nav-link"
+           target="_blank"
+           rel="noreferrer">
+          <i class="fa-solid fa-file-arrow-down"></i>
+          Reports
+        </a>
+      </li>
+      <li class="nav-item">
         <a href="https://mozilla-hub.atlassian.net/secure/CreateIssueDetails!init.jspa?pid=10203&issuetype=10097"
            class="nav-link"
            target="_blank"


### PR DESCRIPTION
Because

* We need to include the report download link on the new list page

This commit

* Adds teh report download link to the new list page

fixes #10800

<img width="613" alt="image" src="https://github.com/mozilla/experimenter/assets/119884/8265026d-08e1-4686-8253-f3059ec24d77">
