### PR TITLE
feat(nimbus): Show rollout version warning

### DIFF
--- a/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/detail.html
+++ b/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/detail.html
@@ -50,10 +50,12 @@
         <ul class="mb-1">
           {% for slug in warning.slugs %}<li>{{ slug }}</li>{% endfor %}
         </ul>
-        <a href="{{ warning.learn_more_link }}"
-           target="_blank"
-           rel="noopener noreferrer"
-           class="btn btn-link p-0">Learn more</a>
+        {% if warning.learn_more_link %}
+          <a href="{{ warning.learn_more_link }}"
+             target="_blank"
+             rel="noopener noreferrer"
+             class="btn btn-link p-0">Learn more</a>
+        {% endif %}
       </div>
     {% endfor %}
   {% endif %}


### PR DESCRIPTION
Because

- We want to warn users if they select a version that can prevent them from adjusting the population size while the rollout is live.

This commit

- Shows the warning according to the selected application- "WARNING: Adjusting the population size while the rollout is live is not supported for Firefox Desktop versions under 115.0."

Fixes #12752 

<img width="1327" alt="Screenshot 2025-06-16 at 2 14 47 PM" src="https://github.com/user-attachments/assets/b077e83c-cba2-4f0b-99d8-6f82cce51994" />

