### PR TITLE
feat(nimbus): Add cloned experiment/rollout link on new summary page

### DIFF
--- a/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/detail.html
+++ b/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/detail.html
@@ -14,7 +14,15 @@
         <span class="{{ experiment.qa_status_badge_class }}">
           QA Status: {{ experiment.qa_status|default:"Not Set"|title }}
         </span>
-        <p class="text-secondary">{{ experiment.slug }}</p>
+        <p class="text-secondary mb-0">{{ experiment.slug }}</p>
+        {% if experiment.parent %}
+          <p class="text-secondary small">
+            Cloned from
+            <a href="{% url 'nimbus-new-detail' experiment.parent.slug %}"
+               target="_blank"
+               rel="noopener noreferrer">{{ experiment.parent.name }}</a>
+          </p>
+        {% endif %}
       </div>
       {% include "nimbus_experiments/timeline.html" %}
 


### PR DESCRIPTION
Because

* The new summary page should display the link for the original experiment/rollout if it was cloned

This commit

* Adds a link to the original experiment/rollout on the new summary page

Fixes #11727

![image](https://github.com/user-attachments/assets/969c4f0d-edac-49f0-b4e0-83d44667a50d)
