### PR TITLE
chore(tests): Update general UI tests for new UI.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -230,7 +230,7 @@ jobs:
     working_directory: ~/experimenter
     environment:
       FIREFOX_CHANNEL: release
-      PYTEST_ARGS: -m nimbus_ui -n 1 --reruns 1 --base-url https://nginx/nimbus/
+      PYTEST_ARGS: -m nimbus_ui -n 4 --reruns 1 --base-url https://nginx/nimbus/
       PYTEST_BASE_URL: https://nginx/nimbus/
     steps:
       - checkout
@@ -576,36 +576,6 @@ jobs:
           command: |
             cp .env.integration-tests .env
             make refresh SKIP_DUMMY=1 PYTEST_SENTRY_DSN=$PYTEST_SENTRY_DSN CIRCLECI=$CIRCLECI up_prod_detached integration_test_nimbus_sdk integration_test_and_report
-      - store_artifacts:
-          path: ~/experimenter/experimenter/tests/integration/test-reports/report.htm
-      - store_test_results:
-          path: workspace/test-results/experimenter_integration_tests.xml
-      - upload-to-gcs:
-          source: dashboard/test-results
-          destination: gs://ecosystem-test-eng-metrics/experimenter/junit
-          extension: xml
-
-  integration_nimbus_cirrus:
-    machine:
-      image: ubuntu-2204:2024.11.1
-      docker_layer_caching: true
-    resource_class: xlarge
-    working_directory: ~/experimenter
-    environment:
-      FIREFOX_CHANNEL: release
-      PYTEST_ARGS: -k DEMO_APP -m cirrus_enrollment --base-url https://nginx/nimbus/
-      PYTEST_BASE_URL: https://nginx/nimbus/
-    steps:
-      - checkout
-      - check_file_paths:
-          paths: "experimenter/experimenter/experiments/|cirrus/|application-services/"
-      - create_test_result_workspace
-      - run:
-          name: Run integration tests
-          command: |
-            cp .env.integration-tests .env
-            export CIRRUS=1
-            make refresh SKIP_DUMMY=1 PYTEST_SENTRY_DSN=$PYTEST_SENTRY_DSN CIRCLECI=$CIRCLECI up_prod_detached integration_test_nimbus_desktop PYTEST_ARGS="$PYTEST_ARGS" integration_test_and_report
       - store_artifacts:
           path: ~/experimenter/experimenter/tests/integration/test-reports/report.htm
       - store_test_results:
@@ -1015,12 +985,6 @@ workflows:
                 - update_firefox_versions
       - integration_nimbus_sdk_targeting:
           name: Test SDK Targeting (Release Firefox)
-          filters:
-            branches:
-              ignore:
-                - main
-      - integration_nimbus_cirrus:
-          name: Test Demo app with Cirrus
           filters:
             branches:
               ignore:

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/archive_button.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/archive_button.html
@@ -3,6 +3,7 @@
   {% csrf_token %}
   <div class="d-flex align-items-center pb-2">
     <button type="submit"
+            data-testid="nav-edit-archive"
             class="nav-link d-flex align-items-center nav-link-hover w-100"
             {% if not experiment.can_archive %}disabled{% endif %}>
       <i class="fa-regular fa-trash-can pe-3"></i>

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/detail.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/detail.html
@@ -266,9 +266,9 @@
             {% if experiment.is_mobile %}
               <tr>
                 <th>First Run Experiment</th>
-                <td>{{ experiment.is_first_run }}</td>
+                <td data-testid="experiment-is-first-run">{{ experiment.is_first_run }}</td>
                 <th>First Run Release Date</th>
-                <td>{{ experiment.proposed_release_date }}</td>
+                <td data-testid="experiment-release-date">{{ experiment.proposed_release_date }}</td>
               </tr>
             {% endif %}
             <tr>
@@ -356,6 +356,7 @@
             {% if not experiment.is_rollout %}
               <div class="col-md-4 text-end">
                 <button class="btn btn-outline-primary btn-sm"
+                        data-testid="promote-rollout"
                         data-bs-toggle="modal"
                         data-bs-target="#promoteToRolloutModal-{{ branch.slug }}">Promote to Rollout</button>
               </div>
@@ -392,7 +393,7 @@
                   <th>Screenshots</th>
                   <td colspan="3">
                     {% for screenshot in branch.screenshots.all %}
-                      <figure class="d-block">
+                      <figure data-testid="branch-screenshot" class="d-block">
                         <figcaption>{{ screenshot.description }}</figcaption>
                         {% if screenshot.image %}
                           <img src="{{ screenshot.image.url }}"

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/edit_audience.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/edit_audience.html
@@ -45,7 +45,7 @@
           </div>
         </div>
         <div class="row mb-3">
-          <div class="col-6">
+          <div data-testid="locales" class="col-6">
             {% if experiment.is_desktop %}
               <label for="id_locales" class="form-label">Locales</label>
               {{ form.locales|add_class:"form-control"|add_error_class:"is-invalid" }}
@@ -58,7 +58,7 @@
               {% for error in validation_errors.languages %}<div class="form-text text-danger">{{ error }}</div>{% endfor %}
             {% endif %}
           </div>
-          <div class="col-6">
+          <div data-testid="countries" class="col-6">
             <label for="id_countries" class="form-label">Countries</label>
             {{ form.countries|add_class:"form-control"|add_error_class:"is-invalid" }}
             {% for error in form.countries.errors %}<div class="invalid-feedback">{{ error }}</div>{% endfor %}

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/edit_branches.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/edit_branches.html
@@ -248,6 +248,7 @@
                     {% endwith %}
                   {% endfor %}
                   <button type="button"
+                          id="add-screenshot-button"
                           class="btn btn-outline-primary btn-sm"
                           hx-post="{% url 'nimbus-ui-create-branch-screenshot' slug=experiment.slug %}{% if request.GET.show_errors == 'true' %}?show_errors=true{% endif %}"
                           hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
@@ -377,10 +378,11 @@
       </div>
     {% endif %}
     <div class="d-flex justify-content-end">
-      <button type="submit" class="btn btn-primary">Save</button>
+      <button type="submit" id="save-button" class="btn btn-primary">Save</button>
       <button type="submit"
               name="save_action"
               value="continue"
+              id="save-and-continue-button"
               class="btn btn-secondary ms-2">Save and Continue</button>
     </div>
     {% if form.is_bound %}

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/edit_metrics.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/edit_metrics.html
@@ -82,10 +82,11 @@
       </div>
     </div>
     <div class="d-flex justify-content-end">
-      <button type="submit" class="btn btn-primary">Save</button>
+      <button type="submit" id="save-button" class="btn btn-primary">Save</button>
       <button type="submit"
               name="save_action"
               value="continue"
+              id="save-and-continue-button"
               class="btn btn-secondary ms-2">Save and Continue</button>
     </div>
     {% if form.is_bound %}

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/edit_overview.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/edit_overview.html
@@ -183,6 +183,7 @@
           <div class="col-12 text-end">
             <button class="btn btn-outline-primary btn-sm"
                     type="button"
+                    id="add-additional-links-button"
                     hx-post="{% url 'nimbus-ui-create-documentation-link' slug=experiment.slug %}"
                     hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
                     hx-params="none"
@@ -193,10 +194,11 @@
       </div>
     </div>
     <div class="d-flex justify-content-end">
-      <button type="submit" class="btn btn-primary">Save</button>
+      <button type="submit" id="save-button" class="btn btn-primary">Save</button>
       <button type="submit"
               name="save_action"
               value="continue"
+              id="save-and-continue-button"
               class="btn btn-secondary ms-2">Save and Continue</button>
     </div>
     {% if form.is_bound %}

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/experiment_base.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/experiment_base.html
@@ -34,6 +34,7 @@
           Cloned from
           <a href="{% url 'nimbus-ui-detail' experiment.parent.slug %}"
              target="_blank"
+             data-testid="experiment-parent"
              rel="noopener noreferrer">{{ experiment.parent.name }}</a>
         </p>
       {% endif %}

--- a/experimenter/tests/integration/nimbus/models/base_dataclass.py
+++ b/experimenter/tests/integration/nimbus/models/base_dataclass.py
@@ -7,9 +7,6 @@ class BaseExperimentApplications(Enum):
     FIREFOX_DESKTOP = "DESKTOP"
     FIREFOX_FENIX = "FENIX"
     FIREFOX_IOS = "IOS"
-    FOCUS_ANDROID = "FOCUS_ANDROID"
-    FOCUS_IOS = "FOCUS_IOS"
-    DEMO_APP = "DEMO_APP"
 
 
 class BaseExperimentAudienceChannels(Enum):
@@ -28,7 +25,7 @@ class BaseExperimentBranchDataClass:
 @dataclass
 class BaseExperimentAudienceDataClass:
     channel: BaseExperimentAudienceChannels
-    min_version: int
+    min_version: str
     targeting: Optional[str]
     percentage: float
     expected_clients: int

--- a/experimenter/tests/integration/nimbus/pages/base.py
+++ b/experimenter/tests/integration/nimbus/pages/base.py
@@ -11,7 +11,7 @@ class Base(Page):
     """Base page."""
 
     def __init__(self, selenium, base_url, **kwargs):
-        super().__init__(selenium, base_url, timeout=300, **kwargs)
+        super().__init__(selenium, base_url, timeout=120, **kwargs)
         self.logging = logging
 
     def wait_for_page_to_load(self):
@@ -71,11 +71,15 @@ class Base(Page):
     def wait_for_and_find_element(
         self, strategy, locator, description=None, refresh=False
     ):
-        self.wait_for_locator((strategy, locator), description, refresh=refresh)
+        self.wait_for_locator((strategy, locator), description)
+        element = self.find_element(strategy, locator)
+        self._scroll_into_view(element)
         return self.find_element(strategy, locator)
 
     def wait_for_and_find_elements(self, strategy, locator, description=None):
         self.wait_for_locator((strategy, locator), description)
+        elements = self.find_elements(strategy, locator)
+        self._scroll_into_view(elements[0])
         return self.find_elements(strategy, locator)
 
     def non_blocking_sleep(self, seconds):
@@ -83,8 +87,12 @@ class Base(Page):
 
     def execute_script(self, script, *args):
         self.selenium.execute_script(script, *args)
-        time.sleep(2)
+        time.sleep(1)
 
     def js_click(self, elem):
         self.execute_script("arguments[0].scrollIntoView({block: 'center'});", elem)
         self.execute_script("arguments[0].click();", elem)
+
+    def _scroll_into_view(self, element):
+        self.execute_script("arguments[0].scrollIntoView({block: 'center'});", element)
+        time.sleep(0.5)

--- a/experimenter/tests/integration/nimbus/pages/experimenter/audience.py
+++ b/experimenter/tests/integration/nimbus/pages/experimenter/audience.py
@@ -1,5 +1,3 @@
-import os
-
 from selenium.webdriver.common.by import By
 from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.support import expected_conditions as EC
@@ -14,45 +12,42 @@ class AudiencePage(ExperimenterBase):
 
     PAGE_TITLE = "Audience Page"
 
-    _page_wait_locator = (
-        (By.CSS_SELECTOR, "#audience-form")
-        if "nimbus" in str(os.environ.get("PYTEST_BASE_URL"))
-        else (By.CSS_SELECTOR, "#PageEditAudience")
-    )
-    _channel_select_locator = (By.CSS_SELECTOR, "#channel")
-    _min_version_select_locator = (By.CSS_SELECTOR, "#minVersion")
-    _targeting_select_locator = (By.CSS_SELECTOR, "#targeting")
+    _page_wait_locator = (By.CSS_SELECTOR, "#audience-form")
+    _channel_select_locator = (By.CSS_SELECTOR, "#id_channel")
+    _min_version_select_locator = (By.CSS_SELECTOR, "#id_firefox_min_version")
+    _targeting_select_locator = (By.CSS_SELECTOR, "#id_targeting_config_slug")
     _population_fill_locator = (
-        (
-            By.CSS_SELECTOR,
-            "#id_population_percent",
-        )
-        if "nimbus" in str(os.environ.get("PYTEST_BASE_URL"))
-        else (
-            By.CSS_SELECTOR,
-            '[data-testid="population-percent-text"]',
-        )
+        By.CSS_SELECTOR,
+        "#id_population_percent",
     )
-    _expected_clients_locator = (By.CSS_SELECTOR, "#totalEnrolledClients")
+    _expected_clients_locator = (By.CSS_SELECTOR, "#id_total_enrolled_clients")
     _enrollment_period_locator = (By.CSS_SELECTOR, "#proposedEnrollment")
     _duration_locator = (By.CSS_SELECTOR, "#proposedDuration")
     _locales_input_locator = (By.CSS_SELECTOR, "div[data-testid='locales'] input")
     _locales_value_locator = (
         By.CSS_SELECTOR,
-        "div[data-testid='locales'] > div:nth-child(1)",
+        "div[data-testid='locales'] > div",
+    )
+    _countries_dropdown_button_loator = (
+        By.CSS_SELECTOR,
+        "div[data-testid='countries'] button",
     )
     _countries_input_locator = (By.CSS_SELECTOR, "div[data-testid='countries'] input")
     _countries_value_locator = (
         By.CSS_SELECTOR,
-        "div[data-testid='countries'] > div:nth-child(1)",
+        "div[data-testid='countries'] > div)",
     )
     _languages_input_locator = (By.CSS_SELECTOR, "div[data-testid='languages'] input")
     _languages_value_locator = (
         By.CSS_SELECTOR,
-        "div[data-testid='languages'] > div:nth-child(1)",
+        "div[data-testid='localses'] > div",
     )
-    _first_run_checkbox_locator = (By.CSS_SELECTOR, '[data-testid="isFirstRun"]')
-    _release_date_locator = (By.CSS_SELECTOR, '[data-testid="proposedReleaseDate"]')
+    _dropdown_input_locator = (
+        By.CSS_SELECTOR,
+        "#audience-form .bs-searchbox input.form-control",
+    )
+    _first_run_checkbox_locator = (By.CSS_SELECTOR, "#id_is_first_run")
+    _release_date_locator = (By.CSS_SELECTOR, "#id_proposed_release_date")
     _saved_locator = (By.CSS_SELECTOR, "form.was-validated")
 
     NEXT_PAGE = SummaryPage
@@ -83,8 +78,9 @@ class AudiencePage(ExperimenterBase):
     @min_version.setter
     def min_version(self, version=80):
         el = self.wait_for_and_find_element(*self._min_version_select_locator)
+        el.click()
         select = Select(el)
-        select.select_by_value(f"FIREFOX_{version}")
+        select.select_by_value(f"{version}")
 
     @property
     def targeting(self):
@@ -105,13 +101,9 @@ class AudiencePage(ExperimenterBase):
         name = self.wait_for_and_find_element(*self._population_fill_locator)
         self.execute_script("arguments[0].scrollIntoView({block: 'center'});", name)
         self.execute_script("arguments[0].click();", name)
-        if "nimbus" in str(os.environ.get("PYTEST_BASE_URL")):
-            self.execute_script(
-                "arguments[0].setAttribute('value', arguments[1]);", name, text
-            )
-        else:
-            name.clear()
-            name.send_keys(f"{text}")
+        self.execute_script(
+            "arguments[0].setAttribute('value', arguments[1]);", name, text
+        )
 
     @property
     def expected_clients(self):
@@ -146,10 +138,10 @@ class AudiencePage(ExperimenterBase):
 
     @countries.setter
     def countries(self, text=None):
+        self.wait_for_and_find_element(*self._countries_dropdown_button_loator).click()
         el = self.wait_for_and_find_element(*self._countries_input_locator)
-        for _ in text:
-            el.send_keys(f"{_}")
-            el.send_keys(Keys.ENTER)
+        el.click()
+        el.send_keys(text, Keys.ENTER)
 
     @property
     def languages(self):

--- a/experimenter/tests/integration/nimbus/pages/experimenter/base.py
+++ b/experimenter/tests/integration/nimbus/pages/experimenter/base.py
@@ -8,7 +8,7 @@ class ExperimenterBase(Base):
 
     _save_btn_locator = (By.CSS_SELECTOR, "#save-button")
     _save_continue_btn_locator = (By.CSS_SELECTOR, "#save-and-continue-button")
-    _sidebar_summary_link = (By.CSS_SELECTOR, 'a[data-testid="nav-summary"]')
+    _sidebar_summary_link = (By.CSS_SELECTOR, 'a[data-testid="nav-edit-summary"]')
     _sidebar_edit_overview_link = (By.CSS_SELECTOR, 'a[data-testid="nav-edit-overview"]')
     _sidebar_edit_branches_link = (By.CSS_SELECTOR, 'a[data-testid="nav-edit-branches"]')
     _sidebar_edit_audience_link = (By.CSS_SELECTOR, 'a[data-testid="nav-edit-audience"]')

--- a/experimenter/tests/integration/nimbus/pages/experimenter/metrics.py
+++ b/experimenter/tests/integration/nimbus/pages/experimenter/metrics.py
@@ -10,11 +10,12 @@ class MetricsPage(ExperimenterBase):
 
     PAGE_TITLE = "Metrics Page"
 
-    _page_wait_locator = (By.CSS_SELECTOR, "#PageEditMetrics")
-    _outcomes_selector_locator = (By.CSS_SELECTOR, "#PageEditMetrics .form-group input")
-    _primary_outcome_root_locator = (
+    _page_wait_locator = (By.CSS_SELECTOR, "#metrics-form")
+    _outcomes_selector_locator = (By.CSS_SELECTOR, ".card-body button")
+    _outcomes_input_locator = (By.CSS_SELECTOR, ".card-body input")
+    _outcomes_text_locator = (
         By.CSS_SELECTOR,
-        "div[data-testid='primary-outcomes']",
+        ".card-body button .filter-option-inner-inner",
     )
     _secondary_outcome_root_locator = (
         By.CSS_SELECTOR,
@@ -25,25 +26,22 @@ class MetricsPage(ExperimenterBase):
 
     @property
     def primary_outcomes(self):
-        self.wait_for_and_find_element(*self._primary_outcome_root_locator)
-        multifeature_el = self.wait_for_and_find_element(
-            *self._multifeature_element_locator
-        )
-        return multifeature_el.find_element(By.CSS_SELECTOR, "div")
+        els = self.wait_for_and_find_elements(*self._outcomes_text_locator)
+        return els[0]
 
     def set_primary_outcomes(self, values=None):
         els = self.wait_for_and_find_elements(*self._outcomes_selector_locator)
-        els[0].send_keys(values)
-        els[0].send_keys(Keys.RETURN)
+        els[0].click()
+        search_box = self.wait_for_and_find_elements(*self._outcomes_input_locator)
+        search_box[0].send_keys(values, Keys.RETURN)
 
     @property
     def secondary_outcomes(self):
-        multifeature_el = self.wait_for_and_find_element(
-            *self._multifeature_element_locator
-        )
-        return multifeature_el.find_element(By.CSS_SELECTOR, "div")
+        els = self.wait_for_and_find_elements(*self._outcomes_text_locator)
+        return els[1]
 
     def set_secondary_outcomes(self, values=None):
         els = self.wait_for_and_find_elements(*self._outcomes_selector_locator)
-        els[1].send_keys(values)
-        els[1].send_keys(Keys.RETURN)
+        els[1].click()
+        search_box = self.wait_for_and_find_elements(*self._outcomes_input_locator)
+        search_box[1].send_keys(values, Keys.RETURN)

--- a/experimenter/tests/integration/nimbus/pages/experimenter/overview.py
+++ b/experimenter/tests/integration/nimbus/pages/experimenter/overview.py
@@ -1,5 +1,5 @@
+from selenium.common.exceptions import ElementNotInteractableException
 from selenium.webdriver.common.by import By
-from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.support.ui import Select
 
 from nimbus.pages.experimenter.base import ExperimenterBase
@@ -11,23 +11,31 @@ class OverviewPage(ExperimenterBase):
 
     PAGE_TITLE = "Overview Page"
 
-    _page_wait_locator = (By.CSS_SELECTOR, "#PageEditOverview")
-    _additional_link_root_locator = (By.CSS_SELECTOR, "#documentation-link")
-    _additional_link_type_locator = (By.CSS_SELECTOR, "#documentation-link select")
+    _page_wait_locator = (By.CSS_SELECTOR, "#metrics-form")
+    _additional_link_root_locator = (By.CSS_SELECTOR, "#documentation-links .form-group")
+    _additional_link_input_locator = (
+        By.CSS_SELECTOR,
+        "#documentation-links .form-group input",
+    )
+    _additional_link_select_locator = (
+        By.CSS_SELECTOR,
+        "#documentation-links .form-group select",
+    )
     _additional_links_button_locator = (
         By.CSS_SELECTOR,
-        "#documentation-links button.btn-outline-primary",
+        "#metrics-form button.btn.btn-outline-primary",
     )
-    _public_description_locator = (By.CSS_SELECTOR, "#publicDescription")
-    _risk_brand_locator = (By.CSS_SELECTOR, "#riskBrand-false")
-    _risk_message_locator = (By.CSS_SELECTOR, "#riskMessage-false")
-    _risk_revenue_locator = (By.CSS_SELECTOR, "#riskRevenue-false")
-    _risk_partner_locator = (By.CSS_SELECTOR, "#riskPartnerRelated-false")
-    _projects_input_locator = (By.CSS_SELECTOR, "input[id^='react-select']")
+    _public_description_locator = (By.CSS_SELECTOR, "#id_public_description")
+    _risk_brand_locator = (By.CSS_SELECTOR, "#id_risk_brand_1")
+    _risk_message_locator = (By.CSS_SELECTOR, "#id_risk_message_1")
+    _risk_revenue_locator = (By.CSS_SELECTOR, "#id_risk_revenue_1")
+    _risk_partner_locator = (By.CSS_SELECTOR, "#id_risk_partner_related_1")
+    _projects_input_locator = (By.CSS_SELECTOR, "#id_projects")
     _projects_value_locator = (
         By.CSS_SELECTOR,
         "div[class*='multiValue'] > div:nth-child(1)",
     )
+    _project_dropdown_locator = (By.CSS_SELECTOR, "#metrics-form .dropdown")
     NEXT_PAGE = BranchesPage
 
     @property
@@ -38,10 +46,10 @@ class OverviewPage(ExperimenterBase):
 
     @projects.setter
     def projects(self, text=None):
+        self.wait_for_and_find_element(*self._project_dropdown_locator).click()
         el = self.wait_for_and_find_element(*self._projects_input_locator)
-        for _ in text:
-            el.send_keys(f"{_}")
-            el.send_keys(Keys.ENTER)
+        select = Select(el)
+        select.select_by_value(text)
 
     @property
     def public_description(self):
@@ -76,11 +84,19 @@ class OverviewPage(ExperimenterBase):
 
     def set_additional_links(self, value=None, url="http://www.nimbus-rocks.com"):
         els = self.wait_for_and_find_elements(*self._additional_link_root_locator)
-        for item in els:
-            if item.find_element(By.CSS_SELECTOR, "input").get_attribute("value") == "":
-                item.find_element(By.CSS_SELECTOR, "input").send_keys(url)
-                select = Select(item.find_element(By.CSS_SELECTOR, "select"))
+        for _ in els:
+            try:
+                self.wait_for_and_find_element(
+                    By.CSS_SELECTOR, "#id_documentation_links-0-link"
+                ).send_keys(url)
+                select = Select(
+                    self.wait_for_and_find_element(
+                        By.CSS_SELECTOR, "#id_documentation_links-0-title"
+                    )
+                )
                 select.select_by_value(value)
+            except ElementNotInteractableException:
+                continue
 
     def add_additional_links(self):
         self.wait_for_and_find_element(*self._additional_links_button_locator).click()

--- a/experimenter/tests/integration/nimbus/pages/experimenter/summary.py
+++ b/experimenter/tests/integration/nimbus/pages/experimenter/summary.py
@@ -1,4 +1,3 @@
-import os
 import random
 import string
 
@@ -18,95 +17,44 @@ class SummaryPage(ExperimenterBase):
 
     _page_wait_locator = (By.CSS_SELECTOR, "#PageSummary")
     _promote_rollout_locator = (By.CSS_SELECTOR, 'button[data-testid="promote-rollout"]')
-    _header_slug = (By.CSS_SELECTOR, 'p[data-testid="header-experiment-slug"]')
-    _approve_request_button_locator = (
-        (By.CSS_SELECTOR, "#review-controls .btn-success")
-        if "nimbus" in str(os.environ.get("PYTEST_BASE_URL"))
-        else (By.CSS_SELECTOR, "#approve-request-button")
-    )
-    _reject_request_button_locator = (
-        (By.CSS_SELECTOR, "#reject-button")
-        if "nimbus" in str(os.environ.get("PYTEST_BASE_URL"))
-        else (By.CSS_SELECTOR, "#reject-request-button")
-    )
+    _header_slug = (By.CSS_SELECTOR, "#experiment-slug")
+    _approve_request_button_locator = (By.CSS_SELECTOR, "#review-controls .btn-success")
+    _reject_request_button_locator = (By.CSS_SELECTOR, "#reject-button")
     _reject_input_text_locator = (
-        (
-            By.CSS_SELECTOR,
-            "#changelog_message",
-        )
-        if "nimbus" in str(os.environ.get("PYTEST_BASE_URL"))
-        else (
-            By.CSS_SELECTOR,
-            'textarea[data-testid="reject-reason"]',
-        )
+        By.CSS_SELECTOR,
+        "#changelog_message",
     )
-    _reject_input_text_submit_locator = (
-        (By.CSS_SELECTOR, "#submit-rejection-button")
-        if "nimbus" in str(os.environ.get("PYTEST_BASE_URL"))
-        else (By.CSS_SELECTOR, '[data-testid="reject-submit"]')
-    )
-    _rejection_notice_locator = (
-        (By.CSS_SELECTOR, "#rejection-reason")
-        if "nimbus" in str(os.environ.get("PYTEST_BASE_URL"))
-        else (By.CSS_SELECTOR, '[data-testid="rejection-notice"]')
-    )
-    _launch_to_preview_locator = (
-        (By.CSS_SELECTOR, "#draft-to-preview-button")
-        if "nimbus" in str(os.environ.get("PYTEST_BASE_URL"))
-        else (By.CSS_SELECTOR, "#launch-to-preview-button")
-    )
-    _launch_without_preview_locator = (
-        (By.CSS_SELECTOR, "#draft-to-review-button")
-        if "nimbus" in str(os.environ.get("PYTEST_BASE_URL"))
-        else (By.CSS_SELECTOR, "#launch-to-review-button")
-    )
+    _reject_input_text_submit_locator = (By.CSS_SELECTOR, "#submit-rejection-button")
+    _rejection_notice_locator = (By.CSS_SELECTOR, "#rejection-reason")
+    _launch_to_preview_locator = (By.CSS_SELECTOR, "#draft-to-preview-button")
+    _launch_without_preview_locator = (By.CSS_SELECTOR, "#draft-to-review-button")
     _rejected_text_alert_locator = (By.CSS_SELECTOR, '[data-testid="rejection-notice"]')
-    _timeout_alert_locator = (
-        (By.CSS_SELECTOR, "#rejection-message")
-        if "nimbus" in str(os.environ.get("PYTEST_BASE_URL"))
-        else (By.CSS_SELECTOR, '[data-testid="timeout-notice"]')
-    )
-    _status_live_locator = (
-        (By.CSS_SELECTOR, "#experiment-timeline .bg-primary strong")
-        if "nimbus" in str(os.environ.get("PYTEST_BASE_URL"))
-        else (By.CSS_SELECTOR, ".status-Live.border-primary")
-    )
+    _timeout_alert_locator = (By.CSS_SELECTOR, "#rejection-message")
+    _status_live_locator = (By.CSS_SELECTOR, "#experiment-timeline .bg-primary strong")
     _status_preview_locator = (By.CSS_SELECTOR, ".status-Preview.border-primary")
     _status_complete_locator = (
-        (
-            By.CSS_SELECTOR,
-            "#experiment-timeline .bg-primary strong",
-        )
-        if "nimbus" in str(os.environ.get("PYTEST_BASE_URL"))
-        else (By.CSS_SELECTOR, ".status-Complete.border-primary")
+        By.CSS_SELECTOR,
+        "#experiment-timeline .bg-primary strong",
     )
     _update_request_locator = (By.CSS_SELECTOR, "#request-update-button")
     _experiment_status_icon_locator = (
         By.CSS_SELECTOR,
         ".header-experiment-status .border-primary",
     )
-    _end_experiment_button_locator = (
-        (By.CSS_SELECTOR, "#end-experiment")
-        if "nimbus" in str(os.environ.get("PYTEST_BASE_URL"))
-        else (By.CSS_SELECTOR, ".end-experiment-start-button")
-    )
-    _end_rollout_button_locator = (
-        (By.CSS_SELECTOR, "#end-rollout")
-        if "nimbus" in str(os.environ.get("PYTEST_BASE_URL"))
-        else (By.CSS_SELECTOR, ".end-experiment-start-button")
-    )
-    _archive_button_locator = (By.CSS_SELECTOR, 'button[data-testid="action-archive"]')
+    _end_experiment_button_locator = (By.CSS_SELECTOR, "#end-experiment")
+    _end_rollout_button_locator = (By.CSS_SELECTOR, "#end-rollout")
+    _archive_button_locator = (By.CSS_SELECTOR, 'button[data-testid="nav-edit-archive"]')
     _archive_label_locator = (
         By.CSS_SELECTOR,
-        'span[data-testid="header-experiment-status-archived"]',
+        "#archive-badge",
     )
-    _clone_action_locator = (By.CSS_SELECTOR, 'button[data-testid="action-clone"]')
+    _clone_action_locator = (By.CSS_SELECTOR, 'a[data-testid="nav-edit-clone"]')
     _clone_name_field_locator = (
         By.CSS_SELECTOR,
-        'form[data-testid="FormClone"] input[name="name"]',
+        "#clone-name",
     )
-    _clone_save_locator = (By.CSS_SELECTOR, ".modal .btn-primary")
-    _clone_parent_locator = (By.CSS_SELECTOR, 'p[data-testid="header-experiment-parent"]')
+    _clone_save_locator = (By.CSS_SELECTOR, "#cloneForm .btn-primary")
+    _clone_parent_locator = (By.CSS_SELECTOR, 'a[data-testid="experiment-parent"]')
     _branch_screenshot_description_locator = (
         By.CSS_SELECTOR,
         'figure[data-testid="branch-screenshot"] figcaption',
@@ -115,11 +63,7 @@ class SummaryPage(ExperimenterBase):
         By.CSS_SELECTOR,
         'figure[data-testid="branch-screenshot"] img',
     )
-    _takeaways_edit_button = (
-        (By.CSS_SELECTOR, 'a[data-testid="edit-takeaways"]')
-        if "nimbus" in str(os.environ.get("PYTEST_BASE_URL"))
-        else (By.CSS_SELECTOR, 'button[data-testid="edit-takeaways"]')
-    )
+    _takeaways_edit_button = (By.CSS_SELECTOR, 'a[data-testid="edit-takeaways"]')
     _takeaways_save_button = (
         By.CSS_SELECTOR,
         'button[data-testid="takeaways-edit-save"]',
@@ -129,26 +73,12 @@ class SummaryPage(ExperimenterBase):
         'form[data-testid="FormTakeaways"] input[name="conclusionRecommendations"]',
     )
     _takeaways_summary_field = (
-        (
-            By.CSS_SELECTOR,
-            "#takeawaysSummary",
-        )
-        if "nimbus" in str(os.environ.get("PYTEST_BASE_URL"))
-        else (
-            By.CSS_SELECTOR,
-            'form[data-testid="FormTakeaways"] textarea[name="takeawaysSummary"]',
-        )
+        By.CSS_SELECTOR,
+        "#takeawaysSummary",
     )
     _takeaways_summary_text = (
-        (
-            By.CSS_SELECTOR,
-            "#takeawaysSummaryText",
-        )
-        if "nimbus" in str(os.environ.get("PYTEST_BASE_URL"))
-        else (
-            By.CSS_SELECTOR,
-            'div[data-testid="takeaways-summary-rendered"]',
-        )
+        By.CSS_SELECTOR,
+        "#takeawaysSummaryText",
     )
     _takeaways_recommendation_badge = (
         By.CSS_SELECTOR,
@@ -168,11 +98,17 @@ class SummaryPage(ExperimenterBase):
     )
     _timeline_locator = (
         By.CSS_SELECTOR,
-        '[data-testid="summary-timeline"]',
+        "#experiment-timeline",
     )
     _timeline_proposed_release_date_locator = (
         By.CSS_SELECTOR,
         '[data-testid="label-release-date"]',
+    )
+    _promote_to_rollout_form_locator = (By.CSS_SELECTOR, "#promoteToRolloutForm-control")
+    _promote_to_rollout_name_locator = (By.CSS_SELECTOR, "#promote-control-name")
+    _promote_to_rollout_save_locator = (
+        By.CSS_SELECTOR,
+        "#promoteToRolloutForm-control .btn-primary",
     )
 
     def wait_for_archive_label_visible(self):
@@ -188,14 +124,10 @@ class SummaryPage(ExperimenterBase):
         )
 
     def wait_for_live_status(self):
-        if "nimbus" in str(os.environ.get("PYTEST_BASE_URL")):
-            self.wait_with_refresh_and_assert(
-                self._status_live_locator,
-                "Enrollment",
-                "Summary Page: Unable to find live status",
-            )
-        self.wait_with_refresh(
-            self._status_live_locator, "Summary Page: Unable to find live status"
+        self.wait_with_refresh_and_assert(
+            self._status_live_locator,
+            "Enrollment",
+            "Summary Page: Unable to find live status",
         )
 
     def wait_for_preview_status(self):
@@ -204,14 +136,10 @@ class SummaryPage(ExperimenterBase):
         )
 
     def wait_for_complete_status(self):
-        if "nimbus" in str(os.environ.get("PYTEST_BASE_URL")):
-            self.wait_with_refresh_and_assert(
-                self._status_complete_locator,
-                "Complete",
-                "Summary Page: Unable to find complete status",
-            )
-        self.wait_with_refresh(
-            self._status_complete_locator, "Summary Page: Unable to find complete status"
+        self.wait_with_refresh_and_assert(
+            self._status_complete_locator,
+            "Complete",
+            "Summary Page: Unable to find complete status",
         )
 
     def wait_for_rejected_alert(self):
@@ -324,21 +252,9 @@ class SummaryPage(ExperimenterBase):
 
     class RequestReview(Region, Base):
         PAGE_TITLE = "Review Region"
-        _root_locator = (
-            (By.CSS_SELECTOR, "#launch-controls")
-            if "nimbus" in str(os.environ.get("PYTEST_BASE_URL"))
-            else (By.CSS_SELECTOR, "#request-launch-alert")
-        )
-        _checkbox1_locator = (
-            (By.CSS_SELECTOR, "#checkbox-1")
-            if "nimbus" in str(os.environ.get("PYTEST_BASE_URL"))
-            else (By.CSS_SELECTOR, "#checkbox-0")
-        )
-        _checkbox2_locator = (
-            (By.CSS_SELECTOR, "#checkbox-2")
-            if "nimbus" in str(os.environ.get("PYTEST_BASE_URL"))
-            else (By.CSS_SELECTOR, "#checkbox-1")
-        )
+        _root_locator = (By.CSS_SELECTOR, "#launch-controls")
+        _checkbox1_locator = (By.CSS_SELECTOR, "#checkbox-1")
+        _checkbox2_locator = (By.CSS_SELECTOR, "#checkbox-2")
         _request_launch_locator = (By.CSS_SELECTOR, "#request-launch-button")
 
         def click_launch_checkboxes(self):
@@ -377,6 +293,19 @@ class SummaryPage(ExperimenterBase):
         self.clone_name_field.send_keys(f"{text}")
 
     @property
+    def promote_to_rollout_name(self):
+        return self.wait_for_and_find_element(*self._promote_to_rollout_name_locator).text
+
+    @promote_to_rollout_name.setter
+    def promote_to_rollout_name(self, text=None):
+        el = self.wait_for_and_find_element(*self._promote_to_rollout_name_locator)
+        el.send_keys(f"{Keys.CONTROL}a", f"{text}")
+
+    @property
+    def promote_to_rollout_save(self):
+        return self.wait_for_and_find_element(*self._promote_to_rollout_save_locator)
+
+    @property
     def clone_save(self):
         return self.wait_for_and_find_element(*self._clone_save_locator)
 
@@ -393,8 +322,8 @@ class SummaryPage(ExperimenterBase):
         random_chars = "".join(
             random.choices(string.ascii_uppercase + string.digits, k=6)
         )
-        self.clone_name = f"Rollout {random_chars}"
-        self.clone_save.click()
+        self.promote_to_rollout_name = f"Rollout {random_chars}"
+        self.promote_to_rollout_save.click()
 
     @property
     def takeaways_edit_button(self):

--- a/experimenter/tests/integration/nimbus/test_cirrus_integration.py
+++ b/experimenter/tests/integration/nimbus/test_cirrus_integration.py
@@ -15,7 +15,7 @@ def test_create_new_rollout_approve_remote_settings_cirrus(
     experiment_url,
     create_experiment,
     kinto_client,
-    old_base_url,
+    base_url,
     experiment_name,
     demo_app,
 ):
@@ -30,7 +30,7 @@ def test_create_new_rollout_approve_remote_settings_cirrus(
 
     SummaryPage(selenium, experiment_url).open().wait_for_live_status()
 
-    HomePage(selenium, old_base_url).open().find_in_table(experiment_name)
+    HomePage(selenium, base_url).open().find_in_table(experiment_name)
 
     # Demo app frontend, default displays "Not Enrolled"
     navigate_to(selenium)
@@ -76,7 +76,7 @@ def test_create_new_experiment_approve_remote_settings_cirrus(
     experiment_url,
     create_experiment,
     kinto_client,
-    old_base_url,
+    base_url,
     experiment_name,
     demo_app,
 ):
@@ -91,7 +91,7 @@ def test_create_new_experiment_approve_remote_settings_cirrus(
 
     SummaryPage(selenium, experiment_url).open().wait_for_live_status()
 
-    HomePage(selenium, old_base_url).open().find_in_table(experiment_name)
+    HomePage(selenium, base_url).open().find_in_table(experiment_name)
 
     # Demo app frontend, by default, returns "Not Enrolled" message
     navigate_to(selenium)
@@ -166,7 +166,7 @@ def test_check_cirrus_targeting(
     experiment_url,
     create_experiment,
     kinto_client,
-    old_base_url,
+    base_url,
     experiment_name,
     demo_app,
 ):
@@ -183,7 +183,7 @@ def test_check_cirrus_targeting(
 
     SummaryPage(selenium, experiment_url).open().wait_for_live_status()
 
-    HomePage(selenium, old_base_url).open()
+    HomePage(selenium, base_url).open()
 
     # Demo app frontend, by default, returns "Not Enrolled" message
     navigate_to(selenium)

--- a/experimenter/tests/integration/nimbus/test_remote_settings.py
+++ b/experimenter/tests/integration/nimbus/test_remote_settings.py
@@ -10,7 +10,7 @@ def test_create_new_experiment_approve_remote_settings(
     selenium,
     experiment_url,
     kinto_client,
-    old_base_url,
+    base_url,
     application,
     default_data_api,
     experiment_slug,
@@ -24,7 +24,7 @@ def test_create_new_experiment_approve_remote_settings(
 
     SummaryPage(selenium, experiment_url).open().wait_for_live_status()
 
-    HomePage(selenium, old_base_url).open().find_in_table(experiment_slug)
+    HomePage(selenium, base_url).open().find_in_table(experiment_slug)
 
 
 @pytest.mark.remote_settings_all
@@ -33,7 +33,6 @@ def test_create_new_rollout_approve_remote_settings(
     experiment_url,
     kinto_client,
     base_url,
-    old_base_url,
     application,
     default_data_api,
     experiment_slug,
@@ -49,7 +48,7 @@ def test_create_new_rollout_approve_remote_settings(
 
     SummaryPage(selenium, experiment_url).open().wait_for_live_status()
 
-    HomePage(selenium, old_base_url).open().find_in_table(experiment_slug)
+    HomePage(selenium, base_url).open().find_in_table(experiment_slug)
 
 
 @pytest.mark.remote_settings_all


### PR DESCRIPTION
Because

- We now use a new UI based on HTMX but our generic UI tests were using the old selectors and such from the older UI.

This commit

- Updates the UI tests to work with the new UI
- Removes Firefox iOS as well as the Focus's as we just need to test 1 mobile app now.

Fixes #13088