### PR TITLE
chore(tests): Extend base timeout for integration tests.

### DIFF
--- a/experimenter/tests/integration/nimbus/pages/base.py
+++ b/experimenter/tests/integration/nimbus/pages/base.py
@@ -10,7 +10,7 @@ class Base(Page):
     """Base page."""
 
     def __init__(self, selenium, base_url, **kwargs):
-        super().__init__(selenium, base_url, timeout=120, **kwargs)
+        super().__init__(selenium, base_url, timeout=300, **kwargs)
 
     def wait_for_page_to_load(self):
         self.wait.until(EC.presence_of_element_located(self._page_wait_locator))


### PR DESCRIPTION
Because

- We keep seeing timeout related errors within our integration tests that are quite hard to pinpoint.

This commit

- Extends the base page timeout for the entire test suite. This has seemed to help during my testing.

Fixes #12517 