### PR TITLE
chore(nimbus): prefetch feature configs on new nimbus list page

### DIFF
--- a/experimenter/experimenter/nimbus_ui_new/views.py
+++ b/experimenter/experimenter/nimbus_ui_new/views.py
@@ -18,7 +18,11 @@ class NimbusChangeLogsView(DetailView):
 
 class NimbusExperimentsListView(FilterView):
     model = NimbusExperiment
-    queryset = NimbusExperiment.objects.all().order_by("-_updated_date_time")
+    queryset = (
+        NimbusExperiment.objects.all()
+        .order_by("-_updated_date_time")
+        .prefetch_related("feature_configs")
+    )
     filterset_class = NimbusExperimentFilter
     context_object_name = "experiments"
     template_name = "nimbus_experiments/list.html"


### PR DESCRIPTION
Because

* Now that all the fields are in place for the new nimbus list page we can clean up the db queries
* Looks like the only n+1 related call is to feature configs

This commit

* Prefetches feature configs on the new nimbus list page

fixes #10713
