### PR TITLE
feat(nimbus): Adds new advanced targeting - Windows 10+ and backgroudTaskMode and 1hr+ of inactivity (CFR only)

### DIFF
--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -1542,17 +1542,18 @@ WINDOWS_10_PLUS_BACKGROUND_TASK_NOTIFICATION_1HR_INACTIVITY = NimbusTargetingCon
     application_choice_names=(Application.DESKTOP.name,),
 )
 
-WINDOWS_10_PLUS_BACKGROUND_TASK_NOTIFICATION_1HR_INACTIVITY_CFR_ONLY = NimbusTargetingConfig(
-    name=(
-        "Windows 10+ users w/ background task notification "
-        "and 1hr+ of inactivity (CFR only)"
-    ),
-    slug="windows10_background_task_notification_1hr_inactivity_CFR_only",
-    description=(
-        "Windows 10+ users with 1hr+ of inactivity in the past day "
-        "who are running a background task with CFR enabled"
-    ),
-    targeting="""
+WINDOWS_10_PLUS_BACKGROUND_TASK_NOTIFICATION_1HR_INACTIVITY_CFR_ONLY = (
+    NimbusTargetingConfig(
+        name=(
+            "Windows 10+ users w/ background task notification "
+            "and 1hr+ of inactivity (CFR only)"
+        ),
+        slug="windows10_background_task_notification_1hr_inactivity_CFR_only",
+        description=(
+            "Windows 10+ users with 1hr+ of inactivity in the past day "
+            "who are running a background task with CFR enabled"
+        ),
+        targeting="""
     (
         (
             os.isWindows
@@ -1569,10 +1570,11 @@ WINDOWS_10_PLUS_BACKGROUND_TASK_NOTIFICATION_1HR_INACTIVITY_CFR_ONLY = NimbusTar
         'browser.newtabpage.activity-stream.asrouter.userprefs.cfr.features'|preferenceValue
     )
     """,
-    desktop_telemetry="",
-    sticky_required=True,
-    is_first_run_required=False,
-    application_choice_names=(Application.DESKTOP.name,),
+        desktop_telemetry="",
+        sticky_required=True,
+        is_first_run_required=False,
+        application_choice_names=(Application.DESKTOP.name,),
+    )
 )
 
 NEWTAB_SPONSORED_TOPSITES_ENABLED = NimbusTargetingConfig(

--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -1542,6 +1542,39 @@ WINDOWS_10_PLUS_BACKGROUND_TASK_NOTIFICATION_1HR_INACTIVITY = NimbusTargetingCon
     application_choice_names=(Application.DESKTOP.name,),
 )
 
+WINDOWS_10_PLUS_BACKGROUND_TASK_NOTIFICATION_1HR_INACTIVITY_CFR_ONLY = NimbusTargetingConfig(
+    name=(
+        "Windows 10+ users w/ background task notification "
+        "and 1hr+ of inactivity (CFR only)"
+    ),
+    slug="windows10_background_task_notification_1hr_inactivity_CFR_only",
+    description=(
+        "Windows 10+ users with 1hr+ of inactivity in the past day "
+        "who are running a background task with CFR enabled"
+    ),
+    targeting="""
+    (
+        (
+            os.isWindows
+            &&
+            (os.windowsVersion >= 10)
+        )
+        &&
+        (
+            ((currentDate|date - defaultProfile.currentDate|date) / 3600000 >= 1)
+        )
+        &&
+        isBackgroundTaskMode
+        &&
+        'browser.newtabpage.activity-stream.asrouter.userprefs.cfr.features'|preferenceValue
+    )
+    """,
+    desktop_telemetry="",
+    sticky_required=True,
+    is_first_run_required=False,
+    application_choice_names=(Application.DESKTOP.name,),
+)
+
 NEWTAB_SPONSORED_TOPSITES_ENABLED = NimbusTargetingConfig(
     name="Newtab has Sponsored TopSites enabled ",
     slug="newtab_sponsored_topsites_enabled",


### PR DESCRIPTION
Because

- We'd like to expand on the targeting added in https://github.com/mozilla/experimenter/pull/12314 to respect CFR pref for an upcoming rollout of the following [experiment](https://docs.google.com/document/d/170-BQ5rOhESZeymUZtnVwn2NCpSHEssoGZMJ-cXgHto/edit?tab=t.0)

This commit

- Adds the CFR pref check

Fixes #12800