### PR TITLE
feat(nimbus): more helpful message when observation period is too short

### DIFF
--- a/experimenter/experimenter/nimbus-ui/src/components/AppLayoutSidebarLaunched/index.test.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/AppLayoutSidebarLaunched/index.test.tsx
@@ -186,6 +186,52 @@ describe("AppLayoutSidebarLaunched", () => {
       );
     });
 
+    it("displays helpful message when observation period is too short", () => {
+      const expectedDate = "2023-01-01T00:00:00.000+0000";
+      render(
+        <Subject
+          status={NimbusExperimentStatusEnum.COMPLETE}
+          experiment={
+            mockExperimentQuery("my-special-slug/design", {
+              resultsExpectedDate: expectedDate,
+              computedEndDate: new Date().toISOString(),
+              enrollmentEndDate: new Date().toISOString(),
+            }).experiment
+          }
+        />,
+      );
+      expect(screen.queryByTestId("show-no-results")).toHaveTextContent(
+        "Experiment could not be analyzed:",
+      );
+
+      expect(
+        screen.queryByText(humanDate(expectedDate)),
+      ).not.toBeInTheDocument();
+    });
+
+    it("displays helpful observation too short message when enrollment never ended", () => {
+      const expectedDate = "2023-01-01T00:00:00.000+0000";
+      render(
+        <Subject
+          status={NimbusExperimentStatusEnum.COMPLETE}
+          experiment={
+            mockExperimentQuery("my-special-slug/design", {
+              resultsExpectedDate: expectedDate,
+              computedEndDate: new Date().toISOString(),
+              isEnrollmentPaused: false,
+            }).experiment
+          }
+        />,
+      );
+      expect(screen.queryByTestId("show-no-results")).toHaveTextContent(
+        "Experiment could not be analyzed:",
+      );
+
+      expect(
+        screen.queryByText(humanDate(expectedDate)),
+      ).not.toBeInTheDocument();
+    });
+
     it("when complete and has analysis results displays summary and results items", () => {
       const { experiment } = mockExperimentQuery("my-special-slug", {
         showResultsUrl: true,

--- a/experimenter/experimenter/nimbus-ui/src/components/AppLayoutSidebarLaunched/index.test.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/AppLayoutSidebarLaunched/index.test.tsx
@@ -203,6 +203,9 @@ describe("AppLayoutSidebarLaunched", () => {
       expect(screen.queryByTestId("show-no-results")).toHaveTextContent(
         "Experiment could not be analyzed:",
       );
+      expect(screen.queryByTestId("show-no-results")).toHaveTextContent(
+        "must last at least 1 week.",
+      );
 
       expect(
         screen.queryByText(humanDate(expectedDate)),
@@ -225,6 +228,9 @@ describe("AppLayoutSidebarLaunched", () => {
       );
       expect(screen.queryByTestId("show-no-results")).toHaveTextContent(
         "Experiment could not be analyzed:",
+      );
+      expect(screen.queryByTestId("show-no-results")).toHaveTextContent(
+        "must last at least 1 week.",
       );
 
       expect(

--- a/experimenter/experimenter/nimbus-ui/src/components/AppLayoutSidebarLaunched/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/AppLayoutSidebarLaunched/index.tsx
@@ -166,6 +166,20 @@ export const AppLayoutSidebarLaunched = ({
     </>
   );
 
+  // compute the observation period in days (or default to a value > 7)
+  const observationPeriodDays =
+    experiment.enrollmentEndDate && experiment.computedEndDate
+      ? Math.round(
+          (new Date(experiment.computedEndDate).getTime() -
+            new Date(experiment.enrollmentEndDate).getTime()) /
+            (1000 * 60 * 60 * 24),
+        )
+      : 8;
+
+  const observationTooShort =
+    status.complete &&
+    (observationPeriodDays < 7 || !!!experiment.isEnrollmentPaused);
+
   return (
     <Container fluid className="h-100vh" data-testid={testid}>
       <Row className="h-md-100">
@@ -233,6 +247,14 @@ export const AppLayoutSidebarLaunched = ({
                     </>
                   ) : analysis?.metadata?.external_config?.skip ? (
                     "Experiment analysis was skipped"
+                  ) : observationTooShort ? (
+                    <>
+                      Experiment could not be analyzed:{" "}
+                      <LinkExternal href="https://experimenter.info/configuring/#the-observation-window">
+                        observation period
+                      </LinkExternal>
+                      {" "}too short.
+                    </>
                   ) : (
                     <>
                       {experiment.isRollout

--- a/experimenter/experimenter/nimbus-ui/src/components/AppLayoutSidebarLaunched/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/AppLayoutSidebarLaunched/index.tsx
@@ -253,7 +253,7 @@ export const AppLayoutSidebarLaunched = ({
                       <LinkExternal href="https://experimenter.info/configuring/#the-observation-window">
                         observation period
                       </LinkExternal>
-                      {" "}too short.
+                      {" "}must last at least 1 week.
                     </>
                   ) : (
                     <>

--- a/experimenter/experimenter/nimbus-ui/src/components/AppLayoutSidebarLaunched/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/AppLayoutSidebarLaunched/index.tsx
@@ -252,8 +252,8 @@ export const AppLayoutSidebarLaunched = ({
                       Experiment could not be analyzed:{" "}
                       <LinkExternal href="https://experimenter.info/configuring/#the-observation-window">
                         observation period
-                      </LinkExternal>
-                      {" "}must last at least 1 week.
+                      </LinkExternal>{" "}
+                      must last at least 1 week.
                     </>
                   ) : (
                     <>


### PR DESCRIPTION
Because

- we display a message indicating that results are expected even when we know the observation period is too short for results to be computed

This commit

- displays a more helpful message when the observation period is too short
- links to the docs on observation window https://experimenter.info/configuring/#the-observation-window

Fixes #11901 

![image](https://github.com/user-attachments/assets/504ce21c-4217-4135-a90b-883fb31806ff)
