### PR TITLE
chore(tests): Add error catch for SDK Targeting helper methods on startup.

### DIFF
--- a/experimenter/tests/integration/nimbus/utils/helpers.py
+++ b/experimenter/tests/integration/nimbus/utils/helpers.py
@@ -9,7 +9,7 @@ from nimbus.models.base_dataclass import (
     BaseExperimentApplications,
 )
 
-LOAD_DATA_RETRIES = 10
+LOAD_DATA_RETRIES = 30
 LOAD_DATA_RETRY_DELAY = 1.0
 
 


### PR DESCRIPTION
Because

- There have been intermittent errors on CI within the SDK targeting tests. These are due to the test making a query to the graphQL API before it is ready.

This commit

- Adds a retry within the called function to attempt to query the API again if it fails.

Fixes #11766 