### PR TITLE
feat(nimbus): add links for included/excluded experiments and message consult

### DIFF
--- a/experimenter/experimenter/experiments/constants.py
+++ b/experimenter/experimenter/experiments/constants.py
@@ -828,10 +828,7 @@ RISK_QUESTIONS = {
         "description, do you think it could negatively impact their perception "
         "of the brand?"
     ),
-    "MESSAGE": (
-        "Does your experiment include ANY messages? If yes, this requires "
-        "the Message Consult"
-    ),
+    "MESSAGE": ("Does your experiment include ANY messages? If yes, this requires the "),
     "PARTNER": (
         "Does this experiment rely on AI (e.g. ML, chatbot), impact or rely on a partner "
         "or outside company (e.g. Google, Amazon), or deliver any encryption or VPN?"

--- a/experimenter/experimenter/experiments/models.py
+++ b/experimenter/experimenter/experiments/models.py
@@ -926,6 +926,18 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
             )
 
     @property
+    def required_experiments_branches(self):
+        return NimbusExperimentBranchThroughRequired.objects.filter(
+            parent_experiment=self
+        )
+
+    @property
+    def excluded_experiments_branches(self):
+        return NimbusExperimentBranchThroughExcluded.objects.filter(
+            parent_experiment=self
+        )
+
+    @property
     def review_url(self):
         try:
             collection = self.kinto_collection

--- a/experimenter/experimenter/experiments/tests/test_models.py
+++ b/experimenter/experimenter/experiments/tests/test_models.py
@@ -2144,6 +2144,41 @@ class TestNimbusExperiment(TestCase):
             "firefox-desktop-feature-release-mac_only-rollout",
         )
 
+    def test_required_experiments_branches(self):
+        parent_experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED
+        )
+        child_experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED
+        )
+
+        NimbusExperimentBranchThroughRequired.objects.create(
+            parent_experiment=parent_experiment,
+            child_experiment=child_experiment,
+            branch_slug="branch-test",
+        )
+
+        required_branches = parent_experiment.required_experiments_branches.all()
+        self.assertEqual(len(required_branches), 1)
+        self.assertEqual(required_branches[0].branch_slug, "branch-test")
+
+    def test_excluded_experiments_branches(self):
+        parent_experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED
+        )
+        child_experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED
+        )
+
+        NimbusExperimentBranchThroughExcluded.objects.create(
+            parent_experiment=parent_experiment,
+            child_experiment=child_experiment,
+        )
+
+        excluded_branches = parent_experiment.excluded_experiments_branches.all()
+        self.assertEqual(len(excluded_branches), 1)
+        self.assertIsNone(excluded_branches[0].branch_slug)
+
     def test_bucket_namespace_with_group_id(self):
         feature = NimbusFeatureConfigFactory(slug="feature")
         experiment = NimbusExperimentFactory.create_with_lifecycle(

--- a/experimenter/experimenter/nimbus_ui_new/constants.py
+++ b/experimenter/experimenter/nimbus_ui_new/constants.py
@@ -11,3 +11,5 @@ Optional - We believe this outcome will <describe impact> on <core metric>
     ERROR_NAME_INVALID = "This is not a valid name."
     ERROR_SLUG_DUPLICATE = "An experiment with this slug already exists."
     ERROR_HYPOTHESIS_PLACEHOLDER = "Please enter a hypothesis."
+
+    RISK_MESSAGE_URL = "https://mozilla-hub.atlassian.net/wiki/spaces/FIREFOX/pages/208308555/Message+Consult+Creation"

--- a/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/detail.html
+++ b/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/detail.html
@@ -128,9 +128,9 @@
             <tr>
               <th colspan="3">
                 {{ RISK_QUESTIONS.MESSAGE }}
-                <a href="https://mozilla-hub.atlassian.net/wiki/spaces/FIREFOX/pages/208308555/Message+Consult+Creation">
-                  Message Consult
-                </a>
+                <a href="{{ risk_message_url }}"
+                   target="_blank"
+                   rel="noopener noreferrer">Message Consult</a>
               </th>
               <td class="{% if experiment.risk_message %}text-danger font-weight-bold{% endif %}">
                 {% if experiment.risk_message != None %}
@@ -207,9 +207,18 @@
             <tr>
               <th>Required experiments</th>
               <td>
-                {% if experiment.required_experiments.all %}
-                  {% for exp in experiment.required_experiments.all %}
-                    <a href="/nimbus/{{ exp.slug }}/summary">{{ exp.name }}</a>
+                {% if required_experiments_branches %}
+                  {% for branch in required_experiments_branches %}
+                    <a href="{% url 'nimbus-new-detail' branch.child_experiment.slug %}"
+                       target="_blank"
+                       rel="noopener noreferrer">
+                      {{ branch.child_experiment.name }}
+                      {% if branch.branch_slug %}
+                        ({{ branch.branch_slug }} branch)
+                      {% else %}
+                        (All branches)
+                      {% endif %}
+                    </a>
                     <br>
                   {% endfor %}
                 {% else %}
@@ -218,9 +227,18 @@
               </td>
               <th>Excluded experiments</th>
               <td>
-                {% if experiment.excluded_experiments.all %}
-                  {% for exp in experiment.excluded_experiments.all %}
-                    <a href="/nimbus/{{ exp.slug }}/summary">{{ exp.name }}</a>
+                {% if excluded_experiments_branches %}
+                  {% for branch in excluded_experiments_branches %}
+                    <a href="{% url 'nimbus-new-detail' branch.child_experiment.slug %}"
+                       target="_blank"
+                       rel="noopener noreferrer">
+                      {{ branch.child_experiment.name }}
+                      {% if branch.branch_slug %}
+                        ({{ branch.branch_slug }} branch)
+                      {% else %}
+                        (All branches)
+                      {% endif %}
+                    </a>
                     <br>
                   {% endfor %}
                 {% else %}

--- a/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/detail.html
+++ b/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/detail.html
@@ -207,8 +207,8 @@
             <tr>
               <th>Required experiments</th>
               <td>
-                {% if required_experiments_branches %}
-                  {% for branch in required_experiments_branches %}
+                {% if experiment.required_experiments_branches.all %}
+                  {% for branch in experiment.required_experiments_branches.all %}
                     <a href="{% url 'nimbus-new-detail' branch.child_experiment.slug %}"
                        target="_blank"
                        rel="noopener noreferrer">
@@ -227,8 +227,8 @@
               </td>
               <th>Excluded experiments</th>
               <td>
-                {% if excluded_experiments_branches %}
-                  {% for branch in excluded_experiments_branches %}
+                {% if experiment.excluded_experiments_branches.all %}
+                  {% for branch in experiment.excluded_experiments_branches.all %}
                     <a href="{% url 'nimbus-new-detail' branch.child_experiment.slug %}"
                        target="_blank"
                        rel="noopener noreferrer">

--- a/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/detail.html
+++ b/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/detail.html
@@ -207,43 +207,39 @@
             <tr>
               <th>Required experiments</th>
               <td>
-                {% if experiment.required_experiments_branches.all %}
-                  {% for branch in experiment.required_experiments_branches.all %}
-                    <a href="{% url 'nimbus-new-detail' branch.child_experiment.slug %}"
-                       target="_blank"
-                       rel="noopener noreferrer">
-                      {{ branch.child_experiment.name }}
-                      {% if branch.branch_slug %}
-                        ({{ branch.branch_slug }} branch)
-                      {% else %}
-                        (All branches)
-                      {% endif %}
-                    </a>
-                    <br>
-                  {% endfor %}
-                {% else %}
-                  None
-                {% endif %}
+                {% with experiment.required_experiments_branches.all as required_branches %}
+                  {% if required_branches %}
+                    {% for branch in required_branches %}
+                      <a href="{% url 'nimbus-new-detail' branch.child_experiment.slug %}"
+                         target="_blank"
+                         rel="noopener noreferrer">
+                        {{ branch.child_experiment.name }}
+                        ({{ branch.branch_slug|add:" branch"|default:"All branches" }})
+                      </a>
+                      <br>
+                    {% endfor %}
+                  {% else %}
+                    None
+                  {% endif %}
+                {% endwith %}
               </td>
               <th>Excluded experiments</th>
               <td>
-                {% if experiment.excluded_experiments_branches.all %}
-                  {% for branch in experiment.excluded_experiments_branches.all %}
-                    <a href="{% url 'nimbus-new-detail' branch.child_experiment.slug %}"
-                       target="_blank"
-                       rel="noopener noreferrer">
-                      {{ branch.child_experiment.name }}
-                      {% if branch.branch_slug %}
-                        ({{ branch.branch_slug }} branch)
-                      {% else %}
-                        (All branches)
-                      {% endif %}
-                    </a>
-                    <br>
-                  {% endfor %}
-                {% else %}
-                  None
-                {% endif %}
+                {% with experiment.excluded_experiments_branches.all as excluded_branches %}
+                  {% if excluded_branches %}
+                    {% for branch in excluded_branches %}
+                      <a href="{% url 'nimbus-new-detail' branch.child_experiment.slug %}"
+                         target="_blank"
+                         rel="noopener noreferrer">
+                        {{ branch.child_experiment.name }}
+                        ({{ branch.branch_slug|add:" branch"|default:"All branches" }})
+                      </a>
+                      <br>
+                    {% endfor %}
+                  {% else %}
+                    None
+                  {% endif %}
+                {% endwith %}
               </td>
             </tr>
             <tr>

--- a/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/detail.html
+++ b/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/detail.html
@@ -126,7 +126,12 @@
               </td>
             </tr>
             <tr>
-              <th colspan="3">{{ RISK_QUESTIONS.MESSAGE }}</th>
+              <th colspan="3">
+                {{ RISK_QUESTIONS.MESSAGE }}
+                <a href="https://mozilla-hub.atlassian.net/wiki/spaces/FIREFOX/pages/208308555/Message+Consult+Creation">
+                  Message Consult
+                </a>
+              </th>
               <td class="{% if experiment.risk_message %}text-danger font-weight-bold{% endif %}">
                 {% if experiment.risk_message != None %}
                   {{ experiment.risk_message|yesno:"Yes,No" }}
@@ -202,11 +207,25 @@
             <tr>
               <th>Required experiments</th>
               <td>
-                {{ experiment.required_experiments.all|join:"<br>"|default:"None" }}
+                {% if experiment.required_experiments.all %}
+                  {% for exp in experiment.required_experiments.all %}
+                    <a href="/nimbus/{{ exp.slug }}/summary">{{ exp.name }}</a>
+                    <br>
+                  {% endfor %}
+                {% else %}
+                  None
+                {% endif %}
               </td>
               <th>Excluded experiments</th>
               <td>
-                {{ experiment.excluded_experiments.all|join:"<br>"|default:"None" }}
+                {% if experiment.excluded_experiments.all %}
+                  {% for exp in experiment.excluded_experiments.all %}
+                    <a href="/nimbus/{{ exp.slug }}/summary">{{ exp.name }}</a>
+                    <br>
+                  {% endfor %}
+                {% else %}
+                  None
+                {% endif %}
               </td>
             </tr>
             <tr>

--- a/experimenter/experimenter/nimbus_ui_new/views.py
+++ b/experimenter/experimenter/nimbus_ui_new/views.py
@@ -8,8 +8,6 @@ from django_filters.views import FilterView
 from experimenter.experiments.constants import RISK_QUESTIONS
 from experimenter.experiments.models import (
     NimbusExperiment,
-    NimbusExperimentBranchThroughExcluded,
-    NimbusExperimentBranchThroughRequired,
 )
 from experimenter.nimbus_ui_new.constants import NimbusUIConstants
 from experimenter.nimbus_ui_new.filtersets import (
@@ -149,16 +147,6 @@ class NimbusExperimentDetailView(NimbusExperimentViewMixin, DetailView):
         if context["takeaways_edit_mode"]:
             context["takeaways_form"] = TakeawaysForm(instance=self.object)
         context["risk_message_url"] = NimbusUIConstants.RISK_MESSAGE_URL
-        context[
-            "required_experiments_branches"
-        ] = NimbusExperimentBranchThroughRequired.objects.filter(
-            parent_experiment=self.object
-        )
-        context[
-            "excluded_experiments_branches"
-        ] = NimbusExperimentBranchThroughExcluded.objects.filter(
-            parent_experiment=self.object
-        )
         return context
 
 

--- a/experimenter/experimenter/nimbus_ui_new/views.py
+++ b/experimenter/experimenter/nimbus_ui_new/views.py
@@ -6,7 +6,12 @@ from django.views.generic.edit import UpdateView
 from django_filters.views import FilterView
 
 from experimenter.experiments.constants import RISK_QUESTIONS
-from experimenter.experiments.models import NimbusExperiment
+from experimenter.experiments.models import (
+    NimbusExperiment,
+    NimbusExperimentBranchThroughExcluded,
+    NimbusExperimentBranchThroughRequired,
+)
+from experimenter.nimbus_ui_new.constants import NimbusUIConstants
 from experimenter.nimbus_ui_new.filtersets import (
     STATUS_FILTERS,
     NimbusExperimentFilter,
@@ -143,6 +148,17 @@ class NimbusExperimentDetailView(NimbusExperimentViewMixin, DetailView):
             context["form"] = QAStatusForm(instance=self.object)
         if context["takeaways_edit_mode"]:
             context["takeaways_form"] = TakeawaysForm(instance=self.object)
+        context["risk_message_url"] = NimbusUIConstants.RISK_MESSAGE_URL
+        context[
+            "required_experiments_branches"
+        ] = NimbusExperimentBranchThroughRequired.objects.filter(
+            parent_experiment=self.object
+        )
+        context[
+            "excluded_experiments_branches"
+        ] = NimbusExperimentBranchThroughExcluded.objects.filter(
+            parent_experiment=self.object
+        )
         return context
 
 

--- a/experimenter/experimenter/nimbus_ui_new/views.py
+++ b/experimenter/experimenter/nimbus_ui_new/views.py
@@ -129,6 +129,7 @@ def build_experiment_context(experiment):
         "primary_outcome_links": primary_outcome_links,
         "secondary_outcome_links": secondary_outcome_links,
         "segment_links": segment_links,
+        "risk_message_url": NimbusUIConstants.RISK_MESSAGE_URL,
     }
     return context
 
@@ -146,7 +147,6 @@ class NimbusExperimentDetailView(NimbusExperimentViewMixin, DetailView):
             context["form"] = QAStatusForm(instance=self.object)
         if context["takeaways_edit_mode"]:
             context["takeaways_form"] = TakeawaysForm(instance=self.object)
-        context["risk_message_url"] = NimbusUIConstants.RISK_MESSAGE_URL
         return context
 
 


### PR DESCRIPTION
Because

* summary page lacked direct links to excluded and included experiments
* message consult lacked a direct link to relevant wiki page

This commit

* adds all the relevant links

Fixes #11798

![image](https://github.com/user-attachments/assets/f100b955-4d7a-4027-a9ba-f2b803644238)
![image](https://github.com/user-attachments/assets/3ddf1348-2cf8-4309-9db4-add856fa8937)

