### PR TITLE
feat(nimbus): Sign off recommendation actions

### DIFF
--- a/experimenter/experimenter/nimbus_ui_new/forms.py
+++ b/experimenter/experimenter/nimbus_ui_new/forms.py
@@ -122,3 +122,25 @@ class TakeawaysForm(NimbusChangeLogFormMixin, forms.ModelForm):
 
     def get_changelog_message(self):
         return f"{self.request.user} updated takeaways"
+
+
+class SignoffForm(NimbusChangeLogFormMixin, forms.ModelForm):
+    class Meta:
+        model = NimbusExperiment
+        fields = ["qa_signoff", "vp_signoff", "legal_signoff"]
+        widgets = {
+            "qa_signoff": forms.CheckboxInput(),
+            "vp_signoff": forms.CheckboxInput(),
+            "legal_signoff": forms.CheckboxInput(),
+        }
+
+    def get_changelog_message(self):
+        changed_fields = []
+        if self.cleaned_data.get("qa_signoff") != self.initial.get("qa_signoff"):
+            changed_fields.append("QA signoff")
+        if self.cleaned_data.get("vp_signoff") != self.initial.get("vp_signoff"):
+            changed_fields.append("VP signoff")
+        if self.cleaned_data.get("legal_signoff") != self.initial.get("legal_signoff"):
+            changed_fields.append("Legal signoff")
+
+        return f"{self.request.user} updated {', '.join(changed_fields)}"

--- a/experimenter/experimenter/nimbus_ui_new/forms.py
+++ b/experimenter/experimenter/nimbus_ui_new/forms.py
@@ -135,12 +135,4 @@ class SignoffForm(NimbusChangeLogFormMixin, forms.ModelForm):
         }
 
     def get_changelog_message(self):
-        changed_fields = []
-        if self.cleaned_data.get("qa_signoff") != self.initial.get("qa_signoff"):
-            changed_fields.append("QA signoff")
-        if self.cleaned_data.get("vp_signoff") != self.initial.get("vp_signoff"):
-            changed_fields.append("VP signoff")
-        if self.cleaned_data.get("legal_signoff") != self.initial.get("legal_signoff"):
-            changed_fields.append("Legal signoff")
-
-        return f"{self.request.user} updated {', '.join(changed_fields)}"
+        return f"{self.request.user} updated sign off"

--- a/experimenter/experimenter/nimbus_ui_new/static/js/scripts/experiment_detail.js
+++ b/experimenter/experimenter/nimbus_ui_new/static/js/scripts/experiment_detail.js
@@ -1,0 +1,5 @@
+$(() => {
+  document.body.addEventListener("htmx:afterSwap", function () {
+    $(".selectpicker").selectpicker();
+  });
+});

--- a/experimenter/experimenter/nimbus_ui_new/static/webpack.config.js
+++ b/experimenter/experimenter/nimbus_ui_new/static/webpack.config.js
@@ -5,6 +5,7 @@ module.exports = {
   entry: {
     app: "./js/index.js",
     experiment_list: "./js/scripts/experiment_list.js",
+    experiment_detail: "./js/scripts/experiment_detail.js",
     theme: "./js/scripts/theme.js",
   },
   output: {

--- a/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/detail.html
+++ b/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/detail.html
@@ -239,38 +239,8 @@
       </div>
     </div>
     <!-- Actions Recommended Before Launch Card -->
-    <div class="card mb-3">
-      <div class="card-header">
-        <h4>Actions that were recommended before launch</h4>
-      </div>
-      <div class="card-body">
-        <table class="table table-striped">
-          <tbody>
-            <tr>
-              <th>QA Sign-off</th>
-              <td colspan="3">
-                {% if experiment.signoff_recommendations.qa_signoff %}<span class="text-success">Recommended:</span>{% endif %}
-                Please file a QA request. Learn More
-              </td>
-            </tr>
-            <tr>
-              <th>VP Sign-off</th>
-              <td colspan="3">
-                {% if experiment.signoff_recommendations.vp_signoff %}<span class="text-success">Recommended:</span>{% endif %}
-                Please email your VP. Learn More
-              </td>
-            </tr>
-            <tr>
-              <th>Legal Sign-off</th>
-              <td colspan="3">
-                {% if experiment.signoff_recommendations.legal_signoff %}<span class="text-success">Recommended:</span>{% endif %}
-                Please email legal. Learn More
-              </td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
-    </div>
+    {% include "nimbus_experiments/signoff_card.html" %}
+
     <!-- Branches Card -->
     <div class="card mb-3">
       <div class="card-header">

--- a/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/detail.html
+++ b/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/detail.html
@@ -1,5 +1,6 @@
 {% extends "common/with_sidebar.html" %}
 
+{% load static %}
 {% load nimbus_extras %}
 
 {% block title %}Summary{% endblock %}
@@ -239,7 +240,7 @@
       </div>
     </div>
     <!-- Actions Recommended Before Launch Card -->
-    {% include "nimbus_experiments/signoff_card.html" %}
+    {% include "nimbus_experiments/signoff_card.html" with edit=False experiment=experiment %}
 
     <!-- Branches Card -->
     <div class="card mb-3">
@@ -312,4 +313,9 @@
     {% include "nimbus_experiments/qa_card.html" %}
 
   </div>
+{% endblock %}
+
+{% block extrascripts %}
+  {{ block.super }}
+  <script src="{% static 'nimbus_ui_new/experiment_detail.bundle.js' %}"></script>
 {% endblock %}

--- a/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/signoff_card.html
+++ b/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/signoff_card.html
@@ -26,64 +26,59 @@
     {% endif %}
   </div>
   <div class="card-body p-0">
-    <div class="container">
-      <div class="row py-2">
-        <div class="col-md-2">
-          <strong>QA Signoff</strong>
-        </div>
-        <div class="col-md-10 d-flex align-items-center">
-          {% if edit %}
-            {{ form.qa_signoff }}
-          {% else %}
-            {% if experiment.qa_signoff %}
-              <i class="fa fa-check-circle text-success"></i>
+    <table class="table table-striped mb-0">
+      <tbody>
+        <tr>
+          <th scope="row">QA Signoff</th>
+          <td class="d-flex align-items-center">
+            {% if edit %}
+              {{ form.qa_signoff }}
             {% else %}
-              <i class="fa fa-times-circle text-danger"></i>
+              {% if experiment.qa_signoff %}
+                <i class="fa fa-check-circle text-success"></i>
+              {% else %}
+                <i class="fa fa-times-circle text-danger"></i>
+              {% endif %}
             {% endif %}
-          {% endif %}
-          {% if experiment.signoff_recommendations.qa_signoff %}
-            <span class="text-success ms-3">Recommended: Please file a QA request. <a href="#">Learn More</a></span>
-          {% endif %}
-        </div>
-      </div>
-      <div class="row py-2">
-        <div class="col-md-2">
-          <strong>VP Signoff</strong>
-        </div>
-        <div class="col-md-10 d-flex align-items-center">
-          {% if edit %}
-            {{ form.vp_signoff }}
-          {% else %}
-            {% if experiment.vp_signoff %}
-              <i class="fa fa-check-circle text-success"></i>
+            {% if experiment.signoff_recommendations.qa_signoff %}<span class="text-success ms-1">Recommended:</span>{% endif %}
+            <span class="ms-1">Please file a QA request. <a href="https://experimenter.info/qa-sign-off">Learn More</a></span>
+          </td>
+        </tr>
+        <tr>
+          <th scope="row">VP Signoff</th>
+          <td class="d-flex align-items-center">
+            {% if edit %}
+              {{ form.vp_signoff }}
             {% else %}
-              <i class="fa fa-times-circle text-danger"></i>
+              {% if experiment.vp_signoff %}
+                <i class="fa fa-check-circle text-success"></i>
+              {% else %}
+                <i class="fa fa-times-circle text-danger"></i>
+              {% endif %}
             {% endif %}
-          {% endif %}
-          {% if experiment.signoff_recommendations.vp_signoff %}
-            <span class="text-success ms-3">Recommended: Please email your VP. <a href="#">Learn More</a></span>
-          {% endif %}
-        </div>
-      </div>
-      <div class="row py-2">
-        <div class="col-md-2">
-          <strong>Legal Signoff</strong>
-        </div>
-        <div class="col-md-10 d-flex align-items-center">
-          {% if edit %}
-            {{ form.legal_signoff }}
-          {% else %}
-            {% if experiment.legal_signoff %}
-              <i class="fa fa-check-circle text-success"></i>
+            {% if experiment.signoff_recommendations.vp_signoff %}<span class="text-success ms-1">Recommended:</span>{% endif %}
+            <span class="ms-1">Please email your VP. <a href="https://experimenter.info/vp-sign-off">Learn More</a></span>
+          </td>
+        </tr>
+        <tr>
+          <th scope="row">Legal Signoff</th>
+          <td class="d-flex align-items-center">
+            {% if edit %}
+              {{ form.legal_signoff }}
             {% else %}
-              <i class="fa fa-times-circle text-danger"></i>
+              {% if experiment.legal_signoff %}
+                <i class="fa fa-check-circle text-success"></i>
+              {% else %}
+                <i class="fa fa-times-circle text-danger"></i>
+              {% endif %}
             {% endif %}
-          {% endif %}
-          {% if experiment.signoff_recommendations.legal_signoff %}
-            <span class="text-success ms-3">Recommended: Please email legal. <a href="#">Learn More</a></span>
-          {% endif %}
-        </div>
-      </div>
-    </div>
+            {% if experiment.signoff_recommendations.legal_signoff %}
+              <span class="text-success ms-1">Recommended:</span>
+            {% endif %}
+            <span class="ms-1">Please email legal. <a href="https://experimenter.info/legal-sign-off">Learn More</a></span>
+          </td>
+        </tr>
+      </tbody>
+    </table>
   </div>
 </form>

--- a/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/signoff_card.html
+++ b/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/signoff_card.html
@@ -1,94 +1,89 @@
-<div class="card mb-3">
+{% load nimbus_extras %}
+
+<form id="signoff" class="card mb-3">
+  {% csrf_token %}
   <div class="card-header d-flex justify-content-between align-items-center">
-    <h4 class="mb-0">Sign-offs</h4>
-    {% if not signoff_edit_mode %}
-      <button class="btn btn-outline-primary btn-sm"
-              hx-get="{% url 'nimbus-new-detail' experiment.slug %}?edit_signoff=true"
-              hx-target="body"
-              hx-swap="outerHTML">Edit</button>
-    {% endif %}
-  </div>
-  <div class="card-body" id="signoff-form-container">
-    {% if signoff_edit_mode %}
-      <form method="post"
-            hx-post="{% url 'update-signoff' experiment.slug %}"
-            hx-target="body"
-            hx-swap="outerHTML">
-        {% csrf_token %}
-        <div class="mb-3">
-          <label for="id_qa_signoff">QA Sign-off:</label>
-          {{ signoff_form.qa_signoff }}
-          {% if experiment.signoff_recommendations.qa_signoff %}
-            <span class="text-success">Recommended: Please file a QA request. <a href="#">Learn More</a></span>
-          {% endif %}
-        </div>
-        <div class="mb-3">
-          <label for="id_vp_signoff">VP Sign-off:</label>
-          {{ signoff_form.vp_signoff }}
-          {% if experiment.signoff_recommendations.vp_signoff %}
-            <span class="text-success">Recommended: Please email your VP. <a href="#">Learn More</a></span>
-          {% endif %}
-        </div>
-        <div class="mb-3">
-          <label for="id_legal_signoff">Legal Sign-off:</label>
-          {{ signoff_form.legal_signoff }}
-          {% if experiment.signoff_recommendations.legal_signoff %}
-            <span class="text-success">Recommended: Please email legal. <a href="#">Learn More</a></span>
-          {% endif %}
-        </div>
-        <div class="d-flex justify-content-end mt-3">
-          <button type="submit" class="btn btn-primary me-2">Save</button>
-          <button type="button"
-                  class="btn btn-secondary"
-                  hx-get="{% url 'nimbus-new-detail' experiment.slug %}"
-                  hx-target="body"
-                  hx-swap="outerHTML">Cancel</button>
-        </div>
-      </form>
+    <h4>Sign-Offs</h4>
+    {{ errors }}
+    {% if edit %}
+      <div>
+        <a class="btn btn-primary btn-sm me-2"
+           hx-post="{% url 'update-signoff' experiment.slug %}"
+           hx-select="#signoff"
+           hx-target="#signoff"
+           hx-swap="outerHTML">Save</a>
+        <a class="btn btn-secondary btn-sm"
+           hx-get="{% url 'nimbus-new-detail' experiment.slug %}"
+           hx-select="#signoff"
+           hx-target="#signoff"
+           hx-swap="outerHTML">Cancel</a>
+      </div>
     {% else %}
-      <table class="table table-striped">
-        <tbody>
-          <tr>
-            <th>QA Sign-off</th>
-            <td>
-              {% if experiment.qa_signoff %}
-                <i class="fa fa-check-circle text-success"></i>
-              {% else %}
-                <i class="fa fa-times-circle text-danger"></i>
-              {% endif %}
-              {% if experiment.signoff_recommendations.qa_signoff %}
-                <span class="text-success">Recommended: Please file a QA request. <a href="https://experimenter.info/qa-sign-off/">Learn More</a></span>
-              {% endif %}
-            </td>
-          </tr>
-          <tr>
-            <th>VP Sign-off</th>
-            <td>
-              {% if experiment.vp_signoff %}
-                <i class="fa fa-check-circle text-success"></i>
-              {% else %}
-                <i class="fa fa-times-circle text-danger"></i>
-              {% endif %}
-              {% if experiment.signoff_recommendations.vp_signoff %}
-                <span class="text-success">Recommended: Please email your VP. <a href="https://experimenter.info/vp-sign-off/">Learn More</a></span>
-              {% endif %}
-            </td>
-          </tr>
-          <tr>
-            <th>Legal Sign-off</th>
-            <td>
-              {% if experiment.legal_signoff %}
-                <i class="fa fa-check-circle text-success"></i>
-              {% else %}
-                <i class="fa fa-times-circle text-danger"></i>
-              {% endif %}
-              {% if experiment.signoff_recommendations.legal_signoff %}
-                <span class="text-success">Recommended: Please email legal. <a href="https://experimenter.info/legal-sign-off/">Learn More</a></span>
-              {% endif %}
-            </td>
-          </tr>
-        </tbody>
-      </table>
+      <a class="btn btn-outline-primary btn-sm"
+         hx-get="{% url 'update-signoff' experiment.slug %}"
+         hx-target="#signoff"
+         hx-swap="outerHTML">Edit</a>
     {% endif %}
   </div>
-</div>
+  <div class="card-body p-0">
+    <div class="container">
+      <div class="row py-2">
+        <div class="col-md-2">
+          <strong>QA Signoff</strong>
+        </div>
+        <div class="col-md-10 d-flex align-items-center">
+          {% if edit %}
+            {{ form.qa_signoff }}
+          {% else %}
+            {% if experiment.qa_signoff %}
+              <i class="fa fa-check-circle text-success"></i>
+            {% else %}
+              <i class="fa fa-times-circle text-danger"></i>
+            {% endif %}
+          {% endif %}
+          {% if experiment.signoff_recommendations.qa_signoff %}
+            <span class="text-success ms-3">Recommended: Please file a QA request. <a href="#">Learn More</a></span>
+          {% endif %}
+        </div>
+      </div>
+      <div class="row py-2">
+        <div class="col-md-2">
+          <strong>VP Signoff</strong>
+        </div>
+        <div class="col-md-10 d-flex align-items-center">
+          {% if edit %}
+            {{ form.vp_signoff }}
+          {% else %}
+            {% if experiment.vp_signoff %}
+              <i class="fa fa-check-circle text-success"></i>
+            {% else %}
+              <i class="fa fa-times-circle text-danger"></i>
+            {% endif %}
+          {% endif %}
+          {% if experiment.signoff_recommendations.vp_signoff %}
+            <span class="text-success ms-3">Recommended: Please email your VP. <a href="#">Learn More</a></span>
+          {% endif %}
+        </div>
+      </div>
+      <div class="row py-2">
+        <div class="col-md-2">
+          <strong>Legal Signoff</strong>
+        </div>
+        <div class="col-md-10 d-flex align-items-center">
+          {% if edit %}
+            {{ form.legal_signoff }}
+          {% else %}
+            {% if experiment.legal_signoff %}
+              <i class="fa fa-check-circle text-success"></i>
+            {% else %}
+              <i class="fa fa-times-circle text-danger"></i>
+            {% endif %}
+          {% endif %}
+          {% if experiment.signoff_recommendations.legal_signoff %}
+            <span class="text-success ms-3">Recommended: Please email legal. <a href="#">Learn More</a></span>
+          {% endif %}
+        </div>
+      </div>
+    </div>
+  </div>
+</form>

--- a/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/signoff_card.html
+++ b/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/signoff_card.html
@@ -1,0 +1,94 @@
+<div class="card mb-3">
+  <div class="card-header d-flex justify-content-between align-items-center">
+    <h4 class="mb-0">Sign-offs</h4>
+    {% if not signoff_edit_mode %}
+      <button class="btn btn-outline-primary btn-sm"
+              hx-get="{% url 'nimbus-new-detail' experiment.slug %}?edit_signoff=true"
+              hx-target="body"
+              hx-swap="outerHTML">Edit</button>
+    {% endif %}
+  </div>
+  <div class="card-body" id="signoff-form-container">
+    {% if signoff_edit_mode %}
+      <form method="post"
+            hx-post="{% url 'update-signoff' experiment.slug %}"
+            hx-target="body"
+            hx-swap="outerHTML">
+        {% csrf_token %}
+        <div class="mb-3">
+          <label for="id_qa_signoff">QA Sign-off:</label>
+          {{ signoff_form.qa_signoff }}
+          {% if experiment.signoff_recommendations.qa_signoff %}
+            <span class="text-success">Recommended: Please file a QA request. <a href="#">Learn More</a></span>
+          {% endif %}
+        </div>
+        <div class="mb-3">
+          <label for="id_vp_signoff">VP Sign-off:</label>
+          {{ signoff_form.vp_signoff }}
+          {% if experiment.signoff_recommendations.vp_signoff %}
+            <span class="text-success">Recommended: Please email your VP. <a href="#">Learn More</a></span>
+          {% endif %}
+        </div>
+        <div class="mb-3">
+          <label for="id_legal_signoff">Legal Sign-off:</label>
+          {{ signoff_form.legal_signoff }}
+          {% if experiment.signoff_recommendations.legal_signoff %}
+            <span class="text-success">Recommended: Please email legal. <a href="#">Learn More</a></span>
+          {% endif %}
+        </div>
+        <div class="d-flex justify-content-end mt-3">
+          <button type="submit" class="btn btn-primary me-2">Save</button>
+          <button type="button"
+                  class="btn btn-secondary"
+                  hx-get="{% url 'nimbus-new-detail' experiment.slug %}"
+                  hx-target="body"
+                  hx-swap="outerHTML">Cancel</button>
+        </div>
+      </form>
+    {% else %}
+      <table class="table table-striped">
+        <tbody>
+          <tr>
+            <th>QA Sign-off</th>
+            <td>
+              {% if experiment.qa_signoff %}
+                <i class="fa fa-check-circle text-success"></i>
+              {% else %}
+                <i class="fa fa-times-circle text-danger"></i>
+              {% endif %}
+              {% if experiment.signoff_recommendations.qa_signoff %}
+                <span class="text-success">Recommended: Please file a QA request. <a href="https://experimenter.info/qa-sign-off/">Learn More</a></span>
+              {% endif %}
+            </td>
+          </tr>
+          <tr>
+            <th>VP Sign-off</th>
+            <td>
+              {% if experiment.vp_signoff %}
+                <i class="fa fa-check-circle text-success"></i>
+              {% else %}
+                <i class="fa fa-times-circle text-danger"></i>
+              {% endif %}
+              {% if experiment.signoff_recommendations.vp_signoff %}
+                <span class="text-success">Recommended: Please email your VP. <a href="https://experimenter.info/vp-sign-off/">Learn More</a></span>
+              {% endif %}
+            </td>
+          </tr>
+          <tr>
+            <th>Legal Sign-off</th>
+            <td>
+              {% if experiment.legal_signoff %}
+                <i class="fa fa-check-circle text-success"></i>
+              {% else %}
+                <i class="fa fa-times-circle text-danger"></i>
+              {% endif %}
+              {% if experiment.signoff_recommendations.legal_signoff %}
+                <span class="text-success">Recommended: Please email legal. <a href="https://experimenter.info/legal-sign-off/">Learn More</a></span>
+              {% endif %}
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    {% endif %}
+  </div>
+</div>

--- a/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/update_signoff.html
+++ b/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/update_signoff.html
@@ -1,0 +1,1 @@
+{% include "nimbus_experiments/signoff_card.html" with edit=True experiment=experiment form=form %}

--- a/experimenter/experimenter/nimbus_ui_new/tests/test_forms.py
+++ b/experimenter/experimenter/nimbus_ui_new/tests/test_forms.py
@@ -7,6 +7,7 @@ from experimenter.nimbus_ui_new.constants import NimbusUIConstants
 from experimenter.nimbus_ui_new.forms import (
     NimbusExperimentCreateForm,
     QAStatusForm,
+    SignoffForm,
     TakeawaysForm,
 )
 from experimenter.openidc.tests.factories import UserFactory
@@ -152,3 +153,44 @@ class TestTakeawaysForm(RequestFormTestCase):
             changelog.message,
             "dev@example.com updated takeaways",
         )
+
+
+class TestSignoffForm(RequestFormTestCase):
+    def setUp(self):
+        super().setUp()
+        self.experiment = NimbusExperimentFactory.create(
+            name="Test Experiment",
+            owner=self.user,
+            qa_signoff=False,
+            vp_signoff=False,
+            legal_signoff=False,
+        )
+
+    def test_signoff_form_valid(self):
+        data = {
+            "qa_signoff": True,
+            "vp_signoff": True,
+            "legal_signoff": False,
+        }
+        form = SignoffForm(data=data, instance=self.experiment, request=self.request)
+        self.assertTrue(form.is_valid(), form.errors)
+
+        experiment = form.save()
+        self.assertTrue(experiment.qa_signoff)
+        self.assertTrue(experiment.vp_signoff)
+        self.assertFalse(experiment.legal_signoff)
+
+    def test_signoff_form_saves_to_changelog(self):
+        """Test that saving the form also creates an entry in the changelog."""
+        data = {
+            "qa_signoff": True,
+            "vp_signoff": True,
+            "legal_signoff": True,
+        }
+        form = SignoffForm(data=data, instance=self.experiment, request=self.request)
+        self.assertTrue(form.is_valid())
+        experiment = form.save()
+
+        changelog = experiment.changes.get()
+        self.assertEqual(changelog.changed_by, self.user)
+        self.assertIn("updated QA signoff, VP signoff, Legal signoff", changelog.message)

--- a/experimenter/experimenter/nimbus_ui_new/tests/test_forms.py
+++ b/experimenter/experimenter/nimbus_ui_new/tests/test_forms.py
@@ -193,4 +193,4 @@ class TestSignoffForm(RequestFormTestCase):
 
         changelog = experiment.changes.get()
         self.assertEqual(changelog.changed_by, self.user)
-        self.assertIn("updated QA signoff, VP signoff, Legal signoff", changelog.message)
+        self.assertIn("dev@example.com updated sign off", changelog.message)

--- a/experimenter/experimenter/nimbus_ui_new/tests/test_views.py
+++ b/experimenter/experimenter/nimbus_ui_new/tests/test_views.py
@@ -1058,14 +1058,6 @@ class NimbusExperimentDetailViewTest(AuthTestCase):
         self.assertIsInstance(response.context["takeaways_form"], TakeawaysForm)
         self.assertFalse(response.context["takeaways_form"].is_valid())
 
-    def test_signoff_edit_mode_get(self):
-        response = self.client.get(
-            reverse("nimbus-new-detail", kwargs={"slug": self.experiment.slug}),
-            {"edit_signoff": "true"},
-        )
-        self.assertEqual(response.status_code, 200)
-        self.assertTrue(response.context["signoff_edit_mode"])
-        self.assertIsInstance(response.context["signoff_form"], SignoffForm)
 
     def test_signoff_edit_mode_post_valid_form(self):
         data = {

--- a/experimenter/experimenter/nimbus_ui_new/tests/test_views.py
+++ b/experimenter/experimenter/nimbus_ui_new/tests/test_views.py
@@ -17,7 +17,7 @@ from experimenter.experiments.tests.factories import (
     NimbusFeatureConfigFactory,
 )
 from experimenter.nimbus_ui_new.filtersets import SortChoices, TypeChoices
-from experimenter.nimbus_ui_new.forms import QAStatusForm, TakeawaysForm
+from experimenter.nimbus_ui_new.forms import QAStatusForm, SignoffForm, TakeawaysForm
 from experimenter.nimbus_ui_new.views import StatusChoices
 from experimenter.openidc.tests.factories import UserFactory
 from experimenter.projects.tests.factories import ProjectFactory
@@ -1057,6 +1057,31 @@ class NimbusExperimentDetailViewTest(AuthTestCase):
         self.assertTrue(response.context["takeaways_edit_mode"])
         self.assertIsInstance(response.context["takeaways_form"], TakeawaysForm)
         self.assertFalse(response.context["takeaways_form"].is_valid())
+
+    def test_signoff_edit_mode_get(self):
+        response = self.client.get(
+            reverse("nimbus-new-detail", kwargs={"slug": self.experiment.slug}),
+            {"edit_signoff": "true"},
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.context["signoff_edit_mode"])
+        self.assertIsInstance(response.context["signoff_form"], SignoffForm)
+
+    def test_signoff_edit_mode_post_valid_form(self):
+        data = {
+            "qa_signoff": True,
+            "vp_signoff": True,
+            "legal_signoff": True,
+        }
+        response = self.client.post(
+            reverse("update-signoff", kwargs={"slug": self.experiment.slug}),
+            data,
+        )
+        self.assertEqual(response.status_code, 302)
+        self.experiment.refresh_from_db()
+        self.assertTrue(self.experiment.qa_signoff)
+        self.assertTrue(self.experiment.vp_signoff)
+        self.assertTrue(self.experiment.legal_signoff)
 
 
 class TestNimbusExperimentsCreateView(AuthTestCase):

--- a/experimenter/experimenter/nimbus_ui_new/tests/test_views.py
+++ b/experimenter/experimenter/nimbus_ui_new/tests/test_views.py
@@ -17,7 +17,7 @@ from experimenter.experiments.tests.factories import (
     NimbusFeatureConfigFactory,
 )
 from experimenter.nimbus_ui_new.filtersets import SortChoices, TypeChoices
-from experimenter.nimbus_ui_new.forms import QAStatusForm, SignoffForm, TakeawaysForm
+from experimenter.nimbus_ui_new.forms import QAStatusForm, TakeawaysForm
 from experimenter.nimbus_ui_new.views import StatusChoices
 from experimenter.openidc.tests.factories import UserFactory
 from experimenter.projects.tests.factories import ProjectFactory
@@ -1057,7 +1057,6 @@ class NimbusExperimentDetailViewTest(AuthTestCase):
         self.assertTrue(response.context["takeaways_edit_mode"])
         self.assertIsInstance(response.context["takeaways_form"], TakeawaysForm)
         self.assertFalse(response.context["takeaways_form"].is_valid())
-
 
     def test_signoff_edit_mode_post_valid_form(self):
         data = {

--- a/experimenter/experimenter/nimbus_ui_new/urls.py
+++ b/experimenter/experimenter/nimbus_ui_new/urls.py
@@ -6,6 +6,7 @@ from experimenter.nimbus_ui_new.views import (
     NimbusExperimentsCreateView,
     NimbusExperimentsListTableView,
     QAStatusUpdateView,
+    SignoffUpdateView,
     TakeawaysUpdateView,
 )
 
@@ -34,6 +35,11 @@ urlpatterns = [
         r"^(?P<slug>[\w-]+)/update_takeaways/$",
         TakeawaysUpdateView.as_view(),
         name="update-takeaways",
+    ),
+    re_path(
+        r"^(?P<slug>[\w-]+)/update_signoff/$",
+        SignoffUpdateView.as_view(),
+        name="update-signoff",
     ),
     re_path(
         r"^create/",

--- a/experimenter/experimenter/nimbus_ui_new/views.py
+++ b/experimenter/experimenter/nimbus_ui_new/views.py
@@ -123,14 +123,11 @@ class NimbusExperimentDetailView(DetailView):
         context.update(experiment_context)
         context["qa_edit_mode"] = self.request.GET.get("edit_qa_status") == "true"
         context["takeaways_edit_mode"] = self.request.GET.get("edit_takeaways") == "true"
-        context["signoff_edit_mode"] = self.request.GET.get("edit_signoff") == "true"
 
         if context["qa_edit_mode"]:
             context["form"] = QAStatusForm(instance=self.object)
         if context["takeaways_edit_mode"]:
             context["takeaways_form"] = TakeawaysForm(instance=self.object)
-        if context["signoff_edit_mode"]:
-            context["signoff_form"] = SignoffForm(instance=self.object)
         return context
 
 

--- a/experimenter/experimenter/nimbus_ui_new/views.py
+++ b/experimenter/experimenter/nimbus_ui_new/views.py
@@ -123,7 +123,6 @@ class NimbusExperimentDetailView(DetailView):
         context.update(experiment_context)
         context["qa_edit_mode"] = self.request.GET.get("edit_qa_status") == "true"
         context["takeaways_edit_mode"] = self.request.GET.get("edit_takeaways") == "true"
-
         if context["qa_edit_mode"]:
             context["form"] = QAStatusForm(instance=self.object)
         if context["takeaways_edit_mode"]:

--- a/experimenter/experimenter/nimbus_ui_new/views.py
+++ b/experimenter/experimenter/nimbus_ui_new/views.py
@@ -16,6 +16,7 @@ from experimenter.nimbus_ui_new.filtersets import (
 from experimenter.nimbus_ui_new.forms import (
     NimbusExperimentCreateForm,
     QAStatusForm,
+    SignoffForm,
     TakeawaysForm,
 )
 
@@ -122,10 +123,14 @@ class NimbusExperimentDetailView(DetailView):
         context.update(experiment_context)
         context["qa_edit_mode"] = self.request.GET.get("edit_qa_status") == "true"
         context["takeaways_edit_mode"] = self.request.GET.get("edit_takeaways") == "true"
+        context["signoff_edit_mode"] = self.request.GET.get("edit_signoff") == "true"
+
         if context["qa_edit_mode"]:
             context["form"] = QAStatusForm(instance=self.object)
         if context["takeaways_edit_mode"]:
             context["takeaways_form"] = TakeawaysForm(instance=self.object)
+        if context["signoff_edit_mode"]:
+            context["signoff_form"] = SignoffForm(instance=self.object)
         return context
 
 
@@ -159,6 +164,15 @@ class TakeawaysUpdateView(RequestFormMixin, UpdateView):
         context["takeaways_edit_mode"] = True
         context["takeaways_form"] = form
         return self.render_to_response(context)
+
+    def get_success_url(self):
+        return reverse("nimbus-new-detail", kwargs={"slug": self.object.slug})
+
+
+class SignoffUpdateView(RequestFormMixin, UpdateView):
+    model = NimbusExperiment
+    form_class = SignoffForm
+    template_name = "nimbus_experiments/signoff_card.html"
 
     def get_success_url(self):
         return reverse("nimbus-new-detail", kwargs={"slug": self.object.slug})

--- a/experimenter/experimenter/nimbus_ui_new/views.py
+++ b/experimenter/experimenter/nimbus_ui_new/views.py
@@ -172,7 +172,8 @@ class TakeawaysUpdateView(RequestFormMixin, UpdateView):
 class SignoffUpdateView(RequestFormMixin, UpdateView):
     model = NimbusExperiment
     form_class = SignoffForm
-    template_name = "nimbus_experiments/signoff_card.html"
+    template_name = "nimbus_experiments/update_signoff.html"
+    context_object_name = "experiment"
 
     def get_success_url(self):
         return reverse("nimbus-new-detail", kwargs={"slug": self.object.slug})


### PR DESCRIPTION
Because

- We want to record the action of sign-off recommendations on the new summary page

This commit

- Record sign-off actions taken or not

Fixes #11344 
<img width="1429" alt="Screenshot 2024-09-12 at 7 50 04 PM" src="https://github.com/user-attachments/assets/936beb4d-706a-4b81-a3f5-6d65b12f9165">
<img width="1429" alt="Screenshot 2024-09-12 at 7 46 12 PM" src="https://github.com/user-attachments/assets/b37b48ae-23c0-48e4-8e3e-65e9658ea0fa">

