### PR TITLE
bug(nimbus): dont throw when cached population sizing data is None

### DIFF
--- a/experimenter/experimenter/experiments/api/v5/types.py
+++ b/experimenter/experimenter/experiments/api/v5/types.py
@@ -402,10 +402,11 @@ class NimbusConfigurationType(graphene.ObjectType):
     def resolve_population_sizing_data(self, info):
         try:
             sizing_data = cache.get(settings.SIZING_DATA_KEY)
-            if not isinstance(sizing_data, str):
-                raise TypeError(f"expected str, got {type(sizing_data).__name__}")
+            if sizing_data is not None:
+                if not isinstance(sizing_data, str):
+                    raise TypeError(f"expected str, got {type(sizing_data).__name__}")
 
-            return SampleSizes.parse_raw(sizing_data).json()
+                return SampleSizes.parse_raw(sizing_data).json()
         except Exception as e:
             logger.error(
                 f"Could not parse sizing data in cache key '{settings.SIZING_DATA_KEY}': "


### PR DESCRIPTION
Because:

- we now throw when we get an unexpected data type from the cache when reading the population sizing data; and
- we are not doing a check for None, which is causing an exception to be logged for every graphQL query for nimbus configuration

This commit:

- adds an explicit `is not None` check to the cache read.

Fixes #11654