### PR TITLE
feat(ci): Add Firefox for iOS branch data for tracking changes.

### DIFF
--- a/experimenter/tests/firefox_fennec_beta_build.env
+++ b/experimenter/tests/firefox_fennec_beta_build.env
@@ -1,0 +1,3 @@
+FIREFOX_FENNEC_BETA_VERSION_ID="release/v131"
+BRANCH="release/v131"
+Firefox version is "130.0.1"

--- a/experimenter/tests/firefox_fennec_release_build.env
+++ b/experimenter/tests/firefox_fennec_release_build.env
@@ -1,0 +1,3 @@
+FIREFOX_FENNEC_RELEASE_VERSION_ID="firefox-v130.1"
+BRANCH="release/v130"
+Firefox version is "130.0.1"

--- a/scripts/external_integration_updater_script.sh
+++ b/scripts/external_integration_updater_script.sh
@@ -2,15 +2,18 @@
 
 TASKCLUSTER_API="https://firefox-ci-tc.services.mozilla.com/api/index/v1"
 WHAT_TRAIN_IS_IT_NOW_API="https://whattrainisitnow.com/api/firefox/releases/"
+FENNEC_GITHUB_API="https://api.github.com/repos/mozilla-mobile/firefox-ios"
 CURLFLAGS=("--proto" "=https" "--tlsv1.2" "-sS")
 
 git checkout main
 git checkout main
 git pull origin main
 git checkout -B check_external_firefox_integrations
-firefox_types=("fenix_beta" "fenix_nightly" "desktop_beta" "desktop_release")
+firefox_types=("fenix_beta" "fenix_nightly" "fennec_release" "fennec_beta" "desktop_beta" "desktop_release")
 
 fetch_task_info() {
+    local release_version=$(curl "${CURLFLAGS[@]}" "${WHAT_TRAIN_IS_IT_NOW_API}" | jq 'to_entries | last | .key')
+    local major_version="$(echo "$release_version" | cut -d'.' -f1 | tr -d '"')"
     local variant=$1
     local index_base=""
     local namespace=""
@@ -18,6 +21,19 @@ fetch_task_info() {
     local task_id=""
     
     case "$variant" in
+        desktop_beta)
+            index_base="gecko.v2.mozilla-beta.latest.firefox"
+            namespace="gecko.v2.mozilla-beta.latest.firefox.linux64-debug"
+            env_file="firefox_desktop_beta_build.env"
+            ;;
+        desktop_release)
+            # Fetch release version separately 
+            # release_version=$(curl "${CURLFLAGS[@]}" "${WHAT_TRAIN_IS_IT_NOW_API}" | jq 'to_entries | last | .key')
+            echo "FIREFOX_DESKTOP_RELEASE_VERSION_ID ${release_version}"
+            echo "FIREFOX_DESKTOP_RELEASE_VERSION_ID=${release_version}" > firefox_desktop_release_build.env
+            mv firefox_desktop_release_build.env experimenter/tests
+            return
+            ;;
         fenix_beta)
             index_base="mobile.v3.firefox-android.apks.fenix-beta.latest"
             namespace="mobile.v3.firefox-android.apks.fenix-beta.latest.x86_64"
@@ -28,17 +44,28 @@ fetch_task_info() {
             namespace="mobile.v3.firefox-android.apks.fenix-nightly.latest.x86_64"
             env_file="firefox_fenix_nightly_build.env"
             ;;
-        desktop_beta)
-            index_base="gecko.v2.mozilla-beta.latest.firefox"
-            namespace="gecko.v2.mozilla-beta.latest.firefox.linux64-debug"
-            env_file="firefox_desktop_beta_build.env"
+        fennec_release)
+            version=$(curl "${CURLFLAGS[@]}" "${FENNEC_GITHUB_API}/releases" | jq '.[0].name')
+            branch=$(curl "${CURLFLAGS[@]}" "${FENNEC_GITHUB_API}/releases" | jq '.[0].target_commitish')
+            echo "FIREFOX_FENNEC_RELEASE_VERSION_ID ${version}"
+            echo "FIREFOX_FENNEC_RELEASE_VERSION_ID=${version}" > firefox_fennec_release_build.env
+            echo "BRANCH=${branch}" >> firefox_fennec_release_build.env
+            echo "Firefox version is ${release_version}" >> firefox_fennec_release_build.env
+            mv firefox_fennec_release_build.env experimenter/tests
+            return
             ;;
-        desktop_release)
-            # Fetch release version separately 
-            release_version=$(curl "${CURLFLAGS[@]}" "${WHAT_TRAIN_IS_IT_NOW_API}" | jq 'to_entries | last | .key')
-            echo "FIREFOX_DESKTOP_RELEASE_VERSION_ID ${release_version}"
-            echo "FIREFOX_DESKTOP_RELEASE_VERSION_ID=${release_version}" > firefox_desktop_release_build.env
-            mv firefox_desktop_release_build.env experimenter/tests
+        fennec_beta)
+            version=$(curl "${CURLFLAGS[@]}" "${FENNEC_GITHUB_API}/branches?protected=true" | jq --argjson major "$major_version" '
+                .[-1].name as $name | 
+                ( $name | capture("release/v(?<major_version>[0-9]+)") 
+                | (.major_version | tonumber) == ($major | tonumber + 1) ) 
+                // empty | if . then $name else empty end'
+            )
+            echo "FIREFOX_FENNEC_BETA_VERSION_ID ${version}"
+            echo "FIREFOX_FENNEC_BETA_VERSION_ID=${version}" > firefox_fennec_beta_build.env
+            echo "BRANCH=${version}" >> firefox_fennec_beta_build.env
+            echo "Firefox version is ${release_version}" >> firefox_fennec_beta_build.env
+            mv firefox_fennec_beta_build.env experimenter/tests
             return
             ;;
         *)
@@ -62,9 +89,9 @@ fetch_task_info() {
 
 for name in "${firefox_types[@]}"
 do
-    CURRENT_BUILD_ID=$(cat experimenter/tests/firefox_${name}_build.env | grep -oP '(?<=TASK_ID=).*')
+    CURRENT_BUILD_ID=$(cat experimenter/tests/firefox_${name}_build.env | grep -oP '(?<=TASK_ID=).*|(?<=VERSION_ID=).*')
     fetch_task_info $name
-    LATEST_BUILD_ID=$(cat experimenter/tests/firefox_${name}_build.env | grep -oP '(?<=TASK_ID=).*')
+    LATEST_BUILD_ID=$(cat experimenter/tests/firefox_${name}_build.env | grep -oP '(?<=TASK_ID=).*|(?<=VERSION_ID=).*')
     if [[ "${CURRENT_BUILD_ID}" != "${LATEST_BUILD_ID}" ]]; then
         echo "Adding firefox_${name}_build.env" 
     fi


### PR DESCRIPTION
Because

- We are tracking external firefox versions changes for the clients we support to better test our integrations with them

This commit

- Adds Firefox for iOS (fennec) to the external tracking script

Fixes #11436 