### PR TITLE
feat(nimbus): Hide missing details if its not in draft mode

### DIFF
--- a/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/detail.html
+++ b/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/detail.html
@@ -6,41 +6,43 @@
 {% block title %}{{ experiment.name }}{% endblock %}
 
 {% block main_content %}
-  <!-- Invalid Pages Warnings Card -->
-  {% with invalid_pages=experiment.get_invalid_pages %}
-    {% if invalid_pages %}
-      <div class="alert alert-danger" role="alert">
-        <p class="mb-1">
-          Before this experiment can be reviewed or launched, all required fields must be completed. Fields on the
-          <strong>
-            {% for page in invalid_pages %}
-              {% if page == "overview" %}
-                <a href="{{ experiment.get_update_overview_url }}?show_errors=true"
-                   rel="noopener noreferrer">Overview</a>
-              {% elif page == "branches" %}
-                <a href="" rel="noopener noreferrer">Branches</a>
-              {% elif page == "metrics" %}
-                <a href="{{ experiment.get_update_metrics_url }}?show_errors=true"
-                   rel="noopener noreferrer">Metrics</a>
-              {% elif page == "audience" %}
-                <a href="{{ experiment.get_update_audience_url }}?show_errors=true"
-                   rel="noopener noreferrer">Audience</a>
-              {% else %}
-                {{ page|capfirst }}
-              {% endif %}
-              {% if not forloop.last %},{% endif %}
-            {% endfor %}
-          </strong>
-          {% if invalid_pages|length == 1 %}
-            page
-          {% else %}
-            pages
-          {% endif %}
-          are missing details.
-        </p>
-      </div>
-    {% endif %}
-  {% endwith %}
+  {% if experiment.is_draft %}
+    <!-- Invalid Pages Warnings Card -->
+    {% with invalid_pages=experiment.get_invalid_pages %}
+      {% if invalid_pages %}
+        <div class="alert alert-danger" role="alert">
+          <p class="mb-1">
+            Before this experiment can be reviewed or launched, all required fields must be completed. Fields on the
+            <strong>
+              {% for page in invalid_pages %}
+                {% if page == "overview" %}
+                  <a href="{{ experiment.get_update_overview_url }}?show_errors=true"
+                     rel="noopener noreferrer">Overview</a>
+                {% elif page == "branches" %}
+                  <a href="" rel="noopener noreferrer">Branches</a>
+                {% elif page == "metrics" %}
+                  <a href="{{ experiment.get_update_metrics_url }}?show_errors=true"
+                     rel="noopener noreferrer">Metrics</a>
+                {% elif page == "audience" %}
+                  <a href="{{ experiment.get_update_audience_url }}?show_errors=true"
+                     rel="noopener noreferrer">Audience</a>
+                {% else %}
+                  {{ page|capfirst }}
+                {% endif %}
+                {% if not forloop.last %},{% endif %}
+              {% endfor %}
+            </strong>
+            {% if invalid_pages|length == 1 %}
+              page
+            {% else %}
+              pages
+            {% endif %}
+            are missing details.
+          </p>
+        </div>
+      {% endif %}
+    {% endwith %}
+  {% endif %}
   <!-- Audience Overlap Warnings Card -->
   {% if experiment.audience_overlap_warnings %}
     {% for warning in experiment.audience_overlap_warnings %}


### PR DESCRIPTION
Because

- On the new UI summary page, we should only show the missing details of the other pages if it's in draft state only

This commit

- Adds the check to only show missing details warning if its in a draft state, hides for all the other states

Fixes #12909 