### PR TITLE
bug(nimbus): fix intermittent rollout test

### DIFF
--- a/experimenter/experimenter/nimbus_ui_new/tests/test_forms.py
+++ b/experimenter/experimenter/nimbus_ui_new/tests/test_forms.py
@@ -1464,6 +1464,7 @@ class TestAudienceForm(RequestFormTestCase):
             population_percent=5,
             application=NimbusExperiment.Application.DESKTOP,
             channel=NimbusExperiment.Channel.BETA,
+            targeting_config_slug=NimbusExperiment.TargetingConfig.NO_TARGETING,
         )
 
         form = AudienceForm(

--- a/experimenter/experimenter/nimbus_ui_new/tests/test_views.py
+++ b/experimenter/experimenter/nimbus_ui_new/tests/test_views.py
@@ -2559,6 +2559,7 @@ class TestAudienceUpdateView(AuthTestCase):
             population_percent=5,
             application=NimbusExperiment.Application.DESKTOP,
             channel=NimbusExperiment.Channel.BETA,
+            targeting_config_slug=NimbusExperiment.TargetingConfig.NO_TARGETING,
         )
 
         response = self.client.post(


### PR DESCRIPTION
Becuase

* We recently added a new test to update live rollouts
* We neglected to explicitly set the targeting_config_slug
* The factory was randomly setting it to a random targeting config
* Since we added per application filtering, it was sometimes selecting a targeting config for the wrong application
* This was causing the form to intermittently invalidate and fail to save which was causing the test to fail

This commit

* Explicitly sets the targeting config slug to a known valid value

fixes #12943

