### PR TITLE
Revert "feat: split start/end dates into separate columns on main list (#11989)"

### DIFF
--- a/experimenter/experimenter/nimbus_ui_new/filtersets.py
+++ b/experimenter/experimenter/nimbus_ui_new/filtersets.py
@@ -1,10 +1,8 @@
-from datetime import datetime
-
 import django_filters
 from django import forms
 from django.contrib.auth.models import User
 from django.db import models
-from django.db.models import Case, IntegerField, Q, Value, When
+from django.db.models import Q
 from django.db.models.functions import Concat
 
 from experimenter.base.models import Country, Language, Locale
@@ -67,10 +65,8 @@ class SortChoices(models.TextChoices):
     FEATURES_DOWN = "-feature_configs__slug"
     VERSIONS_UP = "firefox_min_version"
     VERSIONS_DOWN = "-firefox_min_version"
-    START_DATE_UP = "_start_date"
-    START_DATE_DOWN = "-_start_date"
-    END_DATE_UP = "computed_end_date"
-    END_DATE_DOWN = "-computed_end_date"
+    DATES_UP = "_start_date"
+    DATES_DOWN = "-_start_date"
 
 
 class IconMultiSelectWidget(MultiSelectWidget):
@@ -262,33 +258,6 @@ class NimbusExperimentFilter(django_filters.FilterSet):
         ]
 
     def filter_sort(self, queryset, name, value):
-        if value in [SortChoices.END_DATE_UP, SortChoices.END_DATE_DOWN]:
-            reverse = value == SortChoices.END_DATE_DOWN
-            if value == SortChoices.END_DATE_UP:
-                default_date = datetime.max.date()
-            else:
-                default_date = datetime.min.date()
-
-            queryset_sorted = sorted(
-                queryset,
-                key=lambda exp: exp.computed_end_date
-                if exp.computed_end_date
-                else default_date,
-                reverse=reverse,
-            )
-
-            preserved_order = Case(
-                *[
-                    When(pk=exp.id, then=Value(pos))
-                    for pos, exp in enumerate(queryset_sorted)
-                ],
-                output_field=IntegerField()
-            )
-
-            return queryset.filter(pk__in=[exp.id for exp in queryset_sorted]).order_by(
-                preserved_order
-            )
-
         return queryset.order_by(value)
 
     def filter_status(self, queryset, name, value):

--- a/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/table.html
+++ b/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/table.html
@@ -64,8 +64,7 @@
         {% include "nimbus_experiments/table_header.html" with field="Size" up=sort_choices.SIZE_UP down=sort_choices.SIZE_DOWN %}
         {% include "nimbus_experiments/table_header.html" with field="Features" up=sort_choices.FEATURES_UP down=sort_choices.FEATURES_DOWN %}
         {% include "nimbus_experiments/table_header.html" with field="Versions" up=sort_choices.VERSIONS_UP down=sort_choices.VERSIONS_DOWN %}
-        {% include "nimbus_experiments/table_header.html" with field="Start" up=sort_choices.START_DATE_UP down=sort_choices.START_DATE_DOWN %}
-        {% include "nimbus_experiments/table_header.html" with field="End" up=sort_choices.END_DATE_UP down=sort_choices.END_DATE_DOWN %}
+        {% include "nimbus_experiments/table_header.html" with field="Dates" up=sort_choices.DATES_UP down=sort_choices.DATES_DOWN %}
 
         <th scope="col">Results</th>
       </tr>
@@ -149,14 +148,11 @@
           </td>
           <td>
             {% if experiment.start_date %}
-              {{ experiment.start_date|date:"Y-m-d" }}
-            {% else %}
-              N/A
-            {% endif %}
-          </td>
-          <td>
-            {% if experiment.computed_end_date %}
-              {{ experiment.computed_end_date|date:"Y-m-d" }}({{ experiment.computed_duration_days }} days)
+              {{ experiment.start_date|date:"Y-m-d" }} -
+              <br>
+              {{ experiment.computed_end_date|date:"Y-m-d" }}
+              <br>
+              ({{ experiment.computed_duration_days }} days)
             {% else %}
               N/A
             {% endif %}

--- a/experimenter/experimenter/nimbus_ui_new/tests/test_views.py
+++ b/experimenter/experimenter/nimbus_ui_new/tests/test_views.py
@@ -847,7 +847,7 @@ class NimbusExperimentsListViewTest(AuthTestCase):
             [experiment2.slug, experiment1.slug],
         )
 
-    def test_sort_by_start_date(self):
+    def test_sort_by_dates(self):
         experiment1 = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.LIVE_ENROLLING,
             start_date=datetime.date(2024, 1, 1),
@@ -860,7 +860,7 @@ class NimbusExperimentsListViewTest(AuthTestCase):
         response = self.client.get(
             reverse("nimbus-list"),
             {
-                "sort": SortChoices.START_DATE_UP,
+                "sort": SortChoices.DATES_UP,
             },
         )
 
@@ -872,67 +872,13 @@ class NimbusExperimentsListViewTest(AuthTestCase):
         response = self.client.get(
             reverse("nimbus-list"),
             {
-                "sort": SortChoices.START_DATE_DOWN,
+                "sort": SortChoices.DATES_DOWN,
             },
         )
 
         self.assertEqual(
             [e.slug for e in response.context["experiments"]],
             [experiment2.slug, experiment1.slug],
-        )
-
-    def test_sort_by_end_date(self):
-        experiment1 = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperimentFactory.Lifecycles.ENDING_APPROVE,
-            start_date=datetime.date(2024, 1, 1),
-            end_date=datetime.date(2024, 2, 1),
-        )
-        experiment2 = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperimentFactory.Lifecycles.ENDING_APPROVE,
-            start_date=datetime.date(2024, 1, 2),
-            end_date=datetime.date(2024, 2, 2),
-        )
-        experiment3 = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperimentFactory.Lifecycles.LIVE_ENROLLING,
-            start_date=datetime.date(2024, 1, 2),
-            proposed_duration=10,
-        )
-        experiment4 = NimbusExperimentFactory.create(
-            status=NimbusExperiment.Status.LIVE,
-        )
-
-        response = self.client.get(
-            reverse("nimbus-list"),
-            {
-                "sort": SortChoices.END_DATE_UP,
-            },
-        )
-
-        expected_order_up = sorted(
-            [experiment1, experiment2, experiment3], key=lambda exp: exp.computed_end_date
-        )
-
-        self.assertEqual(
-            [e.slug for e in response.context["experiments"]],
-            ([exp.slug for exp in expected_order_up] + [experiment4.slug]),
-        )
-
-        response = self.client.get(
-            reverse("nimbus-list"),
-            {
-                "sort": SortChoices.END_DATE_DOWN,
-            },
-        )
-
-        expected_order_down = sorted(
-            [experiment1, experiment2, experiment3],
-            key=lambda exp: exp.computed_end_date,
-            reverse=True,
-        )
-
-        self.assertEqual(
-            [e.slug for e in response.context["experiments"]],
-            ([exp.slug for exp in expected_order_down] + [experiment4.slug]),
         )
 
 


### PR DESCRIPTION
This reverts commit 0d53c8a2d10f04888bb76f269291587b759395a9.

Because

- Dynamically computing the end dates for sorting takes too long to process
- We will need to further performance optimize this before we can re deploy it

This commit

- Reverts splitting the date into separate start and end dates

Fixes #12113