### PR TITLE
fix(tests): Fix archive integration test.

### DIFF
--- a/experimenter/tests/integration/nimbus/pages/experimenter/summary.py
+++ b/experimenter/tests/integration/nimbus/pages/experimenter/summary.py
@@ -102,8 +102,8 @@ class SummaryPage(ExperimenterBase):
     )
 
     def wait_for_archive_label_visible(self):
-        self.wait.until(
-            EC.presence_of_all_elements_located(self._archive_label_locator),
+        self.wait_with_refresh(
+            self._archive_label_locator,
             message="Summary Page: could not find archive label",
         )
 


### PR DESCRIPTION
Because

- Our archive integration test is failing due to the page not refreshing soon enough during the test.

This commit

- Changes how the tests wait for the archive label by refreshing the page instead of just waiting for the page to update.

Fixes #12286 