### PR TITLE
chore(nimbus): prevent tabs from wrapping on new list page

### DIFF
--- a/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/table.html
+++ b/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/table.html
@@ -2,7 +2,7 @@
 
 <div class="col-12 p-0 border-bottom d-flex flex-column flex-md-row justify-content-between align-items-center">
   <div class="order-2 order-md-1">
-    <ul class="nav nav-tabs border-0">
+    <ul class="nav nav-tabs border-0 flex-nowrap">
       {% include "common/list_tab.html" with status="Live" count=status_counts.Live icon="fa-regular fa-circle-play" %}
       {% include "common/list_tab.html" with status="Review" count=status_counts.Review icon="fa-solid fa-eye" %}
       {% include "common/list_tab.html" with status="Preview" count=status_counts.Preview icon="fa-solid fa-person-circle-check" %}


### PR DESCRIPTION
Because
    
* Below a certain width the tabs were wrapping into two lines and then they're disconnected from the table which looks weird
    
This commit
    
* Prevents the tabs from wrapping so they stay attached to the table
    
fixes #11008

Before:
<img width="697" alt="image" src="https://github.com/user-attachments/assets/97269eb2-0e58-4f9d-8e38-17699bc3f170">

After:
<img width="811" alt="image" src="https://github.com/user-attachments/assets/9605ed2d-632d-4d9d-91d6-5e96ac45778e">
