### PR TITLE
chore(cirrus) explicitly set uvicorn workers to 1

### DIFF
--- a/cirrus/server/Dockerfile
+++ b/cirrus/server/Dockerfile
@@ -67,4 +67,4 @@ RUN mkdir -p /var/glean && chown -R $USERNAME:$USERNAME /var/glean
 USER $USERNAME
 
 # Start application with Uvicorn server
-CMD ["uvicorn", "cirrus.main:app", "--host", "0.0.0.0", "--port", "8001"]
+CMD ["uvicorn", "cirrus.main:app", "--host", "0.0.0.0", "--port", "8001", "--workers", "1"]


### PR DESCRIPTION
Because

- Just in case so that it never tries to set it based on the number of available CPUs or anything

This commit

- add `--workers 1` to the cirrus docker image default command