### PR TITLE
feat(nimbus): add firefox labs to branches page

### DIFF
--- a/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/edit_branches.html
+++ b/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/edit_branches.html
@@ -312,68 +312,70 @@
         {% endif %}
       </div>
     </div>
-    <div id="labs" class="card mb-3">
-      <div class="card-header">
-        <h4>Firefox Labs</h4>
-      </div>
-      <div class="card-body">
-        <div class="row mb-3">
-          <div class="col">
-            <div class="form-check">
-              {{ form.is_firefox_labs_opt_in }}
-              <label class="form-check-label" for="id_is_firefox_labs_opt_in">Is this a Firefox Labs rollout?</label>
-            </div>
-          </div>
+    {% if experiment.is_desktop %}
+      <div id="labs" class="card mb-3">
+        <div class="card-header">
+          <h4>Firefox Labs</h4>
         </div>
-        {% if experiment.is_firefox_labs_opt_in %}
-          <div class="row mb-3">
-            <div class="col">
-              <label class="d-block">
-                The title to display in Firefox Labs (Fluent ID)
-                {{ form.firefox_labs_title }}
-              </label>
-              {{ form.firefox_labs_title.errors }}
-            </div>
-          </div>
-          <div class="row mb-3">
-            <div class="col">
-              <label class="d-block">
-                The description to display in Firefox Labs (Fluent ID)
-                {{ form.firefox_labs_description }}
-              </label>
-              {{ form.firefox_labs_description.errors }}
-            </div>
-          </div>
-          <div class="row mb-3">
-            <div class="col">
-              <label class="d-block">
-                Description Links (JSON)
-                {{ form.firefox_labs_description_links }}
-              </label>
-              {{ form.firefox_labs_description_links.errors }}
-            </div>
-          </div>
-          <div class="row mb-3">
-            <div class="col">
-              <label class="d-block">
-                Firefox Labs Group
-                {{ form.firefox_labs_group }}
-              </label>
-              {{ form.firefox_labs_group.errors }}
-            </div>
-          </div>
+        <div class="card-body">
           <div class="row mb-3">
             <div class="col">
               <div class="form-check">
-                {{ form.requires_restart }}
-                <label class="form-check-label" for="id_requires_restart">Requires restart to take effect?</label>
+                {{ form.is_firefox_labs_opt_in }}
+                <label class="form-check-label" for="id_is_firefox_labs_opt_in">Is this a Firefox Labs rollout?</label>
               </div>
-              {{ form.requires_restart.errors }}
             </div>
           </div>
-        {% endif %}
+          {% if experiment.is_firefox_labs_opt_in %}
+            <div class="row mb-3">
+              <div class="col">
+                <label class="d-block">
+                  The title to display in Firefox Labs (Fluent ID)
+                  {{ form.firefox_labs_title }}
+                </label>
+                {{ form.firefox_labs_title.errors }}
+              </div>
+            </div>
+            <div class="row mb-3">
+              <div class="col">
+                <label class="d-block">
+                  The description to display in Firefox Labs (Fluent ID)
+                  {{ form.firefox_labs_description }}
+                </label>
+                {{ form.firefox_labs_description.errors }}
+              </div>
+            </div>
+            <div class="row mb-3">
+              <div class="col">
+                <label class="d-block">
+                  Description Links (JSON)
+                  {{ form.firefox_labs_description_links }}
+                </label>
+                {{ form.firefox_labs_description_links.errors }}
+              </div>
+            </div>
+            <div class="row mb-3">
+              <div class="col">
+                <label class="d-block">
+                  Firefox Labs Group
+                  {{ form.firefox_labs_group }}
+                </label>
+                {{ form.firefox_labs_group.errors }}
+              </div>
+            </div>
+            <div class="row mb-3">
+              <div class="col">
+                <div class="form-check">
+                  {{ form.requires_restart }}
+                  <label class="form-check-label" for="id_requires_restart">Requires restart to take effect?</label>
+                </div>
+                {{ form.requires_restart.errors }}
+              </div>
+            </div>
+          {% endif %}
+        </div>
       </div>
-    </div>
+    {% endif %}
     <div class="d-flex justify-content-end">
       <button type="submit" class="btn btn-primary">Save</button>
       <button type="submit"

--- a/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/edit_branches.html
+++ b/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/edit_branches.html
@@ -122,8 +122,8 @@
                               hx-post="{% url 'nimbus-new-delete-branch' experiment.slug %}{% if request.GET.show_errors == 'true' %}?show_errors=true{% endif %}"
                               hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
                               hx-vals='{"branch_id": {{ branch_form.instance.id }} }'
-                              hx-select="#branches"
-                              hx-target="#branches">
+                              hx-select="#branches-form"
+                              hx-target="#branches-form">
                         <i class="fa-solid fa-circle-xmark"></i>
                       </button>
                     {% endif %}
@@ -229,8 +229,8 @@
                                   hx-post="{% url 'nimbus-new-delete-branch-screenshot' slug=experiment.slug %}{% if request.GET.show_errors == 'true' %}?show_errors=true{% endif %}"
                                   hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
                                   hx-vals='{"screenshot_id": {{ screenshot_form.instance.id }} }'
-                                  hx-select="#branches"
-                                  hx-target="#branches">
+                                  hx-select="#branches-form"
+                                  hx-target="#branches-form">
                             <i class="fa-solid fa-circle-xmark"></i>
                           </button>
                         </div>
@@ -252,8 +252,11 @@
                           hx-post="{% url 'nimbus-new-create-branch-screenshot' slug=experiment.slug %}{% if request.GET.show_errors == 'true' %}?show_errors=true{% endif %}"
                           hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
                           hx-vals='{"branch_id": {{ branch_form.instance.id }} }'
-                          hx-select="#branches"
-                          hx-target="#branches">+ Add Screenshot</button>
+                          hx-select="#branches-form"
+                          hx-target="#branches-form">
+                    +
+                    Add Screenshot
+                  </button>
                 </div>
               </div>
             </div>
@@ -266,8 +269,11 @@
                           type="button"
                           hx-post="{% url 'nimbus-new-create-branch' experiment.slug %}{% if request.GET.show_errors == 'true' %}?show_errors=true{% endif %}"
                           hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
-                          hx-select="#branches"
-                          hx-target="#branches">+ Add Branch</button>
+                          hx-select="#branches-form"
+                          hx-target="#branches-form">
+                    + Add
+                    Branch
+                  </button>
                 {% else %}
                   <p class="form-text">An experiment may have no more than 20 branches.</p>
                   <button class="btn btn-outline-primary btn-sm disabled" type="button">+ Add Branch</button>
@@ -301,6 +307,68 @@
               </label>
               {% for error in form.localizations.errors %}<div class="invalid-feedback d-block">{{ error }}</div>{% endfor %}
               {% for error in validation_errors.localizations %}<div class="form-text text-danger">{{ error }}</div>{% endfor %}
+            </div>
+          </div>
+        {% endif %}
+      </div>
+    </div>
+    <div id="labs" class="card mb-3">
+      <div class="card-header">
+        <h4>Firefox Labs</h4>
+      </div>
+      <div class="card-body">
+        <div class="row mb-3">
+          <div class="col">
+            <div class="form-check">
+              {{ form.is_firefox_labs_opt_in }}
+              <label class="form-check-label" for="id_is_firefox_labs_opt_in">Is this a Firefox Labs rollout?</label>
+            </div>
+          </div>
+        </div>
+        {% if experiment.is_firefox_labs_opt_in %}
+          <div class="row mb-3">
+            <div class="col">
+              <label class="d-block">
+                The title to display in Firefox Labs (Fluent ID)
+                {{ form.firefox_labs_title }}
+              </label>
+              {{ form.firefox_labs_title.errors }}
+            </div>
+          </div>
+          <div class="row mb-3">
+            <div class="col">
+              <label class="d-block">
+                The description to display in Firefox Labs (Fluent ID)
+                {{ form.firefox_labs_description }}
+              </label>
+              {{ form.firefox_labs_description.errors }}
+            </div>
+          </div>
+          <div class="row mb-3">
+            <div class="col">
+              <label class="d-block">
+                Description Links (JSON)
+                {{ form.firefox_labs_description_links }}
+              </label>
+              {{ form.firefox_labs_description_links.errors }}
+            </div>
+          </div>
+          <div class="row mb-3">
+            <div class="col">
+              <label class="d-block">
+                Firefox Labs Group
+                {{ form.firefox_labs_group }}
+              </label>
+              {{ form.firefox_labs_group.errors }}
+            </div>
+          </div>
+          <div class="row mb-3">
+            <div class="col">
+              <div class="form-check">
+                {{ form.requires_restart }}
+                <label class="form-check-label" for="id_requires_restart">Requires restart to take effect?</label>
+              </div>
+              {{ form.requires_restart.errors }}
             </div>
           </div>
         {% endif %}


### PR DESCRIPTION
Becuase

* Now that Firefox Desktop supports Firefox Labs with Nimbus
* We need to add all the Firefox Labs fields to the forms

This commit

* Adds the Firefox Labs fields to the Branches page
* Hides them behind a checkbox similar to Localizations
* Uses CodeMirror for the links JSON field
* Forces the rollout checkbox if labs is checked
* Forces labs unchecked if rollout is unchecked

fixes #13012


https://github.com/user-attachments/assets/81fb64f7-97d2-4094-915a-0e48e5fceb46

