### PR TITLE
bug(nimbus): use get_results_url in templates

### DIFF
--- a/experimenter/experimenter/experiments/tests/factories.py
+++ b/experimenter/experimenter/experiments/tests/factories.py
@@ -490,6 +490,7 @@ class NimbusExperimentFactory(factory.django.DjangoModelFactory):
     requires_restart = factory.LazyAttribute(
         lambda o: (random.choice([True, False]) if o.is_firefox_labs_opt_in else False)
     )
+    results_data = {"v3": {"overall": {"enrollments": {"all": [1]}}}}
 
     class Meta:
         model = NimbusExperiment

--- a/experimenter/experimenter/experiments/tests/test_changelog_utils.py
+++ b/experimenter/experimenter/experiments/tests/test_changelog_utils.py
@@ -215,7 +215,7 @@ class TestNimbusExperimentChangeLogSerializer(TestCase):
                 "qa_status": experiment.qa_status,
                 "required_experiments": [],
                 "requires_restart": False,
-                "results_data": None,
+                "results_data": experiment.results_data,
                 "risk_brand": experiment.risk_brand,
                 "risk_message": experiment.risk_message,
                 "risk_mitigation_link": experiment.risk_mitigation_link,

--- a/experimenter/experimenter/jetstream/tests/test_tasks.py
+++ b/experimenter/experimenter/jetstream/tests/test_tasks.py
@@ -1105,6 +1105,7 @@ class TestFetchJetstreamDataTask(MockSizingDataMixin, TestCase):
             lifecycle,
             primary_outcomes=primary_outcomes,
             secondary_outcomes=secondary_outcomes,
+            results_data=None,
         )
         experiment.reference_branch.slug = "control"
         experiment.reference_branch.save()
@@ -1170,6 +1171,7 @@ class TestFetchJetstreamDataTask(MockSizingDataMixin, TestCase):
             lifecycle,
             primary_outcomes=primary_outcomes,
             secondary_outcomes=secondary_outcomes,
+            results_data=None,
         )
         experiment.reference_branch.slug = "control"
         experiment.reference_branch.save()
@@ -2239,7 +2241,9 @@ class TestFetchJetstreamDataTask(MockSizingDataMixin, TestCase):
     @patch("experimenter.jetstream.tasks.fetch_experiment_data.delay")
     def test_data_fetch_in_loop(self, mock_delay):
         lifecycle = NimbusExperimentFactory.Lifecycles.ENDING_APPROVE_APPROVE
-        experiment = NimbusExperimentFactory.create_with_lifecycle(lifecycle)
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            lifecycle, results_data=None
+        )
         tasks.fetch_jetstream_data()
         mock_delay.assert_called_once_with(experiment.id)
 
@@ -2302,7 +2306,9 @@ class TestFetchJetstreamDataTask(MockSizingDataMixin, TestCase):
         lifecycle = NimbusExperimentFactory.Lifecycles.ENDING_APPROVE_APPROVE
         offset = NimbusExperiment.DAYS_ANALYSIS_BUFFER + 1
         experiment = NimbusExperimentFactory.create_with_lifecycle(
-            lifecycle, end_date=datetime.date.today() - datetime.timedelta(days=offset)
+            lifecycle,
+            end_date=datetime.date.today() - datetime.timedelta(days=offset),
+            results_data=None,
         )
 
         tasks.fetch_jetstream_data()
@@ -2318,7 +2324,7 @@ class TestFetchJetstreamDataTask(MockSizingDataMixin, TestCase):
     @patch("experimenter.jetstream.tasks.fetch_experiment_data.delay")
     def test_exception_for_fetch_jetstream_data(self, mock_delay):
         NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperimentFactory.Lifecycles.ENDING_APPROVE_APPROVE,
+            NimbusExperimentFactory.Lifecycles.ENDING_APPROVE_APPROVE, results_data=None
         )
         mock_delay.side_effect = Exception
         with self.assertRaises(Exception):

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/table.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/table.html
@@ -164,7 +164,7 @@
           </td>
           <td>
             {% if experiment.show_results_url %}
-              <a href="{% url "nimbus-ui-results" slug=experiment.slug %}">View Results</a>
+              <a href="{{ experiment.get_results_url }}">View Results</a>
             {% else %}
               <a>N/A</a>
             {% endif %}

--- a/experimenter/experimenter/visualization/tests/api/test_views.py
+++ b/experimenter/experimenter/visualization/tests/api/test_views.py
@@ -27,7 +27,7 @@ class TestVisualizationView(TestCase):
         mock_exists.return_value = False
         primary_outcome = "outcome"
         experiment = NimbusExperimentFactory.create_with_lifecycle(
-            lifecycle, primary_outcomes=[primary_outcome]
+            lifecycle, primary_outcomes=[primary_outcome], results_data=None
         )
 
         # test None object/response


### PR DESCRIPTION
Because

* We just launched the new HTMX UI to prod and discovered we had not updated a url name in the templates from nimbus-results to nimbus-ui-results
* This was missed in unit testing and local/manual testing
* The factories do not set results_data and so we never hit this case
* We should make sure we're stress testing the case where an experiment has results in our tests

This commit

* Sets a minimally valid results_data in the factories
* Updates tests that explicitly depend on having empty results_data
* Updates the table template to use the get_results_url method rather than hard coding the url name

fixes #13064
