### PR TITLE
feat(nimbus): add takeaways to csv report

### DIFF
--- a/docs/experimenter/openapi-schema.json
+++ b/docs/experimenter/openapi-schema.json
@@ -4067,6 +4067,20 @@
           },
           "hypothesis": {
             "type": "string"
+          },
+          "takeaways_metric_gain": {
+            "type": "boolean"
+          },
+          "takeaways_gain_amount": {
+            "type": "string",
+            "nullable": true
+          },
+          "takeaways_qbr_learning": {
+            "type": "boolean"
+          },
+          "takeaways_summary": {
+            "type": "string",
+            "nullable": true
           }
         },
         "required": [

--- a/docs/experimenter/swagger-ui.html
+++ b/docs/experimenter/swagger-ui.html
@@ -4079,6 +4079,20 @@
           },
           "hypothesis": {
             "type": "string"
+          },
+          "takeaways_metric_gain": {
+            "type": "boolean"
+          },
+          "takeaways_gain_amount": {
+            "type": "string",
+            "nullable": true
+          },
+          "takeaways_qbr_learning": {
+            "type": "boolean"
+          },
+          "takeaways_summary": {
+            "type": "string",
+            "nullable": true
           }
         },
         "required": [

--- a/experimenter/experimenter/experiments/api/v5/serializers.py
+++ b/experimenter/experimenter/experiments/api/v5/serializers.py
@@ -1085,6 +1085,10 @@ class NimbusExperimentCsvSerializer(serializers.ModelSerializer):
             "experiment_summary",
             "rollout",
             "hypothesis",
+            "takeaways_metric_gain",
+            "takeaways_gain_amount",
+            "takeaways_qbr_learning",
+            "takeaways_summary",
         ]
 
     def get_feature_configs(self, obj):

--- a/experimenter/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_experiment_csv_serializer.py
+++ b/experimenter/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_experiment_csv_serializer.py
@@ -35,6 +35,10 @@ class TestNimbusExperimentCsvSerializer(TestCase):
                 "experiment_summary": experiment.experiment_url,
                 "rollout": experiment.is_rollout,
                 "hypothesis": experiment.hypothesis,
+                "takeaways_metric_gain": experiment.takeaways_metric_gain,
+                "takeaways_gain_amount": experiment.takeaways_gain_amount,
+                "takeaways_qbr_learning": experiment.takeaways_qbr_learning,
+                "takeaways_summary": experiment.takeaways_summary,
             },
         )
 
@@ -69,5 +73,9 @@ class TestNimbusExperimentCsvSerializer(TestCase):
                 "experiment_summary": experiment.experiment_url,
                 "rollout": experiment.is_rollout,
                 "hypothesis": experiment.hypothesis,
+                "takeaways_metric_gain": experiment.takeaways_metric_gain,
+                "takeaways_gain_amount": experiment.takeaways_gain_amount,
+                "takeaways_qbr_learning": experiment.takeaways_qbr_learning,
+                "takeaways_summary": experiment.takeaways_summary,
             },
         )


### PR DESCRIPTION
Because

* It would be helpful to know how many experiments have takeaways set
* An easy way to do that is to put the takeaways fields into the csv report

This commit

* Adds takeaways to the csv report

fixes #11952

