### PR TITLE
bug(nimbus): Fix name of results URL in experiment table

### DIFF
--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/table.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/table.html
@@ -164,7 +164,7 @@
           </td>
           <td>
             {% if experiment.show_results_url %}
-              <a href="{% url "nimbus-results" slug=experiment.slug %}">View Results</a>
+              <a href="{% url "nimbus-ui-results" slug=experiment.slug %}">View Results</a>
             {% else %}
               <a>N/A</a>
             {% endif %}


### PR DESCRIPTION
Because:

- we changed a bunch of URL names when we cut over to the new UI; and
- we missed updating the nimbus-results URL name to nimbus-ui-results, causing Experimenter to go down

This commit:

- updates the URL name in the experiment list view

Fixes #13054
