### PR TITLE
chore(ci): Add proper branch filtering for recipe generator.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -723,6 +723,10 @@ workflows:
                 - main
       - create_fenix_fennec_recipes:
           name: Create fenix and fennec recipes
+          filters:
+            branches:
+              ignore:
+                - main
       - integration_nimbus_desktop_release_targeting:
           name: Test Desktop Targeting (Release Firefox)
           filters:


### PR DESCRIPTION
Because

- We are running an integration test on main that doesn't need to be run

This commit

- Adds the proper filtering to that job in the circleci config

Fixes #11158 