### PR TITLE
feat(nimbus): Specify a User-Agent when fetching manifests

### DIFF
--- a/experimenter/manifesttool/download.py
+++ b/experimenter/manifesttool/download.py
@@ -1,11 +1,11 @@
 from pathlib import Path
 
-import requests
+from manifesttool.http import http_client
 
 
 def to_path(url: str, download_path: Path):
     """Download the given url to the given path."""
-    with requests.get(url, stream=True) as rsp:
+    with http_client().get(url, stream=True) as rsp:
         rsp.raise_for_status()
 
         with download_path.open("wb") as f:
@@ -15,7 +15,7 @@ def to_path(url: str, download_path: Path):
 
 def as_text(url: str) -> str:
     """Return the contents of the given URL."""
-    rsp = requests.get(url)
+    rsp = http_client().get(url)
     rsp.raise_for_status()
 
     return rsp.text

--- a/experimenter/manifesttool/github_api.py
+++ b/experimenter/manifesttool/github_api.py
@@ -1,11 +1,13 @@
 import os
 from pathlib import Path
-from typing import Any, Generator, Optional, overload
+from typing import Any, Generator, TYPE_CHECKING, Optional, overload
 
 import requests
 
 from manifesttool import download
+from manifesttool.http import http_client
 from manifesttool.repository import Ref
+
 
 GITHUB_API_URL = "https://api.github.com"
 GITHUB_API_HEADERS = {
@@ -22,7 +24,7 @@ def api_request(
 ) -> requests.Response:
     """Make a request to the GitHub API."""
     url = f"{GITHUB_API_URL}/{path}"
-    rsp = requests.get(url, headers=GITHUB_API_HEADERS, **kwargs)
+    rsp = http_client().get(url, headers=GITHUB_API_HEADERS, **kwargs)
 
     if rsp.status_code == 403:
         if rsp.headers.get("X-RateLimit-Remaining") == "0":

--- a/experimenter/manifesttool/hgmo_api.py
+++ b/experimenter/manifesttool/hgmo_api.py
@@ -2,9 +2,8 @@ from pathlib import Path
 from typing import Any, Optional, overload
 from urllib.parse import urlencode
 
-import requests
-
 from manifesttool import download
+from manifesttool.http import http_client
 from manifesttool.repository import Ref
 
 HGMO_URL = "https://hg.mozilla.org"
@@ -12,7 +11,7 @@ HGMO_URL = "https://hg.mozilla.org"
 
 def api_request(path: str, **kwargs) -> dict[str, Any]:
     """Make a request to hg.mozilla.org."""
-    return requests.get(f"{HGMO_URL}/{path}", **kwargs).json()
+    return http_client().get(f"{HGMO_URL}/{path}", **kwargs).json()
 
 
 def resolve_branch(repo: str, bookmark: str) -> Ref:

--- a/experimenter/manifesttool/http.py
+++ b/experimenter/manifesttool/http.py
@@ -1,0 +1,17 @@
+import requests
+
+_client = None
+
+
+def http_client():
+    global _client
+
+    if _client is None:
+        _client = requests.Session()
+        _client.headers.update(
+            {
+                "User-Agent": "experimenter-manifest-tool",
+            }
+        )
+
+    return _client


### PR DESCRIPTION
Because:

- we are being blocked from hg.mozilla.org because we have a generic user agent

This commit:

- adds a user agent to manifesttool

Fixes #12464