### PR TITLE
chore(nimbus): sort nimbus list filter drop downs

### DIFF
--- a/experimenter/experimenter/nimbus_ui_new/filtersets.py
+++ b/experimenter/experimenter/nimbus_ui_new/filtersets.py
@@ -124,7 +124,7 @@ class NimbusExperimentFilter(django_filters.FilterSet):
         ),
     )
     feature_configs = django_filters.ModelMultipleChoiceFilter(
-        queryset=NimbusFeatureConfig.objects.all(),
+        queryset=NimbusFeatureConfig.objects.all().order_by("application", "slug"),
         widget=MultiSelectWidget(
             icon="fa-solid fa-boxes-stacked",
             attrs={
@@ -135,7 +135,7 @@ class NimbusExperimentFilter(django_filters.FilterSet):
         ),
     )
     countries = django_filters.ModelMultipleChoiceFilter(
-        queryset=Country.objects.all(),
+        queryset=Country.objects.all().order_by("code"),
         widget=MultiSelectWidget(
             icon="fa-solid fa-globe",
             attrs={
@@ -146,7 +146,7 @@ class NimbusExperimentFilter(django_filters.FilterSet):
         ),
     )
     languages = django_filters.ModelMultipleChoiceFilter(
-        queryset=Language.objects.all(),
+        queryset=Language.objects.all().order_by("code"),
         widget=MultiSelectWidget(
             icon="fa-solid fa-language",
             attrs={
@@ -157,7 +157,7 @@ class NimbusExperimentFilter(django_filters.FilterSet):
         ),
     )
     locales = django_filters.ModelMultipleChoiceFilter(
-        queryset=Locale.objects.all(),
+        queryset=Locale.objects.all().order_by("code"),
         widget=MultiSelectWidget(
             icon="fa-solid fa-earth-americas",
             attrs={
@@ -168,7 +168,7 @@ class NimbusExperimentFilter(django_filters.FilterSet):
         ),
     )
     targeting_config_slug = django_filters.MultipleChoiceFilter(
-        choices=TargetingConstants.TargetingConfig.choices,
+        choices=sorted(TargetingConstants.TargetingConfig.choices),
         widget=MultiSelectWidget(
             icon="fa-solid fa-users-rectangle",
             attrs={
@@ -179,7 +179,7 @@ class NimbusExperimentFilter(django_filters.FilterSet):
         ),
     )
     projects = django_filters.ModelMultipleChoiceFilter(
-        queryset=Project.objects.all(),
+        queryset=Project.objects.all().order_by("slug"),
         widget=MultiSelectWidget(
             icon="fa-solid fa-person-chalkboard",
             attrs={


### PR DESCRIPTION
Because

* It's easier to scan through drop down lists when their entries are sorted

This commit

* Sorts some of the filter drop downs on the new Nimbus list page
* Some drop downs with a small number of enum choices can be left alone since the enum ordering is often semantic

fixes #10850

