### PR TITLE
chore(nimbus): Update fenix integration test.

### DIFF
--- a/experimenter/tests/integration/nimbus/android/test_fenix_integration.py
+++ b/experimenter/tests/integration/nimbus/android/test_fenix_integration.py
@@ -11,6 +11,7 @@ def experiment_slug():
 
 
 @pytest.mark.generic_test
+@pytest.mark.xfail(reason="Timeouts due to system lag")
 def test_experiment_unenrolls_via_studies_toggle(
     setup_experiment, gradlewbuild, open_app
 ):


### PR DESCRIPTION
Because

- The `test_experiment_unenrolls_via_studies_toggle` test can sometimes fail due to the emulator lagging and not updating as quickly as it should

This commit

- xfails this test so that it doesn't cause too many false failures. I will look into this test and make some changes but for now this will work.

Fixes #11114