### PR TITLE
bug(nimbus): targeting config drop down is too wide

### DIFF
--- a/experimenter/experimenter/nimbus_ui/forms.py
+++ b/experimenter/experimenter/nimbus_ui/forms.py
@@ -276,6 +276,23 @@ class MultiSelectWidget(forms.SelectMultiple):
         super().__init__(*args, attrs=attrs, **kwargs)
 
 
+class SingleSelectWidget(forms.Select):
+    class_attrs = "selectpicker form-control"
+
+    def __init__(self, *args, attrs=None, **kwargs):
+        attrs = attrs or {}
+        attrs.update(
+            {
+                "class": self.class_attrs,
+                "data-live-search": "true",
+                "data-live-search-placeholder": "Search",
+                "data-max-options": 1,
+            }
+        )
+
+        super().__init__(*args, attrs=attrs, **kwargs)
+
+
 class InlineRadioSelect(forms.RadioSelect):
     template_name = "common/widgets/inline_radio.html"
     option_template_name = "common/widgets/inline_radio_option.html"
@@ -937,9 +954,7 @@ class AudienceForm(NimbusChangeLogFormMixin, forms.ModelForm):
     targeting_config_slug = forms.ChoiceField(
         required=False,
         label="",
-        widget=forms.widgets.Select(
-            attrs={"class": "form-select"},
-        ),
+        widget=SingleSelectWidget(),
     )
 
     excluded_experiments_branches = forms.MultipleChoiceField(

--- a/experimenter/experimenter/nimbus_ui/static/css/style.scss
+++ b/experimenter/experimenter/nimbus_ui/static/css/style.scss
@@ -21,6 +21,34 @@
   .dropdown-toggle::after {
     content: none;
   }
+
+  .dropdown-menu {
+    .dropdown-item {
+      white-space: normal; // Allow text to wrap
+      word-break: break-word; // Break long words
+      overflow-wrap: anywhere; // Ensure long words wrap
+      max-width: 100%; // Prevent overflow
+    }
+
+    .dropdown-item:hover,
+    .dropdown-item:focus,
+    .dropdown-item.active,
+    .dropdown-item.selected {
+      background-color: var(--bs-primary-bg-subtle, #e7f1ff) !important;
+      color: var(--bs-primary-text-emphasis, #084298) !important;
+      box-shadow: 0 1px 4px rgba(0, 0, 0, 0.04);
+      outline: none;
+    }
+  }
+
+  .filter-option-inner-inner {
+    white-space: normal;
+    word-break: break-word;
+    overflow-wrap: anywhere;
+    max-width: 100%;
+    min-height: 1.5em;
+    line-height: 1.3;
+  }
 }
 
 .was-validated .bootstrap-select {


### PR DESCRIPTION
Becuase

* The advanced targeting configs have very long names and descriptions
* The bootstrap-select widget will naively flow off the edge of the page for long values
* This makes it difficult to use the advanced targeting drop down

This commit

* Forces the width to be fixed
* Forces text to wrap properly
* Adds a hover highlight to make it clear where the separation between options is

fixes #12881
<img width="3238" height="2032" alt="Screenshot 2025-07-31 at 12-44-51 Advanced exuding superstructure - Audience Experimenter" src="https://github.com/user-attachments/assets/419146b4-630a-48c7-982a-06f6a9ea5909" />
<img width="3238" height="2032" alt="Screenshot 2025-07-31 at 12-44-59 Advanced exuding superstructure - Audience Experimenter" src="https://github.com/user-attachments/assets/f23792dd-2a1d-4592-abf8-1a24a8da03d9" />
