### PR TITLE
chore(nimbus): disable reportargumenttype in pyright

### DIFF
--- a/experimenter/pyproject.toml
+++ b/experimenter/pyproject.toml
@@ -94,6 +94,9 @@ exclude = [
     "**/tests",
 ]
 
+reportAttributeAccessIssue = false
+reportIndexIssue = false
+reportArgumentType = false
 reportCallInDefaultInitializer = true
 reportConstantRedefinition = false
 reportFunctionMemberAccess = false


### PR DESCRIPTION
Becuase

* We use pyright to do some type checking in our Python code
* There is an argument called reportArgumentType that we didn't specify
* A new version of VSCode/Pylance is now spuriously reporting errors becuase we didn't disable this rule

This commit

* Disables the reportArgumentType rule in pyright

fixes #12739

