### PR TITLE
chore(ci): Point to the correct updater script for circleci.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -640,7 +640,7 @@ jobs:
       - run:
           name: Check for external Update
           command: |
-            ./.circleci/updater_script.sh
+            ./scripts/external_integration_updater_script.sh
 
   build_firefox_versions:
     working_directory: ~/experimenter


### PR DESCRIPTION
Because

- I forgot a change in my excitement to land the previous PR

This commit

- Runs the correct script for the hourly updater

Fixes #11302

