### PR TITLE
Adding advanced targeting for Mozilla Testday Events

### DIFF
--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -2162,12 +2162,8 @@ EXISTING_USER_HASNT_CHANGED_BOOKMARKS_TOOLBAR = NimbusTargetingConfig(
 MOZILLA_TESTDAY_EVENT = NimbusTargetingConfig(
     name="Mozilla Testday",
     slug="users_that_have_testday_pref",
-    description=(
-        "Users that will be part of the Mozilla Testday events"
-    ),
-    targeting=(
-        "messaging-system-action.testday|preferenceValue == 'testday'"
-    ),
+    description="Users that will be part of the Mozilla Testday events",
+    targeting="messaging-system-action.testday|preferenceValue == 'testday'",
     desktop_telemetry="",
     sticky_required=False,
     is_first_run_required=False,

--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -2159,6 +2159,21 @@ EXISTING_USER_HASNT_CHANGED_BOOKMARKS_TOOLBAR = NimbusTargetingConfig(
     application_choice_names=(Application.DESKTOP.name,),
 )
 
+MOZILLA_TESTDAY_EVENT = NimbusTargetingConfig(
+    name="Mozilla Testday",
+    slug="users_that_have_testday_pref",
+    description=(
+        "Users that will be part of the Mozilla Testday events"
+    ),
+    targeting=(
+        "messaging-system-action.testday|preferenceValue == 'testday'"
+    ),
+    desktop_telemetry="",
+    sticky_required=False,
+    is_first_run_required=False,
+    application_choice_names=(Application.DESKTOP.name,),
+)
+
 
 class TargetingConstants:
     TARGETING_VERSION = "version|versionCompare('{version}') >= 0"


### PR DESCRIPTION
Fixes #11375 