### PR TITLE
feat(nimbus): Update advanced targeting expression for TOU_NOT_ACCEPT…

### DIFF
--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -127,6 +127,9 @@ ADS_DISABLED = f"""
     {SPONSORED_SEARCH_SUGGESTIONS_DISABLED}
 )
 """
+# Most sponsored content is off by default in Brazil and Mexico, last updated
+# June 26, 2025.
+ADS_DISABLED_BR_MX_2025_06_26 = TOPSITES_OR_SPONSORED_TOPSITES_DISABLED
 
 NO_TARGETING = NimbusTargetingConfig(
     name="No Targeting",
@@ -2787,6 +2790,10 @@ TOU_NOT_ACCEPTED_EXISTING_USER_ADS_ENABLED_MAC_OR_WIN = NimbusTargetingConfig(
         "have not disabled ads, "
         "and are on Mac or Windows"
     ),
+    # For MX/BR users, respect the region-specific ADS_DISABLED_BR_MX_2025_06_26
+    # constant. Ffor all other regions, fall back to the global ADS_DISABLED.
+    # This ensures we never enroll users whose ads have been disabled regionally
+    # due to a mismatch between the two ads disabled constants.
     targeting=f"""
     (
         (
@@ -2801,7 +2808,17 @@ TOU_NOT_ACCEPTED_EXISTING_USER_ADS_ENABLED_MAC_OR_WIN = NimbusTargetingConfig(
         &&
         !{TOU_NOTIFICATION_BYPASS_ENABLED}
         &&
-        !{ADS_DISABLED}
+        (
+            (
+                (region == "MX" || region == "BR")
+                && !{ADS_DISABLED_BR_MX_2025_06_26}
+            )
+            ||
+            (
+                (region != "MX" && region != "BR")
+                && !{ADS_DISABLED}
+            )
+        )
     )
     """,
     desktop_telemetry="",

--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -127,7 +127,7 @@ ADS_DISABLED = f"""
     {SPONSORED_SEARCH_SUGGESTIONS_DISABLED}
 )
 """
-# Most sponsored content is off by default in Brazil and Mexico, last updated
+# Most sponsored content is off by default in Brazil and Mexico, as of
 # June 26, 2025.
 ADS_DISABLED_BR_MX_2025_06_26 = TOPSITES_OR_SPONSORED_TOPSITES_DISABLED
 

--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -2791,7 +2791,7 @@ TOU_NOT_ACCEPTED_EXISTING_USER_ADS_ENABLED_MAC_OR_WIN = NimbusTargetingConfig(
         "and are on Mac or Windows"
     ),
     # For MX/BR users, respect the region-specific ADS_DISABLED_BR_MX_2025_06_26
-    # constant. Ffor all other regions, fall back to the global ADS_DISABLED.
+    # constant. For all other regions, fall back to the global ADS_DISABLED.
     # This ensures we never enroll users whose ads have been disabled regionally
     # due to a mismatch between the two ads disabled constants.
     targeting=f"""


### PR DESCRIPTION
…ED_ADS_ENABLED_MAC_OR_WIN to handle BR and MX specific ad defaults

Because

- We want to run an infobar baseline experiment in Mexico and Brazil

This commit

- Updates the advanced targeting `TOU_NOT_ACCEPTED_EXISTING_USER_ADS_ENABLED_MAC_OR_WIN` with changes to the definition of "ads disabled" to reflect defaults in Brazil and Mexico. This will remain backwards compatible with the one current use of this targeting for [a US, Canada, and India only experiment.](https://experimenter.services.mozilla.com/nimbus/tos-existing-users-infobar-baseline-test/summary)

Users in Brazil and Mexico  are considered to have ads disabled if New Tab sponsored shortcuts (topsites) are disabled (see [this Slack discussion](https://mozilla.slack.com/archives/C08FQ6FQ9RS/p1750883714703869) for additional context).

Fixes #12858