### PR TITLE
feat(nimbus): make slug and preview url click copy to clipboard

### DIFF
--- a/experimenter/experimenter/nimbus_ui/static/js/experiment_detail.js
+++ b/experimenter/experimenter/nimbus_ui/static/js/experiment_detail.js
@@ -1,4 +1,6 @@
-document.addEventListener("DOMContentLoaded", function () {
+import * as bootstrap from "bootstrap";
+
+const setupCollapseRecipe = () => {
   const collapseRecipe = document.getElementById("collapse-recipe");
   if (!collapseRecipe) return;
 
@@ -22,4 +24,26 @@ document.addEventListener("DOMContentLoaded", function () {
       setTimeout(showRecipeJson, 50);
     });
   }
+};
+
+const setupPreviewUrlCopyToast = () => {
+  var previewUrl = document.getElementById("preview-url");
+  var copiedToast = document.getElementById("preview-toast");
+  if (previewUrl && copiedToast) {
+    previewUrl.addEventListener("click", function () {
+      navigator.clipboard.writeText(previewUrl.textContent);
+      var toast = bootstrap.Toast.getOrCreateInstance(copiedToast);
+      toast.show();
+    });
+  }
+};
+
+document.addEventListener("DOMContentLoaded", function () {
+  setupCollapseRecipe();
+  setupPreviewUrlCopyToast();
+
+  document.body.addEventListener("htmx:afterSwap", function () {
+    setupCollapseRecipe();
+    setupPreviewUrlCopyToast();
+  });
 });

--- a/experimenter/experimenter/nimbus_ui/static/js/index.js
+++ b/experimenter/experimenter/nimbus_ui/static/js/index.js
@@ -53,22 +53,36 @@ const setupTooltips = () => {
 };
 
 const setupToasts = () => {
-  const toastElList = document.querySelectorAll(".toast");
+  const toastElList = document.querySelectorAll(".toast:not(.hide)");
   [...toastElList].map((toastEl) => {
     const toast = new bootstrap.Toast(toastEl);
     toast.show();
   });
 };
 
+const setupSlugCopyToast = () => {
+  var slug = document.getElementById("experiment-slug");
+  var copiedToast = document.getElementById("slug-toast");
+  if (slug && copiedToast) {
+    slug.addEventListener("click", function () {
+      navigator.clipboard.writeText(slug.textContent);
+      var toast = bootstrap.Toast.getOrCreateInstance(copiedToast);
+      toast.show();
+    });
+  }
+};
+
 $(() => {
   setupThemeSwitcher();
   setupTooltips();
   setupToasts();
+  setupSlugCopyToast();
 
   document.body.addEventListener("htmx:afterSwap", function () {
     $(".selectpicker").selectpicker();
     setupTooltips();
     setupToasts();
+    setupSlugCopyToast();
   });
 
   // To support HTMX onchange updates on selectpicker, we need to

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/experiment_base.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/experiment_base.html
@@ -21,12 +21,9 @@
         <span class="badge rounded-pill bg-danger" id="unpublished-rollout-badge">Unpublished changes</span>
       {% endif %}
       <div class="d-flex align-items-center mb-2">
-        <p class="text-secondary mb-0 me-1" id="experiment-slug">{{ experiment.slug }}</p>
-        <button type="button"
-                class="btn btn-sm"
-                onclick=" navigator.clipboard.writeText(document.getElementById('experiment-slug').textContent); alert('Copied to clipboard!'); "
-                aria-label="Copy slug">
-          <i class="fa-solid fa-copy text-secondary"></i>
+        <button type="button" class="btn text-secondary ps-0" aria-label="Copy slug">
+          <span id="experiment-slug">{{ experiment.slug }}</span>
+          <i class="fa-solid fa-copy"></i>
         </button>
       </div>
       {% if experiment.parent %}
@@ -43,6 +40,16 @@
     <div class="col-md-12 col-xl-7" id="experiment-timeline">
       {% include "nimbus_experiments/timeline.html" %}
 
+    </div>
+  </div>
+  <div id="slug-toast"
+       class="toast hide text-bg-primary position-fixed top-0 end-0 m-3 w-auto"
+       role="alert"
+       aria-live="assertive"
+       aria-atomic="true">
+    <div class="toast-body">
+      <i class="fa-regular fa-circle-check"></i>
+      Slug copied to clipboard!
     </div>
   </div>
 {% endblock %}

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/launch_controls.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/launch_controls.html
@@ -165,9 +165,11 @@
                     {% if branch == experiment.reference_branch %}selected{% endif %}>{{ branch.name }}</option>
           {% endfor %}
         </select>
-        <code id="preview-url" class="d-block text-danger user-select-all">
-          about:studies?optin_slug={{ experiment.slug }}&optin_branch={{ experiment.reference_branch.slug }}&optin_collection=nimbus-preview
-        </code>
+        <button class="btn btn-sm" type="button">
+          <code id="preview-url" class="d-block text-danger user-select-all">
+            about:studies?optin_slug={{ experiment.slug }}&optin_branch={{ experiment.reference_branch.slug }}&optin_collection=nimbus-preview
+          </code>
+        </button>
       </div>
       <!-- Review Mode Controls -->
     {% elif experiment|should_show_remote_settings_pending:user %}
@@ -245,4 +247,14 @@
       {% endif %}
     {% endif %}
   </form>
+</div>
+<div id="preview-toast"
+     class="toast hide text-bg-primary position-fixed top-0 end-0 m-3 w-auto"
+     role="alert"
+     aria-live="assertive"
+     aria-atomic="true">
+  <div class="toast-body">
+    <i class="fa-regular fa-circle-check"></i>
+    Preview URL copied to clipboard!
+  </div>
 </div>


### PR DESCRIPTION
Becuase

* In the old ui, clicking on the preview url would copy it to the clipboard
* The slug is clickable to copy but it shows a very intrusive alert to show success

This commit

* Makes both the preview url and the slug clickable to copy
* Shows a more gentle toast when copy is successful

fixes #12976

https://github.com/user-attachments/assets/d772629b-d092-4f87-8a6c-d034b67bd436


