### PR TITLE
chore(nimbus): exclude MSIX targeting

### DIFF
--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -1785,6 +1785,18 @@ WINDOWS_10_PLUS = NimbusTargetingConfig(
     application_choice_names=(Application.DESKTOP.name,),
 )
 
+
+WINDOWS_10_NOMSIX = NimbusTargetingConfig(
+    name="Windows 10+ without msix",
+    slug="windows_10_plus_nomsix",
+    description="Windows users on version 10 or higher, but no MSIX intallations",
+    targeting="(os.isWindows && os.windowsVersion >= 10 && !isMSIX)",
+    desktop_telemetry="",
+    sticky_required=False,
+    is_first_run_required=False,
+    application_choice_names=(Application.DESKTOP.name,),
+)
+
 IOS_IPHONE_USERS_ONLY = NimbusTargetingConfig(
     name="iPhone users only",
     slug="ios_iphone_users_only",


### PR DESCRIPTION
Because

* We need a way to experiment with non-MSIX installations

This commit

* Basically clones the WINDOWS_10_PLUS and excludes MSIX

Fixes #11092 