### PR TITLE
Add targeting for use with FxA Bookmarks experiment

### DIFF
--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -3001,6 +3001,23 @@ SIGNED_OUT_EXISTING_USER_FXA_ENABLED_NO_ENTERPRISE = NimbusTargetingConfig(
     application_choice_names=(Application.DESKTOP.name,),
 )
 
+SIGNED_OUT_POST_FIRST_RUN_USER_FXA_ENABLED_NO_ENTERPRISE = NimbusTargetingConfig(
+    name="Signed-out user, post first run, FxA enabled, no enterprise policies",
+    slug="signed_out_user_post_first_run_fxa_enabled_no_enterprise",
+    description=(
+        "Users with profiles older than 7 days, post first run, "
+        "who are NOT signed into FxA, with FxA enabled, and no enterprise policies"
+    ),
+    targeting=(
+        f"{PROFILEMORETHAN7DAYS} && {NO_ENTERPRISE.targeting} "
+        "&& !isFirstStartup && !isFxASignedIn && isFxAEnabled"
+    ),
+    desktop_telemetry="",
+    sticky_required=True,
+    is_first_run_required=False,
+    application_choice_names=(Application.DESKTOP.name,),
+)
+
 TOU_NOT_ACCEPTED_EXISTING_USER_ADS_ENABLED_MAC_OR_WIN = NimbusTargetingConfig(
     name="TOU not accepted yet, existing user, ads enabled, Mac or Win",
     slug="tou_not_accepted_existing_user_ads_enabled_mac_win",


### PR DESCRIPTION
To support the [Account Adoption experiment targeting bookmarks,](https://docs.google.com/document/d/1XT27bFVJXwKNiQIi1MI1tanyqMR8azp-8bDFvEjtPcE/edit?tab=t.0#heading=h.kzffe2a93ndd) this commit adds targeting that covers both early-day & existing users while excluding first run and enterprise:

- !isFxASignedIn
- isFxAEnabled
- Exclude Enterprise users
- Exclude first run users
- Profile age 7 days +
