### PR TITLE
feat(nimbus): add advanced targeting for users with notifications

### DIFF
--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -1960,6 +1960,17 @@ IOS_BOTTOM_TOOLBAR_USER = NimbusTargetingConfig(
     application_choice_names=(Application.IOS.name,),
 )
 
+IOS_TIPS_NOTIFICATIONS_ENABLED_USER = NimbusTargetingConfig(
+    name="Users With Tips Notifications Enabled",
+    slug="ios_tips_notifications_enabled_user",
+    description="Users that already have enabled notifications for tips and features",
+    targeting="has_enabled_tips_notifications == true",
+    desktop_telemetry="",
+    sticky_required=False,
+    is_first_run_required=False,
+    application_choice_names=(Application.IOS.name,),
+)
+
 IOS_IPHONE_USERS_ONLY = NimbusTargetingConfig(
     name="iPhone users only",
     slug="ios_iphone_users_only",

--- a/experimenter/tests/integration/nimbus/test_mobile_targeting.py
+++ b/experimenter/tests/integration/nimbus/test_mobile_targeting.py
@@ -100,6 +100,7 @@ def test_check_mobile_targeting(
             "is_review_checker_enabled": True,
             "is_default_browser": True,
             "is_bottom_toolbar_user": True,
+            "has_enabled_tips_notifications": True,
             "install_referrer_response_utm_source": "test",
             "number_of_app_launches": 1,
         }


### PR DESCRIPTION
Because

we want to be able to target users with notifications enabled for tips and features

This commit

allows that to happen

Fixes[ #26683](https://github.com/mozilla-mobile/firefox-ios/issues/26683). Related [iOS PR](https://github.com/mozilla-mobile/firefox-ios/pull/26729)