### PR TITLE
bug(nimbus): only show missing details for draft

### DIFF
--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/sidebar.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/sidebar.html
@@ -8,7 +8,7 @@
 
     {% endif %}
   {% endfor %}
-  {% if invalid_pages %}
+  {% if experiment.is_draft and invalid_pages %}
     <div class="alert alert-primary" role="alert">
       <p class="mb-1">
         Missing details in


### PR DESCRIPTION
Becuase

* We added the missing details links in the sidebar for experiments with validation errors
* We didn't gate it on status so it's showing for live experiments even though it's no longer actionable

This commit

* Only shows missing details links for draft experiments

fixes #13184
