### PR TITLE
chore(ci): Fix the paths used to trigger fenix builder job.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -666,7 +666,7 @@ jobs:
     steps:
       - checkout
       - check_file_paths:
-          paths: "experimenter/tests/firefox-fenix-build.env"
+          paths: "experimenter/experimenter/targeting|experimenter/experimenter/experiments|experimenter/tests/firefox_fenix_beta_build.env|experimenter/tests/firefox_fenix_release_build.env"
       - docker_login:
           username: $DOCKER_USER
           password: $DOCKER_PASS


### PR DESCRIPTION
Because

- The Fenix builder job wasn't being correctly triggered even though there were fenix tracking file changes.

This commit

- Fixes that so that the fenix APKs can be correctly built for the test job.

Fixes #11950 