### PR TITLE
feat(nimbus): Add missing url for branches page

### DIFF
--- a/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/detail.html
+++ b/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/detail.html
@@ -18,7 +18,8 @@
                 <a href="{{ experiment.get_update_overview_url }}?show_errors=true"
                    rel="noopener noreferrer">Overview</a>
               {% elif page == "branches" %}
-                <a href="" rel="noopener noreferrer">Branches</a>
+                <a href="{{ experiment.get_update_branches_url }}?show_errors=true"
+                   rel="noopener noreferrer">Branches</a>
               {% elif page == "metrics" %}
                 <a href="{{ experiment.get_update_metrics_url }}?show_errors=true"
                    rel="noopener noreferrer">Metrics</a>


### PR DESCRIPTION
Because

- When we show the missing details errors to the users for the different pages, branches page url was missing

This commit

- Adds the branches page url

Fixes #12885 