### PR TITLE
bug(nimbus): only initialize codemirror to branch form updates

### DIFF
--- a/experimenter/experimenter/nimbus_ui_new/static/js/edit_branches.js
+++ b/experimenter/experimenter/nimbus_ui_new/static/js/edit_branches.js
@@ -72,9 +72,11 @@ $(() => {
   setupCodemirrorLabs();
   setupCodeMirrorLocalizations();
 
-  document.body.addEventListener("htmx:afterSwap", function () {
-    setupCodemirrorFeatures();
-    setupCodemirrorLabs();
-    setupCodeMirrorLocalizations();
+  document.body.addEventListener("htmx:afterSwap", function (event) {
+    if (event.detail.target.id === "branches-form") {
+      setupCodemirrorFeatures();
+      setupCodemirrorLabs();
+      setupCodeMirrorLocalizations();
+    }
   });
 });


### PR DESCRIPTION
Becuase

* We are using codemirror on the branches page for json inputs
* We have to initialize it at two times: on page load, and after an htmx swap
* Swapping the branch form and reinitializing codemirror correctly results in a single codemirror instance for each json field
* However we can also do an htmx swap in the clone form for regenerating the slug, which triggers the htmx afterswap listener but doesn't replace the branch form
* This causes codemirror to reinitialize while the existing codemirror instances are still present in the dom, creating duplicate codemirror instances for each json field

This commit

* Only reinitializes codemirror if the branch form was swapped

fixes #13008

