### PR TITLE
bug(nimbus): dark mode for bootstrap select no results

### DIFF
--- a/experimenter/experimenter/nimbus_ui_new/static/css/style.scss
+++ b/experimenter/experimenter/nimbus_ui_new/static/css/style.scss
@@ -87,6 +87,10 @@
           color: var(--bs-body-color); // White text for active item
         }
       }
+
+      .no-results {
+        background-color: var(--bs-dropdown-link-hover-bg);
+      }
     }
 
     .dropdown-toggle {


### PR DESCRIPTION
Becuase

* Bootstrap-select does not support dark mode out of the box
* We added additional rules for it to support dark mode
* We missed the 'no results' element

This commit

* Adds the correct background colour to the no results message in dark mode

fixes #10881
<img width="263" alt="image" src="https://github.com/mozilla/experimenter/assets/119884/5164db2e-0fec-4bff-91e4-c2244406aa4c">
