### PR TITLE
feat(nimbus): include subscribers in my experiments on new nimbus list page

### DIFF
--- a/experimenter/experimenter/nimbus_ui_new/filtersets.py
+++ b/experimenter/experimenter/nimbus_ui_new/filtersets.py
@@ -272,7 +272,9 @@ class NimbusExperimentFilter(django_filters.FilterSet):
             case StatusChoices.ARCHIVED:
                 return queryset.filter(is_archived=True)
             case StatusChoices.MY_EXPERIMENTS:
-                return queryset.filter(owner=self.request.user)
+                return queryset.filter(
+                    Q(owner=self.request.user) | Q(subscribers=self.request.user)
+                )
             case _:
                 return queryset.filter(
                     status=value,

--- a/experimenter/experimenter/nimbus_ui_new/tests/test_views.py
+++ b/experimenter/experimenter/nimbus_ui_new/tests/test_views.py
@@ -138,6 +138,7 @@ class NimbusExperimentsListViewTest(TestCase):
                 StatusChoices.DRAFT,
                 [
                     "my-experiment",
+                    "subscribed-experiment",
                     NimbusExperiment.Status.DRAFT,
                     "draft-review-experiment",
                 ],
@@ -150,7 +151,7 @@ class NimbusExperimentsListViewTest(TestCase):
             (StatusChoices.COMPLETE, [NimbusExperiment.Status.COMPLETE]),
             (StatusChoices.REVIEW, ["draft-review-experiment", "live-review-experiment"]),
             (StatusChoices.ARCHIVED, ["archived-experiment"]),
-            (StatusChoices.MY_EXPERIMENTS, ["my-experiment"]),
+            (StatusChoices.MY_EXPERIMENTS, ["my-experiment", "subscribed-experiment"]),
         )
     )
     def test_filter_status(self, filter_status, expected_slugs):
@@ -168,7 +169,18 @@ class NimbusExperimentsListViewTest(TestCase):
             slug="live-review-experiment",
         )
         NimbusExperimentFactory.create(is_archived=True, slug="archived-experiment")
-        NimbusExperimentFactory.create(owner=self.user, slug="my-experiment")
+        NimbusExperimentFactory.create(
+            status=NimbusExperiment.Status.DRAFT,
+            publish_status=NimbusExperiment.PublishStatus.IDLE,
+            owner=self.user,
+            slug="my-experiment",
+        )
+        NimbusExperimentFactory.create(
+            status=NimbusExperiment.Status.DRAFT,
+            publish_status=NimbusExperiment.PublishStatus.IDLE,
+            slug="subscribed-experiment",
+            subscribers=[self.user],
+        )
 
         response = self.client.get(
             reverse("nimbus-new-list"),


### PR DESCRIPTION


Becuase

* We only included owned experiments in the My Experiments tab in the new list page
* It should include subscribed experiments as well

This commit

* Adds subscribed experiments to the My Experiments tab on the new Nimbus list page

fixes #10856
