### PR TITLE
chore(cirrus) use uid and gid 10001

### DIFF
--- a/cirrus/server/Dockerfile
+++ b/cirrus/server/Dockerfile
@@ -32,7 +32,7 @@ FROM python:3.11-slim-bullseye as deploy
 
 # Create a non-root user
 ARG USERNAME=cirrus
-ARG USER_UID=1000
+ARG USER_UID=10001
 ARG USER_GID=$USER_UID
 
 RUN groupadd --gid $USER_GID $USERNAME \


### PR DESCRIPTION
Because

- @jaredlockhart pointed out in https://github.com/mozilla/webservices-infra/pull/6682#pullrequestreview-3056779940 that 10001 is the value recommended by dockerflow

This commit

- Changes cirrus uid and gid to 10001