### PR TITLE
chore(ci): Change external firefox integration test job to run once per day.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -717,6 +717,16 @@ workflows:
     jobs:
       - update_external_configs
       - update_application_services
+  
+  check_firefox_integrations:
+    triggers:
+      - schedule:
+          cron: "0 12 * * *"
+          filters:
+            branches:
+              only:
+                - main
+    jobs:
       - check_external_firefox_integrations
 
   build:


### PR DESCRIPTION
Because

- We have noticed a lot of PRs back to back with regards to our external firefox integration job. Firefox Beta on Desktop specifically has a decent number of daily builds.

This commit

- Reduces the amount of times this job is run on CI to once per day.

Fixes #11350 