### PR TITLE
chore(project): Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,4 +2,4 @@
 /experimenter/experimenter/ @jaredlockhart @yashikakhurana @brennie
 /experimenter/manifesttool/ @jaredlockhart @brennie
 /schemas/ @jaredlockhart @mikewilli
-/experimenter/tests @jrbenny35
+/experimenter/tests @b4handjr


### PR DESCRIPTION
Because:

- jrbenny35 is now b4handjr

this commit:

- updates CODEOWNERS to reflect that change.