### PR TITLE
fix(nimbus): if available, show results regardless of date

### DIFF
--- a/experimenter/experimenter/experiments/models.py
+++ b/experimenter/experimenter/experiments/models.py
@@ -1384,15 +1384,18 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
             results_data = self.results_data["v3"]
             for window in ["overall", "weekly"]:
                 if results_data.get(window):
-                    enrollments = results_data[window].get("enrollments", {}).get("all")
-                    if enrollments is not None:
-                        return True
+                    for base in ["enrollments", "exposures"]:
+                        base_results = results_data[window].get(base, {}).get("all")
+                        if base_results is not None:
+                            return True
 
         return False
 
     @property
     def show_results_url(self):
-        return self.has_displayable_results and self.results_ready and not self.is_rollout
+        # if there are results, show them! even if the dates are wrong
+        # (the dates may have been overridden in metric-hub)
+        return not self.is_rollout and self.has_displayable_results
 
     @property
     def results_expected_date(self):

--- a/experimenter/experimenter/experiments/tests/test_models.py
+++ b/experimenter/experimenter/experiments/tests/test_models.py
@@ -2640,12 +2640,24 @@ class TestNimbusExperiment(TestCase):
 
         self.assertFalse(experiment.has_displayable_results)
 
-    def test_show_results_url_true(self):
+    @parameterized.expand(
+        [
+            (
+                {"v3": {"overall": {"enrollments": {"all": {}}}}},
+                datetime.date.today(),
+            ),
+            (
+                {"v3": {"weekly": {"exposures": {"all": {}}}}},
+                datetime.date(2020, 1, 1),
+            ),
+        ]
+    )
+    def test_show_results_url_true(self, results_data, start_date):
         lifecycle = NimbusExperimentFactory.Lifecycles.LIVE_APPROVE_APPROVE
         experiment = NimbusExperimentFactory.create_with_lifecycle(
-            lifecycle, start_date=datetime.date(2020, 1, 1), proposed_enrollment=2
+            lifecycle, start_date=start_date, proposed_enrollment=2
         )
-        experiment.results_data = {"v3": {"overall": {"enrollments": {"all": {}}}}}
+        experiment.results_data = results_data
         experiment.is_rollout = False
         experiment.save()
 
@@ -2655,12 +2667,12 @@ class TestNimbusExperiment(TestCase):
         [
             ({}, datetime.date(2020, 1, 1), False),
             (
-                {"v3": {"overall": {"enrollments": {"all": {}}}}},
+                {"v3": {"weekly": {}}},
                 datetime.date.today(),
                 False,
             ),
             (
-                {"v3": {"overall": {"enrollments": {"all": {}}}}},
+                {"v3": {"overall": {"exposures": {"all": {}}}}},
                 datetime.date(2020, 1, 1),
                 True,
             ),


### PR DESCRIPTION
Because

- a custom config can override dates without Experimenter's knowledge
- Jetstream uses the custom config dates to compute results 

This commit

- ignores dates when determining whether the Results link should be shown

Fixes #12806