### PR TITLE
chore(nimbus): remove deprecated pydantic v1 functions from jetstream client

### DIFF
--- a/experimenter/experimenter/jetstream/client.py
+++ b/experimenter/experimenter/jetstream/client.py
@@ -53,7 +53,7 @@ def load_data_from_gcs(path):
 
 def validate_data(data_json):
     if data_json:
-        Statistics.parse_obj(data_json)
+        Statistics.model_validate(data_json)
     return data_json
 
 
@@ -65,7 +65,7 @@ def get_data(slug, window):
 
 def validate_metadata(metadata_json):
     if metadata_json:
-        Metadata.parse_obj(metadata_json)
+        Metadata.model_validate(metadata_json)
     return metadata_json
 
 
@@ -77,7 +77,7 @@ def get_metadata(slug):
 
 def validate_analysis_errors(analysis_errors_json):
     if analysis_errors_json:
-        AnalysisErrors.parse_obj(analysis_errors_json)
+        AnalysisErrors.model_validate(analysis_errors_json)
     return analysis_errors_json
 
 
@@ -275,7 +275,7 @@ def get_experiment_data(experiment: NimbusExperiment):
                 data = ResultsObjectModel(result_metrics, data, experiment, window)
 
             # Convert output object to dict and put into the final object
-            transformed_data = data.dict(exclude_none=True) or None
+            transformed_data = data.model_dump(exclude_none=True) or None
             experiment_data[window][AnalysisBasis.ENROLLMENTS][segment] = transformed_data
 
         for segment, segment_data in segment_points_exposures.items():
@@ -309,7 +309,7 @@ def get_experiment_data(experiment: NimbusExperiment):
 
                 data = ResultsObjectModel(result_metrics, data, experiment, window)
 
-            transformed_data = data.dict(exclude_none=True) or None
+            transformed_data = data.model_dump(exclude_none=True) or None
             experiment_data[window][AnalysisBasis.EXPOSURES][segment] = transformed_data
 
     errors_by_metric = {}
@@ -351,7 +351,7 @@ def get_experiment_data(experiment: NimbusExperiment):
                 message=e,
                 timestamp=datetime.now(),
             )
-            errors_experiment_overall.append(analysis_error.dict())
+            errors_experiment_overall.append(analysis_error.model_dump())
 
     errors_by_metric["experiment"] = errors_experiment_overall
 
@@ -364,5 +364,5 @@ def get_experiment_data(experiment: NimbusExperiment):
 
 def get_population_sizing_data():
     sizing_data = get_sizing_data(suffix="latest")
-    sizing = SampleSizes.parse_obj(sizing_data) if sizing_data is not None else {}
+    sizing = SampleSizes.model_validate(sizing_data) if sizing_data is not None else {}
     return {"v1": sizing}

--- a/experimenter/experimenter/jetstream/models.py
+++ b/experimenter/experimenter/jetstream/models.py
@@ -243,7 +243,7 @@ class ResultsObjectModelBase(BaseModel):
                 # significance for each window. Overall should always be 1 because
                 # there is only ever one overall window.
                 window_index = (
-                    1
+                    "1"
                     if window == AnalysisWindow.OVERALL
                     else jetstream_data_point.window_index
                 )

--- a/experimenter/experimenter/jetstream/tests/constants.py
+++ b/experimenter/experimenter/jetstream/tests/constants.py
@@ -44,8 +44,8 @@ class JetstreamTestData:
         if is_retention:
             all_data_points.append(DATA_POINT)
 
-        significance = cls.get_pairwise_significance_data()().dict()
-        difference = cls.get_pairwise_branch_comparison_data()().dict()
+        significance = cls.get_pairwise_significance_data()().model_dump()
+        difference = cls.get_pairwise_branch_comparison_data()().model_dump()
 
         # initialize pairwise branch comparisons inside dicts
         for branch in branches:
@@ -55,7 +55,7 @@ class JetstreamTestData:
         # set the comparison branch's data
         comparison_data = BranchComparisonData(
             first=DATA_POINT, all=all_data_points
-        ).dict()
+        ).model_dump()
         significance[comparison_to_branch] = deepcopy(SIGNIFICANCE.model_dump())
         difference[comparison_to_branch] = comparison_data
 
@@ -273,7 +273,7 @@ class JetstreamTestData:
             difference=cls.get_pairwise_branch_comparison_data()(),
             relative_uplift=cls.get_pairwise_branch_comparison_data()(),
             significance=cls.get_pairwise_significance_data()(),
-        ).dict(exclude_none=True)
+        ).model_dump(exclude_none=True)
 
     @classmethod
     def add_outcome_data(
@@ -308,14 +308,14 @@ class JetstreamTestData:
 
                 data.append(
                     JetstreamDataPoint(
-                        **range_data.dict(exclude_none=True),
+                        **range_data.model_dump(exclude_none=True),
                         metric=primary_metric,
                         branch=branch,
                         statistic="binomial",
                         window_index="1",
                         segment=Segment.ALL,
                         analysis_basis=analysis_basis,
-                    ).dict(exclude_none=True)
+                    ).model_dump(exclude_none=True)
                 )
 
     @classmethod
@@ -351,14 +351,14 @@ class JetstreamTestData:
 
                 data.append(
                     JetstreamDataPoint(
-                        **range_data.dict(exclude_none=True),
+                        **range_data.model_dump(exclude_none=True),
                         metric=primary_metric,
                         branch=branch,
                         statistic="mean",
                         window_index="1",
                         segment=Segment.ALL,
                         analysis_basis=analysis_basis,
-                    ).dict(exclude_none=True)
+                    ).model_dump(exclude_none=True)
                 )
 
     @classmethod
@@ -527,38 +527,46 @@ class JetstreamTestData:
         )
 
         DAILY_DATA = [
-            CONTROL_DATA_ROW.dict(exclude_none=True),
-            VARIANT_DATA_ROW.dict(exclude_none=True),
-            VARIANT_DATA_DEFAULT_METRIC_ROW_MEAN.dict(exclude_none=True),
-            VARIANT_DATA_DEFAULT_METRIC_ROW_RATIO.dict(exclude_none=True),
-            VARIANT_DATA_DEFAULT_METRIC_ROW_DAU_IMPACT.dict(exclude_none=True),
-            VARIANT_DATA_DEFAULT_METRIC_ROW_BINOMIAL.dict(exclude_none=True),
-            VARIANT_POSITIVE_SIGNIFICANCE_DATA_ROW.dict(exclude_none=True),
-            VARIANT_NEGATIVE_SIGNIFICANCE_DATA_ROW.dict(exclude_none=True),
-            CONTROL_NEUTRAL_SIGNIFICANCE_DATA_ROW.dict(exclude_none=True),
-            BROKEN_STATISTIC_DATA_ROW.dict(exclude_none=True),
-            VARIANT_BROKEN_STATISTIC_DATA_ROW.dict(exclude_none=True),
+            CONTROL_DATA_ROW.model_dump(exclude_none=True),
+            VARIANT_DATA_ROW.model_dump(exclude_none=True),
+            VARIANT_DATA_DEFAULT_METRIC_ROW_MEAN.model_dump(exclude_none=True),
+            VARIANT_DATA_DEFAULT_METRIC_ROW_RATIO.model_dump(exclude_none=True),
+            VARIANT_DATA_DEFAULT_METRIC_ROW_DAU_IMPACT.model_dump(exclude_none=True),
+            VARIANT_DATA_DEFAULT_METRIC_ROW_BINOMIAL.model_dump(exclude_none=True),
+            VARIANT_POSITIVE_SIGNIFICANCE_DATA_ROW.model_dump(exclude_none=True),
+            VARIANT_NEGATIVE_SIGNIFICANCE_DATA_ROW.model_dump(exclude_none=True),
+            CONTROL_NEUTRAL_SIGNIFICANCE_DATA_ROW.model_dump(exclude_none=True),
+            BROKEN_STATISTIC_DATA_ROW.model_dump(exclude_none=True),
+            VARIANT_BROKEN_STATISTIC_DATA_ROW.model_dump(exclude_none=True),
         ]
         DAILY_EXPOSURES_DATA = [
-            EXPOSURES_CONTROL_DATA_ROW.dict(exclude_none=True),
-            EXPOSURES_VARIANT_DATA_ROW.dict(exclude_none=True),
-            EXPOSURES_VARIANT_DATA_DEFAULT_METRIC_ROW_MEAN.dict(exclude_none=True),
-            EXPOSURES_VARIANT_DATA_DEFAULT_METRIC_ROW_RATIO.dict(exclude_none=True),
-            EXPOSURES_VARIANT_DATA_DEFAULT_METRIC_ROW_DAU_IMPACT.dict(exclude_none=True),
-            EXPOSURES_VARIANT_DATA_DEFAULT_METRIC_ROW_BINOMIAL.dict(exclude_none=True),
-            EXPOSURES_VARIANT_POSITIVE_SIGNIFICANCE_DATA_ROW.dict(exclude_none=True),
-            EXPOSURES_VARIANT_NEGATIVE_SIGNIFICANCE_DATA_ROW.dict(exclude_none=True),
-            EXPOSURES_CONTROL_NEUTRAL_SIGNIFICANCE_DATA_ROW.dict(exclude_none=True),
-            EXPOSURES_BROKEN_STATISTIC_DATA_ROW.dict(exclude_none=True),
-            VARIANT_EXPOSURES_BROKEN_STATISTIC_DATA_ROW.dict(exclude_none=True),
+            EXPOSURES_CONTROL_DATA_ROW.model_dump(exclude_none=True),
+            EXPOSURES_VARIANT_DATA_ROW.model_dump(exclude_none=True),
+            EXPOSURES_VARIANT_DATA_DEFAULT_METRIC_ROW_MEAN.model_dump(exclude_none=True),
+            EXPOSURES_VARIANT_DATA_DEFAULT_METRIC_ROW_RATIO.model_dump(exclude_none=True),
+            EXPOSURES_VARIANT_DATA_DEFAULT_METRIC_ROW_DAU_IMPACT.model_dump(
+                exclude_none=True
+            ),
+            EXPOSURES_VARIANT_DATA_DEFAULT_METRIC_ROW_BINOMIAL.model_dump(
+                exclude_none=True
+            ),
+            EXPOSURES_VARIANT_POSITIVE_SIGNIFICANCE_DATA_ROW.model_dump(
+                exclude_none=True
+            ),
+            EXPOSURES_VARIANT_NEGATIVE_SIGNIFICANCE_DATA_ROW.model_dump(
+                exclude_none=True
+            ),
+            EXPOSURES_CONTROL_NEUTRAL_SIGNIFICANCE_DATA_ROW.model_dump(exclude_none=True),
+            EXPOSURES_BROKEN_STATISTIC_DATA_ROW.model_dump(exclude_none=True),
+            VARIANT_EXPOSURES_BROKEN_STATISTIC_DATA_ROW.model_dump(exclude_none=True),
         ]
         SEGMENT_DATA = [
-            SEGMENTED_ROW_VARIANT.dict(exclude_none=True),
-            SEGMENTED_ROW_CONTROL.dict(exclude_none=True),
+            SEGMENTED_ROW_VARIANT.model_dump(exclude_none=True),
+            SEGMENTED_ROW_CONTROL.model_dump(exclude_none=True),
         ]
         SEGMENT_EXPOSURES_DATA = [
-            EXPOSURES_SEGMENTED_ROW_VARIANT.dict(exclude_none=True),
-            EXPOSURES_SEGMENTED_ROW_CONTROL.dict(exclude_none=True),
+            EXPOSURES_SEGMENTED_ROW_VARIANT.model_dump(exclude_none=True),
+            EXPOSURES_SEGMENTED_ROW_CONTROL.model_dump(exclude_none=True),
         ]
 
         (
@@ -610,19 +618,23 @@ class JetstreamTestData:
                 "is_control": True,
                 "branch_data": {
                     Group.SEARCH.value: {
-                        "search_count": EMPTY_METRIC_DATA.dict(exclude_none=True),
+                        "search_count": EMPTY_METRIC_DATA.model_dump(exclude_none=True),
                     },
                     Group.USAGE.value: {},
                     Group.OTHER.value: {
-                        "identity": ABSOLUTE_METRIC_DATA_A.dict(exclude_none=True),
-                        "some_count": EMPTY_METRIC_DATA.dict(exclude_none=True),
-                        "some_ratio": EMPTY_METRIC_DATA.dict(exclude_none=True),
-                        "some_dau_impact": EMPTY_METRIC_DATA.dict(exclude_none=True),
-                        "another_count": EMPTY_METRIC_DATA.dict(exclude_none=True),
-                        "retained": DIFFERENCE_METRIC_DATA_WEEKLY_NEUTRAL_VARIANT.dict(
+                        "identity": ABSOLUTE_METRIC_DATA_A.model_dump(exclude_none=True),
+                        "some_count": EMPTY_METRIC_DATA.model_dump(exclude_none=True),
+                        "some_ratio": EMPTY_METRIC_DATA.model_dump(exclude_none=True),
+                        "some_dau_impact": EMPTY_METRIC_DATA.model_dump(
                             exclude_none=True
                         ),
-                        "custom_metric": EMPTY_METRIC_DATA.dict(exclude_none=True),
+                        "another_count": EMPTY_METRIC_DATA.model_dump(exclude_none=True),
+                        "retained": (
+                            DIFFERENCE_METRIC_DATA_WEEKLY_NEUTRAL_VARIANT.model_dump(
+                                exclude_none=True
+                            )
+                        ),
+                        "custom_metric": EMPTY_METRIC_DATA.model_dump(exclude_none=True),
                     },
                 },
             },
@@ -631,22 +643,30 @@ class JetstreamTestData:
                 "branch_data": {
                     Group.SEARCH.value: {
                         "search_count": (
-                            DIFFERENCE_METRIC_DATA_WEEKLY_POSITIVE_CONTROL.dict(
+                            DIFFERENCE_METRIC_DATA_WEEKLY_POSITIVE_CONTROL.model_dump(
                                 exclude_none=True
                             )
                         ),
                     },
                     Group.USAGE.value: {},
                     Group.OTHER.value: {
-                        "identity": ABSOLUTE_METRIC_DATA_A.dict(exclude_none=True),
-                        "some_count": ABSOLUTE_METRIC_DATA_A.dict(exclude_none=True),
-                        "some_ratio": EMPTY_METRIC_DATA.dict(exclude_none=True),
-                        "some_dau_impact": ABSOLUTE_METRIC_DATA_A.dict(exclude_none=True),
-                        "another_count": ABSOLUTE_METRIC_DATA_A.dict(exclude_none=True),
-                        "retained": DIFFERENCE_METRIC_DATA_WEEKLY_NEGATIVE_CONTROL.dict(
+                        "identity": ABSOLUTE_METRIC_DATA_A.model_dump(exclude_none=True),
+                        "some_count": ABSOLUTE_METRIC_DATA_A.model_dump(
                             exclude_none=True
                         ),
-                        "custom_metric": EMPTY_METRIC_DATA.dict(exclude_none=True),
+                        "some_ratio": EMPTY_METRIC_DATA.model_dump(exclude_none=True),
+                        "some_dau_impact": ABSOLUTE_METRIC_DATA_A.model_dump(
+                            exclude_none=True
+                        ),
+                        "another_count": ABSOLUTE_METRIC_DATA_A.model_dump(
+                            exclude_none=True
+                        ),
+                        "retained": (
+                            DIFFERENCE_METRIC_DATA_WEEKLY_NEGATIVE_CONTROL.model_dump(
+                                exclude_none=True
+                            )
+                        ),
+                        "custom_metric": EMPTY_METRIC_DATA.model_dump(exclude_none=True),
                     },
                 },
             },
@@ -657,24 +677,28 @@ class JetstreamTestData:
                 "is_control": True,
                 "branch_data": {
                     Group.SEARCH.value: {
-                        "search_count": EMPTY_METRIC_DATA.dict(exclude_none=True),
+                        "search_count": EMPTY_METRIC_DATA.model_dump(exclude_none=True),
                     },
                     Group.USAGE.value: {},
                     Group.OTHER.value: {
-                        "identity": ABSOLUTE_METRIC_DATA_F_WITH_PERCENT.dict(
+                        "identity": ABSOLUTE_METRIC_DATA_F_WITH_PERCENT.model_dump(
                             exclude_none=True
                         ),
-                        "some_count": EMPTY_METRIC_DATA.dict(exclude_none=True),
-                        "some_ratio": EMPTY_METRIC_DATA.dict(exclude_none=True),
-                        "some_dau_impact": EMPTY_METRIC_DATA.dict(exclude_none=True),
-                        "another_count": EMPTY_METRIC_DATA.dict(exclude_none=True),
-                        "default_browser_action": EMPTY_METRIC_DATA.dict(
+                        "some_count": EMPTY_METRIC_DATA.model_dump(exclude_none=True),
+                        "some_ratio": EMPTY_METRIC_DATA.model_dump(exclude_none=True),
+                        "some_dau_impact": EMPTY_METRIC_DATA.model_dump(
                             exclude_none=True
                         ),
-                        "retained": DIFFERENCE_METRIC_DATA_OVERALL_NEUTRAL_VARIANT.dict(
+                        "another_count": EMPTY_METRIC_DATA.model_dump(exclude_none=True),
+                        "default_browser_action": EMPTY_METRIC_DATA.model_dump(
                             exclude_none=True
                         ),
-                        "custom_metric": EMPTY_METRIC_DATA.dict(exclude_none=True),
+                        "retained": (
+                            DIFFERENCE_METRIC_DATA_OVERALL_NEUTRAL_VARIANT.model_dump(
+                                exclude_none=True
+                            )
+                        ),
+                        "custom_metric": EMPTY_METRIC_DATA.model_dump(exclude_none=True),
                     },
                 },
             },
@@ -683,24 +707,32 @@ class JetstreamTestData:
                 "branch_data": {
                     Group.SEARCH.value: {
                         "search_count": (
-                            DIFFERENCE_METRIC_DATA_OVERALL_POSITIVE_CONTROL.dict(
+                            DIFFERENCE_METRIC_DATA_OVERALL_POSITIVE_CONTROL.model_dump(
                                 exclude_none=True
                             )
                         ),
                     },
                     Group.USAGE.value: {},
                     Group.OTHER.value: {
-                        "identity": ABSOLUTE_METRIC_DATA_F_WITH_PERCENT.dict(
+                        "identity": ABSOLUTE_METRIC_DATA_F_WITH_PERCENT.model_dump(
                             exclude_none=True
                         ),
-                        "some_count": ABSOLUTE_METRIC_DATA_F.dict(exclude_none=True),
-                        "some_ratio": EMPTY_METRIC_DATA.dict(exclude_none=True),
-                        "some_dau_impact": ABSOLUTE_METRIC_DATA_F.dict(exclude_none=True),
-                        "another_count": ABSOLUTE_METRIC_DATA_F.dict(exclude_none=True),
-                        "retained": DIFFERENCE_METRIC_DATA_OVERALL_NEGATIVE_CONTROL.dict(
+                        "some_count": ABSOLUTE_METRIC_DATA_F.model_dump(
                             exclude_none=True
                         ),
-                        "custom_metric": EMPTY_METRIC_DATA.dict(exclude_none=True),
+                        "some_ratio": EMPTY_METRIC_DATA.model_dump(exclude_none=True),
+                        "some_dau_impact": ABSOLUTE_METRIC_DATA_F.model_dump(
+                            exclude_none=True
+                        ),
+                        "another_count": ABSOLUTE_METRIC_DATA_F.model_dump(
+                            exclude_none=True
+                        ),
+                        "retained": (
+                            DIFFERENCE_METRIC_DATA_OVERALL_NEGATIVE_CONTROL.model_dump(
+                                exclude_none=True
+                            )
+                        ),
+                        "custom_metric": EMPTY_METRIC_DATA.model_dump(exclude_none=True),
                     },
                 },
             },
@@ -881,27 +913,29 @@ class JetstreamTestData:
         )
 
         DAILY_DATA = [
-            CONTROL_DATA_ROW.dict(exclude_none=True),
-            VARIANT_DATA_ROW.dict(exclude_none=True),
-            VARIANT_DATA_DEFAULT_METRIC_ROW_MEAN.dict(exclude_none=True),
-            VARIANT_DATA_DEFAULT_METRIC_ROW_BINOMIAL.dict(exclude_none=True),
-            VARIANT_POSITIVE_SIGNIFICANCE_DATA_ROW.dict(exclude_none=True),
-            VARIANT_NEGATIVE_SIGNIFICANCE_DATA_ROW.dict(exclude_none=True),
-            CONTROL_NEUTRAL_SIGNIFICANCE_DATA_ROW.dict(exclude_none=True),
+            CONTROL_DATA_ROW.model_dump(exclude_none=True),
+            VARIANT_DATA_ROW.model_dump(exclude_none=True),
+            VARIANT_DATA_DEFAULT_METRIC_ROW_MEAN.model_dump(exclude_none=True),
+            VARIANT_DATA_DEFAULT_METRIC_ROW_BINOMIAL.model_dump(exclude_none=True),
+            VARIANT_POSITIVE_SIGNIFICANCE_DATA_ROW.model_dump(exclude_none=True),
+            VARIANT_NEGATIVE_SIGNIFICANCE_DATA_ROW.model_dump(exclude_none=True),
+            CONTROL_NEUTRAL_SIGNIFICANCE_DATA_ROW.model_dump(exclude_none=True),
         ]
         DAILY_EXPOSURES_DATA = [
-            EXPOSURES_CONTROL_DATA_ROW.dict(exclude_none=True),
-            EXPOSURES_VARIANT_DATA_ROW.dict(exclude_none=True),
-            EXPOSURES_VARIANT_DATA_DEFAULT_METRIC_ROW_MEAN.dict(exclude_none=True),
-            EXPOSURES_VARIANT_DATA_DEFAULT_METRIC_ROW_BINOMIAL.dict(exclude_none=True),
+            EXPOSURES_CONTROL_DATA_ROW.model_dump(exclude_none=True),
+            EXPOSURES_VARIANT_DATA_ROW.model_dump(exclude_none=True),
+            EXPOSURES_VARIANT_DATA_DEFAULT_METRIC_ROW_MEAN.model_dump(exclude_none=True),
+            EXPOSURES_VARIANT_DATA_DEFAULT_METRIC_ROW_BINOMIAL.model_dump(
+                exclude_none=True
+            ),
         ]
         SEGMENT_DATA = [
-            SEGMENTED_ROW_VARIANT.dict(exclude_none=True),
-            SEGMENTED_ROW_CONTROL.dict(exclude_none=True),
+            SEGMENTED_ROW_VARIANT.model_dump(exclude_none=True),
+            SEGMENTED_ROW_CONTROL.model_dump(exclude_none=True),
         ]
         SEGMENT_EXPOSURES_DATA = [
-            EXPOSURES_SEGMENTED_ROW_VARIANT.dict(exclude_none=True),
-            EXPOSURES_SEGMENTED_ROW_CONTROL.dict(exclude_none=True),
+            EXPOSURES_SEGMENTED_ROW_VARIANT.model_dump(exclude_none=True),
+            EXPOSURES_SEGMENTED_ROW_CONTROL.model_dump(exclude_none=True),
         ]
 
         (
@@ -953,15 +987,17 @@ class JetstreamTestData:
                 "is_control": True,
                 "branch_data": {
                     Group.SEARCH.value: {
-                        "search_count": EMPTY_METRIC_DATA.dict(exclude_none=True),
+                        "search_count": EMPTY_METRIC_DATA.model_dump(exclude_none=True),
                     },
                     Group.USAGE.value: {},
                     Group.OTHER.value: {
-                        "identity": ABSOLUTE_METRIC_DATA_A.dict(exclude_none=True),
-                        "some_count": EMPTY_METRIC_DATA.dict(exclude_none=True),
-                        "another_count": EMPTY_METRIC_DATA.dict(exclude_none=True),
-                        "retained": DIFFERENCE_METRIC_DATA_WEEKLY_NEUTRAL_VARIANT.dict(
-                            exclude_none=True
+                        "identity": ABSOLUTE_METRIC_DATA_A.model_dump(exclude_none=True),
+                        "some_count": EMPTY_METRIC_DATA.model_dump(exclude_none=True),
+                        "another_count": EMPTY_METRIC_DATA.model_dump(exclude_none=True),
+                        "retained": (
+                            DIFFERENCE_METRIC_DATA_WEEKLY_NEUTRAL_VARIANT.model_dump(
+                                exclude_none=True
+                            )
                         ),
                     },
                 },
@@ -971,18 +1007,24 @@ class JetstreamTestData:
                 "branch_data": {
                     Group.SEARCH.value: {
                         "search_count": (
-                            DIFFERENCE_METRIC_DATA_WEEKLY_POSITIVE_CONTROL.dict(
+                            DIFFERENCE_METRIC_DATA_WEEKLY_POSITIVE_CONTROL.model_dump(
                                 exclude_none=True
                             )
                         ),
                     },
                     Group.USAGE.value: {},
                     Group.OTHER.value: {
-                        "identity": ABSOLUTE_METRIC_DATA_A.dict(exclude_none=True),
-                        "some_count": ABSOLUTE_METRIC_DATA_A.dict(exclude_none=True),
-                        "another_count": ABSOLUTE_METRIC_DATA_A.dict(exclude_none=True),
-                        "retained": DIFFERENCE_METRIC_DATA_WEEKLY_NEGATIVE_CONTROL.dict(
+                        "identity": ABSOLUTE_METRIC_DATA_A.model_dump(exclude_none=True),
+                        "some_count": ABSOLUTE_METRIC_DATA_A.model_dump(
                             exclude_none=True
+                        ),
+                        "another_count": ABSOLUTE_METRIC_DATA_A.model_dump(
+                            exclude_none=True
+                        ),
+                        "retained": (
+                            DIFFERENCE_METRIC_DATA_WEEKLY_NEGATIVE_CONTROL.model_dump(
+                                exclude_none=True
+                            )
                         ),
                     },
                 },
@@ -1017,17 +1059,19 @@ class JetstreamTestData:
                 "is_control": True,
                 "branch_data": {
                     Group.SEARCH.value: {
-                        "search_count": EMPTY_METRIC_DATA.dict(exclude_none=True),
+                        "search_count": EMPTY_METRIC_DATA.model_dump(exclude_none=True),
                     },
                     Group.USAGE.value: {},
                     Group.OTHER.value: {
-                        "identity": ABSOLUTE_METRIC_DATA_F_WITH_PERCENT.dict(
+                        "identity": ABSOLUTE_METRIC_DATA_F_WITH_PERCENT.model_dump(
                             exclude_none=True
                         ),
-                        "some_count": EMPTY_METRIC_DATA.dict(exclude_none=True),
-                        "another_count": EMPTY_METRIC_DATA.dict(exclude_none=True),
-                        "retained": DIFFERENCE_METRIC_DATA_OVERALL_NEUTRAL_VARIANT.dict(
-                            exclude_none=True
+                        "some_count": EMPTY_METRIC_DATA.model_dump(exclude_none=True),
+                        "another_count": EMPTY_METRIC_DATA.model_dump(exclude_none=True),
+                        "retained": (
+                            DIFFERENCE_METRIC_DATA_OVERALL_NEUTRAL_VARIANT.model_dump(
+                                exclude_none=True
+                            )
                         ),
                     },
                 },
@@ -1037,20 +1081,26 @@ class JetstreamTestData:
                 "branch_data": {
                     Group.SEARCH.value: {
                         "search_count": (
-                            DIFFERENCE_METRIC_DATA_OVERALL_POSITIVE_CONTROL.dict(
+                            DIFFERENCE_METRIC_DATA_OVERALL_POSITIVE_CONTROL.model_dump(
                                 exclude_none=True
                             )
                         ),
                     },
                     Group.USAGE.value: {},
                     Group.OTHER.value: {
-                        "identity": ABSOLUTE_METRIC_DATA_F_WITH_PERCENT.dict(
+                        "identity": ABSOLUTE_METRIC_DATA_F_WITH_PERCENT.model_dump(
                             exclude_none=True
                         ),
-                        "some_count": ABSOLUTE_METRIC_DATA_F.dict(exclude_none=True),
-                        "another_count": ABSOLUTE_METRIC_DATA_F.dict(exclude_none=True),
-                        "retained": DIFFERENCE_METRIC_DATA_OVERALL_NEGATIVE_CONTROL.dict(
+                        "some_count": ABSOLUTE_METRIC_DATA_F.model_dump(
                             exclude_none=True
+                        ),
+                        "another_count": ABSOLUTE_METRIC_DATA_F.model_dump(
+                            exclude_none=True
+                        ),
+                        "retained": (
+                            DIFFERENCE_METRIC_DATA_OVERALL_NEGATIVE_CONTROL.model_dump(
+                                exclude_none=True
+                            )
                         ),
                     },
                 },
@@ -1301,14 +1351,14 @@ class ZeroJetstreamTestData(JetstreamTestData):
 
                 data.append(
                     JetstreamDataPoint(
-                        **range_data.dict(exclude_none=True),
+                        **range_data.model_dump(exclude_none=True),
                         metric=primary_metric,
                         branch=branch,
                         statistic="binomial",
                         window_index="1",
                         segment=Segment.ALL,
                         analysis_basis=analysis_basis,
-                    ).dict(exclude_none=True)
+                    ).model_dump(exclude_none=True)
                 )
 
 


### PR DESCRIPTION
Because

- we upgraded schemas package to pydantic v2
- we also upgraded the pydantic dep in Experimenter to v2
- there are some deprecated functions from pydantic v1 with direct replacements in v2

This commit

- removes deprecated pydantic v1 functions from Jetstream client

Fixes #12218