### PR TITLE
feat(nimbus): Should not show launch controls if there are errors

### DIFF
--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/detail.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/detail.html
@@ -62,7 +62,7 @@
       {% endfor %}
     {% endif %}
     <!-- Launch Controls Card-->
-    {% if not experiment.get_invalid_pages or not experiment.is_draft %}
+    {% if not invalid_pages or not experiment.is_draft %}
       {% include "nimbus_experiments/launch_controls.html" %}
 
     {% endif %}


### PR DESCRIPTION
Because

- We should not allow users to send experiment for preview if there are errors that need to be resolved
- We recently https://github.com/mozilla/experimenter/pull/13003 and missed updating the flag in a template; as a result, launch controls were showing even when the errors are present

This commit

- Checks if there are any invalid pages in that case hides the launch controls

Fixes #13053 