### PR TITLE
chore(nimbus): Update owner information for some Desktop features

### DIFF
--- a/experimenter/experimenter/features/manifests/firefox-desktop/v120.0.0/experimenter.yaml
+++ b/experimenter/experimenter/features/manifests/firefox-desktop/v120.0.0/experimenter.yaml
@@ -1166,6 +1166,7 @@ glean:
 
 gleanInternalSdk:
   description: "The Glean internal SDK feature intended only for internal Glean Team use"
+  owner: glean-team@mozilla.com
   hasExposure: false
   # Some variables are used through the C++ API and thus require pref-storage.
   # We rely on those values at Glean.init time, which happens at startup.
@@ -1925,6 +1926,7 @@ feltPrivacy:
 
 attribution:
   description: Prefs related to install attribution
+  owner: bhearsum@mozilla.com
   hasExposure: false
   isEarlyStartup: true
   variables:

--- a/experimenter/experimenter/features/manifests/firefox-desktop/v120.0.1/experimenter.yaml
+++ b/experimenter/experimenter/features/manifests/firefox-desktop/v120.0.1/experimenter.yaml
@@ -1166,6 +1166,7 @@ glean:
 
 gleanInternalSdk:
   description: "The Glean internal SDK feature intended only for internal Glean Team use"
+  owner: glean-team@mozilla.com
   hasExposure: false
   # Some variables are used through the C++ API and thus require pref-storage.
   # We rely on those values at Glean.init time, which happens at startup.
@@ -1925,6 +1926,7 @@ feltPrivacy:
 
 attribution:
   description: Prefs related to install attribution
+  owner: bhearsum@mozilla.com
   hasExposure: false
   isEarlyStartup: true
   variables:

--- a/experimenter/experimenter/features/manifests/firefox-desktop/v120.0.2/experimenter.yaml
+++ b/experimenter/experimenter/features/manifests/firefox-desktop/v120.0.2/experimenter.yaml
@@ -1166,6 +1166,7 @@ glean:
 
 gleanInternalSdk:
   description: "The Glean internal SDK feature intended only for internal Glean Team use"
+  owner: glean-team@mozilla.com
   hasExposure: false
   # Some variables are used through the C++ API and thus require pref-storage.
   # We rely on those values at Glean.init time, which happens at startup.
@@ -1925,6 +1926,7 @@ feltPrivacy:
 
 attribution:
   description: Prefs related to install attribution
+  owner: bhearsum@mozilla.com
   hasExposure: false
   isEarlyStartup: true
   variables:

--- a/experimenter/experimenter/features/manifests/firefox-desktop/v121.0.0/experimenter.yaml
+++ b/experimenter/experimenter/features/manifests/firefox-desktop/v121.0.0/experimenter.yaml
@@ -1178,6 +1178,7 @@ glean:
 
 gleanInternalSdk:
   description: "The Glean internal SDK feature intended only for internal Glean Team use"
+  owner: glean-team@mozilla.com
   hasExposure: false
   # Some variables are used through the C++ API and thus require pref-storage.
   # We rely on those values at Glean.init time, which happens at startup.
@@ -1935,6 +1936,7 @@ backgroundThreads:
 
 reportBrokenSite:
   description: the Report Broken Site feature
+  owner: twisniewski@mozilla.com
   hasExposure: false
   isEarlyStartup: true
   variables:
@@ -1977,6 +1979,7 @@ feltPrivacy:
 
 attribution:
   description: Prefs related to install attribution
+  owner: bhearsum@mozilla.com
   hasExposure: false
   isEarlyStartup: true
   variables:

--- a/experimenter/experimenter/features/manifests/firefox-desktop/v122.0.0/experimenter.yaml
+++ b/experimenter/experimenter/features/manifests/firefox-desktop/v122.0.0/experimenter.yaml
@@ -1229,6 +1229,7 @@ glean:
 
 gleanInternalSdk:
   description: "The Glean internal SDK feature intended only for internal Glean Team use"
+  owner: glean-team@mozilla.com
   hasExposure: false
   # Some variables are used through the C++ API and thus require pref-storage.
   # We rely on those values at Glean.init time, which happens at startup.
@@ -1992,6 +1993,7 @@ backgroundThreads:
 
 reportBrokenSite:
   description: the Report Broken Site feature
+  owner: twisniewski@mozilla.com
   hasExposure: false
   isEarlyStartup: true
   variables:

--- a/experimenter/experimenter/features/manifests/firefox-desktop/v122.0.1/experimenter.yaml
+++ b/experimenter/experimenter/features/manifests/firefox-desktop/v122.0.1/experimenter.yaml
@@ -1229,6 +1229,7 @@ glean:
 
 gleanInternalSdk:
   description: "The Glean internal SDK feature intended only for internal Glean Team use"
+  owner: glean-team@mozilla.com
   hasExposure: false
   # Some variables are used through the C++ API and thus require pref-storage.
   # We rely on those values at Glean.init time, which happens at startup.
@@ -1992,6 +1993,7 @@ backgroundThreads:
 
 reportBrokenSite:
   description: the Report Broken Site feature
+  owner: twisniewski@mozilla.com
   hasExposure: false
   isEarlyStartup: true
   variables:

--- a/experimenter/experimenter/features/manifests/firefox-desktop/v122.0.2/experimenter.yaml
+++ b/experimenter/experimenter/features/manifests/firefox-desktop/v122.0.2/experimenter.yaml
@@ -1229,6 +1229,7 @@ glean:
 
 gleanInternalSdk:
   description: "The Glean internal SDK feature intended only for internal Glean Team use"
+  owner: glean-team@mozilla.com
   hasExposure: false
   # Some variables are used through the C++ API and thus require pref-storage.
   # We rely on those values at Glean.init time, which happens at startup.
@@ -1992,6 +1993,7 @@ backgroundThreads:
 
 reportBrokenSite:
   description: the Report Broken Site feature
+  owner: twisniewski@mozilla.com
   hasExposure: false
   isEarlyStartup: true
   variables:

--- a/experimenter/experimenter/features/manifests/firefox-desktop/v123.0.0/experimenter.yaml
+++ b/experimenter/experimenter/features/manifests/firefox-desktop/v123.0.0/experimenter.yaml
@@ -1240,6 +1240,7 @@ glean:
 
 gleanInternalSdk:
   description: "The Glean internal SDK feature intended only for internal Glean Team use"
+  owner: glean-team@mozilla.com
   hasExposure: false
   # Some variables are used through the C++ API and thus require pref-storage.
   # We rely on those values at Glean.init time, which happens at startup.
@@ -2007,6 +2008,7 @@ backgroundThreads:
 
 reportBrokenSite:
   description: the Report Broken Site feature
+  owner: twisniewski@mozilla.com
   hasExposure: false
   isEarlyStartup: true
   variables:

--- a/experimenter/experimenter/features/manifests/firefox-desktop/v123.0.1/experimenter.yaml
+++ b/experimenter/experimenter/features/manifests/firefox-desktop/v123.0.1/experimenter.yaml
@@ -1240,6 +1240,7 @@ glean:
 
 gleanInternalSdk:
   description: "The Glean internal SDK feature intended only for internal Glean Team use"
+  owner: glean-team@mozilla.com
   hasExposure: false
   # Some variables are used through the C++ API and thus require pref-storage.
   # We rely on those values at Glean.init time, which happens at startup.
@@ -2007,6 +2008,7 @@ backgroundThreads:
 
 reportBrokenSite:
   description: the Report Broken Site feature
+  owner: twisniewski@mozilla.com
   hasExposure: false
   isEarlyStartup: true
   variables:

--- a/experimenter/experimenter/features/manifests/firefox-desktop/v123.0.2/experimenter.yaml
+++ b/experimenter/experimenter/features/manifests/firefox-desktop/v123.0.2/experimenter.yaml
@@ -1240,6 +1240,7 @@ glean:
 
 gleanInternalSdk:
   description: "The Glean internal SDK feature intended only for internal Glean Team use"
+  owner: glean-team@mozilla.com
   hasExposure: false
   # Some variables are used through the C++ API and thus require pref-storage.
   # We rely on those values at Glean.init time, which happens at startup.
@@ -2007,6 +2008,7 @@ backgroundThreads:
 
 reportBrokenSite:
   description: the Report Broken Site feature
+  owner: twisniewski@mozilla.com
   hasExposure: false
   isEarlyStartup: true
   variables:

--- a/experimenter/experimenter/features/manifests/firefox-desktop/v124.0.0/experimenter.yaml
+++ b/experimenter/experimenter/features/manifests/firefox-desktop/v124.0.0/experimenter.yaml
@@ -1325,6 +1325,7 @@ glean:
 
 gleanInternalSdk:
   description: "The Glean internal SDK feature intended only for internal Glean Team use"
+  owner: glean-team@mozilla.com
   hasExposure: false
   # Some variables are used through the C++ API and thus require pref-storage.
   # We rely on those values at Glean.init time, which happens at startup.
@@ -2294,6 +2295,7 @@ backgroundThreads:
 
 reportBrokenSite:
   description: the Report Broken Site feature
+  owner: twisniewski@mozilla.com
   hasExposure: false
   isEarlyStartup: true
   variables:

--- a/experimenter/experimenter/features/manifests/firefox-desktop/v124.0.1/experimenter.yaml
+++ b/experimenter/experimenter/features/manifests/firefox-desktop/v124.0.1/experimenter.yaml
@@ -1325,6 +1325,7 @@ glean:
 
 gleanInternalSdk:
   description: "The Glean internal SDK feature intended only for internal Glean Team use"
+  owner: glean-team@mozilla.com
   hasExposure: false
   # Some variables are used through the C++ API and thus require pref-storage.
   # We rely on those values at Glean.init time, which happens at startup.
@@ -2294,6 +2295,7 @@ backgroundThreads:
 
 reportBrokenSite:
   description: the Report Broken Site feature
+  owner: twisniewski@mozilla.com
   hasExposure: false
   isEarlyStartup: true
   variables:

--- a/experimenter/experimenter/features/manifests/firefox-desktop/v124.0.2/experimenter.yaml
+++ b/experimenter/experimenter/features/manifests/firefox-desktop/v124.0.2/experimenter.yaml
@@ -1325,6 +1325,7 @@ glean:
 
 gleanInternalSdk:
   description: "The Glean internal SDK feature intended only for internal Glean Team use"
+  owner: glean-team@mozilla.com
   hasExposure: false
   # Some variables are used through the C++ API and thus require pref-storage.
   # We rely on those values at Glean.init time, which happens at startup.
@@ -2294,6 +2295,7 @@ backgroundThreads:
 
 reportBrokenSite:
   description: the Report Broken Site feature
+  owner: twisniewski@mozilla.com
   hasExposure: false
   isEarlyStartup: true
   variables:

--- a/experimenter/experimenter/features/manifests/firefox-desktop/v124.0.3/experimenter.yaml
+++ b/experimenter/experimenter/features/manifests/firefox-desktop/v124.0.3/experimenter.yaml
@@ -1325,6 +1325,7 @@ glean:
 
 gleanInternalSdk:
   description: "The Glean internal SDK feature intended only for internal Glean Team use"
+  owner: glean-team@mozilla.com
   hasExposure: false
   # Some variables are used through the C++ API and thus require pref-storage.
   # We rely on those values at Glean.init time, which happens at startup.
@@ -2294,6 +2295,7 @@ backgroundThreads:
 
 reportBrokenSite:
   description: the Report Broken Site feature
+  owner: twisniewski@mozilla.com
   hasExposure: false
   isEarlyStartup: true
   variables:


### PR DESCRIPTION
Because:

- the desktop feature manifest requires owner information;
- we are switching to generating the desktop feature manifest in the schemas package; and
- using that model to load our feature configurations was causing validation errors

this commit:

- adds the missing ownership information to these schemas, which is fine because they will never be re-synced by manifesttool (as their versions are too old).

Fixes #11553