### PR TITLE
bug(nimbus): use docker-selenium 0.27.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -649,7 +649,8 @@ jobs:
       - run:
           name: Build and upload images
           command: |
-            git clone --depth=1 git@github.com:SeleniumHQ/docker-selenium.git
+            # Clone last working version to ensure compatibility with aarch64 apple silicon machines
+            git clone --branch selenium-grid-0.27.0 --depth 1 git@github.com:SeleniumHQ/docker-selenium.git
             cd docker-selenium
             BUILD_ARGS="--build-arg FIREFOX_VERSION=latest" VERSION="firefox" BUILD_DATE="release" make standalone_firefox
             BUILD_ARGS="--build-arg FIREFOX_VERSION=devedition-latest" VERSION="firefox" BUILD_DATE="beta" make standalone_firefox


### PR DESCRIPTION
Because

* Recent builds of docker-selenium prevent us from running tests locally on M chip macs
* After investigation we find that 0.27.0 still works

This commit

* Locks our docker-selenium container to the last working version

fixes #10947

