### PR TITLE
chore(nimbus): Fix fenix integration tests to not use circleci cache.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -673,7 +673,6 @@ jobs:
           name: Build and upload images
           command: |
             cd experimenter/tests/integration/nimbus/android
-            docker build -t moz-central-builder -f moz-central.test-container.Dockerfile . 
             docker run --name fenix-builder ${DOCKERHUB_REPO}:experimenter-moz-central bash build_android.sh
             docker cp fenix-builder:mozilla-central/mobile/android/fenix/app-fenix-debug-androidTest.apk ./
             docker cp fenix-builder:mozilla-central/mobile/android/fenix/app-fenix-x86_64-debug.apk ./

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -403,9 +403,6 @@ jobs:
     environment:
       PYTEST_ARGS: --reruns 1
     steps:
-      - restore_cache:
-          keys:
-            - experimenter-firefox-fenix-apks
       - checkout
       - android/accept-licenses
       - android/create-avd:
@@ -418,8 +415,10 @@ jobs:
       - run:
           name: Install APKs
           command: |
-            adb install /home/circleci/experimenter/experimenter/tests/integration/nimbus/android/app-fenix-x86_64-debug.apk
-            adb install /home/circleci/experimenter/experimenter/tests/integration/nimbus/android/app-fenix-debug-androidTest.apk
+            docker run -d --name fenix-files ${DOCKERHUB_REPO}:fenix-apk-store
+            docker cp fenix-files:/usr/src/app/files /home/circleci/experimenter/experimenter/tests/integration/nimbus/android
+            adb install /home/circleci/experimenter/experimenter/tests/integration/nimbus/android/files/app-fenix-x86_64-debug.apk
+            adb install /home/circleci/experimenter/experimenter/tests/integration/nimbus/android/files/app-fenix-debug-androidTest.apk
       - run:
           name: Download test files and run
           command: |
@@ -679,13 +678,10 @@ jobs:
             docker cp fenix-builder:mozilla-central/mobile/android/fenix/app-fenix-x86_64-debug.apk ./
             docker commit fenix-builder moz-central-builder
             docker tag moz-central-builder ${DOCKERHUB_REPO}:experimenter-moz-central
+            docker build -f fenix-apk-store.Dockerfile -t ${DOCKERHUB_REPO}:fenix-apk-store .
             docker push ${DOCKERHUB_REPO}:experimenter-moz-central
+            docker push ${DOCKERHUB_REPO}:fenix-apk-store
           no_output_timeout: 1h
-      - save_cache:
-          key: experimenter-firefox-fenix-apks-{{ checksum "experimenter/tests/integration/nimbus/android/app-fenix-x86_64-debug.apk" }}
-          paths:
-            - experimenter/tests/integration/nimbus/android/app-fenix-debug-androidTest.apk
-            - experimenter/tests/integration/nimbus/android/app-fenix-x86_64-debug.apk
 
 workflows:
   build_firefox:
@@ -714,6 +710,7 @@ workflows:
 
   build:
     jobs:
+      - build_firefox_fenix
       - check_experimenter_x86_64:
           name: Check Experimenter x86_64
       - check_experimenter_aarch64:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -673,6 +673,7 @@ jobs:
           name: Build and upload images
           command: |
             cd experimenter/tests/integration/nimbus/android
+            docker build -t moz-central-builder -f moz-central.test-container.Dockerfile . 
             docker run --name fenix-builder ${DOCKERHUB_REPO}:experimenter-moz-central bash build_android.sh
             docker cp fenix-builder:mozilla-central/mobile/android/fenix/app-fenix-debug-androidTest.apk ./
             docker cp fenix-builder:mozilla-central/mobile/android/fenix/app-fenix-x86_64-debug.apk ./

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -673,7 +673,8 @@ jobs:
           name: Build and upload images
           command: |
             cd experimenter/tests/integration/nimbus/android
-            docker run --name fenix-builder ${DOCKERHUB_REPO}:experimenter-moz-central bash build_android.sh
+            docker build -t moz-central-builder -f moz-central.test-container.Dockerfile . 
+            docker run --name fenix-builder moz-central-builder bash build_android.sh
             docker cp fenix-builder:mozilla-central/mobile/android/fenix/app-fenix-debug-androidTest.apk ./
             docker cp fenix-builder:mozilla-central/mobile/android/fenix/app-fenix-x86_64-debug.apk ./
             docker commit fenix-builder moz-central-builder

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -416,9 +416,9 @@ jobs:
           name: Install APKs
           command: |
             docker run -d --name fenix-files ${DOCKERHUB_REPO}:fenix-apk-store
-            docker cp fenix-files:/usr/src/app/files /home/circleci/experimenter/experimenter/tests/integration/nimbus/android
-            adb install /home/circleci/experimenter/experimenter/tests/integration/nimbus/android/files/app-fenix-x86_64-debug.apk
-            adb install /home/circleci/experimenter/experimenter/tests/integration/nimbus/android/files/app-fenix-debug-androidTest.apk
+            docker cp fenix-files:/usr/src/app/files /home/circleci/project
+            adb install /home/circleci/project/files/app-fenix-x86_64-debug.apk
+            adb install /home/circleci/project/files/app-fenix-debug-androidTest.apk
       - run:
           name: Download test files and run
           command: |
@@ -673,8 +673,7 @@ jobs:
           name: Build and upload images
           command: |
             cd experimenter/tests/integration/nimbus/android
-            docker build -t moz-central-builder -f moz-central.test-container.Dockerfile . 
-            docker run --name fenix-builder moz-central-builder bash build_android.sh
+            docker run --name fenix-builder ${DOCKERHUB_REPO}:experimenter-moz-central bash build_android.sh
             docker commit fenix-builder moz-central-builder
             docker tag moz-central-builder ${DOCKERHUB_REPO}:experimenter-moz-central
             docker push ${DOCKERHUB_REPO}:experimenter-moz-central
@@ -711,7 +710,6 @@ workflows:
 
   build:
     jobs:
-      - build_firefox_fenix
       - check_experimenter_x86_64:
           name: Check Experimenter x86_64
       - check_experimenter_aarch64:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -675,12 +675,12 @@ jobs:
             cd experimenter/tests/integration/nimbus/android
             docker build -t moz-central-builder -f moz-central.test-container.Dockerfile . 
             docker run --name fenix-builder moz-central-builder bash build_android.sh
-            docker cp fenix-builder:mozilla-central/mobile/android/fenix/app-fenix-debug-androidTest.apk ./
-            docker cp fenix-builder:mozilla-central/mobile/android/fenix/app-fenix-x86_64-debug.apk ./
             docker commit fenix-builder moz-central-builder
             docker tag moz-central-builder ${DOCKERHUB_REPO}:experimenter-moz-central
-            docker build -f fenix-apk-store.Dockerfile -t ${DOCKERHUB_REPO}:fenix-apk-store .
             docker push ${DOCKERHUB_REPO}:experimenter-moz-central
+            docker cp fenix-builder:mozilla-central/mobile/android/fenix/app-fenix-debug-androidTest.apk ./
+            docker cp fenix-builder:mozilla-central/mobile/android/fenix/app-fenix-x86_64-debug.apk ./
+            docker build -f fenix-apk-store.Dockerfile -t ${DOCKERHUB_REPO}:fenix-apk-store .
             docker push ${DOCKERHUB_REPO}:fenix-apk-store
           no_output_timeout: 1h
 

--- a/experimenter/tests/integration/nimbus/android/build_android.sh
+++ b/experimenter/tests/integration/nimbus/android/build_android.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 
 hg pull && hg update
 
+./mach clobber
 ./mach build
 cd mobile/android/fenix
 ./gradlew clean app:assembleFenixDebug

--- a/experimenter/tests/integration/nimbus/android/fenix-apk-store.Dockerfile
+++ b/experimenter/tests/integration/nimbus/android/fenix-apk-store.Dockerfile
@@ -1,0 +1,8 @@
+FROM alpine:latest
+
+WORKDIR /usr/src/app
+
+RUN mkdir -p /usr/src/app/files
+
+COPY app-fenix-debug-androidTest.apk /usr/src/app/files/
+COPY app-fenix-x86_64-debug.apk /usr/src/app/files/


### PR DESCRIPTION
Because

- Using the circleci cache on forks in our fenix integration tests doesn't work due to our security policy

This commit

- Fixes that by storing the APKs in a small docker image.

Fixes #10933