### PR TITLE
chore(nimbus): set use_group_id to true for clones

### DIFF
--- a/experimenter/experimenter/experiments/models.py
+++ b/experimenter/experimenter/experiments/models.py
@@ -1489,6 +1489,7 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
         cloned.takeaways_metric_gain = False
         cloned.takeaways_gain_amount = None
         cloned.takeaways_qbr_learning = False
+        cloned.use_group_id = True
         cloned._start_date = None
         cloned._end_date = None
         cloned._enrollment_end_date = None

--- a/experimenter/experimenter/experiments/tests/test_models.py
+++ b/experimenter/experimenter/experiments/tests/test_models.py
@@ -3011,6 +3011,7 @@ class TestNimbusExperiment(TestCase):
             NimbusExperimentFactory.Lifecycles.LIVE_DIRTY,
             is_rollout=True,
             is_rollout_dirty=True,
+            use_group_id=False,
         )
         rollout_branch = parent.branches.first()
         child = self._clone_experiment_and_assert_common_expectations(
@@ -3043,6 +3044,7 @@ class TestNimbusExperiment(TestCase):
         self.assertEqual(child.takeaways_metric_gain, False)
         self.assertEqual(child.takeaways_qbr_learning, False)
         self.assertEqual(child.takeaways_summary, None)
+        self.assertEqual(child.use_group_id, True)
         self.assertEqual(child.conclusion_recommendations, [])
         self.assertEqual(child.qa_status, NimbusExperiment.QAStatus.NOT_SET)
         self.assertEqual(child.qa_comment, None)


### PR DESCRIPTION
Becuase

* We recently changed the default randomization unit on desktop to group_id
* Clones of experiments before that change will still fall back to normandy_id
* We need to force clones to switch to group_id

This commit

* Forces use_group_id to true for cloned experiments

fixes #12558

