### PR TITLE
feat(nimbus): Fix audience warning space

### DIFF
--- a/experimenter/experimenter/experiments/constants.py
+++ b/experimenter/experimenter/experiments/constants.py
@@ -955,7 +955,7 @@ Optional - We believe this outcome will <describe impact> on <core metric>
         you will not be able to adjust the sizing for this rollout."
 
     ERROR_ROLLOUT_VERSION = (
-        "WARNING: Adjusting the population size while the"
+        "WARNING: Adjusting the population size while the "
         "rollout is live is not supported for {application} versions under {version}."
     )
 


### PR DESCRIPTION
Because

- The Rollout live editability console warning string is missing a space

This commit

- Adds the space in the warning

Fixes #10086 

Before fix
<img width="1227" height="401" alt="Screenshot 2025-07-23 at 2 58 55 PM" src="https://github.com/user-attachments/assets/1d66c57b-a802-45d5-8e3e-68340d55d5bd" />
After fix
<img width="1227" height="401" alt="Screenshot 2025-07-23 at 3 00 38 PM" src="https://github.com/user-attachments/assets/22da96a1-508c-403c-b586-8b7cadf95a66" />
