### PR TITLE
chore(schemas): push new version)

### DIFF
--- a/schemas/package.json
+++ b/schemas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mozilla/nimbus-schemas",
-  "version": "2024.3.1",
+  "version": "2024.7.1",
   "description": "Schemas used by Mozilla Nimbus and related projects.",
   "main": "index.d.ts",
   "repository": {

--- a/schemas/pyproject.toml
+++ b/schemas/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "mozilla-nimbus-schemas"
-version = "2024.3.1"
+version = "2024.7.1"
 description = "Schemas used by Mozilla Nimbus and related projects."
 authors = ["mikewilli"]
 license = "MPL 2.0"


### PR DESCRIPTION
Because

- #10930 forgot to change the version number for the npm and pypi packages so a new version was not published

This commit

- changes the version numbers

Fixes #10931 