### PR TITLE
Advanced targeting: Existing users who have not changed default bookmarks toolbar visibility

### DIFF
--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -2126,6 +2126,23 @@ SYNC_USER = NimbusTargetingConfig(
     application_choice_names=(Application.DESKTOP.name,),
 )
 
+EXISTING_USER_HASNT_CHANGED_BOOKMARKS_TOOLBAR = NimbusTargetingConfig(
+    name="Existing User, Hasn't Changed Bookmarks Toolbar Behavior",
+    slug="existing_user_bookmarks_toolbar_unchanged",
+    description=(
+        "Existing users (>=28 days) who have not edited the default bookmarks' "
+        "toolbar behavior"
+    ),
+    targeting=(
+        f"{PROFILE28DAYS} &&"
+        " !('browser.toolbars.bookmarks.visibility'|preferenceIsUserSet)"
+    ),
+    desktop_telemetry="",
+    sticky_required=True,
+    is_first_run_required=False,
+    application_choice_names=(Application.DESKTOP.name,),
+)
+
 
 class TargetingConstants:
     TARGETING_VERSION = "version|versionCompare('{version}') >= 0"


### PR DESCRIPTION
Because

We'd like to run two experiments targeting early day and existing users who have not changed their bookmarks toolbar visibility. We already have the targeting for [EARLY_DAY_USER_HASNT_CHANGED_BOOKMARKS_TOOLBAR](https://github.com/mozilla/experimenter/blob/main/experimenter/experimenter/targeting/constants.py#L1782), we'd like to expose this targeting for existing as well.

This commit

Adds the existing user targeting.

Fixes  #11394