### PR TITLE
feat(nimbus): Show sticky is required message

### DIFF
--- a/experimenter/experimenter/experiments/models.py
+++ b/experimenter/experimenter/experiments/models.py
@@ -1617,6 +1617,7 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
 
         serializer_data = NimbusReviewSerializer(self).data
         serializer = NimbusReviewSerializer(self, data=serializer_data)
+        self.is_ready_to_launch = serializer.is_valid()
 
         if serializer.is_valid():
             return {}

--- a/experimenter/experimenter/experiments/models.py
+++ b/experimenter/experimenter/experiments/models.py
@@ -1617,7 +1617,6 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
 
         serializer_data = NimbusReviewSerializer(self).data
         serializer = NimbusReviewSerializer(self, data=serializer_data)
-        self.is_ready_to_launch = serializer.is_valid()
 
         if serializer.is_valid():
             return {}

--- a/experimenter/experimenter/experiments/tests/test_models.py
+++ b/experimenter/experimenter/experiments/tests/test_models.py
@@ -2690,6 +2690,131 @@ class TestNimbusExperiment(TestCase):
 
         self.assertTrue(experiment.can_review(UserFactory.create()))
 
+    @parameterized.expand(
+        [
+            (NimbusExperiment.Status.DRAFT, NimbusExperiment.PublishStatus.IDLE, True),
+            (NimbusExperiment.Status.DRAFT, NimbusExperiment.PublishStatus.REVIEW, False),
+            (
+                NimbusExperiment.Status.DRAFT,
+                NimbusExperiment.PublishStatus.APPROVED,
+                False,
+            ),
+            (NimbusExperiment.Status.PREVIEW, NimbusExperiment.PublishStatus.IDLE, False),
+            (NimbusExperiment.Status.LIVE, NimbusExperiment.PublishStatus.IDLE, False),
+            (
+                NimbusExperiment.Status.COMPLETE,
+                NimbusExperiment.PublishStatus.IDLE,
+                False,
+            ),
+        ]
+    )
+    def test_can_draft_to_preview_flag(self, status, publish_status, expected):
+        experiment = NimbusExperimentFactory.create(
+            status=status, publish_status=publish_status
+        )
+        self.assertEqual(
+            experiment.can_draft_to_preview,
+            expected,
+            f"Expected can_draft_to_preview={expected} for status={status},\
+            publish_status={publish_status}",
+        )
+
+    @parameterized.expand(
+        [
+            (NimbusExperiment.Status.DRAFT, NimbusExperiment.PublishStatus.IDLE, True),
+            (NimbusExperiment.Status.DRAFT, NimbusExperiment.PublishStatus.REVIEW, False),
+            (
+                NimbusExperiment.Status.DRAFT,
+                NimbusExperiment.PublishStatus.APPROVED,
+                False,
+            ),
+            (NimbusExperiment.Status.PREVIEW, NimbusExperiment.PublishStatus.IDLE, False),
+            (NimbusExperiment.Status.LIVE, NimbusExperiment.PublishStatus.IDLE, False),
+            (
+                NimbusExperiment.Status.COMPLETE,
+                NimbusExperiment.PublishStatus.IDLE,
+                False,
+            ),
+        ]
+    )
+    def test_can_draft_to_review_flag(self, status, publish_status, expected):
+        experiment = NimbusExperimentFactory.create(
+            status=status, publish_status=publish_status
+        )
+        self.assertEqual(
+            experiment.can_draft_to_review,
+            expected,
+            f"Expected can_draft_to_review={expected} for status={status},\
+            publish_status={publish_status}",
+        )
+
+    @parameterized.expand(
+        [
+            ("live_rollout", NimbusExperiment.Status.LIVE, True, True),
+            ("live_not_rollout", NimbusExperiment.Status.LIVE, False, False),
+            ("draft_rollout", NimbusExperiment.Status.DRAFT, True, False),
+            ("complete_rollout", NimbusExperiment.Status.COMPLETE, True, False),
+        ]
+    )
+    def test_should_show_rollout_request_update(self, _, status, is_rollout, expected):
+        experiment = NimbusExperimentFactory.create(
+            status=status,
+            is_rollout=is_rollout,
+        )
+        self.assertEqual(
+            experiment.should_show_rollout_request_update,
+            expected,
+            f"Expected should_show_rollout_request_update={expected} "
+            f"for status={status}, is_rollout={is_rollout}",
+        )
+
+    @parameterized.expand(
+        [
+            (
+                "live_to_complete_in_review",
+                NimbusExperiment.Status.LIVE,
+                NimbusExperiment.Status.COMPLETE,
+                NimbusExperiment.PublishStatus.REVIEW,
+                True,
+            ),
+            (
+                "live_to_complete_idle",
+                NimbusExperiment.Status.LIVE,
+                NimbusExperiment.Status.COMPLETE,
+                NimbusExperiment.PublishStatus.IDLE,
+                False,
+            ),
+            (
+                "live_to_draft_in_review",
+                NimbusExperiment.Status.LIVE,
+                NimbusExperiment.Status.DRAFT,
+                NimbusExperiment.PublishStatus.REVIEW,
+                False,
+            ),
+            (
+                "complete_to_complete_in_review",
+                NimbusExperiment.Status.COMPLETE,
+                NimbusExperiment.Status.COMPLETE,
+                NimbusExperiment.PublishStatus.REVIEW,
+                False,
+            ),
+        ]
+    )
+    def test_is_end_experiment_requested(
+        self, _, status, status_next, publish_status, expected
+    ):
+        experiment = NimbusExperimentFactory.create(
+            status=status,
+            status_next=status_next,
+            publish_status=publish_status,
+        )
+        self.assertEqual(
+            experiment.is_end_experiment_requested,
+            expected,
+            f"Expected is_end_experiment_requested={expected} for status={status}, "
+            f"status_next={status_next}, publish_status={publish_status}",
+        )
+
     def test_results_ready_true(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.ENDING_APPROVE_APPROVE,

--- a/experimenter/experimenter/experiments/tests/test_models.py
+++ b/experimenter/experimenter/experiments/tests/test_models.py
@@ -3994,7 +3994,7 @@ class TestNimbusExperiment(TestCase):
             channel=NimbusExperiment.Channel.RELEASE,
             is_sticky=False,
         )
-        
+
         errors = experiment.get_invalid_fields_errors()
         self.assertIn("is_sticky", errors)
         self.assertTrue(

--- a/experimenter/experimenter/experiments/tests/test_models.py
+++ b/experimenter/experimenter/experiments/tests/test_models.py
@@ -3984,6 +3984,26 @@ class TestNimbusExperiment(TestCase):
             errors["required_experiments_branches"],
         )
 
+    def test_invalid_pages_for_missing_sticky_requirement(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            application=NimbusExperiment.Application.DESKTOP,
+            firefox_min_version=NimbusExperiment.Version.FIREFOX_100,
+            firefox_max_version=NimbusExperiment.Version.FIREFOX_101,
+            targeting_config_slug=NimbusExperiment.TargetingConfig.FIRST_RUN,
+            channel=NimbusExperiment.Channel.RELEASE,
+            is_sticky=False,
+        )
+        
+        errors = experiment.get_invalid_fields_errors()
+        self.assertIn("is_sticky", errors)
+        self.assertTrue(
+            any("sticky" in msg.lower() for msg in errors["is_sticky"]),
+            msg="Expected sticky-related error message on is_sticky field",
+        )
+        invalid_pages = experiment.get_invalid_pages
+        self.assertIn("audience", invalid_pages)
+
     @parameterized.expand(
         [
             (

--- a/experimenter/experimenter/nimbus_ui_new/constants.py
+++ b/experimenter/experimenter/nimbus_ui_new/constants.py
@@ -110,5 +110,6 @@ Optional - We believe this outcome will <describe impact> on <core metric>
             "total_enrolled_clients",
             "required_experiments_branches",
             "excluded_experiments_branches",
+            "is_sticky",
         ],
     }

--- a/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/approval_rejection_controls.html
+++ b/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/approval_rejection_controls.html
@@ -28,18 +28,20 @@
       </p>
     </div>
   {% else %}
-    <div class="alert alert-primary">
-      <p>
-        <strong>{{ experiment.latest_review_requested_by|add:" requested to" }} {{ experiment.review_messages }}</strong>
-      </p>
-      <button type="button"
-              class="btn btn-success"
-              hx-post="{% url approval_url slug=experiment.slug %}"
-              hx-select="#content"
-              hx-target="#content"
-              hx-swap="outerHTML">Approve and {{ action_label }}</button>
-      <button type="button" class="btn btn-danger" id="reject-button">Reject</button>
-    </div>
+    {% if is_ready_to_launch %}
+      <div class="alert alert-primary">
+        <p>
+          <strong>{{ experiment.latest_review_requested_by|add:" requested to" }} {{ experiment.review_messages }}</strong>
+        </p>
+        <button type="button"
+                class="btn btn-success"
+                hx-post="{% url approval_url slug=experiment.slug %}"
+                hx-select="#content"
+                hx-target="#content"
+                hx-swap="outerHTML">Approve and {{ action_label }}</button>
+        <button type="button" class="btn btn-danger" id="reject-button">Reject</button>
+      </div>
+    {% endif %}
   {% endif %}
   <div class="alert alert-primary">
     <button type="button"

--- a/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/launch_controls.html
+++ b/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/launch_controls.html
@@ -1,231 +1,7 @@
 {% load nimbus_extras %}
 
 <div id="launch-controls">
-  {% if is_ready_to_launch %}
-    {% with rejection=experiment.rejection_block %}
-      {% if rejection %}
-        <div class="alert alert-warning"
-             id="rejection-reason"
-             data-testid="rejection-notice">
-          <div class="text-body">
-            <p class="mb-2">
-              The request to {{ rejection.action }} was <strong>Rejected</strong> due to:
-            </p>
-            <p class="mb-2">{{ rejection.email }} on {{ rejection.date|date:"F j, Y" }}:</p>
-            <p class="bg-light text-dark rounded border p-2 mb-0">{{ rejection.message }}</p>
-          </div>
-        </div>
-      {% endif %}
-    {% endwith %}
-    <form>
-      {% csrf_token %}
-      <!-- Draft Mode Controls -->
-      {% if experiment.is_draft %}
-        <div id="default-controls" class="alert alert-secondary">
-          <p>
-            Do you want to test this experiment before launching to production?
-            <a href="{{ EXTERNAL_URLS.PREVIEW_LAUNCH_DOC }}"
-               target="_blank"
-               class="mr-1">Learn more</a>
-          </p>
-          {% if experiment.can_draft_to_preview %}
-            <button type="button"
-                    class="btn btn-primary"
-                    hx-post="{% url 'nimbus-new-draft-to-preview' slug=experiment.slug %}"
-                    hx-select="#content"
-                    hx-target="#content"
-                    hx-swap="outerHTML">Preview for Testing</button>
-          {% endif %}
-          {% if experiment.can_draft_to_review %}
-            <button type="button"
-                    class="btn btn-secondary"
-                    onclick="showRecommendation()">Request Launch without Preview</button>
-          {% endif %}
-        </div>
-        <!-- Recommendation Message -->
-        <div id="recommendation-message" class="d-none">
-          <div class="alert alert-warning">
-            <p>
-              <strong>We recommend previewing before launch</strong>
-              <button type="button"
-                      class="btn btn-primary"
-                      hx-post="{% url 'nimbus-new-draft-to-preview' slug=experiment.slug %}"
-                      hx-select="#content"
-                      hx-target="#content"
-                      hx-swap="outerHTML">Preview Now</button>
-            </p>
-            <div class="form-check">
-              <input type="checkbox"
-                     class="form-check-input"
-                     id="checkbox-1"
-                     onchange="toggleSubmitButton()">
-              <label class="form-check-label" for="checkbox-1">I understand the risks associated with launching an experiment</label>
-            </div>
-            <div class="form-check">
-              <input type="checkbox"
-                     class="form-check-input"
-                     id="checkbox-2"
-                     onchange="toggleSubmitButton()">
-              <label class="form-check-label" for="checkbox-2">
-                I have gone through the <a href="{{ EXTERNAL_URLS.TRAINING_AND_PLANNING_DOC }}" target="_blank">experiment onboarding program</a>
-              </label>
-            </div>
-            <button type="button"
-                    class="btn btn-primary"
-                    id="request-launch-button"
-                    hx-post="{% url 'nimbus-new-draft-to-review' slug=experiment.slug %}"
-                    hx-select="#content"
-                    hx-target="#content"
-                    hx-swap="outerHTML"
-                    disabled>Request Launch</button>
-            <button type="button"
-                    class="btn btn-secondary"
-                    hx-post="{% url 'nimbus-new-review-to-draft' slug=experiment.slug %}"
-                    hx-select="#content"
-                    hx-target="#content"
-                    hx-swap="outerHTML">Cancel</button>
-          </div>
-        </div>
-        <!-- Preview Mode Controls -->
-      {% elif experiment.is_preview %}
-        <div class="alert alert-success bg-transparent text-success">
-          <p class="my-1">All set! Your experiment is in Preview mode and you can test it now.</p>
-        </div>
-        <div class="alert alert-secondary">
-          <p class="my-1">
-            This experiment is currently <strong>live for testing</strong>, but you will need to let QA know in your
-            <a href="{{ EXTERNAL_URLS.SIGNOFF_QA }}" target="_blank">PI request</a>. When you have received a sign-off, click “Request Launch” to launch the experiment.
-            <strong>Note: It can take up to an hour before clients receive a preview experiment.</strong>
-          </p>
-          <div class="form-check">
-            <input type="checkbox"
-                   class="form-check-input"
-                   id="checkbox-1"
-                   onchange="toggleSubmitButton()">
-            <label class="form-check-label" for="checkbox-1">I understand the risks associated with launching an experiment</label>
-          </div>
-          <div class="form-check">
-            <input type="checkbox"
-                   class="form-check-input"
-                   id="checkbox-2"
-                   onchange="toggleSubmitButton()">
-            <label class="form-check-label" for="checkbox-2">
-              I have gone through the <a href="{{ EXTERNAL_URLS.TRAINING_AND_PLANNING_DOC }}" target="_blank">experiment onboarding program</a>
-            </label>
-          </div>
-          {% if experiment.can_preview_to_review %}
-            <button type="button"
-                    class="btn btn-primary"
-                    id="request-launch-button"
-                    hx-post="{% url 'nimbus-new-preview-to-review' slug=experiment.slug %}"
-                    hx-select="#content"
-                    hx-target="#content"
-                    hx-swap="outerHTML"
-                    disabled>Request Launch</button>
-          {% endif %}
-          {% if experiment.can_preview_to_draft %}
-            <button type="button"
-                    class="btn btn-secondary"
-                    hx-post="{% url 'nimbus-new-preview-to-draft' slug=experiment.slug %}"
-                    hx-select="#content"
-                    hx-target="#content"
-                    hx-swap="outerHTML">Go back to Draft</button>
-          {% endif %}
-        </div>
-        <div class="alert alert-light border my-3">
-          <h5 class="mb-2">Preview URL</h5>
-          <p class="mb-1">
-            <strong> Click the <code>about:studies</code> link below to copy</strong> then paste it in your browser. Ensure you enable <code>nimbus.debug</code> in <code>about:config</code> first.
-          </p>
-          <label for="branch-selector" class="form-label mt-2">Select Branch</label>
-          <select id="branch-selector"
-                  class="form-select mb-3"
-                  onchange="updatePreviewURL()">
-            {% for branch in experiment.branches.all %}
-              <option value="{{ branch.slug }}"
-                      {% if branch == experiment.reference_branch %}selected{% endif %}>{{ branch.name }}</option>
-            {% endfor %}
-          </select>
-          <code id="preview-url" class="d-block text-danger user-select-all">
-            about:studies?optin_slug={{ experiment.slug }}&optin_branch={{ experiment.reference_branch.slug }}&optin_collection=nimbus-preview
-          </code>
-        </div>
-        <!-- Review Mode Controls -->
-      {% elif experiment|should_show_remote_settings_pending:user %}
-        <div class="alert alert-danger" role="alert">
-          <p>
-            <strong>Action required:</strong>
-            Please review this change in Remote Settings to {{ experiment.remote_settings_pending_message }}.
-          </p>
-          <a href="{{ experiment.review_url }}"
-             class="btn btn-primary"
-             target="_blank"
-             rel="noopener noreferrer">Open Remote Settings</a>
-        </div>
-      {% elif experiment.is_review %}
-        {% if experiment.is_rollout %}
-          {% include "nimbus_experiments/approval_rejection_controls.html" with action_label="Launch Rollout" approval_url="nimbus-new-review-to-approve" cancel_reject_url="nimbus-new-review-to-draft" experiment=experiment %}
-
-        {% else %}
-          {% include "nimbus_experiments/approval_rejection_controls.html" with action_label="Launch Experiment" approval_url="nimbus-new-review-to-approve" cancel_reject_url="nimbus-new-review-to-draft" experiment=experiment %}
-
-        {% endif %}
-      {% elif experiment.is_enrolling or experiment.is_observation %}
-        {% if experiment.is_rollout_update_requested %}
-          {% include "nimbus_experiments/approval_rejection_controls.html" with action_label="Update Rollout" approval_url="nimbus-new-approve-update-rollout" cancel_reject_url="nimbus-new-cancel-update-rollout" experiment=experiment %}
-
-        {% elif experiment.is_enrollment_pause_requested %}
-          {% include "nimbus_experiments/approval_rejection_controls.html" with action_label="End Enrollment" approval_url="nimbus-new-approve-end-enrollment" cancel_reject_url="nimbus-new-cancel-end-enrollment" experiment=experiment %}
-
-        {% elif experiment.is_end_experiment_requested %}
-          {% if experiment.is_rollout %}
-            {% include "nimbus_experiments/approval_rejection_controls.html" with action_label="End Rollout" approval_url="nimbus-new-approve-end-rollout" cancel_reject_url="nimbus-new-cancel-end-rollout" experiment=experiment %}
-
-          {% else %}
-            {% include "nimbus_experiments/approval_rejection_controls.html" with action_label="End Experiment" approval_url="nimbus-new-approve-end-experiment" cancel_reject_url="nimbus-new-cancel-end-experiment" experiment=experiment %}
-
-          {% endif %}
-        {% elif experiment.should_show_end_enrollment or experiment.should_show_end_experiment or experiment.should_show_end_rollout or experiment.should_show_rollout_request_update %}
-          <div id="default-controls" class="alert alert-primary mt-3">
-            <h5 class="mb-3 ms-2">Actions</h5>
-            {% if experiment.should_show_end_enrollment %}
-              <button type="button"
-                      hx-post="{% url 'nimbus-new-live-to-end-enrollment' slug=experiment.slug %}"
-                      hx-select="#content"
-                      hx-target="#content"
-                      hx-swap="outerHTML"
-                      class="btn btn-primary m-2">End Enrollment</button>
-            {% endif %}
-            {% if experiment.should_show_end_experiment %}
-              <button type="button"
-                      hx-post="{% url 'nimbus-new-live-to-complete' slug=experiment.slug %}"
-                      hx-select="#content"
-                      hx-target="#content"
-                      hx-swap="outerHTML"
-                      class="btn btn-primary">End Experiment</button>
-            {% endif %}
-            {% if experiment.should_show_rollout_request_update %}
-              <button type="button"
-                      hx-post="{% url 'nimbus-new-live-to-update-rollout' slug=experiment.slug %}"
-                      hx-select="#content"
-                      hx-target="#content"
-                      hx-swap="outerHTML"
-                      class="btn btn-primary"
-                      {% if not experiment.is_rollout_dirty %}disabled{% endif %}>Request Update</button>
-            {% endif %}
-            {% if experiment.should_show_end_rollout %}
-              <button type="button"
-                      hx-post="{% url 'nimbus-new-live-to-complete-rollout' slug=experiment.slug %}"
-                      hx-select="#content"
-                      hx-target="#content"
-                      hx-swap="outerHTML"
-                      class="btn btn-primary">End Rollout</button>
-            {% endif %}
-          </div>
-        {% endif %}
-      {% endif %}
-    </form>
-  {% else %}
+  {% if not is_ready_to_launch %}
     <div class="alert alert-danger" role="alert">
       <p class="mb-1">This experiment cannot be launched due to the following validation errors:</p>
       <ul class="mb-2">
@@ -243,4 +19,227 @@
       </p>
     </div>
   {% endif %}
+  {% with rejection=experiment.rejection_block %}
+    {% if rejection %}
+      <div class="alert alert-warning"
+           id="rejection-reason"
+           data-testid="rejection-notice">
+        <div class="text-body">
+          <p class="mb-2">
+            The request to {{ rejection.action }} was <strong>Rejected</strong> due to:
+          </p>
+          <p class="mb-2">{{ rejection.email }} on {{ rejection.date|date:"F j, Y" }}:</p>
+          <p class="bg-light text-dark rounded border p-2 mb-0">{{ rejection.message }}</p>
+        </div>
+      </div>
+    {% endif %}
+  {% endwith %}
+  <form>
+    {% csrf_token %}
+    <!-- Draft Mode Controls -->
+    {% if experiment.is_draft %}
+      <div id="default-controls" class="alert alert-secondary">
+        <p>
+          Do you want to test this experiment before launching to production?
+          <a href="{{ EXTERNAL_URLS.PREVIEW_LAUNCH_DOC }}"
+             target="_blank"
+             class="mr-1">Learn more</a>
+        </p>
+        {% if experiment.can_draft_to_preview %}
+          <button type="button"
+                  class="btn btn-primary"
+                  hx-post="{% url 'nimbus-new-draft-to-preview' slug=experiment.slug %}"
+                  hx-select="#content"
+                  hx-target="#content"
+                  hx-swap="outerHTML">Preview for Testing</button>
+        {% endif %}
+        {% if experiment.can_draft_to_review %}
+          <button type="button"
+                  class="btn btn-secondary"
+                  onclick="showRecommendation()">Request Launch without Preview</button>
+        {% endif %}
+      </div>
+      <!-- Recommendation Message -->
+      <div id="recommendation-message" class="d-none">
+        <div class="alert alert-warning">
+          <p>
+            <strong>We recommend previewing before launch</strong>
+            <button type="button"
+                    class="btn btn-primary"
+                    hx-post="{% url 'nimbus-new-draft-to-preview' slug=experiment.slug %}"
+                    hx-select="#content"
+                    hx-target="#content"
+                    hx-swap="outerHTML">Preview Now</button>
+          </p>
+          <div class="form-check">
+            <input type="checkbox"
+                   class="form-check-input"
+                   id="checkbox-1"
+                   onchange="toggleSubmitButton()">
+            <label class="form-check-label" for="checkbox-1">I understand the risks associated with launching an experiment</label>
+          </div>
+          <div class="form-check">
+            <input type="checkbox"
+                   class="form-check-input"
+                   id="checkbox-2"
+                   onchange="toggleSubmitButton()">
+            <label class="form-check-label" for="checkbox-2">
+              I have gone through the <a href="{{ EXTERNAL_URLS.TRAINING_AND_PLANNING_DOC }}" target="_blank">experiment onboarding program</a>
+            </label>
+          </div>
+          <button type="button"
+                  class="btn btn-primary"
+                  id="request-launch-button"
+                  hx-post="{% url 'nimbus-new-draft-to-review' slug=experiment.slug %}"
+                  hx-select="#content"
+                  hx-target="#content"
+                  hx-swap="outerHTML"
+                  disabled>Request Launch</button>
+          <button type="button"
+                  class="btn btn-secondary"
+                  hx-post="{% url 'nimbus-new-review-to-draft' slug=experiment.slug %}"
+                  hx-select="#content"
+                  hx-target="#content"
+                  hx-swap="outerHTML">Cancel</button>
+        </div>
+      </div>
+      <!-- Preview Mode Controls -->
+    {% elif experiment.is_preview %}
+      <div class="alert alert-success bg-transparent text-success">
+        <p class="my-1">All set! Your experiment is in Preview mode and you can test it now.</p>
+      </div>
+      <div class="alert alert-secondary">
+        <p class="my-1">
+          This experiment is currently <strong>live for testing</strong>, but you will need to let QA know in your
+          <a href="{{ EXTERNAL_URLS.SIGNOFF_QA }}" target="_blank">PI request</a>. When you have received a sign-off, click “Request Launch” to launch the experiment.
+          <strong>Note: It can take up to an hour before clients receive a preview experiment.</strong>
+        </p>
+        <div class="form-check">
+          <input type="checkbox"
+                 class="form-check-input"
+                 id="checkbox-1"
+                 onchange="toggleSubmitButton()">
+          <label class="form-check-label" for="checkbox-1">I understand the risks associated with launching an experiment</label>
+        </div>
+        <div class="form-check">
+          <input type="checkbox"
+                 class="form-check-input"
+                 id="checkbox-2"
+                 onchange="toggleSubmitButton()">
+          <label class="form-check-label" for="checkbox-2">
+            I have gone through the <a href="{{ EXTERNAL_URLS.TRAINING_AND_PLANNING_DOC }}" target="_blank">experiment onboarding program</a>
+          </label>
+        </div>
+        {% if experiment.can_preview_to_review %}
+          <button type="button"
+                  class="btn btn-primary"
+                  id="request-launch-button"
+                  hx-post="{% url 'nimbus-new-preview-to-review' slug=experiment.slug %}"
+                  hx-select="#content"
+                  hx-target="#content"
+                  hx-swap="outerHTML"
+                  disabled>Request Launch</button>
+        {% endif %}
+        {% if experiment.can_preview_to_draft %}
+          <button type="button"
+                  class="btn btn-secondary"
+                  hx-post="{% url 'nimbus-new-preview-to-draft' slug=experiment.slug %}"
+                  hx-select="#content"
+                  hx-target="#content"
+                  hx-swap="outerHTML">Go back to Draft</button>
+        {% endif %}
+      </div>
+      <div class="alert alert-light border my-3">
+        <h5 class="mb-2">Preview URL</h5>
+        <p class="mb-1">
+          <strong> Click the <code>about:studies</code> link below to copy</strong> then paste it in your browser. Ensure you enable <code>nimbus.debug</code> in <code>about:config</code> first.
+        </p>
+        <label for="branch-selector" class="form-label mt-2">Select Branch</label>
+        <select id="branch-selector"
+                class="form-select mb-3"
+                onchange="updatePreviewURL()">
+          {% for branch in experiment.branches.all %}
+            <option value="{{ branch.slug }}"
+                    {% if branch == experiment.reference_branch %}selected{% endif %}>{{ branch.name }}</option>
+          {% endfor %}
+        </select>
+        <code id="preview-url" class="d-block text-danger user-select-all">
+          about:studies?optin_slug={{ experiment.slug }}&optin_branch={{ experiment.reference_branch.slug }}&optin_collection=nimbus-preview
+        </code>
+      </div>
+      <!-- Review Mode Controls -->
+    {% elif experiment|should_show_remote_settings_pending:user %}
+      <div class="alert alert-danger" role="alert">
+        <p>
+          <strong>Action required:</strong>
+          Please review this change in Remote Settings to {{ experiment.remote_settings_pending_message }}.
+        </p>
+        <a href="{{ experiment.review_url }}"
+           class="btn btn-primary"
+           target="_blank"
+           rel="noopener noreferrer">Open Remote Settings</a>
+      </div>
+    {% elif experiment.is_review %}
+      {% if experiment.is_rollout %}
+        {% include "nimbus_experiments/approval_rejection_controls.html" with action_label="Launch Rollout" approval_url="nimbus-new-review-to-approve" cancel_reject_url="nimbus-new-review-to-draft" experiment=experiment %}
+
+      {% else %}
+        {% include "nimbus_experiments/approval_rejection_controls.html" with action_label="Launch Experiment" approval_url="nimbus-new-review-to-approve" cancel_reject_url="nimbus-new-review-to-draft" experiment=experiment %}
+
+      {% endif %}
+    {% elif experiment.is_enrolling or experiment.is_observation %}
+      {% if experiment.is_rollout_update_requested %}
+        {% include "nimbus_experiments/approval_rejection_controls.html" with action_label="Update Rollout" approval_url="nimbus-new-approve-update-rollout" cancel_reject_url="nimbus-new-cancel-update-rollout" experiment=experiment %}
+
+      {% elif experiment.is_enrollment_pause_requested %}
+        {% include "nimbus_experiments/approval_rejection_controls.html" with action_label="End Enrollment" approval_url="nimbus-new-approve-end-enrollment" cancel_reject_url="nimbus-new-cancel-end-enrollment" experiment=experiment %}
+
+      {% elif experiment.is_end_experiment_requested %}
+        {% if experiment.is_rollout %}
+          {% include "nimbus_experiments/approval_rejection_controls.html" with action_label="End Rollout" approval_url="nimbus-new-approve-end-rollout" cancel_reject_url="nimbus-new-cancel-end-rollout" experiment=experiment %}
+
+        {% else %}
+          {% include "nimbus_experiments/approval_rejection_controls.html" with action_label="End Experiment" approval_url="nimbus-new-approve-end-experiment" cancel_reject_url="nimbus-new-cancel-end-experiment" experiment=experiment %}
+
+        {% endif %}
+      {% elif experiment.should_show_end_enrollment or experiment.should_show_end_experiment or experiment.should_show_end_rollout or experiment.should_show_rollout_request_update %}
+        <div id="default-controls" class="alert alert-primary mt-3">
+          <h5 class="mb-3 ms-2">Actions</h5>
+          {% if experiment.should_show_end_enrollment %}
+            <button type="button"
+                    hx-post="{% url 'nimbus-new-live-to-end-enrollment' slug=experiment.slug %}"
+                    hx-select="#content"
+                    hx-target="#content"
+                    hx-swap="outerHTML"
+                    class="btn btn-primary m-2">End Enrollment</button>
+          {% endif %}
+          {% if experiment.should_show_end_experiment %}
+            <button type="button"
+                    hx-post="{% url 'nimbus-new-live-to-complete' slug=experiment.slug %}"
+                    hx-select="#content"
+                    hx-target="#content"
+                    hx-swap="outerHTML"
+                    class="btn btn-primary">End Experiment</button>
+          {% endif %}
+          {% if experiment.should_show_rollout_request_update %}
+            <button type="button"
+                    hx-post="{% url 'nimbus-new-live-to-update-rollout' slug=experiment.slug %}"
+                    hx-select="#content"
+                    hx-target="#content"
+                    hx-swap="outerHTML"
+                    class="btn btn-primary"
+                    {% if not experiment.is_rollout_dirty %}disabled{% endif %}>Request Update</button>
+          {% endif %}
+          {% if experiment.should_show_end_rollout %}
+            <button type="button"
+                    hx-post="{% url 'nimbus-new-live-to-complete-rollout' slug=experiment.slug %}"
+                    hx-select="#content"
+                    hx-target="#content"
+                    hx-swap="outerHTML"
+                    class="btn btn-primary">End Rollout</button>
+          {% endif %}
+        </div>
+      {% endif %}
+    {% endif %}
+  </form>
 </div>

--- a/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/launch_controls.html
+++ b/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/launch_controls.html
@@ -1,7 +1,7 @@
 {% load nimbus_extras %}
 
 <div id="launch-controls">
-  {% if experiment.is_ready_to_launch %}
+  {% if is_ready_to_launch %}
     {% with rejection=experiment.rejection_block %}
       {% if rejection %}
         <div class="alert alert-warning"
@@ -229,7 +229,7 @@
     <div class="alert alert-danger" role="alert">
       <p class="mb-1">This experiment cannot be launched due to the following validation errors:</p>
       <ul class="mb-2">
-        {% for field, errors in experiment.get_invalid_fields_errors.items %}
+        {% for field, errors in validation_errors.items %}
           <li>
             <strong>{{ field|remove_underscores|title }}:</strong>
             <ul class="mb-1">

--- a/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/launch_controls.html
+++ b/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/launch_controls.html
@@ -1,57 +1,101 @@
 {% load nimbus_extras %}
 
 <div id="launch-controls">
-  {% with rejection=experiment.rejection_block %}
-    {% if rejection %}
-      <div class="alert alert-warning"
-           id="rejection-reason"
-           data-testid="rejection-notice">
-        <div class="text-body">
-          <p class="mb-2">
-            The request to {{ rejection.action }} was <strong>Rejected</strong> due to:
-          </p>
-          <p class="mb-2">{{ rejection.email }} on {{ rejection.date|date:"F j, Y" }}:</p>
-          <p class="bg-light text-dark rounded border p-2 mb-0">{{ rejection.message }}</p>
+  {% if ready %}
+    {% with rejection=experiment.rejection_block %}
+      {% if rejection %}
+        <div class="alert alert-warning"
+             id="rejection-reason"
+             data-testid="rejection-notice">
+          <div class="text-body">
+            <p class="mb-2">
+              The request to {{ rejection.action }} was <strong>Rejected</strong> due to:
+            </p>
+            <p class="mb-2">{{ rejection.email }} on {{ rejection.date|date:"F j, Y" }}:</p>
+            <p class="bg-light text-dark rounded border p-2 mb-0">{{ rejection.message }}</p>
+          </div>
         </div>
-      </div>
-    {% endif %}
-  {% endwith %}
-  <form>
-    {% csrf_token %}
-    <!-- Draft Mode Controls -->
-    {% if experiment.is_draft %}
-      <div id="default-controls" class="alert alert-secondary">
-        <p>
-          Do you want to test this experiment before launching to production?
-          <a href="{{ EXTERNAL_URLS.PREVIEW_LAUNCH_DOC }}"
-             target="_blank"
-             class="mr-1">Learn more</a>
-        </p>
-        {% if experiment.can_draft_to_preview %}
-          <button type="button"
-                  class="btn btn-primary"
-                  hx-post="{% url 'nimbus-new-draft-to-preview' slug=experiment.slug %}"
-                  hx-select="#content"
-                  hx-target="#content"
-                  hx-swap="outerHTML">Preview for Testing</button>
-        {% endif %}
-        {% if experiment.can_draft_to_review %}
-          <button type="button"
-                  class="btn btn-secondary"
-                  onclick="showRecommendation()">Request Launch without Preview</button>
-        {% endif %}
-      </div>
-      <!-- Recommendation Message -->
-      <div id="recommendation-message" class="d-none">
-        <div class="alert alert-warning">
+      {% endif %}
+    {% endwith %}
+    <form>
+      {% csrf_token %}
+      <!-- Draft Mode Controls -->
+      {% if experiment.is_draft %}
+        <div id="default-controls" class="alert alert-secondary">
           <p>
-            <strong>We recommend previewing before launch</strong>
+            Do you want to test this experiment before launching to production?
+            <a href="{{ EXTERNAL_URLS.PREVIEW_LAUNCH_DOC }}"
+               target="_blank"
+               class="mr-1">Learn more</a>
+          </p>
+          {% if experiment.can_draft_to_preview %}
             <button type="button"
                     class="btn btn-primary"
                     hx-post="{% url 'nimbus-new-draft-to-preview' slug=experiment.slug %}"
                     hx-select="#content"
                     hx-target="#content"
-                    hx-swap="outerHTML">Preview Now</button>
+                    hx-swap="outerHTML">Preview for Testing</button>
+          {% endif %}
+          {% if experiment.can_draft_to_review %}
+            <button type="button"
+                    class="btn btn-secondary"
+                    onclick="showRecommendation()">Request Launch without Preview</button>
+          {% endif %}
+        </div>
+        <!-- Recommendation Message -->
+        <div id="recommendation-message" class="d-none">
+          <div class="alert alert-warning">
+            <p>
+              <strong>We recommend previewing before launch</strong>
+              <button type="button"
+                      class="btn btn-primary"
+                      hx-post="{% url 'nimbus-new-draft-to-preview' slug=experiment.slug %}"
+                      hx-select="#content"
+                      hx-target="#content"
+                      hx-swap="outerHTML">Preview Now</button>
+            </p>
+            <div class="form-check">
+              <input type="checkbox"
+                     class="form-check-input"
+                     id="checkbox-1"
+                     onchange="toggleSubmitButton()">
+              <label class="form-check-label" for="checkbox-1">I understand the risks associated with launching an experiment</label>
+            </div>
+            <div class="form-check">
+              <input type="checkbox"
+                     class="form-check-input"
+                     id="checkbox-2"
+                     onchange="toggleSubmitButton()">
+              <label class="form-check-label" for="checkbox-2">
+                I have gone through the <a href="{{ EXTERNAL_URLS.TRAINING_AND_PLANNING_DOC }}" target="_blank">experiment onboarding program</a>
+              </label>
+            </div>
+            <button type="button"
+                    class="btn btn-primary"
+                    id="request-launch-button"
+                    hx-post="{% url 'nimbus-new-draft-to-review' slug=experiment.slug %}"
+                    hx-select="#content"
+                    hx-target="#content"
+                    hx-swap="outerHTML"
+                    disabled>Request Launch</button>
+            <button type="button"
+                    class="btn btn-secondary"
+                    hx-post="{% url 'nimbus-new-review-to-draft' slug=experiment.slug %}"
+                    hx-select="#content"
+                    hx-target="#content"
+                    hx-swap="outerHTML">Cancel</button>
+          </div>
+        </div>
+        <!-- Preview Mode Controls -->
+      {% elif experiment.is_preview %}
+        <div class="alert alert-success bg-transparent text-success">
+          <p class="my-1">All set! Your experiment is in Preview mode and you can test it now.</p>
+        </div>
+        <div class="alert alert-secondary">
+          <p class="my-1">
+            This experiment is currently <strong>live for testing</strong>, but you will need to let QA know in your
+            <a href="{{ EXTERNAL_URLS.SIGNOFF_QA }}" target="_blank">PI request</a>. When you have received a sign-off, click “Request Launch” to launch the experiment.
+            <strong>Note: It can take up to an hour before clients receive a preview experiment.</strong>
           </p>
           <div class="form-check">
             <input type="checkbox"
@@ -69,159 +113,122 @@
               I have gone through the <a href="{{ EXTERNAL_URLS.TRAINING_AND_PLANNING_DOC }}" target="_blank">experiment onboarding program</a>
             </label>
           </div>
-          <button type="button"
-                  class="btn btn-primary"
-                  id="request-launch-button"
-                  hx-post="{% url 'nimbus-new-draft-to-review' slug=experiment.slug %}"
-                  hx-select="#content"
-                  hx-target="#content"
-                  hx-swap="outerHTML"
-                  disabled>Request Launch</button>
-          <button type="button"
-                  class="btn btn-secondary"
-                  hx-post="{% url 'nimbus-new-review-to-draft' slug=experiment.slug %}"
-                  hx-select="#content"
-                  hx-target="#content"
-                  hx-swap="outerHTML">Cancel</button>
+          {% if experiment.can_preview_to_review %}
+            <button type="button"
+                    class="btn btn-primary"
+                    id="request-launch-button"
+                    hx-post="{% url 'nimbus-new-preview-to-review' slug=experiment.slug %}"
+                    hx-select="#content"
+                    hx-target="#content"
+                    hx-swap="outerHTML"
+                    disabled>Request Launch</button>
+          {% endif %}
+          {% if experiment.can_preview_to_draft %}
+            <button type="button"
+                    class="btn btn-secondary"
+                    hx-post="{% url 'nimbus-new-preview-to-draft' slug=experiment.slug %}"
+                    hx-select="#content"
+                    hx-target="#content"
+                    hx-swap="outerHTML">Go back to Draft</button>
+          {% endif %}
         </div>
-      </div>
-      <!-- Preview Mode Controls -->
-    {% elif experiment.is_preview %}
-      <div class="alert alert-success bg-transparent text-success">
-        <p class="my-1">All set! Your experiment is in Preview mode and you can test it now.</p>
-      </div>
-      <div class="alert alert-secondary">
-        <p class="my-1">
-          This experiment is currently <strong>live for testing</strong>, but you will need to let QA know in your
-          <a href="{{ EXTERNAL_URLS.SIGNOFF_QA }}" target="_blank">PI request</a>. When you have received a sign-off, click “Request Launch” to launch the experiment.
-          <strong>Note: It can take up to an hour before clients receive a preview experiment.</strong>
-        </p>
-        <div class="form-check">
-          <input type="checkbox"
-                 class="form-check-input"
-                 id="checkbox-1"
-                 onchange="toggleSubmitButton()">
-          <label class="form-check-label" for="checkbox-1">I understand the risks associated with launching an experiment</label>
+        <div class="alert alert-light border my-3">
+          <h5 class="mb-2">Preview URL</h5>
+          <p class="mb-1">
+            <strong> Click the <code>about:studies</code> link below to copy</strong> then paste it in your browser. Ensure you enable <code>nimbus.debug</code> in <code>about:config</code> first.
+          </p>
+          <label for="branch-selector" class="form-label mt-2">Select Branch</label>
+          <select id="branch-selector"
+                  class="form-select mb-3"
+                  onchange="updatePreviewURL()">
+            {% for branch in experiment.branches.all %}
+              <option value="{{ branch.slug }}"
+                      {% if branch == experiment.reference_branch %}selected{% endif %}>{{ branch.name }}</option>
+            {% endfor %}
+          </select>
+          <code id="preview-url" class="d-block text-danger user-select-all">
+            about:studies?optin_slug={{ experiment.slug }}&optin_branch={{ experiment.reference_branch.slug }}&optin_collection=nimbus-preview
+          </code>
         </div>
-        <div class="form-check">
-          <input type="checkbox"
-                 class="form-check-input"
-                 id="checkbox-2"
-                 onchange="toggleSubmitButton()">
-          <label class="form-check-label" for="checkbox-2">
-            I have gone through the <a href="{{ EXTERNAL_URLS.TRAINING_AND_PLANNING_DOC }}" target="_blank">experiment onboarding program</a>
-          </label>
+        <!-- Review Mode Controls -->
+      {% elif experiment|should_show_remote_settings_pending:user %}
+        <div class="alert alert-danger" role="alert">
+          <p>
+            <strong>Action required:</strong>
+            Please review this change in Remote Settings to {{ experiment.remote_settings_pending_message }}.
+          </p>
+          <a href="{{ experiment.review_url }}"
+             class="btn btn-primary"
+             target="_blank"
+             rel="noopener noreferrer">Open Remote Settings</a>
         </div>
-        {% if experiment.can_preview_to_review %}
-          <button type="button"
-                  class="btn btn-primary"
-                  id="request-launch-button"
-                  hx-post="{% url 'nimbus-new-preview-to-review' slug=experiment.slug %}"
-                  hx-select="#content"
-                  hx-target="#content"
-                  hx-swap="outerHTML"
-                  disabled>Request Launch</button>
-        {% endif %}
-        {% if experiment.can_preview_to_draft %}
-          <button type="button"
-                  class="btn btn-secondary"
-                  hx-post="{% url 'nimbus-new-preview-to-draft' slug=experiment.slug %}"
-                  hx-select="#content"
-                  hx-target="#content"
-                  hx-swap="outerHTML">Go back to Draft</button>
-        {% endif %}
-      </div>
-      <div class="alert alert-light border my-3">
-        <h5 class="mb-2">Preview URL</h5>
-        <p class="mb-1">
-          <strong> Click the <code>about:studies</code> link below to copy</strong> then paste it in your browser. Ensure you enable <code>nimbus.debug</code> in <code>about:config</code> first.
-        </p>
-        <label for="branch-selector" class="form-label mt-2">Select Branch</label>
-        <select id="branch-selector"
-                class="form-select mb-3"
-                onchange="updatePreviewURL()">
-          {% for branch in experiment.branches.all %}
-            <option value="{{ branch.slug }}"
-                    {% if branch == experiment.reference_branch %}selected{% endif %}>{{ branch.name }}</option>
-          {% endfor %}
-        </select>
-        <code id="preview-url" class="d-block text-danger user-select-all">
-          about:studies?optin_slug={{ experiment.slug }}&optin_branch={{ experiment.reference_branch.slug }}&optin_collection=nimbus-preview
-        </code>
-      </div>
-      <!-- Review Mode Controls -->
-    {% elif experiment|should_show_remote_settings_pending:user %}
-      <div class="alert alert-danger" role="alert">
-        <p>
-          <strong>Action required:</strong>
-          Please review this change in Remote Settings to {{ experiment.remote_settings_pending_message }}.
-        </p>
-        <a href="{{ experiment.review_url }}"
-           class="btn btn-primary"
-           target="_blank"
-           rel="noopener noreferrer">Open Remote Settings</a>
-      </div>
-    {% elif experiment.is_review %}
-      {% if experiment.is_rollout %}
-        {% include "nimbus_experiments/approval_rejection_controls.html" with action_label="Launch Rollout" approval_url="nimbus-new-review-to-approve" cancel_reject_url="nimbus-new-review-to-draft" experiment=experiment %}
-
-      {% else %}
-        {% include "nimbus_experiments/approval_rejection_controls.html" with action_label="Launch Experiment" approval_url="nimbus-new-review-to-approve" cancel_reject_url="nimbus-new-review-to-draft" experiment=experiment %}
-
-      {% endif %}
-    {% elif experiment.is_enrolling or experiment.is_observation %}
-      {% if experiment.is_rollout_update_requested %}
-        {% include "nimbus_experiments/approval_rejection_controls.html" with action_label="Update Rollout" approval_url="nimbus-new-approve-update-rollout" cancel_reject_url="nimbus-new-cancel-update-rollout" experiment=experiment %}
-
-      {% elif experiment.is_enrollment_pause_requested %}
-        {% include "nimbus_experiments/approval_rejection_controls.html" with action_label="End Enrollment" approval_url="nimbus-new-approve-end-enrollment" cancel_reject_url="nimbus-new-cancel-end-enrollment" experiment=experiment %}
-
-      {% elif experiment.is_end_experiment_requested %}
+      {% elif experiment.is_review %}
         {% if experiment.is_rollout %}
-          {% include "nimbus_experiments/approval_rejection_controls.html" with action_label="End Rollout" approval_url="nimbus-new-approve-end-rollout" cancel_reject_url="nimbus-new-cancel-end-rollout" experiment=experiment %}
+          {% include "nimbus_experiments/approval_rejection_controls.html" with action_label="Launch Rollout" approval_url="nimbus-new-review-to-approve" cancel_reject_url="nimbus-new-review-to-draft" experiment=experiment %}
 
         {% else %}
-          {% include "nimbus_experiments/approval_rejection_controls.html" with action_label="End Experiment" approval_url="nimbus-new-approve-end-experiment" cancel_reject_url="nimbus-new-cancel-end-experiment" experiment=experiment %}
+          {% include "nimbus_experiments/approval_rejection_controls.html" with action_label="Launch Experiment" approval_url="nimbus-new-review-to-approve" cancel_reject_url="nimbus-new-review-to-draft" experiment=experiment %}
 
         {% endif %}
-      {% elif experiment.should_show_end_enrollment or experiment.should_show_end_experiment or experiment.should_show_end_rollout or experiment.should_show_rollout_request_update %}
-        <div id="default-controls" class="alert alert-primary mt-3">
-          <h5 class="mb-3 ms-2">Actions</h5>
-          {% if experiment.should_show_end_enrollment %}
-            <button type="button"
-                    hx-post="{% url 'nimbus-new-live-to-end-enrollment' slug=experiment.slug %}"
-                    hx-select="#content"
-                    hx-target="#content"
-                    hx-swap="outerHTML"
-                    class="btn btn-primary m-2">End Enrollment</button>
+      {% elif experiment.is_enrolling or experiment.is_observation %}
+        {% if experiment.is_rollout_update_requested %}
+          {% include "nimbus_experiments/approval_rejection_controls.html" with action_label="Update Rollout" approval_url="nimbus-new-approve-update-rollout" cancel_reject_url="nimbus-new-cancel-update-rollout" experiment=experiment %}
+
+        {% elif experiment.is_enrollment_pause_requested %}
+          {% include "nimbus_experiments/approval_rejection_controls.html" with action_label="End Enrollment" approval_url="nimbus-new-approve-end-enrollment" cancel_reject_url="nimbus-new-cancel-end-enrollment" experiment=experiment %}
+
+        {% elif experiment.is_end_experiment_requested %}
+          {% if experiment.is_rollout %}
+            {% include "nimbus_experiments/approval_rejection_controls.html" with action_label="End Rollout" approval_url="nimbus-new-approve-end-rollout" cancel_reject_url="nimbus-new-cancel-end-rollout" experiment=experiment %}
+
+          {% else %}
+            {% include "nimbus_experiments/approval_rejection_controls.html" with action_label="End Experiment" approval_url="nimbus-new-approve-end-experiment" cancel_reject_url="nimbus-new-cancel-end-experiment" experiment=experiment %}
+
           {% endif %}
-          {% if experiment.should_show_end_experiment %}
-            <button type="button"
-                    hx-post="{% url 'nimbus-new-live-to-complete' slug=experiment.slug %}"
-                    hx-select="#content"
-                    hx-target="#content"
-                    hx-swap="outerHTML"
-                    class="btn btn-primary">End Experiment</button>
-          {% endif %}
-          {% if experiment.should_show_rollout_request_update %}
-            <button type="button"
-                    hx-post="{% url 'nimbus-new-live-to-update-rollout' slug=experiment.slug %}"
-                    hx-select="#content"
-                    hx-target="#content"
-                    hx-swap="outerHTML"
-                    class="btn btn-primary"
-                    {% if not experiment.is_rollout_dirty %}disabled{% endif %}>Request Update</button>
-          {% endif %}
-          {% if experiment.should_show_end_rollout %}
-            <button type="button"
-                    hx-post="{% url 'nimbus-new-live-to-complete-rollout' slug=experiment.slug %}"
-                    hx-select="#content"
-                    hx-target="#content"
-                    hx-swap="outerHTML"
-                    class="btn btn-primary">End Rollout</button>
-          {% endif %}
-        </div>
+        {% elif experiment.should_show_end_enrollment or experiment.should_show_end_experiment or experiment.should_show_end_rollout or experiment.should_show_rollout_request_update %}
+          <div id="default-controls" class="alert alert-primary mt-3">
+            <h5 class="mb-3 ms-2">Actions</h5>
+            {% if experiment.should_show_end_enrollment %}
+              <button type="button"
+                      hx-post="{% url 'nimbus-new-live-to-end-enrollment' slug=experiment.slug %}"
+                      hx-select="#content"
+                      hx-target="#content"
+                      hx-swap="outerHTML"
+                      class="btn btn-primary m-2">End Enrollment</button>
+            {% endif %}
+            {% if experiment.should_show_end_experiment %}
+              <button type="button"
+                      hx-post="{% url 'nimbus-new-live-to-complete' slug=experiment.slug %}"
+                      hx-select="#content"
+                      hx-target="#content"
+                      hx-swap="outerHTML"
+                      class="btn btn-primary">End Experiment</button>
+            {% endif %}
+            {% if experiment.should_show_rollout_request_update %}
+              <button type="button"
+                      hx-post="{% url 'nimbus-new-live-to-update-rollout' slug=experiment.slug %}"
+                      hx-select="#content"
+                      hx-target="#content"
+                      hx-swap="outerHTML"
+                      class="btn btn-primary"
+                      {% if not experiment.is_rollout_dirty %}disabled{% endif %}>Request Update</button>
+            {% endif %}
+            {% if experiment.should_show_end_rollout %}
+              <button type="button"
+                      hx-post="{% url 'nimbus-new-live-to-complete-rollout' slug=experiment.slug %}"
+                      hx-select="#content"
+                      hx-target="#content"
+                      hx-swap="outerHTML"
+                      class="btn btn-primary">End Rollout</button>
+            {% endif %}
+          </div>
+        {% endif %}
       {% endif %}
-    {% endif %}
-  </form>
+    </form>
+  {% else %}
+    <div class="alert alert-danger" role="alert">
+      This experiment cannot be launched due to an internal Experimenter error.
+      Please ask in <code>#ask-experimenter</code>.
+    </div>
+  {% endif %}
 </div>

--- a/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/launch_controls.html
+++ b/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/launch_controls.html
@@ -1,7 +1,7 @@
 {% load nimbus_extras %}
 
 <div id="launch-controls">
-  {% if ready %}
+  {% if experiment.is_ready_to_launch %}
     {% with rejection=experiment.rejection_block %}
       {% if rejection %}
         <div class="alert alert-warning"
@@ -227,8 +227,20 @@
     </form>
   {% else %}
     <div class="alert alert-danger" role="alert">
-      This experiment cannot be launched due to an internal Experimenter error.
-      Please ask in <code>#ask-experimenter</code>.
+      <p class="mb-1">This experiment cannot be launched due to the following validation errors:</p>
+      <ul class="mb-2">
+        {% for field, errors in experiment.get_invalid_fields_errors.items %}
+          <li>
+            <strong>{{ field|remove_underscores|title }}:</strong>
+            <ul class="mb-1">
+              {% for error in errors %}<li>{{ error }}</li>{% endfor %}
+            </ul>
+          </li>
+        {% endfor %}
+      </ul>
+      <p class="mb-0">
+        Please fix the above issues or ask in <code>#ask-experimenter</code>.
+      </p>
     </div>
   {% endif %}
 </div>

--- a/experimenter/experimenter/nimbus_ui_new/tests/test_views.py
+++ b/experimenter/experimenter/nimbus_ui_new/tests/test_views.py
@@ -1201,6 +1201,28 @@ class NimbusExperimentDetailViewTest(AuthTestCase):
         self.assertNotIn(self.user, self.experiment.subscribers.all())
         self.assertEqual(response.status_code, 200)
 
+    def test_ready_is_false_if_review_serializer_invalid(self):
+        experiment = NimbusExperimentFactory.create(
+            public_description="",
+            population_percent=0,
+            total_enrolled_clients=0,
+            proposed_enrollment=0,
+            proposed_duration=0,
+            hypothesis=NimbusExperiment.HYPOTHESIS_DEFAULT,
+            feature_configs=[],
+        )
+
+        response = self.client.get(
+            reverse("nimbus-new-detail", kwargs={"slug": experiment.slug})
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("ready", response.context)
+        self.assertFalse(
+            response.context["ready"],
+            "`ready` should be False when the review serializer is invalid",
+        )
+
 
 class TestNimbusExperimentsCreateView(AuthTestCase):
     def test_post_creates_experiment(self):

--- a/experimenter/experimenter/nimbus_ui_new/tests/test_views.py
+++ b/experimenter/experimenter/nimbus_ui_new/tests/test_views.py
@@ -1212,15 +1212,12 @@ class NimbusExperimentDetailViewTest(AuthTestCase):
             feature_configs=[],
         )
 
-        response = self.client.get(
-            reverse("nimbus-new-detail", kwargs={"slug": experiment.slug})
-        )
+        self.client.get(reverse("nimbus-new-detail", kwargs={"slug": experiment.slug}))
 
-        self.assertEqual(response.status_code, 200)
-        self.assertIn("ready", response.context)
+        experiment.get_invalid_fields_errors()
         self.assertFalse(
-            response.context["ready"],
-            "`ready` should be False when the review serializer is invalid",
+            experiment.is_ready_to_launch,
+            "Expected experiment.is_ready_to_launch to be False due to validation errors",
         )
 
 

--- a/experimenter/experimenter/nimbus_ui_new/tests/test_views.py
+++ b/experimenter/experimenter/nimbus_ui_new/tests/test_views.py
@@ -1212,12 +1212,15 @@ class NimbusExperimentDetailViewTest(AuthTestCase):
             feature_configs=[],
         )
 
-        self.client.get(reverse("nimbus-new-detail", kwargs={"slug": experiment.slug}))
+        response = self.client.get(
+            reverse("nimbus-new-detail", kwargs={"slug": experiment.slug})
+        )
 
-        experiment.get_invalid_fields_errors()
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("validation_errors", response.context)
         self.assertFalse(
-            experiment.is_ready_to_launch,
-            "Expected experiment.is_ready_to_launch to be False due to validation errors",
+            response.context["is_ready_to_launch"],
+            "`is_ready_to_launch` should be False when the review serializer is invalid",
         )
 
 

--- a/experimenter/experimenter/nimbus_ui_new/views.py
+++ b/experimenter/experimenter/nimbus_ui_new/views.py
@@ -6,6 +6,7 @@ from django.views.generic import CreateView, DetailView
 from django.views.generic.edit import UpdateView
 from django_filters.views import FilterView
 
+from experimenter.experiments.api.v5.serializers import NimbusReviewSerializer
 from experimenter.experiments.constants import EXTERNAL_URLS, RISK_QUESTIONS
 from experimenter.experiments.models import (
     NimbusExperiment,
@@ -239,6 +240,11 @@ class NimbusExperimentDetailView(
             context["form"] = QAStatusForm(instance=self.object)
         if context["takeaways_edit_mode"]:
             context["takeaways_form"] = TakeawaysForm(instance=self.object)
+
+        experiment = self.object
+        review_serializer = NimbusReviewSerializer(experiment)
+        serializer = NimbusReviewSerializer(experiment, data=review_serializer.data)
+        context["ready"] = serializer.is_valid()
 
         return context
 

--- a/experimenter/experimenter/nimbus_ui_new/views.py
+++ b/experimenter/experimenter/nimbus_ui_new/views.py
@@ -6,7 +6,6 @@ from django.views.generic import CreateView, DetailView
 from django.views.generic.edit import UpdateView
 from django_filters.views import FilterView
 
-from experimenter.experiments.api.v5.serializers import NimbusReviewSerializer
 from experimenter.experiments.constants import EXTERNAL_URLS, RISK_QUESTIONS
 from experimenter.experiments.models import (
     NimbusExperiment,
@@ -240,11 +239,6 @@ class NimbusExperimentDetailView(
             context["form"] = QAStatusForm(instance=self.object)
         if context["takeaways_edit_mode"]:
             context["takeaways_form"] = TakeawaysForm(instance=self.object)
-
-        experiment = self.object
-        review_serializer = NimbusReviewSerializer(experiment)
-        serializer = NimbusReviewSerializer(experiment, data=review_serializer.data)
-        context["ready"] = serializer.is_valid()
 
         return context
 


### PR DESCRIPTION
Because

- If the targeting selected requires is sticky to be true, then the new UI summary page doesn't show the error
- If there is error where it is not mapped to any field, show the error to the user and let them know about the issue

This commit

- Adds the fields to show the `is_sticky` error
- Adds the regular check if serializer is failing, don't let the users launch the experiment and show them the error with the message

Fixes #12980 
<img width="1059" height="296" alt="Screenshot 2025-07-11 at 10 30 13 AM" src="https://github.com/user-attachments/assets/88b560a1-af0e-47b1-948e-f5a8a16e4680" />
<img width="1059" height="296" alt="Screenshot 2025-07-11 at 10 29 57 AM" src="https://github.com/user-attachments/assets/799c8d91-b3f3-403c-9398-5c3ae026dd84" />
<img width="1089" height="197" alt="Screenshot 2025-07-14 at 9 52 08 AM" src="https://github.com/user-attachments/assets/dfde8edb-f584-45ec-903f-ac2f42f48964" />
