### PR TITLE
feat(nimbus): use offcanvas sidebar for narrow screens

### DIFF
--- a/experimenter/experimenter/nimbus_ui_new/static/css/style.scss
+++ b/experimenter/experimenter/nimbus_ui_new/static/css/style.scss
@@ -124,3 +124,9 @@
     }
   }
 }
+
+.bootstrap-select:not([class*="col-"]):not([class*="form-control"]):not(
+    .input-group-btn
+  ) {
+  width: 100%;
+}

--- a/experimenter/experimenter/nimbus_ui_new/templates/common/header.html
+++ b/experimenter/experimenter/nimbus_ui_new/templates/common/header.html
@@ -3,13 +3,11 @@
 <nav class="navbar">
   <div class="container-fluid">
     <div class="d-flex align-items-center">
-      <button class="navbar-toggler me-3 d-xl-none"
+      <button class="btn d-xl-none"
               type="button"
-              data-bs-toggle="collapse"
-              data-bs-target="#sidebarMenu"
-              aria-controls="sidebarMenu"
-              aria-expanded="false"
-              aria-label="Toggle navigation">
+              data-bs-toggle="offcanvas"
+              data-bs-target="#offcanvasSidebar"
+              aria-controls="offcanvasSidebar">
         <span class="navbar-toggler-icon"></span>
       </button>
       <a class="navbar-brand d-flex align-items-center fs-3"

--- a/experimenter/experimenter/nimbus_ui_new/templates/common/list_tab.html
+++ b/experimenter/experimenter/nimbus_ui_new/templates/common/list_tab.html
@@ -12,8 +12,11 @@
     {% endfor %}
     <button type="submit"
             class="nav-link pb-3 {% if active_status == status %}active{% endif %}">
-      <i class="{{ icon }}"></i>
-      {{ status }} ({{ count }})
+      <div class="d-inline-flex align-items-center">
+        <i class="{{ icon }} me-2"></i>
+        <span>{{ status }}</span>
+      </div>
+      <span>({{ count }})</span>
     </button>
   </form>
 </li>

--- a/experimenter/experimenter/nimbus_ui_new/templates/common/with_sidebar.html
+++ b/experimenter/experimenter/nimbus_ui_new/templates/common/with_sidebar.html
@@ -5,16 +5,27 @@
 {% block content %}
   <div id="content" class="container-fluid">
     <div class="row">
-      <div class="col-lg-12 col-xl-3 col-xxl-2 d-md-block">
-        <nav class="navbar navbar-expand-xl py-0">
-          <div class="collapse navbar-collapse" id="sidebarMenu">
+      <div class="col-xl-2 col-xxl-2">
+        <div class="offcanvas-xl offcanvas-start"
+             tabindex="-1"
+             id="offcanvasSidebar"
+             aria-labelledby="offcanvasSidebarLabel">
+          <div class="offcanvas-header">
+            <h5 class="offcanvas-title" id="offcanvasSidebarLabel">Filter</h5>
+            <button type="button"
+                    class="btn-close"
+                    data-bs-dismiss="offcanvas"
+                    data-bs-target="#offcanvasSidebar"
+                    aria-label="Close"></button>
+          </div>
+          <div class="offcanvas-body">
             {% block sidebar %}
             {% endblock sidebar %}
 
           </div>
-        </nav>
+        </div>
       </div>
-      <div class="col-lg-12 col-xl-9 col-xxl-10">
+      <div class="col-xl-10 col-xxl-10">
         {% block main_content %}
         {% endblock main_content %}
 


### PR DESCRIPTION
Because

* Bootstrap 5.2 offers responsive offcanvas slideouts
* We can use that for the sidebar on narrow screens
* Much nicer than putting the filters above the table

This commit

* Uses responsive offcanvas to slide the sidebar out on narrow screens

fixes #11017

https://github.com/user-attachments/assets/dc2ffc30-edc3-411b-99a5-7cbf030ea0ee

