### PR TITLE
chore(ci): Fix gcp test report uploads.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,7 +72,7 @@ commands:
           name: Upload << parameters.source >> << parameters.extension >> Files to GCS
           when: always  # Ensure the step runs even if previous steps, like test runs, fail
           command: |
-            allowed_branches=("update_firefox_versions" "update-application-services" "fix-12587")
+            allowed_branches=("update_firefox_versions" "update-application-services")
 
             for branch in "${allowed_branches[@]}"; do
               if [[ "$CIRCLE_BRANCH" == "$branch" || "$CIRCLE_BRANCH" == gh-readonly-queue/$branch/* ]]; then
@@ -875,6 +875,12 @@ workflows:
           name: Check Experimenter aarch64
       - check_experimenter_and_report:
           name: Check Experimenter and report
+          filters:
+            branches:
+              only:
+                - main
+                - update_firefox_versions
+                - update-application-services
       - check_cirrus_x86_64:
           name: Check Cirrus x86_64
       - check_cirrus_aarch64:

--- a/Makefile
+++ b/Makefile
@@ -171,7 +171,7 @@ lint: build_test  ## Running linting on source code
 check: lint
 
 check_and_report: build_test  ## Only to be used on CI
-	$(COMPOSE_TEST_RUN) experimenter sh -c '$(WAIT_FOR_DB) (${PARALLEL} "$(PYTHON_COVERAGE)" "$(JS_TEST_NIMBUS_UI)") ${COLOR_CHECK}'
+	$(COMPOSE_TEST_RUN) experimenter sh -c '$(WAIT_FOR_DB) (${PARALLEL} "$(PYTHON_COVERAGE)" "$(JS_TEST_NIMBUS_UI)") ${COLOR_CHECK}' || true
 	docker cp experimenter_test:/experimenter/experimenter_coverage.json workspace/test-results
 	docker cp experimenter_test:/experimenter/experimenter_tests.xml workspace/test-results
 	docker cp experimenter_test:/experimenter/experimenter/nimbus-ui/coverage_report workspace/test-results


### PR DESCRIPTION
Because

- We thought we didn't need to skip a specific makefile step within our `check_and_report` command.

This commit

- Adds `|| true` to the makefile command so that it always passes and we can capture the logs from the docker containers.
- Adds correct branch filtering for the reporting job

Fixes #12830 