### PR TITLE
bug(nimbus): fix the @mozilla/nimbus-schemas package update

### DIFF
--- a/experimenter/experimenter/nimbus-ui/package.json
+++ b/experimenter/experimenter/nimbus-ui/package.json
@@ -68,7 +68,7 @@
     "zod": "^3.23.0"
   },
   "devDependencies": {
-    "@mozilla/nimbus-schemas": "^2023.10.1",
+    "@mozilla/nimbus-schemas": "^2024.7.1",
     "@rescripts/cli": "^0.0.16",
     "@testing-library/dom": "^8.20.0",
     "@testing-library/jest-dom": "^5.17.0",

--- a/experimenter/package.json
+++ b/experimenter/package.json
@@ -38,8 +38,5 @@
   "bugs": {
     "url": "https://github.com/mozilla/experimenter/issues"
   },
-  "homepage": "https://github.com/mozilla/experimenter#readme",
-  "dependencies": {
-    "@mozilla/nimbus-schemas": "2024.7.1"
-  }
+  "homepage": "https://github.com/mozilla/experimenter#readme"
 }

--- a/experimenter/yarn.lock
+++ b/experimenter/yarn.lock
@@ -2472,15 +2472,10 @@
   dependencies:
     "@lezer/common" "^1.0.0"
 
-"@mozilla/nimbus-schemas@2024.7.1":
+"@mozilla/nimbus-schemas@^2024.7.1":
   version "2024.7.1"
   resolved "https://registry.yarnpkg.com/@mozilla/nimbus-schemas/-/nimbus-schemas-2024.7.1.tgz#d0e16b93731fa2f279203518b12bf65eeb294cca"
   integrity sha512-AdNQbJh8J8lq6q9TNQ7/udpjFmxIImP4xk0I9T1HC7Uc5GKxDw9nUM6d+ko9SSseBDvJ1m6lNz8AGtWBKrZKaw==
-
-"@mozilla/nimbus-schemas@^2023.10.1":
-  version "2023.10.1"
-  resolved "https://registry.yarnpkg.com/@mozilla/nimbus-schemas/-/nimbus-schemas-2023.10.1.tgz#19fc58c8fb848b0b6d0309cd51802b599c844abc"
-  integrity sha512-MIW1UuOr1shYDtLOdGg31WnNkahJDHzZah622lp55nq3WeAm1H3bsc4nlIuGlLHYxvKfU5enJHVy4SFx+XahKQ==
 
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"


### PR DESCRIPTION
Because

- #10936 updated the wrong package.json and didn't remove the old version from the lockfile

This commit

- reverts the erroneous change from #10936
- adds the proper package.json change to experimenter/experimenter/nimbus-ui/package.json

Fixes #10943 