### PR TITLE
chore(cirrus): only deploy cirrus when the image might have changed

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -666,6 +666,20 @@ jobs:
     steps:
       - checkout
       - run:
+          name: Skip if no changes to cirrus
+          command: |
+            if test -z "<< pipeline.git.base_revision >>"; then
+                echo "No base revision, continuing"
+            else
+                echo "Changed files:"
+                if git diff --exit-code --name-only "<< pipeline.git.base_revision >>" HEAD -- cirrus/ experimenter/experimenter/features/manifests/ .circleci/ $(find -maxdepth 1 -type f); then
+                    echo "No changes to cirrus or fml or .circleci or files in root directory, skipping"
+                    circleci-agent step halt
+                else
+                    echo "Changes detected in cirrus or fml or .circleci or files in root directory, continuing"
+                fi
+            fi
+      - run:
           name: Prepare environment variables for OIDC authentication
           command: |
             echo 'export GOOGLE_PROJECT_ID="moz-fx-cirrus-prod"' >> "$BASH_ENV"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -896,147 +896,147 @@ workflows:
 
   build:
     jobs:
-     #- check_experimenter_x86_64:
-     #    name: Check Experimenter x86_64
-     #- check_experimenter_aarch64:
-     #    name: Check Experimenter aarch64
-     #- check_experimenter_and_report:
-     #    name: Check Experimenter and report
-     #    filters:
-     #      branches:
-     #        only:
-     #          - main
-     #          - update_firefox_versions
-     #          - update-application-services
-     #- check_cirrus_x86_64:
-     #    name: Check Cirrus x86_64
-     #- check_cirrus_aarch64:
-     #    name: Check Cirrus aarch64
-     #- check_schemas:
-     #    name: Check Schemas
-     #    filters:
-     #      branches:
-     #        ignore:
-     #          - main
-     #- create_mobile_recipes:
-     #    name: Create Fenix and iOS recipes
-     #    filters:
-     #      branches:
-     #        only:
-     #          - update_firefox_versions
-     #- integration_nimbus_desktop_ui:
-     #    name: Test Desktop Nimbus UI (Release Firefox)
-     #    filters:
-     #      branches:
-     #        ignore:
-     #          - main
-     #- integration_nimbus_remote_settings_launch:
-     #    name: Test Remote Settings Launch (All Applications)
-     #    filters:
-     #      branches:
-     #        ignore:
-     #          - main
-     #- integration_nimbus_remote_settings_all:
-     #    name: Test Remote Settings All Workflows (Release Firefox Desktop)
-     #    filters:
-     #      branches:
-     #        ignore:
-     #          - main
-     #- integration_nimbus_desktop_release_targeting:
-     #    name: Test Desktop Targeting (Release Firefox)
-     #    filters:
-     #      branches:
-     #        ignore:
-     #          - main
-     #- integration_nimbus_desktop_beta_targeting:
-     #    name: Test Desktop Targeting (Beta Firefox)
-     #    filters:
-     #      branches:
-     #        ignore:
-     #          - main
-     #- integration_nimbus_desktop_nightly_targeting:
-     #    name: Test Desktop Targeting (Nightly Firefox)
-     #    filters:
-     #      branches:
-     #        ignore:
-     #          - main
-     #- integration_nimbus_desktop_enrollment:
-     #    name: Test Desktop Enrollment (Release Firefox)
-     #    filters:
-     #      branches:
-     #        ignore:
-     #          - main
-     #- build_firefox_fenix:
-     #    name: Build Fenix APKs
-     #    filters:
-     #      branches:
-     #        only:
-     #          - update_firefox_versions
-     #- integration_nimbus_fenix_enrollment:
-     #    name: Test Firefox for Android (Fenix)
-     #    requires:
-     #      - Create Fenix and iOS recipes
-     #      - Build Fenix APKs
-     #    filters:
-     #      branches:
-     #        only:
-     #          - update_firefox_versions
-     #- integration_nimbus_ios_enrollment:
-     #    name: Test Firefox for iOS Beta
-     #    requires:
-     #      - Create Fenix and iOS recipes
-     #    file_path: experimenter/tests/firefox_fennec_beta_build.env
-     #    ios_version: "18.2"
-     #    simulator_device: iPhone 16
-     #    filters:
-     #      branches:
-     #        only:
-     #          - update_firefox_versions
-     #- integration_nimbus_ios_enrollment:
-     #    name: Test Firefox for iOS Release
-     #    requires:
-     #      - Create Fenix and iOS recipes
-     #    file_path: experimenter/tests/firefox_fennec_release_build.env
-     #    ios_version: "18.2"
-     #    simulator_device: iPhone 16
-     #    filters:
-     #      branches:
-     #        only:
-     #          - update_firefox_versions
-     #- integration_nimbus_sdk_targeting:
-     #    name: Test SDK Targeting (Release Firefox)
-     #    filters:
-     #      branches:
-     #        ignore:
-     #          - main
-     #- integration_nimbus_cirrus:
-     #    name: Test Demo app with Cirrus
-     #    filters:
-     #      branches:
-     #        ignore:
-     #          - main
-     #- deploy_experimenter:
-     #    name: Deploy Experimenter
-     #    context:
-     #      - gcpv2-workload-identity
-     #    filters:
-     #      branches:
-     #        only: main
-     #    requires:
-     #      - Check Experimenter x86_64
-     #      - Check Experimenter aarch64
+      - check_experimenter_x86_64:
+          name: Check Experimenter x86_64
+      - check_experimenter_aarch64:
+          name: Check Experimenter aarch64
+      - check_experimenter_and_report:
+          name: Check Experimenter and report
+          filters:
+            branches:
+              only:
+                - main
+                - update_firefox_versions
+                - update-application-services
+      - check_cirrus_x86_64:
+          name: Check Cirrus x86_64
+      - check_cirrus_aarch64:
+          name: Check Cirrus aarch64
+      - check_schemas:
+          name: Check Schemas
+          filters:
+            branches:
+              ignore:
+                - main
+      - create_mobile_recipes:
+          name: Create Fenix and iOS recipes
+          filters:
+            branches:
+              only:
+                - update_firefox_versions
+      - integration_nimbus_desktop_ui:
+          name: Test Desktop Nimbus UI (Release Firefox)
+          filters:
+            branches:
+              ignore:
+                - main
+      - integration_nimbus_remote_settings_launch:
+          name: Test Remote Settings Launch (All Applications)
+          filters:
+            branches:
+              ignore:
+                - main
+      - integration_nimbus_remote_settings_all:
+          name: Test Remote Settings All Workflows (Release Firefox Desktop)
+          filters:
+            branches:
+              ignore:
+                - main
+      - integration_nimbus_desktop_release_targeting:
+          name: Test Desktop Targeting (Release Firefox)
+          filters:
+            branches:
+              ignore:
+                - main
+      - integration_nimbus_desktop_beta_targeting:
+          name: Test Desktop Targeting (Beta Firefox)
+          filters:
+            branches:
+              ignore:
+                - main
+      - integration_nimbus_desktop_nightly_targeting:
+          name: Test Desktop Targeting (Nightly Firefox)
+          filters:
+            branches:
+              ignore:
+                - main
+      - integration_nimbus_desktop_enrollment:
+          name: Test Desktop Enrollment (Release Firefox)
+          filters:
+            branches:
+              ignore:
+                - main
+      - build_firefox_fenix:
+          name: Build Fenix APKs
+          filters:
+            branches:
+              only:
+                - update_firefox_versions
+      - integration_nimbus_fenix_enrollment:
+          name: Test Firefox for Android (Fenix)
+          requires:
+            - Create Fenix and iOS recipes
+            - Build Fenix APKs
+          filters:
+            branches:
+              only:
+                - update_firefox_versions
+      - integration_nimbus_ios_enrollment:
+          name: Test Firefox for iOS Beta
+          requires:
+            - Create Fenix and iOS recipes
+          file_path: experimenter/tests/firefox_fennec_beta_build.env
+          ios_version: "18.2"
+          simulator_device: iPhone 16
+          filters:
+            branches:
+              only:
+                - update_firefox_versions
+      - integration_nimbus_ios_enrollment:
+          name: Test Firefox for iOS Release
+          requires:
+            - Create Fenix and iOS recipes
+          file_path: experimenter/tests/firefox_fennec_release_build.env
+          ios_version: "18.2"
+          simulator_device: iPhone 16
+          filters:
+            branches:
+              only:
+                - update_firefox_versions
+      - integration_nimbus_sdk_targeting:
+          name: Test SDK Targeting (Release Firefox)
+          filters:
+            branches:
+              ignore:
+                - main
+      - integration_nimbus_cirrus:
+          name: Test Demo app with Cirrus
+          filters:
+            branches:
+              ignore:
+                - main
+      - deploy_experimenter:
+          name: Deploy Experimenter
+          context:
+            - gcpv2-workload-identity
+          filters:
+            branches:
+              only: main
+          requires:
+            - Check Experimenter x86_64
+            - Check Experimenter aarch64
       - deploy_cirrus:
           name: Deploy Cirrus
           context:
             - gcpv2-workload-identity
           filters:
             branches:
-              only: relud-patch-1
-     #    requires:
-     #      - Check Cirrus x86_64
-     #      - Check Cirrus aarch64
-     #- deploy_schemas:
-     #    name: Deploy Schemas
-     #    filters:
-     #      branches:
-     #        only: main
+              only: main
+          requires:
+            - Check Cirrus x86_64
+            - Check Cirrus aarch64
+      - deploy_schemas:
+          name: Deploy Schemas
+          filters:
+            branches:
+              only: main

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -896,147 +896,147 @@ workflows:
 
   build:
     jobs:
-      - check_experimenter_x86_64:
-          name: Check Experimenter x86_64
-      - check_experimenter_aarch64:
-          name: Check Experimenter aarch64
-      - check_experimenter_and_report:
-          name: Check Experimenter and report
-          filters:
-            branches:
-              only:
-                - main
-                - update_firefox_versions
-                - update-application-services
-      - check_cirrus_x86_64:
-          name: Check Cirrus x86_64
-      - check_cirrus_aarch64:
-          name: Check Cirrus aarch64
-      - check_schemas:
-          name: Check Schemas
-          filters:
-            branches:
-              ignore:
-                - main
-      - create_mobile_recipes:
-          name: Create Fenix and iOS recipes
-          filters:
-            branches:
-              only:
-                - update_firefox_versions
-      - integration_nimbus_desktop_ui:
-          name: Test Desktop Nimbus UI (Release Firefox)
-          filters:
-            branches:
-              ignore:
-                - main
-      - integration_nimbus_remote_settings_launch:
-          name: Test Remote Settings Launch (All Applications)
-          filters:
-            branches:
-              ignore:
-                - main
-      - integration_nimbus_remote_settings_all:
-          name: Test Remote Settings All Workflows (Release Firefox Desktop)
-          filters:
-            branches:
-              ignore:
-                - main
-      - integration_nimbus_desktop_release_targeting:
-          name: Test Desktop Targeting (Release Firefox)
-          filters:
-            branches:
-              ignore:
-                - main
-      - integration_nimbus_desktop_beta_targeting:
-          name: Test Desktop Targeting (Beta Firefox)
-          filters:
-            branches:
-              ignore:
-                - main
-      - integration_nimbus_desktop_nightly_targeting:
-          name: Test Desktop Targeting (Nightly Firefox)
-          filters:
-            branches:
-              ignore:
-                - main
-      - integration_nimbus_desktop_enrollment:
-          name: Test Desktop Enrollment (Release Firefox)
-          filters:
-            branches:
-              ignore:
-                - main
-      - build_firefox_fenix:
-          name: Build Fenix APKs
-          filters:
-            branches:
-              only:
-                - update_firefox_versions
-      - integration_nimbus_fenix_enrollment:
-          name: Test Firefox for Android (Fenix)
-          requires:
-            - Create Fenix and iOS recipes
-            - Build Fenix APKs
-          filters:
-            branches:
-              only:
-                - update_firefox_versions
-      - integration_nimbus_ios_enrollment:
-          name: Test Firefox for iOS Beta
-          requires:
-            - Create Fenix and iOS recipes
-          file_path: experimenter/tests/firefox_fennec_beta_build.env
-          ios_version: "18.2"
-          simulator_device: iPhone 16
-          filters:
-            branches:
-              only:
-                - update_firefox_versions
-      - integration_nimbus_ios_enrollment:
-          name: Test Firefox for iOS Release
-          requires:
-            - Create Fenix and iOS recipes
-          file_path: experimenter/tests/firefox_fennec_release_build.env
-          ios_version: "18.2"
-          simulator_device: iPhone 16
-          filters:
-            branches:
-              only:
-                - update_firefox_versions
-      - integration_nimbus_sdk_targeting:
-          name: Test SDK Targeting (Release Firefox)
-          filters:
-            branches:
-              ignore:
-                - main
-      - integration_nimbus_cirrus:
-          name: Test Demo app with Cirrus
-          filters:
-            branches:
-              ignore:
-                - main
-      - deploy_experimenter:
-          name: Deploy Experimenter
-          context:
-            - gcpv2-workload-identity
-          filters:
-            branches:
-              only: main
-          requires:
-            - Check Experimenter x86_64
-            - Check Experimenter aarch64
+     #- check_experimenter_x86_64:
+     #    name: Check Experimenter x86_64
+     #- check_experimenter_aarch64:
+     #    name: Check Experimenter aarch64
+     #- check_experimenter_and_report:
+     #    name: Check Experimenter and report
+     #    filters:
+     #      branches:
+     #        only:
+     #          - main
+     #          - update_firefox_versions
+     #          - update-application-services
+     #- check_cirrus_x86_64:
+     #    name: Check Cirrus x86_64
+     #- check_cirrus_aarch64:
+     #    name: Check Cirrus aarch64
+     #- check_schemas:
+     #    name: Check Schemas
+     #    filters:
+     #      branches:
+     #        ignore:
+     #          - main
+     #- create_mobile_recipes:
+     #    name: Create Fenix and iOS recipes
+     #    filters:
+     #      branches:
+     #        only:
+     #          - update_firefox_versions
+     #- integration_nimbus_desktop_ui:
+     #    name: Test Desktop Nimbus UI (Release Firefox)
+     #    filters:
+     #      branches:
+     #        ignore:
+     #          - main
+     #- integration_nimbus_remote_settings_launch:
+     #    name: Test Remote Settings Launch (All Applications)
+     #    filters:
+     #      branches:
+     #        ignore:
+     #          - main
+     #- integration_nimbus_remote_settings_all:
+     #    name: Test Remote Settings All Workflows (Release Firefox Desktop)
+     #    filters:
+     #      branches:
+     #        ignore:
+     #          - main
+     #- integration_nimbus_desktop_release_targeting:
+     #    name: Test Desktop Targeting (Release Firefox)
+     #    filters:
+     #      branches:
+     #        ignore:
+     #          - main
+     #- integration_nimbus_desktop_beta_targeting:
+     #    name: Test Desktop Targeting (Beta Firefox)
+     #    filters:
+     #      branches:
+     #        ignore:
+     #          - main
+     #- integration_nimbus_desktop_nightly_targeting:
+     #    name: Test Desktop Targeting (Nightly Firefox)
+     #    filters:
+     #      branches:
+     #        ignore:
+     #          - main
+     #- integration_nimbus_desktop_enrollment:
+     #    name: Test Desktop Enrollment (Release Firefox)
+     #    filters:
+     #      branches:
+     #        ignore:
+     #          - main
+     #- build_firefox_fenix:
+     #    name: Build Fenix APKs
+     #    filters:
+     #      branches:
+     #        only:
+     #          - update_firefox_versions
+     #- integration_nimbus_fenix_enrollment:
+     #    name: Test Firefox for Android (Fenix)
+     #    requires:
+     #      - Create Fenix and iOS recipes
+     #      - Build Fenix APKs
+     #    filters:
+     #      branches:
+     #        only:
+     #          - update_firefox_versions
+     #- integration_nimbus_ios_enrollment:
+     #    name: Test Firefox for iOS Beta
+     #    requires:
+     #      - Create Fenix and iOS recipes
+     #    file_path: experimenter/tests/firefox_fennec_beta_build.env
+     #    ios_version: "18.2"
+     #    simulator_device: iPhone 16
+     #    filters:
+     #      branches:
+     #        only:
+     #          - update_firefox_versions
+     #- integration_nimbus_ios_enrollment:
+     #    name: Test Firefox for iOS Release
+     #    requires:
+     #      - Create Fenix and iOS recipes
+     #    file_path: experimenter/tests/firefox_fennec_release_build.env
+     #    ios_version: "18.2"
+     #    simulator_device: iPhone 16
+     #    filters:
+     #      branches:
+     #        only:
+     #          - update_firefox_versions
+     #- integration_nimbus_sdk_targeting:
+     #    name: Test SDK Targeting (Release Firefox)
+     #    filters:
+     #      branches:
+     #        ignore:
+     #          - main
+     #- integration_nimbus_cirrus:
+     #    name: Test Demo app with Cirrus
+     #    filters:
+     #      branches:
+     #        ignore:
+     #          - main
+     #- deploy_experimenter:
+     #    name: Deploy Experimenter
+     #    context:
+     #      - gcpv2-workload-identity
+     #    filters:
+     #      branches:
+     #        only: main
+     #    requires:
+     #      - Check Experimenter x86_64
+     #      - Check Experimenter aarch64
       - deploy_cirrus:
           name: Deploy Cirrus
           context:
             - gcpv2-workload-identity
           filters:
             branches:
-              only: main
-          requires:
-            - Check Cirrus x86_64
-            - Check Cirrus aarch64
-      - deploy_schemas:
-          name: Deploy Schemas
-          filters:
-            branches:
-              only: main
+              only: relud-patch-1
+     #    requires:
+     #      - Check Cirrus x86_64
+     #      - Check Cirrus aarch64
+     #- deploy_schemas:
+     #    name: Deploy Schemas
+     #    filters:
+     #      branches:
+     #        only: main


### PR DESCRIPTION
Because

- Cirrus doesn't need to deploy every time experimenter is modified

This commit

- Early-exits the deploy cirrus CI job when no changes are detected to cirrus, fml, .circleci, or files in the root directory

Fixes [EXP-5646](https://mozilla-hub.atlassian.net/browse/EXP-5646) along with https://github.com/mozilla/global-platform-admin/pull/3651