### PR TITLE
fix(tests): Hardcode sdk targeting test path.

### DIFF
--- a/experimenter/tests/nimbus_rust_tests.sh
+++ b/experimenter/tests/nimbus_rust_tests.sh
@@ -14,5 +14,5 @@ poetry -C experimenter/tests/integration \
     --base-url https://nginx/nimbus/ \
     --html=test-reports/report.htm \
     --self-contained-html \
-    experimenter/tests/integration/nimbus/test_mobile_targeting.py \
+    /code/experimenter/tests/integration/nimbus/test_mobile_targeting.py \
     -vvv


### PR DESCRIPTION
Because

- Something changed recently with the rust image we use for the sdk targeting tests that now causes pytest to not detect the test file we need to run

This commit

- Hard codes the path so that we don't need to rely on resolving it.

Fixes #11994 