### PR TITLE
feat(nimbus): validate primary secondary outcome intersection

### DIFF
--- a/experimenter/experimenter/experiments/api/v5/serializers.py
+++ b/experimenter/experimenter/experiments/api/v5/serializers.py
@@ -2290,6 +2290,24 @@ class NimbusReviewSerializer(serializers.ModelSerializer):
 
         return data
 
+    def _validate_primary_secondary_outcomes(self, data):
+        primary_outcomes = set(data.get("primary_outcomes", []))
+        secondary_outcomes = set(data.get("secondary_outcomes", []))
+
+        if primary_outcomes.intersection(secondary_outcomes):
+            raise serializers.ValidationError(
+                {
+                    "primary_outcomes": [
+                        NimbusExperiment.ERROR_PRIMARY_SECONDARY_OUTCOMES_INTERSECTION
+                    ],
+                    "secondary_outcomes": [
+                        NimbusExperiment.ERROR_PRIMARY_SECONDARY_OUTCOMES_INTERSECTION
+                    ],
+                }
+            )
+
+        return data
+
     def validate(self, data):
         application = data.get("application")
         channel = data.get("channel")
@@ -2307,6 +2325,7 @@ class NimbusReviewSerializer(serializers.ModelSerializer):
         data = self._validate_bucket_duplicates(data)
         data = self._validate_proposed_release_date(data)
         data = self._validate_feature_value_variables(data)
+        data = self._validate_primary_secondary_outcomes(data)
         if application == NimbusExperiment.Application.DESKTOP:
             data = self._validate_desktop_pref_rollouts(data)
             data = self._validate_desktop_pref_flips(data)

--- a/experimenter/experimenter/experiments/constants.py
+++ b/experimenter/experimenter/experiments/constants.py
@@ -955,6 +955,10 @@ Optional - We believe this outcome will <describe impact> on <core metric>
 
     ERROR_FML_VALIDATION = "Feature Manifest errors occurred during validation"
 
+    ERROR_PRIMARY_SECONDARY_OUTCOMES_INTERSECTION = (
+        "Primary outcomes cannot overlap with secondary outcomes."
+    )
+
     # Analysis can be computed starting the week after enrollment
     # completion for "week 1" of the experiment. However, an extra
     # buffer day is added for Jetstream to compute the results.

--- a/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/edit_metrics.html
+++ b/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/edit_metrics.html
@@ -39,6 +39,7 @@
             <div class="rounded border border-1 p-0 {% if form.is_bound %}border-success{% endif %}">
               {{ form.primary_outcomes }}
             </div>
+            {% for error in validation_errors.primary_outcomes %}<div class="form-text text-danger">{{ error }}</div>{% endfor %}
             <p class="form-text">
               Select the user action or feature that you are measuring with this experiment. You may select up to 2 primary outcomes.
             </p>
@@ -57,6 +58,9 @@
             <div class="rounded border border-1 p-0 {% if form.is_bound %}border-success{% endif %}">
               {{ form.secondary_outcomes }}
             </div>
+            {% for error in validation_errors.secondary_outcomes %}
+              <div class="form-text text-danger">{{ error }}</div>
+            {% endfor %}
             <p class="form-text">Select the user action or feature that you are measuring with this experiment.</p>
           </div>
         </div>

--- a/experimenter/experimenter/nimbus_ui_new/views.py
+++ b/experimenter/experimenter/nimbus_ui_new/views.py
@@ -467,6 +467,7 @@ class MetricsUpdateView(
     RequestFormMixin,
     RenderResponseMixin,
     CloneExperimentFormMixin,
+    ValidationErrorsMixin,
     UpdateView,
 ):
     form_class = MetricsForm


### PR DESCRIPTION
Because
    
* The old Nimbus UI would dynamically remove selected primary/secondary outcomes from the drop downs
* We didn't do the same thing in the new HTMX UI
* This means a user could select an outcome for both primary and secondary
* We should prevent that with the review serializer
    
This commit
    
* Adds a new check to the review serializer to prevent an outcome from being selected as both primary and secondary
* Hooks up the review serializer to the metrics page
    
fixes #11399