### PR TITLE
added the 10 min to 2 day old profile targeting

### DIFF
--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -88,7 +88,7 @@ HB_LESS_THAN_2_DAY_PROFILE = NimbusTargetingConfig(
     description="Profile between 10 minutes and 2 days old (used for HB surveys)",
     targeting="({is_older_than_10_min} && {is_newer_than_2_days})".format(
         is_older_than_10_min="(currentDate|date - profileAgeCreated|date) / 60000 > 10",
-        is_newer_than_2_days="(currentDate|date - profileAgeCreated|date) / 3600000 <= 48"
+        is_newer_than_2_days="(currentDate|date - profileAgeCreated|date) / 3600000 <= 48",
     ),
     desktop_telemetry="environment.profile.creation_date",
     sticky_required=True,

--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -86,9 +86,9 @@ HB_LESS_THAN_2_DAY_PROFILE = NimbusTargetingConfig(
     name="Heartbeat less than 2 day old profile",
     slug="hb_2_day_profile",
     description="Profile between 10 minutes and 2 days old (used for HB surveys)",
-    targeting="({is_older_than_10_min} && {is_newer_than_2_days})".format(
-        is_older_than_10_min="(currentDate|date - profileAgeCreated|date) / 60000 > 10",
-        is_newer_than_2_days="(currentDate|date - profileAgeCreated|date) / 3600000 <= 48",
+    targeting="({older_than_10_min} && {newer_than_2_days})".format(
+        older_than_10_min="(currentDate|date - profileAgeCreated|date) / 60000 > 10",
+        newer_than_2_days="(currentDate|date - profileAgeCreated|date) / 3600000 <= 48",
     ),
     desktop_telemetry="environment.profile.creation_date",
     sticky_required=True,

--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -82,6 +82,20 @@ NEW_PROFILE_CREATED = NimbusTargetingConfig(
     application_choice_names=(Application.DESKTOP.name,),
 )
 
+HB_LESS_THAN_2_DAY_PROFILE = NimbusTargetingConfig(
+    name="Heartbeat less than 2 day old profile",
+    slug="hb_2_day_profile",
+    description="Profile between 10 minutes and 2 days old (used for HB surveys)",
+    targeting="({is_older_than_10_min} && {is_newer_than_2_days})".format(
+        is_older_than_10_min="(currentDate|date - profileAgeCreated|date) / 60000 > 10",
+        is_newer_than_2_days="(currentDate|date - profileAgeCreated|date) / 3600000 <= 48"
+    ),
+    desktop_telemetry="environment.profile.creation_date",
+    sticky_required=True,
+    is_first_run_required=False,
+    application_choice_names=(Application.DESKTOP.name,),
+)
+
 NOT_NEW_PROFILE_CREATED = NimbusTargetingConfig(
     name="Not new profile created",
     slug="not_new_profile_created",


### PR DESCRIPTION
This targeting can be used for in-product surveys that want to talk to new profiles but also not bother them in the first few minutes. 

The targeting will be QA'ed along with the experimenter recipe that uses it. 