### PR TITLE
chore(tests): Reduce base timeout for integration tests.

### DIFF
--- a/experimenter/tests/integration/nimbus/pages/base.py
+++ b/experimenter/tests/integration/nimbus/pages/base.py
@@ -10,7 +10,7 @@ class Base(Page):
     """Base page."""
 
     def __init__(self, selenium, base_url, **kwargs):
-        super().__init__(selenium, base_url, timeout=500, **kwargs)
+        super().__init__(selenium, base_url, timeout=120, **kwargs)
 
     def wait_for_page_to_load(self):
         self.wait.until(EC.presence_of_element_located(self._page_wait_locator))


### PR DESCRIPTION
Because

- We changed the base page timeout of our integration tests to 500 seconds.

This commit

- Changes it to a more reasonable 120 seconds.

Fixes #12478 