### PR TITLE
feat(nimbus): add tooltip with un-rounded result values

### DIFF
--- a/experimenter/experimenter/nimbus-ui/src/components/PageResults/ConfidenceInterval/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageResults/ConfidenceInterval/index.tsx
@@ -6,6 +6,7 @@
 // TODO: EXP-638 remove this ^
 
 import React from "react";
+import ReactTooltip from "react-tooltip";
 
 const MIN_BOUNDS_WIDTH = 22;
 
@@ -66,7 +67,8 @@ const ConfidenceInterval: React.FC<{
   range: number;
   significance: string;
   referenceBranch: string;
-}> = ({ upper, lower, range, significance, referenceBranch }) => {
+  tooltip?: string;
+}> = ({ upper, lower, range, significance, referenceBranch, tooltip }) => {
   const fullWidth = range * 2;
   const barWidth = ((upper - lower) / fullWidth) * 100;
   const leftPercent = (Math.abs(lower - range * -1) / fullWidth) * 100;
@@ -80,10 +82,18 @@ const ConfidenceInterval: React.FC<{
   );
   const line = renderLine(leftPercent, barWidth, significance);
 
+  const tooltipId = `${tooltip}_tooltip`;
+
   return (
     <div className="pr-5">
-      <div className="row w-100 float-right position-relative">{bounds}</div>
-
+      <div
+        className="row w-100 float-right position-relative"
+        data-tip
+        data-for={tooltipId}
+      >
+        {bounds}
+      </div>
+      <ReactTooltip id={tooltipId}>{tooltip}</ReactTooltip>
       <div
         className="row w-50 float-right mt-4"
         data-testid={`${significance}-block`}

--- a/experimenter/experimenter/nimbus-ui/src/components/PageResults/TableResults/index.test.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageResults/TableResults/index.test.tsx
@@ -79,6 +79,9 @@ describe("TableResults", () => {
     expect(screen.getAllByText("-45.5% to 51%", { exact: false })).toHaveLength(
       4,
     );
+    expect(
+      screen.getAllByText("-45.52103% to 51.049857%", { exact: false }),
+    ).toHaveLength(4);
     expect(screen.getByText("198")).toBeInTheDocument();
     expect(screen.getByText("45%")).toBeInTheDocument();
     expect(screen.getByText("200")).toBeInTheDocument();

--- a/experimenter/experimenter/nimbus-ui/src/components/PageResults/TableResultsWeekly/index.test.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageResults/TableResultsWeekly/index.test.tsx
@@ -62,6 +62,9 @@ describe("TableResultsWeekly", () => {
     expect(
       screen.getAllByText("2.4% to 8.4% (baseline)", { exact: false }),
     ).toHaveLength(2);
+    expect(
+      screen.getAllByText("2.435727% to 8.411464%", { exact: false }),
+    ).toHaveLength(2);
   });
 
   it("behaves as expected when clicked", () => {

--- a/experimenter/experimenter/nimbus-ui/src/components/PageResults/TableVisualizationRow/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageResults/TableVisualizationRow/index.tsx
@@ -40,7 +40,10 @@ const showSignificanceField = (
   // Attributes set to 'undefined' don't render in the DOM
   const className = significance ? `${significance}-significance` : undefined;
   const tooltipId = `${name}_tooltip`;
-  const intervalTooltipId = `${name}_${fullInterval.replaceAll(' ', '_')}_interval_tooltip`;
+  const intervalTooltipId = `${name}_${fullInterval.replaceAll(
+    " ",
+    "_",
+  )}_interval_tooltip`;
   switch (significance) {
     case SIGNIFICANCE.POSITIVE:
       significanceIcon = (
@@ -80,12 +83,10 @@ const showSignificanceField = (
           <TooltipWithMarkdown markdown={tooltip} {...{ tooltipId }} />
           {changeText}
           &nbsp;
-          <span data-tip data-for={intervalTooltipId} >
+          <span data-tip data-for={intervalTooltipId}>
             {intervalText}
           </span>
-          <ReactTooltip id={intervalTooltipId}>
-            {fullInterval}
-          </ReactTooltip>
+          <ReactTooltip id={intervalTooltipId}>{fullInterval}</ReactTooltip>
         </div>
         <ReactTooltip />
       </>
@@ -95,14 +96,11 @@ const showSignificanceField = (
     <>
       <span {...{ className }} data-testid={className}>
         {significanceIcon}&nbsp;
-        
-        <span data-tip data-for={intervalTooltipId} >
+        <span data-tip data-for={intervalTooltipId}>
           {interval}
         </span>
         &nbsp;
-        <ReactTooltip id={intervalTooltipId}>
-          {fullInterval}
-        </ReactTooltip>
+        <ReactTooltip id={intervalTooltipId}>{fullInterval}</ReactTooltip>
         {isControlBranch && BASELINE_TEXT}
       </span>
       <ReactTooltip />

--- a/experimenter/experimenter/nimbus-ui/src/components/PageResults/TableVisualizationRow/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageResults/TableVisualizationRow/index.tsx
@@ -97,11 +97,10 @@ const showSignificanceField = (
       <span {...{ className }} data-testid={className}>
         {significanceIcon}&nbsp;
         <span data-tip data-for={intervalTooltipId}>
-          {interval}
+          {interval} {isControlBranch && BASELINE_TEXT}
         </span>
         &nbsp;
         <ReactTooltip id={intervalTooltipId}>{fullInterval}</ReactTooltip>
-        {isControlBranch && BASELINE_TEXT}
       </span>
       <ReactTooltip />
     </>
@@ -126,13 +125,16 @@ const conversionChangeField = (
   significance: string | undefined,
   referenceBranch: string,
 ) => {
+  const tooltip = `${Math.round(lower * 100000000) / 1000000}% to ${
+    Math.round(upper * 100000000) / 1000000
+  }%`;
   lower = Math.round(lower * 1000) / 10;
   upper = Math.round(upper * 1000) / 10;
   range = Math.round(range * 1000) / 10;
   significance = significance || SIGNIFICANCE.NEUTRAL;
   return (
     <ConfidenceInterval
-      {...{ upper, lower, range, significance, referenceBranch }}
+      {...{ upper, lower, range, significance, referenceBranch, tooltip }}
     />
   );
 };
@@ -160,7 +162,8 @@ const countField = (
   const interval = `${lower ? lower.toFixed(2) : lower} to ${
     upper ? upper.toFixed(2) : upper
   }`;
-  const fullInterval = `${lower} to ${upper}`;
+  const fullInterval =
+    lower && upper ? `${lower.toFixed(6)} to ${upper.toFixed(6)}` : "";
   return showSignificanceField(
     significance,
     interval,
@@ -188,7 +191,12 @@ const percentField = (
   const interval = `${Math.round(lower * 1000) / 10}% to ${
     Math.round(upper * 1000) / 10
   }%`;
-  const fullInterval = `${lower * 100}% to ${upper * 100}%`;
+  const fullInterval =
+    lower && upper
+      ? `${Math.round(lower * 100000000) / 1000000}% to ${
+          Math.round(upper * 100000000) / 1000000
+        }%`
+      : "";
   return showSignificanceField(
     significance,
     interval,

--- a/experimenter/experimenter/nimbus-ui/src/components/PageResults/TableVisualizationRow/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/PageResults/TableVisualizationRow/index.tsx
@@ -27,6 +27,7 @@ const BASELINE_TEXT = "(baseline)";
 const showSignificanceField = (
   significance: string | undefined,
   interval: string,
+  fullInterval: string,
   name: string,
   tableLabel: string,
   tooltip: string,
@@ -39,6 +40,7 @@ const showSignificanceField = (
   // Attributes set to 'undefined' don't render in the DOM
   const className = significance ? `${significance}-significance` : undefined;
   const tooltipId = `${name}_tooltip`;
+  const intervalTooltipId = `${name}_${fullInterval.replaceAll(' ', '_')}_interval_tooltip`;
   switch (significance) {
     case SIGNIFICANCE.POSITIVE:
       significanceIcon = (
@@ -76,7 +78,14 @@ const showSignificanceField = (
           </span>
           &nbsp;
           <TooltipWithMarkdown markdown={tooltip} {...{ tooltipId }} />
-          {changeText} {intervalText}
+          {changeText}
+          &nbsp;
+          <span data-tip data-for={intervalTooltipId} >
+            {intervalText}
+          </span>
+          <ReactTooltip id={intervalTooltipId}>
+            {fullInterval}
+          </ReactTooltip>
         </div>
         <ReactTooltip />
       </>
@@ -85,7 +94,15 @@ const showSignificanceField = (
   return (
     <>
       <span {...{ className }} data-testid={className}>
-        {significanceIcon}&nbsp;{interval}&nbsp;
+        {significanceIcon}&nbsp;
+        
+        <span data-tip data-for={intervalTooltipId} >
+          {interval}
+        </span>
+        &nbsp;
+        <ReactTooltip id={intervalTooltipId}>
+          {fullInterval}
+        </ReactTooltip>
         {isControlBranch && BASELINE_TEXT}
       </span>
       <ReactTooltip />
@@ -145,9 +162,11 @@ const countField = (
   const interval = `${lower ? lower.toFixed(2) : lower} to ${
     upper ? upper.toFixed(2) : upper
   }`;
+  const fullInterval = `${lower} to ${upper}`;
   return showSignificanceField(
     significance,
     interval,
+    fullInterval,
     metricName,
     tableLabel,
     tooltip,
@@ -171,9 +190,11 @@ const percentField = (
   const interval = `${Math.round(lower * 1000) / 10}% to ${
     Math.round(upper * 1000) / 10
   }%`;
+  const fullInterval = `${lower * 100}% to ${upper * 100}%`;
   return showSignificanceField(
     significance,
     interval,
+    fullInterval,
     metricName,
     tableLabel,
     tooltip,
@@ -266,7 +287,7 @@ const TableVisualizationRow: React.FC<{
               lower!,
               upper!,
               significance,
-              metricName,
+              metricName || metricKey,
               tableLabel,
               tooltipText,
               isControlBranch,


### PR DESCRIPTION
Because

- rounded values can cause confusion when differences are small
- we have the un-rounded values in the database already

This commit

- shows the un-rounded values in a tooltip when hovering on the actual values

Fixes #12263 

/cc @danielkberry I believe we've talked about doing this, let me know what you think.

![Screenshot from 2025-03-03 17-23-42](https://github.com/user-attachments/assets/afee4a1f-0989-4c91-8a77-1af09e883f12)