### PR TITLE
bug(nimbus): push query args to list page url properly

### DIFF
--- a/experimenter/experimenter/nimbus_ui_new/tests/test_views.py
+++ b/experimenter/experimenter/nimbus_ui_new/tests/test_views.py
@@ -795,3 +795,10 @@ class NimbusExperimentsListTableViewTest(TestCase):
     def test_render_to_response(self):
         response = self.client.get(reverse("nimbus-new-table"))
         self.assertEqual(response.status_code, 200)
+
+    def test_includes_request_get_parameters_in_response_header(self):
+        response = self.client.get(
+            reverse("nimbus-new-table"),
+            {"status": "test"},
+        )
+        self.assertEqual(response.headers["HX-Push"], "?status=test")

--- a/experimenter/experimenter/nimbus_ui_new/views.py
+++ b/experimenter/experimenter/nimbus_ui_new/views.py
@@ -75,3 +75,8 @@ class NimbusExperimentsListView(FilterView):
 
 class NimbusExperimentsListTableView(NimbusExperimentsListView):
     template_name = "nimbus_experiments/table.html"
+
+    def get(self, *args, **kwargs):
+        response = super().get(*args, **kwargs)
+        response.headers["HX-Push"] = f"?{self.request.GET.urlencode()}"
+        return response


### PR DESCRIPTION
Becuase

* When you fetch a url with htmx it will override the current url in the urlbar and history
* When we separated the experiment table into its own template/view/url, then the url after fetching becomes the url of the table and not the list page
* We need a way to push only the query args to the url without changing the path
* HTMX allows you to do this by setting a header in the response

This commit

* Sets the HX-Push header in the response from the table view to only include the query args so that the path will remain the same but the query args will be updated with the new values

fixes #10810

