### PR TITLE
feat(nimbus): remove individual pages from table paginator

### DIFF
--- a/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/table.html
+++ b/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/table.html
@@ -129,28 +129,52 @@
       <ul class="pagination justify-content-center">
         {% if page_obj.has_previous %}
           <li class="page-item">
+            <a class="page-link" href="{% pagination_url 1 %}"><i class="fa-solid fa-angles-left"></i></a>
+          </li>
+          <li class="page-item">
             <a class="page-link"
                href="{% pagination_url page_obj.previous_page_number %}"
-               tabindex="-1">Previous</a>
+               tabindex="-1"><i class="fa-solid fa-angle-left"></i></a>
           </li>
         {% else %}
           <li class="page-item disabled">
-            <a class="page-link" href="#">Previous</a>
+            <a class="page-link" href="#">
+              <i class="fa-solid fa-angles-left"></i>
+            </a>
+          </li>
+          <li class="page-item disabled">
+            <a class="page-link" href="#">
+              <i class="fa-solid fa-angle-left"></i>
+            </a>
           </li>
         {% endif %}
-        {% for page_num in page_obj.paginator.page_range %}
-          <li class="page-item {% if page_obj.number == page_num %}active{% endif %}">
-            <a class="page-link" href="{% pagination_url page_num %}">{{ page_num }}</a>
-          </li>
-        {% endfor %}
+        <li class="page-item">
+          <div class="page-link">
+          {{ page_obj.number }} of {{ page_obj.paginator.num_pages }}</a>
+        </li>
         {% if page_obj.has_next %}
           <li class="page-item">
             <a class="page-link"
-               href="{% pagination_url page_obj.next_page_number %}">Next</a>
+               href="{% pagination_url page_obj.next_page_number %}">
+              <i class="fa-solid fa-angle-right"></i>
+            </a>
+          </li>
+          <li class="page-item">
+            <a class="page-link"
+               href="{% pagination_url page_obj.paginator.num_pages %}">
+              <i class="fa-solid fa-angles-right"></i>
+            </a>
           </li>
         {% else %}
           <li class="page-item disabled">
-            <a class="page-link" href="#">Next</a>
+            <a class="page-link" href="#">
+              <i class="fa-solid fa-angle-right"></i>
+            </a>
+          </li>
+          <li class="page-item disabled">
+            <a class="page-link" href="#">
+              <i class="fa-solid fa-angles-right"></i>
+            </a>
           </li>
         {% endif %}
       </ul>


### PR DESCRIPTION
Because

* We put a link to each individual page in the new list page paginator
* For large numbers of pages, this causes the paginator to overflow past the edge of the page
* We probably don't need to put a link to each individual page

This commit

* Removes links to individual pages
* Adds links for first and last pages

fixes #11100

<img width="388" alt="image" src="https://github.com/user-attachments/assets/bf11eec7-ba72-41b9-8877-c9a131dea1d7">
