### PR TITLE
chore(project): Bump our resource class for check CI jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,7 @@ jobs:
     machine:
       image: ubuntu-2004:2023.10.1
       docker_layer_caching: true
-    resource_class: large
+    resource_class: xlarge
     working_directory: ~/experimenter
     steps:
       - checkout


### PR DESCRIPTION
Because:

- our CI jobs for check_experimenter_x86_64 are timing out with 100% CPU usage

This commit:

- bumps our resource class for this jobs from large to xlarge.

Fixes #12424