### PR TITLE
bug(project): install poetry with install script

### DIFF
--- a/experimenter/tests/experimenter_legacy_tests.sh
+++ b/experimenter/tests/experimenter_legacy_tests.sh
@@ -5,12 +5,7 @@ set +x
 
 export PATH=$PATH:/home/seluser/.local/bin
 
-sudo apt-get -qqy update && sudo apt-get -qqy install python3-venv python3-pip
-
-# https://pip.pypa.io/en/stable/cli/pip_install/#cmdoption-break-system-packages
-# we are doing this because we don't control this docker image and this allows us
-# to install poetry globally
-pip install poetry --break-system-packages
+curl -sSL https://install.python-poetry.org | python3 - --version 1.8.3
 sudo chmod -R a+rwx /code/experimenter/tests/integration/
 mkdir -m a+rwx /code/experimenter/tests/integration/test-reports
 

--- a/experimenter/tests/nimbus_integration_tests.sh
+++ b/experimenter/tests/nimbus_integration_tests.sh
@@ -9,12 +9,7 @@ if [[ -n "${UPDATE_FIREFOX_VERSION}" ]]; then
     sudo ./experimenter/tests/integration/nimbus/utils/nightly-install.sh
 fi
 
-sudo apt-get -qqy update && sudo apt-get -qqy install python3-venv python3-pip
-
-# https://pip.pypa.io/en/stable/cli/pip_install/#cmdoption-break-system-packages
-# we are doing this because we don't control this docker image and this allows us 
-# to install poetry globally
-pip install poetry --break-system-packages
+curl -sSL https://install.python-poetry.org | python3 - --version 1.8.3
 sudo chmod -R a+rwx /code/experimenter/tests/integration/
 mkdir -m a+rwx /code/experimenter/tests/integration/test-reports
 


### PR DESCRIPTION
Because

* We recently switched our integration tests to use poetry instead of tox
* We also recently discovered that the most recent version of selenium docker images are buggy on mac
* We rolled back the selenium docker image to a version that works on mac
* This version comes with an old version of pip that's incompatible with the install script we setup to install poetry

This commit

* Uses the official poetry installer script locked to the same version we use in the Experimenter image

fixes #10957

