### PR TITLE
bug(nimbus): only highlight one timeline state at a time

### DIFF
--- a/experimenter/experimenter/experiments/models.py
+++ b/experimenter/experimenter/experiments/models.py
@@ -715,7 +715,7 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
 
     @property
     def is_observation(self):
-        return self._enrollment_end_date is not None and not self.is_complete
+        return self.status == self.Status.LIVE and self.is_paused_published
 
     @property
     def is_started(self):


### PR DESCRIPTION
Becuase

* An experiment can only be in one state at a time
* The timeline should clearly reflect this
* We hit a bug where both enrolling and observing were highlighted simultaneously

This commit

* Changes the definition of is_observation to only be true when an experiment is live and paused

fixes #13136

