### PR TITLE
chore(nimbus): change pop sizing task to crontab scheduling

### DIFF
--- a/experimenter/experimenter/settings.py
+++ b/experimenter/experimenter/settings.py
@@ -395,7 +395,7 @@ CELERY_BEAT_SCHEDULE = {
     },
     "fetch_population_sizing_data": {
         "task": "experimenter.jetstream.tasks.fetch_population_sizing_data",
-        "schedule": 86400,
+        "schedule": crontab(minute=0, hour=6, day_of_week=1),
     },
 }
 


### PR DESCRIPTION
Because

- Tasks with integer-based scheduling first fire <integer> seconds after the latest deploy
- Pop sizing fetch task is scheduled for 24 hours
- We often have multiple deployments per day, so 24 hours after the latest deploy will usually not occur until the weekend

This commit

- changes the scheduling to use crontab so that the task will fire at 06:00 UTC every day regardless of deployments

Fixes #11851