### PR TITLE
chore(ci): Remove docker login from fenix builder job.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -645,9 +645,6 @@ jobs:
       - checkout
       - check_file_paths:
           paths: "experimenter/experimenter/targeting|experimenter/experimenter/experiments|experimenter/tests/firefox_fenix_beta_build.env|experimenter/tests/firefox_fenix_release_build.env"
-      - docker_login:
-          username: $DOCKER_USER
-          password: $DOCKER_PASS
       - run:
           name: Build and upload images
           command: |


### PR DESCRIPTION
Because

- We no longer use docker hub to store our docker images, and the login steps are causing the job to fail on CI

This commit

- Removes the login steps from the Firefox Fenix APK builder job.

Fixes #12463 