### PR TITLE
chore(nimbus): display verions in descending order

### DIFF
--- a/experimenter/experimenter/nimbus_ui_new/filtersets.py
+++ b/experimenter/experimenter/nimbus_ui_new/filtersets.py
@@ -113,7 +113,7 @@ class NimbusExperimentFilter(django_filters.FilterSet):
         ),
     )
     firefox_min_version = django_filters.MultipleChoiceFilter(
-        choices=NimbusExperiment.Version.choices,
+        choices=reversed(NimbusExperiment.Version.choices),
         widget=MultiSelectWidget(
             icon="fa-solid fa-code-branch",
             attrs={


### PR DESCRIPTION
Because

* Users will most likely want to filter by the most recent versions
* The existing Nimbus list page shows the versions in descending order

This commit

* Shows versions in descending order in the version filter drop down

fixes #10879

