### PR TITLE
chore(schemas): upgrade to Poetry 1.8.4

### DIFF
--- a/schemas/Dockerfile
+++ b/schemas/Dockerfile
@@ -33,7 +33,7 @@ RUN . "$NVM_DIR/nvm.sh" && nvm alias default v${NODE_VERSION}
 ENV PYTHONDONTWRITEBYTECODE 1
 
 # Python packages
-RUN curl -sSL https://install.python-poetry.org | python3 - --version 1.6.0
+RUN curl -sSL https://install.python-poetry.org | python3 - --version 1.8.4
 ENV PATH "/root/.local/bin:$PATH"
 RUN poetry config virtualenvs.create false
 

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -5,8 +5,8 @@ This directory contains a package of schemas published to various repositories f
 
 ## Installation/Usage
 ### Prerequisites
-- python ^3.11
-- poetry ^1.2.2
+- python ^3.10
+- poetry ^1.8.4
 - node ^16
 - yarn ^1.22
 


### PR DESCRIPTION
chore(schemas): upgrade to Poetry 1.8.4

Because:

- everything else is using Poetry 1.8.4; and
- the README says we're using Python 3.11 but actually we're using 3.10

This commit:

- updates mozilla_nimbus_schemas to use Poetry 1.8.4; and
- updates the Python version in the README.

Fixes #11645
