### PR TITLE
feat(nimbus): Updates advanced targeting - Windows 10+ and backgroudTaskMode and 1hr+ of inactivity

### DIFF
--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -1608,13 +1608,13 @@ WINDOWS_10_PLUS_BACKGROUND_TASK_NOTIFICATION_1HR_INACTIVITY_CFR_ONLY = (
 WHATS_NEW_NOTIFICATION_SIDEBAR_VERTICAL_TABS_ROLLOUT_V2 = NimbusTargetingConfig(
     name=(
         "Windows 10+ users with 1hr+ of inactivity in the past day "
-        "who are running a background task with CFR enabled and "
+        "who are running a background task and are "
         "not enrolled in treatment-a of WNN sidebar/vertical tabs experiment"
     ),
     slug="whats_new_notification_sidebar_vertical_tabs_rollout_v2",
     description=(
         "Windows 10+ users with 1hr+ of inactivity in the past day "
-        "who are running a background task with CFR enabled and "
+        "who are running a background task and are "
         "not enrolled in treatment-a of WNN sidebar/vertical tabs experiment"
     ),
     targeting="""

--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -1605,6 +1605,44 @@ WINDOWS_10_PLUS_BACKGROUND_TASK_NOTIFICATION_1HR_INACTIVITY_CFR_ONLY = (
     )
 )
 
+WHATS_NEW_NOTIFICATION_SIDEBAR_VERTICAL_TABS_ROLLOUT = NimbusTargetingConfig(
+    name=(
+        "Windows 10+ users with 1hr+ of inactivity in the past day "
+        "who are running a background task with CFR enabled and "
+        "not enrolled in treatment-a of WNN sidebar/vertical tabs experiment"
+    ),
+    slug="whats_new_notification_sidebar_vertical_tabs_rollout",
+    description=(
+        "Windows 10+ users with 1hr+ of inactivity in the past day "
+        "who are running a background task with CFR enabled and "
+        "not enrolled in treatment-a of WNN sidebar/vertical tabs experiment"
+    ),
+    targeting="""
+    (
+        (
+            os.isWindows
+            &&
+            (os.windowsVersion >= 10)
+        )
+        &&
+        (
+            ((currentDate|date - defaultProfile.currentDate|date) / 3600000 >= 1)
+        )
+        &&
+        isBackgroundTaskMode
+        &&
+        'browser.newtabpage.activity-stream.asrouter.userprefs.cfr.features'|preferenceValue
+        &&
+        ((defaultProfile.enrollmentsMap['whats-new-notification-sidebarvertical-tabs']
+        == 'treatment-a') == false)
+    )
+    """,
+    desktop_telemetry="",
+    sticky_required=True,
+    is_first_run_required=False,
+    application_choice_names=(Application.DESKTOP.name,),
+)
+
 WHATS_NEW_NOTIFICATION_SIDEBAR_VERTICAL_TABS_ROLLOUT_V2 = NimbusTargetingConfig(
     name=(
         "Windows 10+ users with 1hr+ of inactivity in the past day "

--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -1605,13 +1605,13 @@ WINDOWS_10_PLUS_BACKGROUND_TASK_NOTIFICATION_1HR_INACTIVITY_CFR_ONLY = (
     )
 )
 
-WHATS_NEW_NOTIFICATION_SIDEBAR_VERTICAL_TABS_ROLLOUT = NimbusTargetingConfig(
+WHATS_NEW_NOTIFICATION_SIDEBAR_VERTICAL_TABS_ROLLOUT_V2 = NimbusTargetingConfig(
     name=(
         "Windows 10+ users with 1hr+ of inactivity in the past day "
         "who are running a background task with CFR enabled and "
         "not enrolled in treatment-a of WNN sidebar/vertical tabs experiment"
     ),
-    slug="whats_new_notification_sidebar_vertical_tabs_rollout",
+    slug="whats_new_notification_sidebar_vertical_tabs_rollout_v2",
     description=(
         "Windows 10+ users with 1hr+ of inactivity in the past day "
         "who are running a background task with CFR enabled and "
@@ -1630,8 +1630,6 @@ WHATS_NEW_NOTIFICATION_SIDEBAR_VERTICAL_TABS_ROLLOUT = NimbusTargetingConfig(
         )
         &&
         isBackgroundTaskMode
-        &&
-        'browser.newtabpage.activity-stream.asrouter.userprefs.cfr.features'|preferenceValue
         &&
         ((defaultProfile.enrollmentsMap['whats-new-notification-sidebarvertical-tabs']
         == 'treatment-a') == false)


### PR DESCRIPTION
Because

- The original adv targeting https://github.com/mozilla/experimenter/issues/12800 added the `cfr.features` pref check for this [rollout](https://experimenter.services.mozilla.com/nimbus/whats-new-notification-sidebarvertical-tabs-rollout-re-run/summary), but the background task [sets it to false](https://searchfox.org/mozilla-central/source/toolkit/components/backgroundtasks/defaults/backgroundtasks_browser.js#32). Product is aligned that on reverting the check (experiment originally did not include it) as we investigate an on-train change.


This commit

- Removes the original targeting, introduces the new targeting with`_v2` appended. 

The [rollout](https://experimenter.services.mozilla.com/nimbus/whats-new-notification-sidebarvertical-tabs-rollout-re-run/summary) ended and no other experiments are using the original targeting but let me know if I shouldn't be updating/removing the original targeting.

Fixes #12918