### PR TITLE
bug(nimbus): always show end experiment button for live experiments

### DIFF
--- a/experimenter/experimenter/experiments/models.py
+++ b/experimenter/experimenter/experiments/models.py
@@ -798,7 +798,6 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
         return (
             self.status == self.Status.LIVE
             and self.publish_status != self.PublishStatus.REVIEW
-            and not self.should_end
             and not self.is_rollout
         )
 


### PR DESCRIPTION
Becuase

* We were gating the display of the end experiment button on whether the experiment had passed some date
* Experiments should always be endable

This change

* Removes the date check from the end experiment button display logic

fixes #13133

