### PR TITLE
feat(nimbus): Enable dark mode in launch rejection message

### DIFF
--- a/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/launch_controls.html
+++ b/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/launch_controls.html
@@ -11,7 +11,7 @@
             The request to {{ rejection.action }} was <strong>Rejected</strong> due to:
           </p>
           <p class="mb-2">{{ rejection.email }} on {{ rejection.date|date:"F j, Y" }}:</p>
-          <p class="bg-white rounded border p-2 mb-0">{{ rejection.message }}</p>
+          <p class="bg-light text-dark rounded border p-2 mb-0">{{ rejection.message }}</p>
         </div>
       </div>
     {% endif %}


### PR DESCRIPTION
Because

- When a user rejects launching/ending the experiment or rollout, they can enter a rejection message; currently, that rejection message is not readable in dark mode

This commit

- Changes the class of the bootstrap to support the dark mode with the rejection message

Fixes #12879 
<img width="1192" alt="Screenshot 2025-07-04 at 10 34 33 AM" src="https://github.com/user-attachments/assets/4c9ff309-5bb8-4797-9351-f1b573ce71ad" />

