### PR TITLE
chore(ci): Fix fenix APK builder paths.

### DIFF
--- a/experimenter/tests/integration/nimbus/android/moz-central.test-container.Dockerfile
+++ b/experimenter/tests/integration/nimbus/android/moz-central.test-container.Dockerfile
@@ -41,6 +41,6 @@ RUN ./mach build
 
 RUN cd mobile/android/fenix \
     && ./gradlew clean app:assembleFenixDebug \
-    && mv app/build/outputs/apk/fenix/debug/app-fenix-x86_64-debug.apk ./ \
+    && mv /mozilla-central/objdir-frontend/gradle/build/mobile/android/fenix/app/outputs/apk/fenix/debug/app-fenix-x86_64-debug.apk ./ \
     && ./gradlew clean app:assembleFenixDebugAndroidTest \
-    && mv app/build/outputs/apk/androidTest/fenix/debug/app-fenix-debug-androidTest.apk ./
+    && mv /mozilla-central/objdir-frontend/gradle/build/mobile/android/fenix/app/outputs/apk/androidTest/fenix/debug/app-fenix-debug-androidTest.apk ./


### PR DESCRIPTION
Because

- The paths for the build APK files we use for the fenix builder job have changed recently and so our CI job is failing to find them.

This commit

- Updates the APK builder dockerfile to the new paths.

Fixes #12470 