### PR TITLE
chore(nimbus): Add newtabTrainhopAddon to the secure feature list for…

### DIFF
--- a/experimenter/experimenter/experiments/constants.py
+++ b/experimenter/experimenter/experiments/constants.py
@@ -104,6 +104,7 @@ class ApplicationConfig:
 
 
 DESKTOP_PREFFLIPS_SLUG = "prefFlips"
+DESKTOP_NEWTAB_ADDON_SLUG = "newtabTrainhopAddon"
 
 APPLICATION_CONFIG_DESKTOP = ApplicationConfig(
     name="Firefox Desktop",
@@ -123,6 +124,7 @@ APPLICATION_CONFIG_DESKTOP = ApplicationConfig(
     is_web=False,
     kinto_collections_by_feature_id={
         DESKTOP_PREFFLIPS_SLUG: settings.KINTO_COLLECTION_NIMBUS_SECURE,
+        DESKTOP_NEWTAB_ADDON_SLUG: settings.KINTO_COLLECTION_NIMBUS_SECURE,
     },
     preview_collection=settings.KINTO_COLLECTION_NIMBUS_PREVIEW,
 )
@@ -406,6 +408,7 @@ class NimbusConstants:
     )
 
     DESKTOP_PREFFLIPS_SLUG = DESKTOP_PREFFLIPS_SLUG
+    DESKTOP_NEWTAB_ADDON_SLUG = DESKTOP_NEWTAB_ADDON_SLUG
 
     Channel = Channel
 

--- a/experimenter/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_experiment_serializer.py
+++ b/experimenter/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_experiment_serializer.py
@@ -665,11 +665,23 @@ class TestNimbusExperimentSerializer(TestCase):
         self.assertTrue(NimbusBucketRange.objects.filter(experiment=experiment).exists())
         self.assertEqual(experiment.bucket_range.count, 5000)
 
-    def test_cannot_preview_prefflips(self):
-        prefflips_feature = NimbusFeatureConfigFactory.create_desktop_prefflips_feature()
+    @parameterized.expand(
+        [
+            NimbusExperiment.DESKTOP_PREFFLIPS_SLUG,
+            NimbusExperiment.DESKTOP_NEWTAB_ADDON_SLUG,
+        ]
+    )
+    def test_cannot_preview_secure_features(self, feature_id):
+        feature = NimbusFeatureConfigFactory.create(
+            name=feature_id,
+            slug=feature_id,
+            description=feature_id,
+            application=NimbusExperiment.Application.DESKTOP,
+        )
+
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.CREATED,
-            feature_configs=[prefflips_feature],
+            feature_configs=[feature],
         )
 
         serializer = NimbusExperimentSerializer(


### PR DESCRIPTION
… Desktop

Because:

- the newtabTrainhopAddon feature is marked as secure in Firefox Desktop

This commit:

- adds the feature to the list of features that publish to the secure collection for Desktop.

Fixes #12948