### PR TITLE
feat(schemas): Add documentationLinks to v7 experiment schema

### DIFF
--- a/schemas/index.d.ts
+++ b/schemas/index.d.ts
@@ -145,6 +145,7 @@ export interface DesktopAllVersionsNimbusExperiment {
    * If null, all locales are targeted.
    */
   locales?: string[] | null;
+  localizations?: ExperimentLocalizations | null;
   /**
    * The date that this experiment was first published to Remote Settings.
    *
@@ -187,7 +188,6 @@ export interface DesktopAllVersionsNimbusExperiment {
    * Only used by Firefox Labs Opt-Ins.
    */
   requiresRestart?: boolean;
-  localizations?: ExperimentLocalizations | null;
 }
 export interface ExperimentBucketConfig {
   randomizationUnit: RandomizationUnit;
@@ -219,6 +219,17 @@ export interface ExperimentOutcome {
    * e.g., "primary" or "secondary".
    */
   priority: string;
+}
+/**
+ * Per-locale localization substitutions.
+ *
+ * The top level key is the locale (e.g., "en-US" or "fr"). Each entry is a mapping of
+ * string IDs to their localized equivalents.
+ */
+export interface ExperimentLocalizations {
+  [k: string]: {
+    [k: string]: string;
+  };
 }
 /**
  * The branch definition supported on all Firefox Desktop versions.
@@ -267,17 +278,6 @@ export interface DesktopPre95FeatureConfig {
     [k: string]: unknown;
   };
   enabled: false;
-}
-/**
- * Per-locale localization substitutions.
- *
- * The top level key is the locale (e.g., "en-US" or "fr"). Each entry is a mapping of
- * string IDs to their localized equivalents.
- */
-export interface ExperimentLocalizations {
-  [k: string]: {
-    [k: string]: string;
-  };
 }
 /**
  * A Nimbus experiment for Firefox Desktop.
@@ -391,6 +391,7 @@ export interface DesktopNimbusExperiment {
    * If null, all locales are targeted.
    */
   locales?: string[] | null;
+  localizations?: ExperimentLocalizations | null;
   /**
    * The date that this experiment was first published to Remote Settings.
    *
@@ -433,7 +434,6 @@ export interface DesktopNimbusExperiment {
    * Only used by Firefox Labs Opt-Ins.
    */
   requiresRestart?: boolean;
-  localizations?: ExperimentLocalizations | null;
 }
 /**
  * The branch definition supported on Firefox Desktop 95+.
@@ -567,6 +567,10 @@ export interface SdkNimbusExperiment {
    * If null, all locales are targeted.
    */
   locales?: string[] | null;
+  /**
+   * Per-locale localization substitutions.
+   */
+  localizations?: ExperimentLocalizations | null;
   /**
    * The date that this experiment was first published to Remote Settings.
    *

--- a/schemas/mozilla_nimbus_schemas/experimenter_apis/common.py
+++ b/schemas/mozilla_nimbus_schemas/experimenter_apis/common.py
@@ -1,4 +1,3 @@
-# experimenter_apis/common.py
 import datetime
 from enum import Enum
 from typing import Any
@@ -214,6 +213,9 @@ class BaseExperiment(BaseModel):
             "If null, all locales are targeted."
         ),
         default=None,
+    )
+    localizations: ExperimentLocalizations | None = Field(
+        description="Per-locale localization substitutions.", default=None
     )
     publishedDate: datetime.datetime | None = Field(
         description=(

--- a/schemas/mozilla_nimbus_schemas/experimenter_apis/experiments_v7/experiments_v7.py
+++ b/schemas/mozilla_nimbus_schemas/experimenter_apis/experiments_v7/experiments_v7.py
@@ -1,19 +1,23 @@
-from pydantic import Field
+from pydantic import BaseModel, Field
 
 from mozilla_nimbus_schemas.experimenter_apis.common import (
     BaseExperiment,
     BaseExperimentBranch,
-    ExperimentLocalizations,
 )
+
+
+class DocumentationLink(BaseModel):
+    title: str = Field(description="The name associated with the link.")
+    link: str = Field(description="The URL associated with the link.")
 
 
 class NimbusExperimentV7(BaseExperiment):
     """A Nimbus experiment for V7."""
 
-    localizations: ExperimentLocalizations | None = Field(
-        description="Per-locale localization substitutions.", default=None
-    )
-
     branches: list[BaseExperimentBranch] = Field(
         description="Branch configuration for the experiment."
+    )
+
+    documentationLinks: list[DocumentationLink] = Field(
+        description="All documentation links associated with this experiment."
     )

--- a/schemas/mozilla_nimbus_schemas/tests/experiments_v7/fixtures/experiments_v7/desktop.json
+++ b/schemas/mozilla_nimbus_schemas/tests/experiments_v7/fixtures/experiments_v7/desktop.json
@@ -64,5 +64,11 @@
   "startDate": "2023-12-01",
   "targeting": "true",
   "userFacingDescription": "Testing upgrade spotlight holdback",
-  "userFacingName": "MR2 Upgrade Spotlight Holdback V7"
+  "userFacingName": "MR2 Upgrade Spotlight Holdback V7",
+  "documentationLinks": [
+    {
+      "title": "document title",
+      "link": "https://example.com"
+    }
+  ]
 }

--- a/schemas/mozilla_nimbus_schemas/tests/experiments_v7/fixtures/experiments_v7/sdk.json
+++ b/schemas/mozilla_nimbus_schemas/tests/experiments_v7/fixtures/experiments_v7/sdk.json
@@ -76,5 +76,6 @@
   "startDate": "2023-12-01",
   "targeting": "true",
   "userFacingDescription": "Testing mobile experiment for new tab experience",
-  "userFacingName": "Mobile Multi-Feature Test V7"
+  "userFacingName": "Mobile Multi-Feature Test V7",
+  "documentationLinks": []
 }

--- a/schemas/schemas/DesktopAllVersionsNimbusExperiment.schema.json
+++ b/schemas/schemas/DesktopAllVersionsNimbusExperiment.schema.json
@@ -142,6 +142,16 @@
       ],
       "description": "The list of locale codes (e.g., \"en-US\" or \"fr\") that this experiment is targeting. If null, all locales are targeted."
     },
+    "localizations": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/ExperimentLocalizations"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "publishedDate": {
       "anyOf": [
         {
@@ -222,16 +232,6 @@
     "requiresRestart": {
       "description": "Does the experiment require a restart to take effect? Only used by Firefox Labs Opt-Ins.",
       "type": "boolean"
-    },
-    "localizations": {
-      "anyOf": [
-        {
-          "$ref": "#/$defs/ExperimentLocalizations"
-        },
-        {
-          "type": "null"
-        }
-      ]
     }
   },
   "required": [

--- a/schemas/schemas/DesktopNimbusExperiment.schema.json
+++ b/schemas/schemas/DesktopNimbusExperiment.schema.json
@@ -142,6 +142,16 @@
       ],
       "description": "The list of locale codes (e.g., \"en-US\" or \"fr\") that this experiment is targeting. If null, all locales are targeted."
     },
+    "localizations": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/ExperimentLocalizations"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "publishedDate": {
       "anyOf": [
         {
@@ -222,16 +232,6 @@
     "requiresRestart": {
       "description": "Does the experiment require a restart to take effect? Only used by Firefox Labs Opt-Ins.",
       "type": "boolean"
-    },
-    "localizations": {
-      "anyOf": [
-        {
-          "$ref": "#/$defs/ExperimentLocalizations"
-        },
-        {
-          "type": "null"
-        }
-      ]
     }
   },
   "required": [

--- a/schemas/schemas/NimbusExperimentV7.schema.json
+++ b/schemas/schemas/NimbusExperimentV7.schema.json
@@ -142,6 +142,17 @@
       ],
       "description": "The list of locale codes (e.g., \"en-US\" or \"fr\") that this experiment is targeting. If null, all locales are targeted."
     },
+    "localizations": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/ExperimentLocalizations"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "description": "Per-locale localization substitutions."
+    },
     "publishedDate": {
       "anyOf": [
         {
@@ -154,21 +165,17 @@
       ],
       "description": "The date that this experiment was first published to Remote Settings. If null, it has not yet been published."
     },
-    "localizations": {
-      "anyOf": [
-        {
-          "$ref": "#/$defs/ExperimentLocalizations"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "Per-locale localization substitutions."
-    },
     "branches": {
       "description": "Branch configuration for the experiment.",
       "items": {
         "$ref": "#/$defs/BaseExperimentBranch"
+      },
+      "type": "array"
+    },
+    "documentationLinks": {
+      "description": "All documentation links associated with this experiment.",
+      "items": {
+        "$ref": "#/$defs/DocumentationLink"
       },
       "type": "array"
     }
@@ -188,7 +195,8 @@
     "endDate",
     "proposedEnrollment",
     "referenceBranch",
-    "branches"
+    "branches",
+    "documentationLinks"
   ],
   "$defs": {
     "BaseExperimentBranch": {
@@ -213,6 +221,23 @@
         "slug",
         "ratio",
         "features"
+      ],
+      "type": "object"
+    },
+    "DocumentationLink": {
+      "properties": {
+        "title": {
+          "description": "The name associated with the link.",
+          "type": "string"
+        },
+        "link": {
+          "description": "The URL associated with the link.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "title",
+        "link"
       ],
       "type": "object"
     },

--- a/schemas/schemas/SdkNimbusExperiment.schema.json
+++ b/schemas/schemas/SdkNimbusExperiment.schema.json
@@ -142,6 +142,17 @@
       ],
       "description": "The list of locale codes (e.g., \"en-US\" or \"fr\") that this experiment is targeting. If null, all locales are targeted."
     },
+    "localizations": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/ExperimentLocalizations"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "description": "Per-locale localization substitutions."
+    },
     "publishedDate": {
       "anyOf": [
         {
@@ -226,6 +237,16 @@
         "featureId",
         "value"
       ],
+      "type": "object"
+    },
+    "ExperimentLocalizations": {
+      "additionalProperties": {
+        "additionalProperties": {
+          "type": "string"
+        },
+        "type": "object"
+      },
+      "description": "Per-locale localization substitutions. The top level key is the locale (e.g., \"en-US\" or \"fr\"). Each entry is a mapping of string IDs to their localized equivalents.",
       "type": "object"
     },
     "ExperimentOutcome": {


### PR DESCRIPTION
Because:

- The v7 Experiment contains a documentationLinks field that does not appear in the schema; and
- The localizations field is included in all Experiment API responses

This commit:

- Adds the documentationLinks field to the v7 API; and
- Moves the localizations field into the common schema.

Fixes #12349