### PR TITLE
feat(nimbus): Filter archived experiments on home page

### DIFF
--- a/experimenter/experimenter/nimbus_ui/tests/test_views.py
+++ b/experimenter/experimenter/nimbus_ui/tests/test_views.py
@@ -3015,6 +3015,19 @@ class TestNimbusExperimentsHomeView(AuthTestCase):
         self.assertIn(owned_exp.slug, page_slugs)
         self.assertIn(subscribed_exp.slug, page_slugs)
 
+    def test_home_view_filter_archived_experiments(self):
+        non_archived_exp = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED, owner=self.user, slug="owned-exp"
+        )
+        archived_exp = NimbusExperimentFactory.create(is_archived=True, owner=self.user)
+        response = self.client.get(reverse("nimbus-ui-home"))
+        self.assertEqual(response.status_code, 200)
+
+        experiments = list(response.context["experiments"])
+        slugs = {e.slug for e in experiments}
+        self.assertIn(non_archived_exp.slug, slugs)
+        self.assertNotIn(archived_exp.slug, slugs)
+
     def test_home_view_renders_template(self):
         NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.CREATED, owner=self.user

--- a/experimenter/experimenter/nimbus_ui/views.py
+++ b/experimenter/experimenter/nimbus_ui/views.py
@@ -643,9 +643,8 @@ class NimbusExperimentsHomeView(FilterView):
 
     def get_queryset(self):
         return (
-            NimbusExperiment.objects.filter(
-                Q(owner=self.request.user) | Q(subscribers=self.request.user)
-            )
+            NimbusExperiment.objects.filter(is_archived=False)
+            .filter(Q(owner=self.request.user) | Q(subscribers=self.request.user))
             .distinct()
             .order_by("-_updated_date_time")
             .prefetch_related("subscribers")


### PR DESCRIPTION
Because

- Because on the home page, we don't want to show the archived experiments

This commit

- Filters the archived experiments from the owned and subscribed list

Fixes #13141 