### PR TITLE
chore(schemas): easier JSON/TS schema generate for new packages

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,4 +3,4 @@
 /experimenter/jetstream @jaredlockhart @mikewilli
 /experimenter/manifesttool/ @jaredlockhart @brennie
 /experimenter/tests @b4handjr
-/schemas/ @jaredlockhart @mikewilli
+/schemas/ @jaredlockhart @mikewilli @brennie

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -10,28 +10,52 @@ This directory contains a package of schemas published to various repositories f
 - node ^16
 - yarn ^1.22
 
-#### Common Operations
+### Common Operations
 From project root (i.e., parent to this directory)
 - Build: `make schemas_build`
 - Run linting and tests: `make schemas_check`
 - Code formatting: `make schemas_format`
 
-#### Building Python Schemas Package
-`make schemas_build_pypi`
 
-#### Building Typescript Schemas Package
-`make schemas_build_npm`
+### Adding New Schemas
+
+**Example**
+Creating a new sub-package `new_stuff`
+1. Add new directory `mozilla_nimbus_schemas` / `new_stuff` with schemas inside.
+1. Add `new_stuff` schemas to the `new_stuff` directory's `__init__.py` file.
+1. Add `new_stuff` to top level `__init__.py`:
+    >`from mozilla_nimbus_schemas.new_stuff import *`
+1. Generate Typescript and/or JSON Schemas for `new_stuff` by updating the `generate_json_schema.py` script like so:
+    
+    a. Import `new_stuff` alongside existing `mozilla_nimbus_schemas` imports, e.g.,
+      >`from mozilla_nimbus_schemas import experiments, jetstream, new_stuff`
+  
+    b. (optional) Add `new_stuff` to Typescript generation
+    * Update `TS_SCHEMA_PACKAGES` list, e.g.,
+      >`TS_SCHEMA_PACKAGES = [experiments, jetstream, new_stuff]`
+
+    c. (optional) Add `new_stuff` to JSON Schema generation
+    * Update `JSON_SCHEMA_PACKAGES` list, e.g.,
+      >`JSON_SCHEMA_PACKAGES = [experiments, new_stuff]`
+
+1. Build everything with `make schemas_build`
+
+1. Update the version (see [Versioning](#versioningversioning) below).
 
 ## Schemas
 ### Jetstream
 
 Contains schemas describing analysis results, metadata, and errors from [Jetstream](https://github.com/mozilla/jetstream).
 
+### Experiments
+
+Defines the schemas used for validating the Experimenter v6 API. Previously defined in the now-deprecated [`nimbus-shared`](https://github.com/mozilla/nimbus-shared).
+
 
 ## Deployment
 The build and deployment occurs automatically through CI. A deployment is triggered on merges into the `main` branch when the version number changes. Schemas are published to various repos for access in different languages.
 
-#### Versioning
+### Versioning
 `mozilla-nimbus-schemas` uses a date-based versioning scheme (`CalVer`). The format is `yyyy.m.MINOR`, where `m` is the non-zero-padded month, and `MINOR` is an incrementing number starting from 1 for each month. Notably, this `MINOR` number does NOT correspond to the day of the month. For example, the second release in June of 2023 would have a version of `2023.6.2`.
 
 #### Version Updates

--- a/schemas/generate_json_schema.py
+++ b/schemas/generate_json_schema.py
@@ -19,6 +19,11 @@ from mozilla_nimbus_schemas import experiments, jetstream
 
 NEWLINES_RE = re.compile("\n+")
 
+# Add new sub-packages to list(s) below if you want them to have
+# JSON Schema and/or Typescript generated.
+JSON_SCHEMA_PACKAGES = [experiments]
+TS_SCHEMA_PACKAGES = [experiments, jetstream]
+
 
 def clean_output_file(ts_path: Path) -> None:
     """Clean up the output file typescript definitions were written to by:
@@ -85,10 +90,9 @@ def iterate_models() -> dict[str, Any]:
     model_names = list(experiments.__all__) + list(jetstream.__all__)
     models = []
     for model_name_str in model_names:
-        if model_name_str in experiments.__all__:
-            model = getattr(experiments, model_name_str)
-        else:
-            model = getattr(jetstream, model_name_str)
+        for package in TS_SCHEMA_PACKAGES:
+            if model_name_str in package.__all__:
+                model = getattr(package, model_name_str)
         if not issubclass(model, ModelFactory):
             models.append(model)
     top_model: BaseModel = create_model(
@@ -189,11 +193,16 @@ def prettify_json_schema(schema: dict[str, Any]) -> dict[str, Any]:
 def write_json_schemas(json_schemas_path: Path, python_package_dir: Path):
     json_schemas_path.mkdir(exist_ok=True)
 
-    models = {
-        model_name: getattr(experiments, model_name)
-        for model_name in experiments.__all__
-        if issubclass(getattr(experiments, model_name), BaseModel)
-    }
+    models = {}
+
+    for package in JSON_SCHEMA_PACKAGES:
+        models.update(
+            {
+                model_name: getattr(package, model_name)
+                for model_name in package.__all__
+                if issubclass(getattr(package, model_name), BaseModel)
+            }
+        )
 
     written_paths = set()
 


### PR DESCRIPTION
Because

- it isn't clear how to generate Typescript and JSON Schemas for new sub-packages in schemas

This commit

- makes it more obvious what needs to be changed in `generate_json_schemas.py`
- updates the README with a new section on adding new schemas
- adds @brennie to CODEOWNERS for schemas (because she is the most knowledgeable on the JSON Schemas generation and usage)

Fixes #12173 