### PR TITLE
chore(project): Stop publishing experimenter to dockerhub for deployment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -441,33 +441,6 @@ jobs:
       docker_layer_caching: true
     steps:
       - checkout
-      - docker_login:
-          username: $DOCKER_USER
-          password: $DOCKER_PASS
-      - run:
-          name: Deploy to Dockerhub
-          command: |
-            ./scripts/store_git_info.sh
-            make build_prod
-            docker tag experimenter:deploy ${DOCKERHUB_REPO}:latest
-            docker push ${DOCKERHUB_REPO}:latest
-            GIT_SHA=$(git rev-parse --short HEAD)
-            docker tag experimenter:deploy ${DOCKERHUB_REPO}:${GIT_SHA}
-            docker push ${DOCKERHUB_REPO}:${GIT_SHA}
-      - gcp-cli/setup
-      - run:
-          name: Deploy to Google Container Registry
-          command: |
-            echo $GCLOUD_SERVICE_KEY | gcloud auth activate-service-account --key-file=-
-            gcloud --quiet config set project ${GOOGLE_PROJECT_ID}
-            gcloud --quiet config set compute/zone ${GOOGLE_COMPUTE_ZONE}
-            gcloud auth configure-docker
-            DOCKER_IMAGE="gcr.io/${GOOGLE_PROJECT_ID}/experimenter"
-            docker tag experimenter:deploy ${DOCKER_IMAGE}:latest
-            docker push "${DOCKER_IMAGE}:latest"
-            GIT_SHA=$(git rev-parse --short HEAD)
-            docker tag experimenter:deploy ${DOCKERHUB_REPO}:${GIT_SHA}
-            docker push ${DOCKERHUB_REPO}:${GIT_SHA}
       - run:
           name: Prepare environment variables for OIDC authentication
           command: |
@@ -481,6 +454,8 @@ jobs:
       - run:
           name: Deploy to Google Artifact Registry
           command: |
+            ./scripts/store_git_info.sh
+            make build_prod
             gcloud auth configure-docker us-docker.pkg.dev --quiet
             DOCKER_IMAGE="us-docker.pkg.dev/moz-fx-experimenter-prod-6cd5/experimenter-prod/experimenter"
             docker tag experimenter:deploy ${DOCKER_IMAGE}:latest


### PR DESCRIPTION
Because:

- we are deploying through GAR images now

This commit:

- removes our push to dockerhub; and
- removes our push to gcr

Fixes #11665