### PR TITLE
feat(nimbus): Override remote system access check pref in integration…

### DIFF
--- a/experimenter/tests/integration/nimbus/conftest.py
+++ b/experimenter/tests/integration/nimbus/conftest.py
@@ -110,6 +110,7 @@ def sensitive_url():
 def firefox_options(firefox_options):
     """Set Firefox Options."""
     firefox_options.log.level = "trace"
+    firefox_options.set_preference("remote.system-access-check.enabled", False)
     return firefox_options
 
 


### PR DESCRIPTION
… tests

Because:

- Firefox 138 now requires either a commandline flag or setting a pref to allow remote agents to run chrome JS

This commit:

- sets that pref in our integration tests.

Fixes #12377 