### PR TITLE
feat(nimbus): Adds one-off advanced targeting - Whats New Notification Sidebar Vertical Tabs Rollout (excluding experiment treatment)

### DIFF
--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -1589,9 +1589,26 @@ WHATS_NEW_NOTIFICATION_SIDEBAR_VERTICAL_TABS_ROLLOUT = NimbusTargetingConfig(
         "who are running a background task with CFR enabled and "
         "not enrolled in treatment-a of WNN sidebar/vertical tabs experiment"
     ),
-    targeting=(
-        f"{WINDOWS_10_PLUS_BACKGROUND_TASK_NOTIFICATION_1HR_INACTIVITY_CFR_ONLY.targeting} && ((defaultProfile.enrollmentsMap['whats-new-notification-sidebarvertical-tabs'] == 'treatment-a') == false)"
-    ),
+    targeting="""
+    (
+        (
+            os.isWindows
+            &&
+            (os.windowsVersion >= 10)
+        )
+        &&
+        (
+            ((currentDate|date - defaultProfile.currentDate|date) / 3600000 >= 1)
+        )
+        &&
+        isBackgroundTaskMode
+        &&
+        'browser.newtabpage.activity-stream.asrouter.userprefs.cfr.features'|preferenceValue
+        &&
+        ((defaultProfile.enrollmentsMap['whats-new-notification-sidebarvertical-tabs']
+        == 'treatment-a') == false)
+    )
+    """,
     desktop_telemetry="",
     sticky_required=True,
     is_first_run_required=False,

--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -1577,6 +1577,27 @@ WINDOWS_10_PLUS_BACKGROUND_TASK_NOTIFICATION_1HR_INACTIVITY_CFR_ONLY = (
     )
 )
 
+WHATS_NEW_NOTIFICATION_SIDEBAR_VERTICAL_TABS_ROLLOUT = NimbusTargetingConfig(
+    name=(
+        "Windows 10+ users with 1hr+ of inactivity in the past day "
+        "who are running a background task with CFR enabled and "
+        "not enrolled in treatment-a of WNN sidebar/vertical tabs experiment"
+    ),
+    slug="whats_new_notification_sidebar_vertical_tabs_rollout",
+    description=(
+        "Windows 10+ users with 1hr+ of inactivity in the past day "
+        "who are running a background task with CFR enabled and "
+        "not enrolled in treatment-a of WNN sidebar/vertical tabs experiment"
+    ),
+    targeting=(
+        f"{WINDOWS_10_PLUS_BACKGROUND_TASK_NOTIFICATION_1HR_INACTIVITY_CFR_ONLY.targeting} && ((defaultProfile.enrollmentsMap['whats-new-notification-sidebarvertical-tabs'] == 'treatment-a') == false)"
+    ),
+    desktop_telemetry="",
+    sticky_required=True,
+    is_first_run_required=False,
+    application_choice_names=(Application.DESKTOP.name,),
+)
+
 NEWTAB_SPONSORED_TOPSITES_ENABLED = NimbusTargetingConfig(
     name="Newtab has Sponsored TopSites enabled ",
     slug="newtab_sponsored_topsites_enabled",


### PR DESCRIPTION
Because

- For the this [rollout](https://experimenter.services.mozilla.com/nimbus/whats-new-notification-sidebarvertical-tabs-rollout/summary) we'd like to avoid enrolling users who saw the treatment branch of the original experiment but because of the nature of the [backgroundTaskMessage feature](https://searchfox.org/mozilla-central/source/toolkit/components/backgroundtasks/tests/xpcshell/test_backgroundtask_experiments.js#322), we need to check the defaultProfile for the user's experiments.

This commit

- Adds the treatment branch exclusion to the [experiment targeting](https://github.com/mozilla/experimenter/issues/12800) 

Fixes #12814