### PR TITLE
feat(nimbus): add documentation links to v7 api

### DIFF
--- a/experimenter/experimenter/experiments/api/v7/serializers.py
+++ b/experimenter/experimenter/experiments/api/v7/serializers.py
@@ -7,8 +7,15 @@ from rest_framework import serializers
 from experimenter.experiments.api.v6.serializers import NimbusBucketRangeSerializer
 from experimenter.experiments.models import (
     NimbusBranch,
+    NimbusDocumentationLink,
     NimbusExperiment,
 )
+
+
+class NimbusDocumentationLinkSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = NimbusDocumentationLink
+        fields = ("title", "link")
 
 
 class NimbusBranchSerializer(serializers.ModelSerializer):
@@ -66,6 +73,9 @@ class NimbusExperimentSerializer(serializers.ModelSerializer):
     locales = serializers.SerializerMethodField()
     localizations = serializers.SerializerMethodField()
     publishedDate = serializers.DateTimeField(source="published_date")
+    documentationLinks = NimbusDocumentationLinkSerializer(
+        source="documentation_links", many=True
+    )
 
     class Meta:
         model = NimbusExperiment
@@ -98,6 +108,7 @@ class NimbusExperimentSerializer(serializers.ModelSerializer):
             "locales",
             "localizations",
             "publishedDate",
+            "documentationLinks",
         )
 
     def get_application(self, obj):

--- a/experimenter/experimenter/experiments/tests/api/v7/test_serializers.py
+++ b/experimenter/experimenter/experiments/tests/api/v7/test_serializers.py
@@ -9,6 +9,7 @@ from experimenter.base.tests.factories import LocaleFactory
 from experimenter.experiments.api.v7.serializers import NimbusExperimentSerializer
 from experimenter.experiments.models import NimbusExperiment
 from experimenter.experiments.tests.factories import (
+    NimbusDocumentationLinkFactory,
     NimbusExperimentFactory,
     NimbusFeatureConfigFactory,
 )
@@ -28,6 +29,7 @@ class TestNimbusExperimentSerializer(TestCase):
         application = NimbusExperiment.Application.DESKTOP
         feature1 = NimbusFeatureConfigFactory.create(application=application)
         feature2 = NimbusFeatureConfigFactory.create(application=application)
+        documentation_link = NimbusDocumentationLinkFactory.create()
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.ENDING_APPROVE_APPROVE,
             application=application,
@@ -43,6 +45,7 @@ class TestNimbusExperimentSerializer(TestCase):
                 json.dumps(localizations) if localizations is not None else None
             ),
             _enrollment_end_date=datetime.date(2022, 1, 5),
+            documentation_links=[documentation_link],
         )
         serializer = NimbusExperimentSerializer(experiment)
         experiment_data = serializer.data.copy()
@@ -99,6 +102,9 @@ class TestNimbusExperimentSerializer(TestCase):
                 "locales": ["en-US"],
                 "localizations": localizations,
                 "publishedDate": experiment.published_date,
+                "documentationLinks": [
+                    {"title": documentation_link.title, "link": documentation_link.link}
+                ],
             },
         )
 


### PR DESCRIPTION
Because

* The V7 API is consumed by the OMC team for their external tool Skylight
* They would like to include experiment doc links in their UI

This commit

* Adds documentation links to the V7 API

fixes #11475

