### PR TITLE
fix(tests): Update integration test helper function

### DIFF
--- a/experimenter/tests/integration/nimbus/conftest.py
+++ b/experimenter/tests/integration/nimbus/conftest.py
@@ -371,15 +371,14 @@ def trigger_experiment_loader(selenium):
         with selenium.context(selenium.CONTEXT_CHROME):
             selenium.execute_script(
                 """
+                    const { ExperimentAPI } = ChromeUtils.importESModule("resource://nimbus/ExperimentAPI.sys.mjs");
                     const { RemoteSettings } = ChromeUtils.importESModule(
                         "resource://services-settings/remote-settings.sys.mjs"
                     );
-                    const { RemoteSettingsExperimentLoader } = ChromeUtils.importESModule(
-                        "resource://nimbus/lib/RemoteSettingsExperimentLoader.sys.mjs"
-                    );
 
                     RemoteSettings.pollChanges();
-                    RemoteSettingsExperimentLoader.updateRecipes();
+                    ExperimentAPI.ready();
+                    ExperimentAPI._rsLoader.updateRecipes("test");
                 """
             )
         time.sleep(5)


### PR DESCRIPTION
Because

- In the newest Firefox release there have been some module changes to Experimenter and we use some of these modules to trigger certain things for testing.

This commit

- Updates our experiment loader function to use the new ExperimenterAPI module.

Fixes #12850 