### PR TITLE
chore(nimbus): disable PageHome tests

### DIFF
--- a/experimenter/experimenter/nimbus-ui/package.json
+++ b/experimenter/experimenter/nimbus-ui/package.json
@@ -27,6 +27,9 @@
       "!src/lib/test-utils.tsx",
       "!src/**/*.svg"
     ],
+    "coveragePathIgnorePatterns": [
+      "PageHome"
+    ],
     "coverageThreshold": {
       "global": {
         "lines": 100

--- a/experimenter/experimenter/nimbus-ui/src/components/PageHome/DirectoryTable/index.test.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageHome/DirectoryTable/index.test.tsx
@@ -49,7 +49,7 @@ const TestTable = ({ children }: { children: React.ReactNode }) => {
 };
 
 describe("DirectoryColumnTitle", () => {
-  it("renders the experiment name", () => {
+  it.skip("renders the experiment name", () => {
     render(
       <TestTable>
         <DirectoryColumnTitle {...experiment} />
@@ -62,7 +62,7 @@ describe("DirectoryColumnTitle", () => {
 });
 
 describe("DirectoryColumnOwner", () => {
-  it("renders the experiment owner if present", () => {
+  it.skip("renders the experiment owner if present", () => {
     render(
       <TestTable>
         <DirectoryColumnOwner {...experiment} />
@@ -73,7 +73,7 @@ describe("DirectoryColumnOwner", () => {
     );
   });
 
-  it("renders the NotSet label if owner is not present", () => {
+  it.skip("renders the NotSet label if owner is not present", () => {
     render(
       <TestTable>
         {/**
@@ -106,7 +106,7 @@ describe("DirectoryColumnQA", () => {
 });
 
 describe("DirectoryColumnFeature", () => {
-  it("renders the feature config if present", () => {
+  it.skip("renders the feature config if present", () => {
     render(
       <TestTable>
         <DirectoryColumnFeature {...experiment} />
@@ -122,7 +122,7 @@ describe("DirectoryColumnFeature", () => {
     );
   });
 
-  it("renders the None label if feature config is not present", () => {
+  it.skip("renders the None label if feature config is not present", () => {
     render(
       <TestTable>
         <DirectoryColumnFeature {...experiment} featureConfigs={[]} />
@@ -135,7 +135,7 @@ describe("DirectoryColumnFeature", () => {
 });
 
 describe("DirectoryColumnApplication", () => {
-  it("renders the application", () => {
+  it.skip("renders the application", () => {
     render(
       <TestTable>
         <DirectoryColumnApplication {...experiment} />
@@ -148,7 +148,7 @@ describe("DirectoryColumnApplication", () => {
 });
 
 describe("DirectoryColumnChannel", () => {
-  it("renders the channel", () => {
+  it.skip("renders the channel", () => {
     render(
       <TestTable>
         <DirectoryColumnChannel {...experiment} />
@@ -161,7 +161,7 @@ describe("DirectoryColumnChannel", () => {
 });
 
 describe("DirectoryColumnPopulationPercent", () => {
-  it("renders the population percent", () => {
+  it.skip("renders the population percent", () => {
     render(
       <TestTable>
         <DirectoryColumnPopulationPercent {...experiment} />
@@ -174,7 +174,7 @@ describe("DirectoryColumnPopulationPercent", () => {
 });
 
 describe("DirectoryColumnFirefoxMinVersion", () => {
-  it("renders the firefox min version", () => {
+  it.skip("renders the firefox min version", () => {
     render(
       <TestTable>
         <DirectoryColumnFirefoxMinVersion {...experiment} />
@@ -187,7 +187,7 @@ describe("DirectoryColumnFirefoxMinVersion", () => {
 });
 
 describe("DirectoryColumnFirefoxMaxVersion", () => {
-  it("renders the firefox max version", () => {
+  it.skip("renders the firefox max version", () => {
     render(
       <TestTable>
         <DirectoryColumnFirefoxMaxVersion {...experiment} />
@@ -197,7 +197,7 @@ describe("DirectoryColumnFirefoxMaxVersion", () => {
       "Firefox 64",
     );
   });
-  it("renders no version if no max version is set", () => {
+  it.skip("renders no version if no max version is set", () => {
     render(
       <TestTable>
         <DirectoryColumnFirefoxMaxVersion
@@ -213,7 +213,7 @@ describe("DirectoryColumnFirefoxMaxVersion", () => {
 });
 
 describe("DirectoryColumneEnrollmentDate", () => {
-  it("renders the enrollment date period", () => {
+  it.skip("renders the enrollment date period", () => {
     render(
       <TestTable>
         <DirectoryColumnEnrollmentDate {...experiment} />
@@ -223,7 +223,7 @@ describe("DirectoryColumneEnrollmentDate", () => {
       getProposedEnrollmentRange(experiment),
     );
   });
-  it("renders days if date is null for enrollment column", () => {
+  it.skip("renders days if date is null for enrollment column", () => {
     render(
       <TestTable>
         <DirectoryColumnEnrollmentDate {...experiment} computedEndDate={null} />
@@ -236,7 +236,7 @@ describe("DirectoryColumneEnrollmentDate", () => {
 });
 
 describe("DirectoryColumnStartDate", () => {
-  it("renders the start date", () => {
+  it.skip("renders the start date", () => {
     render(
       <TestTable>
         <DirectoryColumnStartDate {...experiment} />
@@ -246,7 +246,7 @@ describe("DirectoryColumnStartDate", () => {
       humanDate(experiment.startDate!),
     );
   });
-  it("renders not set start date", () => {
+  it.skip("renders not set start date", () => {
     render(
       <TestTable>
         <DirectoryColumnStartDate {...experiment} startDate={null} />
@@ -259,7 +259,7 @@ describe("DirectoryColumnStartDate", () => {
 });
 
 describe("DirectoryColumnEndDate", () => {
-  it("renders the end date", () => {
+  it.skip("renders the end date", () => {
     render(
       <TestTable>
         <DirectoryColumnEndDate {...experiment} />
@@ -269,7 +269,7 @@ describe("DirectoryColumnEndDate", () => {
       humanDate(experiment.computedEndDate!),
     );
   });
-  it("renders not set end date", () => {
+  it.skip("renders not set end date", () => {
     render(
       <TestTable>
         <DirectoryColumnEndDate {...experiment} computedEndDate={null} />
@@ -282,7 +282,7 @@ describe("DirectoryColumnEndDate", () => {
 });
 
 describe("DirectoryColumnUnpublishedUpdates", () => {
-  it("renders unpublished updates badge when dirty", () => {
+  it.skip("renders unpublished updates badge when dirty", () => {
     render(
       <TestTable>
         <DirectoryColumnUnpublishedUpdates
@@ -294,7 +294,7 @@ describe("DirectoryColumnUnpublishedUpdates", () => {
     expect(screen.getByTestId("directory-table-cell")).toHaveTextContent("YES");
   });
 
-  it("renders blank unpublished updates when not dirty", () => {
+  it.skip("renders blank unpublished updates when not dirty", () => {
     render(
       <TestTable>
         <DirectoryColumnUnpublishedUpdates
@@ -316,7 +316,7 @@ function expectTableCells(testId: string, cellTexts: string[]) {
 }
 
 describe("DirectoryTable", () => {
-  it("renders as expected without experiments", () => {
+  it.skip("renders as expected without experiments", () => {
     render(
       <RouterSlugProvider>
         <DirectoryTable experiments={[]} />
@@ -327,7 +327,7 @@ describe("DirectoryTable", () => {
 
   // TODO: not exhaustively testing all sort orders here, might be worth adding more?
   // Sorting is more fully covered in lib/experiment.test.ts
-  it("supports sorting by name", async () => {
+  it.skip("supports sorting by name", async () => {
     const experiments = mockDirectoryExperiments();
     const experimentNames = experiments.map((experiment) => experiment.name);
     const getExperimentNamesFromTable = () =>
@@ -518,17 +518,17 @@ describe("SortableColumnTitle", () => {
       ]();
     };
 
-  it(
+  it.skip(
     "renders default as expected and supports ascending sort selection",
     commonTestCase(false, false, true, false),
   );
 
-  it(
+  it.skip(
     "renders ascending sort as expected and support descending sort selection",
     commonTestCase(true, false, true, true),
   );
 
-  it(
+  it.skip(
     "renders descending sort as expected and support sort reset",
     commonTestCase(true, true, false, false),
   );

--- a/experimenter/experimenter/nimbus-ui/src/components/PageHome/FilterBar/index.test.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageHome/FilterBar/index.test.tsx
@@ -12,7 +12,7 @@ import {
 import { MockedCache } from "src/lib/mocks";
 
 describe("FilterBar", () => {
-  it("renders as expected", () => {
+  it.skip("renders as expected", () => {
     render(
       <MockedCache>
         <Subject value={EVERYTHING_SELECTED_VALUE} />
@@ -22,7 +22,7 @@ describe("FilterBar", () => {
 });
 
 describe("FilterSelect", () => {
-  it("pluralizes the filter names correctly", () => {
+  it.skip("pluralizes the filter names correctly", () => {
     render(
       <MockedCache>
         <FilterSelectSubject

--- a/experimenter/experimenter/nimbus-ui/src/components/PageHome/SearchBar/index.test.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageHome/SearchBar/index.test.tsx
@@ -11,7 +11,7 @@ import { RouterSlugProvider } from "src/lib/test-utils";
 import { getAllExperiments_experiments } from "src/types/getAllExperiments";
 
 describe("SearchBar", () => {
-  it("renders as expected", async () => {
+  it.skip("renders as expected", async () => {
     const onChange = jest.fn();
     render(<Subject experiments={[]} onChange={onChange} />);
     const searchInput = screen.getByTestId("SearchExperiments");

--- a/experimenter/experimenter/nimbus-ui/src/components/PageHome/index.test.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageHome/index.test.tsx
@@ -24,14 +24,14 @@ import { CurrentLocation, RouterSlugProvider } from "src/lib/test-utils";
 import { getAllExperiments_experiments } from "src/types/getAllExperiments";
 
 describe("PageHome", () => {
-  it("renders as expected", () => {
+  it.skip("renders as expected", () => {
     render(<Subject />);
 
     expect(screen.getByTestId("PageHome")).toBeInTheDocument();
     expect(screen.getByText("Create New")).toBeInTheDocument();
   });
 
-  it("displays loading when experiments are still loading", () => {
+  it.skip("displays loading when experiments are still loading", () => {
     (jest.spyOn(apollo, "useQuery") as jest.Mock).mockReturnValueOnce({
       loading: true,
     });
@@ -63,7 +63,7 @@ describe("PageHome", () => {
       ["owned", screen.getByText("My Experiments (0)")],
     ] as const;
 
-  it("displays five Directory Tables (one for each status type)", async () => {
+  it.skip("displays five Directory Tables (one for each status type)", async () => {
     await renderAndWaitForLoaded();
     // renders all experiments
     expect(screen.queryAllByTestId("DirectoryTable")).toHaveLength(7);
@@ -112,7 +112,7 @@ describe("PageHome", () => {
     }
   });
 
-  it("renders the error warning and refetches when an error occurs querying experiments", async () => {
+  it.skip("renders the error warning and refetches when an error occurs querying experiments", async () => {
     jest.useFakeTimers();
     const experiments = mockDirectoryExperiments();
     const mock = mockDirectoryExperimentsQuery(experiments);
@@ -163,12 +163,12 @@ describe("PageHome", () => {
     });
   });
 
-  it("renders the report button", async () => {
+  it.skip("renders the report button", async () => {
     await renderAndWaitForLoaded();
     expect(screen.queryByText("Reports")).toBeInTheDocument();
   });
 
-  it("report button renders and fetches api", async () => {
+  it.skip("report button renders and fetches api", async () => {
     await renderAndWaitForLoaded();
     const path = "/api/v5/csv";
     const anchor = screen.queryByTestId("reports-anchor");


### PR DESCRIPTION
Because

* The new Nimbus List page is now the default home page
* The old home page tests have intermittent failures
* These tests can be safely disabled for now until the old UI is removed entirely

This commit

* Disables the tests in PageHome in Nimbus UI

fixes #10994

