### PR TITLE
chore(nimbus): Hard code experimenter docker repo in fenix integration tests.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -415,7 +415,7 @@ jobs:
       - run:
           name: Install APKs
           command: |
-            docker run -d --name fenix-files ${DOCKERHUB_REPO}:fenix-apk-store
+            docker run -d --name fenix-files mozilla/experimenter:fenix-apk-store
             docker cp fenix-files:/usr/src/app/files /home/circleci/project
             adb install /home/circleci/project/files/app-fenix-x86_64-debug.apk
             adb install /home/circleci/project/files/app-fenix-debug-androidTest.apk


### PR DESCRIPTION
Because

- We want to support forks but environment variables aren't shared with forks due to security polices. Because of this, the fenix integration test job was failing due to not having access to an environment variable.

This commit

- Hard code's experimenter docker hub repo `mozilla/experimenter` within the fenix test job.

Fixes #11045 