### PR TITLE
fix(nimbus): Make name field in new UI required

### DIFF
--- a/experimenter/experimenter/nimbus_ui_new/forms.py
+++ b/experimenter/experimenter/nimbus_ui_new/forms.py
@@ -192,7 +192,7 @@ class OverviewForm(NimbusChangeLogFormMixin, forms.ModelForm):
     )
 
     name = forms.CharField(
-        required=False, widget=forms.TextInput(attrs={"class": "form-control"})
+        required=True, widget=forms.TextInput(attrs={"class": "form-control"})
     )
     hypothesis = forms.CharField(
         required=False, widget=forms.Textarea(attrs={"class": "form-control"})

--- a/experimenter/experimenter/nimbus_ui_new/tests/test_forms.py
+++ b/experimenter/experimenter/nimbus_ui_new/tests/test_forms.py
@@ -378,6 +378,31 @@ class TestOverviewForm(RequestFormTestCase):
         )
         self.assertEqual(documentation_link.link, "https://www.example.com")
 
+    def test_name_field_is_required(self):
+        project = ProjectFactory.create()
+        documentation_link = NimbusDocumentationLinkFactory.create()
+
+        form_data = {
+            "hypothesis": "new hypothesis",
+            "risk_brand": True,
+            "risk_message": True,
+            "projects": [project.id],
+            "public_description": "new description",
+            "risk_revenue": True,
+            "risk_partner_related": True,
+            "documentation_links-TOTAL_FORMS": "1",
+            "documentation_links-INITIAL_FORMS": "1",
+            "documentation_links-0-id": documentation_link.id,
+            "documentation_links-0-title": (
+                NimbusExperiment.DocumentationLink.DESIGN_DOC.value
+            ),
+            "documentation_links-0-link": "https://www.example.com",
+        }
+
+        form = OverviewForm(data=form_data)
+
+        self.assertFalse(form.is_valid())
+
 
 class TestDocumentationLinkCreateForm(RequestFormTestCase):
     def test_valid_form_adds_documentation_link(self):


### PR DESCRIPTION
Because

- Submitting a form with an empty name field in the new Nimbus UI causes a 500 error.

This commit

- Adds validation to ensure the name field is required and prevents submission with an empty value

Fixes #12016