### PR TITLE
bug(nimbus): tabs should fill full table width on new list page

### DIFF
--- a/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/table.html
+++ b/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/table.html
@@ -1,29 +1,25 @@
 {% load nimbus_extras %}
 
-<div class="container border-bottom">
-  <div class="row">
-    <div class="col-12 p-0 d-flex flex-column flex-md-row justify-content-between align-items-center">
-      <div class="order-2 order-md-1">
-        <ul class="nav nav-tabs border-0">
-          {% include "common/list_tab.html" with status="Live" count=status_counts.Live icon="fa-regular fa-circle-play" %}
-          {% include "common/list_tab.html" with status="Review" count=status_counts.Review icon="fa-solid fa-eye" %}
-          {% include "common/list_tab.html" with status="Preview" count=status_counts.Preview icon="fa-solid fa-person-circle-check" %}
-          {% include "common/list_tab.html" with status="Complete" count=status_counts.Complete icon="fa-solid fa-vial-circle-check" %}
-          {% include "common/list_tab.html" with status="Draft" count=status_counts.Draft icon="fa-solid fa-pen-to-square" %}
-          {% include "common/list_tab.html" with status="Archived" count=status_counts.Archived icon="fa-solid fa-box-archive" %}
-          {% include "common/list_tab.html" with status="MyExperiments" count=status_counts.MyExperiments icon="fa-solid fa-heart" %}
+<div class="col-12 p-0 border-bottom d-flex flex-column flex-md-row justify-content-between align-items-center">
+  <div class="order-2 order-md-1">
+    <ul class="nav nav-tabs border-0">
+      {% include "common/list_tab.html" with status="Live" count=status_counts.Live icon="fa-regular fa-circle-play" %}
+      {% include "common/list_tab.html" with status="Review" count=status_counts.Review icon="fa-solid fa-eye" %}
+      {% include "common/list_tab.html" with status="Preview" count=status_counts.Preview icon="fa-solid fa-person-circle-check" %}
+      {% include "common/list_tab.html" with status="Complete" count=status_counts.Complete icon="fa-solid fa-vial-circle-check" %}
+      {% include "common/list_tab.html" with status="Draft" count=status_counts.Draft icon="fa-solid fa-pen-to-square" %}
+      {% include "common/list_tab.html" with status="Archived" count=status_counts.Archived icon="fa-solid fa-box-archive" %}
+      {% include "common/list_tab.html" with status="MyExperiments" count=status_counts.MyExperiments icon="fa-solid fa-heart" %}
 
-        </ul>
-      </div>
-      <div class="order-1 order-md-2 mb-2 mb-md-0">
-        <a id="create-new-button"
-           class="btn btn-primary"
-           href="{% url 'nimbus-create' %}">
-          <i class="fa-regular fa-pen-to-square"></i>
-          Create Experiment
-        </a>
-      </div>
-    </div>
+    </ul>
+  </div>
+  <div class="order-1 order-md-2 mb-2 mb-md-0">
+    <a id="create-new-button"
+       class="btn btn-primary"
+       href="{% url 'nimbus-create' %}">
+      <i class="fa-regular fa-pen-to-square"></i>
+      Create Experiment
+    </a>
   </div>
 </div>
 <div id="experiment-list"></div>


### PR DESCRIPTION
Becuase

* The tabs at the top of the table in the new list page should always fill the full width of the table
* When fixing the create button staying to the right of the tabs, we introduced some extra html elements that prevented the tabs from filling the full width on wide viewports

This commit

* Removes the unnecessary html elements which preserves both keeping the create button on the right as well as the tabs filling the full width

fixes #11006

Before:
<img width="1672" alt="image" src="https://github.com/user-attachments/assets/0ef39c41-0584-4073-bac2-28658a37ccab">

After:
<img width="1679" alt="image" src="https://github.com/user-attachments/assets/74008a08-6acc-451c-b2e8-9776b2ce8a17">
