### PR TITLE
chore(ci): Fix branch name in external integration script.

### DIFF
--- a/scripts/external_integration_updater_script.sh
+++ b/scripts/external_integration_updater_script.sh
@@ -18,7 +18,7 @@ if (($(git status --porcelain | wc -c) > 0)); then
     git add .
     git commit -m "chore(nimbus): Check external firefox integrations and update keys"
     git push origin -f check_external_firefox_integrations
-    gh pr create -t "chore(nimbus): Check external firefox integrations and update keys" -b "" --base main --head check-external-firefox-integrations --repo mozilla/experimenter || echo "PR already exists, skipping"
+    gh pr create -t "chore(nimbus): Check external firefox integrations and update keys" -b "" --base main --head check_external_firefox_integrations --repo mozilla/experimenter || echo "PR already exists, skipping"
 else
     echo "No config changes, skipping"
 fi

--- a/scripts/external_integration_updater_script.sh
+++ b/scripts/external_integration_updater_script.sh
@@ -2,7 +2,7 @@
 
 git checkout main
 git pull origin main
-git checkout -B check-external-firefox-integrations
+git checkout -B check_external_firefox_integrations
 firefox_types=("fenix" "desktop-beta")
 for name in "${firefox_types[@]}"
 do


### PR DESCRIPTION
Because

- The branch that was being created did not match the branch being pushed within our external integration script

This commit

- Fixes the branch names

Fixes #11363 