### PR TITLE
Add 4GB of RAM or more target

### DIFF
--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -2318,6 +2318,7 @@ IS_4GB_RAM = NimbusTargetingConfig(
     sticky_required=False,
     is_first_run_required=False,
     application_choice_names=(Application.DESKTOP.name,),
+)
 
 IS_64BIT_WITH_8GB_RAM = NimbusTargetingConfig(
     name="64bit Firefox build running on a computer with at least 8GB of RAM",


### PR DESCRIPTION
adds targeting for devices with 4GB or more of system memory

Because

- to use in an experiment to target users meeting the minimum requirements of a new feature

This commit

- adds a targeting rule for 4GB of system memory or more