### PR TITLE
feat(schemas): align schemas with nimbus-shared and Firefox Desktop

### DIFF
--- a/schemas/generate_json_schema.py
+++ b/schemas/generate_json_schema.py
@@ -43,7 +43,8 @@ def clean_output_file(ts_path: Path) -> None:
         "/* eslint-disable */\n",
         "/**\n",
         "/* This file was automatically generated from pydantic models.\n",
-        "/* Do not modify by hand - update the pydantic models and re-run the script\n",
+        "/* Do not modify by hand - update the pydantic models and re-run\n",
+        " * make schemas_build\n",
         " */\n\n",
     ]
 

--- a/schemas/index.d.ts
+++ b/schemas/index.d.ts
@@ -2,16 +2,17 @@
 /* eslint-disable */
 /**
 /* This file was automatically generated from pydantic models.
-/* Do not modify by hand - update the pydantic models and re-run the script
+/* Do not modify by hand - update the pydantic models and re-run
+ * make schemas_build
  */
 
+export type DesktopApplication = "firefox-desktop" | "firefox-desktop-background-task";
+export type FeatureVariableType = "int" | "string" | "boolean" | "json";
+export type PrefBranch = "default" | "user";
 /**
  * A unique, stable indentifier for the user used as an input to bucket hashing.
  */
 export type RandomizationUnit = "normandy_id" | "nimbus_id" | "user_id" | "group_id";
-export type Feature = FeatureWithExposure | FeatureWithoutExposure;
-export type FeatureVariableType = "int" | "string" | "boolean" | "json";
-export type PrefBranch = "default" | "user";
 export type AnalysisBasis = "enrollments" | "exposures";
 export type LogSource = "jetstream" | "sizing" | "jetstream-preview";
 export type AnalysisErrors = AnalysisError[];
@@ -31,6 +32,107 @@ export type SizingMetricName = "active_hours" | "search_count" | "days_of_use" |
 export type StatisticIngestEnum = "percentage" | "binomial" | "mean" | "count";
 export type Statistics = Statistic[];
 
+/**
+ * The Firefox Desktop-specific feature manifest.
+ *
+ * Firefox Desktop requires different fields for its features compared to the general
+ * Nimbus feature manifest.
+ */
+export interface DesktopFeatureManifest {
+  [k: string]: DesktopFeature;
+}
+/**
+ * A feature.
+ */
+export interface DesktopFeature {
+  /**
+   * The description of the feature.
+   */
+  description: string;
+  /**
+   * Whether or not this feature records exposure telemetry.
+   */
+  hasExposure: boolean;
+  /**
+   * A description of the exposure telemetry collected by this feature.
+   *
+   * Only required if hasExposure is true.
+   */
+  exposureDescription?: string;
+  /**
+   * The owner of the feature.
+   */
+  owner: string;
+  /**
+   * If true, the feature values will be cached in prefs so that they can be read before Nimbus is initialized during Firefox startup.
+   */
+  isEarlyStartup?: boolean;
+  /**
+   * The applications that can enroll in experiments for this feature.
+   *
+   * Defaults to "firefox-desktop".
+   */
+  applications?: DesktopApplication[];
+  /**
+   * The variables that this feature can set.
+   */
+  variables: {
+    [k: string]: DesktopFeatureVariable;
+  };
+  schema?: NimbusFeatureSchema;
+}
+/**
+ * A feature variable.
+ */
+export interface DesktopFeatureVariable {
+  /**
+   * A description of the feature.
+   */
+  description: string;
+  type: FeatureVariableType;
+  /**
+   * An optional list of possible string or integer values.
+   *
+   * Only allowed when type is string or int.
+   *
+   * The types in the enum must match the type of the field.
+   */
+  enum?: string[] | number[];
+  /**
+   * A pref that provides the default value for a feature when none is present.
+   */
+  fallbackPref?: string;
+  /**
+   * A pref that should be set to the value of this variable when enrolling in experiments.
+   *
+   * Using a string is deprecated and unsupported in Firefox 124+.
+   */
+  setPref?: string | SetPref;
+}
+export interface SetPref {
+  branch: PrefBranch;
+  /**
+   * The name of the pref to set.
+   */
+  pref: string;
+}
+/**
+ * Information about a JSON schema.
+ */
+export interface NimbusFeatureSchema {
+  /**
+   * The resource:// or chrome:// URI that can be loaded at runtime within Firefox.
+   *
+   * Required by Firefox so that Nimbus can import the schema for validation.
+   */
+  uri: string;
+  /**
+   * The path to the schema file in the source checkout.
+   *
+   * Required by Experimenter so that it can find schema files in source checkouts.
+   */
+  path: string;
+}
 /**
  * The experiment definition accessible to:
  *
@@ -106,6 +208,9 @@ export interface NimbusExperiment {
     | ExperimentSingleFeatureBranch[]
     | ExperimentMultiFeatureDesktopBranch[]
     | ExperimentMultiFeatureMobileBranch[];
+  /**
+   * A JEXL targeting expression used to filter out experiments.
+   */
   targeting?: string | null;
   /**
    * Actual publish date of the experiment.
@@ -168,7 +273,7 @@ export interface NimbusExperiment {
    *
    * If null, it has not yet been published.
    */
-  publishedDate?: string;
+  publishedDate?: string | null;
 }
 export interface ExperimentBucketConfig {
   randomizationUnit: RandomizationUnit;
@@ -282,48 +387,52 @@ export interface ExperimentMultiFeatureMobileBranch {
    */
   features: ExperimentFeatureConfig[];
 }
-export interface FeatureManifest {
-  [k: string]: Feature;
+/**
+ * The SDK-specific feature manifest.
+ */
+export interface SdkFeatureManifest {
+  [k: string]: SdkFeature;
 }
 /**
- * A feature that has exposure.
+ * A feature.
  */
-export interface FeatureWithExposure {
-  description?: string | null;
-  isEarlyStartup?: boolean | null;
+export interface SdkFeature {
+  /**
+   * The description of the feature.
+   */
+  description: string;
+  /**
+   * Whether or not this feature records exposure telemetry.
+   */
+  hasExposure: boolean;
+  /**
+   * A description of the exposure telemetry collected by this feature.
+   *
+   * Only required if hasExposure is true.
+   */
+  exposureDescription?: string;
+  /**
+   * The variables that this feature can set.
+   */
   variables: {
-    [k: string]: FeatureVariable;
+    [k: string]: SdkFeatureVariable;
   };
-  schema?: NimbusFeatureSchema | null;
-  hasExposure: true;
-  exposureDescription: string;
-}
-export interface FeatureVariable {
-  description?: string | null;
-  enum?: string[] | null;
-  fallbackPref?: string | null;
-  type?: FeatureVariableType | null;
-  setPref?: string | SetPref | null;
-}
-export interface SetPref {
-  branch: PrefBranch;
-  pref: string;
-}
-export interface NimbusFeatureSchema {
-  uri: string;
-  path: string;
 }
 /**
- * A feature without exposure.
+ * A feature variable.
  */
-export interface FeatureWithoutExposure {
-  description?: string | null;
-  isEarlyStartup?: boolean | null;
-  variables: {
-    [k: string]: FeatureVariable;
-  };
-  schema?: NimbusFeatureSchema | null;
-  hasExposure: false;
+export interface SdkFeatureVariable {
+  /**
+   * A description of the feature.
+   */
+  description: string;
+  type: FeatureVariableType;
+  /**
+   * An optional list of possible string values.
+   *
+   * Only allowed when type is string.
+   */
+  enum?: string[];
 }
 export interface AnalysisError {
   analysis_basis?: AnalysisBasis | null;

--- a/schemas/mozilla_nimbus_schemas/experiments/__init__.py
+++ b/schemas/mozilla_nimbus_schemas/experiments/__init__.py
@@ -1,4 +1,9 @@
 from .experiments import NimbusExperiment, RandomizationUnit
-from .feature_manifests import FeatureManifest
+from .feature_manifests import DesktopFeatureManifest, SdkFeatureManifest
 
-__all__ = ("NimbusExperiment", "RandomizationUnit", "FeatureManifest")
+__all__ = (
+    "DesktopFeatureManifest",
+    "NimbusExperiment",
+    "RandomizationUnit",
+    "SdkFeatureManifest",
+)

--- a/schemas/mozilla_nimbus_schemas/experiments/experiments.py
+++ b/schemas/mozilla_nimbus_schemas/experiments/experiments.py
@@ -1,6 +1,6 @@
 import datetime
 from enum import Enum
-from typing import Any, Literal, Optional, Union
+from typing import Any, Literal, Union
 
 from pydantic import BaseModel, ConfigDict, Field
 from pydantic.json_schema import SkipJsonSchema
@@ -193,15 +193,18 @@ class NimbusExperiment(BaseModel):
         list[ExperimentMultiFeatureDesktopBranch],
         list[ExperimentMultiFeatureMobileBranch],
     ] = Field(description="Branch configuration for the experiment.")
-    targeting: str | None = None
-    startDate: str | None = Field(
+    targeting: str | None = Field(
+        description="A JEXL targeting expression used to filter out experiments.",
+        default=None,
+    )
+    startDate: datetime.date | None = Field(
         description=(
             "Actual publish date of the experiment.\n"
             "\n"
             "Note that this value is expected to be null in Remote Settings."
         ),
     )
-    enrollmentEndDate: Optional[str] = Field(
+    enrollmentEndDate: datetime.date | None = Field(
         description=(
             "Actual enrollment end date of the experiment.\n"
             "\n"
@@ -209,7 +212,7 @@ class NimbusExperiment(BaseModel):
         ),
         default=None,
     )
-    endDate: str | None = Field(
+    endDate: datetime.date | None = Field(
         description=(
             "Actual end date of this experiment.\n"
             "\n"
@@ -262,7 +265,7 @@ class NimbusExperiment(BaseModel):
         ),
         default=None,
     )
-    publishedDate: datetime.datetime | SkipJsonSchema[None] = Field(
+    publishedDate: datetime.datetime | None = Field(
         description=(
             "The date that this experiment was first published to Remote Settings.\n"
             "\n"

--- a/schemas/mozilla_nimbus_schemas/experiments/feature_manifests.py
+++ b/schemas/mozilla_nimbus_schemas/experiments/feature_manifests.py
@@ -1,77 +1,244 @@
 from enum import Enum
-from typing import Literal, Optional, Union
 
-from pydantic import BaseModel, Field, RootModel
+from pydantic import (
+    BaseModel,
+    Field,
+    RootModel,
+    model_validator,
+)
+from pydantic.json_schema import SkipJsonSchema
+from pydantic.types import StrictInt, StrictStr
+from typing_extensions import Self
 
 
-class FeatureVariableType(Enum):
+class FeatureVariableType(str, Enum):
     INT = "int"
     STRING = "string"
     BOOLEAN = "boolean"
     JSON = "json"
 
 
-class PrefBranch(Enum):
+class PrefBranch(str, Enum):
     DEFAULT = "default"
     USER = "user"
 
 
+class DesktopApplication(str, Enum):
+    FIREFOX_DESKTOP = "firefox-desktop"
+    BACKGROUND_TASK = "firefox-desktop-background-task"
+
+
 class SetPref(BaseModel):
-    branch: PrefBranch
-    pref: str
+    branch: PrefBranch = Field(
+        description=(
+            "The branch the pref will be set on.\n"
+            "\n"
+            "Prefs set on the user branch persists through restarts."
+        ),
+    )
+    pref: str = Field(description="The name of the pref to set.")
 
 
-class FeatureVariable(BaseModel):
-    description: Optional[str] = None
-    enum: Optional[list[str]] = None
-    fallback_pref: Optional[str] = Field(None, alias="fallbackPref")
-    type: Optional[FeatureVariableType] = None
-    set_pref: Optional[Union[str, SetPref]] = Field(None, alias="setPref")
+class BaseFeatureVariable(BaseModel):
+    description: str = Field(description="A description of the feature.")
+    type: FeatureVariableType = Field(description="The field type.")
+
+
+class SdkFeatureVariable(BaseFeatureVariable):
+    """A feature variable."""
+
+    enum: list[str] | SkipJsonSchema[None] = Field(
+        description=(
+            "An optional list of possible string values.\n"
+            "\n"
+            f"Only allowed when type is {FeatureVariableType.STRING.value}."
+        ),
+        default=None,
+    )
+
+    @model_validator(mode="after")
+    @classmethod
+    def validate_enum(cls, data: Self) -> Self:
+        if data.enum is not None:
+            if data.type != FeatureVariableType.STRING:
+                raise ValueError("only string enums are supported")
+
+            # The other cases are handled by regular model validation.
+
+        return data
+
+
+class DesktopFeatureVariable(BaseFeatureVariable):
+    """A feature variable."""
+
+    enum: list[StrictStr] | list[StrictInt] | SkipJsonSchema[None] = Field(
+        description=(
+            "An optional list of possible string or integer values.\n"
+            "\n"
+            f"Only allowed when type is {FeatureVariableType.STRING.value} or "
+            f"{FeatureVariableType.INT.value}.\n"
+            "\n"
+            "The types in the enum must match the type of the field."
+        ),
+        default=None,
+    )
+
+    fallback_pref: str | SkipJsonSchema[None] = Field(
+        alias="fallbackPref",
+        description=(
+            "A pref that provides the default value for a feature when none is present."
+        ),
+        default=None,
+    )
+
+    set_pref: str | SetPref | SkipJsonSchema[None] = Field(
+        alias="setPref",
+        description=(
+            "A pref that should be set to the value of this variable when enrolling in "
+            "experiments.\n"
+            "\n"
+            "Using a string is deprecated and unsupported in Firefox 124+."
+        ),
+        default=None,
+    )
+
+    @model_validator(mode="after")
+    @classmethod
+    def validate_set_pref_fallback_pref_mutually_exclusive(cls, data: Self) -> Self:
+        has_set_pref = data.set_pref is not None
+        has_fallback_pref = data.fallback_pref is not None
+
+        if has_set_pref and has_fallback_pref:
+            raise ValueError("fallback_pref and set_pref are mutually exclusive")
+
+        return data
+
+    @model_validator(mode="after")
+    @classmethod
+    def validate_enum(cls, data: Self) -> Self:
+        if data.enum is not None:
+            if data.type in (FeatureVariableType.STRING, FeatureVariableType.INT):
+                expected_cls = str if data.type == FeatureVariableType.STRING else int
+
+                if not all(isinstance(variant, expected_cls) for variant in data.enum):
+                    raise ValueError("enum values do not match variable type")
+
+            # The other cases are handled by regular model validation.
+
+        return data
 
 
 class NimbusFeatureSchema(BaseModel):
-    uri: str
-    path: str
+    """Information about a JSON schema."""
 
+    uri: str = Field(
+        description=(
+            "The resource:// or chrome:// URI that can be loaded at runtime within "
+            "Firefox.\n"
+            "\n"
+            "Required by Firefox so that Nimbus can import the schema for validation."
+        ),
+    )
 
-class BaseFeature(BaseModel):
-    """The base Feature type.
-
-    The real Feature type has conditionally required fields (if the feature has
-    exposure, then the exposure description is required), so this class includes
-    the fields common in both cases.
-    """
-
-    description: Optional[str] = None
-    is_early_startup: Optional[bool] = Field(None, alias="isEarlyStartup")
-    variables: dict[str, FeatureVariable]
-
-    #: Only used by Firefox Desktop.
-    json_schema: Optional[NimbusFeatureSchema] = Field(None, alias="schema")
-
-
-class FeatureWithExposure(BaseFeature):
-    """A feature that has exposure."""
-
-    has_exposure: Literal[True] = Field(alias="hasExposure")
-    exposure_description: str = Field(alias="exposureDescription")
-
-
-class FeatureWithoutExposure(BaseFeature):
-    """A feature without exposure."""
-
-    has_exposure: Literal[False] = Field(alias="hasExposure")
-
-    @property
-    def exposure_description(self):
-        return None
-
-
-class Feature(RootModel):
-    root: Union[FeatureWithExposure, FeatureWithoutExposure] = Field(
-        discriminator="has_exposure"
+    path: str = Field(
+        description=(
+            "The path to the schema file in the source checkout.\n"
+            "\n"
+            "Required by Experimenter so that it can find schema files in source "
+            "checkouts."
+        )
     )
 
 
-class FeatureManifest(RootModel):
-    root: dict[str, Feature]
+class BaseFeature(BaseModel):
+    """The Feature type."""
+
+    description: str = Field(description="The description of the feature.")
+
+    has_exposure: bool = Field(
+        alias="hasExposure",
+        description="Whether or not this feature records exposure telemetry.",
+    )
+
+    exposure_description: str = Field(
+        alias="exposureDescription",
+        description=(
+            "A description of the exposure telemetry collected by this feature.\n"
+            "\n"
+            "Only required if hasExposure is true."
+        ),
+        default=None,
+    )
+
+    @model_validator(mode="after")
+    @classmethod
+    def validate_exposure_description(cls, data: Self) -> Self:
+        if data.has_exposure and data.exposure_description is None:
+            raise TypeError("exposure_description is required if has_exposure is True")
+
+        return data
+
+
+class SdkFeature(BaseFeature):
+    """A feature."""
+
+    # The Nimbus SDK requires different fields for its features compared to the Desktop
+    # client.
+
+    variables: dict[str, SdkFeatureVariable] = Field(
+        description="The variables that this feature can set."
+    )
+
+
+class DesktopFeature(BaseFeature):
+    """A feature."""
+
+    # The Firefox Desktop Nimbus client requires different fields for its features
+    # compared to the SDK.
+
+    owner: str = Field(description="The owner of the feature.")
+
+    is_early_startup: bool = Field(
+        alias="isEarlyStartup",
+        description=(
+            "If true, the feature values will be cached in prefs so that they can be "
+            "read before Nimbus is initialized during Firefox startup."
+        ),
+        default=False,
+    )
+
+    applications: list[DesktopApplication] | SkipJsonSchema[None] = Field(
+        description=(
+            "The applications that can enroll in experiments for this feature.\n"
+            "\n"
+            'Defaults to "firefox-desktop".'
+        ),
+        default_factory=lambda: [DesktopApplication.FIREFOX_DESKTOP.value],
+        min_length=1,
+    )
+
+    variables: dict[str, DesktopFeatureVariable] = Field(
+        description="The variables that this feature can set.",
+    )
+
+    json_schema: NimbusFeatureSchema | SkipJsonSchema[None] = Field(
+        alias="schema",
+        description="An optional JSON schema that describes the feature variables.",
+        default=None,
+    )
+
+
+class DesktopFeatureManifest(RootModel):
+    """The Firefox Desktop-specific feature manifest.
+
+    Firefox Desktop requires different fields for its features compared to the general
+    Nimbus feature manifest.
+    """
+
+    root: dict[str, DesktopFeature]
+
+
+class SdkFeatureManifest(RootModel):
+    """The SDK-specific feature manifest."""
+
+    root: dict[str, SdkFeature]

--- a/schemas/mozilla_nimbus_schemas/tests/experiments/fixtures/feature_manifests/desktop/firefox-desktop-setPref-str.yaml
+++ b/schemas/mozilla_nimbus_schemas/tests/experiments/fixtures/feature_manifests/desktop/firefox-desktop-setPref-str.yaml
@@ -25,9 +25,7 @@ testFeature:
       description: Int pref used by platform API tests
     testSetString:
       type: string
-      setPref:
-        branch: user
-        pref: nimbus.testing.testSetString
+      setPref: nimbus.testing.testSetString
       description: A string pref set by Nimbus tests
 
 nimbus-qa-1:
@@ -37,9 +35,7 @@ nimbus-qa-1:
   variables:
     value:
       type: string
-      setPref:
-        branch: default
-        pref: nimbus.qa.pref-1
+      setPref: nimbus.qa.pref-1
       description: The value to set for the pref.
 
 nimbus-qa-2:
@@ -50,21 +46,22 @@ nimbus-qa-2:
   variables:
     value:
       type: string
-      setPref:
-        branch: user
-        pref: nimbus.qa.pref-2
+      setPref: nimbus.qa.pref-2
       description: The value to set for the pref.
 
 feature-with-exposure:
+  description: A feature with exposure.
   hasExposure: true
   owner: nobody@example.com
   exposureDescription: A description of the exposure event.
   variables: {}
 
 feature-with-schema:
+  description: A feature with a schema.
   variables: {}
   owner: nobody@example.com
   hasExposure: false
+  variables: {}
   schema:
     uri: "resource://gre/foo/schema.json"
     path: "/toolkit/components/foo/schema.json"

--- a/schemas/mozilla_nimbus_schemas/tests/experiments/fixtures/feature_manifests/desktop/firefox-desktop.yaml
+++ b/schemas/mozilla_nimbus_schemas/tests/experiments/fixtures/feature_manifests/desktop/firefox-desktop.yaml
@@ -25,7 +25,9 @@ testFeature:
       description: Int pref used by platform API tests
     testSetString:
       type: string
-      setPref: nimbus.testing.testSetString
+      setPref:
+        branch: user
+        pref: nimbus.testing.testSetString
       description: A string pref set by Nimbus tests
 
 nimbus-qa-1:
@@ -35,7 +37,9 @@ nimbus-qa-1:
   variables:
     value:
       type: string
-      setPref: nimbus.qa.pref-1
+      setPref:
+        branch: default
+        pref: nimbus.qa.pref-1
       description: The value to set for the pref.
 
 nimbus-qa-2:
@@ -46,19 +50,24 @@ nimbus-qa-2:
   variables:
     value:
       type: string
-      setPref: nimbus.qa.pref-2
+      setPref:
+        branch: user
+        pref: nimbus.qa.pref-2
       description: The value to set for the pref.
 
 feature-with-exposure:
+  description: A feature with exposure.
   hasExposure: true
   owner: nobody@example.com
   exposureDescription: A description of the exposure event.
   variables: {}
 
 feature-with-schema:
+  description: A feature with a schema.
   variables: {}
   owner: nobody@example.com
   hasExposure: false
+  variables: {}
   schema:
     uri: "resource://gre/foo/schema.json"
     path: "/toolkit/components/foo/schema.json"

--- a/schemas/mozilla_nimbus_schemas/tests/experiments/fixtures/feature_manifests/sdk/sdk.yaml
+++ b/schemas/mozilla_nimbus_schemas/tests/experiments/fixtures/feature_manifests/sdk/sdk.yaml
@@ -1,0 +1,313 @@
+---
+account-settings-redux-feature:
+  description: "This feature is for managing the roll out of the Account Settings Redux implementation\n"
+  hasExposure: true
+  exposureDescription: ""
+  variables:
+    enabled:
+      type: boolean
+      description: "Enables the feature\n"
+address-autofill-edit:
+  description: This property defines if the address editing is enabled in Settings
+  hasExposure: true
+  exposureDescription: ""
+  variables:
+    status:
+      type: boolean
+      description: "If true, we will allow user to edit the address"
+bookmark-refactor-feature:
+  description: "The Feature for managing the roll out of the Bookmark refactor feature\n"
+  hasExposure: true
+  exposureDescription: ""
+  variables:
+    enabled:
+      type: boolean
+      description: "Enables the bookmark refactor feature\n"
+contextual-hint-feature:
+  description: This set holds all features pertaining to contextual hints.
+  hasExposure: true
+  exposureDescription: ""
+  variables:
+    features-enabled:
+      type: json
+      description: "This property provides a lookup table of whether specific contextual hints are enabled.\n"
+credit-card-autofill:
+  description: This property defines the credit card autofill feature
+  hasExposure: true
+  exposureDescription: ""
+  variables:
+    credit-card-autofill-status:
+      type: boolean
+      description: "If true, we will allow user to use the credit autofill feature"
+felt-privacy-feature:
+  description: The feature that enhances private browsing mode
+  hasExposure: true
+  exposureDescription: ""
+  variables:
+    felt-deletion-enabled:
+      type: boolean
+      description: "If true, enable Felt Deletion part of Felt Privacy"
+    simplified-ui-enabled:
+      type: boolean
+      description: "If true, enable simplified UI part of Felt Privacy"
+firefox-suggest-feature:
+  description: Configuration for the Firefox Suggest feature.
+  hasExposure: true
+  exposureDescription: ""
+  variables:
+    available-suggestions-types:
+      type: json
+      description: "A map of suggestion types to booleans that indicate whether or not the provider should return suggestions of those types.\n"
+    status:
+      type: boolean
+      description: "Whether the feature is enabled. When Firefox Suggest is enabled, Firefox will download and store new search suggestions in the background, and show additional Search settings to control which suggestions appear in the awesomebar. When Firefox Suggest is disabled, Firefox will not download new suggestions, and hide the additional Search settings.\n"
+general-app-features:
+  description: The feature that contains feature flags for the entire application
+  hasExposure: true
+  exposureDescription: ""
+  variables:
+    report-site-issue:
+      type: json
+      description: This property defines whether or not the feature is enabled
+glean-server-knobs:
+  description: A feature that provides server-side configurations for Glean metrics (aka Server Knobs).
+  hasExposure: true
+  exposureDescription: ""
+  variables:
+    metrics-enabled:
+      type: json
+      description: "A map of metric base-identifiers to booleans representing the state of the 'enabled' flag for that metric."
+homepage-rebuild-feature:
+  description: "This feature is for managing the roll out of the Homepage rebuild feature\n"
+  hasExposure: true
+  exposureDescription: ""
+  variables:
+    enabled:
+      type: boolean
+      description: "If true, enables the feature\n"
+homescreenFeature:
+  description: The homescreen that the user goes to when they press home or new tab.
+  hasExposure: true
+  exposureDescription: ""
+  variables:
+    prefer-switch-to-open-tab:
+      type: boolean
+      description: "Enables the feature to automatically switch to an existing tab with the same content instead of opening a new one.\n"
+    sections-enabled:
+      type: json
+      description: "This property provides a lookup table of whether or not the given section should be enabled. If the section is enabled, it should be toggleable in the settings screen, and on by default.\n"
+login-autofill:
+  description: This property defines the login autofill feature for automatically filling in usernames and passwords.
+  hasExposure: true
+  exposureDescription: ""
+  variables:
+    login-autofill-status:
+      type: boolean
+      description: "If true, allows the user to use the login autofill feature for usernames and passwords."
+menu-refactor-feature:
+  description: "Controls the menu refactor feature\n"
+  hasExposure: true
+  exposureDescription: ""
+  variables:
+    enabled:
+      type: boolean
+      description: "Controls which menu users will see\n"
+    menu-hint:
+      type: boolean
+      description: "If true, enables the menu contextual hint.\n"
+messaging:
+  description: "The in-app messaging system\n"
+  hasExposure: true
+  exposureDescription: ""
+  variables:
+    actions:
+      type: json
+      description: A growable map of action URLs.
+    message-under-experiment:
+      type: string
+      description: "Deprecated. Please use \"experiment\": \"{experiment}\" instead."
+    messages:
+      type: json
+      description: "A growable collection of messages, where the Key is the message identifier and the value is its associated MessageData.\n"
+    on-control:
+      type: string
+      description: What should be displayed when a control message is selected.
+      enum:
+        - show-next-message
+        - show-none
+    styles:
+      type: json
+      description: "A map of styles to configure message appearance.\n"
+    triggers:
+      type: json
+      description: "A collection of out the box trigger expressions. Each entry maps to a valid JEXL expression.\n"
+    ~~experiment:
+      type: string
+      description: Not to be set by experiment.
+microsurvey-feature:
+  description: "A feature that shows the microsurvey for users to interact with and submit responses.\n"
+  hasExposure: true
+  exposureDescription: ""
+  variables:
+    enabled:
+      type: boolean
+      description: "If true, the feature is active.\n"
+native-error-page-feature:
+  description: "This feature is for managing the roll out of the native error page feature\n"
+  hasExposure: true
+  exposureDescription: ""
+  variables:
+    enabled:
+      type: boolean
+      description: "If true, the feature is active.\n"
+night-mode-feature:
+  description: "Describes the night mode feature's configuration\n"
+  hasExposure: true
+  exposureDescription: ""
+  variables:
+    enabled:
+      type: boolean
+      description: "Whether night mode is available for users or not\n"
+onboarding-framework-feature:
+  description: "The new onboarding framework feature that will allow onboarding to be experimentable through initial experiments.\n"
+  hasExposure: true
+  exposureDescription: ""
+  variables:
+    cards:
+      type: json
+      description: "The list of available cards for onboarding.\n"
+    conditions:
+      type: json
+      description: "A collection of out the box conditional expressions to be used in determining whether a card should show or not. Each entry maps to a valid JEXL expression.\n"
+    dismissable:
+      type: boolean
+      description: "Whether or not the entire onboarding is dismissable by pressing an X at the top right corner of the screen.\n"
+password-generator-feature:
+  description: Password Generator Feature
+  hasExposure: true
+  exposureDescription: ""
+  variables:
+    enabled:
+      type: boolean
+      description: "If true, the password generator feature is enabled"
+redux-search-settings-feature:
+  description: "This feature is for managing the roll out of redux on the search settings screen\n"
+  hasExposure: true
+  exposureDescription: ""
+  variables:
+    enabled:
+      type: boolean
+      description: "Enables the feature\n"
+remote-tab-management:
+  description: "Features that let users manage tabs on other devices that are connected to the same Mozilla account.\n"
+  hasExposure: true
+  exposureDescription: ""
+  variables:
+    close-tabs-enabled:
+      type: boolean
+      description: "Whether the feature to close synced tabs is enabled. When enabled, this device will allow other devices to close tabs that are open on this device, and show a \"close\" button for tabs that are currently open on other supported devices in the synced tabs tray.\n"
+search:
+  description: "Configuring the functionality to do with search. This will be separated into smaller sub-features in later releases.\n"
+  hasExposure: true
+  exposureDescription: ""
+  variables:
+    awesome-bar:
+      type: json
+      description: Configuring the awesome bar.
+shopping2023:
+  description: "The configuration setting for the status of the Fakespot feature\n"
+  hasExposure: true
+  exposureDescription: ""
+  variables:
+    back_in_stock_reporting:
+      type: boolean
+      description: "If true, enables for users the reporting feature for products back in stock.\n"
+    config:
+      type: json
+      description: "A Map of website configurations\n"
+    product_ads:
+      type: boolean
+      description: "If true, enables the product advertisement feature, allowing users to see and interact with ads for various products.\n"
+    relay:
+      type: string
+      description: "Configurable relay URL for production environment\n"
+    status:
+      type: boolean
+      description: "Whether the Fakespot feature is enabled or disabled\n"
+splash-screen:
+  description: "A feature that extends splash screen duration, allowing additional data fetching time for the app's initial run.\n"
+  hasExposure: true
+  exposureDescription: ""
+  variables:
+    enabled:
+      type: boolean
+      description: "If true, the feature is active.\n"
+    maximum_duration_ms:
+      type: int
+      description: "The maximum amount of time in milliseconds the splashscreen will be visible while waiting for initialization calls to complete.\n"
+spotlight-search:
+  description: Add pages as items findable with Spotlight.
+  hasExposure: true
+  exposureDescription: ""
+  variables:
+    enabled:
+      type: boolean
+      description: "If this is true, then on each page load adds a new item to Spotlight."
+    icon-type:
+      type: string
+      description: "The icon that is displayed next to the item in the search results. If this is `null`, then no icon is displayed.\n"
+    keep-for-days:
+      type: int
+      description: "Number of days to keep the item before automatic deletion. If this is left `null`, then it is left to iOS's default.\n"
+    searchable-content:
+      type: string
+      description: "The text content that is made searchable. If this is `null` then no additional content is used, and only the title and URL will be used.\n"
+tab-tray-refactor-feature:
+  description: "This feature is for managing the roll out of the Tab Tray refactor feature\n"
+  hasExposure: true
+  exposureDescription: ""
+  variables:
+    enabled:
+      type: boolean
+      description: "Enables the feature\n"
+tabTrayFeature:
+  description: The tab tray screen that the user goes to when they open the tab tray.
+  hasExposure: true
+  exposureDescription: ""
+  variables:
+    sections-enabled:
+      type: json
+      description: "This property provides a lookup table of whether or not the given section should be enabled. If the section is enabled, it should be toggleable in the settings screen, and on by default."
+toolbar-refactor-feature:
+  description: "This feature is for managing the roll out of the Toolbar refactor feature\n"
+  hasExposure: true
+  exposureDescription: ""
+  variables:
+    enabled:
+      type: boolean
+      description: "Enables the feature\n"
+    navigation_hint:
+      type: boolean
+      description: "If true, enables the navigation contextual hint.\n"
+    one_tap_new_tab:
+      type: boolean
+      description: "If true, enables the one tap new tab feature for users.\n"
+    unified_search:
+      type: boolean
+      description: "Enables the unified search feature\n"
+tracking-protection-refactor:
+  description: "The Enhanced Tracking Protection refactor\n"
+  hasExposure: true
+  exposureDescription: ""
+  variables:
+    enabled:
+      type: boolean
+      description: "Whether the Enhanced Tracking Protection refactor is enabled or not\n"
+zoom-feature:
+  description: "The configuration for the status of the zoom feature\n"
+  hasExposure: true
+  exposureDescription: ""
+  variables:
+    status:
+      type: boolean
+      description: "Whether the page zoom feature is enabled or not\n"

--- a/schemas/mozilla_nimbus_schemas/tests/experiments/test_feature_manifests.py
+++ b/schemas/mozilla_nimbus_schemas/tests/experiments/test_feature_manifests.py
@@ -1,16 +1,181 @@
 from pathlib import Path
+from typing import Any
 
+import pydantic
 import pytest
 import yaml
 
-from mozilla_nimbus_schemas.experiments import FeatureManifest
+from mozilla_nimbus_schemas.experiments.feature_manifests import (
+    DesktopFeatureManifest,
+    DesktopFeatureVariable,
+    SdkFeatureManifest,
+    SdkFeatureVariable,
+)
 
 FIXTURE_DIR = Path(__file__).parent / "fixtures" / "feature_manifests"
 
 
-@pytest.mark.parametrize("manifest_file", FIXTURE_DIR.iterdir())
-def test_manifest_fixtures_are_valid(manifest_file):
+@pytest.mark.parametrize("manifest_file", FIXTURE_DIR.joinpath("desktop").iterdir())
+def test_desktop_manifest_fixtures_are_valid(manifest_file):
     with manifest_file.open() as f:
         contents = yaml.safe_load(f)
 
-    FeatureManifest.model_validate(contents)
+    DesktopFeatureManifest.model_validate(contents)
+
+
+@pytest.mark.parametrize("manifest_file", FIXTURE_DIR.joinpath("sdk").iterdir())
+def test_sdk_manifest_fixtures_are_valid(manifest_file):
+    with manifest_file.open() as f:
+        contents = yaml.safe_load(f)
+
+    SdkFeatureManifest.model_validate(contents)
+
+
+def test_sdk_feature_variable_valid_enum():
+    SdkFeatureVariable.model_validate(
+        {"description": "valid enum", "type": "string", "enum": ["hello", "world"]},
+    )
+
+
+@pytest.mark.parametrize(
+    "model_json",
+    [
+        {
+            "description": "invalid enum (int not supported)",
+            "type": "int",
+            "enum": [1, 2, 3],
+        },
+        {
+            "description": "invalid enum (boolean not supported)",
+            "type": "boolean",
+            "enum": [True],
+        },
+        {
+            "description": "invalid enum (json not supported)",
+            "type": "json",
+            "enum": [{}, {}],
+        },
+    ],
+)
+def test_sdk_feature_variable_invalid_enum_unsupported_type(model_json):
+    with pytest.raises(pydantic.ValidationError, match="Input should be a valid string"):
+        SdkFeatureVariable.model_validate(model_json)
+
+
+@pytest.mark.parametrize(
+    "model_json,expected_pydantic_error",
+    [
+        (
+            {
+                "description": "invalid enum (string options for int type)",
+                "type": "int",
+                "enum": ["hello"],
+            },
+            "only string enums are supported",
+        ),
+        (
+            {
+                "description": "invalid enum (int options for string type)",
+                "type": "string",
+                "enum": [1],
+            },
+            "Input should be a valid string",
+        ),
+    ],
+)
+def test_sdk_feature_variable_invalid_enum_type_mismatch(
+    model_json,
+    expected_pydantic_error,
+):
+    with pytest.raises(pydantic.ValidationError, match=expected_pydantic_error):
+        SdkFeatureVariable.model_validate(model_json)
+
+
+@pytest.mark.parametrize(
+    "model_json",
+    [
+        {
+            "description": "valid enum (string)",
+            "type": "string",
+            "enum": ["foo", "bar"],
+        },
+        {
+            "description": "valid enum (int)",
+            "type": "int",
+            "enum": [1, 2, 10],
+        },
+    ],
+)
+def test_desktop_feature_variable_valid_enum(model_json):
+    DesktopFeatureVariable.model_validate(model_json)
+
+
+def _desktop_feature_with_variable(variable: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "description": "description",
+        "hasExposure": False,
+        "owner": "placeholder@example.com",
+        "variables": {
+            "variable": variable,
+        },
+    }
+
+
+@pytest.mark.parametrize(
+    "model_json",
+    [
+        {
+            "description": "invalid enum (boolean)",
+            "type": "boolean",
+            "enum": [True],
+        },
+        {
+            "description": "invalid enum (json)",
+            "type": "json",
+            "enum": [{}],
+        },
+    ],
+)
+def test_desktop_feature_variable_invalid_enum_types(model_json):
+    with pytest.raises(pydantic.ValidationError):
+        DesktopFeatureVariable.model_validate(model_json)
+
+
+@pytest.mark.parametrize(
+    "model_json",
+    [
+        {
+            "description": "invalid enum (string options for int type)",
+            "type": "int",
+            "enum": ["hello"],
+        },
+        {
+            "description": "invalid enum (int options for string type)",
+            "type": "string",
+            "enum": [1],
+        },
+    ],
+)
+def test_desktop_feature_variable_invalid_enum_type_mismatch(model_json):
+    with pytest.raises(
+        pydantic.ValidationError, match="enum values do not match variable type"
+    ):
+        DesktopFeatureVariable.model_validate(model_json)
+
+
+def test_desktop_feature_variable_invalid_fallback_pref_set_pref_mutually_exclusive():
+    model_json = {
+        "description": "invalid variable (fallbackPref and setPref mutually exclusive)",
+        "type": "string",
+        "setPref": {
+            "branch": "user",
+            "pref": "foo.bar",
+        },
+        "fallbackPref": "baz.qux",
+    }
+
+    with pytest.raises(
+        pydantic.ValidationError,
+        match="fallback_pref and set_pref are mutually exclusive",
+    ):
+        DesktopFeatureVariable.model_validate(model_json)


### PR DESCRIPTION
Because:

- our schemas were still slightly misaligned with nimbus-shared and Firefox Desktop;
- some fields were missing descriptions; and
- the feature manifest formats for Desktop and the SDK are sufficiently different that they warrant separate schemas

This commit:

- splits the FeatureManifest schema into DesktopFeatureManifest and SdkFeatureManifest schemas;
- aligns the schemas with nimbus-shared and Desktop;
- adds field descriptions; and
- adds unit tests for the new validation logic.

Fixes #11571