### PR TITLE
fix(nimbus): undefined metric friendly name fallback to slug in sidebar

### DIFF
--- a/experimenter/experimenter/nimbus-ui/src/components/AppLayoutSidebarLaunched/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/AppLayoutSidebarLaunched/index.tsx
@@ -24,7 +24,6 @@ import { OutcomesList } from "src/lib/types";
 import { AnalysisData, MetadataPoint } from "src/lib/visualization/types";
 import { getExperiment_experimentBySlug } from "src/types/getExperiment";
 
-export const RESULTS_LOADING_TEXT = "Checking results availability...";
 export const RESULTS_WAITING_FOR_LAUNCH_TEXT =
   "Waiting for experiment to launch";
 
@@ -105,20 +104,19 @@ export const AppLayoutSidebarLaunched = ({
     title: string,
   ) => {
     const sidebarItems = Object.keys(metrics).map((sidebarKey) => {
+      const metricName = metrics[sidebarKey] || sidebarKey;
       if (analysisRequired) {
         return (
-          <li className="ml-4 mb-2" key={metrics[sidebarKey]}>
+          <li className="ml-4 mb-2" key={metricName}>
             <a
               href={`#${sidebarKey}`}
               className="inherit-color font-weight-normal"
             >
-              {metrics[sidebarKey]}
+              {metricName}
             </a>
           </li>
         );
       }
-      const metricName =
-        metrics[sidebarKey] !== null ? metrics[sidebarKey] : sidebarKey;
       return (
         <LinkNav
           key={sidebarKey}


### PR DESCRIPTION
Because

- metrics without the friendly name defined in metric-hub have no link text in the sidebar

This commit

- uses the metric slug as a fallback for missing friendly name

Fixes #10009 