### PR TITLE
chore(nimbus): add locale, language, country to admin

### DIFF
--- a/experimenter/experimenter/base/admin.py
+++ b/experimenter/experimenter/base/admin.py
@@ -1,7 +1,24 @@
 from django import forms
 from django.contrib import admin
 
-from experimenter.base.models import SiteFlag, SiteFlagNameChoices
+from experimenter.base.models import (
+    Country,
+    Language,
+    Locale,
+    SiteFlag,
+    SiteFlagNameChoices,
+)
+
+
+class CreateOnlyAdminMixin:
+    def has_add_permission(self, request, obj=None):
+        return True
+
+    def has_change_permission(self, request, obj=None):
+        return False
+
+    def has_delete_permission(self, request, obj=None):
+        return False
 
 
 class SiteFlagAdminForm(forms.ModelForm):
@@ -13,10 +30,23 @@ class SiteFlagAdminForm(forms.ModelForm):
         exclude = ("id",)
 
 
+@admin.register(SiteFlag)
 class SiteFlagAdmin(admin.ModelAdmin[SiteFlag]):
     form = SiteFlagAdminForm
     list_display = ("value", "description", "modified_on", "created_on")
     list_display_links = ("description",)
 
 
-admin.site.register(SiteFlag, SiteFlagAdmin)
+@admin.register(Locale)
+class LocaleAdmin(CreateOnlyAdminMixin, admin.ModelAdmin[Locale]):
+    pass
+
+
+@admin.register(Language)
+class LanguageAdmin(CreateOnlyAdminMixin, admin.ModelAdmin[Language]):
+    pass
+
+
+@admin.register(Country)
+class CountryAdmin(CreateOnlyAdminMixin, admin.ModelAdmin[Country]):
+    pass


### PR DESCRIPTION
Becuase

* We need to add some missing locales, languages, countries to the db
* We could do this through a data migration but it ends up conflicting with the test factories
* Let's add a create only interface for those models to the admin for special cases

This commit

* Adds a create only interface for locale, language, country in the admin

fixes #12150

