### PR TITLE
chore(nimbus): update require/exclude field guidance

### DIFF
--- a/experimenter/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageEditAudience/FormAudience/index.tsx
@@ -708,8 +708,8 @@ export const FormAudience = ({
         <Form.Row>
           <Form.Group as={Col} controlId="excludedExperiments">
             <Form.Label className="d-flex align-items-center">
-              Exclude users enrolled in these experiments/rollouts (past or
-              present)
+              Exclude users enrolled in all of these experiments/rollouts (past
+              or present)
             </Form.Label>
             <SelectExperimentField
               name="excludedExperiments"
@@ -726,8 +726,8 @@ export const FormAudience = ({
         <Form.Row>
           <Form.Group as={Col} controlId="requiredExperiments">
             <Form.Label className="d-flex align-items-center">
-              Require users to be enrolled in these experiments/rollouts (past
-              or present)
+              Require users to be enrolled in all of these experiments/rollouts
+              (past or present)
             </Form.Label>
             <SelectExperimentField
               name="requiredExperiments"

--- a/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/edit_audience.html
+++ b/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/edit_audience.html
@@ -58,7 +58,7 @@
         <div class="row mb-3">
           <div class="col">
             <label for="id_excluded_experiments" class="form-label">
-              Exclude users enrolled in these experiments/rollouts (past or present)
+              Exclude users enrolled in all of these experiments/rollouts (past or present)
             </label>
             {{ form.excluded_experiments_branches|add_error_class:"is-invalid" }}
             {% for error in form.excluded_experiments_branches.errors %}
@@ -69,7 +69,7 @@
         <div class="row mb-3">
           <div class="col">
             <label for="id_required_experiments" class="form-label">
-              Require users to be enrolled in these experiments/rollouts (past or present)
+              Require users to be enrolled in all of these experiments/rollouts (past or present)
             </label>
             {{ form.required_experiments_branches|add_error_class:"is-invalid" }}
             {% for error in form.required_experiments_branches.errors %}


### PR DESCRIPTION
* The required/excluded audience filters will filter on clients enrolled in all selected experiments
* It was not clear to users whether it filtered on all or any enrollments so users selected multiple experiments expecting clients from any rather than all of those experiments

This commit

* Adds additional clarity to the field labels that the required/excluded experiments apply to all selected experiments

fixes #12021

