### PR TITLE
feat(nimbus): Create advanced targeting for the sidebar 136 experimentation

### DIFF
--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -2298,6 +2298,20 @@ NO_HTTPS_ONLY_DESKTOP = NimbusTargetingConfig(
     application_choice_names=(Application.DESKTOP.name,),
 )
 
+NON_SIDEBAR_USERS = NimbusTargetingConfig(
+    name="Users that have never used the sidebar",
+    slug="non_sidebar_users",
+    description="Target users who have never used the new or old sidebar",
+    targeting=(
+        "!('sidebar.revamp'|preferenceValue) && "
+        "'sidebar.backupState'|preferenceValue == '{}'"
+    ),
+    desktop_telemetry="",
+    sticky_required=False,
+    is_first_run_required=False,
+    application_choice_names=(Application.DESKTOP.name,),
+)
+
 
 class TargetingConstants:
     TARGETING_VERSION = "version|versionCompare('{version}') >= 0"


### PR DESCRIPTION
Because we need to add a new advanced targeting into the Nimbus targeting repository that selects users who:
- never used the old sidebar: sidebar.backupState = empty object
- are not new sidebar users: sidebar.revamp = false

This commit adds targeting for the above.

Fixes [Bug 1943195](https://bugzilla.mozilla.org/show_bug.cgi?id=1943195)