### PR TITLE
bug(nimbus): list page filters should fit in sidebar

### DIFF
--- a/experimenter/experimenter/nimbus_ui_new/filtersets.py
+++ b/experimenter/experimenter/nimbus_ui_new/filtersets.py
@@ -71,9 +71,15 @@ class SortChoices(models.TextChoices):
 class MultiSelectWidget(forms.SelectMultiple):
     template_name = "common/sidebar_select.html"
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, attrs, **kwargs):
         self.icon = kwargs.pop("icon", None)
-        super().__init__(*args, **kwargs)
+        attrs.update(
+            {
+                "class": "selectpicker form-control bg-body-tertiary",
+                "data-live-search": "true",
+            }
+        )
+        super().__init__(*args, attrs=attrs, **kwargs)
 
     def get_context(self, name, value, attrs):
         context = super().get_context(name, value, attrs)
@@ -108,8 +114,6 @@ class NimbusExperimentFilter(django_filters.FilterSet):
             icon="fa-solid fa-flask-vial",
             attrs={
                 "title": "All Types",
-                "class": "selectpicker",
-                "data-live-search": "true",
             },
         ),
     )
@@ -119,8 +123,6 @@ class NimbusExperimentFilter(django_filters.FilterSet):
             icon="fa-solid fa-desktop",
             attrs={
                 "title": "All Applications",
-                "class": "selectpicker",
-                "data-live-search": "true",
             },
         ),
     )
@@ -130,8 +132,6 @@ class NimbusExperimentFilter(django_filters.FilterSet):
             icon="fa-solid fa-road",
             attrs={
                 "title": "All Channels",
-                "class": "selectpicker",
-                "data-live-search": "true",
             },
         ),
     )
@@ -141,8 +141,6 @@ class NimbusExperimentFilter(django_filters.FilterSet):
             icon="fa-solid fa-code-branch",
             attrs={
                 "title": "All Versions",
-                "class": "selectpicker",
-                "data-live-search": "true",
             },
         ),
     )
@@ -152,8 +150,6 @@ class NimbusExperimentFilter(django_filters.FilterSet):
             icon="fa-solid fa-boxes-stacked",
             attrs={
                 "title": "All Features",
-                "class": "selectpicker",
-                "data-live-search": "true",
             },
         ),
     )
@@ -163,8 +159,6 @@ class NimbusExperimentFilter(django_filters.FilterSet):
             icon="fa-solid fa-globe",
             attrs={
                 "title": "All Countries",
-                "class": "selectpicker",
-                "data-live-search": "true",
             },
         ),
     )
@@ -174,8 +168,6 @@ class NimbusExperimentFilter(django_filters.FilterSet):
             icon="fa-solid fa-language",
             attrs={
                 "title": "All Languages",
-                "class": "selectpicker",
-                "data-live-search": "true",
             },
         ),
     )
@@ -185,8 +177,6 @@ class NimbusExperimentFilter(django_filters.FilterSet):
             icon="fa-solid fa-earth-americas",
             attrs={
                 "title": "All Locales",
-                "class": "selectpicker",
-                "data-live-search": "true",
             },
         ),
     )
@@ -196,8 +186,6 @@ class NimbusExperimentFilter(django_filters.FilterSet):
             icon="fa-solid fa-users-rectangle",
             attrs={
                 "title": "All Audiences",
-                "class": "selectpicker",
-                "data-live-search": "true",
             },
         ),
     )
@@ -207,8 +195,6 @@ class NimbusExperimentFilter(django_filters.FilterSet):
             icon="fa-solid fa-person-chalkboard",
             attrs={
                 "title": "All Projects",
-                "class": "selectpicker",
-                "data-live-search": "true",
             },
         ),
     )
@@ -218,8 +204,6 @@ class NimbusExperimentFilter(django_filters.FilterSet):
             icon="fa-solid fa-user-shield",
             attrs={
                 "title": "All QA Statuses",
-                "class": "selectpicker",
-                "data-live-search": "true",
             },
         ),
     )
@@ -233,8 +217,6 @@ class NimbusExperimentFilter(django_filters.FilterSet):
             icon="fa-solid fa-list-check",
             attrs={
                 "title": "All Takeaways",
-                "class": "selectpicker",
-                "data-live-search": "true",
             },
         ),
     )
@@ -244,8 +226,6 @@ class NimbusExperimentFilter(django_filters.FilterSet):
             icon="fa-solid fa-users",
             attrs={
                 "title": "All Owners",
-                "class": "selectpicker",
-                "data-live-search": "true",
             },
         ),
     )
@@ -255,8 +235,6 @@ class NimbusExperimentFilter(django_filters.FilterSet):
             icon="fa-solid fa-bell",
             attrs={
                 "title": "All Subscribers",
-                "class": "selectpicker",
-                "data-live-search": "true",
             },
         ),
     )

--- a/experimenter/experimenter/nimbus_ui_new/static/css/style.scss
+++ b/experimenter/experimenter/nimbus_ui_new/static/css/style.scss
@@ -124,9 +124,3 @@
     }
   }
 }
-
-.bootstrap-select:not([class*="col-"]):not([class*="form-control"]):not(
-    .input-group-btn
-  ) {
-  width: 100%;
-}

--- a/experimenter/experimenter/nimbus_ui_new/templates/common/sidebar_select.html
+++ b/experimenter/experimenter/nimbus_ui_new/templates/common/sidebar_select.html
@@ -1,7 +1,11 @@
 <div class="row">
-  <div class="col d-flex align-items-center mb-2">
-    <i class="{{ icon }}" style="width:30px;"></i>
-    {% include "django/forms/widgets/select.html" %}
+  <div class="col">
+    <div class="form-group">
+      <div class="d-flex align-items-center mb-2">
+        <i class="{{ icon }}" style="width:30px;"></i>
+        {% include "django/forms/widgets/select.html" %}
 
+      </div>
+    </div>
   </div>
 </div>

--- a/experimenter/experimenter/nimbus_ui_new/templates/common/with_sidebar.html
+++ b/experimenter/experimenter/nimbus_ui_new/templates/common/with_sidebar.html
@@ -6,7 +6,7 @@
   <div id="content" class="container-fluid">
     <div class="row">
       <div class="col-xl-2 col-xxl-2">
-        <div class="offcanvas-xl offcanvas-start"
+        <div class="offcanvas-xl offcanvas-start bg-body-tertiary"
              tabindex="-1"
              id="offcanvasSidebar"
              aria-labelledby="offcanvasSidebarLabel">

--- a/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/list.html
+++ b/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/list.html
@@ -14,6 +14,7 @@
 
 {% block sidebar %}
   <form id="filter-form"
+        class="w-100"
         hx-get="{% url "nimbus-new-table" %}"
         hx-trigger="keyup,mouseup delay:100ms"
         hx-target="#experiment-list"


### PR DESCRIPTION
Because

* The list page filters use bootstrap-select which has a hard coded width of 220px
* We overrode that width with a custom css rule
* That was resulting in the selects overflowing into the main content

This commit

* Uses the proper bootstrap form classes instead of custom css rules
* The bootstrap select pickers now scale with the sidebar correctly

fixes #11079

After:
<img width="752" alt="image" src="https://github.com/user-attachments/assets/e9c9763b-7182-4234-95de-3b7b86f74983">

Before:
<img width="1017" alt="image" src="https://github.com/user-attachments/assets/aaadcb0c-5a00-4823-ab71-cc94e65c7fd1">
