### PR TITLE
bug(nimbus): validating localized feature values is causing 502 timeouts

### DIFF
--- a/experimenter/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_ready_for_review_serializer.py
+++ b/experimenter/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_ready_for_review_serializer.py
@@ -3582,20 +3582,20 @@ class VersionedFeatureValidationTests(MockFmlErrorMixin, TestCase):
                                 "'true' is not of type 'boolean' at version 121.0.0",
                                 (
                                     "Schema validation errors occured during locale "
-                                    "substitution for locale en-CA at version 121.0.0"
-                                ),
-                                "'true' is not of type 'boolean' at version 121.0.0",
-                                (
-                                    "Schema validation errors occured during locale "
                                     "substitution for locale en-US at version 120.0.0"
                                 ),
                                 "'true' is not of type 'boolean' at version 120.0.0",
                                 (
                                     "Schema validation errors occured during locale "
+                                    "substitution for locale en-CA at version 121.0.0"
+                                ),
+                                "'true' is not of type 'boolean' at version 121.0.0",
+                                (
+                                    "Schema validation errors occured during locale "
                                     "substitution for locale en-CA at version 120.0.0"
                                 ),
                                 "'true' is not of type 'boolean' at version 120.0.0",
-                            ],
+                            ]
                         }
                     ]
                 }


### PR DESCRIPTION
Because

* We validate the feature value for every locale for every version
* This can cause a large number of versions and locales to be checked even if the schema is the same
* This can cause nginx to timeout and lock users out of their experiments

This commit

* Only validates for the unique set of schemas if they are unchanged across versions

fixes #11216
