### PR TITLE
feat(nimbus): use channels in table filters

### DIFF
--- a/experimenter/experimenter/experiments/tests/factories.py
+++ b/experimenter/experimenter/experiments/tests/factories.py
@@ -455,16 +455,18 @@ class NimbusExperimentFactory(factory.django.DjangoModelFactory):
     channels = factory.LazyAttribute(
         lambda o: [
             str(c)
-            for c in random.choices(
-                list(
-                    set(
-                        NimbusExperiment.APPLICATION_CONFIGS[
-                            o.application
-                        ].channel_app_id.keys()
-                    )
-                    - {NimbusExperiment.Channel.NO_CHANNEL}
-                ),
-                k=2,
+            for c in set(
+                random.choices(
+                    list(
+                        set(
+                            NimbusExperiment.APPLICATION_CONFIGS[
+                                o.application
+                            ].channel_app_id.keys()
+                        )
+                        - {NimbusExperiment.Channel.NO_CHANNEL}
+                    ),
+                    k=2,
+                )
             )
         ]
     )

--- a/experimenter/experimenter/nimbus_ui/filtersets.py
+++ b/experimenter/experimenter/nimbus_ui/filtersets.py
@@ -126,6 +126,7 @@ class NimbusExperimentFilter(django_filters.FilterSet):
         ),
     )
     channel = django_filters.MultipleChoiceFilter(
+        method="filter_channel",
         choices=NimbusExperiment.Channel.choices,
         widget=IconMultiSelectWidget(
             icon="fa-solid fa-road",
@@ -300,4 +301,10 @@ class NimbusExperimentFilter(django_filters.FilterSet):
                 query |= Q(takeaways_metric_gain=True)
             elif value in NimbusExperiment.ConclusionRecommendation:
                 query |= Q(conclusion_recommendations__contains=[value])
+        return queryset.filter(query)
+
+    def filter_channel(self, queryset, name, value):
+        query = Q(channel__in=value)
+        for channel in value:
+            query |= Q(channels__contains=[channel])
         return queryset.filter(query)


### PR DESCRIPTION
Becuase

* We want to be able to filter on both the channel and channels fields
* This should be transparent to the user so there should only be one channel filter

This commit

* Searches both the channel and channels fields in the channel filter on the table page

fixes #13239

