### PR TITLE
feat(nimbus): use codemirror for localizations

### DIFF
--- a/experimenter/experimenter/nimbus_ui_new/forms.py
+++ b/experimenter/experimenter/nimbus_ui_new/forms.py
@@ -621,7 +621,7 @@ class NimbusBranchesForm(NimbusChangeLogFormMixin, forms.ModelForm):
                 attrs={"class": "form-check-input"}
             ),
             "is_localized": forms.CheckboxInput(attrs={"class": "form-check-input"}),
-            "localizations": forms.Textarea(attrs={"class": "form-control", "rows": 5}),
+            "localizations": forms.HiddenInput(),
         }
 
     def __init__(self, *args, **kwargs):

--- a/experimenter/experimenter/nimbus_ui_new/static/js/edit_branches.js
+++ b/experimenter/experimenter/nimbus_ui_new/static/js/edit_branches.js
@@ -60,12 +60,21 @@ const setupCodemirrorLabs = () => {
   setupCodemirror(selector, textarea, []);
 };
 
+const setupCodeMirrorLocalizations = () => {
+  const selector = "#id_localizations";
+  const textarea = document.querySelector(selector);
+
+  setupCodemirror(selector, textarea, []);
+};
+
 $(() => {
   setupCodemirrorFeatures();
   setupCodemirrorLabs();
+  setupCodeMirrorLocalizations();
 
   document.body.addEventListener("htmx:afterSwap", function () {
     setupCodemirrorFeatures();
     setupCodemirrorLabs();
+    setupCodeMirrorLocalizations();
   });
 });


### PR DESCRIPTION
Becuase
    
* The localizations field stores JSON
* We can use CodeMirror with its JSON validation for this field
    
This commit
    
* Enables CodeMirror for the localizations JSON field
    
fixes #13014

<img width="1342" height="204" alt="image" src="https://github.com/user-attachments/assets/4b1bbe4f-42c8-4e89-b6f9-76fe19465694" />
