### PR TITLE
stop application edit after creation

### DIFF
--- a/experimenter/experimenter/experiments/api/v5/serializers.py
+++ b/experimenter/experimenter/experiments/api/v5/serializers.py
@@ -234,6 +234,11 @@ class NimbusBranchSerializer(serializers.ModelSerializer):
 
     def validate(self, data):
         data = super().validate(data)
+        
+        if self.instance and "application" in data:
+            raise serializers.ValidationError(
+                {"application": "Application cannot be updated after creation."}
+            )
 
         feature_values = data.get("feature_values")
 
@@ -894,6 +899,12 @@ class NimbusExperimentSerializer(
         return value
 
     def validate(self, data):
+
+        if self.instance and "application" in data and self.instance.application != data["application"]:
+            raise serializers.ValidationError(
+                {"application": "Application cannot be updated after creation."}
+            )
+
         data = super().validate(data)
 
         non_is_archived_fields = set(data.keys()) - set(
@@ -955,6 +966,11 @@ class NimbusExperimentSerializer(
         return data
 
     def update(self, experiment, validated_data):
+        if "application" in validated_data and experiment.application != validated_data["application"]:
+            raise serializers.ValidationError(
+                {"application": "Application cannot be updated after creation."}
+            )
+            
         if (
             experiment.is_rollout
             and validated_data.get("population_percent") != experiment.population_percent

--- a/experimenter/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_experiment_serializer.py
+++ b/experimenter/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_experiment_serializer.py
@@ -299,7 +299,7 @@ class TestNimbusExperimentSerializer(TestCase):
         )
         self.assertEqual(experiment.changes.count(), 1)
 
-        data = {
+        invalid_data = {
             "application": NimbusExperiment.Application.DESKTOP,
             "hypothesis": "New Hypothesis",
             "name": "New Name",
@@ -310,11 +310,31 @@ class TestNimbusExperimentSerializer(TestCase):
         }
 
         serializer = NimbusExperimentSerializer(
-            experiment, data=data, context={"user": self.user}
+            experiment, data=invalid_data, context={"user": self.user}
+        )
+
+        self.assertFalse(serializer.is_valid())
+        self.assertIn("application", serializer.errors)
+        self.assertEqual(
+            serializer.errors["application"],
+            ["Application cannot be updated after creation."],
+        )
+
+        valid_data = {
+            "hypothesis": "New Hypothesis",
+            "name": "New Name",
+            "public_description": "New public description",
+            "changelog_message": "test changelog message",
+            "feature_configs": [feature_config.id],
+            "prevent_pref_conflicts": True,
+        }
+
+        serializer = NimbusExperimentSerializer(
+            experiment, data=valid_data, context={"user": self.user}, partial=True
         )
 
         self.assertTrue(serializer.is_valid(), serializer.errors)
-
+        
         experiment = serializer.save()
         self.assertEqual(experiment.changes.count(), 2)
         self.assertEqual(experiment.application, NimbusExperiment.Application.DESKTOP)


### PR DESCRIPTION
Because

- it shouldn't be possible to edit applications after creation since that can invalidate other fields.

This commit

- will stop application from being edited after creation

Fixes #7083 