### PR TITLE
feat(nimbus): Add changelogs to qa status and takeaways forms

### DIFF
--- a/experimenter/experimenter/nimbus_ui_new/forms.py
+++ b/experimenter/experimenter/nimbus_ui_new/forms.py
@@ -91,7 +91,7 @@ class NimbusExperimentCreateForm(NimbusChangeLogFormMixin, forms.ModelForm):
         return cleaned_data
 
 
-class QAStatusForm(forms.ModelForm):
+class QAStatusForm(NimbusChangeLogFormMixin, forms.ModelForm):
     class Meta:
         model = NimbusExperiment
         fields = ["qa_status", "qa_comment"]
@@ -99,8 +99,11 @@ class QAStatusForm(forms.ModelForm):
             "qa_status": forms.Select(choices=NimbusExperiment.QAStatus),
         }
 
+    def get_changelog_message(self):
+        return f"{self.request.user} updated QA"
 
-class TakeawaysForm(forms.ModelForm):
+
+class TakeawaysForm(NimbusChangeLogFormMixin, forms.ModelForm):
     conclusion_recommendations = forms.MultipleChoiceField(
         choices=NimbusExperiment.ConclusionRecommendation.choices,
         widget=forms.CheckboxSelectMultiple,
@@ -116,3 +119,6 @@ class TakeawaysForm(forms.ModelForm):
             "takeaways_summary",
             "conclusion_recommendations",
         ]
+
+    def get_changelog_message(self):
+        return f"{self.request.user} updated takeaways"

--- a/experimenter/experimenter/nimbus_ui_new/views.py
+++ b/experimenter/experimenter/nimbus_ui_new/views.py
@@ -20,6 +20,13 @@ from experimenter.nimbus_ui_new.forms import (
 )
 
 
+class RequestFormMixin:
+    def get_form_kwargs(self):
+        kwargs = super().get_form_kwargs()
+        kwargs["request"] = self.request
+        return kwargs
+
+
 class NimbusChangeLogsView(DetailView):
     model = NimbusExperiment
     context_object_name = "experiment"
@@ -122,7 +129,7 @@ class NimbusExperimentDetailView(DetailView):
         return context
 
 
-class QAStatusUpdateView(UpdateView):
+class QAStatusUpdateView(RequestFormMixin, UpdateView):
     form_class = QAStatusForm
     model = NimbusExperiment
     template_name = "nimbus_experiments/detail.html"
@@ -139,7 +146,7 @@ class QAStatusUpdateView(UpdateView):
         return reverse("nimbus-new-detail", kwargs={"slug": self.object.slug})
 
 
-class TakeawaysUpdateView(UpdateView):
+class TakeawaysUpdateView(RequestFormMixin, UpdateView):
     form_class = TakeawaysForm
     model = NimbusExperiment
     template_name = "nimbus_experiments/detail.html"
@@ -157,7 +164,7 @@ class TakeawaysUpdateView(UpdateView):
         return reverse("nimbus-new-detail", kwargs={"slug": self.object.slug})
 
 
-class NimbusExperimentsCreateView(CreateView):
+class NimbusExperimentsCreateView(RequestFormMixin, CreateView):
     model = NimbusExperiment
     form_class = NimbusExperimentCreateForm
     template_name = "nimbus_experiments/create.html"
@@ -166,7 +173,6 @@ class NimbusExperimentsCreateView(CreateView):
         kwargs = super().get_form_kwargs()
         kwargs["data"] = kwargs["data"].copy()
         kwargs["data"]["owner"] = self.request.user
-        kwargs["request"] = self.request
         return kwargs
 
     def post(self, *args, **kwargs):


### PR DESCRIPTION
Becuase

* We recently added new forms for qa status and takeaways on the new summary page
* We need to create changelogs when those forms are saved
* There is already a mixin to handle this

This commit

* Adds the changelogs mixin to the new qa status and takeaways forms
* Updates views
* Updates tests

fixes #11087

