### PR TITLE
bug(nimbus): fix initial required/excluded values on audience page

### DIFF
--- a/experimenter/experimenter/nimbus_ui_new/tests/test_views.py
+++ b/experimenter/experimenter/nimbus_ui_new/tests/test_views.py
@@ -2355,9 +2355,20 @@ class TestLaunchViews(AuthTestCase):
 
 class TestAudienceUpdateView(AuthTestCase):
     def test_get_renders_page(self):
-        experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperimentFactory.Lifecycles.CREATED
+        required = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            application=NimbusExperiment.Application.DESKTOP,
         )
+        excluded = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            application=NimbusExperiment.Application.DESKTOP,
+        )
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            application=NimbusExperiment.Application.DESKTOP,
+        )
+        experiment.required_experiments.add(required)
+        experiment.excluded_experiments.add(excluded)
 
         response = self.client.get(
             reverse("nimbus-new-update-audience", kwargs={"slug": experiment.slug})


### PR DESCRIPTION
Becuase

* We improved the performance of the Audience form
* We accidentally missed a reference to a removed method for setting up the initial values
* This was not covered by any tests

This commit

* Fixes the missing format method
* Updates existing tests to cover this case

fixes #12941

