### PR TITLE
chore(nimbus): Fix fenix apk updater circleci logic.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -633,8 +633,6 @@ jobs:
               git add .
               git commit -m "chore(nimbus): Update fenix apks for testing"
               if [[ "${CURRENT_FENIX_BUILD_ID}" != "${LATEST_FENIX_BUILD_ID}" ]]; then
-                echo "Changes already committed, skipping"
-              else
                 git push origin update-fenix-apks
                 gh pr create -t "chore(nimbus): Update fenix apks for testing" -b "" --base main --head update-fenix-apks --repo mozilla/experimenter || echo "PR already exists, skipping"
               fi


### PR DESCRIPTION
Because

- The logic in the circleci job to create a PR updating our fenix APKs was incorrect. The recent changes triggered correctly but the if statement was wrong and didn't allow the PR to be created

This commit

- Fixes this logic by just having 1 condition when it checks if there is a new build on taskcluster,

Fixes #11036 