### PR TITLE
feat(nimbus): Align welcome message to center

### DIFF
--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/home.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/home.html
@@ -6,24 +6,21 @@
   <div id="home-page" class="bg-body-tertiary py-4">
     <div class="container">
       <div class="card shadow-sm border-0 p-4 mb-4">
-        <div class="row align-items-center">
-          <div class="col-auto">
+        <div class="d-flex flex-column align-items-center text-center">
+          <div class="d-flex align-items-start justify-content-center">
             <img src="{% static 'assets/welcome.svg' %}"
                  alt="Hugging Foxes"
                  style="width: 80px;
                         height: auto" />
-          </div>
-          <div id="welcome-banner" class="col">
-            <h4 id="welcome-message" class="fw-semibold mb-1">Welcome to Nimbus, {{ request.user }}!</h4>
-            <p class="text-muted mb-2 fs-6">
-              Learn what is possible for experiments, roll-outs, surveys,
-              and more!
-            </p>
-            <a id="welcome-learn-more-link"
-               href="{{ links.welcome_learn_more_url }}"
-               class="btn btn-primary btn-sm"
-               target="_blank"
-               rel="noopener noreferrer">Learn More</a>
+            <div id="welcome-banner">
+              <h4 id="welcome-message" class="fw-semibold mb-1">Welcome to Nimbus, {{ request.user }}!</h4>
+              <p class="text-muted mb-2 fs-6">Learn what is possible for experiments, roll-outs, surveys, and more!</p>
+              <a id="welcome-learn-more-link"
+                 href="{{ links.welcome_learn_more_url }}"
+                 class="btn btn-primary btn-sm"
+                 target="_blank"
+                 rel="noopener noreferrer">Learn More</a>
+            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
Because

- Currently, the welcome message of the home page is aligned left and creates lot of white space in the right side

This commit

- Align welcome message to the center for better symmetry

Fixes #13200 

<img width="1302" height="249" alt="Screenshot 2025-08-05 at 9 35 45 AM" src="https://github.com/user-attachments/assets/ab1721ff-3809-464b-b7a4-f505e880f53d" />
<img width="1302" height="249" alt="Screenshot 2025-08-05 at 9 35 32 AM" src="https://github.com/user-attachments/assets/08693312-f3e1-40fe-bd4f-b6126d6dc899" />
