### PR TITLE
feat(nimbus): hide archived experiments from require/exclude fields

### DIFF
--- a/experimenter/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/index.test.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/index.test.tsx
@@ -150,6 +150,61 @@ describe("FormAudience", () => {
       ).toBeUndefined();
     });
 
+    it("only hides archived experiments from required and excluded drop downs", async () => {
+      const experiment = {
+        ...MOCK_EXPERIMENT,
+        name: MOCK_EXPERIMENTS_BY_APPLICATION[0].name,
+        slug: MOCK_EXPERIMENTS_BY_APPLICATION[0].slug,
+        id: MOCK_EXPERIMENTS_BY_APPLICATION[0].id,
+      };
+
+      const experimentsByApplication = [
+        {
+          ...MOCK_EXPERIMENTS_BY_APPLICATION[1],
+          name: "available",
+          treatmentBranches: [],
+          isArchived: false,
+        },
+        {
+          ...MOCK_EXPERIMENTS_BY_APPLICATION[2],
+          name: "archived",
+          treatmentBranches: [],
+          isArchived: true,
+        },
+      ];
+
+      const { container } = render(
+        <Subject
+          experiment={experiment}
+          experimentsByApplication={{
+            allExperiments: experimentsByApplication,
+          }}
+        />,
+      );
+
+      const excluded = screen.getByLabelText(/Exclude users enrolled/);
+      await selectEvent.openMenu(excluded);
+      let options = container.querySelectorAll(query("excludedExperiments"));
+
+      expect(options.length).toEqual(2);
+      expect(
+        Array.from(options, (e) => e.textContent).filter((text) =>
+          text?.includes("archived"),
+        ).length,
+      ).toEqual(0);
+
+      const required = screen.getByLabelText(/Require users to be enrolled/);
+      await selectEvent.openMenu(required);
+      options = container.querySelectorAll(query("requiredExperiments"));
+
+      expect(options.length).toEqual(2);
+      expect(
+        Array.from(options, (e) => e.textContent).filter((text) =>
+          text?.includes("archived"),
+        ).length,
+      ).toEqual(0);
+    });
+
     it("saves required and excluded experiments with all branches for experiments", async () => {
       const onSubmit = jest.fn();
       const MOCK_EXPERIMENTS_BY_APPLICATION: getAllExperimentsByApplication_experimentsByApplication[] =
@@ -163,6 +218,7 @@ describe("FormAudience", () => {
             publicDescription: "mock description",
             referenceBranch: { slug: "control" },
             treatmentBranches: [{ slug: "treatment" }],
+            isArchived: false,
           }),
         );
       const experiment: getExperiment_experimentBySlug = mockExperimentQuery(
@@ -241,6 +297,7 @@ describe("FormAudience", () => {
             publicDescription: "mock description",
             referenceBranch: { slug: "control" },
             treatmentBranches: [{ slug: "treatment" }],
+            isArchived: false,
           }),
         );
       const experiment: getExperiment_experimentBySlug = mockExperimentQuery(
@@ -320,6 +377,7 @@ describe("FormAudience", () => {
             publicDescription: "mock description",
             referenceBranch: { slug: "control" },
             treatmentBranches: [{ slug: "treatment" }],
+            isArchived: false,
           }),
         );
       const experiment: getExperiment_experimentBySlug = mockExperimentQuery(
@@ -398,6 +456,7 @@ describe("FormAudience", () => {
             publicDescription: "mock description",
             referenceBranch: { slug: "control" },
             treatmentBranches: [{ slug: "treatment" }],
+            isArchived: false,
           }),
         );
       const experiment: getExperiment_experimentBySlug = mockExperimentQuery(

--- a/experimenter/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/index.tsx
@@ -159,9 +159,9 @@ function selectExperimentOptions(
   allExperiments: getAllExperimentsByApplication_experimentsByApplication[],
   selectedExperimentBranchValues?: string[],
 ): SelectExperimentBranchOption[] {
-  let selectableExperimentBranchOptions = allExperiments.flatMap(
-    toSelectExperimentBranchOptions,
-  );
+  let selectableExperimentBranchOptions = allExperiments
+    .filter((experiment) => !experiment.isArchived)
+    .flatMap(toSelectExperimentBranchOptions);
 
   if (selectedExperimentBranchValues) {
     const selectedExperimentBranchValuesSet = new Set(

--- a/experimenter/experimenter/nimbus-ui/src/gql/experiments.ts
+++ b/experimenter/experimenter/nimbus-ui/src/gql/experiments.ts
@@ -149,6 +149,7 @@ export const GET_EXPERIMENT_QUERY = gql`
           treatmentBranches {
             slug
           }
+          isArchived
         }
         branchSlug
       }
@@ -164,6 +165,7 @@ export const GET_EXPERIMENT_QUERY = gql`
           treatmentBranches {
             slug
           }
+          isArchived
         }
         branchSlug
       }
@@ -343,6 +345,7 @@ export const GET_ALL_EXPERIMENTS_BY_APPLICATION_QUERY = gql`
       treatmentBranches {
         slug
       }
+      isArchived
     }
   }
 `;

--- a/experimenter/experimenter/nimbus-ui/src/lib/mocks.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/lib/mocks.tsx
@@ -1150,6 +1150,7 @@ export const MOCK_EXPERIMENTS_BY_APPLICATION: getAllExperimentsByApplication_exp
     publicDescription: "mock description",
     referenceBranch: { slug: "control" },
     treatmentBranches: [{ slug: "treatment" }],
+    isArchived: false,
   }));
 
 // Basically the same as useOutcomes, but uses the mocked config values

--- a/experimenter/experimenter/nimbus-ui/src/types/getAllExperimentsByApplication.ts
+++ b/experimenter/experimenter/nimbus-ui/src/types/getAllExperimentsByApplication.ts
@@ -24,6 +24,7 @@ export interface getAllExperimentsByApplication_experimentsByApplication {
   publicDescription: string | null;
   referenceBranch: getAllExperimentsByApplication_experimentsByApplication_referenceBranch | null;
   treatmentBranches: (getAllExperimentsByApplication_experimentsByApplication_treatmentBranches | null)[] | null;
+  isArchived: boolean | null;
 }
 
 export interface getAllExperimentsByApplication {

--- a/experimenter/experimenter/nimbus-ui/src/types/getExperiment.ts
+++ b/experimenter/experimenter/nimbus-ui/src/types/getExperiment.ts
@@ -107,6 +107,7 @@ export interface getExperiment_experimentBySlug_excludedExperimentsBranches_excl
   publicDescription: string | null;
   referenceBranch: getExperiment_experimentBySlug_excludedExperimentsBranches_excludedExperiment_referenceBranch | null;
   treatmentBranches: (getExperiment_experimentBySlug_excludedExperimentsBranches_excludedExperiment_treatmentBranches | null)[] | null;
+  isArchived: boolean | null;
 }
 
 export interface getExperiment_experimentBySlug_excludedExperimentsBranches {
@@ -129,6 +130,7 @@ export interface getExperiment_experimentBySlug_requiredExperimentsBranches_requ
   publicDescription: string | null;
   referenceBranch: getExperiment_experimentBySlug_requiredExperimentsBranches_requiredExperiment_referenceBranch | null;
   treatmentBranches: (getExperiment_experimentBySlug_requiredExperimentsBranches_requiredExperiment_treatmentBranches | null)[] | null;
+  isArchived: boolean | null;
 }
 
 export interface getExperiment_experimentBySlug_requiredExperimentsBranches {

--- a/experimenter/experimenter/nimbus_ui_new/forms.py
+++ b/experimenter/experimenter/nimbus_ui_new/forms.py
@@ -342,7 +342,7 @@ class AudienceForm(NimbusChangeLogFormMixin, forms.ModelForm):
         return sorted(
             [
                 branch_choice
-                for experiment in NimbusExperiment.objects.all()
+                for experiment in NimbusExperiment.objects.exclude(is_archived=True)
                 for branch_choice in experiment.branch_choices()
             ]
         )


### PR DESCRIPTION
Because

* We need a way to hide some experiments from the require/exclude field so users don't accidentally select the wrong one when they have nearly identical names
* The simplest way to do that for now is to just use archiving as a way to hide them from the drop downs

This commit

* Hides archived experiments from the require/exclude drop downs in both the old and new Nimbus UI

fixes #12013

