### PR TITLE
Closes #12084: Create advanced targeting for Android DMA users.

### DIFF
--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -1985,6 +1985,17 @@ ANDROID_REVIEW_CHECKER_ENABLED_USERS_ONLY = NimbusTargetingConfig(
     application_choice_names=(Application.FENIX.name,),
 )
 
+ANDROID_DMA_USERS_ONLY = NimbusTargetingConfig(
+    name="DMA users only",
+    slug="android_dma_users_only",
+    description="Targeting users who installed Firefox Android through DMA choice screen",
+    targeting="install_referrer_response_utm_source == 'eea-browser-choice'",
+    desktop_telemetry="",
+    sticky_required=False,
+    is_first_run_required=False,
+    application_choice_names=(Application.FENIX.name,),
+)
+
 DEFAULT_PDF_IS_DIFFERENT_BROWSER = NimbusTargetingConfig(
     name="Default PDF handler is a different browser",
     slug="default_pdf_is_different_browser",

--- a/experimenter/tests/integration/nimbus/test_mobile_targeting.py
+++ b/experimenter/tests/integration/nimbus/test_mobile_targeting.py
@@ -99,6 +99,7 @@ def test_check_mobile_targeting(
             "is_phone": True,
             "is_review_checker_enabled": True,
             "is_default_browser": True,
+            "install_referrer_response_utm_source": "test",
         }
     )
     client = sdk_client(load_app_context(context))


### PR DESCRIPTION
Because

- In the future, we want to target users who have installed Firefox Android through the DMA choice screen.

This commit

- Adds advance targeting for users who installed Firefox Android through DMA choice SCreen.

Fixes #12084 