### PR TITLE
feat(nimbus): push docker image with the short git sha as the tag

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -447,6 +447,9 @@ jobs:
             make build_prod
             docker tag experimenter:deploy ${DOCKERHUB_REPO}:latest
             docker push ${DOCKERHUB_REPO}:latest
+            GIT_SHA=$(git rev-parse --short HEAD)
+            docker tag experimenter:deploy ${DOCKERHUB_REPO}:${GIT_SHA}
+            docker push ${DOCKERHUB_REPO}:${GIT_SHA}
       - gcp-cli/setup
       - run:
           name: Deploy to Google Container Registry
@@ -458,6 +461,9 @@ jobs:
             DOCKER_IMAGE="gcr.io/${GOOGLE_PROJECT_ID}/experimenter"
             docker tag experimenter:deploy ${DOCKER_IMAGE}:latest
             docker push "${DOCKER_IMAGE}:latest"
+            GIT_SHA=$(git rev-parse --short HEAD)
+            docker tag experimenter:deploy ${DOCKERHUB_REPO}:${GIT_SHA}
+            docker push ${DOCKERHUB_REPO}:${GIT_SHA}
 
   deploy_cirrus:
     working_directory: ~/cirrus


### PR DESCRIPTION
Because

- Images tagged with the git sha are needed for the 'Four Keys' metrics work 

This commit

- Pushes a copy of the deploy image to docker hub and google container registry with the git sha as the tag

Fixes #10807