### PR TITLE
bug(nimbus): Redirect to correct review URL for prefFlips experiments

### DIFF
--- a/experimenter/experimenter/experiments/models.py
+++ b/experimenter/experimenter/experiments/models.py
@@ -764,7 +764,7 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
             return "{base_url}{collection_path}/{collection}/{review_path}".format(
                 base_url=settings.KINTO_ADMIN_URL,
                 collection_path="#/buckets/main-workspace/collections",
-                collection=self.application_config.default_kinto_collection,
+                collection=self.application_config.get_kinto_collection_for(self),
                 review_path="simple-review",
             )
 

--- a/experimenter/experimenter/experiments/tests/test_models.py
+++ b/experimenter/experimenter/experiments/tests/test_models.py
@@ -1578,6 +1578,26 @@ class TestNimbusExperiment(TestCase):
             )
             self.assertEqual(experiment.review_url, expected)
 
+    def test_review_url_prefflips_feature(self):
+        feature_config = NimbusFeatureConfigFactory.create(
+            slug="prefFlips",
+            application=NimbusExperiment.Application.DESKTOP,
+        )
+
+        with override_settings(
+            KINTO_ADMIN_URL="http://kinto/v1/admin/",
+        ):
+            experiment = NimbusExperimentFactory.create_with_lifecycle(
+                NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE,
+                application=NimbusExperiment.Application.DESKTOP,
+                feature_configs=[feature_config],
+            )
+
+            self.assertEqual(
+                experiment.review_url,
+                "http://kinto/v1/admin/#/buckets/main-workspace/collections/nimbus-secure-experiments/simple-review",
+            )
+
     def test_clear_branches_deletes_branches_without_deleting_experiment(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.CREATED,


### PR DESCRIPTION
Because:
- the prefFlips feature on Firefox Desktop publishes to a different collection than regular Firefox Desktop experiments

this commit:
- updates the review URL for experiments with this feature.

Fixes #10829.