### PR TITLE
chore(tests): Fix desktop targeting tests to check targeting slugs more accurately.

### DIFF
--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -111,7 +111,7 @@ MSIX_FIRST_RUN = NimbusTargetingConfig(
     name="First start-up users with MSIX Firefox",
     slug="msix_first_run",
     description=("First start-up users (e.g. for about:welcome) with MSIX Firefox"),
-    targeting="(isFirstRun && os.isWindows && os.windowsVersion >= 10 && isMSIX)",
+    targeting="(isFirstStartup && os.isWindows && os.windowsVersion >= 10 && isMSIX)",
     desktop_telemetry="",
     sticky_required=False,
     is_first_run_required=True,
@@ -1432,17 +1432,6 @@ POST_FIRST_RUN_USER_UNSUPPORTED_WINDOWS_VERSION = NimbusTargetingConfig(
     application_choice_names=(Application.DESKTOP.name,),
 )
 
-TEST_STICKY_TARGETING = NimbusTargetingConfig(
-    name="Test targeting",
-    slug="test_targeting",
-    description="Config for sticky targeting",
-    targeting="'sticky.targeting.test.pref'|preferenceValue",
-    desktop_telemetry="",
-    sticky_required=True,
-    is_first_run_required=False,
-    application_choice_names=[a.name for a in Application],
-)
-
 ANDROID_CORE_ACTIVE_USER = NimbusTargetingConfig(
     name="Core Active Users",
     slug="android_core_active_users",
@@ -1960,8 +1949,7 @@ DEFAULT_PDF_IS_DIFFERENT_BROWSER = NimbusTargetingConfig(
         "than the current Firefox installation"
     ),
     targeting=(
-        "!(isDefaultHandler || {})['pdf'] &&"
-        "  (defaultPDFHandler || {})['knownBrowser']"
+        "!(isDefaultHandler || {}).pdf &&  (defaultPDFHandler || {}).knownBrowser"
     ),
     desktop_telemetry="",
     sticky_required=False,

--- a/experimenter/tests/integration/nimbus/conftest.py
+++ b/experimenter/tests/integration/nimbus/conftest.py
@@ -262,7 +262,7 @@ def default_data(
         audience=BaseExperimentAudienceDataClass(
             channel=BaseExperimentAudienceChannels.RELEASE,
             min_version=106,
-            targeting="test_targeting",
+            targeting="no_targeting",
             percentage="50",
             expected_clients=50,
             locale=None,

--- a/experimenter/tests/integration/nimbus/test_desktop_targeting.py
+++ b/experimenter/tests/integration/nimbus/test_desktop_targeting.py
@@ -1,4 +1,5 @@
 import json
+import logging
 from pathlib import Path
 
 import pytest
@@ -27,15 +28,19 @@ def test_check_advanced_targeting(
     default_data_api,
     filter_expression_path,
 ):
-    helpers.create_experiment(
+    default_data_api["targetingConfigSlug"] = targeting_config_slug
+    experiment = helpers.create_experiment(
         experiment_slug,
         BaseExperimentApplications.FIREFOX_DESKTOP.value,
         default_data_api,
         targeting=targeting_config_slug,
     )
+    logging.info(f"GraphQL creation: {experiment}")
     experiment_data = helpers.load_experiment_data(experiment_slug)
     targeting = experiment_data["data"]["experimentBySlug"]["jexlTargetingExpression"]
+    logging.info(f"Experiment Targeting: {targeting}")
     recipe = experiment_data["data"]["experimentBySlug"]["recipeJson"]
+    logging.info(f"Experiment Recipe: {recipe}")
 
     # Inject filter expression
     selenium.get("about:blank")
@@ -80,15 +85,18 @@ def test_check_audience_targeting(
     filter_expression_path,
 ):
     default_data_api.update(audience_field)
-    helpers.create_experiment(
+    experiment = helpers.create_experiment(
         experiment_slug,
         BaseExperimentApplications.FIREFOX_DESKTOP.value,
         default_data_api,
         targeting="no_targeting",
     )
+    logging.info(f"GraphQL creation: {experiment}")
     experiment_data = helpers.load_experiment_data(experiment_slug)
     targeting = experiment_data["data"]["experimentBySlug"]["jexlTargetingExpression"]
+    logging.info(f"Experiment Targeting: {targeting}")
     recipe = experiment_data["data"]["experimentBySlug"]["recipeJson"]
+    logging.info(f"Experiment Recipe: {recipe}")
 
     # Inject filter expression
     selenium.get("about:blank")


### PR DESCRIPTION

Because

- We have been testing targeting strings for desktop for a while now but somewhere there was a change that defaulted out tests to the `no_targeting` slug. This means we haven't been actually testing the targeting constants we add.

This commit

- Fixes how the test is setup and run to actually test each targeting slug. It also adds log outputs that are visible in the HTML report.

Fixes #11461 