### PR TITLE
Revert "fix(nimbus): change jetstream fetch to integer scheduling"

### DIFF
--- a/experimenter/experimenter/settings.py
+++ b/experimenter/experimenter/settings.py
@@ -13,6 +13,7 @@ https://docs.djangoproject.com/en/1.9/ref/settings/
 from pathlib import Path
 from urllib.parse import urljoin
 
+from celery.schedules import crontab
 from decouple import config
 from django.contrib.admin import ModelAdmin, StackedInline, TabularInline
 from django.db.models import DecimalField, ForeignKey, JSONField, ManyToManyField
@@ -390,11 +391,11 @@ CELERY_BEAT_SCHEDULE = {
     },
     "fetch_jetstream_data": {
         "task": "experimenter.jetstream.tasks.fetch_jetstream_data",
-        "schedule": 14400,  # 4 hours
+        "schedule": crontab(minute=0, hour="*/6"),
     },
     "fetch_population_sizing_data": {
         "task": "experimenter.jetstream.tasks.fetch_population_sizing_data",
-        "schedule": 86400,  # 24 hours
+        "schedule": 86400,
     },
 }
 


### PR DESCRIPTION
Reverts mozilla/experimenter#11800

This didn't resolve the issue, and we've determined that this was not actually the cause of the problem, so let's go back to the crontab-style scheduling.