### PR TITLE
feat(nimbus): add segments to new Nimbus UI Metrics form

### DIFF
--- a/experimenter/experimenter/nimbus_ui_new/forms.py
+++ b/experimenter/experimenter/nimbus_ui_new/forms.py
@@ -7,6 +7,7 @@ from experimenter.experiments.changelog_utils import generate_nimbus_changelog
 from experimenter.experiments.models import NimbusExperiment
 from experimenter.nimbus_ui_new.constants import NimbusUIConstants
 from experimenter.outcomes import Outcomes
+from experimenter.segments import Segments
 
 
 class NimbusChangeLogFormMixin:
@@ -159,12 +160,14 @@ class MetricsForm(NimbusChangeLogFormMixin, forms.ModelForm):
     secondary_outcomes = forms.MultipleChoiceField(
         required=False, widget=MultiSelectWidget()
     )
+    segments = forms.MultipleChoiceField(required=False, widget=MultiSelectWidget())
 
     class Meta:
         model = NimbusExperiment
         fields = [
             "primary_outcomes",
             "secondary_outcomes",
+            "segments",
         ]
 
     def __init__(self, *args, **kwargs):
@@ -177,6 +180,14 @@ class MetricsForm(NimbusChangeLogFormMixin, forms.ModelForm):
         )
         self.fields["primary_outcomes"].choices = application_outcomes
         self.fields["secondary_outcomes"].choices = application_outcomes
+
+        application_segments = sorted(
+            [
+                (s.slug, s.friendly_name)
+                for s in Segments.by_application(self.instance.application)
+            ]
+        )
+        self.fields["segments"].choices = application_segments
 
     def get_changelog_message(self):
         return f"{self.request.user} updated metrics"

--- a/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/edit_metrics.html
+++ b/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/edit_metrics.html
@@ -61,6 +61,7 @@
               <p class="form-text">Select the user action or feature that you are measuring with this experiment.</p>
             </div>
           </div>
+          <hr>
           <div class="row">
             <div class="col">
               <label for="segments" class="form-label">
@@ -68,11 +69,11 @@
                 <i class="fa-regular fa-circle-question"
                    data-bs-toggle="tooltip"
                    data-bs-placement="top"
-                   data-bs-title="Specific segments that you are interested in analyzing in your experiment."></i>
+                   data-bs-title="Select user segments if you want to view your results sliced by specific sub-groups of users."></i>
                 {% if form.is_bound %}<i class="fa-solid fa-check text-success"></i>{% endif %}
               </label>
               <div class="rounded border border-1 p-0 {% if form.is_bound %}border-success{% endif %}">{{ form.segments }}</div>
-              <p class="form-text">Select the segments you wish to compute metrics for.</p>
+              <p class="form-text">Select the user segments you wish to analyze.</p>
             </div>
           </div>
         </div>

--- a/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/edit_metrics.html
+++ b/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/edit_metrics.html
@@ -61,6 +61,20 @@
               <p class="form-text">Select the user action or feature that you are measuring with this experiment.</p>
             </div>
           </div>
+          <div class="row">
+            <div class="col">
+              <label for="segments" class="form-label">
+                Segments
+                <i class="fa-regular fa-circle-question"
+                   data-bs-toggle="tooltip"
+                   data-bs-placement="top"
+                   data-bs-title="Specific segments that you are interested in analyzing in your experiment."></i>
+                {% if form.is_bound %}<i class="fa-solid fa-check text-success"></i>{% endif %}
+              </label>
+              <div class="rounded border border-1 p-0 {% if form.is_bound %}border-success{% endif %}">{{ form.segments }}</div>
+              <p class="form-text">Select the segments you wish to compute metrics for.</p>
+            </div>
+          </div>
         </div>
       </div>
       <div class="d-flex justify-content-end">

--- a/experimenter/experimenter/nimbus_ui_new/tests/test_views.py
+++ b/experimenter/experimenter/nimbus_ui_new/tests/test_views.py
@@ -23,6 +23,8 @@ from experimenter.openidc.tests.factories import UserFactory
 from experimenter.outcomes import Outcomes
 from experimenter.outcomes.tests import mock_valid_outcomes
 from experimenter.projects.tests.factories import ProjectFactory
+from experimenter.segments import Segments
+from experimenter.segments.tests import mock_valid_segments
 from experimenter.targeting.constants import TargetingConstants
 
 
@@ -1095,6 +1097,7 @@ class TestNimbusExperimentsCreateView(AuthTestCase):
 
 
 @mock_valid_outcomes
+@mock_valid_segments
 class TestMetricsUpdateView(AuthTestCase):
     @classmethod
     def setUpClass(cls):
@@ -1118,18 +1121,27 @@ class TestMetricsUpdateView(AuthTestCase):
             application=application,
             primary_outcomes=[],
             secondary_outcomes=[],
+            segments=[],
         )
         outcomes = Outcomes.by_application(application)
+        segments = Segments.by_application(application)
+
         outcome1 = outcomes[0]
         outcome2 = outcomes[1]
+        segment1 = segments[0]
+        segment2 = segments[1]
+
         response = self.client.post(
             reverse("nimbus-new-update-metrics", kwargs={"slug": experiment.slug}),
             {
                 "primary_outcomes": [outcome1.slug],
                 "secondary_outcomes": [outcome2.slug],
+                "segments": [segment1.slug, segment2.slug],
             },
         )
+
         self.assertEqual(response.status_code, 200)
         experiment = NimbusExperiment.objects.get(slug=experiment.slug)
         self.assertEqual(experiment.primary_outcomes, [outcome1.slug])
         self.assertEqual(experiment.secondary_outcomes, [outcome2.slug])
+        self.assertEqual(experiment.segments, [segment1.slug, segment2.slug])


### PR DESCRIPTION
Because
* We want to allow the user to select the segments they want analyzed through the UI.

This commit
* Updates the new Nimbus UI Metrics form to display available segments for selection. 

Fixes #11246

![image](https://github.com/user-attachments/assets/30e12e98-2662-424a-a6c9-0c9f10d7a6e8)
![image](https://github.com/user-attachments/assets/22d94256-732b-44dd-8571-aeb67184b8e2)
![image](https://github.com/user-attachments/assets/d6810b11-816a-49d6-9f72-3c1a765a0587)
![image](https://github.com/user-attachments/assets/87f4766a-e0af-4cbb-8e81-5b8bf2b07843)


