### PR TITLE
bug(nimbus): don't clone _computed_end_date

### DIFF
--- a/experimenter/experimenter/experiments/models.py
+++ b/experimenter/experimenter/experiments/models.py
@@ -317,16 +317,18 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
         "Takeaways QBR Learning", default=False, blank=False, null=False
     )
     takeaways_summary = models.TextField("Takeaways Summary", blank=True, null=True)
-    _updated_date_time = models.DateTimeField(auto_now=True)
     is_first_run = models.BooleanField("Is First Run Flag", default=False)
     is_client_schema_disabled = models.BooleanField(
         "Is Client Schema Disabled Flag", default=False
     )
 
+    # Cached dates
+    _updated_date_time = models.DateTimeField(auto_now=True)
     _start_date = models.DateField("Start Date", blank=True, null=True)
     _enrollment_end_date = models.DateField("Enrollment End Date", blank=True, null=True)
     _computed_end_date = models.DateField("Computed End Date", blank=True, null=True)
     _end_date = models.DateField("End Date", blank=True, null=True)
+
     prevent_pref_conflicts = models.BooleanField(
         "Prevent Preference Conflicts Flag", blank=True, null=True, default=False
     )
@@ -984,7 +986,8 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
             return None
 
         if self._computed_end_date:
-            return self._computed_end_date
+            if self.start_date is not None and self._computed_end_date >= self.start_date:
+                return self._computed_end_date
 
         end_date = self._get_computed_end_date()
         self.update_computed_end_date(end_date)
@@ -1665,6 +1668,7 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
         cloned._start_date = None
         cloned._end_date = None
         cloned._enrollment_end_date = None
+        cloned._computed_end_date = None
         cloned.qa_status = NimbusExperiment.QAStatus.NOT_SET
         cloned.qa_comment = None
         cloned.klaatu_status = False


### PR DESCRIPTION
Becuase

* We added a cached field for _computed_end_date to prevent expensively recomputing it
* However we neglected to empy it for cloned experiments
* This caused some experiments to erroneously show end dates in the past or negative durations

This commit

* Sets _computed_end_date to None when cloning experiments

fixes #13155

