### PR TITLE
feat(nimbus): Copy slug button

### DIFF
--- a/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/experiment_base.html
+++ b/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/experiment_base.html
@@ -20,7 +20,15 @@
       {% if experiment.is_rollout_dirty %}
         <span class="badge rounded-pill bg-danger" id="unpublished-rollout-badge">Unpublished changes</span>
       {% endif %}
-      <p class="text-secondary mb-0">{{ experiment.slug }}</p>
+      <div class="d-flex align-items-center mb-2">
+        <p class="text-secondary mb-0 me-1" id="experiment-slug">{{ experiment.slug }}</p>
+        <button type="button"
+                class="btn btn-sm"
+                onclick=" navigator.clipboard.writeText(document.getElementById('experiment-slug').textContent); alert('Copied to clipboard!'); "
+                aria-label="Copy slug">
+          <i class="fa-solid fa-copy text-secondary"></i>
+        </button>
+      </div>
       {% if experiment.parent %}
         <p class="text-secondary small">
           Cloned from


### PR DESCRIPTION
Because

- User wants to copy the slug from time to time, it is inconvenient for them to manually copy it 

This commit

- Adds the button to copy the slug

Fixes #12844 
<img width="1348" alt="Screenshot 2025-06-24 at 3 32 26 PM" src="https://github.com/user-attachments/assets/93d067a4-24d9-4d43-9154-6daf55e3b8f5" />
