### PR TITLE
chore(nimbus): Change fenix checker to run with update_config job.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -698,8 +698,6 @@ workflows:
                 - main
     jobs:
       - build_firefox_versions
-      - build_firefox_fenix:
-          name: Build Fenix APKs
 
   update_configs:
     triggers:
@@ -712,6 +710,7 @@ workflows:
     jobs:
       - update_external_configs
       - update_application_services
+      - update_fenix_apks
 
   build:
     jobs:


### PR DESCRIPTION
Because

- I added a circleci job to check mozilla-central for new fenix builds, but I forgot to enable it under the correct workflow

This commit

- Enables the job correctly

Fixes https://github.com/mozilla/experimenter/issues/10915