### PR TITLE
chore(ci): Modify integration test script to install firefox desktop from stored key.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -226,7 +226,7 @@ integration_test_legacy: build_prod
 	MOZ_HEADLESS=1 $(COMPOSE_INTEGRATION) run firefox sh -c "./experimenter/tests/experimenter_legacy_tests.sh"
 
 integration_test_nimbus: build_prod
-	MOZ_HEADLESS=1 $(COMPOSE_INTEGRATION) run firefox sh -c "UPDATE_FIREFOX_VERSION=$(UPDATE_FIREFOX_VERSION) FIREFOX_BETA=$(FIREFOX_BETA) PYTEST_SENTRY_DSN=$(PYTEST_SENTRY_DSN) PYTEST_SENTRY_ALWAYS_REPORT=$(PYTEST_SENTRY_ALWAYS_REPORT) CIRCLECI=$(CIRCLECI) ./experimenter/tests/nimbus_integration_tests.sh"
+	MOZ_HEADLESS=1 $(COMPOSE_INTEGRATION) run firefox sh -c "UPDATE_FIREFOX_VERSION=$(UPDATE_FIREFOX_VERSION) FIREFOX_BETA=$(FIREFOX_BETA) FIREFOX_RELEASE=$(FIREFOX_RELEASE) PYTEST_SENTRY_DSN=$(PYTEST_SENTRY_DSN) PYTEST_SENTRY_ALWAYS_REPORT=$(PYTEST_SENTRY_ALWAYS_REPORT) CIRCLECI=$(CIRCLECI) ./experimenter/tests/nimbus_integration_tests.sh"
 
 integration_test_nimbus_rust: build_integration_test build_prod
 	MOZ_HEADLESS=1 $(COMPOSE_INTEGRATION) run -it rust-sdk sh -c "./experimenter/tests/nimbus_rust_tests.sh"


### PR DESCRIPTION

Because

- We added the capability to track and store what version of firefox release is current for use in our integration tests

This commit

- Follows on from that to modify the script so that it will download and install that specific version

Fixes #11411 