### PR TITLE
chore(ci): Extend firefox iOS ci tests to test against specific branches.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -374,10 +374,13 @@ jobs:
   integration_test_ios_fennec:
     macos:
       xcode: 15.3.0
+    parameters:
+      file_path:
+        type: string
     steps:
       - checkout
       - check_file_paths:
-          paths: "experimenter/tests/firefox-fenix-build.env"
+          paths: << parameters.file_path >>
       - macos/preboot-simulator:
           version: "17.4"
           platform: "iOS"
@@ -386,7 +389,10 @@ jobs:
           at: /tmp/experimenter
       - run:
           name: Clone Firefox iOS Repo
-          command: git clone https://github.com/mozilla-mobile/firefox-ios.git
+          command: |
+            source << parameters.file_path >>
+            git clone https://github.com/mozilla-mobile/firefox-ios.git
+            git checkout "$BRANCH"
       - run:
           name: Install nimbus-cli
           command: curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/mozilla/application-services/main/install-nimbus-cli.sh | bash
@@ -818,9 +824,19 @@ workflows:
               only:
                 - check_external_firefox_integrations
       - integration_test_ios_fennec:
-          name: Test Firefox for iOS (Fennec)
+          name: Test Firefox for iOS (Fennec) Beta
           requires:
             - Create fenix and fennec recipes
+          file_path: experimenter/tests/firefox_fennec_beta_build.env
+          filters:
+            branches:
+              only:
+                - check_external_firefox_integrations
+      - integration_test_ios_fennec:
+          name: Test Firefox for iOS (Fennec) Release
+          requires:
+            - Create fenix and fennec recipes
+          file_path: experimenter/tests/firefox_fennec_release_build.env
           filters:
             branches:
               only:

--- a/experimenter/tests/firefox_fennec_beta_build.env
+++ b/experimenter/tests/firefox_fennec_beta_build.env
@@ -1,3 +1,3 @@
 FIREFOX_FENNEC_BETA_VERSION_ID="release/v132"
 BRANCH="release/v132"
-Firefox version is "131.0.3"
+# Firefox version is "131.0.3"

--- a/experimenter/tests/firefox_fennec_release_build.env
+++ b/experimenter/tests/firefox_fennec_release_build.env
@@ -1,3 +1,3 @@
 FIREFOX_FENNEC_RELEASE_VERSION_ID="Firefox v131.4"
 BRANCH="release/v131"
-Firefox version is "131.0.3"
+# Firefox version is "131.0.3"

--- a/scripts/external_integration_updater_script.sh
+++ b/scripts/external_integration_updater_script.sh
@@ -55,7 +55,7 @@ fetch_task_info() {
             echo "FIREFOX_FENNEC_RELEASE_VERSION_ID ${version}"
             echo "FIREFOX_FENNEC_RELEASE_VERSION_ID=${version}" > firefox_fennec_release_build.env
             echo "BRANCH=${branch}" >> firefox_fennec_release_build.env
-            echo "Firefox version is ${release_version}" >> firefox_fennec_release_build.env
+            echo "# Firefox version is ${release_version}" >> firefox_fennec_release_build.env
             mv firefox_fennec_release_build.env experimenter/tests
             return
             ;;
@@ -75,7 +75,7 @@ fetch_task_info() {
             echo "FIREFOX_FENNEC_BETA_VERSION_ID ${version}"
             echo "FIREFOX_FENNEC_BETA_VERSION_ID=${version}" > firefox_fennec_beta_build.env
             echo "BRANCH=${version}" >> firefox_fennec_beta_build.env
-            echo "Firefox version is ${release_version}" >> firefox_fennec_beta_build.env
+            echo "# Firefox version is ${release_version}" >> firefox_fennec_beta_build.env
             mv firefox_fennec_beta_build.env experimenter/tests
             return
             ;;


### PR DESCRIPTION
Because

- Our iOS integration tests only test against the `main` branch even though we are tracking release and beta branches.

This commit

- Parametrizes the iOS job in the `circleci.yml` to accept different types of files.
- Adds a `git checkout` to checkout the specific branch that has changed

Fixes #11597 