### PR TITLE
adding new advanced targeting: WINDOWS_10_MSIX_ONLY

### DIFF
--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -1819,6 +1819,17 @@ WINDOWS_10_NOMSIX = NimbusTargetingConfig(
     application_choice_names=(Application.DESKTOP.name,),
 )
 
+WINDOWS_10_MSIX_ONLY = NimbusTargetingConfig(
+    name="Windows 10+ msix only",
+    slug="windows_10_plus_msix_only",
+    description="Windows users on version 10 or higher using msix installation",
+    targeting="(os.isWindows && os.windowsVersion >= 10 && isMSIX)",
+    desktop_telemetry="",
+    sticky_required=False,
+    is_first_run_required=False,
+    application_choice_names=(Application.DESKTOP.name,),
+)
+
 IOS_IPHONE_USERS_ONLY = NimbusTargetingConfig(
     name="iPhone users only",
     slug="ios_iphone_users_only",


### PR DESCRIPTION
Because a msix-only targeting does not exists right now,
This commit adds the relevant targeting to be used for the msix start menu pinning experiment