### PR TITLE
feat(nimbus): Targeting for users not in HTTPS-Only mode

### DIFF
--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -2270,6 +2270,23 @@ DEFAULT_AUTOFILL_CREDIT_CARDS_SUPPORTED = NimbusTargetingConfig(
     application_choice_names=(Application.DESKTOP.name,),
 )
 
+NO_HTTPS_ONLY_DESKTOP = NimbusTargetingConfig(
+    name="Users who are not in HTTPS-Only Mode",
+    slug="no_https_only_desktop",
+    description=(
+        "Targets users who do not have HTTPS-Only Mode enabled. Neither with "
+        "'dom.security.https_only_mode' nor 'dom.security.https_only_mode_pbm'."
+    ),
+    targeting=(
+        "!('dom.security.https_only_mode'|preferenceValue || "
+        "'dom.security.https_only_mode_pbm'|preferenceValue)"
+    ),
+    desktop_telemetry="",
+    sticky_required=False,
+    is_first_run_required=False,
+    application_choice_names=(Application.DESKTOP.name,),
+)
+
 
 class TargetingConstants:
     TARGETING_VERSION = "version|versionCompare('{version}') >= 0"


### PR DESCRIPTION
Because

- this is needed for a timeout which is better tested in HTTPS-First

This commit

- adds an option to exclude HTTPS-Only users