### PR TITLE
feat(project): Add segments to v8 api

### DIFF
--- a/docs/experimenter/openapi-schema.json
+++ b/docs/experimenter/openapi-schema.json
@@ -4186,6 +4186,10 @@
             "type": "string",
             "readOnly": true
           },
+          "segments": {
+            "type": "string",
+            "readOnly": true
+          },
           "branches": {
             "type": "string",
             "readOnly": true

--- a/docs/experimenter/swagger-ui.html
+++ b/docs/experimenter/swagger-ui.html
@@ -4198,6 +4198,10 @@
             "type": "string",
             "readOnly": true
           },
+          "segments": {
+            "type": "string",
+            "readOnly": true
+          },
           "branches": {
             "type": "string",
             "readOnly": true

--- a/experimenter/experimenter/experiments/api/v8/serializers.py
+++ b/experimenter/experimenter/experiments/api/v8/serializers.py
@@ -99,6 +99,7 @@ class NimbusExperimentSerializer(serializers.ModelSerializer):
     featureIds = serializers.SerializerMethodField()
     probeSets = serializers.ReadOnlyField(default=[])
     outcomes = serializers.SerializerMethodField()
+    segments = serializers.SerializerMethodField()
     startDate = serializers.DateField(source="start_date")
     enrollmentEndDate = serializers.DateField(source="actual_enrollment_end_date")
     endDate = serializers.DateField(source="end_date")
@@ -131,6 +132,7 @@ class NimbusExperimentSerializer(serializers.ModelSerializer):
             "featureIds",
             "probeSets",
             "outcomes",
+            "segments",
             "branches",
             "targeting",
             "startDate",
@@ -178,6 +180,9 @@ class NimbusExperimentSerializer(serializers.ModelSerializer):
             for (priority, outcomes) in prioritized_outcomes
             for slug in outcomes
         ]
+
+    def get_segments(self, obj):
+        return [{"slug": slug} for slug in obj.segments]
 
     def get_referenceBranch(self, obj):
         if obj.reference_branch:

--- a/experimenter/experimenter/experiments/tests/api/v8/test_serializers.py
+++ b/experimenter/experimenter/experiments/tests/api/v8/test_serializers.py
@@ -34,6 +34,7 @@ class TestNimbusExperimentSerializer(TestCase):
             channel=NimbusExperiment.Channel.NIGHTLY,
             primary_outcomes=["foo", "bar", "baz"],
             secondary_outcomes=["quux", "xyzzy"],
+            segments=["segment1", "segment2"],
             locales=[locale_en_us],
             _enrollment_end_date=datetime.date(2022, 1, 5),
         )
@@ -88,6 +89,7 @@ class TestNimbusExperimentSerializer(TestCase):
                     {"priority": "secondary", "slug": "quux"},
                     {"priority": "secondary", "slug": "xyzzy"},
                 ],
+                "segments": [{"slug": "segment1"}, {"slug": "segment2"}],
                 "featureValidationOptOut": experiment.is_client_schema_disabled,
                 "localizations": None,
                 "locales": ["en-US"],
@@ -149,6 +151,7 @@ class TestNimbusExperimentSerializer(TestCase):
             channel=NimbusExperiment.Channel.NIGHTLY,
             primary_outcomes=["foo", "bar", "baz"],
             secondary_outcomes=["quux", "xyzzy"],
+            segments=["segment1", "segment2"],
             locales=[locale_en_us],
         )
         serializer = NimbusExperimentSerializer(experiment)
@@ -310,6 +313,7 @@ class TestNimbusExperimentSerializer(TestCase):
             channel=NimbusExperiment.Channel.NIGHTLY,
             primary_outcomes=["foo", "bar", "baz"],
             secondary_outcomes=["qux", "quux"],
+            segments=["segment1", "segment2"],
             is_localized=True,
             localizations=TEST_LOCALIZATIONS,
             locales=[locale_en_us, locale_en_ca, locale_fr],


### PR DESCRIPTION
Because
* The current v8 API does not support segments

This commit
* Adds segments to the v8 API for consumption by jetstream

Fixes #11401
