### PR TITLE
chore(ci): prefix images pushed to GAR with `sha-`.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -480,8 +480,9 @@ jobs:
             docker tag experimenter:deploy ${DOCKER_IMAGE}:latest
             docker push "${DOCKER_IMAGE}:latest"
             GIT_SHA=$(git rev-parse --short HEAD)
-            docker tag experimenter:deploy ${DOCKER_IMAGE}:${GIT_SHA}
-            docker push ${DOCKER_IMAGE}:${GIT_SHA}
+            docker tag experimenter:deploy ${DOCKER_IMAGE}:sha-${GIT_SHA}
+            docker push ${DOCKER_IMAGE}:sha-${GIT_SHA}
+
 
   deploy_cirrus:
     working_directory: ~/cirrus


### PR DESCRIPTION
Because

- All digits short commit sha can be interpreted as an integer or scientific notation (if starting with `1e` followed by digits) in some systems ([1](https://github.com/helm/helm/issues/3001), [2](https://github.com/helm/helm/issues/6867)).

This commit

- Prefixes commit SHA with `sha-` for images pushed to GAR. Dockerhub/GCR images still use the SHA without prefix.
