### PR TITLE
chore(nimbus): set valid defaults in experiment factory

### DIFF
--- a/experimenter/experimenter/experiments/tests/api/v5/test_mutations.py
+++ b/experimenter/experimenter/experiments/tests/api/v5/test_mutations.py
@@ -800,7 +800,6 @@ class TestUpdateExperimentMutationSingleFeature(
             proposed_duration=0,
             proposed_enrollment=0,
             proposed_release_date=None,
-            targeting_config_slug=NimbusExperiment.TargetingConfig.NO_TARGETING,
             total_enrolled_clients=0,
             is_sticky=False,
         )
@@ -863,7 +862,6 @@ class TestUpdateExperimentMutationSingleFeature(
             population_percent=0.0,
             proposed_duration=0,
             proposed_enrollment=0,
-            targeting_config_slug=NimbusExperiment.TargetingConfig.NO_TARGETING,
             total_enrolled_clients=0,
         )
         response = self.query(

--- a/experimenter/experimenter/experiments/tests/api/v5/test_queries.py
+++ b/experimenter/experimenter/experiments/tests/api/v5/test_queries.py
@@ -1190,7 +1190,6 @@ class TestNimbusExperimentBySlugQuery(GraphQLTestCase):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.CREATED,
             application=NimbusExperiment.Application.DESKTOP,
-            targeting_config_slug=NimbusExperiment.TargetingConfig.NO_TARGETING,
             feature_configs=[
                 NimbusFeatureConfigFactory(
                     application=NimbusExperiment.Application.DESKTOP

--- a/experimenter/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_experiment_serializer.py
+++ b/experimenter/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_experiment_serializer.py
@@ -486,7 +486,6 @@ class TestNimbusExperimentSerializer(TestCase):
             proposed_duration=0,
             proposed_enrollment=0,
             proposed_release_date=None,
-            targeting_config_slug=NimbusExperiment.TargetingConfig.NO_TARGETING,
             total_enrolled_clients=0,
             is_sticky=False,
         )

--- a/experimenter/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_ready_for_review_serializer.py
+++ b/experimenter/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_ready_for_review_serializer.py
@@ -1092,7 +1092,6 @@ class TestNimbusReviewSerializerSingleFeature(MockFmlErrorMixin, TestCase):
             application=NimbusExperiment.Application.DESKTOP,
             channel=NimbusExperiment.Channel.NO_CHANNEL,
             warn_feature_schema=True,
-            targeting_config_slug=NimbusExperiment.TargetingConfig.NO_TARGETING,
             feature_configs=[
                 NimbusFeatureConfigFactory.create(
                     application=NimbusExperiment.Application.DESKTOP,
@@ -1193,7 +1192,6 @@ class TestNimbusReviewSerializerSingleFeature(MockFmlErrorMixin, TestCase):
             application=NimbusExperiment.Application.DESKTOP,
             channel=NimbusExperiment.Channel.NO_CHANNEL,
             warn_feature_schema=True,
-            targeting_config_slug=NimbusExperiment.TargetingConfig.NO_TARGETING,
             feature_configs=[
                 NimbusFeatureConfigFactory.create(
                     application=NimbusExperiment.Application.DESKTOP,
@@ -1247,7 +1245,6 @@ class TestNimbusReviewSerializerSingleFeature(MockFmlErrorMixin, TestCase):
             application=NimbusExperiment.Application.DESKTOP,
             channel=NimbusExperiment.Channel.NO_CHANNEL,
             warn_feature_schema=True,
-            targeting_config_slug=NimbusExperiment.TargetingConfig.NO_TARGETING,
             feature_configs=[
                 NimbusFeatureConfigFactory.create(
                     application=NimbusExperiment.Application.DESKTOP,
@@ -1757,7 +1754,6 @@ class TestNimbusReviewSerializerSingleFeature(MockFmlErrorMixin, TestCase):
             status=NimbusExperiment.Status.DRAFT,
             application=NimbusExperiment.Application.DESKTOP,
             channel=NimbusExperiment.Channel.NO_CHANNEL,
-            targeting_config_slug=NimbusExperiment.TargetingConfig.NO_TARGETING,
             feature_configs=[
                 NimbusFeatureConfigFactory.create(
                     application=NimbusExperiment.Application.DESKTOP,
@@ -2525,7 +2521,6 @@ class TestNimbusReviewSerializerSingleFeature(MockFmlErrorMixin, TestCase):
     def test_targeting_exclude_require_self(self, field):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.CREATED,
-            targeting_config_slug=NimbusExperiment.TargetingConfig.NO_TARGETING,
             firefox_min_version=NimbusExperiment.EXCLUDED_REQUIRED_MIN_VERSION,
         )
 
@@ -2559,14 +2554,12 @@ class TestNimbusReviewSerializerSingleFeature(MockFmlErrorMixin, TestCase):
         other = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.CREATED,
             application=app1,
-            targeting_config_slug=NimbusExperiment.TargetingConfig.NO_TARGETING,
             firefox_min_version=NimbusExperiment.MIN_REQUIRED_VERSION,
         )
 
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.CREATED,
             application=app2,
-            targeting_config_slug=NimbusExperiment.TargetingConfig.NO_TARGETING,
             firefox_min_version=NimbusExperiment.EXCLUDED_REQUIRED_MIN_VERSION,
             **{field: [other]},
         )
@@ -2604,14 +2597,12 @@ class TestNimbusReviewSerializerSingleFeature(MockFmlErrorMixin, TestCase):
         other = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.CREATED,
             application=application,
-            targeting_config_slug=NimbusExperiment.TargetingConfig.NO_TARGETING,
             firefox_min_version=NimbusExperiment.MIN_REQUIRED_VERSION,
         )
 
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.CREATED,
             application=application,
-            targeting_config_slug=NimbusExperiment.TargetingConfig.NO_TARGETING,
             firefox_min_version=NimbusExperiment.Version.FIREFOX_115,
             **{field: [other]},
         )
@@ -2641,13 +2632,11 @@ class TestNimbusReviewSerializerSingleFeature(MockFmlErrorMixin, TestCase):
     def test_targeting_exclude_require_mutally_exclusive(self):
         other = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.CREATED,
-            targeting_config_slug=NimbusExperiment.TargetingConfig.NO_TARGETING,
             firefox_min_version=NimbusExperiment.MIN_REQUIRED_VERSION,
         )
 
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.CREATED,
-            targeting_config_slug=NimbusExperiment.TargetingConfig.NO_TARGETING,
             firefox_min_version=NimbusExperiment.EXCLUDED_REQUIRED_MIN_VERSION,
             excluded_experiments=[other],
             required_experiments=[other],
@@ -2680,7 +2669,6 @@ class TestNimbusReviewSerializerSingleFeature(MockFmlErrorMixin, TestCase):
         self.maxDiff = None
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.CREATED,
-            targeting_config_slug=NimbusExperiment.TargetingConfig.NO_TARGETING,
             firefox_min_version=NimbusExperiment.ROLLOUT_SUPPORT_VERSION[
                 NimbusExperiment.Application.DESKTOP
             ],
@@ -2853,7 +2841,6 @@ class TestNimbusReviewSerializerSingleFeature(MockFmlErrorMixin, TestCase):
 
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.CREATED,
-            targeting_config_slug=NimbusExperiment.TargetingConfig.NO_TARGETING,
             firefox_min_version=NimbusExperiment.Version.FIREFOX_120,
             application=NimbusExperiment.Application.DESKTOP,
             channel=NimbusExperiment.Channel.RELEASE,
@@ -2961,7 +2948,6 @@ class TestNimbusReviewSerializerSingleFeature(MockFmlErrorMixin, TestCase):
         prefflips_feature = NimbusFeatureConfigFactory.create_desktop_prefflips_feature()
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.CREATED,
-            targeting_config_slug=NimbusExperiment.TargetingConfig.NO_TARGETING,
             application=NimbusExperiment.Application.DESKTOP,
             firefox_min_version=NimbusExperiment.Version.FIREFOX_129,
             firefox_max_version=NimbusExperiment.Version.NO_VERSION,
@@ -3004,7 +2990,6 @@ class TestNimbusReviewSerializerSingleFeature(MockFmlErrorMixin, TestCase):
         prefflips_feature = NimbusFeatureConfigFactory.create_desktop_prefflips_feature()
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.CREATED,
-            targeting_config_slug=NimbusExperiment.TargetingConfig.NO_TARGETING,
             application=NimbusExperiment.Application.DESKTOP,
             firefox_min_version=NimbusExperiment.Version.FIREFOX_128,
             firefox_max_version=NimbusExperiment.Version.NO_VERSION,
@@ -3054,7 +3039,6 @@ class TestNimbusReviewSerializerSingleFeature(MockFmlErrorMixin, TestCase):
         prefflips_feature = NimbusFeatureConfigFactory.create_desktop_prefflips_feature()
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.CREATED,
-            targeting_config_slug=NimbusExperiment.TargetingConfig.NO_TARGETING,
             application=NimbusExperiment.Application.DESKTOP,
             firefox_min_version=NimbusExperiment.Version.FIREFOX_129,
             firefox_max_version=NimbusExperiment.Version.NO_VERSION,
@@ -3109,7 +3093,6 @@ class TestNimbusReviewSerializerSingleFeature(MockFmlErrorMixin, TestCase):
         prefflips_feature = NimbusFeatureConfigFactory.create_desktop_prefflips_feature()
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.CREATED,
-            targeting_config_slug=NimbusExperiment.TargetingConfig.NO_TARGETING,
             application=NimbusExperiment.Application.DESKTOP,
             firefox_min_version=NimbusExperiment.Version.FIREFOX_129,
             firefox_max_version=NimbusExperiment.Version.NO_VERSION,
@@ -3161,7 +3144,6 @@ class TestNimbusReviewSerializerSingleFeature(MockFmlErrorMixin, TestCase):
     def test_empty_segments(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.CREATED,
-            targeting_config_slug=NimbusExperiment.TargetingConfig.NO_TARGETING,
             application=NimbusExperiment.Application.DESKTOP,
             firefox_min_version=NimbusConstants.MIN_REQUIRED_VERSION,
             segments=[],
@@ -3237,7 +3219,6 @@ class VersionedFeatureValidationTests(MockFmlErrorMixin, TestCase):
 
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.CREATED,
-            targeting_config_slug=NimbusExperiment.TargetingConfig.NO_TARGETING,
             application=NimbusExperiment.Application.DESKTOP,
             firefox_min_version=min_version,
             firefox_max_version=max_version,
@@ -3327,7 +3308,6 @@ class VersionedFeatureValidationTests(MockFmlErrorMixin, TestCase):
 
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.CREATED,
-            targeting_config_slug=NimbusExperiment.TargetingConfig.NO_TARGETING,
             application=NimbusExperiment.Application.DESKTOP,
             firefox_min_version=min_version,
             firefox_max_version=max_version,
@@ -3402,7 +3382,6 @@ class VersionedFeatureValidationTests(MockFmlErrorMixin, TestCase):
 
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.CREATED,
-            targeting_config_slug=NimbusExperiment.TargetingConfig.NO_TARGETING,
             application=NimbusExperiment.Application.DESKTOP,
             firefox_min_version=NimbusExperiment.Version.FIREFOX_120,
             firefox_max_version=NimbusExperiment.Version.FIREFOX_123,
@@ -3489,7 +3468,6 @@ class VersionedFeatureValidationTests(MockFmlErrorMixin, TestCase):
 
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.CREATED,
-            targeting_config_slug=NimbusExperiment.TargetingConfig.NO_TARGETING,
             application=NimbusExperiment.Application.DESKTOP,
             firefox_min_version=min_version,
             firefox_max_version=max_version,
@@ -3560,7 +3538,6 @@ class VersionedFeatureValidationTests(MockFmlErrorMixin, TestCase):
 
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.CREATED,
-            targeting_config_slug=NimbusExperiment.TargetingConfig.NO_TARGETING,
             application=NimbusExperiment.Application.DESKTOP,
             firefox_min_version=NimbusExperiment.Version.FIREFOX_110,
             firefox_max_version=NimbusExperiment.Version.FIREFOX_111,
@@ -3658,7 +3635,6 @@ class VersionedFeatureValidationTests(MockFmlErrorMixin, TestCase):
 
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.CREATED,
-            targeting_config_slug=NimbusExperiment.TargetingConfig.NO_TARGETING,
             application=NimbusExperiment.Application.DESKTOP,
             firefox_min_version=min_version,
             firefox_max_version=max_version,
@@ -3730,7 +3706,6 @@ class VersionedFeatureValidationTests(MockFmlErrorMixin, TestCase):
 
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.CREATED,
-            targeting_config_slug=NimbusExperiment.TargetingConfig.NO_TARGETING,
             application=NimbusExperiment.Application.DESKTOP,
             firefox_min_version=NimbusExperiment.Version.FIREFOX_120,
             firefox_max_version=NimbusExperiment.Version.FIREFOX_122,
@@ -3865,7 +3840,6 @@ class VersionedFeatureValidationTests(MockFmlErrorMixin, TestCase):
 
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.CREATED,
-            targeting_config_slug=NimbusExperiment.TargetingConfig.NO_TARGETING,
             application=application,
             firefox_min_version=min_version,
             firefox_max_version=max_version,
@@ -3939,7 +3913,6 @@ class VersionedFeatureValidationTests(MockFmlErrorMixin, TestCase):
 
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.CREATED,
-            targeting_config_slug=NimbusExperiment.TargetingConfig.NO_TARGETING,
             application=application,
             firefox_min_version=min_version,
             firefox_max_version=max_version,
@@ -4005,7 +3978,6 @@ class VersionedFeatureValidationTests(MockFmlErrorMixin, TestCase):
 
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.CREATED,
-            targeting_config_slug=NimbusExperiment.TargetingConfig.NO_TARGETING,
             application=NimbusExperiment.Application.FENIX,
             firefox_min_version=NimbusExperiment.Version.FIREFOX_110,
             firefox_max_version=NimbusExperiment.Version.FIREFOX_111,
@@ -4077,7 +4049,6 @@ class VersionedFeatureValidationTests(MockFmlErrorMixin, TestCase):
 
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.CREATED,
-            targeting_config_slug=NimbusExperiment.TargetingConfig.NO_TARGETING,
             application=NimbusExperiment.Application.FENIX,
             firefox_min_version=NimbusExperiment.Version.FIREFOX_120,
             firefox_max_version=NimbusExperiment.Version.FIREFOX_122,
@@ -4154,7 +4125,6 @@ class VersionedFeatureValidationTests(MockFmlErrorMixin, TestCase):
 
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.CREATED,
-            targeting_config_slug=NimbusExperiment.TargetingConfig.NO_TARGETING,
             application=NimbusExperiment.Application.FENIX,
             firefox_min_version=NimbusExperiment.Version.FIREFOX_121,
             firefox_max_version=NimbusExperiment.Version.FIREFOX_121,
@@ -4197,7 +4167,6 @@ class VersionedFeatureValidationTests(MockFmlErrorMixin, TestCase):
 
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.CREATED,
-            targeting_config_slug=NimbusExperiment.TargetingConfig.NO_TARGETING,
             application=NimbusExperiment.Application.FENIX,
             firefox_min_version=NimbusExperiment.Version.FIREFOX_120,
             firefox_max_version=NimbusExperiment.Version.NO_VERSION,
@@ -4329,7 +4298,6 @@ class TestNimbusReviewSerializerMultiFeature(MockFmlErrorMixin, TestCase):
             status=NimbusExperiment.Status.DRAFT,
             application=NimbusExperiment.Application.DESKTOP,
             channel=NimbusExperiment.Channel.NO_CHANNEL,
-            targeting_config_slug=NimbusExperiment.TargetingConfig.NO_TARGETING,
             feature_configs=[
                 self.feature_without_schema,
                 self.feature_with_schema,
@@ -4376,7 +4344,6 @@ class TestNimbusReviewSerializerMultiFeature(MockFmlErrorMixin, TestCase):
             status=NimbusExperiment.Status.DRAFT,
             application=NimbusExperiment.Application.DESKTOP,
             channel=NimbusExperiment.Channel.NO_CHANNEL,
-            targeting_config_slug=NimbusExperiment.TargetingConfig.NO_TARGETING,
             feature_configs=[
                 self.feature_without_schema,
                 self.feature_with_schema,
@@ -4423,7 +4390,6 @@ class TestNimbusReviewSerializerMultiFeature(MockFmlErrorMixin, TestCase):
             status=NimbusExperiment.Status.DRAFT,
             application=NimbusExperiment.Application.DESKTOP,
             channel=NimbusExperiment.Channel.NO_CHANNEL,
-            targeting_config_slug=NimbusExperiment.TargetingConfig.NO_TARGETING,
             feature_configs=[
                 self.feature_without_schema,
                 self.feature_with_schema,
@@ -4472,7 +4438,6 @@ class TestNimbusReviewSerializerMultiFeature(MockFmlErrorMixin, TestCase):
             status=NimbusExperiment.Status.DRAFT,
             application=NimbusExperiment.Application.DESKTOP,
             channel=NimbusExperiment.Channel.NO_CHANNEL,
-            targeting_config_slug=NimbusExperiment.TargetingConfig.NO_TARGETING,
             feature_configs=[
                 self.feature_without_schema,
                 self.feature_with_schema,
@@ -4520,7 +4485,6 @@ class TestNimbusReviewSerializerMultiFeature(MockFmlErrorMixin, TestCase):
             status=NimbusExperiment.Status.DRAFT,
             application=NimbusExperiment.Application.DESKTOP,
             channel=NimbusExperiment.Channel.NO_CHANNEL,
-            targeting_config_slug=NimbusExperiment.TargetingConfig.NO_TARGETING,
             warn_feature_schema=False,
             feature_configs=[
                 self.feature_without_schema,
@@ -4561,7 +4525,6 @@ class TestNimbusReviewSerializerMultiFeature(MockFmlErrorMixin, TestCase):
             status=NimbusExperiment.Status.DRAFT,
             application=NimbusExperiment.Application.DESKTOP,
             channel=NimbusExperiment.Channel.NO_CHANNEL,
-            targeting_config_slug=NimbusExperiment.TargetingConfig.NO_TARGETING,
             warn_feature_schema=True,
             feature_configs=[
                 self.feature_without_schema,
@@ -4615,7 +4578,6 @@ class TestNimbusReviewSerializerMultiFeature(MockFmlErrorMixin, TestCase):
             status=NimbusExperiment.Status.DRAFT,
             application=NimbusExperiment.Application.DESKTOP,
             channel=NimbusExperiment.Channel.NO_CHANNEL,
-            targeting_config_slug=NimbusExperiment.TargetingConfig.NO_TARGETING,
             warn_feature_schema=True,
             feature_configs=[
                 self.feature_without_schema,
@@ -4741,7 +4703,6 @@ class TestNimbusReviewSerializerMultiFeature(MockFmlErrorMixin, TestCase):
             NimbusExperimentFactory.Lifecycles.CREATED,
             application=application,
             firefox_min_version=firefox_min_version,
-            targeting_config_slug=NimbusExperiment.TargetingConfig.NO_TARGETING,
         )
 
         serializer = NimbusReviewSerializer(
@@ -4805,7 +4766,6 @@ class TestNimbusReviewSerializerMultiFeature(MockFmlErrorMixin, TestCase):
             application=application,
             feature_configs=[feature],
             firefox_min_version=NimbusExperiment.Version.FIREFOX_100,
-            targeting_config_slug=NimbusExperiment.TargetingConfig.NO_TARGETING,
         )
         feature_value = experiment.reference_branch.feature_values.get()
         feature_value.value = json.dumps(value)
@@ -4845,7 +4805,6 @@ class TestNimbusReviewSerializerMultiFeature(MockFmlErrorMixin, TestCase):
             application=application,
             feature_configs=features,
             firefox_min_version=NimbusExperiment.MIN_REQUIRED_VERSION,
-            targeting_config_slug=NimbusExperiment.TargetingConfig.NO_TARGETING,
         )
 
         for fv in experiment.reference_branch.feature_values.all():
@@ -4899,7 +4858,6 @@ class TestNimbusReviewSerializerMultiFeature(MockFmlErrorMixin, TestCase):
             experiment = NimbusExperimentFactory.create_with_lifecycle(
                 NimbusExperimentFactory.Lifecycles.CREATED,
                 firefox_min_version=NimbusExperiment.Version.FIREFOX_100,
-                targeting_config_slug=NimbusExperiment.TargetingConfig.NO_TARGETING,
                 feature_configs=[
                     NimbusFeatureConfigFactory.create(
                         name="feature-1",
@@ -4939,7 +4897,6 @@ class TestNimbusReviewSerializerMultiFeature(MockFmlErrorMixin, TestCase):
             experiment = NimbusExperimentFactory.create_with_lifecycle(
                 NimbusExperimentFactory.Lifecycles.CREATED,
                 firefox_min_version=NimbusExperiment.Version.FIREFOX_100,
-                targeting_config_slug=NimbusExperiment.TargetingConfig.NO_TARGETING,
                 feature_configs=[
                     NimbusFeatureConfigFactory.create(
                         name=slug,
@@ -4989,7 +4946,6 @@ class TestNimbusReviewSerializerMultiFeature(MockFmlErrorMixin, TestCase):
             application=application,
             feature_configs=[feature],
             firefox_min_version=NimbusExperiment.Version.FIREFOX_100,
-            targeting_config_slug=NimbusExperiment.TargetingConfig.NO_TARGETING,
             warn_feature_schema=False,
         )
         feature_value = experiment.reference_branch.feature_values.get()
@@ -5031,7 +4987,6 @@ class TestNimbusReviewSerializerMultiFeature(MockFmlErrorMixin, TestCase):
             application=application,
             feature_configs=[feature],
             firefox_min_version=NimbusExperiment.Version.FIREFOX_100,
-            targeting_config_slug=NimbusExperiment.TargetingConfig.NO_TARGETING,
             warn_feature_schema=False,
         )
         feature_value = experiment.reference_branch.feature_values.get()
@@ -5064,7 +5019,6 @@ class TestNimbusReviewSerializerMultiFeature(MockFmlErrorMixin, TestCase):
             application=application,
             feature_configs=[feature],
             firefox_min_version=NimbusExperiment.Version.FIREFOX_100,
-            targeting_config_slug=NimbusExperiment.TargetingConfig.NO_TARGETING,
             warn_feature_schema=True,
         )
         feature_value = experiment.reference_branch.feature_values.get()

--- a/experimenter/experimenter/experiments/tests/api/v6/test_serializers.py
+++ b/experimenter/experimenter/experiments/tests/api/v6/test_serializers.py
@@ -47,7 +47,6 @@ class TestNimbusExperimentSerializer(TestCase):
             application=application,
             firefox_min_version=NimbusExperiment.MIN_REQUIRED_VERSION,
             feature_configs=[feature1, feature2],
-            targeting_config_slug=NimbusExperiment.TargetingConfig.NO_TARGETING,
             channel=NimbusExperiment.Channel.NIGHTLY,
             primary_outcomes=["foo", "bar", "baz"],
             secondary_outcomes=["quux", "xyzzy"],
@@ -122,7 +121,6 @@ class TestNimbusExperimentSerializer(TestCase):
             application=application,
             firefox_min_version=NimbusExperiment.MIN_REQUIRED_VERSION,
             feature_configs=[feature1, feature2],
-            targeting_config_slug=NimbusExperiment.TargetingConfig.NO_TARGETING,
             channel=NimbusExperiment.Channel.NIGHTLY,
             primary_outcomes=["foo", "bar", "baz"],
             secondary_outcomes=["quux", "xyzzy"],
@@ -175,7 +173,6 @@ class TestNimbusExperimentSerializer(TestCase):
             application=application,
             firefox_min_version=NimbusExperiment.MIN_REQUIRED_VERSION,
             feature_configs=[feature1, feature2],
-            targeting_config_slug=NimbusExperiment.TargetingConfig.NO_TARGETING,
             channel=NimbusExperiment.Channel.NIGHTLY,
             primary_outcomes=["foo", "bar", "baz"],
             secondary_outcomes=["quux", "xyzzy"],
@@ -320,7 +317,6 @@ class TestNimbusExperimentSerializer(TestCase):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE,
             publish_status=NimbusExperiment.PublishStatus.APPROVED,
-            targeting_config_slug=NimbusExperiment.TargetingConfig.NO_TARGETING,
             application=NimbusExperiment.Application.FENIX,
             firefox_min_version=NimbusExperiment.Version.FIREFOX_94,
         )
@@ -336,7 +332,6 @@ class TestNimbusExperimentSerializer(TestCase):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.ENDING_APPROVE_APPROVE,
             application=NimbusExperiment.Application.DESKTOP,
-            targeting_config_slug=NimbusExperiment.TargetingConfig.NO_TARGETING,
             channel=NimbusExperiment.Channel.NIGHTLY,
             primary_outcomes=["foo", "bar", "baz"],
             secondary_outcomes=["qux", "quux"],
@@ -358,7 +353,6 @@ class TestNimbusExperimentSerializer(TestCase):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.ENDING_APPROVE_APPROVE,
             application=NimbusExperiment.Application.DESKTOP,
-            targeting_config_slug=NimbusExperiment.TargetingConfig.NO_TARGETING,
             locales=[locale_en_us, locale_en_ca, locale_fr],
         )
 
@@ -371,7 +365,6 @@ class TestNimbusExperimentSerializer(TestCase):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.ENDING_APPROVE_APPROVE,
             application=NimbusExperiment.Application.DESKTOP,
-            targeting_config_slug=NimbusExperiment.TargetingConfig.NO_TARGETING,
         )
 
         serializer = NimbusExperimentSerializer(experiment)

--- a/experimenter/experimenter/experiments/tests/api/v7/test_serializers.py
+++ b/experimenter/experimenter/experiments/tests/api/v7/test_serializers.py
@@ -35,7 +35,6 @@ class TestNimbusExperimentSerializer(TestCase):
             application=application,
             firefox_min_version=NimbusExperiment.MIN_REQUIRED_VERSION,
             feature_configs=[feature1, feature2],
-            targeting_config_slug=NimbusExperiment.TargetingConfig.NO_TARGETING,
             channel=NimbusExperiment.Channel.NIGHTLY,
             primary_outcomes=["foo", "bar", "baz"],
             secondary_outcomes=["quux", "xyzzy"],

--- a/experimenter/experimenter/experiments/tests/api/v8/test_serializers.py
+++ b/experimenter/experimenter/experiments/tests/api/v8/test_serializers.py
@@ -30,7 +30,6 @@ class TestNimbusExperimentSerializer(TestCase):
             application=application,
             firefox_min_version=NimbusExperiment.MIN_REQUIRED_VERSION,
             feature_configs=[feature1, feature2],
-            targeting_config_slug=NimbusExperiment.TargetingConfig.NO_TARGETING,
             channel=NimbusExperiment.Channel.NIGHTLY,
             primary_outcomes=["foo", "bar", "baz"],
             secondary_outcomes=["quux", "xyzzy"],
@@ -106,7 +105,6 @@ class TestNimbusExperimentSerializer(TestCase):
             application=application,
             firefox_min_version=NimbusExperiment.MIN_REQUIRED_VERSION,
             feature_configs=[feature1, feature2],
-            targeting_config_slug=NimbusExperiment.TargetingConfig.NO_TARGETING,
             channel=NimbusExperiment.Channel.NIGHTLY,
             primary_outcomes=["foo", "bar", "baz"],
             secondary_outcomes=["quux", "xyzzy"],
@@ -153,7 +151,6 @@ class TestNimbusExperimentSerializer(TestCase):
             application=application,
             firefox_min_version=NimbusExperiment.MIN_REQUIRED_VERSION,
             feature_configs=[feature1, feature2],
-            targeting_config_slug=NimbusExperiment.TargetingConfig.NO_TARGETING,
             channel=NimbusExperiment.Channel.NIGHTLY,
             primary_outcomes=["foo", "bar", "baz"],
             secondary_outcomes=["quux", "xyzzy"],
@@ -295,7 +292,6 @@ class TestNimbusExperimentSerializer(TestCase):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE,
             publish_status=NimbusExperiment.PublishStatus.APPROVED,
-            targeting_config_slug=NimbusExperiment.TargetingConfig.NO_TARGETING,
             application=NimbusExperiment.Application.FENIX,
             firefox_min_version=NimbusExperiment.Version.FIREFOX_94,
         )
@@ -310,7 +306,6 @@ class TestNimbusExperimentSerializer(TestCase):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.ENDING_APPROVE_APPROVE,
             application=NimbusExperiment.Application.DESKTOP,
-            targeting_config_slug=NimbusExperiment.TargetingConfig.NO_TARGETING,
             channel=NimbusExperiment.Channel.NIGHTLY,
             primary_outcomes=["foo", "bar", "baz"],
             secondary_outcomes=["qux", "quux"],
@@ -332,7 +327,6 @@ class TestNimbusExperimentSerializer(TestCase):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.ENDING_APPROVE_APPROVE,
             application=NimbusExperiment.Application.DESKTOP,
-            targeting_config_slug=NimbusExperiment.TargetingConfig.NO_TARGETING,
             locales=[locale_en_us, locale_en_ca, locale_fr],
         )
 
@@ -345,7 +339,6 @@ class TestNimbusExperimentSerializer(TestCase):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.ENDING_APPROVE_APPROVE,
             application=NimbusExperiment.Application.DESKTOP,
-            targeting_config_slug=NimbusExperiment.TargetingConfig.NO_TARGETING,
         )
 
         serializer = NimbusExperimentSerializer(experiment)

--- a/experimenter/experimenter/experiments/tests/factories.py
+++ b/experimenter/experimenter/experiments/tests/factories.py
@@ -443,9 +443,7 @@ class NimbusExperimentFactory(factory.django.DjangoModelFactory):
     total_enrolled_clients = factory.LazyAttribute(
         lambda o: random.randint(1, 100) * 1000
     )
-    firefox_min_version = factory.LazyAttribute(
-        lambda o: random.choice(list(NimbusExperiment.Version)).value
-    )
+    firefox_min_version = NimbusExperiment.Version.FIREFOX_100
     application = NimbusExperiment.Application.DESKTOP
     channel = factory.LazyAttribute(
         lambda o: random.choice(
@@ -455,9 +453,7 @@ class NimbusExperimentFactory(factory.django.DjangoModelFactory):
         ).value
     )
     hypothesis = factory.LazyAttribute(lambda o: faker.text(1000))
-    targeting_config_slug = factory.LazyAttribute(
-        lambda o: random.choice(list(NimbusExperiment.TargetingConfig)).value
-    )
+    targeting_config_slug = NimbusExperiment.TargetingConfig.NO_TARGETING
     primary_outcomes = factory.LazyAttribute(
         lambda o: random_slice([oc.slug for oc in Outcomes.all()[:2]])
     )

--- a/experimenter/experimenter/experiments/tests/test_models.py
+++ b/experimenter/experimenter/experiments/tests/test_models.py
@@ -505,7 +505,6 @@ class TestNimbusExperiment(TestCase):
             NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE_APPROVE,
             firefox_min_version=NimbusExperiment.Version.NO_VERSION,
             firefox_max_version=NimbusExperiment.Version.NO_VERSION,
-            targeting_config_slug=NimbusExperiment.TargetingConfig.NO_TARGETING,
             application=NimbusExperiment.Application.FENIX,
             channel=NimbusExperiment.Channel.NO_CHANNEL,
             locales=[],
@@ -536,7 +535,6 @@ class TestNimbusExperiment(TestCase):
             application=application,
             firefox_min_version=version,
             firefox_max_version=version,
-            targeting_config_slug=NimbusExperiment.TargetingConfig.NO_TARGETING,
             channel=NimbusExperiment.Channel.NO_CHANNEL,
             locales=[],
             countries=[],
@@ -567,7 +565,6 @@ class TestNimbusExperiment(TestCase):
             application=application,
             firefox_min_version=version,
             firefox_max_version=NimbusExperiment.Version.NO_VERSION,
-            targeting_config_slug=NimbusExperiment.TargetingConfig.NO_TARGETING,
             channel=NimbusExperiment.Channel.NO_CHANNEL,
             locales=[],
             countries=[],
@@ -585,7 +582,6 @@ class TestNimbusExperiment(TestCase):
             application=NimbusExperiment.Application.FENIX,
             firefox_min_version=NimbusExperiment.Version.FIREFOX_100,
             firefox_max_version=NimbusExperiment.Version.NO_VERSION,
-            targeting_config_slug=NimbusExperiment.TargetingConfig.NO_TARGETING,
             channel=NimbusExperiment.Channel.NO_CHANNEL,
             locales=[],
             countries=[],
@@ -603,7 +599,6 @@ class TestNimbusExperiment(TestCase):
             application=NimbusExperiment.Application.FENIX,
             firefox_min_version=NimbusExperiment.Version.NO_VERSION,
             firefox_max_version=NimbusExperiment.Version.FIREFOX_100,
-            targeting_config_slug=NimbusExperiment.TargetingConfig.NO_TARGETING,
             channel=NimbusExperiment.Channel.NO_CHANNEL,
             locales=[],
             countries=[],
@@ -637,7 +632,6 @@ class TestNimbusExperiment(TestCase):
             application=application,
             firefox_min_version=NimbusExperiment.Version.NO_VERSION,
             firefox_max_version=version,
-            targeting_config_slug=NimbusExperiment.TargetingConfig.NO_TARGETING,
             channel=NimbusExperiment.Channel.NO_CHANNEL,
             locales=[],
             countries=[],
@@ -672,7 +666,6 @@ class TestNimbusExperiment(TestCase):
             application=application,
             firefox_min_version=version,
             firefox_max_version=version,
-            targeting_config_slug=NimbusExperiment.TargetingConfig.NO_TARGETING,
             channel=NimbusExperiment.Channel.NO_CHANNEL,
             locales=[],
             countries=[],
@@ -979,7 +972,6 @@ class TestNimbusExperiment(TestCase):
             application=NimbusExperiment.Application.DESKTOP,
             firefox_min_version=NimbusExperiment.Version.NO_VERSION,
             firefox_max_version=NimbusExperiment.Version.NO_VERSION,
-            targeting_config_slug=NimbusExperiment.TargetingConfig.NO_TARGETING,
             channel=NimbusExperiment.Channel.RELEASE,
             languages=[],
             locales=[],
@@ -1003,7 +995,6 @@ class TestNimbusExperiment(TestCase):
             application=NimbusExperiment.Application.DESKTOP,
             firefox_min_version=NimbusExperiment.Version.NO_VERSION,
             firefox_max_version=NimbusExperiment.Version.NO_VERSION,
-            targeting_config_slug=NimbusExperiment.TargetingConfig.NO_TARGETING,
             channel=NimbusExperiment.Channel.RELEASE,
             languages=[],
             locales=[],
@@ -1039,7 +1030,6 @@ class TestNimbusExperiment(TestCase):
             application=NimbusExperiment.Application.DESKTOP,
             firefox_min_version=NimbusExperiment.Version.NO_VERSION,
             firefox_max_version=NimbusExperiment.Version.NO_VERSION,
-            targeting_config_slug=NimbusExperiment.TargetingConfig.NO_TARGETING,
             channel=NimbusExperiment.Channel.RELEASE,
             languages=[],
             locales=[],
@@ -1129,7 +1119,6 @@ class TestNimbusExperiment(TestCase):
                 application=application,
                 slug=slug,
                 firefox_min_version=NimbusExperiment.Version.NO_VERSION,
-                targeting_config_slug=NimbusExperiment.TargetingConfig.NO_TARGETING,
             )
             for slug in ("foo", "bar", "baz")
         }
@@ -1139,7 +1128,6 @@ class TestNimbusExperiment(TestCase):
             application=application,
             slug="slug",
             firefox_min_version=NimbusExperiment.Version.NO_VERSION,
-            targeting_config_slug=NimbusExperiment.TargetingConfig.NO_TARGETING,
             channel=NimbusExperiment.Channel.NO_CHANNEL,
         )
         for required_slug, required_branch_slug in require:
@@ -1176,9 +1164,7 @@ class TestNimbusExperiment(TestCase):
         )
 
     def test_targeting_config_returns_config_with_valid_slug(self):
-        experiment = NimbusExperimentFactory.create(
-            targeting_config_slug=NimbusExperiment.TargetingConfig.NO_TARGETING
-        )
+        experiment = NimbusExperimentFactory.create()
         self.assertEqual(
             experiment.targeting_config,
             NimbusExperiment.TARGETING_CONFIGS[
@@ -3844,7 +3830,6 @@ class TestNimbusExperiment(TestCase):
             slug: NimbusExperimentFactory.create_with_lifecycle(
                 NimbusExperimentFactory.Lifecycles.LIVE_APPROVE_APPROVE,
                 application=NimbusExperiment.Application.DESKTOP,
-                targeting_config_slug=NimbusExperiment.TargetingConfig.NO_TARGETING,
             )
             for slug in ("foo", "bar", "baz")
         }
@@ -3853,7 +3838,6 @@ class TestNimbusExperiment(TestCase):
             application=NimbusExperiment.Application.DESKTOP,
             slug="slug",
             firefox_min_version=NimbusExperiment.Version.NO_VERSION,
-            targeting_config_slug=NimbusExperiment.TargetingConfig.NO_TARGETING,
             channel=NimbusExperiment.Channel.NO_CHANNEL,
         )
 
@@ -3874,14 +3858,12 @@ class TestNimbusExperiment(TestCase):
                 NimbusExperimentFactory.Lifecycles.LIVE_APPROVE_APPROVE,
                 slug=slug,
                 application=NimbusExperiment.Application.DESKTOP,
-                targeting_config_slug=NimbusExperiment.TargetingConfig.NO_TARGETING,
             )
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.CREATED,
             slug="slug",
             application=NimbusExperiment.Application.DESKTOP,
             firefox_min_version=NimbusExperiment.Version.NO_VERSION,
-            targeting_config_slug=NimbusExperiment.TargetingConfig.NO_TARGETING,
             channel=NimbusExperiment.Channel.NO_CHANNEL,
         )
 

--- a/experimenter/experimenter/nimbus_ui_new/tests/test_forms.py
+++ b/experimenter/experimenter/nimbus_ui_new/tests/test_forms.py
@@ -1306,7 +1306,6 @@ class TestAudienceForm(RequestFormTestCase):
             proposed_duration=0,
             proposed_enrollment=0,
             proposed_release_date=None,
-            targeting_config_slug=NimbusExperiment.TargetingConfig.NO_TARGETING,
             total_enrolled_clients=0,
             is_sticky=False,
             countries=[],
@@ -1382,7 +1381,6 @@ class TestAudienceForm(RequestFormTestCase):
             proposed_duration=0,
             proposed_enrollment=0,
             proposed_release_date=None,
-            targeting_config_slug=NimbusExperiment.TargetingConfig.NO_TARGETING,
             total_enrolled_clients=0,
             is_sticky=False,
             is_first_run=False,
@@ -1445,7 +1443,6 @@ class TestAudienceForm(RequestFormTestCase):
             proposed_duration=0,
             proposed_enrollment=0,
             proposed_release_date=None,
-            targeting_config_slug=NimbusExperiment.TargetingConfig.NO_TARGETING,
             total_enrolled_clients=0,
             is_sticky=False,
             countries=[],
@@ -1489,7 +1486,6 @@ class TestAudienceForm(RequestFormTestCase):
             population_percent=5,
             application=NimbusExperiment.Application.DESKTOP,
             channel=NimbusExperiment.Channel.BETA,
-            targeting_config_slug=NimbusExperiment.TargetingConfig.NO_TARGETING,
         )
 
         form = AudienceForm(

--- a/experimenter/experimenter/nimbus_ui_new/tests/test_views.py
+++ b/experimenter/experimenter/nimbus_ui_new/tests/test_views.py
@@ -2449,7 +2449,6 @@ class TestAudienceUpdateView(AuthTestCase):
             proposed_duration=0,
             proposed_enrollment=0,
             proposed_release_date=None,
-            targeting_config_slug=NimbusExperiment.TargetingConfig.NO_TARGETING,
             total_enrolled_clients=0,
             is_sticky=False,
             countries=[],
@@ -2526,7 +2525,6 @@ class TestAudienceUpdateView(AuthTestCase):
             proposed_duration=0,
             proposed_enrollment=0,
             proposed_release_date=None,
-            targeting_config_slug=NimbusExperiment.TargetingConfig.NO_TARGETING,
             total_enrolled_clients=0,
             is_sticky=False,
             countries=[],
@@ -2577,7 +2575,6 @@ class TestAudienceUpdateView(AuthTestCase):
             proposed_duration=0,
             proposed_enrollment=0,
             proposed_release_date=None,
-            targeting_config_slug=NimbusExperiment.TargetingConfig.NO_TARGETING,
             total_enrolled_clients=0,
             is_sticky=False,
             countries=[],
@@ -2613,7 +2610,6 @@ class TestAudienceUpdateView(AuthTestCase):
             population_percent=5,
             application=NimbusExperiment.Application.DESKTOP,
             channel=NimbusExperiment.Channel.BETA,
-            targeting_config_slug=NimbusExperiment.TargetingConfig.NO_TARGETING,
         )
 
         response = self.client.post(


### PR DESCRIPTION
Becuase

* We have recently seen some intermittency in unit tests
* This can happen because the factory randomly selects combinations of values that fail the conditions in the review serializer
* We can update the factory to always have valid defaults

This commit

* Sets the NimbusExperimentFactory targeting to NO_TARGETING
* Sets the NimbusExperimentFactory version to 100

fixes #13005

