### PR TITLE
chore(nimbus): split start/end date columns with performance tweaks

### DIFF
--- a/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/table.html
+++ b/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/table.html
@@ -64,7 +64,8 @@
         {% include "nimbus_experiments/table_header.html" with field="Size" up=sort_choices.SIZE_UP down=sort_choices.SIZE_DOWN %}
         {% include "nimbus_experiments/table_header.html" with field="Features" up=sort_choices.FEATURES_UP down=sort_choices.FEATURES_DOWN %}
         {% include "nimbus_experiments/table_header.html" with field="Versions" up=sort_choices.VERSIONS_UP down=sort_choices.VERSIONS_DOWN %}
-        {% include "nimbus_experiments/table_header.html" with field="Dates" up=sort_choices.DATES_UP down=sort_choices.DATES_DOWN %}
+        {% include "nimbus_experiments/table_header.html" with field="Start" up=sort_choices.START_DATE_UP down=sort_choices.START_DATE_DOWN %}
+        {% include "nimbus_experiments/table_header.html" with field="End" up=sort_choices.END_DATE_UP down=sort_choices.END_DATE_DOWN %}
 
         <th scope="col">Results</th>
       </tr>
@@ -148,11 +149,14 @@
           </td>
           <td>
             {% if experiment.start_date %}
-              {{ experiment.start_date|date:"Y-m-d" }} -
-              <br>
-              {{ experiment.computed_end_date|date:"Y-m-d" }}
-              <br>
-              ({{ experiment.computed_duration_days }} days)
+              {{ experiment.start_date|date:"Y-m-d" }}
+            {% else %}
+              N/A
+            {% endif %}
+          </td>
+          <td>
+            {% if experiment.computed_end_date %}
+              {{ experiment.computed_end_date|date:"Y-m-d" }}({{ experiment.computed_duration_days }} days)
             {% else %}
               N/A
             {% endif %}

--- a/experimenter/experimenter/nimbus_ui_new/tests/test_views.py
+++ b/experimenter/experimenter/nimbus_ui_new/tests/test_views.py
@@ -847,7 +847,7 @@ class NimbusExperimentsListViewTest(AuthTestCase):
             [experiment2.slug, experiment1.slug],
         )
 
-    def test_sort_by_dates(self):
+    def test_sort_by_start_date(self):
         experiment1 = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.LIVE_ENROLLING,
             start_date=datetime.date(2024, 1, 1),
@@ -860,7 +860,7 @@ class NimbusExperimentsListViewTest(AuthTestCase):
         response = self.client.get(
             reverse("nimbus-list"),
             {
-                "sort": SortChoices.DATES_UP,
+                "sort": SortChoices.START_DATE_UP,
             },
         )
 
@@ -872,13 +872,67 @@ class NimbusExperimentsListViewTest(AuthTestCase):
         response = self.client.get(
             reverse("nimbus-list"),
             {
-                "sort": SortChoices.DATES_DOWN,
+                "sort": SortChoices.START_DATE_DOWN,
             },
         )
 
         self.assertEqual(
             [e.slug for e in response.context["experiments"]],
             [experiment2.slug, experiment1.slug],
+        )
+
+    def test_sort_by_end_date(self):
+        experiment1 = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.ENDING_APPROVE,
+            start_date=datetime.date(2024, 1, 1),
+            end_date=datetime.date(2024, 2, 1),
+        )
+        experiment2 = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.ENDING_APPROVE,
+            start_date=datetime.date(2024, 1, 2),
+            end_date=datetime.date(2024, 2, 2),
+        )
+        experiment3 = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.LIVE_ENROLLING,
+            start_date=datetime.date(2024, 1, 2),
+            proposed_duration=10,
+        )
+        experiment4 = NimbusExperimentFactory.create(
+            status=NimbusExperiment.Status.LIVE,
+        )
+
+        response = self.client.get(
+            reverse("nimbus-list"),
+            {
+                "sort": SortChoices.END_DATE_UP,
+            },
+        )
+
+        expected_order_up = sorted(
+            [experiment1, experiment2, experiment3], key=lambda exp: exp.computed_end_date
+        )
+
+        self.assertEqual(
+            [e.slug for e in response.context["experiments"]],
+            ([exp.slug for exp in expected_order_up] + [experiment4.slug]),
+        )
+
+        response = self.client.get(
+            reverse("nimbus-list"),
+            {
+                "sort": SortChoices.END_DATE_DOWN,
+            },
+        )
+
+        expected_order_down = sorted(
+            [experiment1, experiment2, experiment3],
+            key=lambda exp: exp.computed_end_date,
+            reverse=True,
+        )
+
+        self.assertEqual(
+            [e.slug for e in response.context["experiments"]],
+            ([exp.slug for exp in expected_order_down] + [experiment4.slug]),
         )
 
 


### PR DESCRIPTION
Becuase

* We split the start/end date columns in the landing page table
* Sorting by end date was too slow

This commit

* Re-adds the commit to split the start/end date columns in the list view
* Optimizes for db query performance by removing extraneous queries

fixes #12115

Revert "Revert "feat: split start/end dates into separate columns on main list (#11989)" (#12114)"

This reverts commit fa3ab303c6aace0555de51456c0b01611e7298c0.

