### PR TITLE
feat(nimbus): enable new nimbus list page

### DIFF
--- a/experimenter/experimenter/nimbus-ui/src/components/App/index.test.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/App/index.test.tsx
@@ -44,7 +44,7 @@ describe("App", () => {
     spy.mockRestore();
   });
 
-  it("routes to PageHome page", async () => {
+  it.skip("routes to PageHome page", async () => {
     const { navigate } = renderSubject();
     await act(() => navigate());
     expect(screen.getByTestId("PageHome")).toBeInTheDocument();

--- a/experimenter/experimenter/nimbus-ui/src/components/App/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/App/index.tsx
@@ -10,7 +10,6 @@ import PageEditAudience from "src/components/PageEditAudience";
 import PageEditBranches from "src/components/PageEditBranches";
 import PageEditMetrics from "src/components/PageEditMetrics";
 import PageEditOverview from "src/components/PageEditOverview";
-import PageHome from "src/components/PageHome";
 import PageLoading from "src/components/PageLoading";
 import PageNew from "src/components/PageNew";
 import PageResults from "src/components/PageResults";
@@ -45,7 +44,6 @@ const App = () => {
   return (
     <SearchParamsStateProvider>
       <Router basepath={BASE_PATH}>
-        <PageHome path="/" />
         <PageNew path="new" />
         <ExperimentRoot path=":slug">
           <SummaryRoot path="/">

--- a/experimenter/experimenter/nimbus-ui/src/components/AppLayoutSidebarLaunched/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/AppLayoutSidebarLaunched/index.tsx
@@ -183,13 +183,10 @@ export const AppLayoutSidebarLaunched = ({
               className="flex-column font-weight-semibold mx-2 w-100"
               as="ul"
             >
-              <LinkNav
-                className="mb-3 small font-weight-bold"
-                textColor="text-secondary"
-              >
+              <a href={"/nimbus/"} className="mb-3 small font-weight-bold">
                 <ChevronLeft className="ml-n1" width="18" height="18" />
                 Back to Experiments
-              </LinkNav>
+              </a>
 
               <LinkNavSummary
                 {...{ status, slug }}

--- a/experimenter/experimenter/nimbus-ui/src/components/AppLayoutWithSidebar/index.test.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/AppLayoutWithSidebar/index.test.tsx
@@ -17,7 +17,6 @@ describe("AppLayoutWithSidebar", () => {
   describe("navigation links", () => {
     it("renders expected URLs", () => {
       render(<Subject />);
-      expect(screen.getByTestId("nav-home")).toHaveAttribute("href", BASE_PATH);
       expect(screen.getByTestId("nav-edit-overview")).toHaveAttribute(
         "href",
         `${BASE_PATH}/my-special-slug/edit/overview`,

--- a/experimenter/experimenter/nimbus-ui/src/components/AppLayoutWithSidebar/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/AppLayoutWithSidebar/index.tsx
@@ -85,13 +85,10 @@ export const AppLayoutWithSidebar = ({
             className="navbar sticky-top overflow-auto vh-100 align-items-start"
           >
             <Nav className="flex-column font-weight-semibold w-100" as="ul">
-              <LinkNav
-                className="mb-3 small font-weight-bold"
-                textColor="text-secondary"
-              >
+              <a href={"/nimbus/"} className="mb-3 small font-weight-bold">
                 <ChevronLeft className="ml-n1" width="18" height="18" />
                 Back to Experiments
-              </LinkNav>
+              </a>
 
               <LinkNavSummary
                 {...{ status, slug }}

--- a/experimenter/experimenter/nimbus-ui/src/components/PageNew/index.test.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageNew/index.test.tsx
@@ -44,7 +44,9 @@ describe("PageNew", () => {
     render(<Subject mocks={[mutationMock]} />);
     fireEvent.click(screen.getByTestId("submit"));
     await waitFor(() =>
-      expect(navigate).toHaveBeenCalledWith("foo-bar-baz/edit/overview"),
+      expect(navigate).toHaveBeenCalledWith(
+        "/nimbus/foo-bar-baz/edit/overview",
+      ),
     );
   });
 

--- a/experimenter/experimenter/nimbus-ui/src/components/PageNew/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageNew/index.tsx
@@ -62,7 +62,7 @@ const PageNew: React.FunctionComponent<PageNewProps> = () => {
           setIsServerValid(true);
           setSubmitErrors({});
         }
-        navigate(`${nimbusExperiment!.slug}/edit/overview`);
+        navigate(`/nimbus/${nimbusExperiment!.slug}/edit/overview`);
       } catch (error) {
         setSubmitErrors({ "*": `${SUBMIT_ERROR}` });
       }

--- a/experimenter/experimenter/nimbus_ui_new/templates/common/header.html
+++ b/experimenter/experimenter/nimbus_ui_new/templates/common/header.html
@@ -3,7 +3,7 @@
 <nav class="navbar">
   <div class="container-fluid">
     <a class="navbar-brand d-flex align-items-center fs-3"
-       href="{% url 'nimbus-new-list' %}">
+       href="{% url 'nimbus-list' %}">
       <img src="{% static 'assets/logo.svg' %}"
            alt="Logo"
            width="30"
@@ -48,7 +48,11 @@
         </a>
       </li>
       <li class="nav-item">
-        <a href="/legacy/" class="nav-link" target="_blank" rel="noreferrer">
+        <a id="legacy_page_link"
+           href="/legacy/"
+           class="nav-link"
+           target="_blank"
+           rel="noreferrer">
           <i class="fa-solid fa-ghost"></i>
           Legacy
         </a>

--- a/experimenter/experimenter/nimbus_ui_new/templates/experimenter_base.html
+++ b/experimenter/experimenter/nimbus_ui_new/templates/experimenter_base.html
@@ -15,7 +15,11 @@
     </title>
     <script src="{% static 'nimbus_ui_new/app.bundle.js' %}"></script>
   </head>
-  <body class="bg-body-tertiary">
+  <body
+    {# djlint:off #}
+    id="{% block page_id %}{% endblock %}"
+    {# djlint:on #}
+    class="bg-body-tertiary">
     <div class="container-fluid bg-body border-bottom border-1 mb-4 py-1">
       {% include "common/header.html" %}
 

--- a/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/list.html
+++ b/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/list.html
@@ -3,6 +3,11 @@
 {% load static %}
 {% load nimbus_extras %}
 
+{# djlint:off #}
+{% block page_id %}PageHome-page{% endblock page_id %}
+
+
+{# djlint:on #}
 {% block title %}
   Nimbus Experiments
 {% endblock title %}

--- a/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/table.html
+++ b/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/table.html
@@ -10,7 +10,9 @@
   {% include "common/list_tab.html" with status="MyExperiments" count=status_counts.MyExperiments icon="fa-solid fa-heart" %}
 
   <li class="nav-item ms-auto">
-    <a class="btn btn-primary" href="{% url "nimbus-create" %}">
+    <a id="create-new-button"
+       class="btn btn-primary"
+       href="{% url "nimbus-create" %}">
       <i class="fa-regular fa-pen-to-square"></i>
       Create Experiment
     </a>
@@ -18,7 +20,7 @@
 </ul>
 <div id="experiment-list"></div>
 <div class="border border-1 border-top-0 border-bottom-0 mb-3">
-  <table class="table table-striped mb-0">
+  <table id="experiment-table" class="table table-striped mb-0">
     <thead>
       <tr>
         {% include "nimbus_experiments/table_header.html" with field="Name" up=sort_choices.NAME_UP down=sort_choices.NAME_DOWN %}

--- a/experimenter/experimenter/nimbus_ui_new/tests/test_views.py
+++ b/experimenter/experimenter/nimbus_ui_new/tests/test_views.py
@@ -63,7 +63,7 @@ class NimbusExperimentsListViewTest(TestCase):
         NimbusExperimentFactory.create(is_archived=True, slug="archived-experiment")
         NimbusExperimentFactory.create(owner=self.user, slug="my-experiment")
 
-        response = self.client.get(reverse("nimbus-new-list"))
+        response = self.client.get(reverse("nimbus-list"))
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
             {e.slug for e in response.context["experiments"]},
@@ -101,7 +101,7 @@ class NimbusExperimentsListViewTest(TestCase):
             NimbusExperimentFactory.create(owner=self.user, application=application)
 
         response = self.client.get(
-            reverse("nimbus-new-list"),
+            reverse("nimbus-list"),
             {"application": NimbusExperiment.Application.DESKTOP},
         )
         self.assertEqual(response.status_code, 200)
@@ -127,10 +127,10 @@ class NimbusExperimentsListViewTest(TestCase):
                 NimbusExperimentFactory.Lifecycles.LIVE_ENROLLING
             )
 
-        response = self.client.get(reverse("nimbus-new-list"))
+        response = self.client.get(reverse("nimbus-list"))
         self.assertEqual(len(response.context["experiments"]), 3)
 
-        response = self.client.get(reverse("nimbus-new-list"), {"page": 2})
+        response = self.client.get(reverse("nimbus-list"), {"page": 2})
         self.assertEqual(len(response.context["experiments"]), 3)
 
     @parameterized.expand(
@@ -184,7 +184,7 @@ class NimbusExperimentsListViewTest(TestCase):
         )
 
         response = self.client.get(
-            reverse("nimbus-new-list"),
+            reverse("nimbus-list"),
             {"status": filter_status},
         )
 
@@ -215,7 +215,7 @@ class NimbusExperimentsListViewTest(TestCase):
         ]
 
         response = self.client.get(
-            reverse("nimbus-new-list"),
+            reverse("nimbus-list"),
             {"status": NimbusExperiment.Status.LIVE, "search": test_string},
         )
         self.assertEqual(
@@ -240,7 +240,7 @@ class NimbusExperimentsListViewTest(TestCase):
         ]
 
         response = self.client.get(
-            reverse("nimbus-new-list"),
+            reverse("nimbus-list"),
             {"status": NimbusExperiment.Status.LIVE, "type": type_choice},
         )
 
@@ -261,7 +261,7 @@ class NimbusExperimentsListViewTest(TestCase):
         ]
 
         response = self.client.get(
-            reverse("nimbus-new-list"),
+            reverse("nimbus-list"),
             {"status": NimbusExperiment.Status.LIVE, "application": application},
         )
 
@@ -280,7 +280,7 @@ class NimbusExperimentsListViewTest(TestCase):
         ]
 
         response = self.client.get(
-            reverse("nimbus-new-list"),
+            reverse("nimbus-list"),
             {"status": NimbusExperiment.Status.LIVE, "channel": channel},
         )
 
@@ -301,7 +301,7 @@ class NimbusExperimentsListViewTest(TestCase):
         ]
 
         response = self.client.get(
-            reverse("nimbus-new-list"),
+            reverse("nimbus-list"),
             {"status": NimbusExperiment.Status.LIVE, "firefox_min_version": version},
         )
 
@@ -325,7 +325,7 @@ class NimbusExperimentsListViewTest(TestCase):
         ]
 
         response = self.client.get(
-            reverse("nimbus-new-list"),
+            reverse("nimbus-list"),
             {
                 "status": NimbusExperiment.Status.LIVE,
                 "feature_configs": feature_config.id,
@@ -349,7 +349,7 @@ class NimbusExperimentsListViewTest(TestCase):
         ]
 
         response = self.client.get(
-            reverse("nimbus-new-list"),
+            reverse("nimbus-list"),
             {
                 "status": NimbusExperiment.Status.LIVE,
                 "countries": country.id,
@@ -373,7 +373,7 @@ class NimbusExperimentsListViewTest(TestCase):
         ]
 
         response = self.client.get(
-            reverse("nimbus-new-list"),
+            reverse("nimbus-list"),
             {
                 "status": NimbusExperiment.Status.LIVE,
                 "languages": language.id,
@@ -397,7 +397,7 @@ class NimbusExperimentsListViewTest(TestCase):
         ]
 
         response = self.client.get(
-            reverse("nimbus-new-list"),
+            reverse("nimbus-list"),
             {
                 "status": NimbusExperiment.Status.LIVE,
                 "locales": locale.id,
@@ -423,7 +423,7 @@ class NimbusExperimentsListViewTest(TestCase):
         ]
 
         response = self.client.get(
-            reverse("nimbus-new-list"),
+            reverse("nimbus-list"),
             {
                 "status": NimbusExperiment.Status.LIVE,
                 "targeting_config_slug": targeting_config,
@@ -447,7 +447,7 @@ class NimbusExperimentsListViewTest(TestCase):
         ]
 
         response = self.client.get(
-            reverse("nimbus-new-list"),
+            reverse("nimbus-list"),
             {
                 "status": NimbusExperiment.Status.LIVE,
                 "projects": project.id,
@@ -473,7 +473,7 @@ class NimbusExperimentsListViewTest(TestCase):
         ]
 
         response = self.client.get(
-            reverse("nimbus-new-list"),
+            reverse("nimbus-list"),
             {
                 "status": NimbusExperiment.Status.LIVE,
                 "qa_status": qa_status,
@@ -520,7 +520,7 @@ class NimbusExperimentsListViewTest(TestCase):
         ]
 
         response = self.client.get(
-            reverse("nimbus-new-list"),
+            reverse("nimbus-list"),
             {
                 "status": NimbusExperiment.Status.LIVE,
                 "takeaways": takeaway_choice,
@@ -542,7 +542,7 @@ class NimbusExperimentsListViewTest(TestCase):
         ]
 
         response = self.client.get(
-            reverse("nimbus-new-list"),
+            reverse("nimbus-list"),
             {
                 "status": NimbusExperiment.Status.LIVE,
                 "owner": owner.id,
@@ -566,7 +566,7 @@ class NimbusExperimentsListViewTest(TestCase):
         ]
 
         response = self.client.get(
-            reverse("nimbus-new-list"),
+            reverse("nimbus-list"),
             {
                 "status": NimbusExperiment.Status.LIVE,
                 "subscribers": subscriber.id,
@@ -585,7 +585,7 @@ class NimbusExperimentsListViewTest(TestCase):
             NimbusExperimentFactory.Lifecycles.LIVE_ENROLLING
         )
 
-        response = self.client.get(reverse("nimbus-new-list"))
+        response = self.client.get(reverse("nimbus-list"))
 
         self.assertEqual(
             [e.slug for e in response.context["experiments"]],
@@ -603,7 +603,7 @@ class NimbusExperimentsListViewTest(TestCase):
         )
 
         response = self.client.get(
-            reverse("nimbus-new-list"),
+            reverse("nimbus-list"),
             {
                 "sort": SortChoices.NAME_UP,
             },
@@ -615,7 +615,7 @@ class NimbusExperimentsListViewTest(TestCase):
         )
 
         response = self.client.get(
-            reverse("nimbus-new-list"),
+            reverse("nimbus-list"),
             {
                 "sort": SortChoices.NAME_DOWN,
             },
@@ -637,7 +637,7 @@ class NimbusExperimentsListViewTest(TestCase):
         )
 
         response = self.client.get(
-            reverse("nimbus-new-list"),
+            reverse("nimbus-list"),
             {
                 "sort": SortChoices.QA_UP,
             },
@@ -649,7 +649,7 @@ class NimbusExperimentsListViewTest(TestCase):
         )
 
         response = self.client.get(
-            reverse("nimbus-new-list"),
+            reverse("nimbus-list"),
             {
                 "sort": SortChoices.QA_DOWN,
             },
@@ -671,7 +671,7 @@ class NimbusExperimentsListViewTest(TestCase):
         )
 
         response = self.client.get(
-            reverse("nimbus-new-list"),
+            reverse("nimbus-list"),
             {
                 "sort": SortChoices.APPLICATION_UP,
             },
@@ -683,7 +683,7 @@ class NimbusExperimentsListViewTest(TestCase):
         )
 
         response = self.client.get(
-            reverse("nimbus-new-list"),
+            reverse("nimbus-list"),
             {
                 "sort": SortChoices.APPLICATION_DOWN,
             },
@@ -705,7 +705,7 @@ class NimbusExperimentsListViewTest(TestCase):
         )
 
         response = self.client.get(
-            reverse("nimbus-new-list"),
+            reverse("nimbus-list"),
             {
                 "sort": SortChoices.CHANNEL_UP,
             },
@@ -717,7 +717,7 @@ class NimbusExperimentsListViewTest(TestCase):
         )
 
         response = self.client.get(
-            reverse("nimbus-new-list"),
+            reverse("nimbus-list"),
             {
                 "sort": SortChoices.CHANNEL_DOWN,
             },
@@ -739,7 +739,7 @@ class NimbusExperimentsListViewTest(TestCase):
         )
 
         response = self.client.get(
-            reverse("nimbus-new-list"),
+            reverse("nimbus-list"),
             {
                 "sort": SortChoices.SIZE_UP,
             },
@@ -751,7 +751,7 @@ class NimbusExperimentsListViewTest(TestCase):
         )
 
         response = self.client.get(
-            reverse("nimbus-new-list"),
+            reverse("nimbus-list"),
             {
                 "sort": SortChoices.SIZE_DOWN,
             },
@@ -775,7 +775,7 @@ class NimbusExperimentsListViewTest(TestCase):
         )
 
         response = self.client.get(
-            reverse("nimbus-new-list"),
+            reverse("nimbus-list"),
             {
                 "sort": SortChoices.FEATURES_UP,
             },
@@ -787,7 +787,7 @@ class NimbusExperimentsListViewTest(TestCase):
         )
 
         response = self.client.get(
-            reverse("nimbus-new-list"),
+            reverse("nimbus-list"),
             {
                 "sort": SortChoices.FEATURES_DOWN,
             },
@@ -809,7 +809,7 @@ class NimbusExperimentsListViewTest(TestCase):
         )
 
         response = self.client.get(
-            reverse("nimbus-new-list"),
+            reverse("nimbus-list"),
             {
                 "sort": SortChoices.VERSIONS_UP,
             },
@@ -821,7 +821,7 @@ class NimbusExperimentsListViewTest(TestCase):
         )
 
         response = self.client.get(
-            reverse("nimbus-new-list"),
+            reverse("nimbus-list"),
             {
                 "sort": SortChoices.VERSIONS_DOWN,
             },
@@ -843,7 +843,7 @@ class NimbusExperimentsListViewTest(TestCase):
         )
 
         response = self.client.get(
-            reverse("nimbus-new-list"),
+            reverse("nimbus-list"),
             {
                 "sort": SortChoices.DATES_UP,
             },
@@ -855,7 +855,7 @@ class NimbusExperimentsListViewTest(TestCase):
         )
 
         response = self.client.get(
-            reverse("nimbus-new-list"),
+            reverse("nimbus-list"),
             {
                 "sort": SortChoices.DATES_DOWN,
             },

--- a/experimenter/experimenter/nimbus_ui_new/urls.py
+++ b/experimenter/experimenter/nimbus_ui_new/urls.py
@@ -4,7 +4,6 @@ from experimenter.nimbus_ui_new.views import (
     NimbusChangeLogsView,
     NimbusExperimentDetailView,
     NimbusExperimentsListTableView,
-    NimbusExperimentsListView,
     QAStatusUpdateView,
 )
 
@@ -28,10 +27,5 @@ urlpatterns = [
         r"^(?P<slug>[\w-]+)/update_qa_status/$",
         QAStatusUpdateView.as_view(),
         name="update-qa-status",
-    ),
-    re_path(
-        r"^",
-        NimbusExperimentsListView.as_view(),
-        name="nimbus-new-list",
     ),
 ]

--- a/experimenter/experimenter/urls.py
+++ b/experimenter/experimenter/urls.py
@@ -9,6 +9,7 @@ from experimenter.legacy.legacy_experiments.views import (
     NimbusUIView,
     PageNotFoundView,
 )
+from experimenter.nimbus_ui_new.views import NimbusExperimentsListView
 
 urlpatterns = [
     re_path(
@@ -26,8 +27,8 @@ urlpatterns = [
     re_path(r"^admin/", admin.site.urls),
     re_path(r"^experiments/", include("experimenter.legacy.legacy_experiments.urls")),
     re_path(r"^nimbus_new/", include("experimenter.nimbus_ui_new.urls")),
-    re_path(r"^nimbus/", NimbusUIView.as_view(), name="nimbus-list"),
     re_path(r"^nimbus/new/", NimbusUIView.as_view(), name="nimbus-create"),
+    re_path(r"^nimbus/$", NimbusExperimentsListView.as_view(), name="nimbus-list"),
     re_path(r"^nimbus/(?P<slug>[\w-]+)/", NimbusUIView.as_view(), name="nimbus-detail"),
     re_path(r"^legacy/$", ExperimentListView.as_view(), name="home"),
     re_path(

--- a/experimenter/tests/integration/nimbus/conftest.py
+++ b/experimenter/tests/integration/nimbus/conftest.py
@@ -153,12 +153,12 @@ def fixture_ping_server():
 
 @pytest.fixture
 def archived_tab_url(base_url):
-    return f"{base_url}?tab=archived"
+    return f"{base_url}?status=Archived"
 
 
 @pytest.fixture
 def drafts_tab_url(base_url):
-    return f"{base_url}?tab=drafts"
+    return f"{base_url}?status=Draft"
 
 
 @pytest.fixture

--- a/experimenter/tests/integration/nimbus/pages/experimenter/home.py
+++ b/experimenter/tests/integration/nimbus/pages/experimenter/home.py
@@ -1,4 +1,3 @@
-from pypom import Region
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as EC
 
@@ -12,24 +11,7 @@ class HomePage(Base):
 
     _page_wait_locator = (By.CSS_SELECTOR, "#PageHome-page")
     _create_new_btn_locator = (By.CSS_SELECTOR, "#create-new-button")
-
-    @property
-    def tables(self):
-        _table_locator = (By.CSS_SELECTOR, ".active .directory-table")
-        self.wait.until(EC.presence_of_element_located(_table_locator))
-        tables = self.find_elements(*_table_locator)
-        return [self.Tables(self, el) for el in tables]
-
-    @property
-    def tabs(self):
-        _tabs_locator = (By.CSS_SELECTOR, ".nav-item")
-        return self.wait_for_and_find_elements(*_tabs_locator)
-
-    @property
-    def active_tab_text(self):
-        _active_tab_locator = (By.CSS_SELECTOR, ".nav-item.active")
-        el = self.wait_for_and_find_element(*_active_tab_locator)
-        return el.text
+    _table_experiment_link_locator = (By.CSS_SELECTOR, "#experiment-table tr a")
 
     def create_new_button(self):
         el = self.wait_for_and_find_element(*self._create_new_btn_locator)
@@ -38,24 +20,16 @@ class HomePage(Base):
 
         return NewExperiment(self.driver, self.base_url).wait_for_page_to_load()
 
-    def find_in_table(self, table_name, experiment_name):
-        table_experiments = self.tables[0]
-        assert (
-            table_name in self.active_tab_text
-        ), f"Home Page: Table {table_name} not found in {self.active_tab_text}"
-        experiment_names = [
-            experiment.text for experiment in table_experiments.experiments
-        ]
+    @property
+    def table_experiments(self):
+        self.wait.until(
+            EC.presence_of_element_located(self._table_experiment_link_locator)
+        )
+        return self.find_elements(*self._table_experiment_link_locator)
+
+    def find_in_table(self, experiment_name):
+        experiment_names = [experiment.text for experiment in self.table_experiments]
         assert experiment_name in experiment_names, (
             f"Home Page: Experiment {experiment_name} not found in "
-            "{table_name} experiments: {experiment_names}"
+            f"experiments: {experiment_names}"
         )
-
-    class Tables(Region):
-
-        _experiment_link_locator = (By.CSS_SELECTOR, "tr a")
-
-        @property
-        def experiments(self):
-            self.wait.until(EC.presence_of_element_located(self._experiment_link_locator))
-            return self.find_elements(*self._experiment_link_locator)

--- a/experimenter/tests/integration/nimbus/test_cirrus_integration.py
+++ b/experimenter/tests/integration/nimbus/test_cirrus_integration.py
@@ -29,8 +29,7 @@ def test_create_new_rollout_approve_remote_settings_cirrus(
 
     SummaryPage(selenium, experiment_url).open().wait_for_live_status()
 
-    home = HomePage(selenium, base_url).open()
-    assert True in [experiment_name in item.text for item in home.tables[0].experiments]
+    HomePage(selenium, base_url).open().find_in_table(experiment_name)
 
     # demo app frontend, default displays "Not Enrolled"
     navigate_to(selenium)
@@ -93,8 +92,7 @@ def test_create_new_experiment_approve_remote_settings_cirrus(
 
     SummaryPage(selenium, experiment_url).open().wait_for_live_status()
 
-    home = HomePage(selenium, base_url).open()
-    assert True in [experiment_name in item.text for item in home.tables[0].experiments]
+    HomePage(selenium, base_url).open().find_in_table(experiment_name)
 
     # Demo app frontend, by default, returns "Not Enrolled" message
     navigate_to(selenium)

--- a/experimenter/tests/integration/nimbus/test_experimenter_ui.py
+++ b/experimenter/tests/integration/nimbus/test_experimenter_ui.py
@@ -38,9 +38,7 @@ def test_archive_experiment(
     summary.wait_for_archive_label_visible()
 
     # Check it's archived on the home page
-    HomePage(selenium, archived_tab_url).open().find_in_table(
-        "Archived", default_data.public_name
-    )
+    HomePage(selenium, archived_tab_url).open().find_in_table(default_data.public_name)
 
     # Unarchive the experiment
     summary = SummaryPage(selenium, experiment_url).open()
@@ -48,9 +46,7 @@ def test_archive_experiment(
     summary.wait_for_archive_label_not_visible()
 
     # Check it's in drafts on the home page
-    HomePage(selenium, drafts_tab_url).open().find_in_table(
-        "Draft", default_data.public_name
-    )
+    HomePage(selenium, drafts_tab_url).open().find_in_table(default_data.public_name)
 
 
 @pytest.mark.nimbus_ui

--- a/experimenter/tests/integration/nimbus/test_remote_settings.py
+++ b/experimenter/tests/integration/nimbus/test_remote_settings.py
@@ -24,8 +24,7 @@ def test_create_new_experiment_approve_remote_settings(
 
     SummaryPage(selenium, experiment_url).open().wait_for_live_status()
 
-    home = HomePage(selenium, base_url).open()
-    assert experiment_slug in [item.text for item in home.tables[0].experiments]
+    HomePage(selenium, base_url).open().find_in_table(experiment_slug)
 
 
 @pytest.mark.remote_settings
@@ -49,8 +48,7 @@ def test_create_new_rollout_approve_remote_settings(
 
     SummaryPage(selenium, experiment_url).open().wait_for_live_status()
 
-    home = HomePage(selenium, base_url).open()
-    assert experiment_slug in [item.text for item in home.tables[0].experiments]
+    HomePage(selenium, base_url).open().find_in_table(experiment_slug)
 
 
 @pytest.mark.remote_settings


### PR DESCRIPTION
Because

* The new Nimbus list page has completed testing and is ready for use

This commit

* Swaps the urls in both the Django and React routers for the new Nimbus List page
* Disables React tests that expect PageHome to be available at /

fixes #10714

