### PR TITLE
chore(nimbus): Set Cross-Origin-Opener-Policy response header

### DIFF
--- a/experimenter/experimenter/openidc/middleware.py
+++ b/experimenter/experimenter/openidc/middleware.py
@@ -51,7 +51,9 @@ class OpenIDCAuthMiddleware(AuthenticationMiddleware):
         request.user = user
 
         if self.get_response:
-            return self.get_response(request)
+            response = self.get_response(request)
+            response.headers["Cross-Origin-Opener-Policy"] = "same-origin"
+            return response
 
 
 class OpenIDCRestFrameworkAuthenticator(SessionAuthentication):

--- a/experimenter/experimenter/openidc/tests/test_middleware.py
+++ b/experimenter/experimenter/openidc/tests/test_middleware.py
@@ -10,7 +10,8 @@ from experimenter.openidc.middleware import OpenIDCAuthMiddleware
 
 class OpenIDCAuthMiddlewareTests(TestCase):
     def setUp(self):
-        self.response = "Response"
+        self.response = mock.Mock()
+        self.response.headers = {}
         self.middleware = OpenIDCAuthMiddleware(lambda request: self.response)
 
         mock_resolve_patcher = mock.patch("experimenter.openidc.middleware.resolve")
@@ -61,6 +62,7 @@ class OpenIDCAuthMiddlewareTests(TestCase):
             response = self.middleware(request)
 
         self.assertEqual(response, self.response)
+        self.assertEqual(response.headers["Cross-Origin-Opener-Policy"], "same-origin")
         self.assertEqual(User.objects.all().count(), 1)
 
         self.assertEqual(request.user.email, user_email)


### PR DESCRIPTION
Becuase

* We must set the Cross-Origin-Opener-Policy header to prevent auth tokens from leaking

This commit

* Sets the Cross-Origin-Opener-Policy header to same-origin

fixes #12636

