### PR TITLE
feat(nimbus): add custom targeting for users with large screen devices

### DIFF
--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -2092,6 +2092,18 @@ ANDROID_DMA_USERS_ONLY = NimbusTargetingConfig(
     application_choice_names=(Application.FENIX.name,),
 )
 
+
+ANDROID_LARGE_SCREEN_USERS_ONLY = NimbusTargetingConfig(
+    name="Large screen device users only",
+    slug="large_screen_device_users_only",
+    description="Targeting users who have large screen devices",
+    targeting="is_large_device",
+    desktop_telemetry="",
+    sticky_required=False,
+    is_first_run_required=False,
+    application_choice_names=(Application.FENIX.name,),
+)
+
 DEFAULT_PDF_IS_DIFFERENT_BROWSER = NimbusTargetingConfig(
     name="Default PDF handler is a different browser",
     slug="default_pdf_is_different_browser",

--- a/experimenter/tests/integration/nimbus/test_mobile_targeting.py
+++ b/experimenter/tests/integration/nimbus/test_mobile_targeting.py
@@ -103,6 +103,7 @@ def test_check_mobile_targeting(
             "has_enabled_tips_notifications": True,
             "install_referrer_response_utm_source": "test",
             "number_of_app_launches": 1,
+            "is_large_device": True,
         }
     )
     client = sdk_client(load_app_context(context))


### PR DESCRIPTION
Because

it's required to target users with large screen devices

This commit

adds the custom targeting keys for experimenter

Fixes #12644