### PR TITLE
feat(nimbus): Preview studies URL

### DIFF
--- a/experimenter/experimenter/nimbus_ui_new/static/js/review_controls.js
+++ b/experimenter/experimenter/nimbus_ui_new/static/js/review_controls.js
@@ -13,6 +13,19 @@ window.toggleSubmitButton = function () {
   submitButton.disabled = !(checkbox1.checked && checkbox2.checked);
 };
 
+window.updatePreviewURL = function () {
+  const select = document.getElementById("branch-selector");
+  const previewUrl = document.getElementById("preview-url");
+  const slugElement = document.getElementById("experiment-slug");
+
+  if (select && previewUrl && slugElement) {
+    const selectedSlug = select.value;
+    const experimentSlug = slugElement.textContent.trim();
+    const url = `about:studies?optin_slug=${experimentSlug}&optin_branch=${selectedSlug}&optin_collection=nimbus-preview`;
+    previewUrl.textContent = url;
+  }
+};
+
 function initializeRejectApproveListeners() {
   const rejectButton = document.getElementById("reject-button");
   const reviewControls = document.getElementById("review-controls");

--- a/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/launch_controls.html
+++ b/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/launch_controls.html
@@ -131,6 +131,24 @@
                   hx-swap="outerHTML">Go back to Draft</button>
         {% endif %}
       </div>
+      <div class="alert alert-light border my-3">
+        <h5 class="mb-2">Preview URL</h5>
+        <p class="mb-1">
+          <strong> Click the <code>about:studies</code> link below to copy</strong> then paste it in your browser. Ensure you enable <code>nimbus.debug</code> in <code>about:config</code> first.
+        </p>
+        <label for="branch-selector" class="form-label mt-2">Select Branch</label>
+        <select id="branch-selector"
+                class="form-select mb-3"
+                onchange="updatePreviewURL()">
+          {% for branch in experiment.branches.all %}
+            <option value="{{ branch.slug }}"
+                    {% if branch == experiment.reference_branch %}selected{% endif %}>{{ branch.name }}</option>
+          {% endfor %}
+        </select>
+        <code id="preview-url" class="d-block text-danger user-select-all">
+          about:studies?optin_slug={{ experiment.slug }}&optin_branch={{ experiment.reference_branch.slug }}&optin_collection=nimbus-preview
+        </code>
+      </div>
       <!-- Review Mode Controls -->
     {% elif experiment|should_show_remote_settings_pending:user %}
       <div class="alert alert-danger" role="alert">


### PR DESCRIPTION
Because

- If the experiment is in preview mode, we should show users how they can use studies to test it

This commit

- Adds the instruction to show preview url
- Ability to select different branches to get the url

Fixes #12822 
<img width="1334" alt="Screenshot 2025-06-30 at 4 18 27 PM" src="https://github.com/user-attachments/assets/31f38038-1e59-4889-a327-16c809a267db" />
<img width="1334" alt="Screenshot 2025-06-30 at 4 18 12 PM" src="https://github.com/user-attachments/assets/c379f943-8b01-45f3-9e6d-d94ee12a5606" />

