### PR TITLE
bug(nimbus): Use ChromeUtils.importESModule in integration tests

### DIFF
--- a/experimenter/tests/integration/legacy/utils/filter_expression.js
+++ b/experimenter/tests/integration/legacy/utils/filter_expression.js
@@ -1,12 +1,9 @@
-Components.utils.import("resource://gre/modules/components-utils/FilterExpressions.jsm");
-Components.utils.import("resource://gre/modules/components-utils/ClientEnvironment.jsm");
-
 // Targeting
 
 async function remoteSettings(arguments) {
 
-    const { TargetingContext } = ChromeUtils.import(
-        "resource://messaging-system/targeting/Targeting.jsm"
+    const { TargetingContext } = ChromeUtils.importESModule(
+        "resource://messaging-system/targeting/Targeting.sys.mjs"
     );
     const ENVIRONMENT = {version: arguments[0], localeLanguageCode: "en-US"};
     let targeting = new TargetingContext(ENVIRONMENT);

--- a/experimenter/tests/integration/nimbus/conftest.py
+++ b/experimenter/tests/integration/nimbus/conftest.py
@@ -366,11 +366,11 @@ def trigger_experiment_loader(selenium):
         with selenium.context(selenium.CONTEXT_CHROME):
             selenium.execute_script(
                 """
-                    const { RemoteSettings } = ChromeUtils.import(
-                        "resource://services-settings/remote-settings.js"
+                    const { RemoteSettings } = ChromeUtils.importESModule(
+                        "resource://services-settings/remote-settings.sys.mjs"
                     );
-                    const { RemoteSettingsExperimentLoader } = ChromeUtils.import(
-                        "resource://nimbus/lib/RemoteSettingsExperimentLoader.jsm"
+                    const { RemoteSettingsExperimentLoader } = ChromeUtils.importESModule(
+                        "resource://nimbus/lib/RemoteSettingsExperimentLoader.sys.mjs"
                     );
 
                     RemoteSettings.pollChanges();

--- a/experimenter/tests/integration/nimbus/utils/filter_expression.js
+++ b/experimenter/tests/integration/nimbus/utils/filter_expression.js
@@ -11,14 +11,14 @@ async function remoteSettings(arguments) {
     // browser/components/asrouter and its import path changed.
     const { TelemetryEnvironment } = ChromeUtils.importESModule("resource://gre/modules/TelemetryEnvironment.sys.mjs");
     await TelemetryEnvironment.onInitialized();
-    
+
     let ASRouterTargeting;
 
     try {
-        ASRouterTargeting = ChromeUtils.import("resource:///modules/asrouter/ASRouterTargeting.jsm");
+        ASRouterTargeting = ChromeUtils.importESModule("resource:///modules/asrouter/ASRouterTargeting.sys.mjs");
     } catch (ex) {
         if (ex.result === Cr.NS_ERROR_FILE_NOT_FOUND) {
-            ASRouterTargeting = ChromeUtils.import("resource://activity-stream/lib/ASRouterTargeting.jsm");
+            ASRouterTargeting = ChromeUtils.importESModule("resource://activity-stream/lib/ASRouterTargeting.sys.mjs");
         } else {
             throw ex;
         }


### PR DESCRIPTION
Because:

- Firefox Desktop used to use `ChromeUtils.import` to import JSM modules;
- Firefox Desktop mirgated to using ESMs, but supported using `ChromeUtils.import` with the original JSM paths to allow for a migration period;
- that migration period is now over and ChromeUtils.import was removed from Firefox Desktop in [bug 1881888][1].

This commit:

- migrates all `ChromeUtils.imports` of JSM paths to `ChromeUtils.importESModule` calls with ESM paths.

[1]: https://bugzilla.mozilla.org/show_bug.cgi?id=1881888

Fixes #12105