### PR TITLE
chore(nimbus): Add viewpoint targeting for iOS and Android

### DIFF
--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -2501,21 +2501,38 @@ VIEWPOINT_SURVEY_DESKTOP = NimbusTargetingConfig(
     application_choice_names=(Application.DESKTOP.name,),
 )
 
-VIEWPOINT_SURVEY_MOBILE = NimbusTargetingConfig(
-    name="User Research Viewpoint Survey (Rolling Enrollment)",
-    slug="viewpoint_survey_mobile",
+VIEWPOINT_SURVEY_IOS = NimbusTargetingConfig(
+    name="User Research Viewpoint Survey (Rolling Enrollmment)",
+    slug="viewpoint_survey_ios",
     description=(
         "Rolling enrollment based on date. Only for use by User Research Viewpoint "
         "surveys."
     ),
     targeting=(
         "['rolling-viewpoint', nimbus_id]"
-        "|bucketSample(current_date / (24 * 60 * 60 * 1000), 7, 3500)"
+        "|bucketSample(current_date / (24 * 60 * 60 * 1000), 7, 233)"
     ),
     desktop_telemetry="",
     sticky_required=False,
     is_first_run_required=False,
-    application_choice_names=(Application.IOS.name, Application.FENIX.name),
+    application_choice_names=(Application.IOS.name,),
+)
+
+VIEWPOINT_SURVEY_FENIX = NimbusTargetingConfig(
+    name="User Research Viewpoint Survey (Rolling Enrollmment)",
+    slug="viewpoint_survey_fenix",
+    description=(
+        "Rolling enrollment based on date. Only for use by User Research Viewpoint "
+        "surveys."
+    ),
+    targeting=(
+        "['rolling-viewpoint', nimbus_id]"
+        "|bucketSample(current_date / (24 * 60 * 60 * 1000), 7, 350)"
+    ),
+    desktop_telemetry="",
+    sticky_required=False,
+    is_first_run_required=False,
+    application_choice_names=(Application.FENIX.name,),
 )
 
 NEW_PROFILE_MAC_ONLY = NimbusTargetingConfig(


### PR DESCRIPTION
Because:

- the number of buckets used in the existing `VIEWPOINT_SURVEY_MOBILE`
  was too large, resulting in lower-than-expected enrollment numbers
  for Firefox for iOS and Firefox for Android viewpoint surveys

This commit:

- adds new `VIEWPOINT_SURVEY_IOS` and `VIEWPOINT_SURVEY_FENIX` advanced
  targetings for Firefox   for iOS and Firefox for Android, respectively,
  each with a much smaller number of buckets, which should result in
  enrollment numbers closer to what we expect.
- removes the existing `VIEWPOINT_SURVEY_MOBILE` advanced targeting.

Fixes #13050
Fixes #13051
