### PR TITLE
bug(nimbus): Rename ja-JP-mac locale to ja-JP-macos

### DIFF
--- a/experimenter/experimenter/base/fixtures/locales.json
+++ b/experimenter/experimenter/base/fixtures/locales.json
@@ -417,6 +417,14 @@
   },
   {
     "model": "base.locale",
+    "pk": 78,
+    "fields": {
+      "code": "ja-JP-macos",
+      "name": "Japanese (macOS)"
+    }
+  },
+  {
+    "model": "base.locale",
     "pk": 79,
     "fields": {
       "code": "ka",

--- a/experimenter/experimenter/base/migrations/0005_jajpmacos.py
+++ b/experimenter/experimenter/base/migrations/0005_jajpmacos.py
@@ -1,0 +1,19 @@
+from django.db import migrations
+
+
+def update_ja_jp_mac_locale(apps, schema_editor):
+    Locale = apps.get_model("base", "Locale")
+
+    Locale.objects.filter(code="ja-JP-mac").update(
+        code="ja-JP-macos", name="Japanese (macOS)"
+    )
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("base", "0004_language"),
+    ]
+
+    operations = [
+        migrations.RunPython(update_ja_jp_mac_locale),
+    ]

--- a/experimenter/experimenter/experiments/tests/test_migrations.py
+++ b/experimenter/experimenter/experiments/tests/test_migrations.py
@@ -3,37 +3,26 @@ from django_test_migrations.contrib.unittest_case import MigratorTestCase
 
 class TestMigrations(MigratorTestCase):
     migrate_from = (
-        "experiments",
-        "0269_nimbusexperiment_conclusion_recommendations",
+        "base",
+        "0004_language",
     )
     migrate_to = (
-        "experiments",
-        "0270_alter_conclusion_recommendations",
+        "base",
+        "0005_jajpmacos",
     )
 
     def prepare(self):
         """Prepare some data before the migration."""
-        User = self.old_state.apps.get_model("auth", "User")
-        NimbusExperiment = self.old_state.apps.get_model(
-            "experiments", "NimbusExperiment"
-        )
-        owner = User.objects.create()
+        Locale = self.old_state.apps.get_model("base", "Locale")
 
-        # Create NimbusExperiment objects with old values for conclusion_recommendation
-        NimbusExperiment.objects.create(
-            owner=owner,
-            slug="should_change",
-            name="should_change",
-            conclusion_recommendation="RERUN",
-        )
+        Locale.objects.create(code="ja-JP-mac", name="Japanese")
 
     def test_migration(self):
         """Run the test itself."""
-        NimbusExperiment = self.new_state.apps.get_model(
-            "experiments", "NimbusExperiment"
-        )
+        Locale = self.new_state.apps.get_model("base", "Locale")
 
-        self.assertEqual(
-            NimbusExperiment.objects.get(slug="should_change").conclusion_recommendations,
-            ["RERUN"],
-        )
+        self.assertFalse(Locale.objects.filter(code="ja-JP-mac").exists())
+
+        locale = Locale.objects.get(code="ja-JP-macos")
+
+        self.assertEqual(locale.name, "Japanese (macOS)")


### PR DESCRIPTION
Because:

- Firefox reports its macOS-specific locale as `ja-JP-macos`;
- Experimenter exposes a `ja-JP-mac` locale code in stage and prod; and
- the `ja-JP-mac` locale fixture was removed, but the Japanese macOS locale is a specific variant from a targeting point of view;

this commit:

- adds a locale fixture for `ja-JP-macos` named "Japanese (macOS)" so it is clear that it is different from the regular `ja` locale; and
- adds a migration to rename the `ja-JP-mac` locale to `ja-JP-macos` and change its name to "Japanese (macOS)".

Fixes #11041.