### PR TITLE
feat(UI): Add tooltip for 'Ready for Attention' card.

### DIFF
--- a/experimenter/experimenter/nimbus_ui/constants.py
+++ b/experimenter/experimenter/nimbus_ui/constants.py
@@ -77,8 +77,14 @@ Optional - We believe this outcome will <describe impact> on <core metric>
     }
     HOME_PAGE_TOOLTIPS = {
         "draft_or_preview": """This is anything that you own or are subscribed
-        to follow - which are in Draft or Preview states. Go to the link to check the
-        message for the next actions needed."""
+            to follow - which are in Draft or Preview states. Go to the link to
+            check the message for the next actions needed.
+        """,
+        "ready_for_attention": """This is anything that you own or are subscribed to
+            follow when they are in a Review state; have a change due for ending
+            enrollment or ending entirely; or have ended and have no information in
+            the take-aways section.
+        """,
     }
 
     class ReviewRequestMessages(Enum):

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/home.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/home.html
@@ -28,12 +28,12 @@
       <div class="row g-4 align-items-start">
         <!-- Draft or Preview -->
         <div id="draft-preview" class="col-md-6">
-          {% include "nimbus_experiments/home_experiments_layout.html" with title="Draft or Preview" experiments=draft_or_preview_page.object_list page_obj=draft_or_preview_page pagination_param="draft_page" empty_message="No draft or preview experiments." empty_image_path="assets/empty-draft.svg" %}
+          {% include "nimbus_experiments/home_experiments_layout.html" with title="Draft or Preview" experiments=draft_or_preview_page.object_list page_obj=draft_or_preview_page pagination_param="draft_page" empty_message="No draft or preview experiments." empty_image_path="assets/empty-draft.svg" tooltip=tooltips.draft_or_preview %}
 
         </div>
         <!-- Ready for Attention -->
         <div id="ready-for-attention" class="col-md-6">
-          {% include "nimbus_experiments/home_experiments_layout.html" with title="Ready for Attention" experiments=ready_for_attention_page.object_list page_obj=ready_for_attention_page pagination_param="attention_page" empty_message="No ready for attention experiments." empty_image_path="assets/empty-attention.svg" %}
+          {% include "nimbus_experiments/home_experiments_layout.html" with title="Ready for Attention" experiments=ready_for_attention_page.object_list page_obj=ready_for_attention_page pagination_param="attention_page" empty_message="No ready for attention experiments." empty_image_path="assets/empty-attention.svg" tooltip=tooltips.ready_for_attention %}
 
         </div>
       </div>

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/home_experiments_layout.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/home_experiments_layout.html
@@ -8,7 +8,7 @@
       <i class="fa-regular fa-circle-question"
          data-bs-toggle="tooltip"
          data-bs-placement="top"
-         data-bs-title="{{ tooltips.draft_or_preview }}"></i>
+         data-bs-title="{{ tooltip }}"></i>
     </h5>
     <span class="badge rounded-pill bg-primary fs-6 px-3 py-1">{{ page_obj.paginator.count }}</span>
   </div>


### PR DESCRIPTION
Because

- We need to add a tooltip on the "Ready for Attention" card on the new UI.

This commit

- Adds the tooltip

Fixes #13210 