### PR TITLE
chore(schemas): Fix string formatting in experimenter_apis/

### DIFF
--- a/schemas/index.d.ts
+++ b/schemas/index.d.ts
@@ -49,40 +49,52 @@ export interface DesktopAllVersionsNimbusExperiment {
    */
   slug: string;
   /**
-   * Unique identifier for the experiment. This is a duplicate of slug,             but is required field for all Remote Settings records.
+   * Unique identifier for the experiiment.
+   *
+   * This is a duplicate of slug, but is required field for all Remote Settings records.
    */
   id: string;
   /**
-   * A slug identifying the targeted product of this experiment.             It should be a lowercased_with_underscores name that is short and                 unambiguous and it should match the app_name found in                     https://probeinfo.telemetry.mozilla.org/glean/repositories.                         Examples are "fenix" and "firefox_desktop".
+   * A slug identifying the targeted product of this experiment.
+   *
+   * It should be a lowercased_with_underscores name that is short and unambiguous and it should match the app_name found in https://probeinfo.telemetry.mozilla.org/glean/repositories. Examples are "fenix" and "firefox_desktop".
    */
   appName: string;
   /**
-   * The platform identifier for the targeted app.             This should match app's identifier exactly as it appears in                 the relevant app store listing (for relevant platforms) or the app's                      Glean initialization (for other platforms). Examples are                       "org.mozilla.firefox_beta" and "firefox-desktop".
+   * The platform identifier for the targeted app.
+   *
+   * This should match app's identifier exactly as it appears in the relevant app store listing (for relevant platforms) or the app's Glean initialization (for other platforms).
+   *
+   * Examples are "org.mozilla.firefox_beta" and "firefox-desktop".
    */
   appId: string;
   /**
-   * A specific channel of an application such as 'nightly',             'beta', or 'release'.
+   * A specific channel of an application such as "nightly", "beta", or "release".
    */
   channel: string;
   /**
-   * Public name of the experiment displayed on 'about:studies'.
+   * Public name of the experiment that will be displayed on "about:studies".
    */
   userFacingName: string;
   /**
-   * Short public description of the experiment.             that will be displayed on "about:studies".
+   * Short public description of the experiment that will be displayed on "about:studies".
    */
   userFacingDescription: string;
   /**
-   * When this property is set to true, the SDK should not enroll              new users into the experiment that have not already been enrolled.
+   * When this property is set to true, the SDK should not enroll new users into the experiment that have not already been enrolled.
    */
   isEnrollmentPaused: boolean;
   /**
-   * When this property is set to true, treat this experiment               as a rollout. Rollouts are currently handled as single-branch               experiments separated from the bucketing namespace for normal experiments.               See-also: https://mozilla-hub.atlassian.net/browse/SDK-405
+   * When this property is set to true, treat this experiment as a rollout.
+   *
+   * Rollouts are currently handled as single-branch experiments separated from the bucketing namespace for normal experiments.
+   *
+   * See-also: https://mozilla-hub.atlassian.net/browse/SDK-405
    */
   isRollout?: boolean;
   bucketConfig: ExperimentBucketConfig;
   /**
-   * List of outcomes relevant to analysis.
+   * A list of outcomes relevant to the experiment analysis.
    */
   outcomes?: ExperimentOutcome[];
   /**
@@ -94,35 +106,49 @@ export interface DesktopAllVersionsNimbusExperiment {
    */
   targeting?: string | null;
   /**
-   * Actual publish date of the experiment.         Note that this value is expected to be null in Remote Settings.
+   * Actual publish date of the experiment.
+   *
+   * Note that this value is expected to be null in Remote Settings.
    */
   startDate: string | null;
   /**
-   * Actual enrollment end date of the experiment.             Note that this value is expected to be null in Remote Settings.
+   * Actual enrollment end date of the experiment.
+   *
+   * Note that this value is expected to be null in Remote Settings.
    */
   enrollmentEndDate?: string | null;
   /**
-   * Actual end date of this experiment.              Note that this field is expected to be null in Remote Settings.
+   * Actual end date of this experiment.
+   *
+   * Note that this field is expected to be null in Remote Settings.
    */
   endDate: string | null;
   /**
-   * Duration of the experiment from the start date in days.             Note that this property is only used during the analysis phase                 (i.e., not by the SDK).
+   * Duration of the experiment from the start date in days.
+   *
+   * Note that this property is only used during the analysis phase (i.e., not by the SDK).
    */
   proposedDuration?: number;
   /**
-   * This represents the number of days that we expect to             enroll new users. Note that this property is only used during                  the analysis phase (i.e., not by the SDK).
+   * This represents the number of days that we expect to enroll new users.
+   *
+   * Note that this property is only used during the analysis phase (i.e., not by the SDK).
    */
   proposedEnrollment: number;
   /**
-   * The slug of the reference branch             (i.e., the branch we consider "control").
+   * The slug of the reference branch (i.e., the branch we consider "control").
    */
   referenceBranch: string | null;
   /**
-   * The list of locale codes (e.g., "en-US" or "fr") that this             experiment is targeting. If null, all locales are targeted.
+   * The list of locale codes (e.g., "en-US" or "fr") that this experiment is targeting.
+   *
+   * If null, all locales are targeted.
    */
   locales?: string[] | null;
   /**
-   * The date that this experiment was first published to             Remote Settings. If null, it has not yet been published.
+   * The date that this experiment was first published to Remote Settings.
+   *
+   * If null, it has not yet been published.
    */
   publishedDate?: string | null;
   /**
@@ -130,7 +156,7 @@ export interface DesktopAllVersionsNimbusExperiment {
    */
   branches: DesktopAllVersionsExperimentBranch[];
   /**
-   * When this property is set to true, treat this experiment as a             Firefox Labs experiment
+   * When this property is set to true, treat this experiment as aFirefox Labs experiment
    */
   isFirefoxLabsOptIn?: boolean;
   /**
@@ -146,7 +172,7 @@ export interface DesktopAllVersionsNimbusExperiment {
    */
   firefoxLabsDescription?: string | null;
   /**
-   * Links that will be used with the Firefox Labs             description Fluent ID. May be null for Firefox Labs Opt-In recipes                 that do not use links.
+   * Links that will be used with the firefoxLabsDescription Fluent ID. May be null for Firefox Labs Opt-In recipes that do not use links.
    */
   firefoxLabsDescriptionLinks?: {
     [k: string]: string;
@@ -157,13 +183,12 @@ export interface DesktopAllVersionsNimbusExperiment {
   featureValidationOptOut?: boolean;
   /**
    * Does the experiment require a restart to take effect?
+   *
+   * Only used by Firefox Labs Opt-Ins.
    */
   requiresRestart?: boolean;
   localizations?: ExperimentLocalizations | null;
 }
-/**
- * Common Bucketing Configuration used across all versions.
- */
 export interface ExperimentBucketConfig {
   randomizationUnit: RandomizationUnit;
   /**
@@ -179,7 +204,9 @@ export interface ExperimentBucketConfig {
    */
   count: number;
   /**
-   * The total number of buckets. You can assume             this will always be 10000.
+   * The total number of buckets.
+   *
+   * You can assume this will always be 10000.
    */
   total: number;
 }
@@ -206,7 +233,8 @@ export interface DesktopAllVersionsExperimentBranch {
   slug: string;
   /**
    * Relative ratio of population for the branch.
-   * e.g., if branch A=1 and branch B=3, then branch A                 would get 25% of the population.
+   *
+   * e.g., if branch A=1 and branch B=3, then branch A would get 25% of the population.
    */
   ratio: number;
   /**
@@ -267,40 +295,52 @@ export interface DesktopNimbusExperiment {
    */
   slug: string;
   /**
-   * Unique identifier for the experiment. This is a duplicate of slug,             but is required field for all Remote Settings records.
+   * Unique identifier for the experiiment.
+   *
+   * This is a duplicate of slug, but is required field for all Remote Settings records.
    */
   id: string;
   /**
-   * A slug identifying the targeted product of this experiment.             It should be a lowercased_with_underscores name that is short and                 unambiguous and it should match the app_name found in                     https://probeinfo.telemetry.mozilla.org/glean/repositories.                         Examples are "fenix" and "firefox_desktop".
+   * A slug identifying the targeted product of this experiment.
+   *
+   * It should be a lowercased_with_underscores name that is short and unambiguous and it should match the app_name found in https://probeinfo.telemetry.mozilla.org/glean/repositories. Examples are "fenix" and "firefox_desktop".
    */
   appName: string;
   /**
-   * The platform identifier for the targeted app.             This should match app's identifier exactly as it appears in                 the relevant app store listing (for relevant platforms) or the app's                      Glean initialization (for other platforms). Examples are                       "org.mozilla.firefox_beta" and "firefox-desktop".
+   * The platform identifier for the targeted app.
+   *
+   * This should match app's identifier exactly as it appears in the relevant app store listing (for relevant platforms) or the app's Glean initialization (for other platforms).
+   *
+   * Examples are "org.mozilla.firefox_beta" and "firefox-desktop".
    */
   appId: string;
   /**
-   * A specific channel of an application such as 'nightly',             'beta', or 'release'.
+   * A specific channel of an application such as "nightly", "beta", or "release".
    */
   channel: string;
   /**
-   * Public name of the experiment displayed on 'about:studies'.
+   * Public name of the experiment that will be displayed on "about:studies".
    */
   userFacingName: string;
   /**
-   * Short public description of the experiment.             that will be displayed on "about:studies".
+   * Short public description of the experiment that will be displayed on "about:studies".
    */
   userFacingDescription: string;
   /**
-   * When this property is set to true, the SDK should not enroll              new users into the experiment that have not already been enrolled.
+   * When this property is set to true, the SDK should not enroll new users into the experiment that have not already been enrolled.
    */
   isEnrollmentPaused: boolean;
   /**
-   * When this property is set to true, treat this experiment               as a rollout. Rollouts are currently handled as single-branch               experiments separated from the bucketing namespace for normal experiments.               See-also: https://mozilla-hub.atlassian.net/browse/SDK-405
+   * When this property is set to true, treat this experiment as a rollout.
+   *
+   * Rollouts are currently handled as single-branch experiments separated from the bucketing namespace for normal experiments.
+   *
+   * See-also: https://mozilla-hub.atlassian.net/browse/SDK-405
    */
   isRollout?: boolean;
   bucketConfig: ExperimentBucketConfig;
   /**
-   * List of outcomes relevant to analysis.
+   * A list of outcomes relevant to the experiment analysis.
    */
   outcomes?: ExperimentOutcome[];
   /**
@@ -312,35 +352,49 @@ export interface DesktopNimbusExperiment {
    */
   targeting?: string | null;
   /**
-   * Actual publish date of the experiment.         Note that this value is expected to be null in Remote Settings.
+   * Actual publish date of the experiment.
+   *
+   * Note that this value is expected to be null in Remote Settings.
    */
   startDate: string | null;
   /**
-   * Actual enrollment end date of the experiment.             Note that this value is expected to be null in Remote Settings.
+   * Actual enrollment end date of the experiment.
+   *
+   * Note that this value is expected to be null in Remote Settings.
    */
   enrollmentEndDate?: string | null;
   /**
-   * Actual end date of this experiment.              Note that this field is expected to be null in Remote Settings.
+   * Actual end date of this experiment.
+   *
+   * Note that this field is expected to be null in Remote Settings.
    */
   endDate: string | null;
   /**
-   * Duration of the experiment from the start date in days.             Note that this property is only used during the analysis phase                 (i.e., not by the SDK).
+   * Duration of the experiment from the start date in days.
+   *
+   * Note that this property is only used during the analysis phase (i.e., not by the SDK).
    */
   proposedDuration?: number;
   /**
-   * This represents the number of days that we expect to             enroll new users. Note that this property is only used during                  the analysis phase (i.e., not by the SDK).
+   * This represents the number of days that we expect to enroll new users.
+   *
+   * Note that this property is only used during the analysis phase (i.e., not by the SDK).
    */
   proposedEnrollment: number;
   /**
-   * The slug of the reference branch             (i.e., the branch we consider "control").
+   * The slug of the reference branch (i.e., the branch we consider "control").
    */
   referenceBranch: string | null;
   /**
-   * The list of locale codes (e.g., "en-US" or "fr") that this             experiment is targeting. If null, all locales are targeted.
+   * The list of locale codes (e.g., "en-US" or "fr") that this experiment is targeting.
+   *
+   * If null, all locales are targeted.
    */
   locales?: string[] | null;
   /**
-   * The date that this experiment was first published to             Remote Settings. If null, it has not yet been published.
+   * The date that this experiment was first published to Remote Settings.
+   *
+   * If null, it has not yet been published.
    */
   publishedDate?: string | null;
   /**
@@ -348,7 +402,7 @@ export interface DesktopNimbusExperiment {
    */
   branches: DesktopExperimentBranch[];
   /**
-   * When this property is set to true, treat this experiment as a             Firefox Labs experiment
+   * When this property is set to true, treat this experiment as aFirefox Labs experiment
    */
   isFirefoxLabsOptIn?: boolean;
   /**
@@ -364,7 +418,7 @@ export interface DesktopNimbusExperiment {
    */
   firefoxLabsDescription?: string | null;
   /**
-   * Links that will be used with the Firefox Labs             description Fluent ID. May be null for Firefox Labs Opt-In recipes                 that do not use links.
+   * Links that will be used with the firefoxLabsDescription Fluent ID. May be null for Firefox Labs Opt-In recipes that do not use links.
    */
   firefoxLabsDescriptionLinks?: {
     [k: string]: string;
@@ -375,6 +429,8 @@ export interface DesktopNimbusExperiment {
   featureValidationOptOut?: boolean;
   /**
    * Does the experiment require a restart to take effect?
+   *
+   * Only used by Firefox Labs Opt-Ins.
    */
   requiresRestart?: boolean;
   localizations?: ExperimentLocalizations | null;
@@ -389,7 +445,8 @@ export interface DesktopExperimentBranch {
   slug: string;
   /**
    * Relative ratio of population for the branch.
-   * e.g., if branch A=1 and branch B=3, then branch A                 would get 25% of the population.
+   *
+   * e.g., if branch A=1 and branch B=3, then branch A would get 25% of the population.
    */
   ratio: number;
   /**
@@ -414,40 +471,52 @@ export interface SdkNimbusExperiment {
    */
   slug: string;
   /**
-   * Unique identifier for the experiment. This is a duplicate of slug,             but is required field for all Remote Settings records.
+   * Unique identifier for the experiiment.
+   *
+   * This is a duplicate of slug, but is required field for all Remote Settings records.
    */
   id: string;
   /**
-   * A slug identifying the targeted product of this experiment.             It should be a lowercased_with_underscores name that is short and                 unambiguous and it should match the app_name found in                     https://probeinfo.telemetry.mozilla.org/glean/repositories.                         Examples are "fenix" and "firefox_desktop".
+   * A slug identifying the targeted product of this experiment.
+   *
+   * It should be a lowercased_with_underscores name that is short and unambiguous and it should match the app_name found in https://probeinfo.telemetry.mozilla.org/glean/repositories. Examples are "fenix" and "firefox_desktop".
    */
   appName: string;
   /**
-   * The platform identifier for the targeted app.             This should match app's identifier exactly as it appears in                 the relevant app store listing (for relevant platforms) or the app's                      Glean initialization (for other platforms). Examples are                       "org.mozilla.firefox_beta" and "firefox-desktop".
+   * The platform identifier for the targeted app.
+   *
+   * This should match app's identifier exactly as it appears in the relevant app store listing (for relevant platforms) or the app's Glean initialization (for other platforms).
+   *
+   * Examples are "org.mozilla.firefox_beta" and "firefox-desktop".
    */
   appId: string;
   /**
-   * A specific channel of an application such as 'nightly',             'beta', or 'release'.
+   * A specific channel of an application such as "nightly", "beta", or "release".
    */
   channel: string;
   /**
-   * Public name of the experiment displayed on 'about:studies'.
+   * Public name of the experiment that will be displayed on "about:studies".
    */
   userFacingName: string;
   /**
-   * Short public description of the experiment.             that will be displayed on "about:studies".
+   * Short public description of the experiment that will be displayed on "about:studies".
    */
   userFacingDescription: string;
   /**
-   * When this property is set to true, the SDK should not enroll              new users into the experiment that have not already been enrolled.
+   * When this property is set to true, the SDK should not enroll new users into the experiment that have not already been enrolled.
    */
   isEnrollmentPaused: boolean;
   /**
-   * When this property is set to true, treat this experiment               as a rollout. Rollouts are currently handled as single-branch               experiments separated from the bucketing namespace for normal experiments.               See-also: https://mozilla-hub.atlassian.net/browse/SDK-405
+   * When this property is set to true, treat this experiment as a rollout.
+   *
+   * Rollouts are currently handled as single-branch experiments separated from the bucketing namespace for normal experiments.
+   *
+   * See-also: https://mozilla-hub.atlassian.net/browse/SDK-405
    */
   isRollout?: boolean;
   bucketConfig: ExperimentBucketConfig;
   /**
-   * List of outcomes relevant to analysis.
+   * A list of outcomes relevant to the experiment analysis.
    */
   outcomes?: ExperimentOutcome[];
   /**
@@ -459,35 +528,49 @@ export interface SdkNimbusExperiment {
    */
   targeting?: string | null;
   /**
-   * Actual publish date of the experiment.         Note that this value is expected to be null in Remote Settings.
+   * Actual publish date of the experiment.
+   *
+   * Note that this value is expected to be null in Remote Settings.
    */
   startDate: string | null;
   /**
-   * Actual enrollment end date of the experiment.             Note that this value is expected to be null in Remote Settings.
+   * Actual enrollment end date of the experiment.
+   *
+   * Note that this value is expected to be null in Remote Settings.
    */
   enrollmentEndDate?: string | null;
   /**
-   * Actual end date of this experiment.              Note that this field is expected to be null in Remote Settings.
+   * Actual end date of this experiment.
+   *
+   * Note that this field is expected to be null in Remote Settings.
    */
   endDate: string | null;
   /**
-   * Duration of the experiment from the start date in days.             Note that this property is only used during the analysis phase                 (i.e., not by the SDK).
+   * Duration of the experiment from the start date in days.
+   *
+   * Note that this property is only used during the analysis phase (i.e., not by the SDK).
    */
   proposedDuration?: number;
   /**
-   * This represents the number of days that we expect to             enroll new users. Note that this property is only used during                  the analysis phase (i.e., not by the SDK).
+   * This represents the number of days that we expect to enroll new users.
+   *
+   * Note that this property is only used during the analysis phase (i.e., not by the SDK).
    */
   proposedEnrollment: number;
   /**
-   * The slug of the reference branch             (i.e., the branch we consider "control").
+   * The slug of the reference branch (i.e., the branch we consider "control").
    */
   referenceBranch: string | null;
   /**
-   * The list of locale codes (e.g., "en-US" or "fr") that this             experiment is targeting. If null, all locales are targeted.
+   * The list of locale codes (e.g., "en-US" or "fr") that this experiment is targeting.
+   *
+   * If null, all locales are targeted.
    */
   locales?: string[] | null;
   /**
-   * The date that this experiment was first published to             Remote Settings. If null, it has not yet been published.
+   * The date that this experiment was first published to Remote Settings.
+   *
+   * If null, it has not yet been published.
    */
   publishedDate?: string | null;
   /**
@@ -507,7 +590,8 @@ export interface SdkExperimentBranch {
   slug: string;
   /**
    * Relative ratio of population for the branch.
-   * e.g., if branch A=1 and branch B=3, then branch A                 would get 25% of the population.
+   *
+   * e.g., if branch A=1 and branch B=3, then branch A would get 25% of the population.
    */
   ratio: number;
   /**

--- a/schemas/mozilla_nimbus_schemas/experimenter_apis/common.py
+++ b/schemas/mozilla_nimbus_schemas/experimenter_apis/common.py
@@ -17,8 +17,6 @@ class RandomizationUnit(str, Enum):
 
 
 class ExperimentBucketConfig(BaseModel):
-    """Common Bucketing Configuration used across all versions."""
-
     # NB: We can't include a description on the randomizationUnit field because that
     # causes json-schema-to-typescript to generate an extra RandomizationUnit1 type. See
     # https://github.com/bcherny/json-schema-to-typescript/issues/466
@@ -28,8 +26,11 @@ class ExperimentBucketConfig(BaseModel):
     start: int = Field(description="Index of the starting bucket of the range.")
     count: int = Field(description="Number of buckets in the range.")
     total: int = Field(
-        description="The total number of buckets. You can assume \
-            this will always be 10000."
+        description=(
+            "The total number of buckets.\n"
+            "\n"
+            "You can assume this will always be 10000."
+        )
     )
 
     model_config = ConfigDict(use_enum_values=True)
@@ -66,8 +67,9 @@ class BaseExperimentBranch(BaseModel):
     ratio: int = Field(
         description=(
             "Relative ratio of population for the branch.\n"
-            "e.g., if branch A=1 and branch B=3, then branch A \
-                would get 25% of the population."
+            "\n"
+            "e.g., if branch A=1 and branch B=3, then branch A would get 25% of the "
+            "population."
         )
     )
     features: list[ExperimentFeatureConfig] = Field(
@@ -75,57 +77,82 @@ class BaseExperimentBranch(BaseModel):
     )
 
 
-class _CommonBaseExperiment(BaseModel):
-    """Common base class for all Nimbus experiment
-    versions (used in V6 & V7)."""
+class BaseExperiment(BaseModel):
+    """Common base class that contains all fields included in both the v6 and v7 "
+    Experiment API.
+    """
 
     schemaVersion: str = Field(
         description="Version of the NimbusExperiment schema this experiment refers to"
     )
     slug: str = Field(description="Unique identifier for the experiment")
     id: str = Field(
-        description="Unique identifier for the experiment. This is a duplicate of slug, \
-            but is required field for all Remote Settings records."
+        description=(
+            "Unique identifier for the experiiment.\n"
+            "\n"
+            "This is a duplicate of slug, but is required field for all Remote Settings "
+            "records."
+        )
     )
     appName: str = Field(
-        description='A slug identifying the targeted product of this experiment. \
-            It should be a lowercased_with_underscores name that is short and \
-                unambiguous and it should match the app_name found in \
-                    https://probeinfo.telemetry.mozilla.org/glean/repositories. \
-                        Examples are "fenix" and "firefox_desktop".'
+        description=(
+            "A slug identifying the targeted product of this experiment.\n"
+            "\n"
+            "It should be a lowercased_with_underscores name that is short and "
+            "unambiguous and it should match the app_name found in "
+            "https://probeinfo.telemetry.mozilla.org/glean/repositories. Examples are "
+            '"fenix" and "firefox_desktop".'
+        )
     )
     appId: str = Field(
-        description='The platform identifier for the targeted app. \
-            This should match app\'s identifier exactly as it appears in \
-                the relevant app store listing (for relevant platforms) or the app\'s\
-                      Glean initialization (for other platforms). Examples are \
-                      "org.mozilla.firefox_beta" and "firefox-desktop".'
+        description=(
+            "The platform identifier for the targeted app.\n"
+            "\n"
+            "This should match app's identifier exactly as it appears in the relevant "
+            "app store listing (for relevant platforms) or the app's Glean "
+            "initialization (for other platforms).\n"
+            "\n"
+            'Examples are "org.mozilla.firefox_beta" and "firefox-desktop".'
+        )
     )
     channel: str = Field(
-        description="A specific channel of an application such as 'nightly', \
-            'beta', or 'release'."
+        description=(
+            'A specific channel of an application such as "nightly", "beta", or '
+            '"release".'
+        )
     )
     userFacingName: str = Field(
-        description="Public name of the experiment displayed on 'about:studies'."
+        description=(
+            'Public name of the experiment that will be displayed on "about:studies".'
+        )
     )
     userFacingDescription: str = Field(
-        description='Short public description of the experiment. \
-            that will be displayed on "about:studies".'
+        description=(
+            "Short public description of the experiment that will be displayed on "
+            '"about:studies".'
+        )
     )
     isEnrollmentPaused: bool = Field(
-        description="When this property is set to true, the SDK should not enroll\
-              new users into the experiment that have not already been enrolled."
+        description=(
+            "When this property is set to true, the SDK should not enroll new users "
+            "into the experiment that have not already been enrolled."
+        )
     )
     isRollout: bool | SkipJsonSchema[None] = Field(
-        description="When this property is set to true, treat this experiment \
-              as a rollout. Rollouts are currently handled as single-branch \
-              experiments separated from the bucketing namespace for normal experiments. \
-              See-also: https://mozilla-hub.atlassian.net/browse/SDK-405",
+        description=(
+            "When this property is set to true, treat this experiment as a rollout.\n"
+            "\n"
+            "Rollouts are currently handled as single-branch experiments separated from "
+            "the bucketing namespace for normal experiments.\n"
+            "\n"
+            "See-also: https://mozilla-hub.atlassian.net/browse/SDK-405"
+        ),
         default=None,
     )
     bucketConfig: ExperimentBucketConfig = Field(description="Bucketing configuration.")
     outcomes: list[ExperimentOutcome] | SkipJsonSchema[None] = Field(
-        description="List of outcomes relevant to analysis.", default=None
+        description="A list of outcomes relevant to the experiment analysis.",
+        default=None,
     )
     featureIds: list[str] | SkipJsonSchema[None] = Field(
         description="A list of featureIds the experiment contains configurations for.",
@@ -136,41 +163,64 @@ class _CommonBaseExperiment(BaseModel):
         default=None,
     )
     startDate: datetime.date | None = Field(
-        description="Actual publish date of the experiment. \
-        Note that this value is expected to be null in Remote Settings."
+        description=(
+            "Actual publish date of the experiment.\n"
+            "\n"
+            "Note that this value is expected to be null in Remote Settings."
+        ),
     )
     enrollmentEndDate: datetime.date | None = Field(
-        description="Actual enrollment end date of the experiment. \
-            Note that this value is expected to be null in Remote Settings.",
+        description=(
+            "Actual enrollment end date of the experiment.\n"
+            "\n"
+            "Note that this value is expected to be null in Remote Settings."
+        ),
         default=None,
     )
     endDate: datetime.date | None = Field(
-        description="Actual end date of this experiment.\
-              Note that this field is expected to be null in Remote Settings."
+        description=(
+            "Actual end date of this experiment.\n"
+            "\n"
+            "Note that this field is expected to be null in Remote Settings."
+        ),
     )
     proposedDuration: int | SkipJsonSchema[None] = Field(
-        description="Duration of the experiment from the start date in days. \
-            Note that this property is only used during the analysis phase \
-                (i.e., not by the SDK).",
+        description=(
+            "Duration of the experiment from the start date in days.\n"
+            "\n"
+            "Note that this property is only used during the analysis phase (i.e., not "
+            "by the SDK)."
+        ),
         default=None,
     )
     proposedEnrollment: int = Field(
-        description="This represents the number of days that we expect to \
-            enroll new users. Note that this property is only used during\
-                  the analysis phase (i.e., not by the SDK)."
+        description=(
+            "This represents the number of days that we expect to enroll new users.\n"
+            "\n"
+            "Note that this property is only used during the analysis phase (i.e., not "
+            "by the SDK)."
+        )
     )
     referenceBranch: str | None = Field(
-        description='The slug of the reference branch \
-            (i.e., the branch we consider "control").'
+        description=(
+            'The slug of the reference branch (i.e., the branch we consider "control").'
+        )
     )
     locales: list[str] | None = Field(
-        description='The list of locale codes (e.g., "en-US" or "fr") that this \
-            experiment is targeting. If null, all locales are targeted.',
+        description=(
+            'The list of locale codes (e.g., "en-US" or "fr") that this experiment is '
+            "targeting.\n"
+            "\n"
+            "If null, all locales are targeted."
+        ),
         default=None,
     )
     publishedDate: datetime.datetime | None = Field(
-        description="The date that this experiment was first published to \
-            Remote Settings. If null, it has not yet been published.",
+        description=(
+            "The date that this experiment was first published to Remote Settings.\n"
+            "\n"
+            "If null, it has not yet been published."
+        ),
         default=None,
     )
 

--- a/schemas/mozilla_nimbus_schemas/experimenter_apis/experiments/experiments.py
+++ b/schemas/mozilla_nimbus_schemas/experimenter_apis/experiments/experiments.py
@@ -5,10 +5,10 @@ from pydantic.json_schema import SkipJsonSchema
 from typing_extensions import Self
 
 from mozilla_nimbus_schemas.experimenter_apis.common import (
+    BaseExperiment,
     BaseExperimentBranch,
     ExperimentFeatureConfig,
     ExperimentLocalizations,
-    _CommonBaseExperiment,
 )
 
 
@@ -54,14 +54,6 @@ class DesktopAllVersionsExperimentBranch(DesktopExperimentBranch):
     )
 
 
-class BaseExperiment(_CommonBaseExperiment):
-    """The base experiment definition accessible to:
-
-    1. The Nimbus SDK via Remote Settings
-    2. Jetstream via the Experimenter API
-    """
-
-
 class DesktopNimbusExperiment(BaseExperiment):
     """A Nimbus experiment for Firefox Desktop.
 
@@ -77,30 +69,42 @@ class DesktopNimbusExperiment(BaseExperiment):
     )
 
     isFirefoxLabsOptIn: bool = Field(
-        description="When this property is set to true, treat this experiment as a \
-            Firefox Labs experiment",
+        description=(
+            "When this property is set to true, treat this experiment as a"
+            "Firefox Labs experiment"
+        ),
         default=None,
     )
     firefoxLabsGroup: str | None = Field(
-        description="The group this should appear under in Firefox Labs", default=None
+        description="The group this should appear under in Firefox Labs",
+        default=None,
     )
     firefoxLabsTitle: str | None = Field(
-        description="The title shown in Firefox Labs (Fluent ID)", default=None
+        description="The title shown in Firefox Labs (Fluent ID)",
+        default=None,
     )
     firefoxLabsDescription: str | None = Field(
-        description="The description shown in Firefox Labs (Fluent ID)", default=None
+        description="The description shown in Firefox Labs (Fluent ID)",
+        default=None,
     )
     firefoxLabsDescriptionLinks: dict[str, HttpUrl] | None = Field(
-        description="Links that will be used with the Firefox Labs \
-            description Fluent ID. May be null for Firefox Labs Opt-In recipes \
-                that do not use links.",
+        description=(
+            "Links that will be used with the firefoxLabsDescription Fluent ID. May be "
+            "null for Firefox Labs Opt-In recipes that do not use links."
+        ),
         default=None,
     )
     featureValidationOptOut: bool | SkipJsonSchema[None] = Field(
-        description="Opt out of feature schema validation.", default=None
+        description="Opt out of feature schema validation.",
+        default=None,
     )
     requiresRestart: bool | SkipJsonSchema[None] = Field(
-        description="Does the experiment require a restart to take effect?", default=False
+        description=(
+            "Does the experiment require a restart to take effect?\n"
+            "\n"
+            "Only used by Firefox Labs Opt-Ins."
+        ),
+        default=False,
     )
     localizations: ExperimentLocalizations | None = Field(default=None)
 
@@ -110,23 +114,28 @@ class DesktopNimbusExperiment(BaseExperiment):
         if data.isFirefoxLabsOptIn:
             if data.firefoxLabsTitle is None:
                 raise ValueError(
-                    "missing field firefoxLabsTitle (required for Firefox Labs)"
+                    "missing field firefoxLabsTitle (required because isFirefoxLabsOptIn "
+                    "is True)"
                 )
             if data.firefoxLabsDescription is None:
                 raise ValueError(
-                    "missing field firefoxLabsDescription (required for Firefox Labs)"
+                    "missing field firefoxLabsDescription (required because "
+                    "isFirefoxLabsOptIn is True)"
                 )
             if data.firefoxLabsGroup is None:
                 raise ValueError(
-                    "missing field firefoxLabsGroup (required for Firefox Labs)"
+                    "missing field firefoxLabsGroup (required because isFirefoxLabsOptIn "
+                    "is True)"
                 )
             if not data.isRollout:
                 for branch in data.branches:
                     if branch.firefoxLabsTitle is None:
                         raise ValueError(
-                            f"branch with slug {branch.slug} is missing \
-                                firefoxLabsTitle (required for Firefox Labs)"
+                            f"branch with slug {branch.slug} is missing "
+                            "firefoxLabsTitle field "
+                            "(required because firefoxLabsTitle is True)"
                         )
+
         return data
 
     model_config = ConfigDict(

--- a/schemas/mozilla_nimbus_schemas/experimenter_apis/experiments_v7/experiments_v7.py
+++ b/schemas/mozilla_nimbus_schemas/experimenter_apis/experiments_v7/experiments_v7.py
@@ -1,13 +1,13 @@
 from pydantic import Field
 
 from mozilla_nimbus_schemas.experimenter_apis.common import (
+    BaseExperiment,
     BaseExperimentBranch,
     ExperimentLocalizations,
-    _CommonBaseExperiment,
 )
 
 
-class NimbusExperimentV7(_CommonBaseExperiment):
+class NimbusExperimentV7(BaseExperiment):
     """A Nimbus experiment for V7."""
 
     localizations: ExperimentLocalizations | None = Field(

--- a/schemas/schemas/DesktopAllVersionsNimbusExperiment.schema.json
+++ b/schemas/schemas/DesktopAllVersionsNimbusExperiment.schema.json
@@ -13,35 +13,35 @@
       "type": "string"
     },
     "id": {
-      "description": "Unique identifier for the experiment. This is a duplicate of slug,             but is required field for all Remote Settings records.",
+      "description": "Unique identifier for the experiiment. This is a duplicate of slug, but is required field for all Remote Settings records.",
       "type": "string"
     },
     "appName": {
-      "description": "A slug identifying the targeted product of this experiment.             It should be a lowercased_with_underscores name that is short and                 unambiguous and it should match the app_name found in                     https://probeinfo.telemetry.mozilla.org/glean/repositories.                         Examples are \"fenix\" and \"firefox_desktop\".",
+      "description": "A slug identifying the targeted product of this experiment. It should be a lowercased_with_underscores name that is short and unambiguous and it should match the app_name found in https://probeinfo.telemetry.mozilla.org/glean/repositories. Examples are \"fenix\" and \"firefox_desktop\".",
       "type": "string"
     },
     "appId": {
-      "description": "The platform identifier for the targeted app.             This should match app's identifier exactly as it appears in                 the relevant app store listing (for relevant platforms) or the app's                      Glean initialization (for other platforms). Examples are                       \"org.mozilla.firefox_beta\" and \"firefox-desktop\".",
+      "description": "The platform identifier for the targeted app. This should match app's identifier exactly as it appears in the relevant app store listing (for relevant platforms) or the app's Glean initialization (for other platforms). Examples are \"org.mozilla.firefox_beta\" and \"firefox-desktop\".",
       "type": "string"
     },
     "channel": {
-      "description": "A specific channel of an application such as 'nightly',             'beta', or 'release'.",
+      "description": "A specific channel of an application such as \"nightly\", \"beta\", or \"release\".",
       "type": "string"
     },
     "userFacingName": {
-      "description": "Public name of the experiment displayed on 'about:studies'.",
+      "description": "Public name of the experiment that will be displayed on \"about:studies\".",
       "type": "string"
     },
     "userFacingDescription": {
-      "description": "Short public description of the experiment.             that will be displayed on \"about:studies\".",
+      "description": "Short public description of the experiment that will be displayed on \"about:studies\".",
       "type": "string"
     },
     "isEnrollmentPaused": {
-      "description": "When this property is set to true, the SDK should not enroll              new users into the experiment that have not already been enrolled.",
+      "description": "When this property is set to true, the SDK should not enroll new users into the experiment that have not already been enrolled.",
       "type": "boolean"
     },
     "isRollout": {
-      "description": "When this property is set to true, treat this experiment               as a rollout. Rollouts are currently handled as single-branch               experiments separated from the bucketing namespace for normal experiments.               See-also: https://mozilla-hub.atlassian.net/browse/SDK-405",
+      "description": "When this property is set to true, treat this experiment as a rollout. Rollouts are currently handled as single-branch experiments separated from the bucketing namespace for normal experiments. See-also: https://mozilla-hub.atlassian.net/browse/SDK-405",
       "type": "boolean"
     },
     "bucketConfig": {
@@ -49,7 +49,7 @@
       "description": "Bucketing configuration."
     },
     "outcomes": {
-      "description": "List of outcomes relevant to analysis.",
+      "description": "A list of outcomes relevant to the experiment analysis.",
       "items": {
         "$ref": "#/$defs/ExperimentOutcome"
       },
@@ -83,7 +83,7 @@
           "type": "null"
         }
       ],
-      "description": "Actual publish date of the experiment.         Note that this value is expected to be null in Remote Settings."
+      "description": "Actual publish date of the experiment. Note that this value is expected to be null in Remote Settings."
     },
     "enrollmentEndDate": {
       "anyOf": [
@@ -95,7 +95,7 @@
           "type": "null"
         }
       ],
-      "description": "Actual enrollment end date of the experiment.             Note that this value is expected to be null in Remote Settings."
+      "description": "Actual enrollment end date of the experiment. Note that this value is expected to be null in Remote Settings."
     },
     "endDate": {
       "anyOf": [
@@ -107,14 +107,14 @@
           "type": "null"
         }
       ],
-      "description": "Actual end date of this experiment.              Note that this field is expected to be null in Remote Settings."
+      "description": "Actual end date of this experiment. Note that this field is expected to be null in Remote Settings."
     },
     "proposedDuration": {
-      "description": "Duration of the experiment from the start date in days.             Note that this property is only used during the analysis phase                 (i.e., not by the SDK).",
+      "description": "Duration of the experiment from the start date in days. Note that this property is only used during the analysis phase (i.e., not by the SDK).",
       "type": "integer"
     },
     "proposedEnrollment": {
-      "description": "This represents the number of days that we expect to             enroll new users. Note that this property is only used during                  the analysis phase (i.e., not by the SDK).",
+      "description": "This represents the number of days that we expect to enroll new users. Note that this property is only used during the analysis phase (i.e., not by the SDK).",
       "type": "integer"
     },
     "referenceBranch": {
@@ -126,7 +126,7 @@
           "type": "null"
         }
       ],
-      "description": "The slug of the reference branch             (i.e., the branch we consider \"control\")."
+      "description": "The slug of the reference branch (i.e., the branch we consider \"control\")."
     },
     "locales": {
       "anyOf": [
@@ -140,7 +140,7 @@
           "type": "null"
         }
       ],
-      "description": "The list of locale codes (e.g., \"en-US\" or \"fr\") that this             experiment is targeting. If null, all locales are targeted."
+      "description": "The list of locale codes (e.g., \"en-US\" or \"fr\") that this experiment is targeting. If null, all locales are targeted."
     },
     "publishedDate": {
       "anyOf": [
@@ -152,7 +152,7 @@
           "type": "null"
         }
       ],
-      "description": "The date that this experiment was first published to             Remote Settings. If null, it has not yet been published."
+      "description": "The date that this experiment was first published to Remote Settings. If null, it has not yet been published."
     },
     "branches": {
       "description": "Branch configuration for the experiment.",
@@ -162,7 +162,7 @@
       "type": "array"
     },
     "isFirefoxLabsOptIn": {
-      "description": "When this property is set to true, treat this experiment as a             Firefox Labs experiment",
+      "description": "When this property is set to true, treat this experiment as aFirefox Labs experiment",
       "type": "boolean"
     },
     "firefoxLabsGroup": {
@@ -213,14 +213,14 @@
           "type": "null"
         }
       ],
-      "description": "Links that will be used with the Firefox Labs             description Fluent ID. May be null for Firefox Labs Opt-In recipes                 that do not use links."
+      "description": "Links that will be used with the firefoxLabsDescription Fluent ID. May be null for Firefox Labs Opt-In recipes that do not use links."
     },
     "featureValidationOptOut": {
       "description": "Opt out of feature schema validation.",
       "type": "boolean"
     },
     "requiresRestart": {
-      "description": "Does the experiment require a restart to take effect?",
+      "description": "Does the experiment require a restart to take effect? Only used by Firefox Labs Opt-Ins.",
       "type": "boolean"
     },
     "localizations": {
@@ -300,7 +300,7 @@
           "type": "string"
         },
         "ratio": {
-          "description": "Relative ratio of population for the branch. e.g., if branch A=1 and branch B=3, then branch A                 would get 25% of the population.",
+          "description": "Relative ratio of population for the branch. e.g., if branch A=1 and branch B=3, then branch A would get 25% of the population.",
           "type": "integer"
         },
         "features": {
@@ -356,7 +356,6 @@
       "type": "object"
     },
     "ExperimentBucketConfig": {
-      "description": "Common Bucketing Configuration used across all versions.",
       "properties": {
         "randomizationUnit": {
           "$ref": "#/$defs/RandomizationUnit"
@@ -374,7 +373,7 @@
           "type": "integer"
         },
         "total": {
-          "description": "The total number of buckets. You can assume             this will always be 10000.",
+          "description": "The total number of buckets. You can assume this will always be 10000.",
           "type": "integer"
         }
       },

--- a/schemas/schemas/DesktopNimbusExperiment.schema.json
+++ b/schemas/schemas/DesktopNimbusExperiment.schema.json
@@ -13,35 +13,35 @@
       "type": "string"
     },
     "id": {
-      "description": "Unique identifier for the experiment. This is a duplicate of slug,             but is required field for all Remote Settings records.",
+      "description": "Unique identifier for the experiiment. This is a duplicate of slug, but is required field for all Remote Settings records.",
       "type": "string"
     },
     "appName": {
-      "description": "A slug identifying the targeted product of this experiment.             It should be a lowercased_with_underscores name that is short and                 unambiguous and it should match the app_name found in                     https://probeinfo.telemetry.mozilla.org/glean/repositories.                         Examples are \"fenix\" and \"firefox_desktop\".",
+      "description": "A slug identifying the targeted product of this experiment. It should be a lowercased_with_underscores name that is short and unambiguous and it should match the app_name found in https://probeinfo.telemetry.mozilla.org/glean/repositories. Examples are \"fenix\" and \"firefox_desktop\".",
       "type": "string"
     },
     "appId": {
-      "description": "The platform identifier for the targeted app.             This should match app's identifier exactly as it appears in                 the relevant app store listing (for relevant platforms) or the app's                      Glean initialization (for other platforms). Examples are                       \"org.mozilla.firefox_beta\" and \"firefox-desktop\".",
+      "description": "The platform identifier for the targeted app. This should match app's identifier exactly as it appears in the relevant app store listing (for relevant platforms) or the app's Glean initialization (for other platforms). Examples are \"org.mozilla.firefox_beta\" and \"firefox-desktop\".",
       "type": "string"
     },
     "channel": {
-      "description": "A specific channel of an application such as 'nightly',             'beta', or 'release'.",
+      "description": "A specific channel of an application such as \"nightly\", \"beta\", or \"release\".",
       "type": "string"
     },
     "userFacingName": {
-      "description": "Public name of the experiment displayed on 'about:studies'.",
+      "description": "Public name of the experiment that will be displayed on \"about:studies\".",
       "type": "string"
     },
     "userFacingDescription": {
-      "description": "Short public description of the experiment.             that will be displayed on \"about:studies\".",
+      "description": "Short public description of the experiment that will be displayed on \"about:studies\".",
       "type": "string"
     },
     "isEnrollmentPaused": {
-      "description": "When this property is set to true, the SDK should not enroll              new users into the experiment that have not already been enrolled.",
+      "description": "When this property is set to true, the SDK should not enroll new users into the experiment that have not already been enrolled.",
       "type": "boolean"
     },
     "isRollout": {
-      "description": "When this property is set to true, treat this experiment               as a rollout. Rollouts are currently handled as single-branch               experiments separated from the bucketing namespace for normal experiments.               See-also: https://mozilla-hub.atlassian.net/browse/SDK-405",
+      "description": "When this property is set to true, treat this experiment as a rollout. Rollouts are currently handled as single-branch experiments separated from the bucketing namespace for normal experiments. See-also: https://mozilla-hub.atlassian.net/browse/SDK-405",
       "type": "boolean"
     },
     "bucketConfig": {
@@ -49,7 +49,7 @@
       "description": "Bucketing configuration."
     },
     "outcomes": {
-      "description": "List of outcomes relevant to analysis.",
+      "description": "A list of outcomes relevant to the experiment analysis.",
       "items": {
         "$ref": "#/$defs/ExperimentOutcome"
       },
@@ -83,7 +83,7 @@
           "type": "null"
         }
       ],
-      "description": "Actual publish date of the experiment.         Note that this value is expected to be null in Remote Settings."
+      "description": "Actual publish date of the experiment. Note that this value is expected to be null in Remote Settings."
     },
     "enrollmentEndDate": {
       "anyOf": [
@@ -95,7 +95,7 @@
           "type": "null"
         }
       ],
-      "description": "Actual enrollment end date of the experiment.             Note that this value is expected to be null in Remote Settings."
+      "description": "Actual enrollment end date of the experiment. Note that this value is expected to be null in Remote Settings."
     },
     "endDate": {
       "anyOf": [
@@ -107,14 +107,14 @@
           "type": "null"
         }
       ],
-      "description": "Actual end date of this experiment.              Note that this field is expected to be null in Remote Settings."
+      "description": "Actual end date of this experiment. Note that this field is expected to be null in Remote Settings."
     },
     "proposedDuration": {
-      "description": "Duration of the experiment from the start date in days.             Note that this property is only used during the analysis phase                 (i.e., not by the SDK).",
+      "description": "Duration of the experiment from the start date in days. Note that this property is only used during the analysis phase (i.e., not by the SDK).",
       "type": "integer"
     },
     "proposedEnrollment": {
-      "description": "This represents the number of days that we expect to             enroll new users. Note that this property is only used during                  the analysis phase (i.e., not by the SDK).",
+      "description": "This represents the number of days that we expect to enroll new users. Note that this property is only used during the analysis phase (i.e., not by the SDK).",
       "type": "integer"
     },
     "referenceBranch": {
@@ -126,7 +126,7 @@
           "type": "null"
         }
       ],
-      "description": "The slug of the reference branch             (i.e., the branch we consider \"control\")."
+      "description": "The slug of the reference branch (i.e., the branch we consider \"control\")."
     },
     "locales": {
       "anyOf": [
@@ -140,7 +140,7 @@
           "type": "null"
         }
       ],
-      "description": "The list of locale codes (e.g., \"en-US\" or \"fr\") that this             experiment is targeting. If null, all locales are targeted."
+      "description": "The list of locale codes (e.g., \"en-US\" or \"fr\") that this experiment is targeting. If null, all locales are targeted."
     },
     "publishedDate": {
       "anyOf": [
@@ -152,7 +152,7 @@
           "type": "null"
         }
       ],
-      "description": "The date that this experiment was first published to             Remote Settings. If null, it has not yet been published."
+      "description": "The date that this experiment was first published to Remote Settings. If null, it has not yet been published."
     },
     "branches": {
       "description": "Branch configuration for the experiment.",
@@ -162,7 +162,7 @@
       "type": "array"
     },
     "isFirefoxLabsOptIn": {
-      "description": "When this property is set to true, treat this experiment as a             Firefox Labs experiment",
+      "description": "When this property is set to true, treat this experiment as aFirefox Labs experiment",
       "type": "boolean"
     },
     "firefoxLabsGroup": {
@@ -213,14 +213,14 @@
           "type": "null"
         }
       ],
-      "description": "Links that will be used with the Firefox Labs             description Fluent ID. May be null for Firefox Labs Opt-In recipes                 that do not use links."
+      "description": "Links that will be used with the firefoxLabsDescription Fluent ID. May be null for Firefox Labs Opt-In recipes that do not use links."
     },
     "featureValidationOptOut": {
       "description": "Opt out of feature schema validation.",
       "type": "boolean"
     },
     "requiresRestart": {
-      "description": "Does the experiment require a restart to take effect?",
+      "description": "Does the experiment require a restart to take effect? Only used by Firefox Labs Opt-Ins.",
       "type": "boolean"
     },
     "localizations": {
@@ -300,7 +300,7 @@
           "type": "string"
         },
         "ratio": {
-          "description": "Relative ratio of population for the branch. e.g., if branch A=1 and branch B=3, then branch A                 would get 25% of the population.",
+          "description": "Relative ratio of population for the branch. e.g., if branch A=1 and branch B=3, then branch A would get 25% of the population.",
           "type": "integer"
         },
         "features": {
@@ -330,7 +330,6 @@
       "type": "object"
     },
     "ExperimentBucketConfig": {
-      "description": "Common Bucketing Configuration used across all versions.",
       "properties": {
         "randomizationUnit": {
           "$ref": "#/$defs/RandomizationUnit"
@@ -348,7 +347,7 @@
           "type": "integer"
         },
         "total": {
-          "description": "The total number of buckets. You can assume             this will always be 10000.",
+          "description": "The total number of buckets. You can assume this will always be 10000.",
           "type": "integer"
         }
       },

--- a/schemas/schemas/ExperimentBucketConfig.schema.json
+++ b/schemas/schemas/ExperimentBucketConfig.schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2019-09/schema",
   "title": "ExperimentBucketConfig",
-  "description": "Common Bucketing Configuration used across all versions.",
   "type": "object",
   "properties": {
     "randomizationUnit": {
@@ -20,7 +19,7 @@
       "type": "integer"
     },
     "total": {
-      "description": "The total number of buckets. You can assume             this will always be 10000.",
+      "description": "The total number of buckets. You can assume this will always be 10000.",
       "type": "integer"
     }
   },

--- a/schemas/schemas/NimbusExperimentV7.schema.json
+++ b/schemas/schemas/NimbusExperimentV7.schema.json
@@ -13,35 +13,35 @@
       "type": "string"
     },
     "id": {
-      "description": "Unique identifier for the experiment. This is a duplicate of slug,             but is required field for all Remote Settings records.",
+      "description": "Unique identifier for the experiiment. This is a duplicate of slug, but is required field for all Remote Settings records.",
       "type": "string"
     },
     "appName": {
-      "description": "A slug identifying the targeted product of this experiment.             It should be a lowercased_with_underscores name that is short and                 unambiguous and it should match the app_name found in                     https://probeinfo.telemetry.mozilla.org/glean/repositories.                         Examples are \"fenix\" and \"firefox_desktop\".",
+      "description": "A slug identifying the targeted product of this experiment. It should be a lowercased_with_underscores name that is short and unambiguous and it should match the app_name found in https://probeinfo.telemetry.mozilla.org/glean/repositories. Examples are \"fenix\" and \"firefox_desktop\".",
       "type": "string"
     },
     "appId": {
-      "description": "The platform identifier for the targeted app.             This should match app's identifier exactly as it appears in                 the relevant app store listing (for relevant platforms) or the app's                      Glean initialization (for other platforms). Examples are                       \"org.mozilla.firefox_beta\" and \"firefox-desktop\".",
+      "description": "The platform identifier for the targeted app. This should match app's identifier exactly as it appears in the relevant app store listing (for relevant platforms) or the app's Glean initialization (for other platforms). Examples are \"org.mozilla.firefox_beta\" and \"firefox-desktop\".",
       "type": "string"
     },
     "channel": {
-      "description": "A specific channel of an application such as 'nightly',             'beta', or 'release'.",
+      "description": "A specific channel of an application such as \"nightly\", \"beta\", or \"release\".",
       "type": "string"
     },
     "userFacingName": {
-      "description": "Public name of the experiment displayed on 'about:studies'.",
+      "description": "Public name of the experiment that will be displayed on \"about:studies\".",
       "type": "string"
     },
     "userFacingDescription": {
-      "description": "Short public description of the experiment.             that will be displayed on \"about:studies\".",
+      "description": "Short public description of the experiment that will be displayed on \"about:studies\".",
       "type": "string"
     },
     "isEnrollmentPaused": {
-      "description": "When this property is set to true, the SDK should not enroll              new users into the experiment that have not already been enrolled.",
+      "description": "When this property is set to true, the SDK should not enroll new users into the experiment that have not already been enrolled.",
       "type": "boolean"
     },
     "isRollout": {
-      "description": "When this property is set to true, treat this experiment               as a rollout. Rollouts are currently handled as single-branch               experiments separated from the bucketing namespace for normal experiments.               See-also: https://mozilla-hub.atlassian.net/browse/SDK-405",
+      "description": "When this property is set to true, treat this experiment as a rollout. Rollouts are currently handled as single-branch experiments separated from the bucketing namespace for normal experiments. See-also: https://mozilla-hub.atlassian.net/browse/SDK-405",
       "type": "boolean"
     },
     "bucketConfig": {
@@ -49,7 +49,7 @@
       "description": "Bucketing configuration."
     },
     "outcomes": {
-      "description": "List of outcomes relevant to analysis.",
+      "description": "A list of outcomes relevant to the experiment analysis.",
       "items": {
         "$ref": "#/$defs/ExperimentOutcome"
       },
@@ -83,7 +83,7 @@
           "type": "null"
         }
       ],
-      "description": "Actual publish date of the experiment.         Note that this value is expected to be null in Remote Settings."
+      "description": "Actual publish date of the experiment. Note that this value is expected to be null in Remote Settings."
     },
     "enrollmentEndDate": {
       "anyOf": [
@@ -95,7 +95,7 @@
           "type": "null"
         }
       ],
-      "description": "Actual enrollment end date of the experiment.             Note that this value is expected to be null in Remote Settings."
+      "description": "Actual enrollment end date of the experiment. Note that this value is expected to be null in Remote Settings."
     },
     "endDate": {
       "anyOf": [
@@ -107,14 +107,14 @@
           "type": "null"
         }
       ],
-      "description": "Actual end date of this experiment.              Note that this field is expected to be null in Remote Settings."
+      "description": "Actual end date of this experiment. Note that this field is expected to be null in Remote Settings."
     },
     "proposedDuration": {
-      "description": "Duration of the experiment from the start date in days.             Note that this property is only used during the analysis phase                 (i.e., not by the SDK).",
+      "description": "Duration of the experiment from the start date in days. Note that this property is only used during the analysis phase (i.e., not by the SDK).",
       "type": "integer"
     },
     "proposedEnrollment": {
-      "description": "This represents the number of days that we expect to             enroll new users. Note that this property is only used during                  the analysis phase (i.e., not by the SDK).",
+      "description": "This represents the number of days that we expect to enroll new users. Note that this property is only used during the analysis phase (i.e., not by the SDK).",
       "type": "integer"
     },
     "referenceBranch": {
@@ -126,7 +126,7 @@
           "type": "null"
         }
       ],
-      "description": "The slug of the reference branch             (i.e., the branch we consider \"control\")."
+      "description": "The slug of the reference branch (i.e., the branch we consider \"control\")."
     },
     "locales": {
       "anyOf": [
@@ -140,7 +140,7 @@
           "type": "null"
         }
       ],
-      "description": "The list of locale codes (e.g., \"en-US\" or \"fr\") that this             experiment is targeting. If null, all locales are targeted."
+      "description": "The list of locale codes (e.g., \"en-US\" or \"fr\") that this experiment is targeting. If null, all locales are targeted."
     },
     "publishedDate": {
       "anyOf": [
@@ -152,7 +152,7 @@
           "type": "null"
         }
       ],
-      "description": "The date that this experiment was first published to             Remote Settings. If null, it has not yet been published."
+      "description": "The date that this experiment was first published to Remote Settings. If null, it has not yet been published."
     },
     "localizations": {
       "anyOf": [
@@ -198,7 +198,7 @@
           "type": "string"
         },
         "ratio": {
-          "description": "Relative ratio of population for the branch. e.g., if branch A=1 and branch B=3, then branch A                 would get 25% of the population.",
+          "description": "Relative ratio of population for the branch. e.g., if branch A=1 and branch B=3, then branch A would get 25% of the population.",
           "type": "integer"
         },
         "features": {
@@ -217,7 +217,6 @@
       "type": "object"
     },
     "ExperimentBucketConfig": {
-      "description": "Common Bucketing Configuration used across all versions.",
       "properties": {
         "randomizationUnit": {
           "$ref": "#/$defs/RandomizationUnit"
@@ -235,7 +234,7 @@
           "type": "integer"
         },
         "total": {
-          "description": "The total number of buckets. You can assume             this will always be 10000.",
+          "description": "The total number of buckets. You can assume this will always be 10000.",
           "type": "integer"
         }
       },

--- a/schemas/schemas/SdkNimbusExperiment.schema.json
+++ b/schemas/schemas/SdkNimbusExperiment.schema.json
@@ -13,35 +13,35 @@
       "type": "string"
     },
     "id": {
-      "description": "Unique identifier for the experiment. This is a duplicate of slug,             but is required field for all Remote Settings records.",
+      "description": "Unique identifier for the experiiment. This is a duplicate of slug, but is required field for all Remote Settings records.",
       "type": "string"
     },
     "appName": {
-      "description": "A slug identifying the targeted product of this experiment.             It should be a lowercased_with_underscores name that is short and                 unambiguous and it should match the app_name found in                     https://probeinfo.telemetry.mozilla.org/glean/repositories.                         Examples are \"fenix\" and \"firefox_desktop\".",
+      "description": "A slug identifying the targeted product of this experiment. It should be a lowercased_with_underscores name that is short and unambiguous and it should match the app_name found in https://probeinfo.telemetry.mozilla.org/glean/repositories. Examples are \"fenix\" and \"firefox_desktop\".",
       "type": "string"
     },
     "appId": {
-      "description": "The platform identifier for the targeted app.             This should match app's identifier exactly as it appears in                 the relevant app store listing (for relevant platforms) or the app's                      Glean initialization (for other platforms). Examples are                       \"org.mozilla.firefox_beta\" and \"firefox-desktop\".",
+      "description": "The platform identifier for the targeted app. This should match app's identifier exactly as it appears in the relevant app store listing (for relevant platforms) or the app's Glean initialization (for other platforms). Examples are \"org.mozilla.firefox_beta\" and \"firefox-desktop\".",
       "type": "string"
     },
     "channel": {
-      "description": "A specific channel of an application such as 'nightly',             'beta', or 'release'.",
+      "description": "A specific channel of an application such as \"nightly\", \"beta\", or \"release\".",
       "type": "string"
     },
     "userFacingName": {
-      "description": "Public name of the experiment displayed on 'about:studies'.",
+      "description": "Public name of the experiment that will be displayed on \"about:studies\".",
       "type": "string"
     },
     "userFacingDescription": {
-      "description": "Short public description of the experiment.             that will be displayed on \"about:studies\".",
+      "description": "Short public description of the experiment that will be displayed on \"about:studies\".",
       "type": "string"
     },
     "isEnrollmentPaused": {
-      "description": "When this property is set to true, the SDK should not enroll              new users into the experiment that have not already been enrolled.",
+      "description": "When this property is set to true, the SDK should not enroll new users into the experiment that have not already been enrolled.",
       "type": "boolean"
     },
     "isRollout": {
-      "description": "When this property is set to true, treat this experiment               as a rollout. Rollouts are currently handled as single-branch               experiments separated from the bucketing namespace for normal experiments.               See-also: https://mozilla-hub.atlassian.net/browse/SDK-405",
+      "description": "When this property is set to true, treat this experiment as a rollout. Rollouts are currently handled as single-branch experiments separated from the bucketing namespace for normal experiments. See-also: https://mozilla-hub.atlassian.net/browse/SDK-405",
       "type": "boolean"
     },
     "bucketConfig": {
@@ -49,7 +49,7 @@
       "description": "Bucketing configuration."
     },
     "outcomes": {
-      "description": "List of outcomes relevant to analysis.",
+      "description": "A list of outcomes relevant to the experiment analysis.",
       "items": {
         "$ref": "#/$defs/ExperimentOutcome"
       },
@@ -83,7 +83,7 @@
           "type": "null"
         }
       ],
-      "description": "Actual publish date of the experiment.         Note that this value is expected to be null in Remote Settings."
+      "description": "Actual publish date of the experiment. Note that this value is expected to be null in Remote Settings."
     },
     "enrollmentEndDate": {
       "anyOf": [
@@ -95,7 +95,7 @@
           "type": "null"
         }
       ],
-      "description": "Actual enrollment end date of the experiment.             Note that this value is expected to be null in Remote Settings."
+      "description": "Actual enrollment end date of the experiment. Note that this value is expected to be null in Remote Settings."
     },
     "endDate": {
       "anyOf": [
@@ -107,14 +107,14 @@
           "type": "null"
         }
       ],
-      "description": "Actual end date of this experiment.              Note that this field is expected to be null in Remote Settings."
+      "description": "Actual end date of this experiment. Note that this field is expected to be null in Remote Settings."
     },
     "proposedDuration": {
-      "description": "Duration of the experiment from the start date in days.             Note that this property is only used during the analysis phase                 (i.e., not by the SDK).",
+      "description": "Duration of the experiment from the start date in days. Note that this property is only used during the analysis phase (i.e., not by the SDK).",
       "type": "integer"
     },
     "proposedEnrollment": {
-      "description": "This represents the number of days that we expect to             enroll new users. Note that this property is only used during                  the analysis phase (i.e., not by the SDK).",
+      "description": "This represents the number of days that we expect to enroll new users. Note that this property is only used during the analysis phase (i.e., not by the SDK).",
       "type": "integer"
     },
     "referenceBranch": {
@@ -126,7 +126,7 @@
           "type": "null"
         }
       ],
-      "description": "The slug of the reference branch             (i.e., the branch we consider \"control\")."
+      "description": "The slug of the reference branch (i.e., the branch we consider \"control\")."
     },
     "locales": {
       "anyOf": [
@@ -140,7 +140,7 @@
           "type": "null"
         }
       ],
-      "description": "The list of locale codes (e.g., \"en-US\" or \"fr\") that this             experiment is targeting. If null, all locales are targeted."
+      "description": "The list of locale codes (e.g., \"en-US\" or \"fr\") that this experiment is targeting. If null, all locales are targeted."
     },
     "publishedDate": {
       "anyOf": [
@@ -152,7 +152,7 @@
           "type": "null"
         }
       ],
-      "description": "The date that this experiment was first published to             Remote Settings. If null, it has not yet been published."
+      "description": "The date that this experiment was first published to Remote Settings. If null, it has not yet been published."
     },
     "branches": {
       "description": "Branch configuration for the SDK experiment.",
@@ -181,7 +181,6 @@
   ],
   "$defs": {
     "ExperimentBucketConfig": {
-      "description": "Common Bucketing Configuration used across all versions.",
       "properties": {
         "randomizationUnit": {
           "$ref": "#/$defs/RandomizationUnit"
@@ -199,7 +198,7 @@
           "type": "integer"
         },
         "total": {
-          "description": "The total number of buckets. You can assume             this will always be 10000.",
+          "description": "The total number of buckets. You can assume this will always be 10000.",
           "type": "integer"
         }
       },
@@ -264,7 +263,7 @@
           "type": "string"
         },
         "ratio": {
-          "description": "Relative ratio of population for the branch. e.g., if branch A=1 and branch B=3, then branch A                 would get 25% of the population.",
+          "description": "Relative ratio of population for the branch. e.g., if branch A=1 and branch B=3, then branch A would get 25% of the population.",
           "type": "integer"
         },
         "features": {


### PR DESCRIPTION
Because:

- The formatting of strings got messed up in #12170

This commit:

- Fixes the formatting; and
- Removes an unnecessary base class.

Fixes #12340