### PR TITLE
bug(nimbus): wrap v7 NimbusExperimentSerializer.get_localizations in try/except

### DIFF
--- a/experimenter/experimenter/experiments/api/v7/serializers.py
+++ b/experimenter/experimenter/experiments/api/v7/serializers.py
@@ -131,7 +131,10 @@ class NimbusExperimentSerializer(serializers.ModelSerializer):
 
     def get_localizations(self, obj):
         if obj.is_localized:
-            return json.loads(obj.localizations)
+            try:
+                return json.loads(obj.localizations)
+            except json.decoder.JSONDecodeError:
+                return None
 
     def get_locales(self, obj):
         locale_codes = [locale.code for locale in obj.locales.all()]

--- a/experimenter/experimenter/experiments/tests/api/v7/test_serializers.py
+++ b/experimenter/experimenter/experiments/tests/api/v7/test_serializers.py
@@ -39,9 +39,9 @@ class TestNimbusExperimentSerializer(TestCase):
             secondary_outcomes=["quux", "xyzzy"],
             locales=[locale_en_us],
             is_localized=localizations is not None,
-            localizations=json.dumps(localizations)
-            if localizations is not None
-            else None,
+            localizations=(
+                json.dumps(localizations) if localizations is not None else None
+            ),
             _enrollment_end_date=datetime.date(2022, 1, 5),
         )
         serializer = NimbusExperimentSerializer(experiment)
@@ -135,3 +135,13 @@ class TestNimbusExperimentSerializer(TestCase):
                 },
                 branches_data,
             )
+
+    def test_serializer_invalid_localizations_field(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.ENDING_APPROVE_APPROVE,
+            is_localized=True,
+            localizations="",
+        )
+
+        serializer = NimbusExperimentSerializer(experiment)
+        self.assertEqual(serializer.data["localizations"], None)


### PR DESCRIPTION
Because:

- it should be impossible to launch an experiment with `is_localized=True` and an empty `localizations` field; but
- #11767 made it possible to do so

This commit:

- adds a try/except around the `json.loads()` in `NimbusExperimentSerializer.get_localizations`

Fixes #11763
