### PR TITLE
chore(nimbus): disable intermittently failing nimbus ui tests

### DIFF
--- a/experimenter/experimenter/nimbus-ui/src/components/PageHome/FilterBar/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageHome/FilterBar/index.tsx
@@ -183,6 +183,7 @@ export const FilterSelect = <
             )!,
           options: filterOptions as Options<OptionType>,
           onChange: (fieldValue: Options<OptionType>) => {
+            /* istanbul ignore next */
             onChange({
               ...filterValue,
               [filterValueName]: fieldValue,

--- a/experimenter/experimenter/nimbus-ui/src/components/PageHome/index.test.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageHome/index.test.tsx
@@ -98,7 +98,8 @@ describe("PageHome", () => {
     }
   });
 
-  it("supports updating search params when tabs are clicked", async () => {
+  // Skipping due to intermittency
+  it.skip("supports updating search params when tabs are clicked", async () => {
     await renderAndWaitForLoaded();
     for (const [tabKey, tab] of findTabs()) {
       fireEvent.click(tab);
@@ -143,7 +144,8 @@ describe("PageHome", () => {
 
   // TODO: not exhaustively testing all filters here, might be worth adding more?
   // Filtering itself is more fully covered in filterExperiments.test.tsx
-  it("supports filtering by feature", async () => {
+  // Skipping due to intermittency
+  it.skip("supports filtering by feature", async () => {
     await renderAndWaitForLoaded();
     const expectedFeatureConfigNameWithApplication =
       "Picture-in-Picture (Android)";

--- a/experimenter/experimenter/nimbus-ui/src/components/PageHome/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageHome/index.tsx
@@ -48,6 +48,7 @@ export const Body: React.FC<BodyProps> = ({
 
   const selectedTab = searchParams.get("tab") || "live";
   const onSelectTab = useCallback(
+    /* istanbul ignore next */
     (nextTab) => updateSearchParams((params) => params.set("tab", nextTab)),
     [updateSearchParams],
   );
@@ -100,6 +101,7 @@ const PageHome: React.FunctionComponent<PageHomeProps> = () => {
   const config = useConfig();
   const [searchParams, updateSearchParams] = useSearchParamsState("PageHome");
   const filterValue = getFilterValueFromParams(config, searchParams);
+  /* istanbul ignore next */
   const onFilterChange = (newFilterValue: FilterValue) =>
     updateParamsFromFilterValue(updateSearchParams, newFilterValue);
 


### PR DESCRIPTION
Because

* We are in the process of migrating our frontend from react to django templates/htmx
* There are some intermittently failing tests in the react frontend
* We are not making any significant changes to the react frontend
* We can safely disable these tests until we deprecate the react frontend

This commit

* Skips two intermittently failing tests
* Skips coverage for the affected lines

fixes #10812

