### PR TITLE
feat(targeting): add SIGNED_IN_USER and SIGNED_OUT_USER targeting configs

### DIFF
--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -2212,6 +2212,28 @@ EXISTING_WIN1903_USER_HAS_DEFAULT = NimbusTargetingConfig(
     application_choice_names=(Application.DESKTOP.name,),
 )
 
+SIGNED_IN_USER = NimbusTargetingConfig(
+    name="Signed-in User",
+    slug="signed_in_user",
+    description="Users who are signed into FxA",
+    targeting="isFxASignedIn",
+    desktop_telemetry="",
+    sticky_required=False,
+    is_first_run_required=False,
+    application_choice_names=(Application.DESKTOP.name,),
+)
+
+SIGNED_OUT_USER = NimbusTargetingConfig(
+    name="Signed-out User",
+    slug="signed_out_user",
+    description="Users who are NOT signed into FxA",
+    targeting="!isFxASignedIn",
+    desktop_telemetry="",
+    sticky_required=False,
+    is_first_run_required=False,
+    application_choice_names=(Application.DESKTOP.name,),
+)
+
 SYNC_USER = NimbusTargetingConfig(
     name="Sync User",
     slug="sync_user",


### PR DESCRIPTION
Because

- We can't currently target signed-in/out users ...

This commit

- adds `SIGNED_IN_USER` and `SIGNED_OUT_USER` targeting configs.