### PR TITLE
feat(nimbus): Add advanced targeting for tou users with no sponsored content or Adjust opt outs

### DIFF
--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -2394,15 +2394,23 @@ TOU_TARGETING_ANDROID_ACCEPTED = NimbusTargetingConfig(
     application_choice_names=(Application.FENIX.name,),
 )
 
-TOU_TARGETING_ANDROID_NOT_ACCEPTED_AND_NO_SHORTCUTS_STORIES_OR_MKT = NimbusTargetingConfig(
-    name="Users that have not accepted the Terms of Use and have not opted out of any sponsored content or Adjust",
-    slug="users_not_accepted_tou_no_shortcuts_stories_mkt",
-    description="Targeting users who have NOT accepted the Terms of Use and have NOT opted out of any sponsored content or Adjust",
-    targeting="user_accepted_tou == false && no_shortcuts_stories_mkt == true",
-    desktop_telemetry="",
-    sticky_required=False,
-    is_first_run_required=False,
-    application_choice_names=(Application.FENIX.name,),
+TOU_TARGETING_ANDROID_NOT_ACCEPTED_AND_NO_SHORTCUTS_STORIES_OR_MKT = (
+    NimbusTargetingConfig(
+        name=(
+            "Users that have not accepted the Terms of Use "
+            "and have not opted out of any sponsored content or Adjust"
+        ),
+        slug="users_not_accepted_tou_no_shortcuts_stories_mkt",
+        description=(
+            "Targeting users who have NOT accepted the Terms of Use "
+            "and have NOT opted out of any sponsored content or Adjust"
+        ),
+        targeting="user_accepted_tou == false && no_shortcuts_stories_mkt == true",
+        desktop_telemetry="",
+        sticky_required=False,
+        is_first_run_required=False,
+        application_choice_names=(Application.FENIX.name,),
+    )
 )
 
 CHATBOT_IS_HUGGINGCHAT = NimbusTargetingConfig(

--- a/experimenter/tests/integration/nimbus/test_mobile_targeting.py
+++ b/experimenter/tests/integration/nimbus/test_mobile_targeting.py
@@ -107,6 +107,7 @@ def test_check_mobile_targeting(
             "number_of_app_launches": 1,
             "is_large_device": True,
             "user_accepted_tou": True,
+            "no_shortcuts_stories_mkt": True,
         }
     )
     client = sdk_client(load_app_context(context))


### PR DESCRIPTION
Because

- We want to be able to target users that have not accepted or the Terms of Use (ToU) and have NOT opted out from any sponsored content or Adjust. See associated https://bugzilla.mozilla.org/show_bug.cgi?id=1970165 for more details.

This commit

- Adds the advanced targeting for users who have not yet accepted the ToU and have NOT opted out of any sponsored content or Adjust.

Fixes https://bugzilla.mozilla.org/show_bug.cgi?id=1970165
Fixes https://mozilla-hub.atlassian.net/browse/FXDROID-4670
