### PR TITLE
fix(cirrus): Run cirrus pytest in verbose mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -241,7 +241,7 @@ CIRRUS_BLACK_CHECK = black -l 90 --check --diff .
 CIRRUS_BLACK_FIX = black -l 90 .
 CIRRUS_RUFF_CHECK = ruff check .
 CIRRUS_RUFF_FIX = ruff check --fix .
-CIRRUS_PYTEST = pytest . --cov-config=.coveragerc --cov=cirrus
+CIRRUS_PYTEST = pytest . --cov-config=.coveragerc --cov=cirrus -v
 CIRRUS_PYTHON_TYPECHECK = pyright -p .
 CIRRUS_PYTHON_TYPECHECK_CREATESTUB = pyright -p . --createstub cirrus
 CIRRUS_GENERATE_DOCS = python cirrus/generate_docs.py


### PR DESCRIPTION
Because

- To make it easier to identify failing tests

This commit

- make cirrus pytest tests run in verbose mode

Fixes #9148 