### PR TITLE
Update targeting expression for Mozilla Testday Event

### DIFF
--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -2163,7 +2163,7 @@ MOZILLA_TESTDAY_EVENT = NimbusTargetingConfig(
     name="Mozilla Testday",
     slug="users_that_have_testday_pref",
     description="Users that will be part of the Mozilla Testday events",
-    targeting="messaging-system-action.testday|preferenceValue == 'testday'",
+    targeting="'messaging-system-action.testday'|preferenceValue == 'testday'",
     desktop_telemetry="",
     sticky_required=False,
     is_first_run_required=False,


### PR DESCRIPTION
Fixes #11457 

I typoed my initial expression and used `messaging-system-action.testday|preferenceValue` when I should have used `'messaging-system-action.testday'|preferenceValue`
