### PR TITLE
Fix fenix apk update script

### DIFF
--- a/experimenter/tests/integration/nimbus/android/update-fenix-apks.sh
+++ b/experimenter/tests/integration/nimbus/android/update-fenix-apks.sh
@@ -4,18 +4,10 @@ set -euo pipefail
 set +x
 
 TASKCLUSTER_API="https://firefox-ci-tc.services.mozilla.com/api/index/v1"
-INDEX_BASE="mobile.v3.firefox-android.apks.fenix-beta.2024"
+INDEX_BASE="gecko.v2.mozilla-beta.latest.mobile"
 CURLFLAGS=("--proto" "=https" "--tlsv1.2" "-sS")
 
-LATEST_BASE=$(curl ${CURLFLAGS[@]} "${TASKCLUSTER_API}/namespaces/${INDEX_BASE}" | jq -r '.namespaces[-1].name' )
-
-echo LATEST_BASE "${LATEST_BASE}"
-
-LATEST_VERSION=$(curl ${CURLFLAGS[@]} "${TASKCLUSTER_API}/namespaces/${INDEX_BASE}.${LATEST_BASE}" | jq -r '.namespaces[-1].name' )
-
-echo LATEST_VERSION "${LATEST_VERSION}"
-
-TASK_ID=$(curl ${CURLFLAGS[@]} "${TASKCLUSTER_API}/tasks/${INDEX_BASE}.${LATEST_BASE}.${LATEST_VERSION}.latest" | jq -r '.tasks[-1].taskId')
+TASK_ID=$(curl ${CURLFLAGS[@]} "${TASKCLUSTER_API}/tasks/${INDEX_BASE}" | jq '.tasks[] | select(.namespace == "gecko.v2.mozilla-beta.latest.mobile.fenix-beta") | .taskId')
 
 echo TASK ID "${TASK_ID}"
 


### PR DESCRIPTION
Because

- Our current script uses the wrong API path for querying current fenix beta builds

This commit

- Changes to the correct path that is currently being used

Fixes #11030 