### PR TITLE
chore(project): use absolute paths for CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
-cirrus/ @jaredlockhart @yashikakhurana @jeddai
-experimenter/experimenter/ @jaredlockhart @yashikakhurana @brennie
-experimenter/manifesttool/ @jaredlockhart @brennie
-schemas/ @jaredlockhart @mikewilli
-experimenter/tests @jrbenny35
+/cirrus/ @jaredlockhart @yashikakhurana @jeddai
+/experimenter/experimenter/ @jaredlockhart @yashikakhurana @brennie
+/experimenter/manifesttool/ @jaredlockhart @brennie
+/schemas/ @jaredlockhart @mikewilli
+/experimenter/tests @jrbenny35


### PR DESCRIPTION
Because

- the CODEOWNERS file matches paths that do not begin with a slash on any part of files names
- our paths listed in CODEOWNERS are actually relative to the repository root

This commit:

- updates CODEOWNERS to use absolute paths.