### PR TITLE
chore(project): reduce circleci instance size for desktop enrollment tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -188,7 +188,7 @@ jobs:
     machine:
       image: ubuntu-2004:2023.10.1
       docker_layer_caching: true
-    resource_class: xlarge
+    resource_class: large
     working_directory: ~/experimenter
     environment:
       FIREFOX_VERSION: nimbus-firefox-release


### PR DESCRIPTION


Because

* We use a large instance size for all of our integration tests except for the desktop enrollment tests which uses xlarge
* The desktop enrollment tests are consuming significantly more circleci credits than the rest of our tests
* The desktop enrollment tests should be able to run in a large instance since they're no different than the rest of our integration tests that run experimenter and firefox

This commit

* Reduces the desktop enrollment integration test instance size from xlarge to large

fixes #11857
