### PR TITLE
bug(nimbus): Don't use the JSON django-redis serializer

### DIFF
--- a/experimenter/experimenter/settings.py
+++ b/experimenter/experimenter/settings.py
@@ -369,10 +369,6 @@ CACHES = {
         "BACKEND": "django_redis.cache.RedisCache",
         "LOCATION": f"redis://{REDIS_HOST}:{REDIS_PORT}/{REDIS_DB}",
         "TIMEOUT": None,
-        "OPTIONS": {
-            "CLIENT_CLASS": "django_redis.client.DefaultClient",
-            "SERIALIZER": "django_redis.serializers.json.JSONSerializer",
-        },
     },
 }
 API_CACHE_DURATION = 60 * 60


### PR DESCRIPTION
Because:

- we're caching some of our HTTP responses in the API; and
- these responses are not JSON serializable

This commit:

- reverts us to using the default pickle serializer for django-redis.

Fixes #11656