### PR TITLE
chore(ci): Push docker image to GAR using OIDC.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -461,39 +461,6 @@ jobs:
             GIT_SHA=$(git rev-parse --short HEAD)
             docker tag experimenter:deploy ${DOCKERHUB_REPO}:${GIT_SHA}
             docker push ${DOCKERHUB_REPO}:${GIT_SHA}
-#      - run:
-#          name: Prepare environment variables for OIDC authentication
-#          command: |
-#            echo 'export GOOGLE_PROJECT_ID="moz-fx-experimenter-prod-6cd5"' >> "$BASH_ENV"
-#            echo "export OIDC_WIP_ID=$GCPV2_WORKLOAD_IDENTITY_POOL_ID" >> "$BASH_ENV"
-#            echo "export OIDC_WIP_PROVIDER_ID=$GCPV2_CIRCLECI_WORKLOAD_IDENTITY_PROVIDER" >> "$BASH_ENV"
-#            echo "export GOOGLE_PROJECT_NUMBER=$GCPV2_WORKLOAD_IDENTITY_POOL_PROJECT_NUMBER" >> "$BASH_ENV"
-#            echo "export OIDC_SERVICE_ACCOUNT_EMAIL=$GCP_SERVICE_ACCOUNT_EMAIL" >> "$BASH_ENV"
-#      - gcp-cli/setup:
-#          use_oidc: true
-#      - run:
-#          name: Deploy to Google Artifact Registry
-#          command: |
-#            DOCKER_IMAGE="us-docker.pkg.dev/moz-fx-experimenter-prod-6cd5/experimenter-prod/experimenter"
-#            docker tag experimenter:deploy ${DOCKER_IMAGE}:latest
-#            docker push "${DOCKER_IMAGE}:latest"
-#            GIT_SHA=$(git rev-parse --short HEAD)
-#            docker tag experimenter:deploy ${DOCKERHUB_REPO}:${GIT_SHA}
-#            docker push ${DOCKERHUB_REPO}:${GIT_SHA}
-
-  # Temporary step to test CI in PR, will be moved to deploy_experimenter when ready
-  push_to_gar:
-    working_directory: ~/experimenter
-    machine:
-      image: ubuntu-2004:2023.10.1
-      docker_layer_caching: true
-    steps:
-      - checkout
-      - run:
-          name: Build Image
-          command: |
-            ./scripts/store_git_info.sh
-            make build_prod
       - run:
           name: Prepare environment variables for OIDC authentication
           command: |
@@ -766,9 +733,6 @@ workflows:
 
   build:
     jobs:
-      - push_to_gar:
-          context:
-            - gcpv2-workload-identity
       - check_experimenter_x86_64:
           name: Check Experimenter x86_64
       - check_experimenter_aarch64:
@@ -879,6 +843,8 @@ workflows:
                 - main
       - deploy_experimenter:
           name: Deploy Experimenter
+          context:
+            - gcpv2-workload-identity
           filters:
             branches:
               only: main

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -512,7 +512,7 @@ jobs:
             docker tag experimenter:deploy ${DOCKER_IMAGE}:latest
             docker push "${DOCKER_IMAGE}:latest"
             GIT_SHA=$(git rev-parse --short HEAD)
-            docker tag experimenter:deploy ${DOCKERHUB_REPO}:${GIT_SHA}
+            docker tag experimenter:deploy ${DOCKER_IMAGE}:${GIT_SHA}
             docker push ${DOCKERHUB_REPO}:${GIT_SHA}
 
   deploy_cirrus:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -489,9 +489,6 @@ jobs:
       docker_layer_caching: true
     steps:
       - checkout
-      - docker_login:
-          username: $DOCKER_USER
-          password: $DOCKER_PASS
       - run:
           name: Build Image
           command: |
@@ -768,7 +765,9 @@ workflows:
 
   build:
     jobs:
-      - push_to_gar
+      - push_to_gar:
+          context:
+            - gcpv2-workload-identity
       - check_experimenter_x86_64:
           name: Check Experimenter x86_64
       - check_experimenter_aarch64:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -507,6 +507,7 @@ jobs:
       - run:
           name: Deploy to Google Artifact Registry
           command: |
+            gcloud auth configure-docker us-docker.pkg.dev
             DOCKER_IMAGE="us-docker.pkg.dev/moz-fx-experimenter-prod-6cd5/experimenter-prod/experimenter"
             docker tag experimenter:deploy ${DOCKER_IMAGE}:latest
             docker push "${DOCKER_IMAGE}:latest"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -507,13 +507,13 @@ jobs:
       - run:
           name: Deploy to Google Artifact Registry
           command: |
-            gcloud auth configure-docker us-docker.pkg.dev
+            gcloud auth configure-docker us-docker.pkg.dev --quiet
             DOCKER_IMAGE="us-docker.pkg.dev/moz-fx-experimenter-prod-6cd5/experimenter-prod/experimenter"
             docker tag experimenter:deploy ${DOCKER_IMAGE}:latest
             docker push "${DOCKER_IMAGE}:latest"
             GIT_SHA=$(git rev-parse --short HEAD)
             docker tag experimenter:deploy ${DOCKER_IMAGE}:${GIT_SHA}
-            docker push ${DOCKERHUB_REPO}:${GIT_SHA}
+            docker push ${DOCKER_IMAGE}:${GIT_SHA}
 
   deploy_cirrus:
     working_directory: ~/cirrus

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -461,6 +461,61 @@ jobs:
             GIT_SHA=$(git rev-parse --short HEAD)
             docker tag experimenter:deploy ${DOCKERHUB_REPO}:${GIT_SHA}
             docker push ${DOCKERHUB_REPO}:${GIT_SHA}
+#      - run:
+#          name: Prepare environment variables for OIDC authentication
+#          command: |
+#            echo 'export GOOGLE_PROJECT_ID="moz-fx-experimenter-prod-6cd5"' >> "$BASH_ENV"
+#            echo "export OIDC_WIP_ID=$GCPV2_WORKLOAD_IDENTITY_POOL_ID" >> "$BASH_ENV"
+#            echo "export OIDC_WIP_PROVIDER_ID=$GCPV2_CIRCLECI_WORKLOAD_IDENTITY_PROVIDER" >> "$BASH_ENV"
+#            echo "export GOOGLE_PROJECT_NUMBER=$GCPV2_WORKLOAD_IDENTITY_POOL_PROJECT_NUMBER" >> "$BASH_ENV"
+#            echo "export OIDC_SERVICE_ACCOUNT_EMAIL=$GCP_SERVICE_ACCOUNT_EMAIL" >> "$BASH_ENV"
+#      - gcp-cli/setup:
+#          use_oidc: true
+#      - run:
+#          name: Deploy to Google Artifact Registry
+#          command: |
+#            DOCKER_IMAGE="us-docker.pkg.dev/moz-fx-experimenter-prod-6cd5/experimenter-prod/experimenter"
+#            docker tag experimenter:deploy ${DOCKER_IMAGE}:latest
+#            docker push "${DOCKER_IMAGE}:latest"
+#            GIT_SHA=$(git rev-parse --short HEAD)
+#            docker tag experimenter:deploy ${DOCKERHUB_REPO}:${GIT_SHA}
+#            docker push ${DOCKERHUB_REPO}:${GIT_SHA}
+
+  # Temporary step to test CI in PR, will be moved to deploy_experimenter when ready
+  push_to_gar:
+    working_directory: ~/experimenter
+    machine:
+      image: ubuntu-2004:2023.10.1
+      docker_layer_caching: true
+    steps:
+      - checkout
+      - docker_login:
+          username: $DOCKER_USER
+          password: $DOCKER_PASS
+      - run:
+          name: Build Image
+          command: |
+            ./scripts/store_git_info.sh
+            make build_prod
+      - run:
+          name: Prepare environment variables for OIDC authentication
+          command: |
+            echo 'export GOOGLE_PROJECT_ID="moz-fx-experimenter-prod-6cd5"' >> "$BASH_ENV"
+            echo "export OIDC_WIP_ID=$GCPV2_WORKLOAD_IDENTITY_POOL_ID" >> "$BASH_ENV"
+            echo "export OIDC_WIP_PROVIDER_ID=$GCPV2_CIRCLECI_WORKLOAD_IDENTITY_PROVIDER" >> "$BASH_ENV"
+            echo "export GOOGLE_PROJECT_NUMBER=$GCPV2_WORKLOAD_IDENTITY_POOL_PROJECT_NUMBER" >> "$BASH_ENV"
+            echo "export OIDC_SERVICE_ACCOUNT_EMAIL=$GCP_SERVICE_ACCOUNT_EMAIL" >> "$BASH_ENV"
+      - gcp-cli/setup:
+          use_oidc: true
+      - run:
+          name: Deploy to Google Artifact Registry
+          command: |
+            DOCKER_IMAGE="us-docker.pkg.dev/moz-fx-experimenter-prod-6cd5/experimenter-prod/experimenter"
+            docker tag experimenter:deploy ${DOCKER_IMAGE}:latest
+            docker push "${DOCKER_IMAGE}:latest"
+            GIT_SHA=$(git rev-parse --short HEAD)
+            docker tag experimenter:deploy ${DOCKERHUB_REPO}:${GIT_SHA}
+            docker push ${DOCKERHUB_REPO}:${GIT_SHA}
 
   deploy_cirrus:
     working_directory: ~/cirrus
@@ -713,6 +768,7 @@ workflows:
 
   build:
     jobs:
+      - push_to_gar
       - check_experimenter_x86_64:
           name: Check Experimenter x86_64
       - check_experimenter_aarch64:


### PR DESCRIPTION
Because

- GCPv2 tooling uses GAR as the image registry. Registry authentication is handled with OIDC.

This commit

- Changes CI to push to GAR.

# Validation
:heavy_check_mark:  Successful CI job [here](https://app.circleci.com/pipelines/github/mozilla/experimenter/43499/workflows/b825967e-cbca-4396-90ab-2a86831079d4/jobs/227478)

:heavy_check_mark: Image pushed to GAR
![image](https://github.com/user-attachments/assets/bdc91158-2709-4f41-a898-a7d7696936b3)

