### PR TITLE
feat(nimbus): add missing details to sidebar

### DIFF
--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/sidebar.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/sidebar.html
@@ -8,6 +8,33 @@
 
     {% endif %}
   {% endfor %}
+  {% if invalid_pages %}
+    <div class="alert alert-primary" role="alert">
+      <p class="mb-1">
+        Missing details in
+        <strong>
+          {% for page in invalid_pages %}
+            {% if page == "overview" %}
+              <a href="{{ experiment.get_update_overview_url }}?show_errors=true"
+                 rel="noopener noreferrer">Overview</a>
+            {% elif page == "branches" %}
+              <a href="{{ experiment.get_update_branches_url }}?show_errors=true"
+                 rel="noopener noreferrer">Branches</a>
+            {% elif page == "metrics" %}
+              <a href="{{ experiment.get_update_metrics_url }}?show_errors=true"
+                 rel="noopener noreferrer">Metrics</a>
+            {% elif page == "audience" %}
+              <a href="{{ experiment.get_update_audience_url }}?show_errors=true"
+                 rel="noopener noreferrer">Audience</a>
+            {% else %}
+              {{ page|capfirst }}
+            {% endif %}
+            {% if not forloop.last %},{% endif %}
+          {% endfor %}
+        </strong>
+      </p>
+    </div>
+  {% endif %}
   <strong class="ms-3">Actions</strong>
   <hr class="my-0 mb-2">
   {% include "common/sidebar_link.html" with title="Clone" link="" icon="fa-regular fa-copy fa-lg" data_bs_toggle="modal" data_bs_target="#cloneModal" %}


### PR DESCRIPTION
Becuase

* In the old Nimbus UI, we showed the invalid form pages in the sidebar
* This is handy and user like and expect it to be there

This commit

* Adds the invalid pages list to the sidebar

fixes #12887

<img width="3238" height="2032" alt="Screenshot 2025-07-31 at 14-11-09 aasdf - Branches Experimenter" src="https://github.com/user-attachments/assets/10df6b46-6497-49be-9246-ab0932712c6f" />
