### PR TITLE
chore(ci): Fix ios log path for artifact fetching on CI.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -376,7 +376,7 @@ jobs:
       - run:
           name: Collect xcodebuild log
           command: |
-            cp /private/var/folders/ln/**/T/pytest-of-distiller/pytest-*/**/xcodebuild.log ./
+            cp /private/var/folders/**/**/T/pytest-of-distiller/pytest-*/**/xcodebuild.log ./
           when: always
       - store_artifacts:
           path: ~/project/firefox-ios/firefox-ios/firefox-ios-tests/Tests/ExperimentIntegrationTests/results/index.html


### PR DESCRIPTION
Because

- The log path changed recently on our iOS CI job (maybe due to new macos images on circleci).

This commit

- Changes the path to be a bit more generic.

Fixes #11973