### PR TITLE
bug(nimbus): copy icon should copy slug

### DIFF
--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/experiment_base.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/experiment_base.html
@@ -21,8 +21,11 @@
         <span class="badge rounded-pill bg-danger" id="unpublished-rollout-badge">Unpublished changes</span>
       {% endif %}
       <div class="d-flex align-items-center mb-2">
-        <button type="button" class="btn text-secondary ps-0" aria-label="Copy slug">
-          <span id="experiment-slug">{{ experiment.slug }}</span>
+        <button id="experiment-slug"
+                type="button"
+                class="btn text-secondary ps-0"
+                aria-label="Copy slug">
+          <span>{{ experiment.slug }}</span>
           <i class="fa-solid fa-copy"></i>
         </button>
       </div>


### PR DESCRIPTION
Becuase

* We made the entire slug on the detail page clickable to copy the slug
* We missed the copy icon also triggering the copy

This commit

* Moves the element id to the button so both the slug and copy icon trigger the copy

fixes #13182

