### PR TITLE
bug(nimbus): Clear published_dto field when moving from preview to draft

### DIFF
--- a/experimenter/experimenter/nimbus_ui/forms.py
+++ b/experimenter/experimenter/nimbus_ui/forms.py
@@ -1209,7 +1209,12 @@ class PreviewToDraftForm(UpdateStatusForm):
         return f"{self.request.user} moved the experiment back to Draft"
 
     def save(self, commit=True):
-        experiment = super().save(commit=commit)
+        experiment = super().save(commit=False)
+        experiment.published_dto = None
+
+        if commit:  # pragma: nocover
+            experiment.save()
+
         nimbus_synchronize_preview_experiments_in_kinto.apply_async(countdown=5)
         return experiment
 


### PR DESCRIPTION
Because:

- the `published_dto` field is set on experiments when they are published to a RemoteSettings collection;
- if the `published_dto` field is set, the targeting property will return `published_dto.targeting`;
- the v5 serializer cleared the `published_dto` field when moving an experiment from preview to draft;
- the `PreviewToDraftForm` did not clear the `published_dto` field; and
- thus after publishing a recipe to preview, the `targeting` property would return an incorrect value

this commit:

- clears the `published_dto` field in the `PreviewToDraftForm`, which makes the `targeting` property behave correctly after a experiment is moved from preview to draft.

Fixes #13080