### PR TITLE
feat(nimbus): add save and continue redirects to new nimbus forms

### DIFF
--- a/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/edit_audience.html
+++ b/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/edit_audience.html
@@ -201,7 +201,10 @@
     </div>
     <div class="d-flex justify-content-end">
       <button type="submit" class="btn btn-primary">Save</button>
-      <button type="submit" class="btn btn-secondary ms-2">Save and Continue</button>
+      <button type="submit"
+              name="save_action"
+              value="continue"
+              class="btn btn-secondary ms-2">Save and Continue</button>
     </div>
     {% if form.is_bound %}
       {% if form.is_valid %}

--- a/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/edit_branches.html
+++ b/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/edit_branches.html
@@ -173,7 +173,10 @@
     </div>
     <div class="d-flex justify-content-end">
       <button type="submit" class="btn btn-primary">Save</button>
-      <button type="submit" class="btn btn-secondary ms-2">Save and Continue</button>
+      <button type="submit"
+              name="save_action"
+              value="continue"
+              class="btn btn-secondary ms-2">Save and Continue</button>
     </div>
     {% if form.is_bound %}
       <div class="toast text-bg-success position-fixed top-0 end-0 m-3 w-auto"

--- a/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/edit_metrics.html
+++ b/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/edit_metrics.html
@@ -78,8 +78,11 @@
       </div>
     </div>
     <div class="d-flex justify-content-end">
-      <button class="btn btn-primary">Save</button>
-      <button class="btn btn-secondary ms-2">Save and Continue</button>
+      <button type="submit" class="btn btn-primary">Save</button>
+      <button type="submit"
+              name="save_action"
+              value="continue"
+              class="btn btn-secondary ms-2">Save and Continue</button>
     </div>
     {% if form.is_bound %}
       <div class="toast text-bg-success position-absolute top-0 end-0 m-3 w-auto"

--- a/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/edit_overview.html
+++ b/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/edit_overview.html
@@ -194,7 +194,10 @@
     </div>
     <div class="d-flex justify-content-end">
       <button type="submit" class="btn btn-primary">Save</button>
-      <button type="submit" class="btn btn-secondary ms-2">Save and Continue</button>
+      <button type="submit"
+              name="save_action"
+              value="continue"
+              class="btn btn-secondary ms-2">Save and Continue</button>
     </div>
     {% if form.is_bound %}
       {% if form.is_valid %}

--- a/experimenter/experimenter/nimbus_ui_new/views.py
+++ b/experimenter/experimenter/nimbus_ui_new/views.py
@@ -343,7 +343,22 @@ class ToggleArchiveView(
         return response
 
 
+class SaveAndContinueMixin:
+    def form_valid(self, form):
+        response = super().form_valid(form)
+        if (
+            self.request.headers.get("HX-Request")
+            and self.request.POST.get("save_action") == "continue"
+        ):
+            response = HttpResponse()
+            response.headers["HX-Redirect"] = reverse(
+                self.continue_url_name, kwargs={"slug": self.object.slug}
+            )
+        return response
+
+
 class OverviewUpdateView(
+    SaveAndContinueMixin,
     NimbusExperimentViewMixin,
     RequestFormMixin,
     RenderResponseMixin,
@@ -353,6 +368,7 @@ class OverviewUpdateView(
 ):
     form_class = OverviewForm
     template_name = "nimbus_experiments/edit_overview.html"
+    continue_url_name = "nimbus-new-update-branches"
 
 
 class DocumentationLinkCreateView(RenderParentDBResponseMixin, OverviewUpdateView):
@@ -372,8 +388,8 @@ class BranchesPartialUpdateView(RenderDBResponseMixin, BranchesBaseView):
     pass
 
 
-class BranchesUpdateView(RenderResponseMixin, BranchesBaseView):
-    pass
+class BranchesUpdateView(SaveAndContinueMixin, RenderResponseMixin, BranchesBaseView):
+    continue_url_name = "nimbus-new-update-metrics"
 
 
 class BranchCreateView(RenderParentDBResponseMixin, BranchesBaseView):
@@ -385,6 +401,7 @@ class BranchDeleteView(RenderParentDBResponseMixin, BranchesBaseView):
 
 
 class MetricsUpdateView(
+    SaveAndContinueMixin,
     NimbusExperimentViewMixin,
     RequestFormMixin,
     RenderResponseMixin,
@@ -393,9 +410,11 @@ class MetricsUpdateView(
 ):
     form_class = MetricsForm
     template_name = "nimbus_experiments/edit_metrics.html"
+    continue_url_name = "nimbus-new-update-audience"
 
 
 class AudienceUpdateView(
+    SaveAndContinueMixin,
     NimbusExperimentViewMixin,
     RequestFormMixin,
     RenderResponseMixin,
@@ -405,6 +424,7 @@ class AudienceUpdateView(
 ):
     form_class = AudienceForm
     template_name = "nimbus_experiments/edit_audience.html"
+    continue_url_name = "nimbus-new-detail"
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)


### PR DESCRIPTION
Because

* We want the Save and Continue buttons on all the new Nimbus UI forms to save and redirect to the next form

This commit

* Adds a mixin to handle redirecting to the next form or the summary page after the audience form
* Updates the save buttons in the templates
* Adds tests

fixes #11400

