### PR TITLE
chore(ci): Change PR title the external integration script creates.

### DIFF
--- a/scripts/external_integration_updater_script.sh
+++ b/scripts/external_integration_updater_script.sh
@@ -72,9 +72,9 @@ done
 
 if (($(git status --porcelain | wc -c) > 0)); then
     git add .
-    git commit -m "chore(nimbus): Check external firefox integrations and update keys"
+    git commit -m "chore(nimbus): Check external firefox integrations and task ids and versions"
     git push origin -f check_external_firefox_integrations
-    gh pr create -t "chore(nimbus): Check external firefox integrations and update keys" -b "" --base main --head check_external_firefox_integrations --repo mozilla/experimenter || echo "PR already exists, skipping"
+    gh pr create -t "chore(nimbus):  Check external firefox integrations and task ids and versions" -b "" --base main --head check_external_firefox_integrations --repo mozilla/experimenter || echo "PR already exists, skipping"
 else
     echo "No config changes, skipping"
 fi


### PR DESCRIPTION
Because

- The title we are using for the PR can be interpreted to mean something security related by using the word "keys".

This commit

- Changes the wording to closer reference what the PR is actually updating

Fixes #11470 