### PR TITLE
feat(nimbus): Add Explore Matching Audience link to new summary page

### DIFF
--- a/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/detail.html
+++ b/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/detail.html
@@ -162,7 +162,17 @@
     <!-- Audience Card -->
     <div class="card mb-3">
       <div class="card-header">
-        <h4>Audience</h4>
+        <div class="row">
+          <div class="col">
+            <h4>Audience</h4>
+          </div>
+          <div class="col pt-1 text-end">
+            <a href="{{ experiment.audience_url }}"
+               target="_blank"
+               rel="noopener noreferrer"
+               class="text-decoration-none">Explore matching audiences</a>
+          </div>
+        </div>
       </div>
       <div class="card-body">
         <table class="table table-striped">


### PR DESCRIPTION
Because

* The old summary page included a link to explore matching audiences and this functionality needs to be replicated on the new summary page

This commit

* Adds the Explore Matching Audience link to the new summary page

Fixes #11728

![image](https://github.com/user-attachments/assets/b00fbd2a-4c25-4426-84df-955998b5f9d2)
