### PR TITLE
feat(nimbus): add advanced targeting for bottom toolbar users

### DIFF
--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -1949,6 +1949,17 @@ IOS_DEFAULT_BROWSER_FIRST_RUN_USER = NimbusTargetingConfig(
     application_choice_names=(Application.IOS.name,),
 )
 
+IOS_BOTTOM_TOOLBAR_USER = NimbusTargetingConfig(
+    name="Existing Bottom Toolbar Users",
+    slug="ios_bottom_toolbar_user",
+    description="Users that already have a preference set to bottom for the toolbar",
+    targeting="ios_bottom_toolbar_user == true",
+    desktop_telemetry="",
+    sticky_required=False,
+    is_first_run_required=False,
+    application_choice_names=(Application.IOS.name,),
+)
+
 IOS_IPHONE_USERS_ONLY = NimbusTargetingConfig(
     name="iPhone users only",
     slug="ios_iphone_users_only",

--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -1953,7 +1953,7 @@ IOS_BOTTOM_TOOLBAR_USER = NimbusTargetingConfig(
     name="Existing Bottom Toolbar Users",
     slug="ios_bottom_toolbar_user",
     description="Users that already have a preference set to bottom for the toolbar",
-    targeting="ios_bottom_toolbar_user == true",
+    targeting="is_bottom_toolbar_user == true",
     desktop_telemetry="",
     sticky_required=False,
     is_first_run_required=False,

--- a/experimenter/tests/integration/nimbus/test_mobile_targeting.py
+++ b/experimenter/tests/integration/nimbus/test_mobile_targeting.py
@@ -99,6 +99,7 @@ def test_check_mobile_targeting(
             "is_phone": True,
             "is_review_checker_enabled": True,
             "is_default_browser": True,
+            "is_bottom_toolbar_user": True,
             "install_referrer_response_utm_source": "test",
             "number_of_app_launches": 1,
         }


### PR DESCRIPTION
Because

* Andy requested the ability to target existing users who have set the toolbar to the bottom

This commit

* Adds advanced targeting to do exactly that

Fixes mozilla-mobile/firefox-ios#26646

Related [PR](https://github.com/mozilla-mobile/firefox-ios/pull/26647) on FXiOS side