### PR TITLE
feat(nimbus): separate view for experiment table in new nimbus ui

### DIFF
--- a/experimenter/experimenter/nimbus_ui_new/templates/common/list_tab.html
+++ b/experimenter/experimenter/nimbus_ui_new/templates/common/list_tab.html
@@ -1,9 +1,8 @@
 <li class="nav-item">
-  <form hx-get="{% url "nimbus-new-list" %}"
+  <form id="tab-form"
+        hx-get="{% url "nimbus-new-table" %}"
         hx-trigger="submit"
-        hx-select="#content"
-        hx-target="#content"
-        hx-swap="outerHTML"
+        hx-target="#experiment-list"
         hx-push-url="true">
     <input type="hidden" name="status" value="{{ status }}">
     {% for field in filter.form %}

--- a/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/list.html
+++ b/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/list.html
@@ -7,11 +7,10 @@
 {% endblock title %}
 
 {% block sidebar %}
-  <form hx-get="{% url "nimbus-new-list" %}"
+  <form id="filter-form"
+        hx-get="{% url "nimbus-new-table" %}"
         hx-trigger="keyup,mouseup delay:100ms"
-        hx-select="#experiment-list"
         hx-target="#experiment-list"
-        hx-swap="outerHTML"
         hx-push-url="true">
     {% for field in filter.form %}{{ field }}{% endfor %}
   </form>
@@ -19,128 +18,21 @@
 
 {% block main_content %}
   <div id="experiment-list">
-    <ul class="nav nav-tabs">
-      {% include "common/list_tab.html" with status="Live" count=status_counts.Live icon="fa-regular fa-circle-play" %}
-      {% include "common/list_tab.html" with status="Review" count=status_counts.Review icon="fa-solid fa-eye" %}
-      {% include "common/list_tab.html" with status="Preview" count=status_counts.Preview icon="fa-solid fa-person-circle-check" %}
-      {% include "common/list_tab.html" with status="Complete" count=status_counts.Complete icon="fa-solid fa-vial-circle-check" %}
-      {% include "common/list_tab.html" with status="Draft" count=status_counts.Draft icon="fa-solid fa-pen-to-square" %}
-      {% include "common/list_tab.html" with status="Archived" count=status_counts.Archived icon="fa-solid fa-box-archive" %}
-      {% include "common/list_tab.html" with status="MyExperiments" count=status_counts.MyExperiments icon="fa-solid fa-heart" %}
+    {% include "nimbus_experiments/table.html" with experiments=experiments page_obj=page_obj filter=filter %}
 
-      <li class="nav-item ms-auto">
-        <a class="btn btn-primary" href="{% url "nimbus-create" %}">
-          <i class="fa-regular fa-pen-to-square"></i>
-          Create Experiment
-        </a>
-      </li>
-    </ul>
-    <div class="border border-1 border-top-0 border-bottom-0 mb-3">
-      <table class="table table-striped mb-0">
-        <thead>
-          <tr>
-            {% include "nimbus_experiments/table_header.html" with field="Name" up=sort_choices.NAME_UP down=sort_choices.NAME_DOWN %}
-            {% include "nimbus_experiments/table_header.html" with field="QA" up=sort_choices.QA_UP down=sort_choices.QA_DOWN %}
-            {% include "nimbus_experiments/table_header.html" with field="Application" up=sort_choices.APPLICATION_UP down=sort_choices.APPLICATION_DOWN %}
-            {% include "nimbus_experiments/table_header.html" with field="Channel" up=sort_choices.CHANNEL_UP down=sort_choices.CHANNEL_DOWN %}
-            {% include "nimbus_experiments/table_header.html" with field="Size" up=sort_choices.SIZE_UP down=sort_choices.SIZE_DOWN %}
-            {% include "nimbus_experiments/table_header.html" with field="Features" up=sort_choices.FEATURES_UP down=sort_choices.FEATURES_DOWN %}
-            {% include "nimbus_experiments/table_header.html" with field="Versions" up=sort_choices.VERSIONS_UP down=sort_choices.VERSIONS_DOWN %}
-            {% include "nimbus_experiments/table_header.html" with field="Dates" up=sort_choices.DATES_UP down=sort_choices.DATES_DOWN %}
-
-          </tr>
-        </thead>
-        <tbody>
-          {% for experiment in experiments %}
-            <tr>
-              <th scope="row">
-                <a href="{% url "nimbus-detail" slug=experiment.slug %}">{{ experiment.name }}</a>
-              </th>
-              <td>
-                {% if experiment.qa_status == 'NOT SET' %}<i class="fa-regular fa-circle-question"></i>{% endif %}
-                {% if experiment.qa_status == 'GREEN' %}
-                  <span class="text-success"><i class="fa-regular fa-circle-check"></i></span>
-                {% endif %}
-                {% if experiment.qa_status == 'YELLOW' %}
-                  <span class="text-warning"><i class="fa-regular fa-circle-pause"></i></span>
-                {% endif %}
-                {% if experiment.qa_status == 'RED' %}
-                  <span class="text-danger"><i class="fa-regular fa-circle-xmark"></i></span>
-                {% endif %}
-              </td>
-              <td>{{ experiment.get_application_display }}</td>
-              <td>{{ experiment.get_channel_display }}</td>
-              <td>{{ experiment.population_percent|floatformat }}%</td>
-              <td>
-                {% for feature in experiment.feature_configs.all %}
-                  {{ feature.name }}
-                  <br>
-                {% endfor %}
-              </td>
-              <td>
-                {{ experiment.get_firefox_min_version_display }}
-                {% if experiment.firefox_max_version %}
-                  - {{ experiment.get_firefox_max_version_display }}
-                {% else %}
-                  +
-                {% endif %}
-              </td>
-              <td>
-                {% if experiment.start_date %}
-                  {{ experiment.start_date|date:"M j/y" }} -
-                  <br>
-                  {{ experiment.computed_end_date|date:"M j/y" }}
-                  <br>
-                  ({{ experiment.computed_duration_days }} days)
-                {% else %}
-                  N/A
-                {% endif %}
-              </td>
-            </tr>
-          {% endfor %}
-        </tbody>
-      </table>
-    </div>
-    {% if page_obj.paginator.num_pages > 1 %}
-      <div class="row">
-        <div class="col text-center">
-          <ul class="pagination justify-content-center">
-            {% if page_obj.has_previous %}
-              <li class="page-item">
-                <a class="page-link"
-                   href="{% pagination_url page_obj.previous_page_number %}"
-                   tabindex="-1">Previous</a>
-              </li>
-            {% else %}
-              <li class="page-item disabled">
-                <a class="page-link" href="#">Previous</a>
-              </li>
-            {% endif %}
-            {% for page_num in page_obj.paginator.page_range %}
-              <li class="page-item {% if page_obj.number == page_num %}active{% endif %}">
-                <a class="page-link" href="{% pagination_url page_num %}">{{ page_num }}</a>
-              </li>
-            {% endfor %}
-            {% if page_obj.has_next %}
-              <li class="page-item">
-                <a class="page-link"
-                   href="{% pagination_url page_obj.next_page_number %}">Next</a>
-              </li>
-            {% else %}
-              <li class="page-item disabled">
-                <a class="page-link" href="#">Next</a>
-              </li>
-            {% endif %}
-          </ul>
-        </div>
-      </div>
-    {% endif %}
   </div>
 {% endblock main_content %}
 
 {% block extrascripts %}
   {{ block.super }}
   document.body.addEventListener('htmx:afterSwap', function(evt) {
-  $('.selectpicker').selectpicker()
+  $('.selectpicker').selectpicker();
+  // After reloading the table, we must update the values for status and sort in the sidebar form
+  // since it will not have been reloaded in the htmx get call
+  const urlParams = new URLSearchParams(window.location.search);
+  const sortValue = urlParams.get('sort');
+  const statusValue = urlParams.get('status');
+  $('#filter-form input[name="status"]').each((i, e) => e.value = statusValue);
+  $('#filter-form input[name="sort"]').each((i, e) => e.value = sortValue);
   });
 {% endblock %}

--- a/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/table.html
+++ b/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/table.html
@@ -1,0 +1,119 @@
+{% load nimbus_extras %}
+
+<ul class="nav nav-tabs">
+  {% include "common/list_tab.html" with status="Live" count=status_counts.Live icon="fa-regular fa-circle-play" %}
+  {% include "common/list_tab.html" with status="Review" count=status_counts.Review icon="fa-solid fa-eye" %}
+  {% include "common/list_tab.html" with status="Preview" count=status_counts.Preview icon="fa-solid fa-person-circle-check" %}
+  {% include "common/list_tab.html" with status="Complete" count=status_counts.Complete icon="fa-solid fa-vial-circle-check" %}
+  {% include "common/list_tab.html" with status="Draft" count=status_counts.Draft icon="fa-solid fa-pen-to-square" %}
+  {% include "common/list_tab.html" with status="Archived" count=status_counts.Archived icon="fa-solid fa-box-archive" %}
+  {% include "common/list_tab.html" with status="MyExperiments" count=status_counts.MyExperiments icon="fa-solid fa-heart" %}
+
+  <li class="nav-item ms-auto">
+    <a class="btn btn-primary" href="{% url "nimbus-create" %}">
+      <i class="fa-regular fa-pen-to-square"></i>
+      Create Experiment
+    </a>
+  </li>
+</ul>
+<div id="experiment-list"></div>
+<div class="border border-1 border-top-0 border-bottom-0 mb-3">
+  <table class="table table-striped mb-0">
+    <thead>
+      <tr>
+        {% include "nimbus_experiments/table_header.html" with field="Name" up=sort_choices.NAME_UP down=sort_choices.NAME_DOWN %}
+        {% include "nimbus_experiments/table_header.html" with field="QA" up=sort_choices.QA_UP down=sort_choices.QA_DOWN %}
+        {% include "nimbus_experiments/table_header.html" with field="Application" up=sort_choices.APPLICATION_UP down=sort_choices.APPLICATION_DOWN %}
+        {% include "nimbus_experiments/table_header.html" with field="Channel" up=sort_choices.CHANNEL_UP down=sort_choices.CHANNEL_DOWN %}
+        {% include "nimbus_experiments/table_header.html" with field="Size" up=sort_choices.SIZE_UP down=sort_choices.SIZE_DOWN %}
+        {% include "nimbus_experiments/table_header.html" with field="Features" up=sort_choices.FEATURES_UP down=sort_choices.FEATURES_DOWN %}
+        {% include "nimbus_experiments/table_header.html" with field="Versions" up=sort_choices.VERSIONS_UP down=sort_choices.VERSIONS_DOWN %}
+        {% include "nimbus_experiments/table_header.html" with field="Dates" up=sort_choices.DATES_UP down=sort_choices.DATES_DOWN %}
+
+      </tr>
+    </thead>
+    <tbody>
+      {% for experiment in experiments %}
+        <tr>
+          <th scope="row">
+            <a href="{% url "nimbus-detail" slug=experiment.slug %}">{{ experiment.name }}</a>
+          </th>
+          <td>
+            {% if experiment.qa_status == 'NOT SET' %}<i class="fa-regular fa-circle-question"></i>{% endif %}
+            {% if experiment.qa_status == 'GREEN' %}
+              <span class="text-success"><i class="fa-regular fa-circle-check"></i></span>
+            {% endif %}
+            {% if experiment.qa_status == 'YELLOW' %}
+              <span class="text-warning"><i class="fa-regular fa-circle-pause"></i></span>
+            {% endif %}
+            {% if experiment.qa_status == 'RED' %}
+              <span class="text-danger"><i class="fa-regular fa-circle-xmark"></i></span>
+            {% endif %}
+          </td>
+          <td>{{ experiment.get_application_display }}</td>
+          <td>{{ experiment.get_channel_display }}</td>
+          <td>{{ experiment.population_percent|floatformat }}%</td>
+          <td>
+            {% for feature in experiment.feature_configs.all %}
+              {{ feature.name }}
+              <br>
+            {% endfor %}
+          </td>
+          <td>
+            {{ experiment.get_firefox_min_version_display }}
+            {% if experiment.firefox_max_version %}
+              - {{ experiment.get_firefox_max_version_display }}
+            {% else %}
+              +
+            {% endif %}
+          </td>
+          <td>
+            {% if experiment.start_date %}
+              {{ experiment.start_date|date:"M j/y" }} -
+              <br>
+              {{ experiment.computed_end_date|date:"M j/y" }}
+              <br>
+              ({{ experiment.computed_duration_days }} days)
+            {% else %}
+              N/A
+            {% endif %}
+          </td>
+        </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</div>
+{% if page_obj.paginator.num_pages > 1 %}
+  <div class="row">
+    <div class="col text-center">
+      <ul class="pagination justify-content-center">
+        {% if page_obj.has_previous %}
+          <li class="page-item">
+            <a class="page-link"
+               href="{% pagination_url page_obj.previous_page_number %}"
+               tabindex="-1">Previous</a>
+          </li>
+        {% else %}
+          <li class="page-item disabled">
+            <a class="page-link" href="#">Previous</a>
+          </li>
+        {% endif %}
+        {% for page_num in page_obj.paginator.page_range %}
+          <li class="page-item {% if page_obj.number == page_num %}active{% endif %}">
+            <a class="page-link" href="{% pagination_url page_num %}">{{ page_num }}</a>
+          </li>
+        {% endfor %}
+        {% if page_obj.has_next %}
+          <li class="page-item">
+            <a class="page-link"
+               href="{% pagination_url page_obj.next_page_number %}">Next</a>
+          </li>
+        {% else %}
+          <li class="page-item disabled">
+            <a class="page-link" href="#">Next</a>
+          </li>
+        {% endif %}
+      </ul>
+    </div>
+  </div>
+{% endif %}

--- a/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/table_header.html
+++ b/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/table_header.html
@@ -1,9 +1,8 @@
 <th scope="col">
-  <form hx-get="{% url "nimbus-new-list" %}"
+  <form id="sort-form"
+        hx-get="{% url "nimbus-new-table" %}"
         hx-trigger="submit"
-        hx-select="#content"
-        hx-target="#content"
-        hx-swap="outerHTML"
+        hx-target="#experiment-list"
         hx-push-url="true">
     <input type="hidden"
            name="sort"

--- a/experimenter/experimenter/nimbus_ui_new/tests/test_views.py
+++ b/experimenter/experimenter/nimbus_ui_new/tests/test_views.py
@@ -783,3 +783,15 @@ class NimbusExperimentsListViewTest(TestCase):
             [e.slug for e in response.context["experiments"]],
             [experiment2.slug, experiment1.slug],
         )
+
+
+class NimbusExperimentsListTableViewTest(TestCase):
+    maxDiff = None
+
+    def setUp(self):
+        self.user = UserFactory.create(email="user@example.com")
+        self.client.defaults[settings.OPENIDC_EMAIL_HEADER] = self.user.email
+
+    def test_render_to_response(self):
+        response = self.client.get(reverse("nimbus-new-table"))
+        self.assertEqual(response.status_code, 200)

--- a/experimenter/experimenter/nimbus_ui_new/urls.py
+++ b/experimenter/experimenter/nimbus_ui_new/urls.py
@@ -2,6 +2,7 @@ from django.urls import re_path
 
 from experimenter.nimbus_ui_new.views import (
     NimbusChangeLogsView,
+    NimbusExperimentsListTableView,
     NimbusExperimentsListView,
 )
 
@@ -10,6 +11,11 @@ urlpatterns = [
         r"^(?P<slug>[\w-]+)/history/$",
         NimbusChangeLogsView.as_view(),
         name="nimbus-new-history",
+    ),
+    re_path(
+        r"^table/",
+        NimbusExperimentsListTableView.as_view(),
+        name="nimbus-new-table",
     ),
     re_path(
         r"^",

--- a/experimenter/experimenter/nimbus_ui_new/views.py
+++ b/experimenter/experimenter/nimbus_ui_new/views.py
@@ -67,3 +67,7 @@ class NimbusExperimentsListView(FilterView):
             sort_choices=SortChoices,
             **kwargs,
         )
+
+
+class NimbusExperimentsListTableView(NimbusExperimentsListView):
+    template_name = "nimbus_experiments/table.html"


### PR DESCRIPTION
Because

* After profiling the new nimbus ui list view we see that the bulk of time rendering is in the sidebar
* We only need to render the sidebar once on initial page load
* We can update only the table after filters, tabs, sorts change
* This should significantly improve the responsiveness of the page

This commit

* Splits the table out into its own template
* Adds a new view that renders only the table
* Updates the htmx directives to call the table renderer

fixes #10803

Before:


https://github.com/mozilla/experimenter/assets/119884/7807c453-ad72-4a75-a8e3-0416b027b7da

After:

https://github.com/mozilla/experimenter/assets/119884/653c0d60-302f-43a4-95e7-1dc6bcb4c0cc


