### PR TITLE
chore(project): prevent celerybeat schedule from leaking out of container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -83,7 +83,7 @@ services:
     volumes:
       - ./experimenter:/experimenter
       - ${GOOGLE_ADC_FILE}:${GOOGLE_APPLICATION_CREDENTIALS}:ro
-    command: bash -c "/experimenter/bin/wait-for-it.sh db:5432 -- celery -A experimenter beat -l DEBUG"
+    command: bash -c "/experimenter/bin/wait-for-it.sh db:5432 -- celery -A experimenter beat -s /tmp/celerybeat-schedule -l DEBUG"
 
   nginx:
     build: ./nginx


### PR DESCRIPTION


Becuase

* We recently changed the Experimenter Dockerfile to run as non root
* To prevent conflict with the celery db file, we removed the command arg that specifies a path for the celerybeat schedule file
* This results in the file being written to the local project dir
* The local project dir is mapped to the host filesystem in our dev docker compose
* This results in the celerybeat schedule file being leaked out of the container to the host filesystem where it may be detected by git

This commit

* Sets the path to the celerybeat schedule file to a dir that the process has write access to and will not leak out of the container

fixes #11409
