### PR TITLE
feat(nimbus): push cirrus image to commit hash tag

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -495,6 +495,10 @@ jobs:
             docker tag cirrus:deploy ${DOCKERHUB_CIRRUS_REPO}:latest
             docker push ${DOCKERHUB_CIRRUS_REPO}:latest
 
+            GIT_SHA=$(git rev-parse --short HEAD)
+            docker tag cirrus:deploy ${DOCKERHUB_CIRRUS_REPO}:sha-${GIT_SHA}
+            docker push ${DOCKERHUB_CIRRUS_REPO}:sha-${GIT_SHA}
+
   deploy_schemas:
     machine:
       image: ubuntu-2004:2023.10.1


### PR DESCRIPTION
Because

* In addition to pushing cirrus docker images to a latest tag, we should also push to a commit hash tag
* This will allow downstream consumers to hardcode a known working tag and either bump or revert as necessary

This commit

* Pushes cirrus docker image to a git commit hash tag in addition to latest

fixes #12052

