### PR TITLE
chore(project): Pin poetry version to 1.8.4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -304,7 +304,7 @@ jobs:
           name: Download test files and run
           command: |
             curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/mozilla/application-services/main/install-nimbus-cli.sh | bash
-            pip install poetry
+            pip install poetry=1.8.4
             make integration_test_nimbus_fenix PYTEST_ARGS="$PYTEST_ARGS"
       - android/save-gradle-cache:
           cache-prefix: v1a

--- a/experimenter/tests/integration/Dockerfile
+++ b/experimenter/tests/integration/Dockerfile
@@ -10,6 +10,6 @@ RUN apt-get update -qqy && \
         python3-venv \
         python3-pip
 
-RUN pip install poetry
+RUN pip install poetry==1.8.4
 
 WORKDIR /code


### PR DESCRIPTION
Because

- Poetry introduced some breaking changes with their v2 release

This commit

- Pins all poetry installs to 1.8.4 for now.

Fixes #11998 