### PR TITLE
bug(nimbus): status counts and filters should match

### DIFF
--- a/experimenter/experimenter/nimbus_ui_new/filtersets.py
+++ b/experimenter/experimenter/nimbus_ui_new/filtersets.py
@@ -266,9 +266,8 @@ class NimbusExperimentFilter(django_filters.FilterSet):
     def filter_status(self, queryset, name, value):
         match value:
             case StatusChoices.REVIEW:
-                return queryset.filter(
-                    status=NimbusExperiment.Status.DRAFT,
-                    publish_status=NimbusExperiment.PublishStatus.REVIEW,
+                return queryset.exclude(
+                    publish_status=NimbusExperiment.PublishStatus.IDLE,
                 )
             case StatusChoices.ARCHIVED:
                 return queryset.filter(is_archived=True)
@@ -278,7 +277,7 @@ class NimbusExperimentFilter(django_filters.FilterSet):
                 return queryset.filter(
                     status=value,
                     is_archived=False,
-                ).exclude(publish_status=NimbusExperiment.PublishStatus.REVIEW)
+                )
 
     def filter_search(self, queryset, name, value):
         search_fields = Concat(

--- a/experimenter/experimenter/nimbus_ui_new/tests/test_views.py
+++ b/experimenter/experimenter/nimbus_ui_new/tests/test_views.py
@@ -52,7 +52,12 @@ class NimbusExperimentsListViewTest(TestCase):
         NimbusExperimentFactory.create(
             status=NimbusExperiment.Status.DRAFT,
             publish_status=NimbusExperiment.PublishStatus.REVIEW,
-            slug="review-experiment",
+            slug="draft-review-experiment",
+        )
+        NimbusExperimentFactory.create(
+            status=NimbusExperiment.Status.LIVE,
+            publish_status=NimbusExperiment.PublishStatus.REVIEW,
+            slug="live-review-experiment",
         )
         NimbusExperimentFactory.create(is_archived=True, slug="archived-experiment")
         NimbusExperimentFactory.create(owner=self.user, slug="my-experiment")
@@ -72,10 +77,10 @@ class NimbusExperimentsListViewTest(TestCase):
             dict(response.context["status_counts"]),
             {
                 NimbusExperiment.Status.COMPLETE: 1,
-                NimbusExperiment.Status.DRAFT: 2,
-                NimbusExperiment.Status.LIVE: 1,
+                NimbusExperiment.Status.DRAFT: 3,
+                NimbusExperiment.Status.LIVE: 2,
                 NimbusExperiment.Status.PREVIEW: 1,
-                "Review": 1,
+                "Review": 2,
                 "Archived": 1,
                 "MyExperiments": 1,
             },
@@ -103,7 +108,7 @@ class NimbusExperimentsListViewTest(TestCase):
             dict(response.context["status_counts"]),
             {
                 NimbusExperiment.Status.COMPLETE: 1,
-                NimbusExperiment.Status.DRAFT: 2,
+                NimbusExperiment.Status.DRAFT: 3,
                 NimbusExperiment.Status.LIVE: 1,
                 NimbusExperiment.Status.PREVIEW: 1,
                 "Review": 1,
@@ -129,11 +134,21 @@ class NimbusExperimentsListViewTest(TestCase):
 
     @parameterized.expand(
         (
-            (StatusChoices.DRAFT, ["my-experiment", NimbusExperiment.Status.DRAFT]),
+            (
+                StatusChoices.DRAFT,
+                [
+                    "my-experiment",
+                    NimbusExperiment.Status.DRAFT,
+                    "draft-review-experiment",
+                ],
+            ),
             (StatusChoices.PREVIEW, [NimbusExperiment.Status.PREVIEW]),
-            (StatusChoices.LIVE, [NimbusExperiment.Status.LIVE]),
+            (
+                StatusChoices.LIVE,
+                [NimbusExperiment.Status.LIVE, "live-review-experiment"],
+            ),
             (StatusChoices.COMPLETE, [NimbusExperiment.Status.COMPLETE]),
-            (StatusChoices.REVIEW, ["review-experiment"]),
+            (StatusChoices.REVIEW, ["draft-review-experiment", "live-review-experiment"]),
             (StatusChoices.ARCHIVED, ["archived-experiment"]),
             (StatusChoices.MY_EXPERIMENTS, ["my-experiment"]),
         )
@@ -145,7 +160,12 @@ class NimbusExperimentsListViewTest(TestCase):
         NimbusExperimentFactory.create(
             status=NimbusExperiment.Status.DRAFT,
             publish_status=NimbusExperiment.PublishStatus.REVIEW,
-            slug="review-experiment",
+            slug="draft-review-experiment",
+        )
+        NimbusExperimentFactory.create(
+            status=NimbusExperiment.Status.LIVE,
+            publish_status=NimbusExperiment.PublishStatus.REVIEW,
+            slug="live-review-experiment",
         )
         NimbusExperimentFactory.create(is_archived=True, slug="archived-experiment")
         NimbusExperimentFactory.create(owner=self.user, slug="my-experiment")

--- a/experimenter/experimenter/nimbus_ui_new/views.py
+++ b/experimenter/experimenter/nimbus_ui_new/views.py
@@ -57,7 +57,6 @@ class NimbusExperimentsListView(FilterView):
         status_counts = {
             StatusChoices.DRAFT: unarchived.filter(
                 status=NimbusExperiment.Status.DRAFT,
-                publish_status=NimbusExperiment.PublishStatus.IDLE,
             ).count(),
             StatusChoices.PREVIEW: unarchived.filter(
                 status=NimbusExperiment.Status.PREVIEW


### PR DESCRIPTION
Because

* We discovered a case where the Review tab counted 1 experiment but there were no experiments in the table
* This is becuase the definition of review for the counts did not match the definition of the review filter
* This uncovered a broader inconsistency around how we handle the review publish statuses in the list page
* By having anything in review appear only in the review tab, the user would experience their live experiment disappearing from the live tab and moving into the review tab, and then moving back to the live tab, which is probably less desirable than just having all live experiments always appear in the live tab and also in the review tab when they're in review

This commit

* Simplifies the status counts and filters by having the draft and live tabs always show all draft and live experiments, including ones in review
* The review tab will show experiments in any publish status other than idle, so that they're still marked as in review while they're being reviewed in remote settings

fixes #10851

