### PR TITLE
bug(nimbus): remove bzip2 from fetch firefox nightly script

### DIFF
--- a/experimenter/tests/integration/nimbus/utils/nightly-install.sh
+++ b/experimenter/tests/integration/nimbus/utils/nightly-install.sh
@@ -1,9 +1,10 @@
 set +x
 echo "Installing the Latest Nightly"
 apt-get update -qqy
+apt-get install -qqy xz-utils
 rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-wget --no-verbose -O /tmp/firefox.tar.bz2 "https://download.mozilla.org/?product=firefox-nightly-latest-ssl&os=linux64&lang=en-US"
+wget --no-verbose -O /tmp/firefox-latest "https://download.mozilla.org/?product=firefox-nightly-latest-ssl&os=linux64&lang=en-US"
 rm -rf /opt/firefox-latest
-tar -C /opt -xjf /tmp/firefox.tar.bz2
-rm /tmp/firefox.tar.bz2
+tar -C /opt -xf /tmp/firefox-latest
+rm /tmp/firefox-latest
 ln -fs /opt/firefox/firefox /usr/bin/firefox


### PR DESCRIPTION
Becuase

* Firefox was previously compressed using bzip2
* Firefox now uses xz compression
* Our nightly firefox fetch script had bzip2 hard coded as the compression format
* This caused our CI tasks to fail

This commit

* Removes explicitly references to bzip2 from our nightly firefox fetch script

fixes #11868
