### PR TITLE
feat(nimbus): Only allow prefFlips feature on 128 ESR

### DIFF
--- a/experimenter/experimenter/experiments/constants.py
+++ b/experimenter/experimenter/experiments/constants.py
@@ -780,6 +780,13 @@ Optional - We believe this outcome will <describe impact> on <core metric>
     )
     ERROR_CANNOT_PUBLISH_TO_PREVIEW = "This experiment cannot be published to preview."
 
+    ERROR_DESKTOP_PREFFLIPS_CHANNEL_REQUIRED = (
+        "A channel is required for using the prefFlips feature."
+    )
+    ERROR_DESKTOP_PREFFLIPS_128_ESR_ONLY = (
+        "The prefFlips feature is only available on Firefox 128 on the ESR branch."
+    )
+
 
 RISK_QUESTIONS = {
     "BRAND": (


### PR DESCRIPTION
Because:

- the prefFlips feature will be uplifted to esr128; and
- it is not implemented on v128 of other Firefox channels

this commit:

- adds a check in the serializer to limit the prefFlips feature to v129+ on all Desktop channels and v128 of ESR.

Fixes #11086.