### PR TITLE
fix(ci): Always force push to external integrations branch.

### DIFF
--- a/scripts/external_integration_updater_script.sh
+++ b/scripts/external_integration_updater_script.sh
@@ -17,7 +17,7 @@ done
 if (($(git status --porcelain | wc -c) > 0)); then
     git add .
     git commit -m "chore(nimbus): Check external firefox integrations and update keys"
-    git push origin check-external-firefox-integrations
+    git push origin -f check-external-firefox-integrations
     gh pr create -t "chore(nimbus): Check external firefox integrations and update keys" -b "" --base main --head check-external-firefox-integrations --repo mozilla/experimenter || echo "PR already exists, skipping"
 else
     echo "No config changes, skipping"


### PR DESCRIPTION
Because

- We weren't force pushing to the external integrations branch and this would cause issues if the branch was not deleted.

This commit

- Adds the change to force push to the branch

Fixes #11332 