### PR TITLE
feat(nimbus): format JSON for better readability in branch configuration

### DIFF
--- a/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/detail.html
+++ b/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/detail.html
@@ -276,7 +276,7 @@
                   <tr>
                     <th>{{ feature_value.feature_config.name|format_not_set }} Value</th>
                     <td colspan="3">
-                      <code>{{ feature_value.value|format_json }}</code>
+                      <code>{{ feature_value.value|format_not_set|format_json }}</code>
                     </td>
                   </tr>
                 {% endfor %}

--- a/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/detail.html
+++ b/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/detail.html
@@ -275,7 +275,9 @@
                 {% for feature_value in branch.feature_values.all %}
                   <tr>
                     <th>{{ feature_value.feature_config.name|format_not_set }} Value</th>
-                    <td colspan="3">{{ feature_value.value|format_not_set }}</td>
+                    <td colspan="3">
+                      <code>{{ feature_value.value|format_json }}</code>
+                    </td>
                   </tr>
                 {% endfor %}
               {% else %}

--- a/experimenter/experimenter/nimbus_ui_new/templatetags/nimbus_extras.py
+++ b/experimenter/experimenter/nimbus_ui_new/templatetags/nimbus_extras.py
@@ -71,17 +71,13 @@ def format_not_set(value):
 
 @register.filter(name="format_json")
 def format_json(value):
-    """Formats the JSON value for display by pretty-printing the JSON,
-    and if the JSON is empty or None, it calls format_not_set."""
-    if value in [None, "", "NOT SET"]:
-        return format_not_set(value)
-
+    """Formats the JSON value for display by pretty-printing it."""
     try:
         parsed_json = json.dumps(json.loads(value), indent=2)
     except (json.JSONDecodeError, TypeError):
         parsed_json = value
 
     return mark_safe(
-        '<pre class="text-monospace" style="white-space: pre-wrap; '
-        'word-wrap: break-word;">' + parsed_json + "</pre>"
+        f'<pre class="text-monospace" style="white-space: pre-wrap; '
+        f'word-wrap: break-word;">{parsed_json}</pre>'
     )

--- a/experimenter/experimenter/nimbus_ui_new/templatetags/nimbus_extras.py
+++ b/experimenter/experimenter/nimbus_ui_new/templatetags/nimbus_extras.py
@@ -1,3 +1,5 @@
+import json
+
 from django import template
 from django.utils.safestring import mark_safe
 
@@ -65,3 +67,21 @@ def format_not_set(value):
     if value in [None, "", "NOT SET"]:
         return mark_safe('<span class="text-danger">Not set</span>')
     return value
+
+
+@register.filter(name="format_json")
+def format_json(value):
+    """Formats the JSON value for display by pretty-printing the JSON,
+    and if the JSON is empty or None, it calls format_not_set."""
+    if value in [None, "", "NOT SET"]:
+        return format_not_set(value)
+
+    try:
+        parsed_json = json.dumps(json.loads(value), indent=2)
+    except (json.JSONDecodeError, TypeError):
+        parsed_json = value
+
+    return mark_safe(
+        '<pre class="text-monospace" style="white-space: pre-wrap; '
+        'word-wrap: break-word;">' + parsed_json + "</pre>"
+    )

--- a/experimenter/experimenter/nimbus_ui_new/tests/test_filters.py
+++ b/experimenter/experimenter/nimbus_ui_new/tests/test_filters.py
@@ -1,6 +1,7 @@
 from django.test import TestCase
 
 from experimenter.nimbus_ui_new.templatetags.nimbus_extras import (
+    format_json,
     format_not_set,
     remove_underscores,
 )
@@ -24,3 +25,27 @@ class FilterTests(TestCase):
             '<span class="text-danger">Not set</span>',
         )
         self.assertEqual(format_not_set("Some value"), "Some value")
+
+    def test_format_json(self):
+        input_json = '{"key": "value", "number": 123}'
+        expected_output = (
+            '<pre class="text-monospace" style="white-space: pre-wrap; '
+            'word-wrap: break-word;">'
+            '{\n  "key": "value",\n  "number": 123\n}'
+            "</pre>"
+        )
+        result = format_json(input_json)
+        self.assertEqual(result, expected_output)
+
+        self.assertEqual(
+            format_json(""),
+            format_not_set(""),
+        )
+
+        self.assertEqual(
+            format_json("{key: value}"),
+            '<pre class="text-monospace" '
+            'style="white-space: pre-wrap; word-wrap: break-word;">'
+            "{key: value}"
+            "</pre>",
+        )

--- a/experimenter/experimenter/nimbus_ui_new/tests/test_filters.py
+++ b/experimenter/experimenter/nimbus_ui_new/tests/test_filters.py
@@ -38,11 +38,6 @@ class FilterTests(TestCase):
         self.assertEqual(result, expected_output)
 
         self.assertEqual(
-            format_json(""),
-            format_not_set(""),
-        )
-
-        self.assertEqual(
             format_json("{key: value}"),
             '<pre class="text-monospace" '
             'style="white-space: pre-wrap; word-wrap: break-word;">'


### PR DESCRIPTION
Because

* Branch configuration values were displayed in paragraph format, making them difficult to read

This commit

* Pretty-prints JSON with indentation for improved readability in the branch configuration

Fixes #11722

![image](https://github.com/user-attachments/assets/8b50f347-a4de-4222-87fc-a0364029738a)
![image](https://github.com/user-attachments/assets/14bbdb95-5399-42e0-b638-71d52cc7ba63)
