### PR TITLE
feat(UI): Add tooltip for My Stuff section.

### DIFF
--- a/experimenter/experimenter/nimbus_ui/constants.py
+++ b/experimenter/experimenter/nimbus_ui/constants.py
@@ -85,9 +85,10 @@ Optional - We believe this outcome will <describe impact> on <core metric>
             enrollment or ending entirely; or have ended and have no information in
             the take-aways section.
         """,
-        "my_stuff": """
-            Shows all experiments that you are the owner of, subscribed to, or where
-            you are a collaborator. Learn how to get started.
+        "my_deliveries": """
+            Shows all deliveries (experiments, rollouts, etc) that you are the owner of,
+            subscribed to or where you are a collaborator.
+            <a href="https://experimenter.info/for-product">Learn</a> how to get started.
         """,
     }
 

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/home.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/home.html
@@ -50,9 +50,11 @@
                         height: auto" />
             My Deliveries
             <i class="fa-regular fa-circle-question"
-               data-bs-toggle="tooltip"
-               data-bs-placement="top"
-               data-bs-title="{{ tooltips.my_stuff }}">
+              data-bs-toggle="tooltip"
+              data-bs-placement="top"
+              data-bs-html="true"
+              data-bs-title="{{ tooltips.my_deliveries }}"
+              data-bs-delay={"hide":5000}>
             </i>
           </h5>
         </div>


### PR DESCRIPTION
Because

- We want to add a tooltip to the My Stuff section on the new homepage

This commit

- Adds the tooltip

Fixes #13223 

<img width="1328" height="949" alt="image" src="https://github.com/user-attachments/assets/961f4fe0-fc4f-49f7-82d0-f5cc80c4dd89" />
