### PR TITLE
feat(nimbus) Add DMA targeting for iOS users

### DIFF
--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -1886,6 +1886,17 @@ WINDOWS_10_MSIX_ONLY = NimbusTargetingConfig(
     application_choice_names=(Application.DESKTOP.name,),
 )
 
+IOS_DEFAULT_BROWSER_USER = NimbusTargetingConfig(
+    name="Default Browser FXiOS Users",
+    slug="ios_default_browser_user",
+    description="Users that already have FXiOS set as the default browser",
+    targeting="is_default_browser == 'true'",
+    desktop_telemetry="",
+    sticky_required=False,
+    is_first_run_required=True,
+    application_choice_names=(Application.IOS.name,),
+)
+
 IOS_IPHONE_USERS_ONLY = NimbusTargetingConfig(
     name="iPhone users only",
     slug="ios_iphone_users_only",

--- a/experimenter/tests/integration/nimbus/test_mobile_targeting.py
+++ b/experimenter/tests/integration/nimbus/test_mobile_targeting.py
@@ -98,6 +98,7 @@ def test_check_mobile_targeting(
             "is_first_run": True,
             "is_phone": True,
             "is_review_checker_enabled": True,
+            "is_default_browser": True,
         }
     )
     client = sdk_client(load_app_context(context))


### PR DESCRIPTION
Because

- we [need to be able to target DMA users](https://mozilla-hub.atlassian.net/browse/FXIOS-10864) for onboarding, 

This commit

- adds that ability. Yay!

Fixes [this req](https://github.com/mozilla-mobile/firefox-ios/issues/23699)