### PR TITLE
bug(nimbus): format empty versions properly in new nimbus list page

### DIFF
--- a/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/table.html
+++ b/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/table.html
@@ -60,11 +60,15 @@
             {% endfor %}
           </td>
           <td>
-            {{ experiment.get_firefox_min_version_display }}
-            {% if experiment.firefox_max_version %}
-              - {{ experiment.get_firefox_max_version_display }}
+            {% if experiment.firefox_min_version %}
+              {{ experiment.get_firefox_min_version_display }}
+              {% if experiment.firefox_max_version %}
+                - {{ experiment.get_firefox_max_version_display }}
+              {% else %}
+                +
+              {% endif %}
             {% else %}
-              +
+              N/A
             {% endif %}
           </td>
           <td>


### PR DESCRIPTION
Becuase

* In the new Nimbus list page we neglected to display empty versions properly

This commit

* Displays N/A if no versions are selected

fixes #10857

