### PR TITLE
chore(nimbus): Fetch manifests from Desktop esr128

### DIFF
--- a/experimenter/experimenter/features/manifests/apps.yaml
+++ b/experimenter/experimenter/features/manifests/apps.yaml
@@ -126,3 +126,4 @@ firefox_desktop:
           - "beta"
           - "release"
           - "esr115"
+          - "esr128"


### PR DESCRIPTION
Because:

- there is now a esr128 channel for Desktop

This commit:

- adds esr128 to the list of branches to fetch.

Fixes #11085.