### PR TITLE
feat(nimbus): redirect on save for non editable experiments

### DIFF
--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/detail.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/detail.html
@@ -443,6 +443,17 @@
     {% include "nimbus_experiments/qa_card.html" %}
 
   </div>
+  {% if save_failed %}
+    <div class="toast text-bg-danger position-fixed top-0 end-0 m-3 w-auto"
+         role="alert"
+         aria-live="assertive"
+         aria-atomic="true">
+      <div class="toast-body">
+        <i class="fa-regular fa-circle-check"></i>
+        Save Failed: This experiment is not editable in its current state.
+      </div>
+    </div>
+  {% endif %}
 {% endblock %}
 
 {% block extrascripts %}

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/edit_audience.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/edit_audience.html
@@ -251,23 +251,24 @@
             <i class="fa-regular fa-circle-check"></i>
             Audience saved!
           </div>
-        {% endif %}
-        {% if not form.is_valid or validation_errors %}
-          <div class="toast text-bg-danger position-fixed top-1 end-0 m-3 w-auto"
-               role="alert"
-               aria-live="assertive"
-               aria-atomic="true">
-            <div class="toast-body">
-              <i class="fa-regular fa-circle-check"></i>
-              Please fix the errors
-            </div>
-          {% endif %}
         </div>
       {% endif %}
-    </form>
-  {% endblock main_content %}
+      {% if not form.is_valid or validation_errors %}
+        <div class="toast text-bg-danger position-fixed top-1 end-0 m-3 w-auto"
+             role="alert"
+             aria-live="assertive"
+             aria-atomic="true">
+          <div class="toast-body">
+            <i class="fa-regular fa-circle-xmark"></i>
+            Please fix the errors
+          </div>
+        </div>
+      {% endif %}
+    {% endif %}
+  </form>
+{% endblock main_content %}
 
-  {% block extrascripts %}
-    {{ block.super }}
-    <script src="{% static 'nimbus_ui/edit_audience.bundle.js' %}"></script>
-  {% endblock extrascripts %}
+{% block extrascripts %}
+  {{ block.super }}
+  <script src="{% static 'nimbus_ui/edit_audience.bundle.js' %}"></script>
+{% endblock extrascripts %}

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/edit_branches.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/edit_branches.html
@@ -394,8 +394,9 @@
             Branches saved!
           </div>
         </div>
-      {% elif validation_errors %}
-        <div class="toast text-bg-danger position-fixed top-0 end-0 m-3 w-auto"
+      {% endif %}
+      {% if not form.is_valid or validation_errors %}
+        <div class="toast text-bg-danger position-fixed top-1 end-0 m-3 w-auto"
              role="alert"
              aria-live="assertive"
              aria-atomic="true">

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/edit_metrics.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/edit_metrics.html
@@ -89,15 +89,28 @@
               class="btn btn-secondary ms-2">Save and Continue</button>
     </div>
     {% if form.is_bound %}
-      <div class="toast text-bg-success position-absolute top-0 end-0 m-3 w-auto"
-           role="alert"
-           aria-live="assertive"
-           aria-atomic="true">
-        <div class="toast-body">
-          <i class="fa-regular fa-circle-check"></i>
-          Metrics saved!
+      {% if form.is_valid %}
+        <div class="toast text-bg-success position-fixed top-0 end-0 m-3 w-auto"
+             role="alert"
+             aria-live="assertive"
+             aria-atomic="true">
+          <div class="toast-body">
+            <i class="fa-regular fa-circle-check"></i>
+            Metrics saved!
+          </div>
         </div>
-      </div>
+      {% endif %}
+      {% if not form.is_valid or validation_errors %}
+        <div class="toast text-bg-danger position-fixed top-1 end-0 m-3 w-auto"
+             role="alert"
+             aria-live="assertive"
+             aria-atomic="true">
+          <div class="toast-body">
+            <i class="fa-regular fa-circle-xmark"></i>
+            Please fix the errors
+          </div>
+        </div>
+      {% endif %}
     {% endif %}
   </form>
 {% endblock main_content %}

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/edit_overview.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/edit_overview.html
@@ -208,18 +208,19 @@
             <i class="fa-regular fa-circle-check"></i>
             Overview saved!
           </div>
-        {% endif %}
-        {% if not form.is_valid or validation_errors %}
-          <div class="toast text-bg-danger position-fixed top-1 end-0 m-3 w-auto"
-               role="alert"
-               aria-live="assertive"
-               aria-atomic="true">
-            <div class="toast-body">
-              <i class="fa-regular fa-circle-check"></i>
-              Please fix the errors
-            </div>
-          {% endif %}
         </div>
       {% endif %}
-    </form>
-  {% endblock main_content %}
+      {% if not form.is_valid or validation_errors %}
+        <div class="toast text-bg-danger position-fixed top-1 end-0 m-3 w-auto"
+             role="alert"
+             aria-live="assertive"
+             aria-atomic="true">
+          <div class="toast-body">
+            <i class="fa-regular fa-circle-xmark"></i>
+            Please fix the errors
+          </div>
+        </div>
+      {% endif %}
+    {% endif %}
+  </form>
+{% endblock main_content %}

--- a/experimenter/experimenter/nimbus_ui/tests/test_views.py
+++ b/experimenter/experimenter/nimbus_ui/tests/test_views.py
@@ -987,6 +987,14 @@ class NimbusExperimentDetailViewTest(AuthTestCase):
         self.assertEqual(response.context["experiment"], self.experiment)
         self.assertIn("RISK_QUESTIONS", response.context)
 
+    def test_save_failed_query_arg_passed_in_context(self):
+        response = self.client.get(
+            reverse("nimbus-ui-detail", kwargs={"slug": self.experiment.slug}),
+            {"save_failed": "true"},
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.context["save_failed"])
+
     def test_outcome_and_segment_links(self):
         response = self.client.get(
             reverse("nimbus-ui-detail", kwargs={"slug": self.experiment.slug}),
@@ -1429,6 +1437,27 @@ class TestOverviewUpdateView(AuthTestCase):
             response.url, reverse("nimbus-ui-detail", kwargs={"slug": experiment.slug})
         )
 
+    @parameterized.expand(
+        [
+            (NimbusExperimentFactory.Lifecycles.PREVIEW,),
+            (NimbusExperimentFactory.Lifecycles.LIVE_ENROLLING,),
+            (NimbusExperimentFactory.Lifecycles.ENDING_APPROVE_APPROVE,),
+        ]
+    )
+    def test_post_non_draft_hx_redirects_to_summary(self, lifecycle):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(lifecycle)
+        response = self.client.post(
+            reverse("nimbus-ui-update-overview", kwargs={"slug": experiment.slug}), {}
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.headers.get("HX-Redirect"),
+            (
+                f"{reverse('nimbus-ui-detail', kwargs={'slug': experiment.slug})}"
+                "?save_failed=true"
+            ),
+        )
+
     def test_post_updates_overview(self):
         project = ProjectFactory.create()
         documentation_link = NimbusDocumentationLinkFactory.create()
@@ -1648,6 +1677,27 @@ class TestBranchesUpdateViews(AuthTestCase):
         self.assertEqual(response.status_code, 302)
         self.assertEqual(
             response.url, reverse("nimbus-ui-detail", kwargs={"slug": experiment.slug})
+        )
+
+    @parameterized.expand(
+        [
+            (NimbusExperimentFactory.Lifecycles.PREVIEW,),
+            (NimbusExperimentFactory.Lifecycles.LIVE_ENROLLING,),
+            (NimbusExperimentFactory.Lifecycles.ENDING_APPROVE_APPROVE,),
+        ]
+    )
+    def test_post_non_draft_hx_redirects_to_summary(self, lifecycle):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(lifecycle)
+        response = self.client.post(
+            reverse("nimbus-ui-update-branches", kwargs={"slug": experiment.slug}), {}
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.headers.get("HX-Redirect"),
+            (
+                f"{reverse('nimbus-ui-detail', kwargs={'slug': experiment.slug})}"
+                "?save_failed=true"
+            ),
         )
 
     @parameterized.expand(
@@ -1915,6 +1965,27 @@ class TestMetricsUpdateView(AuthTestCase):
         self.assertEqual(response.status_code, 302)
         self.assertEqual(
             response.url, reverse("nimbus-ui-detail", kwargs={"slug": experiment.slug})
+        )
+
+    @parameterized.expand(
+        [
+            (NimbusExperimentFactory.Lifecycles.PREVIEW,),
+            (NimbusExperimentFactory.Lifecycles.LIVE_ENROLLING,),
+            (NimbusExperimentFactory.Lifecycles.ENDING_APPROVE_APPROVE,),
+        ]
+    )
+    def test_post_non_draft_hx_redirects_to_summary(self, lifecycle):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(lifecycle)
+        response = self.client.post(
+            reverse("nimbus-ui-update-metrics", kwargs={"slug": experiment.slug}), {}
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.headers.get("HX-Redirect"),
+            (
+                f"{reverse('nimbus-ui-detail', kwargs={'slug': experiment.slug})}"
+                "?save_failed=true"
+            ),
         )
 
     def test_post_updates_metrics_and_segments(self):
@@ -2591,6 +2662,29 @@ class TestAudienceUpdateView(AuthTestCase):
         self.assertEqual(response.status_code, 302)
         self.assertEqual(
             response.url, reverse("nimbus-ui-detail", kwargs={"slug": experiment.slug})
+        )
+
+    @parameterized.expand(
+        [
+            (NimbusExperimentFactory.Lifecycles.PREVIEW,),
+            (NimbusExperimentFactory.Lifecycles.LIVE_ENROLLING,),
+            (NimbusExperimentFactory.Lifecycles.ENDING_APPROVE_APPROVE,),
+        ]
+    )
+    def test_post_non_draft_hx_redirects_to_summary(self, lifecycle):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            lifecycle, is_rollout=False
+        )
+        response = self.client.post(
+            reverse("nimbus-ui-update-audience", kwargs={"slug": experiment.slug}), {}
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.headers.get("HX-Redirect"),
+            (
+                f"{reverse('nimbus-ui-detail', kwargs={'slug': experiment.slug})}"
+                "?save_failed=true"
+            ),
         )
 
     def test_post_updates_overview(self):

--- a/experimenter/experimenter/nimbus_ui/views.py
+++ b/experimenter/experimenter/nimbus_ui/views.py
@@ -152,6 +152,15 @@ class UpdateRedirectViewMixin:
             )
         return super().get(request, *args, **kwargs)
 
+    def post(self, request, *args, **kwargs):
+        self.object = self.get_object()
+        if not self.can_edit():
+            response = HttpResponse()
+            base_url = reverse("nimbus-ui-detail", kwargs={"slug": self.object.slug})
+            response.headers["HX-Redirect"] = f"{base_url}?save_failed=true"
+            return response
+        return super().post(request, *args, **kwargs)
+
 
 class CloneExperimentFormMixin:
     def get_context_data(self, **kwargs):
@@ -282,6 +291,9 @@ class NimbusExperimentDetailView(
             context["form"] = QAStatusForm(instance=self.object)
         if context["takeaways_edit_mode"]:
             context["takeaways_form"] = TakeawaysForm(instance=self.object)
+
+        if "save_failed" in self.request.GET:
+            context["save_failed"] = True
 
         return context
 


### PR DESCRIPTION
Becuase

* If a user keeps a form tab open while the experiment changes into a non editable state, we should block saving

This commit

* Checks if an experiment is not editable during a POST and uses HX-Redirect to send the client to the detail page
* Adds a toast to the detail page to inform the user their save failed

fixes #13093

https://github.com/user-attachments/assets/524b6daa-d457-4af3-a8c0-71c50de6cec4


