### PR TITLE
bug(nimbus): fix monitoring dashboard url timestamps

### DIFF
--- a/experimenter/experimenter/settings.py
+++ b/experimenter/experimenter/settings.py
@@ -406,7 +406,7 @@ RECIPE_SLUG_MAX_LEN = 80
 MONITORING_URL = (
     # from_date and to_date format is YYYY-mm-dd
     "https://mozilla.cloud.looker.com/dashboards-next/216?"
-    "Experiment={slug}&Time+Range={from_date}+to+{to_date}"
+    "Experiment={slug}&Time+Range+[UTC]={from_date}+to+{to_date}"
 )
 ROLLOUT_MONITORING_URL = (
     "https://mozilla.cloud.looker.com/dashboards/operational_monitoring::{slug}"


### PR DESCRIPTION
Because

* We were passing the incorrect timestamp parameter to the monitoring dashboard url
* This resulted in the dashboard defaulting to the most recent 28 days instead of the proper time range

This commit

* Updates the monitoring dashboard url to use the correct timestamp parameter

fixes #12050

