### PR TITLE
fixes #11610 feat(nimbus): add targeting configuration for android version 10 and higher

### DIFF
--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -1819,6 +1819,17 @@ ANDROID_8_OR_HIGHER_USERS = NimbusTargetingConfig(
     application_choice_names=(Application.FENIX.name,),
 )
 
+ANDROID_10_OR_HIGHER_USERS = NimbusTargetingConfig(
+    name="Android Version 10+ Users",
+    slug="android_10_or_higher_users",
+    description="Users on Android version 10 or higher",
+    targeting="(android_sdk_version|versionCompare('29') >= 0)",
+    desktop_telemetry="",
+    sticky_required=False,
+    is_first_run_required=False,
+    application_choice_names=(Application.FENIX.name,),
+)
+
 WINDOWS_10_PLUS = NimbusTargetingConfig(
     name="Windows 10+",
     slug="windows_10_plus",


### PR DESCRIPTION
Because

- A targeting config targeting Android version 10 and above is needed for https://github.com/mozilla/experimenter/issues/11610

This commit

- Adds the aforementioned targeting config


This is essentially a clone of the existing [Android 8 targeting configuration task](https://github.com/mozilla/experimenter/pull/9400).
cc @jeddai 