### PR TITLE
chore(project): skip intermittent legacy integration test

### DIFF
--- a/experimenter/tests/integration/legacy/test_branched_addon_e2e.py
+++ b/experimenter/tests/integration/legacy/test_branched_addon_e2e.py
@@ -44,6 +44,7 @@ def fixture_default_data(experiment_name, experiment_type):
 
 @pytest.mark.use_variables
 @pytest.mark.nondestructive
+@pytest.mark.skip(reason="intermittently failing")
 def test_branched_addon_e2e(
     base_url,
     selenium,


### PR DESCRIPTION
Because

* Legacy and Normandy are nearing their EOL
* There is an intermittently failing integration test in Legacy UI
* We can safely disable it now until we completely decomission Normandy and disable Legacy permanently

This commit

* Skips the intermittently failing integration test in Legacy UI

fixes #11034

