### PR TITLE
bug(nimbus): Fix typo in prefFlips QA recommendation

### DIFF
--- a/experimenter/experimenter/nimbus-ui/src/components/PageSummary/FormLaunchDraftToReview.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageSummary/FormLaunchDraftToReview.tsx
@@ -59,7 +59,7 @@ const FormLaunchDraftToReview = ({
             </p>
             <p className="my-1">
               This experiment uses features that prevent it from being launched
-              to preview. We highly reccomend QAing this experiment on stage
+              to preview. We highly recommend QAing this experiment on stage
               first.
             </p>
           </>


### PR DESCRIPTION
Because:

- the QA recommendation message for prefFlips had a typo

This commit:

- fixes that typo.

Fixes #11057