### PR TITLE
feat(nimbus): add end date filter to v8 api

### DIFF
--- a/docs/experimenter/openapi-schema.json
+++ b/docs/experimenter/openapi-schema.json
@@ -2032,6 +2032,15 @@
             }
           },
           {
+            "name": "end_date",
+            "required": false,
+            "in": "query",
+            "description": "end_date",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
             "name": "application",
             "required": false,
             "in": "query",
@@ -2128,6 +2137,15 @@
                 "Live",
                 "Complete"
               ]
+            }
+          },
+          {
+            "name": "end_date",
+            "required": false,
+            "in": "query",
+            "description": "end_date",
+            "schema": {
+              "type": "string"
             }
           },
           {

--- a/docs/experimenter/swagger-ui.html
+++ b/docs/experimenter/swagger-ui.html
@@ -2044,6 +2044,15 @@
             }
           },
           {
+            "name": "end_date",
+            "required": false,
+            "in": "query",
+            "description": "end_date",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
             "name": "application",
             "required": false,
             "in": "query",
@@ -2140,6 +2149,15 @@
                 "Live",
                 "Complete"
               ]
+            }
+          },
+          {
+            "name": "end_date",
+            "required": false,
+            "in": "query",
+            "description": "end_date",
+            "schema": {
+              "type": "string"
             }
           },
           {

--- a/experimenter/experimenter/experiments/api/v8/views.py
+++ b/experimenter/experimenter/experiments/api/v8/views.py
@@ -26,9 +26,19 @@ class BaseExperimentFilterSet(FilterSet):
 
 
 class NimbusExperimentFilterSet(BaseExperimentFilterSet):
+    end_date = filters.DateFilter(
+        field_name="_end_date",
+        lookup_expr="gte",
+    )
+
     class Meta:
         model = NimbusExperiment
-        fields = (*BaseExperimentFilterSet.Meta.fields, "is_first_run", "status")
+        fields = (
+            *BaseExperimentFilterSet.Meta.fields,
+            "is_first_run",
+            "status",
+            "end_date",
+        )
 
 
 class NimbusDraftExperimentFilterSet(BaseExperimentFilterSet):


### PR DESCRIPTION
Becuase

* We only need to query recently ended experiments to process analysis in jetstream
* We can add a date filter to the v8 api to reduce querying past experiments unnecessarily

This commit

* Adds an end date filter to the v8 api

fixes #12657

