### PR TITLE
bug(nimbus): save overviewform when creating/deleting documentation links

### DIFF
--- a/experimenter/experimenter/nimbus_ui/forms.py
+++ b/experimenter/experimenter/nimbus_ui/forms.py
@@ -376,13 +376,9 @@ class OverviewForm(NimbusChangeLogFormMixin, forms.ModelForm):
         return f"{self.request.user} updated overview"
 
 
-class DocumentationLinkCreateForm(NimbusChangeLogFormMixin, forms.ModelForm):
-    class Meta:
-        model = NimbusExperiment
-        fields = []
-
-    def save(self):
-        super().save(commit=False)
+class DocumentationLinkCreateForm(OverviewForm):
+    def save(self, *args, **kwargs):
+        super().save(*args, **kwargs)
         self.instance.documentation_links.create()
         return self.instance
 
@@ -390,15 +386,15 @@ class DocumentationLinkCreateForm(NimbusChangeLogFormMixin, forms.ModelForm):
         return f"{self.request.user} added a documentation link"
 
 
-class DocumentationLinkDeleteForm(NimbusChangeLogFormMixin, forms.ModelForm):
+class DocumentationLinkDeleteForm(OverviewForm):
     link_id = forms.ModelChoiceField(queryset=NimbusDocumentationLink.objects.all())
 
     class Meta:
         model = NimbusExperiment
-        fields = ["link_id"]
+        fields = [*OverviewForm.Meta.fields, "link_id"]
 
-    def save(self):
-        super().save(commit=False)
+    def save(self, *args, **kwargs):
+        super().save(*args, **kwargs)
         documentation_link = self.cleaned_data["link_id"]
         documentation_link.delete()
         return self.instance

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/edit_overview.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/edit_overview.html
@@ -8,11 +8,11 @@
 {% block title %}{{ experiment.name }} - Overview{% endblock %}
 
 {% block main_content %}
-  <form id="metrics-form"
+  <form id="overview-form"
         {% if form.is_bound and form.is_valid %}class="was-validated"{% endif %}
         hx-post="{% url 'nimbus-ui-update-overview' experiment.slug %}{% if request.GET.show_errors == 'true' %}?show_errors=true{% endif %}"
-        hx-select="#metrics-form"
-        hx-target="#metrics-form"
+        hx-select="#overview-form"
+        hx-target="#overview-form"
         hx-swap="outerHTML">
     {% csrf_token %}
     <div class="card mb-3">
@@ -162,15 +162,15 @@
                     {{ link_form.link|add_class:"form-control"|add_error_class:"is-invalid" }}
                     {% for error in link_form.link.errors %}<div class="invalid-feedback">{{ error }}</div>{% endfor %}
                   </div>
-                  <a class="text-primary"
-                     hx-post="{% url 'nimbus-ui-delete-documentation-link' slug=experiment.slug %}"
-                     hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
-                     hx-params="link_id"
-                     hx-vals='{"link_id": {{ link_form.instance.id }} }'
-                     hx-select="#documentation-links"
-                     hx-target="#documentation-links">
+                  <button type="button"
+                          class="btn btn-link p-0 mt-1"
+                          hx-post="{% url 'nimbus-ui-delete-documentation-link' slug=experiment.slug %}"
+                          hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
+                          hx-vals='{"link_id": {{ link_form.instance.id }} }'
+                          hx-select="#overview-form"
+                          hx-target="#overview-form">
                     <i class="fa-solid fa-circle-xmark"></i>
-                  </a>
+                  </button>
                 </div>
               </div>
               <div class="row mb-3">
@@ -185,9 +185,8 @@
                     type="button"
                     hx-post="{% url 'nimbus-ui-create-documentation-link' slug=experiment.slug %}"
                     hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
-                    hx-params="none"
-                    hx-select="#documentation-links"
-                    hx-target="#documentation-links">+ Add Link</button>
+                    hx-select="#overview-form"
+                    hx-target="#overview-form">+ Add Link</button>
           </div>
         </div>
       </div>

--- a/experimenter/experimenter/nimbus_ui/tests/test_forms.py
+++ b/experimenter/experimenter/nimbus_ui/tests/test_forms.py
@@ -1256,7 +1256,21 @@ class TestDocumentationLinkCreateForm(RequestFormTestCase):
         )
 
         form = DocumentationLinkCreateForm(
-            instance=experiment, data={}, request=self.request
+            instance=experiment,
+            data={
+                "name": "new name",
+                "hypothesis": "new hypothesis",
+                "risk_brand": True,
+                "risk_message": True,
+                "projects": [],
+                "public_description": "new description",
+                "risk_revenue": True,
+                "risk_partner_related": True,
+                # Management form data for the inline formset
+                "documentation_links-TOTAL_FORMS": "0",
+                "documentation_links-INITIAL_FORMS": "0",
+            },
+            request=self.request,
         )
 
         self.assertTrue(form.is_valid())
@@ -1276,7 +1290,25 @@ class TestDocumentationLinkDeleteForm(RequestFormTestCase):
 
         form = DocumentationLinkDeleteForm(
             instance=experiment,
-            data={"link_id": documentation_link.id},
+            data={
+                "name": "new name",
+                "hypothesis": "new hypothesis",
+                "risk_brand": True,
+                "risk_message": True,
+                "projects": [],
+                "public_description": "new description",
+                "risk_revenue": True,
+                "risk_partner_related": True,
+                # Management form data for the inline formset
+                "documentation_links-TOTAL_FORMS": "1",
+                "documentation_links-INITIAL_FORMS": "1",
+                "documentation_links-0-id": documentation_link.id,
+                "documentation_links-0-title": (
+                    NimbusExperiment.DocumentationLink.DESIGN_DOC.value
+                ),
+                "documentation_links-0-link": "https://www.example.com",
+                "link_id": documentation_link.id,
+            },
             request=self.request,
         )
 

--- a/experimenter/experimenter/nimbus_ui/tests/test_views.py
+++ b/experimenter/experimenter/nimbus_ui/tests/test_views.py
@@ -1570,6 +1570,19 @@ class TestDocumentationLinkCreateView(AuthTestCase):
             reverse(
                 "nimbus-ui-create-documentation-link", kwargs={"slug": experiment.slug}
             ),
+            {
+                "name": "new name",
+                "hypothesis": "new hypothesis",
+                "risk_brand": True,
+                "risk_message": True,
+                "projects": [],
+                "public_description": "new description",
+                "risk_revenue": True,
+                "risk_partner_related": True,
+                # Management form data for the inline formset
+                "documentation_links-TOTAL_FORMS": "0",
+                "documentation_links-INITIAL_FORMS": "0",
+            },
         )
 
         self.assertEqual(response.status_code, 200)
@@ -1589,6 +1602,22 @@ class TestDocumentationLinkDeleteView(AuthTestCase):
                 "nimbus-ui-delete-documentation-link", kwargs={"slug": experiment.slug}
             ),
             {
+                "name": "new name",
+                "hypothesis": "new hypothesis",
+                "risk_brand": True,
+                "risk_message": True,
+                "projects": [],
+                "public_description": "new description",
+                "risk_revenue": True,
+                "risk_partner_related": True,
+                # Management form data for the inline formset
+                "documentation_links-TOTAL_FORMS": "1",
+                "documentation_links-INITIAL_FORMS": "1",
+                "documentation_links-0-id": documentation_link.id,
+                "documentation_links-0-title": (
+                    NimbusExperiment.DocumentationLink.DESIGN_DOC.value
+                ),
+                "documentation_links-0-link": "https://www.example.com",
                 "link_id": documentation_link.id,
             },
         )


### PR DESCRIPTION


Because

* We now know as a general pattern in HTMX if you dynamically swap out some elements of a form without explicitly saving the fields will reset
* This could cause users to lose data as they're filling in the forms
* We already fixed this on the branch page by always saving the whole form when dynamically creating/deleting related entities

This commit

* Saves the entire overview form when creating/deleting documentation links

fixes #13046

https://github.com/user-attachments/assets/66016cd6-cae7-45c0-81a9-d74a21fbc797


