### PR TITLE
feat(nimbus): lag one day before reporting results fetch error

### DIFF
--- a/experimenter/experimenter/jetstream/client.py
+++ b/experimenter/experimenter/jetstream/client.py
@@ -1,6 +1,6 @@
 import json
 from collections import defaultdict
-from datetime import date, datetime
+from datetime import date, datetime, timedelta
 from itertools import chain
 from pathlib import Path
 
@@ -346,10 +346,11 @@ def get_experiment_data(experiment: NimbusExperiment):
 
     for e in runtime_errors:
         # only store runtime errors for overall window if we expect those results
+        # (and lag by one day so there is time for analysis to complete)
         if "overall.json" not in e or (
             "overall.json" in e
             and experiment.end_date
-            and experiment.end_date < date.today()
+            and experiment.end_date < (date.today() - timedelta(days=1))
         ):
             analysis_error = AnalysisError(
                 experiment=experiment.slug,

--- a/experimenter/experimenter/jetstream/tests/test_tasks.py
+++ b/experimenter/experimenter/jetstream/tests/test_tasks.py
@@ -2115,14 +2115,17 @@ class TestFetchJetstreamDataTask(MockSizingDataMixin, TestCase):
 
     @parameterized.expand(
         [
-            (NimbusExperimentFactory.Lifecycles.CREATED,),
-            (NimbusExperimentFactory.Lifecycles.ENDING_APPROVE_APPROVE,),
+            (NimbusExperimentFactory.Lifecycles.CREATED, 1),
+            (NimbusExperimentFactory.Lifecycles.ENDING_APPROVE_APPROVE, 1),
+            (NimbusExperimentFactory.Lifecycles.ENDING_APPROVE_APPROVE, 2),
         ]
     )
-    def test_results_data_null(self, lifecycle):
+    def test_results_data_null(self, lifecycle, offset):
         primary_outcome = "default-browser"
         experiment = NimbusExperimentFactory.create_with_lifecycle(
-            lifecycle, primary_outcomes=[primary_outcome]
+            lifecycle,
+            primary_outcomes=[primary_outcome],
+            end_date=datetime.date.today() - datetime.timedelta(days=offset),
         )
 
         now = timezone.now()
@@ -2190,7 +2193,10 @@ class TestFetchJetstreamDataTask(MockSizingDataMixin, TestCase):
                     + "Z",
                 },
             ]
-            if lifecycle == NimbusExperimentFactory.Lifecycles.ENDING_APPROVE_APPROVE:
+            if (
+                lifecycle == NimbusExperimentFactory.Lifecycles.ENDING_APPROVE_APPROVE
+                and offset > 1
+            ):
                 experiment_errors.append(
                     {
                         "analysis_basis": None,


### PR DESCRIPTION
Because

- Jetstream runs at approx 4am UTC daily
- Experimenter's results fetch occurs every 2 hours
- experiment results are expected based on dates (not times)
- results fetch expects results the day after the experiment ends, but results are never available the first few fetches due to the time between 12am and whenever jetstream finishes analysis
- it is confusing to see an error on the Results UI when you expect to see results

This commit

- waits a day before reporting any errors in fetching results to allow for jetstream to complete

Fixes #12379 