### PR TITLE
chore(tests): Add chown command to fix integration tests docker permission error.

### DIFF
--- a/docker-compose-integration-test.yml
+++ b/docker-compose-integration-test.yml
@@ -11,6 +11,7 @@ services:
       - PYTEST_ARGS
       - INTEGRATION_TEST_KINTO_URL
       - INTEGRATION_TEST_NGINX_URL
+      - MOZ_REMOTE_SETTINGS_DEVTOOLS=1
     volumes:
       - .:/code
       - /code/experimenter/tests/integration/.tox

--- a/experimenter/tests/nimbus_integration_tests.sh
+++ b/experimenter/tests/nimbus_integration_tests.sh
@@ -47,6 +47,7 @@ esac
 curl -sSL https://install.python-poetry.org | python3 - --version 1.8.4
 sudo chmod -R a+rwx /code/experimenter/tests/integration/
 mkdir -m a+rwx -p /code/experimenter/tests/integration/test-reports
+sudo chown -R seluser /opt/venv/
 
 firefox --version
 


### PR DESCRIPTION
Because

- Selenium recently added a python virtual environment as part of their docker images but it is owned by `root` and the docker images are ran by `seluser`.

This commit

- Changes ownership of that directory so that the running user can access it.
- We also removed an environment variable in the docker image needed for testing against firefox release, this adds that back.

Fixes #12459 