### PR TITLE
chore(nimbus): Use new ENV KEY=value syntax in all Dockerfiles

### DIFF
--- a/cirrus/server/Dockerfile
+++ b/cirrus/server/Dockerfile
@@ -17,7 +17,7 @@ ENV PATH=$PATH:/root/.cargo/bin
 RUN curl -sSL https://install.python-poetry.org | python3 - --version 1.6.0
 
 # Add poetry to PATH environment variable
-ENV PATH "/root/.local/bin:$PATH"
+ENV PATH="/root/.local/bin:$PATH"
 
 # Copy only the pyproject.toml file and poetry.lock file to install dependencies ignoring dev dependencies
 COPY pyproject.toml /cirrus/

--- a/experimenter/Dockerfile
+++ b/experimenter/Dockerfile
@@ -17,16 +17,16 @@ RUN . "$NVM_DIR/nvm.sh" && nvm use v${NODE_VERSION}
 RUN . "$NVM_DIR/nvm.sh" && nvm alias default v${NODE_VERSION}
 
 # Disable python pyc files
-ENV PYTHONDONTWRITEBYTECODE 1
+ENV PYTHONDONTWRITEBYTECODE=1
 
 # Python packages
 RUN curl -sSL https://install.python-poetry.org | python3 - --version 1.8.4
-ENV PATH "/root/.local/bin:$PATH"
+ENV PATH="/root/.local/bin:$PATH"
 RUN poetry config virtualenvs.create false
 
 # Rust cargo
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | /bin/sh -s -- -y --profile minimal
-ENV PATH "/root/.cargo/bin:$PATH"
+ENV PATH="/root/.cargo/bin:$PATH"
 
 # Python image
 #-------------------------
@@ -123,7 +123,7 @@ WORKDIR /experimenter
 EXPOSE 7001
 
 # Disable python pyc files
-ENV PYTHONDONTWRITEBYTECODE 1
+ENV PYTHONDONTWRITEBYTECODE=1
 
 # System packages
 RUN apt-get update

--- a/schemas/Dockerfile
+++ b/schemas/Dockerfile
@@ -8,20 +8,20 @@ RUN apt-get update
 RUN apt-get --no-install-recommends install -y apt-utils ca-certificates yarn parallel
 
 # Install nvm with node and npm
-ENV NODE_VERSION 16.19.0
-ENV NVM_DIR /root/.nvm
-ENV PATH "/root/.nvm/versions/node/v${NODE_VERSION}/bin/:${PATH}"
+ENV NODE_VERSION=16.19.0
+ENV NVM_DIR=/root/.nvm
+ENV PATH="/root/.nvm/versions/node/v${NODE_VERSION}/bin/:${PATH}"
 RUN curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.35.3/install.sh | bash
 RUN . "$NVM_DIR/nvm.sh" && nvm install ${NODE_VERSION}
 RUN . "$NVM_DIR/nvm.sh" && nvm use v${NODE_VERSION}
 RUN . "$NVM_DIR/nvm.sh" && nvm alias default v${NODE_VERSION}
 
 # Disable python pyc files
-ENV PYTHONDONTWRITEBYTECODE 1
+ENV PYTHONDONTWRITEBYTECODE=1
 
 # Python packages
 RUN curl -sSL https://install.python-poetry.org | python3 - --version 1.8.4
-ENV PATH "/root/.local/bin:$PATH"
+ENV PATH="/root/.local/bin:$PATH"
 RUN poetry config virtualenvs.create false
 
 


### PR DESCRIPTION
Because:

- Docker has deprecated `ENV KEY value` syntax and is now complaining about our usage

This commit:

- updates our usage to the new syntax.

Fixes #11678