### PR TITLE
bug(project): find bash via env in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-SHELL = /bin/bash
+SHELL = /usr/bin/env bash
 
 WAIT_FOR_DB = /experimenter/bin/wait-for-it.sh -t 30 db:5432 &&
 WAIT_FOR_RUNSERVER = /experimenter/bin/wait-for-it.sh -t 30 localhost:7001 &&


### PR DESCRIPTION
Because:

- bash isn't at /bin/bash on all systems (NixOS, some BSDs)

This commit:

- uses env (which is a part of POSIX) to invoke bash

Fixes #12278