### PR TITLE
feat(nimbus): Disable/enable forms

### DIFF
--- a/experimenter/experimenter/experiments/models.py
+++ b/experimenter/experimenter/experiments/models.py
@@ -1033,7 +1033,6 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
         return None
 
     def sidebar_links(self, current_path):
-        # Determine editability based on status
         is_draft = self.is_draft
         is_live_rollout = self.is_rollout and self.is_enrolling
 
@@ -1059,7 +1058,7 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
             },
             {
                 "title": "Results",
-                "link": "",  # Real URL later
+                "link": "",
                 "icon": "fa-solid fa-chart-column",
                 "active": False,
                 "disabled": True,

--- a/experimenter/experimenter/experiments/models.py
+++ b/experimenter/experimenter/experiments/models.py
@@ -1032,6 +1032,69 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
             return (self.computed_end_date - enrollment_end_date).days
         return None
 
+    def sidebar_links(self, current_path):
+        # Determine editability based on status
+        is_draft = self.is_draft
+        is_live_rollout = self.is_rollout and self.is_enrolling
+
+        def is_edit_enabled(section):
+            if is_draft:
+                return True
+            return bool(section == "Audience" and is_live_rollout)
+
+        return [
+            {
+                "title": "Summary",
+                "link": self.get_detail_url(),
+                "icon": "fa-regular fa-paper-plane",
+                "active": current_path == self.get_detail_url(),
+                "disabled": False,
+            },
+            {
+                "title": "History",
+                "link": self.get_history_url(),
+                "icon": "fa-solid fa-network-wired",
+                "active": current_path == self.get_history_url(),
+                "disabled": False,
+            },
+            {
+                "title": "Results",
+                "link": "",  # Real URL later
+                "icon": "fa-solid fa-chart-column",
+                "active": False,
+                "disabled": True,
+            },
+            {"title": "Edit", "is_header": True},
+            {
+                "title": "Overview",
+                "link": self.get_update_overview_url(),
+                "icon": "fa-solid fa-gear",
+                "active": current_path == self.get_update_overview_url(),
+                "disabled": not is_edit_enabled("Overview"),
+            },
+            {
+                "title": "Branches",
+                "link": self.get_update_branches_url(),
+                "icon": "fa-solid fa-layer-group",
+                "active": current_path == self.get_update_branches_url(),
+                "disabled": not is_edit_enabled("Branches"),
+            },
+            {
+                "title": "Metrics",
+                "link": self.get_update_metrics_url(),
+                "icon": "fa-solid fa-arrow-trend-up",
+                "active": current_path == self.get_update_metrics_url(),
+                "disabled": not is_edit_enabled("Metrics"),
+            },
+            {
+                "title": "Audience",
+                "link": self.get_update_audience_url(),
+                "icon": "fa-solid fa-user-group",
+                "active": current_path == self.get_update_audience_url(),
+                "disabled": not is_edit_enabled("Audience"),
+            },
+        ]
+
     def timeline(self):
         timeline_entries = [
             {

--- a/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/experiment_base.html
+++ b/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/experiment_base.html
@@ -8,7 +8,7 @@
 {% block main_content_header %}
   <div class="row mb-2">
     <!-- Experiment Details -->
-    <div class="col-md-12 col-xl-6">
+    <div class="col-md-12 col-xl-5">
       <h4 class="mb-0">{{ experiment.name }}</h4>
       {% if experiment.is_archived %}
         <span class="badge rounded-pill bg-danger" id="archive-badge">Archived</span>
@@ -31,7 +31,7 @@
       {% endif %}
     </div>
     <!-- Experiment Timeline -->
-    <div class="col-md-12 col-xl-6" id="experiment-timeline">
+    <div class="col-md-12 col-xl-7" id="experiment-timeline">
       {% include "nimbus_experiments/timeline.html" %}
 
     </div>

--- a/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/sidebar.html
+++ b/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/sidebar.html
@@ -1,15 +1,13 @@
 <div class="nav flex-column nav-pills fw-medium w-100">
-  {% include "common/sidebar_link.html" with title="Summary" link=experiment.get_detail_url icon="fa-regular fa-paper-plane" %}
-  {% include "common/sidebar_link.html" with title="History" link=experiment.get_history_url icon="fa-solid fa-network-wired" active=True %}
-  {% include "common/sidebar_link.html" with title="Results" link="" icon="fa-solid fa-chart-column" disabled=True %}
+  {% for item in sidebar_links %}
+    {% if item.is_header %}
+      <strong class="ms-3">{{ item.title }}</strong>
+      <hr class="my-0 mb-2">
+    {% else %}
+      {% include "common/sidebar_link.html" with title=item.title link=item.link icon=item.icon active=item.active disabled=item.disabled %}
 
-  <strong class="ms-3">Edit</strong>
-  <hr class="my-0 mb-2">
-  {% include "common/sidebar_link.html" with title="Overview" link=experiment.get_update_overview_url icon="fa-regular fa-solid fa-gear" %}
-  {% include "common/sidebar_link.html" with title="Branches" link=experiment.get_update_branches_url icon="fa-solid fa-layer-group" %}
-  {% include "common/sidebar_link.html" with title="Metrics" link=experiment.get_update_metrics_url icon="fa-solid fa-arrow-trend-up" %}
-  {% include "common/sidebar_link.html" with title="Audience" link=experiment.get_update_audience_url icon="fa-solid fa-user-group" %}
-
+    {% endif %}
+  {% endfor %}
   <strong class="ms-3">Actions</strong>
   <hr class="my-0 mb-2">
   {% include "common/sidebar_link.html" with title="Clone" link="" icon="fa-regular fa-copy fa-lg" data_bs_toggle="modal" data_bs_target="#cloneModal" %}

--- a/experimenter/experimenter/nimbus_ui_new/views.py
+++ b/experimenter/experimenter/nimbus_ui_new/views.py
@@ -314,9 +314,6 @@ class NimbusExperimentsCloneView(NimbusExperimentViewMixin, RequestFormMixin, Up
     # TODO: https://github.com/mozilla/experimenter/issues/12432
     def get_context_data(self, **kwargs):
         return super().get_context_data(experiment=self.get_object(), **kwargs)
-        # context = super().get_context_data(**kwargs)
-        # context["experiment"] = self.get_object()
-        # return context
 
     def post(self, *args, **kwargs):
         response = super().post(*args, **kwargs)

--- a/experimenter/experimenter/nimbus_ui_new/views.py
+++ b/experimenter/experimenter/nimbus_ui_new/views.py
@@ -99,6 +99,17 @@ class NimbusExperimentViewMixin:
     model = NimbusExperiment
     context_object_name = "experiment"
 
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        experiment = getattr(self, "object", None)
+
+        context["sidebar_links"] = (
+            experiment.sidebar_links(self.request.path)
+            if experiment and experiment.slug
+            else []
+        )
+        return context
+
 
 class CloneExperimentFormMixin:
     def get_context_data(self, **kwargs):
@@ -215,6 +226,7 @@ class NimbusExperimentDetailView(
         context = super().get_context_data(**kwargs)
         experiment_context = build_experiment_context(self.object)
         context.update(experiment_context)
+
         context["promote_to_rollout_forms"] = NimbusExperimentPromoteToRolloutForm(
             instance=self.object
         )
@@ -224,6 +236,7 @@ class NimbusExperimentDetailView(
             context["form"] = QAStatusForm(instance=self.object)
         if context["takeaways_edit_mode"]:
             context["takeaways_form"] = TakeawaysForm(instance=self.object)
+
         return context
 
 
@@ -301,6 +314,9 @@ class NimbusExperimentsCloneView(NimbusExperimentViewMixin, RequestFormMixin, Up
     # TODO: https://github.com/mozilla/experimenter/issues/12432
     def get_context_data(self, **kwargs):
         return super().get_context_data(experiment=self.get_object(), **kwargs)
+        # context = super().get_context_data(**kwargs)
+        # context["experiment"] = self.get_object()
+        # return context
 
     def post(self, *args, **kwargs):
         response = super().post(*args, **kwargs)


### PR DESCRIPTION
Because

- We only want users to edit the forms if they're in a draft state, and the only exception we have is that the audience page should be allowed to edit if it's live and a rollout.

This commit

- Enable/disable forms
- Enable audience page if it's a rollout and in a live state

Note: Currently, it allows the whole audience page enabled to edit that. In a separate ticket, it will only restrict to allow only audience percentage to change.

Fixes #12781 
<img width="1384" alt="Screenshot 2025-06-18 at 3 06 52 PM" src="https://github.com/user-attachments/assets/3594f3d7-449f-4df6-9a16-c684793a24e2" />
<img width="1384" alt="Screenshot 2025-06-18 at 3 06 41 PM" src="https://github.com/user-attachments/assets/8c985b86-f789-4a5d-a730-43ddd56472ff" />
<img width="1384" alt="Screenshot 2025-06-18 at 3 06 30 PM" src="https://github.com/user-attachments/assets/1181f0ca-f028-4a73-868c-d7083df6a8b3" />
<img width="1384" alt="Screenshot 2025-06-18 at 3 06 11 PM" src="https://github.com/user-attachments/assets/2e323801-aa47-489b-8103-4bca6a817add" />
