### PR TITLE
fix(nimbus): Support multiple version files per app

### DIFF
--- a/experimenter/experimenter/features/manifests/apps.yaml
+++ b/experimenter/experimenter/features/manifests/apps.yaml
@@ -30,11 +30,14 @@ firefox_ios:
     - "nimbus.fml.yaml"
   release_discovery:
     version_file:
-      type: "plist"
-      path:
-        - "firefox-ios/Client/Info.plist"
-        - "Client/Info.plist"
-      key: "CFBundleShortVersionString"
+      - type: "plaintext"
+        path: "version.txt"
+      - type: "plist"
+        path: "firefox-ios/Client/Info.plist"
+        key: "CFBundleShortVersionString"
+      - type: "plist"
+        path: "Client/Info.plist"
+        key: "CFBundleShortVersionString"
     strategies:
       - type: "tagged"
         branch_re: 'release/v(?P<major>\d+)(?:\.(?P<minor>\d+))?'
@@ -66,11 +69,14 @@ focus_ios:
     - "focus-ios/nimbus.fml.yaml"
   release_discovery:
     version_file:
-      type: "plist"
-      path:
-        - "focus-ios/Blockzilla/Info.plist"
-        - "Blockzilla/Info.plist"
-      key: "CFBundleShortVersionString"
+      - type: "plaintext"
+        path: "version.txt"
+      - type: "plist"
+        path: "Blockzilla/Info.plist"
+        key: "CFBundleShortVersionString"
+      - type: "plist"
+        path: "Blockzilla/Info.plist"
+        key: "CFBundleShortVersionString"
     strategies:
       - type: "tagged"
         branch_re: 'release/v(?P<major>\d+)'

--- a/experimenter/manifesttool/tests/test_releases.py
+++ b/experimenter/manifesttool/tests/test_releases.py
@@ -66,7 +66,8 @@ def mocks_for_discover_tagged_releases(
     # Mocking plist files is more annoying.
     assert app_config.release_discovery is not None
     assert (
-        app_config.release_discovery.version_file.root.type == VersionFileType.PLAIN_TEXT
+        app_config.release_discovery.version_file[0].root.type
+        == VersionFileType.PLAIN_TEXT
     )
 
     # Ensure tags are defined if app specifies a tag regex.
@@ -84,7 +85,7 @@ def mocks_for_discover_tagged_releases(
     ):
         assert repo == app_config.repo.name
         assert download_path is None
-        assert path == app_config.release_discovery.version_file.root.path
+        assert path == app_config.release_discovery.version_file[0].root.path
         assert ref in ref_versions
 
         return str(ref_versions[ref])


### PR DESCRIPTION
Because:

- Firefox for iOS and Focus for iOS no longer have the current version in Info.plist files and now use a top-level version.txt as of v138; and
- we need to continue reading Info.plist for versions before 138

This commit:

- Adds support for manifesttool to specify multiple kinds of version files, not just multiple paths
- Updates the apps.yaml entries for Firefox for iOS and Focus for iOS.

Fixes #12416