### PR TITLE
fix #12775 (constants): set sticky_required=True for all signed-out targets

### DIFF
--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -2502,7 +2502,7 @@ SIGNED_OUT_USER = NimbusTargetingConfig(
     description="Users who are NOT signed into FxA",
     targeting="!isFxASignedIn",
     desktop_telemetry="",
-    sticky_required=False,
+    sticky_required=True,
     is_first_run_required=False,
     application_choice_names=(Application.DESKTOP.name,),
 )
@@ -2665,7 +2665,7 @@ SIGNED_OUT_EARLY_DAY_USER = NimbusTargetingConfig(
     description="Early day users who are NOT signed into FxA",
     targeting=f"{PROFILELESSTHAN28DAYS} && !isFxASignedIn",
     desktop_telemetry="",
-    sticky_required=False,
+    sticky_required=True,
     is_first_run_required=False,
     application_choice_names=(Application.DESKTOP.name,),
 )
@@ -2676,7 +2676,7 @@ SIGNED_OUT_EXISTING_USER = NimbusTargetingConfig(
     description="Existing users who are NOT signed into FxA",
     targeting=f"{PROFILE28DAYS} && !isFxASignedIn",
     desktop_telemetry="",
-    sticky_required=False,
+    sticky_required=True,
     is_first_run_required=False,
     application_choice_names=(Application.DESKTOP.name,),
 )


### PR DESCRIPTION
Because experiments that target signed-out users are typically used to get them to sign-in, this commit sets `sticky_required=True` for all signed-out targets, so the users won't be unenrolled as soon as they sign in.

Fixes #12775 