### PR TITLE
feat(nimbus): End experiment and End enrollment workflow

### DIFF
--- a/experimenter/experimenter/nimbus_ui_new/constants.py
+++ b/experimenter/experimenter/nimbus_ui_new/constants.py
@@ -61,6 +61,12 @@ Optional - We believe this outcome will <describe impact> on <core metric>
         ),
     }
 
+    REVIEW_REQUEST_MESSAGES = {
+        "END_EXPERIMENT": "end this experiment",
+        "END_ENROLLMENT": "end enrollment for this experiment",
+        "LAUNCH_EXPERIMENT": "launch this experiment",
+    }
+
     FIELD_PAGE_MAP = {
         "overview": [
             "projects",

--- a/experimenter/experimenter/nimbus_ui_new/static/js/review_controls.js
+++ b/experimenter/experimenter/nimbus_ui_new/static/js/review_controls.js
@@ -17,7 +17,7 @@ function initializeRejectApproveListeners() {
   const rejectButton = document.getElementById("reject-button");
   const reviewControls = document.getElementById("review-controls");
   const rejectFormContainer = document.getElementById("reject-form-container");
-  const cancelReject = document.getElementById("cancel-reject");
+  const cancelButton = document.getElementById("cancel");
 
   if (rejectButton) {
     rejectButton.addEventListener("click", () => {
@@ -26,8 +26,8 @@ function initializeRejectApproveListeners() {
     });
   }
 
-  if (cancelReject) {
-    cancelReject.addEventListener("click", () => {
+  if (cancelButton) {
+    cancelButton.addEventListener("click", () => {
       rejectFormContainer.classList.add("d-none");
       reviewControls.classList.remove("d-none");
     });

--- a/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/approval_rejection_controls.html
+++ b/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/approval_rejection_controls.html
@@ -1,0 +1,56 @@
+{% load nimbus_extras %}
+
+{% if experiment.should_show_timeout_message %}
+  <div class="alert alert-danger">
+    <p>
+      <span role="img" aria-label="red X emoji">❌</span>
+      Remote Settings request has timed out, please go through the approval flow to {{ experiment.review_messages }} again.
+    </p>
+  </div>
+{% endif %}
+<div id="review-controls">
+  <div class="alert alert-primary">
+    <p>
+      <strong>{{ experiment.latest_review_requested_by|add:" requested to" }} {{ experiment.review_messages }}</strong>
+    </p>
+    <button type="button"
+            class="btn btn-success"
+            hx-post="{% url approval_url slug=experiment.slug %}"
+            hx-select="#content"
+            hx-target="#content"
+            hx-swap="outerHTML">Approve and {{ action_type|title |remove_underscores }}</button>
+    <button type="button" class="btn btn-danger" id="reject-button">Reject</button>
+  </div>
+  <div class="alert alert-primary">
+    <button type="button"
+            class="btn btn-secondary"
+            hx-post="{% url cancel_url slug=experiment.slug %}"
+            hx-select="#content"
+            hx-target="#content"
+            hx-swap="outerHTML"
+            hx-vals='{"cancel_message": "cancelled the review request to {{ experiment.review_messages }}",  "action_type": "{{ action_type }}"}}'>
+      Cancel Review
+    </button>
+  </div>
+</div>
+<!-- Rejection Form -->
+<div id="reject-form-container" class="d-none alert alert-warning">
+  <label for="changelog_message">
+    <strong>You are rejecting the request to {{ experiment.review_messages }}. Please provide a reason:</strong>
+  </label>
+  <textarea id="changelog_message"
+            name="changelog_message"
+            class="form-control"
+            rows="4"
+            required></textarea>
+  <input type="hidden" name="action_type" value="{{ action_type }}">
+  <!-- Hidden input field -->
+  <button type="submit"
+          class="btn btn-danger mt-2"
+          hx-post="{% url reject_url slug=experiment.slug %}"
+          hx-select="#content"
+          hx-target="#content"
+          hx-swap="outerHTML"
+          hx-include="[name='changelog_message'], [name='action_type']">Submit Rejection</button>
+  <button type="button" class="btn btn-secondary mt-2" id="cancel-reject">Cancel</button>
+</div>

--- a/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/approval_rejection_controls.html
+++ b/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/approval_rejection_controls.html
@@ -18,17 +18,17 @@
             hx-post="{% url approval_url slug=experiment.slug %}"
             hx-select="#content"
             hx-target="#content"
-            hx-swap="outerHTML">Approve and {{ action_type|title |remove_underscores }}</button>
+            hx-swap="outerHTML">Approve and {{ action_label }}</button>
     <button type="button" class="btn btn-danger" id="reject-button">Reject</button>
   </div>
   <div class="alert alert-primary">
     <button type="button"
             class="btn btn-secondary"
-            hx-post="{% url cancel_url slug=experiment.slug %}"
+            hx-post="{% url cancel_reject_url slug=experiment.slug %}"
             hx-select="#content"
             hx-target="#content"
             hx-swap="outerHTML"
-            hx-vals='{"cancel_message": "cancelled the review request to {{ experiment.review_messages }}",  "action_type": "{{ action_type }}"}}'>
+            hx-vals='{"cancel_message": "cancelled the review request to {{ experiment.review_messages }}"}'>
       Cancel Review
     </button>
   </div>
@@ -43,14 +43,12 @@
             class="form-control"
             rows="4"
             required></textarea>
-  <input type="hidden" name="action_type" value="{{ action_type }}">
-  <!-- Hidden input field -->
   <button type="submit"
           class="btn btn-danger mt-2"
-          hx-post="{% url reject_url slug=experiment.slug %}"
+          hx-post="{% url cancel_reject_url slug=experiment.slug %}"
           hx-select="#content"
           hx-target="#content"
           hx-swap="outerHTML"
-          hx-include="[name='changelog_message'], [name='action_type']">Submit Rejection</button>
-  <button type="button" class="btn btn-secondary mt-2" id="cancel-reject">Cancel</button>
+          hx-include="[name='changelog_message']">Submit Rejection</button>
+  <button type="button" class="btn btn-secondary mt-2" id="cancel">Cancel</button>
 </div>

--- a/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/launch_controls.html
+++ b/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/launch_controls.html
@@ -117,65 +117,48 @@
         {% endif %}
       </div>
       <!-- Review Mode Controls -->
-    {% elif experiment.is_review %}
-      {% if experiment.should_show_timeout_message %}
-        <div class="alert alert-danger" role="alert">
-          <p>
-            <span role="img" aria-label="red X emoji">❌</span>
-            Remote Settings request has timed out, please go through the approval flow to launch this experiment again.
-          </p>
-        </div>
-      {% endif %}
-      <div id="review-controls" class="alert alert-primary">
-        <p>
-          <strong>{{ experiment.changes.latest_review_request.changed_by.email }}</strong> requested to Launch this experiment.
-        </p>
-        <button type="button"
-                class="btn btn-success"
-                hx-post="{% url 'nimbus-new-review-to-approve' slug=experiment.slug %}"
-                hx-select="#content"
-                hx-target="#content"
-                hx-swap="outerHTML">Approve and Launch Experiment</button>
-        <button type="button" class="btn btn-danger" id="reject-button">Reject</button>
-      </div>
-      <!-- Rejection Form -->
-      <div id="reject-form-container" class="d-none alert alert-warning">
-        <label for="changelog_message">
-          <strong>You are rejecting the request to launch this experiment.</strong> Please add some comments:
-        </label>
-        <textarea id="changelog_message"
-                  name="changelog_message"
-                  class="form-control"
-                  rows="4"
-                  required></textarea>
-        <button type="submit"
-                class="btn btn-danger mt-2"
-                hx-post="{% url 'nimbus-new-review-to-reject' slug=experiment.slug %}"
-                hx-select="#content"
-                hx-target="#content"
-                hx-swap="outerHTML"
-                hx-include="#changelog_message">Submit</button>
-        <button type="button" class="btn btn-secondary mt-2" id="cancel-reject">Cancel</button>
-      </div>
-      <div class="alert alert-warning">
-        <p>The experiment is currently under review. If you wish to cancel the review, click the button below:</p>
-        <button type="button"
-                class="btn btn-primary"
-                hx-post="{% url 'nimbus-new-review-to-draft' slug=experiment.slug %}"
-                hx-select="#content"
-                hx-target="#content"
-                hx-swap="outerHTML">Cancel Review</button>
-      </div>
     {% elif experiment|should_show_remote_settings_pending:user %}
-      <div class="alert alert-primary">
+      <div class="alert alert-danger" role="alert">
         <p>
-          <strong>Action required:</strong> Please review this change in Remote Settings to launch this experiment.
+          <strong>Action required:</strong>
+          Please review this change in Remote Settings to {{ experiment.remote_settings_pending_message }}.
         </p>
         <a href="{{ experiment.review_url }}"
            class="btn btn-primary"
            target="_blank"
            rel="noopener noreferrer">Open Remote Settings</a>
       </div>
+    {% elif experiment.is_review %}
+      {% include "nimbus_experiments/approval_rejection_controls.html" with approval_url="nimbus-new-review-to-approve" reject_url="nimbus-new-review-to-reject" cancel_url="nimbus-new-review-to-draft" experiment=experiment action_type="launch_experiment" %}
+
+    {% elif experiment.is_enrolling or experiment.is_observation %}
+      {% if experiment.is_enrollment_pause_requested %}
+        {% include "nimbus_experiments/approval_rejection_controls.html" with approval_url="nimbus-new-approve-end-enrollment" reject_url="nimbus-new-cancel-reject-end" cancel_url="nimbus-new-cancel-reject-end" experiment=experiment action_type="end_enrollment" %}
+
+      {% elif experiment.is_end_experiment_requested %}
+        {% include "nimbus_experiments/approval_rejection_controls.html" with approval_url="nimbus-new-approve-end-experiment" reject_url="nimbus-new-cancel-reject-end" cancel_url="nimbus-new-cancel-reject-end" experiment=experiment action_type="end_experiment" %}
+
+      {% elif experiment.should_show_end_enrollment or experiment.should_show_end_experiment %}
+        <div id="default-controls" class="alert alert-primary mt-3">
+          <h5 class="mb-3 ms-2">Actions</h5>
+          {% if experiment.should_show_end_enrollment %}
+            <button type="button"
+                    hx-post="{% url 'nimbus-new-live-to-end-enrollment' slug=experiment.slug %}"
+                    hx-select="#content"
+                    hx-target="#content"
+                    hx-swap="outerHTML"
+                    class="btn btn-primary m-2">End Enrollment</button>
+          {% endif %}
+          {% if experiment.should_show_end_experiment %}
+            <button type="button"
+                    hx-post="{% url 'nimbus-new-live-to-complete' slug=experiment.slug %}"
+                    hx-select="#content"
+                    hx-target="#content"
+                    hx-swap="outerHTML"
+                    class="btn btn-primary">End Experiment</button>
+          {% endif %}
+        </div>
+      {% endif %}
     {% endif %}
   </form>
 </div>

--- a/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/launch_controls.html
+++ b/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/launch_controls.html
@@ -129,14 +129,14 @@
            rel="noopener noreferrer">Open Remote Settings</a>
       </div>
     {% elif experiment.is_review %}
-      {% include "nimbus_experiments/approval_rejection_controls.html" with approval_url="nimbus-new-review-to-approve" reject_url="nimbus-new-review-to-reject" cancel_url="nimbus-new-review-to-draft" experiment=experiment action_type="launch_experiment" %}
+      {% include "nimbus_experiments/approval_rejection_controls.html" with action_label="Launch Experiment" approval_url="nimbus-new-review-to-approve" cancel_reject_url="nimbus-new-review-to-draft" experiment=experiment %}
 
     {% elif experiment.is_enrolling or experiment.is_observation %}
       {% if experiment.is_enrollment_pause_requested %}
-        {% include "nimbus_experiments/approval_rejection_controls.html" with approval_url="nimbus-new-approve-end-enrollment" reject_url="nimbus-new-cancel-reject-end" cancel_url="nimbus-new-cancel-reject-end" experiment=experiment action_type="end_enrollment" %}
+        {% include "nimbus_experiments/approval_rejection_controls.html" with action_label="End Enrollment" approval_url="nimbus-new-approve-end-enrollment" cancel_reject_url="nimbus-new-cancel-end-enrollment" experiment=experiment %}
 
       {% elif experiment.is_end_experiment_requested %}
-        {% include "nimbus_experiments/approval_rejection_controls.html" with approval_url="nimbus-new-approve-end-experiment" reject_url="nimbus-new-cancel-reject-end" cancel_url="nimbus-new-cancel-reject-end" experiment=experiment action_type="end_experiment" %}
+        {% include "nimbus_experiments/approval_rejection_controls.html" with action_label="End Experiment" approval_url="nimbus-new-approve-end-experiment" cancel_reject_url="nimbus-new-cancel-end-experiment" experiment=experiment %}
 
       {% elif experiment.should_show_end_enrollment or experiment.should_show_end_experiment %}
         <div id="default-controls" class="alert alert-primary mt-3">

--- a/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/table.html
+++ b/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/table.html
@@ -96,7 +96,7 @@
                   <i class="fa-solid fa-eye text-muted fa-sm"></i>
                   <span class="text-muted fw-lighter">Review</span>
                 </p>
-              {% elif experiment.is_enrollment %}
+              {% elif experiment.is_enrolling %}
                 <p class="pt-1">
                   <i class="fa-regular fa-circle-play text-muted fa-sm"></i>
                   <span class="text-muted fw-lighter">Live (Enrolling)</span>

--- a/experimenter/experimenter/nimbus_ui_new/tests/test_forms.py
+++ b/experimenter/experimenter/nimbus_ui_new/tests/test_forms.py
@@ -26,11 +26,16 @@ from experimenter.kinto.tasks import (
 )
 from experimenter.nimbus_ui_new.constants import NimbusUIConstants
 from experimenter.nimbus_ui_new.forms import (
+    ApproveEndEnrollmentForm,
+    ApproveEndExperimentForm,
     AudienceForm,
+    CancelRejectEndForm,
     DocumentationLinkCreateForm,
     DocumentationLinkDeleteForm,
     DraftToPreviewForm,
     DraftToReviewForm,
+    LiveToCompleteForm,
+    LiveToEndEnrollmentForm,
     MetricsForm,
     NimbusBranchCreateForm,
     NimbusBranchDeleteForm,
@@ -735,6 +740,216 @@ class TestLaunchForms(RequestFormTestCase):
             f"{self.user} rejected the review with reason: Needs more work.",
             changelog.message,
         )
+
+    def test_live_to_end_enrollment_form(self):
+        self.experiment.status = NimbusExperiment.Status.LIVE
+        self.experiment.status_next = None
+        self.experiment.publish_status = NimbusExperiment.PublishStatus.IDLE
+        self.experiment.is_paused = False
+        self.experiment.save()
+
+        form = LiveToEndEnrollmentForm(
+            data={}, instance=self.experiment, request=self.request
+        )
+        self.assertTrue(form.is_valid(), form.errors)
+
+        experiment = form.save()
+        self.assertEqual(experiment.status, NimbusExperiment.Status.LIVE)
+        self.assertEqual(experiment.status_next, NimbusExperiment.Status.LIVE)
+        self.assertEqual(experiment.publish_status, NimbusExperiment.PublishStatus.REVIEW)
+        self.assertTrue(experiment.is_paused)
+
+        changelog = experiment.changes.latest("changed_on")
+        self.assertEqual(changelog.changed_by, self.user)
+        self.assertIn("requested review to end enrollment", changelog.message)
+
+    def test_approve_end_enrollment_form(self):
+        self.experiment.status = NimbusExperiment.Status.LIVE
+        self.experiment.status_next = NimbusExperiment.Status.LIVE
+        self.experiment.publish_status = NimbusExperiment.PublishStatus.REVIEW
+        self.experiment.is_paused = True
+        self.experiment.save()
+
+        form = ApproveEndEnrollmentForm(
+            data={}, instance=self.experiment, request=self.request
+        )
+        self.assertTrue(form.is_valid(), form.errors)
+
+        experiment = form.save()
+        self.assertEqual(experiment.status, NimbusExperiment.Status.LIVE)
+        self.assertEqual(experiment.status_next, NimbusExperiment.Status.LIVE)
+        self.assertEqual(
+            experiment.publish_status, NimbusExperiment.PublishStatus.APPROVED
+        )
+        self.assertTrue(experiment.is_paused)
+
+        changelog = experiment.changes.latest("changed_on")
+        self.assertEqual(changelog.changed_by, self.user)
+        self.assertIn("approved the end enrollment request", changelog.message)
+        self.mock_push_task.assert_called_once_with(
+            countdown=5, args=[experiment.kinto_collection]
+        )
+
+    def test_live_to_complete_form(self):
+        self.experiment.status = NimbusExperiment.Status.LIVE
+        self.experiment.status_next = None
+        self.experiment.publish_status = NimbusExperiment.PublishStatus.IDLE
+        self.experiment.is_paused = False
+        self.experiment.save()
+
+        form = LiveToCompleteForm(data={}, instance=self.experiment, request=self.request)
+        self.assertTrue(form.is_valid(), form.errors)
+
+        experiment = form.save()
+        self.assertEqual(experiment.status, NimbusExperiment.Status.LIVE)
+        self.assertEqual(experiment.status_next, NimbusExperiment.Status.COMPLETE)
+        self.assertEqual(experiment.publish_status, NimbusExperiment.PublishStatus.REVIEW)
+        self.assertTrue(experiment.is_paused)
+
+        changelog = experiment.changes.latest("changed_on")
+        self.assertEqual(changelog.changed_by, self.user)
+        self.assertIn("requested review to end experiment", changelog.message)
+
+    def test_approve_end_experiment_form(self):
+        self.experiment.status = NimbusExperiment.Status.LIVE
+        self.experiment.status_next = NimbusExperiment.Status.COMPLETE
+        self.experiment.publish_status = NimbusExperiment.PublishStatus.REVIEW
+        self.experiment.is_paused = True
+        self.experiment.save()
+
+        form = ApproveEndExperimentForm(
+            data={}, instance=self.experiment, request=self.request
+        )
+        self.assertTrue(form.is_valid(), form.errors)
+
+        experiment = form.save()
+        self.assertEqual(experiment.status, NimbusExperiment.Status.LIVE)
+        self.assertEqual(experiment.status_next, NimbusExperiment.Status.COMPLETE)
+        self.assertEqual(
+            experiment.publish_status, NimbusExperiment.PublishStatus.APPROVED
+        )
+        self.assertTrue(experiment.is_paused)
+
+        changelog = experiment.changes.latest("changed_on")
+        self.assertEqual(changelog.changed_by, self.user)
+        self.assertIn("approved the end experiment request", changelog.message)
+        self.mock_push_task.assert_called_once_with(
+            countdown=5, args=[experiment.kinto_collection]
+        )
+
+    def test_reject_end_enrollment_request(self):
+        self.experiment.status = NimbusExperiment.Status.LIVE
+        self.experiment.status_next = NimbusExperiment.Status.LIVE
+        self.experiment.publish_status = NimbusExperiment.PublishStatus.REVIEW
+        self.experiment.is_paused = True
+        self.experiment.save()
+
+        form = CancelRejectEndForm(
+            data={
+                "changelog_message": "Enrollment should continue.",
+                "action_type": "end_enrollment",
+            },
+            instance=self.experiment,
+            request=self.request,
+        )
+        self.assertTrue(form.is_valid(), form.errors)
+
+        experiment = form.save()
+        self.assertEqual(experiment.status, NimbusExperiment.Status.LIVE)
+        self.assertEqual(experiment.status_next, None)
+        self.assertEqual(experiment.publish_status, NimbusExperiment.PublishStatus.IDLE)
+        self.assertFalse(experiment.is_paused)
+
+        changelog = experiment.changes.latest("changed_on")
+        self.assertEqual(changelog.changed_by, self.user)
+        self.assertIn(
+            "rejected the review with reason: Enrollment should continue.",
+            changelog.message,
+        )
+
+    def test_cancel_end_enrollment_request(self):
+        self.experiment.status = NimbusExperiment.Status.LIVE
+        self.experiment.status_next = NimbusExperiment.Status.LIVE
+        self.experiment.publish_status = NimbusExperiment.PublishStatus.REVIEW
+        self.experiment.is_paused = True
+        self.experiment.save()
+
+        form = CancelRejectEndForm(
+            data={
+                "cancel_message": "Cancelled end enrollment request.",
+                "action_type": "end_enrollment",
+            },
+            instance=self.experiment,
+            request=self.request,
+        )
+        self.assertTrue(form.is_valid(), form.errors)
+
+        experiment = form.save()
+        self.assertEqual(experiment.status, NimbusExperiment.Status.LIVE)
+        self.assertEqual(experiment.status_next, None)
+        self.assertEqual(experiment.publish_status, NimbusExperiment.PublishStatus.IDLE)
+        self.assertFalse(experiment.is_paused)
+
+        changelog = experiment.changes.latest("changed_on")
+        self.assertEqual(changelog.changed_by, self.user)
+        self.assertIn("Cancelled end enrollment request.", changelog.message)
+
+    def test_reject_end_experiment_request(self):
+        self.experiment.status = NimbusExperiment.Status.LIVE
+        self.experiment.status_next = NimbusExperiment.Status.COMPLETE
+        self.experiment.publish_status = NimbusExperiment.PublishStatus.REVIEW
+        self.experiment.is_paused = True
+        self.experiment.save()
+
+        form = CancelRejectEndForm(
+            data={
+                "changelog_message": "Experiment should continue.",
+                "action_type": "end_experiment",
+            },
+            instance=self.experiment,
+            request=self.request,
+        )
+        self.assertTrue(form.is_valid(), form.errors)
+
+        experiment = form.save()
+        self.assertEqual(experiment.status, NimbusExperiment.Status.LIVE)
+        self.assertEqual(experiment.status_next, None)
+        self.assertEqual(experiment.publish_status, NimbusExperiment.PublishStatus.IDLE)
+        self.assertFalse(experiment.is_paused)
+
+        changelog = experiment.changes.latest("changed_on")
+        self.assertEqual(changelog.changed_by, self.user)
+        self.assertIn(
+            "rejected the review with reason: Experiment should continue.",
+            changelog.message,
+        )
+
+    def test_cancel_end_experiment_request(self):
+        self.experiment.status = NimbusExperiment.Status.LIVE
+        self.experiment.status_next = NimbusExperiment.Status.COMPLETE
+        self.experiment.publish_status = NimbusExperiment.PublishStatus.REVIEW
+        self.experiment.is_paused = True
+        self.experiment.save()
+
+        form = CancelRejectEndForm(
+            data={
+                "cancel_message": "Cancelled end experiment request.",
+                "action_type": "end_experiment",
+            },
+            instance=self.experiment,
+            request=self.request,
+        )
+        self.assertTrue(form.is_valid(), form.errors)
+
+        experiment = form.save()
+        self.assertEqual(experiment.status, NimbusExperiment.Status.LIVE)
+        self.assertEqual(experiment.status_next, None)
+        self.assertEqual(experiment.publish_status, NimbusExperiment.PublishStatus.IDLE)
+        self.assertFalse(experiment.is_paused)
+
+        changelog = experiment.changes.latest("changed_on")
+        self.assertEqual(changelog.changed_by, self.user)
+        self.assertIn("Cancelled end experiment request.", changelog.message)
 
 
 class TestOverviewForm(RequestFormTestCase):

--- a/experimenter/experimenter/nimbus_ui_new/urls.py
+++ b/experimenter/experimenter/nimbus_ui_new/urls.py
@@ -10,7 +10,6 @@ from experimenter.nimbus_ui_new.views import (
     BranchesUpdateView,
     CancelEndEnrollmentView,
     CancelEndExperimentView,
-    CancelRejectEndView,
     DocumentationLinkCreateView,
     DocumentationLinkDeleteView,
     DraftToPreviewView,
@@ -30,7 +29,6 @@ from experimenter.nimbus_ui_new.views import (
     QAStatusUpdateView,
     ReviewToApproveView,
     ReviewToDraftView,
-    ReviewToRejectView,
     SignoffUpdateView,
     SubscribeView,
     TakeawaysUpdateView,
@@ -181,11 +179,6 @@ urlpatterns = [
         name="nimbus-new-review-to-approve",
     ),
     re_path(
-        r"^(?P<slug>[\w-]+)/review-to-reject/$",
-        ReviewToRejectView.as_view(),
-        name="nimbus-new-review-to-reject",
-    ),
-    re_path(
         r"^(?P<slug>[\w-]+)/live-to-end-enrollment/$",
         LiveToEndEnrollmentView.as_view(),
         name="nimbus-new-live-to-end-enrollment",
@@ -206,8 +199,13 @@ urlpatterns = [
         name="nimbus-new-approve-end-experiment",
     ),
     re_path(
+        r"^(?P<slug>[\w-]+)/reject-end-enrollment/$",
+        CancelEndEnrollmentView.as_view(),
+        name="nimbus-new-cancel-end-enrollment",
+    ),
+    re_path(
         r"^(?P<slug>[\w-]+)/reject-end-experiment/$",
-        CancelRejectEndView.as_view(),
-        name="nimbus-new-cancel-reject-end",
+        CancelEndExperimentView.as_view(),
+        name="nimbus-new-cancel-end-experiment",
     ),
 ]

--- a/experimenter/experimenter/nimbus_ui_new/urls.py
+++ b/experimenter/experimenter/nimbus_ui_new/urls.py
@@ -1,15 +1,22 @@
 from django.urls import re_path
 
 from experimenter.nimbus_ui_new.views import (
+    ApproveEndEnrollmentView,
+    ApproveEndExperimentView,
     AudienceUpdateView,
     BranchCreateView,
     BranchDeleteView,
     BranchesPartialUpdateView,
     BranchesUpdateView,
+    CancelEndEnrollmentView,
+    CancelEndExperimentView,
+    CancelRejectEndView,
     DocumentationLinkCreateView,
     DocumentationLinkDeleteView,
     DraftToPreviewView,
     DraftToReviewView,
+    LiveToCompleteView,
+    LiveToEndEnrollmentView,
     MetricsUpdateView,
     NimbusChangeLogsView,
     NimbusExperimentDetailView,
@@ -177,5 +184,30 @@ urlpatterns = [
         r"^(?P<slug>[\w-]+)/review-to-reject/$",
         ReviewToRejectView.as_view(),
         name="nimbus-new-review-to-reject",
+    ),
+    re_path(
+        r"^(?P<slug>[\w-]+)/live-to-end-enrollment/$",
+        LiveToEndEnrollmentView.as_view(),
+        name="nimbus-new-live-to-end-enrollment",
+    ),
+    re_path(
+        r"^(?P<slug>[\w-]+)/live-to-complete/$",
+        LiveToCompleteView.as_view(),
+        name="nimbus-new-live-to-complete",
+    ),
+    re_path(
+        r"^(?P<slug>[\w-]+)/approve-end-enrollment/$",
+        ApproveEndEnrollmentView.as_view(),
+        name="nimbus-new-approve-end-enrollment",
+    ),
+    re_path(
+        r"^(?P<slug>[\w-]+)/approve-end-experiment/$",
+        ApproveEndExperimentView.as_view(),
+        name="nimbus-new-approve-end-experiment",
+    ),
+    re_path(
+        r"^(?P<slug>[\w-]+)/reject-end-experiment/$",
+        CancelRejectEndView.as_view(),
+        name="nimbus-new-cancel-reject-end",
     ),
 ]

--- a/experimenter/experimenter/nimbus_ui_new/views.py
+++ b/experimenter/experimenter/nimbus_ui_new/views.py
@@ -21,7 +21,8 @@ from experimenter.nimbus_ui_new.forms import (
     ApproveEndEnrollmentForm,
     ApproveEndExperimentForm,
     AudienceForm,
-    CancelRejectEndForm,
+    CancelEndEnrollmentForm,
+    CancelEndExperimentForm,
     DocumentationLinkCreateForm,
     DocumentationLinkDeleteForm,
     DraftToPreviewForm,
@@ -41,7 +42,6 @@ from experimenter.nimbus_ui_new.forms import (
     QAStatusForm,
     ReviewToApproveForm,
     ReviewToDraftForm,
-    ReviewToRejectForm,
     SignoffForm,
     SubscribeForm,
     TakeawaysForm,
@@ -464,10 +464,6 @@ class ReviewToApproveView(StatusUpdateView):
     form_class = ReviewToApproveForm
 
 
-class ReviewToRejectView(StatusUpdateView):
-    form_class = ReviewToRejectForm
-
-
 class LiveToEndEnrollmentView(StatusUpdateView):
     form_class = LiveToEndEnrollmentForm
 
@@ -484,5 +480,9 @@ class ApproveEndExperimentView(StatusUpdateView):
     form_class = ApproveEndExperimentForm
 
 
-class CancelRejectEndView(StatusUpdateView):
-    form_class = CancelRejectEndForm
+class CancelEndEnrollmentView(StatusUpdateView):
+    form_class = CancelEndEnrollmentForm
+
+
+class CancelEndExperimentView(StatusUpdateView):
+    form_class = CancelEndExperimentForm

--- a/experimenter/experimenter/nimbus_ui_new/views.py
+++ b/experimenter/experimenter/nimbus_ui_new/views.py
@@ -18,11 +18,16 @@ from experimenter.nimbus_ui_new.filtersets import (
     StatusChoices,
 )
 from experimenter.nimbus_ui_new.forms import (
+    ApproveEndEnrollmentForm,
+    ApproveEndExperimentForm,
     AudienceForm,
+    CancelRejectEndForm,
     DocumentationLinkCreateForm,
     DocumentationLinkDeleteForm,
     DraftToPreviewForm,
     DraftToReviewForm,
+    LiveToCompleteForm,
+    LiveToEndEnrollmentForm,
     MetricsForm,
     NimbusBranchCreateForm,
     NimbusBranchDeleteForm,
@@ -461,3 +466,23 @@ class ReviewToApproveView(StatusUpdateView):
 
 class ReviewToRejectView(StatusUpdateView):
     form_class = ReviewToRejectForm
+
+
+class LiveToEndEnrollmentView(StatusUpdateView):
+    form_class = LiveToEndEnrollmentForm
+
+
+class ApproveEndEnrollmentView(StatusUpdateView):
+    form_class = ApproveEndEnrollmentForm
+
+
+class LiveToCompleteView(StatusUpdateView):
+    form_class = LiveToCompleteForm
+
+
+class ApproveEndExperimentView(StatusUpdateView):
+    form_class = ApproveEndExperimentForm
+
+
+class CancelRejectEndView(StatusUpdateView):
+    form_class = CancelRejectEndForm


### PR DESCRIPTION
Because

- We want to add the workflow to able to end experiment and enrollment
This commit

- Allows the user to end experiment
- Allows the user to end enrollment
- Allows to accept and reject the review
- Allows to cancel the review
- Shows the timeout message

Fixes #12254 
<img width="1461" alt="Screenshot 2025-03-07 at 5 18 37 PM" src="https://github.com/user-attachments/assets/cc93cc8e-3973-40a2-87f8-20886ec5b207" />


https://github.com/user-attachments/assets/964a5624-f2d0-41c7-8eaf-6aee02418b62


https://github.com/user-attachments/assets/e683151b-5711-4897-a37c-20c88eb2a7e4

https://github.com/user-attachments/assets/bafd444a-64d3-4dc4-90bd-638078af7512


