### PR TITLE
feat(nimbus): add no sizing data message to audience page

### DIFF
--- a/experimenter/experimenter/experiments/api/v5/types.py
+++ b/experimenter/experimenter/experiments/api/v5/types.py
@@ -322,6 +322,7 @@ class NimbusExperimentBranchThroughExcludedType(DjangoObjectType):
 class NimbusConfigurationType(graphene.ObjectType):
     application_configs = graphene.List(NimbusExperimentApplicationConfigType)
     applications = graphene.List(NimbusLabelValueType)
+    application_name_map = graphene.List(NimbusLabelValueType)
     channels = graphene.List(NimbusLabelValueType)
     countries = graphene.List(NimbusCountryType)
     documentation_link = graphene.List(NimbusLabelValueType)
@@ -358,6 +359,9 @@ class NimbusConfigurationType(graphene.ObjectType):
 
     def resolve_applications(self, info):
         return self._text_choices_to_label_value_list(NimbusExperiment.Application)
+
+    def resolve_application_name_map(self, info):
+        return self._text_choices_to_label_value_list(NimbusExperiment.ApplicationNameMap)
 
     def resolve_channels(self, info):
         return self._text_choices_to_label_value_list(NimbusExperiment.Channel)

--- a/experimenter/experimenter/experiments/constants.py
+++ b/experimenter/experimenter/experiments/constants.py
@@ -280,29 +280,6 @@ NO_FEATURE_SLUG = [
 ]
 
 
-class ApplicationNameMap(models.TextChoices):
-    DESKTOP = (APPLICATION_CONFIG_DESKTOP.slug, APPLICATION_CONFIG_DESKTOP.app_name)
-    FENIX = (APPLICATION_CONFIG_FENIX.slug, APPLICATION_CONFIG_FENIX.app_name)
-    IOS = (APPLICATION_CONFIG_IOS.slug, APPLICATION_CONFIG_IOS.app_name)
-    FOCUS_ANDROID = (
-        APPLICATION_CONFIG_FOCUS_ANDROID.slug,
-        APPLICATION_CONFIG_FOCUS_ANDROID.app_name,
-    )
-    KLAR_ANDROID = (
-        APPLICATION_CONFIG_KLAR_ANDROID.slug,
-        APPLICATION_CONFIG_KLAR_ANDROID.app_name,
-    )
-    FOCUS_IOS = (APPLICATION_CONFIG_FOCUS_IOS.slug, APPLICATION_CONFIG_FOCUS_IOS.app_name)
-    KLAR_IOS = (APPLICATION_CONFIG_KLAR_IOS.slug, APPLICATION_CONFIG_KLAR_IOS.app_name)
-    MONITOR = (
-        APPLICATION_CONFIG_MONITOR_WEB.slug,
-        APPLICATION_CONFIG_MONITOR_WEB.app_name,
-    )
-    VPN = (APPLICATION_CONFIG_VPN_WEB.slug, APPLICATION_CONFIG_VPN_WEB.app_name)
-    FXA = (APPLICATION_CONFIG_FXA_WEB.slug, APPLICATION_CONFIG_FXA_WEB.app_name)
-    DEMO_APP = (APPLICATION_CONFIG_DEMO_APP.slug, APPLICATION_CONFIG_DEMO_APP.app_name)
-
-
 class Application(models.TextChoices):
     DESKTOP = (APPLICATION_CONFIG_DESKTOP.slug, APPLICATION_CONFIG_DESKTOP.name)
     FENIX = (APPLICATION_CONFIG_FENIX.slug, APPLICATION_CONFIG_FENIX.name)
@@ -381,8 +358,6 @@ class NimbusConstants:
 
     Application = Application
 
-    ApplicationNameMap = ApplicationNameMap
-
     class Type(models.TextChoices):
         EXPERIMENT = "Experiment"
         ROLLOUT = "Rollout"
@@ -417,6 +392,10 @@ class NimbusConstants:
         Application.FXA: APPLICATION_CONFIG_FXA_WEB,
         Application.DEMO_APP: APPLICATION_CONFIG_DEMO_APP,
     }
+
+    ApplicationNameMap = models.TextChoices(
+        "ApplicationNameMap", [(a.slug, a.app_name) for a in APPLICATION_CONFIGS.values()]
+    )
 
     DESKTOP_PREFFLIPS_SLUG = DESKTOP_PREFFLIPS_SLUG
 

--- a/experimenter/experimenter/experiments/constants.py
+++ b/experimenter/experimenter/experiments/constants.py
@@ -280,6 +280,29 @@ NO_FEATURE_SLUG = [
 ]
 
 
+class ApplicationNameMap(models.TextChoices):
+    DESKTOP = (APPLICATION_CONFIG_DESKTOP.slug, APPLICATION_CONFIG_DESKTOP.app_name)
+    FENIX = (APPLICATION_CONFIG_FENIX.slug, APPLICATION_CONFIG_FENIX.app_name)
+    IOS = (APPLICATION_CONFIG_IOS.slug, APPLICATION_CONFIG_IOS.app_name)
+    FOCUS_ANDROID = (
+        APPLICATION_CONFIG_FOCUS_ANDROID.slug,
+        APPLICATION_CONFIG_FOCUS_ANDROID.app_name,
+    )
+    KLAR_ANDROID = (
+        APPLICATION_CONFIG_KLAR_ANDROID.slug,
+        APPLICATION_CONFIG_KLAR_ANDROID.app_name,
+    )
+    FOCUS_IOS = (APPLICATION_CONFIG_FOCUS_IOS.slug, APPLICATION_CONFIG_FOCUS_IOS.app_name)
+    KLAR_IOS = (APPLICATION_CONFIG_KLAR_IOS.slug, APPLICATION_CONFIG_KLAR_IOS.app_name)
+    MONITOR = (
+        APPLICATION_CONFIG_MONITOR_WEB.slug,
+        APPLICATION_CONFIG_MONITOR_WEB.app_name,
+    )
+    VPN = (APPLICATION_CONFIG_VPN_WEB.slug, APPLICATION_CONFIG_VPN_WEB.app_name)
+    FXA = (APPLICATION_CONFIG_FXA_WEB.slug, APPLICATION_CONFIG_FXA_WEB.app_name)
+    DEMO_APP = (APPLICATION_CONFIG_DEMO_APP.slug, APPLICATION_CONFIG_DEMO_APP.app_name)
+
+
 class Application(models.TextChoices):
     DESKTOP = (APPLICATION_CONFIG_DESKTOP.slug, APPLICATION_CONFIG_DESKTOP.name)
     FENIX = (APPLICATION_CONFIG_FENIX.slug, APPLICATION_CONFIG_FENIX.name)
@@ -357,6 +380,8 @@ class NimbusConstants:
         NONE = "NONE", "None"
 
     Application = Application
+
+    ApplicationNameMap = ApplicationNameMap
 
     class Type(models.TextChoices):
         EXPERIMENT = "Experiment"

--- a/experimenter/experimenter/experiments/tests/api/v5/test_queries.py
+++ b/experimenter/experimenter/experiments/tests/api/v5/test_queries.py
@@ -2249,25 +2249,27 @@ class TestNimbusExperimentBySlugQuery(GraphQLTestCase):
             experiment=experiment,
             feature_values=[],
         )
-        NimbusBranchFeatureValue.objects.bulk_create(
-            [
-                NimbusBranchFeatureValue(
-                    branch=treatment,
-                    feature_config=feature2,
-                    value="""{"value": 2}""",
-                ),
-                NimbusBranchFeatureValue(
-                    branch=treatment,
-                    feature_config=feature3,
-                    value="""{"value": 3}""",
-                ),
-                NimbusBranchFeatureValue(
-                    branch=treatment,
-                    feature_config=feature1,
-                    value="""{"value": 1}""",
-                ),
-            ]
-        ),
+        (
+            NimbusBranchFeatureValue.objects.bulk_create(
+                [
+                    NimbusBranchFeatureValue(
+                        branch=treatment,
+                        feature_config=feature2,
+                        value="""{"value": 2}""",
+                    ),
+                    NimbusBranchFeatureValue(
+                        branch=treatment,
+                        feature_config=feature3,
+                        value="""{"value": 3}""",
+                    ),
+                    NimbusBranchFeatureValue(
+                        branch=treatment,
+                        feature_config=feature1,
+                        value="""{"value": 1}""",
+                    ),
+                ]
+            ),
+        )
         experiment.branches.add(treatment)
         experiment.save()
 
@@ -2463,6 +2465,10 @@ class TestNimbusConfigQuery(MockSizingDataMixin, GraphQLTestCase):
                         label
                         value
                     }
+                    applicationNameMap {
+                        label
+                        value
+                    }
                     channels {
                         label
                         value
@@ -2575,6 +2581,7 @@ class TestNimbusConfigQuery(MockSizingDataMixin, GraphQLTestCase):
                 self.assertEqual(data[index]["value"], name)
 
         assertChoices(config["applications"], NimbusExperiment.Application)
+        assertChoices(config["applicationNameMap"], NimbusExperiment.ApplicationNameMap)
         assertChoices(config["takeaways"], NimbusExperiment.Takeaways)
         assertChoices(config["qaStatus"], NimbusExperiment.QAStatus)
         assertChoices(config["types"], NimbusExperiment.Type)

--- a/experimenter/experimenter/nimbus-ui/schema.graphql
+++ b/experimenter/experimenter/nimbus-ui/schema.graphql
@@ -475,6 +475,7 @@ type NimbusExperimentTargetingConfigType {
 type NimbusConfigurationType {
   applicationConfigs: [NimbusExperimentApplicationConfigType]
   applications: [NimbusLabelValueType]
+  applicationNameMap: [NimbusLabelValueType]
   channels: [NimbusLabelValueType]
   countries: [NimbusCountryType]
   documentationLink: [NimbusLabelValueType]

--- a/experimenter/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/index.tsx
@@ -16,10 +16,9 @@ import Form from "react-bootstrap/Form";
 import InputGroup from "react-bootstrap/InputGroup";
 import Select, { createFilter, FormatOptionLabelMeta } from "react-select";
 import ReactTooltip from "react-tooltip";
-import { Code } from "src/components/Code";
 import LinkExternal from "src/components/LinkExternal";
 import PopulationSizing from "src/components/PageEditAudience/PopulationSizing";
-import TooltipWithMarkdown from "src/components/PageResults/TooltipWithMarkdown";
+import PopulationSizingNoData from "src/components/PageEditAudience/PopulationSizingNoData";
 import { GET_ALL_EXPERIMENTS_BY_APPLICATION_QUERY } from "src/gql/experiments";
 import { useCommonForm, useConfig, useReviewCheck } from "src/hooks";
 import { ReactComponent as Info } from "src/images/info.svg";
@@ -81,10 +80,6 @@ export const audienceFieldNames = [
   "isSticky",
   "isFirstRun",
 ] as const;
-
-const popSizingNoDataMarkdown =
-  "Pre-computed sizing is computed for limited targets using the [auto-sizing](https://experimenter.info/auto-sizing-cli/) tool.";
-
 
 export const MOBILE_APPLICATIONS = [
   NimbusExperimentApplicationEnum.FENIX,
@@ -333,7 +328,10 @@ export const FormAudience = ({
       applicationConfig?.application === experiment.application,
   );
 
-  const applicationName = config.applicationNameMap!.find((appName) => appName!.value === experiment.application)!.label;
+  const applicationName =
+    config.applicationNameMap!.find(
+      (appName) => appName!.value === experiment.application,
+    )?.label || experiment.application;
 
   const [populationPercent, setPopulationPercent] = useState(
     experiment!.populationPercent?.toString(),
@@ -556,7 +554,7 @@ export const FormAudience = ({
     );
     // filter to current application for brevity
     return allSizing.filter((recipe) => applicationName === recipe.app_id);
-  }, [config, experiment.application]);
+  }, [config, applicationName]);
 
   const isDesktop =
     experiment.application === NimbusExperimentApplicationEnum.DESKTOP;
@@ -1006,49 +1004,10 @@ export const FormAudience = ({
             />
           </>
         ) : (
-          <>
-            <Form.Label
-              as="h5"
-              className="d-flex align-items-center"
-              data-testid="population-sizing-precomputed-values"
-            >
-              Pre-computed population sizing data Not Available
-              <Info
-                data-tip
-                data-for="auto-sizing-nodata-help"
-                width="20"
-                height="20"
-                className="ml-1"
-              />
-              <TooltipWithMarkdown
-                tooltipId="auto-sizing-nodata-help"
-                markdown={popSizingNoDataMarkdown}
-              />
-            </Form.Label>
-            <hr />
-            <p className="text-secondary">
-              Pre-computed sizing information is available for certain targeting
-              criteria. See below for target combinations with sizing available
-              for the current application (
-              <strong>{applicationName}</strong>):
-            </p>
-            <p>
-              {getSizingAvailableTargets.length > 0 ? (
-                getSizingAvailableTargets.map((target) => (
-                  <Code
-                    codeString={JSON.stringify(target, (k, v) =>
-                      k === "new_or_existing" || k === "app_id" || v === null
-                        ? undefined
-                        : v,
-                    )}
-                    key={JSON.stringify(target)}
-                  />
-                ))
-              ) : (
-                <Code codeString="No pre-computed sizing available for this application." />
-              )}
-            </p>
-          </>
+          <PopulationSizingNoData
+            availableTargets={getSizingAvailableTargets}
+            applicationName={applicationName!}
+          />
         )}
       </Form.Group>
 

--- a/experimenter/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/index.tsx
@@ -88,20 +88,6 @@ export const MOBILE_APPLICATIONS = [
   NimbusExperimentApplicationEnum.FOCUS_IOS,
 ];
 
-const APP_NAME_TO_SLUG_MAP: Record<NimbusExperimentApplicationEnum, string> = {
-  DESKTOP: "firefox_desktop",
-  FENIX: "fenix",
-  IOS: "firefox_ios",
-  DEMO_APP: "NOT_SUPPORTED",
-  FOCUS_ANDROID: "focus_android",
-  FOCUS_IOS: "focus_ios",
-  FXA: "NOT_SUPPORTED",
-  KLAR_ANDROID: "klar_android",
-  KLAR_IOS: "klar_ios",
-  MONITOR: "monitor_cirrus",
-  VPN: "NOT_SUPPORTED",
-};
-
 interface SelectExperimentBranchOption {
   id: number;
   name: string;
@@ -342,6 +328,8 @@ export const FormAudience = ({
       applicationConfig?.application === experiment.application,
   );
 
+  const applicationName = config.applicationNameMap!.find((appName) => appName!.value === experiment.application)!.label;
+
   const [populationPercent, setPopulationPercent] = useState(
     experiment!.populationPercent?.toString(),
   );
@@ -562,10 +550,7 @@ export const FormAudience = ({
       (targetKey: string) => sizingJson[targetKey].new.target_recipe,
     );
     // filter to current application for brevity
-    return allSizing.filter(
-      (recipe) =>
-        APP_NAME_TO_SLUG_MAP[experiment.application] === recipe.app_id,
-    );
+    return allSizing.filter((recipe) => applicationName === recipe.app_id);
   }, [config, experiment.application]);
 
   const isDesktop =
@@ -1023,7 +1008,7 @@ export const FormAudience = ({
               Pre-computed sizing information is available for certain targeting
               criteria. See below for target combinations with sizing available
               for the current application (
-              {APP_NAME_TO_SLUG_MAP[experiment.application]}):
+              <strong>{applicationName}</strong>):
             </p>
             <p>
               {getSizingAvailableTargets.length > 0 ? (

--- a/experimenter/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/index.tsx
@@ -19,6 +19,7 @@ import ReactTooltip from "react-tooltip";
 import { Code } from "src/components/Code";
 import LinkExternal from "src/components/LinkExternal";
 import PopulationSizing from "src/components/PageEditAudience/PopulationSizing";
+import TooltipWithMarkdown from "src/components/PageResults/TooltipWithMarkdown";
 import { GET_ALL_EXPERIMENTS_BY_APPLICATION_QUERY } from "src/gql/experiments";
 import { useCommonForm, useConfig, useReviewCheck } from "src/hooks";
 import { ReactComponent as Info } from "src/images/info.svg";
@@ -80,6 +81,10 @@ export const audienceFieldNames = [
   "isSticky",
   "isFirstRun",
 ] as const;
+
+const popSizingNoDataMarkdown =
+  "Pre-computed sizing is computed for limited targets using the [auto-sizing](https://experimenter.info/auto-sizing-cli/) tool.";
+
 
 export const MOBILE_APPLICATIONS = [
   NimbusExperimentApplicationEnum.FENIX,
@@ -1002,7 +1007,24 @@ export const FormAudience = ({
           </>
         ) : (
           <>
-            <h5>Pre-computed Sizing Data Not Available</h5>
+            <Form.Label
+              as="h5"
+              className="d-flex align-items-center"
+              data-testid="population-sizing-precomputed-values"
+            >
+              Pre-computed population sizing data Not Available
+              <Info
+                data-tip
+                data-for="auto-sizing-nodata-help"
+                width="20"
+                height="20"
+                className="ml-1"
+              />
+              <TooltipWithMarkdown
+                tooltipId="auto-sizing-nodata-help"
+                markdown={popSizingNoDataMarkdown}
+              />
+            </Form.Label>
             <hr />
             <p className="text-secondary">
               Pre-computed sizing information is available for certain targeting

--- a/experimenter/experimenter/nimbus-ui/src/components/PageEditAudience/PopulationSizingNoData/index.test.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageEditAudience/PopulationSizingNoData/index.test.tsx
@@ -1,0 +1,67 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { SizingRecipe } from "@mozilla/nimbus-schemas";
+import { render, screen } from "@testing-library/react";
+import React from "react";
+import PopulationSizingNoData from "src/components/PageEditAudience/PopulationSizingNoData";
+
+describe("PopulationSizingNoData", () => {
+  it("renders targets as expected", () => {
+    const sizingRecipes: SizingRecipe[] = [
+      {
+        app_id: "firefox_desktop",
+        channel: "release",
+        locale: "('EN-US')",
+        country: "US",
+        new_or_existing: "new",
+      },
+      {
+        app_id: "firefox_desktop",
+        channel: "release",
+        locale: "('EN-US')",
+        language: undefined,
+        country: "all",
+        new_or_existing: "existing",
+      },
+    ];
+    render(
+      <PopulationSizingNoData
+        availableTargets={sizingRecipes}
+        applicationName="firefox_desktop"
+      />,
+    );
+
+    expect(
+      screen.getByText("Pre-computed population sizing data Not Available"),
+    );
+    expect(
+      screen.getByTestId("population-sizing-nodata-info"),
+    ).toHaveTextContent("firefox_desktop", { normalizeWhitespace: true });
+    expect(
+      screen.getByTestId("population-sizing-nodata-targets"),
+    ).toHaveTextContent(
+      '{ "channel": "release", "locale": "(\'EN-US\')", "country": "US" }{ "channel": "release", "locale": "(\'EN-US\')", "country": "all" }',
+      { normalizeWhitespace: true },
+    );
+  });
+  it("renders lack of targets as expected", () => {
+    render(
+      <PopulationSizingNoData availableTargets={[]} applicationName="fenix" />,
+    );
+
+    expect(
+      screen.getByText("Pre-computed population sizing data Not Available"),
+    );
+    expect(
+      screen.getByTestId("population-sizing-nodata-info"),
+    ).toHaveTextContent("fenix", { normalizeWhitespace: true });
+    expect(
+      screen.getByTestId("population-sizing-nodata-targets"),
+    ).toHaveTextContent(
+      "No pre-computed sizing available for this application.",
+      { normalizeWhitespace: true },
+    );
+  });
+});

--- a/experimenter/experimenter/nimbus-ui/src/components/PageEditAudience/PopulationSizingNoData/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageEditAudience/PopulationSizingNoData/index.tsx
@@ -1,0 +1,70 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { SizingRecipe } from "@mozilla/nimbus-schemas";
+import React from "react";
+import { Form } from "react-bootstrap";
+import { Code } from "src/components/Code";
+import TooltipWithMarkdown from "src/components/PageResults/TooltipWithMarkdown";
+import { ReactComponent as Info } from "src/images/info.svg";
+
+type PopulationSizingNoDataProps = {
+  availableTargets: SizingRecipe[];
+  applicationName: string;
+};
+
+const popSizingNoDataMarkdown =
+  "Pre-computed sizing is computed for limited targets using the [auto-sizing](https://experimenter.info/auto-sizing-cli/) tool.";
+
+const PopulationSizingNoData = ({
+  availableTargets,
+  applicationName,
+}: PopulationSizingNoDataProps) => {
+  return (
+    <>
+      <Form.Label
+        as="h5"
+        className="d-flex align-items-center"
+        data-testid="population-sizing-nodata"
+      >
+        Pre-computed population sizing data Not Available
+        <Info
+          data-tip
+          data-for="auto-sizing-nodata-help"
+          width="20"
+          height="20"
+          className="ml-1"
+        />
+        <TooltipWithMarkdown
+          tooltipId="auto-sizing-nodata-help"
+          markdown={popSizingNoDataMarkdown}
+        />
+      </Form.Label>
+      <hr />
+      <p className="text-secondary" data-testid="population-sizing-nodata-info">
+        Pre-computed sizing information is available for certain targeting
+        criteria. See below for target combinations with sizing available for
+        the current application (<strong>{applicationName}</strong>):
+      </p>
+      <p data-testid="population-sizing-nodata-targets">
+        {availableTargets.length > 0 ? (
+          availableTargets.map((target) => (
+            <Code
+              codeString={JSON.stringify(target, (k, v) =>
+                k === "new_or_existing" || k === "app_id" || v === null
+                  ? undefined
+                  : v,
+              )}
+              key={JSON.stringify(target)}
+            />
+          ))
+        ) : (
+          <Code codeString="No pre-computed sizing available for this application." />
+        )}
+      </p>
+    </>
+  );
+};
+
+export default React.memo(PopulationSizingNoData);

--- a/experimenter/experimenter/nimbus-ui/src/gql/config.ts
+++ b/experimenter/experimenter/nimbus-ui/src/gql/config.ts
@@ -11,6 +11,10 @@ export const GET_CONFIG_QUERY = gql`
         label
         value
       }
+      applicationNameMap {
+        label
+        value
+      }
       channels {
         label
         value

--- a/experimenter/experimenter/nimbus-ui/src/lib/mocks.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/lib/mocks.tsx
@@ -91,6 +91,28 @@ export const MOCK_CONFIG: getConfig_nimbusConfig = {
       value: NimbusExperimentApplicationEnum.MONITOR,
     },
   ],
+  applicationNameMap: [
+    {
+      label: "firefox_desktop",
+      value: NimbusExperimentApplicationEnum.DESKTOP,
+    },
+    {
+      label: "toaster",
+      value: "TOASTER",
+    },
+    {
+      label: "ios",
+      value: NimbusExperimentApplicationEnum.IOS,
+    },
+    {
+      label: "fenix",
+      value: NimbusExperimentApplicationEnum.FENIX,
+    },
+    {
+      label: "monitor_cirrus",
+      value: NimbusExperimentApplicationEnum.MONITOR,
+    },
+  ],
   takeaways: [
     { label: "DAU Gain", value: "DAU_GAIN" },
     { label: "QBR Learning", value: "QBR_LEARNING" },

--- a/experimenter/experimenter/nimbus-ui/src/types/getConfig.ts
+++ b/experimenter/experimenter/nimbus-ui/src/types/getConfig.ts
@@ -14,6 +14,11 @@ export interface getConfig_nimbusConfig_applications {
   value: string | null;
 }
 
+export interface getConfig_nimbusConfig_applicationNameMap {
+  label: string | null;
+  value: string | null;
+}
+
 export interface getConfig_nimbusConfig_channels {
   label: string | null;
   value: string | null;
@@ -140,6 +145,7 @@ export interface getConfig_nimbusConfig_subscribers {
 
 export interface getConfig_nimbusConfig {
   applications: (getConfig_nimbusConfig_applications | null)[] | null;
+  applicationNameMap: (getConfig_nimbusConfig_applicationNameMap | null)[] | null;
   channels: (getConfig_nimbusConfig_channels | null)[] | null;
   conclusionRecommendationsChoices: (getConfig_nimbusConfig_conclusionRecommendationsChoices | null)[] | null;
   applicationConfigs: (getConfig_nimbusConfig_applicationConfigs | null)[] | null;


### PR DESCRIPTION
Because

- we don't always have pre-computed sizing information, and we only show it when we have it
- inconsistent UI can be confusing
- low number of pre-computed targets mean the feature may not be well-known

This commit

- adds a note about how to find pre-computed sizing information if we don't have it available for the selected targeting

Fixes #10126 

**Screenshots**
![image](https://github.com/user-attachments/assets/549826e5-812c-419c-9e8a-08fdf0fd8c04)


No sizing data available
![image](https://github.com/user-attachments/assets/bce6ae8b-cc51-4232-89aa-29d002a37b7a)
