### PR TITLE
feat(nimbus): Adds new advanced targeting - Windows 10+ and backgroundTaskMode and 1hr+ of inactivity

### DIFF
--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -1392,7 +1392,7 @@ WINDOWS_10_PLUS_WITH_BACKGROUND_TASK_NOTIFICATION = NimbusTargetingConfig(
 )
 
 WINDOWS_10_PLUS_BACKGROUND_TASK_NOTIFICATION_1HR_INACTIVITY = NimbusTargetingConfig(
-    name="Windows 10+ users with Firefox running a background task and 1hr+ of inactivity",
+    name="Windows 10+ users with background task notification and 1hr+ of inactivity",
     slug="windows10_background_task_notification_1hr_inactivity",
     description=(
         "Windows 10+ users with 1hr+ of inactivity in the past day "

--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -1391,6 +1391,34 @@ WINDOWS_10_PLUS_WITH_BACKGROUND_TASK_NOTIFICATION = NimbusTargetingConfig(
     application_choice_names=(Application.DESKTOP.name,),
 )
 
+WINDOWS_10_PLUS_BACKGROUND_TASK_NOTIFICATION_1HR_INACTIVITY = NimbusTargetingConfig(
+    name="Windows 10+ users with Firefox running a background task and 1hr+ of inactivity",
+    slug="windows10_background_task_notification_1hr_inactivity",
+    description=(
+        "Windows 10+ users with 1hr+ of inactivity in the past day "
+        "who are running a background task"
+    ),
+    targeting="""
+    (
+        (
+            os.isWindows
+            &&
+            (os.windowsVersion >= 10)
+        )
+        &&
+        (
+            ((currentDate|date - defaultProfile.currentDate|date) / 3600000 >= 1)
+        )
+        &&
+        isBackgroundTaskMode
+    )
+    """,
+    desktop_telemetry="",
+    sticky_required=True,
+    is_first_run_required=False,
+    application_choice_names=(Application.DESKTOP.name,),
+)
+
 NEWTAB_SPONSORED_TOPSITES_ENABLED = NimbusTargetingConfig(
     name="Newtab has Sponsored TopSites enabled ",
     slug="newtab_sponsored_topsites_enabled",


### PR DESCRIPTION
Because

- For [this experiment](https://docs.google.com/document/d/153zhbfq-dd_txiC94fJauYNTBSpYwe0LI29TkFVzciw/edit?tab=t.0), we want to target users who are on Windows10+ and running in backgroundTaskMode and **at least 1hr of inactivity.** Expanding on this [targeting](https://github.com/mozilla/experimenter/issues/12270) that was recently added  after discussion with product over UX

This commit

- Adds new advanced targeting that includes the 1hr+ of inactivity check

Fixes #12313