### PR TITLE
feat(schemas): Add coenrollment fields to Desktop and SDK manifest schemas

### DIFF
--- a/schemas/index.d.ts
+++ b/schemas/index.d.ts
@@ -554,6 +554,10 @@ export interface DesktopFeature {
     [k: string]: DesktopFeatureVariable;
   };
   schema?: NimbusFeatureSchema;
+  /**
+   * If true, clients can enroll in multiple experiments and rollouts that use this feature.
+   */
+  allowCoenrollment?: boolean;
 }
 /**
  * A feature variable.
@@ -646,6 +650,10 @@ export interface SdkFeature {
   variables: {
     [k: string]: SdkFeatureVariable;
   };
+  /**
+   * If true, clients can enroll in multiple experiments and rollouts that use this feature.
+   */
+  "allow-coenrollment"?: boolean;
 }
 /**
  * A feature variable.

--- a/schemas/mozilla_nimbus_schemas/experimenter_apis/experiments/feature_manifests.py
+++ b/schemas/mozilla_nimbus_schemas/experimenter_apis/experiments/feature_manifests.py
@@ -298,6 +298,15 @@ class SdkFeature(BaseFeature):
         description="The variables that this feature can set."
     )
 
+    allow_coenrollment: bool = Field(
+        alias="allow-coenrollment",
+        description=(
+            "If true, clients can enroll in multiple experiments and rollouts that use "
+            "this feature."
+        ),
+        default=False,
+    )
+
 
 class DesktopFeature(BaseFeature):
     """A feature."""
@@ -334,6 +343,15 @@ class DesktopFeature(BaseFeature):
         alias="schema",
         description="An optional JSON schema that describes the feature variables.",
         default=None,
+    )
+
+    allow_coenrollment: bool = Field(
+        alias="allowCoenrollment",
+        description=(
+            "If true, clients can enroll in multiple experiments and rollouts that use "
+            "this feature."
+        ),
+        default=False,
     )
 
 

--- a/schemas/schemas/DesktopFeature.schema.json
+++ b/schemas/schemas/DesktopFeature.schema.json
@@ -42,6 +42,10 @@
     "schema": {
       "$ref": "#/$defs/NimbusFeatureSchema",
       "description": "An optional JSON schema that describes the feature variables."
+    },
+    "allowCoenrollment": {
+      "description": "If true, clients can enroll in multiple experiments and rollouts that use this feature.",
+      "type": "boolean"
     }
   },
   "required": [

--- a/schemas/schemas/DesktopFeatureManifest.schema.json
+++ b/schemas/schemas/DesktopFeatureManifest.schema.json
@@ -62,6 +62,10 @@
         "schema": {
           "$ref": "#/$defs/NimbusFeatureSchema",
           "description": "An optional JSON schema that describes the feature variables."
+        },
+        "allowCoenrollment": {
+          "description": "If true, clients can enroll in multiple experiments and rollouts that use this feature.",
+          "type": "boolean"
         }
       },
       "required": [

--- a/schemas/schemas/SdkFeatureManifest.schema.json
+++ b/schemas/schemas/SdkFeatureManifest.schema.json
@@ -44,6 +44,10 @@
           },
           "description": "The variables that this feature can set.",
           "type": "object"
+        },
+        "allow-coenrollment": {
+          "description": "If true, clients can enroll in multiple experiments and rollouts that use this feature.",
+          "type": "boolean"
         }
       },
       "required": [


### PR DESCRIPTION
Because:

- the Nimbus SDK already supports co-enrollment; and
- Firefox Desktop is gaining co-enrollment support

This commit:

- adds the `allow-coenrollment` field to the SDK manifest;
- adds the `allowCoenrollment` field to the Desktop manifest;

Fixes #12279