### PR TITLE
Fix(ci): Fix iOS integration test failures.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -423,7 +423,11 @@ jobs:
           command: |
             cp .env.integration-tests .env
             export CIRRUS=1
-            make refresh SKIP_DUMMY=1 PYTEST_SENTRY_DSN=$PYTEST_SENTRY_DSN CIRCLECI=$CIRCLECI up_prod_detached integration_test_nimbus_desktop PYTEST_ARGS="-k test_create_mobile_experiment_for_integration_test"
+            make refresh SKP_DUMMY=1 PYTEST_SENTRY_DSN=$PYTEST_SENTRY_DSN CIRCLECI=$CIRCLECI up_prod_detached integration_test_nimbus_desktop PYTEST_ARGS="-k test_create_mobile_experiment_for_integration_test"
+      - store_artifacts:
+          path: experimenter/tests/integration/ios_recipe.json
+      - store_artifacts:
+          path: experimenter/tests/integration/fenix_recipe.json
       - persist_to_workspace:
           root: experimenter
           paths:
@@ -724,6 +728,7 @@ workflows:
             branches:
               only:
                 - update_firefox_versions
+                - fix-11936
       - integration_nimbus_desktop_ui:
           name: Test Desktop Nimbus UI (Release Firefox)
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -368,8 +368,22 @@ jobs:
             poetry add pydantic==2.10.3
             poetry install
             poetry run pytest -k test_ios_integration.py --feature ios_enrollment
+      - run:
+          name: Collect XCTest Results
+          command: |
+            zip -r results.zip /Users/distiller/Library/Developer/Xcode/DerivedData/**/Logs/Test/*.xcresult
+          when: always
+      - run:
+          name: Collect xcodebuild log
+          command: |
+            cp /private/var/folders/ln/**/T/pytest-of-distiller/pytest-*/**/xcodebuild.log ./
+          when: always
       - store_artifacts:
           path: ~/project/firefox-ios/firefox-ios/firefox-ios-tests/Tests/ExperimentIntegrationTests/results/index.html
+      - store_artifacts:
+          path: ~/project/xcodebuild.log
+      - store_artifacts:
+          path: ~/project/results.zip
 
   integration_nimbus_sdk_targeting:
     machine:
@@ -728,7 +742,6 @@ workflows:
             branches:
               only:
                 - update_firefox_versions
-                - fix-11936
       - integration_nimbus_desktop_ui:
           name: Test Desktop Nimbus UI (Release Firefox)
           filters:

--- a/experimenter/tests/integration/nimbus/ios/xcodebuild.py
+++ b/experimenter/tests/integration/nimbus/ios/xcodebuild.py
@@ -18,7 +18,7 @@ class XCodeBuild:
             f"platform=iOS Simulator,name={self.device},OS={self.ios_version}"
         )
         self.scheme = "Fennec"
-        self.testPlan = "SyncIntegrationTestPlan"
+        self.testPlan = "ExperimentIntegrationTests"
         self.xcrun = XCRun()
         self.scheme = kwargs.get("scheme", self.scheme)
         self.test_plan = kwargs.get("test_plan", self.testPlan)

--- a/experimenter/tests/integration/nimbus/test_create_mobile_experiment.py
+++ b/experimenter/tests/integration/nimbus/test_create_mobile_experiment.py
@@ -36,6 +36,7 @@ def test_create_mobile_experiment_for_integration_test(
                     "value": "{}",
                 },
             ],
+        "userFacingName": experiment_slug,
         },
     }
     default_data_api.update(test_data)

--- a/experimenter/tests/integration/nimbus/test_create_mobile_experiment.py
+++ b/experimenter/tests/integration/nimbus/test_create_mobile_experiment.py
@@ -36,7 +36,6 @@ def test_create_mobile_experiment_for_integration_test(
                     "value": "{}",
                 },
             ],
-        "userFacingName": experiment_slug,
         },
     }
     default_data_api.update(test_data)


### PR DESCRIPTION
Because

- Our iOS integration Tests were failing due to an incorrectly named test plan

This commit

- Updates to the correct test plan.

Fixes #11936