### PR TITLE
chore(project): update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,6 @@
 /cirrus/ @jaredlockhart @yashikakhurana @jeddai
 /experimenter/experimenter/ @jaredlockhart @yashikakhurana @brennie
+/experimenter/jetstream @jaredlockhart @mikewilli
 /experimenter/manifesttool/ @jaredlockhart @brennie
-/schemas/ @jaredlockhart @mikewilli
 /experimenter/tests @b4handjr
+/schemas/ @jaredlockhart @mikewilli


### PR DESCRIPTION
Because:

- Mike was not listed as a code owner for jetstream; and
- the file was not sorted

This commit:

- adds Mike as an owner for jetstream; and
- sorts the file.

Fixes #11641.