### PR TITLE
fix win10 eos toast targeting

### DIFF
--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -1013,8 +1013,10 @@ WIN10_EOS_SYNC_TOAST_ELIGIBLE = NimbusTargetingConfig(
     description="Users in the Windows 10 EOS Sync treatment branch",
     targeting=(
         "isBackgroundTaskMode "
-        "&& defaultProfile.enrollmentsMap['optin-windows-10-eos-sync-messaging'] "
-        "== 'treatment-a'"
+        "&& ((defaultProfile.enrollmentsMap['optin-windows-10-eos-sync-messaging'] "
+        "== 'treatment-a')"
+        " || (defaultProfile.enrollmentsMap['windows-10-eos-sync-messaging'] "
+        "== 'treatment-a')"
     ),
     desktop_telemetry="",
     sticky_required=False,


### PR DESCRIPTION
I accidentally included only the force enrollment slug in the original PR. This adds the natural enrollment slug so it will actually work in the wild.