### PR TITLE
fix(cirrus): use different glean data dir per pid

### DIFF
--- a/cirrus/server/cirrus/main.py
+++ b/cirrus/server/cirrus/main.py
@@ -1,7 +1,6 @@
 import logging
 import sys
 from contextlib import asynccontextmanager
-from pathlib import Path
 from typing import Any, List, NamedTuple, TypedDict
 
 import sentry_sdk
@@ -140,8 +139,6 @@ def initialize_glean():
     pings = load_pings(pings_path)
     metrics = load_metrics(metrics_path)
 
-    data_dir_path = Path(metrics_config.data_dir)
-
     config = Configuration(
         channel=metrics_config.channel,
         max_events=metrics_config.max_events_buffer,
@@ -153,7 +150,7 @@ def initialize_glean():
         application_id=metrics_config.app_id,
         application_version=metrics_config.version,
         configuration=config,
-        data_dir=data_dir_path,
+        data_dir=metrics_config.data_dir,
         log_level=int(metrics_config.log_level),
         upload_enabled=metrics_config.upload_enabled,
     )

--- a/cirrus/server/cirrus/settings.py
+++ b/cirrus/server/cirrus/settings.py
@@ -1,6 +1,8 @@
 import json
 import logging
+import os
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Optional, Union, cast
 
 from decouple import config  # type: ignore
@@ -43,7 +45,7 @@ class MetricsConfiguration:
     app_id: str = app_id
     build: Optional[str] = None
     channel: str = channel
-    data_dir: str = "/var/glean"
+    data_dir: Path = Path("/var/glean") / str(os.getpid())
     log_level: Union[str, int] = logging.WARNING
     max_events_buffer: int = glean_max_events_buffer
     server_endpoint: Optional[str] = None


### PR DESCRIPTION
Because

- glean can only have one process per data dir

This commit

- Change cirrus metrics_config.data_dir to be a Path like /var/glean/$PID

Fixes #13119