### PR TITLE
bug(nimbus): Filter versioned schemas inclusively

### DIFF
--- a/experimenter/experimenter/experiments/api/v5/serializers.py
+++ b/experimenter/experimenter/experiments/api/v5/serializers.py
@@ -1464,12 +1464,18 @@ class NimbusReviewSerializer(serializers.ModelSerializer):
             unsupported_version_strs = [
                 str(v) for v in schemas_in_range.unsupported_versions
             ]
-            min_unsupported_version = min(unsupported_version_strs)
-            max_unsupported_version = max(unsupported_version_strs)
+            if len(unsupported_version_strs) == 1:
+                unsupported_versions = unsupported_version_strs[0]
+            else:
+                min_unsupported_version = min(unsupported_version_strs)
+                max_unsupported_version = max(unsupported_version_strs)
+                unsupported_versions = (
+                    f"{min_unsupported_version}-{max_unsupported_version}"
+                )
             result.append(
                 NimbusConstants.ERROR_FEATURE_CONFIG_UNSUPPORTED_IN_VERSIONS.format(
                     feature_config=feature_config.name,
-                    versions=f"{min_unsupported_version}-{max_unsupported_version}",
+                    versions=unsupported_versions,
                 ),
                 suppress_errors,
             )

--- a/experimenter/experimenter/experiments/tests/test_models.py
+++ b/experimenter/experimenter/experiments/tests/test_models.py
@@ -3965,7 +3965,7 @@ class NimbusFeatureConfigTests(TestCase):
                     minor=minor,
                     patch=patch,
                 )
-                for major in range(1, 3)
+                for major in range(1, 4)
                 for minor in range(3)
                 for patch in range(3)
             )
@@ -3978,7 +3978,7 @@ class NimbusFeatureConfigTests(TestCase):
                     feature_config=feature,
                     version=versions[(major, minor, patch)],
                 )
-                for major in range(1, 3)
+                for major in range(1, 4)
                 for minor in range(3)
                 for patch in range(3)
             )
@@ -4001,6 +4001,7 @@ class NimbusFeatureConfigTests(TestCase):
                     (2, 0, 1),
                     (2, 0, 2),
                     (2, 1, 0),
+                    (2, 1, 1),
                 )
             },
         )
@@ -4190,6 +4191,7 @@ class NimbusFeatureConfigTests(TestCase):
                 schemas=[
                     schemas[versions[v]]
                     for v in (
+                        (123, 1, 0),
                         (123, 0, 0),
                         (122, 1, 0),
                         (122, 0, 0),


### PR DESCRIPTION
Because:

- the firefox_max_version logic uses inclusive ranges; and
- filtering schema ranges was using exclusive ranges, which is not correct behaviour

This commit

- updates schema ranges to be inclusive

Fixes #11002