### PR TITLE
feat(nimbus): add link to matching audiences

### DIFF
--- a/experimenter/experimenter/experiments/api/v5/types.py
+++ b/experimenter/experimenter/experiments/api/v5/types.py
@@ -490,6 +490,7 @@ class NimbusConfigurationType(graphene.ObjectType):
 
 class NimbusExperimentType(DjangoObjectType):
     application = graphene.NonNull(NimbusExperimentApplicationEnum)
+    audience_url = graphene.NonNull(graphene.String)
     can_archive = graphene.Boolean()
     can_edit = graphene.Boolean()
     can_review = graphene.Boolean()
@@ -584,6 +585,7 @@ class NimbusExperimentType(DjangoObjectType):
         model = NimbusExperiment
         fields = (
             "application",
+            "audience_url",
             "can_archive",
             "can_edit",
             "can_review",

--- a/experimenter/experimenter/experiments/tests/test_models.py
+++ b/experimenter/experimenter/experiments/tests/test_models.py
@@ -1867,6 +1867,41 @@ class TestNimbusExperiment(TestCase):
                 "http://kinto/v1/admin/#/buckets/main-workspace/collections/nimbus-secure-experiments/simple-review",
             )
 
+    def test_audience_url(self):
+        feature1 = NimbusFeatureConfigFactory.create(
+            application=NimbusExperiment.Application.DESKTOP, slug="a"
+        )
+        feature2 = NimbusFeatureConfigFactory.create(
+            application=NimbusExperiment.Application.DESKTOP, slug="b"
+        )
+        language1 = LanguageFactory.create(code="a")
+        language2 = LanguageFactory.create(code="b")
+        locale1 = LocaleFactory.create(code="a")
+        locale2 = LocaleFactory.create(code="b")
+        country1 = CountryFactory.create(code="a")
+        country2 = CountryFactory.create(code="b")
+        experiment = NimbusExperimentFactory.create(
+            application=NimbusExperiment.Application.DESKTOP,
+            channel=NimbusExperiment.Channel.RELEASE,
+            firefox_min_version=NimbusExperiment.Version.FIREFOX_100,
+            feature_configs=[feature1, feature2],
+            languages=[language1, language2],
+            locales=[locale1, locale2],
+            countries=[country1, country2],
+            targeting_config_slug="targeting",
+        )
+        self.assertEqual(
+            experiment.audience_url,
+            (
+                "/nimbus/?application=firefox-desktop&channel=release&firefox_min_version=100.%21"
+                f"&feature_configs={feature1.id}&feature_configs={feature2.id}"
+                f"&countries={country1.id}&countries={country2.id}"
+                f"&locales={locale1.id}&locales={locale2.id}"
+                f"&languages={language1.id}&languages={language2.id}"
+                "&targeting_config_slug=targeting"
+            ),
+        )
+
     def test_clear_branches_deletes_branches_without_deleting_experiment(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.CREATED,

--- a/experimenter/experimenter/nimbus-ui/schema.graphql
+++ b/experimenter/experimenter/nimbus-ui/schema.graphql
@@ -65,6 +65,7 @@ type NimbusExperimentType {
   subscribers: [NimbusUserType!]!
   documentationLinks: [NimbusDocumentationLinkType!]
   changes: [NimbusChangeLogType]
+  audienceUrl: String!
   canArchive: Boolean
   canEdit: Boolean
   canReview: Boolean

--- a/experimenter/experimenter/nimbus-ui/src/components/AppLayoutWithExperiment/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/AppLayoutWithExperiment/index.tsx
@@ -95,8 +95,8 @@ const AppLayoutWithExperiment = ({
             <p>Polling will be retried automatically.</p>
           </Alert>
         )}
-        {title && <h2 className="mt-3 mb-4 h3">{title}</h2>}
-        <div className="my-4">{children}</div>
+        {title && <h2 className="mt-3 h3">{title}</h2>}
+        {children}
       </section>
     </Layout>
   );

--- a/experimenter/experimenter/nimbus-ui/src/components/PageEditAudience/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageEditAudience/index.tsx
@@ -5,6 +5,7 @@
 import { useMutation } from "@apollo/client";
 import { navigate, RouteComponentProps } from "@reach/router";
 import React, { useCallback, useContext, useState } from "react";
+import { Col, Row } from "react-bootstrap";
 import AppLayoutWithExperiment from "src/components/AppLayoutWithExperiment";
 import FormAudience from "src/components/PageEditAudience/FormAudience";
 import { UPDATE_EXPERIMENT_MUTATION } from "src/gql/experiments";
@@ -114,6 +115,13 @@ const PageEditAudience: React.FunctionComponent<RouteComponentProps> = () => {
 
   return (
     <AppLayoutWithExperiment title="Audience" testId="PageEditAudience">
+      <Row className="mb-4">
+        <Col>
+          <a target="_blank" href={experiment.audienceUrl} rel="noreferrer">
+            Explore matching audiences
+          </a>
+        </Col>
+      </Row>
       <FormAudience
         {...{
           experiment,

--- a/experimenter/experimenter/nimbus-ui/src/components/Summary/TableAudience/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/Summary/TableAudience/index.tsx
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React, { useState } from "react";
-import { Accordion, Button, Card, Table } from "react-bootstrap";
+import { Accordion, Button, Card, Col, Row, Table } from "react-bootstrap";
 import { Code } from "src/components/Code";
 import NotSet from "src/components/NotSet";
 import { MOBILE_APPLICATIONS } from "src/components/PageEditAudience/FormAudience";
@@ -112,7 +112,18 @@ const TableAudience = ({ experiment }: TableAudienceProps) => {
 
   return (
     <Card className="border-left-0 border-right-0 border-bottom-0">
-      <Card.Header as="h5">Audience</Card.Header>
+      <Card.Header>
+        <Row>
+          <Col>
+            <h5>Audience</h5>
+          </Col>
+          <Col className="text-right">
+            <a target="_blank" href={experiment.audienceUrl} rel="noreferrer">
+              Explore matching audiences
+            </a>
+          </Col>
+        </Row>
+      </Card.Header>
       <Card.Body>
         <Table data-testid="table-audience" className="table-fixed">
           <tbody>

--- a/experimenter/experimenter/nimbus-ui/src/gql/experiments.ts
+++ b/experimenter/experimenter/nimbus-ui/src/gql/experiments.ts
@@ -41,6 +41,7 @@ export const GET_EXPERIMENT_QUERY = gql`
       resultsExpectedDate
       resultsReady
       showResultsUrl
+      audienceUrl
 
       hypothesis
       application

--- a/experimenter/experimenter/nimbus-ui/src/types/getExperiment.ts
+++ b/experimenter/experimenter/nimbus-ui/src/types/getExperiment.ts
@@ -222,6 +222,7 @@ export interface getExperiment_experimentBySlug {
   resultsExpectedDate: DateTime | null;
   resultsReady: boolean | null;
   showResultsUrl: boolean | null;
+  audienceUrl: string;
   hypothesis: string | null;
   application: NimbusExperimentApplicationEnum;
   publicDescription: string | null;


### PR DESCRIPTION
Because

* Before we fully automate population sizing, we can use previously launched experiments as a way to estimate population sizes
* To find matching audiences, we can add a link that filters the new list page to experiments that match another experiments audience parameters

This commit

* Adds helpful links to matching audiences to the summary and edit audience pages

fixes #10816
<img width="1281" alt="Screenshot 2024-07-11 at 15 31 53" src="https://github.com/user-attachments/assets/e5d90f0c-d23f-46c8-b80f-57c492984ac4">
<img width="1269" alt="Screenshot 2024-07-11 at 15 31 31" src="https://github.com/user-attachments/assets/c4580fb4-ba79-4dfc-ab45-dd9db119de76">
