### PR TITLE
fix(nimbus): change jetstream fetch to integer scheduling

### DIFF
--- a/experimenter/experimenter/settings.py
+++ b/experimenter/experimenter/settings.py
@@ -13,7 +13,6 @@ https://docs.djangoproject.com/en/1.9/ref/settings/
 from pathlib import Path
 from urllib.parse import urljoin
 
-from celery.schedules import crontab
 from decouple import config
 from django.contrib.admin import ModelAdmin, StackedInline, TabularInline
 from django.db.models import DecimalField, ForeignKey, JSONField, ManyToManyField
@@ -391,11 +390,11 @@ CELERY_BEAT_SCHEDULE = {
     },
     "fetch_jetstream_data": {
         "task": "experimenter.jetstream.tasks.fetch_jetstream_data",
-        "schedule": crontab(minute=0, hour="*/6"),
+        "schedule": 14400,  # 4 hours
     },
     "fetch_population_sizing_data": {
         "task": "experimenter.jetstream.tasks.fetch_population_sizing_data",
-        "schedule": 86400,
+        "schedule": 86400,  # 24 hours
     },
 }
 


### PR DESCRIPTION
Because

- jetstream fetch isn't firing
- jetstream fetch is the only scheduled task using crontab style schedule

This commit

- changes the jetstream fetch to integer-based schedule
- decreases the scheduled time from 6 to 4 hours to account for the fact that the integer-based schedule is interrupted by each deploy (i.e., first task fires 4 hours after deployment)

Fixes #11799