### PR TITLE
feat(nimbus): add mac and linux targeting

### DIFF
--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -562,6 +562,17 @@ LINUX_ONLY = NimbusTargetingConfig(
     application_choice_names=(Application.DESKTOP.name,),
 )
 
+MAC_LINUX_ONLY = NimbusTargetingConfig(
+    name="Mac and Linux users only",
+    slug="mac_linux_only",
+    description="All users with Mac or Linux",
+    targeting="(os.isLinux || os.isMac)",
+    desktop_telemetry="",
+    sticky_required=False,
+    is_first_run_required=False,
+    application_choice_names=(Application.DESKTOP.name,),
+)
+
 NO_DISTRIBUTIONS = NimbusTargetingConfig(
     name="No distribution builds",
     slug="no_distribution_builds",


### PR DESCRIPTION
Becuase

* We want to target users on either mac or linux but not windows

This commit

* Adds a targeting for mac or linux

fixes #11058
