### PR TITLE
chore(nimbus): Add esr140 to Desktop branches to fetch

### DIFF
--- a/experimenter/experimenter/features/manifests/apps.yaml
+++ b/experimenter/experimenter/features/manifests/apps.yaml
@@ -133,6 +133,7 @@ firefox_desktop:
           - "release"
           - "esr115"
           - "esr128"
+          - "esr140"
 
 experimenter_cirrus:
   slug: "experimenter"


### PR DESCRIPTION
Because:

- the new ESR branch is esr140

This commit:

- adds esr140 to the list of branches to fetch in manifesttool.

Fixes #13059