### PR TITLE
feat(UI): Add Tooltip to draft/preview card on the new homepage.

### DIFF
--- a/experimenter/experimenter/nimbus_ui/constants.py
+++ b/experimenter/experimenter/nimbus_ui/constants.py
@@ -75,6 +75,11 @@ Optional - We believe this outcome will <describe impact> on <core metric>
     HOME_PAGE_LINKS = {
         "welcome_learn_more_url": "https://experimenter.info/workflow/overview/"
     }
+    HOME_PAGE_TOOLTIPS = {
+        "draft_or_preview": """This is anything that you own or are subscribed
+        to follow - which are in Draft or Preview states. Go to the link to check the
+        message for the next actions needed."""
+    }
 
     class ReviewRequestMessages(Enum):
         END_EXPERIMENT = "end this experiment"

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/home_experiments_layout.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/home_experiments_layout.html
@@ -3,7 +3,13 @@
 <div class="card shadow-sm border-0 px-3 pt-3 h-100 rounded-3 bg-primary-subtle"
      style="min-height: 400px">
   <div class="d-flex justify-content-between align-items-center mb-3">
-    <h5 class="fw-semibold mb-0">{{ title }}</h5>
+    <h5 class="fw-semibold mb-0">
+      {{ title }}
+      <i class="fa-regular fa-circle-question"
+         data-bs-toggle="tooltip"
+         data-bs-placement="top"
+         data-bs-title="{{ tooltips.draft_or_preview }}"></i>
+    </h5>
     <span class="badge rounded-pill bg-primary fs-6 px-3 py-1">{{ page_obj.paginator.count }}</span>
   </div>
   {% if experiments %}

--- a/experimenter/experimenter/nimbus_ui/views.py
+++ b/experimenter/experimenter/nimbus_ui/views.py
@@ -647,4 +647,5 @@ class NimbusExperimentsHomeView(FilterView):
             draft_or_preview_experiments, 4
         ).get_page(draft_page)
         context["links"] = NimbusUIConstants.HOME_PAGE_LINKS
+        context["tooltips"] = NimbusUIConstants.HOME_PAGE_TOOLTIPS
         return context


### PR DESCRIPTION
Because

- We need a tooltip in the draft/preview card on the new homepage.

This commit

- Adds a simple tooltip with the text: `This is anything that you own or are subscribed to follow – which are in Draft or Preview states. Go to the link to check the message for the next actions needed.`

<img width="1718" height="765" alt="image" src="https://github.com/user-attachments/assets/5efe43d4-6e52-40c0-851c-445558af5b92" />


Fixes #13174 