### PR TITLE
chore(nimbus): change to correct monitoring url

### DIFF
--- a/experimenter/experimenter/nimbus-ui/src/lib/mocks.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/lib/mocks.tsx
@@ -981,7 +981,7 @@ export function mockSingleDirectoryExperiment(
     firefoxMaxVersion: MOCK_CONFIG.firefoxVersions![3]!
       .value as NimbusExperimentFirefoxVersionEnum,
     monitoringDashboardUrl:
-      "https://mozilla.cloud.looker.com/dashboards-next/216?Experiment=bug-1668861-pref-measure-set-to-default-adoption-impact-of-chang-release-81-83",
+      "https://mozilla.cloud.looker.com/dashboards/experimentation::experiment_enrollments?Experiment=bug-1668861-pref-measure-set-to-default-adoption-impact-of-chang-release-81-83",
     rolloutMonitoringDashboardUrl:
       "https://mozilla.cloud.looker.com/dashboards/operational_monitoring::experiment_slug",
     name: "Open-architected background installation",

--- a/experimenter/experimenter/settings.py
+++ b/experimenter/experimenter/settings.py
@@ -405,7 +405,7 @@ RECIPE_SLUG_MAX_LEN = 80
 # Monitoring
 MONITORING_URL = (
     # from_date and to_date format is YYYY-mm-dd
-    "https://mozilla.cloud.looker.com/dashboards-next/216?"
+    "https://mozilla.cloud.looker.com/dashboards/experimentation::experiment_enrollments?"
     "Experiment={slug}&Time+Range+[UTC]={from_date}+to+{to_date}"
 )
 ROLLOUT_MONITORING_URL = (


### PR DESCRIPTION
Because

- the current link to `/216` is not the one managed by the lookml we maintain
- this is confusing when making changes because they don't appear to get deployed
- changes to `/216` must be made in the Looker UI which is less sustainable

This commit

- changes the URL to the correct managed dashboard

Fixes #12252 