### PR TITLE
bug(nimbus): Don't provide a default value for KINTO_ADMIN_URL

### DIFF
--- a/.env.integration-tests
+++ b/.env.integration-tests
@@ -25,6 +25,7 @@ GOOGLE_APPLICATION_CREDENTIALS=/tmp/keys/application_default_credentials.json
 GOOGLE_ADC_FILE=~/.config/gcloud/application_default_credentials.json
 HOSTNAME=localhost
 KINTO_HOST=http://kinto:8888/v1
+KINTO_ADMIN_URL=http://localhost:8888/v1/admin
 KINTO_PASS=experimenter
 KINTO_USER=experimenter
 KINTO_REVIEW_TIMEOUT=40

--- a/experimenter/experimenter/settings.py
+++ b/experimenter/experimenter/settings.py
@@ -482,7 +482,7 @@ KINTO_COLLECTION_NIMBUS_SECURE = "nimbus-secure-experiments"
 KINTO_COLLECTION_NIMBUS_MOBILE = "nimbus-mobile-experiments"
 KINTO_COLLECTION_NIMBUS_WEB = "nimbus-web-experiments"
 KINTO_COLLECTION_NIMBUS_PREVIEW = "nimbus-preview"
-KINTO_ADMIN_URL = config("KINTO_ADMIN_URL", default=urljoin(KINTO_HOST, "/admin/"))
+KINTO_ADMIN_URL = config("KINTO_ADMIN_URL")
 KINTO_REVIEW_TIMEOUT = config("KINTO_REVIEW_TIMEOUT", cast=int)
 
 # Jetstream GCS Bucket data


### PR DESCRIPTION
Because:
- We were providing a computed default value for KINTO_ADMIN_URL based on KINTO_HOST, but it was incorrectly using urljoin

this commit:
- removes the computed default, making KINTO_ADMIN_URL a required setting.

Fixes #10852.