### PR TITLE
feat(nimbus): Enable population precentage only for live rollout

### DIFF
--- a/experimenter/experimenter/experiments/models.py
+++ b/experimenter/experimenter/experiments/models.py
@@ -1038,6 +1038,10 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
             return (self.computed_end_date - enrollment_end_date).days
         return None
 
+    @property
+    def is_live_rollout(self):
+        return self.is_rollout and self.is_enrolling
+
     def can_edit_overview(self):
         return self.is_draft
 
@@ -1048,7 +1052,7 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
         return self.is_draft
 
     def can_edit_audience(self):
-        return self.is_draft or (self.is_rollout and self.is_enrolling)
+        return self.is_draft or self.is_live_rollout
 
     def sidebar_links(self, current_path):
         return [

--- a/experimenter/experimenter/nimbus_ui_new/forms.py
+++ b/experimenter/experimenter/nimbus_ui_new/forms.py
@@ -839,6 +839,11 @@ class AudienceForm(NimbusChangeLogFormMixin, forms.ModelForm):
                 "hx-target": "#first-run-fields",
             }
         )
+        # If this is a live rollout, restrict edits to only population_percent
+        if self.instance.is_live_rollout:
+            for field_name in self.fields:
+                if field_name != "population_percent":
+                    self.fields[field_name].disabled = True
 
     def setup_initial_experiments_branches(self, field_name):
         self.initial[field_name] = [


### PR DESCRIPTION
Because

- We only want to allow the population percentage to be editable on the Audience page if it's a live rollout. Currently, all fields are editable on the new Audience page.

This commit

- Only allows audience population percentage to be editable (in case its a live rollout only)

Fixes #12821 
<img width="1336" alt="Screenshot 2025-07-03 at 9 38 56 AM" src="https://github.com/user-attachments/assets/984ab164-4da2-49dd-bccf-d23773ac7b24" />

