### PR TITLE
feat(nimbus): collapse sidebar into hamburger menu in new nimbus ui

### DIFF
--- a/experimenter/experimenter/nimbus_ui_new/templates/common/with_sidebar.html
+++ b/experimenter/experimenter/nimbus_ui_new/templates/common/with_sidebar.html
@@ -3,16 +3,31 @@
 {% load static %}
 
 {% block content %}
-  <div id="content" class="row px-3">
-    <div class="col-2">
-      {% block sidebar %}
-      {% endblock sidebar %}
+  <div id="content" class="container-fluid px-3">
+    <div class="row">
+      <div class="col-lg-12 col-xl-3 col-xxl-2 d-md-block mb-4">
+        <nav class="navbar navbar-expand-xl py-0">
+          <button class="navbar-toggler mb-3"
+                  type="button"
+                  data-bs-toggle="collapse"
+                  data-bs-target="#sidebarMenu"
+                  aria-controls="sidebarMenu"
+                  aria-expanded="false"
+                  aria-label="Toggle navigation">
+            <span class="navbar-toggler-icon"></span>
+          </button>
+          <div class="collapse navbar-collapse" id="sidebarMenu">
+            {% block sidebar %}
+            {% endblock sidebar %}
 
-    </div>
-    <div class="col-10">
-      {% block main_content %}
-      {% endblock main_content %}
+          </div>
+        </nav>
+      </div>
+      <div class="col-lg-12 col-xl-9 col-xxl-10">
+        {% block main_content %}
+        {% endblock main_content %}
 
+      </div>
     </div>
   </div>
 {% endblock content %}

--- a/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/table.html
+++ b/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/table.html
@@ -13,7 +13,7 @@
 
     </ul>
   </div>
-  <div class="order-1 order-md-2 mb-2 mb-md-0">
+  <div class="order-1 order-md-2 mb-2 mb-md-0 ms-2">
     <a id="create-new-button"
        class="btn btn-primary"
        href="{% url 'nimbus-create' %}">


### PR DESCRIPTION
Because

* For narrow screens we can collapse the sidebar into a hamburger menu rather than just having it collide with the main content

This commit

* Collapses the sidebar into a hamburger menu on narrow viewports

fixes #11010

![Screenshot 2024-07-15 at 11-50-03 Nimbus Experiments](https://github.com/user-attachments/assets/0e553ba9-8c1f-4ab2-83bd-781488e25a58)
![Screenshot 2024-07-15 at 11-50-16 Nimbus Experiments](https://github.com/user-attachments/assets/a155d5c4-a10d-42b7-acef-1f4034f50537)
