### PR TITLE
feat(nimbus): Update targeting for non_sidebar_users to include "side…

### DIFF
--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -2461,6 +2461,7 @@ NON_SIDEBAR_USERS = NimbusTargetingConfig(
     slug="non_sidebar_users",
     description="Target users who have never used the new or old sidebar",
     targeting=(
+        "!('sidebar.old-sidebar.has-used'|preferenceValue) && "
         "!('sidebar.revamp'|preferenceValue) && "
         "!('browser.engagement.sidebar-button.has-used'|preferenceValue) && "
         "primaryResolution.width > 1366 && "


### PR DESCRIPTION
…bar.old-sidebar.has-used" pref

Because

- This pref was introduced in 137 after the initial targeting patch. Whilst it won't help with pre 137 sidebar users, it will help weed out sidebar user 137 onwards.

This commit

- Adds this pref to the targeting

Fixes [Bug 1943195](https://bugzilla.mozilla.org/show_bug.cgi?id=1943195)