### PR TITLE
chore(nimbus): Update klaatu client to accept a list of branches.

### DIFF
--- a/experimenter/experimenter/klaatu/client.py
+++ b/experimenter/experimenter/klaatu/client.py
@@ -71,7 +71,7 @@ class KlaatuClient:
     def run_test(
         self,
         experiment_slug: str,
-        branch_slug: str,
+        branch_slugs: list[str],
         targets: list[Union[KlaatuTargets, str]],
     ) -> None:
         path = KlaatuEndpoints.DISPATCH.format(workflow=self.workflow_name)
@@ -81,7 +81,7 @@ class KlaatuClient:
             "ref": "main",
             "inputs": {
                 "slug": experiment_slug,
-                "branch": json.dumps([branch_slug]),
+                "branch": json.dumps(branch_slugs),
                 "firefox-version": json.dumps(targets),
             },
         }

--- a/experimenter/experimenter/klaatu/tests/test_client.py
+++ b/experimenter/experimenter/klaatu/tests/test_client.py
@@ -23,7 +23,7 @@ class TestKlaatuClient(unittest.TestCase):
 
         self.client.run_test(
             experiment_slug="training-only-for-dev-tools",
-            branch_slug="control",
+            branch_slugs=["control"],
             targets=[KlaatuTargets.LATEST_BETA, "137.0"],
         )
 
@@ -33,7 +33,7 @@ class TestKlaatuClient(unittest.TestCase):
         mock_post.return_value.text = "Bad Request"
 
         with self.assertRaises(KlaatuError) as error:
-            self.client.run_test("slug", "branch", [KlaatuTargets.LATEST_RELEASE])
+            self.client.run_test("slug", ["branch"], [KlaatuTargets.LATEST_RELEASE])
 
         self.assertIn("Failed to trigger workflow", str(error.exception))
 


### PR DESCRIPTION
Because

- We want all available branches to be tested at once when a klaatu job triggers

This commit

- Updates the klaatu client to send a list of branches instead of just 1.

Fixes #12784 