### PR TITLE
feat(nimbus): Show recipe json on new summary page

### DIFF
--- a/experimenter/experimenter/experiments/models.py
+++ b/experimenter/experimenter/experiments/models.py
@@ -1,5 +1,6 @@
 import copy
 import datetime
+import json
 from collections import defaultdict
 from dataclasses import dataclass
 from decimal import Decimal
@@ -1219,6 +1220,20 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
             NimbusConstants.ConclusionRecommendation(rec).label
             for rec in self.conclusion_recommendations
         ]
+
+    @property
+    def recipe_json(self):
+        from experimenter.experiments.api.v6.serializers import NimbusExperimentSerializer
+
+        return (
+            json.dumps(
+                self.published_dto or NimbusExperimentSerializer(self).data,
+                indent=2,
+                sort_keys=True,
+            )
+            .replace("&&", "\n&&")  # Add helpful newlines to targeting
+            .replace("\\n", "\n")  # Handle hard coded newlines in targeting
+        )
 
 
 class NimbusBranch(models.Model):

--- a/experimenter/experimenter/experiments/tests/test_models.py
+++ b/experimenter/experimenter/experiments/tests/test_models.py
@@ -1,4 +1,5 @@
 import datetime
+import json
 from decimal import Decimal
 from itertools import product
 from pathlib import Path
@@ -20,6 +21,7 @@ from experimenter.base.tests.factories import (
     LanguageFactory,
     LocaleFactory,
 )
+from experimenter.experiments.api.v6.serializers import NimbusExperimentSerializer
 from experimenter.experiments.changelog_utils import generate_nimbus_changelog
 from experimenter.experiments.constants import (
     ApplicationConfig,
@@ -3182,6 +3184,21 @@ class TestNimbusExperiment(TestCase):
             firefox_max_version=NimbusExperiment.Version.FIREFOX_100
         )
         self.assertEqual(experiment.get_firefox_max_version_display, "100.0")
+
+    def test_recipe_json_renders_published_dto(self):
+        published_dto = {"published": "dto"}
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED, published_dto=published_dto
+        )
+        self.assertEqual(experiment.recipe_json, '{\n  "published": "dto"\n}')
+
+    def test_recipe_json_renders_nimbus_experiment_serializer(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+        )
+        serialized_keys = sorted(NimbusExperimentSerializer(experiment).data.keys())
+        recipe_json_keys = sorted(json.loads(experiment.recipe_json.replace("\n", "")))
+        self.assertEqual(serialized_keys, recipe_json_keys)
 
 
 class TestNimbusBranch(TestCase):

--- a/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/detail.html
+++ b/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/detail.html
@@ -216,7 +216,23 @@
             </tr>
             <tr>
               <th>Recipe JSON</th>
-              <td colspan="3">{{ experiment.targeting }}</td>
+              <td colspan="3">
+                <div class="collapse" id="collapseRecipe">
+                  <code>
+                    <pre class="text-monospace" style="white-space: pre-wrap; word-wrap: break-word;">
+                      {{ experiment.recipe_json|linebreaks|linebreaksbr }}
+                    </pre>
+                  </code>
+                </div>
+                <button class="btn btn-outline-primary btn-sm"
+                        type="button"
+                        data-bs-toggle="collapse"
+                        data-bs-target="#collapseRecipe"
+                        aria-expanded="false"
+                        aria-controls="collapseRecipe">
+                  <i class="fa-solid fa-plus"></i> Show/Hide Recipe
+                </button>
+              </td>
             </tr>
           </tbody>
         </table>


### PR DESCRIPTION
Because

- We are showing targeting value in recipe JSON on new summary page

This commit

- Builds the recipe JSON and shows it in the new UI

Fixes #11229 
Note: Show more and hide recipe will come up in the next PR
<img width="1288" alt="Screenshot 2024-08-26 at 2 30 23 PM" src="https://github.com/user-attachments/assets/6b779df1-b9d8-4579-a392-12fb3a4a5a0f">
