### PR TITLE
feat(nimbus): add labs filter to landing page

### DIFF
--- a/experimenter/experimenter/nimbus_ui_new/filtersets.py
+++ b/experimenter/experimenter/nimbus_ui_new/filtersets.py
@@ -48,6 +48,7 @@ STATUS_FILTERS = {
 class TypeChoices(models.TextChoices):
     ROLLOUT = "Rollout"
     EXPERIMENT = "Experiment"
+    LABS = "Labs"
 
 
 class SortChoices(models.TextChoices):
@@ -286,6 +287,8 @@ class NimbusExperimentFilter(django_filters.FilterSet):
             query |= Q(is_rollout=False)
         if TypeChoices.ROLLOUT in value:
             query |= Q(is_rollout=True)
+        if TypeChoices.LABS in value:
+            query |= Q(is_firefox_labs_opt_in=True)
         return queryset.filter(query)
 
     def filter_takeaways(self, queryset, name, values):

--- a/experimenter/experimenter/nimbus_ui_new/tests/test_views.py
+++ b/experimenter/experimenter/nimbus_ui_new/tests/test_views.py
@@ -248,17 +248,22 @@ class NimbusExperimentsListViewTest(AuthTestCase):
 
     @parameterized.expand(
         (
-            (TypeChoices.ROLLOUT, True),
-            (TypeChoices.EXPERIMENT, False),
+            (TypeChoices.ROLLOUT, True, False),
+            (TypeChoices.EXPERIMENT, False, False),
+            (TypeChoices.LABS, False, True),
         )
     )
-    def test_filter_type(self, type_choice, is_rollout):
+    def test_filter_type(self, type_choice, is_rollout, is_labs):
         experiment = NimbusExperimentFactory.create(
-            status=NimbusExperiment.Status.LIVE, is_rollout=is_rollout
+            status=NimbusExperiment.Status.LIVE,
+            is_rollout=is_rollout,
+            is_firefox_labs_opt_in=is_labs,
         )
         [
             NimbusExperimentFactory.create(
-                status=NimbusExperiment.Status.LIVE, is_rollout=(not is_rollout)
+                status=NimbusExperiment.Status.LIVE,
+                is_rollout=(not is_rollout),
+                is_firefox_labs_opt_in=(not is_labs),
             )
             for _i in range(3)
         ]


### PR DESCRIPTION
Becuase

* Now that we have labs support, we should add labs as an option in the type filter

This commit

* Adds labs as an option in the type filter

fixes #12306

