### PR TITLE
feat(nimbus): End rollout should show even when the end date is not reached

### DIFF
--- a/experimenter/experimenter/experiments/models.py
+++ b/experimenter/experimenter/experiments/models.py
@@ -807,7 +807,6 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
         return (
             self.status == self.Status.LIVE
             and self.publish_status != self.PublishStatus.REVIEW
-            and not self.should_end
             and self.is_rollout
         )
 

--- a/experimenter/experimenter/experiments/tests/test_models.py
+++ b/experimenter/experimenter/experiments/tests/test_models.py
@@ -3987,6 +3987,42 @@ class TestNimbusExperiment(TestCase):
     @parameterized.expand(
         [
             (
+                NimbusExperiment.Status.LIVE,
+                NimbusExperiment.PublishStatus.IDLE,
+                True,
+                True,
+            ),
+            (
+                NimbusExperiment.Status.COMPLETE,
+                NimbusExperiment.PublishStatus.IDLE,
+                True,
+                False,
+            ),
+            (
+                NimbusExperiment.Status.LIVE,
+                NimbusExperiment.PublishStatus.REVIEW,
+                True,
+                False,
+            ),
+            (
+                NimbusExperiment.Status.LIVE,
+                NimbusExperiment.PublishStatus.IDLE,
+                False,
+                False,
+            ),
+        ]
+    )
+    def test_should_show_end_rollout(self, status, publish_status, is_rollout, expected):
+        experiment = NimbusExperimentFactory.create(
+            status=status,
+            publish_status=publish_status,
+            is_rollout=is_rollout,
+        )
+        self.assertEqual(experiment.should_show_end_rollout, expected)
+
+    @parameterized.expand(
+        [
+            (
                 NimbusExperimentFactory.Lifecycles.LIVE_APPROVE,
                 NimbusUIConstants.ReviewRequestMessages.LAUNCH_EXPERIMENT.value,
                 False,

--- a/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/detail.html
+++ b/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/detail.html
@@ -63,7 +63,7 @@
     {% endfor %}
   {% endif %}
   <!-- Launch Controls Card-->
-  {% if not experiment.get_invalid_pages %}
+  {% if not experiment.get_invalid_pages or not experiment.is_draft %}
     {% include "nimbus_experiments/launch_controls.html" %}
 
   {% endif %}


### PR DESCRIPTION

Because

- In the new UI we were only showing the `End Rollout` option if the proposed end date has passed, where as user should have always the option to end the rollout early too

This commit

- Updates the logic of end rollout check and only show invalid pages error if its draft only

Fixes #12891 
<img width="1224" height="411" alt="Screenshot 2025-07-10 at 9 16 52 AM" src="https://github.com/user-attachments/assets/f8901d7d-9cfa-42df-b9f4-1cfb5a3b6bda" />

