### PR TITLE
feat(nimbus): Show preview recipe json

### DIFF
--- a/experimenter/experimenter/experiments/models.py
+++ b/experimenter/experimenter/experiments/models.py
@@ -473,6 +473,9 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
     def get_update_audience_url(self):
         return reverse("nimbus-new-update-audience", kwargs={"slug": self.slug})
 
+    def get_detail_preview_recipe_json_url(self):
+        return f"{self.get_detail_url()}#preview-recipe-json"
+
     @property
     def experiment_url(self):
         return urljoin(f"https://{settings.HOSTNAME}", self.get_absolute_url())

--- a/experimenter/experimenter/nimbus_ui_new/static/js/experiment_detail.js
+++ b/experimenter/experimenter/nimbus_ui_new/static/js/experiment_detail.js
@@ -1,0 +1,16 @@
+document.addEventListener("DOMContentLoaded", function () {
+  const collapseRecipe = document.getElementById("collapse-recipe");
+  if (!collapseRecipe) return;
+  const bsCollapse = new window.bootstrap.Collapse(collapseRecipe, {
+    toggle: false,
+  });
+  collapseRecipe.addEventListener("hide.bs.collapse", () => bsCollapse.hide());
+
+  function showRecipeJson() {
+    if (window.location.hash.includes("preview-recipe-json")) {
+      bsCollapse.show();
+    }
+  }
+  showRecipeJson();
+  window.addEventListener("hashchange", showRecipeJson);
+});

--- a/experimenter/experimenter/nimbus_ui_new/static/js/experiment_detail.js
+++ b/experimenter/experimenter/nimbus_ui_new/static/js/experiment_detail.js
@@ -1,16 +1,24 @@
 document.addEventListener("DOMContentLoaded", function () {
   const collapseRecipe = document.getElementById("collapse-recipe");
   if (!collapseRecipe) return;
+
   const bsCollapse = new window.bootstrap.Collapse(collapseRecipe, {
     toggle: false,
   });
-  collapseRecipe.addEventListener("hide.bs.collapse", () => bsCollapse.hide());
 
   function showRecipeJson() {
-    if (window.location.hash.includes("preview-recipe-json")) {
-      bsCollapse.show();
-    }
+    bsCollapse.show();
   }
-  showRecipeJson();
-  window.addEventListener("hashchange", showRecipeJson);
+  // Expand JSON if URL contains the hash on page load
+  if (window.location.hash.includes("preview-recipe-json")) {
+    showRecipeJson();
+  }
+  // Ensure it expands every time "Preview Recipe JSON" is clicked
+  const previewJsonLink = document.querySelector('a[href$="preview-recipe-json"]');
+  if (previewJsonLink) {
+    previewJsonLink.addEventListener("click", function () {
+      setTimeout(showRecipeJson, 50);
+    });
+  }
 });
+

--- a/experimenter/experimenter/nimbus_ui_new/static/js/experiment_detail.js
+++ b/experimenter/experimenter/nimbus_ui_new/static/js/experiment_detail.js
@@ -14,11 +14,12 @@ document.addEventListener("DOMContentLoaded", function () {
     showRecipeJson();
   }
   // Ensure it expands every time "Preview Recipe JSON" is clicked
-  const previewJsonLink = document.querySelector('a[href$="preview-recipe-json"]');
+  const previewJsonLink = document.querySelector(
+    'a[href$="preview-recipe-json"]',
+  );
   if (previewJsonLink) {
     previewJsonLink.addEventListener("click", function () {
       setTimeout(showRecipeJson, 50);
     });
   }
 });
-

--- a/experimenter/experimenter/nimbus_ui_new/static/js/index.js
+++ b/experimenter/experimenter/nimbus_ui_new/static/js/index.js
@@ -8,6 +8,7 @@ import * as bootstrap from "bootstrap";
 import "htmx.org";
 import "bootstrap-select";
 
+window.bootstrap = bootstrap;
 const setupThemeSwitcher = () => {
   const LIGHT = "light";
   const DARK = "dark";

--- a/experimenter/experimenter/nimbus_ui_new/static/webpack.config.js
+++ b/experimenter/experimenter/nimbus_ui_new/static/webpack.config.js
@@ -7,6 +7,7 @@ module.exports = {
     experiment_list: "./js/experiment_list.js",
     review_controls: "./js/review_controls.js",
     edit_audience: "./js/edit_audience.js",
+    experiment_detail: "./js/experiment_detail.js",
   },
   output: {
     filename: "[name].bundle.js",

--- a/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/detail.html
+++ b/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/detail.html
@@ -263,7 +263,7 @@
             <td colspan="3">{{ experiment.targeting }}</td>
           </tr>
           <tr>
-            <th>Recipe JSON</th>
+            <th id="recipe-json">Recipe JSON</th>
             <td colspan="3">
               <div class="collapse" id="collapseRecipe">
                 <code>

--- a/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/detail.html
+++ b/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/detail.html
@@ -264,8 +264,8 @@
           </tr>
           <tr>
             <th id="recipe-json">Recipe JSON</th>
-            <td colspan="3">
-              <div class="collapse" id="collapseRecipe">
+            <td colspan="3" id="preview-recipe-json">
+              <div class="collapse" id="collapse-recipe">
                 <code>
                   <pre class="text-monospace" style="white-space: pre-wrap; word-wrap: break-word;">
                       {{ experiment.recipe_json|linebreaks|linebreaksbr }}
@@ -275,9 +275,9 @@
               <button class="btn btn-outline-primary btn-sm"
                       type="button"
                       data-bs-toggle="collapse"
-                      data-bs-target="#collapseRecipe"
+                      data-bs-target="#collapse-recipe"
                       aria-expanded="false"
-                      aria-controls="collapseRecipe">
+                      aria-controls="collapse-recipe">
                 <i class="fa-solid fa-plus"></i> Show/Hide Recipe
               </button>
             </td>
@@ -367,4 +367,5 @@
   {{ block.super }}
   <script src="{% static 'nimbus_ui_new/setup_selectpicker.bundle.js' %}"></script>
   <script src="{% static 'nimbus_ui_new/review_controls.bundle.js' %}"></script>
+  <script src="{% static 'nimbus_ui_new/experiment_detail.bundle.js' %}"></script>
 {% endblock %}

--- a/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/sidebar.html
+++ b/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/sidebar.html
@@ -23,7 +23,8 @@
 
     {% endif %}
   {% endfor %}
-  <a class="nav-link d-flex align-items-center" href="#recipe-json">
+  <a class="nav-link d-flex align-items-center"
+     href="{{ experiment.get_detail_preview_recipe_json_url }}">
     <i class="fa-solid fa-file-code me-2"></i>
     Preview Recipe JSON
   </a>

--- a/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/sidebar.html
+++ b/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/sidebar.html
@@ -23,4 +23,8 @@
 
     {% endif %}
   {% endfor %}
+  <a class="nav-link d-flex align-items-center" href="#recipe-json">
+    <i class="fa-solid fa-file-code me-2"></i>
+    Preview Recipe JSON
+  </a>
 </div>


### PR DESCRIPTION
Because

- We want to have a link on the summary page to preview recipe json easily

This commit

- Adds a link on the sidebar to preview recipe json

Fixes #12112 
<img width="827" alt="Screenshot 2025-01-29 at 10 26 27 AM" src="https://github.com/user-attachments/assets/13a515c8-77ad-4c4b-aad4-49a9423a6a29" />
