### PR TITLE
feat(nimbus): add MOBILE_14_DAY_USER to constants.py

### DIFF
--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -581,6 +581,19 @@ MOBILE_FIRST_RUN_USER = NimbusTargetingConfig(
     ),
 )
 
+MOBILE_14_DAY_USER = NimbusTargetingConfig(
+    name="Users who installed the app in the last 14 days",
+    slug="mobile_14_day_users",
+    description=("New users on mobile who installed the app in the last 2 weeks"),
+    targeting="days_since_install < 15",
+    desktop_telemetry="",
+    sticky_required=True,
+    is_first_run_required=False,
+    application_choice_names=(
+        Application.FENIX.name,
+    ),
+)
+
 MOBILE_RECENTLY_UPDATED = NimbusTargetingConfig(
     name="Recently Updated Users",
     slug="mobile_recently_updated_users",

--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -589,9 +589,7 @@ MOBILE_14_DAY_USER = NimbusTargetingConfig(
     desktop_telemetry="",
     sticky_required=True,
     is_first_run_required=False,
-    application_choice_names=(
-        Application.FENIX.name,
-    ),
+    application_choice_names=(Application.FENIX.name,),
 )
 
 MOBILE_RECENTLY_UPDATED = NimbusTargetingConfig(


### PR DESCRIPTION
Because

- We need this constant to perform an experiment on new users within 14 days of app install

This commit

    Adds MOBILE_14_DAY_USER to constants.py

Fixes [Bugzilla 1979401](https://bugzilla.mozilla.org/show_bug.cgi?id=1979401)

