### PR TITLE
bug(nimbus): Don't throw in NimbusExperiment.review_url

### DIFF
--- a/experimenter/experimenter/experiments/constants.py
+++ b/experimenter/experimenter/experiments/constants.py
@@ -53,6 +53,13 @@ class BucketRandomizationUnit(models.TextChoices):
     USER_ID = "user_id"
 
 
+class TargetingMultipleKintoCollectionsError(Exception):
+    """An error that is raised when an experiment contains multiple features
+    that each would require it to be published to different kinto
+    collections.
+    """
+
+
 @dataclass
 class ApplicationConfig:
     name: str
@@ -80,7 +87,9 @@ class ApplicationConfig:
                 return next(iter(target_collections))
 
             elif len(target_collections) > 1:
-                raise AssertionError("Experiment targets multiple collections")
+                raise TargetingMultipleKintoCollectionsError(
+                    "Experiment targets multiple collections"
+                )
 
         return self.default_kinto_collection
 

--- a/experimenter/experimenter/experiments/tests/test_models.py
+++ b/experimenter/experimenter/experiments/tests/test_models.py
@@ -27,6 +27,7 @@ from experimenter.experiments.constants import (
     BucketRandomizationUnit,
     ChangeEventType,
     NimbusConstants,
+    TargetingMultipleKintoCollectionsError,
 )
 from experimenter.experiments.models import (
     NimbusBranch,
@@ -3858,7 +3859,8 @@ class ApplicationConfigTests(TestCase):
             experiment = self._create_experiment(["feature-1", "feature-2"])
 
             with self.assertRaisesRegex(
-                AssertionError, "Experiment targets multiple collections"
+                TargetingMultipleKintoCollectionsError,
+                "Experiment targets multiple collections",
             ):
                 experiment.kinto_collection  # noqa: B018
 


### PR DESCRIPTION
Because:

- we serialize the review_url in the graphQL API;
- the review_url isn't always available (e.g., when a multi-feature experiment targets multiple kinto collections for publishing)

this commit:

- adds a new exception type for the multiple kinto collection case; and
- catches that exception in `NimbusExperiment.review_url`.

Fixes #10949.