### PR TITLE
feat(nimbus): Warn about prefFlips that could use setPref variables

### DIFF
--- a/experimenter/experimenter/experiments/api/v5/serializers.py
+++ b/experimenter/experimenter/experiments/api/v5/serializers.py
@@ -10,6 +10,7 @@ from dataclasses import dataclass
 from typing import Any, NotRequired, Optional, Self, TypedDict
 
 import jsonschema
+import packaging
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.db import models, transaction
@@ -1231,6 +1232,10 @@ class NimbusReviewSerializer(serializers.ModelSerializer):
             str, NimbusFeatureConfig.VersionedSchemaRange
         ] = {}
 
+        self.desktop_setpref_schemas: Optional[
+            dict[NimbusFeatureConfig, NimbusVersionedSchema]
+        ] = None
+
     def to_representation(self, instance):
         data = super().to_representation(instance)
         data["feature_config"] = None
@@ -1399,7 +1404,7 @@ class NimbusReviewSerializer(serializers.ModelSerializer):
                 feature_config=feature_config,
                 feature_value=feature_value_data["value"],
                 localizations=localizations,
-                schemas_in_range=self.schemas_by_feature_id[feature_config.id],
+                schemas_in_range=self.schemas_by_feature_id[feature_config.slug],
                 suppress_errors=suppress_errors,
             )
 
@@ -1428,9 +1433,8 @@ class NimbusReviewSerializer(serializers.ModelSerializer):
             else:
                 self.errors.append(msg)
 
-    @classmethod
     def _validate_feature_value(
-        cls,
+        self,
         *,
         application: str,
         channel: str,
@@ -1440,7 +1444,7 @@ class NimbusReviewSerializer(serializers.ModelSerializer):
         localizations: Optional[dict[str, Any]],
         suppress_errors: bool,
     ) -> ValidateFeatureResult:
-        result = cls.ValidateFeatureResult()
+        result = self.ValidateFeatureResult()
 
         if schemas_in_range.unsupported_in_range:
             result.append(
@@ -1467,7 +1471,7 @@ class NimbusReviewSerializer(serializers.ModelSerializer):
 
         if application == NimbusExperiment.Application.DESKTOP:
             result.extend_with_result(
-                cls._validate_feature_value_with_schema(
+                self._validate_feature_value_with_schema(
                     feature_config,
                     schemas_in_range,
                     feature_value,
@@ -1477,7 +1481,7 @@ class NimbusReviewSerializer(serializers.ModelSerializer):
             )
         else:
             result.extend(
-                cls._validate_feature_value_with_fml(
+                self._validate_feature_value_with_fml(
                     schemas_in_range,
                     NimbusFmlLoader.create_loader(application, channel),
                     feature_config,
@@ -1488,16 +1492,15 @@ class NimbusReviewSerializer(serializers.ModelSerializer):
 
         return result
 
-    @classmethod
     def _validate_feature_value_with_schema(
-        cls,
+        self,
         feature_config: NimbusFeatureConfig,
         schemas_in_range: NimbusFeatureConfig.VersionedSchemaRange,
         value: str,
         localizations: Optional[dict[str, Any]],
         suppress_errors: bool,
     ) -> ValidateFeatureResult:
-        result = cls.ValidateFeatureResult()
+        result = self.ValidateFeatureResult()
 
         json_value = json.loads(value)
         for schema in schemas_in_range.schemas:
@@ -1505,20 +1508,20 @@ class NimbusReviewSerializer(serializers.ModelSerializer):
                 json_schema = json.loads(schema.schema)
                 if not localizations:
                     result.extend(
-                        cls._validate_schema(json_value, json_schema, schema.version),
+                        self._validate_schema(json_value, json_schema, schema.version),
                         suppress_errors,
                     )
                 else:
                     for locale_code, substitutions in localizations.items():
                         try:
-                            substituted_value = cls._substitute_localizations(
+                            substituted_value = self._substitute_localizations(
                                 json_value, substitutions, locale_code
                             )
                         except LocalizationError as e:
                             result.append(str(e), suppress_errors)
                             continue
 
-                        if schema_errors := cls._validate_schema(
+                        if schema_errors := self._validate_schema(
                             substituted_value, json_schema, schema.version
                         ):
                             err_msg = (
@@ -1546,13 +1549,77 @@ class NimbusReviewSerializer(serializers.ModelSerializer):
                     continue
 
             result.extend_with_result(
-                cls._validate_desktop_feature_value_pref_lengths(
+                self._validate_desktop_feature_value_pref_lengths(
                     feature_config,
                     schema,
                     json_value,
                     suppress_errors,
                 ),
             )
+
+        if feature_config.slug == NimbusConstants.DESKTOP_PREFFLIPS_SLUG:
+            result.extend_with_result(
+                self._validate_desktop_pref_flips_value(
+                    json_value,
+                    schemas_in_range.min_version,
+                    schemas_in_range.max_version,
+                )
+            )
+
+        return result
+
+    def _validate_desktop_pref_flips_value(
+        self,
+        value: dict[str, Any],
+        min_version: packaging.version.Version,
+        max_version: Optional[packaging.version.Version],
+    ) -> ValidateFeatureResult:
+        result = self.ValidateFeatureResult()
+
+        if not self.desktop_setpref_schemas:
+            schemas = (
+                NimbusVersionedSchema.objects.filter(
+                    NimbusFeatureVersion.objects.between_versions_q(
+                        min_version,
+                        max_version,
+                        prefix="version",
+                    ),
+                    feature_config__application=NimbusExperiment.Application.DESKTOP,
+                )
+                .exclude(set_pref_vars={})
+                .prefetch_related("feature_config", "version")
+            )
+
+            self.desktop_setpref_schemas = {}
+            for schema in schemas:
+                self.desktop_setpref_schemas.setdefault(schema.feature_config, []).append(
+                    schema
+                )
+
+        for pref in value.get("prefs", {}):
+            for feature_config, schemas in self.desktop_setpref_schemas.items():
+                conflicting_versions = []
+
+                for schema in schemas:
+                    if pref in schema.set_pref_vars.values():
+                        conflicting_versions.append(schema.version.as_packaging_version())
+
+                if conflicting_versions:
+                    if len(conflicting_versions) == 1:
+                        versions = str(conflicting_versions[0])
+                    else:
+                        versions = (
+                            f"{min(conflicting_versions)}-{max(conflicting_versions)}"
+                        )
+
+                    msg = NimbusConstants.WARNING_FEATURE_VALUE_IN_VERSIONS.format(
+                        versions=versions,
+                        warning=NimbusConstants.WARNING_PREF_FLIPS_PREF_CONTROLLED_BY_FEATURE.format(
+                            pref=pref, feature_config_slug=feature_config.slug
+                        ),
+                    )
+
+                    result.append(msg, warning=True)
 
         return result
 
@@ -1692,7 +1759,7 @@ class NimbusReviewSerializer(serializers.ModelSerializer):
         # Cache the versioned schema range for each feature so we can re-use
         # them in the validation for each branch.
         self.schemas_by_feature_id = {
-            feature_config.id: feature_config.get_versioned_schema_range(
+            feature_config.slug: feature_config.get_versioned_schema_range(
                 min_version,
                 max_version,
             )

--- a/experimenter/experimenter/experiments/constants.py
+++ b/experimenter/experimenter/experiments/constants.py
@@ -758,6 +758,7 @@ Optional - We believe this outcome will <describe impact> on <core metric>
     )
 
     ERROR_FEATURE_VALUE_IN_VERSIONS = "In versions {versions}: {error}"
+    WARNING_FEATURE_VALUE_IN_VERSIONS = "Warning: In versions {versions}: {warning}"
 
     WARNING_ROLLOUT_PREF_REENROLL = (
         "WARNING: One or more features of this rollouts sets prefs and this rollout is "
@@ -797,6 +798,10 @@ Optional - We believe this outcome will <describe impact> on <core metric>
     )
     ERROR_DESKTOP_PREFFLIPS_128_ESR_ONLY = (
         "The prefFlips feature is only available on Firefox 128 on the ESR branch."
+    )
+
+    WARNING_PREF_FLIPS_PREF_CONTROLLED_BY_FEATURE = (
+        "Pref '{pref}' is controlled by a variable in feature {feature_config_slug}'"
     )
 
 

--- a/experimenter/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_ready_for_review_serializer.py
+++ b/experimenter/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_ready_for_review_serializer.py
@@ -2958,17 +2958,25 @@ class TestNimbusReviewSerializerSingleFeature(MockFmlErrorMixin, TestCase):
             )
 
     def test_desktop_prefflips_channel_required(self):
+        prefflips_feature = NimbusFeatureConfigFactory.create_desktop_prefflips_feature()
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.CREATED,
             targeting_config_slug=NimbusExperiment.TargetingConfig.NO_TARGETING,
             application=NimbusExperiment.Application.DESKTOP,
             firefox_min_version=NimbusExperiment.Version.FIREFOX_129,
             firefox_max_version=NimbusExperiment.Version.NO_VERSION,
-            feature_configs=[
-                NimbusFeatureConfigFactory.create_desktop_prefflips_feature()
-            ],
+            feature_configs=[prefflips_feature],
             channel=NimbusExperiment.Channel.NO_CHANNEL,
         )
+
+        for branch in experiment.treatment_branches:
+            branch.delete()
+
+        feature_value = experiment.reference_branch.feature_values.get(
+            feature_config=prefflips_feature
+        )
+        feature_value.value = json.dumps({"prefs": {}})
+        feature_value.save()
 
         serializer = NimbusReviewSerializer(
             experiment,
@@ -2993,22 +3001,30 @@ class TestNimbusReviewSerializerSingleFeature(MockFmlErrorMixin, TestCase):
         )
     )
     def test_desktop_prefflips_feature_allowed_on_v128_esr_only(self, channel):
+        prefflips_feature = NimbusFeatureConfigFactory.create_desktop_prefflips_feature()
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.CREATED,
             targeting_config_slug=NimbusExperiment.TargetingConfig.NO_TARGETING,
             application=NimbusExperiment.Application.DESKTOP,
             firefox_min_version=NimbusExperiment.Version.FIREFOX_128,
             firefox_max_version=NimbusExperiment.Version.NO_VERSION,
-            feature_configs=[
-                NimbusFeatureConfigFactory.create_desktop_prefflips_feature()
-            ],
+            feature_configs=[prefflips_feature],
             channel=channel,
         )
+
+        for branch in experiment.treatment_branches:
+            branch.delete()
+
+        feature_value = experiment.reference_branch.feature_values.get(
+            feature_config=prefflips_feature
+        )
+        feature_value.value = json.dumps({"prefs": {}})
+        feature_value.save()
 
         serializer = NimbusReviewSerializer(
             experiment,
             data=NimbusReviewSerializer(experiment, context={"user": self.user}).data,
-            context={"user", self.user},
+            context={"user": self.user},
         )
 
         if channel == NimbusExperiment.Channel.ESR:
@@ -3035,17 +3051,25 @@ class TestNimbusReviewSerializerSingleFeature(MockFmlErrorMixin, TestCase):
         )
     )
     def test_desktop_prefflips_feature_allowed_on_v129(self, channel):
+        prefflips_feature = NimbusFeatureConfigFactory.create_desktop_prefflips_feature()
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.CREATED,
             targeting_config_slug=NimbusExperiment.TargetingConfig.NO_TARGETING,
             application=NimbusExperiment.Application.DESKTOP,
             firefox_min_version=NimbusExperiment.Version.FIREFOX_129,
             firefox_max_version=NimbusExperiment.Version.NO_VERSION,
-            feature_configs=[
-                NimbusFeatureConfigFactory.create_desktop_prefflips_feature()
-            ],
+            feature_configs=[prefflips_feature],
             channel=channel,
         )
+
+        for branch in experiment.treatment_branches:
+            branch.delete()
+
+        feature_value = experiment.reference_branch.feature_values.get(
+            feature_config=prefflips_feature
+        )
+        feature_value.value = json.dumps({"prefs": {}})
+        feature_value.save()
 
         serializer = NimbusReviewSerializer(
             experiment,
@@ -3054,6 +3078,85 @@ class TestNimbusReviewSerializerSingleFeature(MockFmlErrorMixin, TestCase):
         )
 
         self.assertTrue(serializer.is_valid(), serializer.errors)
+
+    @parameterized.expand(
+        [
+            ([(126, 0, 0)], None),
+            ([(129, 1, 2)], "129.1.2"),
+            ([(129, 0, 0), (129, 0, 1), (130, 0, 0)], "129.0.0-130.0.0"),
+        ]
+    )
+    def test_desktop_prefflips_warns_setpref_conflicts(
+        self, versions, formatted_versions
+    ):
+        pref = "foo.bar.baz"
+
+        NimbusFeatureConfigFactory.create(
+            name="test-feature",
+            slug="test-feature",
+            application=NimbusExperiment.Application.DESKTOP,
+            schemas=[
+                NimbusVersionedSchemaFactory.build(
+                    set_pref_vars={"variable": pref},
+                    version=NimbusFeatureVersion.objects.create(
+                        major=major, minor=minor, patch=patch
+                    ),
+                )
+                for (major, minor, patch) in versions
+            ],
+        )
+
+        prefflips_feature = NimbusFeatureConfigFactory.create_desktop_prefflips_feature()
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            targeting_config_slug=NimbusExperiment.TargetingConfig.NO_TARGETING,
+            application=NimbusExperiment.Application.DESKTOP,
+            firefox_min_version=NimbusExperiment.Version.FIREFOX_129,
+            firefox_max_version=NimbusExperiment.Version.NO_VERSION,
+            channel=NimbusExperiment.Channel.RELEASE,
+            feature_configs=[prefflips_feature],
+        )
+
+        for branch in experiment.treatment_branches:
+            branch.delete()
+
+        feature_value = experiment.reference_branch.feature_values.get(
+            feature_config=prefflips_feature
+        )
+        feature_value.value = json.dumps(
+            {"prefs": {pref: {"branch": "user", "value": "hello, world"}}}
+        )
+        feature_value.save()
+
+        serializer = NimbusReviewSerializer(
+            experiment,
+            data=NimbusReviewSerializer(experiment, context={"user": self.user}).data,
+            context={"user": self.user},
+        )
+
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+        if formatted_versions is None:
+            self.assertEqual(serializer.warnings, {})
+        else:
+            self.assertEqual(
+                serializer.warnings,
+                {
+                    "reference_branch": {
+                        "feature_values": [
+                            {
+                                "value": [
+                                    NimbusConstants.WARNING_FEATURE_VALUE_IN_VERSIONS.format(
+                                        versions=formatted_versions,
+                                        warning=NimbusConstants.WARNING_PREF_FLIPS_PREF_CONTROLLED_BY_FEATURE.format(
+                                            pref=pref, feature_config_slug="test-feature"
+                                        ),
+                                    )
+                                ]
+                            }
+                        ]
+                    }
+                },
+            )
 
 
 class VersionedFeatureValidationTests(MockFmlErrorMixin, TestCase):

--- a/experimenter/experimenter/experiments/tests/test_models.py
+++ b/experimenter/experimenter/experiments/tests/test_models.py
@@ -3640,6 +3640,8 @@ class NimbusFeatureConfigTests(TestCase):
         self.assertEqual(
             schemas_in_range,
             NimbusFeatureConfig.VersionedSchemaRange(
+                min_version=packaging.version.Version("111.0.0"),
+                max_version=packaging.version.Version("112.0.0"),
                 schemas=[unversioned_schema],
                 unsupported_in_range=False,
                 unsupported_versions=[],
@@ -3667,6 +3669,12 @@ class NimbusFeatureConfigTests(TestCase):
         self.assertEqual(
             info,
             NimbusFeatureConfig.VersionedSchemaRange(
+                min_version=NimbusExperiment.Version.parse(
+                    NimbusConstants.MIN_VERSIONED_FEATURE_VERSION[
+                        NimbusExperiment.Application.DESKTOP
+                    ]
+                ),
+                max_version=max_version,
                 schemas=[versioned_schema],
                 unsupported_in_range=False,
                 unsupported_versions=[],
@@ -3685,6 +3693,8 @@ class NimbusFeatureConfigTests(TestCase):
         self.assertEqual(
             info,
             NimbusFeatureConfig.VersionedSchemaRange(
+                min_version=packaging.version.Version("1.0.0"),
+                max_version=None,
                 schemas=[unversioned_schema],
                 unsupported_in_range=False,
                 unsupported_versions=[],
@@ -3704,6 +3714,8 @@ class NimbusFeatureConfigTests(TestCase):
         self.assertEqual(
             schemas_in_range,
             NimbusFeatureConfig.VersionedSchemaRange(
+                min_version=packaging.version.Version("121.0.0"),
+                max_version=packaging.version.Version("122.0.0"),
                 schemas=[],
                 unsupported_in_range=True,
                 unsupported_versions=[],
@@ -3745,6 +3757,8 @@ class NimbusFeatureConfigTests(TestCase):
         self.assertEqual(
             schemas_in_range,
             NimbusFeatureConfig.VersionedSchemaRange(
+                min_version=packaging.version.Version("121.0.0"),
+                max_version=packaging.version.Version("124.0.0"),
                 schemas=[schema],
                 unsupported_in_range=False,
                 unsupported_versions=[
@@ -3790,6 +3804,8 @@ class NimbusFeatureConfigTests(TestCase):
         self.assertEqual(
             schemas_in_range,
             NimbusFeatureConfig.VersionedSchemaRange(
+                min_version=packaging.version.Version("122.0.0"),
+                max_version=packaging.version.Version("123.1.0"),
                 schemas=[
                     schemas[versions[v]]
                     for v in (


### PR DESCRIPTION
Because

- we now have multiple ways to set prefs on Firefox Desktop (setPref variables and the prefFlips feature); and
- setting the same pref via both mechanisms can cause unenrollments

this commit:

- adds warnings for the prefFlips feature when existing setPref variables could be used.

Fixes #10842