### PR TITLE
feat(nimbus): add proposed release date to audience form

### DIFF
--- a/experimenter/experimenter/experiments/models.py
+++ b/experimenter/experimenter/experiments/models.py
@@ -664,6 +664,10 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
         return self.application == self.Application.DESKTOP
 
     @property
+    def is_mobile(self):
+        return self.Application.is_mobile(self.application)
+
+    @property
     def is_draft(self):
         return (
             self.status == self.Status.DRAFT
@@ -921,8 +925,12 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
 
     @property
     def computed_end_date(self):
+        if self.status == self.Status.DRAFT:
+            return None
+
         if self._computed_end_date:
             return self._computed_end_date
+
         end_date = self._get_computed_end_date()
         self.update_computed_end_date(end_date)
         return end_date

--- a/experimenter/experimenter/experiments/tests/test_models.py
+++ b/experimenter/experimenter/experiments/tests/test_models.py
@@ -1600,6 +1600,13 @@ class TestNimbusExperiment(TestCase):
             experiment.proposed_duration,
         )
 
+    def test_computed_end_date_returns_None_for_draft(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+        )
+
+        self.assertIsNone(experiment.computed_end_date)
+
     def test_computed_end_date_returns_proposed(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.LIVE_PAUSED,

--- a/experimenter/experimenter/nimbus_ui_new/forms.py
+++ b/experimenter/experimenter/nimbus_ui_new/forms.py
@@ -780,6 +780,7 @@ class AudienceForm(NimbusChangeLogFormMixin, forms.ModelForm):
         widget=MultiSelectWidget(),
     )
     is_sticky = forms.BooleanField(required=False)
+    is_first_run = forms.BooleanField(required=False)
     population_percent = forms.DecimalField(
         required=False, widget=forms.NumberInput(attrs={"class": "form-control"})
     )
@@ -792,6 +793,10 @@ class AudienceForm(NimbusChangeLogFormMixin, forms.ModelForm):
     proposed_duration = forms.IntegerField(
         required=False, widget=forms.NumberInput(attrs={"class": "form-control"})
     )
+    proposed_release_date = forms.DateField(
+        required=False,
+        widget=forms.DateInput(attrs={"type": "date", "class": "form-control"}),
+    )
 
     class Meta:
         model = NimbusExperiment
@@ -802,11 +807,13 @@ class AudienceForm(NimbusChangeLogFormMixin, forms.ModelForm):
             "firefox_max_version",
             "firefox_min_version",
             "is_sticky",
+            "is_first_run",
             "languages",
             "locales",
             "population_percent",
             "proposed_duration",
             "proposed_enrollment",
+            "proposed_release_date",
             "required_experiments_branches",
             "targeting_config_slug",
             "total_enrolled_clients",
@@ -821,6 +828,17 @@ class AudienceForm(NimbusChangeLogFormMixin, forms.ModelForm):
             for channel in NimbusExperiment.Channel
             if channel in self.instance.application_config.channel_app_id
         ]
+
+        self.fields["is_first_run"].widget.attrs.update(
+            {
+                "hx-post": reverse(
+                    "nimbus-new-update-audience", kwargs={"slug": self.instance.slug}
+                ),
+                "hx-trigger": "change",
+                "hx-select": "#first-run-fields",
+                "hx-target": "#first-run-fields",
+            }
+        )
 
     def setup_initial_experiments_branches(self, field_name):
         self.initial[field_name] = [

--- a/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/detail.html
+++ b/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/detail.html
@@ -259,6 +259,14 @@
             <th>Sticky enrollment</th>
             <td colspan="3">{{ experiment.is_sticky }}</td>
           </tr>
+          {% if experiment.is_mobile %}
+            <tr>
+              <th>First Run Experiment</th>
+              <td>{{ experiment.is_first_run }}</td>
+              <th>First Run Release Date</th>
+              <td>{{ experiment.proposed_release_date }}</td>
+            </tr>
+          {% endif %}
           <tr>
             <th>Required experiments</th>
             <td>

--- a/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/edit_audience.html
+++ b/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/edit_audience.html
@@ -129,6 +129,40 @@
             {% for error in validation_errors.is_sticky %}<div class="form-text text-danger">{{ error }}</div>{% endfor %}
           </div>
         </div>
+        {% if experiment.is_mobile %}
+          <div id="first-run-fields">
+            <div class="row mb-4">
+              <div class="col">
+                {{ form.is_first_run|add_error_class:"is-invalid" }}
+                <label for="id_is_first_run">First run experiment</label>
+                {% for error in form.is_first_run.errors %}<div class="invalid-feedback">{{ error }}</div>{% endfor %}
+                {% for error in validation_errors.is_first_run %}<div class="form-text text-danger">{{ error }}</div>{% endfor %}
+              </div>
+            </div>
+            <div class="row mb-4">
+              <div class="col">
+                <label class="mb-2" for="id_proposed_release_date">
+                  First Run Release Date
+                  <a href="https://whattrainisitnow.com/" target="_blank">
+                    <i class="fa-regular fa-circle-question"
+                       data-bs-toggle="tooltip"
+                       data-bs-placement="top"
+                       data-bs-title="This is the approximate release date of the version that is being targeted. Click here to find your date!"></i>
+                  </a>
+                </label>
+                {% if experiment.is_first_run %}
+                  {{ form.proposed_release_date|add_error_class:"is-invalid" }}
+                {% else %}
+                  {{ form.proposed_release_date|add_error_class:"is-invalid"|attr:"disabled:disabled" }}
+                {% endif %}
+                {% for error in form.proposed_release_date.errors %}<div class="invalid-feedback">{{ error }}</div>{% endfor %}
+                {% for error in validation_errors.proposed_release_date %}
+                  <div class="form-text text-danger">{{ error }}</div>
+                {% endfor %}
+              </div>
+            </div>
+          </div>
+        {% endif %}
         <div class="card bg-body-tertiary border-0 p-4">
           <p class="text-secondary mb-4">
             Please ask a data scientist to help you determine these values.


### PR DESCRIPTION
Becuase

* We need the proposed release date for the audience form for mobile clients

This commit

* Adds the is first run checkbox to the audience page for mobile clients
* Adds the proposed release date selector for mobile clients
* Adds the first run and release date fields to the audience card on the summary page for mobile clients

fixes #11945

