### PR TITLE
fix(nimbus): ingestion for ratio stats for custom metrics

### DIFF
--- a/experimenter/experimenter/jetstream/client.py
+++ b/experimenter/experimenter/jetstream/client.py
@@ -166,6 +166,7 @@ def get_other_metrics_names_and_map(
         Statistic.MEAN,
         Statistic.BINOMIAL,
         Statistic.PER_CLIENT_DAU_IMPACT,
+        Statistic.POPULATION_RATIO,
     ]
     other_data = [
         data_point for data_point in data if data_point.metric not in results_metrics_map

--- a/experimenter/experimenter/jetstream/tests/constants.py
+++ b/experimenter/experimenter/jetstream/tests/constants.py
@@ -736,7 +736,9 @@ class JetstreamTestData:
                         "some_count": ABSOLUTE_METRIC_DATA_A_COVARIATE.model_dump(
                             exclude_none=True
                         ),
-                        "some_ratio": EMPTY_METRIC_DATA.model_dump(exclude_none=True),
+                        "some_ratio": ABSOLUTE_METRIC_DATA_A.model_dump(
+                            exclude_none=True
+                        ),
                         "some_dau_impact": ABSOLUTE_METRIC_DATA_A.model_dump(
                             exclude_none=True
                         ),
@@ -802,7 +804,9 @@ class JetstreamTestData:
                         "some_count": ABSOLUTE_METRIC_DATA_F_COVARIATE.model_dump(
                             exclude_none=True
                         ),
-                        "some_ratio": EMPTY_METRIC_DATA.model_dump(exclude_none=True),
+                        "some_ratio": ABSOLUTE_METRIC_DATA_F.model_dump(
+                            exclude_none=True
+                        ),
                         "some_dau_impact": ABSOLUTE_METRIC_DATA_F.model_dump(
                             exclude_none=True
                         ),

--- a/experimenter/experimenter/jetstream/tests/test_tasks.py
+++ b/experimenter/experimenter/jetstream/tests/test_tasks.py
@@ -449,6 +449,7 @@ class TestFetchJetstreamDataTask(MockSizingDataMixin, TestCase):
                         "some_count": "Some Count",
                         "another_count": "Another Count",
                         "some_dau_impact": "Some Dau Impact",
+                        "some_ratio": "Some Ratio",
                     },
                 },
                 "metadata": {
@@ -1050,6 +1051,7 @@ class TestFetchJetstreamDataTask(MockSizingDataMixin, TestCase):
                         "some_count": "Some Count",
                         "another_count": "Another Count",
                         "some_dau_impact": "Some Dau Impact",
+                        "some_ratio": "Some Ratio",
                     },
                 },
                 "metadata": {},


### PR DESCRIPTION
Because

- we added population ratio stats to jetstream client
- we weren't ingesting population ratio results for custom config metrics

This commit

- fixes the ingestion to get these results for custom metrics (in addition to guardrails and outcomes)
- updates the tests

Fixes #12386 