### PR TITLE
Adds advanced targeting for existing users, need default, on windows build 1903

### DIFF
--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -1528,7 +1528,10 @@ EXISTING_USER_NEED_DEFAULT = NimbusTargetingConfig(
 EXISTING_USER_NEED_DEFAULT_WIN1903 = NimbusTargetingConfig(
     name="Existing user (need default, Windows 1903+)",
     slug="existing_user_need_default_windows_1903",
-    description="Users with profiles older than 28 days who have not set to default, on Windows 1903+",
+    description=(
+        "Users with profiles older than 28 days "
+        "who have not set to default, on Windows 1903+"
+        ),
     targeting=f"{PROFILE28DAYS} && {NEED_DEFAULT} && {WIN1903}",
     desktop_telemetry="",
     sticky_required=True,

--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -1525,6 +1525,17 @@ EXISTING_USER_NEED_DEFAULT = NimbusTargetingConfig(
     application_choice_names=(Application.DESKTOP.name,),
 )
 
+EXISTING_USER_NEED_DEFAULT_WIN1903 = NimbusTargetingConfig(
+    name="Existing user (need default)",
+    slug="existing_user_need_default",
+    description="Users with profiles older than 28 days who have not set to default, on Windows 1903+",
+    targeting=f"{PROFILE28DAYS} && {NEED_DEFAULT} && {WIN1903}",
+    desktop_telemetry="",
+    sticky_required=True,
+    is_first_run_required=False,
+    application_choice_names=(Application.DESKTOP.name,),
+)
+
 NEW_USER_FIVE_BOOKMARKS = NimbusTargetingConfig(
     name="New user (5 bookmarks)",
     slug="new_user_5_bookmarks",

--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -1531,7 +1531,7 @@ EXISTING_USER_NEED_DEFAULT_WIN1903 = NimbusTargetingConfig(
     description=(
         "Users with profiles older than 28 days "
         "who have not set to default, on Windows 1903+"
-        ),
+    ),
     targeting=f"{PROFILE28DAYS} && {NEED_DEFAULT} && {WIN1903}",
     desktop_telemetry="",
     sticky_required=True,

--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -1526,8 +1526,8 @@ EXISTING_USER_NEED_DEFAULT = NimbusTargetingConfig(
 )
 
 EXISTING_USER_NEED_DEFAULT_WIN1903 = NimbusTargetingConfig(
-    name="Existing user (need default)",
-    slug="existing_user_need_default",
+    name="Existing user (need default, Windows 1903+)",
+    slug="existing_user_need_default_windows_1903",
     description="Users with profiles older than 28 days who have not set to default, on Windows 1903+",
     targeting=f"{PROFILE28DAYS} && {NEED_DEFAULT} && {WIN1903}",
     desktop_telemetry="",


### PR DESCRIPTION
Because

- We'd like to target existing users, needing default on windows 10+ (build 1903+) so that we can run the [1-click default existing users experiment](https://docs.google.com/document/d/1dY6smuMFfT_cf05vtUe4MaSeHvTmy88DydrGhtLLvLY/edit)

This commit

- Extends the existing [EXISTING_USER_NEED_DEFAULT](https://github.com/mozilla/experimenter/blob/main/experimenter/experimenter/targeting/constants.py#L1517) to include [WIN1903](https://github.com/mozilla/experimenter/blob/main/experimenter/experimenter/targeting/constants.py#L36) check.

Fixes #10904