### PR TITLE
chore(nimbus): map validation errors to form fields

### DIFF
--- a/experimenter/experimenter/experiments/models.py
+++ b/experimenter/experimenter/experiments/models.py
@@ -1635,22 +1635,6 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
 
             return errors
 
-    @property
-    def get_invalid_pages(self):
-        field_errors = self.get_invalid_fields_errors()
-
-        if not field_errors:
-            return []
-
-        error_fields = field_errors.keys()
-        pages_with_errors = []
-
-        for page, fields in NimbusUIConstants.FIELD_PAGE_MAP.items():
-            if any(field in error_fields for field in fields):
-                pages_with_errors.append(page)
-
-        return pages_with_errors
-
     def clone(self, name, user, rollout_branch_slug=None, changed_on=None):
         # Inline import to prevent circular import
         from experimenter.experiments.changelog_utils import generate_nimbus_changelog

--- a/experimenter/experimenter/experiments/tests/test_models.py
+++ b/experimenter/experimenter/experiments/tests/test_models.py
@@ -4033,38 +4033,6 @@ class TestNimbusExperiment(TestCase):
         recipe_json_keys = sorted(json.loads(experiment.recipe_json.replace("\n", "")))
         self.assertEqual(serialized_keys, recipe_json_keys)
 
-    def test_get_invalid_pages(self):
-        experiment_1 = NimbusExperimentFactory.create(
-            name="test-experiment-1",
-            public_description="",
-        )
-        invalid_pages = experiment_1.get_invalid_pages
-        self.assertEqual(invalid_pages, ["overview"])
-
-        experiment_2 = NimbusExperimentFactory.create(
-            name="test-experiment-2",
-            feature_configs=[],
-            population_percent=0,
-        )
-        invalid_pages = experiment_2.get_invalid_pages
-        self.assertEqual(invalid_pages, ["branches", "audience"])
-
-        experiment_3 = NimbusExperimentFactory.create(
-            name="test-experiment-3",
-            public_description="",
-            population_percent=0,
-        )
-        invalid_pages = experiment_3.get_invalid_pages
-        self.assertEqual(invalid_pages, ["overview", "audience"])
-
-        experiment_4 = NimbusExperimentFactory.create(
-            name="test-experiment-4",
-            firefox_min_version=NimbusExperiment.Version.FIREFOX_129,
-            is_sticky=True,
-        )
-        invalid_pages = experiment_4.get_invalid_pages
-        self.assertEqual(invalid_pages, [])
-
     def test_get_invalid_fields_errors(self):
         experiment_1 = NimbusExperimentFactory.create(
             name="test-experiment-1",
@@ -4108,26 +4076,6 @@ class TestNimbusExperiment(TestCase):
             "excluded experiments",
             errors["required_experiments_branches"],
         )
-
-    def test_invalid_pages_for_missing_sticky_requirement(self):
-        experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperimentFactory.Lifecycles.CREATED,
-            application=NimbusExperiment.Application.DESKTOP,
-            firefox_min_version=NimbusExperiment.Version.FIREFOX_100,
-            firefox_max_version=NimbusExperiment.Version.FIREFOX_101,
-            targeting_config_slug=NimbusExperiment.TargetingConfig.FIRST_RUN,
-            channel=NimbusExperiment.Channel.RELEASE,
-            is_sticky=False,
-        )
-
-        errors = experiment.get_invalid_fields_errors()
-        self.assertIn("is_sticky", errors)
-        self.assertTrue(
-            any("sticky" in msg.lower() for msg in errors["is_sticky"]),
-            msg="Expected sticky-related error message on is_sticky field",
-        )
-        invalid_pages = experiment.get_invalid_pages
-        self.assertIn("audience", invalid_pages)
 
     @parameterized.expand(
         [

--- a/experimenter/experimenter/nimbus_ui_new/constants.py
+++ b/experimenter/experimenter/nimbus_ui_new/constants.py
@@ -80,36 +80,3 @@ Optional - We believe this outcome will <describe impact> on <core metric>
         LAUNCH_ROLLOUT = "launch this rollout"
         UPDATE_ROLLOUT = "update this rollout"
         END_ROLLOUT = "end this rollout"
-
-    FIELD_PAGE_MAP = {
-        "overview": [
-            "projects",
-            "public_description",
-            "risk_brand",
-            "risk_message",
-            "risk_revenue",
-            "risk_partner_related",
-        ],
-        "branches": [
-            "reference_branch",
-            "treatment_branches",
-            "feature_configs",
-            "is_rollout",
-            "localizations",
-        ],
-        "audience": [
-            "channel",
-            "firefox_min_version",
-            "languages",
-            "locales",
-            "countries",
-            "targeting_config_slug",
-            "proposed_enrollment",
-            "proposed_duration",
-            "population_percent",
-            "total_enrolled_clients",
-            "required_experiments_branches",
-            "excluded_experiments_branches",
-            "is_sticky",
-        ],
-    }

--- a/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/detail.html
+++ b/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/detail.html
@@ -8,41 +8,39 @@
 {% block main_content %}
   {% if experiment.is_draft %}
     <!-- Invalid Pages Warnings Card -->
-    {% with invalid_pages=experiment.get_invalid_pages %}
-      {% if invalid_pages %}
-        <div class="alert alert-danger" role="alert">
-          <p class="mb-1">
-            Before this experiment can be reviewed or launched, all required fields must be completed. Fields on the
-            <strong>
-              {% for page in invalid_pages %}
-                {% if page == "overview" %}
-                  <a href="{{ experiment.get_update_overview_url }}?show_errors=true"
-                     rel="noopener noreferrer">Overview</a>
-                {% elif page == "branches" %}
-                  <a href="{{ experiment.get_update_branches_url }}?show_errors=true"
-                     rel="noopener noreferrer">Branches</a>
-                {% elif page == "metrics" %}
-                  <a href="{{ experiment.get_update_metrics_url }}?show_errors=true"
-                     rel="noopener noreferrer">Metrics</a>
-                {% elif page == "audience" %}
-                  <a href="{{ experiment.get_update_audience_url }}?show_errors=true"
-                     rel="noopener noreferrer">Audience</a>
-                {% else %}
-                  {{ page|capfirst }}
-                {% endif %}
-                {% if not forloop.last %},{% endif %}
-              {% endfor %}
-            </strong>
-            {% if invalid_pages|length == 1 %}
-              page
-            {% else %}
-              pages
-            {% endif %}
-            are missing details.
-          </p>
-        </div>
-      {% endif %}
-    {% endwith %}
+    {% if invalid_pages %}
+      <div class="alert alert-danger" role="alert">
+        <p class="mb-1">
+          Before this experiment can be reviewed or launched, all required fields must be completed. Fields on the
+          <strong>
+            {% for page in invalid_pages %}
+              {% if page == "overview" %}
+                <a href="{{ experiment.get_update_overview_url }}?show_errors=true"
+                   rel="noopener noreferrer">Overview</a>
+              {% elif page == "branches" %}
+                <a href="{{ experiment.get_update_branches_url }}?show_errors=true"
+                   rel="noopener noreferrer">Branches</a>
+              {% elif page == "metrics" %}
+                <a href="{{ experiment.get_update_metrics_url }}?show_errors=true"
+                   rel="noopener noreferrer">Metrics</a>
+              {% elif page == "audience" %}
+                <a href="{{ experiment.get_update_audience_url }}?show_errors=true"
+                   rel="noopener noreferrer">Audience</a>
+              {% else %}
+                {{ page|capfirst }}
+              {% endif %}
+              {% if not forloop.last %},{% endif %}
+            {% endfor %}
+          </strong>
+          {% if invalid_pages|length == 1 %}
+            page
+          {% else %}
+            pages
+          {% endif %}
+          are missing details.
+        </p>
+      </div>
+    {% endif %}
   {% endif %}
   <!-- Audience Overlap Warnings Card -->
   {% if experiment.audience_overlap_warnings %}

--- a/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/launch_controls.html
+++ b/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/launch_controls.html
@@ -1,7 +1,7 @@
 {% load nimbus_extras %}
 
 <div id="launch-controls">
-  {% if not is_ready_to_launch %}
+  {% if non_page_errors %}
     <div class="alert alert-danger" role="alert">
       <p class="mb-1">This experiment cannot be launched due to the following validation errors:</p>
       <ul class="mb-2">

--- a/experimenter/experimenter/nimbus_ui_new/tests/test_views.py
+++ b/experimenter/experimenter/nimbus_ui_new/tests/test_views.py
@@ -1218,6 +1218,9 @@ class NimbusExperimentDetailViewTest(AuthTestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertIn("validation_errors", response.context)
+        self.assertEqual(
+            set(response.context["invalid_pages"]), {"overview", "branches", "audience"}
+        )
         self.assertFalse(
             response.context["is_ready_to_launch"],
             "`is_ready_to_launch` should be False when the review serializer is invalid",


### PR DESCRIPTION
Becuase

* When the review serializer is invalid, we want to direct the user to the page with the errors
* If we have an explicit map of fields to pages, we can forget to add a field to that list
* Instead we should use the list of fields defined on the forms
* That way if we add/change a field on a form, it will automatically be mapped correctly

This commit

* Removes the explicit map of fields to pages
* Moves the page mapping logic to the ValidationMixin
* Uses the form field lists to map to pages

fixes #13000

