### PR TITLE
feat(nimbus): QA status tile

### DIFF
--- a/experimenter/experimenter/experiments/models.py
+++ b/experimenter/experimenter/experiments/models.py
@@ -1323,6 +1323,17 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
             .replace("\\n", "\n")  # Handle hard coded newlines in targeting
         )
 
+    @property
+    def qa_status_badge_class(self):
+        if self.qa_status == self.QAStatus.RED:
+            return "badge rounded-pill bg-danger"
+        elif self.qa_status == self.QAStatus.YELLOW:
+            return "badge rounded-pill bg-warning text-dark"
+        elif self.qa_status == self.QAStatus.GREEN:
+            return "badge rounded-pill bg-success"
+        else:
+            return "badge rounded-pill bg-secondary"
+
 
 class NimbusBranch(models.Model):
     experiment = models.ForeignKey(

--- a/experimenter/experimenter/experiments/tests/test_models.py
+++ b/experimenter/experimenter/experiments/tests/test_models.py
@@ -2582,6 +2582,23 @@ class TestNimbusExperiment(TestCase):
             )
             self.assertEqual(experiment.should_timeout, expected)
 
+    @parameterized.expand(
+        [
+            [NimbusExperiment.QAStatus.RED, "badge rounded-pill bg-danger"],
+            [
+                NimbusExperiment.QAStatus.YELLOW,
+                "badge rounded-pill bg-warning text-dark",
+            ],
+            [NimbusExperiment.QAStatus.GREEN, "badge rounded-pill bg-success"],
+            [NimbusExperiment.QAStatus.NOT_SET, "badge rounded-pill bg-secondary"],
+        ]
+    )
+    def test_qa_status_badge_class(self, qa_status, expected_badge_class):
+        experiment = NimbusExperimentFactory.create(
+            name="Test Experiment", slug="test-experiment", qa_status=qa_status
+        )
+        self.assertEqual(experiment.qa_status_badge_class, expected_badge_class)
+
     def test_clone_created_experiment(self):
         owner = UserFactory.create()
         required_experiment = NimbusExperimentFactory.create()

--- a/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/detail.html
+++ b/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/detail.html
@@ -11,6 +11,9 @@
     <div class="row">
       <div class="col-6">
         <h4 class="mb-0">{{ experiment.name }}</h4>
+        <span class="{{ experiment.qa_status_badge_class }}">
+          QA Status: {{ experiment.qa_status|default:"Not Set"|title }}
+        </span>
         <p class="text-secondary">{{ experiment.slug }}</p>
       </div>
       {% include "nimbus_experiments/timeline.html" %}


### PR DESCRIPTION
Because

- We want to show QA status on top as well so that reviewers can easily see the QA status

This commit

- Adds the QA status tile on top


<img width="1296" alt="Screenshot 2024-10-21 at 3 35 36 PM" src="https://github.com/user-attachments/assets/800a7db4-dcb7-448c-a461-6a4802b29006">
<img width="1296" alt="Screenshot 2024-10-21 at 3 35 25 PM" src="https://github.com/user-attachments/assets/75975e54-b5ce-4243-b9f0-4b1f34a743f5">
<img width="1296" alt="Screenshot 2024-10-21 at 3 35 15 PM" src="https://github.com/user-attachments/assets/67303fb3-ca4d-47be-b788-d437a5356d9c">
<img width="1296" alt="Screenshot 2024-10-21 at 3 35 03 PM" src="https://github.com/user-attachments/assets/c26c5cea-cc01-450c-a75f-2358d8eb0598">

Fixes #11591 