### PR TITLE
feat(nimbus): Create advanced targeting for Android users depending on number of app launches

### DIFF
--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -2001,6 +2001,28 @@ ANDROID_LATER_DAY_USERS_ONLY = NimbusTargetingConfig(
     application_choice_names=(Application.FENIX.name,),
 )
 
+ANDROID_EARLY_APP_LAUNCH_USERS_ONLY = NimbusTargetingConfig(
+    name="Android early app launch users only",
+    slug="android_early_app_launch_users_only",
+    description="Targeting users under or equal 20 app launches since install",
+    targeting="number_of_app_launches <= 20",
+    desktop_telemetry="",
+    sticky_required=True,
+    is_first_run_required=False,
+    application_choice_names=(Application.FENIX.name,),
+)
+
+ANDROID_LATER_APP_LAUNCH_USERS_ONLY = NimbusTargetingConfig(
+    name="Android later app launch users only",
+    slug="android_later_app_launch_users_only",
+    description="Targeting users over 20 app launches since install",
+    targeting="number_of_app_launches > 20",
+    desktop_telemetry="",
+    sticky_required=True,
+    is_first_run_required=False,
+    application_choice_names=(Application.FENIX.name,),
+)
+
 IOS_REVIEW_CHECKER_ENABLED_USERS_ONLY = NimbusTargetingConfig(
     name="Review checker enabled users only",
     slug="ios_review_checker_enabled_users_only",

--- a/experimenter/tests/integration/nimbus/test_mobile_targeting.py
+++ b/experimenter/tests/integration/nimbus/test_mobile_targeting.py
@@ -100,6 +100,7 @@ def test_check_mobile_targeting(
             "is_review_checker_enabled": True,
             "is_default_browser": True,
             "install_referrer_response_utm_source": "test",
+            "number_of_app_launches": 1,
         }
     )
     client = sdk_client(load_app_context(context))


### PR DESCRIPTION
Because

- This targeting will be needed for trending search experiments. We will not target users who have not started the application less or equal to 10 times. This way we can ensure users have enough local data for our recent and top sites suggestions.

This commit

- Create advanced targeting for Android users depending on number of app launches.

Fixes #12321