### PR TITLE
feat(nimbus): Summary page timeline

### DIFF
--- a/experimenter/experimenter/experiments/models.py
+++ b/experimenter/experimenter/experiments/models.py
@@ -1256,9 +1256,6 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
 
     @property
     def preview_date(self):
-        """
-        Finds the first changelog entry where the status changed to 'PREVIEW'.
-        """
         preview_changelog = (
             self.changes.filter(new_status=self.Status.PREVIEW)
             .order_by("changed_on")

--- a/experimenter/experimenter/experiments/models.py
+++ b/experimenter/experimenter/experiments/models.py
@@ -613,8 +613,53 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
         return list(branches)
 
     @property
+    def is_draft(self):
+        return self.status == self.Status.DRAFT
+
+    @property
+    def is_review(self):
+        return self.is_draft and self.publish_status == self.PublishStatus.REVIEW
+
+    @property
+    def is_preview(self):
+        return self.status == self.Status.PREVIEW
+
+    @property
+    def is_live(self):
+        return self.status == self.Status.LIVE
+
+    @property
+    def is_complete(self):
+        return self.status == self.Status.COMPLETE
+
+    @property
     def is_started(self):
         return self.status in (self.Status.LIVE, self.Status.COMPLETE)
+
+    @property
+    def draft_date(self):
+        if change := self.changes.all().order_by("changed_on").first():
+            return change.changed_on.date()
+
+    @property
+    def preview_date(self):
+        if change := (
+            self.changes.filter(new_status=self.Status.PREVIEW)
+            .order_by("changed_on")
+            .first()
+        ):
+            return change.changed_on.date()
+
+    @property
+    def review_date(self):
+        if change := (
+            self.changes.filter(
+                new_status=self.Status.DRAFT, new_publish_status=self.PublishStatus.REVIEW
+            )
+            .order_by("changed_on")
+            .first()
+        ):
+            return change.changed_on.date()
 
     @property
     def start_date(self):
@@ -746,6 +791,35 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
         if self.computed_end_date and self.enrollment_start_date is not None:
             return (self.computed_end_date - self.enrollment_start_date).days
         return self.proposed_duration
+
+    def timeline(self):
+        return [
+            {
+                "label": self.Status.DRAFT,
+                "date": self.draft_date,
+                "is_active": self.is_draft,
+            },
+            {
+                "label": self.Status.PREVIEW,
+                "date": self.preview_date,
+                "is_active": self.is_preview,
+            },
+            {
+                "label": self.PublishStatus.REVIEW,
+                "date": self.review_date,
+                "is_active": self.is_review,
+            },
+            {
+                "label": self.Status.LIVE,
+                "date": self.start_date,
+                "is_active": self.is_live,
+            },
+            {
+                "label": self.Status.COMPLETE,
+                "date": self.computed_end_date,
+                "is_active": self.is_complete,
+            },
+        ]
 
     @property
     def should_end(self):
@@ -1247,29 +1321,6 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
             )
             .replace("&&", "\n&&")  # Add helpful newlines to targeting
             .replace("\\n", "\n")  # Handle hard coded newlines in targeting
-        )
-
-    def get_changelog_date(self, status_field=None, status_value=None):
-        queryset = self.changes.order_by("changed_on")
-        if status_field and status_value:
-            queryset = queryset.filter(**{status_field: status_value})
-        changelog = queryset.first()
-        return changelog.changed_on.date() if changelog else None
-
-    @property
-    def draft_date(self):
-        return self.get_changelog_date()
-
-    @property
-    def preview_date(self):
-        return self.get_changelog_date(
-            status_field="new_status", status_value=self.Status.PREVIEW
-        )
-
-    @property
-    def review_date(self):
-        return self.get_changelog_date(
-            status_field="new_publish_status", status_value=self.PublishStatus.REVIEW
         )
 
 

--- a/experimenter/experimenter/experiments/models.py
+++ b/experimenter/experimenter/experiments/models.py
@@ -1249,6 +1249,23 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
             .replace("\\n", "\n")  # Handle hard coded newlines in targeting
         )
 
+    @property
+    def draft_date(self):
+        first_changelog_entry = self.changes.order_by("changed_on").first()
+        return first_changelog_entry.changed_on.date() if first_changelog_entry else None
+
+    @property
+    def preview_date(self):
+        """
+        Finds the first changelog entry where the status changed to 'PREVIEW'.
+        """
+        preview_changelog = (
+            self.changes.filter(new_status=self.Status.PREVIEW)
+            .order_by("changed_on")
+            .first()
+        )
+        return preview_changelog.changed_on.date() if preview_changelog else None
+
 
 class NimbusBranch(models.Model):
     experiment = models.ForeignKey(

--- a/experimenter/experimenter/experiments/tests/test_models.py
+++ b/experimenter/experimenter/experiments/tests/test_models.py
@@ -1640,6 +1640,33 @@ class TestNimbusExperiment(TestCase):
             ),
         )
 
+    def test_draft_date_uses_first_changelog_if_no_start_date(self):
+        experiment = NimbusExperimentFactory.create(_start_date=None)
+        first_changelog = NimbusChangeLogFactory.create(
+            experiment=experiment, changed_on=datetime.datetime(2023, 2, 1)
+        )
+        self.assertEqual(experiment.draft_date, first_changelog.changed_on.date())
+
+    def test_preview_date_returns_first_preview_change(self):
+        experiment = NimbusExperimentFactory.create()
+        preview_change = NimbusChangeLogFactory.create(
+            experiment=experiment,
+            old_status=NimbusExperiment.Status.DRAFT,
+            new_status=NimbusExperiment.Status.PREVIEW,
+            changed_on=datetime.datetime(2023, 3, 1),
+        )
+        self.assertEqual(experiment.preview_date, preview_change.changed_on.date())
+
+    def test_preview_date_returns_none_if_no_preview_status(self):
+        experiment = NimbusExperimentFactory.create()
+        NimbusChangeLogFactory.create(
+            experiment=experiment,
+            old_status=NimbusExperiment.Status.DRAFT,
+            new_status=NimbusExperiment.Status.DRAFT,
+            changed_on=datetime.datetime(2023, 4, 1),
+        )
+        self.assertIsNone(experiment.preview_date)
+
     def test_monitoring_dashboard_url_is_valid_when_experiment_not_begun(self):
         experiment = NimbusExperimentFactory.create(
             slug="experiment",

--- a/experimenter/experimenter/experiments/tests/test_models.py
+++ b/experimenter/experimenter/experiments/tests/test_models.py
@@ -1667,6 +1667,26 @@ class TestNimbusExperiment(TestCase):
         )
         self.assertIsNone(experiment.preview_date)
 
+    def test_review_date_returns_first_review_change(self):
+        experiment = NimbusExperimentFactory.create()
+        review_change = NimbusChangeLogFactory.create(
+            experiment=experiment,
+            old_publish_status=NimbusExperiment.Status.PREVIEW,
+            new_publish_status=NimbusExperiment.PublishStatus.REVIEW,
+            changed_on=datetime.datetime(2023, 5, 1),
+        )
+        self.assertEqual(experiment.review_date, review_change.changed_on.date())
+
+    def test_review_date_returns_none_if_no_review_status(self):
+        experiment = NimbusExperimentFactory.create()
+        NimbusChangeLogFactory.create(
+            experiment=experiment,
+            old_publish_status=NimbusExperiment.Status.DRAFT,
+            new_publish_status=NimbusExperiment.Status.PREVIEW,
+            changed_on=datetime.datetime(2023, 6, 1),
+        )
+        self.assertIsNone(experiment.review_date)
+
     def test_monitoring_dashboard_url_is_valid_when_experiment_not_begun(self):
         experiment = NimbusExperimentFactory.create(
             slug="experiment",

--- a/experimenter/experimenter/nimbus_ui_new/static/css/style.scss
+++ b/experimenter/experimenter/nimbus_ui_new/static/css/style.scss
@@ -58,6 +58,9 @@
       }
     }
   }
+  .mode-sensitive {
+    background-color: var(--bg-light-color);
+  }
 }
 
 @include color-mode(dark) {
@@ -116,5 +119,9 @@
         }
       }
     }
+  }
+  .mode-sensitive {
+    background-color: var(--bs-secondary);
+    /* Bootstrap's secondary color */
   }
 }

--- a/experimenter/experimenter/nimbus_ui_new/static/css/style.scss
+++ b/experimenter/experimenter/nimbus_ui_new/static/css/style.scss
@@ -58,9 +58,6 @@
       }
     }
   }
-  .mode-sensitive {
-    background-color: var(--bg-light-color);
-  }
 }
 
 @include color-mode(dark) {
@@ -119,9 +116,5 @@
         }
       }
     }
-  }
-  .mode-sensitive {
-    background-color: var(--bs-secondary);
-    /* Bootstrap's secondary color */
   }
 }

--- a/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/detail.html
+++ b/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/detail.html
@@ -8,20 +8,13 @@
 {% block main_content %}
   <div class="container-fluid">
     <!-- Experiment Details Card -->
-    <div class="card mb-3">
-      <div class="card-header">
-        <h4>Experiment Details</h4>
+    <div class="row">
+      <div class="col-4">
+        <h4 class="mb-0">{{ experiment.name }}</h4>
+        <p class="text-secondary">{{ experiment.slug }}</p>
       </div>
-      <div class="card-body">
-        {% include "nimbus_experiments/timeline.html" %}
+      {% include "nimbus_experiments/timeline.html" %}
 
-        <p>
-          <strong>Slug:</strong> {{ experiment.slug }}
-        </p>
-        <p>
-          <strong>Name:</strong> {{ experiment.name }}
-        </p>
-      </div>
     </div>
     <!-- Takeaways Card -->
     {% include "nimbus_experiments/takeaways_card.html" %}

--- a/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/detail.html
+++ b/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/detail.html
@@ -9,7 +9,7 @@
   <div class="container-fluid">
     <!-- Experiment Details Card -->
     <div class="row">
-      <div class="col-4">
+      <div class="col-6">
         <h4 class="mb-0">{{ experiment.name }}</h4>
         <p class="text-secondary">{{ experiment.slug }}</p>
       </div>

--- a/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/detail.html
+++ b/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/detail.html
@@ -13,6 +13,8 @@
         <h4>Experiment Details</h4>
       </div>
       <div class="card-body">
+        {% include "nimbus_experiments/timeline.html" %}
+
         <p>
           <strong>Slug:</strong> {{ experiment.slug }}
         </p>

--- a/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/timeline.html
+++ b/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/timeline.html
@@ -1,29 +1,29 @@
 <div class="col-8">
   <ul class="list-group list-group-horizontal justify-content-between mb-3">
     <!-- Draft Status -->
-    <li class="list-group-item flex-fill text-center d-flex flex-column justify-content-center {% if experiment.status == 'Draft'  and experiment.publish_status == 'Idle' %} bg-primary text-white {% else %} bg-light text-muted {% endif %}">
+    <li class="list-group-item flex-fill text-center d-flex flex-column justify-content-center {% if experiment.status == 'Draft' and experiment.publish_status == 'Idle' %} bg-primary text-light {% else %} mode-sensitive text-dark {% endif %}">
       <strong>Draft</strong>
-      <small class="{% if experiment.status == 'Draft' %}text-white{% else %}text-secondary{% endif %}">{{ experiment.draft_date|default:'---' }}</small>
+      <small>{{ experiment.draft_date|default:'---' }}</small>
     </li>
     <!-- Preview Status -->
-    <li class="list-group-item flex-fill text-center d-flex flex-column justify-content-center {% if experiment.status == 'Preview'  and experiment.publish_status == 'Idle' %} bg-warning text-white {% else %} bg-light text-muted {% endif %}">
+    <li class="list-group-item flex-fill text-center d-flex flex-column justify-content-center {% if experiment.status == 'Preview' and experiment.publish_status == 'Idle' %} bg-primary text-light {% else %} mode-sensitive text-dark {% endif %}">
       <strong>Preview</strong>
-      <small class="{% if experiment.status == 'Preview' %}text-white{% else %}text-secondary{% endif %}">{{ experiment.preview_date|default:'---' }}</small>
+      <small>{{ experiment.preview_date|default:'---' }}</small>
     </li>
     <!-- Review Status -->
-    <li class="list-group-item flex-fill text-center d-flex flex-column justify-content-center {% if experiment.publish_status != 'Idle' %} {% if experiment.status == 'Preview' %} bg-danger text-white {% elif experiment.status == 'Draft' %} bg-danger text-white {% else %} bg-light text-muted {% endif %} {% else %} bg-light text-muted {% endif %}">
+    <li class="list-group-item flex-fill text-center d-flex flex-column justify-content-center {% if experiment.publish_status != 'Idle' %} {% if experiment.status == 'Preview' or experiment.status == 'Draft' %} bg-primary text-light {% else %} mode-sensitive text-dark {% endif %} {% else %} mode-sensitive text-dark {% endif %}">
       <strong>Review</strong>
-      <small class="{% if experiment.publish_status != 'Idle' and experiment.status == 'Preview' %}text-white{% elif experiment.publish_status != 'Idle' and experiment.status == 'Draft' %}text-white{% else %}text-secondary{% endif %}">{{ experiment.review_date|default:'---' }}</small>
+      <small>{{ experiment.review_date|default:'---' }}</small>
     </li>
     <!-- Live Status -->
-    <li class="list-group-item flex-fill text-center d-flex flex-column justify-content-center {% if experiment.status == 'Live' %} bg-success text-white {% else %} bg-light text-muted {% endif %}">
+    <li class="list-group-item flex-fill text-center d-flex flex-column justify-content-center {% if experiment.status == 'Live' %} bg-primary text-light {% else %} mode-sensitive text-dark {% endif %}">
       <strong>Live</strong>
-      <small class="{% if experiment.status == 'Live' %}text-white{% else %}text-secondary{% endif %}">{{ experiment.start_date|default:'---' }}</small>
+      <small>{{ experiment.start_date|default:'---' }}</small>
     </li>
     <!-- Complete Status -->
-    <li class="list-group-item flex-fill text-center d-flex flex-column justify-content-center {% if experiment.status == 'Complete' %} bg-secondary text-white {% else %} bg-light text-muted {% endif %}">
+    <li class="list-group-item flex-fill text-center d-flex flex-column justify-content-center {% if experiment.status == 'Complete' %} bg-primary text-light {% else %} mode-sensitive text-dark {% endif %}">
       <strong>Complete</strong>
-      <small class="{% if experiment.status == 'Complete' %}text-white{% else %}text-secondary{% endif %}">{{ experiment.end_date|default:'---' }}</small>
+      <small>{{ experiment.end_date|default:'---' }}</small>
     </li>
   </ul>
 </div>

--- a/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/timeline.html
+++ b/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/timeline.html
@@ -1,25 +1,29 @@
-<div class="container-fluid py-4">
-  <!-- Timeline Row -->
-  <div class="d-flex align-items-center justify-content-between position-relative">
+<!-- Timeline Row -->
+<div class="col-8">
+  <ul class="list-group list-group-horizontal justify-content-end mb-3">
     <!-- Draft Status -->
-    <div class="border border-dark rounded p-3 text-center flex-grow-1 mx-2 {% if experiment.status == 'Draft' %}bg-primary text-white{% else %}bg-light{% endif %}">
-      <h5>Draft</h5>
-      <div>{{ experiment.draft_date|default:'---' }}</div>
-    </div>
+    <li class="list-group-item flex-fill text-center {% if experiment.status == 'Draft' and experiment.publish_status == 'Idle' %}bg-info text-white{% else %}bg-light{% endif %}">
+      <strong>Draft</strong>
+      <p class="m-0 p-0 text-secondary small">{{ experiment.draft_date|default:'---' }}</p>
+    </li>
     <!-- Preview Status -->
-    <div class="border border-dark rounded p-3 text-center flex-grow-1 mx-2 {% if experiment.status == 'Preview' %}bg-warning text-white{% else %}bg-light{% endif %}">
-      <h5>Preview</h5>
-      <div>{{ experiment.preview_date|default:'---' }}</div>
-    </div>
+    <li class="list-group-item flex-fill text-center {% if experiment.status == 'Preview' and experiment.publish_status == 'Idle' %}bg-warning text-white{% else %}bg-light{% endif %}">
+      <strong>Preview</strong>
+      <p class="m-0 p-0 text-secondary small">{{ experiment.preview_date|default:'---' }}</p>
+    </li>
+    <li class="list-group-item flex-fill text-center {% if experiment.publish_status != 'Idle' %}{% if experiment.status == 'Preview' or experiment.status == 'Draft' %}bg-danger text-white{% else %}bg-light{% endif %}{% endif %}">
+      <strong>Review</strong>
+      <p class="m-0 p-0 text-secondary small">{{ experiment.review_date|default:'---' }}</p>
+    </li>
     <!-- Live Status -->
-    <div class="border border-dark rounded p-3 text-center flex-grow-1 mx-2 {% if experiment.status == 'Live' %}bg-success text-white{% else %}bg-light{% endif %}">
-      <h5>Live</h5>
-      <div>{{ experiment.start_date|default:'---' }}</div>
-    </div>
+    <li class="list-group-item flex-fill text-center {% if experiment.status == 'Live' %}bg-success text-white{% else %}bg-light{% endif %}">
+      <strong>Live</strong>
+      <p class="m-0 p-0 text-secondary small">{{ experiment.start_date|default:'---' }}</p>
+    </li>
     <!-- Complete Status -->
-    <div class="border border-dark rounded p-3 text-center flex-grow-1 mx-2 {% if experiment.status == 'Complete' %}bg-info text-white{% else %}bg-light{% endif %}">
-      <h5>Complete</h5>
-      <div>{{ experiment.end_date|default:'---' }}</div>
-    </div>
-  </div>
+    <li class="list-group-item flex-fill text-center {% if experiment.status == 'Complete' %}bg-secondary text-white{% else %}bg-light{% endif %}">
+      <strong>Complete</strong>
+      <p class="m-0 p-0 text-secondary small">{{ experiment.end_date|default:'---' }}</p>
+    </li>
+  </ul>
 </div>

--- a/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/timeline.html
+++ b/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/timeline.html
@@ -1,29 +1,10 @@
 <div class="col-6">
   <ul class="list-group list-group-horizontal justify-content-between mb-3">
-    <!-- Draft Status -->
-    <li class="list-group-item flex-fill text-center d-flex flex-column justify-content-center {% if experiment.status == 'Draft' and experiment.publish_status == 'Idle' %} bg-primary text-light {% else %} mode-sensitive text-dark {% endif %}">
-      <strong>Draft</strong>
-      <small>{{ experiment.draft_date|default:'---' }}</small>
-    </li>
-    <!-- Preview Status -->
-    <li class="list-group-item flex-fill text-center d-flex flex-column justify-content-center {% if experiment.status == 'Preview' and experiment.publish_status == 'Idle' %} bg-primary text-light {% else %} mode-sensitive text-dark {% endif %}">
-      <strong>Preview</strong>
-      <small>{{ experiment.preview_date|default:'---' }}</small>
-    </li>
-    <!-- Review Status -->
-    <li class="list-group-item flex-fill text-center d-flex flex-column justify-content-center {% if experiment.publish_status != 'Idle' %} {% if experiment.status == 'Preview' or experiment.status == 'Draft' %} bg-primary text-light {% else %} mode-sensitive text-dark {% endif %} {% else %} mode-sensitive text-dark {% endif %}">
-      <strong>Review</strong>
-      <small>{{ experiment.review_date|default:'---' }}</small>
-    </li>
-    <!-- Live Status -->
-    <li class="list-group-item flex-fill text-center d-flex flex-column justify-content-center {% if experiment.status == 'Live' %} bg-primary text-light {% else %} mode-sensitive text-dark {% endif %}">
-      <strong>Live</strong>
-      <small>{{ experiment.start_date|default:'---' }}</small>
-    </li>
-    <!-- Complete Status -->
-    <li class="list-group-item flex-fill text-center d-flex flex-column justify-content-center {% if experiment.status == 'Complete' %} bg-primary text-light {% else %} mode-sensitive text-dark {% endif %}">
-      <strong>Complete</strong>
-      <small>{{ experiment.end_date|default:'---' }}</small>
-    </li>
+    {% for status in experiment.timeline %}
+      <li class="list-group-item flex-fill text-center d-flex flex-column justify-content-center {% if status.is_active %}bg-primary text-white{% endif %}">
+        <strong>{{ status.label }}</strong>
+        <small>{{ status.date|default:'---' }}</small>
+      </li>
+    {% endfor %}
   </ul>
 </div>

--- a/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/timeline.html
+++ b/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/timeline.html
@@ -1,0 +1,25 @@
+<div class="container-fluid py-4">
+  <!-- Timeline Row -->
+  <div class="d-flex align-items-center justify-content-between position-relative">
+    <!-- Draft Status -->
+    <div class="border border-dark rounded p-3 text-center flex-grow-1 mx-2 {% if experiment.status == 'Draft' %}bg-primary text-white{% else %}bg-light{% endif %}">
+      <div>Draft</div>
+      <div>{{ experiment.draft_date|default:'---' }}</div>
+    </div>
+    <!-- Preview Status -->
+    <div class="border border-dark rounded p-3 text-center flex-grow-1 mx-2 {% if experiment.status == 'Preview' %}bg-warning text-white{% else %}bg-light{% endif %}">
+      <div>Preview</div>
+      <div>{{ experiment.preview_date|default:'---' }}</div>
+    </div>
+    <!-- Live Status -->
+    <div class="border border-dark rounded p-3 text-center flex-grow-1 mx-2 {% if experiment.status == 'Live' %}bg-success text-white{% else %}bg-light{% endif %}">
+      <div>Live</div>
+      <div>{{ experiment.start_date|default:'---' }}</div>
+    </div>
+    <!-- Complete Status -->
+    <div class="border border-dark rounded p-3 text-center flex-grow-1 mx-2 {% if experiment.status == 'Complete' %}bg-info text-white{% else %}bg-light{% endif %}">
+      <div>Complete</div>
+      <div>{{ experiment.end_date|default:'---' }}</div>
+    </div>
+  </div>
+</div>

--- a/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/timeline.html
+++ b/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/timeline.html
@@ -1,4 +1,4 @@
-<div class="col-8">
+<div class="col-6">
   <ul class="list-group list-group-horizontal justify-content-between mb-3">
     <!-- Draft Status -->
     <li class="list-group-item flex-fill text-center d-flex flex-column justify-content-center {% if experiment.status == 'Draft' and experiment.publish_status == 'Idle' %} bg-primary text-light {% else %} mode-sensitive text-dark {% endif %}">

--- a/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/timeline.html
+++ b/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/timeline.html
@@ -3,22 +3,22 @@
   <div class="d-flex align-items-center justify-content-between position-relative">
     <!-- Draft Status -->
     <div class="border border-dark rounded p-3 text-center flex-grow-1 mx-2 {% if experiment.status == 'Draft' %}bg-primary text-white{% else %}bg-light{% endif %}">
-      <div>Draft</div>
+      <h5>Draft</h5>
       <div>{{ experiment.draft_date|default:'---' }}</div>
     </div>
     <!-- Preview Status -->
     <div class="border border-dark rounded p-3 text-center flex-grow-1 mx-2 {% if experiment.status == 'Preview' %}bg-warning text-white{% else %}bg-light{% endif %}">
-      <div>Preview</div>
+      <h5>Preview</h5>
       <div>{{ experiment.preview_date|default:'---' }}</div>
     </div>
     <!-- Live Status -->
     <div class="border border-dark rounded p-3 text-center flex-grow-1 mx-2 {% if experiment.status == 'Live' %}bg-success text-white{% else %}bg-light{% endif %}">
-      <div>Live</div>
+      <h5>Live</h5>
       <div>{{ experiment.start_date|default:'---' }}</div>
     </div>
     <!-- Complete Status -->
     <div class="border border-dark rounded p-3 text-center flex-grow-1 mx-2 {% if experiment.status == 'Complete' %}bg-info text-white{% else %}bg-light{% endif %}">
-      <div>Complete</div>
+      <h5>Complete</h5>
       <div>{{ experiment.end_date|default:'---' }}</div>
     </div>
   </div>

--- a/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/timeline.html
+++ b/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/timeline.html
@@ -1,29 +1,64 @@
-<!-- Timeline Row -->
 <div class="col-8">
-  <ul class="list-group list-group-horizontal justify-content-end mb-3">
+  <ul class="list-group list-group-horizontal justify-content-between mb-3">
     <!-- Draft Status -->
-    <li class="list-group-item flex-fill text-center {% if experiment.status == 'Draft' and experiment.publish_status == 'Idle' %}bg-info text-white{% else %}bg-light{% endif %}">
+    <li class="list-group-item flex-fill text-center d-flex flex-column justify-content-center 
+        {% if experiment.status == 'Draft'  and experiment.publish_status == 'Idle' %}
+            bg-primary text-white
+        {% else %}
+            bg-light text-muted
+        {% endif %}">
       <strong>Draft</strong>
-      <p class="m-0 p-0 text-secondary small">{{ experiment.draft_date|default:'---' }}</p>
+      <small class="{% if experiment.status == 'Draft' %}text-white{% else %}text-secondary{% endif %}">{{ experiment.draft_date|default:'---' }}</small>
     </li>
+    
     <!-- Preview Status -->
-    <li class="list-group-item flex-fill text-center {% if experiment.status == 'Preview' and experiment.publish_status == 'Idle' %}bg-warning text-white{% else %}bg-light{% endif %}">
+    <li class="list-group-item flex-fill text-center d-flex flex-column justify-content-center 
+        {% if experiment.status == 'Preview'  and experiment.publish_status == 'Idle' %}
+            bg-warning text-white
+        {% else %}
+            bg-light text-muted
+        {% endif %}">
       <strong>Preview</strong>
-      <p class="m-0 p-0 text-secondary small">{{ experiment.preview_date|default:'---' }}</p>
+      <small class="{% if experiment.status == 'Preview' %}text-white{% else %}text-secondary{% endif %}">{{ experiment.preview_date|default:'---' }}</small>
     </li>
-    <li class="list-group-item flex-fill text-center {% if experiment.publish_status != 'Idle' %}{% if experiment.status == 'Preview' or experiment.status == 'Draft' %}bg-danger text-white{% else %}bg-light{% endif %}{% endif %}">
+    
+    <!-- Review Status -->
+    <li class="list-group-item flex-fill text-center d-flex flex-column justify-content-center 
+        {% if experiment.publish_status != 'Idle' %}
+            {% if experiment.status == 'Preview' %}
+                bg-danger text-white
+            {% elif experiment.status == 'Draft' %}
+                bg-danger text-white
+            {% else %}
+                bg-light text-muted
+            {% endif %}
+        {% else %}
+            bg-light text-muted
+        {% endif %}">
       <strong>Review</strong>
-      <p class="m-0 p-0 text-secondary small">{{ experiment.review_date|default:'---' }}</p>
+      <small class="{% if experiment.publish_status != 'Idle' and experiment.status == 'Preview' %}text-white{% elif experiment.publish_status != 'Idle' and experiment.status == 'Draft' %}text-white{% else %}text-secondary{% endif %}">{{ experiment.review_date|default:'---' }}</small>
     </li>
+    
     <!-- Live Status -->
-    <li class="list-group-item flex-fill text-center {% if experiment.status == 'Live' %}bg-success text-white{% else %}bg-light{% endif %}">
+    <li class="list-group-item flex-fill text-center d-flex flex-column justify-content-center 
+        {% if experiment.status == 'Live' %}
+            bg-success text-white
+        {% else %}
+            bg-light text-muted
+        {% endif %}">
       <strong>Live</strong>
-      <p class="m-0 p-0 text-secondary small">{{ experiment.start_date|default:'---' }}</p>
+      <small class="{% if experiment.status == 'Live' %}text-white{% else %}text-secondary{% endif %}">{{ experiment.start_date|default:'---' }}</small>
     </li>
+    
     <!-- Complete Status -->
-    <li class="list-group-item flex-fill text-center {% if experiment.status == 'Complete' %}bg-secondary text-white{% else %}bg-light{% endif %}">
+    <li class="list-group-item flex-fill text-center d-flex flex-column justify-content-center 
+        {% if experiment.status == 'Complete' %}
+            bg-secondary text-white
+        {% else %}
+            bg-light text-muted
+        {% endif %}">
       <strong>Complete</strong>
-      <p class="m-0 p-0 text-secondary small">{{ experiment.end_date|default:'---' }}</p>
+      <small class="{% if experiment.status == 'Complete' %}text-white{% else %}text-secondary{% endif %}">{{ experiment.end_date|default:'---' }}</small>
     </li>
   </ul>
 </div>

--- a/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/timeline.html
+++ b/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/timeline.html
@@ -1,62 +1,27 @@
 <div class="col-8">
   <ul class="list-group list-group-horizontal justify-content-between mb-3">
     <!-- Draft Status -->
-    <li class="list-group-item flex-fill text-center d-flex flex-column justify-content-center 
-        {% if experiment.status == 'Draft'  and experiment.publish_status == 'Idle' %}
-            bg-primary text-white
-        {% else %}
-            bg-light text-muted
-        {% endif %}">
+    <li class="list-group-item flex-fill text-center d-flex flex-column justify-content-center {% if experiment.status == 'Draft'  and experiment.publish_status == 'Idle' %} bg-primary text-white {% else %} bg-light text-muted {% endif %}">
       <strong>Draft</strong>
       <small class="{% if experiment.status == 'Draft' %}text-white{% else %}text-secondary{% endif %}">{{ experiment.draft_date|default:'---' }}</small>
     </li>
-    
     <!-- Preview Status -->
-    <li class="list-group-item flex-fill text-center d-flex flex-column justify-content-center 
-        {% if experiment.status == 'Preview'  and experiment.publish_status == 'Idle' %}
-            bg-warning text-white
-        {% else %}
-            bg-light text-muted
-        {% endif %}">
+    <li class="list-group-item flex-fill text-center d-flex flex-column justify-content-center {% if experiment.status == 'Preview'  and experiment.publish_status == 'Idle' %} bg-warning text-white {% else %} bg-light text-muted {% endif %}">
       <strong>Preview</strong>
       <small class="{% if experiment.status == 'Preview' %}text-white{% else %}text-secondary{% endif %}">{{ experiment.preview_date|default:'---' }}</small>
     </li>
-    
     <!-- Review Status -->
-    <li class="list-group-item flex-fill text-center d-flex flex-column justify-content-center 
-        {% if experiment.publish_status != 'Idle' %}
-            {% if experiment.status == 'Preview' %}
-                bg-danger text-white
-            {% elif experiment.status == 'Draft' %}
-                bg-danger text-white
-            {% else %}
-                bg-light text-muted
-            {% endif %}
-        {% else %}
-            bg-light text-muted
-        {% endif %}">
+    <li class="list-group-item flex-fill text-center d-flex flex-column justify-content-center {% if experiment.publish_status != 'Idle' %} {% if experiment.status == 'Preview' %} bg-danger text-white {% elif experiment.status == 'Draft' %} bg-danger text-white {% else %} bg-light text-muted {% endif %} {% else %} bg-light text-muted {% endif %}">
       <strong>Review</strong>
       <small class="{% if experiment.publish_status != 'Idle' and experiment.status == 'Preview' %}text-white{% elif experiment.publish_status != 'Idle' and experiment.status == 'Draft' %}text-white{% else %}text-secondary{% endif %}">{{ experiment.review_date|default:'---' }}</small>
     </li>
-    
     <!-- Live Status -->
-    <li class="list-group-item flex-fill text-center d-flex flex-column justify-content-center 
-        {% if experiment.status == 'Live' %}
-            bg-success text-white
-        {% else %}
-            bg-light text-muted
-        {% endif %}">
+    <li class="list-group-item flex-fill text-center d-flex flex-column justify-content-center {% if experiment.status == 'Live' %} bg-success text-white {% else %} bg-light text-muted {% endif %}">
       <strong>Live</strong>
       <small class="{% if experiment.status == 'Live' %}text-white{% else %}text-secondary{% endif %}">{{ experiment.start_date|default:'---' }}</small>
     </li>
-    
     <!-- Complete Status -->
-    <li class="list-group-item flex-fill text-center d-flex flex-column justify-content-center 
-        {% if experiment.status == 'Complete' %}
-            bg-secondary text-white
-        {% else %}
-            bg-light text-muted
-        {% endif %}">
+    <li class="list-group-item flex-fill text-center d-flex flex-column justify-content-center {% if experiment.status == 'Complete' %} bg-secondary text-white {% else %} bg-light text-muted {% endif %}">
       <strong>Complete</strong>
       <small class="{% if experiment.status == 'Complete' %}text-white{% else %}text-secondary{% endif %}">{{ experiment.end_date|default:'---' }}</small>
     </li>


### PR DESCRIPTION
Because

- We want to show the timeline on the new summary page

This commit

- Adds new status timeline

Note: On the same timeline, in the next PR, I will add the functionality to go back from preview to draft or preview to launch 

Fixes #11361 
<img width="1589" alt="Screenshot 2024-09-19 at 5 15 39 PM" src="https://github.com/user-attachments/assets/60532b4f-b305-4c3a-ade0-5b22bbce53c6">
<img width="1589" alt="Screenshot 2024-09-19 at 5 10 35 PM" src="https://github.com/user-attachments/assets/ea32031f-0455-415b-8a26-46dd4986ee37">
<img width="1589" alt="Screenshot 2024-09-19 at 5 09 49 PM" src="https://github.com/user-attachments/assets/cdab6df7-ed3b-442b-bed8-2f921e3a0a89">
<img width="1589" alt="Screenshot 2024-09-19 at 5 08 56 PM" src="https://github.com/user-attachments/assets/58898acc-047a-498f-ab82-c0b2b661566f">

Future design 
![image (7)](https://github.com/user-attachments/assets/ce31d166-9dc9-4dba-a754-76f0293a58eb)
