### PR TITLE
feat(nimbus): add filter reset link to filters on new list page

### DIFF
--- a/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/list.html
+++ b/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/list.html
@@ -20,6 +20,11 @@
         hx-target="#experiment-list"
         hx-push-url="true">
     {% for field in filter.form %}{{ field }}{% endfor %}
+    <a class="text-sm link-secondary link-underline-opacity-0"
+       href="{% url "nimbus-list" %}">
+      <i class="fa-solid fa-square-xmark" style="width:30px;"></i>
+      <span class="ms-1">Reset Filters</span>
+    </a>
   </form>
 {% endblock sidebar %}
 


### PR DESCRIPTION
Because

* We need a way to clear the filters on the list page

This commit

* Adds a filter reset link to the bottom of the filters on the new list page

fixes #11248

<img width="280" alt="image" src="https://github.com/user-attachments/assets/b63da3e7-5a9b-4527-8835-ccebab82aa03">
