### PR TITLE
    feat(nimbus): use channels in nimbus ui

### DIFF
--- a/experimenter/experimenter/experiments/models.py
+++ b/experimenter/experimenter/experiments/models.py
@@ -1822,6 +1822,13 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
         return transformed_changelogs
 
     @property
+    def get_channel_display(self):
+        if self.is_desktop and self.channels:
+            return ", ".join(self.Channel(c).label for c in sorted(self.channels))
+        elif self.channel:
+            return self.Channel(self.channel).label
+
+    @property
     def get_firefox_min_version_display(self):
         return self.firefox_min_version.replace("!", "0")
 

--- a/experimenter/experimenter/experiments/tests/test_models.py
+++ b/experimenter/experimenter/experiments/tests/test_models.py
@@ -4143,6 +4143,36 @@ class TestNimbusExperiment(TestCase):
         matching_experiments = experiment.live_experiments_in_namespace
         self.assertEqual(len(matching_experiments), 0)
 
+    @parameterized.expand(
+        [
+            (
+                NimbusExperiment.Application.DESKTOP,
+                NimbusExperiment.Channel.RELEASE,
+                [],
+                "Release",
+            ),
+            (
+                NimbusExperiment.Application.DESKTOP,
+                NimbusExperiment.Channel.NO_CHANNEL,
+                [NimbusExperiment.Channel.NIGHTLY, NimbusExperiment.Channel.BETA],
+                "Beta, Nightly",
+            ),
+            (
+                NimbusExperiment.Application.FENIX,
+                NimbusExperiment.Channel.NIGHTLY,
+                [],
+                "Nightly",
+            ),
+        ]
+    )
+    def test_get_channel_display(self, application, channel, channels, expected):
+        experiment = NimbusExperimentFactory.create(
+            application=application,
+            channel=channel,
+            channels=channels,
+        )
+        self.assertEqual(experiment.get_channel_display, expected)
+
     def test_get_firefox_min_version_display(self):
         experiment = NimbusExperimentFactory.create(
             firefox_min_version=NimbusExperiment.Version.FIREFOX_100

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/detail.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/detail.html
@@ -233,7 +233,7 @@
           <tbody>
             <tr>
               <th>Channel</th>
-              <td>{{ experiment.channel.title|default:"No Channel" }}</td>
+              <td>{{ experiment.get_channel_display|default:"No Channel" }}</td>
               <th>Advanced Targeting</th>
               <td>{{ experiment.targeting_config.name }}</td>
             </tr>

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/home_experiments_layout.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/home_experiments_layout.html
@@ -25,7 +25,9 @@
           <div class="text-muted small">
             {{ experiment.status|capfirst }}
             {% if experiment.application %}• {{ experiment.application }}{% endif %}
-            {% if experiment.channel %}• {{ experiment.channel }}{% endif %}
+            {% with channel=experiment.get_channel_display %}
+              {% if channel %}• {{ channel }}{% endif %}
+            {% endwith %}
           </div>
         </li>
       {% endfor %}


### PR DESCRIPTION
Becuase
    
* We added a new channels field for desktop experiments
* We kept the existing channel field for all non-desktop experiments
* We only want to show channel(s) in one place so we need to handle both cases in each place a channel would be shown
    
This commit
    
* Overrides the get_channel_display method on NimbusExperiment to handle both the channels and channel case
* Updates the templates to always call get_channel_display where ever a channel is shown
    
fixes #13230

<img width="220" height="197" alt="image" src="https://github.com/user-attachments/assets/40d62d75-3a00-49f2-aef6-12ce748833bc" />
<img width="404" height="191" alt="image" src="https://github.com/user-attachments/assets/41f5a41f-81c1-4bf0-92ff-a25730cef744" />
<img width="268" height="575" alt="image" src="https://github.com/user-attachments/assets/0503a3f4-f9ec-4804-acde-0ebfbc6211c4" />
