### PR TITLE
fix(nimbus): respect boolean instead of string

### DIFF
--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -1886,8 +1886,8 @@ WINDOWS_10_MSIX_ONLY = NimbusTargetingConfig(
     application_choice_names=(Application.DESKTOP.name,),
 )
 
-IOS_DEFAULT_BROWSER_USER = NimbusTargetingConfig(
-    name="Default Browser FXiOS Users",
+IOS_DEFAULT_BROWSER_FIRST_RUN_USER = NimbusTargetingConfig(
+    name="Default Browser & First Run FXiOS Users",
     slug="ios_default_browser_user",
     description="Users that already have FXiOS set as the default browser",
     targeting="is_default_browser == true && is_first_run",

--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -1890,7 +1890,7 @@ IOS_DEFAULT_BROWSER_USER = NimbusTargetingConfig(
     name="Default Browser FXiOS Users",
     slug="ios_default_browser_user",
     description="Users that already have FXiOS set as the default browser",
-    targeting="is_default_browser == 'true'",
+    targeting="is_default_browser == true && is_first_run",
     desktop_telemetry="",
     sticky_required=False,
     is_first_run_required=True,


### PR DESCRIPTION
Because

- I used a string instead of a boolean, things are borked when we try to run the experiment.

This commit

- Uses a boolean, instead of a string, thus, unborking things.

Fixes mozilla-mobile/firefox-ios#24037