### PR TITLE
fix(nimbus): Update review request message for experiment enrollment

### DIFF
--- a/experimenter/experimenter/nimbus-ui/src/components/ChangeApprovalOperations/index.tsx
+++ b/experimenter/experimenter/nimbus-ui/src/components/ChangeApprovalOperations/index.tsx
@@ -131,7 +131,7 @@ export const ChangeApprovalOperations: React.FC<
             </LinkExternal>{" "}
             or a qualified reviewer to review and {actionDescription}. If you
             don’t have a team reviewer, paste the experiment URL in
-            #ask-experimenter and ask for a review to launch your experiment.{" "}
+            #ask-experimenter and ask for a review to end enrollment of your experiment.{" "}
             <a
               href="#copy"
               className="cursor-copy"


### PR DESCRIPTION
Because
there was typo in end enrollment error message
- Reason
to make more clarity

This commit

- Change
updated it to - paste the experiment URL in #ask-experimenter and ask for a review to end enrollment of your experiment.

Fixes #12347 