### PR TITLE
feat(nimbus): add overview form to new nimbus ui

### DIFF
--- a/experimenter/experimenter/experiments/models.py
+++ b/experimenter/experimenter/experiments/models.py
@@ -464,6 +464,9 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
     def get_history_url(self):
         return reverse("nimbus-new-history", kwargs={"slug": self.slug})
 
+    def get_update_overview_url(self):
+        return reverse("nimbus-new-update-overview", kwargs={"slug": self.slug})
+
     def get_update_metrics_url(self):
         return reverse("nimbus-new-update-metrics", kwargs={"slug": self.slug})
 

--- a/experimenter/experimenter/nimbus_ui_new/static/css/style.scss
+++ b/experimenter/experimenter/nimbus_ui_new/static/css/style.scss
@@ -5,6 +5,42 @@
 @import "~bootstrap/scss/variables";
 @import "~bootstrap/scss/mixins";
 
+.bootstrap-select {
+  border-radius: var(--bs-border-radius) !important;
+  border-width: 1px !important;
+  border: var(--bs-border-width) var(--bs-border-style) var(--bs-border-color) !important;
+  --bs-form-select-bg-img: url("data:image/svg+xml,%3csvg xmlns=%27http://www.w3.org/2000/svg%27 viewBox=%270 0 16 16%27%3e%3cpath fill=%27none%27 stroke=%27%23343a40%27 stroke-linecap=%27round%27 stroke-linejoin=%27round%27 stroke-width=%272%27 d=%27m2 5 6 6 6-6%27/%3e%3c/svg%3e");
+  background-image: var(--bs-form-select-bg-img),
+    var(--bs-form-select-bg-icon, none);
+  background-repeat: no-repeat;
+  background-position: right 0.75rem center;
+  background-size:
+    16px 12px,
+    calc(0.75em + 0.375rem) calc(0.75em + 0.375rem);
+
+  .dropdown-toggle::after {
+    content: none;
+  }
+}
+
+.was-validated .bootstrap-select {
+  border-radius: var(--bs-border-radius) !important;
+  border-width: 1px !important;
+  border: var(--bs-border-width) var(--bs-border-style)
+    var(--bs-form-valid-border-color) !important;
+  --bs-form-select-bg-img: url("data:image/svg+xml,%3csvg xmlns=%27http://www.w3.org/2000/svg%27 viewBox=%270 0 16 16%27%3e%3cpath fill=%27none%27 stroke=%27%23343a40%27 stroke-linecap=%27round%27 stroke-linejoin=%27round%27 stroke-width=%272%27 d=%27m2 5 6 6 6-6%27/%3e%3c/svg%3e");
+  --bs-form-select-bg-icon: url("data:image/svg+xml,%3csvg xmlns=%27http://www.w3.org/2000/svg%27 viewBox=%270 0 8 8%27%3e%3cpath fill=%27%23198754%27 d=%27M2.3 6.73.6 4.53c-.4-1.04.46-1.4 1.1-.8l1.1 1.4 3.4-3.8c.6-.63 1.6-.27 1.2.7l-4 4.6c-.43.5-.8.4-1.1.1z%27/%3e%3c/svg%3e");
+  background-image: var(--bs-form-select-bg-img),
+    var(--bs-form-select-bg-icon, none);
+  background-repeat: no-repeat;
+  background-position:
+    right 0.75rem center,
+    center right 2.25rem;
+  background-size:
+    16px 12px,
+    calc(0.75em + 0.375rem) calc(0.75em + 0.375rem);
+}
+
 @include color-mode(light) {
   .bootstrap-select {
     .dropdown-menu {

--- a/experimenter/experimenter/nimbus_ui_new/templates/common/widgets/inline_radio.html
+++ b/experimenter/experimenter/nimbus_ui_new/templates/common/widgets/inline_radio.html
@@ -1,0 +1,18 @@
+{% with id=widget.attrs.id %}
+  <div {% if id %}id="{{ id }}"{% endif %}
+       {% if widget.attrs.class %}class="{{ widget.attrs.class }}"{% endif %}>
+    {% for group, options, index in widget.optgroups %}
+      {% if group %}
+        <div>
+          <label>{{ group }}</label>
+        {% endif %}
+        {% for option in options %}
+          <div class="form-check form-check-inline ms-3 me-0">
+            {% include option.template_name with widget=option %}
+
+          </div>
+        {% endfor %}
+        {% if group %}</div>{% endif %}
+    {% endfor %}
+  </div>
+{% endwith %}

--- a/experimenter/experimenter/nimbus_ui_new/templates/common/widgets/inline_radio_option.html
+++ b/experimenter/experimenter/nimbus_ui_new/templates/common/widgets/inline_radio_option.html
@@ -1,0 +1,10 @@
+{% if widget.wrap_label %}
+  <label class="form-check-label"
+         {% if widget.attrs.id %}for="{{ widget.attrs.id }}"{% endif %}>
+  {% endif %}
+  {% include "common/widgets/inline_radio_option_input.html" %}
+
+  {% if widget.wrap_label %}
+    {{ widget.label }}
+  </label>
+{% endif %}

--- a/experimenter/experimenter/nimbus_ui_new/templates/common/widgets/inline_radio_option_input.html
+++ b/experimenter/experimenter/nimbus_ui_new/templates/common/widgets/inline_radio_option_input.html
@@ -1,0 +1,2 @@
+<input type="{{ widget.type }}" class="form-check-input" name="{{ widget.name }}"{% if widget.value != None %} value="{{ widget.value|stringformat:'s' }}"{% endif %}{% include "django/forms/widgets/attrs.html" %}
+  >

--- a/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/edit_overview.html
+++ b/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/edit_overview.html
@@ -1,0 +1,184 @@
+{% extends "nimbus_experiments/experiment_base.html" %}
+
+{% load static %}
+{% load nimbus_extras %}
+{% load django_bootstrap5 %}
+{% load widget_tweaks %}
+
+{% block title %}{{ experiment.name }} - Overview{% endblock %}
+
+{% block main_content %}
+  <form id="metrics-form"
+        {% if form.is_bound %}class="was-validated"{% endif %}
+        hx-post="{% url 'nimbus-new-update-overview' experiment.slug %}"
+        hx-select="#metrics-form"
+        hx-target="#metrics-form"
+        hx-swap="outerHTML">
+    {% csrf_token %}
+    {{ form.errors }}
+    <div class="card mb-3">
+      <div class="card-header">
+        <h4>Overview</h4>
+      </div>
+      <div class="card-body">
+        <div class="row mb-3">
+          <div class="col">
+            <label for="id_name" class="form-label">Public Name</label>
+            {{ form.name }}
+            <p class="form-text">This name will be public to users in about:studies.</p>
+          </div>
+        </div>
+        <div class="row mb-3">
+          <div class="col">
+            <label for="id_hypothesis" class="form-label">Hypothesis</label>
+            {{ form.hypothesis }}
+            <p class="form-text">You can add any supporting documents here.</p>
+          </div>
+        </div>
+        <div class="row mb-3">
+          <div class="col-10">
+            <label for="id_risk_brand" class="form-label">
+              If the public, users or press, were to discover this experiment and description, do you think it could negatively impact their perception of the brand?
+              <a target="_blank"
+                 href="https://mana.mozilla.org/wiki/display/FIREFOX/Pref-Flip+and+Add-On+Experiments#PrefFlipandAddOnExperiments-Doesthishavehighrisktothebrand?">
+                Learn more
+              </a>
+            </label>
+          </div>
+          <div class="col-2 text-end">{{ form.risk_brand }}</div>
+        </div>
+        <div class="row mb-3">
+          <div class="col-10">
+            <label for="id_risk_message" class="form-label">
+              Does your experiment include ANY messages? If yes, this requires the
+              <a target="_blank"
+                 href="https://mozilla-hub.atlassian.net/wiki/spaces/FIREFOX/pages/208308555/Message+Consult+Creation">
+                Message Consult
+              </a>
+            </label>
+          </div>
+          <div class="col-2 text-end">{{ form.risk_message }}</div>
+        </div>
+        <div class="row mb-3">
+          <div class="col">
+            <label for="id_application" class="form-label">Application</label>
+            <input class="form-control"
+                   value="{{ experiment.get_application_display }}"
+                   disabled>
+            <p class="form-text">
+              Experiments can only target one Application at a time.
+              <br>
+              Application can not be changed after an experiment is created.
+            </p>
+          </div>
+        </div>
+        <div class="row mb-3">
+          <div class="col">
+            <label for="id_projects" class="form-label">Team Projects</label>
+            {{ form.projects }}
+          </div>
+        </div>
+        <div class="row mb-3">
+          <div class="col">
+            <label for="id_public_description" class="form-label">Public Description</label>
+            {{ form.public_description }}
+            <p class="form-text">This description will be public to users on about:studies</p>
+          </div>
+        </div>
+        <div class="row mb-3">
+          <div class="col-10">
+            <label for="id_risk_revenue" class="form-label">
+              Does this experiment have a risk to negatively impact revenue (e.g. search, Pocket revenue)?
+              <a target="_blank"
+                 href="https://mana.mozilla.org/wiki/display/FIREFOX/Pref-Flip+and+Add-On+Experiments#PrefFlipandAddOnExperiments-riskREV">
+                Learn more
+              </a>
+            </label>
+          </div>
+          <div class="col-2 text-end">{{ form.risk_revenue }}</div>
+        </div>
+        <div class="row mb-3">
+          <div class="col-10">
+            <label for="id_risk_partner_related" class="form-label">
+              Does this experiment impact or rely on a partner or outside company (e.g. Google, Amazon) or deliver any encryption or VPN?
+              <a target="_blank"
+                 href="https://mana.mozilla.org/wiki/display/FIREFOX/Pref-Flip+and+Add-On+Experiments#PrefFlipandAddOnExperiments-Isthisstudypartnerrelated?riskPARTNER">
+                Learn more
+              </a>
+            </label>
+          </div>
+          <div class="col-2 text-end">{{ form.risk_partner_related }}</div>
+        </div>
+        <div class="row mb-2">
+          <div class="col-12">
+            <div>
+              Additional Links
+              <i class="fa-regular fa-circle-question"
+                 data-bs-toggle="tooltip"
+                 data-bs-placement="top"
+                 data-bs-title="Any additional links you would like to add, for example, Jira DS Ticket, Jira QA ticket, or experiment brief."></i>
+            </div>
+          </div>
+        </div>
+        <div id="documentation-links">
+          {{ form.documentation_links.management_form }}
+          {% for link_form in form.documentation_links %}
+            <div class="form-group">
+              {{ link_form.id }}
+              <div class="row mb-3">
+                <div class="col-4">
+                  {{ link_form.title }}
+                  {{ link_form.title.errors }}
+                </div>
+                <div class="col-8 d-flex align-items-center">
+                  <div class="flex-grow-1 me-2">
+                    {{ link_form.link|add_class:"form-control"|add_error_class:"is-invalid" }}
+                    {% for error in link_form.link.errors %}<div class="invalid-feedback">{{ error }}</div>{% endfor %}
+                  </div>
+                  <a class="text-primary"
+                     hx-post="{% url 'nimbus-new-delete-documentation-link' slug=experiment.slug %}"
+                     hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
+                     hx-params="link_id"
+                     hx-vals='{"link_id": {{ link_form.instance.id }} }'
+                     hx-select="#documentation-links"
+                     hx-target="#documentation-links">
+                    <i class="fa-solid fa-circle-xmark"></i>
+                  </a>
+                </div>
+              </div>
+              <div class="row mb-3">
+                <div class="col-8 d-flex justify-content-between align-items-center"></div>
+              </div>
+            </div>
+          {% endfor %}
+        </div>
+        <div class="row mb-3">
+          <div class="col-12 text-end">
+            <button class="btn btn-outline-primary btn-sm"
+                    type="button"
+                    hx-post="{% url 'nimbus-new-create-documentation-link' slug=experiment.slug %}"
+                    hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
+                    hx-params="none"
+                    hx-select="#documentation-links"
+                    hx-target="#documentation-links">+ Add Link</button>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="d-flex justify-content-end">
+      <button type="submit" class="btn btn-primary">Save</button>
+      <button type="submit" class="btn btn-secondary ms-2">Save and Continue</button>
+    </div>
+    {% if form.is_bound %}
+      <div class="toast text-bg-success position-fixed top-0 end-0 m-3 w-auto"
+           role="alert"
+           aria-live="assertive"
+           aria-atomic="true">
+        <div class="toast-body">
+          <i class="fa-regular fa-circle-check"></i>
+          Overview saved!
+        </div>
+      </div>
+    {% endif %}
+  </form>
+{% endblock main_content %}

--- a/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/sidebar.html
+++ b/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/sidebar.html
@@ -5,7 +5,7 @@
 
   <strong class="ms-3">Edit</strong>
   <hr class="my-0 mb-2">
-  {% include "common/sidebar_link.html" with title="Overview" link="" icon="fa-regular fa-solid fa-gear" disabled=True %}
+  {% include "common/sidebar_link.html" with title="Overview" link=experiment.get_update_overview_url icon="fa-regular fa-solid fa-gear" %}
   {% include "common/sidebar_link.html" with title="Branches" link="" icon="fa-solid fa-layer-group" disabled=True %}
   {% include "common/sidebar_link.html" with title="Metrics" link=experiment.get_update_metrics_url icon="fa-solid fa-arrow-trend-up" %}
   {% include "common/sidebar_link.html" with title="Audience" link="" icon="fa-solid fa-user-group" disabled=True %}

--- a/experimenter/experimenter/nimbus_ui_new/urls.py
+++ b/experimenter/experimenter/nimbus_ui_new/urls.py
@@ -1,11 +1,14 @@
 from django.urls import re_path
 
 from experimenter.nimbus_ui_new.views import (
+    DocumentationLinkCreateView,
+    DocumentationLinkDeleteView,
     MetricsUpdateView,
     NimbusChangeLogsView,
     NimbusExperimentDetailView,
     NimbusExperimentsCreateView,
     NimbusExperimentsListTableView,
+    OverviewUpdateView,
     QAStatusUpdateView,
     SignoffUpdateView,
     SubscribeView,
@@ -43,6 +46,21 @@ urlpatterns = [
         r"^(?P<slug>[\w-]+)/update_signoff/$",
         SignoffUpdateView.as_view(),
         name="update-signoff",
+    ),
+    re_path(
+        r"^(?P<slug>[\w-]+)/update_overview/$",
+        OverviewUpdateView.as_view(),
+        name="nimbus-new-update-overview",
+    ),
+    re_path(
+        r"^(?P<slug>[\w-]+)/create_documentation_link/$",
+        DocumentationLinkCreateView.as_view(),
+        name="nimbus-new-create-documentation-link",
+    ),
+    re_path(
+        r"^(?P<slug>[\w-]+)/delete_documentation_link/$",
+        DocumentationLinkDeleteView.as_view(),
+        name="nimbus-new-delete-documentation-link",
     ),
     re_path(
         r"^(?P<slug>[\w-]+)/update_metrics/$",

--- a/experimenter/experimenter/nimbus_ui_new/views.py
+++ b/experimenter/experimenter/nimbus_ui_new/views.py
@@ -17,8 +17,11 @@ from experimenter.nimbus_ui_new.filtersets import (
     StatusChoices,
 )
 from experimenter.nimbus_ui_new.forms import (
+    DocumentationLinkCreateForm,
+    DocumentationLinkDeleteForm,
     MetricsForm,
     NimbusExperimentCreateForm,
+    OverviewForm,
     QAStatusForm,
     SignoffForm,
     SubscribeForm,
@@ -32,6 +35,19 @@ class RequestFormMixin:
         kwargs = super().get_form_kwargs()
         kwargs["request"] = self.request
         return kwargs
+
+
+class RenderResponseMixin:
+    def form_valid(self, form):
+        super().form_valid(form)
+        return self.render_to_response(self.get_context_data(form=form))
+
+
+class RenderParentResponseMixin:
+    def form_valid(self, form):
+        super().form_valid(form)
+        form = super().form_class(instance=self.object)
+        return self.render_to_response(self.get_context_data(form=form))
 
 
 class NimbusExperimentViewMixin:
@@ -214,28 +230,37 @@ class NimbusExperimentsCreateView(
         return response
 
 
-class MetricsUpdateView(NimbusExperimentViewMixin, RequestFormMixin, UpdateView):
+class OverviewUpdateView(
+    NimbusExperimentViewMixin, RequestFormMixin, RenderResponseMixin, UpdateView
+):
+    form_class = OverviewForm
+    template_name = "nimbus_experiments/edit_overview.html"
+
+
+class DocumentationLinkCreateView(RenderParentResponseMixin, OverviewUpdateView):
+    form_class = DocumentationLinkCreateForm
+
+
+class DocumentationLinkDeleteView(RenderParentResponseMixin, OverviewUpdateView):
+    form_class = DocumentationLinkDeleteForm
+
+
+class MetricsUpdateView(
+    NimbusExperimentViewMixin, RequestFormMixin, RenderResponseMixin, UpdateView
+):
     form_class = MetricsForm
     template_name = "nimbus_experiments/edit_metrics.html"
 
-    def form_valid(self, form):
-        super().form_valid(form)
-        return self.render_to_response(self.get_context_data(form=form))
 
-
-class SubscribeView(NimbusExperimentViewMixin, RequestFormMixin, UpdateView):
+class SubscribeView(
+    NimbusExperimentViewMixin, RequestFormMixin, RenderResponseMixin, UpdateView
+):
     form_class = SubscribeForm
     template_name = "nimbus_experiments/subscribers_list.html"
 
-    def form_valid(self, form):
-        super().form_valid(form)
-        return self.render_to_response(self.get_context_data(form=form))
 
-
-class UnsubscribeView(NimbusExperimentViewMixin, RequestFormMixin, UpdateView):
+class UnsubscribeView(
+    NimbusExperimentViewMixin, RequestFormMixin, RenderResponseMixin, UpdateView
+):
     form_class = UnsubscribeForm
     template_name = "nimbus_experiments/subscribers_list.html"
-
-    def form_valid(self, form):
-        super().form_valid(form)
-        return self.render_to_response(self.get_context_data(form=form))


### PR DESCRIPTION
Becuase
    
* We need to add the overview to the new Nimbus UI
    
This commit
    
* Adds the overview form
* Adds documentation link add/remove functionality with HTMX
    
fixes #10841
![image](https://github.com/user-attachments/assets/58651934-f43b-4eaf-b678-cefc2a83d42f)

![image](https://github.com/user-attachments/assets/6987891b-b0d4-4a84-947b-58cd7d06afef)

