### PR TITLE
chore(nimbus): Fix build step name for fenix updater.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -615,7 +615,7 @@ jobs:
             git config --local user.email "dataops+ci-bot@mozilla.com"
             gh config set git_protocol https
       - run:
-          name: Check for Application Services update
+          name: Check for Fenix Update
           command: |
             git checkout main
             git pull origin main


### PR DESCRIPTION
Because

- The step name is referencing another job

This commit

- Fixes the step name

Fixes #10916