### PR TITLE
chore(nimbus): use iso 8601 date format on new list page

### DIFF
--- a/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/table.html
+++ b/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/table.html
@@ -73,9 +73,9 @@
           </td>
           <td>
             {% if experiment.start_date %}
-              {{ experiment.start_date|date:"M j/y" }} -
+              {{ experiment.start_date|date:"Y-m-d" }} -
               <br>
-              {{ experiment.computed_end_date|date:"M j/y" }}
+              {{ experiment.computed_end_date|date:"Y-m-d" }}
               <br>
               ({{ experiment.computed_duration_days }} days)
             {% else %}


### PR DESCRIPTION
Becuase

* To keep our date formatting consistent with other pages we should use ISO 8601 on the new list page

This commit

* Changes the date formatting on the new list page to ISO 8601 format

fixes #10875

<img width="147" alt="image" src="https://github.com/mozilla/experimenter/assets/119884/8d5721ff-d98a-4896-9a80-63dfd136065b">