### PR TITLE
chore(nimbus): remove feature manifest django system check

### DIFF
--- a/experimenter/experimenter/features/__init__.py
+++ b/experimenter/experimenter/features/__init__.py
@@ -7,7 +7,6 @@ from typing import Optional
 
 import yaml
 from django.conf import settings
-from django.core.checks import Error, register
 from mozilla_nimbus_schemas.experiments.feature_manifests import (
     DesktopFeature,
     DesktopFeatureManifest,
@@ -170,14 +169,3 @@ class Features:
     @classmethod
     def versioned(cls) -> Iterable[Feature]:
         return (f for f in cls.all() if f.version is not None)
-
-
-@register()
-def check_features(app_configs, **kwargs):
-    errors = []
-
-    try:
-        Features.all()
-    except Exception as e:
-        errors.append(Error(f"Error loading feature data {e}"))
-    return errors

--- a/experimenter/experimenter/features/tests/test_features.py
+++ b/experimenter/experimenter/features/tests/test_features.py
@@ -1,5 +1,4 @@
 import json
-import re
 
 from django.test import TestCase
 from mozilla_nimbus_schemas.experiments.feature_manifests import (
@@ -14,10 +13,8 @@ from experimenter.experiments.models import NimbusExperiment
 from experimenter.features import (
     Feature,
     Features,
-    check_features,
 )
 from experimenter.features.tests import (
-    mock_invalid_features,
     mock_invalid_remote_schema_features,
     mock_remote_schema_features,
     mock_valid_features,
@@ -181,35 +178,7 @@ class TestRemoteSchemaFeatures(TestCase):
         self.assertIsNone(desktop_feature.get_jsonschema())
 
 
-class TestCheckFeatures(TestCase):
-    maxDiff = None
-
-    def setUp(self):
+class TestValidateFeatureManifests(TestCase):
+    def test_valid_feature_manifest_for_application(self):
         Features.clear_cache()
-
-    @mock_valid_features
-    def test_valid_features_do_not_trigger_check_error(self):
-        errors = check_features(None)
-        self.assertEqual(errors, [])
-
-    @mock_invalid_features
-    def test_invalid_features_do_trigger_check_error(self):
-        errors = check_features(None)
-        self.assertEqual(len(errors), 1)
-
-        # Strip Pydantic version from URL before comparing
-        actual_msg = re.sub(
-            r"https://errors\.pydantic\.dev/\d+\.\d+/v/",
-            "https://errors.pydantic.dev/x/v/",
-            errors[0].msg,
-        )
-        expected_msg = (
-            "Error loading feature data 1 validation error for "
-            "DesktopFeatureManifest\n"
-            "readerMode.variables\n"
-            "  Input should be a valid dictionary [type=dict_type, "
-            "input_value=[{'fallbackPref': 'reader...pty string is no CTA)'}],"
-            " input_type=list]\n"
-            "    For further information visit https://errors.pydantic.dev/x/v/dict_type"
-        )
-        self.assertEqual(actual_msg, expected_msg)
+        Features.all()


### PR DESCRIPTION
Becuase

* We added a django system check to validate that the feature manifests will load correctly
* This lets us quickly verify that the feature manifest files are valid before starting the service
* However, we also run the system checks as part of the heartbeat endpoint, which is probed regularly by the infrastructure management tools
* As the number of feature manifest files grows, the amount of time to load and verify all that data increases
* We recently saw that the heartbeat endpoint was hanging and killing the python request handler processes
* We already validate the feature manifest files during deploys as part of the load_feature_manifests step
* So we don't need to repeatedly reload and validate them on each heartbeat call, which can happen frequently

This commit

* Removes the django system check that loads and validates the feature manifests
* Adds a unit test to load and validate the feature manifests so that we can still validate them in CI

fixes #12742

