### PR TITLE
fix(nimbus): Fix a typo in the focus_ios app definition

### DIFF
--- a/experimenter/experimenter/features/manifests/apps.yaml
+++ b/experimenter/experimenter/features/manifests/apps.yaml
@@ -72,7 +72,7 @@ focus_ios:
       - type: "plaintext"
         path: "version.txt"
       - type: "plist"
-        path: "Blockzilla/Info.plist"
+        path: "focus-ios/Blockzilla/Info.plist"
         key: "CFBundleShortVersionString"
       - type: "plist"
         path: "Blockzilla/Info.plist"


### PR DESCRIPTION
Because:

- I made a typo in #12417 that broke fetching for focus iOS

This commit:

- Fixes the typo.

Fixes #12418