### PR TITLE
feat(nimbus): redirect to summary page when missing slug subpaths

### DIFF
--- a/experimenter/experimenter/nimbus_ui/tests/test_views.py
+++ b/experimenter/experimenter/nimbus_ui/tests/test_views.py
@@ -2882,3 +2882,33 @@ class TestBranchScreenshotDeleteView(AuthTestCase):
         self.assertEqual(response.status_code, 200)
         experiment.refresh_from_db()
         self.assertFalse(branch.screenshots.filter(id=screenshot.id).exists())
+
+
+class TestSlugRedirectToSummary(AuthTestCase):
+    def test_slug_with_trailing_slash_redirects_to_summary(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED
+        )
+        url = reverse("nimbus-ui-detail", kwargs={"slug": experiment.slug}).replace(
+            "summary/", ""
+        )
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(
+            response.url,
+            reverse("nimbus-ui-detail", kwargs={"slug": experiment.slug}),
+        )
+
+    def test_slug_without_trailing_slash_redirects_to_summary(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED
+        )
+        url = reverse("nimbus-ui-detail", kwargs={"slug": experiment.slug}).replace(
+            "/summary/", ""
+        )
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(
+            response.url,
+            reverse("nimbus-ui-detail", kwargs={"slug": experiment.slug}),
+        )

--- a/experimenter/experimenter/nimbus_ui/urls.py
+++ b/experimenter/experimenter/nimbus_ui/urls.py
@@ -1,4 +1,5 @@
 from django.urls import re_path
+from django.views.generic import RedirectView
 
 from experimenter.nimbus_ui.views import (
     ApproveEndEnrollmentView,
@@ -47,14 +48,24 @@ from experimenter.nimbus_ui.views import (
 
 urlpatterns = [
     re_path(
-        r"^(?P<slug>[\w-]+)/history/$",
-        NimbusChangeLogsView.as_view(),
-        name="nimbus-ui-history",
-    ),
-    re_path(
         r"^table/",
         NimbusExperimentsListTableView.as_view(),
         name="nimbus-ui-table",
+    ),
+    re_path(
+        r"^create/",
+        NimbusExperimentsCreateView.as_view(),
+        name="nimbus-ui-create",
+    ),
+    re_path(
+        r"^(?P<slug>[\w-]+)[/]?$",
+        RedirectView.as_view(pattern_name="nimbus-ui-detail", permanent=False),
+        name="nimbus-ui-redirect-to-summary",
+    ),
+    re_path(
+        r"^(?P<slug>[\w-]+)/history/$",
+        NimbusChangeLogsView.as_view(),
+        name="nimbus-ui-history",
     ),
     re_path(
         r"^(?P<slug>[\w-]+)/summary/$",
@@ -120,11 +131,6 @@ urlpatterns = [
         r"^(?P<slug>[\w-]+)/update_audience/$",
         AudienceUpdateView.as_view(),
         name="nimbus-ui-update-audience",
-    ),
-    re_path(
-        r"^create/",
-        NimbusExperimentsCreateView.as_view(),
-        name="nimbus-ui-create",
     ),
     re_path(
         r"^(?P<slug>[\w-]+)/clone/$",


### PR DESCRIPTION
Becuase

* In the old ui a url for a slug without any subpath would redirect to the summary page
* Users may have urls of this form bookmarked

This commit

* Adds a redirect condition for /nimbus/slug and /nimbus/slug/ to redirect to /nimbus/slug/summary/

fixes #13091

