### PR TITLE
bug(nimbus): handle None in results data

### DIFF
--- a/experimenter/experimenter/experiments/models.py
+++ b/experimenter/experimenter/experiments/models.py
@@ -1212,7 +1212,7 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
         if self.results_data and "v3" in self.results_data:
             results_data = self.results_data["v3"]
             for window in ["overall", "weekly"]:
-                if window in results_data:
+                if results_data.get(window):
                     enrollments = results_data[window].get("enrollments", {}).get("all")
                     if enrollments is not None:
                         return True

--- a/experimenter/experimenter/experiments/tests/test_models.py
+++ b/experimenter/experimenter/experiments/tests/test_models.py
@@ -2458,6 +2458,7 @@ class TestNimbusExperiment(TestCase):
             ({"v3": {"weekly": {"enrollments": {}}}},),
             ({"v3": {"overall": {"enrollments": {"all": None}}}},),
             ({"v3": {"weekly": {"enrollments": {"all": None}}}},),
+            ({"v3": {"overall": None}},),
         ]
     )
     def test_has_displayable_results_false(self, results_data):


### PR DESCRIPTION
Becuase

* We recently added the show results url link on the landing page
* That involves checking the contents of the results data payload
* In old experiments, some keys unexpected contain null/None values
* The method to check did not handle this case and was raising 500

This commit

* Adds a test case for null values in the results data payload
* Handles the null case in the show results data method

fixes #12094

