### PR TITLE
feat(nimbus): Store sizing data as JSON in the cache and validate

### DIFF
--- a/experimenter/experimenter/experiments/api/v5/types.py
+++ b/experimenter/experimenter/experiments/api/v5/types.py
@@ -1,10 +1,13 @@
 import json
+import logging
 
 import graphene
+from django.conf import settings
 from django.contrib.auth.models import User
 from django.core.cache import cache
 from graphene_django import DjangoListField
 from graphene_django.types import DjangoObjectType
+from mozilla_nimbus_schemas.jetstream import SampleSizes
 
 from experimenter.base.models import Country, Language, Locale
 from experimenter.experiments.api.v5.serializers import (
@@ -26,7 +29,8 @@ from experimenter.experiments.models import (
 )
 from experimenter.outcomes import Outcomes
 from experimenter.projects.models import Project
-from experimenter.settings import SIZING_DATA_KEY
+
+logger = logging.getLogger(__name__)
 
 
 class NimbusExperimentStatusEnum(graphene.Enum):
@@ -396,8 +400,20 @@ class NimbusConfigurationType(graphene.ObjectType):
         )
 
     def resolve_population_sizing_data(self, info):
-        sizing_data = cache.get(SIZING_DATA_KEY)
-        return sizing_data.json() if sizing_data else "{}"
+        try:
+            sizing_data = cache.get(settings.SIZING_DATA_KEY)
+            if not isinstance(sizing_data, str):
+                raise TypeError(f"expected str, got {type(sizing_data).__name__}")
+
+            return SampleSizes.parse_raw(sizing_data).json()
+        except Exception as e:
+            logger.error(
+                f"Could not parse sizing data in cache key '{settings.SIZING_DATA_KEY}': "
+                f"{e}; evicting cache entry"
+            )
+            cache.delete(settings.SIZING_DATA_KEY)
+
+        return "{}"
 
     @staticmethod
     def sort_version_choices(choices):

--- a/experimenter/experimenter/jetstream/tasks.py
+++ b/experimenter/experimenter/jetstream/tasks.py
@@ -2,13 +2,13 @@ import datetime as dt
 
 import markus
 from celery.utils.log import get_task_logger
+from django.conf import settings
 from django.core.cache import cache
 
 from experimenter.celery import app
 from experimenter.experiments.constants import NimbusConstants
 from experimenter.experiments.models import NimbusExperiment
 from experimenter.jetstream.client import get_experiment_data, get_population_sizing_data
-from experimenter.settings import SIZING_DATA_KEY
 
 logger = get_task_logger(__name__)
 metrics = markus.get_metrics("jetstream.tasks")
@@ -80,7 +80,9 @@ def fetch_population_sizing_data():
         sizing_data = get_population_sizing_data()
         sizing = sizing_data.get("v1")
 
-        cache.set(SIZING_DATA_KEY, sizing)
+        if sizing is not None:
+            cache.set(settings.SIZING_DATA_KEY, sizing.json())
+
         metrics.incr("fetch_population_sizing_data.completed")
     except Exception as e:
         metrics.incr("fetch_population_sizing_data.failed")

--- a/experimenter/experimenter/jetstream/tests/mixins.py
+++ b/experimenter/experimenter/jetstream/tests/mixins.py
@@ -1,8 +1,7 @@
+from django.conf import settings
 from django.core.cache import cache
 from django.test import TestCase, override_settings
 from mozilla_nimbus_schemas.jetstream import SampleSizesFactory
-
-from experimenter.settings import SIZING_DATA_KEY
 
 
 @override_settings(
@@ -19,9 +18,11 @@ class MockSizingDataMixin(TestCase):
         super().setUp()
         cache.clear()
 
-    def setup_cached_sizing_data(self):
-        self.sizing_test_data = SampleSizesFactory.build()
-        cache.set(SIZING_DATA_KEY, self.sizing_test_data)
+    def setup_cached_sizing_data(self, data=None):
+        self.sizing_test_data = data
+        if self.sizing_test_data is None:
+            self.sizing_test_data = SampleSizesFactory.build().json()
+        cache.set(settings.SIZING_DATA_KEY, self.sizing_test_data)
 
     def get_cached_sizing_data(self):
         return self.sizing_test_data

--- a/experimenter/experimenter/jetstream/tests/test_tasks.py
+++ b/experimenter/experimenter/jetstream/tests/test_tasks.py
@@ -2,9 +2,10 @@ import datetime
 import json
 from unittest.mock import patch
 
+from django.conf import settings
 from django.core.cache import cache
 from django.test import TestCase, override_settings
-from mozilla_nimbus_schemas.jetstream import SampleSizesFactory
+from mozilla_nimbus_schemas.jetstream import SampleSizes, SampleSizesFactory
 from parameterized import parameterized
 
 from experimenter.experiments.models import NimbusExperiment
@@ -20,7 +21,6 @@ from experimenter.jetstream.tests.constants import (
 )
 from experimenter.jetstream.tests.mixins import MockSizingDataMixin
 from experimenter.outcomes import Outcomes
-from experimenter.settings import SIZING_DATA_KEY
 
 
 @mock_valid_outcomes
@@ -2350,11 +2350,11 @@ class TestFetchJetstreamDataTask(MockSizingDataMixin, TestCase):
         mock_open.side_effect = open_file
         mock_exists.return_value = True
 
-        sizing_results = cache.get(SIZING_DATA_KEY)
+        sizing_results = cache.get(settings.SIZING_DATA_KEY)
         self.assertIsNone(sizing_results)
 
         tasks.fetch_population_sizing_data()
-        sizing_results = cache.get(SIZING_DATA_KEY)
+        sizing_results = SampleSizes.parse_raw(cache.get(settings.SIZING_DATA_KEY))
 
         self.assertEqual(
             json.dumps(json.loads(sizing_test_data)),
@@ -2377,12 +2377,12 @@ class TestFetchJetstreamDataTask(MockSizingDataMixin, TestCase):
         mock_open.side_effect = open_file
         mock_exists.return_value = True
 
-        sizing_results = cache.get(SIZING_DATA_KEY)
+        sizing_results = cache.get(settings.SIZING_DATA_KEY)
         self.assertIsNone(sizing_results)
 
         tasks.fetch_population_sizing_data()
-        sizing_results = cache.get(SIZING_DATA_KEY)
-        self.assertEqual(sizing_results.json(), "{}")
+        sizing_results = cache.get(settings.SIZING_DATA_KEY)
+        self.assertEqual(sizing_results, "{}")
 
     @patch("experimenter.jetstream.client.analysis_storage.open")
     @patch("experimenter.jetstream.client.analysis_storage.exists")

--- a/experimenter/experimenter/settings.py
+++ b/experimenter/experimenter/settings.py
@@ -369,6 +369,10 @@ CACHES = {
         "BACKEND": "django_redis.cache.RedisCache",
         "LOCATION": f"redis://{REDIS_HOST}:{REDIS_PORT}/{REDIS_DB}",
         "TIMEOUT": None,
+        "OPTIONS": {
+            "CLIENT_CLASS": "django_redis.client.DefaultClient",
+            "SERIALIZER": "django_redis.serializers.json.JSONSerializer",
+        },
     },
 }
 API_CACHE_DURATION = 60 * 60


### PR DESCRIPTION
Because:

- by default, django-redis will pickle objects to cache them;
- we were storing pickled SampleSizes instances in the cache; and
- updating to mozilla-nimbus-schemas v2024.10.1 (and pydantic v2) broke the unpickling

This commit:

- changes our django-redis configuration to use a JSON serializer;
- updates the usage of the cache to always store a JSON representation of the sizing data; and
- evicts invalid sample size cache entries if they cannot be parsed

Fixes #11638