### PR TITLE
feat(cirrus): Update cirrus to include features

### DIFF
--- a/cirrus/README.md
+++ b/cirrus/README.md
@@ -214,19 +214,22 @@ Example output:
 
 ```json
 {
-  "Feature1": {
-    "Variable1.1": "valueA",
-    "Variable1.2": "valueB"
-  },
-  "Feature2": {
-    "Variable2.1": "valueC",
-    "Variable2.2": "valueD"
-  },
-  "FeatureN": {
-    "VariableN.1": "valueX",
-    "VariableN.2": "valueY"
+  "Features": {
+    "Feature1": {
+      "Variable1.1": "valueA",
+      "Variable1.2": "valueB"
+    },
+    "Feature2": {
+      "Variable2.1": "valueC",
+      "Variable2.2": "valueD"
+    },
+    "FeatureN": {
+      "VariableN.1": "valueX",
+      "VariableN.2": "valueY"
+    }
   }
 }
+
 ```
 
 ## Notes

--- a/cirrus/server/cirrus/main.py
+++ b/cirrus/server/cirrus/main.py
@@ -263,7 +263,7 @@ async def compute_features(
         nimbus_preview_flag=nimbus_preview or False,
     )
 
-    return client_feature_configuration
+    return {"Features": client_feature_configuration}
 
 
 async def fetch_schedule_recipes() -> None:

--- a/cirrus/server/tests/test_main.py
+++ b/cirrus/server/tests/test_main.py
@@ -61,7 +61,7 @@ def test_get_features_with_required_field(client):
     response = client.post("/v1/features/", json=request_data)
     assert response.status_code == 200
     assert response.json() == {
-        "example-feature": {"enabled": False, "something": "wicked"}
+        "Features": {"example-feature": {"enabled": False, "something": "wicked"}}
     }
 
 
@@ -337,7 +337,7 @@ def test_get_features_with_nimbus_preview(client):
     response = client.post("/v1/features/?nimbus_preview=true", json=request_data)
     assert response.status_code == 200
     assert response.json() == {
-        "example-feature": {"enabled": False, "something": "wicked"}
+        "Features": {"example-feature": {"enabled": False, "something": "wicked"}}
     }
 
 
@@ -512,14 +512,14 @@ def test_get_features_with_and_without_nimbus_preview(
         response = client.post("/v1/features/", json=request_data)
         assert response.status_code == 200
         assert response.json() == {
-            "example-feature": {"enabled": False, "something": "wicked"}
+            "Features": {"example-feature": {"enabled": False, "something": "wicked"}}
         }
 
         # With nimbus_preview
         response = client.post("/v1/features/?nimbus_preview=true", json=request_data)
         assert response.status_code == 200
         assert response.json() == {
-            "example-feature": {"enabled": True, "something": "preview"}
+            "Features": {"example-feature": {"enabled": True, "something": "preview"}}
         }
 
 

--- a/demo-app/server/index.js
+++ b/demo-app/server/index.js
@@ -51,7 +51,17 @@ const server = http.createServer(async (req, res) => {
       });
 
       responseFromAPI.on('end', () => {
-        res.end(responseData);
+          try {
+            const parsedResponse = JSON.parse(responseData);
+            // Get the features
+            const clientFeatureConfig = parsedResponse['Features'] || parsedResponse;
+            // Send back the raw clientFeatureConfig to the frontend
+            res.end(JSON.stringify(clientFeatureConfig));
+        } catch (error) {
+            console.error('Error parsing API response:', error);
+            res.statusCode = 500;
+            res.end('Internal Server Error');
+        }
       });
     });
 


### PR DESCRIPTION
Because

- We want to return features under a single key called `Features`

This commit

- Update the return format to include new key in the response

Fixes #11810 