### PR TITLE
feat(nimbus): add channels to jexl targeting

### DIFF
--- a/experimenter/experimenter/experiments/models.py
+++ b/experimenter/experimenter/experiments/models.py
@@ -572,8 +572,12 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
         if self.targeting_config and self.targeting_config.targeting:
             sticky_expressions.append(self.targeting_config.targeting)
 
-        if self.is_desktop and self.channel:
-            expressions.append(f'browserSettings.update.channel == "{self.channel}"')
+        if self.is_desktop:
+            if self.channels:
+                channels = json.dumps(sorted(self.channels))
+                expressions.append(f"browserSettings.update.channel in {channels}")
+            elif self.channel:  # TODO remove in #13224
+                expressions.append(f'browserSettings.update.channel == "{self.channel}"')
 
         sticky_expressions.extend(self._get_targeting_min_version())
         expressions.extend(self._get_targeting_max_version())

--- a/experimenter/experimenter/experiments/tests/api/v6/test_serializers.py
+++ b/experimenter/experimenter/experiments/tests/api/v6/test_serializers.py
@@ -48,6 +48,7 @@ class TestNimbusExperimentSerializer(TestCase):
             firefox_min_version=NimbusExperiment.MIN_REQUIRED_VERSION,
             feature_configs=[feature1, feature2],
             channel=NimbusExperiment.Channel.NIGHTLY,
+            channels=[],
             primary_outcomes=["foo", "bar", "baz"],
             secondary_outcomes=["quux", "xyzzy"],
             locales=[locale_en_us],
@@ -60,9 +61,9 @@ class TestNimbusExperimentSerializer(TestCase):
         branches_data = [dict(b) for b in experiment_data.pop("branches")]
         feature_ids_data = experiment_data.pop("featureIds")
 
-        assert experiment.start_date
-        assert experiment.actual_enrollment_end_date
-        assert experiment.end_date
+        self.assertIsNotNone(experiment.start_date)
+        self.assertIsNotNone(experiment.actual_enrollment_end_date)
+        self.assertIsNotNone(experiment.end_date)
 
         min_required_version = NimbusExperiment.MIN_REQUIRED_VERSION
         expected_experiment_data = self._experiment_data_without_branches_and_featureIds(
@@ -122,6 +123,7 @@ class TestNimbusExperimentSerializer(TestCase):
             firefox_min_version=NimbusExperiment.MIN_REQUIRED_VERSION,
             feature_configs=[feature1, feature2],
             channel=NimbusExperiment.Channel.NIGHTLY,
+            channels=[],
             primary_outcomes=["foo", "bar", "baz"],
             secondary_outcomes=["quux", "xyzzy"],
             segments=["segment1", "segment2"],
@@ -181,7 +183,7 @@ class TestNimbusExperimentSerializer(TestCase):
         serializer = NimbusExperimentSerializer(experiment)
         experiment_data = serializer.data.copy()
 
-        assert experiment.start_date
+        self.assertIsNotNone(experiment.start_date)
         self.assertIsNone(experiment.actual_enrollment_end_date)
         self.assertIsNone(experiment.end_date)
 

--- a/experimenter/experimenter/experiments/tests/api/v7/test_serializers.py
+++ b/experimenter/experimenter/experiments/tests/api/v7/test_serializers.py
@@ -36,6 +36,7 @@ class TestNimbusExperimentSerializer(TestCase):
             firefox_min_version=NimbusExperiment.MIN_REQUIRED_VERSION,
             feature_configs=[feature1, feature2],
             channel=NimbusExperiment.Channel.NIGHTLY,
+            channels=[],
             primary_outcomes=["foo", "bar", "baz"],
             secondary_outcomes=["quux", "xyzzy"],
             locales=[locale_en_us],
@@ -52,9 +53,9 @@ class TestNimbusExperimentSerializer(TestCase):
         branches_data = [dict(b) for b in experiment_data.pop("branches")]
         feature_ids_data = experiment_data.pop("featureIds")
 
-        assert experiment.start_date
-        assert experiment.actual_enrollment_end_date
-        assert experiment.end_date
+        self.assertIsNotNone(experiment.start_date)
+        self.assertIsNotNone(experiment.actual_enrollment_end_date)
+        self.assertIsNotNone(experiment.end_date)
 
         min_required_version = NimbusExperiment.MIN_REQUIRED_VERSION
 

--- a/experimenter/experimenter/experiments/tests/api/v8/test_serializers.py
+++ b/experimenter/experimenter/experiments/tests/api/v8/test_serializers.py
@@ -31,6 +31,7 @@ class TestNimbusExperimentSerializer(TestCase):
             firefox_min_version=NimbusExperiment.MIN_REQUIRED_VERSION,
             feature_configs=[feature1, feature2],
             channel=NimbusExperiment.Channel.NIGHTLY,
+            channels=[],
             primary_outcomes=["foo", "bar", "baz"],
             secondary_outcomes=["quux", "xyzzy"],
             segments=["segment1", "segment2"],
@@ -46,9 +47,9 @@ class TestNimbusExperimentSerializer(TestCase):
         branches_data = [dict(b) for b in experiment_data.pop("branches")]
         feature_ids_data = experiment_data.pop("featureIds")
 
-        assert experiment.start_date
-        assert experiment.actual_enrollment_end_date
-        assert experiment.end_date
+        self.assertIsNotNone(experiment.start_date)
+        self.assertIsNotNone(experiment.actual_enrollment_end_date)
+        self.assertIsNotNone(experiment.end_date)
 
         min_required_version = NimbusExperiment.MIN_REQUIRED_VERSION
         expected_experiment_data = self._experiment_data_without_branches_and_featureIds(
@@ -106,6 +107,7 @@ class TestNimbusExperimentSerializer(TestCase):
             firefox_min_version=NimbusExperiment.MIN_REQUIRED_VERSION,
             feature_configs=[feature1, feature2],
             channel=NimbusExperiment.Channel.NIGHTLY,
+            channels=[],
             primary_outcomes=["foo", "bar", "baz"],
             secondary_outcomes=["quux", "xyzzy"],
             segments=["segment1", "segment2"],
@@ -160,7 +162,7 @@ class TestNimbusExperimentSerializer(TestCase):
         serializer = NimbusExperimentSerializer(experiment)
         experiment_data = serializer.data.copy()
 
-        assert experiment.start_date
+        self.assertIsNotNone(experiment.start_date)
         self.assertIsNone(experiment.actual_enrollment_end_date)
         self.assertIsNone(experiment.end_date)
 

--- a/experimenter/experimenter/experiments/tests/test_models.py
+++ b/experimenter/experimenter/experiments/tests/test_models.py
@@ -484,6 +484,7 @@ class TestNimbusExperiment(TestCase):
             targeting_config_slug=NimbusExperiment.TargetingConfig.MAC_ONLY,
             application=NimbusExperiment.Application.DESKTOP,
             channel=NimbusExperiment.Channel.NO_CHANNEL,
+            channels=[],
             locales=[],
             countries=[],
             languages=[],
@@ -507,6 +508,7 @@ class TestNimbusExperiment(TestCase):
             firefox_max_version=NimbusExperiment.Version.NO_VERSION,
             application=NimbusExperiment.Application.FENIX,
             channel=NimbusExperiment.Channel.NO_CHANNEL,
+            channels=[],
             locales=[],
             countries=[],
             languages=[],
@@ -536,6 +538,7 @@ class TestNimbusExperiment(TestCase):
             firefox_min_version=version,
             firefox_max_version=version,
             channel=NimbusExperiment.Channel.NO_CHANNEL,
+            channels=[],
             locales=[],
             countries=[],
             languages=[],
@@ -566,6 +569,7 @@ class TestNimbusExperiment(TestCase):
             firefox_min_version=version,
             firefox_max_version=NimbusExperiment.Version.NO_VERSION,
             channel=NimbusExperiment.Channel.NO_CHANNEL,
+            channels=[],
             locales=[],
             countries=[],
             languages=[],
@@ -583,6 +587,7 @@ class TestNimbusExperiment(TestCase):
             firefox_min_version=NimbusExperiment.Version.FIREFOX_100,
             firefox_max_version=NimbusExperiment.Version.NO_VERSION,
             channel=NimbusExperiment.Channel.NO_CHANNEL,
+            channels=[],
             locales=[],
             countries=[],
             languages=[],
@@ -600,6 +605,7 @@ class TestNimbusExperiment(TestCase):
             firefox_min_version=NimbusExperiment.Version.NO_VERSION,
             firefox_max_version=NimbusExperiment.Version.FIREFOX_100,
             channel=NimbusExperiment.Channel.NO_CHANNEL,
+            channels=[],
             locales=[],
             countries=[],
             languages=[],
@@ -633,6 +639,7 @@ class TestNimbusExperiment(TestCase):
             firefox_min_version=NimbusExperiment.Version.NO_VERSION,
             firefox_max_version=version,
             channel=NimbusExperiment.Channel.NO_CHANNEL,
+            channels=[],
             locales=[],
             countries=[],
             languages=[],
@@ -667,6 +674,7 @@ class TestNimbusExperiment(TestCase):
             firefox_min_version=version,
             firefox_max_version=version,
             channel=NimbusExperiment.Channel.NO_CHANNEL,
+            channels=[],
             locales=[],
             countries=[],
             languages=[],
@@ -681,6 +689,53 @@ class TestNimbusExperiment(TestCase):
         )
         JEXLParser().parse(experiment.targeting)
 
+    def test_targeting_desktop_single_channel(
+        self,
+    ):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE_APPROVE,
+            firefox_min_version=NimbusExperiment.Version.NO_VERSION,
+            firefox_max_version=NimbusExperiment.Version.NO_VERSION,
+            targeting_config_slug="",
+            application=NimbusExperiment.Application.DESKTOP,
+            channel=NimbusExperiment.Channel.NIGHTLY,
+            channels=[],
+            locales=[],
+            countries=[],
+            languages=[],
+        )
+
+        self.assertEqual(
+            experiment.targeting,
+            ('(browserSettings.update.channel == "nightly")'),
+        )
+        JEXLParser().parse(experiment.targeting)
+
+    def test_targeting_desktop_multiple_channels(
+        self,
+    ):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE_APPROVE,
+            firefox_min_version=NimbusExperiment.Version.NO_VERSION,
+            firefox_max_version=NimbusExperiment.Version.NO_VERSION,
+            targeting_config_slug="",
+            application=NimbusExperiment.Application.DESKTOP,
+            channel=NimbusExperiment.Channel.NO_CHANNEL,
+            channels=[
+                NimbusExperiment.Channel.NIGHTLY,
+                NimbusExperiment.Channel.BETA,
+            ],
+            locales=[],
+            countries=[],
+            languages=[],
+        )
+
+        self.assertEqual(
+            experiment.targeting,
+            ('(browserSettings.update.channel in ["beta", "nightly"])'),
+        )
+        JEXLParser().parse(experiment.targeting)
+
     def test_targeting_without_firefox_min_version(
         self,
     ):
@@ -691,6 +746,7 @@ class TestNimbusExperiment(TestCase):
             targeting_config_slug=NimbusExperiment.TargetingConfig.MAC_ONLY,
             application=NimbusExperiment.Application.DESKTOP,
             channel=NimbusExperiment.Channel.NIGHTLY,
+            channels=[],
             locales=[],
             countries=[],
             languages=[],
@@ -716,6 +772,7 @@ class TestNimbusExperiment(TestCase):
             targeting_config_slug=NimbusExperiment.TargetingConfig.MAC_ONLY,
             application=NimbusExperiment.Application.DESKTOP,
             channel=NimbusExperiment.Channel.NIGHTLY,
+            channels=[],
             locales=[],
             countries=[],
             languages=[],
@@ -739,6 +796,7 @@ class TestNimbusExperiment(TestCase):
             targeting_config_slug=NimbusExperiment.TargetingConfig.MAC_ONLY,
             application=NimbusExperiment.Application.DESKTOP,
             channel=NimbusExperiment.Channel.NO_CHANNEL,
+            channels=[],
             locales=[],
             countries=[],
             languages=[],
@@ -759,6 +817,7 @@ class TestNimbusExperiment(TestCase):
             firefox_max_version=NimbusExperiment.Version.NO_VERSION,
             targeting_config_slug=NimbusExperiment.TargetingConfig.MAC_ONLY,
             channel=NimbusExperiment.Channel.NO_CHANNEL,
+            channels=[],
             locales=[locale_ca, locale_us],
             countries=[],
             languages=[],
@@ -779,6 +838,7 @@ class TestNimbusExperiment(TestCase):
             firefox_max_version=NimbusExperiment.Version.NO_VERSION,
             targeting_config_slug=NimbusExperiment.TargetingConfig.MAC_ONLY,
             channel=NimbusExperiment.Channel.NO_CHANNEL,
+            channels=[],
             locales=[],
             countries=[country_ca, country_us],
             languages=[],
@@ -801,6 +861,7 @@ class TestNimbusExperiment(TestCase):
             firefox_max_version=NimbusExperiment.Version.NO_VERSION,
             targeting_config_slug=NimbusExperiment.TargetingConfig.MAC_ONLY,
             channel=NimbusExperiment.Channel.NO_CHANNEL,
+            channels=[],
             locales=[locale_ca, locale_us],
             countries=[country_ca, country_us],
             languages=[],
@@ -822,6 +883,7 @@ class TestNimbusExperiment(TestCase):
             firefox_max_version=NimbusExperiment.Version.NO_VERSION,
             targeting_config_slug=NimbusExperiment.TargetingConfig.MOBILE_NEW_USERS,
             channel=NimbusExperiment.Channel.NO_CHANNEL,
+            channels=[],
             languages=[language_en, language_es, language_fr],
         )
         self.assertEqual(
@@ -860,6 +922,7 @@ class TestNimbusExperiment(TestCase):
             firefox_max_version=NimbusExperiment.Version.FIREFOX_101,
             targeting_config_slug=NimbusExperiment.TargetingConfig.NO_ENTERPRISE_USERS,
             channel=NimbusExperiment.Channel.RELEASE,
+            channels=[],
             languages=[],
             locales=[locale_en],
             countries=[country_ca],
@@ -900,6 +963,7 @@ class TestNimbusExperiment(TestCase):
             firefox_max_version=NimbusExperiment.Version.FIREFOX_101,
             targeting_config_slug=NimbusExperiment.TargetingConfig.NO_ENTERPRISE_USERS,
             channel=NimbusExperiment.Channel.RELEASE,
+            channels=[],
             languages=[],
             locales=[locale_en],
             countries=[country_ca],
@@ -940,6 +1004,7 @@ class TestNimbusExperiment(TestCase):
             firefox_max_version=NimbusExperiment.Version.FIREFOX_101,
             targeting_config_slug=NimbusExperiment.TargetingConfig.MOBILE_NEW_USERS,
             channel=NimbusExperiment.Channel.RELEASE,
+            channels=[],
             languages=[language_en],
             locales=[],
             countries=[country_ca],
@@ -973,6 +1038,7 @@ class TestNimbusExperiment(TestCase):
             firefox_min_version=NimbusExperiment.Version.NO_VERSION,
             firefox_max_version=NimbusExperiment.Version.NO_VERSION,
             channel=NimbusExperiment.Channel.RELEASE,
+            channels=[],
             languages=[],
             locales=[],
             countries=[],
@@ -996,6 +1062,7 @@ class TestNimbusExperiment(TestCase):
             firefox_min_version=NimbusExperiment.Version.NO_VERSION,
             firefox_max_version=NimbusExperiment.Version.NO_VERSION,
             channel=NimbusExperiment.Channel.RELEASE,
+            channels=[],
             languages=[],
             locales=[],
             countries=[],
@@ -1031,6 +1098,7 @@ class TestNimbusExperiment(TestCase):
             firefox_min_version=NimbusExperiment.Version.NO_VERSION,
             firefox_max_version=NimbusExperiment.Version.NO_VERSION,
             channel=NimbusExperiment.Channel.RELEASE,
+            channels=[],
             languages=[],
             locales=[],
             countries=[],
@@ -1129,6 +1197,7 @@ class TestNimbusExperiment(TestCase):
             slug="slug",
             firefox_min_version=NimbusExperiment.Version.NO_VERSION,
             channel=NimbusExperiment.Channel.NO_CHANNEL,
+            channels=[],
         )
         for required_slug, required_branch_slug in require:
             NimbusExperimentBranchThroughRequired.objects.create(

--- a/experimenter/experimenter/nimbus_ui/tests/test_forms.py
+++ b/experimenter/experimenter/nimbus_ui/tests/test_forms.py
@@ -711,6 +711,7 @@ class TestLaunchForms(RequestFormTestCase):
         self.experiment.publish_status = NimbusExperiment.PublishStatus.IDLE
         self.experiment.firefox_min_version = NimbusExperiment.Version.FIREFOX_116
         self.experiment.channel = NimbusExperiment.Channel.NIGHTLY
+        self.experiment.channels = []
 
         # Publishing to the preview collection would set the published_dto field
         # to the value in Remote Settings. However, since we're not actually


### PR DESCRIPTION
Becuase
    
* We added a new field called channels for desktop to target multiple channels
    
This commit
    
* Adds a channels clause to the jexl targeting for desktop
* Preserves the existing single channel case while we migrate the forms over to use the new field
    
fixes #13222