### PR TITLE
chore(cirrus): publish docker image to GAR

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -882,147 +882,147 @@ workflows:
 
   build:
     jobs:
-      - check_experimenter_x86_64:
-          name: Check Experimenter x86_64
-      - check_experimenter_aarch64:
-          name: Check Experimenter aarch64
-      - check_experimenter_and_report:
-          name: Check Experimenter and report
-          filters:
-            branches:
-              only:
-                - main
-                - update_firefox_versions
-                - update-application-services
-      - check_cirrus_x86_64:
-          name: Check Cirrus x86_64
-      - check_cirrus_aarch64:
-          name: Check Cirrus aarch64
-      - check_schemas:
-          name: Check Schemas
-          filters:
-            branches:
-              ignore:
-                - main
-      - create_mobile_recipes:
-          name: Create Fenix and iOS recipes
-          filters:
-            branches:
-              only:
-                - update_firefox_versions
-      - integration_nimbus_desktop_ui:
-          name: Test Desktop Nimbus UI (Release Firefox)
-          filters:
-            branches:
-              ignore:
-                - main
-      - integration_nimbus_remote_settings_launch:
-          name: Test Remote Settings Launch (All Applications)
-          filters:
-            branches:
-              ignore:
-                - main
-      - integration_nimbus_remote_settings_all:
-          name: Test Remote Settings All Workflows (Release Firefox Desktop)
-          filters:
-            branches:
-              ignore:
-                - main
-      - integration_nimbus_desktop_release_targeting:
-          name: Test Desktop Targeting (Release Firefox)
-          filters:
-            branches:
-              ignore:
-                - main
-      - integration_nimbus_desktop_beta_targeting:
-          name: Test Desktop Targeting (Beta Firefox)
-          filters:
-            branches:
-              ignore:
-                - main
-      - integration_nimbus_desktop_nightly_targeting:
-          name: Test Desktop Targeting (Nightly Firefox)
-          filters:
-            branches:
-              ignore:
-                - main
-      - integration_nimbus_desktop_enrollment:
-          name: Test Desktop Enrollment (Release Firefox)
-          filters:
-            branches:
-              ignore:
-                - main
-      - build_firefox_fenix:
-          name: Build Fenix APKs
-          filters:
-            branches:
-              only:
-                - update_firefox_versions
-      - integration_nimbus_fenix_enrollment:
-          name: Test Firefox for Android (Fenix)
-          requires:
-            - Create Fenix and iOS recipes
-            - Build Fenix APKs
-          filters:
-            branches:
-              only:
-                - update_firefox_versions
-      - integration_nimbus_ios_enrollment:
-          name: Test Firefox for iOS Beta
-          requires:
-            - Create Fenix and iOS recipes
-          file_path: experimenter/tests/firefox_fennec_beta_build.env
-          ios_version: "18.2"
-          simulator_device: iPhone 16
-          filters:
-            branches:
-              only:
-                - update_firefox_versions
-      - integration_nimbus_ios_enrollment:
-          name: Test Firefox for iOS Release
-          requires:
-            - Create Fenix and iOS recipes
-          file_path: experimenter/tests/firefox_fennec_release_build.env
-          ios_version: "18.2"
-          simulator_device: iPhone 16
-          filters:
-            branches:
-              only:
-                - update_firefox_versions
-      - integration_nimbus_sdk_targeting:
-          name: Test SDK Targeting (Release Firefox)
-          filters:
-            branches:
-              ignore:
-                - main
-      - integration_nimbus_cirrus:
-          name: Test Demo app with Cirrus
-          filters:
-            branches:
-              ignore:
-                - main
-      - deploy_experimenter:
-          name: Deploy Experimenter
-          context:
-            - gcpv2-workload-identity
-          filters:
-            branches:
-              only: main
-          requires:
-            - Check Experimenter x86_64
-            - Check Experimenter aarch64
+     #- check_experimenter_x86_64:
+     #    name: Check Experimenter x86_64
+     #- check_experimenter_aarch64:
+     #    name: Check Experimenter aarch64
+     #- check_experimenter_and_report:
+     #    name: Check Experimenter and report
+     #    filters:
+     #      branches:
+     #        only:
+     #          - main
+     #          - update_firefox_versions
+     #          - update-application-services
+     #- check_cirrus_x86_64:
+     #    name: Check Cirrus x86_64
+     #- check_cirrus_aarch64:
+     #    name: Check Cirrus aarch64
+     #- check_schemas:
+     #    name: Check Schemas
+     #    filters:
+     #      branches:
+     #        ignore:
+     #          - main
+     #- create_mobile_recipes:
+     #    name: Create Fenix and iOS recipes
+     #    filters:
+     #      branches:
+     #        only:
+     #          - update_firefox_versions
+     #- integration_nimbus_desktop_ui:
+     #    name: Test Desktop Nimbus UI (Release Firefox)
+     #    filters:
+     #      branches:
+     #        ignore:
+     #          - main
+     #- integration_nimbus_remote_settings_launch:
+     #    name: Test Remote Settings Launch (All Applications)
+     #    filters:
+     #      branches:
+     #        ignore:
+     #          - main
+     #- integration_nimbus_remote_settings_all:
+     #    name: Test Remote Settings All Workflows (Release Firefox Desktop)
+     #    filters:
+     #      branches:
+     #        ignore:
+     #          - main
+     #- integration_nimbus_desktop_release_targeting:
+     #    name: Test Desktop Targeting (Release Firefox)
+     #    filters:
+     #      branches:
+     #        ignore:
+     #          - main
+     #- integration_nimbus_desktop_beta_targeting:
+     #    name: Test Desktop Targeting (Beta Firefox)
+     #    filters:
+     #      branches:
+     #        ignore:
+     #          - main
+     #- integration_nimbus_desktop_nightly_targeting:
+     #    name: Test Desktop Targeting (Nightly Firefox)
+     #    filters:
+     #      branches:
+     #        ignore:
+     #          - main
+     #- integration_nimbus_desktop_enrollment:
+     #    name: Test Desktop Enrollment (Release Firefox)
+     #    filters:
+     #      branches:
+     #        ignore:
+     #          - main
+     #- build_firefox_fenix:
+     #    name: Build Fenix APKs
+     #    filters:
+     #      branches:
+     #        only:
+     #          - update_firefox_versions
+     #- integration_nimbus_fenix_enrollment:
+     #    name: Test Firefox for Android (Fenix)
+     #    requires:
+     #      - Create Fenix and iOS recipes
+     #      - Build Fenix APKs
+     #    filters:
+     #      branches:
+     #        only:
+     #          - update_firefox_versions
+     #- integration_nimbus_ios_enrollment:
+     #    name: Test Firefox for iOS Beta
+     #    requires:
+     #      - Create Fenix and iOS recipes
+     #    file_path: experimenter/tests/firefox_fennec_beta_build.env
+     #    ios_version: "18.2"
+     #    simulator_device: iPhone 16
+     #    filters:
+     #      branches:
+     #        only:
+     #          - update_firefox_versions
+     #- integration_nimbus_ios_enrollment:
+     #    name: Test Firefox for iOS Release
+     #    requires:
+     #      - Create Fenix and iOS recipes
+     #    file_path: experimenter/tests/firefox_fennec_release_build.env
+     #    ios_version: "18.2"
+     #    simulator_device: iPhone 16
+     #    filters:
+     #      branches:
+     #        only:
+     #          - update_firefox_versions
+     #- integration_nimbus_sdk_targeting:
+     #    name: Test SDK Targeting (Release Firefox)
+     #    filters:
+     #      branches:
+     #        ignore:
+     #          - main
+     #- integration_nimbus_cirrus:
+     #    name: Test Demo app with Cirrus
+     #    filters:
+     #      branches:
+     #        ignore:
+     #          - main
+     #- deploy_experimenter:
+     #    name: Deploy Experimenter
+     #    context:
+     #      - gcpv2-workload-identity
+     #    filters:
+     #      branches:
+     #        only: main
+     #    requires:
+     #      - Check Experimenter x86_64
+     #      - Check Experimenter aarch64
       - deploy_cirrus:
           name: Deploy Cirrus
           context:
             - gcpv2-workload-identity
           filters:
             branches:
-              only: main
-          requires:
-            - Check Cirrus x86_64
-            - Check Cirrus aarch64
-      - deploy_schemas:
-          name: Deploy Schemas
-          filters:
-            branches:
-              only: main
+              only: [main, relud-patch-2]
+         #requires:
+         #  - Check Cirrus x86_64
+         #  - Check Cirrus aarch64
+     #- deploy_schemas:
+     #    name: Deploy Schemas
+     #    filters:
+     #      branches:
+     #        only: main

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -665,19 +665,32 @@ jobs:
       docker_layer_caching: true
     steps:
       - checkout
+      - run:
+          name: Prepare environment variables for OIDC authentication
+          command: |
+            echo 'export GOOGLE_PROJECT_ID="moz-fx-cirrus-prod"' >> "$BASH_ENV"
+            echo "export OIDC_SERVICE_ACCOUNT_EMAIL=$DEPLOY_CIRRUS_GCP_SERVICE_ACCOUNT_EMAIL" >> "$BASH_ENV"
+      - gcp-cli/setup:
+          use_oidc: true
       - docker_login:
           username: $DOCKERHUB_CIRRUS_USER
           password: $DOCKERHUB_CIRRUS_PASS
       - run:
-          name: Deploy to latest
+          name: Deploy to Google Artifact Registry and Docker Hub
           command: |
             make cirrus_build
-            docker tag cirrus:deploy ${DOCKERHUB_CIRRUS_REPO}:latest
-            docker push ${DOCKERHUB_CIRRUS_REPO}:latest
+
+            gcloud auth configure-docker us-docker.pkg.dev --quiet
 
             GIT_SHA=$(git rev-parse --short HEAD)
-            docker tag cirrus:deploy ${DOCKERHUB_CIRRUS_REPO}:sha-${GIT_SHA}
-            docker push ${DOCKERHUB_CIRRUS_REPO}:sha-${GIT_SHA}
+
+            for DOCKER_IMAGE in "us-docker.pkg.dev/moz-fx-cirrus-prod/cirrus-prod/cirrus" "${DOCKERHUB_CIRRUS_REPO}"; do
+              docker tag cirrus:deploy ${DOCKER_IMAGE}:latest
+              docker push "${DOCKER_IMAGE}:latest"
+
+              docker tag cirrus:deploy ${DOCKER_IMAGE}:sha-${GIT_SHA}
+              docker push ${DOCKER_IMAGE}:sha-${GIT_SHA}
+            done
 
   deploy_schemas:
     machine:
@@ -1000,6 +1013,8 @@ workflows:
             - Check Experimenter aarch64
       - deploy_cirrus:
           name: Deploy Cirrus
+          context:
+            - gcpv2-workload-identity
           filters:
             branches:
               only: main

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -882,147 +882,147 @@ workflows:
 
   build:
     jobs:
-     #- check_experimenter_x86_64:
-     #    name: Check Experimenter x86_64
-     #- check_experimenter_aarch64:
-     #    name: Check Experimenter aarch64
-     #- check_experimenter_and_report:
-     #    name: Check Experimenter and report
-     #    filters:
-     #      branches:
-     #        only:
-     #          - main
-     #          - update_firefox_versions
-     #          - update-application-services
-     #- check_cirrus_x86_64:
-     #    name: Check Cirrus x86_64
-     #- check_cirrus_aarch64:
-     #    name: Check Cirrus aarch64
-     #- check_schemas:
-     #    name: Check Schemas
-     #    filters:
-     #      branches:
-     #        ignore:
-     #          - main
-     #- create_mobile_recipes:
-     #    name: Create Fenix and iOS recipes
-     #    filters:
-     #      branches:
-     #        only:
-     #          - update_firefox_versions
-     #- integration_nimbus_desktop_ui:
-     #    name: Test Desktop Nimbus UI (Release Firefox)
-     #    filters:
-     #      branches:
-     #        ignore:
-     #          - main
-     #- integration_nimbus_remote_settings_launch:
-     #    name: Test Remote Settings Launch (All Applications)
-     #    filters:
-     #      branches:
-     #        ignore:
-     #          - main
-     #- integration_nimbus_remote_settings_all:
-     #    name: Test Remote Settings All Workflows (Release Firefox Desktop)
-     #    filters:
-     #      branches:
-     #        ignore:
-     #          - main
-     #- integration_nimbus_desktop_release_targeting:
-     #    name: Test Desktop Targeting (Release Firefox)
-     #    filters:
-     #      branches:
-     #        ignore:
-     #          - main
-     #- integration_nimbus_desktop_beta_targeting:
-     #    name: Test Desktop Targeting (Beta Firefox)
-     #    filters:
-     #      branches:
-     #        ignore:
-     #          - main
-     #- integration_nimbus_desktop_nightly_targeting:
-     #    name: Test Desktop Targeting (Nightly Firefox)
-     #    filters:
-     #      branches:
-     #        ignore:
-     #          - main
-     #- integration_nimbus_desktop_enrollment:
-     #    name: Test Desktop Enrollment (Release Firefox)
-     #    filters:
-     #      branches:
-     #        ignore:
-     #          - main
-     #- build_firefox_fenix:
-     #    name: Build Fenix APKs
-     #    filters:
-     #      branches:
-     #        only:
-     #          - update_firefox_versions
-     #- integration_nimbus_fenix_enrollment:
-     #    name: Test Firefox for Android (Fenix)
-     #    requires:
-     #      - Create Fenix and iOS recipes
-     #      - Build Fenix APKs
-     #    filters:
-     #      branches:
-     #        only:
-     #          - update_firefox_versions
-     #- integration_nimbus_ios_enrollment:
-     #    name: Test Firefox for iOS Beta
-     #    requires:
-     #      - Create Fenix and iOS recipes
-     #    file_path: experimenter/tests/firefox_fennec_beta_build.env
-     #    ios_version: "18.2"
-     #    simulator_device: iPhone 16
-     #    filters:
-     #      branches:
-     #        only:
-     #          - update_firefox_versions
-     #- integration_nimbus_ios_enrollment:
-     #    name: Test Firefox for iOS Release
-     #    requires:
-     #      - Create Fenix and iOS recipes
-     #    file_path: experimenter/tests/firefox_fennec_release_build.env
-     #    ios_version: "18.2"
-     #    simulator_device: iPhone 16
-     #    filters:
-     #      branches:
-     #        only:
-     #          - update_firefox_versions
-     #- integration_nimbus_sdk_targeting:
-     #    name: Test SDK Targeting (Release Firefox)
-     #    filters:
-     #      branches:
-     #        ignore:
-     #          - main
-     #- integration_nimbus_cirrus:
-     #    name: Test Demo app with Cirrus
-     #    filters:
-     #      branches:
-     #        ignore:
-     #          - main
-     #- deploy_experimenter:
-     #    name: Deploy Experimenter
-     #    context:
-     #      - gcpv2-workload-identity
-     #    filters:
-     #      branches:
-     #        only: main
-     #    requires:
-     #      - Check Experimenter x86_64
-     #      - Check Experimenter aarch64
+      - check_experimenter_x86_64:
+          name: Check Experimenter x86_64
+      - check_experimenter_aarch64:
+          name: Check Experimenter aarch64
+      - check_experimenter_and_report:
+          name: Check Experimenter and report
+          filters:
+            branches:
+              only:
+                - main
+                - update_firefox_versions
+                - update-application-services
+      - check_cirrus_x86_64:
+          name: Check Cirrus x86_64
+      - check_cirrus_aarch64:
+          name: Check Cirrus aarch64
+      - check_schemas:
+          name: Check Schemas
+          filters:
+            branches:
+              ignore:
+                - main
+      - create_mobile_recipes:
+          name: Create Fenix and iOS recipes
+          filters:
+            branches:
+              only:
+                - update_firefox_versions
+      - integration_nimbus_desktop_ui:
+          name: Test Desktop Nimbus UI (Release Firefox)
+          filters:
+            branches:
+              ignore:
+                - main
+      - integration_nimbus_remote_settings_launch:
+          name: Test Remote Settings Launch (All Applications)
+          filters:
+            branches:
+              ignore:
+                - main
+      - integration_nimbus_remote_settings_all:
+          name: Test Remote Settings All Workflows (Release Firefox Desktop)
+          filters:
+            branches:
+              ignore:
+                - main
+      - integration_nimbus_desktop_release_targeting:
+          name: Test Desktop Targeting (Release Firefox)
+          filters:
+            branches:
+              ignore:
+                - main
+      - integration_nimbus_desktop_beta_targeting:
+          name: Test Desktop Targeting (Beta Firefox)
+          filters:
+            branches:
+              ignore:
+                - main
+      - integration_nimbus_desktop_nightly_targeting:
+          name: Test Desktop Targeting (Nightly Firefox)
+          filters:
+            branches:
+              ignore:
+                - main
+      - integration_nimbus_desktop_enrollment:
+          name: Test Desktop Enrollment (Release Firefox)
+          filters:
+            branches:
+              ignore:
+                - main
+      - build_firefox_fenix:
+          name: Build Fenix APKs
+          filters:
+            branches:
+              only:
+                - update_firefox_versions
+      - integration_nimbus_fenix_enrollment:
+          name: Test Firefox for Android (Fenix)
+          requires:
+            - Create Fenix and iOS recipes
+            - Build Fenix APKs
+          filters:
+            branches:
+              only:
+                - update_firefox_versions
+      - integration_nimbus_ios_enrollment:
+          name: Test Firefox for iOS Beta
+          requires:
+            - Create Fenix and iOS recipes
+          file_path: experimenter/tests/firefox_fennec_beta_build.env
+          ios_version: "18.2"
+          simulator_device: iPhone 16
+          filters:
+            branches:
+              only:
+                - update_firefox_versions
+      - integration_nimbus_ios_enrollment:
+          name: Test Firefox for iOS Release
+          requires:
+            - Create Fenix and iOS recipes
+          file_path: experimenter/tests/firefox_fennec_release_build.env
+          ios_version: "18.2"
+          simulator_device: iPhone 16
+          filters:
+            branches:
+              only:
+                - update_firefox_versions
+      - integration_nimbus_sdk_targeting:
+          name: Test SDK Targeting (Release Firefox)
+          filters:
+            branches:
+              ignore:
+                - main
+      - integration_nimbus_cirrus:
+          name: Test Demo app with Cirrus
+          filters:
+            branches:
+              ignore:
+                - main
+      - deploy_experimenter:
+          name: Deploy Experimenter
+          context:
+            - gcpv2-workload-identity
+          filters:
+            branches:
+              only: main
+          requires:
+            - Check Experimenter x86_64
+            - Check Experimenter aarch64
       - deploy_cirrus:
           name: Deploy Cirrus
           context:
             - gcpv2-workload-identity
           filters:
             branches:
-              only: [main, relud-patch-2]
-         #requires:
-         #  - Check Cirrus x86_64
-         #  - Check Cirrus aarch64
-     #- deploy_schemas:
-     #    name: Deploy Schemas
-     #    filters:
-     #      branches:
-     #        only: main
+              only: main
+          requires:
+            - Check Cirrus x86_64
+            - Check Cirrus aarch64
+      - deploy_schemas:
+          name: Deploy Schemas
+          filters:
+            branches:
+              only: main


### PR DESCRIPTION
Because

- Cirrus is currently deployed using the docker hub mirror, but ArgoCD's image updater can't use that for automatic deploys, so we need to publish this image to GAR like we do for experimenter

This commit

- Uploads cirrus docker images to GAR in addition to existing docker hub image

Fixes [EXP-5623](https://mozilla-hub.atlassian.net/browse/EXP-5623)
Requires https://github.com/mozilla/webservices-infra/pull/6431