### PR TITLE
feat(nimbus): Update year 2025

### DIFF
--- a/experimenter/experimenter/nimbus_ui_new/templates/common/footer.html
+++ b/experimenter/experimenter/nimbus_ui_new/templates/common/footer.html
@@ -1,3 +1,3 @@
 <footer class="text-center my-4">
-  <div>© Mozilla Corporation 2024</div>
+  <div>© Mozilla Corporation 2025</div>
 </footer>


### PR DESCRIPTION
Because

- We are showing the year as 2024 

This commit

- Update to the year 2025 

Fixes #12097
<img width="1691" alt="Screenshot 2025-01-23 at 11 09 35 AM" src="https://github.com/user-attachments/assets/893dcafb-e874-45fa-90bc-0a3879766254" />
