### PR TITLE
chore(project): Change fenix task id script to move the generated key.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -642,10 +642,9 @@ jobs:
           command: |
             git checkout main
             git pull origin main
-            cd experimenter/tests/integration/nimbus/android
-            CURRENT_FENIX_BUILD_ID=$(cat fenix-build.env | grep -oP '(?<=FIREFOX_FENIX_TASK_ID=).*')
-            ./update-fenix-apks.sh
-            LATEST_FENIX_BUILD_ID=$(cat fenix-build.env | grep -oP '(?<=FIREFOX_FENIX_TASK_ID=).*')
+            CURRENT_FENIX_BUILD_ID=$(cat experimenter/tests/fenix-build.env | grep -oP '(?<=FIREFOX_FENIX_TASK_ID=).*')
+            ./experimenter/tests/integration/nimbus/android/update-fenix-apks.sh
+            LATEST_FENIX_BUILD_ID=$(cat experimenter/tests/fenix-build.env | grep -oP '(?<=FIREFOX_FENIX_TASK_ID=).*')
             if (($(git status --porcelain | wc -c) > 0)); then
               git checkout -B check-mobile-integrations
               git add .

--- a/experimenter/tests/integration/nimbus/android/update-fenix-apks.sh
+++ b/experimenter/tests/integration/nimbus/android/update-fenix-apks.sh
@@ -12,3 +12,5 @@ TASK_ID=$(curl ${CURLFLAGS[@]} "${TASKCLUSTER_API}/tasks/${INDEX_BASE}" | jq '.t
 echo TASK ID "${TASK_ID}"
 
 echo "FIREFOX_FENIX_TASK_ID=${TASK_ID}" > fenix-build.env
+
+mv fenix-build.env ../../../


### PR DESCRIPTION
Because

- The file that stores our trracked key of the fenix taskcluster build is a bit buried in the repo.

This commit

- Moves that file so that it is a bit easier to find.

Fixes #11277 