### PR TITLE
chore(ci): Add file path check to mobile recipe generator job.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -413,6 +413,8 @@ jobs:
       docker_layer_caching: true
     steps:
       - checkout
+      - check_file_paths:
+          paths: "experimenter/"
       - run:
           name: Create experiment on experimenter
           command: |


### PR DESCRIPTION
Because

- This job could run on changes to other parts of the repo when it shouldn't

This commit

- Fixes it to run on the correct change paths. This will be fixed soon with the change to how we test external dependencies.

Fixes #11157 