### PR TITLE
test(nimbus): Add Firefox for iOS integration tests.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,7 @@ orbs:
   gh: circleci/github-cli@2.2
   gcp-cli: circleci/gcp-cli@3.1.1
   android: circleci/android@2.5.0
+  macos: circleci/macos@2.5.1
 commands:
   check_file_paths:
     description: "Check file paths"
@@ -367,6 +368,62 @@ jobs:
       - store_artifacts:
           path: /home/circleci/project/test-reports/report.htm
 
+  integration_test_ios_fennec:
+    macos:
+      xcode: 15.3.0
+    steps:
+      - checkout
+      - check_file_paths:
+          paths: "experimenter/"
+      - macos/preboot-simulator:
+          version: "17.4"
+          platform: "iOS"
+          device: "iPhone 15"
+      - attach_workspace:
+          at: /tmp/experimenter
+      - run:
+          name: Clone Firefox iOS Repo
+          command: git clone https://github.com/mozilla-mobile/firefox-ios.git
+      - run:
+          name: Install nimbus-cli
+          command: curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/mozilla/application-services/main/install-nimbus-cli.sh | bash
+      - run:
+          name: Setup and build Firefox app
+          command: |
+            cd firefox-ios
+            sh ./bootstrap.sh
+            cd firefox-ios
+            pip3 install virtualenv poetry
+            xcodebuild build-for-testing -project Client.xcodeproj -scheme Fennec -configuration Fennec -sdk iphonesimulator -quiet -destination 'platform=iOS Simulator,name=iPhone 15,OS=17.4'
+      - run:
+          name: Run Tests
+          command: |
+            cd firefox-ios/firefox-ios/firefox-ios-tests/Tests/ExperimentIntegrationTests
+            export SIMULATOR_UDID=$(python get_specific_device_udid.py)
+            cp -f ~/project/experimenter/tests/integration/nimbus/ios/test_ios_integration.py ./
+            poetry install
+            poetry run pytest -k test_ios_integration.py --feature ios_enrollment
+      - store_artifacts:
+          path: ~/project/firefox-ios/firefox-ios/firefox-ios-tests/Tests/ExperimentIntegrationTests/results/index.html
+
+  create_fenix_fennec_recipes:
+    working_directory: ~/experimenter
+    machine:
+      image: ubuntu-2004:2023.10.1
+      docker_layer_caching: true
+    steps:
+      - checkout
+      - run:
+          name: Create experiment on experimenter
+          command: |
+            cp .env.integration-tests .env
+            export CIRRUS=1
+            make refresh SKIP_DUMMY=1 PYTEST_SENTRY_DSN=$PYTEST_SENTRY_DSN CIRCLECI=$CIRCLECI up_prod_detached integration_test_nimbus PYTEST_ARGS="-k test_create_ios_experiment_for_integration_test[FIREFOX_IOS]"
+      - persist_to_workspace:
+          root: experimenter
+          paths:
+            - tests/integration/ios_recipe.json
+      
   deploy_experimenter:
     working_directory: ~/experimenter
     machine:
@@ -666,6 +723,8 @@ workflows:
             branches:
               ignore:
                 - main
+      - create_fenix_fennec_recipes:
+          name: Create fenix and fennec recipes
       - integration_nimbus_desktop_release_targeting:
           name: Test Desktop Targeting (Release Firefox)
           filters:
@@ -728,6 +787,14 @@ workflows:
                 - main
       - integration_test_android_fenix:
           name: Test Firefox for Android (Fenix)
+          filters:
+            branches:
+              ignore:
+                - main
+      - integration_test_ios_fennec:
+          name: Test Firefox for iOS (Fennec)
+          requires:
+            - Create fenix and fennec recipes
           filters:
             branches:
               ignore:

--- a/experimenter/tests/integration/nimbus/ios/test_ios_integration.py
+++ b/experimenter/tests/integration/nimbus/ios/test_ios_integration.py
@@ -1,0 +1,91 @@
+import logging
+import os
+import subprocess
+import time
+from pathlib import Path
+
+import pytest
+
+here = Path(__file__)
+
+
+@pytest.fixture
+def experiment_slug():
+    return "firefox-ios-integration-test"
+
+
+@pytest.fixture(name="device_control", scope="module", autouse=True)
+def fixture_device_control(xcrun):
+    ...
+
+
+@pytest.fixture(name="experiment_url", scope="module")
+def fixture_experiment_url(request, variables):
+    ...
+
+
+@pytest.fixture(name="experiment_data")
+def fixture_experiment_data(experiment_url, request):
+    ...
+
+
+@pytest.fixture(name="set_env_variables", autouse=True)
+def fixture_set_env_variables(experiment_slug):
+    """Set any env variables XCUITests might need"""
+    os.environ["EXPERIMENT_NAME"] = experiment_slug
+
+
+@pytest.fixture(name="setup_experiment")
+def setup_experiment(experiment_slug, nimbus_cli_args):
+    def _setup_experiment():
+        logging.info(f"Testing experiment {experiment_slug}")
+        command = [
+            "nimbus-cli",
+            "--app",
+            "firefox_ios",
+            "--channel",
+            "developer",
+            "enroll",
+            f"{experiment_slug}",
+            "--branch",
+            "control",
+            "--file",
+            "/tmp/experimenter/tests/integration/ios_recipe.json",
+            "--reset-app",
+            "--",
+            f"{nimbus_cli_args}",
+        ]
+        logging.info(f"Nimbus CLI Command: {' '.join(command)}")
+        out = subprocess.check_output(
+            " ".join(command),
+            cwd=here.parent,
+            stderr=subprocess.STDOUT,
+            universal_newlines=True,
+            shell=True,
+        )
+        logging.info(out)
+
+    return _setup_experiment
+
+
+@pytest.mark.ios_enrollment
+def test_experiment_unenrolls_after_studies_toggle(
+    xcodebuild, setup_experiment, start_app
+):
+    xcodebuild.install(boot=False)
+    xcodebuild.test(
+        "XCUITests/ExperimentIntegrationTests/testAppStartup", build=False, erase=False
+    )
+    setup_experiment()
+    time.sleep(5)
+    xcodebuild.test(
+        "XCUITests/ExperimentIntegrationTests/testVerifyExperimentEnrolled",
+        build=False,
+        erase=False,
+    )
+    start_app()
+    xcodebuild.test(
+        "XCUITests/ExperimentIntegrationTests/testStudiesToggleDisablesExperiment",
+        build=False,
+        erase=False,
+    )

--- a/experimenter/tests/integration/nimbus/ios/test_ios_integration.py
+++ b/experimenter/tests/integration/nimbus/ios/test_ios_integration.py
@@ -16,17 +16,17 @@ def experiment_slug():
 
 @pytest.fixture(name="device_control", scope="module", autouse=True)
 def fixture_device_control(xcrun):
-    ...
+    ...  # Overriding for Experimenter Integration Test
 
 
 @pytest.fixture(name="experiment_url", scope="module")
 def fixture_experiment_url(request, variables):
-    ...
+    ...  # Overriding for Experimenter Integration Test
 
 
 @pytest.fixture(name="experiment_data")
 def fixture_experiment_data(experiment_url, request):
-    ...
+    ...  # Overriding for Experimenter Integration Test
 
 
 @pytest.fixture(name="set_env_variables", autouse=True)

--- a/experimenter/tests/integration/nimbus/ios/test_setup_ios_integration.py
+++ b/experimenter/tests/integration/nimbus/ios/test_setup_ios_integration.py
@@ -1,0 +1,73 @@
+import json
+import logging
+import time
+from pathlib import Path
+
+import pytest
+import requests
+from nimbus.models.base_dataclass import BaseExperimentApplications
+from nimbus.pages.experimenter.summary import SummaryPage
+from nimbus.utils import helpers
+
+
+@pytest.fixture
+def experiment_slug():
+    return "firefox-ios-integration-test"
+
+
+@pytest.fixture
+def default_data_api(default_data_api):
+    feature_config_id = helpers.get_feature_id_as_string(
+        "messaging", BaseExperimentApplications.FIREFOX_IOS.value
+    )
+    test_data = {
+        "featureConfigIds": [int(feature_config_id)],
+        "referenceBranch": {
+            "description": "control",
+            "name": "control",
+            "ratio": 50,
+            "featureValues": [
+                {
+                    "featureConfig": str(feature_config_id),
+                    "value": "{}",
+                },
+            ],
+        },
+    }
+    default_data_api.update(test_data)
+    return default_data_api
+
+
+@pytest.mark.ios
+def test_create_ios_experiment_for_integration_test(
+    selenium, experiment_url, kinto_client, default_data_api, experiment_slug
+):
+    """Create an ios experiment for device integration tests"""
+    helpers.create_experiment(
+        experiment_slug, BaseExperimentApplications.FIREFOX_IOS.value, default_data_api
+    )
+
+    summary = SummaryPage(selenium, experiment_url).open()
+    summary.launch_and_approve()
+
+    kinto_client.approve()
+
+    SummaryPage(selenium, experiment_url).open().wait_for_live_status()
+
+    path = Path.cwd()
+    timeout = time.time() + 30
+    while time.time() < timeout:
+        try:
+            recipe = requests.get(
+                f"https://nginx/api/v6/experiments/{experiment_slug}/", verify=False
+            ).json()
+        except Exception:
+            time.sleep(1)
+            continue
+        else:
+            json_file = (
+                path / "experimenter" / "tests" / "integration" / "ios_recipe.json"
+            )
+            json_file.write_text(json.dumps(recipe))
+            logging.info(f"ios recipe created at {json_file}")
+            break


### PR DESCRIPTION
Because:

- We have integration tests for fenix and desktop, we should add ios

This commit:

- Adds ios integration tests to the circleci workflow.

This test creates an experiment on experimenter and copies the recipe from that experiment.
It then uses nimbus cli to enroll the device into that experiment and does a few checks, namely
making sure the experiment is enrolled and that it can be unenrolled.

Fixes #11028