### PR TITLE
bug(project): disable signed urls

### DIFF
--- a/experimenter/experimenter/settings.py
+++ b/experimenter/experimenter/settings.py
@@ -506,11 +506,14 @@ UPLOADS_FILE_STORAGE = config(
 STORAGES = {
     "default": {
         "BACKEND": UPLOADS_FILE_STORAGE,
-        "OPTIONS": {
-            "bucket_name": UPLOADS_GS_BUCKET_NAME,
-        }
-        if UPLOADS_GS_BUCKET_NAME
-        else {},
+        "OPTIONS": (
+            {
+                "bucket_name": UPLOADS_GS_BUCKET_NAME,
+                "querystring_auth": False,
+            }
+            if UPLOADS_GS_BUCKET_NAME
+            else {}
+        ),
     },
     "staticfiles": {
         "BACKEND": "django.contrib.staticfiles.storage.StaticFilesStorage",


### PR DESCRIPTION
Because

* As part of the migration to GCPV2 we discovered that django-storages has an open bug for supporting signed urls
* We generate GCS bucket urls for uploaded images (ie branch screenshots)
* To display those screenshots we need URLs
* Using signed URLs is not supported on the new GCPV2 deployment
* We can disable signed URLs altogether until it is supported by django-storages

This commit

* Disables signed urls

fixes #11651

