### PR TITLE
feat(nimbus): move hamburger button to header

### DIFF
--- a/experimenter/experimenter/nimbus_ui_new/templates/common/header.html
+++ b/experimenter/experimenter/nimbus_ui_new/templates/common/header.html
@@ -2,14 +2,25 @@
 
 <nav class="navbar">
   <div class="container-fluid">
-    <a class="navbar-brand d-flex align-items-center fs-3"
-       href="{% url 'nimbus-list' %}">
-      <img src="{% static 'assets/logo.svg' %}"
-           alt="Logo"
-           width="30"
-           class="d-inline-block align-text-top me-2">
-      Nimbus Experiments
-    </a>
+    <div class="d-flex align-items-center">
+      <button class="navbar-toggler me-3 d-xl-none"
+              type="button"
+              data-bs-toggle="collapse"
+              data-bs-target="#sidebarMenu"
+              aria-controls="sidebarMenu"
+              aria-expanded="false"
+              aria-label="Toggle navigation">
+        <span class="navbar-toggler-icon"></span>
+      </button>
+      <a class="navbar-brand d-flex align-items-center fs-3"
+         href="{% url 'nimbus-list' %}">
+        <img src="{% static 'assets/logo.svg' %}"
+             alt="Logo"
+             width="30"
+             class="d-inline-block align-text-top me-2">
+        Nimbus Experiments
+      </a>
+    </div>
     <ul class="nav nav-pills">
       <li class="nav-item">
         <a href="https://experimenter.info/"

--- a/experimenter/experimenter/nimbus_ui_new/templates/common/with_sidebar.html
+++ b/experimenter/experimenter/nimbus_ui_new/templates/common/with_sidebar.html
@@ -3,19 +3,10 @@
 {% load static %}
 
 {% block content %}
-  <div id="content" class="container-fluid px-3">
+  <div id="content" class="container-fluid">
     <div class="row">
-      <div class="col-lg-12 col-xl-3 col-xxl-2 d-md-block mb-4">
+      <div class="col-lg-12 col-xl-3 col-xxl-2 d-md-block">
         <nav class="navbar navbar-expand-xl py-0">
-          <button class="navbar-toggler mb-3"
-                  type="button"
-                  data-bs-toggle="collapse"
-                  data-bs-target="#sidebarMenu"
-                  aria-controls="sidebarMenu"
-                  aria-expanded="false"
-                  aria-label="Toggle navigation">
-            <span class="navbar-toggler-icon"></span>
-          </button>
           <div class="collapse navbar-collapse" id="sidebarMenu">
             {% block sidebar %}
             {% endblock sidebar %}


### PR DESCRIPTION
Because

* We can put the hamburger button that shows the sidebar in the header
* Neater and tidier

This commit

* Moves the hamburger button to the header

fixes #11017

<img width="973" alt="image" src="https://github.com/user-attachments/assets/48c19fda-571e-43e4-a373-5190fa0b6a91">

