### PR TITLE
bug(nimbus): Correctly publish and reject recipes for applications with multiple kinto collections

### DIFF
--- a/experimenter/experimenter/experiments/api/v5/serializers.py
+++ b/experimenter/experimenter/experiments/api/v5/serializers.py
@@ -1042,9 +1042,7 @@ class NimbusExperimentSerializer(
 
             if self.should_call_push_task:
                 # We validate that this won't throw in NimbusReviewSerializer.
-                collection = experiment.application_config.get_kinto_collection_for(
-                    experiment
-                )
+                collection = experiment.kinto_collection
                 nimbus_check_kinto_push_queue_by_collection.apply_async(
                     countdown=5, args=[collection]
                 )

--- a/experimenter/experimenter/experiments/constants.py
+++ b/experimenter/experimenter/experiments/constants.py
@@ -93,6 +93,8 @@ class ApplicationConfig:
         return collections
 
 
+DESKTOP_PREFFLIPS_SLUG = "prefFlips"
+
 APPLICATION_CONFIG_DESKTOP = ApplicationConfig(
     name="Firefox Desktop",
     slug="firefox-desktop",
@@ -110,7 +112,7 @@ APPLICATION_CONFIG_DESKTOP = ApplicationConfig(
     randomization_unit=BucketRandomizationUnit.NORMANDY,
     is_web=False,
     kinto_collections_by_feature_id={
-        "prefFlips": settings.KINTO_COLLECTION_NIMBUS_SECURE,
+        DESKTOP_PREFFLIPS_SLUG: settings.KINTO_COLLECTION_NIMBUS_SECURE,
     },
 )
 
@@ -369,6 +371,8 @@ class NimbusConstants:
         Application.FXA: APPLICATION_CONFIG_FXA_WEB,
         Application.DEMO_APP: APPLICATION_CONFIG_DEMO_APP,
     }
+
+    DESKTOP_PREFFLIPS_SLUG = DESKTOP_PREFFLIPS_SLUG
 
     Channel = Channel
 

--- a/experimenter/experimenter/experiments/models.py
+++ b/experimenter/experimenter/experiments/models.py
@@ -66,71 +66,65 @@ class NimbusExperimentManager(models.Manager["NimbusExperiment"]):
             .order_by("-_updated_date_time")
         )
 
+    def for_collection(self, query, collection):
+        return (e for e in query if e.kinto_collection == collection)
+
     def launch_queue(self, applications, collection):
-        return (
-            e
-            for e in self.filter(
+        return self.for_collection(
+            self.filter(
                 NimbusExperiment.Filters.IS_LAUNCH_QUEUED,
                 application__in=applications,
-            )
-            if e.kinto_collection == collection
+            ),
+            collection,
         )
 
     def update_queue(self, applications, collection):
-        return (
-            e
-            for e in self.filter(
+        return self.for_collection(
+            self.filter(
                 NimbusExperiment.Filters.IS_UPDATE_QUEUED,
                 application__in=applications,
-            )
-            if e.kinto_collection == collection
+            ),
+            collection,
         )
 
     def end_queue(self, applications, collection):
-        return (
-            e
-            for e in self.filter(
+        return self.for_collection(
+            self.filter(
                 NimbusExperiment.Filters.IS_END_QUEUED,
                 application__in=applications,
-            )
-            if e.kinto_collection == collection
+            ),
+            collection,
         )
 
     def waiting(self, applications, collection):
-        return (
-            e
-            for e in self.filter(
+        return self.for_collection(
+            self.filter(
                 publish_status=NimbusExperiment.PublishStatus.WAITING,
                 application__in=applications,
-            )
-            if e.kinto_collection == collection
+            ),
+            collection,
         )
 
     def waiting_to_launch_queue(self, applications, collection):
-        return (
-            e
-            for e in self.filter(
+        return self.for_collection(
+            self.filter(
                 NimbusExperiment.Filters.IS_LAUNCHING, application__in=applications
-            )
-            if e.kinto_collection == collection
+            ),
+            collection,
         )
 
     def waiting_to_update_queue(self, applications, collection):
-        return (
-            e
-            for e in self.filter(
+        return self.for_collection(
+            self.filter(
                 NimbusExperiment.Filters.IS_UPDATING, application__in=applications
-            )
-            if e.kinto_collection == collection
+            ),
+            collection,
         )
 
     def waiting_to_end_queue(self, applications, collection):
-        return (
-            e
-            for e in self.filter(
-                NimbusExperiment.Filters.IS_ENDING, application__in=applications
-            )
-            if e.kinto_collection == collection
+        return self.for_collection(
+            self.filter(NimbusExperiment.Filters.IS_ENDING, application__in=applications),
+            collection,
         )
 
 

--- a/experimenter/experimenter/experiments/models.py
+++ b/experimenter/experimenter/experiments/models.py
@@ -66,43 +66,71 @@ class NimbusExperimentManager(models.Manager["NimbusExperiment"]):
             .order_by("-_updated_date_time")
         )
 
-    def launch_queue(self, applications):
-        return self.filter(
-            NimbusExperiment.Filters.IS_LAUNCH_QUEUED,
-            application__in=applications,
+    def launch_queue(self, applications, collection):
+        return (
+            e
+            for e in self.filter(
+                NimbusExperiment.Filters.IS_LAUNCH_QUEUED,
+                application__in=applications,
+            )
+            if e.kinto_collection == collection
         )
 
-    def update_queue(self, applications):
-        return self.filter(
-            NimbusExperiment.Filters.IS_UPDATE_QUEUED,
-            application__in=applications,
+    def update_queue(self, applications, collection):
+        return (
+            e
+            for e in self.filter(
+                NimbusExperiment.Filters.IS_UPDATE_QUEUED,
+                application__in=applications,
+            )
+            if e.kinto_collection == collection
         )
 
-    def end_queue(self, applications):
-        return self.filter(
-            NimbusExperiment.Filters.IS_END_QUEUED,
-            application__in=applications,
+    def end_queue(self, applications, collection):
+        return (
+            e
+            for e in self.filter(
+                NimbusExperiment.Filters.IS_END_QUEUED,
+                application__in=applications,
+            )
+            if e.kinto_collection == collection
         )
 
-    def waiting(self, applications):
-        return self.filter(
-            publish_status=NimbusExperiment.PublishStatus.WAITING,
-            application__in=applications,
+    def waiting(self, applications, collection):
+        return (
+            e
+            for e in self.filter(
+                publish_status=NimbusExperiment.PublishStatus.WAITING,
+                application__in=applications,
+            )
+            if e.kinto_collection == collection
         )
 
-    def waiting_to_launch_queue(self, applications):
-        return self.filter(
-            NimbusExperiment.Filters.IS_LAUNCHING, application__in=applications
+    def waiting_to_launch_queue(self, applications, collection):
+        return (
+            e
+            for e in self.filter(
+                NimbusExperiment.Filters.IS_LAUNCHING, application__in=applications
+            )
+            if e.kinto_collection == collection
         )
 
-    def waiting_to_update_queue(self, applications):
-        return self.filter(
-            NimbusExperiment.Filters.IS_UPDATING, application__in=applications
+    def waiting_to_update_queue(self, applications, collection):
+        return (
+            e
+            for e in self.filter(
+                NimbusExperiment.Filters.IS_UPDATING, application__in=applications
+            )
+            if e.kinto_collection == collection
         )
 
-    def waiting_to_end_queue(self, applications):
-        return self.filter(
-            NimbusExperiment.Filters.IS_ENDING, application__in=applications
+    def waiting_to_end_queue(self, applications, collection):
+        return (
+            e
+            for e in self.filter(
+                NimbusExperiment.Filters.IS_ENDING, application__in=applications
+            )
+            if e.kinto_collection == collection
         )
 
 
@@ -1136,6 +1164,13 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
     @property
     def get_firefox_max_version_display(self):
         return self.firefox_max_version.replace("!", "0")
+
+    @property
+    def kinto_collection(self):
+        # Note: this can throw if there are conflicting features targeting
+        # different collections.
+        if self.application_config:
+            return self.application_config.get_kinto_collection_for(self)
 
 
 class NimbusBranch(models.Model):

--- a/experimenter/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_experiment_serializer.py
+++ b/experimenter/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_experiment_serializer.py
@@ -954,10 +954,7 @@ class TestNimbusExperimentSerializer(TestCase):
         )
         self.assertTrue(serializer.is_valid())
 
-        expected_collection = experiment.application_config.get_kinto_collection_for(
-            experiment,
-        )
-
+        expected_collection = experiment.kinto_collection
         experiment = serializer.save()
         self.assertEqual(
             experiment.publish_status, NimbusExperiment.PublishStatus.APPROVED

--- a/experimenter/experimenter/experiments/tests/test_models.py
+++ b/experimenter/experimenter/experiments/tests/test_models.py
@@ -90,10 +90,54 @@ class TestNimbusExperimentManager(TestCase):
         self.assertEqual(
             list(
                 NimbusExperiment.objects.launch_queue(
-                    [NimbusExperiment.Application.DESKTOP]
+                    [NimbusExperiment.Application.DESKTOP],
+                    settings.KINTO_COLLECTION_NIMBUS_DESKTOP,
                 )
             ),
             [experiment1],
+        )
+
+    def test_launch_queue_multiple_collections(self):
+        test_feature = NimbusFeatureConfigFactory.create(
+            slug="test-feature",
+            name="test-feature",
+            application=NimbusExperiment.Application.DESKTOP,
+        )
+        prefflips_feature = NimbusFeatureConfigFactory.create(
+            slug=NimbusConstants.DESKTOP_PREFFLIPS_SLUG,
+            name=NimbusConstants.DESKTOP_PREFFLIPS_SLUG,
+            application=NimbusExperiment.Application.DESKTOP,
+        )
+
+        test_feature_experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE,
+            application=NimbusExperiment.Application.DESKTOP,
+            feature_configs=[test_feature],
+        )
+        prefflips_experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE,
+            application=NimbusExperiment.Application.DESKTOP,
+            feature_configs=[prefflips_feature],
+        )
+
+        self.assertEqual(
+            list(
+                NimbusExperiment.objects.launch_queue(
+                    [NimbusExperiment.Application.DESKTOP],
+                    settings.KINTO_COLLECTION_NIMBUS_DESKTOP,
+                )
+            ),
+            [test_feature_experiment],
+        )
+
+        self.assertEqual(
+            list(
+                NimbusExperiment.objects.launch_queue(
+                    [NimbusExperiment.Application.DESKTOP],
+                    settings.KINTO_COLLECTION_NIMBUS_SECURE,
+                )
+            ),
+            [prefflips_experiment],
         )
 
     def test_end_queue_returns_ending_experiments_with_correct_application(self):
@@ -118,9 +162,55 @@ class TestNimbusExperimentManager(TestCase):
         )
         self.assertEqual(
             list(
-                NimbusExperiment.objects.end_queue([NimbusExperiment.Application.DESKTOP])
+                NimbusExperiment.objects.end_queue(
+                    [NimbusExperiment.Application.DESKTOP],
+                    settings.KINTO_COLLECTION_NIMBUS_DESKTOP,
+                )
             ),
             [experiment1],
+        )
+
+    def test_end_queue_multiple_collections(self):
+        test_feature = NimbusFeatureConfigFactory.create(
+            slug="test-feature",
+            name="test-feature",
+            application=NimbusExperiment.Application.DESKTOP,
+        )
+        prefflips_feature = NimbusFeatureConfigFactory.create(
+            slug=NimbusConstants.DESKTOP_PREFFLIPS_SLUG,
+            name=NimbusConstants.DESKTOP_PREFFLIPS_SLUG,
+            application=NimbusExperiment.Application.DESKTOP,
+        )
+
+        test_feature_experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.ENDING_APPROVE,
+            application=NimbusExperiment.Application.DESKTOP,
+            feature_configs=[test_feature],
+        )
+        prefflips_experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.ENDING_APPROVE,
+            application=NimbusExperiment.Application.DESKTOP,
+            feature_configs=[prefflips_feature],
+        )
+
+        self.assertEqual(
+            list(
+                NimbusExperiment.objects.end_queue(
+                    [NimbusExperiment.Application.DESKTOP],
+                    settings.KINTO_COLLECTION_NIMBUS_DESKTOP,
+                )
+            ),
+            [test_feature_experiment],
+        )
+
+        self.assertEqual(
+            list(
+                NimbusExperiment.objects.end_queue(
+                    [NimbusExperiment.Application.DESKTOP],
+                    settings.KINTO_COLLECTION_NIMBUS_SECURE,
+                )
+            ),
+            [prefflips_experiment],
         )
 
     def test_update_queue_returns_experiments_that_should_update_by_application(self):
@@ -145,10 +235,53 @@ class TestNimbusExperimentManager(TestCase):
         self.assertEqual(
             list(
                 NimbusExperiment.objects.update_queue(
-                    [NimbusExperiment.Application.DESKTOP]
+                    [NimbusExperiment.Application.DESKTOP],
+                    settings.KINTO_COLLECTION_NIMBUS_DESKTOP,
                 )
             ),
             [experiment_should_update],
+        )
+
+    def test_update_queue_multiple_collections(self):
+        test_feature = NimbusFeatureConfigFactory.create(
+            slug="test-feature",
+            name="test-feature",
+            application=NimbusExperiment.Application.DESKTOP,
+        )
+        prefflips_feature = NimbusFeatureConfigFactory.create(
+            slug=NimbusConstants.DESKTOP_PREFFLIPS_SLUG,
+            name=NimbusConstants.DESKTOP_PREFFLIPS_SLUG,
+            application=NimbusExperiment.Application.DESKTOP,
+        )
+
+        test_feature_experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.PAUSING_APPROVE,
+            application=NimbusExperiment.Application.DESKTOP,
+            feature_configs=[test_feature],
+        )
+        prefflips_experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.PAUSING_APPROVE,
+            application=NimbusExperiment.Application.DESKTOP,
+            feature_configs=[prefflips_feature],
+        )
+        self.assertEqual(
+            list(
+                NimbusExperiment.objects.update_queue(
+                    [NimbusExperiment.Application.DESKTOP],
+                    settings.KINTO_COLLECTION_NIMBUS_DESKTOP,
+                )
+            ),
+            [test_feature_experiment],
+        )
+
+        self.assertEqual(
+            list(
+                NimbusExperiment.objects.update_queue(
+                    [NimbusExperiment.Application.DESKTOP],
+                    settings.KINTO_COLLECTION_NIMBUS_SECURE,
+                )
+            ),
+            [prefflips_experiment],
         )
 
     def test_waiting_returns_any_waiting_experiments(self):
@@ -162,9 +295,55 @@ class TestNimbusExperimentManager(TestCase):
         )
         self.assertEqual(
             list(
-                NimbusExperiment.objects.waiting([NimbusExperiment.Application.DESKTOP])
+                NimbusExperiment.objects.waiting(
+                    [NimbusExperiment.Application.DESKTOP],
+                    settings.KINTO_COLLECTION_NIMBUS_DESKTOP,
+                )
             ),
             [desktop_live_waiting],
+        )
+
+    def test_waiting_multiple_collections(self):
+        test_feature = NimbusFeatureConfigFactory.create(
+            slug="test-feature",
+            name="test-feature",
+            application=NimbusExperiment.Application.DESKTOP,
+        )
+        prefflips_feature = NimbusFeatureConfigFactory.create(
+            slug=NimbusConstants.DESKTOP_PREFFLIPS_SLUG,
+            name=NimbusConstants.DESKTOP_PREFFLIPS_SLUG,
+            application=NimbusExperiment.Application.DESKTOP,
+        )
+
+        test_feature_experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE_WAITING,
+            application=NimbusExperiment.Application.DESKTOP,
+            feature_configs=[test_feature],
+        )
+        prefflips_experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE_WAITING,
+            application=NimbusExperiment.Application.DESKTOP,
+            feature_configs=[prefflips_feature],
+        )
+
+        self.assertEqual(
+            list(
+                NimbusExperiment.objects.waiting(
+                    [NimbusExperiment.Application.DESKTOP],
+                    settings.KINTO_COLLECTION_NIMBUS_DESKTOP,
+                )
+            ),
+            [test_feature_experiment],
+        )
+
+        self.assertEqual(
+            list(
+                NimbusExperiment.objects.waiting(
+                    [NimbusExperiment.Application.DESKTOP],
+                    settings.KINTO_COLLECTION_NIMBUS_SECURE,
+                )
+            ),
+            [prefflips_experiment],
         )
 
     def test_waiting_to_launch_only_returns_launching_experiments(self):
@@ -187,9 +366,53 @@ class TestNimbusExperimentManager(TestCase):
 
         self.assertEqual(
             list(
-                NimbusExperiment.objects.waiting_to_launch_queue([launching.application])
+                NimbusExperiment.objects.waiting_to_launch_queue(
+                    [launching.application], settings.KINTO_COLLECTION_NIMBUS_DESKTOP
+                )
             ),
             [launching],
+        )
+
+    def test_waiting_to_launch_multiple_collections(self):
+        test_feature = NimbusFeatureConfigFactory.create(
+            slug="test-feature",
+            name="test-feature",
+            application=NimbusExperiment.Application.DESKTOP,
+        )
+        prefflips_feature = NimbusFeatureConfigFactory.create(
+            slug=NimbusConstants.DESKTOP_PREFFLIPS_SLUG,
+            name=NimbusConstants.DESKTOP_PREFFLIPS_SLUG,
+            application=NimbusExperiment.Application.DESKTOP,
+        )
+
+        test_feature_experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE_WAITING,
+            application=NimbusExperiment.Application.DESKTOP,
+            feature_configs=[test_feature],
+        )
+        prefflips_experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE_WAITING,
+            application=NimbusExperiment.Application.DESKTOP,
+            feature_configs=[prefflips_feature],
+        )
+
+        self.assertEqual(
+            list(
+                NimbusExperiment.objects.waiting_to_launch_queue(
+                    [NimbusExperiment.Application.DESKTOP],
+                    settings.KINTO_COLLECTION_NIMBUS_DESKTOP,
+                )
+            ),
+            [test_feature_experiment],
+        )
+        self.assertEqual(
+            list(
+                NimbusExperiment.objects.waiting_to_launch_queue(
+                    [NimbusExperiment.Application.DESKTOP],
+                    settings.KINTO_COLLECTION_NIMBUS_SECURE,
+                )
+            ),
+            [prefflips_experiment],
         )
 
     def test_waiting_to_update_only_returns_updating_experiments(self):
@@ -217,8 +440,54 @@ class TestNimbusExperimentManager(TestCase):
         )
 
         self.assertEqual(
-            list(NimbusExperiment.objects.waiting_to_update_queue([application])),
+            list(
+                NimbusExperiment.objects.waiting_to_update_queue(
+                    [application], settings.KINTO_COLLECTION_NIMBUS_DESKTOP
+                )
+            ),
             [pausing],
+        )
+
+    def test_waiting_to_update_multiple_collection(self):
+        test_feature = NimbusFeatureConfigFactory.create(
+            slug="test-feature",
+            name="test-feature",
+            application=NimbusExperiment.Application.DESKTOP,
+        )
+        prefflips_feature = NimbusFeatureConfigFactory.create(
+            slug=NimbusConstants.DESKTOP_PREFFLIPS_SLUG,
+            name=NimbusConstants.DESKTOP_PREFFLIPS_SLUG,
+            application=NimbusExperiment.Application.DESKTOP,
+        )
+
+        test_feature_experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.PAUSING_APPROVE_WAITING,
+            application=NimbusExperiment.Application.DESKTOP,
+            feature_configs=[test_feature],
+        )
+        prefflips_experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.PAUSING_APPROVE_WAITING,
+            application=NimbusExperiment.Application.DESKTOP,
+            feature_configs=[prefflips_feature],
+        )
+
+        self.assertEqual(
+            list(
+                NimbusExperiment.objects.waiting_to_update_queue(
+                    [NimbusExperiment.Application.DESKTOP],
+                    settings.KINTO_COLLECTION_NIMBUS_DESKTOP,
+                )
+            ),
+            [test_feature_experiment],
+        )
+        self.assertEqual(
+            list(
+                NimbusExperiment.objects.waiting_to_update_queue(
+                    [NimbusExperiment.Application.DESKTOP],
+                    settings.KINTO_COLLECTION_NIMBUS_SECURE,
+                )
+            ),
+            [prefflips_experiment],
         )
 
 
@@ -1580,7 +1849,7 @@ class TestNimbusExperiment(TestCase):
 
     def test_review_url_prefflips_feature(self):
         feature_config = NimbusFeatureConfigFactory.create(
-            slug="prefFlips",
+            slug=NimbusConstants.DESKTOP_PREFFLIPS_SLUG,
             application=NimbusExperiment.Application.DESKTOP,
         )
 
@@ -3570,7 +3839,7 @@ class ApplicationConfigTests(TestCase):
         ):
             experiment = self._create_experiment(["feature-1"])
             self.assertEqual(
-                self.application_config.get_kinto_collection_for(experiment),
+                experiment.kinto_collection,
                 self.application_config.default_kinto_collection,
             )
 
@@ -3591,7 +3860,7 @@ class ApplicationConfigTests(TestCase):
             with self.assertRaisesRegex(
                 AssertionError, "Experiment targets multiple collections"
             ):
-                self.application_config.get_kinto_collection_for(experiment)
+                experiment.kinto_collection  # noqa: B018
 
     @parameterized.expand(
         [

--- a/experimenter/experimenter/experiments/tests/test_models.py
+++ b/experimenter/experimenter/experiments/tests/test_models.py
@@ -97,7 +97,7 @@ class TestNimbusExperimentManager(TestCase):
             [experiment1],
         )
 
-    def test_launch_queue_multiple_collections(self):
+    def test_launch_queue_filters_by_collection(self):
         test_feature = NimbusFeatureConfigFactory.create(
             slug="test-feature",
             name="test-feature",
@@ -170,7 +170,7 @@ class TestNimbusExperimentManager(TestCase):
             [experiment1],
         )
 
-    def test_end_queue_multiple_collections(self):
+    def test_end_queue_filters_by_collection(self):
         test_feature = NimbusFeatureConfigFactory.create(
             slug="test-feature",
             name="test-feature",
@@ -242,7 +242,7 @@ class TestNimbusExperimentManager(TestCase):
             [experiment_should_update],
         )
 
-    def test_update_queue_multiple_collections(self):
+    def test_update_queue_filters_by_collection(self):
         test_feature = NimbusFeatureConfigFactory.create(
             slug="test-feature",
             name="test-feature",
@@ -303,7 +303,7 @@ class TestNimbusExperimentManager(TestCase):
             [desktop_live_waiting],
         )
 
-    def test_waiting_multiple_collections(self):
+    def test_waiting_filters_by_collection(self):
         test_feature = NimbusFeatureConfigFactory.create(
             slug="test-feature",
             name="test-feature",
@@ -373,7 +373,7 @@ class TestNimbusExperimentManager(TestCase):
             [launching],
         )
 
-    def test_waiting_to_launch_multiple_collections(self):
+    def test_waiting_to_launch_filters_by_collection(self):
         test_feature = NimbusFeatureConfigFactory.create(
             slug="test-feature",
             name="test-feature",

--- a/experimenter/experimenter/experiments/tests/test_models.py
+++ b/experimenter/experimenter/experiments/tests/test_models.py
@@ -448,7 +448,7 @@ class TestNimbusExperimentManager(TestCase):
             [pausing],
         )
 
-    def test_waiting_to_update_multiple_collection(self):
+    def test_waiting_to_update_filters_by_collection(self):
         test_feature = NimbusFeatureConfigFactory.create(
             slug="test-feature",
             name="test-feature",

--- a/experimenter/experimenter/kinto/tests/test_tasks.py
+++ b/experimenter/experimenter/kinto/tests/test_tasks.py
@@ -13,10 +13,26 @@ from experimenter.experiments.models import (
     NimbusEmail,
     NimbusExperiment,
 )
-from experimenter.experiments.tests.factories import NimbusExperimentFactory
+from experimenter.experiments.tests.factories import (
+    NimbusExperimentFactory,
+    NimbusFeatureConfigFactory,
+)
 from experimenter.kinto import tasks
 from experimenter.kinto.client import KINTO_REVIEW_STATUS, KINTO_ROLLBACK_STATUS
 from experimenter.kinto.tests.mixins import MockKintoClientMixin
+
+PREFFLIPS_PARAMETERIZED_CASES = [
+    (
+        "test-feature",
+        settings.KINTO_COLLECTION_NIMBUS_DESKTOP,
+        settings.KINTO_COLLECTION_NIMBUS_SECURE,
+    ),
+    (
+        "prefFlips",
+        settings.KINTO_COLLECTION_NIMBUS_SECURE,
+        settings.KINTO_COLLECTION_NIMBUS_DESKTOP,
+    ),
+]
 
 
 class TestNimbusCheckKintoPushQueue(MockKintoClientMixin, TestCase):
@@ -38,7 +54,144 @@ class TestNimbusCheckKintoPushQueue(MockKintoClientMixin, TestCase):
             self.mock_dispatchee_task.assert_any_call(collection)
 
 
-class TestNimbusCheckKintoPushQueueByCollection(MockKintoClientMixin, TestCase):
+@staticmethod
+def create_desktop_feature(slug):
+    return NimbusFeatureConfigFactory.create(
+        name=slug,
+        slug=slug,
+        application=NimbusExperiment.Application.DESKTOP,
+    )
+
+
+class KintoTaskTestUtilsMixin:
+    def _assert_experiment_status_unchanged(self, experiment):
+        old_status = experiment.status
+        old_publish_status = experiment.publish_status
+
+        experiment.refresh_from_db()
+
+        self.assertEqual(old_status, experiment.status)
+        self.assertEqual(old_publish_status, experiment.publish_status)
+
+    def _assert_experiment_status_changed(
+        self,
+        experiment,
+        *,
+        old_status,
+        new_status,
+        old_publish_status,
+        new_publish_status,
+        filter_kwargs=None,
+    ):
+        if filter_kwargs is None:
+            filter_kwargs = {}
+
+        self.assertEqual(experiment.status, old_status)
+        self.assertEqual(experiment.publish_status, old_publish_status)
+
+        experiment.refresh_from_db()
+        self.assertEqual(experiment.status, new_status)
+        self.assertEqual(experiment.publish_status, new_publish_status)
+        self.assertTrue(
+            experiment.changes.filter(
+                old_status=old_status,
+                new_status=new_status,
+                old_publish_status=old_publish_status,
+                new_publish_status=new_publish_status,
+                **filter_kwargs,
+            ).exists()
+        )
+
+    def _assert_check_collection_unchanged(self, collection):
+        tasks.nimbus_check_kinto_push_queue_by_collection(collection)
+        self.mock_push_task.assert_not_called()
+        self.mock_update_task.assert_not_called()
+        self.mock_end_task.assert_not_called()
+        self.mock_kinto_client.patch_collection.assert_not_called()
+
+    def _assert_check_collection_changed(
+        self,
+        collection,
+        *,
+        updated=None,
+        ended=None,
+        pushed=None,
+        collection_patched=False,
+    ):
+        if not any((updated, ended, pushed, collection_patched)):
+            raise ValueError("Expected at least one keyword arugment")
+
+        tasks.nimbus_check_kinto_push_queue_by_collection(collection)
+
+        if updated:
+            self.mock_update_task.assert_called_once_with(collection, updated.id)
+        else:
+            self.mock_update_task.assert_not_called()
+
+        if ended:
+            self.mock_end_task.assert_called_once_with(collection, ended.id)
+        else:
+            self.mock_end_task.assert_not_called()
+
+        if pushed:
+            self.mock_push_task.assert_called_once_with(collection, pushed.id)
+        else:
+            self.mock_push_task.assert_not_called()
+
+        if collection_patched:
+            self.mock_kinto_client.patch_collection.assert_called_once_with(
+                id=collection,
+                data={"status": KINTO_ROLLBACK_STATUS},
+                bucket=settings.KINTO_BUCKET_WORKSPACE,
+            )
+        else:
+            self.mock_kinto_client.patch_collection.assert_not_called()
+
+    def _assert_push_experiment_creates_record(self, collection, experiment):
+        tasks.nimbus_push_experiment_to_kinto(collection, experiment.id)
+
+        self.mock_kinto_client.create_record.assert_called_with(
+            data=mock.ANY,
+            collection=collection,
+            bucket=settings.KINTO_BUCKET_WORKSPACE,
+            if_not_exists=True,
+        )
+
+    def _assert_update_experiment_updates_record(self, collection, experiment):
+        tasks.nimbus_update_experiment_in_kinto(collection, experiment.id)
+
+        self.mock_kinto_client.update_record.assert_called_with(
+            data=NimbusExperimentSerializer(experiment).data,
+            collection=collection,
+            bucket=settings.KINTO_BUCKET_WORKSPACE,
+            if_match='"0"',
+        )
+
+        self.mock_kinto_client.patch_collection.assert_called_with(
+            id=collection,
+            data={"status": KINTO_REVIEW_STATUS},
+            bucket=settings.KINTO_BUCKET_WORKSPACE,
+        )
+
+    def _assert_end_experiment_deletes_record(self, collection, experiment):
+        tasks.nimbus_end_experiment_in_kinto(collection, experiment.id)
+
+        self.mock_kinto_client.delete_record.assert_called_with(
+            id=experiment.slug,
+            collection=collection,
+            bucket=settings.KINTO_BUCKET_WORKSPACE,
+        )
+
+        self.mock_kinto_client.patch_collection.assert_called_with(
+            id=collection,
+            data={"status": KINTO_REVIEW_STATUS},
+            bucket=settings.KINTO_BUCKET_WORKSPACE,
+        )
+
+
+class TestNimbusCheckKintoPushQueueByCollection(
+    MockKintoClientMixin, KintoTaskTestUtilsMixin, TestCase
+):
     def setUp(self):
         super().setUp()
         mock_push_task_patcher = mock.patch(
@@ -99,506 +252,490 @@ class TestNimbusCheckKintoPushQueueByCollection(MockKintoClientMixin, TestCase):
 
     @parameterized.expand(
         [
-            [
+            (lifecycle, *params)
+            for lifecycle in (
                 NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE_WAITING,
-            ],
-            [
                 NimbusExperimentFactory.Lifecycles.PAUSING_APPROVE_WAITING,
-            ],
-            [
                 NimbusExperimentFactory.Lifecycles.ENDING_APPROVE_WAITING,
-            ],
+            )
+            for params in PREFFLIPS_PARAMETERIZED_CASES
         ]
     )
     @override_settings(KINTO_REVIEW_TIMEOUT=60)
-    def test_check_with_pending_review_before_timeout_aborts_early(self, lifecycle):
-        NimbusExperimentFactory.create_with_lifecycle(
+    def test_check_with_pending_review_before_timeout_aborts_early(
+        self, lifecycle, feature_slug, target_collection, alternate_collection
+    ):
+        feature_config = create_desktop_feature(feature_slug)
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
             lifecycle=lifecycle,
             application=NimbusExperiment.Application.DESKTOP,
             with_latest_change_now=True,
+            feature_configs=[feature_config],
         )
 
         self.setup_kinto_get_main_records([])
+        self.setup_kinto_no_pending_review()
+
+        self._assert_check_collection_unchanged(alternate_collection)
+        self._assert_experiment_status_unchanged(experiment)
+
         self.setup_kinto_pending_review()
 
-        tasks.nimbus_check_kinto_push_queue_by_collection(
-            settings.KINTO_COLLECTION_NIMBUS_DESKTOP
-        )
-        self.mock_kinto_client.patch_collection.assert_not_called()
-        self.mock_push_task.assert_not_called()
-        self.mock_update_task.assert_not_called()
-        self.mock_end_task.assert_not_called()
+        self._assert_check_collection_unchanged(target_collection)
+        self._assert_experiment_status_unchanged(experiment)
 
+    @parameterized.expand(PREFFLIPS_PARAMETERIZED_CASES)
     def test_check_with_approved_launch_and_no_kinto_pending_pushes_experiment(
         self,
+        feature_slug,
+        target_collection,
+        alternate_collection,
     ):
+        feature_config = create_desktop_feature(feature_slug)
         launching_experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE,
             application=NimbusExperiment.Application.DESKTOP,
+            feature_configs=[feature_config],
         )
 
         self.setup_kinto_get_main_records([])
         self.setup_kinto_no_pending_review()
 
-        tasks.nimbus_check_kinto_push_queue_by_collection(
-            settings.KINTO_COLLECTION_NIMBUS_DESKTOP
-        )
-        self.mock_push_task.assert_called_with(
-            settings.KINTO_COLLECTION_NIMBUS_DESKTOP, launching_experiment.id
+        self._assert_check_collection_unchanged(alternate_collection)
+        self._assert_experiment_status_unchanged(launching_experiment)
+
+        self._assert_check_collection_changed(
+            target_collection, pushed=launching_experiment
         )
 
+    @parameterized.expand(PREFFLIPS_PARAMETERIZED_CASES)
     def test_check_with_approved_update_and_no_kinto_pending_updates_experiment(
         self,
+        feature_slug,
+        target_collection,
+        alternate_collection,
     ):
+        feature_config = create_desktop_feature(feature_slug)
         launching_experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.PAUSING_APPROVE,
             application=NimbusExperiment.Application.DESKTOP,
+            feature_configs=[feature_config],
         )
 
         self.setup_kinto_get_main_records([])
         self.setup_kinto_no_pending_review()
 
-        tasks.nimbus_check_kinto_push_queue_by_collection(
-            settings.KINTO_COLLECTION_NIMBUS_DESKTOP
-        )
-        self.mock_update_task.assert_called_with(
-            settings.KINTO_COLLECTION_NIMBUS_DESKTOP, launching_experiment.id
+        self._assert_check_collection_unchanged(alternate_collection)
+        self._assert_experiment_status_unchanged(launching_experiment)
+
+        self._assert_check_collection_changed(
+            target_collection, updated=launching_experiment
         )
 
-    def test_check_with_approved_end_and_no_kinto_pending_ends_experiment(self):
+    @parameterized.expand(PREFFLIPS_PARAMETERIZED_CASES)
+    def test_check_with_approved_end_and_no_kinto_pending_ends_experiment(
+        self, feature_slug, target_collection, alternate_collection
+    ):
+        feature_config = create_desktop_feature(feature_slug)
         ending_experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.ENDING_APPROVE,
             application=NimbusExperiment.Application.DESKTOP,
+            feature_configs=[feature_config],
         )
 
         self.setup_kinto_get_main_records([])
         self.setup_kinto_no_pending_review()
 
-        tasks.nimbus_check_kinto_push_queue_by_collection(
-            settings.KINTO_COLLECTION_NIMBUS_DESKTOP
-        )
-        self.mock_end_task.assert_called_with(
-            settings.KINTO_COLLECTION_NIMBUS_DESKTOP, ending_experiment.id
-        )
+        self._assert_check_collection_unchanged(alternate_collection)
+        self._assert_experiment_status_unchanged(ending_experiment)
 
+        self._assert_check_collection_changed(target_collection, ended=ending_experiment)
+
+    @parameterized.expand(PREFFLIPS_PARAMETERIZED_CASES)
     @override_settings(KINTO_REVIEW_TIMEOUT=0)
     def test_check_with_timeout_launch_review_and_queued_launch_rolls_back_and_pushes(
-        self,
+        self, feature_slug, target_collection, alternate_collection
     ):
+        feature_config = create_desktop_feature(feature_slug)
         pending_experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE_WAITING,
             application=NimbusExperiment.Application.DESKTOP,
             published_date=timezone.now(),
+            feature_configs=[feature_config],
         )
         launching_experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE,
             application=NimbusExperiment.Application.DESKTOP,
+            feature_configs=[feature_config],
         )
 
         self.setup_kinto_get_main_records([])
+        self.setup_kinto_no_pending_review()
+
+        self._assert_check_collection_unchanged(alternate_collection)
+        self._assert_experiment_status_unchanged(pending_experiment)
+        self._assert_experiment_status_unchanged(launching_experiment)
+
         self.setup_kinto_pending_review()
 
-        tasks.nimbus_check_kinto_push_queue_by_collection(
-            settings.KINTO_COLLECTION_NIMBUS_DESKTOP
+        self._assert_check_collection_changed(
+            target_collection, pushed=launching_experiment, collection_patched=True
         )
-
-        self.mock_push_task.assert_called_with(
-            settings.KINTO_COLLECTION_NIMBUS_DESKTOP, launching_experiment.id
-        )
-        self.mock_kinto_client.patch_collection.assert_called_with(
-            id=settings.KINTO_COLLECTION_NIMBUS_DESKTOP,
-            data={"status": "to-rollback"},
-            bucket="main-workspace",
-        )
-
-        pending_experiment = NimbusExperiment.objects.get(id=pending_experiment.id)
-        self.assertEqual(
-            pending_experiment.publish_status, NimbusExperiment.PublishStatus.REVIEW
+        self._assert_experiment_status_changed(
+            pending_experiment,
+            old_status=NimbusExperiment.Status.DRAFT,
+            new_status=NimbusExperiment.Status.DRAFT,
+            old_publish_status=NimbusExperiment.PublishStatus.WAITING,
+            new_publish_status=NimbusExperiment.PublishStatus.REVIEW,
         )
         self.assertIsNone(pending_experiment.published_date)
-        self.assertTrue(
-            pending_experiment.changes.filter(
-                old_status=NimbusExperiment.Status.DRAFT,
-                old_publish_status=NimbusExperiment.PublishStatus.WAITING,
-                new_status=NimbusExperiment.Status.DRAFT,
-                new_publish_status=NimbusExperiment.PublishStatus.REVIEW,
-            ).exists()
-        )
 
+    @parameterized.expand(PREFFLIPS_PARAMETERIZED_CASES)
     @override_settings(KINTO_REVIEW_TIMEOUT=0)
     def test_check_with_timeout_update_review_and_queued_launch_rolls_back_and_pushes(
-        self,
+        self, feature_slug, target_collection, alternate_collection
     ):
+        feature_config = create_desktop_feature(feature_slug)
         expected_published_date = timezone.now()
         pending_experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.PAUSING_APPROVE_WAITING,
             application=NimbusExperiment.Application.DESKTOP,
             published_date=expected_published_date,
+            feature_configs=[feature_config],
         )
         launching_experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE,
             application=NimbusExperiment.Application.DESKTOP,
+            feature_configs=[feature_config],
         )
 
         self.setup_kinto_get_main_records([])
+        self.setup_kinto_no_pending_review()
+
+        self._assert_check_collection_unchanged(alternate_collection)
+        self._assert_experiment_status_unchanged(pending_experiment)
+        self._assert_experiment_status_unchanged(launching_experiment)
+
         self.setup_kinto_pending_review()
 
-        tasks.nimbus_check_kinto_push_queue_by_collection(
-            settings.KINTO_COLLECTION_NIMBUS_DESKTOP
+        self._assert_check_collection_changed(
+            target_collection, pushed=launching_experiment, collection_patched=True
         )
-
-        self.mock_push_task.assert_called_with(
-            settings.KINTO_COLLECTION_NIMBUS_DESKTOP, launching_experiment.id
-        )
-        self.mock_kinto_client.patch_collection.assert_called_with(
-            id=settings.KINTO_COLLECTION_NIMBUS_DESKTOP,
-            data={"status": "to-rollback"},
-            bucket="main-workspace",
-        )
-
-        pending_experiment = NimbusExperiment.objects.get(id=pending_experiment.id)
-        self.assertEqual(
-            pending_experiment.publish_status, NimbusExperiment.PublishStatus.REVIEW
+        self._assert_experiment_status_changed(
+            pending_experiment,
+            old_status=NimbusExperiment.Status.LIVE,
+            new_status=NimbusExperiment.Status.LIVE,
+            old_publish_status=NimbusExperiment.PublishStatus.WAITING,
+            new_publish_status=NimbusExperiment.PublishStatus.REVIEW,
         )
         self.assertEqual(pending_experiment.published_date, expected_published_date)
-        self.assertTrue(
-            pending_experiment.changes.filter(
-                old_status=NimbusExperiment.Status.LIVE,
-                old_publish_status=NimbusExperiment.PublishStatus.WAITING,
-                new_status=NimbusExperiment.Status.LIVE,
-                new_publish_status=NimbusExperiment.PublishStatus.REVIEW,
-            ).exists()
-        )
 
+    @parameterized.expand(PREFFLIPS_PARAMETERIZED_CASES)
     @override_settings(KINTO_REVIEW_TIMEOUT=0)
     def test_check_with_timeout_end_review_and_queued_launch_rolls_back_and_pushes(
-        self,
+        self, feature_slug, target_collection, alternate_collection
     ):
+        feature_config = create_desktop_feature(feature_slug)
         expected_published_date = timezone.now()
         pending_experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.ENDING_APPROVE_WAITING,
             application=NimbusExperiment.Application.DESKTOP,
             published_date=expected_published_date,
+            feature_configs=[feature_config],
         )
         launching_experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE,
             application=NimbusExperiment.Application.DESKTOP,
+            feature_configs=[feature_config],
         )
 
         self.setup_kinto_get_main_records([])
+        self.setup_kinto_no_pending_review()
+
+        self._assert_check_collection_unchanged(alternate_collection)
+        self._assert_experiment_status_unchanged(pending_experiment)
+        self._assert_experiment_status_unchanged(launching_experiment)
+
         self.setup_kinto_pending_review()
 
-        tasks.nimbus_check_kinto_push_queue_by_collection(
-            settings.KINTO_COLLECTION_NIMBUS_DESKTOP
+        self._assert_check_collection_changed(
+            target_collection, pushed=launching_experiment, collection_patched=True
         )
-
-        self.mock_push_task.assert_called_with(
-            settings.KINTO_COLLECTION_NIMBUS_DESKTOP, launching_experiment.id
-        )
-        self.mock_kinto_client.patch_collection.assert_called_with(
-            id=settings.KINTO_COLLECTION_NIMBUS_DESKTOP,
-            data={"status": "to-rollback"},
-            bucket="main-workspace",
-        )
-
-        pending_experiment = NimbusExperiment.objects.get(id=pending_experiment.id)
-        self.assertEqual(
-            pending_experiment.publish_status, NimbusExperiment.PublishStatus.REVIEW
+        self._assert_experiment_status_changed(
+            pending_experiment,
+            old_status=NimbusExperiment.Status.LIVE,
+            new_status=NimbusExperiment.Status.LIVE,
+            old_publish_status=NimbusExperiment.PublishStatus.WAITING,
+            new_publish_status=NimbusExperiment.PublishStatus.REVIEW,
         )
         self.assertEqual(pending_experiment.published_date, expected_published_date)
-        self.assertTrue(
-            pending_experiment.changes.filter(
-                old_status=NimbusExperiment.Status.LIVE,
-                old_publish_status=NimbusExperiment.PublishStatus.WAITING,
-                new_status=NimbusExperiment.Status.LIVE,
-                new_publish_status=NimbusExperiment.PublishStatus.REVIEW,
-            ).exists()
-        )
 
-    def test_check_with_rejected_launch_rolls_back_and_pushes(self):
+    @parameterized.expand(PREFFLIPS_PARAMETERIZED_CASES)
+    def test_check_with_rejected_launch_rolls_back_and_pushes(
+        self,
+        feature_slug,
+        target_collection,
+        alternate_collection,
+    ):
+        feature_config = create_desktop_feature(feature_slug)
         rejected_experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE_WAITING,
             application=NimbusExperiment.Application.DESKTOP,
             published_date=timezone.now(),
+            feature_configs=[feature_config],
         )
         launching_experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE,
             application=NimbusExperiment.Application.DESKTOP,
+            feature_configs=[feature_config],
         )
 
         self.setup_kinto_get_main_records([])
+        self.setup_kinto_no_pending_review()
+
+        self._assert_check_collection_unchanged(alternate_collection)
+        self._assert_experiment_status_unchanged(rejected_experiment)
+        self._assert_experiment_status_unchanged(launching_experiment)
+
         self.setup_kinto_rejected_review()
-
-        tasks.nimbus_check_kinto_push_queue_by_collection(
-            settings.KINTO_COLLECTION_NIMBUS_DESKTOP
+        self._assert_check_collection_changed(
+            target_collection, pushed=launching_experiment, collection_patched=True
         )
-
-        self.mock_push_task.assert_called_with(
-            settings.KINTO_COLLECTION_NIMBUS_DESKTOP, launching_experiment.id
-        )
-        self.mock_kinto_client.patch_collection.assert_called_with(
-            id=settings.KINTO_COLLECTION_NIMBUS_DESKTOP,
-            bucket=settings.KINTO_BUCKET_WORKSPACE,
-            data={"status": KINTO_ROLLBACK_STATUS},
-        )
-
-        rejected_experiment = NimbusExperiment.objects.get(id=rejected_experiment.id)
-        self.assertEqual(rejected_experiment.status, NimbusExperiment.Status.DRAFT)
-        self.assertEqual(
-            rejected_experiment.publish_status, NimbusExperiment.PublishStatus.IDLE
+        self._assert_experiment_status_changed(
+            rejected_experiment,
+            old_status=NimbusExperiment.Status.DRAFT,
+            new_status=NimbusExperiment.Status.DRAFT,
+            old_publish_status=NimbusExperiment.PublishStatus.WAITING,
+            new_publish_status=NimbusExperiment.PublishStatus.IDLE,
+            filter_kwargs={
+                "changed_by__email": settings.KINTO_DEFAULT_CHANGELOG_USER,
+            },
         )
         self.assertIsNone(rejected_experiment.status_next)
         self.assertIsNone(rejected_experiment.published_date)
 
-        self.assertTrue(
-            rejected_experiment.changes.filter(
-                changed_by__email=settings.KINTO_DEFAULT_CHANGELOG_USER,
-                old_status=NimbusExperiment.Status.DRAFT,
-                old_publish_status=NimbusExperiment.PublishStatus.WAITING,
-                new_status=NimbusExperiment.Status.DRAFT,
-                new_publish_status=NimbusExperiment.PublishStatus.IDLE,
-            ).exists()
-        )
-
-    def test_check_with_rejected_update_rolls_back_and_pushes(self):
+    @parameterized.expand(PREFFLIPS_PARAMETERIZED_CASES)
+    def test_check_with_rejected_update_rolls_back_and_pushes(
+        self, feature_slug, target_collection, alternate_collection
+    ):
         expected_published_date = timezone.now()
+        feature_config = create_desktop_feature(feature_slug)
         rejected_experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.PAUSING_APPROVE_WAITING,
             application=NimbusExperiment.Application.DESKTOP,
             published_date=expected_published_date,
+            feature_configs=[feature_config],
         )
         launching_experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE,
             application=NimbusExperiment.Application.DESKTOP,
+            feature_configs=[feature_config],
         )
 
         self.setup_kinto_get_main_records([])
+        self.setup_kinto_no_pending_review()
+
+        self._assert_check_collection_unchanged(alternate_collection)
+        self._assert_experiment_status_unchanged(rejected_experiment)
+        self._assert_experiment_status_unchanged(launching_experiment)
+
         self.setup_kinto_rejected_review()
 
-        tasks.nimbus_check_kinto_push_queue_by_collection(
-            settings.KINTO_COLLECTION_NIMBUS_DESKTOP
+        self._assert_check_collection_changed(
+            target_collection, pushed=launching_experiment, collection_patched=True
         )
-
-        self.mock_push_task.assert_called_with(
-            settings.KINTO_COLLECTION_NIMBUS_DESKTOP, launching_experiment.id
-        )
-        self.mock_kinto_client.patch_collection.assert_called_with(
-            id=settings.KINTO_COLLECTION_NIMBUS_DESKTOP,
-            bucket=settings.KINTO_BUCKET_WORKSPACE,
-            data={"status": KINTO_ROLLBACK_STATUS},
-        )
-
-        rejected_experiment = NimbusExperiment.objects.get(id=rejected_experiment.id)
-        self.assertEqual(rejected_experiment.status, NimbusExperiment.Status.LIVE)
-        self.assertEqual(
-            rejected_experiment.publish_status, NimbusExperiment.PublishStatus.IDLE
+        self._assert_experiment_status_changed(
+            rejected_experiment,
+            old_status=NimbusExperiment.Status.LIVE,
+            old_publish_status=NimbusExperiment.PublishStatus.WAITING,
+            new_status=NimbusExperiment.Status.LIVE,
+            new_publish_status=NimbusExperiment.PublishStatus.IDLE,
+            filter_kwargs={
+                "changed_by__email": settings.KINTO_DEFAULT_CHANGELOG_USER,
+            },
         )
         self.assertIsNone(rejected_experiment.status_next)
         self.assertFalse(rejected_experiment.is_paused)
         self.assertEqual(rejected_experiment.published_date, expected_published_date)
 
-        self.assertTrue(
-            rejected_experiment.changes.filter(
-                changed_by__email=settings.KINTO_DEFAULT_CHANGELOG_USER,
-                old_status=NimbusExperiment.Status.LIVE,
-                old_publish_status=NimbusExperiment.PublishStatus.WAITING,
-                new_status=NimbusExperiment.Status.LIVE,
-                new_publish_status=NimbusExperiment.PublishStatus.IDLE,
-            ).exists()
-        )
-
-    def test_check_with_rejected_update_live_rollout_rolls_back_and_pushes(self):
+    @parameterized.expand(PREFFLIPS_PARAMETERIZED_CASES)
+    def test_check_with_rejected_update_live_rollout_rolls_back_and_pushes(
+        self, feature_slug, target_collection, alternate_collection
+    ):
         expected_published_date = timezone.now()
+        feature_config = create_desktop_feature(feature_slug)
         rejected_experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.LIVE_APPROVE_WAITING,
             application=NimbusExperiment.Application.DESKTOP,
             is_rollout=True,
             is_rollout_dirty=True,
             published_date=expected_published_date,
+            feature_configs=[feature_config],
         )
+
         self.setup_kinto_get_main_records([])
+        self.setup_kinto_no_pending_review()
+
+        self._assert_check_collection_unchanged(alternate_collection)
+        self._assert_experiment_status_unchanged(rejected_experiment)
+
         self.setup_kinto_rejected_review()
 
-        tasks.nimbus_check_kinto_push_queue_by_collection(
-            settings.KINTO_COLLECTION_NIMBUS_DESKTOP
-        )
-
-        self.mock_kinto_client.patch_collection.assert_called_with(
-            id=settings.KINTO_COLLECTION_NIMBUS_DESKTOP,
-            bucket=settings.KINTO_BUCKET_WORKSPACE,
-            data={"status": KINTO_ROLLBACK_STATUS},
-        )
-
-        rejected_experiment = NimbusExperiment.objects.get(id=rejected_experiment.id)
-        self.assertEqual(rejected_experiment.status, NimbusExperiment.Status.LIVE)
-        self.assertEqual(
-            rejected_experiment.publish_status, NimbusExperiment.PublishStatus.IDLE
+        self._assert_check_collection_changed(target_collection, collection_patched=True)
+        self._assert_experiment_status_changed(
+            rejected_experiment,
+            old_status=NimbusExperiment.Status.LIVE,
+            old_publish_status=NimbusExperiment.PublishStatus.WAITING,
+            new_status=NimbusExperiment.Status.LIVE,
+            new_publish_status=NimbusExperiment.PublishStatus.IDLE,
+            filter_kwargs={
+                "changed_by__email": settings.KINTO_DEFAULT_CHANGELOG_USER,
+            },
         )
         self.assertTrue(rejected_experiment.is_rollout_dirty)
         self.assertIsNone(rejected_experiment.status_next)
         self.assertFalse(rejected_experiment.is_paused)
         self.assertEqual(rejected_experiment.published_date, expected_published_date)
 
-        self.assertTrue(
-            rejected_experiment.changes.filter(
-                changed_by__email=settings.KINTO_DEFAULT_CHANGELOG_USER,
-                old_status=NimbusExperiment.Status.LIVE,
-                old_publish_status=NimbusExperiment.PublishStatus.WAITING,
-                new_status=NimbusExperiment.Status.LIVE,
-                new_publish_status=NimbusExperiment.PublishStatus.IDLE,
-            ).exists()
-        )
-
-    def test_check_with_rejected_end_rolls_back_and_pushes(self):
+    @parameterized.expand(PREFFLIPS_PARAMETERIZED_CASES)
+    def test_check_with_rejected_end_rolls_back_and_pushes(
+        self, feature_slug, target_collection, alternate_collection
+    ):
         expected_published_date = timezone.now()
+        feature_config = create_desktop_feature(feature_slug)
         rejected_experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.ENDING_APPROVE_WAITING,
             application=NimbusExperiment.Application.DESKTOP,
             published_date=expected_published_date,
+            feature_configs=[feature_config],
         )
         launching_experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE,
             application=NimbusExperiment.Application.DESKTOP,
+            feature_configs=[feature_config],
         )
 
         self.setup_kinto_get_main_records([])
+        self.setup_kinto_no_pending_review()
+
+        self._assert_check_collection_unchanged(alternate_collection)
+        self._assert_experiment_status_unchanged(rejected_experiment)
+        self._assert_experiment_status_unchanged(launching_experiment)
+
         self.setup_kinto_rejected_review()
-
-        tasks.nimbus_check_kinto_push_queue_by_collection(
-            settings.KINTO_COLLECTION_NIMBUS_DESKTOP
+        self._assert_check_collection_changed(
+            target_collection, pushed=launching_experiment, collection_patched=True
         )
 
-        self.mock_push_task.assert_called_with(
-            settings.KINTO_COLLECTION_NIMBUS_DESKTOP, launching_experiment.id
-        )
-        self.mock_kinto_client.patch_collection.assert_called_with(
-            id=settings.KINTO_COLLECTION_NIMBUS_DESKTOP,
-            bucket=settings.KINTO_BUCKET_WORKSPACE,
-            data={"status": KINTO_ROLLBACK_STATUS},
-        )
-
-        rejected_experiment = NimbusExperiment.objects.get(id=rejected_experiment.id)
-        self.assertEqual(rejected_experiment.status, NimbusExperiment.Status.LIVE)
-        self.assertEqual(
-            rejected_experiment.publish_status, NimbusExperiment.PublishStatus.IDLE
+        self._assert_experiment_status_changed(
+            rejected_experiment,
+            old_status=NimbusExperiment.Status.LIVE,
+            new_status=NimbusExperiment.Status.LIVE,
+            old_publish_status=NimbusExperiment.PublishStatus.WAITING,
+            new_publish_status=NimbusExperiment.PublishStatus.IDLE,
+            filter_kwargs={
+                "changed_by__email": settings.KINTO_DEFAULT_CHANGELOG_USER,
+            },
         )
         self.assertEqual(rejected_experiment.status_next, None)
         self.assertEqual(rejected_experiment.published_date, expected_published_date)
 
-        self.assertTrue(
-            rejected_experiment.changes.filter(
-                changed_by__email=settings.KINTO_DEFAULT_CHANGELOG_USER,
-                old_status=NimbusExperiment.Status.LIVE,
-                old_publish_status=NimbusExperiment.PublishStatus.WAITING,
-                new_status=NimbusExperiment.Status.LIVE,
-                new_publish_status=NimbusExperiment.PublishStatus.IDLE,
-            ).exists()
-        )
-
-    def test_check_with_rollout_rejected_end_rolls_back_and_pushes(self):
+    @parameterized.expand(PREFFLIPS_PARAMETERIZED_CASES)
+    def test_check_with_rollout_rejected_end_rolls_back_and_pushes(
+        self, feature_slug, target_collection, alternate_collection
+    ):
         expected_published_date = timezone.now()
+        feature_config = create_desktop_feature(feature_slug)
         rejected_rollout = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.ENDING_APPROVE_WAITING,
             application=NimbusExperiment.Application.DESKTOP,
             is_rollout=True,
             published_date=expected_published_date,
+            feature_configs=[feature_config],
         )
         launching_rollout = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE,
             application=NimbusExperiment.Application.DESKTOP,
             is_rollout=True,
+            feature_configs=[feature_config],
         )
 
         self.setup_kinto_get_main_records([])
+        self.setup_kinto_no_pending_review()
+
+        self._assert_check_collection_unchanged(alternate_collection)
+        self._assert_experiment_status_unchanged(rejected_rollout)
+        self._assert_experiment_status_unchanged(launching_rollout)
+
         self.setup_kinto_rejected_review()
-
-        tasks.nimbus_check_kinto_push_queue_by_collection(
-            settings.KINTO_COLLECTION_NIMBUS_DESKTOP
+        self._assert_check_collection_changed(
+            target_collection, pushed=launching_rollout, collection_patched=True
         )
-
-        self.mock_push_task.assert_called_with(
-            settings.KINTO_COLLECTION_NIMBUS_DESKTOP, launching_rollout.id
-        )
-        self.mock_kinto_client.patch_collection.assert_called_with(
-            id=settings.KINTO_COLLECTION_NIMBUS_DESKTOP,
-            bucket=settings.KINTO_BUCKET_WORKSPACE,
-            data={"status": KINTO_ROLLBACK_STATUS},
-        )
-
-        rejected_rollout = NimbusExperiment.objects.get(id=rejected_rollout.id)
-        self.assertEqual(rejected_rollout.status, NimbusExperiment.Status.LIVE)
-        self.assertEqual(
-            rejected_rollout.publish_status, NimbusExperiment.PublishStatus.IDLE
+        self._assert_experiment_status_changed(
+            rejected_rollout,
+            old_status=NimbusExperiment.Status.LIVE,
+            old_publish_status=NimbusExperiment.PublishStatus.WAITING,
+            new_status=NimbusExperiment.Status.LIVE,
+            new_publish_status=NimbusExperiment.PublishStatus.IDLE,
+            filter_kwargs={
+                "changed_by__email": settings.KINTO_DEFAULT_CHANGELOG_USER,
+            },
         )
         self.assertEqual(rejected_rollout.status_next, None)
         self.assertEqual(rejected_rollout.published_date, expected_published_date)
 
-        self.assertTrue(
-            rejected_rollout.changes.filter(
-                changed_by__email=settings.KINTO_DEFAULT_CHANGELOG_USER,
-                old_status=NimbusExperiment.Status.LIVE,
-                old_publish_status=NimbusExperiment.PublishStatus.WAITING,
-                new_status=NimbusExperiment.Status.LIVE,
-                new_publish_status=NimbusExperiment.PublishStatus.IDLE,
-            ).exists()
-        )
-
-    def test_check_with_dirty_rollout_rejected_end_rolls_back_and_pushes(self):
+    @parameterized.expand(PREFFLIPS_PARAMETERIZED_CASES)
+    def test_check_with_dirty_rollout_rejected_end_rolls_back_and_pushes(
+        self, feature_slug, target_collection, alternate_collection
+    ):
         expected_published_date = timezone.now()
+        feature_config = create_desktop_feature(feature_slug)
         rejected_rollout = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.LIVE_DIRTY_ENDING_APPROVE_WAITING,
             application=NimbusExperiment.Application.DESKTOP,
             is_rollout=True,
             is_rollout_dirty=True,
             published_date=expected_published_date,
+            feature_configs=[feature_config],
         )
         launching_rollout = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE,
             application=NimbusExperiment.Application.DESKTOP,
             is_rollout=True,
+            feature_configs=[feature_config],
         )
 
-        # launch
         self.setup_kinto_get_main_records([])
+        self.setup_kinto_no_pending_review()
+
+        self._assert_check_collection_unchanged(alternate_collection)
+        self._assert_experiment_status_unchanged(rejected_rollout)
+        self._assert_experiment_status_unchanged(launching_rollout)
+
         self.setup_kinto_rejected_review()
 
-        tasks.nimbus_check_kinto_push_queue_by_collection(
-            settings.KINTO_COLLECTION_NIMBUS_DESKTOP
+        self._assert_check_collection_changed(
+            target_collection, pushed=launching_rollout, collection_patched=True
         )
-
-        self.mock_push_task.assert_called_with(
-            settings.KINTO_COLLECTION_NIMBUS_DESKTOP, launching_rollout.id
-        )
-
-        self.mock_kinto_client.patch_collection.assert_called_with(
-            id=settings.KINTO_COLLECTION_NIMBUS_DESKTOP,
-            bucket=settings.KINTO_BUCKET_WORKSPACE,
-            data={"status": KINTO_ROLLBACK_STATUS},
-        )
-
-        # get rejected rollout
-        rejected_rollout = NimbusExperiment.objects.get(id=rejected_rollout.id)
-        self.assertEqual(rejected_rollout.status, NimbusExperiment.Status.LIVE)
-        self.assertEqual(
-            rejected_rollout.publish_status, NimbusExperiment.PublishStatus.IDLE
+        self._assert_experiment_status_changed(
+            rejected_rollout,
+            old_status=NimbusExperiment.Status.LIVE,
+            old_publish_status=NimbusExperiment.PublishStatus.WAITING,
+            new_status=NimbusExperiment.Status.LIVE,
+            new_publish_status=NimbusExperiment.PublishStatus.IDLE,
+            filter_kwargs={
+                "changed_by__email": settings.KINTO_DEFAULT_CHANGELOG_USER,
+            },
         )
         self.assertEqual(rejected_rollout.status_next, None)
         self.assertTrue(rejected_rollout.is_rollout_dirty)
         self.assertEqual(rejected_rollout.published_date, expected_published_date)
 
-        self.assertTrue(
-            rejected_rollout.changes.filter(
-                changed_by__email=settings.KINTO_DEFAULT_CHANGELOG_USER,
-                old_status=NimbusExperiment.Status.LIVE,
-                old_publish_status=NimbusExperiment.PublishStatus.WAITING,
-                new_status=NimbusExperiment.Status.LIVE,
-                new_publish_status=NimbusExperiment.PublishStatus.IDLE,
-            ).exists()
-        )
-
+    @parameterized.expand(PREFFLIPS_PARAMETERIZED_CASES)
     def test_check_with_approved_update_sets_experiment_to_idle_saves_published_dto(
-        self,
+        self, feature_slug, target_collection, alternate_collection
     ):
+        feature_config = create_desktop_feature(feature_slug)
         updated_experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.PAUSING_APPROVE_WAITING,
             application=NimbusExperiment.Application.DESKTOP,
@@ -608,268 +745,276 @@ class TestNimbusCheckKintoPushQueueByCollection(MockKintoClientMixin, TestCase):
                 "something": "else",
                 "last_modified": "123",
             },
+            feature_configs=[feature_config],
         )
 
         self.setup_kinto_get_main_records([updated_experiment.slug])
         self.setup_kinto_no_pending_review()
 
-        tasks.nimbus_check_kinto_push_queue_by_collection(
-            settings.KINTO_COLLECTION_NIMBUS_DESKTOP
+        self._assert_check_collection_unchanged(alternate_collection)
+        self._assert_experiment_status_unchanged(updated_experiment)
+
+        self._assert_check_collection_unchanged(target_collection)
+        self._assert_experiment_status_changed(
+            updated_experiment,
+            old_status=NimbusExperiment.Status.LIVE,
+            new_status=NimbusExperiment.Status.LIVE,
+            old_publish_status=NimbusExperiment.PublishStatus.WAITING,
+            new_publish_status=NimbusExperiment.PublishStatus.IDLE,
+            filter_kwargs={
+                "changed_by__email": settings.KINTO_DEFAULT_CHANGELOG_USER,
+            },
         )
 
-        updated_experiment = NimbusExperiment.objects.get(id=updated_experiment.id)
-        self.assertEqual(updated_experiment.status, NimbusExperiment.Status.LIVE)
         self.assertIsNone(updated_experiment.status_next)
-        self.assertEqual(
-            updated_experiment.publish_status, NimbusExperiment.PublishStatus.IDLE
-        )
         self.assertEqual(
             updated_experiment.published_dto,
             {"id": updated_experiment.slug},
         )
-        self.assertTrue(
-            updated_experiment.changes.filter(
-                changed_by__email=settings.KINTO_DEFAULT_CHANGELOG_USER,
-                old_status=NimbusExperiment.Status.LIVE,
-                old_publish_status=NimbusExperiment.PublishStatus.WAITING,
-                new_status=NimbusExperiment.Status.LIVE,
-                new_publish_status=NimbusExperiment.PublishStatus.IDLE,
-            ).exists()
-        )
         self.assertFalse(updated_experiment.is_rollout_dirty)
 
-    def test_check_with_missing_review_and_queued_launch_rolls_back_and_pushes(self):
+    @parameterized.expand(PREFFLIPS_PARAMETERIZED_CASES)
+    def test_check_with_missing_review_and_queued_launch_rolls_back_and_pushes(
+        self, feature_slug, target_collection, alternate_collection
+    ):
+        feature_config = create_desktop_feature(feature_slug)
         launching_experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE,
             application=NimbusExperiment.Application.DESKTOP,
+            feature_configs=[feature_config],
         )
 
         self.setup_kinto_get_main_records([])
+        self.setup_kinto_no_pending_review()
+
+        self._assert_check_collection_unchanged(alternate_collection)
+        self._assert_experiment_status_unchanged(launching_experiment)
+
         self.setup_kinto_pending_review()
 
-        tasks.nimbus_check_kinto_push_queue_by_collection(
-            settings.KINTO_COLLECTION_NIMBUS_DESKTOP
+        self._assert_check_collection_changed(
+            target_collection, pushed=launching_experiment, collection_patched=True
         )
 
-        self.mock_push_task.assert_called_with(
-            settings.KINTO_COLLECTION_NIMBUS_DESKTOP, launching_experiment.id
-        )
-        self.mock_kinto_client.patch_collection.assert_called_with(
-            id=settings.KINTO_COLLECTION_NIMBUS_DESKTOP,
-            data={"status": "to-rollback"},
-            bucket="main-workspace",
-        )
-
-    def test_check_with_missing_rejection_and_queued_launch_rolls_back_and_pushes(self):
+    @parameterized.expand(PREFFLIPS_PARAMETERIZED_CASES)
+    def test_check_with_missing_rejection_and_queued_launch_rolls_back_and_pushes(
+        self, feature_slug, target_collection, alternate_collection
+    ):
+        feature_config = create_desktop_feature(feature_slug)
         launching_experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE,
             application=NimbusExperiment.Application.DESKTOP,
+            feature_configs=[feature_config],
         )
 
         self.setup_kinto_get_main_records([])
+        self.setup_kinto_no_pending_review()
+
+        self._assert_check_collection_unchanged(alternate_collection)
+        self._assert_experiment_status_unchanged(launching_experiment)
+
         self.setup_kinto_rejected_review()
-
-        tasks.nimbus_check_kinto_push_queue_by_collection(
-            settings.KINTO_COLLECTION_NIMBUS_DESKTOP
+        self._assert_check_collection_changed(
+            target_collection, pushed=launching_experiment, collection_patched=True
         )
 
-        self.mock_push_task.assert_called_with(
-            settings.KINTO_COLLECTION_NIMBUS_DESKTOP, launching_experiment.id
-        )
-        self.mock_kinto_client.patch_collection.assert_called_with(
-            id=settings.KINTO_COLLECTION_NIMBUS_DESKTOP,
-            data={"status": "to-rollback"},
-            bucket="main-workspace",
-        )
-
+    @parameterized.expand(PREFFLIPS_PARAMETERIZED_CASES)
     def test_check_waiting_launching_experiment_with_signed_collection_becomes_rejection(
-        self,
+        self, feature_slug, target_collection, alternate_collection
     ):
+        feature_config = create_desktop_feature(feature_slug)
         waiting_experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE_WAITING,
             application=NimbusExperiment.Application.DESKTOP,
             published_date=timezone.now(),
+            feature_configs=[feature_config],
         )
 
         self.setup_kinto_get_main_records([])
         self.setup_kinto_no_pending_review()
 
-        tasks.nimbus_check_kinto_push_queue_by_collection(
-            settings.KINTO_COLLECTION_NIMBUS_DESKTOP
-        )
+        self._assert_check_collection_unchanged(alternate_collection)
+        self._assert_experiment_status_unchanged(waiting_experiment)
 
-        waiting_experiment = NimbusExperiment.objects.get(id=waiting_experiment.id)
-        self.assertEqual(waiting_experiment.status, NimbusExperiment.Status.DRAFT)
+        self._assert_check_collection_unchanged(target_collection)
+        self._assert_experiment_status_changed(
+            waiting_experiment,
+            old_status=NimbusExperiment.Status.DRAFT,
+            new_status=NimbusExperiment.Status.DRAFT,
+            old_publish_status=NimbusExperiment.PublishStatus.WAITING,
+            new_publish_status=NimbusExperiment.PublishStatus.IDLE,
+            filter_kwargs={
+                "changed_by__email": settings.KINTO_DEFAULT_CHANGELOG_USER,
+                "message": NimbusChangeLog.Messages.REJECTED_FROM_KINTO,
+            },
+        )
         self.assertIsNone(waiting_experiment.status_next)
-        self.assertEqual(
-            waiting_experiment.publish_status, NimbusExperiment.PublishStatus.IDLE
-        )
         self.assertIsNone(waiting_experiment.published_date)
-        self.assertTrue(
-            waiting_experiment.changes.filter(
-                changed_by__email=settings.KINTO_DEFAULT_CHANGELOG_USER,
-                old_status=NimbusExperiment.Status.DRAFT,
-                old_publish_status=NimbusExperiment.PublishStatus.WAITING,
-                new_status=NimbusExperiment.Status.DRAFT,
-                new_publish_status=NimbusExperiment.PublishStatus.IDLE,
-                message=NimbusChangeLog.Messages.REJECTED_FROM_KINTO,
-            ).exists()
-        )
 
-    def test_launching_experiment_live_when_record_is_in_main(self):
+    @parameterized.expand(PREFFLIPS_PARAMETERIZED_CASES)
+    def test_launching_experiment_live_when_record_is_in_main(
+        self, feature_slug, target_collection, alternate_collection
+    ):
+        feature_config = create_desktop_feature(feature_slug)
         launching_experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE_WAITING,
             application=NimbusExperiment.Application.DESKTOP,
+            feature_configs=[feature_config],
         )
 
-        self.setup_kinto_get_main_records([launching_experiment.slug])
+        self.setup_kinto_get_main_records([])
         self.setup_kinto_no_pending_review()
 
-        tasks.nimbus_check_kinto_push_queue_by_collection(
-            settings.KINTO_COLLECTION_NIMBUS_DESKTOP
-        )
+        self._assert_check_collection_unchanged(alternate_collection)
+        self._assert_experiment_status_unchanged(launching_experiment)
 
-        launching_experiment = NimbusExperiment.objects.get(id=launching_experiment.id)
-        self.assertEqual(launching_experiment.status, NimbusExperiment.Status.LIVE)
-        self.assertIsNone(launching_experiment.status_next)
-        self.assertEqual(
-            launching_experiment.publish_status, NimbusExperiment.PublishStatus.IDLE
+        self.setup_kinto_get_main_records([launching_experiment.slug])
+
+        self._assert_check_collection_unchanged(target_collection)
+        self._assert_experiment_status_changed(
+            launching_experiment,
+            old_status=NimbusExperiment.Status.DRAFT,
+            new_status=NimbusExperiment.Status.LIVE,
+            old_publish_status=NimbusExperiment.PublishStatus.WAITING,
+            new_publish_status=NimbusExperiment.PublishStatus.IDLE,
+            filter_kwargs={
+                "changed_by__email": settings.KINTO_DEFAULT_CHANGELOG_USER,
+            },
         )
+        self.assertIsNone(launching_experiment.status_next)
         self.assertEqual(
             launching_experiment.published_dto, {"id": launching_experiment.slug}
         )
 
-        self.assertTrue(
-            launching_experiment.changes.filter(
-                changed_by__email=settings.KINTO_DEFAULT_CHANGELOG_USER,
-                old_status=NimbusExperiment.Status.DRAFT,
-                old_publish_status=NimbusExperiment.PublishStatus.WAITING,
-                new_status=NimbusExperiment.Status.LIVE,
-                new_publish_status=NimbusExperiment.PublishStatus.IDLE,
-            ).exists()
-        )
-
-    def test_ending_experiment_completed_when_record_is_not_in_main(self):
+    @parameterized.expand(PREFFLIPS_PARAMETERIZED_CASES)
+    def test_ending_experiment_completed_when_record_is_not_in_main(
+        self, feature_slug, target_collection, alternate_collection
+    ):
+        feature_config = create_desktop_feature(feature_slug)
         experiment1 = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE_APPROVE,
             application=NimbusExperiment.Application.DESKTOP,
+            feature_configs=[feature_config],
         )
         experiment2 = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.ENDING_APPROVE_WAITING,
             application=NimbusExperiment.Application.DESKTOP,
+            feature_configs=[feature_config],
         )
 
-        self.setup_kinto_get_main_records([experiment1.slug])
+        self.setup_kinto_get_main_records([])
         self.setup_kinto_no_pending_review()
 
-        tasks.nimbus_check_kinto_push_queue_by_collection(
-            settings.KINTO_COLLECTION_NIMBUS_DESKTOP
+        self._assert_check_collection_unchanged(alternate_collection)
+
+        self.setup_kinto_get_main_records([experiment1.slug])
+
+        self._assert_check_collection_unchanged(
+            target_collection,
+        )
+        self._assert_experiment_status_unchanged(experiment1)
+        self._assert_experiment_status_changed(
+            experiment2,
+            old_status=NimbusExperiment.Status.LIVE,
+            new_status=NimbusExperiment.Status.COMPLETE,
+            old_publish_status=NimbusExperiment.PublishStatus.WAITING,
+            new_publish_status=NimbusExperiment.PublishStatus.IDLE,
+            filter_kwargs={
+                "changed_by__email": settings.KINTO_DEFAULT_CHANGELOG_USER,
+                "message": NimbusChangeLog.Messages.COMPLETED,
+            },
         )
 
-        self.assertTrue(
-            experiment2.changes.filter(
-                changed_by__email=settings.KINTO_DEFAULT_CHANGELOG_USER,
-                old_status=NimbusExperiment.Status.LIVE,
-                old_publish_status=NimbusExperiment.PublishStatus.WAITING,
-                new_status=NimbusExperiment.Status.COMPLETE,
-                new_publish_status=NimbusExperiment.PublishStatus.IDLE,
-                message=NimbusChangeLog.Messages.COMPLETED,
-            ).exists()
-        )
-
-    def test_updating_experiment_with_published_dto_none_is_skipped(self):
+    @parameterized.expand(PREFFLIPS_PARAMETERIZED_CASES)
+    def test_updating_experiment_with_published_dto_none_is_skipped(
+        self, feature_slug, target_collection, alternate_collection
+    ):
+        feature_config = create_desktop_feature(feature_slug)
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.PAUSING_APPROVE_WAITING,
             application=NimbusExperiment.Application.DESKTOP,
             published_dto=None,
+            feature_configs=[feature_config],
         )
 
-        self.setup_kinto_get_main_records([experiment.slug])
+        self.setup_kinto_get_main_records([])
         self.setup_kinto_no_pending_review()
 
-        tasks.nimbus_check_kinto_push_queue_by_collection(
-            settings.KINTO_COLLECTION_NIMBUS_DESKTOP
-        )
+        self._assert_check_collection_unchanged(alternate_collection)
+        self._assert_experiment_status_unchanged(experiment)
 
-        self.mock_kinto_client.patch_collection.assert_not_called()
-        self.mock_push_task.assert_not_called()
-        self.mock_update_task.assert_not_called()
-        self.mock_end_task.assert_not_called()
+        self.setup_kinto_get_main_records([experiment.slug])
+
+        self._assert_check_collection_unchanged(target_collection)
 
 
-class TestNimbusPushExperimentToKintoTask(MockKintoClientMixin, TestCase):
+class TestNimbusPushExperimentToKintoTask(
+    MockKintoClientMixin, KintoTaskTestUtilsMixin, TestCase
+):
+    @parameterized.expand(PREFFLIPS_PARAMETERIZED_CASES)
     def test_push_experiment_to_kinto(
         self,
+        feature_slug,
+        target_collection,
+        *_unused,
     ):
         """Push desktop experiment to Kinto and validate its outgoing publish status,
         published_date, and changelogs"""
+        feature_config = create_desktop_feature(feature_slug)
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE,
             application=NimbusExperiment.Application.DESKTOP,
             published_date=None,
+            feature_configs=[feature_config],
         )
 
-        tasks.nimbus_push_experiment_to_kinto(
-            settings.KINTO_COLLECTION_NIMBUS_DESKTOP, experiment.id
-        )
-
-        self.mock_kinto_client.create_record.assert_called_with(
-            data=mock.ANY,
-            collection=settings.KINTO_COLLECTION_NIMBUS_DESKTOP,
-            bucket=settings.KINTO_BUCKET_WORKSPACE,
-            if_not_exists=True,
-        )
-
-        experiment = NimbusExperiment.objects.get(id=experiment.id)
-        self.assertEqual(
-            experiment.publish_status, NimbusExperiment.PublishStatus.WAITING
-        )
-        self.assertTrue(
-            experiment.changes.filter(
-                old_publish_status=NimbusExperiment.PublishStatus.APPROVED,
-                new_publish_status=NimbusExperiment.PublishStatus.WAITING,
-                message=NimbusChangeLog.Messages.LAUNCHING_TO_KINTO,
-            ).exists()
+        self._assert_push_experiment_creates_record(target_collection, experiment)
+        self._assert_experiment_status_changed(
+            experiment,
+            old_status=NimbusExperiment.Status.DRAFT,
+            new_status=NimbusExperiment.Status.DRAFT,
+            old_publish_status=NimbusExperiment.PublishStatus.APPROVED,
+            new_publish_status=NimbusExperiment.PublishStatus.WAITING,
+            filter_kwargs={
+                "message": NimbusChangeLog.Messages.LAUNCHING_TO_KINTO,
+            },
         )
         self.assertIsNotNone(experiment.published_date)
 
-    def test_push_experiment_to_kinto_overwrites_existing_published_date_for_draft(self):
+    @parameterized.expand(PREFFLIPS_PARAMETERIZED_CASES)
+    def test_push_experiment_to_kinto_overwrites_existing_published_date_for_draft(
+        self, feature_slug, target_collection, *_unused
+    ):
         existing_published_date = timezone.now()
+        feature_config = create_desktop_feature(feature_slug)
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE,
             application=NimbusExperiment.Application.DESKTOP,
             published_date=existing_published_date,
+            feature_configs=[feature_config],
         )
 
-        tasks.nimbus_push_experiment_to_kinto(
-            settings.KINTO_COLLECTION_NIMBUS_DESKTOP, experiment.id
-        )
-
-        self.mock_kinto_client.create_record.assert_called_with(
-            data=mock.ANY,
-            collection=settings.KINTO_COLLECTION_NIMBUS_DESKTOP,
-            bucket=settings.KINTO_BUCKET_WORKSPACE,
-            if_not_exists=True,
-        )
-
-        experiment = NimbusExperiment.objects.get(id=experiment.id)
-        self.assertEqual(
-            experiment.publish_status, NimbusExperiment.PublishStatus.WAITING
-        )
-        self.assertTrue(
-            experiment.changes.filter(
-                old_publish_status=NimbusExperiment.PublishStatus.APPROVED,
-                new_publish_status=NimbusExperiment.PublishStatus.WAITING,
-                message=NimbusChangeLog.Messages.LAUNCHING_TO_KINTO,
-            ).exists()
+        self._assert_push_experiment_creates_record(target_collection, experiment)
+        self._assert_experiment_status_changed(
+            experiment,
+            old_status=NimbusExperiment.Status.DRAFT,
+            new_status=NimbusExperiment.Status.DRAFT,
+            old_publish_status=NimbusExperiment.PublishStatus.APPROVED,
+            new_publish_status=NimbusExperiment.PublishStatus.WAITING,
+            filter_kwargs={
+                "message": NimbusChangeLog.Messages.LAUNCHING_TO_KINTO,
+            },
         )
         self.assertIsNotNone(experiment.published_date)
         self.assertNotEqual(experiment.published_date, existing_published_date)
 
     def test_push_experiment_to_kinto_reraises_exception(self):
+        feature_config = create_desktop_feature("test-feature")
         experiment = NimbusExperimentFactory.create(
             publish_status=NimbusExperiment.PublishStatus.APPROVED,
+            feature_configs=[feature_config],
         )
+
         self.mock_kinto_client.create_record.side_effect = Exception
         with self.assertRaises(Exception):
             tasks.nimbus_push_experiment_to_kinto(
@@ -877,51 +1022,39 @@ class TestNimbusPushExperimentToKintoTask(MockKintoClientMixin, TestCase):
             )
 
 
-class TestNimbusUpdateExperimentInKinto(MockKintoClientMixin, TestCase):
-    def test_updates_experiment_record_in_kinto(self):
+class TestNimbusUpdateExperimentInKinto(
+    MockKintoClientMixin, KintoTaskTestUtilsMixin, TestCase
+):
+    @parameterized.expand(PREFFLIPS_PARAMETERIZED_CASES)
+    def test_updates_experiment_record_in_kinto(
+        self, feature_slug, target_collection, *_unused
+    ):
         existing_published_date = timezone.now()
+        feature_config = create_desktop_feature(feature_slug)
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.PAUSING_APPROVE,
             application=NimbusExperiment.Application.DESKTOP,
             published_date=existing_published_date,
+            feature_configs=[feature_config],
         )
 
-        tasks.nimbus_update_experiment_in_kinto(
-            settings.KINTO_COLLECTION_NIMBUS_DESKTOP, experiment.id
-        )
-
-        data = NimbusExperimentSerializer(experiment).data
-
-        self.mock_kinto_client.update_record.assert_called_with(
-            data=data,
-            collection=settings.KINTO_COLLECTION_NIMBUS_DESKTOP,
-            bucket=settings.KINTO_BUCKET_WORKSPACE,
-            if_match='"0"',
-        )
-
-        self.mock_kinto_client.patch_collection.assert_called_with(
-            id=settings.KINTO_COLLECTION_NIMBUS_DESKTOP,
-            data={"status": KINTO_REVIEW_STATUS},
-            bucket=settings.KINTO_BUCKET_WORKSPACE,
-        )
-
-        experiment = NimbusExperiment.objects.get(id=experiment.id)
-        self.assertEqual(
-            experiment.publish_status, NimbusExperiment.PublishStatus.WAITING
-        )
-
-        self.assertTrue(
-            experiment.changes.filter(
-                old_publish_status=NimbusExperiment.PublishStatus.APPROVED,
-                new_publish_status=NimbusExperiment.PublishStatus.WAITING,
-                message=NimbusChangeLog.Messages.UPDATING_IN_KINTO,
-            ).exists()
+        self._assert_update_experiment_updates_record(target_collection, experiment)
+        self._assert_experiment_status_changed(
+            experiment,
+            old_status=NimbusExperiment.Status.LIVE,
+            new_status=NimbusExperiment.Status.LIVE,
+            old_publish_status=NimbusExperiment.PublishStatus.APPROVED,
+            new_publish_status=NimbusExperiment.PublishStatus.WAITING,
+            filter_kwargs={
+                "message": NimbusChangeLog.Messages.UPDATING_IN_KINTO,
+            },
         )
         self.assertEqual(experiment.published_date, existing_published_date)
 
-    def test_push_experiment_to_kinto_reraises_exception(self):
+    def test_update_experiment_in_kinto_reraises_exception(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE_APPROVE,
+            application=NimbusExperiment.Application.DESKTOP,
         )
         self.mock_kinto_client.update_record.side_effect = Exception
         with self.assertRaises(Exception):
@@ -930,11 +1063,15 @@ class TestNimbusUpdateExperimentInKinto(MockKintoClientMixin, TestCase):
             )
 
 
-class TestNimbusEndExperimentInKinto(MockKintoClientMixin, TestCase):
+class TestNimbusEndExperimentInKinto(
+    MockKintoClientMixin, KintoTaskTestUtilsMixin, TestCase
+):
     def test_exception_for_failed_delete(self):
+        feature_config = create_desktop_feature("test-feature")
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.CREATED,
             application=NimbusExperiment.Application.DESKTOP,
+            feature_configs=[feature_config],
         )
         self.mock_kinto_client.delete_record.side_effect = Exception
         with self.assertRaises(Exception):
@@ -942,42 +1079,33 @@ class TestNimbusEndExperimentInKinto(MockKintoClientMixin, TestCase):
                 settings.KINTO_COLLECTION_NIMBUS_DESKTOP, experiment.id
             )
 
-    def test_end_experiment_in_kinto_deletes_experiment(self):
+    @parameterized.expand(PREFFLIPS_PARAMETERIZED_CASES)
+    def test_end_experiment_in_kinto_deletes_experiment(
+        self, feature_slug, target_collection, *_unused
+    ):
+        feature_config = create_desktop_feature(feature_slug)
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.ENDING_APPROVE,
             application=NimbusExperiment.Application.DESKTOP,
+            feature_configs=[feature_config],
         )
 
-        tasks.nimbus_end_experiment_in_kinto(
-            settings.KINTO_COLLECTION_NIMBUS_DESKTOP, experiment.id
-        )
-
-        self.mock_kinto_client.delete_record.assert_called_with(
-            id=experiment.slug,
-            collection=settings.KINTO_COLLECTION_NIMBUS_DESKTOP,
-            bucket=settings.KINTO_BUCKET_WORKSPACE,
-        )
-
-        self.mock_kinto_client.patch_collection.assert_called_with(
-            id=settings.KINTO_COLLECTION_NIMBUS_DESKTOP,
-            bucket=settings.KINTO_BUCKET_WORKSPACE,
-            data={"status": KINTO_REVIEW_STATUS},
-        )
-
-        experiment = NimbusExperiment.objects.get(id=experiment.id)
-        self.assertEqual(
-            experiment.publish_status, NimbusExperiment.PublishStatus.WAITING
-        )
-        self.assertTrue(
-            experiment.changes.filter(
-                old_publish_status=NimbusExperiment.PublishStatus.APPROVED,
-                new_publish_status=NimbusExperiment.PublishStatus.WAITING,
-                message=NimbusChangeLog.Messages.DELETING_FROM_KINTO,
-            ).exists()
+        self._assert_end_experiment_deletes_record(target_collection, experiment)
+        self._assert_experiment_status_changed(
+            experiment,
+            old_status=NimbusExperiment.Status.LIVE,
+            new_status=NimbusExperiment.Status.LIVE,
+            old_publish_status=NimbusExperiment.PublishStatus.APPROVED,
+            new_publish_status=NimbusExperiment.PublishStatus.WAITING,
+            filter_kwargs={
+                "message": NimbusChangeLog.Messages.DELETING_FROM_KINTO,
+            },
         )
 
 
-class TestNimbusSynchronizePreviewExperimentsInKinto(MockKintoClientMixin, TestCase):
+class TestNimbusSynchronizePreviewExperimentsInKinto(
+    MockKintoClientMixin, KintoTaskTestUtilsMixin, TestCase
+):
     def test_publishes_preview_experiments_and_unpublishes_non_preview_experiments(
         self,
     ):


### PR DESCRIPTION
Because:

- it used to be the case that a given application would always publish to the same collection; and
- that is no longer the case with the prefFlips feature on Firefox Desktop

this commit:

- updates our publishing logic to take per-experiment kinto collections into account.

Fixes #10830
Fixes #10831