### PR TITLE
bug(nimbus): fix storage config for analysis results

### DIFF
--- a/experimenter/experimenter/jetstream/client.py
+++ b/experimenter/experimenter/jetstream/client.py
@@ -5,7 +5,7 @@ from itertools import chain
 from pathlib import Path
 
 from django.conf import settings
-from django.core.files.storage import default_storage
+from django.core.files.storage import storages
 from mozilla_nimbus_schemas.jetstream import (
     AnalysisBasis,
     AnalysisErrors,
@@ -41,8 +41,11 @@ ALL_STATISTICS = {
 
 
 def load_data_from_gcs(path):
-    if default_storage.exists(path):
-        return json.loads(default_storage.open(path).read())
+    analysis_storage = storages["analysis"]
+    if analysis_storage.exists(path):
+        return json.loads(analysis_storage.open(path).read())
+    else:
+        raise RuntimeError(f"Could not find data in analysis bucket at path {path}")
 
 
 def validate_data(data_json):

--- a/experimenter/experimenter/jetstream/tests/test_tasks.py
+++ b/experimenter/experimenter/jetstream/tests/test_tasks.py
@@ -595,8 +595,8 @@ class TestFetchJetstreamDataTask(MockSizingDataMixin, TestCase):
             return File(filename)
 
         with (
-            patch("experimenter.jetstream.client.default_storage.open") as mock_open,
-            patch("experimenter.jetstream.client.default_storage.exists") as mock_exists,
+            patch("experimenter.jetstream.client.analysis_storage.open") as mock_open,
+            patch("experimenter.jetstream.client.analysis_storage.exists") as mock_exists,
         ):
             mock_open.side_effect = open_file
             mock_exists.return_value = True
@@ -722,8 +722,8 @@ class TestFetchJetstreamDataTask(MockSizingDataMixin, TestCase):
             return File(filename)
 
         with (
-            patch("experimenter.jetstream.client.default_storage.open") as mock_open,
-            patch("experimenter.jetstream.client.default_storage.exists") as mock_exists,
+            patch("experimenter.jetstream.client.analysis_storage.open") as mock_open,
+            patch("experimenter.jetstream.client.analysis_storage.exists") as mock_exists,
         ):
             mock_open.side_effect = open_file
             mock_exists.return_value = True
@@ -806,8 +806,8 @@ class TestFetchJetstreamDataTask(MockSizingDataMixin, TestCase):
             return File(filename)
 
         with (
-            patch("experimenter.jetstream.client.default_storage.open") as mock_open,
-            patch("experimenter.jetstream.client.default_storage.exists") as mock_exists,
+            patch("experimenter.jetstream.client.analysis_storage.open") as mock_open,
+            patch("experimenter.jetstream.client.analysis_storage.exists") as mock_exists,
         ):
             mock_open.side_effect = open_file
             mock_exists.return_value = True
@@ -1073,8 +1073,8 @@ class TestFetchJetstreamDataTask(MockSizingDataMixin, TestCase):
             return File(filename)
 
         with (
-            patch("experimenter.jetstream.client.default_storage.open") as mock_open,
-            patch("experimenter.jetstream.client.default_storage.exists") as mock_exists,
+            patch("experimenter.jetstream.client.analysis_storage.open") as mock_open,
+            patch("experimenter.jetstream.client.analysis_storage.exists") as mock_exists,
         ):
             mock_open.side_effect = open_file
             mock_exists.return_value = True
@@ -1130,8 +1130,8 @@ class TestFetchJetstreamDataTask(MockSizingDataMixin, TestCase):
             return File(filename)
 
         with (
-            patch("experimenter.jetstream.client.default_storage.open") as mock_open,
-            patch("experimenter.jetstream.client.default_storage.exists") as mock_exists,
+            patch("experimenter.jetstream.client.analysis_storage.open") as mock_open,
+            patch("experimenter.jetstream.client.analysis_storage.exists") as mock_exists,
         ):
             mock_open.side_effect = open_file
             mock_exists.return_value = True
@@ -2089,8 +2089,8 @@ class TestFetchJetstreamDataTask(MockSizingDataMixin, TestCase):
             return File(filename)
 
         with (
-            patch("experimenter.jetstream.client.default_storage.open") as mock_open,
-            patch("experimenter.jetstream.client.default_storage.exists") as mock_exists,
+            patch("experimenter.jetstream.client.analysis_storage.open") as mock_open,
+            patch("experimenter.jetstream.client.analysis_storage.exists") as mock_exists,
         ):
             mock_open.side_effect = open_file
             mock_exists.return_value = True
@@ -2120,10 +2120,78 @@ class TestFetchJetstreamDataTask(MockSizingDataMixin, TestCase):
             lifecycle, primary_outcomes=[primary_outcome]
         )
 
+        now = datetime.datetime.now()
+
         with (
-            patch("experimenter.jetstream.client.default_storage.exists") as mock_exists,
+            patch("experimenter.jetstream.client.analysis_storage.exists") as mock_exists,
+            patch("experimenter.jetstream.client.datetime") as mock_datetime,
         ):
             mock_exists.return_value = False
+            mock_datetime.now.return_value = now
+
+            experiment_errors = [
+                {
+                    "analysis_basis": None,
+                    "source": None,
+                    "exception": None,
+                    "exception_type": None,
+                    "experiment": f"{experiment.slug}",
+                    "filename": "experimenter/jetstream/client.py",
+                    "func_name": "load_data_from_gcs",
+                    "log_level": "ERROR",
+                    "message": f"Could not find data in analysis bucket at path metadata/metadata_{experiment.slug.replace('-', '_')}.json",  # noqa: E501
+                    "metric": None,
+                    "segment": None,
+                    "statistic": None,
+                    "timestamp": now.isoformat(timespec="milliseconds"),
+                },
+                {
+                    "analysis_basis": None,
+                    "source": None,
+                    "exception": None,
+                    "exception_type": None,
+                    "experiment": f"{experiment.slug}",
+                    "filename": "experimenter/jetstream/client.py",
+                    "func_name": "load_data_from_gcs",
+                    "log_level": "ERROR",
+                    "message": f"Could not find data in analysis bucket at path errors/errors_{experiment.slug.replace('-', '_')}.json",  # noqa: E501
+                    "metric": None,
+                    "segment": None,
+                    "statistic": None,
+                    "timestamp": now.isoformat(timespec="milliseconds"),
+                },
+                {
+                    "analysis_basis": None,
+                    "source": None,
+                    "exception": None,
+                    "exception_type": None,
+                    "experiment": f"{experiment.slug}",
+                    "filename": "experimenter/jetstream/client.py",
+                    "func_name": "load_data_from_gcs",
+                    "log_level": "ERROR",
+                    "message": f"Could not find data in analysis bucket at path statistics/statistics_{experiment.slug.replace('-', '_')}_weekly.json",  # noqa: E501
+                    "metric": None,
+                    "segment": None,
+                    "statistic": None,
+                    "timestamp": now.isoformat(timespec="milliseconds"),
+                },
+                {
+                    "analysis_basis": None,
+                    "source": None,
+                    "exception": None,
+                    "exception_type": None,
+                    "experiment": f"{experiment.slug}",
+                    "filename": "experimenter/jetstream/client.py",
+                    "func_name": "load_data_from_gcs",
+                    "log_level": "ERROR",
+                    "message": f"Could not find data in analysis bucket at path statistics/statistics_{experiment.slug.replace('-', '_')}_overall.json",  # noqa: E501
+                    "metric": None,
+                    "segment": None,
+                    "statistic": None,
+                    "timestamp": now.isoformat(timespec="milliseconds"),
+                },
+            ]
+
             tasks.fetch_experiment_data(experiment.id)
             experiment = NimbusExperiment.objects.get(id=experiment.id)
             self.assertEqual(
@@ -2134,7 +2202,9 @@ class TestFetchJetstreamDataTask(MockSizingDataMixin, TestCase):
                         "overall": {},
                         "show_analysis": False,
                         "weekly": {},
-                        "errors": {"experiment": []},
+                        "errors": {
+                            "experiment": experiment_errors,
+                        },
                     },
                 },
             )
@@ -2259,8 +2329,8 @@ class TestFetchJetstreamDataTask(MockSizingDataMixin, TestCase):
         assert "AnalysisWindow" not in filename
         assert "overall" in filename
 
-    @patch("experimenter.jetstream.client.default_storage.open")
-    @patch("experimenter.jetstream.client.default_storage.exists")
+    @patch("experimenter.jetstream.client.analysis_storage.open")
+    @patch("experimenter.jetstream.client.analysis_storage.exists")
     def test_sizing_data_parsed_and_stored(self, mock_exists, mock_open):
         sizing_test_data = SampleSizesFactory.build().json()
 
@@ -2288,8 +2358,8 @@ class TestFetchJetstreamDataTask(MockSizingDataMixin, TestCase):
             sizing_results.json(exclude_unset=True),
         )
 
-    @patch("experimenter.jetstream.client.default_storage.open")
-    @patch("experimenter.jetstream.client.default_storage.exists")
+    @patch("experimenter.jetstream.client.analysis_storage.open")
+    @patch("experimenter.jetstream.client.analysis_storage.exists")
     def test_empty_fetch_population_sizing_data(self, mock_exists, mock_open):
         class File:
             def __init__(self, filename):
@@ -2311,8 +2381,8 @@ class TestFetchJetstreamDataTask(MockSizingDataMixin, TestCase):
         sizing_results = cache.get(SIZING_DATA_KEY)
         self.assertEqual(sizing_results.json(), "{}")
 
-    @patch("experimenter.jetstream.client.default_storage.open")
-    @patch("experimenter.jetstream.client.default_storage.exists")
+    @patch("experimenter.jetstream.client.analysis_storage.open")
+    @patch("experimenter.jetstream.client.analysis_storage.exists")
     def test_fetch_population_sizing_data_invalid(self, mock_exists, mock_open):
         class File:
             def __init__(self, filename):

--- a/experimenter/experimenter/settings.py
+++ b/experimenter/experimenter/settings.py
@@ -487,8 +487,8 @@ KINTO_ADMIN_URL = config("KINTO_ADMIN_URL", default=urljoin(KINTO_HOST, "/admin/
 KINTO_REVIEW_TIMEOUT = config("KINTO_REVIEW_TIMEOUT", cast=int)
 
 # Jetstream GCS Bucket data
-GS_PROJECT_ID = "experiments-analysis"
-GS_BUCKET_NAME = "mozanalysis"
+ANALYSIS_GS_PROJECT_ID = "experiments-analysis"
+ANALYSIS_GS_BUCKET_NAME = "mozanalysis"
 
 # GCS bucket for user uploads, e.g. branch screenshots
 UPLOADS_GS_BUCKET_NAME = config("UPLOADS_GS_BUCKET_NAME", default=None)
@@ -509,6 +509,12 @@ STORAGES = {
     },
     "staticfiles": {
         "BACKEND": "django.contrib.staticfiles.storage.StaticFilesStorage",
+    },
+    "analysis": {
+        "BACKEND": UPLOADS_FILE_STORAGE,
+        "OPTIONS": {
+            "bucket_name": ANALYSIS_GS_BUCKET_NAME,
+        },
     },
 }
 

--- a/experimenter/experimenter/settings.py
+++ b/experimenter/experimenter/settings.py
@@ -487,6 +487,7 @@ KINTO_ADMIN_URL = config("KINTO_ADMIN_URL", default=urljoin(KINTO_HOST, "/admin/
 KINTO_REVIEW_TIMEOUT = config("KINTO_REVIEW_TIMEOUT", cast=int)
 
 # Jetstream GCS Bucket data
+ANALYSIS_FILE_STORAGE = "storages.backends.gcloud.GoogleCloudStorage"
 ANALYSIS_GS_PROJECT_ID = "experiments-analysis"
 ANALYSIS_GS_BUCKET_NAME = "mozanalysis"
 
@@ -511,7 +512,7 @@ STORAGES = {
         "BACKEND": "django.contrib.staticfiles.storage.StaticFilesStorage",
     },
     "analysis": {
-        "BACKEND": UPLOADS_FILE_STORAGE,
+        "BACKEND": ANALYSIS_FILE_STORAGE,
         "OPTIONS": {
             "bucket_name": ANALYSIS_GS_BUCKET_NAME,
         },


### PR DESCRIPTION
Because

- something about #11193 seems to have broken the analysis results fetching
- results fetch failure due to nonexistent bucket path contents fails silently

This commit

- makes the results bucket config more explicit in settings and jetstream client
- raises an error if the path is not found instead of failing silently

Fixes #11218 