### PR TITLE
chore(nimbus): reduce number of remote settings integration tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -186,7 +186,7 @@ jobs:
       - store_artifacts:
           path: ~/experimenter/experimenter/tests/integration/test-reports/report.htm
 
-  integration_nimbus_desktop_remote_settings:
+  integration_nimbus_remote_settings_launch:
     machine:
       image: ubuntu-2004:2023.10.1
       docker_layer_caching: true
@@ -194,7 +194,7 @@ jobs:
     working_directory: ~/experimenter
     environment:
       FIREFOX_VERSION: nimbus-firefox-release
-      PYTEST_ARGS: -k FIREFOX_DESKTOP -m remote_settings --reruns 1
+      PYTEST_ARGS: -m remote_settings_launch --reruns 1
     steps:
       - checkout
       - check_file_paths:
@@ -207,7 +207,7 @@ jobs:
       - store_artifacts:
           path: ~/experimenter/experimenter/tests/integration/test-reports/report.htm
 
-  integration_nimbus_fenix_remote_settings:
+  integration_nimbus_remote_settings_all:
     machine:
       image: ubuntu-2004:2023.10.1
       docker_layer_caching: true
@@ -215,70 +215,7 @@ jobs:
     working_directory: ~/experimenter
     environment:
       FIREFOX_VERSION: nimbus-firefox-release
-      PYTEST_ARGS: -k FIREFOX_FENIX -m remote_settings --reruns 1
-    steps:
-      - checkout
-      - check_file_paths:
-          paths: "experimenter/"
-      - run:
-          name: Run integration tests
-          command: |
-            cp .env.integration-tests .env
-            make refresh SKIP_DUMMY=1 PYTEST_SENTRY_DSN=$PYTEST_SENTRY_DSN CIRCLECI=$CIRCLECI up_prod_detached integration_test_nimbus PYTEST_ARGS="$PYTEST_ARGS"
-      - store_artifacts:
-          path: ~/experimenter/experimenter/tests/integration/test-reports/report.htm
-
-  integration_nimbus_ios_remote_settings:
-    machine:
-      image: ubuntu-2004:2023.10.1
-      docker_layer_caching: true
-    resource_class: medium
-    working_directory: ~/experimenter
-    environment:
-      FIREFOX_VERSION: nimbus-firefox-release
-      PYTEST_ARGS: -k FIREFOX_IOS -m remote_settings --reruns 1
-    steps:
-      - checkout
-      - check_file_paths:
-          paths: "experimenter/"
-      - run:
-          name: Run integration tests
-          command: |
-            cp .env.integration-tests .env
-            make refresh SKIP_DUMMY=1 PYTEST_SENTRY_DSN=$PYTEST_SENTRY_DSN CIRCLECI=$CIRCLECI up_prod_detached integration_test_nimbus PYTEST_ARGS="$PYTEST_ARGS"
-      - store_artifacts:
-          path: ~/experimenter/experimenter/tests/integration/test-reports/report.htm
-
-  integration_nimbus_focus_android_remote_settings:
-    machine:
-      image: ubuntu-2004:2023.10.1
-      docker_layer_caching: true
-    resource_class: medium
-    working_directory: ~/experimenter
-    environment:
-      FIREFOX_VERSION: nimbus-firefox-release
-      PYTEST_ARGS: -k FOCUS_ANDROID -m remote_settings --reruns 1
-    steps:
-      - checkout
-      - check_file_paths:
-          paths: "experimenter/"
-      - run:
-          name: Run integration tests
-          command: |
-            cp .env.integration-tests .env
-            make refresh SKIP_DUMMY=1 PYTEST_SENTRY_DSN=$PYTEST_SENTRY_DSN CIRCLECI=$CIRCLECI up_prod_detached integration_test_nimbus PYTEST_ARGS="$PYTEST_ARGS"
-      - store_artifacts:
-          path: ~/experimenter/experimenter/tests/integration/test-reports/report.htm
-
-  integration_nimbus_focus_ios_remote_settings:
-    machine:
-      image: ubuntu-2004:2023.10.1
-      docker_layer_caching: true
-    resource_class: medium
-    working_directory: ~/experimenter
-    environment:
-      FIREFOX_VERSION: nimbus-firefox-release
-      PYTEST_ARGS: -k FOCUS_IOS -m remote_settings --reruns 1
+      PYTEST_ARGS: -k FIREFOX_DESKTOP -m remote_settings_all --reruns 1
     steps:
       - checkout
       - check_file_paths:
@@ -753,32 +690,14 @@ workflows:
             branches:
               ignore:
                 - main
-      - integration_nimbus_desktop_remote_settings:
-          name: Test Desktop and Remote Settings (Release Firefox)
+      - integration_nimbus_remote_settings_launch:
+          name: Test Remote Settings Launch (All Applications)
           filters:
             branches:
               ignore:
                 - main
-      - integration_nimbus_fenix_remote_settings:
-          name: Test Fenix and Remote Settings (Release Firefox)
-          filters:
-            branches:
-              ignore:
-                - main
-      - integration_nimbus_ios_remote_settings:
-          name: Test iOS and Remote Settings (Release Firefox)
-          filters:
-            branches:
-              ignore:
-                - main
-      - integration_nimbus_focus_android_remote_settings:
-          name: Test Focus Android and Remote Settings (Release Firefox)
-          filters:
-            branches:
-              ignore:
-                - main
-      - integration_nimbus_focus_ios_remote_settings:
-          name: Test Focus iOS and Remote Settings (Release Firefox)
+      - integration_nimbus_remote_settings_all:
+          name: Test Remote Settings All Workflows (Release Firefox Desktop)
           filters:
             branches:
               ignore:

--- a/experimenter/tests/integration/nimbus/test_remote_settings.py
+++ b/experimenter/tests/integration/nimbus/test_remote_settings.py
@@ -5,7 +5,7 @@ from nimbus.pages.experimenter.summary import SummaryPage
 from nimbus.utils import helpers
 
 
-@pytest.mark.remote_settings
+@pytest.mark.remote_settings_launch
 def test_create_new_experiment_approve_remote_settings(
     selenium,
     experiment_url,
@@ -27,7 +27,7 @@ def test_create_new_experiment_approve_remote_settings(
     HomePage(selenium, base_url).open().find_in_table(experiment_slug)
 
 
-@pytest.mark.remote_settings
+@pytest.mark.remote_settings_all
 def test_create_new_rollout_approve_remote_settings(
     selenium,
     experiment_url,
@@ -51,7 +51,7 @@ def test_create_new_rollout_approve_remote_settings(
     HomePage(selenium, base_url).open().find_in_table(experiment_slug)
 
 
-@pytest.mark.remote_settings
+@pytest.mark.remote_settings_all
 def test_create_new_experiment_reject_remote_settings(
     selenium,
     experiment_url,
@@ -70,7 +70,7 @@ def test_create_new_experiment_reject_remote_settings(
     SummaryPage(selenium, experiment_url).open().wait_for_rejected_alert()
 
 
-@pytest.mark.remote_settings
+@pytest.mark.remote_settings_all
 def test_create_new_rollout_reject_remote_settings(
     selenium,
     experiment_url,
@@ -91,7 +91,7 @@ def test_create_new_rollout_reject_remote_settings(
     SummaryPage(selenium, experiment_url).open().wait_for_rejected_alert()
 
 
-@pytest.mark.remote_settings
+@pytest.mark.remote_settings_all
 def test_end_experiment_and_approve_end_set_takeaways(
     selenium,
     experiment_url,
@@ -123,7 +123,7 @@ def test_end_experiment_and_approve_end_set_takeaways(
     assert summary.takeaways_recommendation_badge_text == "Change course"
 
 
-@pytest.mark.remote_settings
+@pytest.mark.remote_settings_all
 def test_end_rollout_and_approve_end_set_takeaways(
     selenium,
     experiment_url,
@@ -157,7 +157,7 @@ def test_end_rollout_and_approve_end_set_takeaways(
     assert summary.takeaways_recommendation_badge_text == "Change course"
 
 
-@pytest.mark.remote_settings
+@pytest.mark.remote_settings_all
 def test_end_experiment_and_reject_end(
     selenium,
     experiment_url,
@@ -182,7 +182,7 @@ def test_end_experiment_and_reject_end(
     SummaryPage(selenium, experiment_url).open().wait_for_rejected_alert()
 
 
-@pytest.mark.remote_settings
+@pytest.mark.remote_settings_all
 def test_end_rollout_and_reject_end(
     selenium,
     experiment_url,
@@ -209,7 +209,7 @@ def test_end_rollout_and_reject_end(
     SummaryPage(selenium, experiment_url).open().wait_for_rejected_alert()
 
 
-@pytest.mark.remote_settings
+@pytest.mark.remote_settings_all
 def test_rollout_live_update_approve(
     selenium,
     kinto_client,
@@ -239,7 +239,7 @@ def test_rollout_live_update_approve(
     kinto_client.approve()
 
 
-@pytest.mark.remote_settings
+@pytest.mark.remote_settings_all
 def test_rollout_live_update_approve_and_reject(
     selenium,
     kinto_client,
@@ -272,7 +272,7 @@ def test_rollout_live_update_approve_and_reject(
     summary.wait_for_rejection_notice_visible()
 
 
-@pytest.mark.remote_settings
+@pytest.mark.remote_settings_all
 def test_rollout_live_update_reject_on_experimenter(
     selenium,
     kinto_client,
@@ -307,7 +307,7 @@ def test_rollout_live_update_reject_on_experimenter(
     summary.wait_for_rejection_notice_visible()
 
 
-@pytest.mark.remote_settings
+@pytest.mark.remote_settings_all
 def test_create_new_experiment_timeout_remote_settings(
     selenium,
     application,

--- a/experimenter/tests/pytest.ini
+++ b/experimenter/tests/pytest.ini
@@ -5,7 +5,8 @@ log_cli_level = info
 markers =
     use_variables: marks tests that need to use pytest-variables
     run_targeting: run jexl targeting tests in firefox
-    remote_settings: tests that involve remote settings
+    remote_settings_launch: a single test for launching to remote settings
+    remote_settings_all: a full suite of tests for remote settings integration
     nimbus_ui: tests that only involve the UI, nothing else
     desktop_enrollment: tests that integrate with nimbus and external services
     cirrus_enrollment: tests that integrate with demo app and cirrus


### PR DESCRIPTION
Becuase

* We want to run at least one remote settings integration test for every app to make sure all the configuration and code is intact for every application
* We don't need to check every remote settings case for every application
* Reducing the number of remote settings tests will free up some CI space to add fun new tests

This commit

* Collapses the remote settings integration tests down to two tasks
* One for launching every application
* One for the entire suite for a single application

fixes #11047

