### PR TITLE
feat(project): add a make refresh_db target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -201,7 +201,9 @@ migrate: build_dev  ## Run database migrations
 bash: build_dev
 	$(COMPOSE) run experimenter bash
 
-refresh: kill build_dev compose_build  ## Rebuild all containers
+refresh: kill build_dev compose_build refresh_db  ## Rebuild all containers and the database
+
+refresh_db:  # Rebuild the database
 	$(COMPOSE) run -e SKIP_DUMMY=$$SKIP_DUMMY experimenter bash -c '$(WAIT_FOR_DB) $(PYTHON_MIGRATE)&&$(LOAD_LOCALES)&&$(LOAD_COUNTRIES)&&$(LOAD_LANGUAGES)&&$(LOAD_FEATURES)&&$(LOAD_DUMMY_EXPERIMENTS)'
 
 dependabot_approve:

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Check out the [🌩 **Nimbus Documentation Hub**](https://experimenter.info) or 
 
 1.  Setup the database
 
-        make refresh
+        make refresh_db
 
 #### Fully Dockerized Setup (continuation from General Setup 1-7)
 
@@ -298,7 +298,10 @@ Populates the database with dummy experiments of all types/statuses using the te
 
 #### make refresh
 
-Run kill, migrate, load_locales_countries load_dummy_experiments. Useful for resetting your dev environment when switching branches or after package updates.
+Run kill followed by refresh_db. Useful for resetting your dev environment when switching branches or after package updates.
+
+### make refresh_db
+Run migrate, load_locales_countries, and load_dummy_experiments.
 
 ### Running a dev instance
 


### PR DESCRIPTION
Because:

- make refresh does rebuild the DB but also blows away all containers; and
- I just want to rebuild the DB

This commit:

- adds a make refresh_db (which refresh depends on) that will just recreate the database.

Fixes #11661