### PR TITLE
chore(nimbus): swap update and save branch urls

### DIFF
--- a/experimenter/experimenter/nimbus_ui/urls.py
+++ b/experimenter/experimenter/nimbus_ui/urls.py
@@ -93,12 +93,12 @@ urlpatterns = [
         name="nimbus-ui-delete-documentation-link",
     ),
     re_path(
-        r"^(?P<slug>[\w-]+)/update_branches/$",
+        r"^(?P<slug>[\w-]+)/save_branches/$",
         BranchesPartialUpdateView.as_view(),
         name="nimbus-ui-partial-update-branches",
     ),
     re_path(
-        r"^(?P<slug>[\w-]+)/save_branches/$",
+        r"^(?P<slug>[\w-]+)/update_branches/$",
         BranchesUpdateView.as_view(),
         name="nimbus-ui-update-branches",
     ),


### PR DESCRIPTION
Becuase

* We have two URLs for the branch page, one for the outer page on initial load, and one for HTMX form updates
* We accidentally used the wrong url paths, it should be that the outer page is called update_branches and the inner HTMX one is save_branches but they're swapped
* This makes the urls inconsistent with the other forms

This commit

* Swaps the update and save urls so they match the other forms

fixes #13039
