### PR TITLE
feat(nimbus): add pop ratio as valid stat for results ingestion

### DIFF
--- a/experimenter/experimenter/jetstream/client.py
+++ b/experimenter/experimenter/jetstream/client.py
@@ -38,6 +38,7 @@ ALL_STATISTICS = {
     Statistic.MEAN,
     Statistic.COUNT,
     Statistic.PERCENT,
+    Statistic.POPULATION_RATIO,
 }
 
 analysis_storage = storages["analysis"]

--- a/experimenter/experimenter/jetstream/models.py
+++ b/experimenter/experimenter/jetstream/models.py
@@ -43,6 +43,7 @@ class Statistic(StrEnum):
     BINOMIAL = "binomial"
     MEAN = "mean"
     COUNT = "count"
+    POPULATION_RATIO = "population_ratio"
 
 
 class Segment(StrEnum):

--- a/experimenter/experimenter/jetstream/tests/constants.py
+++ b/experimenter/experimenter/jetstream/tests/constants.py
@@ -395,6 +395,11 @@ class JetstreamTestData:
         VARIANT_DATA_DEFAULT_METRIC_ROW_MEAN.statistic = Statistic.MEAN
         VARIANT_DATA_DEFAULT_METRIC_ROW_MEAN.branch = "variant"
 
+        VARIANT_DATA_DEFAULT_METRIC_ROW_RATIO = DATA_IDENTITY_ROW.copy()
+        VARIANT_DATA_DEFAULT_METRIC_ROW_RATIO.metric = "some_ratio"
+        VARIANT_DATA_DEFAULT_METRIC_ROW_RATIO.statistic = Statistic.POPULATION_RATIO
+        VARIANT_DATA_DEFAULT_METRIC_ROW_RATIO.branch = "variant"
+
         VARIANT_DATA_DEFAULT_METRIC_ROW_BINOMIAL = DATA_IDENTITY_ROW.copy()
         VARIANT_DATA_DEFAULT_METRIC_ROW_BINOMIAL.metric = "another_count"
         VARIANT_DATA_DEFAULT_METRIC_ROW_BINOMIAL.statistic = Statistic.BINOMIAL
@@ -456,6 +461,16 @@ class JetstreamTestData:
             AnalysisBasis.EXPOSURES
         )
 
+        EXPOSURES_VARIANT_DATA_DEFAULT_METRIC_ROW_RATIO = DATA_IDENTITY_ROW.copy()
+        EXPOSURES_VARIANT_DATA_DEFAULT_METRIC_ROW_RATIO.metric = "some_ratio"
+        EXPOSURES_VARIANT_DATA_DEFAULT_METRIC_ROW_RATIO.statistic = (
+            Statistic.POPULATION_RATIO
+        )
+        EXPOSURES_VARIANT_DATA_DEFAULT_METRIC_ROW_RATIO.branch = "variant"
+        EXPOSURES_VARIANT_DATA_DEFAULT_METRIC_ROW_RATIO.analysis_basis = (
+            AnalysisBasis.EXPOSURES
+        )
+
         EXPOSURES_VARIANT_DATA_DEFAULT_METRIC_ROW_BINOMIAL = DATA_IDENTITY_ROW.copy()
         EXPOSURES_VARIANT_DATA_DEFAULT_METRIC_ROW_BINOMIAL.metric = "another_count"
         EXPOSURES_VARIANT_DATA_DEFAULT_METRIC_ROW_BINOMIAL.statistic = Statistic.BINOMIAL
@@ -487,6 +502,7 @@ class JetstreamTestData:
             CONTROL_DATA_ROW.dict(exclude_none=True),
             VARIANT_DATA_ROW.dict(exclude_none=True),
             VARIANT_DATA_DEFAULT_METRIC_ROW_MEAN.dict(exclude_none=True),
+            VARIANT_DATA_DEFAULT_METRIC_ROW_RATIO.dict(exclude_none=True),
             VARIANT_DATA_DEFAULT_METRIC_ROW_BINOMIAL.dict(exclude_none=True),
             VARIANT_POSITIVE_SIGNIFICANCE_DATA_ROW.dict(exclude_none=True),
             VARIANT_NEGATIVE_SIGNIFICANCE_DATA_ROW.dict(exclude_none=True),
@@ -498,6 +514,7 @@ class JetstreamTestData:
             EXPOSURES_CONTROL_DATA_ROW.dict(exclude_none=True),
             EXPOSURES_VARIANT_DATA_ROW.dict(exclude_none=True),
             EXPOSURES_VARIANT_DATA_DEFAULT_METRIC_ROW_MEAN.dict(exclude_none=True),
+            EXPOSURES_VARIANT_DATA_DEFAULT_METRIC_ROW_RATIO.dict(exclude_none=True),
             EXPOSURES_VARIANT_DATA_DEFAULT_METRIC_ROW_BINOMIAL.dict(exclude_none=True),
             EXPOSURES_VARIANT_POSITIVE_SIGNIFICANCE_DATA_ROW.dict(exclude_none=True),
             EXPOSURES_VARIANT_NEGATIVE_SIGNIFICANCE_DATA_ROW.dict(exclude_none=True),
@@ -569,6 +586,7 @@ class JetstreamTestData:
                     Group.OTHER.value: {
                         "identity": ABSOLUTE_METRIC_DATA_A.dict(exclude_none=True),
                         "some_count": EMPTY_METRIC_DATA.dict(exclude_none=True),
+                        "some_ratio": EMPTY_METRIC_DATA.dict(exclude_none=True),
                         "another_count": EMPTY_METRIC_DATA.dict(exclude_none=True),
                         "retained": DIFFERENCE_METRIC_DATA_WEEKLY_NEUTRAL_VARIANT.dict(
                             exclude_none=True
@@ -591,6 +609,7 @@ class JetstreamTestData:
                     Group.OTHER.value: {
                         "identity": ABSOLUTE_METRIC_DATA_A.dict(exclude_none=True),
                         "some_count": ABSOLUTE_METRIC_DATA_A.dict(exclude_none=True),
+                        "some_ratio": EMPTY_METRIC_DATA.dict(exclude_none=True),
                         "another_count": ABSOLUTE_METRIC_DATA_A.dict(exclude_none=True),
                         "retained": DIFFERENCE_METRIC_DATA_WEEKLY_NEGATIVE_CONTROL.dict(
                             exclude_none=True
@@ -614,6 +633,7 @@ class JetstreamTestData:
                             exclude_none=True
                         ),
                         "some_count": EMPTY_METRIC_DATA.dict(exclude_none=True),
+                        "some_ratio": EMPTY_METRIC_DATA.dict(exclude_none=True),
                         "another_count": EMPTY_METRIC_DATA.dict(exclude_none=True),
                         "default_browser_action": EMPTY_METRIC_DATA.dict(
                             exclude_none=True
@@ -641,6 +661,7 @@ class JetstreamTestData:
                             exclude_none=True
                         ),
                         "some_count": ABSOLUTE_METRIC_DATA_F.dict(exclude_none=True),
+                        "some_ratio": EMPTY_METRIC_DATA.dict(exclude_none=True),
                         "another_count": ABSOLUTE_METRIC_DATA_F.dict(exclude_none=True),
                         "retained": DIFFERENCE_METRIC_DATA_OVERALL_NEGATIVE_CONTROL.dict(
                             exclude_none=True


### PR DESCRIPTION
Because

- population ratio stats are available
- pop ratio results look like other stats that we visualize

This commit

- adds pop ratio as a valid stat during jetstream results ingestion

Fixes #9083 