### PR TITLE
feat(nimbus): Prevent launching prefFlips experiments to preview

### DIFF
--- a/experimenter/experimenter/experiments/api/v5/serializers.py
+++ b/experimenter/experimenter/experiments/api/v5/serializers.py
@@ -945,6 +945,11 @@ class NimbusExperimentSerializer(
                 }
             )
 
+        if self.should_call_preview_task and not self.instance.can_publish_to_preview:
+            raise serializers.ValidationError(
+                {"status": [NimbusConstants.ERROR_CANNOT_PUBLISH_TO_PREVIEW]},
+            )
+
         return data
 
     def update(self, experiment, validated_data):

--- a/experimenter/experimenter/experiments/api/v5/types.py
+++ b/experimenter/experimenter/experiments/api/v5/types.py
@@ -493,6 +493,7 @@ class NimbusExperimentType(DjangoObjectType):
     audience_url = graphene.NonNull(graphene.String)
     can_archive = graphene.Boolean()
     can_edit = graphene.Boolean()
+    can_publish_to_preview = graphene.NonNull(graphene.Boolean)
     can_review = graphene.Boolean()
     changes = graphene.List(NimbusChangeLogType)
     channel = NimbusExperimentChannelEnum()

--- a/experimenter/experimenter/experiments/constants.py
+++ b/experimenter/experimenter/experiments/constants.py
@@ -778,6 +778,7 @@ Optional - We believe this outcome will <describe impact> on <core metric>
     ERROR_FEATURE_TARGET_COLLECTION = (
         "Feature '{feature_id}' publishes to collection '{collection}'"
     )
+    ERROR_CANNOT_PUBLISH_TO_PREVIEW = "This experiment cannot be published to preview."
 
 
 RISK_QUESTIONS = {

--- a/experimenter/experimenter/experiments/models.py
+++ b/experimenter/experimenter/experiments/models.py
@@ -822,6 +822,17 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
             filters.append(("targeting_config_slug", self.targeting_config_slug))
         return f"{reverse('nimbus-list')}?{urlencode(filters)}"
 
+    @property
+    def can_publish_to_preview(self):
+        if self.application_config:
+            try:
+                return (
+                    self.kinto_collection
+                    == self.application_config.default_kinto_collection
+                )
+            except TargetingMultipleKintoCollectionsError:
+                return False
+
     def delete_branches(self):
         self.reference_branch = None
         self.save()

--- a/experimenter/experimenter/experiments/tests/api/v5/test_queries.py
+++ b/experimenter/experimenter/experiments/tests/api/v5/test_queries.py
@@ -2344,11 +2344,7 @@ class TestNimbusExperimentBySlugQuery(GraphQLTestCase):
         )
 
     def test_query_experiment_targets_multiple_kinto_collections(self):
-        prefflips_feature = NimbusFeatureConfigFactory.create(
-            application=NimbusExperiment.Application.DESKTOP,
-            name=NimbusExperiment.DESKTOP_PREFFLIPS_SLUG,
-            slug=NimbusExperiment.DESKTOP_PREFFLIPS_SLUG,
-        )
+        prefflips_feature = NimbusFeatureConfigFactory.create_desktop_prefflips_feature()
 
         test_feature = NimbusFeatureConfigFactory.create(
             application=NimbusExperiment.Application.DESKTOP,
@@ -2367,6 +2363,7 @@ class TestNimbusExperimentBySlugQuery(GraphQLTestCase):
             query experimentBySlug($slug: String!) {
                 experimentBySlug(slug: $slug) {
                     reviewUrl
+                    canPublishToPreview
                 }
             }
             """,
@@ -2380,6 +2377,7 @@ class TestNimbusExperimentBySlugQuery(GraphQLTestCase):
 
         experiment_data = content["data"]["experimentBySlug"]
         self.assertEqual(experiment_data["reviewUrl"], None)
+        self.assertEqual(experiment_data["canPublishToPreview"], False)
 
 
 class TestNimbusExperimentsByApplicationMetaQuery(GraphQLTestCase):

--- a/experimenter/experimenter/experiments/tests/factories.py
+++ b/experimenter/experimenter/experiments/tests/factories.py
@@ -106,6 +106,14 @@ class NimbusFeatureConfigFactory(factory.django.DjangoModelFactory):
                 )
             )
 
+    @classmethod
+    def create_desktop_prefflips_feature(cls, **kwargs):
+        return cls.create(
+            name=NimbusExperiment.DESKTOP_PREFFLIPS_SLUG,
+            slug=NimbusExperiment.DESKTOP_PREFFLIPS_SLUG,
+            application=NimbusExperiment.Application.DESKTOP,
+        )
+
     class Meta:
         model = NimbusFeatureConfig
 

--- a/experimenter/experimenter/experiments/tests/test_models.py
+++ b/experimenter/experimenter/experiments/tests/test_models.py
@@ -104,11 +104,7 @@ class TestNimbusExperimentManager(TestCase):
             name="test-feature",
             application=NimbusExperiment.Application.DESKTOP,
         )
-        prefflips_feature = NimbusFeatureConfigFactory.create(
-            slug=NimbusConstants.DESKTOP_PREFFLIPS_SLUG,
-            name=NimbusConstants.DESKTOP_PREFFLIPS_SLUG,
-            application=NimbusExperiment.Application.DESKTOP,
-        )
+        prefflips_feature = NimbusFeatureConfigFactory.create_desktop_prefflips_feature()
 
         test_feature_experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE,
@@ -177,11 +173,7 @@ class TestNimbusExperimentManager(TestCase):
             name="test-feature",
             application=NimbusExperiment.Application.DESKTOP,
         )
-        prefflips_feature = NimbusFeatureConfigFactory.create(
-            slug=NimbusConstants.DESKTOP_PREFFLIPS_SLUG,
-            name=NimbusConstants.DESKTOP_PREFFLIPS_SLUG,
-            application=NimbusExperiment.Application.DESKTOP,
-        )
+        prefflips_feature = NimbusFeatureConfigFactory.create_desktop_prefflips_feature()
 
         test_feature_experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.ENDING_APPROVE,
@@ -249,11 +241,7 @@ class TestNimbusExperimentManager(TestCase):
             name="test-feature",
             application=NimbusExperiment.Application.DESKTOP,
         )
-        prefflips_feature = NimbusFeatureConfigFactory.create(
-            slug=NimbusConstants.DESKTOP_PREFFLIPS_SLUG,
-            name=NimbusConstants.DESKTOP_PREFFLIPS_SLUG,
-            application=NimbusExperiment.Application.DESKTOP,
-        )
+        prefflips_feature = NimbusFeatureConfigFactory.create_desktop_prefflips_feature()
 
         test_feature_experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.PAUSING_APPROVE,
@@ -310,11 +298,7 @@ class TestNimbusExperimentManager(TestCase):
             name="test-feature",
             application=NimbusExperiment.Application.DESKTOP,
         )
-        prefflips_feature = NimbusFeatureConfigFactory.create(
-            slug=NimbusConstants.DESKTOP_PREFFLIPS_SLUG,
-            name=NimbusConstants.DESKTOP_PREFFLIPS_SLUG,
-            application=NimbusExperiment.Application.DESKTOP,
-        )
+        prefflips_feature = NimbusFeatureConfigFactory.create_desktop_prefflips_feature()
 
         test_feature_experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE_WAITING,
@@ -380,11 +364,7 @@ class TestNimbusExperimentManager(TestCase):
             name="test-feature",
             application=NimbusExperiment.Application.DESKTOP,
         )
-        prefflips_feature = NimbusFeatureConfigFactory.create(
-            slug=NimbusConstants.DESKTOP_PREFFLIPS_SLUG,
-            name=NimbusConstants.DESKTOP_PREFFLIPS_SLUG,
-            application=NimbusExperiment.Application.DESKTOP,
-        )
+        prefflips_feature = NimbusFeatureConfigFactory.create_desktop_prefflips_feature()
 
         test_feature_experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE_WAITING,
@@ -455,11 +435,7 @@ class TestNimbusExperimentManager(TestCase):
             name="test-feature",
             application=NimbusExperiment.Application.DESKTOP,
         )
-        prefflips_feature = NimbusFeatureConfigFactory.create(
-            slug=NimbusConstants.DESKTOP_PREFFLIPS_SLUG,
-            name=NimbusConstants.DESKTOP_PREFFLIPS_SLUG,
-            application=NimbusExperiment.Application.DESKTOP,
-        )
+        prefflips_feature = NimbusFeatureConfigFactory.create_desktop_prefflips_feature()
 
         test_feature_experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.PAUSING_APPROVE_WAITING,
@@ -1849,10 +1825,7 @@ class TestNimbusExperiment(TestCase):
             self.assertEqual(experiment.review_url, expected)
 
     def test_review_url_prefflips_feature(self):
-        feature_config = NimbusFeatureConfigFactory.create(
-            slug=NimbusConstants.DESKTOP_PREFFLIPS_SLUG,
-            application=NimbusExperiment.Application.DESKTOP,
-        )
+        feature_config = NimbusFeatureConfigFactory.create_desktop_prefflips_feature()
 
         with override_settings(
             KINTO_ADMIN_URL="http://kinto/v1/admin/",

--- a/experimenter/experimenter/nimbus-ui/schema.graphql
+++ b/experimenter/experimenter/nimbus-ui/schema.graphql
@@ -68,6 +68,7 @@ type NimbusExperimentType {
   audienceUrl: String!
   canArchive: Boolean
   canEdit: Boolean
+  canPublishToPreview: Boolean!
   canReview: Boolean
   computedDurationDays: Int
   computedEndDate: DateTime

--- a/experimenter/experimenter/nimbus-ui/src/components/PageSummary/FormLaunchDraftToReview.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageSummary/FormLaunchDraftToReview.tsx
@@ -13,11 +13,13 @@ const FormLaunchDraftToReview = ({
   onLaunchToPreview,
   onSubmit,
   onCancel,
+  canPublishToPreview,
 }: {
   isLoading: boolean;
   onLaunchToPreview: () => void;
   onSubmit: () => void;
   onCancel: () => void;
+  canPublishToPreview: boolean;
 }) => {
   const [allBoxesChecked, setAllBoxesChecked] = useState(false);
   const handleLaunchToPreviewClick = useCallback(
@@ -31,19 +33,37 @@ const FormLaunchDraftToReview = ({
   return (
     <Alert variant="secondary" id="request-launch-alert">
       <Form className="text-body">
-        <p className="my-1">
-          <span className="text-danger">
-            <AlertCircle /> We recommend previewing before launch.
-          </span>{" "}
-          <button
-            data-testid="launch-to-preview-instead"
-            type="button"
-            className="btn btn-sm btn-primary"
-            onClick={handleLaunchToPreviewClick}
-          >
-            Launch to Preview Now
-          </button>
-        </p>
+        {canPublishToPreview ? (
+          <p className="my-1">
+            <span className="text-danger">
+              <AlertCircle /> We recommend previewing before launch.
+            </span>{" "}
+            <button
+              data-testid="launch-to-preview-instead"
+              type="button"
+              className="btn btn-sm btn-primary"
+              onClick={handleLaunchToPreviewClick}
+            >
+              Launch to Preview Now
+            </button>
+          </p>
+        ) : (
+          <>
+            <p className="my-1">
+              <span
+                className="text-danger"
+                data-testid="cannot-launch-to-preview"
+              >
+                <AlertCircle /> This experiment cannot be previewed!
+              </span>
+            </p>
+            <p className="my-1">
+              This experiment uses features that prevent it from being launched
+              to preview. We highly reccomend QAing this experiment on stage
+              first.
+            </p>
+          </>
+        )}
 
         <FormLaunchConfirmationCheckboxes onChange={setAllBoxesChecked} />
 

--- a/experimenter/experimenter/nimbus-ui/src/components/PageSummary/index.test.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageSummary/index.test.tsx
@@ -262,6 +262,18 @@ describe("PageSummary", () => {
     await act(async () => void fireEvent.click(launchButton));
   });
 
+  it("prevents launching to preview for experiments that cannot", async () => {
+    const { mock, experiment } = mockExperimentQuery("slug", {
+      canPublishToPreview: false,
+    });
+
+    render(<Subject mocks={[mock]} />);
+
+    expect(screen.queryByTestId("launch-to-preview-instead")).toBeNull();
+
+    screen.getByTestId("cannot-launch-to-preview");
+  });
+
   it("handles Launch without Preview from Draft as expected", async () => {
     const { mock, experiment } = mockExperimentQuery("demo-slug", {
       status: NimbusExperimentStatusEnum.DRAFT,

--- a/experimenter/experimenter/nimbus-ui/src/components/PageSummary/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageSummary/index.tsx
@@ -261,13 +261,14 @@ const PageSummary = (props: RouteComponentProps) => {
       >
         {status.draft &&
           !experiment.isArchived &&
-          (showLaunchToReview ? (
+          (!experiment.canPublishToPreview || showLaunchToReview ? (
             <FormLaunchDraftToReview
               {...{
                 isLoading,
                 onSubmit: onLaunchClicked,
                 onCancel: () => setShowLaunchToReview(false),
                 onLaunchToPreview: onLaunchToPreviewClicked,
+                canPublishToPreview: experiment.canPublishToPreview,
               }}
             />
           ) : (

--- a/experimenter/experimenter/nimbus-ui/src/gql/experiments.ts
+++ b/experimenter/experimenter/nimbus-ui/src/gql/experiments.ts
@@ -31,6 +31,7 @@ export const GET_EXPERIMENT_QUERY = gql`
       isArchived
       canEdit
       canArchive
+      canPublishToPreview
       name
       slug
       status

--- a/experimenter/experimenter/nimbus-ui/src/lib/mocks.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/lib/mocks.tsx
@@ -579,6 +579,7 @@ export const MOCK_EXPERIMENT: Partial<getExperiment["experimentBySlug"]> = {
   isRollout: false,
   canEdit: true,
   canArchive: true,
+  canPublishToPreview: true,
   owner: {
     email: "example@mozilla.com",
   },

--- a/experimenter/experimenter/nimbus-ui/src/types/getExperiment.ts
+++ b/experimenter/experimenter/nimbus-ui/src/types/getExperiment.ts
@@ -212,6 +212,7 @@ export interface getExperiment_experimentBySlug {
   isArchived: boolean | null;
   canEdit: boolean | null;
   canArchive: boolean | null;
+  canPublishToPreview: boolean;
   name: string;
   slug: string;
   status: NimbusExperimentStatusEnum | null;


### PR DESCRIPTION
Because:

- Firefox will reject prefFlips experiments from the preview collection

This commit:

- prevents prefFlips experiments from being launched to the preview collection.

Fixes #10832.